### PR TITLE
Drop channel messages before bot identity is known

### DIFF
--- a/src/channels/adapters/discord-bot-classify.test.ts
+++ b/src/channels/adapters/discord-bot-classify.test.ts
@@ -121,6 +121,14 @@ describe('classifyInbound — drop paths', () => {
 
     expect(verdict).toEqual({ kind: 'drop', reason: 'self_author' })
   })
+
+  test('drops messages before bot identity is known with reason=pre_connect', () => {
+    const event = buildEvent({ content: 'no explicit mention' })
+
+    const verdict = classifyInbound(event, baseConfig, null)
+
+    expect(verdict).toEqual({ kind: 'drop', reason: 'pre_connect' })
+  })
 })
 
 describe('classifyInbound — peer-bot routing', () => {
@@ -229,18 +237,7 @@ describe('classifyInbound — route path', () => {
     expect(verdict.payload.replyToOtherMessageId).toBeNull()
   })
 
-  test('treats every event as a mention while botUserId is unknown (pre-connected race window)', () => {
-    const event = buildEvent({ content: 'no explicit mention' })
-
-    const verdict = classifyInbound(event, baseConfig, null)
-
-    expect(verdict.kind).toBe('route')
-    if (verdict.kind !== 'route') throw new Error('expected route')
-    expect(verdict.payload.isBotMention).toBe(true)
-    expect(verdict.payload.replyToBotMessageId).toBeNull()
-  })
-
-  test('drops replyToBotMessageId before bot identity is known (cannot be sure parent was ours)', () => {
+  test('drops replies before bot identity is known (cannot classify parent target safely)', () => {
     const event = buildEvent({
       content: 'reply',
       message_reference: { message_id: 'parent-1' },
@@ -248,9 +245,7 @@ describe('classifyInbound — route path', () => {
 
     const verdict = classifyInbound(event, baseConfig, null)
 
-    expect(verdict.kind).toBe('route')
-    if (verdict.kind !== 'route') throw new Error('expected route')
-    expect(verdict.payload.replyToBotMessageId).toBeNull()
+    expect(verdict).toEqual({ kind: 'drop', reason: 'pre_connect' })
   })
 })
 
@@ -294,7 +289,7 @@ describe('discord-bot classifyInbound — targets-others detection', () => {
     expect(verdict.payload.mentionsOthers).toBe(false)
   })
 
-  test('marks mentionsOthers=false during the pre-connected race window (botUserId unknown)', () => {
+  test('drops mentioned messages during the pre-connected race window (botUserId unknown)', () => {
     const event = buildEvent({
       content: 'hey <@u2>',
       mentions: [{ id: 'u2', username: 'bob' }],
@@ -302,9 +297,7 @@ describe('discord-bot classifyInbound — targets-others detection', () => {
 
     const verdict = classifyInbound(event, baseConfig, null)
 
-    expect(verdict.kind).toBe('route')
-    if (verdict.kind !== 'route') throw new Error('expected route')
-    expect(verdict.payload.mentionsOthers).toBe(false)
+    expect(verdict).toEqual({ kind: 'drop', reason: 'pre_connect' })
   })
 
   test('reply to a non-bot message surfaces replyToOtherMessageId, not replyToBotMessageId', () => {

--- a/src/channels/adapters/discord-bot-classify.ts
+++ b/src/channels/adapters/discord-bot-classify.ts
@@ -12,6 +12,7 @@ export type InboundDropReason =
   | 'self_author' // event.author.id === botUserId; we never route our own messages back to ourselves
   | 'empty_content' // SDK delivered content: '' — usually missing MessageContent intent
   | 'not_in_allow_list' // workspace/channel not admitted by typeclaw.json `channels.discord-bot.allow`
+  | 'pre_connect' // bot identity is not known yet, so mention/self/reply classification cannot be trusted
 
 export type InboundClassification =
   | { kind: 'drop'; reason: InboundDropReason }
@@ -30,10 +31,8 @@ export function classifyInbound(
 ): InboundClassification {
   // Self-drop is the hard floor: we must never route our own messages back to
   // ourselves under any circumstance. We can only do this once botUserId is
-  // known (post-connect); before that, fall through and let downstream layers
-  // see the message — the cold-start race window is small and the alternative
-  // (dropping every bot message including foreign ones) silently disables
-  // peer-bot conversation.
+  // known (post-connect); before that, fail closed below because mention,
+  // reply, and self classification all depend on the bot identity.
   if (botUserId !== null && event.author.id === botUserId) {
     return { kind: 'drop', reason: 'self_author' }
   }
@@ -46,10 +45,10 @@ export function classifyInbound(
     return { kind: 'drop', reason: 'not_in_allow_list' }
   }
 
-  // botUserId is null until the listener has dispatched 'connected'. Treating
-  // an event as a mention in that race window prevents the very first message
-  // after start-up from being misclassified as ambient chatter.
-  //
+  if (botUserId === null) {
+    return { kind: 'drop', reason: 'pre_connect' }
+  }
+
   // Group mentions (`@everyone`, `@here`, role mentions) are coerced to
   // direct mentions: the broadcast explicitly includes the bot, and the
   // engagement layer doesn't meaningfully distinguish "@bot" from "@channel"
@@ -59,29 +58,21 @@ export function classifyInbound(
   // for these, so we don't need to parse content.
   const hasGroupMention = event.mention_everyone === true || (event.mention_roles ?? []).length > 0
   const isBotMention =
-    hasGroupMention ||
-    (botUserId !== null
-      ? event.content.includes(`<@${botUserId}>`) || event.content.includes(`<@!${botUserId}>`)
-      : true)
+    hasGroupMention || event.content.includes(`<@${botUserId}>`) || event.content.includes(`<@!${botUserId}>`)
 
   // Discord sends a structured `mentions` array on every message, so we can
   // tell "tagged someone other than us" apart from "no mentions at all"
-  // without parsing the content. We hold off until botUserId is known —
-  // during the cold-start race we'd otherwise misclassify our own mention
-  // as `mentionsOthers` and silently drop the very first inbound.
-  const mentionsOthers =
-    botUserId !== null && (event.mentions ?? []).length > 0 && !(event.mentions ?? []).some((m) => m.id === botUserId)
+  // without parsing the content.
+  const mentionsOthers = (event.mentions ?? []).length > 0 && !(event.mentions ?? []).some((m) => m.id === botUserId)
 
   const replyToParentId = event.message_reference?.message_id
-  const replyToBotMessageId =
-    replyToParentId !== undefined && botUserId !== null && isReplyToBot(event, botUserId) ? replyToParentId : null
+  const replyToBotMessageId = replyToParentId !== undefined && isReplyToBot(event, botUserId) ? replyToParentId : null
   // Discord does not echo the parent message's author on `message_reference`,
   // but in practice the replied-to user is auto-mentioned in the reply's
   // `mentions` array (this is how the Discord client renders the "Replying
   // to @user" header). So when the parent reference exists and our id is NOT
   // among the mentions, the reply is targeted at someone else.
-  const replyToOtherMessageId =
-    replyToParentId !== undefined && replyToBotMessageId === null && botUserId !== null ? replyToParentId : null
+  const replyToOtherMessageId = replyToParentId !== undefined && replyToBotMessageId === null ? replyToParentId : null
 
   const ts = Date.parse(event.timestamp)
 

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -569,6 +569,7 @@ function dropHint(reason: InboundDropReason): string {
       return ' (enable MESSAGE CONTENT INTENT in Discord Developer Portal and restart)'
     case 'not_in_allow_list':
       return ' (extend channels.discord-bot.allow in typeclaw.json to admit this workspace/channel)'
+    case 'pre_connect':
     case 'self_author':
       return ''
   }

--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -81,6 +81,14 @@ describe('slack-bot classifyInbound — drop paths', () => {
 
     expect(verdict).toEqual({ kind: 'drop', reason: 'self_author' })
   })
+
+  test('drops messages before bot identity is known with reason=pre_connect', () => {
+    const event = buildEvent({ text: 'no explicit mention' })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: null })
+
+    expect(verdict).toEqual({ kind: 'drop', reason: 'pre_connect' })
+  })
 })
 
 describe('slack-bot classifyInbound — peer-bot routing', () => {
@@ -209,18 +217,7 @@ describe('slack-bot classifyInbound — route path', () => {
     expect(verdict.payload.replyToBotMessageId).toBeNull()
   })
 
-  test('treats every event as a mention while botUserId is unknown (pre-connected race window)', () => {
-    const event = buildEvent({ text: 'no explicit mention' })
-
-    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: null })
-
-    expect(verdict.kind).toBe('route')
-    if (verdict.kind !== 'route') throw new Error('expected route')
-    expect(verdict.payload.isBotMention).toBe(true)
-    expect(verdict.payload.replyToBotMessageId).toBeNull()
-  })
-
-  test('drops replyToBotMessageId before bot identity is known (cannot be sure parent was ours)', () => {
+  test('drops thread replies before bot identity is known (cannot classify parent target safely)', () => {
     const event = buildEvent({
       text: 'reply',
       ts: '1700000010.000200',
@@ -229,9 +226,7 @@ describe('slack-bot classifyInbound — route path', () => {
 
     const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: null })
 
-    expect(verdict.kind).toBe('route')
-    if (verdict.kind !== 'route') throw new Error('expected route')
-    expect(verdict.payload.replyToBotMessageId).toBeNull()
+    expect(verdict).toEqual({ kind: 'drop', reason: 'pre_connect' })
   })
 })
 
@@ -276,14 +271,12 @@ describe('slack-bot classifyInbound — targets-others detection', () => {
     expect(verdict.payload.mentionsOthers).toBe(true)
   })
 
-  test('marks mentionsOthers=false during the pre-connected race window (botUserId unknown)', () => {
+  test('drops mentioned messages during the pre-connected race window (botUserId unknown)', () => {
     const event = buildEvent({ text: 'hey <@UBOB>' })
 
     const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: null })
 
-    expect(verdict.kind).toBe('route')
-    if (verdict.kind !== 'route') throw new Error('expected route')
-    expect(verdict.payload.mentionsOthers).toBe(false)
+    expect(verdict).toEqual({ kind: 'drop', reason: 'pre_connect' })
   })
 
   test('Slack does not surface the parent author on inbounds, so replyToOtherMessageId is always null', () => {

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -9,6 +9,7 @@ export type InboundDropReason =
   | 'no_user' // event has no `user` field (e.g. system messages: channel_join, message_changed)
   | 'empty_text' // event.text is empty or missing — nothing for the agent to act on
   | 'not_in_allow_list' // workspace/channel not admitted by typeclaw.json `channels.slack-bot.allow`
+  | 'pre_connect' // bot identity is not known yet, so mention/self/reply classification cannot be trusted
 
 export type InboundClassification =
   | { kind: 'drop'; reason: InboundDropReason }
@@ -31,10 +32,9 @@ export function classifyInbound(
   context: SlackInboundContext,
 ): InboundClassification {
   // Self-drop is the hard floor: never route our own messages back to
-  // ourselves. The check requires `botUserId` (post-auth.test) — before
-  // that, slack-bot.ts already rejects with `pre_connected`, so reaching
-  // here without botUserId means a bot peer's message in the cold-start
-  // window. Let it through (loop guard in the router covers the worst case).
+  // ourselves. The check requires `botUserId` (post-auth.test); before that,
+  // fail closed below because mention, reply, and self classification all
+  // depend on the bot identity.
   if (context.botUserId !== null && event.user === context.botUserId) {
     return { kind: 'drop', reason: 'self_author' }
   }
@@ -56,10 +56,10 @@ export function classifyInbound(
     return { kind: 'drop', reason: 'not_in_allow_list' }
   }
 
-  // botUserId is null until app.connections.open returns auth metadata. In
-  // that race window, treat any inbound as a mention so the very first
-  // message after start-up isn't misclassified as ambient chatter.
-  //
+  if (context.botUserId === null) {
+    return { kind: 'drop', reason: 'pre_connect' }
+  }
+
   // Group mentions (`<!here>`, `<!channel>`, `<!everyone>`) are coerced to
   // direct mentions: the user fired a broadcast that explicitly includes the
   // bot, and from the engagement layer's perspective there is no meaningful
@@ -68,23 +68,17 @@ export function classifyInbound(
   // means the existing 'mention' trigger in typeclaw.json catches both
   // without any new config surface.
   const hasGroupMention = GROUP_MENTION_PATTERN.test(text)
-  const isBotMention = hasGroupMention || (context.botUserId !== null ? text.includes(`<@${context.botUserId}>`) : true)
+  const isBotMention = hasGroupMention || text.includes(`<@${context.botUserId}>`)
   const thread = event.thread_ts ?? (!isDm && isBotMention ? event.ts : null)
 
   // thread_ts identifies the parent message of a thread. We can only know it
   // is a reply to the bot if we recognize the bot's own user id and have a
   // thread_ts that differs from the event ts (the parent message itself
   // shares its ts with thread_ts).
-  const replyToBotMessageId =
-    event.thread_ts !== undefined && event.thread_ts !== event.ts && context.botUserId !== null ? event.thread_ts : null
+  const replyToBotMessageId = event.thread_ts !== undefined && event.thread_ts !== event.ts ? event.thread_ts : null
 
-  // Defer the mentionsOthers signal until botUserId is known. During the
-  // cold-start race window we cannot tell our own mention apart from a
-  // foreign one, and a wrong `true` here would silently suppress the
-  // very first inbound after start-up via the engagement layer.
   const mentionedUserIds = extractMentionedUserIds(text)
-  const mentionsOthers =
-    context.botUserId !== null && mentionedUserIds.length > 0 && !mentionedUserIds.includes(context.botUserId)
+  const mentionsOthers = mentionedUserIds.length > 0 && !mentionedUserIds.includes(context.botUserId)
 
   // Slack does not surface the parent message's author on `event`, so we
   // cannot positively identify a reply-to-other from the inbound alone.

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -727,6 +727,7 @@ function dropHint(reason: InboundDropReason): string {
       return ' (extend channels.slack-bot.allow in typeclaw.json to admit this team/channel)'
     case 'empty_text':
     case 'no_user':
+    case 'pre_connect':
     case 'self_author':
       return ''
   }


### PR DESCRIPTION
## Summary
- Fail closed in Discord and Slack bot classifiers when the bot user ID is not known yet.
- Add `pre_connect` drop handling so cold-start/reconnect messages no longer look like explicit bot mentions.
- Update classifier tests to cover ambient messages, replies, and mentions during the pre-connect window.

## Validation
- `bun test src/channels/adapters/discord-bot-classify.test.ts src/channels/adapters/slack-bot-classify.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format`
- `bun run format:check`
- `bun run test` (1505 pass)

## Notes
- Implemented in isolated worktree: `/tmp/typeclaw-cold-start-mention`.