### PR TITLE
Use Slack parent_user_id to classify thread replies

### DIFF
--- a/src/channels/adapters/agent-messenger-slack-shim.ts
+++ b/src/channels/adapters/agent-messenger-slack-shim.ts
@@ -35,6 +35,13 @@ export type SlackSocketMessageEvent = {
   text?: string
   ts: string
   thread_ts?: string
+  // Slack populates this on every reply within a thread and sets it to the
+  // user id of the message that started the thread (i.e. the author of
+  // `thread_ts`). Absent on top-level messages and on the thread root
+  // itself. The classifier uses it to decide whether a reply is a reply to
+  // *us* (the bot) — the `event` payload alone otherwise has no way to
+  // know who authored the parent.
+  parent_user_id?: string
   event_ts?: string
   edited?: { user: string; ts: string }
   hidden?: boolean

--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -296,9 +296,44 @@ describe('slack-bot classifyInbound — route path', () => {
     expect(verdict.payload).toMatchObject({ workspace: '@dm', chat: 'D0DMID', isDm: true })
   })
 
-  test('thread reply surfaces thread_ts as thread and replyToBotMessageId when ts differs', () => {
+  test('thread reply to the bot surfaces thread_ts as both thread and replyToBotMessageId', () => {
     const event = buildEvent({
       text: 'thanks',
+      ts: '1700000010.000200',
+      thread_ts: '1700000000.000100',
+      parent_user_id: BOT_USER_ID,
+    })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.thread).toBe('1700000000.000100')
+    expect(verdict.payload.replyToBotMessageId).toBe('1700000000.000100')
+    expect(verdict.payload.replyToOtherMessageId).toBeNull()
+  })
+
+  test('thread reply between humans (parent is a human) sets replyToOtherMessageId, not replyToBotMessageId', () => {
+    const event = buildEvent({
+      user: 'UALICE',
+      text: 'i agree',
+      ts: '1700000010.000200',
+      thread_ts: '1700000000.000100',
+      parent_user_id: 'UCAROL',
+    })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.thread).toBe('1700000000.000100')
+    expect(verdict.payload.replyToBotMessageId).toBeNull()
+    expect(verdict.payload.replyToOtherMessageId).toBe('1700000000.000100')
+  })
+
+  test('thread reply with no parent_user_id leaves both reply fields null (refuses to guess)', () => {
+    const event = buildEvent({
+      text: 'reply with unknown parent',
       ts: '1700000010.000200',
       thread_ts: '1700000000.000100',
     })
@@ -308,7 +343,8 @@ describe('slack-bot classifyInbound — route path', () => {
     expect(verdict.kind).toBe('route')
     if (verdict.kind !== 'route') throw new Error('expected route')
     expect(verdict.payload.thread).toBe('1700000000.000100')
-    expect(verdict.payload.replyToBotMessageId).toBe('1700000000.000100')
+    expect(verdict.payload.replyToBotMessageId).toBeNull()
+    expect(verdict.payload.replyToOtherMessageId).toBeNull()
   })
 
   test('parent message of a thread (ts === thread_ts) does not register as a reply', () => {
@@ -323,6 +359,7 @@ describe('slack-bot classifyInbound — route path', () => {
     expect(verdict.kind).toBe('route')
     if (verdict.kind !== 'route') throw new Error('expected route')
     expect(verdict.payload.replyToBotMessageId).toBeNull()
+    expect(verdict.payload.replyToOtherMessageId).toBeNull()
   })
 
   test('drops thread replies before bot identity is known (cannot classify parent target safely)', () => {

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -75,22 +75,31 @@ export function classifyInbound(
   const isBotMention = hasGroupMention || rawText.includes(`<@${context.botUserId}>`)
   const thread = event.thread_ts ?? (!isDm && isBotMention ? event.ts : null)
 
-  // thread_ts identifies the parent message of a thread. We can only know it
-  // is a reply to the bot if we recognize the bot's own user id and have a
-  // thread_ts that differs from the event ts (the parent message itself
-  // shares its ts with thread_ts).
-  const replyToBotMessageId = event.thread_ts !== undefined && event.thread_ts !== event.ts ? event.thread_ts : null
+  // A reply is "to the bot" only when the thread parent was authored by the
+  // bot. Slack surfaces the parent author via `parent_user_id` on every
+  // reply event; without that match we don't know who authored the parent
+  // and MUST NOT engage on the `reply` trigger — otherwise every threaded
+  // reply between two humans (or two peer bots) wakes us up. The thread
+  // root itself shares its ts with thread_ts and carries no parent_user_id.
+  const isReply = event.thread_ts !== undefined && event.thread_ts !== event.ts
+  const replyToBotMessageId =
+    isReply && context.botUserId !== null && event.parent_user_id === context.botUserId ? event.thread_ts! : null
 
   const mentionedUserIds = extractMentionedUserIds(rawText)
   const mentionsOthers = mentionedUserIds.length > 0 && !mentionedUserIds.includes(context.botUserId)
 
-  // Slack does not surface the parent message's author on `event`, so we
-  // cannot positively identify a reply-to-other from the inbound alone.
-  // Leaving this null keeps the contract honest — the engagement layer's
-  // mention-based suppressor still covers the common case of "@-someone
-  // in a thread reply", and the solo-human fallback only matters in
-  // 1-human channels where there is no "other" human to reply to anyway.
-  const replyToOtherMessageId: string | null = null
+  // Symmetric to `replyToBotMessageId` above: a reply whose parent author
+  // is identifiable AND is not the bot is a reply-to-other. The engagement
+  // layer uses this to suppress the solo-human fallback so the bot stays
+  // quiet when two humans (or a peer bot and a human) hold a thread side-
+  // conversation in a busy channel — the exact incident this fix addresses.
+  const replyToOtherMessageId =
+    isReply &&
+    event.parent_user_id !== undefined &&
+    event.parent_user_id !== '' &&
+    event.parent_user_id !== context.botUserId
+      ? event.thread_ts!
+      : null
 
   // Slack signals "this message was authored by a bot" via either a non-empty
   // bot_id or subtype === 'bot_message'. Either is sufficient.

--- a/src/channels/engagement.test.ts
+++ b/src/channels/engagement.test.ts
@@ -734,6 +734,31 @@ describe('decideEngagement (targets-others suppressors)', () => {
     expect(decision).toBe('observe')
   })
 
+  test('observes a thread side-conversation between two humans in a busy channel (incident regression)', () => {
+    // Incident: a thread root authored by Jiyoung mentions Rio (a human peer).
+    // Rio replies in the thread. The bot was engaging on Rio's reply because
+    // the Slack adapter set replyToBotMessageId for every threaded reply
+    // regardless of parent author. Once the adapter correctly populates
+    // replyToOtherMessageId from parent_user_id, this gate fires and the bot
+    // stays out of the human-to-human side-conversation.
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({
+        authorId: 'rio',
+        text: 'i finished the cancellation work',
+        thread: 'jiyoung-thread-root-ts',
+        replyToBotMessageId: null,
+        replyToOtherMessageId: 'jiyoung-thread-root-ts',
+      }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: [participant('rio')],
+    })
+    expect(decision).toBe('observe')
+  })
+
   test('mention-of-us still engages even when the message also tags others', () => {
     const ledger = new StickyLedger()
     const decision = decideEngagement({


### PR DESCRIPTION
## Why

The Slack inbound classifier was setting `replyToBotMessageId` on every threaded reply where `event.ts !== thread_ts`, regardless of who authored the parent. With the default `reply` trigger, that meant the bot engaged on every threaded reply between two humans (or two peer bots) in any allowed channel — even when neither message mentioned the bot.

The root issue: the classifier had a comment claiming "Slack does not surface the parent message's author on `event`", and left `replyToOtherMessageId = null` unconditionally. That comment was wrong. Slack carries `parent_user_id` on every reply event, pointing at the author of the thread root. The history mapper in `slack-bot.ts:408` already uses it correctly — the inbound classifier just wasn't.

The engagement layer already has a suppressor for `replyToOtherMessageId` at `engagement.ts:135` that fires when the bot isn't the thread parent; it just wasn't receiving the right signal.

## Changes

**`src/channels/adapters/agent-messenger-slack-shim.ts`**

Adds `parent_user_id?: string` to the `SlackSocketMessageEvent` shim type. Previously it was buried under the catchall `[key: string]: unknown`, so the classifier was reading it untyped.

**`src/channels/adapters/slack-bot-classify.ts`**

Two targeted changes to the reply classifier:

- `replyToBotMessageId` is now set only when `parent_user_id === botUserId`. Previously it was set for any reply in a thread — firing on every human-to-human threaded exchange in every allowed channel.
- `replyToOtherMessageId` is now populated from `parent_user_id` when present and not the bot. This is the signal the engagement layer's existing suppressor (`engagement.ts:135`) needs to stay quiet during threaded conversations between humans.

The `no parent_user_id` path (thread reply on the root message itself, or an unusual event shape) leaves both fields null — the classifier refuses to guess rather than defaulting to engagement.

**`src/channels/adapters/slack-bot-classify.test.ts`**

Three new test cases covering the new paths:

- Thread reply where `parent_user_id` matches the bot → `replyToBotMessageId` set, `replyToOtherMessageId` null.
- Thread reply where `parent_user_id` is a human peer → `replyToBotMessageId` null, `replyToOtherMessageId` set.
- Thread reply with no `parent_user_id` → both null.

The existing "thread reply" test was also updated to pass `parent_user_id: BOT_USER_ID` so it reflects the path that actually sets the field.

**`src/channels/engagement.test.ts`**

Regression test pinned to the production incident: a thread reply by a human (`rio`) to a thread root authored by another human (`jiyoung`) — with `replyToOtherMessageId` populated and `replyToBotMessageId` null — produces `'observe'`, not `'engage'`. No changes to `engagement.ts` itself; the suppressor logic was already correct.

## Tests

1608/1608 pass (90 in the affected files). Typecheck clean. 0 lint warnings.

```
bun run typecheck   # clean
bun run lint        # 0 warnings, 0 errors
bun run format      # clean
bun test            # 1608 pass, 0 fail
```