### PR TITLE
Time-bound session.idle hooks so a hung plugin cannot wedge the channel drain

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1621,6 +1621,71 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     expect(events).toEqual(['idle:ses_fake_1:-', 'end:ses_fake_1'])
     expect(sessions[0]!.disposed).toBe(1)
   })
+
+  test('a hung session.idle hook does not wedge the drain loop forever', async () => {
+    // given a session.idle hook that never resolves (production failure
+    // mode: a plugin handler awaiting a network call that hangs). Without
+    // the watchdog, `live.draining` would stay `true` and every subsequent
+    // mention would silently enqueue forever. The test seam shortens the
+    // chain ceiling so the path is exercisable in milliseconds.
+    const dir = await tempDir()
+    const sessions: FakeSession[] = []
+    const logs: string[] = []
+    const hooks: HookBus = {
+      registerAll: () => {},
+      unregisterAll: () => {},
+      runSessionStart: async () => {},
+      runSessionEnd: async () => {},
+      runSessionIdle: () => new Promise(() => {}),
+      runSessionPrompt: async () => {},
+      runToolBefore: async () => undefined,
+      runToolAfter: async () => {},
+      count: () => 0,
+    }
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      sessionIdleTimeoutMs: 30,
+      logger: {
+        info: (m) => logs.push(`info:${m}`),
+        warn: (m) => logs.push(`warn:${m}`),
+        error: (m) => logs.push(`error:${m}`),
+      },
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        sessions.push(fake)
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: `ses_fake_${sessions.length}`,
+          dispose: async () => {
+            fake.dispose()
+          },
+          hooks,
+          getTranscriptPath: () => undefined,
+        }
+      },
+    })
+
+    // when a first message engages the bot and a second arrives after the
+    // idle-hook watchdog should have fired
+    const start = Date.now()
+    await router.route(inbound({ text: 'first' }))
+    await router.__testing!.flushDebounce(KEY)
+    await router.route(inbound({ externalMessageId: 'm2', text: 'second' }))
+    await router.__testing!.flushDebounce(KEY)
+    const elapsed = Date.now() - start
+
+    // then both prompts ran (the second is the real proof — without the
+    // watchdog the drain loop would still be parked inside the hung idle
+    // hook and `live.draining` would block enqueue from firing a new drain),
+    // the run completed within the watchdog window, and a warning naming
+    // the timeout was emitted so an operator can attribute the hang
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(elapsed).toBeLessThan(2000)
+    const idleWarn = logs.find((l) => l.includes('warn:[channels]') && l.includes('session.idle hook threw'))
+    expect(idleWarn).toBeDefined()
+    expect(idleWarn).toMatch(/session\.idle timed out after 30ms/)
+  })
 })
 
 describe('ChannelRouter channel name resolver', () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -96,6 +96,19 @@ export const ENSURE_LIVE_TIMEOUT_MS = 30_000
 export const RESOLVE_CHANNEL_NAMES_TIMEOUT_MS = 5_000
 export const FETCH_HISTORY_TIMEOUT_MS = 5_000
 
+// Watchdog over the whole session.idle hook chain. The drain loop awaits
+// `fireSessionIdle` between turns; a single hung plugin handler (e.g. a
+// memory-logger awaiting a network call that never resolves) wedges the
+// loop with `live.draining` stuck `true`, which means subsequent mention
+// inbounds enqueue silently and never fire. Observe-decisions still log
+// because engagement runs in `route()` before the draining check, so the
+// symptom from logs alone is "thread receives observed lines forever
+// after the last `prompted elapsed_ms=...`". Bounding the chain here
+// matches the ensureLive watchdog (30s) so a misbehaving plugin
+// degrades the current turn instead of bricking the channel until
+// container restart. Per-handler attribution lives in plugin/hooks.ts.
+export const SESSION_IDLE_TIMEOUT_MS = 30_000
+
 // Two-axis loop guard for peer-bot conversation. Peer bots route into
 // engagement under the SAME rules as humans, so a small ring (A→B→C→A) or
 // a fast cascade can otherwise ping-pong without bound. The guard trips
@@ -292,6 +305,9 @@ export type CreateChannelRouterOptions = {
   resolveChannelNamesTimeoutMs?: number
   // Test seam: per-callback ceiling for history fetches.
   fetchHistoryTimeoutMs?: number
+  // Test seam: bound the session.idle hook chain so the timeout path is
+  // exercisable in tens of milliseconds instead of the 30s default.
+  sessionIdleTimeoutMs?: number
 }
 
 export function createChannelRouter(options: CreateChannelRouterOptions): ChannelRouter {
@@ -300,6 +316,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const ensureLiveTimeoutMs = options.ensureLiveTimeoutMs ?? ENSURE_LIVE_TIMEOUT_MS
   const resolveChannelNamesTimeoutMs = options.resolveChannelNamesTimeoutMs ?? RESOLVE_CHANNEL_NAMES_TIMEOUT_MS
   const fetchHistoryTimeoutMs = options.fetchHistoryTimeoutMs ?? FETCH_HISTORY_TIMEOUT_MS
+  const sessionIdleTimeoutMs = options.sessionIdleTimeoutMs ?? SESSION_IDLE_TIMEOUT_MS
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
   const outboundCallbacks = new Map<ChannelKey['adapter'], Set<OutboundCallback>>()
@@ -746,13 +763,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
   const fireSessionIdle = async (live: LiveSession): Promise<void> => {
     if (!live.hooks) return
+    const work = live.hooks.runSessionIdle({
+      sessionId: live.sessionId,
+      parentTranscriptPath: live.getTranscriptPath?.(),
+      idleMs: 0,
+      origin: buildLiveOrigin(live),
+    })
     try {
-      await live.hooks.runSessionIdle({
-        sessionId: live.sessionId,
-        parentTranscriptPath: live.getTranscriptPath?.(),
-        idleMs: 0,
-        origin: buildLiveOrigin(live),
-      })
+      await raceWithTimeout(work, sessionIdleTimeoutMs, `[channels] ${live.keyId} session.idle`)
     } catch (err) {
       logger.warn(`[channels] session.idle hook threw for ${live.keyId}: ${describe(err)}`)
     }

--- a/src/plugin/hooks.test.ts
+++ b/src/plugin/hooks.test.ts
@@ -113,6 +113,45 @@ describe('HookBus session.idle / session.start / session.end', () => {
   })
 })
 
+describe('HookBus session.idle per-handler timeout', () => {
+  test('a hung handler is bounded; the offending plugin is named; later handlers still run', async () => {
+    // given a bus where the first session.idle handler never resolves and
+    // the second is observable. the per-handler timeout is a test seam so
+    // the timeout fires in milliseconds instead of the production 25s.
+    const errors: { plugin: string; message: string }[] = []
+    const recordLogger = (pluginName: string) => ({
+      info: () => {},
+      warn: () => {},
+      error: (m: string) => errors.push({ plugin: pluginName, message: m }),
+    })
+    const bus = createHookBus({ idleHandlerTimeoutMs: 30 })
+    bus.registerAll('hung-plugin', '/agent', recordLogger('hung-plugin'), {
+      'session.idle': () => new Promise(() => {}),
+    })
+    let secondRan = false
+    bus.registerAll('healthy-plugin', '/agent', recordLogger('healthy-plugin'), {
+      'session.idle': () => {
+        secondRan = true
+      },
+    })
+
+    // when the chain runs
+    const start = Date.now()
+    await bus.runSessionIdle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 0 })
+    const elapsed = Date.now() - start
+
+    // then the chain returned within the per-handler ceiling, the offending
+    // plugin's logger received the timeout error with attribution, and the
+    // healthy plugin still got to run
+    expect(elapsed).toBeLessThan(500)
+    expect(secondRan).toBe(true)
+    const hungError = errors.find((e) => e.plugin === 'hung-plugin')
+    expect(hungError?.message).toMatch(/plugin hung-plugin session\.idle timed out after 30ms/)
+    // the healthy plugin must not have been blamed
+    expect(errors.find((e) => e.plugin === 'healthy-plugin')).toBeUndefined()
+  })
+})
+
 describe('HookBus unregisterAll', () => {
   test('removes hooks for a single plugin and leaves others intact', () => {
     const bus = createHookBus()

--- a/src/plugin/hooks.ts
+++ b/src/plugin/hooks.ts
@@ -11,6 +11,15 @@ import type {
   ToolBeforeResult,
 } from './types'
 
+// Per-handler ceiling for session.idle. The channels-side router wraps the
+// whole chain at SESSION_IDLE_TIMEOUT_MS = 30s; this inner bound fires
+// first so the offending plugin gets named in the logs instead of the
+// chain-level timeout swallowing attribution. A handler that legitimately
+// needs longer (large transcript replay, dreaming subagent) is rare — and
+// `setTimeout`-driven plugins like memory-logger normally return in
+// milliseconds. 25s leaves headroom under the chain watchdog.
+export const IDLE_HANDLER_TIMEOUT_MS = 25_000
+
 export type RegisteredHook<K extends keyof Hooks> = {
   pluginName: string
   agentDir: string
@@ -30,6 +39,13 @@ export type HookBus = {
   count: (name: keyof Hooks) => number
 }
 
+export type CreateHookBusOptions = {
+  // Test seam: per-handler ceiling for session.idle invocations. Lets the
+  // timeout path be exercised in tens of milliseconds instead of the 25s
+  // production default.
+  idleHandlerTimeoutMs?: number
+}
+
 type Registries = {
   'session.start': RegisteredHook<'session.start'>[]
   'session.end': RegisteredHook<'session.end'>[]
@@ -39,7 +55,8 @@ type Registries = {
   'tool.after': RegisteredHook<'tool.after'>[]
 }
 
-export function createHookBus(): HookBus {
+export function createHookBus(options: CreateHookBusOptions = {}): HookBus {
+  const idleHandlerTimeoutMs = options.idleHandlerTimeoutMs ?? IDLE_HANDLER_TIMEOUT_MS
   const r: Registries = {
     'session.start': [],
     'session.end': [],
@@ -96,7 +113,11 @@ export function createHookBus(): HookBus {
     async runSessionIdle(event) {
       for (const reg of r['session.idle']) {
         try {
-          await reg.handler(event, ctx(reg))
+          await raceWithTimeout(
+            Promise.resolve(reg.handler(event, ctx(reg))),
+            idleHandlerTimeoutMs,
+            `plugin ${reg.pluginName} session.idle`,
+          )
         } catch (err) {
           reportHookError(reg, 'session.idle', err)
         }
@@ -152,4 +173,16 @@ export function createHookBus(): HookBus {
 function reportHookError(reg: { logger: PluginLogger }, hook: keyof Hooks, err: unknown): void {
   const message = err instanceof Error ? err.message : String(err)
   reg.logger.error(`hook ${hook} threw: ${message}`)
+}
+
+async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+  })
+  try {
+    return await Promise.race([work, timeout])
+  } finally {
+    if (timer !== null) clearTimeout(timer)
+  }
 }


### PR DESCRIPTION
## Summary

A single hung plugin handler in the `session.idle` chain can park the channel router's drain loop forever. Because engagement decisions run in `route()` *before* the `live.draining` check, observe-decisions still log normally while every queued mention silently piles up in `live.promptQueue` and never fires. From the operator's seat the bot looks alive but unresponsive: typing-heartbeat timeouts, no `prompting batch=` lines, only `observed id=...`. Container restart is the only recovery.

This PR bounds the hook chain at two layers, mirroring how `ensureLive` is already protected, and gives operators enough log attribution to tell *which* plugin hung.

## What changed

- `src/channels/router.ts` — wrap `fireSessionIdle` in `raceWithTimeout` against a new `SESSION_IDLE_TIMEOUT_MS = 30_000` (matching `ENSURE_LIVE_TIMEOUT_MS`). New `sessionIdleTimeoutMs` test seam on `CreateChannelRouterOptions` mirrors the existing `ensureLiveTimeoutMs` / `fetchHistoryTimeoutMs` pattern. On timeout, the existing `try/catch` logs `[channels] session.idle hook threw for <keyId>: ... timed out after 30000ms` and the drain loop continues — `live.draining` becomes `false` in the existing `finally`, queued mentions actually drain.
- `src/plugin/hooks.ts` — wrap each `session.idle` handler in `raceWithTimeout` against a new `IDLE_HANDLER_TIMEOUT_MS = 25_000`. The inner ceiling fires *before* the outer chain watchdog so the offending plugin gets named (`plugin <name> session.idle timed out after 25000ms`) instead of the chain-level timeout swallowing attribution. New `idleHandlerTimeoutMs` option on `createHookBus` is the test seam; existing 34 call sites pass nothing and keep the production default. A local `raceWithTimeout` helper duplicates the one in `router.ts` to avoid a cross-module dependency from `plugin/` to `channels/`.

## Why session.idle and not the other hooks

`session.idle` is the only hook the channels-side drain `await`s in its hot loop ([`router.ts:842`](src/channels/router.ts)). The other hooks either run on lifecycle boundaries (`session.start`/`session.end`) or in paths that already isolate failure (`session.prompt` / `tool.before` / `tool.after` mutate event payloads but don't gate the drain). Scope is intentionally minimal — drop-in fix for the observed wedge, no behavior change for healthy plugins.

## Why two layers instead of one

The router-level timeout alone would catch the wedge but log only `[channels] <key> session.idle timed out after 30000ms` — operators would have to grep plugin code to find the culprit. Per-handler attribution at the bus level names the offending plugin in the same log line, so first-line triage is `grep "plugin .* session.idle timed out"`. Belt and suspenders: a misbehaving plugin that catches and ignores the inner timeout error still gets caught by the outer chain watchdog.

## Production trace this fixes

For a 21-minute observation window in a 노답이 deployment:

```
[channels] slack-bot:T...:C...:1778254357.941449 prompted elapsed_ms=39062
[channels] slack-bot:T...:C...:1778254357.941449 observed id=1778254955.594189
[channels] slack-bot:T...:C...:1778254357.941449 observed id=1778255029.468679
... 13 more observed lines ...
[channels] slack-bot:T...:C...:1778254357.941449: typing heartbeat timed out after 120000ms
... no `prompting batch=` ever again on this thread ...
```

`prompted/prompting` count was 21:21 (no stuck `prompt()`), and the only thing left running was the post-prompt `await fireSessionIdle(live)` at [`router.ts:842`](src/channels/router.ts) — confirmed by reading the surrounding code: `fireSessionIdle` was the *only* unbounded `await` between `prompted elapsed_ms=...` and the `finally` block that resets `live.draining`. With this PR, the same scenario logs a warning naming the plugin within 30s and the drain resumes.

## Tests

- `src/plugin/hooks.test.ts` — new test in a `HookBus session.idle per-handler timeout` describe block:
  - given a session.idle handler that never resolves and a healthy second handler
  - when the chain runs (via the test seam at `idleHandlerTimeoutMs: 30`)
  - then the chain returns under the watchdog, the offending plugin's logger sees `plugin hung-plugin session.idle timed out after 30ms`, the healthy handler still ran, and the healthy plugin was not blamed
- `src/channels/router.test.ts` — new test in `ChannelRouter plugin lifecycle hooks`:
  - given a `runSessionIdle` that returns a never-resolving promise (production failure mode)
  - when two messages route through the engage path with `sessionIdleTimeoutMs: 30`
  - then both prompts fire (proving `live.draining` was released), elapsed time is bounded, and a `session.idle hook threw ... timed out after 30ms` warning is logged

Pattern mirrors the existing `ensureLive watchdog` tests at [`router.test.ts:401`](src/channels/router.test.ts) so future maintainers find the timeout family in one place.

## Verification

- `bun test` — 2266 pass, 0 fail
- `bun run typecheck` — clean
- `bun run lint` — 0 warnings, 0 errors
- `bun run format` — clean

## Operator playbook after merge

To find which plugin is wedging idle hooks, grep:

```sh
typeclaw logs | grep -E 'plugin .* session\.idle timed out|session\.idle hook threw'
```

The first pattern names the plugin; the second is the channels-side fallback if the inner timeout fails for any reason. A healthy fleet should see neither line.
