### PR TITLE
Engage on group mentions like @here and @channel

### DIFF
--- a/src/channels/adapters/agent-messenger-shim.ts
+++ b/src/channels/adapters/agent-messenger-shim.ts
@@ -31,6 +31,8 @@ export type DiscordGatewayMessageCreateEvent = {
   timestamp: string
   edited_timestamp?: string
   mentions?: Array<{ id: string; username: string }>
+  mention_everyone?: boolean
+  mention_roles?: string[]
   message_reference?: {
     message_id?: string
     channel_id?: string

--- a/src/channels/adapters/discord-bot-classify.test.ts
+++ b/src/channels/adapters/discord-bot-classify.test.ts
@@ -346,3 +346,59 @@ describe('discord-bot classifyInbound — targets-others detection', () => {
     expect(verdict.payload.replyToOtherMessageId).toBeNull()
   })
 })
+
+describe('discord-bot classifyInbound — group mentions', () => {
+  test('treats mention_everyone=true (covers @everyone and @here) as a bot mention', () => {
+    const event = buildEvent({ content: '@everyone deploy starting', mention_everyone: true })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(true)
+  })
+
+  test('treats role mentions (mention_roles non-empty) as a bot mention', () => {
+    const event = buildEvent({ content: '<@&role-eng> can someone look', mention_roles: ['role-eng'] })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(true)
+  })
+
+  test('absent mention_everyone/mention_roles fields fall back to direct-mention check', () => {
+    const event = buildEvent({ content: 'just chatter' })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(false)
+  })
+
+  test('mention_everyone=false with empty mention_roles does not flip isBotMention', () => {
+    const event = buildEvent({ content: 'no broadcast', mention_everyone: false, mention_roles: [] })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(false)
+  })
+
+  test('group mention combined with @-someone-else still engages the bot', () => {
+    const event = buildEvent({
+      content: '@here can <@u2> take this?',
+      mention_everyone: true,
+      mentions: [{ id: 'u2', username: 'bob' }],
+    })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(true)
+  })
+})

--- a/src/channels/adapters/discord-bot-classify.ts
+++ b/src/channels/adapters/discord-bot-classify.ts
@@ -49,8 +49,20 @@ export function classifyInbound(
   // botUserId is null until the listener has dispatched 'connected'. Treating
   // an event as a mention in that race window prevents the very first message
   // after start-up from being misclassified as ambient chatter.
+  //
+  // Group mentions (`@everyone`, `@here`, role mentions) are coerced to
+  // direct mentions: the broadcast explicitly includes the bot, and the
+  // engagement layer doesn't meaningfully distinguish "@bot" from "@channel"
+  // — both invite participation. Reusing isBotMention also means the
+  // existing 'mention' trigger in typeclaw.json catches both with no new
+  // config surface. Discord's gateway already provides structured fields
+  // for these, so we don't need to parse content.
+  const hasGroupMention = event.mention_everyone === true || (event.mention_roles ?? []).length > 0
   const isBotMention =
-    botUserId !== null ? event.content.includes(`<@${botUserId}>`) || event.content.includes(`<@!${botUserId}>`) : true
+    hasGroupMention ||
+    (botUserId !== null
+      ? event.content.includes(`<@${botUserId}>`) || event.content.includes(`<@!${botUserId}>`)
+      : true)
 
   // Discord sends a structured `mentions` array on every message, so we can
   // tell "tagged someone other than us" apart from "no mentions at all"

--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -300,3 +300,60 @@ describe('slack-bot classifyInbound — targets-others detection', () => {
     expect(verdict.payload.replyToOtherMessageId).toBeNull()
   })
 })
+
+describe('slack-bot classifyInbound — group mentions', () => {
+  test.each([
+    ['<!here>', '<!here> deploy is starting'],
+    ['<!channel>', 'heads up <!channel> — meeting moved'],
+    ['<!everyone>', '<!everyone> the building is on fire'],
+    ['<!here|here>', '<!here|here> labelled form'],
+  ])('treats Slack group mention %s as a bot mention', (_label, text) => {
+    const event = buildEvent({ text })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(true)
+  })
+
+  test('group mention in a team channel roots a thread at the message ts (same as direct mention)', () => {
+    const event = buildEvent({ text: '<!channel> ping' })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.thread).toBe('1700000000.000100')
+  })
+
+  test('does NOT treat <!subteam^ID> as a group mention (would require subteam membership context)', () => {
+    const event = buildEvent({ text: '<!subteam^S0ENG|engineering> please review' })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(false)
+  })
+
+  test('group mention overrides mentionsOthers — bot is included in the broadcast', () => {
+    const event = buildEvent({ text: '<!here> <@UBOB> can you take this?' })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(true)
+  })
+
+  test('non-group "<!" markup (e.g. <!date^…>) does not flip isBotMention', () => {
+    const event = buildEvent({ text: 'meeting at <!date^1700000000^{date_short}|Nov 14>' })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(false)
+  })
+})

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -59,7 +59,16 @@ export function classifyInbound(
   // botUserId is null until app.connections.open returns auth metadata. In
   // that race window, treat any inbound as a mention so the very first
   // message after start-up isn't misclassified as ambient chatter.
-  const isBotMention = context.botUserId !== null ? text.includes(`<@${context.botUserId}>`) : true
+  //
+  // Group mentions (`<!here>`, `<!channel>`, `<!everyone>`) are coerced to
+  // direct mentions: the user fired a broadcast that explicitly includes the
+  // bot, and from the engagement layer's perspective there is no meaningful
+  // difference between "@bot, look at this" and "@channel, look at this" —
+  // both are an invitation to participate. Treating them identically also
+  // means the existing 'mention' trigger in typeclaw.json catches both
+  // without any new config surface.
+  const hasGroupMention = GROUP_MENTION_PATTERN.test(text)
+  const isBotMention = hasGroupMention || (context.botUserId !== null ? text.includes(`<@${context.botUserId}>`) : true)
   const thread = event.thread_ts ?? (!isDm && isBotMention ? event.ts : null)
 
   // thread_ts identifies the parent message of a thread. We can only know it
@@ -116,6 +125,13 @@ export function classifyInbound(
 // every distinct id out of the text — duplicates collapse so the caller
 // can do a clean `includes()` check against the bot's own id.
 const MENTION_PATTERN = /<@([UW][A-Z0-9]+)(?:\|[^>]*)?>/g
+
+// Slack's group mention markup uses `!` (not `@`) and may carry an optional
+// `|label` suffix, same as user mentions. We deliberately exclude the
+// `<!subteam^ID>` form — engaging on every user-group ping would require
+// knowing which subteams the bot is a member of, which is outside what
+// Socket Mode events surface to us.
+const GROUP_MENTION_PATTERN = /<!(?:here|channel|everyone)(?:\|[^>]*)?>/
 
 function extractMentionedUserIds(text: string): string[] {
   const seen = new Set<string>()


### PR DESCRIPTION
## Summary

Before this change, the agent only engaged on direct user mentions (`<@UBOT>` on Slack, `<@id>`/`<@!id>` on Discord). A message like \`@here deploy is starting\` was classified as ambient chatter — even though the human author obviously intended every member of the channel, including the bot, to see it. The bot would silently observe and only re-engage if someone followed up with an explicit `@bot`.

This PR teaches both classifiers to treat group mentions as direct mentions: Slack's \`<!here>\` / \`<!channel>\` / \`<!everyone>\` and Discord's \`@everyone\` / \`@here\` / role pings now flip \`isBotMention\` to \`true\` at the classifier layer. The engagement layer's existing \`'mention'\` trigger does the rest — no schema change, no new config knob, no migration required.

## Why coerce to \`isBotMention\` instead of adding a new trigger?

Two interpretations were on the table:

1. **Add a \`'group_mention'\` trigger** to \`engagementTriggerSchema\`, require users to opt in via \`typeclaw.json\`.
2. **Reuse \`isBotMention\`** — group mentions are direct mentions for engagement purposes.

Option 2 won because the engagement layer's question is \"did this message invite participation?\" and a broadcast that includes the bot answers \"yes\" just as clearly as a direct \`@-tag\`. Splitting them would mean every existing user who turned on \`mention\` engagement would still miss \`@here\` until they re-edited their config — a silent behavioral regression that an existing-user can't discover except by noticing the bot stopped responding to broadcasts. Reusing \`isBotMention\` makes the change retroactive in the right way.

The downstream \`mentionsOthers\` suppressor still works correctly: a message like \`<!here> <@UBOB> can you take this?\` flips \`isBotMention=true\` (group mention path), which short-circuits the \`mentionsOthers\` check at the engagement layer (the bot is in the broadcast set, so this isn't a \"targeted at someone else\" situation).

## Changes

### \`src/channels/adapters/slack-bot-classify.ts\` — Slack group-mention detection

A new \`GROUP_MENTION_PATTERN\` regex matches \`<!here>\`, \`<!channel>\`, \`<!everyone>\`, optionally with the \`|label\` suffix Slack appends. \`isBotMention\` becomes \`hasGroupMention || (existing direct-mention check)\`. Thread rooting (\`event.thread_ts ?? (!isDm && isBotMention ? event.ts : null)\`) is unchanged — group mentions in a team channel root a thread at the message ts, exactly like direct mentions.

**Deliberate exclusion: \`<!subteam^ID>\` (Slack user groups).** Engaging on every user-group ping would require knowing which subteams the bot is a member of. Socket Mode events do not surface that membership, and resolving it via \`usergroups.list\` + \`usergroups.users.list\` would add a permissioned API call to every cold start. The trade-off is documented in a comment on the regex; users who want the bot to respond to a specific subteam can still get there by mentioning the bot directly inside the subteam ping.

### \`src/channels/adapters/discord-bot-classify.ts\` — Discord group-mention detection

Discord's gateway already provides \`mention_everyone: boolean\` (covers both \`@everyone\` and \`@here\`) and \`mention_roles: string[]\` (role mentions), so no content parsing is needed. \`isBotMention\` becomes \`hasGroupMention || (existing direct-mention check)\` where \`hasGroupMention\` is \`event.mention_everyone === true || (event.mention_roles ?? []).length > 0\`.

### \`src/channels/adapters/agent-messenger-shim.ts\` — Discord shim type extension

\`DiscordGatewayMessageCreateEvent\` gains \`mention_everyone?: boolean\` and \`mention_roles?: string[]\`. The shim file already exists specifically to type-augment the upstream \`agent-messenger\` package's runtime values; this is the same pattern used for the existing \`mentions\` array.

### \`src/channels/adapters/slack-bot-classify.test.ts\` — 6 new tests

- \`<!here>\` / \`<!channel>\` / \`<!everyone>\` each treated as a bot mention (parameterized via \`test.each\`)
- Labelled form \`<!here|here>\` recognized
- Group mention in a team channel still roots a thread at the message ts
- \`<!subteam^ID>\` is **not** treated as a group mention (deliberate scope exclusion locked in by test)
- Group mention combined with \`@-someone-else\` still engages the bot (\`mentionsOthers\` does not override)
- Non-group \`<!\` markup (e.g. \`<!date^…>\` for inline timestamps) does not flip \`isBotMention\`

### \`src/channels/adapters/discord-bot-classify.test.ts\` — 5 new tests

- \`mention_everyone: true\` flips \`isBotMention\`
- \`mention_roles: ['…']\` flips \`isBotMention\`
- Both fields absent falls back to direct-mention check (no false positives on plain chatter)
- \`mention_everyone: false\` + \`mention_roles: []\` does not flip \`isBotMention\` (locks in the strict-truthy semantics)
- Group mention combined with \`@-someone-else\` still engages the bot

## Verification

- \`bun run typecheck\` — clean (\`tsgo --noEmit\`)
- \`bun run lint\` — 0 warnings, 0 errors (\`oxlint\`)
- \`bun run format:check\` — clean (\`oxfmt --check\`)
- \`bun test\` — 1518 pass, 0 fail (was 1505; +13 new tests, no regressions)

## Out of scope

- **Slack \`<!subteam^ID>\` user groups** — see rationale above.
- **Outbound mention syntax** — \`channel-send\`/\`channel-reply\` tool descriptions still document only direct mentions. The agent rarely needs to fire group mentions outbound (those are typically human-driven attention escalations), so the tool surface is left unchanged for now.