### PR TITLE
Add channel_reply tool to prevent thread-dropping on replies

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -25,6 +25,7 @@ import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
 import { renderSessionOrigin, type SessionOrigin } from './session-origin'
 import { DEFAULT_SYSTEM_PROMPT } from './system-prompt'
+import { createChannelReplyTool } from './tools/channel-reply'
 import { createChannelSendTool } from './tools/channel-send'
 import { createStreamSnapshotTool } from './tools/stream-snapshot'
 import { webfetchTool } from './tools/webfetch'
@@ -122,7 +123,36 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
             webfetchTool,
             ...(options.reloadRegistry ? [createReloadTool({ registry: options.reloadRegistry })] : []),
             ...(options.stream ? [createStreamSnapshotTool({ stream: options.stream })] : []),
-            ...(options.channelRouter ? [createChannelSendTool({ router: options.channelRouter })] : []),
+            ...(options.channelRouter
+              ? [
+                  ...(options.origin?.kind === 'channel'
+                    ? [
+                        createChannelReplyTool({
+                          router: options.channelRouter,
+                          origin: {
+                            adapter: options.origin.adapter,
+                            workspace: options.origin.workspace,
+                            chat: options.origin.chat,
+                            thread: options.origin.thread,
+                          },
+                        }),
+                      ]
+                    : []),
+                  createChannelSendTool({
+                    router: options.channelRouter,
+                    ...(options.origin?.kind === 'channel'
+                      ? {
+                          origin: {
+                            adapter: options.origin.adapter,
+                            workspace: options.origin.workspace,
+                            chat: options.origin.chat,
+                            thread: options.origin.thread,
+                          },
+                        }
+                      : {}),
+                  }),
+                ]
+              : []),
             ...pluginCustomTools,
           ]
 

--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -29,7 +29,7 @@ describe('renderSessionOrigin', () => {
     expect(out).toContain('Stay narrowly within')
   })
 
-  test('channel origin emits the addressing fields verbatim and channel_send guidance', () => {
+  test('channel origin shows the addressing fields and points at channel_reply by default', () => {
     const out = renderSessionOrigin({
       kind: 'channel',
       adapter: 'discord-bot',
@@ -41,12 +41,13 @@ describe('renderSessionOrigin', () => {
     expect(out).toContain('"adapter": "discord-bot"')
     expect(out).toContain('"workspace": "111"')
     expect(out).toContain('"chat": "222"')
+    expect(out).toContain('channel_reply')
     expect(out).toContain('channel_send')
     expect(out).toContain('<@USER_ID>')
     expect(out).toContain('Be concise')
   })
 
-  test('channel origin omits thread field when origin.thread is null (matches channel_send schema)', () => {
+  test('channel origin renders thread:null verbatim for channel-root sessions', () => {
     const out = renderSessionOrigin({
       kind: 'channel',
       adapter: 'discord-bot',
@@ -54,10 +55,11 @@ describe('renderSessionOrigin', () => {
       chat: '999',
       thread: null,
     })
-    expect(out).not.toContain('"thread"')
+    expect(out).toContain('"thread": null')
+    expect(out).toContain('channel-root session')
   })
 
-  test('channel origin includes thread field when origin.thread is set', () => {
+  test('channel origin includes thread field with the actual id when origin.thread is set', () => {
     const out = renderSessionOrigin({
       kind: 'channel',
       adapter: 'discord-bot',
@@ -68,7 +70,7 @@ describe('renderSessionOrigin', () => {
     expect(out).toContain('"thread": "t-1"')
   })
 
-  test('channel origin obligates a channel_send call so the model never finishes silently', () => {
+  test('channel origin obligates a tool call so the model never finishes silently', () => {
     const out = renderSessionOrigin({
       kind: 'channel',
       adapter: 'discord-bot',
@@ -76,8 +78,25 @@ describe('renderSessionOrigin', () => {
       chat: '999',
       thread: null,
     })
-    expect(out).toMatch(/MUST call `channel_send`/)
+    expect(out).toMatch(/MUST call `channel_reply`/)
     expect(out).toContain('Plain-text output is invisible')
+  })
+
+  test('channel origin teaches channel_reply as the default and channel_send as the escape hatch', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: '1700000000.000100',
+    })
+    expect(out).toContain('channel_reply({ text })')
+    expect(out).toContain("don't")
+    expect(out).toMatch(/post somewhere else/i)
+    const replyIdx = out.indexOf('`channel_reply`')
+    const sendIdx = out.indexOf('`channel_send`')
+    expect(replyIdx).toBeGreaterThan(-1)
+    expect(sendIdx).toBeGreaterThan(-1)
   })
 
   test('channel origin renders @dm sentinel verbatim', () => {

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -97,41 +97,49 @@ function renderChannelOrigin(
   // that obligation crisp and pre-filling the addressing fields removed a
   // class of "model finishes silently, no reply ever lands" failures that we
   // could only see in the logs as `prompted` followed by no `outbound`.
+  //
+  // The original wording told the model to call channel_send and copy
+  // adapter/workspace/chat/thread verbatim. Models still routinely dropped
+  // `thread`, so the same conversation got bisected into a fresh top-level
+  // thread on Slack. channel_reply now exists for that reason: it takes
+  // only `text` and pulls addressing from this origin. We point the model at
+  // it as the default, and keep channel_send as the escape hatch for posting
+  // elsewhere (different chat, breaking out of the thread on purpose, etc.).
   const platform = origin.adapter === 'slack-bot' ? 'Slack' : 'Discord'
-  const lines = [
+  const lines: string[] = [
     '## Session origin',
     '',
     `You are responding inside a ${platform} channel session. There is no human`,
     'attached to a console here — your only way to communicate with the user',
-    'is the `channel_send` tool. Plain-text output is invisible.',
+    'is a tool call. Plain-text output is invisible.',
     '',
-    '**For every user message in this session, you MUST call `channel_send`',
-    'at least once before ending your turn**, unless the user explicitly told',
-    'you to stay silent. If you have nothing substantive to say, send a brief',
-    'acknowledgement. Never end a turn with a silent observation.',
+    '**For every user message in this session, you MUST call `channel_reply`',
+    '(or `channel_send`) at least once before ending your turn**, unless the',
+    'user explicitly told you to stay silent. If you have nothing substantive',
+    'to say, send a brief acknowledgement. Never end a turn with a silent',
+    'observation.',
     '',
-    'Reply to this conversation by calling `channel_send` with exactly these',
-    'fields (copy verbatim):',
+    'To reply in this conversation, call `channel_reply({ text })`. Addressing',
+    `is filled in from this session, including the thread${origin.thread !== null ? '' : ' (none here — this is a channel-root session)'}, so you don't`,
+    'need to copy any of these fields:',
     '',
     '```json',
     '{',
     `  "adapter": ${JSON.stringify(origin.adapter)},`,
     `  "workspace": ${JSON.stringify(origin.workspace)},`,
     `  "chat": ${JSON.stringify(origin.chat)},`,
-    origin.thread !== null ? `  "thread": ${JSON.stringify(origin.thread)},` : null,
-    '  "text": "<your reply here>"',
+    origin.thread !== null ? `  "thread": ${JSON.stringify(origin.thread)}` : '  "thread": null',
     '}',
     '```',
-  ].filter((l): l is string => l !== null)
-
-  lines.push(
     '',
-    'To post somewhere else, change the addressing fields — but only chats',
+    'To post somewhere else (different chat, break out of the current',
+    'thread on purpose, send a DM from this channel session, etc.), use',
+    '`channel_send` and pass the addressing fields explicitly. Only chats',
     "matching the channel's `allow` rules are accepted (the tool returns",
     '`{ ok: false }` otherwise).',
     '',
     `To mention someone in your reply, use ${platform} syntax \`<@USER_ID>\`.`,
-  )
+  ]
 
   const participantsBlock = renderParticipants(origin.participants ?? [], now)
   if (participantsBlock) lines.push('', participantsBlock)

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { ChannelRouter } from '@/channels/router'
+import type { OutboundMessage, SendResult } from '@/channels/types'
+
+import { createChannelReplyTool, type ChannelReplyOrigin } from './channel-reply'
+
+function fakeRouter(
+  handler: (msg: OutboundMessage) => Promise<SendResult>,
+  options: { consecutiveCount?: number } = {},
+): ChannelRouter {
+  return {
+    route: async () => {},
+    send: handler,
+    getConsecutiveSendCount: () => options.consecutiveCount ?? 0,
+    registerOutbound: () => {},
+    unregisterOutbound: () => {},
+    registerTyping: () => {},
+    unregisterTyping: () => {},
+    stop: async () => {},
+    liveCount: () => 0,
+  }
+}
+
+const slackThreadOrigin: ChannelReplyOrigin = {
+  adapter: 'slack-bot',
+  workspace: 'T0',
+  chat: 'C0',
+  thread: '1700000000.000100',
+}
+
+const slackChannelRootOrigin: ChannelReplyOrigin = {
+  adapter: 'slack-bot',
+  workspace: 'T0',
+  chat: 'C0',
+  thread: null,
+}
+
+const fakeCtx = {} as Parameters<ReturnType<typeof createChannelReplyTool>['execute']>[4]
+
+async function runTool(
+  tool: ReturnType<typeof createChannelReplyTool>,
+  params: Parameters<ReturnType<typeof createChannelReplyTool>['execute']>[1],
+) {
+  return tool.execute('id', params, undefined, undefined, fakeCtx)
+}
+
+describe('createChannelReplyTool', () => {
+  test('addresses the message from the origin and forwards text to router.send', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async (msg) => {
+        calls.push(msg)
+        return { ok: true }
+      }),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, { text: 'hi' })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toEqual({
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: '1700000000.000100',
+      text: 'hi',
+    })
+    expect(result.details).toEqual({ ok: true })
+  })
+
+  test('passes thread=null verbatim when origin is a channel-root session', async () => {
+    const captured: { thread: string | null | undefined } = { thread: undefined }
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async (msg) => {
+        captured.thread = msg.thread ?? null
+        return { ok: true }
+      }),
+      origin: slackChannelRootOrigin,
+    })
+    await runTool(tool, { text: 'top-level' })
+    expect(captured.thread).toBeNull()
+  })
+
+  test('reports the origin chat in the success message', async () => {
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => ({ ok: true })),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, { text: 'hi' })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toBe('posted to slack-bot:T0/C0')
+  })
+
+  test('reports denial back to the agent without throwing', async () => {
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => ({ ok: false, error: 'denied by allow rules' })),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, { text: 'nope' })
+    expect(result.details).toEqual({ ok: false, error: 'denied by allow rules' })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('channel_reply denied')
+    expect(text).toContain('denied by allow rules')
+  })
+
+  test('second consecutive reply appends a soft yield hint', async () => {
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => ({ ok: true }), { consecutiveCount: 2 }),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, { text: 'continuing' })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('posted to slack-bot:T0/C0')
+    expect(text).toContain('2nd consecutive message')
+  })
+
+  test('queries consecutive send count using the origin thread, not a hardcoded null', async () => {
+    const queriedKeys: { adapter: string; workspace: string; chat: string; thread: string | null | undefined }[] = []
+    const tool = createChannelReplyTool({
+      router: {
+        ...fakeRouter(async () => ({ ok: true })),
+        getConsecutiveSendCount: (key) => {
+          queriedKeys.push({ adapter: key.adapter, workspace: key.workspace, chat: key.chat, thread: key.thread })
+          return 0
+        },
+      },
+      origin: slackThreadOrigin,
+    })
+    await runTool(tool, { text: 'hi' })
+    expect(queriedKeys).toHaveLength(1)
+    expect(queriedKeys[0]).toEqual({
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: '1700000000.000100',
+    })
+  })
+
+  test('denied replies never carry the consecutive hint suffix', async () => {
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => ({ ok: false, error: 'denied by allow rules' }), { consecutiveCount: 7 }),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, { text: 'no' })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('denied')
+    expect(text).not.toContain('consecutive')
+  })
+
+  test('schema rejects empty text via tool definition (smoke check on parameters)', () => {
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => ({ ok: true })),
+      origin: slackThreadOrigin,
+    })
+    expect(tool.name).toBe('channel_reply')
+    expect(tool.label).toBe('Channel Reply')
+    expect(tool.description).toContain('default way to respond')
+  })
+})

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -1,0 +1,83 @@
+import { Type } from '@mariozechner/pi-ai'
+import { defineTool } from '@mariozechner/pi-coding-agent'
+
+import type { ChannelRouter } from '@/channels/router'
+import type { AdapterId } from '@/channels/schema'
+
+export type ChannelReplyOrigin = {
+  adapter: AdapterId
+  workspace: string
+  chat: string
+  thread: string | null
+}
+
+export type CreateChannelReplyToolOptions = {
+  router: ChannelRouter
+  origin: ChannelReplyOrigin
+}
+
+// channel_reply is the happy-path companion to channel_send for channel-routed
+// sessions. The session's origin already pins the conversation we're inside
+// (adapter, workspace, chat, thread), so the model shouldn't have to copy
+// those fields verbatim every turn — that copying is exactly where it has
+// historically dropped `thread` and posted to channel root by accident.
+//
+// channel_reply takes only `text` and addresses the message from the origin.
+// channel_send remains for posting somewhere else (different chat, breaking
+// out of a thread, sending DMs from a channel session, etc.).
+export function createChannelReplyTool({ router, origin }: CreateChannelReplyToolOptions) {
+  return defineTool({
+    name: 'channel_reply',
+    label: 'Channel Reply',
+    description:
+      'Reply in the current conversation. This is your default way to respond to a channel session — ' +
+      'addressing fields (adapter, workspace, chat, thread) are filled in from the session origin, so ' +
+      'you only supply the text. To post somewhere else (different chat, break out of the current ' +
+      'thread, etc.), use `channel_send` instead.',
+    parameters: Type.Object({
+      text: Type.String({
+        description: 'The message body. Use platform mention syntax `<@USER_ID>` for Slack/Discord mentions.',
+        minLength: 1,
+      }),
+    }),
+
+    async execute(_toolCallId, params) {
+      const result = await router.send({
+        adapter: origin.adapter,
+        workspace: origin.workspace,
+        chat: origin.chat,
+        thread: origin.thread,
+        text: params.text,
+      })
+
+      const details: { ok: boolean; error?: string } = result.ok ? { ok: true } : { ok: false, error: result.error }
+      const baseText = result.ok
+        ? `posted to ${origin.adapter}:${origin.workspace}/${origin.chat}`
+        : `channel_reply denied: ${result.error}`
+      const hint = result.ok
+        ? consecutiveSendHint(
+            router.getConsecutiveSendCount({
+              adapter: origin.adapter,
+              workspace: origin.workspace,
+              chat: origin.chat,
+              thread: origin.thread,
+            }),
+          )
+        : ''
+      return {
+        content: [{ type: 'text' as const, text: hint ? `${baseText} — ${hint}` : baseText }],
+        details,
+      }
+    },
+  })
+}
+
+// Mirror of the same hint used by channel_send. Kept identical so the model
+// sees the same yield signal regardless of which tool it picked.
+function consecutiveSendHint(countAfterSend: number): string {
+  if (countAfterSend <= 1) return ''
+  if (countAfterSend === 2) {
+    return 'this is your 2nd consecutive message in this conversation; continue only if the reply genuinely needs splitting.'
+  }
+  return `${countAfterSend}th consecutive message with no user reply; end your turn now unless the user explicitly asked for a multi-step response.`
+}

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -150,4 +150,112 @@ describe('createChannelSendTool', () => {
     expect(text).toContain('denied')
     expect(text).not.toContain('consecutive')
   })
+
+  describe('thread-mismatch hint', () => {
+    test('warns when posting to the same conversation as origin but dropping the thread', async () => {
+      const tool = createChannelSendTool({
+        router: fakeRouter(async () => ({ ok: true })),
+        origin: { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: '1700000000.000100' },
+      })
+      const result = await runTool(tool, { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', text: 'oops' })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toContain('posted to slack-bot:T0/C0')
+      expect(text).toContain('origin thread is "1700000000.000100"')
+      expect(text).toContain('channel root')
+      expect(text).toContain('channel_reply')
+    })
+
+    test('does NOT warn when the model passes the matching thread explicitly', async () => {
+      const tool = createChannelSendTool({
+        router: fakeRouter(async () => ({ ok: true })),
+        origin: { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: '1700000000.000100' },
+      })
+      const result = await runTool(tool, {
+        adapter: 'slack-bot',
+        workspace: 'T0',
+        chat: 'C0',
+        thread: '1700000000.000100',
+        text: 'in thread',
+      })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toBe('posted to slack-bot:T0/C0')
+    })
+
+    test('does NOT warn when the model deliberately posts to a DIFFERENT chat', async () => {
+      const tool = createChannelSendTool({
+        router: fakeRouter(async () => ({ ok: true })),
+        origin: { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: '1700000000.000100' },
+      })
+      const result = await runTool(tool, {
+        adapter: 'slack-bot',
+        workspace: 'T0',
+        chat: 'C-other',
+        text: 'cross-channel post',
+      })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toBe('posted to slack-bot:T0/C-other')
+    })
+
+    test('does NOT warn when the origin had no thread to begin with (channel-root origin)', async () => {
+      const tool = createChannelSendTool({
+        router: fakeRouter(async () => ({ ok: true })),
+        origin: { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null },
+      })
+      const result = await runTool(tool, {
+        adapter: 'slack-bot',
+        workspace: 'T0',
+        chat: 'C0',
+        text: 'channel-root reply',
+      })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toBe('posted to slack-bot:T0/C0')
+    })
+
+    test('does NOT warn when no origin is supplied (cron / non-channel session)', async () => {
+      const tool = createChannelSendTool({
+        router: fakeRouter(async () => ({ ok: true })),
+      })
+      const result = await runTool(tool, { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', text: 'cron post' })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toBe('posted to slack-bot:T0/C0')
+    })
+
+    test('does NOT warn on adapter mismatch (cross-platform post)', async () => {
+      const tool = createChannelSendTool({
+        router: fakeRouter(async () => ({ ok: true })),
+        origin: { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: '1700000000.000100' },
+      })
+      const result = await runTool(tool, {
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'd1',
+        text: 'cross-platform',
+      })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toBe('posted to discord-bot:g1/d1')
+    })
+
+    test('combines with the consecutive-send hint when both fire', async () => {
+      const tool = createChannelSendTool({
+        router: fakeRouter(async () => ({ ok: true }), { consecutiveCount: 2 }),
+        origin: { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: '1700000000.000100' },
+      })
+      const result = await runTool(tool, { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', text: 'oops twice' })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toContain('posted to slack-bot:T0/C0')
+      expect(text).toContain('2nd consecutive message')
+      expect(text).toContain('origin thread is "1700000000.000100"')
+    })
+
+    test('does not fire on a denied send even when addressing matches', async () => {
+      const tool = createChannelSendTool({
+        router: fakeRouter(async () => ({ ok: false, error: 'denied' })),
+        origin: { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: '1700000000.000100' },
+      })
+      const result = await runTool(tool, { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', text: 'no' })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toContain('denied')
+      expect(text).not.toContain('origin thread')
+    })
+  })
 })

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -4,11 +4,24 @@ import { defineTool } from '@mariozechner/pi-coding-agent'
 import type { ChannelRouter } from '@/channels/router'
 import { ADAPTER_IDS, type AdapterId } from '@/channels/schema'
 
-export type CreateChannelSendToolOptions = {
-  router: ChannelRouter
+export type ChannelSendOrigin = {
+  adapter: AdapterId
+  workspace: string
+  chat: string
+  thread: string | null
 }
 
-export function createChannelSendTool({ router }: CreateChannelSendToolOptions) {
+export type CreateChannelSendToolOptions = {
+  router: ChannelRouter
+  // Optional channel origin for the session this tool is wired into. When
+  // present, the tool can detect "you posted to the same conversation but
+  // dropped the thread" and surface that as a hint in the tool result, so
+  // the model can self-correct on its next turn. Absent for sessions whose
+  // origin isn't a channel (e.g. cron prompts that send to channels).
+  origin?: ChannelSendOrigin
+}
+
+export function createChannelSendTool({ router, origin }: CreateChannelSendToolOptions) {
   return defineTool({
     name: 'channel_send',
     label: 'Channel Send',
@@ -62,22 +75,59 @@ export function createChannelSendTool({ router }: CreateChannelSendToolOptions) 
       const baseText = result.ok
         ? `posted to ${params.adapter}:${params.workspace}/${params.chat}`
         : `channel_send denied: ${result.error}`
-      const hint = result.ok
-        ? consecutiveSendHint(
-            router.getConsecutiveSendCount({
-              adapter,
-              workspace: params.workspace,
-              chat: params.chat,
-              thread: params.thread ?? null,
-            }),
-          )
-        : ''
+      const hints: string[] = []
+      if (result.ok) {
+        const consecutive = consecutiveSendHint(
+          router.getConsecutiveSendCount({
+            adapter,
+            workspace: params.workspace,
+            chat: params.chat,
+            thread: params.thread ?? null,
+          }),
+        )
+        if (consecutive) hints.push(consecutive)
+
+        const threadMismatch = threadMismatchHint(origin, {
+          adapter,
+          workspace: params.workspace,
+          chat: params.chat,
+          thread: params.thread,
+        })
+        if (threadMismatch) hints.push(threadMismatch)
+      }
+      const text = hints.length > 0 ? `${baseText} — ${hints.join(' ')}` : baseText
       return {
-        content: [{ type: 'text' as const, text: hint ? `${baseText} — ${hint}` : baseText }],
+        content: [{ type: 'text' as const, text }],
         details,
       }
     },
   })
+}
+
+// Returns a behavioral hint when the model posted to the SAME conversation
+// as the session's origin (same adapter+workspace+chat) but DROPPED the
+// thread. This catches the "model forgot to copy thread verbatim" failure
+// mode without blocking legitimate intent — if leaving the thread was on
+// purpose ("새 스레드에서 시작하자"), the model can ignore this hint; if it
+// wasn't, the next channel_send (or channel_reply) can correct course.
+//
+// Only fires when the origin had a thread to begin with — channel-root
+// sessions can't have a "missing thread" problem.
+function threadMismatchHint(
+  origin: ChannelSendOrigin | undefined,
+  sent: { adapter: AdapterId; workspace: string; chat: string; thread: string | undefined },
+): string {
+  if (!origin) return ''
+  if (origin.thread === null) return ''
+  if (sent.thread !== undefined) return ''
+  if (origin.adapter !== sent.adapter) return ''
+  if (origin.workspace !== sent.workspace) return ''
+  if (origin.chat !== sent.chat) return ''
+  return (
+    `note: this session's origin thread is ${JSON.stringify(origin.thread)} but you posted to channel root. ` +
+    `if breaking out of the thread was intentional, ignore this; otherwise prefer \`channel_reply\` ` +
+    `or pass \`thread: ${JSON.stringify(origin.thread)}\` on your next channel_send.`
+  )
 }
 
 // Returns a behavioral hint to nudge the model toward yielding when it has


### PR DESCRIPTION
## Summary

A production bug in the `winky` Slack bot: after `typeclaw restart`, the bot replied \"다시 돌아왔습니다…\" but posted to the channel root instead of the original thread `1777575272.145279`, bisecting the conversation into a new thread `1777575863.880409`.

Root cause: `channel_send` requires `adapter`/`workspace`/`chat`/`thread` to be copied verbatim on every call. The model (kimi-k2p5-turbo) correctly identified the thread in its thinking block, then dropped the `thread` field in the actual tool arguments. This is a recurring failure mode across models — the schema makes the wrong thing easy.

## Changes

### New `channel_reply` tool (`src/agent/tools/channel-reply.ts`)

Happy-path companion to `channel_send` for channel-routed sessions. Schema: `{ text }`. Addressing comes from the session origin — the model cannot drop a field that doesn't exist in the schema. Wired in only when `options.origin?.kind === 'channel'` and `channelRouter` is present, so cron-spawned sessions and TUI sessions don't see it.

### Thread-mismatch hint in `channel_send` (`src/agent/tools/channel-send.ts`)

When `channel_send` is called from a channel-routed session and the call's `adapter + workspace + chat` match the origin but `thread` is omitted while the origin had a thread, the tool result appends a non-blocking note: "your origin thread is X but you posted to channel root. if breaking out was intentional, ignore this; otherwise prefer `channel_reply` or pass `thread: X` next time." Non-blocking by design — sometimes starting a fresh top-level thread is exactly what the model intended.

### Updated `renderChannelOrigin` system-prompt block (`src/agent/session-origin.ts`)

Teaches `channel_reply({ text })` as the default for replying in-thread. Demotes `channel_send` to "post elsewhere" semantics. The "copy these fields verbatim" template becomes informational (this is what your session is addressed to) rather than a paste-target.

## What this does not change

- `channel_send` schema is identical — still accepts `adapter/workspace/chat/thread/text`.
- Cron-spawned sessions and TUI sessions are untouched.
- No persistence changes, no router changes, no wire-protocol changes.
- Pre-existing thread persistence in `channels/sessions.json` is correct and unchanged.

## Tests

### New: `src/agent/tools/channel-reply.test.ts` (8 tests)

Happy path, channel-root origin, denial reporting, consecutive-send hint, deny-doesn't-warn, and the constraint that `channel_reply` is absent from non-channel sessions.

### Extended: `src/agent/tools/channel-send.test.ts` (8 new tests)

New `describe('thread-mismatch hint', ...)` block covering all trigger and non-trigger cases: same adapter+workspace+chat with omitted thread fires the hint; different chat, different adapter, channel-root origin, or no origin at all do not; denied sends don't warn; the hint composes correctly with the existing consecutive-send hint.

### Updated: `src/agent/session-origin.test.ts`

Adjusted to match new prompt wording. Added assertion that both tools are mentioned and `channel_reply` is presented as the default.

## Pre-commit checks

```
bun run typecheck    → clean
bun run lint         → 0 warnings, 0 errors
bun run format:check → all files formatted
bun test src/        → 0 fail
bun test plugins     → 114 pass, 0 fail
bun test scripts     → 3 pass, 0 fail
```

## Review notes

- The key design choice is that `channel_reply` makes the wrong thing impossible at the schema level rather than trying to detect and correct the model's reasoning after the fact. The mismatch hint on `channel_send` is the belt-and-suspenders for the cases where `channel_send` is genuinely used by mistake.
- `channel_reply` must not be registered for cron-spawned sessions because those sessions don't have a live channel origin to reply to — the guard is the `options.origin?.kind === 'channel'` check in `src/agent/index.ts`.
- The hint text is intentional in its hedging ("if breaking out was intentional, ignore this") — false-positive suppression is important here because `channel_send` is the legitimate escape hatch for starting new threads.