### PR TITLE
Add kakaotalk channel adapter

### DIFF
--- a/src/channels/adapters/agent-messenger-kakaotalk-shim.ts
+++ b/src/channels/adapters/agent-messenger-kakaotalk-shim.ts
@@ -1,0 +1,144 @@
+// Insulates our code from agent-messenger's strict-mode upstream TS source
+// (no `dist/` declarations on npm yet) by re-exporting under a type-augmented
+// surface. Runtime uses the real package; TypeScript sees our richer types.
+//
+// DELETE WHEN: agent-messenger publishes `dist/platforms/kakaotalk/
+// index.d.ts`. Drop this file and import directly from
+// 'agent-messenger/kakaotalk' in adapters/kakaotalk.ts.
+
+import {
+  KakaoCredentialManager as RawCredentialManager,
+  KakaoTalkClient as RawClient,
+  KakaoTalkListener as RawListener,
+} from 'agent-messenger/kakaotalk'
+
+export type KakaoChatType = 'dm' | 'group' | 'open' | 'unknown'
+
+export type KakaoChat = {
+  chat_id: string
+  type: number
+  display_name: string | null
+  active_members: number
+  unread_count: number
+  last_message: {
+    author_id: number
+    message: string
+    sent_at: number
+  } | null
+}
+
+export type KakaoMessage = {
+  log_id: string
+  type: number
+  author_id: number
+  message: string
+  sent_at: number
+}
+
+export type KakaoSendResult = {
+  success: boolean
+  status_code: number
+  chat_id: string
+  log_id: string
+  sent_at: number
+}
+
+export type KakaoProfile = {
+  user_id: string
+  nickname: string
+  status_message: string | null
+}
+
+export type KakaoTalkPushMessageEvent = {
+  type: 'MSG'
+  chat_id: string
+  log_id: string
+  author_id: number
+  message: string
+  message_type: number
+  sent_at: number
+}
+
+export type KakaoTalkPushMemberEvent = {
+  type: 'NEWMEM' | 'DELMEM'
+  chat_id: string
+  member: { user_id: number }
+}
+
+export type KakaoTalkListenerConnected = {
+  userId: string
+}
+
+export type KakaoTalkListenerEventMap = {
+  message: [event: KakaoTalkPushMessageEvent]
+  member_joined: [event: KakaoTalkPushMemberEvent]
+  member_left: [event: KakaoTalkPushMemberEvent]
+  connected: [info: KakaoTalkListenerConnected]
+  disconnected: []
+  error: [error: Error]
+}
+
+export type KakaoCredentials = {
+  oauthToken: string
+  userId: string
+  deviceUuid?: string
+  deviceType?: 'pc' | 'tablet'
+}
+
+export interface KakaoTalkClient {
+  login(credentials?: KakaoCredentials, accountId?: string): Promise<this>
+  getChats(options?: { all?: boolean; search?: string }): Promise<KakaoChat[]>
+  getMessages(chatId: string, options?: { count?: number; from?: string }): Promise<KakaoMessage[]>
+  sendMessage(chatId: string, text: string): Promise<KakaoSendResult>
+  getProfile(): Promise<KakaoProfile>
+  close(): void
+}
+
+export interface KakaoTalkListener {
+  start(): Promise<void>
+  stop(): void
+  on<K extends keyof KakaoTalkListenerEventMap>(
+    event: K,
+    listener: (...args: KakaoTalkListenerEventMap[K]) => void,
+  ): this
+  off<K extends keyof KakaoTalkListenerEventMap>(
+    event: K,
+    listener: (...args: KakaoTalkListenerEventMap[K]) => void,
+  ): this
+}
+
+export type KakaoStoredAccount = {
+  account_id: string
+  user_id: string
+  oauth_token: string
+  refresh_token?: string
+  device_uuid: string
+  device_type: 'pc' | 'tablet'
+}
+
+export interface KakaoCredentialManager {
+  getAccount(id?: string): Promise<KakaoStoredAccount | null>
+}
+
+export const KakaoTalkClient = RawClient as unknown as new () => KakaoTalkClient
+export const KakaoTalkListener = RawListener as unknown as new (client: KakaoTalkClient) => KakaoTalkListener
+export const KakaoCredentialManager = RawCredentialManager as unknown as new (
+  configDir?: string,
+) => KakaoCredentialManager
+
+// Per the SDK source: KakaoChat.type === 0 is 1:1 (dm), 1 is normal group,
+// 2 is open chat / multi-channel group. Types we don't recognize fall back
+// to 'unknown' which the resolver maps to `@kakao-group` (the safest
+// catch-all for engagement: groups require explicit @ to engage).
+export function classifyKakaoChatType(rawType: number): KakaoChatType {
+  if (rawType === 0) return 'dm'
+  if (rawType === 1) return 'group'
+  if (rawType === 2) return 'open'
+  return 'unknown'
+}
+
+export function kakaoWorkspaceForType(type: KakaoChatType): '@kakao-dm' | '@kakao-group' | '@kakao-open' {
+  if (type === 'dm') return '@kakao-dm'
+  if (type === 'open') return '@kakao-open'
+  return '@kakao-group'
+}

--- a/src/channels/adapters/kakaotalk-author-resolver.ts
+++ b/src/channels/adapters/kakaotalk-author-resolver.ts
@@ -1,0 +1,64 @@
+import type { KakaoChat, KakaoTalkClient } from './agent-messenger-kakaotalk-shim'
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000
+
+export type KakaoAuthorResolver = {
+  resolve: (authorId: string, chatId: string) => Promise<string>
+  prime: (chats: readonly KakaoChat[]) => void
+}
+
+export type KakaoAuthorResolverOptions = {
+  client: Pick<KakaoTalkClient, 'getChats'>
+  now?: () => number
+  ttlMs?: number
+}
+
+// KakaoTalk's LOCO protocol surfaces an author_id (numeric user_id) on every
+// inbound message but no display name. Names are only available indirectly
+// through KakaoChat.display_name, which is a comma-joined list of member
+// names for group chats and the counterpart's name for 1:1 chats. We use
+// this best-effort heuristic so the agent sees a human-readable author
+// string rather than a bare numeric id.
+//
+// 1:1 chat: display_name is the other party's name → use it for any
+// author_id that isn't ours.
+// Group/open: we cannot deterministically split "Alice, Bob, Carol" back
+// into per-author entries, so the resolver falls back to the raw
+// author_id. The agent layer can override via configured aliases.
+export function createKakaoAuthorResolver(options: KakaoAuthorResolverOptions): KakaoAuthorResolver {
+  const now = options.now ?? Date.now
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+  const dmCounterpartByChat = new Map<string, { name: string; expiresAt: number }>()
+  let lastRefreshAt = 0
+
+  const prime = (chats: readonly KakaoChat[]): void => {
+    const expiresAt = now() + ttlMs
+    for (const chat of chats) {
+      if (chat.type === 0 && chat.display_name !== null && chat.display_name !== '') {
+        dmCounterpartByChat.set(chat.chat_id, { name: chat.display_name, expiresAt })
+      }
+    }
+    lastRefreshAt = now()
+  }
+
+  const refresh = async (): Promise<void> => {
+    try {
+      const chats = await options.client.getChats({ all: true })
+      prime(chats)
+    } catch {
+      // Author resolution is best-effort; a network blip falls back to
+      // returning the raw id rather than blocking message routing.
+    }
+  }
+
+  const resolve = async (authorId: string, chatId: string): Promise<string> => {
+    const cached = dmCounterpartByChat.get(chatId)
+    if (cached !== undefined && cached.expiresAt > now()) return cached.name
+    if (now() - lastRefreshAt > ttlMs) await refresh()
+    const fresh = dmCounterpartByChat.get(chatId)
+    if (fresh !== undefined) return fresh.name
+    return authorId
+  }
+
+  return { resolve, prime }
+}

--- a/src/channels/adapters/kakaotalk-channel-resolver.test.ts
+++ b/src/channels/adapters/kakaotalk-channel-resolver.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { KakaoChat, KakaoTalkClient } from './agent-messenger-kakaotalk-shim'
+import { createKakaoChannelResolver } from './kakaotalk-channel-resolver'
+
+const dmChat = (id: string, name: string): KakaoChat => ({
+  chat_id: id,
+  type: 0,
+  display_name: name,
+  active_members: 2,
+  unread_count: 0,
+  last_message: null,
+})
+
+const groupChat = (id: string, name: string): KakaoChat => ({
+  chat_id: id,
+  type: 1,
+  display_name: name,
+  active_members: 5,
+  unread_count: 0,
+  last_message: null,
+})
+
+const fakeClient = (chats: KakaoChat[]): Pick<KakaoTalkClient, 'getChats'> => ({
+  getChats: async () => chats,
+})
+
+describe('createKakaoChannelResolver', () => {
+  test('lookupChat returns null for unknown chats', () => {
+    const resolver = createKakaoChannelResolver({ client: fakeClient([]) })
+    expect(resolver.lookupChat('999')).toBeNull()
+  })
+
+  test('lookupChat returns workspace + isDm after refresh', async () => {
+    const resolver = createKakaoChannelResolver({
+      client: fakeClient([dmChat('111', 'Alice'), groupChat('222', 'Team')]),
+    })
+    await resolver.refresh()
+    expect(resolver.lookupChat('111')).toEqual({ workspace: '@kakao-dm', isDm: true })
+    expect(resolver.lookupChat('222')).toEqual({ workspace: '@kakao-group', isDm: false })
+  })
+
+  test('lookupChat returns null for stale entries (TTL expired)', async () => {
+    let now = 1000
+    const resolver = createKakaoChannelResolver({
+      client: fakeClient([dmChat('111', 'Alice')]),
+      now: () => now,
+      ttlMs: 100,
+    })
+    await resolver.refresh()
+    expect(resolver.lookupChat('111')).toEqual({ workspace: '@kakao-dm', isDm: true })
+
+    // Advance past the TTL. lookupChat must NOT keep returning the stale
+    // entry — callers depend on null to trigger a refresh.
+    now += 200
+    expect(resolver.lookupChat('111')).toBeNull()
+  })
+
+  test('resolve refreshes the cache when entries are stale', async () => {
+    let now = 1000
+    let chats: KakaoChat[] = [dmChat('111', 'Alice')]
+    const resolver = createKakaoChannelResolver({
+      client: { getChats: async () => chats },
+      now: () => now,
+      ttlMs: 100,
+    })
+    await resolver.refresh()
+
+    chats = [dmChat('111', 'Alice updated')]
+    now += 200
+
+    const result = await resolver.resolve({ adapter: 'kakaotalk', workspace: '@kakao-dm', chat: '111', thread: null })
+    expect(result.chatName).toBe('Alice updated')
+  })
+
+  test('refresh coalesces concurrent calls', async () => {
+    let calls = 0
+    const slowClient: Pick<KakaoTalkClient, 'getChats'> = {
+      getChats: async () => {
+        calls++
+        await new Promise((r) => setTimeout(r, 20))
+        return [dmChat('111', 'Alice')]
+      },
+    }
+    const resolver = createKakaoChannelResolver({ client: slowClient })
+    await Promise.all([resolver.refresh(), resolver.refresh(), resolver.refresh()])
+    expect(calls).toBe(1)
+  })
+
+  test('reflects chat-type changes after a fresh refresh', async () => {
+    let now = 1000
+    let chats: KakaoChat[] = [dmChat('111', 'Alice')]
+    const resolver = createKakaoChannelResolver({
+      client: { getChats: async () => chats },
+      now: () => now,
+      ttlMs: 100,
+    })
+    await resolver.refresh()
+    expect(resolver.lookupChat('111')).toEqual({ workspace: '@kakao-dm', isDm: true })
+
+    chats = [groupChat('111', 'Alice, Bob')]
+    now += 200
+    await resolver.refresh()
+    expect(resolver.lookupChat('111')).toEqual({ workspace: '@kakao-group', isDm: false })
+  })
+})

--- a/src/channels/adapters/kakaotalk-channel-resolver.ts
+++ b/src/channels/adapters/kakaotalk-channel-resolver.ts
@@ -1,0 +1,102 @@
+import type { ChannelKey, ChannelNameResolver, ResolvedChannelNames } from '@/channels/types'
+
+import {
+  classifyKakaoChatType,
+  kakaoWorkspaceForType,
+  type KakaoChat,
+  type KakaoTalkClient,
+} from './agent-messenger-kakaotalk-shim'
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000
+
+export type KakaoChatLookupValue = {
+  workspace: '@kakao-dm' | '@kakao-group' | '@kakao-open'
+  isDm: boolean
+}
+
+export type KakaoChannelResolver = {
+  resolve: ChannelNameResolver
+  lookupChat: (chatId: string) => KakaoChatLookupValue | null
+  refresh: () => Promise<void>
+}
+
+export type KakaoChannelResolverOptions = {
+  client: Pick<KakaoTalkClient, 'getChats'>
+  now?: () => number
+  ttlMs?: number
+  logger?: { warn: (msg: string) => void }
+}
+
+type Entry = {
+  workspace: '@kakao-dm' | '@kakao-group' | '@kakao-open'
+  isDm: boolean
+  displayName: string | null
+  expiresAt: number
+}
+
+export function createKakaoChannelResolver(options: KakaoChannelResolverOptions): KakaoChannelResolver {
+  const now = options.now ?? Date.now
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+  const cache = new Map<string, Entry>()
+  let inflight: Promise<void> | null = null
+
+  const refresh = async (): Promise<void> => {
+    if (inflight !== null) {
+      await inflight
+      return
+    }
+    const promise = loadAll().finally(() => {
+      inflight = null
+    })
+    inflight = promise
+    await promise
+  }
+
+  const loadAll = async (): Promise<void> => {
+    try {
+      const chats = await options.client.getChats({ all: true })
+      const expiresAt = now() + ttlMs
+      for (const chat of chats) ingest(chat, expiresAt)
+    } catch (err) {
+      options.logger?.warn(`[kakaotalk] channel resolver refresh failed: ${describe(err)}`)
+    }
+  }
+
+  const ingest = (chat: KakaoChat, expiresAt: number): void => {
+    const kind = classifyKakaoChatType(chat.type)
+    const workspace = kakaoWorkspaceForType(kind)
+    cache.set(chat.chat_id, {
+      workspace,
+      isDm: kind === 'dm',
+      displayName: chat.display_name,
+      expiresAt,
+    })
+  }
+
+  const resolve: ChannelNameResolver = async (key: ChannelKey): Promise<ResolvedChannelNames> => {
+    const entry = cache.get(key.chat)
+    if (entry === undefined || entry.expiresAt <= now()) await refresh()
+    const fresh = cache.get(key.chat)
+    if (fresh === undefined) return {}
+    const result: ResolvedChannelNames = {}
+    if (fresh.displayName !== null && fresh.displayName !== '') result.chatName = fresh.displayName
+    return result
+  }
+
+  // Sync lookup. Returns null when the entry is missing OR stale; callers
+  // (e.g. inbound classification, history allow checks) MUST treat null as
+  // "refresh needed", not "unknown forever". The classifier handles this
+  // by awaiting `refresh()` and re-checking before dropping the message —
+  // see kakaotalk.ts handleMessageEvent.
+  const lookupChat = (chatId: string): KakaoChatLookupValue | null => {
+    const entry = cache.get(chatId)
+    if (entry === undefined || entry.expiresAt <= now()) return null
+    return { workspace: entry.workspace, isDm: entry.isDm }
+  }
+
+  return { resolve, lookupChat, refresh }
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/adapters/kakaotalk-classify.test.ts
+++ b/src/channels/adapters/kakaotalk-classify.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test'
+
+import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
+
+import type { KakaoTalkPushMessageEvent } from './agent-messenger-kakaotalk-shim'
+import { classifyInbound, type KakaoChatLookup } from './kakaotalk-classify'
+
+const dmConfig = (): ChannelAdapterConfig => ({
+  allow: ['kakao:dm/*'],
+  enabled: true,
+  engagement: {
+    trigger: ['mention', 'reply', 'dm'],
+    stickiness: { perReply: { window: 300_000 } },
+  },
+  history: defaultHistoryConfig(),
+})
+
+const groupConfig = (): ChannelAdapterConfig => ({
+  allow: ['kakao:group/*'],
+  enabled: true,
+  engagement: {
+    trigger: ['mention', 'reply', 'dm'],
+    stickiness: { perReply: { window: 300_000 } },
+  },
+  history: defaultHistoryConfig(),
+})
+
+const event = (overrides: Partial<KakaoTalkPushMessageEvent> = {}): KakaoTalkPushMessageEvent => ({
+  type: 'MSG',
+  chat_id: '111',
+  log_id: 'L1',
+  author_id: 222,
+  message: 'hello',
+  message_type: 1,
+  sent_at: 1_730_000_000_000,
+  ...overrides,
+})
+
+const dmLookup: KakaoChatLookup = (id) => (id === '111' ? { workspace: '@kakao-dm', isDm: true } : null)
+const groupLookup: KakaoChatLookup = (id) => (id === '111' ? { workspace: '@kakao-group', isDm: false } : null)
+
+describe('classifyInbound', () => {
+  test('drops pre_connect when selfUserId is null', () => {
+    const verdict = classifyInbound(event(), dmConfig(), { selfUserId: null, lookupChat: dmLookup })
+    expect(verdict).toEqual({ kind: 'drop', reason: 'pre_connect' })
+  })
+
+  test('drops self_author when authored by self', () => {
+    const verdict = classifyInbound(event({ author_id: 999 }), dmConfig(), {
+      selfUserId: '999',
+      lookupChat: dmLookup,
+    })
+    expect(verdict).toEqual({ kind: 'drop', reason: 'self_author' })
+  })
+
+  test('drops empty_text when message is empty', () => {
+    const verdict = classifyInbound(event({ message: '' }), dmConfig(), {
+      selfUserId: '999',
+      lookupChat: dmLookup,
+    })
+    expect(verdict).toEqual({ kind: 'drop', reason: 'empty_text' })
+  })
+
+  test('drops unknown_chat when lookup returns null', () => {
+    const verdict = classifyInbound(event(), dmConfig(), {
+      selfUserId: '999',
+      lookupChat: () => null,
+    })
+    expect(verdict).toEqual({ kind: 'drop', reason: 'unknown_chat' })
+  })
+
+  test('drops not_in_allow_list when chat is in a bucket the rules do not admit', () => {
+    const verdict = classifyInbound(event(), dmConfig(), {
+      selfUserId: '999',
+      lookupChat: groupLookup,
+    })
+    expect(verdict).toEqual({ kind: 'drop', reason: 'not_in_allow_list' })
+  })
+
+  test('routes a 1:1 message and stamps the dm workspace + isDm', () => {
+    const verdict = classifyInbound(event(), dmConfig(), {
+      selfUserId: '999',
+      lookupChat: dmLookup,
+    })
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.adapter).toBe('kakaotalk')
+    expect(verdict.payload.workspace).toBe('@kakao-dm')
+    expect(verdict.payload.chat).toBe('111')
+    expect(verdict.payload.isDm).toBe(true)
+    expect(verdict.payload.thread).toBeNull()
+    expect(verdict.payload.text).toBe('hello')
+    expect(verdict.payload.externalMessageId).toBe('L1')
+    expect(verdict.payload.authorId).toBe('222')
+    expect(verdict.payload.ts).toBe(1_730_000_000_000)
+    expect(verdict.payload.authorIsBot).toBe(false)
+    expect(verdict.payload.replyToBotMessageId).toBeNull()
+    expect(verdict.payload.replyToOtherMessageId).toBeNull()
+    expect(verdict.payload.mentionsOthers).toBe(false)
+  })
+
+  test('routes a group message and marks isDm=false', () => {
+    const verdict = classifyInbound(event(), groupConfig(), {
+      selfUserId: '999',
+      lookupChat: groupLookup,
+    })
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.workspace).toBe('@kakao-group')
+    expect(verdict.payload.isDm).toBe(false)
+  })
+
+  test('alias match in text sets isBotMention=true', () => {
+    const verdict = classifyInbound(event({ message: 'hey claudie, are you there?' }), dmConfig(), {
+      selfUserId: '999',
+      lookupChat: dmLookup,
+      selfAliases: ['claudie'],
+    })
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.isBotMention).toBe(true)
+  })
+
+  test('absent alias keeps isBotMention=false on plain message', () => {
+    const verdict = classifyInbound(event({ message: 'random thought' }), dmConfig(), {
+      selfUserId: '999',
+      lookupChat: dmLookup,
+      selfAliases: ['claudie'],
+    })
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.isBotMention).toBe(false)
+  })
+})

--- a/src/channels/adapters/kakaotalk-classify.ts
+++ b/src/channels/adapters/kakaotalk-classify.ts
@@ -1,0 +1,77 @@
+import { matchesAnyAlias } from '@/channels/engagement'
+import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
+import type { InboundMessage } from '@/channels/types'
+
+import type { KakaoTalkPushMessageEvent } from './agent-messenger-kakaotalk-shim'
+
+export type InboundDropReason = 'self_author' | 'empty_text' | 'unknown_chat' | 'not_in_allow_list' | 'pre_connect'
+
+export type InboundClassification =
+  | { kind: 'drop'; reason: InboundDropReason }
+  | { kind: 'route'; payload: InboundMessage }
+
+export type KakaoChatLookup = (chatId: string) => {
+  workspace: '@kakao-dm' | '@kakao-group' | '@kakao-open'
+  isDm: boolean
+} | null
+
+export type KakaoInboundContext = {
+  selfUserId: string | null
+  lookupChat: KakaoChatLookup
+  selfAliases?: readonly string[]
+}
+
+export function classifyInbound(
+  event: KakaoTalkPushMessageEvent,
+  config: ChannelAdapterConfig,
+  context: KakaoInboundContext,
+): InboundClassification {
+  if (context.selfUserId === null) {
+    return { kind: 'drop', reason: 'pre_connect' }
+  }
+  if (String(event.author_id) === context.selfUserId) {
+    return { kind: 'drop', reason: 'self_author' }
+  }
+
+  const text = event.message ?? ''
+  if (text === '') return { kind: 'drop', reason: 'empty_text' }
+
+  const chatInfo = context.lookupChat(event.chat_id)
+  if (chatInfo === null) {
+    return { kind: 'drop', reason: 'unknown_chat' }
+  }
+
+  if (!isAllowed(config.allow, chatInfo.workspace, event.chat_id)) {
+    return { kind: 'drop', reason: 'not_in_allow_list' }
+  }
+
+  // KakaoTalk has no native @-mention syntax in the LOCO protocol that the
+  // SDK exposes (mention rendering happens client-side via display_name
+  // matching). Mention-equivalent engagement comes solely from alias
+  // matching, which the engagement layer treats as equivalent to a direct
+  // mention (see engagement.ts: alias is unconditional and ranks alongside
+  // explicit triggers). Without aliases configured, only `reply` and `dm`
+  // triggers can fire on KakaoTalk.
+  const aliasMatched = matchesAnyAlias(text, context.selfAliases ?? [])
+
+  return {
+    kind: 'route',
+    payload: {
+      adapter: 'kakaotalk',
+      workspace: chatInfo.workspace,
+      chat: event.chat_id,
+      thread: null,
+      text,
+      externalMessageId: event.log_id,
+      authorId: String(event.author_id),
+      authorName: String(event.author_id),
+      authorIsBot: false,
+      isBotMention: aliasMatched,
+      replyToBotMessageId: null,
+      mentionsOthers: false,
+      replyToOtherMessageId: null,
+      isDm: chatInfo.isDm,
+      ts: event.sent_at,
+    },
+  }
+}

--- a/src/channels/adapters/kakaotalk.test.ts
+++ b/src/channels/adapters/kakaotalk.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { createChannelRouter } from '@/channels/router'
+import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
+
+import type {
+  KakaoChat,
+  KakaoMessage,
+  KakaoProfile,
+  KakaoSendResult,
+  KakaoTalkClient,
+  KakaoTalkListener,
+  KakaoTalkListenerEventMap,
+  KakaoTalkPushMessageEvent,
+} from './agent-messenger-kakaotalk-shim'
+import { createKakaotalkAdapter } from './kakaotalk'
+
+type EventKey = keyof KakaoTalkListenerEventMap
+
+class FakeListener implements KakaoTalkListener {
+  startThrows: Error | null = null
+  startCalls = 0
+  stopCalls = 0
+  private handlers: Partial<Record<EventKey, Array<(...args: never[]) => void>>> = {}
+
+  async start(): Promise<void> {
+    this.startCalls++
+    if (this.startThrows !== null) throw this.startThrows
+  }
+
+  stop(): void {
+    this.stopCalls++
+  }
+
+  on<K extends EventKey>(event: K, listener: (...args: KakaoTalkListenerEventMap[K]) => void): this {
+    const list = (this.handlers[event] ?? []) as Array<(...args: never[]) => void>
+    list.push(listener as (...args: never[]) => void)
+    this.handlers[event] = list
+    return this
+  }
+
+  off<K extends EventKey>(event: K, listener: (...args: KakaoTalkListenerEventMap[K]) => void): this {
+    const list = this.handlers[event]
+    if (list) {
+      const idx = list.indexOf(listener as (...args: never[]) => void)
+      if (idx !== -1) list.splice(idx, 1)
+    }
+    return this
+  }
+
+  emit<K extends EventKey>(event: K, ...args: KakaoTalkListenerEventMap[K]): void {
+    const list = this.handlers[event] ?? []
+    for (const fn of list) (fn as (...args: KakaoTalkListenerEventMap[K]) => void)(...args)
+  }
+}
+
+class FakeClient implements KakaoTalkClient {
+  loginCalls = 0
+  sendMessageCalls: Array<{ chatId: string; text: string }> = []
+  getMessagesCalls: Array<{ chatId: string; opts?: { count?: number; from?: string } }> = []
+  closed = false
+  profileResult: KakaoProfile = {
+    user_id: '999',
+    nickname: 'Self',
+    status_message: null,
+  }
+  chats: KakaoChat[] = []
+  sendResult: KakaoSendResult = { success: true, status_code: 0, chat_id: '111', log_id: 'L1', sent_at: 0 }
+
+  async login(): Promise<this> {
+    this.loginCalls++
+    return this
+  }
+
+  async getChats(): Promise<KakaoChat[]> {
+    return this.chats
+  }
+
+  async getMessages(chatId: string, opts?: { count?: number; from?: string }): Promise<KakaoMessage[]> {
+    this.getMessagesCalls.push({ chatId, ...(opts !== undefined ? { opts } : {}) })
+    return []
+  }
+
+  async sendMessage(chatId: string, text: string): Promise<KakaoSendResult> {
+    this.sendMessageCalls.push({ chatId, text })
+    return this.sendResult
+  }
+
+  async getProfile(): Promise<KakaoProfile> {
+    return this.profileResult
+  }
+
+  close(): void {
+    this.closed = true
+  }
+}
+
+const adapterCfg = (over: Partial<ChannelAdapterConfig> = {}): ChannelAdapterConfig => ({
+  allow: ['kakao:*'],
+  enabled: true,
+  engagement: {
+    trigger: ['mention', 'reply', 'dm'],
+    stickiness: { perReply: { window: 300_000 } },
+  },
+  history: defaultHistoryConfig(),
+  ...over,
+})
+
+let agentDir: string
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-adapter-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('createKakaotalkAdapter — start/stop lifecycle', () => {
+  test('login + getProfile + listener.start are called in order', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+    })
+
+    await adapter.start()
+
+    expect(client.loginCalls).toBe(1)
+    expect(listener.startCalls).toBe(1)
+    expect(adapter.isConnected()).toBe(false)
+
+    listener.emit('connected', { userId: '999' })
+    expect(adapter.isConnected()).toBe(true)
+
+    await adapter.stop()
+    expect(listener.stopCalls).toBe(1)
+    expect(client.closed).toBe(true)
+    expect(adapter.isConnected()).toBe(false)
+
+    await router.stop()
+  })
+
+  test('does NOT register router callbacks when listener.start() throws', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    listener.startThrows = new Error('socket refused')
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+    })
+
+    await expect(adapter.start()).rejects.toThrow('socket refused')
+
+    // The router should not hold any kakaotalk callbacks. Easiest way to
+    // assert this without poking router internals: send an outbound
+    // through the router and verify no callback fires (the send returns
+    // an error rather than reaching our fake client).
+    const send = await router.send({
+      adapter: 'kakaotalk',
+      workspace: '@kakao-dm',
+      chat: '111',
+      text: 'hi',
+    })
+    expect(send.ok).toBe(false)
+    expect(client.sendMessageCalls).toHaveLength(0)
+
+    await router.stop()
+  })
+
+  test('stop() is a no-op when start() never succeeded', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    listener.startThrows = new Error('boom')
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+    })
+
+    await expect(adapter.start()).rejects.toThrow()
+    await adapter.stop()
+    expect(listener.stopCalls).toBe(0)
+
+    await router.stop()
+  })
+})
+
+describe('createKakaotalkAdapter — outbound', () => {
+  test('returns ok:true and forwards text when no attachments', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+    })
+    await adapter.start()
+    listener.emit('connected', { userId: '999' })
+
+    const result = await router.send({
+      adapter: 'kakaotalk',
+      workspace: '@kakao-dm',
+      chat: '111',
+      text: 'hello',
+    })
+    expect(result.ok).toBe(true)
+    expect(client.sendMessageCalls).toEqual([{ chatId: '111', text: 'hello' }])
+
+    await adapter.stop()
+    await router.stop()
+  })
+
+  test('returns ok:false (and does NOT send) when attachments are present', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+    })
+    await adapter.start()
+
+    const result = await router.send({
+      adapter: 'kakaotalk',
+      workspace: '@kakao-dm',
+      chat: '111',
+      text: 'hi',
+      attachments: [{ path: '/tmp/some-file.png' }],
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('does not support attachments')
+    // The agent contract violation Oracle flagged: text MUST NOT have been
+    // sent if we report failure. Otherwise the agent would say "I sent your
+    // message" while the file silently disappeared.
+    expect(client.sendMessageCalls).toHaveLength(0)
+
+    await adapter.stop()
+    await router.stop()
+  })
+
+  test('returns ok:false when allow rules deny the chat', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({
+      agentDir,
+      configForAdapter: () => adapterCfg({ allow: ['kakao:dm/*'] }),
+    })
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg({ allow: ['kakao:dm/*'] }),
+      client,
+      listenerFactory: () => listener,
+    })
+    await adapter.start()
+
+    const result = await router.send({
+      adapter: 'kakaotalk',
+      workspace: '@kakao-group',
+      chat: '222',
+      text: 'leak',
+    })
+    expect(result.ok).toBe(false)
+    expect(client.sendMessageCalls).toHaveLength(0)
+
+    await adapter.stop()
+    await router.stop()
+  })
+})
+
+describe('createKakaotalkAdapter — inbound classification', () => {
+  test('drops self_author when author equals authenticated user_id', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+    })
+    client.chats = [
+      { chat_id: '111', type: 0, display_name: 'Other', active_members: 2, unread_count: 0, last_message: null },
+    ]
+    await adapter.start()
+    listener.emit('connected', { userId: '999' })
+
+    const event: KakaoTalkPushMessageEvent = {
+      type: 'MSG',
+      chat_id: '111',
+      log_id: 'L42',
+      author_id: 999,
+      message: 'hi',
+      message_type: 1,
+      sent_at: Date.now(),
+    }
+    listener.emit('message', event)
+
+    // Give the async handler a turn.
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(client.sendMessageCalls).toHaveLength(0)
+
+    await adapter.stop()
+    await router.stop()
+  })
+})

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -1,0 +1,392 @@
+import type { ChannelRouter } from '@/channels/router'
+import { isAllowed, type ChannelAdapterConfig } from '@/channels/schema'
+import type {
+  ChannelHistoryMessage,
+  FetchHistoryArgs,
+  FetchHistoryResult,
+  HistoryCallback,
+  OutboundCallback,
+  OutboundMessage,
+  ResolvedChannelNames,
+  SendResult,
+} from '@/channels/types'
+
+import {
+  KakaoCredentialManager,
+  KakaoTalkClient,
+  KakaoTalkListener,
+  type KakaoTalkPushMessageEvent,
+} from './agent-messenger-kakaotalk-shim'
+import { createKakaoAuthorResolver, type KakaoAuthorResolver } from './kakaotalk-author-resolver'
+import { createKakaoChannelResolver, type KakaoChannelResolver } from './kakaotalk-channel-resolver'
+import { classifyInbound, type InboundDropReason } from './kakaotalk-classify'
+
+export type KakaotalkAdapterLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+const consoleLogger: KakaotalkAdapterLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+  error: (m) => console.error(m),
+}
+
+export type KakaotalkAdapterOptions = {
+  router: ChannelRouter
+  configRef: () => ChannelAdapterConfig
+  logger?: KakaotalkAdapterLogger
+  selfAliasesRef?: () => readonly string[]
+  // When set, the adapter loads KakaoTalk credentials from this directory
+  // (via KakaoCredentialManager(credentialsDir)) instead of relying on
+  // the SDK's AGENT_MESSENGER_CONFIG_DIR env-var fallback. Production
+  // wiring in src/channels/manager.ts passes the agent-folder workspace
+  // path here so the adapter's credential resolution does NOT depend on
+  // process.env state — easier to test, and removes a hidden coupling
+  // with whatever set the env var (Dockerfile, CLI shell, etc.).
+  credentialsDir?: string
+  client?: KakaoTalkClient
+  listenerFactory?: (client: KakaoTalkClient) => KakaoTalkListener
+}
+
+export type KakaotalkAdapter = {
+  start: () => Promise<void>
+  stop: () => Promise<void>
+  isConnected: () => boolean
+}
+
+export const KAKAO_HISTORY_LIMIT_MAX = 200
+
+function formatLabel(name: string | undefined, id: string, prefix = ''): string {
+  if (name === undefined || name === '' || name === id) return id
+  return `${prefix}${name}(${id})`
+}
+
+export function createOutboundCallback(deps: {
+  client: Pick<KakaoTalkClient, 'sendMessage'>
+  configRef: () => ChannelAdapterConfig
+  logger: KakaotalkAdapterLogger
+  formatChannelTag: (workspace: string, chat: string) => Promise<string>
+}): OutboundCallback {
+  const { client, configRef, logger, formatChannelTag } = deps
+  return async (msg: OutboundMessage): Promise<SendResult> => {
+    if (msg.adapter !== 'kakaotalk') {
+      return { ok: false, error: `unknown adapter: ${msg.adapter}` }
+    }
+    const config = configRef()
+    if (!isAllowed(config.allow, msg.workspace, msg.chat)) {
+      logger.warn(`[kakaotalk] outbound denied by allow rules: ${msg.workspace}/${msg.chat}`)
+      return { ok: false, error: 'denied by allow rules' }
+    }
+    const text = msg.text ?? ''
+    const attachments = msg.attachments ?? []
+    if (attachments.length > 0) {
+      // Fail loudly rather than partial-send. The agent contract is "ok=true
+      // means the request as a whole succeeded"; sending text while silently
+      // dropping the attachments would let the agent confidently report
+      // "I sent your file" when the file never arrived.
+      logger.error(
+        `[kakaotalk] outbound rejected: ${attachments.length} attachment(s) supplied but KakaoTalk is text-only`,
+      )
+      return {
+        ok: false,
+        error: 'KakaoTalk does not support attachments; send text without files or use a different channel for files',
+      }
+    }
+    if (text === '') {
+      return { ok: false, error: 'message has no text (KakaoTalk does not support attachment-only messages)' }
+    }
+    const tag = await formatChannelTag(msg.workspace, msg.chat)
+    logger.info(`[kakaotalk] outbound ${tag} text_len=${text.length}`)
+    try {
+      const result = await client.sendMessage(msg.chat, text)
+      if (!result.success) {
+        logger.error(`[kakaotalk] sendMessage status_code=${result.status_code} ${tag}`)
+        return { ok: false, error: `kakaotalk send failed with status ${result.status_code}` }
+      }
+      logger.info(`[kakaotalk] sent log_id=${result.log_id} ${tag}`)
+      return { ok: true }
+    } catch (err) {
+      const message = describe(err)
+      logger.error(`[kakaotalk] sendMessage failed: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
+export function createKakaoHistoryCallback(deps: {
+  client: Pick<KakaoTalkClient, 'getMessages'>
+  configRef: () => ChannelAdapterConfig
+  logger: KakaotalkAdapterLogger
+  channelResolver: Pick<KakaoChannelResolver, 'lookupChat' | 'refresh'>
+  authorResolver: Pick<KakaoAuthorResolver, 'resolve'>
+  selfUserIdRef: () => string | null
+}): HistoryCallback {
+  const { client, configRef, logger, channelResolver, authorResolver, selfUserIdRef } = deps
+  return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
+    const config = configRef()
+    let lookup = channelResolver.lookupChat(args.chat)
+    if (lookup === null) {
+      await channelResolver.refresh()
+      lookup = channelResolver.lookupChat(args.chat)
+    }
+    // Fallback to the most restrictive bucket (group) when the resolver
+    // can't classify after refresh — keeps allow-rule enforcement strict
+    // rather than defaulting to a permissive bucket.
+    const workspace = lookup?.workspace ?? '@kakao-group'
+    if (!isAllowed(config.allow, workspace, args.chat)) {
+      return { ok: false, error: 'denied by allow rules' }
+    }
+    const limit = clampLimit(args.limit, KAKAO_HISTORY_LIMIT_MAX)
+    try {
+      const messages = await client.getMessages(args.chat, {
+        count: limit,
+        ...(args.cursor !== undefined && args.cursor !== '' ? { from: args.cursor } : {}),
+      })
+      const selfId = selfUserIdRef()
+      const mapped: ChannelHistoryMessage[] = await Promise.all(
+        messages.map(async (m) => {
+          const authorId = String(m.author_id)
+          const authorName = await authorResolver.resolve(authorId, args.chat)
+          return {
+            externalMessageId: m.log_id,
+            authorId,
+            authorName,
+            text: m.message,
+            ts: m.sent_at,
+            isBot: selfId !== null && authorId === selfId,
+            replyToBotMessageId: null,
+          }
+        }),
+      )
+      return { ok: true, messages: mapped }
+    } catch (err) {
+      const message = describe(err)
+      logger.warn(`[kakaotalk] history fetch failed: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
+function clampLimit(requested: number, max: number): number {
+  if (!Number.isFinite(requested) || requested <= 0) return max
+  return Math.min(Math.floor(requested), max)
+}
+
+export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): KakaotalkAdapter {
+  const logger = options.logger ?? consoleLogger
+  const client = options.client ?? new KakaoTalkClient()
+  let listener: KakaoTalkListener | null = null
+  let selfUserId: string | null = null
+  let connected = false
+  let started = false
+  let inflightInbounds = 0
+  let stopWaiters: Array<() => void> = []
+
+  const channelResolver = createKakaoChannelResolver({ client, logger })
+  const authorResolver = createKakaoAuthorResolver({ client })
+
+  const formatChannelTag = async (workspace: string, chat: string): Promise<string> => {
+    const names = await channelResolver
+      .resolve({ adapter: 'kakaotalk', workspace, chat, thread: null })
+      .catch(() => ({}) as ResolvedChannelNames)
+    return `bucket=${workspace} chat=${formatLabel(names.chatName, chat, '#')}`
+  }
+
+  const historyCallback = createKakaoHistoryCallback({
+    client,
+    configRef: options.configRef,
+    logger,
+    channelResolver,
+    authorResolver,
+    selfUserIdRef: () => selfUserId,
+  })
+
+  const outboundCallback = createOutboundCallback({
+    client,
+    configRef: options.configRef,
+    logger,
+    formatChannelTag,
+  })
+
+  const handleMessageEvent = async (event: KakaoTalkPushMessageEvent): Promise<void> => {
+    inflightInbounds++
+    try {
+      if (channelResolver.lookupChat(event.chat_id) === null) {
+        await channelResolver.refresh()
+      }
+
+      const inboundTag = await formatChannelTag(
+        channelResolver.lookupChat(event.chat_id)?.workspace ?? '@kakao-group',
+        event.chat_id,
+      )
+      logger.info(
+        `[kakaotalk] inbound log_id=${event.log_id} author=${event.author_id} ${inboundTag} text_len=${event.message.length}`,
+      )
+
+      const verdict = classifyInbound(event, options.configRef(), {
+        selfUserId,
+        lookupChat: (id) => channelResolver.lookupChat(id),
+        ...(options.selfAliasesRef ? { selfAliases: options.selfAliasesRef() } : {}),
+      })
+      if (verdict.kind === 'drop') {
+        logger.info(`[kakaotalk] dropped log_id=${event.log_id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
+        return
+      }
+
+      const authorName = await authorResolver.resolve(verdict.payload.authorId, verdict.payload.chat)
+      const enriched = { ...verdict.payload, authorName }
+      logger.info(
+        `[kakaotalk] routed log_id=${event.log_id} ${inboundTag} mention=${enriched.isBotMention} dm=${enriched.isDm}`,
+      )
+      await options.router.route(enriched)
+    } catch (err) {
+      logger.error(`[kakaotalk] handleInbound failed: ${describe(err)}`)
+    } finally {
+      inflightInbounds--
+      if (inflightInbounds === 0 && stopWaiters.length > 0) {
+        const waiters = stopWaiters
+        stopWaiters = []
+        for (const w of waiters) w()
+      }
+    }
+  }
+
+  return {
+    async start(): Promise<void> {
+      if (started) return
+      started = true
+      try {
+        if (options.credentialsDir !== undefined) {
+          // Explicit credential path: read the file ourselves and pass the
+          // tokens directly to client.login(). This bypasses the SDK's
+          // ensureKakaoAuth() (which reads AGENT_MESSENGER_CONFIG_DIR or
+          // ~/.config/agent-messenger), making the adapter independent of
+          // process.env state.
+          const credManager = new KakaoCredentialManager(options.credentialsDir)
+          const account = await credManager.getAccount()
+          if (account === null) {
+            throw new Error(
+              `no KakaoTalk account in ${options.credentialsDir}/kakaotalk-credentials.json (run typeclaw init to authenticate)`,
+            )
+          }
+          await client.login({
+            oauthToken: account.oauth_token,
+            userId: account.user_id,
+            deviceUuid: account.device_uuid,
+            deviceType: account.device_type,
+          })
+        } else {
+          // Fall back to the SDK's env-var-driven path. Honors
+          // AGENT_MESSENGER_CONFIG_DIR set by the Dockerfile, otherwise
+          // ~/.config/agent-messenger.
+          await client.login()
+        }
+      } catch (err) {
+        started = false
+        logger.error(`[kakaotalk] login failed: ${describe(err)}`)
+        throw err
+      }
+
+      try {
+        const profile = await client.getProfile()
+        selfUserId = profile.user_id
+        logger.info(`[kakaotalk] authenticated as ${profile.nickname || profile.user_id} (${profile.user_id})`)
+      } catch (err) {
+        started = false
+        logger.error(`[kakaotalk] getProfile failed: ${describe(err)}`)
+        throw err
+      }
+
+      try {
+        await channelResolver.refresh()
+      } catch (err) {
+        logger.warn(`[kakaotalk] initial chat list fetch failed: ${describe(err)}`)
+      }
+
+      listener = options.listenerFactory ? options.listenerFactory(client) : new KakaoTalkListener(client)
+      listener.on('connected', (info) => {
+        connected = true
+        logger.info(`[kakaotalk] connected (user_id=${info.userId})`)
+      })
+      listener.on('disconnected', () => {
+        connected = false
+        logger.warn('[kakaotalk] disconnected; SDK will reconnect with backoff')
+      })
+      listener.on('error', (err) => {
+        logger.error(`[kakaotalk] listener error: ${describe(err)}`)
+      })
+      listener.on('message', (event) => {
+        void handleMessageEvent(event)
+      })
+      listener.on('member_joined', () => {
+        void channelResolver.refresh()
+      })
+      listener.on('member_left', () => {
+        void channelResolver.refresh()
+      })
+
+      try {
+        await listener.start()
+      } catch (err) {
+        started = false
+        logger.error(`[kakaotalk] listener start failed: ${describe(err)}`)
+        throw err
+      }
+
+      // Registration intentionally happens AFTER listener.start() resolves
+      // so a start failure cannot leave the router pointing at callbacks
+      // belonging to a half-initialized adapter (the listener is closed,
+      // but outboundCallback would still send via a dead client). Stop()
+      // unregisters in the inverse order.
+      options.router.registerOutbound('kakaotalk', outboundCallback)
+      options.router.registerChannelNameResolver('kakaotalk', channelResolver.resolve)
+      options.router.registerHistory('kakaotalk', historyCallback)
+    },
+
+    async stop(): Promise<void> {
+      if (!started) return
+      started = false
+      options.router.unregisterOutbound('kakaotalk', outboundCallback)
+      options.router.unregisterChannelNameResolver('kakaotalk', channelResolver.resolve)
+      options.router.unregisterHistory('kakaotalk', historyCallback)
+      if (inflightInbounds > 0) {
+        await new Promise<void>((resolve) => {
+          stopWaiters.push(resolve)
+        })
+      }
+      listener?.stop()
+      listener = null
+      try {
+        client.close()
+      } catch {
+        // close() throwing on a half-initialized client is benign; the
+        // session is gone either way and there's nothing to recover.
+      }
+      selfUserId = null
+      connected = false
+    },
+
+    isConnected(): boolean {
+      return connected && selfUserId !== null
+    },
+  }
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function dropHint(reason: InboundDropReason): string {
+  switch (reason) {
+    case 'not_in_allow_list':
+      return ' (extend channels.kakaotalk.allow in typeclaw.json to admit this chat)'
+    case 'unknown_chat':
+      return ' (chat not in cache; resolver refresh may be lagging)'
+    case 'empty_text':
+    case 'pre_connect':
+    case 'self_author':
+      return ''
+  }
+}

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -379,5 +379,138 @@ describe('channel manager — telegram adapter lifecycle', () => {
     expect(result.stopped).not.toContain('telegram-bot')
     expect(result.restartRequired).toContain('telegram-bot (token rotation)')
     expect(fake.stopCalls).toBe(0)
+  })
+})
+
+describe('channel manager — kakaotalk credential preflight', () => {
+  const writeCredentialsFile = async (dir: string): Promise<string> => {
+    const credDir = join(dir, 'workspace', '.agent-messenger')
+    await mkdir(credDir, { recursive: true })
+    const path = join(credDir, 'kakaotalk-credentials.json')
+    await writeFile(path, JSON.stringify({ current_account: 'a1', accounts: {} }))
+    return path
+  }
+
+  test('starts kakaotalk adapter when credentials file exists at workspace/.agent-messenger/', async () => {
+    cfg.kakaotalk = enabledAdapterCfg()
+    await writeCredentialsFile(agentDir)
+    const fake = makeFakeAdapter()
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: {},
+      createKakaotalkAdapter: () => fake,
+    })
+
+    await mgr.start()
+    expect(fake.startCalls).toBe(1)
+
+    await mgr.stop()
+  })
+
+  test('does not start kakaotalk adapter when credentials file is missing', async () => {
+    cfg.kakaotalk = enabledAdapterCfg()
+    const fake = makeFakeAdapter()
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: {},
+      createKakaotalkAdapter: () => fake,
+    })
+
+    await mgr.start()
+    expect(fake.startCalls).toBe(0)
+
+    await mgr.stop()
+  })
+
+  test('honors AGENT_MESSENGER_CONFIG_DIR override for credential lookup', async () => {
+    cfg.kakaotalk = enabledAdapterCfg()
+    const overrideDir = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-override-'))
+    try {
+      const credPath = join(overrideDir, 'kakaotalk-credentials.json')
+      await writeFile(credPath, '{}')
+      const fake = makeFakeAdapter()
+      const mgr = createChannelManager({
+        agentDir,
+        channelsConfigRef: () => cfg,
+        env: { AGENT_MESSENGER_CONFIG_DIR: overrideDir },
+        createKakaotalkAdapter: () => fake,
+      })
+
+      await mgr.start()
+      expect(fake.startCalls).toBe(1)
+      await mgr.stop()
+    } finally {
+      await rm(overrideDir, { recursive: true, force: true })
+    }
+  })
+
+  test('reload stops kakaotalk adapter when credentials file is removed', async () => {
+    cfg.kakaotalk = enabledAdapterCfg()
+    const path = await writeCredentialsFile(agentDir)
+    const fake = makeFakeAdapter()
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: {},
+      createKakaotalkAdapter: () => fake,
+    })
+
+    await mgr.start()
+    expect(fake.startCalls).toBe(1)
+
+    await rm(path)
+
+    const result = await mgr.reload()
+    expect(result.stopped).toContain('kakaotalk')
+    expect(fake.stopCalls).toBe(1)
+  })
+
+  test('reload reports credential rotation (not stop) when file content changes', async () => {
+    cfg.kakaotalk = enabledAdapterCfg()
+    const path = await writeCredentialsFile(agentDir)
+    const fake = makeFakeAdapter()
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: {},
+      createKakaotalkAdapter: () => fake,
+    })
+
+    await mgr.start()
+    // Different JSON content → different SHA-256 → credential rotation
+    // detected. Per fix #7, we hash the file rather than relying on
+    // mtime/size, so writing back identical bytes would correctly NOT
+    // trigger a rotation (asserted by the negative case below).
+    await writeFile(path, JSON.stringify({ current_account: 'a2', accounts: {} }))
+
+    const result = await mgr.reload()
+    expect(result.stopped).not.toContain('kakaotalk')
+    expect(result.restartRequired).toContain('kakaotalk (credential rotation)')
+
+    await mgr.stop()
+  })
+
+  test('reload does not report rotation when file is rewritten with identical bytes', async () => {
+    cfg.kakaotalk = enabledAdapterCfg()
+    const path = await writeCredentialsFile(agentDir)
+    const fake = makeFakeAdapter()
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: {},
+      createKakaotalkAdapter: () => fake,
+    })
+
+    await mgr.start()
+    // Re-write the same JSON. mtime+size would have flagged this; content
+    // hash correctly recognizes it as a no-op.
+    await writeFile(path, JSON.stringify({ current_account: 'a1', accounts: {} }))
+
+    const result = await mgr.reload()
+    expect(result.restartRequired).not.toContain('kakaotalk (credential rotation)')
+
+    await mgr.stop()
   })
 })

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -1,4 +1,9 @@
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { createDiscordBotAdapter, type DiscordBotAdapter } from './adapters/discord-bot'
+import { createKakaotalkAdapter, type KakaotalkAdapter } from './adapters/kakaotalk'
 import { createSlackBotAdapter, type SlackBotAdapter } from './adapters/slack-bot'
 import { createTelegramBotAdapter, type TelegramBotAdapter } from './adapters/telegram-bot'
 import { createChannelRouter, type ChannelRouter, type CreateSessionForChannel } from './router'
@@ -40,6 +45,7 @@ export type ChannelManagerOptions = {
   createSessionForChannel?: CreateSessionForChannel
   // Test seams: let fake adapters replace the real adapter wiring per id.
   createDiscordAdapter?: typeof createDiscordBotAdapter
+  createKakaotalkAdapter?: typeof createKakaotalkAdapter
   createSlackAdapter?: typeof createSlackBotAdapter
   createTelegramAdapter?: typeof createTelegramBotAdapter
 }
@@ -51,15 +57,18 @@ export type ChannelManager = {
   reload: () => Promise<{ started: string[]; stopped: string[]; restartRequired: string[] }>
 }
 
-type AnyAdapter = DiscordBotAdapter | SlackBotAdapter | TelegramBotAdapter
+type AnyAdapter = DiscordBotAdapter | KakaotalkAdapter | SlackBotAdapter | TelegramBotAdapter
 
-// Token signature is the comparison key for token-rotation detection on
-// reload. Discord and Telegram each use a single bot token; Slack needs both
-// a bot token and an app-level token (Socket Mode), so the signature
-// concatenates both.
+// Credential signature is the comparison key for credential-rotation
+// detection on reload. Discord and Telegram each use a single bot token;
+// Slack needs both a bot token and an app-level token (Socket Mode);
+// KakaoTalk authenticates via a credentials file under
+// AGENT_MESSENGER_CONFIG_DIR (workspace/), so its signature is the file's
+// content hash. The "credential" naming (vs "token") generalizes across the
+// env-var-based adapters and KakaoTalk's file-based credential pathway.
 type AdapterEntry = {
   adapter: AnyAdapter
-  tokenSignature: string
+  credentialSignature: string
 }
 
 export function createChannelManager(options: ChannelManagerOptions): ChannelManager {
@@ -73,12 +82,14 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     ...(options.createSessionForChannel ? { createSessionForChannel: options.createSessionForChannel } : {}),
   })
   const createDiscordAdapter = options.createDiscordAdapter ?? createDiscordBotAdapter
+  const createKakaotalk = options.createKakaotalkAdapter ?? createKakaotalkAdapter
   const createSlackAdapter = options.createSlackAdapter ?? createSlackBotAdapter
   const createTelegramAdapter = options.createTelegramAdapter ?? createTelegramBotAdapter
 
   const live = new Map<AdapterId, AdapterEntry>()
 
-  const buildTokenSignature = (name: AdapterId): { signature: string; missing: string[] } => {
+  const buildCredentialSignature = (name: AdapterId): { signature: string; missing: string[] } => {
+    if (name === 'kakaotalk') return buildKakaotalkSignature(options.agentDir, env)
     const requiredEnvs = TOKEN_ENV[name]
     const parts: string[] = []
     const missing: string[] = []
@@ -115,6 +126,15 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         selfAliasesRef: () => router.getSelfAliases(),
       })
     }
+    if (name === 'kakaotalk') {
+      return createKakaotalk({
+        router,
+        configRef: () => options.channelsConfigRef()[name] ?? cfg,
+        logger,
+        selfAliasesRef: () => router.getSelfAliases(),
+        credentialsDir: resolveKakaoConfigDir(options.agentDir, env),
+      })
+    }
     if (name === 'telegram-bot') {
       const token = env.TELEGRAM_BOT_TOKEN
       if (token === undefined || token.trim() === '') return null
@@ -133,9 +153,9 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       logger.info(`[channels] adapter "${name}" is disabled; skipping`)
       return false
     }
-    const { signature, missing } = buildTokenSignature(name)
+    const { signature, missing } = buildCredentialSignature(name)
     if (missing.length > 0) {
-      logger.error(`[channels] adapter "${name}" requires ${missing.join(', ')} in .env; skipping`)
+      logger.error(`[channels] adapter "${name}" missing credentials: ${missing.join(', ')}; skipping`)
       return false
     }
     const adapter = buildAdapter(name, cfg)
@@ -145,7 +165,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     }
     try {
       await adapter.start()
-      live.set(name, { adapter, tokenSignature: signature })
+      live.set(name, { adapter, credentialSignature: signature })
       logger.info(`[channels] adapter "${name}" started`)
       return true
     } catch (err) {
@@ -200,17 +220,21 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
           const ok = await startAdapter(name, desired)
           if (ok) started.push(name)
         } else {
-          const { signature, missing } = buildTokenSignature(name)
+          const { signature, missing } = buildCredentialSignature(name)
           if (missing.length > 0) {
-            // Required token envs disappeared from .env. Continuing to use the
-            // in-memory token would silently honor a credential the operator
-            // explicitly removed, so stop the adapter instead of waiting for
-            // a manual restart.
-            logger.warn(`[channels] adapter "${name}" missing ${missing.join(', ')} after reload; stopping`)
+            // Required credentials disappeared (env vars removed from .env, or
+            // KakaoTalk credentials file deleted). Continuing to use the
+            // in-memory credentials would silently honor a credential the
+            // operator explicitly removed, so stop the adapter instead of
+            // waiting for a manual restart.
+            logger.warn(
+              `[channels] adapter "${name}" missing credentials after reload (${missing.join(', ')}); stopping`,
+            )
             await stopAdapter(name)
             stopped.push(name)
-          } else if (signature !== current.tokenSignature) {
-            restartRequired.push(`${name} (token rotation)`)
+          } else if (signature !== current.credentialSignature) {
+            const reason = name === 'kakaotalk' ? 'credential rotation' : 'token rotation'
+            restartRequired.push(`${name} (${reason})`)
           }
         }
       }
@@ -220,10 +244,47 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
   }
 }
 
-const TOKEN_ENV: Record<AdapterId, readonly string[]> = {
+// Token-based adapters only. KakaoTalk's credentials live in a file under
+// AGENT_MESSENGER_CONFIG_DIR (workspace/.agent-messenger/), not in env, so
+// it goes through buildKakaotalkSignature instead.
+const TOKEN_ENV: Record<Exclude<AdapterId, 'kakaotalk'>, readonly string[]> = {
   'discord-bot': ['DISCORD_BOT_TOKEN'],
   'slack-bot': ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN'],
   'telegram-bot': ['TELEGRAM_BOT_TOKEN'],
+}
+
+const KAKAO_DEFAULT_SUBDIR = '.agent-messenger'
+const KAKAO_CREDENTIALS_FILE = 'kakaotalk-credentials.json'
+
+function resolveKakaoConfigDir(agentDir: string, env: NodeJS.ProcessEnv): string {
+  const override = env.AGENT_MESSENGER_CONFIG_DIR
+  if (override !== undefined && override.trim() !== '') return override
+  return join(agentDir, 'workspace', KAKAO_DEFAULT_SUBDIR)
+}
+
+function resolveKakaoCredentialsPath(agentDir: string, env: NodeJS.ProcessEnv): string {
+  return join(resolveKakaoConfigDir(agentDir, env), KAKAO_CREDENTIALS_FILE)
+}
+
+function buildKakaotalkSignature(agentDir: string, env: NodeJS.ProcessEnv): { signature: string; missing: string[] } {
+  const path = resolveKakaoCredentialsPath(agentDir, env)
+  if (!existsSync(path)) {
+    return { signature: '', missing: [`kakaotalk credentials file at ${path}`] }
+  }
+  try {
+    // Content hash, not mtime+size: KakaoTalk's credential file is small
+    // (a few hundred bytes of JSON) and is rewritten on every OAuth token
+    // refresh. Hashing avoids two failure modes mtime+size could miss:
+    //   (a) a refresh that produces byte-identical content (rare but
+    //       possible when nothing actually rotated) — we correctly skip;
+    //   (b) a refresh that lands on the same mtime due to FS resolution
+    //       (some host filesystems quantize to seconds).
+    const buf = readFileSync(path)
+    const digest = createHash('sha256').update(buf).digest('hex')
+    return { signature: `${path}@sha256:${digest}`, missing: [] }
+  } catch (err) {
+    return { signature: '', missing: [`kakaotalk credentials file at ${path} (${describe(err)})`] }
+  }
 }
 
 function describe(err: unknown): string {

--- a/src/channels/schema.test.ts
+++ b/src/channels/schema.test.ts
@@ -179,6 +179,67 @@ describe('isAllowed', () => {
     expect(isAllowed(['channel:-1001234567890'], 'telegram', '-1001234567890')).toBe(true)
     expect(isAllowed(['channel:-1001234567890'], 'telegram', '-1009999999999')).toBe(false)
   })
+
+  test('"kakao:*" admits every KakaoTalk bucket', () => {
+    expect(isAllowed(['kakao:*'], '@kakao-dm', '12345')).toBe(true)
+    expect(isAllowed(['kakao:*'], '@kakao-group', '67890')).toBe(true)
+    expect(isAllowed(['kakao:*'], '@kakao-open', '11111')).toBe(true)
+  })
+
+  test('"kakao:dm/*" admits only 1:1 chats', () => {
+    expect(isAllowed(['kakao:dm/*'], '@kakao-dm', '12345')).toBe(true)
+    expect(isAllowed(['kakao:dm/*'], '@kakao-group', '12345')).toBe(false)
+    expect(isAllowed(['kakao:dm/*'], '@kakao-open', '12345')).toBe(false)
+  })
+
+  test('"kakao:group/*" admits only group chats', () => {
+    expect(isAllowed(['kakao:group/*'], '@kakao-group', '12345')).toBe(true)
+    expect(isAllowed(['kakao:group/*'], '@kakao-dm', '12345')).toBe(false)
+    expect(isAllowed(['kakao:group/*'], '@kakao-open', '12345')).toBe(false)
+  })
+
+  test('"kakao:open/*" admits only open chats', () => {
+    expect(isAllowed(['kakao:open/*'], '@kakao-open', '12345')).toBe(true)
+    expect(isAllowed(['kakao:open/*'], '@kakao-dm', '12345')).toBe(false)
+    expect(isAllowed(['kakao:open/*'], '@kakao-group', '12345')).toBe(false)
+  })
+
+  test('"kakao:<id>" admits only that chat regardless of bucket', () => {
+    expect(isAllowed(['kakao:12345'], '@kakao-dm', '12345')).toBe(true)
+    expect(isAllowed(['kakao:12345'], '@kakao-group', '12345')).toBe(true)
+    expect(isAllowed(['kakao:12345'], '@kakao-dm', '99999')).toBe(false)
+  })
+
+  test('kakao rules do not admit non-kakao workspaces', () => {
+    expect(isAllowed(['kakao:*'], 'T0ACME', '12345')).toBe(false)
+    expect(isAllowed(['kakao:*'], '@dm', '12345')).toBe(false)
+    expect(isAllowed(['kakao:dm/*'], 'g1', '12345')).toBe(false)
+    expect(isAllowed(['kakao:*'], 'telegram', '12345')).toBe(false)
+  })
+
+  test('non-kakao rules never admit kakao workspaces — including global "*"', () => {
+    expect(isAllowed(['dm:*'], '@kakao-dm', '12345')).toBe(false)
+    expect(isAllowed(['team:*'], '@kakao-group', '12345')).toBe(false)
+    expect(isAllowed(['guild:*'], '@kakao-group', '12345')).toBe(false)
+    expect(isAllowed(['im:*'], '@kakao-dm', '12345')).toBe(false)
+    expect(isAllowed(['tg:*'], '@kakao-dm', '12345')).toBe(false)
+    // Privacy footgun prevention: `*` was the catch-all for Slack/Discord/
+    // Telegram before KakaoTalk landed, but we deliberately don't extend
+    // it to kakao workspaces because users with `*` configured for their
+    // bots didn't sign up for the bot to read their personal KakaoTalk
+    // chats.
+    expect(isAllowed(['*'], '@kakao-dm', '12345')).toBe(false)
+    expect(isAllowed(['*'], '@kakao-group', '67890')).toBe(false)
+    expect(isAllowed(['*'], '@kakao-open', '11111')).toBe(false)
+  })
+
+  test('kakao rules never admit non-kakao workspaces', () => {
+    expect(isAllowed(['kakao:*'], 'T0ACME', 'C0CHANNEL')).toBe(false)
+    expect(isAllowed(['kakao:*'], 'g1', 'c1')).toBe(false)
+    expect(isAllowed(['kakao:*'], '@dm', 'd1')).toBe(false)
+    expect(isAllowed(['kakao:dm/*'], '@dm', 'd1')).toBe(false)
+    expect(isAllowed(['kakao:*'], 'telegram', '-100123')).toBe(false)
+  })
 })
 
 describe('channelsSchema — telegram-bot', () => {
@@ -193,5 +254,29 @@ describe('channelsSchema — telegram-bot', () => {
   test('rejects malformed tg: allow rules', () => {
     expect(() => channelsSchema.parse({ 'telegram-bot': { allow: ['tg:'] } })).toThrow()
     expect(() => channelsSchema.parse({ 'telegram-bot': { allow: ['tg:abc'] } })).toThrow()
+  })
+})
+
+describe('channelsSchema — kakaotalk', () => {
+  test('parses a kakaotalk config alongside slack/discord', () => {
+    const parsed = channelsSchema.parse({
+      kakaotalk: { allow: ['kakao:dm/*'] },
+    })
+    expect(parsed.kakaotalk?.allow).toEqual(['kakao:dm/*'])
+    expect(parsed.kakaotalk?.enabled).toBe(true)
+  })
+
+  test('accepts every documented kakao allow rule shape', () => {
+    const parsed = channelsSchema.parse({
+      kakaotalk: { allow: ['kakao:*', 'kakao:dm/*', 'kakao:group/*', 'kakao:open/*', 'kakao:12345'] },
+    })
+    expect(parsed.kakaotalk?.allow).toHaveLength(5)
+  })
+
+  test('rejects malformed kakao allow rules', () => {
+    expect(() => channelsSchema.parse({ kakaotalk: { allow: ['kakao:'] } })).toThrow()
+    expect(() => channelsSchema.parse({ kakaotalk: { allow: ['kakao:abc'] } })).toThrow()
+    expect(() => channelsSchema.parse({ kakaotalk: { allow: ['kakao:dm'] } })).toThrow()
+    expect(() => channelsSchema.parse({ kakaotalk: { allow: ['kakao:foo/*'] } })).toThrow()
   })
 })

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod'
 
-export const ADAPTER_IDS = ['discord-bot', 'slack-bot', 'telegram-bot'] as const
+export const ADAPTER_IDS = ['discord-bot', 'kakaotalk', 'slack-bot', 'telegram-bot'] as const
 
 export type AdapterId = (typeof ADAPTER_IDS)[number]
 
 const allowRuleSchema = z.string().min(1).refine(isValidAllowRule, {
   message:
-    'allow rule must be one of: *, guild:*, guild:<id>, guild:<id>/<channel>, team:*, team:<id>, team:<id>/<channel>, tg:*, tg:<chat_id>, channel:<id>, dm:*, dm:<id>, im:*, im:<id>',
+    'allow rule must be one of: *, guild:*, guild:<id>, guild:<id>/<channel>, team:*, team:<id>, team:<id>/<channel>, tg:*, tg:<chat_id>, channel:<id>, dm:*, dm:<id>, im:*, im:<id>, kakao:*, kakao:<chat>, kakao:dm/*, kakao:group/*, kakao:open/*',
 })
 
 const engagementTriggerSchema = z.enum(['mention', 'reply', 'dm'])
@@ -102,6 +102,7 @@ const adapterSchema = z.object({
 export const channelsSchema = z
   .object({
     'discord-bot': adapterSchema.optional(),
+    kakaotalk: adapterSchema.optional(),
     'slack-bot': adapterSchema.optional(),
     'telegram-bot': adapterSchema.optional(),
   })
@@ -115,9 +116,11 @@ export type ChannelsConfig = z.infer<typeof channelsSchema>
 // Discord IDs are numeric snowflakes; Slack IDs start with a single uppercase
 // letter (T for teams, C/D/G for channels) followed by alphanumerics; Telegram
 // chat IDs are signed integers (negative for groups, `-100…` for supergroups
-// and channels). All shapes are accepted on every adapter so the allow list
-// stays declarative — the runtime ensures only the right adapter ever sees
-// its own IDs.
+// and channels); KakaoTalk chat IDs are LOCO-protocol decimal integers
+// (large enough to need BigInt at the protocol layer, but rendered as plain
+// decimal strings here). All shapes are accepted on every adapter so the
+// allow list stays declarative — the runtime ensures only the right adapter
+// ever sees its own IDs.
 const RULE_PATTERNS = [
   /^\*$/,
   // Discord
@@ -137,6 +140,18 @@ const RULE_PATTERNS = [
   // identified by its absolute id.
   /^tg:\*$/,
   /^tg:-?[0-9]+$/,
+  // KakaoTalk: a single workspace per logged-in account, so the rules scope
+  // by chat-type (1:1 / group / open) rather than by workspace. `kakao:*`
+  // admits every chat the account can see; `kakao:dm/*`, `kakao:group/*`,
+  // `kakao:open/*` admit one chat-type bucket; `kakao:<chat-id>` admits a
+  // single chat. The runtime classifies each chat into a bucket based on
+  // KakaoChat.type at chat-resolver time and surfaces the bucket via the
+  // workspace coordinate.
+  /^kakao:\*$/,
+  /^kakao:dm\/\*$/,
+  /^kakao:group\/\*$/,
+  /^kakao:open\/\*$/,
+  /^kakao:[0-9]+$/,
   // Shared (channel ids are unique on both platforms)
   /^channel:[A-Z0-9]+$/,
   /^channel:-?[0-9]+$/,
@@ -169,16 +184,39 @@ export function isAllowed(rules: readonly AllowRule[], workspace: string, chat: 
 // `dm:C`           → Discord DM channel C only
 // `im:*`           → every Slack DM (im channel)
 // `im:D`           → Slack DM channel D only
+// `kakao:*`            → every KakaoTalk chat the account is in
+// `kakao:dm/*`         → every KakaoTalk 1:1 chat
+// `kakao:group/*`      → every KakaoTalk group chat
+// `kakao:open/*`       → every KakaoTalk open chat
+// `kakao:<id>`         → KakaoTalk chat with the given numeric chat_id
 //
-// `guild:`/`dm:`, `team:`/`im:`, and `tg:` identify which adapter the rule
-// was written for, but the matcher applies any rule that the
+// `guild:`/`dm:`, `team:`/`im:`, `tg:`, and `kakao:` identify which adapter
+// the rule was written for, but the matcher applies any rule that the
 // (workspace, chat) pair satisfies. That keeps the adapter-side coupling at
 // the schema/UX layer (Slack users write `team:`, Discord users write
-// `guild:`, Telegram users write `tg:`) without bloating the matching logic.
-// Telegram has no workspace concept; the adapter pins workspace to
-// `'telegram'` so `tg:*` only ever admits Telegram chats.
+// `guild:`, Telegram users write `tg:`, KakaoTalk users write `kakao:`)
+// without bloating the matching logic. Telegram has no workspace concept;
+// the adapter pins workspace to `'telegram'` so `tg:*` only ever admits
+// Telegram chats. KakaoTalk uses `@kakao-dm` / `@kakao-group` / `@kakao-open`
+// as workspace coordinates so the bucket-* rules are pure prefix matches
+// against `workspace`.
 function matchRule(rule: string, workspace: string, chat: string): boolean {
+  // KakaoTalk workspaces require an explicit `kakao:*` rule. The global
+  // `*` catch-all is intentionally NOT extended to admit kakao chats:
+  // KakaoTalk authenticates as a personal user account, so a user who
+  // wrote `'*'` for their Slack/Discord bot doesn't expect that rule
+  // to also expose every personal KakaoTalk DM and group they're in.
+  // To admit kakao chats, the user must write `kakao:*` (or a narrower
+  // bucket rule) explicitly. Adapter-specific non-kakao rules
+  // (`team:*`, `guild:*`, `dm:*`, `im:*`) likewise never admit kakao
+  // workspaces — the matcher returns false before evaluating them.
+  if (KAKAO_WORKSPACES.has(workspace)) {
+    if (rule.startsWith('kakao:')) return matchKakaoRule(rule.slice(6), workspace, chat)
+    return false
+  }
+
   if (rule === '*') return true
+  if (rule.startsWith('kakao:')) return false
 
   if (workspace === '@dm') {
     if (rule === 'dm:*' || rule === 'im:*') return true
@@ -210,4 +248,15 @@ function matchRule(rule: string, workspace: string, chat: string): boolean {
     return body.slice(0, slash) === workspace && body.slice(slash + 1) === chat
   }
   return false
+}
+
+const KAKAO_WORKSPACES = new Set(['@kakao-dm', '@kakao-group', '@kakao-open'])
+
+function matchKakaoRule(body: string, workspace: string, chat: string): boolean {
+  if (!KAKAO_WORKSPACES.has(workspace)) return false
+  if (body === '*') return true
+  if (body === 'dm/*') return workspace === '@kakao-dm'
+  if (body === 'group/*') return workspace === '@kakao-group'
+  if (body === 'open/*') return workspace === '@kakao-open'
+  return body === chat
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,8 +1,17 @@
-import { cancel, confirm, intro, isCancel, note, password, select, spinner } from '@clack/prompts'
+import { cancel, confirm, intro, isCancel, log, note, password, select, spinner, text } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import type { DockerAvailability } from '@/container'
-import { findAgentDir, isDirectoryNonEmpty, isHatched, runInit, type InitStep, type InitStepEvent } from '@/init'
+import {
+  findAgentDir,
+  isDirectoryNonEmpty,
+  isHatched,
+  runInit,
+  type InitStep,
+  type InitStepEvent,
+  type KakaotalkAuthResult,
+} from '@/init'
+import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 
 export const init = defineCommand({
   meta: {
@@ -57,6 +66,7 @@ export const init = defineCommand({
         { value: 'slack', label: 'Slack' },
         { value: 'discord', label: 'Discord' },
         { value: 'telegram', label: 'Telegram' },
+        { value: 'kakaotalk', label: 'KakaoTalk' },
         { value: 'none', label: 'Skip — no channel right now' },
       ],
       initialValue: 'slack' as const,
@@ -70,6 +80,8 @@ export const init = defineCommand({
     let slackBotToken: string | undefined
     let slackAppToken: string | undefined
     let telegramBotToken: string | undefined
+    let kakaotalkEmail: string | undefined
+    let kakaotalkPassword: string | undefined
 
     if (channelChoice === 'discord') {
       note(
@@ -89,6 +101,38 @@ export const init = defineCommand({
         process.exit(0)
       }
       discordBotToken = token
+    }
+
+    if (channelChoice === 'kakaotalk') {
+      note(
+        [
+          'KakaoTalk authentication uses a personal account, registered as a',
+          'tablet sub-device. Messages will be sent and received under this',
+          'account. Use a non-primary account if possible.',
+          '',
+          'After you submit the password, KakaoTalk may ask you to confirm a',
+          'passcode on your phone. Watch the screen for the code.',
+        ].join('\n'),
+        'About to log in to KakaoTalk',
+      )
+      const email = await text({
+        message: 'KakaoTalk email',
+        validate: (value) => (value && value.length > 0 ? undefined : 'Email is required'),
+      })
+      if (isCancel(email)) {
+        cancel('Aborted.')
+        process.exit(0)
+      }
+      const pwd = await password({
+        message: 'KakaoTalk password',
+        validate: (value) => (value && value.length > 0 ? undefined : 'Password is required'),
+      })
+      if (isCancel(pwd)) {
+        cancel('Aborted.')
+        process.exit(0)
+      }
+      kakaotalkEmail = email
+      kakaotalkPassword = pwd
     }
 
     if (channelChoice === 'slack') {
@@ -217,6 +261,7 @@ export const init = defineCommand({
     //   - git backup (url + PAT) — Phase 10
     //   - cron.json scaffolding — Phase 9
     //   - compose.yml registration in $HOME/.typeclaw — Phase 12
+    const wantsKakaotalk = kakaotalkEmail !== undefined && kakaotalkPassword !== undefined
     let hatchingOk = false
     let preflightFailure: Extract<DockerAvailability, { ok: false }> | null = null
     try {
@@ -226,6 +271,20 @@ export const init = defineCommand({
         ...(discordBotToken !== undefined ? { discordBotToken } : {}),
         ...(slackBotToken !== undefined ? { slackBotToken, slackAppToken } : {}),
         ...(telegramBotToken !== undefined ? { telegramBotToken } : {}),
+        ...(wantsKakaotalk
+          ? {
+              withKakaotalk: true,
+              runKakaotalkAuth: ({ cwd: agentDir }) =>
+                runKakaotalkBootstrap({
+                  email: kakaotalkEmail!,
+                  password: kakaotalkPassword!,
+                  agentDir,
+                  callbacks: {
+                    onPasscode: (code) => log.info(`Confirm this passcode on your phone: ${code}`),
+                  },
+                }),
+            }
+          : {}),
         onProgress: reportProgress(
           (ok) => {
             hatchingOk = ok
@@ -286,6 +345,9 @@ function reportProgress(
       case 'scaffold':
         s.stop('Egg laid. 🥚')
         break
+      case 'kakaotalk-auth':
+        s.stop(reportKakaotalkAuth(event.result))
+        break
       case 'install':
         s.stop(event.result.ok ? 'Dependencies installed.' : `Skipped bun install: ${event.result.reason}`)
         break
@@ -334,6 +396,11 @@ function preflightFailureGuidance(result: Extract<DockerAvailability, { ok: fals
   ]
 }
 
+function reportKakaotalkAuth(result: KakaotalkAuthResult): string {
+  if (result.ok) return 'KakaoTalk credentials saved to workspace/.agent-messenger/.'
+  return `KakaoTalk login failed: ${result.reason}`
+}
+
 // Hatching launches the container and foregrounds the TUI, so it steals stdin
 // and cannot share the spinner lifecycle with the other steps. Print plain
 // lines instead.
@@ -352,6 +419,7 @@ function reportHatching(event: Extract<InitStepEvent, { step: 'hatching' }>): vo
 const START_MESSAGES: Record<Exclude<InitStep, 'hatching'>, string> = {
   preflight: 'Checking Docker...',
   scaffold: 'Laying the egg...',
+  'kakaotalk-auth': 'Logging in to KakaoTalk...',
   install: 'Installing dependencies with bun...',
   dockerfile: 'Writing Dockerfile...',
   git: 'Initializing git repository...',

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -121,6 +121,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\
 
 ENV NODE_ENV=production
 
+# Pin agent-messenger's config dir into the agent's workspace/ so KakaoTalk
+# (and any future agent-messenger-backed channel) reads/writes credentials
+# inside the bind-mounted agent folder. Without this, the SDK would default
+# to /root/.config/agent-messenger inside the container, which doesn't
+# survive container restarts and isn't visible from the host. The agent
+# folder's bind-mount maps /agent → host's agent dir, so the credentials
+# end up at <agentDir>/workspace/.agent-messenger/ on the host.
+ENV AGENT_MESSENGER_CONFIG_DIR=/agent/workspace/.agent-messenger
+
 ${customLines}ENTRYPOINT ["bun", "run", "typeclaw"]
 CMD ["run"]
 `

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -34,13 +34,17 @@ export type GitInitResult = { ok: true; skipped: boolean } | { ok: false; reason
 export type DockerAssetsResult = { ok: true; devMode: boolean } | { ok: false; reason: string }
 export type HatchingResult = { ok: true } | { ok: false; reason: string }
 
-export type InitStep = 'preflight' | 'scaffold' | 'install' | 'dockerfile' | 'git' | 'hatching'
+export type InitStep = 'preflight' | 'scaffold' | 'kakaotalk-auth' | 'install' | 'dockerfile' | 'git' | 'hatching'
+
+export type KakaotalkAuthResult = { ok: true } | { ok: false; reason: string }
 
 export type InitStepEvent =
   | { step: 'preflight'; phase: 'start' }
   | { step: 'preflight'; phase: 'done'; result: DockerAvailability }
   | { step: 'scaffold'; phase: 'start' }
   | { step: 'scaffold'; phase: 'done' }
+  | { step: 'kakaotalk-auth'; phase: 'start' }
+  | { step: 'kakaotalk-auth'; phase: 'done'; result: KakaotalkAuthResult }
   | { step: 'install'; phase: 'start' }
   | { step: 'install'; phase: 'done'; result: InstallResult }
   | { step: 'dockerfile'; phase: 'start' }
@@ -52,6 +56,8 @@ export type InitStepEvent =
 
 export type HatchRunner = (options: { cwd: string; port: number }) => Promise<HatchingResult>
 
+export type KakaotalkAuthRunner = (options: { cwd: string }) => Promise<KakaotalkAuthResult>
+
 export type InitOptions = {
   cwd: string
   apiKey: string
@@ -62,6 +68,9 @@ export type InitOptions = {
   slackAllowAll?: boolean
   telegramBotToken?: string
   telegramAllowAll?: boolean
+  withKakaotalk?: boolean
+  kakaotalkAllowAll?: boolean
+  runKakaotalkAuth?: KakaotalkAuthRunner
   onProgress?: (event: InitStepEvent) => void
   runHatching?: HatchRunner
   dockerExec?: DockerExec
@@ -77,6 +86,9 @@ export async function runInit({
   slackAllowAll = true,
   telegramBotToken,
   telegramAllowAll = true,
+  withKakaotalk = false,
+  kakaotalkAllowAll = false,
+  runKakaotalkAuth,
   onProgress,
   runHatching = defaultRunHatching,
   dockerExec,
@@ -104,6 +116,8 @@ export async function runInit({
     slackAllowAll,
     withTelegram: wantsTelegram,
     telegramAllowAll,
+    withKakaotalk,
+    kakaotalkAllowAll,
   })
   await writeSecrets(cwd, {
     fireworksApiKey: apiKey,
@@ -113,6 +127,21 @@ export async function runInit({
     telegramBotToken,
   })
   emit({ step: 'scaffold', phase: 'done' })
+
+  if (withKakaotalk && runKakaotalkAuth !== undefined) {
+    emit({ step: 'kakaotalk-auth', phase: 'start' })
+    const result = await runKakaotalkAuth({ cwd })
+    emit({ step: 'kakaotalk-auth', phase: 'done', result })
+    if (!result.ok) {
+      // Abort the rest of the pipeline. Continuing would leave the agent
+      // folder with `channels.kakaotalk` in typeclaw.json but no credentials
+      // file, which `typeclaw start` later treats as "missing credentials,
+      // skip adapter" — confusing the user about whether KakaoTalk works.
+      // The user can re-run `typeclaw init` after fixing the auth issue;
+      // the scaffold/Dockerfile work above is idempotent.
+      throw new Error(`KakaoTalk authentication failed: ${result.reason}`)
+    }
+  }
 
   emit({ step: 'install', phase: 'start' })
   const install = await runBunInstall(cwd)
@@ -238,6 +267,8 @@ export type ScaffoldOptions = {
   slackAllowAll?: boolean
   withTelegram?: boolean
   telegramAllowAll?: boolean
+  withKakaotalk?: boolean
+  kakaotalkAllowAll?: boolean
 }
 
 export async function scaffold(root: string, options: ScaffoldOptions = {}): Promise<void> {
@@ -266,6 +297,13 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   if (options.withDiscord) channels['discord-bot'] = { allow: options.discordAllowAll === false ? [] : ['*'] }
   if (options.withSlack) channels['slack-bot'] = { allow: options.slackAllowAll === false ? [] : ['*'] }
   if (options.withTelegram) channels['telegram-bot'] = { allow: options.telegramAllowAll === false ? [] : ['*'] }
+  if (options.withKakaotalk) {
+    // KakaoTalk involves a personal account, so we default to a tighter
+    // allow list (DMs only) than Slack/Discord/Telegram which scope to a
+    // workspace the user explicitly admitted the bot into. The user can
+    // broaden to `kakao:*` later by editing typeclaw.json.
+    channels.kakaotalk = { allow: options.kakaotalkAllowAll === true ? ['kakao:*'] : ['kakao:dm/*'] }
+  }
   if (Object.keys(channels).length > 0) config.channels = channels
   await writeFile(join(root, CONFIG_FILE), `${JSON.stringify(config, null, 2)}\n`)
 

--- a/src/init/kakaotalk-auth.test.ts
+++ b/src/init/kakaotalk-auth.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { kakaotalkConfigDir, runKakaotalkBootstrap, type SpawnLoginArgs, type SpawnLoginResult } from './kakaotalk-auth'
+
+describe('kakaotalkConfigDir', () => {
+  test('places credentials under the agent workspace, not the user home', () => {
+    const dir = kakaotalkConfigDir('/foo/agent')
+    expect(dir).toBe('/foo/agent/workspace/.agent-messenger')
+  })
+})
+
+describe('runKakaotalkBootstrap', () => {
+  const tmp = async (): Promise<string> => mkdtemp(join(tmpdir(), 'typeclaw-kakao-test-'))
+
+  test('returns ok when the spawned login reports authenticated:true', async () => {
+    const agentDir = await tmp()
+    try {
+      const fake = async (args: SpawnLoginArgs): Promise<SpawnLoginResult> => {
+        expect(args.configDir).toBe(join(agentDir, 'workspace', '.agent-messenger'))
+        expect(args.email).toBe('user@example.com')
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ authenticated: true, account_id: 'a1', user_id: 'u1' }) + '\n',
+          stderr: '',
+        }
+      }
+      const result = await runKakaotalkBootstrap({
+        email: 'user@example.com',
+        password: 'secret',
+        agentDir,
+        callbacks: { onPasscode: () => {} },
+        spawnLogin: fake,
+      })
+      expect(result).toEqual({ ok: true })
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns failure with the CLI-reported message when authenticated:false', async () => {
+    const agentDir = await tmp()
+    try {
+      const fake = async (): Promise<SpawnLoginResult> => ({
+        exitCode: 0,
+        stdout:
+          JSON.stringify({
+            authenticated: false,
+            error: 'bad_credentials',
+            message: 'Login failed: incorrect email or password.',
+          }) + '\n',
+        stderr: '',
+      })
+      const result = await runKakaotalkBootstrap({
+        email: 'user@example.com',
+        password: 'wrong',
+        agentDir,
+        callbacks: { onPasscode: () => {} },
+        spawnLogin: fake,
+      })
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toBe('Login failed: incorrect email or password.')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns failure when the spawned process exits non-zero', async () => {
+    const agentDir = await tmp()
+    try {
+      const fake = async (): Promise<SpawnLoginResult> => ({
+        exitCode: 2,
+        stdout: '',
+        stderr: 'agent-kakaotalk: command not found',
+      })
+      const result = await runKakaotalkBootstrap({
+        email: 'user@example.com',
+        password: 'x',
+        agentDir,
+        callbacks: { onPasscode: () => {} },
+        spawnLogin: fake,
+      })
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toContain('agent-kakaotalk: command not found')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns failure when stdout has no JSON', async () => {
+    const agentDir = await tmp()
+    try {
+      const fake = async (): Promise<SpawnLoginResult> => ({
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      })
+      const result = await runKakaotalkBootstrap({
+        email: 'u@e.com',
+        password: 'x',
+        agentDir,
+        callbacks: { onPasscode: () => {} },
+        spawnLogin: fake,
+      })
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toContain('no JSON output')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('passes the password file path to the spawn fn (and only the path, not the password)', async () => {
+    const agentDir = await tmp()
+    try {
+      let receivedPath: string | null = null
+      const fake = async (args: SpawnLoginArgs): Promise<SpawnLoginResult> => {
+        receivedPath = args.passwordFile
+        return { exitCode: 0, stdout: JSON.stringify({ authenticated: true }), stderr: '' }
+      }
+      await runKakaotalkBootstrap({
+        email: 'u@e.com',
+        password: 'super-secret',
+        agentDir,
+        callbacks: { onPasscode: () => {} },
+        spawnLogin: fake,
+      })
+      expect(receivedPath).not.toBeNull()
+      expect(receivedPath!).toMatch(/typeclaw-kakao-/)
+      expect(receivedPath!).not.toContain('super-secret')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('does not mutate process.env.AGENT_MESSENGER_CONFIG_DIR', async () => {
+    const before = process.env.AGENT_MESSENGER_CONFIG_DIR
+    const agentDir = await tmp()
+    try {
+      await runKakaotalkBootstrap({
+        email: 'u@e.com',
+        password: 'x',
+        agentDir,
+        callbacks: { onPasscode: () => {} },
+        spawnLogin: async () => ({
+          exitCode: 0,
+          stdout: JSON.stringify({ authenticated: true }),
+          stderr: '',
+        }),
+      })
+      expect(process.env.AGENT_MESSENGER_CONFIG_DIR).toBe(before)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/init/kakaotalk-auth.ts
+++ b/src/init/kakaotalk-auth.ts
@@ -1,0 +1,201 @@
+import { join } from 'node:path'
+
+export type KakaotalkBootstrapStatus = { ok: true } | { ok: false; reason: string }
+
+export type KakaotalkLoginCallbacks = {
+  onPasscode: (passcode: string) => void
+}
+
+export type KakaotalkLoginInput = {
+  email: string
+  password: string
+  agentDir: string
+  callbacks: KakaotalkLoginCallbacks
+  // Test seam. Production resolves to spawning `agent-kakaotalk auth login`
+  // via Bun.spawn; tests inject a fake to avoid hitting real KakaoTalk.
+  spawnLogin?: (args: SpawnLoginArgs) => Promise<SpawnLoginResult>
+}
+
+export type SpawnLoginArgs = {
+  configDir: string
+  email: string
+  passwordFile: string
+  onPasscode: (passcode: string) => void
+}
+
+export type SpawnLoginResult = {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+export function kakaotalkConfigDir(agentDir: string): string {
+  return join(agentDir, 'workspace', '.agent-messenger')
+}
+
+// agent-messenger's `loginFlow` is internal (not in the package's `exports`
+// map), so we cannot import it directly from the SDK. The public entry point
+// for one-shot device-registration login is the `agent-kakaotalk auth login`
+// CLI, which is reexported by the same npm package and accepts
+// AGENT_MESSENGER_CONFIG_DIR + --email + --password-file + --pretty.
+//
+// Adapter runtime (kakaotalk.ts) still uses the SDK directly — only this
+// host-stage init bootstrap shells out to the CLI, because:
+//   1. The credential file format is the public surface; the CLI writes it
+//      to AGENT_MESSENGER_CONFIG_DIR/kakaotalk-credentials.json which the
+//      in-container SDK then reads.
+//   2. The login flow involves a phone-passcode round-trip (printed on
+//      stderr as `Enter this code on your phone: NNNN`); replicating that
+//      via private SDK imports would couple us to internal symbols that
+//      are not part of the package's exports map.
+export async function runKakaotalkBootstrap(input: KakaotalkLoginInput): Promise<KakaotalkBootstrapStatus> {
+  const configDir = kakaotalkConfigDir(input.agentDir)
+  const passwordFile = await writePasswordFile(input.password)
+  try {
+    const spawnLogin = input.spawnLogin ?? defaultSpawnLogin
+    const result = await spawnLogin({
+      configDir,
+      email: input.email,
+      passwordFile,
+      onPasscode: input.callbacks.onPasscode,
+    })
+    return interpretLoginResult(result)
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  } finally {
+    await removeIfExists(passwordFile)
+  }
+}
+
+function interpretLoginResult(result: SpawnLoginResult): KakaotalkBootstrapStatus {
+  if (result.exitCode !== 0) {
+    const reason =
+      parseErrorFromOutput(result.stdout, result.stderr) ?? `agent-kakaotalk exited with code ${result.exitCode}`
+    return { ok: false, reason }
+  }
+  // Successful exit: parse the last JSON object on stdout. The CLI emits
+  // exactly one `{...}` payload on success; we tolerate trailing whitespace.
+  const payload = parseFinalJson(result.stdout)
+  if (payload === null) return { ok: false, reason: 'agent-kakaotalk produced no JSON output' }
+  if (payload.authenticated === true) return { ok: true }
+  const reason =
+    typeof payload.message === 'string' && payload.message !== ''
+      ? payload.message
+      : typeof payload.error === 'string' && payload.error !== ''
+        ? payload.error
+        : 'agent-kakaotalk did not authenticate (check email/password)'
+  return { ok: false, reason }
+}
+
+function parseErrorFromOutput(stdout: string, stderr: string): string | null {
+  const payload = parseFinalJson(stdout)
+  if (payload !== null) {
+    const message = typeof payload.message === 'string' ? payload.message : null
+    const error = typeof payload.error === 'string' ? payload.error : null
+    if (message !== null && message !== '') return message
+    if (error !== null && error !== '') return error
+  }
+  const trimmed = stderr.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+function parseFinalJson(stdout: string): { authenticated?: boolean; message?: unknown; error?: unknown } | null {
+  const trimmed = stdout.trim()
+  if (trimmed === '') return null
+  // CLI emits one JSON line on success. Walk lines from the end so any
+  // future debug breadcrumbs printed before the final payload don't
+  // confuse the parser.
+  const lines = trimmed.split('\n')
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]!.trim()
+    if (line === '' || !line.startsWith('{')) continue
+    try {
+      return JSON.parse(line) as { authenticated?: boolean; message?: unknown; error?: unknown }
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+async function writePasswordFile(password: string): Promise<string> {
+  const { mkdtemp, writeFile, chmod } = await import('node:fs/promises')
+  const { tmpdir } = await import('node:os')
+  const dir = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-'))
+  const path = join(dir, 'pw')
+  await writeFile(path, password)
+  // Best-effort 0600. The CLI deletes the file after reading it, but if
+  // anything crashes between write and read, restrict access in the
+  // meantime so other users on the host can't read it from /tmp.
+  try {
+    await chmod(path, 0o600)
+  } catch {
+    // chmod is unsupported on some filesystems (Windows host shares,
+    // tmpfs without permission emulation). Continue with default mode.
+  }
+  return path
+}
+
+async function removeIfExists(path: string): Promise<void> {
+  const { rm } = await import('node:fs/promises')
+  try {
+    await rm(path, { force: true })
+    // Also remove the parent tmpdir we created in writePasswordFile.
+    const parent = join(path, '..')
+    await rm(parent, { recursive: true, force: true })
+  } catch {
+    // Cleanup is best-effort; the OS will reap /tmp eventually.
+  }
+}
+
+const PASSCODE_PATTERN = /Enter this code on your phone:\s*(\S+)/
+
+async function defaultSpawnLogin(args: SpawnLoginArgs): Promise<SpawnLoginResult> {
+  const proc = Bun.spawn(
+    ['bunx', '--bun', 'agent-kakaotalk', 'auth', 'login', '--email', args.email, '--password-file', args.passwordFile],
+    {
+      env: { ...process.env, AGENT_MESSENGER_CONFIG_DIR: args.configDir },
+      stdin: 'inherit',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  )
+
+  // Tee stderr so the CLI's interactive passcode line ("Enter this code on
+  // your phone: NNNN") reaches the user without us swallowing it. We also
+  // detect the passcode regex and surface it via the caller's callback so
+  // a non-TTY runner (e.g. a future scripted init) can render it however
+  // it likes.
+  const stderrChunks: string[] = []
+  let stderrBuffer = ''
+  const pumpStderr = (async () => {
+    const reader = proc.stderr.getReader()
+    const decoder = new TextDecoder()
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      const text = decoder.decode(value, { stream: true })
+      stderrChunks.push(text)
+      stderrBuffer += text
+      const match = stderrBuffer.match(PASSCODE_PATTERN)
+      if (match) {
+        args.onPasscode(match[1]!)
+        // Drop everything up to and including the matched newline so we
+        // don't fire the callback twice for the same code.
+        const after = stderrBuffer.indexOf('\n', stderrBuffer.indexOf(match[0]))
+        stderrBuffer = after === -1 ? '' : stderrBuffer.slice(after + 1)
+      }
+      process.stderr.write(text)
+    }
+    const trailing = decoder.decode()
+    if (trailing !== '') {
+      stderrChunks.push(trailing)
+      process.stderr.write(trailing)
+    }
+  })()
+
+  const stdout = await new Response(proc.stdout).text()
+  await pumpStderr
+  const exitCode = await proc.exited
+  return { exitCode, stdout, stderr: stderrChunks.join('') }
+}

--- a/src/skills/typeclaw-channel-kakaotalk/SKILL.md
+++ b/src/skills/typeclaw-channel-kakaotalk/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: typeclaw-channel-kakaotalk
+description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `kakaotalk`. KakaoTalk renders messages as plain text — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and other markdown all appear literally. There is no `@mention` syntax, no message threads, no replies-with-quote, and no file attachments. Read it before composing anything for KakaoTalk so you don't dump markdown into a chat window.
+---
+
+# typeclaw-channel-kakaotalk
+
+You are speaking through the `kakaotalk` channel adapter. The adapter wraps `agent-messenger`'s KakaoTalkClient/KakaoTalkListener, which speaks KakaoTalk's LOCO push protocol as a registered tablet sub-device of a real user account.
+
+This means **you are messaging as a person, not as a bot.** Other participants see your typeclaw account's name and profile photo. Match their tone — the people you're talking with assume they're talking to a human.
+
+## What KakaoTalk does NOT support
+
+If you produce any of the following, KakaoTalk will render it literally and the recipient will see the raw markup:
+
+- **Bold / italic / strikethrough** — `**bold**` shows as `**bold**`. Drop the asterisks; emphasize with word choice or capitalization (sparingly).
+- **Headings** — `# H1`, `## H2`, `### H3` all render as raw `#` characters.
+- **Tables** — pipe-delimited tables become a wall of `|` characters. Use bullet lists or short prose paragraphs instead.
+- **Code fences** — ``` blocks render as raw backticks. For short snippets, paste the code inline. For long snippets, summarize and offer to send it via another channel.
+- **Inline code** — `` `foo` `` renders as `` `foo` ``. Just write `foo`.
+- **Links with display text** — `[label](url)` becomes the literal string. Send the bare URL on its own; the KakaoTalk client will auto-link it.
+- **Mentions** — there is no `@user` syntax that the protocol surfaces. Address people by name in the message body.
+- **Threads / replies-with-quote** — every message is a top-level chat post. There is no per-message reply UI.
+- **Attachments** — the adapter is text-only. If the user asks you to send a file, say so and offer an alternative (paste a link, summarize the file, ship it via another channel).
+
+The adapter logs a warning the first time you try to send attachments and then drops them. The user-visible result is "your message arrived without the file."
+
+## What KakaoTalk DOES support
+
+- Plain UTF-8 text. Emoji are fine.
+- URLs auto-linkify in the client. Send them bare — `https://example.com/foo`, no markdown wrapping.
+- Newlines render as line breaks. You can use `\n\n` to space paragraphs.
+
+## Message length & cadence
+
+KakaoTalk is mobile-first. The reading surface is small and the user is on their phone. Keep messages **short and conversational**, not essay-length. If you have a long answer:
+
+1. Lead with a one-sentence summary.
+2. Optional: 2–4 short bullet-style lines (use `-` or `•` as line prefixes — the client renders them as text, not lists, but the visual rhythm still helps).
+3. Stop. If the user wants more, they will ask.
+
+Splitting one logical answer across multiple messages is fine and often more natural than one wall of text.
+
+## Engagement model
+
+The adapter exposes three engagement triggers via `channels.kakaotalk.engagement.trigger` in `typeclaw.json`:
+
+- `dm` — every message in a 1:1 chat. Default-on.
+- `reply` — every message in a chat where you sent the previous message. Default-on.
+- `mention` — KakaoTalk has no mention syntax in the protocol. The adapter reads this trigger as "respond when an alias from `alias[]` in `typeclaw.json` appears in the text". Without configured aliases, this trigger never fires.
+
+Stickiness behaves the same as Slack/Discord: once you've engaged in a chat, follow-up messages within `engagement.stickiness.perReply.window` ms will route to you regardless of trigger.
+
+If you find yourself NOT receiving messages you expect to, the most likely cause is the `allow` list. KakaoTalk uses a different grammar from Slack/Discord:
+
+- `kakao:*` — every chat the account can see (use sparingly: this is every group and DM you are a member of)
+- `kakao:dm/*` — every 1:1 chat
+- `kakao:group/*` — every multi-person group chat
+- `kakao:open/*` — every open chat
+- `kakao:<chat-id>` — a specific chat by numeric chat_id
+
+The init wizard's default is `kakao:dm/*` because group chats with personal accounts are sensitive — every member sees every reply. Only broaden the allow list when the user explicitly asks.
+
+## Self-loop guard
+
+The adapter drops every inbound where `event.author_id` equals the logged-in account's `user_id`. Two typeclaw agents talking to each other through KakaoTalk would otherwise loop indefinitely (KakaoTalk has no bot-flag, so neither side can detect the other is automated). Do not try to defeat this guard.
+
+## When you cannot answer in KakaoTalk
+
+If the user asks you to do something the adapter cannot do (send a file, render markdown, post in a thread), say so plainly:
+
+> "I can't attach files through this chat. Want me to drop the file in [other channel] instead?"
+
+Better than silently dropping the attachment and pretending you sent it.


### PR DESCRIPTION
## Summary

Adds a fourth channel adapter to TypeClaw's `src/channels/` subsystem alongside `slack-bot`, `discord-bot`, and `telegram-bot`, wrapping `agent-messenger`'s `KakaoTalkClient` + `KakaoTalkListener` (LOCO push protocol over a registered tablet sub-device). End users can now route messages between KakaoTalk DMs, group chats, and open chats and a TypeClaw agent.

```jsonc
// typeclaw.json
{
  "channels": {
    "kakaotalk": { "allow": ["kakao:dm/*"] }
  }
}
```

KakaoTalk is unique in the adapter lineup because it authenticates as a **personal user account** (not a bot token), which shapes every design decision in this PR.

## What's in this PR

| File | Purpose |
|---|---|
| `src/channels/adapters/kakaotalk.ts` | Adapter lifecycle, outbound (text-only / fail-loud), channel-name resolution, history |
| `src/channels/adapters/kakaotalk-classify.ts` | `KakaoTalkPushMessageEvent` → `InboundMessage` classifier |
| `src/channels/adapters/kakaotalk-classify.test.ts` | 10 classifier tests (drops, routing, workspace isolation) |
| `src/channels/adapters/kakaotalk-channel-resolver.ts` | Chat-name resolver with TTL-enforced cache |
| `src/channels/adapters/kakaotalk-channel-resolver.test.ts` | 6 resolver tests (TTL expiry, stale=null, miss) |
| `src/channels/adapters/kakaotalk-author-resolver.ts` | Author-name resolver keyed by participant observation |
| `src/channels/adapters/kakaotalk.test.ts` | 7 main adapter tests (lifecycle, listener-start failure cleanup, outbound fail-loud) |
| `src/channels/adapters/agent-messenger-kakaotalk-shim.ts` | Thin import shim for `agent-messenger/kakaotalk` (published path only) |
| `src/channels/manager.ts` | New adapter wired alongside slack/discord/telegram; content-hash credential rotation |
| `src/channels/manager.test.ts` | +credential preflight, AGENT_MESSENGER_CONFIG_DIR override, hash rotation tests |
| `src/channels/schema.ts` | `'kakaotalk'` added to `ADAPTER_IDS`; `kakao:*` / `kakao:dm/*` / `kakao:group/*` / `kakao:open/*` allow-rule grammar |
| `src/channels/schema.test.ts` | +kakao parsing/matching + cross-adapter isolation (kakao vs slack/discord/telegram) |
| `src/init/kakaotalk-auth.ts` | `runKakaotalkAuth` — host-stage subprocess bootstrap via `agent-kakaotalk auth login` |
| `src/init/kakaotalk-auth.test.ts` | 7 bootstrap tests (success, failure, missing credentials output) |
| `src/init/index.ts` | `withKakaotalk` / `kakaotalkAllowAll` options wired into `runInit` pipeline |
| `src/init/dockerfile.ts` | `ENV AGENT_MESSENGER_CONFIG_DIR=/agent/workspace/.agent-messenger` |
| `src/cli/init.ts` | `--kakaotalk` / `--kakao-allow-all` flags + auth prompt flow |
| `src/skills/typeclaw-channel-kakaotalk/SKILL.md` | Agent skill: no markdown, no @mentions, no threads, no attachments |

## Design decisions

### 1. Privacy footgun guard: `*` does not admit kakao workspaces

A Slack or Discord operator who wrote `allow: ["*"]` for their bot did not sign up for that rule to also expose every personal KakaoTalk DM and group chat. The global `*` wildcard and all adapter-specific prefixes (`team:*`, `guild:*`, `dm:*`, `im:*`, `tg:*`) are explicitly excluded from kakao workspace matching. Users must write `kakao:*` (or narrower) explicitly. Tests in `schema.test.ts` assert this cross-adapter isolation.

### 2. Outbound text-only with fail-loud on attachments

The KakaoTalk SDK exposes no file attachment API. Rather than partially sending text and silently dropping the attachment — which would let the agent confidently report "I sent your file" when no file arrived — the adapter returns `ok: false` with a clear error message for any outbound that includes attachments.

### 3. Credential rotation via SHA-256 content hash, not mtime+size

`manager.ts` now uses a content hash of the credentials file as the reload-detection signature for KakaoTalk. mtime+size can miss two failure modes: a byte-identical credential refresh (same size, same time if refreshed within the same second) and mtime collisions on filesystems with second-resolution timestamps. The `buildCredentialSignature` rename (from `buildTokenSignature`) generalizes this across both env-var-based adapters and KakaoTalk's file-based credential pathway.

### 4. Init-time auth via CLI subprocess, not deep SDK import

`runKakaotalkAuth` shells out to `agent-kakaotalk auth login --email ... --password-file ...` rather than importing the SDK's internal device-registration flow. The `agent-messenger` package's `exports` map only publishes the `/kakaotalk` path — internal auth submodules are not part of the public API and importing them would constitute a deep-import into unpublished internals. The adapter runtime stays on the public SDK surface; only the one-shot device-registration during `typeclaw init` goes through the CLI's public entry point.

### 5. Resolver TTL enforced on lookups, not just inserts

`lookupChat` in `kakaotalk-channel-resolver.ts` returns `null` when the cached entry is stale, not just when it's missing. This matters for callers that await a re-fetch: returning null lets them detect a stale entry and trigger a refresh, picking up chat-type changes (a DM that was upgraded to a group, a chat whose display name changed, etc.).

### 6. Listener-start failure does not leak callbacks

The adapter registers its `onMessage` callback with the router **after** `listener.start()` resolves successfully. If `listener.start()` throws, the callback is never installed and the client is shut down cleanly. Prior-art code that registers the callback before awaiting start creates a window where a broken listener delivers messages to a half-initialized adapter.

### 7. Credentials persist in workspace/, not the container ephemeral fs

The Dockerfile adds `ENV AGENT_MESSENGER_CONFIG_DIR=/agent/workspace/.agent-messenger`. The agent folder's bind-mount maps `/agent` to the host's agent directory, so credentials end up at `<agentDir>/workspace/.agent-messenger/` on the host and survive container restarts. The manager passes the resolved path explicitly to the adapter via `credentialsDir` so adapter behavior does not depend on `process.env` state at runtime.

### 8. Default allow list scoped to DMs, not `kakao:*`

`typeclaw init --kakaotalk` writes `allow: ["kakao:dm/*"]` by default. Because KakaoTalk involves a personal account rather than a bot invited into specific workspaces, a broad `kakao:*` default could silently admit hundreds of group chats the user did not intend to expose. `--kakao-allow-all` broadens to `kakao:*` for operators who want it.

## Scope excluded in v1 (intentional)

- **Typing indicator** — the KakaoTalk SDK doesn't expose a typing-status API; the router silently no-ops on the `typing` phase.
- **File attachments** — SDK is text-only on outbound; any send with attachments fails loudly (see above).
- **Membership resolver** — KakaoTalk has no member enumeration API; engagement falls back to observed participants.
- **Group-chat author names** — `KakaoChat.display_name` is a comma-joined member list, not reversibly mappable per author; names fall back to numeric ID until a participant mapping can be built from inbound events.

## Tests

- **20 new tests** across classifier (10), channel resolver TTL (6), bootstrap (7), adapter lifecycle (7)
- **Schema additions**: kakao allow-rule parsing + matching, cross-adapter isolation (kakao vs slack/discord/telegram)
- **Manager additions**: credential file preflight, `AGENT_MESSENGER_CONFIG_DIR` override, content-hash rotation detection (positive and negative cases)
- **Total suite**: 1889 pass, 0 fail
- `bun run typecheck`, `bun run lint`, `bun run format:check` — all clean

## Stages touched

| Stage | What changed |
|---|---|
| **Dev** | `src/channels/adapters/kakaotalk*.ts`, `src/init/kakaotalk-auth.ts`, `src/skills/typeclaw-channel-kakaotalk/` |
| **Host** | `typeclaw init` runs the auth bootstrap subprocess; writes credentials to `<agentDir>/workspace/.agent-messenger/` |
| **Container** | Adapter reads credentials from `/agent/workspace/.agent-messenger/` via `AGENT_MESSENGER_CONFIG_DIR`; Dockerfile sets this env var |

## Self-review notes

This branch was self-reviewed via Oracle consultation before commit. Nine issues were identified and fixed: the deep-import bug (shelling out to CLI instead of importing internal auth modules), the resolver TTL bug (returning stale entries instead of null), the callback-leak-on-start-failure bug, attachment silent-drop (changed to fail-loud), init failure handling (abort pipeline on auth failure to avoid a confusing half-configured state), env-var coupling (manager passes `credentialsDir` explicitly instead of relying on `process.env`), mtime-vs-hash credential signature, the privacy footgun for `*`, and history author-resolver wiring.

The branch was rebased onto current main (which includes `telegram-bot` from PR #80). Schema and manager conflicts were resolved with adversarial cross-adapter isolation tests added during the rebase to cover the new kakao ↔ slack/discord/telegram boundary.