### PR TITLE
Auto-commit package.json and bun.lock drift on start

### DIFF
--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -939,6 +939,122 @@ describe('start (composition)', () => {
     expect(headAfterSecond).toBe(headAfterFirst)
   })
 
+  test('auto-commits bun.lock drift on start (e.g. after a typeclaw CLI upgrade rewrote it)', async () => {
+    // given: a migrated agent folder where the user already ran `bun install`
+    // and bun.lock is now dirty (typical after upgrading the typeclaw CLI)
+    await gitInit(root)
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1,"workspaces":{}}\n')
+    await runGit(root, ['add', '.gitignore', 'package.json', 'packages/.gitkeep', 'bun.lock'])
+    await runGit(root, ['commit', '-m', 'initial'])
+    // and: bun.lock now drifts (simulating a post-upgrade rewrite)
+    await writeFile(
+      join(root, 'bun.lock'),
+      '{"lockfileVersion":1,"workspaces":{"":{"dependencies":{"typeclaw":"^0.2.0"}}}}\n',
+    )
+    const headBefore = await runGit(root, ['rev-parse', 'HEAD'])
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    // when
+    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+
+    // then
+    expect(result.ok).toBe(true)
+    const headAfter = await runGit(root, ['rev-parse', 'HEAD'])
+    expect(headAfter).not.toBe(headBefore)
+    const subjects = (await runGit(root, ['log', '--format=%s'])).split('\n')
+    expect(subjects).toContain('Update dependencies')
+    const filesInCommit = (await runGit(root, ['show', '--name-only', '--format=', 'HEAD'])).split('\n').sort()
+    expect(filesInCommit).toEqual(['bun.lock'])
+  })
+
+  test('auto-commits package.json and bun.lock atomically when both drift', async () => {
+    await gitInit(root)
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1}\n')
+    await runGit(root, ['add', '.gitignore', 'package.json', 'packages/.gitkeep', 'bun.lock'])
+    await runGit(root, ['commit', '-m', 'initial'])
+    // and: both files drift (e.g., user manually bumped typeclaw and re-ran bun install)
+    await writePackageJson(root, { typeclaw: '^0.2.0' })
+    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1,"deps":"new"}\n')
+    const headBefore = await runGit(root, ['rev-parse', 'HEAD'])
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+
+    expect(result.ok).toBe(true)
+    const headAfter = await runGit(root, ['rev-parse', 'HEAD'])
+    expect(headAfter).not.toBe(headBefore)
+    const subjects = (await runGit(root, ['log', '--format=%s'])).split('\n')
+    expect(subjects).toContain('Update dependencies')
+    // and: a single atomic commit covers both files (not two separate commits)
+    const filesInCommit = (await runGit(root, ['show', '--name-only', '--format=', 'HEAD'])).split('\n').sort()
+    expect(filesInCommit).toEqual(['bun.lock', 'package.json'])
+  })
+
+  test('does not commit dependency files when they are clean', async () => {
+    await gitInit(root)
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1}\n')
+    await runGit(root, ['add', '.gitignore', 'package.json', 'packages/.gitkeep', 'bun.lock'])
+    await runGit(root, ['commit', '-m', 'initial'])
+    const headBefore = await runGit(root, ['rev-parse', 'HEAD'])
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+
+    expect(result.ok).toBe(true)
+    const headAfter = await runGit(root, ['rev-parse', 'HEAD'])
+    expect(headAfter).toBe(headBefore)
+  })
+
+  test('skips dependency auto-commit silently when the agent folder is not a git repo', async () => {
+    // given: a non-git agent folder with drifted bun.lock
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1,"deps":"new"}\n')
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+
+    expect(result.ok).toBe(true)
+    expect(existsSync(join(root, '.git'))).toBe(false)
+  })
+
+  test('separates the workspaces migration commit from the dependency drift commit when both apply', async () => {
+    // given: a pre-migration agent folder (no `workspaces` field) with a bun.lock that
+    // also drifted independently
+    await gitInit(root)
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+    await writePackageJsonPreMigration(root, { typeclaw: '^0.1.0' })
+    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1}\n')
+    await runGit(root, ['add', '.gitignore', 'package.json', 'bun.lock'])
+    await runGit(root, ['commit', '-m', 'initial'])
+    // and: bun.lock drifts (user upgraded typeclaw, re-ran bun install)
+    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1,"deps":"new"}\n')
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+
+    expect(result.ok).toBe(true)
+    // then: two distinct commits exist with the right messages and file scopes
+    const subjects = (await runGit(root, ['log', '--format=%s'])).split('\n')
+    expect(subjects[0]).toBe('Update dependencies')
+    expect(subjects[1]).toBe('Enable bun workspaces (packages/*)')
+    const headFiles = (await runGit(root, ['show', '--name-only', '--format=', 'HEAD'])).split('\n').sort()
+    expect(headFiles).toEqual(['bun.lock'])
+    const prevFiles = (await runGit(root, ['show', '--name-only', '--format=', 'HEAD~1'])).split('\n').sort()
+    expect(prevFiles).toEqual(['package.json', 'packages/.gitkeep'])
+  })
+
   test('can register through the current hostd without drift respawn during daemon-owned restart', async () => {
     const previousHome = process.env.TYPECLAW_HOME
     const home = await mkdtemp(join(tmpdir(), 'typeclaw-current-hostd-'))

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -15,6 +15,8 @@ import { CONTAINER_PORT, findFreePort, isPortAllocatedError } from './port'
 import { containerNameFromCwd, defaultDockerExec, type DockerExec, getBun, imageTagFromCwd } from './shared'
 
 const PACKAGE_FILE = 'package.json'
+const BUN_LOCK_FILE = 'bun.lock'
+const DEPENDENCY_FILES = [PACKAGE_FILE, BUN_LOCK_FILE] as const
 const CONFIG_FILE = 'typeclaw.json'
 const ENV_FILE = '.env'
 const COMPOSE_PROJECT = 'typeclaw'
@@ -122,6 +124,13 @@ export async function start({
     if (pkgRefresh.changed) {
       await commitSystemFile(cwd, pkgRefresh.files, 'Enable bun workspaces (packages/*)')
     }
+    // Catch dependency drift not covered by the migration commit above:
+    // upgrading the global typeclaw CLI causes `bun install` to rewrite
+    // bun.lock, and future template changes could nudge package.json past
+    // workspaces. Both files are tracked, so without this they'd surface as
+    // dirty working tree on every `typeclaw start`. Atomic commit so reviewers
+    // see bun.lock alongside its triggering package.json change.
+    await commitSystemFile(cwd, DEPENDENCY_FILES, 'Update dependencies')
 
     if (state.exists) {
       // Container is stopped/exited/being-removed but still holds the name.


### PR DESCRIPTION
## Summary

When a user upgrades the global typeclaw CLI (`bun add -g typeclaw`), bun's automatic install behavior rewrites the agent folder's `bun.lock` (and sometimes `package.json`) to point at the new version. Today this leaves those files sitting dirty in the working tree across every subsequent `typeclaw start` — visually noisy, and it conflicts with the agent's `git-nudge` system prompt, which surfaces untracked changes as files for the agent to commit. With this change, typeclaw owns those edits and lands them in git automatically with a clear "Update dependencies" commit, exactly the same way it already owns `.gitignore` and workspace-migration changes.

## Changes

### `src/container/start.ts`

- Adds `BUN_LOCK_FILE` and `DEPENDENCY_FILES` constants.
- Adds one `commitSystemFile(cwd, DEPENDENCY_FILES, 'Update dependencies')` call immediately after the existing workspaces-migration commit in `start()`.
- Reuses the `commitSystemFile` helper so silent-skip semantics come for free: no-op when files are already clean, no-op when the folder is not a git repo, no-op when the bun runtime is unavailable.
- Atomic commit so `bun.lock` always lands alongside its triggering `package.json` change rather than in two confusingly-separate commits.

### `src/container/start.test.ts`

Five new tests alongside the existing workspaces-migration tests:

1. Auto-commits `bun.lock` drift on start (the primary scenario).
2. Atomic commit when both `package.json` and `bun.lock` drift together.
3. Idempotency: clean files produce no commit.
4. Silent skip when the agent folder is not a git repo.
5. Separates the workspaces-migration commit from the dependency-drift commit when both apply in the same `start()` run — verifies reviewers see two distinct, well-scoped commits.

## Pre-commit checks

```
$ bun run typecheck    # clean
$ bun run lint         # 0 warnings, 0 errors
$ bun run format:check # all files correctly formatted
$ bun test            # 1852 pass, 0 fail (5 new, 1847 pre-existing)
```

## Review Notes

- **Self-contained.** No schema, config, or wire-protocol impact. No breaking changes. No migration cost. Two files changed, 125 insertions.
- **Mirrors existing patterns exactly.** The `commitSystemFile` call shape, placement, and guard semantics are identical to the `.gitignore` and workspaces-migration calls already in `start()`. No new abstractions.
- **Atomic by design.** `DEPENDENCY_FILES = [PACKAGE_JSON, BUN_LOCK_FILE]` is passed as a single array to `commitSystemFile`, which stages both before committing. A `package.json`-only or `bun.lock`-only drift also works because `commitSystemFile` skips files that aren't dirty.