### PR TITLE
Use agent-messenger SDK directly so KakaoTalk login passcode actually shows

### DIFF
--- a/src/channels/adapters/agent-messenger-kakaotalk-shim.ts
+++ b/src/channels/adapters/agent-messenger-kakaotalk-shim.ts
@@ -116,8 +116,31 @@ export type KakaoStoredAccount = {
   device_type: 'pc' | 'tablet'
 }
 
+export type KakaoPendingLoginState = {
+  device_uuid: string
+  device_type: 'pc' | 'tablet'
+  email: string
+  created_at: string
+}
+
+export type KakaoAccountToPersist = {
+  account_id: string
+  user_id: string
+  oauth_token: string
+  refresh_token?: string
+  device_uuid: string
+  device_type: 'pc' | 'tablet'
+  auth_method: 'login' | 'extract'
+  created_at: string
+  updated_at: string
+}
+
 export interface KakaoCredentialManager {
-  getAccount(id?: string): Promise<KakaoStoredAccount | null>
+  getAccount(id?: string): Promise<(KakaoStoredAccount & { auth_method?: 'login' | 'extract' }) | null>
+  setAccount(account: KakaoAccountToPersist): Promise<void>
+  setCurrentAccount(id: string): Promise<void>
+  loadPendingLogin(): Promise<KakaoPendingLoginState | null>
+  clearPendingLogin(): Promise<void>
 }
 
 export const KakaoTalkClient = RawClient as unknown as new () => KakaoTalkClient

--- a/src/init/kakaotalk-auth.test.ts
+++ b/src/init/kakaotalk-auth.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { kakaotalkConfigDir, runKakaotalkBootstrap, type SpawnLoginArgs, type SpawnLoginResult } from './kakaotalk-auth'
+import {
+  kakaotalkConfigDir,
+  type LoginFlowFn,
+  type LoginFlowOptions,
+  type LoginFlowResult,
+  runKakaotalkBootstrap,
+} from './kakaotalk-auth'
 
 describe('kakaotalkConfigDir', () => {
   test('places credentials under the agent workspace, not the user home', () => {
@@ -12,53 +18,64 @@ describe('kakaotalkConfigDir', () => {
   })
 })
 
-describe('runKakaotalkBootstrap', () => {
-  const tmp = async (): Promise<string> => mkdtemp(join(tmpdir(), 'typeclaw-kakao-test-'))
+const tmp = async (): Promise<string> => mkdtemp(join(tmpdir(), 'typeclaw-kakao-test-'))
 
-  test('returns ok when the spawned login reports authenticated:true', async () => {
+const successResult: LoginFlowResult = {
+  authenticated: true,
+  credentials: {
+    access_token: 'oauth-abc',
+    refresh_token: 'refresh-xyz',
+    user_id: 'user-1',
+    device_uuid: 'uuid-1',
+    device_type: 'tablet',
+  },
+}
+
+describe('runKakaotalkBootstrap', () => {
+  test('persists credentials when loginFlow returns authenticated', async () => {
     const agentDir = await tmp()
     try {
-      const fake = async (args: SpawnLoginArgs): Promise<SpawnLoginResult> => {
-        expect(args.configDir).toBe(join(agentDir, 'workspace', '.agent-messenger'))
-        expect(args.email).toBe('user@example.com')
-        return {
-          exitCode: 0,
-          stdout: JSON.stringify({ authenticated: true, account_id: 'a1', user_id: 'u1' }) + '\n',
-          stderr: '',
-        }
+      const fake: LoginFlowFn = async (opts) => {
+        expect(opts.email).toBe('user@example.com')
+        expect(opts.password).toBe('secret')
+        expect(opts.deviceType).toBe('tablet')
+        return successResult
       }
       const result = await runKakaotalkBootstrap({
         email: 'user@example.com',
         password: 'secret',
         agentDir,
         callbacks: { onPasscode: () => {} },
-        spawnLogin: fake,
+        loginFlow: fake,
       })
       expect(result).toEqual({ ok: true })
+      const credPath = join(kakaotalkConfigDir(agentDir), 'kakaotalk-credentials.json')
+      const stored = JSON.parse(await readFile(credPath, 'utf8')) as {
+        current_account: string
+        accounts: Record<string, { user_id: string; auth_method: string; oauth_token: string }>
+      }
+      expect(stored.current_account).toBe('user-1')
+      expect(stored.accounts['user-1']?.oauth_token).toBe('oauth-abc')
+      expect(stored.accounts['user-1']?.auth_method).toBe('login')
     } finally {
       await rm(agentDir, { recursive: true, force: true })
     }
   })
 
-  test('returns failure with the CLI-reported message when authenticated:false', async () => {
+  test('returns failure with the loginFlow message when authentication fails', async () => {
     const agentDir = await tmp()
     try {
-      const fake = async (): Promise<SpawnLoginResult> => ({
-        exitCode: 0,
-        stdout:
-          JSON.stringify({
-            authenticated: false,
-            error: 'bad_credentials',
-            message: 'Login failed: incorrect email or password.',
-          }) + '\n',
-        stderr: '',
+      const fake: LoginFlowFn = async () => ({
+        authenticated: false,
+        error: 'bad_credentials',
+        message: 'Login failed: incorrect email or password.',
       })
       const result = await runKakaotalkBootstrap({
         email: 'user@example.com',
         password: 'wrong',
         agentDir,
         callbacks: { onPasscode: () => {} },
-        spawnLogin: fake,
+        loginFlow: fake,
       })
       expect(result.ok).toBe(false)
       if (result.ok) return
@@ -68,91 +85,104 @@ describe('runKakaotalkBootstrap', () => {
     }
   })
 
-  test('returns failure when the spawned process exits non-zero', async () => {
+  test('returns failure when loginFlow throws', async () => {
     const agentDir = await tmp()
     try {
-      const fake = async (): Promise<SpawnLoginResult> => ({
-        exitCode: 2,
-        stdout: '',
-        stderr: 'agent-kakaotalk: command not found',
-      })
-      const result = await runKakaotalkBootstrap({
-        email: 'user@example.com',
-        password: 'x',
-        agentDir,
-        callbacks: { onPasscode: () => {} },
-        spawnLogin: fake,
-      })
-      expect(result.ok).toBe(false)
-      if (result.ok) return
-      expect(result.reason).toContain('agent-kakaotalk: command not found')
-    } finally {
-      await rm(agentDir, { recursive: true, force: true })
-    }
-  })
-
-  test('returns failure when stdout has no JSON', async () => {
-    const agentDir = await tmp()
-    try {
-      const fake = async (): Promise<SpawnLoginResult> => ({
-        exitCode: 0,
-        stdout: '',
-        stderr: '',
-      })
+      const fake: LoginFlowFn = async () => {
+        throw new Error('network unreachable')
+      }
       const result = await runKakaotalkBootstrap({
         email: 'u@e.com',
         password: 'x',
         agentDir,
         callbacks: { onPasscode: () => {} },
-        spawnLogin: fake,
+        loginFlow: fake,
       })
       expect(result.ok).toBe(false)
       if (result.ok) return
-      expect(result.reason).toContain('no JSON output')
+      expect(result.reason).toBe('network unreachable')
     } finally {
       await rm(agentDir, { recursive: true, force: true })
     }
   })
 
-  test('passes the password file path to the spawn fn (and only the path, not the password)', async () => {
+  test('forwards onPasscode through to loginFlow as onPasscodeDisplay', async () => {
     const agentDir = await tmp()
     try {
-      let receivedPath: string | null = null
-      const fake = async (args: SpawnLoginArgs): Promise<SpawnLoginResult> => {
-        receivedPath = args.passwordFile
-        return { exitCode: 0, stdout: JSON.stringify({ authenticated: true }), stderr: '' }
+      const codes: string[] = []
+      const fake: LoginFlowFn = async (opts: LoginFlowOptions) => {
+        opts.onPasscodeDisplay?.('1234')
+        return successResult
       }
       await runKakaotalkBootstrap({
         email: 'u@e.com',
-        password: 'super-secret',
+        password: 'x',
         agentDir,
-        callbacks: { onPasscode: () => {} },
-        spawnLogin: fake,
+        callbacks: { onPasscode: (code) => codes.push(code) },
+        loginFlow: fake,
       })
-      expect(receivedPath).not.toBeNull()
-      expect(receivedPath!).toMatch(/typeclaw-kakao-/)
-      expect(receivedPath!).not.toContain('super-secret')
+      expect(codes).toEqual(['1234'])
     } finally {
       await rm(agentDir, { recursive: true, force: true })
     }
   })
 
-  test('does not mutate process.env.AGENT_MESSENGER_CONFIG_DIR', async () => {
-    const before = process.env.AGENT_MESSENGER_CONFIG_DIR
+  test('reuses savedDeviceUuid from prior pending login', async () => {
     const agentDir = await tmp()
     try {
+      const configDir = kakaotalkConfigDir(agentDir)
+      await mkdir(configDir, { recursive: true })
+      await writeFile(
+        join(configDir, 'kakaotalk-pending-login.json'),
+        JSON.stringify({
+          device_uuid: 'previous-uuid',
+          device_type: 'tablet',
+          email: 'u@e.com',
+          created_at: new Date().toISOString(),
+        }),
+      )
+      let received: string | undefined
+      const fake: LoginFlowFn = async (opts) => {
+        received = opts.savedDeviceUuid
+        return successResult
+      }
       await runKakaotalkBootstrap({
         email: 'u@e.com',
         password: 'x',
         agentDir,
         callbacks: { onPasscode: () => {} },
-        spawnLogin: async () => ({
-          exitCode: 0,
-          stdout: JSON.stringify({ authenticated: true }),
-          stderr: '',
-        }),
+        loginFlow: fake,
       })
-      expect(process.env.AGENT_MESSENGER_CONFIG_DIR).toBe(before)
+      expect(received).toBe('previous-uuid')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('uses default account_id when user_id is empty', async () => {
+    const agentDir = await tmp()
+    try {
+      const fake: LoginFlowFn = async () => ({
+        authenticated: true,
+        credentials: {
+          access_token: 'oauth',
+          refresh_token: 'refresh',
+          user_id: '',
+          device_uuid: 'uuid',
+          device_type: 'tablet',
+        },
+      })
+      const result = await runKakaotalkBootstrap({
+        email: 'u@e.com',
+        password: 'x',
+        agentDir,
+        callbacks: { onPasscode: () => {} },
+        loginFlow: fake,
+      })
+      expect(result).toEqual({ ok: true })
+      const credPath = join(kakaotalkConfigDir(agentDir), 'kakaotalk-credentials.json')
+      const stored = JSON.parse(await readFile(credPath, 'utf8')) as { current_account: string }
+      expect(stored.current_account).toBe('default')
     } finally {
       await rm(agentDir, { recursive: true, force: true })
     }

--- a/src/init/kakaotalk-auth.ts
+++ b/src/init/kakaotalk-auth.ts
@@ -1,4 +1,7 @@
+import { createRequire } from 'node:module'
 import { join } from 'node:path'
+
+import { KakaoCredentialManager } from '@/channels/adapters/agent-messenger-kakaotalk-shim'
 
 export type KakaotalkBootstrapStatus = { ok: true } | { ok: false; reason: string }
 
@@ -11,191 +14,101 @@ export type KakaotalkLoginInput = {
   password: string
   agentDir: string
   callbacks: KakaotalkLoginCallbacks
-  // Test seam. Production resolves to spawning `agent-kakaotalk auth login`
-  // via Bun.spawn; tests inject a fake to avoid hitting real KakaoTalk.
-  spawnLogin?: (args: SpawnLoginArgs) => Promise<SpawnLoginResult>
+  loginFlow?: LoginFlowFn
 }
 
-export type SpawnLoginArgs = {
-  configDir: string
+export type LoginFlowOptions = {
   email: string
-  passwordFile: string
-  onPasscode: (passcode: string) => void
+  password: string
+  deviceType?: 'pc' | 'tablet'
+  force?: boolean
+  savedDeviceUuid?: string
+  onPasscodeDisplay?: (code: string) => void
+  debugLog?: (message: string) => void
 }
 
-export type SpawnLoginResult = {
-  exitCode: number
-  stdout: string
-  stderr: string
+export type LoginFlowCredentials = {
+  access_token: string
+  refresh_token: string
+  user_id: string
+  device_uuid: string
+  device_type: 'pc' | 'tablet'
 }
+
+export type LoginFlowResult = {
+  authenticated: boolean
+  next_action?: string
+  message?: string
+  warning?: string
+  error?: string
+  credentials?: LoginFlowCredentials
+}
+
+export type LoginFlowFn = (options: LoginFlowOptions) => Promise<LoginFlowResult>
 
 export function kakaotalkConfigDir(agentDir: string): string {
   return join(agentDir, 'workspace', '.agent-messenger')
 }
 
-// agent-messenger's `loginFlow` is internal (not in the package's `exports`
-// map), so we cannot import it directly from the SDK. The public entry point
-// for one-shot device-registration login is the `agent-kakaotalk auth login`
-// CLI, which is reexported by the same npm package and accepts
-// AGENT_MESSENGER_CONFIG_DIR + --email + --password-file + --pretty.
-//
-// Adapter runtime (kakaotalk.ts) still uses the SDK directly — only this
-// host-stage init bootstrap shells out to the CLI, because:
-//   1. The credential file format is the public surface; the CLI writes it
-//      to AGENT_MESSENGER_CONFIG_DIR/kakaotalk-credentials.json which the
-//      in-container SDK then reads.
-//   2. The login flow involves a phone-passcode round-trip (printed on
-//      stderr as `Enter this code on your phone: NNNN`); replicating that
-//      via private SDK imports would couple us to internal symbols that
-//      are not part of the package's exports map.
 export async function runKakaotalkBootstrap(input: KakaotalkLoginInput): Promise<KakaotalkBootstrapStatus> {
   const configDir = kakaotalkConfigDir(input.agentDir)
-  const passwordFile = await writePasswordFile(input.password)
   try {
-    const spawnLogin = input.spawnLogin ?? defaultSpawnLogin
-    const result = await spawnLogin({
-      configDir,
+    const loginFlow = input.loginFlow ?? (await resolveLoginFlow())
+    const credManager = new KakaoCredentialManager(configDir)
+    const pending = await credManager.loadPendingLogin()
+    const existing = await credManager.getAccount()
+    const savedDeviceUuid =
+      pending?.device_uuid ?? (existing?.auth_method === 'login' ? existing.device_uuid : undefined)
+
+    const result = await loginFlow({
       email: input.email,
-      passwordFile,
-      onPasscode: input.callbacks.onPasscode,
+      password: input.password,
+      deviceType: 'tablet',
+      force: false,
+      ...(savedDeviceUuid !== undefined ? { savedDeviceUuid } : {}),
+      onPasscodeDisplay: input.callbacks.onPasscode,
     })
-    return interpretLoginResult(result)
+
+    if (!result.authenticated || !result.credentials) {
+      const reason = result.message ?? result.error ?? 'agent-kakaotalk did not authenticate (check email/password)'
+      return { ok: false, reason }
+    }
+
+    const now = new Date().toISOString()
+    const accountId = result.credentials.user_id || 'default'
+    await credManager.setAccount({
+      account_id: accountId,
+      oauth_token: result.credentials.access_token,
+      user_id: result.credentials.user_id,
+      refresh_token: result.credentials.refresh_token,
+      device_uuid: result.credentials.device_uuid,
+      device_type: result.credentials.device_type,
+      auth_method: 'login',
+      created_at: now,
+      updated_at: now,
+    })
+    await credManager.setCurrentAccount(accountId)
+    await credManager.clearPendingLogin()
+
+    return { ok: true }
   } catch (err) {
     return { ok: false, reason: err instanceof Error ? err.message : String(err) }
-  } finally {
-    await removeIfExists(passwordFile)
   }
 }
 
-function interpretLoginResult(result: SpawnLoginResult): KakaotalkBootstrapStatus {
-  if (result.exitCode !== 0) {
-    const reason =
-      parseErrorFromOutput(result.stdout, result.stderr) ?? `agent-kakaotalk exited with code ${result.exitCode}`
-    return { ok: false, reason }
+// agent-messenger does not export `loginFlow` from its public `exports` map
+// (only the runtime client + credential manager), so we resolve the package's
+// installed location and import the implementation file directly. This
+// bypasses the exports gate but stays within the same installed copy of the
+// package — no version drift risk. If a future agent-messenger release adds
+// `loginFlow` to its public exports, swap this for a normal import and delete
+// the resolveLoginFlow helper.
+async function resolveLoginFlow(): Promise<LoginFlowFn> {
+  const require = createRequire(import.meta.url)
+  const pkgJson = require.resolve('agent-messenger/package.json')
+  const pkgDir = pkgJson.replace(/\/package\.json$/, '')
+  const mod = (await import(`${pkgDir}/dist/src/platforms/kakaotalk/auth/kakao-login.js`)) as {
+    loginFlow: LoginFlowFn
   }
-  // Successful exit: parse the last JSON object on stdout. The CLI emits
-  // exactly one `{...}` payload on success; we tolerate trailing whitespace.
-  const payload = parseFinalJson(result.stdout)
-  if (payload === null) return { ok: false, reason: 'agent-kakaotalk produced no JSON output' }
-  if (payload.authenticated === true) return { ok: true }
-  const reason =
-    typeof payload.message === 'string' && payload.message !== ''
-      ? payload.message
-      : typeof payload.error === 'string' && payload.error !== ''
-        ? payload.error
-        : 'agent-kakaotalk did not authenticate (check email/password)'
-  return { ok: false, reason }
-}
-
-function parseErrorFromOutput(stdout: string, stderr: string): string | null {
-  const payload = parseFinalJson(stdout)
-  if (payload !== null) {
-    const message = typeof payload.message === 'string' ? payload.message : null
-    const error = typeof payload.error === 'string' ? payload.error : null
-    if (message !== null && message !== '') return message
-    if (error !== null && error !== '') return error
-  }
-  const trimmed = stderr.trim()
-  return trimmed === '' ? null : trimmed
-}
-
-function parseFinalJson(stdout: string): { authenticated?: boolean; message?: unknown; error?: unknown } | null {
-  const trimmed = stdout.trim()
-  if (trimmed === '') return null
-  // CLI emits one JSON line on success. Walk lines from the end so any
-  // future debug breadcrumbs printed before the final payload don't
-  // confuse the parser.
-  const lines = trimmed.split('\n')
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i]!.trim()
-    if (line === '' || !line.startsWith('{')) continue
-    try {
-      return JSON.parse(line) as { authenticated?: boolean; message?: unknown; error?: unknown }
-    } catch {
-      continue
-    }
-  }
-  return null
-}
-
-async function writePasswordFile(password: string): Promise<string> {
-  const { mkdtemp, writeFile, chmod } = await import('node:fs/promises')
-  const { tmpdir } = await import('node:os')
-  const dir = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-'))
-  const path = join(dir, 'pw')
-  await writeFile(path, password)
-  // Best-effort 0600. The CLI deletes the file after reading it, but if
-  // anything crashes between write and read, restrict access in the
-  // meantime so other users on the host can't read it from /tmp.
-  try {
-    await chmod(path, 0o600)
-  } catch {
-    // chmod is unsupported on some filesystems (Windows host shares,
-    // tmpfs without permission emulation). Continue with default mode.
-  }
-  return path
-}
-
-async function removeIfExists(path: string): Promise<void> {
-  const { rm } = await import('node:fs/promises')
-  try {
-    await rm(path, { force: true })
-    // Also remove the parent tmpdir we created in writePasswordFile.
-    const parent = join(path, '..')
-    await rm(parent, { recursive: true, force: true })
-  } catch {
-    // Cleanup is best-effort; the OS will reap /tmp eventually.
-  }
-}
-
-const PASSCODE_PATTERN = /Enter this code on your phone:\s*(\S+)/
-
-async function defaultSpawnLogin(args: SpawnLoginArgs): Promise<SpawnLoginResult> {
-  const proc = Bun.spawn(
-    ['bunx', '--bun', 'agent-kakaotalk', 'auth', 'login', '--email', args.email, '--password-file', args.passwordFile],
-    {
-      env: { ...process.env, AGENT_MESSENGER_CONFIG_DIR: args.configDir },
-      stdin: 'inherit',
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-  )
-
-  // Tee stderr so the CLI's interactive passcode line ("Enter this code on
-  // your phone: NNNN") reaches the user without us swallowing it. We also
-  // detect the passcode regex and surface it via the caller's callback so
-  // a non-TTY runner (e.g. a future scripted init) can render it however
-  // it likes.
-  const stderrChunks: string[] = []
-  let stderrBuffer = ''
-  const pumpStderr = (async () => {
-    const reader = proc.stderr.getReader()
-    const decoder = new TextDecoder()
-    while (true) {
-      const { value, done } = await reader.read()
-      if (done) break
-      const text = decoder.decode(value, { stream: true })
-      stderrChunks.push(text)
-      stderrBuffer += text
-      const match = stderrBuffer.match(PASSCODE_PATTERN)
-      if (match) {
-        args.onPasscode(match[1]!)
-        // Drop everything up to and including the matched newline so we
-        // don't fire the callback twice for the same code.
-        const after = stderrBuffer.indexOf('\n', stderrBuffer.indexOf(match[0]))
-        stderrBuffer = after === -1 ? '' : stderrBuffer.slice(after + 1)
-      }
-      process.stderr.write(text)
-    }
-    const trailing = decoder.decode()
-    if (trailing !== '') {
-      stderrChunks.push(trailing)
-      process.stderr.write(trailing)
-    }
-  })()
-
-  const stdout = await new Response(proc.stdout).text()
-  await pumpStderr
-  const exitCode = await proc.exited
-  return { exitCode, stdout, stderr: stderrChunks.join('') }
+  return mod.loginFlow
 }


### PR DESCRIPTION
## Bug

`typeclaw init` shelled out to `bunx --bun agent-kakaotalk auth login` to authenticate the user during first setup. KakaoTalk's PC-login flow requires the user to confirm a one-time numeric passcode on their phone — without this confirmation, the device-registration polling never completes and the spawn hangs until the user cancels.

The CLI only prints that passcode when `process.stdin.isTTY && process.stdout.isTTY` are both true. Our `Bun.spawn` piped both `stdout` and `stderr` (to parse the `{ authenticated: true, ... }` JSON result line and extract the passcode via stderr regex). Piping flips `isTTY` to false in the child, so `agent-kakaotalk` treated itself as non-interactive, silently swallowed the passcode, and proceeded to poll device-registration while the user stared at a spinner with no idea what code to enter.

## Fix

Stop shelling out. Call agent-messenger's `loginFlow` directly as an SDK function — it is the same function the CLI wraps, and it accepts `onPasscodeDisplay` as a first-class callback parameter with no TTY check. Credentials are then persisted with `KakaoCredentialManager` (calling `setAccount`, `setCurrentAccount`, `clearPendingLogin`) to match exactly what the CLI's own `handleLoginResult` does.

`loginFlow` is not in agent-messenger's public `exports` map. We resolve the package directory via `createRequire(import.meta.url).resolve('agent-messenger/package.json')` and import `dist/.../kakao-login.js` directly. This bypasses the exports gate but stays within the same installed copy of the package — no version drift risk. A comment in the code documents the deletion criterion: remove the deep-import workaround when agent-messenger ships `loginFlow` publicly.

## Changes

**`src/init/kakaotalk-auth.ts`** — rewritten. Removed: `Bun.spawn`, `bunx --bun agent-kakaotalk` invocation, password-file temp dir + cleanup, stderr regex extractor, JSON line parsing, `SpawnLoginArgs`/`SpawnLoginResult` types. Replaced with: direct `loginFlow` call + `KakaoCredentialManager` persistence. Test seam changes from `spawnLogin?: SpawnLoginFn` to `loginFlow?: LoginFlowFn`. Net: ~241 LoC → ~115 LoC.

**`src/channels/adapters/agent-messenger-kakaotalk-shim.ts`** — extends `KakaoCredentialManager` interface from just `getAccount` to also include `setAccount`, `setCurrentAccount`, `loadPendingLogin`, and `clearPendingLogin`, with supporting types `KakaoPendingLoginState` and `KakaoAccountToPersist`.

**`src/init/kakaotalk-auth.test.ts`** — rewritten around the new `loginFlow` seam. Tests verify: credentials persisted to `kakaotalk-credentials.json` with correct shape, failure messages propagate, exceptions are caught, `onPasscode` flows through to `onPasscodeDisplay`, `savedDeviceUuid` reused from pending login state, and `'default'` used as `account_id` when `user_id` is empty (matching CLI behavior). 7 tests, all green.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 warnings, 0 errors
- `bun run format` — clean
- `bun test` — 2271 pass, 0 fail (including 7 new `kakaotalk-auth` tests)
- End-to-end: `typeclaw init --with-kakaotalk` shows the passcode on screen, user confirms on phone, credentials persist, agent hatches successfully.