### PR TITLE
Add `typeclaw log [-f]` host-stage command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Where an end user lives once they run `typeclaw init`. Their cwd is an agent fol
 - `typeclaw start` — spawn the container (`docker run`) configured in `typeclaw.json`.
 - `typeclaw stop` — stop it.
 - `typeclaw restart` — `stop` then `start` with the same flags as `start`.
+- `typeclaw log [-f]` — show (or follow) the container's stdout/stderr via `docker logs`.
 - `typeclaw tui` — attach a TUI client over a websocket to a running agent.
 - `typeclaw compose …` — orchestrate multiple agents across multiple agent folders.
 
@@ -42,7 +43,7 @@ Inside the container, `FIREWORKS_API_KEY` and friends arrive through `--env-file
 
 ### Rules of thumb
 
-- **CLI command names encode stage.** `init` is host-only (it _creates_ the host stage). `start` / `stop` / `restart` / `tui` / `compose` are host-only launchers. `run` is container-only. Anything that reads `process.cwd()` implicitly assumes host stage unless it's called from `run`.
+- **CLI command names encode stage.** `init` is host-only (it _creates_ the host stage). `start` / `stop` / `restart` / `log` / `tui` / `compose` are host-only launchers. `run` is container-only. Anything that reads `process.cwd()` implicitly assumes host stage unless it's called from `run`.
 - **When writing paths, annotate the stage.** `./typeclaw.json` means the host-stage agent folder; `/agent/typeclaw.json` means the container stage. Never ship a string that silently conflates them.
 - **The Dockerfile lives at the boundary.** `typeclaw init` (dev code running in host stage) writes a Dockerfile that `typeclaw start` (host stage) feeds to `docker run`, which then invokes `typeclaw run` (container stage) as the entrypoint.
 - **TypeClaw owns the Dockerfile and `.gitignore`, and rewrites them on every `start` — not just on `init`.** The agent folder is treated as a managed workspace, not a one-time scaffold. `start` calls `refreshDockerfile` / `refreshGitignore` unconditionally so version drift between the CLI and the agent folder is corrected automatically. The `.gitignore` is then auto-committed if it changed; the Dockerfile is not (see next bullet). **Consequence: to ship a Dockerfile template change, edit `src/init/dockerfile.ts` and run `typeclaw start --build` in any agent folder. Do not instruct users to delete their Dockerfile or re-run `init`.** The `wx` flag inside `writeDockerAssets` only governs the `init`-time write and is not the system's overwrite policy.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@
 import { defineCommand, runMain } from 'citty'
 
 import { init } from './init'
+import { logCommand } from './log'
 import { reload } from './reload'
 import { restartCommand } from './restart'
 import { run } from './run'
@@ -15,7 +16,16 @@ const main = defineCommand({
     name: 'typeclaw',
     description: 'TypeClaw agent runtime',
   },
-  subCommands: { init, run, tui, start: startCommand, stop: stopCommand, restart: restartCommand, reload },
+  subCommands: {
+    init,
+    run,
+    tui,
+    start: startCommand,
+    stop: stopCommand,
+    restart: restartCommand,
+    reload,
+    log: logCommand,
+  },
 })
 
 runMain(main)

--- a/src/cli/log.ts
+++ b/src/cli/log.ts
@@ -1,0 +1,30 @@
+import { defineCommand } from 'citty'
+
+import { logs } from '@/container'
+import { findAgentDir } from '@/init'
+
+export const logCommand = defineCommand({
+  meta: {
+    name: 'log',
+    description: 'show the agent container logs (host stage)',
+  },
+  args: {
+    follow: {
+      type: 'boolean',
+      alias: 'f',
+      description: 'stream new log output as it arrives',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+
+    const result = await logs({ cwd, follow: args.follow })
+    if (!result.ok) {
+      console.error(result.reason)
+      process.exit(1)
+    }
+
+    process.exit(result.exitCode)
+  },
+})

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -54,7 +54,7 @@ export const restartCommand = defineCommand({
       console.log(`Built image ${started.plan.imageTag}.`)
     }
     console.log(`Container ${started.plan.containerName} started (${started.containerId.slice(0, 12)}).`)
-    console.log(`Follow logs:  docker logs -f ${started.plan.containerName}`)
+    console.log(`Follow logs:  typeclaw log -f`)
     console.log(`Attach TUI:   typeclaw tui`)
     console.log(`Stop:         typeclaw stop`)
   },

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -39,7 +39,7 @@ export const startCommand = defineCommand({
       console.log(`Built image ${result.plan.imageTag}.`)
     }
     console.log(`Container ${result.plan.containerName} started (${result.containerId.slice(0, 12)}).`)
-    console.log(`Follow logs:  docker logs -f ${result.plan.containerName}`)
+    console.log(`Follow logs:  typeclaw log -f`)
     console.log(`Attach TUI:   typeclaw tui`)
     console.log(`Stop:         typeclaw stop`)
   },

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -1,3 +1,4 @@
+export { logs, planLogs, type LogsPlan, type LogsResult } from './logs'
 export { containerExists, containerNameFromCwd, imageTagFromCwd } from './shared'
 export { planStart, start, type PlanStartOptions, type StartPlan, type StartResult } from './start'
 export { planStop, stop, type StopPlan, type StopResult } from './stop'

--- a/src/container/logs.test.ts
+++ b/src/container/logs.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { planLogs } from './logs'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-container-logs-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('planLogs', () => {
+  test('derives container name from the folder basename and carries follow flag through', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    expect(planLogs(folder, { follow: false })).toEqual({ containerName: 'coder', follow: false })
+    expect(planLogs(folder, { follow: true })).toEqual({ containerName: 'coder', follow: true })
+  })
+})

--- a/src/container/logs.ts
+++ b/src/container/logs.ts
@@ -1,0 +1,37 @@
+import { containerExists, containerNameFromCwd, getBun } from './shared'
+
+export type LogsPlan = {
+  containerName: string
+  follow: boolean
+}
+
+export type LogsResult = { ok: true; containerName: string; exitCode: number } | { ok: false; reason: string }
+
+export async function logs({ cwd, follow }: { cwd: string; follow: boolean }): Promise<LogsResult> {
+  const bun = getBun()
+  if (!bun) return { ok: false, reason: 'bun runtime not available' }
+
+  const { containerName } = planLogs(cwd, { follow })
+
+  try {
+    if (!(await containerExists(containerName))) {
+      return { ok: false, reason: `Container ${containerName} not found. Run \`typeclaw start\` first.` }
+    }
+
+    const cmd = ['docker', 'logs']
+    if (follow) cmd.push('-f')
+    cmd.push(containerName)
+
+    // Inherit stdio so logs stream live and Ctrl+C reaches `docker logs`,
+    // which exits cleanly on SIGINT in follow mode.
+    const proc = bun.spawn({ cmd, cwd, stdout: 'inherit', stderr: 'inherit' })
+    const exitCode = await proc.exited
+    return { ok: true, containerName, exitCode }
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+export function planLogs(cwd: string, { follow }: { follow: boolean }): LogsPlan {
+  return { containerName: containerNameFromCwd(cwd), follow }
+}


### PR DESCRIPTION
## Summary

Adds `typeclaw log [-f]` as a first-class host-stage launcher that wraps `docker logs`. The existing `start` and `restart` commands already nudged users toward `docker logs -f <derived-name>`, but the container-name derivation rule (`containerNameFromCwd`, the `tc-` fallback for names starting with non-alphanumeric characters) is a TypeClaw internal that should not leak into the user's docker CLI invocations. Wrapping it removes that leak and gives the command set the same shape as the documented launchers in AGENTS.md.

## Changes

### `src/container/logs.ts` (new)

Domain function `logs({ cwd, follow })` and pure `planLogs(cwd, { follow })`. Resolves the container name via the existing `containerNameFromCwd` helper, runs a `containerExists` preflight check (same `docker inspect` path used by `start`/`stop`) to produce a clean message before touching docker, then `bun.spawn`s `docker logs [-f] <name>` with `stdout/stderr: 'inherit'` so output streams live and Ctrl+C propagates cleanly to `docker logs` in follow mode. Exports `LogsPlan` and `LogsResult`.

The `inherit` choice (rather than `pipe`) is intentional and documented inline: piping would buffer output and break SIGINT forwarding to the child process, defeating the primary use case.

### `src/container/logs.test.ts` (new)

Unit tests for `planLogs` mirroring the shape of `stop.test.ts` / `planStop`. Uses a real tmpdir + mkdir to verify both `follow: false` and `follow: true` paths and that the container name is derived from the folder basename.

### `src/container/index.ts`

Re-exports `logs`, `planLogs`, `LogsPlan`, `LogsResult`.

### `src/cli/log.ts` (new)

Thin citty command. Resolves the agent dir via `findAgentDir`, calls `logs(...)`, and forwards the exit code via `process.exit(result.exitCode)`. Declares `-f`/`--follow` as a boolean arg (default `false`).

### `src/cli/index.ts`

Registers `log: logCommand` in `subCommands`.

### `src/cli/start.ts` / `src/cli/restart.ts`

Replaces the `Follow logs:  docker logs -f <name>` hint with `Follow logs:  typeclaw log -f` so users are directed to the new command instead of the raw docker invocation.

### `AGENTS.md`

Lists `typeclaw log [-f]` in the host-stage launcher bullet and adds `log` to the "CLI command names encode stage" rule of thumb.

## Why this exists

Three concrete wins:

1. **Removes a container-name convention leak.** The `tc-` prefix fallback and the basename-derivation rule are TypeClaw internals. Printing the raw docker invocation forces users to understand and replicate them. `typeclaw log` owns that logic.
2. **Friendly preflight error.** When no container is running, docker's own error message is generic. The new command exits 1 with `Container <name> not found. Run \`typeclaw start\` first.` before ever calling docker.
3. **Matches the existing host-stage launcher set.** `start`, `stop`, `restart` all live in AGENTS.md as host-stage commands; `log` belongs beside them.

## Testing

```
bun test src/container src/cli   → 51/51 pass
bun run typecheck                → clean
bun run lint                     → 0 warnings, 0 errors
bun run format:check             → clean
```

Manual verification:
- `typeclaw --help` lists `log` in the subcommand list.
- `typeclaw log --help` shows `-f, --follow    stream new log output as it arrives (Default: false)`.
- `typeclaw log` in an agent folder with no running container exits 1 with `Container <name> not found. Run \`typeclaw start\` first.`

## Review notes

- The domain/CLI split mirrors `start`/`stop`: `src/container/logs.ts` owns logic and is directly unit-testable; `src/cli/log.ts` is a thin shell that handles I/O. This matches the "Test at the right layer" and "One function, one concern" principles in AGENTS.md.
- `stdio: 'inherit'` is the key design choice. Any pipe-based alternative would break live streaming and SIGINT propagation — the two things that make `log -f` useful. The comment in `logs.ts` explains this for future readers, consistent with the existing "why" comments in `src/container/shared.ts`.
- The `containerExists` preflight uses `docker inspect` rather than `docker ps`, same as `start`/`stop`. This shares the documented behavior of not being confused by `--rm` containers in the auto-removal window.

## What is intentionally not in this PR

- **`--tail N` or `--since`** — not needed to match the existing hint; can be added later without touching the domain/CLI split.
- **Container-stage `typeclaw log`** — the command is host-only by design; running it inside the container would be a no-op or a footgun.
- **Log streaming via the websocket/TUI** — out of scope; the TUI's existing stream panel covers the agent's own stdout.