### PR TITLE
Also shadow agent-browser at /agent/node_modules/.bin

### DIFF
--- a/plugins/agent-browser/index.ts
+++ b/plugins/agent-browser/index.ts
@@ -2,12 +2,15 @@ import { join } from 'node:path'
 
 import { definePlugin } from '@/plugin'
 
-import { installShim, type InstallShimResult } from './shim-install'
+import { installShim, KNOWN_BIN_PATHS, type InstallShimResult } from './shim-install'
+
+type SafeResult = InstallShimResult | { kind: 'error'; binPath: string; error: unknown }
 
 export default definePlugin({
   plugin: async (ctx) => {
-    const result = safeInstallShim()
-    logInstallResult(ctx.logger, result)
+    for (const binPath of Object.values(KNOWN_BIN_PATHS)) {
+      logInstallResult(ctx.logger, safeInstallShim(binPath))
+    }
 
     return {
       skillsDirs: [join(import.meta.dir, 'skills')],
@@ -15,17 +18,17 @@ export default definePlugin({
   },
 })
 
-function safeInstallShim(): InstallShimResult | { kind: 'error'; error: unknown } {
+function safeInstallShim(binPath: string): SafeResult {
   try {
-    return installShim()
+    return installShim({ binPath })
   } catch (error) {
-    return { kind: 'error', error }
+    return { kind: 'error', binPath, error }
   }
 }
 
 function logInstallResult(
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
-  result: InstallShimResult | { kind: 'error'; error: unknown },
+  result: SafeResult,
 ): void {
   if (result.kind === 'installed') {
     logger.info(`installed agent-browser shim at ${result.binPath} (real bin: ${result.realBin})`)
@@ -36,11 +39,8 @@ function logInstallResult(
     return
   }
   if (result.kind === 'no-upstream') {
-    logger.warn(
-      `no upstream agent-browser binary found at ${result.binPath}; ` +
-        `dashboard requests will run unproxied. Run \`bun install -g agent-browser\` inside the container.`,
-    )
+    logger.info(`no agent-browser binary at ${result.binPath}; skipping`)
     return
   }
-  logger.warn(`failed to install agent-browser shim: ${String((result as { error: unknown }).error)}`)
+  logger.warn(`failed to install agent-browser shim at ${result.binPath}: ${String(result.error)}`)
 }

--- a/plugins/agent-browser/shim-install.test.ts
+++ b/plugins/agent-browser/shim-install.test.ts
@@ -71,10 +71,13 @@ describe('installShim', () => {
     expect(result.realBin).toBe('/root/.bun/install/global/node_modules/agent-browser/bin/agent-browser.js')
 
     expect(fake.events).toContain('unlink:/usr/local/bin/agent-browser')
-    expect(fake.events).toContain(
-      'symlink:/usr/local/lib/typeclaw-agent-browser/agent-browser-real->/root/.bun/install/global/node_modules/agent-browser/bin/agent-browser.js',
+    expect(result.stashTarget).toBe(
+      '/usr/local/lib/typeclaw-agent-browser/usr-local-bin-agent-browser/agent-browser-real',
     )
-    const stash = fake.files.get('/usr/local/lib/typeclaw-agent-browser/agent-browser-real')
+    expect(fake.events).toContain(
+      `symlink:${result.stashTarget}->/root/.bun/install/global/node_modules/agent-browser/bin/agent-browser.js`,
+    )
+    const stash = fake.files.get(result.stashTarget)
     if (!stash || stash.kind !== 'symlink') throw new Error('stash not a symlink')
     expect(stash.target.startsWith('/')).toBe(true)
 
@@ -82,20 +85,65 @@ describe('installShim', () => {
     if (!wrapper || wrapper.kind !== 'file') throw new Error('wrapper not written')
     expect(wrapper.mode).toBe(0o755)
     expect(wrapper.data).toContain('TYPECLAW_AGENT_BROWSER_REAL_BIN')
-    expect(wrapper.data).toContain('/usr/local/lib/typeclaw-agent-browser/agent-browser-real')
+    expect(wrapper.data).toContain(result.stashTarget)
     expect(wrapper.data).toContain('exec bun run /agent/node_modules/typeclaw/plugins/agent-browser/shim.ts')
     expect(wrapper.data).toContain('# typeclaw-agent-browser-shim')
+  })
+
+  test('per-binPath stash directory keeps global and local installs from colliding', () => {
+    const fake = new FakeFs()
+    fake.files.set('/usr/local/bin/agent-browser', { kind: 'symlink', target: '/global/real' })
+    fake.files.set('/agent/node_modules/.bin/agent-browser', { kind: 'symlink', target: '/local/real' })
+
+    const global = installShim({ binPath: '/usr/local/bin/agent-browser', shimEntry: '/x/shim.ts', fs: fake.fs() })
+    const local = installShim({
+      binPath: '/agent/node_modules/.bin/agent-browser',
+      shimEntry: '/x/shim.ts',
+      fs: fake.fs(),
+    })
+
+    if (global.kind !== 'installed' || local.kind !== 'installed') throw new Error('expected both installed')
+    expect(global.stashTarget).not.toBe(local.stashTarget)
+    expect(global.realBin).toBe('/global/real')
+    expect(local.realBin).toBe('/local/real')
   })
 
   test('renames an upstream regular file aside (rare: future bun layouts may copy instead of symlink)', () => {
     const fake = new FakeFs()
     fake.files.set('/usr/local/bin/agent-browser', { kind: 'file', data: '#!/usr/bin/env node\n', mode: 0o755 })
 
-    installShim({ binPath: '/usr/local/bin/agent-browser', shimEntry: '/x/shim.ts', fs: fake.fs() })
+    const result = installShim({ binPath: '/usr/local/bin/agent-browser', shimEntry: '/x/shim.ts', fs: fake.fs() })
 
-    expect(fake.events).toContain(
-      'rename:/usr/local/bin/agent-browser->/usr/local/lib/typeclaw-agent-browser/agent-browser-real',
-    )
+    if (result.kind !== 'installed') throw new Error('expected installed')
+    expect(fake.events).toContain(`rename:/usr/local/bin/agent-browser->${result.stashTarget}`)
+  })
+
+  test('re-installs after host-side bun install restored the original symlink (idempotent re-shim)', () => {
+    const fake = new FakeFs()
+    fake.files.set('/agent/node_modules/.bin/agent-browser', {
+      kind: 'symlink',
+      target: '../agent-browser/bin/agent-browser.js',
+    })
+
+    const first = installShim({
+      binPath: '/agent/node_modules/.bin/agent-browser',
+      shimEntry: '/x/shim.ts',
+      fs: fake.fs(),
+    })
+    expect(first.kind).toBe('installed')
+
+    fake.files.set('/agent/node_modules/.bin/agent-browser', {
+      kind: 'symlink',
+      target: '../agent-browser/bin/agent-browser.js',
+    })
+
+    const second = installShim({
+      binPath: '/agent/node_modules/.bin/agent-browser',
+      shimEntry: '/x/shim.ts',
+      fs: fake.fs(),
+    })
+
+    expect(second.kind).toBe('installed')
   })
 
   test('is idempotent: a second run sees the marker and short-circuits', () => {

--- a/plugins/agent-browser/shim-install.ts
+++ b/plugins/agent-browser/shim-install.ts
@@ -3,13 +3,14 @@ import { dirname, join, resolve as resolvePath } from 'node:path'
 
 import { REAL_BIN_ENV } from './shim'
 
-const DEFAULT_BIN_PATH = '/usr/local/bin/agent-browser'
-const STASH_DIR = '/usr/local/lib/typeclaw-agent-browser'
-const STASH_TARGET = join(STASH_DIR, 'agent-browser-real')
+const DEFAULT_GLOBAL_BIN_PATH = '/usr/local/bin/agent-browser'
+const DEFAULT_LOCAL_BIN_PATH = '/agent/node_modules/.bin/agent-browser'
+const STASH_ROOT = '/usr/local/lib/typeclaw-agent-browser'
 const SHIM_MARKER = '# typeclaw-agent-browser-shim'
 
 export type InstallShimOptions = {
   binPath?: string
+  stashDir?: string
   shimEntry?: string
   fs?: ShimFs
 }
@@ -26,14 +27,16 @@ export type ShimFs = {
 }
 
 export type InstallShimResult =
-  | { kind: 'installed'; realBin: string; binPath: string }
+  | { kind: 'installed'; realBin: string; binPath: string; stashTarget: string }
   | { kind: 'already-installed'; binPath: string }
   | { kind: 'no-upstream'; binPath: string }
 
 export function installShim(opts: InstallShimOptions = {}): InstallShimResult {
-  const binPath = opts.binPath ?? DEFAULT_BIN_PATH
+  const binPath = opts.binPath ?? DEFAULT_GLOBAL_BIN_PATH
   const shimEntry = opts.shimEntry ?? defaultShimEntry()
   const fs = opts.fs ?? defaultFs()
+  const stashDir = opts.stashDir ?? defaultStashDir(binPath)
+  const stashTarget = join(stashDir, 'agent-browser-real')
 
   const stat = fs.lstat(binPath)
   if (stat === null) return { kind: 'no-upstream', binPath }
@@ -41,16 +44,32 @@ export function installShim(opts: InstallShimOptions = {}): InstallShimResult {
   if (isAlreadyShim(binPath, fs)) return { kind: 'already-installed', binPath }
 
   const realBin = resolveCurrentTarget(binPath, stat, fs)
-  fs.mkdirp(STASH_DIR)
+  fs.mkdirp(stashDir)
   if (stat.isSymbolicLink()) {
     fs.unlink(binPath)
-    fs.symlink(realBin, STASH_TARGET)
+    if (fs.lstat(stashTarget) !== null) fs.unlink(stashTarget)
+    fs.symlink(realBin, stashTarget)
   } else {
-    fs.rename(binPath, STASH_TARGET)
+    if (fs.lstat(stashTarget) !== null) fs.unlink(stashTarget)
+    fs.rename(binPath, stashTarget)
   }
 
-  fs.writeFile(binPath, renderWrapper(shimEntry), 0o755)
-  return { kind: 'installed', realBin, binPath }
+  fs.writeFile(binPath, renderWrapper(shimEntry, stashTarget), 0o755)
+  return { kind: 'installed', realBin, binPath, stashTarget }
+}
+
+export const KNOWN_BIN_PATHS = {
+  global: DEFAULT_GLOBAL_BIN_PATH,
+  local: DEFAULT_LOCAL_BIN_PATH,
+} as const
+
+function defaultStashDir(binPath: string): string {
+  // Per-binPath subdirectory under the image-owned stash root. Lives outside
+  // every bind-mounted agent folder so a host-side `bun install` cannot
+  // touch it; the wrapper at the bind-mounted location can be clobbered by
+  // host-side installs but the stash and image-level real binary stay safe.
+  const slug = binPath.replace(/[^A-Za-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+  return join(STASH_ROOT, slug)
 }
 
 function isAlreadyShim(binPath: string, fs: ShimFs): boolean {
@@ -67,10 +86,10 @@ function resolveCurrentTarget(binPath: string, stat: { isSymbolicLink: () => boo
   return resolvePath(dirname(binPath), target)
 }
 
-function renderWrapper(shimEntry: string): string {
+function renderWrapper(shimEntry: string, stashTarget: string): string {
   return `#!/bin/sh
 ${SHIM_MARKER}
-export ${REAL_BIN_ENV}="\${${REAL_BIN_ENV}:-${STASH_TARGET}}"
+export ${REAL_BIN_ENV}="\${${REAL_BIN_ENV}:-${stashTarget}}"
 exec bun run ${shimEntry} "$@"
 `
 }


### PR DESCRIPTION
## Why

Follow-up to #73 (PATH-shadow agent-browser to make the dashboard proxy unavoidable). #73 shimmed `/usr/local/bin/agent-browser` — the path `bun install -g` occupies — but missed the per-agent local install that typeclaw scaffolds into every agent folder.

**Bug observed in production after #73 merged:** after restarting the agent, `agent-browser dashboard start` was still bypassing the proxy. Inside the container, `which agent-browser` (under bun's package-runner context) returned `/agent/node_modules/.bin/agent-browser` — not the `/usr/local/bin/agent-browser` that #73 shimmed.

**Root cause:** typeclaw scaffolds every agent with `agent-browser` as a per-folder `package.json` dependency (`src/init/index.ts`, `src/init/packagejson.ts`). After `bun install` runs, `node_modules/.bin/agent-browser` exists as a symlink to `node_modules/agent-browser/bin/agent-browser.js`. **bun's package runner resolves `node_modules/.bin` ahead of `PATH`** — same behavior as `npm exec` / `yarn run` — so `agent-browser` invoked from the agent's bash tool goes to the local symlink, not the global shim.

Result: #73 correctly covered callers that found `agent-browser` via raw `PATH` lookup (manual `typeclaw shell`, subprocesses spawned outside bun's project context), but the primary caller — the agent's bash tool, which inherits bun's resolution order — bypassed it. The dashboard kept binding raw on 4848 with hardcoded-localhost JS.

**Verified in `oven/bun:1-slim`:**
```
$ bun run check   # script context, like the agent's bash tool
$ which agent-browser
/agent/node_modules/.bin/agent-browser   ← bypasses /usr/local/bin shim

$ bun -e 'console.log(Bun.which("agent-browser"))'   # outside script context
/usr/local/bin/agent-browser   ← hits the shim, but agents don't run this way
```

## What changed

### `plugins/agent-browser/shim-install.ts`

- `installShim` now accepts an explicit `binPath` (it already did) and derives a per-binPath stash directory under `/usr/local/lib/typeclaw-agent-browser/<slug>/agent-browser-real`, where `<slug>` is the binPath with non-alphanumeric characters replaced by `-`. This keeps the global and local stash files from colliding.
- New `KNOWN_BIN_PATHS` constant exports both locations the plugin walks: `/usr/local/bin/agent-browser` (image-baked global) and `/agent/node_modules/.bin/agent-browser` (per-agent local).

### `plugins/agent-browser/index.ts`

- Plugin boot loops over `KNOWN_BIN_PATHS` and installs the shim at each location. The `isAlreadyShim` guard makes re-installs cheap.

### `plugins/agent-browser/shim-install.test.ts`

- New: `per-binPath stash directory keeps global and local installs from colliding` — installs both shims back-to-back and asserts the stash targets are distinct and the resolved real-bin paths differ.
- New: `re-installs after host-side bun install restored the original symlink` — guards the bind-mount churn case (host-side `bun install` clobbers the local shim; plugin re-shims on next agent boot).
- Existing tests updated to use `result.stashTarget` instead of the hard-coded path, since the path is now derived from binPath.
- Existing 1735 tests still pass.

## End-to-end verification (in `oven/bun:1-slim` with both global and local installs present)

- Both `/usr/local/bin/agent-browser` and `/agent/node_modules/.bin/agent-browser` get shimmed with separate stash dirs.
- `bun run` script context: `which agent-browser` → local shim at `/tmp/runner/node_modules/.bin/agent-browser`.
- `agent-browser dashboard stop` through the local shim: upstream prints "Dashboard is not running" (correct passthrough).

## Risks / review notes

1. **Local wrapper sits on a bind-mounted path.** A `bun install` from the host will revert `/agent/node_modules/.bin/agent-browser` to the upstream symlink. Mitigation: the plugin re-shims on every agent boot (`typeclaw restart` is sufficient). Edge case: an in-container `bun install` mid-session would restore the symlink until the next boot. In-container `bun install` is rare and the user can `typeclaw restart` to re-shim. Acceptable trade-off.

2. **Slug collision footgun.** The slug function maps `[^A-Za-z0-9]+` → `-`. Two binPaths differing only in non-alphanumeric characters (e.g. `/foo/bar` vs `/foo-bar`) would produce the same slug and share a stash directory. Not a real risk for the two paths shipped today, but documented for anyone adding a third location.

3. **`bunx`/`npx` invocations are not covered.** `bunx agent-browser` resolves through the package manager directly to `node_modules/agent-browser/bin/agent-browser.js`, bypassing both shimmed paths. Known gap; in practice agents do not invoke via `bunx`/`npx` because the binary is already on PATH and in `node_modules/.bin`.