### PR TITLE
Let the agent fetch upstream channel history on demand

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -4,9 +4,11 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { createChannelRouter } from '@/channels/router'
 import { createHookBus, type PluginRegistry } from '@/plugin'
 
-import { createOverrideResourceLoader, createResourceLoader, getBundledSkillsDir } from './index'
+import { buildChannelTools, createOverrideResourceLoader, createResourceLoader, getBundledSkillsDir } from './index'
+import type { SessionOrigin } from './session-origin'
 import { DEFAULT_SYSTEM_PROMPT } from './system-prompt'
 
 async function runGit(cwd: string, args: string[]): Promise<void> {
@@ -286,6 +288,87 @@ describe('createOverrideResourceLoader', () => {
 
     // then
     expect(loader.getAppendSystemPrompt()).toEqual([])
+  })
+})
+
+describe('buildChannelTools', () => {
+  function makeRouter() {
+    return createChannelRouter({
+      agentDir: '/tmp/test-channel-tools',
+      configForAdapter: () => ({
+        allow: ['*'],
+        engagement: { trigger: ['mention'], stickiness: 'off' },
+        enabled: true,
+      }),
+    })
+  }
+
+  const channelOrigin: SessionOrigin = {
+    kind: 'channel',
+    adapter: 'slack-bot',
+    workspace: 'T0',
+    chat: 'C0',
+    thread: '1700000000.000100',
+  }
+
+  const tuiOrigin: SessionOrigin = { kind: 'tui', sessionId: 'ses-tui-1' }
+  const cronOrigin: SessionOrigin = { kind: 'cron', jobId: 'j1', jobKind: 'prompt' }
+
+  test('exposes channel_send, channel_reply, AND channel_history when origin is channel', () => {
+    // given
+    const router = makeRouter()
+
+    // when
+    const tools = buildChannelTools(router, channelOrigin)
+
+    // then
+    const names = tools.map((t) => t.name).sort()
+    expect(names).toEqual(['channel_history', 'channel_reply', 'channel_send'])
+  })
+
+  test('exposes only channel_send (no reply or history) when origin is non-channel', () => {
+    // given
+    const router = makeRouter()
+
+    // when
+    const tools = buildChannelTools(router, tuiOrigin)
+
+    // then
+    const names = tools.map((t) => t.name).sort()
+    expect(names).toEqual(['channel_send'])
+  })
+
+  test('exposes only channel_send when origin is cron (not channel-routed)', () => {
+    // given
+    const router = makeRouter()
+
+    // when
+    const tools = buildChannelTools(router, cronOrigin)
+
+    // then
+    const names = tools.map((t) => t.name).sort()
+    expect(names).toEqual(['channel_send'])
+  })
+
+  test('exposes no channel tools when channelRouter is undefined', () => {
+    // when
+    const tools = buildChannelTools(undefined, channelOrigin)
+    // then
+    expect(tools).toHaveLength(0)
+  })
+
+  test('exposes no channel tools when origin is undefined and channelRouter is undefined', () => {
+    // when
+    const tools = buildChannelTools(undefined, undefined)
+    // then
+    expect(tools).toHaveLength(0)
+  })
+
+  test('exposes only channel_send when channelRouter is set but origin is undefined', () => {
+    // when
+    const tools = buildChannelTools(makeRouter(), undefined)
+    // then
+    expect(tools.map((t) => t.name)).toEqual(['channel_send'])
   })
 })
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -26,6 +26,7 @@ import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
 import { renderSessionOrigin, type SessionOrigin } from './session-origin'
 import { DEFAULT_SYSTEM_PROMPT } from './system-prompt'
+import { createChannelHistoryTool } from './tools/channel-history'
 import { createChannelReplyTool } from './tools/channel-reply'
 import { createChannelSendTool } from './tools/channel-send'
 import { createRestartTool } from './tools/restart'
@@ -129,36 +130,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
             webfetchTool,
             ...(options.reloadRegistry ? [createReloadTool({ registry: options.reloadRegistry })] : []),
             ...(options.stream ? [createStreamSnapshotTool({ stream: options.stream })] : []),
-            ...(options.channelRouter
-              ? [
-                  ...(options.origin?.kind === 'channel'
-                    ? [
-                        createChannelReplyTool({
-                          router: options.channelRouter,
-                          origin: {
-                            adapter: options.origin.adapter,
-                            workspace: options.origin.workspace,
-                            chat: options.origin.chat,
-                            thread: options.origin.thread,
-                          },
-                        }),
-                      ]
-                    : []),
-                  createChannelSendTool({
-                    router: options.channelRouter,
-                    ...(options.origin?.kind === 'channel'
-                      ? {
-                          origin: {
-                            adapter: options.origin.adapter,
-                            workspace: options.origin.workspace,
-                            chat: options.origin.chat,
-                            thread: options.origin.thread,
-                          },
-                        }
-                      : {}),
-                  }),
-                ]
-              : []),
+            ...buildChannelTools(options.channelRouter, options.origin),
             ...(options.containerName ? [createRestartTool({ containerName: options.containerName })] : []),
             ...pluginCustomTools,
           ]
@@ -177,6 +149,33 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     if (materializedSkills) await materializedSkills.dispose()
   }
   return { session, dispose }
+}
+
+// Builds the channel tool subset: channel_send (always when a router is
+// available), plus channel_reply + channel_history (only when the session
+// origin is a channel — those rely on origin-bound addressing). Extracted
+// from createSessionWithDispose so composition can be unit-tested without
+// going through createAgentSession / auth.
+export function buildChannelTools(
+  channelRouter: ChannelRouter | undefined,
+  origin: SessionOrigin | undefined,
+): ToolDefinition[] {
+  if (!channelRouter) return []
+  const tools: ToolDefinition[] = []
+  if (origin?.kind === 'channel') {
+    const channelOrigin = {
+      adapter: origin.adapter,
+      workspace: origin.workspace,
+      chat: origin.chat,
+      thread: origin.thread,
+    }
+    tools.push(createChannelReplyTool({ router: channelRouter, origin: channelOrigin }))
+    tools.push(createChannelHistoryTool({ router: channelRouter, origin: channelOrigin }))
+    tools.push(createChannelSendTool({ router: channelRouter, origin: channelOrigin }))
+  } else {
+    tools.push(createChannelSendTool({ router: channelRouter }))
+  }
+  return tools
 }
 
 function wrapRegistryTools(plugins: PluginSessionWiring | undefined): ToolDefinition[] {

--- a/src/agent/tools/channel-history.test.ts
+++ b/src/agent/tools/channel-history.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createChannelRouter, type ChannelRouter } from '@/channels/router'
+import type { ChannelAdapterConfig } from '@/channels/schema'
+import type { ChannelHistoryMessage, FetchHistoryArgs, FetchHistoryResult, HistoryCallback } from '@/channels/types'
+
+import { createChannelHistoryTool, type ChannelHistoryOrigin } from './channel-history'
+
+function emptyAdapterConfig(): ChannelAdapterConfig {
+  return { allow: ['*'], engagement: { trigger: ['mention'], stickiness: 'off' }, enabled: true }
+}
+
+async function makeRouter(): Promise<ChannelRouter> {
+  return createChannelRouter({
+    agentDir: '/tmp/test-channel-history',
+    configForAdapter: () => emptyAdapterConfig(),
+  })
+}
+
+const slackThreadOrigin: ChannelHistoryOrigin = {
+  adapter: 'slack-bot',
+  workspace: 'T0',
+  chat: 'C0',
+  thread: '1700000000.000100',
+}
+
+const slackChannelRootOrigin: ChannelHistoryOrigin = {
+  adapter: 'slack-bot',
+  workspace: 'T0',
+  chat: 'C0',
+  thread: null,
+}
+
+const fakeCtx = {} as Parameters<ReturnType<typeof createChannelHistoryTool>['execute']>[4]
+
+async function runTool(
+  tool: ReturnType<typeof createChannelHistoryTool>,
+  params: Parameters<ReturnType<typeof createChannelHistoryTool>['execute']>[1],
+) {
+  return tool.execute('id', params, undefined, undefined, fakeCtx)
+}
+
+function userMessage(overrides: Partial<ChannelHistoryMessage> = {}): ChannelHistoryMessage {
+  return {
+    externalMessageId: 'm1',
+    authorId: 'UALICE',
+    authorName: 'Alice',
+    text: 'hello',
+    ts: 1_700_000_000_000,
+    isBot: false,
+    replyToBotMessageId: null,
+    ...overrides,
+  }
+}
+
+describe('createChannelHistoryTool', () => {
+  test('defaults to thread scope when origin has a thread', async () => {
+    // given
+    const seen: FetchHistoryArgs[] = []
+    const cb: HistoryCallback = async (args) => {
+      seen.push(args)
+      return { ok: true, messages: [userMessage()] }
+    }
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // when
+    await runTool(tool, {})
+
+    // then
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toEqual({ chat: 'C0', thread: '1700000000.000100', limit: 20 })
+  })
+
+  test('defaults to channel scope when origin has no thread', async () => {
+    // given
+    const seen: FetchHistoryArgs[] = []
+    const cb: HistoryCallback = async (args) => {
+      seen.push(args)
+      return { ok: true, messages: [] }
+    }
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackChannelRootOrigin })
+
+    // when
+    await runTool(tool, {})
+
+    // then
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toEqual({ chat: 'C0', thread: null, limit: 20 })
+  })
+
+  test('rejects scope:thread on a channel-root session without calling the adapter', async () => {
+    // given
+    let called = 0
+    const cb: HistoryCallback = async () => {
+      called++
+      return { ok: true, messages: [] }
+    }
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackChannelRootOrigin })
+
+    // when
+    const result = await runTool(tool, { scope: 'thread' })
+
+    // then
+    expect(called).toBe(0)
+    expect(result.details).toEqual({ ok: false, error: 'thread-scope-requires-thread-session' })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('thread-scope-requires-thread-session')
+  })
+
+  test('forwards explicit scope:channel even when origin is in a thread', async () => {
+    // given
+    const seen: FetchHistoryArgs[] = []
+    const cb: HistoryCallback = async (args) => {
+      seen.push(args)
+      return { ok: true, messages: [] }
+    }
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // when
+    await runTool(tool, { scope: 'channel' })
+
+    // then
+    expect(seen[0]!.thread).toBeNull()
+  })
+
+  test('reports history-not-supported verbatim when adapter has no callback registered', async () => {
+    // given (router with no history callback for slack-bot)
+    const router = await makeRouter()
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // when
+    const result = await runTool(tool, {})
+
+    // then
+    expect(result.details).toEqual({ ok: false, error: 'history-not-supported' })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('history-not-supported')
+  })
+
+  test('forwards cursor through to the adapter unchanged on a follow-up call', async () => {
+    // given
+    const seen: FetchHistoryArgs[] = []
+    const cb: HistoryCallback = async (args) => {
+      seen.push(args)
+      return { ok: true, messages: [], nextCursor: 'next-page' }
+    }
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // when
+    await runTool(tool, { cursor: 'first-page' })
+
+    // then
+    expect(seen[0]!.cursor).toBe('first-page')
+  })
+
+  test('exposes nextCursor in the tool result so the agent can page', async () => {
+    // given
+    const cb: HistoryCallback = async (): Promise<FetchHistoryResult> => ({
+      ok: true,
+      messages: [userMessage()],
+      nextCursor: 'cur-2',
+    })
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // when
+    const result = await runTool(tool, {})
+
+    // then
+    expect(result.details).toEqual({ ok: true, count: 1, nextCursor: 'cur-2' })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('cur-2')
+  })
+
+  test('omits nextCursor in the result when the adapter does not return one', async () => {
+    // given
+    const cb: HistoryCallback = async () => ({ ok: true, messages: [userMessage()] })
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // when
+    const result = await runTool(tool, {})
+
+    // then
+    expect(result.details).toEqual({ ok: true, count: 1 })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).not.toContain('more older messages available')
+  })
+
+  test('renders messages in adapter-supplied order (already chronological)', async () => {
+    // given
+    const cb: HistoryCallback = async () => ({
+      ok: true,
+      messages: [
+        userMessage({ externalMessageId: 'a', text: 'first', ts: 1_000_000_000_000 }),
+        userMessage({ externalMessageId: 'b', text: 'second', ts: 1_000_000_001_000 }),
+        userMessage({ externalMessageId: 'c', text: 'third', ts: 1_000_000_002_000 }),
+      ],
+    })
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // when
+    const result = await runTool(tool, {})
+
+    // then
+    const text = (result.content[0] as { text: string }).text
+    const idxFirst = text.indexOf('first')
+    const idxSecond = text.indexOf('second')
+    const idxThird = text.indexOf('third')
+    expect(idxFirst).toBeGreaterThan(-1)
+    expect(idxSecond).toBeGreaterThan(idxFirst)
+    expect(idxThird).toBeGreaterThan(idxSecond)
+  })
+
+  test('renders bot entries with a BOT marker and user entries with @mention', async () => {
+    // given
+    const cb: HistoryCallback = async () => ({
+      ok: true,
+      messages: [
+        userMessage({ authorId: 'UALICE', authorName: 'Alice', isBot: false, text: 'hi' }),
+        userMessage({ authorId: 'UBOT', authorName: 'typeclaw', isBot: true, text: 'auto-reply' }),
+      ],
+    })
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // when
+    const result = await runTool(tool, {})
+
+    // then
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('Alice (<@UALICE>): hi')
+    expect(text).toContain('BOT (typeclaw): auto-reply')
+  })
+
+  test('renders an empty history with the (no messages) marker', async () => {
+    // given
+    const cb: HistoryCallback = async () => ({ ok: true, messages: [] })
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // when
+    const result = await runTool(tool, {})
+
+    // then
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('(no messages)')
+  })
+
+  test('passes limit through verbatim and clamps via the adapter (tool itself does not clamp)', async () => {
+    // given
+    const seen: FetchHistoryArgs[] = []
+    const cb: HistoryCallback = async (args) => {
+      seen.push(args)
+      return { ok: true, messages: [] }
+    }
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // when
+    await runTool(tool, { limit: 50 })
+
+    // then
+    expect(seen[0]!.limit).toBe(50)
+  })
+
+  test('surfaces adapter ok:false errors to the agent', async () => {
+    // given
+    const cb: HistoryCallback = async () => ({ ok: false, error: 'channel_not_found' })
+    const router = await makeRouter()
+    router.registerHistory('slack-bot', cb)
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // when
+    const result = await runTool(tool, {})
+
+    // then
+    expect(result.details).toEqual({ ok: false, error: 'channel_not_found' })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('channel_history error: channel_not_found')
+  })
+
+  test('schema metadata names the tool channel_history', () => {
+    // given/when
+    const router = createChannelRouter({ agentDir: '/tmp/test-name', configForAdapter: () => emptyAdapterConfig() })
+    const tool = createChannelHistoryTool({ router, origin: slackThreadOrigin })
+
+    // then
+    expect(tool.name).toBe('channel_history')
+    expect(tool.label).toBe('Channel History')
+  })
+})

--- a/src/agent/tools/channel-history.ts
+++ b/src/agent/tools/channel-history.ts
@@ -1,0 +1,119 @@
+import { Type } from '@mariozechner/pi-ai'
+import { defineTool } from '@mariozechner/pi-coding-agent'
+
+import type { ChannelRouter } from '@/channels/router'
+import type { AdapterId } from '@/channels/schema'
+import type { ChannelHistoryMessage } from '@/channels/types'
+
+export type ChannelHistoryOrigin = {
+  adapter: AdapterId
+  workspace: string
+  chat: string
+  thread: string | null
+}
+
+export type CreateChannelHistoryToolOptions = {
+  router: ChannelRouter
+  origin: ChannelHistoryOrigin
+}
+
+// channel_history is a lazy "look back" capability for channel-routed
+// sessions. The agent only sees the current turn's batch and a small
+// observed-context buffer by default; this tool lets it pull older
+// messages from the upstream service when context demands it.
+//
+// Addressing comes from the session origin (same idea as channel_reply):
+// the agent supplies only the slicing parameters (limit/cursor/scope).
+// `scope` defaults to thread when the origin has one, channel otherwise.
+// Thread scope on a channel-root session is rejected rather than silently
+// downgraded so the agent doesn't conflate the two views.
+export function createChannelHistoryTool({ router, origin }: CreateChannelHistoryToolOptions) {
+  return defineTool({
+    name: 'channel_history',
+    label: 'Channel History',
+    description:
+      'Fetch older messages from the current conversation. Useful when a user references context you do not have ' +
+      '(e.g. "as we discussed earlier"). Returns messages oldest-first. Pass `cursor` from a previous result to page further back. ' +
+      'Default scope is the current thread when the session is in a thread, otherwise the channel. ' +
+      'Thread scope is rejected when the session is not in a thread — switch to `scope: "channel"` if you want channel-root context.',
+    parameters: Type.Object({
+      limit: Type.Optional(
+        Type.Number({
+          description: 'Number of messages to fetch (default 20). Adapters cap this further (Slack 200, Discord 100).',
+          minimum: 1,
+          maximum: 200,
+        }),
+      ),
+      cursor: Type.Optional(
+        Type.String({
+          description: 'Opaque cursor from a previous channel_history result. Pass to page further back.',
+          minLength: 1,
+        }),
+      ),
+      scope: Type.Optional(
+        Type.Union([Type.Literal('thread'), Type.Literal('channel')], {
+          description:
+            'Whether to fetch the current thread or the whole channel. Defaults to thread when the session is in a thread, channel otherwise.',
+        }),
+      ),
+    }),
+
+    async execute(_toolCallId, params) {
+      const limit = params.limit ?? 20
+      const scope = params.scope ?? (origin.thread !== null ? 'thread' : 'channel')
+      type Details = { ok: boolean; error?: string; count?: number; nextCursor?: string }
+
+      if (scope === 'thread' && origin.thread === null) {
+        const text =
+          'channel_history error: thread-scope-requires-thread-session — this session is not in a thread; pass `scope: "channel"` instead.'
+        const details: Details = { ok: false, error: 'thread-scope-requires-thread-session' }
+        return { content: [{ type: 'text' as const, text }], details }
+      }
+
+      const result = await router.fetchHistory(origin.adapter, {
+        chat: origin.chat,
+        thread: scope === 'thread' ? origin.thread : null,
+        limit,
+        ...(params.cursor !== undefined ? { cursor: params.cursor } : {}),
+      })
+
+      if (!result.ok) {
+        const details: Details = { ok: false, error: result.error }
+        return {
+          content: [{ type: 'text' as const, text: `channel_history error: ${result.error}` }],
+          details,
+        }
+      }
+
+      const rendered = renderMessages(result.messages)
+      const cursorLine =
+        result.nextCursor !== undefined
+          ? `\n\n(more older messages available — call channel_history again with cursor: ${JSON.stringify(result.nextCursor)})`
+          : ''
+      const header = `## ${scope} history (${result.messages.length} message${result.messages.length === 1 ? '' : 's'}, oldest first)`
+      const details: Details =
+        result.nextCursor !== undefined
+          ? { ok: true, count: result.messages.length, nextCursor: result.nextCursor }
+          : { ok: true, count: result.messages.length }
+      return {
+        content: [{ type: 'text' as const, text: `${header}\n${rendered}${cursorLine}` }],
+        details,
+      }
+    },
+  })
+}
+
+// Render history as one line per message, chronological order. `BOT` marker
+// distinguishes the agent's own past replies from user messages so the
+// model doesn't treat them as user input. Author name is shown alongside
+// the id so the agent can refer to people by name in its reply.
+function renderMessages(messages: readonly ChannelHistoryMessage[]): string {
+  if (messages.length === 0) return '(no messages)'
+  const lines: string[] = []
+  for (const m of messages) {
+    const iso = m.ts > 0 ? new Date(m.ts).toISOString() : 'unknown-time'
+    const who = m.isBot ? `BOT (${m.authorName})` : `${m.authorName} (<@${m.authorId}>)`
+    lines.push(`[${iso}] ${who}: ${m.text}`)
+  }
+  return lines.join('\n')
+}

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -19,6 +19,9 @@ function fakeRouter(
     unregisterTyping: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
+    registerHistory: () => {},
+    unregisterHistory: () => {},
+    fetchHistory: async () => ({ ok: false, error: 'history-not-supported' }),
     stop: async () => {},
     liveCount: () => 0,
   }

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -19,6 +19,9 @@ function fakeRouter(
     unregisterTyping: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
+    registerHistory: () => {},
+    unregisterHistory: () => {},
+    fetchHistory: async () => ({ ok: false, error: 'history-not-supported' }),
     stop: async () => {},
     liveCount: () => 0,
   }

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
-import { isAllowed } from '@/channels/schema'
+import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 
 import { DiscordIntent } from './agent-messenger-shim'
-import { createTypingCallback, DISCORD_BOT_INTENTS } from './discord-bot'
+import {
+  createDiscordHistoryCallback,
+  createTypingCallback,
+  DISCORD_BOT_INTENTS,
+  DISCORD_HISTORY_LIMIT_MAX,
+} from './discord-bot'
 
 describe('discord-bot adapter (unit-level pure helpers)', () => {
   test('isAllowed denies a guild channel not in the allow list', () => {
@@ -126,5 +131,351 @@ describe('createTypingCallback', () => {
     })
     await cb({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })
     expect(calls).toHaveLength(0)
+  })
+})
+
+describe('createDiscordHistoryCallback', () => {
+  type FetchCall = { url: string; init: RequestInit }
+
+  function fakeFetch(jsonOrStatus: unknown[] | { status: number }): { fn: typeof fetch; calls: FetchCall[] } {
+    const calls: FetchCall[] = []
+    const fn = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      calls.push({ url, init: init ?? {} })
+      if (Array.isArray(jsonOrStatus)) {
+        return new Response(JSON.stringify(jsonOrStatus), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response(null, { status: jsonOrStatus.status })
+    }) as unknown as typeof fetch
+    return { fn, calls }
+  }
+
+  function silentLogger() {
+    return { info: () => {}, warn: () => {}, error: () => {} }
+  }
+
+  function permissiveConfig(): ChannelAdapterConfig {
+    return { allow: ['*'], engagement: { trigger: ['mention'], stickiness: 'off' }, enabled: true }
+  }
+
+  test('GETs /channels/{chat}/messages with bot token authorization', async () => {
+    // given
+    const { fn, calls } = fakeFetch([])
+    const cb = createDiscordHistoryCallback({
+      token: 'bot-tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    await cb({ chat: 'channel-id', thread: null, limit: 10 })
+    // then
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.init.method).toBe('GET')
+    expect(calls[0]!.url.startsWith('https://discord.com/api/v10/channels/channel-id/messages?')).toBe(true)
+    const headers = calls[0]!.init.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bot bot-tok')
+    const params = new URL(calls[0]!.url).searchParams
+    expect(params.get('limit')).toBe('10')
+    expect(params.get('before')).toBeNull()
+  })
+
+  test('uses args.thread as the channel id when set, falling back to args.chat otherwise', async () => {
+    // given (matches the inbound classifier convention: chat = thread channel id, thread = null)
+    const { fn, calls } = fakeFetch([])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    await cb({ chat: 'thread-channel-id', thread: null, limit: 10 })
+    // then
+    expect(calls[0]!.url.startsWith('https://discord.com/api/v10/channels/thread-channel-id/messages?')).toBe(true)
+
+    // and given (forward-compatible: a future caller passes a non-null thread)
+    const { fn: fn2, calls: calls2 } = fakeFetch([])
+    const cb2 = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn2,
+    })
+    // when
+    await cb2({ chat: 'parent-channel-id', thread: 'thread-id', limit: 10 })
+    // then
+    expect(calls2[0]!.url.startsWith('https://discord.com/api/v10/channels/thread-id/messages?')).toBe(true)
+  })
+
+  test('reverses Discord newest-first ordering into oldest-first', async () => {
+    // given
+    const { fn } = fakeFetch([
+      {
+        id: '3',
+        channel_id: 'c1',
+        author: { id: 'u3', username: 'C', bot: false },
+        content: 'newest',
+        timestamp: '2026-04-27T00:00:03Z',
+      },
+      {
+        id: '2',
+        channel_id: 'c1',
+        author: { id: 'u2', username: 'B', bot: false },
+        content: 'middle',
+        timestamp: '2026-04-27T00:00:02Z',
+      },
+      {
+        id: '1',
+        channel_id: 'c1',
+        author: { id: 'u1', username: 'A', bot: false },
+        content: 'oldest',
+        timestamp: '2026-04-27T00:00:01Z',
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.messages.map((m) => m.text)).toEqual(['oldest', 'middle', 'newest'])
+  })
+
+  test('marks author.bot as isBot', async () => {
+    // given
+    const { fn } = fakeFetch([
+      {
+        id: '1',
+        channel_id: 'c1',
+        author: { id: 'u-human', username: 'human', bot: false },
+        content: 'hi',
+        timestamp: '2026-04-27T00:00:01Z',
+      },
+      {
+        id: '2',
+        channel_id: 'c1',
+        author: { id: 'u-bot', username: 'a-bot', bot: true },
+        content: 'auto',
+        timestamp: '2026-04-27T00:00:02Z',
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const byId = Object.fromEntries(result.messages.map((m) => [m.externalMessageId, m.isBot]))
+    expect(byId['1']).toBe(false)
+    expect(byId['2']).toBe(true)
+  })
+
+  test('marks our own bot user id as isBot even when author.bot is missing', async () => {
+    // given
+    const { fn } = fakeFetch([
+      {
+        id: '1',
+        channel_id: 'c1',
+        author: { id: 'u-bot' },
+        content: 'self',
+        timestamp: '2026-04-27T00:00:01Z',
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => 'u-bot',
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.messages[0]!.isBot).toBe(true)
+  })
+
+  test('sets nextCursor to the oldest message id when the page is full', async () => {
+    // given (limit=2 and exactly 2 messages returned → there may be more before)
+    const { fn } = fakeFetch([
+      {
+        id: '5',
+        channel_id: 'c1',
+        author: { id: 'u', username: 'u', bot: false },
+        content: 'b',
+        timestamp: '2026-04-27T00:00:05Z',
+      },
+      {
+        id: '4',
+        channel_id: 'c1',
+        author: { id: 'u', username: 'u', bot: false },
+        content: 'a',
+        timestamp: '2026-04-27T00:00:04Z',
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 2 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.nextCursor).toBe('4')
+  })
+
+  test('omits nextCursor when the page is not full (channel start reached)', async () => {
+    // given (limit=10 but only 1 message returned)
+    const { fn } = fakeFetch([
+      {
+        id: '1',
+        channel_id: 'c1',
+        author: { id: 'u', username: 'u', bot: false },
+        content: 'a',
+        timestamp: '2026-04-27T00:00:01Z',
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.nextCursor).toBeUndefined()
+  })
+
+  test('passes cursor through as ?before= verbatim', async () => {
+    // given
+    const { fn, calls } = fakeFetch([])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    await cb({ chat: 'c1', thread: null, limit: 10, cursor: 'snowflake-42' })
+    // then
+    const params = new URL(calls[0]!.url).searchParams
+    expect(params.get('before')).toBe('snowflake-42')
+  })
+
+  test('clamps limit to DISCORD_HISTORY_LIMIT_MAX', async () => {
+    // given
+    const { fn, calls } = fakeFetch([])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    await cb({ chat: 'c1', thread: null, limit: 999 })
+    // then
+    const params = new URL(calls[0]!.url).searchParams
+    expect(params.get('limit')).toBe(String(DISCORD_HISTORY_LIMIT_MAX))
+  })
+
+  test('returns ok:false on non-2xx response (does not throw)', async () => {
+    // given
+    const { fn } = fakeFetch({ status: 429 })
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 10 })
+    // then
+    expect(result).toEqual({ ok: false, error: 'http 429' })
+  })
+
+  test('swallows fetch rejection into ok:false', async () => {
+    // given
+    const fn = (async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 10 })
+    // then
+    expect(result).toEqual({ ok: false, error: 'network down' })
+  })
+
+  test('refuses fetch when chat is not in the allow list', async () => {
+    // given
+    const { fn, calls } = fakeFetch([])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: (): ChannelAdapterConfig => ({
+        allow: ['guild:other-guild'],
+        engagement: { trigger: ['mention'], stickiness: 'off' },
+        enabled: true,
+      }),
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'channel-id', thread: null, limit: 10 })
+    // then
+    expect(calls).toHaveLength(0)
+    expect(result).toEqual({ ok: false, error: 'denied by allow rules' })
+  })
+
+  test('admits per-channel allow rule (channel:<id>) without a workspace at fetch time', async () => {
+    // given
+    const { fn, calls } = fakeFetch([])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      configRef: (): ChannelAdapterConfig => ({
+        allow: ['channel:channel-id'],
+        engagement: { trigger: ['mention'], stickiness: 'off' },
+        enabled: true,
+      }),
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'channel-id', thread: null, limit: 10 })
+    // then
+    expect(calls).toHaveLength(1)
+    expect(result.ok).toBe(true)
   })
 })

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -1,6 +1,10 @@
 import type { ChannelRouter } from '@/channels/router'
 import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 import type {
+  ChannelHistoryMessage,
+  FetchHistoryArgs,
+  FetchHistoryResult,
+  HistoryCallback,
   OutboundCallback,
   OutboundMessage,
   ResolvedChannelNames,
@@ -100,6 +104,122 @@ export function createTypingCallback(deps: {
   }
 }
 
+export const DISCORD_HISTORY_LIMIT_MAX = 100
+
+type DiscordRawHistoryMessage = {
+  id: string
+  channel_id: string
+  author: { id: string; username?: string; global_name?: string | null; bot?: boolean }
+  content: string
+  timestamp: string
+  message_reference?: { message_id?: string }
+}
+
+// Discord treats threads as separate channels with their own snowflake ids,
+// and the gateway puts the thread's id in `event.channel_id`. The inbound
+// classifier therefore stores the thread channel id in `chat` and leaves
+// `thread` null. This callback uses `args.chat` as the channel id directly,
+// which works for both top-level channels and threads. When a future caller
+// passes a non-null `args.thread`, that wins (forward-compatible with a
+// design where `chat` is the parent and `thread` is the thread channel id).
+export function createDiscordHistoryCallback(deps: {
+  token: string
+  configRef: () => ChannelAdapterConfig
+  logger: DiscordBotAdapterLogger
+  botUserIdRef: () => string | null
+  fetchImpl?: typeof fetch
+}): HistoryCallback {
+  const { token, configRef, logger, botUserIdRef } = deps
+  const fetchFn = deps.fetchImpl ?? fetch
+  return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
+    const config = configRef()
+    if (!isAllowedAnyGuild(config.allow, args.chat)) {
+      return { ok: false, error: 'denied by allow rules' }
+    }
+
+    const channelId = args.thread ?? args.chat
+    const limit = clampLimit(args.limit, DISCORD_HISTORY_LIMIT_MAX)
+    const params = new URLSearchParams({ limit: String(limit) })
+    if (args.cursor !== undefined && args.cursor !== '') params.set('before', args.cursor)
+
+    let raw: DiscordRawHistoryMessage[]
+    let response: Response
+    try {
+      response = await fetchFn(`${DISCORD_API_BASE}/channels/${channelId}/messages?${params.toString()}`, {
+        method: 'GET',
+        headers: { Authorization: `Bot ${token}` },
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.warn(`[discord-bot] history fetch failed: ${message}`)
+      return { ok: false, error: message }
+    }
+    if (!response.ok) {
+      return { ok: false, error: `http ${response.status}` }
+    }
+    try {
+      raw = (await response.json()) as DiscordRawHistoryMessage[]
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return { ok: false, error: `parse failed: ${message}` }
+    }
+
+    const botUserId = botUserIdRef()
+    // Discord returns newest-first; reverse for oldest-first chronological.
+    const mapped = raw.map((m) => mapDiscordMessage(m, botUserId)).reverse()
+
+    // Cursor for the next (older) page is the oldest message id we just
+    // received — Discord's `before=` is exclusive and content-addressed.
+    // Only present when this page was fully populated; otherwise the agent
+    // has reached the start of the channel.
+    const nextCursor = raw.length === limit && raw.length > 0 ? raw[raw.length - 1]!.id : undefined
+    if (nextCursor !== undefined) {
+      return { ok: true, messages: mapped, nextCursor }
+    }
+    return { ok: true, messages: mapped }
+  }
+}
+
+function mapDiscordMessage(msg: DiscordRawHistoryMessage, botUserId: string | null): ChannelHistoryMessage {
+  const isBot = msg.author.bot === true || (botUserId !== null && msg.author.id === botUserId)
+  const ts = Date.parse(msg.timestamp)
+  return {
+    externalMessageId: msg.id,
+    authorId: msg.author.id,
+    authorName: msg.author.global_name ?? msg.author.username ?? msg.author.id,
+    text: msg.content,
+    ts: Number.isFinite(ts) ? ts : 0,
+    isBot,
+    replyToBotMessageId: msg.message_reference?.message_id ?? null,
+  }
+}
+
+function clampLimit(requested: number, max: number): number {
+  if (!Number.isFinite(requested) || requested <= 0) return max
+  return Math.min(Math.floor(requested), max)
+}
+
+// Discord channel ids are globally unique snowflakes, so a `channel:<id>`
+// or `guild:<g>/<id>` rule for any guild admits this chat. We match this
+// way because at fetch time the tool has resolved the chat from session
+// origin but does not always re-supply the guild id (esp. across cursor
+// pagination), so the workspace-aware `isAllowed` is too narrow here.
+function isAllowedAnyGuild(rules: readonly string[], chat: string): boolean {
+  for (const rule of rules) {
+    if (rule === '*') return true
+    if (rule === 'guild:*' || rule === 'team:*') return true
+    if (rule === 'dm:*') return true
+    if (rule.startsWith('channel:') && rule.slice(8) === chat) return true
+    if (rule.startsWith('dm:') && rule.slice(3) === chat) return true
+    if (rule.startsWith('guild:')) {
+      const body = rule.slice(6)
+      const slash = body.indexOf('/')
+      if (slash !== -1 && body.slice(slash + 1) === chat) return true
+    }
+  }
+  return false
+}
+
 export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): DiscordBotAdapter {
   const logger = options.logger ?? consoleLogger
   const client = new DiscordBotClient()
@@ -125,6 +245,13 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
     configRef: options.configRef,
     logger,
     formatChannelTag,
+  })
+
+  const historyCallback = createDiscordHistoryCallback({
+    token: options.token,
+    configRef: options.configRef,
+    logger,
+    botUserIdRef: () => botUserId,
   })
 
   const outboundCallback: OutboundCallback = async (msg: OutboundMessage): Promise<SendResult> => {
@@ -217,6 +344,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       options.router.registerOutbound('discord-bot', outboundCallback)
       options.router.registerTyping('discord-bot', typingCallback)
       options.router.registerChannelNameResolver('discord-bot', channelResolver)
+      options.router.registerHistory('discord-bot', historyCallback)
 
       try {
         await listener.start()
@@ -233,6 +361,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       options.router.unregisterOutbound('discord-bot', outboundCallback)
       options.router.unregisterTyping('discord-bot', typingCallback)
       options.router.unregisterChannelNameResolver('discord-bot', channelResolver)
+      options.router.unregisterHistory('discord-bot', historyCallback)
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {
           stopWaiters.push(resolve)

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from 'bun:test'
 
-import { isAllowed } from '@/channels/schema'
+import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 
 import type { SlackSocketAppMentionEvent } from './agent-messenger-slack-shim'
-import { createTypingCallback, promoteAppMentionToMessage } from './slack-bot'
+import {
+  createSlackHistoryCallback,
+  createTypingCallback,
+  promoteAppMentionToMessage,
+  SLACK_HISTORY_LIMIT_MAX,
+} from './slack-bot'
 import { classifyInbound } from './slack-bot-classify'
 
 describe('slack-bot adapter (unit-level pure helpers)', () => {
@@ -177,5 +182,326 @@ describe('slack-bot promoteAppMentionToMessage', () => {
       isBotMention: true,
       isDm: false,
     })
+  })
+})
+
+describe('createSlackHistoryCallback', () => {
+  type FetchCall = { url: string; init: RequestInit }
+
+  function fakeFetch(response: unknown): { fn: typeof fetch; calls: FetchCall[] } {
+    const calls: FetchCall[] = []
+    const fn = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      calls.push({ url, init: init ?? {} })
+      return new Response(JSON.stringify(response), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }) as unknown as typeof fetch
+    return { fn, calls }
+  }
+
+  function silentLogger() {
+    return { info: () => {}, warn: () => {}, error: () => {} }
+  }
+
+  function permissiveConfig(): ChannelAdapterConfig {
+    return { allow: ['*'], engagement: { trigger: ['mention'], stickiness: 'off' }, enabled: true }
+  }
+
+  test('uses conversations.replies when thread is set, with channel + ts in the body', async () => {
+    // given
+    const { fn, calls } = fakeFetch({
+      ok: true,
+      messages: [
+        { ts: '1700000000.000100', user: 'UALICE', text: 'parent', thread_ts: '1700000000.000100' },
+        { ts: '1700000001.000200', user: 'UBOB', text: 'reply', thread_ts: '1700000000.000100' },
+      ],
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'xoxb-tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => 'UBOT',
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0CHANNEL', thread: '1700000000.000100', limit: 10 })
+    // then
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toBe('https://slack.com/api/conversations.replies')
+    expect(calls[0]!.init.method).toBe('POST')
+    const headers = calls[0]!.init.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer xoxb-tok')
+    expect(headers['Content-Type']).toContain('application/x-www-form-urlencoded')
+    const body = (calls[0]!.init.body as string) ?? ''
+    const params = new URLSearchParams(body)
+    expect(params.get('channel')).toBe('C0CHANNEL')
+    expect(params.get('ts')).toBe('1700000000.000100')
+    expect(params.get('limit')).toBe('10')
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.messages.map((m) => m.externalMessageId)).toEqual(['1700000000.000100', '1700000001.000200'])
+  })
+
+  test('uses conversations.history when thread is null', async () => {
+    // given
+    const { fn, calls } = fakeFetch({ ok: true, messages: [] })
+    const cb = createSlackHistoryCallback({
+      token: 'xoxb-tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    await cb({ chat: 'C0CHANNEL', thread: null, limit: 5 })
+    // then
+    expect(calls[0]!.url).toBe('https://slack.com/api/conversations.history')
+    const params = new URLSearchParams(calls[0]!.init.body as string)
+    expect(params.get('channel')).toBe('C0CHANNEL')
+    expect(params.get('ts')).toBeNull()
+  })
+
+  test('reverses conversations.history (newest-first) into oldest-first', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [
+        { ts: '1700000003.000300', user: 'UC', text: 'newest' },
+        { ts: '1700000002.000200', user: 'UB', text: 'middle' },
+        { ts: '1700000001.000100', user: 'UA', text: 'oldest' },
+      ],
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.messages.map((m) => m.text)).toEqual(['oldest', 'middle', 'newest'])
+  })
+
+  test('preserves conversations.replies order (already oldest-first)', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [
+        { ts: '1700000001.000100', user: 'UA', text: 'first', thread_ts: '1700000001.000100' },
+        { ts: '1700000002.000200', user: 'UB', text: 'second', thread_ts: '1700000001.000100' },
+      ],
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: '1700000001.000100', limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.messages.map((m) => m.text)).toEqual(['first', 'second'])
+  })
+
+  test('marks bot_message subtype as isBot', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [
+        { ts: '1.1', user: 'UALICE', text: 'human' },
+        { ts: '2.2', subtype: 'bot_message', bot_id: 'B123', text: 'from a bot' },
+      ],
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const byTs = Object.fromEntries(result.messages.map((m) => [m.externalMessageId, m.isBot]))
+    expect(byTs['1.1']).toBe(false)
+    expect(byTs['2.2']).toBe(true)
+  })
+
+  test('marks our own bot user id as isBot even when subtype is missing', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [
+        { ts: '1.1', user: 'UBOT', text: 'self message via web api' },
+        { ts: '2.2', user: 'UHUMAN', text: 'human reply' },
+      ],
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => 'UBOT',
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const byTs = Object.fromEntries(result.messages.map((m) => [m.externalMessageId, m.isBot]))
+    expect(byTs['1.1']).toBe(true)
+    expect(byTs['2.2']).toBe(false)
+  })
+
+  test('exposes nextCursor when Slack returns response_metadata.next_cursor', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [{ ts: '1.1', user: 'UA', text: 'a' }],
+      response_metadata: { next_cursor: 'cur-page-2' },
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.nextCursor).toBe('cur-page-2')
+  })
+
+  test('omits nextCursor when Slack returns an empty cursor', async () => {
+    // given
+    const { fn } = fakeFetch({ ok: true, messages: [], response_metadata: { next_cursor: '' } })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.nextCursor).toBeUndefined()
+  })
+
+  test('passes cursor through verbatim on follow-up calls', async () => {
+    // given
+    const { fn, calls } = fakeFetch({ ok: true, messages: [] })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    await cb({ chat: 'C0', thread: null, limit: 10, cursor: 'cur-page-2' })
+    // then
+    const params = new URLSearchParams(calls[0]!.init.body as string)
+    expect(params.get('cursor')).toBe('cur-page-2')
+  })
+
+  test('clamps limit to SLACK_HISTORY_LIMIT_MAX', async () => {
+    // given
+    const { fn, calls } = fakeFetch({ ok: true, messages: [] })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    await cb({ chat: 'C0', thread: null, limit: 999 })
+    // then
+    const params = new URLSearchParams(calls[0]!.init.body as string)
+    expect(params.get('limit')).toBe(String(SLACK_HISTORY_LIMIT_MAX))
+  })
+
+  test('returns ok:false with the slack error string when ok=false', async () => {
+    // given
+    const { fn } = fakeFetch({ ok: false, error: 'channel_not_found' })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    expect(result).toEqual({ ok: false, error: 'channel_not_found' })
+  })
+
+  test('swallows fetch rejection into ok:false (does not throw)', async () => {
+    // given
+    const fn = (async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: permissiveConfig,
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    expect(result).toEqual({ ok: false, error: 'network down' })
+  })
+
+  test('refuses fetch when chat is not in the allow list', async () => {
+    // given
+    const { fn, calls } = fakeFetch({ ok: true, messages: [] })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: () => ({
+        allow: ['team:T0OTHER'],
+        engagement: { trigger: ['mention'], stickiness: 'off' },
+        enabled: true,
+      }),
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0CHANNEL', thread: null, limit: 10 })
+    // then
+    expect(calls).toHaveLength(0)
+    expect(result).toEqual({ ok: false, error: 'denied by allow rules' })
+  })
+
+  test('admits per-channel allow rule (channel:C0) without a workspace at fetch time', async () => {
+    // given
+    const { fn, calls } = fakeFetch({ ok: true, messages: [] })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      configRef: (): ChannelAdapterConfig => ({
+        allow: ['channel:C0CHANNEL'],
+        engagement: { trigger: ['mention'], stickiness: 'off' },
+        enabled: true,
+      }),
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0CHANNEL', thread: null, limit: 10 })
+    // then
+    expect(calls).toHaveLength(1)
+    expect(result.ok).toBe(true)
   })
 })

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -1,6 +1,10 @@
 import type { ChannelRouter } from '@/channels/router'
 import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 import type {
+  ChannelHistoryMessage,
+  FetchHistoryArgs,
+  FetchHistoryResult,
+  HistoryCallback,
   OutboundCallback,
   OutboundMessage,
   ResolvedChannelNames,
@@ -118,6 +122,158 @@ export function createTypingCallback(deps: {
   }
 }
 
+export const SLACK_HISTORY_LIMIT_MAX = 200
+
+const SLACK_API_BASE = 'https://slack.com/api'
+
+type SlackRawHistoryMessage = {
+  ts: string
+  type?: string
+  subtype?: string
+  user?: string
+  bot_id?: string
+  text?: string
+  thread_ts?: string
+  parent_user_id?: string
+}
+
+type SlackHistoryResponse = {
+  ok: boolean
+  error?: string
+  messages?: SlackRawHistoryMessage[]
+  response_metadata?: { next_cursor?: string }
+}
+
+// Direct fetch to Slack's Web API. The shim only exposes postMessage /
+// setAssistantStatus / testAuth, so history calls go through fetch using
+// the same pattern the Discord adapter uses for /typing. Slack uses
+// application/x-www-form-urlencoded for these endpoints; JSON works too
+// when paired with the right Content-Type but URL-encoded is what every
+// client library defaults to and is the most-tested wire format.
+export function createSlackHistoryCallback(deps: {
+  token: string
+  configRef: () => ChannelAdapterConfig
+  logger: SlackBotAdapterLogger
+  botUserIdRef: () => string | null
+  fetchImpl?: typeof fetch
+}): HistoryCallback {
+  const { token, configRef, logger, botUserIdRef } = deps
+  const fetchFn = deps.fetchImpl ?? fetch
+  return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
+    const config = configRef()
+    if (!isAllowed(config.allow, '@dm', args.chat) && !isAllowedAnyTeam(config.allow, args.chat)) {
+      // Same defense-in-depth as outbound: refuse to fetch history for a
+      // channel the operator hasn't admitted, even if the agent somehow
+      // resolved its id. Returning an error rather than empty so the
+      // agent doesn't think the channel is genuinely silent.
+      return { ok: false, error: 'denied by allow rules' }
+    }
+
+    const limit = clampLimit(args.limit, SLACK_HISTORY_LIMIT_MAX)
+    const endpoint = args.thread === null ? 'conversations.history' : 'conversations.replies'
+    const body = new URLSearchParams()
+    body.set('channel', args.chat)
+    body.set('limit', String(limit))
+    if (args.thread !== null) body.set('ts', args.thread)
+    if (args.cursor !== undefined && args.cursor !== '') body.set('cursor', args.cursor)
+
+    let raw: SlackHistoryResponse
+    try {
+      const response = await fetchFn(`${SLACK_API_BASE}/${endpoint}`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+        },
+        body: body.toString(),
+      })
+      raw = (await response.json()) as SlackHistoryResponse
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.warn(`[slack-bot] history fetch failed: ${message}`)
+      return { ok: false, error: message }
+    }
+
+    if (!raw.ok) {
+      return { ok: false, error: raw.error ?? 'unknown slack error' }
+    }
+
+    const botUserId = botUserIdRef()
+    const rawMessages = raw.messages ?? []
+    const mapped = rawMessages.map((m) => mapSlackMessage(m, botUserId))
+    // Slack's `conversations.history` returns newest-first; `replies`
+    // returns oldest-first. Normalize to oldest-first so the agent always
+    // reads chronological order regardless of scope.
+    if (args.thread === null) mapped.reverse()
+
+    const nextCursor = raw.response_metadata?.next_cursor
+    if (nextCursor !== undefined && nextCursor !== '') {
+      return { ok: true, messages: mapped, nextCursor }
+    }
+    return { ok: true, messages: mapped }
+  }
+}
+
+function mapSlackMessage(msg: SlackRawHistoryMessage, botUserId: string | null): ChannelHistoryMessage {
+  const isBot =
+    msg.subtype === 'bot_message' ||
+    (msg.user !== undefined && botUserId !== null && msg.user === botUserId) ||
+    (msg.bot_id !== undefined && (msg.user === undefined || msg.user === ''))
+  // Slack's parent_user_id is set on thread replies and points at the
+  // author of the parent message. When that parent author is our bot, we
+  // expose this as `replyToBotMessageId = thread_ts` so the agent can
+  // recognize threads it started — same convention as the inbound
+  // classifier uses for live messages.
+  const replyToBotMessageId =
+    msg.thread_ts !== undefined &&
+    msg.parent_user_id !== undefined &&
+    botUserId !== null &&
+    msg.parent_user_id === botUserId
+      ? msg.thread_ts
+      : null
+  return {
+    externalMessageId: msg.ts,
+    authorId: msg.user ?? msg.bot_id ?? 'unknown',
+    authorName: msg.user ?? msg.bot_id ?? 'unknown',
+    text: msg.text ?? '',
+    ts: slackTsToMillis(msg.ts),
+    isBot,
+    replyToBotMessageId,
+  }
+}
+
+function clampLimit(requested: number, max: number): number {
+  if (!Number.isFinite(requested) || requested <= 0) return max
+  return Math.min(Math.floor(requested), max)
+}
+
+// Slack timestamps are "<seconds>.<microseconds>" strings. Convert to ms
+// so callers can sort/render chronologically without re-parsing.
+function slackTsToMillis(ts: string): number {
+  const parsed = Number.parseFloat(ts)
+  if (!Number.isFinite(parsed)) return 0
+  return Math.round(parsed * 1000)
+}
+
+// Slack channel ids are globally unique on Slack's side, so a `channel:C…`
+// or `team:T/C` rule for any team admits this chat. We use this for the
+// history allow check because at fetch time we only know the channel id,
+// not the workspace (the tool resolves the chat from session origin and
+// the workspace doesn't always round-trip through cursor pagination).
+function isAllowedAnyTeam(rules: readonly string[], chat: string): boolean {
+  for (const rule of rules) {
+    if (rule === '*') return true
+    if (rule === 'team:*' || rule === 'guild:*') return true
+    if (rule.startsWith('channel:') && rule.slice(8) === chat) return true
+    if (rule.startsWith('team:')) {
+      const body = rule.slice(5)
+      const slash = body.indexOf('/')
+      if (slash !== -1 && body.slice(slash + 1) === chat) return true
+    }
+  }
+  return false
+}
+
 export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBotAdapter {
   const logger = options.logger ?? consoleLogger
   const client = new SlackBotClient()
@@ -141,6 +297,13 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
   }
 
   const typingCallback = createTypingCallback({ client, configRef: options.configRef, logger, formatChannelTag })
+
+  const historyCallback = createSlackHistoryCallback({
+    token: options.token,
+    configRef: options.configRef,
+    logger,
+    botUserIdRef: () => botUserId,
+  })
 
   const outboundCallback: OutboundCallback = async (msg: OutboundMessage): Promise<SendResult> => {
     if (msg.adapter !== 'slack-bot') {
@@ -290,6 +453,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       options.router.registerOutbound('slack-bot', outboundCallback)
       options.router.registerTyping('slack-bot', typingCallback)
       options.router.registerChannelNameResolver('slack-bot', channelResolver)
+      options.router.registerHistory('slack-bot', historyCallback)
 
       try {
         await listener.start()
@@ -306,6 +470,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       options.router.unregisterOutbound('slack-bot', outboundCallback)
       options.router.unregisterTyping('slack-bot', typingCallback)
       options.router.unregisterChannelNameResolver('slack-bot', channelResolver)
+      options.router.unregisterHistory('slack-bot', historyCallback)
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {
           stopWaiters.push(resolve)

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -13,7 +13,7 @@ import type { HookBus } from '@/plugin'
 import { loadChannelSessions } from './persistence'
 import { createChannelRouter, type ChannelRouter } from './router'
 import type { ChannelAdapterConfig } from './schema'
-import type { ChannelKey, InboundMessage } from './types'
+import type { ChannelKey, FetchHistoryArgs, HistoryCallback, InboundMessage } from './types'
 
 class FakeSession {
   public prompts: string[] = []
@@ -852,5 +852,103 @@ describe('ChannelRouter channel name resolver', () => {
     await router.__testing!.flushDebounce(KEY)
 
     expect(calls).toBe(1)
+  })
+})
+
+describe('ChannelRouter history dispatch', () => {
+  test('fetchHistory invokes the registered callback with the args verbatim', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    const seen: FetchHistoryArgs[] = []
+    router.registerHistory('discord-bot', async (args) => {
+      seen.push(args)
+      return { ok: true, messages: [] }
+    })
+
+    const result = await router.fetchHistory('discord-bot', { chat: 'c1', thread: 't1', limit: 5, cursor: 'cur' })
+
+    expect(result).toEqual({ ok: true, messages: [] })
+    expect(seen).toEqual([{ chat: 'c1', thread: 't1', limit: 5, cursor: 'cur' }])
+  })
+
+  test('returns history-not-supported when no callback is registered for the adapter', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+
+    const result = await router.fetchHistory('discord-bot', { chat: 'c1', thread: null, limit: 1 })
+
+    expect(result).toEqual({ ok: false, error: 'history-not-supported' })
+  })
+
+  test('first ok callback wins; later callbacks are not invoked', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    let secondCalled = false
+    router.registerHistory('discord-bot', async () => ({
+      ok: true,
+      messages: [
+        {
+          externalMessageId: 'm1',
+          authorId: 'u1',
+          authorName: 'Alice',
+          text: 'hi',
+          ts: 1000,
+          isBot: false,
+          replyToBotMessageId: null,
+        },
+      ],
+    }))
+    router.registerHistory('discord-bot', async () => {
+      secondCalled = true
+      return { ok: false, error: 'second' }
+    })
+
+    const result = await router.fetchHistory('discord-bot', { chat: 'c1', thread: null, limit: 5 })
+
+    expect(result.ok).toBe(true)
+    expect(secondCalled).toBe(false)
+  })
+
+  test('surfaces the last error verbatim when every callback returns ok: false', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerHistory('discord-bot', async () => ({ ok: false, error: 'first-failed' }))
+    router.registerHistory('discord-bot', async () => ({ ok: false, error: 'second-failed' }))
+
+    const result = await router.fetchHistory('discord-bot', { chat: 'c1', thread: null, limit: 1 })
+
+    expect(result).toEqual({ ok: false, error: 'second-failed' })
+  })
+
+  test('unregisterHistory removes the callback so subsequent calls fall back to history-not-supported', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    const cb: HistoryCallback = async () => ({ ok: true, messages: [] })
+    router.registerHistory('discord-bot', cb)
+    router.unregisterHistory('discord-bot', cb)
+
+    const result = await router.fetchHistory('discord-bot', { chat: 'c1', thread: null, limit: 1 })
+
+    expect(result).toEqual({ ok: false, error: 'history-not-supported' })
+  })
+
+  test('history registrations are isolated per adapter', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    let discordCalls = 0
+    let slackCalls = 0
+    router.registerHistory('discord-bot', async () => {
+      discordCalls++
+      return { ok: true, messages: [] }
+    })
+    router.registerHistory('slack-bot', async () => {
+      slackCalls++
+      return { ok: true, messages: [] }
+    })
+
+    await router.fetchHistory('discord-bot', { chat: 'c1', thread: null, limit: 1 })
+
+    expect(discordCalls).toBe(1)
+    expect(slackCalls).toBe(0)
   })
 })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -18,6 +18,9 @@ import type { ChannelAdapterConfig } from './schema'
 import type {
   ChannelKey,
   ChannelNameResolver,
+  FetchHistoryArgs,
+  FetchHistoryResult,
+  HistoryCallback,
   InboundMessage,
   OutboundCallback,
   OutboundMessage,
@@ -129,6 +132,9 @@ export type ChannelRouter = {
   unregisterTyping: (adapter: ChannelKey['adapter'], cb: TypingCallback) => void
   registerChannelNameResolver: (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver) => void
   unregisterChannelNameResolver: (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver) => void
+  registerHistory: (adapter: ChannelKey['adapter'], cb: HistoryCallback) => void
+  unregisterHistory: (adapter: ChannelKey['adapter'], cb: HistoryCallback) => void
+  fetchHistory: (adapter: ChannelKey['adapter'], args: FetchHistoryArgs) => Promise<FetchHistoryResult>
   stop: () => Promise<void>
   liveCount: () => number
   __testing?: {
@@ -156,6 +162,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const outboundCallbacks = new Map<ChannelKey['adapter'], Set<OutboundCallback>>()
   const typingCallbacks = new Map<ChannelKey['adapter'], Set<TypingCallback>>()
   const channelNameResolvers = new Map<ChannelKey['adapter'], Set<ChannelNameResolver>>()
+  const historyCallbacks = new Map<ChannelKey['adapter'], Set<HistoryCallback>>()
   const stickyLedger = new StickyLedger()
 
   let mappings: ChannelSessionRecord[] | null = null
@@ -575,6 +582,36 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     channelNameResolvers.get(adapter)?.delete(resolver)
   }
 
+  const registerHistory = (adapter: ChannelKey['adapter'], cb: HistoryCallback): void => {
+    let set = historyCallbacks.get(adapter)
+    if (!set) {
+      set = new Set()
+      historyCallbacks.set(adapter, set)
+    }
+    set.add(cb)
+  }
+
+  const unregisterHistory = (adapter: ChannelKey['adapter'], cb: HistoryCallback): void => {
+    historyCallbacks.get(adapter)?.delete(cb)
+  }
+
+  const fetchHistory = async (adapter: ChannelKey['adapter'], args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
+    const callbacks = historyCallbacks.get(adapter)
+    if (!callbacks || callbacks.size === 0) {
+      return { ok: false, error: 'history-not-supported' }
+    }
+    // Snapshot before iterating, mirroring `send`: a callback that mutates
+    // the set (e.g. unregisters mid-call) must not skip siblings.
+    const snapshot = Array.from(callbacks)
+    let lastError: FetchHistoryResult & { ok: false } = { ok: false, error: 'history-not-supported' }
+    for (const cb of snapshot) {
+      const result = await cb(args)
+      if (result.ok) return result
+      lastError = result
+    }
+    return lastError
+  }
+
   const send = async (msg: OutboundMessage): Promise<SendResult> => {
     const callbacks = outboundCallbacks.get(msg.adapter)
     if (!callbacks || callbacks.size === 0) {
@@ -700,6 +737,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     unregisterTyping,
     registerChannelNameResolver,
     unregisterChannelNameResolver,
+    registerHistory,
+    unregisterHistory,
+    fetchHistory,
     stop,
     liveCount: () => liveSessions.size,
     __testing: {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -49,6 +49,38 @@ export type ResolvedChannelNames = {
 
 export type ChannelNameResolver = (key: ChannelKey) => Promise<ResolvedChannelNames>
 
+// History entries are intentionally distinct from InboundMessage:
+// `InboundMessage` carries router-classification fields (`isBotMention`,
+// `isDm`) that are turn-delivery concerns, not history concerns. History
+// entries instead need `isBot` so the agent can tell its own past replies
+// from user messages, and a sortable `ts` for chronological rendering.
+export type ChannelHistoryMessage = {
+  externalMessageId: string
+  authorId: string
+  authorName: string
+  text: string
+  ts: number
+  isBot: boolean
+  replyToBotMessageId: string | null
+}
+
+export type FetchHistoryArgs = {
+  chat: string
+  thread: string | null
+  limit: number
+  cursor?: string
+}
+
+export type FetchHistoryResult =
+  | { ok: true; messages: ChannelHistoryMessage[]; nextCursor?: string }
+  | { ok: false; error: string }
+
+// Registered per-adapter on the ChannelRouter alongside outbound/typing
+// callbacks. Adapters that cannot fetch history (e.g. webhook-only future
+// adapters) simply do not register one; the router answers
+// 'history-not-supported' for those.
+export type HistoryCallback = (args: FetchHistoryArgs) => Promise<FetchHistoryResult>
+
 export function channelKeyId(key: ChannelKey): string {
   return `${key.adapter}:${key.workspace}:${key.chat}:${key.thread ?? ''}`
 }


### PR DESCRIPTION
## Why

Today a channel-routed agent (Slack, Discord) only sees the current turn's batch plus a small in-process `observed` ring buffer (max 20 messages). When a user replies to an old thread, references a decision made earlier in the day, or picks up a conversation after a restart, the agent has no way to recover that context — it cannot reach back into Slack or Discord to fetch what it missed.

Rather than eagerly backfilling history into every `composeTurnPrompt` call (expensive, wasteful for threads the agent is answering for the first time), this PR gives the agent a **lazy, on-demand `channel_history` tool** it can call when it decides context is needed. Zero cost when not used.

## What

### New agent tool: `channel_history`

The agent calls `channel_history({ scope?, limit?, cursor? })` to pull messages from the upstream platform:

- `scope: 'thread'` — fetch the replies in the current thread (`conversations.replies` / Discord thread channel).
- `scope: 'channel'` — fetch the parent channel's top-level history (`conversations.history` / Discord channel messages).
- Defaults to `'thread'` when the session origin has a thread id, `'channel'` otherwise.
- `scope: 'thread'` is rejected (not silently fallen back) on channel-root sessions that have no thread id, keeping tool semantics explicit.
- Returns an ordered oldest-first list of messages with `authorName`, `text`, `isBot`, and `timestamp`.
- Surfaces the literal string `'history-not-supported'` when the registered adapter has no history callback, so the agent can communicate the limitation to the user.

Tool is gated on `channelRouter` being present AND `origin.kind === 'channel'`, same gate as the existing `channel_reply` tool.

### New `HistoryCallback` contract on `ChannelRouter`

Follows the established `OutboundCallback` / `TypingCallback` pattern exactly:

```ts
router.registerHistory(adapterId, callback)   // mirror of registerOutbound
router.unregisterHistory(adapterId)
router.fetchHistory(args)                     // dispatches to the first registered callback
```

`fetchHistory` uses first-ok-wins semantics with last-error pass-through, matching `ChannelRouter.send`.

### Slack adapter (`createSlackHistoryCallback`)

- `scope: 'thread'` → `conversations.replies?channel=C…&ts=<thread_ts>`
- `scope: 'channel'` → `conversations.history?channel=C…`
- Slack returns `conversations.history` newest-first; normalized to oldest-first before returning.
- `conversations.replies` preserves Slack's native oldest-first order.
- `isBot` from `subtype === 'bot_message'` OR matching the adapter's own bot user id.
- Cursor pagination via `response_metadata.next_cursor`.
- Limit clamped to 200 (Slack's hard cap).

### Discord adapter (`createDiscordHistoryCallback`)

- Discord treats threads as channels with their own ids; the inbound classifier already sets `chat` to the thread channel id, so the callback uses `args.thread ?? args.chat`.
- `GET /channels/{id}/messages?limit&before=` — Discord returns newest-first; reversed before returning.
- Cursor = oldest snowflake of the last page (only included when a full page was returned, signaling more results exist).
- `isBot` from `author.bot === true` OR matching the adapter's own user id.
- Limit clamped to 100 (Discord's hard cap).
- Non-2xx responses surface as errors; fetch rejections are caught and surfaced.

### Composition refactor: `buildChannelTools`

The inline tool-list assembly in `createSessionWithDispose` was extracted into a small exported pure function `buildChannelTools(router, origin)` so the composition logic — specifically that `channel_history` appears iff router is present AND origin is a channel origin — is unit-testable without spinning up `createAgentSession` or auth.

## Test coverage

All written TDD. 51 new tests across 5 files.

| Area | Tests | What's covered |
|---|---|---|
| `src/channels/router.test.ts` | 6 | register/unregister/dispatch, `'history-not-supported'` literal, first-ok-wins, last-error pass-through, adapter isolation |
| `src/channels/adapters/slack-bot.test.ts` | 13 | endpoint selection, ordering normalization, `isBot` from subtype + own bot id, cursor in/out, limit clamping, error pass-through, allow-list refusal |
| `src/channels/adapters/discord-bot.test.ts` | 12 | endpoint format, thread-id semantics (fixtures lock in the inbound-classifier convention), ordering reversal, `isBot` from `author.bot` + own user id, cursor as oldest snowflake, limit clamping, non-2xx error, fetch rejection |
| `src/agent/tools/channel-history.test.ts` | 14 | default scope from origin, `scope: 'thread'` rejected on channel-root, `'history-not-supported'` surfaced verbatim, cursor passthrough, BOT marker rendering, empty history rendering, limit passthrough |
| `src/agent/index.test.ts` | 6 | `channel_history` in tool set iff (router present AND channel origin) — mutation check verified manually |

Full suite: 547 tests pass across `src/agent/`, `src/channels/`, and `plugins/memory/`.

Pre-commit gate per AGENTS.md: `bun run typecheck`, `bun run lint`, `bun run format` — all clean.

## Out of scope

- **Eager backfill into `composeTurnPrompt`.** The `router.fetchHistory` seam is the right place to wire this later without touching the tool layer.
- **Mention resolution.** Raw `<@U…>` tokens in history entries are left as-is. A resolver layer (similar to the existing author-name resolver) can be added independently.
- **Caching.** Each `channel_history` call is a live fetch. A TTL cache keyed by `(channel, cursor, limit)` would be a clean add-on.
- **Rate-limit retry.** 429s are surfaced as errors today. Retry-with-backoff can be layered in the callback without changing the tool contract.

## Review notes

- The `scope: 'thread'` rejection (not silent fallback) on channel-root sessions is a deliberate API choice — silent fallback would mask agent bugs where the model calls the wrong scope. Reviewers should confirm this matches how `channel_reply` handles similar mismatches.
- The `buildChannelTools` extraction is small but important for testability — the composition invariant (history tool iff router+channel) was previously untestable without mocking `createAgentSession`.
- Discord thread semantics (thread id in `chat` field) are locked in by explicit test fixtures in `discord-bot.test.ts`, so regressions in the inbound classifier would immediately break history tests.

## Note on pre-existing test failure

`src/run/index.test.ts` has one failing test on `origin/main` that predates this branch — reproducible on a clean checkout of `main` with no changes from this PR. This branch does not introduce or change that failure.