### PR TITLE
Add a plugin system loaded from typeclaw.json plugins[]

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -5,11 +5,21 @@ import { createAgentSession, DefaultResourceLoader, SessionManager } from '@mari
 import type { AgentSession, ToolDefinition } from '@mariozechner/pi-coding-agent'
 
 import { getConfig, resolveModel } from '@/config'
+import type {
+  BuiltinToolRef,
+  HookBus,
+  MaterializedSkills,
+  PluginRegistry,
+  RegisteredTool as PluginRegisteredTool,
+  Tool as PluginTool,
+} from '@/plugin'
+import { materializeSkills } from '@/plugin'
 import type { ReloadRegistry } from '@/reload'
 import type { Stream } from '@/stream'
 
 import { getAuth } from './auth'
 import { loadMemory } from './memory'
+import { resolveBuiltinToolRefs, wrapPluginTool } from './plugin-tools'
 import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
 import { DEFAULT_SYSTEM_PROMPT } from './system-prompt'
@@ -21,6 +31,20 @@ export type { AgentSession }
 
 type AgentSessionTools = NonNullable<Parameters<typeof createAgentSession>[0]>['tools']
 
+export type PluginSessionWiring = {
+  registry: PluginRegistry
+  hooks: HookBus
+  sessionId: string
+  agentDir: string
+}
+
+export type PluginSubagentSelection = {
+  pluginName: string
+  toolRefs?: BuiltinToolRef[]
+  customTools?: PluginTool<any>[]
+  toolNamePrefix: string
+}
+
 export type CreateSessionOptions = {
   reloadRegistry?: ReloadRegistry
   sessionManager?: SessionManager
@@ -30,20 +54,63 @@ export type CreateSessionOptions = {
   systemPromptOverride?: string
   tools?: AgentSessionTools
   customTools?: ToolDefinition[]
+  plugins?: PluginSessionWiring
+  // When set, only the named plugin subagent's own tools are exposed; the
+  // wider plugin registry's tools are NOT injected. Used by plugin subagent
+  // session creation so subagents see exactly what they declared.
+  pluginSubagent?: PluginSubagentSelection
+}
+
+export type CreateSessionResult = {
+  session: AgentSession
+  dispose: () => Promise<void>
 }
 
 export async function createSession(options: CreateSessionOptions = {}): Promise<AgentSession> {
+  const { session } = await createSessionWithDispose(options)
+  return session
+}
+
+export async function createSessionWithDispose(options: CreateSessionOptions = {}): Promise<CreateSessionResult> {
   const { authStorage, modelRegistry } = getAuth()
+
+  const materializedSkills =
+    options.plugins && options.plugins.registry.skills.length > 0
+      ? await materializeSkills(
+          options.plugins.registry.skills.map((s) => ({
+            pluginName: s.pluginName,
+            localName: s.localName,
+            skill: s.skill,
+          })),
+        )
+      : null
+
   const resourceLoader =
     options.systemPromptOverride !== undefined
       ? await createOverrideResourceLoader(options.systemPromptOverride)
-      : await createResourceLoader()
-  const customTools = options.customTools ?? [
-    websearchTool,
-    webfetchTool,
-    ...(options.reloadRegistry ? [createReloadTool({ registry: options.reloadRegistry })] : []),
-    ...(options.stream ? [createStreamSnapshotTool({ stream: options.stream })] : []),
-  ]
+      : await createResourceLoader(options.plugins ? { plugins: options.plugins, materializedSkills } : {})
+
+  const subagentBuiltinTools = options.pluginSubagent?.toolRefs
+    ? resolveBuiltinToolRefs(options.pluginSubagent.toolRefs)
+    : undefined
+  const pluginCustomTools = options.pluginSubagent
+    ? wrapSubagentCustomTools(options.pluginSubagent, options.plugins)
+    : wrapRegistryTools(options.plugins)
+
+  const tools = options.tools ?? (subagentBuiltinTools as AgentSessionTools | undefined)
+
+  const customTools =
+    options.customTools !== undefined
+      ? [...options.customTools, ...pluginCustomTools]
+      : options.pluginSubagent
+        ? pluginCustomTools
+        : [
+            websearchTool,
+            webfetchTool,
+            ...(options.reloadRegistry ? [createReloadTool({ registry: options.reloadRegistry })] : []),
+            ...(options.stream ? [createStreamSnapshotTool({ stream: options.stream })] : []),
+            ...pluginCustomTools,
+          ]
 
   const { session } = await createAgentSession({
     model: resolveModel(getConfig().model),
@@ -51,10 +118,55 @@ export async function createSession(options: CreateSessionOptions = {}): Promise
     authStorage,
     modelRegistry,
     resourceLoader,
-    ...(options.tools ? { tools: options.tools } : {}),
+    ...(tools ? { tools } : {}),
     customTools,
   })
-  return session
+
+  const dispose = async () => {
+    if (materializedSkills) await materializedSkills.dispose()
+  }
+  return { session, dispose }
+}
+
+function wrapRegistryTools(plugins: PluginSessionWiring | undefined): ToolDefinition[] {
+  if (!plugins) return []
+  return plugins.registry.tools.map((t: PluginRegisteredTool) =>
+    wrapPluginTool(t.tool, {
+      pluginName: t.pluginName,
+      toolName: t.toolName,
+      agentDir: plugins.agentDir,
+      sessionId: plugins.sessionId,
+      logger: t.logger,
+      hooks: plugins.hooks,
+    }),
+  )
+}
+
+function wrapSubagentCustomTools(
+  selection: PluginSubagentSelection,
+  plugins: PluginSessionWiring | undefined,
+): ToolDefinition[] {
+  if (!selection.customTools || !plugins) return []
+  const logger = makePluginLogger(selection.pluginName)
+  return selection.customTools.map((tool, i) =>
+    wrapPluginTool(tool, {
+      pluginName: selection.pluginName,
+      toolName: `${selection.toolNamePrefix}_${i}`,
+      agentDir: plugins.agentDir,
+      sessionId: plugins.sessionId,
+      logger,
+      hooks: plugins.hooks,
+    }),
+  )
+}
+
+function makePluginLogger(pluginName: string) {
+  const prefix = `[plugin:${pluginName}]`
+  return {
+    info: (m: string) => console.log(`${prefix} ${m}`),
+    warn: (m: string) => console.warn(`${prefix} ${m}`),
+    error: (m: string) => console.error(`${prefix} ${m}`),
+  }
 }
 
 export async function createOverrideResourceLoader(systemPrompt: string): Promise<DefaultResourceLoader> {
@@ -66,15 +178,37 @@ export async function createOverrideResourceLoader(systemPrompt: string): Promis
   return loader
 }
 
-export async function createResourceLoader(options: { agentDir?: string } = {}): Promise<DefaultResourceLoader> {
+export type CreateResourceLoaderOptions = {
+  agentDir?: string
+  plugins?: PluginSessionWiring
+  materializedSkills?: MaterializedSkills | null
+}
+
+export async function createResourceLoader(options: CreateResourceLoaderOptions = {}): Promise<DefaultResourceLoader> {
   const agentDir = options.agentDir ?? process.cwd()
   const [self, memory] = await Promise.all([loadSelf(agentDir), loadMemory(agentDir)])
-  const systemPrompt = `${DEFAULT_SYSTEM_PROMPT}\n\n${self}\n\n${memory}`
+  let systemPrompt = `${DEFAULT_SYSTEM_PROMPT}\n\n${self}\n\n${memory}`
+
+  if (options.plugins) {
+    const event = { prompt: systemPrompt, sessionId: options.plugins.sessionId, agentDir }
+    await options.plugins.hooks.runSessionPrompt(event)
+    systemPrompt = event.prompt
+  }
+
+  const additionalSkillPaths = [getBundledSkillsDir()]
+  if (options.plugins) {
+    for (const dir of options.plugins.registry.skillsDirs) {
+      additionalSkillPaths.push(dir.path)
+    }
+  }
+  if (options.materializedSkills) {
+    additionalSkillPaths.push(options.materializedSkills.dir)
+  }
 
   const loader = new DefaultResourceLoader({
     systemPromptOverride: () => systemPrompt,
     appendSystemPromptOverride: () => [],
-    additionalSkillPaths: [getBundledSkillsDir()],
+    additionalSkillPaths,
   })
   await loader.reload()
   return loader

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from 'bun:test'
+
+import { z } from 'zod'
+
+import { createHookBus, defineTool } from '@/plugin'
+
+import { wrapPluginTool, zodToToolParameters } from './plugin-tools'
+
+const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
+
+describe('zodToToolParameters', () => {
+  test('produces a JSON-schema-shaped object from a Zod schema', () => {
+    const schema = z.object({ name: z.string(), age: z.number().optional() })
+    const json = zodToToolParameters(schema) as { type?: string; properties?: Record<string, unknown> }
+    expect(json.type).toBe('object')
+    expect(json.properties).toBeDefined()
+    expect(json.properties).toHaveProperty('name')
+    expect(json.properties).toHaveProperty('age')
+  })
+})
+
+describe('wrapPluginTool', () => {
+  test('passes parsed args to plugin execute and exposes ToolContext', async () => {
+    const seen: { args: unknown; ctx: { sessionId: string; agentDir: string } }[] = []
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ q: z.string() }),
+      async execute(args, ctx) {
+        seen.push({ args, ctx: { sessionId: ctx.sessionId, agentDir: ctx.agentDir } })
+        return { content: [{ type: 'text', text: `q=${args.q}` }] }
+      },
+    })
+
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'search',
+      agentDir: '/agent',
+      sessionId: 'sess-1',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+
+    const result = (await wrapped.execute('call-1', { q: 'hello' }, undefined, undefined, {} as never)) as {
+      content: { type: string; text: string }[]
+    }
+    expect(result.content[0]?.text).toBe('q=hello')
+    expect(seen[0]?.args).toEqual({ q: 'hello' })
+    expect(seen[0]?.ctx.sessionId).toBe('sess-1')
+    expect(seen[0]?.ctx.agentDir).toBe('/agent')
+  })
+
+  test('tool.before mutations to args propagate to the plugin tool execute', async () => {
+    const seen: unknown[] = []
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ q: z.string() }),
+      async execute(args) {
+        seen.push(args)
+        return { content: [{ type: 'text', text: '' }] }
+      },
+    })
+    const hooks = createHookBus()
+    hooks.registerAll('p1', '/agent', noopLogger, {
+      'tool.before': (event) => {
+        event.args.q = 'mutated'
+      },
+    })
+
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'x',
+      agentDir: '/agent',
+      sessionId: 's',
+      logger: noopLogger,
+      hooks,
+    })
+
+    await wrapped.execute('c', { q: 'original' }, undefined, undefined, {} as never)
+    expect(seen[0]).toEqual({ q: 'mutated' })
+  })
+
+  test('tool.before { block: true } refuses execution and never invokes plugin tool', async () => {
+    const calls: number[] = []
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({}),
+      async execute() {
+        calls.push(1)
+        return { content: [] }
+      },
+    })
+    const hooks = createHookBus()
+    hooks.registerAll('p1', '/agent', noopLogger, {
+      'tool.before': () => ({ block: true, reason: 'no thanks' }),
+    })
+
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'x',
+      agentDir: '/agent',
+      sessionId: 's',
+      logger: noopLogger,
+      hooks,
+    })
+
+    const result = (await wrapped.execute('c', {}, undefined, undefined, {} as never)) as {
+      content: { type: string; text: string }[]
+      isError?: boolean
+    }
+    expect(calls).toEqual([])
+    expect(result.isError).toBe(true)
+    expect(result.content[0]?.text).toContain('no thanks')
+  })
+
+  test('tool.after observes the plugin tool result', async () => {
+    const observed: unknown[] = []
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({}),
+      async execute() {
+        return { content: [{ type: 'text', text: 'done' }] }
+      },
+    })
+    const hooks = createHookBus()
+    hooks.registerAll('p1', '/agent', noopLogger, {
+      'tool.after': (event) => {
+        observed.push(event.result.content[0])
+      },
+    })
+
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'x',
+      agentDir: '/agent',
+      sessionId: 's',
+      logger: noopLogger,
+      hooks,
+    })
+
+    await wrapped.execute('c', {}, undefined, undefined, {} as never)
+    expect(observed[0]).toEqual({ type: 'text', text: 'done' })
+  })
+
+  test('returns error result when args fail Zod validation', async () => {
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ q: z.string() }),
+      async execute() {
+        return { content: [] }
+      },
+    })
+
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'x',
+      agentDir: '/agent',
+      sessionId: 's',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+    const result = (await wrapped.execute('c', { q: 42 }, undefined, undefined, {} as never)) as {
+      isError?: boolean
+    }
+    expect(result.isError).toBe(true)
+  })
+
+  test('returns error result when plugin tool throws', async () => {
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({}),
+      async execute() {
+        throw new Error('kaboom')
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'x',
+      agentDir: '/agent',
+      sessionId: 's',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+    const result = (await wrapped.execute('c', {}, undefined, undefined, {} as never)) as {
+      isError?: boolean
+      content: { type: string; text: string }[]
+    }
+    expect(result.isError).toBe(true)
+    expect(result.content[0]?.text).toContain('kaboom')
+  })
+
+  test('forwards the AbortSignal from the engine through to the plugin tool', async () => {
+    const captured: { signal: AbortSignal | undefined } = { signal: undefined }
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({}),
+      async execute(_args, ctx) {
+        captured.signal = ctx.signal
+        return { content: [] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'x',
+      agentDir: '/agent',
+      sessionId: 's',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+
+    const controller = new AbortController()
+    await wrapped.execute('c', {}, controller.signal, undefined, {} as never)
+    expect(captured.signal).toBe(controller.signal)
+  })
+})

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -1,0 +1,129 @@
+import {
+  bashTool as piBashTool,
+  defineTool as piDefineTool,
+  editTool as piEditTool,
+  findTool as piFindTool,
+  grepTool as piGrepTool,
+  lsTool as piLsTool,
+  readTool as piReadTool,
+  writeTool as piWriteTool,
+} from '@mariozechner/pi-coding-agent'
+import type { ToolDefinition } from '@mariozechner/pi-coding-agent'
+import type { TSchema } from '@sinclair/typebox'
+import { z } from 'zod'
+
+import type {
+  BuiltinToolRef,
+  ContentPart,
+  HookBus,
+  PluginLogger,
+  Tool,
+  ToolBeforeEvent,
+  ToolContext,
+  ToolResult,
+} from '@/plugin'
+
+type AnyAgentTool =
+  | typeof piReadTool
+  | typeof piBashTool
+  | typeof piEditTool
+  | typeof piWriteTool
+  | typeof piGrepTool
+  | typeof piFindTool
+  | typeof piLsTool
+
+const BUILTIN_TOOL_MAP: Record<string, AnyAgentTool> = {
+  bash: piBashTool,
+  edit: piEditTool,
+  find: piFindTool,
+  grep: piGrepTool,
+  ls: piLsTool,
+  read: piReadTool,
+  write: piWriteTool,
+}
+
+export function resolveBuiltinToolRefs(refs: BuiltinToolRef[]): AnyAgentTool[] {
+  return refs.map((ref) => {
+    const tool = BUILTIN_TOOL_MAP[ref.__builtinTool]
+    if (!tool) throw new Error(`unknown built-in tool ref: ${ref.__builtinTool}`)
+    return tool
+  })
+}
+
+export type WrapToolOptions = {
+  pluginName: string
+  toolName: string
+  agentDir: string
+  sessionId: string
+  logger: PluginLogger
+  hooks: HookBus
+}
+
+export function zodToToolParameters(schema: z.ZodType<unknown>): TSchema {
+  const json = z.toJSONSchema(schema, { io: 'input', reused: 'inline' })
+  return json as unknown as TSchema
+}
+
+export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefinition {
+  const parameters = zodToToolParameters(tool.parameters)
+
+  return piDefineTool({
+    name: opts.toolName,
+    label: opts.toolName,
+    description: tool.description,
+    parameters,
+    async execute(toolCallId, params, signal) {
+      const validated = tool.parameters.safeParse(params)
+      if (!validated.success) {
+        return errorResult(`invalid arguments: ${validated.error.message}`)
+      }
+
+      const mutableArgs = validated.data as Record<string, unknown>
+      const before: ToolBeforeEvent = {
+        tool: opts.toolName,
+        sessionId: opts.sessionId,
+        callId: toolCallId,
+        args: mutableArgs,
+      }
+      const blockResult = await opts.hooks.runToolBefore(before)
+      if (blockResult !== undefined) {
+        return errorResult(`blocked: ${blockResult.reason}`)
+      }
+
+      const toolCtx: ToolContext = {
+        signal,
+        sessionId: opts.sessionId,
+        agentDir: opts.agentDir,
+        logger: opts.logger,
+      }
+
+      let result: ToolResult
+      try {
+        result = await tool.execute(before.args, toolCtx)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return errorResult(message)
+      }
+
+      await opts.hooks.runToolAfter({
+        tool: opts.toolName,
+        sessionId: opts.sessionId,
+        callId: toolCallId,
+        result,
+      })
+
+      return {
+        content: result.content as ContentPart[],
+        details: result.details,
+      }
+    },
+  })
+}
+
+function errorResult(message: string) {
+  return {
+    content: [{ type: 'text' as const, text: message }],
+    details: { error: true, message },
+    isError: true,
+  }
+}

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -48,7 +48,10 @@ function describePayload(payload: unknown): string {
   return typeof payload
 }
 
-export type CreateSessionForSubagent = (subagent: Subagent<any>) => Promise<AgentSession>
+export type CreateSessionForSubagentResult = { session: AgentSession; dispose?: () => Promise<void> }
+export type CreateSessionForSubagent = (
+  subagent: Subagent<any>,
+) => Promise<AgentSession | CreateSessionForSubagentResult>
 
 export const defaultCreateSessionForSubagent: CreateSessionForSubagent = (subagent) =>
   createSession({
@@ -56,6 +59,16 @@ export const defaultCreateSessionForSubagent: CreateSessionForSubagent = (subage
     ...(subagent.tools ? { tools: subagent.tools } : {}),
     customTools: subagent.customTools ?? [],
   })
+
+function normalizeSubagentSession(result: AgentSession | CreateSessionForSubagentResult): {
+  session: AgentSession
+  dispose: () => Promise<void>
+} {
+  if ('session' in result) {
+    return { session: result.session, dispose: result.dispose ?? (async () => {}) }
+  }
+  return { session: result, dispose: async () => {} }
+}
 
 export type InvokeSubagentOptions = {
   registry: SubagentRegistry
@@ -73,11 +86,12 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
   const createSessionForSubagent = options.createSessionForSubagent ?? defaultCreateSessionForSubagent
 
   const runSession: RunSession = async (override) => {
-    const session = await createSessionForSubagent(subagent)
+    const { session, dispose } = normalizeSubagentSession(await createSessionForSubagent(subagent))
     try {
       await session.prompt(override?.userPrompt ?? options.userPrompt)
     } finally {
       session.dispose()
+      await dispose()
     }
   }
 

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -3,7 +3,14 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { configSchema, loadConfigSync, mountSchema, validateConfig } from './config'
+import {
+  configSchema,
+  extractPluginConfigs,
+  loadConfigSync,
+  loadPluginConfigsSync,
+  mountSchema,
+  validateConfig,
+} from './config'
 
 const VALID_MODEL = 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'
 
@@ -240,5 +247,64 @@ describe('loadConfigSync', () => {
       }),
     )
     expect(() => loadConfigSync(cwd)).toThrow(/typeclaw\.json is invalid/)
+  })
+})
+
+describe('plugin config layout', () => {
+  test('plugins defaults to [] when omitted', () => {
+    const parsed = configSchema.parse({ model: VALID_MODEL })
+    expect(parsed.plugins).toEqual([])
+  })
+
+  test('plugins accepts an array of strings', () => {
+    const parsed = configSchema.parse({
+      model: VALID_MODEL,
+      plugins: ['typeclaw-plugin-foo', './plugins/local'],
+    })
+    expect(parsed.plugins).toEqual(['typeclaw-plugin-foo', './plugins/local'])
+  })
+
+  test('catchall preserves unknown top-level keys (per-plugin config blocks)', () => {
+    const parsed = configSchema.parse({
+      model: VALID_MODEL,
+      plugins: ['typeclaw-plugin-standup-log'],
+      'standup-log': { schedule: '0 17 * * 5' },
+    }) as Record<string, unknown>
+    expect(parsed['standup-log']).toEqual({ schedule: '0 17 * * 5' })
+  })
+
+  test('extractPluginConfigs filters known top-level keys and returns the rest', () => {
+    const result = extractPluginConfigs({
+      $schema: 'x',
+      port: 1,
+      model: 'm',
+      memory: {},
+      mounts: [],
+      plugins: [],
+      'standup-log': { schedule: '0 17 * * 5' },
+      memory_keeper: { idleMs: 5000 },
+    })
+    expect(result).toEqual({
+      'standup-log': { schedule: '0 17 * * 5' },
+      memory_keeper: { idleMs: 5000 },
+    })
+  })
+
+  test('loadPluginConfigsSync reads per-plugin blocks from disk', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-cfg-'))
+    try {
+      await writeFile(
+        join(cwd, 'typeclaw.json'),
+        JSON.stringify({
+          model: VALID_MODEL,
+          plugins: ['typeclaw-plugin-foo'],
+          foo: { bar: 1 },
+        }),
+      )
+      const result = loadPluginConfigsSync(cwd)
+      expect(result).toEqual({ foo: { bar: 1 } })
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
   })
 })

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -43,21 +43,24 @@ const dreamingSchema = z
   })
   .default({ schedule: DEFAULT_DREAMING_SCHEDULE })
 
-export const configSchema = z.object({
-  $schema: z.string().optional(),
-  port: z.number().int().min(1).max(65535).default(DEFAULT_PORT),
-  model: z.enum(knownModelRefs).default('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'), // FIXME: TEMP default
-  memory: z
-    .object({
-      idleMs: z.number().int().min(1000).default(DEFAULT_MEMORY_IDLE_MS),
-      dreaming: dreamingSchema.optional(),
-    })
-    .default({ idleMs: DEFAULT_MEMORY_IDLE_MS }),
-  // Defaults to `[]` so configs predating the field still load. `typeclaw init`
-  // writes `"mounts": []` explicitly, but a missing field is treated the same
-  // way (no host paths exposed) rather than failing the whole config load.
-  mounts: z.array(mountSchema).default([]),
-})
+export const configSchema = z
+  .object({
+    $schema: z.string().optional(),
+    port: z.number().int().min(1).max(65535).default(DEFAULT_PORT),
+    model: z.enum(knownModelRefs).default('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'), // FIXME: TEMP default
+    memory: z
+      .object({
+        idleMs: z.number().int().min(1000).default(DEFAULT_MEMORY_IDLE_MS),
+        dreaming: dreamingSchema.optional(),
+      })
+      .default({ idleMs: DEFAULT_MEMORY_IDLE_MS }),
+    // Defaults to `[]` so configs predating the field still load. `typeclaw init`
+    // writes `"mounts": []` explicitly, but a missing field is treated the same
+    // way (no host paths exposed) rather than failing the whole config load.
+    mounts: z.array(mountSchema).default([]),
+    plugins: z.array(z.string().min(1)).default([]),
+  })
+  .catchall(z.unknown())
 
 function isValidCronExpression(schedule: string): boolean {
   try {
@@ -140,6 +143,7 @@ export const FIELD_EFFECTS: Record<string, FieldEffect> = {
   mounts: 'restart-required',
   'memory.idleMs': 'restart-required',
   'memory.dreaming': 'applied',
+  plugins: 'restart-required',
 }
 
 // Stable JSON for value comparison. Fields are small JSON-shaped objects, so
@@ -160,7 +164,7 @@ function stableStringify(value: unknown): string {
 
 function diffConfig(before: Config, after: Config): ConfigReloadDiff {
   const diff: ConfigReloadDiff = { applied: [], restartRequired: [], ignored: [] }
-  const keys = new Set<string>([...Object.keys(FIELD_EFFECTS)])
+  const keys = new Set<string>(Object.keys(FIELD_EFFECTS))
 
   for (const path of keys) {
     const b = readPath(before, path)
@@ -184,6 +188,37 @@ function readPath(obj: unknown, path: string): unknown {
     cur = (cur as Record<string, unknown>)[part]
   }
   return cur
+}
+
+// Plugin configs live at the top level of typeclaw.json keyed by plugin name
+// (e.g. "standup-log": { ... }). They are preserved by configSchema.catchall(z.unknown())
+// because the schema does not predeclare these keys. This helper returns the
+// raw map of unknown values keyed by plugin name; the plugin loader re-validates
+// each block against its plugin's `configSchema`.
+export function extractPluginConfigs(raw: unknown): Record<string, unknown> {
+  if (typeof raw !== 'object' || raw === null) return {}
+  const known = new Set(['$schema', 'port', 'model', 'memory', 'mounts', 'plugins'])
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!known.has(key)) result[key] = value
+  }
+  return result
+}
+
+export function loadPluginConfigsSync(cwd: string): Record<string, unknown> {
+  let raw: string
+  try {
+    raw = readFileSync(join(cwd, CONFIG_FILE), 'utf8')
+  } catch {
+    return {}
+  }
+  let json: unknown
+  try {
+    json = JSON.parse(raw)
+  } catch {
+    return {}
+  }
+  return extractPluginConfigs(json)
 }
 
 export function loadConfigSync(cwd: string): Config {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,10 @@
 export {
   config,
+  configSchema,
+  extractPluginConfigs,
   getConfig,
+  loadConfigSync,
+  loadPluginConfigsSync,
   mountSchema,
   reloadConfig,
   resolveModel,

--- a/src/plugin/context.test.ts
+++ b/src/plugin/context.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createPluginContext } from './context'
+
+const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
+
+describe('createPluginContext', () => {
+  test('exposes name, version, agentDir, config, logger', () => {
+    const ctx = createPluginContext({
+      name: 'foo',
+      version: '1.0.0',
+      agentDir: '/x',
+      config: { k: 1 },
+      logger: noopLogger,
+      spawnSubagent: async () => {},
+      isBooted: () => true,
+    })
+    expect(ctx.name).toBe('foo')
+    expect(ctx.version).toBe('1.0.0')
+    expect(ctx.agentDir).toBe('/x')
+    expect(ctx.config).toEqual({ k: 1 })
+  })
+
+  test('spawnSubagent throws when called before boot completes', async () => {
+    const ctx = createPluginContext({
+      name: 'foo',
+      version: undefined,
+      agentDir: '/x',
+      config: undefined as never,
+      logger: noopLogger,
+      spawnSubagent: async () => {},
+      isBooted: () => false,
+    })
+    await expect(ctx.spawnSubagent('any')).rejects.toThrow(/before boot completed/)
+  })
+
+  test('spawnSubagent forwards to underlying impl after boot', async () => {
+    const calls: { name: string; payload: unknown }[] = []
+    const ctx = createPluginContext({
+      name: 'foo',
+      version: undefined,
+      agentDir: '/x',
+      config: undefined as never,
+      logger: noopLogger,
+      spawnSubagent: async (name, payload) => {
+        calls.push({ name, payload })
+      },
+      isBooted: () => true,
+    })
+    await ctx.spawnSubagent('worker', { x: 1 })
+    expect(calls).toEqual([{ name: 'worker', payload: { x: 1 } }])
+  })
+})

--- a/src/plugin/context.ts
+++ b/src/plugin/context.ts
@@ -1,0 +1,40 @@
+import type { PluginContext, PluginLogger } from './types'
+
+export type SpawnSubagentFn = (name: string, payload?: unknown) => Promise<void>
+
+export type CreatePluginContextOptions<TConfig> = {
+  name: string
+  version: string | undefined
+  agentDir: string
+  config: TConfig
+  logger: PluginLogger
+  spawnSubagent: SpawnSubagentFn
+  isBooted: () => boolean
+}
+
+export function createPluginContext<TConfig>(opts: CreatePluginContextOptions<TConfig>): PluginContext<TConfig> {
+  return Object.freeze({
+    name: opts.name,
+    version: opts.version,
+    agentDir: opts.agentDir,
+    config: opts.config,
+    logger: opts.logger,
+    spawnSubagent: async (name: string, payload?: unknown) => {
+      if (!opts.isBooted()) {
+        throw new Error(
+          `plugin ${opts.name}: spawnSubagent("${name}") called before boot completed; subagent registry is not yet wired`,
+        )
+      }
+      await opts.spawnSubagent(name, payload)
+    },
+  })
+}
+
+export function createPluginLogger(name: string): PluginLogger {
+  const prefix = `[plugin:${name}]`
+  return {
+    info: (m) => console.log(`${prefix} ${m}`),
+    warn: (m) => console.warn(`${prefix} ${m}`),
+    error: (m) => console.error(`${prefix} ${m}`),
+  }
+}

--- a/src/plugin/define.test.ts
+++ b/src/plugin/define.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+
+import { z } from 'zod'
+
+import { definePlugin, readTool, writeTool } from './define'
+
+describe('definePlugin', () => {
+  test('infers config type from configSchema and feeds validated values into the factory ctx', async () => {
+    const captured: { value: unknown } = { value: undefined }
+    const spec = definePlugin({
+      configSchema: z.object({ count: z.number().default(7) }),
+      plugin: async (ctx) => {
+        captured.value = ctx.config.count
+        return {}
+      },
+    })
+    await spec.plugin({
+      name: 't',
+      version: undefined,
+      agentDir: '/tmp',
+      config: { count: 42 },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      spawnSubagent: async () => {},
+    })
+    expect(captured.value).toBe(42)
+  })
+})
+
+describe('built-in tool refs', () => {
+  test('each ref is a distinct opaque token carrying the engine tool name', () => {
+    expect(readTool).not.toBe(writeTool)
+    expect(readTool.__builtinTool).toBe('read')
+    expect(writeTool.__builtinTool).toBe('write')
+  })
+})

--- a/src/plugin/define.ts
+++ b/src/plugin/define.ts
@@ -1,0 +1,35 @@
+import type { z } from 'zod'
+
+import type { BuiltinToolRef, DefinedPlugin, PluginContext, PluginExports, Subagent, Tool } from './types'
+
+type DefinePluginSpec<S extends z.ZodType<unknown> | undefined> =
+  S extends z.ZodType<infer T>
+    ? {
+        configSchema: S
+        plugin: (ctx: PluginContext<T>) => Promise<PluginExports>
+      }
+    : {
+        plugin: (ctx: PluginContext<never>) => Promise<PluginExports>
+      }
+
+export function definePlugin<S extends z.ZodType<unknown> | undefined = undefined>(
+  spec: DefinePluginSpec<S>,
+): DefinedPlugin<S extends z.ZodType<infer T> ? T : never> {
+  return spec as DefinedPlugin<S extends z.ZodType<infer T> ? T : never>
+}
+
+export function defineTool<P>(tool: Tool<P>): Tool<P> {
+  return tool
+}
+
+export function defineSubagent<P>(subagent: Subagent<P>): Subagent<P> {
+  return subagent
+}
+
+export const readTool: BuiltinToolRef = { __builtinTool: 'read' }
+export const bashTool: BuiltinToolRef = { __builtinTool: 'bash' }
+export const editTool: BuiltinToolRef = { __builtinTool: 'edit' }
+export const writeTool: BuiltinToolRef = { __builtinTool: 'write' }
+export const grepTool: BuiltinToolRef = { __builtinTool: 'grep' }
+export const findTool: BuiltinToolRef = { __builtinTool: 'find' }
+export const lsTool: BuiltinToolRef = { __builtinTool: 'ls' }

--- a/src/plugin/hooks.test.ts
+++ b/src/plugin/hooks.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createHookBus } from './hooks'
+
+const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
+
+describe('HookBus session.prompt', () => {
+  test('multiple plugins compose; each sees the previous mutation', async () => {
+    const bus = createHookBus()
+    bus.registerAll('p1', '/agent', noopLogger, {
+      'session.prompt': (event) => {
+        event.prompt += '\n[from p1]'
+      },
+    })
+    bus.registerAll('p2', '/agent', noopLogger, {
+      'session.prompt': (event) => {
+        event.prompt += '\n[from p2]'
+      },
+    })
+
+    const event = { prompt: 'BASE', sessionId: 's', agentDir: '/agent' }
+    await bus.runSessionPrompt(event)
+
+    expect(event.prompt).toBe('BASE\n[from p1]\n[from p2]')
+  })
+
+  test('plugin-throwing handler does not break later plugins', async () => {
+    const bus = createHookBus()
+    bus.registerAll('p1', '/agent', noopLogger, {
+      'session.prompt': () => {
+        throw new Error('boom')
+      },
+    })
+    bus.registerAll('p2', '/agent', noopLogger, {
+      'session.prompt': (event) => {
+        event.prompt += '\n[ok]'
+      },
+    })
+    const event = { prompt: 'BASE', sessionId: 's', agentDir: '/agent' }
+    await bus.runSessionPrompt(event)
+    expect(event.prompt).toBe('BASE\n[ok]')
+  })
+})
+
+describe('HookBus tool.before', () => {
+  test('mutations to event.args compose; first { block } short-circuits', async () => {
+    const bus = createHookBus()
+    const seen: Record<string, unknown>[] = []
+    bus.registerAll('p1', '/agent', noopLogger, {
+      'tool.before': (event) => {
+        seen.push({ ...event.args })
+        event.args.via = 'p1'
+      },
+    })
+    bus.registerAll('p2', '/agent', noopLogger, {
+      'tool.before': (event) => {
+        seen.push({ ...event.args })
+        return { block: true, reason: 'denied' }
+      },
+    })
+    bus.registerAll('p3', '/agent', noopLogger, {
+      'tool.before': (event) => {
+        seen.push({ ...event.args })
+      },
+    })
+
+    const result = await bus.runToolBefore({
+      tool: 't',
+      sessionId: 's',
+      callId: 'c1',
+      args: { foo: 1 },
+    })
+    expect(result).toEqual({ block: true, reason: 'denied' })
+    expect(seen).toEqual([{ foo: 1 }, { foo: 1, via: 'p1' }])
+  })
+
+  test('returns undefined when no plugin blocks', async () => {
+    const bus = createHookBus()
+    bus.registerAll('p1', '/agent', noopLogger, {
+      'tool.before': () => {},
+    })
+    const result = await bus.runToolBefore({ tool: 't', sessionId: 's', callId: 'c', args: {} })
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('HookBus session.idle / session.start / session.end', () => {
+  test('observe-only hooks fire in registration order with the event payload', async () => {
+    const bus = createHookBus()
+    const calls: string[] = []
+    bus.registerAll('p1', '/agent', noopLogger, {
+      'session.idle': (event) => {
+        calls.push(`p1:${event.sessionId}:${event.idleMs}`)
+      },
+      'session.start': (event) => {
+        calls.push(`p1:start:${event.sessionId}`)
+      },
+      'session.end': (event) => {
+        calls.push(`p1:end:${event.sessionId}`)
+      },
+    })
+    bus.registerAll('p2', '/agent', noopLogger, {
+      'session.idle': (event) => {
+        calls.push(`p2:${event.sessionId}`)
+      },
+    })
+
+    await bus.runSessionStart({ sessionId: 's1', agentDir: '/agent' })
+    await bus.runSessionIdle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 1000 })
+    await bus.runSessionEnd({ sessionId: 's1' })
+
+    expect(calls).toEqual(['p1:start:s1', 'p1:s1:1000', 'p2:s1', 'p1:end:s1'])
+  })
+})
+
+describe('HookBus unregisterAll', () => {
+  test('removes hooks for a single plugin and leaves others intact', () => {
+    const bus = createHookBus()
+    bus.registerAll('p1', '/agent', noopLogger, { 'session.start': () => {}, 'tool.before': () => {} })
+    bus.registerAll('p2', '/agent', noopLogger, { 'session.start': () => {} })
+    expect(bus.count('session.start')).toBe(2)
+    expect(bus.count('tool.before')).toBe(1)
+
+    bus.unregisterAll('p1')
+
+    expect(bus.count('session.start')).toBe(1)
+    expect(bus.count('tool.before')).toBe(0)
+  })
+})

--- a/src/plugin/hooks.ts
+++ b/src/plugin/hooks.ts
@@ -1,0 +1,155 @@
+import type {
+  HookContext,
+  Hooks,
+  PluginLogger,
+  SessionEndEvent,
+  SessionIdleEvent,
+  SessionPromptEvent,
+  SessionStartEvent,
+  ToolAfterEvent,
+  ToolBeforeEvent,
+  ToolBeforeResult,
+} from './types'
+
+export type RegisteredHook<K extends keyof Hooks> = {
+  pluginName: string
+  agentDir: string
+  logger: PluginLogger
+  handler: NonNullable<Hooks[K]>
+}
+
+export type HookBus = {
+  registerAll: (pluginName: string, agentDir: string, logger: PluginLogger, hooks: Hooks) => void
+  unregisterAll: (pluginName: string) => void
+  runSessionStart: (event: SessionStartEvent) => Promise<void>
+  runSessionEnd: (event: SessionEndEvent) => Promise<void>
+  runSessionIdle: (event: SessionIdleEvent) => Promise<void>
+  runSessionPrompt: (event: SessionPromptEvent) => Promise<void>
+  runToolBefore: (event: ToolBeforeEvent) => Promise<{ block: true; reason: string } | undefined>
+  runToolAfter: (event: ToolAfterEvent) => Promise<void>
+  count: (name: keyof Hooks) => number
+}
+
+type Registries = {
+  'session.start': RegisteredHook<'session.start'>[]
+  'session.end': RegisteredHook<'session.end'>[]
+  'session.idle': RegisteredHook<'session.idle'>[]
+  'session.prompt': RegisteredHook<'session.prompt'>[]
+  'tool.before': RegisteredHook<'tool.before'>[]
+  'tool.after': RegisteredHook<'tool.after'>[]
+}
+
+export function createHookBus(): HookBus {
+  const r: Registries = {
+    'session.start': [],
+    'session.end': [],
+    'session.idle': [],
+    'session.prompt': [],
+    'tool.before': [],
+    'tool.after': [],
+  }
+
+  function ctx(reg: { pluginName: string; agentDir: string; logger: PluginLogger }): HookContext {
+    return { agentDir: reg.agentDir, pluginName: reg.pluginName, logger: reg.logger }
+  }
+
+  return {
+    registerAll(pluginName, agentDir, logger, hooks) {
+      const base = { pluginName, agentDir, logger }
+      if (hooks['session.start']) r['session.start'].push({ ...base, handler: hooks['session.start'] })
+      if (hooks['session.end']) r['session.end'].push({ ...base, handler: hooks['session.end'] })
+      if (hooks['session.idle']) r['session.idle'].push({ ...base, handler: hooks['session.idle'] })
+      if (hooks['session.prompt']) r['session.prompt'].push({ ...base, handler: hooks['session.prompt'] })
+      if (hooks['tool.before']) r['tool.before'].push({ ...base, handler: hooks['tool.before'] })
+      if (hooks['tool.after']) r['tool.after'].push({ ...base, handler: hooks['tool.after'] })
+    },
+
+    unregisterAll(pluginName) {
+      r['session.start'] = r['session.start'].filter((h) => h.pluginName !== pluginName)
+      r['session.end'] = r['session.end'].filter((h) => h.pluginName !== pluginName)
+      r['session.idle'] = r['session.idle'].filter((h) => h.pluginName !== pluginName)
+      r['session.prompt'] = r['session.prompt'].filter((h) => h.pluginName !== pluginName)
+      r['tool.before'] = r['tool.before'].filter((h) => h.pluginName !== pluginName)
+      r['tool.after'] = r['tool.after'].filter((h) => h.pluginName !== pluginName)
+    },
+
+    async runSessionStart(event) {
+      for (const reg of r['session.start']) {
+        try {
+          await reg.handler(event, ctx(reg))
+        } catch (err) {
+          reportHookError(reg, 'session.start', err)
+        }
+      }
+    },
+
+    async runSessionEnd(event) {
+      for (const reg of r['session.end']) {
+        try {
+          await reg.handler(event, ctx(reg))
+        } catch (err) {
+          reportHookError(reg, 'session.end', err)
+        }
+      }
+    },
+
+    async runSessionIdle(event) {
+      for (const reg of r['session.idle']) {
+        try {
+          await reg.handler(event, ctx(reg))
+        } catch (err) {
+          reportHookError(reg, 'session.idle', err)
+        }
+      }
+    },
+
+    async runSessionPrompt(event) {
+      for (const reg of r['session.prompt']) {
+        try {
+          await reg.handler(event, ctx(reg))
+        } catch (err) {
+          reportHookError(reg, 'session.prompt', err)
+        }
+      }
+    },
+
+    // First plugin to return `{ block: true, reason }` short-circuits. Earlier
+    // plugins' arg mutations remain visible to later plugins via the shared
+    // event.args object.
+    async runToolBefore(event) {
+      for (const reg of r['tool.before']) {
+        let result: ToolBeforeResult
+        try {
+          result = await reg.handler(event, ctx(reg))
+        } catch (err) {
+          reportHookError(reg, 'tool.before', err)
+          continue
+        }
+        if (result && typeof result === 'object' && (result as { block?: unknown }).block === true) {
+          const reason = (result as { reason?: unknown }).reason
+          return { block: true, reason: typeof reason === 'string' ? reason : 'blocked by plugin' }
+        }
+      }
+      return undefined
+    },
+
+    async runToolAfter(event) {
+      for (const reg of r['tool.after']) {
+        try {
+          await reg.handler(event, ctx(reg))
+        } catch (err) {
+          reportHookError(reg, 'tool.after', err)
+        }
+      }
+    },
+
+    count(name) {
+      return r[name].length
+    },
+  }
+}
+
+function reportHookError(reg: { logger: PluginLogger }, hook: keyof Hooks, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err)
+  reg.logger.error(`hook ${hook} threw: ${message}`)
+}

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,0 +1,63 @@
+export {
+  bashTool,
+  defineTool,
+  definePlugin,
+  defineSubagent,
+  editTool,
+  findTool,
+  grepTool,
+  lsTool,
+  readTool,
+  writeTool,
+} from './define'
+
+export type {
+  BuiltinToolRef,
+  ContentPart,
+  DefinedPlugin,
+  HookContext,
+  HookName,
+  Hooks,
+  PluginContext,
+  PluginCronJob,
+  PluginExecCronJob,
+  PluginExports,
+  PluginLogger,
+  PluginPromptCronJob,
+  PluginSkill,
+  RunSession,
+  SessionEndEvent,
+  SessionIdleEvent,
+  SessionPromptEvent,
+  SessionStartEvent,
+  Subagent,
+  SubagentContext,
+  Tool,
+  ToolAfterEvent,
+  ToolBeforeEvent,
+  ToolBeforeResult,
+  ToolContext,
+  ToolLogger,
+  ToolResult,
+} from './types'
+
+export {
+  loadPlugins,
+  summarizeLoaded,
+  pluginCronJobs,
+  type LoadPluginsOptions,
+  type LoadPluginsResult,
+} from './manager'
+export type { LoadPluginEntryFn, ResolvedPlugin } from './loader'
+export { loadPluginEntry, derivePluginNameFromPackage } from './loader'
+export { materializeSkills, type MaterializedSkills, type SkillEntry } from './skills'
+export {
+  buildPluginCronGlobalId,
+  type PluginRegistry,
+  type RegisteredCronJob,
+  type RegisteredSubagent,
+  type RegisteredTool,
+  type RegisteredSkillEntry,
+  type RegisteredSkillDir,
+} from './registry'
+export { createHookBus, type HookBus } from './hooks'

--- a/src/plugin/loader.test.ts
+++ b/src/plugin/loader.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { derivePluginNameFromPackage, loadPluginEntry } from './loader'
+
+describe('derivePluginNameFromPackage', () => {
+  test('strips typeclaw-plugin- prefix', () => {
+    expect(derivePluginNameFromPackage('typeclaw-plugin-standup-log')).toBe('standup-log')
+  })
+
+  test('strips scoped prefix and typeclaw-plugin- prefix', () => {
+    expect(derivePluginNameFromPackage('@acme/typeclaw-plugin-helicone')).toBe('helicone')
+  })
+
+  test('keeps unprefixed names as-is', () => {
+    expect(derivePluginNameFromPackage('memory')).toBe('memory')
+  })
+
+  test('strips scope from scoped names without typeclaw prefix', () => {
+    expect(derivePluginNameFromPackage('@acme/cool-plugin')).toBe('cool-plugin')
+  })
+})
+
+describe('loadPluginEntry — local path', () => {
+  test('loads a relative-path plugin and derives name from basename', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-loader-'))
+    try {
+      await mkdir(join(dir, 'plugins'))
+      await writeFile(
+        join(dir, 'plugins', 'local-thing.ts'),
+        `import { definePlugin } from '${process.cwd()}/src/plugin/index.ts'
+export default definePlugin({
+  plugin: async () => ({}),
+})`,
+      )
+      const resolved = await loadPluginEntry('./plugins/local-thing.ts', dir)
+      expect(resolved.name).toBe('local-thing')
+      expect(resolved.version).toBeUndefined()
+      expect(resolved.source).toBe('./plugins/local-thing.ts')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('throws when local path does not exist', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-loader-'))
+    try {
+      await expect(loadPluginEntry('./plugins/missing.ts', dir)).rejects.toThrow(/does not exist/)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('throws when default export is not a definePlugin result', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-loader-'))
+    try {
+      await mkdir(join(dir, 'plugins'))
+      await writeFile(join(dir, 'plugins', 'bad.ts'), `export default { plugin: 'not a function' }`)
+      await expect(loadPluginEntry('./plugins/bad.ts', dir)).rejects.toThrow(/default export is not/)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('loadPluginEntry — npm', () => {
+  test('reads package.json for name + version when located in node_modules', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-loader-npm-'))
+    try {
+      const pkgDir = join(dir, 'node_modules', 'typeclaw-plugin-standup-log')
+      await mkdir(pkgDir, { recursive: true })
+      await writeFile(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: 'typeclaw-plugin-standup-log',
+          version: '0.1.2',
+          type: 'module',
+          main: 'index.js',
+        }),
+      )
+      await writeFile(
+        join(pkgDir, 'index.js'),
+        `import { definePlugin } from '${process.cwd()}/src/plugin/index.ts'
+export default definePlugin({
+  plugin: async () => ({}),
+})`,
+      )
+      const resolved = await loadPluginEntry('typeclaw-plugin-standup-log', dir)
+      expect(resolved.name).toBe('standup-log')
+      expect(resolved.version).toBe('0.1.2')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/plugin/loader.ts
+++ b/src/plugin/loader.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import type { DefinedPlugin } from './types'
+
+export type ResolvedPlugin = {
+  name: string
+  version: string | undefined
+  source: string
+  defined: DefinedPlugin<any>
+}
+
+export type LoadPluginEntryFn = (entry: string, agentDir: string) => Promise<ResolvedPlugin>
+
+export async function loadPluginEntry(entry: string, agentDir: string): Promise<ResolvedPlugin> {
+  if (isLocalPath(entry)) {
+    return loadLocal(entry, agentDir)
+  }
+  return loadNpm(entry, agentDir)
+}
+
+function isLocalPath(entry: string): boolean {
+  return entry.startsWith('./') || entry.startsWith('../') || isAbsolute(entry)
+}
+
+async function loadLocal(entry: string, agentDir: string): Promise<ResolvedPlugin> {
+  const resolved = resolve(agentDir, entry)
+  // Confine local plugin paths to within agentDir so a malicious typeclaw.json
+  // cannot point at arbitrary files on the host.
+  const rel = relative(agentDir, resolved)
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error(`plugin path escapes agent directory: ${entry} (resolved to ${resolved})`)
+  }
+  if (!existsSync(resolved)) {
+    throw new Error(`plugin path does not exist: ${entry} (resolved to ${resolved})`)
+  }
+  const url = pathToFileURL(resolved).href
+  const mod = (await import(url)) as { default?: unknown }
+  const defined = expectDefined(mod, entry)
+  const name = basename(resolved).replace(/\.(ts|tsx|js|mjs|cjs)$/i, '')
+  return { name, version: undefined, source: entry, defined }
+}
+
+async function loadNpm(entry: string, agentDir: string): Promise<ResolvedPlugin> {
+  const pkgJsonPath = findPackageJson(entry, agentDir)
+  let pkgName = entry
+  let version: string | undefined
+  let entryPath: string | null = null
+  if (pkgJsonPath !== null) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) as {
+        name?: unknown
+        version?: unknown
+        main?: unknown
+        module?: unknown
+      }
+      if (typeof pkg.name === 'string' && pkg.name.length > 0) pkgName = pkg.name
+      if (typeof pkg.version === 'string' && pkg.version.length > 0) version = pkg.version
+      const main = typeof pkg.module === 'string' ? pkg.module : typeof pkg.main === 'string' ? pkg.main : null
+      if (main !== null) {
+        const candidate = join(dirname(pkgJsonPath), main)
+        if (existsSync(candidate)) {
+          entryPath = candidate
+        }
+      }
+    } catch {
+      // Fall through to bare-import resolution.
+    }
+  }
+  // Falls back to bare-import resolution when entryPath cannot be located on
+  // disk. Modern packages with `exports` map (and no `main`/`module`) take
+  // this path so Bun's resolver can read `exports`.
+  const importTarget = entryPath !== null ? pathToFileURL(entryPath).href : entry
+  const mod = (await import(importTarget)) as { default?: unknown }
+  const defined = expectDefined(mod, entry)
+  const name = derivePluginNameFromPackage(pkgName)
+  return { name, version, source: entry, defined }
+}
+
+export function derivePluginNameFromPackage(packageName: string): string {
+  const PREFIX = 'typeclaw-plugin-'
+  const SCOPED_PREFIX_RE = /^@[^/]+\//
+  const stripped = packageName.replace(SCOPED_PREFIX_RE, '')
+  return stripped.startsWith(PREFIX) ? stripped.slice(PREFIX.length) : stripped
+}
+
+function findPackageJson(entry: string, agentDir: string): string | null {
+  const PACKAGE_JSON = 'package.json'
+  let cur = agentDir
+  while (true) {
+    const p = join(cur, 'node_modules', entry, PACKAGE_JSON)
+    if (existsSync(p)) return p
+    const parent = dirname(cur)
+    if (parent === cur) return null
+    cur = parent
+  }
+}
+
+function expectDefined(mod: { default?: unknown }, entry: string): DefinedPlugin<any> {
+  const def = mod.default
+  if (
+    def !== null &&
+    typeof def === 'object' &&
+    'plugin' in (def as Record<string, unknown>) &&
+    typeof (def as { plugin: unknown }).plugin === 'function'
+  ) {
+    return def as DefinedPlugin<any>
+  }
+  throw new Error(`plugin ${entry}: default export is not a definePlugin(...) result`)
+}

--- a/src/plugin/manager.test.ts
+++ b/src/plugin/manager.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, test } from 'bun:test'
+
+import { z } from 'zod'
+
+import { defineTool } from './define'
+import type { LoadPluginEntryFn } from './loader'
+import { loadPlugins, summarizeLoaded, pluginCronJobs } from './manager'
+
+describe('loadPlugins — atomic rollback', () => {
+  test('throws and discards all registrations if a factory throws', async () => {
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({}),
+      async execute() {
+        return { content: [] }
+      },
+    })
+    const loadEntry: LoadPluginEntryFn = async (entry) => {
+      if (entry === 'good') {
+        return {
+          name: 'good',
+          version: undefined,
+          source: 'good',
+          defined: {
+            plugin: async () => ({ tools: { ok: tool } }),
+          },
+        }
+      }
+      return {
+        name: 'bad',
+        version: undefined,
+        source: 'bad',
+        defined: {
+          plugin: async () => {
+            throw new Error('factory failed')
+          },
+        },
+      }
+    }
+
+    await expect(
+      loadPlugins({ entries: ['good', 'bad'], agentDir: '/tmp', configsByName: {}, loadEntry }),
+    ).rejects.toThrow(/bad: factory threw: factory failed/)
+  })
+
+  test('throws on conflicting tool registration mid-load and rolls back the offending plugin', async () => {
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({}),
+      async execute() {
+        return { content: [] }
+      },
+    })
+    const loadEntry: LoadPluginEntryFn = async (entry) => ({
+      name: entry,
+      version: undefined,
+      source: entry,
+      defined: {
+        plugin: async () => ({ tools: { same: tool } }),
+      },
+    })
+
+    await expect(
+      loadPlugins({ entries: ['p1', 'p2'], agentDir: '/tmp', configsByName: {}, loadEntry }),
+    ).rejects.toThrow(/already registered by plugin p1/)
+  })
+
+  test('rejects duplicate plugin names', async () => {
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({}),
+      async execute() {
+        return { content: [] }
+      },
+    })
+    const loadEntry: LoadPluginEntryFn = async () => ({
+      name: 'same',
+      version: undefined,
+      source: 's',
+      defined: { plugin: async () => ({ tools: { t: tool } }) },
+    })
+
+    await expect(loadPlugins({ entries: ['x', 'y'], agentDir: '/tmp', configsByName: {}, loadEntry })).rejects.toThrow(
+      /plugin name conflict: same/,
+    )
+  })
+})
+
+describe('loadPlugins — config validation', () => {
+  test("validates per-plugin config against the plugin's configSchema", async () => {
+    const captured: { value: unknown } = { value: undefined }
+    const loadEntry: LoadPluginEntryFn = async () => ({
+      name: 'standup-log',
+      version: '0.1.0',
+      source: 'standup-log',
+      defined: {
+        configSchema: z.object({ schedule: z.string().default('0 9 * * 1') }),
+        plugin: async (ctx) => {
+          captured.value = ctx.config
+          return {}
+        },
+      },
+    })
+
+    await loadPlugins({
+      entries: ['standup-log'],
+      agentDir: '/tmp',
+      configsByName: { 'standup-log': { schedule: '0 17 * * 5' } },
+      loadEntry,
+    })
+
+    expect(captured.value).toEqual({ schedule: '0 17 * * 5' })
+  })
+
+  test('applies schema defaults when config is absent', async () => {
+    const captured: { value: unknown } = { value: undefined }
+    const loadEntry: LoadPluginEntryFn = async () => ({
+      name: 'standup-log',
+      version: undefined,
+      source: 's',
+      defined: {
+        configSchema: z.object({ schedule: z.string().default('0 9 * * 1') }),
+        plugin: async (ctx) => {
+          captured.value = ctx.config
+          return {}
+        },
+      },
+    })
+
+    await loadPlugins({ entries: ['s'], agentDir: '/tmp', configsByName: {}, loadEntry })
+    expect(captured.value).toEqual({ schedule: '0 9 * * 1' })
+  })
+
+  test('rejects invalid config with plugin name + field path in the error', async () => {
+    const loadEntry: LoadPluginEntryFn = async () => ({
+      name: 'standup-log',
+      version: undefined,
+      source: 's',
+      defined: {
+        configSchema: z.object({ schedule: z.string() }),
+        plugin: async () => ({}),
+      },
+    })
+
+    await expect(
+      loadPlugins({
+        entries: ['s'],
+        agentDir: '/tmp',
+        configsByName: { 'standup-log': { schedule: 42 } },
+        loadEntry,
+      }),
+    ).rejects.toThrow(/standup-log: config invalid: schedule:/)
+  })
+
+  test('rejects config block when plugin declares no configSchema', async () => {
+    const loadEntry: LoadPluginEntryFn = async () => ({
+      name: 'no-config-plugin',
+      version: undefined,
+      source: 's',
+      defined: {
+        plugin: async () => ({}),
+      },
+    })
+
+    await expect(
+      loadPlugins({
+        entries: ['s'],
+        agentDir: '/tmp',
+        configsByName: { 'no-config-plugin': { foo: 1 } },
+        loadEntry,
+      }),
+    ).rejects.toThrow(/declares no configSchema/)
+  })
+})
+
+describe('loadPlugins — markBooted gates spawnSubagent', () => {
+  test('spawnSubagent in factory throws; callable after markBooted', async () => {
+    const calls: string[] = []
+    const setup: { spawn?: (name: string) => Promise<void> } = {}
+
+    const loadEntry: LoadPluginEntryFn = async () => ({
+      name: 'p1',
+      version: undefined,
+      source: 's',
+      defined: {
+        plugin: async (ctx) => {
+          setup.spawn = (n) => ctx.spawnSubagent(n)
+          return {}
+        },
+      },
+    })
+
+    const result = await loadPlugins({
+      entries: ['p1'],
+      agentDir: '/tmp',
+      configsByName: {},
+      loadEntry,
+    })
+
+    await expect(setup.spawn!('worker')).rejects.toThrow(/before boot completed/)
+
+    result.setSpawnSubagent(async (name) => {
+      calls.push(name)
+    })
+    result.markBooted()
+
+    await setup.spawn!('worker')
+    expect(calls).toEqual(['worker'])
+  })
+
+  test('spawnSubagent inside the factory throws synchronously', async () => {
+    const loadEntry: LoadPluginEntryFn = async () => ({
+      name: 'p1',
+      version: undefined,
+      source: 's',
+      defined: {
+        plugin: async (ctx) => {
+          await ctx.spawnSubagent('w')
+          return {}
+        },
+      },
+    })
+
+    await expect(loadPlugins({ entries: ['p1'], agentDir: '/tmp', configsByName: {}, loadEntry })).rejects.toThrow(
+      /before boot completed/,
+    )
+  })
+})
+
+describe('loadPlugins — registry shape', () => {
+  test('pluginCronJobs returns CronJob[] with __plugin_<name>_<key> ids', async () => {
+    const loadEntry: LoadPluginEntryFn = async () => ({
+      name: 'p1',
+      version: undefined,
+      source: 's',
+      defined: {
+        plugin: async () => ({
+          cronJobs: {
+            'weekly-digest': { schedule: '0 9 * * 1', kind: 'prompt', prompt: 'go' },
+          },
+        }),
+      },
+    })
+
+    const result = await loadPlugins({ entries: ['p1'], agentDir: '/tmp', configsByName: {}, loadEntry })
+    const jobs = pluginCronJobs(result.registry)
+    expect(jobs.map((j) => j.id)).toEqual(['__plugin_p1_weekly-digest'])
+  })
+
+  test('summarizeLoaded includes counts and version when present', async () => {
+    const loadEntry: LoadPluginEntryFn = async (entry) => ({
+      name: entry,
+      version: entry === 'a' ? '1.2.3' : undefined,
+      source: entry,
+      defined: {
+        plugin: async () => ({}),
+      },
+    })
+
+    const result = await loadPlugins({
+      entries: ['a', 'b'],
+      agentDir: '/tmp',
+      configsByName: {},
+      loadEntry,
+    })
+    const s = summarizeLoaded(result.loadedPlugins, result.registry)
+    expect(s).toContain('a v1.2.3')
+    expect(s).toContain('b')
+    expect(s).toContain('0 tool(s)')
+  })
+})

--- a/src/plugin/manager.ts
+++ b/src/plugin/manager.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod'
+
+import type { CronJob } from '@/cron'
+
+import { createPluginContext, createPluginLogger, type SpawnSubagentFn } from './context'
+import { createHookBus, type HookBus } from './hooks'
+import { loadPluginEntry, type LoadPluginEntryFn } from './loader'
+import { discardRegistrationsBy, emptyRegistry, type PluginRegistry, registerContributions } from './registry'
+import type { PluginExports } from './types'
+
+export type LoadPluginsOptions = {
+  entries: string[]
+  agentDir: string
+  configsByName: Record<string, unknown>
+  loadEntry?: LoadPluginEntryFn
+}
+
+export type LoadPluginsResult = {
+  registry: PluginRegistry
+  hooks: HookBus
+  loadedPlugins: { name: string; version: string | undefined; source: string }[]
+  markBooted: () => void
+  setSpawnSubagent: (fn: SpawnSubagentFn) => void
+}
+
+export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPluginsResult> {
+  const registry = emptyRegistry()
+  const hooks = createHookBus()
+  const loaded: { name: string; version: string | undefined; source: string }[] = []
+  const loadEntry = opts.loadEntry ?? loadPluginEntry
+
+  let booted = false
+  let spawnSubagentImpl: SpawnSubagentFn = async () => {
+    throw new Error('plugin: spawnSubagent is not yet wired')
+  }
+
+  for (const entry of opts.entries) {
+    const resolved = await loadEntry(entry, opts.agentDir)
+
+    if (loaded.find((l) => l.name === resolved.name)) {
+      throw new Error(`plugin name conflict: ${resolved.name} (entry ${entry}) already loaded`)
+    }
+
+    let validatedConfig: unknown = undefined
+    if (resolved.defined.configSchema) {
+      const raw = opts.configsByName[resolved.name]
+      const parsed = (resolved.defined.configSchema as z.ZodType<unknown>).safeParse(raw ?? {})
+      if (!parsed.success) {
+        throw new Error(`plugin ${resolved.name}: config invalid: ${formatZodIssues(parsed.error)}`)
+      }
+      validatedConfig = parsed.data
+    } else if (opts.configsByName[resolved.name] !== undefined) {
+      throw new Error(
+        `plugin ${resolved.name}: config block "${resolved.name}" present in typeclaw.json but plugin declares no configSchema`,
+      )
+    }
+
+    const logger = createPluginLogger(resolved.name)
+    const ctx = createPluginContext({
+      name: resolved.name,
+      version: resolved.version,
+      agentDir: opts.agentDir,
+      config: validatedConfig as never,
+      logger,
+      spawnSubagent: (name, payload) => spawnSubagentImpl(name, payload),
+      isBooted: () => booted,
+    })
+
+    let exports: PluginExports
+    try {
+      exports = await resolved.defined.plugin(ctx)
+    } catch (err) {
+      discardRegistrationsBy(resolved.name, registry, hooks)
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`plugin ${resolved.name}: factory threw: ${message}`)
+    }
+
+    try {
+      registerContributions({
+        pluginName: resolved.name,
+        logger,
+        exports,
+        registry,
+        hooks,
+        agentDir: opts.agentDir,
+      })
+    } catch (err) {
+      discardRegistrationsBy(resolved.name, registry, hooks)
+      throw err
+    }
+
+    loaded.push({ name: resolved.name, version: resolved.version, source: resolved.source })
+  }
+
+  return {
+    registry,
+    hooks,
+    loadedPlugins: loaded,
+    markBooted: () => {
+      booted = true
+    },
+    setSpawnSubagent: (fn) => {
+      spawnSubagentImpl = fn
+    },
+  }
+}
+
+export function summarizeLoaded(loaded: LoadPluginsResult['loadedPlugins'], registry: PluginRegistry): string {
+  const head = loaded.map((p) => (p.version !== undefined ? `${p.name} v${p.version}` : p.name)).join(', ')
+  const counts = [
+    `${registry.tools.length} tool(s)`,
+    `${registry.subagents.length} subagent(s)`,
+    `${registry.cronJobs.length} cron job(s)`,
+    `${registry.skills.length} skill(s)`,
+    `${registry.skillsDirs.length} skills dir(s)`,
+  ].join(', ')
+  return `${loaded.length} plugin(s): ${head} [${counts}]`
+}
+
+export function pluginCronJobs(registry: PluginRegistry): CronJob[] {
+  return registry.cronJobs.map((j) => j.job)
+}
+
+function formatZodIssues(error: z.ZodError): string {
+  return error.issues.map((i) => `${i.path.length > 0 ? i.path.join('.') : '<root>'}: ${i.message}`).join('; ')
+}

--- a/src/plugin/registry.test.ts
+++ b/src/plugin/registry.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from 'bun:test'
+
+import { z } from 'zod'
+
+import { defineSubagent, defineTool } from './define'
+import { createHookBus } from './hooks'
+import { buildPluginCronGlobalId, discardRegistrationsBy, emptyRegistry, registerContributions } from './registry'
+import type { PluginExports } from './types'
+
+const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
+
+function makeOptions(pluginName: string, ex: PluginExports) {
+  return {
+    pluginName,
+    logger: noopLogger,
+    exports: ex,
+    registry: emptyRegistry(),
+    hooks: createHookBus(),
+    agentDir: '/tmp',
+  }
+}
+
+describe('registerContributions', () => {
+  test('records tools, subagents, cron jobs, skills, skillsDirs', () => {
+    const tool = defineTool({
+      description: 'echo',
+      parameters: z.object({ msg: z.string() }),
+      async execute(args) {
+        return { content: [{ type: 'text', text: args.msg }] }
+      },
+    })
+    const sub = defineSubagent({ systemPrompt: 'you' })
+    const opts = makeOptions('p1', {
+      tools: { echo: tool },
+      subagents: { worker: sub },
+      cronJobs: {
+        nightly: { schedule: '0 0 * * *', kind: 'prompt', prompt: 'go' },
+      },
+      skills: { howto: { description: 'h', content: 'hello' } },
+      skillsDirs: ['/abs/skills'],
+    })
+    registerContributions(opts)
+
+    expect(opts.registry.tools.map((t) => t.toolName)).toEqual(['echo'])
+    expect(opts.registry.subagents.map((s) => s.subagentName)).toEqual(['worker'])
+    expect(opts.registry.cronJobs[0]?.globalId).toBe('__plugin_p1_nightly')
+    expect(opts.registry.skills.map((s) => s.localName)).toEqual(['howto'])
+    expect(opts.registry.skillsDirs.map((d) => d.path)).toEqual(['/abs/skills'])
+  })
+
+  test('rejects duplicate tool name across plugins', () => {
+    const tool = defineTool({
+      description: 'echo',
+      parameters: z.object({}),
+      async execute() {
+        return { content: [] }
+      },
+    })
+    const opts1 = makeOptions('p1', { tools: { same: tool } })
+    registerContributions(opts1)
+
+    expect(() => registerContributions({ ...opts1, pluginName: 'p2' })).toThrow(/already registered by plugin p1/)
+  })
+
+  test('rejects duplicate subagent name across plugins', () => {
+    const sub = defineSubagent({ systemPrompt: 'x' })
+    const opts1 = makeOptions('p1', { subagents: { worker: sub } })
+    registerContributions(opts1)
+    expect(() => registerContributions({ ...opts1, pluginName: 'p2' })).toThrow(/subagent "worker" already registered/)
+  })
+
+  test('rejects duplicate cron suffix when the same plugin is registered twice', () => {
+    const opts = makeOptions('p1', {
+      cronJobs: {
+        a: { schedule: '* * * * *', kind: 'prompt', prompt: 'x' },
+      },
+    })
+    registerContributions(opts)
+    expect(() => registerContributions(opts)).toThrow(/conflicts with plugin p1/)
+  })
+
+  test('cron globalId uses __plugin_<name>_<key> format', () => {
+    expect(buildPluginCronGlobalId('standup-log', 'weekly-digest')).toBe('__plugin_standup-log_weekly-digest')
+  })
+})
+
+describe('discardRegistrationsBy', () => {
+  test('removes all registrations for the named plugin and leaves others intact', () => {
+    const registry = emptyRegistry()
+    const hooks = createHookBus()
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({}),
+      async execute() {
+        return { content: [] }
+      },
+    })
+
+    registerContributions({
+      pluginName: 'p1',
+      logger: noopLogger,
+      exports: {
+        tools: { t1: tool },
+        subagents: { s1: defineSubagent({ systemPrompt: '' }) },
+        cronJobs: { c1: { schedule: '* * * * *', kind: 'prompt', prompt: '' } },
+        skills: { sk1: { description: '', content: '' } },
+        skillsDirs: ['/p1/skills'],
+        hooks: { 'session.start': () => {} },
+      },
+      registry,
+      hooks,
+      agentDir: '/tmp',
+    })
+    registerContributions({
+      pluginName: 'p2',
+      logger: noopLogger,
+      exports: {
+        tools: { t2: tool },
+        hooks: { 'session.end': () => {} },
+      },
+      registry,
+      hooks,
+      agentDir: '/tmp',
+    })
+
+    expect(hooks.count('session.start')).toBe(1)
+    expect(hooks.count('session.end')).toBe(1)
+
+    discardRegistrationsBy('p1', registry, hooks)
+
+    expect(registry.tools.map((t) => t.pluginName)).toEqual(['p2'])
+    expect(registry.subagents).toEqual([])
+    expect(registry.cronJobs).toEqual([])
+    expect(registry.skills).toEqual([])
+    expect(registry.skillsDirs).toEqual([])
+    expect(hooks.count('session.start')).toBe(0)
+    expect(hooks.count('session.end')).toBe(1)
+  })
+})

--- a/src/plugin/registry.ts
+++ b/src/plugin/registry.ts
@@ -1,0 +1,145 @@
+import { existsSync } from 'node:fs'
+
+import type { CronJob, PromptJob } from '@/cron'
+
+import type { HookBus } from './hooks'
+import type { PluginCronJob, PluginExports, PluginLogger, PluginSkill, Subagent, Tool } from './types'
+
+export type RegisteredTool = { pluginName: string; toolName: string; tool: Tool<any>; logger: PluginLogger }
+export type RegisteredSubagent = { pluginName: string; subagentName: string; subagent: Subagent<any> }
+export type RegisteredCronJob = { pluginName: string; localId: string; globalId: string; job: CronJob }
+export type RegisteredSkillEntry = { pluginName: string; localName: string; skill: PluginSkill }
+export type RegisteredSkillDir = { pluginName: string; path: string }
+
+export type PluginRegistry = {
+  tools: RegisteredTool[]
+  subagents: RegisteredSubagent[]
+  cronJobs: RegisteredCronJob[]
+  skills: RegisteredSkillEntry[]
+  skillsDirs: RegisteredSkillDir[]
+}
+
+export type RegisterContributionsOptions = {
+  pluginName: string
+  logger: PluginLogger
+  exports: PluginExports
+  registry: PluginRegistry
+  hooks: HookBus
+  agentDir: string
+}
+
+export function buildPluginCronGlobalId(pluginName: string, localId: string): string {
+  return `__plugin_${pluginName}_${localId}`
+}
+
+export function registerContributions(opts: RegisterContributionsOptions): void {
+  const { pluginName, logger, exports: ex, registry, hooks, agentDir } = opts
+
+  if (ex.tools) {
+    for (const [toolName, tool] of Object.entries(ex.tools)) {
+      assertNotEmpty('tool name', toolName, pluginName)
+      const conflict = registry.tools.find((t) => t.toolName === toolName)
+      if (conflict) {
+        throw new Error(`plugin ${pluginName}: tool "${toolName}" already registered by plugin ${conflict.pluginName}`)
+      }
+      registry.tools.push({ pluginName, toolName, tool, logger })
+    }
+  }
+
+  if (ex.subagents) {
+    for (const [subagentName, subagent] of Object.entries(ex.subagents)) {
+      assertNotEmpty('subagent name', subagentName, pluginName)
+      const conflict = registry.subagents.find((s) => s.subagentName === subagentName)
+      if (conflict) {
+        throw new Error(
+          `plugin ${pluginName}: subagent "${subagentName}" already registered by plugin ${conflict.pluginName}`,
+        )
+      }
+      registry.subagents.push({ pluginName, subagentName, subagent })
+    }
+  }
+
+  if (ex.cronJobs) {
+    for (const [localId, spec] of Object.entries(ex.cronJobs)) {
+      assertNotEmpty('cron job id', localId, pluginName)
+      const globalId = buildPluginCronGlobalId(pluginName, localId)
+      const conflict = registry.cronJobs.find((j) => j.globalId === globalId)
+      if (conflict) {
+        throw new Error(
+          `plugin ${pluginName}: cron job "${localId}" globalId "${globalId}" conflicts with plugin ${conflict.pluginName}`,
+        )
+      }
+      const job = toCronJob(globalId, spec)
+      registry.cronJobs.push({ pluginName, localId, globalId, job })
+    }
+  }
+
+  if (ex.skills) {
+    for (const [localName, skill] of Object.entries(ex.skills)) {
+      assertNotEmpty('skill name', localName, pluginName)
+      const conflict = registry.skills.find((s) => s.localName === localName)
+      if (conflict) {
+        throw new Error(
+          `plugin ${pluginName}: skill "${localName}" already registered by plugin ${conflict.pluginName}`,
+        )
+      }
+      registry.skills.push({ pluginName, localName, skill })
+    }
+  }
+
+  if (ex.skillsDirs) {
+    for (const path of ex.skillsDirs) {
+      if (!existsSync(path)) {
+        logger.warn(`skillsDirs entry does not exist on disk: ${path}`)
+      }
+      registry.skillsDirs.push({ pluginName, path })
+    }
+  }
+
+  if (ex.hooks) {
+    hooks.registerAll(pluginName, agentDir, logger, ex.hooks)
+  }
+}
+
+export function discardRegistrationsBy(pluginName: string, registry: PluginRegistry, hooks: HookBus): void {
+  registry.tools = registry.tools.filter((t) => t.pluginName !== pluginName)
+  registry.subagents = registry.subagents.filter((s) => s.pluginName !== pluginName)
+  registry.cronJobs = registry.cronJobs.filter((j) => j.pluginName !== pluginName)
+  registry.skills = registry.skills.filter((s) => s.pluginName !== pluginName)
+  registry.skillsDirs = registry.skillsDirs.filter((d) => d.pluginName !== pluginName)
+  hooks.unregisterAll(pluginName)
+}
+
+export function emptyRegistry(): PluginRegistry {
+  return { tools: [], subagents: [], cronJobs: [], skills: [], skillsDirs: [] }
+}
+
+function assertNotEmpty(kind: string, value: string, pluginName: string): void {
+  if (value.length === 0) {
+    throw new Error(`plugin ${pluginName}: empty ${kind}`)
+  }
+}
+
+function toCronJob(globalId: string, spec: PluginCronJob): CronJob {
+  if (spec.kind === 'prompt') {
+    const job: PromptJob = {
+      id: globalId,
+      schedule: spec.schedule,
+      enabled: spec.enabled ?? true,
+      kind: 'prompt',
+      prompt: spec.prompt,
+      ...(spec.timezone !== undefined ? { timezone: spec.timezone } : {}),
+      ...(spec.subagent !== undefined ? { subagent: spec.subagent } : {}),
+      ...(spec.payload !== undefined ? { payload: spec.payload } : {}),
+    }
+    return job
+  }
+  return {
+    id: globalId,
+    schedule: spec.schedule,
+    enabled: spec.enabled ?? true,
+    kind: 'exec',
+    command: spec.command,
+    ...(spec.timezone !== undefined ? { timezone: spec.timezone } : {}),
+  }
+}

--- a/src/plugin/skills.test.ts
+++ b/src/plugin/skills.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { materializeSkills } from './skills'
+
+describe('materializeSkills', () => {
+  test('writes one SKILL.md per skill into a fresh tmpdir; dispose removes it', async () => {
+    const m = await materializeSkills([
+      {
+        pluginName: 'p1',
+        localName: 'standup',
+        skill: { description: 'how to standup', content: '# Standup\n\nSay yes.' },
+      },
+      {
+        pluginName: 'p2',
+        localName: 'note',
+        skill: { description: 'how to note', content: '# Note\n\n…' },
+      },
+    ])
+
+    expect(existsSync(m.dir)).toBe(true)
+    expect(existsSync(join(m.dir, 'standup', 'SKILL.md'))).toBe(true)
+    expect(existsSync(join(m.dir, 'note', 'SKILL.md'))).toBe(true)
+    const standup = readFileSync(join(m.dir, 'standup', 'SKILL.md'), 'utf8')
+    expect(standup).toContain('description:')
+    expect(standup).toContain('# Standup')
+
+    await m.dispose()
+    expect(existsSync(m.dir)).toBe(false)
+  })
+
+  test('throws on duplicate sanitized skill names', async () => {
+    await expect(
+      materializeSkills([
+        {
+          pluginName: 'p1',
+          localName: 'a-name',
+          skill: { description: 'd', content: 'x' },
+        },
+        {
+          pluginName: 'p2',
+          localName: 'a-name',
+          skill: { description: 'd', content: 'x' },
+        },
+      ]),
+    ).rejects.toThrow(/duplicate skill name/)
+  })
+})

--- a/src/plugin/skills.ts
+++ b/src/plugin/skills.ts
@@ -1,0 +1,62 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PluginSkill } from './types'
+
+export type SkillEntry = { pluginName: string; localName: string; skill: PluginSkill }
+
+export type MaterializedSkills = {
+  dir: string
+  dispose: () => Promise<void>
+}
+
+const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-_]*$/
+
+export async function materializeSkills(skills: SkillEntry[]): Promise<MaterializedSkills> {
+  const root = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-skills-'))
+
+  try {
+    const seen = new Set<string>()
+    for (const entry of skills) {
+      const sanitized = sanitizeSkillName(entry.localName)
+      if (seen.has(sanitized)) {
+        throw new Error(`plugin ${entry.pluginName}: duplicate skill name after sanitization: ${entry.localName}`)
+      }
+      seen.add(sanitized)
+
+      const skillDir = join(root, sanitized)
+      await mkdir(skillDir, { recursive: true })
+      const body = renderSkillFile(entry.skill)
+      await writeFile(join(skillDir, 'SKILL.md'), body, 'utf8')
+    }
+  } catch (err) {
+    await rm(root, { recursive: true, force: true })
+    throw err
+  }
+
+  return {
+    dir: root,
+    dispose: async () => {
+      await rm(root, { recursive: true, force: true })
+    },
+  }
+}
+
+function sanitizeSkillName(name: string): string {
+  if (SKILL_NAME_PATTERN.test(name)) return name
+  return name.toLowerCase().replace(/[^a-z0-9_-]/g, '-')
+}
+
+function renderSkillFile(skill: PluginSkill): string {
+  const fm = skill.frontmatter ?? {}
+  const fmEntries = Object.entries({ ...fm, description: skill.description })
+  if (fmEntries.length === 0) return skill.content
+  const lines = ['---']
+  for (const [key, value] of fmEntries) {
+    lines.push(`${key}: ${JSON.stringify(value)}`)
+  }
+  lines.push('---', '')
+  lines.push(skill.content)
+  return lines.join('\n')
+}

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -1,0 +1,162 @@
+import type { z } from 'zod'
+
+export type ContentPart = { type: 'text'; text: string } | { type: 'image'; mimeType: string; data: string }
+
+export type ToolResult = {
+  content: ContentPart[]
+  details?: unknown
+}
+
+export type ToolLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+export type ToolContext = {
+  signal: AbortSignal | undefined
+  sessionId: string
+  agentDir: string
+  logger: ToolLogger
+}
+
+export type Tool<P = unknown> = {
+  description: string
+  parameters: z.ZodType<P>
+  execute: (args: P, ctx: ToolContext) => Promise<ToolResult>
+}
+
+export type BuiltinToolRef = { readonly __builtinTool: string }
+
+export type SubagentContext<P = unknown> = {
+  userPrompt: string
+  agentDir: string
+  payload: P
+}
+
+export type RunSession = (override?: { userPrompt?: string }) => Promise<void>
+
+export type Subagent<P = unknown> = {
+  systemPrompt: string
+  tools?: BuiltinToolRef[]
+  customTools?: Tool<any>[]
+  payloadSchema?: z.ZodType<P>
+  handler?: (ctx: SubagentContext<P>, runSession: RunSession) => Promise<void>
+}
+
+// Cron job map keys are local; the runtime prefixes with `__plugin_<plugin-name>_`
+// to form the global cron id, guaranteeing no collision with cron.json user
+// jobs (no underscore prefix) or across plugins.
+export type PluginPromptCronJob = {
+  schedule: string
+  kind: 'prompt'
+  prompt: string
+  enabled?: boolean
+  timezone?: string
+  subagent?: string
+  payload?: unknown
+}
+
+export type PluginExecCronJob = {
+  schedule: string
+  kind: 'exec'
+  command: string[]
+  enabled?: boolean
+  timezone?: string
+}
+
+export type PluginCronJob = PluginPromptCronJob | PluginExecCronJob
+
+export type PluginSkill = {
+  description: string
+  content: string
+  frontmatter?: Record<string, unknown>
+}
+
+export type SessionStartEvent = {
+  sessionId: string
+  agentDir: string
+}
+
+export type SessionEndEvent = {
+  sessionId: string
+}
+
+export type SessionIdleEvent = {
+  sessionId: string
+  parentTranscriptPath: string | undefined
+  idleMs: number
+}
+
+// Provider prompt caching requires byte-identical prefixes. Mutations near the
+// end of `event.prompt` preserve cache hits across sessions; mutations near
+// the start invalidate the cache on every LLM call.
+export type SessionPromptEvent = {
+  prompt: string
+  sessionId: string
+  agentDir: string
+}
+
+// Plugin-defined custom tools only. Built-in pi tools (read/bash/edit/write)
+// are not intercepted in v0.1.
+export type ToolBeforeEvent = {
+  tool: string
+  sessionId: string
+  callId: string
+  args: Record<string, unknown>
+}
+
+export type ToolBeforeResult = void | undefined | { block: true; reason: string }
+
+export type ToolAfterEvent = {
+  tool: string
+  sessionId: string
+  callId: string
+  result: ToolResult
+}
+
+export type HookContext = {
+  agentDir: string
+  pluginName: string
+  logger: PluginLogger
+}
+
+export type Hooks = {
+  'session.start'?: (event: SessionStartEvent, ctx: HookContext) => Promise<void> | void
+  'session.end'?: (event: SessionEndEvent, ctx: HookContext) => Promise<void> | void
+  'session.idle'?: (event: SessionIdleEvent, ctx: HookContext) => Promise<void> | void
+  'session.prompt'?: (event: SessionPromptEvent, ctx: HookContext) => Promise<void> | void
+  'tool.before'?: (event: ToolBeforeEvent, ctx: HookContext) => Promise<ToolBeforeResult> | ToolBeforeResult
+  'tool.after'?: (event: ToolAfterEvent, ctx: HookContext) => Promise<void> | void
+}
+
+export type HookName = keyof Hooks
+
+export type PluginLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+export type PluginContext<TConfig = never> = {
+  readonly name: string
+  readonly version: string | undefined
+  readonly agentDir: string
+  readonly config: TConfig
+  readonly logger: PluginLogger
+  spawnSubagent: (name: string, payload?: unknown) => Promise<void>
+}
+
+export type PluginExports = {
+  tools?: Record<string, Tool<any>>
+  subagents?: Record<string, Subagent<any>>
+  cronJobs?: Record<string, PluginCronJob>
+  skills?: Record<string, PluginSkill>
+  skillsDirs?: string[]
+  hooks?: Hooks
+}
+
+export type DefinedPlugin<TConfig = never> = {
+  readonly configSchema?: z.ZodType<TConfig>
+  readonly plugin: (ctx: PluginContext<TConfig>) => Promise<PluginExports>
+}

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -1,8 +1,15 @@
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
-import { createSession } from '@/agent'
-import { createSubagentConsumer, defaultCreateSessionForSubagent, type SubagentConsumer } from '@/agent/subagents'
-import { config, type Config, createConfigReloadable, getConfig } from '@/config'
+import { createSession, createSessionWithDispose } from '@/agent'
+import {
+  createSubagentConsumer,
+  defaultCreateSessionForSubagent,
+  invokeSubagent,
+  type Subagent as InternalSubagent,
+  type SubagentConsumer,
+  type SubagentRegistry,
+} from '@/agent/subagents'
+import { config, type Config, createConfigReloadable, getConfig, loadConfigSync, loadPluginConfigsSync } from '@/config'
 import {
   type CronConsumer,
   type CronJob,
@@ -15,6 +22,14 @@ import {
   type Scheduler,
 } from '@/cron'
 import { dreamingSubagent, isDreamingPayload, isMemoryLoggerPayload, memoryLoggerSubagent } from '@/memory'
+import {
+  type HookBus,
+  loadPlugins,
+  type LoadPluginsResult,
+  pluginCronJobs,
+  type PluginRegistry,
+  summarizeLoaded,
+} from '@/plugin'
 import { ReloadRegistry } from '@/reload'
 import { createServer, type Server } from '@/server'
 import { createSessionFactory, type SessionFactory } from '@/sessions'
@@ -27,10 +42,7 @@ type BunServer = ReturnType<Server['start']>
 
 export type TuiFactory = (options: TuiOptions) => { run: () => Promise<void> }
 
-export type LoadCronFn = (
-  agentDir: string,
-  options?: { subagents?: import('@/agent/subagents').SubagentRegistry },
-) => Promise<LoadCronResult>
+export type LoadCronFn = (agentDir: string, options?: { subagents?: SubagentRegistry }) => Promise<LoadCronResult>
 export type SchedulerFactory = (options: { cwd: string; file: CronFile; onFire: (job: CronJob) => void }) => Scheduler
 
 export type StartAgentOptions = {
@@ -53,6 +65,9 @@ export type StartAgentResult = {
   subagentConsumer: SubagentConsumer
   reloadRegistry: ReloadRegistry
   stream: Stream
+  pluginRegistry: PluginRegistry
+  pluginHooks: HookBus
+  loadedPlugins: LoadPluginsResult['loadedPlugins']
   stop: () => void
 }
 
@@ -70,16 +85,46 @@ export async function startAgent({
   const reloadRegistry = new ReloadRegistry()
   reloadRegistry.register(createConfigReloadable({ cwd }))
 
-  const subagents = {
-    'memory-logger': memoryLoggerSubagent,
-    dreaming: dreamingSubagent,
+  const pluginConfigsByName = loadPluginConfigsSync(cwd)
+  const cwdConfig = loadConfigSync(cwd)
+  const pluginsLoaded = await loadPlugins({
+    entries: cwdConfig.plugins,
+    agentDir: cwd,
+    configsByName: pluginConfigsByName,
+  })
+  const pluginRegistry = pluginsLoaded.registry
+  const pluginHooks = pluginsLoaded.hooks
+
+  const { registry: subagents, pluginSubagentByShim } = mergeSubagents(pluginRegistry)
+
+  const createSessionForSubagent: import('@/agent/subagents').CreateSessionForSubagent = async (subagent) => {
+    const entry = pluginSubagentByShim.get(subagent)
+    if (entry) {
+      const sessionId = `subagent-${entry.pluginName}-${crypto.randomUUID()}`
+      return createSessionWithDispose({
+        systemPromptOverride: entry.pluginSubagent.systemPrompt,
+        plugins: {
+          registry: pluginRegistry,
+          hooks: pluginHooks,
+          sessionId,
+          agentDir: cwd,
+        },
+        pluginSubagent: {
+          pluginName: entry.pluginName,
+          ...(entry.pluginSubagent.tools ? { toolRefs: entry.pluginSubagent.tools } : {}),
+          ...(entry.pluginSubagent.customTools ? { customTools: entry.pluginSubagent.customTools } : {}),
+          toolNamePrefix: `__plugin_${entry.pluginName}_${entry.subagentName}`,
+        },
+      })
+    }
+    return defaultCreateSessionForSubagent(subagent)
   }
 
   const subagentConsumer = createSubagentConsumer({
     stream,
     registry: subagents,
     agentDir: cwd,
-    createSessionForSubagent: defaultCreateSessionForSubagent,
+    createSessionForSubagent,
     inFlightKey: (name, payload) => {
       if (name === 'memory-logger' && isMemoryLoggerPayload(payload)) {
         return `${name}:${payload.parentSessionId}`
@@ -92,6 +137,14 @@ export async function startAgent({
   })
   subagentConsumer.start()
 
+  const hasAnyPluginContent =
+    pluginRegistry.tools.length > 0 ||
+    pluginRegistry.subagents.length > 0 ||
+    pluginRegistry.cronJobs.length > 0 ||
+    pluginRegistry.skills.length > 0 ||
+    pluginRegistry.skillsDirs.length > 0 ||
+    pluginsLoaded.loadedPlugins.length > 0
+
   const cronConsumer = createCronConsumer({
     stream,
     cwd,
@@ -100,10 +153,20 @@ export async function startAgent({
         reloadRegistry,
         sessionManager: SessionManager.create(cwd, sessionFactory.sessionDir()),
         stream,
+        ...(hasAnyPluginContent
+          ? {
+              plugins: {
+                registry: pluginRegistry,
+                hooks: pluginHooks,
+                sessionId: `cron-${crypto.randomUUID()}`,
+                agentDir: cwd,
+              },
+            }
+          : {}),
       }),
   })
 
-  const internalJobs = () => buildInternalJobs(cwd, getConfig())
+  const internalJobs = () => [...buildInternalJobs(cwd, getConfig()), ...pluginCronJobs(pluginRegistry)]
   const factory = createSchedulerFor ?? makeDefaultSchedulerFactory(internalJobs)
   const scheduler = await startScheduler({
     cwd,
@@ -119,6 +182,20 @@ export async function startAgent({
     reloadRegistry.register(createCronReloadable({ cwd, scheduler, internalJobs, subagents }))
   }
 
+  pluginsLoaded.setSpawnSubagent(async (name, payload) => {
+    await invokeSubagent(name, {
+      registry: subagents,
+      agentDir: cwd,
+      userPrompt: '',
+      payload,
+    })
+  })
+  pluginsLoaded.markBooted()
+
+  if (pluginsLoaded.loadedPlugins.length > 0) {
+    console.log(`[plugin] loaded ${summarizeLoaded(pluginsLoaded.loadedPlugins, pluginRegistry)}`)
+  }
+
   const server = createServer({
     port,
     reloadAll: () => reloadRegistry.reloadAll(),
@@ -127,6 +204,8 @@ export async function startAgent({
     stream,
     memoryIdleMs: config.memory.idleMs,
     agentDir: cwd,
+    pluginRegistry,
+    pluginHooks,
   }).start()
 
   let stopped = false
@@ -148,6 +227,9 @@ export async function startAgent({
       subagentConsumer,
       reloadRegistry,
       stream,
+      pluginRegistry,
+      pluginHooks,
+      loadedPlugins: pluginsLoaded.loadedPlugins,
       stop,
     }
   }
@@ -163,6 +245,9 @@ export async function startAgent({
     subagentConsumer,
     reloadRegistry,
     stream,
+    pluginRegistry,
+    pluginHooks,
+    loadedPlugins: pluginsLoaded.loadedPlugins,
     stop,
   }
 }
@@ -180,7 +265,7 @@ async function startScheduler({
   createSchedulerFor: SchedulerFactory
   stream: Stream
   hasInternalJobs: boolean
-  subagents?: import('@/agent/subagents').SubagentRegistry
+  subagents?: SubagentRegistry
 }): Promise<Scheduler | null> {
   let result: LoadCronResult
   try {
@@ -193,8 +278,6 @@ async function startScheduler({
     console.error(`[cron] failed to load cron.json: ${result.reason}`)
     return null
   }
-  // Without cron.json, the scheduler still needs to run if internal jobs
-  // (like dreaming) are configured. Construct an empty file in that case.
   const file: CronFile = result.file ?? { jobs: [] }
   if (!result.file && !hasInternalJobs) return null
 
@@ -208,6 +291,46 @@ async function startScheduler({
 
 function makeDefaultSchedulerFactory(internalJobs: () => CronJob[]): SchedulerFactory {
   return ({ file, onFire }) => createScheduler({ jobs: [...file.jobs, ...internalJobs()], onFire })
+}
+
+type PluginSubagentEntry = {
+  pluginName: string
+  subagentName: string
+  pluginSubagent: import('@/plugin').Subagent<any>
+}
+
+function mergeSubagents(pluginRegistry: PluginRegistry): {
+  registry: SubagentRegistry
+  pluginSubagentByShim: WeakMap<InternalSubagent<any>, PluginSubagentEntry>
+} {
+  const merged: Record<string, InternalSubagent<any>> = {
+    'memory-logger': memoryLoggerSubagent,
+    dreaming: dreamingSubagent,
+  }
+  const pluginSubagentByShim = new WeakMap<InternalSubagent<any>, PluginSubagentEntry>()
+  for (const reg of pluginRegistry.subagents) {
+    if (merged[reg.subagentName] !== undefined) {
+      throw new Error(
+        `plugin ${reg.pluginName}: subagent name "${reg.subagentName}" conflicts with a built-in subagent`,
+      )
+    }
+    const shim = pluginSubagentShim(reg.subagent)
+    merged[reg.subagentName] = shim
+    pluginSubagentByShim.set(shim, {
+      pluginName: reg.pluginName,
+      subagentName: reg.subagentName,
+      pluginSubagent: reg.subagent,
+    })
+  }
+  return { registry: merged, pluginSubagentByShim }
+}
+
+function pluginSubagentShim(subagent: import('@/plugin').Subagent<any>): InternalSubagent<any> {
+  return {
+    systemPrompt: subagent.systemPrompt,
+    ...(subagent.payloadSchema ? { payloadSchema: subagent.payloadSchema } : {}),
+    ...(subagent.handler ? { handler: subagent.handler as InternalSubagent<any>['handler'] } : {}),
+  }
 }
 
 function buildInternalJobs(cwd: string, cfg: Config): CronJob[] {

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { LoadCronResult } from '@/cron'
+
+import { startAgent, type LoadCronFn } from './index'
+
+const noCron: LoadCronFn = async () => ({ ok: true, file: null }) as LoadCronResult
+
+let running: Awaited<ReturnType<typeof startAgent>> | null = null
+let agentDir: string | null = null
+
+afterEach(async () => {
+  if (running) {
+    running.stop()
+    running.tuiPromise?.catch(() => {})
+    running = null
+  }
+  if (agentDir) {
+    await rm(agentDir, { recursive: true, force: true })
+    agentDir = null
+  }
+})
+
+async function writePlugin(dir: string, body: string) {
+  await writeFile(join(dir, 'plugin.ts'), body)
+}
+
+describe('startAgent + plugin loading', () => {
+  test('loads a local plugin and merges its cron job under __plugin_<name>_<key>', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({
+        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        plugins: ['./plugin.ts'],
+      }),
+    )
+    await writePlugin(
+      agentDir,
+      `export default {
+  plugin: async () => ({
+    cronJobs: {
+      'weekly-digest': { schedule: '0 9 * * 1', kind: 'prompt', prompt: 'go' },
+    },
+  }),
+}`,
+    )
+
+    running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })
+
+    const ids = running.pluginRegistry.cronJobs.map((j) => j.globalId)
+    expect(ids).toEqual(['__plugin_plugin_weekly-digest'])
+    expect(running.loadedPlugins.map((p) => p.name)).toEqual(['plugin'])
+  })
+
+  test('plugin factory exception aborts startAgent and does not leak partial registrations', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({
+        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        plugins: ['./plugin.ts'],
+      }),
+    )
+    await writePlugin(
+      agentDir,
+      `export default {
+  plugin: async () => {
+    throw new Error('boom')
+  },
+}`,
+    )
+
+    await expect(startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })).rejects.toThrow(
+      /factory threw: boom/,
+    )
+  })
+
+  test('plugin session.start hook fires when a websocket session opens', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    const sentinelFile = join(agentDir, 'session-start.log')
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({
+        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        plugins: ['./plugin.ts'],
+      }),
+    )
+    await writePlugin(
+      agentDir,
+      `import { writeFile } from 'node:fs/promises'
+export default {
+  plugin: async () => ({
+    hooks: {
+      'session.start': async (event) => {
+        await writeFile(${JSON.stringify(sentinelFile)}, \`opened: \${event.sessionId}\`)
+      },
+    },
+  }),
+}`,
+    )
+
+    running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })
+
+    const ws = new WebSocket(`ws://localhost:${running.server.port}`)
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener('open', () => resolve(), { once: true })
+      ws.addEventListener('error', () => reject(new Error('ws error')), { once: true })
+    })
+
+    const TIMEOUT_MS = 5000
+    const POLL_MS = 25
+    const iterations = Math.ceil(TIMEOUT_MS / POLL_MS)
+    for (let i = 0; i < iterations; i++) {
+      try {
+        const content = await Bun.file(sentinelFile).text()
+        if (content.startsWith('opened:')) {
+          ws.close()
+          return
+        }
+      } catch {}
+      await new Promise((r) => setTimeout(r, POLL_MS))
+    }
+    ws.close()
+    throw new Error(`session.start hook never fired within ${TIMEOUT_MS}ms (sentinel ${sentinelFile} missing)`)
+  })
+
+  test('plugin skill is materialized and present in the resource loader for new sessions', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({
+        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        plugins: ['./plugin.ts'],
+      }),
+    )
+    await writePlugin(
+      agentDir,
+      `export default {
+  plugin: async () => ({
+    skills: {
+      'how-to-x': { description: 'how to do X', content: '# X\\n\\nSteps...' },
+    },
+  }),
+}`,
+    )
+
+    running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })
+    expect(running.pluginRegistry.skills.map((s) => s.localName)).toEqual(['how-to-x'])
+  })
+
+  test('plugin subagent is registered and its tools are forwarded to the spawned session', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({
+        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        plugins: ['./plugin.ts'],
+      }),
+    )
+    await writePlugin(
+      agentDir,
+      `export default {
+  plugin: async () => ({
+    subagents: {
+      worker: {
+        systemPrompt: 'you are a worker',
+        tools: [{ __builtinTool: 'read' }],
+      },
+    },
+  }),
+}`,
+    )
+
+    running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })
+    const subagent = running.pluginRegistry.subagents.find((s) => s.subagentName === 'worker')
+    expect(subagent).toBeDefined()
+    expect(subagent?.subagent.tools).toEqual([{ __builtinTool: 'read' }])
+  })
+
+  test('plugin config block is validated against configSchema and exposed as ctx.config', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    await symlink(join(process.cwd(), 'node_modules'), join(agentDir, 'node_modules'), 'dir')
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({
+        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        plugins: ['./plugin.ts'],
+        plugin: { magicNumber: 7 },
+      }),
+    )
+    await writePlugin(
+      agentDir,
+      `import { z } from 'zod'
+export default {
+  configSchema: z.object({ magicNumber: z.number() }),
+  plugin: async (ctx) => ({
+    cronJobs: {
+      magic: { schedule: \`\${ctx.config.magicNumber} * * * *\`, kind: 'prompt', prompt: 'tick' },
+    },
+  }),
+}`,
+    )
+
+    running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })
+
+    const job = running.pluginRegistry.cronJobs[0]?.job
+    expect(job?.kind).toBe('prompt')
+    expect(job?.schedule).toBe('7 * * * *')
+  })
+})

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -65,6 +65,8 @@ async function startWithSession(
     sessionFactory?: SessionFactory
     memoryIdleMs?: number
     agentDir?: string
+    pluginRegistry?: import('@/plugin').PluginRegistry
+    pluginHooks?: import('@/plugin').HookBus
   } = {},
 ): Promise<{ url: string }> {
   const built = createServer({
@@ -74,6 +76,8 @@ async function startWithSession(
     ...(extra.sessionFactory ? { sessionFactory: extra.sessionFactory } : {}),
     ...(extra.memoryIdleMs !== undefined ? { memoryIdleMs: extra.memoryIdleMs } : {}),
     ...(extra.agentDir !== undefined ? { agentDir: extra.agentDir } : {}),
+    ...(extra.pluginRegistry ? { pluginRegistry: extra.pluginRegistry } : {}),
+    ...(extra.pluginHooks ? { pluginHooks: extra.pluginHooks } : {}),
   }).start()
   server = built
   return { url: `ws://localhost:${built.port}` }
@@ -683,5 +687,130 @@ describe('createServer memory idle detector', () => {
     await new Promise((r) => setTimeout(r, 50))
     expect(messages).toHaveLength(1)
     ws.close()
+  })
+})
+
+describe('createServer plugin hooks', () => {
+  test('fires session.start with the session id and agentDir on websocket open', async () => {
+    const { createHookBus } = await import('@/plugin')
+    const { emptyRegistry } = await import('@/plugin/registry')
+    const fired: { sessionId: string; agentDir: string }[] = []
+    const hooks = createHookBus()
+    hooks.registerAll(
+      'p',
+      '/agent',
+      { info: () => {}, warn: () => {}, error: () => {} },
+      {
+        'session.start': (event) => {
+          fired.push({ sessionId: event.sessionId, agentDir: event.agentDir })
+        },
+      },
+    )
+
+    const session = createFakeSession()
+    const { url } = await startWithSession(session, {
+      pluginRegistry: emptyRegistry(),
+      pluginHooks: hooks,
+      agentDir: '/agent',
+    })
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    expect(fired).toHaveLength(1)
+    expect(fired[0]?.agentDir).toBe('/agent')
+    ws.close()
+  })
+
+  test('fires session.idle BEFORE the memory-logger spawn (deterministic order)', async () => {
+    const { createHookBus } = await import('@/plugin')
+    const { emptyRegistry } = await import('@/plugin/registry')
+    const ordering: string[] = []
+    const hooks = createHookBus()
+    hooks.registerAll(
+      'p',
+      '/agent',
+      { info: () => {}, warn: () => {}, error: () => {} },
+      {
+        'session.idle': () => {
+          ordering.push('idle')
+        },
+      },
+    )
+
+    const session = createFakeSession()
+    const stream = createStream()
+    stream.subscribe({ target: { kind: 'new-session' } }, () => {
+      ordering.push('memory-logger')
+    })
+
+    const stubFactory: SessionFactory = {
+      sessionDir: () => '/tmp/test-sessions',
+      createPersisted: () =>
+        ({
+          getSessionId: () => 'ses_idle',
+          getSessionFile: () => '/tmp/test-sessions/ses_idle.jsonl',
+        }) as unknown as SessionManager,
+    }
+
+    const { url } = await startWithSession(session, {
+      stream,
+      sessionFactory: stubFactory,
+      memoryIdleMs: 30,
+      agentDir: '/agent',
+      pluginRegistry: emptyRegistry(),
+      pluginHooks: hooks,
+    })
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    stream.publish({
+      target: { kind: 'session', sessionId: 'ses_idle' },
+      payload: { kind: 'prompt', text: 'hi', delivery: 'queue' },
+    })
+    await new Promise((r) => setTimeout(r, 10))
+    session.resolvePrompt()
+    await waitFor((m) => m.type === 'done')
+
+    await new Promise((r) => setTimeout(r, 80))
+    expect(ordering).toEqual(['idle', 'memory-logger'])
+    ws.close()
+  })
+
+  test('awaits session.end before resolving the close handler', async () => {
+    const { createHookBus } = await import('@/plugin')
+    const { emptyRegistry } = await import('@/plugin/registry')
+    const endResolve: { fn: (() => void) | null } = { fn: null }
+    let ended = false
+    const hooks = createHookBus()
+    hooks.registerAll(
+      'p',
+      '/agent',
+      { info: () => {}, warn: () => {}, error: () => {} },
+      {
+        'session.end': () =>
+          new Promise<void>((resolve) => {
+            endResolve.fn = () => {
+              ended = true
+              resolve()
+            }
+          }),
+      },
+    )
+
+    const session = createFakeSession()
+    const { url } = await startWithSession(session, {
+      pluginRegistry: emptyRegistry(),
+      pluginHooks: hooks,
+      agentDir: '/agent',
+    })
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    ws.close()
+    await new Promise((r) => setTimeout(r, 30))
+    expect(ended).toBe(false)
+    endResolve.fn?.()
+    await new Promise((r) => setTimeout(r, 30))
+    expect(ended).toBe(true)
   })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,14 +1,20 @@
 import type { Server as BunServer, ServerWebSocket } from 'bun'
 
-import { createSession as defaultCreateSession, type AgentSession, type CreateSessionOptions } from '@/agent'
+import {
+  createSessionWithDispose as defaultCreateSessionWithDispose,
+  type AgentSession,
+  type CreateSessionOptions,
+  type CreateSessionResult,
+} from '@/agent'
 import { createIdleDetector, type IdleDetector } from '@/memory'
+import type { HookBus, PluginRegistry } from '@/plugin'
 import type { ReloadAllResult, ReloadRegistry } from '@/reload'
 import type { SessionFactory } from '@/sessions'
 import type { ClientMessage, PromptDelivery, QueueStateItem, ReloadResultPayload, ServerMessage } from '@/shared'
 import type { Stream, StreamMessage, StreamMessageId, Unsubscribe } from '@/stream'
 
 export type ReloadAllFn = () => Promise<ReloadAllResult>
-export type CreateSessionFn = (options?: CreateSessionOptions) => Promise<AgentSession>
+export type CreateSessionFn = (options?: CreateSessionOptions) => Promise<AgentSession | CreateSessionResult>
 
 export type ServerOptions = {
   port: number
@@ -19,6 +25,8 @@ export type ServerOptions = {
   stream?: Stream
   memoryIdleMs?: number
   agentDir?: string
+  pluginRegistry?: PluginRegistry
+  pluginHooks?: HookBus
 }
 
 export type Server = ReturnType<typeof createServer>
@@ -42,6 +50,7 @@ type SessionState = {
   unsubBroadcast: Unsubscribe | null
   unsubPrompts: Unsubscribe | null
   idleDetector: IdleDetector | null
+  dispose: () => Promise<void>
 }
 
 function send(ws: Ws, msg: ServerMessage) {
@@ -52,11 +61,13 @@ export function createServer({
   port,
   reloadAll,
   reloadRegistry,
-  createSession = defaultCreateSession,
+  createSession = defaultCreateSessionWithDispose,
   sessionFactory,
   stream,
   memoryIdleMs,
   agentDir,
+  pluginRegistry,
+  pluginHooks,
 }: ServerOptions) {
   const sessionStates = new WeakMap<Ws, SessionState>()
 
@@ -71,8 +82,19 @@ export function createServer({
       websocket: {
         async open(ws) {
           const sessionManager = sessionFactory?.createPersisted()
-          const session = await createSession({ reloadRegistry, sessionManager, ...(stream ? { stream } : {}) })
           const sessionFileId = sessionManager?.getSessionId() ?? ws.data.sessionId
+          const pluginsWiring =
+            pluginRegistry !== undefined && pluginHooks !== undefined && agentDir !== undefined
+              ? { registry: pluginRegistry, hooks: pluginHooks, sessionId: sessionFileId, agentDir }
+              : undefined
+          const result = await createSession({
+            reloadRegistry,
+            sessionManager,
+            ...(stream ? { stream } : {}),
+            ...(pluginsWiring ? { plugins: pluginsWiring } : {}),
+          })
+          const session = 'session' in result ? result.session : result
+          const dispose = 'session' in result && result.dispose ? result.dispose : async () => {}
 
           const state: SessionState = {
             session,
@@ -83,13 +105,27 @@ export function createServer({
             unsubBroadcast: null,
             unsubPrompts: null,
             idleDetector: null,
+            dispose,
           }
           sessionStates.set(ws, state)
+
+          if (pluginHooks !== undefined && agentDir !== undefined) {
+            await pluginHooks.runSessionStart({ sessionId: sessionFileId, agentDir })
+          }
 
           if (stream !== undefined && memoryIdleMs !== undefined && agentDir !== undefined) {
             state.idleDetector = createIdleDetector({
               idleMs: memoryIdleMs,
-              onIdle: () => publishMemoryLoggerSpawn(state, stream, agentDir),
+              onIdle: async () => {
+                if (pluginHooks !== undefined) {
+                  await pluginHooks.runSessionIdle({
+                    sessionId: state.sessionFileId,
+                    parentTranscriptPath: state.sessionManager?.getSessionFile(),
+                    idleMs: memoryIdleMs,
+                  })
+                }
+                publishMemoryLoggerSpawn(state, stream, agentDir)
+              },
             })
           }
 
@@ -157,13 +193,19 @@ export function createServer({
             return
           }
         },
-        close(ws) {
+        async close(ws) {
           const state = sessionStates.get(ws)
           state?.unsubBroadcast?.()
           state?.unsubPrompts?.()
           state?.idleDetector?.dispose()
+          if (state) {
+            if (pluginHooks !== undefined) {
+              await pluginHooks.runSessionEnd({ sessionId: state.sessionFileId })
+            }
+            await state.dispose()
+          }
           sessionStates.delete(ws)
-          console.log(`session ${ws.data.sessionId}: close`)
+          console.log(`session ${state?.sessionFileId ?? ws.data.sessionId}: close`)
         },
       },
     })


### PR DESCRIPTION
## Summary

Adds a plugin system. A plugin is a TypeScript module with one default export — a call to `definePlugin({ ... })`. The factory it wraps returns a contributions object that the runtime translates into tools, subagents, cron jobs, skills, and event hooks. Plugin code imports only from `typeclaw/plugin` and `zod`; the underlying engine (`@mariozechner/pi-coding-agent`) stays hidden behind TypeClaw types so engine details don't leak into plugin authors' code.

A plugin's name is derived, never declared: from the npm package name (with any `typeclaw-plugin-` prefix and scope stripped) or from the local path basename. Per-plugin config lives at the top level of `typeclaw.json` keyed by that derived name and is validated against the plugin's optional `configSchema` before the factory runs. `definePlugin` infers the config type from the schema literal, so authors never write the generic.

```ts
import { z } from 'zod'
import { definePlugin, defineTool } from 'typeclaw/plugin'

export default definePlugin({
  configSchema: z.object({ schedule: z.string().default('0 9 * * 1') }),
  plugin: async (ctx) => ({
    tools: {
      lookup: defineTool({
        description: 'Look up a journal entry.',
        parameters: z.object({ date: z.string() }),
        async execute(args) {
          return { content: [{ type: 'text', text: \`looked up \${args.date}\` }] }
        },
      }),
    },
    cronJobs: {
      'weekly-digest': { schedule: ctx.config.schedule, kind: 'prompt', prompt: 'compile a digest' },
    },
    hooks: {
      'session.prompt': (event) => {
        event.prompt += \`\n\n[plugin: \${ctx.name}]\`
      },
    },
  }),
})
```

## Hooks

| Hook | When | Payload | Notes |
|---|---|---|---|
| `session.start` | WebSocket open | `{ sessionId, agentDir }` | Awaited before the connected message is sent. |
| `session.end` | WebSocket close | `{ sessionId }` | Awaited before the close handler resolves and the materialized-skills tmpdir is removed. |
| `session.idle` | Idle detector trip after a prompt completes | `{ sessionId, parentTranscriptPath, idleMs }` | Awaited *before* the memory-logger spawn so plugins can finalize transcript state first. |
| `session.prompt` | System-prompt assembly, once per session | `{ prompt, sessionId, agentDir }` | Reassign `event.prompt` to mutate. Multiple plugins compose in load order. |
| `tool.before` | Pre-execute, plugin-defined custom tools only | `{ tool, sessionId, callId, args }` | `event.args` is the schema-validated mutable bag (no double-parse). Mutate to rewrite, or return `{ block: true, reason }` to refuse. First block short-circuits. |
| `tool.after` | Post-execute, plugin-defined custom tools only | `{ tool, sessionId, callId, result }` | Observe or transform `event.result`. |

`tool.before` / `tool.after` intercept plugin-registered custom tools only — the engine's built-in tools (read/bash/edit/write/etc.) are not wrapped.

## Loading and rollback

`startAgent` reads `typeclaw.json`, loads each entry in `plugins[]` in order, derives the plugin name, validates the per-plugin config against `configSchema`, runs the factory with a `PluginContext`, and merges contributions into the runtime registries.

A factory throw or a registration conflict (duplicate tool, subagent, cron, skill, or plugin name) discards every contribution from the offending plugin — tools, subagents, cron jobs, skills, **and hooks** — before the error bubbles up. There is no partial state.

`ctx.spawnSubagent(name, payload?)` is gated by an internal boot flag: calling it from inside the factory throws `plugin <name>: spawnSubagent("<x>") called before boot completed` because the subagent consumer is not wired yet. After boot completes, the same call works from event handlers, tool execute functions, and subagent handlers.

Local plugin paths are confined to within `agentDir`; absolute paths or parent-traversing paths are rejected with a clear error so a malicious `typeclaw.json` cannot point at arbitrary host files. NPM packages with `exports` maps fall back to bare-import resolution when no `main`/`module` entry resolves on disk.

## Cron prefix

Plugin cron jobs use a global id of `__plugin_<plugin-name>_<key>`. `cron.json` user job ids cannot start with an underscore, and the registry rejects duplicate global ids across plugins, so collisions are impossible by construction.

## Subagents

Plugin subagents are merged into the existing subagent registry alongside the built-in `memory-logger` and `dreaming` subagents. The runtime resolves each plugin subagent's declared `tools` (built-in tool refs) and `customTools` (plugin tools) at invocation time, so a spawned subagent session receives **only** what the subagent declared — not the entire plugin registry. The runtime owns session creation, model resolution, materialized-skill disposal, and lifecycle.

## Tools

Plugin authors use Zod for tool parameters. The runtime converts the schema to JSON Schema (`z.toJSONSchema(... { io: 'input', reused: 'inline' })`) and feeds it to the engine's `defineTool` cast as `TSchema`. The plugin's `execute(args, ctx)` is wrapped to fit the engine's `execute(toolCallId, params, signal, onUpdate, ctx)` shape. Args are validated **once** (transforms run once, defaults applied once), exposed as a mutable bag to `tool.before`, then handed to the plugin tool. `ToolContext` is curated to `{ signal, sessionId, agentDir, logger }` — the engine's `ExtensionContext` is never exposed.

## Skills

Two forms:

- `skills: { 'skill-name': { description, content, frontmatter? } }` — string-form skills materialize to a per-session tmpdir as `<name>/SKILL.md` at session start. The tmpdir is cleaned up on websocket close and on subagent invocation completion. Materialization is wrapped in `try/catch` so partial state on failure does not leak.
- `skillsDirs: ['/abs/path']` — file-form, paths flow into the resource loader's additional-skills paths verbatim. Non-existent dirs are warned at registration time.

## Config

`typeclaw.json` gains:

- `plugins: string[]` — npm package names or relative paths.
- A catchall on the schema (`z.unknown()`) so per-plugin config blocks at the top level (e.g. `"standup-log": { schedule: "0 17 * * 5" }`) survive validation without being predeclared.
- `FIELD_EFFECTS.plugins = 'restart-required'` — adding, removing, or reordering plugins requires `typeclaw restart` to take effect.

Two helpers: `extractPluginConfigs(raw)` filters known top-level keys and returns the rest as `Record<string, unknown>`; `loadPluginConfigsSync(cwd)` reads `typeclaw.json` and returns the plugin-config map.

## Engine boundary

The boundary is structural: `src/plugin/**` does **not** import from `@mariozechner/*`. The single bridge file is `src/agent/plugin-tools.ts`, which lives in the agent layer and is the only place that legitimately imports both the plugin types and the engine types. The runtime layer (`src/agent/index.ts`, `src/run/index.ts`, `src/server/index.ts`) does the engine translation. Tests for the bridge live next to it (`src/agent/plugin-tools.test.ts`).

## Wiring sites

- `src/plugin/` (new module): `types.ts`, `define.ts`, `loader.ts`, `registry.ts`, `manager.ts`, `hooks.ts`, `skills.ts`, `context.ts`, `index.ts`, plus tests.
- `src/agent/plugin-tools.ts` (new) — Zod→JSON-Schema bridge, `BuiltinToolRef` resolver against the engine's tool set, `wrapPluginTool` adapter with single-parse `tool.before`/`tool.after` integration.
- `src/agent/index.ts` — `CreateSessionOptions.plugins?` threads the registry, hook bus, sessionId, and agentDir through. `createSessionWithDispose` materializes string-form skills (and exposes a `dispose` callback to clean them up at session close), wraps plugin tools, fires `session.prompt` once during system-prompt assembly inside `createResourceLoader`, merges plugin `skillsDirs` into `additionalSkillPaths`, and supports `pluginSubagent` for subagent-scoped tool exposure.
- `src/agent/subagents.ts` — `CreateSessionForSubagent` may now return `{ session, dispose }`; `invokeSubagent` calls both `session.dispose()` and the optional outer `dispose()` so plugin subagent sessions clean up their materialized-skill tmpdirs.
- `src/server/index.ts` — `ServerOptions` accepts `pluginRegistry` and `pluginHooks`. WebSocket open computes `sessionFileId` once, creates the session with `plugins: { ... }` wired, then awaits `session.start`. The `IdleDetector` callback awaits `session.idle` *before* publishing the memory-logger spawn. `close` awaits `session.end` and then the session's outer `dispose()`.
- `src/run/index.ts` — `startAgent` loads `typeclaw.json` directly via `loadConfigSync(cwd)` so per-agent `plugins[]` resolves correctly under tests with their own `cwd`. It calls `loadPlugins`, merges plugin subagents into the existing subagent registry (using a `WeakMap` keyed by the shim object so identity lookup is robust), builds a custom `createSessionForSubagent` that uses the plugin wiring for plugin-owned subagents and falls back to the default for `memory-logger` / `dreaming`, prefixes plugin cron jobs and merges them into `internalJobs`, wires `setSpawnSubagent` against the merged registry, calls `markBooted`, and emits a registration audit on stdout.
- `src/config/config.ts` — adds `plugins`, switches the schema to `.catchall(z.unknown())`, registers `plugins` as `restart-required` in `FIELD_EFFECTS`, adds `extractPluginConfigs` and `loadPluginConfigsSync`.

## Testing

73 new tests across 9 files. **Total suite: 615 pass, 0 fail.** `bun run typecheck`, `bun run lint`, `bun run format:check` all clean.

Coverage highlights:

- **Atomic rollback.** A factory throw or registration conflict discards every contribution kind, including hooks (verified by counting hook handlers before and after `discardRegistrationsBy`).
- **Hook composition.** `session.prompt` mutations chain across plugins, per-plugin throws don't break later plugins, `tool.before` mutations propagate without double-parse, first `{ block: true }` short-circuits.
- **Materialized skills lifecycle.** `<name>/SKILL.md` written per skill, `dispose` removes the tmpdir, duplicate sanitized names throw, mid-failure errors clean up the tmpdir.
- **AbortSignal propagation.** A real `AbortController.signal` flows through `wrapPluginTool` and arrives at the plugin tool's `ctx.signal`.
- **End-to-end.** `startAgent` boots against a real local plugin written into a tmp `typeclaw.json` and asserts: cron job global id format, factory-exception abort with plugin name in the error, `configSchema` validation feeding `ctx.config` into a generated cron schedule, plugin skill registration, plugin subagent tool preservation, and `session.start` hook firing when a real WebSocket connects.
- **Server hooks.** `session.start` fires with the right payload on ws open. `session.idle` runs before the memory-logger spawn (deterministic ordering verified by capturing both events). `session.end` is awaited — the close handler does not resolve until the hook resolves.
- **Mutation checks.** Three production lines were commented out in turn during development and the suite was confirmed to fail: `markBooted` gating `spawnSubagent`, `HookBus.unregisterAll(pluginName)` on rollback, and `tool.before` block short-circuit.

## What is intentionally not in this PR

- **Plugin sandboxing.** Plugins run with full Bun privileges. The container is the sandbox.
- **Hot plugin reload.** `typeclaw restart` to pick up plugin code or config changes.
- **Stream subscriptions.** Plugins observe the in-process pub/sub through the typed `hooks` surface; they cannot subscribe directly.
- **Server-side TUI push notifications** from plugin code.
- **Dockerfile fragments** contributed by plugins.
- **New cron job kinds** beyond `prompt` and `exec`. (Subagent invocation is a `prompt` variant, not a separate kind.)
- **Reload-registry scopes** for plugin-owned state.
- **Host-stage CLI command registration.**
- **`extendConfig`** for arbitrary top-level fields outside the plugin's own config block.
- **Per-LLM-call hooks** (`llm.params` / `llm.headers`). Wiring them requires reaching past `createAgentSession` into the engine's pre-provider-request event, which is invasive enough that it should wait until a real plugin needs them.
- **`tool.before` / `tool.after` for built-in engine tools.** Only plugin-defined custom tools are intercepted.

## Review notes

- `discardRegistrationsBy` evicts hooks via `HookBus.unregisterAll`. The corresponding registry test enumerates every contribution kind; update it when adding a new one.
- The Zod → JSON-Schema → `TSchema` cast in `src/agent/plugin-tools.ts` works because the engine validates parameters as JSON-Schema-shaped data. If the engine ever switches to a stricter TypeBox-only path, this is the line to revisit.
- `startAgent` loads `typeclaw.json` via `loadConfigSync(cwd)` for the plugin entries (rather than the module-import-time `config` snapshot) because per-agent test cwds need their own `plugins[]`. The eager `config` snapshot is still used elsewhere where it was already correct.
- Plugin subagent identity is tracked via `WeakMap<InternalSubagent, PluginSubagentEntry>` keyed by the shim object the runtime registered. Reference equality on `(systemPrompt, handler)` was considered and rejected — two plugins with identical system prompts and undefined handlers would collide.