### PR TITLE
Trigger memory-logger by transcript byte growth

### DIFF
--- a/plugins/memory/README.md
+++ b/plugins/memory/README.md
@@ -10,29 +10,31 @@ This plugin is **auto-loaded** by every TypeClaw agent. There is no `plugins[]` 
 {
   "memory": {
     "idleMs": 30000,
+    "bufferBytes": 100000,
     "dreaming": { "schedule": "0 4 * * *" }
   }
 }
 ```
 
-| Field                      | Default               | Effect                                                                                  |
-| -------------------------- | --------------------- | --------------------------------------------------------------------------------------- |
-| `memory.idleMs`            | `30000`               | Debounce window before `memory-logger` spawns after a prompt completes. Minimum `1000`. |
-| `memory.dreaming`          | omitted (no cron job) | When present, registers the dreaming cron job.                                          |
-| `memory.dreaming.schedule` | `"0 4 * * *"`         | Cron expression. Parsed via `cron-parser`.                                              |
+| Field                      | Default               | Effect                                                                                                                                                                                    |
+| -------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `memory.idleMs`            | `30000`               | Debounce window before `memory-logger` spawns after a prompt completes. Minimum `1000`.                                                                                                   |
+| `memory.bufferBytes`       | `100000`              | Size-based ceiling: spawns `memory-logger` when the transcript grows by this many bytes since the last run, even during continuous activity. `0` disables. Minimum `10000` when non-zero. |
+| `memory.dreaming`          | omitted (no cron job) | When present, registers the dreaming cron job.                                                                                                                                            |
+| `memory.dreaming.schedule` | `"0 4 * * *"`         | Cron expression. Parsed via `cron-parser`.                                                                                                                                                |
 
-Both fields are **restart-required** — the plugin reads them once at boot.
+All fields are **restart-required** — the plugin reads them once at boot.
 
 ## What it contributes
 
-| Kind     | Name                       | Notes                                                                                                                                                                                                                                                    |
-| -------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Subagent | `memory-logger`            | Reads a parent transcript past a watermark and appends fragments to `memory/<today>.md`. Coalesced per `parentSessionId`.                                                                                                                                |
-| Subagent | `dreaming`                 | Reads `MEMORY.md` plus undreamed daily-stream tails, rewrites `MEMORY.md`, optionally writes muscle-memory skills under `memory/skills/<name>/SKILL.md`, advances the per-day watermark, and `git commit -m Dream` the result. Coalesced per `agentDir`. |
-| Cron job | `__plugin_memory_dreaming` | `kind: 'prompt'`, `subagent: 'dreaming'`, scheduled per `memory.dreaming.schedule`.                                                                                                                                                                      |
-| Hook     | `session.prompt`           | Appends the rendered memory section (`# Memory`, `MEMORY.md`, undreamed stream tails) to `event.prompt`.                                                                                                                                                 |
-| Hook     | `session.idle`             | Per-session debouncer. Resets a `setTimeout(idleMs)` on every event; on fire, calls `ctx.spawnSubagent('memory-logger', ...)`.                                                                                                                           |
-| Hook     | `session.end`              | Cancels the debounce timer and immediately spawns `memory-logger` (so the final transcript is captured even when the user disconnects right away).                                                                                                       |
+| Kind     | Name                       | Notes                                                                                                                                                                                                                                                                             |
+| -------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Subagent | `memory-logger`            | Reads a parent transcript past a watermark and appends fragments to `memory/<today>.md`. Coalesced per `parentSessionId`.                                                                                                                                                         |
+| Subagent | `dreaming`                 | Reads `MEMORY.md` plus undreamed daily-stream tails, rewrites `MEMORY.md`, optionally writes muscle-memory skills under `memory/skills/<name>/SKILL.md`, advances the per-day watermark, and `git commit -m Dream` the result. Coalesced per `agentDir`.                          |
+| Cron job | `__plugin_memory_dreaming` | `kind: 'prompt'`, `subagent: 'dreaming'`, scheduled per `memory.dreaming.schedule`.                                                                                                                                                                                               |
+| Hook     | `session.prompt`           | Appends the rendered memory section (`# Memory`, `MEMORY.md`, undreamed stream tails) to `event.prompt`.                                                                                                                                                                          |
+| Hook     | `session.idle`             | Per-session debouncer with size-based ceiling. Resets a `setTimeout(idleMs)` on every event; on fire, calls `ctx.spawnSubagent('memory-logger', ...)`. Also `fs.stat`s the transcript on every event and spawns immediately when growth since the last run reaches `bufferBytes`. |
+| Hook     | `session.end`              | Cancels the debounce timer and immediately spawns `memory-logger` (so the final transcript is captured even when the user disconnects right away).                                                                                                                                |
 
 ## Files on disk
 
@@ -48,6 +50,8 @@ Both fields are **restart-required** — the plugin reads them once at boot.
 Core fires `session.idle` immediately after every `session.prompt()` completion (success or error). The plugin owns the debounce: it keeps a `Map<sessionId, Timeout>` and resets the timer on every event. When the timer fires, the plugin spawns `memory-logger` for that session.
 
 If the user starts a new prompt before the timer fires, the next `session.idle` event resets the timer. If the user disconnects, `session.end` cancels the timer and fires `memory-logger` immediately so the final transcript is captured.
+
+In channel sessions, the agent rarely goes idle long enough to trip the timer because new participant messages keep arriving. The size-based ceiling handles this: on every `session.idle` the plugin `fs.stat`s the transcript and compares against the size at the last memory-logger run. Once growth reaches `memory.bufferBytes`, the timer is cancelled and `memory-logger` spawns immediately. The watermark on the output side absorbs any over-firing — if a buffer-trip arrives on a transcript chunk that's all tool noise, `memory-logger` reads it, decides nothing is worth logging, advances the watermark, and exits.
 
 ## Migration notes (from before the plugin existed)
 

--- a/plugins/memory/index.test.ts
+++ b/plugins/memory/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { appendFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -197,5 +197,164 @@ describe('session.end hook', () => {
     await new Promise((r) => setTimeout(r, 1200))
 
     expect(spawned).toHaveLength(1)
+  })
+})
+
+describe('bufferBytes config', () => {
+  test('defaults to 100_000 when omitted', async () => {
+    const parsed = memoryPlugin.configSchema!.safeParse({})
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect((parsed.data as { bufferBytes: number }).bufferBytes).toBe(100_000)
+    }
+  })
+
+  test('accepts 0 to disable', async () => {
+    const parsed = memoryPlugin.configSchema!.safeParse({ bufferBytes: 0 })
+    expect(parsed.success).toBe(true)
+  })
+
+  test('rejects values between 1 and 9_999 (would thrash the subagent)', async () => {
+    await expect(bootMemoryPlugin(agentDir, { bufferBytes: 5000 })).rejects.toThrow()
+  })
+
+  test('accepts values >= 10_000', async () => {
+    const parsed = memoryPlugin.configSchema!.safeParse({ bufferBytes: 10_000 })
+    expect(parsed.success).toBe(true)
+  })
+
+  test('rejects negative values', async () => {
+    await expect(bootMemoryPlugin(agentDir, { bufferBytes: -1 })).rejects.toThrow()
+  })
+})
+
+describe('session.idle hook (buffer-bytes ceiling)', () => {
+  test('does NOT fire on the first idle event (initializes baseline)', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'x'.repeat(50_000))
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 60_000, bufferBytes: 10_000 })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }, ctx)
+
+    expect(spawned).toHaveLength(0)
+  })
+
+  test('fires synchronously when growth since last run reaches bufferBytes', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'x'.repeat(1000))
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 60_000, bufferBytes: 10_000 })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    // given: first idle initializes baseline at 1000 bytes
+    await exports.hooks!['session.idle']!(event, ctx)
+    expect(spawned).toHaveLength(0)
+
+    // when: transcript grows by 10_000 bytes and another idle fires
+    await appendFile(transcript, 'y'.repeat(10_000))
+    await exports.hooks!['session.idle']!(event, ctx)
+
+    // then: memory-logger spawns synchronously, before idleMs elapses
+    expect(spawned).toHaveLength(1)
+    expect(spawned[0]!.name).toBe('memory-logger')
+  })
+
+  test('does NOT fire when growth is below bufferBytes', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'x'.repeat(1000))
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 60_000, bufferBytes: 10_000 })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    await exports.hooks!['session.idle']!(event, ctx)
+    await appendFile(transcript, 'y'.repeat(9_999))
+    await exports.hooks!['session.idle']!(event, ctx)
+
+    expect(spawned).toHaveLength(0)
+  })
+
+  test('resets baseline after spawn so next ceiling requires another bufferBytes of growth', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, '')
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 60_000, bufferBytes: 10_000 })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    // given: baseline at 0 bytes
+    await exports.hooks!['session.idle']!(event, ctx)
+    expect(spawned).toHaveLength(0)
+
+    // when: 10_000 bytes appended → first trip
+    await appendFile(transcript, 'a'.repeat(10_000))
+    await exports.hooks!['session.idle']!(event, ctx)
+    expect(spawned).toHaveLength(1)
+
+    // and: only 5_000 more bytes appended → no second trip
+    await appendFile(transcript, 'b'.repeat(5_000))
+    await exports.hooks!['session.idle']!(event, ctx)
+    expect(spawned).toHaveLength(1)
+
+    // and: another 5_000 bytes (10_000 since last spawn) → second trip
+    await appendFile(transcript, 'c'.repeat(5_000))
+    await exports.hooks!['session.idle']!(event, ctx)
+    expect(spawned).toHaveLength(2)
+  })
+
+  test('disabled when bufferBytes is 0 (idle-only legacy behavior)', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'x'.repeat(1000))
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 60_000, bufferBytes: 0 })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    await exports.hooks!['session.idle']!(event, ctx)
+    await appendFile(transcript, 'y'.repeat(1_000_000))
+    await exports.hooks!['session.idle']!(event, ctx)
+
+    expect(spawned).toHaveLength(0)
+  })
+
+  test('fail-opens when transcript file does not exist (no spawn, no crash)', async () => {
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 60_000, bufferBytes: 10_000 })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = {
+      sessionId: 'ses_a',
+      parentTranscriptPath: join(agentDir, 'does-not-exist.jsonl'),
+      idleMs: 0,
+    }
+
+    await exports.hooks!['session.idle']!(event, ctx)
+    await exports.hooks!['session.idle']!(event, ctx)
+
+    expect(spawned).toHaveLength(0)
+  })
+
+  test('different sessions track buffers independently', async () => {
+    const transcriptA = join(agentDir, 'a.jsonl')
+    const transcriptB = join(agentDir, 'b.jsonl')
+    await writeFile(transcriptA, '')
+    await writeFile(transcriptB, '')
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 60_000, bufferBytes: 10_000 })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+
+    // given: baselines at 0 for both
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_a', parentTranscriptPath: transcriptA, idleMs: 0 }, ctx)
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_b', parentTranscriptPath: transcriptB, idleMs: 0 }, ctx)
+
+    // when: A grows by 10_000 but B does not
+    await appendFile(transcriptA, 'a'.repeat(10_000))
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_a', parentTranscriptPath: transcriptA, idleMs: 0 }, ctx)
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_b', parentTranscriptPath: transcriptB, idleMs: 0 }, ctx)
+
+    // then: only A's session triggered a spawn
+    expect(spawned).toHaveLength(1)
+    expect((spawned[0]!.payload as { parentSessionId: string }).parentSessionId).toBe('ses_a')
   })
 })

--- a/plugins/memory/index.ts
+++ b/plugins/memory/index.ts
@@ -1,3 +1,5 @@
+import { stat } from 'node:fs/promises'
+
 import { CronExpressionParser } from 'cron-parser'
 import { z } from 'zod'
 
@@ -8,6 +10,8 @@ import { loadMemory } from './load-memory'
 import { memoryLoggerSubagent, type MemoryLoggerPayload } from './memory-logger'
 
 const DEFAULT_IDLE_MS = 30_000
+const DEFAULT_BUFFER_BYTES = 100_000
+const MIN_BUFFER_BYTES = 10_000
 const DEFAULT_DREAMING_SCHEDULE = '0 4 * * *'
 
 function isValidCronExpression(schedule: string): boolean {
@@ -27,21 +31,37 @@ const dreamingConfigSchema = z.object({
     .refine(isValidCronExpression, { message: 'memory.dreaming.schedule must be a valid cron expression' }),
 })
 
+// `bufferBytes` is a size-based ceiling on top of the `idleMs` debounce. In
+// busy channel sessions the agent rarely goes idle long enough to trip the
+// timer, so memory-logger needs a second trigger that responds to accumulated
+// transcript volume. `0` disables the size trigger (idle-only legacy
+// behavior); any non-zero value must be >= 10_000 to avoid thrashing the
+// subagent on tiny conversations.
 const memoryConfigSchema = z
   .object({
     idleMs: z.number().int().min(1000).default(DEFAULT_IDLE_MS),
+    bufferBytes: z
+      .number()
+      .int()
+      .min(0)
+      .refine((n) => n === 0 || n >= MIN_BUFFER_BYTES, {
+        message: `memory.bufferBytes must be 0 (disabled) or >= ${MIN_BUFFER_BYTES}`,
+      })
+      .default(DEFAULT_BUFFER_BYTES),
     dreaming: dreamingConfigSchema.optional(),
   })
-  .default({ idleMs: DEFAULT_IDLE_MS })
+  .default({ idleMs: DEFAULT_IDLE_MS, bufferBytes: DEFAULT_BUFFER_BYTES })
 
 export default definePlugin({
   configSchema: memoryConfigSchema,
   plugin: async (ctx) => {
     const idleMs = ctx.config.idleMs
+    const bufferBytes = ctx.config.bufferBytes
     const dreamingSchedule = ctx.config.dreaming?.schedule
 
     const idleTimers = new Map<string, ReturnType<typeof setTimeout>>()
     const lastIdleEvent = new Map<string, { parentTranscriptPath: string | undefined }>()
+    const bytesAtLastRun = new Map<string, number>()
 
     const fireMemoryLogger = async (sessionId: string): Promise<void> => {
       const last = lastIdleEvent.get(sessionId)
@@ -51,6 +71,8 @@ export default definePlugin({
         parentTranscriptPath: last.parentTranscriptPath,
         agentDir: ctx.agentDir,
       }
+      const currentSize = await readSize(last.parentTranscriptPath)
+      bytesAtLastRun.set(sessionId, currentSize)
       try {
         await ctx.spawnSubagent('memory-logger', payload)
       } catch (err) {
@@ -64,6 +86,17 @@ export default definePlugin({
         clearTimeout(t)
         idleTimers.delete(sessionId)
       }
+    }
+
+    const shouldTripBufferCeiling = async (sessionId: string, transcriptPath: string): Promise<boolean> => {
+      if (bufferBytes === 0) return false
+      const currentSize = await readSize(transcriptPath)
+      const baseline = bytesAtLastRun.get(sessionId)
+      if (baseline === undefined) {
+        bytesAtLastRun.set(sessionId, currentSize)
+        return false
+      }
+      return currentSize - baseline >= bufferBytes
     }
 
     return {
@@ -93,7 +126,10 @@ export default definePlugin({
         // the plugin owns the debounce timer so memory-logger only spawns
         // after the user has been quiet for `idleMs`. Re-arming a still-armed
         // timer cancels it first, matching the previous core IdleDetector.
-        'session.idle': (event) => {
+        // The size-based ceiling fires synchronously when the transcript has
+        // grown by `bufferBytes` since the last run, so busy channel sessions
+        // (which rarely go idle) still produce memory updates.
+        'session.idle': async (event) => {
           lastIdleEvent.set(event.sessionId, { parentTranscriptPath: event.parentTranscriptPath })
           cancelTimer(event.sessionId)
           const sessionId = event.sessionId
@@ -102,13 +138,30 @@ export default definePlugin({
             void fireMemoryLogger(sessionId)
           }, idleMs)
           idleTimers.set(sessionId, timer)
+          if (
+            event.parentTranscriptPath !== undefined &&
+            (await shouldTripBufferCeiling(sessionId, event.parentTranscriptPath))
+          ) {
+            cancelTimer(sessionId)
+            await fireMemoryLogger(sessionId)
+          }
         },
         'session.end': async (event) => {
           cancelTimer(event.sessionId)
           await fireMemoryLogger(event.sessionId)
           lastIdleEvent.delete(event.sessionId)
+          bytesAtLastRun.delete(event.sessionId)
         },
       },
     }
   },
 })
+
+async function readSize(path: string): Promise<number> {
+  try {
+    const s = await stat(path)
+    return s.size
+  } catch {
+    return 0
+  }
+}


### PR DESCRIPTION
## Summary

In busy channel sessions (Slack/Discord with multiple participants), the `memory-logger` subagent rarely fires. The existing trigger is a 30-second idle debounce on `session.idle` — but continuous participant activity keeps resetting the timer, so the agent never goes idle long enough to trip it. Long stretches of conversation go unsummarized as a result.

This PR adds a **size-based ceiling** layered on top of the existing idle debounce, controlled by a new `memory.bufferBytes` field. On every `session.idle`, the plugin stats the parent transcript file and spawns `memory-logger` synchronously when growth since the last run reaches the threshold. The idle timer remains the fast path for quiet sessions; the byte ceiling catches busy ones.

## Changes

### `plugins/memory/index.ts`

- Adds `bufferBytes` to `memoryConfigSchema`: default `100_000` bytes (100 KB), minimum `10_000` when non-zero, `0` disables the ceiling entirely.
- Adds a per-session `bytesAtLastRun` Map to track the transcript size watermark after each `memory-logger` invocation.
- Adds `shouldTripBufferCeiling()` helper that stats the transcript and compares against the watermark.
- Wires the byte check into the `session.idle` handler: if the ceiling is reached, the idle timer is cancelled and `memory-logger` spawns synchronously rather than after the debounce delay.
- Adds `readSize()` helper with fail-open semantics: a missing transcript returns `0` and does not crash.

### `plugins/memory/index.test.ts`

12 new tests covering:

- Config validation: defaults, `0`-disable, minimum enforcement, negative-value rejection.
- First-idle baseline initialization (watermark is set without spawning).
- Synchronous trip when growth reaches the threshold.
- No-trip when growth is below the threshold.
- Watermark reset after a spawn so the next measurement starts fresh.
- Disabled mode (`bufferBytes: 0`) never trips.
- Fail-open on missing transcript files.
- Per-session independence (two sessions with different growth profiles do not interfere).

### `plugins/memory/README.md`

Documents the new `bufferBytes` field. Expands the `session.idle` section to explain the busy-channel motivation and the watermark-absorbs-overfiring property (if `session.idle` fires twice before the transcript actually grows, the second check is a cheap no-op).

## Why size-based instead of time-based

A time-based ceiling (e.g. `flushEveryMs`) bounds how long memory goes without a run, but lets arbitrary transcript volume accumulate between runs. `memory-logger` has a finite context window; bounding **input size** directly bounds cost and quality per invocation. The name `bufferBytes` was chosen to pair cleanly with `idleMs` — both are nouns describing thresholds, not verbs describing actions.

## Trigger matrix

| Session type | Trigger that fires |
|---|---|
| Quiet TUI session | `idleMs` (existing — unchanged) |
| TUI disconnect | `session.end` (existing — unchanged) |
| Busy channel, slow growth | `idleMs` during lulls |
| Busy channel, continuous activity | `bufferBytes` (new) — fires every ~100 KB of transcript |

## Backward compatibility

- Existing agents will start firing on byte growth at 100 KB by default. Agents that want strict legacy behavior can set `memory.bufferBytes: 0` in `typeclaw.json`.
- The schema change is additive; no existing field is removed or renamed.
- Restart-required per AGENTS.md plugin config rules — the plugin reads `bufferBytes` once at factory time.
- The existing `inFlightKey: parentSessionId` on `memory-logger` already coalesces races between the two triggers, so a simultaneous idle-debounce fire and a byte-ceiling fire for the same session cannot double-spawn.

## Testing

```
bun run typecheck    → clean
bun run lint         → 0 warnings, 0 errors
bun run format:check → clean
bun test             → 840 pass / 0 fail
```

The `bun test` count increased from 828 to 840 (12 new tests). The `typeclaw.schema.json` drift-guard test now passes because `scripts/generate-schema.ts` picked up `bufferBytes` automatically; the schema file is gitignored and not committed.

## Review notes

- `shouldTripBufferCeiling()` is the load-bearing new function. It reads the transcript size on every `session.idle` event, which is an `fs.stat` syscall — intentionally cheap. If this becomes a concern for high-frequency idle events, a debounce on the stat itself can be added without touching the surrounding logic.
- The fail-open path in `readSize()` means a session whose transcript disappears mid-run silently stops tripping the ceiling and falls back to the idle debounce. This is preferable to crashing or permanently disabling memory-logger for that session.
- The `bytesAtLastRun` Map is keyed by `sessionId`, same as the existing `timers` Map, and is cleared in the `session.end` hook alongside the timer cancellation to prevent leaks.
- The first `session.idle` call after session start sets the baseline watermark without spawning, so a session that loads a large pre-existing transcript does not immediately trip the ceiling on its first prompt.