### PR TITLE
Fire session.idle/session.end for non-TUI sessions

### DIFF
--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -2,10 +2,29 @@ import { describe, expect, test } from 'bun:test'
 
 import { z } from 'zod'
 
+import type { HookBus } from '@/plugin'
 import { createStream } from '@/stream'
 
 import type { AgentSession } from './index'
 import { createSubagentConsumer, invokeSubagent, type Subagent, validateSubagentPayload } from './subagents'
+
+function makeFakeHookBus(events: string[]): HookBus {
+  return {
+    registerAll: () => {},
+    unregisterAll: () => {},
+    runSessionStart: async () => {},
+    runSessionEnd: async (e) => {
+      events.push(`end:${e.sessionId}`)
+    },
+    runSessionIdle: async (e) => {
+      events.push(`idle:${e.sessionId}:${e.parentTranscriptPath ?? '-'}`)
+    },
+    runSessionPrompt: async () => {},
+    runToolBefore: async () => undefined,
+    runToolAfter: async () => {},
+    count: () => 0,
+  }
+}
 
 function fakeSession(): { session: AgentSession; calls: { prompt: string[]; disposed: number } } {
   const calls = { prompt: [] as string[], disposed: 0 }
@@ -237,6 +256,54 @@ describe('invokeSubagent', () => {
       }),
     ).rejects.toThrow(/boom/)
     expect(calls.disposed).toBe(1)
+  })
+
+  test('fires session.idle and session.end on the supplied HookBus around runSession', async () => {
+    // given
+    const { session } = fakeSession()
+    const events: string[] = []
+    const hooks = makeFakeHookBus(events)
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+
+    // when
+    await invokeSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => ({
+        session,
+        hooks,
+        sessionId: 'sub-sess-1',
+        getTranscriptPath: () => '/tmp/sub-transcript.jsonl',
+      }),
+      agentDir: '/agent',
+      userPrompt: 'hi',
+    })
+
+    // then
+    expect(events).toEqual(['idle:sub-sess-1:/tmp/sub-transcript.jsonl', 'end:sub-sess-1'])
+  })
+
+  test('fires session.end even when the prompt throws so plugins can react to abnormal subagent termination', async () => {
+    // given
+    const events: string[] = []
+    const hooks = makeFakeHookBus(events)
+    const session = {
+      prompt: async () => {
+        throw new Error('subagent boom')
+      },
+      dispose: () => {},
+    } as unknown as AgentSession
+    const registry = { fragile: { systemPrompt: 'X' } satisfies Subagent }
+
+    // when / then
+    await expect(
+      invokeSubagent('fragile', {
+        registry,
+        createSessionForSubagent: async () => ({ session, hooks, sessionId: 'sub-boom' }),
+        agentDir: '/agent',
+        userPrompt: 'crash',
+      }),
+    ).rejects.toThrow(/subagent boom/)
+    expect(events).toEqual(['end:sub-boom'])
   })
 })
 

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -1,6 +1,7 @@
 import type { ToolDefinition } from '@mariozechner/pi-coding-agent'
 import type { z } from 'zod'
 
+import type { HookBus } from '@/plugin'
 import type { Stream, Unsubscribe } from '@/stream'
 
 import { type AgentSession, createSession } from './index'
@@ -48,7 +49,13 @@ function describePayload(payload: unknown): string {
   return typeof payload
 }
 
-export type CreateSessionForSubagentResult = { session: AgentSession; dispose?: () => Promise<void> }
+export type CreateSessionForSubagentResult = {
+  session: AgentSession
+  dispose?: () => Promise<void>
+  hooks?: HookBus
+  sessionId?: string
+  getTranscriptPath?: () => string | undefined
+}
 export type CreateSessionForSubagentOptions = {
   name?: string
   parentSessionId?: string
@@ -70,14 +77,31 @@ export const defaultCreateSessionForSubagent: CreateSessionForSubagent = (subage
     customTools: subagent.customTools ?? [],
   })
 
-function normalizeSubagentSession(result: AgentSession | CreateSessionForSubagentResult): {
+type NormalizedSubagentSession = {
   session: AgentSession
   dispose: () => Promise<void>
-} {
+  hooks: HookBus | undefined
+  sessionId: string | undefined
+  getTranscriptPath: (() => string | undefined) | undefined
+}
+
+function normalizeSubagentSession(result: AgentSession | CreateSessionForSubagentResult): NormalizedSubagentSession {
   if ('session' in result) {
-    return { session: result.session, dispose: result.dispose ?? (async () => {}) }
+    return {
+      session: result.session,
+      dispose: result.dispose ?? (async () => {}),
+      hooks: result.hooks,
+      sessionId: result.sessionId,
+      getTranscriptPath: result.getTranscriptPath,
+    }
   }
-  return { session: result, dispose: async () => {} }
+  return {
+    session: result,
+    dispose: async () => {},
+    hooks: undefined,
+    sessionId: undefined,
+    getTranscriptPath: undefined,
+  }
 }
 
 export type InvokeSubagentOptions = {
@@ -101,10 +125,22 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
   }
 
   const runSession: RunSession = async (override) => {
-    const { session, dispose } = normalizeSubagentSession(await createSessionForSubagent(subagent, sessionOptions))
+    const { session, dispose, hooks, sessionId, getTranscriptPath } = normalizeSubagentSession(
+      await createSessionForSubagent(subagent, sessionOptions),
+    )
     try {
       await session.prompt(override?.userPrompt ?? options.userPrompt)
+      if (hooks && sessionId !== undefined) {
+        await hooks.runSessionIdle({
+          sessionId,
+          parentTranscriptPath: getTranscriptPath?.(),
+          idleMs: 0,
+        })
+      }
     } finally {
+      if (hooks && sessionId !== undefined) {
+        await hooks.runSessionEnd({ sessionId })
+      }
       session.dispose()
       await dispose()
     }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import type { AgentSession } from '@/agent'
+import type { HookBus } from '@/plugin'
 
 import { loadChannelSessions } from './persistence'
 import { createChannelRouter, type ChannelRouter } from './router'
@@ -519,5 +520,126 @@ describe('ChannelRouter typing indicator', () => {
     router.unregisterTyping('discord-bot', cb)
     await router.__testing!.fireTypingHeartbeat(KEY)
     expect(calls).toHaveLength(1)
+  })
+})
+
+describe('ChannelRouter plugin lifecycle hooks', () => {
+  function makeRouterWithHooks(
+    agentDir: string,
+    events: string[],
+    options: { transcriptPath?: string } = {},
+  ): { router: ChannelRouter; sessions: FakeSession[] } {
+    const sessions: FakeSession[] = []
+    const hooks: HookBus = {
+      registerAll: () => {},
+      unregisterAll: () => {},
+      runSessionStart: async () => {},
+      runSessionEnd: async (e) => {
+        events.push(`end:${e.sessionId}`)
+      },
+      runSessionIdle: async (e) => {
+        events.push(`idle:${e.sessionId}:${e.parentTranscriptPath ?? '-'}`)
+      },
+      runSessionPrompt: async () => {},
+      runToolBefore: async () => undefined,
+      runToolAfter: async () => {},
+      count: () => 0,
+    }
+    const router = createChannelRouter({
+      agentDir,
+      configForAdapter: () => baseConfig,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        sessions.push(fake)
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: `ses_fake_${sessions.length}`,
+          dispose: async () => {
+            fake.dispose()
+          },
+          hooks,
+          getTranscriptPath: () => options.transcriptPath,
+        }
+      },
+    })
+    return { router, sessions }
+  }
+
+  test('fires session.idle after each prompt completion with the transcript path', async () => {
+    // given
+    const dir = await tempDir()
+    const events: string[] = []
+    const { router, sessions } = makeRouterWithHooks(dir, events, { transcriptPath: '/tmp/t.jsonl' })
+
+    // when
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(events).toEqual(['idle:ses_fake_1:/tmp/t.jsonl'])
+  })
+
+  test('fires session.idle even when prompt throws so plugins still wake up', async () => {
+    // given
+    const dir = await tempDir()
+    const events: string[] = []
+    const hooks: HookBus = {
+      registerAll: () => {},
+      unregisterAll: () => {},
+      runSessionStart: async () => {},
+      runSessionEnd: async (e) => {
+        events.push(`end:${e.sessionId}`)
+      },
+      runSessionIdle: async (e) => {
+        events.push(`idle:${e.sessionId}`)
+      },
+      runSessionPrompt: async () => {},
+      runToolBefore: async () => undefined,
+      runToolAfter: async () => {},
+      count: () => 0,
+    }
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        fake.prompt = async () => {
+          throw new Error('llm down')
+        }
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: 'ses_fake_throws',
+          dispose: async () => {},
+          hooks,
+          getTranscriptPath: () => undefined,
+        }
+      },
+    })
+
+    // when
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then
+    expect(events).toEqual(['idle:ses_fake_throws'])
+  })
+
+  test('fires session.end on stop() before disposing each live session', async () => {
+    // given
+    const dir = await tempDir()
+    const events: string[] = []
+    const { router, sessions } = makeRouterWithHooks(dir, events)
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when
+    await router.stop()
+
+    // then
+    expect(events).toEqual(['idle:ses_fake_1:-', 'end:ses_fake_1'])
+    expect(sessions[0]!.disposed).toBe(1)
   })
 })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2,6 +2,7 @@ import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession, type AgentSession } from '@/agent'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
+import type { HookBus } from '@/plugin'
 
 import { decideEngagement, grantStickyForReplyTargets, StickyLedger, type EngagementDecision } from './engagement'
 import { updateParticipants } from './participants'
@@ -43,7 +44,13 @@ export type CreateSessionForChannel = (params: {
   existingSessionId?: string
   participants: readonly ChannelParticipant[]
   origin: SessionOrigin
-}) => Promise<{ session: AgentSession; sessionId: string; dispose: () => Promise<void> }>
+}) => Promise<{
+  session: AgentSession
+  sessionId: string
+  dispose: () => Promise<void>
+  hooks?: HookBus
+  getTranscriptPath?: () => string | undefined
+}>
 
 export type ConfigForAdapter = (adapter: ChannelKey['adapter']) => ChannelAdapterConfig | undefined
 
@@ -71,6 +78,8 @@ type LiveSession = {
   session: AgentSession
   sessionId: string
   dispose: () => Promise<void>
+  hooks: HookBus | undefined
+  getTranscriptPath: (() => string | undefined) | undefined
   participants: ChannelParticipant[]
   promptQueue: QueuedInbound[]
   contextBuffer: ObservedInbound[]
@@ -231,6 +240,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         session: created.session,
         sessionId: created.sessionId,
         dispose: created.dispose,
+        hooks: created.hooks,
+        getTranscriptPath: created.getTranscriptPath,
         participants,
         promptQueue: [],
         contextBuffer: [],
@@ -323,6 +334,28 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.typingTimer = null
   }
 
+  const fireSessionIdle = async (live: LiveSession): Promise<void> => {
+    if (!live.hooks) return
+    try {
+      await live.hooks.runSessionIdle({
+        sessionId: live.sessionId,
+        parentTranscriptPath: live.getTranscriptPath?.(),
+        idleMs: 0,
+      })
+    } catch (err) {
+      logger.warn(`[channels] session.idle hook threw for ${live.keyId}: ${describe(err)}`)
+    }
+  }
+
+  const fireSessionEnd = async (live: LiveSession): Promise<void> => {
+    if (!live.hooks) return
+    try {
+      await live.hooks.runSessionEnd({ sessionId: live.sessionId })
+    } catch (err) {
+      logger.warn(`[channels] session.end hook threw for ${live.keyId}: ${describe(err)}`)
+    }
+  }
+
   const drain = async (live: LiveSession): Promise<void> => {
     if (live.draining || live.destroyed) return
     live.draining = true
@@ -362,6 +395,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           logger.warn(`[channels] ${live.keyId}: prompt threw: ${describe(err)}`)
           live.consecutiveSends.clear()
         }
+        await fireSessionIdle(live)
         live.lastTurnAuthorIds = new Set(live.currentTurnAuthorIds)
       }
     } finally {
@@ -564,6 +598,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       } catch (err) {
         logger.warn(`[channels] abort failed for ${live.keyId}: ${describe(err)}`)
       }
+      await fireSessionEnd(live)
       try {
         await live.dispose()
       } catch (err) {

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -3,10 +3,29 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import type { HookBus } from '@/plugin'
 import { createStream } from '@/stream'
 
 import { createCronConsumer, type CronConsumerLogger, type CronSession } from './consumer'
 import type { CronJob, ExecJob, PromptJob } from './schema'
+
+function fakeHooks(events: string[]): HookBus {
+  return {
+    registerAll: () => {},
+    unregisterAll: () => {},
+    runSessionStart: async () => {},
+    runSessionEnd: async (e) => {
+      events.push(`end:${e.sessionId}`)
+    },
+    runSessionIdle: async (e) => {
+      events.push(`idle:${e.sessionId}:${e.parentTranscriptPath ?? '-'}`)
+    },
+    runSessionPrompt: async () => {},
+    runToolBefore: async () => undefined,
+    runToolAfter: async () => {},
+    count: () => 0,
+  }
+}
 
 const silentLogger: CronConsumerLogger = { info: () => {}, warn: () => {}, error: () => {} }
 
@@ -392,6 +411,67 @@ describe('createCronConsumer', () => {
     await new Promise((r) => setImmediate(r))
 
     expect(factory.callsByJob.size).toBe(0)
+
+    consumer.stop()
+  })
+
+  test('fires session.idle and session.end on the supplied HookBus around each prompt run', async () => {
+    // given
+    const stream = createStream()
+    const events: string[] = []
+    const hooks = fakeHooks(events)
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: async () => ({
+        prompt: async (text: string) => {
+          events.push(`prompt:${text}`)
+        },
+        hooks,
+        sessionId: 'cron-sess-1',
+        getTranscriptPath: () => '/tmp/transcript-1.jsonl',
+      }),
+      logger: silentLogger,
+    })
+    consumer.start()
+
+    // when
+    publishCron(stream, promptJob('hooked', 'do work'))
+    await new Promise((r) => setImmediate(r))
+
+    // then
+    expect(events).toEqual(['prompt:do work', 'idle:cron-sess-1:/tmp/transcript-1.jsonl', 'end:cron-sess-1'])
+
+    consumer.stop()
+  })
+
+  test('fires session.end even when prompt throws so plugins can react to abnormal termination', async () => {
+    // given
+    const stream = createStream()
+    const events: string[] = []
+    const hooks = fakeHooks(events)
+    const errors: string[] = []
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: async () => ({
+        prompt: async () => {
+          throw new Error('llm down')
+        },
+        hooks,
+        sessionId: 'cron-boom',
+      }),
+      logger: { ...silentLogger, error: (m) => errors.push(m) },
+    })
+    consumer.start()
+
+    // when
+    publishCron(stream, promptJob('boom', 'go'))
+    await new Promise((r) => setImmediate(r))
+
+    // then
+    expect(events).toEqual(['end:cron-boom'])
+    expect(errors.some((e) => /llm down/.test(e))).toBe(true)
 
     consumer.stop()
   })

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -1,8 +1,21 @@
+import type { HookBus } from '@/plugin'
 import type { Stream, Unsubscribe } from '@/stream'
 
 import type { CronJob, ExecJob, PromptJob } from './schema'
 
-export type CronSession = { prompt: (text: string) => Promise<void>; dispose?: () => void }
+// `hooks`, `sessionId`, and `getTranscriptPath` are optional so test fakes can
+// stay one-liners. When present, the consumer fires `session.idle` after every
+// prompt completion and `session.end` on dispose, mirroring the lifecycle
+// signals the TUI server already emits in `src/server/index.ts`. Without this
+// the bundled memory plugin's debounced `memory-logger` never spawns for cron
+// prompt jobs because it only wakes on `session.idle`.
+export type CronSession = {
+  prompt: (text: string) => Promise<void>
+  dispose?: () => void
+  hooks?: HookBus
+  sessionId?: string
+  getTranscriptPath?: () => string | undefined
+}
 
 export type CronConsumerLogger = {
   info: (msg: string) => void
@@ -91,7 +104,17 @@ async function runPrompt(
   const session = await createSessionForCron(job)
   try {
     await session.prompt(job.prompt)
+    if (session.hooks && session.sessionId !== undefined) {
+      await session.hooks.runSessionIdle({
+        sessionId: session.sessionId,
+        parentTranscriptPath: session.getTranscriptPath?.(),
+        idleMs: 0,
+      })
+    }
   } finally {
+    if (session.hooks && session.sessionId !== undefined) {
+      await session.hooks.runSessionEnd({ sessionId: session.sessionId })
+    }
     session.dispose?.()
   }
 }

--- a/src/run/channel-session-factory.test.ts
+++ b/src/run/channel-session-factory.test.ts
@@ -266,4 +266,51 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
 
     expect(capturedSm).not.toBeNull()
   })
+
+  test('returns hooks and getTranscriptPath so the channel router can fire session.idle/session.end', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const runtime = makeRuntimeWithPlugin()
+
+    const factory = buildChannelSessionFactory({
+      cwd: tmp,
+      sessionFactory: makeFakeSessionFactory(join(tmp, 'sessions')),
+      stream: makeFakeStream(),
+      reloadRegistry: makeFakeReloadRegistry(),
+      pluginRuntime: runtime,
+      getChannelRouter: makeFakeRouter,
+      createSession: async () => STUB_SESSION,
+    })
+
+    const result = await factory({
+      key: { adapter: 'discord-bot', workspace: '@dm', chat: 'c1', thread: null },
+      participants: [],
+      origin: { kind: 'channel', adapter: 'discord-bot', workspace: '@dm', chat: 'c1', thread: null, participants: [] },
+    })
+
+    expect(result.hooks).toBe(runtime.get().hooks)
+    expect(typeof result.getTranscriptPath).toBe('function')
+    expect(result.getTranscriptPath?.()).toMatch(/sessions\//)
+  })
+
+  test('omits hooks when no plugin runtime content (matches existing plugin-omission policy)', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+
+    const factory = buildChannelSessionFactory({
+      cwd: tmp,
+      sessionFactory: makeFakeSessionFactory(join(tmp, 'sessions')),
+      stream: makeFakeStream(),
+      reloadRegistry: makeFakeReloadRegistry(),
+      pluginRuntime: makeEmptyRuntime(),
+      getChannelRouter: makeFakeRouter,
+      createSession: async () => STUB_SESSION,
+    })
+
+    const result = await factory({
+      key: { adapter: 'discord-bot', workspace: '@dm', chat: 'c1', thread: null },
+      participants: [],
+      origin: { kind: 'channel', adapter: 'discord-bot', workspace: '@dm', chat: 'c1', thread: null, participants: [] },
+    })
+
+    expect(result.hooks).toBeUndefined()
+  })
 })

--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -65,6 +65,8 @@ export function buildChannelSessionFactory(deps: BuildChannelSessionFactoryDeps)
       dispose: async () => {
         session.dispose()
       },
+      ...(snap.hasAnyPluginContent ? { hooks: snap.hooks } : {}),
+      getTranscriptPath: () => sessionManager.getSessionFile(),
     }
   }
 }

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -132,7 +132,7 @@ export async function startAgent({
     const entry = snap.pluginSubagentByShim.get(subagent)
     if (entry) {
       const sessionId = `subagent-${entry.pluginName}-${crypto.randomUUID()}`
-      return createSessionWithDispose({
+      const created = await createSessionWithDispose({
         systemPromptOverride: entry.pluginSubagent.systemPrompt,
         channelRouter: channelManager.router,
         origin: {
@@ -153,6 +153,11 @@ export async function startAgent({
           toolNamePrefix: `__plugin_${entry.pluginName}_${entry.subagentName}`,
         },
       })
+      return {
+        ...created,
+        hooks: snap.hooks,
+        sessionId,
+      }
     }
     return defaultCreateSessionForSubagent(subagent, subagentOptions)
   }
@@ -180,11 +185,13 @@ export async function startAgent({
   const cronConsumer = createCronConsumer({
     stream,
     cwd,
-    createSessionForCron: (job) => {
+    createSessionForCron: async (job) => {
       const snap = pluginRuntime.get()
-      return createSession({
+      const sessionManager = SessionManager.create(cwd, sessionFactory.sessionDir())
+      const sessionId = sessionManager.getSessionId()
+      const session = await createSession({
         reloadRegistry,
-        sessionManager: SessionManager.create(cwd, sessionFactory.sessionDir()),
+        sessionManager,
         stream,
         channelRouter: channelManager.router,
         origin: { kind: 'cron', jobId: job.id, jobKind: 'prompt' },
@@ -193,12 +200,19 @@ export async function startAgent({
               plugins: {
                 registry: snap.registry,
                 hooks: snap.hooks,
-                sessionId: `cron-${crypto.randomUUID()}`,
+                sessionId,
                 agentDir: cwd,
               },
             }
           : {}),
       })
+      return {
+        prompt: (text) => session.prompt(text),
+        dispose: () => session.dispose(),
+        sessionId,
+        ...(snap.hasAnyPluginContent ? { hooks: snap.hooks } : {}),
+        getTranscriptPath: () => sessionManager.getSessionFile(),
+      }
     },
   })
 


### PR DESCRIPTION
## Summary

The bundled memory plugin's `memory-logger` subagent never spawned for channel (Slack/Discord), cron prompt, or subagent sessions. Those entry points called `session.prompt()` and disposed the session without ever firing `session.idle` or `session.end` — the two hooks the plugin's idle debounce depends on. A winky-style Slack-bot agent could burn through a full day of sessions and produce zero `memory/yyyy-MM-dd.md` files; the `memory/` directory only appeared on disk at all because the 4 AM dreaming cron creates it as a side effect of writing `.dreaming-state.json`.

The TUI WebSocket server has been firing both hooks correctly all along (`src/server/index.ts` lines 208 and 319). This PR brings the three other lifecycle owners up to the same contract documented in `src/skills/typeclaw-plugins/SKILL.md:289`: "session.idle fires after every prompt completion (success or error)."

## Changes

### `src/channels/router.ts`

- `drain()` calls `runSessionIdle` with the persisted transcript path after each `live.session.prompt(text)`.
- `stop()` calls `runSessionEnd` for every live session before disposing it, so a graceful shutdown is observed by plugins.

### `src/cron/consumer.ts`

- `runPrompt()` calls `runSessionIdle` after the prompt resolves and `runSessionEnd` in the `finally` block, so plugin hooks fire even on abnormal termination.

### `src/agent/subagents.ts`

- `invokeSubagent`'s `runSession` applies the same idle-then-end pattern around `session.prompt(...)`.

### Session factory plumbing (`src/run/index.ts`, `src/run/channel-session-factory.ts`)

To plumb the hooks through, the per-call-site session factories now return optional `hooks: HookBus`, `sessionId: string`, and `getTranscriptPath: () => string | undefined` alongside the existing `session`/`dispose` pair. Test factories that don't care about lifecycle simply omit the new fields, which is why all existing tests keep passing untouched.

## Tests

Each fixed call site received two new composition-level tests (per the AGENTS.md testing philosophy — composition must be verified, not just individual steps):

| File | Tests |
|---|---|
| `src/cron/consumer.test.ts` | Happy path (`prompt → idle → end`); throw path (`end` still fires). |
| `src/agent/subagents.test.ts` | Same two cases for `invokeSubagent`, including `runSession` rejection. |
| `src/channels/router.test.ts` | New `plugin lifecycle hooks` describe block: idle after debounce drain, idle when `prompt()` throws, end during `stop()` ahead of dispose. |
| `src/run/channel-session-factory.test.ts` | Production factory returns `hooks`/`getTranscriptPath` when plugin runtime has content; omits `hooks` when it does not. |

501 tests pass across all affected directories (`src/cron`, `src/agent`, `src/channels`, `plugins/memory`, `src/run/channel-session-factory.test.ts`). `bun run typecheck`, `bun run lint`, and `bun run format` are all clean.

## Why call sites instead of centralizing in AgentSession

The architecturally cleaner path would be to make `AgentSession.prompt()` itself fire the hooks so no caller can forget. That approach was considered and deferred because it touches the TUI drain-loop ordering invariants — specifically the `prompt_started`/queued-prompt rendering contract documented in AGENTS.md (the wire protocol depends on when `prompt_started` is emitted relative to the `await session.prompt()` call). The current approach is minimum-risk: each lifecycle owner fires its own hooks at the same point it already controls. If a future refactor centralizes this in `AgentSession`, all four call sites become trivial to port.

## Review notes

- The new `hooks` / `sessionId` / `getTranscriptPath` fields on the factory return type are all optional. Callers that don't inject a plugin runtime receive `undefined` and skip the hook calls — no behavioral change for existing tests or configurations.
- The `finally`-wrapping pattern in cron and subagents matches the TUI server's own `session.end` pattern (`src/server/index.ts:208`). Consistency here is intentional.
- `channel-session-factory.test.ts` is a new file rather than an extension of an existing test because the factory itself is new in this PR; it asserts the production wiring rather than the hook behavior (which is already covered per-call-site).