### PR TITLE
Prefix hostd log lines with ISO timestamps

### DIFF
--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -19,11 +19,11 @@ export const hostdCommand = defineCommand({
     const version = srcRoot === null ? UNVERSIONED_SENTINEL : await computeSourceVersion({ srcRoot })
 
     const portbroker = createPortbrokerManager({
-      onLog: (msg) => console.log(msg),
+      onLog: (msg) => writeLogLine(msg),
     })
 
     const daemon = await startDaemon({
-      onLog: (e) => console.log(formatLog(e)),
+      onLog: (e) => writeLogLine(formatLog(e)),
       version,
       onShutdown: () => process.exit(0),
       portbroker,
@@ -58,6 +58,10 @@ export const hostdCommand = defineCommand({
     await new Promise<void>(() => {})
   },
 })
+
+function writeLogLine(msg: string): void {
+  console.log(`${new Date().toISOString()} ${msg}`)
+}
 
 function formatLog(event: DaemonLogEvent | SupervisorLogEvent): string {
   switch (event.kind) {


### PR DESCRIPTION
## Summary
- `~/.typeclaw/log/hostd.log` lines had no timestamps, making it hard to correlate hostd events (registers, port-forwards, restarts) with container behaviour.
- Route both daemon and portbroker log writes through a single `writeLogLine` helper that prefixes every line with `new Date().toISOString()`.

## Notes
- Only the CLI-level entry point in `src/cli/hostd.ts` changes; the daemon/portbroker modules still emit plain strings/events, so unit tests that assert on those payloads stay untouched.
- Both stdout and stderr from `_hostd` are redirected to the same log file by `spawn.ts`, so a single `console.log`-based helper covers every line that ends up on disk.