### PR TITLE
Defer dashboard proxy bind off the plugin factory critical path

### DIFF
--- a/plugins/agent-browser/index.test.ts
+++ b/plugins/agent-browser/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
 
-import agentBrowserPlugin, { __resetProxyForTesting } from './index'
+import agentBrowserPlugin, { __resetProxyForTesting, __waitForProxyBindForTesting } from './index'
 
 beforeEach(() => {
   process.env['TYPECLAW_DASHBOARD_PROXY_PORT'] = '0'
@@ -24,7 +24,7 @@ describe('agent-browser plugin', () => {
     expect(exports.hooks).toBeUndefined()
   })
 
-  test('binds the dashboard proxy on the configured port at agent boot', async () => {
+  test('binds the dashboard proxy in the background after the plugin factory returns', async () => {
     const messages: string[] = []
     const logger = {
       info: (msg: string) => messages.push(`info:${msg}`),
@@ -32,6 +32,7 @@ describe('agent-browser plugin', () => {
       error: (msg: string) => messages.push(`error:${msg}`),
     }
 
+    const factoryStart = Date.now()
     await agentBrowserPlugin.plugin(
       createPluginContext({
         name: 'agent-browser',
@@ -43,6 +44,14 @@ describe('agent-browser plugin', () => {
         isBooted: () => true,
       }),
     )
+    const factoryReturnedAt = Date.now()
+
+    // Factory must return immediately — the bind happens off the critical path.
+    // Without this guarantee the boot sequence would block on bindWithForward
+    // before the broker that delivers forward-result events even exists.
+    expect(factoryReturnedAt - factoryStart).toBeLessThan(500)
+
+    await __waitForProxyBindForTesting()
 
     expect(messages.some((m) => m.startsWith('info:dashboard proxy listening on port '))).toBe(true)
   })

--- a/plugins/agent-browser/index.ts
+++ b/plugins/agent-browser/index.ts
@@ -10,8 +10,11 @@ type SafeResult = InstallShimResult | { kind: 'error'; binPath: string; error: u
 
 const PROXY_PORT_HINT_PATH = '/tmp/typeclaw-agent-browser-proxy-port'
 const PORT_CANDIDATE_RANGE = 10
+const BROKER_HANDSHAKE_DELAY_MS = 1_000
+const FORWARD_RESULT_TIMEOUT_MS = 10_000
 
 let activeProxy: DashboardProxy | null = null
+let bindingInFlight: Promise<void> | null = null
 
 export default definePlugin({
   plugin: async (ctx) => {
@@ -19,16 +22,19 @@ export default definePlugin({
       logInstallResult(ctx.logger, safeInstallShim(binPath))
     }
 
-    if (activeProxy === null) {
-      const bound = await bindProxyOnFirstFreePort(ctx.logger)
-      if (bound !== null) {
-        activeProxy = bound.proxy
-        recordProxyPort(bound.port, ctx.logger)
-        ctx.logger.info(
-          `dashboard proxy listening on port ${bound.port}` +
-            (bound.hostPort !== null ? ` (forwarded to host:${bound.hostPort})` : ''),
-        )
-      }
+    // Kick off the proxy bind in the background and let the plugin factory
+    // return immediately. Two reasons:
+    //   1. The container-side broker is created AFTER pluginsLoaded.markBooted()
+    //      runs (see src/run/index.ts). If we awaited bindWithForward here, we
+    //      would block the boot sequence past 20s of timeouts before the broker
+    //      even existed to send forward-result events.
+    //   2. The dashboard isn't typically used at boot — the user runs
+    //      `agent-browser dashboard start` later. The proxy has plenty of time
+    //      to settle before its first request.
+    if (activeProxy === null && bindingInFlight === null) {
+      bindingInFlight = bindProxyAfterBrokerSettles(ctx.logger).finally(() => {
+        bindingInFlight = null
+      })
     }
 
     return {
@@ -40,22 +46,34 @@ export default definePlugin({
 export function __resetProxyForTesting(): void {
   activeProxy?.stop()
   activeProxy = null
+  bindingInFlight = null
 }
 
-async function bindProxyOnFirstFreePort(logger: {
+export function __waitForProxyBindForTesting(): Promise<void> {
+  return bindingInFlight ?? Promise.resolve()
+}
+
+async function bindProxyAfterBrokerSettles(logger: {
   info: (msg: string) => void
   warn: (msg: string) => void
-}): Promise<{ proxy: DashboardProxy; port: number; hostPort: number | null } | null> {
+}): Promise<void> {
+  // Give the run-loop time to construct the container broker and let it
+  // complete its WS handshake with hostd. Without this the first candidate
+  // bind fires before the broker is ready, the bus never delivers a result,
+  // and we waste the full timeout × candidate-count budget tearing down
+  // every port in the range. The exact delay isn't load-bearing — anything
+  // longer than the broker's connect+hello round-trip works.
+  if (defaultBrokerEnabled()) {
+    await Bun.sleep(BROKER_HANDSHAKE_DELAY_MS)
+  }
+
   const config = readPortConfig()
   const candidates = buildCandidatePorts(config.listenPort)
-  // Auto-discovery only — we never pin upstream here. The proxy reads
-  // /tmp/typeclaw-agent-browser-upstream-port (written by the shim) and
-  // falls back to procfs. TYPECLAW_DASHBOARD_UPSTREAM_PORT remains as a
-  // unit-test escape hatch only.
   const upstreamOverride = config.upstreamPort
 
   const result = await bindWithForward<DashboardProxy>({
     candidates,
+    timeoutMs: FORWARD_RESULT_TIMEOUT_MS,
     factory: (port) => {
       try {
         const proxy = startDashboardProxy({ listenPort: port, upstreamPort: upstreamOverride })
@@ -73,9 +91,20 @@ async function bindProxyOnFirstFreePort(logger: {
       `could not allocate a host-forwardable dashboard proxy port from ${candidates[0]}-${candidates[candidates.length - 1]}; ` +
         `remote dashboard access will not work until another container releases its port`,
     )
-    return null
+    return
   }
-  return { proxy: result.resource, port: result.port, hostPort: result.hostPort }
+
+  activeProxy = result.resource
+  recordProxyPort(result.port, logger)
+  logger.info(
+    `dashboard proxy listening on port ${result.port}` +
+      (result.hostPort !== null ? ` (forwarded to host:${result.hostPort})` : ''),
+  )
+}
+
+function defaultBrokerEnabled(): boolean {
+  const token = process.env['TYPECLAW_HOSTD_BROKER_TOKEN']
+  return token !== undefined && token.length > 0
 }
 
 function buildCandidatePorts(start: number): number[] {


### PR DESCRIPTION
## Why

PR #77 introduced a boot-ordering deadlock that only surfaced under realistic conditions (real container, post-restart). The plugin's factory called `await bindWithForward(...)` synchronously, but the container-side broker is constructed in `src/run/index.ts` **after** `pluginsLoaded.markBooted()` fires. With no broker, the forward-result bus never delivers events, every candidate times out, and the plugin silently gives up — leaving no proxy bound.

**Production failure observed:** After #77 merged, `/tmp/typeclaw-agent-browser-proxy-port` was missing post-restart. No proxy bound on 4848–4857. Dashboard reachable internally on 4849 but no external forward confirmed.

**The ordering bug in detail:**

1. Plugin factory calls `await bindWithForward(4848)` (synchronous, blocking).
2. `bindWithForward` tries 4848 internally (succeeds — netns is empty), then subscribes to the forward-result bus and awaits.
3. The bus never fires — the broker hasn't been constructed yet, hasn't connected to hostd, hasn't completed its handshake.
4. The 2s default timeout fires. Plugin tears down 4848, tries 4849. Same race.
5. After 10 candidates × 2s = ~20s, the plugin gives up and returns null.
6. `markBooted()` was blocked for those 20s, so the broker doesn't even start being constructed until after the plugin gives up. By then every candidate has already been bound and torn down.

## What changed

**Don't await the bind in the factory.** The factory now calls `bindProxyAfterBrokerSettles()` in the background and returns immediately. Three supporting changes give the deferred bind time to succeed:

1. **`BROKER_HANDSHAKE_DELAY_MS` (1s) at the start of the deferred bind** when `TYPECLAW_HOSTD_BROKER_TOKEN` is set. Gives `run/index.ts` time to construct the broker and complete its WS handshake with hostd before the plugin emits any `port-listen-opened` events that need round-tripping.

2. **Per-candidate timeout bumped from 2s → 10s** for additional margin against slow WS round-trips under load. Total worst-case wait when all 10 candidates collide: 1s delay + 10 × 10s = 101s. Acceptable because (a) it runs in the background and (b) the pathological case requires 10 cross-container port collisions.

3. **`__waitForProxyBindForTesting()` test-only export** so tests can deterministically await the in-flight binding before asserting on log output. `afterEach` resets `bindingInFlight` to prevent test bleed.

## End-to-end verification (oven/bun:1-slim, simulated broker)

- Factory returns in **0ms** (deadlock gone).
- After ~1s broker-handshake delay, plugin tries 5848 → simulated broker emits `EADDRINUSE` → tears down.
- Plugin tries 5849 → simulated broker emits ok → binds.
- Hint file written: `5849`.
- Total time from boot to proxy-ready: ~1.7s.

## Test additions

The existing "binds the dashboard proxy at agent boot" test now:
- Asserts the factory returns within 500ms (regression guard against the deadlock returning).
- Awaits `__waitForProxyBindForTesting()` before checking the log message.

## Risks and review notes

1. **The 1s pre-bind delay is a magic number.** Anything longer than the broker's connect + hello round-trip works. 1s is comfortable on observed hardware. Could be wired to a config or env var if it proves too short on slow hosts; left as a constant for now.

2. **`bindingInFlight` is a module-level singleton.** Same trade-off as `activeProxy` from #75: simpler than threading through plugin context. `__resetProxyForTesting()` clears it.

3. **Background errors are swallowed except via `logger.warn`.** If the deferred bind throws unexpectedly, the only signal is in the logs. Acceptable for a non-critical-path background task.

4. **Sub-1.5s window after boot.** A user who runs `agent-browser dashboard start` within ~1.5s of agent boot will see the upstream bind on 4849 but no external proxy yet. The hint file is still written, and once the deferred bind completes the proxy retroactively comes online. UX-acceptable.