### PR TITLE
Log when a cron job's schedule fails to parse instead of silently dropping it

### DIFF
--- a/src/cron/scheduler.test.ts
+++ b/src/cron/scheduler.test.ts
@@ -533,3 +533,115 @@ describe('Scheduler.replaceJobs', () => {
     sched.stop()
   })
 })
+
+describe('schedule failure surfacing', () => {
+  function createCapturingLogger(): SchedulerLogger & { warns: string[]; errors: string[] } {
+    const warns: string[] = []
+    const errors: string[] = []
+    return {
+      info: () => {},
+      warn: (m) => warns.push(m),
+      error: (m) => errors.push(m),
+      warns,
+      errors,
+    }
+  }
+
+  test('logs a warning naming the job id and parse error when schedule cannot be parsed', () => {
+    const clock = createFakeClock()
+    const recorder = createFireRecorder()
+    const logger = createCapturingLogger()
+    const scheduler = createScheduler({
+      jobs: [promptJob('broken', 'not a real schedule')],
+      onFire: recorder.onFire,
+      clock,
+      logger,
+    })
+
+    scheduler.start()
+
+    expect(logger.warns).toHaveLength(1)
+    expect(logger.warns[0]).toContain('broken')
+    expect(logger.warns[0]).toMatch(/schedule|parse|invalid/i)
+
+    scheduler.stop()
+  })
+
+  test('logs a warning when timezone is unresolvable at runtime', () => {
+    const clock = createFakeClock()
+    const recorder = createFireRecorder()
+    const logger = createCapturingLogger()
+    const scheduler = createScheduler({
+      jobs: [promptJob('bad-tz', '* * * * *', { timezone: 'Not/A_Real_Zone' })],
+      onFire: recorder.onFire,
+      clock,
+      logger,
+    })
+
+    scheduler.start()
+
+    expect(logger.warns).toHaveLength(1)
+    expect(logger.warns[0]).toContain('bad-tz')
+    expect(logger.warns[0]).toContain('Not/A_Real_Zone')
+  })
+
+  test('a single broken schedule does not block sibling jobs from firing', async () => {
+    const clock = createFakeClock()
+    const recorder = createFireRecorder()
+    const logger = createCapturingLogger()
+    const scheduler = createScheduler({
+      jobs: [promptJob('broken', 'not a real schedule'), promptJob('healthy', '* * * * *')],
+      onFire: recorder.onFire,
+      clock,
+      logger,
+    })
+
+    scheduler.start()
+    await clock.advance(60 * 1000 + 100)
+
+    expect(recorder.fires.map((c) => c.id)).toEqual(['healthy'])
+    expect(logger.warns.some((w) => w.includes('broken'))).toBe(true)
+
+    scheduler.stop()
+  })
+
+  test('replaceJobs warns when an added job has an unparseable schedule', () => {
+    const clock = createFakeClock()
+    const recorder = createFireRecorder()
+    const logger = createCapturingLogger()
+    const scheduler = createScheduler({
+      jobs: [promptJob('healthy', '* * * * *')],
+      onFire: recorder.onFire,
+      clock,
+      logger,
+    })
+    scheduler.start()
+    expect(logger.warns).toHaveLength(0)
+
+    scheduler.replaceJobs([promptJob('healthy', '* * * * *'), promptJob('broken', 'not a real schedule')])
+
+    expect(logger.warns.some((w) => w.includes('broken'))).toBe(true)
+
+    scheduler.stop()
+  })
+
+  test('warning is emitted only once per scheduling attempt, not on every reload of an unchanged broken job', () => {
+    const clock = createFakeClock()
+    const recorder = createFireRecorder()
+    const logger = createCapturingLogger()
+    const scheduler = createScheduler({
+      jobs: [promptJob('broken', 'not a real schedule')],
+      onFire: recorder.onFire,
+      clock,
+      logger,
+    })
+    scheduler.start()
+    const warnsAfterStart = logger.warns.length
+
+    scheduler.replaceJobs([promptJob('broken', 'not a real schedule')])
+
+    expect(logger.warns.length).toBe(warnsAfterStart)
+
+    scheduler.stop()
+  })
+})

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -69,12 +69,15 @@ export function createScheduler({
     const job = currentEnabled(id)
     if (!job) return
 
-    const nextFire = computeNextFire(job, clock.now())
-    if (nextFire === null) return
+    const result = computeNextFire(job, clock.now())
+    if (!result.ok) {
+      logger.warn(`[cron] ${id} not scheduled: invalid schedule "${job.schedule}"${tzSuffix(job)}: ${result.reason}`)
+      return
+    }
 
     cancel(id)
 
-    const delay = Math.max(0, nextFire - clock.now())
+    const delay = Math.max(0, result.nextFire - clock.now())
     const handle = clock.setTimeout(() => {
       handles.delete(id)
       if (!started) return
@@ -177,14 +180,21 @@ function jobPayload(job: CronJob): unknown {
   return job.command
 }
 
-function computeNextFire(job: CronJob, now: number): number | null {
+type ComputeNextFireResult = { ok: true; nextFire: number } | { ok: false; reason: string }
+
+function computeNextFire(job: CronJob, now: number): ComputeNextFireResult {
   try {
     const expr = CronExpressionParser.parse(job.schedule, {
       currentDate: new Date(now),
       ...(job.timezone ? { tz: job.timezone } : {}),
     })
-    return expr.next().getTime()
-  } catch {
-    return null
+    return { ok: true, nextFire: expr.next().getTime() }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    return { ok: false, reason }
   }
+}
+
+function tzSuffix(job: CronJob): string {
+  return job.timezone ? ` (timezone "${job.timezone}")` : ''
 }


### PR DESCRIPTION
When a cron job's schedule string fails to parse at runtime — after passing schema validation — the scheduler added the job to its registry and then silently discarded it. No warning, no error, no indication in `typeclaw logs`. The job appeared healthy in `cron.json` and showed up in reload summaries as `unchanged`. It simply never fired.

## Symptom

A cron job is configured with a valid-looking `schedule` string and a `timezone`. `loadCron` accepts it without complaint. `typeclaw start` completes normally. The reload tool reports the job in the `unchanged` bucket on every subsequent reload. No `[cron] firing` line ever appears in `docker logs` / `typeclaw logs -f`. Nothing fires, nothing explains why.

The most realistic trigger is an IANA timezone that resolves fine on the developer's machine but is absent from the container's tzdata (the validator calls `expr.next()` once at config-parse time on the host; the scheduler calls `CronExpressionParser.parse` again at runtime inside the container). Any other gap between the schema-time validator and the runtime parser produces the same silent drop.

## Root cause

`computeNextFire` (previously `scheduler.ts:187`) wrapped the `cron-parser` call in `try { ... } catch { return null }` — every parse exception was swallowed with no log, no error, no side effect. `scheduleNext` (previously `scheduler.ts:73`) handled the `null` return with `if (nextFire === null) return`, also silent. Together: the job was registered, never scheduled, and left with zero observable signal.

## Fix

`computeNextFire` now returns a discriminated `ComputeNextFireResult` (`{ ok: true; nextFire: number } | { ok: false; reason: string }`) instead of `number | null`, carrying the underlying `cron-parser` error message.

`scheduleNext`'s `null`-check becomes a `logger.warn(...)` that names the job `id`, the offending `schedule` string, the `timezone` (formatted by a small `tzSuffix` helper so the line is readable whether or not `timezone` is set), and the parser's `reason`. `consoleLogger` routes `warn` to `console.warn`, so the message reaches container stdout — and therefore `docker logs` / `typeclaw logs -f` — with no further wiring.

The same `scheduleNext` path is hit by the recursive re-arm inside the timer callback, so if a job's schedule starts failing mid-life (e.g. a tzdata reload while the container is running) the warn fires on the next re-arm attempt as well.

Two files changed: `src/cron/scheduler.ts` (+17 / -7) and `src/cron/scheduler.test.ts` (+112 / -0).

## Tests

A new `describe('schedule failure surfacing', ...)` block with 5 tests, each using a small `createCapturingLogger()` helper that records `warn` and `error` calls against the existing `createFakeClock()` infrastructure:

1. **Parse error warning** — `scheduler.start()` with an unparseable schedule emits exactly one `warn` naming the job id and matching `/schedule|parse|invalid/i`.
2. **Unresolvable timezone warning** — a syntactically valid schedule with `timezone: 'Not/A_Real_Zone'` emits a `warn` naming both the job id and the timezone string.
3. **Sibling isolation** — a broken job alongside a healthy `* * * * *` job does not block the healthy job from firing after one minute tick; only `healthy` appears in the fire recorder.
4. **`replaceJobs` path** — adding a broken job via `replaceJobs` also triggers the warn.
5. **No re-warn on unchanged reload** — the broken job stays in the `unchanged` bucket across two `replaceJobs` calls; the warn count does not increase beyond the initial scheduling attempt.

Mutation check: commenting out the `logger.warn(...)` line in `scheduleNext` breaks tests 1–4 as expected. Test 5 passes vacuously (it asserts the warn count does not grow beyond 1; when nothing warns at all, the count stays at 0, which is ≤ 1). That's by design — the test's job is to confirm the warn is not re-emitted on unchanged reloads, not to assert it fires at all (test 1 covers that).

## Out of scope

- **`src/cron/schema.ts` unchanged.** The schema-time validator still calls `expr.next()` once at parse time and rejects clearly malformed schedules early. The common case (a typo in `cron.json`) is still caught at the user-facing boundary; this PR only closes the gap the validator cannot cover.
- **`JobDiff` shape unchanged.** We considered adding a `failed` bucket to surface unscheduled jobs in the reload-tool summary without log scraping. Rejected: the same signal is reconstructible from logs, and changing the public type would touch the reload tool, e2e tests, and downstream consumers without proportional benefit.