### PR TITLE
Guard shim installer against dangling symlinks in container

### DIFF
--- a/plugins/agent-browser/shim-install.test.ts
+++ b/plugins/agent-browser/shim-install.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { resolve as resolvePath } from 'node:path'
 
 import { installShim, type ShimFs } from './shim-install'
 
@@ -15,6 +16,7 @@ class FakeFs {
         if (!file) return null
         return { isSymbolicLink: () => file.kind === 'symlink' }
       },
+      statExists: (path) => this.resolveLink(path, 0) !== null,
       readlink: (path) => {
         const file = this.files.get(path)
         if (!file || file.kind !== 'symlink') throw new Error(`not a symlink: ${path}`)
@@ -49,6 +51,20 @@ class FakeFs {
       },
     }
   }
+
+  // Models POSIX stat() symlink-following: walks the chain and reports
+  // whether it terminates at a real file. Bounded to break cycles, matching
+  // the kernel's ELOOP behavior.
+  private resolveLink(path: string, depth: number): FakeFile | null {
+    if (depth > 32) return null
+    const file = this.files.get(path)
+    if (!file) return null
+    if (file.kind !== 'symlink') return file
+    const target = file.target.startsWith('/')
+      ? file.target
+      : resolvePath(path.split('/').slice(0, -1).join('/') || '/', file.target)
+    return this.resolveLink(target, depth + 1)
+  }
 }
 
 describe('installShim', () => {
@@ -57,6 +73,11 @@ describe('installShim', () => {
     fake.files.set('/usr/local/bin/agent-browser', {
       kind: 'symlink',
       target: '../../../root/.bun/install/global/node_modules/agent-browser/bin/agent-browser.js',
+    })
+    fake.files.set('/root/.bun/install/global/node_modules/agent-browser/bin/agent-browser.js', {
+      kind: 'file',
+      data: '#!/usr/bin/env node\n',
+      mode: 0o755,
     })
 
     const result = installShim({
@@ -93,7 +114,9 @@ describe('installShim', () => {
   test('per-binPath stash directory keeps global and local installs from colliding', () => {
     const fake = new FakeFs()
     fake.files.set('/usr/local/bin/agent-browser', { kind: 'symlink', target: '/global/real' })
+    fake.files.set('/global/real', { kind: 'file', data: 'global-bin', mode: 0o755 })
     fake.files.set('/agent/node_modules/.bin/agent-browser', { kind: 'symlink', target: '/local/real' })
+    fake.files.set('/local/real', { kind: 'file', data: 'local-bin', mode: 0o755 })
 
     const global = installShim({ binPath: '/usr/local/bin/agent-browser', shimEntry: '/x/shim.ts', fs: fake.fs() })
     const local = installShim({
@@ -124,6 +147,11 @@ describe('installShim', () => {
       kind: 'symlink',
       target: '../agent-browser/bin/agent-browser.js',
     })
+    fake.files.set('/agent/node_modules/agent-browser/bin/agent-browser.js', {
+      kind: 'file',
+      data: '#!/usr/bin/env node\n',
+      mode: 0o755,
+    })
 
     const first = installShim({
       binPath: '/agent/node_modules/.bin/agent-browser',
@@ -152,6 +180,7 @@ describe('installShim', () => {
       kind: 'symlink',
       target: '/some/upstream/bin',
     })
+    fake.files.set('/some/upstream/bin', { kind: 'file', data: 'real', mode: 0o755 })
 
     installShim({ binPath: '/usr/local/bin/agent-browser', shimEntry: '/x/shim.ts', fs: fake.fs() })
     fake.events.length = 0
@@ -169,5 +198,65 @@ describe('installShim', () => {
 
     expect(result.kind).toBe('no-upstream')
     expect(fake.events).toEqual([])
+  })
+
+  test('returns no-upstream when binPath is a dangling symlink, leaving the filesystem untouched', () => {
+    // Reproduces the production bug: host bun install creates
+    // /agent/node_modules/.bin/agent-browser pointing into a node_modules
+    // tree that doesn't exist inside the container. lstat sees the link
+    // entry and used to proceed; now we follow the link and bail.
+    const fake = new FakeFs()
+    fake.files.set('/agent/node_modules/.bin/agent-browser', {
+      kind: 'symlink',
+      target: '../agent-browser/bin/agent-browser.js',
+    })
+
+    const result = installShim({
+      binPath: '/agent/node_modules/.bin/agent-browser',
+      shimEntry: '/x/shim.ts',
+      fs: fake.fs(),
+    })
+
+    expect(result.kind).toBe('no-upstream')
+    expect(fake.events).toEqual([])
+    const entry = fake.files.get('/agent/node_modules/.bin/agent-browser')
+    if (!entry || entry.kind !== 'symlink') throw new Error('original symlink was mutated')
+    expect(entry.target).toBe('../agent-browser/bin/agent-browser.js')
+  })
+
+  test('self-heals stale wrapper when stash target is missing', () => {
+    // Container restart wipes the image-owned STASH_ROOT but leaves the
+    // bind-mounted wrapper intact. Without self-heal, isAlreadyShim would
+    // short-circuit and the wrapper would ENOENT every invocation forever.
+    const fake = new FakeFs()
+    fake.files.set('/agent/node_modules/.bin/agent-browser', {
+      kind: 'symlink',
+      target: '../agent-browser/bin/agent-browser.js',
+    })
+    fake.files.set('/agent/node_modules/agent-browser/bin/agent-browser.js', {
+      kind: 'file',
+      data: '#!/usr/bin/env node\n',
+      mode: 0o755,
+    })
+
+    const first = installShim({
+      binPath: '/agent/node_modules/.bin/agent-browser',
+      shimEntry: '/x/shim.ts',
+      fs: fake.fs(),
+    })
+    if (first.kind !== 'installed') throw new Error('expected initial install to succeed')
+
+    fake.files.delete(first.stashTarget)
+    fake.events.length = 0
+
+    const second = installShim({
+      binPath: '/agent/node_modules/.bin/agent-browser',
+      shimEntry: '/x/shim.ts',
+      fs: fake.fs(),
+    })
+
+    expect(second.kind).toBe('no-upstream')
+    expect(fake.events).toEqual(['unlink:/agent/node_modules/.bin/agent-browser'])
+    expect(fake.files.has('/agent/node_modules/.bin/agent-browser')).toBe(false)
   })
 })

--- a/plugins/agent-browser/shim-install.ts
+++ b/plugins/agent-browser/shim-install.ts
@@ -1,4 +1,13 @@
-import { lstatSync, readFileSync, readlinkSync, renameSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
+import {
+  lstatSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { dirname, join, resolve as resolvePath } from 'node:path'
 
 import { REAL_BIN_ENV } from './shim'
@@ -17,6 +26,11 @@ export type InstallShimOptions = {
 
 export type ShimFs = {
   lstat: (path: string) => { isSymbolicLink: () => boolean } | null
+  // statExists follows symlinks: a broken symlink (link entry exists, target
+  // does not) returns false. This is the discriminator we need to skip
+  // installation when the host bind-mount surfaces dangling node_modules/.bin
+  // entries inside the container — see installShim's upstream guard.
+  statExists: (path: string) => boolean
   readlink: (path: string) => string
   readFile: (path: string) => string
   rename: (from: string, to: string) => void
@@ -41,7 +55,23 @@ export function installShim(opts: InstallShimOptions = {}): InstallShimResult {
   const stat = fs.lstat(binPath)
   if (stat === null) return { kind: 'no-upstream', binPath }
 
-  if (isAlreadyShim(binPath, fs)) return { kind: 'already-installed', binPath }
+  if (isAlreadyShim(binPath, fs)) {
+    if (fs.statExists(stashTarget)) return { kind: 'already-installed', binPath }
+    // Wrapper survived a container restart but the image-owned stash did not
+    // (STASH_ROOT lives outside the bind-mount). The wrapper now points at a
+    // non-existent stashTarget, so executing it would ENOENT. Drop it and
+    // report no-upstream — there is nothing valid here to preserve, and the
+    // global-path shim (if it exists) stands on its own.
+    fs.unlink(binPath)
+    return { kind: 'no-upstream', binPath }
+  }
+
+  // Bind-mounted node_modules/.bin entries can be dangling symlinks inside
+  // the container (host ran bun install; the container image did not). lstat
+  // alone passes for those. Follow the link with statExists before mutating
+  // anything — otherwise we'd stash a broken symlink and write a wrapper
+  // pointing at a target that never resolves.
+  if (!fs.statExists(binPath)) return { kind: 'no-upstream', binPath }
 
   const realBin = resolveCurrentTarget(binPath, stat, fs)
   fs.mkdirp(stashDir)
@@ -105,6 +135,14 @@ function defaultFs(): ShimFs {
         return lstatSync(path)
       } catch {
         return null
+      }
+    },
+    statExists: (path) => {
+      try {
+        statSync(path)
+        return true
+      } catch {
+        return false
       }
     },
     readlink: readlinkSync,


### PR DESCRIPTION
## Why

Inside the TypeClaw container, `agent-browser --version` failed at runtime:

```
ENOENT: no such file or directory, posix_spawn '/usr/local/lib/typeclaw-agent-browser/agent-node-modules-bin-agent-browser/agent-browser-real'
```

The skill markdown claimed "agent-browser preinstalled" but the binary exploded on every invocation.

The bug was confirmed live by inspecting the container: the directory `/usr/local/lib/typeclaw-agent-browser/agent-node-modules-bin-agent-browser/` did not exist, which is the exact slug derived from `/agent/node_modules/.bin/agent-browser` — matching the broken stash path precisely.

## Root cause

Cross-stage filesystem asymmetry (see AGENTS.md "Stages"):

1. `src/init/index.ts` writes `agent-browser` as a dependency in scaffolded agents' `package.json`.
2. Host-side `bun install` creates `<agentDir>/node_modules/.bin/agent-browser` as a symlink pointing to `../agent-browser/bin/agent-browser.js`.
3. The agent folder bind-mounts to `/agent` inside the container at runtime.
4. `src/init/dockerfile.ts` only runs `bun install -g agent-browser` (global) — the container image **never** runs `bun install` in `/agent`. So `/agent/node_modules/.bin/agent-browser` is a **dangling symlink** inside the container: the link entry exists, but its target does not.
5. The old `installShim` called `lstat` (link entry exists → passes) and proceeded to:
   - Create the stash dir under `STASH_ROOT` (image-owned, not bind-mounted)
   - Write a wrapper script **back** to the bind-mounted `binPath`
   - Stash a new broken symlink at `stashTarget`
6. The wrapper persisted on the host via the bind-mount. On container restart, `STASH_ROOT` was wiped (image reset), but the wrapper survived. `isAlreadyShim` returned `true` on every subsequent plugin load, so the corrupt state was **permanent**.

## What changed

### `plugins/agent-browser/shim-install.ts`

**`statExists(path)` added to `ShimFs`** — follows symlinks and reports whether the target exists (`statSync` + try/catch in `defaultFs`). A dangling symlink (entry exists, target absent) returns `false`.

**Dangling-symlink guard**: after `lstat` passes, `statExists(binPath)` is checked before any filesystem mutation. A dangling `binPath` now returns `'no-upstream'` cleanly with zero side effects. This is the primary fix.

**Stale-wrapper self-heal**: when `isAlreadyShim` is `true` but `statExists(stashTarget)` is `false` (container restart wiped `STASH_ROOT`; bind-mounted wrapper survived), the stale wrapper is unlinked and `'no-upstream'` is returned. Oxidized containers recover automatically on the next plugin load without manual intervention.

### `plugins/agent-browser/shim-install.test.ts`

- **`FakeFs` updated** to model POSIX `stat()` symlink-following — bounded to 32 hops to match kernel ELOOP behavior.
- **Existing tests updated** to register symlink targets alongside the link entries (the old tests were incidentally compatible with the bug; new semantics require targets to exist for `statExists` to return `true`).
- **New test**: `'returns no-upstream when binPath is a dangling symlink, leaving the filesystem untouched'` — reproduces the exact production failure. Asserts `result.kind === 'no-upstream'` and that `fake.events` is empty (no filesystem mutations).
- **New test**: `'self-heals stale wrapper when stash target is missing'` — covers the container-restart recovery path. Asserts `result.kind === 'no-upstream'` and that only an `unlink` of the stale wrapper was emitted.

## Scope and non-changes

- **No behavior change for the working (global) install path.** The global binary is a real file; `statExists` returns `true` and the install proceeds exactly as before.
- **`KNOWN_BIN_PATHS.local` is retained**, not removed. With the `statExists` guard in place, the local path is a clean no-op unless `bun install` is actually run inside the container (currently never). Reviewed by Oracle; removing the local path would be a separate architectural decision.
- **The skill's "preinstalled" claim** is now accurate for the global path. For the local path the installer exits with `'no-upstream'` — correct semantics, no observable user impact.

## Checks

```
bun run typecheck  # 0 errors
bun run lint       # 0 warnings, 0 errors
bun run format     # clean (oxfmt --write)
bun test           # 2264 pass, 0 fail (full suite)
                   # shim-install.test.ts: 8 pass (6 existing + 2 new)
```