### PR TITLE
Fix membership fallback fabricating wrong bot/human counts

### DIFF
--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 import { defaultHistoryConfig, isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
-import type { OutboundMessage } from '@/channels/types'
+import type { FetchHistoryResult, HistoryCallback, OutboundMessage } from '@/channels/types'
 
 import type { DiscordBotClient, DiscordFile, DiscordMessage } from './agent-messenger-shim'
 import { DiscordIntent } from './agent-messenger-shim'
@@ -166,6 +166,7 @@ describe('createTypingCallback', () => {
 
 describe('createDiscordMembershipResolver', () => {
   type FetchCall = { url: string; init: RequestInit }
+  type HistoryCall = { chat: string; thread: string | null; limit: number }
 
   function fakeFetch(responses: Response[]): { fn: typeof fetch; calls: FetchCall[] } {
     const calls: FetchCall[] = []
@@ -185,11 +186,28 @@ describe('createDiscordMembershipResolver', () => {
     return { info: () => {}, warn: () => {}, error: () => {} }
   }
 
-  test('DM short-circuits without hitting Discord', async () => {
+  function fakeHistory(result: FetchHistoryResult | (() => Promise<FetchHistoryResult>)): {
+    cb: HistoryCallback
+    calls: HistoryCall[]
+  } {
+    const calls: HistoryCall[] = []
+    const cb: HistoryCallback = async (args) => {
+      calls.push({ chat: args.chat, thread: args.thread, limit: args.limit })
+      return typeof result === 'function' ? await result() : result
+    }
+    return { cb, calls }
+  }
+
+  function emptyHistory(): HistoryCallback {
+    return fakeHistory({ ok: true, messages: [] }).cb
+  }
+
+  test('DM short-circuits without hitting Discord or history', async () => {
     const { fn, calls } = fakeFetch([])
     const resolver = createDiscordMembershipResolver({
       token: 'tok',
       logger: silentLogger(),
+      historyCallback: emptyHistory(),
       fetchImpl: fn,
       now: () => 42,
     })
@@ -211,6 +229,7 @@ describe('createDiscordMembershipResolver', () => {
     const resolver = createDiscordMembershipResolver({
       token: 'tok',
       logger: silentLogger(),
+      historyCallback: emptyHistory(),
       fetchImpl: fn,
       now: () => 100,
     })
@@ -225,49 +244,155 @@ describe('createDiscordMembershipResolver', () => {
     expect(calls[1]!.url).toBe('https://discord.com/api/v10/guilds/g1/members?limit=100')
   })
 
-  test('large guild uses preview approximation and skips enumeration', async () => {
+  test('large guild (>cap) falls back to history-derived count', async () => {
     const { fn, calls } = fakeFetch([jsonResponse({ approximate_member_count: 75 })])
+    const { cb, calls: historyCalls } = fakeHistory({
+      ok: true,
+      messages: [
+        {
+          externalMessageId: '1',
+          authorId: 'alice',
+          authorName: 'alice',
+          text: 'hi',
+          ts: 0,
+          isBot: false,
+          replyToBotMessageId: null,
+        },
+        {
+          externalMessageId: '2',
+          authorId: 'bob',
+          authorName: 'bob',
+          text: 'hey',
+          ts: 0,
+          isBot: false,
+          replyToBotMessageId: null,
+        },
+        {
+          externalMessageId: '3',
+          authorId: 'b1',
+          authorName: 'b1',
+          text: 'beep',
+          ts: 0,
+          isBot: true,
+          replyToBotMessageId: null,
+        },
+      ],
+    })
     const resolver = createDiscordMembershipResolver({
       token: 'tok',
       logger: silentLogger(),
+      historyCallback: cb,
       fetchImpl: fn,
-      botUserIdRef: () => 'bot-id',
       now: () => 200,
     })
 
     await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
-      humans: 74,
+      humans: 2,
       bots: 1,
       fetchedAt: 200,
       truncated: true,
     })
     expect(calls).toHaveLength(1)
+    expect(historyCalls).toEqual([{ chat: 'c1', thread: null, limit: 100 }])
   })
 
-  test('403 from member fetch falls back to truncated preview count', async () => {
+  test('403 from member fetch falls back to history-derived count', async () => {
     const { fn } = fakeFetch([jsonResponse({ approximate_member_count: 10 }), new Response(null, { status: 403 })])
+    const { cb } = fakeHistory({
+      ok: true,
+      messages: [
+        {
+          externalMessageId: '1',
+          authorId: 'devxoul',
+          authorName: 'devxoul',
+          text: 'hi',
+          ts: 0,
+          isBot: false,
+          replyToBotMessageId: null,
+        },
+        {
+          externalMessageId: '2',
+          authorId: 'bongbong',
+          authorName: 'bongbong',
+          text: 'hey',
+          ts: 0,
+          isBot: true,
+          replyToBotMessageId: null,
+        },
+        {
+          externalMessageId: '3',
+          authorId: 'penpen',
+          authorName: 'penpen',
+          text: 'oi',
+          ts: 0,
+          isBot: true,
+          replyToBotMessageId: null,
+        },
+      ],
+    })
     const resolver = createDiscordMembershipResolver({
       token: 'tok',
       logger: silentLogger(),
+      historyCallback: cb,
       fetchImpl: fn,
       now: () => 300,
     })
 
     await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
-      humans: 10,
-      bots: 0,
+      humans: 1,
+      bots: 2,
       fetchedAt: 300,
       truncated: true,
     })
   })
 
-  test('403 from guild preview is a permanent resolver failure', async () => {
+  test('403 from member fetch + history failure surfaces a transient (cache retries soon)', async () => {
+    const { fn } = fakeFetch([jsonResponse({ approximate_member_count: 10 }), new Response(null, { status: 403 })])
+    const { cb } = fakeHistory({ ok: false, error: 'rate-limited' })
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: cb,
+      fetchImpl: fn,
+      now: () => 0,
+    })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      kind: 'transient',
+    })
+  })
+
+  test('non-403 member-fetch failure propagates without falling back to history', async () => {
+    const { fn } = fakeFetch([jsonResponse({ approximate_member_count: 10 }), new Response(null, { status: 500 })])
+    const { cb, calls: historyCalls } = fakeHistory({ ok: true, messages: [] })
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: cb,
+      fetchImpl: fn,
+      now: () => 0,
+    })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      kind: 'transient',
+    })
+    expect(historyCalls).toHaveLength(0)
+  })
+
+  test('403 from guild preview is a permanent resolver failure (no fallback)', async () => {
     const { fn } = fakeFetch([new Response(null, { status: 403 })])
-    const resolver = createDiscordMembershipResolver({ token: 'tok', logger: silentLogger(), fetchImpl: fn })
+    const { cb, calls: historyCalls } = fakeHistory({ ok: true, messages: [] })
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: cb,
+      fetchImpl: fn,
+    })
 
     await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
       kind: 'permanent',
     })
+    expect(historyCalls).toHaveLength(0)
   })
 })
 

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -1,10 +1,10 @@
 import {
   MEMBERSHIP_ENUMERATION_CAP,
-  type MembershipCount,
   type MembershipResolver,
   type MembershipResolverFailure,
   type MembershipResolverResult,
 } from '@/channels/membership'
+import { deriveMembershipFromHistory } from '@/channels/membership-from-history'
 import type { ChannelRouter } from '@/channels/router'
 import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 import type {
@@ -124,7 +124,7 @@ type DiscordGuildMember = {
 export function createDiscordMembershipResolver(deps: {
   token: string
   logger: DiscordBotAdapterLogger
-  botUserIdRef?: () => string | null
+  historyCallback: HistoryCallback
   fetchImpl?: typeof fetch
   now?: () => number
 }): MembershipResolver {
@@ -132,6 +132,12 @@ export function createDiscordMembershipResolver(deps: {
   const now = deps.now ?? Date.now
   return async (key): Promise<MembershipResolverResult> => {
     if (key.workspace === '@dm') return { humans: 1, bots: 1, fetchedAt: now(), truncated: false }
+
+    const fallback = (): Promise<MembershipResolverResult> =>
+      deriveMembershipFromHistory({
+        fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit }),
+        now,
+      })
 
     const preview = await fetchDiscordJson<DiscordGuildPreview>(
       fetchFn,
@@ -145,7 +151,10 @@ export function createDiscordMembershipResolver(deps: {
 
     const approximate = Math.max(0, Math.floor(preview.value.approximate_member_count ?? 0))
     if (approximate > MEMBERSHIP_ENUMERATION_CAP) {
-      return approximateDiscordMembership(approximate, deps.botUserIdRef?.() ?? null, now())
+      // Beyond the enumeration cap, /members truncates anyway, and the
+      // recent-speakers count is more useful for engagement than a raw
+      // guild-wide approximation that double-counts lurkers.
+      return await fallback()
     }
 
     const members = await fetchDiscordJson<DiscordGuildMember[]>(
@@ -155,10 +164,15 @@ export function createDiscordMembershipResolver(deps: {
     )
     if (!members.ok) {
       if (members.status === 403) {
+        // 403 here is almost always the GUILD_MEMBERS privileged intent
+        // missing on the application (Developer Portal → Bot →
+        // Privileged Gateway Intents → SERVER MEMBERS INTENT). Server-side
+        // ADMINISTRATOR perms do not unlock this — the gate is at the
+        // gateway/API privacy layer.
         deps.logger.warn(
-          `[discord-bot] membership members guild=${key.workspace} status=403; falling back to guild preview`,
+          `[discord-bot] membership members guild=${key.workspace} status=403 (likely missing GUILD_MEMBERS intent); deriving from recent message authors`,
         )
-        return approximateDiscordMembership(approximate, deps.botUserIdRef?.() ?? null, now())
+        return await fallback()
       }
       deps.logger.warn(`[discord-bot] membership members guild=${key.workspace} failed: ${members.reason}`)
       return members.failure
@@ -203,15 +217,6 @@ async function fetchDiscordJson<T>(fetchFn: typeof fetch, url: string, token: st
 function discordFailureForStatus(status: number): MembershipResolverFailure {
   if (status === 401 || status === 403 || status === 404) return { kind: 'permanent' }
   return { kind: 'transient' }
-}
-
-function approximateDiscordMembership(
-  approximate: number,
-  botUserId: string | null,
-  fetchedAt: number,
-): MembershipCount {
-  const bots = botUserId === null ? 0 : 1
-  return { humans: Math.max(0, approximate - bots), bots, fetchedAt, truncated: true }
 }
 
 type DiscordRawHistoryMessage = {
@@ -441,7 +446,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
   const membershipResolver = createDiscordMembershipResolver({
     token: options.token,
     logger,
-    botUserIdRef: () => botUserId,
+    historyCallback,
   })
 
   const outboundCallback = createOutboundCallback({

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import { defaultHistoryConfig, isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
-import type { OutboundMessage } from '@/channels/types'
+import type { FetchHistoryResult, HistoryCallback, OutboundMessage } from '@/channels/types'
 
 import type {
   SlackBotClient,
@@ -170,6 +170,7 @@ describe('slack-bot createTypingCallback', () => {
 
 describe('createSlackMembershipResolver', () => {
   type FetchCall = { url: string; init: RequestInit }
+  type HistoryCall = { chat: string; thread: string | null; limit: number }
 
   function fakeFetch(responses: Response[]): { fn: typeof fetch; calls: FetchCall[] } {
     const calls: FetchCall[] = []
@@ -189,11 +190,28 @@ describe('createSlackMembershipResolver', () => {
     return { info: () => {}, warn: () => {}, error: () => {} }
   }
 
-  test('DM short-circuits without hitting Slack', async () => {
+  function fakeHistory(result: FetchHistoryResult | (() => Promise<FetchHistoryResult>)): {
+    cb: HistoryCallback
+    calls: HistoryCall[]
+  } {
+    const calls: HistoryCall[] = []
+    const cb: HistoryCallback = async (args) => {
+      calls.push({ chat: args.chat, thread: args.thread, limit: args.limit })
+      return typeof result === 'function' ? await result() : result
+    }
+    return { cb, calls }
+  }
+
+  function emptyHistory(): HistoryCallback {
+    return fakeHistory({ ok: true, messages: [] }).cb
+  }
+
+  test('DM short-circuits without hitting Slack or history', async () => {
     const { fn, calls } = fakeFetch([])
     const resolver = createSlackMembershipResolver({
       token: 'tok',
       logger: silentLogger(),
+      historyCallback: emptyHistory(),
       fetchImpl: fn,
       now: () => 10,
     })
@@ -218,6 +236,7 @@ describe('createSlackMembershipResolver', () => {
     const resolver = createSlackMembershipResolver({
       token: 'tok',
       logger: silentLogger(),
+      historyCallback: emptyHistory(),
       fetchImpl: fn,
       now: () => 20,
     })
@@ -237,37 +256,150 @@ describe('createSlackMembershipResolver', () => {
     ])
   })
 
-  test('large channel uses conversations.info approximation', async () => {
+  test('large channel (>cap) falls back to history-derived count', async () => {
     const { fn, calls } = fakeFetch([slackResponse({ ok: true, channel: { num_members: 80 } })])
+    const { cb, calls: historyCalls } = fakeHistory({
+      ok: true,
+      messages: [
+        {
+          externalMessageId: '1',
+          authorId: 'UALICE',
+          authorName: 'alice',
+          text: 'hi',
+          ts: 0,
+          isBot: false,
+          replyToBotMessageId: null,
+        },
+        {
+          externalMessageId: '2',
+          authorId: 'BBOT',
+          authorName: 'bot',
+          text: 'beep',
+          ts: 0,
+          isBot: true,
+          replyToBotMessageId: null,
+        },
+      ],
+    })
     const resolver = createSlackMembershipResolver({
       token: 'tok',
       logger: silentLogger(),
+      historyCallback: cb,
       fetchImpl: fn,
-      botUserIdRef: () => 'UBOT',
       now: () => 30,
     })
 
     await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toEqual({
-      humans: 79,
+      humans: 1,
       bots: 1,
       fetchedAt: 30,
       truncated: true,
     })
     expect(calls).toHaveLength(1)
+    expect(historyCalls).toEqual([{ chat: 'C1', thread: null, limit: 100 }])
   })
 
-  test('missing-scope style errors return permanent failures', async () => {
+  test('missing_scope on conversations.info falls back to history-derived count', async () => {
     const { fn } = fakeFetch([slackResponse({ ok: false, error: 'missing_scope' })])
-    const resolver = createSlackMembershipResolver({ token: 'tok', logger: silentLogger(), fetchImpl: fn })
+    const { cb } = fakeHistory({
+      ok: true,
+      messages: [
+        {
+          externalMessageId: '1',
+          authorId: 'UALICE',
+          authorName: 'alice',
+          text: 'hi',
+          ts: 0,
+          isBot: false,
+          replyToBotMessageId: null,
+        },
+      ],
+    })
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: cb,
+      fetchImpl: fn,
+      now: () => 40,
+    })
 
     await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toEqual({
-      kind: 'permanent',
+      humans: 1,
+      bots: 0,
+      fetchedAt: 40,
+      truncated: true,
     })
   })
 
-  test('rate-limit style errors return transient failures', async () => {
+  test('not_in_channel on conversations.members falls back to history-derived count', async () => {
+    const { fn } = fakeFetch([
+      slackResponse({ ok: true, channel: { num_members: 3 } }),
+      slackResponse({ ok: false, error: 'not_in_channel' }),
+    ])
+    const { cb } = fakeHistory({
+      ok: true,
+      messages: [
+        {
+          externalMessageId: '1',
+          authorId: 'UDEV',
+          authorName: 'dev',
+          text: 'q',
+          ts: 0,
+          isBot: false,
+          replyToBotMessageId: null,
+        },
+        {
+          externalMessageId: '2',
+          authorId: 'BBOT',
+          authorName: 'b',
+          text: 'a',
+          ts: 0,
+          isBot: true,
+          replyToBotMessageId: null,
+        },
+      ],
+    })
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: cb,
+      fetchImpl: fn,
+      now: () => 50,
+    })
+
+    await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toEqual({
+      humans: 1,
+      bots: 1,
+      fetchedAt: 50,
+      truncated: true,
+    })
+  })
+
+  test('rate-limit style errors return transient failures (no fallback)', async () => {
     const { fn } = fakeFetch([slackResponse({ ok: false, error: 'rate_limited' })])
-    const resolver = createSlackMembershipResolver({ token: 'tok', logger: silentLogger(), fetchImpl: fn })
+    const { cb, calls: historyCalls } = fakeHistory({ ok: true, messages: [] })
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: cb,
+      fetchImpl: fn,
+    })
+
+    await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toEqual({
+      kind: 'transient',
+    })
+    expect(historyCalls).toHaveLength(0)
+  })
+
+  test('permanent failure + history failure surfaces transient (cache retries soon)', async () => {
+    const { fn } = fakeFetch([slackResponse({ ok: false, error: 'missing_scope' })])
+    const { cb } = fakeHistory({ ok: false, error: 'boom' })
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: cb,
+      fetchImpl: fn,
+    })
 
     await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toEqual({
       kind: 'transient',

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -1,10 +1,10 @@
 import {
   MEMBERSHIP_ENUMERATION_CAP,
-  type MembershipCount,
   type MembershipResolver,
   type MembershipResolverFailure,
   type MembershipResolverResult,
 } from '@/channels/membership'
+import { deriveMembershipFromHistory } from '@/channels/membership-from-history'
 import type { ChannelRouter } from '@/channels/router'
 import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 import type {
@@ -173,7 +173,7 @@ type SlackUserInfoResponse = {
 export function createSlackMembershipResolver(deps: {
   token: string
   logger: SlackBotAdapterLogger
-  botUserIdRef?: () => string | null
+  historyCallback: HistoryCallback
   fetchImpl?: typeof fetch
   now?: () => number
 }): MembershipResolver {
@@ -183,17 +183,38 @@ export function createSlackMembershipResolver(deps: {
   return async (key): Promise<MembershipResolverResult> => {
     if (key.workspace === '@dm') return { humans: 1, bots: 1, fetchedAt: now(), truncated: false }
 
+    const fallback = (): Promise<MembershipResolverResult> =>
+      deriveMembershipFromHistory({
+        fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit }),
+        now,
+      })
+
     const info = await slackApi<SlackConversationInfoResponse>(fetchFn, deps.token, 'conversations.info', {
       channel: key.chat,
     })
     if (!info.ok) {
+      // missing_scope / not_in_channel: the bot cannot see the channel's
+      // member list at all, but `conversations.history` (or app_mention
+      // delivery) usually still works enough to derive recent speakers.
+      // Treat any permanent failure here as a signal to fall back rather
+      // than propagate "I don't know" upstream — same shape as Discord's
+      // 403 path.
+      if (info.failure.kind === 'permanent') {
+        deps.logger.warn(
+          `[slack-bot] membership info channel=${key.chat} failed permanently: ${info.reason}; deriving from recent message authors`,
+        )
+        return await fallback()
+      }
       deps.logger.warn(`[slack-bot] membership info channel=${key.chat} failed: ${info.reason}`)
       return info.failure
     }
 
     const total = Math.max(0, Math.floor(info.value.channel?.num_members ?? 0))
     if (total > MEMBERSHIP_ENUMERATION_CAP) {
-      return approximateSlackMembership(total, deps.botUserIdRef?.() ?? null, now())
+      // Beyond the enumeration cap, the recent-speakers count is more
+      // useful for engagement than a raw channel-wide approximation that
+      // double-counts lurkers.
+      return await fallback()
     }
 
     const members = await slackApi<SlackConversationMembersResponse>(fetchFn, deps.token, 'conversations.members', {
@@ -201,6 +222,12 @@ export function createSlackMembershipResolver(deps: {
       limit: String(MEMBERSHIP_ENUMERATION_CAP),
     })
     if (!members.ok) {
+      if (members.failure.kind === 'permanent') {
+        deps.logger.warn(
+          `[slack-bot] membership members channel=${key.chat} failed permanently: ${members.reason}; deriving from recent message authors`,
+        )
+        return await fallback()
+      }
       deps.logger.warn(`[slack-bot] membership members channel=${key.chat} failed: ${members.reason}`)
       return members.failure
     }
@@ -267,11 +294,6 @@ function slackFailureForError(error: string): MembershipResolverFailure {
     return { kind: 'permanent' }
   }
   return { kind: 'transient' }
-}
-
-function approximateSlackMembership(total: number, botUserId: string | null, fetchedAt: number): MembershipCount {
-  const bots = botUserId === null ? 0 : 1
-  return { humans: Math.max(0, total - bots), bots, fetchedAt, truncated: true }
 }
 
 // Direct fetch to Slack's Web API. The shim only exposes postMessage /
@@ -523,7 +545,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
   const membershipResolver = createSlackMembershipResolver({
     token: options.token,
     logger,
-    botUserIdRef: () => botUserId,
+    historyCallback,
   })
 
   const outboundCallback = createOutboundCallback({

--- a/src/channels/membership-from-history.test.ts
+++ b/src/channels/membership-from-history.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test'
+
+import { countAuthors, deriveMembershipFromHistory, HISTORY_LOOKBACK_LIMIT } from './membership-from-history'
+import type { ChannelHistoryMessage, FetchHistoryResult } from './types'
+
+function msg(
+  over: Partial<ChannelHistoryMessage> & Pick<ChannelHistoryMessage, 'authorId' | 'isBot'>,
+): ChannelHistoryMessage {
+  return {
+    externalMessageId: over.externalMessageId ?? `m-${over.authorId}-${Math.random()}`,
+    authorId: over.authorId,
+    authorName: over.authorName ?? over.authorId,
+    text: over.text ?? '',
+    ts: over.ts ?? 0,
+    isBot: over.isBot,
+    replyToBotMessageId: over.replyToBotMessageId ?? null,
+  }
+}
+
+describe('countAuthors', () => {
+  test('empty history returns zero counts (not a failure)', () => {
+    expect(countAuthors([], 100)).toEqual({ humans: 0, bots: 0, fetchedAt: 100, truncated: true })
+  })
+
+  test('dedupes by author id and splits humans/bots', () => {
+    const result = countAuthors(
+      [
+        msg({ authorId: 'alice', isBot: false }),
+        msg({ authorId: 'alice', isBot: false }),
+        msg({ authorId: 'bot1', isBot: true }),
+        msg({ authorId: 'bob', isBot: false }),
+        msg({ authorId: 'bot1', isBot: true }),
+      ],
+      200,
+    )
+    expect(result).toEqual({ humans: 2, bots: 1, fetchedAt: 200, truncated: true })
+  })
+
+  test('first occurrence wins on classification disagreement (data-glitch resilience)', () => {
+    const result = countAuthors([msg({ authorId: 'flip', isBot: false }), msg({ authorId: 'flip', isBot: true })], 0)
+    expect(result).toEqual({ humans: 1, bots: 0, fetchedAt: 0, truncated: true })
+  })
+
+  test('always marks result truncated (history is a partial view by definition)', () => {
+    const result = countAuthors([msg({ authorId: 'a', isBot: false })], 0)
+    expect('humans' in result && result.truncated).toBe(true)
+  })
+})
+
+describe('deriveMembershipFromHistory', () => {
+  test('asks history for the lookback limit', async () => {
+    let askedLimit = -1
+    const fetchHistory = async (limit: number): Promise<FetchHistoryResult> => {
+      askedLimit = limit
+      return { ok: true, messages: [] }
+    }
+    await deriveMembershipFromHistory({ fetchHistory, now: () => 0 })
+    expect(askedLimit).toBe(HISTORY_LOOKBACK_LIMIT)
+  })
+
+  test('maps a successful fetch into a truncated count', async () => {
+    const fetchHistory = async (): Promise<FetchHistoryResult> => ({
+      ok: true,
+      messages: [
+        msg({ authorId: 'alice', isBot: false }),
+        msg({ authorId: 'penpen', isBot: true }),
+        msg({ authorId: 'arti', isBot: true }),
+      ],
+    })
+    const result = await deriveMembershipFromHistory({ fetchHistory, now: () => 999 })
+    expect(result).toEqual({ humans: 1, bots: 2, fetchedAt: 999, truncated: true })
+  })
+
+  test('history failure returns transient (cache retries soon)', async () => {
+    const fetchHistory = async (): Promise<FetchHistoryResult> => ({ ok: false, error: 'boom' })
+    const result = await deriveMembershipFromHistory({ fetchHistory, now: () => 0 })
+    expect(result).toEqual({ kind: 'transient' })
+  })
+})

--- a/src/channels/membership-from-history.ts
+++ b/src/channels/membership-from-history.ts
@@ -1,0 +1,53 @@
+import { type MembershipResolverResult } from './membership'
+import type { ChannelHistoryMessage, FetchHistoryResult } from './types'
+
+// History-derived membership counts only the authors visible in the most
+// recent N history messages — explicitly NOT a full guild/workspace
+// membership snapshot. We mark `truncated: true` so the engagement layer
+// (`resolveEffectiveHumans`) treats it as a quieting hint rather than
+// ground truth and `Math.max`-folds it with persisted speakers.
+//
+// Used as a fallback when the platform's authoritative membership
+// endpoint is unavailable (Discord 403 from missing GUILD_MEMBERS
+// privileged intent, Slack `missing_scope` / `not_in_channel`, or any
+// future adapter that lacks an enumeration capability), and as the
+// preferred answer when the authoritative endpoint says "too many to
+// enumerate" — a 1000-member guild's "5 active speakers" is more useful
+// for engagement than "1000 members minus self".
+//
+// Returns a `transient` failure when history fetch itself fails, so the
+// cache retries soon. Returns a count of zero humans/bots (rather than a
+// failure) when history is empty — a brand-new channel is a legitimate
+// state, not an error.
+export const HISTORY_LOOKBACK_LIMIT = 100
+
+export type DeriveMembershipDeps = {
+  fetchHistory: (limit: number) => Promise<FetchHistoryResult>
+  now: () => number
+}
+
+export async function deriveMembershipFromHistory(deps: DeriveMembershipDeps): Promise<MembershipResolverResult> {
+  const result = await deps.fetchHistory(HISTORY_LOOKBACK_LIMIT)
+  if (!result.ok) return { kind: 'transient' }
+  return countAuthors(result.messages, deps.now())
+}
+
+export function countAuthors(messages: readonly ChannelHistoryMessage[], fetchedAt: number): MembershipResolverResult {
+  // Dedupe by author id; once we've classified an author as bot or human
+  // (via the adapter's `isBot` flag), keep that classification stable
+  // even if a later message disagrees. The first occurrence wins for
+  // determinism — Discord's `author.bot` and Slack's `subtype === 'bot_message'`
+  // are stable for a given user, so disagreement would indicate a data
+  // glitch we don't want to swing the count on.
+  const seen = new Map<string, boolean>()
+  for (const m of messages) {
+    if (!seen.has(m.authorId)) seen.set(m.authorId, m.isBot)
+  }
+  let humans = 0
+  let bots = 0
+  for (const isBot of seen.values()) {
+    if (isBot) bots++
+    else humans++
+  }
+  return { humans, bots, fetchedAt, truncated: true }
+}

--- a/src/channels/membership.ts
+++ b/src/channels/membership.ts
@@ -1,7 +1,16 @@
 import type { ChannelKey } from './types'
 
 export const MEMBERSHIP_ENUMERATION_CAP = 50
-export const MEMBERSHIP_CACHE_TTL_MS = 5 * 60 * 1000
+// Engagement decisions read this every inbound but tolerate moderate
+// staleness — the count rarely changes between turns. The router
+// invalidates the cache when a previously-unseen author posts (see
+// router.ts), so the only practical sources of staleness this TTL
+// governs are: (1) silent leavers we don't notice until next refetch,
+// (2) lurkers with permission overwrites who never speak. Both are
+// quieting hints at most. 30min matches the upper bound of "session
+// idle" so the cache typically expires around the same time the
+// LiveSession would be GC'd anyway.
+export const MEMBERSHIP_CACHE_TTL_MS = 30 * 60 * 1000
 export const MEMBERSHIP_CACHE_PERMANENT_TTL_MS = 5 * 60 * 1000
 export const MEMBERSHIP_CACHE_TRANSIENT_TTL_MS = 30_000
 export const MEMBERSHIP_FRESHNESS_MS = 60_000

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -502,6 +502,60 @@ describe('ChannelRouter engagement and prompt composition', () => {
 
     expect(sessions[0]!.prompts).toHaveLength(0)
   })
+
+  test('previously-unseen author triggers a membership refetch (warmup after invalidate)', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    let resolverCalls = 0
+    router.registerMembership('discord-bot', async () => {
+      resolverCalls++
+      return { humans: 1, bots: 0, fetchedAt: Date.now(), truncated: false }
+    })
+
+    await router.route(inbound({ authorId: 'alice', authorName: 'alice' }))
+    await router.__testing!.flushDebounce(KEY)
+    const callsAfterFirstAuthor = resolverCalls
+
+    // Same author — no invalidation, no extra resolver call (cache still hot)
+    await router.route(inbound({ authorId: 'alice', authorName: 'alice', externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(resolverCalls).toBe(callsAfterFirstAuthor)
+
+    // Novel author — cache invalidated, warmup kicks off (additional resolver hit)
+    await router.route(inbound({ authorId: 'bob', authorName: 'bob', externalMessageId: 'm3' }))
+    await router.__testing!.flushDebounce(KEY)
+    await waitFor(() => resolverCalls > callsAfterFirstAuthor)
+    expect(resolverCalls).toBeGreaterThan(callsAfterFirstAuthor)
+  })
+
+  test('DM channels skip the new-author invalidation path', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    let resolverCalls = 0
+    router.registerMembership('discord-bot', async () => {
+      resolverCalls++
+      return { humans: 1, bots: 1, fetchedAt: Date.now(), truncated: false }
+    })
+
+    const dmKey: ChannelKey = { adapter: 'discord-bot', workspace: '@dm', chat: 'd1', thread: null }
+    await router.route(inbound({ workspace: '@dm', chat: 'd1', isDm: true, authorId: 'alice', authorName: 'alice' }))
+    await router.__testing!.flushDebounce(dmKey)
+    const callsAfterFirst = resolverCalls
+
+    await router.route(
+      inbound({
+        workspace: '@dm',
+        chat: 'd1',
+        isDm: true,
+        authorId: 'bob',
+        authorName: 'bob',
+        externalMessageId: 'm2',
+      }),
+    )
+    await router.__testing!.flushDebounce(dmKey)
+
+    expect(resolverCalls).toBe(callsAfterFirst)
+  })
 })
 
 describe('ChannelRouter sticky credits', () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -767,6 +767,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
     const live = await ensureLive(key, event.externalMessageId)
 
+    const isNewAuthor = !live.participants.some((p) => p.authorId === event.authorId)
     live.participants = updateParticipants(
       live.participants,
       event.authorId,
@@ -775,6 +776,22 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       event.authorIsBot,
     )
     void persistParticipants(live)
+
+    // A previously-unseen author just spoke. The cached membership count
+    // (from /members or history-derived) was computed without them, so
+    // invalidate and warm in the background. We don't await — the warmup
+    // runs alongside this turn's `membershipForEngagement` call so the
+    // *next* turn sees fresh data, but the current turn still gets a
+    // fast answer (cache miss → cold fetch with timeout, or stale-ok).
+    if (isNewAuthor && live.key.workspace !== '@dm') {
+      const cache = membershipCaches.get(live.key.adapter)
+      if (cache !== undefined) {
+        cache.invalidate(live.key)
+        void cache.warmUp(live.key).catch((err) => {
+          logger.warn(`[channels] membership warmup after new author failed for ${live.keyId}: ${describe(err)}`)
+        })
+      }
+    }
 
     const membership = await membershipForEngagement(live)
 


### PR DESCRIPTION
## Summary

When Discord's `/members` endpoint returns 403 (missing GUILD_MEMBERS privileged intent) or Slack's `conversations.members` fails permanently (missing_scope, not_in_channel), the previous fallback fabricated wrong human/bot counts: it assumed "I'm the only bot in this channel" and counted every other member as human.

In a multi-bot channel — e.g. four typeclaw agents running side-by-side, each addressed by a Korean nickname — this inflated `humans` by the bot count (`{humans: 5, bots: 1}` for a 2-human + 4-bot channel). The engagement layer's solo-human gate (`effectiveHumans <= 1 && !authorIsBot`) saw a falsely large human count and either engaged unconditionally or stayed silent unconditionally, never just the named one. Same miscount applied to channels with >50 members where enumeration was skipped entirely.

This PR replaces the fabricated approximation with a count derived from recent message authors via the existing history callback.

## Changes

### New module: `src/channels/membership-from-history.ts`

Exports `deriveMembershipFromHistory()` and `countAuthors()`. Walks the channel's recent message history, classifies each author as bot or human, deduplicates by author ID, and returns `{ humans, bots, truncated: true }`. The `truncated` flag tells `resolveEffectiveHumans` in engagement.ts to fold the result conservatively via `Math.max` against persisted speakers rather than treating it as an exact ground truth — "who spoke recently" is close enough to "who is here" for the solo-human heuristic, but it's not a headcount.

### Discord adapter (`src/channels/adapters/discord-bot.ts`)

Falls back to `deriveMembershipFromHistory()` on HTTP 403 (with a warn log that names the GUILD_MEMBERS privileged intent and links to the Developer Portal toggle — the most common operational footgun, separate from ADMINISTRATOR perms and MESSAGE_CONTENT). Also uses it for >50-member guilds where full enumeration was previously skipped. `approximateDiscordMembership` is deleted; no callers remain.

### Slack adapter (`src/channels/adapters/slack-bot.ts`)

Falls back to `deriveMembershipFromHistory()` on permanent failures (`missing_scope`, `not_in_channel`) and on >50-member channels. `approximateSlackMembership` is deleted; no callers remain. Transient failures (rate limits, network errors) still propagate as-is.

### Cache TTL: 5min → 30min (`src/channels/membership.ts`)

The history-derived count rarely changes between turns. TTL is bumped to reduce redundant history fetches. The router now invalidates and warms the cache when a previously-unseen author posts, so novel speakers are reflected within one turn rather than waiting for TTL expiry.

### Router cache invalidation hook (`src/channels/router.ts`)

On every inbound message, the router checks whether the author was previously unseen in this channel. If so, it invalidates the membership cache entry and kicks off a non-blocking warmup alongside the current turn's resolution — the current turn resolves immediately, the next turn sees fresh data.

## Why this approach

The engagement layer's solo-human fallback answers the question "is this effectively a 1-on-1 channel?" — not "is this person a full guild member?" Recent speakers are the right population for that question. A 1000-member guild where only 2 people talk should let the bot engage on plain-text addressing; a 6-member channel where 4 are peer bots should not pretend to be 1-on-1. The history-derived count captures exactly this signal without requiring privileged intents.

## Tests

- **`src/channels/membership-from-history.test.ts`** (new, 7 tests): empty history, author deduplication, classification stability, truncation flag always set, lookback limit, transient failure propagation.
- **`src/channels/adapters/discord-bot.test.ts`** (2 tests replaced, 5 added): 403 path uses history fallback, >50-member path uses history fallback, transient vs. permanent distinction verified, history fetch failure during fallback returns transient.
- **`src/channels/adapters/slack-bot.test.ts`** (2 tests replaced, 5 added): same coverage for Slack permanent-failure and oversize paths.
- **`src/channels/router.test.ts`** (2 new tests): novel author triggers invalidation + warmup; DM channels skip the invalidation path.

Full suite: 1505 pass / 0 fail. `typecheck`, `lint`, and `format` all clean.

## Operational note

Operators whose bots hit the 403 fallback should still enable **Server Members Intent** in Discord Developer Portal → Bot → Privileged Gateway Intents for best accuracy — full member list including lurkers who never post. The history-derived fallback now produces correct engagement decisions when they don't, instead of the previous all-or-nothing behavior.