### PR TITLE
Refuse byte-equivalent fragment duplicates within a daily stream

### DIFF
--- a/plugins/memory/append-tool.test.ts
+++ b/plugins/memory/append-tool.test.ts
@@ -10,7 +10,7 @@ import { appendTool } from './append-tool'
 async function callExpectingThrow(path: string, content: string): Promise<unknown> {
   try {
     await appendTool.execute({ path, content }, ctx)
-    throw new Error(`expected appendTool.execute to throw for content with secret, but it returned`)
+    throw new Error(`expected appendTool.execute to throw, but it returned`)
   } catch (err) {
     return err
   }
@@ -175,5 +175,92 @@ describe('appendTool', () => {
 
     await call(path, content)
     expect(readFileSync(path, 'utf8')).toBe(content)
+  })
+
+  test('refuses to append a fragment whose topic+body already exists in the file (the winky duplication case)', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'fragments.md')
+    const fragment = (sessionId: string, entryId: string): string =>
+      [
+        `<!-- fragment source=${sessionId} entry=${entryId} -->`,
+        '## Review System Final Design Decisions',
+        'Three Key Decisions raised by Jamie and confirmed:',
+        '1. Eligibility (Conservative) - DELIVERED + no cancellation + no return',
+        '2. Delete Strategy (Hybrid) - hard for user, soft for admin hide',
+        '3. Review Count per Order Item - 1 per (user, order_item) with UNIQUE constraint',
+        '',
+      ].join('\n')
+
+    await call(path, fragment('ses_first', '92ad3a70'))
+    const err = await callExpectingThrow(path, fragment('ses_second', '1db7920a'))
+
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toMatch(/already exist|duplicate|byte-equivalent/i)
+    expect((err as Error).message).toContain('Review System Final Design Decisions')
+  })
+
+  test('does not modify the file when an append is rejected for duplication', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'fragments.md')
+    const original = '<!-- fragment source=ses_a entry=11 -->\n## Existing\noriginal body\n'
+    writeFileSync(path, original)
+
+    const dup = '<!-- fragment source=ses_b entry=22 -->\n## Existing\noriginal body\n'
+    await callExpectingThrow(path, dup)
+
+    expect(readFileSync(path, 'utf8')).toBe(original)
+  })
+
+  test('allows fragments whose topic matches but body differs (legitimately distinct)', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'fragments.md')
+    await call(path, '<!-- fragment source=ses_a entry=11 -->\n## Decision\nuse option A\n')
+    await call(path, '<!-- fragment source=ses_b entry=22 -->\n## Decision\nactually use option B (decision changed)\n')
+
+    const content = readFileSync(path, 'utf8')
+    expect(content).toContain('use option A')
+    expect(content).toContain('actually use option B')
+  })
+
+  test('allows watermark-only appends regardless of existing fragments (no fragments to dedup)', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'fragments.md')
+    writeFileSync(path, '<!-- fragment source=ses_a entry=11 -->\n## Existing\nbody\n')
+
+    await call(path, '<!-- watermark source=ses_b entry=22 -->\n')
+
+    expect(readFileSync(path, 'utf8')).toContain('<!-- watermark source=ses_b')
+  })
+
+  test('refuses an append that contains a duplicate even if other fragments in the same append are new', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'fragments.md')
+    await call(path, '<!-- fragment source=ses_a entry=11 -->\n## ExistingTopic\nshared body\n')
+
+    const mixedAppend = [
+      '<!-- fragment source=ses_b entry=22 -->',
+      '## NewTopic',
+      'genuinely new body',
+      '',
+      '<!-- fragment source=ses_b entry=23 -->',
+      '## ExistingTopic',
+      'shared body',
+      '',
+    ].join('\n')
+
+    const err = await callExpectingThrow(path, mixedAppend)
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toContain('ExistingTopic')
+    expect(readFileSync(path, 'utf8')).not.toContain('NewTopic')
+  })
+
+  test('treats whitespace-only differences as duplicates (semantic equivalence)', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'fragments.md')
+    await call(path, '<!-- fragment source=ses_a entry=11 -->\n## Topic\nbody line\n')
+
+    const trailingSpaces = '<!-- fragment source=ses_b entry=22 -->\n## Topic\nbody line   \n'
+    const err = await callExpectingThrow(path, trailingSpaces)
+    expect((err as Error).message).toContain('Topic')
   })
 })

--- a/plugins/memory/append-tool.ts
+++ b/plugins/memory/append-tool.ts
@@ -1,17 +1,18 @@
-import { appendFile, mkdir, open, stat } from 'node:fs/promises'
+import { appendFile, mkdir, open, readFile, stat } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
 import { z } from 'zod'
 
 import { defineTool } from '@/plugin'
 
+import { fragmentContentHash, parseFragments } from './fragment-parser'
 import { detectSecrets } from './secret-detector'
 
 const NEWLINE_BYTE = 0x0a
 
 export const appendTool = defineTool({
   description:
-    'Append content to a file. Creates the file (and any missing parent directories) if needed. Never truncates or overwrites existing content. If the file is non-empty and does not already end in a newline, a single newline is inserted before the appended content so consecutive appends do not run together. Refuses to write content that contains recognizable credential patterns (API keys, tokens, private keys); record the variable name and how it was discovered, never the value.',
+    'Append content to a file. Creates the file (and any missing parent directories) if needed. Never truncates or overwrites existing content. If the file is non-empty and does not already end in a newline, a single newline is inserted before the appended content so consecutive appends do not run together. Refuses to write content that contains recognizable credential patterns (API keys, tokens, private keys); record the variable name and how it was discovered, never the value. Refuses to append a fragment whose topic+body already exists in the file (case-by-case; topics legitimately repeat across days, but byte-equivalent fragments within the same daily stream are duplicates by design).',
   parameters: z.object({
     path: z.string().describe('Path to the file to append to (relative or absolute).'),
     content: z.string().describe('Content to append, exactly as given.'),
@@ -26,6 +27,21 @@ export const appendTool = defineTool({
           `was discovered, not the value itself.`,
       )
     }
+    const incomingFragments = parseFragments(content)
+    if (incomingFragments.length > 0) {
+      const existingHashes = await readExistingFragmentHashes(path)
+      const duplicates = incomingFragments.filter((f) => existingHashes.has(fragmentContentHash(f)))
+      if (duplicates.length > 0) {
+        const topics = duplicates.map((d) => `"${d.topic}"`).join(', ')
+        throw new Error(
+          `Refusing to append: ${duplicates.length} fragment${duplicates.length === 1 ? '' : 's'} (${topics}) ` +
+            `already exist in ${path} with byte-equivalent content. The dreaming subagent will see the existing ` +
+            `fragment; do not write it again. If the new occurrence is genuinely informative (e.g. a recurrence ` +
+            `that establishes a pattern), write a fragment that says so explicitly rather than restating the ` +
+            `original.`,
+        )
+      }
+    }
     await mkdir(dirname(path), { recursive: true })
     const prefix = (await needsLeadingNewline(path)) ? '\n' : ''
     await appendFile(path, prefix + content, 'utf-8')
@@ -36,6 +52,17 @@ export const appendTool = defineTool({
     }
   },
 })
+
+async function readExistingFragmentHashes(path: string): Promise<Set<string>> {
+  let content: string
+  try {
+    content = await readFile(path, 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return new Set()
+    throw err
+  }
+  return new Set(parseFragments(content).map((f) => fragmentContentHash(f)))
+}
 
 async function needsLeadingNewline(path: string): Promise<boolean> {
   let info: Awaited<ReturnType<typeof stat>>

--- a/plugins/memory/fragment-parser.test.ts
+++ b/plugins/memory/fragment-parser.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test'
+
+import { fragmentContentHash, parseFragments } from './fragment-parser'
+
+describe('parseFragments', () => {
+  test('returns empty for content with no fragment markers', () => {
+    expect(parseFragments('# 2026-04-27\n\njust prose\n')).toEqual([])
+  })
+
+  test('extracts a single fragment with topic and body', () => {
+    const content = ['<!-- fragment source=ses_a entry=11111111 -->', '## Bug Fix', 'one line body', ''].join('\n')
+    const fragments = parseFragments(content)
+    expect(fragments).toHaveLength(1)
+    expect(fragments[0]).toEqual({ source: 'ses_a', entry: '11111111', topic: 'Bug Fix', body: 'one line body' })
+  })
+
+  test('extracts multiple fragments in document order', () => {
+    const content = [
+      '<!-- fragment source=ses_a entry=aaaa -->',
+      '## first',
+      'body one',
+      '',
+      '<!-- fragment source=ses_b entry=bbbb -->',
+      '## second',
+      'body two',
+      '',
+    ].join('\n')
+    const fragments = parseFragments(content)
+    expect(fragments.map((f) => f.topic)).toEqual(['first', 'second'])
+    expect(fragments.map((f) => f.entry)).toEqual(['aaaa', 'bbbb'])
+  })
+
+  test('stops a fragment body at the next fragment marker (does not bleed)', () => {
+    const content = [
+      '<!-- fragment source=ses_a entry=11 -->',
+      '## first',
+      'first body',
+      '<!-- fragment source=ses_a entry=22 -->',
+      '## second',
+      'second body',
+    ].join('\n')
+    const fragments = parseFragments(content)
+    expect(fragments[0]!.body).toBe('first body')
+    expect(fragments[1]!.body).toBe('second body')
+  })
+
+  test('stops a fragment body at the next bare watermark marker', () => {
+    const content = [
+      '<!-- fragment source=ses_a entry=11 -->',
+      '## first',
+      'first body',
+      '<!-- watermark source=ses_a entry=22 -->',
+    ].join('\n')
+    const fragments = parseFragments(content)
+    expect(fragments).toHaveLength(1)
+    expect(fragments[0]!.body).toBe('first body')
+  })
+
+  test('ignores bare watermark markers (they have no topic or body to parse)', () => {
+    const content = '<!-- watermark source=ses_a entry=quietday -->\n'
+    expect(parseFragments(content)).toEqual([])
+  })
+
+  test('skips a fragment header that has no topic line following it', () => {
+    const content = ['<!-- fragment source=ses_a entry=11 -->', '', 'body without topic'].join('\n')
+    expect(parseFragments(content)).toEqual([])
+  })
+
+  test('preserves multi-line bodies verbatim', () => {
+    const content = [
+      '<!-- fragment source=ses_a entry=11 -->',
+      '## Topic',
+      '**Claim**: one',
+      '**Evidence**: two',
+      '',
+      '**Implication**: three',
+      '',
+    ].join('\n')
+    const fragment = parseFragments(content)[0]!
+    expect(fragment.body).toBe(['**Claim**: one', '**Evidence**: two', '', '**Implication**: three'].join('\n'))
+  })
+
+  test('tolerates extra attributes on the fragment marker (forward compat)', () => {
+    const content = ['<!-- fragment source=ses_a entry=11 ts=2026-05-06T07:43:10Z -->', '## Topic', 'body', ''].join(
+      '\n',
+    )
+    expect(parseFragments(content)[0]).toMatchObject({ source: 'ses_a', entry: '11', topic: 'Topic', body: 'body' })
+  })
+})
+
+describe('fragmentContentHash', () => {
+  test('produces a stable hex sha256 string', () => {
+    const hash = fragmentContentHash({ topic: 'Topic', body: 'body' })
+    expect(hash).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  test('two fragments with identical topic+body hash to the same value', () => {
+    const a = { topic: 'My Topic', body: 'shared body' }
+    const b = { topic: 'My Topic', body: 'shared body' }
+    expect(fragmentContentHash(a)).toBe(fragmentContentHash(b))
+  })
+
+  test('different topics with the same body produce different hashes', () => {
+    expect(fragmentContentHash({ topic: 'a', body: 'shared' })).not.toBe(
+      fragmentContentHash({ topic: 'b', body: 'shared' }),
+    )
+  })
+
+  test('different bodies with the same topic produce different hashes', () => {
+    expect(fragmentContentHash({ topic: 'shared', body: 'a' })).not.toBe(
+      fragmentContentHash({ topic: 'shared', body: 'b' }),
+    )
+  })
+
+  test('ignores trailing whitespace on body lines (semantic equivalence)', () => {
+    expect(fragmentContentHash({ topic: 'T', body: 'line  ' })).toBe(fragmentContentHash({ topic: 'T', body: 'line' }))
+  })
+
+  test('ignores leading and trailing blank lines on body (semantic equivalence)', () => {
+    expect(fragmentContentHash({ topic: 'T', body: '\n\nbody\n\n' })).toBe(
+      fragmentContentHash({ topic: 'T', body: 'body' }),
+    )
+  })
+
+  test('does NOT collapse near-duplicates that differ in actual content', () => {
+    expect(fragmentContentHash({ topic: 'Decision', body: 'use option A because faster' })).not.toBe(
+      fragmentContentHash({ topic: 'Decision', body: 'use option B because faster' }),
+    )
+  })
+})

--- a/plugins/memory/fragment-parser.ts
+++ b/plugins/memory/fragment-parser.ts
@@ -1,0 +1,67 @@
+import { createHash } from 'node:crypto'
+
+export type Fragment = {
+  readonly source: string
+  readonly entry: string
+  readonly topic: string
+  readonly body: string
+}
+
+const FRAGMENT_HEADER = /<!--\s*fragment\s+source=(\S+)\s+entry=(\S+)(?:\s+\S+=\S+)*\s*-->/g
+
+export function parseFragments(content: string): Fragment[] {
+  const fragments: Fragment[] = []
+  const headers: { source: string; entry: string; index: number; endIndex: number }[] = []
+  for (const match of content.matchAll(FRAGMENT_HEADER)) {
+    if (match.index === undefined) continue
+    headers.push({
+      source: match[1]!,
+      entry: match[2]!,
+      index: match.index,
+      endIndex: match.index + match[0].length,
+    })
+  }
+
+  for (let i = 0; i < headers.length; i++) {
+    const header = headers[i]!
+    const nextStart = headers[i + 1]?.index ?? content.length
+    const between = content.slice(header.endIndex, nextStart)
+    const parsed = parseTopicAndBody(between)
+    if (parsed === null) continue
+    fragments.push({ source: header.source, entry: header.entry, topic: parsed.topic, body: parsed.body })
+  }
+  return fragments
+}
+
+export function fragmentContentHash(fragment: Pick<Fragment, 'topic' | 'body'>): string {
+  const normalized = `${normalize(fragment.topic)}\n\n${normalize(fragment.body)}`
+  return createHash('sha256').update(normalized, 'utf8').digest('hex')
+}
+
+function parseTopicAndBody(between: string): { topic: string; body: string } | null {
+  const lines = between.split('\n')
+  let i = 0
+  while (i < lines.length && lines[i]!.trim() === '') i++
+  if (i >= lines.length) return null
+  const topicLine = lines[i]!
+  const topicMatch = topicLine.match(/^##\s+(.+?)\s*$/)
+  if (topicMatch === null) return null
+  const topic = topicMatch[1]!
+
+  const bodyLines: string[] = []
+  for (let j = i + 1; j < lines.length; j++) {
+    const line = lines[j]!
+    if (/<!--\s*(?:fragment|watermark)\s/.test(line)) break
+    bodyLines.push(line)
+  }
+  while (bodyLines.length > 0 && bodyLines[bodyLines.length - 1]!.trim() === '') bodyLines.pop()
+  return { topic, body: bodyLines.join('\n') }
+}
+
+function normalize(value: string): string {
+  return value
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .join('\n')
+    .trim()
+}

--- a/plugins/memory/memory-logger.test.ts
+++ b/plugins/memory/memory-logger.test.ts
@@ -143,8 +143,14 @@ describe('MEMORY_LOGGER_SYSTEM_PROMPT', () => {
     expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/Forbidden:.*GH_TOKEN=/s)
   })
 
-  test('warns the subagent that the append tool enforces this rule', () => {
-    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/append.*refuse|refuse.*append/i)
+  test('warns the subagent that the append tool enforces the secret-handling rule', () => {
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/append.*refuse.*credential|append.*refuse.*recognizable/i)
+  })
+
+  test('warns about the append-tool dedup rule (content-equality, not marker-equality)', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toMatch(/byte-equivalent|content-equality|same daily stream/)
+    expect(lower).toMatch(/refuse.*fragment|reject.*fragment/)
   })
 })
 

--- a/plugins/memory/memory-logger.ts
+++ b/plugins/memory/memory-logger.ts
@@ -89,6 +89,8 @@ Before reading the transcript, read \`MEMORY.md\` and the current \`memory/yyyy-
 
 Light dedup, not strict dedup. When unsure whether something is "already known," err on writing it. Dreaming will collapse duplicates.
 
+The \`append\` tool refuses byte-equivalent fragments within the same daily stream — if your fragment's topic+body is identical to one already in today's file (modulo whitespace), the tool will reject it and you must rewrite. Two reasonable rewrites: (1) skip the fragment entirely, (2) frame the new occurrence explicitly as "this is the second time today" with a different topic. Do not retry an identical fragment with a different \`entry=\` hoping it will land — content-equality, not marker-equality, is what's checked.
+
 # Fragment format
 
 Each fragment is an HTML comment marker followed by a topic heading and a body:


### PR DESCRIPTION
## Why

Daily memory streams contain many byte-equivalent fragments. From a real `2026-05-06` log:

- "Review System Final Design Decisions" — written twice (entries `92ad3a70` and `1db7920a`), bodies byte-identical
- "Project Context: Review System Implementation" — duplicated at the same two entry IDs
- "Tool Limitation: Slack Attachments Not Visible" — twice at the same entry
- "Response Discipline: Three Corrections Applied" — twice (entries `f6a680a2` and `5a2f5a59`)
- "vReview Widget Loading: Direct Script vs Cafe24 App Injection" — twice in the same session

Two failure modes produce these:
1. **Per-session inFlightKey**: two concurrent sessions can both spawn a memory-logger, both read the same MEMORY.md and same daily file, then both write a near-identical fragment. There is no read-after-write check.
2. **Same-session retries**: the LLM is non-deterministic; a second run within the same session can produce semantically identical fragments because the watermark advancement only fires on the latest entry id, leaving room for re-evaluation overlap.

Each duplicate is force-committed by dreaming and dilutes MEMORY.md.

## What changed

`plugins/memory/fragment-parser.ts` (new) — extracts `(source, entry, topic, body)` tuples from a stream content blob. Stops a body at the next fragment or watermark marker so adjacency does not bleed. Tolerates extra attributes on the marker (forward-compat for fields like `ts=` that future PRs may add). Computes `sha256(normalize(topic) + "\n\n" + normalize(body))` where normalization trims trailing whitespace per line and leading/trailing blank lines.

`plugins/memory/append-tool.ts` — before writing, parses the incoming content for fragments, reads the existing file, and refuses the append if any incoming fragment hashes to an existing one. The error names the duplicate topics so the LLM can rewrite. Watermark-only appends pass through unchanged. The whole append is refused, not selectively filtered: filtering would silently mutate the LLM's output in a non-obvious way.

`plugins/memory/memory-logger.ts` — adds a paragraph in the *Read existing memory first* section explaining the rule and that retrying with a different `entry=` will not bypass it (content-equality, not marker-equality, is what's checked).

## Test layer

- `fragment-parser.test.ts` (new, 17 tests) — extraction order, marker boundaries, multi-line bodies, watermark-only files, malformed headers, hash determinism, semantic-equivalence under whitespace, no false collapses on near-duplicates with substantively different bodies.
- `append-tool.test.ts` — refuses the winky duplicate scenario, does not modify the file on rejection, allows topic-equivalent / body-different fragments through, allows watermark-only appends regardless of existing fragments, refuses an append that contains *any* duplicate even when other fragments in the same append are new, treats trailing-whitespace differences as duplicates.
- `memory-logger.test.ts` — system prompt invariant (warns about content-equality refusal).

## Verification

```
bun run lint     → 0 warnings, 0 errors
bun run format   → 286 files clean
bun run typecheck → ok
bun test         → 1640 pass, 0 fail (was 1617 on base, +23 new)
```

## Interaction with PR #61

Independent. PR #61 adds a secret-detector that runs first (any append with a recognizable secret pattern is refused before dedup is even consulted). Both checks now run on every append; the order in `append-tool.ts` is secrets → dedup → write. No merge ordering required.

## What this does NOT change

- Cross-session race: two parallel memory-logger runs on the same agent will still both *try* to write the duplicate. One wins, the other gets the rejection error and must rewrite. PR #62 (in progress) addresses the underlying cause by serializing memory-logger per `agentDir`. This PR is the safety net regardless of which inFlightKey is used.
- The `dreaming` subagent's `write` to MEMORY.md is not gated. Dreaming consolidates fragments into topic-grouped paragraphs, so the MEMORY.md format is structurally different from a daily stream and the same hash function would not apply.