### PR TITLE
Fix channel engagement: drop dead helper, fix session eviction, anchor alias threads

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -33,6 +33,7 @@ function fakeRouter(
     registerFetchAttachment: () => {},
     unregisterFetchAttachment: () => {},
     fetchAttachment: async () => ({ ok: false, error: 'fetch-attachment-not-supported' }),
+    getSelfAliases: () => [],
     stop: async () => {},
     liveCount: () => 0,
   }

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -27,6 +27,7 @@ function fakeRouter(
     registerFetchAttachment: () => {},
     unregisterFetchAttachment: () => {},
     fetchAttachment: async () => ({ ok: false, error: 'fetch-attachment-not-supported' }),
+    getSelfAliases: () => [],
     stop: async () => {},
     liveCount: () => 0,
   }

--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -286,6 +286,97 @@ describe('slack-bot classifyInbound — route path', () => {
     expect(verdict.payload.thread).toBeNull()
   })
 
+  test('top-level alias-only addressing anchors thread on the inbound ts so the bot can reply in-thread', () => {
+    // given: a top-level message with no @mention and no thread_ts, but
+    // containing one of the bot's plain-text aliases. Slack treats this
+    // as an isolated channel post; without anchoring `thread` here, the
+    // bot's reply would post as another top-level message, fragmenting
+    // the conversation. Anchoring on `event.ts` lets the outbound
+    // callback set `thread_ts` and turn the bot's reply into the first
+    // thread reply under the user's message — same conversational
+    // affordance as a Slack-native @mention.
+    const event = buildEvent({ text: '윙키야 안녕' })
+
+    const verdict = classifyInbound(event, baseConfig, {
+      teamId: TEAM_ID,
+      botUserId: BOT_USER_ID,
+      selfAliases: ['윙키', 'winky'],
+    })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(false)
+    expect(verdict.payload.thread).toBe('1700000000.000100')
+  })
+
+  test('alias matching is case-insensitive and substring-based, mirroring the engagement layer', () => {
+    const event = buildEvent({ text: 'WinKy please look at this' })
+
+    const verdict = classifyInbound(event, baseConfig, {
+      teamId: TEAM_ID,
+      botUserId: BOT_USER_ID,
+      selfAliases: ['winky'],
+    })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.thread).toBe('1700000000.000100')
+  })
+
+  test('an existing thread_ts always wins over alias anchoring (sanity check on the `??` short-circuit)', () => {
+    // This is intentionally not a strong mutation guard for the alias
+    // branch — the `event.thread_ts ?? ...` short-circuit at the head of
+    // the thread expression means an inbound that already has a
+    // thread_ts is preserved regardless of what the right-hand-side
+    // does. Kept as a guard against someone "simplifying" by inverting
+    // the precedence (e.g. anchoring on event.ts whenever an alias
+    // matches, even mid-thread, which would silently re-root replies).
+    const event = buildEvent({
+      text: '윙키 in this thread',
+      ts: '1700000010.000200',
+      thread_ts: '1700000000.000100',
+      parent_user_id: 'UCAROL',
+    })
+
+    const verdict = classifyInbound(event, baseConfig, {
+      teamId: TEAM_ID,
+      botUserId: BOT_USER_ID,
+      selfAliases: ['윙키'],
+    })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.thread).toBe('1700000000.000100')
+  })
+
+  test('alias-only addressing in a DM does NOT anchor a thread (DMs are flat)', () => {
+    const event = buildEvent({ channel_type: 'im', channel: 'D0DM', text: '윙키야' })
+
+    const verdict = classifyInbound(event, baseConfig, {
+      teamId: TEAM_ID,
+      botUserId: BOT_USER_ID,
+      selfAliases: ['윙키'],
+    })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.thread).toBeNull()
+  })
+
+  test('non-mention team message with no alias match leaves thread null (existing behavior)', () => {
+    const event = buildEvent({ text: 'just chatting' })
+
+    const verdict = classifyInbound(event, baseConfig, {
+      teamId: TEAM_ID,
+      botUserId: BOT_USER_ID,
+      selfAliases: ['윙키'],
+    })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.thread).toBeNull()
+  })
+
   test('DMs (channel_type=im) route with workspace=@dm and isDm=true', () => {
     const event = buildEvent({ channel_type: 'im', channel: 'D0DMID', text: 'private hi' })
 

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -1,3 +1,4 @@
+import { matchesAnyAlias } from '@/channels/engagement'
 import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
 import type { InboundMessage } from '@/channels/types'
 
@@ -18,6 +19,15 @@ export type InboundClassification =
 export type SlackInboundContext = {
   teamId: string
   botUserId: string | null
+  // Lowered self-aliases (`alias` from typeclaw.json plus the implicit
+  // basename(agentDir)). When a top-level message contains one of these
+  // but no `<@bot>` mention, the classifier still anchors `thread` on
+  // `event.ts` so the bot's reply lands in a thread under the user's
+  // message instead of as a fragmented top-level post. Optional for
+  // backward compatibility — omitted means "behave like before, no
+  // alias-driven thread anchoring". The router's `computeSelfAliases`
+  // is the source of truth; the adapter just forwards it.
+  selfAliases?: readonly string[]
 }
 
 // All decision logic for "should this Socket Mode message event be routed to
@@ -73,7 +83,15 @@ export function classifyInbound(
   // without any new config surface.
   const hasGroupMention = GROUP_MENTION_PATTERN.test(rawText)
   const isBotMention = hasGroupMention || rawText.includes(`<@${context.botUserId}>`)
-  const thread = event.thread_ts ?? (!isDm && isBotMention ? event.ts : null)
+  // Top-level alias addressing (e.g. "윙키야") is engagement-equivalent
+  // to a `<@bot>` mention (see engagement.ts: alias is unconditional and
+  // ranks alongside explicit triggers). Anchor `thread` on the inbound
+  // ts in that case too, so the bot's reply threads under the user's
+  // message rather than landing as a sibling top-level post. Mention
+  // wins the OR short-circuit; alias matching only runs when no @ was
+  // found, keeping the cost negligible in mention-heavy channels.
+  const aliasMatched = !isBotMention && matchesAnyAlias(rawText, context.selfAliases ?? [])
+  const thread = event.thread_ts ?? (!isDm && (isBotMention || aliasMatched) ? event.ts : null)
 
   // A reply is "to the bot" only when the thread parent was authored by the
   // bot. Slack surfaces the parent author via `parent_user_id` on every

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -79,6 +79,11 @@ export type SlackBotAdapterOptions = {
   token: string
   appToken: string
   logger?: SlackBotAdapterLogger
+  // Read live so an `applied`-class reload of `alias` flows through to
+  // thread anchoring without restart. Optional: omitted means the
+  // classifier behaves as before (no alias-driven thread anchoring), so
+  // tests and ad-hoc adapter constructions stay backwards-compatible.
+  selfAliasesRef?: () => readonly string[]
 }
 
 export type SlackBotAdapter = {
@@ -692,7 +697,11 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
         return
       }
 
-      const verdict = classifyInbound(event, options.configRef(), { teamId, botUserId })
+      const verdict = classifyInbound(event, options.configRef(), {
+        teamId,
+        botUserId,
+        ...(options.selfAliasesRef ? { selfAliases: options.selfAliasesRef() } : {}),
+      })
       if (verdict.kind === 'drop') {
         logger.info(`[slack-bot] dropped ts=${event.ts} reason=${verdict.reason}${dropHint(verdict.reason)}`)
         return

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -9,7 +9,6 @@ export { createChannelsReloadable } from './reloadable'
 export {
   channelsSchema,
   isAllowed,
-  isEngagementOff,
   ADAPTER_IDS,
   STICKY_DEFAULT_WINDOW_MS,
   type AdapterId,

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -239,6 +239,43 @@ describe('channel manager — reload detects missing tokens and stops adapter', 
     expect(prompts[prompts.length - 1]).toContain('윙키야')
   })
 
+  test('forwards selfAliasesRef to the slack adapter so the classifier can anchor threads on alias-only inbounds', async () => {
+    // given: a manager wired with `aliasesRef` returning ["윙키", "winky"]
+    //   AND a `createSlackAdapter` test seam that captures the options the
+    //   manager passes. The point of this test is the wiring itself: if a
+    //   future refactor drops `selfAliasesRef` from manager.ts, every
+    //   adapter-side and router-side test still passes (the seams keep
+    //   their own fake aliases), but the production thread-anchoring path
+    //   silently regresses. This test fails the moment that wiring
+    //   disappears, so it's the only mutation guard between manager.ts
+    //   and slack-bot-classify.ts.
+    cfg['slack-bot'] = enabledAdapterCfg()
+    let captured: { selfAliasesRef?: () => readonly string[] } | undefined
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      aliasesRef: () => ['윙키', 'winky'],
+      env: { SLACK_BOT_TOKEN: 'xoxb-a', SLACK_APP_TOKEN: 'xapp-b' },
+      createSlackAdapter: (opts) => {
+        captured = opts
+        return makeFakeAdapter()
+      },
+    })
+
+    // when: the adapter is constructed at start
+    await mgr.start()
+
+    // then: the captured options carry a live selfAliasesRef whose result
+    //   includes both the configured aliases AND the implicit dir-name
+    //   alias the router seeds at construction (basename(agentDir))
+    expect(captured?.selfAliasesRef).toBeDefined()
+    const aliases = captured!.selfAliasesRef!()
+    expect(aliases).toContain('윙키')
+    expect(aliases).toContain('winky')
+
+    await mgr.stop()
+  })
+
   test('stops discord adapter when DISCORD_BOT_TOKEN disappears (parity with slack)', async () => {
     cfg['discord-bot'] = enabledAdapterCfg()
     const fake = makeFakeAdapter()

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -108,6 +108,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         token,
         appToken,
         logger,
+        selfAliasesRef: () => router.getSelfAliases(),
       })
     }
     return null

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -14,6 +14,7 @@ import { channelsSessionsPath, loadChannelSessions, saveChannelSessions } from '
 import {
   createChannelRouter,
   MAX_TYPING_HEARTBEAT_MS,
+  SESSION_GC_INTERVAL_MS,
   SESSION_IDLE_MS,
   sliceHeadTail,
   type ChannelRouter,
@@ -2246,6 +2247,65 @@ describe('ChannelRouter idle session GC', () => {
     // eviction; end must precede dispose so plugins can still touch state.
     expect(events).toEqual(['idle:ses_fake_1', 'end:ses_fake_1'])
     expect(sessions[0]!.disposed).toBe(1)
+  })
+
+  test('observe-only session is not evicted on the next GC tick after creation', async () => {
+    // given: a session created by an observe-only inbound (suppressed by
+    // mentionsOthers, no engage signal). lastInboundAt is initialized to
+    // `now()` at creation (not 0) so a freshly created observe-only
+    // session gets a full SESSION_IDLE_MS window before GC, instead of
+    // being immediately evicted with a `Date.now() - 0` (~56yr) reading.
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router } = makeRouter(dir, { nowRef })
+    await router.route(
+      inbound({
+        isBotMention: false,
+        mentionsOthers: true, // suppressor → observe
+        text: 'hey @someone-else look at this',
+      }),
+    )
+    expect(router.liveCount()).toBe(1)
+
+    // when: GC runs at the next tick (well within SESSION_IDLE_MS)
+    nowRef.value = 1000 + SESSION_GC_INTERVAL_MS
+    await router.__testing!.runIdleGc!()
+
+    // then: session is preserved
+    expect(router.liveCount()).toBe(1)
+  })
+
+  test('observe-only session DOES evict after SESSION_IDLE_MS (passive observation does not keep it warm forever)', async () => {
+    // given: an observe-only session
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router } = makeRouter(dir, { nowRef })
+    await router.route(
+      inbound({
+        isBotMention: false,
+        mentionsOthers: true, // suppressor → observe
+        text: 'hey @someone-else look at this',
+      }),
+    )
+    expect(router.liveCount()).toBe(1)
+
+    // when: more passive observation arrives but never engages, then time
+    // advances past the threshold from session CREATION (not from last
+    // observation) — observe deliberately does not bump lastInboundAt
+    nowRef.value = 1000 + 5 * 60_000
+    await router.route(
+      inbound({
+        externalMessageId: 'm2',
+        isBotMention: false,
+        mentionsOthers: true,
+        text: 'still chatting with someone else',
+      }),
+    )
+    nowRef.value = 1000 + SESSION_IDLE_MS + 1
+    await router.__testing!.runIdleGc!()
+
+    // then: session is evicted; passive traffic does not pin memory
+    expect(router.liveCount()).toBe(0)
   })
 
   test('runIdleGc tolerates dispose throwing and still removes the entry', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -68,7 +68,10 @@ export const MAX_TYPING_HEARTBEAT_MS = 2 * 60 * 1000
 // give the next conversation a fresh start without forcing the user to
 // notice anything. `lastInboundAt` is bumped only by *engaged* inbounds
 // (see scheduleDebouncedDrain), so passive observation alone won't keep
-// a session warm forever — that's intentional.
+// a session warm forever — that's intentional. The session is seeded
+// with `now()` at creation (not `0`) so a freshly-created observe-only
+// session gets a full SESSION_IDLE_MS window before its first GC sweep,
+// not a 56-year-old idle reading from `Date.now() - 0`.
 export const SESSION_IDLE_MS = 30 * 60 * 1000
 export const SESSION_GC_INTERVAL_MS = 60 * 1000
 
@@ -495,7 +498,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         typingStartedAt: 0,
         typingTimedOut: false,
         typingStopPromise: null,
-        lastInboundAt: 0,
+        lastInboundAt: now(),
         firstUnprocessedAt: 0,
         currentTurnAuthorId: null,
         currentTurnAuthorIds: new Set(),
@@ -935,7 +938,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       authorId: event.authorId,
       authorName: event.authorName,
       authorIsBot: event.authorIsBot,
-      receivedAt: event.replyToBotMessageId === null ? now() : now(),
+      receivedAt: now(),
       ts: event.ts,
     })
     if (live.contextBuffer.length > CONTEXT_BUFFER_SIZE) {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -230,6 +230,11 @@ export type ChannelRouter = {
   registerFetchAttachment: (adapter: ChannelKey['adapter'], cb: FetchAttachmentCallback) => void
   unregisterFetchAttachment: (adapter: ChannelKey['adapter'], cb: FetchAttachmentCallback) => void
   fetchAttachment: (adapter: ChannelKey['adapter'], args: FetchAttachmentArgs) => Promise<FetchAttachmentResult>
+  // Lowered self-aliases (configured + implicit dir-name). Adapters use
+  // this to anchor outbound threading on alias-only inbounds — see
+  // slack-bot-classify.ts. Read live so a reload of `alias` propagates
+  // to adapters without a restart.
+  getSelfAliases: () => readonly string[]
   stop: () => Promise<void>
   liveCount: () => number
   __testing?: {
@@ -1247,6 +1252,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     registerFetchAttachment,
     unregisterFetchAttachment,
     fetchAttachment,
+    getSelfAliases: computeSelfAliases,
     stop,
     liveCount: () => liveSessions.size,
     __testing: {

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -191,7 +191,3 @@ function matchRule(rule: string, workspace: string, chat: string): boolean {
   }
   return false
 }
-
-export function isEngagementOff(engagement: EngagementConfig): boolean {
-  return engagement.trigger.length === 0 && engagement.stickiness === 'off'
-}


### PR DESCRIPTION
## Why

A production incident in the Slack adapter (agent had narrowed `engagement.trigger` to mention-only — a config error) led to a broader investigation that surfaced three latent code issues. Each is independent of the config error and worth fixing on its own.

This PR went through one round of self-review (Oracle pass on the original draft) — see the **Self-review notes** at the bottom for the H1 fix that was made before merge.

---

## What changed

### 1. Drop unused `isEngagementOff` helper (`src/channels/schema.ts`, `src/channels/index.ts`)

`isEngagementOff` was defined, exported, and never called. Wiring it as an early-return in the engagement path would have been wrong: alias matching and the solo-human fallback are both intentionally unconditional (engagement is never fully "off" in the sense that those two paths bypass the trigger config). The cleanest action is deletion — 4 lines removed, no callers to update.

### 2. Initialize `lastInboundAt` at session creation, not 0 (`src/channels/router.ts`)

`lastInboundAt` was hardcoded to `0` at session creation and only bumped by *engaged* inbounds in `scheduleDebouncedDrain`. Observe-only sessions therefore kept `lastInboundAt` at `0` forever. The 60s idle-GC tick computed `Date.now() - 0` (~56 years) ≫ `SESSION_IDLE_MS` and evicted the session immediately.

Smoking gun from production logs: `idle_gc evicting after 1778063029742ms idle` — that 1.778T-ms reading is `Date.now()` minus zero.

**Fix**: seed `lastInboundAt` with `now()` at creation. This preserves the documented idle-GC contract ("passive observation alone won't keep a session warm forever — that's intentional") — observe-only sessions still evict after `SESSION_IDLE_MS` measured from creation, just not 56 years too early. Lifecycle comment is extended (not replaced) to document the new init invariant.

Also drops a dead ternary `event.replyToBotMessageId === null ? now() : now()` in `observe()` — both branches were identical.

**2 new tests** in `src/channels/router.test.ts`:

| Test | What it locks in |
| --- | --- |
| `observe-only session is not evicted on the next GC tick after creation` | The 56-year bug fix (revert `lastInboundAt: now()` → `0` and this test fails) |
| `observe-only session DOES evict after SESSION_IDLE_MS` | Original GC contract preserved (passive observation does not pin memory forever) |

### 3. Anchor Slack thread on top-level alias addressing

(`src/channels/adapters/slack-bot-classify.ts`, `slack-bot.ts`, `src/channels/manager.ts`, `src/channels/router.ts`)

When a user addressed the bot by alias in a top-level Slack message (e.g. `윙키야`) with no `<@bot>` mention and no existing `thread_ts`, the classifier set `thread: null`. `isBotMention` was the only condition that triggered auto-anchoring (`thread = event.ts`). The bot engaged correctly via the alias path in `engagement.ts`, but its reply went out as another top-level message — fragmenting the conversation into two parallel top-level posts under the same channel root.

**Fix**: extend the auto-anchor condition to also fire on alias matches. `SlackInboundContext` gains an optional `selfAliases` field; the classifier reuses `matchesAnyAlias` from `engagement.ts` so the matching semantics are identical to engagement (case-insensitive substring). Backwards-compatible: omitting `selfAliases` preserves prior behavior exactly.

Plumbing:
- `slack-bot.ts` — adapter reads aliases via a new `selfAliasesRef?: () => readonly string[]` option and forwards them through `SlackInboundContext`.
- `manager.ts` — wires `selfAliasesRef` from `router.getSelfAliases()`.
- `router.ts` — exposes `getSelfAliases(): readonly string[]` on `ChannelRouter`.

**5 new classifier tests** in `src/channels/adapters/slack-bot-classify.test.ts`:

| Test | What it locks in |
| --- | --- |
| Top-level alias match → `thread = event.ts` | The anchoring fix itself |
| Case-insensitive substring alias matching mirrors engagement | Semantics consistency with `engagement.ts` |
| Existing `thread_ts` always wins (sanity check on `??` precedence) | Prevents future regression where alias mid-thread re-roots the thread |
| Alias-only DM does NOT anchor a thread (DMs are flat) | Slack DMs have no thread concept |
| Non-mention with no alias match leaves `thread: null` | Existing behavior preserved |

**1 new manager test** in `src/channels/manager.test.ts`:

| Test | What it locks in |
| --- | --- |
| `forwards selfAliasesRef to the slack adapter…` | The wiring between `manager.ts` and `slack-bot.ts`. Without this, dropping `selfAliasesRef: () => router.getSelfAliases()` lets every adapter and router test pass while production silently regresses. Mutation-verified during development. |

---

## Verification

```
bun run typecheck   → ok
bun run lint        → 0 warnings, 0 errors
bun run format      → clean
bun test            → 1713/1713 pass (+7 new tests)
```

Each commit individually typechecks (verified with bisect-style checkout).

---

## Self-review notes (for transparency)

The original draft of this PR had a different fix for issue #2: bumping `lastInboundAt` inside `observe()` on every observed inbound. Self-review (Oracle) flagged that this overrides the explicitly-documented intent ("passive observation alone won't keep a session warm forever — that's intentional") and creates indefinite memory retention in busy passive channels.

The current fix (init `lastInboundAt: now()` at creation) is the minimal-diff alternative that fixes the 56-year smoking-gun bug while preserving the original GC policy. Reviewers can verify the policy is preserved by reading the `observe-only session DOES evict after SESSION_IDLE_MS` test — it would fail under the original draft.

The original draft also missed a manager-level test for the `selfAliasesRef` wiring; that gap is closed in this revision (mutation-verified — deleting the wiring causes the new manager test to fail).

---

## Out of scope

The config error that triggered the investigation (engagement narrowed to mention-only) is a user-configuration issue, not a code defect. No change to the config schema or validation is needed — the existing documentation in `typeclaw.json` for `engagement.trigger` is accurate.
