### PR TITLE
Clear Slack typing indicator after every send

### DIFF
--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -13,6 +13,7 @@ import {
   createOutboundCallback,
   createSlackHistoryCallback,
   createSlackMembershipResolver,
+  createSlackTypingTracker,
   createTypingCallback,
   promoteAppMentionToMessage,
   SLACK_HISTORY_LIMIT_MAX,
@@ -46,27 +47,31 @@ describe('slack-bot adapter (unit-level pure helpers)', () => {
 describe('slack-bot createTypingCallback', () => {
   type SetStatusCall = { channel: string; threadTs: string; status: string }
 
-  function makeFakeClient(behavior: 'ok' | 'reject' = 'ok'): {
-    client: { setAssistantStatus: (channel: string, threadTs: string, status: string) => Promise<void> }
+  function makeFakeTracker(behavior: 'ok' | 'reject' = 'ok'): {
+    tracker: {
+      setStatus: (chat: string, threadTs: string, status: string) => Promise<void>
+      clearAfterSend: () => Promise<void>
+    }
     calls: SetStatusCall[]
   } {
     const calls: SetStatusCall[] = []
     return {
       calls,
-      client: {
-        setAssistantStatus: async (channel, threadTs, status) => {
+      tracker: {
+        setStatus: async (channel, threadTs, status) => {
           calls.push({ channel, threadTs, status })
           if (behavior === 'reject') throw new Error('channel_not_found')
         },
+        clearAfterSend: async () => {},
       },
     }
   }
 
-  test('calls setAssistantStatus with chat + thread when target is in a thread', async () => {
+  test('calls tracker.setStatus with chat + thread when target is in a thread', async () => {
     // given
-    const { client, calls } = makeFakeClient()
+    const { tracker, calls } = makeFakeTracker()
     const cb = createTypingCallback({
-      client,
+      typingTracker: tracker,
       configRef: () => ({
         allow: ['*'],
         engagement: { trigger: ['mention'], stickiness: 'off' },
@@ -83,10 +88,10 @@ describe('slack-bot createTypingCallback', () => {
 
   test('is a no-op (logs info, no API call) for top-level chats without a thread', async () => {
     // given
-    const { client, calls } = makeFakeClient()
+    const { tracker, calls } = makeFakeTracker()
     const infos: string[] = []
     const cb = createTypingCallback({
-      client,
+      typingTracker: tracker,
       configRef: () => ({
         allow: ['*'],
         engagement: { trigger: ['mention'], stickiness: 'off' },
@@ -104,10 +109,19 @@ describe('slack-bot createTypingCallback', () => {
 
   test('warns (does not throw) when Slack rejects the API call', async () => {
     // given
-    const { client, calls } = makeFakeClient('reject')
+    const calls: SetStatusCall[] = []
     const warns: string[] = []
+    const tracker = createSlackTypingTracker({
+      client: {
+        setAssistantStatus: async (channel, threadTs, status) => {
+          calls.push({ channel, threadTs, status })
+          throw new Error('channel_not_found')
+        },
+      },
+      logger: { info: () => {}, warn: (m) => warns.push(m), error: () => {} },
+    })
     const cb = createTypingCallback({
-      client,
+      typingTracker: tracker,
       configRef: () => ({
         allow: ['*'],
         engagement: { trigger: ['mention'], stickiness: 'off' },
@@ -125,11 +139,11 @@ describe('slack-bot createTypingCallback', () => {
 
   test('skips disallowed channels silently (no API call, no log)', async () => {
     // given
-    const { client, calls } = makeFakeClient()
+    const { tracker, calls } = makeFakeTracker()
     const infos: string[] = []
     const warns: string[] = []
     const cb = createTypingCallback({
-      client,
+      typingTracker: tracker,
       configRef: () => ({
         allow: ['team:T0OTHER'],
         engagement: { trigger: ['mention'], stickiness: 'off' },
@@ -148,10 +162,10 @@ describe('slack-bot createTypingCallback', () => {
 
   test('rejects non-slack adapter without API call or logging', async () => {
     // given
-    const { client, calls } = makeFakeClient()
+    const { tracker, calls } = makeFakeTracker()
     const infos: string[] = []
     const cb = createTypingCallback({
-      client,
+      typingTracker: tracker,
       configRef: () => ({
         allow: ['*'],
         engagement: { trigger: ['mention'], stickiness: 'off' },
@@ -165,6 +179,126 @@ describe('slack-bot createTypingCallback', () => {
     // then
     expect(calls).toHaveLength(0)
     expect(infos).toHaveLength(0)
+  })
+})
+
+describe('createSlackTypingTracker', () => {
+  type SetStatusCall = { channel: string; threadTs: string; status: string }
+
+  function makeDeferredClient(): {
+    client: { setAssistantStatus: (channel: string, threadTs: string, status: string) => Promise<void> }
+    calls: SetStatusCall[]
+    pending: Array<{ resolve: () => void; reject: (err: Error) => void }>
+    settledOrder: string[]
+  } {
+    const calls: SetStatusCall[] = []
+    const pending: Array<{ resolve: () => void; reject: (err: Error) => void }> = []
+    const settledOrder: string[] = []
+    return {
+      calls,
+      pending,
+      settledOrder,
+      client: {
+        setAssistantStatus: (channel, threadTs, status) => {
+          calls.push({ channel, threadTs, status })
+          const idx = calls.length - 1
+          return new Promise<void>((resolve, reject) => {
+            pending.push({
+              resolve: () => {
+                settledOrder.push(`${idx}:${status}`)
+                resolve()
+              },
+              reject,
+            })
+          })
+        },
+      },
+    }
+  }
+
+  // Flush all pending microtasks so chained `.then()` continuations run
+  // before the next assertion. The tracker queues calls via promise
+  // chaining, so the first client call is reached on the next microtask
+  // tick rather than synchronously.
+  async function flushMicrotasks(): Promise<void> {
+    for (let i = 0; i < 5; i++) await Promise.resolve()
+  }
+
+  test('serializes calls per (chat, thread) so an explicit clear lands AFTER an in-flight typing call', async () => {
+    // given
+    const { client, pending, settledOrder } = makeDeferredClient()
+    const tracker = createSlackTypingTracker({
+      client,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    // when
+    const typingPromise = tracker.setStatus('C0', 'T0', 'is typing...')
+    const clearPromise = tracker.clearAfterSend('C0', 'T0')
+    await flushMicrotasks()
+    expect(pending).toHaveLength(1)
+    pending[0]!.resolve()
+    await typingPromise
+    await flushMicrotasks()
+    expect(pending).toHaveLength(2)
+    pending[1]!.resolve()
+    await clearPromise
+    // then
+    expect(settledOrder).toEqual(['0:is typing...', '1:'])
+  })
+
+  test('does not block calls for a different (chat, thread) pair', async () => {
+    // given
+    const { client, pending } = makeDeferredClient()
+    const tracker = createSlackTypingTracker({
+      client,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    const a = tracker.setStatus('C0', 'T0', 'is typing...')
+    // when
+    const b = tracker.setStatus('C0', 'T1', 'is typing...')
+    const c = tracker.setStatus('C1', 'T0', 'is typing...')
+    await flushMicrotasks()
+    // then
+    expect(pending).toHaveLength(3)
+    pending[0]!.resolve()
+    pending[1]!.resolve()
+    pending[2]!.resolve()
+    await Promise.all([a, b, c])
+  })
+
+  test('clearAfterSend with no thread is a no-op (top-level chats have no typing indicator)', async () => {
+    const { client, calls } = makeDeferredClient()
+    const tracker = createSlackTypingTracker({
+      client,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    await tracker.clearAfterSend('C0', null)
+    await tracker.clearAfterSend('C0', undefined)
+    await tracker.clearAfterSend('C0', '')
+    expect(calls).toHaveLength(0)
+  })
+
+  test('a failing typing call does not poison the queue for the next call', async () => {
+    // given
+    const { client, pending } = makeDeferredClient()
+    const warns: string[] = []
+    const tracker = createSlackTypingTracker({
+      client,
+      logger: { info: () => {}, warn: (m) => warns.push(m), error: () => {} },
+    })
+    const first = tracker.setStatus('C0', 'T0', 'is typing...')
+    const second = tracker.clearAfterSend('C0', 'T0')
+    await flushMicrotasks()
+    expect(pending).toHaveLength(1)
+    pending[0]!.reject(new Error('channel_not_found'))
+    await first
+    await flushMicrotasks()
+    // when
+    expect(pending).toHaveLength(2)
+    pending[1]!.resolve()
+    await second
+    // then
+    expect(warns.some((m) => m.includes('channel_not_found'))).toBe(true)
   })
 })
 
@@ -1036,5 +1170,97 @@ describe('slack-bot createOutboundCallback', () => {
     expect(posts).toHaveLength(0)
     expect(uploads).toHaveLength(0)
     expect(readCalls).toBe(0)
+  })
+
+  test('threaded postMessage triggers typingTracker.clearAfterSend so the indicator does not stay stuck', async () => {
+    // given
+    const { client, posts } = makeFakeClient()
+    const clearCalls: Array<{ chat: string; thread: string | null | undefined }> = []
+    const cb = createOutboundCallback({
+      client,
+      configRef: permissive,
+      logger: silentLogger(),
+      formatChannelTag: tag,
+      readFile: fakeRead,
+      typingTracker: {
+        clearAfterSend: async (chat, thread) => {
+          clearCalls.push({ chat, thread })
+        },
+      },
+    })
+    // when
+    const result = await cb(makeMsg({ text: 'hello', thread: '1700.000100' }))
+    // then
+    expect(result.ok).toBe(true)
+    expect(posts).toHaveLength(1)
+    expect(clearCalls).toEqual([{ chat: 'C0', thread: '1700.000100' }])
+  })
+
+  test('top-level postMessage still calls clearAfterSend (tracker decides the no-op)', async () => {
+    const { client } = makeFakeClient()
+    const clearCalls: Array<{ chat: string; thread: string | null | undefined }> = []
+    const cb = createOutboundCallback({
+      client,
+      configRef: permissive,
+      logger: silentLogger(),
+      formatChannelTag: tag,
+      readFile: fakeRead,
+      typingTracker: {
+        clearAfterSend: async (chat, thread) => {
+          clearCalls.push({ chat, thread })
+        },
+      },
+    })
+    await cb(makeMsg({ text: 'hello' }))
+    expect(clearCalls).toEqual([{ chat: 'C0', thread: undefined }])
+  })
+
+  test('threaded uploadFile triggers clearAfterSend after the LAST attachment', async () => {
+    // given
+    const { client, uploads } = makeFakeClient()
+    const clearCalls: Array<{ chat: string; thread: string | null | undefined }> = []
+    const cb = createOutboundCallback({
+      client,
+      configRef: permissive,
+      logger: silentLogger(),
+      formatChannelTag: tag,
+      readFile: fakeRead,
+      typingTracker: {
+        clearAfterSend: async (chat, thread) => {
+          clearCalls.push({ chat, thread })
+        },
+      },
+    })
+    // when
+    await cb(
+      makeMsg({
+        text: 'caption',
+        thread: '1700.000100',
+        attachments: [{ path: '/agent/a.png' }, { path: '/agent/b.pdf' }],
+      }),
+    )
+    // then
+    expect(uploads).toHaveLength(2)
+    expect(clearCalls).toEqual([{ chat: 'C0', thread: '1700.000100' }])
+  })
+
+  test('failed postMessage does not call clearAfterSend (no message was actually sent)', async () => {
+    const { client } = makeFakeClient({ postMessage: 'reject' })
+    const clearCalls: Array<unknown> = []
+    const cb = createOutboundCallback({
+      client,
+      configRef: permissive,
+      logger: silentLogger(),
+      formatChannelTag: tag,
+      readFile: fakeRead,
+      typingTracker: {
+        clearAfterSend: async () => {
+          clearCalls.push({})
+        },
+      },
+    })
+    const result = await cb(makeMsg({ text: 'hello', thread: '1700.000100' }))
+    expect(result.ok).toBe(false)
+    expect(clearCalls).toHaveLength(0)
   })
 })

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -91,21 +91,63 @@ export type SlackBotAdapter = {
 // `thread_ts`. The classic `user_typing` is RTM-only and rejects bot
 // tokens, so there is nothing to send for top-level (non-threaded) chats —
 // we log and bail in that case. Slack auto-clears the status when the bot
-// posts its reply, so we only set; we never explicitly clear.
+// posts its reply (per the assistant.threads.setStatus docs), but the
+// router heartbeat (~every 8s) and the outbound postMessage can race: an
+// in-flight setStatus("is typing...") that lands AFTER postMessage will
+// re-set the indicator, and Slack's server-side timeout won't clear it
+// for ~2 minutes. The fix is per-thread serialization (see
+// `createSlackTypingTracker`) plus an explicit empty-string setStatus
+// queued by the outbound callback after every successful send.
 //
-// The router fires this on a heartbeat (~every few seconds while
-// debouncing/generating). Slack rejects calls in non-Assistant channels
-// with `channel_not_found` / `not_in_channel`-style errors; we surface
-// those as a single warn line per heartbeat (matching the Discord
-// adapter's non-2xx handling) rather than escalating to error, because
-// the bot may simply be deployed in a regular channel.
-export function createTypingCallback(deps: {
+// Slack rejects calls in non-Assistant channels with `channel_not_found` /
+// `not_in_channel`-style errors; we surface those as a single warn line
+// per heartbeat (matching the Discord adapter's non-2xx handling) rather
+// than escalating to error, because the bot may simply be deployed in a
+// regular channel.
+export type SlackTypingTracker = {
+  setStatus: (chat: string, threadTs: string, status: string) => Promise<void>
+  clearAfterSend: (chat: string, threadTs: string | null | undefined) => Promise<void>
+}
+
+export function createSlackTypingTracker(deps: {
   client: Pick<SlackBotClient, 'setAssistantStatus'>
+  logger: SlackBotAdapterLogger
+}): SlackTypingTracker {
+  const { client, logger } = deps
+  const queues = new Map<string, Promise<void>>()
+
+  const enqueue = (chat: string, threadTs: string, status: string): Promise<void> => {
+    const key = `${chat}\x00${threadTs}`
+    const prev = queues.get(key) ?? Promise.resolve()
+    const next = prev
+      .catch(() => {})
+      .then(() => client.setAssistantStatus(chat, threadTs, status))
+      .catch((err: unknown) => {
+        logger.warn(`[slack-bot] typing chat=${chat} thread=${threadTs} status="${status}" failed: ${describe(err)}`)
+      })
+    queues.set(key, next)
+    void next.finally(() => {
+      if (queues.get(key) === next) queues.delete(key)
+    })
+    return next
+  }
+
+  return {
+    setStatus: (chat, threadTs, status) => enqueue(chat, threadTs, status),
+    clearAfterSend: async (chat, threadTs) => {
+      if (threadTs === null || threadTs === undefined || threadTs === '') return
+      await enqueue(chat, threadTs, '')
+    },
+  }
+}
+
+export function createTypingCallback(deps: {
+  typingTracker: Pick<SlackTypingTracker, 'setStatus'>
   configRef: () => ChannelAdapterConfig
   logger: SlackBotAdapterLogger
   formatChannelTag?: (workspace: string, chat: string) => Promise<string>
 }): TypingCallback {
-  const { client, configRef, logger, formatChannelTag } = deps
+  const { typingTracker, configRef, logger, formatChannelTag } = deps
   return async (target: TypingTarget): Promise<void> => {
     if (target.adapter !== 'slack-bot') return
     const config = configRef()
@@ -117,11 +159,7 @@ export function createTypingCallback(deps: {
       logger.info(`[slack-bot] typing (no-op, top-level chat) ${tag}`)
       return
     }
-    try {
-      await client.setAssistantStatus(target.chat, target.thread, 'is typing...')
-    } catch (err) {
-      logger.warn(`[slack-bot] typing ${tag} failed: ${describe(err)}`)
-    }
+    await typingTracker.setStatus(target.chat, target.thread, 'is typing...')
   }
 }
 
@@ -440,8 +478,9 @@ export function createOutboundCallback(deps: {
   logger: SlackBotAdapterLogger
   formatChannelTag: (workspace: string, chat: string) => Promise<string>
   readFile?: (path: string) => Promise<Buffer>
+  typingTracker?: Pick<SlackTypingTracker, 'clearAfterSend'>
 }): OutboundCallback {
-  const { client, configRef, logger, formatChannelTag } = deps
+  const { client, configRef, logger, formatChannelTag, typingTracker } = deps
   const readFile = deps.readFile ?? readAttachmentBuffer
   return async (msg: OutboundMessage): Promise<SendResult> => {
     if (msg.adapter !== 'slack-bot') {
@@ -470,6 +509,7 @@ export function createOutboundCallback(deps: {
           msg.thread !== undefined && msg.thread !== null ? { thread_ts: msg.thread } : undefined,
         )
         logger.info(`[slack-bot] sent ts=${sent.ts} ${tag}`)
+        if (typingTracker) await typingTracker.clearAfterSend(msg.chat, msg.thread)
         return { ok: true }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
@@ -502,6 +542,7 @@ export function createOutboundCallback(deps: {
         return { ok: false, error: `uploadFile failed: ${message}` }
       }
     }
+    if (typingTracker) await typingTracker.clearAfterSend(msg.chat, msg.thread)
     return { ok: true }
   }
 }
@@ -528,7 +569,14 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
     return `${workspacePart} ${chatPart}`
   }
 
-  const typingCallback = createTypingCallback({ client, configRef: options.configRef, logger, formatChannelTag })
+  const typingTracker = createSlackTypingTracker({ client, logger })
+
+  const typingCallback = createTypingCallback({
+    typingTracker,
+    configRef: options.configRef,
+    logger,
+    formatChannelTag,
+  })
 
   const historyCallback = createSlackHistoryCallback({
     token: options.token,
@@ -548,6 +596,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
     configRef: options.configRef,
     logger,
     formatChannelTag,
+    typingTracker,
   })
 
   const dedupe = createSlackDedupe()


### PR DESCRIPTION
## Symptom

After the agent sends a message in a Slack thread, the \"is typing...\" indicator stays visible for ~2 minutes. Operators see a stuck indicator on a thread that is clearly idle.

## Root cause

The Slack adapter relied on Slack's documented auto-clear: \`assistant.threads.setStatus\` is cleared automatically when the bot posts a reply. But the router fires a typing heartbeat every 8s (\`TYPING_HEARTBEAT_MS\`), and \`setStatus\` and \`postMessage\` are independent HTTP calls that race over the network.

Sequence that triggers the bug:

1. \`drain\` loop fires the heartbeat → \`setStatus(\"is typing...\")\` is sent to Slack.
2. Agent finishes generating; \`router.send\` fires \`postMessage\`.
3. \`postMessage\` arrives at Slack → indicator is cleared.
4. The \`setStatus\` call from step 1 arrives → indicator is **re-set**.
5. Slack's server-side timeout (~2 min) is the only thing that finally clears it.

This is a known issue in [slackapi/bolt-js#2340](https://github.com/slackapi/bolt-js/issues/2340) — the recommended fix is to call \`setStatus(channel, threadTs, \"\")\` explicitly after the send.

## Fix

\`createSlackTypingTracker\` (new in \`src/channels/adapters/slack-bot.ts\`) is a per-\`(chat, thread)\` FIFO around \`setAssistantStatus\`. Both halves of the lifecycle now share one tracker:

- \`createTypingCallback\` calls \`tracker.setStatus(...)\` instead of the raw client → all heartbeat calls for a given thread are serialized.
- \`createOutboundCallback\` calls \`tracker.clearAfterSend(chat, thread)\` after every successful \`postMessage\`/\`uploadFile\` → an explicit empty-string \`setStatus\` is queued.

Because the tracker is FIFO per \`(chat, thread)\`, the explicit clear is guaranteed to land **after** any in-flight heartbeat call for the same thread, eliminating the race. Different threads are independent (no head-of-line blocking).

Top-level chats (no \`thread_ts\`) are still no-ops — Slack only supports the indicator in Assistant threads.

## Tests

New unit tests in \`src/channels/adapters/slack-bot.test.ts\`:

- **\`createSlackTypingTracker\`** (4 tests): FIFO ordering using a deferred-promise client, no head-of-line blocking across keys, no-op on missing thread, error in one call doesn't poison the queue.
- **\`createOutboundCallback\`** (4 tests): \`clearAfterSend\` fires after threaded \`postMessage\`, after top-level \`postMessage\`, after the **last** \`uploadFile\` in a multi-attachment send, and **never** after a failed \`postMessage\`.
- **\`createTypingCallback\`** existing tests rewired to use the tracker abstraction.

Mutation-tested:
- Removing \`if (typingTracker) await typingTracker.clearAfterSend(...)\` → 2 tests fail.
- Removing the FIFO chaining in the tracker → 2 tests fail.

## Verification

\`\`\`
bun run typecheck   # clean
bun run lint        # 0 warnings, 0 errors
bun run format      # clean
bun test            # 1567 pass, 0 fail
\`\`\`

## Out of scope

- Other adapters (Discord) are unaffected; their typing API has different semantics.
- The router's heartbeat cadence (\`TYPING_HEARTBEAT_MS = 8000\`) is unchanged.
- No public router/types changes.