### PR TITLE
Add `typeclaw channel add` for post-init channel wiring

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -1,0 +1,380 @@
+import { cancel, confirm, intro, isCancel, log, note, password, select, spinner, text } from '@clack/prompts'
+import { defineCommand } from 'citty'
+
+import { config } from '@/config'
+import { start, status, stop } from '@/container'
+import {
+  CHANNEL_KINDS,
+  findAgentDir,
+  isInitialized,
+  readConfiguredChannels,
+  runAddChannel,
+  type AddChannelStepEvent,
+  type ChannelKind,
+  type KakaotalkAuthResult,
+} from '@/init'
+import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
+
+const CHANNEL_LABELS: Record<ChannelKind, string> = {
+  'slack-bot': 'Slack',
+  'discord-bot': 'Discord',
+  'telegram-bot': 'Telegram',
+  kakaotalk: 'KakaoTalk',
+}
+
+const addSub = defineCommand({
+  meta: {
+    name: 'add',
+    description: 'add a new channel adapter to an existing agent (run this from inside the agent folder)',
+  },
+  args: {
+    adapter: {
+      type: 'positional',
+      description: `which adapter to add (${CHANNEL_KINDS.join(' | ')}); omit to pick interactively`,
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+
+    if (!isInitialized(cwd)) {
+      console.error('TypeClaw config file not found. Run `typeclaw init` first, or cd into an agent folder.')
+      process.exit(1)
+    }
+
+    const configured = await readConfiguredChannels(cwd)
+    const requested = args.adapter
+    const channel = requested === undefined ? await pickChannel(configured) : validateAdapterArg(requested, configured)
+
+    intro(`Adding channel: ${CHANNEL_LABELS[channel]}`)
+
+    const credentials = await collectCredentials(channel)
+
+    const events: AddChannelStepEvent[] = []
+    try {
+      await runAddChannel({
+        cwd,
+        ...credentials,
+        onProgress: reportProgress(events),
+      })
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error))
+      process.exit(1)
+    }
+
+    await maybePromptRestart(cwd)
+  },
+})
+
+export const channelCommand = defineCommand({
+  meta: {
+    name: 'channel',
+    description: 'manage channel adapters wired into the agent',
+  },
+  subCommands: {
+    add: addSub,
+  },
+})
+
+function validateAdapterArg(adapter: string, configured: Set<ChannelKind>): ChannelKind {
+  if (!isChannelKind(adapter)) {
+    console.error(`Unknown adapter "${adapter}". Expected one of: ${CHANNEL_KINDS.join(', ')}.`)
+    process.exit(1)
+  }
+  if (configured.has(adapter)) {
+    console.error(
+      `${CHANNEL_LABELS[adapter]} ("${adapter}") is already configured in typeclaw.json. Edit the file directly to change its allow list.`,
+    )
+    process.exit(1)
+  }
+  return adapter
+}
+
+function isChannelKind(value: string): value is ChannelKind {
+  return (CHANNEL_KINDS as ReadonlyArray<string>).includes(value)
+}
+
+async function pickChannel(configured: Set<ChannelKind>): Promise<ChannelKind> {
+  const available = CHANNEL_KINDS.filter((kind) => !configured.has(kind))
+  if (available.length === 0) {
+    console.error('All supported channel adapters are already configured in typeclaw.json. Nothing to add.')
+    process.exit(0)
+  }
+
+  const selected = await select<ChannelKind>({
+    message: 'Pick a channel to add',
+    options: available.map((kind) => ({ value: kind, label: CHANNEL_LABELS[kind] })),
+    initialValue: available[0],
+  })
+  if (isCancel(selected)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return selected
+}
+
+type CollectedCredentials =
+  | { channel: 'discord-bot'; discordBotToken: string }
+  | { channel: 'slack-bot'; slackBotToken: string; slackAppToken: string }
+  | { channel: 'telegram-bot'; telegramBotToken: string }
+  | { channel: 'kakaotalk'; runKakaotalkAuth: (options: { cwd: string }) => Promise<KakaotalkAuthResult> }
+
+async function collectCredentials(channel: ChannelKind): Promise<CollectedCredentials> {
+  switch (channel) {
+    case 'discord-bot':
+      return { channel, discordBotToken: await promptDiscordToken() }
+    case 'slack-bot': {
+      const slack = await promptSlackTokens()
+      return { channel, slackBotToken: slack.bot, slackAppToken: slack.app }
+    }
+    case 'telegram-bot':
+      return { channel, telegramBotToken: await promptTelegramToken() }
+    case 'kakaotalk': {
+      const creds = await promptKakaotalkCredentials()
+      return {
+        channel,
+        runKakaotalkAuth: ({ cwd: agentDir }) =>
+          runKakaotalkBootstrap({
+            email: creds.email,
+            password: creds.password,
+            agentDir,
+            callbacks: { onPasscode: (code) => log.info(`Confirm this passcode on your phone: ${code}`) },
+          }),
+      }
+    }
+  }
+}
+
+async function promptDiscordToken(): Promise<string> {
+  note(
+    [
+      'https://discord.com/developers/applications',
+      'New Application → Bot tab → Reset Token.',
+      'Enable the MESSAGE CONTENT intent.',
+    ].join('\n'),
+    'Get a Discord bot token',
+  )
+  const token = await password({
+    message: 'Discord bot token',
+    validate: (value) => (value && value.length > 0 ? undefined : 'Token is required'),
+  })
+  if (isCancel(token)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return token
+}
+
+async function promptSlackTokens(): Promise<{ bot: string; app: string }> {
+  note(
+    [
+      '1. https://api.slack.com/apps → Create New App → From a manifest.',
+      '   Pick your workspace, then paste this JSON manifest:',
+      '',
+      '   {',
+      '     "display_information": { "name": "TypeClaw" },',
+      '     "features": {',
+      '       "bot_user": { "display_name": "TypeClaw", "always_online": true }',
+      '     },',
+      '     "oauth_config": {',
+      '       "scopes": {',
+      '         "bot": [',
+      '           "app_mentions:read", "chat:write", "users:read", "files:read",',
+      '           "channels:history", "channels:read",',
+      '           "groups:history",   "groups:read",',
+      '           "im:history",       "im:read",',
+      '           "mpim:history",     "mpim:read"',
+      '         ]',
+      '       }',
+      '     },',
+      '     "settings": {',
+      '       "event_subscriptions": {',
+      '         "bot_events": [',
+      '           "app_mention",',
+      '           "message.channels", "message.groups",',
+      '           "message.im",       "message.mpim"',
+      '         ]',
+      '       },',
+      '       "socket_mode_enabled": true',
+      '     }',
+      '   }',
+      '',
+      '2. Install to Workspace, then OAuth & Permissions →',
+      '   copy the Bot User OAuth Token (xoxb-...).',
+      '3. Basic Information → App-Level Tokens → Generate Token and',
+      '   Scopes, add the connections:write scope, and copy the',
+      '   token (xapp-...). Socket Mode needs this; the manifest',
+      '   cannot grant it.',
+      '4. Invite the bot to any private channel or DM you want it in:',
+      '   /invite @TypeClaw',
+    ].join('\n'),
+    'Get a Slack bot',
+  )
+  const botToken = await password({
+    message: 'Slack bot token (xoxb-...)',
+    validate: (value) =>
+      value && value.length > 0
+        ? value.startsWith('xoxb-')
+          ? undefined
+          : 'Bot token must start with "xoxb-"'
+        : 'Token is required',
+  })
+  if (isCancel(botToken)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  note(
+    [
+      'Slack does not accept connections:write inside the manifest, so',
+      'this token has to be generated by hand:',
+      '',
+      '1. Basic Information → App-Level Tokens → Generate Token and Scopes.',
+      '2. Token Name: anything (e.g. "socket-mode").',
+      '3. Add Scope → connections:write → Generate.',
+      '4. Copy the xapp-... token shown once on screen.',
+      '   (You cannot retrieve it later — only revoke and regenerate.)',
+    ].join('\n'),
+    'Generate the Slack app-level token',
+  )
+  const appToken = await password({
+    message: 'Slack app-level token (xapp-...) — Socket Mode requires this',
+    validate: (value) =>
+      value && value.length > 0
+        ? value.startsWith('xapp-')
+          ? undefined
+          : 'App-level token must start with "xapp-"'
+        : 'Token is required',
+  })
+  if (isCancel(appToken)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return { bot: botToken, app: appToken }
+}
+
+async function promptTelegramToken(): Promise<string> {
+  note(
+    [
+      'Open Telegram and message @BotFather.',
+      '/newbot → pick a name and username, copy the HTTP API token',
+      '  (looks like 1234567890:ABCdef...).',
+      'In @BotFather: /setprivacy → Disable, so the bot can see group messages.',
+    ].join('\n'),
+    'Get a Telegram bot token',
+  )
+  const token = await password({
+    message: 'Telegram bot token',
+    validate: (value) =>
+      value && value.length > 0
+        ? /^\d+:/.test(value)
+          ? undefined
+          : 'Bot token must look like "<digits>:<secret>" (from @BotFather)'
+        : 'Token is required',
+  })
+  if (isCancel(token)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return token
+}
+
+async function promptKakaotalkCredentials(): Promise<{ email: string; password: string }> {
+  note(
+    [
+      'KakaoTalk authentication uses a personal account, registered as a',
+      'tablet sub-device. Messages will be sent and received under this',
+      'account. Use a non-primary account if possible.',
+      '',
+      'After you submit the password, KakaoTalk may ask you to confirm a',
+      'passcode on your phone. Watch the screen for the code.',
+    ].join('\n'),
+    'About to log in to KakaoTalk',
+  )
+  const email = await text({
+    message: 'KakaoTalk email',
+    validate: (value) => (value && value.length > 0 ? undefined : 'Email is required'),
+  })
+  if (isCancel(email)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  const pwd = await password({
+    message: 'KakaoTalk password',
+    validate: (value) => (value && value.length > 0 ? undefined : 'Password is required'),
+  })
+  if (isCancel(pwd)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return { email, password: pwd }
+}
+
+function reportProgress(events: AddChannelStepEvent[]): (event: AddChannelStepEvent) => void {
+  const spinners: Partial<Record<AddChannelStepEvent['step'], ReturnType<typeof spinner>>> = {}
+
+  return (event) => {
+    events.push(event)
+    if (event.phase === 'start') {
+      const s = spinner()
+      s.start(START_MESSAGES[event.step])
+      spinners[event.step] = s
+      return
+    }
+
+    const s = spinners[event.step]
+    if (!s) return
+
+    switch (event.step) {
+      case 'kakaotalk-auth':
+        s.stop(reportKakaotalkAuth(event.result))
+        break
+      case 'config':
+        s.stop('Updated typeclaw.json.')
+        break
+      case 'secrets':
+        s.stop('Appended credentials to .env.')
+        break
+    }
+  }
+}
+
+const START_MESSAGES: Record<AddChannelStepEvent['step'], string> = {
+  'kakaotalk-auth': 'Logging in to KakaoTalk...',
+  config: 'Updating typeclaw.json...',
+  secrets: 'Appending credentials to .env...',
+}
+
+function reportKakaotalkAuth(result: KakaotalkAuthResult): string {
+  if (result.ok) return 'KakaoTalk credentials saved to workspace/.agent-messenger/.'
+  return `KakaoTalk login failed: ${result.reason}`
+}
+
+async function maybePromptRestart(cwd: string): Promise<void> {
+  const current = await status({ cwd }).catch(() => null)
+  if (current === null || current.kind !== 'running') {
+    console.log('Channel added. Run `typeclaw start` (or `typeclaw restart`) to apply the change.')
+    return
+  }
+
+  const restartNow = await confirm({
+    message:
+      'Channel config is restart-required and the agent container is running. Restart it now to apply the new channel?',
+    initialValue: true,
+  })
+  if (isCancel(restartNow) || !restartNow) {
+    console.log('Channel added. Run `typeclaw restart` when you want the new channel to come online.')
+    return
+  }
+
+  const stopped = await stop({ cwd })
+  if (!stopped.ok) {
+    console.error(`Restart failed during stop: ${stopped.reason}`)
+    process.exit(1)
+  }
+  const started = await start({ cwd, preferredHostPort: config.port, cliEntry: process.argv[1] })
+  if (!started.ok) {
+    console.error(`Restart failed during start: ${started.reason}`)
+    process.exit(1)
+  }
+  console.log(`Restarted ${started.plan.containerName} on host port ${started.hostPort}.`)
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 
 import { defineCommand, runMain } from 'citty'
 
+import { channelCommand } from './channel'
 import { composeCommand } from './compose'
 import { hostdCommand } from './hostd'
 import { init } from './init'
@@ -32,6 +33,7 @@ const main = defineCommand({
     logs: logsCommand,
     shell: shellCommand,
     compose: composeCommand,
+    channel: channelCommand,
     _hostd: hostdCommand,
   },
 })

--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { type AddChannelStepEvent, readConfiguredChannels, runAddChannel, scaffold, writeSecrets } from './index'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-add-channel-'))
+  await scaffold(root)
+  await writeSecrets(root, { fireworksApiKey: 'fw_existing' })
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function readConfig(): Promise<{ channels?: Record<string, { allow: string[] }>; [k: string]: unknown }> {
+  return JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
+    channels?: Record<string, { allow: string[] }>
+  }
+}
+
+async function readEnv(): Promise<string> {
+  return readFile(join(root, '.env'), 'utf8')
+}
+
+describe('runAddChannel', () => {
+  test('adds discord-bot to typeclaw.json with allow=["*"] by default', async () => {
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-token-x' })
+
+    const cfg = await readConfig()
+    expect(cfg.channels?.['discord-bot']?.allow).toEqual(['*'])
+  })
+
+  test('adds discord-bot with allow=[] when allowAll=false', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'discord-bot',
+      discordBotToken: 'discord-token-x',
+      allowAll: false,
+    })
+
+    const cfg = await readConfig()
+    expect(cfg.channels?.['discord-bot']?.allow).toEqual([])
+  })
+
+  test('appends DISCORD_BOT_TOKEN to .env without disturbing FIREWORKS_API_KEY', async () => {
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-token-x' })
+
+    const env = await readEnv()
+    expect(env).toContain('FIREWORKS_API_KEY=fw_existing')
+    expect(env).toContain('DISCORD_BOT_TOKEN=discord-token-x')
+  })
+
+  test('adds slack-bot with both bot+app tokens to .env', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'slack-bot',
+      slackBotToken: 'xoxb-bot',
+      slackAppToken: 'xapp-app',
+    })
+
+    const cfg = await readConfig()
+    expect(cfg.channels?.['slack-bot']?.allow).toEqual(['*'])
+    const env = await readEnv()
+    expect(env).toContain('SLACK_BOT_TOKEN=xoxb-bot')
+    expect(env).toContain('SLACK_APP_TOKEN=xapp-app')
+  })
+
+  test('adds telegram-bot to typeclaw.json + .env', async () => {
+    await runAddChannel({ cwd: root, channel: 'telegram-bot', telegramBotToken: '123:tg-secret' })
+
+    const cfg = await readConfig()
+    expect(cfg.channels?.['telegram-bot']?.allow).toEqual(['*'])
+    const env = await readEnv()
+    expect(env).toContain('TELEGRAM_BOT_TOKEN=123:tg-secret')
+  })
+
+  test('adds kakaotalk with kakao:dm/* allow by default and runs auth runner', async () => {
+    const authCalls: string[] = []
+    await runAddChannel({
+      cwd: root,
+      channel: 'kakaotalk',
+      runKakaotalkAuth: async ({ cwd }) => {
+        authCalls.push(cwd)
+        return { ok: true }
+      },
+    })
+
+    expect(authCalls).toEqual([root])
+    const cfg = await readConfig()
+    expect(cfg.channels?.kakaotalk?.allow).toEqual(['kakao:dm/*'])
+    expect(await readEnv()).toBe('FIREWORKS_API_KEY=fw_existing\n')
+  })
+
+  test('kakaotalk with allowAll=true broadens allow to kakao:*', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'kakaotalk',
+      runKakaotalkAuth: async () => ({ ok: true }),
+      allowAll: true,
+    })
+
+    const cfg = await readConfig()
+    expect(cfg.channels?.kakaotalk?.allow).toEqual(['kakao:*'])
+  })
+
+  test('aborts and leaves typeclaw.json + .env untouched when kakaotalk auth fails', async () => {
+    const beforeConfig = await readFile(join(root, 'typeclaw.json'), 'utf8')
+    const beforeEnv = await readEnv()
+
+    await expect(
+      runAddChannel({
+        cwd: root,
+        channel: 'kakaotalk',
+        runKakaotalkAuth: async () => ({ ok: false, reason: 'bad password' }),
+      }),
+    ).rejects.toThrow(/bad password/)
+
+    expect(await readFile(join(root, 'typeclaw.json'), 'utf8')).toBe(beforeConfig)
+    expect(await readEnv()).toBe(beforeEnv)
+  })
+
+  test('preserves an existing channel when adding a different one', async () => {
+    await runAddChannel({ cwd: root, channel: 'slack-bot', slackBotToken: 'xoxb-x', slackAppToken: 'xapp-x' })
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-x' })
+
+    const cfg = await readConfig()
+    expect(cfg.channels?.['slack-bot']?.allow).toEqual(['*'])
+    expect(cfg.channels?.['discord-bot']?.allow).toEqual(['*'])
+    const env = await readEnv()
+    expect(env).toContain('SLACK_BOT_TOKEN=xoxb-x')
+    expect(env).toContain('SLACK_APP_TOKEN=xapp-x')
+    expect(env).toContain('DISCORD_BOT_TOKEN=discord-x')
+  })
+
+  test('preserves arbitrary unrelated keys in typeclaw.json (does not strip user fields)', async () => {
+    const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as Record<string, unknown>
+    cfg.mounts = [{ source: '~/data', target: '/data' }]
+    cfg.idleMs = 60_000
+    await writeFile(join(root, 'typeclaw.json'), `${JSON.stringify(cfg, null, 2)}\n`)
+
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-x' })
+
+    const after = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as Record<string, unknown>
+    expect(after.mounts).toEqual([{ source: '~/data', target: '/data' }])
+    expect(after.idleMs).toBe(60_000)
+  })
+
+  test('rejects re-adding an already-configured channel', async () => {
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-first' })
+
+    await expect(
+      runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-second' }),
+    ).rejects.toThrow(/already configured/i)
+
+    const env = await readEnv()
+    expect(env).toContain('DISCORD_BOT_TOKEN=discord-first')
+    expect(env).not.toContain('DISCORD_BOT_TOKEN=discord-second')
+  })
+
+  test('rejects when an env var the channel needs already exists (does not overwrite user secrets)', async () => {
+    await writeFile(join(root, '.env'), 'FIREWORKS_API_KEY=fw_existing\nDISCORD_BOT_TOKEN=keep-me\n')
+
+    await expect(runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'overwrite-me' })).rejects.toThrow(
+      /DISCORD_BOT_TOKEN/,
+    )
+
+    const env = await readEnv()
+    expect(env).toContain('DISCORD_BOT_TOKEN=keep-me')
+    expect(env).not.toContain('overwrite-me')
+  })
+
+  test('throws a helpful error when run from a non-initialized directory', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'typeclaw-add-empty-'))
+    try {
+      await expect(runAddChannel({ cwd: empty, channel: 'discord-bot', discordBotToken: 'x' })).rejects.toThrow(
+        /typeclaw\.json not found/,
+      )
+    } finally {
+      await rm(empty, { recursive: true, force: true })
+    }
+  })
+
+  test('emits config + secrets events in order for a non-kakaotalk channel', async () => {
+    const events: AddChannelStepEvent[] = []
+    await runAddChannel({
+      cwd: root,
+      channel: 'telegram-bot',
+      telegramBotToken: '123:t',
+      onProgress: (e) => events.push(e),
+    })
+
+    expect(events.map((e) => `${e.step}:${e.phase}`)).toEqual([
+      'config:start',
+      'config:done',
+      'secrets:start',
+      'secrets:done',
+    ])
+  })
+
+  test('emits kakaotalk-auth before config + secrets when adding kakaotalk', async () => {
+    const events: AddChannelStepEvent[] = []
+    await runAddChannel({
+      cwd: root,
+      channel: 'kakaotalk',
+      runKakaotalkAuth: async () => ({ ok: true }),
+      onProgress: (e) => events.push(e),
+    })
+
+    expect(events.map((e) => `${e.step}:${e.phase}`)).toEqual([
+      'kakaotalk-auth:start',
+      'kakaotalk-auth:done',
+      'config:start',
+      'config:done',
+      'secrets:start',
+      'secrets:done',
+    ])
+  })
+})
+
+describe('readConfiguredChannels', () => {
+  test('returns empty set when no channels are configured', async () => {
+    const present = await readConfiguredChannels(root)
+    expect(present.size).toBe(0)
+  })
+
+  test('returns the set of configured channel keys', async () => {
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'd' })
+    await runAddChannel({ cwd: root, channel: 'telegram-bot', telegramBotToken: '1:t' })
+
+    const present = await readConfiguredChannels(root)
+    expect([...present].sort()).toEqual(['discord-bot', 'telegram-bot'])
+  })
+
+  test('returns empty set when typeclaw.json is missing', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'typeclaw-add-noconfig-'))
+    try {
+      const present = await readConfiguredChannels(empty)
+      expect(present.size).toBe(0)
+    } finally {
+      await rm(empty, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -509,3 +509,224 @@ export async function writeSecrets(
 function ignoreExists(error: NodeJS.ErrnoException): void {
   if (error.code !== 'EEXIST') throw error
 }
+
+// ----------------------------------------------------------------------------
+// `typeclaw channel add`
+//
+// `runAddChannel` is the post-init counterpart to `runInit`'s channel-related
+// steps. It is intentionally a separate pipeline rather than a mode switch on
+// `runInit` because the two have opposite file semantics:
+//
+//   - `runInit` creates a fresh agent folder. Writes overwrite by design
+//     (typeclaw.json, .env), and idempotency comes from `wx`-flag guards on
+//     never-rewritten files (markdown stubs, cron.json, package.json).
+//
+//   - `runAddChannel` mutates an already-initialized agent folder. It MUST
+//     preserve the user's existing channel config and existing .env values.
+//     The only writes are an additive merge of one new channel adapter and
+//     an append of that adapter's env vars.
+//
+// Sharing one function would pile mode flags on every helper and turn the
+// "is this overwrite or merge?" question into a runtime branch the test
+// suite would have to cover for both behaviors. The mass of independent
+// scaffold-test cases above demonstrates how easy it is to lose a single
+// behavior under a mode flag.
+
+export type ChannelKind = 'discord-bot' | 'slack-bot' | 'telegram-bot' | 'kakaotalk'
+
+// Public adapter names match the typeclaw.json `channels.*` keys exactly.
+// The CLI takes these as the optional positional arg, the picker shows
+// these labels, and they're the keys we use to detect "already configured"
+// when reading typeclaw.json.
+export const CHANNEL_KINDS: ReadonlyArray<ChannelKind> = ['slack-bot', 'discord-bot', 'telegram-bot', 'kakaotalk']
+
+export type AddChannelStep = 'kakaotalk-auth' | 'config' | 'secrets'
+
+export type AddChannelStepEvent =
+  | { step: 'config'; phase: 'start' }
+  | { step: 'config'; phase: 'done' }
+  | { step: 'kakaotalk-auth'; phase: 'start' }
+  | { step: 'kakaotalk-auth'; phase: 'done'; result: KakaotalkAuthResult }
+  | { step: 'secrets'; phase: 'start' }
+  | { step: 'secrets'; phase: 'done' }
+
+// Discriminated union per channel so the type system enforces "you must pass
+// the right credentials for the channel you're adding". The CLI builds these
+// from prompts; tests build them inline.
+export type AddChannelOptions = {
+  cwd: string
+  allowAll?: boolean
+  onProgress?: (event: AddChannelStepEvent) => void
+} & (
+  | { channel: 'discord-bot'; discordBotToken: string }
+  | { channel: 'slack-bot'; slackBotToken: string; slackAppToken: string }
+  | { channel: 'telegram-bot'; telegramBotToken: string }
+  | { channel: 'kakaotalk'; runKakaotalkAuth: KakaotalkAuthRunner }
+)
+
+export async function runAddChannel(options: AddChannelOptions): Promise<void> {
+  const emit = options.onProgress ?? (() => {})
+
+  // Order: kakaotalk-auth (if applicable) -> config -> secrets.
+  //
+  // We run KakaoTalk auth FIRST so a failed login leaves typeclaw.json and
+  // .env untouched. The runtime treats `channels.kakaotalk` without a
+  // credentials file as "missing credentials, skip adapter", which silently
+  // drops messages — the same trap `runInit` already guards against. Aborting
+  // before any file write means the user's next `typeclaw channel add
+  // kakaotalk` retry has no half-applied state to clean up.
+  if (options.channel === 'kakaotalk') {
+    emit({ step: 'kakaotalk-auth', phase: 'start' })
+    const result = await options.runKakaotalkAuth({ cwd: options.cwd })
+    emit({ step: 'kakaotalk-auth', phase: 'done', result })
+    if (!result.ok) throw new Error(`KakaoTalk authentication failed: ${result.reason}`)
+  }
+
+  emit({ step: 'config', phase: 'start' })
+  await mergeChannelIntoConfig(options.cwd, options.channel, options.allowAll ?? defaultAllowAll(options.channel))
+  emit({ step: 'config', phase: 'done' })
+
+  emit({ step: 'secrets', phase: 'start' })
+  await appendChannelSecrets(options.cwd, channelSecretsFromOptions(options))
+  emit({ step: 'secrets', phase: 'done' })
+}
+
+// `channel add` mirrors `runInit`'s allow defaults: workspace-scoped adapters
+// (discord/slack/telegram) default to `*` because the bot only sees what the
+// operator invited it into, while KakaoTalk uses a personal account and
+// defaults to DMs only.
+function defaultAllowAll(channel: ChannelKind): boolean {
+  return channel !== 'kakaotalk'
+}
+
+function channelSecretsFromOptions(options: AddChannelOptions): ChannelSecrets {
+  switch (options.channel) {
+    case 'discord-bot':
+      return { DISCORD_BOT_TOKEN: options.discordBotToken }
+    case 'slack-bot':
+      return { SLACK_BOT_TOKEN: options.slackBotToken, SLACK_APP_TOKEN: options.slackAppToken }
+    case 'telegram-bot':
+      return { TELEGRAM_BOT_TOKEN: options.telegramBotToken }
+    case 'kakaotalk':
+      // Credentials live in workspace/.agent-messenger/, not .env.
+      return {}
+  }
+}
+
+type ChannelSecrets = Record<string, string>
+
+// Returns the set of channel keys already present in typeclaw.json. Used by
+// the CLI's picker to hide already-configured adapters and to reject explicit
+// re-adds with a clear error rather than silently merging.
+export async function readConfiguredChannels(cwd: string): Promise<Set<ChannelKind>> {
+  const path = join(cwd, CONFIG_FILE)
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return new Set()
+    throw error
+  }
+  const parsed = JSON.parse(raw) as { channels?: Record<string, unknown> }
+  const channels = parsed.channels ?? {}
+  const present = new Set<ChannelKind>()
+  for (const kind of CHANNEL_KINDS) {
+    if (kind in channels) present.add(kind)
+  }
+  return present
+}
+
+async function mergeChannelIntoConfig(cwd: string, channel: ChannelKind, allowAll: boolean): Promise<void> {
+  const path = join(cwd, CONFIG_FILE)
+  let parsed: Record<string, unknown>
+  try {
+    const raw = await readFile(path, 'utf8')
+    parsed = JSON.parse(raw) as Record<string, unknown>
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `${CONFIG_FILE} not found at ${cwd}. Run \`typeclaw init\` before adding channels, or run this command from inside an agent folder.`,
+      )
+    }
+    throw error
+  }
+
+  const existingChannels =
+    typeof parsed.channels === 'object' && parsed.channels !== null && !Array.isArray(parsed.channels)
+      ? (parsed.channels as Record<string, unknown>)
+      : {}
+
+  if (channel in existingChannels) {
+    // Defense in depth — the CLI already filters configured channels out of
+    // the picker and rejects them as the positional arg. Hitting this branch
+    // means a programmatic caller passed a duplicate; better to fail loudly
+    // than silently overwrite the user's existing allow list.
+    throw new Error(`Channel "${channel}" is already configured in ${CONFIG_FILE}.`)
+  }
+
+  parsed.channels = {
+    ...existingChannels,
+    [channel]: { allow: buildAllow(channel, allowAll) },
+  }
+
+  await writeFile(path, `${JSON.stringify(parsed, null, 2)}\n`)
+}
+
+function buildAllow(channel: ChannelKind, allowAll: boolean): string[] {
+  if (channel === 'kakaotalk') return allowAll ? ['kakao:*'] : ['kakao:dm/*']
+  return allowAll ? ['*'] : []
+}
+
+// Appends only keys that are not already present in .env. We never rewrite
+// existing values: if the user has `SLACK_BOT_TOKEN=` left over from a manual
+// edit, we surface that as a hard error rather than overwrite the user's
+// hand-rolled value.
+//
+// `.env` parsing is intentionally line-based and dumb (matching dotenv's
+// minimum surface): trim, skip blanks/comments, split on the first `=`. We do
+// not unquote values because we only check for key presence.
+async function appendChannelSecrets(cwd: string, secrets: ChannelSecrets): Promise<void> {
+  if (Object.keys(secrets).length === 0) return
+
+  const path = join(cwd, SECRETS_FILE)
+  let existing: string
+  try {
+    existing = await readFile(path, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `${SECRETS_FILE} not found at ${cwd}. Run \`typeclaw init\` before adding channels, or run this command from inside an agent folder.`,
+      )
+    }
+    throw error
+  }
+
+  const presentKeys = parseEnvKeys(existing)
+  for (const key of Object.keys(secrets)) {
+    if (presentKeys.has(key)) {
+      throw new Error(
+        `${key} is already set in ${SECRETS_FILE}. Remove it before re-adding the channel, or edit the value by hand.`,
+      )
+    }
+  }
+
+  // Ensure exactly one trailing newline before our appended block so the
+  // resulting file remains POSIX-clean even if the user's editor stripped it.
+  const trailingNewline = existing.endsWith('\n') || existing === '' ? '' : '\n'
+  const appended = Object.entries(secrets)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n')
+  await writeFile(path, `${existing}${trailingNewline}${appended}\n`)
+}
+
+function parseEnvKeys(content: string): Set<string> {
+  const keys = new Set<string>()
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim()
+    if (line === '' || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq <= 0) continue
+    keys.add(line.slice(0, eq).trim())
+  }
+  return keys
+}


### PR DESCRIPTION
## Summary

`typeclaw init` only wires one channel at hatch time and offers no way to add another later short of hand-editing `typeclaw.json` + `.env`. This adds `typeclaw channel add [adapter]` to do exactly the channel-only subset of init against an already-hatched agent.

- New CLI: `typeclaw channel add` (interactive picker, hides already-configured adapters) and `typeclaw channel add <adapter>` (positional, skips the picker; rejects already-configured names with a clear error).
- New domain pipeline: `runAddChannel` in `src/init/index.ts`. Merges into `typeclaw.json` and appends to `.env` without overwriting existing values — duplicate channel config and env-key collisions fail loud rather than clobber. KakaoTalk auth runs **before** any file write so a failed login leaves zero half-applied state (the same trap the existing init flow guards against).
- Detects a running container after the add and offers to restart it, since `channels.*` is restart-required (per `FIELD_EFFECTS` in `src/config/config.ts`).

## Why a separate pipeline (not a flag on \`runInit\`)

\`runInit\` creates a fresh agent folder with overwrite semantics; \`runAddChannel\` mutates an existing one and must preserve user state. Sharing one function would pile mode flags on every helper and blur the "overwrite vs merge" contract that the init test suite already encodes for one branch only. Kept the two pipelines parallel and independently tested.

## Tests

- \`src/init/add-channel.test.ts\` — 18 new tests covering: per-adapter config + env writes, default vs \`allowAll: false\`, KakaoTalk auth ordering (config + env untouched on auth failure), preservation of existing channels and unrelated config keys, duplicate-channel rejection, env-key collision rejection, missing-config error path, event emission ordering, and \`readConfiguredChannels\` semantics.
- Mutation-checked: deleting the merge spread (\`...existingChannels\`) breaks 2 tests as expected.
- \`bun run typecheck\`, \`bun run lint\`, \`bun run format\`, full \`bun test\` (2289 tests) all pass.

## Out of scope

- No multi-channel-per-invocation: matches \`init\`'s "one channel at a time" UX (per design discussion). Run the command twice to add two channels.
- No \`channel remove\` / \`channel list\` yet — could be follow-ups.