### PR TITLE
Resolve real channel membership for engagement gate

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -356,4 +356,82 @@ describe('renderSessionOrigin', () => {
     })
     expect(out).toContain('"workspace": "@dm"')
   })
+
+  test('channel origin renders exact Slack membership summary', () => {
+    const now = 100_000
+    const out = renderSessionOrigin(
+      {
+        kind: 'channel',
+        adapter: 'slack-bot',
+        workspace: 'T0',
+        chat: 'C0',
+        thread: null,
+        membership: { humans: 12, bots: 35, fetchedAt: now, truncated: false },
+      },
+      now,
+    )
+
+    expect(out).toContain('This channel has 47 members: 12 humans, 35 bots.')
+    expect(out).toContain('The 10 most recent speakers are listed below.')
+    expect(out).not.toContain('guild members')
+  })
+
+  test('channel origin renders Discord guild-level caveat for exact counts', () => {
+    const now = 100_000
+    const out = renderSessionOrigin(
+      {
+        kind: 'channel',
+        adapter: 'discord-bot',
+        workspace: 'G0',
+        chat: 'C0',
+        thread: null,
+        membership: { humans: 12, bots: 35, fetchedAt: now, truncated: false },
+      },
+      now,
+    )
+
+    expect(out).toContain('This channel has 47 members: 12 humans, 35 bots.')
+    expect(out).toContain('this is the count of guild members')
+  })
+
+  test('channel origin renders large-channel truncated summary', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: null,
+      membership: { humans: 195, bots: 5, fetchedAt: 0, truncated: true },
+    })
+
+    expect(out).toContain('approximately 200 members (about 195 humans, 5 bots')
+    expect(out).toContain('exceeds the 50-member cap')
+  })
+
+  test('channel origin adds Discord caveat to truncated summaries', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'discord-bot',
+      workspace: 'G0',
+      chat: 'C0',
+      thread: null,
+      membership: { humans: 195, bots: 5, fetchedAt: 0, truncated: true },
+    })
+
+    expect(out).toContain('approximately 200 members')
+    expect(out).toContain('private channels with permission overwrites')
+  })
+
+  test('channel origin omits member summary when membership is missing', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: null,
+    })
+
+    expect(out).not.toContain('This channel has')
+    expect(out).not.toContain('members:')
+  })
 })

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -1,3 +1,4 @@
+import { MEMBERSHIP_FRESHNESS_MS, type MembershipCount } from '@/channels/membership'
 import type { AdapterId } from '@/channels/schema'
 
 export type ChannelParticipant = {
@@ -32,6 +33,7 @@ export type SessionOrigin =
       thread: string | null
       lastInboundAuthorId?: string
       participants?: readonly ChannelParticipant[]
+      membership?: MembershipCount
     }
   | { kind: 'subagent'; subagent: string; parentSessionId: string }
 
@@ -96,6 +98,7 @@ function renderChannelOrigin(
     chatName?: string
     thread: string | null
     participants?: readonly ChannelParticipant[]
+    membership?: MembershipCount
   },
   now: number,
 ): string {
@@ -159,10 +162,31 @@ function renderChannelOrigin(
   )
 
   const participantsBlock = renderParticipants(origin.participants ?? [], now)
+  const membershipLine = renderMembershipSummary(origin, now)
+  if (membershipLine !== null) lines.push('', membershipLine)
   if (participantsBlock) lines.push('', participantsBlock)
 
   lines.push('', 'Be concise; chat clients punish multi-paragraph replies.')
   return lines.join('\n')
+}
+
+function renderMembershipSummary(
+  origin: { adapter: AdapterId; workspace: string; membership?: MembershipCount },
+  now: number,
+): string | null {
+  const membership = origin.membership
+  if (membership === undefined) return null
+
+  const total = membership.humans + membership.bots
+  const caveat =
+    origin.adapter === 'discord-bot' && origin.workspace !== '@dm'
+      ? ' (Note: this is the count of guild members; private channels with permission overwrites may have fewer actual viewers.)'
+      : ''
+  const isExact = !membership.truncated && now - membership.fetchedAt < MEMBERSHIP_FRESHNESS_MS
+  if (isExact) {
+    return `This channel has ${total} members: ${membership.humans} humans, ${membership.bots} bots.${caveat} The 10 most recent speakers are listed below.`
+  }
+  return `This channel has approximately ${total} members (about ${membership.humans} humans, ${membership.bots} bots — the bot count is approximate, the full member list was not enumerated because it exceeds the 50-member cap).${caveat} The 10 most recent speakers are listed below.`
 }
 
 function renderMentionExample(

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -25,6 +25,8 @@ function fakeRouter(
     unregisterTyping: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
+    registerMembership: () => {},
+    unregisterMembership: () => {},
     registerHistory: () => {},
     unregisterHistory: () => {},
     fetchHistory: async () => ({ ok: false, error: 'history-not-supported' }),

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -19,6 +19,8 @@ function fakeRouter(
     unregisterTyping: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
+    registerMembership: () => {},
+    unregisterMembership: () => {},
     registerHistory: () => {},
     unregisterHistory: () => {},
     fetchHistory: async () => ({ ok: false, error: 'history-not-supported' }),

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -7,6 +7,7 @@ import type { DiscordBotClient, DiscordFile, DiscordMessage } from './agent-mess
 import { DiscordIntent } from './agent-messenger-shim'
 import {
   createDiscordHistoryCallback,
+  createDiscordMembershipResolver,
   createOutboundCallback,
   createTypingCallback,
   DISCORD_BOT_INTENTS,
@@ -160,6 +161,113 @@ describe('createTypingCallback', () => {
     })
     await cb({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })
     expect(calls).toHaveLength(0)
+  })
+})
+
+describe('createDiscordMembershipResolver', () => {
+  type FetchCall = { url: string; init: RequestInit }
+
+  function fakeFetch(responses: Response[]): { fn: typeof fetch; calls: FetchCall[] } {
+    const calls: FetchCall[] = []
+    const fn = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      calls.push({ url, init: init ?? {} })
+      return responses.shift() ?? new Response(null, { status: 500 })
+    }) as unknown as typeof fetch
+    return { fn, calls }
+  }
+
+  function jsonResponse(value: unknown, status = 200): Response {
+    return new Response(JSON.stringify(value), { status, headers: { 'Content-Type': 'application/json' } })
+  }
+
+  function silentLogger() {
+    return { info: () => {}, warn: () => {}, error: () => {} }
+  }
+
+  test('DM short-circuits without hitting Discord', async () => {
+    const { fn, calls } = fakeFetch([])
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      fetchImpl: fn,
+      now: () => 42,
+    })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: '@dm', chat: 'd1', thread: null })).resolves.toEqual({
+      humans: 1,
+      bots: 1,
+      fetchedAt: 42,
+      truncated: false,
+    })
+    expect(calls).toHaveLength(0)
+  })
+
+  test('small guild enumerates members for an exact bot/human split', async () => {
+    const { fn, calls } = fakeFetch([
+      jsonResponse({ approximate_member_count: 3 }),
+      jsonResponse([{ user: { id: 'u1' } }, { user: { id: 'b1', bot: true } }, { user: { id: 'u2', bot: false } }]),
+    ])
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      fetchImpl: fn,
+      now: () => 100,
+    })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      humans: 2,
+      bots: 1,
+      fetchedAt: 100,
+      truncated: false,
+    })
+    expect(calls[0]!.url).toBe('https://discord.com/api/v10/guilds/g1/preview')
+    expect(calls[1]!.url).toBe('https://discord.com/api/v10/guilds/g1/members?limit=100')
+  })
+
+  test('large guild uses preview approximation and skips enumeration', async () => {
+    const { fn, calls } = fakeFetch([jsonResponse({ approximate_member_count: 75 })])
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      fetchImpl: fn,
+      botUserIdRef: () => 'bot-id',
+      now: () => 200,
+    })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      humans: 74,
+      bots: 1,
+      fetchedAt: 200,
+      truncated: true,
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  test('403 from member fetch falls back to truncated preview count', async () => {
+    const { fn } = fakeFetch([jsonResponse({ approximate_member_count: 10 }), new Response(null, { status: 403 })])
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      fetchImpl: fn,
+      now: () => 300,
+    })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      humans: 10,
+      bots: 0,
+      fetchedAt: 300,
+      truncated: true,
+    })
+  })
+
+  test('403 from guild preview is a permanent resolver failure', async () => {
+    const { fn } = fakeFetch([new Response(null, { status: 403 })])
+    const resolver = createDiscordMembershipResolver({ token: 'tok', logger: silentLogger(), fetchImpl: fn })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      kind: 'permanent',
+    })
   })
 })
 

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -1,3 +1,10 @@
+import {
+  MEMBERSHIP_ENUMERATION_CAP,
+  type MembershipCount,
+  type MembershipResolver,
+  type MembershipResolverFailure,
+  type MembershipResolverResult,
+} from '@/channels/membership'
 import type { ChannelRouter } from '@/channels/router'
 import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 import type {
@@ -105,6 +112,107 @@ export function createTypingCallback(deps: {
 }
 
 export const DISCORD_HISTORY_LIMIT_MAX = 100
+
+type DiscordGuildPreview = {
+  approximate_member_count?: number
+}
+
+type DiscordGuildMember = {
+  user?: { id?: string; bot?: boolean }
+}
+
+export function createDiscordMembershipResolver(deps: {
+  token: string
+  logger: DiscordBotAdapterLogger
+  botUserIdRef?: () => string | null
+  fetchImpl?: typeof fetch
+  now?: () => number
+}): MembershipResolver {
+  const fetchFn = deps.fetchImpl ?? fetch
+  const now = deps.now ?? Date.now
+  return async (key): Promise<MembershipResolverResult> => {
+    if (key.workspace === '@dm') return { humans: 1, bots: 1, fetchedAt: now(), truncated: false }
+
+    const preview = await fetchDiscordJson<DiscordGuildPreview>(
+      fetchFn,
+      `${DISCORD_API_BASE}/guilds/${key.workspace}/preview`,
+      deps.token,
+    )
+    if (!preview.ok) {
+      deps.logger.warn(`[discord-bot] membership preview guild=${key.workspace} failed: ${preview.reason}`)
+      return preview.failure
+    }
+
+    const approximate = Math.max(0, Math.floor(preview.value.approximate_member_count ?? 0))
+    if (approximate > MEMBERSHIP_ENUMERATION_CAP) {
+      return approximateDiscordMembership(approximate, deps.botUserIdRef?.() ?? null, now())
+    }
+
+    const members = await fetchDiscordJson<DiscordGuildMember[]>(
+      fetchFn,
+      `${DISCORD_API_BASE}/guilds/${key.workspace}/members?limit=100`,
+      deps.token,
+    )
+    if (!members.ok) {
+      if (members.status === 403) {
+        deps.logger.warn(
+          `[discord-bot] membership members guild=${key.workspace} status=403; falling back to guild preview`,
+        )
+        return approximateDiscordMembership(approximate, deps.botUserIdRef?.() ?? null, now())
+      }
+      deps.logger.warn(`[discord-bot] membership members guild=${key.workspace} failed: ${members.reason}`)
+      return members.failure
+    }
+
+    let bots = 0
+    let humans = 0
+    for (const member of members.value) {
+      if (member.user?.bot === true) bots++
+      else humans++
+    }
+    return { humans, bots, fetchedAt: now(), truncated: false }
+  }
+}
+
+type DiscordFetchResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; status: number | null; reason: string; failure: MembershipResolverFailure }
+
+async function fetchDiscordJson<T>(fetchFn: typeof fetch, url: string, token: string): Promise<DiscordFetchResult<T>> {
+  let response: Response
+  try {
+    response = await fetchFn(url, { method: 'GET', headers: { Authorization: `Bot ${token}` } })
+  } catch (err) {
+    return { ok: false, status: null, reason: describe(err), failure: { kind: 'transient' } }
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      reason: `http ${response.status}`,
+      failure: discordFailureForStatus(response.status),
+    }
+  }
+  try {
+    return { ok: true, value: (await response.json()) as T }
+  } catch (err) {
+    return { ok: false, status: null, reason: `parse failed: ${describe(err)}`, failure: { kind: 'transient' } }
+  }
+}
+
+function discordFailureForStatus(status: number): MembershipResolverFailure {
+  if (status === 401 || status === 403 || status === 404) return { kind: 'permanent' }
+  return { kind: 'transient' }
+}
+
+function approximateDiscordMembership(
+  approximate: number,
+  botUserId: string | null,
+  fetchedAt: number,
+): MembershipCount {
+  const bots = botUserId === null ? 0 : 1
+  return { humans: Math.max(0, approximate - bots), bots, fetchedAt, truncated: true }
+}
 
 type DiscordRawHistoryMessage = {
   id: string
@@ -330,6 +438,12 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
     botUserIdRef: () => botUserId,
   })
 
+  const membershipResolver = createDiscordMembershipResolver({
+    token: options.token,
+    logger,
+    botUserIdRef: () => botUserId,
+  })
+
   const outboundCallback = createOutboundCallback({
     client,
     configRef: options.configRef,
@@ -403,6 +517,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       options.router.registerTyping('discord-bot', typingCallback)
       options.router.registerChannelNameResolver('discord-bot', channelResolver)
       options.router.registerHistory('discord-bot', historyCallback)
+      options.router.registerMembership('discord-bot', membershipResolver)
 
       try {
         await listener.start()
@@ -420,6 +535,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       options.router.unregisterTyping('discord-bot', typingCallback)
       options.router.unregisterChannelNameResolver('discord-bot', channelResolver)
       options.router.unregisterHistory('discord-bot', historyCallback)
+      options.router.unregisterMembership('discord-bot', membershipResolver)
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {
           stopWaiters.push(resolve)

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -12,6 +12,7 @@ import type {
 import {
   createOutboundCallback,
   createSlackHistoryCallback,
+  createSlackMembershipResolver,
   createTypingCallback,
   promoteAppMentionToMessage,
   SLACK_HISTORY_LIMIT_MAX,
@@ -164,6 +165,113 @@ describe('slack-bot createTypingCallback', () => {
     // then
     expect(calls).toHaveLength(0)
     expect(infos).toHaveLength(0)
+  })
+})
+
+describe('createSlackMembershipResolver', () => {
+  type FetchCall = { url: string; init: RequestInit }
+
+  function fakeFetch(responses: Response[]): { fn: typeof fetch; calls: FetchCall[] } {
+    const calls: FetchCall[] = []
+    const fn = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      calls.push({ url, init: init ?? {} })
+      return responses.shift() ?? slackResponse({ ok: false, error: 'rate_limited' })
+    }) as unknown as typeof fetch
+    return { fn, calls }
+  }
+
+  function slackResponse(value: unknown): Response {
+    return new Response(JSON.stringify(value), { status: 200, headers: { 'Content-Type': 'application/json' } })
+  }
+
+  function silentLogger() {
+    return { info: () => {}, warn: () => {}, error: () => {} }
+  }
+
+  test('DM short-circuits without hitting Slack', async () => {
+    const { fn, calls } = fakeFetch([])
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      fetchImpl: fn,
+      now: () => 10,
+    })
+
+    await expect(resolver({ adapter: 'slack-bot', workspace: '@dm', chat: 'D1', thread: null })).resolves.toEqual({
+      humans: 1,
+      bots: 1,
+      fetchedAt: 10,
+      truncated: false,
+    })
+    expect(calls).toHaveLength(0)
+  })
+
+  test('small channel enumerates members and classifies bots with users.info', async () => {
+    const { fn, calls } = fakeFetch([
+      slackResponse({ ok: true, channel: { num_members: 3 } }),
+      slackResponse({ ok: true, members: ['U1', 'B1', 'U2'] }),
+      slackResponse({ ok: true, user: { is_bot: false } }),
+      slackResponse({ ok: true, user: { is_bot: true } }),
+      slackResponse({ ok: true, user: { is_bot: false } }),
+    ])
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      fetchImpl: fn,
+      now: () => 20,
+    })
+
+    await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toEqual({
+      humans: 2,
+      bots: 1,
+      fetchedAt: 20,
+      truncated: false,
+    })
+    expect(calls.map((c) => c.url)).toEqual([
+      'https://slack.com/api/conversations.info',
+      'https://slack.com/api/conversations.members',
+      'https://slack.com/api/users.info',
+      'https://slack.com/api/users.info',
+      'https://slack.com/api/users.info',
+    ])
+  })
+
+  test('large channel uses conversations.info approximation', async () => {
+    const { fn, calls } = fakeFetch([slackResponse({ ok: true, channel: { num_members: 80 } })])
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      fetchImpl: fn,
+      botUserIdRef: () => 'UBOT',
+      now: () => 30,
+    })
+
+    await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toEqual({
+      humans: 79,
+      bots: 1,
+      fetchedAt: 30,
+      truncated: true,
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  test('missing-scope style errors return permanent failures', async () => {
+    const { fn } = fakeFetch([slackResponse({ ok: false, error: 'missing_scope' })])
+    const resolver = createSlackMembershipResolver({ token: 'tok', logger: silentLogger(), fetchImpl: fn })
+
+    await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toEqual({
+      kind: 'permanent',
+    })
+  })
+
+  test('rate-limit style errors return transient failures', async () => {
+    const { fn } = fakeFetch([slackResponse({ ok: false, error: 'rate_limited' })])
+    const resolver = createSlackMembershipResolver({ token: 'tok', logger: silentLogger(), fetchImpl: fn })
+
+    await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toEqual({
+      kind: 'transient',
+    })
   })
 })
 

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -1,3 +1,10 @@
+import {
+  MEMBERSHIP_ENUMERATION_CAP,
+  type MembershipCount,
+  type MembershipResolver,
+  type MembershipResolverFailure,
+  type MembershipResolverResult,
+} from '@/channels/membership'
 import type { ChannelRouter } from '@/channels/router'
 import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 import type {
@@ -143,6 +150,128 @@ type SlackHistoryResponse = {
   error?: string
   messages?: SlackRawHistoryMessage[]
   response_metadata?: { next_cursor?: string }
+}
+
+type SlackConversationInfoResponse = {
+  ok: boolean
+  error?: string
+  channel?: { num_members?: number }
+}
+
+type SlackConversationMembersResponse = {
+  ok: boolean
+  error?: string
+  members?: string[]
+}
+
+type SlackUserInfoResponse = {
+  ok: boolean
+  error?: string
+  user?: { is_bot?: boolean; deleted?: boolean }
+}
+
+export function createSlackMembershipResolver(deps: {
+  token: string
+  logger: SlackBotAdapterLogger
+  botUserIdRef?: () => string | null
+  fetchImpl?: typeof fetch
+  now?: () => number
+}): MembershipResolver {
+  const fetchFn = deps.fetchImpl ?? fetch
+  const now = deps.now ?? Date.now
+  const userBotCache = new Map<string, boolean>()
+  return async (key): Promise<MembershipResolverResult> => {
+    if (key.workspace === '@dm') return { humans: 1, bots: 1, fetchedAt: now(), truncated: false }
+
+    const info = await slackApi<SlackConversationInfoResponse>(fetchFn, deps.token, 'conversations.info', {
+      channel: key.chat,
+    })
+    if (!info.ok) {
+      deps.logger.warn(`[slack-bot] membership info channel=${key.chat} failed: ${info.reason}`)
+      return info.failure
+    }
+
+    const total = Math.max(0, Math.floor(info.value.channel?.num_members ?? 0))
+    if (total > MEMBERSHIP_ENUMERATION_CAP) {
+      return approximateSlackMembership(total, deps.botUserIdRef?.() ?? null, now())
+    }
+
+    const members = await slackApi<SlackConversationMembersResponse>(fetchFn, deps.token, 'conversations.members', {
+      channel: key.chat,
+      limit: String(MEMBERSHIP_ENUMERATION_CAP),
+    })
+    if (!members.ok) {
+      deps.logger.warn(`[slack-bot] membership members channel=${key.chat} failed: ${members.reason}`)
+      return members.failure
+    }
+
+    let bots = 0
+    let humans = 0
+    for (const userId of members.value.members ?? []) {
+      const cached = userBotCache.get(userId)
+      const isBot = cached ?? (await resolveSlackUserIsBot(fetchFn, deps.token, userId, deps.logger, userBotCache))
+      if (isBot) bots++
+      else humans++
+    }
+    return { humans, bots, fetchedAt: now(), truncated: false }
+  }
+}
+
+type SlackApiResult<T> = { ok: true; value: T } | { ok: false; reason: string; failure: MembershipResolverFailure }
+
+async function slackApi<T>(
+  fetchFn: typeof fetch,
+  token: string,
+  method: string,
+  fields: Record<string, string>,
+): Promise<SlackApiResult<T>> {
+  const body = new URLSearchParams(fields)
+  let raw: { ok?: boolean; error?: string }
+  try {
+    const response = await fetchFn(`${SLACK_API_BASE}/${method}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8' },
+      body: body.toString(),
+    })
+    raw = (await response.json()) as { ok?: boolean; error?: string }
+  } catch (err) {
+    return { ok: false, reason: describe(err), failure: { kind: 'transient' } }
+  }
+  if (raw.ok !== true) {
+    const reason = raw.error ?? 'unknown slack error'
+    return { ok: false, reason, failure: slackFailureForError(reason) }
+  }
+  return { ok: true, value: raw as T }
+}
+
+async function resolveSlackUserIsBot(
+  fetchFn: typeof fetch,
+  token: string,
+  userId: string,
+  logger: SlackBotAdapterLogger,
+  cache: Map<string, boolean>,
+): Promise<boolean> {
+  const info = await slackApi<SlackUserInfoResponse>(fetchFn, token, 'users.info', { user: userId })
+  if (!info.ok) {
+    logger.warn(`[slack-bot] membership users.info user=${userId} failed: ${info.reason}`)
+    cache.set(userId, false)
+    return false
+  }
+  const isBot = info.value.user?.is_bot === true
+  cache.set(userId, isBot)
+  return isBot
+}
+
+function slackFailureForError(error: string): MembershipResolverFailure {
+  if (['invalid_auth', 'not_authed', 'not_in_channel', 'channel_not_found', 'missing_scope'].includes(error)) {
+    return { kind: 'permanent' }
+  }
+  return { kind: 'transient' }
+}
+
+function approximateSlackMembership(total: number, botUserId: string | null, fetchedAt: number): MembershipCount {
+  const bots = botUserId === null ? 0 : 1
+  return { humans: Math.max(0, total - bots), bots, fetchedAt, truncated: true }
 }
 
 // Direct fetch to Slack's Web API. The shim only exposes postMessage /
@@ -391,6 +520,12 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
     botUserIdRef: () => botUserId,
   })
 
+  const membershipResolver = createSlackMembershipResolver({
+    token: options.token,
+    logger,
+    botUserIdRef: () => botUserId,
+  })
+
   const outboundCallback = createOutboundCallback({
     client,
     configRef: options.configRef,
@@ -521,6 +656,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       options.router.registerTyping('slack-bot', typingCallback)
       options.router.registerChannelNameResolver('slack-bot', channelResolver)
       options.router.registerHistory('slack-bot', historyCallback)
+      options.router.registerMembership('slack-bot', membershipResolver)
 
       try {
         await listener.start()
@@ -538,6 +674,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       options.router.unregisterTyping('slack-bot', typingCallback)
       options.router.unregisterChannelNameResolver('slack-bot', channelResolver)
       options.router.unregisterHistory('slack-bot', historyCallback)
+      options.router.unregisterMembership('slack-bot', membershipResolver)
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {
           stopWaiters.push(resolve)

--- a/src/channels/engagement.test.ts
+++ b/src/channels/engagement.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from 'bun:test'
 
 import type { ChannelParticipant } from '@/agent/session-origin'
 
-import { decideEngagement, grantStickyForReplyTargets, StickyLedger } from './engagement'
+import {
+  decideEngagement as decideEngagementRaw,
+  grantStickyForReplyTargets,
+  resolveEffectiveHumans,
+  StickyLedger,
+  type EngagementInput,
+} from './engagement'
 import type { EngagementConfig } from './schema'
 import type { InboundMessage } from './types'
 
@@ -24,6 +30,12 @@ function participant(authorId: string, lastMessageAt = 0): ChannelParticipant {
 }
 
 const crowded: readonly ChannelParticipant[] = [participant('alice'), participant('bob')]
+
+function decideEngagement(
+  input: Omit<EngagementInput, 'membership'> & Partial<Pick<EngagementInput, 'membership'>>,
+): ReturnType<typeof decideEngagementRaw> {
+  return decideEngagementRaw({ membership: null, ...input })
+}
 
 function inbound(over: Partial<InboundMessage> = {}): InboundMessage {
   return {
@@ -356,6 +368,95 @@ describe('decideEngagement (solo-human fallback)', () => {
       participants: [participant('alice'), participant('bob'), { ...participant('peer1'), isBot: true }],
     })
     expect(twoHumans).toBe('observe')
+  })
+
+  test('observes lurker channels when fresh exact membership has two humans', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound(),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 10_000,
+      participants: [
+        participant('alice'),
+        { ...participant('peer1'), isBot: true },
+        { ...participant('peer2'), isBot: true },
+      ],
+      membership: { humans: 2, bots: 2, fetchedAt: 10_000, truncated: false },
+    })
+
+    expect(decision).toBe('observe')
+  })
+
+  test('preserves legacy solo fallback when membership is unavailable', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound(),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: [participant('alice'), { ...participant('peer1'), isBot: true }],
+      membership: null,
+    })
+
+    expect(decision).toBe('engage')
+  })
+
+  test('fresh exact membership wins when persisted speakers have left', () => {
+    expect(resolveEffectiveHumans(3, { humans: 1, bots: 1, fetchedAt: 20_000, truncated: false }, 20_000)).toBe(1)
+  })
+
+  test('truncated and stale membership fall back to the max count', () => {
+    expect(resolveEffectiveHumans(2, { humans: 1, bots: 1, fetchedAt: 0, truncated: true }, 10_000)).toBe(2)
+    expect(resolveEffectiveHumans(2, { humans: 1, bots: 1, fetchedAt: 0, truncated: false }, 120_000)).toBe(2)
+  })
+
+  test('large truncated channels observe even with one persisted human', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound(),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: [participant('alice')],
+      membership: { humans: 30, bots: 5, fetchedAt: 0, truncated: true },
+    })
+
+    expect(decision).toBe('observe')
+  })
+
+  test('peer bots never qualify for fallback even with bot-only membership', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({ authorId: 'peer1', authorName: 'peer1', authorIsBot: true }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: [{ ...participant('peer1'), isBot: true }],
+      membership: { humans: 0, bots: 5, fetchedAt: 0, truncated: false },
+    })
+
+    expect(decision).toBe('observe')
+  })
+
+  test('sticky credit still bypasses high membership counts', () => {
+    const ledger = new StickyLedger()
+    ledger.grant(KEY, 'alice', 10_000)
+    const decision = decideEngagement({
+      message: inbound(),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 1000,
+      participants: [participant('alice')],
+      membership: { humans: 50, bots: 5, fetchedAt: 1000, truncated: false },
+    })
+
+    expect(decision).toBe('engage')
   })
 })
 

--- a/src/channels/engagement.ts
+++ b/src/channels/engagement.ts
@@ -1,5 +1,6 @@
 import type { ChannelParticipant } from '@/agent/session-origin'
 
+import { MEMBERSHIP_FRESHNESS_MS, type MembershipCount } from './membership'
 import type { EngagementConfig } from './schema'
 import type { InboundMessage } from './types'
 
@@ -53,6 +54,7 @@ export type EngagementInput = {
   // before), so the solo-human fallback below filters them out explicitly
   // — otherwise a 1-human + N-bot channel would silently exit solo mode.
   participants: readonly ChannelParticipant[]
+  membership: MembershipCount | null
 }
 
 export function decideEngagement(input: EngagementInput): EngagementDecision {
@@ -111,10 +113,28 @@ export function decideEngagement(input: EngagementInput): EngagementDecision {
   if (message.mentionsOthers) return 'observe'
   if (message.replyToOtherMessageId !== null) return 'observe'
 
-  const humanParticipants = participants.filter((p) => p.isBot !== true)
-  if (humanParticipants.length <= 1 && !message.authorIsBot) return 'engage'
+  const persistedHumans = participants.filter((p) => p.isBot !== true).length
+  const effectiveHumans = resolveEffectiveHumans(persistedHumans, input.membership, now)
+  if (effectiveHumans <= 1 && !message.authorIsBot) return 'engage'
 
   return 'observe'
+}
+
+export function resolveEffectiveHumans(
+  persistedHumans: number,
+  membership: MembershipCount | null,
+  now: number,
+): number {
+  if (membership === null) return persistedHumans
+  // A fresh complete API read is the only signal that can see lurkers AND
+  // prune recent leavers. Letting persisted speakers win here would preserve
+  // the exact stale-authorship bug the membership lookup exists to fix.
+  const isFresh = now - membership.fetchedAt < MEMBERSHIP_FRESHNESS_MS
+  if (!membership.truncated && isFresh) return membership.humans
+  // Truncated and stale reads are useful quieting hints, not ground truth.
+  // Persisted speakers are bounded to the last 7 days, so `max()` avoids
+  // under-counting active humans while the platform count is approximate.
+  return Math.max(persistedHumans, membership.humans)
 }
 
 export function grantStickyForReplyTargets(

--- a/src/channels/membership-cache.test.ts
+++ b/src/channels/membership-cache.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'bun:test'
+
+import { MEMBERSHIP_CACHE_TRANSIENT_TTL_MS, MEMBERSHIP_CACHE_TTL_MS, type MembershipResolver } from './membership'
+import { createMembershipCache } from './membership-cache'
+import type { ChannelKey } from './types'
+
+const key: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null }
+
+describe('createMembershipCache', () => {
+  test('returns cached membership within the positive TTL', async () => {
+    let now = 1000
+    let calls = 0
+    const cache = createMembershipCache({
+      now: () => now,
+      resolver: async () => {
+        calls++
+        return { humans: 2, bots: 1, fetchedAt: now, truncated: false }
+      },
+    })
+
+    expect(await cache.warmUp(key)).toEqual({ humans: 2, bots: 1, fetchedAt: 1000, truncated: false })
+    now += MEMBERSHIP_CACHE_TTL_MS - 1
+
+    expect(cache.get(key)).toEqual({ humans: 2, bots: 1, fetchedAt: 1000, truncated: false })
+    expect(calls).toBe(1)
+  })
+
+  test('expires positive entries after one stale read', async () => {
+    let now = 1000
+    let calls = 0
+    const cache = createMembershipCache({
+      now: () => now,
+      resolver: async () => {
+        calls++
+        return { humans: calls, bots: 0, fetchedAt: now, truncated: false }
+      },
+    })
+    await cache.warmUp(key)
+    now += MEMBERSHIP_CACHE_TTL_MS + 1
+
+    expect(cache.read(key)).toEqual({
+      kind: 'stale',
+      membership: { humans: 1, bots: 0, fetchedAt: 1000, truncated: false },
+    })
+    expect(await cache.warmUp(key)).toEqual({ humans: 2, bots: 0, fetchedAt: now, truncated: false })
+    expect(calls).toBe(2)
+  })
+
+  test('deduplicates concurrent resolver calls', async () => {
+    let calls = 0
+    let release!: () => void
+    const unblock = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const resolver: MembershipResolver = async () => {
+      calls++
+      await unblock
+      return { humans: 3, bots: 1, fetchedAt: 10, truncated: false }
+    }
+    const cache = createMembershipCache({ now: () => 10, resolver })
+
+    const first = cache.warmUp(key)
+    const second = cache.warmUp(key)
+    release()
+
+    expect(await Promise.all([first, second])).toEqual([
+      { humans: 3, bots: 1, fetchedAt: 10, truncated: false },
+      { humans: 3, bots: 1, fetchedAt: 10, truncated: false },
+    ])
+    expect(calls).toBe(1)
+  })
+
+  test('negative cache uses the transient TTL', async () => {
+    let now = 1000
+    let calls = 0
+    const cache = createMembershipCache({
+      now: () => now,
+      resolver: async () => {
+        calls++
+        return calls === 1 ? { kind: 'transient' } : { humans: 4, bots: 1, fetchedAt: now, truncated: false }
+      },
+    })
+
+    expect(await cache.warmUp(key)).toBeNull()
+    now += MEMBERSHIP_CACHE_TRANSIENT_TTL_MS - 1
+    expect(await cache.warmUp(key)).toBeNull()
+    now += 2
+    expect(await cache.warmUp(key)).toEqual({ humans: 4, bots: 1, fetchedAt: now, truncated: false })
+    expect(calls).toBe(2)
+  })
+
+  test('manual invalidation clears an entry', async () => {
+    let calls = 0
+    const cache = createMembershipCache({
+      now: () => 0,
+      resolver: async () => {
+        calls++
+        return { humans: calls, bots: 0, fetchedAt: 0, truncated: false }
+      },
+    })
+
+    await cache.warmUp(key)
+    cache.invalidate(key)
+
+    expect(cache.get(key)).toBeNull()
+    expect(await cache.warmUp(key)).toEqual({ humans: 2, bots: 0, fetchedAt: 0, truncated: false })
+  })
+})

--- a/src/channels/membership-cache.ts
+++ b/src/channels/membership-cache.ts
@@ -1,0 +1,116 @@
+import {
+  MEMBERSHIP_CACHE_PERMANENT_TTL_MS,
+  MEMBERSHIP_CACHE_TRANSIENT_TTL_MS,
+  MEMBERSHIP_CACHE_TTL_MS,
+  type MembershipCount,
+  type MembershipResolver,
+  type MembershipResolverFailure,
+  type MembershipResolverResult,
+} from './membership'
+import type { ChannelKey } from './types'
+import { channelKeyId } from './types'
+
+export type MembershipCacheRead =
+  | { kind: 'hit'; membership: MembershipCount | null }
+  | { kind: 'stale'; membership: MembershipCount }
+  | { kind: 'miss' }
+
+type CacheEntry = {
+  result: MembershipResolverResult
+  expiresAt: number
+  servedStale: boolean
+}
+
+export type MembershipCacheLogger = {
+  warn: (msg: string) => void
+}
+
+export type MembershipCacheOptions = {
+  resolver: MembershipResolver
+  now?: () => number
+  logger?: MembershipCacheLogger
+}
+
+export type MembershipCache = {
+  read: (key: ChannelKey) => MembershipCacheRead
+  get: (key: ChannelKey) => MembershipCount | null
+  warmUp: (key: ChannelKey) => Promise<MembershipCount | null>
+  invalidate: (key: ChannelKey) => void
+}
+
+export function createMembershipCache(options: MembershipCacheOptions): MembershipCache {
+  const now = options.now ?? Date.now
+  const entries = new Map<string, CacheEntry>()
+  const inFlight = new Map<string, Promise<MembershipCount | null>>()
+
+  const read = (key: ChannelKey): MembershipCacheRead => {
+    const entry = entries.get(channelKeyId(key))
+    if (entry === undefined) return { kind: 'miss' }
+
+    if (entry.expiresAt > now()) return { kind: 'hit', membership: toMembership(entry.result) }
+    if (isMembershipCount(entry.result) && !entry.servedStale) {
+      entry.servedStale = true
+      return { kind: 'stale', membership: entry.result }
+    }
+    return { kind: 'miss' }
+  }
+
+  const warmUp = (key: ChannelKey): Promise<MembershipCount | null> => {
+    const keyId = channelKeyId(key)
+    const cached = read(key)
+    if (cached.kind === 'hit') return Promise.resolve(cached.membership)
+    if (cached.kind === 'stale') return Promise.resolve(cached.membership)
+
+    const existing = inFlight.get(keyId)
+    if (existing !== undefined) return existing
+
+    const promise = resolveAndStore(key, keyId).finally(() => {
+      inFlight.delete(keyId)
+    })
+    inFlight.set(keyId, promise)
+    return promise
+  }
+
+  const resolveAndStore = async (key: ChannelKey, keyId: string): Promise<MembershipCount | null> => {
+    let result: MembershipResolverResult
+    try {
+      result = await options.resolver(key)
+    } catch (err) {
+      options.logger?.warn(`[channels] membership resolver threw for ${keyId}: ${describe(err)}`)
+      result = { kind: 'transient' }
+    }
+    entries.set(keyId, { result, expiresAt: now() + ttlFor(result), servedStale: false })
+    return toMembership(result)
+  }
+
+  return {
+    read,
+    get: (key) => {
+      const cached = read(key)
+      return cached.kind === 'hit' ? cached.membership : null
+    },
+    warmUp,
+    invalidate: (key) => {
+      entries.delete(channelKeyId(key))
+    },
+  }
+}
+
+function ttlFor(result: MembershipResolverResult): number {
+  if (isMembershipCount(result)) return MEMBERSHIP_CACHE_TTL_MS
+  return result.kind === 'permanent' ? MEMBERSHIP_CACHE_PERMANENT_TTL_MS : MEMBERSHIP_CACHE_TRANSIENT_TTL_MS
+}
+
+function toMembership(result: MembershipResolverResult): MembershipCount | null {
+  return isMembershipCount(result) ? result : null
+}
+
+function isMembershipCount(result: MembershipResolverResult): result is MembershipCount {
+  return 'humans' in result
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+export type { MembershipResolverFailure }

--- a/src/channels/membership.ts
+++ b/src/channels/membership.ts
@@ -1,0 +1,21 @@
+import type { ChannelKey } from './types'
+
+export const MEMBERSHIP_ENUMERATION_CAP = 50
+export const MEMBERSHIP_CACHE_TTL_MS = 5 * 60 * 1000
+export const MEMBERSHIP_CACHE_PERMANENT_TTL_MS = 5 * 60 * 1000
+export const MEMBERSHIP_CACHE_TRANSIENT_TTL_MS = 30_000
+export const MEMBERSHIP_FRESHNESS_MS = 60_000
+export const MEMBERSHIP_COLD_FETCH_TIMEOUT_MS = 1500
+
+export type MembershipCount = {
+  humans: number
+  bots: number
+  fetchedAt: number
+  truncated: boolean
+}
+
+export type MembershipResolverFailure = { kind: 'transient' } | { kind: 'permanent' }
+
+export type MembershipResolverResult = MembershipCount | MembershipResolverFailure
+
+export type MembershipResolver = (key: ChannelKey) => Promise<MembershipResolverResult>

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -457,6 +457,51 @@ describe('ChannelRouter engagement and prompt composition', () => {
     await router.__testing!.flushDebounce(KEY)
     expect(sessions[0]!.prompts).toHaveLength(2)
   })
+
+  test('registered membership resolver gates first cold inbound before sticky can start', async () => {
+    const dir = await tempDir()
+    const { router, sessions, origins } = makeRouter(dir)
+    router.registerMembership('discord-bot', async () => ({
+      humans: 5,
+      bots: 2,
+      fetchedAt: Date.now(),
+      truncated: false,
+    }))
+
+    await router.route(inbound({ isBotMention: false, text: 'ambient hello' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(0)
+    expect(origins[0]).toMatchObject({ kind: 'channel', membership: { humans: 5, bots: 2, truncated: false } })
+  })
+
+  test('membership resolver failure preserves legacy null fallback', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.registerMembership('discord-bot', async () => ({ kind: 'transient' }))
+
+    await router.route(inbound({ isBotMention: false, text: 'solo hello' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sessions[0]!.prompts[0]).toContain('solo hello')
+  })
+
+  test('large approximate membership counts still quiet plain chatter', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.registerMembership('discord-bot', async () => ({
+      humans: 30,
+      bots: 5,
+      fetchedAt: Date.now(),
+      truncated: true,
+    }))
+
+    await router.route(inbound({ isBotMention: false, text: 'ambient hello' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(0)
+  })
 })
 
 describe('ChannelRouter sticky credits', () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -9,6 +9,13 @@ import { createCommandRegistry } from '@/commands'
 import type { HookBus } from '@/plugin'
 
 import { decideEngagement, grantStickyForReplyTargets, StickyLedger, type EngagementDecision } from './engagement'
+import {
+  MEMBERSHIP_COLD_FETCH_TIMEOUT_MS,
+  type MembershipCount,
+  type MembershipResolver,
+  type MembershipResolverResult,
+} from './membership'
+import { createMembershipCache, type MembershipCache } from './membership-cache'
 import { updateParticipants } from './participants'
 import {
   channelsSessionsPath,
@@ -177,6 +184,7 @@ type LiveSession = {
   recentEngagedPeerBotTurns: { authorId: string; ts: number }[]
   consecutiveEngagedPeerBotTurns: number
   loopGuardActive: boolean
+  membershipFetch: Promise<MembershipCount | null> | null
   destroyed: boolean
 }
 
@@ -200,6 +208,8 @@ export type ChannelRouter = {
   unregisterTyping: (adapter: ChannelKey['adapter'], cb: TypingCallback) => void
   registerChannelNameResolver: (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver) => void
   unregisterChannelNameResolver: (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver) => void
+  registerMembership: (adapter: ChannelKey['adapter'], resolver: MembershipResolver) => void
+  unregisterMembership: (adapter: ChannelKey['adapter'], resolver: MembershipResolver) => void
   registerHistory: (adapter: ChannelKey['adapter'], cb: HistoryCallback) => void
   unregisterHistory: (adapter: ChannelKey['adapter'], cb: HistoryCallback) => void
   fetchHistory: (adapter: ChannelKey['adapter'], args: FetchHistoryArgs) => Promise<FetchHistoryResult>
@@ -231,6 +241,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const outboundCallbacks = new Map<ChannelKey['adapter'], Set<OutboundCallback>>()
   const typingCallbacks = new Map<ChannelKey['adapter'], Set<TypingCallback>>()
   const channelNameResolvers = new Map<ChannelKey['adapter'], Set<ChannelNameResolver>>()
+  const membershipResolvers = new Map<ChannelKey['adapter'], Set<MembershipResolver>>()
+  const membershipCaches = new Map<ChannelKey['adapter'], MembershipCache>()
   const historyCallbacks = new Map<ChannelKey['adapter'], Set<HistoryCallback>>()
   const stickyLedger = new StickyLedger()
   const commands = createCommandRegistry<ChannelCommandContext>([
@@ -303,6 +315,64 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return merged
   }
 
+  const readMembership = (key: ChannelKey): MembershipCount | null => {
+    if (key.workspace === '@dm') return dmMembership(now())
+    return membershipCaches.get(key.adapter)?.get(key) ?? null
+  }
+
+  const warmMembership = (key: ChannelKey): Promise<MembershipCount | null> | null => {
+    if (key.workspace === '@dm') return Promise.resolve(dmMembership(now()))
+    const cache = membershipCaches.get(key.adapter)
+    if (cache === undefined) return null
+    return cache.warmUp(key)
+  }
+
+  const resolveThroughRegisteredMembership = async (key: ChannelKey): Promise<MembershipResolverResult> => {
+    const resolvers = membershipResolvers.get(key.adapter)
+    if (!resolvers || resolvers.size === 0) return { kind: 'transient' }
+    const snapshot = Array.from(resolvers)
+    let lastFailure: MembershipResolverResult = { kind: 'transient' }
+    for (const resolver of snapshot) {
+      const result = await resolver(key)
+      if ('humans' in result) return result
+      lastFailure = result
+    }
+    return lastFailure
+  }
+
+  const membershipForPrompt = async (
+    key: ChannelKey,
+    fetchPromise: Promise<MembershipCount | null> | null,
+  ): Promise<MembershipCount | null> => {
+    if (key.workspace === '@dm') return dmMembership(now())
+    const cached = readMembership(key)
+    if (cached !== null) return cached
+    if (fetchPromise === null) return null
+    return await withMembershipTimeout(fetchPromise, key, logger)
+  }
+
+  const membershipForEngagement = async (live: LiveSession): Promise<MembershipCount | null> => {
+    if (live.key.workspace === '@dm') return dmMembership(now())
+    const cache = membershipCaches.get(live.key.adapter)
+    if (cache === undefined) return null
+
+    const cached = cache.read(live.key)
+    if (cached.kind === 'hit') return cached.membership
+    if (cached.kind === 'stale') {
+      void cache.warmUp(live.key).catch((err) => {
+        logger.warn(`[channels] membership refresh failed for ${live.keyId}: ${describe(err)}`)
+      })
+      return cached.membership
+    }
+
+    const fetchPromise = live.membershipFetch ?? warmMembership(live.key)
+    live.membershipFetch = fetchPromise
+    if (fetchPromise === null) return null
+    const membership = await withMembershipTimeout(fetchPromise, live.key, logger)
+    if (live.membershipFetch === fetchPromise) live.membershipFetch = null
+    return membership
+  }
+
   const ensureLive = async (key: ChannelKey, triggeringMessageId?: string): Promise<LiveSession> => {
     const keyId = channelKeyId(key)
     const existing = liveSessions.get(keyId)
@@ -315,7 +385,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       await ensureLoaded()
       const record = mappings ? findRecord(mappings, key) : undefined
       const participants = (record?.participants ?? []) as ChannelParticipant[]
+      const membershipFetch = warmMembership(key)
       const resolvedNames = await resolveChannelNames(key)
+      const membership = await membershipForPrompt(key, membershipFetch)
       const origin: SessionOrigin = {
         kind: 'channel',
         adapter: key.adapter,
@@ -325,6 +397,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         ...(resolvedNames.chatName !== undefined ? { chatName: resolvedNames.chatName } : {}),
         thread: key.thread,
         participants,
+        ...(membership !== null ? { membership } : {}),
       }
 
       const isColdStart = record?.sessionId === undefined
@@ -388,6 +461,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         recentEngagedPeerBotTurns: [],
         consecutiveEngagedPeerBotTurns: 0,
         loopGuardActive: false,
+        membershipFetch,
         destroyed: false,
       }
       liveSessions.set(keyId, live)
@@ -501,16 +575,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     await persist()
   }
 
-  const regenerateOrigin = (live: LiveSession): SessionOrigin => ({
-    kind: 'channel',
-    adapter: live.key.adapter,
-    workspace: live.key.workspace,
-    ...(live.resolvedNames.workspaceName !== undefined ? { workspaceName: live.resolvedNames.workspaceName } : {}),
-    chat: live.key.chat,
-    ...(live.resolvedNames.chatName !== undefined ? { chatName: live.resolvedNames.chatName } : {}),
-    thread: live.key.thread,
-    participants: live.participants,
-  })
+  const regenerateOrigin = (live: LiveSession): SessionOrigin => buildLiveOrigin(live)
 
   const fireTyping = async (live: LiveSession): Promise<void> => {
     const callbacks = typingCallbacks.get(live.key.adapter)
@@ -566,17 +631,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
-  const buildLiveOrigin = (live: LiveSession): SessionOrigin => ({
-    kind: 'channel',
-    adapter: live.key.adapter,
-    workspace: live.key.workspace,
-    ...(live.resolvedNames.workspaceName !== undefined ? { workspaceName: live.resolvedNames.workspaceName } : {}),
-    chat: live.key.chat,
-    ...(live.resolvedNames.chatName !== undefined ? { chatName: live.resolvedNames.chatName } : {}),
-    thread: live.key.thread,
-    ...(live.currentTurnAuthorId !== null ? { lastInboundAuthorId: live.currentTurnAuthorId } : {}),
-    participants: live.participants,
-  })
+  const buildLiveOrigin = (live: LiveSession): SessionOrigin => {
+    const membership = readMembership(live.key)
+    return {
+      kind: 'channel',
+      adapter: live.key.adapter,
+      workspace: live.key.workspace,
+      ...(live.resolvedNames.workspaceName !== undefined ? { workspaceName: live.resolvedNames.workspaceName } : {}),
+      chat: live.key.chat,
+      ...(live.resolvedNames.chatName !== undefined ? { chatName: live.resolvedNames.chatName } : {}),
+      thread: live.key.thread,
+      ...(live.currentTurnAuthorId !== null ? { lastInboundAuthorId: live.currentTurnAuthorId } : {}),
+      participants: live.participants,
+      ...(membership !== null ? { membership } : {}),
+    }
+  }
 
   const fireSessionEnd = async (live: LiveSession): Promise<void> => {
     if (!live.hooks) return
@@ -707,6 +776,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     )
     void persistParticipants(live)
 
+    const membership = await membershipForEngagement(live)
+
     const decision: EngagementDecision = decideEngagement({
       message: event,
       config: adapterConfig.engagement,
@@ -714,6 +785,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       ledger: stickyLedger,
       now: now(),
       participants: live.participants,
+      membership,
     })
 
     if (decision === 'observe') {
@@ -828,6 +900,28 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
   const unregisterChannelNameResolver = (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver): void => {
     channelNameResolvers.get(adapter)?.delete(resolver)
+  }
+
+  const registerMembership = (adapter: ChannelKey['adapter'], resolver: MembershipResolver): void => {
+    let set = membershipResolvers.get(adapter)
+    if (!set) {
+      set = new Set()
+      membershipResolvers.set(adapter, set)
+    }
+    set.add(resolver)
+    if (!membershipCaches.has(adapter)) {
+      membershipCaches.set(
+        adapter,
+        createMembershipCache({ resolver: resolveThroughRegisteredMembership, now, logger }),
+      )
+    }
+  }
+
+  const unregisterMembership = (adapter: ChannelKey['adapter'], resolver: MembershipResolver): void => {
+    membershipResolvers.get(adapter)?.delete(resolver)
+    if ((membershipResolvers.get(adapter)?.size ?? 0) === 0) {
+      membershipCaches.delete(adapter)
+    }
   }
 
   const registerHistory = (adapter: ChannelKey['adapter'], cb: HistoryCallback): void => {
@@ -1015,6 +1109,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     unregisterTyping,
     registerChannelNameResolver,
     unregisterChannelNameResolver,
+    registerMembership,
+    unregisterMembership,
     registerHistory,
     unregisterHistory,
     fetchHistory,
@@ -1155,6 +1251,31 @@ function tryOpenSessionManager(
 
 function consecutiveSendKey(chat: string, thread: string | null | undefined): string {
   return `${chat}:${thread ?? ''}`
+}
+
+function dmMembership(fetchedAt: number): MembershipCount {
+  return { humans: 1, bots: 1, fetchedAt, truncated: false }
+}
+
+async function withMembershipTimeout(
+  promise: Promise<MembershipCount | null>,
+  key: ChannelKey,
+  logger: RouterLogger,
+): Promise<MembershipCount | null> {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const timeout = new Promise<null>((resolve) => {
+    timer = setTimeout(() => {
+      logger.warn(
+        `[channels] ${channelKeyId(key)}: membership cold fetch timed out after ${MEMBERSHIP_COLD_FETCH_TIMEOUT_MS}ms`,
+      )
+      resolve(null)
+    }, MEMBERSHIP_COLD_FETCH_TIMEOUT_MS)
+  })
+  try {
+    return await Promise.race([promise, timeout])
+  } finally {
+    if (timer !== null) clearTimeout(timer)
+  }
 }
 
 function latestAssistantText(session: AgentSession): string | null {


### PR DESCRIPTION
## Summary

Today the channels engagement gate's solo-human fallback fires whenever the persisted speaker history shows ≤1 human, regardless of how many humans are actually in the channel. In a Discord channel where two humans hang out but only one types, every bot sees \`humanParticipants.length === 1\` and replies to messages that aren't addressed to any of them. Captured live in a chat where four bots all chimed in on \"아놔 다른애들은 대답하지 말고 아티만 대답해\" — a message with no \`<@>\` mention to any of them, intended for one specific bot.

This PR resolves real channel/guild membership from the platform APIs, threads the count through engagement, and surfaces a one-line summary in the system prompt.

- **\`MembershipResolver\`** per adapter (Discord, Slack), DM short-circuit, typed transient/permanent failures.
- **TTL cache** (5min positive, 5min permanent-failure, 30s transient-failure) with concurrent-resolve dedup.
- **Tiered \`resolveEffectiveHumans\`** in engagement: exact-fresh non-truncated reads win directly; truncated/stale reads fall back to \`max(persistedHumans, membership.humans)\` so we never under-count humans during the approximation window.
- **Cold-fetch synchronous wait** with 1500ms timeout on the very first inbound to a brand-new channel — closes the sticky-amplification trap where a single cold-cache false-engage would grant sticky credit and keep engagement alive for the sticky window even after the cache warms.
- **System prompt summary** rendered above \`## Recent participants\` at session-creation time. Discord adds a guild-vs-channel caveat (private channels with permission overwrites may have fewer actual viewers); Slack does not (\`conversations.members\` returns true channel membership).
- **Cap of 50** for exact enumeration; channels above the cap use the platform's approximate count + a heuristic bot/human split, marked \`truncated: true\`.

The change is fully additive: every code path treats a missing membership as \"use legacy behavior\". Engagement philosophy is unchanged — peer bots remain first-class under the same triggers as humans, and the \`PEER BOTS NEVER QUALIFY\` rule for the solo-human fallback stays intact.

## Design review

Plan reviewed by Oracle and Momus before implementation. Oracle flagged five concerns that the plan and this implementation address:

1. **Cold-cache + sticky amplification** — solved by 1.5s synchronous wait on \`ensureLive\` before the first \`decideEngagement\` call.
2. **\`max()\` too conservative for fresh exact reads** — split into tiered policy via \`MEMBERSHIP_FRESHNESS_MS = 60s\`.
3. **Negative-cache TTL too short** — typed failures: 5min for permanent (403/missing scope), 30s for transient (5xx/timeout/429).
4. **\`regenerateOrigin\` is a no-op** — membership is creation-time-pinned in v1; per-prompt origin refresh is acknowledged as a v0.2 work item.
5. **Slack DM detection by id-prefix** — replaced with \`key.workspace === '@dm'\`, the durable post-routing signal both adapters share.

## Out of scope

- **Name-based addressing detection** (suppress fallback when text leads with a peer-bot's plain-text name) — separate orthogonal proposal.
- **Group-chat etiquette block in the system prompt** — separate.
- **Loop guard from advisory to forced \`NO_REPLY\`** — separate.
- **Bundled \`typeclaw-channel-discord\` skill** — separate.
- **Per-prompt origin refresh** — known v0.2 work item.
- **Real channel-permission-filtered membership for Discord** — would require per-member ACL evaluation; the guild-level count plus the surfaced caveat is the v1 tradeoff.
- **\`GUILD_MEMBER_ADD\` event invalidation** — current adapter shim doesn't expose it, requires the privileged \`GUILD_MEMBERS\` intent we don't require for v1, and it's guild-level not channel-level. The 5-minute TTL is the v1 freshness budget.

## Verification

- \`bun run lint\` — 0 warnings, 0 errors
- \`bun run format:check\` — clean
- \`bun typecheck\` — clean
- \`bun run test\` — 1446 pass / 0 fail

New test coverage:
- Membership cache: hit/miss within TTL, expiry, concurrent-resolve dedup, transient and permanent negative TTLs, manual invalidation.
- Engagement: lurker case (the bug), null fallback, exact-fresh wins over persisted (kicked-user case), truncated-or-stale falls back to max, large-channel truncated still observes, peer-bot fallback unchanged regardless of membership, stickiness still bypasses fallback.
- Router: cold-fetch synchronous wait, timeout fallback to null, transient cache (30s) vs permanent cache (5min), membership flows into system prompt at \`createSession\` time, missing membership omits the summary line.
- Session origin: small-channel exact summary (Slack and Discord), truncated summary, Discord guild-vs-channel caveat, missing-membership omits the line.
- Discord adapter: DM short-circuit, small guild exact, large guild approximate + truncated, 403 fallthrough preserves preview count, transient failures.
- Slack adapter: DM short-circuit, small channel exact, large channel approximate, missing-scope permanent failures, transient failures.

## Notes

- Implemented in worktree: \`/tmp/typeclaw-membership-awareness\`.
- Plan: \`.sisyphus/plans/group-chat-membership-awareness.md\` (gitignored; saved locally for review trail).
- Seven atomic commits, one per logical change: types → cache → engagement → session-origin → router → Discord adapter → Slack adapter.