### PR TITLE
Surface channel attachments to the agent and let it fetch them

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -341,7 +341,7 @@ describe('buildChannelTools', () => {
   const tuiOrigin: SessionOrigin = { kind: 'tui', sessionId: 'ses-tui-1' }
   const cronOrigin: SessionOrigin = { kind: 'cron', jobId: 'j1', jobKind: 'prompt' }
 
-  test('exposes channel_send, channel_reply, AND channel_history when origin is channel', () => {
+  test('exposes channel_send, channel_reply, channel_history, AND channel_fetch_attachment when origin is channel', () => {
     // given
     const router = makeRouter()
 
@@ -350,7 +350,7 @@ describe('buildChannelTools', () => {
 
     // then
     const names = tools.map((t) => t.name).sort()
-    expect(names).toEqual(['channel_history', 'channel_reply', 'channel_send'])
+    expect(names).toEqual(['channel_fetch_attachment', 'channel_history', 'channel_reply', 'channel_send'])
   })
 
   test('exposes only channel_send (no reply or history) when origin is non-channel', () => {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -27,6 +27,7 @@ import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
 import { renderSessionOrigin, type SessionOrigin } from './session-origin'
 import { DEFAULT_SYSTEM_PROMPT } from './system-prompt'
+import { createChannelFetchAttachmentTool } from './tools/channel-fetch-attachment'
 import { createChannelHistoryTool } from './tools/channel-history'
 import { createChannelReplyTool } from './tools/channel-reply'
 import { createChannelSendTool } from './tools/channel-send'
@@ -281,6 +282,12 @@ export function buildChannelTools(
     tools.push(createChannelReplyTool({ router: channelRouter, origin: channelOrigin }))
     tools.push(createChannelHistoryTool({ router: channelRouter, origin: channelOrigin }))
     tools.push(createChannelSendTool({ router: channelRouter, origin: channelOrigin }))
+    tools.push(
+      createChannelFetchAttachmentTool({
+        router: channelRouter,
+        origin: { adapter: origin.adapter },
+      }),
+    )
   } else {
     tools.push(createChannelSendTool({ router: channelRouter }))
   }

--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { createChannelRouter, type ChannelRouter } from '@/channels/router'
+import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
+import type { FetchAttachmentArgs, FetchAttachmentResult } from '@/channels/types'
+
+import { createChannelFetchAttachmentTool } from './channel-fetch-attachment'
+
+function emptyAdapterConfig(): ChannelAdapterConfig {
+  return {
+    allow: ['*'],
+    engagement: { trigger: ['mention'], stickiness: 'off' },
+    enabled: true,
+    history: defaultHistoryConfig(),
+  }
+}
+
+function makeRouter(): ChannelRouter {
+  return createChannelRouter({
+    agentDir: '/tmp/test-channel-fetch-attachment',
+    configForAdapter: () => emptyAdapterConfig(),
+  })
+}
+
+const fakeCtx = {} as Parameters<ReturnType<typeof createChannelFetchAttachmentTool>['execute']>[4]
+
+async function runTool(
+  tool: ReturnType<typeof createChannelFetchAttachmentTool>,
+  params: Parameters<ReturnType<typeof createChannelFetchAttachmentTool>['execute']>[1],
+) {
+  return tool.execute('id', params, undefined, undefined, fakeCtx)
+}
+
+describe('channel_fetch_attachment', () => {
+  let inboxDir: string
+
+  beforeEach(() => {
+    inboxDir = mkdtempSync(join(tmpdir(), 'typeclaw-fetch-attachment-'))
+  })
+
+  afterEach(() => {
+    rmSync(inboxDir, { recursive: true, force: true })
+  })
+
+  test('downloads a Slack file via the adapter callback and writes it to the inbox dir', async () => {
+    const router = makeRouter()
+    const calls: FetchAttachmentArgs[] = []
+    router.registerFetchAttachment('slack-bot', async (args): Promise<FetchAttachmentResult> => {
+      calls.push(args)
+      return {
+        ok: true,
+        buffer: Buffer.from('hello-bytes'),
+        filename: 'diagram.png',
+        mimetype: 'image/png',
+        size: 11,
+      }
+    })
+
+    const tool = createChannelFetchAttachmentTool({
+      router,
+      origin: { adapter: 'slack-bot' },
+      inboxDir,
+    })
+
+    const result = await runTool(tool, { ref: 'F12345' })
+
+    expect(calls).toEqual([{ ref: 'F12345' }])
+    expect(result.details).toMatchObject({ ok: true, mimetype: 'image/png', size: 11 })
+    const expectedPath = join(inboxDir, 'slack-bot', 'F12345', 'diagram.png')
+    expect(result.details?.path).toBe(expectedPath)
+    expect(readFileSync(expectedPath, 'utf8')).toBe('hello-bytes')
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: `saved 11 bytes to ${expectedPath} (image/png)`,
+    })
+  })
+
+  test('strips the `id=` prefix from a Slack ref so the agent can paste the classifier output verbatim', async () => {
+    const router = makeRouter()
+    const calls: FetchAttachmentArgs[] = []
+    router.registerFetchAttachment('slack-bot', async (args) => {
+      calls.push(args)
+      return { ok: true, buffer: Buffer.from('x'), filename: 'a.txt', mimetype: 'text/plain', size: 1 }
+    })
+
+    const tool = createChannelFetchAttachmentTool({
+      router,
+      origin: { adapter: 'slack-bot' },
+      inboxDir,
+    })
+
+    await runTool(tool, { ref: 'id=FABC123' })
+
+    expect(calls[0]?.ref).toBe('FABC123')
+  })
+
+  test('downloads a Discord CDN URL and slugs the URL basename into the directory layout', async () => {
+    const router = makeRouter()
+    router.registerFetchAttachment('discord-bot', async (_args) => ({
+      ok: true,
+      buffer: Buffer.from('discord-bytes'),
+      filename: 'one.png',
+      mimetype: 'image/png',
+      size: 13,
+    }))
+
+    const tool = createChannelFetchAttachmentTool({
+      router,
+      origin: { adapter: 'discord-bot' },
+      inboxDir,
+    })
+
+    const result = await runTool(tool, {
+      ref: 'https://cdn.discordapp.com/attachments/c1/a1/one.png',
+    })
+
+    expect(result.details?.ok).toBe(true)
+    expect(result.details?.path).toBe(join(inboxDir, 'discord-bot', 'one.png', 'one.png'))
+    expect(readFileSync(result.details!.path!, 'utf8')).toBe('discord-bytes')
+  })
+
+  test('forwards a custom filename through to the adapter and uses it as the on-disk name', async () => {
+    const router = makeRouter()
+    const calls: FetchAttachmentArgs[] = []
+    router.registerFetchAttachment('slack-bot', async (args) => {
+      calls.push(args)
+      return {
+        ok: true,
+        buffer: Buffer.from('z'),
+        filename: args.filename ?? 'fallback.bin',
+        mimetype: 'application/octet-stream',
+        size: 1,
+      }
+    })
+
+    const tool = createChannelFetchAttachmentTool({
+      router,
+      origin: { adapter: 'slack-bot' },
+      inboxDir,
+    })
+
+    const result = await runTool(tool, { ref: 'F1', filename: 'renamed.bin' })
+
+    expect(calls[0]).toEqual({ ref: 'F1', filename: 'renamed.bin' })
+    expect(result.details?.ok).toBe(true)
+    expect(result.details?.path?.endsWith('/renamed.bin')).toBe(true)
+  })
+
+  test('sanitizes path-traversal attempts in the filename so the agent cannot escape the inbox dir', async () => {
+    const router = makeRouter()
+    router.registerFetchAttachment('slack-bot', async () => ({
+      ok: true,
+      buffer: Buffer.from('safe'),
+      filename: '../../etc/passwd',
+      mimetype: 'text/plain',
+      size: 4,
+    }))
+
+    const tool = createChannelFetchAttachmentTool({
+      router,
+      origin: { adapter: 'slack-bot' },
+      inboxDir,
+    })
+
+    const result = await runTool(tool, { ref: 'F1' })
+
+    expect(result.details?.ok).toBe(true)
+    expect(result.details?.path?.startsWith(inboxDir)).toBe(true)
+    expect(result.details?.path?.split('/').includes('..')).toBe(false)
+  })
+
+  test('returns the upstream error verbatim when the adapter rejects the ref', async () => {
+    const router = makeRouter()
+    router.registerFetchAttachment('slack-bot', async () => ({
+      ok: false,
+      error: 'invalid Slack file id: F-bogus',
+    }))
+
+    const tool = createChannelFetchAttachmentTool({
+      router,
+      origin: { adapter: 'slack-bot' },
+      inboxDir,
+    })
+
+    const result = await runTool(tool, { ref: 'F-bogus' })
+
+    expect(result.details).toEqual({ ok: false, error: 'invalid Slack file id: F-bogus' })
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: 'channel_fetch_attachment error: invalid Slack file id: F-bogus',
+    })
+  })
+
+  test('reports a friendly error when no adapter has registered a fetch callback', async () => {
+    const router = makeRouter()
+    const tool = createChannelFetchAttachmentTool({
+      router,
+      origin: { adapter: 'slack-bot' },
+      inboxDir,
+    })
+
+    const result = await runTool(tool, { ref: 'F1' })
+
+    expect(result.details).toEqual({ ok: false, error: 'fetch-attachment-not-supported' })
+  })
+})

--- a/src/agent/tools/channel-fetch-attachment.ts
+++ b/src/agent/tools/channel-fetch-attachment.ts
@@ -1,0 +1,118 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { Type } from '@mariozechner/pi-ai'
+import { defineTool } from '@mariozechner/pi-coding-agent'
+
+import type { ChannelRouter } from '@/channels/router'
+import type { AdapterId } from '@/channels/schema'
+
+export type ChannelFetchAttachmentOrigin = {
+  adapter: AdapterId
+}
+
+export type CreateChannelFetchAttachmentToolOptions = {
+  router: ChannelRouter
+  origin: ChannelFetchAttachmentOrigin
+  inboxDir?: string
+}
+
+export const DEFAULT_INBOX_DIR = '/agent/workspace/inbox'
+
+export function createChannelFetchAttachmentTool({
+  router,
+  origin,
+  inboxDir,
+}: CreateChannelFetchAttachmentToolOptions) {
+  const baseDir = inboxDir ?? DEFAULT_INBOX_DIR
+  const adapter = origin.adapter
+  return defineTool({
+    name: 'channel_fetch_attachment',
+    label: 'Channel Fetch Attachment',
+    description:
+      'Download a file the user attached to the inbound channel message and save it to disk. Inbound channel ' +
+      'messages with uploads carry a `[<Platform> message with attachment: <name> (<mime>) <ref>]` summary — pass ' +
+      "the literal `<ref>` value as `ref`. For Slack the ref looks like `id=Fxxxx` (use `Fxxxx`); for Discord it's " +
+      'the full `https://cdn.discordapp.com/...` URL. The tool authenticates with the channel adapter (Slack ' +
+      'url_private requires the bot token; Discord CDN URLs are signed and expire ~24h, so fetch promptly). On ' +
+      'success returns the absolute path of the saved file plus its detected mimetype and size. On failure returns ' +
+      'the upstream error verbatim.',
+    parameters: Type.Object({
+      ref: Type.String({
+        description:
+          'Slack: the file id `Fxxxx` (with or without the `id=` prefix). Discord: the full `https://cdn.discordapp.com/...` or `https://media.discordapp.net/...` URL.',
+        minLength: 1,
+      }),
+      filename: Type.Optional(
+        Type.String({
+          description:
+            'Override the saved filename. Defaults to the upstream filename (Slack) or the URL basename (Discord).',
+          minLength: 1,
+        }),
+      ),
+    }),
+
+    async execute(_toolCallId, params) {
+      type Details = { ok: boolean; error?: string; path?: string; mimetype?: string; size?: number }
+      const ref = normalizeRef(params.ref)
+      const result = await router.fetchAttachment(adapter, {
+        ref,
+        ...(params.filename !== undefined ? { filename: params.filename } : {}),
+      })
+      if (!result.ok) {
+        const text = `channel_fetch_attachment error: ${result.error}`
+        const details: Details = { ok: false, error: result.error }
+        return { content: [{ type: 'text' as const, text }], details }
+      }
+
+      const safeFilename = sanitizeFilename(result.filename)
+      const refSlug = sanitizeRefSlug(ref)
+      const targetDir = join(baseDir, adapter, refSlug)
+      const targetPath = join(targetDir, safeFilename)
+      try {
+        await mkdir(targetDir, { recursive: true })
+        await writeFile(targetPath, result.buffer)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        const text = `channel_fetch_attachment error: write failed: ${message}`
+        const details: Details = { ok: false, error: `write failed: ${message}` }
+        return { content: [{ type: 'text' as const, text }], details }
+      }
+
+      const mimetypePart = result.mimetype !== undefined ? ` (${result.mimetype})` : ''
+      const text = `saved ${result.size} bytes to ${targetPath}${mimetypePart}`
+      const details: Details = {
+        ok: true,
+        path: targetPath,
+        ...(result.mimetype !== undefined ? { mimetype: result.mimetype } : {}),
+        size: result.size,
+      }
+      return { content: [{ type: 'text' as const, text }], details }
+    },
+  })
+}
+
+function normalizeRef(ref: string): string {
+  const trimmed = ref.trim()
+  if (trimmed.startsWith('id=')) return trimmed.slice(3)
+  return trimmed
+}
+
+const UNSAFE_FILENAME_CHARS = /[^A-Za-z0-9._-]/g
+
+function sanitizeFilename(name: string): string {
+  const cleaned = name.replace(UNSAFE_FILENAME_CHARS, '_')
+  if (cleaned === '' || cleaned === '.' || cleaned === '..') return 'attachment'
+  return cleaned
+}
+
+function sanitizeRefSlug(ref: string): string {
+  const trailing =
+    ref
+      .split('/')
+      .filter((s) => s.length > 0)
+      .pop() ?? 'ref'
+  const cleaned = trailing.replace(UNSAFE_FILENAME_CHARS, '_').slice(0, 64)
+  if (cleaned === '' || cleaned === '.' || cleaned === '..') return 'ref'
+  return cleaned
+}

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -30,6 +30,9 @@ function fakeRouter(
     registerHistory: () => {},
     unregisterHistory: () => {},
     fetchHistory: async () => ({ ok: false, error: 'history-not-supported' }),
+    registerFetchAttachment: () => {},
+    unregisterFetchAttachment: () => {},
+    fetchAttachment: async () => ({ ok: false, error: 'fetch-attachment-not-supported' }),
     stop: async () => {},
     liveCount: () => 0,
   }

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -24,6 +24,9 @@ function fakeRouter(
     registerHistory: () => {},
     unregisterHistory: () => {},
     fetchHistory: async () => ({ ok: false, error: 'history-not-supported' }),
+    registerFetchAttachment: () => {},
+    unregisterFetchAttachment: () => {},
+    fetchAttachment: async () => ({ ok: false, error: 'fetch-attachment-not-supported' }),
     stop: async () => {},
     liveCount: () => 0,
   }

--- a/src/channels/adapters/agent-messenger-slack-shim.ts
+++ b/src/channels/adapters/agent-messenger-slack-shim.ts
@@ -44,6 +44,13 @@ export type SlackSocketMessageEvent = {
   // key for the case where one user action surfaces as two events with
   // different `ts` values. Absent on bot messages and most system events.
   client_msg_id?: string
+  // Files uploaded by the user alongside (or in lieu of) text. Slack
+  // delivers file metadata on the same `message` event — there is no
+  // separate `file_share` event for messages we receive. Surfaced as a
+  // typed field (rather than relying on the catchall below) so the
+  // classifier can read it without `as` casts and so adapters can hand
+  // file ids to the SDK's downloadFile API for fetching.
+  files?: SlackFile[]
   [key: string]: unknown
 }
 
@@ -115,6 +122,7 @@ export interface SlackBotClient {
     filename: string,
     options?: { thread_ts?: string; title?: string; initial_comment?: string },
   ): Promise<SlackFile>
+  downloadFile(fileId: string): Promise<{ buffer: Buffer; file: SlackFile }>
 }
 
 export interface SlackBotListener {

--- a/src/channels/adapters/discord-bot-classify.test.ts
+++ b/src/channels/adapters/discord-bot-classify.test.ts
@@ -95,6 +95,46 @@ describe('classifyInbound — drop paths', () => {
     expect(verdict.payload.text).toBe('[Discord message with embed: Release notes https://example.com/releases]')
   })
 
+  test('appends attachment summary to user content so the agent sees BOTH text and the file when the user typed something alongside an upload', () => {
+    const event = buildEvent({
+      content: 'look at this',
+      attachments: [
+        {
+          id: 'a1',
+          filename: 'diagram.png',
+          url: 'https://cdn.discordapp.com/attachments/c1/a1/diagram.png',
+          content_type: 'image/png',
+        },
+      ],
+    })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.text).toBe(
+      'look at this\n[Discord message with attachment: diagram.png (image/png) https://cdn.discordapp.com/attachments/c1/a1/diagram.png]',
+    )
+  })
+
+  test('appends multiple attachments separated by `;` so each file ref reaches the agent', () => {
+    const event = buildEvent({
+      content: 'two files',
+      attachments: [
+        { id: 'a1', filename: 'one.png', url: 'https://cdn.discordapp.com/.../one.png', content_type: 'image/png' },
+        { id: 'a2', filename: 'two.txt', url: 'https://cdn.discordapp.com/.../two.txt', content_type: 'text/plain' },
+      ],
+    })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.text).toBe(
+      'two files\n[Discord message with attachment: one.png (image/png) https://cdn.discordapp.com/.../one.png; attachment: two.txt (text/plain) https://cdn.discordapp.com/.../two.txt]',
+    )
+  })
+
   test('drops messages from a workspace not in the allow list with reason=not_in_allow_list', () => {
     const config: ChannelAdapterConfig = { ...baseConfig, allow: ['guild:other'] }
     const event = buildEvent({ guild_id: 'g1' })

--- a/src/channels/adapters/discord-bot-classify.ts
+++ b/src/channels/adapters/discord-bot-classify.ts
@@ -107,9 +107,10 @@ function isReplyToBot(event: DiscordGatewayMessageCreateEvent, botUserId: string
 }
 
 function inboundText(event: DiscordGatewayMessageCreateEvent): string {
-  if (event.content !== '') return event.content
   const mediaSummary = summarizeDiscordMedia(event)
-  return mediaSummary.length > 0 ? `[Discord message with ${mediaSummary.join('; ')}]` : ''
+  if (mediaSummary.length === 0) return event.content
+  const summary = `[Discord message with ${mediaSummary.join('; ')}]`
+  return event.content === '' ? summary : `${event.content}\n${summary}`
 }
 
 function summarizeDiscordMedia(event: DiscordGatewayMessageCreateEvent): string[] {

--- a/src/channels/adapters/discord-bot-fetch-attachment.test.ts
+++ b/src/channels/adapters/discord-bot-fetch-attachment.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createFetchAttachmentCallback, type DiscordBotAdapterLogger } from './discord-bot'
+
+function silentLogger(): DiscordBotAdapterLogger & { errors: string[] } {
+  const errors: string[] = []
+  return {
+    info: () => {},
+    warn: () => {},
+    error: (m) => {
+      errors.push(m)
+    },
+    errors,
+  }
+}
+
+function fakeFetch(responder: (url: string, init?: RequestInit) => Promise<Response> | Response): typeof fetch {
+  return ((url: string | URL | Request, init?: RequestInit) =>
+    Promise.resolve(responder(typeof url === 'string' ? url : url.toString(), init))) as typeof fetch
+}
+
+describe('discord-bot createFetchAttachmentCallback', () => {
+  test('downloads from cdn.discordapp.com and reports the buffer + URL basename + content-type', async () => {
+    const seen: Array<{ url: string; auth: string | null }> = []
+    const cb = createFetchAttachmentCallback({
+      token: 'BOT_TOKEN_XYZ',
+      logger: silentLogger(),
+      fetchImpl: fakeFetch((url, init) => {
+        const headers = new Headers(init?.headers)
+        seen.push({ url, auth: headers.get('Authorization') })
+        return new Response('discord-bytes', {
+          status: 200,
+          headers: { 'content-type': 'image/png' },
+        })
+      }),
+    })
+
+    const result = await cb({ ref: 'https://cdn.discordapp.com/attachments/c1/a1/diagram.png' })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.filename).toBe('diagram.png')
+    expect(result.mimetype).toBe('image/png')
+    expect(result.size).toBe(13)
+    expect(result.buffer.toString('utf8')).toBe('discord-bytes')
+    expect(seen[0]?.auth).toBe('Bot BOT_TOKEN_XYZ')
+  })
+
+  test('also accepts media.discordapp.net (Discord uses both hosts for proxied attachments)', async () => {
+    const cb = createFetchAttachmentCallback({
+      token: 'T',
+      logger: silentLogger(),
+      fetchImpl: fakeFetch(() => new Response('ok', { status: 200 })),
+    })
+
+    const result = await cb({ ref: 'https://media.discordapp.net/attachments/c1/a1/img.jpg' })
+
+    expect(result.ok).toBe(true)
+  })
+
+  test('refuses non-Discord hosts so the bot token is never sent to attacker-controlled URLs', async () => {
+    let fetchCalled = false
+    const cb = createFetchAttachmentCallback({
+      token: 'T',
+      logger: silentLogger(),
+      fetchImpl: fakeFetch(() => {
+        fetchCalled = true
+        return new Response('should not happen', { status: 200 })
+      }),
+    })
+
+    const result = await cb({ ref: 'https://evil.example.com/steal' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected error')
+    expect(result.error).toContain('not a Discord CDN URL')
+    expect(fetchCalled).toBe(false)
+  })
+
+  test('rejects malformed URLs without dispatching a fetch', async () => {
+    let fetchCalled = false
+    const cb = createFetchAttachmentCallback({
+      token: 'T',
+      logger: silentLogger(),
+      fetchImpl: fakeFetch(() => {
+        fetchCalled = true
+        return new Response('', { status: 200 })
+      }),
+    })
+
+    const result = await cb({ ref: 'not-a-url' })
+
+    expect(result.ok).toBe(false)
+    expect(fetchCalled).toBe(false)
+  })
+
+  test('surfaces non-2xx CDN responses (e.g. expired signed URL) as a structured error', async () => {
+    const logger = silentLogger()
+    const cb = createFetchAttachmentCallback({
+      token: 'T',
+      logger,
+      fetchImpl: fakeFetch(() => new Response('expired', { status: 403, statusText: 'Forbidden' })),
+    })
+
+    const result = await cb({ ref: 'https://cdn.discordapp.com/attachments/c1/a1/expired.png' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected error')
+    expect(result.error).toContain('403')
+    expect(result.error).toContain('Forbidden')
+    expect(logger.errors[0]).toContain('fetchAttachment failed')
+  })
+
+  test('respects an explicit filename override even when the URL has its own basename', async () => {
+    const cb = createFetchAttachmentCallback({
+      token: 'T',
+      logger: silentLogger(),
+      fetchImpl: fakeFetch(() => new Response('z', { status: 200, headers: { 'content-type': 'text/plain' } })),
+    })
+
+    const result = await cb({
+      ref: 'https://cdn.discordapp.com/attachments/c1/a1/upstream.png',
+      filename: 'renamed.png',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.filename).toBe('renamed.png')
+  })
+})

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -9,6 +9,7 @@ import type { ChannelRouter } from '@/channels/router'
 import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 import type {
   ChannelHistoryMessage,
+  FetchAttachmentCallback,
   FetchHistoryArgs,
   FetchHistoryResult,
   HistoryCallback,
@@ -409,6 +410,63 @@ export function createOutboundCallback(deps: {
   }
 }
 
+// Discord CDN URLs (`cdn.discordapp.com/attachments/...`) are signed and
+// expire (~24h). Sending the bot token alongside makes no difference for
+// public CDN URLs (Discord ignores it), but is required for the rare
+// guild-restricted attachment, so we set it unconditionally — fail-open
+// to ensure-public is the wrong default for a fetch primitive that the
+// agent will lean on. URL validation refuses anything outside Discord's
+// own domains so the agent can't be tricked into using this callback as
+// a generic credentialed fetch.
+const DISCORD_ATTACHMENT_HOSTS = new Set(['cdn.discordapp.com', 'media.discordapp.net'])
+
+export function createFetchAttachmentCallback(deps: {
+  token: string
+  logger: DiscordBotAdapterLogger
+  fetchImpl?: typeof fetch
+}): FetchAttachmentCallback {
+  const { token, logger } = deps
+  const fetchImpl = deps.fetchImpl ?? fetch
+  return async ({ ref, filename }) => {
+    let url: URL
+    try {
+      url = new URL(ref)
+    } catch {
+      return { ok: false, error: `invalid Discord attachment URL: ${ref}` }
+    }
+    if (!DISCORD_ATTACHMENT_HOSTS.has(url.hostname)) {
+      return { ok: false, error: `not a Discord CDN URL: ${url.hostname}` }
+    }
+    try {
+      const res = await fetchImpl(url.toString(), { headers: { Authorization: `Bot ${token}` } })
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        const message = `discord cdn fetch ${res.status} ${res.statusText}${body ? `: ${body.slice(0, 200)}` : ''}`
+        logger.error(`[discord-bot] fetchAttachment failed for ${url.toString()}: ${message}`)
+        return { ok: false, error: message }
+      }
+      const arrayBuffer = await res.arrayBuffer()
+      const buffer = Buffer.from(arrayBuffer)
+      const inferredFilename = filename ?? url.pathname.split('/').pop() ?? 'attachment'
+      const contentType = res.headers.get('content-type') ?? undefined
+      logger.info(
+        `[discord-bot] downloaded url=${url.toString()} name=${inferredFilename} size=${buffer.length}${contentType ? ` type=${contentType}` : ''}`,
+      )
+      return {
+        ok: true,
+        buffer,
+        filename: inferredFilename,
+        ...(contentType !== undefined ? { mimetype: contentType } : {}),
+        size: buffer.length,
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error(`[discord-bot] fetchAttachment failed for ${url.toString()}: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
 export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): DiscordBotAdapter {
   const logger = options.logger ?? consoleLogger
   const client = new DiscordBotClient()
@@ -455,6 +513,8 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
     logger,
     formatChannelTag,
   })
+
+  const fetchAttachmentCallback = createFetchAttachmentCallback({ token: options.token, logger })
 
   const handleMessageCreate = async (event: DiscordGatewayMessageCreateEvent): Promise<void> => {
     inflightInbounds++
@@ -522,6 +582,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       options.router.registerTyping('discord-bot', typingCallback)
       options.router.registerChannelNameResolver('discord-bot', channelResolver)
       options.router.registerHistory('discord-bot', historyCallback)
+      options.router.registerFetchAttachment('discord-bot', fetchAttachmentCallback)
       options.router.registerMembership('discord-bot', membershipResolver)
 
       try {
@@ -540,6 +601,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       options.router.unregisterTyping('discord-bot', typingCallback)
       options.router.unregisterChannelNameResolver('discord-bot', channelResolver)
       options.router.unregisterHistory('discord-bot', historyCallback)
+      options.router.unregisterFetchAttachment('discord-bot', fetchAttachmentCallback)
       options.router.unregisterMembership('discord-bot', membershipResolver)
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {

--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -47,12 +47,120 @@ describe('slack-bot classifyInbound — drop paths', () => {
     expect(verdict).toEqual({ kind: 'drop', reason: 'no_user' })
   })
 
-  test('drops empty-text messages with reason=empty_text', () => {
+  test('drops messages with neither text nor files with reason=empty_text', () => {
     const event = buildEvent({ text: '' })
 
     const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
 
     expect(verdict).toEqual({ kind: 'drop', reason: 'empty_text' })
+  })
+
+  test('routes file-only uploads (empty text) with attachment summary so the agent sees the upload', () => {
+    const event = buildEvent({
+      text: '',
+      files: [
+        {
+          id: 'F1',
+          name: 'diagram.png',
+          title: 'diagram',
+          mimetype: 'image/png',
+          size: 1234,
+          url_private: 'https://files.slack.com/f/F1/diagram.png',
+          created: 1700000000,
+          user: 'UALICE',
+        },
+      ],
+    })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.text).toBe('[Slack message with attachment: diagram.png (image/png) id=F1]')
+  })
+
+  test('appends attachment summary to user text so the agent sees BOTH text and the file when the user typed something alongside the upload', () => {
+    const event = buildEvent({
+      text: 'look at this',
+      files: [
+        {
+          id: 'F1',
+          name: 'diagram.png',
+          title: 'diagram',
+          mimetype: 'image/png',
+          size: 1234,
+          url_private: 'https://files.slack.com/f/F1/diagram.png',
+          created: 1700000000,
+          user: 'UALICE',
+        },
+      ],
+    })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.text).toBe('look at this\n[Slack message with attachment: diagram.png (image/png) id=F1]')
+  })
+
+  test('multiple file uploads each surface as a separate attachment ref so the agent can fetch any of them', () => {
+    const event = buildEvent({
+      text: '',
+      files: [
+        {
+          id: 'F1',
+          name: 'one.png',
+          title: 'one',
+          mimetype: 'image/png',
+          size: 1,
+          url_private: 'https://files.slack.com/f/F1/one.png',
+          created: 1700000000,
+          user: 'UALICE',
+        },
+        {
+          id: 'F2',
+          name: 'two.txt',
+          title: 'two',
+          mimetype: 'text/plain',
+          size: 2,
+          url_private: 'https://files.slack.com/f/F2/two.txt',
+          created: 1700000001,
+          user: 'UALICE',
+        },
+      ],
+    })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.text).toBe(
+      '[Slack message with attachment: one.png (image/png) id=F1; attachment: two.txt (text/plain) id=F2]',
+    )
+  })
+
+  test('appended attachment summary does not register `<@…>` ids inside file URLs as bot mentions', () => {
+    const event = buildEvent({
+      text: 'check this',
+      files: [
+        {
+          id: 'F1',
+          name: 'note.txt',
+          title: 'note',
+          mimetype: 'text/plain',
+          size: 1,
+          url_private: `https://files.slack.com/<@${BOT_USER_ID}>/F1/note.txt`,
+          created: 1700000000,
+          user: 'UALICE',
+        },
+      ],
+    })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(false)
   })
 
   test('drops messages from a team not in the allow list with reason=not_in_allow_list', () => {

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -1,13 +1,13 @@
 import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 import type { InboundMessage } from '@/channels/types'
 
-import type { SlackSocketMessageEvent } from './agent-messenger-slack-shim'
+import type { SlackFile, SlackSocketMessageEvent } from './agent-messenger-slack-shim'
 import { slackTsToMillis } from './slack-bot-time'
 
 export type InboundDropReason =
   | 'self_author' // event.user === botUserId; we never route our own messages back to ourselves
   | 'no_user' // event has no `user` field (e.g. system messages: channel_join, message_changed)
-  | 'empty_text' // event.text is empty or missing — nothing for the agent to act on
+  | 'empty_text' // event has neither text nor files — nothing for the agent to act on
   | 'not_in_allow_list' // workspace/channel not admitted by typeclaw.json `channels.slack-bot.allow`
   | 'pre_connect' // bot identity is not known yet, so mention/self/reply classification cannot be trusted
 
@@ -47,7 +47,8 @@ export function classifyInbound(
     return { kind: 'drop', reason: 'no_user' }
   }
 
-  const text = event.text ?? ''
+  const rawText = event.text ?? ''
+  const text = inboundText(event)
   if (text === '') return { kind: 'drop', reason: 'empty_text' }
 
   const isDm = event.channel_type === 'im'
@@ -60,6 +61,9 @@ export function classifyInbound(
     return { kind: 'drop', reason: 'pre_connect' }
   }
 
+  // Mention parsing runs against the raw user-typed text only — the
+  // appended `[Slack message with attachment: ...]` summary contains URLs
+  // and ids that must not be misread as mentions or group broadcasts.
   // Group mentions (`<!here>`, `<!channel>`, `<!everyone>`) are coerced to
   // direct mentions: the user fired a broadcast that explicitly includes the
   // bot, and from the engagement layer's perspective there is no meaningful
@@ -67,8 +71,8 @@ export function classifyInbound(
   // both are an invitation to participate. Treating them identically also
   // means the existing 'mention' trigger in typeclaw.json catches both
   // without any new config surface.
-  const hasGroupMention = GROUP_MENTION_PATTERN.test(text)
-  const isBotMention = hasGroupMention || text.includes(`<@${context.botUserId}>`)
+  const hasGroupMention = GROUP_MENTION_PATTERN.test(rawText)
+  const isBotMention = hasGroupMention || rawText.includes(`<@${context.botUserId}>`)
   const thread = event.thread_ts ?? (!isDm && isBotMention ? event.ts : null)
 
   // thread_ts identifies the parent message of a thread. We can only know it
@@ -77,7 +81,7 @@ export function classifyInbound(
   // shares its ts with thread_ts).
   const replyToBotMessageId = event.thread_ts !== undefined && event.thread_ts !== event.ts ? event.thread_ts : null
 
-  const mentionedUserIds = extractMentionedUserIds(text)
+  const mentionedUserIds = extractMentionedUserIds(rawText)
   const mentionsOthers = mentionedUserIds.length > 0 && !mentionedUserIds.includes(context.botUserId)
 
   // Slack does not surface the parent message's author on `event`, so we
@@ -133,4 +137,21 @@ function extractMentionedUserIds(text: string): string[] {
     seen.add(match[1]!)
   }
   return Array.from(seen)
+}
+
+function inboundText(event: SlackSocketMessageEvent): string {
+  const rawText = event.text ?? ''
+  const mediaSummary = summarizeSlackMedia(event)
+  if (mediaSummary.length === 0) return rawText
+  const summary = `[Slack message with ${mediaSummary.join('; ')}]`
+  return rawText === '' ? summary : `${rawText}\n${summary}`
+}
+
+function summarizeSlackMedia(event: SlackSocketMessageEvent): string[] {
+  return (event.files ?? []).map(summarizeSlackFile)
+}
+
+function summarizeSlackFile(file: SlackFile): string {
+  const parts: string[] = [`attachment: ${file.name}`, `(${file.mimetype})`, `id=${file.id}`]
+  return parts.join(' ')
 }

--- a/src/channels/adapters/slack-bot-fetch-attachment.test.ts
+++ b/src/channels/adapters/slack-bot-fetch-attachment.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createFetchAttachmentCallback, type SlackBotAdapterLogger } from './slack-bot'
+
+function silentLogger(): SlackBotAdapterLogger & { errors: string[] } {
+  const errors: string[] = []
+  return {
+    info: () => {},
+    warn: () => {},
+    error: (m) => {
+      errors.push(m)
+    },
+    errors,
+  }
+}
+
+describe('slack-bot createFetchAttachmentCallback', () => {
+  test('hands a valid Fxxxx file id to the SDK and surfaces the buffer + metadata to the router', async () => {
+    const logger = silentLogger()
+    const cb = createFetchAttachmentCallback({
+      client: {
+        downloadFile: async (fileId) => ({
+          buffer: Buffer.from(`bytes-for-${fileId}`),
+          file: {
+            id: fileId,
+            name: 'diagram.png',
+            title: 'diagram',
+            mimetype: 'image/png',
+            size: 17,
+            url_private: 'https://files.slack.com/.../diagram.png',
+            created: 1700000000,
+            user: 'UALICE',
+          },
+        }),
+      },
+      logger,
+    })
+
+    const result = await cb({ ref: 'F12345' })
+
+    expect(result).toEqual({
+      ok: true,
+      buffer: Buffer.from('bytes-for-F12345'),
+      filename: 'diagram.png',
+      mimetype: 'image/png',
+      size: 17,
+    })
+    expect(logger.errors).toEqual([])
+  })
+
+  test('respects an explicit filename override (lets the agent rename inflight)', async () => {
+    const cb = createFetchAttachmentCallback({
+      client: {
+        downloadFile: async () => ({
+          buffer: Buffer.from('x'),
+          file: {
+            id: 'F1',
+            name: 'upstream.png',
+            title: 'u',
+            mimetype: 'image/png',
+            size: 1,
+            url_private: 'https://files.slack.com/.../upstream.png',
+            created: 1700000000,
+            user: 'UALICE',
+          },
+        }),
+      },
+      logger: silentLogger(),
+    })
+
+    const result = await cb({ ref: 'F1', filename: 'renamed.png' })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.filename).toBe('renamed.png')
+  })
+
+  test('rejects refs that are not Slack file ids without calling the SDK (prevents url leakage)', async () => {
+    let downloadCalled = false
+    const cb = createFetchAttachmentCallback({
+      client: {
+        downloadFile: async () => {
+          downloadCalled = true
+          throw new Error('should not be called')
+        },
+      },
+      logger: silentLogger(),
+    })
+
+    const result = await cb({ ref: 'https://files.slack.com/private/F1/diagram.png' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected error')
+    expect(result.error).toContain('invalid Slack file id')
+    expect(downloadCalled).toBe(false)
+  })
+
+  test('returns a structured error when the SDK download throws', async () => {
+    const logger = silentLogger()
+    const cb = createFetchAttachmentCallback({
+      client: {
+        downloadFile: async () => {
+          throw new Error('files.info: file_not_found')
+        },
+      },
+      logger,
+    })
+
+    const result = await cb({ ref: 'F404' })
+
+    expect(result).toEqual({ ok: false, error: 'files.info: file_not_found' })
+    expect(logger.errors[0]).toContain('downloadFile failed for F404')
+  })
+})

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -9,6 +9,7 @@ import type { ChannelRouter } from '@/channels/router'
 import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 import type {
   ChannelHistoryMessage,
+  FetchAttachmentCallback,
   FetchHistoryArgs,
   FetchHistoryResult,
   HistoryCallback,
@@ -506,6 +507,41 @@ export function createOutboundCallback(deps: {
   }
 }
 
+// Slack file URLs (`url_private`) require Bearer auth and an html-page is
+// returned for unauthenticated GETs, so the agent cannot fetch them via a
+// plain HTTP tool. Routing through the SDK's `downloadFile(fileId)` is
+// the only path that works — it issues `files.info` to fetch metadata
+// (mimetype + name) then GETs `url_private` with the bot token. The
+// classifier emits `id=Fxxxx` in the inbound text exactly so the agent
+// can hand the id back to this callback.
+export function createFetchAttachmentCallback(deps: {
+  client: Pick<SlackBotClient, 'downloadFile'>
+  logger: SlackBotAdapterLogger
+}): FetchAttachmentCallback {
+  const { client, logger } = deps
+  return async ({ ref, filename }) => {
+    const fileId = ref.trim()
+    if (!/^F[A-Z0-9]+$/.test(fileId)) {
+      return { ok: false, error: `invalid Slack file id: ${ref}` }
+    }
+    try {
+      const { buffer, file } = await client.downloadFile(fileId)
+      logger.info(`[slack-bot] downloaded id=${file.id} name=${file.name} size=${file.size}`)
+      return {
+        ok: true,
+        buffer,
+        filename: filename ?? file.name,
+        mimetype: file.mimetype,
+        size: file.size,
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error(`[slack-bot] downloadFile failed for ${fileId}: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
 export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBotAdapter {
   const logger = options.logger ?? consoleLogger
   const client = new SlackBotClient()
@@ -549,6 +585,8 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
     logger,
     formatChannelTag,
   })
+
+  const fetchAttachmentCallback = createFetchAttachmentCallback({ client, logger })
 
   const dedupe = createSlackDedupe()
 
@@ -664,6 +702,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       options.router.registerTyping('slack-bot', typingCallback)
       options.router.registerChannelNameResolver('slack-bot', channelResolver)
       options.router.registerHistory('slack-bot', historyCallback)
+      options.router.registerFetchAttachment('slack-bot', fetchAttachmentCallback)
       options.router.registerMembership('slack-bot', membershipResolver)
 
       try {
@@ -682,6 +721,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       options.router.unregisterTyping('slack-bot', typingCallback)
       options.router.unregisterChannelNameResolver('slack-bot', channelResolver)
       options.router.unregisterHistory('slack-bot', historyCallback)
+      options.router.unregisterFetchAttachment('slack-bot', fetchAttachmentCallback)
       options.router.unregisterMembership('slack-bot', membershipResolver)
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -29,6 +29,9 @@ import type {
   ChannelHistoryMessage,
   ChannelKey,
   ChannelNameResolver,
+  FetchAttachmentArgs,
+  FetchAttachmentCallback,
+  FetchAttachmentResult,
   FetchHistoryArgs,
   FetchHistoryResult,
   HistoryCallback,
@@ -213,6 +216,9 @@ export type ChannelRouter = {
   registerHistory: (adapter: ChannelKey['adapter'], cb: HistoryCallback) => void
   unregisterHistory: (adapter: ChannelKey['adapter'], cb: HistoryCallback) => void
   fetchHistory: (adapter: ChannelKey['adapter'], args: FetchHistoryArgs) => Promise<FetchHistoryResult>
+  registerFetchAttachment: (adapter: ChannelKey['adapter'], cb: FetchAttachmentCallback) => void
+  unregisterFetchAttachment: (adapter: ChannelKey['adapter'], cb: FetchAttachmentCallback) => void
+  fetchAttachment: (adapter: ChannelKey['adapter'], args: FetchAttachmentArgs) => Promise<FetchAttachmentResult>
   stop: () => Promise<void>
   liveCount: () => number
   __testing?: {
@@ -253,6 +259,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const membershipResolvers = new Map<ChannelKey['adapter'], Set<MembershipResolver>>()
   const membershipCaches = new Map<ChannelKey['adapter'], MembershipCache>()
   const historyCallbacks = new Map<ChannelKey['adapter'], Set<HistoryCallback>>()
+  const fetchAttachmentCallbacks = new Map<ChannelKey['adapter'], Set<FetchAttachmentCallback>>()
   const stickyLedger = new StickyLedger()
   const commands = createCommandRegistry<ChannelCommandContext>([
     {
@@ -998,6 +1005,37 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return lastError
   }
 
+  const registerFetchAttachment = (adapter: ChannelKey['adapter'], cb: FetchAttachmentCallback): void => {
+    let set = fetchAttachmentCallbacks.get(adapter)
+    if (!set) {
+      set = new Set()
+      fetchAttachmentCallbacks.set(adapter, set)
+    }
+    set.add(cb)
+  }
+
+  const unregisterFetchAttachment = (adapter: ChannelKey['adapter'], cb: FetchAttachmentCallback): void => {
+    fetchAttachmentCallbacks.get(adapter)?.delete(cb)
+  }
+
+  const fetchAttachment = async (
+    adapter: ChannelKey['adapter'],
+    args: FetchAttachmentArgs,
+  ): Promise<FetchAttachmentResult> => {
+    const callbacks = fetchAttachmentCallbacks.get(adapter)
+    if (!callbacks || callbacks.size === 0) {
+      return { ok: false, error: 'fetch-attachment-not-supported' }
+    }
+    const snapshot = Array.from(callbacks)
+    let lastError: FetchAttachmentResult & { ok: false } = { ok: false, error: 'fetch-attachment-not-supported' }
+    for (const cb of snapshot) {
+      const result = await cb(args)
+      if (result.ok) return result
+      lastError = result
+    }
+    return lastError
+  }
+
   const send = async (msg: OutboundMessage): Promise<SendResult> => {
     const callbacks = outboundCallbacks.get(msg.adapter)
     if (!callbacks || callbacks.size === 0) {
@@ -1158,6 +1196,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     registerHistory,
     unregisterHistory,
     fetchHistory,
+    registerFetchAttachment,
+    unregisterFetchAttachment,
+    fetchAttachment,
     stop,
     liveCount: () => liveSessions.size,
     __testing: {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -136,6 +136,17 @@ export type FetchHistoryResult =
 // 'history-not-supported' for those.
 export type HistoryCallback = (args: FetchHistoryArgs) => Promise<FetchHistoryResult>
 
+export type FetchAttachmentArgs = {
+  ref: string
+  filename?: string
+}
+
+export type FetchAttachmentResult =
+  | { ok: true; buffer: Buffer; filename: string; mimetype?: string; size: number }
+  | { ok: false; error: string }
+
+export type FetchAttachmentCallback = (args: FetchAttachmentArgs) => Promise<FetchAttachmentResult>
+
 export function channelKeyId(key: ChannelKey): string {
   return `${key.adapter}:${key.workspace}:${key.chat}:${key.thread ?? ''}`
 }


### PR DESCRIPTION
## Symptom

The agent reports it can't see attachments in either Slack or Discord channels. In practice:

- **Slack:** if a user uploads a file with no caption, the entire message is dropped (`reason: empty_text`); if the user types something alongside the upload, the file is silently stripped and the agent only sees the typed text.
- **Discord:** if a user uploads a file with no message, the agent gets a `[Discord message with attachment: …]` annotation. But the moment the user types anything alongside the upload — the common case — the attachment is silently dropped because of an early-return on non-empty `event.content`.

Either way, attachments don't reach the agent on the input side, and even when an annotation does come through (Discord, file-only path), there's no way for the agent to actually read the file: Slack `url_private` requires Bearer auth and Discord CDN URLs are signed and expire ~24h.

## Root cause

Two separate per-adapter bugs that both produce the same user-visible failure:

1. **`slack-bot-classify.ts`** drops on `event.text === ''` and never reads `event.files`. Files are completely invisible to the agent regardless of whether text accompanies them.
2. **`discord-bot-classify.ts`** does extract attachments, but the helper short-circuits with `if (event.content !== '') return event.content`, dropping the media summary the moment any text is present.

`InboundMessage` only has `text: string` (no `attachments` field), so per-adapter text composition is the right place to surface this — there's no plumbing to add a structured field through the router and into the `AgentSession.prompt(string)` API.

## Fix

### Commit 1 — `Surface channel attachments to the agent in inbound text` (8d45110)

Both classifiers now compose inbound text as

```
<user text>
[<Platform> message with attachment: <name> (<mime>) <ref>]
```

where `<ref>` is the Slack file id (`F12345`) or the Discord CDN URL. When user text is empty, only the bracket annotation is emitted (matches Discord's existing file-only behaviour).

**Subtle correctness invariant on the Slack side:** mention parsing (`<@USER>` and `<!here>`/`<!channel>`/`<!everyone>`) runs against the raw `event.text` only — the appended summary may legitimately contain URLs and ids that must not be misread as mentions or group broadcasts. Without this guard, an attachment URL containing a `<@…>` substring could trigger a phantom bot mention.

Slack shim now types `files?: SlackFile[]` explicitly so the classifier reads it without an `as` cast. Type was previously hidden under `[key: string]: unknown`.

**Files:** `slack-bot-classify.ts`, `discord-bot-classify.ts`, `agent-messenger-slack-shim.ts`, plus 5 new classifier tests covering file-only / text+file / multi-file / mention-injection-via-URL.

### Commit 2 — `Add channel_fetch_attachment tool so the agent can read user uploads` (733b9ce)

The classifier surfaces refs but the agent had no way to actually read the files those refs name — Slack `url_private` needs the bot token, Discord CDN URLs are signed/expire. The new `channel_fetch_attachment` tool routes through the channel adapter that owns the conversation (`origin.adapter`), keeping auth and platform-specific fetch logic where the credentials already live.

The router gains a register/dispatch surface mirroring the existing `HistoryCallback`:

```ts
registerFetchAttachment(adapter, cb)
unregisterFetchAttachment(adapter, cb)
fetchAttachment(adapter, args): Promise<FetchAttachmentResult>
```

Adapters that don't implement it cleanly answer `'fetch-attachment-not-supported'` — the tool doesn't need to know which adapters can fetch.

**Slack adapter:** uses the SDK's `client.downloadFile(fileId)` which already handles `files.info` + Bearer-auth GET of `url_private`. The callback validates that `ref` looks like `Fxxxx` so an attacker-controlled URL never reaches the SDK.

**Discord adapter:** fetches the CDN URL directly with `Authorization: Bot <token>`, but only after **whitelisting the URL host** to `cdn.discordapp.com` or `media.discordapp.net`. This is an SSRF guard — without it, a malicious inbound could trick the bot into leaking its token to an arbitrary URL via a poisoned `[Discord message with attachment: … <evil-url>]`.

**On-disk layout:** files land at `/agent/workspace/inbox/<adapter>/<refSlug>/<filename>`. Both filename and ref-slug are sanitized so a malicious upstream filename (e.g. `../../etc/passwd`) cannot escape the inbox dir. Test `sanitizes path-traversal attempts in the filename` exercises this directly.

**Files:** `channel-fetch-attachment.ts` (new tool), `slack-bot.ts` + `discord-bot.ts` (`createFetchAttachmentCallback` factory + register/unregister), `router.ts` + `types.ts` (callback plumbing), `agent/index.ts` (wiring in `buildChannelTools`). Plus three new test files (tool + two adapter callbacks) and three test fakes updated for the new router methods.

## Design decisions

**Why text-summary parity instead of full multimodal?** End-to-end multimodal would require adding `attachments` to `InboundMessage`, plumbing it through the router and `composeTurnPrompt`, and changing `AgentSession.prompt()` (in the external `@mariozechner/pi-coding-agent` package) to accept multimodal content. That's a much larger scope and an upstream dependency change. The chosen approach gets the agent unblocked end-to-end without modifying the external package — the agent sees the attachment metadata in text and can call `channel_fetch_attachment` to read the bytes.

**Why per-adapter `fetchAttachment` and not a generic `download_url` tool?** Because each platform has a different auth and URL story (Slack needs Bearer-auth `url_private` access via `files.info`; Discord uses signed CDN URLs). A generic tool would either duplicate the per-platform logic in the tool layer or leak credentials. Routing through the adapter keeps each platform's auth in exactly one place.

**Why a Discord URL whitelist?** The Slack ref is structurally `Fxxxx`, which is its own validation. Discord refs are full URLs, so without a host whitelist a poisoned inbound message could trick the agent into calling `channel_fetch_attachment` with an attacker URL — and the callback would happily attach `Authorization: Bot <token>` to it. The whitelist is the simplest mitigation that doesn't break legitimate Discord CDN fetches.

**Why not handle Discord URL expiry by downloading on receipt?** Per the user's preference: lazy fetch-on-demand. Discord CDN URLs have a ~24h TTL. If the agent processes a message minutes after receipt (the common case) it works; for a queued/cron-driven message processed >24h later the fetch will return 403. The error is surfaced verbatim so the agent can act on it (re-prompt the user, etc.). Eager download would cost disk + bandwidth on every inbound, which is the wrong default for this primitive.

## Tests

1582 pass / 0 fail across 109 files (was 1559/106 before; +23 tests, +3 files).

- **5 new classifier tests** — file-only Slack, text+file Slack (parity with Discord), multi-file ordering, the URL-as-mention-injection attack, the `event.content !== ''` Discord regression.
- **5 new Slack `createFetchAttachmentCallback` tests** — happy path, filename override, URL ref refusal (must be `Fxxxx`), SDK error surfacing.
- **6 new Discord `createFetchAttachmentCallback` tests** — happy path on both `cdn.discordapp.com` and `media.discordapp.net`, non-Discord host refusal, malformed URL refusal, expired-URL 403 handling, filename override.
- **7 new `channel_fetch_attachment` tool tests** — Slack download + on-disk write, `id=Fxxxx` prefix stripping, Discord URL handling, filename forwarding, path-traversal sanitization, upstream error verbatim, missing adapter callback.

Updated: `buildChannelTools` test now asserts the four-tool set including `channel_fetch_attachment` (was three).

## Verification

```sh
bun run typecheck    # clean
bun run lint         # 0 warnings, 0 errors
bun run format       # clean
bun test             # 1582 pass, 0 fail
```

## Out of scope

- **Full multimodal input to the LLM.** Even though Fireworks/Kimi K2.5 Turbo declares `input: ['text', 'image']`, this PR doesn't pass image bytes to the LLM as image content. The agent reads the file via the tool and processes it as bytes-on-disk. End-to-end multimodal would touch `pi-coding-agent`.
- **Slack legacy `attachments` field.** The classifier reads `event.files` (the modern file-upload field). Slack also has a legacy `event.attachments` for link unfurls and rich-message attachments — out of scope; can be added if needed.
- **Discord embed/sticker fetching.** Only `attachments[]` (uploaded files) get a fetchable ref. Embeds and stickers are rendered into the text summary as before but don't have a fetch path.
