### PR TITLE
Move dashboard proxy from shim to agent process

### DIFF
--- a/plugins/agent-browser/index.test.ts
+++ b/plugins/agent-browser/index.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
 
-import agentBrowserPlugin from './index'
+import agentBrowserPlugin, { __resetProxyForTesting } from './index'
+
+beforeEach(() => {
+  process.env['TYPECLAW_DASHBOARD_PROXY_PORT'] = '0'
+  process.env['TYPECLAW_DASHBOARD_UPSTREAM_PORT'] = '0'
+})
+
+afterEach(() => {
+  __resetProxyForTesting()
+  delete process.env['TYPECLAW_DASHBOARD_PROXY_PORT']
+  delete process.env['TYPECLAW_DASHBOARD_UPSTREAM_PORT']
+})
 
 describe('agent-browser plugin', () => {
   test('contributes the agent-browser skill directory and no hooks/tools', async () => {
@@ -11,6 +22,29 @@ describe('agent-browser plugin', () => {
     expect(exports.skillsDirs).toEqual([expect.stringContaining('plugins/agent-browser/skills')])
     expect(exports.tools).toBeUndefined()
     expect(exports.hooks).toBeUndefined()
+  })
+
+  test('binds the dashboard proxy on the configured port at agent boot', async () => {
+    const messages: string[] = []
+    const logger = {
+      info: (msg: string) => messages.push(`info:${msg}`),
+      warn: (msg: string) => messages.push(`warn:${msg}`),
+      error: (msg: string) => messages.push(`error:${msg}`),
+    }
+
+    await agentBrowserPlugin.plugin(
+      createPluginContext({
+        name: 'agent-browser',
+        version: undefined,
+        agentDir: '/agent',
+        config: undefined,
+        logger,
+        spawnSubagent: async () => {},
+        isBooted: () => true,
+      }),
+    )
+
+    expect(messages.some((m) => m.startsWith('info:dashboard proxy listening on port '))).toBe(true)
   })
 })
 

--- a/plugins/agent-browser/index.ts
+++ b/plugins/agent-browser/index.ts
@@ -2,9 +2,17 @@ import { join } from 'node:path'
 
 import { definePlugin } from '@/plugin'
 
+import {
+  AGENT_BROWSER_DASHBOARD_PROXY_PORT,
+  AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT,
+  startDashboardProxy,
+  type DashboardProxy,
+} from './dashboard-proxy'
 import { installShim, KNOWN_BIN_PATHS, type InstallShimResult } from './shim-install'
 
 type SafeResult = InstallShimResult | { kind: 'error'; binPath: string; error: unknown }
+
+let activeProxy: DashboardProxy | null = null
 
 export default definePlugin({
   plugin: async (ctx) => {
@@ -12,11 +20,58 @@ export default definePlugin({
       logInstallResult(ctx.logger, safeInstallShim(binPath))
     }
 
+    // The proxy lives in the long-lived agent process, NOT in the per-call
+    // shim. `agent-browser dashboard start` daemonizes the upstream and
+    // returns immediately, so a shim-owned proxy would tear down the moment
+    // the start command exits — leaving 4849 alive but 4848 dead. Binding
+    // here means the proxy is up the whole time the agent is up, regardless
+    // of how many times the dashboard is started/stopped.
+    if (activeProxy === null) {
+      activeProxy = safeStartProxy(ctx.logger, readPortConfig())
+      if (activeProxy !== null) {
+        ctx.logger.info(`dashboard proxy listening on port ${activeProxy.server.port ?? '?'}`)
+      }
+    }
+
     return {
       skillsDirs: [join(import.meta.dir, 'skills')],
     }
   },
 })
+
+export function __resetProxyForTesting(): void {
+  activeProxy?.stop()
+  activeProxy = null
+}
+
+type PortConfig = { listenPort: number; upstreamPort: number }
+
+function readPortConfig(): PortConfig {
+  return {
+    listenPort: numberFromEnv('TYPECLAW_DASHBOARD_PROXY_PORT', AGENT_BROWSER_DASHBOARD_PROXY_PORT),
+    upstreamPort: numberFromEnv('TYPECLAW_DASHBOARD_UPSTREAM_PORT', AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT),
+  }
+}
+
+function numberFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined || raw === '') return fallback
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65_535) return fallback
+  return parsed
+}
+
+function safeStartProxy(logger: { warn: (msg: string) => void }, config: PortConfig): DashboardProxy | null {
+  try {
+    return startDashboardProxy(config)
+  } catch (error) {
+    logger.warn(
+      `failed to bind dashboard proxy on port ${config.listenPort}: ${String(error)}; ` +
+        `remote dashboard access will not work until restart`,
+    )
+    return null
+  }
+}
 
 function safeInstallShim(binPath: string): SafeResult {
   try {

--- a/plugins/agent-browser/shim.test.ts
+++ b/plugins/agent-browser/shim.test.ts
@@ -18,7 +18,7 @@ describe('classifyDashboardCommand', () => {
     expect(classifyDashboardCommand(cmd.split(' ').filter(Boolean))).toBe(expected as never)
   })
 
-  test('classifies an unknown subcommand as other so we do not start a proxy for it', () => {
+  test('classifies an unknown subcommand as other so we do not rewrite for it', () => {
     expect(classifyDashboardCommand(['dashboard', 'reload'])).toBe('other')
   })
 
@@ -79,32 +79,24 @@ describe('rewriteDashboardArgs', () => {
 })
 
 describe('runShim', () => {
-  test('passthrough: spawns real bin with unchanged argv and no proxy', async () => {
-    let proxyStarted = false
+  test('passthrough: spawns real bin with unchanged argv for non-dashboard commands', async () => {
     const spawned: string[][] = []
 
     const exit = await runShim({
       argv: ['open', 'https://example.com'],
       realBin: '/stub/agent-browser',
-      proxyPort: 4848,
       upstreamPort: 4849,
       spawn: (cmd) => {
         spawned.push(cmd)
         return { exited: Promise.resolve(0) }
       },
-      startProxy: () => {
-        proxyStarted = true
-        return { server: { stop: () => {} } as never, stop: () => {} }
-      },
     })
 
     expect(exit).toBe(0)
-    expect(proxyStarted).toBe(false)
     expect(spawned).toEqual([['/stub/agent-browser', 'open', 'https://example.com']])
   })
 
-  test('dashboard stop: passthrough, no proxy started', async () => {
-    let proxyStarted = false
+  test('dashboard stop: passthrough, no rewrite', async () => {
     const spawned: string[][] = []
 
     const exit = await runShim({
@@ -114,41 +106,26 @@ describe('runShim', () => {
         spawned.push(cmd)
         return { exited: Promise.resolve(0) }
       },
-      startProxy: () => {
-        proxyStarted = true
-        return { server: { stop: () => {} } as never, stop: () => {} }
-      },
     })
 
     expect(exit).toBe(0)
-    expect(proxyStarted).toBe(false)
     expect(spawned).toEqual([['/stub/agent-browser', 'dashboard', 'stop']])
   })
 
-  test('dashboard start: starts proxy, rewrites --port, spawns real bin, stops proxy on exit', async () => {
+  test('dashboard start: rewrites --port to upstream port and spawns real bin', async () => {
     const spawned: string[][] = []
-    const proxyEvents: string[] = []
 
     const exit = await runShim({
       argv: ['dashboard', 'start', '--port', '9999'],
       realBin: '/stub/agent-browser',
-      proxyPort: 4848,
       upstreamPort: 4849,
       spawn: (cmd) => {
         spawned.push(cmd)
         return { exited: Promise.resolve(0) }
       },
-      startProxy: (opts = {}) => {
-        proxyEvents.push(`start:${opts.listenPort}:${opts.upstreamPort}`)
-        return {
-          server: { stop: () => {} } as never,
-          stop: () => proxyEvents.push('stop'),
-        }
-      },
     })
 
     expect(exit).toBe(0)
-    expect(proxyEvents).toEqual(['start:4848:4849', 'stop'])
     expect(spawned).toEqual([['/stub/agent-browser', 'dashboard', 'start', '--port', '4849']])
   })
 
@@ -162,50 +139,18 @@ describe('runShim', () => {
         spawned.push(cmd)
         return { exited: Promise.resolve(0) }
       },
-      startProxy: () => ({ server: { stop: () => {} } as never, stop: () => {} }),
     })
 
     expect(spawned).toEqual([['/stub/agent-browser', 'dashboard', 'start', '--port', '4849']])
   })
 
-  test('dashboard start: stops proxy even when the real binary exits non-zero', async () => {
-    const proxyEvents: string[] = []
-
+  test('propagates the real binary exit code', async () => {
     const exit = await runShim({
       argv: ['dashboard'],
       realBin: '/stub/agent-browser',
       spawn: () => ({ exited: Promise.resolve(42) }),
-      startProxy: () => {
-        proxyEvents.push('start')
-        return {
-          server: { stop: () => {} } as never,
-          stop: () => proxyEvents.push('stop'),
-        }
-      },
     })
 
     expect(exit).toBe(42)
-    expect(proxyEvents).toEqual(['start', 'stop'])
-  })
-
-  test('dashboard start: stops proxy even when spawn rejects', async () => {
-    const proxyEvents: string[] = []
-
-    await expect(
-      runShim({
-        argv: ['dashboard'],
-        realBin: '/stub/agent-browser',
-        spawn: () => ({ exited: Promise.reject(new Error('boom')) }),
-        startProxy: () => {
-          proxyEvents.push('start')
-          return {
-            server: { stop: () => {} } as never,
-            stop: () => proxyEvents.push('stop'),
-          }
-        },
-      }),
-    ).rejects.toThrow('boom')
-
-    expect(proxyEvents).toEqual(['start', 'stop'])
   })
 })

--- a/plugins/agent-browser/shim.ts
+++ b/plugins/agent-browser/shim.ts
@@ -3,16 +3,16 @@
 // bash-regex `tool.before` block, which was leaky (missed shell variations,
 // bypassed by `typeclaw shell`, by spawned subprocesses, by the user typing
 // it directly). Now ANY in-container `agent-browser` caller routes through
-// here — the dashboard subcommand transparently gets the proxy in front,
-// every other subcommand passes through unchanged.
+// here — the dashboard subcommand transparently gets its --port rewritten
+// onto the agent-process-owned proxy's upstream port, every other subcommand
+// passes through unchanged. The proxy itself lives in the long-lived agent
+// process (see plugins/agent-browser/index.ts); the shim does NOT own its
+// lifecycle, because `agent-browser dashboard start` daemonizes upstream and
+// returns immediately — a shim-owned proxy would die the moment start exits.
 
 import { existsSync } from 'node:fs'
 
-import {
-  AGENT_BROWSER_DASHBOARD_PROXY_PORT,
-  AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT,
-  startDashboardProxy,
-} from './dashboard-proxy'
+import { AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT } from './dashboard-proxy'
 
 export const REAL_BIN_ENV = 'TYPECLAW_AGENT_BROWSER_REAL_BIN'
 
@@ -32,9 +32,9 @@ export function classifyDashboardCommand(argv: readonly string[]): DashboardInte
   if (dashboardIdx === -1) return 'other'
 
   // Look for the next non-flag token after `dashboard`. Upstream treats a
-  // missing subcommand as `start`, so we do too — that path needs the proxy.
-  // `--port <n>` and `-p <n>` consume two argv entries; the value is not a
-  // subcommand and must not be classified as one.
+  // missing subcommand as `start`, so we do too. `--port <n>` and `-p <n>`
+  // consume two argv entries; the value is not a subcommand and must not be
+  // classified as one.
   for (let i = dashboardIdx + 1; i < argv.length; i += 1) {
     const arg = argv[i]!
     if (arg === '--port' || arg === '-p') {
@@ -51,7 +51,7 @@ export function classifyDashboardCommand(argv: readonly string[]): DashboardInte
 
 export function rewriteDashboardArgs(argv: readonly string[], upstreamPort: number): string[] {
   // Force --port to upstreamPort regardless of what the caller passed. The
-  // proxy on AGENT_BROWSER_DASHBOARD_PROXY_PORT is the only externally
+  // proxy on AGENT_BROWSER_DASHBOARD_PROXY_PORT (4848) is the only externally
   // visible surface; honoring a user --port would let a caller bypass the
   // proxy by listening directly on the externally forwarded port. Insert
   // `start` explicitly when the caller relied on the implicit-start behavior
@@ -89,9 +89,9 @@ export function resolveRealAgentBrowserBin(): string {
 
   // Fallback: `bun install -g agent-browser` ships per-platform native bins
   // under this stable path inside the bun image. The installer should have
-  // stashed a copy/symlink, but if a user ran `typeclaw start` against an
-  // image where the installer hasn't yet run, we can still find the real
-  // bin and proxy correctly (the next plugin boot will install the shim).
+  // stashed a copy/symlink, but if the shim runs before the plugin's
+  // installer ever did (e.g. first agent boot), we can still find the real
+  // bin and the next plugin boot will install the shim properly.
   const arch = process.arch === 'arm64' ? 'arm64' : process.arch === 'x64' ? 'x64' : null
   const platform = process.platform === 'linux' ? 'linux' : process.platform === 'darwin' ? 'darwin' : null
   if (arch !== null && platform !== null) {
@@ -108,19 +108,15 @@ export function resolveRealAgentBrowserBin(): string {
 export type ShimOptions = {
   argv?: readonly string[]
   realBin?: string
-  proxyPort?: number
   upstreamPort?: number
   spawn?: (cmd: string[]) => { exited: Promise<number> }
-  startProxy?: typeof startDashboardProxy
 }
 
 export async function runShim(opts: ShimOptions = {}): Promise<number> {
   const argv = opts.argv ?? process.argv.slice(2)
   const realBin = opts.realBin ?? resolveRealAgentBrowserBin()
-  const proxyPort = opts.proxyPort ?? AGENT_BROWSER_DASHBOARD_PROXY_PORT
   const upstreamPort = opts.upstreamPort ?? AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT
   const spawn = opts.spawn ?? defaultSpawn
-  const startProxy = opts.startProxy ?? startDashboardProxy
 
   const intent = classifyDashboardCommand(argv)
   if (intent !== 'start') {
@@ -128,16 +124,7 @@ export async function runShim(opts: ShimOptions = {}): Promise<number> {
   }
 
   const rewritten = rewriteDashboardArgs(argv, upstreamPort)
-  const proxy = startProxy({ listenPort: proxyPort, upstreamPort })
-  try {
-    return await spawn([realBin, ...rewritten]).exited
-  } finally {
-    // Always release the proxy port. If we leak it, the next dashboard call
-    // (from this shim or a reboot of the same agent) sees `EADDRINUSE` and
-    // the shim hard-fails — exactly the silent degradation we are trying
-    // to eliminate.
-    proxy.stop()
-  }
+  return await spawn([realBin, ...rewritten]).exited
 }
 
 function defaultSpawn(cmd: string[]): { exited: Promise<number> } {


### PR DESCRIPTION
## Why

Follow-up to #73 and #74. After both merged and the agent restarted, the dashboard was STILL bypassing the proxy. The shim was correctly installed at both `/usr/local/bin/agent-browser` AND `/agent/node_modules/.bin/agent-browser` (verified by reading the wrapper script — `#!/bin/sh` with the `typeclaw-agent-browser-shim` marker). The shim correctly forced upstream onto port 4849 (verified — `Dashboard started at http://localhost:4849`). But port 4848 was completely dead. Verified via `/proc/net/tcp` showing only `12F1` (4849) bound, no `12F0` (4848).

**Root cause:**

The previous shim design owned the proxy lifecycle:

```ts
const proxy = startProxy({ listenPort: 4848, upstreamPort: 4849 })
try {
  return await spawn([realBin, ...rewrittenArgs]).exited
} finally {
  proxy.stop()
}
```

This relied on the upstream being a foreground process whose `exited` would resolve when the dashboard goes away. It is not. `agent-browser dashboard start` daemonizes the dashboard and the start command itself returns immediately (within ~500ms after the daemon is up). So the sequence was:

1. Shim binds 4848 proxy ✓
2. Shim spawns `agent-browser-real dashboard start --port 4849`
3. Upstream forks the dashboard daemon, foreground returns 0 immediately
4. Shim's `finally { proxy.stop() }` tears down 4848
5. Result: dashboard daemon survives on 4849, proxy on 4848 dies — exactly what was observed

## What changed

Move the proxy into the long-lived agent process. The plugin's factory now binds `startDashboardProxy({ listenPort: 4848, upstreamPort: 4849 })` at agent boot. The proxy lives for the lifetime of the agent process, regardless of how many times `dashboard start` / `dashboard stop` runs. The shim shrinks to just argv classification + `--port` rewriting; no `startProxy`, no `finally`, no proxy lifecycle in the per-call process.

Why this is the right design:

- Bun's long-lived agent process is the natural home for any long-lived TCP listener. `AGENTS.md` explicitly forbids new detached spawning ("This is the only place in the codebase that uses detached spawning — keep it that way" — referring to hostd), so the bug cannot be fixed by daemonizing the proxy as its own process.
- The proxy and the agent share a lifecycle. Container goes down → agent dies → proxy dies → port is freed.
- Multiple `dashboard start` calls in the same agent lifetime no longer race on 4848 because nobody but the agent process binds it.
- `dashboard stop` no longer kills the proxy. The proxy returns 502 on requests until the next `dashboard start` brings 4849 back, which is acceptable.

### `plugins/agent-browser/index.ts`

Plugin factory calls `startDashboardProxy({ listenPort: 4848, upstreamPort: 4849 })` at boot and never tears it down. Module-level `let activeProxy` singleton guards against double-bind in the same process (only relevant in tests; doesn't happen in production).

### `plugins/agent-browser/shim.ts`

Stripped to argv classification + `--port` rewriting. All proxy lifecycle code removed.

### Tests

- `TYPECLAW_DASHBOARD_PROXY_PORT=0` / `TYPECLAW_DASHBOARD_UPSTREAM_PORT=0` — ephemeral ports, no cross-run collisions.
- New `__resetProxyForTesting()` export releases the module-level singleton in `afterEach`.
- Shim tests drop all proxy-related stubbing. The shim's contract is now: classify, rewrite, exec.

### End-to-end verification (`oven/bun:1-slim`, both global + local installs)

1. Boot the plugin (binds proxy on 4848, installs both shims, returns).
2. Spawn `agent-browser dashboard start` through the local shim.
3. Wait for it to exit (the buggy state in production).
4. Curl `http://localhost:4848/` → HTTP 200 (proxy alive after dashboard start exited — opposite of the previous bug).
5. Verify proxy injects `typeclaw_agent_browser_http` script ✓
6. Verify proxy forwards `/api/sessions` to upstream ✓
7. Verify upstream `http://localhost:4849/` does NOT have the injected script (raw upstream, by design) ✓

## Risks / review notes

1. **Proxy outlives the dashboard daemon by design.** If the user runs `dashboard stop` and never `dashboard start` again, port 4848 stays bound to a proxy that 502s on every request. This is strictly better than the alternative (502 vs ECONNREFUSED for the user's browser tab; same effective outcome).

2. **Plugin re-boot does not re-bind.** A `typeclaw reload` does not re-run the plugin factory (per `AGENTS.md`'s `restart-required` rules), so a config change to the proxy port requires a container restart. The agent-browser plugin currently has no config schema, so this is a non-issue today, but worth noting if config is added later.

3. **Test singletons.** The proxy is a module-level `let activeProxy` to survive multiple plugin boots in the same process (which doesn't happen in production but does in tests). `__resetProxyForTesting()` is the test-only escape hatch. If a future test triggers two plugin boots without calling reset, the second boot is a no-op (already-bound). Documented in code.