### PR TITLE
Add typeclaw compose command

### DIFF
--- a/src/cli/compose.ts
+++ b/src/cli/compose.ts
@@ -1,0 +1,187 @@
+import { defineCommand } from 'citty'
+
+import {
+  composeDown,
+  composeLogs,
+  composePs,
+  composeRestart,
+  composeUp,
+  type AgentResult,
+  type AgentStatus,
+} from '@/compose'
+import { config } from '@/config'
+
+const upSub = defineCommand({
+  meta: { name: 'up', description: 'start every agent in immediate subdirectories of cwd' },
+  args: {
+    port: {
+      type: 'string',
+      description: 'preferred host port for each agent; collisions fall back to ephemeral per-agent',
+      default: String(config.port),
+    },
+    build: {
+      type: 'boolean',
+      description: 'regenerate each Dockerfile from the template and rebuild',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const { agents, results } = await composeUp({
+      rootCwd: process.cwd(),
+      preferredHostPort: Number(args.port),
+      forceBuild: args.build,
+      cliEntry: process.argv[1],
+    })
+    if (agents.length === 0) {
+      console.log('No typeclaw agents found in immediate subdirectories of cwd.')
+      return
+    }
+    let failed = 0
+    for (const r of results) {
+      if (r.ok) {
+        console.log(`[${r.name}] started on host port ${r.data.hostPort}`)
+      } else {
+        failed++
+        console.error(`[${r.name}] failed: ${r.reason}`)
+      }
+    }
+    summarize(results, 'started', failed)
+    if (failed > 0) process.exit(1)
+  },
+})
+
+const downSub = defineCommand({
+  meta: { name: 'down', description: 'stop every agent in immediate subdirectories of cwd' },
+  async run() {
+    const { agents, results } = await composeDown(process.cwd())
+    if (agents.length === 0) {
+      console.log('No typeclaw agents found in immediate subdirectories of cwd.')
+      return
+    }
+    let failed = 0
+    for (const r of results) {
+      if (r.ok) {
+        console.log(r.data.running ? `[${r.name}] stopped` : `[${r.name}] not running`)
+      } else {
+        failed++
+        console.error(`[${r.name}] failed: ${r.reason}`)
+      }
+    }
+    summarize(results, 'stopped', failed)
+    if (failed > 0) process.exit(1)
+  },
+})
+
+const restartSub = defineCommand({
+  meta: { name: 'restart', description: 'stop and relaunch every agent in immediate subdirectories of cwd' },
+  args: {
+    port: {
+      type: 'string',
+      description: 'preferred host port for each agent; collisions fall back to ephemeral per-agent',
+      default: String(config.port),
+    },
+    build: {
+      type: 'boolean',
+      description: 'regenerate each Dockerfile from the template and rebuild',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const { agents, results } = await composeRestart({
+      rootCwd: process.cwd(),
+      preferredHostPort: Number(args.port),
+      forceBuild: args.build,
+      cliEntry: process.argv[1],
+    })
+    if (agents.length === 0) {
+      console.log('No typeclaw agents found in immediate subdirectories of cwd.')
+      return
+    }
+    let failed = 0
+    for (const r of results) {
+      if (r.ok) {
+        console.log(`[${r.name}] restarted on host port ${r.data.start.hostPort}`)
+      } else {
+        failed++
+        console.error(`[${r.name}] failed: ${r.reason}`)
+      }
+    }
+    summarize(results, 'restarted', failed)
+    if (failed > 0) process.exit(1)
+  },
+})
+
+const psSub = defineCommand({
+  meta: { name: 'ps', description: 'show status of every agent in immediate subdirectories of cwd' },
+  async run() {
+    const { entries } = await composePs(process.cwd())
+    if (entries.length === 0) {
+      console.log('No typeclaw agents found in immediate subdirectories of cwd.')
+      return
+    }
+    const nameW = entries.reduce((w, e) => Math.max(w, e.name.length), 'NAME'.length)
+    const containerW = entries.reduce((w, e) => Math.max(w, e.containerName.length), 'CONTAINER'.length)
+    console.log(`${'NAME'.padEnd(nameW)}  ${'CONTAINER'.padEnd(containerW)}  STATUS`)
+    for (const e of entries) {
+      console.log(`${e.name.padEnd(nameW)}  ${e.containerName.padEnd(containerW)}  ${labelStatus(e.status)}`)
+    }
+  },
+})
+
+const logsSub = defineCommand({
+  meta: { name: 'logs', description: 'multiplex docker logs for every running agent in immediate subdirectories' },
+  args: {
+    follow: {
+      type: 'boolean',
+      alias: 'f',
+      description: 'stream new log output as it arrives',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const controller = new AbortController()
+    const onSig = (): void => controller.abort()
+    process.once('SIGINT', onSig)
+    process.once('SIGTERM', onSig)
+    try {
+      const result = await composeLogs({ rootCwd: process.cwd(), follow: args.follow, signal: controller.signal })
+      if (result.agents.length === 0) {
+        console.log('No typeclaw agents found in immediate subdirectories of cwd.')
+        return
+      }
+      if (result.exitCode !== 0) process.exit(result.exitCode)
+    } finally {
+      process.off('SIGINT', onSig)
+      process.off('SIGTERM', onSig)
+    }
+  },
+})
+
+export const composeCommand = defineCommand({
+  meta: {
+    name: 'compose',
+    description: 'orchestrate every typeclaw agent in immediate subdirectories of cwd',
+  },
+  subCommands: {
+    up: upSub,
+    down: downSub,
+    restart: restartSub,
+    ps: psSub,
+    logs: logsSub,
+  },
+})
+
+function labelStatus(s: AgentStatus): string {
+  if (s === 'running') return 'RUNNING'
+  if (s === 'stopped') return 'STOPPED'
+  return 'NOT CREATED'
+}
+
+function summarize<T>(results: AgentResult<T>[], verb: string, failed: number): void {
+  const ok = results.length - failed
+  if (failed === 0) {
+    console.log(`${verb} ${ok}/${results.length}`)
+  } else {
+    console.error(`${verb} ${ok}/${results.length} (${failed} failed)`)
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 
 import { defineCommand, runMain } from 'citty'
 
+import { composeCommand } from './compose'
 import { hostdCommand } from './hostd'
 import { init } from './init'
 import { logsCommand } from './logs'
@@ -28,6 +29,7 @@ const main = defineCommand({
     reload,
     logs: logsCommand,
     shell: shellCommand,
+    compose: composeCommand,
     _hostd: hostdCommand,
   },
 })

--- a/src/compose/discover.test.ts
+++ b/src/compose/discover.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { discoverAgents } from './discover'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-compose-discover-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function makeAgent(parent: string, name: string): Promise<string> {
+  const dir = join(parent, name)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'typeclaw.json'), '{}\n')
+  return dir
+}
+
+describe('discoverAgents', () => {
+  test('returns immediate subdirs that contain typeclaw.json', async () => {
+    await makeAgent(root, 'coder')
+    await makeAgent(root, 'planner')
+
+    const agents = discoverAgents(root)
+
+    expect(agents.map((a) => a.name)).toEqual(['coder', 'planner'])
+    expect(agents[0]?.cwd).toBe(join(root, 'coder'))
+    expect(agents[0]?.containerName).toBe('coder')
+  })
+
+  test('ignores subdirs without typeclaw.json', async () => {
+    await makeAgent(root, 'coder')
+    await mkdir(join(root, 'not-an-agent'))
+
+    expect(discoverAgents(root).map((a) => a.name)).toEqual(['coder'])
+  })
+
+  test('skips dot-prefixed directories', async () => {
+    await makeAgent(root, 'coder')
+    // A `.git` dir at the compose root would otherwise pass if it ever held a
+    // typeclaw.json — keep the filter explicit so future weirdness can't leak in.
+    await makeAgent(root, '.hidden-agent')
+
+    expect(discoverAgents(root).map((a) => a.name)).toEqual(['coder'])
+  })
+
+  test('ignores files at the compose root, even if named typeclaw.json', async () => {
+    await writeFile(join(root, 'typeclaw.json'), '{}\n')
+    await makeAgent(root, 'coder')
+
+    expect(discoverAgents(root).map((a) => a.name)).toEqual(['coder'])
+  })
+
+  test('does not recurse beyond one depth', async () => {
+    await makeAgent(root, 'team')
+    // Nested agent — should not be discovered. `team/` itself is the agent
+    // because it has typeclaw.json; the nested one is invisible to compose.
+    await makeAgent(join(root, 'team'), 'nested')
+
+    expect(discoverAgents(root).map((a) => a.name)).toEqual(['team'])
+  })
+
+  test('returns empty array when root has no agent subdirs', async () => {
+    expect(discoverAgents(root)).toEqual([])
+  })
+
+  test('returns empty array when root does not exist', async () => {
+    expect(discoverAgents(join(root, 'does-not-exist'))).toEqual([])
+  })
+
+  test('sorts agents alphabetically for deterministic output', async () => {
+    await makeAgent(root, 'zebra')
+    await makeAgent(root, 'alpha')
+    await makeAgent(root, 'mango')
+
+    expect(discoverAgents(root).map((a) => a.name)).toEqual(['alpha', 'mango', 'zebra'])
+  })
+})

--- a/src/compose/discover.ts
+++ b/src/compose/discover.ts
@@ -1,0 +1,43 @@
+import { readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+import { containerNameFromCwd } from '@/container'
+import { isInitialized } from '@/init'
+
+export type AgentEntry = {
+  name: string
+  cwd: string
+  containerName: string
+}
+
+// One-depth scan: lists immediate subdirectories of `rootCwd`, keeps the ones
+// that contain a typeclaw.json, and skips dot-prefixed names (.git, .vscode,
+// node_modules-style hidden dirs are not skipped because they don't match the
+// dot-prefix rule, but they also won't pass the typeclaw.json filter).
+//
+// Returns an empty array when rootCwd doesn't exist or is empty — discovery is
+// not the place to fail; the caller decides what to do with zero agents.
+//
+// Sort by name so output across operations (up/down/ps/restart/logs) is
+// deterministic regardless of filesystem readdir order.
+export function discoverAgents(rootCwd: string): AgentEntry[] {
+  const root = resolve(rootCwd)
+  let entries: { name: string; isDir: boolean }[]
+  try {
+    entries = readdirSync(root, { withFileTypes: true }).map((d) => ({ name: d.name, isDir: d.isDirectory() }))
+  } catch {
+    return []
+  }
+
+  const agents: AgentEntry[] = []
+  for (const entry of entries) {
+    if (!entry.isDir) continue
+    if (entry.name.startsWith('.')) continue
+    const cwd = join(root, entry.name)
+    if (!isInitialized(cwd)) continue
+    agents.push({ name: entry.name, cwd, containerName: containerNameFromCwd(cwd) })
+  }
+
+  agents.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+  return agents
+}

--- a/src/compose/down.ts
+++ b/src/compose/down.ts
@@ -1,0 +1,27 @@
+import { stop, type StopResult } from '@/container'
+
+import { discoverAgents, type AgentEntry } from './discover'
+import type { AgentResult } from './up'
+
+export type StopSuccess = Extract<StopResult, { ok: true }>
+
+export type ComposeDownResult = {
+  agents: AgentEntry[]
+  results: AgentResult<StopSuccess>[]
+}
+
+export async function composeDown(rootCwd: string): Promise<ComposeDownResult> {
+  const agents = discoverAgents(rootCwd)
+  const results = await Promise.all(
+    agents.map(async (agent): Promise<AgentResult<StopSuccess>> => {
+      try {
+        const data = await stop({ cwd: agent.cwd })
+        if (!data.ok) return { name: agent.name, ok: false, reason: data.reason }
+        return { name: agent.name, ok: true, data }
+      } catch (error) {
+        return { name: agent.name, ok: false, reason: error instanceof Error ? error.message : String(error) }
+      }
+    }),
+  )
+  return { agents, results }
+}

--- a/src/compose/index.ts
+++ b/src/compose/index.ts
@@ -1,0 +1,6 @@
+export { discoverAgents, type AgentEntry } from './discover'
+export { composeDown, type ComposeDownResult, type StopSuccess } from './down'
+export { colorFor, composeLogs, makeLinePrefixer, type ComposeLogsOptions, type ComposeLogsResult } from './logs'
+export { composePs, type AgentStatus, type AgentStatusEntry, type ComposePsResult } from './ps'
+export { composeRestart, type ComposeRestartOptions, type ComposeRestartResult, type RestartData } from './restart'
+export { composeUp, type AgentResult, type ComposeUpOptions, type ComposeUpResult, type StartSuccess } from './up'

--- a/src/compose/logs.test.ts
+++ b/src/compose/logs.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test'
+
+import { colorFor, makeLinePrefixer } from './logs'
+
+describe('colorFor', () => {
+  test('is deterministic for the same name', () => {
+    expect(colorFor('coder')).toBe(colorFor('coder'))
+  })
+
+  test('returns a value from the provided palette', () => {
+    const palette: readonly string[] = ['1', '2', '3']
+    expect(palette).toContain(colorFor('alpha', palette))
+    expect(palette).toContain(colorFor('beta', palette))
+  })
+})
+
+describe('makeLinePrefixer', () => {
+  test('emits complete lines with name padding and bar', () => {
+    const p = makeLinePrefixer('coder', 7, '36', false)
+
+    expect(p.write('hello\n')).toBe('coder   | hello\n')
+  })
+
+  test('buffers partial lines until newline arrives', () => {
+    const p = makeLinePrefixer('coder', 5, '36', false)
+
+    expect(p.write('hello')).toBe('')
+    expect(p.write(' world\n')).toBe('coder | hello world\n')
+  })
+
+  test('handles multiple newlines in one chunk', () => {
+    const p = makeLinePrefixer('a', 1, '36', false)
+
+    expect(p.write('one\ntwo\nthree\n')).toBe('a | one\na | two\na | three\n')
+  })
+
+  test('handles partial line followed by chunk with multiple newlines', () => {
+    const p = makeLinePrefixer('a', 1, '36', false)
+
+    p.write('hel')
+    expect(p.write('lo\nworld\n')).toBe('a | hello\na | world\n')
+  })
+
+  test('flush emits the un-terminated tail with a trailing newline', () => {
+    const p = makeLinePrefixer('a', 1, '36', false)
+
+    p.write('partial')
+    expect(p.flush()).toBe('a | partial\n')
+  })
+
+  test('flush is a no-op when the buffer is empty', () => {
+    const p = makeLinePrefixer('a', 1, '36', false)
+
+    p.write('done\n')
+    expect(p.flush()).toBe('')
+  })
+
+  test('emits ANSI escapes when useColor is true', () => {
+    const p = makeLinePrefixer('coder', 5, '36', true)
+
+    expect(p.write('hi\n')).toBe('\x1b[36mcoder\x1b[0m | hi\n')
+  })
+
+  test('does not splice across chunks within a single line', () => {
+    // given a name shorter than the column width
+    const p = makeLinePrefixer('a', 5, '36', false)
+
+    // when bytes arrive in tiny pieces
+    let out = ''
+    for (const ch of 'hello world\n') out += p.write(ch)
+
+    // then a single complete line is emitted (not 12 fragments)
+    expect(out).toBe('a     | hello world\n')
+  })
+})

--- a/src/compose/logs.ts
+++ b/src/compose/logs.ts
@@ -1,0 +1,162 @@
+import { containerExists } from '@/container'
+import { getBun } from '@/container/shared'
+
+import { discoverAgents, type AgentEntry } from './discover'
+
+export type ComposeLogsOptions = {
+  rootCwd: string
+  follow: boolean
+  out?: NodeJS.WritableStream
+  err?: NodeJS.WritableStream
+  signal?: AbortSignal
+}
+
+export type ComposeLogsResult = {
+  agents: AgentEntry[]
+  attached: AgentEntry[]
+  missing: AgentEntry[]
+  exitCode: number
+}
+
+const COLORS = ['36', '33', '32', '35', '34', '31', '96', '93', '92', '95'] as const
+
+export function colorFor(name: string, palette: readonly string[] = COLORS): string {
+  let h = 0
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0
+  return palette[h % palette.length] ?? '0'
+}
+
+// Stateful chunker that buffers partial lines across chunks: only emits
+// newline-terminated lines (each prefixed with the agent name + bar), and
+// flushes the un-terminated tail on EOF. Without this, interleaved chunks
+// from multiple agents would shred lines mid-character.
+export function makeLinePrefixer(
+  name: string,
+  width: number,
+  color: string,
+  useColor: boolean,
+): { write: (chunk: string) => string; flush: () => string } {
+  const padded = name.padEnd(width)
+  const prefix = useColor ? `\x1b[${color}m${padded}\x1b[0m | ` : `${padded} | `
+  let buffer = ''
+  return {
+    write(chunk: string): string {
+      buffer += chunk
+      const nl = buffer.lastIndexOf('\n')
+      if (nl < 0) return ''
+      const complete = buffer.slice(0, nl + 1)
+      buffer = buffer.slice(nl + 1)
+      return complete
+        .split('\n')
+        .slice(0, -1)
+        .map((l) => `${prefix}${l}\n`)
+        .join('')
+    },
+    flush(): string {
+      if (buffer.length === 0) return ''
+      const out = `${prefix}${buffer}\n`
+      buffer = ''
+      return out
+    },
+  }
+}
+
+export async function composeLogs({
+  rootCwd,
+  follow,
+  out = process.stdout,
+  err = process.stderr,
+  signal,
+}: ComposeLogsOptions): Promise<ComposeLogsResult> {
+  const agents = discoverAgents(rootCwd)
+
+  const liveness = await Promise.all(
+    agents.map(async (a) => ({ agent: a, exists: await containerExists(a.containerName) })),
+  )
+  const attached = liveness.filter((l) => l.exists).map((l) => l.agent)
+  const missing = liveness.filter((l) => !l.exists).map((l) => l.agent)
+
+  for (const a of missing) {
+    err.write(`compose: skipping ${a.name} (container not running)\n`)
+  }
+  if (attached.length === 0) return { agents, attached, missing, exitCode: 0 }
+
+  const bun = getBun()
+  if (!bun) {
+    err.write('compose: bun runtime not available\n')
+    return { agents, attached, missing, exitCode: 1 }
+  }
+
+  const width = attached.reduce((w, a) => Math.max(w, a.name.length), 0)
+  const useColor = supportsColor(out)
+
+  const procs = attached.map((agent) => {
+    const cmd = follow ? ['docker', 'logs', '-f', agent.containerName] : ['docker', 'logs', agent.containerName]
+    const proc = bun.spawn({ cmd, stdout: 'pipe', stderr: 'pipe' })
+    return { agent, proc }
+  })
+
+  const onAbort = (): void => {
+    for (const { proc } of procs) {
+      try {
+        proc.kill('SIGTERM')
+      } catch {
+        // already exited
+      }
+    }
+  }
+  signal?.addEventListener('abort', onAbort, { once: true })
+
+  const pumps = procs.flatMap(({ agent, proc }) => {
+    const color = colorFor(agent.name)
+    return [
+      pumpStream(proc.stdout, makeLinePrefixer(agent.name, width, color, useColor), out),
+      pumpStream(proc.stderr, makeLinePrefixer(agent.name, width, color, useColor), err),
+    ]
+  })
+
+  await Promise.all(pumps)
+  const exits = await Promise.all(procs.map((p) => p.proc.exited))
+  signal?.removeEventListener('abort', onAbort)
+
+  // 143 = 128 + SIGTERM(15). When we cancel via signal, every child exits 143;
+  // that's expected, not failure. Surface only the first non-OK, non-cancelled
+  // exit so a real `docker logs` failure (e.g. "no such container") still bubbles.
+  const exitCode = exits.find((c) => c !== 0 && c !== 143) ?? 0
+  return { agents, attached, missing, exitCode }
+}
+
+async function pumpStream(
+  stream: ReadableStream<Uint8Array>,
+  prefixer: { write: (s: string) => string; flush: () => string },
+  sink: NodeJS.WritableStream,
+): Promise<void> {
+  const decoder = new TextDecoder()
+  const reader = stream.getReader()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value && value.byteLength > 0) {
+        const out = prefixer.write(decoder.decode(value, { stream: true }))
+        if (out.length > 0) sink.write(out)
+      }
+    }
+    const tail = decoder.decode()
+    if (tail.length > 0) {
+      const out = prefixer.write(tail)
+      if (out.length > 0) sink.write(out)
+    }
+    const flushed = prefixer.flush()
+    if (flushed.length > 0) sink.write(flushed)
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+function supportsColor(stream: NodeJS.WritableStream): boolean {
+  const tty = (stream as unknown as { isTTY?: boolean }).isTTY === true
+  if (!tty) return false
+  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') return false
+  return true
+}

--- a/src/compose/ps.ts
+++ b/src/compose/ps.ts
@@ -1,0 +1,25 @@
+import { inspectContainer } from '@/container'
+
+import { discoverAgents, type AgentEntry } from './discover'
+
+export type AgentStatus = 'running' | 'stopped' | 'absent'
+
+export type AgentStatusEntry = AgentEntry & {
+  status: AgentStatus
+}
+
+export type ComposePsResult = {
+  entries: AgentStatusEntry[]
+}
+
+export async function composePs(rootCwd: string): Promise<ComposePsResult> {
+  const agents = discoverAgents(rootCwd)
+  const entries = await Promise.all(
+    agents.map(async (agent): Promise<AgentStatusEntry> => {
+      const state = await inspectContainer(agent.containerName)
+      const status: AgentStatus = !state.exists ? 'absent' : state.running ? 'running' : 'stopped'
+      return { ...agent, status }
+    }),
+  )
+  return { entries }
+}

--- a/src/compose/restart.ts
+++ b/src/compose/restart.ts
@@ -1,0 +1,45 @@
+import { validateConfig } from '@/config'
+import { start, stop } from '@/container'
+
+import { discoverAgents, type AgentEntry } from './discover'
+import type { StopSuccess } from './down'
+import type { AgentResult, StartSuccess } from './up'
+
+export type RestartData = { stop: StopSuccess; start: StartSuccess }
+
+export type ComposeRestartOptions = {
+  rootCwd: string
+  preferredHostPort: number
+  forceBuild?: boolean
+  cliEntry?: string
+}
+
+export type ComposeRestartResult = {
+  agents: AgentEntry[]
+  results: AgentResult<RestartData>[]
+}
+
+export async function composeRestart({
+  rootCwd,
+  preferredHostPort,
+  forceBuild = false,
+  cliEntry,
+}: ComposeRestartOptions): Promise<ComposeRestartResult> {
+  const agents = discoverAgents(rootCwd)
+  const results = await Promise.all(
+    agents.map(async (agent): Promise<AgentResult<RestartData>> => {
+      const validated = validateConfig(agent.cwd)
+      if (!validated.ok) return { name: agent.name, ok: false, reason: validated.reason }
+      try {
+        const stopped = await stop({ cwd: agent.cwd })
+        if (!stopped.ok) return { name: agent.name, ok: false, reason: stopped.reason }
+        const started = await start({ cwd: agent.cwd, preferredHostPort, forceBuild, cliEntry })
+        if (!started.ok) return { name: agent.name, ok: false, reason: started.reason }
+        return { name: agent.name, ok: true, data: { stop: stopped, start: started } }
+      } catch (error) {
+        return { name: agent.name, ok: false, reason: error instanceof Error ? error.message : String(error) }
+      }
+    }),
+  )
+  return { agents, results }
+}

--- a/src/compose/up.ts
+++ b/src/compose/up.ts
@@ -1,0 +1,43 @@
+import { validateConfig } from '@/config'
+import { start, type StartResult } from '@/container'
+
+import { discoverAgents, type AgentEntry } from './discover'
+
+export type AgentResult<T> = { name: string; ok: true; data: T } | { name: string; ok: false; reason: string }
+
+export type StartSuccess = Extract<StartResult, { ok: true }>
+
+export type ComposeUpOptions = {
+  rootCwd: string
+  preferredHostPort: number
+  forceBuild?: boolean
+  cliEntry?: string
+}
+
+export type ComposeUpResult = {
+  agents: AgentEntry[]
+  results: AgentResult<StartSuccess>[]
+}
+
+export async function composeUp({
+  rootCwd,
+  preferredHostPort,
+  forceBuild = false,
+  cliEntry,
+}: ComposeUpOptions): Promise<ComposeUpResult> {
+  const agents = discoverAgents(rootCwd)
+  const results = await Promise.all(
+    agents.map(async (agent): Promise<AgentResult<StartSuccess>> => {
+      const validated = validateConfig(agent.cwd)
+      if (!validated.ok) return { name: agent.name, ok: false, reason: validated.reason }
+      try {
+        const data = await start({ cwd: agent.cwd, preferredHostPort, forceBuild, cliEntry })
+        if (!data.ok) return { name: agent.name, ok: false, reason: data.reason }
+        return { name: agent.name, ok: true, data }
+      } catch (error) {
+        return { name: agent.name, ok: false, reason: error instanceof Error ? error.message : String(error) }
+      }
+    }),
+  )
+  return { agents, results }
+}

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -6,6 +6,8 @@ export {
   containerNameFromCwd,
   defaultDockerExec,
   imageTagFromCwd,
+  inspectContainer,
+  type ContainerState,
   type DockerExec,
   type DockerExecResult,
 } from './shared'


### PR DESCRIPTION
## Summary

Add a minimal `typeclaw compose` command that orchestrates every typeclaw agent in immediate subdirectories of the cwd. No compose file, no global registry — the directory layout is the manifest.

**Discovery rule**: one-depth scan of cwd, skip dot-prefixed directories, keep subdirs containing `typeclaw.json`, sort alphabetically, return empty (not error) when nothing matches.

## Commands

- `typeclaw compose up` — start all agents in parallel
- `typeclaw compose down` — stop all agents in parallel
- `typeclaw compose restart` — stop + start each agent in parallel
- `typeclaw compose ps` — table of NAME / CONTAINER / STATUS (RUNNING / STOPPED / NOT CREATED)
- `typeclaw compose logs [-f]` — multiplexed `docker logs` with name-prefixed lines, ANSI color when TTY, SIGINT-aware

## Files

New:
- `src/compose/discover.ts` + `discover.test.ts`
- `src/compose/up.ts`
- `src/compose/down.ts`
- `src/compose/restart.ts`
- `src/compose/ps.ts`
- `src/compose/logs.ts` + `logs.test.ts`
- `src/compose/index.ts`
- `src/cli/compose.ts`

Modified:
- `src/cli/index.ts` — register `compose: composeCommand`
- `src/container/index.ts` — export `inspectContainer` + `ContainerState` (used by `compose ps`)

## Design notes

**Best-effort failure model**: per-agent results are collected in parallel; a non-zero exit code is returned only when at least one agent fails. One broken agent doesn't block the rest.

**Parallelism is safe**: each agent's `start()`/`stop()` is independent; the existing `ensureDaemon()` lock and host-port retry path are already race-safe.

**`compose logs -f` snapshots at invocation**: agents started after `logs -f` begins won't appear in that run. Intentional and documented.

**Bulk verbs forward `--port` and `--build`** where applicable, mirroring `typeclaw start`/`restart` semantics. `--port` is a per-agent preferred port; falls back to ephemeral on collision.

**Deliberate non-features for v1**: no `compose init`, no `compose tui <name>`, no compose file. The directory layout is the manifest and that's enough for the first iteration. Doors left open.

Follows the `src/<domain>/` + `src/cli/` split per AGENTS.md.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 warnings, 0 errors
- `bun run format` — clean
- `bun test` — 1475 pass, 0 fail (18 new compose tests, no regressions)

No breaking changes. The container barrel additions (`inspectContainer`, `ContainerState`) are purely additive.