### PR TITLE
Enable bun monorepo support for agent folders

### DIFF
--- a/plugins/guard/index.test.ts
+++ b/plugins/guard/index.test.ts
@@ -102,6 +102,30 @@ describe('guard plugin', () => {
     expect(absoluteResult).toBeUndefined()
   })
 
+  test('allows writes under the agent root packages directory (bun workspace root)', async () => {
+    const hook = await toolBeforeHook()
+
+    const newPackageFile = await hook(
+      toolEvent('write', { path: 'packages/my-plugin/index.ts', content: 'export {}' }),
+      hookContext('/agent'),
+    )
+    const newPackageJson = await hook(
+      toolEvent('write', { path: 'packages/my-plugin/package.json', content: '{}' }),
+      hookContext('/agent'),
+    )
+    const editAbsolute = await hook(
+      toolEvent('edit', {
+        path: '/agent/packages/my-plugin/index.ts',
+        edits: [{ oldText: 'export {}', newText: 'export const x = 1' }],
+      }),
+      hookContext('/agent'),
+    )
+
+    expect(newPackageFile).toBeUndefined()
+    expect(newPackageJson).toBeUndefined()
+    expect(editAbsolute).toBeUndefined()
+  })
+
   test('still blocks unknown files and nested paths under allowed root names', async () => {
     const hook = await toolBeforeHook()
 

--- a/plugins/guard/policies/non-workspace-write.ts
+++ b/plugins/guard/policies/non-workspace-write.ts
@@ -16,7 +16,12 @@ const AGENT_ROOT_WRITE_ALLOWLIST = new Set([
   'typeclaw.json',
 ])
 
-const AGENT_ROOT_DIRECTORY_ALLOWLIST = new Set(['mounts'])
+// `packages/` is a bun workspace root scaffolded at init (see
+// src/init/index.ts#DIRECTORIES). Reusable systems and custom typeclaw
+// plugins live there as standalone packages, so the agent must be able to
+// write into `packages/<name>/...` without acknowledging the guard — same
+// as `workspace/`, but for code intended to be reused rather than discarded.
+const AGENT_ROOT_DIRECTORY_ALLOWLIST = new Set(['mounts', 'packages'])
 
 export async function checkNonWorkspaceWriteGuard(options: {
   tool: string

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -21,7 +21,24 @@ afterEach(async () => {
   await rm(root, { recursive: true, force: true })
 })
 
+// Mirror the post-init agent-folder shape: package.json declares the
+// `packages/*` bun workspace and `packages/.gitkeep` exists so refreshPackageJson
+// is a no-op. Tests that want to exercise the migration path should call
+// `writePackageJsonPreMigration` instead.
 async function writePackageJson(dir: string, deps: Record<string, string>): Promise<void> {
+  const pkg = {
+    name: basename(dir),
+    private: true,
+    type: 'module',
+    workspaces: ['packages/*'],
+    dependencies: deps,
+  }
+  await writeFile(join(dir, 'package.json'), `${JSON.stringify(pkg, null, 2)}\n`)
+  await mkdir(join(dir, 'packages'), { recursive: true })
+  await writeFile(join(dir, 'packages', '.gitkeep'), '')
+}
+
+async function writePackageJsonPreMigration(dir: string, deps: Record<string, string>): Promise<void> {
   const pkg = { name: basename(dir), private: true, type: 'module', dependencies: deps }
   await writeFile(join(dir, 'package.json'), `${JSON.stringify(pkg, null, 2)}\n`)
 }
@@ -869,6 +886,57 @@ describe('start (composition)', () => {
     expect(result.ok).toBe(true)
     const headAfter = await runGit(root, ['rev-parse', 'HEAD'])
     expect(headAfter).toBe(headBefore)
+  })
+
+  test('migrates a pre-monorepo agent folder by injecting workspaces and committing the change', async () => {
+    // given: an agent folder from before bun-workspaces support — package.json has no
+    // `workspaces` field, packages/.gitkeep does not exist
+    await gitInit(root)
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+    await writePackageJsonPreMigration(root, { typeclaw: '^0.1.0' })
+    await runGit(root, ['add', '.gitignore', 'package.json'])
+    await runGit(root, ['commit', '-m', 'initial'])
+    const headBefore = await runGit(root, ['rev-parse', 'HEAD'])
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    // when: start runs (refreshPackageJson should inject workspaces and create .gitkeep)
+    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+
+    // then: a new commit landed with the migration
+    expect(result.ok).toBe(true)
+    const headAfter = await runGit(root, ['rev-parse', 'HEAD'])
+    expect(headAfter).not.toBe(headBefore)
+    const subjects = (await runGit(root, ['log', '--format=%s'])).split('\n')
+    expect(subjects).toContain('Enable bun workspaces (packages/*)')
+    // and: the agent folder is now in the post-migration shape
+    const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as Record<string, unknown>
+    expect(pkg.workspaces).toEqual(['packages/*'])
+    expect(existsSync(join(root, 'packages', '.gitkeep'))).toBe(true)
+    // and: the migration commit tracks both files
+    const filesInCommit = (await runGit(root, ['show', '--name-only', '--format=', 'HEAD'])).split('\n').sort()
+    expect(filesInCommit).toEqual(['package.json', 'packages/.gitkeep'])
+  })
+
+  test('migration is idempotent: a second start on the migrated folder does not create another commit', async () => {
+    await gitInit(root)
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+    await writePackageJsonPreMigration(root, { typeclaw: '^0.1.0' })
+    await runGit(root, ['add', '.gitignore', 'package.json'])
+    await runGit(root, ['commit', '-m', 'initial'])
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    // first start: migrates
+    const first = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    expect(first.ok).toBe(true)
+    const headAfterFirst = await runGit(root, ['rev-parse', 'HEAD'])
+
+    // second start: no-op
+    const second = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    expect(second.ok).toBe(true)
+    const headAfterSecond = await runGit(root, ['rev-parse', 'HEAD'])
+    expect(headAfterSecond).toBe(headAfterFirst)
   })
 
   test('can register through the current hostd without drift respawn during daemon-owned restart', async () => {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -9,6 +9,7 @@ import type { HttpInfoResult } from '@/hostd/protocol'
 import { ensureDaemon } from '@/hostd/spawn'
 import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
+import { refreshPackageJson } from '@/init/packagejson'
 
 import { CONTAINER_PORT, findFreePort, isPortAllocatedError } from './port'
 import { containerNameFromCwd, defaultDockerExec, type DockerExec, getBun, imageTagFromCwd } from './shared'
@@ -97,21 +98,30 @@ export async function start({
 
     // Probe container state BEFORE refreshing Dockerfile/.gitignore: when the
     // container is already running, start() is a no-op and must not produce
-    // side effects (template writes, .gitignore commits) that would surprise
-    // a user invoking `compose up` against a partially-up tree.
+    // side effects (template writes, .gitignore commits, package.json migration)
+    // that would surprise a user invoking `compose up` against a partially-up
+    // tree.
     const state = await inspectContainer(exec, containerName)
     if (state.exists && state.running) {
       return await reportAlreadyRunning(exec, cwd, containerName)
     }
 
-    // TypeClaw owns Dockerfile and .gitignore. Refresh them from the current
-    // CLI templates on every fresh start (not just --build) so version drift
-    // between the agent folder and the CLI is corrected automatically. The
-    // Dockerfile is gitignored (regenerated on every start, never tracked),
-    // so only the .gitignore needs an auto-commit if its content changed.
+    // TypeClaw owns Dockerfile, .gitignore, and the bun-workspaces shape of
+    // package.json. Refresh them from the current CLI templates on every fresh
+    // start (not just --build) so version drift between the agent folder and
+    // the CLI is corrected automatically. The Dockerfile is gitignored
+    // (regenerated on every start, never tracked), so only .gitignore and the
+    // package.json migration land in git. The package.json migration is
+    // one-shot and idempotent — once `workspaces` is set, refreshPackageJson
+    // is a no-op, so users who never edit their agent folder pay zero cost on
+    // subsequent starts and users who customized `workspaces` are not clobbered.
     await refreshDockerfile(cwd)
     await refreshGitignore(cwd)
+    const pkgRefresh = await refreshPackageJson(cwd)
     await commitSystemFile(cwd, GITIGNORE_FILE, 'Update .gitignore')
+    if (pkgRefresh.changed) {
+      await commitSystemFile(cwd, pkgRefresh.files, 'Enable bun workspaces (packages/*)')
+    }
 
     if (state.exists) {
       // Container is stopped/exited/being-removed but still holds the name.
@@ -276,17 +286,24 @@ export async function refreshGitignore(cwd: string): Promise<void> {
   await writeFile(join(cwd, GITIGNORE_FILE), buildGitignore(cfg.gitignore))
 }
 
-// Commits a TypeClaw-owned system file if it's dirty in git. Skips silently
+// Commits TypeClaw-owned system file(s) if any are dirty in git. Skips silently
 // when the agent folder is not a git repo, when bun is unavailable, or when
-// the file is clean (no changes since last commit). Uses the user's global
-// git config for authorship — TypeClaw does not impersonate the user here.
-export async function commitSystemFile(cwd: string, file: string, message: string): Promise<void> {
+// every named file is clean (no changes since last commit). Uses the user's
+// global git config for authorship — TypeClaw does not impersonate the user
+// here. Accepts a single file or an array; the array form produces a single
+// atomic commit covering all listed paths, used for migrations that touch
+// multiple files together (e.g. enabling bun workspaces writes both
+// package.json and packages/.gitkeep in one commit).
+export async function commitSystemFile(cwd: string, file: string | readonly string[], message: string): Promise<void> {
+  const files = typeof file === 'string' ? [file] : file
+  if (files.length === 0) return
+
   const bun = getBun()
   if (!bun) return
   if (!existsSync(join(cwd, '.git'))) return
 
   const status = bun.spawn({
-    cmd: ['git', 'status', '--porcelain', '--', file],
+    cmd: ['git', 'status', '--porcelain', '--', ...files],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -295,11 +312,11 @@ export async function commitSystemFile(cwd: string, file: string, message: strin
   const dirty = (await new Response(status.stdout).text()).trim().length > 0
   if (!dirty) return
 
-  const add = bun.spawn({ cmd: ['git', 'add', '--', file], cwd, stdout: 'pipe', stderr: 'pipe' })
+  const add = bun.spawn({ cmd: ['git', 'add', '--', ...files], cwd, stdout: 'pipe', stderr: 'pipe' })
   if ((await add.exited) !== 0) return
 
   const commit = bun.spawn({
-    cmd: ['git', 'commit', '-m', message, '--only', '--', file],
+    cmd: ['git', 'commit', '-m', message, '--only', '--', ...files],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',

--- a/src/init/gitignore.ts
+++ b/src/init/gitignore.ts
@@ -15,6 +15,7 @@ export function buildGitignore(config: GitignoreConfig = { append: [] }): string
 .env
 .env.local
 node_modules/
+packages/*/node_modules/
 workspace/
 mounts/
 Dockerfile

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -133,6 +133,9 @@ describe('runInit', () => {
     expect(tracked).toContain('package.json')
     expect(tracked).toContain('.gitignore')
     expect(tracked).toContain('AGENTS.md')
+    // packages/.gitkeep must be tracked so cloning the agent folder onto a
+    // fresh machine still has the workspace root present (git ignores empty dirs).
+    expect(tracked).toContain('packages/.gitkeep')
     // Dockerfile is gitignored (regenerated on every `typeclaw start`),
     // so it must NOT appear in the initial commit even though it exists on disk.
     expect(tracked).not.toContain('Dockerfile')
@@ -354,11 +357,19 @@ describe('scaffold', () => {
   test('creates expected directories', async () => {
     await scaffold(root)
 
-    for (const dir of ['workspace', 'sessions', '.agents/skills', 'mounts']) {
+    for (const dir of ['workspace', 'sessions', '.agents/skills', 'mounts', 'packages']) {
       const path = join(root, dir)
       expect(existsSync(path)).toBe(true)
       expect(statSync(path).isDirectory()).toBe(true)
     }
+  })
+
+  test('writes packages/.gitkeep so the empty workspace root survives the initial git commit', async () => {
+    await scaffold(root)
+
+    const gitkeep = join(root, 'packages', '.gitkeep')
+    expect(existsSync(gitkeep)).toBe(true)
+    expect(await readFile(gitkeep, 'utf8')).toBe('')
   })
 
   test('does NOT scaffold MEMORY.md or memory/ (owned by the bundled memory plugin)', async () => {
@@ -453,6 +464,13 @@ describe('scaffold', () => {
     expect(pkg.scripts).toBeUndefined()
   })
 
+  test('package.json declares packages/* as a bun workspace root', async () => {
+    await scaffold(root)
+
+    const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as Record<string, unknown>
+    expect(pkg.workspaces).toEqual(['packages/*'])
+  })
+
   test('package.json bundles agent-browser so the agent-browser skill can shell out to the CLI', async () => {
     await scaffold(root)
 
@@ -495,6 +513,7 @@ describe('scaffold', () => {
     expect(gitignore).toMatch(/^workspace\/$/m)
     expect(gitignore).toContain('mounts/')
     expect(gitignore).toMatch(/^Dockerfile$/m)
+    expect(gitignore).toMatch(/^packages\/\*\/node_modules\/$/m)
   })
 
   test('buildGitignore includes custom entries from gitignore.append before managed entries', () => {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -10,6 +10,9 @@ import { createTui } from '@/tui'
 import { buildDockerfile, DOCKERFILE } from './dockerfile'
 import { buildGitignore, GITIGNORE_FILE } from './gitignore'
 import { HATCHING_PROMPT } from './hatching'
+import { GITKEEP_FILE, PACKAGES_DIR } from './paths'
+
+export { GITKEEP_FILE, PACKAGES_DIR } from './paths'
 
 const CONFIG_FILE = 'typeclaw.json'
 const CRON_FILE = 'cron.json'
@@ -18,7 +21,13 @@ const PACKAGE_FILE = 'package.json'
 
 const MARKDOWN_FILES = ['AGENTS.md', 'IDENTITY.md', 'SOUL.md', 'USER.md'] as const
 
-const DIRECTORIES = ['workspace', 'sessions', '.agents/skills', 'mounts'] as const
+// `packages/` is a bun workspace root (see `workspaces` in buildPackageJson).
+// Reusable systems the agent builds — including custom plugins wired into
+// typeclaw.json — live there as standalone packages, while one-off scripts
+// stay in `workspace/`. The directory is scaffolded empty so the layout is
+// discoverable on day one; a `.gitkeep` is written below so it survives the
+// initial commit.
+const DIRECTORIES = ['workspace', 'sessions', '.agents/skills', 'mounts', 'packages'] as const
 
 export type InstallResult = { ok: true } | { ok: false; reason: string }
 export type GitInitResult = { ok: true; skipped: boolean } | { ok: false; reason: string }
@@ -205,6 +214,13 @@ export type ScaffoldOptions = {
 export async function scaffold(root: string, options: ScaffoldOptions = {}): Promise<void> {
   await Promise.all(DIRECTORIES.map((dir) => mkdir(join(root, dir), { recursive: true })))
 
+  // git does not track empty directories, so without this file the `packages/`
+  // workspace root would silently disappear from the initial commit and confuse
+  // the agent (its workspaces glob would resolve to nothing). The other
+  // DIRECTORIES are either gitignored (workspace, sessions, mounts) or
+  // immediately populated, so packages/ is the only one that needs this.
+  await writeFile(join(root, PACKAGES_DIR, GITKEEP_FILE), '', { flag: 'wx' }).catch(ignoreExists)
+
   // TODO: hardcoded model. Mirror src/config/index.ts until the config loader
   // and provider registry exist (TypeClaw.md Phase 1 + Phase 4).
   //
@@ -255,6 +271,7 @@ function buildPackageJson(root: string, name: string): Record<string, unknown> {
     name,
     private: true,
     type: 'module',
+    workspaces: [`${PACKAGES_DIR}/*`],
     dependencies: {
       typeclaw: fileSpec,
       'agent-browser': AGENT_BROWSER_VERSION,

--- a/src/init/packagejson.test.ts
+++ b/src/init/packagejson.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { refreshPackageJson } from './packagejson'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-pkgjson-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function writePkg(content: Record<string, unknown>): Promise<void> {
+  await writeFile(join(root, 'package.json'), `${JSON.stringify(content, null, 2)}\n`)
+}
+
+async function readPkg(): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as Record<string, unknown>
+}
+
+describe('refreshPackageJson', () => {
+  test('injects workspaces and creates packages/.gitkeep when both are missing', async () => {
+    await writePkg({ name: 'agent', private: true, type: 'module', dependencies: { typeclaw: 'file:../typeclaw' } })
+
+    const result = await refreshPackageJson(root)
+
+    expect(result.changed).toBe(true)
+    expect(result.files.sort()).toEqual(['package.json', 'packages/.gitkeep'])
+    const pkg = await readPkg()
+    expect(pkg.workspaces).toEqual(['packages/*'])
+    expect(existsSync(join(root, 'packages', '.gitkeep'))).toBe(true)
+  })
+
+  test('is idempotent: a second call after the first reports no changes', async () => {
+    await writePkg({ name: 'agent', private: true, type: 'module' })
+
+    const first = await refreshPackageJson(root)
+    const second = await refreshPackageJson(root)
+
+    expect(first.changed).toBe(true)
+    expect(second.changed).toBe(false)
+    expect(second.files).toEqual([])
+  })
+
+  test('preserves an existing workspaces field (does not clobber a customized layout)', async () => {
+    await writePkg({
+      name: 'agent',
+      private: true,
+      type: 'module',
+      workspaces: ['custom/*', 'libs/*'],
+    })
+
+    const result = await refreshPackageJson(root)
+
+    const pkg = await readPkg()
+    expect(pkg.workspaces).toEqual(['custom/*', 'libs/*'])
+    // package.json is unchanged, but .gitkeep may still be created if missing
+    expect(result.files).not.toContain('package.json')
+  })
+
+  test('preserves all other top-level fields (name, deps, scripts, custom keys)', async () => {
+    await writePkg({
+      name: 'my-agent',
+      private: true,
+      type: 'module',
+      scripts: { test: 'bun test' },
+      dependencies: { typeclaw: 'file:../typeclaw', 'agent-browser': '^0.26.0' },
+      devDependencies: { '@types/bun': 'latest' },
+      customField: { keep: 'me' },
+    })
+
+    await refreshPackageJson(root)
+
+    const pkg = await readPkg()
+    expect(pkg.name).toBe('my-agent')
+    expect(pkg.private).toBe(true)
+    expect(pkg.type).toBe('module')
+    expect(pkg.scripts).toEqual({ test: 'bun test' })
+    expect(pkg.dependencies).toEqual({ typeclaw: 'file:../typeclaw', 'agent-browser': '^0.26.0' })
+    expect(pkg.devDependencies).toEqual({ '@types/bun': 'latest' })
+    expect(pkg.customField).toEqual({ keep: 'me' })
+  })
+
+  test('places workspaces immediately after type for clean diffs', async () => {
+    await writePkg({
+      name: 'agent',
+      private: true,
+      type: 'module',
+      dependencies: { typeclaw: 'file:../typeclaw' },
+    })
+
+    await refreshPackageJson(root)
+
+    const raw = await readFile(join(root, 'package.json'), 'utf8')
+    const typeIdx = raw.indexOf('"type"')
+    const workspacesIdx = raw.indexOf('"workspaces"')
+    const dependenciesIdx = raw.indexOf('"dependencies"')
+    expect(typeIdx).toBeGreaterThan(-1)
+    expect(workspacesIdx).toBeGreaterThan(typeIdx)
+    expect(workspacesIdx).toBeLessThan(dependenciesIdx)
+  })
+
+  test('skips silently when package.json is missing (folder not initialized)', async () => {
+    const result = await refreshPackageJson(root)
+
+    // gitkeep is still created — it's orthogonal to package.json existence
+    expect(result.changed).toBe(true)
+    expect(result.files).toEqual(['packages/.gitkeep'])
+    expect(existsSync(join(root, 'package.json'))).toBe(false)
+    expect(existsSync(join(root, 'packages', '.gitkeep'))).toBe(true)
+  })
+
+  test('skips silently when package.json is unparseable (never touches corrupt files)', async () => {
+    await writeFile(join(root, 'package.json'), '{ not json')
+
+    const result = await refreshPackageJson(root)
+
+    // gitkeep created, but package.json is left alone
+    expect(result.files).not.toContain('package.json')
+    const raw = await readFile(join(root, 'package.json'), 'utf8')
+    expect(raw).toBe('{ not json')
+  })
+
+  test('skips silently when package.json is a non-object JSON value', async () => {
+    await writeFile(join(root, 'package.json'), '[1, 2, 3]')
+
+    const result = await refreshPackageJson(root)
+
+    expect(result.files).not.toContain('package.json')
+    const raw = await readFile(join(root, 'package.json'), 'utf8')
+    expect(raw).toBe('[1, 2, 3]')
+  })
+
+  test('creates packages/ directory if it does not exist when writing .gitkeep', async () => {
+    await writePkg({ name: 'agent', private: true, type: 'module' })
+
+    await refreshPackageJson(root)
+
+    expect(existsSync(join(root, 'packages'))).toBe(true)
+    expect(existsSync(join(root, 'packages', '.gitkeep'))).toBe(true)
+  })
+
+  test('skips writing .gitkeep when it already exists with non-empty content (does not clobber)', async () => {
+    await writePkg({ name: 'agent', private: true, type: 'module' })
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(join(root, 'packages'), { recursive: true })
+    const customContent = '# placeholder for git-tracked empty dir, do not delete\n'
+    await writeFile(join(root, 'packages', '.gitkeep'), customContent)
+
+    const result = await refreshPackageJson(root)
+
+    expect(result.files).not.toContain('packages/.gitkeep')
+    expect(await readFile(join(root, 'packages', '.gitkeep'), 'utf8')).toBe(customContent)
+  })
+})

--- a/src/init/packagejson.ts
+++ b/src/init/packagejson.ts
@@ -1,0 +1,94 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { GITKEEP_FILE, PACKAGES_DIR } from './paths'
+
+export const PACKAGE_FILE = 'package.json'
+export const WORKSPACES_GLOB = `${PACKAGES_DIR}/*`
+
+export type PackageJsonRefreshResult = {
+  changed: boolean
+  files: string[]
+}
+
+// Migrates an existing agent folder into a bun monorepo layout. Idempotent —
+// running twice is a no-op. Skips silently when:
+//   - package.json is missing (folder not initialized yet)
+//   - package.json is unparseable (we never touch corrupt user files)
+//   - workspaces is already set (user opted in or customized)
+//
+// Always ensures `packages/<GITKEEP_FILE>` exists so the directory survives the
+// initial git commit, regardless of whether package.json was touched.
+//
+// Returns the list of paths the caller should consider for git auto-commit.
+// The caller (typeclaw start) commits these via the same `commitSystemFile`
+// pattern as .gitignore, keeping the monorepo migration on git's record.
+export async function refreshPackageJson(cwd: string): Promise<PackageJsonRefreshResult> {
+  const changed: string[] = []
+  const pkgPath = join(cwd, PACKAGE_FILE)
+
+  if (existsSync(pkgPath)) {
+    const updated = await ensureWorkspacesField(pkgPath)
+    if (updated) changed.push(PACKAGE_FILE)
+  }
+
+  const gitkeepRel = join(PACKAGES_DIR, GITKEEP_FILE)
+  const gitkeepPath = join(cwd, gitkeepRel)
+  if (!existsSync(gitkeepPath)) {
+    await mkdir(join(cwd, PACKAGES_DIR), { recursive: true })
+    await writeFile(gitkeepPath, '')
+    changed.push(gitkeepRel)
+  }
+
+  return { changed: changed.length > 0, files: changed }
+}
+
+async function ensureWorkspacesField(pkgPath: string): Promise<boolean> {
+  let raw: string
+  try {
+    raw = await readFile(pkgPath, 'utf8')
+  } catch {
+    return false
+  }
+
+  let pkg: Record<string, unknown>
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return false
+    pkg = parsed as Record<string, unknown>
+  } catch {
+    return false
+  }
+
+  if ('workspaces' in pkg) return false
+
+  // Insertion order matters: place `workspaces` right after `type` (or after
+  // top-of-object metadata if `type` is absent) so the diff reads cleanly
+  // alongside the buildPackageJson template's field order. Without this, a
+  // freshly-migrated package.json has `workspaces` at the bottom — visually
+  // jarring and harder to spot on review.
+  const next = insertAfterKey(pkg, 'type', 'workspaces', [WORKSPACES_GLOB])
+  await writeFile(pkgPath, `${JSON.stringify(next, null, 2)}\n`)
+  return true
+}
+
+function insertAfterKey(
+  obj: Record<string, unknown>,
+  anchor: string,
+  key: string,
+  value: unknown,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  const keys = Object.keys(obj)
+  const anchorIdx = keys.indexOf(anchor)
+  if (anchorIdx === -1) {
+    return { [key]: value, ...obj }
+  }
+  for (let i = 0; i < keys.length; i++) {
+    const k = keys[i] as string
+    out[k] = obj[k]
+    if (i === anchorIdx) out[key] = value
+  }
+  return out
+}

--- a/src/init/paths.ts
+++ b/src/init/paths.ts
@@ -1,0 +1,2 @@
+export const PACKAGES_DIR = 'packages'
+export const GITKEEP_FILE = '.gitkeep'

--- a/src/skills/typeclaw-monorepo/SKILL.md
+++ b/src/skills/typeclaw-monorepo/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: typeclaw-monorepo
+description: Use this skill whenever you are about to write code that another part of your agent folder might want to reuse, or you need to decide where new code goes. Triggers include "create a package", "extract this into a library", "make this reusable", "where should this script live", "add a workspace", "edit root scripts", "bun workspaces", "packages/", "monorepo", or any tool/utility/library you intend to call from more than one place. Read it before scaffolding anything under `packages/` — the layout has conventions for plugins, custom scripts, and root-level wiring that you must not improvise around.
+---
+
+# typeclaw-monorepo
+
+Your agent folder is a **bun monorepo**. The root `package.json` declares `"workspaces": ["packages/*"]`, and each subdirectory of `packages/` is a fully independent bun package that can be installed, depended on, and run from anywhere in the agent folder. This skill exists so you put new code in the right place, follow the workspace conventions, and do not surprise the user with random script files scattered around.
+
+## The two zones, and which to pick
+
+You have two free-write zones at the agent root: `workspace/` and `packages/`. Both are exempt from the non-workspace-write guard so you can edit them without acknowledging anything, but their relationship to git is opposite, and picking the wrong one is the most common mistake.
+
+| Zone         | Purpose                                                            | Tracked in git?                                                                                           | Reusable?                                    |
+| ------------ | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `workspace/` | One-off scripts, scratch work, throwaway experiments               | **No** — entire dir is gitignored                                                                         | No (the dir itself is invisible to git)      |
+| `packages/`  | Reusable packages, custom plugins, shared utilities, internal libs | **Yes** — every file is tracked and MUST be committed when edited (only `*/node_modules/` ignored inside) | Yes (committed and importable across agents) |
+
+The two columns to internalize:
+
+- **Guard allowlist** (write permission): `workspace/` and `packages/` are both free-write — no `acknowledgeGuards` needed. This is about whether the agent can write the file at all.
+- **Git tracking** (persistence): `workspace/` is gitignored end-to-end (a true scratch zone, lost on clone), while `packages/` is fully tracked (committed to git, shipped with the agent folder, visible in PRs). This is about whether the file survives.
+
+Anything you put in `packages/` MUST land in a commit — see `typeclaw-git`. The non-`node_modules/` files in `packages/` are not gitignored; treating them as throwaway will surprise the user when their PR includes a half-baked package they did not expect.
+
+**Decision rule, top to bottom — stop at the first match:**
+
+1. **Will another script or another part of the agent folder import this?** → `packages/<name>/`. Even if "another part" is just "tomorrow's me writing a sibling script", a reusable thing belongs here.
+2. **Is this a custom typeclaw plugin** (anything you'd list in `typeclaw.json`'s `plugins`)? → `packages/<plugin-name>/`. Always. Plugins are the canonical packages.
+3. **Will the user want to track this in git, see it in PRs, depend on it from a cron job?** → `packages/<name>/`.
+4. **Is this throwaway** — a one-shot data transformation, a debug script, a scratch experiment that exists for one task and dies? → `workspace/`.
+5. **Default if unsure** → `packages/<name>/`. Better to commit something reusable than to lose something useful in the gitignored void.
+
+The hidden cost of getting this wrong: code in `workspace/` is invisible to git (the entire `workspace/` dir is gitignored as a "free-write zone"), so a reusable utility you put there will silently disappear on the next clone, the next session that runs `git clean`, or the next time a user tarballs the agent folder for backup.
+
+## Anatomy of a `packages/<name>/` package
+
+A bun workspace package is just a normal package directory:
+
+```
+packages/
+  my-utility/
+    package.json        # name, version, dependencies, scripts
+    index.ts            # entrypoint
+    index.test.ts       # tests, if appropriate
+```
+
+Minimal `packages/my-utility/package.json`:
+
+```json
+{
+  "name": "my-utility",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./index.ts",
+  "exports": {
+    ".": "./index.ts"
+  }
+}
+```
+
+Notes that catch people:
+
+- **`private: true`** keeps the package out of any accidental publish. Default to `true` unless the user explicitly asks for a publishable package.
+- **`type: "module"`** matches the agent root and avoids ESM/CJS surprises. Always set it.
+- **`main` and `exports` point at `index.ts` directly.** Bun executes TypeScript natively in the workspace; no build step required.
+- **`name` is the import specifier.** `import { foo } from 'my-utility'` works from anywhere in the agent folder once you `bun install`. Pick a name you would not be embarrassed to type — descriptive and lowercase, no scope unless you have a reason.
+- **No version churn.** Workspace packages stay at `0.0.0` unless the user explicitly versions them. Bun resolves them by name, not by version.
+
+## Wiring a workspace package into another package
+
+To depend on `packages/my-utility` from another package (e.g. `packages/my-plugin`), add it to that package's `dependencies` with the workspace protocol:
+
+```json
+{
+  "name": "my-plugin",
+  "dependencies": {
+    "my-utility": "workspace:*"
+  }
+}
+```
+
+Then `bun install` from the agent folder root. Bun symlinks the workspace package into `packages/my-plugin/node_modules/my-utility` and `import` resolves it normally. The `*` matches any version because workspace packages don't track versions.
+
+To depend on a workspace package from the **agent root** (e.g. so cron `exec` jobs or root scripts can call into it), add it to the **root** `package.json#dependencies` the same way:
+
+```json
+{
+  "dependencies": {
+    "typeclaw": "file:../typeclaw",
+    "agent-browser": "^0.26.0",
+    "my-utility": "workspace:*"
+  }
+}
+```
+
+## Custom typeclaw plugins live under `packages/`
+
+If you are writing a typeclaw plugin (anything that uses `definePlugin` from `typeclaw/plugin`), the canonical home is `packages/<plugin-name>/`. The workflow:
+
+1. **Author**: `packages/my-plugin/index.ts` exports `definePlugin({ ... })` as default.
+2. **Wire**: edit `typeclaw.json` so the `plugins` array contains the local path:
+
+   ```json
+   {
+     "plugins": ["./packages/my-plugin"]
+   }
+   ```
+
+3. **Per-plugin config block** uses the **derived name** (basename of the path with extensions stripped — see the `typeclaw-plugins` skill for the full naming rule). For `./packages/my-plugin`, the derived name is `my-plugin`, so:
+
+   ```json
+   {
+     "plugins": ["./packages/my-plugin"],
+     "my-plugin": {
+       "/* ... your config ... */": ""
+     }
+   }
+   ```
+
+4. **Restart**: `plugins[]` is `restart-required`. Run `typeclaw restart` (or call the `restart` tool); reload alone will not pick up a new plugin entry.
+
+Read the `typeclaw-plugins` skill before authoring the plugin code — it covers `definePlugin`, hooks, tools, subagents, cron, the engine boundary, and the failure-mode error messages.
+
+## Editing the root `package.json`
+
+The root `package.json` is in the agent root's writable allowlist (alongside `AGENTS.md`, `IDENTITY.md`, etc.) and is fair game for additions. **Welcome editing patterns:**
+
+- **`scripts`**: add convenience scripts the user (or you, in cron `exec` jobs) can run. Example: `"scripts": { "summarize": "bun run packages/summarizer/index.ts" }`. Then `bun summarize` from anywhere in the agent folder runs it.
+- **`dependencies`** / **`devDependencies`**: add libraries you actually use. Run `bun install` after adding. Don't add deps speculatively — only what the code imports today.
+- **`workspaces`**: by default `["packages/*"]`. The user may extend it (e.g. `["packages/*", "tools/*"]`) if they want a second workspace root. Don't change the existing entry without a reason.
+
+**Patterns to avoid at the root:**
+
+- **Don't add a `main` or `bin` field at the root.** The root package is a workspace coordinator, not an executable. Put entrypoints inside `packages/<name>/`.
+- **Don't change `name`, `private`, or `type`.** These are scaffolded by typeclaw and the rest of the system assumes them.
+- **Don't add the typeclaw or agent-browser deps to packages.** They live at the root and are shared via the bun workspace mechanism. If a workspace package needs typeclaw types, depend on it via `"typeclaw": "workspace:*"` only if it needs the plugin SDK at runtime — and even then, `import { definePlugin } from 'typeclaw/plugin'` resolves through the root's `node_modules` automatically.
+
+## When you start a new package, do this exactly
+
+1. **Pick a name.** Lowercase, kebab-case, descriptive. `journal-store`, not `js`. Plugin packages are named after what the plugin does, not what it is — `standup-log`, not `my-plugin`.
+2. **Create the directory.** `packages/<name>/`.
+3. **Write `package.json`** using the minimal template above. Set `name` to the directory name (they don't have to match, but matching avoids confusion).
+4. **Write `index.ts`** with the actual code.
+5. **Add tests** as `<file>.test.ts` next to the implementation if the logic is non-trivial.
+6. **`bun install` from the agent root** — only needed when you add dependencies. Bun automatically links new workspace packages on install; you don't need to manually register the package anywhere.
+7. **Commit.** Per `typeclaw-git`, commit the new package immediately with the decision context — why this is reusable, what it solves.
+
+## `bun install` and the monorepo
+
+Run `bun install` **from the agent root**, never from inside a `packages/<name>/` directory. The root install:
+
+- Resolves all workspace packages and creates symlinks
+- Hoists shared dependencies to the root `node_modules/`
+- Honors per-package dependencies that are not in the root
+
+Per-package `node_modules/` is gitignored (`packages/*/node_modules/` in `.gitignore`), but those directories rarely have anything in them after a hoist — bun puts most things at the root.
+
+If you see `Cannot find module 'my-utility'` after creating a new workspace package, the fix is `bun install` from the agent root. There is no separate "register the workspace" step.
+
+## Things you must not do
+
+- **Do not put reusable code in `workspace/`.** It will be lost. Re-read the decision rule above if you're tempted.
+- **Do not put one-off throwaway scripts in `packages/`.** Each `packages/<name>` is a real package the user will see in git, in PRs, and in dependency graphs. Keep it small. If it's a 10-line script that runs once, `workspace/scratch-<date>.ts` is correct.
+- **Do not edit the root `workspaces` field to point outside `packages/*`** unless the user explicitly asks. The default convention is part of the agent's identity layout; extending it surprises every other tool that walks the workspace.
+- **Do not version workspace packages with semver** unless the user is publishing them. Internal packages stay at `0.0.0` and depend on each other via `workspace:*`.
+- **Do not nest workspaces.** A package inside `packages/` cannot itself declare `workspaces`. Bun rejects nested workspaces, and even if it didn't, the cognitive load is not worth it.
+- **Do not add `node_modules/` to `packages/<name>/.gitignore`.** The root `.gitignore` already covers `packages/*/node_modules/`. Adding a sub-`.gitignore` is noise that will get out of sync.
+
+## Cross-references
+
+- **`typeclaw-plugins`** — read this before authoring any custom plugin. Covers the plugin SDK, hooks, tools, subagents, cron, naming derivation, and failure modes.
+- **`typeclaw-git`** — commit policy. Every new package and every meaningful edit to `package.json` (root or workspace) gets a commit immediately with decision context.
+- **`typeclaw-cron`** — if your package is invoked from a cron job, the `prompt` vs `exec` choice and the schedule semantics live there.

--- a/src/skills/typeclaw-plugins/SKILL.md
+++ b/src/skills/typeclaw-plugins/SKILL.md
@@ -125,6 +125,30 @@ plugin path escapes agent directory: <entry> (resolved to <abs-path>)
 
 This is why `./plugins/x.ts` works and `/Users/me/x.ts` does not.
 
+### Recommended location: `packages/<plugin-name>/`
+
+The agent folder is a **bun monorepo**, and `packages/` is its workspace root. **Custom plugins go there.** A `./packages/standup-log/` plugin is a real workspace package — bun installs its dependencies, the workspace symlink machinery makes it importable, and it lands in git like any other reusable code. Concretely:
+
+```
+packages/
+  standup-log/
+    package.json
+    index.ts            # exports default definePlugin({ ... })
+    index.test.ts
+```
+
+```json
+// typeclaw.json
+{
+  "plugins": ["./packages/standup-log"],
+  "standup-log": { "schedule": "0 17 * * 5" }
+}
+```
+
+The derived plugin name is `standup-log` (basename of the path), so the per-plugin config block uses that key. Read the `typeclaw-monorepo` skill for the full package layout, dependency wiring (`workspace:*`), root-script conventions, and how to share code between multiple workspace packages.
+
+Putting plugins anywhere else (a top-level `./plugins/` folder, a script under `workspace/`, an absolute path) works — but loses the workspace's dependency hoisting, gets you no `bun install` integration, and (for `workspace/`) silently disappears on the next clone because `workspace/` is gitignored.
+
 ### Boot-time effects
 
 - `plugins` is a **`restart-required`** field. Editing the array (add/remove/reorder) needs `typeclaw restart` to take effect — `reload` won't pick it up.


### PR DESCRIPTION
## Summary

Agent folders are now first-class bun monorepos. The root `package.json` gains `"workspaces": ["packages/*"]`, and a `packages/` directory is scaffolded alongside `workspace/`. Reusable systems the agent builds — custom plugins, shared utilities, typed SDKs — live there as standalone packages; one-off scripts continue to live in `workspace/`. This distinction matters because packages are installed by bun, can have their own `package.json`, and can be depended on from other packages in the same workspace. Workspace scripts stay ephemeral and unversioned. Nothing about the existing init/start/run pipeline changes for existing workflows.

## Changes

### `typeclaw init` — scaffold the workspace root

- `packages/` is added to the `DIRECTORIES` list and created at scaffold time.
- `packages/.gitkeep` is written with `flag: 'wx'` so an existing directory is not clobbered. The `.gitkeep` is necessary because git does not track empty directories — without it, `packages/` would disappear from the initial commit and the agent's workspace glob would silently resolve to nothing.
- `buildPackageJson` injects `"workspaces": ["packages/*"]` between `type` and `dependencies`, matching the canonical field order.
- `.gitignore` gains `packages/*/node_modules/` in the truly-ignored section (bun installs into each workspace package; those should never be committed).

### `typeclaw start` — migrate existing agent folders

A new `refreshPackageJson(cwd)` function in `src/init/packagejson.ts` handles the one-shot migration for agent folders that predate this change:

- If `package.json` is missing or unparseable, the function is a no-op (never corrupts user files).
- If `workspaces` is already present (user customized or previously migrated), only the `.gitkeep` check runs — the `package.json` is not touched.
- Otherwise, `workspaces: ["packages/*"]` is injected immediately after `type` via `insertAfterKey`, preserving all other fields verbatim. Field insertion order is deliberate: placing `workspaces` at the end would produce noisy git diffs for users who review their agent folder history.
- `packages/.gitkeep` is created if absent, regardless of whether `package.json` was touched.

`refreshPackageJson` returns `{ changed: boolean, files: string[] }`. In `start()`, this feeds directly into `commitSystemFile` — the same path that auto-commits `.gitignore` changes — producing a single atomic commit titled `"Enable bun workspaces (packages/*)"`. The migration commit only lands once; the second `typeclaw start` on an already-migrated folder is a no-op (no new commit).

`commitSystemFile` is extended from `(file: string)` to `(file: string | readonly string[])` so the migration can commit `package.json` and `packages/.gitkeep` atomically in a single commit rather than two.

### Guard plugin — allow writes into `packages/`

`packages/` joins `mounts/` in `AGENT_ROOT_DIRECTORY_ALLOWLIST`. Before this change, the non-workspace-write guard would block the agent from creating files under `packages/my-plugin/index.ts` — even though `packages/` is the explicitly scaffolded zone for agent-authored code. The guard's blocking logic is unchanged for every other path.

### New `typeclaw-monorepo` skill

`src/skills/typeclaw-monorepo/SKILL.md` teaches the agent the two-zone mental model (`packages/` vs `workspace/`), the conventions for authoring workspace packages, how to wire a custom plugin into `typeclaw.json`, and how to edit root-level scripts. The skill description is written as a trigger list so the agent loads it before scaffolding anything under `packages/` rather than discovering the conventions mid-way through a multi-file write.

`src/skills/typeclaw-plugins/SKILL.md` gains a cross-reference to `typeclaw-monorepo` in the "authoring a plugin" section, because the most natural home for a custom plugin is a workspace package.

## Files

New:
- `src/init/packagejson.ts` — `refreshPackageJson` + `ensureWorkspacesField` + `insertAfterKey`
- `src/init/packagejson.test.ts` — 161 lines of unit tests covering all `refreshPackageJson` branches
- `src/init/paths.ts` — shared `PACKAGES_DIR` / `GITKEEP_FILE` constants
- `src/skills/typeclaw-monorepo/SKILL.md`

Modified:
- `src/init/index.ts` — add `packages/` to `DIRECTORIES`, write `.gitkeep`, add `workspaces` to `buildPackageJson`, re-export `PACKAGES_DIR`/`GITKEEP_FILE`
- `src/init/gitignore.ts` — add `packages/*/node_modules/` to truly-ignored entries
- `src/container/start.ts` — call `refreshPackageJson` + extend `commitSystemFile` to accept `string | readonly string[]`
- `plugins/guard/policies/non-workspace-write.ts` — add `packages` to `AGENT_ROOT_DIRECTORY_ALLOWLIST`
- `src/skills/typeclaw-plugins/SKILL.md` — cross-reference `typeclaw-monorepo`

Test files updated:
- `src/init/index.test.ts` — assert `packages/.gitkeep` is tracked in initial commit, `workspaces` field present, `packages/*/node_modules/` in `.gitignore`
- `src/container/start.test.ts` — two new tests: migration lands a commit, second start is idempotent
- `plugins/guard/index.test.ts` — assert writes under `packages/` pass the guard

## Design notes

**Why `packages/` and not `src/` or `lib/`?** Bun's workspace convention is neutral on the directory name, but `packages/` is the established monorepo norm (npm/yarn/bun workspaces all use it as their default example). Agents and docs already use it as a mental anchor. `workspace/` vs `packages/` is also a clear split: *ephemeral scripting* vs *versioned packages*.

**Why inject `workspaces` after `type`?** `insertAfterKey` walks the existing field order and splices after the anchor. If the user has reordered their `package.json`, the result respects their ordering of the existing fields and places `workspaces` as early as reasonable. Without this, a migrated file would have `workspaces` appended after `dependencies` — visually jarring and harder to spot in review.

**Why a single atomic migration commit?** Two separate commits (`package.json` then `.gitkeep`, or vice versa) would leave the agent folder in an inconsistent intermediate state if `start` were killed between them. A single commit is the atomic unit: either the migration landed or it didn't.

**Why is the migration one-shot?** Once `workspaces` is present, `refreshPackageJson` returns `changed: false` and no commit is produced. Users who customized `workspaces` to point at different directories are not clobbered — the function treats any existing `workspaces` value as intentional.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 warnings, 0 errors
- `bun run format:check` — clean
- `bun test` — 1472 pass, 0 fail (no regressions; new coverage in `packagejson.test.ts`, `start.test.ts`, `guard/index.test.ts`, and `init/index.test.ts`)

No breaking changes. The `commitSystemFile` signature change is backward-compatible (existing callers pass a string, which the new overload accepts unchanged).