### PR TITLE
Evict idle channel sessions after 30 minutes

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -11,7 +11,7 @@ import type { SessionOrigin } from '@/agent/session-origin'
 import type { HookBus } from '@/plugin'
 
 import { loadChannelSessions, saveChannelSessions } from './persistence'
-import { createChannelRouter, sliceHeadTail, type ChannelRouter } from './router'
+import { createChannelRouter, SESSION_IDLE_MS, sliceHeadTail, type ChannelRouter } from './router'
 import { defaultHistoryConfig, type ChannelAdapterConfig } from './schema'
 import type { ChannelHistoryMessage, ChannelKey, FetchHistoryArgs, HistoryCallback, InboundMessage } from './types'
 
@@ -1424,5 +1424,192 @@ describe('ChannelRouter cold-start prefetch', () => {
     await router.__testing!.flushDebounce(THREAD_KEY)
 
     expect(captured).toEqual([{ chat: 'c1', thread: 't-A', limit: 8 }])
+  })
+})
+
+// Idle GC evicts LiveSessions whose lastInboundAt is older than
+// SESSION_IDLE_MS. Persistence (channels/sessions.json) is intentionally
+// untouched: the next inbound rehydrates from disk against the same
+// sessionId, so the agent gets a fresh in-memory session but the on-disk
+// transcript continues. Tests drive the GC via the `__testing.runIdleGc()`
+// seam; production uses a setInterval.
+describe('ChannelRouter idle session GC', () => {
+  test('evicts a session that has been idle longer than SESSION_IDLE_MS', async () => {
+    // given: an engaged session at t=1000 (creates the session)
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(router.liveCount()).toBe(1)
+
+    // when: time advances past the idle threshold and the GC runs
+    nowRef.value = 1000 + SESSION_IDLE_MS + 1
+    await router.__testing!.runIdleGc!()
+
+    // then: live map drops the entry, the session is aborted+disposed
+    expect(router.liveCount()).toBe(0)
+    expect(sessions[0]!.aborted).toBe(1)
+    expect(sessions[0]!.disposed).toBe(1)
+  })
+
+  test('does not evict a session whose lastInboundAt is within SESSION_IDLE_MS', async () => {
+    // given
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when: advance time but stay just under the threshold
+    nowRef.value = 1000 + SESSION_IDLE_MS - 1
+    await router.__testing!.runIdleGc!()
+
+    // then
+    expect(router.liveCount()).toBe(1)
+    expect(sessions[0]!.aborted).toBe(0)
+  })
+
+  test('does not evict a session that is currently draining', async () => {
+    // given: a session whose prompt() blocks until we release it
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    let release: (() => void) | undefined
+    const blocked = new Promise<void>((r) => {
+      release = r
+    })
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    await router.route(inbound({ text: 'hi bot' }))
+    sessions[0]!.onPrompt = async () => {
+      await blocked
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+
+    // when: time leaps past the threshold while the turn is in flight
+    nowRef.value = 1000 + SESSION_IDLE_MS + 1
+    await router.__testing!.runIdleGc!()
+
+    // then: GC respects the in-flight turn and leaves the session alone
+    expect(router.liveCount()).toBe(1)
+    expect(sessions[0]!.aborted).toBe(0)
+
+    // cleanup so the test process can exit
+    release!()
+    await draining
+  })
+
+  test('next inbound after eviction creates a fresh session and rehydrates the persisted sessionId', async () => {
+    // given: session is evicted
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value = 1000 + SESSION_IDLE_MS + 1
+    await router.__testing!.runIdleGc!()
+    expect(router.liveCount()).toBe(0)
+
+    // when
+    await router.route(inbound({ text: 'still here?', externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then
+    expect(sessions).toHaveLength(2)
+    expect(router.liveCount()).toBe(1)
+    const persisted = await loadChannelSessions(dir)
+    expect(persisted).toHaveLength(1)
+    expect(persisted[0]?.sessionId).toBeDefined()
+  })
+
+  test('fires session.end hook on the evicted session before disposing', async () => {
+    // given: a session with hooks
+    const dir = await tempDir()
+    const events: string[] = []
+    const nowRef = { value: 1000 }
+    const sessions: FakeSession[] = []
+    const hooks: HookBus = {
+      registerAll: () => {},
+      unregisterAll: () => {},
+      runSessionStart: async () => {},
+      runSessionEnd: async (e) => {
+        events.push(`end:${e.sessionId}`)
+      },
+      runSessionIdle: async (e) => {
+        events.push(`idle:${e.sessionId}`)
+      },
+      runSessionPrompt: async () => {},
+      runToolBefore: async () => undefined,
+      runToolAfter: async () => {},
+      count: () => 0,
+    }
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      now: () => nowRef.value,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        sessions.push(fake)
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: `ses_fake_${sessions.length}`,
+          dispose: async () => {
+            fake.dispose()
+          },
+          hooks,
+          getTranscriptPath: () => undefined,
+        }
+      },
+    })
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when
+    nowRef.value = 1000 + SESSION_IDLE_MS + 1
+    await router.__testing!.runIdleGc!()
+
+    // then: idle fires after the prompt (existing behavior), then end on
+    // eviction; end must precede dispose so plugins can still touch state.
+    expect(events).toEqual(['idle:ses_fake_1', 'end:ses_fake_1'])
+    expect(sessions[0]!.disposed).toBe(1)
+  })
+
+  test('runIdleGc tolerates dispose throwing and still removes the entry', async () => {
+    // given
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const sessions: FakeSession[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      now: () => nowRef.value,
+      logger: {
+        info: (m) => logs.push(`info:${m}`),
+        warn: (m) => logs.push(`warn:${m}`),
+        error: (m) => logs.push(`error:${m}`),
+      },
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        sessions.push(fake)
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: `ses_fake_${sessions.length}`,
+          dispose: async () => {
+            throw new Error('dispose boom')
+          },
+        }
+      },
+    })
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when
+    nowRef.value = 1000 + SESSION_IDLE_MS + 1
+    await router.__testing!.runIdleGc!()
+
+    // then
+    expect(router.liveCount()).toBe(0)
+    expect(logs.some((l) => l.includes('dispose'))).toBe(true)
   })
 })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -41,6 +41,19 @@ export const CONTEXT_BUFFER_SIZE = 20
 // continuously visible while we debounce + generate without spamming the API.
 export const TYPING_HEARTBEAT_MS = 8000
 
+// Idle GC: a LiveSession whose `lastInboundAt` is older than
+// SESSION_IDLE_MS gets evicted on the next GC tick. Persistence
+// (channels/sessions.json) is intentionally untouched — the next inbound
+// rehydrates from disk against the same sessionId, so the on-disk
+// transcript continues across the eviction. The point is to free memory
+// (LiveSession holds an open SessionManager + transcript in RAM) and to
+// give the next conversation a fresh start without forcing the user to
+// notice anything. `lastInboundAt` is bumped only by *engaged* inbounds
+// (see scheduleDebouncedDrain), so passive observation alone won't keep
+// a session warm forever — that's intentional.
+export const SESSION_IDLE_MS = 30 * 60 * 1000
+export const SESSION_GC_INTERVAL_MS = 60 * 1000
+
 // Two-axis loop guard for peer-bot conversation. Peer bots route into
 // engagement under the SAME rules as humans, so a small ring (A→B→C→A) or
 // a fast cascade can otherwise ping-pong without bound. The guard trips
@@ -181,6 +194,7 @@ export type ChannelRouter = {
     flushDebounce: (key: ChannelKey) => Promise<void>
     fireTypingHeartbeat: (key: ChannelKey) => Promise<void>
     isTypingActive: (key: ChannelKey) => boolean
+    runIdleGc: () => Promise<void>
   }
 }
 
@@ -867,25 +881,55 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return live.consecutiveSends.get(consecutiveSendKey(target.chat, target.thread)) ?? 0
   }
 
+  const tearDownLive = async (live: LiveSession): Promise<void> => {
+    live.destroyed = true
+    if (live.debounceTimer) clearTimeout(live.debounceTimer)
+    live.debounceTimer = null
+    stopTypingHeartbeat(live)
+    try {
+      await live.session.abort()
+    } catch (err) {
+      logger.warn(`[channels] abort failed for ${live.keyId}: ${describe(err)}`)
+    }
+    await fireSessionEnd(live)
+    try {
+      await live.dispose()
+    } catch (err) {
+      logger.warn(`[channels] dispose failed for ${live.keyId}: ${describe(err)}`)
+    }
+  }
+
+  const runIdleGc = async (): Promise<void> => {
+    const t = now()
+    const victims: LiveSession[] = []
+    for (const live of liveSessions.values()) {
+      if (live.destroyed) continue
+      if (live.draining) continue
+      if (live.promptQueue.length > 0) continue
+      if (t - live.lastInboundAt <= SESSION_IDLE_MS) continue
+      victims.push(live)
+    }
+    for (const live of victims) {
+      liveSessions.delete(live.keyId)
+      logger.info(`[channels] ${live.keyId} idle_gc evicting after ${t - live.lastInboundAt}ms idle`)
+      await tearDownLive(live)
+    }
+  }
+
+  let gcTimer: ReturnType<typeof setInterval> | null = setInterval(() => {
+    void runIdleGc()
+  }, SESSION_GC_INTERVAL_MS)
+  // Don't keep the Bun process alive just for the GC tick; the host
+  // server's WebSocket listener owns process lifetime.
+  gcTimer.unref?.()
+
   const stop = async (): Promise<void> => {
+    if (gcTimer) clearInterval(gcTimer)
+    gcTimer = null
     const all = Array.from(liveSessions.values())
     liveSessions.clear()
     for (const live of all) {
-      live.destroyed = true
-      if (live.debounceTimer) clearTimeout(live.debounceTimer)
-      live.debounceTimer = null
-      stopTypingHeartbeat(live)
-      try {
-        await live.session.abort()
-      } catch (err) {
-        logger.warn(`[channels] abort failed for ${live.keyId}: ${describe(err)}`)
-      }
-      await fireSessionEnd(live)
-      try {
-        await live.dispose()
-      } catch (err) {
-        logger.warn(`[channels] dispose failed for ${live.keyId}: ${describe(err)}`)
-      }
+      await tearDownLive(live)
     }
   }
 
@@ -924,6 +968,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const live = liveSessions.get(channelKeyId(key))
         return live?.typingTimer !== null && live?.typingTimer !== undefined
       },
+      runIdleGc,
     },
   }
 }


### PR DESCRIPTION
## Why

`LiveSession` instances in the channel router persisted indefinitely once created. The only teardown path was `router.stop()` (process exit or adapter reload), so a busy bot accumulated one open `SessionManager` per channel forever, with the transcript growing unbounded across days.

## Fix

Add a GC tick — a 60-second `setInterval` (unref'd) — that evicts any `LiveSession` whose `lastInboundAt` is older than `SESSION_IDLE_MS` (30 minutes). Eviction mirrors `stop()`'s per-session teardown via a new `tearDownLive` helper: abort the session, fire the `session.end` hook, dispose, then drop from the live map.

## Design decisions

**Persistence is intentionally untouched.** The next inbound rehydrates the session against the same `sessionId`, so the on-disk transcript in `channels/sessions.json` continues across the eviction. The agent gets fresh in-memory context; the user sees nothing.

**Idle-ness is keyed on `lastInboundAt`, not any inbound.** `lastInboundAt` is bumped only by engaged inbounds (in `scheduleDebouncedDrain`), not the observe path. Passive chatter the bot is watching but not participating in does not keep a session warm — that's the right behavior for long-running channels where humans rarely talk to the bot but talk to each other constantly.

**In-flight work is protected.** Sessions with `draining=true` or a non-empty `promptQueue` are skipped. The interval is unref'd so it does not pin process lifetime.

## Test coverage

6 new tests in `src/channels/router.test.ts`:

1. Evicts a session past the threshold
2. Does not evict within the threshold
3. Does not evict while a turn is in flight (`draining=true`)
4. Next inbound after eviction creates a fresh in-memory session; the persisted `sessionId` mapping survives
5. `session.end` hook fires on eviction
6. Tolerates `dispose()` throwing and still removes the entry

Mutation check: commenting out the eviction breaks 4 of the 6 tests; removing the threshold guard breaks the "within threshold" test.

`bun test src/channels/` — 261/261 pass. `bun run typecheck`, `bun run lint`, `bun run format:check` — all clean.

Note: `src/run/index.test.ts` has a pre-existing failure that reproduces on a clean `origin/main` checkout — unrelated to this PR.

## Future work

This PR evicts stale in-memory sessions; it does not compact the on-disk transcript. Transcript compaction at ~80% context window belongs in the `AgentSession` layer (`src/agent/`) rather than `src/channels/`, because TUI sessions have the same unbounded-context problem. That is planned as a separate follow-up PR.