### PR TITLE
Fix hostd self-shutdown during agent restart

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test'
+
+import { configSchema } from '@/config'
+import type { StartOptions, StartResult } from '@/container'
+
+import { buildHostdRestart } from './hostd'
+
+describe('buildHostdRestart', () => {
+  test('restarts through the already-running hostd instead of triggering drift respawn', async () => {
+    const starts: StartOptions[] = []
+    const restart = buildHostdRestart('/repo/src/cli/index.ts', {
+      validateConfig: () => ({ ok: true }),
+      stop: async () => ({ ok: true, containerName: 'agent', running: true }),
+      loadConfigSync: () => configSchema.parse({ port: 61234 }),
+      start: async (opts) => {
+        starts.push(opts)
+        return startOk(opts)
+      },
+    })
+
+    const result = await restart({ containerName: 'agent', cwd: '/agent-dir' })
+
+    expect(result.ok).toBe(true)
+    expect(starts).toHaveLength(1)
+    expect(starts[0]).toMatchObject({
+      cwd: '/agent-dir',
+      preferredHostPort: 61234,
+      cliEntry: '/repo/src/cli/index.ts',
+      reuseCurrentHostDaemon: true,
+    })
+  })
+})
+
+function startOk(opts: StartOptions): StartResult {
+  return {
+    ok: true,
+    plan: {
+      containerName: 'agent',
+      imageTag: 'typeclaw-agent',
+      buildContext: opts.cwd,
+      dockerfile: `${opts.cwd}/Dockerfile`,
+      runArgs: ['run'],
+      needsBuild: false,
+      hostPort: opts.preferredHostPort,
+    },
+    containerId: 'container-id',
+    built: false,
+    hostPort: opts.preferredHostPort,
+    hostd: { state: 'registered' },
+  }
+}

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -1,10 +1,10 @@
 import { defineCommand } from 'citty'
 
-import { loadConfigSync, validateConfig } from '@/config'
-import { start, stop } from '@/container'
+import { loadConfigSync, validateConfig, type Config, type ValidateConfigResult } from '@/config'
+import { start, stop, type StartOptions, type StartResult, type StopResult } from '@/container'
 import { startDaemon, type DaemonLogEvent } from '@/hostd/daemon'
 import { createPortbrokerManager } from '@/hostd/portbroker-manager'
-import type { SupervisorLogEvent } from '@/hostd/supervisor'
+import type { SupervisorLogEvent, SupervisorRestart } from '@/hostd/supervisor'
 import { computeSourceVersion, resolveSrcRoot, UNVERSIONED_SENTINEL } from '@/hostd/version'
 
 export const hostdCommand = defineCommand({
@@ -27,23 +27,7 @@ export const hostdCommand = defineCommand({
       version,
       onShutdown: () => process.exit(0),
       portbroker,
-      restart: async ({ containerName, cwd }) => {
-        const validated = validateConfig(cwd)
-        if (!validated.ok) {
-          return { ok: false, reason: `invalid config for ${containerName}: ${validated.reason}` }
-        }
-        const stopResult = await stop({ cwd })
-        if (!stopResult.ok) return { ok: false, reason: `stop failed: ${stopResult.reason}` }
-
-        const cfg = loadConfigSync(cwd)
-        const startResult = await start({
-          cwd,
-          preferredHostPort: cfg.port,
-          cliEntry,
-        })
-        if (!startResult.ok) return { ok: false, reason: `start failed: ${startResult.reason}` }
-        return { ok: true }
-      },
+      restart: buildHostdRestart(cliEntry),
     })
 
     const shutdown = (): void => {
@@ -58,6 +42,41 @@ export const hostdCommand = defineCommand({
     await new Promise<void>(() => {})
   },
 })
+
+export type HostdRestartDeps = {
+  validateConfig: (cwd: string) => ValidateConfigResult
+  stop: (opts: { cwd: string }) => Promise<StopResult>
+  loadConfigSync: (cwd: string) => Config
+  start: (opts: StartOptions) => Promise<StartResult>
+}
+
+const defaultRestartDeps: HostdRestartDeps = {
+  validateConfig,
+  stop,
+  loadConfigSync,
+  start,
+}
+
+export function buildHostdRestart(cliEntry: string, deps: HostdRestartDeps = defaultRestartDeps): SupervisorRestart {
+  return async ({ containerName, cwd }) => {
+    const validated = deps.validateConfig(cwd)
+    if (!validated.ok) {
+      return { ok: false, reason: `invalid config for ${containerName}: ${validated.reason}` }
+    }
+    const stopResult = await deps.stop({ cwd })
+    if (!stopResult.ok) return { ok: false, reason: `stop failed: ${stopResult.reason}` }
+
+    const cfg = deps.loadConfigSync(cwd)
+    const startResult = await deps.start({
+      cwd,
+      preferredHostPort: cfg.port,
+      cliEntry,
+      reuseCurrentHostDaemon: true,
+    })
+    if (!startResult.ok) return { ok: false, reason: `start failed: ${startResult.reason}` }
+    return { ok: true }
+  }
+}
 
 function writeLogLine(msg: string): void {
   console.log(`${new Date().toISOString()} ${msg}`)

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -14,6 +14,7 @@ export {
   start,
   type HostDaemonStatus,
   type PlanStartOptions,
+  type StartOptions,
   type StartPlan,
   type StartResult,
 } from './start'

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -4,6 +4,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 
+import { startDaemon, type Daemon } from '@/hostd/daemon'
 import { buildDockerfile } from '@/init/dockerfile'
 import { buildGitignore } from '@/init/gitignore'
 
@@ -711,6 +712,39 @@ describe('start (composition)', () => {
     expect(result.ok).toBe(true)
     const headAfter = await runGit(root, ['rev-parse', 'HEAD'])
     expect(headAfter).toBe(headBefore)
+  })
+
+  test('can register through the current hostd without drift respawn during daemon-owned restart', async () => {
+    const previousHome = process.env.TYPECLAW_HOME
+    const home = await mkdtemp(join(tmpdir(), 'typeclaw-current-hostd-'))
+    let daemon: Daemon | null = null
+    try {
+      process.env.TYPECLAW_HOME = home
+      await writeDockerfile(root)
+      await writePackageJson(root, { typeclaw: '^0.1.0' })
+      await writeTypeclawConfig(root)
+      daemon = await startDaemon({ version: 'old-hostd-version', gcIntervalMs: 1_000_000 })
+      const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+      const result = await start({
+        cwd: root,
+        preferredHostPort: 8973,
+        exec,
+        allocatePort: deterministicAllocator,
+        cliEntry: '/nonexistent/newer-cli.ts',
+        reuseCurrentHostDaemon: true,
+      })
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.hostd.state).toBe('registered')
+      expect(daemon.registered()).toContain(basename(root))
+    } finally {
+      if (daemon) await daemon.stop().catch(() => {})
+      if (previousHome === undefined) delete process.env.TYPECLAW_HOME
+      else process.env.TYPECLAW_HOME = previousHome
+      await rm(home, { recursive: true, force: true })
+    }
   })
 
   test('forceBuild=false skips build entirely when image already exists', async () => {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -5,6 +5,7 @@ import { isAbsolute, join, resolve } from 'node:path'
 
 import { configSchema, expandMountPath, type Mount } from '@/config/config'
 import { send as sendToDaemon } from '@/hostd/client'
+import type { HttpInfoResult } from '@/hostd/protocol'
 import { ensureDaemon } from '@/hostd/spawn'
 import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
@@ -54,6 +55,9 @@ export type StartOptions = {
   // production we go through the real kernel via `findFreePort`.
   allocatePort?: (preferred: number) => Promise<number>
   cliEntry?: string
+  // Hostd's supervisor restart callback already runs inside the daemon process.
+  // Reusing that daemon avoids a self-shutdown when disk source has drifted.
+  reuseCurrentHostDaemon?: boolean
 }
 
 export type HostDaemonStatus =
@@ -79,6 +83,7 @@ export async function start({
   exec = defaultDockerExec,
   allocatePort = findFreePort,
   cliEntry,
+  reuseCurrentHostDaemon = false,
 }: StartOptions): Promise<StartResult> {
   try {
     // TypeClaw owns Dockerfile and .gitignore. Refresh them from the current
@@ -123,7 +128,7 @@ export async function start({
     // Register AFTER port allocation so the daemon's portbroker has the right
     // wsHostPort. Re-register on TOCTOU retry below if the port changes.
     let hostd: PreparedHostDaemonStatus = cliEntry
-      ? await registerWithDaemon({ cwd, containerName, cliEntry, hostPort })
+      ? await registerWithDaemon({ cwd, containerName, cliEntry, hostPort, reuseCurrentHostDaemon })
       : { state: 'disabled' as const }
     let hostdControl = hostd.state === 'registered' ? hostd.control : undefined
 
@@ -149,7 +154,7 @@ export async function start({
     if (run.exitCode !== 0 && isPortAllocatedError(run.stderr)) {
       hostPort = await allocatePort(0)
       if (cliEntry) {
-        hostd = await registerWithDaemon({ cwd, containerName, cliEntry, hostPort })
+        hostd = await registerWithDaemon({ cwd, containerName, cliEntry, hostPort, reuseCurrentHostDaemon })
         hostdControl = hostd.state === 'registered' ? hostd.control : undefined
       }
       plan = await planStart({ cwd, hostPort, imageExists: true, forceBuild: false, hostdControl })
@@ -341,14 +346,16 @@ async function registerWithDaemon({
   containerName,
   cliEntry,
   hostPort,
+  reuseCurrentHostDaemon,
 }: {
   cwd: string
   containerName: string
   cliEntry: string
   hostPort: number
+  reuseCurrentHostDaemon: boolean
 }): Promise<PreparedHostDaemonStatus> {
-  const ensured = await ensureDaemon({ cliEntry })
-  if (!ensured.ok) return { state: 'unavailable', reason: ensured.reason }
+  const prepared = reuseCurrentHostDaemon ? await useCurrentHostDaemon() : await ensureDaemon({ cliEntry })
+  if (!prepared.ok) return { state: 'unavailable', reason: prepared.reason }
   const token = randomBytes(32).toString('base64url')
   const brokerToken = randomBytes(32).toString('base64url')
   const cfg = configSchema.parse(await loadConfigJson(cwd))
@@ -364,8 +371,18 @@ async function registerWithDaemon({
   if (!reply.ok) return { state: 'unavailable', reason: reply.reason }
   return {
     state: 'registered',
-    control: { url: `http://${CONTAINER_HOSTD_HOST}:${ensured.httpPort}`, token, brokerToken },
+    control: { url: `http://${CONTAINER_HOSTD_HOST}:${prepared.httpPort}`, token, brokerToken },
   }
+}
+
+async function useCurrentHostDaemon(): Promise<{ ok: true; httpPort: number } | { ok: false; reason: string }> {
+  const reply = await sendToDaemon({ kind: 'http-info' })
+  if (!reply.ok) return { ok: false, reason: reply.reason }
+  const result = reply.result as HttpInfoResult | undefined
+  if (typeof result?.port !== 'number' || result.port <= 0 || result.port > 65_535) {
+    return { ok: false, reason: 'daemon did not report an HTTP control port' }
+  }
+  return { ok: true, httpPort: result.port }
 }
 
 async function loadConfigJson(cwd: string): Promise<unknown> {


### PR DESCRIPTION
## Summary
- Add a current-hostd registration path so daemon-owned container restarts can reuse the already-running hostd instead of triggering version-drift shutdown.
- Wire `_hostd` supervisor restarts through that path, preventing the daemon from exiting mid `stop`/`start` when disk source is newer.
- Cover both the container registration behavior and hostd restart wiring with focused tests.

## Verification
- `bun run lint`
- `bun run format:check`
- `bun typecheck`
- `bun run test` (1342 pass)
- Focused restart tests: `bun test src/cli/hostd.test.ts src/container/start.test.ts src/hostd/spawn.test.ts src/hostd/daemon.test.ts src/agent/tools/restart.test.ts` (86 pass)