### PR TITLE
Nudge the agent with current dirty-files state at session start

### DIFF
--- a/src/agent/git-nudge.test.ts
+++ b/src/agent/git-nudge.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { formatNudge, parsePorcelain, renderGitNudge, type GitNudgeDeps } from './git-nudge'
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-git-nudge-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('parsePorcelain', () => {
+  test('extracts paths from standard status lines', () => {
+    const out = parsePorcelain(' M src/foo.ts\n?? src/bar.ts\nA  src/baz.ts\n')
+    expect(out).toEqual(['src/foo.ts', 'src/bar.ts', 'src/baz.ts'])
+  })
+
+  test('returns the destination path for renames', () => {
+    const out = parsePorcelain('R  src/old.ts -> src/new.ts\n')
+    expect(out).toEqual(['src/new.ts'])
+  })
+
+  test('ignores blank and too-short lines', () => {
+    const out = parsePorcelain('\n M\n M ok.ts\n')
+    expect(out).toEqual(['ok.ts'])
+  })
+
+  test('handles a trailing newline without producing an empty entry', () => {
+    const out = parsePorcelain(' M a.ts\n M b.ts\n')
+    expect(out).toEqual(['a.ts', 'b.ts'])
+  })
+})
+
+describe('formatNudge', () => {
+  test('renders a single-file count grammatically', () => {
+    const text = formatNudge(['src/foo.ts'])
+    expect(text).toContain('1 uncommitted file ')
+    expect(text).toContain('- src/foo.ts')
+  })
+
+  test('renders a plural count grammatically', () => {
+    const text = formatNudge(['a.ts', 'b.ts'])
+    expect(text).toContain('2 uncommitted files ')
+  })
+
+  test('lists up to ten paths inline and summarizes the rest', () => {
+    const paths = Array.from({ length: 13 }, (_, i) => `src/file-${i}.ts`)
+    const text = formatNudge(paths)
+    expect(text).toContain('13 uncommitted files')
+    expect(text).toContain('- src/file-0.ts')
+    expect(text).toContain('- src/file-9.ts')
+    expect(text).not.toContain('- src/file-10.ts')
+    expect(text).toContain('… and 3 more')
+  })
+
+  test('does not add a "and N more" line when the list fits', () => {
+    const paths = Array.from({ length: 10 }, (_, i) => `f-${i}.ts`)
+    const text = formatNudge(paths)
+    expect(text).not.toContain('and 0 more')
+    expect(text).not.toContain('… and')
+  })
+
+  test('starts with a markdown section header that mirrors system-prompt style', () => {
+    const text = formatNudge(['x.ts'])
+    expect(text.startsWith('## Uncommitted changes at session start')).toBe(true)
+  })
+})
+
+describe('renderGitNudge', () => {
+  test('returns empty string when the directory is not a git repo', async () => {
+    const deps: GitNudgeDeps = {
+      readStatus: async () => {
+        throw new Error('should not be called when no .git is present')
+      },
+    }
+    const text = await renderGitNudge(agentDir, deps)
+    expect(text).toBe('')
+  })
+
+  test('returns empty string when the worktree is clean', async () => {
+    await mkdir(join(agentDir, '.git'))
+    const deps: GitNudgeDeps = { readStatus: async () => [] }
+    const text = await renderGitNudge(agentDir, deps)
+    expect(text).toBe('')
+  })
+
+  test('returns empty string when readStatus signals failure (null)', async () => {
+    await mkdir(join(agentDir, '.git'))
+    const deps: GitNudgeDeps = { readStatus: async () => null }
+    const text = await renderGitNudge(agentDir, deps)
+    expect(text).toBe('')
+  })
+
+  test('renders a nudge listing the dirty paths when the worktree is dirty', async () => {
+    await mkdir(join(agentDir, '.git'))
+    const deps: GitNudgeDeps = { readStatus: async () => ['src/foo.ts', 'src/bar.ts'] }
+    const text = await renderGitNudge(agentDir, deps)
+    expect(text).toContain('2 uncommitted files')
+    expect(text).toContain('- src/foo.ts')
+    expect(text).toContain('- src/bar.ts')
+  })
+
+  test('drops paths under sessions/ and memory/ from the nudge', async () => {
+    await mkdir(join(agentDir, '.git'))
+    const deps: GitNudgeDeps = {
+      readStatus: async () => ['sessions/abc.jsonl', 'memory/2026-04-27.md', 'src/foo.ts'],
+    }
+    const text = await renderGitNudge(agentDir, deps)
+    expect(text).toContain('1 uncommitted file ')
+    expect(text).toContain('- src/foo.ts')
+    expect(text).not.toContain('sessions/abc.jsonl')
+    expect(text).not.toContain('memory/2026-04-27.md')
+  })
+
+  test('returns empty string when every dirty path is runtime-owned', async () => {
+    await mkdir(join(agentDir, '.git'))
+    const deps: GitNudgeDeps = {
+      readStatus: async () => ['sessions/abc.jsonl', 'memory/2026-04-27.md'],
+    }
+    const text = await renderGitNudge(agentDir, deps)
+    expect(text).toBe('')
+  })
+})

--- a/src/agent/git-nudge.ts
+++ b/src/agent/git-nudge.ts
@@ -1,0 +1,95 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const MAX_LISTED_PATHS = 10
+
+// `sessions/` is auto-snapshotted and `memory/` is force-committed by the
+// dreaming subagent — both are runtime-owned, never agent-owned. Nudging the
+// agent to commit them would mislead it into staging files outside its remit.
+const RUNTIME_OWNED_PREFIXES = ['sessions/', 'memory/']
+
+export type GitNudgeDeps = {
+  readStatus: (agentDir: string) => Promise<readonly string[] | null>
+}
+
+// Returns "" (not a placeholder string) when there is nothing to nudge about.
+// The empty case must add zero bytes to the system prompt so cache prefixes
+// stay identical to a clean-worktree agent folder.
+export async function renderGitNudge(agentDir: string, deps: GitNudgeDeps = defaultDeps): Promise<string> {
+  if (!existsSync(join(agentDir, '.git'))) return ''
+  const status = await deps.readStatus(agentDir)
+  if (status === null) return ''
+  const dirty = filterAgentOwned(status)
+  if (dirty.length === 0) return ''
+  return formatNudge(dirty)
+}
+
+export function formatNudge(dirtyPaths: readonly string[]): string {
+  const total = dirtyPaths.length
+  const shown = dirtyPaths.slice(0, MAX_LISTED_PATHS)
+  const remaining = total - shown.length
+
+  const lines = [
+    '## Uncommitted changes at session start',
+    '',
+    `git reports ${total} uncommitted file${total === 1 ? '' : 's'} in your agent folder right now:`,
+    '',
+    ...shown.map((p) => `- ${p}`),
+  ]
+  if (remaining > 0) {
+    lines.push(`- … and ${remaining} more`)
+  }
+  lines.push(
+    '',
+    "These are real, current modifications — not advice. Before declaring this session's task done, commit any of these you're responsible for, with `git add <paths>` and `git commit -m \"…\"` per the version-control rules above. If a listed path is from earlier work you didn't touch, leave it alone.",
+  )
+  return lines.join('\n')
+}
+
+// Porcelain v1 line shape: "XY <path>" or, for renames, "XY <orig> -> <dest>".
+// We drop the status code and, on rename, return the destination because that
+// is the live file the agent would `git add`.
+export function parsePorcelain(stdout: string): string[] {
+  const out: string[] = []
+  for (const raw of stdout.split('\n')) {
+    if (raw.length < 4) continue
+    const rest = raw.slice(3)
+    const arrowIdx = rest.indexOf(' -> ')
+    out.push(arrowIdx === -1 ? rest : rest.slice(arrowIdx + 4))
+  }
+  return out
+}
+
+function filterAgentOwned(paths: readonly string[]): string[] {
+  return paths.filter((p) => !RUNTIME_OWNED_PREFIXES.some((prefix) => p.startsWith(prefix)))
+}
+
+// Mirrors the spawn pattern in `src/container/start.ts` `commitSystemFile`.
+const defaultDeps: GitNudgeDeps = {
+  async readStatus(agentDir) {
+    const bun = getBun()
+    if (!bun) return null
+    try {
+      const proc = bun.spawn({
+        cmd: ['git', 'status', '--porcelain=v1'],
+        cwd: agentDir,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      const exit = await proc.exited
+      if (exit !== 0) return null
+      const text = await new Response(proc.stdout).text()
+      return parsePorcelain(text)
+    } catch {
+      return null
+    }
+  },
+}
+
+// Pieces of `@/agent` are exercised under Node in some tests where
+// `globalThis.Bun` is undefined; this fallback matches the helper in
+// `src/container/start.ts`.
+function getBun(): typeof Bun | null {
+  const g = globalThis as { Bun?: typeof Bun }
+  return g.Bun ?? null
+}

--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -4,8 +4,39 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { createHookBus, type PluginRegistry } from '@/plugin'
+
 import { createOverrideResourceLoader, createResourceLoader, getBundledSkillsDir } from './index'
 import { DEFAULT_SYSTEM_PROMPT } from './system-prompt'
+
+async function runGit(cwd: string, args: string[]): Promise<void> {
+  const proc = Bun.spawn({
+    cmd: ['git', ...args],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  })
+  const code = await proc.exited
+  if (code !== 0) {
+    const stderr = await new Response(proc.stderr).text()
+    throw new Error(`git ${args.join(' ')} failed: ${stderr}`)
+  }
+}
+
+async function initGitRepo(cwd: string): Promise<void> {
+  await runGit(cwd, ['init', '-q', '-b', 'main'])
+}
+
+function silentLogger() {
+  return { info: () => {}, warn: () => {}, error: () => {} }
+}
 
 let agentDir: string
 
@@ -150,6 +181,84 @@ describe('createResourceLoader', () => {
     // when / then
     const loader = await createResourceLoader({ agentDir })
     expect(loader.getSkills().skills).toBeDefined()
+  })
+
+  test('appends a dirty-files nudge to the system prompt when the agent folder has uncommitted changes', async () => {
+    // given
+    await initGitRepo(agentDir)
+    await writeFile(join(agentDir, 'IDENTITY.md'), 'tracked file')
+    await runGit(agentDir, ['add', 'IDENTITY.md'])
+    await runGit(agentDir, ['commit', '-m', 'init'])
+    await writeFile(join(agentDir, 'IDENTITY.md'), 'modified content')
+
+    // when
+    const loader = await createResourceLoader({ agentDir })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).toContain('## Uncommitted changes at session start')
+    expect(prompt).toContain('IDENTITY.md')
+  })
+
+  test('omits the dirty-files nudge entirely when the worktree is clean', async () => {
+    // given
+    await initGitRepo(agentDir)
+    await writeFile(join(agentDir, 'IDENTITY.md'), 'committed')
+    await runGit(agentDir, ['add', 'IDENTITY.md'])
+    await runGit(agentDir, ['commit', '-m', 'init'])
+
+    // when
+    const loader = await createResourceLoader({ agentDir })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).not.toContain('## Uncommitted changes at session start')
+  })
+
+  test('omits the dirty-files nudge when the agent folder is not a git repo', async () => {
+    // when (no .git in agentDir)
+    const loader = await createResourceLoader({ agentDir })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).not.toContain('## Uncommitted changes at session start')
+  })
+
+  test('places the nudge after the plugin session.prompt mutation so plugin-injected text remains in the cacheable prefix', async () => {
+    // given
+    await initGitRepo(agentDir)
+    await writeFile(join(agentDir, 'IDENTITY.md'), 'baseline')
+    await runGit(agentDir, ['add', 'IDENTITY.md'])
+    await runGit(agentDir, ['commit', '-m', 'init'])
+    await writeFile(join(agentDir, 'IDENTITY.md'), 'dirty edit')
+
+    const hooks = createHookBus()
+    hooks.registerAll('plugin-test', agentDir, silentLogger(), {
+      'session.prompt': async (event) => {
+        event.prompt = `${event.prompt}\n\nPLUGIN-INJECTED-MARKER`
+      },
+    })
+    const registry: PluginRegistry = {
+      tools: [],
+      subagents: [],
+      cronJobs: [],
+      skills: [],
+      skillsDirs: [],
+    }
+
+    // when
+    const loader = await createResourceLoader({
+      agentDir,
+      plugins: { registry, hooks, sessionId: 'test-session', agentDir },
+    })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    const pluginIdx = prompt.indexOf('PLUGIN-INJECTED-MARKER')
+    const nudgeIdx = prompt.indexOf('## Uncommitted changes at session start')
+    expect(pluginIdx).toBeGreaterThan(-1)
+    expect(nudgeIdx).toBeGreaterThan(-1)
+    expect(nudgeIdx).toBeGreaterThan(pluginIdx)
   })
 })
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -20,6 +20,7 @@ import type { ReloadRegistry } from '@/reload'
 import type { Stream } from '@/stream'
 
 import { getAuth } from './auth'
+import { renderGitNudge } from './git-nudge'
 import { resolveBuiltinToolRefs, wrapPluginTool } from './plugin-tools'
 import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
@@ -247,6 +248,14 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
     const event = { prompt: systemPrompt, sessionId: options.plugins.sessionId, agentDir }
     await options.plugins.hooks.runSessionPrompt(event)
     systemPrompt = event.prompt
+  }
+
+  // Appended last so the dirty-files snapshot is the most-recent context the
+  // agent reads, and so its bytes sit in the cache-suffix region rather than
+  // splitting the cacheable prefix shared by clean-worktree sessions.
+  const gitNudge = await renderGitNudge(agentDir)
+  if (gitNudge !== '') {
+    systemPrompt = `${systemPrompt}\n\n${gitNudge}`
   }
 
   const additionalSkillPaths = [getBundledSkillsDir()]


### PR DESCRIPTION
## Why

The agent regularly forgets to commit after editing files even though both the system prompt and the bundled `typeclaw-git` skill explicitly tell it to. The instruction is there. What's missing is **situational awareness**: by the time the agent considers "am I done?", it has lost track of which files it touched. Telling it "commit before finishing" when it doesn't know the worktree is dirty is just hoping it remembers.

Rather than auto-committing on the agent's behalf, this PR gives the agent the missing situational data: a per-session snapshot of `git status` rendered into the system prompt, so the existing version-control instructions have something concrete to act on.

## What

Append a section like this to the system prompt at session creation:

> ## Uncommitted changes at session start
>
> git reports 3 uncommitted files in your agent folder right now:
>
> - src/agent/foo.ts
> - src/agent/bar.ts
> - README.md
>
> These are real, current modifications — not advice. Before declaring this session's task done, commit any of these you're responsible for, with `git add <paths>` and `git commit -m "…"` per the version-control rules above. If a listed path is from earlier work you didn't touch, leave it alone.

- Up to 10 paths listed inline; the rest summarized as "and N more".
- Paths under `sessions/` and `memory/` are filtered — those are runtime-owned (auto-snapshotted and force-committed by the dreaming subagent), not agent-owned.
- When the worktree is clean, when there's no `.git` folder, or when git/bun is unavailable, the function adds **zero bytes** to the prompt — clean-worktree sessions stay byte-identical to before, so prompt caching is unaffected.

## Where

- New file `src/agent/git-nudge.ts` — pure renderer (`formatNudge`, `parsePorcelain`) plus a thin spawn-out-to-git default. Mirrors the spawn pattern from `commitSystemFile` in `src/container/start.ts`.
- New file `src/agent/git-nudge.test.ts` — 15 unit tests covering the pure layer (porcelain parsing including the rename `->` form, formatting/pluralization, truncation at 10, runtime-owned filtering, all empty-string cases).
- Modified `src/agent/index.ts` — `createResourceLoader` calls `renderGitNudge(agentDir)` after the plugin `session.prompt` hook runs and appends the result to the system prompt. Plugin-injected text remains in the cacheable prefix.
- Modified `src/agent/index.test.ts` — 4 integration tests asserting the wiring: dirty repo → nudge appears, clean repo → no nudge, non-git folder → no nudge, plugin text comes before nudge (cache-ordering invariant).

## Cache strategy

Per the existing comment in `src/plugin/types.ts` (lines 97-99), provider prompt caching requires byte-identical prefixes; mutations near the end of the system prompt preserve cache hits. The git nudge is appended **after** the plugin `session.prompt` mutation so plugin-injected sections (e.g. memory plugin's MEMORY.md injection) stay in the cacheable region. Empty-string return on clean worktrees keeps the prompt byte-identical to a freshly-cloned agent folder.

## What this is NOT

- **Not auto-commit.** No background process runs `git add` / `git commit` on the agent's behalf. The agent stays the sole author of commits — this PR just makes sure it has the data it needs to follow its own instructions.
- **Not a plugin.** Implemented in core because force-nudging dirty state is a typeclaw guarantee, not an opt-in capability. Bundling it as a plugin would suggest it's optional.
- **Not turn-by-turn.** Like the memory plugin's section, this is computed once at session creation. Within a long session, the snapshot can go stale (the agent might commit and the section still says dirty until next session); the failure mode is a redundant nudge, not a missed one.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 warnings, 0 errors on 204 files
- `bun run format:check` — all files formatted
- `bun test --dots` (full suite) — passes
- `bun test src/agent/` — 197 tests pass

## Note on the default test reporter

`bun run test` (which uses bun's default reporter) currently exits with code 1 in non-TTY contexts even when every test passes — this reproduces on a clean `origin/main` checkout with no changes from this PR. Per-area test runs (`bun test src/agent/` etc.) and the `--dots` reporter both report exit 0. Looks like a bun-test reporter issue, orthogonal to this PR. Worth filing separately.