### PR TITLE
Engage on thread replies once the bot is in the thread

### DIFF
--- a/src/channels/engagement.test.ts
+++ b/src/channels/engagement.test.ts
@@ -32,10 +32,10 @@ function participant(authorId: string, lastMessageAt = 0): ChannelParticipant {
 const crowded: readonly ChannelParticipant[] = [participant('alice'), participant('bob')]
 
 function decideEngagement(
-  input: Omit<EngagementInput, 'membership' | 'selfAliases'> &
-    Partial<Pick<EngagementInput, 'membership' | 'selfAliases'>>,
+  input: Omit<EngagementInput, 'membership' | 'selfAliases' | 'botInThread'> &
+    Partial<Pick<EngagementInput, 'membership' | 'selfAliases' | 'botInThread'>>,
 ): ReturnType<typeof decideEngagementRaw> {
-  return decideEngagementRaw({ membership: null, selfAliases: [], ...input })
+  return decideEngagementRaw({ membership: null, selfAliases: [], botInThread: false, ...input })
 }
 
 function inbound(over: Partial<InboundMessage> = {}): InboundMessage {
@@ -755,6 +755,60 @@ describe('decideEngagement (targets-others suppressors)', () => {
       ledger,
       now: 0,
       participants: [participant('rio')],
+    })
+    expect(decision).toBe('observe')
+  })
+
+  test('engages in a thread we already participate in even when parent_user_id resolves to a human (PR #58 follow-up)', () => {
+    // Incident: a human starts a thread by @-mentioning the bot. The bot
+    // replies (mention trigger). The human follows up in the thread. Slack
+    // surfaces parent_user_id = the human (the thread ROOT author, not the
+    // immediate parent), so the adapter sets replyToOtherMessageId. Without
+    // botInThread, the suppressor at the bottom of decideEngagement drops
+    // the follow-up — silently, with no log line — and the bot appears dead
+    // for the rest of the thread. The fix: once botInThread is true, the
+    // replyToOtherMessageId suppressor stops firing, because this is no
+    // longer a side conversation between humans. The two-humans regression
+    // test above still passes because that case has botInThread=false.
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({
+        authorId: 'human-asker',
+        text: 'follow-up question',
+        thread: 'human-asker-thread-root-ts',
+        replyToBotMessageId: null,
+        replyToOtherMessageId: 'human-asker-thread-root-ts',
+      }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: [participant('human-asker')],
+      botInThread: true,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('mentionsOthers still suppresses even when bot is in the thread (only the replyToOther gate is conditional)', () => {
+    // botInThread relaxes the parent-author gate (which is wrong-ish for
+    // Slack semantics) but NOT the explicit-tag-of-someone-else gate. If
+    // the human is now @-mentioning a third party in the thread, the bot
+    // should stay quiet — explicit tagging is unambiguous, parent_user_id
+    // is not.
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({
+        authorId: 'human-asker',
+        text: 'hey <@UBOB> can you help here?',
+        thread: 'thread-root-ts',
+        mentionsOthers: true,
+      }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: crowded,
+      botInThread: true,
     })
     expect(decision).toBe('observe')
   })

--- a/src/channels/engagement.ts
+++ b/src/channels/engagement.ts
@@ -64,10 +64,22 @@ export type EngagementInput = {
   // generic ("bot", "ai") it WILL produce false matches and the operator
   // owns curation.
   selfAliases: readonly string[]
+  // True when the bot has previously sent into this exact thread (or
+  // channel — the suppressor only checks this when the message is a
+  // thread reply, but the field is general). Set by the router from
+  // `live.successfulChannelSends > 0` plus any bot-authored prefetched
+  // history in `contextBuffer`. Suppresses the `replyToOtherMessageId`
+  // gate below: once the bot is participating in a thread, subsequent
+  // replies are part of OUR conversation even when `parent_user_id` (the
+  // thread root author) is a human. Without this, a thread that started
+  // with a human @-mention drops every follow-up reply because Slack's
+  // `parent_user_id` always points at the (human) thread root, never the
+  // bot's intermediate replies — see incident in PR #58 follow-up.
+  botInThread: boolean
 }
 
 export function decideEngagement(input: EngagementInput): EngagementDecision {
-  const { message, config, key, ledger, now, participants, selfAliases } = input
+  const { message, config, key, ledger, now, participants, selfAliases, botInThread } = input
 
   if (config.trigger.includes('dm') && message.isDm) return 'engage'
   if (config.trigger.includes('mention') && message.isBotMention) return 'engage'
@@ -132,7 +144,18 @@ export function decideEngagement(input: EngagementInput): EngagementDecision {
   // (which already applies symmetrically to humans and bots) plus this
   // fallback fix.
   if (message.mentionsOthers) return 'observe'
-  if (message.replyToOtherMessageId !== null) return 'observe'
+  // The replyToOtherMessageId suppressor exists to keep the bot out of
+  // human-to-human side conversations in busy channels. But Slack's
+  // `parent_user_id` is the THREAD ROOT author, not the immediate parent
+  // author — so a thread the human starts by @-mentioning the bot
+  // produces `replyToOtherMessageId` on every follow-up (root author is
+  // the human, not us), which would silently drop every reply after the
+  // first. Once the bot has actually sent into this thread, subsequent
+  // replies are part of OUR conversation regardless of who started it,
+  // so the suppressor stops applying. The two-humans-in-a-thread case
+  // PR #58 fixed is preserved because the bot never sent into that
+  // thread in the first place.
+  if (message.replyToOtherMessageId !== null && !botInThread) return 'observe'
 
   // Plain-text peer-bot addressing as a fallback suppressor. We've reached
   // here because the message lacks a structural mention/reply/dm AND

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -843,6 +843,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       participants: live.participants,
       membership,
       selfAliases: computeSelfAliases(),
+      botInThread: hasBotParticipated(live),
     })
 
     if (decision === 'observe') {
@@ -889,6 +890,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     ) {
       live.loopGuardActive = true
     }
+  }
+
+  const hasBotParticipated = (live: LiveSession): boolean => {
+    if (live.successfulChannelSends > 0) return true
+    for (const item of live.contextBuffer) {
+      if (item.authorIsBot) return true
+    }
+    return false
   }
 
   const observe = (live: LiveSession, event: InboundMessage): void => {


### PR DESCRIPTION
## Why

PR #58 introduced a regression: the agent stopped responding in any Slack thread that a human started by @-mentioning the bot. The first reply went through (mention trigger fires); every subsequent follow-up was silently dropped — no log line, no error, just silence.

The root cause is a misread of Slack's `parent_user_id` semantics. The shim's own type comment (`src/channels/adapters/agent-messenger-slack-shim.ts:38–44`) is explicit:

> Slack populates this on every reply within a thread and sets it to the user id of the message that started the thread (i.e. the author of `thread_ts`).

`parent_user_id` is the **thread root** author, not the immediate parent author. PR #58's classifier set `replyToOtherMessageId = thread_ts` whenever `parent_user_id !== botUserId`. The suppressor at `src/channels/engagement.ts:135` (pre-this-PR) then returned `'observe'`.

This correctly handles two humans chatting in a thread they started — the bot has never sent there and should stay quiet. But it also suppresses the common @-mention flow:

1. Human @-mentions bot in a channel → bot replies, starting a thread (mention trigger).
2. Human follows up in the thread.
3. Slack delivers `parent_user_id = the human` (the thread root author — always the human in this flow).
4. Classifier sets `replyToOtherMessageId = thread_root_ts`.
5. Suppressor at line 135 returns `'observe'`.
6. Bot is silent for every subsequent reply in that thread.

PR #58's regression test at `src/channels/engagement.test.ts:737` covered only the two-humans case; the human-asks-bot follow-up had no test, so the regression slipped through.

## What changed

### `src/channels/engagement.ts`

Adds `botInThread: boolean` to `EngagementInput`, with a field-level comment explaining the Slack `parent_user_id` semantics and the incident.

Gates the `replyToOtherMessageId` suppressor on `!botInThread`:

```ts
// Before (PR #58):
if (message.replyToOtherMessageId !== null) return 'observe'

// After:
if (message.replyToOtherMessageId !== null && !botInThread) return 'observe'
```

Semantics: a thread the bot is already in is OUR conversation regardless of who started it. The suppressor retains a block-level comment (matching the existing PHILOSOPHY block at lines 92–133) explaining why the gate is conditional.

`mentionsOthers` stays unconditional — an explicit `<@user>` tag of someone else is unambiguous, `parent_user_id` is not.

### `src/channels/router.ts`

Adds a `hasBotParticipated(live: LiveSession): boolean` helper:

```ts
const hasBotParticipated = (live: LiveSession): boolean => {
  if (live.successfulChannelSends > 0) return true
  for (const item of live.contextBuffer) {
    if (item.authorIsBot) return true
  }
  return false
}
```

The first clause covers warm sessions (the bot has already replied in this container lifetime). The second covers cold sessions where prefetched history shows prior bot participation. Passes `botInThread: hasBotParticipated(live)` into `decideEngagement`.

### `src/channels/engagement.test.ts`

Updates the `decideEngagement` test helper to default `botInThread: false` — the 51 pre-existing tests needed no individual edits, since they all describe scenarios where the bot has not previously sent into the thread.

Adds two new tests:

| Test | What it locks in |
| --- | --- |
| Engages on human follow-up in a thread the bot is already in | The PR #58 regression — `botInThread: true` overrides the `replyToOtherMessageId` suppressor |
| `mentionsOthers` still suppresses even when `botInThread: true` | The explicit-tag gate is unaffected by `botInThread`; only the parent-author gate is conditional |

**Mutation-tested:**
- Reverting `&& !botInThread` from `engagement.ts` → the regression test fails.
- Removing `hasBotParticipated` from `router.ts` → TypeScript error (field required by `EngagementInput`).

## Verification

```
bun run typecheck   # clean
bun run lint        # 0 warnings, 0 errors
bun run format      # clean
bun test            # 1646/1646 pass (+2 from these tests; +38 from PR #58; +36 from prior PRs)
```