### PR TITLE
Humanize tool call results in TUI

### DIFF
--- a/src/tui/format.test.ts
+++ b/src/tui/format.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatToolEnd, formatToolStart } from './format'
+
+const stripAnsi = (s: string) =>
+  // oxlint-disable-next-line no-control-regex -- intentionally strips ANSI sequences from rendered output
+  s.replace(/\x1b\[[0-9;]*m/g, '')
+
+const visible = (s: string) => stripAnsi(s)
+
+describe('formatToolStart args', () => {
+  test('read shows just the path when no offset/limit', () => {
+    const out = visible(formatToolStart('read', { path: '/foo/bar.ts' }))
+    expect(out).toContain('read')
+    expect(out).toContain('/foo/bar.ts')
+    expect(out).not.toContain('"path"')
+  })
+
+  test('read renders offset and limit as a line range', () => {
+    const out = visible(formatToolStart('read', { path: 'a.ts', offset: 10, limit: 5 }))
+    expect(out).toContain('a.ts')
+    expect(out).toContain('lines 10-14')
+  })
+
+  test('read with only offset says "from line N"', () => {
+    const out = visible(formatToolStart('read', { path: 'a.ts', offset: 50 }))
+    expect(out).toContain('from line 50')
+  })
+
+  test('read with only limit says "first N lines"', () => {
+    const out = visible(formatToolStart('read', { path: 'a.ts', limit: 20 }))
+    expect(out).toContain('first 20 lines')
+  })
+
+  test('bash shows the command, not JSON', () => {
+    const out = visible(formatToolStart('bash', { command: 'ls -la /tmp' }))
+    expect(out).toContain('ls -la /tmp')
+    expect(out).not.toContain('"command"')
+  })
+
+  test('bash collapses internal whitespace', () => {
+    const out = visible(formatToolStart('bash', { command: 'echo  foo\n  &&  echo  bar' }))
+    expect(out).toContain('echo foo && echo bar')
+  })
+
+  test('grep shows quoted pattern and target path', () => {
+    const out = visible(formatToolStart('grep', { pattern: 'foo', path: 'src/' }))
+    expect(out).toContain('"foo" in src/')
+    expect(out).not.toContain('"pattern"')
+  })
+
+  test('grep with only pattern shows just the quoted pattern', () => {
+    const out = visible(formatToolStart('grep', { pattern: 'TODO' }))
+    expect(out).toContain('"TODO"')
+    expect(out).not.toContain(' in ')
+  })
+
+  test('edit shows path and edit count', () => {
+    const out = visible(formatToolStart('edit', { path: 'a.ts', edits: [{ oldText: 'a', newText: 'b' }] }))
+    expect(out).toContain('a.ts')
+    expect(out).toContain('1 edit')
+    expect(out).not.toContain('"oldText"')
+  })
+
+  test('edit pluralizes for multiple edits', () => {
+    const out = visible(
+      formatToolStart('edit', {
+        path: 'a.ts',
+        edits: [
+          { oldText: 'a', newText: 'b' },
+          { oldText: 'c', newText: 'd' },
+        ],
+      }),
+    )
+    expect(out).toContain('2 edits')
+  })
+
+  test('write shows path and human byte size', () => {
+    const out = visible(formatToolStart('write', { path: 'a.ts', content: 'x'.repeat(2048) }))
+    expect(out).toContain('a.ts')
+    expect(out).toMatch(/\b2(\.0)?KB\b/)
+  })
+
+  test('ls shows the path', () => {
+    const out = visible(formatToolStart('ls', { path: '/etc' }))
+    expect(out).toContain('/etc')
+    expect(out).not.toContain('"path"')
+  })
+
+  test('find shows pattern and path', () => {
+    const out = visible(formatToolStart('find', { pattern: '*.ts', path: 'src' }))
+    expect(out).toContain('*.ts in src')
+  })
+
+  test('websearch shows quoted query', () => {
+    const out = visible(formatToolStart('websearch', { query: 'lmk what' }))
+    expect(out).toContain('"lmk what"')
+    expect(out).not.toContain('"query"')
+  })
+
+  test('websearch shows source when not the default', () => {
+    const out = visible(formatToolStart('websearch', { query: 'foo', source: 'wikipedia' }))
+    expect(out).toContain('"foo" (wikipedia)')
+  })
+
+  test('webfetch shows the url', () => {
+    const out = visible(formatToolStart('webfetch', { url: 'https://example.com/page' }))
+    expect(out).toContain('https://example.com/page')
+    expect(out).not.toContain('"url"')
+  })
+
+  test('unknown tool falls back to compact JSON args', () => {
+    const out = visible(formatToolStart('mystery', { foo: 'bar' }))
+    expect(out).toContain('mystery')
+    expect(out).toContain('{"foo":"bar"}')
+  })
+
+  test('empty args produce no preview at all', () => {
+    const out = visible(formatToolStart('read', {}))
+    expect(out.trim()).toBe('● read')
+  })
+})
+
+describe('formatToolEnd results', () => {
+  test('extracts content[].text from the standard tool result shape', () => {
+    const result = { content: [{ type: 'text', text: 'hello world' }], details: { meta: 1 } }
+    const out = visible(formatToolEnd('read', false, result, 12))
+    expect(out).toContain('hello world')
+    expect(out).not.toContain('"content"')
+    expect(out).not.toContain('"details"')
+    expect(out).toContain('12ms')
+  })
+
+  test('joins multiple text parts with blank lines', () => {
+    const result = {
+      content: [
+        { type: 'text', text: 'first' },
+        { type: 'text', text: 'second' },
+      ],
+    }
+    const out = visible(formatToolEnd('read', false, result, 1))
+    expect(out).toMatch(/first[\s\S]+second/)
+  })
+
+  test('plain string results are rendered as-is', () => {
+    const out = visible(formatToolEnd('something', false, 'just text', 5))
+    expect(out).toContain('just text')
+    expect(out).not.toContain('"')
+  })
+
+  test('null result produces only the header', () => {
+    const out = visible(formatToolEnd('read', false, null, 1))
+    expect(out.trim()).toBe('✓ read 1ms')
+  })
+
+  test('image read collapses to a placeholder, not base64', () => {
+    const result = {
+      content: [
+        { type: 'text', text: 'Read image file [image/png]' },
+        { type: 'image', data: 'AAAAAAAAAAAAAAA==', mimeType: 'image/png' },
+      ],
+    }
+    const out = visible(formatToolEnd('read', false, result, 8))
+    expect(out).toContain('[image: image/png]')
+    expect(out).not.toContain('AAAAAAAAA')
+  })
+
+  test('edit result shows the diff from details, not the raw text confirmation', () => {
+    const diff = '@@ -1 +1 @@\n-old\n+new'
+    const result = {
+      content: [{ type: 'text', text: 'Updated 1 file' }],
+      details: { diff, firstChangedLine: 1 },
+    }
+    const out = visible(formatToolEnd('edit', false, result, 3))
+    expect(out).toContain('-old')
+    expect(out).toContain('+new')
+    expect(out).not.toContain('Updated 1 file')
+  })
+
+  test('bash result appends the full output path footer when present', () => {
+    const result = {
+      content: [{ type: 'text', text: 'first 10 lines…' }],
+      details: { fullOutputPath: '/tmp/full.txt' },
+    }
+    const out = visible(formatToolEnd('bash', false, result, 50))
+    expect(out).toContain('first 10 lines')
+    expect(out).toContain('Full output saved to: /tmp/full.txt')
+  })
+
+  test('websearch reformats results into a numbered list', () => {
+    const result = {
+      content: [{ type: 'text', text: 'Search results for "x"…' }],
+      details: {
+        query: 'x',
+        source: 'web',
+        count: 2,
+        results: [
+          { title: 'First', url: 'https://a.example', snippet: 'a' },
+          { title: 'Second', url: 'https://b.example', snippet: 'b' },
+        ],
+      },
+    }
+    const out = visible(formatToolEnd('websearch', false, result, 100))
+    expect(out).toContain('2 results for "x" (web)')
+    expect(out).toContain('1. First — https://a.example')
+    expect(out).toContain('2. Second — https://b.example')
+  })
+
+  test('error result is rendered (color is applied internally)', () => {
+    const result = { content: [{ type: 'text', text: 'boom' }] }
+    const out = visible(formatToolEnd('bash', true, result, 7))
+    expect(out).toContain('✗')
+    expect(out).toContain('bash')
+    expect(out).toContain('boom')
+  })
+
+  test('truncation kicks in for very long results', () => {
+    const long = 'x'.repeat(5000)
+    const result = { content: [{ type: 'text', text: long }] }
+    const out = visible(formatToolEnd('read', false, result, 1))
+    expect(out).toContain('…')
+    expect(out).toContain('chars)')
+    expect(out.length).toBeLessThan(long.length)
+  })
+
+  test('non-standard result shape falls back to pretty JSON', () => {
+    const out = visible(formatToolEnd('mystery', false, { foo: 'bar' }, 1))
+    expect(out).toContain('"foo": "bar"')
+  })
+
+  test('result without content key falls back to pretty JSON', () => {
+    const out = visible(formatToolEnd('mystery', false, { details: { x: 1 } }, 1))
+    expect(out).toContain('"details"')
+  })
+})

--- a/src/tui/format.ts
+++ b/src/tui/format.ts
@@ -5,7 +5,7 @@ const RESULT_PREVIEW_MAX = 400
 
 export function formatToolStart(name: string, args: unknown): string {
   const head = `${colors.cyan('●')} ${colors.bold(name)}`
-  const preview = previewArgs(args)
+  const preview = previewArgs(name, args)
   return preview === null ? head : `${head} ${colors.dim(preview)}`
 }
 
@@ -13,7 +13,7 @@ export function formatToolEnd(name: string, error: boolean, result: unknown, dur
   const glyph = error ? colors.red('✗') : colors.green('✓')
   const dur = colors.gray(formatDuration(durationMs))
   const head = `${glyph} ${colors.bold(name)} ${dur}`
-  const preview = previewResult(result, error)
+  const preview = previewResult(name, error, result)
   return preview === null ? head : `${head}\n${preview}`
 }
 
@@ -40,16 +40,220 @@ function firstLine(text: string): string {
   return `${head} ${colors.dim(`(+${remaining} chars)`)}`
 }
 
-function previewArgs(args: unknown): string | null {
-  if (args === undefined || args === null) return null
-  if (typeof args === 'object' && Object.keys(args as object).length === 0) return null
-  return truncate(toCompactString(args), ARGS_PREVIEW_MAX)
+// Tool-specific argument summaries. Each humanizer collapses the typical
+// `{path, pattern, command, …}` parameter object into a single line that
+// reads naturally next to the tool name. Returning null means "I don't
+// recognize this shape, fall back to the generic compact JSON".
+type ArgRecord = Record<string, unknown>
+
+function humanizeArgs(name: string, args: unknown): string | null {
+  if (!isObject(args)) return null
+  switch (name) {
+    case 'read':
+      return humanizeReadArgs(args)
+    case 'bash':
+      return humanizeBashArgs(args)
+    case 'edit':
+      return humanizeEditArgs(args)
+    case 'write':
+      return humanizeWriteArgs(args)
+    case 'grep':
+      return humanizeGrepArgs(args)
+    case 'find':
+      return humanizeFindArgs(args)
+    case 'ls':
+      return humanizeLsArgs(args)
+    case 'websearch':
+      return humanizeWebsearchArgs(args)
+    case 'webfetch':
+      return humanizeWebfetchArgs(args)
+    default:
+      return null
+  }
 }
 
-function previewResult(result: unknown, error: boolean): string | null {
+function humanizeReadArgs(args: ArgRecord): string | null {
+  const path = asString(args.path)
+  if (path === null) return null
+  const offset = asNumber(args.offset)
+  const limit = asNumber(args.limit)
+  if (offset !== null && limit !== null) return `${path} (lines ${offset}-${offset + limit - 1})`
+  if (offset !== null) return `${path} (from line ${offset})`
+  if (limit !== null) return `${path} (first ${limit} lines)`
+  return path
+}
+
+function humanizeBashArgs(args: ArgRecord): string | null {
+  const command = asString(args.command)
+  if (command === null) return null
+  return command.replace(/\s+/g, ' ').trim()
+}
+
+function humanizeEditArgs(args: ArgRecord): string | null {
+  const path = asString(args.path)
+  if (path === null) return null
+  const edits = Array.isArray(args.edits) ? args.edits.length : 0
+  return edits > 0 ? `${path} (${edits} edit${edits === 1 ? '' : 's'})` : path
+}
+
+function humanizeWriteArgs(args: ArgRecord): string | null {
+  const path = asString(args.path)
+  if (path === null) return null
+  const content = asString(args.content)
+  if (content === null) return path
+  const bytes = Buffer.byteLength(content, 'utf-8')
+  return `${path} (${formatBytes(bytes)})`
+}
+
+function humanizeGrepArgs(args: ArgRecord): string | null {
+  const pattern = asString(args.pattern)
+  if (pattern === null) return null
+  const where = asString(args.path) ?? asString(args.glob)
+  return where ? `"${pattern}" in ${where}` : `"${pattern}"`
+}
+
+function humanizeFindArgs(args: ArgRecord): string | null {
+  const pattern = asString(args.pattern)
+  if (pattern === null) return null
+  const where = asString(args.path)
+  return where ? `${pattern} in ${where}` : pattern
+}
+
+function humanizeLsArgs(args: ArgRecord): string | null {
+  return asString(args.path) ?? '.'
+}
+
+function humanizeWebsearchArgs(args: ArgRecord): string | null {
+  const query = asString(args.query)
+  if (query === null) return null
+  const source = asString(args.source)
+  return source && source !== 'web' ? `"${query}" (${source})` : `"${query}"`
+}
+
+function humanizeWebfetchArgs(args: ArgRecord): string | null {
+  return asString(args.url)
+}
+
+// Tool-specific result enrichments. Most tools already embed a human-readable
+// summary in `content[].text`, so the default path simply extracts that. The
+// exceptions: `edit` benefits from showing the diff, `bash` likes a footer
+// with truncation/full-output info, image reads collapse to `[image]`.
+function humanizeResult(name: string, result: unknown): string | null {
+  if (!isObject(result)) return null
+  const enriched = enrichResult(name, result)
+  if (enriched !== null) return enriched
+  return extractContentText(result)
+}
+
+function enrichResult(name: string, result: ArgRecord): string | null {
+  switch (name) {
+    case 'edit':
+      return enrichEditResult(result)
+    case 'bash':
+      return enrichBashResult(result)
+    case 'read':
+      return enrichReadResult(result)
+    case 'websearch':
+      return enrichWebsearchResult(result)
+    default:
+      return null
+  }
+}
+
+function enrichEditResult(result: ArgRecord): string | null {
+  const details = isObject(result.details) ? result.details : null
+  const diff = details ? asString(details.diff) : null
+  if (diff !== null) return diff
+  return null
+}
+
+function enrichBashResult(result: ArgRecord): string | null {
+  const text = extractContentText(result)
+  if (text === null) return null
+  const details = isObject(result.details) ? result.details : null
+  const fullOutput = details ? asString(details.fullOutputPath) : null
+  if (fullOutput === null) return text
+  return `${text}\n\nFull output saved to: ${fullOutput}`
+}
+
+function enrichReadResult(result: ArgRecord): string | null {
+  const content = Array.isArray(result.content) ? result.content : null
+  if (content === null) return null
+  const hasImage = content.some((part) => isObject(part) && part.type === 'image')
+  if (!hasImage) return null
+  const mime = content
+    .map((part) => (isObject(part) && part.type === 'image' ? asString(part.mimeType) : null))
+    .find((m) => m !== null)
+  return mime ? `[image: ${mime}]` : '[image]'
+}
+
+function enrichWebsearchResult(result: ArgRecord): string | null {
+  const details = isObject(result.details) ? result.details : null
+  if (details === null) return null
+  const results = Array.isArray(details.results) ? details.results : null
+  if (results === null || results.length === 0) {
+    return extractContentText(result)
+  }
+  const query = asString(details.query) ?? ''
+  const source = asString(details.source) ?? ''
+  const header = query ? `${results.length} result${results.length === 1 ? '' : 's'} for "${query}" (${source})` : null
+  const lines = results
+    .map((entry, i) => formatWebsearchEntry(entry, i + 1))
+    .filter((line): line is string => line !== null)
+  if (lines.length === 0) return extractContentText(result)
+  return header === null ? lines.join('\n') : `${header}\n${lines.join('\n')}`
+}
+
+function formatWebsearchEntry(entry: unknown, index: number): string | null {
+  if (!isObject(entry)) return null
+  const title = asString(entry.title)
+  const url = asString(entry.url)
+  if (title === null || url === null) return null
+  return `${index}. ${title} — ${url}`
+}
+
+// AI-SDK style results carry a `content` array of `{type, text|data, …}` parts.
+// We join all `text` parts with blank lines between them and replace any
+// non-text parts with a placeholder so the user sees that something was there.
+function extractContentText(result: ArgRecord): string | null {
+  const content = result.content
+  if (!Array.isArray(content) || content.length === 0) return null
+  const parts: string[] = []
+  for (const part of content) {
+    if (!isObject(part)) continue
+    if (part.type === 'text') {
+      const text = asString(part.text)
+      if (text !== null) parts.push(text)
+      continue
+    }
+    if (part.type === 'image') {
+      const mime = asString(part.mimeType)
+      parts.push(mime ? `[image: ${mime}]` : '[image]')
+      continue
+    }
+    parts.push(`[${asString(part.type) ?? 'attachment'}]`)
+  }
+  if (parts.length === 0) return null
+  return parts.join('\n\n')
+}
+
+function previewArgs(name: string, args: unknown): string | null {
+  if (args === undefined || args === null) return null
+  if (typeof args === 'object' && Object.keys(args as object).length === 0) return null
+  const humanized = humanizeArgs(name, args)
+  const raw = humanized ?? toCompactString(args)
+  return truncate(raw, ARGS_PREVIEW_MAX)
+}
+
+function previewResult(name: string, error: boolean, result: unknown): string | null {
   if (result === undefined || result === null) return null
-  const raw = toReadableString(result)
-  if (raw.length === 0) return null
+  if (typeof result === 'string') return formatPreviewBlock(result, error)
+  const humanized = humanizeResult(name, result)
+  const raw = humanized ?? toReadableString(result)
+  return raw.length === 0 ? null : formatPreviewBlock(raw, error)
+}
+
+function formatPreviewBlock(raw: string, error: boolean): string {
   const truncated = truncate(raw, RESULT_PREVIEW_MAX)
   const colorize = error ? colors.red : colors.gray
   return truncated
@@ -90,4 +294,24 @@ function truncate(text: string, max: number): string {
   const cut = text.slice(0, max)
   const remaining = text.length - max
   return `${cut}… (+${remaining} chars)`
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`
+  const kb = bytes / 1024
+  if (kb < 1024) return `${kb < 10 ? kb.toFixed(1) : Math.round(kb)}KB`
+  const mb = kb / 1024
+  return `${mb < 10 ? mb.toFixed(1) : Math.round(mb)}MB`
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
 }


### PR DESCRIPTION
## Summary

The TUI was rendering tool results as raw pretty-printed JSON, including the standard `{ content: [{ type: 'text', text }], details }` envelope that wraps every tool's actual human-readable output. Instead of seeing the summary a tool author already wrote inside `content[].text`, users saw walls of escaped JSON.

Before (from a real session):

```
✓ reload 11ms
  {
    "content": [
      {
        "type": "text",
        "text": "Reloaded 2 subsystem(s).\n[config] ok: 0 applied, ..."
      }
    ],
    "details": { ... (+1077 chars)
```

After:

```
✓ reload 11ms
  Reloaded 2 subsystem(s).
  [config] ok: 0 applied, 0 restart-required, 0 ignored
  [cron] ok: 1 jobs (added 0, removed 0, updated 0, unchanged 1)
```

## Changes

### Result rendering (`formatToolEnd`)

`formatToolEnd` now extracts `content[].text` directly for any AI-SDK shaped result (the `{ content: Array<{ type, text }>, details? }` envelope) and falls back to pretty-printed JSON only when the shape is unrecognized.

Four tools receive extra polish on top of the default text extraction:

- **edit** — shows the unified diff from `details.diff` instead of the generic "Updated 1 file" confirmation text.
- **bash** — appends a `Full output saved to: <path>` footer when `details.fullOutputPath` is present (truncated runs).
- **read** — collapses image reads to `[image: <mime>]` instead of inlining base64.
- **websearch** — reformats `details.results` as a numbered `1. Title — URL` list.

### Argument rendering (`formatToolStart`)

`formatToolStart` got the same per-tool treatment so call sites display a compact human label instead of raw JSON args:

| Tool | Before | After |
|---|---|---|
| `read` | `{"path":"a.ts","offset":10,"limit":5}` | `a.ts (lines 10-14)` |
| `bash` | `{"command":"ls -la /tmp"}` | `ls -la /tmp` |
| `grep` | `{"pattern":"foo","path":"src/"}` | `"foo" in src/` |
| `edit` | `{"path":"a.ts","edits":[...]}` | `a.ts (2 edits)` |
| `write` | `{"path":"a.ts","content":"..."}` | `a.ts (2.0KB)` |
| `websearch` | `{"query":"x"}` | `"x"` |
| `webfetch` | `{"url":"https://…"}` | `https://…` |

Tools are matched by lowercase name (read, bash, edit, write, grep, find, ls, websearch, webfetch). Anything else falls back to compact JSON args and pretty JSON results, so plugin-supplied tools still render reasonably without per-plugin hand-coding.

## Testing

`src/tui/format.test.ts` is a new file with 30 tests / 57 expectations covering:

- Every argument humanizer (read with/without line range, bash, edit, write, grep, find, ls, websearch, webfetch).
- Every result humanizer, including the four special-case enrichments (edit diff, bash full-output footer, image read placeholder, websearch reformatting).
- JSON fallback for unrecognized tool names.
- The `RESULT_PREVIEW_MAX` truncation cap.
- Null, string, and non-standard result shapes.

Existing `src/tui/index.test.ts` continues to pass unchanged — its assertions use `'Read'` (capitalized), which intentionally doesn't match any humanizer and exercises the JSON fallback path, confirming backward compatibility for unknown/cased tool names.

```
bun test src/tui/   → 45 pass, 0 fail
bun run typecheck   → clean
bun run lint        → 0 warnings, 0 errors
```