### PR TITLE
Fix Chrome shared-library deps on amd64 + correct stale cache path in comments

### DIFF
--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { dockerfileSchema } from '@/config/config'
 
-import { buildDockerfile } from './dockerfile'
+import { buildDockerfile, CHROME_RUNTIME_APT_PACKAGES_AMD64 } from './dockerfile'
 
 // Layer ordering, cache-mount preservation, and on-disk write behavior are
 // covered by integration tests in src/init/index.test.ts. This file only
@@ -104,5 +104,50 @@ describe('buildDockerfile feature toggles', () => {
   test('rejects version strings containing whitespace or "=" (apt-injection guard)', () => {
     expect(() => dockerfileSchema.parse({ gh: '2.40.0 curl' })).toThrow(/must not contain whitespace/)
     expect(() => dockerfileSchema.parse({ tmux: '3.3a=evil' })).toThrow(/must not contain whitespace/)
+  })
+})
+
+function amd64ElseBranchPackages(out: string): string[] {
+  const m = out.match(/else \\\n\s+apt-get install -y --no-install-recommends \\\n\s+([^\n]+); \\\n\s+fi/)
+  if (!m || !m[1]) throw new Error('amd64 else-branch apt-get install line not found')
+  return m[1].split(/\s+/).filter(Boolean)
+}
+
+function arm64IfBranchPackages(out: string): string[] {
+  const m = out.match(
+    /if \[ "\$TARGETARCH" = "arm64" \]; then \\\n\s+apt-get install -y --no-install-recommends ([^\n]+); \\\n\s+else/,
+  )
+  if (!m || !m[1]) throw new Error('arm64 if-branch apt-get install line not found')
+  return m[1].split(/\s+/).filter(Boolean)
+}
+
+describe('Chrome runtime deps (amd64)', () => {
+  test('amd64 branch installs libglib2.0-0t64 — without it Chrome dies on launch with `libglib-2.0.so.0: cannot open shared object file`', () => {
+    expect(amd64ElseBranchPackages(buildDockerfile())).toContain('libglib2.0-0t64')
+  })
+
+  test('amd64 branch installs the full Playwright-tested chromium dep set (regression guard against silent drops on agent-browser refactors)', () => {
+    const pkgs = amd64ElseBranchPackages(buildDockerfile())
+    for (const p of CHROME_RUNTIME_APT_PACKAGES_AMD64) expect(pkgs).toContain(p)
+  })
+
+  test('amd64 branch does not install fonts (the reported failure is linker-level, not glyph rendering; CJK fonts cost ~50MB+ for no launch impact)', () => {
+    const pkgs = amd64ElseBranchPackages(buildDockerfile())
+    expect(pkgs.some((p) => p.startsWith('fonts-'))).toBe(false)
+  })
+
+  test('arm64 branch installs chromium only — Chrome runtime libs are unnecessary when chromium pulls its own deps via apt', () => {
+    const pkgs = arm64IfBranchPackages(buildDockerfile())
+    expect(pkgs).toContain('chromium')
+    for (const p of CHROME_RUNTIME_APT_PACKAGES_AMD64) expect(pkgs).not.toContain(p)
+  })
+
+  test('Chrome runtime deps are installed in Layer 2 (before agent-browser CLI install in Layer 4), not only via the Layer 5 --with-deps backstop', () => {
+    const out = buildDockerfile()
+    const layer2Idx = out.indexOf('libglib2.0-0t64')
+    const layer4Idx = out.indexOf('bun install -g agent-browser')
+    expect(layer2Idx).toBeGreaterThan(-1)
+    expect(layer4Idx).toBeGreaterThan(-1)
+    expect(layer2Idx).toBeLessThan(layer4Idx)
   })
 })

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -8,6 +8,48 @@ export const DOCKERFILE = 'Dockerfile'
 // the package set is self-documenting at a glance.
 const BASELINE_APT_PACKAGES = ['git', 'ca-certificates', 'curl', 'gnupg'] as const
 
+// Shared-library runtime deps Chrome for Testing needs to launch on amd64
+// Debian trixie (base of `oven/bun:1-slim`). `agent-browser install
+// --with-deps` (v0.27.0) is supposed to install these but silently no-ops:
+// its hardcoded list omits `libglib2.0-0t64`, so Chrome dies on launch
+// with `libglib-2.0.so.0: cannot open shared object file` even though the
+// binary download and `--with-deps` both exit 0. We install the full
+// Playwright-tested chromium dep set here in Layer 2 so the bug doesn't
+// recur if upstream omits another package; Layer 5 still calls
+// `--with-deps` as a no-op-on-cache-hit backstop for future deps.
+//
+// Package list mirrors Playwright's `debian13-x64` chromium deps in
+// nativeDeps.ts (https://github.com/microsoft/playwright). t64-suffixed
+// names are the trixie-renamed variants from the 64-bit time_t ABI
+// transition; SONAMEs (libglib-2.0.so.0 etc.) are unchanged. Packages
+// without t64 here have no t64 sibling on trixie — verified against
+// packages.debian.org/trixie. Fonts are intentionally omitted: the
+// reported failure is launch-time linker errors, not rendering glyphs;
+// font packages (esp. fonts-noto-cjk) cost ~50MB+ for no launch impact.
+export const CHROME_RUNTIME_APT_PACKAGES_AMD64 = [
+  'libasound2t64',
+  'libatk-bridge2.0-0t64',
+  'libatk1.0-0t64',
+  'libatspi2.0-0t64',
+  'libcairo2',
+  'libcups2t64',
+  'libdbus-1-3',
+  'libdrm2',
+  'libgbm1',
+  'libglib2.0-0t64',
+  'libnspr4',
+  'libnss3',
+  'libpango-1.0-0',
+  'libx11-6',
+  'libxcb1',
+  'libxcomposite1',
+  'libxdamage1',
+  'libxext6',
+  'libxfixes3',
+  'libxkbcommon0',
+  'libxrandr2',
+] as const
+
 type AptFeature = {
   toAptArgs: (toggle: DockerfileFeatureToggle) => string[]
 }
@@ -82,6 +124,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\
       ${aptArgs.join(' ')} \\
  && if [ "$TARGETARCH" = "arm64" ]; then \\
       apt-get install -y --no-install-recommends chromium; \\
+    else \\
+      apt-get install -y --no-install-recommends \\
+        ${CHROME_RUNTIME_APT_PACKAGES_AMD64.join(' ')}; \\
     fi
 
 # Layer 3 (stable, arm64 only): point agent-browser at the apt-installed
@@ -102,13 +147,16 @@ RUN --mount=type=cache,target=/root/.bun/install/cache,sharing=locked \\
     bun install -g agent-browser
 
 # Layer 5 (heavy, amd64 only): download the pinned Chrome for Testing build
-# into ~/.agent-browser/browsers/ and apt-install the libs it needs. NO
-# cache mount on ~/.agent-browser/browsers/: the runtime needs the binary
-# in the image, and cache mounts are excluded from the final image. The
-# apt-cache mounts ARE used for the --with-deps system libs install.
-# Kept last so it benefits from every layer above being cached, and so
-# changes to git or the apt base don't invalidate hundreds of MB of Chrome
-# state.
+# into ~/.agent-browser/browsers/. NO cache mount on that path: the runtime
+# needs the binary in the image, and cache mounts are excluded from the
+# final image. The system shared libraries Chrome needs at runtime were
+# already installed in Layer 2 above (CHROME_RUNTIME_APT_PACKAGES_AMD64);
+# we still pass --with-deps as a defense-in-depth backstop so a future
+# agent-browser bump that adds new deps installs them automatically. The
+# apt-cache mounts make that backstop a near-no-op when Layer 2 already
+# satisfied everything. Kept last so it benefits from every layer above
+# being cached, and so changes to git or the apt base don't invalidate
+# hundreds of MB of Chrome state.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \\
     if [ "$TARGETARCH" != "arm64" ]; then \\

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -38,8 +38,8 @@ export function buildDockerfile(config: DockerfileConfig = defaultConfig()): str
 # package manager caches (.deb files, bun's tarball cache) where we want
 # fast rebuilds without bloating the runtime image. Cache mounts are
 # explicitly NOT used for tool output that the runtime needs (e.g. the
-# Chrome for Testing binary at \`~/.cache/agent-browser\`); those go through
-# normal layers so they ship with the image.
+# Chrome for Testing binary under \`~/.agent-browser/browsers/\`); those go
+# through normal layers so they ship with the image.
 
 FROM oven/bun:1-slim
 
@@ -102,10 +102,10 @@ RUN --mount=type=cache,target=/root/.bun/install/cache,sharing=locked \\
     bun install -g agent-browser
 
 # Layer 5 (heavy, amd64 only): download the pinned Chrome for Testing build
-# into ~/.cache/agent-browser and apt-install the libs it needs. NO cache
-# mount on ~/.cache/agent-browser: the runtime needs the binary in the
-# image, and cache mounts are excluded from the final image. The apt-cache
-# mounts ARE used for the --with-deps system libs install.
+# into ~/.agent-browser/browsers/ and apt-install the libs it needs. NO
+# cache mount on ~/.agent-browser/browsers/: the runtime needs the binary
+# in the image, and cache mounts are excluded from the final image. The
+# apt-cache mounts ARE used for the --with-deps system libs install.
 # Kept last so it benefits from every layer above being cached, and so
 # changes to git or the apt base don't invalidate hundreds of MB of Chrome
 # state.

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -970,13 +970,13 @@ describe('writeDockerAssets', () => {
     await writeDockerAssets(root)
 
     const dockerfile = await readFile(join(root, 'Dockerfile'), 'utf8')
-    // Common cache-optimization mistake: mounting ~/.cache/agent-browser
+    // Common cache-optimization mistake: mounting ~/.agent-browser/browsers
     // would make rebuilds faster but ship a broken image, because cache
     // mounts are excluded from the final image. The Chrome for Testing
-    // binary lives at ~/.cache/agent-browser/<version>/chrome and the
-    // runtime calls into it directly; if it disappears, the agent's
+    // binary lives at ~/.agent-browser/browsers/chrome-<version>/chrome and
+    // the runtime calls into it directly; if it disappears, the agent's
     // browser tool fails to launch on every container start.
-    expect(dockerfile).not.toMatch(/--mount=type=cache,target=[^\s]*\.cache\/agent-browser/)
+    expect(dockerfile).not.toMatch(/--mount=type=cache,target=[^\s]*\.agent-browser\/browsers/)
   })
 
   test('Dockerfile registers the GitHub CLI apt repo in a layer separate from the package install', async () => {


### PR DESCRIPTION
## Summary

Two related fixes to the auto-managed \`Dockerfile\` that handles agent-browser setup:

1. **Install Chrome runtime libs explicitly on amd64 (Debian trixie).** \`agent-browser install --with-deps\` (v0.27.0) silently no-ops missing packages — its hardcoded apt list omits \`libglib2.0-0t64\` (the package providing \`libglib-2.0.so.0\`). Chrome downloads fine and the command exits 0, but on first launch Chrome dies with \`error while loading shared libraries: libglib-2.0.so.0: cannot open shared object file\`. We now install Playwright's \`debian13-x64\` chromium dep set in Layer 2 so the build no longer relies on the broken \`--with-deps\` for these libraries. \`--with-deps\` stays in Layer 5 as a backstop for any deps a future agent-browser version adds.
2. **Correct stale Chrome cache-path references in comments and tests.** agent-browser stores its downloaded Chrome at \`~/.agent-browser/browsers/chrome-<version>/\` (hardcoded in the Rust CLI's \`get_browsers_dir()\`), not \`~/.cache/agent-browser/\` as several comments and a test assertion claimed.

## Why

Real failure mode reported by a user with an \`oven/bun:1-slim\` (Debian 13 / trixie) container:

\`\`\`
/root/.agent-browser/browsers/chrome-148.0.7778.97/chrome:
  error while loading shared libraries: libglib-2.0.so.0:
  cannot open shared object file: No such file or directory
\`\`\`

The user worked around it manually (\`apt install libglib2.0-0t64 ...\`), but the next user shouldn't have to. Tracing it back: \`agent-browser/cli/src/install.rs\` has a hardcoded apt-deps list with t64 fallbacks for many GTK/cairo packages, but **\`libglib2.0-0\` / \`libglib2.0-0t64\` is missing from the list entirely**. And \`report_install_status()\` only logs warnings on failure — it never \`exit(1)\`s — so the Docker build succeeds with a Chrome binary that can't actually start.

We could ship the smallest fix (just \`libglib2.0-0t64\`), but that bets the next agent-browser omission won't bite us the same way. Mirroring Playwright's well-tested chromium dep list — which is the same project's response to the same upstream Chrome dep instability — is a near-zero-cost defense.

## What changed

**\`src/init/dockerfile.ts\`**
- Added \`CHROME_RUNTIME_APT_PACKAGES_AMD64\` (21 packages, byte-for-byte equal to Playwright's \`debian13-x64\` chromium deps in \`nativeDeps.ts\`). Each package name verified against \`packages.debian.org/trixie\` — packages without a t64 suffix here have no t64 sibling on trixie.
- Layer 2's \`apt-get install\` now branches on \`$TARGETARCH\`: \`arm64\` keeps installing \`chromium\` (which pulls its own deps); amd64 installs the explicit Chrome runtime set.
- Updated comments around Layer 5 to reflect that \`--with-deps\` is now a backstop, not the primary install path.
- Fixed two stale references to \`~/.cache/agent-browser\` → \`~/.agent-browser/browsers/\`.
- **No fonts.** The reported failure is launch-time linker errors, not glyph rendering. Including \`fonts-noto-cjk\` (~50MB+) for a launch-fix would be unjustified bloat. If multilingual rendering ever matters in the default image, that's a separate change with its own size justification.

**\`src/init/dockerfile.test.ts\`**
- 5 new tests in a \`Chrome runtime deps (amd64)\` block:
  - **Regression guard for the exact failure**: amd64 branch must install \`libglib2.0-0t64\`.
  - **Drift guard**: every package in \`CHROME_RUNTIME_APT_PACKAGES_AMD64\` must end up in the rendered amd64 branch.
  - **No fonts**: explicit guard that \`fonts-*\` packages don't sneak in (the reported bug doesn't justify them).
  - **arm64 isolation**: arm64 branch installs \`chromium\` and must not contain any of the amd64 t64 packages.
  - **Layer ordering**: deps land in Layer 2 (before \`bun install -g agent-browser\` in Layer 4), not only via Layer 5's \`--with-deps\` backstop.
- Helpers \`amd64ElseBranchPackages\` / \`arm64IfBranchPackages\` parse the actual rendered apt-install lines so assertions can't false-match against package names appearing in surrounding comment prose.
- Mutation-checked: dropping \`'libglib2.0-0t64'\` from the list breaks 2 tests; sneaking \`fonts-noto-cjk\` back in breaks 1.

**\`src/init/index.test.ts\`**
- Updated stale comment + assertion regex from \`.cache/agent-browser\` to \`.agent-browser/browsers\`. The test's intent (don't cache-mount the Chrome binary path) is unchanged; the regex now matches the path agent-browser actually uses.

## Verification

- \`bun run typecheck\`, \`bun run lint\`, \`bun run format:check\`, \`bun test\` — all green (2271 pass / 0 fail)
- Mutation-checked the regression guards (see above)
- Out of scope: rebuilding an image and exec'ing into the container to confirm Chrome launches — leaving that for the maintainer's own \`typeclaw start --build\` against the merged change

## Out of scope (intentional non-changes)

- **\`--with-deps\` itself**: still invoked in Layer 5. Future agent-browser bumps that add new deps install them via this backstop with apt cache mounts making it nearly free.
- **arm64 Chrome runtime list**: \`chromium\` package on Debian trixie pulls its own dependencies, so we don't duplicate them.
- **Upstream agent-browser bug**: a separate report belongs at https://github.com/vercel-labs/agent-browser. This PR is the Dockerfile-side defensive fix.