### PR TITLE
Wire configured aliases from typeclaw.json to channel router

### DIFF
--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -3,8 +3,11 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import type { AgentSession } from '@/agent'
+
 import { createChannelManager } from './manager'
-import { defaultHistoryConfig, type ChannelsConfig } from './schema'
+import { defaultHistoryConfig, type ChannelAdapterConfig, type ChannelsConfig } from './schema'
+import type { ChannelKey, InboundMessage } from './types'
 
 type FakeAdapter = {
   start: () => Promise<void>
@@ -151,6 +154,89 @@ describe('channel manager — reload detects missing tokens and stops adapter', 
     expect(result.stopped).not.toContain('slack-bot')
     expect(result.restartRequired).toContain('slack-bot (token rotation)')
     expect(fake.stopCalls).toBe(0)
+  })
+
+  test('forwards aliasesRef to the router so configured aliases trigger engagement', async () => {
+    // given: a manager wired with `aliasesRef` returning ["윙키", "winky"], a
+    //   slack-bot config with strict-mention trigger and stickiness off
+    //   (so the ONLY remaining engagement paths are alias-substring match
+    //   at engagement.ts:102 or the solo-human fallback at :174), and a
+    //   participant cache primed with two distinct humans so the
+    //   solo-human fallback is disabled and the alias path is the only
+    //   engagement gate that can fire
+    const slackCfg: ChannelAdapterConfig = {
+      allow: ['*'],
+      enabled: true,
+      engagement: { trigger: ['mention'], stickiness: 'off' },
+      history: defaultHistoryConfig(),
+    }
+    cfg['slack-bot'] = slackCfg
+    const prompts: string[] = []
+    const fakeSession = {
+      prompt: async (text: string) => {
+        prompts.push(text)
+      },
+      abort: async () => {},
+      sessionManager: { getLeafEntry: () => undefined },
+    } as unknown as AgentSession
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      aliasesRef: () => ['윙키', 'winky'],
+      env: { SLACK_BOT_TOKEN: 'xoxb-a', SLACK_APP_TOKEN: 'xapp-b' },
+      createSlackAdapter: () => makeFakeAdapter(),
+      createSessionForChannel: async () => ({
+        session: fakeSession,
+        sessionId: 'ses_test_alias',
+        dispose: async () => {},
+      }),
+    })
+
+    const key: ChannelKey = { adapter: 'slack-bot', workspace: 'TXXX', chat: 'C111', thread: '1.0' }
+    const baseInbound = (over: Partial<InboundMessage>): InboundMessage => ({
+      ...key,
+      text: '',
+      externalMessageId: 'm0',
+      authorId: 'U?',
+      authorName: '?',
+      authorIsBot: false,
+      isBotMention: false,
+      replyToBotMessageId: null,
+      mentionsOthers: false,
+      replyToOtherMessageId: null,
+      isDm: false,
+      ts: Date.parse('2026-05-01T00:00:00.000Z'),
+      ...over,
+    })
+
+    // when: a first @-mention inbound from human A primes the channel (so
+    //   the session exists), then a non-alias inbound from human B brings
+    //   the participant count to two (defeating the solo-human fallback),
+    //   and finally a NON-mention inbound from A whose text contains only
+    //   the configured alias "윙키" arrives — every structural trigger
+    //   (mention, reply, dm, sticky) is off, leaving alias-match as the
+    //   sole gate
+    await mgr.router.route(
+      baseInbound({ externalMessageId: 'm1', text: 'hello bot', authorId: 'U_A', authorName: 'A', isBotMention: true }),
+    )
+    await mgr.router.__testing!.flushDebounce(key)
+    await mgr.router.route(
+      baseInbound({ externalMessageId: 'm2', text: 'side comment', authorId: 'U_B', authorName: 'B' }),
+    )
+    await mgr.router.__testing!.flushDebounce(key)
+    const promptsBeforeAlias = prompts.length
+    await mgr.router.route(baseInbound({ externalMessageId: 'm3', text: '윙키야', authorId: 'U_A', authorName: 'A' }))
+    await mgr.router.__testing!.flushDebounce(key)
+
+    // then: the alias-only inbound produces exactly one new prompt; if the
+    //   manager dropped `aliasesRef` on the floor (the bug this fix
+    //   addresses), `selfAliases` would fall back to `[basename(agentDir)]`
+    //   only, "윙키야" would not match any alias, and with the solo-human
+    //   fallback disabled by U_B's prior inbound the message would be
+    //   silently observed — promptsAfterAlias would equal promptsBeforeAlias
+    const promptsAfterAlias = prompts.length
+    expect(promptsAfterAlias - promptsBeforeAlias).toBe(1)
+    expect(prompts[prompts.length - 1]).toContain('윙키야')
   })
 
   test('stops discord adapter when DISCORD_BOT_TOKEN disappears (parity with slack)', async () => {

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -18,6 +18,16 @@ const consoleLogger: ChannelManagerLogger = {
 export type ChannelManagerOptions = {
   agentDir: string
   channelsConfigRef: () => ChannelsConfig
+  // Plain-text names the agent answers to in channel engagement (the
+  // `alias` field in `typeclaw.json`), forwarded to the router as
+  // `configuredAliases`. Read live on every inbound so an `applied`-class
+  // reload of `alias` takes effect without a container restart. Omitted
+  // means alias-based engagement is off — `basename(agentDir)` is still
+  // implicit. This MUST be wired up in production (`src/run/index.ts`)
+  // or the configured aliases are silently orphaned: parsed by the
+  // schema, never read by anyone. See `manager.test.ts` for the
+  // end-to-end engagement assertion that guards this wiring.
+  aliasesRef?: () => readonly string[]
   logger?: ChannelManagerLogger
   env?: NodeJS.ProcessEnv
   // Production wiring passes a factory that builds sessions with the full
@@ -56,6 +66,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     agentDir: options.agentDir,
     configForAdapter: (adapter) => options.channelsConfigRef()[adapter],
     logger,
+    ...(options.aliasesRef ? { configuredAliases: options.aliasesRef } : {}),
     ...(options.createSessionForChannel ? { createSessionForChannel: options.createSessionForChannel } : {}),
   })
   const createDiscordAdapter = options.createDiscordAdapter ?? createDiscordBotAdapter

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -122,6 +122,7 @@ export async function startAgent({
   const channelManager = createChannelManager({
     agentDir: cwd,
     channelsConfigRef: () => getConfig().channels,
+    aliasesRef: () => getConfig().alias,
     createSessionForChannel: buildChannelSessionFactory({
       cwd,
       sessionFactory,


### PR DESCRIPTION
## Why

`createChannelManager()` in `src/channels/manager.ts` called `createChannelRouter()` without passing `configuredAliases`. The `alias` field declared in `typeclaw.json` — parsed and validated by the config schema — was silently orphaned: it never reached the router that uses it. As a result, `selfAliases` collapsed to just `[basename(agentDir)]`, and any alias that differs from the agent's directory name was unreachable.

In production this surfaced as a Slack agent whose directory name was `winky` but whose config carried `alias: ["윙키", "winky"]`. The agent responded correctly to explicit `@winky` mentions, but ignored "윙키야" in the same thread — the alias substring match in `engagement.ts:102` had nothing to match against and the message fell through to `observe`. Production logs confirmed: a `[slack-bot] inbound` event for "윙키야" was followed by `routed mention=false reply=false` with no `prompting` line.

## What changed

### `src/channels/manager.ts` (+11, -0)

Adds an optional `aliasesRef?: () => readonly string[]` field to `ChannelManagerOptions` and forwards it to `createChannelRouter` as `configuredAliases`. The option is a getter function rather than a snapshot so that live config reload of `alias` (classified `'applied'` in `FIELD_EFFECTS`, meaning reload takes effect immediately) continues to work — the router reads aliases on every inbound, not once at construction time.

A comment on the forwarding line explains why this option MUST be wired in production.

### `src/run/index.ts` (+1, -0)

One-line production wiring: passes `aliasesRef: () => getConfig().alias` when constructing the channel manager.

### `src/channels/manager.test.ts` (+87, -1)

Adds a behavioral regression test that drives an alias-only inbound through `mgr.router` and asserts engagement fires (`promptFn` called once).

**Why a manager-level test, not a router-level test.** Router-level alias tests already existed (`router.test.ts` lines 594-622) and they passed — the router logic was never broken. The bug lived in the manager→router wiring, which had zero test coverage before this PR. The new test covers exactly that seam.

**Why two distinct prior authors.** The test uses `strict-mention` engagement config (disabling structural triggers) with sticky off, making alias the only engagement path — but also making the solo-human fallback (`effectiveHumans <= 1 && !authorIsBot → engage` at `engagement.ts:174`) a false-positive risk. Two prior inbounds from different authors prime the participant cache above 1 human, defeating the fallback and ensuring the test assertion is specific to the alias path.

**Mutation-checked.** Removing the new wiring line in `manager.ts` causes this test to fail with `Expected: 1, Received: 0`. No other tests fail — confirming the test guards exactly the wiring it claims to guard.

## Verification

```
bun run typecheck  → ok
bun run lint       → 0 warnings, 0 errors  (oxlint)
bun run format     → clean  (oxfmt)
bun test src/channels/  → 468 pass, 0 fail
bun test            → 1697 pass, 0 fail
```