### PR TITLE
Switch DuckDuckGo backend to lite.duckduckgo.com

### DIFF
--- a/src/agent/tools/ddg.test.ts
+++ b/src/agent/tools/ddg.test.ts
@@ -3,29 +3,34 @@ import { describe, expect, test } from 'bun:test'
 import { parseDdgHtml } from './ddg'
 
 const REAL_RESULT_HTML = `
-<div id="links" class="results">
-<div class="result results_links results_links_deep web-result ">
-  <div class="links_main">
-    <h2 class="result__title">
-      <a rel="nofollow" class="result__a" href="https://bun.sh/">Bun &mdash; A fast all-in-one JavaScript runtime</a>
-    </h2>
-    <div class="result__extras">
-      <div class="result__extras__url">
-        <a class="result__url" href="https://bun.sh/">bun.sh</a>
-      </div>
-    </div>
-    <a class="result__snippet" href="https://bun.sh/"><b>Bun</b> is a fast, all-in-one JavaScript &amp; <b>TypeScript</b> &#x27;toolkit&#x27;.</a>
-  </div>
-</div>
-<div class="result results_links results_links_deep web-result ">
-  <div class="links_main">
-    <h2 class="result__title">
-      <a rel="nofollow" class="result__a" href="https://github.com/oven-sh/bun">oven-sh/bun</a>
-    </h2>
-    <a class="result__snippet" href="https://github.com/oven-sh/bun">Incredibly fast JavaScript runtime.</a>
-  </div>
-</div>
-</div>
+<html><body><table>
+  <tr><td>1.&nbsp;</td>
+    <td>
+      <a rel="nofollow" href="https://bun.sh/" class='result-link'>Bun &mdash; A fast all-in-one JavaScript runtime</a>
+    </td>
+  </tr>
+  <tr>
+    <td class='result-snippet'>
+      <b>Bun</b> is a fast, all-in-one JavaScript &amp; <b>TypeScript</b> &#x27;toolkit&#x27;.
+    </td>
+  </tr>
+  <tr>
+    <td>&nbsp;</td>
+    <td>
+      <span class='link-text'>bun.sh</span>
+    </td>
+  </tr>
+  <tr><td>2.&nbsp;</td>
+    <td>
+      <a rel="nofollow" href="https://github.com/oven-sh/bun" class='result-link'>oven-sh/bun</a>
+    </td>
+  </tr>
+  <tr>
+    <td class='result-snippet'>
+      Incredibly fast JavaScript runtime.
+    </td>
+  </tr>
+</table></body></html>
 `
 
 describe('parseDdgHtml', () => {
@@ -54,12 +59,8 @@ describe('parseDdgHtml', () => {
   test('strips inline highlight tags and decodes HTML entities in titles and snippets', () => {
     // given
     const html = `
-      <div class="result results_links results_links_deep web-result ">
-        <h2 class="result__title">
-          <a rel="nofollow" class="result__a" href="https://example.com/">Foo &amp; Bar &lt;v2&gt;</a>
-        </h2>
-        <a class="result__snippet" href="https://example.com/">A &quot;quoted&quot; <b>snippet</b> with &#39;apostrophe&#39;.</a>
-      </div>
+      <tr><td><a rel="nofollow" href="https://example.com/" class='result-link'>Foo &amp; Bar &lt;v2&gt;</a></td></tr>
+      <tr><td class='result-snippet'>A &quot;quoted&quot; <b>snippet</b> with &#39;apostrophe&#39;.</td></tr>
     `
 
     // when
@@ -73,12 +74,8 @@ describe('parseDdgHtml', () => {
   test('unwraps DDG redirect URLs (//duckduckgo.com/l/?uddg=...)', () => {
     // given
     const html = `
-      <div class="result results_links results_links_deep web-result ">
-        <h2 class="result__title">
-          <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Freal.example%2Fpath&rut=abc">Real Site</a>
-        </h2>
-        <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Freal.example%2Fpath">snippet</a>
-      </div>
+      <tr><td><a rel="nofollow" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Freal.example%2Fpath&rut=abc" class='result-link'>Real Site</a></td></tr>
+      <tr><td class='result-snippet'>snippet</td></tr>
     `
 
     // when
@@ -88,17 +85,10 @@ describe('parseDdgHtml', () => {
     expect(results[0]?.url).toBe('https://real.example/path')
   })
 
-  test('skips blocks with no title (defensive against malformed responses)', () => {
-    // given
+  test('keeps results that have no snippet (snippet is optional in lite SERPs)', () => {
+    // given: a single result with no following result-snippet row
     const html = `
-      <div class="result results_links results_links_deep web-result ">
-        <a class="result__snippet" href="https://example.com/">snippet only</a>
-      </div>
-      <div class="result results_links results_links_deep web-result ">
-        <h2 class="result__title">
-          <a rel="nofollow" class="result__a" href="https://valid.example/">Valid</a>
-        </h2>
-      </div>
+      <tr><td><a rel="nofollow" href="https://valid.example/" class='result-link'>Valid</a></td></tr>
     `
 
     // when
@@ -107,5 +97,27 @@ describe('parseDdgHtml', () => {
     // then
     expect(results).toHaveLength(1)
     expect(results[0]?.title).toBe('Valid')
+    expect(results[0]?.url).toBe('https://valid.example/')
+    expect(results[0]?.snippet).toBe('')
+  })
+
+  test('skips snippet rows that have no preceding result-link (defensive against malformed responses)', () => {
+    // given
+    const html = `
+      <tr><td class='result-snippet'>orphan snippet with no link</td></tr>
+      <tr><td><a rel="nofollow" href="https://valid.example/" class='result-link'>Valid</a></td></tr>
+      <tr><td class='result-snippet'>real snippet</td></tr>
+    `
+
+    // when
+    const results = parseDdgHtml(html)
+
+    // then
+    expect(results).toHaveLength(1)
+    expect(results[0]).toEqual({
+      title: 'Valid',
+      url: 'https://valid.example/',
+      snippet: 'real snippet',
+    })
   })
 })

--- a/src/agent/tools/ddg.ts
+++ b/src/agent/tools/ddg.ts
@@ -1,12 +1,21 @@
-// DDG's no-JS HTML endpoint is the only major engine that serves a parseable,
-// key-free, registration-free SERP. We mimic a no-JS browser POST and parse the
-// result page.
+// DDG's no-JS "lite" endpoint is the only major engine that serves a
+// parseable, key-free, registration-free SERP. We mimic a no-JS browser POST
+// and parse the result page.
+//
+// We target `lite.duckduckgo.com/lite/` rather than `html.duckduckgo.com/html/`
+// because `html` has been gated by the "anomaly-modal" CAPTCHA flow since
+// early 2025 — even residential IPs hit it after 1-2 requests, since DDG
+// fingerprints TLS at the transport layer and Bun's TLS stack does not match
+// Chrome's. The `lite` endpoint exists for non-browser clients (text browsers,
+// accessibility tools) and has historically been gated less aggressively. The
+// markup is plain `<table>` rows with no CSS classes for layout — same
+// underlying index, just less rendering.
 //
 // TODO(engine-config): Make the search backend swappable via typeclaw.json once
 // we have a concrete second engine in mind (self-hosted SearXNG, Brave with a
 // user-supplied key, Tavily, ...). Defer until there's a real use case.
 
-const DDG_HTML_URL = 'https://html.duckduckgo.com/html/'
+const DDG_LITE_URL = 'https://lite.duckduckgo.com/lite/'
 
 // Browser-ish UA + Sec-Fetch-Mode: navigate is what SearXNG uses to evade DDG's
 // bot detection. Without these, the response is a CAPTCHA page.
@@ -43,7 +52,7 @@ export class DdgCaptchaError extends Error {
 
 async function fetchDdgHtml(query: string, signal?: AbortSignal): Promise<string> {
   const body = new URLSearchParams({ q: query }).toString()
-  const response = await fetch(DDG_HTML_URL, {
+  const response = await fetch(DDG_LITE_URL, {
     method: 'POST',
     headers: {
       ...BROWSER_HEADERS,
@@ -58,44 +67,44 @@ async function fetchDdgHtml(query: string, signal?: AbortSignal): Promise<string
   return await response.text()
 }
 
-// Per SearXNG's `is_ddg_captcha`, the CAPTCHA page contains an "anomaly" modal.
+// The `lite` endpoint's CAPTCHA page is plainer than `html`'s anomaly-modal:
+// it returns either an HTTP error (caught above) or a "challenge-form" page
+// asking the user to verify they're human. We also keep the legacy anomaly
+// markers as a belt-and-suspenders check in case DDG ever unifies the flows.
 function isCaptcha(html: string): boolean {
-  return html.includes('anomaly-modal') || html.includes('class="anomaly"')
+  return (
+    html.includes('challenge-form') ||
+    html.includes('Please verify you are a human') ||
+    html.includes('anomaly-modal') ||
+    html.includes('class="anomaly"')
+  )
 }
 
-// Parses the SERP HTML. The structure is stable enough that regex is safer than
-// pulling in cheerio: each result starts with `<div class="result results_links...">`
-// and contains one `<a class="result__a" href="...">title</a>` and (usually) one
-// `<a class="result__snippet" ...>snippet</a>`. We split on the opening tag rather
-// than try to balance closing divs (DDG's nesting varies between page revisions).
+// Parses the lite SERP HTML. Each result is a triplet of `<tr>` rows:
+//   1. <a class='result-link' href="…">Title</a>
+//   2. <td class='result-snippet'>snippet…</td>
+//   3. <span class='link-text'>display.url</span>
+// Rows 2 and 3 are sometimes absent (e.g. ad placements without snippets), so
+// we anchor on `result-link` and walk forward looking for the optional
+// snippet within a small window. Sponsored entries are wrapped in adjacent
+// rows that don't carry `result-link`, so they fall out naturally.
 export function parseDdgHtml(html: string): DdgResult[] {
   const results: DdgResult[] = []
-  const opener = /<div class="result results_links[^"]*">/g
-  const positions: number[] = []
-  for (const match of html.matchAll(opener)) {
-    if (match.index !== undefined) positions.push(match.index)
-  }
-  for (let i = 0; i < positions.length; i++) {
-    const start = positions[i] ?? 0
-    const end = positions[i + 1] ?? html.length
-    const block = html.slice(start, end)
-    const result = parseResultBlock(block)
-    if (result) results.push(result)
+  const linkRegex = /<a\s+[^>]*href=(['"])([^'"]+)\1[^>]*class=(['"])result-link\3[^>]*>([\s\S]*?)<\/a>/g
+  for (const match of html.matchAll(linkRegex)) {
+    const url = decodeDdgUrl(match[2] ?? '')
+    const title = stripHtml(match[4] ?? '').trim()
+    if (!url || !title) continue
+
+    const blockEnd = match.index !== undefined ? match.index + 2000 : html.length
+    const blockStart = match.index !== undefined ? match.index : 0
+    const window = html.slice(blockStart, blockEnd)
+    const snippetMatch = /<td\s+[^>]*class=(['"])result-snippet\1[^>]*>([\s\S]*?)<\/td>/.exec(window)
+    const snippet = snippetMatch ? stripHtml(snippetMatch[2] ?? '').trim() : ''
+
+    results.push({ title, url, snippet })
   }
   return results
-}
-
-function parseResultBlock(block: string): DdgResult | null {
-  const titleMatch = /<a [^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/.exec(block)
-  if (!titleMatch) return null
-  const url = decodeDdgUrl(titleMatch[1] ?? '')
-  const title = stripHtml(titleMatch[2] ?? '').trim()
-
-  const snippetMatch = /<a [^>]*class="result__snippet"[^>]*>([\s\S]*?)<\/a>/.exec(block)
-  const snippet = snippetMatch ? stripHtml(snippetMatch[1] ?? '').trim() : ''
-
-  if (!url || !title) return null
-  return { title, url, snippet }
 }
 
 // DDG sometimes wraps result URLs in a redirect like

--- a/src/agent/tools/websearch.test.ts
+++ b/src/agent/tools/websearch.test.ts
@@ -25,12 +25,8 @@ afterEach(() => {
 const ctx = {} as Parameters<typeof websearchTool.execute>[4]
 
 const MINIMAL_DDG_HTML = `
-<div class="result results_links results_links_deep web-result ">
-  <h2 class="result__title">
-    <a rel="nofollow" class="result__a" href="https://example.com/">Example Domain</a>
-  </h2>
-  <a class="result__snippet" href="https://example.com/">Example snippet text.</a>
-</div>
+<tr><td><a rel="nofollow" href="https://example.com/" class='result-link'>Example Domain</a></td></tr>
+<tr><td class='result-snippet'>Example snippet text.</td></tr>
 `
 
 describe('websearch tool: web (DuckDuckGo)', () => {
@@ -43,7 +39,7 @@ describe('websearch tool: web (DuckDuckGo)', () => {
 
     // then
     expect(fetchCalls).toHaveLength(1)
-    expect(fetchCalls[0]?.url).toBe('https://html.duckduckgo.com/html/')
+    expect(fetchCalls[0]?.url).toBe('https://lite.duckduckgo.com/lite/')
     expect(fetchCalls[0]?.init?.method).toBe('POST')
     expect(fetchCalls[0]?.init?.body).toBe('q=example')
 
@@ -60,7 +56,8 @@ describe('websearch tool: web (DuckDuckGo)', () => {
 
   test('returns a clear error when DuckDuckGo serves a CAPTCHA page', async () => {
     // given
-    fetchResponse = () => new Response('<div class="anomaly-modal">…</div>', { status: 200 })
+    fetchResponse = () =>
+      new Response('<form id="challenge-form">Please verify you are a human</form>', { status: 200 })
 
     // when
     const result = await websearchTool.execute('id', { query: 'spam' }, undefined, undefined, ctx)
@@ -102,9 +99,12 @@ describe('websearch tool: web (DuckDuckGo)', () => {
   test('respects the limit parameter', async () => {
     // given: 3 results in the SERP, ask for 2
     const html = `
-      <div class="result results_links results_links_deep web-result "><h2 class="result__title"><a class="result__a" href="https://a/">A</a></h2><a class="result__snippet" href="https://a/">a</a></div>
-      <div class="result results_links results_links_deep web-result "><h2 class="result__title"><a class="result__a" href="https://b/">B</a></h2><a class="result__snippet" href="https://b/">b</a></div>
-      <div class="result results_links results_links_deep web-result "><h2 class="result__title"><a class="result__a" href="https://c/">C</a></h2><a class="result__snippet" href="https://c/">c</a></div>
+      <tr><td><a href="https://a/" class='result-link'>A</a></td></tr>
+      <tr><td class='result-snippet'>a</td></tr>
+      <tr><td><a href="https://b/" class='result-link'>B</a></td></tr>
+      <tr><td class='result-snippet'>b</td></tr>
+      <tr><td><a href="https://c/" class='result-link'>C</a></td></tr>
+      <tr><td class='result-snippet'>c</td></tr>
     `
     fetchResponse = () => new Response(html, { status: 200 })
 


### PR DESCRIPTION
## Problem

The websearch tool's DuckDuckGo backend was hitting `html.duckduckgo.com/html/`. As of early 2025 that endpoint serves the anomaly-modal CAPTCHA flow and now blocks even residential IPs after 1-2 requests. The root cause is TLS-layer fingerprinting: DDG fingerprints JA3 at the transport layer, and Bun's TLS stack does not match Chrome's, so header-only impersonation cannot help.

## Fix

Swap the backend to `lite.duckduckgo.com/lite/`. The lite endpoint hits the same underlying search index with the same ranking, but is gated less aggressively because it exists for non-browser clients (text browsers, accessibility tools). This is not a fallback strategy — `html` is dropped entirely; `lite` is the new primary.

Wikipedia (the existing second source) remains unchanged and is the genuine cross-provider fallback for callers that explicitly pass `source: "wikipedia"`.

## Code changes

**`src/agent/tools/ddg.ts`**

URL constant updated. Parser rewritten to walk the lite SERP's `<table>`-row triplet structure — rows of `result-link` / `result-snippet` / `link-text` — instead of the html SERP's classed `<div>`s. CAPTCHA detector now also matches lite's `challenge-form` and "Please verify you are a human" markers; the legacy `anomaly-modal` / `class="anomaly"` markers are retained as belt-and-suspenders.

**`src/agent/tools/ddg.test.ts`**

Fixtures rewritten to lite-shape HTML. `parseDdgHtml` tests now cover the triplet structure plus a defensive "orphan snippet with no preceding result-link" case. New test for "snippet is optional in lite SERPs" replaces the old html-style "block with no title" test.

**`src/agent/tools/websearch.test.ts`**

URL assertion updated to `https://lite.duckduckgo.com/lite/`; CAPTCHA fixture updated to use challenge-form HTML.

## What this PR does not do

- **No swappable search backend via `typeclaw.json`.** The `TODO(engine-config)` comment is preserved verbatim. That requires schema design and a concrete second engine choice (Tavily / Brave / SearXNG).
- **No automatic Wikipedia fallback when DDG fails.** Today the agent must explicitly pass `source: "wikipedia"`. Keeping that behavior in this PR for scope discipline.
- **No cron silent-failure changes.** The original investigation also surfaced that the cron consumer logs to console only and never notifies on tool failures; that is a separate, larger change.

## Checks

```
$ bun run lint         # oxlint, 0 warnings, 0 errors (318 files)
$ bun run format:check # oxfmt, clean (337 files)
$ bun run typecheck    # tsgo --noEmit, clean
$ bun test             # 2148 pass, 0 fail (4274 expect() calls)
```

Manual smoke test against the live endpoint (same headers as the tool) returned 23 KB of real results with no CAPTCHA and no anomaly markers.