### PR TITLE
Resolve channel and author names for agent context

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -198,4 +198,83 @@ describe('renderSessionOrigin', () => {
     expect(out).not.toContain('Recent participants')
     expect(out).toContain('Be concise')
   })
+
+  test('channel origin shows human-readable workspace and chat names alongside raw IDs', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0ACME',
+      workspaceName: 'Acme Corp',
+      chat: 'C0DEPLOY',
+      chatName: 'deploy',
+      thread: null,
+    })
+    expect(out).toContain('Acme Corp')
+    expect(out).toContain('T0ACME')
+    expect(out).toContain('#deploy')
+    expect(out).toContain('C0DEPLOY')
+    expect(out).toContain('"workspace": "T0ACME"')
+    expect(out).toContain('"chat": "C0DEPLOY"')
+  })
+
+  test('channel origin uses # prefix for Slack channels, bare name for Discord', () => {
+    const slackOut = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      workspaceName: 'Acme',
+      chat: 'C0',
+      chatName: 'general',
+      thread: null,
+    })
+    expect(slackOut).toContain('#general')
+
+    const discordOut = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'discord-bot',
+      workspace: '111',
+      workspaceName: 'Acme Guild',
+      chat: '222',
+      chatName: 'general',
+      thread: null,
+    })
+    expect(discordOut).toContain('general')
+    expect(discordOut).not.toContain('#general')
+  })
+
+  test('channel origin renders even when chatName is missing (workspace name only)', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      workspaceName: 'Acme',
+      chat: 'C0',
+      thread: null,
+    })
+    expect(out).toContain('Acme')
+    expect(out).toContain('C0')
+  })
+
+  test('channel origin emits no malformed name prose when both names are absent', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'discord-bot',
+      workspace: '@dm',
+      chat: '999',
+      thread: null,
+    })
+    expect(out).not.toMatch(/in \*\*\*\*/)
+    expect(out).not.toContain('undefined')
+  })
+
+  test('channel origin keeps the @dm workspace sentinel in the JSON block', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: '@dm',
+      chat: 'D0DMID',
+      thread: null,
+    })
+    expect(out).toContain('"workspace": "@dm"')
+  })
 })

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -20,7 +20,9 @@ export type SessionOrigin =
       kind: 'channel'
       adapter: AdapterId
       workspace: string
+      workspaceName?: string
       chat: string
+      chatName?: string
       thread: string | null
       lastInboundAuthorId?: string
       participants?: readonly ChannelParticipant[]
@@ -83,7 +85,9 @@ function renderChannelOrigin(
   origin: {
     adapter: AdapterId
     workspace: string
+    workspaceName?: string
     chat: string
+    chatName?: string
     thread: string | null
     participants?: readonly ChannelParticipant[]
   },
@@ -112,6 +116,12 @@ function renderChannelOrigin(
     `You are responding inside a ${platform} channel session. There is no human`,
     'attached to a console here — your only way to communicate with the user',
     'is a tool call. Plain-text output is invisible.',
+  ]
+
+  const conversationLine = renderConversationLine(origin)
+  if (conversationLine !== null) lines.push('', conversationLine)
+
+  lines.push(
     '',
     '**For every user message in this session, you MUST call `channel_reply`',
     '(or `channel_send`) at least once before ending your turn**, unless the',
@@ -139,13 +149,31 @@ function renderChannelOrigin(
     '`{ ok: false }` otherwise).',
     '',
     `To mention someone in your reply, use ${platform} syntax \`<@USER_ID>\`.`,
-  ]
+  )
 
   const participantsBlock = renderParticipants(origin.participants ?? [], now)
   if (participantsBlock) lines.push('', participantsBlock)
 
   lines.push('', 'Be concise; chat clients punish multi-paragraph replies.')
   return lines.join('\n')
+}
+
+function renderConversationLine(origin: {
+  adapter: AdapterId
+  workspace: string
+  workspaceName?: string
+  chat: string
+  chatName?: string
+}): string | null {
+  const hasChat = origin.chatName !== undefined && origin.chatName !== ''
+  const hasWorkspace = origin.workspaceName !== undefined && origin.workspaceName !== ''
+  if (!hasChat && !hasWorkspace) return null
+
+  const chatPrefix = origin.adapter === 'slack-bot' ? '#' : ''
+  const chatLabel = hasChat ? `**${chatPrefix}${origin.chatName!}** (${origin.chat})` : `\`${origin.chat}\``
+  const workspaceLabel = hasWorkspace ? `**${origin.workspaceName!}** (${origin.workspace})` : `\`${origin.workspace}\``
+
+  return `Conversation: ${chatLabel} in ${workspaceLabel}.`
 }
 
 function renderParticipants(participants: readonly ChannelParticipant[], now: number): string {

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -17,6 +17,8 @@ function fakeRouter(
     unregisterOutbound: () => {},
     registerTyping: () => {},
     unregisterTyping: () => {},
+    registerChannelNameResolver: () => {},
+    unregisterChannelNameResolver: () => {},
     stop: async () => {},
     liveCount: () => 0,
   }

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -17,6 +17,8 @@ function fakeRouter(
     unregisterOutbound: () => {},
     registerTyping: () => {},
     unregisterTyping: () => {},
+    registerChannelNameResolver: () => {},
+    unregisterChannelNameResolver: () => {},
     stop: async () => {},
     liveCount: () => 0,
   }

--- a/src/channels/adapters/discord-bot-channel-resolver.test.ts
+++ b/src/channels/adapters/discord-bot-channel-resolver.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { createDiscordChannelResolver } from './discord-bot-channel-resolver'
+
+type FetchCall = { url: string; init: RequestInit }
+
+const DISCORD_API_BASE = 'https://discord.com/api/v10'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+describe('discord-bot channel resolver', () => {
+  let originalFetch: typeof fetch
+  let calls: FetchCall[]
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    calls = []
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  const installFetch = (handler: (url: string) => Response | Promise<Response>): void => {
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      calls.push({ url, init: init ?? {} })
+      return await handler(url)
+    }) as unknown as typeof fetch
+  }
+
+  test('resolves chat name and guild name from /channels and /guilds', async () => {
+    installFetch((url) => {
+      if (url.endsWith('/channels/222')) return jsonResponse({ id: '222', name: 'general' })
+      if (url.endsWith('/guilds/111')) return jsonResponse({ id: '111', name: 'Acme Guild' })
+      throw new Error(`unexpected url: ${url}`)
+    })
+    const resolver = createDiscordChannelResolver({ token: 'tok-abc', now: () => 1000 })
+
+    const result = await resolver({ adapter: 'discord-bot', workspace: '111', chat: '222', thread: null })
+
+    expect(result).toEqual({ chatName: 'general', workspaceName: 'Acme Guild' })
+    expect(calls).toHaveLength(2)
+    const channelCall = calls.find((c) => c.url.endsWith('/channels/222'))!
+    expect(channelCall.url).toBe(`${DISCORD_API_BASE}/channels/222`)
+    expect((channelCall.init.headers as Record<string, string>).Authorization).toBe('Bot tok-abc')
+  })
+
+  test('skips both lookups for DM workspace (workspace=@dm)', async () => {
+    installFetch(() => jsonResponse({}))
+    const resolver = createDiscordChannelResolver({ token: 'tok', now: () => 1000 })
+
+    const result = await resolver({ adapter: 'discord-bot', workspace: '@dm', chat: '999', thread: null })
+
+    expect(result).toEqual({})
+    expect(calls).toHaveLength(0)
+  })
+
+  test('returns workspace name only when channel lookup 404s', async () => {
+    installFetch((url) => {
+      if (url.includes('/channels/')) return new Response(null, { status: 404 })
+      return jsonResponse({ id: '111', name: 'Acme' })
+    })
+    const resolver = createDiscordChannelResolver({ token: 'tok', now: () => 1000 })
+
+    const result = await resolver({ adapter: 'discord-bot', workspace: '111', chat: '222', thread: null })
+
+    expect(result).toEqual({ workspaceName: 'Acme' })
+  })
+
+  test('returns chat name only when guild lookup fails', async () => {
+    installFetch((url) => {
+      if (url.includes('/guilds/')) return new Response(null, { status: 500 })
+      return jsonResponse({ id: '222', name: 'general' })
+    })
+    const resolver = createDiscordChannelResolver({ token: 'tok', now: () => 1000 })
+
+    const result = await resolver({ adapter: 'discord-bot', workspace: '111', chat: '222', thread: null })
+
+    expect(result).toEqual({ chatName: 'general' })
+  })
+
+  test('handles a channel with no name field by omitting chatName', async () => {
+    installFetch((url) => {
+      if (url.includes('/channels/')) return jsonResponse({ id: '222' })
+      return jsonResponse({ id: '111', name: 'Acme' })
+    })
+    const resolver = createDiscordChannelResolver({ token: 'tok', now: () => 1000 })
+
+    const result = await resolver({ adapter: 'discord-bot', workspace: '111', chat: '222', thread: null })
+
+    expect(result).toEqual({ workspaceName: 'Acme' })
+  })
+
+  test('caches resolved names within TTL', async () => {
+    let nowVal = 1000
+    installFetch((url) =>
+      jsonResponse(url.includes('/channels/') ? { id: '222', name: 'general' } : { id: '111', name: 'Acme' }),
+    )
+    const resolver = createDiscordChannelResolver({ token: 'tok', now: () => nowVal, ttlMs: 60_000 })
+
+    await resolver({ adapter: 'discord-bot', workspace: '111', chat: '222', thread: null })
+    nowVal = 50_000
+    await resolver({ adapter: 'discord-bot', workspace: '111', chat: '222', thread: null })
+
+    expect(calls).toHaveLength(2)
+  })
+
+  test('returns empty object on total network failure', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+    const resolver = createDiscordChannelResolver({ token: 'tok', now: () => 1000 })
+
+    const result = await resolver({ adapter: 'discord-bot', workspace: '111', chat: '222', thread: null })
+
+    expect(result).toEqual({})
+  })
+})

--- a/src/channels/adapters/discord-bot-channel-resolver.ts
+++ b/src/channels/adapters/discord-bot-channel-resolver.ts
@@ -1,0 +1,77 @@
+import type { ChannelKey, ChannelNameResolver, ResolvedChannelNames } from '@/channels/types'
+
+const DISCORD_API_BASE = 'https://discord.com/api/v10'
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
+
+export type DiscordChannelResolverOptions = {
+  token: string
+  now?: () => number
+  ttlMs?: number
+}
+
+type CacheEntry<T> = { value: T; expiresAt: number }
+
+type DiscordChannel = { id?: string; name?: string }
+type DiscordGuild = { id?: string; name?: string }
+
+export function createDiscordChannelResolver(options: DiscordChannelResolverOptions): ChannelNameResolver {
+  const now = options.now ?? Date.now
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+
+  const channelCache = new Map<string, CacheEntry<string>>()
+  const guildCache = new Map<string, CacheEntry<string>>()
+
+  const fetchCached = async <T>(
+    cache: Map<string, CacheEntry<T>>,
+    key: string,
+    fetcher: () => Promise<T | null>,
+  ): Promise<T | null> => {
+    const cached = cache.get(key)
+    if (cached && cached.expiresAt > now()) return cached.value
+    const value = await fetcher()
+    if (value !== null) cache.set(key, { value, expiresAt: now() + ttlMs })
+    return value
+  }
+
+  return async (key: ChannelKey): Promise<ResolvedChannelNames> => {
+    if (key.workspace === '@dm') return {}
+
+    const [chatName, workspaceName] = await Promise.all([
+      fetchCached(channelCache, key.chat, () => fetchChannelName(key.chat, options.token)),
+      fetchCached(guildCache, key.workspace, () => fetchGuildName(key.workspace, options.token)),
+    ])
+
+    const result: ResolvedChannelNames = {}
+    if (chatName !== null) result.chatName = chatName
+    if (workspaceName !== null) result.workspaceName = workspaceName
+    return result
+  }
+}
+
+async function fetchChannelName(channelId: string, token: string): Promise<string | null> {
+  try {
+    const response = await fetch(`${DISCORD_API_BASE}/channels/${encodeURIComponent(channelId)}`, {
+      headers: { Authorization: `Bot ${token}` },
+    })
+    if (!response.ok) return null
+    const body = (await response.json()) as DiscordChannel
+    if (typeof body.name !== 'string' || body.name === '') return null
+    return body.name
+  } catch {
+    return null
+  }
+}
+
+async function fetchGuildName(guildId: string, token: string): Promise<string | null> {
+  try {
+    const response = await fetch(`${DISCORD_API_BASE}/guilds/${encodeURIComponent(guildId)}`, {
+      headers: { Authorization: `Bot ${token}` },
+    })
+    if (!response.ok) return null
+    const body = (await response.json()) as DiscordGuild
+    if (typeof body.name !== 'string' || body.name === '') return null
+    return body.name
+  } catch {
+    return null
+  }
+}

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -8,6 +8,7 @@ import {
   DiscordIntent,
   type DiscordGatewayMessageCreateEvent,
 } from './agent-messenger-shim'
+import { createDiscordChannelResolver } from './discord-bot-channel-resolver'
 import { classifyInbound, type InboundDropReason } from './discord-bot-classify'
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10'
@@ -95,6 +96,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
   let stopWaiters: Array<() => void> = []
 
   const typingCallback = createTypingCallback({ token: options.token, configRef: options.configRef, logger })
+  const channelResolver = createDiscordChannelResolver({ token: options.token })
 
   const outboundCallback: OutboundCallback = async (msg: OutboundMessage): Promise<SendResult> => {
     if (msg.adapter !== 'discord-bot') {
@@ -182,6 +184,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
 
       options.router.registerOutbound('discord-bot', outboundCallback)
       options.router.registerTyping('discord-bot', typingCallback)
+      options.router.registerChannelNameResolver('discord-bot', channelResolver)
 
       try {
         await listener.start()
@@ -197,6 +200,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       started = false
       options.router.unregisterOutbound('discord-bot', outboundCallback)
       options.router.unregisterTyping('discord-bot', typingCallback)
+      options.router.unregisterChannelNameResolver('discord-bot', channelResolver)
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {
           stopWaiters.push(resolve)

--- a/src/channels/adapters/slack-bot-author-resolver.test.ts
+++ b/src/channels/adapters/slack-bot-author-resolver.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { createSlackAuthorResolver } from './slack-bot-author-resolver'
+
+type FetchCall = { url: string; init: RequestInit }
+
+const SLACK_API_BASE = 'https://slack.com/api'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+describe('slack-bot author resolver', () => {
+  let originalFetch: typeof fetch
+  let calls: FetchCall[]
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    calls = []
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  const installFetch = (handler: (url: string) => Response | Promise<Response>): void => {
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      calls.push({ url, init: init ?? {} })
+      return await handler(url)
+    }) as unknown as typeof fetch
+  }
+
+  test('calls users.info with the bot token and returns profile.display_name', async () => {
+    installFetch(() =>
+      jsonResponse({
+        ok: true,
+        user: {
+          id: 'UALICE',
+          name: 'alice',
+          real_name: 'Alice Smith',
+          profile: { display_name: 'alice.s', real_name: 'Alice Smith' },
+        },
+      }),
+    )
+    const resolver = createSlackAuthorResolver({ token: 'xoxb-test', now: () => 1000 })
+
+    const name = await resolver.resolve('UALICE')
+
+    expect(name).toBe('alice.s')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toBe(`${SLACK_API_BASE}/users.info?user=UALICE`)
+    const headers = calls[0]!.init.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer xoxb-test')
+  })
+
+  test('falls back to real_name when display_name is empty', async () => {
+    installFetch(() =>
+      jsonResponse({
+        ok: true,
+        user: {
+          id: 'UBOB',
+          name: 'bob',
+          real_name: 'Bob Jones',
+          profile: { display_name: '', real_name: 'Bob Jones' },
+        },
+      }),
+    )
+    const resolver = createSlackAuthorResolver({ token: 'tok', now: () => 1000 })
+
+    const name = await resolver.resolve('UBOB')
+
+    expect(name).toBe('Bob Jones')
+  })
+
+  test('falls back to name when real_name is also missing', async () => {
+    installFetch(() =>
+      jsonResponse({
+        ok: true,
+        user: { id: 'UCAROL', name: 'carol', profile: {} },
+      }),
+    )
+    const resolver = createSlackAuthorResolver({ token: 'tok', now: () => 1000 })
+
+    const name = await resolver.resolve('UCAROL')
+
+    expect(name).toBe('carol')
+  })
+
+  test('returns the user id when Slack returns ok: false', async () => {
+    installFetch(() => jsonResponse({ ok: false, error: 'user_not_found' }))
+    const resolver = createSlackAuthorResolver({ token: 'tok', now: () => 1000 })
+
+    const name = await resolver.resolve('UGHOST')
+
+    expect(name).toBe('UGHOST')
+  })
+
+  test('returns the user id when the HTTP request fails', async () => {
+    installFetch(() => new Response(null, { status: 503 }))
+    const resolver = createSlackAuthorResolver({ token: 'tok', now: () => 1000 })
+
+    const name = await resolver.resolve('UFLAKY')
+
+    expect(name).toBe('UFLAKY')
+  })
+
+  test('returns the user id when fetch throws', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+    const resolver = createSlackAuthorResolver({ token: 'tok', now: () => 1000 })
+
+    const name = await resolver.resolve('UNETERR')
+
+    expect(name).toBe('UNETERR')
+  })
+
+  test('caches successful lookups and does not re-fetch within TTL', async () => {
+    let nowVal = 0
+    installFetch(() =>
+      jsonResponse({
+        ok: true,
+        user: { id: 'UALICE', name: 'alice', profile: { display_name: 'alice' } },
+      }),
+    )
+    const resolver = createSlackAuthorResolver({ token: 'tok', now: () => nowVal, ttlMs: 60_000 })
+
+    nowVal = 1000
+    expect(await resolver.resolve('UALICE')).toBe('alice')
+    nowVal = 50_000
+    expect(await resolver.resolve('UALICE')).toBe('alice')
+
+    expect(calls).toHaveLength(1)
+  })
+
+  test('re-fetches after TTL expires (handles renames)', async () => {
+    let nowVal = 0
+    let displayName = 'alice'
+    installFetch(() =>
+      jsonResponse({
+        ok: true,
+        user: { id: 'UALICE', name: 'alice', profile: { display_name: displayName } },
+      }),
+    )
+    const resolver = createSlackAuthorResolver({ token: 'tok', now: () => nowVal, ttlMs: 60_000 })
+
+    nowVal = 1000
+    expect(await resolver.resolve('UALICE')).toBe('alice')
+    displayName = 'alice.renamed'
+    nowVal = 100_000
+    expect(await resolver.resolve('UALICE')).toBe('alice.renamed')
+
+    expect(calls).toHaveLength(2)
+  })
+
+  test('coalesces concurrent lookups for the same user (single fetch)', async () => {
+    let resolveFetch: (response: Response) => void = () => {}
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      calls.push({ url, init: init ?? {} })
+      return await new Promise<Response>((res) => {
+        resolveFetch = res
+      })
+    }) as unknown as typeof fetch
+    const resolver = createSlackAuthorResolver({ token: 'tok', now: () => 1000 })
+
+    const a = resolver.resolve('UALICE')
+    const b = resolver.resolve('UALICE')
+
+    resolveFetch(
+      jsonResponse({
+        ok: true,
+        user: { id: 'UALICE', name: 'alice', profile: { display_name: 'alice' } },
+      }),
+    )
+
+    expect(await a).toBe('alice')
+    expect(await b).toBe('alice')
+    expect(calls).toHaveLength(1)
+  })
+
+  test('does not cache failures (so a transient error is retried next call)', async () => {
+    let mode: 'fail' | 'ok' = 'fail'
+    installFetch(() =>
+      mode === 'fail'
+        ? new Response(null, { status: 500 })
+        : jsonResponse({ ok: true, user: { id: 'UALICE', name: 'alice', profile: { display_name: 'alice' } } }),
+    )
+    const resolver = createSlackAuthorResolver({ token: 'tok', now: () => 1000 })
+
+    expect(await resolver.resolve('UALICE')).toBe('UALICE')
+    mode = 'ok'
+    expect(await resolver.resolve('UALICE')).toBe('alice')
+
+    expect(calls).toHaveLength(2)
+  })
+})

--- a/src/channels/adapters/slack-bot-author-resolver.ts
+++ b/src/channels/adapters/slack-bot-author-resolver.ts
@@ -1,0 +1,80 @@
+const SLACK_API_BASE = 'https://slack.com/api'
+const DEFAULT_TTL_MS = 60 * 60 * 1000
+
+export type SlackAuthorResolverOptions = {
+  token: string
+  now?: () => number
+  ttlMs?: number
+}
+
+export type SlackAuthorResolver = {
+  resolve: (userId: string) => Promise<string>
+}
+
+type CacheEntry = { name: string; expiresAt: number }
+
+type SlackUsersInfoResponse = {
+  ok: boolean
+  user?: {
+    id?: string
+    name?: string
+    real_name?: string
+    profile?: {
+      display_name?: string
+      real_name?: string
+    }
+  }
+}
+
+export function createSlackAuthorResolver(options: SlackAuthorResolverOptions): SlackAuthorResolver {
+  const now = options.now ?? Date.now
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+  const cache = new Map<string, CacheEntry>()
+  const inflight = new Map<string, Promise<string>>()
+
+  const resolve = async (userId: string): Promise<string> => {
+    const cached = cache.get(userId)
+    if (cached && cached.expiresAt > now()) return cached.name
+
+    const existing = inflight.get(userId)
+    if (existing) return existing
+
+    const promise = fetchUserName(userId, options.token)
+      .then((name) => {
+        if (name !== userId) {
+          cache.set(userId, { name, expiresAt: now() + ttlMs })
+        }
+        return name
+      })
+      .finally(() => {
+        inflight.delete(userId)
+      })
+
+    inflight.set(userId, promise)
+    return promise
+  }
+
+  return { resolve }
+}
+
+async function fetchUserName(userId: string, token: string): Promise<string> {
+  try {
+    const response = await fetch(`${SLACK_API_BASE}/users.info?user=${encodeURIComponent(userId)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!response.ok) return userId
+    const body = (await response.json()) as SlackUsersInfoResponse
+    if (!body.ok || !body.user) return userId
+    return pickDisplayName(body.user) ?? userId
+  } catch {
+    return userId
+  }
+}
+
+function pickDisplayName(user: NonNullable<SlackUsersInfoResponse['user']>): string | null {
+  const candidates = [user.profile?.display_name, user.profile?.real_name, user.real_name, user.name]
+  for (const c of candidates) {
+    if (typeof c === 'string' && c !== '') return c
+  }
+  return null
+}

--- a/src/channels/adapters/slack-bot-channel-resolver.test.ts
+++ b/src/channels/adapters/slack-bot-channel-resolver.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { createSlackChannelResolver } from './slack-bot-channel-resolver'
+
+type FetchCall = { url: string; init: RequestInit }
+
+const SLACK_API_BASE = 'https://slack.com/api'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+describe('slack-bot channel resolver', () => {
+  let originalFetch: typeof fetch
+  let calls: FetchCall[]
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    calls = []
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  const installFetch = (handler: (url: string) => Response | Promise<Response>): void => {
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      calls.push({ url, init: init ?? {} })
+      return await handler(url)
+    }) as unknown as typeof fetch
+  }
+
+  test('resolves chat name and workspace name in parallel from conversations.info and team.info', async () => {
+    installFetch((url) => {
+      if (url.includes('/conversations.info')) {
+        return jsonResponse({ ok: true, channel: { id: 'C0DEPLOY', name: 'deploy' } })
+      }
+      if (url.includes('/team.info')) {
+        return jsonResponse({ ok: true, team: { id: 'T0ACME', name: 'Acme Corp' } })
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
+    const resolver = createSlackChannelResolver({ token: 'xoxb-test', now: () => 1000 })
+
+    const result = await resolver({
+      adapter: 'slack-bot',
+      workspace: 'T0ACME',
+      chat: 'C0DEPLOY',
+      thread: null,
+    })
+
+    expect(result).toEqual({ chatName: 'deploy', workspaceName: 'Acme Corp' })
+    expect(calls).toHaveLength(2)
+    const conv = calls.find((c) => c.url.includes('/conversations.info'))!
+    expect(conv.url).toBe(`${SLACK_API_BASE}/conversations.info?channel=C0DEPLOY`)
+    expect((conv.init.headers as Record<string, string>).Authorization).toBe('Bearer xoxb-test')
+    const team = calls.find((c) => c.url.includes('/team.info'))!
+    expect(team.url).toBe(`${SLACK_API_BASE}/team.info?team=T0ACME`)
+  })
+
+  test('skips both lookups for DM channels (workspace=@dm)', async () => {
+    installFetch(() => jsonResponse({ ok: true }))
+    const resolver = createSlackChannelResolver({ token: 'tok', now: () => 1000 })
+
+    const result = await resolver({ adapter: 'slack-bot', workspace: '@dm', chat: 'D0DMID', thread: null })
+
+    expect(result).toEqual({})
+    expect(calls).toHaveLength(0)
+  })
+
+  test('returns workspace name only when the channel lookup fails', async () => {
+    installFetch((url) => {
+      if (url.includes('/conversations.info')) return new Response(null, { status: 500 })
+      return jsonResponse({ ok: true, team: { id: 'T0', name: 'Acme' } })
+    })
+    const resolver = createSlackChannelResolver({ token: 'tok', now: () => 1000 })
+
+    const result = await resolver({ adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null })
+
+    expect(result).toEqual({ workspaceName: 'Acme' })
+  })
+
+  test('returns chat name only when the team lookup fails', async () => {
+    installFetch((url) => {
+      if (url.includes('/team.info')) return jsonResponse({ ok: false, error: 'auth_revoked' })
+      return jsonResponse({ ok: true, channel: { id: 'C0', name: 'general' } })
+    })
+    const resolver = createSlackChannelResolver({ token: 'tok', now: () => 1000 })
+
+    const result = await resolver({ adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null })
+
+    expect(result).toEqual({ chatName: 'general' })
+  })
+
+  test('caches resolved names within TTL (no re-fetch on repeat lookup)', async () => {
+    let nowVal = 1000
+    installFetch((url) =>
+      jsonResponse(
+        url.includes('/conversations.info')
+          ? { ok: true, channel: { id: 'C0', name: 'general' } }
+          : { ok: true, team: { id: 'T0', name: 'Acme' } },
+      ),
+    )
+    const resolver = createSlackChannelResolver({ token: 'tok', now: () => nowVal, ttlMs: 60_000 })
+
+    await resolver({ adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null })
+    nowVal = 50_000
+    await resolver({ adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null })
+
+    expect(calls).toHaveLength(2)
+  })
+
+  test('re-fetches after TTL expires', async () => {
+    let nowVal = 1000
+    let chatName = 'general'
+    installFetch((url) =>
+      jsonResponse(
+        url.includes('/conversations.info')
+          ? { ok: true, channel: { id: 'C0', name: chatName } }
+          : { ok: true, team: { id: 'T0', name: 'Acme' } },
+      ),
+    )
+    const resolver = createSlackChannelResolver({ token: 'tok', now: () => nowVal, ttlMs: 60_000 })
+
+    await resolver({ adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null })
+    chatName = 'general-renamed'
+    nowVal = 100_000
+    const second = await resolver({ adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null })
+
+    expect(second.chatName).toBe('general-renamed')
+  })
+
+  test('returns empty object on total network failure', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+    const resolver = createSlackChannelResolver({ token: 'tok', now: () => 1000 })
+
+    const result = await resolver({ adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null })
+
+    expect(result).toEqual({})
+  })
+})

--- a/src/channels/adapters/slack-bot-channel-resolver.ts
+++ b/src/channels/adapters/slack-bot-channel-resolver.ts
@@ -1,0 +1,84 @@
+import type { ChannelKey, ChannelNameResolver, ResolvedChannelNames } from '@/channels/types'
+
+const SLACK_API_BASE = 'https://slack.com/api'
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
+
+export type SlackChannelResolverOptions = {
+  token: string
+  now?: () => number
+  ttlMs?: number
+}
+
+type CacheEntry<T> = { value: T; expiresAt: number }
+
+type SlackConversationsInfoResponse = {
+  ok: boolean
+  channel?: { id?: string; name?: string }
+}
+
+type SlackTeamInfoResponse = {
+  ok: boolean
+  team?: { id?: string; name?: string }
+}
+
+export function createSlackChannelResolver(options: SlackChannelResolverOptions): ChannelNameResolver {
+  const now = options.now ?? Date.now
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+
+  const chatCache = new Map<string, CacheEntry<string>>()
+  const teamCache = new Map<string, CacheEntry<string>>()
+
+  const fetchCached = async <T>(
+    cache: Map<string, CacheEntry<T>>,
+    key: string,
+    fetcher: () => Promise<T | null>,
+  ): Promise<T | null> => {
+    const cached = cache.get(key)
+    if (cached && cached.expiresAt > now()) return cached.value
+    const value = await fetcher()
+    if (value !== null) cache.set(key, { value, expiresAt: now() + ttlMs })
+    return value
+  }
+
+  return async (key: ChannelKey): Promise<ResolvedChannelNames> => {
+    if (key.workspace === '@dm') return {}
+
+    const [chatName, workspaceName] = await Promise.all([
+      fetchCached(chatCache, key.chat, () => fetchChannelName(key.chat, options.token)),
+      fetchCached(teamCache, key.workspace, () => fetchTeamName(key.workspace, options.token)),
+    ])
+
+    const result: ResolvedChannelNames = {}
+    if (chatName !== null) result.chatName = chatName
+    if (workspaceName !== null) result.workspaceName = workspaceName
+    return result
+  }
+}
+
+async function fetchChannelName(channelId: string, token: string): Promise<string | null> {
+  try {
+    const response = await fetch(`${SLACK_API_BASE}/conversations.info?channel=${encodeURIComponent(channelId)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!response.ok) return null
+    const body = (await response.json()) as SlackConversationsInfoResponse
+    if (!body.ok || !body.channel?.name) return null
+    return body.channel.name
+  } catch {
+    return null
+  }
+}
+
+async function fetchTeamName(teamId: string, token: string): Promise<string | null> {
+  try {
+    const response = await fetch(`${SLACK_API_BASE}/team.info?team=${encodeURIComponent(teamId)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!response.ok) return null
+    const body = (await response.json()) as SlackTeamInfoResponse
+    if (!body.ok || !body.team?.name) return null
+    return body.team.name
+  } catch {
+    return null
+  }
+}

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -8,6 +8,7 @@ import {
   type SlackSocketAppMentionEvent,
   type SlackSocketMessageEvent,
 } from './agent-messenger-slack-shim'
+import { createSlackAuthorResolver } from './slack-bot-author-resolver'
 import { classifyInbound, type InboundDropReason } from './slack-bot-classify'
 
 // Bound on the dedupe ring buffer. Slack's Events API may deliver the same
@@ -91,6 +92,8 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
 
+  const authorResolver = createSlackAuthorResolver({ token: options.token })
+
   const typingCallback = createTypingCallback({ configRef: options.configRef, logger })
 
   const outboundCallback: OutboundCallback = async (msg: OutboundMessage): Promise<SendResult> => {
@@ -161,10 +164,12 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       }
 
       markSeen(dedupeKey)
+      const resolvedAuthorName = await authorResolver.resolve(verdict.payload.authorId)
+      const enriched = { ...verdict.payload, authorName: resolvedAuthorName }
       logger.info(
-        `[slack-bot] routed ts=${event.ts} workspace=${verdict.payload.workspace} mention=${verdict.payload.isBotMention} reply=${verdict.payload.replyToBotMessageId !== null}`,
+        `[slack-bot] routed ts=${event.ts} workspace=${enriched.workspace} mention=${enriched.isBotMention} reply=${enriched.replyToBotMessageId !== null}`,
       )
-      await options.router.route(verdict.payload)
+      await options.router.route(enriched)
     } catch (err) {
       logger.error(`[slack-bot] handleInbound failed: ${describe(err)}`)
     } finally {

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -9,6 +9,7 @@ import {
   type SlackSocketMessageEvent,
 } from './agent-messenger-slack-shim'
 import { createSlackAuthorResolver } from './slack-bot-author-resolver'
+import { createSlackChannelResolver } from './slack-bot-channel-resolver'
 import { classifyInbound, type InboundDropReason } from './slack-bot-classify'
 
 // Bound on the dedupe ring buffer. Slack's Events API may deliver the same
@@ -93,6 +94,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
   let stopWaiters: Array<() => void> = []
 
   const authorResolver = createSlackAuthorResolver({ token: options.token })
+  const channelResolver = createSlackChannelResolver({ token: options.token })
 
   const typingCallback = createTypingCallback({ configRef: options.configRef, logger })
 
@@ -237,6 +239,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
 
       options.router.registerOutbound('slack-bot', outboundCallback)
       options.router.registerTyping('slack-bot', typingCallback)
+      options.router.registerChannelNameResolver('slack-bot', channelResolver)
 
       try {
         await listener.start()
@@ -252,6 +255,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       started = false
       options.router.unregisterOutbound('slack-bot', outboundCallback)
       options.router.unregisterTyping('slack-bot', typingCallback)
+      options.router.unregisterChannelNameResolver('slack-bot', channelResolver)
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {
           stopWaiters.push(resolve)

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7,6 +7,7 @@ import type { AssistantMessage } from '@mariozechner/pi-ai'
 import type { SessionEntry } from '@mariozechner/pi-coding-agent'
 
 import type { AgentSession } from '@/agent'
+import type { SessionOrigin } from '@/agent/session-origin'
 import type { HookBus } from '@/plugin'
 
 import { loadChannelSessions } from './persistence'
@@ -88,9 +89,11 @@ function makeRouter(
     sessions?: FakeSession[]
     nowRef?: { value: number }
     logs?: string[]
+    origins?: SessionOrigin[]
   } = {},
-): { router: ChannelRouter; sessions: FakeSession[] } {
+): { router: ChannelRouter; sessions: FakeSession[]; origins: SessionOrigin[] } {
   const sessions: FakeSession[] = options.sessions ?? []
+  const origins: SessionOrigin[] = options.origins ?? []
   const nowRef = options.nowRef ?? { value: 1000 }
   const router = createChannelRouter({
     agentDir,
@@ -101,7 +104,8 @@ function makeRouter(
       warn: (m) => options.logs?.push(`warn:${m}`),
       error: (m) => options.logs?.push(`error:${m}`),
     },
-    createSessionForChannel: async () => {
+    createSessionForChannel: async ({ origin }) => {
+      origins.push(origin)
       const fake = new FakeSession()
       sessions.push(fake)
       return {
@@ -113,7 +117,7 @@ function makeRouter(
       }
     },
   })
-  return { router, sessions }
+  return { router, sessions, origins }
 }
 
 function inbound(over: Partial<InboundMessage> = {}): InboundMessage {
@@ -737,5 +741,93 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     // then
     expect(events).toEqual(['idle:ses_fake_1:-', 'end:ses_fake_1'])
     expect(sessions[0]!.disposed).toBe(1)
+  })
+})
+
+describe('ChannelRouter channel name resolver', () => {
+  test('calls the registered resolver and forwards resolved names into the session origin', async () => {
+    const dir = await tempDir()
+    const { router, origins } = makeRouter(dir)
+    const calls: ChannelKey[] = []
+    router.registerChannelNameResolver('discord-bot', async (key) => {
+      calls.push(key)
+      return { chatName: 'general', workspaceName: 'Acme Guild' }
+    })
+
+    await router.route(inbound())
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toEqual({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })
+    expect(origins).toHaveLength(1)
+    const origin = origins[0]!
+    if (origin.kind !== 'channel') throw new Error('expected channel origin')
+    expect(origin.chatName).toBe('general')
+    expect(origin.workspaceName).toBe('Acme Guild')
+  })
+
+  test('falls back to undefined names when no resolver is registered', async () => {
+    const dir = await tempDir()
+    const { router, origins } = makeRouter(dir)
+
+    await router.route(inbound())
+
+    const origin = origins[0]!
+    if (origin.kind !== 'channel') throw new Error('expected channel origin')
+    expect(origin.chatName).toBeUndefined()
+    expect(origin.workspaceName).toBeUndefined()
+  })
+
+  test('routes through to undefined names when the resolver throws (does not break session creation)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router, origins } = makeRouter(dir, { logs })
+    router.registerChannelNameResolver('discord-bot', async () => {
+      throw new Error('rate limited')
+    })
+
+    await router.route(inbound())
+
+    const origin = origins[0]!
+    if (origin.kind !== 'channel') throw new Error('expected channel origin')
+    expect(origin.chatName).toBeUndefined()
+    expect(origin.workspaceName).toBeUndefined()
+    expect(logs.some((l) => l.startsWith('warn:') && l.includes('name resolver'))).toBe(true)
+  })
+
+  test('only invokes the resolver matching the inbound adapter', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    let discordCalls = 0
+    let slackCalls = 0
+    router.registerChannelNameResolver('discord-bot', async () => {
+      discordCalls++
+      return {}
+    })
+    router.registerChannelNameResolver('slack-bot', async () => {
+      slackCalls++
+      return {}
+    })
+
+    await router.route(inbound({ adapter: 'discord-bot' }))
+
+    expect(discordCalls).toBe(1)
+    expect(slackCalls).toBe(0)
+  })
+
+  test('does not re-call the resolver on a hot session (only at session creation)', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    let calls = 0
+    router.registerChannelNameResolver('discord-bot', async () => {
+      calls++
+      return { chatName: 'general', workspaceName: 'Acme' }
+    })
+
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+    await router.route(inbound({ externalMessageId: 'm2', text: 'second' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(calls).toBe(1)
   })
 })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -15,7 +15,16 @@ import {
   type ChannelSessionRecord,
 } from './persistence'
 import type { ChannelAdapterConfig } from './schema'
-import type { ChannelKey, InboundMessage, OutboundCallback, OutboundMessage, SendResult, TypingCallback } from './types'
+import type {
+  ChannelKey,
+  ChannelNameResolver,
+  InboundMessage,
+  OutboundCallback,
+  OutboundMessage,
+  ResolvedChannelNames,
+  SendResult,
+  TypingCallback,
+} from './types'
 import { channelKeyId } from './types'
 
 export const INITIAL_DEBOUNCE_MS = 600
@@ -82,6 +91,7 @@ type LiveSession = {
   hooks: HookBus | undefined
   getTranscriptPath: (() => string | undefined) | undefined
   participants: ChannelParticipant[]
+  resolvedNames: ResolvedChannelNames
   promptQueue: QueuedInbound[]
   contextBuffer: ObservedInbound[]
   draining: boolean
@@ -117,6 +127,8 @@ export type ChannelRouter = {
   unregisterOutbound: (adapter: ChannelKey['adapter'], cb: OutboundCallback) => void
   registerTyping: (adapter: ChannelKey['adapter'], cb: TypingCallback) => void
   unregisterTyping: (adapter: ChannelKey['adapter'], cb: TypingCallback) => void
+  registerChannelNameResolver: (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver) => void
+  unregisterChannelNameResolver: (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver) => void
   stop: () => Promise<void>
   liveCount: () => number
   __testing?: {
@@ -143,6 +155,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const creating = new Map<string, Promise<LiveSession>>()
   const outboundCallbacks = new Map<ChannelKey['adapter'], Set<OutboundCallback>>()
   const typingCallbacks = new Map<ChannelKey['adapter'], Set<TypingCallback>>()
+  const channelNameResolvers = new Map<ChannelKey['adapter'], Set<ChannelNameResolver>>()
   const stickyLedger = new StickyLedger()
 
   let mappings: ChannelSessionRecord[] | null = null
@@ -185,6 +198,25 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       }
     })
 
+  const resolveChannelNames = async (key: ChannelKey): Promise<ResolvedChannelNames> => {
+    const resolvers = channelNameResolvers.get(key.adapter)
+    if (!resolvers || resolvers.size === 0) return {}
+    const snapshot = Array.from(resolvers)
+    const merged: ResolvedChannelNames = {}
+    for (const resolver of snapshot) {
+      try {
+        const result = await resolver(key)
+        if (result.chatName !== undefined && merged.chatName === undefined) merged.chatName = result.chatName
+        if (result.workspaceName !== undefined && merged.workspaceName === undefined) {
+          merged.workspaceName = result.workspaceName
+        }
+      } catch (err) {
+        logger.warn(`[channels] name resolver threw for ${channelKeyId(key)}: ${describe(err)}`)
+      }
+    }
+    return merged
+  }
+
   const ensureLive = async (key: ChannelKey): Promise<LiveSession> => {
     const keyId = channelKeyId(key)
     const existing = liveSessions.get(keyId)
@@ -197,11 +229,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       await ensureLoaded()
       const record = mappings ? findRecord(mappings, key) : undefined
       const participants = (record?.participants ?? []) as ChannelParticipant[]
+      const resolvedNames = await resolveChannelNames(key)
       const origin: SessionOrigin = {
         kind: 'channel',
         adapter: key.adapter,
         workspace: key.workspace,
+        ...(resolvedNames.workspaceName !== undefined ? { workspaceName: resolvedNames.workspaceName } : {}),
         chat: key.chat,
+        ...(resolvedNames.chatName !== undefined ? { chatName: resolvedNames.chatName } : {}),
         thread: key.thread,
         participants,
       }
@@ -245,6 +280,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         hooks: created.hooks,
         getTranscriptPath: created.getTranscriptPath,
         participants,
+        resolvedNames,
         promptQueue: [],
         contextBuffer: [],
         draining: false,
@@ -292,7 +328,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     kind: 'channel',
     adapter: live.key.adapter,
     workspace: live.key.workspace,
+    ...(live.resolvedNames.workspaceName !== undefined ? { workspaceName: live.resolvedNames.workspaceName } : {}),
     chat: live.key.chat,
+    ...(live.resolvedNames.chatName !== undefined ? { chatName: live.resolvedNames.chatName } : {}),
     thread: live.key.thread,
     participants: live.participants,
   })
@@ -524,6 +562,19 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     typingCallbacks.get(adapter)?.delete(cb)
   }
 
+  const registerChannelNameResolver = (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver): void => {
+    let set = channelNameResolvers.get(adapter)
+    if (!set) {
+      set = new Set()
+      channelNameResolvers.set(adapter, set)
+    }
+    set.add(resolver)
+  }
+
+  const unregisterChannelNameResolver = (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver): void => {
+    channelNameResolvers.get(adapter)?.delete(resolver)
+  }
+
   const send = async (msg: OutboundMessage): Promise<SendResult> => {
     const callbacks = outboundCallbacks.get(msg.adapter)
     if (!callbacks || callbacks.size === 0) {
@@ -637,6 +688,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     unregisterOutbound,
     registerTyping,
     unregisterTyping,
+    registerChannelNameResolver,
+    unregisterChannelNameResolver,
     stop,
     liveCount: () => liveSessions.size,
     __testing: {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -42,6 +42,13 @@ export type TypingTarget = {
 
 export type TypingCallback = (target: TypingTarget) => Promise<void>
 
+export type ResolvedChannelNames = {
+  chatName?: string
+  workspaceName?: string
+}
+
+export type ChannelNameResolver = (key: ChannelKey) => Promise<ResolvedChannelNames>
+
 export function channelKeyId(key: ChannelKey): string {
   return `${key.adapter}:${key.workspace}:${key.chat}:${key.thread ?? ''}`
 }


### PR DESCRIPTION
## Summary

TypeClaw agents have two surfaces where chat metadata shows up. The per-turn message header — rendered as `<@authorId> (authorName): text` in `composeTurnPrompt` — is meant to give the model a stable, readable handle for each participant. The session-origin block in the system prompt frames the conversation the agent is operating in, including the addressing JSON it must copy into `channel_send`.

Before this PR, both surfaces were giving agents raw IDs instead of human-readable names.

**Author names on Slack** — Slack Socket Mode events carry `event.user` (e.g. `U0ABC123`) but no display name. The classifier was setting `authorName` to the same string as `authorId`, so every inbound message rendered as `<@U0ABC123> (U0ABC123): hey can you check the deploy?`. The duplication was noise at best and mildly confusing at worst, because the model's only signal that the two tokens mean the same thing is the surrounding formatting. Discord events already include `event.author.username` so this problem is Slack-specific.

**Channel and workspace names, both platforms** — the session-origin block showed `"chat": "C0DEPLOY"` and `"workspace": "T0ACME"` with no human-readable counterpart. Agents had no way to know which Slack channel or Discord server they were in, only opaque identifiers. Injecting names into the addressing JSON was not an option because agents must copy those fields verbatim into `channel_send`; adding names there would break or complicate that contract. The prose surrounding the JSON block is the right place.

## Changes

### Author resolution (Slack only)

`src/channels/adapters/slack-bot-author-resolver.ts` calls `users.info` with the existing bot token and walks the display-name fallback chain: `display_name` → `real_name` → `profile.real_name` → `name` → raw ID. Successful lookups are cached for 1 hour so renames eventually propagate; failures are not cached so a transient network error gets retried on the next message. Concurrent lookups for the same user ID are coalesced into a single in-flight request.

The overlay is applied in `slack-bot.ts handleMessageEvent` after `classifyInbound` returns, replacing `payload.authorName` before the inbound reaches the router. This keeps `classifyInbound` pure — no network, no token — and leaves the classifier's golden tests untouched.

After this change, the same message renders as `<@U0ABC123> (alice.smith): hey can you check the deploy?`.

### Channel and workspace name resolution (both platforms)

`src/agent/session-origin.ts` gains optional `chatName` and `workspaceName` on the channel SessionOrigin variant. When present, `renderChannelOrigin` inserts a `Conversation: **#deploy** (C0DEPLOY) in **Acme Corp** (T0ACME).` line immediately after the platform sentence, before the addressing JSON block. Slack uses the `#name` prefix to match its client UI; Discord uses the bare channel name because Discord's mention syntax is `<#id>`, not `#name`, and we don't want to imply otherwise. The addressing JSON itself is unchanged so `channel_send` and `channel_reply` tool contracts are not affected.

`ChannelRouter` gains `registerChannelNameResolver` / `unregisterChannelNameResolver`, mirroring the existing `registerOutbound` / `registerTyping` callback pattern. `ensureLive` consults the registered resolver once at session creation, stashes the result on `LiveSession.resolvedNames`, and feeds it into `SessionOrigin`. Resolver throws are caught with a warn-level log so a misbehaving resolver never blocks session creation.

The Slack resolver (`slack-bot-channel-resolver.ts`) calls `conversations.info` for the channel name and `team.info` for the workspace name in parallel via raw `fetch` against the Slack Web API, using the existing bot token. The Discord resolver (`discord-bot-channel-resolver.ts`) calls `GET /channels/{id}` and `GET /guilds/{id}` against `discord.com/api/v10` via the same raw-fetch pattern already used by the existing typing callback in `discord-bot.ts` — no new dependency in either case. Both resolvers cache for 24 hours (channels and workspaces rename rarely) and skip all lookups for DMs (workspace `@dm` has no real workspace and DM channels have no name). Partial failures are handled gracefully: a channel-name 404 does not suppress a successful workspace-name lookup, and the renderer drops the `Conversation:` line when both names are missing, so agents in a flaky-network situation see exactly the prompt they got before.

## Test coverage

24 new tests; all 1001 existing tests continue to pass.

- 10 unit tests for the Slack author resolver — display-name fallback chain, cache TTL and non-caching of failures, concurrent coalescing, all error paths (network error, `ok: false`, malformed body).
- 7 unit tests for the Slack channel resolver — parallel fan-out, partial failures, DM skip, cache TTL.
- 7 unit tests for the Discord channel resolver — same shape as Slack.
- 4 new router tests — resolver registration, fallback when no resolver is registered, error swallowing, single call per session.
- 6 new session-origin tests — names rendered alongside IDs, platform-specific prefix, partial-name graceful degradation, no-name back-compat.

Pre-commit checks clean: `bun run typecheck`, `bun run lint`, `bun run format`, `bun test`.