### PR TITLE
Add ensureLive watchdog to prevent hung REST calls from bricking a channel

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -106,6 +106,7 @@ function makeRouter(
     factoryCalls?: SessionFactoryArgs[]
     transcriptPathFor?: (sessionId: string) => string | undefined
     configuredAliases?: () => readonly string[]
+    ensureLiveTimeoutMs?: number
   } = {},
 ): { router: ChannelRouter; sessions: FakeSession[]; origins: SessionOrigin[] } {
   const sessions: FakeSession[] = options.sessions ?? []
@@ -115,6 +116,7 @@ function makeRouter(
     agentDir,
     configForAdapter: () => options.config ?? baseConfig,
     ...(options.configuredAliases !== undefined ? { configuredAliases: options.configuredAliases } : {}),
+    ...(options.ensureLiveTimeoutMs !== undefined ? { ensureLiveTimeoutMs: options.ensureLiveTimeoutMs } : {}),
     now: () => nowRef.value,
     logger: {
       info: (m) => options.logs?.push(`info:${m}`),
@@ -393,6 +395,84 @@ describe('ChannelRouter session lifecycle', () => {
     const { router, sessions } = makeRouter(dir)
     await Promise.all([router.route(inbound()), router.route(inbound({ externalMessageId: 'm2' }))])
     expect(sessions).toHaveLength(1)
+  })
+})
+
+describe('ChannelRouter ensureLive watchdog', () => {
+  test('hung session factory rejects after the timeout instead of awaiting forever', async () => {
+    // given a factory that never resolves (simulates a hung Discord REST chain
+    // inside createForChannel — the production failure mode that bricked the
+    // bot for 2 days when a previously-evicted channel got a new inbound
+    // during a gateway-disconnect storm)
+    const dir = await tempDir()
+    const logs: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      ensureLiveTimeoutMs: 50,
+      logger: {
+        info: (m) => logs.push(`info:${m}`),
+        warn: (m) => logs.push(`warn:${m}`),
+        error: (m) => logs.push(`error:${m}`),
+      },
+      createSessionForChannel: () => new Promise(() => {}),
+    })
+
+    // when the route promise resolves (the adapter's outer catch is responsible
+    // for swallowing the thrown timeout in production; here we observe the
+    // throw directly to assert the watchdog actually fired)
+    const start = Date.now()
+    await expect(router.route(inbound())).rejects.toThrow(/ensureLive timed out after 50ms/)
+    const elapsed = Date.now() - start
+
+    // then we returned within the watchdog window (production-relevant: the
+    // adapter's outer catch sees the timeout error promptly and decrements
+    // its inflight counter, instead of sitting forever)
+    expect(elapsed).toBeLessThan(500)
+    expect(logs.some((l) => l.includes('error:[channels]') && l.includes('ensureLive failed'))).toBe(true)
+  })
+
+  test('after a watchdog timeout, the next inbound retries instead of awaiting the dead promise', async () => {
+    // given a factory that hangs the FIRST call but resolves the second.
+    // This is the diagnostic that proves the `creating` map entry was evicted
+    // — the original bug had every subsequent message await the same dead
+    // promise from the first hung call (commit message reproduces from logs).
+    const dir = await tempDir()
+    const logs: string[] = []
+    let callCount = 0
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      ensureLiveTimeoutMs: 50,
+      logger: {
+        info: (m) => logs.push(`info:${m}`),
+        warn: (m) => logs.push(`warn:${m}`),
+        error: (m) => logs.push(`error:${m}`),
+      },
+      createSessionForChannel: async () => {
+        callCount++
+        if (callCount === 1) await new Promise(() => {})
+        const fake = new FakeSession()
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: `ses_retry_${callCount}`,
+          dispose: async () => {
+            fake.dispose()
+          },
+        }
+      },
+    })
+
+    // when first inbound times out, then a second inbound arrives
+    await expect(router.route(inbound())).rejects.toThrow(/ensureLive timed out/)
+    expect(logs.some((l) => l.includes('ensureLive failed'))).toBe(true)
+    await router.route(inbound({ externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then the factory was called twice (proving the creating-map entry was
+    // evicted on timeout) and the second call succeeded into a live session
+    expect(callCount).toBe(2)
+    expect(router.liveCount()).toBe(1)
   })
 })
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -441,6 +441,32 @@ describe('ChannelRouter engagement and prompt composition', () => {
     expect(sessions[0]!.prompts).toHaveLength(0)
   })
 
+  test('logs an `observed id=...` line when engagement decides observe', async () => {
+    // given a 2-human channel under strict trigger so a non-mention observes
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router } = makeRouter(dir, {
+      config: {
+        allow: ['*'],
+        engagement: { trigger: ['mention'], stickiness: 'off' },
+        enabled: true,
+        history: defaultHistoryConfig(),
+      },
+      logs,
+    })
+    await router.route(inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when a non-mention from a different author arrives (must observe)
+    logs.length = 0
+    await router.route(inbound({ isBotMention: false, externalMessageId: 'm-observed' }))
+
+    // then exactly one observed log is emitted with the inbound message id
+    const observedLogs = logs.filter((l) => l.includes('observed id='))
+    expect(observedLogs).toHaveLength(1)
+    expect(observedLogs[0]).toContain('id=m-observed')
+  })
+
   test('solo-human channel: plain message engages without mention/reply/dm', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1709,6 +1709,46 @@ describe('ChannelRouter channel name resolver', () => {
 
     expect(calls).toBe(1)
   })
+
+  test('a hung name resolver times out without dragging ensureLive past the per-callback ceiling', async () => {
+    // given a name resolver that never resolves (production failure mode:
+    // Discord REST stuck during a gateway-disconnect storm)
+    const dir = await tempDir()
+    const logs: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      resolveChannelNamesTimeoutMs: 50,
+      logger: {
+        info: (m) => logs.push(`info:${m}`),
+        warn: (m) => logs.push(`warn:${m}`),
+        error: (m) => logs.push(`error:${m}`),
+      },
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: 'ses_after_timeout',
+          dispose: async () => {
+            fake.dispose()
+          },
+        }
+      },
+    })
+    router.registerChannelNameResolver('discord-bot', () => new Promise(() => {}))
+
+    // when an inbound triggers ensureLive
+    const start = Date.now()
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+    const elapsed = Date.now() - start
+
+    // then ensureLive completes without the resolved name (graceful
+    // degradation), the timeout is logged, and the session is created
+    expect(elapsed).toBeLessThan(500)
+    expect(router.liveCount()).toBe(1)
+    expect(logs.some((l) => l.includes('name resolver threw') && l.includes('timed out after 50ms'))).toBe(true)
+  })
 })
 
 describe('ChannelRouter peer-bot loop guard', () => {
@@ -1989,6 +2029,36 @@ describe('ChannelRouter history dispatch', () => {
 
     expect(discordCalls).toBe(1)
     expect(slackCalls).toBe(0)
+  })
+
+  test('a hung history callback times out and degrades to history-not-supported', async () => {
+    // given a fetchHistory callback that never resolves (production failure
+    // mode: same root cause as the hung name resolver — REST stuck inside
+    // the cold-start chain). Without the timeout, prefetchChannelContext
+    // would block ensureLive forever even on a known-existing channel.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      fetchHistoryTimeoutMs: 50,
+      logger: {
+        info: (m) => logs.push(`info:${m}`),
+        warn: (m) => logs.push(`warn:${m}`),
+        error: (m) => logs.push(`error:${m}`),
+      },
+    })
+    router.registerHistory('discord-bot', () => new Promise(() => {}))
+
+    // when fetchHistory is invoked
+    const start = Date.now()
+    const result = await router.fetchHistory('discord-bot', { chat: 'c1', thread: null, limit: 1 })
+    const elapsed = Date.now() - start
+
+    // then it returns the not-supported degraded result and logs the timeout
+    expect(elapsed).toBeLessThan(500)
+    expect(result.ok).toBe(false)
+    expect(logs.some((l) => l.includes('history fetch threw') && l.includes('timed out after 50ms'))).toBe(true)
   })
 })
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -192,6 +192,56 @@ describe('ChannelRouter session lifecycle', () => {
     expect(router.liveCount()).toBe(1)
   })
 
+  test('emits ordered ensureLive phase logs bracketing each await', async () => {
+    // given a fresh router and a captured log buffer
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router } = makeRouter(dir, { logs })
+
+    // when a first inbound triggers cold-start ensureLive
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    // then phase logs appear in order: begin → resolved-names → resolved-membership
+    //   → session-created → done. The bracketing is what makes a stuck phase
+    //   visible from logs alone (begin without done == hung at that phase).
+    const phaseLogs = logs
+      .filter((l) => l.startsWith('info:[channels]') && l.includes('ensureLive'))
+      .map((l) => l.replace(/^.*ensureLive /, ''))
+    const beginIdx = phaseLogs.findIndex((p) => p.startsWith('begin'))
+    const namesIdx = phaseLogs.findIndex((p) => p.startsWith('resolved-names'))
+    const membershipIdx = phaseLogs.findIndex((p) => p.startsWith('resolved-membership'))
+    const createdIdx = phaseLogs.findIndex((p) => p.startsWith('session-created'))
+    const doneIdx = phaseLogs.findIndex((p) => p.startsWith('done'))
+    expect(beginIdx).toBeGreaterThanOrEqual(0)
+    expect(namesIdx).toBeGreaterThan(beginIdx)
+    expect(membershipIdx).toBeGreaterThan(namesIdx)
+    expect(createdIdx).toBeGreaterThan(membershipIdx)
+    expect(doneIdx).toBeGreaterThan(createdIdx)
+    expect(phaseLogs[beginIdx]).toContain('cold-start')
+    expect(phaseLogs[doneIdx]).toContain('cold-start')
+  })
+
+  test('rehydrate path logs `ensureLive begin (rehydrate)` after restart', async () => {
+    // given a persisted mapping from a prior run
+    const dir = await tempDir()
+    const firstRun = makeRouter(dir)
+    await firstRun.router.route(inbound())
+    await firstRun.router.__testing!.flushDebounce(KEY)
+    await firstRun.router.stop()
+
+    // when a fresh router (simulating restart) handles a new inbound for the same channel
+    const logs: string[] = []
+    const secondRun = makeRouter(dir, { logs })
+    await secondRun.router.route(inbound({ externalMessageId: 'm-rehydrate' }))
+    await secondRun.router.__testing!.flushDebounce(KEY)
+
+    // then the begin and done logs both flag the rehydrate path
+    const phaseLogs = logs.filter((l) => l.includes('ensureLive'))
+    expect(phaseLogs.some((l) => l.includes('begin (rehydrate)'))).toBe(true)
+    expect(phaseLogs.some((l) => l.includes('done (rehydrate)'))).toBe(true)
+  })
+
   test('persists the (4-tuple → sessionId) mapping to channels/sessions.json', async () => {
     const dir = await tempDir()
     const { router } = makeRouter(dir)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -884,6 +884,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     })
 
     if (decision === 'observe') {
+      // Log every observe so an unanswered mention is diagnosable from logs
+      // alone instead of "routed but no prompting" silence. The bracketed
+      // shape mirrors `prompting batch=` so log scraping can pair them.
+      logger.info(`[channels] ${live.keyId} observed id=${event.externalMessageId}`)
       observe(live, event)
       return
     }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -86,6 +86,16 @@ export const SESSION_GC_INTERVAL_MS = 60 * 1000
 // instead of awaiting the same dead promise forever.
 export const ENSURE_LIVE_TIMEOUT_MS = 30_000
 
+// Per-callback ceilings inside the ensureLive chain. The outer watchdog
+// catches the worst case, but per-step timeouts give better log
+// attribution (which step hung) AND graceful degradation: a hung name
+// resolver still lets engagement run on IDs alone, a hung history fetch
+// still lets the agent answer without prefetched context. Both paths
+// loop over registered callbacks and currently `await` each unbounded.
+// 5s matches Discord's median REST p99 with comfortable headroom.
+export const RESOLVE_CHANNEL_NAMES_TIMEOUT_MS = 5_000
+export const FETCH_HISTORY_TIMEOUT_MS = 5_000
+
 // Two-axis loop guard for peer-bot conversation. Peer bots route into
 // engagement under the SAME rules as humans, so a small ring (A→B→C→A) or
 // a fast cascade can otherwise ping-pong without bound. The guard trips
@@ -277,12 +287,19 @@ export type CreateChannelRouterOptions = {
   // Test seam: override the ensureLive watchdog ceiling so the timeout path
   // is exercisable in <100ms instead of the 30s production default.
   ensureLiveTimeoutMs?: number
+  // Test seam: per-callback ceiling for channel name resolvers; mirrors the
+  // ensureLive seam so timeout paths can be exercised quickly in tests.
+  resolveChannelNamesTimeoutMs?: number
+  // Test seam: per-callback ceiling for history fetches.
+  fetchHistoryTimeoutMs?: number
 }
 
 export function createChannelRouter(options: CreateChannelRouterOptions): ChannelRouter {
   const logger = options.logger ?? consoleLogger
   const now = options.now ?? Date.now
   const ensureLiveTimeoutMs = options.ensureLiveTimeoutMs ?? ENSURE_LIVE_TIMEOUT_MS
+  const resolveChannelNamesTimeoutMs = options.resolveChannelNamesTimeoutMs ?? RESOLVE_CHANNEL_NAMES_TIMEOUT_MS
+  const fetchHistoryTimeoutMs = options.fetchHistoryTimeoutMs ?? FETCH_HISTORY_TIMEOUT_MS
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
   const outboundCallbacks = new Map<ChannelKey['adapter'], Set<OutboundCallback>>()
@@ -368,7 +385,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const merged: ResolvedChannelNames = {}
     for (const resolver of snapshot) {
       try {
-        const result = await resolver(key)
+        const result = await raceWithTimeout(
+          resolver(key),
+          resolveChannelNamesTimeoutMs,
+          `[channels] ${channelKeyId(key)}: name resolver`,
+        )
         if (result.chatName !== undefined && merged.chatName === undefined) merged.chatName = result.chatName
         if (result.workspaceName !== undefined && merged.workspaceName === undefined) {
           merged.workspaceName = result.workspaceName
@@ -1085,9 +1106,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const snapshot = Array.from(callbacks)
     let lastError: FetchHistoryResult & { ok: false } = { ok: false, error: 'history-not-supported' }
     for (const cb of snapshot) {
-      const result = await cb(args)
-      if (result.ok) return result
-      lastError = result
+      try {
+        const result = await raceWithTimeout(cb(args), fetchHistoryTimeoutMs, `[channels] ${adapter} history fetch`)
+        if (result.ok) return result
+        lastError = result
+      } catch (err) {
+        logger.warn(`[channels] history fetch threw for ${adapter}: ${describe(err)}`)
+        lastError = { ok: false, error: 'history-not-supported' }
+      }
     }
     return lastError
   }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -75,6 +75,17 @@ export const MAX_TYPING_HEARTBEAT_MS = 2 * 60 * 1000
 export const SESSION_IDLE_MS = 30 * 60 * 1000
 export const SESSION_GC_INTERVAL_MS = 60 * 1000
 
+// Watchdog ceiling for ensureLive's full async chain (resolve names →
+// fetch membership → open session manager → persist mapping → prefetch
+// history). A legitimate cold-start completes in well under a second;
+// values above ~10s are always either a hung Discord REST call or a
+// rate-limited retry storm. 30s leaves headroom for slow disks or a
+// truly large transcript replay without making operator-noticed hangs
+// indistinguishable from normal latency. On timeout the throw evicts
+// the `creating` map entry so the next inbound retries from scratch
+// instead of awaiting the same dead promise forever.
+export const ENSURE_LIVE_TIMEOUT_MS = 30_000
+
 // Two-axis loop guard for peer-bot conversation. Peer bots route into
 // engagement under the SAME rules as humans, so a small ring (A→B→C→A) or
 // a fast cascade can otherwise ping-pong without bound. The guard trips
@@ -263,11 +274,15 @@ export type CreateChannelRouterOptions = {
   logger?: RouterLogger
   // Test seam: clock for sticky/debounce/participants. Defaults to Date.now.
   now?: () => number
+  // Test seam: override the ensureLive watchdog ceiling so the timeout path
+  // is exercisable in <100ms instead of the 30s production default.
+  ensureLiveTimeoutMs?: number
 }
 
 export function createChannelRouter(options: CreateChannelRouterOptions): ChannelRouter {
   const logger = options.logger ?? consoleLogger
   const now = options.now ?? Date.now
+  const ensureLiveTimeoutMs = options.ensureLiveTimeoutMs ?? ENSURE_LIVE_TIMEOUT_MS
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
   const outboundCallbacks = new Map<ChannelKey['adapter'], Set<OutboundCallback>>()
@@ -538,7 +553,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
     creating.set(keyId, promise)
     try {
-      return await promise
+      return await raceWithTimeout(promise, ensureLiveTimeoutMs, `[channels] ${keyId} ensureLive`)
+    } catch (err) {
+      // The orphaned `promise` may still settle eventually; that's OK because
+      // the only side effect it produces post-timeout is a `liveSessions.set`,
+      // which the next inbound's existence-check short-circuit at the top of
+      // ensureLive will treat as a usable warm session — strictly better than
+      // a permanent silent drop. The caller (route() in this file, ultimately
+      // the adapter's outer catch) sees the timeout error and logs it.
+      logger.error(`[channels] ${keyId}: ensureLive failed: ${describe(err)}`)
+      throw err
     } finally {
       creating.delete(keyId)
     }
@@ -1438,6 +1462,26 @@ async function withMembershipTimeout(
   })
   try {
     return await Promise.race([promise, timeout])
+  } finally {
+    if (timer !== null) clearTimeout(timer)
+  }
+}
+
+// Throwing variant of the membership timeout pattern: races the work against
+// a deadline and rejects with a descriptive error on miss. Used wherever a
+// hung registered callback (Discord/Slack/Telegram REST) would otherwise
+// leave an awaiting caller stuck forever and there is no graceful-
+// degradation value the caller could substitute (contrast withMembershipTimeout,
+// which returns null because engagement can run on a stale membership reading).
+// The helper owns timer lifetime so callers cannot leak timers on a fast
+// resolution.
+async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+  })
+  try {
+    return await Promise.race([work, timeout])
   } finally {
     if (timer !== null) clearTimeout(timer)
   }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -434,10 +434,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const promise = (async () => {
       await ensureLoaded()
       const record = mappings ? findRecord(mappings, key) : undefined
+      const phase = record?.sessionId === undefined ? 'cold-start' : 'rehydrate'
+      logger.info(`[channels] ${keyId}: ensureLive begin (${phase})`)
       const participants = (record?.participants ?? []) as ChannelParticipant[]
       const membershipFetch = warmMembership(key)
       const resolvedNames = await resolveChannelNames(key)
+      logger.info(`[channels] ${keyId}: ensureLive resolved-names`)
       const membership = await membershipForPrompt(key, membershipFetch)
+      logger.info(`[channels] ${keyId}: ensureLive resolved-membership`)
       const origin: SessionOrigin = {
         kind: 'channel',
         adapter: key.adapter,
@@ -459,6 +463,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         participants,
         origin,
       })
+      logger.info(`[channels] ${keyId}: ensureLive session-created sessionId=${created.sessionId}`)
 
       const transcriptPath = created.getTranscriptPath?.()
       const persistedRecord: ChannelSessionRecord = {
@@ -523,9 +528,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const adapterConfig = options.configForAdapter(key.adapter)
         if (adapterConfig) {
           await prefetchChannelContext(live, adapterConfig, triggeringMessageId)
+          logger.info(`[channels] ${keyId}: ensureLive prefetched-context`)
         }
       }
 
+      logger.info(`[channels] ${keyId}: ensureLive done (${phase})`)
       return live
     })()
 


### PR DESCRIPTION
## Problem

A Discord bot went silent in one channel for 2 days while continuing to respond normally in another. No errors in the logs. Three inbound messages arrived in the silent channel, each appearing as `[discord-bot] inbound id=...` and `[discord-bot] routed id=... mention=true reply=false`, but no `[channels] ... prompting batch=` line ever followed.

The other channel — same participants, same engagement config — worked fine the whole time.

## Root cause

The router's `liveSessions` map holds in-memory `LiveSession` objects. A GC sweep (`runIdleGc`, 30-minute idle threshold) had evicted the silent channel's session from `liveSessions` sometime after its last activity. The session record in `channels/sessions.json` and the session JSONL on disk were intact; the eviction was by design.

When the first new inbound arrived, `ensureLive` correctly took the cold-start path. It built a new `Promise<LiveSession>` and registered it in `creating` (the in-flight map). Inside that promise, a Discord REST call — either the `resolveChannelNames` callback or the `prefetchChannelContext` history fetch — never resolved and never rejected. Discord's HTTP client had been destabilized by a gateway-disconnect storm happening at the same time (a cron job overlapping itself produced the storm; that's a separate bug).

A never-settling promise inside `ensureLive` caused two things:
1. `route()` awaited `ensureLive` and hung forever, so it never reached engagement → enqueue → drain.
2. Every subsequent message for the same channel hit `creating.get(keyId)` and returned the same dead promise, silently joining the queue of forever-awaiting routes.

No error was ever thrown. No log was ever emitted. The channel was effectively dead until the container restarted.

The working channel was unaffected because its `LiveSession` was still in `liveSessions` (recent activity = no idle-GC), so `route()` short-circuited before `ensureLive` even ran.

## What changed

**`src/channels/router.ts` (+91 LOC)**

The core fix is `raceWithTimeout` — a generic helper (router.ts:1504) that throws if a promise doesn't settle within a deadline. Two separate layers of timeout now protect the cold-start path:

**Layer 1 — outer watchdog (commit `15585d0`).**
`ENSURE_LIVE_TIMEOUT_MS = 30_000` wraps the entire `ensureLive` inner promise (router.ts:575–588). On timeout, `raceWithTimeout` throws. The `finally` block at router.ts:588 runs and calls `creating.delete(keyId)`, evicting the dead promise from the in-flight map. The orphaned inner promise is intentionally left running — its only remaining side effect is a late `liveSessions.set`, which the next inbound's existence check at the top of `ensureLive` will treat as a usable warm session. That's strictly better than a permanent drop. The thrown error propagates to each adapter's outer `handleInbound` catch (discord-bot, slack-bot, telegram-bot) and appears in logs as `[channels] <keyId>: ensureLive failed: timed out after 30000ms`.

**Layer 2 — per-callback timeouts (commit `fd08edd`).**
`RESOLVE_CHANNEL_NAMES_TIMEOUT_MS = 5_000` and `FETCH_HISTORY_TIMEOUT_MS = 5_000` wrap each individual callback inside `resolveChannelNames` (router.ts:381) and `fetchHistory` (router.ts:1099). On callback timeout, the failure is logged as a warning and treated as if the callback returned nothing — engagement continues on raw IDs (no resolved channel name), and the history prefetch is skipped. These are graceful degradations; a timed-out name resolver doesn't fail the session creation.

**Observability (commits `711c8d9` and `6edfca3`).**
Before this PR, a hung `ensureLive` was completely invisible in logs. Now:
- Five phase logs bracket the cold-start chain: `ensureLive begin (cold-start|rehydrate)` → `resolved-names` → `resolved-membership` → `session-created sessionId=...` → optional `prefetched-context` → `done`. A `begin` without `done` in the logs precisely identifies which phase hung.
- `observe`-suppressed inbounds now log `[channels] <keyId> observed id=...`, matching the shape of `prompting batch=` so an unanswered mention is distinguishable from a silent route.

**`src/channels/router.test.ts` (+226 LOC)**

7 new tests. Mutation-check was applied to each: commenting out the guarded production line causes the test to fail with exactly the expected error message.

The regression test for this specific bug is in the `ChannelRouter ensureLive watchdog` suite (router.test.ts:435):

> **"after a watchdog timeout, the next inbound retries instead of awaiting the dead promise"**

It hangs the factory's first invocation, succeeds on the second, then asserts:
- `callCount === 2` — proves the `creating` map entry was evicted on timeout, allowing a fresh attempt.
- `router.liveCount() === 1` — proves the session was fully recovered.

Without the fix, `callCount` stays at 1 (second inbound joins the dead promise) and `liveCount` stays at 0 forever.

Test count before: 106 in router.test.ts, 1946 repo-wide. After: 113 in router.test.ts, 1953 repo-wide. The one failing test (`scripts/generate-schema.test.ts` drift guard) also fails on `main` before any of these changes — pre-existing, unrelated to this code.

## Reviewer notes

**The orphaned promise is intentional.** When the watchdog fires, the inner `ensureLive` promise continues running. A future maintainer adding `AbortController`-based cancellation should read the comment at router.ts:579–584 before proceeding: cancelling the promise would remove the recovery property where a late-landing `liveSessions.set` rescues the next inbound without a full cold-start.

**30 seconds is a calibration, not a guarantee.** In production, legitimate cold-starts complete in well under a second. If a future workload (e.g., very large transcript replay on a slow disk) pushes past 30s, the watchdog will fire, the operator will see `ensureLive failed: timed out after 30000ms` in logs, and the next inbound will retry — that's still better than a 2-day silent freeze. The constant is exported and can be adjusted if calibration proves necessary.

**The cron storm is out of scope.** The `transcribe-recordings-5m` job overlapping itself is what destabilized Discord's HTTP client and triggered the gateway-disconnect cycle. That's a separate bug requiring separate diagnosis. This PR fixes the consequence (a hung REST call bricking a channel indefinitely) without assuming anything about the cause.

## Checks

```
$ bun run typecheck    # tsgo --noEmit, 0 errors
$ bun run lint         # oxlint, 0 warnings, 0 errors
$ bun run format:check # oxfmt, all files correctly formatted
$ bun test             # 1953 pass, 1 fail (pre-existing drift guard on main)
```