### PR TITLE
Add Discord Bot channel runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@mariozechner/pi-coding-agent": "^0.67.3",
         "@mariozechner/pi-tui": "^0.67.3",
         "@mozilla/readability": "^0.6.0",
+        "agent-messenger": "github:agent-messenger/agent-messenger#main",
         "cheerio": "^1.2.0",
         "citty": "^0.2.2",
         "cron-parser": "^5.5.0",
@@ -20,6 +21,7 @@
         "@types/bun": "latest",
         "@types/jsdom": "^28.0.1",
         "@types/turndown": "^5.0.6",
+        "@types/ws": "^8.18.1",
         "@typescript/native-preview": "^7.0.0-dev.20260416.1",
         "oxfmt": "^0.45.0",
         "oxlint": "^1.60.0",
@@ -112,6 +114,12 @@
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
+    "@cacheable/memory": ["@cacheable/memory@2.0.8", "", { "dependencies": { "@cacheable/utils": "^2.4.0", "@keyv/bigmap": "^1.3.1", "hookified": "^1.15.1", "keyv": "^5.6.0" } }, "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw=="],
+
+    "@cacheable/node-cache": ["@cacheable/node-cache@1.7.6", "", { "dependencies": { "cacheable": "^2.3.1", "hookified": "^1.14.0", "keyv": "^5.5.5" } }, "sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A=="],
+
+    "@cacheable/utils": ["@cacheable/utils@2.4.1", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA=="],
+
     "@clack/core": ["@clack/core@1.2.0", "", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
 
     "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
@@ -128,9 +136,69 @@
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@google/genai": ["@google/genai@1.50.1", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ=="],
+
+    "@hapi/boom": ["@hapi/boom@10.0.1", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA=="],
+
+    "@hapi/hoek": ["@hapi/hoek@11.0.7", "", {}, "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@keyv/bigmap": ["@keyv/bigmap@1.3.1", "", { "dependencies": { "hashery": "^1.4.0", "hookified": "^1.15.0" }, "peerDependencies": { "keyv": "^5.6.0" } }, "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ=="],
+
+    "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
 
     "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.2", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.2", "@mariozechner/clipboard-darwin-universal": "0.3.2", "@mariozechner/clipboard-darwin-x64": "0.3.2", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2", "@mariozechner/clipboard-linux-arm64-musl": "0.3.2", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-musl": "0.3.2", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2", "@mariozechner/clipboard-win32-x64-msvc": "0.3.2" } }, "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA=="],
 
@@ -246,6 +314,24 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-JOro4ZcfBLamJCyfURQmOQByoorgOdx3ZjAkSqnb/CyG/i+lN3KoV5LAgk5ZAW6DPq7/Cx7n23f8DuTWXTWgyQ=="],
 
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@prebuilt-tdlib/darwin-arm64": ["@prebuilt-tdlib/darwin-arm64@0.1008062.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+AHGA293vZyqBxZ9cYTBCAgRUiTSnommsj0LnoT9+b3Pa73LCW9EIy1NGd01/XQpX7TaaChji0BVK3kkS8iQxA=="],
+
+    "@prebuilt-tdlib/darwin-x64": ["@prebuilt-tdlib/darwin-x64@0.1008062.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-v55HgpQ0E0nxIfyd76r6u8czZliD+iCeeBSbe3JvdjWRJXj1wz2Nv3gpqCLBEdHqnTK6GUPlk0MlQFmHyKJMnw=="],
+
+    "@prebuilt-tdlib/linux-arm64-glibc": ["@prebuilt-tdlib/linux-arm64-glibc@0.1008062.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-WetFqYB658vos8KCKNIouo0CNta+Tmj6nUW24V1NJiCmq3OKHH+zvtwxC4AoBqt5miAqF7DBokMtxXyp8z9bVA=="],
+
+    "@prebuilt-tdlib/linux-arm64-musl": ["@prebuilt-tdlib/linux-arm64-musl@0.1008062.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-uAFiBq/xEBr5bSPRtR6xrEzjWC+Y91zfeB6IJW2vT4q+k4AT/IMkKvHCdtAnwcOSiKVEu7lSiYB52xoktuHAew=="],
+
+    "@prebuilt-tdlib/linux-x64-glibc": ["@prebuilt-tdlib/linux-x64-glibc@0.1008062.2", "", { "os": "linux", "cpu": "x64" }, "sha512-NOUOubfeWcZSSm9nvIQJjSXqEOBmBT4kvsWPW5rMuUMaR44VOGas/kB7aGcElNtqX9Bw+IsRgSHU7r8LMQ2CVQ=="],
+
+    "@prebuilt-tdlib/linux-x64-musl": ["@prebuilt-tdlib/linux-x64-musl@0.1008062.2", "", { "os": "linux", "cpu": "x64" }, "sha512-kGpDjDfS169mb+ut9Z9Mi/TBExTBg6oidWEk723S0RU3hp9aSHC0n75NZcmNd3Gi2ncHJoC2m6h01Kug5veZ2Q=="],
+
+    "@prebuilt-tdlib/types": ["@prebuilt-tdlib/types@0.1008062.2", "", {}, "sha512-1T2vKv6RPdUBOYmoWifRCyD5hvxMiA5xFscoXjOhAWdmc8CFzOao5rvZiH8yqgb/IqiMK0/2qZxi5VdmxFRuyw=="],
+
+    "@prebuilt-tdlib/win32-x64": ["@prebuilt-tdlib/win32-x64@0.1008062.2", "", { "os": "win32", "cpu": "x64" }, "sha512-nCvwdCbFQQV/rxz7p782osjSOrHveCZXgoHRCtpYdzQh4ZYwaHBYnlmk5MPGpqY+faUtrD1XFiWgaq8dSjkgzw=="],
+
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
@@ -269,6 +355,12 @@
     "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
+
+    "@slack/logger": ["@slack/logger@3.0.0", "", { "dependencies": { "@types/node": ">=12.0.0" } }, "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA=="],
+
+    "@slack/types": ["@slack/types@2.20.1", "", {}, "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A=="],
+
+    "@slack/web-api": ["@slack/web-api@6.13.0", "", { "dependencies": { "@slack/logger": "^3.0.0", "@slack/types": "^2.11.0", "@types/is-stream": "^1.1.0", "@types/node": ">=12.0.0", "axios": "^1.7.4", "eventemitter3": "^3.1.0", "form-data": "^2.5.0", "is-electron": "2.2.2", "is-stream": "^1.1.0", "p-queue": "^6.6.1", "p-retry": "^4.0.0" } }, "sha512-dv65crIgdh9ZYHrevLU6XFHTQwTyDmNqEqzuIrV+Vqe/vgiG6w37oex5ePDU1RGm2IJ90H8iOvHFvzdEO/vB+g=="],
 
     "@smithy/config-resolver": ["@smithy/config-resolver@4.4.15", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.13", "@smithy/types": "^4.14.0", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-endpoints": "^3.4.0", "@smithy/util-middleware": "^4.2.13", "tslib": "^2.6.2" } }, "sha512-BJdMBY5YO9iHh+lPLYdHv6LbX+J8IcPCYMl1IJdBt2KDWNHwONHrPVHk3ttYBqJd9wxv84wlbN0f7GlQzcQtNQ=="],
 
@@ -366,7 +458,11 @@
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
+    "@types/is-stream": ["@types/is-stream@1.1.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg=="],
+
     "@types/jsdom": ["@types/jsdom@28.0.1", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0", "undici-types": "^7.21.0" } }, "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw=="],
+
+    "@types/long": ["@types/long@4.0.2", "", {}, "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="],
 
     "@types/mime-types": ["@types/mime-types@2.1.4", "", {}, "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w=="],
 
@@ -377,6 +473,8 @@
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
     "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -396,7 +494,13 @@
 
     "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260416.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Ht04G9kt0fopDA0cB1Ng7/X6SScRIXaKZk9m/guyesuRlt3el+9eefF6YrnYCczzKlmZ4doPbR/xXiKFSnZA6Q=="],
 
+    "@whiskeysockets/baileys": ["@whiskeysockets/baileys@7.0.0-rc.9", "", { "dependencies": { "@cacheable/node-cache": "^1.4.0", "@hapi/boom": "^9.1.3", "async-mutex": "^0.5.0", "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git", "lru-cache": "^11.1.0", "music-metadata": "^11.7.0", "p-queue": "^9.0.0", "pino": "^9.6", "protobufjs": "^7.2.4", "ws": "^8.13.0" }, "peerDependencies": { "audio-decode": "^2.1.3", "jimp": "^1.6.0", "link-preview-js": "^3.0.0", "sharp": "*" }, "optionalPeers": ["audio-decode", "jimp", "link-preview-js"] }, "sha512-YFm5gKXfDP9byCXCW3OPHKXLzrAKzolzgVUlRosHHgwbnf2YOO3XknkMm6J7+F0ns8OA0uuSBhgkRHTDtqkacw=="],
+
+    "abstract-level": ["abstract-level@3.1.1", "", { "dependencies": { "buffer": "^6.0.3", "is-buffer": "^2.0.5", "level-supports": "^6.2.0", "level-transcoder": "^1.0.1", "maybe-combine-errors": "^1.0.0", "module-error": "^1.0.1" } }, "sha512-CW2gKbJFTuX1feMvOrvsVMmijAOgI9kg2Ie9Dq3gOcMt/dVVoVmqNlLcEUCT13NxHFMEajcUcVBIplbyDroDiw=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "agent-messenger": ["agent-messenger@github:agent-messenger/agent-messenger#39b2cf4", { "dependencies": { "@hapi/boom": "^10.0.1", "@slack/web-api": "^6.9.0", "@whiskeysockets/baileys": "^7.0.0-rc.9", "better-sqlite3": "^12.0.0", "blessed": "^0.1.81", "bson": "^7.2.0", "classic-level": "^3.0.0", "commander": "^11.1.0", "crypto-js": "^4.2.0", "curve25519-js": "^0.0.4", "node-bignumber": "^1.2.2", "node-int64": "^0.4.0", "node-jose": "^2.2.0", "pino": "^10.3.1", "qrcode": "^1.5.4", "thrift": "^0.20.0", "tweetnacl": "^1.0.3", "ws": "^8.19.0", "zod": "^4.3.6" }, "optionalDependencies": { "koffi": "^2.15.2", "prebuilt-tdlib": "0.1008062.2" }, "bin": { "agent-channeltalk": "./src/platforms/channeltalk/cli.ts", "agent-channeltalkbot": "./src/platforms/channeltalkbot/cli.ts", "agent-discord": "./src/platforms/discord/cli.ts", "agent-discordbot": "./src/platforms/discordbot/cli.ts", "agent-instagram": "./src/platforms/instagram/cli.ts", "agent-kakaotalk": "./src/platforms/kakaotalk/cli.ts", "agent-line": "./src/platforms/line/cli.ts", "agent-messenger": "./src/cli.ts", "agent-slack": "./src/platforms/slack/cli.ts", "agent-slackbot": "./src/platforms/slackbot/cli.ts", "agent-teams": "./src/platforms/teams/cli.ts", "agent-telegram": "./src/platforms/telegram/cli.ts", "agent-webex": "./src/platforms/webex/cli.ts", "agent-wechatbot": "./src/platforms/wechatbot/cli.ts", "agent-whatsapp": "./src/platforms/whatsapp/cli.ts", "agent-whatsappbot": "./src/platforms/whatsappbot/cli.ts", "amsg": "./src/cli.ts" } }, "agent-messenger-agent-messenger-39b2cf4", "sha512-KazoI5ffTIAAkOOpzXCnSnvWWfQurjZqxQhZhvOll6WZpiHZDhqdip4Q7v+r3ck/V9uAElK2hMIjggc2FGo0fw=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -410,15 +514,35 @@
 
     "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
 
+    "async-limiter": ["async-limiter@1.0.1", "", {}, "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="],
+
+    "async-mutex": ["async-mutex@0.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "axios": ["axios@1.15.2", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A=="],
+
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
+    "base64url": ["base64url@3.0.1", "", {}, "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="],
+
     "basic-ftp": ["basic-ftp@5.3.0", "", {}, "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w=="],
+
+    "better-sqlite3": ["better-sqlite3@12.9.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "blessed": ["blessed@0.1.81", "", { "bin": { "blessed": "./bin/tput.js" } }, "sha512-LoF5gae+hlmfORcG1M5+5XZi4LBmvlXTzwJWzUlPryN/SJdSflZvROM2TwkT0GMpq7oqT48NRd4GS7BiVBc5OQ=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
@@ -426,11 +550,23 @@
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
+    "browser-or-node": ["browser-or-node@1.3.0", "", {}, "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg=="],
+
+    "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "cacheable": ["cacheable@2.3.4", "", { "dependencies": { "@cacheable/memory": "^2.0.8", "@cacheable/utils": "^2.4.0", "hookified": "^1.15.0", "keyv": "^5.6.0", "qified": "^0.9.0" } }, "sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -438,7 +574,11 @@
 
     "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
 
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+
     "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
+
+    "classic-level": ["classic-level@3.0.0", "", { "dependencies": { "abstract-level": "^3.1.0", "module-error": "^1.0.1", "napi-macros": "^2.2.2", "node-gyp-build": "^4.3.0" } }, "sha512-yGy8j8LjPbN0Bh3+ygmyYvrmskVita92pD/zCoalfcC9XxZj6iDtZTAnz+ot7GG8p9KLTG+MZ84tSA4AhkgVZQ=="],
 
     "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
 
@@ -448,7 +588,15 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "cron-parser": ["cron-parser@5.5.0", "", { "dependencies": { "luxon": "^3.7.1" } }, "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww=="],
+
+    "crypto-js": ["crypto-js@4.2.0", "", {}, "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
@@ -456,17 +604,31 @@
 
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
+    "curve25519-js": ["curve25519-js@0.0.4", "", {}, "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
+
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -475,6 +637,8 @@
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
@@ -486,6 +650,16 @@
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es6-promise": ["es6-promise@4.2.8", "", {}, "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="],
+
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
@@ -495,6 +669,10 @@
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@3.1.2", "", {}, "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="],
+
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -520,7 +698,19 @@
 
     "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
 
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
+    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
+
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
 
@@ -530,9 +720,15 @@
 
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
     "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
 
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
@@ -540,11 +736,23 @@
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hashery": ["hashery@1.5.1", "", { "dependencies": { "hookified": "^1.15.0" } }, "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
+    "hookified": ["hookified@1.15.1", "", {}, "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg=="],
 
     "hosted-git-info": ["hosted-git-info@9.0.2", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg=="],
 
@@ -562,11 +770,23 @@
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
+
+    "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "is-stream": ["is-stream@1.1.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
+
+    "isomorphic-ws": ["isomorphic-ws@4.0.1", "", { "peerDependencies": { "ws": "*" } }, "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="],
 
     "jq-wasm": ["jq-wasm@1.1.0-jq-1.8.1", "", {}, "sha512-lWfu34lpDFIygOYcL5TzxhZIApDR9iR5XywcVoyUAZ6jlQrj8HKHOKeCcHgUm2dE9RVdbP3eqNAKGLuj+k4seQ=="],
 
@@ -582,7 +802,19 @@
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
+    "keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
+
     "koffi": ["koffi@2.16.0", "", {}, "sha512-h/2NJueOKWd0YYycEOWDspomizgNfuOKf/V7ZE2fytvuRtHoY9Tb+y4x6GJ6pFqaVndWn9dLK+sCI14eWtu5rA=="],
+
+    "level-supports": ["level-supports@6.2.0", "", {}, "sha512-QNxVXP0IRnBmMsJIh+sb2kwNCYcKciQZJEt+L1hPCHrKNELllXhvrlClVHXBYZVT+a7aTSM6StgNXdAldoab3w=="],
+
+    "level-transcoder": ["level-transcoder@1.0.1", "", { "dependencies": { "buffer": "^6.0.3", "module-error": "^1.0.1" } }, "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w=="],
+
+    "libsignal": ["@whiskeysockets/libsignal-node@github:whiskeysockets/libsignal-node#1c30d7d", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "6.8.8" } }, "WhiskeySockets-libsignal-node-1c30d7d", "sha512-5q4/OuDQaMYx3RpDqMqS3WYyqjrsSMpU8ipQZtpYnm5l6DwNoLV9oIYMDK0NILKW+tyk3tVCIA11BMYQ+A1+GA=="],
+
+    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
@@ -592,29 +824,63 @@
 
     "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "maybe-combine-errors": ["maybe-combine-errors@1.0.0", "", {}, "sha512-eefp6IduNPT6fVdwPp+1NgD0PML1NU5P6j1Mj5nz1nidX8/sWY7119WL8vTAHgqfsY74TzW0w1XPgdYEKkGZ5A=="],
+
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "module-error": ["module-error@1.0.2", "", {}, "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "music-metadata": ["music-metadata@11.12.3", "", { "dependencies": { "@borewit/text-codec": "^0.2.2", "@tokenizer/token": "^0.3.0", "content-type": "^1.0.5", "debug": "^4.4.3", "file-type": "^21.3.1", "media-typer": "^1.1.0", "strtok3": "^10.3.4", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0", "win-guid": "^0.2.1" } }, "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
+    "napi-macros": ["napi-macros@2.2.2", "", {}, "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g=="],
+
     "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
+    "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
+
+    "node-bignumber": ["node-bignumber@1.2.2", "", {}, "sha512-VoTZHmdFQpZH1+q1dz2qcHNCwTWsJg2T3PYwlAyDNFOfVhSYUKQBLFcCpCud+wJBGgCttGavZILaIggDIKqEQQ=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
+    "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
+
+    "node-jose": ["node-jose@2.2.0", "", { "dependencies": { "base64url": "^3.0.1", "buffer": "^6.0.3", "es6-promise": "^4.2.8", "lodash": "^4.17.21", "long": "^5.2.0", "node-forge": "^1.2.1", "pako": "^2.0.4", "process": "^0.11.10", "uuid": "^9.0.0" } }, "sha512-XPCvJRr94SjLrSIm4pbYHKLEaOsDvJCpyFw/6V/KK/IXmyZ6SFBzAUDO9HQf4DB/nTEFcRGH87mNciOP23kFjw=="],
+
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -624,11 +890,25 @@
 
     "oxlint": ["oxlint@1.60.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.60.0", "@oxlint/binding-android-arm64": "1.60.0", "@oxlint/binding-darwin-arm64": "1.60.0", "@oxlint/binding-darwin-x64": "1.60.0", "@oxlint/binding-freebsd-x64": "1.60.0", "@oxlint/binding-linux-arm-gnueabihf": "1.60.0", "@oxlint/binding-linux-arm-musleabihf": "1.60.0", "@oxlint/binding-linux-arm64-gnu": "1.60.0", "@oxlint/binding-linux-arm64-musl": "1.60.0", "@oxlint/binding-linux-ppc64-gnu": "1.60.0", "@oxlint/binding-linux-riscv64-gnu": "1.60.0", "@oxlint/binding-linux-riscv64-musl": "1.60.0", "@oxlint/binding-linux-s390x-gnu": "1.60.0", "@oxlint/binding-linux-x64-gnu": "1.60.0", "@oxlint/binding-linux-x64-musl": "1.60.0", "@oxlint/binding-openharmony-arm64": "1.60.0", "@oxlint/binding-win32-arm64-msvc": "1.60.0", "@oxlint/binding-win32-ia32-msvc": "1.60.0", "@oxlint/binding-win32-x64-msvc": "1.60.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.18.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-tnRzTWiWJ9pg3ftRWnD0+Oqh78L6ZSwcEudvCZaER0PIqiAnNyXj5N1dPwjmNpDalkKS9m/WMLN1CTPUBPmsgw=="],
 
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
 
     "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "pako": ["pako@2.1.0", "", {}, "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -638,11 +918,29 @@
 
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
+
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
+    "prebuilt-tdlib": ["prebuilt-tdlib@0.1008062.2", "", { "optionalDependencies": { "@prebuilt-tdlib/darwin-arm64": "0.1008062.2", "@prebuilt-tdlib/darwin-x64": "0.1008062.2", "@prebuilt-tdlib/linux-arm64-glibc": "0.1008062.2", "@prebuilt-tdlib/linux-arm64-musl": "0.1008062.2", "@prebuilt-tdlib/linux-x64-glibc": "0.1008062.2", "@prebuilt-tdlib/linux-x64-musl": "0.1008062.2", "@prebuilt-tdlib/types": "0.1008062.2", "@prebuilt-tdlib/win32-x64": "0.1008062.2" } }, "sha512-JgTOtmDI3eDhxs5/0WOB7BG4q1WWlmrIWLtENA3gwkGHaD/1qjid4HuE5nL0ZbU5kZ5Z8MlYuiuuP6e6NIC1HA=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
@@ -656,19 +954,47 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "q": ["q@1.5.1", "", {}, "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="],
+
+    "qified": ["qified@0.9.1", "", { "dependencies": { "hookified": "^2.1.1" } }, "sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg=="],
+
+    "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
@@ -678,15 +1004,23 @@
 
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
 
@@ -696,9 +1030,17 @@
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
+
+    "thrift": ["thrift@0.20.0", "", { "dependencies": { "browser-or-node": "^1.2.1", "isomorphic-ws": "^4.0.1", "node-int64": "^0.4.0", "q": "^1.5.0", "ws": "^5.2.3" } }, "sha512-oSmJTaoIAGolpupVHFfsWcmdEKX81fcDI6ty0hhezzdgZvp0XyXgMe9+1YusI8Ahy0HK4n8jlNrkPjOPeHZjdQ=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
@@ -716,7 +1058,11 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
     "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -725,6 +1071,8 @@
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
     "undici-types": ["undici-types@7.25.0", "", {}, "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
@@ -739,6 +1087,10 @@
     "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
     "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
+
+    "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -774,6 +1126,18 @@
 
     "@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "@whiskeysockets/baileys/@hapi/boom": ["@hapi/boom@9.1.4", "", { "dependencies": { "@hapi/hoek": "9.x.x" } }, "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw=="],
+
+    "@whiskeysockets/baileys/p-queue": ["p-queue@9.2.0", "", { "dependencies": { "eventemitter3": "^5.0.4", "p-timeout": "^7.0.0" } }, "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g=="],
+
+    "@whiskeysockets/baileys/pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
+
+    "axios/form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "axios/proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
+    "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
@@ -786,19 +1150,33 @@
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "jsdom/parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
     "jsdom/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
+    "libsignal/protobufjs": ["protobufjs@6.8.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.0", "@types/node": "^10.1.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw=="],
+
     "node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "node-jose/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
+    "qified/hookified": ["hookified@2.2.0", "", {}, "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA=="],
+
+    "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "thrift/ws": ["ws@5.2.4", "", { "dependencies": { "async-limiter": "~1.0.0" } }, "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -806,11 +1184,35 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
+    "@whiskeysockets/baileys/@hapi/boom/@hapi/hoek": ["@hapi/hoek@9.3.0", "", {}, "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="],
+
+    "@whiskeysockets/baileys/p-queue/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "@whiskeysockets/baileys/p-queue/p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
+
+    "@whiskeysockets/baileys/pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "@whiskeysockets/baileys/pino/thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
+
+    "axios/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "cli-highlight/parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "jsdom/parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "libsignal/protobufjs/@types/node": ["@types/node@10.17.60", "", {}, "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="],
+
+    "libsignal/protobufjs/long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
+
+    "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -819,5 +1221,13 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "axios/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "qrcode/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "qrcode/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@mariozechner/pi-coding-agent": "^0.67.3",
     "@mariozechner/pi-tui": "^0.67.3",
     "@mozilla/readability": "^0.6.0",
+    "agent-messenger": "github:agent-messenger/agent-messenger#main",
     "cheerio": "^1.2.0",
     "citty": "^0.2.2",
     "cron-parser": "^5.5.0",
@@ -36,6 +37,7 @@
     "@types/bun": "latest",
     "@types/jsdom": "^28.0.1",
     "@types/turndown": "^5.0.6",
+    "@types/ws": "^8.18.1",
     "@typescript/native-preview": "^7.0.0-dev.20260416.1",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0"

--- a/src/channels/adapters/agent-messenger-shim.d.ts
+++ b/src/channels/adapters/agent-messenger-shim.d.ts
@@ -1,0 +1,167 @@
+// Local ambient declarations for `agent-messenger/discordbot`.
+//
+// The agent-messenger package is installed from its GitHub source (no shipped
+// `dist/` declarations) and its `src/` has strict-mode type errors that
+// surface when TypeScript walks our `import type` references into the package
+// source. Bun runs the source fine at runtime — only the typecheck breaks.
+//
+// This shim mirrors the public API surface we actually consume from the
+// package's `src/platforms/discordbot/index.ts`. Keep it minimal: when we
+// start using new exports, add them here. When agent-messenger ships a
+// release with `dist/` declarations and a clean source, delete this file.
+declare module 'agent-messenger/discordbot' {
+  export interface DiscordBotListenerEventMap {
+    message_create: [event: DiscordGatewayMessageCreateEvent]
+    message_update: [event: DiscordGatewayMessageUpdateEvent]
+    message_delete: [event: DiscordGatewayMessageDeleteEvent]
+    message_reaction_add: [event: DiscordGatewayReactionEvent]
+    message_reaction_remove: [event: DiscordGatewayReactionEvent]
+    guild_member_add: [event: DiscordGatewayMemberEvent]
+    guild_member_remove: [event: DiscordGatewayMemberEvent]
+    typing_start: [event: DiscordGatewayTypingEvent]
+    channel_create: [event: DiscordGatewayChannelEvent]
+    channel_update: [event: DiscordGatewayChannelEvent]
+    channel_delete: [event: DiscordGatewayChannelEvent]
+    guild_create: [event: DiscordGatewayGuildEvent]
+    guild_update: [event: DiscordGatewayGuildEvent]
+    guild_delete: [event: DiscordGatewayGuildEvent]
+    interaction_create: [event: DiscordGatewayInteractionEvent]
+    discord_event: [event: DiscordGatewayGenericEvent]
+    connected: [info: { user: { id: string; username: string }; sessionId: string }]
+    disconnected: []
+    error: [error: Error]
+  }
+
+  export interface DiscordGatewayMessageCreateEvent {
+    type: 'MESSAGE_CREATE'
+    id: string
+    channel_id: string
+    guild_id?: string
+    author: { id: string; username: string; bot?: boolean }
+    content: string
+    timestamp: string
+    edited_timestamp?: string
+    mentions?: { id: string; username: string }[]
+    attachments?: { id: string; filename: string; url: string; size?: number }[]
+  }
+
+  export interface DiscordGatewayMessageUpdateEvent {
+    type: 'MESSAGE_UPDATE'
+    id: string
+    channel_id: string
+    guild_id?: string
+    content?: string
+    edited_timestamp?: string
+  }
+
+  export interface DiscordGatewayMessageDeleteEvent {
+    type: 'MESSAGE_DELETE'
+    id: string
+    channel_id: string
+    guild_id?: string
+  }
+
+  export interface DiscordGatewayReactionEvent {
+    type: 'MESSAGE_REACTION_ADD' | 'MESSAGE_REACTION_REMOVE'
+    user_id: string
+    channel_id: string
+    message_id: string
+    guild_id?: string
+    emoji: { id?: string; name: string }
+  }
+
+  export interface DiscordGatewayMemberEvent {
+    type: 'GUILD_MEMBER_ADD' | 'GUILD_MEMBER_REMOVE'
+    guild_id: string
+    user: { id: string; username: string }
+  }
+
+  export interface DiscordGatewayTypingEvent {
+    type: 'TYPING_START'
+    user_id: string
+    channel_id: string
+    guild_id?: string
+    timestamp: number
+  }
+
+  export interface DiscordGatewayChannelEvent {
+    type: 'CHANNEL_CREATE' | 'CHANNEL_UPDATE' | 'CHANNEL_DELETE'
+    id: string
+    guild_id?: string
+    name?: string
+  }
+
+  export interface DiscordGatewayGuildEvent {
+    type: 'GUILD_CREATE' | 'GUILD_UPDATE' | 'GUILD_DELETE'
+    id: string
+    name?: string
+    unavailable?: boolean
+  }
+
+  export interface DiscordGatewayInteractionEvent {
+    type: 'INTERACTION_CREATE'
+    id: string
+    application_id: string
+    token: string
+    data?: Record<string, unknown>
+    channel_id?: string
+    guild_id?: string
+    member?: Record<string, unknown>
+    user?: { id: string; username: string }
+  }
+
+  export interface DiscordGatewayGenericEvent {
+    type: string
+    [key: string]: unknown
+  }
+
+  export const DiscordIntent: {
+    readonly Guilds: number
+    readonly GuildMembers: number
+    readonly GuildModeration: number
+    readonly GuildEmojisAndStickers: number
+    readonly GuildIntegrations: number
+    readonly GuildWebhooks: number
+    readonly GuildInvites: number
+    readonly GuildVoiceStates: number
+    readonly GuildPresences: number
+    readonly GuildMessages: number
+    readonly GuildMessageReactions: number
+    readonly GuildMessageTyping: number
+    readonly DirectMessages: number
+    readonly DirectMessageReactions: number
+    readonly DirectMessageTyping: number
+    readonly MessageContent: number
+    readonly GuildScheduledEvents: number
+    readonly AutoModerationConfiguration: number
+    readonly AutoModerationExecution: number
+  }
+
+  export class DiscordBotClient {
+    login(credentials?: { token: string }): Promise<this>
+    sendMessage(
+      channelId: string,
+      content: string,
+      options?: { thread_id?: string },
+    ): Promise<{ id: string; channel_id: string; content: string }>
+    gatewayConnect(): Promise<{ token: string }>
+  }
+
+  export class DiscordBotListener {
+    constructor(client: DiscordBotClient, options?: { intents?: number })
+    start(): Promise<void>
+    stop(): void
+    on<K extends keyof DiscordBotListenerEventMap>(
+      event: K,
+      listener: (...args: DiscordBotListenerEventMap[K]) => void,
+    ): this
+    off<K extends keyof DiscordBotListenerEventMap>(
+      event: K,
+      listener: (...args: DiscordBotListenerEventMap[K]) => void,
+    ): this
+    once<K extends keyof DiscordBotListenerEventMap>(
+      event: K,
+      listener: (...args: DiscordBotListenerEventMap[K]) => void,
+    ): this
+  }
+}

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -250,6 +250,41 @@ describe('DiscordBotAdapter', () => {
     expect(clientFakes.sends).toEqual([{ channel: 'C1', content: 'hello back' }])
   })
 
+  test('outbound: callback drops replies whose (workspace, chat) is not in the chats allowlist', async () => {
+    const { router } = await makeRouter()
+    const clientFakes = createFakeClient()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['W1/C1'],
+      router,
+      client: clientFakes.client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.outboundCallback({
+      adapter: 'discord-bot',
+      bot: 'main',
+      workspace: 'W1',
+      chat: 'C1',
+      thread: null,
+      text: 'allowed',
+      turnId: 't1',
+    })
+
+    await adapter.outboundCallback({
+      adapter: 'discord-bot',
+      bot: 'main',
+      workspace: 'W2',
+      chat: 'C1',
+      thread: null,
+      text: 'denied',
+      turnId: 't2',
+    })
+
+    expect(clientFakes.sends).toEqual([{ channel: 'C1', content: 'allowed' }])
+  })
+
   test('outbound: callback for a different bot is ignored (multi-bot deployments)', async () => {
     const { router } = await makeRouter()
     const clientFakes = createFakeClient()

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -329,6 +329,43 @@ describe('DiscordBotAdapter', () => {
     expect(errors.some((e) => e.includes('rate limit'))).toBe(true)
   })
 
+  test('stop() awaits in-flight handleInbound before returning', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-adapter-'))
+    const fakes = createFakeSession()
+    let releaseRouter: () => void = () => {}
+    const slowRouter = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => {
+        await new Promise<void>((r) => {
+          releaseRouter = r
+        })
+        return { session: fakes.session, sessionId: 'sess-1' }
+      },
+    })
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['*'],
+      router: slowRouter,
+      client: createFakeClient().client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    const inboundPromise = adapter.handleInbound(makeMessageEvent({ content: 'hi' }))
+    let stopResolved = false
+    const stopPromise = adapter.stop().then(() => {
+      stopResolved = true
+    })
+    await new Promise((r) => setTimeout(r, 30))
+    expect(stopResolved).toBe(false)
+
+    releaseRouter()
+    await inboundPromise
+    await stopPromise
+
+    expect(stopResolved).toBe(true)
+  })
+
   test('end-to-end: inbound → session.prompt → text_delta → message_end → outbound send', async () => {
     const { router, fakes } = await makeRouter()
     const clientFakes = createFakeClient()

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { DiscordGatewayMessageCreateEvent } from 'agent-messenger/discordbot'
+
+import { createChannelRouter, type CreateSessionForChannel } from '../router'
+import { createDiscordBotAdapter } from './discord-bot'
+
+type Listener = (...args: any[]) => void
+
+function createFakeListener() {
+  const handlers = new Map<string, Listener[]>()
+  const startedRef = { value: false }
+  return {
+    listener: {
+      on(event: string, handler: Listener) {
+        const list = handlers.get(event) ?? []
+        list.push(handler)
+        handlers.set(event, list)
+        return this
+      },
+      async start() {
+        startedRef.value = true
+      },
+      stop() {
+        startedRef.value = false
+      },
+    },
+    emit(event: string, ...args: any[]) {
+      for (const h of handlers.get(event) ?? []) h(...args)
+    },
+    started: startedRef,
+  }
+}
+
+function createFakeClient() {
+  const sends: { channel: string; content: string; thread?: string }[] = []
+  return {
+    client: {
+      async sendMessage(channelId: string, content: string, options?: { thread_id?: string }) {
+        sends.push({ channel: channelId, content, ...(options?.thread_id ? { thread: options.thread_id } : {}) })
+        return { id: 'm', channel_id: channelId, content } as any
+      },
+    },
+    sends,
+  }
+}
+
+function createFakeSession() {
+  const listeners: ((event: any) => void)[] = []
+  const promptCalls: string[] = []
+  return {
+    session: {
+      subscribe(l: (e: any) => void) {
+        listeners.push(l)
+        return () => {
+          const i = listeners.indexOf(l)
+          if (i >= 0) listeners.splice(i, 1)
+        }
+      },
+      async prompt(text: string) {
+        promptCalls.push(text)
+      },
+      async abort() {},
+    } as any,
+    listeners,
+    promptCalls,
+  }
+}
+
+function makeMessageEvent(over: Partial<DiscordGatewayMessageCreateEvent> = {}): DiscordGatewayMessageCreateEvent {
+  return {
+    type: 'MESSAGE_CREATE',
+    id: 'msg-1',
+    channel_id: 'C1',
+    guild_id: 'W1',
+    author: { id: 'u1', username: 'alice' },
+    content: 'hello',
+    timestamp: '2026-04-29T00:00:00Z',
+    ...over,
+  } as DiscordGatewayMessageCreateEvent
+}
+
+async function makeRouter(createSession?: CreateSessionForChannel) {
+  const dir = await mkdtemp(join(tmpdir(), 'channels-adapter-'))
+  const fakes = createFakeSession()
+  const router = createChannelRouter({
+    agentDir: dir,
+    createSessionForChannel: createSession ?? (async () => ({ session: fakes.session, sessionId: 'sess-1' })),
+  })
+  return { router, fakes, dir }
+}
+
+describe('DiscordBotAdapter', () => {
+  test('start() wires listener events and binds outbound; stop() unbinds and stops the listener', async () => {
+    const { router } = await makeRouter()
+    const listenerFakes = createFakeListener()
+    const clientFakes = createFakeClient()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['*'],
+      router,
+      client: clientFakes.client,
+      listener: listenerFakes.listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.start()
+    expect(listenerFakes.started.value).toBe(true)
+
+    await adapter.stop()
+    expect(listenerFakes.started.value).toBe(false)
+  })
+
+  test('inbound: matching message routes through and prompts the session', async () => {
+    const { router, fakes } = await makeRouter()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['*'],
+      router,
+      client: createFakeClient().client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.handleInbound(makeMessageEvent({ content: 'hi from user' }))
+
+    expect(fakes.promptCalls).toEqual(['hi from user'])
+    expect(router.knownMappings()).toHaveLength(1)
+    expect(router.knownMappings()[0]).toMatchObject({
+      adapter: 'discord-bot',
+      bot: 'main',
+      workspace: 'W1',
+      chat: 'C1',
+      thread: null,
+    })
+  })
+
+  test('inbound: bot-authored messages are dropped (no echo loop)', async () => {
+    const { router, fakes } = await makeRouter()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['*'],
+      router,
+      client: createFakeClient().client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.handleInbound(
+      makeMessageEvent({ author: { id: 'bot', username: 'self', bot: true }, content: 'echo' }),
+    )
+
+    expect(fakes.promptCalls).toEqual([])
+    expect(router.knownMappings()).toHaveLength(0)
+  })
+
+  test('inbound: empty-content messages are dropped (privileged-intent fallback)', async () => {
+    const { router, fakes } = await makeRouter()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['*'],
+      router,
+      client: createFakeClient().client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.handleInbound(makeMessageEvent({ content: '' }))
+
+    expect(fakes.promptCalls).toEqual([])
+  })
+
+  test('inbound: missing guild_id maps to the @dm sentinel', async () => {
+    const { router, fakes } = await makeRouter()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['*'],
+      router,
+      client: createFakeClient().client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.handleInbound(makeMessageEvent({ guild_id: undefined, content: 'dm hi' }))
+
+    expect(fakes.promptCalls).toEqual(['dm hi'])
+    expect(router.knownMappings()[0]?.workspace).toBe('@dm')
+  })
+
+  test('inbound: chats allowlist with bare chat id admits any workspace', async () => {
+    const { router, fakes } = await makeRouter()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['C1'],
+      router,
+      client: createFakeClient().client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.handleInbound(makeMessageEvent({ guild_id: 'W1', channel_id: 'C1' }))
+    await adapter.handleInbound(makeMessageEvent({ guild_id: 'W2', channel_id: 'C1' }))
+    await adapter.handleInbound(makeMessageEvent({ guild_id: 'W1', channel_id: 'OTHER' }))
+
+    expect(fakes.promptCalls).toHaveLength(2)
+  })
+
+  test('inbound: workspace-qualified rule restricts to (workspace, chat)', async () => {
+    const { router, fakes } = await makeRouter()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['W1/C1'],
+      router,
+      client: createFakeClient().client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.handleInbound(makeMessageEvent({ guild_id: 'W1', channel_id: 'C1' }))
+    await adapter.handleInbound(makeMessageEvent({ guild_id: 'W2', channel_id: 'C1' }))
+
+    expect(fakes.promptCalls).toHaveLength(1)
+  })
+
+  test('outbound: callback for the same bot sends via client', async () => {
+    const { router } = await makeRouter()
+    const clientFakes = createFakeClient()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['*'],
+      router,
+      client: clientFakes.client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.outboundCallback({
+      adapter: 'discord-bot',
+      bot: 'main',
+      workspace: 'W1',
+      chat: 'C1',
+      thread: null,
+      text: 'hello back',
+      turnId: 't1',
+    })
+
+    expect(clientFakes.sends).toEqual([{ channel: 'C1', content: 'hello back' }])
+  })
+
+  test('outbound: callback for a different bot is ignored (multi-bot deployments)', async () => {
+    const { router } = await makeRouter()
+    const clientFakes = createFakeClient()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['*'],
+      router,
+      client: clientFakes.client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.outboundCallback({
+      adapter: 'discord-bot',
+      bot: 'alert',
+      workspace: 'W1',
+      chat: 'C1',
+      thread: null,
+      text: 'wrong bot',
+      turnId: 't1',
+    })
+
+    expect(clientFakes.sends).toEqual([])
+  })
+
+  test('outbound: thread is forwarded as thread_id', async () => {
+    const { router } = await makeRouter()
+    const clientFakes = createFakeClient()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['*'],
+      router,
+      client: clientFakes.client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.outboundCallback({
+      adapter: 'discord-bot',
+      bot: 'main',
+      workspace: 'W1',
+      chat: 'C1',
+      thread: 'T9',
+      text: 'in thread',
+      turnId: 't1',
+    })
+
+    expect(clientFakes.sends).toEqual([{ channel: 'C1', content: 'in thread', thread: 'T9' }])
+  })
+
+  test('outbound: send error is caught and logged, not thrown', async () => {
+    const { router } = await makeRouter()
+    const errors: string[] = []
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['*'],
+      router,
+      client: {
+        async sendMessage() {
+          throw new Error('rate limit')
+        },
+      },
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: (m) => errors.push(m) },
+    })
+
+    await adapter.outboundCallback({
+      adapter: 'discord-bot',
+      bot: 'main',
+      workspace: 'W1',
+      chat: 'C1',
+      thread: null,
+      text: 'fail',
+      turnId: 't1',
+    })
+
+    expect(errors.some((e) => e.includes('rate limit'))).toBe(true)
+  })
+
+  test('end-to-end: inbound → session.prompt → text_delta → message_end → outbound send', async () => {
+    const { router, fakes } = await makeRouter()
+    const clientFakes = createFakeClient()
+    const adapter = createDiscordBotAdapter({
+      bot: 'main',
+      chats: ['*'],
+      router,
+      client: clientFakes.client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.start()
+    await adapter.handleInbound(makeMessageEvent({ content: 'ping' }))
+    expect(fakes.promptCalls).toEqual(['ping'])
+
+    for (const l of fakes.listeners) {
+      l({
+        type: 'message_update',
+        message: { role: 'assistant' },
+        assistantMessageEvent: { type: 'text_delta', delta: 'pong' },
+      })
+      l({ type: 'message_end', message: { role: 'assistant', responseId: 'r1', timestamp: 1 } })
+    }
+    await Promise.resolve()
+
+    expect(clientFakes.sends).toEqual([{ channel: 'C1', content: 'pong' }])
+  })
+})

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from 'bun:test'
-import { mkdtemp } from 'node:fs/promises'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -83,11 +83,22 @@ function makeMessageEvent(over: Partial<DiscordGatewayMessageCreateEvent> = {}):
   } as DiscordGatewayMessageCreateEvent
 }
 
+const tempDirs: string[] = []
+
+beforeEach(() => {
+  tempDirs.length = 0
+})
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((d) => rm(d, { recursive: true, force: true })))
+})
+
 async function makeRouter(createSession?: CreateSessionForChannel) {
   const dir = await mkdtemp(join(tmpdir(), 'channels-adapter-'))
+  tempDirs.push(dir)
   const fakes = createFakeSession()
   const router = createChannelRouter({
-    agentDir: dir,
+    cwd: dir,
     createSessionForChannel: createSession ?? (async () => ({ session: fakes.session, sessionId: 'sess-1' })),
   })
   return { router, fakes, dir }
@@ -366,10 +377,11 @@ describe('DiscordBotAdapter', () => {
 
   test('stop() awaits in-flight handleInbound before returning', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'channels-adapter-'))
+    tempDirs.push(dir)
     const fakes = createFakeSession()
     let releaseRouter: () => void = () => {}
     const slowRouter = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => {
         await new Promise<void>((r) => {
           releaseRouter = r

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -110,8 +110,7 @@ describe('DiscordBotAdapter', () => {
     const listenerFakes = createFakeListener()
     const clientFakes = createFakeClient()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['*'],
+      allow: ['*'],
       router,
       client: clientFakes.client,
       listener: listenerFakes.listener,
@@ -128,8 +127,7 @@ describe('DiscordBotAdapter', () => {
   test('inbound: matching message routes through and prompts the session', async () => {
     const { router, fakes } = await makeRouter()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['*'],
+      allow: ['*'],
       router,
       client: createFakeClient().client,
       listener: createFakeListener().listener,
@@ -142,7 +140,6 @@ describe('DiscordBotAdapter', () => {
     expect(router.knownMappings()).toHaveLength(1)
     expect(router.knownMappings()[0]).toMatchObject({
       adapter: 'discord-bot',
-      bot: 'main',
       workspace: 'W1',
       chat: 'C1',
       thread: null,
@@ -152,8 +149,7 @@ describe('DiscordBotAdapter', () => {
   test('inbound: bot-authored messages are dropped (no echo loop)', async () => {
     const { router, fakes } = await makeRouter()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['*'],
+      allow: ['*'],
       router,
       client: createFakeClient().client,
       listener: createFakeListener().listener,
@@ -171,8 +167,7 @@ describe('DiscordBotAdapter', () => {
   test('inbound: empty-content messages are dropped (privileged-intent fallback)', async () => {
     const { router, fakes } = await makeRouter()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['*'],
+      allow: ['*'],
       router,
       client: createFakeClient().client,
       listener: createFakeListener().listener,
@@ -184,11 +179,10 @@ describe('DiscordBotAdapter', () => {
     expect(fakes.promptCalls).toEqual([])
   })
 
-  test('inbound: missing guild_id maps to the @dm sentinel', async () => {
+  test('inbound: missing guild_id maps to the @dm sentinel and matches dm rules', async () => {
     const { router, fakes } = await makeRouter()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['*'],
+      allow: ['dm:*'],
       router,
       client: createFakeClient().client,
       listener: createFakeListener().listener,
@@ -201,29 +195,26 @@ describe('DiscordBotAdapter', () => {
     expect(router.knownMappings()[0]?.workspace).toBe('@dm')
   })
 
-  test('inbound: chats allowlist with bare chat id admits any workspace', async () => {
+  test('inbound: "guild:*" admits guild messages but not DMs', async () => {
     const { router, fakes } = await makeRouter()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['C1'],
+      allow: ['guild:*'],
       router,
       client: createFakeClient().client,
       listener: createFakeListener().listener,
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     })
 
-    await adapter.handleInbound(makeMessageEvent({ guild_id: 'W1', channel_id: 'C1' }))
-    await adapter.handleInbound(makeMessageEvent({ guild_id: 'W2', channel_id: 'C1' }))
-    await adapter.handleInbound(makeMessageEvent({ guild_id: 'W1', channel_id: 'OTHER' }))
+    await adapter.handleInbound(makeMessageEvent({ guild_id: 'W1' }))
+    await adapter.handleInbound(makeMessageEvent({ guild_id: undefined, content: 'dm' }))
 
-    expect(fakes.promptCalls).toHaveLength(2)
+    expect(fakes.promptCalls).toEqual(['hello'])
   })
 
   test('inbound: workspace-qualified rule restricts to (workspace, chat)', async () => {
     const { router, fakes } = await makeRouter()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['W1/C1'],
+      allow: ['guild:W1/C1'],
       router,
       client: createFakeClient().client,
       listener: createFakeListener().listener,
@@ -236,12 +227,27 @@ describe('DiscordBotAdapter', () => {
     expect(fakes.promptCalls).toHaveLength(1)
   })
 
-  test('outbound: callback for the same bot sends via client', async () => {
+  test('inbound: empty allow list admits nothing', async () => {
+    const { router, fakes } = await makeRouter()
+    const adapter = createDiscordBotAdapter({
+      allow: [],
+      router,
+      client: createFakeClient().client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await adapter.handleInbound(makeMessageEvent({ guild_id: 'W1' }))
+    await adapter.handleInbound(makeMessageEvent({ guild_id: undefined, content: 'dm' }))
+
+    expect(fakes.promptCalls).toEqual([])
+  })
+
+  test('outbound: callback for the same adapter sends via client', async () => {
     const { router } = await makeRouter()
     const clientFakes = createFakeClient()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['*'],
+      allow: ['*'],
       router,
       client: clientFakes.client,
       listener: createFakeListener().listener,
@@ -250,7 +256,6 @@ describe('DiscordBotAdapter', () => {
 
     await adapter.outboundCallback({
       adapter: 'discord-bot',
-      bot: 'main',
       workspace: 'W1',
       chat: 'C1',
       thread: null,
@@ -261,12 +266,11 @@ describe('DiscordBotAdapter', () => {
     expect(clientFakes.sends).toEqual([{ channel: 'C1', content: 'hello back' }])
   })
 
-  test('outbound: callback drops replies whose (workspace, chat) is not in the chats allowlist', async () => {
+  test('outbound: callback drops replies whose (workspace, chat) is not in allow', async () => {
     const { router } = await makeRouter()
     const clientFakes = createFakeClient()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['W1/C1'],
+      allow: ['guild:W1/C1'],
       router,
       client: clientFakes.client,
       listener: createFakeListener().listener,
@@ -275,7 +279,6 @@ describe('DiscordBotAdapter', () => {
 
     await adapter.outboundCallback({
       adapter: 'discord-bot',
-      bot: 'main',
       workspace: 'W1',
       chat: 'C1',
       thread: null,
@@ -285,7 +288,6 @@ describe('DiscordBotAdapter', () => {
 
     await adapter.outboundCallback({
       adapter: 'discord-bot',
-      bot: 'main',
       workspace: 'W2',
       chat: 'C1',
       thread: null,
@@ -296,12 +298,11 @@ describe('DiscordBotAdapter', () => {
     expect(clientFakes.sends).toEqual([{ channel: 'C1', content: 'allowed' }])
   })
 
-  test('outbound: callback for a different bot is ignored (multi-bot deployments)', async () => {
+  test('outbound: DM workspace sentinel routes through dm rules', async () => {
     const { router } = await makeRouter()
     const clientFakes = createFakeClient()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['*'],
+      allow: ['dm:*'],
       router,
       client: clientFakes.client,
       listener: createFakeListener().listener,
@@ -310,23 +311,21 @@ describe('DiscordBotAdapter', () => {
 
     await adapter.outboundCallback({
       adapter: 'discord-bot',
-      bot: 'alert',
-      workspace: 'W1',
-      chat: 'C1',
+      workspace: '@dm',
+      chat: 'D1',
       thread: null,
-      text: 'wrong bot',
+      text: 'dm reply',
       turnId: 't1',
     })
 
-    expect(clientFakes.sends).toEqual([])
+    expect(clientFakes.sends).toEqual([{ channel: 'D1', content: 'dm reply' }])
   })
 
   test('outbound: thread is forwarded as thread_id', async () => {
     const { router } = await makeRouter()
     const clientFakes = createFakeClient()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['*'],
+      allow: ['*'],
       router,
       client: clientFakes.client,
       listener: createFakeListener().listener,
@@ -335,7 +334,6 @@ describe('DiscordBotAdapter', () => {
 
     await adapter.outboundCallback({
       adapter: 'discord-bot',
-      bot: 'main',
       workspace: 'W1',
       chat: 'C1',
       thread: 'T9',
@@ -350,8 +348,7 @@ describe('DiscordBotAdapter', () => {
     const { router } = await makeRouter()
     const errors: string[] = []
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['*'],
+      allow: ['*'],
       router,
       client: {
         async sendMessage() {
@@ -364,7 +361,6 @@ describe('DiscordBotAdapter', () => {
 
     await adapter.outboundCallback({
       adapter: 'discord-bot',
-      bot: 'main',
       workspace: 'W1',
       chat: 'C1',
       thread: null,
@@ -375,50 +371,11 @@ describe('DiscordBotAdapter', () => {
     expect(errors.some((e) => e.includes('rate limit'))).toBe(true)
   })
 
-  test('stop() awaits in-flight handleInbound before returning', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-adapter-'))
-    tempDirs.push(dir)
-    const fakes = createFakeSession()
-    let releaseRouter: () => void = () => {}
-    const slowRouter = createChannelRouter({
-      cwd: dir,
-      createSessionForChannel: async () => {
-        await new Promise<void>((r) => {
-          releaseRouter = r
-        })
-        return { session: fakes.session, sessionId: 'sess-1' }
-      },
-    })
-    const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['*'],
-      router: slowRouter,
-      client: createFakeClient().client,
-      listener: createFakeListener().listener,
-      logger: { info: () => {}, warn: () => {}, error: () => {} },
-    })
-
-    const inboundPromise = adapter.handleInbound(makeMessageEvent({ content: 'hi' }))
-    let stopResolved = false
-    const stopPromise = adapter.stop().then(() => {
-      stopResolved = true
-    })
-    await new Promise((r) => setTimeout(r, 30))
-    expect(stopResolved).toBe(false)
-
-    releaseRouter()
-    await inboundPromise
-    await stopPromise
-
-    expect(stopResolved).toBe(true)
-  })
-
   test('end-to-end: inbound → session.prompt → text_delta → message_end → outbound send', async () => {
     const { router, fakes } = await makeRouter()
     const clientFakes = createFakeClient()
     const adapter = createDiscordBotAdapter({
-      bot: 'main',
-      chats: ['*'],
+      allow: ['*'],
       router,
       client: clientFakes.client,
       listener: createFakeListener().listener,
@@ -440,5 +397,42 @@ describe('DiscordBotAdapter', () => {
     await Promise.resolve()
 
     expect(clientFakes.sends).toEqual([{ channel: 'C1', content: 'pong' }])
+  })
+
+  test('stop() awaits in-flight handleInbound before returning', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-adapter-'))
+    tempDirs.push(dir)
+    const fakes = createFakeSession()
+    let releaseRouter: () => void = () => {}
+    const slowRouter = createChannelRouter({
+      cwd: dir,
+      createSessionForChannel: async () => {
+        await new Promise<void>((r) => {
+          releaseRouter = r
+        })
+        return { session: fakes.session, sessionId: 'sess-1' }
+      },
+    })
+    const adapter = createDiscordBotAdapter({
+      allow: ['*'],
+      router: slowRouter,
+      client: createFakeClient().client,
+      listener: createFakeListener().listener,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    const inboundPromise = adapter.handleInbound(makeMessageEvent({ content: 'hi' }))
+    let stopResolved = false
+    const stopPromise = adapter.stop().then(() => {
+      stopResolved = true
+    })
+    await new Promise((r) => setTimeout(r, 30))
+    expect(stopResolved).toBe(false)
+
+    releaseRouter()
+    await inboundPromise
+    await stopPromise
+
+    expect(stopResolved).toBe(true)
   })
 })

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -1,0 +1,123 @@
+import type {
+  DiscordBotClient,
+  DiscordBotListenerEventMap,
+  DiscordGatewayMessageCreateEvent,
+} from 'agent-messenger/discordbot'
+
+import type { ChannelRouter, InboundMessage, OutboundCallback, OutboundReply } from '../router'
+import { matchesAnyChatRule, type ChatRule } from '../schema'
+
+export type DiscordBotListenerLike = {
+  on<K extends keyof DiscordBotListenerEventMap>(
+    event: K,
+    handler: (...args: DiscordBotListenerEventMap[K]) => void,
+  ): unknown
+  start: () => Promise<void>
+  stop: () => void
+}
+
+const DM_WORKSPACE_SENTINEL = '@dm'
+
+export type DiscordBotAdapterLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+export type DiscordBotAdapter = {
+  start: () => Promise<void>
+  stop: () => Promise<void>
+  handleInbound: (event: DiscordGatewayMessageCreateEvent) => Promise<void>
+  outboundCallback: OutboundCallback
+}
+
+export type CreateDiscordBotAdapterOptions = {
+  bot: string
+  chats: ChatRule[]
+  router: ChannelRouter
+  client: Pick<DiscordBotClient, 'sendMessage'>
+  listener: DiscordBotListenerLike
+  logger?: DiscordBotAdapterLogger
+}
+
+const consoleLogger: DiscordBotAdapterLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+  error: (m) => console.error(m),
+}
+
+export function createDiscordBotAdapter({
+  bot,
+  chats,
+  router,
+  client,
+  listener,
+  logger = consoleLogger,
+}: CreateDiscordBotAdapterOptions): DiscordBotAdapter {
+  let unbindOutbound: (() => void) | null = null
+
+  async function handleInbound(event: DiscordGatewayMessageCreateEvent): Promise<void> {
+    if (event.author.bot === true) return
+
+    const workspace = event.guild_id ?? DM_WORKSPACE_SENTINEL
+    if (!matchesAnyChatRule(chats, workspace, event.channel_id)) return
+
+    if (event.content.length === 0) return
+
+    const inbound: InboundMessage = {
+      adapter: 'discord-bot',
+      bot,
+      workspace,
+      chat: event.channel_id,
+      thread: null,
+      text: event.content,
+      externalMessageId: event.id,
+      authorId: event.author.id,
+    }
+
+    try {
+      await router.route(inbound)
+    } catch (err) {
+      logger.error(`[discord-bot] route failed: ${errMsg(err)}`)
+    }
+  }
+
+  async function outboundCallback(reply: OutboundReply): Promise<void> {
+    if (reply.bot !== bot) return
+    try {
+      await client.sendMessage(reply.chat, reply.text, reply.thread !== null ? { thread_id: reply.thread } : undefined)
+    } catch (err) {
+      logger.error(`[discord-bot] send failed for ${reply.chat}: ${errMsg(err)}`)
+    }
+  }
+
+  return {
+    async start() {
+      listener.on('message_create', (event) => {
+        void handleInbound(event)
+      })
+      listener.on('error', (err) => {
+        logger.error(`[discord-bot] listener error: ${err.message}`)
+      })
+      listener.on('disconnected', () => {
+        logger.warn(`[discord-bot] disconnected (auto-reconnecting)`)
+      })
+      listener.on('connected', (info) => {
+        logger.info(`[discord-bot] connected as ${info.user.username} (${info.user.id})`)
+      })
+      unbindOutbound = router.bindOutbound('discord-bot', outboundCallback)
+      await listener.start()
+    },
+    async stop() {
+      unbindOutbound?.()
+      unbindOutbound = null
+      listener.stop()
+    },
+    handleInbound,
+    outboundCallback,
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -5,7 +5,7 @@ import type {
 } from 'agent-messenger/discordbot'
 
 import type { ChannelRouter, InboundMessage, OutboundCallback, OutboundReply } from '../router'
-import { matchesAnyChatRule, type ChatRule } from '../schema'
+import { type AllowRule, isAllowed } from '../schema'
 
 export type DiscordBotListenerLike = {
   on<K extends keyof DiscordBotListenerEventMap>(
@@ -32,8 +32,7 @@ export type DiscordBotAdapter = {
 }
 
 export type CreateDiscordBotAdapterOptions = {
-  bot: string
-  chats: ChatRule[]
+  allow: AllowRule[]
   router: ChannelRouter
   client: Pick<DiscordBotClient, 'sendMessage'>
   listener: DiscordBotListenerLike
@@ -47,8 +46,7 @@ const consoleLogger: DiscordBotAdapterLogger = {
 }
 
 export function createDiscordBotAdapter({
-  bot,
-  chats,
+  allow,
   router,
   client,
   listener,
@@ -74,15 +72,14 @@ export function createDiscordBotAdapter({
   async function doHandle(event: DiscordGatewayMessageCreateEvent): Promise<void> {
     if (event.author.bot === true) return
 
-    const workspace = event.guild_id ?? DM_WORKSPACE_SENTINEL
-    if (!matchesAnyChatRule(chats, workspace, event.channel_id)) return
+    const guildId = event.guild_id ?? null
+    if (!isAllowed(allow, guildId, event.channel_id)) return
 
     if (event.content.length === 0) return
 
     const inbound: InboundMessage = {
       adapter: 'discord-bot',
-      bot,
-      workspace,
+      workspace: guildId ?? DM_WORKSPACE_SENTINEL,
       chat: event.channel_id,
       thread: null,
       text: event.content,
@@ -98,12 +95,13 @@ export function createDiscordBotAdapter({
   }
 
   async function outboundCallback(reply: OutboundReply): Promise<void> {
-    if (reply.bot !== bot) return
-    // Re-check chats on every outbound. A reload that narrows the allowlist
-    // doesn't terminate already-live sessions in still-allowed chats; without
-    // this guard, those sessions would keep replying into chats the user
-    // just removed from config.
-    if (!matchesAnyChatRule(chats, reply.workspace, reply.chat)) return
+    if (reply.adapter !== 'discord-bot') return
+    // Re-check allow on every outbound. A reload that narrows the rules
+    // doesn't terminate already-live sessions; without this guard, those
+    // sessions would keep replying into chats the user just removed from
+    // config.
+    const guildId = reply.workspace === DM_WORKSPACE_SENTINEL ? null : reply.workspace
+    if (!isAllowed(allow, guildId, reply.chat)) return
     try {
       await client.sendMessage(reply.chat, reply.text, reply.thread !== null ? { thread_id: reply.thread } : undefined)
     } catch (err) {

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -55,8 +55,23 @@ export function createDiscordBotAdapter({
   logger = consoleLogger,
 }: CreateDiscordBotAdapterOptions): DiscordBotAdapter {
   let unbindOutbound: (() => void) | null = null
+  // Tracks every handleInbound() promise so stop() can await them. Without
+  // this, applyChannels() (and shutdown) can rip the listener away while a
+  // route() is mid-await, leaking partial work and double-creating sessions
+  // when a replacement adapter starts immediately.
+  const inFlight = new Set<Promise<void>>()
 
   async function handleInbound(event: DiscordGatewayMessageCreateEvent): Promise<void> {
+    const promise = doHandle(event)
+    inFlight.add(promise)
+    try {
+      await promise
+    } finally {
+      inFlight.delete(promise)
+    }
+  }
+
+  async function doHandle(event: DiscordGatewayMessageCreateEvent): Promise<void> {
     if (event.author.bot === true) return
 
     const workspace = event.guild_id ?? DM_WORKSPACE_SENTINEL
@@ -112,6 +127,7 @@ export function createDiscordBotAdapter({
       unbindOutbound?.()
       unbindOutbound = null
       listener.stop()
+      await Promise.all([...inFlight])
     },
     handleInbound,
     outboundCallback,

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -132,7 +132,7 @@ export function createDiscordBotAdapter({
       unbindOutbound?.()
       unbindOutbound = null
       listener.stop()
-      await Promise.all([...inFlight])
+      await Promise.all(inFlight)
     },
     handleInbound,
     outboundCallback,

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -99,6 +99,11 @@ export function createDiscordBotAdapter({
 
   async function outboundCallback(reply: OutboundReply): Promise<void> {
     if (reply.bot !== bot) return
+    // Re-check chats on every outbound. A reload that narrows the allowlist
+    // doesn't terminate already-live sessions in still-allowed chats; without
+    // this guard, those sessions would keep replying into chats the user
+    // just removed from config.
+    if (!matchesAnyChatRule(chats, reply.workspace, reply.chat)) return
     try {
       await client.sendMessage(reply.chat, reply.text, reply.thread !== null ? { thread_id: reply.thread } : undefined)
     } catch (err) {

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -1,0 +1,29 @@
+export { channelSchema, matchesAnyChatRule, type Channel, type ChatRule, type DiscordBotChannel } from './schema'
+
+export {
+  createChannelRouter,
+  type AdapterId,
+  type ChannelKey,
+  type ChannelRouter,
+  type ChannelRouterLogger,
+  type ChannelSessionMapping,
+  type CreateChannelRouterOptions,
+  type CreateSessionForChannel,
+  type InboundMessage,
+  type OutboundCallback,
+  type OutboundReply,
+} from './router'
+
+export {
+  createChannelManager,
+  createChannelsReloadable,
+  createDefaultDiscordBotFactory,
+  type ChannelDiff,
+  type ChannelManager,
+  type ChannelManagerLogger,
+  type CreateChannelManagerOptions,
+  type CreateChannelsReloadableOptions,
+  type DiscordBotFactory,
+} from './manager'
+
+export { createDiscordBotAdapter, type DiscordBotAdapter, type DiscordBotListenerLike } from './adapters/discord-bot'

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -1,4 +1,4 @@
-export { channelSchema, matchesAnyChatRule, type Channel, type ChatRule, type DiscordBotChannel } from './schema'
+export { channelsSchema, isAllowed, type AllowRule, type Channels, type DiscordBotConfig } from './schema'
 
 export {
   createChannelRouter,
@@ -9,6 +9,7 @@ export {
   type ChannelSessionMapping,
   type CreateChannelRouterOptions,
   type CreateSessionForChannel,
+  type CreateSessionForChannelOptions,
   type InboundMessage,
   type OutboundCallback,
   type OutboundReply,

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { createChannelManager, type DiscordBotFactory } from './manager'
+import { createChannelRouter } from './router'
+import type { Channel } from './schema'
+
+function fakeAdapter() {
+  const events: string[] = []
+  return {
+    adapter: {
+      async start() {
+        events.push('start')
+      },
+      async stop() {
+        events.push('stop')
+      },
+      async handleInbound() {},
+      outboundCallback: async () => {},
+    },
+    events,
+  }
+}
+
+async function makeRouter() {
+  const dir = await mkdtemp(join(tmpdir(), 'channels-mgr-'))
+  return createChannelRouter({
+    agentDir: dir,
+    createSessionForChannel: async () => ({
+      session: { subscribe: () => () => {}, async prompt() {}, async abort() {} } as any,
+      sessionId: 'sess',
+    }),
+  })
+}
+
+const ch1: Channel = { adapter: 'discord-bot', bot: 'main', chats: ['*'], enabled: true }
+const ch2: Channel = { adapter: 'discord-bot', bot: 'alert', chats: ['*'], enabled: true }
+const ch1Disabled: Channel = { ...ch1, enabled: false }
+const ch1NewChats: Channel = { ...ch1, chats: ['W1/C1'] }
+
+describe('ChannelManager', () => {
+  test('start: enabled channels are started, disabled are skipped', async () => {
+    const router = await makeRouter()
+    const created: { fakes: ReturnType<typeof fakeAdapter>; channel: Channel }[] = []
+    const factory: DiscordBotFactory = async (channel) => {
+      const f = fakeAdapter()
+      created.push({ fakes: f, channel })
+      return { adapter: f.adapter as any, close: async () => {} }
+    }
+    const mgr = createChannelManager({
+      router,
+      channels: [ch1, ch1Disabled],
+      discordBotFactory: factory,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await mgr.start()
+
+    expect(created).toHaveLength(1)
+    expect(created[0]?.channel.bot).toBe('main')
+    expect(mgr.activeKeys()).toEqual(['discord-bot|main'])
+  })
+
+  test('stop: stops all active adapters and closes them', async () => {
+    const router = await makeRouter()
+    const created: ReturnType<typeof fakeAdapter>[] = []
+    let closeCalls = 0
+    const factory: DiscordBotFactory = async () => {
+      const f = fakeAdapter()
+      created.push(f)
+      return {
+        adapter: f.adapter as any,
+        close: async () => {
+          closeCalls++
+        },
+      }
+    }
+    const mgr = createChannelManager({
+      router,
+      channels: [ch1, ch2],
+      discordBotFactory: factory,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    await mgr.start()
+    await mgr.stop()
+
+    expect(created.every((c) => c.events.includes('stop'))).toBe(true)
+    expect(closeCalls).toBe(2)
+    expect(mgr.activeKeys()).toEqual([])
+  })
+
+  test('applyChannels diff: added, removed, updated, unchanged', async () => {
+    const router = await makeRouter()
+    const factory: DiscordBotFactory = async () => {
+      const f = fakeAdapter()
+      return { adapter: f.adapter as any, close: async () => {} }
+    }
+    const mgr = createChannelManager({
+      router,
+      channels: [ch1, ch2],
+      discordBotFactory: factory,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    await mgr.start()
+    expect(mgr.activeKeys().sort()).toEqual(['discord-bot|alert', 'discord-bot|main'])
+
+    const ch3: Channel = { adapter: 'discord-bot', bot: 'extra', chats: ['*'], enabled: true }
+    const diff = await mgr.applyChannels([ch1NewChats, ch3])
+
+    expect(diff.removed.map((c) => c.bot)).toEqual(['alert'])
+    expect(diff.updated.map((c) => c.bot)).toEqual(['main'])
+    expect(diff.added.map((c) => c.bot)).toEqual(['extra'])
+    expect(mgr.activeKeys().sort()).toEqual(['discord-bot|extra', 'discord-bot|main'])
+  })
+
+  test('applyChannels: changed chats list is treated as updated (restart)', async () => {
+    const router = await makeRouter()
+    const startedBots: string[] = []
+    const stoppedBots: string[] = []
+    const factory: DiscordBotFactory = async (channel) => ({
+      adapter: {
+        async start() {
+          startedBots.push(channel.bot)
+        },
+        async stop() {
+          stoppedBots.push(channel.bot)
+        },
+        async handleInbound() {},
+        outboundCallback: async () => {},
+      } as any,
+      close: async () => {},
+    })
+    const mgr = createChannelManager({
+      router,
+      channels: [ch1],
+      discordBotFactory: factory,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    await mgr.start()
+    expect(startedBots).toEqual(['main'])
+
+    const diff = await mgr.applyChannels([ch1NewChats])
+
+    expect(diff.updated.map((c) => c.bot)).toEqual(['main'])
+    expect(stoppedBots).toEqual(['main'])
+    expect(startedBots).toEqual(['main', 'main'])
+  })
+
+  test('applyChannels: enabled flag flip stops the adapter without restarting', async () => {
+    const router = await makeRouter()
+    const fakes = fakeAdapter()
+    const factory: DiscordBotFactory = async () => ({ adapter: fakes.adapter as any, close: async () => {} })
+    const mgr = createChannelManager({
+      router,
+      channels: [ch1],
+      discordBotFactory: factory,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    await mgr.start()
+    expect(fakes.events).toEqual(['start'])
+
+    await mgr.applyChannels([ch1Disabled])
+    expect(mgr.activeKeys()).toEqual([])
+    expect(fakes.events).toEqual(['start', 'stop'])
+  })
+
+  test('factory failure: error is logged, manager stays usable for other channels', async () => {
+    const router = await makeRouter()
+    const errors: string[] = []
+    const factory: DiscordBotFactory = async (channel) => {
+      if (channel.bot === 'main') throw new Error('cannot login as main')
+      const f = fakeAdapter()
+      return { adapter: f.adapter as any, close: async () => {} }
+    }
+    const mgr = createChannelManager({
+      router,
+      channels: [ch1, ch2],
+      discordBotFactory: factory,
+      logger: { info: () => {}, warn: () => {}, error: (m) => errors.push(m) },
+    })
+    await mgr.start()
+
+    expect(errors.some((e) => e.includes('cannot login as main'))).toBe(true)
+    expect(mgr.activeKeys()).toEqual(['discord-bot|alert'])
+  })
+})

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import { createChannelManager, type DiscordBotFactory } from './manager'
 import { createChannelRouter } from './router'
-import type { Channel } from './schema'
+import type { Channels } from './schema'
 
 const tempDirs: string[] = []
 
@@ -46,63 +46,100 @@ async function makeRouter() {
   })
 }
 
-const ch1: Channel = { adapter: 'discord-bot', bot: 'main', chats: ['*'], enabled: true }
-const ch2: Channel = { adapter: 'discord-bot', bot: 'alert', chats: ['*'], enabled: true }
-const ch1Disabled: Channel = { ...ch1, enabled: false }
-const ch1NewChats: Channel = { ...ch1, chats: ['W1/C1'] }
+const empty: Channels = {}
+const enabledStar: Channels = { 'discord-bot': { allow: ['*'], enabled: true } }
+const disabled: Channels = { 'discord-bot': { allow: ['*'], enabled: false } }
+const narrowed: Channels = { 'discord-bot': { allow: ['guild:G1'], enabled: true } }
 
 describe('ChannelManager', () => {
-  test('start: enabled channels are started, disabled are skipped', async () => {
+  test('start: enabled discord-bot is started', async () => {
     const router = await makeRouter()
-    const created: { fakes: ReturnType<typeof fakeAdapter>; channel: Channel }[] = []
-    const factory: DiscordBotFactory = async (channel) => {
+    let createCount = 0
+    const factory: DiscordBotFactory = async () => {
+      createCount++
       const f = fakeAdapter()
-      created.push({ fakes: f, channel })
       return { adapter: f.adapter as any, close: async () => {} }
     }
     const mgr = createChannelManager({
       router,
-      channels: [ch1, ch1Disabled],
+      channels: enabledStar,
       discordBotFactory: factory,
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     })
 
     await mgr.start()
 
-    expect(created).toHaveLength(1)
-    expect(created[0]?.channel.bot).toBe('main')
-    expect(mgr.activeKeys()).toEqual(['discord-bot|main'])
+    expect(createCount).toBe(1)
+    expect(mgr.activeAdapters()).toEqual(['discord-bot'])
   })
 
-  test('stop: stops all active adapters and closes them', async () => {
+  test('start: missing discord-bot is a no-op', async () => {
     const router = await makeRouter()
-    const created: ReturnType<typeof fakeAdapter>[] = []
-    let closeCalls = 0
+    let createCount = 0
     const factory: DiscordBotFactory = async () => {
+      createCount++
       const f = fakeAdapter()
-      created.push(f)
-      return {
-        adapter: f.adapter as any,
-        close: async () => {
-          closeCalls++
-        },
-      }
+      return { adapter: f.adapter as any, close: async () => {} }
     }
     const mgr = createChannelManager({
       router,
-      channels: [ch1, ch2],
+      channels: empty,
+      discordBotFactory: factory,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await mgr.start()
+
+    expect(createCount).toBe(0)
+    expect(mgr.activeAdapters()).toEqual([])
+  })
+
+  test('start: disabled discord-bot is not started', async () => {
+    const router = await makeRouter()
+    let createCount = 0
+    const factory: DiscordBotFactory = async () => {
+      createCount++
+      const f = fakeAdapter()
+      return { adapter: f.adapter as any, close: async () => {} }
+    }
+    const mgr = createChannelManager({
+      router,
+      channels: disabled,
+      discordBotFactory: factory,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+
+    await mgr.start()
+
+    expect(createCount).toBe(0)
+    expect(mgr.activeAdapters()).toEqual([])
+  })
+
+  test('stop: stops active adapters and closes them', async () => {
+    const router = await makeRouter()
+    const fakes = fakeAdapter()
+    let closeCalls = 0
+    const factory: DiscordBotFactory = async () => ({
+      adapter: fakes.adapter as any,
+      close: async () => {
+        closeCalls++
+      },
+    })
+    const mgr = createChannelManager({
+      router,
+      channels: enabledStar,
       discordBotFactory: factory,
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     })
     await mgr.start()
     await mgr.stop()
 
-    expect(created.every((c) => c.events.includes('stop'))).toBe(true)
-    expect(closeCalls).toBe(2)
-    expect(mgr.activeKeys()).toEqual([])
+    expect(fakes.events).toEqual(['start', 'stop'])
+    expect(closeCalls).toBe(1)
+    expect(mgr.activeAdapters()).toEqual([])
   })
 
-  test('applyChannels diff: added, removed, updated, unchanged', async () => {
+  test('applyChannels: added when discord-bot appears for the first time', async () => {
     const router = await makeRouter()
     const factory: DiscordBotFactory = async () => {
       const f = fakeAdapter()
@@ -110,33 +147,49 @@ describe('ChannelManager', () => {
     }
     const mgr = createChannelManager({
       router,
-      channels: [ch1, ch2],
+      channels: empty,
       discordBotFactory: factory,
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     })
     await mgr.start()
-    expect(mgr.activeKeys().sort()).toEqual(['discord-bot|alert', 'discord-bot|main'])
+    expect(mgr.activeAdapters()).toEqual([])
 
-    const ch3: Channel = { adapter: 'discord-bot', bot: 'extra', chats: ['*'], enabled: true }
-    const diff = await mgr.applyChannels([ch1NewChats, ch3])
+    const diff = await mgr.applyChannels(enabledStar)
 
-    expect(diff.removed.map((c) => c.bot)).toEqual(['alert'])
-    expect(diff.updated.map((c) => c.bot)).toEqual(['main'])
-    expect(diff.added.map((c) => c.bot)).toEqual(['extra'])
-    expect(mgr.activeKeys().sort()).toEqual(['discord-bot|extra', 'discord-bot|main'])
+    expect(diff.added).toEqual(['discord-bot'])
+    expect(mgr.activeAdapters()).toEqual(['discord-bot'])
   })
 
-  test('applyChannels: changed chats list is treated as updated (restart)', async () => {
+  test('applyChannels: removed when discord-bot disappears', async () => {
     const router = await makeRouter()
-    const startedBots: string[] = []
-    const stoppedBots: string[] = []
-    const factory: DiscordBotFactory = async (channel) => ({
+    const fakes = fakeAdapter()
+    const factory: DiscordBotFactory = async () => ({ adapter: fakes.adapter as any, close: async () => {} })
+    const mgr = createChannelManager({
+      router,
+      channels: enabledStar,
+      discordBotFactory: factory,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    await mgr.start()
+
+    const diff = await mgr.applyChannels(empty)
+
+    expect(diff.removed).toEqual(['discord-bot'])
+    expect(mgr.activeAdapters()).toEqual([])
+    expect(fakes.events).toEqual(['start', 'stop'])
+  })
+
+  test('applyChannels: changed allow list is treated as updated (restart)', async () => {
+    const router = await makeRouter()
+    const startedConfigs: any[] = []
+    const stoppedConfigs: any[] = []
+    const factory: DiscordBotFactory = async (config) => ({
       adapter: {
         async start() {
-          startedBots.push(channel.bot)
+          startedConfigs.push(config)
         },
         async stop() {
-          stoppedBots.push(channel.bot)
+          stoppedConfigs.push(config)
         },
         async handleInbound() {},
         outboundCallback: async () => {},
@@ -145,18 +198,38 @@ describe('ChannelManager', () => {
     })
     const mgr = createChannelManager({
       router,
-      channels: [ch1],
+      channels: enabledStar,
       discordBotFactory: factory,
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     })
     await mgr.start()
-    expect(startedBots).toEqual(['main'])
+    expect(startedConfigs).toHaveLength(1)
 
-    const diff = await mgr.applyChannels([ch1NewChats])
+    const diff = await mgr.applyChannels(narrowed)
 
-    expect(diff.updated.map((c) => c.bot)).toEqual(['main'])
-    expect(stoppedBots).toEqual(['main'])
-    expect(startedBots).toEqual(['main', 'main'])
+    expect(diff.updated).toEqual(['discord-bot'])
+    expect(stoppedConfigs).toHaveLength(1)
+    expect(startedConfigs).toHaveLength(2)
+    expect(startedConfigs[1]?.allow).toEqual(['guild:G1'])
+  })
+
+  test('applyChannels: unchanged when fingerprint matches', async () => {
+    const router = await makeRouter()
+    const fakes = fakeAdapter()
+    const factory: DiscordBotFactory = async () => ({ adapter: fakes.adapter as any, close: async () => {} })
+    const mgr = createChannelManager({
+      router,
+      channels: enabledStar,
+      discordBotFactory: factory,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    await mgr.start()
+
+    const diff = await mgr.applyChannels(enabledStar)
+
+    expect(diff.unchanged).toEqual(['discord-bot'])
+    expect(diff.updated).toEqual([])
+    expect(fakes.events).toEqual(['start'])
   })
 
   test('applyChannels: enabled flag flip stops the adapter without restarting', async () => {
@@ -165,35 +238,33 @@ describe('ChannelManager', () => {
     const factory: DiscordBotFactory = async () => ({ adapter: fakes.adapter as any, close: async () => {} })
     const mgr = createChannelManager({
       router,
-      channels: [ch1],
+      channels: enabledStar,
       discordBotFactory: factory,
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     })
     await mgr.start()
     expect(fakes.events).toEqual(['start'])
 
-    await mgr.applyChannels([ch1Disabled])
-    expect(mgr.activeKeys()).toEqual([])
+    await mgr.applyChannels(disabled)
+    expect(mgr.activeAdapters()).toEqual([])
     expect(fakes.events).toEqual(['start', 'stop'])
   })
 
-  test('factory failure: error is logged, manager stays usable for other channels', async () => {
+  test('factory failure: error is logged, manager stays usable', async () => {
     const router = await makeRouter()
     const errors: string[] = []
-    const factory: DiscordBotFactory = async (channel) => {
-      if (channel.bot === 'main') throw new Error('cannot login as main')
-      const f = fakeAdapter()
-      return { adapter: f.adapter as any, close: async () => {} }
+    const factory: DiscordBotFactory = async () => {
+      throw new Error('cannot login')
     }
     const mgr = createChannelManager({
       router,
-      channels: [ch1, ch2],
+      channels: enabledStar,
       discordBotFactory: factory,
       logger: { info: () => {}, warn: () => {}, error: (m) => errors.push(m) },
     })
     await mgr.start()
 
-    expect(errors.some((e) => e.includes('cannot login as main'))).toBe(true)
-    expect(mgr.activeKeys()).toEqual(['discord-bot|alert'])
+    expect(errors.some((e) => e.includes('cannot login'))).toBe(true)
+    expect(mgr.activeAdapters()).toEqual([])
   })
 })

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -1,11 +1,21 @@
-import { describe, expect, test } from 'bun:test'
-import { mkdtemp } from 'node:fs/promises'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { createChannelManager, type DiscordBotFactory } from './manager'
 import { createChannelRouter } from './router'
 import type { Channel } from './schema'
+
+const tempDirs: string[] = []
+
+beforeEach(() => {
+  tempDirs.length = 0
+})
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((d) => rm(d, { recursive: true, force: true })))
+})
 
 function fakeAdapter() {
   const events: string[] = []
@@ -26,8 +36,9 @@ function fakeAdapter() {
 
 async function makeRouter() {
   const dir = await mkdtemp(join(tmpdir(), 'channels-mgr-'))
+  tempDirs.push(dir)
   return createChannelRouter({
-    agentDir: dir,
+    cwd: dir,
     createSessionForChannel: async () => ({
       session: { subscribe: () => () => {}, async prompt() {}, async abort() {} } as any,
       sessionId: 'sess',

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -1,0 +1,221 @@
+import type { Reloadable, ReloadResult } from '@/reload'
+
+import { createDiscordBotAdapter, type DiscordBotAdapter, type DiscordBotListenerLike } from './adapters/discord-bot'
+import type { ChannelRouter } from './router'
+import type { Channel, DiscordBotChannel } from './schema'
+
+export type DiscordBotFactory = (channel: DiscordBotChannel) => Promise<{
+  adapter: DiscordBotAdapter
+  close: () => Promise<void>
+}>
+
+export type ChannelManagerLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+export type CreateChannelManagerOptions = {
+  router: ChannelRouter
+  channels: Channel[]
+  discordBotFactory: DiscordBotFactory
+  logger?: ChannelManagerLogger
+}
+
+export type ChannelManager = {
+  start: () => Promise<void>
+  stop: () => Promise<void>
+  applyChannels: (next: Channel[]) => Promise<ChannelDiff>
+  activeKeys: () => string[]
+}
+
+export type ChannelDiff = {
+  added: Channel[]
+  removed: Channel[]
+  updated: Channel[]
+  unchanged: Channel[]
+}
+
+const consoleLogger: ChannelManagerLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+  error: (m) => console.error(m),
+}
+
+type ActiveAdapter = {
+  channel: Channel
+  adapter: DiscordBotAdapter
+  close: () => Promise<void>
+}
+
+export function createChannelManager({
+  router,
+  channels: initial,
+  discordBotFactory,
+  logger = consoleLogger,
+}: CreateChannelManagerOptions): ChannelManager {
+  const active = new Map<string, ActiveAdapter>()
+  let started = false
+
+  return {
+    async start() {
+      if (started) return
+      started = true
+      await router.load()
+      for (const channel of initial) {
+        if (!channel.enabled) continue
+        await startOne(channel)
+      }
+    },
+    async stop() {
+      started = false
+      for (const entry of active.values()) {
+        await entry.adapter.stop()
+        await entry.close()
+      }
+      active.clear()
+      await router.stop()
+    },
+    async applyChannels(next) {
+      const diff = computeDiff(
+        [...active.values()].map((a) => a.channel),
+        next,
+      )
+
+      for (const removed of diff.removed) {
+        const key = channelKey(removed)
+        const entry = active.get(key)
+        if (!entry) continue
+        await entry.adapter.stop()
+        await entry.close()
+        active.delete(key)
+      }
+
+      for (const updated of diff.updated) {
+        const key = channelKey(updated)
+        const entry = active.get(key)
+        if (entry) {
+          await entry.adapter.stop()
+          await entry.close()
+          active.delete(key)
+        }
+        if (updated.enabled) await startOne(updated)
+      }
+
+      for (const added of diff.added) {
+        if (added.enabled) await startOne(added)
+      }
+
+      return diff
+    },
+    activeKeys() {
+      return [...active.keys()]
+    },
+  }
+
+  async function startOne(channel: Channel): Promise<void> {
+    if (channel.adapter !== 'discord-bot') {
+      logger.warn(`[channels] adapter ${channel.adapter} is not supported in v0.1; skipping`)
+      return
+    }
+    try {
+      const { adapter, close } = await discordBotFactory(channel)
+      await adapter.start()
+      active.set(channelKey(channel), { channel, adapter, close })
+      logger.info(`[channels] started discord-bot/${channel.bot}`)
+    } catch (err) {
+      logger.error(`[channels] failed to start discord-bot/${channel.bot}: ${errMsg(err)}`)
+    }
+  }
+}
+
+export function createDefaultDiscordBotFactory(opts: {
+  router: ChannelRouter
+  createDiscordBotClientAndListener: (channel: DiscordBotChannel) => Promise<{
+    client: Parameters<typeof createDiscordBotAdapter>[0]['client']
+    listener: DiscordBotListenerLike
+    close: () => Promise<void>
+  }>
+  logger?: ChannelManagerLogger
+}): DiscordBotFactory {
+  return async (channel) => {
+    const built = await opts.createDiscordBotClientAndListener(channel)
+    const adapter = createDiscordBotAdapter({
+      bot: channel.bot,
+      chats: channel.chats,
+      router: opts.router,
+      client: built.client,
+      listener: built.listener,
+      ...(opts.logger ? { logger: opts.logger } : {}),
+    })
+    return { adapter, close: built.close }
+  }
+}
+
+export type CreateChannelsReloadableOptions = {
+  manager: ChannelManager
+  loadChannels: () => Channel[]
+}
+
+export function createChannelsReloadable({ manager, loadChannels }: CreateChannelsReloadableOptions): Reloadable {
+  return {
+    scope: 'channels',
+    description: 'channels from typeclaw.json',
+    reload: async (): Promise<ReloadResult> => {
+      try {
+        const next = loadChannels()
+        const diff = await manager.applyChannels(next)
+        return {
+          scope: 'channels',
+          ok: true,
+          summary: `${next.length} channels (added ${diff.added.length}, removed ${diff.removed.length}, updated ${diff.updated.length}, unchanged ${diff.unchanged.length})`,
+          details: diff,
+        }
+      } catch (err) {
+        return { scope: 'channels', ok: false, reason: errMsg(err) }
+      }
+    },
+  }
+}
+
+function channelKey(channel: Channel): string {
+  return `${channel.adapter}|${channel.bot}`
+}
+
+function fingerprint(channel: Channel): string {
+  return JSON.stringify({ adapter: channel.adapter, bot: channel.bot, chats: channel.chats, enabled: channel.enabled })
+}
+
+function computeDiff(before: Channel[], next: Channel[]): ChannelDiff {
+  const added: Channel[] = []
+  const removed: Channel[] = []
+  const updated: Channel[] = []
+  const unchanged: Channel[] = []
+
+  const beforeByKey = new Map<string, Channel>()
+  for (const c of before) beforeByKey.set(channelKey(c), c)
+  const nextByKey = new Map<string, Channel>()
+  for (const c of next) nextByKey.set(channelKey(c), c)
+
+  for (const [key, beforeC] of beforeByKey) {
+    const nextC = nextByKey.get(key)
+    if (!nextC) {
+      removed.push(beforeC)
+      continue
+    }
+    if (fingerprint(beforeC) === fingerprint(nextC)) {
+      unchanged.push(nextC)
+    } else {
+      updated.push(nextC)
+    }
+  }
+  for (const [key, nextC] of nextByKey) {
+    if (!beforeByKey.has(key)) added.push(nextC)
+  }
+
+  return { added, removed, updated, unchanged }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -1,10 +1,10 @@
 import type { Reloadable, ReloadResult } from '@/reload'
 
 import { createDiscordBotAdapter, type DiscordBotAdapter, type DiscordBotListenerLike } from './adapters/discord-bot'
-import type { ChannelRouter } from './router'
-import type { Channel, DiscordBotChannel } from './schema'
+import type { AdapterId, ChannelRouter } from './router'
+import type { Channels, DiscordBotConfig } from './schema'
 
-export type DiscordBotFactory = (channel: DiscordBotChannel) => Promise<{
+export type DiscordBotFactory = (config: DiscordBotConfig) => Promise<{
   adapter: DiscordBotAdapter
   close: () => Promise<void>
 }>
@@ -17,7 +17,7 @@ export type ChannelManagerLogger = {
 
 export type CreateChannelManagerOptions = {
   router: ChannelRouter
-  channels: Channel[]
+  channels: Channels
   discordBotFactory: DiscordBotFactory
   logger?: ChannelManagerLogger
 }
@@ -25,15 +25,15 @@ export type CreateChannelManagerOptions = {
 export type ChannelManager = {
   start: () => Promise<void>
   stop: () => Promise<void>
-  applyChannels: (next: Channel[]) => Promise<ChannelDiff>
-  activeKeys: () => string[]
+  applyChannels: (next: Channels) => Promise<ChannelDiff>
+  activeAdapters: () => AdapterId[]
 }
 
 export type ChannelDiff = {
-  added: Channel[]
-  removed: Channel[]
-  updated: Channel[]
-  unchanged: Channel[]
+  added: AdapterId[]
+  removed: AdapterId[]
+  updated: AdapterId[]
+  unchanged: AdapterId[]
 }
 
 const consoleLogger: ChannelManagerLogger = {
@@ -43,7 +43,7 @@ const consoleLogger: ChannelManagerLogger = {
 }
 
 type ActiveAdapter = {
-  channel: Channel
+  config: DiscordBotConfig
   adapter: DiscordBotAdapter
   close: () => Promise<void>
 }
@@ -54,17 +54,18 @@ export function createChannelManager({
   discordBotFactory,
   logger = consoleLogger,
 }: CreateChannelManagerOptions): ChannelManager {
-  const active = new Map<string, ActiveAdapter>()
+  const active = new Map<AdapterId, ActiveAdapter>()
   let started = false
+  let current: Channels = initial
 
   return {
     async start() {
       if (started) return
       started = true
       await router.load()
-      for (const channel of initial) {
-        if (!channel.enabled) continue
-        await startOne(channel)
+      const discord = current['discord-bot']
+      if (discord !== undefined && discord.enabled) {
+        await startDiscord(discord)
       }
     },
     async stop() {
@@ -77,72 +78,71 @@ export function createChannelManager({
       await router.stop()
     },
     async applyChannels(next) {
-      const diff = computeDiff(
-        [...active.values()].map((a) => a.channel),
-        next,
-      )
+      const diff = computeDiff(current, next)
+      current = next
 
-      for (const removed of diff.removed) {
-        const key = channelKey(removed)
-        const entry = active.get(key)
+      for (const adapterId of diff.removed) {
+        const entry = active.get(adapterId)
         if (!entry) continue
         await entry.adapter.stop()
         await entry.close()
-        active.delete(key)
+        active.delete(adapterId)
       }
 
-      for (const updated of diff.updated) {
-        const key = channelKey(updated)
-        const entry = active.get(key)
+      for (const adapterId of diff.updated) {
+        const entry = active.get(adapterId)
         if (entry) {
           await entry.adapter.stop()
           await entry.close()
-          active.delete(key)
+          active.delete(adapterId)
         }
-        if (updated.enabled) await startOne(updated)
+        await startIfEnabled(adapterId, next)
       }
 
-      for (const added of diff.added) {
-        if (added.enabled) await startOne(added)
+      for (const adapterId of diff.added) {
+        await startIfEnabled(adapterId, next)
       }
 
       return diff
     },
-    activeKeys() {
+    activeAdapters() {
       return [...active.keys()]
     },
   }
 
-  async function startOne(channel: Channel): Promise<void> {
-    if (channel.adapter !== 'discord-bot') {
-      logger.warn(`[channels] adapter ${channel.adapter} is not supported in v0.1; skipping`)
-      return
+  async function startIfEnabled(adapterId: AdapterId, channels: Channels): Promise<void> {
+    if (adapterId === 'discord-bot') {
+      const config = channels['discord-bot']
+      if (config === undefined || !config.enabled) return
+      await startDiscord(config)
     }
+  }
+
+  async function startDiscord(config: DiscordBotConfig): Promise<void> {
     try {
-      const { adapter, close } = await discordBotFactory(channel)
+      const { adapter, close } = await discordBotFactory(config)
       await adapter.start()
-      active.set(channelKey(channel), { channel, adapter, close })
-      logger.info(`[channels] started discord-bot/${channel.bot}`)
+      active.set('discord-bot', { config, adapter, close })
+      logger.info(`[channels] started discord-bot`)
     } catch (err) {
-      logger.error(`[channels] failed to start discord-bot/${channel.bot}: ${errMsg(err)}`)
+      logger.error(`[channels] failed to start discord-bot: ${errMsg(err)}`)
     }
   }
 }
 
 export function createDefaultDiscordBotFactory(opts: {
   router: ChannelRouter
-  createDiscordBotClientAndListener: (channel: DiscordBotChannel) => Promise<{
+  createDiscordBotClientAndListener: (config: DiscordBotConfig) => Promise<{
     client: Parameters<typeof createDiscordBotAdapter>[0]['client']
     listener: DiscordBotListenerLike
     close: () => Promise<void>
   }>
   logger?: ChannelManagerLogger
 }): DiscordBotFactory {
-  return async (channel) => {
-    const built = await opts.createDiscordBotClientAndListener(channel)
+  return async (config) => {
+    const built = await opts.createDiscordBotClientAndListener(config)
     const adapter = createDiscordBotAdapter({
-      bot: channel.bot,
-      chats: channel.chats,
+      allow: config.allow,
       router: opts.router,
       client: built.client,
       listener: built.listener,
@@ -154,7 +154,7 @@ export function createDefaultDiscordBotFactory(opts: {
 
 export type CreateChannelsReloadableOptions = {
   manager: ChannelManager
-  loadChannels: () => Channel[]
+  loadChannels: () => Channels
 }
 
 export function createChannelsReloadable({ manager, loadChannels }: CreateChannelsReloadableOptions): Reloadable {
@@ -168,7 +168,7 @@ export function createChannelsReloadable({ manager, loadChannels }: CreateChanne
         return {
           scope: 'channels',
           ok: true,
-          summary: `${next.length} channels (added ${diff.added.length}, removed ${diff.removed.length}, updated ${diff.updated.length}, unchanged ${diff.unchanged.length})`,
+          summary: `${diff.added.length} added, ${diff.removed.length} removed, ${diff.updated.length} updated, ${diff.unchanged.length} unchanged`,
           details: diff,
         }
       } catch (err) {
@@ -178,42 +178,26 @@ export function createChannelsReloadable({ manager, loadChannels }: CreateChanne
   }
 }
 
-function channelKey(channel: Channel): string {
-  return `${channel.adapter}|${channel.bot}`
+function discordFingerprint(config: DiscordBotConfig | undefined): string | null {
+  if (config === undefined) return null
+  return JSON.stringify({ allow: config.allow, enabled: config.enabled })
 }
 
-function fingerprint(channel: Channel): string {
-  return JSON.stringify({ adapter: channel.adapter, bot: channel.bot, chats: channel.chats, enabled: channel.enabled })
-}
+function computeDiff(before: Channels, next: Channels): ChannelDiff {
+  const result: ChannelDiff = { added: [], removed: [], updated: [], unchanged: [] }
 
-function computeDiff(before: Channel[], next: Channel[]): ChannelDiff {
-  const added: Channel[] = []
-  const removed: Channel[] = []
-  const updated: Channel[] = []
-  const unchanged: Channel[] = []
-
-  const beforeByKey = new Map<string, Channel>()
-  for (const c of before) beforeByKey.set(channelKey(c), c)
-  const nextByKey = new Map<string, Channel>()
-  for (const c of next) nextByKey.set(channelKey(c), c)
-
-  for (const [key, beforeC] of beforeByKey) {
-    const nextC = nextByKey.get(key)
-    if (!nextC) {
-      removed.push(beforeC)
-      continue
-    }
-    if (fingerprint(beforeC) === fingerprint(nextC)) {
-      unchanged.push(nextC)
-    } else {
-      updated.push(nextC)
+  for (const adapterId of ['discord-bot'] as const) {
+    const beforeFp = discordFingerprint(before[adapterId])
+    const nextFp = discordFingerprint(next[adapterId])
+    if (beforeFp === null && nextFp !== null) result.added.push(adapterId)
+    else if (beforeFp !== null && nextFp === null) result.removed.push(adapterId)
+    else if (beforeFp !== null && nextFp !== null) {
+      if (beforeFp === nextFp) result.unchanged.push(adapterId)
+      else result.updated.push(adapterId)
     }
   }
-  for (const [key, nextC] of nextByKey) {
-    if (!beforeByKey.has(key)) added.push(nextC)
-  }
 
-  return { added, removed, updated, unchanged }
+  return result
 }
 
 function errMsg(err: unknown): string {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -51,7 +51,6 @@ function emitMessageEnd(
 
 const baseEvent: InboundMessage = {
   adapter: 'discord-bot',
-  bot: 'main',
   workspace: 'W1',
   chat: 'C1',
   thread: null,
@@ -89,7 +88,6 @@ describe('ChannelRouter', () => {
     expect(mappings).toHaveLength(1)
     expect(mappings[0]).toMatchObject({
       adapter: 'discord-bot',
-      bot: 'main',
       workspace: 'W1',
       chat: 'C1',
       thread: null,
@@ -97,7 +95,7 @@ describe('ChannelRouter', () => {
     })
 
     const persisted = JSON.parse(await readFile(join(dir, 'channels/sessions.json'), 'utf8'))
-    expect(persisted.version).toBe(1)
+    expect(persisted.version).toBe(2)
     expect(persisted.mappings).toHaveLength(1)
   })
 
@@ -118,13 +116,11 @@ describe('ChannelRouter', () => {
     expect(router.liveSessionCount()).toBe(1)
   })
 
-  test('different (workspace, chat) tuples each get their own session', async () => {
+  test('different (workspace, chat, thread) tuples each get their own session', async () => {
     let n = 0
-    const fakesByCall: ReturnType<typeof createFakeSession>[] = []
     const createSessionForChannel: CreateSessionForChannel = async () => {
       n++
       const f = createFakeSession()
-      fakesByCall.push(f)
       return { session: f.session, sessionId: `sess-${n}` }
     }
     const router = createChannelRouter({ cwd: dir, createSessionForChannel })
@@ -139,7 +135,7 @@ describe('ChannelRouter', () => {
     expect(router.knownMappings()).toHaveLength(4)
   })
 
-  test('reload from disk: on construction, an existing sessions.json is loaded', async () => {
+  test('reload from disk: an existing v2 sessions.json is loaded', async () => {
     const fakes1 = createFakeSession()
     const router1 = createChannelRouter({
       cwd: dir,
@@ -186,7 +182,6 @@ describe('ChannelRouter', () => {
     expect(replies).toHaveLength(1)
     expect(replies[0]).toMatchObject({
       adapter: 'discord-bot',
-      bot: 'main',
       workspace: 'W1',
       chat: 'C1',
       thread: null,
@@ -295,6 +290,24 @@ describe('ChannelRouter', () => {
     expect(router.knownMappings()).toEqual([])
   })
 
+  test('older sessions.json (v1) is ignored with a warning', async () => {
+    await Bun.write(
+      join(dir, 'channels/sessions.json'),
+      JSON.stringify({ version: 1, mappings: [{ adapter: 'discord-bot' }] }),
+    )
+    const fakes = createFakeSession()
+    const warnings: string[] = []
+    const router = createChannelRouter({
+      cwd: dir,
+      createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
+      logger: { info: () => {}, warn: (m) => warnings.push(m), error: () => {} },
+    })
+    await router.load()
+
+    expect(warnings.some((w) => w.includes('not version 2'))).toBe(true)
+    expect(router.knownMappings()).toEqual([])
+  })
+
   test('unknown adapter outbound is dropped with a warning, no throw', async () => {
     const fakes = createFakeSession()
     const warnings: string[] = []
@@ -368,11 +381,10 @@ describe('ChannelRouter', () => {
     await Bun.write(
       join(dir, 'channels/sessions.json'),
       JSON.stringify({
-        version: 1,
+        version: 2,
         mappings: [
           {
             adapter: 'discord-bot',
-            bot: 'main',
             workspace: 'W1',
             chat: 'C1',
             thread: null,

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -313,4 +313,83 @@ describe('ChannelRouter', () => {
 
     expect(warnings.some((w) => w.includes('no outbound callback'))).toBe(true)
   })
+
+  test('concurrent route() for the same key creates only one session', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const fakes = createFakeSession()
+    let createCount = 0
+    const createSessionForChannel: CreateSessionForChannel = async () => {
+      createCount++
+      await new Promise((r) => setTimeout(r, 20))
+      return { session: fakes.session, sessionId: 'sess-1' }
+    }
+    const router = createChannelRouter({ agentDir: dir, createSessionForChannel })
+
+    await Promise.all([
+      router.route({ ...baseEvent, text: 'first', externalMessageId: 'x1' }),
+      router.route({ ...baseEvent, text: 'second', externalMessageId: 'x2' }),
+      router.route({ ...baseEvent, text: 'third', externalMessageId: 'x3' }),
+    ])
+
+    expect(createCount).toBe(1)
+    expect(router.liveSessionCount()).toBe(1)
+    expect(router.knownMappings()).toHaveLength(1)
+  })
+
+  test('concurrent route() for the same key serializes session.prompt() FIFO', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const promptOrder: string[] = []
+    const inFlight: { current: number } = { current: 0 }
+    let maxConcurrent = 0
+    const session = {
+      subscribe: () => () => {},
+      async prompt(text: string) {
+        inFlight.current++
+        if (inFlight.current > maxConcurrent) maxConcurrent = inFlight.current
+        await new Promise((r) => setTimeout(r, 10))
+        promptOrder.push(text)
+        inFlight.current--
+      },
+      async abort() {},
+    }
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => ({ session: session as any, sessionId: 'sess-1' }),
+    })
+
+    await Promise.all([
+      router.route({ ...baseEvent, text: 'a', externalMessageId: 'x1' }),
+      router.route({ ...baseEvent, text: 'b', externalMessageId: 'x2' }),
+      router.route({ ...baseEvent, text: 'c', externalMessageId: 'x3' }),
+    ])
+
+    expect(promptOrder).toEqual(['a', 'b', 'c'])
+    expect(maxConcurrent).toBe(1)
+  })
+
+  test('mapping is persisted to disk before any prompt runs', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const observed: { persisted: boolean | null } = { persisted: null }
+    const session = {
+      subscribe: () => () => {},
+      async prompt() {
+        try {
+          const raw = await readFile(join(dir, 'channels/sessions.json'), 'utf8')
+          const parsed = JSON.parse(raw) as { mappings: { sessionId: string }[] }
+          observed.persisted = parsed.mappings.some((m) => m.sessionId === 'sess-1')
+        } catch {
+          observed.persisted = false
+        }
+      },
+      async abort() {},
+    }
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => ({ session: session as any, sessionId: 'sess-1' }),
+    })
+
+    await router.route(baseEvent)
+
+    expect(observed.persisted).toBe(true)
+  })
 })

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { createChannelRouter, type CreateSessionForChannel, type InboundMessage, type OutboundReply } from './router'
+
+type FakeListener = (event: any) => void
+
+function createFakeSession() {
+  const listeners: FakeListener[] = []
+  const promptCalls: string[] = []
+  return {
+    session: {
+      subscribe(listener: FakeListener) {
+        listeners.push(listener)
+        return () => {
+          const i = listeners.indexOf(listener)
+          if (i >= 0) listeners.splice(i, 1)
+        }
+      },
+      async prompt(text: string) {
+        promptCalls.push(text)
+      },
+      async abort() {},
+    } as any,
+    listeners,
+    promptCalls,
+  }
+}
+
+function emitTextDelta(fakes: { listeners: FakeListener[] }, delta: string) {
+  for (const l of fakes.listeners) {
+    l({
+      type: 'message_update',
+      message: { id: 'm1', role: 'assistant' },
+      assistantMessageEvent: { type: 'text_delta', delta },
+    })
+  }
+}
+
+function emitMessageEnd(
+  fakes: { listeners: FakeListener[] },
+  role: 'assistant' | 'user' = 'assistant',
+  responseId = 'm1',
+) {
+  for (const l of fakes.listeners) {
+    l({ type: 'message_end', message: { role, responseId, timestamp: 1 } })
+  }
+}
+
+const baseEvent: InboundMessage = {
+  adapter: 'discord-bot',
+  bot: 'main',
+  workspace: 'W1',
+  chat: 'C1',
+  thread: null,
+  text: 'hello',
+  externalMessageId: 'xm1',
+  authorId: 'u1',
+}
+
+describe('ChannelRouter', () => {
+  test('first inbound creates a session, persists mapping, and prompts the session', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const fakes = createFakeSession()
+    let createCount = 0
+    const createSessionForChannel: CreateSessionForChannel = async () => {
+      createCount++
+      return { session: fakes.session, sessionId: 'sess-1' }
+    }
+
+    const router = createChannelRouter({ agentDir: dir, createSessionForChannel })
+    await router.route(baseEvent)
+
+    expect(createCount).toBe(1)
+    expect(fakes.promptCalls).toEqual(['hello'])
+    expect(router.liveSessionCount()).toBe(1)
+    const mappings = router.knownMappings()
+    expect(mappings).toHaveLength(1)
+    expect(mappings[0]).toMatchObject({
+      adapter: 'discord-bot',
+      bot: 'main',
+      workspace: 'W1',
+      chat: 'C1',
+      thread: null,
+      sessionId: 'sess-1',
+    })
+
+    const persisted = JSON.parse(await readFile(join(dir, 'channels/sessions.json'), 'utf8'))
+    expect(persisted.version).toBe(1)
+    expect(persisted.mappings).toHaveLength(1)
+  })
+
+  test('subsequent inbound for same key reuses the session (no second create)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const fakes = createFakeSession()
+    let createCount = 0
+    const createSessionForChannel: CreateSessionForChannel = async () => {
+      createCount++
+      return { session: fakes.session, sessionId: 'sess-1' }
+    }
+    const router = createChannelRouter({ agentDir: dir, createSessionForChannel })
+
+    await router.route(baseEvent)
+    await router.route({ ...baseEvent, text: 'second', externalMessageId: 'xm2' })
+
+    expect(createCount).toBe(1)
+    expect(fakes.promptCalls).toEqual(['hello', 'second'])
+    expect(router.liveSessionCount()).toBe(1)
+  })
+
+  test('different (workspace, chat) tuples each get their own session', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    let n = 0
+    const fakesByCall: ReturnType<typeof createFakeSession>[] = []
+    const createSessionForChannel: CreateSessionForChannel = async () => {
+      n++
+      const f = createFakeSession()
+      fakesByCall.push(f)
+      return { session: f.session, sessionId: `sess-${n}` }
+    }
+    const router = createChannelRouter({ agentDir: dir, createSessionForChannel })
+
+    await router.route(baseEvent)
+    await router.route({ ...baseEvent, workspace: 'W2' })
+    await router.route({ ...baseEvent, chat: 'C2' })
+    await router.route({ ...baseEvent, thread: 'T1' })
+
+    expect(n).toBe(4)
+    expect(router.liveSessionCount()).toBe(4)
+    expect(router.knownMappings()).toHaveLength(4)
+  })
+
+  test('reload from disk: on construction, an existing sessions.json is loaded', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const fakes1 = createFakeSession()
+    const router1 = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => ({ session: fakes1.session, sessionId: 'sess-A' }),
+    })
+    await router1.route(baseEvent)
+    await router1.stop()
+
+    const fakes2 = createFakeSession()
+    let createCount = 0
+    const router2 = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => {
+        createCount++
+        return { session: fakes2.session, sessionId: 'sess-B' }
+      },
+    })
+    await router2.load()
+
+    expect(router2.knownMappings()).toHaveLength(1)
+    expect(router2.knownMappings()[0]?.sessionId).toBe('sess-A')
+    expect(createCount).toBe(0)
+  })
+
+  test('outbound: assistant message_end posts accumulated text to the bound callback', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const fakes = createFakeSession()
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
+    })
+
+    const replies: OutboundReply[] = []
+    router.bindOutbound('discord-bot', (r) => {
+      replies.push(r)
+    })
+
+    await router.route(baseEvent)
+    emitTextDelta(fakes, 'hi ')
+    emitTextDelta(fakes, 'there')
+    emitMessageEnd(fakes, 'assistant')
+
+    await Promise.resolve()
+
+    expect(replies).toHaveLength(1)
+    expect(replies[0]).toMatchObject({
+      adapter: 'discord-bot',
+      bot: 'main',
+      workspace: 'W1',
+      chat: 'C1',
+      thread: null,
+      text: 'hi there',
+    })
+    expect(replies[0]?.turnId).toBe('sess-1:m1')
+  })
+
+  test('outbound: user message_end does not trigger a reply', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const fakes = createFakeSession()
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
+    })
+
+    const replies: OutboundReply[] = []
+    router.bindOutbound('discord-bot', (r) => {
+      replies.push(r)
+    })
+
+    await router.route(baseEvent)
+    emitTextDelta(fakes, 'unused')
+    emitMessageEnd(fakes, 'user')
+
+    expect(replies).toHaveLength(0)
+  })
+
+  test('outbound: assistant message with no accumulated text does not post', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const fakes = createFakeSession()
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
+    })
+    const replies: OutboundReply[] = []
+    router.bindOutbound('discord-bot', (r) => {
+      replies.push(r)
+    })
+
+    await router.route(baseEvent)
+    emitMessageEnd(fakes, 'assistant')
+
+    expect(replies).toHaveLength(0)
+  })
+
+  test('bindOutbound returns an unsubscribe that removes the callback', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const fakes = createFakeSession()
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
+    })
+    const replies: OutboundReply[] = []
+    const off = router.bindOutbound('discord-bot', (r) => {
+      replies.push(r)
+    })
+
+    await router.route(baseEvent)
+    emitTextDelta(fakes, 'first')
+    emitMessageEnd(fakes, 'assistant', 'm1')
+    await Promise.resolve()
+
+    off()
+    emitTextDelta(fakes, 'second')
+    emitMessageEnd(fakes, 'assistant', 'm2')
+    await Promise.resolve()
+
+    expect(replies).toHaveLength(1)
+    expect(replies[0]?.text).toBe('first')
+  })
+
+  test('multiple text_delta accumulate per turn and reset across turns', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const fakes = createFakeSession()
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
+    })
+    const replies: OutboundReply[] = []
+    router.bindOutbound('discord-bot', (r) => {
+      replies.push(r)
+    })
+
+    await router.route(baseEvent)
+    emitTextDelta(fakes, 'turn1-')
+    emitTextDelta(fakes, 'final')
+    emitMessageEnd(fakes, 'assistant', 'm1')
+    await Promise.resolve()
+
+    emitTextDelta(fakes, 'turn2')
+    emitMessageEnd(fakes, 'assistant', 'm2')
+    await Promise.resolve()
+
+    expect(replies.map((r) => r.text)).toEqual(['turn1-final', 'turn2'])
+  })
+
+  test('corrupt sessions.json: logs and continues with empty mappings', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    await Bun.write(join(dir, 'channels/sessions.json'), '{not json')
+    const fakes = createFakeSession()
+    const errors: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
+      logger: { info: () => {}, warn: () => {}, error: (m) => errors.push(m) },
+    })
+    await router.load()
+
+    expect(errors.some((e) => e.includes('not valid JSON'))).toBe(true)
+    expect(router.knownMappings()).toEqual([])
+  })
+
+  test('unknown adapter outbound is dropped with a warning, no throw', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const fakes = createFakeSession()
+    const warnings: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
+      logger: { info: () => {}, warn: (m) => warnings.push(m), error: () => {} },
+    })
+
+    await router.route(baseEvent)
+    emitTextDelta(fakes, 'orphan')
+    emitMessageEnd(fakes, 'assistant')
+
+    await Promise.resolve()
+
+    expect(warnings.some((w) => w.includes('no outbound callback'))).toBe(true)
+  })
+})

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -420,6 +420,36 @@ describe('ChannelRouter', () => {
     expect(seen[0]?.existingSessionId).toBeUndefined()
   })
 
+  test('stop() aborts in-flight session prompts', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const abortCalls: string[] = []
+    let resolvePrompt: () => void = () => {}
+    const session = {
+      subscribe: () => () => {},
+      async prompt() {
+        await new Promise<void>((r) => {
+          resolvePrompt = r
+        })
+      },
+      async abort() {
+        abortCalls.push('abort')
+        resolvePrompt()
+      },
+    }
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async () => ({ session: session as any, sessionId: 'sess-1' }),
+    })
+
+    const routePromise = router.route(baseEvent)
+    await new Promise((r) => setTimeout(r, 20))
+    await router.stop()
+    await routePromise
+
+    expect(abortCalls).toEqual(['abort'])
+    expect(router.liveSessionCount()).toBe(0)
+  })
+
   test('mapping is persisted to disk before any prompt runs', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const observed: { persisted: boolean | null } = { persisted: null }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from 'bun:test'
-import { mkdtemp, readFile } from 'node:fs/promises'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -60,9 +60,18 @@ const baseEvent: InboundMessage = {
   authorId: 'u1',
 }
 
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
 describe('ChannelRouter', () => {
   test('first inbound creates a session, persists mapping, and prompts the session', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const fakes = createFakeSession()
     let createCount = 0
     const createSessionForChannel: CreateSessionForChannel = async () => {
@@ -70,7 +79,7 @@ describe('ChannelRouter', () => {
       return { session: fakes.session, sessionId: 'sess-1' }
     }
 
-    const router = createChannelRouter({ agentDir: dir, createSessionForChannel })
+    const router = createChannelRouter({ cwd: dir, createSessionForChannel })
     await router.route(baseEvent)
 
     expect(createCount).toBe(1)
@@ -93,14 +102,13 @@ describe('ChannelRouter', () => {
   })
 
   test('subsequent inbound for same key reuses the session (no second create)', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const fakes = createFakeSession()
     let createCount = 0
     const createSessionForChannel: CreateSessionForChannel = async () => {
       createCount++
       return { session: fakes.session, sessionId: 'sess-1' }
     }
-    const router = createChannelRouter({ agentDir: dir, createSessionForChannel })
+    const router = createChannelRouter({ cwd: dir, createSessionForChannel })
 
     await router.route(baseEvent)
     await router.route({ ...baseEvent, text: 'second', externalMessageId: 'xm2' })
@@ -111,7 +119,6 @@ describe('ChannelRouter', () => {
   })
 
   test('different (workspace, chat) tuples each get their own session', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     let n = 0
     const fakesByCall: ReturnType<typeof createFakeSession>[] = []
     const createSessionForChannel: CreateSessionForChannel = async () => {
@@ -120,7 +127,7 @@ describe('ChannelRouter', () => {
       fakesByCall.push(f)
       return { session: f.session, sessionId: `sess-${n}` }
     }
-    const router = createChannelRouter({ agentDir: dir, createSessionForChannel })
+    const router = createChannelRouter({ cwd: dir, createSessionForChannel })
 
     await router.route(baseEvent)
     await router.route({ ...baseEvent, workspace: 'W2' })
@@ -133,10 +140,9 @@ describe('ChannelRouter', () => {
   })
 
   test('reload from disk: on construction, an existing sessions.json is loaded', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const fakes1 = createFakeSession()
     const router1 = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => ({ session: fakes1.session, sessionId: 'sess-A' }),
     })
     await router1.route(baseEvent)
@@ -145,7 +151,7 @@ describe('ChannelRouter', () => {
     const fakes2 = createFakeSession()
     let createCount = 0
     const router2 = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => {
         createCount++
         return { session: fakes2.session, sessionId: 'sess-B' }
@@ -159,10 +165,9 @@ describe('ChannelRouter', () => {
   })
 
   test('outbound: assistant message_end posts accumulated text to the bound callback', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const fakes = createFakeSession()
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
     })
 
@@ -191,10 +196,9 @@ describe('ChannelRouter', () => {
   })
 
   test('outbound: user message_end does not trigger a reply', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const fakes = createFakeSession()
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
     })
 
@@ -211,10 +215,9 @@ describe('ChannelRouter', () => {
   })
 
   test('outbound: assistant message with no accumulated text does not post', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const fakes = createFakeSession()
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
     })
     const replies: OutboundReply[] = []
@@ -229,10 +232,9 @@ describe('ChannelRouter', () => {
   })
 
   test('bindOutbound returns an unsubscribe that removes the callback', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const fakes = createFakeSession()
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
     })
     const replies: OutboundReply[] = []
@@ -255,10 +257,9 @@ describe('ChannelRouter', () => {
   })
 
   test('multiple text_delta accumulate per turn and reset across turns', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const fakes = createFakeSession()
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
     })
     const replies: OutboundReply[] = []
@@ -280,12 +281,11 @@ describe('ChannelRouter', () => {
   })
 
   test('corrupt sessions.json: logs and continues with empty mappings', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     await Bun.write(join(dir, 'channels/sessions.json'), '{not json')
     const fakes = createFakeSession()
     const errors: string[] = []
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
       logger: { info: () => {}, warn: () => {}, error: (m) => errors.push(m) },
     })
@@ -296,11 +296,10 @@ describe('ChannelRouter', () => {
   })
 
   test('unknown adapter outbound is dropped with a warning, no throw', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const fakes = createFakeSession()
     const warnings: string[] = []
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => ({ session: fakes.session, sessionId: 'sess-1' }),
       logger: { info: () => {}, warn: (m) => warnings.push(m), error: () => {} },
     })
@@ -315,7 +314,6 @@ describe('ChannelRouter', () => {
   })
 
   test('concurrent route() for the same key creates only one session', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const fakes = createFakeSession()
     let createCount = 0
     const createSessionForChannel: CreateSessionForChannel = async () => {
@@ -323,7 +321,7 @@ describe('ChannelRouter', () => {
       await new Promise((r) => setTimeout(r, 20))
       return { session: fakes.session, sessionId: 'sess-1' }
     }
-    const router = createChannelRouter({ agentDir: dir, createSessionForChannel })
+    const router = createChannelRouter({ cwd: dir, createSessionForChannel })
 
     await Promise.all([
       router.route({ ...baseEvent, text: 'first', externalMessageId: 'x1' }),
@@ -337,7 +335,6 @@ describe('ChannelRouter', () => {
   })
 
   test('concurrent route() for the same key serializes session.prompt() FIFO', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const promptOrder: string[] = []
     const inFlight: { current: number } = { current: 0 }
     let maxConcurrent = 0
@@ -353,7 +350,7 @@ describe('ChannelRouter', () => {
       async abort() {},
     }
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => ({ session: session as any, sessionId: 'sess-1' }),
     })
 
@@ -368,7 +365,6 @@ describe('ChannelRouter', () => {
   })
 
   test('rehydrate: passes existingSessionId from sessions.json to createSessionForChannel', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     await Bun.write(
       join(dir, 'channels/sessions.json'),
       JSON.stringify({
@@ -391,7 +387,7 @@ describe('ChannelRouter', () => {
     const seen: { existingSessionId: string | undefined }[] = []
     const fakes = createFakeSession()
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async (_key, opts) => {
         seen.push({ existingSessionId: opts?.existingSessionId })
         return { session: fakes.session, sessionId: opts?.existingSessionId ?? 'sess-fresh' }
@@ -405,11 +401,10 @@ describe('ChannelRouter', () => {
   })
 
   test('rehydrate: cold channel passes undefined existingSessionId', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const seen: { existingSessionId: string | undefined }[] = []
     const fakes = createFakeSession()
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async (_key, opts) => {
         seen.push({ existingSessionId: opts?.existingSessionId })
         return { session: fakes.session, sessionId: 'sess-fresh' }
@@ -421,7 +416,6 @@ describe('ChannelRouter', () => {
   })
 
   test('stop() aborts in-flight session prompts', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const abortCalls: string[] = []
     let resolvePrompt: () => void = () => {}
     const session = {
@@ -437,7 +431,7 @@ describe('ChannelRouter', () => {
       },
     }
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => ({ session: session as any, sessionId: 'sess-1' }),
     })
 
@@ -451,7 +445,6 @@ describe('ChannelRouter', () => {
   })
 
   test('mapping is persisted to disk before any prompt runs', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const observed: { persisted: boolean | null } = { persisted: null }
     const session = {
       subscribe: () => () => {},
@@ -467,7 +460,7 @@ describe('ChannelRouter', () => {
       async abort() {},
     }
     const router = createChannelRouter({
-      agentDir: dir,
+      cwd: dir,
       createSessionForChannel: async () => ({ session: session as any, sessionId: 'sess-1' }),
     })
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -367,6 +367,59 @@ describe('ChannelRouter', () => {
     expect(maxConcurrent).toBe(1)
   })
 
+  test('rehydrate: passes existingSessionId from sessions.json to createSessionForChannel', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    await Bun.write(
+      join(dir, 'channels/sessions.json'),
+      JSON.stringify({
+        version: 1,
+        mappings: [
+          {
+            adapter: 'discord-bot',
+            bot: 'main',
+            workspace: 'W1',
+            chat: 'C1',
+            thread: null,
+            sessionId: 'sess-existing',
+            createdAt: 1,
+            lastInboundTs: 2,
+          },
+        ],
+      }),
+    )
+
+    const seen: { existingSessionId: string | undefined }[] = []
+    const fakes = createFakeSession()
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async (_key, opts) => {
+        seen.push({ existingSessionId: opts?.existingSessionId })
+        return { session: fakes.session, sessionId: opts?.existingSessionId ?? 'sess-fresh' }
+      },
+    })
+    await router.route(baseEvent)
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]?.existingSessionId).toBe('sess-existing')
+    expect(router.knownMappings()[0]?.sessionId).toBe('sess-existing')
+  })
+
+  test('rehydrate: cold channel passes undefined existingSessionId', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
+    const seen: { existingSessionId: string | undefined }[] = []
+    const fakes = createFakeSession()
+    const router = createChannelRouter({
+      agentDir: dir,
+      createSessionForChannel: async (_key, opts) => {
+        seen.push({ existingSessionId: opts?.existingSessionId })
+        return { session: fakes.session, sessionId: 'sess-fresh' }
+      },
+    })
+    await router.route(baseEvent)
+
+    expect(seen[0]?.existingSessionId).toBeUndefined()
+  })
+
   test('mapping is persisted to disk before any prompt runs', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'channels-router-'))
     const observed: { persisted: boolean | null } = { persisted: null }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -282,10 +282,21 @@ export function createChannelRouter({
       }
     },
     async stop() {
-      for (const live of liveSessions.values()) {
-        live.unsubscribe()
-      }
+      const lives = [...liveSessions.values()]
       liveSessions.clear()
+      // Abort in-flight LLM turns AND unsubscribe from events. Without abort(),
+      // the session keeps streaming and may still execute tool calls after the
+      // container is told to stop, burning tokens and producing side effects.
+      await Promise.all(
+        lives.map(async (live) => {
+          live.unsubscribe()
+          try {
+            await live.session.abort()
+          } catch (err) {
+            logger.error(`[channels] abort failed for ${live.sessionId}: ${errMsg(err)}`)
+          }
+        }),
+      )
     },
     knownMappings() {
       return [...mappings.values()]

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -8,7 +8,6 @@ export type AdapterId = 'discord-bot'
 
 export type ChannelKey = {
   adapter: AdapterId
-  bot: string
   workspace: string
   chat: string
   thread: string | null
@@ -33,8 +32,10 @@ export type ChannelSessionMapping = ChannelKey & {
   lastInboundTs: number
 }
 
+const SESSIONS_FILE_VERSION = 2
+
 type SessionsFile = {
-  version: 1
+  version: typeof SESSIONS_FILE_VERSION
   mappings: ChannelSessionMapping[]
 }
 
@@ -126,8 +127,10 @@ export function createChannelRouter({
       logger.error(`[channels] ${SESSIONS_FILE} is not valid JSON: ${errMsg(err)}`)
       return
     }
-    if (parsed.version !== 1 || !Array.isArray(parsed.mappings)) {
-      logger.error(`[channels] ${SESSIONS_FILE} has unsupported version or shape; ignoring`)
+    if (parsed.version !== SESSIONS_FILE_VERSION || !Array.isArray(parsed.mappings)) {
+      logger.warn(
+        `[channels] ${SESSIONS_FILE} is not version ${SESSIONS_FILE_VERSION}; ignoring (will be regenerated on first inbound)`,
+      )
       return
     }
     for (const m of parsed.mappings) {
@@ -136,7 +139,7 @@ export function createChannelRouter({
   }
 
   async function persist(): Promise<void> {
-    const file: SessionsFile = { version: 1, mappings: [...mappings.values()] }
+    const file: SessionsFile = { version: SESSIONS_FILE_VERSION, mappings: [...mappings.values()] }
     await mkdir(dirname(path), { recursive: true })
     await writeFile(path, JSON.stringify(file, null, 2), 'utf8')
   }
@@ -182,7 +185,6 @@ export function createChannelRouter({
         const turnSuffix = sessionEvent.message.responseId ?? `t${sessionEvent.message.timestamp ?? Date.now()}`
         const reply: OutboundReply = {
           adapter: event.adapter,
-          bot: event.bot,
           workspace: event.workspace,
           chat: event.chat,
           thread: event.thread,
@@ -196,7 +198,6 @@ export function createChannelRouter({
     if (existingMapping === undefined || existingMapping.sessionId !== created.sessionId) {
       mappings.set(keyStr, {
         adapter: event.adapter,
-        bot: event.bot,
         workspace: event.workspace,
         chat: event.chat,
         thread: event.thread,
@@ -308,7 +309,7 @@ export function createChannelRouter({
 }
 
 function serializeKey(key: ChannelKey): string {
-  return `${key.adapter}|${key.bot}|${key.workspace}|${key.chat}|${key.thread ?? ''}`
+  return `${key.adapter}|${key.workspace}|${key.chat}|${key.thread ?? ''}`
 }
 
 function errMsg(err: unknown): string {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -63,7 +63,7 @@ export type ChannelRouterLogger = {
 }
 
 export type CreateChannelRouterOptions = {
-  agentDir: string
+  cwd: string
   createSessionForChannel: CreateSessionForChannel
   logger?: ChannelRouterLogger
 }
@@ -86,7 +86,7 @@ const consoleLogger: ChannelRouterLogger = {
 }
 
 export function createChannelRouter({
-  agentDir,
+  cwd,
   createSessionForChannel,
   logger = consoleLogger,
 }: CreateChannelRouterOptions): ChannelRouter {
@@ -97,7 +97,7 @@ export function createChannelRouter({
   // inbounds racing on a cold channel each spawn a full AgentSession.
   const creating = new Map<string, Promise<LiveSession>>()
   const outboundCallbacks = new Map<AdapterId, Set<OutboundCallback>>()
-  const path = join(agentDir, SESSIONS_FILE)
+  const path = join(cwd, SESSIONS_FILE)
   // load() may be invoked concurrently from many route() calls. Cache the
   // first invocation's promise so all callers share it; this also pins
   // before/after relationships in the microtask queue so route() resumption

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -43,6 +43,8 @@ type LiveSession = {
   sessionId: string
   unsubscribe: () => void
   pendingAssistantText: string
+  promptQueue: string[]
+  draining: boolean
 }
 
 export type CreateSessionForChannel = (key: ChannelKey) => Promise<{ session: AgentSession; sessionId: string }>
@@ -83,13 +85,25 @@ export function createChannelRouter({
 }: CreateChannelRouterOptions): ChannelRouter {
   const mappings = new Map<string, ChannelSessionMapping>()
   const liveSessions = new Map<string, LiveSession>()
+  // Concurrent route() calls for the same key share one creation promise so
+  // createSessionForChannel runs at most once per key. Without this, two
+  // inbounds racing on a cold channel each spawn a full AgentSession.
+  const creating = new Map<string, Promise<LiveSession>>()
   const outboundCallbacks = new Map<AdapterId, Set<OutboundCallback>>()
   const path = join(agentDir, SESSIONS_FILE)
-  let loaded = false
+  // load() may be invoked concurrently from many route() calls. Cache the
+  // first invocation's promise so all callers share it; this also pins
+  // before/after relationships in the microtask queue so route() resumption
+  // order tracks call order rather than load() arrival order.
+  let loadPromise: Promise<void> | null = null
 
-  async function load(): Promise<void> {
-    if (loaded) return
-    loaded = true
+  function load(): Promise<void> {
+    if (loadPromise) return loadPromise
+    loadPromise = doLoad()
+    return loadPromise
+  }
+
+  async function doLoad(): Promise<void> {
     if (!existsSync(path)) return
     let raw: string
     try {
@@ -125,12 +139,25 @@ export function createChannelRouter({
     const existingLive = liveSessions.get(keyStr)
     if (existingLive) return existingLive
 
+    const inFlight = creating.get(keyStr)
+    if (inFlight) return inFlight
+
+    const promise = doCreate(event, keyStr).finally(() => {
+      creating.delete(keyStr)
+    })
+    creating.set(keyStr, promise)
+    return promise
+  }
+
+  async function doCreate(event: InboundMessage, keyStr: string): Promise<LiveSession> {
     const created = await createSessionForChannel(event)
     const live: LiveSession = {
       session: created.session,
       sessionId: created.sessionId,
       pendingAssistantText: '',
       unsubscribe: () => {},
+      promptQueue: [],
+      draining: false,
     }
     live.unsubscribe = created.session.subscribe((sessionEvent) => {
       if (sessionEvent.type === 'message_update' && sessionEvent.assistantMessageEvent.type === 'text_delta') {
@@ -155,8 +182,6 @@ export function createChannelRouter({
       }
     })
 
-    liveSessions.set(keyStr, live)
-
     const existingMapping = mappings.get(keyStr)
     if (existingMapping === undefined || existingMapping.sessionId !== created.sessionId) {
       mappings.set(keyStr, {
@@ -169,8 +194,20 @@ export function createChannelRouter({
         createdAt: existingMapping?.createdAt ?? Date.now(),
         lastInboundTs: Date.now(),
       })
-      await persist()
+      // Best-effort persistence. A disk failure must not drop the user's
+      // message — the session is functional in memory; the only cost is a
+      // duplicate session on next process restart.
+      try {
+        await persist()
+      } catch (err) {
+        logger.error(`[channels] persist failed for ${keyStr}: ${errMsg(err)}`)
+      }
     }
+
+    // Expose the live session only after the mapping is durable (or has
+    // best-effort failed). A second concurrent route() that finds this in
+    // liveSessions can safely call session.prompt() — the mapping is on disk.
+    liveSessions.set(keyStr, live)
     return live
   }
 
@@ -180,7 +217,10 @@ export function createChannelRouter({
       logger.warn(`[channels] no outbound callback for adapter=${reply.adapter}; dropping reply`)
       return
     }
-    for (const cb of callbacks) {
+    // Snapshot to avoid surprising skip/add behavior if a callback mutates the
+    // set while iterating.
+    const snapshot = [...callbacks]
+    for (const cb of snapshot) {
       try {
         await cb(reply)
       } catch (err) {
@@ -189,21 +229,36 @@ export function createChannelRouter({
     }
   }
 
+  async function drainPromptQueue(live: LiveSession): Promise<void> {
+    if (live.draining) return
+    live.draining = true
+    try {
+      while (live.promptQueue.length > 0) {
+        const text = live.promptQueue.shift()
+        if (text === undefined) break
+        try {
+          await live.session.prompt(text)
+        } catch (err) {
+          logger.error(`[channels] session ${live.sessionId} prompt failed: ${errMsg(err)}`)
+        }
+      }
+    } finally {
+      live.draining = false
+    }
+  }
+
   return {
     load,
     async route(event) {
-      if (!loaded) await load()
+      await load()
       const live = await ensureLive(event)
       const keyStr = serializeKey(event)
       const mapping = mappings.get(keyStr)
       if (mapping !== undefined) {
         mapping.lastInboundTs = Date.now()
       }
-      try {
-        await live.session.prompt(event.text)
-      } catch (err) {
-        logger.error(`[channels] session ${live.sessionId} prompt failed: ${errMsg(err)}`)
-      }
+      live.promptQueue.push(event.text)
+      await drainPromptQueue(live)
     },
     bindOutbound(adapter, callback) {
       let set = outboundCallbacks.get(adapter)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1,0 +1,240 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+import type { AgentSession } from '@/agent'
+
+export type AdapterId = 'discord-bot'
+
+export type ChannelKey = {
+  adapter: AdapterId
+  bot: string
+  workspace: string
+  chat: string
+  thread: string | null
+}
+
+export type InboundMessage = ChannelKey & {
+  text: string
+  externalMessageId: string
+  authorId: string
+}
+
+export type OutboundReply = ChannelKey & {
+  text: string
+  turnId: string
+}
+
+export type OutboundCallback = (reply: OutboundReply) => void | Promise<void>
+
+export type ChannelSessionMapping = ChannelKey & {
+  sessionId: string
+  createdAt: number
+  lastInboundTs: number
+}
+
+type SessionsFile = {
+  version: 1
+  mappings: ChannelSessionMapping[]
+}
+
+type LiveSession = {
+  session: AgentSession
+  sessionId: string
+  unsubscribe: () => void
+  pendingAssistantText: string
+}
+
+export type CreateSessionForChannel = (key: ChannelKey) => Promise<{ session: AgentSession; sessionId: string }>
+
+export type ChannelRouterLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+export type CreateChannelRouterOptions = {
+  agentDir: string
+  createSessionForChannel: CreateSessionForChannel
+  logger?: ChannelRouterLogger
+}
+
+export type ChannelRouter = {
+  load: () => Promise<void>
+  route: (event: InboundMessage) => Promise<void>
+  bindOutbound: (adapter: AdapterId, callback: OutboundCallback) => () => void
+  stop: () => Promise<void>
+  knownMappings: () => ChannelSessionMapping[]
+  liveSessionCount: () => number
+}
+
+const SESSIONS_FILE = 'channels/sessions.json'
+
+const consoleLogger: ChannelRouterLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+  error: (m) => console.error(m),
+}
+
+export function createChannelRouter({
+  agentDir,
+  createSessionForChannel,
+  logger = consoleLogger,
+}: CreateChannelRouterOptions): ChannelRouter {
+  const mappings = new Map<string, ChannelSessionMapping>()
+  const liveSessions = new Map<string, LiveSession>()
+  const outboundCallbacks = new Map<AdapterId, Set<OutboundCallback>>()
+  const path = join(agentDir, SESSIONS_FILE)
+  let loaded = false
+
+  async function load(): Promise<void> {
+    if (loaded) return
+    loaded = true
+    if (!existsSync(path)) return
+    let raw: string
+    try {
+      raw = await readFile(path, 'utf8')
+    } catch (err) {
+      logger.warn(`[channels] failed to read ${SESSIONS_FILE}: ${errMsg(err)}`)
+      return
+    }
+    let parsed: SessionsFile
+    try {
+      parsed = JSON.parse(raw) as SessionsFile
+    } catch (err) {
+      logger.error(`[channels] ${SESSIONS_FILE} is not valid JSON: ${errMsg(err)}`)
+      return
+    }
+    if (parsed.version !== 1 || !Array.isArray(parsed.mappings)) {
+      logger.error(`[channels] ${SESSIONS_FILE} has unsupported version or shape; ignoring`)
+      return
+    }
+    for (const m of parsed.mappings) {
+      mappings.set(serializeKey(m), m)
+    }
+  }
+
+  async function persist(): Promise<void> {
+    const file: SessionsFile = { version: 1, mappings: [...mappings.values()] }
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, JSON.stringify(file, null, 2), 'utf8')
+  }
+
+  async function ensureLive(event: InboundMessage): Promise<LiveSession> {
+    const keyStr = serializeKey(event)
+    const existingLive = liveSessions.get(keyStr)
+    if (existingLive) return existingLive
+
+    const created = await createSessionForChannel(event)
+    const live: LiveSession = {
+      session: created.session,
+      sessionId: created.sessionId,
+      pendingAssistantText: '',
+      unsubscribe: () => {},
+    }
+    live.unsubscribe = created.session.subscribe((sessionEvent) => {
+      if (sessionEvent.type === 'message_update' && sessionEvent.assistantMessageEvent.type === 'text_delta') {
+        live.pendingAssistantText += sessionEvent.assistantMessageEvent.delta
+        return
+      }
+      if (sessionEvent.type === 'message_end' && sessionEvent.message.role === 'assistant') {
+        const text = live.pendingAssistantText
+        live.pendingAssistantText = ''
+        if (text.length === 0) return
+        const turnSuffix = sessionEvent.message.responseId ?? `t${sessionEvent.message.timestamp ?? Date.now()}`
+        const reply: OutboundReply = {
+          adapter: event.adapter,
+          bot: event.bot,
+          workspace: event.workspace,
+          chat: event.chat,
+          thread: event.thread,
+          text,
+          turnId: `${live.sessionId}:${turnSuffix}`,
+        }
+        void deliverOutbound(reply)
+      }
+    })
+
+    liveSessions.set(keyStr, live)
+
+    const existingMapping = mappings.get(keyStr)
+    if (existingMapping === undefined || existingMapping.sessionId !== created.sessionId) {
+      mappings.set(keyStr, {
+        adapter: event.adapter,
+        bot: event.bot,
+        workspace: event.workspace,
+        chat: event.chat,
+        thread: event.thread,
+        sessionId: created.sessionId,
+        createdAt: existingMapping?.createdAt ?? Date.now(),
+        lastInboundTs: Date.now(),
+      })
+      await persist()
+    }
+    return live
+  }
+
+  async function deliverOutbound(reply: OutboundReply): Promise<void> {
+    const callbacks = outboundCallbacks.get(reply.adapter)
+    if (!callbacks || callbacks.size === 0) {
+      logger.warn(`[channels] no outbound callback for adapter=${reply.adapter}; dropping reply`)
+      return
+    }
+    for (const cb of callbacks) {
+      try {
+        await cb(reply)
+      } catch (err) {
+        logger.error(`[channels] outbound callback failed: ${errMsg(err)}`)
+      }
+    }
+  }
+
+  return {
+    load,
+    async route(event) {
+      if (!loaded) await load()
+      const live = await ensureLive(event)
+      const keyStr = serializeKey(event)
+      const mapping = mappings.get(keyStr)
+      if (mapping !== undefined) {
+        mapping.lastInboundTs = Date.now()
+      }
+      try {
+        await live.session.prompt(event.text)
+      } catch (err) {
+        logger.error(`[channels] session ${live.sessionId} prompt failed: ${errMsg(err)}`)
+      }
+    },
+    bindOutbound(adapter, callback) {
+      let set = outboundCallbacks.get(adapter)
+      if (!set) {
+        set = new Set()
+        outboundCallbacks.set(adapter, set)
+      }
+      set.add(callback)
+      return () => {
+        set?.delete(callback)
+      }
+    },
+    async stop() {
+      for (const live of liveSessions.values()) {
+        live.unsubscribe()
+      }
+      liveSessions.clear()
+    },
+    knownMappings() {
+      return [...mappings.values()]
+    },
+    liveSessionCount() {
+      return liveSessions.size
+    },
+  }
+}
+
+function serializeKey(key: ChannelKey): string {
+  return `${key.adapter}|${key.bot}|${key.workspace}|${key.chat}|${key.thread ?? ''}`
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -47,7 +47,14 @@ type LiveSession = {
   draining: boolean
 }
 
-export type CreateSessionForChannel = (key: ChannelKey) => Promise<{ session: AgentSession; sessionId: string }>
+export type CreateSessionForChannelOptions = {
+  existingSessionId?: string
+}
+
+export type CreateSessionForChannel = (
+  key: ChannelKey,
+  options?: CreateSessionForChannelOptions,
+) => Promise<{ session: AgentSession; sessionId: string }>
 
 export type ChannelRouterLogger = {
   info: (msg: string) => void
@@ -150,7 +157,11 @@ export function createChannelRouter({
   }
 
   async function doCreate(event: InboundMessage, keyStr: string): Promise<LiveSession> {
-    const created = await createSessionForChannel(event)
+    const existingMapping = mappings.get(keyStr)
+    const created = await createSessionForChannel(
+      event,
+      existingMapping !== undefined ? { existingSessionId: existingMapping.sessionId } : undefined,
+    )
     const live: LiveSession = {
       session: created.session,
       sessionId: created.sessionId,
@@ -182,7 +193,6 @@ export function createChannelRouter({
       }
     })
 
-    const existingMapping = mappings.get(keyStr)
     if (existingMapping === undefined || existingMapping.sessionId !== created.sessionId) {
       mappings.set(keyStr, {
         adapter: event.adapter,

--- a/src/channels/schema.test.ts
+++ b/src/channels/schema.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test'
+
+import { channelSchema, matchesAnyChatRule } from './schema'
+
+describe('channelSchema', () => {
+  test('parses a discord-bot channel with default chats and enabled', () => {
+    const parsed = channelSchema.parse({ adapter: 'discord-bot', bot: 'main' })
+    expect(parsed).toEqual({ adapter: 'discord-bot', bot: 'main', chats: ['*'], enabled: true })
+  })
+
+  test('accepts the four chat-rule shapes', () => {
+    const parsed = channelSchema.parse({
+      adapter: 'discord-bot',
+      bot: 'main',
+      chats: ['*', 'C012ABC', 'T0ABC1234/C012ABC', { workspace: 'W', chat: '*' }, { chat: 'X' }],
+    })
+    expect(parsed.chats).toHaveLength(5)
+  })
+
+  test('rejects a bare chat rule containing "/"', () => {
+    expect(() => channelSchema.parse({ adapter: 'discord-bot', bot: 'main', chats: ['a/b/c'] })).toThrow()
+  })
+
+  test('rejects unknown adapter', () => {
+    expect(() => channelSchema.parse({ adapter: 'slack-bot', bot: 'main' })).toThrow()
+  })
+
+  test('rejects empty bot id', () => {
+    expect(() => channelSchema.parse({ adapter: 'discord-bot', bot: '' })).toThrow()
+  })
+})
+
+describe('matchesAnyChatRule', () => {
+  test('"*" matches any (workspace, chat)', () => {
+    expect(matchesAnyChatRule(['*'], 'W1', 'C1')).toBe(true)
+    expect(matchesAnyChatRule(['*'], 'W2', 'C2')).toBe(true)
+  })
+
+  test('bare string matches the chat in any workspace', () => {
+    expect(matchesAnyChatRule(['C012ABC'], 'W1', 'C012ABC')).toBe(true)
+    expect(matchesAnyChatRule(['C012ABC'], 'W2', 'C012ABC')).toBe(true)
+    expect(matchesAnyChatRule(['C012ABC'], 'W1', 'OTHER')).toBe(false)
+  })
+
+  test('"<workspace>/<chat>" matches only that workspace+chat pair', () => {
+    expect(matchesAnyChatRule(['W1/C1'], 'W1', 'C1')).toBe(true)
+    expect(matchesAnyChatRule(['W1/C1'], 'W2', 'C1')).toBe(false)
+    expect(matchesAnyChatRule(['W1/C1'], 'W1', 'C2')).toBe(false)
+  })
+
+  test('structured form with workspace restricts; without workspace matches any', () => {
+    expect(matchesAnyChatRule([{ workspace: 'W1', chat: 'C1' }], 'W1', 'C1')).toBe(true)
+    expect(matchesAnyChatRule([{ workspace: 'W1', chat: 'C1' }], 'W2', 'C1')).toBe(false)
+    expect(matchesAnyChatRule([{ chat: 'C1' }], 'W2', 'C1')).toBe(true)
+    expect(matchesAnyChatRule([{ workspace: 'W1', chat: '*' }], 'W1', 'whatever')).toBe(true)
+    expect(matchesAnyChatRule([{ workspace: 'W1', chat: '*' }], 'W2', 'whatever')).toBe(false)
+  })
+
+  test('rule list is OR — any match admits', () => {
+    const rules = ['W1/C1', 'C99']
+    expect(matchesAnyChatRule(rules, 'W1', 'C1')).toBe(true)
+    expect(matchesAnyChatRule(rules, 'W3', 'C99')).toBe(true)
+    expect(matchesAnyChatRule(rules, 'W2', 'OTHER')).toBe(false)
+  })
+
+  test('empty rule list admits nothing', () => {
+    expect(matchesAnyChatRule([], 'W1', 'C1')).toBe(false)
+  })
+})

--- a/src/channels/schema.test.ts
+++ b/src/channels/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { channelSchema, matchesAnyChatRule } from './schema'
+import { channelSchema, channelsArraySchema, matchesAnyChatRule } from './schema'
 
 describe('channelSchema', () => {
   test('parses a discord-bot channel with default chats and enabled', () => {
@@ -27,6 +27,29 @@ describe('channelSchema', () => {
 
   test('rejects empty bot id', () => {
     expect(() => channelSchema.parse({ adapter: 'discord-bot', bot: '' })).toThrow()
+  })
+})
+
+describe('channelsArraySchema', () => {
+  test('accepts distinct (adapter, bot) entries', () => {
+    const parsed = channelsArraySchema.parse([
+      { adapter: 'discord-bot', bot: 'main' },
+      { adapter: 'discord-bot', bot: 'alert' },
+    ])
+    expect(parsed).toHaveLength(2)
+  })
+
+  test('rejects duplicate (adapter, bot) entries', () => {
+    expect(() =>
+      channelsArraySchema.parse([
+        { adapter: 'discord-bot', bot: 'main' },
+        { adapter: 'discord-bot', bot: 'main', chats: ['C1'] },
+      ]),
+    ).toThrow(/duplicate channel for discord-bot bot/)
+  })
+
+  test('empty array is fine', () => {
+    expect(channelsArraySchema.parse([])).toEqual([])
   })
 })
 

--- a/src/channels/schema.test.ts
+++ b/src/channels/schema.test.ts
@@ -1,92 +1,122 @@
 import { describe, expect, test } from 'bun:test'
 
-import { channelSchema, channelsArraySchema, matchesAnyChatRule } from './schema'
+import { channelsSchema, isAllowed } from './schema'
 
-describe('channelSchema', () => {
-  test('parses a discord-bot channel with default chats and enabled', () => {
-    const parsed = channelSchema.parse({ adapter: 'discord-bot', bot: 'main' })
-    expect(parsed).toEqual({ adapter: 'discord-bot', bot: 'main', chats: ['*'], enabled: true })
+describe('channelsSchema', () => {
+  test('empty object is the default', () => {
+    expect(channelsSchema.parse({})).toEqual({})
+    expect(channelsSchema.parse(undefined)).toEqual({})
   })
 
-  test('accepts the four chat-rule shapes', () => {
-    const parsed = channelSchema.parse({
-      adapter: 'discord-bot',
-      bot: 'main',
-      chats: ['*', 'C012ABC', 'T0ABC1234/C012ABC', { workspace: 'W', chat: '*' }, { chat: 'X' }],
+  test('discord-bot with explicit allow list parses cleanly', () => {
+    expect(channelsSchema.parse({ 'discord-bot': { allow: ['*'] } })).toEqual({
+      'discord-bot': { allow: ['*'], enabled: true },
     })
-    expect(parsed.chats).toHaveLength(5)
   })
 
-  test('rejects a bare chat rule containing "/"', () => {
-    expect(() => channelSchema.parse({ adapter: 'discord-bot', bot: 'main', chats: ['a/b/c'] })).toThrow()
+  test('discord-bot with no allow list defaults to empty (admit nothing)', () => {
+    expect(channelsSchema.parse({ 'discord-bot': {} })).toEqual({
+      'discord-bot': { allow: [], enabled: true },
+    })
   })
 
-  test('rejects unknown adapter', () => {
-    expect(() => channelSchema.parse({ adapter: 'slack-bot', bot: 'main' })).toThrow()
+  test('discord-bot with enabled: false', () => {
+    expect(channelsSchema.parse({ 'discord-bot': { enabled: false } })).toEqual({
+      'discord-bot': { allow: [], enabled: false },
+    })
   })
 
-  test('rejects empty bot id', () => {
-    expect(() => channelSchema.parse({ adapter: 'discord-bot', bot: '' })).toThrow()
+  test('accepts every supported rule shape', () => {
+    const parsed = channelsSchema.parse({
+      'discord-bot': {
+        allow: [
+          '*',
+          'guild:*',
+          'guild:1234567890',
+          'guild:1234567890/9876543210',
+          'channel:9876543210',
+          'dm:*',
+          'dm:5555555555',
+        ],
+      },
+    })
+    expect(parsed['discord-bot']?.allow).toHaveLength(7)
+  })
+
+  test('rejects malformed rules', () => {
+    const cases = [
+      'guild:',
+      'guild:foo',
+      'guild:1234/foo',
+      'channel:',
+      'channel:abc',
+      'dm:',
+      'dm:abc',
+      'thread:1234',
+      'random',
+    ]
+    for (const rule of cases) {
+      expect(() => channelsSchema.parse({ 'discord-bot': { allow: [rule] } })).toThrow()
+    }
+  })
+
+  test('rejects unknown adapter keys', () => {
+    expect(() => channelsSchema.parse({ 'slack-bot': { allow: [] } })).toThrow()
   })
 })
 
-describe('channelsArraySchema', () => {
-  test('accepts distinct (adapter, bot) entries', () => {
-    const parsed = channelsArraySchema.parse([
-      { adapter: 'discord-bot', bot: 'main' },
-      { adapter: 'discord-bot', bot: 'alert' },
-    ])
-    expect(parsed).toHaveLength(2)
+describe('isAllowed', () => {
+  test('"*" admits everything (guilds and DMs)', () => {
+    expect(isAllowed(['*'], 'G1', 'C1')).toBe(true)
+    expect(isAllowed(['*'], null, 'D1')).toBe(true)
   })
 
-  test('rejects duplicate (adapter, bot) entries', () => {
-    expect(() =>
-      channelsArraySchema.parse([
-        { adapter: 'discord-bot', bot: 'main' },
-        { adapter: 'discord-bot', bot: 'main', chats: ['C1'] },
-      ]),
-    ).toThrow(/duplicate channel for discord-bot bot/)
+  test('"guild:*" admits any guild channel but no DMs', () => {
+    expect(isAllowed(['guild:*'], 'G1', 'C1')).toBe(true)
+    expect(isAllowed(['guild:*'], 'G2', 'C2')).toBe(true)
+    expect(isAllowed(['guild:*'], null, 'D1')).toBe(false)
   })
 
-  test('empty array is fine', () => {
-    expect(channelsArraySchema.parse([])).toEqual([])
-  })
-})
-
-describe('matchesAnyChatRule', () => {
-  test('"*" matches any (workspace, chat)', () => {
-    expect(matchesAnyChatRule(['*'], 'W1', 'C1')).toBe(true)
-    expect(matchesAnyChatRule(['*'], 'W2', 'C2')).toBe(true)
+  test('"guild:G1" admits any channel of that guild only', () => {
+    expect(isAllowed(['guild:G1'], 'G1', 'C1')).toBe(true)
+    expect(isAllowed(['guild:G1'], 'G1', 'C2')).toBe(true)
+    expect(isAllowed(['guild:G1'], 'G2', 'C1')).toBe(false)
+    expect(isAllowed(['guild:G1'], null, 'D1')).toBe(false)
   })
 
-  test('bare string matches the chat in any workspace', () => {
-    expect(matchesAnyChatRule(['C012ABC'], 'W1', 'C012ABC')).toBe(true)
-    expect(matchesAnyChatRule(['C012ABC'], 'W2', 'C012ABC')).toBe(true)
-    expect(matchesAnyChatRule(['C012ABC'], 'W1', 'OTHER')).toBe(false)
+  test('"guild:G1/C1" admits only that pair', () => {
+    expect(isAllowed(['guild:G1/C1'], 'G1', 'C1')).toBe(true)
+    expect(isAllowed(['guild:G1/C1'], 'G1', 'C2')).toBe(false)
+    expect(isAllowed(['guild:G1/C1'], 'G2', 'C1')).toBe(false)
   })
 
-  test('"<workspace>/<chat>" matches only that workspace+chat pair', () => {
-    expect(matchesAnyChatRule(['W1/C1'], 'W1', 'C1')).toBe(true)
-    expect(matchesAnyChatRule(['W1/C1'], 'W2', 'C1')).toBe(false)
-    expect(matchesAnyChatRule(['W1/C1'], 'W1', 'C2')).toBe(false)
+  test('"channel:C1" admits that channel id regardless of guild', () => {
+    expect(isAllowed(['channel:C1'], 'G1', 'C1')).toBe(true)
+    expect(isAllowed(['channel:C1'], 'G2', 'C1')).toBe(true)
+    expect(isAllowed(['channel:C1'], 'G1', 'C2')).toBe(false)
   })
 
-  test('structured form with workspace restricts; without workspace matches any', () => {
-    expect(matchesAnyChatRule([{ workspace: 'W1', chat: 'C1' }], 'W1', 'C1')).toBe(true)
-    expect(matchesAnyChatRule([{ workspace: 'W1', chat: 'C1' }], 'W2', 'C1')).toBe(false)
-    expect(matchesAnyChatRule([{ chat: 'C1' }], 'W2', 'C1')).toBe(true)
-    expect(matchesAnyChatRule([{ workspace: 'W1', chat: '*' }], 'W1', 'whatever')).toBe(true)
-    expect(matchesAnyChatRule([{ workspace: 'W1', chat: '*' }], 'W2', 'whatever')).toBe(false)
+  test('"dm:*" admits any DM but no guild channels', () => {
+    expect(isAllowed(['dm:*'], null, 'D1')).toBe(true)
+    expect(isAllowed(['dm:*'], null, 'D2')).toBe(true)
+    expect(isAllowed(['dm:*'], 'G1', 'C1')).toBe(false)
+  })
+
+  test('"dm:D1" admits only that DM channel', () => {
+    expect(isAllowed(['dm:D1'], null, 'D1')).toBe(true)
+    expect(isAllowed(['dm:D1'], null, 'D2')).toBe(false)
+    expect(isAllowed(['dm:D1'], 'G1', 'D1')).toBe(false)
   })
 
   test('rule list is OR — any match admits', () => {
-    const rules = ['W1/C1', 'C99']
-    expect(matchesAnyChatRule(rules, 'W1', 'C1')).toBe(true)
-    expect(matchesAnyChatRule(rules, 'W3', 'C99')).toBe(true)
-    expect(matchesAnyChatRule(rules, 'W2', 'OTHER')).toBe(false)
+    const rules = ['guild:G1', 'dm:*']
+    expect(isAllowed(rules, 'G1', 'C1')).toBe(true)
+    expect(isAllowed(rules, null, 'D1')).toBe(true)
+    expect(isAllowed(rules, 'G2', 'C1')).toBe(false)
   })
 
   test('empty rule list admits nothing', () => {
-    expect(matchesAnyChatRule([], 'W1', 'C1')).toBe(false)
+    expect(isAllowed([], 'G1', 'C1')).toBe(false)
+    expect(isAllowed([], null, 'D1')).toBe(false)
   })
 })

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -1,74 +1,75 @@
 import { z } from 'zod'
 
-// Four discriminated forms: "*" (any), bare string (chat in any workspace),
-// "<workspace>/<chat>" (workspace-qualified), or a structured object that
-// future-proofs additional fields (threads, senders) without re-parsing.
-const chatRuleSchema = z.union([
+// Allow-rule grammar:
+//   "*"                      — all guilds + all DMs (FIXME: too broad as a single
+//                              token; consider splitting into "guild:*" + "dm:*"
+//                              before v0.1 ships, since accidental "*" sweeps in
+//                              private 1:1 conversations).
+//   "guild:*"                — every channel of every guild the bot is in.
+//   "guild:GUILD_ID"         — every channel of that one guild.
+//   "guild:GUILD_ID/CHANNEL_ID" — one specific channel inside that guild.
+//   "channel:CHANNEL_ID"     — that channel id in any guild it appears in.
+//                              Works because Discord channel IDs are globally
+//                              unique snowflakes.
+//   "dm:*"                   — every DM channel the bot has open.
+//   "dm:CHANNEL_ID"          — one specific DM channel.
+const idPattern = String.raw`\d+`
+const allowRuleSchema = z.union([
   z.literal('*'),
-  z.string().regex(/^[^/]+$/, 'bare chat rule must not contain "/"'),
-  z.string().regex(/^[^/]+\/[^/]+$/, 'qualified chat rule must be "<workspace>/<chat>"'),
-  z.object({
-    workspace: z.string().min(1).optional(),
-    chat: z.union([z.string().min(1), z.literal('*')]),
-  }),
+  z
+    .string()
+    .regex(
+      new RegExp(`^guild:(\\*|${idPattern}(/${idPattern})?)$`),
+      'guild rule must be "guild:*", "guild:<id>", or "guild:<id>/<id>"',
+    ),
+  z.string().regex(new RegExp(`^channel:${idPattern}$`), 'channel rule must be "channel:<id>"'),
+  z.string().regex(new RegExp(`^dm:(\\*|${idPattern})$`), 'dm rule must be "dm:*" or "dm:<id>"'),
 ])
 
-export type ChatRule = z.infer<typeof chatRuleSchema>
+export type AllowRule = z.infer<typeof allowRuleSchema>
 
-// Discord bot channel. v0.1 is discord-bot-only; other adapters land later.
-// `bot` is the agent-messenger bot identifier (e.g. "main", "deploy") that
-// resolves to a stored credential set. Workspaces (Discord servers/guilds)
-// are discovered at runtime — one bot can be installed in N servers.
-const discordBotChannelSchema = z.object({
-  adapter: z.literal('discord-bot'),
-  bot: z.string().min(1),
-  chats: z.array(chatRuleSchema).default(['*']),
+const discordBotConfigSchema = z.object({
+  allow: z.array(allowRuleSchema).default([]),
   enabled: z.boolean().default(true),
 })
 
-export type DiscordBotChannel = z.infer<typeof discordBotChannelSchema>
+export type DiscordBotConfig = z.infer<typeof discordBotConfigSchema>
 
-export const channelSchema = z.discriminatedUnion('adapter', [discordBotChannelSchema])
+export const channelsSchema = z
+  .object({
+    'discord-bot': discordBotConfigSchema.optional(),
+  })
+  .strict()
+  .default({})
 
-export type Channel = z.infer<typeof channelSchema>
+export type Channels = z.infer<typeof channelsSchema>
 
-export const channelsArraySchema = z.array(channelSchema).superRefine((channels, ctx) => {
-  const seen = new Set<string>()
-  for (let i = 0; i < channels.length; i++) {
-    const channel = channels[i]
-    if (channel === undefined) continue
-    const key = `${channel.adapter}|${channel.bot}`
-    if (seen.has(key)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: [i, 'bot'],
-        message: `duplicate channel for ${channel.adapter} bot "${channel.bot}"; each (adapter, bot) pair must appear at most once`,
-      })
-    }
-    seen.add(key)
-  }
-})
-
-// Match a (workspace, chat) tuple against a list of rules. At least one rule
-// must match for the event to be admitted. Used at inbound time by the
-// adapter, so a `chats: ["*"]` channel auto-subscribes to every workspace
-// the bot is in (including ones added at runtime via GUILD_CREATE).
-export function matchesAnyChatRule(rules: ChatRule[], workspace: string, chat: string): boolean {
+// Match an inbound event against an allow list. The event is described by the
+// (guildId, channelId) pair from the SDK; guildId is null for DMs.
+export function isAllowed(rules: AllowRule[], guildId: string | null, channelId: string): boolean {
   for (const rule of rules) {
-    if (matchesChatRule(rule, workspace, chat)) return true
+    if (matchesRule(rule, guildId, channelId)) return true
   }
   return false
 }
 
-function matchesChatRule(rule: ChatRule, workspace: string, chat: string): boolean {
+function matchesRule(rule: AllowRule, guildId: string | null, channelId: string): boolean {
   if (rule === '*') return true
-  if (typeof rule === 'string') {
-    if (rule.includes('/')) {
-      const [ruleWorkspace, ruleChat] = rule.split('/', 2)
-      return ruleWorkspace === workspace && ruleChat === chat
-    }
-    return rule === chat
+  if (rule.startsWith('guild:')) {
+    if (guildId === null) return false
+    const tail = rule.slice('guild:'.length)
+    if (tail === '*') return true
+    const slash = tail.indexOf('/')
+    if (slash === -1) return tail === guildId
+    return tail.slice(0, slash) === guildId && tail.slice(slash + 1) === channelId
   }
-  if (rule.workspace !== undefined && rule.workspace !== workspace) return false
-  return rule.chat === '*' || rule.chat === chat
+  if (rule.startsWith('channel:')) {
+    return rule.slice('channel:'.length) === channelId
+  }
+  if (rule.startsWith('dm:')) {
+    if (guildId !== null) return false
+    const tail = rule.slice('dm:'.length)
+    return tail === '*' || tail === channelId
+  }
+  return false
 }

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod'
+
+// Four discriminated forms: "*" (any), bare string (chat in any workspace),
+// "<workspace>/<chat>" (workspace-qualified), or a structured object that
+// future-proofs additional fields (threads, senders) without re-parsing.
+const chatRuleSchema = z.union([
+  z.literal('*'),
+  z.string().regex(/^[^/]+$/, 'bare chat rule must not contain "/"'),
+  z.string().regex(/^[^/]+\/[^/]+$/, 'qualified chat rule must be "<workspace>/<chat>"'),
+  z.object({
+    workspace: z.string().min(1).optional(),
+    chat: z.union([z.string().min(1), z.literal('*')]),
+  }),
+])
+
+export type ChatRule = z.infer<typeof chatRuleSchema>
+
+// Discord bot channel. v0.1 is discord-bot-only; other adapters land later.
+// `bot` is the agent-messenger bot identifier (e.g. "main", "deploy") that
+// resolves to a stored credential set. Workspaces (Discord servers/guilds)
+// are discovered at runtime — one bot can be installed in N servers.
+const discordBotChannelSchema = z.object({
+  adapter: z.literal('discord-bot'),
+  bot: z.string().min(1),
+  chats: z.array(chatRuleSchema).default(['*']),
+  enabled: z.boolean().default(true),
+})
+
+export type DiscordBotChannel = z.infer<typeof discordBotChannelSchema>
+
+export const channelSchema = z.discriminatedUnion('adapter', [discordBotChannelSchema])
+
+export type Channel = z.infer<typeof channelSchema>
+
+// Match a (workspace, chat) tuple against a list of rules. At least one rule
+// must match for the event to be admitted. Used at inbound time by the
+// adapter, so a `chats: ["*"]` channel auto-subscribes to every workspace
+// the bot is in (including ones added at runtime via GUILD_CREATE).
+export function matchesAnyChatRule(rules: ChatRule[], workspace: string, chat: string): boolean {
+  for (const rule of rules) {
+    if (matchesChatRule(rule, workspace, chat)) return true
+  }
+  return false
+}
+
+function matchesChatRule(rule: ChatRule, workspace: string, chat: string): boolean {
+  if (rule === '*') return true
+  if (typeof rule === 'string') {
+    if (rule.includes('/')) {
+      const [ruleWorkspace, ruleChat] = rule.split('/', 2)
+      return ruleWorkspace === workspace && ruleChat === chat
+    }
+    return rule === chat
+  }
+  if (rule.workspace !== undefined && rule.workspace !== workspace) return false
+  return rule.chat === '*' || rule.chat === chat
+}

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -32,6 +32,23 @@ export const channelSchema = z.discriminatedUnion('adapter', [discordBotChannelS
 
 export type Channel = z.infer<typeof channelSchema>
 
+export const channelsArraySchema = z.array(channelSchema).superRefine((channels, ctx) => {
+  const seen = new Set<string>()
+  for (let i = 0; i < channels.length; i++) {
+    const channel = channels[i]
+    if (channel === undefined) continue
+    const key = `${channel.adapter}|${channel.bot}`
+    if (seen.has(key)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [i, 'bot'],
+        message: `duplicate channel for ${channel.adapter} bot "${channel.bot}"; each (adapter, bot) pair must appear at most once`,
+      })
+    }
+    seen.add(key)
+  }
+})
+
 // Match a (workspace, chat) tuple against a list of rules. At least one rule
 // must match for the event to be admitted. Used at inbound time by the
 // adapter, so a `chats: ["*"]` channel auto-subscribes to every workspace

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,7 +5,7 @@ import type { Model } from '@mariozechner/pi-ai'
 import { CronExpressionParser } from 'cron-parser'
 import { z } from 'zod'
 
-import { channelSchema } from '@/channels/schema'
+import { channelsArraySchema } from '@/channels/schema'
 
 import { KNOWN_PROVIDERS, listKnownModelRefs, type KnownModelRef, type KnownProviderId } from './providers'
 
@@ -59,7 +59,7 @@ export const configSchema = z.object({
   // writes `"mounts": []` explicitly, but a missing field is treated the same
   // way (no host paths exposed) rather than failing the whole config load.
   mounts: z.array(mountSchema).default([]),
-  channels: z.array(channelSchema).default([]),
+  channels: channelsArraySchema.default([]),
 })
 
 function isValidCronExpression(schedule: string): boolean {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,7 +5,7 @@ import type { Model } from '@mariozechner/pi-ai'
 import { CronExpressionParser } from 'cron-parser'
 import { z } from 'zod'
 
-import { channelsArraySchema } from '@/channels/schema'
+import { channelsSchema } from '@/channels/schema'
 
 import { KNOWN_PROVIDERS, listKnownModelRefs, type KnownModelRef, type KnownProviderId } from './providers'
 
@@ -59,7 +59,7 @@ export const configSchema = z.object({
   // writes `"mounts": []` explicitly, but a missing field is treated the same
   // way (no host paths exposed) rather than failing the whole config load.
   mounts: z.array(mountSchema).default([]),
-  channels: channelsArraySchema.default([]),
+  channels: channelsSchema,
 })
 
 function isValidCronExpression(schedule: string): boolean {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,6 +5,8 @@ import type { Model } from '@mariozechner/pi-ai'
 import { CronExpressionParser } from 'cron-parser'
 import { z } from 'zod'
 
+import { channelSchema } from '@/channels/schema'
+
 import { KNOWN_PROVIDERS, listKnownModelRefs, type KnownModelRef, type KnownProviderId } from './providers'
 
 const CONFIG_FILE = 'typeclaw.json'
@@ -57,6 +59,7 @@ export const configSchema = z.object({
   // writes `"mounts": []` explicitly, but a missing field is treated the same
   // way (no host paths exposed) rather than failing the whole config load.
   mounts: z.array(mountSchema).default([]),
+  channels: z.array(channelSchema).default([]),
 })
 
 function isValidCronExpression(schedule: string): boolean {
@@ -140,6 +143,7 @@ export const FIELD_EFFECTS: Record<string, FieldEffect> = {
   mounts: 'restart-required',
   'memory.idleMs': 'restart-required',
   'memory.dreaming': 'applied',
+  channels: 'applied',
 }
 
 // Stable JSON for value comparison. Fields are small JSON-shaped objects, so

--- a/src/init/gitignore.ts
+++ b/src/init/gitignore.ts
@@ -8,12 +8,15 @@ export function buildGitignore(): string {
 node_modules/
 workspace/
 mounts/
+channels/state/
 .DS_Store
 
 # System-managed: gitignored by default so the agent never stages them by hand,
 # but TypeClaw force-commits them on its own schedule (sessions/ via auto-backup,
-# memory/ via the dreaming subagent). Treat them as runtime-owned, not agent-owned.
+# memory/ via the dreaming subagent, channels/sessions.json via the channel
+# router). Treat them as runtime-owned, not agent-owned.
 sessions/
 memory/
+channels/sessions.json
 `
 }

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -432,6 +432,8 @@ describe('scaffold', () => {
     expect(gitignore).toContain('memory/')
     expect(gitignore).toMatch(/^workspace\/$/m)
     expect(gitignore).toContain('mounts/')
+    expect(gitignore).toMatch(/^channels\/state\/$/m)
+    expect(gitignore).toMatch(/^channels\/sessions\.json$/m)
   })
 
   test('preserves existing markdown files instead of overwriting', async () => {

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -500,4 +500,56 @@ describe('startAgent session persistence wiring', () => {
     expect(existsSync(join(agentDir, 'sessions'))).toBe(false)
     expect(dirCalls + createCalls).toBe(0)
   })
+
+  test('startAgent exposes a channelRouter and channelManager', async () => {
+    running = await startAgent({ port: 0, attachTui: false, loadCron: noCron })
+
+    expect(running.channelRouter).toBeDefined()
+    expect(running.channelManager).toBeDefined()
+    expect(running.channelManager.activeKeys()).toEqual([])
+  })
+
+  test('channels reload: applyChannels picks up new entries from typeclaw.json', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-channels-'))
+
+    const startCalls: string[] = []
+    const stopCalls: string[] = []
+    const fakeFactory: import('@/channels').DiscordBotFactory = async (channel) => ({
+      adapter: {
+        async start() {
+          startCalls.push(channel.bot)
+        },
+        async stop() {
+          stopCalls.push(channel.bot)
+        },
+        async handleInbound() {},
+        outboundCallback: async () => {},
+      },
+      close: async () => {},
+    })
+
+    running = await startAgent({
+      port: 0,
+      attachTui: false,
+      cwd: agentDir,
+      loadCron: noCron,
+      discordBotFactory: fakeFactory,
+    })
+
+    expect(startCalls).toEqual([])
+    expect(running.channelManager.activeKeys()).toEqual([])
+
+    const diff = await running.channelManager.applyChannels([
+      { adapter: 'discord-bot', bot: 'main', chats: ['*'], enabled: true },
+    ])
+    expect(diff.added.map((c) => c.bot)).toEqual(['main'])
+    expect(running.channelManager.activeKeys()).toEqual(['discord-bot|main'])
+    expect(startCalls).toEqual(['main'])
+
+    running.stop()
+    await new Promise((r) => setTimeout(r, 50))
+    expect(stopCalls).toEqual(['main'])
+
+    await rm(agentDir, { recursive: true, force: true })
+  })
 })

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -506,21 +506,21 @@ describe('startAgent session persistence wiring', () => {
 
     expect(running.channelRouter).toBeDefined()
     expect(running.channelManager).toBeDefined()
-    expect(running.channelManager.activeKeys()).toEqual([])
+    expect(running.channelManager.activeAdapters()).toEqual([])
   })
 
-  test('channels reload: applyChannels picks up new entries from typeclaw.json', async () => {
+  test('channels reload: applyChannels picks up a new discord-bot from typeclaw.json', async () => {
     const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-channels-'))
 
-    const startCalls: string[] = []
-    const stopCalls: string[] = []
-    const fakeFactory: import('@/channels').DiscordBotFactory = async (channel) => ({
+    let started = 0
+    let stopped = 0
+    const fakeFactory: import('@/channels').DiscordBotFactory = async () => ({
       adapter: {
         async start() {
-          startCalls.push(channel.bot)
+          started++
         },
         async stop() {
-          stopCalls.push(channel.bot)
+          stopped++
         },
         async handleInbound() {},
         outboundCallback: async () => {},
@@ -536,19 +536,19 @@ describe('startAgent session persistence wiring', () => {
       discordBotFactory: fakeFactory,
     })
 
-    expect(startCalls).toEqual([])
-    expect(running.channelManager.activeKeys()).toEqual([])
+    expect(started).toBe(0)
+    expect(running.channelManager.activeAdapters()).toEqual([])
 
-    const diff = await running.channelManager.applyChannels([
-      { adapter: 'discord-bot', bot: 'main', chats: ['*'], enabled: true },
-    ])
-    expect(diff.added.map((c) => c.bot)).toEqual(['main'])
-    expect(running.channelManager.activeKeys()).toEqual(['discord-bot|main'])
-    expect(startCalls).toEqual(['main'])
+    const diff = await running.channelManager.applyChannels({
+      'discord-bot': { allow: ['*'], enabled: true },
+    })
+    expect(diff.added).toEqual(['discord-bot'])
+    expect(running.channelManager.activeAdapters()).toEqual(['discord-bot'])
+    expect(started).toBe(1)
 
     running.stop()
     await new Promise((r) => setTimeout(r, 50))
-    expect(stopCalls).toEqual(['main'])
+    expect(stopped).toBe(1)
 
     await rm(agentDir, { recursive: true, force: true })
   })

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -98,7 +98,7 @@ export async function startAgent({
   })
 
   const channelRouter = createChannelRouter({
-    agentDir: cwd,
+    cwd,
     createSessionForChannel: async (_key, options) => {
       const sessionManager = openOrCreateSession(cwd, sessionFactory.sessionDir(), options?.existingSessionId)
       const session = await createSession({ reloadRegistry, sessionManager, stream })

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -1,6 +1,17 @@
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession } from '@/agent'
+import {
+  type ChannelManager,
+  type ChannelRouter,
+  createChannelManager,
+  createChannelRouter,
+  createChannelsReloadable,
+  createDefaultDiscordBotFactory,
+  type DiscordBotChannel,
+  type DiscordBotFactory,
+  type DiscordBotListenerLike,
+} from '@/channels'
 import { config, type Config, createConfigReloadable, getConfig } from '@/config'
 import {
   type CronConsumer,
@@ -41,6 +52,7 @@ export type StartAgentOptions = {
   createSchedulerFor?: SchedulerFactory
   sessionFactory?: SessionFactory
   stream?: Stream
+  discordBotFactory?: DiscordBotFactory
 }
 
 export type StartAgentResult = {
@@ -49,6 +61,8 @@ export type StartAgentResult = {
   scheduler: Scheduler | null
   cronConsumer: CronConsumer | null
   subagentConsumer: SubagentConsumer
+  channelRouter: ChannelRouter
+  channelManager: ChannelManager
   reloadRegistry: ReloadRegistry
   stream: Stream
   stop: () => void
@@ -64,6 +78,7 @@ export async function startAgent({
   createSchedulerFor,
   sessionFactory = createSessionFactory({ agentDir: cwd }),
   stream = createStream(),
+  discordBotFactory,
 }: StartAgentOptions): Promise<StartAgentResult> {
   const reloadRegistry = new ReloadRegistry()
   reloadRegistry.register(createConfigReloadable({ cwd }))
@@ -78,6 +93,33 @@ export async function startAgent({
         stream,
       }),
   })
+
+  const channelRouter = createChannelRouter({
+    agentDir: cwd,
+    createSessionForChannel: async () => {
+      const sessionManager = SessionManager.create(cwd, sessionFactory.sessionDir())
+      const session = await createSession({ reloadRegistry, sessionManager, stream })
+      return { session, sessionId: sessionManager.getSessionId() }
+    },
+  })
+  const resolvedDiscordBotFactory =
+    discordBotFactory ??
+    createDefaultDiscordBotFactory({
+      router: channelRouter,
+      createDiscordBotClientAndListener: createRealDiscordBotClientAndListener,
+    })
+  const channelManager = createChannelManager({
+    router: channelRouter,
+    channels: getConfig().channels,
+    discordBotFactory: resolvedDiscordBotFactory,
+  })
+  await channelManager.start()
+  reloadRegistry.register(
+    createChannelsReloadable({
+      manager: channelManager,
+      loadChannels: () => getConfig().channels,
+    }),
+  )
 
   const subagentConsumer = createSubagentConsumer({
     stream,
@@ -129,6 +171,7 @@ export async function startAgent({
     scheduler?.stop()
     cronConsumer.stop()
     subagentConsumer.stop()
+    void channelManager.stop().catch((err) => console.error(`[channels] stop failed: ${errMessage(err)}`))
     server.stop(true)
   }
 
@@ -139,6 +182,8 @@ export async function startAgent({
       scheduler,
       cronConsumer: scheduler ? cronConsumer : null,
       subagentConsumer,
+      channelRouter,
+      channelManager,
       reloadRegistry,
       stream,
       stop,
@@ -154,10 +199,37 @@ export async function startAgent({
     scheduler,
     cronConsumer: scheduler ? cronConsumer : null,
     subagentConsumer,
+    channelRouter,
+    channelManager,
     reloadRegistry,
     stream,
     stop,
   }
+}
+
+async function createRealDiscordBotClientAndListener(_channel: DiscordBotChannel) {
+  const { DiscordBotClient, DiscordBotListener, DiscordIntent } = await import('agent-messenger/discordbot')
+  const client = await new DiscordBotClient().login()
+  const listener = new DiscordBotListener(client, {
+    intents:
+      DiscordIntent.Guilds |
+      DiscordIntent.GuildMessages |
+      DiscordIntent.GuildMessageReactions |
+      DiscordIntent.DirectMessages |
+      DiscordIntent.MessageContent,
+  })
+  const listenerLike: DiscordBotListenerLike = listener
+  return {
+    client,
+    listener: listenerLike,
+    close: async () => {
+      listener.stop()
+    },
+  }
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }
 
 async function startScheduler({

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -11,7 +11,7 @@ import {
   createChannelRouter,
   createChannelsReloadable,
   createDefaultDiscordBotFactory,
-  type DiscordBotChannel,
+  type DiscordBotConfig,
   type DiscordBotFactory,
   type DiscordBotListenerLike,
 } from '@/channels'
@@ -226,7 +226,7 @@ function openOrCreateSession(cwd: string, sessionDir: string, existingSessionId:
   return SessionManager.create(cwd, sessionDir)
 }
 
-async function createRealDiscordBotClientAndListener(_channel: DiscordBotChannel) {
+async function createRealDiscordBotClientAndListener(_config: DiscordBotConfig) {
   const { DiscordBotClient, DiscordBotListener, DiscordIntent } = await import('agent-messenger/discordbot')
   const client = await new DiscordBotClient().login()
   const listener = new DiscordBotListener(client, {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -1,3 +1,6 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession } from '@/agent'
@@ -96,8 +99,8 @@ export async function startAgent({
 
   const channelRouter = createChannelRouter({
     agentDir: cwd,
-    createSessionForChannel: async () => {
-      const sessionManager = SessionManager.create(cwd, sessionFactory.sessionDir())
+    createSessionForChannel: async (_key, options) => {
+      const sessionManager = openOrCreateSession(cwd, sessionFactory.sessionDir(), options?.existingSessionId)
       const session = await createSession({ reloadRegistry, sessionManager, stream })
       return { session, sessionId: sessionManager.getSessionId() }
     },
@@ -205,6 +208,22 @@ export async function startAgent({
     stream,
     stop,
   }
+}
+
+function openOrCreateSession(cwd: string, sessionDir: string, existingSessionId: string | undefined): SessionManager {
+  if (existingSessionId !== undefined) {
+    const path = join(sessionDir, `${existingSessionId}.jsonl`)
+    if (existsSync(path)) {
+      try {
+        return SessionManager.open(path, sessionDir, cwd)
+      } catch (err) {
+        console.warn(
+          `[channels] failed to rehydrate session ${existingSessionId} (${errMessage(err)}); creating fresh session`,
+        )
+      }
+    }
+  }
+  return SessionManager.create(cwd, sessionDir)
 }
 
 async function createRealDiscordBotClientAndListener(_channel: DiscordBotChannel) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,8 +23,10 @@
     "noPropertyAccessFromIndexSignature": false,
 
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "agent-messenger/discordbot": ["./src/channels/adapters/agent-messenger-shim.d.ts"]
     }
   },
-  "include": ["src", "scripts"]
+  "include": ["src", "scripts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## What you get

One Discord bot per agent, always on. Add `channels.discord-bot` to `typeclaw.json`, specify an `allow` list, and every matched message becomes a prompt — each (guild/channel/DM thread) gets its own persistent `AgentSession`, survives restarts, and reloads live without a container bounce.

```jsonc
// typeclaw.json
{
  "channels": {
    "discord-bot": {
      "allow": ["*"],
      "enabled": true
    }
  }
}
```

**Allow grammar** — rules are matched in order; first match wins:

| Rule | Admits |
|---|---|
| `"*"` | all guild channels + all DMs (FIXME: too broad; consider `guild:*` + `dm:*` before wider rollout) |
| `"guild:*"` | every channel of every guild the bot is in |
| `"guild:1234567890"` | every channel of that guild |
| `"guild:1234567890/9876543210"` | one specific channel in that guild |
| `"channel:9876543210"` | that snowflake ID in any guild |
| `"dm:*"` | every DM the bot has open |
| `"dm:9876543210"` | one specific DM channel |

Missing or empty `allow` → adapter idles and admits nothing. The `typeclaw init` scaffold writes `["*"]` explicitly with a comment so the operator is aware of the scope.

Reload-safe: narrowing the allow list takes effect immediately in both directions. Outbound replies re-check `isAllowed` before sending, so a reload that removes a rule also silences in-flight replies for that channel.

---

## Runtime architecture

```
ChannelManager (diff-based lifecycle, keyed by adapter type)
  └─ DiscordBotAdapter (wraps agent-messenger DiscordBotListener)
       │  inbound: filter → isAllowed → ChannelRouter.handleInbound
       └─ outbound: session events → isAllowed re-check → reply
ChannelRouter
  ├─ per-key creation lock (concurrent inbound dedup)
  ├─ per-key prompt FIFO drain (mirrors src/server's drain pattern)
  ├─ persist-before-expose ordering (crash recovery)
  ├─ channels/sessions.json  (version 2, gitignored, force-committed by TypeClaw)
  └─ session rehydration: existing sessionId → SessionManager.open() not .create()
```

**ChannelKey** is a 4-tuple `(adapter, workspace, chat, thread)`. Discord uses `@dm` as the workspace sentinel for DMs.

**Session persistence** — `channels/sessions.json` stores the key→sessionId mapping. Version 2 format; v1 files are ignored with a warning and regenerated on next inbound. No users on v1, so no migration needed.

**Reload** — `createChannelsReloadable` hooks into `ReloadRegistry`. `typeclaw reload` diffs the old and new config: new adapters are started, removed adapters are stopped (awaiting in-flight `handleInbound`), changed allow lists take effect immediately. `enabled: false` stops the adapter without removing the config key.

---

## Design-review fixes (landed mid-stream)

These were identified during self-review of the initial implementation and fixed before the redesign commit:

| # | Issue | Fix |
|---|---|---|
| M1 | `ensureLive()` could race for the same key | Per-key creation lock; concurrent inbound for the same key awaits the first |
| M2 | `session.prompt()` called concurrently without ordering | Per-key FIFO drain queue (same pattern as `src/server`'s `enqueuePrompt`) |
| M3 | Persisted `sessionId` loaded but not passed to `createSessionForChannel` | Rehydration path: passes `sessionId` → `SessionManager.open()` |
| M4 | `persist()` threw on disk failure, dropping the user's message | Best-effort: disk failures are logged, message delivery continues |
| M5 | `adapter.stop()` didn't await in-flight `handleInbound` | Adapter tracks in-flight promises; `stop()` awaits `Promise.all` |
| M6 | Outbound didn't re-check allow list after reload | `outboundCallback` calls `isAllowed` before sending each reply |
| M7 | `channelManager.stop()` was fire-and-forget | `startAgent` now `await`s `channelManager.stop()` in teardown |
| M8 | `router.stop()` didn't abort in-flight session prompts | `router.stop()` calls `session.abort()` for every live session |
| M9 | Duplicate `(adapter, bot)` entries accepted by schema | Superseded by redesign: record keys are unique by definition |

---

## Deferred (acceptable v0.1 limitations)

- **Outbound is final-text-only** — no proactive posting from the agent mid-turn; only the completed reply is sent.
- **No session eviction** — `channels/sessions.json` grows unbounded with active threads; eviction policy is a follow-up.
- **Channel sessions are not channel-aware in the system prompt** — the agent doesn't know it's talking to Discord; prompt injection is a follow-up.
- **`"*"` allow rule is too broad** — the FIXME in `schema.ts` tracks splitting this into `guild:*` + `dm:*` before any wider rollout.
- **Single bot per adapter type** — multi-bot support deferred until real demand; the record shape (`channels.discord-bot`) leaves room for a future `channels.discord-bot-2` or an array migration.

---

## Upstream dependency note

`agent-messenger` is pinned from the `main` branch (commit after PR #167 which added `DiscordBotListener`). The published npm release 2.10.2 predates that merge and lacks the listener API. The pin will be replaced with a semver range once the next version is published.

The package ships without `dist/` TypeScript declarations, so `src/channels/adapters/agent-messenger-shim.d.ts` + a `tsconfig.json` paths override insulate the build from the missing types. This shim is deleted when the upstream package ships proper declarations.

---

## Numbers

- 16 commits · +2,818 / −3 lines (net new; the stat includes bun.lock and shim)
- **593 tests pass** (up from ~537 on `main`)
- Typecheck: clean · Format: clean · Lint: 1 pre-existing warning in `config.ts`, unrelated to channels