### PR TITLE
Separate per-fragment provenance from the watermark marker

### DIFF
--- a/plugins/memory/memory-logger.test.ts
+++ b/plugins/memory/memory-logger.test.ts
@@ -131,6 +131,30 @@ describe('MEMORY_LOGGER_SYSTEM_PROMPT', () => {
     expect(MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()).toContain('watermark')
   })
 
+  test('declares a separate trailing watermark marker (not stamped on the last fragment)', () => {
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/<!-- watermark source=.+ entry=.+ -->/)
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()).toMatch(/last marker|trailing watermark|after.*fragments/)
+  })
+
+  test('forbids stamping every fragment with the same "latest evaluated" entry id (the winky bug)', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toMatch(/per-fragment|each fragment.*own entry|do not stamp every fragment/i)
+  })
+
+  test('explains that fragment entry= is the evidence anchor, not the latest evaluated entry', () => {
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/anchors.*evidence|specific.*entry that anchors/i)
+  })
+
+  test('explains that the watermark entry= is the latest evaluated entry, regardless of fragment anchors', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toMatch(/latest.*entry.*evaluated|regardless.*anchored/i)
+  })
+
+  test('requires exactly one watermark marker per run (never zero, never multiple)', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toMatch(/exactly one.*watermark|one watermark per run/i)
+  })
+
   test('forbids quoting credential values verbatim and explains why', () => {
     const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
     expect(lower).toMatch(/never quote secret values|never quote credential values/i)
@@ -254,7 +278,7 @@ describe('memoryLoggerSubagent', () => {
     expect(runSessionCalls[0]!.userPrompt!).toContain('watermrk')
   })
 
-  test('handler instructs the subagent to advance the watermark even when nothing is worth remembering', async () => {
+  test('handler instructs the subagent to write a trailing watermark marker on every run', async () => {
     const agentDir = makeAgentDir()
     const transcript = join(agentDir, 'sessions', 'ses_abc.jsonl')
     writeFileSync(transcript, '')
@@ -264,7 +288,23 @@ describe('memoryLoggerSubagent', () => {
       agentDir,
     )
 
-    expect(runSessionCalls[0]!.userPrompt!.toLowerCase()).toMatch(/bare watermark|advance the watermark/)
+    const prompt = runSessionCalls[0]!.userPrompt!
+    expect(prompt).toMatch(/<!-- watermark source=ses_abc entry=<latestEntryId> -->/)
+    expect(prompt.toLowerCase()).toMatch(/regardless of how many fragments|trailing watermark/)
+  })
+
+  test('handler instructs the subagent that each fragment carries its own evidence-anchor entry id', async () => {
+    const agentDir = makeAgentDir()
+    const transcript = join(agentDir, 'sessions', 'ses_abc.jsonl')
+    writeFileSync(transcript, '')
+
+    const { runSessionCalls } = await invokeWith(
+      { parentSessionId: 'ses_abc', parentTranscriptPath: transcript, agentDir },
+      agentDir,
+    )
+
+    const prompt = runSessionCalls[0]!.userPrompt!
+    expect(prompt.toLowerCase()).toMatch(/per-fragment provenance|specific transcript entry that anchors/i)
   })
 
   test('handler points the subagent at MEMORY.md so it can read existing memory first', async () => {

--- a/plugins/memory/memory-logger.ts
+++ b/plugins/memory/memory-logger.ts
@@ -102,7 +102,7 @@ Each fragment is an HTML comment marker followed by a topic heading and a body:
 \`\`\`
 
 - \`source\` is the parent session id from the user message.
-- \`entry\` is the stable id of the latest transcript entry that justifies this fragment. This double-duties as the watermark — see below.
+- \`entry\` is the stable id of the **specific** transcript entry that anchors this fragment's evidence. Each fragment carries its own entry id — do not stamp every fragment with the same "latest evaluated" id. The provenance is per-fragment.
 - \`<topic>\` is a short noun phrase naming what the fragment is about.
 
 The body is the substance of the fragment. The form is flexible, but every body must satisfy two requirements:
@@ -135,12 +135,17 @@ Separate fragments with a blank line.
 
 # Watermark contract
 
-You must record the latest transcript entry id you considered, even when you write zero fragments. The user message will tell you exactly how:
+The watermark is a separate concern from per-fragment provenance. After all fragments (or zero of them), append exactly one trailing watermark marker that records the latest transcript entry id you considered. This marker is what prevents you from re-reading the same transcript prefix on the next run.
 
-- If you write at least one fragment, the \`entry=\` on your last-written fragment must reflect the latest transcript entry you evaluated.
-- If you write zero fragments, append a single bare watermark marker (no body, no topic) recording that latest entry id. The user message gives the exact shape.
+\`\`\`
+<!-- watermark source=<sessionId> entry=<latestEntryId> -->
+\`\`\`
 
-Never exit without either a new fragment or a new watermark marker. The watermark is what prevents you from re-reading the same transcript prefix on the next run.
+- The watermark's \`entry=\` is the latest transcript entry you evaluated, **regardless of which entries actually anchored fragments**. You may have evaluated 50 entries and written 2 fragments anchored to entries 5 and 23; the watermark is still the latest of the 50.
+- The watermark must always be the **last** marker in your appended output, after any fragments.
+- Write exactly one watermark per run, never more.
+
+Never exit without a new watermark marker. Never reuse the watermark trick of stamping a fragment's \`entry=\` with the latest evaluated entry — fragments carry per-evidence provenance, and the watermark is its own marker.
 
 # Stopping
 
@@ -164,9 +169,11 @@ function buildInitialPrompt(payload: MemoryLoggerPayload, streamFile: string, wa
     '',
     'Read MEMORY.md and the daily stream file first to learn what is already remembered. Then read the transcript past the watermark. Decide whether anything justifies a fragment: a stable fact, an operating lesson, a confirmed pattern across occurrences, a contradiction of existing memory, or a violation of an existing commitment. Sometimes the answer is zero fragments; sometimes more than one. Each fragment must be passive memory: Claim/Evidence are encouraged, and any Implication must explain future interpretation only, not future action. Memory cannot authorize proactive duties.',
     '',
-    'Watermark advancement: if you write at least one fragment, the `entry=` on your last fragment must reflect the latest transcript entry you considered. If you write zero fragments, append a single bare watermark marker `<!-- watermark source=' +
+    "Per-fragment provenance: each fragment's `entry=` is the specific transcript entry that anchors that fragment's evidence — not the latest entry you evaluated. Two fragments anchored to two different entries get two different `entry=` values. Do not stamp every fragment with the same id.",
+    '',
+    'Watermark: regardless of how many fragments you wrote (zero or more), append exactly one trailing watermark marker `<!-- watermark source=' +
       payload.parentSessionId +
-      ' entry=<latestEntryId> -->` to the daily stream file recording the latest entry id you evaluated, then stop. Never exit without either a new fragment or a new watermark marker.',
+      ' entry=<latestEntryId> -->` as the last line of your appended output. `<latestEntryId>` is the latest transcript entry you evaluated, regardless of whether it anchored a fragment. Never exit without writing this marker.',
   )
   return lines.join('\n')
 }


### PR DESCRIPTION
## Why

The current spec says: *"the `entry=` on your last-written fragment must reflect the latest transcript entry you evaluated."* The LLM interprets that as **"stamp every fragment with the latest entry."**

The 2026-05-26 winky log shows the result:
- `entry=3ba1be13` stamps **7 different fragments** at lines 201, 214, 228, 243, 253, 266, 280
- `entry=5f03cb94` stamps **3 fragments** at lines 689, 697, 705
- `entry=d28fe2fd` stamps **4 fragments** at lines 380, 390, 400, 413
- `entry=554b8093` stamps 2 fragments
- `entry=f6a680a2` stamps 3 fragments

Each set covers fragments anchored to entirely different evidence — different topics, different conversations, different timestamps. Distinct fragments share `entry=` values because the LLM is following the spec literally.

This breaks dreaming's per-fragment citation system. Dreaming cites `memory/yyyy-MM-dd:<line>-<line>` so it doesn't *strictly* depend on `entry=` for uniqueness — but the entry id is meant to be the durable cross-reference between a fragment and the transcript moment it summarizes. When that link is broken, no later tool (a memory inspector, an audit log analyzer, a future "go-to-source" feature) can rely on it.

## What changed

Spec-only. Two roles that today are conflated into one marker are now split:

**Per-fragment provenance** — each fragment's `entry=` is the **specific** transcript entry that anchors that fragment's evidence. Two fragments anchored to two different entries get two different `entry=` values. The fragment-format section explicitly forbids "do not stamp every fragment with the same 'latest evaluated' id."

**Watermark** — its own trailing marker, written exactly once per run as the last line of the appended output, regardless of how many fragments preceded it:

```
<!-- watermark source=<sessionId> entry=<latestEntryId> -->
```

The watermark's `entry=` is the latest evaluated entry, regardless of whether it anchored a fragment. So if the LLM evaluates 50 entries and writes 2 fragments anchored to entries 5 and 23, the file ends up:

```
<!-- fragment source=ses_a entry=05 -->
## first topic
...

<!-- fragment source=ses_a entry=23 -->
## second topic
...

<!-- watermark source=ses_a entry=50 -->
```

## Why no code change

The `watermark.ts` regex was already permissive — it matches both `(?:fragment|watermark)`. The "last-marker-wins regardless of kind" invariant was already a tested behavior (`watermark.test.ts:65-80`). All this PR does is tell the LLM to actually use the existing watermark marker shape, every time, instead of overloading the last fragment.

## Test layer

`plugins/memory/memory-logger.test.ts` — 5 new system-prompt invariants:

- "declares a separate trailing watermark marker (not stamped on the last fragment)"
- "forbids stamping every fragment with the same 'latest evaluated' entry id (the winky bug)"
- "explains that fragment entry= is the evidence anchor, not the latest evaluated entry"
- "explains that the watermark entry= is the latest evaluated entry, regardless of fragment anchors"
- "requires exactly one watermark marker per run (never zero, never multiple)"

Plus 2 updates to handler tests:

- "handler instructs the subagent to write a trailing watermark marker on every run" (replacing the old "advance the watermark even when nothing is worth remembering" — the new contract is unconditional)
- "handler instructs the subagent that each fragment carries its own evidence-anchor entry id" (new)

## Verification

```
bun run lint     → 0 warnings, 0 errors
bun run format   → 290 files clean
bun run typecheck → ok
bun test         → 1689 pass, 0 fail (was 1684 on main, +5 new)
```

## What this does NOT change

- Existing daily-stream files in deployed agents are not retroactively rewritten. This PR changes the contract for future runs only. Already-written fragments with shared `entry=` values will stay that way until dreaming consolidates and overwrites them.
- The `dreaming` subagent's behavior is unchanged. It already uses line-range citations rather than entry-id citations, so it is not affected by what fragments stamp.
- The `watermark.ts` parser is unchanged. The new contract uses marker shapes the parser already supports.

## Interaction with PR #62 and PR #66

Independent. PR #62 changes `append-tool.ts` and `append-tool.test.ts`. PR #66 changes `index.ts`, `index.test.ts`, and the `inFlightKey` line in `memory-logger.ts`. PR #67 (this) changes the system prompt body and `buildInitialPrompt` in `memory-logger.ts`. The three PRs touch disjoint regions; mechanical merge conflicts at most.