### PR TITLE
Add HTTP hostd transport for container restarts

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -74,8 +74,7 @@ export type CreateSessionOptions = {
   // session creation so subagents see exactly what they declared.
   pluginSubagent?: PluginSubagentSelection
   // Enables the `restart` tool. Set when the agent is running inside a
-  // typeclaw-managed container and the host daemon is reachable via the
-  // bind-mounted run dir. Read from TYPECLAW_CONTAINER_NAME at the call site.
+  // typeclaw-managed container. Read from TYPECLAW_CONTAINER_NAME at the call site.
   containerName?: string
 }
 

--- a/src/agent/tools/restart.test.ts
+++ b/src/agent/tools/restart.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { createRestartTool } from './restart'
+
+let server: ReturnType<typeof Bun.serve> | null = null
+const fakeCtx = {} as Parameters<ReturnType<typeof createRestartTool>['execute']>[4]
+
+afterEach(() => {
+  server?.stop(true)
+  server = null
+})
+
+describe('createRestartTool', () => {
+  test('uses HTTP hostd transport when URL and token are configured', async () => {
+    const requests: Array<{ auth: string | null; body: unknown }> = []
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        requests.push({ auth: req.headers.get('authorization'), body: await req.json() })
+        return Response.json({ ok: true, result: { containerName: 'coder', scheduled: true } })
+      },
+    })
+    let exitCode: number | undefined
+    const tool = createRestartTool({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      exit: (code) => {
+        exitCode = code
+      },
+    })
+
+    const result = await tool.execute('id', {}, undefined, undefined, fakeCtx)
+
+    expect(result.details).toEqual({ ok: true, containerName: 'coder' })
+    expect(requests).toEqual([
+      {
+        auth: 'Bearer secret',
+        body: { kind: 'restart', containerName: 'coder' },
+      },
+    ])
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    expect(exitCode).toBe(0)
+  })
+
+  test('returns denial details when HTTP restart is rejected', async () => {
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ ok: false, reason: 'invalid restart token' })
+      },
+    })
+    const tool = createRestartTool({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'bad',
+      exit: () => {
+        throw new Error('exit should not run')
+      },
+    })
+
+    const result = await tool.execute('id', {}, undefined, undefined, fakeCtx)
+
+    expect(result.details).toEqual({ ok: false, containerName: 'coder', reason: 'invalid restart token' })
+  })
+})

--- a/src/agent/tools/restart.ts
+++ b/src/agent/tools/restart.ts
@@ -1,7 +1,7 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
-import { send } from '@/hostd/client'
+import { send, sendHttp } from '@/hostd/client'
 import { containerSocketPath } from '@/hostd/paths'
 
 const ACK_TIMEOUT_MS = 5_000
@@ -11,12 +11,16 @@ export type CreateRestartToolOptions = {
   containerName: string
   exit?: (code: number) => void
   socketPath?: string
+  hostdUrl?: string
+  hostdToken?: string
 }
 
 export type RestartToolDetails = { ok: boolean; containerName: string; reason?: string }
 
-export function createRestartTool({ containerName, exit, socketPath }: CreateRestartToolOptions) {
+export function createRestartTool({ containerName, exit, socketPath, hostdUrl, hostdToken }: CreateRestartToolOptions) {
   const doExit = exit ?? ((code: number) => process.exit(code))
+  const httpUrl = hostdUrl ?? process.env.TYPECLAW_HOSTD_URL
+  const httpToken = hostdToken ?? process.env.TYPECLAW_HOSTD_TOKEN
 
   return defineTool({
     name: 'restart',
@@ -30,10 +34,11 @@ export function createRestartTool({ containerName, exit, socketPath }: CreateRes
       'TUI must reconnect after the new container is up.',
     parameters: Type.Object({}),
     execute: async () => {
-      const reply = await send(
-        { kind: 'restart', containerName },
-        { timeoutMs: ACK_TIMEOUT_MS, socket: socketPath ?? containerSocketPath() },
-      )
+      const request = { kind: 'restart' as const, containerName }
+      const reply =
+        httpUrl && httpToken
+          ? await sendHttp(request, { timeoutMs: ACK_TIMEOUT_MS, url: httpUrl, token: httpToken })
+          : await send(request, { timeoutMs: ACK_TIMEOUT_MS, socket: socketPath ?? containerSocketPath() })
       if (!reply.ok) {
         const details: RestartToolDetails = { ok: false, containerName, reason: reply.reason }
         return {

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -54,6 +54,8 @@ function formatLog(event: DaemonLogEvent | SupervisorLogEvent): string {
   switch (event.kind) {
     case 'daemon-listening':
       return `[hostd] listening on ${event.socket}`
+    case 'daemon-http-listening':
+      return `[hostd] HTTP control listening on ${event.host}:${event.port}`
     case 'daemon-stopping':
       return `[hostd] stopping`
     case 'shutdown-requested':

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -76,6 +76,26 @@ describe('planStart', () => {
     expect(plan.runArgs.at(-1)).toBe(plan.imageTag)
   })
 
+  test('adds hostd HTTP control env when restart transport is available', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+
+    const plan = await planStart({
+      cwd: root,
+      hostPort: 8973,
+      imageExists: true,
+      hostdControl: { url: 'http://host.docker.internal:49123', token: 'secret' },
+    })
+
+    expect(plan.runArgs).toContain('-e')
+    expect(plan.runArgs).toContain(`TYPECLAW_CONTAINER_NAME=${basename(root)}`)
+    expect(plan.runArgs).toContain('TYPECLAW_HOSTD_URL=http://host.docker.internal:49123')
+    expect(plan.runArgs).toContain('TYPECLAW_HOSTD_TOKEN=secret')
+    expect(plan.runArgs).toContain('--add-host')
+    expect(plan.runArgs).toContain('host.docker.internal:host-gateway')
+    expect(plan.runArgs.some((arg) => arg.includes('/run/typeclaw-host'))).toBe(false)
+  })
+
   test('groups all agents under a single "typeclaw" compose project', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
@@ -5,7 +6,6 @@ import { isAbsolute, join, resolve } from 'node:path'
 
 import { configSchema, type Mount } from '@/config/config'
 import { send as sendToDaemon } from '@/hostd/client'
-import { containerHostRunDir, runDir } from '@/hostd/paths'
 import { ensureDaemon } from '@/hostd/spawn'
 import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
@@ -17,6 +17,8 @@ const PACKAGE_FILE = 'package.json'
 const CONFIG_FILE = 'typeclaw.json'
 const ENV_FILE = '.env'
 const COMPOSE_PROJECT = 'typeclaw'
+const CONTAINER_HOSTD_HOST = 'host.docker.internal'
+const HOST_GATEWAY_ALIAS = `${CONTAINER_HOSTD_HOST}:host-gateway`
 
 const MOUNT_TARGET_PREFIX = '/agent/mounts'
 
@@ -35,6 +37,12 @@ export type PlanStartOptions = {
   hostPort: number
   imageExists: boolean
   forceBuild?: boolean
+  hostdControl?: HostDaemonControl
+}
+
+export type HostDaemonControl = {
+  url: string
+  token: string
 }
 
 export type StartOptions = {
@@ -104,6 +112,9 @@ export async function start({
       }
     }
 
+    const hostd = cliEntry ? await registerWithDaemon({ cwd, containerName, cliEntry }) : { state: 'disabled' as const }
+    const hostdControl = hostd.state === 'registered' ? hostd.control : undefined
+
     const imageExisted = await imageExists(exec, imageTagValue)
 
     // First attempt uses the user's preferred host port (8973 by default, or
@@ -111,12 +122,15 @@ export async function start({
     // we fall through to a kernel-assigned ephemeral port. The container's
     // internal port stays fixed at CONTAINER_PORT regardless.
     let hostPort = await allocatePort(preferredHostPort)
-    let plan = await planStart({ cwd, hostPort, imageExists: imageExisted, forceBuild })
+    let plan = await planStart({ cwd, hostPort, imageExists: imageExisted, forceBuild, hostdControl })
 
     let built = false
     if (plan.needsBuild) {
       const build = await exec(['build', '-t', plan.imageTag, plan.buildContext], { cwd, inheritStdio: true })
-      if (build.exitCode !== 0) return { ok: false, reason: 'docker build failed' }
+      if (build.exitCode !== 0) {
+        await cleanupHostDaemonRegistration(containerName, hostd)
+        return { ok: false, reason: 'docker build failed' }
+      }
       built = true
     }
 
@@ -128,23 +142,16 @@ export async function start({
     // Skip rebuild on retry: the image is already on disk from the first attempt.
     if (run.exitCode !== 0 && isPortAllocatedError(run.stderr)) {
       hostPort = await allocatePort(0)
-      plan = await planStart({ cwd, hostPort, imageExists: true, forceBuild: false })
+      plan = await planStart({ cwd, hostPort, imageExists: true, forceBuild: false, hostdControl })
       run = await exec(plan.runArgs, { cwd })
     }
 
     if (run.exitCode !== 0) {
+      await cleanupHostDaemonRegistration(containerName, hostd)
       return { ok: false, reason: `docker run failed: ${run.stderr.trim() || 'no stderr'}` }
     }
 
-    const hostd = cliEntry
-      ? await registerWithDaemon({
-          cwd,
-          containerName: plan.containerName,
-          cliEntry,
-        })
-      : { state: 'disabled' as const }
-
-    return { ok: true, plan, containerId: run.stdout.trim(), built, hostPort, hostd }
+    return { ok: true, plan, containerId: run.stdout.trim(), built, hostPort, hostd: stripHostDaemonControl(hostd) }
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
   }
@@ -155,6 +162,7 @@ export async function planStart({
   hostPort,
   imageExists,
   forceBuild = false,
+  hostdControl,
 }: PlanStartOptions): Promise<StartPlan> {
   const containerName = containerNameFromCwd(cwd)
   const imageTag = imageTagFromCwd(cwd)
@@ -163,6 +171,10 @@ export async function planStart({
   const mounts = await loadMounts(cwd)
 
   const runArgs = ['run', '-d', '--name', containerName, '--rm', '-p', `${hostPort}:${CONTAINER_PORT}`]
+
+  if (hostdControl) {
+    runArgs.push('--add-host', HOST_GATEWAY_ALIAS)
+  }
 
   for (const [key, value] of Object.entries(composeLabels(cwd, containerName))) {
     runArgs.push('--label', `${key}=${value}`)
@@ -187,15 +199,12 @@ export async function planStart({
   // env var — same way TZ is plumbed.
   runArgs.push('-e', `TYPECLAW_CONTAINER_NAME=${containerName}`)
 
-  runArgs.push('-v', `${cwd}:/agent`)
+  if (hostdControl) {
+    runArgs.push('-e', `TYPECLAW_HOSTD_URL=${hostdControl.url}`)
+    runArgs.push('-e', `TYPECLAW_HOSTD_TOKEN=${hostdControl.token}`)
+  }
 
-  // Bind-mount the host daemon's run dir into the container at a fixed path
-  // so the agent can talk to the singleton hostd over its Unix socket. This
-  // is what makes container-initiated operations (e.g. the `restart` tool)
-  // possible without giving the container access to the Docker socket.
-  // Read-write because the bun TCP/Unix client opens the socket file; the
-  // daemon enforces auth by scoping each RPC to the registered containerName.
-  runArgs.push('-v', `${runDir()}:${containerHostRunDir()}`)
+  runArgs.push('-v', `${cwd}:/agent`)
 
   // Dev mode: node_modules/typeclaw is a symlink to an absolute host path
   // outside /agent. Mirror-mount that path so the symlink resolves in-container.
@@ -331,16 +340,33 @@ async function registerWithDaemon({
   cwd: string
   containerName: string
   cliEntry: string
-}): Promise<HostDaemonStatus> {
+}): Promise<PreparedHostDaemonStatus> {
   const ensured = await ensureDaemon({ cliEntry })
   if (!ensured.ok) return { state: 'unavailable', reason: ensured.reason }
+  const token = randomBytes(32).toString('base64url')
   const reply = await sendToDaemon({
     kind: 'register',
     containerName,
     cwd,
+    restartToken: token,
   })
   if (!reply.ok) return { state: 'unavailable', reason: reply.reason }
-  return { state: 'registered' }
+  return { state: 'registered', control: { url: `http://${CONTAINER_HOSTD_HOST}:${ensured.httpPort}`, token } }
+}
+
+type PreparedHostDaemonStatus =
+  | { state: 'registered'; control: HostDaemonControl }
+  | { state: 'unavailable'; reason: string }
+  | { state: 'disabled' }
+
+function stripHostDaemonControl(status: PreparedHostDaemonStatus): HostDaemonStatus {
+  if (status.state === 'registered') return { state: 'registered' }
+  return status
+}
+
+async function cleanupHostDaemonRegistration(containerName: string, status: PreparedHostDaemonStatus): Promise<void> {
+  if (status.state !== 'registered') return
+  await sendToDaemon({ kind: 'deregister', containerName }).catch(() => {})
 }
 
 // process.env.TZ is honored first because users who explicitly set it (e.g.

--- a/src/hostd/client.ts
+++ b/src/hostd/client.ts
@@ -22,6 +22,38 @@ export type SendOptions = {
   socket?: string
 }
 
+export type SendHttpOptions = {
+  timeoutMs?: number
+  url: string
+  token: string
+}
+
+export async function sendHttp(req: Request, opts: SendHttpOptions): Promise<Response> {
+  const controller = new AbortController()
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(new URL('/rpc', opts.url), {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${opts.token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(req),
+      signal: controller.signal,
+    })
+    const parsed = (await res.json()) as Response
+    return parsed
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      return { ok: false, reason: `daemon ack timeout after ${timeoutMs}ms` }
+    }
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 export async function send(req: Request, opts: SendOptions = {}): Promise<Response> {
   const path = opts.socket ?? socketPath()
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -6,10 +6,10 @@ import { join } from 'node:path'
 
 import type { DockerExec } from '@/container'
 
-import { send } from './client'
+import { send, sendHttp } from './client'
 import { startDaemon, type Daemon } from './daemon'
 import { socketPath } from './paths'
-import type { ListResult, VersionResult } from './protocol'
+import type { HttpInfoResult, ListResult, VersionResult } from './protocol'
 
 let home: string
 let prev: string | undefined
@@ -181,6 +181,63 @@ describe('startDaemon', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 50))
     expect(restartCalls).toEqual([{ containerName: 'coder', cwd: '/agent/coder' }])
+  })
+
+  test('HTTP restart ACKs with the registered container token', async () => {
+    const restartCalls: Array<{ containerName: string; cwd: string }> = []
+    daemon = await startDaemon({
+      exec: fakeExec(new Set(['coder'])),
+      gcIntervalMs: 1_000_000,
+      restart: async ({ containerName, cwd }) => {
+        restartCalls.push({ containerName, cwd })
+        return { ok: true }
+      },
+    })
+    const info = await send({ kind: 'http-info' })
+    expect(info.ok).toBe(true)
+    if (!info.ok) return
+    const port = (info.result as HttpInfoResult).port
+
+    await send({ kind: 'register', containerName: 'coder', cwd: '/agent/coder', restartToken: 'secret' })
+    const ack = await sendHttp(
+      { kind: 'restart', containerName: 'coder' },
+      { url: `http://127.0.0.1:${port}`, token: 'secret' },
+    )
+    expect(ack.ok).toBe(true)
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(restartCalls).toEqual([{ containerName: 'coder', cwd: '/agent/coder' }])
+  })
+
+  test('HTTP restart rejects an invalid container token', async () => {
+    daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, restart: async () => ({ ok: true }) })
+    const info = await send({ kind: 'http-info' })
+    expect(info.ok).toBe(true)
+    if (!info.ok) return
+
+    await send({ kind: 'register', containerName: 'coder', cwd: '/agent/coder', restartToken: 'secret' })
+    const ack = await sendHttp(
+      { kind: 'restart', containerName: 'coder' },
+      { url: `http://127.0.0.1:${(info.result as HttpInfoResult).port}`, token: 'wrong' },
+    )
+    expect(ack.ok).toBe(false)
+    if (ack.ok) return
+    expect(ack.reason).toContain('invalid restart token')
+  })
+
+  test('HTTP restart rejects oversized unauthenticated requests before parsing JSON', async () => {
+    daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, restart: async () => ({ ok: true }) })
+    const info = await send({ kind: 'http-info' })
+    expect(info.ok).toBe(true)
+    if (!info.ok) return
+
+    const res = await fetch(`http://127.0.0.1:${(info.result as HttpInfoResult).port}/rpc`, {
+      method: 'POST',
+      body: '{'.repeat(70_000),
+    })
+    const body = (await res.json()) as { ok: false; reason: string }
+    expect(res.status).toBe(401)
+    expect(body.reason).toContain('missing bearer token')
   })
 
   test('restart RPC rejects unknown containerName (auth: scope by registered name)', async () => {

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -8,9 +8,10 @@ import { defaultDockerExec, type DockerExec } from '@/container'
 import { isDaemonReachable } from './client'
 import { ensureDirs, socketPath } from './paths'
 import type {
+  HttpInfoResult,
   ListResult,
   Request,
-  Response,
+  Response as RpcResponse,
   RestartResult,
   ShutdownResult,
   StatusResult,
@@ -39,10 +40,13 @@ export type DaemonOptions = {
   // a `shutdown` RPC. Production wiring exits the process here so the host
   // can spawn a fresh daemon; tests omit it to keep the process alive.
   onShutdown?: () => void
+  httpHost?: string
+  httpPort?: number
 }
 
 export type DaemonLogEvent =
   | { kind: 'daemon-listening'; socket: string }
+  | { kind: 'daemon-http-listening'; host: string; port: number }
   | { kind: 'daemon-stopping' }
   | { kind: 'register'; containerName: string }
   | { kind: 'deregister'; containerName: string; reason: 'requested' | 'gone' }
@@ -56,8 +60,23 @@ export type Daemon = {
 const DEFAULT_GC_INTERVAL_MS = 30_000
 const DEFAULT_GC_MISSES_TO_DEREGISTER = 3
 const MAX_REQUEST_BUFFER_BYTES = 64 * 1024
+const MAX_HTTP_REQUEST_BYTES = 64 * 1024
 
 type ServerState = { buf: string }
+
+function json(response: RpcResponse, status = 200): globalThis.Response {
+  return new Response(JSON.stringify(response), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function bearerToken(value: string | null): string | null {
+  if (!value) return null
+  const prefix = 'Bearer '
+  if (!value.startsWith(prefix)) return null
+  return value.slice(prefix.length)
+}
 
 export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   await ensureDirs()
@@ -78,9 +97,11 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   const gcMissesToDeregister = opts.gcMissesToDeregister ?? DEFAULT_GC_MISSES_TO_DEREGISTER
   const version = opts.version ?? UNVERSIONED_SENTINEL
   const cwds = new Map<string, string>()
+  const restartTokens = new Map<string, string>()
   const perContainerSerial = new Map<string, Promise<unknown>>()
   const gcMisses = new Map<string, number>()
   let stopped = false
+  let httpPort = 0
 
   const supervisor = opts.restart
     ? buildSupervisor({
@@ -103,12 +124,18 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     return next
   }
 
-  const handleRegister = async (req: { containerName: string; cwd: string }): Promise<Response> => {
+  const handleRegister = async (req: {
+    containerName: string
+    cwd: string
+    restartToken?: string
+  }): Promise<RpcResponse> => {
     if (stopped) return { ok: false, reason: 'daemon stopping' }
     return runSerially(req.containerName, async () => {
       if (stopped) return { ok: false, reason: 'daemon stopping' }
       const alreadyRegistered = cwds.has(req.containerName)
       cwds.set(req.containerName, req.cwd)
+      if (req.restartToken) restartTokens.set(req.containerName, req.restartToken)
+      else restartTokens.delete(req.containerName)
       if (!alreadyRegistered) {
         log({ kind: 'register', containerName: req.containerName })
       }
@@ -116,22 +143,23 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     })
   }
 
-  const handleDeregister = async (req: { containerName: string }): Promise<Response> =>
+  const handleDeregister = async (req: { containerName: string }): Promise<RpcResponse> =>
     runSerially(req.containerName, async () => {
       const hadCwd = cwds.delete(req.containerName)
+      restartTokens.delete(req.containerName)
       gcMisses.delete(req.containerName)
       if (hadCwd) log({ kind: 'deregister', containerName: req.containerName, reason: 'requested' })
       return { ok: true }
     })
 
-  const handleList = (): Response => {
+  const handleList = (): RpcResponse => {
     const result: ListResult = {
       registrations: Array.from(cwds.entries()).map(([containerName, cwd]) => ({ containerName, cwd })),
     }
     return { ok: true, result }
   }
 
-  const handleStatus = (req: { containerName: string }): Response => {
+  const handleStatus = (req: { containerName: string }): RpcResponse => {
     const cwd = cwds.get(req.containerName)
     if (!cwd) return { ok: false, reason: `not registered: ${req.containerName}` }
     const result: StatusResult = {
@@ -146,7 +174,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   // reaches the mounted socket could otherwise restart any peer container on
   // the host. Scoping by registered name limits the blast radius to the set
   // of containers this user already started.
-  const handleRestart = (req: { containerName: string }): Response => {
+  const handleRestart = (req: { containerName: string }): RpcResponse => {
     if (!supervisor) return { ok: false, reason: 'restart capability not enabled on this daemon' }
     const cwd = cwds.get(req.containerName)
     if (!cwd) return { ok: false, reason: `not registered: ${req.containerName}` }
@@ -156,7 +184,12 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     return { ok: true, result }
   }
 
-  const handleVersion = (): Response => {
+  const handleHttpInfo = (): RpcResponse => {
+    const result: HttpInfoResult = { port: httpPort }
+    return { ok: true, result }
+  }
+
+  const handleVersion = (): RpcResponse => {
     const result: VersionResult = { version }
     return { ok: true, result }
   }
@@ -169,7 +202,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   // SIGTERM the AGENTS.md "PID-reuse safety" rule warns about: the socket
   // round-trip itself proves we are talking to the daemon we just registered
   // with, so a stale pidfile cannot redirect the kill to an unrelated process.
-  const handleShutdown = (): Response => {
+  const handleShutdown = (): RpcResponse => {
     if (stopped) return { ok: true, result: { scheduled: true } satisfies ShutdownResult }
     log({ kind: 'shutdown-requested' })
     setTimeout(() => {
@@ -180,7 +213,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     return { ok: true, result: { scheduled: true } satisfies ShutdownResult }
   }
 
-  const dispatch = async (req: Request): Promise<Response> => {
+  const dispatch = async (req: Request): Promise<RpcResponse> => {
     switch (req.kind) {
       case 'register':
         return handleRegister(req)
@@ -192,6 +225,8 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
         return handleStatus(req)
       case 'restart':
         return handleRestart(req)
+      case 'http-info':
+        return handleHttpInfo()
       case 'version':
         return handleVersion()
       case 'shutdown':
@@ -199,7 +234,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     }
   }
 
-  const respond = (sock: Socket<ServerState>, response: Response): void => {
+  const respond = (sock: Socket<ServerState>, response: RpcResponse): void => {
     try {
       sock.write(`${JSON.stringify(response)}\n`)
     } catch {}
@@ -232,6 +267,41 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       newline = sock.data.buf.indexOf('\n')
     }
   }
+
+  const httpServer = Bun.serve({
+    hostname: opts.httpHost ?? '0.0.0.0',
+    port: opts.httpPort ?? 0,
+    async fetch(req) {
+      const url = new URL(req.url)
+      if (req.method !== 'POST' || url.pathname !== '/rpc') {
+        return json({ ok: false, reason: 'not found' }, 404)
+      }
+      const token = bearerToken(req.headers.get('authorization'))
+      if (!token) return json({ ok: false, reason: 'missing bearer token' }, 401)
+      const contentLength = Number(req.headers.get('content-length') ?? '0')
+      if (Number.isFinite(contentLength) && contentLength > MAX_HTTP_REQUEST_BYTES) {
+        return json({ ok: false, reason: 'request exceeds buffer limit' }, 413)
+      }
+      let rpc: Request
+      try {
+        const body = await req.text()
+        if (body.length > MAX_HTTP_REQUEST_BYTES)
+          return json({ ok: false, reason: 'request exceeds buffer limit' }, 413)
+        rpc = JSON.parse(body) as Request
+      } catch {
+        return json({ ok: false, reason: 'invalid request json' }, 400)
+      }
+      if (rpc.kind !== 'restart') {
+        return json({ ok: false, reason: 'http transport only supports restart' }, 403)
+      }
+      if (restartTokens.get(rpc.containerName) !== token) {
+        return json({ ok: false, reason: 'invalid restart token' }, 403)
+      }
+      return json(handleRestart(rpc))
+    },
+  })
+  httpPort = httpServer.port ?? 0
+  log({ kind: 'daemon-http-listening', host: opts.httpHost ?? '0.0.0.0', port: httpPort })
 
   const listener: UnixSocketListener<ServerState> = Bun.listen<ServerState>({
     unix: path,
@@ -302,7 +372,9 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       try {
         listener.stop(true)
       } catch {}
+      httpServer.stop(true)
       cwds.clear()
+      restartTokens.clear()
       try {
         if (existsSync(path)) await unlink(path)
       } catch {}

--- a/src/hostd/protocol.ts
+++ b/src/hostd/protocol.ts
@@ -3,11 +3,13 @@ export type Request =
       kind: 'register'
       containerName: string
       cwd: string
+      restartToken?: string
     }
   | { kind: 'deregister'; containerName: string }
   | { kind: 'list' }
   | { kind: 'status'; containerName: string }
   | { kind: 'restart'; containerName: string }
+  | { kind: 'http-info' }
   | { kind: 'version' }
   | { kind: 'shutdown' }
 
@@ -25,6 +27,10 @@ export type StatusResult = {
 export type RestartResult = {
   containerName: string
   scheduled: true
+}
+
+export type HttpInfoResult = {
+  port: number
 }
 
 export type VersionResult = {

--- a/src/hostd/spawn.ts
+++ b/src/hostd/spawn.ts
@@ -3,7 +3,7 @@ import { open, readFile, unlink, writeFile } from 'node:fs/promises'
 
 import { isDaemonReachable, send } from './client'
 import { ensureDirs, lockfilePath, logfilePath, pidfilePath, socketPath } from './paths'
-import type { VersionResult } from './protocol'
+import type { HttpInfoResult, VersionResult } from './protocol'
 import { computeSourceVersion, resolveSrcRoot, UNVERSIONED_SENTINEL } from './version'
 
 export type EnsureDaemonOptions = {
@@ -15,7 +15,7 @@ export type EnsureDaemonOptions = {
 }
 
 export type EnsureDaemonResult =
-  | { ok: true; pid: number; spawned: boolean; respawned: boolean }
+  | { ok: true; pid: number; spawned: boolean; respawned: boolean; httpPort: number }
   | { ok: false; reason: string }
 
 const DEFAULT_SPAWN_TIMEOUT_MS = 5_000
@@ -25,8 +25,9 @@ const POLL_INTERVAL_MS = 50
 export async function ensureDaemon(opts: EnsureDaemonOptions): Promise<EnsureDaemonResult> {
   if (await isDaemonReachable()) {
     const expected = opts.expectedVersion ?? (await deriveExpectedVersion(opts.cliEntry))
-    if (await daemonVersionMatches(expected)) {
-      return { ok: true, pid: await readPidQuiet(), spawned: false, respawned: false }
+    const httpPort = await readHttpPort()
+    if ((await daemonVersionMatches(expected)) && httpPort !== null) {
+      return { ok: true, pid: await readPidQuiet(), spawned: false, respawned: false, httpPort }
     }
     const shutdownOk = await requestShutdownAndWait()
     if (!shutdownOk) {
@@ -62,6 +63,13 @@ async function daemonVersionMatches(expected: string): Promise<boolean> {
   return result.version === expected
 }
 
+async function readHttpPort(): Promise<number | null> {
+  const reply = await send({ kind: 'http-info' }, { timeoutMs: 1_000 })
+  if (!reply.ok) return null
+  const result = reply.result as HttpInfoResult | undefined
+  return typeof result?.port === 'number' && result.port > 0 && result.port <= 65535 ? result.port : null
+}
+
 async function requestShutdownAndWait(): Promise<boolean> {
   const reply = await send({ kind: 'shutdown' }, { timeoutMs: 1_000 })
   if (!reply.ok) return false
@@ -73,12 +81,14 @@ async function requestShutdownAndWait(): Promise<boolean> {
   return false
 }
 
-type SpawnAttemptResult = { ok: true; pid: number; spawned: boolean } | { ok: false; reason: string }
+type SpawnAttemptResult = { ok: true; pid: number; spawned: boolean; httpPort: number } | { ok: false; reason: string }
 
 async function ensureDaemonWithRetry(opts: EnsureDaemonOptions, retriesLeft: number): Promise<SpawnAttemptResult> {
   const lock = await acquireLockOrWait(opts.spawnTimeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS)
   if (lock.kind === 'daemon-reachable') {
-    return { ok: true, pid: await readPidQuiet(), spawned: false }
+    const httpPort = await readHttpPort()
+    if (httpPort === null) return { ok: false, reason: 'daemon did not report an HTTP control port' }
+    return { ok: true, pid: await readPidQuiet(), spawned: false, httpPort }
   }
   if (lock.kind === 'stale-lock-cleared') {
     if (retriesLeft > 0) return ensureDaemonWithRetry(opts, retriesLeft - 1)
@@ -90,7 +100,9 @@ async function ensureDaemonWithRetry(opts: EnsureDaemonOptions, retriesLeft: num
 
   try {
     if (await isDaemonReachable()) {
-      return { ok: true, pid: await readPidQuiet(), spawned: false }
+      const httpPort = await readHttpPort()
+      if (httpPort === null) return { ok: false, reason: 'daemon did not report an HTTP control port' }
+      return { ok: true, pid: await readPidQuiet(), spawned: false, httpPort }
     }
     return await spawnDaemonDetached(opts)
   } finally {
@@ -137,7 +149,10 @@ async function spawnDaemonDetached(opts: EnsureDaemonOptions): Promise<SpawnAtte
 
   const deadline = Date.now() + (opts.spawnTimeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS)
   while (Date.now() < deadline) {
-    if (await isDaemonReachable()) return { ok: true, pid: proc.pid, spawned: true }
+    if (await isDaemonReachable()) {
+      const httpPort = await readHttpPort()
+      if (httpPort !== null) return { ok: true, pid: proc.pid, spawned: true, httpPort }
+    }
     await sleep(POLL_INTERVAL_MS)
   }
 


### PR DESCRIPTION
## Summary
- add an authenticated HTTP control endpoint to hostd for container-originated restart RPCs
- pass per-container hostd URL/token env vars during `typeclaw start` instead of relying on a bind-mounted Unix socket
- keep Unix socket RPCs for host CLI control and add tests for HTTP restart auth, readiness, and container env plumbing

## Verification
- bun test src/hostd/daemon.test.ts src/hostd/client.test.ts src/hostd/spawn.test.ts src/container/start.test.ts src/agent/tools/restart.test.ts
- bun run typecheck
- bun run lint
- bun run format:check
- FIREWORKS_API_KEY=fw_test bun run test