### PR TITLE
Auto-discover dashboard upstream port

### DIFF
--- a/plugins/agent-browser/dashboard-discovery.test.ts
+++ b/plugins/agent-browser/dashboard-discovery.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { discoverDashboardPort, type ProcFs } from './dashboard-discovery'
+
+let tmp: string
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'tc-discovery-'))
+})
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+function fakeFetcher(byPort: Record<number, { ok: boolean }>): typeof fetch {
+  const impl = async (input: URL | RequestInfo) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    const match = url.match(/:(\d+)\//)
+    if (!match) throw new Error('unexpected fetch url: ' + url)
+    const port = Number(match[1])
+    const cfg = byPort[port]
+    if (!cfg) throw new Error(`ECONNREFUSED ${port}`)
+    return new Response('', { status: cfg.ok ? 200 : 500 })
+  }
+  return impl as unknown as typeof fetch
+}
+
+function fakeProcFs(opts: {
+  pids: Set<number>
+  inodesByPid: Map<number, Set<string>>
+  sockets: Array<{ port: number; inode: string }>
+}): ProcFs {
+  return {
+    pidExists: (pid) => opts.pids.has(pid),
+    listenInodesForPid: (pid) => opts.inodesByPid.get(pid) ?? new Set(),
+    listenSockets: () => opts.sockets,
+  }
+}
+
+describe('discoverDashboardPort', () => {
+  test('returns hint file port when it points at a live dashboard', async () => {
+    const hintPath = join(tmp, 'hint')
+    writeFileSync(hintPath, '4849')
+
+    const port = await discoverDashboardPort({
+      hintPath,
+      pidPath: join(tmp, 'no-pid'),
+      fetchImpl: fakeFetcher({ 4849: { ok: true } }),
+      procfs: fakeProcFs({ pids: new Set(), inodesByPid: new Map(), sockets: [] }),
+    })
+
+    expect(port).toBe(4849)
+  })
+
+  test('falls back to procfs when hint port no longer responds', async () => {
+    const hintPath = join(tmp, 'hint')
+    const pidPath = join(tmp, 'pid')
+    writeFileSync(hintPath, '4849')
+    writeFileSync(pidPath, '42')
+
+    const port = await discoverDashboardPort({
+      hintPath,
+      pidPath,
+      fetchImpl: fakeFetcher({ 7777: { ok: true } }),
+      procfs: fakeProcFs({
+        pids: new Set([42]),
+        inodesByPid: new Map([[42, new Set(['1001'])]]),
+        sockets: [{ port: 7777, inode: '1001' }],
+      }),
+    })
+
+    expect(port).toBe(7777)
+  })
+
+  test('drops the proxy port from the candidate list', async () => {
+    const pidPath = join(tmp, 'pid')
+    writeFileSync(pidPath, '42')
+
+    const port = await discoverDashboardPort({
+      hintPath: join(tmp, 'no-hint'),
+      pidPath,
+      excludePort: 4848,
+      fetchImpl: fakeFetcher({ 9999: { ok: true } }),
+      procfs: fakeProcFs({
+        pids: new Set([42]),
+        inodesByPid: new Map([[42, new Set(['1001', '1002'])]]),
+        sockets: [
+          { port: 4848, inode: '1001' },
+          { port: 9999, inode: '1002' },
+        ],
+      }),
+    })
+
+    expect(port).toBe(9999)
+  })
+
+  test('returns null when pidfile is stale (pid not alive)', async () => {
+    const pidPath = join(tmp, 'pid')
+    writeFileSync(pidPath, '42')
+
+    const port = await discoverDashboardPort({
+      hintPath: join(tmp, 'no-hint'),
+      pidPath,
+      fetchImpl: fakeFetcher({}),
+      procfs: fakeProcFs({ pids: new Set(), inodesByPid: new Map(), sockets: [] }),
+    })
+
+    expect(port).toBeNull()
+  })
+
+  test('returns null when no candidate port responds', async () => {
+    const pidPath = join(tmp, 'pid')
+    writeFileSync(pidPath, '42')
+
+    const port = await discoverDashboardPort({
+      hintPath: join(tmp, 'no-hint'),
+      pidPath,
+      fetchImpl: fakeFetcher({}),
+      procfs: fakeProcFs({
+        pids: new Set([42]),
+        inodesByPid: new Map([[42, new Set(['1001'])]]),
+        sockets: [{ port: 7777, inode: '1001' }],
+      }),
+    })
+
+    expect(port).toBeNull()
+  })
+
+  test('returns null when hint and pid file are both missing', async () => {
+    const port = await discoverDashboardPort({
+      hintPath: join(tmp, 'nope-hint'),
+      pidPath: join(tmp, 'nope-pid'),
+      fetchImpl: fakeFetcher({ 4849: { ok: true } }),
+      procfs: fakeProcFs({ pids: new Set(), inodesByPid: new Map(), sockets: [] }),
+    })
+
+    expect(port).toBeNull()
+  })
+
+  test('rejects malformed hint file content (no probing)', async () => {
+    const hintPath = join(tmp, 'hint')
+    const pidPath = join(tmp, 'pid')
+    writeFileSync(hintPath, 'not a port')
+    writeFileSync(pidPath, '42')
+
+    const probedPorts: number[] = []
+    const fetcher = (async (input: URL | RequestInfo) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      const match = url.match(/:(\d+)\//)
+      if (match) probedPorts.push(Number(match[1]))
+      return new Response('', { status: 200 })
+    }) as unknown as typeof fetch
+
+    await discoverDashboardPort({
+      hintPath,
+      pidPath,
+      fetchImpl: fetcher,
+      procfs: fakeProcFs({
+        pids: new Set([42]),
+        inodesByPid: new Map([[42, new Set(['1001'])]]),
+        sockets: [{ port: 9999, inode: '1001' }],
+      }),
+    })
+
+    expect(probedPorts).not.toContain(NaN)
+    expect(probedPorts).toContain(9999)
+  })
+})

--- a/plugins/agent-browser/dashboard-discovery.ts
+++ b/plugins/agent-browser/dashboard-discovery.ts
@@ -1,0 +1,170 @@
+// Discovers the actual port the agent-browser dashboard daemon is listening
+// on. Necessary because the previous design hardcoded 4849 in the proxy and
+// trusted the shim to force upstream onto that port — but the shim is bypass-
+// able (someone runs `bunx agent-browser dashboard --port 9999`, the binary
+// gets invoked from a path that isn't shimmed, an old container leaves a
+// stale daemon, etc.). The proxy now consults this module to find the
+// dashboard wherever it actually is.
+//
+// Two-stage discovery, fastest signal first:
+//
+//   1. Hint file at PORT_HINT_PATH. The shim writes the port it asked
+//      upstream to bind to (via the rewritten --port). If the file exists,
+//      points at a port, AND that port currently has a LISTEN socket we
+//      can fast-probe with HEAD /api/sessions, we use it. Zero I/O on the
+//      hot path beyond a small file read.
+//
+//   2. Fallback: read the dashboard's own pidfile at DASHBOARD_PID_PATH
+//      (written by upstream itself). If the PID is alive, scan
+//      /proc/<pid>/fd for socket inodes, cross-reference with /proc/net/tcp
+//      to find LISTEN sockets owned by that PID, drop the proxy's own port,
+//      probe each remaining port with HEAD /api/sessions, return the
+//      first that responds 2xx. Linux-only, which is fine — typeclaw runs
+//      in a Linux container.
+//
+// The fallback is what makes "agent uses other port" work when the shim
+// doesn't catch the call. Without it, the proxy is stuck at whatever port
+// it was configured with and silently 502s on a moved dashboard.
+
+import { existsSync, readdirSync, readFileSync, readlinkSync } from 'node:fs'
+
+export const PORT_HINT_PATH = '/tmp/typeclaw-agent-browser-upstream-port'
+export const DASHBOARD_PID_PATH = '/root/.agent-browser/dashboard.pid'
+const DEFAULT_PROBE_TIMEOUT_MS = 250
+
+export type DiscoveryOptions = {
+  hintPath?: string
+  pidPath?: string
+  excludePort?: number
+  fetchImpl?: typeof fetch
+  probeTimeoutMs?: number
+  procfs?: ProcFs
+}
+
+export type ProcFs = {
+  pidExists: (pid: number) => boolean
+  listenInodesForPid: (pid: number) => Set<string>
+  listenSockets: () => Array<{ port: number; inode: string }>
+}
+
+export async function discoverDashboardPort(opts: DiscoveryOptions = {}): Promise<number | null> {
+  const hintPath = opts.hintPath ?? PORT_HINT_PATH
+  const pidPath = opts.pidPath ?? DASHBOARD_PID_PATH
+  const fetcher = opts.fetchImpl ?? fetch
+  const probeTimeout = opts.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS
+  const procfs = opts.procfs ?? defaultProcFs()
+
+  const hint = readPortHint(hintPath)
+  if (hint !== null && (await isDashboardPort(hint, fetcher, probeTimeout))) return hint
+
+  const pidContents = readPidFile(pidPath)
+  if (pidContents === null) return null
+  if (!procfs.pidExists(pidContents)) return null
+
+  const pidInodes = procfs.listenInodesForPid(pidContents)
+  const candidates: number[] = []
+  for (const socket of procfs.listenSockets()) {
+    if (!pidInodes.has(socket.inode)) continue
+    if (opts.excludePort !== undefined && socket.port === opts.excludePort) continue
+    candidates.push(socket.port)
+  }
+
+  for (const port of candidates) {
+    if (await isDashboardPort(port, fetcher, probeTimeout)) return port
+  }
+  return null
+}
+
+export function writePortHint(port: number, hintPath: string = PORT_HINT_PATH): void {
+  Bun.write(hintPath, String(port))
+}
+
+function readPortHint(path: string): number | null {
+  try {
+    const raw = readFileSync(path, 'utf-8').trim()
+    const port = Number(raw)
+    if (!Number.isInteger(port) || port < 1 || port > 65_535) return null
+    return port
+  } catch {
+    return null
+  }
+}
+
+function readPidFile(path: string): number | null {
+  try {
+    const raw = readFileSync(path, 'utf-8').trim()
+    const pid = Number(raw)
+    if (!Number.isInteger(pid) || pid < 1) return null
+    return pid
+  } catch {
+    return null
+  }
+}
+
+async function isDashboardPort(port: number, fetcher: typeof fetch, timeoutMs: number): Promise<boolean> {
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs)
+  try {
+    const res = await fetcher(`http://127.0.0.1:${port}/api/sessions`, {
+      method: 'GET',
+      signal: ctrl.signal,
+    })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function defaultProcFs(): ProcFs {
+  return {
+    pidExists: (pid) => existsSync(`/proc/${pid}`),
+    listenInodesForPid: (pid) => {
+      const inodes = new Set<string>()
+      const fdDir = `/proc/${pid}/fd`
+      let entries: string[]
+      try {
+        entries = readdirSync(fdDir)
+      } catch {
+        return inodes
+      }
+      for (const entry of entries) {
+        try {
+          const target = readlinkSync(`${fdDir}/${entry}`)
+          const match = target.match(/^socket:\[(\d+)\]$/)
+          if (match) inodes.add(match[1]!)
+        } catch {
+          continue
+        }
+      }
+      return inodes
+    },
+    listenSockets: () => {
+      const out: Array<{ port: number; inode: string }> = []
+      for (const file of ['/proc/net/tcp', '/proc/net/tcp6']) {
+        let raw: string
+        try {
+          raw = readFileSync(file, 'utf-8')
+        } catch {
+          continue
+        }
+        const lines = raw.split('\n').slice(1)
+        for (const line of lines) {
+          const cols = line.trim().split(/\s+/)
+          if (cols.length < 10) continue
+          if (cols[3] !== '0A') continue
+          const local = cols[1] ?? ''
+          const colonIdx = local.lastIndexOf(':')
+          if (colonIdx < 0) continue
+          const port = Number.parseInt(local.slice(colonIdx + 1), 16)
+          if (!Number.isInteger(port) || port < 1 || port > 65_535) continue
+          const inode = cols[9]
+          if (inode === undefined) continue
+          out.push({ port, inode })
+        }
+      }
+      return out
+    },
+  }
+}

--- a/plugins/agent-browser/dashboard-proxy.ts
+++ b/plugins/agent-browser/dashboard-proxy.ts
@@ -1,8 +1,11 @@
 import type { Server } from 'bun'
 
+import { discoverDashboardPort } from './dashboard-discovery'
+
 export type DashboardProxyOptions = {
   listenPort?: number
   upstreamPort?: number
+  resolveUpstreamPort?: () => Promise<number | null>
   upstreamHost?: string
   listenHost?: string
   fetchImpl?: typeof fetch
@@ -10,12 +13,13 @@ export type DashboardProxyOptions = {
 }
 
 export type DashboardProxyLogEvent =
-  | { kind: 'started'; listenHost: string; listenPort: number; upstreamHost: string; upstreamPort: number }
+  | { kind: 'started'; listenHost: string; listenPort: number; upstreamHost: string }
   | { kind: 'http-proxy'; port: number; path: string }
   | { kind: 'ws-proxy'; port: number; path: string }
   | { kind: 'invalid-proxy-target'; prefix: string; pathname: string }
   | { kind: 'proxy-target-denied'; port: number; path: string; reason: string }
   | { kind: 'upstream-error'; target: string; reason: string }
+  | { kind: 'no-upstream'; path: string }
 
 export type DashboardProxy = {
   server: Server<WebSocketData>
@@ -37,15 +41,17 @@ const HTTP_PROXY_PREFIX = '/__typeclaw_agent_browser_http/'
 const WS_PROXY_PREFIX = '/__typeclaw_agent_browser_ws/'
 const TYPECLAW_AGENT_PORT = 8973
 const TYPECLAW_HOSTD_CONTROL_PORT = 8974
+const UPSTREAM_PORT_CACHE_MS = 1_000
 
 export function startDashboardProxy(opts: DashboardProxyOptions = {}): DashboardProxy {
   const listenPort = opts.listenPort ?? DEFAULT_PROXY_PORT
-  const upstreamPort = opts.upstreamPort ?? DEFAULT_UPSTREAM_PORT
   const upstreamHost = opts.upstreamHost ?? DEFAULT_HOST
   const listenHost = opts.listenHost ?? DEFAULT_LISTEN_HOST
   const fetcher = opts.fetchImpl ?? fetch
   const log = opts.onLog ?? (() => {})
-  const deniedPorts = new Set([listenPort, upstreamPort, TYPECLAW_AGENT_PORT, TYPECLAW_HOSTD_CONTROL_PORT])
+
+  const resolveUpstreamPort = makeResolverWithCache(opts, listenPort)
+  const reservedPorts = new Set([listenPort, TYPECLAW_AGENT_PORT, TYPECLAW_HOSTD_CONTROL_PORT])
 
   const server = Bun.serve<WebSocketData>({
     hostname: listenHost,
@@ -55,12 +61,13 @@ export function startDashboardProxy(opts: DashboardProxyOptions = {}): Dashboard
 
       const wsTarget = parsePortPath(url.pathname, WS_PROXY_PREFIX)
       if (wsTarget) {
+        const upstreamPort = await resolveUpstreamPort()
         const denied = await denyProxyTarget({
           target: wsTarget,
-          deniedPorts,
+          reservedPorts,
+          upstreamPort,
           fetcher,
           upstreamHost,
-          upstreamPort,
         })
         if (denied) {
           log({ kind: 'proxy-target-denied', port: wsTarget.port, path: wsTarget.path, reason: denied })
@@ -84,12 +91,13 @@ export function startDashboardProxy(opts: DashboardProxyOptions = {}): Dashboard
 
       const httpTarget = parsePortPath(url.pathname, HTTP_PROXY_PREFIX)
       if (httpTarget) {
+        const upstreamPort = await resolveUpstreamPort()
         const denied = await denyProxyTarget({
           target: httpTarget,
-          deniedPorts,
+          reservedPorts,
+          upstreamPort,
           fetcher,
           upstreamHost,
-          upstreamPort,
         })
         if (denied) {
           log({ kind: 'proxy-target-denied', port: httpTarget.port, path: httpTarget.path, reason: denied })
@@ -108,6 +116,14 @@ export function startDashboardProxy(opts: DashboardProxyOptions = {}): Dashboard
       if (url.pathname.startsWith(HTTP_PROXY_PREFIX)) {
         log({ kind: 'invalid-proxy-target', prefix: HTTP_PROXY_PREFIX, pathname: url.pathname })
         return new Response('Invalid HTTP proxy target', { status: 400 })
+      }
+
+      const upstreamPort = await resolveUpstreamPort()
+      if (upstreamPort === null) {
+        log({ kind: 'no-upstream', path: url.pathname })
+        return new Response('agent-browser dashboard is not running. Start it with `agent-browser dashboard start`.', {
+          status: 502,
+        })
       }
 
       const upstreamPath = `${url.pathname}${url.search}`
@@ -140,12 +156,43 @@ export function startDashboardProxy(opts: DashboardProxyOptions = {}): Dashboard
     },
   })
 
-  if (server.port !== undefined) deniedPorts.add(server.port)
-  log({ kind: 'started', listenHost, listenPort: server.port ?? listenPort, upstreamHost, upstreamPort })
+  if (server.port !== undefined) reservedPorts.add(server.port)
+  log({ kind: 'started', listenHost, listenPort: server.port ?? listenPort, upstreamHost })
 
   return {
     server,
     stop: () => server.stop(true),
+  }
+}
+
+function makeResolverWithCache(opts: DashboardProxyOptions, listenPort: number): () => Promise<number | null> {
+  // The resolver is called on every proxied request; cache for a short
+  // window so concurrent dashboard fetches do not each spawn a procfs walk
+  // and a /api/sessions probe. UPSTREAM_PORT_CACHE_MS is below the
+  // perceptible-latency threshold and well under the time it takes to
+  // start/stop a dashboard, so a stale entry resolves itself within one
+  // tick of the user noticing.
+  if (opts.resolveUpstreamPort) {
+    let cached: { port: number | null; at: number } | null = null
+    return async () => {
+      const now = Date.now()
+      if (cached !== null && now - cached.at < UPSTREAM_PORT_CACHE_MS) return cached.port
+      const port = await opts.resolveUpstreamPort!()
+      cached = { port, at: now }
+      return port
+    }
+  }
+  if (opts.upstreamPort !== undefined) {
+    const fixed = opts.upstreamPort
+    return async () => fixed
+  }
+  let cached: { port: number | null; at: number } | null = null
+  return async () => {
+    const now = Date.now()
+    if (cached !== null && now - cached.at < UPSTREAM_PORT_CACHE_MS) return cached.port
+    const port = await discoverDashboardPort({ excludePort: listenPort })
+    cached = { port, at: now }
+    return port
   }
 }
 
@@ -329,18 +376,20 @@ function toWebSocketPayload(data: string | Buffer): string | ArrayBuffer {
 
 async function denyProxyTarget({
   target,
-  deniedPorts,
+  reservedPorts,
+  upstreamPort,
   fetcher,
   upstreamHost,
-  upstreamPort,
 }: {
   target: { port: number; path: string }
-  deniedPorts: Set<number>
+  reservedPorts: Set<number>
+  upstreamPort: number | null
   fetcher: typeof fetch
   upstreamHost: string
-  upstreamPort: number
 }): Promise<string | null> {
-  if (deniedPorts.has(target.port)) return `port ${target.port} is reserved`
+  if (reservedPorts.has(target.port)) return `port ${target.port} is reserved`
+  if (upstreamPort !== null && target.port === upstreamPort) return `port ${target.port} is reserved`
+  if (upstreamPort === null) return 'agent-browser dashboard is not running; cannot validate session port'
   const allowed = await discoverSessionPorts({ fetcher, upstreamHost, upstreamPort })
   if (!allowed.has(target.port)) return `port ${target.port} is not an active agent-browser session port`
   return null

--- a/plugins/agent-browser/index.ts
+++ b/plugins/agent-browser/index.ts
@@ -2,12 +2,7 @@ import { join } from 'node:path'
 
 import { definePlugin } from '@/plugin'
 
-import {
-  AGENT_BROWSER_DASHBOARD_PROXY_PORT,
-  AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT,
-  startDashboardProxy,
-  type DashboardProxy,
-} from './dashboard-proxy'
+import { AGENT_BROWSER_DASHBOARD_PROXY_PORT, startDashboardProxy, type DashboardProxy } from './dashboard-proxy'
 import { installShim, KNOWN_BIN_PATHS, type InstallShimResult } from './shim-install'
 
 type SafeResult = InstallShimResult | { kind: 'error'; binPath: string; error: unknown }
@@ -44,13 +39,25 @@ export function __resetProxyForTesting(): void {
   activeProxy = null
 }
 
-type PortConfig = { listenPort: number; upstreamPort: number }
+type PortConfig = { listenPort: number; upstreamPort: number | undefined }
 
 function readPortConfig(): PortConfig {
+  // The proxy auto-discovers the dashboard's upstream port via the hint
+  // file + procfs scan, so we do NOT pin it here. TYPECLAW_DASHBOARD_UPSTREAM_PORT
+  // exists only as a test escape hatch (set to a fixed port to bypass
+  // discovery in unit tests where /proc and the hint file aren't useful).
+  const overrideUpstream = process.env['TYPECLAW_DASHBOARD_UPSTREAM_PORT']
   return {
     listenPort: numberFromEnv('TYPECLAW_DASHBOARD_PROXY_PORT', AGENT_BROWSER_DASHBOARD_PROXY_PORT),
-    upstreamPort: numberFromEnv('TYPECLAW_DASHBOARD_UPSTREAM_PORT', AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT),
+    upstreamPort:
+      overrideUpstream === undefined || overrideUpstream === '' ? undefined : numberOrUndefined(overrideUpstream),
   }
+}
+
+function numberOrUndefined(raw: string): number | undefined {
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65_535) return undefined
+  return parsed
 }
 
 function numberFromEnv(name: string, fallback: number): number {

--- a/plugins/agent-browser/shim.ts
+++ b/plugins/agent-browser/shim.ts
@@ -12,6 +12,7 @@
 
 import { existsSync } from 'node:fs'
 
+import { writePortHint } from './dashboard-discovery'
 import { AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT } from './dashboard-proxy'
 
 export const REAL_BIN_ENV = 'TYPECLAW_AGENT_BROWSER_REAL_BIN'
@@ -121,6 +122,16 @@ export async function runShim(opts: ShimOptions = {}): Promise<number> {
   const intent = classifyDashboardCommand(argv)
   if (intent !== 'start') {
     return await spawn([realBin, ...argv]).exited
+  }
+
+  // Record the rewritten port to the hint file so the long-lived proxy can
+  // use it as the fast-path upstream lookup. The proxy still falls back to
+  // procfs discovery if the hint is wrong, but the hint avoids that work
+  // on the common path where the shim is the one starting the dashboard.
+  try {
+    writePortHint(upstreamPort)
+  } catch {
+    // Hint is an optimization; failure to write it is non-fatal.
   }
 
   const rewritten = rewriteDashboardArgs(argv, upstreamPort)


### PR DESCRIPTION
> **Stacked PR** — base is `agent-browser/proxy-daemon` (PR #75), NOT `main`. Merge #75 first, then rebase this onto `main` and merge.

## Why

This builds on PR #75 (Move dashboard proxy from shim to agent process). After #75, the proxy lives in the long-lived agent process and the shim rewrites every `dashboard start` onto port 4849. That works as long as the shim is in the call chain. But the shim is bypassable:

- Direct invocation of the unshimmed real binary (path stash, or a different agent-browser install).
- `bunx agent-browser dashboard --port 9999` resolving through the bun cache to a path we don't shadow.
- A stale dashboard left over from a previous container generation that's listening on a different port.
- A user manually starting `agent-browser dashboard --port 5000` in a `typeclaw shell`.

In all those cases the proxy on 4848 silently sat on 4849 while the actual dashboard was elsewhere, and the user got a confusing 502 with the wrong port in the error message.

## What changed

### `plugins/agent-browser/dashboard-discovery.ts` (new)

A two-stage resolver that finds where the dashboard actually is:

1. **Hint file** at `/tmp/typeclaw-agent-browser-upstream-port`. The shim writes the port it asked upstream to bind to. Cheap fast path when the shim was the one starting the dashboard.
2. **Procfs fallback**: read `/root/.agent-browser/dashboard.pid` (written by upstream itself), verify the PID is alive, scan `/proc/<pid>/fd` for socket inodes, cross-reference `/proc/net/tcp[6]` LISTEN sockets, drop the proxy's own port, probe each remaining port with `GET /api/sessions`, return the first 2xx. Linux-only — fine because typeclaw runs in a Linux container.

### `plugins/agent-browser/dashboard-proxy.ts`

Replace the fixed `upstreamPort: number` with `resolveUpstreamPort: () => Promise<number | null>`. The resolver is called per-request with a 1s in-process cache (below perceptible-latency threshold; well under dashboard start/stop time). When the resolver returns `null`, the proxy responds with a clear `502 agent-browser dashboard is not running. Start it with \`agent-browser dashboard start\`` instead of silently trying a hardcoded port and timing out.

### `plugins/agent-browser/shim.ts`

Write the hint file with the rewritten port before exec'ing upstream. Failure to write is non-fatal (hint is an optimization).

### `plugins/agent-browser/index.ts`

Pass `upstreamPort: undefined` to `startDashboardProxy` so the resolver runs the auto-discovery path. The `TYPECLAW_DASHBOARD_UPSTREAM_PORT` env var is preserved as a test-only escape hatch.

## Tests

New `dashboard-discovery.test.ts` covers: hint hit, hint miss → procfs fallback, procfs candidate filtering (drop proxy port), stale pidfile, no candidates respond, malformed hint file (no probing).

Proxy tests still pass with the new resolver signature. 1742 tests pass; lint/typecheck/format clean.

## End-to-end verification (oven/bun:1-slim, 4 scenarios)

1. **Cold (no dashboard)**: `4848` → 502 ✓
2. **Shim default 4849**: `4848` → 200, `[]` body ✓
3. **Bypass on 9999** (real binary invoked directly with `--port 9999`, NO shim): `4848` → 200, `[]` body, injected script present ✓ — **this is the new capability**
4. **Stop everything**: `4848` → 502 ✓

## Risks / review notes

1. **Procfs scan is Linux-only.** macOS containers (rare for typeclaw) and any non-Linux runtime would skip the fallback path. The hint file path still works cross-platform. Documented in `dashboard-discovery.ts`.
2. **The probe is GET, not HEAD.** `/api/sessions` returns a small JSON array; GET is what upstream natively responds to. Cost is ~200 bytes per discovery. Acceptable given the 1s cache.
3. **Cache window is 1s.** A user who runs `dashboard stop && dashboard start --port X && curl proxy` within 1s sees the old port. Considered raising to 5s for less procfs walking, lowering to 100ms for faster bypass detection. 1s is a sensible default.
4. **PID parse rejects PID 0.** Procfs explicitly disallows reading `/proc/0`, so this is correct. We do NOT validate that the discovered PID matches the agent-browser binary — a malicious in-container actor could write a different PID to the pidfile and have the proxy connect to their service. Acceptable: the container is single-trust-domain (the agent owns it).
5. **Reserved-port logic in `denyProxyTarget` updated** — the per-request `upstreamPort` is now in the reservation set dynamically. The hardcoded 4849 reservation went away because we no longer know upstream's port at proxy-construction time.