### PR TITLE
Use Discord global_name when classifying inbound messages

### DIFF
--- a/src/channels/adapters/agent-messenger-shim.ts
+++ b/src/channels/adapters/agent-messenger-shim.ts
@@ -23,7 +23,7 @@ export type DiscordGatewayMessageCreateEvent = {
   id: string
   channel_id: string
   guild_id?: string
-  author: { id: string; username: string; bot?: boolean }
+  author: { id: string; username: string; global_name?: string | null; bot?: boolean }
   content: string
   attachments?: DiscordGatewayAttachment[]
   embeds?: DiscordGatewayEmbed[]

--- a/src/channels/adapters/discord-bot-classify.test.ts
+++ b/src/channels/adapters/discord-bot-classify.test.ts
@@ -435,3 +435,35 @@ describe('discord-bot classifyInbound — group mentions', () => {
     expect(verdict.payload.isBotMention).toBe(true)
   })
 })
+
+describe('classifyInbound — author name resolution', () => {
+  test('prefers global_name (display name) over username so the agent never addresses users by their numeric handle', () => {
+    const event = buildEvent({ author: { id: 'u1', username: '1411531', global_name: '세영', bot: false } })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.authorName).toBe('세영')
+  })
+
+  test('falls back to username when global_name is absent', () => {
+    const event = buildEvent({ author: { id: 'u1', username: 'alice', bot: false } })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.authorName).toBe('alice')
+  })
+
+  test('falls back to username when global_name is null (Discord serializes unset display names this way)', () => {
+    const event = buildEvent({ author: { id: 'u1', username: 'alice', global_name: null, bot: false } })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.authorName).toBe('alice')
+  })
+})

--- a/src/channels/adapters/discord-bot-classify.ts
+++ b/src/channels/adapters/discord-bot-classify.ts
@@ -86,7 +86,12 @@ export function classifyInbound(
       text,
       externalMessageId: event.id,
       authorId: event.author.id,
-      authorName: event.author.username,
+      // Discord's post-2023 username system allows pure-numeric handles (e.g.
+      // "1411531"); the human-facing display name lives on `global_name`. The
+      // history mapper in discord-bot.ts uses the same fallback chain — keep
+      // them aligned so the agent sees a stable identity for a given user
+      // regardless of whether the message arrived live or via history.
+      authorName: event.author.global_name ?? event.author.username,
       authorIsBot: event.author.bot === true,
       isBotMention,
       replyToBotMessageId,


### PR DESCRIPTION
## Summary

Fix a Discord channel adapter bug where the agent could address users by their raw Discord handle instead of their display name. The live-message classifier was reading `author.username` only; switched to `author.global_name ?? author.username` so it matches the history mapper in `discord-bot.ts`.

## Root cause

`src/channels/adapters/discord-bot-classify.ts:89` set `authorName: event.author.username`. Under Discord's post-2023 username system, `username` is a unique handle (which can be pure-numeric for newer accounts), while the human-facing name lives on `author.global_name`. `formatAuthorLine` in `src/channels/router.ts` renders `<@authorId> (authorName): text`, so the LLM sees the handle in the parens and tends to parrot it back as the user's name.

The history-fetch path (`src/channels/adapters/discord-bot.ts:308`) already used the correct `global_name ?? username ?? id` fallback. The live path drifted.

## Changes

- `agent-messenger-shim.ts` — extend `DiscordGatewayMessageCreateEvent.author` with `global_name?: string | null`. Without this, the fix doesn't typecheck.
- `discord-bot-classify.ts` — `authorName: event.author.global_name ?? event.author.username`. Comment explains the cross-file invariant with the history mapper.
- `discord-bot-classify.test.ts` — three tests covering: prefer `global_name`, fall back to `username` when absent, fall back to `username` when `global_name === null` (Discord serializes unset display names as null, not undefined). Mutation check: removing the `??` fallback fails the first test.

Logging at `discord-bot.ts:533` (`formatLabel(event.author.username, event.author.id)`) intentionally untouched — that's operator-facing log lines, not agent context.

## Verification

- `bun test src/channels/adapters/discord-bot-classify.test.ts` — 35 pass (3 new + 32 existing)
- `bun test src/channels/` — 429 pass
- `bun run typecheck` / `bun run lint` / `bun run format` — clean
- Full suite: 1700 pass

## Out of scope (follow-up)

Slack history (`src/channels/adapters/slack-bot.ts:446`) returns `authorName: msg.user ?? msg.bot_id ?? 'unknown'` — a raw user ID, never resolved through `authorResolver`. Same class of bug as this one, but only affects history (live messages are correctly resolved at `slack-bot.ts:702`). Keeping this PR atomic; Slack history fix is a separate change.