### PR TITLE
Skip container ports bound only to 127.0.0.1

### DIFF
--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -68,6 +68,8 @@ function formatLog(event: BrokerLogEvent | DaemonLogEvent | SupervisorLogEvent):
       return `[${event.containerName}] released localhost:${event.hostPort}`
     case 'skip-excluded':
       return `[${event.containerName}] skipping :${event.port} (excluded)`
+    case 'skip-loopback':
+      return `[${event.containerName}] skipping :${event.port} (bound to 127.0.0.1 inside the container — bind to 0.0.0.0 to expose it)`
     case 'skip-eaddrinuse':
       return `[${event.containerName}] localhost:${event.port} unavailable: ${event.reason}`
     case 'ip-resolved':

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -15,7 +15,7 @@ const PROC_HEADER = '  sl  local_address rem_address   st tx_queue rx_queue tr t
 function procWithPorts(ports: number[]): string {
   const lines = ports.map(
     (port, i) =>
-      `   ${i}: 0100007F:${port.toString(16).toUpperCase().padStart(4, '0')} 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0`,
+      `   ${i}: 00000000:${port.toString(16).toUpperCase().padStart(4, '0')} 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0`,
   )
   return PROC_HEADER + lines.join('\n') + '\n'
 }

--- a/src/hostd/index.ts
+++ b/src/hostd/index.ts
@@ -22,7 +22,9 @@ export {
   type StartBrokerResult,
 } from './portbroker/broker'
 export {
+  type ListeningSocket,
   parseListeningPorts,
+  parseListeningSockets,
   startDetector,
   type Detector,
   type DetectorOptions,

--- a/src/hostd/portbroker/broker.test.ts
+++ b/src/hostd/portbroker/broker.test.ts
@@ -7,10 +7,10 @@ import type { Forwarder, ForwarderOptions, ForwarderStartResult } from './forwar
 
 const PROC_HEADER = '  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n'
 
-function procWithPorts(ports: number[]): string {
+function procWithPorts(ports: number[], localAddrHex = '00000000'): string {
   const lines = ports.map(
     (port, i) =>
-      `   ${i}: 0100007F:${port.toString(16).toUpperCase().padStart(4, '0')} 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0`,
+      `   ${i}: ${localAddrHex}:${port.toString(16).toUpperCase().padStart(4, '0')} 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0`,
   )
   return PROC_HEADER + lines.join('\n') + '\n'
 }
@@ -315,6 +315,60 @@ describe('startBroker', () => {
       expect(result.broker.containerIp()).toBe('10.0.0.5')
       await waitFor(() => result.broker.containerIp() === '10.0.0.99', 2000)
       expect(result.broker.containerIp()).toBe('10.0.0.99')
+    } finally {
+      await result.broker.stop()
+    }
+  })
+
+  test('skips ports bound only to 127.0.0.1 inside the container with a skip-loopback log', async () => {
+    const { factory, active } = fakeForwarderFactory()
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'inspect') return { exitCode: 0, stdout: '{"bridge":{"IPAddress":"10.0.0.5"}}', stderr: '' }
+      return { exitCode: 0, stdout: procWithPorts([4848], '0100007F'), stderr: '' }
+    }
+
+    const result = await startBroker({
+      containerName: 'coder',
+      excludePorts: new Set(),
+      exec,
+      intervalMs: 30,
+      forwarderFactory: factory,
+      onLog: (e) => events.push(e),
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    try {
+      await waitFor(() => events.some((e) => e.kind === 'skip-loopback' && e.port === 4848))
+      expect(active().has(4848)).toBe(false)
+      expect(events.some((e) => e.kind === 'open' && e.hostPort === 4848)).toBe(false)
+    } finally {
+      await result.broker.stop()
+    }
+  })
+
+  test('forwards a port that has both a loopback and a wildcard listener', async () => {
+    const { factory, active } = fakeForwarderFactory()
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'inspect') return { exitCode: 0, stdout: '{"bridge":{"IPAddress":"10.0.0.5"}}', stderr: '' }
+      const PROC = `${PROC_HEADER}   0: 0100007F:12F0 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0
+   1: 00000000:12F0 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 200 1 0 200 0
+`
+      return { exitCode: 0, stdout: PROC, stderr: '' }
+    }
+
+    const result = await startBroker({
+      containerName: 'coder',
+      excludePorts: new Set(),
+      exec,
+      intervalMs: 30,
+      forwarderFactory: factory,
+      onLog: (e) => events.push(e),
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    try {
+      await waitFor(() => active().has(4848))
+      expect(events.some((e) => e.kind === 'skip-loopback')).toBe(false)
     } finally {
       await result.broker.stop()
     }

--- a/src/hostd/portbroker/broker.ts
+++ b/src/hostd/portbroker/broker.ts
@@ -9,6 +9,7 @@ export type BrokerLogEvent =
   | { kind: 'open'; containerName: string; hostPort: number; upstreamPort: number; upstreamHost: string }
   | { kind: 'close'; containerName: string; hostPort: number }
   | { kind: 'skip-excluded'; containerName: string; port: number }
+  | { kind: 'skip-loopback'; containerName: string; port: number }
   | { kind: 'skip-eaddrinuse'; containerName: string; port: number; reason: string }
   | { kind: 'ip-resolved'; containerName: string; containerIp: string }
   | { kind: 'ip-changed'; containerName: string; from: string; to: string }
@@ -96,10 +97,14 @@ export async function startBroker(opts: BrokerOptions): Promise<StartBrokerResul
     })
   }
 
-  const installForwarder = async (port: number): Promise<void> => {
+  const installForwarder = async (port: number, reachableFromBridge: boolean): Promise<void> => {
     if (stopped) return
     if (opts.excludePorts.has(port)) {
       log({ kind: 'skip-excluded', containerName: opts.containerName, port })
+      return
+    }
+    if (!reachableFromBridge) {
+      log({ kind: 'skip-loopback', containerName: opts.containerName, port })
       return
     }
     if (forwarders.has(port)) return
@@ -142,7 +147,9 @@ export async function startBroker(opts: BrokerOptions): Promise<StartBrokerResul
     await Promise.all(old.map((f) => f.stop()))
     log({ kind: 'ip-changed', containerName: opts.containerName, from: containerIp, to: nextIp })
     containerIp = nextIp
-    for (const port of ports) await installForwarder(port)
+    // Ports in `forwarders` were already vetted as bridge-reachable when first
+    // installed; reinstall with the same assumption against the new IP.
+    for (const port of ports) await installForwarder(port, true)
   }
 
   detector = startDetector({
@@ -151,7 +158,11 @@ export async function startBroker(opts: BrokerOptions): Promise<StartBrokerResul
     intervalMs: opts.intervalMs,
     maxConsecutiveFailures: opts.maxConsecutiveFailures,
     onChange: (change: PortChange) => {
-      enqueue(() => (change.kind === 'open' ? installForwarder(change.port) : removeForwarder(change.port)))
+      enqueue(() =>
+        change.kind === 'open'
+          ? installForwarder(change.port, change.reachableFromBridge)
+          : removeForwarder(change.port),
+      )
     },
     onError: (err) => {
       log({ kind: 'detector-error', containerName: opts.containerName, message: err.message })

--- a/src/hostd/portbroker/detector.test.ts
+++ b/src/hostd/portbroker/detector.test.ts
@@ -2,15 +2,25 @@ import { describe, expect, test } from 'bun:test'
 
 import type { DockerExec, DockerExecResult } from '@/container'
 
-import { parseListeningPorts, startDetector, type PortChange } from './detector'
+import { parseListeningPorts, parseListeningSockets, startDetector, type PortChange } from './detector'
 
 const PROC_TCP_TWO_LISTEN = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
-   0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0
-   1: 0000000000000000FFFF00000100007F:0050 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 200 1 0 200 0
+   0: 00000000:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0
+   1: 00000000000000000000000000000000:0050 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 200 1 0 200 0
    2: 0100007F:0BB8 0100007F:1234 06 00000000:00000000 00:00000000 00000000     0        0 300 1 0 300 0
 `
 const PROC_TCP_ONE_LISTEN = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
-   0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0
+   0: 00000000:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0
+`
+const PROC_TCP_LOOPBACK_ONLY = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:12F0 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0
+`
+const PROC_TCP_IPV6_LOOPBACK = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000001000000:12F0 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0
+`
+const PROC_TCP_DUAL_LISTEN = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:12F0 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 100 1 0 100 0
+   1: 00000000000000000000000000000000:12F0 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 200 1 0 200 0
 `
 const PROC_TCP_EMPTY = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
 `
@@ -57,6 +67,34 @@ describe('parseListeningPorts', () => {
 
   test('malformed lines are skipped silently', () => {
     expect(parseListeningPorts('garbage\n   sl: nope\n')).toEqual(new Set())
+  })
+})
+
+describe('parseListeningSockets', () => {
+  test('marks IPv4 wildcard listeners as bridge-reachable', () => {
+    const sockets = parseListeningSockets(PROC_TCP_ONE_LISTEN)
+    expect(sockets.size).toBe(1)
+    expect(sockets.get(8080)).toEqual({ port: 8080, reachableFromBridge: true })
+  })
+
+  test('marks IPv4 127.0.0.1-only listeners as not bridge-reachable', () => {
+    const sockets = parseListeningSockets(PROC_TCP_LOOPBACK_ONLY)
+    expect(sockets.get(4848)).toEqual({ port: 4848, reachableFromBridge: false })
+  })
+
+  test('marks IPv6 ::1-only listeners as not bridge-reachable', () => {
+    const sockets = parseListeningSockets(PROC_TCP_IPV6_LOOPBACK)
+    expect(sockets.get(4848)).toEqual({ port: 4848, reachableFromBridge: false })
+  })
+
+  test('IPv6 wildcard listener counts as bridge-reachable', () => {
+    const sockets = parseListeningSockets(PROC_TCP_TWO_LISTEN)
+    expect(sockets.get(80)).toEqual({ port: 80, reachableFromBridge: true })
+  })
+
+  test('a port with both loopback and wildcard listeners is bridge-reachable', () => {
+    const sockets = parseListeningSockets(PROC_TCP_DUAL_LISTEN)
+    expect(sockets.get(4848)).toEqual({ port: 4848, reachableFromBridge: true })
   })
 })
 
@@ -148,7 +186,7 @@ describe('startDetector', () => {
     await waitFor(() => events.length >= 1)
     await detector.stop()
 
-    expect(events).toEqual([{ kind: 'open', port: 8080 }])
+    expect(events).toEqual([{ kind: 'open', port: 8080, reachableFromBridge: true }])
     expect(errors[0]!.message).toContain('transient')
     expect(fatals).toHaveLength(0)
   })
@@ -192,6 +230,43 @@ describe('startDetector', () => {
 
     expect(fatals[0]!.message).toContain('docker exec failed')
     expect(fatals[0]!.message).toContain('3 times')
+  })
+
+  test('emits open with reachableFromBridge=false for loopback-only listeners', async () => {
+    const events: PortChange[] = []
+    const { exec } = fakeExec([{ exitCode: 0, stdout: PROC_TCP_LOOPBACK_ONLY, stderr: '' }])
+    const detector = startDetector({
+      containerName: 'coder',
+      exec,
+      intervalMs: 50,
+      onChange: (c) => events.push(c),
+    })
+    await waitFor(() => events.length >= 1)
+    await detector.stop()
+
+    expect(events).toEqual([{ kind: 'open', port: 4848, reachableFromBridge: false }])
+  })
+
+  test('emits close+open when reachability changes (loopback gains a wildcard listener)', async () => {
+    const events: PortChange[] = []
+    const { exec } = fakeExec([
+      { exitCode: 0, stdout: PROC_TCP_LOOPBACK_ONLY, stderr: '' },
+      { exitCode: 0, stdout: PROC_TCP_DUAL_LISTEN, stderr: '' },
+    ])
+    const detector = startDetector({
+      containerName: 'coder',
+      exec,
+      intervalMs: 30,
+      onChange: (c) => events.push(c),
+    })
+    await waitFor(() => events.length >= 3)
+    await detector.stop()
+
+    expect(events.slice(0, 3)).toEqual([
+      { kind: 'open', port: 4848, reachableFromBridge: false },
+      { kind: 'close', port: 4848 },
+      { kind: 'open', port: 4848, reachableFromBridge: true },
+    ])
   })
 
   test('stop() halts further ticks', async () => {

--- a/src/hostd/portbroker/detector.ts
+++ b/src/hostd/portbroker/detector.ts
@@ -1,6 +1,15 @@
 import type { DockerExec } from '@/container'
 
-export type PortChange = { kind: 'open'; port: number } | { kind: 'close'; port: number }
+export type ListeningSocket = {
+  port: number
+  // `false` means every listener for this port is bound to loopback inside the
+  // container (IPv4 127.0.0.1 or IPv6 ::1). The host-side broker dials the
+  // container's bridge IP, which the kernel will not route to a loopback-only
+  // socket, so such ports must not be forwarded.
+  reachableFromBridge: boolean
+}
+
+export type PortChange = { kind: 'open'; port: number; reachableFromBridge: boolean } | { kind: 'close'; port: number }
 
 export type DetectorOptions = {
   containerName: string
@@ -21,8 +30,25 @@ const DEFAULT_INTERVAL_MS = 750
 const DEFAULT_MAX_FAILURES = 5
 const PROC_NET_CMD = ['exec', '__name__', 'sh', '-c', 'cat /proc/net/tcp /proc/net/tcp6 2>/dev/null']
 
-export function parseListeningPorts(procContent: string): Set<number> {
-  const ports = new Set<number>()
+const IPV4_LOOPBACK_LE = '0100007F'
+// IPv6 ::1 in /proc/net/tcp6 byte order: each 32-bit word is printed
+// big-endian (`00000000`), but the four words appear in little-endian word
+// order, so ::1 (last word = 1) lands as `...00000000 01000000` with the `01`
+// in the final word's least-significant position.
+const IPV6_LOOPBACK_LE = '00000000000000000000000001000000'
+// IPv4-mapped IPv6 loopback (::ffff:127.0.0.1), as emitted by dual-stack
+// listeners that bind to 127.0.0.1 on AF_INET6.
+const IPV4_MAPPED_LOOPBACK_LE = '0000000000000000FFFF00000100007F'
+
+function isLoopbackAddress(addrHex: string): boolean {
+  const upper = addrHex.toUpperCase()
+  if (upper.length === 8) return upper === IPV4_LOOPBACK_LE
+  if (upper.length === 32) return upper === IPV6_LOOPBACK_LE || upper === IPV4_MAPPED_LOOPBACK_LE
+  return false
+}
+
+export function parseListeningSockets(procContent: string): Map<number, ListeningSocket> {
+  const byPort = new Map<number, ListeningSocket>()
   for (const line of procContent.split('\n')) {
     const trimmed = line.trim()
     if (trimmed.length === 0) continue
@@ -35,18 +61,37 @@ export function parseListeningPorts(procContent: string): Set<number> {
     if (!local) continue
     const colon = local.lastIndexOf(':')
     if (colon < 0) continue
+    const addrHex = local.slice(0, colon)
     const portHex = local.slice(colon + 1)
     const port = Number.parseInt(portHex, 16)
     if (!Number.isFinite(port) || port <= 0 || port > 65535) continue
-    ports.add(port)
+    const thisListenerReachable = !isLoopbackAddress(addrHex)
+    const existing = byPort.get(port)
+    // Aggregate across IPv4/IPv6 rows: a port is bridge-reachable if ANY
+    // listener for it is bound to a non-loopback address. This handles the
+    // common case of `0.0.0.0:N` (IPv4) + `::1:N` (IPv6) where one listener
+    // is exposed and the other is loopback.
+    if (existing) {
+      if (thisListenerReachable && !existing.reachableFromBridge) {
+        byPort.set(port, { port, reachableFromBridge: true })
+      }
+    } else {
+      byPort.set(port, { port, reachableFromBridge: thisListenerReachable })
+    }
   }
-  return ports
+  return byPort
+}
+
+// Backward-compatible thin wrapper. Prefer `parseListeningSockets` for new
+// callers that need to know whether a port is reachable from the bridge IP.
+export function parseListeningPorts(procContent: string): Set<number> {
+  return new Set(parseListeningSockets(procContent).keys())
 }
 
 export function startDetector(opts: DetectorOptions): Detector {
   const interval = opts.intervalMs ?? DEFAULT_INTERVAL_MS
   const maxFailures = opts.maxConsecutiveFailures ?? DEFAULT_MAX_FAILURES
-  let known = new Set<number>()
+  let known = new Map<number, ListeningSocket>()
   let consecutiveFailures = 0
   let stopped = false
   let timer: ReturnType<typeof setTimeout> | null = null
@@ -81,11 +126,20 @@ export function startDetector(opts: DetectorOptions): Detector {
     }
     consecutiveFailures = 0
 
-    const next = parseListeningPorts(result.stdout)
-    for (const port of next) {
-      if (!known.has(port)) opts.onChange({ kind: 'open', port })
+    const next = parseListeningSockets(result.stdout)
+    for (const [port, sock] of next) {
+      const prev = known.get(port)
+      if (!prev) {
+        opts.onChange({ kind: 'open', port, reachableFromBridge: sock.reachableFromBridge })
+      } else if (prev.reachableFromBridge !== sock.reachableFromBridge) {
+        // A port previously seen as loopback-only became bridge-reachable
+        // (or vice versa) because the user added/removed a listener. Emit a
+        // close+open pair so the broker reinstalls (or removes) the forwarder.
+        opts.onChange({ kind: 'close', port })
+        opts.onChange({ kind: 'open', port, reachableFromBridge: sock.reachableFromBridge })
+      }
     }
-    for (const port of known) {
+    for (const port of known.keys()) {
       if (!next.has(port)) opts.onChange({ kind: 'close', port })
     }
     known = next


### PR DESCRIPTION
## Summary

The port broker dials the container's bridge IP to reach forwarded ports. When a service inside the container binds exclusively to loopback (`127.0.0.1` or `::1`), the Linux kernel rejects any connection that arrives at the loopback interface from an external IP — the bridge address doesn't match the socket's bound address. The result is worse than not forwarding: hostd reports the port as open, a host listener appears in `lsof`, but every request resets instantly with no useful error message. This fix teaches the detector to read the local address from `/proc/net/tcp[6]`, skips loopback-only ports entirely, and emits a clear log line directing the user to bind to `0.0.0.0`.

## Why this isn't a regression from PR #17

The bug predates PR #17. That PR was a daemon rename and restructure (portbrokerd → hostd) that didn't touch the detector's `/proc/net/tcp` parser at all. The parser always discarded the local address field and only stored the port number — so `127.0.0.1:4848` and `0.0.0.0:4848` were indistinguishable. PR #17 moved the files; this PR fixes the parse logic.

## Root cause

`parseListeningPorts` in `detector.ts` parsed `/proc/net/tcp[6]` and extracted port numbers, but threw away the local address. The broker then blindly dialed `<container-bridge-ip>:<port>` for every LISTEN entry — including ones where the socket is bound only to `127.0.0.1`. The kernel drops those connections on the container side, so `Bun.connect` fails immediately, producing a connection reset on the host. This affects every dev server that binds to localhost by default: Vite, Next.js dev, Rails, Python `http.server`, and more.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Service bound to `0.0.0.0:N` | ✅ Forwarded | ✅ Forwarded |
| Service bound to `127.0.0.1:N` only | ❌ Host listener created; every request resets | ✅ Skipped; log explains how to fix |
| Service bound to `0.0.0.0:N` (IPv4) + `::1:N` (IPv6) | ❌ IPv4 wildcard worked but was masked by IPv6 loopback confusion | ✅ Wildcard wins; port is forwarded |
| Service adds wildcard listener to an already-loopback-tracked port | ❌ State never updated | ✅ `close + open` pair emitted; forwarder reinstalled |

Log line emitted for skipped ports:

```
[coder] skipping :4848 (bound to 127.0.0.1 inside the container — bind to 0.0.0.0 to expose it)
```

## Changes

### `src/hostd/portbroker/detector.ts`

- New `parseListeningSockets(procContent) → Map<port, ListeningSocket>` function. Reads the local address field from each `/proc/net/tcp[6]` row and sets `reachableFromBridge: false` for IPv4 `127.0.0.1` (`0100007F`), IPv6 `::1` (`00000000000000000000000001000000`), and IPv4-mapped loopback (`0000000000000000FFFF00000100007F`). Aggregates across rows: a port is bridge-reachable if _any_ listener for it is non-loopback.
- `PortChange` `open` variant gains `reachableFromBridge: boolean`. When reachability changes between ticks (e.g. user adds a wildcard listener), the detector emits a `close + open` pair so the broker can reinstall the forwarder.
- `parseListeningPorts` preserved as a backward-compatible thin wrapper over `parseListeningSockets`.

### `src/hostd/portbroker/broker.ts`

- `installForwarder` receives `reachableFromBridge: boolean`; if false, logs `skip-loopback` and returns without creating a host listener.
- New `BrokerLogEvent` variant: `{ kind: 'skip-loopback'; containerName: string; port: number }`.

### `src/hostd/index.ts`

Re-exports `parseListeningSockets` and `ListeningSocket` for external consumers.

### `src/cli/hostd.ts`

Formats the new `skip-loopback` event into the human-readable log line shown above.

## Testing

Pre-commit checks (all clean):

```
bun run typecheck    → clean
bun run lint         → 0 warnings, 0 errors
bun run format:check → all files correctly formatted
bun test             → 853 pass, 0 fail across 69 files
```

> `src/run/index.test.ts` is excluded — it hangs even on plain `origin/main` in this worktree (pre-existing environment issue, confirmed by stashing all changes and reproducing).

New tests:

- **`parseListeningSockets`** — 5 parser unit tests: IPv4 wildcard reachable, IPv4 loopback unreachable, IPv6 `::1` unreachable, IPv6 wildcard reachable, dual-listener wildcard wins.
- **`startDetector`** — 2 new cases: loopback open event carries `reachableFromBridge: false`; `close+open` emitted when reachability changes.
- **`startBroker`** — 2 new cases: loopback-only port emits `skip-loopback` and creates no host listener; dual-listener port (loopback + wildcard) still forwards.

Existing test fixtures (`procWithPorts` in broker, daemon, and detector tests) updated from `0100007F` to `00000000` so they continue testing the "port gets forwarded" path with the new correctness check in place.

## Out of scope

A future "true tunnel" via an in-container connector (e.g. `docker exec nc` relay, or a lightweight sidecar) would let loopback-bound services be forwarded without requiring a rebind. That approach was considered and deferred: it involves per-connection process spawns, image-dependency concerns, and significant complexity. The `bind to 0.0.0.0` guidance covers the majority of real-world cases. A connector-based design can be revisited as a separate feature.