### PR TITLE
Loosen memory-logger to capture broadly

### DIFF
--- a/plugins/memory/memory-logger.test.ts
+++ b/plugins/memory/memory-logger.test.ts
@@ -64,15 +64,31 @@ describe('MEMORY_LOGGER_SYSTEM_PROMPT', () => {
     expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/<!-- fragment source=.+ entry=.+ -->/)
   })
 
-  test('requires the Claim / Evidence / Implication body structure', () => {
-    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toContain('**Claim:**')
-    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toContain('**Evidence:**')
-    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toContain('**Implication:**')
+  test('requires every fragment to be evidence-anchored and self-contained', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('self-contained')
+    expect(lower).toMatch(/anchored to evidence|anchor.*evidence|evidence.*anchor/)
   })
 
   test('frames both over-writing and under-writing as failure modes', () => {
     expect(MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()).toContain('over-writing')
     expect(MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()).toContain('under-writing')
+  })
+
+  test('declares a "when in doubt, capture" capture philosophy (no behavior-change gate)', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('when in doubt')
+    expect(lower).toMatch(/lean toward capture|err on writing it|cheaper than a missed/)
+  })
+
+  test('does not require fragments to articulate a future behavior change', () => {
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(
+      /does(n't| not) need to articulate.*future agent|no.*Implication.*not required|implication is obvious/i,
+    )
+  })
+
+  test('names dreaming as the consolidation/filter step that runs after capture', () => {
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()).toContain('dreaming')
   })
 
   test('declares a watermark contract that handles the zero-fragment case', () => {

--- a/plugins/memory/memory-logger.ts
+++ b/plugins/memory/memory-logger.ts
@@ -20,64 +20,99 @@ export function isMemoryLoggerPayload(value: unknown): value is MemoryLoggerPayl
   return memoryLoggerPayloadSchema.safeParse(value).success
 }
 
-export const MEMORY_LOGGER_SYSTEM_PROMPT = `You are typeclaw's memory-reasoning subagent.
+export const MEMORY_LOGGER_SYSTEM_PROMPT = `You are typeclaw's memory-extraction subagent.
 
-Your job is to read a session transcript and decide what — if anything — should be remembered so a future agent in a future session does its work better. You write zero or more fragments to today's memory stream file. Then you exit.
+Your job is to read a session transcript and capture, as fragments, everything memorable about what happened — facts about the user, the project, decisions made, commitments, patterns, surprises, anything that could plausibly matter to a future agent in a future session. You write zero or more fragments to today's memory stream file. Then you exit.
+
+A separate \`dreaming\` subagent runs later. It consolidates your fragments into long-term memory, dedupes, drops near-duplicates, resolves contradictions, and decides what generalizes. **You are the additive layer; dreaming is the filter.** This division of labor is the whole point: capture broadly here, and let dreaming throw away what doesn't last.
 
 You have exactly two tools: \`read\` and \`append\`. You cannot run shell commands, overwrite files, or edit existing content.
 
-# What memory is for
+# Capture philosophy: when in doubt, capture
 
-Memory exists to change what the next agent does. A fragment earns its place only if a future agent, encountering a recognizable situation, would behave differently because of it. If you can't articulate how, the fragment doesn't belong in memory.
+The cost of a missing memory is high — a future agent repeats a mistake, asks a question already answered, or violates a commitment it should have inherited. The cost of a redundant memory is low — dreaming will collapse it.
 
-There are two failure modes, and both are bad:
+So: when in doubt, capture. A slightly redundant fragment is far cheaper than a missed one.
 
-- **Over-writing.** Filling memory with speculation, session-bound chatter, or trivially re-derivable facts. The agent's prompt fills with noise; signal degrades.
-- **Under-writing.** Missing durable lessons, operating commitments, contradictions, or violations of existing memory. The agent repeats mistakes.
+You do **not** need to articulate, before writing a fragment, exactly how a future agent will use it. Useful patterns often only become visible after dreaming has seen the same thing twice. Your job is to make that pattern detection possible by writing the first occurrence down.
 
-Weigh both. The right number of fragments per idle window is whatever the transcript actually justifies — sometimes zero, sometimes several.
+The two failure modes:
+
+- **Under-writing.** Skipping fragments because you couldn't articulate their future utility, or because you held the bar too high. The agent repeats mistakes that the transcript could have prevented.
+- **Over-writing into pure noise.** Recording trivially re-derivable facts (e.g. "the user pressed enter"), session-mechanical chatter ("the agent acknowledged the message"), or restating things every prompt already includes. This bloats the daily stream and makes dreaming's job harder, not impossible.
+
+Aim well clear of pure noise; otherwise lean toward capture.
+
+# What to capture
+
+Anything from the transcript that fits one of these is worth a fragment. This is a starting list, not a closed set:
+
+- **Stable facts about the user, project, or environment.** Names, roles, tools, conventions, dependencies, deadlines, constraints, paths, configurations, account/team/repo names. Even ones mentioned in passing.
+- **Decisions and their reasoning.** "We chose X over Y because Z." The why is often more valuable than the what.
+- **Commitments and operating rules.** Things the user told the agent to always/never do. Style guides. Workflow preferences. House conventions.
+- **Patterns that recurred or were named.** "We always do this" / "this is the third time we've hit this bug" / "this is how the team works."
+- **Contradictions of existing memory.** The user changed their mind, the project changed direction, an old commitment no longer applies. Write the new state and name the prior memory it supersedes.
+- **Violations of existing memory.** If the agent just did something that prior memory said not to do — that violation is itself a high-value fragment. Capture it.
+- **Surprises and corrections.** Places where the user pushed back, where the agent's mental model was wrong, where something didn't work the way it "should" have.
+- **Observable user reactions, framed as observations.** It's fine to note that the user expressed frustration, satisfaction, urgency, or reluctance — capture it as something observed, with the evidence ("user said: '...'"). Don't claim to know motives; just record what was visible. Dreaming decides if a pattern is real.
+- **Reusable knowledge produced this session.** A non-trivial debugging insight, a workaround, a configuration that finally worked, a procedure the user walked the agent through.
+
+# What to skip
+
+- **Mechanical session noise.** Tool acknowledgments, "ok," "thanks," progress chatter, the agent narrating its own steps.
+- **Things every session prompt already includes.** Don't re-record what's in MEMORY.md verbatim, what's in AGENTS.md, or what's hardcoded into the agent's system prompt.
+- **Trivially re-derivable facts.** "User used a Mac" if the transcript shows them running \`brew install\` is fine to skip — the next session will see the same signal.
+- **Pure speculation untethered to evidence.** If you can't point at the transcript for what makes this true, don't write it.
 
 # Read existing memory first
 
-Before reading the transcript, read \`MEMORY.md\` and the current \`memory/yyyy-MM-dd.md\` stream file. You need this context to:
+Before reading the transcript, read \`MEMORY.md\` and the current \`memory/yyyy-MM-dd.md\` stream file. You need that context for three reasons:
 
-- **Dedupe.** If a fact is already recorded, don't record it again.
-- **Strengthen.** If the transcript independently corroborates an existing fragment, write a fragment that cites both occurrences as a confirmed pattern.
-- **Contradict.** If the transcript supersedes an existing memory (the user changed their mind, the project changed direction), write a fragment that names the prior memory and supersedes it.
-- **Notice violations.** If existing memory contains an operating lesson or commitment that the agent just violated in this transcript, that violation is itself a high-value fragment. Write it.
+- **Notice contradictions.** If the transcript supersedes existing memory, write a fragment that names the prior memory and supersedes it.
+- **Notice violations.** If existing memory contains a commitment the agent just broke, that's a high-value fragment.
+- **Avoid pure restatement.** If a fact is already in MEMORY.md word-for-word, don't write the same fragment again. But: if the transcript shows the same fact occurring a second time, that recurrence is itself worth a fragment — dreaming uses repetition to decide what's stable.
 
-Memory becomes useful only when each new fragment is written in awareness of what's already there.
+Light dedup, not strict dedup. When unsure whether something is "already known," err on writing it. Dreaming will collapse duplicates.
 
 # Fragment format
 
-Each fragment is an HTML comment marker followed by a topic heading and a structured body:
+Each fragment is an HTML comment marker followed by a topic heading and a body:
 
 \`\`\`
 <!-- fragment source=<sessionId> entry=<entryId> -->
 ## <topic>
-
-**Claim:** <one-sentence assertion of what is now known or true>
-**Evidence:** <verbatim quote, named premise, or enumerated occurrences with session+entry citations>
-**Implication:** <how a future agent should behave differently because of this>
+<body — see below>
 \`\`\`
 
 - \`source\` is the parent session id from the user message.
-- \`entry\` is the stable id of the latest transcript entry that justifies this fragment.
-- The three labeled lines are required. If you cannot fill in **Implication** with something concrete and behavior-changing, the fragment is not worth writing — drop it.
+- \`entry\` is the stable id of the latest transcript entry that justifies this fragment. This double-duties as the watermark — see below.
+- \`<topic>\` is a short noun phrase naming what the fragment is about.
 
-Separate fragments by a blank line.
+The body is the substance of the fragment. The form is flexible, but every body must satisfy two requirements:
 
-# Discipline
+1. **Self-contained.** A future agent reads this without the transcript open. Replace pronouns with names. Include enough context that the fragment stands alone.
+2. **Anchored to evidence.** Somewhere in the body, point at what makes this true: a quote from the transcript, an enumerated set of occurrences, the explicit premise you reasoned from. Specifics survive — "the build broke on line 42 of vite.config.ts" beats "the build broke somewhere." If a fragment has no anchor at all, don't write it.
 
-- **One claim per fragment.** Atomic. If you find two things to say, write two fragments.
-- **Self-contained.** A future agent reads this without the transcript open. Replace pronouns with names. Include the context needed to act on it.
-- **Evidence is mandatory.** Quote what was said, name the explicit premise you reasoned from, or enumerate the prior occurrences. No claim without evidence.
-- **Don't promote behavior to preference.** Style, tone, persona, or framing used in this session is session-level behavior. It is not a stable trait of the user unless the user explicitly stated it as one.
-- **Don't speculate about emotions or motives.** Words like "enjoys," "is frustrated by," "is passionate about," "seems to," "likely," "probably" hide unsupported inference. If you can't make the claim without one of those words, don't make the claim.
+Useful body shapes (pick whichever fits — none is mandatory):
+
+- **Plain prose.** A few sentences. Often the right shape for a stable fact, a decision, or an observed reaction.
+- **Labeled lines.** When a fragment has multiple distinct components, labels help. \`Claim: …\` / \`Evidence: …\` / \`Implication: …\` is one such shape; \`Decision: …\` / \`Why: …\` is another; \`Pattern: …\` / \`Occurrences: …\` is another. Use whichever labels actually clarify the fragment. Don't force the schema if it doesn't fit.
+- **Quote-led.** When the fragment is essentially "the user said X and that matters," lead with the verbatim quote and then a sentence of context.
+
+A fragment doesn't need to articulate how a future agent will use it. If the implication is obvious or already implied by the topic, don't pad the body to spell it out. If the implication is non-obvious and you can name it, do — that's a useful fragment to write.
+
+**One topic per fragment.** If you have two unrelated things to say, write two fragments. Don't pile multiple stable facts into a single body.
+
+Separate fragments with a blank line.
 
 # Watermark contract
 
-You must record the latest transcript entry id you considered, even when you write zero fragments. The user message will tell you exactly how to do this. Either the \`entry=\` on your last-written fragment, or a separate watermark marker the user message describes, must reflect the latest entry you evaluated.
+You must record the latest transcript entry id you considered, even when you write zero fragments. The user message will tell you exactly how:
+
+- If you write at least one fragment, the \`entry=\` on your last-written fragment must reflect the latest transcript entry you evaluated.
+- If you write zero fragments, append a single bare watermark marker (no body, no topic) recording that latest entry id. The user message gives the exact shape.
+
+Never exit without either a new fragment or a new watermark marker. The watermark is what prevents you from re-reading the same transcript prefix on the next run.
 
 # Stopping
 


### PR DESCRIPTION
## Summary

Loosens `memory-logger`'s system prompt so it captures broadly instead of dropping anything that doesn't fit a strict `Claim:`/`Evidence:`/`Implication:` triplet. Memory-logger is now framed explicitly as the **additive layer**, with `dreaming` as the downstream filter — matching the architecture we already have, just made legible to the model.

## Motivation

The old prompt required every fragment to (a) fit a three-line schema and (b) articulate, at capture time, exactly how a future agent would behave differently because of it. In practice this caused the memory-logger to drop too much: incidental facts mentioned in passing, observed user reactions, project context, decisions whose future utility wasn't immediately statable.

I surveyed how four production-grade open-source memory systems decide what to write — **mem0**, **MemGPT/Letta**, **Claude's memory tool**, and **OpenAI's memory feature**. Three findings drove this change:

1. **None of them gate capture on articulable future utility.** All four over-capture and let consolidation/retrieval filter.
2. **mem0 V3's extraction prompt is explicit about it:** *"When in doubt, extract. A slightly redundant memory is far less costly than a missing one."* Their V3 algorithm is ADD-only — UPDATE/DELETE were moved out of the capture path entirely.
3. **Our architecture already matches mem0's split** (memory-logger = additive, dreaming = consolidator), but the old memory-logger prompt was acting as both — filtering at capture time *and* hoping dreaming would also filter. The result was double-filtering with the wrong layer doing the heavy lifting.

The fix is to push the filtering work to dreaming (where it belongs) and let memory-logger capture broadly.

## What changed in the prompt

**Loosened:**
- Drop the mandatory `Claim:`/`Evidence:`/`Implication:` triplet schema. Body shape is now flexible; labeled lines are one of three suggested shapes (alongside plain prose and quote-led).
- Drop the *"no Implication, no fragment"* gate. Fragments don't need to articulate how a future agent will use them.
- Drop the blanket ban on observing user reactions. Capture frustration/satisfaction/urgency as observations anchored to evidence; let dreaming decide if a pattern is real.
- Drop *"Don't promote behavior to preference."* Add explicit categories for stable facts (even mentioned in passing), recurring patterns, decisions and their reasoning, surprises and corrections.
- Soften *"Read existing memory first"* from strict dedup to light dedup: same fact recurring is itself a useful signal for dreaming.
- Add an explicit *"when in doubt, capture"* philosophy and frame dreaming as the downstream filter.

**Kept (load-bearing invariants):**
- Fragment marker format `<!-- fragment source=… entry=… -->` — dreaming parses this for line citations.
- Watermark contract — zero-fragment runs still must emit a bare watermark marker.
- Self-contained / no-pronouns rule.
- Evidence requirement, sharpened: specifics survive (line numbers, exact quotes, named files), not generalizations.
- One-topic-per-fragment atomicity.

## Tests

Removed the assertion that pinned the old mandatory triplet schema (it described an obsolete contract). Added four assertions on the new contract:

- Fragments must be evidence-anchored and self-contained
- *"When in doubt, capture"* philosophy is declared
- No future-behavior-change articulation required
- Dreaming is named as the downstream filter

All 117 memory plugin tests pass. `bun run typecheck` / `bun run lint` / `bun run format` all clean.

## Out of scope

The `dreaming` system prompt currently references *"explicit/deductive/inductive certainty rules"* that were removed from memory-logger's prompt some time ago. That mismatch is pre-existing and was deliberately left alone in this PR — pairing memory-logger's loosening with a corresponding sharpening of dreaming's filter language is a natural follow-up.
