### PR TITLE
Survive KakaoTalk KICKOUT ping-pong with bounded recovery episodes

### DIFF
--- a/src/channels/adapters/kakaotalk.test.ts
+++ b/src/channels/adapters/kakaotalk.test.ts
@@ -285,13 +285,24 @@ describe('createKakaotalkAdapter — outbound', () => {
 })
 
 describe('createKakaotalkAdapter — KICKOUT recovery', () => {
-  test('auto-restarts the listener once when KICKOUT arrives within the post-init window', async () => {
+  type ScheduledTask = { fn: () => void; delay: number }
+  type RecoveryHarness = {
+    listener: FakeListener
+    adapter: ReturnType<typeof createKakaotalkAdapter>
+    router: ReturnType<typeof createChannelRouter>
+    logs: Array<{ level: string; msg: string }>
+    tasks: ScheduledTask[]
+    advance: (ms: number) => void
+    nowMs: () => number
+  }
+
+  const buildHarness = (agentDirArg: string): RecoveryHarness => {
     const client = new FakeClient()
     const listener = new FakeListener()
-    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const router = createChannelRouter({ agentDir: agentDirArg, configForAdapter: () => adapterCfg() })
     const logs: Array<{ level: string; msg: string }> = []
+    const tasks: ScheduledTask[] = []
     let nowMs = 1_000_000
-    const recoveryTasks: Array<{ fn: () => void; delay: number }> = []
     const adapter = createKakaotalkAdapter({
       router,
       configRef: () => adapterCfg(),
@@ -304,142 +315,190 @@ describe('createKakaotalkAdapter — KICKOUT recovery', () => {
       },
       now: () => nowMs,
       scheduleRecovery: (fn, delay) => {
-        recoveryTasks.push({ fn, delay })
+        tasks.push({ fn, delay })
       },
     })
+    return {
+      listener,
+      adapter,
+      router,
+      logs,
+      tasks,
+      advance: (ms) => {
+        nowMs += ms
+      },
+      nowMs: () => nowMs,
+    }
+  }
 
-    await adapter.start()
-    expect(listener.startCalls).toBe(1)
+  test('starts a recovery episode on a KICKOUT inside the post-init window and reconnects with the first delay', async () => {
+    const h = buildHarness(agentDir)
+    await h.adapter.start()
+    expect(h.listener.startCalls).toBe(1)
 
-    listener.emit('connected', { userId: '999' })
-    expect(adapter.isConnected()).toBe(true)
+    h.listener.emit('connected', { userId: '999' })
+    expect(h.adapter.isConnected()).toBe(true)
 
-    // 5 seconds later — well within the 30s post-init window — the SDK
-    // emits the KICKOUT error.
-    nowMs += 5_000
-    listener.emit('error', new Error('Session kicked — another device logged in'))
+    h.advance(5_000)
+    h.listener.emit('error', new Error('Session kicked — another device logged in'))
 
-    expect(adapter.isConnected()).toBe(false)
-    expect(recoveryTasks).toHaveLength(1)
-    expect(recoveryTasks[0]?.delay).toBeGreaterThan(0)
-    expect(logs.some((l) => l.level === 'warn' && l.msg.includes('Auto-restarting'))).toBe(true)
+    expect(h.adapter.isConnected()).toBe(false)
+    const reconnect = h.tasks.find((t) => t.delay === 2_000)
+    expect(reconnect).toBeDefined()
+    expect(h.logs.some((l) => l.level === 'warn' && l.msg.includes('attempt 1/3'))).toBe(true)
 
-    recoveryTasks[0]?.fn()
-    expect(listener.startCalls).toBe(2)
+    reconnect?.fn()
+    expect(h.listener.startCalls).toBe(2)
 
-    await adapter.stop()
-    await router.stop()
+    await h.adapter.stop()
+    await h.router.stop()
   })
 
-  test('does NOT auto-recover when KICKOUT arrives outside the post-init window', async () => {
-    const client = new FakeClient()
-    const listener = new FakeListener()
-    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
-    const logs: Array<{ level: string; msg: string }> = []
-    let nowMs = 1_000_000
-    const recoveryTasks: Array<{ fn: () => void; delay: number }> = []
-    const adapter = createKakaotalkAdapter({
-      router,
-      configRef: () => adapterCfg(),
-      client,
-      listenerFactory: () => listener,
-      logger: {
-        info: (msg) => logs.push({ level: 'info', msg }),
-        warn: (msg) => logs.push({ level: 'warn', msg }),
-        error: (msg) => logs.push({ level: 'error', msg }),
-      },
-      now: () => nowMs,
-      scheduleRecovery: (fn, delay) => {
-        recoveryTasks.push({ fn, delay })
-      },
-    })
+  test('survives ghost-session ping-pong by retrying with growing delays before giving up', async () => {
+    const h = buildHarness(agentDir)
+    await h.adapter.start()
+    h.listener.emit('connected', { userId: '999' })
 
-    await adapter.start()
-    listener.emit('connected', { userId: '999' })
+    const kick = (): void => h.listener.emit('error', new Error('Session kicked — another device logged in'))
 
-    // 5 minutes later — long past the post-init window. This is a real
-    // cross-device kick; we must NOT loop-fight.
-    nowMs += 5 * 60 * 1000
-    listener.emit('error', new Error('Session kicked — another device logged in'))
+    const expectedDelays = [2_000, 10_000, 60_000] as const
+    for (const [i, delay] of expectedDelays.entries()) {
+      h.advance(1_000)
+      kick()
+      const reconnect = h.tasks.at(-1)
+      expect(reconnect?.delay).toBe(delay)
+      h.advance(delay)
+      reconnect?.fn()
+      expect(h.listener.startCalls).toBe(i + 2)
+      h.listener.emit('connected', { userId: '999' })
+    }
 
-    expect(adapter.isConnected()).toBe(false)
-    expect(recoveryTasks).toHaveLength(0)
-    expect(listener.startCalls).toBe(1)
+    h.advance(1_000)
+    kick()
+    expect(h.listener.startCalls).toBe(expectedDelays.length + 1)
     expect(
-      logs.some(
-        (l) => l.level === 'error' && l.msg.includes('DEAD after KICKOUT') && l.msg.includes('typeclaw restart'),
+      h.logs.some(
+        (l) =>
+          l.level === 'error' &&
+          l.msg.includes('DEAD after KICKOUT') &&
+          (l.msg.includes('attempt(s) exhausted') || l.msg.includes('budget exhausted')),
       ),
     ).toBe(true)
 
-    await adapter.stop()
-    await router.stop()
+    await h.adapter.stop()
+    await h.router.stop()
   })
 
-  test('only attempts auto-recovery once per start() lifecycle', async () => {
-    const client = new FakeClient()
-    const listener = new FakeListener()
-    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
-    let nowMs = 1_000_000
-    const recoveryTasks: Array<{ fn: () => void; delay: number }> = []
-    const adapter = createKakaotalkAdapter({
-      router,
-      configRef: () => adapterCfg(),
-      client,
-      listenerFactory: () => listener,
-      now: () => nowMs,
-      scheduleRecovery: (fn, delay) => {
-        recoveryTasks.push({ fn, delay })
-      },
-    })
+  test('gives up with budget-exhausted reason when stalled retries push past the wall-clock cap', async () => {
+    const h = buildHarness(agentDir)
+    await h.adapter.start()
+    h.listener.emit('connected', { userId: '999' })
 
-    await adapter.start()
-    listener.emit('connected', { userId: '999' })
+    const kick = (): void => h.listener.emit('error', new Error('Session kicked — another device logged in'))
 
-    nowMs += 1_000
-    listener.emit('error', new Error('Session kicked — another device logged in'))
-    expect(recoveryTasks).toHaveLength(1)
+    // Two quick KICKOUTs consume attempts 1 and 2 (delays 2_000 and
+    // 10_000), then we sit at the recovered listener for ~4.5 minutes
+    // before a third KICKOUT arrives. The third attempt's 60_000 delay
+    // would push elapsed-in-episode past the 300_000 cap, so we should
+    // give up via the budget branch rather than scheduling attempt 3.
+    h.advance(1_000)
+    kick()
+    const reconnect1 = h.tasks.at(-1)
+    h.advance(2_000)
+    reconnect1?.fn()
+    h.listener.emit('connected', { userId: '999' })
 
-    // Pretend the recovery ran and we reconnected, then got kicked again
-    // immediately. The second KICKOUT must NOT re-arm recovery.
-    recoveryTasks[0]?.fn()
-    listener.emit('connected', { userId: '999' })
-    nowMs += 1_000
-    listener.emit('error', new Error('Session kicked — another device logged in'))
+    h.advance(1_000)
+    kick()
+    const reconnect2 = h.tasks.at(-1)
+    h.advance(10_000)
+    reconnect2?.fn()
+    h.listener.emit('connected', { userId: '999' })
 
-    expect(recoveryTasks).toHaveLength(1)
+    const tasksBeforeStallKick = h.tasks.length
+    h.advance(4 * 60 * 1000 + 30_000)
+    kick()
 
-    await adapter.stop()
-    await router.stop()
+    expect(h.tasks.length).toBe(tasksBeforeStallKick)
+    expect(h.logs.some((l) => l.level === 'error' && l.msg.includes('budget exhausted'))).toBe(true)
+
+    await h.adapter.stop()
+    await h.router.stop()
   })
 
-  test('non-KICKOUT errors do not trigger recovery and do not flip connected', async () => {
-    const client = new FakeClient()
-    const listener = new FakeListener()
-    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
-    const recoveryTasks: Array<{ fn: () => void; delay: number }> = []
-    const adapter = createKakaotalkAdapter({
-      router,
-      configRef: () => adapterCfg(),
-      client,
-      listenerFactory: () => listener,
-      scheduleRecovery: (fn, delay) => {
-        recoveryTasks.push({ fn, delay })
-      },
-    })
+  test('a stable recovered connection ends the episode and re-arms recovery for a much-later KICKOUT', async () => {
+    const h = buildHarness(agentDir)
+    await h.adapter.start()
+    h.listener.emit('connected', { userId: '999' })
 
-    await adapter.start()
-    listener.emit('connected', { userId: '999' })
-    expect(adapter.isConnected()).toBe(true)
+    h.advance(5_000)
+    h.listener.emit('error', new Error('Session kicked — another device logged in'))
+    const reconnect = h.tasks.at(-1)
+    expect(reconnect?.delay).toBe(2_000)
+    h.advance(2_000)
+    reconnect?.fn()
+    expect(h.listener.startCalls).toBe(2)
 
-    listener.emit('error', new Error('socket closed unexpectedly'))
+    h.listener.emit('connected', { userId: '999' })
+    const stabilityCheck = h.tasks.at(-1)
+    expect(stabilityCheck?.delay).toBe(60_000)
+    h.advance(60_000)
+    stabilityCheck?.fn()
 
-    expect(recoveryTasks).toHaveLength(0)
-    // Generic errors don't flip connected — the SDK's own reconnect path
-    // owns disconnection state via the 'disconnected' event.
-    expect(adapter.isConnected()).toBe(true)
+    expect(h.logs.some((l) => l.level === 'info' && l.msg.includes('recovery episode succeeded'))).toBe(true)
 
-    await adapter.stop()
-    await router.stop()
+    const tasksBeforeFreshKick = h.tasks.length
+    h.advance(10 * 60 * 1000)
+    h.listener.emit('error', new Error('Session kicked — another device logged in'))
+    const freshReconnect = h.tasks.at(-1)
+    expect(h.tasks.length).toBe(tasksBeforeFreshKick + 1)
+    expect(freshReconnect?.delay).toBe(2_000)
+    const attemptOneLogs = h.logs.filter((l) => l.level === 'warn' && l.msg.includes('attempt 1/3'))
+    expect(attemptOneLogs.length).toBe(2)
+
+    await h.adapter.stop()
+    await h.router.stop()
+  })
+
+  test('a brief reconnect that gets kicked again does NOT count as episode success', async () => {
+    const h = buildHarness(agentDir)
+    await h.adapter.start()
+    h.listener.emit('connected', { userId: '999' })
+
+    h.advance(5_000)
+    h.listener.emit('error', new Error('Session kicked — another device logged in'))
+    const reconnect = h.tasks.at(-1)
+    expect(reconnect?.delay).toBe(2_000)
+    h.advance(2_000)
+    reconnect?.fn()
+    h.listener.emit('connected', { userId: '999' })
+    const stabilityCheck = h.tasks.at(-1)
+    expect(stabilityCheck?.delay).toBe(60_000)
+
+    h.advance(1_000)
+    h.listener.emit('error', new Error('Session kicked — another device logged in'))
+
+    h.advance(60_000)
+    stabilityCheck?.fn()
+    expect(h.logs.some((l) => l.msg.includes('recovery episode succeeded'))).toBe(false)
+
+    await h.adapter.stop()
+    await h.router.stop()
+  })
+
+  test('non-KICKOUT errors do not start a recovery episode or flip connected', async () => {
+    const h = buildHarness(agentDir)
+    await h.adapter.start()
+    h.listener.emit('connected', { userId: '999' })
+    expect(h.adapter.isConnected()).toBe(true)
+
+    h.listener.emit('error', new Error('socket closed unexpectedly'))
+
+    expect(h.tasks).toHaveLength(0)
+    expect(h.adapter.isConnected()).toBe(true)
+
+    await h.adapter.stop()
+    await h.router.stop()
   })
 })
 

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -55,15 +55,30 @@ export type KakaotalkAdapterOptions = {
   scheduleRecovery?: (fn: () => void, delayMs: number) => void
 }
 
-// LOCO server emits KICKOUT when the same device_uuid logs in elsewhere.
-// During the post-init handoff (init authenticates → leaves a session
-// briefly → first container start re-logs in with the same UUID) we
-// kick OURSELVES, then a one-shot auto-restart resolves it. Outside that
-// window, we treat KICKOUT as a real cross-device login and stay dead so
-// we don't loop-fight the other device. 30s is the empirical post-init
-// window; widen if init grows slower bootstrap steps.
-const KICKOUT_RECOVERY_WINDOW_MS = 30_000
-const KICKOUT_RECOVERY_DELAY_MS = 2_000
+// LOCO emits KICKOUT when the same device_uuid logs in elsewhere. Three
+// shapes converge on this one signal:
+//   1. Init handoff — `typeclaw init` left a brief session that the
+//      container's re-login kicks. One delayed reconnect resolves it.
+//   2. Ghost session — a previous run's LOCO connection is still
+//      half-alive server-side and ping-pongs with our reconnect for
+//      ~1-2 minutes until it times out. Old one-shot recovery
+//      reconnected once, got kicked again, and died — the bug this
+//      state machine exists to fix.
+//   3. Real conflict — another device or process holds the same
+//      device_uuid. Our retries can't win this fight; we should give up
+//      cleanly so the user notices and intervenes.
+// One signal, three shapes: we always try to recover, but with a
+// strictly bounded budget. Within an episode we allow KICKOUT_RECOVERY_
+// _DELAYS_MS.length retries spaced by the listed delays; an episode is
+// declared successful only after the reconnect stays connected for
+// SUCCESS_MS (bare `connected` is too weak — ghost ping-pong reconnects
+// for seconds before getting kicked again). Past the budget or the
+// MAX_ELAPSED cap we let the session die. After a successful episode
+// the state resets, so a fresh KICKOUT hours later gets a fresh
+// episode rather than being permanently locked out.
+const KICKOUT_RECOVERY_SUCCESS_MS = 60_000
+const KICKOUT_RECOVERY_MAX_ELAPSED_MS = 5 * 60_000
+const KICKOUT_RECOVERY_DELAYS_MS: readonly number[] = [2_000, 10_000, 60_000]
 
 export type KakaotalkAdapter = {
   start: () => Promise<void>
@@ -203,9 +218,19 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
   let connected = false
   let started = false
   let lastConnectedAt: number | null = null
-  let kickoutRecoveryAttempted = false
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
+
+  type RecoveryEpisode = {
+    startedAt: number
+    attemptCount: number
+    pendingStabilityCheck: boolean
+  }
+  let recoveryEpisode: RecoveryEpisode | null = null
+
+  const resetRecoveryEpisode = (): void => {
+    recoveryEpisode = null
+  }
 
   const channelResolver = createKakaoChannelResolver({ client, logger })
   const authorResolver = createKakaoAuthorResolver({ client })
@@ -284,7 +309,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       if (started) return
       started = true
       lastConnectedAt = null
-      kickoutRecoveryAttempted = false
+      resetRecoveryEpisode()
       try {
         if (options.credentialsDir !== undefined) {
           // Explicit credential path: read the file ourselves and pass the
@@ -335,10 +360,27 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
 
       listener = options.listenerFactory ? options.listenerFactory(client) : new KakaoTalkListener(client)
       const activeListener = listener
+      const scheduleStabilityCheck = (): void => {
+        if (recoveryEpisode === null) return
+        if (recoveryEpisode.pendingStabilityCheck) return
+        recoveryEpisode.pendingStabilityCheck = true
+        const expectedConnectedAt = lastConnectedAt
+        scheduleRecovery(() => {
+          if (recoveryEpisode === null) return
+          recoveryEpisode.pendingStabilityCheck = false
+          if (!started || listener !== activeListener) return
+          if (!connected || lastConnectedAt !== expectedConnectedAt) return
+          logger.info(
+            `[kakaotalk] KICKOUT recovery episode succeeded after ${recoveryEpisode.attemptCount} attempt(s); session is stable.`,
+          )
+          resetRecoveryEpisode()
+        }, KICKOUT_RECOVERY_SUCCESS_MS)
+      }
       listener.on('connected', (info) => {
         connected = true
         lastConnectedAt = now()
         logger.info(`[kakaotalk] connected (user_id=${info.userId})`)
+        if (recoveryEpisode !== null) scheduleStabilityCheck()
       })
       listener.on('disconnected', () => {
         connected = false
@@ -347,34 +389,46 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       listener.on('error', (err) => {
         logger.error(`[kakaotalk] listener error: ${describe(err)}`)
         if (!isKickoutError(err)) return
-        // KICKOUT is fatal at the SDK layer: it sets running=false, closes
-        // the session, and skips scheduleReconnect. Without intervention
-        // the adapter goes silent indefinitely. We have to recover here
-        // or surface the dead-listener state to the user explicitly.
+        // KICKOUT closes the SDK session and skips scheduleReconnect, so
+        // without intervention the adapter goes silent. We must either
+        // start/continue a recovery episode or surface the dead state.
         connected = false
-        const elapsed = lastConnectedAt === null ? Infinity : now() - lastConnectedAt
-        const withinPostInitWindow = elapsed <= KICKOUT_RECOVERY_WINDOW_MS
-        if (!started || kickoutRecoveryAttempted || !withinPostInitWindow) {
+        if (!started) return
+        const tNow = now()
+        if (recoveryEpisode === null) {
+          recoveryEpisode = { startedAt: tNow, attemptCount: 0, pendingStabilityCheck: false }
+        }
+        const episode = recoveryEpisode
+        const elapsedInEpisode = tNow - episode.startedAt
+        const nextAttemptIndex = episode.attemptCount
+        const delayMs = KICKOUT_RECOVERY_DELAYS_MS[nextAttemptIndex]
+        if (delayMs === undefined || elapsedInEpisode + delayMs > KICKOUT_RECOVERY_MAX_ELAPSED_MS) {
+          const reason =
+            delayMs === undefined
+              ? `${KICKOUT_RECOVERY_DELAYS_MS.length} attempt(s) exhausted`
+              : `${Math.round(KICKOUT_RECOVERY_MAX_ELAPSED_MS / 1000)}s recovery budget exhausted`
           logger.error(
-            '[kakaotalk] session is DEAD after KICKOUT and will not auto-recover. ' +
-              'Likely cause: another device or process is logged into this KakaoTalk account ' +
-              'with the same device_uuid. Run `typeclaw restart` once you have ensured no other ' +
-              'session is using these credentials, or re-run `typeclaw init` to mint a new device_uuid.',
+            `[kakaotalk] session is DEAD after KICKOUT — ${reason}. ` +
+              'Likely a real cross-device login is fighting our session. ' +
+              'Stop the other client, then run `typeclaw restart`. ' +
+              'If the conflict persists, re-run `typeclaw init` to mint a new device_uuid.',
           )
+          resetRecoveryEpisode()
           return
         }
-        kickoutRecoveryAttempted = true
+        episode.attemptCount = nextAttemptIndex + 1
         logger.warn(
-          `[kakaotalk] KICKOUT received ${Math.round(elapsed)}ms after connect — likely the post-init session handoff. Auto-restarting listener once in ${KICKOUT_RECOVERY_DELAY_MS}ms.`,
+          `[kakaotalk] KICKOUT during recovery episode (attempt ${episode.attemptCount}/${KICKOUT_RECOVERY_DELAYS_MS.length}, episode_elapsed=${Math.round(elapsedInEpisode)}ms); reconnecting in ${delayMs}ms.`,
         )
         scheduleRecovery(() => {
           if (!started || listener !== activeListener) return
+          if (recoveryEpisode !== episode) return
           activeListener.start().catch((retryErr) => {
             logger.error(
               `[kakaotalk] KICKOUT auto-recovery failed: ${describe(retryErr)}. Run \`typeclaw restart\` to retry.`,
             )
           })
-        }, KICKOUT_RECOVERY_DELAY_MS)
+        }, delayMs)
       })
       listener.on('message', (event) => {
         void handleMessageEvent(event)
@@ -426,7 +480,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       selfUserId = null
       connected = false
       lastConnectedAt = null
-      kickoutRecoveryAttempted = false
+      resetRecoveryEpisode()
     },
 
     isConnected(): boolean {


### PR DESCRIPTION
## Summary

The KICKOUT auto-recovery introduced in #97 is one-shot: it allows exactly one reconnect within a 30-second post-init window, then sets `kickoutRecoveryAttempted = true` for the rest of the adapter's lifetime. In production this loses to two real failure modes that share the same KICKOUT signal as the init handoff it was designed for, so a session that successfully recovers once and then gets KICKOUTed again — for any reason — dies permanently and can only be revived with `typeclaw restart`.

This PR replaces the boolean flag with a recovery-episode state machine: bounded retries with a growing delay schedule, an explicit stability threshold for declaring an episode succeeded, and a hard wall-clock cap so we never loop-fight a real second device forever.

## The bug, reproduced from a real log

```
[kakaotalk] connected (user_id=438346815)
[kakaotalk] listener error: Session kicked — another device logged in
[kakaotalk] KICKOUT received 7655ms after connect — Auto-restarting listener once in 2000ms.
[kakaotalk] connected (user_id=438346815)              ← recovery succeeded
[kakaotalk] listener error: Session kicked — another device logged in
[kakaotalk] session is DEAD after KICKOUT and will not auto-recover.
```

Two consecutive KICKOUTs, both within seconds of `connected`. The container has been running KakaoTalk fine; the user has only one container, no other `agent-kakaotalk` process, no copied credentials. The most plausible cause is a **server-side ghost session** — a previous run's LOCO connection that the Kakao server hadn't fully torn down — ping-ponging with our reconnect for ~1–2 minutes until it times out. The old code reconnects once at `T+9.7s`, gets kicked again, and gives up. A second retry 10s later (or 60s later) would almost certainly land cleanly.

The other shape this surfaces is a long-stable session that gets KICKOUTed hours later. Under the old code the elapsed-since-connect check failed it as `real conflict` and went straight to DEAD, even when one delayed retry would have resolved a transient PC-app conflict the user already closed.

## Design

`KICKOUT` is just one signal, but three failure shapes converge on it:

1. **Init handoff** — `typeclaw init` left a brief session and the container's re-login kicks it. One delayed reconnect resolves it. (This is the case #97 was built for.)
2. **Ghost session** — a previous run's LOCO connection is still half-alive on Kakao's side and ping-pongs with our reconnect for ~1–2 minutes until it times out. Old one-shot recovery reconnected once, got kicked again, and died.
3. **Real conflict** — another device or process holds the same `device_uuid`. Our retries can't win this fight; we should give up cleanly so the user notices and intervenes.

Since we can't tell these apart from the first KICKOUT alone, we always try to recover, but with a strictly bounded budget:

- `KICKOUT_RECOVERY_DELAYS_MS = [2_000, 10_000, 60_000]` — three retries, growing delays. The 60s slot specifically lets server-side ghosts time out without us spamming the LOCO endpoint.
- `KICKOUT_RECOVERY_SUCCESS_MS = 60_000` — an episode is declared successful only after the reconnect stays connected for 60s. Bare `connected` is too weak as a success signal: the observed log shows ghost ping-pong reconnects briefly before getting kicked again, and that's exactly what `kickoutRecoveryAttempted` interpreted as "we recovered, no more retries needed."
- `KICKOUT_RECOVERY_MAX_ELAPSED_MS = 5 * 60_000` — hard wall-clock cap on a single episode. Past this we let the session die regardless of remaining attempts. A real second device should win, not get fought forever.

When an episode succeeds, recovery state resets, so a fresh KICKOUT hours later gets a fresh episode rather than being permanently locked out — fixing the long-stable-session case as a bonus.

When the budget runs out (attempts exhausted *or* wall-clock cap), we emit a tightened DEAD message that names which budget tripped, so the next user log doesn't have to guess between "we gave up immediately" and "we tried hard and lost":

```
[kakaotalk] session is DEAD after KICKOUT — 3 attempt(s) exhausted. Likely a real
cross-device login is fighting our session. Stop the other client, then run
`typeclaw restart`. If the conflict persists, re-run `typeclaw init` to mint a
new device_uuid.
```

## Implementation

Replaced the `lastConnectedAt` + `kickoutRecoveryAttempted` pair in `createKakaotalkAdapter` with a `recoveryEpisode` record:

```ts
type RecoveryEpisode = {
  startedAt: number
  attemptCount: number
  pendingStabilityCheck: boolean
}
let recoveryEpisode: RecoveryEpisode | null = null
```

The `error` handler starts a new episode if none is active, increments `attemptCount`, looks up the next delay, checks both budgets, and either schedules the retry or logs the DEAD-with-reason message. The `connected` handler triggers a stability check via the existing `scheduleRecovery` test seam; the check verifies the listener is still on the same connection (`lastConnectedAt` unchanged) and only then resets the episode and logs `recovery episode succeeded`.

Both `start()` and `stop()` reset the episode; `disconnected` deliberately doesn't (an unrelated transient disconnect inside an episode shouldn't cancel ongoing recovery).

The `scheduleRecovery` test seam is reused for both reconnect timers and stability checks, so the existing harness (no real-time waits, deterministic clock) covers everything.

## Tests

Rewrote the `KICKOUT recovery` describe block around the new contract. The existing harness (faked `now`, faked `scheduleRecovery`, fake listener) was extracted into a `buildHarness` helper so the new cases stay readable.

| Test | What it pins down |
|---|---|
| `starts a recovery episode on a KICKOUT inside the post-init window and reconnects with the first delay` | First-attempt path with the 2_000ms slot; matches the existing init-handoff scenario. |
| `survives ghost-session ping-pong by retrying with growing delays before giving up` | Three consecutive KICKOUTs (each with a successful brief reconnect) trigger the [2000, 10000, 60000] schedule, then the fourth gives up with `attempt(s) exhausted`. This is the case the production log proves the old code couldn't handle. |
| `gives up with budget-exhausted reason when stalled retries push past the wall-clock cap` | Two quick KICKOUTs consume attempts 1 and 2, then a 4m30s stall on the recovered listener. The third KICKOUT's 60_000ms delay would push past the 5min cap, so we hit the budget branch instead of scheduling attempt 3 — discriminating the two give-up paths. |
| `a stable recovered connection ends the episode and re-arms recovery for a much-later KICKOUT` | After a successful 60s stability window, the episode logs `recovery episode succeeded` and resets; a KICKOUT 10 minutes later starts a fresh episode (no permanent lockout). |
| `a brief reconnect that gets kicked again does NOT count as episode success` | A reconnect followed by another KICKOUT at T+1s, then the deferred stability check fires — `recovery episode succeeded` must NOT log. Pins down the "60s of stability" semantics against the original bug shape. |
| `non-KICKOUT errors do not start a recovery episode or flip connected` | Preserved from the old suite. |

Per AGENTS.md §7 (Testing Philosophy): the tests verify **behavior** (sequence of scheduled delays, log lines that gate on success vs. failure semantics), never internal flag values. Each new test fails meaningfully if the corresponding production line is removed or reordered.

```
$ bun run typecheck && bun run lint && bun run format:check && bun test
$ tsgo --noEmit
$ oxlint
Found 0 warnings and 0 errors.
$ oxfmt --check .
All matched files use the correct format.
 2319 pass
 0 fail
 4651 expect() calls
```

## Out of scope

- **Cross-process / cross-container session coordination.** This PR doesn't add a hostd-level KakaoTalk lease or a credentials-file lockfile. The user's actual scenario in the bug report is a single container, so concurrent-listener prevention isn't the fix here. If a real cross-device conflict shows up later (#97's "another device logged in" case), the bounded budget will surface it cleanly within ~72s instead of fighting forever, and the DEAD-with-reason message tells the user what to do.
- **Tuning the constants.** `60s` stability and `5min` cap are conservative defaults; if real-world telemetry suggests ghosts time out faster or slower, the constants are colocated at the top of `kakaotalk.ts` for easy adjustment.
