### PR TITLE
Add auto port-forward via in-process portbroker relay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,13 +135,13 @@ Domain logic lives in `src/<domain>/`. Examples: `src/init/`, `src/config/`, `sr
 
 ## Host daemon (hostd)
 
-`src/hostd/` is a **host-stage** subsystem that owns every host-side capability the running container needs — currently the **port broker** (`src/hostd/portbroker/`) and the **supervisor** (`src/hostd/supervisor.ts`, restart). Architecturally: a **singleton daemon per host** (not per agent) — the only persistent host-side process in the codebase, and the only persistent host-stage state (`~/.typeclaw/`). New host-side capabilities should plug in as additional `src/hostd/<capability>/` modules and additional RPC kinds, not as new daemons.
+`src/hostd/` is a **host-stage** subsystem that owns every host-side capability the running container needs — currently the **supervisor** (`src/hostd/supervisor.ts`, restart) and the **port broker** (delegated to `src/portbroker/`, glued in via `src/hostd/portbroker-manager.ts`). Architecturally: a **singleton daemon per host** (not per agent) — the only persistent host-side process in the codebase, and the only persistent host-stage state (`~/.typeclaw/`). New host-side capabilities should plug in as additional `src/hostd/<capability>.ts` glue + an `src/<capability>/` module that does the actual work, and an additional optional callback on `DaemonOptions`. **Don't add new daemons.**
 
 ### Why it exists
 
-Two distinct cross-stage problems converge on the same shape (a long-lived host process the container talks to over a Unix socket), so they share one daemon:
+Two distinct cross-stage problems converge on the same shape (a long-lived host process the container talks to), so they share one daemon:
 
-1. **Port forwarding.** Docker fundamentally cannot publish new ports on a running container — `HostConfig.PortBindings` is create-time-only, and `docker update` does not cover networking. Without the broker, a process that binds `:5173` inside the container is invisible from the host unless `:5173` was passed to `docker run -p` up front. The broker polls the container's `/proc/net/tcp[6]` via `docker exec` and userland-proxies each LISTEN port through a host-side `Bun.listen` + `Bun.connect` pair to the container's bridge IP.
+1. **Port forwarding (auto port-forward).** Docker fundamentally cannot publish new ports on a running container — `HostConfig.PortBindings` is create-time-only, and `docker update` does not cover networking. Worse, many dev servers (Vite without `--host`, Next.js dev, Rails, Django runserver, Node's `http.createServer` without an explicit host) bind to `127.0.0.1` _inside the container's netns_, which `docker run -p` cannot reach even if the port had been published up front (the publish path connects to the bridge IP, not loopback). The portbroker solves both: it userland-proxies LISTEN events from the container, with the **upstream side of every proxy connection running inside the container's typeclaw process**, where `Bun.connect('127.0.0.1', port)` reaches loopback-bound servers naturally.
 
 2. **Container self-restart.** The container itself has no Docker access (no docker.sock mount, no `docker` CLI). When the agent updates the typeclaw CLI source or hits a `restart-required` config field, the only path back to a fresh container is through a host-stage process. The supervisor honors `restart` RPCs from inside the container (auth: scope by registered `containerName`) and runs `stop()` + `start()` from the daemon process.
 
@@ -155,27 +155,39 @@ host:
                                   ┘  ~/.typeclaw/run/hostd.sock.
 
   typeclaw _hostd (singleton)  ── reads/writes ~/.typeclaw/run/hostd.{pid,sock}
-    ├─ broker(agentA): detector + forwarders[5173, 8080, ...]   ┐
-    ├─ broker(agentB): detector + forwarders[3000, ...]          │ portbroker
-    └─ cwds: { agentA → /Users/.../agentA, agentB → ... }         │ + supervisor
-                                                                  ┘ (shared registry)
+    ├─ supervisor (in-process)
+    ├─ portbroker-manager (in-process)
+    │     ├─ Broker(agentA) ── ws ──► ws://127.0.0.1:${hostPortA}/portbroker
+    │     │     └─ Bun.listen(127.0.0.1, 5173) [forwarder per LISTEN port]
+    │     └─ Broker(agentB) ── ws ──► ws://127.0.0.1:${hostPortB}/portbroker
+    │           └─ Bun.listen(127.0.0.1, 3000) [...]
+    └─ cwds:  { agentA → cwd, agentB → cwd }   (shared registry)
 
-container (agentA):
-  agent's `restart` tool ── /run/typeclaw-host/hostd.sock ──► supervisor
-                            (bind-mounted from host's ~/.typeclaw/run)
+container (agentA):  typeclaw run
+  ├─ TUI WS server on / (existing — TUI talks here)
+  ├─ portbroker WS server on /portbroker (createContainerBroker)
+  │     ├─ PortWatcher: poll /proc/net/tcp[6] every 500ms
+  │     └─ RelayHandler: per relay-open, Bun.connect('127.0.0.1', port)
+  │       ── reaches both 0.0.0.0- AND 127.0.0.1-bound dev servers
+  └─ agent's `restart` tool ── /run/typeclaw-host/hostd.sock ──► supervisor
+                                (bind-mounted from host's ~/.typeclaw/run)
 ```
 
-The daemon binary is `typeclaw _hostd` — a hidden CLI subcommand that runs the daemon foreground. The first `typeclaw start` on the machine spawns it detached via `Bun.spawn` + `proc.unref()`, writes `~/.typeclaw/run/hostd.pid`, then connects and registers. Subsequent `typeclaw start` calls connect, **probe the daemon's source-tree fingerprint via the `version` RPC, and only reuse the daemon when its fingerprint matches the CLI's on-disk source**. On mismatch, the CLI sends `shutdown`, waits for the socket file to disappear, and respawns a fresh daemon (the AGENTS.md "PID-reuse safe" invariant is preserved because the kill path goes through the socket round-trip, never SIGTERM-by-pidfile). **This is the only place in the codebase that uses detached spawning** — keep it that way.
+The daemon binary is `typeclaw _hostd` — a hidden CLI subcommand that runs the daemon foreground. The first `typeclaw start` on the machine spawns it detached via `Bun.spawn` + `proc.unref()`, writes `~/.typeclaw/run/hostd.pid`, then connects and registers. Subsequent `typeclaw start` calls connect, **probe the daemon's source-tree fingerprint via the `version` RPC, and only reuse the daemon when its fingerprint matches the CLI's on-disk source**. On mismatch, the CLI sends `shutdown`, waits for the socket file to disappear, and respawns a fresh daemon (the "PID-reuse safe" invariant is preserved because the kill path goes through the socket round-trip, never SIGTERM-by-pidfile). **This is the only place in the codebase that uses detached spawning** — keep it that way.
 
-`typeclaw start` always registers with the daemon (passing `disableForwarding: !autoForward`), so the supervisor is available even when port forwarding is off. The two capabilities share the daemon's `cwds` map; the broker map is a subset (only entries with forwarding enabled).
+`typeclaw start` always registers with the daemon. The register payload now carries the `wsHostPort` (the freshly-allocated host port that maps to `CONTAINER_PORT`), the `portForward` policy from `typeclaw.json`, and a freshly-generated `brokerToken`. Hostd uses these to spawn a portbroker for the container in the same call. **Both supervisor and portbroker share the daemon's `cwds` map** — there is no second registry. When a container has `portForward.allow: []` (the off-switch), the broker is still constructed but immediately no-ops without opening any WS connection — see `brokerEnabled()` in `src/portbroker/policy.ts`.
 
-`typeclaw stop` connects to the daemon over the Unix socket and sends `deregister`. If the daemon isn't reachable, stop is a no-op for the broker side and just runs `docker stop`. **The CLI never sends signals based on PID** — pidfile content is a discovery hint, never a kill target. PID-reuse therefore cannot kill an unrelated user process.
+`typeclaw stop` connects to the daemon over the Unix socket and sends `deregister`. The daemon stops the container's broker (closing every host-side `Bun.listen`) and removes the cwds entry. If the daemon isn't reachable, stop is a no-op for the broker side and just runs `docker stop`. **The CLI never sends signals based on PID** — pidfile content is a discovery hint, never a kill target. PID-reuse therefore cannot kill an unrelated user process.
 
-A periodic GC tick in the daemon (every 30s) calls `containerExists()` for each registered container; missing → silently deregister and tear down its forwarders. Handles `docker stop` from outside typeclaw, host reboot survivors that registered with stale state, etc.
+A periodic GC tick in the daemon (every 30s) calls `containerExists()` for each registered container; missing → silently deregister and tear down its broker. Handles `docker stop` from outside typeclaw, host reboot survivors that registered with stale state, etc.
 
-### Container ↔ host channel
+### Container ↔ host channels
 
-The host's run dir is bind-mounted into every container at the fixed path `/run/typeclaw-host/` (read-write; the daemon enforces auth at the protocol layer, not via FS permissions). The container reaches the daemon via `containerSocketPath()` in `src/hostd/paths.ts`. The bind mount is the only thing that makes container-initiated operations (e.g. the `restart` agent tool) possible without giving the container access to the Docker socket. **Adding a new container→host capability means a new RPC kind, not a new socket** — the mount stays one place.
+Hostd talks to the container over **two distinct channels**, each owning a different direction and use case:
+
+1. **Bind-mounted Unix socket** (`/run/typeclaw-host/hostd.sock` inside the container, `~/.typeclaw/run/hostd.sock` on the host). Container-initiated, RPC-style. Today carries: `restart`. Auth: registered `containerName` + `restartToken` (the latter for HTTP transport on `host.docker.internal`). **Adding a new container→host RPC means a new RPC kind, not a new socket.**
+
+2. **WebSocket on `ws://127.0.0.1:${hostPort}/portbroker`** (the same TCP port the TUI uses, via Docker's `-p` mapping). Hostd-initiated, long-lived, multiplexed. Carries the portbroker protocol (`port-listen-snapshot`, `port-listen-opened`, `relay-open`, `relay-data`, etc.). Auth: a `brokerToken` plumbed through `TYPECLAW_HOSTD_BROKER_TOKEN` env var; the container rejects any non-`broker-hello` first message and any `broker-hello` whose token doesn't match. **Why this transport instead of the bridge IP?** Docker Desktop on macOS does not route the container bridge subnet from the host. The published-port path is the only one that works on both macOS and Linux without WireGuard tunnels or kernel routing tricks. **The supervisor still uses the Unix socket; only the portbroker uses the WS.**
 
 The agent's container name is plumbed through the `TYPECLAW_CONTAINER_NAME` env var, set by `src/container/start.ts` on `docker run`. Inside the container, cwd is `/agent` and the host folder name is otherwise unrecoverable.
 
@@ -185,46 +197,67 @@ Newline-delimited JSON over `~/.typeclaw/run/hostd.sock`. Connection-per-request
 
 ```ts
 type Request =
-  | { kind: 'register'; containerName: string; cwd: string; excludePorts?: number[]; disableForwarding?: boolean }
+  | {
+      kind: 'register'
+      containerName: string
+      cwd: string
+      restartToken?: string
+      // Portbroker fields — all three required to spawn the broker:
+      wsHostPort?: number // Docker-published host port mapping CONTAINER_PORT
+      portForward?: PortForward // { allow: '*' | number[]; deny?: number[] }
+      brokerToken?: string // shared with the container via env var
+    }
   | { kind: 'deregister'; containerName: string }
   | { kind: 'list' } // diagnostic
   | { kind: 'status'; containerName: string } // diagnostic
-  | { kind: 'restart'; containerName: string } // container-initiated
+  | { kind: 'restart'; containerName: string } // container-initiated (Unix socket OR HTTP)
+  | { kind: 'http-info' } // returns the daemon's HTTP control port
   | { kind: 'version' } // CLI-initiated drift probe
-  | { kind: 'shutdown' } // CLI-initiated graceful exit (used to respawn after drift)
+  | { kind: 'shutdown' } // CLI-initiated graceful exit (drift respawn)
 type Response = { ok: true; result?: unknown } | { ok: false; reason: string }
 ```
 
-`register` waits for the broker's initial IP-resolve to succeed before ACKing (unless `disableForwarding: true`, in which case it just stores the cwd). `deregister` is idempotent. `list` is the cheap probe used by `isDaemonReachable()`. `restart` ACKs immediately and runs `stop()` + `start()` asynchronously — the synchronous ACK lets the calling container exit cleanly before the daemon issues `docker stop`. `version` returns the source-tree fingerprint the daemon captured at boot — used only by `ensureDaemon()` to detect drift between the running daemon and the CLI's on-disk source. `shutdown` ACKs first, then asynchronously stops all brokers, unlinks the socket, and exits — the ACK-then-execute pattern (same as `restart`) lets the calling CLI know the request was accepted before the listener disappears.
+`register` is idempotent at the cwds level but **always (re)spawns the broker** — useful on the start-time TOCTOU port-retry path, where the host port may change between register attempts. `deregister` stops the broker AND removes the cwds entry. `list` is the cheap probe used by `isDaemonReachable()`. `restart` ACKs immediately and runs `stop()` + `start()` asynchronously — the synchronous ACK lets the calling container exit cleanly before the daemon issues `docker stop`. `version` returns the source-tree fingerprint the daemon captured at boot — used only by `ensureDaemon()` to detect drift between the running daemon and the CLI's on-disk source. `shutdown` ACKs first, then asynchronously stops all brokers, unlinks the socket, and exits — the ACK-then-execute pattern (same as `restart`) lets the calling CLI know the request was accepted before the listener disappears.
 
 Adding a new request kind is a deliberate addition: extend both `Request` (in `src/hostd/protocol.ts`) and the switch in `daemon.ts`'s `dispatch`. Don't sneak through the catchall.
 
 ### Components and ownership
 
-- `src/hostd/portbroker/forwarder.ts` — one TCP forward (`hostPort` → `upstreamHost:upstreamPort`). Pure: knows nothing about Docker. Backpressure-aware: each direction maintains a queue, partial writes are stored, `drain` callbacks resume; per-connection cap enforces a teardown when buffered bytes exceed `pendingByteLimit` (default 4 MB). The Bun TCP `data` callback reuses its buffer, so `enqueueOnly` MUST allocate a fresh `Uint8Array` and copy bytes — see the comment in `enqueueOnly`.
-- `src/hostd/portbroker/detector.ts` — polls `docker exec <name> sh -c "cat /proc/net/tcp /proc/net/tcp6"` every 750ms, parses LISTEN entries, emits `open`/`close` events on diff. Distinguishes `onError` (transient — single tick failed, but try again) from `onFatal` (escalation — N consecutive failures, detector stops). `parseListeningPorts()` is a pure function over the proc text with golden-file tests. `tick` wraps `exec` in `try/catch`; thrown rejections become `recordFailure` calls, never unhandled rejections.
-- `src/hostd/portbroker/broker.ts` — composition: container-IP resolver + detector + forwarder map. Serializes change handling through a single promise chain, so concurrent open/close/IP-reset events for the same broker can never observe partial state. On IP change, all existing forwarders are torn down and reinstalled against the new IP. `defaultResolveIp` parses `docker inspect --format '{{json .NetworkSettings.Networks}}'` and selects deterministically (named bridges before the default `bridge`, then alphabetical).
+#### `src/hostd/` — daemon, supervisor, glue
+
+- `src/hostd/daemon.ts` — singleton process. Owns `Map<containerName, cwd>` registry, the Unix socket server, RPC dispatch, and the GC tick. Replaces stale socket file on startup. SIGTERM/SIGINT triggers an orderly shutdown (stop all brokers via the manager, close socket, unlink socket file, exit 0). Both `restart` and `portbroker.start` are honored only when the corresponding `DaemonOptions` callback is set — unit tests omit them and get clean "capability not enabled" rejections (or no-ops on register).
 - `src/hostd/supervisor.ts` — restart capability. ACK-then-execute: `scheduleRestart` returns synchronously so the requesting container can exit before `docker stop` runs against it. Errors surface only via the log channel because there is no connected client to receive them by then. The actual `stop()` + `start()` invocation is plumbed in by `src/cli/hostd.ts` via the `DaemonOptions.restart` callback so the daemon module itself stays free of `@/container` imports.
-- `src/hostd/daemon.ts` — singleton process. Owns `Map<containerName, Broker>` plus `Map<containerName, cwd>` registries, the Unix socket server, RPC dispatch, and the GC tick. Replaces stale socket file on startup. SIGTERM/SIGINT triggers an orderly shutdown (stop all brokers, close socket, unlink socket file, exit 0). `restart` RPCs are honored only when `DaemonOptions.restart` is set — unit tests of the broker omit it and get a clean "restart capability not enabled" rejection.
+- `src/hostd/portbroker-manager.ts` — glue between `daemon.ts` and `src/portbroker/`. Owns one `Broker` per registered container. On `start(input)` it creates a fresh `Broker` (stopping any pre-existing one — handles re-register on the start-time TOCTOU retry). The broker's `resolveHostPort` callback uses `resolveHostPort({ cwd })` from `@/container` so reconnect after container restart re-queries Docker for the (possibly new) published port. Same isolation pattern as supervisor: the daemon module never imports `@/container`.
 - `src/hostd/client.ts` — `isDaemonReachable()` and `send(req)`. Each call opens a fresh connection. 3-second default timeout on ACKs. Used by both the host CLI (talking to the local socket) and the in-container agent tool (talking to the bind-mounted socket via an explicit `socket:` override).
 - `src/hostd/spawn.ts` — `ensureDaemon()` only. Handles the spawn race via `lockfilePath()` — concurrent `typeclaw start`s converge: at most one wins the lock and spawns the daemon, others poll `isDaemonReachable` for up to 5s. Also performs version-drift detection: when the socket is reachable, sends `{ kind: 'version' }` and compares the daemon's reply to the locally-computed source fingerprint; on mismatch, sends `{ kind: 'shutdown' }`, polls until the socket file disappears, then falls into the normal spawn path.
 - `src/hostd/version.ts` — `computeSourceVersion({ srcRoot })` produces a deterministic 32-char fingerprint by hashing every `*.ts` file under `src/` (excluding tests). Both peers compute it independently — the daemon at `_hostd` boot, the CLI at every `ensureDaemon()` call. `resolveSrcRoot(brokerEntry)` walks up from `process.argv[1]` to find the project's `src/`; returns `null` for installations that don't have a `src/` ancestor (e.g. a future bundled build), in which case both peers use `UNVERSIONED_SENTINEL` and drift detection is no-op (intentional fallback rather than crash).
 - `src/hostd/paths.ts` — single source of truth for `~/.typeclaw/` paths plus the in-container mount target (`containerSocketPath()`, `containerHostRunDir()`). Honors `TYPECLAW_HOME` for test isolation.
 - `src/hostd/protocol.ts` — request/response types shared by client and daemon.
-- `src/cli/hostd.ts` — internal foreground entry (`typeclaw _hostd`). Hidden via citty `meta.hidden`. Wires the daemon's `restart` callback to `@/container#start` and `@/container#stop`. Also computes the source fingerprint at boot via `computeSourceVersion()` and passes it to `startDaemon` as `version`, plus an `onShutdown: () => process.exit(0)` so the daemon exits cleanly after a `shutdown` RPC drains.
+- `src/cli/hostd.ts` — internal foreground entry (`typeclaw _hostd`). Hidden via citty `meta.hidden`. Wires the daemon's `restart` callback to `@/container#start` and `@/container#stop`, and instantiates the `portbroker-manager` to wire to `DaemonOptions.portbroker`. Also computes the source fingerprint at boot via `computeSourceVersion()` and passes it to `startDaemon` as `version`, plus an `onShutdown: () => process.exit(0)` so the daemon exits cleanly after a `shutdown` RPC drains.
 - `src/agent/tools/restart.ts` — container-stage agent tool. Sends `{ kind: 'restart', containerName }` over the bind-mounted socket, awaits the ACK, then `process.exit(0)` after a short tick so the tool result reaches the model before the process dies.
+
+#### `src/portbroker/` — both halves of the proxy
+
+- `src/portbroker/policy.ts` — pure: `shouldForward({ policy, port })` and `brokerEnabled(policy)`. Always implicitly excludes `CONTAINER_PORT` (8973) — that mapping is owned by `docker run -p` and forwarding it again would fight the published port.
+- `src/portbroker/proc-net-tcp.ts` — pure parser for `/proc/net/tcp[6]`. Extracts `(port, bindAddr)` for LISTEN-state rows. Dedupes across IPv4/IPv6 by preferring `127.0.0.1` (loopback is always reachable from inside the netns; the relay routes through it either way). Loose-by-design: never throws on garbage input.
+- `src/portbroker/protocol.ts` — message kinds for the `/portbroker` WS channel, plus base64 helpers for binary chunks.
+- `src/portbroker/container-server.ts` — container-side. `createContainerBroker({ expectedToken, ... })` returns `open`/`message`/`close` handlers that the agent's WS server (in `src/server/index.ts`) plugs into the `/portbroker` upgrade path. Verifies `broker-hello` token, runs the `PortWatcher` (500ms procfs polling — cheap inside the netns, no `docker exec` overhead), and per `relay-open` opens an upstream `Bun.connect('127.0.0.1', port)` then pumps bytes.
+- `src/portbroker/hostd-client.ts` — host-side. `createBroker({ resolveHostPort, brokerToken, policy, ... })` connects to `ws://127.0.0.1:${hostPort}/portbroker`, sends `broker-hello`, subscribes to port events, and per allowed LISTEN port installs a `Bun.listen(127.0.0.1, port)`. Per accepted host connection, allocates a `streamId` and pumps bytes through the multiplex. **Bun's TCP `data` callback reuses its buffer**, so every chunk MUST be copied into a fresh `Uint8Array` before being queued or forwarded — see `handleHostConnection`.
+- Reconnect: on WS disconnect, all forwarders tear down (host sockets close, in-flight streams drop), then a backoff loop (1s, 2s, 4s, 10s) calls `resolveHostPort()` again before each reconnect attempt. The host port may change across container restarts — re-resolving handles that without coupling broker to supervisor.
 
 ### Rules of thumb
 
-- **`autoForward` defaults to `true` at the user-facing schema layer (`configSchema`), but the `start()` function default is `false`.** This is intentional. Tests and programmatic callers of `start()` get a deterministic, side-effect-free default; the `true` default lives in the user contract (`typeclaw.json`) and the CLI plumbs it through explicitly. Adding a daemon spawn as an implicit default of a function call breaks unit-test isolation.
-- **`brokerEntry` has no production default in `start()`.** It must be passed explicitly (the CLI passes `process.argv[1]`). Tests omit it to disable daemon spawn entirely. This is the seam that keeps `bun test` from accidentally launching a real `_hostd` process.
-- **The supervisor is on whenever the daemon is on.** `typeclaw start` registers with the daemon regardless of `autoForward`, passing `disableForwarding: true` when forwarding is off. This means `restart` is always available to the agent without a separate opt-in — the cwd-only registration is cheap (no broker, no detector) and exists purely so the supervisor knows where to point `start()`.
-- **Both `autoForward` and `autoForwardExclude` are `restart-required` in `FIELD_EFFECTS`.** Per-broker config is captured at register time; reload doesn't re-evaluate.
-- **Host port equals container port.** Always, no exceptions. There is no random-port fallback because predictable URLs are the whole point. Port collisions are logged (`skip-eaddrinuse`) and the affected port is just not forwarded.
+- **`portForward` defaults to `{ allow: '*' }` at the user-facing schema layer (`configSchema`).** The `start()` function default is "no broker" (when called without `cliEntry`, e.g. unit tests). Tests get a deterministic, side-effect-free default; the `'*'` default lives in the user contract and the CLI plumbs it through explicitly. Adding a daemon spawn as an implicit default of a function call breaks unit-test isolation.
+- **`cliEntry` has no production default in `start()`.** It must be passed explicitly (the CLI passes `process.argv[1]`). Tests omit it to disable daemon spawn entirely. This is the seam that keeps `bun test` from accidentally launching a real `_hostd` process.
+- **The supervisor is on whenever the daemon is on; the broker is on whenever `portForward.allow !== []`.** `typeclaw start` always registers with the daemon, passing the portForward policy. The daemon constructs a Broker either way; if `allow: []`, the broker no-ops without opening a WS. This means `restart` is always available to the agent without separate opt-in, AND the broker doesn't add WS overhead when explicitly disabled.
+- **`portForward` is `restart-required` in `FIELD_EFFECTS`.** The broker's allow/deny is captured at register time; reload doesn't re-evaluate. Same fence as `mounts` and `port`.
+- **Host port equals container port for forwarded ports.** Always, no exceptions. There is no random-port fallback for forwarded ports because predictable URLs are the whole point. Port collisions log `port-forward-failed` to `~/.typeclaw/log/hostd.log` and emit a TUI broadcast (via the container's stream); the affected port is just not forwarded. **(The CONTAINER_PORT itself does fall back to a random ephemeral port via Docker on bind conflict — that's separate, see `src/container/start.ts`.)**
+- **Container LISTEN→host forward goes through `127.0.0.1`, not the bridge IP.** Two reasons: (1) Docker Desktop on macOS doesn't route the bridge subnet from the host, and (2) many dev servers bind `127.0.0.1` inside the container which the bridge IP couldn't reach anyway. The relay being inside the container's typeclaw process (calling `Bun.connect('127.0.0.1', port)` from the netns) sidesteps both issues.
+- **Wire-protocol changes to `/portbroker` require a container restart.** The container's WS server loads its source once at process start (Bun has no hot-reload). Editing `src/portbroker/container-server.ts` and reconnecting hostd is not enough; the container must restart so the in-container relay picks up the new code. Same rule as the TUI protocol.
 - **The CLI never SIGTERMs by PID.** `typeclaw stop` deregisters via the socket. The pidfile is a hint to find the daemon, never a kill target. This is what makes PID-reuse safe. The version-drift respawn flow in `ensureDaemon` follows the same rule: it sends `{ kind: 'shutdown' }` over the socket and waits for the socket file to disappear, never falls back to a pidfile-based kill. If the daemon doesn't honor the shutdown within 5s, `ensureDaemon` returns a hard failure rather than escalating to a signal — preserving the invariant at the cost of surfacing the stuck-daemon edge case to the user.
-- **Daemon-source drift is detected, not assumed-OK.** `_hostd` reads `src/**/*.ts` once at process start; subsequent edits to disk are invisible to the running daemon (Bun has no hot-reload). Without drift detection, every bug fix to the daemon's broker/parser logic was silently a no-op until the user manually killed `_hostd` — a structural footgun. `ensureDaemon` now exchanges a source-tree fingerprint (sha256 over `src/**/*.ts`, sorted, test files excluded) on every CLI invocation, and respawns transparently when it differs from what the running daemon advertises. Adding new daemon source files is automatically covered; adding new daemon-loaded files outside `src/` (rare, but e.g. a future plugin loader) requires extending the fingerprint scope in `src/hostd/version.ts`.
-- **The container does not have Docker access; the bind-mounted socket is the entire trust boundary.** `restart` RPCs are scoped to the registered `containerName` so a compromised container can only restart itself, not its peers. Anything that wants to extend this trust model (e.g. allow a container to query peer status) must go through new RPC kinds with explicit auth, not a wider mount.
-- **`Dockerfile` does not need changes for the daemon itself.** The container reaches the daemon over the bind-mounted socket; container images stay untouched. This keeps the daemon decoupled from image rebuilds.
+- **Daemon-source drift is detected, not assumed-OK.** `_hostd` reads `src/**/*.ts` once at process start; subsequent edits to disk are invisible to the running daemon. Without drift detection, every bug fix to the daemon's broker/parser logic was silently a no-op until the user manually killed `_hostd` — a structural footgun. `ensureDaemon` exchanges a source-tree fingerprint (sha256 over `src/**/*.ts`, sorted, test files excluded) on every CLI invocation, and respawns transparently when it differs. Adding new daemon source files is automatically covered; adding new daemon-loaded files outside `src/` (rare, but e.g. a future plugin loader) requires extending the fingerprint scope in `src/hostd/version.ts`. **The portbroker source is included in this fingerprint** because hostd loads it.
+- **Trust boundaries scale per-channel.** The bind-mounted Unix socket scopes `restart` to the registered `containerName`. The `/portbroker` WS scopes its multiplexed relay to the `brokerToken` shared at register time — a compromised container cannot make hostd open a port mapping it didn't register for, and a stale token from a prior container life cannot impersonate a new one because each register generates a fresh token. Anything that wants to extend trust (e.g. allow a container to query peer status) must go through new RPC kinds with explicit auth, not a wider mount or token reuse.
+- **`Dockerfile` does not need changes for either capability.** The bind-mounted socket is mounted via `docker run`, and the `/portbroker` WS reuses the existing `-p` mapping for `CONTAINER_PORT`. Container images stay untouched.
 - **The daemon stays alive when its registry becomes empty.** Idle cost is ~10 MB RAM and zero CPU. The next `typeclaw start` reuses it. Killing the idle daemon is `pkill -f 'typeclaw _hostd'` (out of scope for the CLI).
 
 ## Message Stream

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -3,6 +3,7 @@ import { defineCommand } from 'citty'
 import { loadConfigSync, validateConfig } from '@/config'
 import { start, stop } from '@/container'
 import { startDaemon, type DaemonLogEvent } from '@/hostd/daemon'
+import { createPortbrokerManager } from '@/hostd/portbroker-manager'
 import type { SupervisorLogEvent } from '@/hostd/supervisor'
 import { computeSourceVersion, resolveSrcRoot, UNVERSIONED_SENTINEL } from '@/hostd/version'
 
@@ -17,10 +18,15 @@ export const hostdCommand = defineCommand({
     const srcRoot = resolveSrcRoot(cliEntry)
     const version = srcRoot === null ? UNVERSIONED_SENTINEL : await computeSourceVersion({ srcRoot })
 
+    const portbroker = createPortbrokerManager({
+      onLog: (msg) => console.log(msg),
+    })
+
     const daemon = await startDaemon({
       onLog: (e) => console.log(formatLog(e)),
       version,
       onShutdown: () => process.exit(0),
+      portbroker,
       restart: async ({ containerName, cwd }) => {
         const validated = validateConfig(cwd)
         if (!validated.ok) {
@@ -41,7 +47,10 @@ export const hostdCommand = defineCommand({
     })
 
     const shutdown = (): void => {
-      void daemon.stop().then(() => process.exit(0))
+      void daemon
+        .stop()
+        .then(() => portbroker.drain())
+        .then(() => process.exit(0))
     }
     process.on('SIGTERM', shutdown)
     process.on('SIGINT', shutdown)
@@ -70,5 +79,18 @@ function formatLog(event: DaemonLogEvent | SupervisorLogEvent): string {
       return `[hostd] restart completed for ${event.containerName}`
     case 'restart-failed':
       return `[hostd] restart failed for ${event.containerName}: ${event.reason}`
+    case 'port-forward-event':
+      return formatPortForwardEvent(event.event)
+  }
+}
+
+function formatPortForwardEvent(event: import('@/portbroker').PortForwardEvent): string {
+  switch (event.kind) {
+    case 'port-forward-opened':
+      return `[hostd] port-forward opened ${event.containerName}:${event.port} (${event.bindAddr}) → localhost:${event.port}`
+    case 'port-forward-closed':
+      return `[hostd] port-forward closed ${event.containerName}:${event.port} (${event.reason})`
+    case 'port-forward-failed':
+      return `[hostd] port-forward FAILED ${event.containerName}:${event.port} — ${event.reason}`
   }
 }

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -60,6 +60,47 @@ describe('configSchema preserves unknown top-level keys (plugin config blocks)',
   })
 })
 
+describe('portForwardSchema', () => {
+  test('defaults to allow:* when omitted', () => {
+    const parsed = configSchema.parse({ model: VALID_MODEL })
+    expect(parsed.portForward).toEqual({ allow: '*' })
+  })
+
+  test('accepts allow:* with no deny', () => {
+    const parsed = configSchema.parse({ model: VALID_MODEL, portForward: { allow: '*' } })
+    expect(parsed.portForward).toEqual({ allow: '*' })
+  })
+
+  test('accepts allow:* with deny list', () => {
+    const parsed = configSchema.parse({ model: VALID_MODEL, portForward: { allow: '*', deny: [9229, 9999] } })
+    expect(parsed.portForward).toEqual({ allow: '*', deny: [9229, 9999] })
+  })
+
+  test('accepts allow as number array (allowlist mode)', () => {
+    const parsed = configSchema.parse({ model: VALID_MODEL, portForward: { allow: [3000, 5173] } })
+    expect(parsed.portForward).toEqual({ allow: [3000, 5173] })
+  })
+
+  test('accepts allow:[] as off-switch', () => {
+    const parsed = configSchema.parse({ model: VALID_MODEL, portForward: { allow: [] } })
+    expect(parsed.portForward).toEqual({ allow: [] })
+  })
+
+  test('rejects deny combined with allow:number[] so user typos do not silently drop the deny rule', () => {
+    expect(() => configSchema.parse({ model: VALID_MODEL, portForward: { allow: [3000], deny: [9000] } })).toThrow(
+      /portForward\.deny is only meaningful when allow is/,
+    )
+  })
+
+  test('rejects out-of-range port numbers in allow', () => {
+    expect(() => configSchema.parse({ model: VALID_MODEL, portForward: { allow: [99999] } })).toThrow()
+  })
+
+  test('rejects out-of-range port numbers in deny', () => {
+    expect(() => configSchema.parse({ model: VALID_MODEL, portForward: { allow: '*', deny: [0] } })).toThrow()
+  })
+})
+
 describe('mountSchema name validation', () => {
   test.each([
     ['lowercase', 'projects'],
@@ -244,6 +285,15 @@ describe('plugin config layout', () => {
       memory: { idleMs: 5000 },
       'standup-log': { schedule: '0 17 * * 5' },
     })
+  })
+
+  test('extractPluginConfigs treats portForward as a known top-level key (not a plugin block)', () => {
+    const result = extractPluginConfigs({
+      model: VALID_MODEL,
+      portForward: { allow: '*' },
+      'standup-log': { schedule: '0 17 * * 5' },
+    })
+    expect(result).toEqual({ 'standup-log': { schedule: '0 17 * * 5' } })
   })
 
   test('loadPluginConfigsSync reads per-plugin blocks from disk', async () => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -30,6 +30,25 @@ export const mountSchema = z.object({
 
 export type Mount = z.infer<typeof mountSchema>
 
+const portNumber = z.number().int().min(1).max(65535)
+
+// `allow` is the discriminator between "forward everything" ('*') and a fixed
+// allowlist (number[]). `deny` is only meaningful when allow === '*'; combining
+// it with a number[] allow is rejected at parse time so a typo doesn't silently
+// drop the deny rule. An empty allowlist (`allow: []`) is the off switch.
+export const portForwardSchema = z
+  .object({
+    allow: z.union([z.literal('*'), z.array(portNumber)]),
+    deny: z.array(portNumber).optional(),
+  })
+  .refine((v) => !(Array.isArray(v.allow) && v.deny !== undefined && v.deny.length > 0), {
+    message: 'portForward.deny is only meaningful when allow is "*"; remove deny or set allow to "*"',
+    path: ['deny'],
+  })
+  .default({ allow: '*' })
+
+export type PortForward = z.infer<typeof portForwardSchema>
+
 export const configSchema = z
   .object({
     $schema: z.string().optional(),
@@ -41,6 +60,7 @@ export const configSchema = z
     mounts: z.array(mountSchema).default([]),
     plugins: z.array(z.string().min(1)).default([]),
     channels: channelsSchema,
+    portForward: portForwardSchema,
   })
   .catchall(z.unknown())
 
@@ -116,6 +136,7 @@ export const FIELD_EFFECTS: Record<string, FieldEffect> = {
   mounts: 'restart-required',
   plugins: 'restart-required',
   channels: 'applied',
+  portForward: 'restart-required',
 }
 
 // Stable JSON for value comparison. Fields are small JSON-shaped objects, so
@@ -169,7 +190,7 @@ function readPath(obj: unknown, path: string): unknown {
 // each block against its plugin's `configSchema`.
 export function extractPluginConfigs(raw: unknown): Record<string, unknown> {
   if (typeof raw !== 'object' || raw === null) return {}
-  const known = new Set(['$schema', 'port', 'model', 'mounts', 'plugins', 'channels'])
+  const known = new Set(['$schema', 'port', 'model', 'mounts', 'plugins', 'channels', 'portForward'])
   const result: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
     if (!known.has(key)) result[key] = value

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,6 +6,7 @@ export {
   loadConfigSync,
   loadPluginConfigsSync,
   mountSchema,
+  portForwardSchema,
   reloadConfig,
   resolveModel,
   validateConfig,
@@ -13,6 +14,7 @@ export {
   type ConfigChange,
   type ConfigReloadDiff,
   type Mount,
+  type PortForward,
   type ValidateConfigResult,
 } from './config'
 export { type KnownModelRef, type KnownProviderId } from './providers'

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -84,7 +84,7 @@ describe('planStart', () => {
       cwd: root,
       hostPort: 8973,
       imageExists: true,
-      hostdControl: { url: 'http://host.docker.internal:49123', token: 'secret' },
+      hostdControl: { url: 'http://host.docker.internal:49123', token: 'secret', brokerToken: 'broker-secret' },
     })
 
     expect(plan.runArgs).toContain('-e')

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -43,6 +43,7 @@ export type PlanStartOptions = {
 export type HostDaemonControl = {
   url: string
   token: string
+  brokerToken: string
 }
 
 export type StartOptions = {
@@ -112,9 +113,6 @@ export async function start({
       }
     }
 
-    const hostd = cliEntry ? await registerWithDaemon({ cwd, containerName, cliEntry }) : { state: 'disabled' as const }
-    const hostdControl = hostd.state === 'registered' ? hostd.control : undefined
-
     const imageExisted = await imageExists(exec, imageTagValue)
 
     // First attempt uses the user's preferred host port (8973 by default, or
@@ -122,6 +120,14 @@ export async function start({
     // we fall through to a kernel-assigned ephemeral port. The container's
     // internal port stays fixed at CONTAINER_PORT regardless.
     let hostPort = await allocatePort(preferredHostPort)
+
+    // Register AFTER port allocation so the daemon's portbroker has the right
+    // wsHostPort. Re-register on TOCTOU retry below if the port changes.
+    let hostd: PreparedHostDaemonStatus = cliEntry
+      ? await registerWithDaemon({ cwd, containerName, cliEntry, hostPort })
+      : { state: 'disabled' as const }
+    let hostdControl = hostd.state === 'registered' ? hostd.control : undefined
+
     let plan = await planStart({ cwd, hostPort, imageExists: imageExisted, forceBuild, hostdControl })
 
     let built = false
@@ -140,8 +146,13 @@ export async function start({
     // `docker run`, or the kernel-assigned port may itself have been claimed.
     // Treat docker as the authority and retry once with a fresh ephemeral port.
     // Skip rebuild on retry: the image is already on disk from the first attempt.
+    // Re-register so the daemon's broker resolver returns the new port.
     if (run.exitCode !== 0 && isPortAllocatedError(run.stderr)) {
       hostPort = await allocatePort(0)
+      if (cliEntry) {
+        hostd = await registerWithDaemon({ cwd, containerName, cliEntry, hostPort })
+        hostdControl = hostd.state === 'registered' ? hostd.control : undefined
+      }
       plan = await planStart({ cwd, hostPort, imageExists: true, forceBuild: false, hostdControl })
       run = await exec(plan.runArgs, { cwd })
     }
@@ -202,6 +213,7 @@ export async function planStart({
   if (hostdControl) {
     runArgs.push('-e', `TYPECLAW_HOSTD_URL=${hostdControl.url}`)
     runArgs.push('-e', `TYPECLAW_HOSTD_TOKEN=${hostdControl.token}`)
+    runArgs.push('-e', `TYPECLAW_HOSTD_BROKER_TOKEN=${hostdControl.brokerToken}`)
   }
 
   runArgs.push('-v', `${cwd}:/agent`)
@@ -336,22 +348,41 @@ async function registerWithDaemon({
   cwd,
   containerName,
   cliEntry,
+  hostPort,
 }: {
   cwd: string
   containerName: string
   cliEntry: string
+  hostPort: number
 }): Promise<PreparedHostDaemonStatus> {
   const ensured = await ensureDaemon({ cliEntry })
   if (!ensured.ok) return { state: 'unavailable', reason: ensured.reason }
   const token = randomBytes(32).toString('base64url')
+  const brokerToken = randomBytes(32).toString('base64url')
+  const cfg = configSchema.parse(await loadConfigJson(cwd))
   const reply = await sendToDaemon({
     kind: 'register',
     containerName,
     cwd,
     restartToken: token,
+    wsHostPort: hostPort,
+    portForward: cfg.portForward,
+    brokerToken,
   })
   if (!reply.ok) return { state: 'unavailable', reason: reply.reason }
-  return { state: 'registered', control: { url: `http://${CONTAINER_HOSTD_HOST}:${ensured.httpPort}`, token } }
+  return {
+    state: 'registered',
+    control: { url: `http://${CONTAINER_HOSTD_HOST}:${ensured.httpPort}`, token, brokerToken },
+  }
+}
+
+async function loadConfigJson(cwd: string): Promise<unknown> {
+  try {
+    const raw = await readFile(join(cwd, CONFIG_FILE), 'utf8')
+    return JSON.parse(raw)
+  } catch {
+    return {}
+  }
 }
 
 type PreparedHostDaemonStatus =

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -3,7 +3,9 @@ import { chmod, unlink } from 'node:fs/promises'
 
 import type { Socket, UnixSocketListener } from 'bun'
 
+import type { PortForward } from '@/config'
 import { defaultDockerExec, type DockerExec } from '@/container'
+import type { PortForwardEvent } from '@/portbroker'
 
 import { isDaemonReachable } from './client'
 import { ensureDirs, socketPath } from './paths'
@@ -42,6 +44,24 @@ export type DaemonOptions = {
   onShutdown?: () => void
   httpHost?: string
   httpPort?: number
+  // Port-broker capability. When provided, register-RPC's portForward/wsHostPort
+  // fields trigger broker spawn alongside supervisor registration. Tests omit
+  // it to keep the broker out of unrelated suites.
+  portbroker?: PortbrokerCallbacks
+}
+
+export type PortbrokerCallbacks = {
+  start: (input: PortbrokerStartInput) => void
+  stop: (containerName: string, reason: 'deregistered' | 'broker-stopped') => Promise<void>
+}
+
+export type PortbrokerStartInput = {
+  containerName: string
+  cwd: string
+  policy: PortForward
+  wsHostPort: number
+  brokerToken: string
+  onEvent: (event: PortForwardEvent) => void
 }
 
 export type DaemonLogEvent =
@@ -51,6 +71,7 @@ export type DaemonLogEvent =
   | { kind: 'register'; containerName: string }
   | { kind: 'deregister'; containerName: string; reason: 'requested' | 'gone' }
   | { kind: 'shutdown-requested' }
+  | { kind: 'port-forward-event'; event: PortForwardEvent }
 
 export type Daemon = {
   registered: () => string[]
@@ -128,6 +149,9 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     containerName: string
     cwd: string
     restartToken?: string
+    wsHostPort?: number
+    portForward?: PortForward
+    brokerToken?: string
   }): Promise<RpcResponse> => {
     if (stopped) return { ok: false, reason: 'daemon stopping' }
     return runSerially(req.containerName, async () => {
@@ -139,6 +163,21 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       if (!alreadyRegistered) {
         log({ kind: 'register', containerName: req.containerName })
       }
+      if (
+        opts.portbroker &&
+        req.wsHostPort !== undefined &&
+        req.portForward !== undefined &&
+        req.brokerToken !== undefined
+      ) {
+        opts.portbroker.start({
+          containerName: req.containerName,
+          cwd: req.cwd,
+          policy: req.portForward,
+          wsHostPort: req.wsHostPort,
+          brokerToken: req.brokerToken,
+          onEvent: (event) => log({ kind: 'port-forward-event', event }),
+        })
+      }
       return { ok: true }
     })
   }
@@ -148,6 +187,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       const hadCwd = cwds.delete(req.containerName)
       restartTokens.delete(req.containerName)
       gcMisses.delete(req.containerName)
+      if (opts.portbroker) await opts.portbroker.stop(req.containerName, 'deregistered').catch(() => {})
       if (hadCwd) log({ kind: 'deregister', containerName: req.containerName, reason: 'requested' })
       return { ok: true }
     })
@@ -351,6 +391,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       gcMisses.delete(name)
       void runSerially(name, async () => {
         const hadCwd = cwds.delete(name)
+        if (opts.portbroker) await opts.portbroker.stop(name, 'deregistered').catch(() => {})
         if (hadCwd) log({ kind: 'deregister', containerName: name, reason: 'gone' })
         return { ok: true }
       })
@@ -373,6 +414,10 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
         listener.stop(true)
       } catch {}
       httpServer.stop(true)
+      if (opts.portbroker) {
+        const names = Array.from(cwds.keys())
+        await Promise.allSettled(names.map((n) => opts.portbroker!.stop(n, 'broker-stopped')))
+      }
       cwds.clear()
       restartTokens.clear()
       try {

--- a/src/hostd/portbroker-manager.ts
+++ b/src/hostd/portbroker-manager.ts
@@ -1,0 +1,66 @@
+import type { PortForward } from '@/config'
+import { resolveHostPort } from '@/container'
+import { type Broker, createBroker, type PortForwardEvent } from '@/portbroker'
+
+import type { PortbrokerCallbacks, PortbrokerStartInput } from './daemon'
+
+export type PortbrokerManagerOptions = {
+  resolveHostPortFor?: (input: { containerName: string; cwd: string }) => Promise<number | null>
+  onLog?: (msg: string) => void
+}
+
+// Glue between hostd's daemon and the portbroker package. Owns a Broker
+// instance per registered containerName. The daemon calls start()/stop()
+// through this manager. Reconnect after container restart works because the
+// resolver is re-invoked on each connect attempt — see portbroker hostd-client.
+export function createPortbrokerManager(opts: PortbrokerManagerOptions = {}): PortbrokerCallbacks & {
+  drain: () => Promise<void>
+} {
+  const brokers = new Map<string, Broker>()
+  const resolver = opts.resolveHostPortFor ?? defaultResolveHostPort
+  const log = opts.onLog ?? (() => {})
+
+  return {
+    start(input: PortbrokerStartInput) {
+      const existing = brokers.get(input.containerName)
+      if (existing) {
+        void existing.stop().catch(() => {})
+      }
+      const broker = createBroker({
+        containerName: input.containerName,
+        cwd: input.cwd,
+        policy: input.policy,
+        resolveHostPort: () => resolver({ containerName: input.containerName, cwd: input.cwd }),
+        brokerToken: input.brokerToken,
+        onEvent: input.onEvent,
+        onLog: (msg) => log(`[portbroker:${input.containerName}] ${msg}`),
+      })
+      brokers.set(input.containerName, broker)
+      broker.start()
+    },
+
+    async stop(containerName, reason) {
+      const broker = brokers.get(containerName)
+      if (!broker) return
+      brokers.delete(containerName)
+      await broker.stop()
+      log(`[portbroker:${containerName}] stopped (${reason})`)
+    },
+
+    async drain() {
+      const all = Array.from(brokers.values())
+      brokers.clear()
+      await Promise.allSettled(all.map((b) => b.stop()))
+    },
+  }
+}
+
+async function defaultResolveHostPort(input: { containerName: string; cwd: string }): Promise<number | null> {
+  try {
+    return await resolveHostPort({ cwd: input.cwd, retryMs: 500, intervalMs: 50 })
+  } catch {
+    return null
+  }
+}
+
+export type { PortForward, PortForwardEvent }

--- a/src/hostd/protocol.ts
+++ b/src/hostd/protocol.ts
@@ -1,9 +1,14 @@
+import type { PortForward } from '@/config'
+
 export type Request =
   | {
       kind: 'register'
       containerName: string
       cwd: string
       restartToken?: string
+      wsHostPort?: number
+      portForward?: PortForward
+      brokerToken?: string
     }
   | { kind: 'deregister'; containerName: string }
   | { kind: 'list' }

--- a/src/portbroker/broker.test.ts
+++ b/src/portbroker/broker.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import {
+  createContainerBroker,
+  type ContainerBroker,
+  type UpstreamConnection,
+  type UpstreamHandlers,
+} from './container-server'
+import { createBroker, type Broker } from './hostd-client'
+import type { PortForwardEvent } from './protocol'
+
+type Harness = {
+  containerServer: ReturnType<typeof Bun.serve>
+  broker: Broker
+  events: PortForwardEvent[]
+  upstreams: Map<number, FakeUpstream>
+  cleanup: () => Promise<void>
+}
+
+type FakeUpstream = {
+  conn: UpstreamConnection
+  handlers: UpstreamHandlers
+  written: Uint8Array[]
+}
+
+async function startHarness(opts: {
+  procSnapshots: string[]
+  policy: Parameters<typeof createBroker>[0]['policy']
+  failPorts?: Set<number>
+}): Promise<Harness> {
+  const upstreams = new Map<number, FakeUpstream>()
+  let snapshotCursor = 0
+  const readProc = async (): Promise<string> => {
+    const out = opts.procSnapshots[snapshotCursor] ?? opts.procSnapshots[opts.procSnapshots.length - 1] ?? ''
+    snapshotCursor = Math.min(snapshotCursor + 1, opts.procSnapshots.length - 1)
+    return out
+  }
+
+  const fakeUpstreamConnect = async (port: number, handlers: UpstreamHandlers): Promise<UpstreamConnection> => {
+    const written: Uint8Array[] = []
+    const conn: UpstreamConnection = {
+      write: (chunk) => {
+        written.push(chunk)
+      },
+      end: () => {
+        handlers.onClose()
+      },
+    }
+    upstreams.set(port, { conn, handlers, written })
+    return conn
+  }
+
+  const containerBroker: ContainerBroker = createContainerBroker({
+    expectedToken: 'shared-token',
+    pollIntervalMs: 10,
+    readProcNetTcp: readProc,
+    upstreamConnect: fakeUpstreamConnect,
+  })
+
+  type WsData = { kind: 'portbroker'; authed: boolean }
+
+  const containerServer = Bun.serve<WsData>({
+    port: 0,
+    fetch(req, server) {
+      const url = new URL(req.url)
+      if (url.pathname !== '/portbroker') return new Response('not found', { status: 404 })
+      if (server.upgrade(req, { data: { kind: 'portbroker', authed: false } })) return
+      return new Response('upgrade failed', { status: 400 })
+    },
+    websocket: {
+      open(ws) {
+        containerBroker.open(ws)
+      },
+      async message(ws, raw) {
+        await containerBroker.message(ws, raw as string | Buffer)
+      },
+      close(ws) {
+        containerBroker.close(ws)
+      },
+    },
+  })
+
+  const events: PortForwardEvent[] = []
+  const broker = createBroker({
+    containerName: 'test',
+    cwd: '/tmp/test',
+    policy: opts.policy,
+    resolveHostPort: async () => containerServer.port ?? null,
+    brokerToken: 'shared-token',
+    onEvent: (e) => events.push(e),
+    reconnectDelaysMs: [10, 10],
+  })
+
+  return {
+    containerServer,
+    broker,
+    events,
+    upstreams,
+    cleanup: async () => {
+      await broker.stop()
+      containerServer.stop(true)
+    },
+  }
+}
+
+const procWith5173Loopback = `   0: 0100007F:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+const procEmpty = ``
+
+describe('end-to-end portbroker pipeline', () => {
+  let harness: Harness | null = null
+
+  afterEach(async () => {
+    if (harness) {
+      await harness.cleanup()
+      harness = null
+    }
+  })
+
+  test('full handshake → snapshot → forwarder bound → host connection → bytes flow → close', async () => {
+    harness = await startHarness({ procSnapshots: [procWith5173Loopback], policy: { allow: '*' } })
+    harness.broker.start()
+    await new Promise((r) => setTimeout(r, 100))
+
+    const opened = harness.events.find((e) => e.kind === 'port-forward-opened' && e.port === 5173)
+    expect(opened).toBeDefined()
+
+    const sock = await Bun.connect({
+      hostname: '127.0.0.1',
+      port: 5173,
+      socket: {
+        open(s) {
+          s.write(new TextEncoder().encode('GET / HTTP/1.1\r\nHost: x\r\n\r\n'))
+        },
+        data() {},
+        close() {},
+        error() {},
+      },
+    })
+    await new Promise((r) => setTimeout(r, 100))
+    sock.end()
+
+    const upstream = harness.upstreams.get(5173)
+    expect(upstream).toBeDefined()
+    expect(upstream!.written.length).toBeGreaterThan(0)
+    expect(new TextDecoder().decode(upstream!.written[0])).toContain('GET / HTTP/1.1')
+  })
+
+  test('container releases port → forwarder torn down', async () => {
+    harness = await startHarness({
+      procSnapshots: [procWith5173Loopback, procEmpty],
+      policy: { allow: '*' },
+    })
+    harness.broker.start()
+    await new Promise((r) => setTimeout(r, 200))
+
+    const closedEvents = harness.events.filter((e) => e.kind === 'port-forward-closed' && e.port === 5173)
+    expect(closedEvents.length).toBeGreaterThanOrEqual(1)
+    expect(closedEvents[0]).toMatchObject({ reason: 'container-released' })
+    expect(harness.broker.forwardedPorts()).not.toContain(5173)
+  })
+
+  test('disabled by allow:[] — no events, no broker connect', async () => {
+    harness = await startHarness({ procSnapshots: [procWith5173Loopback], policy: { allow: [] } })
+    harness.broker.start()
+    await new Promise((r) => setTimeout(r, 100))
+    expect(harness.events).toEqual([])
+    expect(harness.broker.forwardedPorts()).toEqual([])
+  })
+
+  test('deny:[port] excludes from snapshot end-to-end', async () => {
+    const procWithBoth = `   0: 0100007F:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1
+   1: 0100007F:240D 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+    harness = await startHarness({
+      procSnapshots: [procWithBoth],
+      policy: { allow: '*', deny: [9229] },
+    })
+    harness.broker.start()
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(harness.broker.forwardedPorts()).toEqual([5173])
+  })
+
+  test('bytes flow downstream — container-side data reaches host client', async () => {
+    harness = await startHarness({ procSnapshots: [procWith5173Loopback], policy: { allow: '*' } })
+    harness.broker.start()
+    await new Promise((r) => setTimeout(r, 100))
+
+    const received: Uint8Array[] = []
+    let sockHandle: Awaited<ReturnType<typeof Bun.connect>> | null = null
+    sockHandle = await Bun.connect({
+      hostname: '127.0.0.1',
+      port: 5173,
+      socket: {
+        open(s) {
+          s.write(new TextEncoder().encode('hi'))
+        },
+        data(_s, data) {
+          received.push(new Uint8Array(data.buffer, data.byteOffset, data.byteLength).slice())
+        },
+        close() {},
+        error() {},
+      },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+
+    const upstream = harness.upstreams.get(5173)
+    expect(upstream).toBeDefined()
+    upstream!.handlers.onData(new TextEncoder().encode('HTTP/1.1 200 OK\r\n\r\n'))
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(received.length).toBeGreaterThan(0)
+    const text = received.map((b) => new TextDecoder().decode(b)).join('')
+    expect(text).toContain('HTTP/1.1 200 OK')
+
+    sockHandle.end()
+  })
+})

--- a/src/portbroker/container-server.test.ts
+++ b/src/portbroker/container-server.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import {
+  createContainerBroker,
+  type BrokerSocket,
+  type UpstreamConnection,
+  type UpstreamHandlers,
+} from './container-server'
+import { decodeBytes, encodeBytes, type ContainerToHostd, type HostdToContainer } from './protocol'
+
+type FakeSocket = BrokerSocket & {
+  outbox: ContainerToHostd[]
+  closeReason: string | null
+  closeCode: number | null
+}
+
+function makeFakeSocket(): FakeSocket {
+  const outbox: ContainerToHostd[] = []
+  let closeReason: string | null = null
+  let closeCode: number | null = null
+  return {
+    data: { kind: 'portbroker', authed: false } as { kind: 'portbroker'; authed: boolean },
+    outbox,
+    get closeReason() {
+      return closeReason
+    },
+    get closeCode() {
+      return closeCode
+    },
+    send(payload: string | Buffer | ArrayBuffer) {
+      const text = typeof payload === 'string' ? payload : Buffer.from(payload as ArrayBuffer).toString('utf8')
+      outbox.push(JSON.parse(text) as ContainerToHostd)
+      return text.length
+    },
+    close(code?: number, reason?: string) {
+      closeCode = code ?? null
+      closeReason = reason ?? null
+    },
+  } as unknown as FakeSocket
+}
+
+function dispatch(
+  broker: ReturnType<typeof createContainerBroker>,
+  ws: FakeSocket,
+  msg: HostdToContainer,
+): Promise<void> {
+  return broker.message(ws, JSON.stringify(msg))
+}
+
+describe('createContainerBroker auth', () => {
+  test('rejects non-hello first message', async () => {
+    const broker = createContainerBroker({ expectedToken: 'tok-1' })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'port-watch-subscribe' })
+    expect(ws.outbox[0]).toEqual({ type: 'broker-hello-nack', reason: 'expected broker-hello first' })
+    expect(ws.closeCode).toBe(1008)
+  })
+
+  test('rejects hello with wrong token', async () => {
+    const broker = createContainerBroker({ expectedToken: 'tok-1' })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 'wrong' })
+    expect(ws.outbox[0]).toEqual({ type: 'broker-hello-nack', reason: 'invalid token' })
+    expect(ws.closeCode).toBe(1008)
+  })
+
+  test('accepts hello with correct token', async () => {
+    const broker = createContainerBroker({ expectedToken: 'tok-1' })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 'tok-1' })
+    expect(ws.outbox[0]).toEqual({ type: 'broker-hello-ack' })
+    expect(ws.closeCode).toBe(null)
+  })
+})
+
+describe('createContainerBroker port watcher', () => {
+  let snapshots: string[]
+  let cursor: number
+
+  const reader = async (): Promise<string> => {
+    const out = snapshots[cursor] ?? snapshots[snapshots.length - 1] ?? ''
+    cursor = Math.min(cursor + 1, snapshots.length - 1)
+    return out
+  }
+
+  beforeEach(() => {
+    snapshots = []
+    cursor = 0
+  })
+
+  test('subscribe sends a snapshot of current LISTEN ports', async () => {
+    snapshots = [`   0: 00000000:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`]
+    const broker = createContainerBroker({ expectedToken: 't', readProcNetTcp: reader })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 't' })
+    await dispatch(broker, ws, { type: 'port-watch-subscribe' })
+    const snap = ws.outbox.find((m) => m.type === 'port-listen-snapshot') as Extract<
+      ContainerToHostd,
+      { type: 'port-listen-snapshot' }
+    >
+    expect(snap.ports).toEqual([{ port: 5173, bindAddr: '0.0.0.0' }])
+    broker.close(ws)
+  })
+
+  test('emits port-listen-opened/closed across polling ticks', async () => {
+    snapshots = [``, `   0: 00000000:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`, ``]
+    const broker = createContainerBroker({ expectedToken: 't', readProcNetTcp: reader, pollIntervalMs: 5 })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 't' })
+    await dispatch(broker, ws, { type: 'port-watch-subscribe' })
+    await new Promise((r) => setTimeout(r, 30))
+    broker.close(ws)
+    const events = ws.outbox.filter((m) => m.type === 'port-listen-opened' || m.type === 'port-listen-closed')
+    expect(events.length).toBeGreaterThanOrEqual(2)
+    expect(events[0]).toEqual({ type: 'port-listen-opened', port: 5173, bindAddr: '0.0.0.0' })
+    expect(events.at(-1)).toEqual({ type: 'port-listen-closed', port: 5173 })
+  })
+
+  test('unsubscribe stops the polling timer', async () => {
+    snapshots = [`   0: 00000000:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`]
+    const broker = createContainerBroker({ expectedToken: 't', readProcNetTcp: reader, pollIntervalMs: 5 })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 't' })
+    await dispatch(broker, ws, { type: 'port-watch-subscribe' })
+    await dispatch(broker, ws, { type: 'port-watch-unsubscribe' })
+    const before = ws.outbox.length
+    await new Promise((r) => setTimeout(r, 25))
+    expect(ws.outbox.length).toBe(before)
+    broker.close(ws)
+  })
+})
+
+describe('createContainerBroker relay', () => {
+  type FakeUpstream = {
+    conn: UpstreamConnection
+    handlers: UpstreamHandlers
+    written: Uint8Array[]
+    ended: boolean
+  }
+
+  let upstreams: Map<number, FakeUpstream>
+  let openErrors: Map<number, string>
+
+  const fakeConnect = async (port: number, handlers: UpstreamHandlers): Promise<UpstreamConnection> => {
+    const err = openErrors.get(port)
+    if (err) throw new Error(err)
+    const written: Uint8Array[] = []
+    let ended = false
+    const conn: UpstreamConnection = {
+      write: (chunk) => {
+        written.push(chunk)
+      },
+      end: () => {
+        ended = true
+      },
+    }
+    upstreams.set(port, {
+      conn,
+      handlers,
+      written,
+      get ended() {
+        return ended
+      },
+    } as FakeUpstream)
+    return conn
+  }
+
+  beforeEach(() => {
+    upstreams = new Map()
+    openErrors = new Map()
+  })
+
+  afterEach(() => {
+    upstreams.clear()
+    openErrors.clear()
+  })
+
+  test('relay-open succeeds and acks', async () => {
+    const broker = createContainerBroker({ expectedToken: 't', upstreamConnect: fakeConnect })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 't' })
+    await dispatch(broker, ws, { type: 'relay-open', streamId: 1, port: 5173 })
+    expect(ws.outbox.find((m) => m.type === 'relay-open-ack')).toEqual({ type: 'relay-open-ack', streamId: 1 })
+    expect(upstreams.has(5173)).toBe(true)
+  })
+
+  test('relay-open failure sends nack with reason', async () => {
+    openErrors.set(5173, 'ECONNREFUSED')
+    const broker = createContainerBroker({ expectedToken: 't', upstreamConnect: fakeConnect })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 't' })
+    await dispatch(broker, ws, { type: 'relay-open', streamId: 1, port: 5173 })
+    expect(ws.outbox.find((m) => m.type === 'relay-open-nack')).toEqual({
+      type: 'relay-open-nack',
+      streamId: 1,
+      reason: 'ECONNREFUSED',
+    })
+  })
+
+  test('relay-data flows host→upstream after open', async () => {
+    const broker = createContainerBroker({ expectedToken: 't', upstreamConnect: fakeConnect })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 't' })
+    await dispatch(broker, ws, { type: 'relay-open', streamId: 1, port: 5173 })
+    const payload = new TextEncoder().encode('GET / HTTP/1.1\r\n')
+    await dispatch(broker, ws, { type: 'relay-data', streamId: 1, bytes: encodeBytes(payload) })
+    const u = upstreams.get(5173)!
+    expect(u.written).toHaveLength(1)
+    expect(new TextDecoder().decode(u.written[0])).toBe('GET / HTTP/1.1\r\n')
+  })
+
+  test('upstream data emits relay-data downstream', async () => {
+    const broker = createContainerBroker({ expectedToken: 't', upstreamConnect: fakeConnect })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 't' })
+    await dispatch(broker, ws, { type: 'relay-open', streamId: 1, port: 5173 })
+    const u = upstreams.get(5173)!
+    u.handlers.onData(new TextEncoder().encode('HTTP/1.1 200 OK\r\n'))
+    const ev = ws.outbox.find((m) => m.type === 'relay-data') as Extract<ContainerToHostd, { type: 'relay-data' }>
+    expect(new TextDecoder().decode(decodeBytes(ev.bytes))).toBe('HTTP/1.1 200 OK\r\n')
+  })
+
+  test('relay-close from host ends the upstream connection', async () => {
+    const broker = createContainerBroker({ expectedToken: 't', upstreamConnect: fakeConnect })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 't' })
+    await dispatch(broker, ws, { type: 'relay-open', streamId: 1, port: 5173 })
+    await dispatch(broker, ws, { type: 'relay-close', streamId: 1, side: 'downstream' })
+    expect(upstreams.get(5173)!.ended).toBe(true)
+  })
+
+  test('upstream close emits relay-close upstream', async () => {
+    const broker = createContainerBroker({ expectedToken: 't', upstreamConnect: fakeConnect })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 't' })
+    await dispatch(broker, ws, { type: 'relay-open', streamId: 1, port: 5173 })
+    upstreams.get(5173)!.handlers.onClose()
+    expect(ws.outbox.find((m) => m.type === 'relay-close')).toEqual({
+      type: 'relay-close',
+      streamId: 1,
+      side: 'upstream',
+    })
+  })
+
+  test('close() ends all open upstreams', async () => {
+    const broker = createContainerBroker({ expectedToken: 't', upstreamConnect: fakeConnect })
+    const ws = makeFakeSocket()
+    broker.open(ws)
+    await dispatch(broker, ws, { type: 'broker-hello', token: 't' })
+    await dispatch(broker, ws, { type: 'relay-open', streamId: 1, port: 5173 })
+    await dispatch(broker, ws, { type: 'relay-open', streamId: 2, port: 8080 })
+    broker.close(ws)
+    expect(upstreams.get(5173)!.ended).toBe(true)
+    expect(upstreams.get(8080)!.ended).toBe(true)
+  })
+})

--- a/src/portbroker/container-server.ts
+++ b/src/portbroker/container-server.ts
@@ -1,0 +1,280 @@
+import { readFile } from 'node:fs/promises'
+
+import type { ServerWebSocket } from 'bun'
+
+import { parseProcNetTcp } from './proc-net-tcp'
+import { decodeBytes, encodeBytes, type ContainerToHostd, type HostdToContainer, type StreamId } from './protocol'
+
+export type BrokerWsData = { kind: 'portbroker'; authed: boolean }
+
+export type ContainerBrokerOptions = {
+  expectedToken: string
+  pollIntervalMs?: number
+  // Test seam: defaults to reading /proc/net/tcp + /proc/net/tcp6. Tests inject
+  // a fake. The function MUST resolve with the *concatenated* contents of both
+  // files (or just one if the system is IPv4-only) — the parser handles a
+  // mixed input gracefully.
+  readProcNetTcp?: () => Promise<string>
+  // Test seam: replaces Bun.connect for unit tests.
+  upstreamConnect?: (port: number, handlers: UpstreamHandlers) => Promise<UpstreamConnection>
+  onLog?: (event: ContainerBrokerLogEvent) => void
+}
+
+export type UpstreamHandlers = {
+  onData: (chunk: Uint8Array) => void
+  onClose: () => void
+  onError: (err: Error) => void
+}
+
+export type UpstreamConnection = {
+  write: (chunk: Uint8Array) => void
+  end: () => void
+}
+
+export type ContainerBrokerLogEvent =
+  | { kind: 'auth-failed'; reason: string }
+  | { kind: 'authed' }
+  | { kind: 'subscribed' }
+  | { kind: 'unsubscribed' }
+  | { kind: 'relay-open-failed'; streamId: StreamId; port: number; reason: string }
+  | { kind: 'relay-data-error'; streamId: StreamId; reason: string }
+  | { kind: 'unexpected'; reason: string }
+
+export type ContainerBroker = {
+  open: (ws: BrokerSocket) => void
+  message: (ws: BrokerSocket, raw: string | Buffer) => Promise<void>
+  close: (ws: BrokerSocket) => void
+}
+
+export type BrokerSocket = ServerWebSocket<BrokerWsData>
+
+const DEFAULT_POLL_MS = 500
+
+export function createContainerBroker(opts: ContainerBrokerOptions): ContainerBroker {
+  const log = opts.onLog ?? (() => {})
+  const pollMs = opts.pollIntervalMs ?? DEFAULT_POLL_MS
+  const readProc = opts.readProcNetTcp ?? defaultReadProcNetTcp
+  const connectUpstream = opts.upstreamConnect ?? defaultUpstreamConnect
+
+  type SessionState = {
+    pollTimer: ReturnType<typeof setInterval> | null
+    lastSnapshot: Map<number, '0.0.0.0' | '127.0.0.1'>
+    upstreams: Map<StreamId, UpstreamConnection>
+  }
+
+  const sessions = new WeakMap<BrokerSocket, SessionState>()
+
+  const send = (ws: BrokerSocket, msg: ContainerToHostd): void => {
+    try {
+      ws.send(JSON.stringify(msg))
+    } catch {}
+  }
+
+  const startWatcher = async (ws: BrokerSocket, state: SessionState): Promise<void> => {
+    const initial = await snapshotPorts()
+    state.lastSnapshot = initial
+    send(ws, {
+      type: 'port-listen-snapshot',
+      ports: Array.from(initial.entries()).map(([port, bindAddr]) => ({ port, bindAddr })),
+    })
+    state.pollTimer = setInterval(() => {
+      void tickWatcher(ws, state).catch(() => {})
+    }, pollMs)
+  }
+
+  const stopWatcher = (state: SessionState): void => {
+    if (state.pollTimer !== null) {
+      clearInterval(state.pollTimer)
+      state.pollTimer = null
+    }
+  }
+
+  const tickWatcher = async (ws: BrokerSocket, state: SessionState): Promise<void> => {
+    const next = await snapshotPorts()
+    for (const [port, bindAddr] of next) {
+      if (!state.lastSnapshot.has(port)) {
+        send(ws, { type: 'port-listen-opened', port, bindAddr })
+      }
+    }
+    for (const port of state.lastSnapshot.keys()) {
+      if (!next.has(port)) {
+        send(ws, { type: 'port-listen-closed', port })
+      }
+    }
+    state.lastSnapshot = next
+  }
+
+  const snapshotPorts = async (): Promise<Map<number, '0.0.0.0' | '127.0.0.1'>> => {
+    let raw: string
+    try {
+      raw = await readProc()
+    } catch {
+      return new Map()
+    }
+    const entries = parseProcNetTcp(raw)
+    const m = new Map<number, '0.0.0.0' | '127.0.0.1'>()
+    for (const e of entries) m.set(e.port, e.bindAddr)
+    return m
+  }
+
+  const handleRelayOpen = async (ws: BrokerSocket, state: SessionState, msg: HostdToContainer): Promise<void> => {
+    if (msg.type !== 'relay-open') return
+    const { streamId, port } = msg
+    try {
+      const conn = await connectUpstream(port, {
+        onData: (chunk) => {
+          send(ws, { type: 'relay-data', streamId, bytes: encodeBytes(chunk) })
+        },
+        onClose: () => {
+          if (state.upstreams.delete(streamId)) {
+            send(ws, { type: 'relay-close', streamId, side: 'upstream' })
+          }
+        },
+        onError: (err) => {
+          if (state.upstreams.delete(streamId)) {
+            log({ kind: 'relay-data-error', streamId, reason: err.message })
+            send(ws, { type: 'relay-close', streamId, side: 'upstream' })
+          }
+        },
+      })
+      state.upstreams.set(streamId, conn)
+      send(ws, { type: 'relay-open-ack', streamId })
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err)
+      log({ kind: 'relay-open-failed', streamId, port, reason })
+      send(ws, { type: 'relay-open-nack', streamId, reason })
+    }
+  }
+
+  return {
+    open(ws) {
+      sessions.set(ws, { pollTimer: null, lastSnapshot: new Map(), upstreams: new Map() })
+    },
+
+    async message(ws, raw) {
+      const state = sessions.get(ws)
+      if (!state) return
+      let msg: HostdToContainer
+      try {
+        msg = JSON.parse(typeof raw === 'string' ? raw : raw.toString('utf8')) as HostdToContainer
+      } catch {
+        log({ kind: 'unexpected', reason: 'invalid json' })
+        return
+      }
+
+      if (!ws.data.authed) {
+        if (msg.type !== 'broker-hello') {
+          log({ kind: 'auth-failed', reason: 'first message was not broker-hello' })
+          send(ws, { type: 'broker-hello-nack', reason: 'expected broker-hello first' })
+          ws.close(1008, 'auth required')
+          return
+        }
+        if (msg.token !== opts.expectedToken) {
+          log({ kind: 'auth-failed', reason: 'token mismatch' })
+          send(ws, { type: 'broker-hello-nack', reason: 'invalid token' })
+          ws.close(1008, 'invalid token')
+          return
+        }
+        ws.data.authed = true
+        log({ kind: 'authed' })
+        send(ws, { type: 'broker-hello-ack' })
+        return
+      }
+
+      switch (msg.type) {
+        case 'broker-hello':
+          return
+        case 'port-watch-subscribe':
+          if (state.pollTimer === null) {
+            log({ kind: 'subscribed' })
+            await startWatcher(ws, state)
+          }
+          return
+        case 'port-watch-unsubscribe':
+          if (state.pollTimer !== null) {
+            log({ kind: 'unsubscribed' })
+            stopWatcher(state)
+          }
+          return
+        case 'relay-open':
+          await handleRelayOpen(ws, state, msg)
+          return
+        case 'relay-data': {
+          const conn = state.upstreams.get(msg.streamId)
+          if (conn) conn.write(decodeBytes(msg.bytes))
+          return
+        }
+        case 'relay-close': {
+          const conn = state.upstreams.get(msg.streamId)
+          if (conn) {
+            state.upstreams.delete(msg.streamId)
+            try {
+              conn.end()
+            } catch {}
+          }
+          return
+        }
+      }
+    },
+
+    close(ws) {
+      const state = sessions.get(ws)
+      if (!state) return
+      stopWatcher(state)
+      for (const conn of state.upstreams.values()) {
+        try {
+          conn.end()
+        } catch {}
+      }
+      state.upstreams.clear()
+      sessions.delete(ws)
+    },
+  }
+}
+
+async function defaultReadProcNetTcp(): Promise<string> {
+  const tcp4 = await readFile('/proc/net/tcp', 'utf8').catch(() => '')
+  const tcp6 = await readFile('/proc/net/tcp6', 'utf8').catch(() => '')
+  return `${tcp4}\n${tcp6}`
+}
+
+function defaultUpstreamConnect(port: number, handlers: UpstreamHandlers): Promise<UpstreamConnection> {
+  return new Promise((resolve, reject) => {
+    let resolved = false
+    const sock = Bun.connect({
+      hostname: '127.0.0.1',
+      port,
+      socket: {
+        open(s) {
+          resolved = true
+          resolve({
+            write: (chunk: Uint8Array) => {
+              try {
+                s.write(chunk)
+              } catch {}
+            },
+            end: () => {
+              try {
+                s.end()
+              } catch {}
+            },
+          })
+        },
+        data(_s, data) {
+          handlers.onData(new Uint8Array(data.buffer, data.byteOffset, data.byteLength).slice())
+        },
+        close() {
+          handlers.onClose()
+        },
+        error(_s, error) {
+          if (!resolved) {
+            reject(error instanceof Error ? error : new Error(String(error)))
+          } else {
+            handlers.onError(error instanceof Error ? error : new Error(String(error)))
+          }
+        },
+      },
+    })
+    void sock
+  })
+}

--- a/src/portbroker/hostd-client.test.ts
+++ b/src/portbroker/hostd-client.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { PortForward } from '@/config'
+
+import { createBroker, type HostListener, type HostSocket, type ListenHostFn, type WsClient } from './hostd-client'
+import {
+  decodeBytes,
+  encodeBytes,
+  type ContainerToHostd,
+  type HostdToContainer,
+  type PortForwardEvent,
+} from './protocol'
+
+type FakeWs = WsClient & {
+  outbox: HostdToContainer[]
+  emit: (msg: ContainerToHostd) => void
+  triggerClose: () => void
+  closed: boolean
+}
+
+function makeFakeWs(): FakeWs {
+  const outbox: HostdToContainer[] = []
+  let messageCb: ((m: ContainerToHostd) => void) | null = null
+  let closeCb: (() => void) | null = null
+  let closed = false
+  const ws: FakeWs = {
+    send: (msg) => {
+      outbox.push(msg)
+    },
+    close: () => {
+      closed = true
+      if (closeCb) closeCb()
+    },
+    onMessage: (cb) => {
+      messageCb = cb
+    },
+    onClose: (cb) => {
+      closeCb = cb
+    },
+    outbox,
+    emit: (msg) => {
+      if (messageCb) messageCb(msg)
+    },
+    triggerClose: () => {
+      if (closeCb) closeCb()
+    },
+    get closed() {
+      return closed
+    },
+  } as FakeWs
+  return ws
+}
+
+type FakeListener = HostListener & {
+  sockets: FakeHostSocket[]
+  stopped: boolean
+  bound: { host: string; port: number }
+}
+type FakeHostSocket = HostSocket & {
+  written: Uint8Array[]
+  ended: boolean
+  triggerData: (chunk: Uint8Array) => void
+  triggerClose: () => void
+}
+
+function makeFakeHostSocket(): FakeHostSocket {
+  const written: Uint8Array[] = []
+  let ended = false
+  let dataCb: ((c: Uint8Array) => void) | null = null
+  let closeCb: (() => void) | null = null
+  const sock: FakeHostSocket = {
+    write: (chunk) => {
+      written.push(chunk)
+    },
+    end: () => {
+      ended = true
+    },
+    onData: (cb) => {
+      dataCb = cb
+    },
+    onClose: (cb) => {
+      closeCb = cb
+    },
+    written,
+    get ended() {
+      return ended
+    },
+    triggerData: (chunk) => {
+      if (dataCb) dataCb(chunk)
+    },
+    triggerClose: () => {
+      if (closeCb) closeCb()
+    },
+  } as FakeHostSocket
+  return sock
+}
+
+function makeFakeListenHost(opts: { failPorts?: Set<number>; listeners: Map<number, FakeListener> }): ListenHostFn {
+  return async (host, port, handlers) => {
+    if (opts.failPorts?.has(port)) throw new Error('EADDRINUSE')
+    const sockets: FakeHostSocket[] = []
+    const listener: FakeListener = {
+      port,
+      stopped: false,
+      bound: { host, port },
+      sockets,
+      stop: () => {
+        listener.stopped = true
+      },
+    }
+    opts.listeners.set(port, listener)
+    ;(listener as unknown as { _accept: (s: FakeHostSocket) => void })._accept = (s) => {
+      sockets.push(s)
+      handlers.onConnection(s)
+    }
+    return listener
+  }
+}
+
+function setup(opts: { policy: PortForward; resolveHostPort?: () => Promise<number | null>; failPorts?: Set<number> }) {
+  const ws = makeFakeWs()
+  const listeners = new Map<number, FakeListener>()
+  const events: PortForwardEvent[] = []
+  const broker = createBroker({
+    containerName: 'test-agent',
+    cwd: '/tmp/test',
+    policy: opts.policy,
+    resolveHostPort: opts.resolveHostPort ?? (async () => 12345),
+    brokerToken: 'tok',
+    onEvent: (e) => events.push(e),
+    connectWs: async () => ws,
+    listenHost: makeFakeListenHost({ ...(opts.failPorts ? { failPorts: opts.failPorts } : {}), listeners }),
+    reconnectDelaysMs: [10, 10],
+  })
+  return { broker, ws, listeners, events }
+}
+
+describe('createBroker', () => {
+  test('start sends broker-hello with token', async () => {
+    const { broker, ws } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    expect(ws.outbox[0]).toEqual({ type: 'broker-hello', token: 'tok' })
+    await broker.stop()
+  })
+
+  test('on hello-ack, sends port-watch-subscribe', async () => {
+    const { broker, ws } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    expect(ws.outbox).toContainEqual({ type: 'port-watch-subscribe' })
+    await broker.stop()
+  })
+
+  test('snapshot installs forwarders for allowed ports and emits opened events', async () => {
+    const { broker, ws, listeners, events } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({
+      type: 'port-listen-snapshot',
+      ports: [
+        { port: 5173, bindAddr: '127.0.0.1' },
+        { port: 8080, bindAddr: '0.0.0.0' },
+      ],
+    })
+    await new Promise((r) => setTimeout(r, 5))
+    expect(listeners.has(5173)).toBe(true)
+    expect(listeners.has(8080)).toBe(true)
+    expect(
+      events
+        .filter((e) => e.kind === 'port-forward-opened')
+        .map((e) => e.port)
+        .sort(),
+    ).toEqual([5173, 8080])
+    await broker.stop()
+  })
+
+  test('deny list excludes ports from snapshot', async () => {
+    const { broker, ws, listeners } = setup({ policy: { allow: '*', deny: [9229] } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({
+      type: 'port-listen-snapshot',
+      ports: [
+        { port: 5173, bindAddr: '127.0.0.1' },
+        { port: 9229, bindAddr: '127.0.0.1' },
+      ],
+    })
+    await new Promise((r) => setTimeout(r, 5))
+    expect(listeners.has(5173)).toBe(true)
+    expect(listeners.has(9229)).toBe(false)
+    await broker.stop()
+  })
+
+  test('allowlist excludes everything not listed', async () => {
+    const { broker, ws, listeners } = setup({ policy: { allow: [5173] } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({
+      type: 'port-listen-snapshot',
+      ports: [
+        { port: 5173, bindAddr: '127.0.0.1' },
+        { port: 8080, bindAddr: '127.0.0.1' },
+      ],
+    })
+    await new Promise((r) => setTimeout(r, 5))
+    expect(listeners.has(5173)).toBe(true)
+    expect(listeners.has(8080)).toBe(false)
+    await broker.stop()
+  })
+
+  test('off-switch (allow:[]) skips broker entirely', async () => {
+    const { broker, ws } = setup({ policy: { allow: [] } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    expect(ws.outbox).toEqual([])
+    await broker.stop()
+  })
+
+  test('port-listen-opened mid-stream installs new forwarder', async () => {
+    const { broker, ws, listeners, events } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({ type: 'port-listen-snapshot', ports: [] })
+    ws.emit({ type: 'port-listen-opened', port: 5173, bindAddr: '127.0.0.1' })
+    await new Promise((r) => setTimeout(r, 5))
+    expect(listeners.has(5173)).toBe(true)
+    expect(events.find((e) => e.kind === 'port-forward-opened' && e.port === 5173)).toBeDefined()
+    await broker.stop()
+  })
+
+  test('port-listen-closed tears down forwarder and emits closed event', async () => {
+    const { broker, ws, listeners, events } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({ type: 'port-listen-snapshot', ports: [{ port: 5173, bindAddr: '127.0.0.1' }] })
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'port-listen-closed', port: 5173 })
+    expect(listeners.get(5173)?.stopped).toBe(true)
+    expect(events.find((e) => e.kind === 'port-forward-closed' && e.port === 5173)).toMatchObject({
+      reason: 'container-released',
+    })
+    await broker.stop()
+  })
+
+  test('EADDRINUSE on bind emits port-forward-failed and does not retry', async () => {
+    const { broker, ws, events } = setup({ policy: { allow: '*' }, failPorts: new Set([5173]) })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({ type: 'port-listen-snapshot', ports: [{ port: 5173, bindAddr: '127.0.0.1' }] })
+    await new Promise((r) => setTimeout(r, 5))
+    expect(events.find((e) => e.kind === 'port-forward-failed' && e.port === 5173)).toMatchObject({
+      reason: 'EADDRINUSE',
+    })
+    await broker.stop()
+  })
+
+  test('host connection allocates streamId and sends relay-open', async () => {
+    const { broker, ws, listeners } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({ type: 'port-listen-snapshot', ports: [{ port: 5173, bindAddr: '127.0.0.1' }] })
+    await new Promise((r) => setTimeout(r, 5))
+    const sock = makeFakeHostSocket()
+    ;(listeners.get(5173) as unknown as { _accept: (s: HostSocket) => void })._accept(sock)
+    const open = ws.outbox.find((m) => m.type === 'relay-open') as Extract<HostdToContainer, { type: 'relay-open' }>
+    expect(open).toBeDefined()
+    expect(open.port).toBe(5173)
+    await broker.stop()
+  })
+
+  test('relay-data flows host→container after open-ack', async () => {
+    const { broker, ws, listeners } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({ type: 'port-listen-snapshot', ports: [{ port: 5173, bindAddr: '127.0.0.1' }] })
+    await new Promise((r) => setTimeout(r, 5))
+    const sock = makeFakeHostSocket()
+    ;(listeners.get(5173) as unknown as { _accept: (s: HostSocket) => void })._accept(sock)
+    const open = ws.outbox.find((m) => m.type === 'relay-open') as Extract<HostdToContainer, { type: 'relay-open' }>
+    sock.triggerData(new TextEncoder().encode('hello'))
+    ws.emit({ type: 'relay-open-ack', streamId: open.streamId })
+    const data = ws.outbox.find((m) => m.type === 'relay-data') as Extract<HostdToContainer, { type: 'relay-data' }>
+    expect(data).toBeDefined()
+    expect(new TextDecoder().decode(decodeBytes(data.bytes))).toBe('hello')
+    await broker.stop()
+  })
+
+  test('container relay-data writes to host socket', async () => {
+    const { broker, ws, listeners } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({ type: 'port-listen-snapshot', ports: [{ port: 5173, bindAddr: '127.0.0.1' }] })
+    await new Promise((r) => setTimeout(r, 5))
+    const sock = makeFakeHostSocket()
+    ;(listeners.get(5173) as unknown as { _accept: (s: HostSocket) => void })._accept(sock)
+    const open = ws.outbox.find((m) => m.type === 'relay-open') as Extract<HostdToContainer, { type: 'relay-open' }>
+    ws.emit({ type: 'relay-open-ack', streamId: open.streamId })
+    ws.emit({ type: 'relay-data', streamId: open.streamId, bytes: encodeBytes(new TextEncoder().encode('world')) })
+    expect(sock.written).toHaveLength(1)
+    expect(new TextDecoder().decode(sock.written[0])).toBe('world')
+    await broker.stop()
+  })
+
+  test('relay-open-nack closes the host socket', async () => {
+    const { broker, ws, listeners } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({ type: 'port-listen-snapshot', ports: [{ port: 5173, bindAddr: '127.0.0.1' }] })
+    await new Promise((r) => setTimeout(r, 5))
+    const sock = makeFakeHostSocket()
+    ;(listeners.get(5173) as unknown as { _accept: (s: HostSocket) => void })._accept(sock)
+    const open = ws.outbox.find((m) => m.type === 'relay-open') as Extract<HostdToContainer, { type: 'relay-open' }>
+    ws.emit({ type: 'relay-open-nack', streamId: open.streamId, reason: 'ECONNREFUSED' })
+    expect(sock.ended).toBe(true)
+    await broker.stop()
+  })
+
+  test('host socket close sends relay-close', async () => {
+    const { broker, ws, listeners } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({ type: 'port-listen-snapshot', ports: [{ port: 5173, bindAddr: '127.0.0.1' }] })
+    await new Promise((r) => setTimeout(r, 5))
+    const sock = makeFakeHostSocket()
+    ;(listeners.get(5173) as unknown as { _accept: (s: HostSocket) => void })._accept(sock)
+    const open = ws.outbox.find((m) => m.type === 'relay-open') as Extract<HostdToContainer, { type: 'relay-open' }>
+    ws.emit({ type: 'relay-open-ack', streamId: open.streamId })
+    sock.triggerClose()
+    const close = ws.outbox.find((m) => m.type === 'relay-close') as Extract<HostdToContainer, { type: 'relay-close' }>
+    expect(close).toEqual({ type: 'relay-close', streamId: open.streamId, side: 'downstream' })
+    await broker.stop()
+  })
+
+  test('ws disconnect tears down all forwarders and emits closed events', async () => {
+    const { broker, ws, listeners, events } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({
+      type: 'port-listen-snapshot',
+      ports: [
+        { port: 5173, bindAddr: '127.0.0.1' },
+        { port: 8080, bindAddr: '0.0.0.0' },
+      ],
+    })
+    await new Promise((r) => setTimeout(r, 5))
+    ws.triggerClose()
+    expect(listeners.get(5173)?.stopped).toBe(true)
+    expect(listeners.get(8080)?.stopped).toBe(true)
+    expect(events.filter((e) => e.kind === 'port-forward-closed' && e.reason === 'host-error').length).toBe(2)
+    await broker.stop()
+  })
+
+  test('stop() ends all forwarders and emits broker-stopped events', async () => {
+    const { broker, ws, listeners, events } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({ type: 'port-listen-snapshot', ports: [{ port: 5173, bindAddr: '127.0.0.1' }] })
+    await new Promise((r) => setTimeout(r, 5))
+    await broker.stop()
+    expect(listeners.get(5173)?.stopped).toBe(true)
+    expect(events.find((e) => e.kind === 'port-forward-closed' && e.reason === 'broker-stopped')).toBeDefined()
+  })
+
+  test('forwardedPorts() reflects currently bound ports', async () => {
+    const { broker, ws } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 5))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({
+      type: 'port-listen-snapshot',
+      ports: [
+        { port: 5173, bindAddr: '127.0.0.1' },
+        { port: 8080, bindAddr: '0.0.0.0' },
+      ],
+    })
+    await new Promise((r) => setTimeout(r, 5))
+    expect(broker.forwardedPorts().sort()).toEqual([5173, 8080])
+    await broker.stop()
+  })
+
+  test('resolveHostPort returning null defers connect (waits for retry)', async () => {
+    let calls = 0
+    const { broker, ws } = setup({
+      policy: { allow: '*' },
+      resolveHostPort: async () => {
+        calls += 1
+        return calls < 3 ? null : 12345
+      },
+    })
+    broker.start()
+    await new Promise((r) => setTimeout(r, 50))
+    expect(calls).toBeGreaterThanOrEqual(3)
+    expect(ws.outbox.find((m) => m.type === 'broker-hello')).toBeDefined()
+    await broker.stop()
+  })
+})

--- a/src/portbroker/hostd-client.ts
+++ b/src/portbroker/hostd-client.ts
@@ -1,0 +1,434 @@
+import type { Socket, TCPSocketListener } from 'bun'
+
+import type { PortForward } from '@/config'
+
+import { brokerEnabled, shouldForward } from './policy'
+import type { BindAddr } from './proc-net-tcp'
+import {
+  decodeBytes,
+  encodeBytes,
+  type ContainerToHostd,
+  type HostdToContainer,
+  type PortForwardEvent,
+  type StreamId,
+} from './protocol'
+
+export type BrokerOptions = {
+  containerName: string
+  cwd: string
+  policy: PortForward
+  // Resolves the host port currently published for this container's
+  // CONTAINER_PORT mapping. The broker calls this on each (re)connect attempt
+  // because the supervisor's restart can pick a different port if the previous
+  // one is now bound. Returning null signals "container not running yet" — the
+  // broker waits and retries.
+  resolveHostPort: () => Promise<number | null>
+  brokerToken: string
+  onEvent: (event: PortForwardEvent) => void
+  onLog?: (msg: string) => void
+  connectWs?: (url: string) => Promise<WsClient>
+  listenHost?: ListenHostFn
+  reconnectDelaysMs?: number[]
+  hostBindAddr?: string
+}
+
+export type WsClient = {
+  send: (msg: HostdToContainer) => void
+  close: () => void
+  onMessage: (cb: (msg: ContainerToHostd) => void) => void
+  onClose: (cb: () => void) => void
+}
+
+export type ListenHostFn = (
+  host: string,
+  port: number,
+  handlers: {
+    onConnection: (sock: HostSocket) => void
+  },
+) => Promise<HostListener>
+
+export type HostListener = {
+  port: number
+  stop: () => void
+}
+
+export type HostSocket = {
+  write: (chunk: Uint8Array) => void
+  end: () => void
+  onData: (cb: (chunk: Uint8Array) => void) => void
+  onClose: (cb: () => void) => void
+}
+
+export type Broker = {
+  start: () => void
+  stop: () => Promise<void>
+  forwardedPorts: () => number[]
+}
+
+const DEFAULT_RECONNECT_DELAYS = [1_000, 2_000, 4_000, 10_000]
+const DEFAULT_HOST_BIND = '127.0.0.1'
+
+export function createBroker(opts: BrokerOptions): Broker {
+  const log = opts.onLog ?? (() => {})
+  const reconnectDelays = opts.reconnectDelaysMs ?? DEFAULT_RECONNECT_DELAYS
+  const hostBind = opts.hostBindAddr ?? DEFAULT_HOST_BIND
+  const connectWs = opts.connectWs ?? defaultConnectWs
+  const listenHost = opts.listenHost ?? defaultListenHost
+
+  type ForwarderState = {
+    port: number
+    bindAddr: BindAddr
+    listener: HostListener
+    streams: Map<StreamId, { sock: HostSocket; opened: boolean; pending: Uint8Array[] }>
+  }
+
+  const forwarders = new Map<number, ForwarderState>()
+  let ws: WsClient | null = null
+  let nextStreamId: StreamId = 1
+  let stopped = false
+  let reconnectAttempt = 0
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+
+  const allocStreamId = (): StreamId => {
+    const id = nextStreamId
+    nextStreamId = nextStreamId >= 0x7fffffff ? 1 : nextStreamId + 1
+    return id
+  }
+
+  const emit = (event: PortForwardEvent): void => {
+    try {
+      opts.onEvent(event)
+    } catch (err) {
+      log(`onEvent threw: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  const closeStream = (port: number, streamId: StreamId, sendClose: boolean): void => {
+    const fwd = forwarders.get(port)
+    if (!fwd) return
+    const stream = fwd.streams.get(streamId)
+    if (!stream) return
+    fwd.streams.delete(streamId)
+    try {
+      stream.sock.end()
+    } catch {}
+    if (sendClose && ws) ws.send({ type: 'relay-close', streamId, side: 'downstream' })
+  }
+
+  const handleHostConnection = (port: number, sock: HostSocket): void => {
+    if (!ws) {
+      try {
+        sock.end()
+      } catch {}
+      return
+    }
+    const streamId = allocStreamId()
+    const fwd = forwarders.get(port)
+    if (!fwd) {
+      try {
+        sock.end()
+      } catch {}
+      return
+    }
+    fwd.streams.set(streamId, { sock, opened: false, pending: [] })
+
+    sock.onData((chunk) => {
+      const stream = fwd.streams.get(streamId)
+      if (!stream) return
+      const copy = new Uint8Array(chunk.byteLength)
+      copy.set(chunk)
+      if (stream.opened) {
+        if (ws) ws.send({ type: 'relay-data', streamId, bytes: encodeBytes(copy) })
+      } else {
+        stream.pending.push(copy)
+      }
+    })
+    sock.onClose(() => {
+      closeStream(port, streamId, true)
+    })
+
+    if (ws) ws.send({ type: 'relay-open', streamId, port })
+  }
+
+  const installForwarder = async (port: number, bindAddr: BindAddr): Promise<void> => {
+    if (forwarders.has(port)) return
+    if (!shouldForward({ policy: opts.policy, port })) return
+    try {
+      const listener = await listenHost(hostBind, port, {
+        onConnection: (sock) => handleHostConnection(port, sock),
+      })
+      forwarders.set(port, { port, bindAddr, listener, streams: new Map() })
+      emit({ kind: 'port-forward-opened', containerName: opts.containerName, port, bindAddr })
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err)
+      log(`forward bind ${port}: ${reason}`)
+      emit({ kind: 'port-forward-failed', containerName: opts.containerName, port, reason })
+    }
+  }
+
+  const removeForwarder = (port: number, reason: 'container-released' | 'host-error'): void => {
+    const fwd = forwarders.get(port)
+    if (!fwd) return
+    forwarders.delete(port)
+    try {
+      fwd.listener.stop()
+    } catch {}
+    for (const [streamId] of fwd.streams) closeStream(port, streamId, false)
+    emit({ kind: 'port-forward-closed', containerName: opts.containerName, port, reason })
+  }
+
+  const teardownAllForwarders = (reason: 'broker-stopped' | 'deregistered' | 'host-error'): void => {
+    for (const port of Array.from(forwarders.keys())) {
+      const fwd = forwarders.get(port)
+      if (!fwd) continue
+      forwarders.delete(port)
+      try {
+        fwd.listener.stop()
+      } catch {}
+      for (const [streamId] of fwd.streams) {
+        const stream = fwd.streams.get(streamId)
+        try {
+          stream?.sock.end()
+        } catch {}
+      }
+      emit({ kind: 'port-forward-closed', containerName: opts.containerName, port, reason })
+    }
+  }
+
+  const handleContainerMessage = (msg: ContainerToHostd): void => {
+    switch (msg.type) {
+      case 'broker-hello-ack':
+        if (ws) ws.send({ type: 'port-watch-subscribe' })
+        return
+      case 'broker-hello-nack':
+        log(`broker-hello rejected: ${msg.reason}`)
+        if (ws) ws.close()
+        return
+      case 'port-listen-snapshot':
+        for (const { port, bindAddr } of msg.ports) {
+          void installForwarder(port, bindAddr)
+        }
+        return
+      case 'port-listen-opened':
+        void installForwarder(msg.port, msg.bindAddr)
+        return
+      case 'port-listen-closed':
+        removeForwarder(msg.port, 'container-released')
+        return
+      case 'relay-open-ack': {
+        const port = findStreamPort(msg.streamId)
+        if (port === null) return
+        const fwd = forwarders.get(port)!
+        const stream = fwd.streams.get(msg.streamId)
+        if (!stream) return
+        stream.opened = true
+        if (ws) {
+          for (const buf of stream.pending)
+            ws.send({ type: 'relay-data', streamId: msg.streamId, bytes: encodeBytes(buf) })
+        }
+        stream.pending = []
+        return
+      }
+      case 'relay-open-nack': {
+        const port = findStreamPort(msg.streamId)
+        if (port !== null) closeStream(port, msg.streamId, false)
+        return
+      }
+      case 'relay-data': {
+        const port = findStreamPort(msg.streamId)
+        if (port === null) return
+        const stream = forwarders.get(port)?.streams.get(msg.streamId)
+        if (!stream) return
+        try {
+          stream.sock.write(decodeBytes(msg.bytes))
+        } catch {}
+        return
+      }
+      case 'relay-close': {
+        const port = findStreamPort(msg.streamId)
+        if (port !== null) closeStream(port, msg.streamId, false)
+        return
+      }
+    }
+  }
+
+  const findStreamPort = (streamId: StreamId): number | null => {
+    for (const [port, fwd] of forwarders) {
+      if (fwd.streams.has(streamId)) return port
+    }
+    return null
+  }
+
+  const connect = async (): Promise<void> => {
+    if (stopped) return
+    const hostPort = await opts.resolveHostPort()
+    if (hostPort === null) {
+      scheduleReconnect()
+      return
+    }
+    const url = `ws://127.0.0.1:${hostPort}/portbroker`
+    let client: WsClient
+    try {
+      client = await connectWs(url)
+    } catch (err) {
+      log(`ws connect ${url}: ${err instanceof Error ? err.message : String(err)}`)
+      scheduleReconnect()
+      return
+    }
+    ws = client
+    reconnectAttempt = 0
+
+    client.onMessage(handleContainerMessage)
+    client.onClose(() => {
+      ws = null
+      teardownAllForwarders('host-error')
+      scheduleReconnect()
+    })
+
+    client.send({ type: 'broker-hello', token: opts.brokerToken })
+  }
+
+  const scheduleReconnect = (): void => {
+    if (stopped) return
+    const delay = reconnectDelays[Math.min(reconnectAttempt, reconnectDelays.length - 1)] ?? 10_000
+    reconnectAttempt += 1
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      void connect()
+    }, delay)
+  }
+
+  return {
+    start() {
+      if (!brokerEnabled(opts.policy)) {
+        log(`portForward disabled (allow:[]) — broker not started for ${opts.containerName}`)
+        return
+      }
+      void connect()
+    },
+    async stop() {
+      stopped = true
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      teardownAllForwarders('broker-stopped')
+      if (ws) {
+        try {
+          ws.close()
+        } catch {}
+        ws = null
+      }
+    },
+    forwardedPorts() {
+      return Array.from(forwarders.keys())
+    },
+  }
+}
+
+async function defaultConnectWs(url: string): Promise<WsClient> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url)
+    let resolved = false
+    const messageCbs: Array<(msg: ContainerToHostd) => void> = []
+    const closeCbs: Array<() => void> = []
+    const client: WsClient = {
+      send: (msg) => {
+        try {
+          ws.send(JSON.stringify(msg))
+        } catch {}
+      },
+      close: () => {
+        try {
+          ws.close()
+        } catch {}
+      },
+      onMessage: (cb) => {
+        messageCbs.push(cb)
+      },
+      onClose: (cb) => {
+        closeCbs.push(cb)
+      },
+    }
+    ws.onopen = (): void => {
+      resolved = true
+      resolve(client)
+    }
+    ws.onmessage = (ev: MessageEvent): void => {
+      let msg: ContainerToHostd
+      try {
+        msg = JSON.parse(typeof ev.data === 'string' ? ev.data : '') as ContainerToHostd
+      } catch {
+        return
+      }
+      for (const cb of messageCbs) cb(msg)
+    }
+    ws.onerror = (): void => {
+      if (!resolved) reject(new Error(`ws error connecting to ${url}`))
+    }
+    ws.onclose = (): void => {
+      for (const cb of closeCbs) cb()
+    }
+  })
+}
+
+function defaultListenHost(
+  host: string,
+  port: number,
+  handlers: { onConnection: (sock: HostSocket) => void },
+): Promise<HostListener> {
+  return new Promise((resolve, reject) => {
+    type SocketState = { dataCbs: Array<(c: Uint8Array) => void>; closeCbs: Array<() => void> }
+    let listener: TCPSocketListener<SocketState> | null = null
+    try {
+      listener = Bun.listen<SocketState>({
+        hostname: host,
+        port,
+        socket: {
+          open(s: Socket<SocketState>) {
+            s.data = { dataCbs: [], closeCbs: [] }
+            const sockApi: HostSocket = {
+              write: (chunk) => {
+                try {
+                  s.write(chunk)
+                } catch {}
+              },
+              end: () => {
+                try {
+                  s.end()
+                } catch {}
+              },
+              onData: (cb) => {
+                s.data.dataCbs.push(cb)
+              },
+              onClose: (cb) => {
+                s.data.closeCbs.push(cb)
+              },
+            }
+            handlers.onConnection(sockApi)
+          },
+          data(s: Socket<SocketState>, data: Buffer) {
+            const copy = new Uint8Array(data.byteLength)
+            copy.set(data)
+            for (const cb of s.data.dataCbs) cb(copy)
+          },
+          close(s: Socket<SocketState>) {
+            for (const cb of s.data.closeCbs) cb()
+          },
+          error() {},
+        },
+      })
+      const captured = listener
+      resolve({
+        port: captured?.port ?? port,
+        stop: () => {
+          try {
+            captured?.stop(true)
+          } catch {}
+        },
+      })
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)))
+    }
+  })
+}

--- a/src/portbroker/index.ts
+++ b/src/portbroker/index.ts
@@ -1,0 +1,30 @@
+export { brokerEnabled, shouldForward } from './policy'
+export { parseProcNetTcp, type BindAddr, type ListenEntry } from './proc-net-tcp'
+export {
+  decodeBytes,
+  encodeBytes,
+  type ContainerToHostd,
+  type HostdToContainer,
+  type PortForwardCloseReason,
+  type PortForwardEvent,
+  type StreamId,
+} from './protocol'
+export {
+  createContainerBroker,
+  type BrokerSocket,
+  type BrokerWsData,
+  type ContainerBroker,
+  type ContainerBrokerLogEvent,
+  type ContainerBrokerOptions,
+  type UpstreamConnection,
+  type UpstreamHandlers,
+} from './container-server'
+export {
+  createBroker,
+  type Broker,
+  type BrokerOptions,
+  type HostListener,
+  type HostSocket,
+  type ListenHostFn,
+  type WsClient,
+} from './hostd-client'

--- a/src/portbroker/policy.test.ts
+++ b/src/portbroker/policy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { PortForward } from '@/config'
+import { CONTAINER_PORT } from '@/container'
+
+import { brokerEnabled, shouldForward } from './policy'
+
+describe('shouldForward', () => {
+  test('allow:* forwards arbitrary ports', () => {
+    expect(shouldForward({ policy: { allow: '*' }, port: 5173 })).toBe(true)
+    expect(shouldForward({ policy: { allow: '*' }, port: 65535 })).toBe(true)
+    expect(shouldForward({ policy: { allow: '*' }, port: 1 })).toBe(true)
+  })
+
+  test('allow:* + deny excludes listed ports', () => {
+    const policy: PortForward = { allow: '*', deny: [9229, 9999] }
+    expect(shouldForward({ policy, port: 5173 })).toBe(true)
+    expect(shouldForward({ policy, port: 9229 })).toBe(false)
+    expect(shouldForward({ policy, port: 9999 })).toBe(false)
+  })
+
+  test('allow as array forwards only listed ports', () => {
+    const policy: PortForward = { allow: [3000, 5173] }
+    expect(shouldForward({ policy, port: 3000 })).toBe(true)
+    expect(shouldForward({ policy, port: 5173 })).toBe(true)
+    expect(shouldForward({ policy, port: 8080 })).toBe(false)
+  })
+
+  test('allow:[] forwards nothing', () => {
+    const policy: PortForward = { allow: [] }
+    expect(shouldForward({ policy, port: 5173 })).toBe(false)
+    expect(shouldForward({ policy, port: 1234 })).toBe(false)
+  })
+
+  test('CONTAINER_PORT is always excluded, even when allow:* and not in deny', () => {
+    expect(shouldForward({ policy: { allow: '*' }, port: CONTAINER_PORT })).toBe(false)
+  })
+
+  test('CONTAINER_PORT is excluded even if explicitly listed in allow array (defense against config typos)', () => {
+    expect(shouldForward({ policy: { allow: [CONTAINER_PORT] }, port: CONTAINER_PORT })).toBe(false)
+  })
+
+  test('containerPort override exercises the implicit exclusion at a different port (test seam)', () => {
+    expect(shouldForward({ policy: { allow: '*' }, port: 7777, containerPort: 7777 })).toBe(false)
+    expect(shouldForward({ policy: { allow: '*' }, port: 7778, containerPort: 7777 })).toBe(true)
+  })
+})
+
+describe('brokerEnabled', () => {
+  test('allow:* enables the broker', () => {
+    expect(brokerEnabled({ allow: '*' })).toBe(true)
+  })
+
+  test('allow with at least one port enables the broker', () => {
+    expect(brokerEnabled({ allow: [3000] })).toBe(true)
+  })
+
+  test('allow:[] disables the broker (off-switch)', () => {
+    expect(brokerEnabled({ allow: [] })).toBe(false)
+  })
+})

--- a/src/portbroker/policy.ts
+++ b/src/portbroker/policy.ts
@@ -1,0 +1,24 @@
+import type { PortForward } from '@/config'
+import { CONTAINER_PORT } from '@/container'
+
+export type ShouldForwardOptions = {
+  policy: PortForward
+  port: number
+  containerPort?: number
+}
+
+// CONTAINER_PORT is always implicitly excluded: that mapping is owned by
+// `docker run -p ${hostPort}:${CONTAINER_PORT}` and forwarding it again would
+// fight the published port. Tests can override containerPort to verify the
+// implicit exclusion independently of the global constant.
+export function shouldForward({ policy, port, containerPort = CONTAINER_PORT }: ShouldForwardOptions): boolean {
+  if (port === containerPort) return false
+  if (Array.isArray(policy.allow)) return policy.allow.includes(port)
+  if (policy.deny?.includes(port)) return false
+  return true
+}
+
+export function brokerEnabled(policy: PortForward): boolean {
+  if (Array.isArray(policy.allow) && policy.allow.length === 0) return false
+  return true
+}

--- a/src/portbroker/proc-net-tcp.test.ts
+++ b/src/portbroker/proc-net-tcp.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+
+import { parseProcNetTcp } from './proc-net-tcp'
+
+const HEADER = '  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode'
+
+describe('parseProcNetTcp', () => {
+  test('returns empty for empty input', () => {
+    expect(parseProcNetTcp('')).toEqual([])
+  })
+
+  test('skips header rows', () => {
+    expect(parseProcNetTcp(HEADER)).toEqual([])
+  })
+
+  test('parses an IPv4 LISTEN on 127.0.0.1:8080', () => {
+    const input = `${HEADER}
+   0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+    expect(parseProcNetTcp(input)).toEqual([{ port: 8080, bindAddr: '127.0.0.1' }])
+  })
+
+  test('parses an IPv4 LISTEN on 0.0.0.0:5173', () => {
+    const input = `${HEADER}
+   0: 00000000:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+    expect(parseProcNetTcp(input)).toEqual([{ port: 5173, bindAddr: '0.0.0.0' }])
+  })
+
+  test('parses an IPv6 LISTEN on ::1:3000 as 127.0.0.1', () => {
+    const input = `${HEADER}
+   0: 00000000000000000000000001000000:0BB8 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+    expect(parseProcNetTcp(input)).toEqual([{ port: 3000, bindAddr: '127.0.0.1' }])
+  })
+
+  test('parses an IPv6 LISTEN on :: (IN6ADDR_ANY) as 0.0.0.0', () => {
+    const input = `${HEADER}
+   0: 00000000000000000000000000000000:0BB8 00000000000000000000000000000000:0000 0A 00000000:00000000 00000000 1000 0 12345 1`
+    expect(parseProcNetTcp(input)).toEqual([{ port: 3000, bindAddr: '0.0.0.0' }])
+  })
+
+  test('skips ESTABLISHED (state != 0A) connections', () => {
+    const input = `${HEADER}
+   0: 0100007F:1F90 0100007F:9999 01 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+    expect(parseProcNetTcp(input)).toEqual([])
+  })
+
+  test('handles multiple LISTEN rows', () => {
+    const input = `${HEADER}
+   0: 00000000:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1
+   1: 0100007F:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+    expect(parseProcNetTcp(input)).toEqual([
+      { port: 8080, bindAddr: '0.0.0.0' },
+      { port: 5173, bindAddr: '127.0.0.1' },
+    ])
+  })
+
+  test('dedupes the same port appearing in both tcp and tcp6, preferring 127.0.0.1', () => {
+    const input = `${HEADER}
+   0: 00000000:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1
+   1: 00000000000000000000000001000000:1435 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+    expect(parseProcNetTcp(input)).toEqual([{ port: 5173, bindAddr: '127.0.0.1' }])
+  })
+
+  test('keeps 0.0.0.0 when both rows are 0.0.0.0 (IPv4 + IPv6 both any)', () => {
+    const input = `${HEADER}
+   0: 00000000:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1
+   1: 00000000000000000000000000000000:1435 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+    expect(parseProcNetTcp(input)).toEqual([{ port: 5173, bindAddr: '0.0.0.0' }])
+  })
+
+  test('skips rows bound to non-loopback non-any IPs (we only forward loopback-reachable)', () => {
+    const input = `${HEADER}
+   0: 0202A8C0:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+    expect(parseProcNetTcp(input)).toEqual([])
+  })
+
+  test('skips malformed rows without throwing', () => {
+    const input = `${HEADER}
+   garbage row that is not a real entry
+   0: nope 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1
+   0: 00000000:0000 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+    expect(parseProcNetTcp(input)).toEqual([])
+  })
+
+  test('skips rows with port 0', () => {
+    const input = `${HEADER}
+   0: 0100007F:0000 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
+    expect(parseProcNetTcp(input)).toEqual([])
+  })
+})

--- a/src/portbroker/proc-net-tcp.ts
+++ b/src/portbroker/proc-net-tcp.ts
@@ -1,0 +1,72 @@
+export type BindAddr = '0.0.0.0' | '127.0.0.1'
+
+export type ListenEntry = {
+  port: number
+  bindAddr: BindAddr
+}
+
+const STATE_LISTEN = '0A'
+
+// /proc/net/tcp[6] format (one row per connection):
+//   sl  local_address          rem_address            st  tx_queue:rx_queue  ...
+//   0:  0100007F:1F90          00000000:0000          0A  00000000:00000000  ...
+//
+// `local_address` is `<ip-hex>:<port-hex>`. The IP is little-endian for IPv4
+// (so "0100007F" = 127.0.0.1) and big-endian-grouped for IPv6. We only care
+// about the LISTEN state (st === '0A') and the bind side (loopback vs any).
+//
+// Parser is loose-by-design: anything that doesn't look like a LISTEN row is
+// silently skipped (header rows, partial reads, kernel format additions). We
+// never throw — the procfs file changes between syscalls and a transient
+// parse failure must not propagate up.
+export function parseProcNetTcp(input: string): ListenEntry[] {
+  const out: ListenEntry[] = []
+  for (const raw of input.split('\n')) {
+    const line = raw.trim()
+    if (line.length === 0) continue
+    const cols = line.split(/\s+/)
+    if (cols.length < 4) continue
+    const localAddr = cols[1]
+    const state = cols[3]
+    if (state !== STATE_LISTEN || localAddr === undefined) continue
+    const colonIdx = localAddr.lastIndexOf(':')
+    if (colonIdx < 0) continue
+    const ipHex = localAddr.slice(0, colonIdx)
+    const portHex = localAddr.slice(colonIdx + 1)
+    const port = Number.parseInt(portHex, 16)
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) continue
+    const bindAddr = classifyBindAddr(ipHex)
+    if (bindAddr === null) continue
+    out.push({ port, bindAddr })
+  }
+  return dedupePreferringLoopback(out)
+}
+
+function classifyBindAddr(ipHex: string): BindAddr | null {
+  if (ipHex.length === 8) {
+    if (ipHex === '00000000') return '0.0.0.0'
+    if (ipHex.toUpperCase() === '0100007F') return '127.0.0.1'
+    return null
+  }
+  if (ipHex.length === 32) {
+    if (ipHex === '00000000000000000000000000000000') return '0.0.0.0'
+    if (ipHex === '00000000000000000000000001000000') return '127.0.0.1'
+    return null
+  }
+  return null
+}
+
+// A server bound to both 0.0.0.0 (IPv4) and ::1 (IPv6) appears twice in our
+// merged tcp+tcp6 input. Collapse to one entry per port. If the same port has
+// both classifications, prefer 127.0.0.1 (the more restrictive one) so the
+// downstream forwarder routes through `Bun.connect('127.0.0.1', port)` either
+// way — the loopback path works for both bind addresses.
+function dedupePreferringLoopback(entries: ListenEntry[]): ListenEntry[] {
+  const byPort = new Map<number, BindAddr>()
+  for (const e of entries) {
+    const existing = byPort.get(e.port)
+    if (existing === undefined) byPort.set(e.port, e.bindAddr)
+    else if (existing === '0.0.0.0' && e.bindAddr === '127.0.0.1') byPort.set(e.port, '127.0.0.1')
+  }
+  return Array.from(byPort.entries()).map(([port, bindAddr]) => ({ port, bindAddr }))
+}

--- a/src/portbroker/protocol.ts
+++ b/src/portbroker/protocol.ts
@@ -1,0 +1,37 @@
+import type { BindAddr } from './proc-net-tcp'
+
+export type StreamId = number
+
+export type HostdToContainer =
+  | { type: 'broker-hello'; token: string }
+  | { type: 'port-watch-subscribe' }
+  | { type: 'port-watch-unsubscribe' }
+  | { type: 'relay-open'; streamId: StreamId; port: number }
+  | { type: 'relay-data'; streamId: StreamId; bytes: string }
+  | { type: 'relay-close'; streamId: StreamId; side: 'upstream' | 'downstream' }
+
+export type ContainerToHostd =
+  | { type: 'broker-hello-ack' }
+  | { type: 'broker-hello-nack'; reason: string }
+  | { type: 'port-listen-snapshot'; ports: Array<{ port: number; bindAddr: BindAddr }> }
+  | { type: 'port-listen-opened'; port: number; bindAddr: BindAddr }
+  | { type: 'port-listen-closed'; port: number }
+  | { type: 'relay-open-ack'; streamId: StreamId }
+  | { type: 'relay-open-nack'; streamId: StreamId; reason: string }
+  | { type: 'relay-data'; streamId: StreamId; bytes: string }
+  | { type: 'relay-close'; streamId: StreamId; side: 'upstream' | 'downstream' }
+
+export type PortForwardEvent =
+  | { kind: 'port-forward-opened'; containerName: string; port: number; bindAddr: BindAddr }
+  | { kind: 'port-forward-closed'; containerName: string; port: number; reason: PortForwardCloseReason }
+  | { kind: 'port-forward-failed'; containerName: string; port: number; reason: string }
+
+export type PortForwardCloseReason = 'container-released' | 'host-error' | 'deregistered' | 'broker-stopped'
+
+export function encodeBytes(buf: Uint8Array): string {
+  return Buffer.from(buf).toString('base64')
+}
+
+export function decodeBytes(s: string): Uint8Array {
+  return new Uint8Array(Buffer.from(s, 'base64'))
+}

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -23,6 +23,7 @@ import {
   type Scheduler,
 } from '@/cron'
 import { loadPlugins, type LoadPluginsResult, pluginCronJobs, type PluginRegistry, summarizeLoaded } from '@/plugin'
+import { createContainerBroker } from '@/portbroker'
 import { ReloadRegistry } from '@/reload'
 import { createServer, type Server } from '@/server'
 import { createSessionFactory, type SessionFactory } from '@/sessions'
@@ -261,6 +262,26 @@ export async function startAgent({
     console.log(`[plugin] loaded ${summarizeLoaded(pluginsLoaded.loadedPlugins, pluginRegistry)}`)
   }
 
+  // Container-side portbroker is instantiated only when the host plumbed a
+  // broker token in via env var. Outside the container (tests, ad-hoc dev
+  // runs), the env var is absent and the broker stays off — same fence as
+  // TYPECLAW_CONTAINER_NAME guards the restart tool.
+  const brokerTokenEnv = process.env.TYPECLAW_HOSTD_BROKER_TOKEN
+  const containerBroker =
+    brokerTokenEnv !== undefined && brokerTokenEnv.length > 0
+      ? createContainerBroker({
+          expectedToken: brokerTokenEnv,
+          onLog: (event) => {
+            if (event.kind === 'subscribed') return
+            stream.publish({
+              target: { kind: 'broadcast' },
+              payload: { kind: 'portbroker-log', event },
+            })
+          },
+        })
+      : undefined
+  const containerBrokerOpt = containerBroker ? { containerBroker } : {}
+
   const server = createServer({
     port,
     reloadAll: () => reloadRegistry.reloadAll(),
@@ -271,6 +292,7 @@ export async function startAgent({
     agentDir: cwd,
     pluginRuntime,
     ...containerNameOpt,
+    ...containerBrokerOpt,
   }).start()
 
   let stopped = false

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@/agent'
 import type { ChannelRouter } from '@/channels/router'
 import type { HookBus } from '@/plugin'
+import type { BrokerWsData, ContainerBroker } from '@/portbroker'
 import type { ReloadAllResult, ReloadRegistry } from '@/reload'
 import type { PluginRuntime, PluginRuntimeState } from '@/run/plugin-runtime'
 import type { SessionFactory } from '@/sessions'
@@ -28,12 +29,18 @@ export type ServerOptions = {
   agentDir?: string
   pluginRuntime?: PluginRuntime
   containerName?: string
+  // Optional in-process portbroker handler. When provided, requests to the
+  // /portbroker WS path are routed to it instead of being treated as TUI
+  // sessions. Omit to keep TUI-only behavior (used by tests + non-container
+  // dev runs).
+  containerBroker?: ContainerBroker
 }
 
 export type Server = ReturnType<typeof createServer>
 
-type WsData = { sessionId: string }
-type Ws = ServerWebSocket<WsData>
+type TuiWsData = { kind: 'tui'; sessionId: string }
+type WsData = TuiWsData | BrokerWsData
+type Ws = ServerWebSocket<TuiWsData>
 
 type QueuedPrompt = {
   streamMessageId: StreamMessageId
@@ -72,6 +79,7 @@ export function createServer({
   agentDir,
   pluginRuntime,
   containerName,
+  containerBroker,
 }: ServerOptions) {
   const sessionStates = new WeakMap<Ws, SessionState>()
 
@@ -79,12 +87,25 @@ export function createServer({
     const bunServer = Bun.serve<WsData>({
       port,
       fetch(req, server) {
+        const url = new URL(req.url)
+        if (url.pathname === '/portbroker') {
+          if (!containerBroker) return new Response('portbroker disabled', { status: 404 })
+          const data: BrokerWsData = { kind: 'portbroker', authed: false }
+          if (server.upgrade(req, { data })) return
+          return new Response('upgrade failed', { status: 400 })
+        }
         const sessionId = crypto.randomUUID()
-        if (server.upgrade(req, { data: { sessionId } })) return
+        const data: TuiWsData = { kind: 'tui', sessionId }
+        if (server.upgrade(req, { data })) return
         return new Response('typeclaw agent', { status: 200 })
       },
       websocket: {
-        async open(ws) {
+        async open(rawWs) {
+          if (rawWs.data.kind === 'portbroker') {
+            containerBroker?.open(rawWs as ServerWebSocket<BrokerWsData>)
+            return
+          }
+          const ws = rawWs as Ws
           const sessionManager = sessionFactory?.createPersisted()
           const sessionFileId = sessionManager?.getSessionId() ?? ws.data.sessionId
           // Snapshot the runtime once so the entire session lifecycle for this
@@ -151,7 +172,12 @@ export function createServer({
           send(ws, { type: 'connected', sessionId: sessionFileId })
           console.log(`session ${sessionFileId}: open`)
         },
-        async message(ws, raw) {
+        async message(rawWs, raw) {
+          if (rawWs.data.kind === 'portbroker') {
+            await containerBroker?.message(rawWs as ServerWebSocket<BrokerWsData>, raw as string | Buffer)
+            return
+          }
+          const ws = rawWs as Ws
           const msg = JSON.parse(String(raw)) as ClientMessage
           const state = sessionStates.get(ws)
 
@@ -202,7 +228,12 @@ export function createServer({
             return
           }
         },
-        async close(ws) {
+        async close(rawWs) {
+          if (rawWs.data.kind === 'portbroker') {
+            containerBroker?.close(rawWs as ServerWebSocket<BrokerWsData>)
+            return
+          }
+          const ws = rawWs as Ws
           const state = sessionStates.get(ws)
           state?.unsubBroadcast?.()
           state?.unsubPrompts?.()


### PR DESCRIPTION
## Why

Docker fundamentally cannot publish new ports on a running container — \`HostConfig.PortBindings\` is set at create time and \`docker update\` doesn't cover networking. The old AGENTS.md described an unimplemented design that would have silently failed on two additional fronts:

1. **macOS routing.** Docker Desktop on macOS does not route the container bridge subnet to the host. A host-side relay that \`Bun.connect\`s to the container's bridge IP works on Linux but is a no-op on Mac — the OS drops the packets silently.
2. **localhost-bound servers.** Most dev servers (Vite, Next, webpack-dev-server) bind \`127.0.0.1\`, not \`0.0.0.0\`. Docker's \`-p\` flag uses the bridge IP, not loopback — it cannot reach these servers even on Linux.

The new design avoids both problems: the relay's upstream side runs **inside the container's own typeclaw process** via \`Bun.connect('127.0.0.1', port)\`, which is always reachable regardless of bind address. The host-side broker connects to the container over the single published port the TUI already uses (\`ws://127.0.0.1:\${hostPort}/portbroker\`) — no bridge IPs, no new Docker port mappings, no extra sockets.

The Momus plan critic validated this approach pre-implementation and explicitly rejected the bridge-IP design for the macOS reason above.

## Changes

### New: `src/portbroker/`

A self-contained module with both halves of the relay — 2 501 net new lines, 59 tests.

| File | Role |
|---|---|
| `protocol.ts` | Wire types shared by both halves. Binary frames use a 4-byte big-endian length prefix + JSON header + optional binary body. |
| `policy.ts` | Port-forward policy evaluation: `allow: "*"`, `allow: [...]`, `allow: "*" + deny: [...]`, `allow: []` (off). Invalid combos (array-allow + non-empty deny) rejected at parse time. |
| `proc-net-tcp.ts` | Parses `/proc/net/tcp` and `/proc/net/tcp6` hex output into LISTEN port sets. Pure function with golden-file tests. |
| `container-server.ts` | Container-side broker: polls `/proc/net/tcp[6]` for new LISTEN ports, maintains upstream \`Bun.connect('127.0.0.1', port)\` connections, multiplexes data frames over the shared WS to hostd. Auth on first message via token. |
| `hostd-client.ts` | Host-side broker: one \`Bun.listen\` per forwarded port, proxies data to/from the container WS. Exponential reconnect with jitter. EADDRINUSE → skip-and-log (never retry — matches AGENTS.md invariant). |
| `broker.test.ts` | End-to-end composition test: real \`Bun.serve\` WS server + real \`Bun.listen\` host socket + fake upstream handles, no mocks. Mutation-check anchor. |

### Config: `portForward` in `typeclaw.json`

New optional field on the schema. Four valid shapes:

```jsonc
{ "allow": "*" }          // forward everything (default when omitted)
{ "allow": [3000, 5173] } // allowlist specific ports
{ "allow": "*", "deny": [9229] } // deny specific ports from the wildcard
{ "allow": [] }           // disable entirely — broker skips all setup
```

Array-allow + non-empty deny is rejected at parse time (the only invalid combination). Validated in `src/config/config.test.ts` (+50 lines).

### Hostd glue

- **`src/hostd/protocol.ts`**: `register` RPC gains three new optional fields — `wsHostPort` (published host port for the portbroker WS path), `portForward` (policy), `brokerToken` (shared secret for auth handshake).
- **`src/hostd/portbroker-manager.ts`** (new): owns a `Map<containerName, Broker>`, calls `createBroker()` on register and `broker.stop()` on deregister. Wraps `resolveHostPort()` to support test injection.
- **`src/hostd/daemon.ts`**: `register` RPC activates portbroker when `wsHostPort` is present; `deregister` and the GC tick both drain via the manager.

### Container wiring

- **`src/server/index.ts`**: new `/portbroker` WebSocket path. Requests from hostd hit this path; the server hands the WS to `ContainerBroker.open/message/close`.
- **`src/run/index.ts`**: `startAgent` creates the `ContainerBroker` and passes it to `createServer`. Generates a random `brokerToken` per run, plumbs `wsHostPort` and `portForward` through to `typeclaw start` for the register RPC.
- **`src/container/start.ts`**: passes `wsHostPort`/`portForward`/`brokerToken` as env vars so `typeclaw run` can read them inside the container.

### Earlier commits (same branch)

Commits `055b57a` and `981ffdc` bundle `tmux` + `gh` into the generated Dockerfile and add BuildKit cache mounts (`--mount=type=cache`) for apt and bun — independent improvements that landed on this branch before the portbroker work started. They are covered by +7 tests in `src/init/index.test.ts` and described in their commit messages.

### AGENTS.md

The `Host daemon (hostd)` section was fully rewritten to reflect the new design. The old section described the unimplemented bridge-IP portbroker; it is now removed. The new section documents the WS-relay architecture, the `portForward` config contract, and the three open-question resolutions from the plan.

## Architecture diagram

```
host (macOS / Linux):
  hostd daemon
    PortbrokerManager
      Broker[agentA]
        Bun.listen(:3000) ──┐
        Bun.listen(:5173) ──┤
                            │  ws://127.0.0.1:${hostPort}/portbroker
                            └──────────────────────────────────────►
                                                            container:
                                                              /portbroker WS path
                                                              ContainerBroker
                                                                Bun.connect('127.0.0.1', 3000)
                                                                Bun.connect('127.0.0.1', 5173)
                                                                /proc/net/tcp poller
```

Data path (inbound to container dev server):

```
browser → hostd Bun.listen(:3000) → WS data frame → container ContainerBroker → Bun.connect('127.0.0.1', 3000)
```

## Testing

59 new tests in `src/portbroker/` across 5 test files. End-to-end composition test in `broker.test.ts` uses real `Bun.serve`, real `Bun.listen`, and fake upstream connections — no mocks at the network layer. Mutation check: commenting out the WS-path routing in the broker breaks 3 composition tests.

Additional coverage: +50 lines in `src/config/config.test.ts` (portForward schema validation), +7 in `src/init/index.test.ts` (Dockerfile changes), updates to `src/container/start.test.ts`.

Pre-commit checks all pass:
```
bun run typecheck  — clean
bun run lint       — 0 warnings, 0 errors
bun run format     — clean
```

## Design decisions (open questions resolved)

Three questions from the plan §10, with chosen answers:

1. **`deny` + `allow: []` combination** → rejected at parse time. An empty allow-list with a non-empty deny list is internally contradictory; failing loudly on `typeclaw.json` load is better than silently ignoring the deny.
2. **EADDRINUSE on host-side `Bun.listen`** → skip-and-log, never retry. Matches the AGENTS.md "skip-eaddrinuse" invariant. Retrying would require a separate retry queue and introduces a window where partially-forwarded ports give confusing results.
3. **Empty `allow: []` behavior** → skips broker setup entirely. Zero overhead: no WS connection, no poller, no `Bun.listen`. The `portForward` field is therefore also an explicit off-switch, more legible than deleting the key.