### PR TITLE
Log Slack typing setStatus lifecycle for diagnostics

### DIFF
--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -116,15 +116,34 @@ export function createSlackTypingTracker(deps: {
 }): SlackTypingTracker {
   const { client, logger } = deps
   const queues = new Map<string, Promise<void>>()
+  // Monotonic per-tracker counter so the three lifecycle log lines for one
+  // call (queued → sent → ok) can be correlated by id even when many calls
+  // for the same (chat, thread) interleave on the wire.
+  let nextCallId = 0
 
   const enqueue = (chat: string, threadTs: string, status: string): Promise<void> => {
     const key = `${chat}\x00${threadTs}`
+    const callId = nextCallId++
+    // queue depth BEFORE this call is added — tells us whether the FIFO is
+    // back-pressuring (depth>0) or this call gets to fly straight to Slack.
+    const queueDepthBefore = queues.has(key) ? 1 : 0
+    logger.info(
+      `[slack-bot] typing call=${callId} chat=${chat} thread=${threadTs} status="${status}" queued (depth=${queueDepthBefore})`,
+    )
     const prev = queues.get(key) ?? Promise.resolve()
     const next = prev
       .catch(() => {})
-      .then(() => client.setAssistantStatus(chat, threadTs, status))
+      .then(() => {
+        logger.info(`[slack-bot] typing call=${callId} sending`)
+        return client.setAssistantStatus(chat, threadTs, status)
+      })
+      .then(() => {
+        logger.info(`[slack-bot] typing call=${callId} ok`)
+      })
       .catch((err: unknown) => {
-        logger.warn(`[slack-bot] typing chat=${chat} thread=${threadTs} status="${status}" failed: ${describe(err)}`)
+        logger.warn(
+          `[slack-bot] typing call=${callId} chat=${chat} thread=${threadTs} status="${status}" failed: ${describe(err)}`,
+        )
       })
     queues.set(key, next)
     void next.finally(() => {


### PR DESCRIPTION
## Why

After PR #52 (\`Clear Slack typing indicator after every send\`), production reports surface two unresolved typing-indicator symptoms in the slack-bot adapter:

1. **In channels**, \`is typing...\` can persist long after the bot has finished replying (the symptom PR #52 was meant to fix).
2. **In Slack Assistant DMs**, no typing indicator ever appears.

The current code path in \`createSlackTypingTracker\` is silent on success — the only diagnostic line is a warn-on-failure inside the FIFO catch handler. From the logs alone we cannot distinguish:

- (a) \`clearAfterSend\` never ran for a given turn,
- (b) the empty-string \`setStatus\` reached Slack and was honored on the wire,
- (c) Slack accepted the call but did not render the change.

Without that distinction, any further fix would be speculative. (See \`/Users/neo/workspace/typeclaw\` analysis session — three competing theories survive without ruling any out: stale-clear contamination across turns, heartbeat-after-final-reply race, and Slack-side rejection of empty-string status.)

## What changed

Three info-level lines per call inside \`createSlackTypingTracker\`:

\`\`\`
[slack-bot] typing call=N chat=C... thread=T... status=\"...\" queued (depth=D)
[slack-bot] typing call=N sending
[slack-bot] typing call=N ok
\`\`\`

- **\`queued\`** fires the moment the router/outbound expresses intent, before any FIFO chaining. Carries the full call context (chat, thread, status string, queue depth).
- **\`sending\`** fires when the FIFO actually drains this call to the wire — the gap between this and \`queued\` reveals back-pressure latency.
- **\`ok\`** fires when Slack returns \`ok: true\`. Total latency from \`queued\` to \`ok\` is the wire-level cost of one \`assistant.threads.setStatus\` call.

A monotonic per-tracker call id (\`call=N\`) correlates the three lines for the same call when many concurrent calls for one \`(chat, thread)\` pair interleave. This is the only reliable way to read the timeline when the heartbeat (~8s) overlaps with multi-attachment sends and the \`clearAfterSend\` queued behind them.

The existing warn-on-failure now also carries \`call=N\` for the same correlation.

## How we will use this

Operator runs \`typeclaw logs -f | rg '\\[slack-bot\\] typing'\` while reproducing the symptom. The output should reveal which of the three theories is correct:

| Observation                                                                                                | Conclusion                                                              |
| ---                                                                                                        | ---                                                                    |
| \`queued status=\"\"\` appears after every send, followed by \`sending\` then \`ok\`, but indicator persists | Slack-side rendering issue or known auto-clear race; not a typeclaw bug |
| \`queued status=\"\"\` appears but \`sending\` is delayed by seconds (\`depth>0\`)                            | FIFO is back-pressuring; cross-turn HOL blocking is real                |
| \`queued status=\"\"\` never appears for a turn                                                              | \`clearAfterSend\` is being skipped; bug is in \`createOutboundCallback\`  |
| \`queued status=\"is typing...\"\` is the LAST line for a key (no following clear)                           | Heartbeat fired after the agent's final reply; race PR #52 didn't cover |

## Verification

\`\`\`
bun run typecheck   # clean
bun run lint        # 0 warnings, 0 errors
bun run format:check # all files use correct format
bun test            # 1608 pass, 0 fail
\`\`\`

## Out of scope

- **No behavior change.** The FIFO ordering, error handling, and \`clearAfterSend\` semantics are unchanged. This is pure observability — every code path that ran before still runs identically, plus \`logger.info(...)\` calls.
- **No router or other-adapter changes.** Discord typing is unaffected.
- **The DM symptom is not addressed by this PR.** Diagnosing the channel symptom should also clarify whether the DM bug is purely a classifier issue (DMs lack \`thread_ts\`, see \`slack-bot-classify.ts:76\`) or compounds with the tracker. We may need an \`assistant.threads.start\` call to materialize a thread for Assistant DMs — out of scope here.

## Followup

After this lands and we collect production logs from a stuck-typing reproduction, the targeted fix will land in a separate small PR. This PR can stay merged or be reverted at that point depending on whether the steady-state log volume (~3 lines per heartbeat per active channel) is acceptable long-term.