### PR TITLE
Add guard acknowledgements for workspace writes

### DIFF
--- a/plugins/guard/index.test.ts
+++ b/plugins/guard/index.test.ts
@@ -71,10 +71,35 @@ describe('guard plugin', () => {
   test('allows known writable files at the agent root', async () => {
     const hook = await toolBeforeHook()
 
-    for (const file of ['AGENTS.md', 'IDENTITY.md', 'MEMORY.md', 'SOUL.md', 'USER.md', 'cron.json', 'typeclaw.json']) {
+    for (const file of [
+      'AGENTS.md',
+      'IDENTITY.md',
+      'MEMORY.md',
+      'SOUL.md',
+      'USER.md',
+      'cron.json',
+      'package.json',
+      'typeclaw.json',
+    ]) {
       const result = await hook(toolEvent('write', { path: file, content: 'x' }), hookContext('/agent'))
       expect(result).toBeUndefined()
     }
+  })
+
+  test('allows writes under the agent root mounts directory', async () => {
+    const hook = await toolBeforeHook()
+
+    const relativeResult = await hook(
+      toolEvent('write', { path: 'mounts/data/file.txt', content: 'x' }),
+      hookContext('/agent'),
+    )
+    const absoluteResult = await hook(
+      toolEvent('edit', { path: '/agent/mounts/config.json', edits: [{ oldText: 'x', newText: 'y' }] }),
+      hookContext('/agent'),
+    )
+
+    expect(relativeResult).toBeUndefined()
+    expect(absoluteResult).toBeUndefined()
   })
 
   test('still blocks unknown files and nested paths under allowed root names', async () => {

--- a/plugins/guard/index.test.ts
+++ b/plugins/guard/index.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, mkdir, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import type { HookContext, PluginContext, ToolBeforeEvent } from '@/plugin'
+
+import guardPlugin from './index'
+
+const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
+
+describe('guard plugin', () => {
+  test('blocks write calls outside workspace until nonWorkspaceWrite is acknowledged', async () => {
+    const hook = await toolBeforeHook()
+
+    const blocked = await hook(toolEvent('write', { path: 'typeclaw.json', content: '{}' }), hookContext('/agent'))
+    const acknowledged = await hook(
+      toolEvent('write', {
+        path: 'typeclaw.json',
+        content: '{}',
+        acknowledgeGuards: { nonWorkspaceWrite: true },
+      }),
+      hookContext('/agent'),
+    )
+
+    expect(blocked).toEqual({
+      block: true,
+      reason:
+        'Guard `nonWorkspaceWrite` blocked write outside the workspace: /agent/typeclaw.json. The free-write zone is /agent/workspace. Retry with `acknowledgeGuards.nonWorkspaceWrite: true` only if this write is intentional.',
+    })
+    expect(acknowledged).toBeUndefined()
+  })
+
+  test('allows write and edit calls inside workspace', async () => {
+    const hook = await toolBeforeHook()
+
+    const writeResult = await hook(
+      toolEvent('write', { path: 'workspace/file.txt', content: 'x' }),
+      hookContext('/agent'),
+    )
+    const editResult = await hook(
+      toolEvent('edit', { path: '/agent/workspace/file.txt', edits: [{ oldText: 'x', newText: 'y' }] }),
+      hookContext('/agent'),
+    )
+
+    expect(writeResult).toBeUndefined()
+    expect(editResult).toBeUndefined()
+  })
+
+  test('blocks lexical workspace escapes and workspace-like sibling paths', async () => {
+    const hook = await toolBeforeHook()
+
+    const dotDotResult = await hook(
+      toolEvent('write', { path: 'workspace/../typeclaw.json', content: '{}' }),
+      hookContext('/agent'),
+    )
+    const siblingResult = await hook(
+      toolEvent('write', { path: 'workspace2/file.txt', content: 'x' }),
+      hookContext('/agent'),
+    )
+    const absoluteResult = await hook(
+      toolEvent('write', { path: '/tmp/outside.txt', content: 'x' }),
+      hookContext('/agent'),
+    )
+
+    expect(dotDotResult?.block).toBe(true)
+    expect(siblingResult?.block).toBe(true)
+    expect(absoluteResult?.block).toBe(true)
+  })
+
+  test('blocks workspace symlinks that escape the real workspace directory', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'typeclaw-guard-'))
+    const agentDir = path.join(root, 'agent')
+    const workspaceDir = path.join(agentDir, 'workspace')
+    const outsideDir = path.join(root, 'outside')
+    await mkdir(workspaceDir, { recursive: true })
+    await mkdir(outsideDir)
+    await symlink(outsideDir, path.join(workspaceDir, 'outside-link'))
+    const hook = await toolBeforeHook()
+
+    const result = await hook(
+      toolEvent('write', { path: 'workspace/outside-link/file.txt', content: 'x' }),
+      hookContext(agentDir),
+    )
+
+    expect(result?.block).toBe(true)
+  })
+
+  test('ignores non-mutating tools and invalid paths', async () => {
+    const hook = await toolBeforeHook()
+
+    const readResult = await hook(toolEvent('read', { path: 'typeclaw.json' }), hookContext('/agent'))
+    const invalidPathResult = await hook(toolEvent('write', { path: 42, content: 'x' }), hookContext('/agent'))
+
+    expect(readResult).toBeUndefined()
+    expect(invalidPathResult).toBeUndefined()
+  })
+})
+
+async function toolBeforeHook(): Promise<
+  NonNullable<NonNullable<Awaited<ReturnType<typeof guardPlugin.plugin>>['hooks']>['tool.before']>
+> {
+  const exports = await guardPlugin.plugin(pluginContext('/agent'))
+  const hook = exports.hooks?.['tool.before']
+  if (!hook) throw new Error('guard plugin did not register tool.before')
+  return hook
+}
+
+function toolEvent(tool: string, args: Record<string, unknown>): ToolBeforeEvent {
+  return { tool, sessionId: 's', callId: 'c', args }
+}
+
+function hookContext(agentDir: string): HookContext {
+  return { agentDir, pluginName: 'guard', logger: noopLogger }
+}
+
+function pluginContext(agentDir: string): PluginContext<undefined> {
+  return {
+    name: 'guard',
+    version: undefined,
+    agentDir,
+    config: undefined,
+    logger: noopLogger,
+    spawnSubagent: async () => {},
+  }
+}

--- a/plugins/guard/index.test.ts
+++ b/plugins/guard/index.test.ts
@@ -13,10 +13,10 @@ describe('guard plugin', () => {
   test('blocks write calls outside workspace until nonWorkspaceWrite is acknowledged', async () => {
     const hook = await toolBeforeHook()
 
-    const blocked = await hook(toolEvent('write', { path: 'typeclaw.json', content: '{}' }), hookContext('/agent'))
+    const blocked = await hook(toolEvent('write', { path: 'notes.md', content: '{}' }), hookContext('/agent'))
     const acknowledged = await hook(
       toolEvent('write', {
-        path: 'typeclaw.json',
+        path: 'notes.md',
         content: '{}',
         acknowledgeGuards: { nonWorkspaceWrite: true },
       }),
@@ -26,7 +26,7 @@ describe('guard plugin', () => {
     expect(blocked).toEqual({
       block: true,
       reason:
-        'Guard `nonWorkspaceWrite` blocked write outside the workspace: /agent/typeclaw.json. The free-write zone is /agent/workspace. Retry with `acknowledgeGuards.nonWorkspaceWrite: true` only if this write is intentional.',
+        'Guard `nonWorkspaceWrite` blocked write outside the workspace: /agent/notes.md. The free-write zone is /agent/workspace. Retry with `acknowledgeGuards.nonWorkspaceWrite: true` only if this write is intentional.',
     })
     expect(acknowledged).toBeUndefined()
   })
@@ -51,7 +51,7 @@ describe('guard plugin', () => {
     const hook = await toolBeforeHook()
 
     const dotDotResult = await hook(
-      toolEvent('write', { path: 'workspace/../typeclaw.json', content: '{}' }),
+      toolEvent('write', { path: 'workspace/../notes.md', content: '{}' }),
       hookContext('/agent'),
     )
     const siblingResult = await hook(
@@ -66,6 +66,28 @@ describe('guard plugin', () => {
     expect(dotDotResult?.block).toBe(true)
     expect(siblingResult?.block).toBe(true)
     expect(absoluteResult?.block).toBe(true)
+  })
+
+  test('allows known writable files at the agent root', async () => {
+    const hook = await toolBeforeHook()
+
+    for (const file of ['AGENTS.md', 'IDENTITY.md', 'MEMORY.md', 'SOUL.md', 'USER.md', 'cron.json', 'typeclaw.json']) {
+      const result = await hook(toolEvent('write', { path: file, content: 'x' }), hookContext('/agent'))
+      expect(result).toBeUndefined()
+    }
+  })
+
+  test('still blocks unknown files and nested paths under allowed root names', async () => {
+    const hook = await toolBeforeHook()
+
+    const unknownRoot = await hook(toolEvent('write', { path: 'notes.md', content: 'x' }), hookContext('/agent'))
+    const nestedUnderAllowedName = await hook(
+      toolEvent('write', { path: 'AGENTS.md/nested.txt', content: 'x' }),
+      hookContext('/agent'),
+    )
+
+    expect(unknownRoot?.block).toBe(true)
+    expect(nestedUnderAllowedName?.block).toBe(true)
   })
 
   test('blocks workspace symlinks that escape the real workspace directory', async () => {

--- a/plugins/guard/index.ts
+++ b/plugins/guard/index.ts
@@ -1,0 +1,12 @@
+import { definePlugin } from '@/plugin'
+
+import { checkNonWorkspaceWriteGuard } from './policy'
+
+export default definePlugin({
+  plugin: async () => ({
+    hooks: {
+      'tool.before': (event, ctx) =>
+        checkNonWorkspaceWriteGuard({ tool: event.tool, args: event.args, agentDir: ctx.agentDir }),
+    },
+  }),
+})

--- a/plugins/guard/policies/non-workspace-write.ts
+++ b/plugins/guard/policies/non-workspace-write.ts
@@ -12,8 +12,11 @@ const AGENT_ROOT_WRITE_ALLOWLIST = new Set([
   'SOUL.md',
   'USER.md',
   'cron.json',
+  'package.json',
   'typeclaw.json',
 ])
+
+const AGENT_ROOT_DIRECTORY_ALLOWLIST = new Set(['mounts'])
 
 export async function checkNonWorkspaceWriteGuard(options: {
   tool: string
@@ -28,12 +31,11 @@ export async function checkNonWorkspaceWriteGuard(options: {
 
   const targetPath = path.resolve(agentDir, rawPath)
   const workspacePath = path.resolve(agentDir, 'workspace')
-  if (isAllowedAgentRootWrite(agentDir, targetPath)) return undefined
-
   const [realTargetPath, realWorkspacePath] = await Promise.all([
     resolveRealIntendedPath(targetPath),
     resolveRealIntendedPath(workspacePath),
   ])
+  if (await isAllowedAgentRootWrite(agentDir, targetPath, realTargetPath)) return undefined
   if (isInside(realWorkspacePath, realTargetPath)) return undefined
   if (isGuardAcknowledged(args, GUARD_NON_WORKSPACE_WRITE)) return undefined
 
@@ -47,10 +49,17 @@ export async function checkNonWorkspaceWriteGuard(options: {
   }
 }
 
-function isAllowedAgentRootWrite(agentDir: string, targetPath: string): boolean {
-  return (
-    path.dirname(targetPath) === path.resolve(agentDir) && AGENT_ROOT_WRITE_ALLOWLIST.has(path.basename(targetPath))
-  )
+async function isAllowedAgentRootWrite(agentDir: string, targetPath: string, realTargetPath: string): Promise<boolean> {
+  const resolvedAgentDir = path.resolve(agentDir)
+  if (path.dirname(targetPath) === resolvedAgentDir && AGENT_ROOT_WRITE_ALLOWLIST.has(path.basename(targetPath))) {
+    return true
+  }
+
+  for (const dir of AGENT_ROOT_DIRECTORY_ALLOWLIST) {
+    const rootDir = path.join(resolvedAgentDir, dir)
+    if (isInside(await resolveRealIntendedPath(rootDir), realTargetPath)) return true
+  }
+  return false
 }
 
 function isInside(parent: string, child: string): boolean {

--- a/plugins/guard/policies/non-workspace-write.ts
+++ b/plugins/guard/policies/non-workspace-write.ts
@@ -1,0 +1,82 @@
+import { realpath } from 'node:fs/promises'
+import path from 'node:path'
+
+import { ACKNOWLEDGE_GUARDS, type GuardBlock, isGuardAcknowledged } from '../policy'
+
+export const GUARD_NON_WORKSPACE_WRITE = 'nonWorkspaceWrite'
+
+const AGENT_ROOT_WRITE_ALLOWLIST = new Set([
+  'AGENTS.md',
+  'IDENTITY.md',
+  'MEMORY.md',
+  'SOUL.md',
+  'USER.md',
+  'cron.json',
+  'typeclaw.json',
+])
+
+export async function checkNonWorkspaceWriteGuard(options: {
+  tool: string
+  args: Record<string, unknown>
+  agentDir: string
+}): Promise<GuardBlock | undefined> {
+  const { tool, args, agentDir } = options
+  if (tool !== 'write' && tool !== 'edit') return undefined
+
+  const rawPath = args.path
+  if (typeof rawPath !== 'string') return undefined
+
+  const targetPath = path.resolve(agentDir, rawPath)
+  const workspacePath = path.resolve(agentDir, 'workspace')
+  if (isAllowedAgentRootWrite(agentDir, targetPath)) return undefined
+
+  const [realTargetPath, realWorkspacePath] = await Promise.all([
+    resolveRealIntendedPath(targetPath),
+    resolveRealIntendedPath(workspacePath),
+  ])
+  if (isInside(realWorkspacePath, realTargetPath)) return undefined
+  if (isGuardAcknowledged(args, GUARD_NON_WORKSPACE_WRITE)) return undefined
+
+  return {
+    block: true,
+    reason: [
+      `Guard \`${GUARD_NON_WORKSPACE_WRITE}\` blocked ${tool} outside the workspace: ${targetPath}.`,
+      `The free-write zone is ${workspacePath}.`,
+      `Retry with \`${ACKNOWLEDGE_GUARDS}.${GUARD_NON_WORKSPACE_WRITE}: true\` only if this write is intentional.`,
+    ].join(' '),
+  }
+}
+
+function isAllowedAgentRootWrite(agentDir: string, targetPath: string): boolean {
+  return (
+    path.dirname(targetPath) === path.resolve(agentDir) && AGENT_ROOT_WRITE_ALLOWLIST.has(path.basename(targetPath))
+  )
+}
+
+function isInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child)
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+async function resolveRealIntendedPath(absolutePath: string): Promise<string> {
+  const pending: string[] = []
+  let current = absolutePath
+
+  while (true) {
+    try {
+      const realCurrent = await realpath(current)
+      return path.join(realCurrent, ...pending.reverse())
+    } catch (err) {
+      if (!isNotFoundError(err)) throw err
+    }
+
+    const parent = path.dirname(current)
+    if (parent === current) throw new Error(`could not resolve existing parent for ${absolutePath}`)
+    pending.push(path.basename(current))
+    current = parent
+  }
+}
+
+function isNotFoundError(err: unknown): boolean {
+  return err instanceof Error && 'code' in err && err.code === 'ENOENT'
+}

--- a/plugins/guard/policy.ts
+++ b/plugins/guard/policy.ts
@@ -1,40 +1,6 @@
-import { realpath } from 'node:fs/promises'
-import path from 'node:path'
-
 export const ACKNOWLEDGE_GUARDS = 'acknowledgeGuards'
-export const GUARD_NON_WORKSPACE_WRITE = 'nonWorkspaceWrite'
 
 export type GuardBlock = { block: true; reason: string }
-
-export async function checkNonWorkspaceWriteGuard(options: {
-  tool: string
-  args: Record<string, unknown>
-  agentDir: string
-}): Promise<GuardBlock | undefined> {
-  const { tool, args, agentDir } = options
-  if (tool !== 'write' && tool !== 'edit') return undefined
-
-  const rawPath = args.path
-  if (typeof rawPath !== 'string') return undefined
-
-  const targetPath = path.resolve(agentDir, rawPath)
-  const workspacePath = path.resolve(agentDir, 'workspace')
-  const [realTargetPath, realWorkspacePath] = await Promise.all([
-    resolveRealIntendedPath(targetPath),
-    resolveRealIntendedPath(workspacePath),
-  ])
-  if (isInside(realWorkspacePath, realTargetPath)) return undefined
-  if (isGuardAcknowledged(args, GUARD_NON_WORKSPACE_WRITE)) return undefined
-
-  return {
-    block: true,
-    reason: [
-      `Guard \`${GUARD_NON_WORKSPACE_WRITE}\` blocked ${tool} outside the workspace: ${targetPath}.`,
-      `The free-write zone is ${workspacePath}.`,
-      `Retry with \`${ACKNOWLEDGE_GUARDS}.${GUARD_NON_WORKSPACE_WRITE}: true\` only if this write is intentional.`,
-    ].join(' '),
-  }
-}
 
 export function isGuardAcknowledged(args: Record<string, unknown>, guard: string): boolean {
   const acknowledgements = args[ACKNOWLEDGE_GUARDS]
@@ -42,30 +8,4 @@ export function isGuardAcknowledged(args: Record<string, unknown>, guard: string
   return (acknowledgements as Record<string, unknown>)[guard] === true
 }
 
-function isInside(parent: string, child: string): boolean {
-  const relative = path.relative(parent, child)
-  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
-}
-
-async function resolveRealIntendedPath(absolutePath: string): Promise<string> {
-  const pending: string[] = []
-  let current = absolutePath
-
-  while (true) {
-    try {
-      const realCurrent = await realpath(current)
-      return path.join(realCurrent, ...pending.reverse())
-    } catch (err) {
-      if (!isNotFoundError(err)) throw err
-    }
-
-    const parent = path.dirname(current)
-    if (parent === current) throw new Error(`could not resolve existing parent for ${absolutePath}`)
-    pending.push(path.basename(current))
-    current = parent
-  }
-}
-
-function isNotFoundError(err: unknown): boolean {
-  return err instanceof Error && 'code' in err && err.code === 'ENOENT'
-}
+export { GUARD_NON_WORKSPACE_WRITE, checkNonWorkspaceWriteGuard } from './policies/non-workspace-write'

--- a/plugins/guard/policy.ts
+++ b/plugins/guard/policy.ts
@@ -1,0 +1,71 @@
+import { realpath } from 'node:fs/promises'
+import path from 'node:path'
+
+export const ACKNOWLEDGE_GUARDS = 'acknowledgeGuards'
+export const GUARD_NON_WORKSPACE_WRITE = 'nonWorkspaceWrite'
+
+export type GuardBlock = { block: true; reason: string }
+
+export async function checkNonWorkspaceWriteGuard(options: {
+  tool: string
+  args: Record<string, unknown>
+  agentDir: string
+}): Promise<GuardBlock | undefined> {
+  const { tool, args, agentDir } = options
+  if (tool !== 'write' && tool !== 'edit') return undefined
+
+  const rawPath = args.path
+  if (typeof rawPath !== 'string') return undefined
+
+  const targetPath = path.resolve(agentDir, rawPath)
+  const workspacePath = path.resolve(agentDir, 'workspace')
+  const [realTargetPath, realWorkspacePath] = await Promise.all([
+    resolveRealIntendedPath(targetPath),
+    resolveRealIntendedPath(workspacePath),
+  ])
+  if (isInside(realWorkspacePath, realTargetPath)) return undefined
+  if (isGuardAcknowledged(args, GUARD_NON_WORKSPACE_WRITE)) return undefined
+
+  return {
+    block: true,
+    reason: [
+      `Guard \`${GUARD_NON_WORKSPACE_WRITE}\` blocked ${tool} outside the workspace: ${targetPath}.`,
+      `The free-write zone is ${workspacePath}.`,
+      `Retry with \`${ACKNOWLEDGE_GUARDS}.${GUARD_NON_WORKSPACE_WRITE}: true\` only if this write is intentional.`,
+    ].join(' '),
+  }
+}
+
+export function isGuardAcknowledged(args: Record<string, unknown>, guard: string): boolean {
+  const acknowledgements = args[ACKNOWLEDGE_GUARDS]
+  if (!acknowledgements || typeof acknowledgements !== 'object') return false
+  return (acknowledgements as Record<string, unknown>)[guard] === true
+}
+
+function isInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child)
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+async function resolveRealIntendedPath(absolutePath: string): Promise<string> {
+  const pending: string[] = []
+  let current = absolutePath
+
+  while (true) {
+    try {
+      const realCurrent = await realpath(current)
+      return path.join(realCurrent, ...pending.reverse())
+    } catch (err) {
+      if (!isNotFoundError(err)) throw err
+    }
+
+    const parent = path.dirname(current)
+    if (parent === current) throw new Error(`could not resolve existing parent for ${absolutePath}`)
+    pending.push(path.basename(current))
+    current = parent
+  }
+}
+
+function isNotFoundError(err: unknown): boolean {
+  return err instanceof Error && 'code' in err && err.code === 'ENOENT'
+}

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -277,6 +277,73 @@ describe('wrapSystemTool', () => {
     await expect(wrapped.execute('c', {}, undefined, undefined, {} as never)).rejects.toThrow('blocked: no restart')
     expect(calls).toEqual([])
   })
+
+  test('write system tool exposes and strips guard acknowledgements before execution', async () => {
+    const seen: unknown[] = []
+    const tool = definePiTool({
+      name: 'write',
+      label: 'write',
+      description: '',
+      parameters: Type.Object(
+        {
+          path: Type.String(),
+          content: Type.String(),
+        },
+        { additionalProperties: false },
+      ),
+      async execute(_callId, params) {
+        seen.push(params)
+        return { content: [{ type: 'text', text: 'wrote' }], details: params }
+      },
+    })
+    const hooks = createHookBus()
+    hooks.registerAll('p1', '/agent', noopLogger, {
+      'tool.before': (event) => {
+        expect(event.args.acknowledgeGuards).toEqual({ nonWorkspaceWrite: true })
+      },
+    })
+
+    const wrapped = wrapSystemTool(tool, { agentDir: '/agent', sessionId: 's', hooks })
+
+    const parameters = wrapped.parameters as { properties?: Record<string, unknown> }
+    expect(parameters.properties).toHaveProperty('acknowledgeGuards')
+    await wrapped.execute(
+      'c',
+      { path: 'typeclaw.json', content: '{}', acknowledgeGuards: { nonWorkspaceWrite: true } },
+      undefined,
+      undefined,
+      {} as never,
+    )
+
+    expect(seen[0]).toEqual({ path: 'typeclaw.json', content: '{}' })
+  })
+
+  test('write system tool runs a final guard after hook mutations', async () => {
+    const calls: number[] = []
+    const tool = definePiTool({
+      name: 'write',
+      label: 'write',
+      description: '',
+      parameters: Type.Object({ path: Type.String(), content: Type.String() }),
+      async execute() {
+        calls.push(1)
+        return { content: [], details: undefined }
+      },
+    })
+    const hooks = createHookBus()
+    hooks.registerAll('p1', '/agent', noopLogger, {
+      'tool.before': (event) => {
+        event.args.path = 'typeclaw.json'
+      },
+    })
+
+    const wrapped = wrapSystemTool(tool, { agentDir: '/agent', sessionId: 's', hooks })
+
+    await expect(
+      wrapped.execute('c', { path: 'workspace/file.txt', content: 'x' }, undefined, undefined, {} as never),
+    ).rejects.toThrow('Guard `nonWorkspaceWrite` blocked write outside the workspace')
+    expect(calls).toEqual([])
+  })
 })
 
 describe('wrapSystemAgentTool', () => {
@@ -335,5 +402,51 @@ describe('wrapSystemAgentTool', () => {
 
     await expect(wrapped.execute('c', { command: 'pwd' })).rejects.toThrow('blocked: no bash')
     expect(calls).toEqual([])
+  })
+
+  test('edit built-in agent tool exposes and strips guard acknowledgements before execution', async () => {
+    const seen: unknown[] = []
+    const tool = {
+      name: 'edit',
+      label: 'edit',
+      description: '',
+      parameters: Type.Object(
+        {
+          path: Type.String(),
+          edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })),
+        },
+        { additionalProperties: false },
+      ),
+      async execute(
+        _callId: string,
+        params: {
+          path: string
+          edits: { oldText: string; newText: string }[]
+          acknowledgeGuards?: { nonWorkspaceWrite?: boolean }
+        },
+      ) {
+        seen.push(params)
+        return { content: [{ type: 'text' as const, text: 'edited' }], details: params }
+      },
+    }
+    const hooks = createHookBus()
+    hooks.registerAll('p1', '/agent', noopLogger, {
+      'tool.before': (event) => {
+        expect(event.args.acknowledgeGuards).toEqual({ nonWorkspaceWrite: true })
+      },
+    })
+
+    const wrapped = wrapSystemAgentTool(tool, { agentDir: '/agent', sessionId: 's', hooks })
+
+    const parameters = wrapped.parameters as { properties?: Record<string, unknown> }
+    expect(parameters.properties).toHaveProperty('acknowledgeGuards')
+    const params = {
+      path: 'typeclaw.json',
+      edits: [{ oldText: 'x', newText: 'y' }],
+      acknowledgeGuards: { nonWorkspaceWrite: true },
+    } as unknown as Parameters<typeof wrapped.execute>[1]
+    await wrapped.execute('c', params)
+
+    expect(seen[0]).toEqual({ path: 'typeclaw.json', edits: [{ oldText: 'x', newText: 'y' }] })
   })
 })

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -333,7 +333,7 @@ describe('wrapSystemTool', () => {
     const hooks = createHookBus()
     hooks.registerAll('p1', '/agent', noopLogger, {
       'tool.before': (event) => {
-        event.args.path = 'typeclaw.json'
+        event.args.path = 'notes.md'
       },
     })
 

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -11,6 +11,7 @@ import {
 } from '@mariozechner/pi-coding-agent'
 import type { ToolDefinition } from '@mariozechner/pi-coding-agent'
 import type { Static, TSchema } from '@sinclair/typebox'
+import { Type } from '@sinclair/typebox'
 import { z } from 'zod'
 
 import type {
@@ -24,6 +25,8 @@ import type {
   ToolResult,
 } from '@/plugin'
 
+import { ACKNOWLEDGE_GUARDS, checkNonWorkspaceWriteGuard } from '../../plugins/guard/policy'
+
 type AnyAgentTool =
   | typeof piReadTool
   | typeof piBashTool
@@ -32,6 +35,15 @@ type AnyAgentTool =
   | typeof piGrepTool
   | typeof piFindTool
   | typeof piLsTool
+
+const ACKNOWLEDGE_GUARDS_SCHEMA = Type.Optional(
+  Type.Object(
+    {
+      nonWorkspaceWrite: Type.Optional(Type.Boolean()),
+    },
+    { additionalProperties: false },
+  ),
+)
 
 const BUILTIN_TOOL_MAP: Record<string, AnyAgentTool> = {
   bash: piBashTool,
@@ -133,6 +145,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
 ): ToolDefinition<TParams, TDetails, TState> {
   return piDefineTool({
     ...tool,
+    parameters: withGuardAcknowledgements(tool.name, tool.parameters),
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const mutableArgs = params as Record<string, unknown>
       const blockResult = await opts.hooks.runToolBefore({
@@ -144,6 +157,15 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       if (blockResult !== undefined) {
         throw new Error(`blocked: ${blockResult.reason}`)
       }
+      const guardResult = await checkNonWorkspaceWriteGuard({
+        tool: tool.name,
+        args: mutableArgs,
+        agentDir: opts.agentDir,
+      })
+      if (guardResult !== undefined) {
+        throw new Error(`blocked: ${guardResult.reason}`)
+      }
+      stripGuardAcknowledgements(mutableArgs)
 
       const result = await tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate, ctx)
       const hookResult: ToolResult = {
@@ -170,6 +192,7 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
 ): AgentTool<TParams, TDetails> {
   return {
     ...tool,
+    parameters: withGuardAcknowledgements(tool.name, tool.parameters),
     async execute(toolCallId, params, signal, onUpdate) {
       const mutableArgs = params as Record<string, unknown>
       const blockResult = await opts.hooks.runToolBefore({
@@ -181,6 +204,15 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
       if (blockResult !== undefined) {
         throw new Error(`blocked: ${blockResult.reason}`)
       }
+      const guardResult = await checkNonWorkspaceWriteGuard({
+        tool: tool.name,
+        args: mutableArgs,
+        agentDir: opts.agentDir,
+      })
+      if (guardResult !== undefined) {
+        throw new Error(`blocked: ${guardResult.reason}`)
+      }
+      stripGuardAcknowledgements(mutableArgs)
 
       const result = await tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate)
       const hookResult: ToolResult = {
@@ -207,4 +239,24 @@ function errorResult(message: string) {
     details: { error: true, message },
     isError: true,
   }
+}
+
+function withGuardAcknowledgements<TParams extends TSchema>(toolName: string, parameters: TParams): TParams {
+  if (toolName !== 'write' && toolName !== 'edit') return parameters
+
+  const schema = parameters as Record<string, unknown>
+  const properties = schema.properties
+  if (!properties || typeof properties !== 'object' || Array.isArray(properties)) return parameters
+
+  return {
+    ...schema,
+    properties: {
+      ...(properties as Record<string, unknown>),
+      [ACKNOWLEDGE_GUARDS]: ACKNOWLEDGE_GUARDS_SCHEMA,
+    },
+  } as unknown as TParams
+}
+
+function stripGuardAcknowledgements(args: Record<string, unknown>): void {
+  delete args[ACKNOWLEDGE_GUARDS]
 }

--- a/src/run/bundled-plugins.ts
+++ b/src/run/bundled-plugins.ts
@@ -1,6 +1,7 @@
 import type { ResolvedPlugin } from '@/plugin'
 
 import agentBrowserPlugin from '../../plugins/agent-browser'
+import guardPlugin from '../../plugins/guard'
 import memoryPlugin from '../../plugins/memory'
 
 // Consumed by both `startAgent` (auto-loaded before user plugins) AND
@@ -9,6 +10,7 @@ import memoryPlugin from '../../plugins/memory'
 // here automatically extends the JSON schema; core `configSchema` does not
 // need to know about plugin-owned blocks.
 export const BUNDLED_PLUGINS: ResolvedPlugin[] = [
+  { name: 'guard', version: undefined, source: '<bundled>', defined: guardPlugin },
   { name: 'memory', version: undefined, source: '<bundled>', defined: memoryPlugin },
   { name: 'agent-browser', version: undefined, source: '<bundled>', defined: agentBrowserPlugin },
 ]


### PR DESCRIPTION
## Summary
- Add a bundled guard plugin that blocks write/edit calls outside the agent `workspace/` unless `acknowledgeGuards.nonWorkspaceWrite` is explicitly set.
- Resolve real paths for existing parents so `workspace/` symlink escapes and lexical escapes like `workspace/../typeclaw.json` are blocked.
- Extend system write/edit wrappers to expose `acknowledgeGuards`, run a final guard after mutable hooks, and strip acknowledgements before upstream tool execution.

## Verification
- `bun run lint`
- `bun run format:check`
- `bun typecheck`
- `bun run test` / `bun test` — 1424 tests passing
- LSP diagnostics: no diagnostics on modified files
- Oracle review completed; symlink and hook-order bypass findings addressed before PR