### PR TITLE
Clear Slack typing on drain stop, not only on send

### DIFF
--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -74,7 +74,7 @@ describe('createTypingCallback', () => {
       }),
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     })
-    await cb({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })
+    await cb({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null, phase: 'tick' })
     expect(calls).toHaveLength(1)
     expect(calls[0]!.url).toBe('https://discord.com/api/v10/channels/c1/typing')
     expect(calls[0]!.init.method).toBe('POST')
@@ -93,7 +93,7 @@ describe('createTypingCallback', () => {
       }),
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     })
-    await cb({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 'thr-9' })
+    await cb({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 'thr-9', phase: 'tick' })
     expect(calls[0]!.url).toBe('https://discord.com/api/v10/channels/thr-9/typing')
   })
 
@@ -108,7 +108,7 @@ describe('createTypingCallback', () => {
       }),
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     })
-    await cb({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })
+    await cb({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null, phase: 'tick' })
     expect(calls).toHaveLength(0)
   })
 
@@ -125,7 +125,7 @@ describe('createTypingCallback', () => {
       }),
       logger: { info: () => {}, warn: (m) => warns.push(m), error: () => {} },
     })
-    await cb({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })
+    await cb({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null, phase: 'tick' })
     expect(warns.some((m) => m.includes('429'))).toBe(true)
   })
 
@@ -144,7 +144,7 @@ describe('createTypingCallback', () => {
       }),
       logger: { info: () => {}, warn: (m) => warns.push(m), error: () => {} },
     })
-    await cb({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })
+    await cb({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null, phase: 'tick' })
     expect(warns.some((m) => m.includes('network down'))).toBe(true)
   })
 
@@ -159,7 +159,22 @@ describe('createTypingCallback', () => {
       }),
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     })
-    await cb({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })
+    await cb({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null, phase: 'tick' })
+    expect(calls).toHaveLength(0)
+  })
+
+  test('phase=stop is a no-op (Discord typing auto-expires; extra POST would re-arm it)', async () => {
+    const cb = createTypingCallback({
+      token: 'tok',
+      configRef: () => ({
+        allow: ['*'],
+        engagement: { trigger: ['mention'], stickiness: 'off' },
+        enabled: true,
+        history: defaultHistoryConfig(),
+      }),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    await cb({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null, phase: 'stop' })
     expect(calls).toHaveLength(0)
   })
 })

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -92,6 +92,11 @@ export function createTypingCallback(deps: {
   const { token, configRef, logger, formatChannelTag } = deps
   return async (target: TypingTarget): Promise<void> => {
     if (target.adapter !== 'discord-bot') return
+    // Discord's typing indicator auto-expires after ~10s on Discord's side,
+    // and there is no API to clear it explicitly. The 'stop' phase exists
+    // for platforms (Slack) that need an explicit clear; for Discord it
+    // would be extra POSTs that confuse the indicator into reappearing.
+    if (target.phase === 'stop') return
     const config = configRef()
     if (!isAllowed(config.allow, target.workspace, target.chat)) return
     // Threads are channels in Discord, so the typing endpoint takes the

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -46,23 +46,29 @@ describe('slack-bot adapter (unit-level pure helpers)', () => {
 
 describe('slack-bot createTypingCallback', () => {
   type SetStatusCall = { channel: string; threadTs: string; status: string }
+  type ClearCall = { chat: string; thread: string | null | undefined }
 
   function makeFakeTracker(behavior: 'ok' | 'reject' = 'ok'): {
     tracker: {
       setStatus: (chat: string, threadTs: string, status: string) => Promise<void>
-      clearAfterSend: () => Promise<void>
+      clearAfterSend: (chat: string, thread: string | null | undefined) => Promise<void>
     }
     calls: SetStatusCall[]
+    clears: ClearCall[]
   } {
     const calls: SetStatusCall[] = []
+    const clears: ClearCall[] = []
     return {
       calls,
+      clears,
       tracker: {
         setStatus: async (channel, threadTs, status) => {
           calls.push({ channel, threadTs, status })
           if (behavior === 'reject') throw new Error('channel_not_found')
         },
-        clearAfterSend: async () => {},
+        clearAfterSend: async (chat, thread) => {
+          clears.push({ chat, thread })
+        },
       },
     }
   }
@@ -81,7 +87,13 @@ describe('slack-bot createTypingCallback', () => {
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     })
     // when
-    await cb({ adapter: 'slack-bot', workspace: 'T0ACME', chat: 'C0CHANNEL', thread: '1700000000.000100' })
+    await cb({
+      adapter: 'slack-bot',
+      workspace: 'T0ACME',
+      chat: 'C0CHANNEL',
+      thread: '1700000000.000100',
+      phase: 'tick',
+    })
     // then
     expect(calls).toEqual([{ channel: 'C0CHANNEL', threadTs: '1700000000.000100', status: 'is typing...' }])
   })
@@ -101,7 +113,7 @@ describe('slack-bot createTypingCallback', () => {
       logger: { info: (m) => infos.push(m), warn: () => {}, error: () => {} },
     })
     // when
-    await cb({ adapter: 'slack-bot', workspace: 'T0ACME', chat: 'C0CHANNEL', thread: null })
+    await cb({ adapter: 'slack-bot', workspace: 'T0ACME', chat: 'C0CHANNEL', thread: null, phase: 'tick' })
     // then
     expect(calls).toHaveLength(0)
     expect(infos.some((m) => m.includes('top-level chat'))).toBe(true)
@@ -131,7 +143,13 @@ describe('slack-bot createTypingCallback', () => {
       logger: { info: () => {}, warn: (m) => warns.push(m), error: () => {} },
     })
     // when
-    await cb({ adapter: 'slack-bot', workspace: 'T0ACME', chat: 'C0CHANNEL', thread: '1700000000.000100' })
+    await cb({
+      adapter: 'slack-bot',
+      workspace: 'T0ACME',
+      chat: 'C0CHANNEL',
+      thread: '1700000000.000100',
+      phase: 'tick',
+    })
     // then
     expect(calls).toHaveLength(1)
     expect(warns.some((m) => m.includes('typing') && m.includes('channel_not_found'))).toBe(true)
@@ -153,7 +171,13 @@ describe('slack-bot createTypingCallback', () => {
       logger: { info: (m) => infos.push(m), warn: (m) => warns.push(m), error: () => {} },
     })
     // when
-    await cb({ adapter: 'slack-bot', workspace: 'T0ACME', chat: 'C0CHANNEL', thread: '1700000000.000100' })
+    await cb({
+      adapter: 'slack-bot',
+      workspace: 'T0ACME',
+      chat: 'C0CHANNEL',
+      thread: '1700000000.000100',
+      phase: 'tick',
+    })
     // then
     expect(calls).toHaveLength(0)
     expect(infos).toHaveLength(0)
@@ -175,10 +199,84 @@ describe('slack-bot createTypingCallback', () => {
       logger: { info: (m) => infos.push(m), warn: () => {}, error: () => {} },
     })
     // when
-    await cb({ adapter: 'discord-bot', workspace: '1', chat: '2', thread: '3' })
+    await cb({ adapter: 'discord-bot', workspace: '1', chat: '2', thread: '3', phase: 'tick' })
     // then
     expect(calls).toHaveLength(0)
     expect(infos).toHaveLength(0)
+  })
+
+  test('phase=stop in a thread routes to clearAfterSend (not setStatus)', async () => {
+    // given
+    const { tracker, calls, clears } = makeFakeTracker()
+    const cb = createTypingCallback({
+      typingTracker: tracker,
+      configRef: () => ({
+        allow: ['*'],
+        engagement: { trigger: ['mention'], stickiness: 'off' },
+        enabled: true,
+        history: defaultHistoryConfig(),
+      }),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    // when
+    await cb({
+      adapter: 'slack-bot',
+      workspace: 'T0ACME',
+      chat: 'C0CHANNEL',
+      thread: '1700000000.000100',
+      phase: 'stop',
+    })
+    // then
+    expect(calls).toHaveLength(0)
+    expect(clears).toEqual([{ chat: 'C0CHANNEL', thread: '1700000000.000100' }])
+  })
+
+  test('phase=stop on a top-level chat is a silent no-op (no clearAfterSend, no log)', async () => {
+    // given
+    const { tracker, calls, clears } = makeFakeTracker()
+    const infos: string[] = []
+    const cb = createTypingCallback({
+      typingTracker: tracker,
+      configRef: () => ({
+        allow: ['*'],
+        engagement: { trigger: ['mention'], stickiness: 'off' },
+        enabled: true,
+        history: defaultHistoryConfig(),
+      }),
+      logger: { info: (m) => infos.push(m), warn: () => {}, error: () => {} },
+    })
+    // when
+    await cb({ adapter: 'slack-bot', workspace: 'T0ACME', chat: 'C0CHANNEL', thread: null, phase: 'stop' })
+    // then
+    expect(calls).toHaveLength(0)
+    expect(clears).toHaveLength(0)
+    expect(infos).toHaveLength(0)
+  })
+
+  test('phase=stop is gated by allow rules (denied chats trigger no clear)', async () => {
+    // given
+    const { tracker, calls, clears } = makeFakeTracker()
+    const cb = createTypingCallback({
+      typingTracker: tracker,
+      configRef: () => ({
+        allow: ['team:T0OTHER'],
+        engagement: { trigger: ['mention'], stickiness: 'off' },
+        enabled: true,
+        history: defaultHistoryConfig(),
+      }),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    // when
+    await cb({
+      adapter: 'slack-bot',
+      workspace: 'T0ACME',
+      chat: 'C0CHANNEL',
+      thread: '1700000000.000100',
+      phase: 'stop',
+    })
+    // then
+    expect(calls).toHaveLength(0)
+    expect(clears).toHaveLength(0)
   })
 })
 

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -162,7 +162,7 @@ export function createSlackTypingTracker(deps: {
 }
 
 export function createTypingCallback(deps: {
-  typingTracker: Pick<SlackTypingTracker, 'setStatus'>
+  typingTracker: Pick<SlackTypingTracker, 'setStatus' | 'clearAfterSend'>
   configRef: () => ChannelAdapterConfig
   logger: SlackBotAdapterLogger
   formatChannelTag?: (workspace: string, chat: string) => Promise<string>
@@ -176,7 +176,11 @@ export function createTypingCallback(deps: {
       ? await formatChannelTag(target.workspace, target.thread ?? target.chat)
       : `channel=${target.thread ?? target.chat}`
     if (target.thread === undefined || target.thread === null || target.thread === '') {
-      logger.info(`[slack-bot] typing (no-op, top-level chat) ${tag}`)
+      if (target.phase === 'tick') logger.info(`[slack-bot] typing (no-op, top-level chat) ${tag}`)
+      return
+    }
+    if (target.phase === 'stop') {
+      await typingTracker.clearAfterSend(target.chat, target.thread)
       return
     }
     await typingTracker.setStatus(target.chat, target.thread, 'is typing...')

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1079,6 +1079,34 @@ describe('ChannelRouter typing indicator', () => {
     await router.__testing!.fireTypingHeartbeat(KEY)
     expect(calls).toHaveLength(1)
   })
+
+  test('fires phase=stop exactly once when drain completes (so adapters can clear)', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    const phases: Array<'tick' | 'stop'> = []
+    router.registerTyping('discord-bot', async (target) => {
+      phases.push(target.phase)
+    })
+    // when
+    await router.route(inbound({ text: 'hi bot' }))
+    expect(phases).toEqual(['tick'])
+    await router.__testing!.flushDebounce(KEY)
+    // then
+    expect(phases).toEqual(['tick', 'stop'])
+    expect(router.__testing!.isTypingActive(KEY)).toBe(false)
+  })
+
+  test('phase=stop carries the same chat/thread coordinates as ticks', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    const stopTargets: Array<{ chat: string; thread: string | null | undefined }> = []
+    router.registerTyping('discord-bot', async (target) => {
+      if (target.phase === 'stop') stopTargets.push({ chat: target.chat, thread: target.thread })
+    })
+    await router.route(inbound({ thread: 'thread-7', text: 'hi bot' }))
+    await router.__testing!.flushDebounce({ ...KEY, thread: 'thread-7' })
+    expect(stopTargets).toEqual([{ chat: 'c1', thread: 'thread-7' }])
+  })
 })
 
 describe('ChannelRouter plugin lifecycle hooks', () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -223,7 +223,7 @@ export type ChannelRouter = {
   liveCount: () => number
   __testing?: {
     flushDebounce: (key: ChannelKey) => Promise<void>
-    fireTypingHeartbeat: (key: ChannelKey) => Promise<void>
+    fireTypingHeartbeat: (key: ChannelKey, phase?: 'tick' | 'stop') => Promise<void>
     isTypingActive: (key: ChannelKey) => boolean
     runIdleGc: () => Promise<void>
   }
@@ -610,7 +610,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
   const regenerateOrigin = (live: LiveSession): SessionOrigin => buildLiveOrigin(live)
 
-  const fireTyping = async (live: LiveSession): Promise<void> => {
+  const fireTyping = async (live: LiveSession, phase: 'tick' | 'stop'): Promise<void> => {
     const callbacks = typingCallbacks.get(live.key.adapter)
     if (!callbacks || callbacks.size === 0) return
     // Snapshot before iterating: a callback could unregister mid-call.
@@ -620,6 +620,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       workspace: live.key.workspace,
       chat: live.key.chat,
       thread: live.key.thread,
+      phase,
     }
     await Promise.all(
       snapshot.map((cb) =>
@@ -634,13 +635,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (live.typingTimer || live.destroyed) return
     // Fire immediately so the indicator appears on the very first inbound,
     // not 8 seconds later.
-    void fireTyping(live)
+    void fireTyping(live, 'tick')
     live.typingTimer = setInterval(() => {
       if (live.destroyed) {
         stopTypingHeartbeat(live)
         return
       }
-      void fireTyping(live)
+      void fireTyping(live, 'tick')
     }, TYPING_HEARTBEAT_MS)
   }
 
@@ -648,6 +649,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (!live.typingTimer) return
     clearInterval(live.typingTimer)
     live.typingTimer = null
+    // Fire 'stop' phase even when destroyed: adapters need the chance to
+    // clear platform-side state (e.g. Slack's 2-min server timeout) on
+    // teardown. The FIFO inside the slack adapter ensures this clear lands
+    // AFTER any in-flight 'tick' from the heartbeat that just stopped.
+    void fireTyping(live, 'stop')
   }
 
   const fireSessionIdle = async (live: LiveSession): Promise<void> => {
@@ -1212,10 +1218,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.firstUnprocessedAt = 0
         await drain(live)
       },
-      fireTypingHeartbeat: async (key: ChannelKey) => {
+      fireTypingHeartbeat: async (key: ChannelKey, phase: 'tick' | 'stop' = 'tick') => {
         const live = liveSessions.get(channelKeyId(key))
         if (!live) return
-        await fireTyping(live)
+        await fireTyping(live, phase)
       },
       isTypingActive: (key: ChannelKey) => {
         const live = liveSessions.get(channelKeyId(key))

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -93,6 +93,14 @@ export type TypingTarget = {
   workspace: string
   chat: string
   thread?: string | null
+  // 'tick' is the heartbeat fired during debouncing/generation; adapters
+  // should set the indicator visible. 'stop' is fired exactly once when the
+  // router decides the turn is over (drain finally, /stop command, or
+  // teardown); adapters should explicitly clear the indicator if their
+  // platform doesn't auto-expire it. Without 'stop', a 'tick' that lands
+  // after the agent's final reply but before the drain returns will leave
+  // the indicator on for Slack's full 2-minute server timeout.
+  phase: 'tick' | 'stop'
 }
 
 export type TypingCallback = (target: TypingTarget) => Promise<void>


### PR DESCRIPTION
## Symptom

Even after PR #52 (\`Clear Slack typing indicator after every send\`), the Slack \`is typing...\` indicator can persist long after the bot finishes replying. Operators see a stuck indicator on threads that are clearly idle.

## Root cause (proven by PR #60's instrumentation in production)

PR #52 added an explicit \`setStatus(\"\")\` after every successful \`postMessage\` to defeat the heartbeat-during-generation race. That fix is correct for the race it targeted. **A second, distinct race remained uncovered.**

A heartbeat tick can fire AFTER the agent's final \`channel_reply\` lands but BEFORE \`drain()\`'s finally block runs (between the agent's last tool call returning and \`session.prompt()\` resolving on post-reply finalization). The \`clearAfterSend\` from the send is therefore queued first; the late heartbeat's \`setStatus(\"is typing...\")\` is queued second. \`stopTypingHeartbeat\` only stops future ticks — it doesn't clear the queue. The FIFO's tail is \`is typing...\`, and Slack waits its full 2-minute server timeout before clearing.

Concrete example from production logs (\`winky\` agent, \`channel=C0AD85G5H09\`, \`thread=1778056264.784349\`):

\`\`\`
call=11 status=\"\"             queued (clearAfterSend after a send)
call=11 sending → ok
call=12 status=\"is typing...\" queued (heartbeat tick)
call=12 sending
prompted elapsed_ms=31835            (drain finished)
call=12 ok
[no further activity for 4+ minutes; indicator stuck]
\`\`\`

## Fix

Promote the typing heartbeat from a fire-only signal into a **two-phase contract**:

- **\`phase: 'tick'\`** — fired by the heartbeat \`setInterval\` and \`route()\` (existing behavior).
- **\`phase: 'stop'\`** — fired exactly once by \`stopTypingHeartbeat\` after the interval is cleared, on every \`drain\` finally / \`/stop\` command / teardown.

Adapters route the phases:

- **slack-bot**: \`'tick'\` → \`tracker.setStatus(\"is typing...\")\`; \`'stop'\` → \`tracker.clearAfterSend\`. Both go through the existing per-\`(chat, thread)\` FIFO, so the \`'stop'\` clear is guaranteed to land **after** any in-flight \`'tick'\` for the same thread. The \`outboundCallback\`'s \`clearAfterSend\` is **preserved** — it still defeats the heartbeat-during-generation race PR #52 fixed; the two clears are complementary, not redundant.
- **discord-bot**: \`'tick'\` → \`POST /typing\`; \`'stop'\` → no-op. Discord's typing auto-expires after ~10s and there is no clear API; an extra POST would re-arm the indicator.

## Tests

| Test | Where | What it locks in |
| --- | --- | --- |
| \`fires phase=stop exactly once when drain completes\` | router.test.ts | mutation guard for \`void fireTyping(live, 'stop')\` in \`stopTypingHeartbeat\` |
| \`phase=stop carries the same chat/thread coordinates as ticks\` | router.test.ts | thread is preserved through stop dispatch |
| \`phase=stop in a thread routes to clearAfterSend (not setStatus)\` | slack-bot.test.ts | mutation guard for the \`stop\` branch in \`createTypingCallback\` |
| \`phase=stop on a top-level chat is a silent no-op\` | slack-bot.test.ts | DM/no-thread case doesn't trigger spurious clears or noisy logs |
| \`phase=stop is gated by allow rules\` | slack-bot.test.ts | denied chats don't leak setStatus calls via the stop path |
| \`phase=stop is a no-op for Discord\` | discord-bot.test.ts | Discord doesn't double-POST on stop |

**Mutation-tested:**
- Removing \`void fireTyping(live, 'stop')\` in \`stopTypingHeartbeat\` → 2 router tests fail.
- Removing the \`phase === 'stop'\` branch in slack-bot's \`createTypingCallback\` → 1 adapter test fails.

## Verification

\`\`\`
bun run typecheck    # clean
bun run lint         # 0 warnings, 0 errors
bun run format:check # all matched files use correct format
bun test             # 1614 pass, 0 fail (was 1608 before; +6 new tests)
\`\`\`

## Out of scope

- **The DM symptom** (no typing indicator at all in Slack DMs) is a separate bug in the classifier (\`slack-bot-classify.ts:76\` sets \`thread = null\` for DMs because Slack DMs lack \`thread_ts\`, and \`assistant.threads.setStatus\` requires one). Fixing that requires materializing an Assistant thread via \`assistant.threads.start\` — a larger change to scope and trade off.
- **PR #60 (\`Log Slack typing setStatus lifecycle for diagnostics\`)** is the instrumentation that proved this bug exists. This PR is the targeted fix; PR #60 is independent and either can land first. If PR #60 lands first, this PR rebases trivially. If both land, the production logs continue to give us visibility into any further wire-level oddities.