### PR TITLE
Bind TUI websocket publish to loopback

### DIFF
--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -84,7 +84,7 @@ function labelValue(runArgs: string[], key: string): string | undefined {
 }
 
 describe('planStart', () => {
-  test('produces a docker run command with name, port publish, env-file, and agent mount', async () => {
+  test('publishes the TUI websocket port on host loopback only', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     await writeFile(join(root, '.env'), 'FIREWORKS_API_KEY=fw_test\n')
@@ -97,7 +97,7 @@ describe('planStart', () => {
     expect(plan.runArgs).toContain('--name')
     expect(plan.runArgs).toContain(plan.containerName)
     expect(plan.runArgs).toContain('-p')
-    expect(plan.runArgs).toContain('8973:8973')
+    expect(plan.runArgs).toContain('127.0.0.1:8973:8973')
     expect(plan.runArgs).toContain('--env-file')
     expect(plan.runArgs).toContain(join(root, '.env'))
     expect(plan.runArgs).toContain(`${root}:/agent`)
@@ -1095,16 +1095,16 @@ describe('start (port allocation)', () => {
     // when
     const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort })
 
-    // then: docker run gets `-p <hostPort>:8973`, NOT `-p 8973:8973`
+    // then: docker run gets `-p 127.0.0.1:<hostPort>:8973`, NOT `-p 8973:8973`
     expect(result.ok).toBe(true)
     const runCall = calls.find((c) => c.args[0] === 'run')
     expect(runCall).toBeDefined()
-    expect(runCall!.args).toContain('51234:8973')
+    expect(runCall!.args).toContain('127.0.0.1:51234:8973')
     expect(runCall!.args).not.toContain('51234:51234')
     if (result.ok) expect(result.hostPort).toBe(51234)
   })
 
-  test('still uses 8973:8973 mapping when the preferred host port is free (default case)', async () => {
+  test('still maps host 8973 to container 8973 when the preferred host port is free', async () => {
     // given: 8973 is free, allocator returns the preferred port unchanged
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
@@ -1116,7 +1116,7 @@ describe('start (port allocation)', () => {
     // then
     expect(result.ok).toBe(true)
     const runCall = calls.find((c) => c.args[0] === 'run')
-    expect(runCall!.args).toContain('8973:8973')
+    expect(runCall!.args).toContain('127.0.0.1:8973:8973')
     if (result.ok) expect(result.hostPort).toBe(8973)
   })
 
@@ -1156,8 +1156,8 @@ describe('start (port allocation)', () => {
     expect(runAttempts).toBe(2)
     const runCalls = calls.filter((c) => c.args[0] === 'run')
     expect(runCalls).toHaveLength(2)
-    expect(runCalls[0]!.args).toContain('8973:8973')
-    expect(runCalls[1]!.args).toContain('49160:8973')
+    expect(runCalls[0]!.args).toContain('127.0.0.1:8973:8973')
+    expect(runCalls[1]!.args).toContain('127.0.0.1:49160:8973')
     if (result.ok) expect(result.hostPort).toBe(49160)
   })
 
@@ -1191,7 +1191,7 @@ describe('planStart port mapping', () => {
     const plan = await planStart({ cwd: root, hostPort: 49160, imageExists: true })
 
     expect(plan.runArgs).toContain('-p')
-    expect(plan.runArgs).toContain('49160:8973')
+    expect(plan.runArgs).toContain('127.0.0.1:49160:8973')
     expect(plan.hostPort).toBe(49160)
   })
 })

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -214,7 +214,7 @@ export async function planStart({
   const devSourcePath = await detectDevSource(cwd)
   const mounts = await loadMounts(cwd)
 
-  const runArgs = ['run', '-d', '--name', containerName, '--rm', '-p', `${hostPort}:${CONTAINER_PORT}`]
+  const runArgs = ['run', '-d', '--name', containerName, '--rm', '-p', `127.0.0.1:${hostPort}:${CONTAINER_PORT}`]
 
   if (hostdControl) {
     runArgs.push('--add-host', HOST_GATEWAY_ALIAS)


### PR DESCRIPTION
## Summary
- Restrict the Docker-published TypeClaw TUI websocket port to host loopback with `127.0.0.1:<hostPort>:8973`.
- Update container start tests to assert loopback-only publishing for default, allocated, retry, and arbitrary host-port mappings.

## Verification
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run test`