### PR TITLE
Guard skill authoring writes

### DIFF
--- a/plugins/guard/index.test.ts
+++ b/plugins/guard/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtemp, mkdir, symlink } from 'node:fs/promises'
+import { mkdtemp, mkdir, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
@@ -157,6 +157,104 @@ describe('guard plugin', () => {
     expect(result?.block).toBe(true)
   })
 
+  test('allows valid skill writes under memory and user-installed skill roots without acknowledgement', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'typeclaw-guard-'))
+    const agentDir = path.join(root, 'agent')
+    await mkdir(path.join(agentDir, 'memory', 'skills'), { recursive: true })
+    await mkdir(path.join(agentDir, '.agents', 'skills'), { recursive: true })
+    const hook = await toolBeforeHook()
+
+    const memoryResult = await hook(
+      toolEvent('write', {
+        path: 'memory/skills/release-checklist/SKILL.md',
+        content: skillFile('release-checklist'),
+      }),
+      hookContext(agentDir),
+    )
+    const userResult = await hook(
+      toolEvent('write', {
+        path: '.agents/skills/review_flow/SKILL.md',
+        content: skillFile('review_flow'),
+      }),
+      hookContext(agentDir),
+    )
+
+    expect(memoryResult).toBeUndefined()
+    expect(userResult).toBeUndefined()
+  })
+
+  test('validates skill authoring path and frontmatter for write calls', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'typeclaw-guard-'))
+    const agentDir = path.join(root, 'agent')
+    await mkdir(path.join(agentDir, 'memory', 'skills'), { recursive: true })
+    const hook = await toolBeforeHook()
+
+    const wrongFile = await hook(
+      toolEvent('write', {
+        path: 'memory/skills/release-checklist/README.md',
+        content: skillFile('release-checklist'),
+      }),
+      hookContext(agentDir),
+    )
+    const wrongName = await hook(
+      toolEvent('write', { path: 'memory/skills/release-checklist/SKILL.md', content: skillFile('other-name') }),
+      hookContext(agentDir),
+    )
+    const reservedName = await hook(
+      toolEvent('write', { path: 'memory/skills/typeclaw-secret/SKILL.md', content: skillFile('typeclaw-secret') }),
+      hookContext(agentDir),
+    )
+
+    expect(wrongFile?.reason).toContain('skillAuthoring')
+    expect(wrongName?.reason).toContain('frontmatter name must match')
+    expect(reservedName?.reason).toContain('reserved')
+  })
+
+  test('validates edited final skill content before allowing edit calls', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'typeclaw-guard-'))
+    const agentDir = path.join(root, 'agent')
+    const skillPath = path.join(agentDir, 'memory', 'skills', 'release-checklist', 'SKILL.md')
+    await mkdir(path.dirname(skillPath), { recursive: true })
+    await writeFile(skillPath, skillFile('release-checklist', 'Old description'))
+    const hook = await toolBeforeHook()
+
+    const validEdit = await hook(
+      toolEvent('edit', {
+        path: 'memory/skills/release-checklist/SKILL.md',
+        edits: [{ oldText: 'Old description', newText: 'New description' }],
+      }),
+      hookContext(agentDir),
+    )
+    const invalidEdit = await hook(
+      toolEvent('edit', {
+        path: 'memory/skills/release-checklist/SKILL.md',
+        edits: [{ oldText: 'name: release-checklist', newText: 'name: other-name' }],
+      }),
+      hookContext(agentDir),
+    )
+
+    expect(validEdit).toBeUndefined()
+    expect(invalidEdit?.reason).toContain('frontmatter name must match')
+  })
+
+  test('blocks skill writes through symlinks that escape the skill root', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'typeclaw-guard-'))
+    const agentDir = path.join(root, 'agent')
+    const skillsDir = path.join(agentDir, 'memory', 'skills')
+    const outsideDir = path.join(root, 'outside')
+    await mkdir(skillsDir, { recursive: true })
+    await mkdir(outsideDir)
+    await symlink(outsideDir, path.join(skillsDir, 'outside-link'))
+    const hook = await toolBeforeHook()
+
+    const result = await hook(
+      toolEvent('write', { path: 'memory/skills/outside-link/SKILL.md', content: skillFile('outside-link') }),
+      hookContext(agentDir),
+    )
+
+    expect(result?.block).toBe(true)
+  })
+
   test('ignores non-mutating tools and invalid paths', async () => {
     const hook = await toolBeforeHook()
 
@@ -194,4 +292,8 @@ function pluginContext(agentDir: string): PluginContext<undefined> {
     logger: noopLogger,
     spawnSubagent: async () => {},
   }
+}
+
+function skillFile(name: string, description = 'Use when shipping a release.'): string {
+  return `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`
 }

--- a/plugins/guard/index.ts
+++ b/plugins/guard/index.ts
@@ -1,12 +1,19 @@
 import { definePlugin } from '@/plugin'
 
-import { checkNonWorkspaceWriteGuard } from './policy'
+import { checkNonWorkspaceWriteGuard, checkSkillAuthoringGuard } from './policy'
 
 export default definePlugin({
   plugin: async () => ({
     hooks: {
-      'tool.before': (event, ctx) =>
-        checkNonWorkspaceWriteGuard({ tool: event.tool, args: event.args, agentDir: ctx.agentDir }),
+      'tool.before': async (event, ctx) => {
+        const skillResult = await checkSkillAuthoringGuard({
+          tool: event.tool,
+          args: event.args,
+          agentDir: ctx.agentDir,
+        })
+        if (skillResult) return skillResult
+        return checkNonWorkspaceWriteGuard({ tool: event.tool, args: event.args, agentDir: ctx.agentDir })
+      },
     },
   }),
 })

--- a/plugins/guard/policies/non-workspace-write.ts
+++ b/plugins/guard/policies/non-workspace-write.ts
@@ -2,6 +2,7 @@ import { realpath } from 'node:fs/promises'
 import path from 'node:path'
 
 import { ACKNOWLEDGE_GUARDS, type GuardBlock, isGuardAcknowledged } from '../policy'
+import { isSkillAuthoringAllowed } from './skill-authoring'
 
 export const GUARD_NON_WORKSPACE_WRITE = 'nonWorkspaceWrite'
 
@@ -40,6 +41,7 @@ export async function checkNonWorkspaceWriteGuard(options: {
     resolveRealIntendedPath(targetPath),
     resolveRealIntendedPath(workspacePath),
   ])
+  if (await isSkillAuthoringAllowed({ tool, args, agentDir })) return undefined
   if (await isAllowedAgentRootWrite(agentDir, targetPath, realTargetPath)) return undefined
   if (isInside(realWorkspacePath, realTargetPath)) return undefined
   if (isGuardAcknowledged(args, GUARD_NON_WORKSPACE_WRITE)) return undefined

--- a/plugins/guard/policies/skill-authoring.test.ts
+++ b/plugins/guard/policies/skill-authoring.test.ts
@@ -28,6 +28,19 @@ describe('skill authoring guard policy', () => {
     })
   })
 
+  test('does not treat dev-stage bundled skill paths as runtime-authorable skills', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-skill-guard-'))
+    await mkdir(path.join(agentDir, 'src', 'skills'), { recursive: true })
+
+    const result = await checkSkillAuthoringDecision({
+      tool: 'write',
+      agentDir,
+      args: { path: 'src/skills/typeclaw-example/SKILL.md', content: skillFile('typeclaw-example') },
+    })
+
+    expect(result).toBeUndefined()
+  })
+
   test('validates the final content produced by edit calls', async () => {
     const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-skill-guard-'))
     const skillPath = path.join(agentDir, 'memory', 'skills', 'release-checklist', 'SKILL.md')

--- a/plugins/guard/policies/skill-authoring.test.ts
+++ b/plugins/guard/policies/skill-authoring.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { checkSkillAuthoringDecision } from './skill-authoring'
+
+describe('skill authoring guard policy', () => {
+  test('allows valid skill writes and blocks invalid frontmatter', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-skill-guard-'))
+    await mkdir(path.join(agentDir, 'memory', 'skills'), { recursive: true })
+
+    const allowed = await checkSkillAuthoringDecision({
+      tool: 'write',
+      agentDir,
+      args: { path: 'memory/skills/release-checklist/SKILL.md', content: skillFile('release-checklist') },
+    })
+    const blocked = await checkSkillAuthoringDecision({
+      tool: 'write',
+      agentDir,
+      args: { path: 'memory/skills/release-checklist/SKILL.md', content: skillFile('other-name') },
+    })
+
+    expect(allowed).toEqual({ allow: true })
+    expect(blocked).toEqual({
+      block: true,
+      reason: expect.stringContaining('frontmatter name must match'),
+    })
+  })
+
+  test('validates the final content produced by edit calls', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-skill-guard-'))
+    const skillPath = path.join(agentDir, 'memory', 'skills', 'release-checklist', 'SKILL.md')
+    await mkdir(path.dirname(skillPath), { recursive: true })
+    await writeFile(skillPath, skillFile('release-checklist', 'Old description'))
+
+    const allowed = await checkSkillAuthoringDecision({
+      tool: 'edit',
+      agentDir,
+      args: {
+        path: 'memory/skills/release-checklist/SKILL.md',
+        edits: [{ oldText: 'Old description', newText: 'New description' }],
+      },
+    })
+    const blocked = await checkSkillAuthoringDecision({
+      tool: 'edit',
+      agentDir,
+      args: {
+        path: 'memory/skills/release-checklist/SKILL.md',
+        edits: [{ oldText: 'name: release-checklist', newText: 'name: other-name' }],
+      },
+    })
+
+    expect(allowed).toEqual({ allow: true })
+    expect(blocked).toEqual({
+      block: true,
+      reason: expect.stringContaining('frontmatter name must match'),
+    })
+  })
+})
+
+function skillFile(name: string, description = 'Use when shipping a release.'): string {
+  return `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`
+}

--- a/plugins/guard/policies/skill-authoring.ts
+++ b/plugins/guard/policies/skill-authoring.ts
@@ -1,0 +1,190 @@
+import { readFile, realpath } from 'node:fs/promises'
+import path from 'node:path'
+
+import type { GuardBlock } from '../policy'
+
+export const GUARD_SKILL_AUTHORING = 'skillAuthoring'
+
+export type SkillAuthoringDecision = GuardBlock | { allow: true } | undefined
+
+const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
+
+type SkillRoot = {
+  path: string
+  reservedPrefixAllowed: boolean
+}
+
+export async function checkSkillAuthoringGuard(options: {
+  tool: string
+  args: Record<string, unknown>
+  agentDir: string
+}): Promise<GuardBlock | undefined> {
+  const decision = await checkSkillAuthoringDecision(options)
+  return decision && 'block' in decision ? decision : undefined
+}
+
+export async function checkSkillAuthoringDecision(options: {
+  tool: string
+  args: Record<string, unknown>
+  agentDir: string
+}): Promise<SkillAuthoringDecision> {
+  const { tool, args, agentDir } = options
+  if (tool !== 'write' && tool !== 'edit') return undefined
+
+  const rawPath = args.path
+  if (typeof rawPath !== 'string') return undefined
+
+  const targetPath = path.resolve(agentDir, rawPath)
+  const target = await resolveSkillTarget(agentDir, targetPath)
+  if (!target) return undefined
+
+  if (target.rest.length !== 2 || target.rest[1] !== 'SKILL.md') {
+    return block(tool, targetPath, 'skill writes must target exactly <skill-name>/SKILL.md')
+  }
+
+  const skillName = target.rest[0]
+  if (!skillName || !SKILL_NAME_PATTERN.test(skillName)) {
+    return block(tool, targetPath, `skill name must match ${SKILL_NAME_PATTERN}`)
+  }
+  if (!target.root.reservedPrefixAllowed && skillName.startsWith('typeclaw-')) {
+    return block(tool, targetPath, 'the typeclaw- skill namespace is reserved for bundled skills')
+  }
+
+  const contentResult = await intendedContent(tool, args, targetPath)
+  if ('block' in contentResult) return contentResult
+
+  const frontmatter = parseFrontmatter(contentResult.content)
+  if (!frontmatter) {
+    return block(tool, targetPath, 'SKILL.md must start with YAML frontmatter')
+  }
+  if (frontmatter.name !== skillName) {
+    return block(tool, targetPath, `frontmatter name must match path segment ${skillName}`)
+  }
+  if (!frontmatter.description || frontmatter.description.trim().length === 0) {
+    return block(tool, targetPath, 'frontmatter description is required')
+  }
+
+  return { allow: true }
+}
+
+export async function isSkillAuthoringAllowed(options: {
+  tool: string
+  args: Record<string, unknown>
+  agentDir: string
+}): Promise<boolean> {
+  const decision = await checkSkillAuthoringDecision(options)
+  return decision !== undefined && 'allow' in decision
+}
+
+async function resolveSkillTarget(
+  agentDir: string,
+  targetPath: string,
+): Promise<{ root: SkillRoot; rest: string[] } | undefined> {
+  const roots: SkillRoot[] = [
+    { path: path.join(agentDir, 'memory', 'skills'), reservedPrefixAllowed: false },
+    { path: path.join(agentDir, '.agents', 'skills'), reservedPrefixAllowed: false },
+    { path: path.join(agentDir, 'src', 'skills'), reservedPrefixAllowed: true },
+  ]
+  const realTargetPath = await resolveRealIntendedPath(targetPath)
+
+  for (const root of roots) {
+    const realRootPath = await resolveRealIntendedPath(root.path)
+    if (!isInside(realRootPath, realTargetPath)) continue
+    return { root, rest: path.relative(realRootPath, realTargetPath).split(path.sep).filter(Boolean) }
+  }
+  return undefined
+}
+
+async function intendedContent(
+  tool: string,
+  args: Record<string, unknown>,
+  targetPath: string,
+): Promise<{ content: string } | GuardBlock> {
+  if (tool === 'write') {
+    const content = args.content
+    if (typeof content !== 'string') return block(tool, targetPath, 'write content must be a string')
+    return { content }
+  }
+
+  const edits = args.edits
+  if (!Array.isArray(edits)) return block(tool, targetPath, 'edit calls must include an edits array')
+
+  let content: string
+  try {
+    content = await readFile(targetPath, 'utf8')
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return block(tool, targetPath, `could not read existing skill before edit: ${message}`)
+  }
+
+  for (const edit of edits) {
+    if (!edit || typeof edit !== 'object') return block(tool, targetPath, 'each edit must be an object')
+    const { oldText, newText } = edit as Record<string, unknown>
+    if (typeof oldText !== 'string' || typeof newText !== 'string') {
+      return block(tool, targetPath, 'each edit must include string oldText and newText')
+    }
+    if (oldText.length === 0) return block(tool, targetPath, 'edit oldText must not be empty')
+    if (!content.includes(oldText)) return block(tool, targetPath, 'edit oldText was not found in existing skill')
+    content = content.replace(oldText, newText)
+  }
+  return { content }
+}
+
+function parseFrontmatter(content: string): { name?: string; description?: string } | undefined {
+  const normalized = content.replaceAll('\r\n', '\n')
+  if (!normalized.startsWith('---\n')) return undefined
+  const close = normalized.indexOf('\n---', 4)
+  if (close === -1) return undefined
+
+  const values: { name?: string; description?: string } = {}
+  for (const line of normalized.slice(4, close).split('\n')) {
+    const separator = line.indexOf(':')
+    if (separator === -1) continue
+    const key = line.slice(0, separator).trim()
+    if (key !== 'name' && key !== 'description') continue
+    values[key] = parseScalar(line.slice(separator + 1).trim())
+  }
+  return values
+}
+
+function parseScalar(value: string): string {
+  if (value.length === 0) return ''
+  const quote = value[0]
+  if ((quote === '"' || quote === "'") && value.endsWith(quote)) return value.slice(1, -1)
+  return value
+}
+
+function block(tool: string, targetPath: string, reason: string): GuardBlock {
+  return {
+    block: true,
+    reason: `Guard \`${GUARD_SKILL_AUTHORING}\` blocked ${tool} for ${targetPath}: ${reason}.`,
+  }
+}
+
+function isInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child)
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+async function resolveRealIntendedPath(absolutePath: string): Promise<string> {
+  const pending: string[] = []
+  let current = absolutePath
+
+  while (true) {
+    try {
+      const realCurrent = await realpath(current)
+      return path.join(realCurrent, ...pending.reverse())
+    } catch (err) {
+      if (!isNotFoundError(err)) throw err
+    }
+
+    const parent = path.dirname(current)
+    if (parent === current) throw new Error(`could not resolve existing parent for ${absolutePath}`)
+    pending.push(path.basename(current))
+    current = parent
+  }
+}
+
+function isNotFoundError(err: unknown): boolean {
+  return err instanceof Error && 'code' in err && err.code === 'ENOENT'
+}

--- a/plugins/guard/policies/skill-authoring.ts
+++ b/plugins/guard/policies/skill-authoring.ts
@@ -11,7 +11,6 @@ const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]*$/
 
 type SkillRoot = {
   path: string
-  reservedPrefixAllowed: boolean
 }
 
 export async function checkSkillAuthoringGuard(options: {
@@ -46,7 +45,7 @@ export async function checkSkillAuthoringDecision(options: {
   if (!skillName || !SKILL_NAME_PATTERN.test(skillName)) {
     return block(tool, targetPath, `skill name must match ${SKILL_NAME_PATTERN}`)
   }
-  if (!target.root.reservedPrefixAllowed && skillName.startsWith('typeclaw-')) {
+  if (skillName.startsWith('typeclaw-')) {
     return block(tool, targetPath, 'the typeclaw- skill namespace is reserved for bundled skills')
   }
 
@@ -76,21 +75,17 @@ export async function isSkillAuthoringAllowed(options: {
   return decision !== undefined && 'allow' in decision
 }
 
-async function resolveSkillTarget(
-  agentDir: string,
-  targetPath: string,
-): Promise<{ root: SkillRoot; rest: string[] } | undefined> {
+async function resolveSkillTarget(agentDir: string, targetPath: string): Promise<{ rest: string[] } | undefined> {
   const roots: SkillRoot[] = [
-    { path: path.join(agentDir, 'memory', 'skills'), reservedPrefixAllowed: false },
-    { path: path.join(agentDir, '.agents', 'skills'), reservedPrefixAllowed: false },
-    { path: path.join(agentDir, 'src', 'skills'), reservedPrefixAllowed: true },
+    { path: path.join(agentDir, 'memory', 'skills') },
+    { path: path.join(agentDir, '.agents', 'skills') },
   ]
   const realTargetPath = await resolveRealIntendedPath(targetPath)
 
   for (const root of roots) {
     const realRootPath = await resolveRealIntendedPath(root.path)
     if (!isInside(realRootPath, realTargetPath)) continue
-    return { root, rest: path.relative(realRootPath, realTargetPath).split(path.sep).filter(Boolean) }
+    return { rest: path.relative(realRootPath, realTargetPath).split(path.sep).filter(Boolean) }
   }
   return undefined
 }

--- a/plugins/guard/policy.ts
+++ b/plugins/guard/policy.ts
@@ -9,3 +9,9 @@ export function isGuardAcknowledged(args: Record<string, unknown>, guard: string
 }
 
 export { GUARD_NON_WORKSPACE_WRITE, checkNonWorkspaceWriteGuard } from './policies/non-workspace-write'
+export {
+  GUARD_SKILL_AUTHORING,
+  checkSkillAuthoringDecision,
+  checkSkillAuthoringGuard,
+  isSkillAuthoringAllowed,
+} from './policies/skill-authoring'

--- a/plugins/memory/README.md
+++ b/plugins/memory/README.md
@@ -40,7 +40,7 @@ All fields are **restart-required** — the plugin reads them once at boot.
 
 - **`MEMORY.md`** — long-term memory. Created by the dreaming subagent on first run if absent. Force-committed by the runtime; `skip-worktree` flag is set so the human's `git status` stays clean.
 - **`memory/yyyy-MM-dd.md`** — daily fragment streams. Appended to by `memory-logger`. Created on demand. Gitignored at the agent's level but force-committed alongside `MEMORY.md` after each dreaming run.
-- **`memory/skills/<name>/SKILL.md`** — _muscle memory_. Skills the dreaming subagent distills from repeated procedures it sees in daily streams. Auto-discovered as first-class skills by `createResourceLoader`, and force-committed under the same `memory/` snapshot path as the daily streams. Written via the dreaming subagent's `skill_write` tool; pruned via `skill_delete`. Sandboxed to single-segment kebab/snake-case names, so the agent cannot escape this directory.
+- **`memory/skills/<name>/SKILL.md`** — _muscle memory_. Skills the dreaming subagent distills from repeated procedures it sees in daily streams. Auto-discovered as first-class skills by `createResourceLoader`, and force-committed under the same `memory/` snapshot path as the daily streams. Written or refined with the standard `write` / `edit` tools; the bundled guard plugin enforces the exact `memory/skills/<name>/SKILL.md` path shape, single-segment kebab/snake-case names, matching frontmatter, and symlink/path-traversal safety. There is no runtime skill-delete tool; outright deletion of muscle-memory skills remains a user decision.
 - **`memory/.dreaming-state.json`** — per-day watermarks (line counts already consolidated into `MEMORY.md`). Plain JSON; on malformed input the plugin fails open with empty state.
 
 `typeclaw init` does **not** scaffold these files. They appear when needed.
@@ -67,5 +67,5 @@ In channel sessions, the agent rarely goes idle long enough to trip the timer be
 - `dreaming-state.test.ts` — fail-open semantics on malformed state.
 - `watermark.test.ts` — marker parsing.
 - `append-tool.test.ts` — append-only semantics.
-- `skill-tool.test.ts` — muscle-memory `skill_write` / `skill_delete`: path sandboxing, name validation, YAML frontmatter, overwrite vs delete semantics.
+- `plugins/guard/policies/skill-authoring.test.ts` — runtime skill authoring guard: path sandboxing, name validation, YAML frontmatter, and write/edit final-content validation.
 - `load-memory.test.ts` — memory section rendering, undreamed-tail filtering, watermark stripping.

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 
 import { defineTool as definePiTool } from '@mariozechner/pi-coding-agent'
 import { Type } from '@sinclair/typebox'
@@ -342,6 +345,36 @@ describe('wrapSystemTool', () => {
     await expect(
       wrapped.execute('c', { path: 'workspace/file.txt', content: 'x' }, undefined, undefined, {} as never),
     ).rejects.toThrow('Guard `nonWorkspaceWrite` blocked write outside the workspace')
+    expect(calls).toEqual([])
+  })
+
+  test('write system tool runs final skill guard after hook mutations', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-plugin-tools-'))
+    await mkdir(path.join(agentDir, 'memory', 'skills'), { recursive: true })
+    const calls: number[] = []
+    const tool = definePiTool({
+      name: 'write',
+      label: 'write',
+      description: '',
+      parameters: Type.Object({ path: Type.String(), content: Type.String() }),
+      async execute() {
+        calls.push(1)
+        return { content: [], details: undefined }
+      },
+    })
+    const hooks = createHookBus()
+    hooks.registerAll('p1', agentDir, noopLogger, {
+      'tool.before': (event) => {
+        event.args.path = 'memory/skills/release-checklist/SKILL.md'
+        event.args.content = 'not a skill file'
+      },
+    })
+
+    const wrapped = wrapSystemTool(tool, { agentDir, sessionId: 's', hooks })
+
+    await expect(
+      wrapped.execute('c', { path: 'workspace/file.txt', content: 'x' }, undefined, undefined, {} as never),
+    ).rejects.toThrow('Guard `skillAuthoring` blocked write')
     expect(calls).toEqual([])
   })
 })

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -25,7 +25,7 @@ import type {
   ToolResult,
 } from '@/plugin'
 
-import { ACKNOWLEDGE_GUARDS, checkNonWorkspaceWriteGuard } from '../../plugins/guard/policy'
+import { ACKNOWLEDGE_GUARDS, checkNonWorkspaceWriteGuard, checkSkillAuthoringGuard } from '../../plugins/guard/policy'
 
 type AnyAgentTool =
   | typeof piReadTool
@@ -157,7 +157,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       if (blockResult !== undefined) {
         throw new Error(`blocked: ${blockResult.reason}`)
       }
-      const guardResult = await checkNonWorkspaceWriteGuard({
+      const guardResult = await runFinalWriteGuards({
         tool: tool.name,
         args: mutableArgs,
         agentDir: opts.agentDir,
@@ -204,7 +204,7 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
       if (blockResult !== undefined) {
         throw new Error(`blocked: ${blockResult.reason}`)
       }
-      const guardResult = await checkNonWorkspaceWriteGuard({
+      const guardResult = await runFinalWriteGuards({
         tool: tool.name,
         args: mutableArgs,
         agentDir: opts.agentDir,
@@ -239,6 +239,10 @@ function errorResult(message: string) {
     details: { error: true, message },
     isError: true,
   }
+}
+
+async function runFinalWriteGuards(options: { tool: string; args: Record<string, unknown>; agentDir: string }) {
+  return (await checkSkillAuthoringGuard(options)) ?? checkNonWorkspaceWriteGuard(options)
 }
 
 function withGuardAcknowledgements<TParams extends TSchema>(toolName: string, parameters: TParams): TParams {


### PR DESCRIPTION
## Summary
- Add a `skillAuthoring` guard policy that validates runtime skill paths, names, frontmatter, symlink escapes, and final content for both `write` and `edit`.
- Wire the bundled guard plugin so valid runtime skill writes can bypass the generic workspace guard while invalid skill authoring is blocked.
- Run the skill guard again after tool hooks to prevent later argument mutation from bypassing validation.
- Update memory plugin docs to remove stale `skill_write` / `skill_delete` references and describe standard `write` / `edit` skill authoring.

## What is allowed
- `write` to valid muscle-memory skill files under `memory/skills/<name>/SKILL.md`.
- `write` to valid user-installed skill files under `.agents/skills/<name>/SKILL.md`.
- `edit` of existing skill files in those runtime roots when the reconstructed final content is still valid.
- Skill names that are a single segment matching `^[a-z0-9][a-z0-9_-]*$`.
- `SKILL.md` files whose YAML frontmatter includes `name` matching the path segment and a non-empty `description`.

## What is blocked
- Writes inside runtime skill roots that do not target exactly `<skill-name>/SKILL.md`.
- Skill names with slashes, dots, uppercase characters, empty names, or other invalid characters.
- Any `typeclaw-` skill name in runtime-authored roots; that namespace remains reserved for bundled package skills, which container-stage agents do not author through this guard.
- Missing frontmatter, mismatched `name`, or empty/missing `description`.
- `edit` calls whose final reconstructed content would violate the skill rules.
- `edit` calls whose existing file cannot be read, whose `edits` payload is malformed, or whose `oldText` is missing.
- Symlink/path traversal escapes out of the allowed runtime skill roots.
- Non-skill writes remain governed by the existing `nonWorkspaceWrite` guard.

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun test`