### PR TITLE
Encourage dreaming to suggest CLIs and plugins

### DIFF
--- a/plugins/memory/dreaming.test.ts
+++ b/plugins/memory/dreaming.test.ts
@@ -102,6 +102,22 @@ describe('dreaming subagent declarations', () => {
     expect(sub.systemPrompt).toMatch(/description:\s+/)
     expect(sub.systemPrompt).toContain('source: muscle-memory')
   })
+
+  test('teaches the dreaming session that muscle memory has three forms (skill, CLI, plugin)', () => {
+    const sub = createDreamingSubagent()
+    // Three forms named explicitly so the model picks the smallest fit.
+    expect(sub.systemPrompt).toMatch(/Form A.*skill/i)
+    expect(sub.systemPrompt).toMatch(/Form B.*CLI/i)
+    expect(sub.systemPrompt).toMatch(/Form C.*plugin/i)
+    // Suggestion target lives under packages/ — wired to typeclaw-monorepo.
+    expect(sub.systemPrompt).toContain('packages/<name>')
+    // `proposal:` line is the wire format the main agent reads on every prompt.
+    expect(sub.systemPrompt).toContain('proposal: cli packages/<name>')
+    expect(sub.systemPrompt).toContain('proposal: plugin packages/<name>')
+    // Sandbox boundary must stay explicit so the model does not try to write
+    // under packages/ itself (its tools have no policy enforcement).
+    expect(sub.systemPrompt).toMatch(/cannot write under .*packages\//)
+  })
 })
 
 describe('dreaming subagent (orchestration)', () => {

--- a/plugins/memory/dreaming.ts
+++ b/plugins/memory/dreaming.ts
@@ -238,7 +238,7 @@ Dreaming is the offline reflection process that promotes the agent's daily memor
 
 You read MEMORY.md (long-term memory, may be missing) and the **undreamed tail** of every \`memory/yyyy-MM-dd.md\` daily stream file. The runtime tells you exactly which line range to read for each day — earlier lines are already consolidated into MEMORY.md and must NOT be re-read or re-cited. You consolidate the new fragments into long-term memory, then rewrite MEMORY.md with the merged result.
 
-You also distill **muscle memory**: when the streams show a repeated multi-step procedure the user has guided the main agent through enough times that it would save effort to codify, you write a skill at \`memory/skills/<name>/SKILL.md\`. The next session's resource loader auto-discovers \`memory/skills/\` and surfaces every skill there as a first-class capability for the main agent.
+You also distill **muscle memory**: when the streams show a repeated multi-step procedure the user has guided the main agent through enough times that it would save effort to codify, you take action. Muscle memory has three forms, in increasing order of investment — a skill at \`memory/skills/<name>/SKILL.md\` (a codified procedure the next session loads on demand), a **CLI suggestion** recorded in MEMORY.md (a small command-line tool the main agent should scaffold under \`packages/<name>/\` when next prompted), or a **plugin suggestion** recorded in MEMORY.md (a typeclaw plugin under \`packages/<name>/\` that hooks into the runtime). You write the skill directly; you only *suggest* CLIs and plugins because they live under \`packages/\`, outside your write sandbox. The main agent sees MEMORY.md on every prompt and acts on suggestions when the moment is right.
 
 # Hard rules
 
@@ -286,15 +286,27 @@ fragments:
 
 The first line is always \`# Memory\`. Topics are level-2 headings. No other top-level structure.
 
-# Muscle memory (skills)
+# Muscle memory (skills, CLIs, plugins)
 
-While you read the streams, watch for **repeated multi-step procedures** the user has guided the main agent through. When you have evidence (across multiple fragments, ideally across multiple days) that the same procedure keeps happening the same way, distill it into a skill at \`memory/skills/<name>/SKILL.md\`. The next session's resource loader auto-discovers that directory and surfaces every skill there to the main agent.
+While you read the streams, watch for **repeated multi-step procedures** the user has guided the main agent through. When you have evidence (across multiple fragments, ideally across multiple days) that the same procedure keeps happening the same way, you have three response shapes available — pick the smallest one that fits.
 
-The bar for creating a skill:
+**Form A — skill at \`memory/skills/<name>/SKILL.md\`.** The default. A skill is a markdown file the next session loads on demand; it teaches the main agent _how_ to do the procedure with the tools it already has. The next session's resource loader auto-discovers the directory and surfaces every skill there.
 
-- The procedure is **multi-step** (single-command shortcuts go in MEMORY.md, not a skill).
+**Form B — CLI suggestion in MEMORY.md.** When the procedure is really "shell out to a small custom command-line tool", a skill is the wrong shape because the agent would copy-paste the same script every time. Suggest a CLI: a tiny bun package under \`packages/<name>/\` with a \`bin\` entry the agent can invoke. You cannot write under \`packages/\` yourself (that path is outside your sandbox). What you do is **add a topic to MEMORY.md** describing the CLI to build. The main agent sees MEMORY.md on every prompt and will scaffold the package when the procedure next comes up.
+
+**Form C — plugin suggestion in MEMORY.md.** When the procedure is really "hook into the typeclaw runtime" — needs a tool the agent can call, a hook on \`session.prompt\`/\`tool.before\`/etc., a cron job, or a subagent — a skill is the wrong shape because skills are passive markdown. Suggest a plugin: a typeclaw plugin under \`packages/<plugin-name>/\` wired into \`typeclaw.json\`'s \`plugins\` array. Same rule as CLIs — you cannot write the plugin yourself, you record the suggestion in MEMORY.md.
+
+**Pick the smallest form that fits — top to bottom, stop at the first match:**
+
+1. **Does the procedure need a runtime hook, custom tool, cron job, or subagent?** → Form C (plugin suggestion). These are things only a plugin can express.
+2. **Does the procedure boil down to "run this small script with these args"?** → Form B (CLI suggestion). A bin in \`packages/<name>/\` is invokable from anywhere, lives in git, and survives across sessions in a way a one-off \`workspace/\` script does not.
+3. **Otherwise** → Form A (skill). Most procedures fit here. A skill teaches the agent the steps in prose; the agent uses its existing tools to execute.
+
+Across all three forms, the bar for codifying is the same:
+
+- The procedure is **multi-step** (single-command shortcuts go in MEMORY.md prose, not muscle memory).
 - The procedure has **recurred** — at least two distinct fragments, ideally across different days, show the same shape.
-- The trigger conditions are **clearly statable** ("Use when ...") so the skill's description teaches a future agent when to reach for it.
+- The trigger conditions are **clearly statable** ("Use when ...") so the skill's description, the CLI's purpose, or the plugin's hook signature teaches a future agent when to reach for it.
 - The steps generalize. If the procedure was entirely user-specific in a way that future variants would diverge, leave it in MEMORY.md as prose instead.
 
 To check what muscle-memory skills already exist, \`ls\` \`memory/skills/\`. To inspect one, \`read\` its \`SKILL.md\`. \`write\` overwrites; do not be afraid to refine an existing skill when new fragments contradict an earlier draft.
@@ -324,13 +336,50 @@ Refining a stale skill. If new fragments show the procedure has changed, \`write
 
 Do not create skills speculatively. A skill the main agent never reaches for is dead weight in the prompt budget. If you cannot point to specific fragments showing the procedure recurring, do not write the skill.
 
+## Suggesting a CLI or a plugin (forms B and C)
+
+You record CLI and plugin suggestions as topics in MEMORY.md. Each suggestion is a single topic with the same fragment-citation rules as every other MEMORY.md entry, plus an explicit \`proposal:\` line that names the form, the package name, and why this shape fits better than a skill. The main agent treats these topics as standing recommendations — when the matching procedure comes up next, it scaffolds the package under \`packages/<name>/\` (see the \`typeclaw-monorepo\` skill it has access to).
+
+Use this exact shape — pick one of the two \`proposal:\` lines:
+
+\`\`\`
+## <topic — what the procedure does>
+<conclusion paragraph: what the user keeps doing, why the current shape is awkward, what the suggested package would do.>
+
+proposal: cli packages/<name>
+
+fragments:
+- memory/yyyy-MM-dd:<line>-<line>
+- memory/yyyy-MM-dd:<line>-<line>
+\`\`\`
+
+\`\`\`
+## <topic — what the procedure does>
+<conclusion paragraph.>
+
+proposal: plugin packages/<name>
+
+fragments:
+- memory/yyyy-MM-dd:<line>-<line>
+- memory/yyyy-MM-dd:<line>-<line>
+\`\`\`
+
+The \`proposal:\` line is the contract. \`cli packages/<name>\` means "scaffold a bun package with a \`bin\` entry under that path". \`plugin packages/<name>\` means "scaffold a typeclaw plugin under that path and wire it into \`typeclaw.json\`'s \`plugins\` array". The package name is single-segment kebab-case (same rule as skill names) and must not collide with anything already in \`packages/\` — the main agent will check before scaffolding, but pick a descriptive name (\`standup-log\`, not \`my-cli\`) so the suggestion is actionable on its own.
+
+You only need to suggest a given CLI or plugin **once**. Once the topic is in MEMORY.md, every future dreaming run sees it as existing content and should leave it alone unless new fragments show the procedure has shifted shape (e.g. what looked like a CLI now needs a hook, so the proposal needs upgrading from \`cli\` to \`plugin\`). Do not duplicate the suggestion under a new topic name on subsequent runs. Do not remove a still-pending suggestion just because the main agent has not acted on it yet — the user may not have hit the moment where it pays off.
+
+Do not suggest CLIs or plugins speculatively. The same recurrence + generalizability bar applies. A suggestion the main agent never acts on is noise in MEMORY.md, which the main agent reads on every prompt.
+
 # Workflow
 
 1. \`read\` MEMORY.md (it may not exist — that is fine, you start from empty).
 2. For each undreamed-tail entry the user message lists, \`read\` the file with \`offset\` set to the first undreamed line. Read every undreamed tail before you start writing.
 3. Reason about what to consolidate. Most fragments will collapse into existing topics or be dropped as already-known / not generalizable.
 4. \`write\` the full new contents of MEMORY.md in one call (only if anything changed). \`write\` overwrites; that is the point — MEMORY.md is the single canonical artifact you produce.
-5. Decide whether any procedure in the new fragments meets the muscle-memory bar above. If yes, \`ls\` \`memory/skills/\` to see what already exists, \`read\` any candidate's existing \`SKILL.md\` if you might be refining it, then \`write\` the new or refined skill at \`memory/skills/<name>/SKILL.md\` with the frontmatter shape shown above. If no procedure clears the bar, skip this step entirely.
+5. Decide whether any procedure in the new fragments meets the muscle-memory bar above, and which of the three forms fits.
+   - **Form A (skill):** \`ls\` \`memory/skills/\` to see what already exists, \`read\` any candidate's existing \`SKILL.md\` if you might be refining it, then \`write\` the new or refined skill at \`memory/skills/<name>/SKILL.md\` with the frontmatter shape shown above.
+   - **Form B (CLI suggestion) or Form C (plugin suggestion):** add a topic to MEMORY.md with the \`proposal:\` line shown above. The CLI/plugin itself is the main agent's responsibility — you do not write under \`packages/\`. Before adding the topic, check the existing MEMORY.md you just read so you do not duplicate a suggestion that's already there.
+   - If no procedure clears the bar, skip this step entirely.
 6. Stop. There is no completion message to emit.
 
 # Doing nothing is a valid outcome


### PR DESCRIPTION
## Summary

Expand dreaming's muscle-memory concept from one form (a skill file) to three, so a recurring procedure that really wants to be a small CLI or a runtime hook gets the right suggestion instead of being flattened into a copy-paste skill or dropped.

Builds on PR #43 (merged): https://github.com/typeclaw/typeclaw/pull/43

## Changes

### `plugins/memory/dreaming.ts` — three-form muscle memory

The muscle-memory section of dreaming's system prompt gains two new forms alongside the existing skill:

- **Form A** — skill at `memory/skills/<name>/SKILL.md` (existing default, unchanged in behavior).
- **Form B** — CLI suggestion: a `proposal: cli packages/<name>` topic recorded in `MEMORY.md`.
- **Form C** — plugin suggestion: a `proposal: plugin packages/<name>` topic recorded in `MEMORY.md`.

The section is renamed from `# Muscle memory (skills)` to `# Muscle memory (skills, CLIs, plugins)` and gains:

- Explicit Form A / B / C definitions with the `proposal:` wire format and two concrete MEMORY.md example blocks (one for each new form), giving the model exact patterns to match rather than implicit inference.
- A "pick the smallest form that fits" decision rule to keep the default biased toward skills: plugins for things only a runtime hook can express, CLIs for things that reduce to a small script with args, skills for everything else.
- A `## Suggesting a CLI or a plugin (forms B and C)` subsection explaining the sandbox boundary (dreaming cannot write under `packages/`, so it records a `proposal:` topic instead) and how the main agent picks it up via `MEMORY.md` and the `typeclaw-monorepo` skill.
- Workflow step 5 updated to branch on the chosen form.

The same recurrence + generalizability bar applies to all three forms so `MEMORY.md` doesn't accumulate speculative proposals.

### `plugins/memory/dreaming.test.ts` — lock in the three-form contract

New test `teaches the dreaming session that muscle memory has three forms (skill, CLI, plugin)` asserts:

- `Form A.*skill`, `Form B.*CLI`, `Form C.*plugin` regex matches (form labels are present).
- `packages/<name>` substring (suggestion target is explicit).
- `proposal: cli packages/<name>` and `proposal: plugin packages/<name>` verbatim substrings (wire format the main agent reads is exact, not paraphrased).
- `cannot write under .*packages/` regex (the sandbox boundary sentence is present so the model doesn't reach outside its allowed paths).

The original `teaches the dreaming session about muscle memory` test is preserved verbatim — all its assertions still hold.

## Design notes

**Why `proposal:` in MEMORY.md instead of expanding the sandbox?** Giving dreaming permission to write under `packages/` would require new tools, sandbox changes, and design discussion about whether a background subagent should be doing build-time scaffolding while the user is asleep. The lighter path records a standing suggestion that surfaces naturally the next time the relevant procedure comes up in a main-agent prompt — no new tools, no sandbox change, no scaffolding while the user isn't watching.

**Why verbatim `proposal: cli packages/<name>` in the system prompt?** The format is the wire. The main agent reads `MEMORY.md` on every prompt and the `typeclaw-monorepo` skill (added in PR #43, commit ad5f4d1) teaches it how to scaffold under `packages/`. Having the exact string in the system prompt gives the model a concrete anchor to pattern-match when both writing and reading the format, rather than relying on implicit inference from an abstract description.

**Why keep the smallest-form-that-fits rule?** Without it, the new forms would compete with skills on every prompt, inflating `MEMORY.md` with proposals for things that are perfectly fine as skills. The rule encodes the intent: forms B and C are for things that genuinely outgrow a skill, not alternatives to one.

## Verification

- `bun run typecheck` — clean (`tsgo --noEmit`)
- `bun run lint` — 0 warnings, 0 errors (`oxlint`)
- `bun run format:check` — clean (`oxfmt --check`)
- `bun test` — 1492 pass, 0 fail (no regressions; new test in `plugins/memory/dreaming.test.ts`)

No breaking changes. The dreaming subagent's tool surface is unchanged (`read`, `write`, `ls`), the sandbox is unchanged (still `MEMORY.md` + `memory/skills/`), and the existing skill-writing path is intact. Existing `MEMORY.md` files keep working — `proposal:` topics are additive.