### PR TITLE
Run bun test in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,12 @@ on:
 
 jobs:
   ci:
-    name: typecheck / lint / format
+    name: typecheck / lint / format / test
     runs-on: ubuntu-latest
+    env:
+      # Tests don't hit Fireworks, but src/agent/auth.ts gates startup on this
+      # var being present (process.exit(1) otherwise). A dummy value is enough.
+      FIREWORKS_API_KEY: dummy
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,3 +34,6 @@ jobs:
 
       - name: Format check
         run: bun run format:check
+
+      - name: Test
+        run: bun test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,7 @@ jobs:
           git config --global user.name "TypeClaw CI"
 
       - name: Test
-        run: bun test
+        # Bump per-test timeout from the 5s default: a handful of runInit tests
+        # shell out to a real `bun install` and run 4-5s on local hardware,
+        # which crosses 5s on the slower GitHub Actions runners.
+        run: bun test --timeout 30000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,13 @@ jobs:
       - name: Format check
         run: bun run format:check
 
+      - name: Configure git identity
+        # Several tests shell out to `git commit` against tmp repos. GitHub
+        # Actions runners have no global user.name/user.email, so the commits
+        # would silently fail and leave files staged.
+        run: |
+          git config --global user.email "ci@typeclaw.dev"
+          git config --global user.name "TypeClaw CI"
+
       - name: Test
         run: bun test


### PR DESCRIPTION
## Summary
- Add a Test step to .github/workflows/ci.yml so `bun test` runs alongside the existing typecheck / lint / format gates
- Set `FIREWORKS_API_KEY: dummy` at the job level so test startup gets past the `getAuth()` guard in src/agent/auth.ts (which calls `process.exit(1)` when the var is missing, killing the test runner mid-suite); tests do not actually hit Fireworks

## Verification
On this branch, against a fresh checkout with no `.env`:

```
$ FIREWORKS_API_KEY=dummy bun test
 1013 pass
 0 fail
 1961 expect() calls
Ran 1013 tests across 81 files. [15.50s]
```

`bun run typecheck`, `bun run lint`, and `bun run format:check` all clean.