### PR TITLE
Dedupe Slack inbounds by client_msg_id

### DIFF
--- a/src/channels/adapters/agent-messenger-slack-shim.ts
+++ b/src/channels/adapters/agent-messenger-slack-shim.ts
@@ -38,6 +38,12 @@ export type SlackSocketMessageEvent = {
   event_ts?: string
   edited?: { user: string; ts: string }
   hidden?: boolean
+  // Client-generated UUID present on user-authored messages. Stable across
+  // network retries of the same user gesture (the Slack client reuses it
+  // when a send fails and is retried), so it is a reliable secondary dedup
+  // key for the case where one user action surfaces as two events with
+  // different `ts` values. Absent on bot messages and most system events.
+  client_msg_id?: string
   [key: string]: unknown
 }
 
@@ -49,6 +55,11 @@ export type SlackSocketAppMentionEvent = {
   ts: string
   thread_ts?: string
   event_ts?: string
+  // Carried verbatim into the promoted message event when present so the
+  // dedupe ring can use it. Slack's `app_mention` envelope does not always
+  // populate this in practice, but typing it keeps the promotion lossless
+  // if Slack starts sending it.
+  client_msg_id?: string
   [key: string]: unknown
 }
 

--- a/src/channels/adapters/slack-bot-dedupe.test.ts
+++ b/src/channels/adapters/slack-bot-dedupe.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createSlackDedupe, SLACK_DEDUPE_CAPACITY } from './slack-bot-dedupe'
+
+describe('createSlackDedupe', () => {
+  test('first sighting of a (channel, ts) is not a duplicate', () => {
+    const dedupe = createSlackDedupe()
+    expect(dedupe.check({ channel: 'C0CHANNEL', ts: '1700000000.000100' })).toBeNull()
+  })
+
+  test('redelivery with the same (channel, ts) is detected as channel_ts duplicate', () => {
+    const dedupe = createSlackDedupe()
+    const event = { channel: 'C0CHANNEL', ts: '1700000000.000100' }
+    dedupe.mark(event)
+    expect(dedupe.check(event)).toBe('channel_ts')
+  })
+
+  test('different ts in the same channel is not a duplicate when no client_msg_id is involved', () => {
+    const dedupe = createSlackDedupe()
+    dedupe.mark({ channel: 'C0CHANNEL', ts: '1700000000.000100' })
+    expect(dedupe.check({ channel: 'C0CHANNEL', ts: '1700000000.000200' })).toBeNull()
+  })
+
+  test('same ts in different channels is not a duplicate', () => {
+    const dedupe = createSlackDedupe()
+    dedupe.mark({ channel: 'C0CHANNEL', ts: '1700000000.000100' })
+    expect(dedupe.check({ channel: 'C0OTHER', ts: '1700000000.000100' })).toBeNull()
+  })
+
+  test('redelivery with the same client_msg_id but different ts is detected as client_msg_id duplicate', () => {
+    // given: the production Winky incident — one user gesture surfaced as
+    // two `message` events with different `ts` values but the same
+    // client_msg_id. This is exactly the case the channel_ts ring cannot
+    // catch and the client_msg_id ring exists for.
+    const dedupe = createSlackDedupe()
+    dedupe.mark({ channel: 'C0CHANNEL', ts: '1778050049.237279', client_msg_id: 'cmid-abc' })
+    expect(dedupe.check({ channel: 'C0CHANNEL', ts: '1778050028.175299', client_msg_id: 'cmid-abc' })).toBe(
+      'client_msg_id',
+    )
+  })
+
+  test('client_msg_id takes precedence over channel_ts when both rings would match', () => {
+    const dedupe = createSlackDedupe()
+    const event = { channel: 'C0CHANNEL', ts: '1700000000.000100', client_msg_id: 'cmid-abc' }
+    dedupe.mark(event)
+    expect(dedupe.check(event)).toBe('client_msg_id')
+  })
+
+  test('empty client_msg_id is treated as absent (falls through to channel_ts)', () => {
+    const dedupe = createSlackDedupe()
+    dedupe.mark({ channel: 'C0CHANNEL', ts: '1700000000.000100', client_msg_id: '' })
+    expect(dedupe.check({ channel: 'C0CHANNEL', ts: '1700000000.000100', client_msg_id: '' })).toBe('channel_ts')
+    expect(dedupe.check({ channel: 'C0CHANNEL', ts: '1700000000.000200', client_msg_id: '' })).toBeNull()
+  })
+
+  test('mark is idempotent — re-marking the same event does not displace older entries', () => {
+    const dedupe = createSlackDedupe(2)
+    const e1 = { channel: 'C0', ts: 't1', client_msg_id: 'cmid-1' }
+    const e2 = { channel: 'C0', ts: 't2', client_msg_id: 'cmid-2' }
+    dedupe.mark(e1)
+    dedupe.mark(e1)
+    dedupe.mark(e2)
+    expect(dedupe.check(e1)).toBe('client_msg_id')
+    expect(dedupe.check(e2)).toBe('client_msg_id')
+  })
+
+  test('ring evicts oldest entries past capacity, on each ring independently', () => {
+    // given: capacity 2 on each ring
+    const dedupe = createSlackDedupe(2)
+    dedupe.mark({ channel: 'C0', ts: 't1', client_msg_id: 'cmid-1' })
+    dedupe.mark({ channel: 'C0', ts: 't2', client_msg_id: 'cmid-2' })
+    // when: a third unique event evicts t1/cmid-1
+    dedupe.mark({ channel: 'C0', ts: 't3', client_msg_id: 'cmid-3' })
+    // then: the evicted entry is no longer detected as a duplicate
+    expect(dedupe.check({ channel: 'C0', ts: 't1', client_msg_id: 'cmid-1' })).toBeNull()
+    expect(dedupe.check({ channel: 'C0', ts: 't2', client_msg_id: 'cmid-2' })).toBe('client_msg_id')
+    expect(dedupe.check({ channel: 'C0', ts: 't3', client_msg_id: 'cmid-3' })).toBe('client_msg_id')
+  })
+
+  test('default capacity matches the published constant', () => {
+    expect(SLACK_DEDUPE_CAPACITY).toBe(256)
+  })
+})

--- a/src/channels/adapters/slack-bot-dedupe.ts
+++ b/src/channels/adapters/slack-bot-dedupe.ts
@@ -1,0 +1,51 @@
+import type { SlackSocketMessageEvent } from './agent-messenger-slack-shim'
+
+export const SLACK_DEDUPE_CAPACITY = 256
+
+export type SlackDedupeMatch = 'client_msg_id' | 'channel_ts'
+
+export type SlackDedupeKeys = {
+  channelTs: string
+  clientMsgId: string | null
+}
+
+export type SlackDedupe = {
+  check: (event: Pick<SlackSocketMessageEvent, 'channel' | 'ts' | 'client_msg_id'>) => SlackDedupeMatch | null
+  mark: (event: Pick<SlackSocketMessageEvent, 'channel' | 'ts' | 'client_msg_id'>) => void
+}
+
+// Two parallel insertion-ordered Sets. `client_msg_id` is the primary key
+// because it is stable across Slack-side resends of the same user gesture
+// (observed in the wild: a single Slack mention surfaced as two `message`
+// events ~21s apart with different `ts` values, identical text, and — per
+// Slack's API contract — identical `client_msg_id`). `channel:ts` is the
+// fallback because it is the only key available for events Slack does not
+// stamp with `client_msg_id` (bot messages, system messages, and historically
+// `app_mention` envelopes).
+export function createSlackDedupe(capacity: number = SLACK_DEDUPE_CAPACITY): SlackDedupe {
+  const tsRing = new Set<string>()
+  const clientMsgIdRing = new Set<string>()
+
+  const remember = (ring: Set<string>, key: string): void => {
+    if (ring.has(key)) return
+    if (ring.size >= capacity) {
+      const oldest = ring.values().next().value
+      if (oldest !== undefined) ring.delete(oldest)
+    }
+    ring.add(key)
+  }
+
+  return {
+    check: (event) => {
+      const cmid = event.client_msg_id
+      if (cmid !== undefined && cmid !== '' && clientMsgIdRing.has(cmid)) return 'client_msg_id'
+      if (tsRing.has(`${event.channel}:${event.ts}`)) return 'channel_ts'
+      return null
+    },
+    mark: (event) => {
+      remember(tsRing, `${event.channel}:${event.ts}`)
+      const cmid = event.client_msg_id
+      if (cmid !== undefined && cmid !== '') remember(clientMsgIdRing, cmid)
+    },
+  }
+}

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -29,14 +29,8 @@ import {
 import { createSlackAuthorResolver } from './slack-bot-author-resolver'
 import { createSlackChannelResolver } from './slack-bot-channel-resolver'
 import { classifyInbound, type InboundDropReason } from './slack-bot-classify'
+import { createSlackDedupe } from './slack-bot-dedupe'
 import { slackTsToMillis } from './slack-bot-time'
-
-// Bound on the dedupe ring buffer. Slack's Events API may deliver the same
-// channel mention twice — once as `message` (when the bot has channel
-// history scope and is a member) and once as `app_mention` — and the two
-// envelopes share the same `ts`. The buffer only needs to cover the gap
-// between the two deliveries; a few hundred is generous.
-const SEEN_TS_CAPACITY = 256
 
 // Resolvers fall back to the raw id on failure, so a name equal to the id
 // means resolution failed; we render the bare id rather than `id(id)`. The
@@ -62,6 +56,7 @@ export function promoteAppMentionToMessage(event: SlackSocketAppMentionEvent): S
     ts: event.ts,
     ...(event.thread_ts !== undefined ? { thread_ts: event.thread_ts } : {}),
     ...(event.event_ts !== undefined ? { event_ts: event.event_ts } : {}),
+    ...(event.client_msg_id !== undefined ? { client_msg_id: event.client_msg_id } : {}),
   }
 }
 
@@ -555,18 +550,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
     formatChannelTag,
   })
 
-  // Bounded set of "channel:ts" keys we've already routed, used to dedupe
-  // the message/app_mention double-delivery. Insertion-ordered Set lets us
-  // evict the oldest entry when we hit the cap.
-  const seenTs = new Set<string>()
-  const markSeen = (key: string): void => {
-    if (seenTs.has(key)) return
-    if (seenTs.size >= SEEN_TS_CAPACITY) {
-      const oldest = seenTs.values().next().value
-      if (oldest !== undefined) seenTs.delete(oldest)
-    }
-    seenTs.add(key)
-  }
+  const dedupe = createSlackDedupe()
 
   const handleMessageEvent = async (
     event: SlackSocketMessageEvent,
@@ -575,7 +559,6 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
     inflightInbounds++
     try {
       const text = event.text ?? ''
-      const dedupeKey = `${event.channel}:${event.ts}`
       const userId = event.user ?? 'unknown'
       const inboundWorkspace = event.channel_type === 'im' ? '@dm' : (teamId ?? 'unknown')
       const [resolvedUserName, inboundTag] = await Promise.all([
@@ -591,8 +574,11 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
         return
       }
 
-      if (seenTs.has(dedupeKey)) {
-        logger.info(`[slack-bot] dropped ts=${event.ts} reason=duplicate_delivery (source=${source})`)
+      const dedupeMatch = dedupe.check(event)
+      if (dedupeMatch !== null) {
+        logger.info(
+          `[slack-bot] dropped ts=${event.ts} reason=duplicate_delivery (source=${source}, matched=${dedupeMatch})`,
+        )
         return
       }
 
@@ -602,7 +588,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
         return
       }
 
-      markSeen(dedupeKey)
+      dedupe.mark(event)
       const enriched = { ...verdict.payload, authorName: resolvedUserName }
       const routedTag = await formatChannelTag(enriched.workspace, enriched.chat)
       logger.info(


### PR DESCRIPTION
## Summary

The existing `channel:ts` dedup ring collapsed the standard Slack double-delivery (one `message` + one `app_mention` event sharing the same `ts`), but not a production failure mode we hit: Slack's Events API surfaced a single user gesture as two `message` events with **different `ts` values** — one arriving ~21 s after the other, the later one's `ts` actually predating the earlier. The `seenTs` ring, keyed on `${channel}:${ts}`, cannot collapse them because the keys differ.

Slack's `client_msg_id` is a stable, client-generated UUID that the SDK reuses across network retries of the same user action. This PR adds a parallel dedupe ring keyed by `client_msg_id`, checked first when present. The `channel:ts` ring is preserved verbatim as the fallback for events Slack does not stamp with `client_msg_id` (bot messages, system events, app_mention envelopes).

## Background: the failure mode

A bot replied twice in a thread to a single user mention. Reconstruction from `docker logs`:

```
T+0.000s — slack delivered message ts=A (user mention) → ROUTED
T+0.000s — slack delivered app_mention dup, dedup'd by seenTs
T+20.6s — agent sent first reply
T+38.9s — slack delivered message ts=B ← PHANTOM (different ts, same gesture)
T+38.9s — slack delivered app_mention dup, dedup'd
T+42.7s — agent prompted again with the phantom
T+47.8s — recovery posted the agent's "I already answered" prose to Slack
```

The phantom's `ts` (B) was numerically earlier than the legit one (A), and lookup of B against the workspace returns "Message not found" — the user's Slack client retried the send at the transport layer with a fresh `ts` while Slack's storage already held the original. `client_msg_id` is stable across both events and would have collapsed them.

## Changes

### `src/channels/adapters/agent-messenger-slack-shim.ts`

Adds `client_msg_id?: string` to both `SlackSocketMessageEvent` and `SlackSocketAppMentionEvent`. The field is modeled explicitly (rather than being accessed off `unknown`) so typo-safety applies and grep-ability is preserved. WHY-comments anchor that `client_msg_id` is a client-generated UUID stable across retries — distinct from the server-assigned `ts`.

### `src/channels/adapters/slack-bot-dedupe.ts` _(new)_

Extracts the dedupe primitive into a small, testable module. `createSlackDedupe()` returns a single `{ check, mark }` interface backed by two parallel LRU ring buffers:

- **Primary ring** — keyed by `client_msg_id`. Checked first when the field is present and non-empty.
- **Fallback ring** — keyed by `${channel}:${ts}`. Checked when `client_msg_id` is absent or empty.

`check()` returns `'client_msg_id' | 'channel_ts' | null` so the drop-log line records which ring matched, which is forensically useful for distinguishing normal double-delivery dedup from retry-collapse dedup. Capacity per ring is `SLACK_DEDUPE_CAPACITY = 256` — same as the prior `SEEN_TS_CAPACITY` constant.

### `src/channels/adapters/slack-bot.ts`

Replaces the inlined `seenTs` Set + `markSeen()` helper with `createSlackDedupe()`. The "dropped-as-duplicate" log entry now records `matched=client_msg_id` or `matched=channel_ts`. `promoteAppMentionToMessage` propagates `client_msg_id` if Slack ever populates it on app_mention envelopes (currently it doesn't, but future-proofed at zero cost).

### `src/channels/adapters/slack-bot-dedupe.test.ts` _(new)_

9 unit tests:

- First-sighting on each axis passes through.
- Redelivery on `client_msg_id` alone is caught (even if `channel:ts` differs — the regression case for the failure mode above).
- Redelivery on `channel:ts` alone is caught.
- Different channels don't collide (`channel:ts` keys are namespaced).
- LRU eviction per ring: oldest entry rolls off at capacity; the dropped entry is admitted again.
- `mark()` is idempotent (double-marking doesn't break anything).
- Empty-string `client_msg_id` is treated as absent and falls through to the `channel:ts` ring.

## Verification

- `bun run typecheck` → clean (`tsgo --noEmit`)
- `bun run lint` → 0 warnings, 0 errors (oxlint, 257 files)
- `bun run format` → no diffs (oxfmt was already content)
- `bun test` → 1528 / 1528 pass (54 in the directly-touched files)

## Behavior preservation

This change can only **narrow** the duplicate set, never widen it. A message is considered a duplicate if **either** ring matches; it is routed iff **both** rings consider it new. The `channel:ts` ring is preserved exactly — existing dedup behavior is unchanged for all events that lack `client_msg_id`.

## Out of scope

The "recovery logic amplified the symptom" half of the incident analysis — `router.ts:validateChannelTurn` force-posting the agent's reflective text when no `channel_reply` tool call was emitted — is intentionally not in this PR. That's a separate behavioral change with more design surface (how to express "model intentionally chose silence" without trampling on the recovery path for genuinely-misbehaving models). Filed as a follow-up.
