### PR TITLE
Include channel context in memory logs

### DIFF
--- a/plugins/memory/index.test.ts
+++ b/plugins/memory/index.test.ts
@@ -150,6 +150,41 @@ describe('session.idle hook (debouncer)', () => {
     })
   })
 
+  test('passes conversation origin to memory-logger payload', async () => {
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 1000 })
+    const origin: SessionIdleEvent['origin'] = {
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T123',
+      workspaceName: 'Acme',
+      chat: 'C456',
+      chatName: 'infra',
+      thread: '171234.0001',
+      lastInboundAuthorId: 'U1',
+      participants: [
+        {
+          authorId: 'U1',
+          authorName: 'Neo',
+          firstMessageAt: 1000,
+          lastMessageAt: 2000,
+          messageCount: 2,
+        },
+      ],
+    }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: '/tmp/t.jsonl', idleMs: 0, origin }
+
+    await exports.hooks!['session.idle']!(event, { agentDir, pluginName: 'memory', logger: createPluginLogger('m') })
+    await new Promise((r) => setTimeout(r, 1100))
+
+    expect(spawned).toHaveLength(1)
+    expect(spawned[0]!.payload).toEqual({
+      parentSessionId: 'ses_a',
+      parentTranscriptPath: '/tmp/t.jsonl',
+      agentDir,
+      origin,
+    })
+  })
+
   test('rapid idle events debounce: only one spawn after the LAST idle + idleMs', async () => {
     const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 1000 })
     const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }

--- a/plugins/memory/index.ts
+++ b/plugins/memory/index.ts
@@ -3,6 +3,7 @@ import { stat } from 'node:fs/promises'
 import { CronExpressionParser } from 'cron-parser'
 import { z } from 'zod'
 
+import type { SessionOrigin } from '@/agent/session-origin'
 import { definePlugin } from '@/plugin'
 
 import { createDreamingSubagent, type DreamingPayload } from './dreaming'
@@ -65,7 +66,7 @@ export default definePlugin({
     const dreamingSchedule = ctx.config.dreaming?.schedule ?? DEFAULT_DREAMING_SCHEDULE
 
     const idleTimers = new Map<string, ReturnType<typeof setTimeout>>()
-    const lastIdleEvent = new Map<string, { parentTranscriptPath: string | undefined }>()
+    const lastIdleEvent = new Map<string, { parentTranscriptPath: string | undefined; origin?: SessionOrigin }>()
     const bytesAtLastRun = new Map<string, number>()
 
     const fireMemoryLogger = async (
@@ -78,6 +79,7 @@ export default definePlugin({
         parentSessionId: sessionId,
         parentTranscriptPath: last.parentTranscriptPath,
         agentDir: ctx.agentDir,
+        ...(last.origin !== undefined ? { origin: last.origin } : {}),
       }
       const currentSize = await readSize(last.parentTranscriptPath)
       bytesAtLastRun.set(sessionId, currentSize)
@@ -145,7 +147,10 @@ export default definePlugin({
         // grown by `bufferBytes` since the last run, so busy channel sessions
         // (which rarely go idle) still produce memory updates.
         'session.idle': async (event) => {
-          lastIdleEvent.set(event.sessionId, { parentTranscriptPath: event.parentTranscriptPath })
+          lastIdleEvent.set(event.sessionId, {
+            parentTranscriptPath: event.parentTranscriptPath,
+            ...(event.origin !== undefined ? { origin: event.origin } : {}),
+          })
           cancelTimer(event.sessionId)
           const sessionId = event.sessionId
           const timer = setTimeout(() => {

--- a/plugins/memory/memory-logger.test.ts
+++ b/plugins/memory/memory-logger.test.ts
@@ -53,6 +53,35 @@ describe('isMemoryLoggerPayload', () => {
     ).toBe(true)
   })
 
+  test('accepts a payload with channel origin context', () => {
+    expect(
+      isMemoryLoggerPayload({
+        parentSessionId: 'ses_abc',
+        parentTranscriptPath: '/path/to/file.jsonl',
+        agentDir: '/path/to/agent',
+        origin: {
+          kind: 'channel',
+          adapter: 'slack-bot',
+          workspace: 'T123',
+          workspaceName: 'Acme',
+          chat: 'C456',
+          chatName: 'infra',
+          thread: '171234.0001',
+          lastInboundAuthorId: 'U1',
+          participants: [
+            {
+              authorId: 'U1',
+              authorName: 'Neo',
+              firstMessageAt: 1000,
+              lastMessageAt: 2000,
+              messageCount: 2,
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
   test('rejects when fields are missing', () => {
     expect(isMemoryLoggerPayload({})).toBe(false)
     expect(isMemoryLoggerPayload({ parentSessionId: '', parentTranscriptPath: 'b', agentDir: 'c' })).toBe(false)
@@ -133,6 +162,49 @@ describe('memoryLoggerSubagent', () => {
     expect(prompt).toContain(transcript)
     expect(prompt).toContain('ses_abc')
     expect(prompt).toMatch(/memory\/\d{4}-\d{2}-\d{2}\.md/)
+  })
+
+  test('handler includes channel location and participants in the initial prompt', async () => {
+    const agentDir = makeAgentDir()
+    const transcript = join(agentDir, 'sessions', 'ses_abc.jsonl')
+    writeFileSync(transcript, '')
+
+    const { runSessionCalls } = await invokeWith(
+      {
+        parentSessionId: 'ses_abc',
+        parentTranscriptPath: transcript,
+        agentDir,
+        origin: {
+          kind: 'channel',
+          adapter: 'slack-bot',
+          workspace: 'T123',
+          workspaceName: 'Acme',
+          chat: 'C456',
+          chatName: 'infra',
+          thread: '171234.0001',
+          lastInboundAuthorId: 'U1',
+          participants: [
+            {
+              authorId: 'U1',
+              authorName: 'Neo',
+              firstMessageAt: 1000,
+              lastMessageAt: 2000,
+              messageCount: 2,
+            },
+          ],
+        },
+      },
+      agentDir,
+    )
+
+    const prompt = runSessionCalls[0]!.userPrompt!
+    expect(prompt).toContain('Conversation context:')
+    expect(prompt).toContain('- Adapter: slack-bot')
+    expect(prompt).toContain('- Workspace: Acme (T123)')
+    expect(prompt).toContain('- Chat: infra (C456)')
+    expect(prompt).toContain('- Thread: 171234.0001')
+    expect(prompt).toContain('- Last inbound author: U1')
+    expect(prompt).toContain('Neo (U1); messages=2')
   })
 
   test('handler includes the watermark when one exists in the daily stream', async () => {

--- a/plugins/memory/memory-logger.ts
+++ b/plugins/memory/memory-logger.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 
 import { z } from 'zod'
 
+import type { SessionOrigin } from '@/agent/session-origin'
 import { type Subagent, readTool } from '@/plugin'
 import { formatLocalDate } from '@/shared'
 
@@ -12,6 +13,7 @@ export const memoryLoggerPayloadSchema = z.object({
   parentSessionId: z.string().min(1),
   parentTranscriptPath: z.string().min(1),
   agentDir: z.string().min(1),
+  origin: z.custom<SessionOrigin>().optional(),
 })
 
 export type MemoryLoggerPayload = z.infer<typeof memoryLoggerPayloadSchema>
@@ -93,6 +95,8 @@ The body is the substance of the fragment. The form is flexible, but every body 
 1. **Self-contained.** A future agent reads this without the transcript open. Replace pronouns with names. Include enough context that the fragment stands alone.
 2. **Anchored to evidence.** Somewhere in the body, point at what makes this true: a quote from the transcript, an enumerated set of occurrences, the explicit premise you reasoned from. Specifics survive — "the build broke on line 42 of vite.config.ts" beats "the build broke somewhere." If a fragment has no anchor at all, don't write it.
 
+When the user prompt includes a Conversation context section, use it to make fragments self-contained: mention the relevant adapter, workspace/chat/thread, and participant names/IDs when that location or participant set matters to the memory. Do not paste the full context into every fragment mechanically; include only the fields that help a future agent understand where the event happened and who was involved.
+
 Useful body shapes (pick whichever fits — none is mandatory):
 
 - **Plain prose.** A few sentences. Often the right shape for a stable fact, a decision, or an observed reaction.
@@ -125,6 +129,8 @@ function buildInitialPrompt(payload: MemoryLoggerPayload, streamFile: string, wa
     `Daily stream file: ${streamFile}`,
     `Long-term memory file: ${join(payload.agentDir, 'MEMORY.md')}`,
   ]
+  const conversationContext = renderConversationContext(payload.origin)
+  if (conversationContext !== null) lines.push('', conversationContext)
   if (watermark === null) {
     lines.push('Watermark: none (no prior fragments for this session — read the transcript from the start)')
   } else {
@@ -139,6 +145,34 @@ function buildInitialPrompt(payload: MemoryLoggerPayload, streamFile: string, wa
       ' entry=<latestEntryId> -->` to the daily stream file recording the latest entry id you evaluated, then stop. Never exit without either a new fragment or a new watermark marker.',
   )
   return lines.join('\n')
+}
+
+function renderConversationContext(origin: SessionOrigin | undefined): string | null {
+  if (origin === undefined) return null
+  if (origin.kind !== 'channel') return ['Conversation context:', `- Origin: ${origin.kind}`].join('\n')
+
+  const lines = [
+    'Conversation context:',
+    `- Adapter: ${origin.adapter}`,
+    `- Workspace: ${formatNamedId(origin.workspace, origin.workspaceName)}`,
+    `- Chat: ${formatNamedId(origin.chat, origin.chatName)}`,
+    `- Thread: ${origin.thread ?? '(channel root)'}`,
+  ]
+  if (origin.lastInboundAuthorId !== undefined) lines.push(`- Last inbound author: ${origin.lastInboundAuthorId}`)
+  if (origin.participants !== undefined && origin.participants.length > 0) {
+    lines.push('- Participants:')
+    for (const participant of origin.participants) {
+      const botLabel = participant.isBot === true ? ' bot' : ''
+      lines.push(
+        `  - ${participant.authorName} (${participant.authorId})${botLabel}; messages=${participant.messageCount}`,
+      )
+    }
+  }
+  return lines.join('\n')
+}
+
+function formatNamedId(id: string, name: string | undefined): string {
+  return name === undefined ? id : `${name} (${id})`
 }
 
 export type MemoryLoggerLogger = {

--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -140,8 +140,22 @@ describe('createResourceLoader', () => {
     expect(configSkill?.description.length).toBeGreaterThan(0)
   })
 
-  test('exposes the agent-browser bundled skill to the agent', async () => {
-    const loader = await createResourceLoader({ agentDir })
+  test('exposes the agent-browser bundled plugin skill to the agent', async () => {
+    const hooks = createHookBus()
+    const registry: PluginRegistry = {
+      tools: [],
+      subagents: [],
+      cronJobs: [],
+      skills: [],
+      skillsDirs: [
+        { pluginName: 'agent-browser', path: join(import.meta.dir, '..', '..', 'plugins', 'agent-browser', 'skills') },
+      ],
+    }
+
+    const loader = await createResourceLoader({
+      agentDir,
+      plugins: { registry, hooks, sessionId: 'test-session', agentDir },
+    })
 
     const { skills } = loader.getSkills()
     const browserSkill = skills.find((s) => s.name === 'agent-browser')

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -8,7 +8,7 @@ import type { SessionEntry } from '@mariozechner/pi-coding-agent'
 
 import type { AgentSession } from '@/agent'
 import type { SessionOrigin } from '@/agent/session-origin'
-import type { HookBus } from '@/plugin'
+import type { HookBus, SessionIdleEvent } from '@/plugin'
 
 import { channelsSessionsPath, loadChannelSessions, saveChannelSessions } from './persistence'
 import { createChannelRouter, SESSION_IDLE_MS, sliceHeadTail, type ChannelRouter } from './router'
@@ -932,6 +932,77 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     // then
     expect(sessions[0]!.prompts).toHaveLength(1)
     expect(events).toEqual(['idle:ses_fake_1:/tmp/t.jsonl'])
+  })
+
+  test('passes current channel origin and participants to session.idle', async () => {
+    // given
+    const dir = await tempDir()
+    const idleEvents: SessionIdleEvent[] = []
+    const hooks: HookBus = {
+      registerAll: () => {},
+      unregisterAll: () => {},
+      runSessionStart: async () => {},
+      runSessionEnd: async () => {},
+      runSessionIdle: async (e) => {
+        idleEvents.push(e)
+      },
+      runSessionPrompt: async () => {},
+      runToolBefore: async () => undefined,
+      runToolAfter: async () => {},
+      count: () => 0,
+    }
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      now: () => 5000,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      createSessionForChannel: async () => ({
+        session: new FakeSession() as unknown as AgentSession,
+        sessionId: 'ses_fake_1',
+        dispose: async () => {},
+        hooks,
+        getTranscriptPath: () => '/tmp/t.jsonl',
+      }),
+    })
+
+    // when
+    await router.route(
+      inbound({
+        adapter: 'slack-bot',
+        workspace: 'T123',
+        chat: 'C456',
+        thread: '171234.0001',
+        authorId: 'U1',
+        authorName: 'Neo',
+      }),
+    )
+    await router.__testing!.flushDebounce({
+      adapter: 'slack-bot',
+      workspace: 'T123',
+      chat: 'C456',
+      thread: '171234.0001',
+    })
+
+    // then
+    expect(idleEvents).toHaveLength(1)
+    expect(idleEvents[0]!.origin).toEqual({
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T123',
+      chat: 'C456',
+      thread: '171234.0001',
+      lastInboundAuthorId: 'U1',
+      participants: [
+        {
+          authorId: 'U1',
+          authorName: 'Neo',
+          firstMessageAt: 5000,
+          lastMessageAt: 5000,
+          messageCount: 1,
+          isBot: false,
+        },
+      ],
+    })
   })
 
   test('fires session.idle even when prompt throws so plugins still wake up', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -559,11 +559,24 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         sessionId: live.sessionId,
         parentTranscriptPath: live.getTranscriptPath?.(),
         idleMs: 0,
+        origin: buildLiveOrigin(live),
       })
     } catch (err) {
       logger.warn(`[channels] session.idle hook threw for ${live.keyId}: ${describe(err)}`)
     }
   }
+
+  const buildLiveOrigin = (live: LiveSession): SessionOrigin => ({
+    kind: 'channel',
+    adapter: live.key.adapter,
+    workspace: live.key.workspace,
+    ...(live.resolvedNames.workspaceName !== undefined ? { workspaceName: live.resolvedNames.workspaceName } : {}),
+    chat: live.key.chat,
+    ...(live.resolvedNames.chatName !== undefined ? { chatName: live.resolvedNames.chatName } : {}),
+    thread: live.key.thread,
+    ...(live.currentTurnAuthorId !== null ? { lastInboundAuthorId: live.currentTurnAuthorId } : {}),
+    participants: live.participants,
+  })
 
   const fireSessionEnd = async (live: LiveSession): Promise<void> => {
     if (!live.hooks) return

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -1,5 +1,7 @@
 import type { z } from 'zod'
 
+import type { SessionOrigin } from '@/agent/session-origin'
+
 export type ContentPart = { type: 'text'; text: string } | { type: 'image'; mimeType: string; data: string }
 
 export type ToolResult = {
@@ -92,6 +94,7 @@ export type SessionIdleEvent = {
   sessionId: string
   parentTranscriptPath: string | undefined
   idleMs: number
+  origin?: SessionOrigin
 }
 
 // Provider prompt caching requires byte-identical prefixes. Mutations near the

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,6 +6,7 @@ import {
   type CreateSessionOptions,
   type CreateSessionResult,
 } from '@/agent'
+import type { SessionOrigin } from '@/agent/session-origin'
 import type { ChannelRouter } from '@/channels/router'
 import type { HookBus } from '@/plugin'
 import type { BrokerWsData, ContainerBroker } from '@/portbroker'
@@ -52,6 +53,7 @@ type QueuedPrompt = {
 type SessionState = {
   session: AgentSession
   sessionFileId: string
+  origin: SessionOrigin
   sessionManager: { getSessionFile: () => string | undefined } | undefined
   drainQueue: QueuedPrompt[]
   draining: boolean
@@ -122,10 +124,11 @@ export function createServer({
                   agentDir,
                 }
               : undefined
+          const origin: SessionOrigin = { kind: 'tui', sessionId: sessionFileId }
           const result = await createSession({
             reloadRegistry,
             sessionManager,
-            origin: { kind: 'tui', sessionId: sessionFileId },
+            origin,
             ...(stream ? { stream } : {}),
             ...(channelRouter ? { channelRouter } : {}),
             ...(pluginsWiring ? { plugins: pluginsWiring } : {}),
@@ -137,6 +140,7 @@ export function createServer({
           const state: SessionState = {
             session,
             sessionFileId,
+            origin,
             sessionManager,
             drainQueue: [],
             draining: false,
@@ -329,6 +333,7 @@ function makeIdleHookCaller(state: SessionState): () => Promise<void> {
       sessionId: state.sessionFileId,
       parentTranscriptPath: state.sessionManager?.getSessionFile(),
       idleMs: 0,
+      origin: state.origin,
     })
   }
 }


### PR DESCRIPTION
## Summary
- Carry `SessionOrigin` through `session.idle` events so plugins can see where a completed prompt came from.
- Pass fresh channel adapter/workspace/chat/thread and participant context from the channel router into memory logging.
- Render conversation context in the memory-logger prompt so fragments can record location and participants when relevant.

## Verification
- `bun test plugins/memory/index.test.ts plugins/memory/memory-logger.test.ts src/channels/router.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format`
- `bun run lint && bun run format:check && bun typecheck && bun run test`

## Notes
- Implemented in worktree: `/tmp/typeclaw-memory-context`
- Oracle review found no PR-blocking issues; optional future polish includes stronger runtime validation of `origin` and participant bounding.