### PR TITLE
Default memory dreaming schedule to every two hours

### DIFF
--- a/plugins/memory/README.md
+++ b/plugins/memory/README.md
@@ -11,17 +11,17 @@ This plugin is **auto-loaded** by every TypeClaw agent. There is no `plugins[]` 
   "memory": {
     "idleMs": 10000,
     "bufferBytes": 100000,
-    "dreaming": { "schedule": "0 4 * * *" }
+    "dreaming": { "schedule": "0 */2 * * *" }
   }
 }
 ```
 
-| Field                      | Default            | Effect                                                                                                                                                                                    |
-| -------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `memory.idleMs`            | `10000`            | Debounce window before `memory-logger` spawns after a prompt completes. Minimum `1000`.                                                                                                   |
-| `memory.bufferBytes`       | `100000`           | Size-based ceiling: spawns `memory-logger` when the transcript grows by this many bytes since the last run, even during continuous activity. `0` disables. Minimum `10000` when non-zero. |
-| `memory.dreaming`          | `{}` (cron job on) | Dreaming cron job is always registered. Override `schedule` to change when it fires.                                                                                                      |
-| `memory.dreaming.schedule` | `"0 4 * * *"`      | Five-field cron expression. Applies whether `memory.dreaming` is omitted, empty, or explicitly set. Second-level schedules are rejected to avoid noisy no-op dreaming loops.              |
+| Field                      | Default            | Effect                                                                                                                                                                                                                                                                                                                                                                                    |
+| -------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `memory.idleMs`            | `10000`            | Debounce window before `memory-logger` spawns after a prompt completes. Minimum `1000`.                                                                                                                                                                                                                                                                                                   |
+| `memory.bufferBytes`       | `100000`           | Size-based ceiling: spawns `memory-logger` when the transcript grows by this many bytes since the last run, even during continuous activity. `0` disables. Minimum `10000` when non-zero.                                                                                                                                                                                                 |
+| `memory.dreaming`          | `{}` (cron job on) | Dreaming cron job is always registered. Override `schedule` to change when it fires.                                                                                                                                                                                                                                                                                                      |
+| `memory.dreaming.schedule` | `"0 */2 * * *"`    | Five-field cron expression. Applies whether `memory.dreaming` is omitted, empty, or explicitly set. Second-level schedules are rejected to avoid noisy no-op dreaming loops. Default fires every two hours so the daily backlog stays bounded even when the container is offline at the legacy 4 AM tick. Idle ticks short-circuit before any LLM call when no undreamed fragments exist. |
 
 All fields are **restart-required** — the plugin reads them once at boot.
 

--- a/plugins/memory/index.test.ts
+++ b/plugins/memory/index.test.ts
@@ -92,15 +92,15 @@ describe('memory plugin shape', () => {
 
   test('registers the dreaming cron job with the default schedule when dreaming is not configured', async () => {
     const { exports } = await bootMemoryPlugin(agentDir, { idleMs: 5000 })
-    expect(exports.cronJobs?.dreaming?.schedule).toBe('0 4 * * *')
+    expect(exports.cronJobs?.dreaming?.schedule).toBe('0 */2 * * *')
   })
 
   test('default config injects an idleMs of 10 seconds and a default dreaming schedule', async () => {
     const { exports: noDream } = await bootMemoryPlugin(agentDir, {})
-    expect(noDream.cronJobs?.dreaming?.schedule).toBe('0 4 * * *')
+    expect(noDream.cronJobs?.dreaming?.schedule).toBe('0 */2 * * *')
 
     const { exports: withDream } = await bootMemoryPlugin(agentDir, { dreaming: {} })
-    expect(withDream.cronJobs?.dreaming?.schedule).toBe('0 4 * * *')
+    expect(withDream.cronJobs?.dreaming?.schedule).toBe('0 */2 * * *')
   })
 
   test('rejects invalid cron expression in dreaming.schedule', async () => {

--- a/plugins/memory/index.ts
+++ b/plugins/memory/index.ts
@@ -13,7 +13,7 @@ import { createMemoryLoggerSubagent, type MemoryLoggerPayload } from './memory-l
 const DEFAULT_IDLE_MS = 10_000
 const DEFAULT_BUFFER_BYTES = 100_000
 const MIN_BUFFER_BYTES = 10_000
-const DEFAULT_DREAMING_SCHEDULE = '0 4 * * *'
+const DEFAULT_DREAMING_SCHEDULE = '0 */2 * * *'
 
 function isValidCronExpression(schedule: string): boolean {
   try {

--- a/src/skills/typeclaw-memory/SKILL.md
+++ b/src/skills/typeclaw-memory/SKILL.md
@@ -38,7 +38,7 @@ The Claim/Evidence/Implication structure is **required** and the bar is intentio
 
 ### Stage 2: dreaming (offline, scheduled)
 
-The dreaming subagent runs on cron, configured under `memory.dreaming.schedule` (default `"0 4 * * *"` — 4 AM in the agent's timezone). Multiple runs per day are fine. The cron job id is `__plugin_memory_dreaming` (you cannot list it via the user-facing cron tools — it is plugin-owned).
+The dreaming subagent runs on cron, configured under `memory.dreaming.schedule` (default `"0 */2 * * *"` — every two hours, on the hour, in the agent's timezone). Multiple runs per day are fine; idle ticks short-circuit before any LLM call when no undreamed fragments exist. The cron job id is `__plugin_memory_dreaming` (you cannot list it via the user-facing cron tools — it is plugin-owned).
 
 When dreaming fires, it reads:
 
@@ -116,7 +116,7 @@ You cannot remove a fragment cleanly. The right response depends on what X is:
 ## When the user asks "what did you dream?" / "when do you dream next?"
 
 1. **What you dreamed**: read the most recent `Dream` git commit on your agent folder (`git log --grep='^Dream' -1`) and show the diff against `MEMORY.md` if useful. The commit timestamp tells you when dreaming last ran. If the answer is "no `Dream` commits yet", say that — `MEMORY.md` may exist but be the auto-created empty file from the first dreaming attempt.
-2. **When you dream next**: read `memory.dreaming.schedule` from `typeclaw.json` (default `"0 4 * * *"`). Translate the cron expression to a wall-clock time in the agent's `TZ`. If `memory.dreaming` is omitted from the config, the cron job is **not registered** — dreaming will not fire on a schedule, only if the user explicitly publishes a `new-session` for the `dreaming` subagent (rare). Tell the user honestly if the schedule is missing.
+2. **When you dream next**: read `memory.dreaming.schedule` from `typeclaw.json` (default `"0 */2 * * *"`). Translate the cron expression to a wall-clock time in the agent's `TZ`. If `memory.dreaming` is omitted from the config, the cron job is **not registered** — dreaming will not fire on a schedule, only if the user explicitly publishes a `new-session` for the `dreaming` subagent (rare). Tell the user honestly if the schedule is missing.
 
 ## When the user asks "what's a daily stream?" / "where is your memory stored?"
 
@@ -139,7 +139,7 @@ These are the only two configurable knobs. They live in the `memory` block of `t
 {
   "memory": {
     "idleMs": 10000,
-    "dreaming": { "schedule": "0 4 * * *" }
+    "dreaming": { "schedule": "0 */2 * * *" }
   }
 }
 ```
@@ -148,7 +148,7 @@ These are the only two configurable knobs. They live in the `memory` block of `t
 | -------------------------- | --------------------- | ----------------------------------------------------------------------------------- | ----------------- |
 | `memory.idleMs`            | `10000` (min `1000`)  | Debounce window before `memory-logger` spawns after a prompt completes.             | Restart-required. |
 | `memory.dreaming`          | omitted → no cron job | When present, registers the dreaming cron job.                                      | Restart-required. |
-| `memory.dreaming.schedule` | `"0 4 * * *"`         | Cron expression. Parsed via `cron-parser`; an invalid expression fails config load. | Restart-required. |
+| `memory.dreaming.schedule` | `"0 */2 * * *"`       | Cron expression. Parsed via `cron-parser`; an invalid expression fails config load. | Restart-required. |
 
 Both fields are restart-required because plugin config is read once at boot. After editing them, tell the user: "Edited `memory.<field>` — restart-required. Run `typeclaw restart` (host stage) to pick up the change." The bundled plugin's config schema is merged into `typeclaw.schema.json`, so editor autocomplete will validate these fields, but a `reload` will not re-instantiate the plugin.
 


### PR DESCRIPTION
## Summary

The `0 4 * * *` default fired only once a day, at 4 AM local time. Any agent whose container was not running at that wall-clock moment never dreamed — daily stream files kept growing, and `loadMemory` stuffed every undreamed tail into the `# Memory` section of every prompt. Switching the default to `0 */2 * * *` bounds the consolidation backlog to ~2 hours of container uptime instead of \"next 4 AM the container happens to be alive\".

## Root cause / diagnosis

Diagnosed live on the `winky` agent: `.dreaming-state.json` showed last consolidation on 2026-05-03 (3 days stale). `memory/2026-05-04.md` was 16.6 KB and `memory/2026-05-06.md` was 45.7 KB (687 lines, 49 fragments) — both fully injected into every turn. `MEMORY.md` was only 62 lines because consolidation had never had a chance to compact them.

This was the dominant cause of the "memory got verbose after a few hours" pattern. Not the memory-logger being too aggressive, but dreaming simply never firing.

## Why every two hours

- **Bounded freshness.** Backlog gets consolidated within 2 h of the container being up; worst-case staleness drops from "next 4 AM the container happens to be alive" to ~2 h.
- **Idle ticks are cheap.** `dreaming.handler` short-circuits at `plugins/memory/dreaming.ts:434–437` when `collectStreamSnapshots` returns zero undreamed days — no LLM call, no commit, just one `fs.stat` per stream file and a single `[dreaming] no undreamed fragments since last run; skipping` log line. 12 ticks/day with nothing pending is essentially free.
- **No tick-overlap thrashing.** Per-`agentDir` coalescing via `inFlightKey` (`plugins/memory/dreaming.ts:428`) prevents concurrent dream runs for the same agent.
- **Today's stream is never consumed anyway.** Dreaming only consolidates days strictly before the local date, so going more aggressive than 2 h adds no fresh-data value.

## Changes

| File | What changed |
|---|---|
| `plugins/memory/index.ts` | `DEFAULT_DREAMING_SCHEDULE = '0 */2 * * *'` |
| `plugins/memory/index.test.ts` | Three default-schedule assertions updated |
| `plugins/memory/README.md` | Default cell updated + extended description (oxfmt re-padded table) |
| `src/skills/typeclaw-memory/SKILL.md` | Four schedule references updated |

4 files changed, 15 insertions(+), 15 deletions(−).

## What does NOT change

- Existing agents that already pin `memory.dreaming.schedule` keep their value — the schema default only fills in when the field is absent.
- `memory.dreaming.schedule` remains restart-required, consistent with the rest of plugin config.
- Wire protocol, on-disk format, and watermark semantics are unchanged.
- Memory-logger verbosity, fragment format, and triggers are unchanged.

## Verification

```
bun run typecheck   # clean
bun run lint        # 0 warnings, 0 errors
bun run format:check  # clean (oxfmt re-padded README table)
bun test plugins/memory/  # 123 pass / 0 fail
```

## Migration

None required. `typeclaw restart` after upgrade picks up the new default for agents on the old one. Agents that pin the old `0 4 * * *` explicitly are unaffected.