### PR TITLE
PATH-shadow agent-browser to make the dashboard proxy unavoidable

### DIFF
--- a/plugins/agent-browser/dashboard-proxy.test.ts
+++ b/plugins/agent-browser/dashboard-proxy.test.ts
@@ -37,6 +37,31 @@ describe('maybeInjectDashboardPatch', () => {
     expect(patched.headers.has('content-length')).toBe(false)
   })
 
+  test('falls back to opening <head> when the closing tag is missing (Next.js streamed HTML)', async () => {
+    const response = new Response('<!DOCTYPE html><html><head><meta charSet="utf-8"/><body>x</body></html>', {
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    })
+
+    const patched = await maybeInjectDashboardPatch(response)
+    const body = await patched.text()
+
+    expect(body).toContain('/__typeclaw_agent_browser_http/')
+    expect(body.indexOf('/__typeclaw_agent_browser_http/')).toBeGreaterThan(body.indexOf('<head>'))
+    expect(body.indexOf('/__typeclaw_agent_browser_http/')).toBeLessThan(body.indexOf('<body>'))
+  })
+
+  test('falls back to opening <html> when no head element is present', async () => {
+    const response = new Response('<!DOCTYPE html><html><body>x</body></html>', {
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    })
+
+    const patched = await maybeInjectDashboardPatch(response)
+    const body = await patched.text()
+
+    expect(body).toContain('/__typeclaw_agent_browser_http/')
+    expect(body.indexOf('/__typeclaw_agent_browser_http/')).toBeGreaterThan(body.indexOf('<html>'))
+  })
+
   test('leaves non-html responses untouched', async () => {
     const response = new Response('{"ok":true}', { headers: { 'content-type': 'application/json' } })
 

--- a/plugins/agent-browser/dashboard-proxy.ts
+++ b/plugins/agent-browser/dashboard-proxy.ts
@@ -1,5 +1,3 @@
-import { accessSync, chmodSync, constants as fsConstants, existsSync } from 'node:fs'
-
 import type { Server } from 'bun'
 
 export type DashboardProxyOptions = {
@@ -9,10 +7,6 @@ export type DashboardProxyOptions = {
   listenHost?: string
   fetchImpl?: typeof fetch
   onLog?: (event: DashboardProxyLogEvent) => void
-}
-
-export type AgentBrowserDashboardCommandOptions = {
-  executable?: string
 }
 
 export type DashboardProxyLogEvent =
@@ -26,11 +20,6 @@ export type DashboardProxyLogEvent =
 export type DashboardProxy = {
   server: Server<WebSocketData>
   stop: () => void
-}
-
-export type AgentBrowserDashboardProxy = {
-  proxy: DashboardProxy
-  stop: () => Promise<void>
 }
 
 type WebSocketData = {
@@ -48,35 +37,6 @@ const HTTP_PROXY_PREFIX = '/__typeclaw_agent_browser_http/'
 const WS_PROXY_PREFIX = '/__typeclaw_agent_browser_ws/'
 const TYPECLAW_AGENT_PORT = 8973
 const TYPECLAW_HOSTD_CONTROL_PORT = 8974
-
-export async function startAgentBrowserDashboardProxy(
-  opts: DashboardProxyOptions = {},
-  commandOpts: AgentBrowserDashboardCommandOptions = {},
-): Promise<AgentBrowserDashboardProxy> {
-  const upstreamPort = opts.upstreamPort ?? DEFAULT_UPSTREAM_PORT
-  const executable = commandOpts.executable ?? resolveAgentBrowserExecutable()
-  await runAgentBrowserDashboardCommand(executable, ['dashboard', 'start', '--port', String(upstreamPort)])
-  let proxy: DashboardProxy
-  try {
-    proxy = startDashboardProxy(opts)
-  } catch (err) {
-    await runAgentBrowserDashboardCommand(executable, ['dashboard', 'stop']).catch(() => {})
-    throw err
-  }
-
-  return {
-    proxy,
-    async stop() {
-      proxy.stop()
-      await runAgentBrowserDashboardCommand(executable, ['dashboard', 'stop']).catch(() => {})
-    },
-  }
-}
-
-export async function stopAgentBrowserDashboard(commandOpts: AgentBrowserDashboardCommandOptions = {}): Promise<void> {
-  const executable = commandOpts.executable ?? resolveAgentBrowserExecutable()
-  await runAgentBrowserDashboardCommand(executable, ['dashboard', 'stop'])
-}
 
 export function startDashboardProxy(opts: DashboardProxyOptions = {}): DashboardProxy {
   const listenPort = opts.listenPort ?? DEFAULT_PROXY_PORT
@@ -199,10 +159,28 @@ export async function maybeInjectDashboardPatch(response: Response): Promise<Res
 
   const html = await response.text()
   const patch = buildDashboardPatchScript()
-  const patched = html.includes('</head>') ? html.replace('</head>', `${patch}</head>`) : `${patch}${html}`
+  const patched = injectPatch(html, patch)
   const headers = new Headers(response.headers)
   headers.delete('content-length')
   return new Response(patched, { status: response.status, statusText: response.statusText, headers })
+}
+
+function injectPatch(html: string, patch: string): string {
+  const closingHead = html.match(/<\/head\s*>/i)
+  if (closingHead && closingHead.index !== undefined) {
+    return html.slice(0, closingHead.index) + patch + html.slice(closingHead.index)
+  }
+  const openingHead = html.match(/<head\b[^>]*>/i)
+  if (openingHead && openingHead.index !== undefined) {
+    const insertAt = openingHead.index + openingHead[0].length
+    return html.slice(0, insertAt) + patch + html.slice(insertAt)
+  }
+  const openingHtml = html.match(/<html\b[^>]*>/i)
+  if (openingHtml && openingHtml.index !== undefined) {
+    const insertAt = openingHtml.index + openingHtml[0].length
+    return html.slice(0, insertAt) + patch + html.slice(insertAt)
+  }
+  return patch + html
 }
 
 export function parsePortPath(pathname: string, prefix: string): { port: number; path: string } | null {
@@ -392,84 +370,3 @@ async function discoverSessionPorts({
 
 export const AGENT_BROWSER_DASHBOARD_PROXY_PORT = DEFAULT_PROXY_PORT
 export const AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT = DEFAULT_UPSTREAM_PORT
-
-if (import.meta.main) {
-  await runDashboardProxyMain()
-}
-
-async function runDashboardProxyMain(): Promise<void> {
-  const listenPort = portFromEnv('TYPECLAW_AGENT_BROWSER_DASHBOARD_PORT', DEFAULT_PROXY_PORT)
-  const upstreamPort = portFromEnv('TYPECLAW_AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT', DEFAULT_UPSTREAM_PORT)
-  const dashboard = await startAgentBrowserDashboardProxy({
-    listenPort,
-    upstreamPort,
-    onLog: (event) => {
-      if (event.kind === 'http-proxy' || event.kind === 'ws-proxy') return
-      console.error(`[agent-browser-dashboard] ${JSON.stringify(event)}`)
-    },
-  })
-
-  console.log(
-    `TypeClaw agent-browser dashboard proxy listening on 0.0.0.0:${dashboard.proxy.server.port ?? listenPort}`,
-  )
-  console.log(`Upstream agent-browser dashboard is on 127.0.0.1:${upstreamPort}`)
-
-  const stop = async () => {
-    await dashboard.stop()
-    process.exit(0)
-  }
-  process.once('SIGINT', () => void stop())
-  process.once('SIGTERM', () => void stop())
-
-  await new Promise(() => {})
-}
-
-function portFromEnv(name: string, fallback: number): number {
-  const raw = process.env[name]
-  if (raw === undefined || raw === '') return fallback
-  const port = Number(raw)
-  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
-    throw new Error(`${name} must be an integer port between 1 and 65535`)
-  }
-  return port
-}
-
-function resolveAgentBrowserExecutable(): string {
-  const arch = process.arch === 'arm64' ? 'arm64' : process.arch === 'x64' ? 'x64' : null
-  if (arch === null)
-    throw new Error(`agent-browser dashboard proxy does not support ${process.platform}-${process.arch}`)
-  const platform = process.platform === 'linux' ? 'linux' : process.platform === 'darwin' ? 'darwin' : null
-  if (platform === null)
-    throw new Error(`agent-browser dashboard proxy does not support ${process.platform}-${process.arch}`)
-
-  const bundled = `/root/.bun/install/global/node_modules/agent-browser/bin/agent-browser-${platform}-${arch}`
-  if (existsSync(bundled)) {
-    ensureExecutable(bundled)
-    return bundled
-  }
-  return 'agent-browser'
-}
-
-function ensureExecutable(path: string): void {
-  try {
-    accessSync(path, fsConstants.X_OK)
-  } catch {
-    chmodSync(path, 0o755)
-  }
-}
-
-async function runAgentBrowserDashboardCommand(executable: string, args: string[]): Promise<void> {
-  const proc = Bun.spawn([executable, ...args], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
-  const [exitCode, stdout, stderr] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ])
-  if (exitCode !== 0) {
-    const detail = [stdout.trim(), stderr.trim()].filter(Boolean).join('\n')
-    throw new Error(`agent-browser ${args.join(' ')} failed${detail ? `: ${detail}` : ''}`)
-  }
-}

--- a/plugins/agent-browser/index.test.ts
+++ b/plugins/agent-browser/index.test.ts
@@ -2,76 +2,17 @@ import { describe, expect, test } from 'bun:test'
 
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
 
-import agentBrowserPlugin, { DASHBOARD_TOOL_NAME, isRawAgentBrowserDashboardCommand } from './index'
+import agentBrowserPlugin from './index'
 
 describe('agent-browser plugin', () => {
-  test('contributes the agent-browser skill directory', async () => {
+  test('contributes the agent-browser skill directory and no hooks/tools', async () => {
     const exports = await bootPlugin('/agent')
 
     expect(exports.skillsDirs).toEqual([expect.stringContaining('plugins/agent-browser/skills')])
+    expect(exports.tools).toBeUndefined()
+    expect(exports.hooks).toBeUndefined()
   })
-
-  test('injects a prompt-level replacement for raw agent-browser dashboard', async () => {
-    const exports = await bootPlugin('/agent')
-    const event = { prompt: 'open the browser dashboard', sessionId: 'ses_test', agentDir: '/agent' }
-
-    await exports.hooks?.['session.prompt']?.(event, {
-      agentDir: '/agent',
-      pluginName: 'agent-browser',
-      logger: createPluginLogger('agent-browser'),
-    })
-
-    expect(event.prompt).toContain('do not execute the raw dashboard command')
-    expect(event.prompt).toContain('agent-browser dashboard')
-    expect(event.prompt).toContain(DASHBOARD_TOOL_NAME)
-  })
-
-  test('contributes a dashboard tool with stopped status before start', async () => {
-    const exports = await bootPlugin('/agent')
-    const tool = exports.tools?.[DASHBOARD_TOOL_NAME]
-
-    const result = await tool?.execute({ action: 'status' }, toolContext())
-
-    expect(result?.content[0]?.type).toBe('text')
-    expect(result?.content[0]?.type === 'text' ? result.content[0].text : '').toContain('stopped')
-  })
-
-  test('blocks raw agent-browser dashboard bash commands', async () => {
-    const exports = await bootPlugin('/agent')
-    const block = await exports.hooks?.['tool.before']?.(
-      { tool: 'bash', sessionId: 'ses_test', callId: 'call_test', args: { command: 'agent-browser dashboard' } },
-      { agentDir: '/agent', pluginName: 'agent-browser', logger: createPluginLogger('agent-browser') },
-    )
-
-    expect(block).toEqual({
-      block: true,
-      reason: `Use the ${DASHBOARD_TOOL_NAME} plugin tool instead of raw agent-browser dashboard.`,
-    })
-  })
-
-  test.each(['agent-browser dashboard', 'npx agent-browser dashboard start', 'echo ok && agent-browser dashboard'])(
-    'detects raw dashboard command: %s',
-    (command) => {
-      expect(isRawAgentBrowserDashboardCommand(command)).toBe(true)
-    },
-  )
-
-  test.each(['agent-browser open https://example.com', 'echo agent-browser dashboard', 'my-agent-browser dashboard'])(
-    'allows non-dashboard command: %s',
-    (command) => {
-      expect(isRawAgentBrowserDashboardCommand(command)).toBe(false)
-    },
-  )
 })
-
-function toolContext() {
-  return {
-    signal: undefined,
-    sessionId: 'ses_test',
-    agentDir: '/agent',
-    logger: createPluginLogger('agent-browser'),
-  }
-}
 
 async function bootPlugin(agentDir: string) {
   return agentBrowserPlugin.plugin(

--- a/plugins/agent-browser/index.ts
+++ b/plugins/agent-browser/index.ts
@@ -1,75 +1,46 @@
 import { join } from 'node:path'
 
-import { z } from 'zod'
+import { definePlugin } from '@/plugin'
 
-import { definePlugin, defineTool } from '@/plugin'
-
-import { startAgentBrowserDashboardProxy, type AgentBrowserDashboardProxy } from './dashboard-proxy'
-
-export const DASHBOARD_TOOL_NAME = 'agent_browser_dashboard'
-const DASHBOARD_PROXY_PORT = 4848
-
-const DASHBOARD_REWRITE_INSTRUCTION = `# agent-browser dashboard override
-
-When the user asks for the agent-browser dashboard, or when you would run \`agent-browser dashboard\`, do not execute the raw dashboard command. Use the \`${DASHBOARD_TOOL_NAME}\` tool instead. That tool starts the real dashboard behind a TypeClaw compatibility proxy so remote/Tailscale dashboard URLs work.`
+import { installShim, type InstallShimResult } from './shim-install'
 
 export default definePlugin({
-  plugin: async () => {
-    let dashboard: AgentBrowserDashboardProxy | null = null
-
-    const dashboardTool = defineTool({
-      description:
-        'Start, stop, or inspect the TypeClaw-compatible agent-browser dashboard proxy. Use this instead of running raw `agent-browser dashboard`.',
-      parameters: z.object({
-        action: z.enum(['start', 'stop', 'status']).optional().describe('Dashboard action. Defaults to start.'),
-      }),
-      async execute(args) {
-        const action = args.action ?? 'start'
-
-        if (action === 'status') {
-          const text = dashboard === null ? 'agent-browser dashboard is stopped.' : dashboardStatus(dashboard)
-          return { content: [{ type: 'text', text }] }
-        }
-
-        if (action === 'stop') {
-          if (dashboard !== null) {
-            await dashboard.stop()
-            dashboard = null
-          }
-          return { content: [{ type: 'text', text: 'agent-browser dashboard stopped.' }] }
-        }
-
-        if (dashboard === null) dashboard = await startAgentBrowserDashboardProxy()
-        return { content: [{ type: 'text', text: dashboardStatus(dashboard) }] }
-      },
-    })
+  plugin: async (ctx) => {
+    const result = safeInstallShim()
+    logInstallResult(ctx.logger, result)
 
     return {
       skillsDirs: [join(import.meta.dir, 'skills')],
-      tools: { [DASHBOARD_TOOL_NAME]: dashboardTool },
-      hooks: {
-        'session.prompt': (event) => {
-          event.prompt = `${event.prompt}\n\n${DASHBOARD_REWRITE_INSTRUCTION}`
-        },
-        'tool.before': (event) => {
-          if (event.tool !== 'bash') return
-          const command = event.args.command
-          if (typeof command !== 'string' || !isRawAgentBrowserDashboardCommand(command)) return
-          return {
-            block: true,
-            reason: `Use the ${DASHBOARD_TOOL_NAME} plugin tool instead of raw agent-browser dashboard.`,
-          }
-        },
-      },
     }
   },
 })
 
-function dashboardStatus(dashboard: AgentBrowserDashboardProxy): string {
-  const port = dashboard.proxy.server.port ?? DASHBOARD_PROXY_PORT
-  return `agent-browser dashboard is running through the TypeClaw proxy on port ${port}. Open the externally visible :${port} URL.`
+function safeInstallShim(): InstallShimResult | { kind: 'error'; error: unknown } {
+  try {
+    return installShim()
+  } catch (error) {
+    return { kind: 'error', error }
+  }
 }
 
-export function isRawAgentBrowserDashboardCommand(command: string): boolean {
-  return command.split(/&&|;|\n/).some((part) => /^\s*(?:bunx\s+|npx\s+)?agent-browser\s+dashboard(?:\s|$)/.test(part))
+function logInstallResult(
+  logger: { info: (msg: string) => void; warn: (msg: string) => void },
+  result: InstallShimResult | { kind: 'error'; error: unknown },
+): void {
+  if (result.kind === 'installed') {
+    logger.info(`installed agent-browser shim at ${result.binPath} (real bin: ${result.realBin})`)
+    return
+  }
+  if (result.kind === 'already-installed') {
+    logger.info(`agent-browser shim already installed at ${result.binPath}`)
+    return
+  }
+  if (result.kind === 'no-upstream') {
+    logger.warn(
+      `no upstream agent-browser binary found at ${result.binPath}; ` +
+        `dashboard requests will run unproxied. Run \`bun install -g agent-browser\` inside the container.`,
+    )
+    return
+  }
+  logger.warn(`failed to install agent-browser shim: ${String((result as { error: unknown }).error)}`)
 }

--- a/plugins/agent-browser/shim-install.test.ts
+++ b/plugins/agent-browser/shim-install.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test'
+
+import { installShim, type ShimFs } from './shim-install'
+
+type FakeFile = { kind: 'file'; data: string; mode: number } | { kind: 'symlink'; target: string }
+
+class FakeFs {
+  files = new Map<string, FakeFile>()
+  events: string[] = []
+
+  fs(): ShimFs {
+    return {
+      lstat: (path) => {
+        const file = this.files.get(path)
+        if (!file) return null
+        return { isSymbolicLink: () => file.kind === 'symlink' }
+      },
+      readlink: (path) => {
+        const file = this.files.get(path)
+        if (!file || file.kind !== 'symlink') throw new Error(`not a symlink: ${path}`)
+        return file.target
+      },
+      readFile: (path) => {
+        const file = this.files.get(path)
+        if (!file || file.kind !== 'file') throw new Error(`not a file: ${path}`)
+        return file.data
+      },
+      rename: (from, to) => {
+        const file = this.files.get(from)
+        if (!file) throw new Error(`missing: ${from}`)
+        this.files.delete(from)
+        this.files.set(to, file)
+        this.events.push(`rename:${from}->${to}`)
+      },
+      symlink: (target, path) => {
+        this.files.set(path, { kind: 'symlink', target })
+        this.events.push(`symlink:${path}->${target}`)
+      },
+      writeFile: (path, data, mode) => {
+        this.files.set(path, { kind: 'file', data, mode })
+        this.events.push(`write:${path}:${mode.toString(8)}`)
+      },
+      unlink: (path) => {
+        this.files.delete(path)
+        this.events.push(`unlink:${path}`)
+      },
+      mkdirp: (path) => {
+        this.events.push(`mkdirp:${path}`)
+      },
+    }
+  }
+}
+
+describe('installShim', () => {
+  test('replaces an upstream symlink with an absolute-target stash so the link still resolves', () => {
+    const fake = new FakeFs()
+    fake.files.set('/usr/local/bin/agent-browser', {
+      kind: 'symlink',
+      target: '../../../root/.bun/install/global/node_modules/agent-browser/bin/agent-browser.js',
+    })
+
+    const result = installShim({
+      binPath: '/usr/local/bin/agent-browser',
+      shimEntry: '/agent/node_modules/typeclaw/plugins/agent-browser/shim.ts',
+      fs: fake.fs(),
+    })
+
+    expect(result.kind).toBe('installed')
+    if (result.kind !== 'installed') throw new Error('unreachable')
+    expect(result.binPath).toBe('/usr/local/bin/agent-browser')
+    expect(result.realBin).toBe('/root/.bun/install/global/node_modules/agent-browser/bin/agent-browser.js')
+
+    expect(fake.events).toContain('unlink:/usr/local/bin/agent-browser')
+    expect(fake.events).toContain(
+      'symlink:/usr/local/lib/typeclaw-agent-browser/agent-browser-real->/root/.bun/install/global/node_modules/agent-browser/bin/agent-browser.js',
+    )
+    const stash = fake.files.get('/usr/local/lib/typeclaw-agent-browser/agent-browser-real')
+    if (!stash || stash.kind !== 'symlink') throw new Error('stash not a symlink')
+    expect(stash.target.startsWith('/')).toBe(true)
+
+    const wrapper = fake.files.get('/usr/local/bin/agent-browser')
+    if (!wrapper || wrapper.kind !== 'file') throw new Error('wrapper not written')
+    expect(wrapper.mode).toBe(0o755)
+    expect(wrapper.data).toContain('TYPECLAW_AGENT_BROWSER_REAL_BIN')
+    expect(wrapper.data).toContain('/usr/local/lib/typeclaw-agent-browser/agent-browser-real')
+    expect(wrapper.data).toContain('exec bun run /agent/node_modules/typeclaw/plugins/agent-browser/shim.ts')
+    expect(wrapper.data).toContain('# typeclaw-agent-browser-shim')
+  })
+
+  test('renames an upstream regular file aside (rare: future bun layouts may copy instead of symlink)', () => {
+    const fake = new FakeFs()
+    fake.files.set('/usr/local/bin/agent-browser', { kind: 'file', data: '#!/usr/bin/env node\n', mode: 0o755 })
+
+    installShim({ binPath: '/usr/local/bin/agent-browser', shimEntry: '/x/shim.ts', fs: fake.fs() })
+
+    expect(fake.events).toContain(
+      'rename:/usr/local/bin/agent-browser->/usr/local/lib/typeclaw-agent-browser/agent-browser-real',
+    )
+  })
+
+  test('is idempotent: a second run sees the marker and short-circuits', () => {
+    const fake = new FakeFs()
+    fake.files.set('/usr/local/bin/agent-browser', {
+      kind: 'symlink',
+      target: '/some/upstream/bin',
+    })
+
+    installShim({ binPath: '/usr/local/bin/agent-browser', shimEntry: '/x/shim.ts', fs: fake.fs() })
+    fake.events.length = 0
+
+    const second = installShim({ binPath: '/usr/local/bin/agent-browser', shimEntry: '/x/shim.ts', fs: fake.fs() })
+
+    expect(second.kind).toBe('already-installed')
+    expect(fake.events).toEqual([])
+  })
+
+  test('returns no-upstream when nothing is at the bin path', () => {
+    const fake = new FakeFs()
+
+    const result = installShim({ binPath: '/nope/agent-browser', shimEntry: '/x/shim.ts', fs: fake.fs() })
+
+    expect(result.kind).toBe('no-upstream')
+    expect(fake.events).toEqual([])
+  })
+})

--- a/plugins/agent-browser/shim-install.ts
+++ b/plugins/agent-browser/shim-install.ts
@@ -1,0 +1,101 @@
+import { lstatSync, readFileSync, readlinkSync, renameSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve as resolvePath } from 'node:path'
+
+import { REAL_BIN_ENV } from './shim'
+
+const DEFAULT_BIN_PATH = '/usr/local/bin/agent-browser'
+const STASH_DIR = '/usr/local/lib/typeclaw-agent-browser'
+const STASH_TARGET = join(STASH_DIR, 'agent-browser-real')
+const SHIM_MARKER = '# typeclaw-agent-browser-shim'
+
+export type InstallShimOptions = {
+  binPath?: string
+  shimEntry?: string
+  fs?: ShimFs
+}
+
+export type ShimFs = {
+  lstat: (path: string) => { isSymbolicLink: () => boolean } | null
+  readlink: (path: string) => string
+  readFile: (path: string) => string
+  rename: (from: string, to: string) => void
+  symlink: (target: string, path: string) => void
+  writeFile: (path: string, data: string, mode: number) => void
+  unlink: (path: string) => void
+  mkdirp: (path: string) => void
+}
+
+export type InstallShimResult =
+  | { kind: 'installed'; realBin: string; binPath: string }
+  | { kind: 'already-installed'; binPath: string }
+  | { kind: 'no-upstream'; binPath: string }
+
+export function installShim(opts: InstallShimOptions = {}): InstallShimResult {
+  const binPath = opts.binPath ?? DEFAULT_BIN_PATH
+  const shimEntry = opts.shimEntry ?? defaultShimEntry()
+  const fs = opts.fs ?? defaultFs()
+
+  const stat = fs.lstat(binPath)
+  if (stat === null) return { kind: 'no-upstream', binPath }
+
+  if (isAlreadyShim(binPath, fs)) return { kind: 'already-installed', binPath }
+
+  const realBin = resolveCurrentTarget(binPath, stat, fs)
+  fs.mkdirp(STASH_DIR)
+  if (stat.isSymbolicLink()) {
+    fs.unlink(binPath)
+    fs.symlink(realBin, STASH_TARGET)
+  } else {
+    fs.rename(binPath, STASH_TARGET)
+  }
+
+  fs.writeFile(binPath, renderWrapper(shimEntry), 0o755)
+  return { kind: 'installed', realBin, binPath }
+}
+
+function isAlreadyShim(binPath: string, fs: ShimFs): boolean {
+  try {
+    return fs.readFile(binPath).includes(SHIM_MARKER)
+  } catch {
+    return false
+  }
+}
+
+function resolveCurrentTarget(binPath: string, stat: { isSymbolicLink: () => boolean }, fs: ShimFs): string {
+  if (!stat.isSymbolicLink()) return binPath
+  const target = fs.readlink(binPath)
+  return resolvePath(dirname(binPath), target)
+}
+
+function renderWrapper(shimEntry: string): string {
+  return `#!/bin/sh
+${SHIM_MARKER}
+export ${REAL_BIN_ENV}="\${${REAL_BIN_ENV}:-${STASH_TARGET}}"
+exec bun run ${shimEntry} "$@"
+`
+}
+
+function defaultShimEntry(): string {
+  return resolvePath(import.meta.dir, 'shim.ts')
+}
+
+function defaultFs(): ShimFs {
+  return {
+    lstat: (path) => {
+      try {
+        return lstatSync(path)
+      } catch {
+        return null
+      }
+    },
+    readlink: readlinkSync,
+    readFile: (path) => readFileSync(path, 'utf-8'),
+    rename: renameSync,
+    symlink: symlinkSync,
+    writeFile: (path, data, mode) => writeFileSync(path, data, { mode }),
+    unlink: unlinkSync,
+    mkdirp: (path) => {
+      Bun.spawnSync(['mkdir', '-p', path])
+    },
+  }
+}

--- a/plugins/agent-browser/shim.test.ts
+++ b/plugins/agent-browser/shim.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from 'bun:test'
+
+import { classifyDashboardCommand, rewriteDashboardArgs, runShim } from './shim'
+
+describe('classifyDashboardCommand', () => {
+  test.each([
+    ['dashboard', 'start'],
+    ['dashboard start', 'start'],
+    ['dashboard start --port 4849', 'start'],
+    ['dashboard --port 4849', 'start'],
+    ['dashboard stop', 'stop'],
+    ['dashboard stop --json', 'stop'],
+    ['open https://example.com', 'other'],
+    ['snapshot', 'other'],
+    ['skills get core', 'other'],
+    ['', 'other'],
+  ])('%s → %s', (cmd, expected) => {
+    expect(classifyDashboardCommand(cmd.split(' ').filter(Boolean))).toBe(expected as never)
+  })
+
+  test('classifies an unknown subcommand as other so we do not start a proxy for it', () => {
+    expect(classifyDashboardCommand(['dashboard', 'reload'])).toBe('other')
+  })
+
+  test('skips leading global flags so a future global flag does not break detection', () => {
+    expect(classifyDashboardCommand(['--verbose', 'dashboard'])).toBe('start')
+    expect(classifyDashboardCommand(['--verbose', 'open', 'https://example.com'])).toBe('other')
+  })
+})
+
+describe('rewriteDashboardArgs', () => {
+  test('inserts start subcommand and --port when the caller relied on implicit start', () => {
+    expect(rewriteDashboardArgs(['dashboard'], 4849)).toEqual(['dashboard', 'start', '--port', '4849'])
+  })
+
+  test('preserves an explicit start and appends --port', () => {
+    expect(rewriteDashboardArgs(['dashboard', 'start'], 4849)).toEqual(['dashboard', 'start', '--port', '4849'])
+  })
+
+  test('strips and replaces a user --port to prevent bypassing the proxy', () => {
+    expect(rewriteDashboardArgs(['dashboard', 'start', '--port', '9999'], 4849)).toEqual([
+      'dashboard',
+      'start',
+      '--port',
+      '4849',
+    ])
+    expect(rewriteDashboardArgs(['dashboard', 'start', '-p', '9999'], 4849)).toEqual([
+      'dashboard',
+      'start',
+      '--port',
+      '4849',
+    ])
+    expect(rewriteDashboardArgs(['dashboard', 'start', '--port=9999'], 4849)).toEqual([
+      'dashboard',
+      'start',
+      '--port',
+      '4849',
+    ])
+  })
+
+  test('handles implicit-start with --port: synthesizes start AND drops the user --port', () => {
+    expect(rewriteDashboardArgs(['dashboard', '--port', '9999'], 4849)).toEqual([
+      'dashboard',
+      'start',
+      '--port',
+      '4849',
+    ])
+  })
+
+  test('preserves non-port flags', () => {
+    expect(rewriteDashboardArgs(['dashboard', 'start', '--json', '--port', '9999'], 4849)).toEqual([
+      'dashboard',
+      'start',
+      '--json',
+      '--port',
+      '4849',
+    ])
+  })
+})
+
+describe('runShim', () => {
+  test('passthrough: spawns real bin with unchanged argv and no proxy', async () => {
+    let proxyStarted = false
+    const spawned: string[][] = []
+
+    const exit = await runShim({
+      argv: ['open', 'https://example.com'],
+      realBin: '/stub/agent-browser',
+      proxyPort: 4848,
+      upstreamPort: 4849,
+      spawn: (cmd) => {
+        spawned.push(cmd)
+        return { exited: Promise.resolve(0) }
+      },
+      startProxy: () => {
+        proxyStarted = true
+        return { server: { stop: () => {} } as never, stop: () => {} }
+      },
+    })
+
+    expect(exit).toBe(0)
+    expect(proxyStarted).toBe(false)
+    expect(spawned).toEqual([['/stub/agent-browser', 'open', 'https://example.com']])
+  })
+
+  test('dashboard stop: passthrough, no proxy started', async () => {
+    let proxyStarted = false
+    const spawned: string[][] = []
+
+    const exit = await runShim({
+      argv: ['dashboard', 'stop'],
+      realBin: '/stub/agent-browser',
+      spawn: (cmd) => {
+        spawned.push(cmd)
+        return { exited: Promise.resolve(0) }
+      },
+      startProxy: () => {
+        proxyStarted = true
+        return { server: { stop: () => {} } as never, stop: () => {} }
+      },
+    })
+
+    expect(exit).toBe(0)
+    expect(proxyStarted).toBe(false)
+    expect(spawned).toEqual([['/stub/agent-browser', 'dashboard', 'stop']])
+  })
+
+  test('dashboard start: starts proxy, rewrites --port, spawns real bin, stops proxy on exit', async () => {
+    const spawned: string[][] = []
+    const proxyEvents: string[] = []
+
+    const exit = await runShim({
+      argv: ['dashboard', 'start', '--port', '9999'],
+      realBin: '/stub/agent-browser',
+      proxyPort: 4848,
+      upstreamPort: 4849,
+      spawn: (cmd) => {
+        spawned.push(cmd)
+        return { exited: Promise.resolve(0) }
+      },
+      startProxy: (opts = {}) => {
+        proxyEvents.push(`start:${opts.listenPort}:${opts.upstreamPort}`)
+        return {
+          server: { stop: () => {} } as never,
+          stop: () => proxyEvents.push('stop'),
+        }
+      },
+    })
+
+    expect(exit).toBe(0)
+    expect(proxyEvents).toEqual(['start:4848:4849', 'stop'])
+    expect(spawned).toEqual([['/stub/agent-browser', 'dashboard', 'start', '--port', '4849']])
+  })
+
+  test('dashboard (implicit start): synthesizes start subcommand', async () => {
+    const spawned: string[][] = []
+
+    await runShim({
+      argv: ['dashboard'],
+      realBin: '/stub/agent-browser',
+      spawn: (cmd) => {
+        spawned.push(cmd)
+        return { exited: Promise.resolve(0) }
+      },
+      startProxy: () => ({ server: { stop: () => {} } as never, stop: () => {} }),
+    })
+
+    expect(spawned).toEqual([['/stub/agent-browser', 'dashboard', 'start', '--port', '4849']])
+  })
+
+  test('dashboard start: stops proxy even when the real binary exits non-zero', async () => {
+    const proxyEvents: string[] = []
+
+    const exit = await runShim({
+      argv: ['dashboard'],
+      realBin: '/stub/agent-browser',
+      spawn: () => ({ exited: Promise.resolve(42) }),
+      startProxy: () => {
+        proxyEvents.push('start')
+        return {
+          server: { stop: () => {} } as never,
+          stop: () => proxyEvents.push('stop'),
+        }
+      },
+    })
+
+    expect(exit).toBe(42)
+    expect(proxyEvents).toEqual(['start', 'stop'])
+  })
+
+  test('dashboard start: stops proxy even when spawn rejects', async () => {
+    const proxyEvents: string[] = []
+
+    await expect(
+      runShim({
+        argv: ['dashboard'],
+        realBin: '/stub/agent-browser',
+        spawn: () => ({ exited: Promise.reject(new Error('boom')) }),
+        startProxy: () => {
+          proxyEvents.push('start')
+          return {
+            server: { stop: () => {} } as never,
+            stop: () => proxyEvents.push('stop'),
+          }
+        },
+      }),
+    ).rejects.toThrow('boom')
+
+    expect(proxyEvents).toEqual(['start', 'stop'])
+  })
+})

--- a/plugins/agent-browser/shim.ts
+++ b/plugins/agent-browser/shim.ts
@@ -1,0 +1,154 @@
+// PATH-shadow shim installed at the global bin path that `bun install -g
+// agent-browser` previously occupied. Replaces the plugin's old prompt-nudge +
+// bash-regex `tool.before` block, which was leaky (missed shell variations,
+// bypassed by `typeclaw shell`, by spawned subprocesses, by the user typing
+// it directly). Now ANY in-container `agent-browser` caller routes through
+// here — the dashboard subcommand transparently gets the proxy in front,
+// every other subcommand passes through unchanged.
+
+import { existsSync } from 'node:fs'
+
+import {
+  AGENT_BROWSER_DASHBOARD_PROXY_PORT,
+  AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT,
+  startDashboardProxy,
+} from './dashboard-proxy'
+
+export const REAL_BIN_ENV = 'TYPECLAW_AGENT_BROWSER_REAL_BIN'
+
+export type DashboardIntent = 'start' | 'stop' | 'other'
+
+export function classifyDashboardCommand(argv: readonly string[]): DashboardIntent {
+  // Find the first non-flag token. `agent-browser` takes no pre-subcommand
+  // global flags today; the loop is defensive against future ones.
+  let dashboardIdx = -1
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]!
+    if (arg.startsWith('-')) continue
+    if (arg !== 'dashboard') return 'other'
+    dashboardIdx = i
+    break
+  }
+  if (dashboardIdx === -1) return 'other'
+
+  // Look for the next non-flag token after `dashboard`. Upstream treats a
+  // missing subcommand as `start`, so we do too — that path needs the proxy.
+  // `--port <n>` and `-p <n>` consume two argv entries; the value is not a
+  // subcommand and must not be classified as one.
+  for (let i = dashboardIdx + 1; i < argv.length; i += 1) {
+    const arg = argv[i]!
+    if (arg === '--port' || arg === '-p') {
+      i += 1
+      continue
+    }
+    if (arg.startsWith('-')) continue
+    if (arg === 'stop') return 'stop'
+    if (arg === 'start') return 'start'
+    return 'other'
+  }
+  return 'start'
+}
+
+export function rewriteDashboardArgs(argv: readonly string[], upstreamPort: number): string[] {
+  // Force --port to upstreamPort regardless of what the caller passed. The
+  // proxy on AGENT_BROWSER_DASHBOARD_PROXY_PORT is the only externally
+  // visible surface; honoring a user --port would let a caller bypass the
+  // proxy by listening directly on the externally forwarded port. Insert
+  // `start` explicitly when the caller relied on the implicit-start behavior
+  // so the appended `--port` lands on a subcommand upstream accepts.
+  const stripped: string[] = []
+  let i = 0
+  while (i < argv.length) {
+    const arg = argv[i]!
+    if (arg === '--port' || arg === '-p') {
+      i += 2
+      continue
+    }
+    if (arg.startsWith('--port=')) {
+      i += 1
+      continue
+    }
+    stripped.push(arg)
+    i += 1
+  }
+
+  const dashboardIdx = stripped.findIndex((a) => !a.startsWith('-'))
+  const hasSubcommand = stripped.slice(dashboardIdx + 1).some((a) => !a.startsWith('-'))
+  const out = hasSubcommand
+    ? [...stripped]
+    : [...stripped.slice(0, dashboardIdx + 1), 'start', ...stripped.slice(dashboardIdx + 1)]
+  out.push('--port', String(upstreamPort))
+  return out
+}
+
+export function resolveRealAgentBrowserBin(): string {
+  // Set by the installer when it moves the upstream symlink aside. Honored
+  // first so unit tests can point at a stub without touching the filesystem.
+  const fromEnv = process.env[REAL_BIN_ENV]
+  if (fromEnv && fromEnv.length > 0) return fromEnv
+
+  // Fallback: `bun install -g agent-browser` ships per-platform native bins
+  // under this stable path inside the bun image. The installer should have
+  // stashed a copy/symlink, but if a user ran `typeclaw start` against an
+  // image where the installer hasn't yet run, we can still find the real
+  // bin and proxy correctly (the next plugin boot will install the shim).
+  const arch = process.arch === 'arm64' ? 'arm64' : process.arch === 'x64' ? 'x64' : null
+  const platform = process.platform === 'linux' ? 'linux' : process.platform === 'darwin' ? 'darwin' : null
+  if (arch !== null && platform !== null) {
+    const native = `/root/.bun/install/global/node_modules/agent-browser/bin/agent-browser-${platform}-${arch}`
+    if (existsSync(native)) return native
+  }
+
+  throw new Error(
+    `${REAL_BIN_ENV} is not set and no fallback agent-browser binary was found. ` +
+      `The shim cannot resolve the real upstream binary; refusing to exec to avoid an infinite loop.`,
+  )
+}
+
+export type ShimOptions = {
+  argv?: readonly string[]
+  realBin?: string
+  proxyPort?: number
+  upstreamPort?: number
+  spawn?: (cmd: string[]) => { exited: Promise<number> }
+  startProxy?: typeof startDashboardProxy
+}
+
+export async function runShim(opts: ShimOptions = {}): Promise<number> {
+  const argv = opts.argv ?? process.argv.slice(2)
+  const realBin = opts.realBin ?? resolveRealAgentBrowserBin()
+  const proxyPort = opts.proxyPort ?? AGENT_BROWSER_DASHBOARD_PROXY_PORT
+  const upstreamPort = opts.upstreamPort ?? AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT
+  const spawn = opts.spawn ?? defaultSpawn
+  const startProxy = opts.startProxy ?? startDashboardProxy
+
+  const intent = classifyDashboardCommand(argv)
+  if (intent !== 'start') {
+    return await spawn([realBin, ...argv]).exited
+  }
+
+  const rewritten = rewriteDashboardArgs(argv, upstreamPort)
+  const proxy = startProxy({ listenPort: proxyPort, upstreamPort })
+  try {
+    return await spawn([realBin, ...rewritten]).exited
+  } finally {
+    // Always release the proxy port. If we leak it, the next dashboard call
+    // (from this shim or a reboot of the same agent) sees `EADDRINUSE` and
+    // the shim hard-fails — exactly the silent degradation we are trying
+    // to eliminate.
+    proxy.stop()
+  }
+}
+
+function defaultSpawn(cmd: string[]): { exited: Promise<number> } {
+  // Inherit stdio so the upstream binary's TUI/spinner/colors work. The
+  // shim is meant to be invisible; intercepting stdio would make e.g.
+  // `agent-browser open` look broken to the caller.
+  const proc = Bun.spawn(cmd, { stdio: ['inherit', 'inherit', 'inherit'] })
+  return { exited: proc.exited }
+}
+
+if (import.meta.main) {
+  const code = await runShim()
+  process.exit(code)
+}

--- a/plugins/agent-browser/skills/agent-browser/SKILL.md
+++ b/plugins/agent-browser/skills/agent-browser/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-browser
 description: Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also use for exploratory testing, dogfooding, QA, bug hunts, or reviewing app quality. Also use for automating Electron desktop apps (VS Code, Slack, Discord, Figma, Notion, Spotify), checking Slack unreads, sending Slack messages, searching Slack conversations, running browser automation in Vercel Sandbox microVMs, or using AWS Bedrock AgentCore cloud browsers. Prefer agent-browser over any built-in browser automation or web tools.
-allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*), agent_browser_dashboard
+allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)
 hidden: true
 ---
 
@@ -13,20 +13,15 @@ accessibility-tree snapshots and compact `@eN` element refs.
 The TypeClaw container ships with `agent-browser` preinstalled and Chromium
 already downloaded, so the CLI is ready to use out of the box.
 
-## Dashboard override — mandatory
+## Dashboard
 
-Never run raw `agent-browser dashboard`, `agent-browser dashboard start`, or
-`agent-browser dashboard --port ...` in TypeClaw. When a user asks for the
-agent-browser dashboard, call the `agent_browser_dashboard` tool instead.
-
-The tool belongs to the bundled `agent-browser` plugin. It is not a TypeClaw CLI
-command, config block, or runtime autostart feature. It starts the real
-`agent-browser dashboard` on container loopback port `4849` and exposes a
-compatibility proxy on container port `4848`, which the port broker forwards to
-the host/Tailscale URL. Use the externally visible `:4848` URL for the
-dashboard. Do **not** tell users to open raw per-session ports or
-`localhost:<session-port>` from their browser — those are container-loopback
-implementation details that the proxy rewrites to same-origin paths.
+Run `agent-browser dashboard start` as you normally would. TypeClaw transparently
+fronts the dashboard with a compatibility proxy so the externally visible
+`http://<host>:4848/` URL works over Tailscale and other remote networks
+(loopback session URLs hardcoded into the dashboard JS get rewritten to traverse
+the same origin). No special flag, tool, or config is required — the shim
+handles the rewrite invisibly. Use the `:4848` URL when sharing the dashboard,
+not raw per-session ports or `localhost:<session-port>`.
 
 **Headless only.** TypeClaw runs inside a Docker container with no X server
 or `$DISPLAY`, so never pass `--headed` to any `agent-browser` command. A


### PR DESCRIPTION
## Why

The agent-browser plugin used to enforce its dashboard proxy via three layers — a `session.prompt` nudge, a `tool.before` bash regex block, and an `agent_browser_dashboard` plugin tool — but every layer leaked:

- The bash regex missed shell variations (env prefixes, nohup, parens, backgrounding, `bash -c '...'`, scripts that wrap the call).
- `typeclaw shell` bypassed the bash tool runner entirely.
- Any subprocess that spawned `agent-browser` directly skipped both.

Concrete failure observed in production: on `m1.chicken-temperature.ts.net:4848` the dashboard responded but the in-page JS connected to `localhost:<sessionPort>` and failed (ERR_CONNECTION_REFUSED), because the agent ran `agent-browser dashboard start` via the bash tool in a way that was not caught by the regex, the upstream bound directly to 4848 with hardcoded-localhost JS, and the proxy never started. The plugin tool was correct; the enforcement around it was leaky.

This PR moves the proxy below the bypass layer. The plugin now installs a tiny shim at `/usr/local/bin/agent-browser` (the same path `bun install -g agent-browser` previously occupied) and stashes the real binary at `/usr/local/lib/typeclaw-agent-browser/agent-browser-real`. Every in-container caller — bash tool, `typeclaw shell`, spawned subprocesses, the user typing it directly — flows through the shim.

## What changed

### Behavior

- `agent-browser dashboard start` (and the implicit-start form `agent-browser dashboard`): forced onto upstream port 4849 with the proxy front on 4848. Caller-supplied `--port`/`-p`/`--port=` are stripped so the proxy cannot be bypassed by listening directly on the externally forwarded port.
- `agent-browser dashboard stop`: passthrough, no proxy.
- Every other subcommand (`open`, `snapshot`, `batch`, `skills get core`, ...): pure passthrough, no behavior change.

### Added

- `plugins/agent-browser/shim.ts` — entrypoint the wrapper exec-runs under bun. Classifies argv into start/stop/other, passes through everything except dashboard start, and on dashboard start forces upstream onto 4849 while standing the proxy front on 4848. Strips any caller-supplied `--port` to prevent bypass.
- `plugins/agent-browser/shim-install.ts` — replaces `/usr/local/bin/agent-browser` with the wrapper.
- `plugins/agent-browser/shim.test.ts` — unit tests for shim argv classifier, `--port` rewriting, proxy lifecycle, installer symlink replacement (absolute-target check), idempotence, and no-upstream branch. New regression tests for `maybeInjectDashboardPatch` cover the missing-`</head>` and no-`<head>`-at-all fallbacks.

### Removed

- `tool.before` bash regex block — gone.
- `session.prompt` nudge — gone.
- `agent_browser_dashboard` plugin tool — gone.
- `isRawAgentBrowserDashboardCommand`, `startAgentBrowserDashboardProxy`, `stopAgentBrowserDashboard`, `runAgentBrowserDashboardCommand`, `resolveAgentBrowserExecutable`, and the `import.meta.main` runner — all callers are gone after the shim takes over.
- The "Dashboard override — mandatory" section from the agent-browser skill markdown — running `agent-browser dashboard start` is the documented happy path again.

Plugin index: 75 lines → 43 lines (net deletions).

## Implementation notes

**Stash symlink uses absolute target.** The original `/usr/local/bin/agent-browser` is a symlink with a relative target like `../../../root/.bun/install/global/node_modules/agent-browser/bin/agent-browser.js`. Resolved from `/usr/local/bin/` that's `/root/.bun/...`; resolved from the deeper stash path `/usr/local/lib/typeclaw-agent-browser/` it becomes `/usr/root/.bun/...` (broken). The installer detects the symlink case and re-symlinks the stash with the absolute resolved target.

**HTML injection fallback.** `maybeInjectDashboardPatch` previously matched only literal `</head>`; production HTML from the agent-browser dashboard (Next.js-streamed) opens `<head>` but the closing tag wasn't in the response body we got. The injector now falls back to inserting after the opening `<head>` (or `<html>`) tag when no closing `</head>` exists.

**Implicit-start subcommand handling.** Upstream treats `agent-browser dashboard` (no sub) as `dashboard start`. The shim synthesizes the `start` token before appending `--port 4849`, so `dashboard --port X` reaches upstream as `dashboard start --port 4849` instead of the rejected `dashboard --port 4849`.

## Tests

1725 tests pass; lint, typecheck, format all clean (per AGENTS.md pre-commit gate).

New unit tests cover: shim argv classifier (start/stop/other, including pre-flag globals and `--port <n>` arg-pair handling), `--port` rewriting (incl. implicit-start synthesis), proxy lifecycle on success/error/throw, installer symlink replacement (absolute-target check), idempotence, no-upstream branch.

New regression tests for `maybeInjectDashboardPatch` cover both the missing-`</head>` and no-`<head>`-at-all fallbacks.

Verified end-to-end inside `oven/bun:1-slim`: `bun install -g agent-browser` → install shim → `agent-browser --help` (passthrough), `agent-browser open --help` (passthrough), `agent-browser dashboard stop` (passthrough, prints "Dashboard is not running"), `agent-browser dashboard start` (real upstream prints `Dashboard started at http://localhost:4849` — i.e. the forced port).

## Risks / review notes

- The shim is per-container and runs in the plugin factory at agent boot. If the plugin is not loaded in `typeclaw.json#plugins`, the shim is not installed and behavior is unchanged. (The plugin is bundled and auto-loaded for everyone, but worth noting.)
- `TYPECLAW_AGENT_BROWSER_REAL_BIN` env var is honored first by the resolver — exposes a clean test seam, but also means a malicious caller inside the container could point it at a different binary. The container is a single-trust-domain (the agent owns it), so this is acceptable.
- We force `--port 4849` unconditionally for dashboard start. A user who wants to run two dashboards on different ports cannot. This is intentional: the proxy owns the externally visible port (4848) and there is no use case for a second uncoordinated dashboard inside the same container.