### PR TITLE
Add typeclaw shell command

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import { logsCommand } from './logs'
 import { reload } from './reload'
 import { restartCommand } from './restart'
 import { run } from './run'
+import { shellCommand } from './shell'
 import { startCommand } from './start'
 import { stopCommand } from './stop'
 import { tui } from './tui'
@@ -26,6 +27,7 @@ const main = defineCommand({
     restart: restartCommand,
     reload,
     logs: logsCommand,
+    shell: shellCommand,
     _hostd: hostdCommand,
   },
 })

--- a/src/cli/shell.ts
+++ b/src/cli/shell.ts
@@ -1,0 +1,29 @@
+import { defineCommand } from 'citty'
+
+import { shell } from '@/container'
+import { findAgentDir } from '@/init'
+
+export const shellCommand = defineCommand({
+  meta: {
+    name: 'shell',
+    description: 'open an interactive shell in the agent container (host stage)',
+  },
+  args: {
+    shell: {
+      type: 'string',
+      description: 'shell executable to run inside the container',
+      default: '/bin/bash',
+    },
+  },
+  async run({ args }) {
+    const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+
+    const result = await shell({ cwd, shell: args.shell })
+    if (!result.ok) {
+      console.error(result.reason)
+      process.exit(1)
+    }
+
+    process.exit(result.exitCode)
+  },
+})

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -1,5 +1,6 @@
 export { logs, planLogs, type LogsPlan, type LogsResult } from './logs'
 export { CONTAINER_PORT, findFreePort, resolveHostPort } from './port'
+export { planShell, shell, type ShellPlan, type ShellResult } from './shell'
 export {
   containerExists,
   containerNameFromCwd,

--- a/src/container/shell.test.ts
+++ b/src/container/shell.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { planShell, shell } from './shell'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-container-shell-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('planShell', () => {
+  test('derives container name from the folder basename and defaults to bash', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    expect(planShell(folder)).toEqual({ containerName: 'coder', shell: '/bin/bash' })
+  })
+
+  test('carries a custom shell through', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    expect(planShell(folder, { shell: '/bin/sh' })).toEqual({ containerName: 'coder', shell: '/bin/sh' })
+  })
+})
+
+describe('shell', () => {
+  test('asks the user to start the container when it is missing', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    const result = await shell(
+      { cwd: folder },
+      {
+        inspect: async () => ({ exists: false }),
+        spawn: () => ({ exited: Promise.resolve(0) }),
+      },
+    )
+
+    expect(result).toEqual({ ok: false, reason: 'Container coder not found. Run `typeclaw start` first.' })
+  })
+
+  test('asks the user to start the container when it is stopped', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    const result = await shell(
+      { cwd: folder },
+      {
+        inspect: async () => ({ exists: true, running: false }),
+        spawn: () => ({ exited: Promise.resolve(0) }),
+      },
+    )
+
+    expect(result).toEqual({ ok: false, reason: 'Container coder is not running. Run `typeclaw start` first.' })
+  })
+
+  test('runs docker exec with interactive stdio in the agent folder', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+    const spawns: Array<{
+      cmd: string[]
+      cwd: string
+      stdin: 'inherit'
+      stdout: 'inherit'
+      stderr: 'inherit'
+    }> = []
+
+    const result = await shell(
+      { cwd: folder, shell: '/bin/sh' },
+      {
+        inspect: async () => ({ exists: true, running: true }),
+        spawn: (options) => {
+          spawns.push(options)
+          return { exited: Promise.resolve(7) }
+        },
+      },
+    )
+
+    expect(result).toEqual({ ok: true, containerName: 'coder', exitCode: 7 })
+    expect(spawns).toEqual([
+      {
+        cmd: ['docker', 'exec', '-it', 'coder', '/bin/sh'],
+        cwd: folder,
+        stdin: 'inherit',
+        stdout: 'inherit',
+        stderr: 'inherit',
+      },
+    ])
+  })
+})

--- a/src/container/shell.ts
+++ b/src/container/shell.ts
@@ -1,0 +1,58 @@
+import { containerNameFromCwd, getBun, inspectContainer, type ContainerState } from './shared'
+
+export type ShellPlan = {
+  containerName: string
+  shell: string
+}
+
+export type ShellResult = { ok: true; containerName: string; exitCode: number } | { ok: false; reason: string }
+
+type ShellDeps = {
+  inspect?: (name: string) => Promise<ContainerState>
+  spawn?: InteractiveSpawn
+}
+
+type InteractiveSpawn = (options: {
+  cmd: string[]
+  cwd: string
+  stdin: 'inherit'
+  stdout: 'inherit'
+  stderr: 'inherit'
+}) => { exited: Promise<number> }
+
+export async function shell(
+  { cwd, shell: shellPath = '/bin/bash' }: { cwd: string; shell?: string },
+  deps: ShellDeps = {},
+): Promise<ShellResult> {
+  const bun = getBun()
+  const spawn = deps.spawn ?? bun?.spawn
+  if (!spawn) return { ok: false, reason: 'bun runtime not available' }
+
+  const { containerName, shell: plannedShell } = planShell(cwd, { shell: shellPath })
+
+  try {
+    const state = await (deps.inspect ?? inspectContainer)(containerName)
+    if (!state.exists) {
+      return { ok: false, reason: `Container ${containerName} not found. Run \`typeclaw start\` first.` }
+    }
+    if (!state.running) {
+      return { ok: false, reason: `Container ${containerName} is not running. Run \`typeclaw start\` first.` }
+    }
+
+    const proc = spawn({
+      cmd: ['docker', 'exec', '-it', containerName, plannedShell],
+      cwd,
+      stdin: 'inherit',
+      stdout: 'inherit',
+      stderr: 'inherit',
+    })
+    const exitCode = await proc.exited
+    return { ok: true, containerName, exitCode }
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+export function planShell(cwd: string, { shell: shellPath = '/bin/bash' }: { shell?: string } = {}): ShellPlan {
+  return { containerName: containerNameFromCwd(cwd), shell: shellPath }
+}


### PR DESCRIPTION
## Summary
- Add a host-stage `typeclaw shell` command that opens an interactive shell in the running agent container.
- Add a container-domain shell helper that verifies the Docker container exists and is running before calling `docker exec -it`.
- Cover default/custom shell planning, missing/stopped containers, and interactive stdio wiring with focused tests.

## Verification
- `bun run lint`
- `bun run format:check`
- `bun typecheck`
- `FIREWORKS_API_KEY=test bun run test` (1322 tests passing)