### PR TITLE
Auto-compact agent context at 80% of the model window

### DIFF
--- a/src/agent/compaction.test.ts
+++ b/src/agent/compaction.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { Model } from '@mariozechner/pi-ai'
+
+import {
+  COMPACTION_KEEP_RECENT_TOKENS,
+  COMPACTION_TRIGGER_PERCENT,
+  createCompactionSettingsManager,
+  reserveTokensForModel,
+} from './compaction'
+
+function fakeModel(contextWindow: number): Model<'openai-completions'> {
+  return {
+    id: 'fake',
+    name: 'Fake',
+    api: 'openai-completions',
+    provider: 'fake',
+    baseUrl: 'https://example',
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow,
+    maxTokens: contextWindow,
+  } as unknown as Model<'openai-completions'>
+}
+
+describe('reserveTokensForModel', () => {
+  test('reserves the (1 - COMPACTION_TRIGGER_PERCENT) fraction of the window', () => {
+    // given
+    const window = 256_000
+    const model = fakeModel(window)
+
+    // when
+    const reserve = reserveTokensForModel(model)
+
+    // then
+    expect(reserve).toBe(Math.round(window * (1 - COMPACTION_TRIGGER_PERCENT)))
+    expect(reserve).toBe(51_200)
+  })
+
+  test('scales with the model context window so trigger fraction stays constant', () => {
+    // given
+    const small = fakeModel(200_000)
+    const large = fakeModel(1_000_000)
+
+    // when
+    const triggerSmall = small.contextWindow - reserveTokensForModel(small)
+    const triggerLarge = large.contextWindow - reserveTokensForModel(large)
+
+    // then: both trip at ~80% of their own window
+    expect(triggerSmall / small.contextWindow).toBeCloseTo(COMPACTION_TRIGGER_PERCENT, 3)
+    expect(triggerLarge / large.contextWindow).toBeCloseTo(COMPACTION_TRIGGER_PERCENT, 3)
+  })
+
+  test('clamps to at least 1 so a degenerate zero-window model never produces a non-positive reserve', () => {
+    // given
+    const broken = fakeModel(0)
+
+    // when
+    const reserve = reserveTokensForModel(broken)
+
+    // then
+    expect(reserve).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('createCompactionSettingsManager', () => {
+  test('produces a SettingsManager whose getCompactionSettings() reflects our chosen values', () => {
+    // given
+    const model = fakeModel(256_000)
+
+    // when
+    const sm = createCompactionSettingsManager(model)
+    const settings = sm.getCompactionSettings()
+
+    // then
+    expect(settings.enabled).toBe(true)
+    expect(settings.reserveTokens).toBe(reserveTokensForModel(model))
+    expect(settings.keepRecentTokens).toBe(COMPACTION_KEEP_RECENT_TOKENS)
+  })
+
+  test('different models produce different reserveTokens but the same keepRecentTokens', () => {
+    // given
+    const a = fakeModel(200_000)
+    const b = fakeModel(1_000_000)
+
+    // when
+    const sa = createCompactionSettingsManager(a).getCompactionSettings()
+    const sb = createCompactionSettingsManager(b).getCompactionSettings()
+
+    // then
+    expect(sa.reserveTokens).not.toBe(sb.reserveTokens)
+    expect(sa.keepRecentTokens).toBe(sb.keepRecentTokens)
+  })
+})

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -1,0 +1,35 @@
+import type { KnownApi, Model } from '@mariozechner/pi-ai'
+import { SettingsManager } from '@mariozechner/pi-coding-agent'
+
+// Compaction trigger threshold expressed as a percentage of the model's
+// context window. pi-coding-agent's auto-compaction fires when
+// `contextTokens > contextWindow - reserveTokens`. To honor a percentage-
+// based intent across models with very different window sizes (200K Claude
+// vs. 1M Gemini vs. 256K Kimi), we derive `reserveTokens` per-model from
+// the model's `contextWindow`. SDK defaults (16384 reserve) are a fixed
+// number of tokens that drift in relative terms across models — at 256K
+// that's ~6% headroom (94% trigger), at 1M it's ~1.6% (98% trigger). A
+// percentage-derived reserve trips at the same fraction regardless of
+// model, which is what we actually want.
+export const COMPACTION_TRIGGER_PERCENT = 0.8
+
+// Tokens to keep in the recent window after compaction. Fixed (not a
+// percentage) because "recent context" is a property of conversation
+// shape, not model capacity — the same recent ~20K is roughly the right
+// amount of history regardless of whether the model has 200K or 1M total.
+// Mirrors pi's DEFAULT_COMPACTION_SETTINGS.keepRecentTokens.
+export const COMPACTION_KEEP_RECENT_TOKENS = 20_000
+
+export function reserveTokensForModel<TApi extends KnownApi>(model: Model<TApi>): number {
+  return Math.max(1, Math.round(model.contextWindow * (1 - COMPACTION_TRIGGER_PERCENT)))
+}
+
+export function createCompactionSettingsManager<TApi extends KnownApi>(model: Model<TApi>): SettingsManager {
+  return SettingsManager.inMemory({
+    compaction: {
+      enabled: true,
+      reserveTokens: reserveTokensForModel(model),
+      keepRecentTokens: COMPACTION_KEEP_RECENT_TOKENS,
+    },
+  })
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -20,6 +20,7 @@ import type { ReloadRegistry } from '@/reload'
 import type { Stream } from '@/stream'
 
 import { getAuth } from './auth'
+import { createCompactionSettingsManager } from './compaction'
 import { renderGitNudge } from './git-nudge'
 import { resolveBuiltinToolRefs, wrapPluginTool } from './plugin-tools'
 import { createReloadTool } from './reload-tool'
@@ -134,9 +135,11 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
             ...pluginCustomTools,
           ]
 
+  const model = resolveModel(getConfig().model)
   const { session } = await createAgentSession({
-    model: resolveModel(getConfig().model),
+    model,
     sessionManager: options.sessionManager ?? SessionManager.inMemory(),
+    settingsManager: createCompactionSettingsManager(model),
     authStorage,
     modelRegistry,
     resourceLoader,


### PR DESCRIPTION
## Why

Long-running TypeClaw sessions (TUI and channel alike) accumulate transcript indefinitely and eventually exhaust the model's context window. pi-coding-agent v0.67.3 already ships a complete auto-compaction subsystem on `AgentSession` (`shouldCompact`, `prepareCompaction`, `generateSummary`, `appendCompaction`, overflow recovery) — but TypeClaw never wired it up.

The `createAgentSession()` call omitted `settingsManager`, so the SDK fell back to `SettingsManager.create(cwd, agentDir)`, which tries to read `~/.pi/agent/settings.json`. In the container that file does not exist; the SDK silently used whatever pi's defaults happened to be, with zero observability and a side effect: it creates the settings file on disk inside the bind-mounted `/agent` directory if writes occur.

## Fix

Add `src/agent/compaction.ts` — a small `createCompactionSettingsManager(model)` helper that returns `SettingsManager.inMemory()` with TypeClaw's explicit compaction settings — and pass it to `createAgentSession()`. This converts implicit, drift-prone behavior into explicit, tested configuration (4 lines added to `src/agent/index.ts`, 1 changed).

## Design decisions

**Per-model percentage-derived reserve, not a fixed token count.** The user intent is "compact when context reaches 80%". pi's trigger formula is `tokens > window - reserveTokens`, so we compute `reserveTokens` as 20% of the model's `contextWindow` per session. A fixed reserve like pi's default of 16384 drifts badly across models — ~94% trigger at 256K, ~98% at 1M. The percentage approach keeps the trigger fraction constant regardless of window size (200K Claude, 256K Kimi, 1M Gemini). `keepRecentTokens` stays at 20K because "recent context" is a property of conversation shape, not model capacity.

**Persistence is free from PR1's design.** pi's compaction subsystem appends a `CompactionEntry` to the session JSONL on trigger, and `SessionManager.open()` honors it on rehydration. PR1's idle-GC eviction (#27) preserves the on-disk JSONL, so compaction state survives channel session reopens with zero extra wiring.

Together, PR1 (#27) and this PR address the two symptoms of unbounded session lifetime: PR1 frees memory by evicting idle in-memory sessions; this PR prevents context window overflow by compacting active sessions before they hit the limit.

## Test coverage

5 new tests in `src/agent/compaction.test.ts`:

1. `reserveTokensForModel` reserves exactly 20% of the window
2. Trigger fraction stays constant across vastly different window sizes (200K vs 1M)
3. Zero-window degenerate model produces a non-zero reserve (no division by zero, no negative reserve)
4. `createCompactionSettingsManager` produces a `SettingsManager` whose `getCompactionSettings()` reflects our values
5. Different models produce different `reserveTokens` but identical `keepRecentTokens`

Mutation check: replacing the formula with pi's fixed default (16384) breaks 3 of 5 tests.

`bun test src/agent/` — 254/254 pass (5 new + 249 baseline). `bun run typecheck`, `bun run lint`, `bun run format:check` — all clean.

## Note on pre-existing test failure

`src/run/index.test.ts` has a pre-existing failure reproducible on a clean `origin/main` checkout — unrelated to this PR.