### PR TITLE
Render Telegram replies as MarkdownV2 instead of plain text

### DIFF
--- a/src/channels/adapters/telegram-bot-format.test.ts
+++ b/src/channels/adapters/telegram-bot-format.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from 'bun:test'
+
+import { escapeMarkdownV2, toTelegramMarkdownV2 } from './telegram-bot-format'
+
+describe('escapeMarkdownV2', () => {
+  test('escapes every MarkdownV2 reserved character outside entities', () => {
+    const input = '_*[]()~`>#+-=|{}.!\\'
+    const out = escapeMarkdownV2(input)
+    for (const ch of input) {
+      expect(out.includes('\\' + ch)).toBe(true)
+    }
+  })
+
+  test('leaves alphanumerics and whitespace untouched', () => {
+    expect(escapeMarkdownV2('hello world\n123')).toBe('hello world\n123')
+  })
+})
+
+describe('toTelegramMarkdownV2 — plain text safety', () => {
+  test('the original v1 mutation-guard string passes through with every special escaped', () => {
+    const out = toTelegramMarkdownV2('a < b & c > d (with) raw . ! _ * special chars')
+    expect(out).toBe('a < b & c \\> d \\(with\\) raw \\. \\! \\_ \\* special chars')
+  })
+
+  test('a string of nothing but reserved chars is fully escaped', () => {
+    expect(toTelegramMarkdownV2('.!?-')).toBe('\\.\\!?\\-')
+  })
+
+  test('newlines pass through unescaped (Telegram treats them as literal)', () => {
+    expect(toTelegramMarkdownV2('line one\nline two')).toBe('line one\nline two')
+  })
+
+  test('returns empty string for empty input', () => {
+    expect(toTelegramMarkdownV2('')).toBe('')
+  })
+})
+
+describe('toTelegramMarkdownV2 — bold', () => {
+  test('converts **bold** to *bold*', () => {
+    expect(toTelegramMarkdownV2('hello **world**!')).toBe('hello *world*\\!')
+  })
+
+  test('converts __bold__ to *bold* when not adjacent to word chars', () => {
+    expect(toTelegramMarkdownV2('hello __world__ ok')).toBe('hello *world* ok')
+  })
+
+  test('does NOT treat my__var__name as bold (snake_case guard)', () => {
+    const out = toTelegramMarkdownV2('use my__var__name here')
+    expect(out).not.toContain('*var*')
+    expect(out).toBe('use my\\_\\_var\\_\\_name here')
+  })
+
+  test('escapes special chars inside bold', () => {
+    expect(toTelegramMarkdownV2('**a.b!c**')).toBe('*a\\.b\\!c*')
+  })
+})
+
+describe('toTelegramMarkdownV2 — italic', () => {
+  test('converts *italic* to _italic_', () => {
+    expect(toTelegramMarkdownV2('this is *italic* text')).toBe('this is _italic_ text')
+  })
+
+  test('converts _italic_ to _italic_', () => {
+    expect(toTelegramMarkdownV2('this is _italic_ text')).toBe('this is _italic_ text')
+  })
+
+  test('does NOT italicize snake_case identifiers', () => {
+    expect(toTelegramMarkdownV2('see my_var_name in code')).toBe('see my\\_var\\_name in code')
+  })
+
+  test('does NOT italicize a*b*c (asterisk between word chars)', () => {
+    expect(toTelegramMarkdownV2('a*b*c')).toBe('a\\*b\\*c')
+  })
+
+  test('does not italicize across line breaks', () => {
+    const out = toTelegramMarkdownV2('start *line one\nline two* end')
+    expect(out).toContain('\\*line one')
+    expect(out).not.toContain('_line one')
+  })
+})
+
+describe('toTelegramMarkdownV2 — inline code', () => {
+  test('preserves inline code and only escapes ` and \\ inside', () => {
+    expect(toTelegramMarkdownV2('use `foo.bar()` here')).toBe('use `foo.bar()` here')
+  })
+
+  test('special chars inside `code` are NOT escaped (would render as literal backslashes)', () => {
+    expect(toTelegramMarkdownV2('`a.b!c`')).toBe('`a.b!c`')
+  })
+
+  test('a backslash inside inline code is doubled', () => {
+    expect(toTelegramMarkdownV2('`a\\b`')).toBe('`a\\\\b`')
+  })
+
+  test('formatting markers inside inline code are literal', () => {
+    expect(toTelegramMarkdownV2('`**not bold**`')).toBe('`**not bold**`')
+  })
+})
+
+describe('toTelegramMarkdownV2 — fenced code blocks', () => {
+  test('renders a fenced block with a language hint', () => {
+    const input = '```python\ndef hi():\n    print("hi")\n```'
+    expect(toTelegramMarkdownV2(input)).toBe('```python\ndef hi():\n    print("hi")\n```')
+  })
+
+  test('renders a fenced block without a language hint', () => {
+    expect(toTelegramMarkdownV2('```\nplain code\n```')).toBe('```\nplain code\n```')
+  })
+
+  test('escapes ` and \\ inside the body but leaves other specials alone', () => {
+    expect(toTelegramMarkdownV2('```\na.b! \\path c`d\n```')).toBe('```\na.b! \\\\path c\\`d\n```')
+  })
+
+  test('inline markers inside fence are literal, not parsed', () => {
+    const out = toTelegramMarkdownV2('```\n**not bold** *not italic*\n```')
+    expect(out).toContain('**not bold** *not italic*')
+  })
+
+  test('text around a fence is tokenized normally', () => {
+    expect(toTelegramMarkdownV2('before **bold**\n```\nx\n```\nafter *italic*')).toBe(
+      'before *bold*\n```\nx\n```\nafter _italic_',
+    )
+  })
+
+  test('unterminated fence falls through to inline handling without swallowing the rest', () => {
+    const out = toTelegramMarkdownV2('```python\nstuck')
+    expect(out).toContain('python')
+    expect(out).toContain('stuck')
+  })
+})
+
+describe('toTelegramMarkdownV2 — links', () => {
+  test('converts [label](url) to a MarkdownV2 link with proper escaping', () => {
+    expect(toTelegramMarkdownV2('see [docs](https://example.com)')).toBe('see [docs](https://example.com)')
+  })
+
+  test('escapes special chars in the label per outside-entity rules', () => {
+    expect(toTelegramMarkdownV2('[hi.](https://x)')).toBe('[hi\\.](https://x)')
+  })
+
+  test('escapes \\ in the url, but leaves dots / dashes literal', () => {
+    expect(toTelegramMarkdownV2('[docs](https://example.com/v1.2-beta\\path)')).toBe(
+      '[docs](https://example.com/v1.2-beta\\\\path)',
+    )
+  })
+
+  test('a url with an unescaped ( falls through as escaped literals (avoids ambiguous close)', () => {
+    const out = toTelegramMarkdownV2('[w](https://en.wikipedia.org/wiki/Foo_(bar))')
+    expect(out).not.toContain('](http')
+    expect(out).toContain('Foo')
+  })
+
+  test('a bare bracket pair without (url) is not a link', () => {
+    expect(toTelegramMarkdownV2('see [todo] item')).toBe('see \\[todo\\] item')
+  })
+
+  test('a label with a newline disqualifies the link match', () => {
+    expect(toTelegramMarkdownV2('[hello\nworld](https://x)')).toContain('\\[hello')
+  })
+})
+
+describe('toTelegramMarkdownV2 — strikethrough and spoiler', () => {
+  test('~~strike~~ becomes ~strike~', () => {
+    expect(toTelegramMarkdownV2('this is ~~gone~~')).toBe('this is ~gone~')
+  })
+
+  test('||spoiler|| stays as ||spoiler||', () => {
+    expect(toTelegramMarkdownV2('the answer is ||42||')).toBe('the answer is ||42||')
+  })
+})
+
+describe('toTelegramMarkdownV2 — combined and adversarial', () => {
+  test("the assistant's example reply formats correctly", () => {
+    const input = 'Ha! See, **yours** works perfectly. *Bold*, *italic*, `code`—all rendered nice.'
+    expect(toTelegramMarkdownV2(input)).toBe(
+      'Ha\\! See, *yours* works perfectly\\. _Bold_, _italic_, `code`—all rendered nice\\.',
+    )
+  })
+
+  test('a fenced code block with the language tag the assistant used', () => {
+    const input = '```python\ndef hello():\n    print("hi")\n```'
+    expect(toTelegramMarkdownV2(input)).toBe('```python\ndef hello():\n    print("hi")\n```')
+  })
+
+  test('mixed inline code and bold with punctuation that must escape', () => {
+    expect(toTelegramMarkdownV2('Run `npm install` first, **then** open it!')).toBe(
+      'Run `npm install` first, *then* open it\\!',
+    )
+  })
+
+  test('a paragraph of pure prose with periods, hyphens, and a link', () => {
+    expect(toTelegramMarkdownV2('Hello — visit [our docs](https://example.com/path-here) for v1.2.3 details.')).toBe(
+      'Hello — visit [our docs](https://example.com/path-here) for v1\\.2\\.3 details\\.',
+    )
+  })
+
+  test('a heading-style line falls through as escaped literals (Telegram has no headings)', () => {
+    expect(toTelegramMarkdownV2('# Title')).toBe('\\# Title')
+  })
+
+  test('list markers fall through escaped (Telegram has no native lists)', () => {
+    expect(toTelegramMarkdownV2('- item one\n- item two')).toBe('\\- item one\n\\- item two')
+  })
+
+  test('an empty bold pair `****` does not crash and does not produce a Telegram-rejected entity', () => {
+    const out = toTelegramMarkdownV2('here ****  there')
+    expect(out).toBe('here \\*\\*\\*\\*  there')
+  })
+})

--- a/src/channels/adapters/telegram-bot-format.ts
+++ b/src/channels/adapters/telegram-bot-format.ts
@@ -1,0 +1,309 @@
+// Convert the model's common-Markdown output to valid Telegram MarkdownV2.
+//
+// Why this exists: the agent writes Markdown the way a human would type
+// it (`**bold**`, `*italic*`, `` `code` ``, fenced blocks, `[text](url)`).
+// Telegram's MarkdownV2 parser is unforgiving — any unescaped special
+// char (`_*[]()~``>#+-=|{}.!\`) outside an entity returns
+// `Bad Request: can't parse entities` and the whole message is rejected.
+// A plain-text send keeps the message intact at the cost of literal
+// `**bold**` artifacts; HTML-mode would still need every `<&>` escaped.
+// MarkdownV2 with smart escaping is the only mode where the agent gets
+// rendered formatting AND raw user text never crashes the parser.
+//
+// Strategy: walk the source, recognize a small fixed set of inline and
+// block constructs, emit MarkdownV2 with the right escape rules per
+// region. Anything we don't recognize (headings, list markers, blockquote
+// arrows, raw special chars) falls through as escaped literal text —
+// MarkdownV2 has no native heading or list rendering anyway, so this
+// matches what Telegram can actually display rather than failing.
+//
+// Telegram entity rules (https://core.telegram.org/bots/api#markdownv2-style):
+//   - Outside entities: escape `_ * [ ] ( ) ~ ` > # + - = | { } . !`.
+//     Backslash is the escape char, so a literal `\` must be `\\`.
+//   - Inside `code` / `pre`: escape `` ` `` and `\` only — every other
+//     special char is literal.
+//   - Inside link `(url)`: escape `)` and `\` only.
+//   - Inside link `[text]`: full outside-entity rules apply.
+
+const SPECIAL_CHARS_OUTSIDE = /[_*[\]()~`>#+\-=|{}.!\\]/g
+const SPECIAL_CHARS_CODE = /[`\\]/g
+const SPECIAL_CHARS_LINK_URL = /[)\\]/g
+
+export function escapeMarkdownV2(text: string): string {
+  return text.replace(SPECIAL_CHARS_OUTSIDE, '\\$&')
+}
+
+function escapeCodeContent(text: string): string {
+  return text.replace(SPECIAL_CHARS_CODE, '\\$&')
+}
+
+function escapeLinkUrl(url: string): string {
+  return url.replace(SPECIAL_CHARS_LINK_URL, '\\$&')
+}
+
+// Public entry point. Takes the agent's raw text (common Markdown) and
+// returns a string safe to send with `parse_mode: 'MarkdownV2'`. The
+// returned string is guaranteed never to crash Telegram's parser for any
+// input the agent could plausibly produce — the conversion is best-effort
+// for formatting and total for safety.
+export function toTelegramMarkdownV2(input: string): string {
+  // Block pass first: pull out fenced code blocks so their contents are
+  // never re-tokenized as inline constructs (a `*` inside ```code``` is
+  // literal, not italic). The remaining text goes through the inline
+  // tokenizer.
+  const out: string[] = []
+  let i = 0
+  while (i < input.length) {
+    if (matchesAt(input, i, '```')) {
+      const fenceEnd = findFenceEnd(input, i + 3)
+      if (fenceEnd !== -1) {
+        const inner = input.slice(i + 3, fenceEnd)
+        out.push(renderFence(inner))
+        i = fenceEnd + 3
+        continue
+      }
+      // Unterminated fence — render the rest of the input as escaped
+      // inline (the open backticks become `\`\`\`` literals) so we
+      // never infinite-loop on `nextFence === i` and never swallow the
+      // rest of the message.
+      out.push(renderInline(input.slice(i)))
+      break
+    }
+    const nextFence = input.indexOf('```', i)
+    const segmentEnd = nextFence === -1 ? input.length : nextFence
+    out.push(renderInline(input.slice(i, segmentEnd)))
+    i = segmentEnd
+  }
+  return out.join('')
+}
+
+function matchesAt(s: string, idx: number, needle: string): boolean {
+  return s.slice(idx, idx + needle.length) === needle
+}
+
+function findFenceEnd(s: string, start: number): number {
+  // Telegram pre-blocks don't nest, so the first ``` after `start` is the
+  // close. We do not require it to be on its own line — the agent often
+  // emits ` ```python\ncode``` ` inline.
+  return s.indexOf('```', start)
+}
+
+function renderFence(inner: string): string {
+  // Optional language hint on the first line (` ```python\n... ``` `).
+  // MarkdownV2 supports it as `\`\`\`<lang>\n...\`\`\``. Strip the
+  // newline immediately after the language if present, and also strip a
+  // bare leading newline (` ```\nbody\n``` `) so the rendered block
+  // doesn't carry an extra empty first line.
+  let lang = ''
+  let body = inner
+  const newline = inner.indexOf('\n')
+  if (newline !== -1) {
+    const candidate = inner.slice(0, newline).trim()
+    if (candidate !== '' && /^[A-Za-z0-9_+\-.]+$/.test(candidate)) {
+      lang = candidate
+      body = inner.slice(newline + 1)
+    } else if (candidate === '') {
+      body = inner.slice(newline + 1)
+    }
+  }
+  if (body.endsWith('\n')) body = body.slice(0, -1)
+  const escapedBody = escapeCodeContent(body)
+  return lang === '' ? '```\n' + escapedBody + '\n```' : '```' + lang + '\n' + escapedBody + '\n```'
+}
+
+// Inline tokenizer. Recognizes (in priority order):
+//   1. Inline code:  `code`
+//   2. Links:        [text](url)
+//   3. Bold:         **text**  or  __text__
+//   4. Strikethrough:~~text~~
+//   5. Spoiler:      ||text||
+//   6. Italic:       *text*  or  _text_
+//
+// Italic is checked LAST because `**` would otherwise be eaten as two
+// italic markers. Underscore italic / underscore bold collapse to the
+// asterisk forms because MarkdownV2 reserves `_` for italic and `__` for
+// underline — using `_` for italic and `*` for bold sidesteps the
+// underline-vs-italic ambiguity.
+function renderInline(text: string): string {
+  const out: string[] = []
+  let i = 0
+  while (i < text.length) {
+    const ch = text[i]!
+
+    if (ch === '`') {
+      const close = text.indexOf('`', i + 1)
+      if (close !== -1) {
+        const inner = text.slice(i + 1, close)
+        out.push('`' + escapeCodeContent(inner) + '`')
+        i = close + 1
+        continue
+      }
+    }
+
+    if (ch === '[') {
+      const link = parseLink(text, i)
+      if (link !== null) {
+        const renderedText = renderInline(link.label)
+        out.push('[' + renderedText + '](' + escapeLinkUrl(link.url) + ')')
+        i = link.end
+        continue
+      }
+    }
+
+    // Paired markers (bold/strike/spoiler): empty content is rejected
+    // by Telegram as an empty entity, so collapse `****` etc. to escaped
+    // literals rather than emit zero-width entities.
+    if (ch === '*' && text[i + 1] === '*') {
+      const close = findClose(text, i + 2, '**')
+      if (close !== -1 && close > i + 2) {
+        const inner = text.slice(i + 2, close)
+        out.push('*' + renderInline(inner) + '*')
+        i = close + 2
+        continue
+      }
+    }
+    if (ch === '_' && text[i + 1] === '_' && !isWordChar(text[i - 1])) {
+      // `__bold__` only when the open marker is not adjacent to a word
+      // char on the LEFT (`my__var__name` is a snake_case identifier the
+      // model accidentally wrote, not bold). The close marker is
+      // checked for the same on its RIGHT side below.
+      const close = findClose(text, i + 2, '__')
+      if (close !== -1 && close > i + 2 && !isWordChar(text[close + 2])) {
+        const inner = text.slice(i + 2, close)
+        out.push('*' + renderInline(inner) + '*')
+        i = close + 2
+        continue
+      }
+    }
+
+    if (ch === '~' && text[i + 1] === '~') {
+      const close = findClose(text, i + 2, '~~')
+      if (close !== -1 && close > i + 2) {
+        const inner = text.slice(i + 2, close)
+        out.push('~' + renderInline(inner) + '~')
+        i = close + 2
+        continue
+      }
+    }
+
+    if (ch === '|' && text[i + 1] === '|') {
+      const close = findClose(text, i + 2, '||')
+      if (close !== -1 && close > i + 2) {
+        const inner = text.slice(i + 2, close)
+        out.push('||' + renderInline(inner) + '||')
+        i = close + 2
+        continue
+      }
+    }
+
+    // Italic: word-boundary guard on BOTH sides — `a*b*c` and
+    // `var_name` must NOT italicize. The model emits literal
+    // asterisks/underscores in math, code references, and identifiers.
+    if (ch === '*' && !isWordChar(text[i - 1])) {
+      const close = findInlineClose(text, i + 1, '*')
+      if (close !== -1 && !isWordChar(text[close + 1])) {
+        const inner = text.slice(i + 1, close)
+        if (inner !== '' && !/^\s|\s$/.test(inner)) {
+          out.push('_' + renderInline(inner) + '_')
+          i = close + 1
+          continue
+        }
+      }
+    }
+    if (ch === '_' && !isWordChar(text[i - 1])) {
+      const close = findInlineClose(text, i + 1, '_')
+      if (close !== -1 && !isWordChar(text[close + 1])) {
+        const inner = text.slice(i + 1, close)
+        if (inner !== '' && !/^\s|\s$/.test(inner)) {
+          out.push('_' + renderInline(inner) + '_')
+          i = close + 1
+          continue
+        }
+      }
+    }
+
+    out.push(SPECIAL_CHARS_OUTSIDE.test(ch) ? '\\' + ch : ch)
+    SPECIAL_CHARS_OUTSIDE.lastIndex = 0
+    i++
+  }
+  return out.join('')
+}
+
+function findClose(text: string, from: number, marker: string): number {
+  // Find the next occurrence of `marker` at or after `from` that is NOT
+  // preceded by a backslash escape. Used for paired `**` / `__` / `~~` /
+  // `||`. A line break inside a marker pair is allowed — the model often
+  // emits multi-line bold.
+  let i = from
+  while (i <= text.length - marker.length) {
+    if (text[i] === '\\') {
+      i += 2
+      continue
+    }
+    if (matchesAt(text, i, marker)) return i
+    i++
+  }
+  return -1
+}
+
+function findInlineClose(text: string, from: number, marker: string): number {
+  // Same as findClose but stops at line breaks — used for single-marker
+  // italic so a stray `*` doesn't stretch across paragraphs.
+  let i = from
+  while (i < text.length) {
+    if (text[i] === '\n') return -1
+    if (text[i] === '\\') {
+      i += 2
+      continue
+    }
+    if (matchesAt(text, i, marker)) return i
+    i++
+  }
+  return -1
+}
+
+function parseLink(text: string, start: number): { label: string; url: string; end: number } | null {
+  // `[label](url)` — labels can contain anything but unescaped `]`,
+  // urls anything but unescaped `)`. Newlines inside either part
+  // disqualify the match (the model meant a literal bracket, not a link).
+  let i = start + 1
+  const labelStart = i
+  while (i < text.length) {
+    const c = text[i]!
+    if (c === '\\') {
+      i += 2
+      continue
+    }
+    if (c === ']') break
+    if (c === '\n') return null
+    i++
+  }
+  if (text[i] !== ']' || text[i + 1] !== '(') return null
+  const label = text.slice(labelStart, i)
+  const urlStart = i + 2
+  let j = urlStart
+  while (j < text.length) {
+    const c = text[j]!
+    if (c === '\\') {
+      j += 2
+      continue
+    }
+    if (c === ')') break
+    // An unescaped `(` makes the close-paren ambiguous (Wikipedia
+    // links like `Foo_(bar)` would close on the inner `)` and emit
+    // mangled MarkdownV2). Drop the link match and let the bracket
+    // chars fall through escaped — the URL still appears as plain
+    // text, just not as a clickable link.
+    if (c === '(') return null
+    if (c === '\n') return null
+    j++
+  }
+  if (text[j] !== ')') return null
+  const url = text.slice(urlStart, j)
+  return { label, url, end: j + 1 }
+}
+
+function isWordChar(ch: string | undefined): boolean {
+  if (ch === undefined) return false
+  return /[A-Za-z0-9_]/.test(ch)
+}

--- a/src/channels/adapters/telegram-bot-outbound.test.ts
+++ b/src/channels/adapters/telegram-bot-outbound.test.ts
@@ -93,7 +93,7 @@ function buildOutbound(over: Partial<OutboundMessage> = {}): OutboundMessage {
 }
 
 describe('telegram-bot createOutboundCallback', () => {
-  test('sends plain text by default with NO parse_mode (HTML/MarkdownV2 reject too many strings)', async () => {
+  test("sends as MarkdownV2 with every reserved char escaped (so Telegram's parser never rejects)", async () => {
     const fake = fakeClient()
     const cb = createOutboundCallback({
       client: fake.client,
@@ -106,11 +106,34 @@ describe('telegram-bot createOutboundCallback', () => {
 
     expect(result.ok).toBe(true)
     expect(fake.sendMessageCalls).toHaveLength(1)
-    expect(fake.sendMessageCalls[0]?.text).toBe('a < b & c > d (with) raw . ! _ * special chars')
-    // Mutation guard: if a refactor re-introduces parse_mode: 'HTML' as a
-    // default, this assertion fails. The whole point of the v2 fix was
-    // that raw `<` / `&` would crash Telegram's HTML parser.
-    expect(fake.sendMessageCalls[0]?.options).toEqual({})
+    expect(fake.sendMessageCalls[0]?.text).toBe('a < b & c \\> d \\(with\\) raw \\. \\! \\_ \\* special chars')
+    // Mutation guard: if a refactor flips back to plain text or to
+    // HTML mode, this fails. MarkdownV2 is the chosen default because
+    // it lets the agent's `**bold**` / `*italic*` / `` `code` `` actually
+    // render — see the formatter at `./telegram-bot-format.ts`.
+    expect(fake.sendMessageCalls[0]?.options).toEqual({ parse_mode: 'MarkdownV2' })
+  })
+
+  test('renders agent Markdown (**bold**, *italic*, `code`) into MarkdownV2 entities', async () => {
+    const fake = fakeClient()
+    const cb = createOutboundCallback({
+      client: fake.client,
+      configRef: () => baseConfig,
+      logger: silentLogger(),
+      formatChannelTag: async () => 'chat=-100123',
+    })
+
+    const result = await cb(
+      buildOutbound({
+        text: 'Ha! See, **yours** works perfectly. *Bold*, *italic*, `code`—all rendered nice.',
+      }),
+    )
+
+    expect(result.ok).toBe(true)
+    expect(fake.sendMessageCalls[0]?.text).toBe(
+      'Ha\\! See, *yours* works perfectly\\. _Bold_, _italic_, `code`—all rendered nice\\.',
+    )
+    expect(fake.sendMessageCalls[0]?.options).toEqual({ parse_mode: 'MarkdownV2' })
   })
 
   test('forwards a numeric thread id as message_thread_id when the session is in a forum topic', async () => {
@@ -125,7 +148,7 @@ describe('telegram-bot createOutboundCallback', () => {
     const result = await cb(buildOutbound({ thread: '42' }))
 
     expect(result.ok).toBe(true)
-    expect(fake.sendMessageCalls[0]?.options).toEqual({ message_thread_id: 42 })
+    expect(fake.sendMessageCalls[0]?.options).toEqual({ message_thread_id: 42, parse_mode: 'MarkdownV2' })
   })
 
   test('drops invalid thread ids silently rather than passing NaN', async () => {
@@ -140,7 +163,7 @@ describe('telegram-bot createOutboundCallback', () => {
     const result = await cb(buildOutbound({ thread: 'not-a-number' }))
 
     expect(result.ok).toBe(true)
-    expect(fake.sendMessageCalls[0]?.options).toEqual({})
+    expect(fake.sendMessageCalls[0]?.options).toEqual({ parse_mode: 'MarkdownV2' })
   })
 
   test('uploads each attachment via sendDocument BEFORE posting text', async () => {

--- a/src/channels/adapters/telegram-bot.ts
+++ b/src/channels/adapters/telegram-bot.ts
@@ -16,6 +16,7 @@ import type {
 } from '@/channels/types'
 
 import { classifyInbound, type InboundDropReason, TELEGRAM_WORKSPACE } from './telegram-bot-classify'
+import { toTelegramMarkdownV2 } from './telegram-bot-format'
 
 export const TELEGRAM_API_BASE = 'https://api.telegram.org'
 
@@ -27,13 +28,15 @@ export const TELEGRAM_API_BASE = 'https://api.telegram.org'
 // log line, making "agent missed an edit" invisible.
 const TELEGRAM_ALLOWED_UPDATES = ['message', 'channel_post']
 
-// Outbound is sent as plain text by default. Picking `parse_mode: 'HTML'`
-// would require us to escape every `<`, `>`, `&` in the agent's text or
-// Telegram returns `Bad Request: can't parse entities`. Picking
-// `MarkdownV2` is even stricter (every `. ! ( ) _ * [ ] ~` etc.). Until a
-// Telegram-aware formatter exists, plain text is the only mode that
-// can't reject a valid string. Operators who want HTML can add a future
-// flag; the SDK type still accepts the option for direct callers.
+// Outbound is rendered through `toTelegramMarkdownV2` and sent with
+// `parse_mode: 'MarkdownV2'`. The formatter takes the model's common
+// Markdown (`**bold**`, `*italic*`, `` `code` ``, fenced blocks,
+// `[label](url)`) and emits MarkdownV2 with every reserved char escaped
+// in the right region (outside-entity vs `code`/`pre` vs link-url),
+// guaranteeing Telegram's parser will never reject the output. See
+// `telegram-bot-format.ts` for the exact rules. Plain text — no
+// formatting markers — round-trips through the formatter unchanged
+// modulo escaped specials, so this is a safe default with no opt-out.
 
 export type TelegramBotAdapterLogger = {
   info: (msg: string) => void
@@ -256,9 +259,10 @@ export function createOutboundCallback(deps: {
     }
 
     try {
-      const sendOptions: { message_thread_id?: number } = {}
+      const rendered = toTelegramMarkdownV2(text)
+      const sendOptions: { message_thread_id?: number; parse_mode: 'MarkdownV2' } = { parse_mode: 'MarkdownV2' }
       if (threadId !== undefined) sendOptions.message_thread_id = threadId
-      const sent = await client.sendMessage(msg.chat, text, sendOptions)
+      const sent = await client.sendMessage(msg.chat, rendered, sendOptions)
       logger.info(`[telegram-bot] sent message_id=${sent.message_id} ${tag}`)
       return { ok: true }
     } catch (err) {

--- a/src/skills/typeclaw-channel-telegram-bot/SKILL.md
+++ b/src/skills/typeclaw-channel-telegram-bot/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: typeclaw-channel-telegram-bot
+description: "How replies sent through the `telegram-bot` channel adapter actually render in Telegram. Read this BEFORE composing a reply that contains formatting markers — `**bold**`, `*italic*`, `_italic_`, `` `code` ``, fenced code blocks (```), `[label](url)`, `~~strike~~`, `||spoiler||`, `# heading`, `- list`, `| table |`, raw `.` `!` `(` `)` `_` `*` punctuation in URLs/IDs, snake_case identifiers — and your draft is going to a Telegram chat or supergroup. Also load if a Telegram user reports your message arrived as raw markdown (literal `**asterisks**`), as garbled text with stray backslashes, or with a Telegram error like `Bad Request: can't parse entities`. Covers: which markers actually render, which ones are stripped or escaped, what Telegram has no equivalent for (headings, bulleted/numbered lists, tables — they fall through as escaped literals), how the adapter's MarkdownV2 escaping behaves, and how to keep your message readable when the rendering and the source diverge."
+---
+
+# typeclaw-channel-telegram-bot
+
+When you reply through the `telegram-bot` channel adapter, your text does NOT go to Telegram unchanged. It goes through `toTelegramMarkdownV2` in `src/channels/adapters/telegram-bot-format.ts`, which translates the common Markdown you write into Telegram's strict **MarkdownV2** dialect and escapes every reserved char that isn't part of a recognized formatting marker. The Telegram Bot API is then called with `parse_mode: 'MarkdownV2'`.
+
+This is necessary because Telegram's MarkdownV2 parser is unforgiving: any unescaped `_ * [ ] ( ) ~ \` > # + - = | { } . !`outside an entity returns`Bad Request: can't parse entities`and the whole message is rejected. Plain text would never crash, but then your`**bold**`would render as the literal six characters`**bold**` — which is the bug this skill exists to prevent you from re-introducing on the user side ("just write what you mean, the adapter will handle it").
+
+## What the adapter renders
+
+These markers translate to native Telegram formatting:
+
+- `**bold**` → bold (renders as `*bold*` on the wire — MarkdownV2 reserves `*` for bold)
+- `__bold__` → bold (when not adjacent to a word char on either side; otherwise treated as literal underscores so `my__var__name` stays a snake_case identifier)
+- `*italic*` → italic (when the asterisks are NOT between word chars — `a*b*c` stays literal)
+- `_italic_` → italic (same word-boundary rule as `*italic*` — `var_name` stays an identifier)
+- `` `inline code` `` → monospace inline code
+- ` ```language\n...code...\n``` ` → fenced code block; the optional language tag rides through (Telegram displays it but does no syntax highlighting)
+- `[label](url)` → clickable hyperlink
+- `~~strike~~` → strikethrough
+- `||spoiler||` → spoiler (tap to reveal)
+
+Empty markers (`****`, ` `` `, `~~~~`, `||||`) are NOT emitted as zero-width entities; they fall through as escaped literals. Telegram rejects empty entities, and the adapter's safety pass catches this for you.
+
+## What the adapter does NOT render
+
+Telegram's MarkdownV2 has no native rendering for any of these. They fall through as escaped literal characters — visible in the message, but not formatted:
+
+- `# Heading`, `## Heading 2`, etc. — appear as `\# Heading` / `\## Heading 2` (the `#` shows but it's not a heading)
+- `- item` / `* item` / `1. item` (bulleted or numbered lists) — the markers escape to `\-` / `\*` / `1\.` and the message stays a plain paragraph with line breaks; Telegram users see the dash or number, not a styled list
+- `| col | col |\n|---|---|\n` (Markdown tables) — every `|` and `-` escapes; the result is illegible. Don't send tables. Send a fenced code block with aligned columns instead.
+- `> quote` — the `>` escapes to `\>`; Telegram does have a native blockquote syntax but the agent's common-Markdown writer has no way to opt into it through this adapter today
+- HTML tags (`<b>`, `<i>`, `<a>`) — the adapter does NOT use HTML mode; tag chars escape and the literal `<b>foo</b>` shows up
+
+When you need any of these effects, **rewrite the message** to use what Telegram does support (bold for emphasis instead of headings; bullet points written as separate lines with bold leading words instead of `-` markers; aligned-column code fences instead of tables).
+
+## Punctuation rules you can stop worrying about
+
+You do NOT need to manually escape any of `_ * [ ] ( ) ~ \` > # + - = | { } . !` in your draft. The adapter handles it.
+
+- Periods, exclamation points, hyphens, plus signs in prose — type them naturally; the adapter escapes them.
+- Snake_case identifiers (`my_var_name`, `foo__bar__baz`) — type them naturally; the word-boundary guards keep them from italicizing.
+- Math/code asterisks in prose (`a*b*c`, `2 * 3 = 6`) — same; the word-boundary guards keep them literal.
+- URLs containing `_`, `.`, `-`, `~` — they pass through fine inside `[label](url)`.
+
+URLs containing **unescaped parentheses** (Wikipedia-style `Foo_(bar)`) intentionally fall back to escaped literal text rather than render as a link — the adapter cannot disambiguate the closing `)` from a content paren. If you need to link such a URL, percent-encode the parens in the URL (`%28`, `%29`) before putting it in the link.
+
+## When the user says "your formatting looks broken"
+
+Three classes of failure to triage in this order:
+
+1. **Literal `**asterisks**` in the rendered message.** Means the adapter was bypassed (someone shipped a regression that flipped `parse_mode` off). Check `src/channels/adapters/telegram-bot.ts` — `sendMessage` MUST include `{ parse_mode: 'MarkdownV2' }` and the text must come from `toTelegramMarkdownV2(...)`. The mutation-guard test in `telegram-bot-outbound.test.ts` exists exactly to catch this.
+2. **Visible backslashes (e.g. `v1\.2\.3`).** Means the user is on a Telegram client too old to honor MarkdownV2 entity-rendering, OR the message was forwarded to a context that doesn't (rare). Nothing the adapter can do — the wire format is correct.
+3. **Telegram error: `Bad Request: can't parse entities`.** Means the formatter emitted invalid MarkdownV2 — either an entity-rule edge case the formatter mishandled, or the agent wrote something pathological (e.g. a literal MarkdownV2-escaped fragment by hand). File a bug against the formatter with the exact input string; do not work around it by sending plain text (that loses formatting for everyone).
+
+## File pointers
+
+- `src/channels/adapters/telegram-bot.ts` — adapter; `createOutboundCallback` is where rendering happens.
+- `src/channels/adapters/telegram-bot-format.ts` — the formatter; pure, no dependencies, fully tested.
+- `src/channels/adapters/telegram-bot-format.test.ts` — every formatter rule above is mutation-guarded by a named test here.
+- `src/channels/adapters/telegram-bot-outbound.test.ts` — the integration mutation guard that pins `parse_mode: 'MarkdownV2'`.


### PR DESCRIPTION
## Summary

The `telegram-bot` channel adapter sent every reply as plain text — `parse_mode` was deliberately omitted because raw model output would crash Telegram's HTML and MarkdownV2 parsers (`Bad Request: can't parse entities`). The cost was that the agent's `**bold**` / `*italic*` / `` `code` `` rendered as the literal source characters in Telegram chats.

This PR adds a Telegram-aware formatter and flips the adapter to `parse_mode: 'MarkdownV2'`, so the agent's common Markdown finally renders correctly. Per the original adapter comment ("Until a Telegram-aware formatter exists, plain text is the only mode that can't reject a valid string"), this is the documented unblocker.

```
Before:  **yours** works perfectly. *Bold*, *italic*, `code`...
         ─ rendered as raw asterisks and backticks in Telegram

After:   yours works perfectly. Bold, italic, code...
         ─ proper bold / italic / monospace rendering
```

## What's in this PR

| File | Purpose |
|---|---|
| `src/channels/adapters/telegram-bot-format.ts` | Pure tokenizing converter: common Markdown → valid MarkdownV2 with per-region escaping |
| `src/channels/adapters/telegram-bot-format.test.ts` | 40 formatter tests covering bold / italic / code / fence / link / strike / spoiler, edge cases (empty entities, unterminated fences, snake_case, math asterisks, parens-in-URL), and pure-prose safety |
| `src/channels/adapters/telegram-bot.ts` | Outbound now runs text through the formatter and sends with `parse_mode: 'MarkdownV2'`; module-header comment updated to document the new default |
| `src/channels/adapters/telegram-bot-outbound.test.ts` | Mutation-guard test flipped from "no parse_mode" to MarkdownV2; +1 new integration test asserting agent Markdown round-trips through render → wire correctly |
| `src/skills/typeclaw-channel-telegram-bot/SKILL.md` | Bundled skill telling the agent which markers actually render through this adapter (and which fall through escaped — Telegram has no headings, lists, or tables) |

## Design decisions

### Why MarkdownV2 over HTML

Both modes need escaping. HTML mode escapes `< > &` only; MarkdownV2 escapes 18 reserved chars. But the chosen mode also has to **render the agent's source faithfully**, and the agent writes common GitHub-flavored Markdown (`**bold**`, `` `code` ``, fenced blocks, `[label](url)`). Translating that to HTML means parsing it AND emitting tags, plus a fallback for anything that doesn't map cleanly. Translating it to MarkdownV2 means only escaping unfamiliar punctuation and re-emitting the rest as already-valid MarkdownV2 (`**` → `*`, `_` already works, `~~` → `~`, fences are identical). Less code, lower-risk pass-through, and the on-wire format is closer to what the agent typed.

### Word-boundary guards on italic markers

The model writes `my_var_name`, `foo__bar__baz`, `a*b*c`, and `2 * 3 = 6` constantly in code-flavored prose. A naive italic converter would silently italicize half of every code review reply. Both `_text_` and `*text*` italic — and `__text__` bold — only fire when the open marker is not adjacent to a word char on its left and the close marker is not adjacent to one on its right. Snake_case identifiers, multiplication, and pointer/dereference syntax all stay literal.

### Empty entities collapse to escaped literals

Telegram rejects empty MarkdownV2 entities (`****`, `~~~~`, `||||`). The formatter detects `close > i + 2` and falls back to escaping each marker char as a literal, so the message still sends. Without this, a stray `****` in a stack trace would crash an otherwise valid reply.

### Unterminated fences degrade gracefully

A fenced code block missing its close fence (` ```python\nstuck`) used to infinite-loop in an early draft of the formatter (the open-fence position equaled the next-fence position, so `i = segmentEnd` never advanced). Now the unterminated-fence branch renders the rest of the input as escaped inline and breaks out of the loop. Mutation-guarded by the `'unterminated fence falls through to inline handling without swallowing the rest'` test.

### URLs containing unescaped parentheses fall back to literal

Wikipedia-style `[w](https://en.wikipedia.org/wiki/Foo_(bar))` is genuinely ambiguous: the URL parser can't tell whether the first `)` closes the link or is content. Rather than guess, the link-parser aborts on unescaped `(` inside the URL and lets the bracket chars escape as literals. The URL still appears as plain text — it just isn't a clickable link. Operators who need such links can percent-encode the parens.

### Bundled skill, not tool description

Per the AGENTS.md note about commit `e2b08ab`/`ccb4669` (per-platform formatting hints embedded in tool descriptions were ignored by the LLM under chat-prose load AND paid the token tax on every channel turn), the new `typeclaw-channel-telegram-bot` skill goes in `src/skills/` where it costs zero tokens until loaded. Skill description names every triggering marker class and the `telegram-bot` adapter explicitly so the LLM reaches for it before composing a reply.

## Mutation guards in this PR

Each of these tests fails if the corresponding piece of production code is reverted:

- `telegram-bot-outbound.test.ts` → "sends as MarkdownV2 with every reserved char escaped" pins `parse_mode: 'MarkdownV2'` and the formatter wiring
- `telegram-bot-format.test.ts` → "the original v1 mutation-guard string passes through with every special escaped" pins outside-entity escaping
- `telegram-bot-format.test.ts` → "does NOT italicize snake_case identifiers" / "does NOT italicize a*b*c" pin the word-boundary guards
- `telegram-bot-format.test.ts` → "unterminated fence falls through" pins the infinite-loop fix
- `telegram-bot-format.test.ts` → "an empty bold pair `****` does not crash" pins the zero-width-entity guard

## Pre-commit checks

```
$ bun run typecheck   # tsgo --noEmit  (clean)
$ bun run lint        # oxlint  (0 warnings, 0 errors)
$ bun run format:check  # oxfmt  (clean)
$ bun test            # 1888 pass / 0 fail across 124 files
```

Net: +621 lines added, -17 changed, 1 commit.