### PR TITLE
Add typeclaw status command for container and hostd state

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,7 @@ import { restartCommand } from './restart'
 import { run } from './run'
 import { shellCommand } from './shell'
 import { startCommand } from './start'
+import { statusCommand } from './status'
 import { stopCommand } from './stop'
 import { tui } from './tui'
 
@@ -26,6 +27,7 @@ const main = defineCommand({
     start: startCommand,
     stop: stopCommand,
     restart: restartCommand,
+    status: statusCommand,
     reload,
     logs: logsCommand,
     shell: shellCommand,

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatStatus, type StatusReport } from './status'
+
+function baseReport(overrides: Partial<StatusReport> = {}): StatusReport {
+  return {
+    cwd: '/agents/coder',
+    container: { kind: 'missing', containerName: 'coder', imageTag: 'typeclaw-coder' },
+    hostd: { kind: 'unreachable' },
+    ...overrides,
+  }
+}
+
+describe('formatStatus', () => {
+  test('renders three sections with labels for missing container + unreachable daemon', () => {
+    const out = formatStatus(baseReport())
+
+    expect(out).toContain('Container  coder')
+    expect(out).toContain('  cwd     /agents/coder')
+    expect(out).toContain('  image   typeclaw-coder')
+    expect(out).toContain('  state   missing')
+    expect(out).toContain('Host daemon')
+    expect(out).toContain('  state   unreachable')
+    expect(out).toContain('Port forwarding')
+    expect(out).toContain('requires the host daemon')
+  })
+
+  test('shows running state with shortened container id and host port mapping', () => {
+    const out = formatStatus(
+      baseReport({
+        container: {
+          kind: 'running',
+          containerName: 'coder',
+          imageTag: 'typeclaw-coder',
+          containerId: 'sha256:abcdef0123456789',
+          configuredImage: 'typeclaw-coder',
+          hostPort: 51234,
+          hostBindAddr: '0.0.0.0',
+        },
+      }),
+    )
+
+    expect(out).toContain('  state   running')
+    expect(out).toContain('  id      abcdef012345')
+    expect(out).toContain('  port    0.0.0.0:51234 -> container:51234')
+  })
+
+  test('shows stopped state with id but no port row', () => {
+    const out = formatStatus(
+      baseReport({
+        container: {
+          kind: 'stopped',
+          containerName: 'coder',
+          imageTag: 'typeclaw-coder',
+          containerId: 'sha256:1234567890ab',
+          configuredImage: 'typeclaw-coder',
+        },
+      }),
+    )
+
+    expect(out).toContain('  state   stopped')
+    expect(out).toContain('  id      1234567890ab')
+    expect(out).not.toContain('  port    ')
+  })
+
+  test('shows running with unknown port when docker port returned nothing', () => {
+    const out = formatStatus(
+      baseReport({
+        container: {
+          kind: 'running',
+          containerName: 'coder',
+          imageTag: 'typeclaw-coder',
+          containerId: 'sha256:abc',
+          configuredImage: 'typeclaw-coder',
+          hostPort: null,
+          hostBindAddr: null,
+        },
+      }),
+    )
+
+    expect(out).toContain('  port    unknown')
+  })
+
+  test('renders forwarded ports sorted ascending when hostd is registered', () => {
+    const out = formatStatus(
+      baseReport({
+        hostd: { kind: 'registered', cwd: '/agents/coder', forwardedPorts: [3000, 5173, 8080] },
+      }),
+    )
+
+    expect(out).toContain('Host daemon')
+    expect(out).toContain('  state   registered')
+    const portsBlock = out.slice(out.indexOf('Port forwarding'))
+    const indices = [3000, 5173, 8080].map((p) => portsBlock.indexOf(`127.0.0.1:${p}`))
+    expect(indices.every((i) => i >= 0)).toBe(true)
+    expect(indices).toEqual([...indices].sort((a, b) => a - b))
+  })
+
+  test('renders empty forwarding hint when registered but no ports open', () => {
+    const out = formatStatus(
+      baseReport({
+        hostd: { kind: 'registered', cwd: '/agents/coder', forwardedPorts: [] },
+      }),
+    )
+
+    expect(out).toContain('Port forwarding')
+    expect(out).toContain('no ports currently forwarded')
+  })
+
+  test('renders not-registered state with reason', () => {
+    const out = formatStatus(
+      baseReport({
+        hostd: { kind: 'not-registered', reason: 'not registered: coder' },
+      }),
+    )
+
+    expect(out).toContain('  state   not registered')
+    expect(out).toContain('  reason  not registered: coder')
+  })
+
+  test('useColor=true wraps section headers with ANSI escapes', () => {
+    const out = formatStatus(baseReport(), { useColor: true })
+    const ESC = '\u001b'
+
+    expect(out).toContain(`${ESC}[1mContainer${ESC}[0m`)
+    expect(out).toContain(`${ESC}[1mHost daemon${ESC}[0m`)
+    expect(out).toContain(`${ESC}[1mPort forwarding${ESC}[0m`)
+  })
+
+  test('useColor=false produces output free of ANSI escape codes', () => {
+    const out = formatStatus(
+      baseReport({
+        container: {
+          kind: 'running',
+          containerName: 'coder',
+          imageTag: 'typeclaw-coder',
+          containerId: 'sha256:abcdef012345',
+          configuredImage: 'typeclaw-coder',
+          hostPort: 51234,
+          hostBindAddr: '127.0.0.1',
+        },
+        hostd: { kind: 'registered', cwd: '/x', forwardedPorts: [5173] },
+      }),
+    )
+
+    expect(out).not.toContain('\u001b[')
+  })
+})

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,0 +1,144 @@
+import { defineCommand } from 'citty'
+
+import { status as containerStatus, type ContainerStatus } from '@/container'
+import { isDaemonReachable, send } from '@/hostd'
+import type { StatusResult } from '@/hostd'
+import { findAgentDir } from '@/init'
+
+export type HostdStatus =
+  | { kind: 'unreachable' }
+  | { kind: 'not-registered'; reason: string }
+  | { kind: 'registered'; cwd: string; forwardedPorts: number[] }
+
+export type StatusReport = {
+  cwd: string
+  container: ContainerStatus
+  hostd: HostdStatus
+}
+
+export const statusCommand = defineCommand({
+  meta: {
+    name: 'status',
+    description: 'show the agent container and host daemon status (host stage)',
+  },
+  async run() {
+    const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+    const container = await containerStatus({ cwd })
+    const hostd = await fetchHostdStatus(container.containerName)
+
+    const useColor = Boolean(process.stdout.isTTY) && process.env.NO_COLOR === undefined
+    process.stdout.write(`${formatStatus({ cwd, container, hostd }, { useColor })}\n`)
+  },
+})
+
+async function fetchHostdStatus(containerName: string): Promise<HostdStatus> {
+  if (!(await isDaemonReachable())) return { kind: 'unreachable' }
+  const reply = await send({ kind: 'status', containerName })
+  if (!reply.ok) return { kind: 'not-registered', reason: reply.reason }
+  const result = reply.result as StatusResult | undefined
+  if (!result) return { kind: 'not-registered', reason: 'daemon returned empty status' }
+  return { kind: 'registered', cwd: result.cwd, forwardedPorts: result.forwardedPorts }
+}
+
+export type FormatOptions = { useColor?: boolean }
+
+const ANSI = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+}
+
+export function formatStatus(report: StatusReport, opts: FormatOptions = {}): string {
+  const useColor = opts.useColor ?? false
+  const style = useColor ? ANSI : (Object.fromEntries(Object.keys(ANSI).map((k) => [k, ''])) as typeof ANSI)
+
+  const lines: string[] = []
+  appendContainerSection(lines, report, style)
+  lines.push('')
+  appendHostdSection(lines, report, style)
+  lines.push('')
+  appendForwardingSection(lines, report, style)
+  while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
+  return lines.join('\n')
+}
+
+function appendContainerSection(lines: string[], report: StatusReport, s: typeof ANSI): void {
+  const c = report.container
+  lines.push(`${s.bold}Container${s.reset}  ${c.containerName}`)
+  lines.push(row('cwd', report.cwd))
+  lines.push(row('image', c.imageTag))
+
+  if (c.kind === 'missing') {
+    lines.push(row('state', badge(s, 'missing', s.dim)))
+    return
+  }
+
+  const stateLabel = c.kind === 'running' ? badge(s, 'running', s.green) : badge(s, 'stopped', s.yellow)
+  lines.push(row('state', stateLabel))
+  lines.push(row('id', shortId(c.containerId)))
+
+  if (c.kind === 'running') {
+    const port = c.hostPort === null ? `${s.dim}unknown${s.reset}` : formatHostMapping(c.hostBindAddr, c.hostPort, s)
+    lines.push(row('port', port))
+  }
+}
+
+function appendHostdSection(lines: string[], report: StatusReport, s: typeof ANSI): void {
+  lines.push(`${s.bold}Host daemon${s.reset}`)
+
+  switch (report.hostd.kind) {
+    case 'unreachable':
+      lines.push(row('state', badge(s, 'unreachable', s.dim)))
+      lines.push(`  ${s.dim}Daemon is not running. \`typeclaw start\` will spawn one.${s.reset}`)
+      return
+    case 'not-registered':
+      lines.push(row('state', badge(s, 'not registered', s.yellow)))
+      lines.push(row('reason', report.hostd.reason))
+      return
+    case 'registered':
+      lines.push(row('state', badge(s, 'registered', s.green)))
+      return
+  }
+}
+
+function appendForwardingSection(lines: string[], report: StatusReport, s: typeof ANSI): void {
+  lines.push(`${s.bold}Port forwarding${s.reset}`)
+
+  if (report.hostd.kind !== 'registered') {
+    lines.push(`  ${s.dim}requires the host daemon${s.reset}`)
+    return
+  }
+
+  const ports = report.hostd.forwardedPorts
+  if (ports.length === 0) {
+    lines.push(`  ${s.dim}no ports currently forwarded${s.reset}`)
+    return
+  }
+
+  for (const port of [...ports].sort((a, b) => a - b)) {
+    lines.push(`  ${s.cyan}127.0.0.1:${port}${s.reset} ${s.dim}->${s.reset} container:${port}`)
+  }
+}
+
+function row(label: string, value: string): string {
+  return `  ${label.padEnd(8)}${value}`
+}
+
+function badge(s: typeof ANSI, text: string, color: string): string {
+  return `${color}${text}${s.reset}`
+}
+
+function shortId(id: string): string {
+  if (id.length === 0) return '-'
+  const trimmed = id.startsWith('sha256:') ? id.slice('sha256:'.length) : id
+  return trimmed.slice(0, 12)
+}
+
+function formatHostMapping(bindAddr: string | null, port: number, s: typeof ANSI): string {
+  const bind = bindAddr ?? '127.0.0.1'
+  return `${s.cyan}${bind}:${port}${s.reset} ${s.dim}->${s.reset} container:${port}`
+}

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -1,6 +1,7 @@
 export { logs, planLogs, type LogsPlan, type LogsResult } from './logs'
 export { CONTAINER_PORT, findFreePort, resolveHostPort } from './port'
 export { planShell, shell, type ShellPlan, type ShellResult } from './shell'
+export { status, type ContainerStatus, type StatusOptions } from './status'
 export {
   containerExists,
   containerNameFromCwd,

--- a/src/container/status.test.ts
+++ b/src/container/status.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { DockerExec, DockerExecResult } from './shared'
+import { status } from './status'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-container-status-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+type FakeDockerOptions = {
+  inspect?: DockerExecResult
+  port?: DockerExecResult
+}
+
+function fakeExec(opts: FakeDockerOptions): DockerExec {
+  return async (args) => {
+    if (args[0] === 'inspect') {
+      return opts.inspect ?? { exitCode: 1, stdout: '', stderr: 'no inspect stub' }
+    }
+    if (args[0] === 'port') {
+      return opts.port ?? { exitCode: 1, stdout: '', stderr: 'no port stub' }
+    }
+    return { exitCode: 1, stdout: '', stderr: `unexpected: ${args.join(' ')}` }
+  }
+}
+
+describe('status', () => {
+  test('reports missing when docker inspect exits non-zero', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    const result = await status({
+      cwd: folder,
+      exec: fakeExec({ inspect: { exitCode: 1, stdout: '', stderr: 'No such object' } }),
+    })
+
+    expect(result).toEqual({ kind: 'missing', containerName: 'coder', imageTag: 'typeclaw-coder' })
+  })
+
+  test('reports stopped when inspect succeeds but Running is false', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    const result = await status({
+      cwd: folder,
+      exec: fakeExec({
+        inspect: { exitCode: 0, stdout: 'false|sha256:abc123|typeclaw-coder\n', stderr: '' },
+      }),
+    })
+
+    expect(result).toEqual({
+      kind: 'stopped',
+      containerName: 'coder',
+      imageTag: 'typeclaw-coder',
+      containerId: 'sha256:abc123',
+      configuredImage: 'typeclaw-coder',
+    })
+  })
+
+  test('reports running with parsed host port and bind address', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    const result = await status({
+      cwd: folder,
+      exec: fakeExec({
+        inspect: { exitCode: 0, stdout: 'true|sha256:def456|typeclaw-coder\n', stderr: '' },
+        port: { exitCode: 0, stdout: '0.0.0.0:51234\n:::51234\n', stderr: '' },
+      }),
+    })
+
+    expect(result).toEqual({
+      kind: 'running',
+      containerName: 'coder',
+      imageTag: 'typeclaw-coder',
+      containerId: 'sha256:def456',
+      configuredImage: 'typeclaw-coder',
+      hostPort: 51234,
+      hostBindAddr: '0.0.0.0',
+    })
+  })
+
+  test('prefers IPv4 mapping when docker reports both', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    const result = await status({
+      cwd: folder,
+      exec: fakeExec({
+        inspect: { exitCode: 0, stdout: 'true|sha256:1|typeclaw-coder\n', stderr: '' },
+        port: { exitCode: 0, stdout: ':::51234\n127.0.0.1:51234\n', stderr: '' },
+      }),
+    })
+
+    expect(result).toMatchObject({ kind: 'running', hostPort: 51234, hostBindAddr: '127.0.0.1' })
+  })
+
+  test('returns running with null port when docker port mapping is missing', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    const result = await status({
+      cwd: folder,
+      exec: fakeExec({
+        inspect: { exitCode: 0, stdout: 'true|sha256:1|typeclaw-coder\n', stderr: '' },
+        port: { exitCode: 1, stdout: '', stderr: 'Error: No public port' },
+      }),
+    })
+
+    expect(result).toMatchObject({ kind: 'running', hostPort: null, hostBindAddr: null })
+  })
+})

--- a/src/container/status.ts
+++ b/src/container/status.ts
@@ -1,0 +1,76 @@
+import { CONTAINER_PORT } from './port'
+import { containerNameFromCwd, defaultDockerExec, imageTagFromCwd, type DockerExec } from './shared'
+
+export type ContainerStatus =
+  | { kind: 'missing'; containerName: string; imageTag: string }
+  | {
+      kind: 'stopped'
+      containerName: string
+      imageTag: string
+      containerId: string
+      configuredImage: string
+    }
+  | {
+      kind: 'running'
+      containerName: string
+      imageTag: string
+      containerId: string
+      configuredImage: string
+      hostPort: number | null
+      hostBindAddr: string | null
+    }
+
+export type StatusOptions = {
+  cwd: string
+  exec?: DockerExec
+}
+
+export async function status({ cwd, exec = defaultDockerExec }: StatusOptions): Promise<ContainerStatus> {
+  const containerName = containerNameFromCwd(cwd)
+  const imageTag = imageTagFromCwd(cwd)
+
+  const inspect = await exec(['inspect', '--format', '{{.State.Running}}|{{.Id}}|{{.Config.Image}}', containerName])
+  if (inspect.exitCode !== 0) {
+    return { kind: 'missing', containerName, imageTag }
+  }
+
+  const [runningRaw = '', containerId = '', configuredImage = ''] = inspect.stdout.trim().split('|')
+  const running = runningRaw.trim() === 'true'
+
+  if (!running) {
+    return { kind: 'stopped', containerName, imageTag, containerId, configuredImage }
+  }
+
+  const mapping = await queryPortMapping(exec, containerName)
+  return {
+    kind: 'running',
+    containerName,
+    imageTag,
+    containerId,
+    configuredImage,
+    hostPort: mapping?.port ?? null,
+    hostBindAddr: mapping?.bindAddr ?? null,
+  }
+}
+
+type PortMapping = { bindAddr: string; port: number }
+
+// Mirrors parseDockerPortOutput in ./port but also keeps the bind address so
+// status can show "127.0.0.1:51234 -> 8973" instead of just the host port.
+async function queryPortMapping(exec: DockerExec, containerName: string): Promise<PortMapping | null> {
+  const result = await exec(['port', containerName, `${CONTAINER_PORT}/tcp`])
+  if (result.exitCode !== 0) return null
+  const lines = result.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  if (lines.length === 0) return null
+
+  const ipv4 = lines.find((line) => /^\d{1,3}(\.\d{1,3}){3}:\d+$/.test(line))
+  const candidate = ipv4 ?? lines[0]!
+  const lastColon = candidate.lastIndexOf(':')
+  if (lastColon < 0) return null
+  const port = Number(candidate.slice(lastColon + 1))
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null
+  return { bindAddr: candidate.slice(0, lastColon), port }
+}

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -75,14 +75,36 @@ describe('startDaemon', () => {
     expect((list.result as ListResult).registrations).toHaveLength(0)
   })
 
-  test('status returns the registered cwd', async () => {
+  test('status returns the registered cwd with empty forwardedPorts when no portbroker is wired', async () => {
     daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000 })
     await send({ kind: 'register', containerName: 'coder', cwd: '/x' })
 
     const status = await send({ kind: 'status', containerName: 'coder' })
     expect(status.ok).toBe(true)
     if (!status.ok) return
-    expect(status.result).toEqual({ containerName: 'coder', cwd: '/x' })
+    expect(status.result).toEqual({ containerName: 'coder', cwd: '/x', forwardedPorts: [] })
+  })
+
+  test('status surfaces forwardedPorts reported by the portbroker callback', async () => {
+    const portbroker: PortbrokerCallbacks = {
+      start: () => {},
+      stop: async () => {},
+      forwardedPorts: (name) => (name === 'coder' ? [3000, 5173] : []),
+    }
+    daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, portbroker })
+    await send({
+      kind: 'register',
+      containerName: 'coder',
+      cwd: '/x',
+      wsHostPort: 12345,
+      portForward: { allow: '*' },
+      brokerToken: 'tok',
+    })
+
+    const status = await send({ kind: 'status', containerName: 'coder' })
+    expect(status.ok).toBe(true)
+    if (!status.ok) return
+    expect(status.result).toEqual({ containerName: 'coder', cwd: '/x', forwardedPorts: [3000, 5173] })
   })
 
   test('deregister of unknown container is a no-op (ok)', async () => {
@@ -497,6 +519,7 @@ describe('startDaemon', () => {
         startCalls.push(input)
       },
       stop: async () => {},
+      forwardedPorts: () => [],
     }
 
     const d1 = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, portbroker })

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -62,6 +62,12 @@ export type RestartPreflight = (input: {
 export type PortbrokerCallbacks = {
   start: (input: PortbrokerStartInput) => void
   stop: (containerName: string, reason: 'deregistered' | 'broker-stopped') => Promise<void>
+  // Returns ports the broker is currently exposing on the host for this
+  // container. Empty array when the container is unregistered, when the broker
+  // is disabled (`portForward.allow: []`), or when nothing inside the
+  // container has bound a forwardable port yet. Read-only — used by the
+  // `status` RPC to surface live forward state.
+  forwardedPorts: (containerName: string) => number[]
 }
 
 export type PortbrokerStartInput = {
@@ -318,6 +324,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     const result: StatusResult = {
       containerName: req.containerName,
       cwd,
+      forwardedPorts: opts.portbroker?.forwardedPorts(req.containerName) ?? [],
     }
     return { ok: true, result }
   }

--- a/src/hostd/portbroker-manager.ts
+++ b/src/hostd/portbroker-manager.ts
@@ -73,6 +73,12 @@ export function createPortbrokerManager(opts: PortbrokerManagerOptions = {}): Po
       log(`[portbroker:${containerName}] stopped (${reason})`)
     },
 
+    forwardedPorts(containerName) {
+      const broker = brokers.get(containerName)
+      if (!broker) return []
+      return broker.forwardedPorts()
+    },
+
     async drain() {
       const all = Array.from(brokers.values())
       const tailscale = Array.from(tailscaleManagers.values())

--- a/src/hostd/protocol.ts
+++ b/src/hostd/protocol.ts
@@ -27,6 +27,7 @@ export type ListResult = {
 export type StatusResult = {
   containerName: string
   cwd: string
+  forwardedPorts: number[]
 }
 
 export type RestartResult = {


### PR DESCRIPTION
## Why

There is no host-stage way to ask \"is my agent running, what host port did it land on, and is the host daemon actually wired to it?\" without piecing it together from \`docker ps\`, \`docker port\`, and inferring whether \`hostd\` is up. New users, scripts, and \`compose\` operators all hit this. \`typeclaw status\` is the missing observability primitive.

## What

A new host-stage subcommand \`typeclaw status\` that resolves the agent folder from cwd (same as \`start\`/\`stop\`/\`logs\`) and prints three sectioned blocks:

\`\`\`
Container  coder
  cwd     ~/agents/coder
  image   typeclaw-coder
  state   running
  id      abcdef012345
  port    127.0.0.1:51234 -> container:51234

Host daemon
  state   registered

Port forwarding
  127.0.0.1:5173 -> container:5173
  127.0.0.1:3000 -> container:3000
\`\`\`

State badges colorize when stdout is a TTY (green = good, yellow = attention, dim = neutral). Empty / off paths render explanatory hints rather than blank sections.

Scope is **current agent only** — multi-agent reporting is out of scope and belongs to a future \`typeclaw compose status\`.

## How

Three layers, each with its own test surface:

1. **\`src/container/status.ts\`** — pure read over a \`DockerExec\`. One \`docker inspect --format\` call gives running/id/image, one \`docker port\` call resolves the published host port + bind addr. Returns a tagged union (\`missing\` | \`stopped\` | \`running\`) so the formatter can branch on shape, not on field presence. 5 unit tests.

2. **\`src/cli/status.ts\`** — thin CLI shell + a pure \`formatStatus(report, { useColor })\` function. The shell does I/O (\`findAgentDir\`, \`containerStatus\`, \`isDaemonReachable\`, hostd \`status\` RPC) and feeds the formatter. Layout is fully covered by 9 unit tests against the pure function — no spinner / TTY mocking.

3. **Daemon \`status\` RPC** now returns \`forwardedPorts: number[]\`. To populate it I added \`forwardedPorts(containerName)\` to \`PortbrokerCallbacks\`, and the \`portbroker-manager\` fulfills it by reading the broker's existing \`forwardedPorts()\` accessor — no new state, just a passthrough.

## Tradeoffs flagged for review

- **\`forwardedPorts\` empty array is overloaded.** Four meanings: container unregistered, broker disabled (\`portForward.allow: []\`), no bound ports yet, or callback not wired (tests). The CLI lumps all four under \"no ports currently forwarded\". Doc-commented on \`PortbrokerCallbacks.forwardedPorts\`. If we later want to disambiguate, the right move is a richer return type, not a separate RPC.
- **Reused \`docker port\`-parsing logic** instead of importing \`parseDockerPortOutput\` from \`./port\`. The reason (preserving the bind addr) is comment-documented. Open to consolidating if a reviewer prefers.
- **No exit-code semantics, no \`--json\`.** Per scope question with the user. If \`compose\` later wants machine-readable output, \`--json\` slots in cleanly because the formatter is already split out.

## Verification

\`\`\`
bun run typecheck   # clean
bun run lint        # 0 warnings, 0 errors
bun run format:check  # clean
bun test            # 1582 pass, 0 fail (was 1568 before)
\`\`\`

New tests:
- \`src/container/status.test.ts\` — 5 tests covering missing / stopped / running / IPv4 preference / missing-mapping
- \`src/cli/status.test.ts\` — 9 tests covering all three sections × all states + ANSI on/off
- \`src/hostd/daemon.test.ts\` — extended existing status test + added a portbroker-callback variant

## Out of scope

- Multi-agent reporting (\`compose status\`)
- JSON output
- Exit-code semantics for scriptability
