### PR TITLE
Preflight Docker before scaffolding in typeclaw init

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,6 +1,7 @@
 import { cancel, confirm, intro, isCancel, note, password, select, spinner } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
+import type { DockerAvailability } from '@/container'
 import { findAgentDir, isDirectoryNonEmpty, isHatched, runInit, type InitStep, type InitStepEvent } from '@/init'
 
 export const init = defineCommand({
@@ -170,6 +171,7 @@ export const init = defineCommand({
     //   - cron.json scaffolding — Phase 9
     //   - compose.yml registration in $HOME/.typeclaw — Phase 12
     let hatchingOk = false
+    let preflightFailure: Extract<DockerAvailability, { ok: false }> | null = null
     try {
       await runInit({
         cwd,
@@ -177,12 +179,22 @@ export const init = defineCommand({
         ...(discordBotToken !== undefined ? { discordBotToken } : {}),
         ...(slackBotToken !== undefined ? { slackBotToken, slackAppToken } : {}),
         ...(telegramBotToken !== undefined ? { telegramBotToken } : {}),
-        onProgress: reportProgress((ok) => {
-          hatchingOk = ok
-        }),
+        onProgress: reportProgress(
+          (ok) => {
+            hatchingOk = ok
+          },
+          (result) => {
+            preflightFailure = result
+          },
+        ),
       })
     } catch (error) {
       console.error(error)
+      process.exit(1)
+    }
+
+    if (preflightFailure !== null) {
+      note(preflightFailureGuidance(preflightFailure).join('\n'), 'Docker check failed')
       process.exit(1)
     }
 
@@ -192,7 +204,10 @@ export const init = defineCommand({
   },
 })
 
-function reportProgress(onHatchingDone: (ok: boolean) => void): (event: InitStepEvent) => void {
+function reportProgress(
+  onHatchingDone: (ok: boolean) => void,
+  onPreflightFail: (result: Extract<DockerAvailability, { ok: false }>) => void,
+): (event: InitStepEvent) => void {
   const spinners: Partial<Record<InitStepEvent['step'], ReturnType<typeof spinner>>> = {}
 
   return (event) => {
@@ -213,6 +228,14 @@ function reportProgress(onHatchingDone: (ok: boolean) => void): (event: InitStep
     if (!s) return
 
     switch (event.step) {
+      case 'preflight':
+        if (event.result.ok) {
+          s.stop('Docker is reachable.')
+        } else {
+          s.error(preflightFailureSummary(event.result))
+          onPreflightFail(event.result)
+        }
+        break
       case 'scaffold':
         s.stop('Egg laid. 🥚')
         break
@@ -237,6 +260,33 @@ function reportProgress(onHatchingDone: (ok: boolean) => void): (event: InitStep
   }
 }
 
+function preflightFailureSummary(result: Extract<DockerAvailability, { ok: false }>): string {
+  if (result.reason === 'binary-missing') return 'Docker is not installed.'
+  return 'Docker is installed but the daemon is not reachable.'
+}
+
+function preflightFailureGuidance(result: Extract<DockerAvailability, { ok: false }>): string[] {
+  if (result.reason === 'binary-missing') {
+    return [
+      'TypeClaw runs every agent inside its own Docker container, so Docker is required.',
+      '',
+      'Install one of:',
+      '  • Docker Desktop — https://docs.docker.com/get-docker/',
+      '  • OrbStack (macOS, lighter) — https://orbstack.dev',
+      '',
+      'Then re-run `typeclaw init`.',
+    ]
+  }
+  return [
+    'The docker CLI is on $PATH, but the daemon refused the connection:',
+    '',
+    `  ${result.detail}`,
+    '',
+    'Start Docker Desktop / OrbStack (or `sudo systemctl start docker` on Linux),',
+    'then re-run `typeclaw init`.',
+  ]
+}
+
 // Hatching launches the container and foregrounds the TUI, so it steals stdin
 // and cannot share the spinner lifecycle with the other steps. Print plain
 // lines instead.
@@ -253,6 +303,7 @@ function reportHatching(event: Extract<InitStepEvent, { step: 'hatching' }>): vo
 }
 
 const START_MESSAGES: Record<Exclude<InitStep, 'hatching'>, string> = {
+  preflight: 'Checking Docker...',
   scaffold: 'Laying the egg...',
   install: 'Installing dependencies with bun...',
   dockerfile: 'Writing Dockerfile...',

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -3,12 +3,15 @@ export { CONTAINER_PORT, findFreePort, resolveHostPort } from './port'
 export { planShell, shell, type ShellPlan, type ShellResult } from './shell'
 export { status, type ContainerStatus, type StatusOptions } from './status'
 export {
+  checkDockerAvailable,
   containerExists,
   containerNameFromCwd,
   defaultDockerExec,
+  DOCKER_NOT_FOUND_STDERR,
   imageTagFromCwd,
   inspectContainer,
   type ContainerState,
+  type DockerAvailability,
   type DockerExec,
   type DockerExecResult,
 } from './shared'

--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -3,7 +3,14 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { containerNameFromCwd, imageTagFromCwd, waitForRemoval } from './shared'
+import {
+  checkDockerAvailable,
+  containerNameFromCwd,
+  DOCKER_NOT_FOUND_STDERR,
+  type DockerExec,
+  imageTagFromCwd,
+  waitForRemoval,
+} from './shared'
 
 let root: string
 
@@ -81,5 +88,67 @@ describe('waitForRemoval', () => {
     })
 
     expect(result).toBe(false)
+  })
+})
+
+describe('checkDockerAvailable', () => {
+  test('returns ok when docker info exits 0', async () => {
+    const exec: DockerExec = async () => ({ exitCode: 0, stdout: '29.4.0\n', stderr: '' })
+
+    const result = await checkDockerAvailable(exec)
+
+    expect(result).toEqual({ ok: true })
+  })
+
+  test('classifies as binary-missing when stderr is the ENOENT sentinel', async () => {
+    const exec: DockerExec = async () => ({ exitCode: -1, stdout: '', stderr: DOCKER_NOT_FOUND_STDERR })
+
+    const result = await checkDockerAvailable(exec)
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'binary-missing',
+      detail: DOCKER_NOT_FOUND_STDERR,
+    })
+  })
+
+  test('classifies any other non-zero exit as daemon-down', async () => {
+    const exec: DockerExec = async () => ({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\n',
+    })
+
+    const result = await checkDockerAvailable(exec)
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'daemon-down',
+      detail: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
+    })
+  })
+
+  test('falls back to a synthetic detail when stderr is empty on non-zero exit', async () => {
+    const exec: DockerExec = async () => ({ exitCode: 7, stdout: '', stderr: '   ' })
+
+    const result = await checkDockerAvailable(exec)
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'daemon-down',
+      detail: 'docker info exited with code 7',
+    })
+  })
+
+  test('passes the right args to the exec stub', async () => {
+    const calls: string[][] = []
+    const exec: DockerExec = async (args) => {
+      calls.push(args)
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    await checkDockerAvailable(exec)
+
+    expect(calls).toEqual([['info', '--format', '{{.ServerVersion}}']])
   })
 })

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -10,16 +10,58 @@ export type DockerExec = (
 export const defaultDockerExec: DockerExec = async (args, options) => {
   const bun = getBun()
   if (!bun) return { exitCode: -1, stdout: '', stderr: 'bun runtime not available' }
-  const proc = bun.spawn({
-    cmd: ['docker', ...args],
-    cwd: options?.cwd,
-    stdout: options?.inheritStdio ? 'inherit' : 'pipe',
-    stderr: options?.inheritStdio ? 'inherit' : 'pipe',
-  })
-  const exitCode = await proc.exited
-  const stdout = options?.inheritStdio ? '' : await new Response(proc.stdout).text()
-  const stderr = options?.inheritStdio ? '' : await new Response(proc.stderr).text()
-  return { exitCode, stdout, stderr }
+  // Bun.spawn throws synchronously with code 'ENOENT' when docker isn't on
+  // $PATH (rather than returning a non-zero exit). Two overloads (pipe vs
+  // inherit) so each spawn call site has the literal stdout/stderr type
+  // attached — that's what lets `new Response(proc.stdout)` typecheck on
+  // the piped path.
+  if (options?.inheritStdio) {
+    try {
+      const proc = bun.spawn({ cmd: ['docker', ...args], cwd: options.cwd, stdout: 'inherit', stderr: 'inherit' })
+      return { exitCode: await proc.exited, stdout: '', stderr: '' }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+        return { exitCode: -1, stdout: '', stderr: DOCKER_NOT_FOUND_STDERR }
+      }
+      throw error
+    }
+  }
+  try {
+    const proc = bun.spawn({ cmd: ['docker', ...args], cwd: options?.cwd, stdout: 'pipe', stderr: 'pipe' })
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+    return { exitCode, stdout, stderr }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return { exitCode: -1, stdout: '', stderr: DOCKER_NOT_FOUND_STDERR }
+    }
+    throw error
+  }
+}
+
+// Sentinel stderr from defaultDockerExec when Bun.spawn throws ENOENT.
+// checkDockerAvailable matches on this exact string to distinguish
+// "binary missing" from "daemon down".
+export const DOCKER_NOT_FOUND_STDERR = 'docker: command not found in $PATH'
+
+export type DockerAvailability = { ok: true } | { ok: false; reason: 'binary-missing' | 'daemon-down'; detail: string }
+
+// `docker info --format {{.ServerVersion}}` is the probe of choice because it
+// requires both the client AND a reachable daemon. `docker --version` would
+// miss the "Docker Desktop installed but not running" case, which is the
+// common failure mode on macOS.
+export async function checkDockerAvailable(exec: DockerExec = defaultDockerExec): Promise<DockerAvailability> {
+  const result = await exec(['info', '--format', '{{.ServerVersion}}'])
+  if (result.exitCode === 0) return { ok: true }
+  if (result.stderr === DOCKER_NOT_FOUND_STDERR) {
+    return { ok: false, reason: 'binary-missing', detail: result.stderr }
+  }
+  return {
+    ok: false,
+    reason: 'daemon-down',
+    detail: result.stderr.trim() || `docker info exited with code ${result.exitCode}`,
+  }
 }
 
 export function containerNameFromCwd(cwd: string): string {

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url'
 import * as z from 'zod'
 
 import { configSchema, dockerfileSchema } from '@/config/config'
+import type { DockerExec } from '@/container'
 
 import { buildDockerfile } from './dockerfile'
 import { buildGitignore } from './gitignore'
@@ -36,6 +37,11 @@ beforeEach(async () => {
 
 const okHatch: HatchRunner = async () => ({ ok: true }) as HatchingResult
 
+// Default exec stub for tests: pretends docker is installed and the daemon
+// is reachable. Tests that exercise the preflight failure path override this
+// with their own DockerExec to simulate ENOENT or daemon-down conditions.
+const okDocker: DockerExec = async () => ({ exitCode: 0, stdout: '29.4.0\n', stderr: '' })
+
 function captureHatch(): { runner: HatchRunner; calls: Array<{ cwd: string; port: number }> } {
   const calls: Array<{ cwd: string; port: number }> = []
   const runner: HatchRunner = async (options) => {
@@ -60,9 +66,17 @@ describe('runInit', () => {
   test('runs scaffold, install, dockerfile, git, and hatching steps in order', async () => {
     const events: InitStepEvent[] = []
 
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch, onProgress: (e) => events.push(e) })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      dockerExec: okDocker,
+      onProgress: (e) => events.push(e),
+    })
 
     expect(events.map((e) => `${e.step}:${e.phase}`)).toEqual([
+      'preflight:start',
+      'preflight:done',
       'scaffold:start',
       'scaffold:done',
       'install:start',
@@ -86,7 +100,7 @@ describe('runInit', () => {
       return { ok: true }
     }
 
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching })
+    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching, dockerExec: okDocker })
 
     expect(seenAt).toEqual([{ hasGit: true, hasDockerfile: true }])
   })
@@ -94,7 +108,7 @@ describe('runInit', () => {
   test('hatching receives the init cwd and the configured port', async () => {
     const { runner, calls } = captureHatch()
 
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: runner })
+    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: runner, dockerExec: okDocker })
 
     expect(calls).toHaveLength(1)
     expect(calls[0]?.cwd).toBe(root)
@@ -105,7 +119,13 @@ describe('runInit', () => {
     const runHatching: HatchRunner = async () => ({ ok: false, reason: 'simulated boom' })
     const events: InitStepEvent[] = []
 
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching, onProgress: (e) => events.push(e) })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching,
+      dockerExec: okDocker,
+      onProgress: (e) => events.push(e),
+    })
 
     const hatchDone = events.find((e) => e.step === 'hatching' && e.phase === 'done')
     if (!(hatchDone && hatchDone.step === 'hatching' && hatchDone.phase === 'done')) {
@@ -115,7 +135,7 @@ describe('runInit', () => {
   })
 
   test('produces an initialized agent folder (config, secrets, markdown, git repo)', async () => {
-    await runInit({ cwd: root, apiKey: 'fw_integration_key', runHatching: okHatch })
+    await runInit({ cwd: root, apiKey: 'fw_integration_key', runHatching: okHatch, dockerExec: okDocker })
 
     expect(isInitialized(root)).toBe(true)
     expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_integration_key\n')
@@ -125,7 +145,7 @@ describe('runInit', () => {
   })
 
   test('git step sees scaffolded files (step ordering)', async () => {
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch })
+    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch, dockerExec: okDocker })
 
     const tracked = (await runGit(root, ['ls-files'])).split('\n')
     expect(tracked).toContain('typeclaw.json')
@@ -145,7 +165,13 @@ describe('runInit', () => {
   test('dockerfile step writes Dockerfile and reports devMode via event', async () => {
     const events: InitStepEvent[] = []
 
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch, onProgress: (e) => events.push(e) })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      dockerExec: okDocker,
+      onProgress: (e) => events.push(e),
+    })
 
     expect(existsSync(join(root, 'Dockerfile'))).toBe(true)
 
@@ -157,7 +183,13 @@ describe('runInit', () => {
   })
 
   test('Dockerfile installs git so agents can use it at runtime', async () => {
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch, onProgress: () => {} })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      dockerExec: okDocker,
+      onProgress: () => {},
+    })
 
     const dockerfile = await readFile(join(root, 'Dockerfile'), 'utf8')
     expect(dockerfile).toMatch(/apt-get[\s\S]+install[\s\S]+\bgit\b/)
@@ -166,7 +198,13 @@ describe('runInit', () => {
   test('emits git done event with skipped: false when repo is freshly initialized', async () => {
     const events: InitStepEvent[] = []
 
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch, onProgress: (e) => events.push(e) })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      dockerExec: okDocker,
+      onProgress: (e) => events.push(e),
+    })
 
     const gitDone = events.find((e) => e.step === 'git' && e.phase === 'done')
     if (!(gitDone && gitDone.step === 'git' && gitDone.phase === 'done' && gitDone.result.ok)) {
@@ -179,7 +217,13 @@ describe('runInit', () => {
     await mkdir(join(root, '.git'))
     const events: InitStepEvent[] = []
 
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch, onProgress: (e) => events.push(e) })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      dockerExec: okDocker,
+      onProgress: (e) => events.push(e),
+    })
 
     const gitDone = events.find((e) => e.step === 'git' && e.phase === 'done')
     if (!(gitDone && gitDone.step === 'git' && gitDone.phase === 'done' && gitDone.result.ok)) {
@@ -195,7 +239,13 @@ describe('runInit', () => {
     const events: InitStepEvent[] = []
 
     // when
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch, onProgress: (e) => events.push(e) })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      dockerExec: okDocker,
+      onProgress: (e) => events.push(e),
+    })
 
     // then: dockerfile failed softly, git and hatching still ran
     const dockerDone = events.find((e) => e.step === 'dockerfile' && e.phase === 'done')
@@ -212,7 +262,7 @@ describe('runInit', () => {
   })
 
   test('works without onProgress callback', async () => {
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch })
+    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch, dockerExec: okDocker })
 
     expect(isInitialized(root)).toBe(true)
   })
@@ -220,16 +270,24 @@ describe('runInit', () => {
   test('is idempotent: re-running after a failed hatching re-runs all steps without crashing', async () => {
     // given: a prior run where hatching failed (e.g. docker daemon was down).
     const failingHatch: HatchRunner = async () => ({ ok: false, reason: 'docker build failed' })
-    await runInit({ cwd: root, apiKey: 'fw_first_key', runHatching: failingHatch })
+    await runInit({ cwd: root, apiKey: 'fw_first_key', runHatching: failingHatch, dockerExec: okDocker })
     expect(isInitialized(root)).toBe(true)
     expect(await isHatched(root)).toBe(false)
 
     // when: the user retries `typeclaw init` with a working setup.
     const events: InitStepEvent[] = []
-    await runInit({ cwd: root, apiKey: 'fw_second_key', runHatching: okHatch, onProgress: (e) => events.push(e) })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_second_key',
+      runHatching: okHatch,
+      dockerExec: okDocker,
+      onProgress: (e) => events.push(e),
+    })
 
     // then: every step ran again, and git step reports skipped because the repo already exists.
     expect(events.map((e) => `${e.step}:${e.phase}`)).toEqual([
+      'preflight:start',
+      'preflight:done',
       'scaffold:start',
       'scaffold:done',
       'install:start',
@@ -247,6 +305,101 @@ describe('runInit', () => {
     }
     expect(gitDone.result.skipped).toBe(true)
     expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_second_key\n')
+  })
+
+  test('aborts before scaffolding when docker binary is missing', async () => {
+    // given: an exec stub that simulates Bun.spawn's ENOENT path
+    // (defaultDockerExec catches the throw and returns this exact stderr).
+    const missingDocker: DockerExec = async () => ({
+      exitCode: -1,
+      stdout: '',
+      stderr: 'docker: command not found in $PATH',
+    })
+    const events: InitStepEvent[] = []
+
+    // when
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      dockerExec: missingDocker,
+      onProgress: (e) => events.push(e),
+    })
+
+    // then: only the preflight step ran; nothing else.
+    expect(events.map((e) => `${e.step}:${e.phase}`)).toEqual(['preflight:start', 'preflight:done'])
+    const preflightDone = events.find((e) => e.step === 'preflight' && e.phase === 'done')
+    if (!(preflightDone && preflightDone.step === 'preflight' && preflightDone.phase === 'done')) {
+      throw new Error('expected preflight:done')
+    }
+    expect(preflightDone.result).toEqual({
+      ok: false,
+      reason: 'binary-missing',
+      detail: 'docker: command not found in $PATH',
+    })
+
+    // then: nothing was written to disk — the agent folder must look exactly
+    // as it did before runInit was called, so the user can re-run init after
+    // installing docker without manual cleanup.
+    expect(isInitialized(root)).toBe(false)
+    expect(existsSync(join(root, '.env'))).toBe(false)
+    expect(existsSync(join(root, 'package.json'))).toBe(false)
+    expect(existsSync(join(root, 'Dockerfile'))).toBe(false)
+    expect(existsSync(join(root, '.git'))).toBe(false)
+    expect(existsSync(join(root, 'AGENTS.md'))).toBe(false)
+    expect(existsSync(join(root, 'workspace'))).toBe(false)
+    expect(existsSync(join(root, 'packages'))).toBe(false)
+  })
+
+  test('aborts before scaffolding when docker daemon is unreachable', async () => {
+    const daemonDown: DockerExec = async () => ({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\n',
+    })
+    const events: InitStepEvent[] = []
+
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      dockerExec: daemonDown,
+      onProgress: (e) => events.push(e),
+    })
+
+    expect(events.map((e) => `${e.step}:${e.phase}`)).toEqual(['preflight:start', 'preflight:done'])
+    const preflightDone = events.find((e) => e.step === 'preflight' && e.phase === 'done')
+    if (!(preflightDone && preflightDone.step === 'preflight' && preflightDone.phase === 'done')) {
+      throw new Error('expected preflight:done')
+    }
+    expect(preflightDone.result.ok).toBe(false)
+    if (preflightDone.result.ok) throw new Error('unreachable')
+    expect(preflightDone.result.reason).toBe('daemon-down')
+    expect(preflightDone.result.detail).toContain('Cannot connect to the Docker daemon')
+
+    expect(isInitialized(root)).toBe(false)
+  })
+
+  test('hatching is not invoked when preflight fails', async () => {
+    const missingDocker: DockerExec = async () => ({
+      exitCode: -1,
+      stdout: '',
+      stderr: 'docker: command not found in $PATH',
+    })
+    let hatchingInvoked = false
+    const trackingHatch: HatchRunner = async () => {
+      hatchingInvoked = true
+      return { ok: true }
+    }
+
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: trackingHatch,
+      dockerExec: missingDocker,
+    })
+
+    expect(hatchingInvoked).toBe(false)
   })
 })
 

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -4,7 +4,7 @@ import { basename, dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { config, configSchema, type Config } from '@/config'
-import { start } from '@/container'
+import { checkDockerAvailable, type DockerAvailability, type DockerExec, start } from '@/container'
 import { createTui } from '@/tui'
 
 import { buildDockerfile, DOCKERFILE } from './dockerfile'
@@ -34,9 +34,11 @@ export type GitInitResult = { ok: true; skipped: boolean } | { ok: false; reason
 export type DockerAssetsResult = { ok: true; devMode: boolean } | { ok: false; reason: string }
 export type HatchingResult = { ok: true } | { ok: false; reason: string }
 
-export type InitStep = 'scaffold' | 'install' | 'dockerfile' | 'git' | 'hatching'
+export type InitStep = 'preflight' | 'scaffold' | 'install' | 'dockerfile' | 'git' | 'hatching'
 
 export type InitStepEvent =
+  | { step: 'preflight'; phase: 'start' }
+  | { step: 'preflight'; phase: 'done'; result: DockerAvailability }
   | { step: 'scaffold'; phase: 'start' }
   | { step: 'scaffold'; phase: 'done' }
   | { step: 'install'; phase: 'start' }
@@ -62,6 +64,7 @@ export type InitOptions = {
   telegramAllowAll?: boolean
   onProgress?: (event: InitStepEvent) => void
   runHatching?: HatchRunner
+  dockerExec?: DockerExec
 }
 
 export async function runInit({
@@ -76,8 +79,19 @@ export async function runInit({
   telegramAllowAll = true,
   onProgress,
   runHatching = defaultRunHatching,
+  dockerExec,
 }: InitOptions): Promise<void> {
   const emit = onProgress ?? (() => {})
+
+  // Docker preflight runs BEFORE any scaffolding so a missing-binary or
+  // daemon-down failure leaves the user's directory untouched. Without this
+  // gate, init would lay the egg, write the Dockerfile, init git, and then
+  // fail at hatching with a raw "Executable not found in $PATH: docker" —
+  // leaving a half-initialized agent folder the user has to clean up by hand.
+  emit({ step: 'preflight', phase: 'start' })
+  const preflight = await checkDockerAvailable(dockerExec)
+  emit({ step: 'preflight', phase: 'done', result: preflight })
+  if (!preflight.ok) return
 
   const wantsDiscord = discordBotToken !== undefined && discordBotToken !== ''
   const wantsSlack = slackBotToken !== undefined && slackBotToken !== ''


### PR DESCRIPTION
## What broke

\`typeclaw init\` on a host without Docker (or with Docker installed but the daemon not running) leaves the user holding a half-initialized agent folder:

\`\`\`
◇  Egg laid. 🥚
◇  Dependencies installed.
◇  Dockerfile + compose.yml written (dev mode).
◇  Git repository initialized.
Hatching...
Hatching failed: Executable not found in \$PATH: \"docker\"
\`\`\`

The four green checkmarks lie. The agent folder is partway initialized — \`typeclaw.json\`, \`.env\`, \`Dockerfile\`, \`package.json\`, an \`Initial commit 🥚\` git repo, all on disk — and the user has to clean it up by hand before they can re-run \`init\` after installing Docker.

## Root cause

Two layered issues:

1. \`defaultDockerExec\` in \`src/container/shared.ts\` didn't catch \`Bun.spawn\`'s **synchronous** \`ENOENT\` throw. The exception bubbled up through \`start()\`'s outer try/catch into \`defaultRunHatching\`, which dutifully reported it as the \"hatching error\" string. Past callers couldn't tell missing-binary from a real spawn failure even if they wanted to.
2. \`runInit\` had no preflight gate, so all the user-visible scaffolding ran *before* the docker-dependent step had a chance to fail.

## Fix

- **\`defaultDockerExec\` catches \`ENOENT\`** and returns a sentinel stderr (\`docker: command not found in \$PATH\`). Two duplicated try/catch arms (pipe vs inherit) so each \`bun.spawn\` call site keeps the literal \`stdout/stderr\` type attached for \`new Response(proc.stdout)\` to typecheck. Source comment explains why the duplication is load-bearing.
- **New \`checkDockerAvailable()\`** probes \`docker info --format {{.ServerVersion}}\` (which requires both client AND daemon — \`docker --version\` would miss the \"Docker Desktop installed but quit\" case, which is the common mode on macOS). Distinguishes \`binary-missing\` from \`daemon-down\` via the sentinel above. Returns a discriminated union.
- **\`runInit\` emits a new \`preflight\` step** *before* scaffold and returns early on failure, leaving the directory untouched. \`dockerExec\` test seam plumbed through \`InitOptions\` so unit tests don't shell out to real \`docker info\`.
- **\`src/cli/init.ts\` renders the failure** with a clack \`note()\` that names the install options for binary-missing:
  > Install one of:
  >  • Docker Desktop — https://docs.docker.com/get-docker/
  >  • OrbStack (macOS, lighter) — https://orbstack.dev
  >
  > Then re-run \`typeclaw init\`.

  …and the daemon-start hint for daemon-down. Exits 1 cleanly, no stack trace.

## Why init-only

Per design discussion: \`typeclaw start\` is left to fail naturally. By the time the user runs \`start\`, they've already proven they can launch a container at least once (init succeeded), so the slim late-failure mode is acceptable and avoids gating every host-stage CLI invocation on a docker round-trip.

## Tests

6 new tests:

- **\`shared.test.ts\`** — three classifications of \`checkDockerAvailable\` (ok, binary-missing via sentinel, daemon-down via any other non-zero) + arg-shape mutation guard + empty-stderr fallback.
- **\`index.test.ts\`** — \`runInit\` with binary-missing aborts before any scaffold (asserts seven specific files/dirs are *not* on disk after the call), daemon-down aborts the same way, hatching is not invoked when preflight fails.

The 14 existing \`runInit\` tests now pass an \`okDocker\` stub via the new \`dockerExec\` seam — also makes them pass on CI runners that don't have Docker installed.

**Mutation check applied**: removing the \`if (!preflight.ok) return\` line in \`runInit\` causes the \"aborts before scaffolding\" test to fail with seven separate assertion failures (every disk-state assertion fires). Removing the \`try/catch\` around the piped \`bun.spawn\` would re-introduce the original bug — covered by the binary-missing classification test through the contract on \`defaultDockerExec\`.

## Checks

\`\`\`
$ bun run typecheck    # tsgo --noEmit, 0 errors
$ bun run lint         # oxlint, 0 warnings 0 errors
$ bun run format:check # all matched files use the correct format
$ bun run test         # 1855 pass, 0 fail (3783 expect() calls)
\`\`\`