### PR TITLE
Add CI workflow for typecheck, lint, and format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    name: typecheck / lint / format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Format check
+        run: bun run format:check


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow that runs the three mandatory pre-commit checks — typecheck, lint, and format — on every push to `main` and on every pull request targeting `main`. The workflow mirrors the checks enforced locally by the AGENTS.md policy, making it impossible for a failing check to land in `main` unnoticed.

## Changes

### `.github/workflows/ci.yml` (new)

- **Triggers:** `push` to `main`, `pull_request` against `main`.
- **Runner:** `ubuntu-latest`.
- **Setup:** `actions/checkout@v4` + `oven-sh/setup-bun@v2` (bun-version: `latest`).
- **Install:** `bun install --frozen-lockfile` — matches reproducibility expectations and will hard-fail if `bun.lock` is out of sync with `package.json`.
- **Single job `ci`** with display name `typecheck / lint / format`, three sequential steps:
  1. `bun run typecheck` — runs `tsgo --noEmit`.
  2. `bun run lint` — runs `oxlint`.
  3. `bun run format:check` — runs `oxfmt --check .`.

## Context

AGENTS.md already requires all three checks to pass before every commit. Without a CI gate, that requirement is enforced only by convention — a contributor who forgets (or skips) the checks locally can open a PR with a broken typecheck or mis-formatted file. This workflow closes that gap by running the same commands on GitHub-hosted infrastructure on every push and PR.

Steps are **sequential, not parallel**, by explicit design request. Keeping them as distinct steps means CI surfaces the exact failing step in the job summary rather than a combined log, making failures faster to diagnose.

## Why `format:check` and not `format`

`bun run format` runs `oxfmt .`, which writes files. Running a write command in CI would produce a dirty working tree with no observable effect on the build — the changes would be silently discarded after the job finishes. `format:check` runs `oxfmt --check .`, which exits non-zero if any file is mis-formatted without writing anything, which is the correct read-only verification behavior for CI.

## What is intentionally not included

`bun test` is **not** in this workflow. The user requested only typecheck / lint / format for this first workflow. Tests can be added in a follow-up PR as a separate job or step without touching this one.

## Testing

```
bun run typecheck    → clean (tsgo --noEmit, 0 errors)
bun run lint         → 0 warnings, 0 errors
bun run format:check → all files correctly formatted
```

Workflow syntax validated by GitHub Actions YAML schema. The workflow will self-verify on the first push to `ci/github-actions`.

## Review Notes

- The job name `ci` with display name `"typecheck / lint / format"` is what appears in the PR status checks UI. If future jobs are added (e.g. `test`), they should be separate jobs so each has its own green/red indicator in the PR.
- `bun-version: latest` tracks the same Bun that `bun install` in local dev uses. If a specific version pin is preferred for reproducibility, it can be set to a semver range (e.g. `1.x`) without other changes.
- `--frozen-lockfile` will surface lockfile drift immediately on CI rather than silently installing a different dependency tree. This is the intended behavior.