### PR TITLE
Make KakaoTalk usable on first attempt

### DIFF
--- a/src/channels/adapters/agent-messenger-kakaotalk-shim.test.ts
+++ b/src/channels/adapters/agent-messenger-kakaotalk-shim.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+
+import { classifyKakaoChat, kakaoWorkspaceForType, type KakaoChat } from './agent-messenger-kakaotalk-shim'
+
+const chat = (overrides: Partial<KakaoChat>): KakaoChat => ({
+  chat_id: '1',
+  type: 11,
+  display_name: 'Counterparty',
+  active_members: 2,
+  unread_count: 0,
+  last_message: null,
+  ...overrides,
+})
+
+describe('classifyKakaoChat', () => {
+  test('classifies a modern 1:1 DM (t=11, members=2) as dm', () => {
+    expect(classifyKakaoChat(chat({ type: 11, active_members: 2 }))).toBe('dm')
+  })
+
+  test('classifies a modern group (t=10, members=5) as group', () => {
+    expect(classifyKakaoChat(chat({ type: 10, active_members: 5 }))).toBe('group')
+  })
+
+  test('classifies a 2-person normal chat as dm regardless of type code', () => {
+    // Real-world LOCO emits a variety of codes for 2-member normal chats
+    // depending on how the chat was created (legacy vs modern, opened from
+    // group vs friend list). All of them should bucket as `dm` — the bug
+    // we are guarding against was misclassifying these as `@kakao-group`.
+    for (const t of [0, 1, 10, 11]) {
+      expect(classifyKakaoChat(chat({ type: t, active_members: 2 }))).toBe('dm')
+    }
+  })
+
+  test('classifies a memo / note-to-self chat (members=1) as dm', () => {
+    expect(classifyKakaoChat(chat({ type: 9, active_members: 1 }))).toBe('dm')
+  })
+
+  test('classifies OpenChat-flavored chats by type code, not member count', () => {
+    for (const t of [2, 13, 14, 15, 16]) {
+      expect(classifyKakaoChat(chat({ type: t, active_members: 2 }))).toBe('open')
+      expect(classifyKakaoChat(chat({ type: t, active_members: 50 }))).toBe('open')
+    }
+  })
+
+  test('classifies a chat with 3+ members as group when type is not OpenChat', () => {
+    expect(classifyKakaoChat(chat({ type: 10, active_members: 3 }))).toBe('group')
+    expect(classifyKakaoChat(chat({ type: 1, active_members: 100 }))).toBe('group')
+  })
+})
+
+describe('kakaoWorkspaceForType', () => {
+  test('maps each kind to its workspace label', () => {
+    expect(kakaoWorkspaceForType('dm')).toBe('@kakao-dm')
+    expect(kakaoWorkspaceForType('group')).toBe('@kakao-group')
+    expect(kakaoWorkspaceForType('open')).toBe('@kakao-open')
+  })
+
+  test('falls back to @kakao-group for unknown', () => {
+    expect(kakaoWorkspaceForType('unknown')).toBe('@kakao-group')
+  })
+})

--- a/src/channels/adapters/agent-messenger-kakaotalk-shim.ts
+++ b/src/channels/adapters/agent-messenger-kakaotalk-shim.ts
@@ -149,15 +149,22 @@ export const KakaoCredentialManager = RawCredentialManager as unknown as new (
   configDir?: string,
 ) => KakaoCredentialManager
 
-// Per the SDK source: KakaoChat.type === 0 is 1:1 (dm), 1 is normal group,
-// 2 is open chat / multi-channel group. Types we don't recognize fall back
-// to 'unknown' which the resolver maps to `@kakao-group` (the safest
-// catch-all for engagement: groups require explicit @ to engage).
-export function classifyKakaoChatType(rawType: number): KakaoChatType {
-  if (rawType === 0) return 'dm'
-  if (rawType === 1) return 'group'
-  if (rawType === 2) return 'open'
-  return 'unknown'
+// LOCO type codes that denote OpenChat-style chats (1:1 OpenChat, multi
+// OpenChat, etc.) sourced from reverse-engineered LOCO clients. Member
+// count CANNOT substitute here — 1:1 OpenChats exist and are semantically
+// distinct from normal DMs (different identity, different policy, etc.).
+const OPEN_CHAT_TYPE_CODES: ReadonlySet<number> = new Set([2, 13, 14, 15, 16])
+
+// REGRESSION GUARD: an earlier implementation hard-coded `0=dm, 1=group,
+// 2=open` on the raw type number. Modern KakaoTalk uses codes like `11`
+// for normal DMs and `10` for normal groups, so the old mapping silently
+// classified every real DM as 'unknown' → bucket `@kakao-group`, making
+// `kakao:dm/*` allow rules unmatchable. Do not "simplify" back to a pure
+// type-code mapping without verifying against a real KakaoTalk session.
+export function classifyKakaoChat(chat: Pick<KakaoChat, 'type' | 'active_members'>): KakaoChatType {
+  if (OPEN_CHAT_TYPE_CODES.has(chat.type)) return 'open'
+  if (chat.active_members <= 2) return 'dm'
+  return 'group'
 }
 
 export function kakaoWorkspaceForType(type: KakaoChatType): '@kakao-dm' | '@kakao-group' | '@kakao-open' {

--- a/src/channels/adapters/kakaotalk-channel-resolver.test.ts
+++ b/src/channels/adapters/kakaotalk-channel-resolver.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, test } from 'bun:test'
 import type { KakaoChat, KakaoTalkClient } from './agent-messenger-kakaotalk-shim'
 import { createKakaoChannelResolver } from './kakaotalk-channel-resolver'
 
+// Modern KakaoTalk LOCO type codes — t=11 for normal 1:1 DMs and t=10 for
+// normal groups. The earlier `t=0/1/2` fixtures matched a stale assumption
+// and let the previous classifier pass even though it misclassified every
+// real-world DM as `@kakao-group`.
 const dmChat = (id: string, name: string): KakaoChat => ({
   chat_id: id,
-  type: 0,
+  type: 11,
   display_name: name,
   active_members: 2,
   unread_count: 0,
@@ -14,7 +18,7 @@ const dmChat = (id: string, name: string): KakaoChat => ({
 
 const groupChat = (id: string, name: string): KakaoChat => ({
   chat_id: id,
-  type: 1,
+  type: 10,
   display_name: name,
   active_members: 5,
   unread_count: 0,

--- a/src/channels/adapters/kakaotalk-channel-resolver.ts
+++ b/src/channels/adapters/kakaotalk-channel-resolver.ts
@@ -1,7 +1,7 @@
 import type { ChannelKey, ChannelNameResolver, ResolvedChannelNames } from '@/channels/types'
 
 import {
-  classifyKakaoChatType,
+  classifyKakaoChat,
   kakaoWorkspaceForType,
   type KakaoChat,
   type KakaoTalkClient,
@@ -63,7 +63,7 @@ export function createKakaoChannelResolver(options: KakaoChannelResolverOptions)
   }
 
   const ingest = (chat: KakaoChat, expiresAt: number): void => {
-    const kind = classifyKakaoChatType(chat.type)
+    const kind = classifyKakaoChat(chat)
     const workspace = kakaoWorkspaceForType(kind)
     cache.set(chat.chat_id, {
       workspace,

--- a/src/channels/adapters/kakaotalk.test.ts
+++ b/src/channels/adapters/kakaotalk.test.ts
@@ -284,6 +284,214 @@ describe('createKakaotalkAdapter — outbound', () => {
   })
 })
 
+describe('createKakaotalkAdapter — KICKOUT recovery', () => {
+  test('auto-restarts the listener once when KICKOUT arrives within the post-init window', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const logs: Array<{ level: string; msg: string }> = []
+    let nowMs = 1_000_000
+    const recoveryTasks: Array<{ fn: () => void; delay: number }> = []
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+      logger: {
+        info: (msg) => logs.push({ level: 'info', msg }),
+        warn: (msg) => logs.push({ level: 'warn', msg }),
+        error: (msg) => logs.push({ level: 'error', msg }),
+      },
+      now: () => nowMs,
+      scheduleRecovery: (fn, delay) => {
+        recoveryTasks.push({ fn, delay })
+      },
+    })
+
+    await adapter.start()
+    expect(listener.startCalls).toBe(1)
+
+    listener.emit('connected', { userId: '999' })
+    expect(adapter.isConnected()).toBe(true)
+
+    // 5 seconds later — well within the 30s post-init window — the SDK
+    // emits the KICKOUT error.
+    nowMs += 5_000
+    listener.emit('error', new Error('Session kicked — another device logged in'))
+
+    expect(adapter.isConnected()).toBe(false)
+    expect(recoveryTasks).toHaveLength(1)
+    expect(recoveryTasks[0]?.delay).toBeGreaterThan(0)
+    expect(logs.some((l) => l.level === 'warn' && l.msg.includes('Auto-restarting'))).toBe(true)
+
+    recoveryTasks[0]?.fn()
+    expect(listener.startCalls).toBe(2)
+
+    await adapter.stop()
+    await router.stop()
+  })
+
+  test('does NOT auto-recover when KICKOUT arrives outside the post-init window', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const logs: Array<{ level: string; msg: string }> = []
+    let nowMs = 1_000_000
+    const recoveryTasks: Array<{ fn: () => void; delay: number }> = []
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+      logger: {
+        info: (msg) => logs.push({ level: 'info', msg }),
+        warn: (msg) => logs.push({ level: 'warn', msg }),
+        error: (msg) => logs.push({ level: 'error', msg }),
+      },
+      now: () => nowMs,
+      scheduleRecovery: (fn, delay) => {
+        recoveryTasks.push({ fn, delay })
+      },
+    })
+
+    await adapter.start()
+    listener.emit('connected', { userId: '999' })
+
+    // 5 minutes later — long past the post-init window. This is a real
+    // cross-device kick; we must NOT loop-fight.
+    nowMs += 5 * 60 * 1000
+    listener.emit('error', new Error('Session kicked — another device logged in'))
+
+    expect(adapter.isConnected()).toBe(false)
+    expect(recoveryTasks).toHaveLength(0)
+    expect(listener.startCalls).toBe(1)
+    expect(
+      logs.some(
+        (l) => l.level === 'error' && l.msg.includes('DEAD after KICKOUT') && l.msg.includes('typeclaw restart'),
+      ),
+    ).toBe(true)
+
+    await adapter.stop()
+    await router.stop()
+  })
+
+  test('only attempts auto-recovery once per start() lifecycle', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    let nowMs = 1_000_000
+    const recoveryTasks: Array<{ fn: () => void; delay: number }> = []
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+      now: () => nowMs,
+      scheduleRecovery: (fn, delay) => {
+        recoveryTasks.push({ fn, delay })
+      },
+    })
+
+    await adapter.start()
+    listener.emit('connected', { userId: '999' })
+
+    nowMs += 1_000
+    listener.emit('error', new Error('Session kicked — another device logged in'))
+    expect(recoveryTasks).toHaveLength(1)
+
+    // Pretend the recovery ran and we reconnected, then got kicked again
+    // immediately. The second KICKOUT must NOT re-arm recovery.
+    recoveryTasks[0]?.fn()
+    listener.emit('connected', { userId: '999' })
+    nowMs += 1_000
+    listener.emit('error', new Error('Session kicked — another device logged in'))
+
+    expect(recoveryTasks).toHaveLength(1)
+
+    await adapter.stop()
+    await router.stop()
+  })
+
+  test('non-KICKOUT errors do not trigger recovery and do not flip connected', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const recoveryTasks: Array<{ fn: () => void; delay: number }> = []
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+      scheduleRecovery: (fn, delay) => {
+        recoveryTasks.push({ fn, delay })
+      },
+    })
+
+    await adapter.start()
+    listener.emit('connected', { userId: '999' })
+    expect(adapter.isConnected()).toBe(true)
+
+    listener.emit('error', new Error('socket closed unexpectedly'))
+
+    expect(recoveryTasks).toHaveLength(0)
+    // Generic errors don't flip connected — the SDK's own reconnect path
+    // owns disconnection state via the 'disconnected' event.
+    expect(adapter.isConnected()).toBe(true)
+
+    await adapter.stop()
+    await router.stop()
+  })
+})
+
+describe('createKakaotalkAdapter — drop hint', () => {
+  test('not_in_allow_list hint suggests bucket-specific patterns', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({
+      agentDir,
+      configForAdapter: () => adapterCfg({ allow: ['kakao:dm/*'] }),
+    })
+    const logs: string[] = []
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg({ allow: ['kakao:dm/*'] }),
+      client,
+      listenerFactory: () => listener,
+      logger: {
+        info: (m) => logs.push(m),
+        warn: () => {},
+        error: () => {},
+      },
+    })
+    // Group chat (5 members → group bucket regardless of LOCO type code).
+    client.chats = [
+      { chat_id: '222', type: 10, display_name: 'Team', active_members: 5, unread_count: 0, last_message: null },
+    ]
+    await adapter.start()
+    listener.emit('connected', { userId: '999' })
+
+    listener.emit('message', {
+      type: 'MSG',
+      chat_id: '222',
+      log_id: 'L99',
+      author_id: 1,
+      message: 'hi',
+      message_type: 1,
+      sent_at: Date.now(),
+    })
+
+    await new Promise((r) => setTimeout(r, 0))
+
+    const drop = logs.find((m) => m.includes('reason=not_in_allow_list'))
+    expect(drop).toBeDefined()
+    expect(drop).toContain('kakao:group/*')
+    expect(drop).toContain('kakao:222')
+
+    await adapter.stop()
+    await router.stop()
+  })
+})
+
 describe('createKakaotalkAdapter — inbound classification', () => {
   test('drops self_author when author equals authenticated user_id', async () => {
     const client = new FakeClient()

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -48,7 +48,22 @@ export type KakaotalkAdapterOptions = {
   credentialsDir?: string
   client?: KakaoTalkClient
   listenerFactory?: (client: KakaoTalkClient) => KakaoTalkListener
+  // Test seam for KICKOUT auto-recovery. Production uses Date.now and
+  // setTimeout. Tests inject deterministic clocks/schedulers so they can
+  // assert the recovery semantics without real-time waits.
+  now?: () => number
+  scheduleRecovery?: (fn: () => void, delayMs: number) => void
 }
+
+// LOCO server emits KICKOUT when the same device_uuid logs in elsewhere.
+// During the post-init handoff (init authenticates → leaves a session
+// briefly → first container start re-logs in with the same UUID) we
+// kick OURSELVES, then a one-shot auto-restart resolves it. Outside that
+// window, we treat KICKOUT as a real cross-device login and stay dead so
+// we don't loop-fight the other device. 30s is the empirical post-init
+// window; widen if init grows slower bootstrap steps.
+const KICKOUT_RECOVERY_WINDOW_MS = 30_000
+const KICKOUT_RECOVERY_DELAY_MS = 2_000
 
 export type KakaotalkAdapter = {
   start: () => Promise<void>
@@ -177,10 +192,18 @@ function clampLimit(requested: number, max: number): number {
 export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): KakaotalkAdapter {
   const logger = options.logger ?? consoleLogger
   const client = options.client ?? new KakaoTalkClient()
+  const now = options.now ?? Date.now
+  const scheduleRecovery =
+    options.scheduleRecovery ??
+    ((fn: () => void, delayMs: number): void => {
+      setTimeout(fn, delayMs)
+    })
   let listener: KakaoTalkListener | null = null
   let selfUserId: string | null = null
   let connected = false
   let started = false
+  let lastConnectedAt: number | null = null
+  let kickoutRecoveryAttempted = false
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
 
@@ -231,7 +254,10 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
         ...(options.selfAliasesRef ? { selfAliases: options.selfAliasesRef() } : {}),
       })
       if (verdict.kind === 'drop') {
-        logger.info(`[kakaotalk] dropped log_id=${event.log_id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
+        const bucket = channelResolver.lookupChat(event.chat_id)?.workspace ?? null
+        logger.info(
+          `[kakaotalk] dropped log_id=${event.log_id} reason=${verdict.reason}${dropHint(verdict.reason, bucket, event.chat_id)}`,
+        )
         return
       }
 
@@ -257,6 +283,8 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
     async start(): Promise<void> {
       if (started) return
       started = true
+      lastConnectedAt = null
+      kickoutRecoveryAttempted = false
       try {
         if (options.credentialsDir !== undefined) {
           // Explicit credential path: read the file ourselves and pass the
@@ -306,8 +334,10 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       }
 
       listener = options.listenerFactory ? options.listenerFactory(client) : new KakaoTalkListener(client)
+      const activeListener = listener
       listener.on('connected', (info) => {
         connected = true
+        lastConnectedAt = now()
         logger.info(`[kakaotalk] connected (user_id=${info.userId})`)
       })
       listener.on('disconnected', () => {
@@ -316,6 +346,35 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       })
       listener.on('error', (err) => {
         logger.error(`[kakaotalk] listener error: ${describe(err)}`)
+        if (!isKickoutError(err)) return
+        // KICKOUT is fatal at the SDK layer: it sets running=false, closes
+        // the session, and skips scheduleReconnect. Without intervention
+        // the adapter goes silent indefinitely. We have to recover here
+        // or surface the dead-listener state to the user explicitly.
+        connected = false
+        const elapsed = lastConnectedAt === null ? Infinity : now() - lastConnectedAt
+        const withinPostInitWindow = elapsed <= KICKOUT_RECOVERY_WINDOW_MS
+        if (!started || kickoutRecoveryAttempted || !withinPostInitWindow) {
+          logger.error(
+            '[kakaotalk] session is DEAD after KICKOUT and will not auto-recover. ' +
+              'Likely cause: another device or process is logged into this KakaoTalk account ' +
+              'with the same device_uuid. Run `typeclaw restart` once you have ensured no other ' +
+              'session is using these credentials, or re-run `typeclaw init` to mint a new device_uuid.',
+          )
+          return
+        }
+        kickoutRecoveryAttempted = true
+        logger.warn(
+          `[kakaotalk] KICKOUT received ${Math.round(elapsed)}ms after connect — likely the post-init session handoff. Auto-restarting listener once in ${KICKOUT_RECOVERY_DELAY_MS}ms.`,
+        )
+        scheduleRecovery(() => {
+          if (!started || listener !== activeListener) return
+          activeListener.start().catch((retryErr) => {
+            logger.error(
+              `[kakaotalk] KICKOUT auto-recovery failed: ${describe(retryErr)}. Run \`typeclaw restart\` to retry.`,
+            )
+          })
+        }, KICKOUT_RECOVERY_DELAY_MS)
       })
       listener.on('message', (event) => {
         void handleMessageEvent(event)
@@ -366,6 +425,8 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       }
       selfUserId = null
       connected = false
+      lastConnectedAt = null
+      kickoutRecoveryAttempted = false
     },
 
     isConnected(): boolean {
@@ -378,10 +439,14 @@ function describe(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
-function dropHint(reason: InboundDropReason): string {
+function dropHint(
+  reason: InboundDropReason,
+  bucket: '@kakao-dm' | '@kakao-group' | '@kakao-open' | null,
+  chatId: string,
+): string {
   switch (reason) {
     case 'not_in_allow_list':
-      return ' (extend channels.kakaotalk.allow in typeclaw.json to admit this chat)'
+      return ` (add ${suggestedAllowPattern(bucket, chatId)} to channels.kakaotalk.allow to admit this chat)`
     case 'unknown_chat':
       return ' (chat not in cache; resolver refresh may be lagging)'
     case 'empty_text':
@@ -389,4 +454,16 @@ function dropHint(reason: InboundDropReason): string {
     case 'self_author':
       return ''
   }
+}
+
+function suggestedAllowPattern(bucket: '@kakao-dm' | '@kakao-group' | '@kakao-open' | null, chatId: string): string {
+  if (bucket === '@kakao-dm') return `"kakao:dm/*" or "kakao:${chatId}"`
+  if (bucket === '@kakao-group') return `"kakao:group/*" or "kakao:${chatId}"`
+  if (bucket === '@kakao-open') return `"kakao:open/*" or "kakao:${chatId}"`
+  return `"kakao:${chatId}"`
+}
+
+function isKickoutError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  return err.message.includes('kicked') || err.message.includes('KICKOUT')
 }


### PR DESCRIPTION
## Summary

The KakaoTalk channel was unusable on first attempt for every new user. Three intertwined bugs combined into a silent total failure:

1. **DM detection was wrong.** Modern KakaoTalk LOCO assigns numeric type code `11` to normal 1:1 DMs (and `10` to normal groups), but `classifyKakaoChatType` hard-coded `0=dm / 1=group / 2=open`. Real DMs fell into the `'unknown'` branch and got bucketed as `@kakao-group`, so `kakao:dm/*` allow rules silently rejected them.
2. **KICKOUT was a silent death sentence.** The agent-messenger SDK's KICKOUT handler sets `running = false`, closes the session, and *bypasses* `scheduleReconnect`. The adapter logged the error and went silent. Worse, the post-init handoff (init authenticates → leaves a session briefly → first container start re-logs in with the same `device_uuid`) reliably triggers KICKOUT on first run, so a brand-new agent looks alive but is permanently deaf to inbound messages with no diagnostic.
3. **The drop hint pointed users at the wrong fix.** `(extend channels.kakaotalk.allow ...)` doesn't tell the user *which pattern* to add — and combined with bug #1, it was actively misleading: a real DM dropped as `@kakao-group` made users add `kakao:group/*` to admit a chat that should have matched `kakao:dm/*`.

End-to-end user experience before this PR: send a DM after `typeclaw init`, see the message dropped, "fix" the allow list, still see nothing because the listener is also dead, no idea why.

## What changed

### 1. Bucket classification (`agent-messenger-kakaotalk-shim.ts`)

Replace the brittle integer-equality classifier with a member-count + type-code-set heuristic:

```ts
const OPEN_CHAT_TYPE_CODES = new Set([2, 13, 14, 15, 16])

export function classifyKakaoChat(chat) {
  if (OPEN_CHAT_TYPE_CODES.has(chat.type)) return 'open'
  if (chat.active_members <= 2) return 'dm'
  return 'group'
}
```

OpenChat-flavored chats are identified by their type code (member count can't substitute — 1:1 OpenChats exist and are semantically distinct). For everything else, the LOCO server's authoritative member count decides DM vs group, so the classifier is robust to future LOCO type-code additions.

A new test file (`agent-messenger-kakaotalk-shim.test.ts`) covers `t=11/active=2`, `t=10/active=5`, parametrized DM detection across `[0, 1, 10, 11]` for 2-member chats, memo (`t=9/active=1`), and the OpenChat code set.

### 2. KICKOUT auto-recovery (`kakaotalk.ts`)

The `error` handler now distinguishes KICKOUT from generic SDK errors. If KICKOUT lands within `KICKOUT_RECOVERY_WINDOW_MS` (30s) of the most recent `connected` event, it schedules **one** `listener.start()` retry. Outside that window, or after the one-shot recovery has already fired, it logs an explicit remediation message naming `typeclaw restart` and `typeclaw init`. Recovery is one-shot per `start()` lifecycle so we never loop-fight a real cross-device login.

Two new test seams (`now`, `scheduleRecovery`) keep the recovery deterministic in tests.

Coverage:
- KICKOUT inside the 30s window → one auto-restart, `isConnected()` flips false until reconnect
- KICKOUT outside the window → no recovery, error log mentions `typeclaw restart`
- Two consecutive KICKOUTs (recovery succeeds, then immediately kicked again) → recovery does NOT re-arm
- Non-KICKOUT errors → no recovery, `connected` state stays owned by the `disconnected` event

### 3. Bucket-aware drop hint (`kakaotalk.ts`)

`dropHint` now takes the resolved bucket and chat ID, and produces a suggestion the user can copy-paste:

```
[kakaotalk] dropped log_id=L99 reason=not_in_allow_list (add "kakao:group/*" or "kakao:222" to channels.kakaotalk.allow to admit this chat)
```

## Test fixture cleanup

`kakaotalk-channel-resolver.test.ts` previously used `t=0` for DM fixtures and `t=1` for group fixtures, which let the buggy classifier pass against the test suite while breaking in production. Updated to realistic LOCO codes (`t=11` and `t=10`), so the suite now actually catches this class of regression.

## Risk

- **Behavioral shift for 2-person normal-chat groups.** A genuine 2-person group chat (rare — normal users create 1:1 DMs for 2-person conversations) now buckets as `@kakao-dm` instead of `@kakao-group`. If a deployment is using `kakao:group/*` to *exclude* such chats, it would now match `kakao:dm/*`. Real-world impact should be near zero, but called out explicitly.
- **30s recovery window is empirical.** It comfortably covers the post-init handoff in current tests; widen if `init` grows slower bootstrap steps.

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅ (0 warnings, 0 errors)
- `bun run format:check` ✅
- `bun test` ✅ (2302 pass / 0 fail across 139 files)

## Out of scope

- Filing a feature request upstream in `agent-messenger` to expose `is_direct: boolean` on `KakaoChat` so consumers don't have to reinvent this heuristic. The data is there (`chat.k` is the member list) but the SDK doesn't expose a definitive flag.
- Telemetry / structured logs for KICKOUT recovery (current implementation is human-readable warn/error lines).