### PR TITLE
Wire OpenAI (API key) and OpenAI Codex (OAuth) providers + pick model at init time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .env.production.local
 .env.local
 
+# Test artifacts: AuthStorage.create() writes auth.json to process.cwd().
+# Tests chdir to a tmpdir, but defense in depth — never check this in.
+auth.json
+
 # caches
 .eslintcache
 .cache

--- a/src/agent/auth.test.ts
+++ b/src/agent/auth.test.ts
@@ -1,44 +1,84 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { __resetConfigForTesting, reloadConfig } from '@/config/config'
 
 import { getAuth, resetAuthForTesting } from './auth'
 
 describe('getAuth', () => {
-  let prevKey: string | undefined
+  let prevOpenai: string | undefined
+  let prevFireworks: string | undefined
   let prevNodeEnv: string | undefined
+  let cwd: string
 
-  beforeEach(() => {
-    prevKey = process.env.FIREWORKS_API_KEY
+  beforeEach(async () => {
+    prevOpenai = process.env.OPENAI_API_KEY
+    prevFireworks = process.env.FIREWORKS_API_KEY
     prevNodeEnv = process.env.NODE_ENV
+    delete process.env.OPENAI_API_KEY
+    delete process.env.FIREWORKS_API_KEY
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-auth-'))
     resetAuthForTesting()
   })
 
-  afterEach(() => {
-    if (prevKey === undefined) delete process.env.FIREWORKS_API_KEY
-    else process.env.FIREWORKS_API_KEY = prevKey
+  afterEach(async () => {
+    if (prevOpenai === undefined) delete process.env.OPENAI_API_KEY
+    else process.env.OPENAI_API_KEY = prevOpenai
+    if (prevFireworks === undefined) delete process.env.FIREWORKS_API_KEY
+    else process.env.FIREWORKS_API_KEY = prevFireworks
     if (prevNodeEnv === undefined) delete process.env.NODE_ENV
     else process.env.NODE_ENV = prevNodeEnv
     resetAuthForTesting()
+    __resetConfigForTesting()
+    await rm(cwd, { recursive: true, force: true })
   })
 
-  test('returns auth object when FIREWORKS_API_KEY is set', () => {
-    process.env.FIREWORKS_API_KEY = 'fw_test_key'
+  test('reads OPENAI_API_KEY when configured model is an OpenAI model', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
+    reloadConfig(cwd)
+    process.env.OPENAI_API_KEY = 'sk-test'
+
     const auth = getAuth()
+
     expect(auth.authStorage).toBeDefined()
     expect(auth.modelRegistry).toBeDefined()
   })
 
-  test('falls back to a dummy key when FIREWORKS_API_KEY is missing under NODE_ENV=test', () => {
-    delete process.env.FIREWORKS_API_KEY
+  test('reads FIREWORKS_API_KEY when configured model is a Fireworks model', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' }),
+    )
+    reloadConfig(cwd)
+    process.env.FIREWORKS_API_KEY = 'fw_test'
+
+    const auth = getAuth()
+
+    expect(auth.authStorage).toBeDefined()
+    expect(auth.modelRegistry).toBeDefined()
+  })
+
+  test('falls back to a dummy key when the provider env var is missing under NODE_ENV=test', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
+    reloadConfig(cwd)
     process.env.NODE_ENV = 'test'
+
     const auth = getAuth()
+
     expect(auth.authStorage).toBeDefined()
     expect(auth.modelRegistry).toBeDefined()
   })
 
-  test('caches the auth object across calls', () => {
-    process.env.FIREWORKS_API_KEY = 'fw_test_key'
+  test('caches the auth object across calls', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
+    reloadConfig(cwd)
+    process.env.OPENAI_API_KEY = 'sk-test'
+
     const a = getAuth()
     const b = getAuth()
+
     expect(a).toBe(b)
   })
 })

--- a/src/agent/auth.test.ts
+++ b/src/agent/auth.test.ts
@@ -11,6 +11,7 @@ describe('getAuth', () => {
   let prevOpenai: string | undefined
   let prevFireworks: string | undefined
   let prevNodeEnv: string | undefined
+  let prevCwd: string
   let cwd: string
 
   beforeEach(async () => {
@@ -20,6 +21,10 @@ describe('getAuth', () => {
     delete process.env.OPENAI_API_KEY
     delete process.env.FIREWORKS_API_KEY
     cwd = await mkdtemp(join(tmpdir(), 'typeclaw-auth-'))
+    // Pin process.cwd() to the tmpdir so AuthStorage.create() writes its
+    // auth.json under the test scratch dir instead of polluting the repo.
+    prevCwd = process.cwd()
+    process.chdir(cwd)
     resetAuthForTesting()
   })
 
@@ -32,6 +37,7 @@ describe('getAuth', () => {
     else process.env.NODE_ENV = prevNodeEnv
     resetAuthForTesting()
     __resetConfigForTesting()
+    process.chdir(prevCwd)
     await rm(cwd, { recursive: true, force: true })
   })
 
@@ -60,7 +66,7 @@ describe('getAuth', () => {
     expect(auth.modelRegistry).toBeDefined()
   })
 
-  test('falls back to a dummy key when the provider env var is missing under NODE_ENV=test', async () => {
+  test('falls back to a dummy in-memory storage when the provider env var is missing under NODE_ENV=test', async () => {
     await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
     reloadConfig(cwd)
     process.env.NODE_ENV = 'test'

--- a/src/agent/auth.ts
+++ b/src/agent/auth.ts
@@ -1,7 +1,15 @@
+import { join } from 'node:path'
+
 import { AuthStorage, ModelRegistry } from '@mariozechner/pi-coding-agent'
 
 import { getConfig } from '@/config'
-import { KNOWN_PROVIDERS, providerForModelRef, type KnownProviderId } from '@/config/providers'
+import {
+  KNOWN_PROVIDERS,
+  providerForModelRef,
+  supportsApiKey,
+  supportsOAuth,
+  type KnownProviderId,
+} from '@/config/providers'
 
 type Auth = {
   authStorage: AuthStorage
@@ -9,6 +17,14 @@ type Auth = {
 }
 
 const TEST_DUMMY_API_KEY = 'test_dummy_key'
+
+// In container stage, /agent is the bind-mounted agent folder; in host stage
+// (only used by `typeclaw init` itself), it falls back to process.cwd(). The
+// host writes auth.json at init time and the container reads + refreshes it
+// at runtime — both paths point at the same file on the host filesystem.
+function authJsonPath(): string {
+  return join(process.cwd(), 'auth.json')
+}
 
 let cached: Auth | null = null
 
@@ -18,19 +34,39 @@ export function getAuth(): Auth {
   const providerId = providerForModelRef(getConfig().model)
   const provider = KNOWN_PROVIDERS[providerId]
 
-  // Bun sets NODE_ENV=test automatically under `bun test`. Use a dummy key
-  // there so suites that build sessions but never hit the LLM don't need real
-  // credentials; production still hard-exits to surface misconfiguration.
-  const apiKey = process.env[provider.apiKeyEnv] ?? (process.env.NODE_ENV === 'test' ? TEST_DUMMY_API_KEY : undefined)
-  if (!apiKey) {
-    console.error(`Set ${provider.apiKeyEnv} to use ${describeModel(providerId)} via ${provider.name}.`)
+  // Bun sets NODE_ENV=test automatically under `bun test`. The dummy path
+  // bypasses both auth.json and process.env so suites that build sessions
+  // but never hit the LLM don't need real credentials; production still
+  // hard-exits to surface misconfiguration.
+  if (process.env.NODE_ENV === 'test' && !hasAnyCredentialInEnv(provider.apiKeyEnv)) {
+    const authStorage = AuthStorage.inMemory()
+    if (supportsApiKey(provider)) {
+      authStorage.setRuntimeApiKey(provider.id, TEST_DUMMY_API_KEY)
+    }
+    const modelRegistry = ModelRegistry.create(authStorage)
+    cached = { authStorage, modelRegistry }
+    return cached
+  }
+
+  const authStorage = AuthStorage.create(authJsonPath())
+
+  if (supportsApiKey(provider) && provider.apiKeyEnv) {
+    const envKey = process.env[provider.apiKeyEnv]
+    if (envKey) {
+      authStorage.setRuntimeApiKey(provider.id, envKey)
+    }
+  }
+
+  // OAuth providers persist their credentials to auth.json at init time. The
+  // file is loaded by AuthStorage.create() above, so we just need to verify
+  // something is there before returning — a missing file means the user
+  // skipped login at init or deleted the file.
+  if (!authStorage.hasAuth(provider.id)) {
+    console.error(missingCredentialMessage(providerId))
     process.exit(1)
   }
 
-  const authStorage = AuthStorage.create()
-  authStorage.setRuntimeApiKey(provider.id, apiKey)
   const modelRegistry = ModelRegistry.create(authStorage)
-
   cached = { authStorage, modelRegistry }
   return cached
 }
@@ -39,10 +75,25 @@ export function resetAuthForTesting(): void {
   cached = null
 }
 
-function describeModel(providerId: KnownProviderId): string {
+function hasAnyCredentialInEnv(apiKeyEnv: string | null): boolean {
+  return apiKeyEnv !== null && process.env[apiKeyEnv] !== undefined && process.env[apiKeyEnv] !== ''
+}
+
+function missingCredentialMessage(providerId: KnownProviderId): string {
+  const provider = KNOWN_PROVIDERS[providerId]
   const ref = getConfig().model
   const slash = ref.indexOf('/')
-  const modelId = ref.slice(slash + 1)
-  const model = (KNOWN_PROVIDERS[providerId].models as Record<string, { name: string }>)[modelId]
-  return model?.name ?? modelId
+  const modelName =
+    (provider.models as Record<string, { name: string }>)[ref.slice(slash + 1)]?.name ?? ref.slice(slash + 1)
+
+  const oauthOnly = supportsOAuth(provider) && !supportsApiKey(provider)
+  const apiKeyOnly = supportsApiKey(provider) && !supportsOAuth(provider)
+
+  if (oauthOnly) {
+    return `No credentials for ${provider.name}. Run \`typeclaw init\` and pick "OAuth" to log in to ${modelName}.`
+  }
+  if (apiKeyOnly && provider.apiKeyEnv) {
+    return `Set ${provider.apiKeyEnv} in .env to use ${modelName} via ${provider.name}.`
+  }
+  return `No credentials for ${provider.name}. Either set ${provider.apiKeyEnv ?? '<api-key-env>'} in .env or run \`typeclaw init\` and pick "OAuth".`
 }

--- a/src/agent/auth.ts
+++ b/src/agent/auth.ts
@@ -1,28 +1,34 @@
 import { AuthStorage, ModelRegistry } from '@mariozechner/pi-coding-agent'
 
+import { getConfig } from '@/config'
+import { KNOWN_PROVIDERS, providerForModelRef, type KnownProviderId } from '@/config/providers'
+
 type Auth = {
   authStorage: AuthStorage
   modelRegistry: ModelRegistry
 }
 
-const TEST_DUMMY_API_KEY = 'fw_test_dummy'
+const TEST_DUMMY_API_KEY = 'test_dummy_key'
 
 let cached: Auth | null = null
 
 export function getAuth(): Auth {
   if (cached) return cached
 
+  const providerId = providerForModelRef(getConfig().model)
+  const provider = KNOWN_PROVIDERS[providerId]
+
   // Bun sets NODE_ENV=test automatically under `bun test`. Use a dummy key
   // there so suites that build sessions but never hit the LLM don't need real
   // credentials; production still hard-exits to surface misconfiguration.
-  const apiKey = process.env.FIREWORKS_API_KEY ?? (process.env.NODE_ENV === 'test' ? TEST_DUMMY_API_KEY : undefined)
+  const apiKey = process.env[provider.apiKeyEnv] ?? (process.env.NODE_ENV === 'test' ? TEST_DUMMY_API_KEY : undefined)
   if (!apiKey) {
-    console.error('Set FIREWORKS_API_KEY to use Kimi K2.5 Turbo via Fireworks.')
+    console.error(`Set ${provider.apiKeyEnv} to use ${describeModel(providerId)} via ${provider.name}.`)
     process.exit(1)
   }
 
   const authStorage = AuthStorage.create()
-  authStorage.setRuntimeApiKey('fireworks', apiKey)
+  authStorage.setRuntimeApiKey(provider.id, apiKey)
   const modelRegistry = ModelRegistry.create(authStorage)
 
   cached = { authStorage, modelRegistry }
@@ -31,4 +37,12 @@ export function getAuth(): Auth {
 
 export function resetAuthForTesting(): void {
   cached = null
+}
+
+function describeModel(providerId: KnownProviderId): string {
+  const ref = getConfig().model
+  const slash = ref.indexOf('/')
+  const modelId = ref.slice(slash + 1)
+  const model = (KNOWN_PROVIDERS[providerId].models as Record<string, { name: string }>)[modelId]
+  return model?.name ?? modelId
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -477,9 +477,16 @@ async function collectLLMAuth(provider: (typeof KNOWN_PROVIDERS)[KnownProviderId
 function buildOAuthCallbacks(providerName: string) {
   return {
     onAuth: (url: string, instructions?: string) => {
-      const lines = [`Open this URL in your browser to authorize ${providerName}:`, '', url]
-      if (instructions) lines.push('', instructions)
-      note(lines.join('\n'), 'Browser login')
+      // Don't put the URL inside note(): clack wraps long lines with the box
+      // border `│` on each wrapped segment, which corrupts the URL when the
+      // user copy-pastes it. Keep instructional text in the box, but print
+      // the URL itself as a bare console.log line that any terminal will
+      // hyperlink intact.
+      const preamble = [`Open this URL in your browser to authorize ${providerName}.`]
+      if (instructions) preamble.push('', instructions)
+      note(preamble.join('\n'), 'Browser login')
+      console.log(url)
+      console.log('')
     },
     onProgress: (message: string) => {
       log.info(message)

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -508,7 +508,7 @@ async function pickModel(): Promise<ModelOption> {
   const providers = uniqueProviders(options)
   const providerChoice = await select({
     message: 'Pick an LLM provider',
-    options: providers.map((id) => ({ value: id, label: KNOWN_PROVIDERS[id].name })),
+    options: providers.map((id) => ({ value: id, label: KNOWN_PROVIDERS[id].name, hint: providerAuthHint(id) })),
     initialValue: providers[0],
   })
   if (isCancel(providerChoice)) {
@@ -552,6 +552,15 @@ function formatModelHint(o: ModelOption): string {
   if (o.contextWindow !== null) parts.push(`${(o.contextWindow / 1000).toFixed(0)}K ctx`)
   if (o.reasoning) parts.push('reasoning')
   return parts.join(' · ')
+}
+
+function providerAuthHint(id: KnownProviderId): string {
+  const provider = KNOWN_PROVIDERS[id]
+  const apiKey = providerSupportsApiKey(provider)
+  const oauth = providerSupportsOAuth(provider)
+  if (apiKey && oauth) return 'API key or OAuth'
+  if (oauth) return 'OAuth login'
+  return 'API key'
 }
 
 const START_MESSAGES: Record<Exclude<InitStep, 'hatching'>, string> = {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,6 +1,7 @@
 import { cancel, confirm, intro, isCancel, log, note, password, select, spinner, text } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
+import { KNOWN_PROVIDERS, type KnownModelRef, type KnownProviderId } from '@/config/providers'
 import type { DockerAvailability } from '@/container'
 import {
   findAgentDir,
@@ -12,6 +13,7 @@ import {
   type KakaotalkAuthResult,
 } from '@/init'
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
+import { fetchModelOptions, type ModelOption } from '@/init/models-dev'
 
 export const init = defineCommand({
   meta: {
@@ -47,12 +49,11 @@ export const init = defineCommand({
 
     intro('Initializing TypeClaw...')
 
-    // TODO: provider/model selection. For now we assume Fireworks + Kimi K2.5 Turbo
-    // because that's the only provider wired up in src/agent/auth.ts and src/config.
-    // Expand to a provider picker (OpenAI, Anthropic, Fireworks, ...) once the
-    // provider abstraction lands (see TypeClaw.md Phase 4).
+    const selectedModel = await pickModel()
+    const provider = KNOWN_PROVIDERS[selectedModel.providerId]
+
     const apiKey = await password({
-      message: 'Put your Fireworks API key',
+      message: `Put your ${provider.name} API key (will be saved to .env as ${provider.apiKeyEnv})`,
       validate: (value) => (value && value.length > 0 ? undefined : 'API key is required'),
     })
     if (isCancel(apiKey)) {
@@ -268,6 +269,7 @@ export const init = defineCommand({
       await runInit({
         cwd,
         apiKey,
+        model: selectedModel.ref,
         ...(discordBotToken !== undefined ? { discordBotToken } : {}),
         ...(slackBotToken !== undefined ? { slackBotToken, slackAppToken } : {}),
         ...(telegramBotToken !== undefined ? { telegramBotToken } : {}),
@@ -414,6 +416,68 @@ function reportHatching(event: Extract<InitStepEvent, { step: 'hatching' }>): vo
   } else {
     console.error(`Hatching failed: ${event.result.reason}`)
   }
+}
+
+// Two-step provider+model picker. We split it because most users have a key
+// for exactly one provider — asking them to scroll through a flat list of
+// every (provider, model) pair would surface options they can't use.
+async function pickModel(): Promise<ModelOption> {
+  const s = spinner()
+  s.start('Loading model catalog from models.dev...')
+  const { options, source, warning } = await fetchModelOptions()
+  if (source === 'curated') {
+    s.stop(`Using built-in catalog (models.dev unavailable: ${warning ?? 'unknown'})`)
+  } else {
+    s.stop('Loaded model catalog.')
+  }
+
+  const providers = uniqueProviders(options)
+  const providerChoice = await select({
+    message: 'Pick an LLM provider',
+    options: providers.map((id) => ({ value: id, label: KNOWN_PROVIDERS[id].name })),
+    initialValue: providers[0],
+  })
+  if (isCancel(providerChoice)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+
+  const candidates = options.filter((o) => o.providerId === providerChoice)
+  const modelChoice = await select<KnownModelRef>({
+    message: `Pick a ${KNOWN_PROVIDERS[providerChoice].name} model`,
+    options: candidates.map((o) => ({
+      value: o.ref,
+      label: o.modelName,
+      hint: formatModelHint(o),
+    })),
+    initialValue: candidates[0]?.ref,
+  })
+  if (isCancel(modelChoice)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+
+  const picked = candidates.find((o) => o.ref === modelChoice)
+  if (!picked) throw new Error(`Internal error: picked model ${modelChoice} not in candidates`)
+  return picked
+}
+
+function uniqueProviders(options: ModelOption[]): KnownProviderId[] {
+  const seen = new Set<KnownProviderId>()
+  const out: KnownProviderId[] = []
+  for (const o of options) {
+    if (seen.has(o.providerId)) continue
+    seen.add(o.providerId)
+    out.push(o.providerId)
+  }
+  return out
+}
+
+function formatModelHint(o: ModelOption): string {
+  const parts: string[] = []
+  if (o.contextWindow !== null) parts.push(`${(o.contextWindow / 1000).toFixed(0)}K ctx`)
+  if (o.reasoning) parts.push('reasoning')
+  return parts.join(' · ')
 }
 
 const START_MESSAGES: Record<Exclude<InitStep, 'hatching'>, string> = {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,7 +1,13 @@
 import { cancel, confirm, intro, isCancel, log, note, password, select, spinner, text } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
-import { KNOWN_PROVIDERS, type KnownModelRef, type KnownProviderId } from '@/config/providers'
+import {
+  KNOWN_PROVIDERS,
+  supportsApiKey as providerSupportsApiKey,
+  supportsOAuth as providerSupportsOAuth,
+  type KnownModelRef,
+  type KnownProviderId,
+} from '@/config/providers'
 import type { DockerAvailability } from '@/container'
 import {
   findAgentDir,
@@ -11,9 +17,11 @@ import {
   type InitStep,
   type InitStepEvent,
   type KakaotalkAuthResult,
+  type LLMAuth,
 } from '@/init'
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { fetchModelOptions, type ModelOption } from '@/init/models-dev'
+import { makeOAuthLoginRunner } from '@/init/oauth-login'
 
 export const init = defineCommand({
   meta: {
@@ -52,14 +60,7 @@ export const init = defineCommand({
     const selectedModel = await pickModel()
     const provider = KNOWN_PROVIDERS[selectedModel.providerId]
 
-    const apiKey = await password({
-      message: `Put your ${provider.name} API key (will be saved to .env as ${provider.apiKeyEnv})`,
-      validate: (value) => (value && value.length > 0 ? undefined : 'API key is required'),
-    })
-    if (isCancel(apiKey)) {
-      cancel('Aborted.')
-      process.exit(0)
-    }
+    const llmAuth = await collectLLMAuth(provider)
 
     const channelChoice = await select({
       message: 'Pick a channel to wire (you can add more later by editing typeclaw.json + .env)',
@@ -268,7 +269,7 @@ export const init = defineCommand({
     try {
       await runInit({
         cwd,
-        apiKey,
+        llmAuth,
         model: selectedModel.ref,
         ...(discordBotToken !== undefined ? { discordBotToken } : {}),
         ...(slackBotToken !== undefined ? { slackBotToken, slackAppToken } : {}),
@@ -350,6 +351,9 @@ function reportProgress(
       case 'kakaotalk-auth':
         s.stop(reportKakaotalkAuth(event.result))
         break
+      case 'oauth-login':
+        s.stop(event.result.ok ? 'Logged in.' : `OAuth login failed: ${event.result.reason}`)
+        break
       case 'install':
         s.stop(event.result.ok ? 'Dependencies installed.' : `Skipped bun install: ${event.result.reason}`)
         break
@@ -418,6 +422,76 @@ function reportHatching(event: Extract<InitStepEvent, { step: 'hatching' }>): vo
   }
 }
 
+// Resolves how the user wants to authenticate to the chosen provider:
+// - api-key only (e.g. Fireworks): prompt for the key, write to .env.
+// - oauth only (e.g. openai-codex): run the browser flow inline, write
+//   auth.json. No API key prompt at all.
+// - both supported (no providers ship this today, but Anthropic will when
+//   wired): ask "API key or OAuth?" first, then dispatch to the chosen path.
+async function collectLLMAuth(provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]): Promise<LLMAuth> {
+  const supportsApiKey = providerSupportsApiKey(provider)
+  const supportsOAuth = providerSupportsOAuth(provider)
+
+  let method: 'api-key' | 'oauth'
+  if (supportsApiKey && supportsOAuth) {
+    const choice = await select<'api-key' | 'oauth'>({
+      message: `How do you want to authenticate to ${provider.name}?`,
+      options: [
+        { value: 'api-key', label: 'API key', hint: `saved to .env as ${provider.apiKeyEnv}` },
+        { value: 'oauth', label: 'OAuth (browser login)', hint: 'saved to auth.json' },
+      ],
+      initialValue: 'api-key',
+    })
+    if (isCancel(choice)) {
+      cancel('Aborted.')
+      process.exit(0)
+    }
+    method = choice
+  } else if (supportsOAuth) {
+    method = 'oauth'
+  } else {
+    method = 'api-key'
+  }
+
+  if (method === 'api-key') {
+    const apiKey = await password({
+      message: `Put your ${provider.name} API key (will be saved to .env as ${provider.apiKeyEnv})`,
+      validate: (value) => (value && value.length > 0 ? undefined : 'API key is required'),
+    })
+    if (isCancel(apiKey)) {
+      cancel('Aborted.')
+      process.exit(0)
+    }
+    return { kind: 'api-key', apiKey }
+  }
+
+  return { kind: 'oauth', runLogin: makeOAuthLoginRunner(buildOAuthCallbacks(provider.name)) }
+}
+
+// Wraps the OAuth lifecycle into the same clack idiom the rest of the wizard
+// uses: a spinner over the "waiting for login" period, with onAuth printing
+// the URL the user needs to open and onPrompt falling back to a `text`
+// prompt for the manual code path. The spinner is started by onAuth and
+// stopped by the caller (runInit) — we don't try to manage it here because
+// the spinner lifecycle has to span emit('start') -> emit('done').
+function buildOAuthCallbacks(providerName: string) {
+  return {
+    onAuth: (url: string, instructions?: string) => {
+      const lines = [`Open this URL in your browser to authorize ${providerName}:`, '', url]
+      if (instructions) lines.push('', instructions)
+      note(lines.join('\n'), 'Browser login')
+    },
+    onProgress: (message: string) => {
+      log.info(message)
+    },
+    onPrompt: async (message: string, placeholder?: string): Promise<string | null> => {
+      const value = await text({ message, ...(placeholder !== undefined ? { placeholder } : {}) })
+      if (isCancel(value)) return null
+      return value
+    },
+  }
+}
+
 // Two-step provider+model picker. We split it because most users have a key
 // for exactly one provider — asking them to scroll through a flat list of
 // every (provider, model) pair would surface options they can't use.
@@ -482,6 +556,7 @@ function formatModelHint(o: ModelOption): string {
 
 const START_MESSAGES: Record<Exclude<InitStep, 'hatching'>, string> = {
   preflight: 'Checking Docker...',
+  'oauth-login': 'Waiting for browser login...',
   scaffold: 'Laying the egg...',
   'kakaotalk-auth': 'Logging in to KakaoTalk...',
   install: 'Installing dependencies with bun...',

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -7,7 +7,13 @@ import { z } from 'zod'
 
 import { channelsSchema } from '@/channels/schema'
 
-import { KNOWN_PROVIDERS, listKnownModelRefs, type KnownModelRef, type KnownProviderId } from './providers'
+import {
+  DEFAULT_MODEL_REF,
+  KNOWN_PROVIDERS,
+  listKnownModelRefs,
+  type KnownModelRef,
+  type KnownProviderId,
+} from './providers'
 
 const CONFIG_FILE = 'typeclaw.json'
 
@@ -102,7 +108,7 @@ export const configSchema = z
   .object({
     $schema: z.string().optional(),
     port: z.number().int().min(1).max(65535).default(DEFAULT_PORT),
-    model: z.enum(knownModelRefs).default('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'), // FIXME: TEMP default
+    model: z.enum(knownModelRefs).default(DEFAULT_MODEL_REF),
     // Defaults to `[]` so the field can be omitted from `typeclaw.json` (no
     // host paths exposed) without failing the whole config load. `typeclaw
     // init` omits this field so users don't see noise for the empty case.
@@ -124,7 +130,7 @@ export const configSchema = z
 
 export type Config = z.infer<typeof configSchema>
 
-export function resolveModel(ref: KnownModelRef): Model<'openai-completions'> {
+export function resolveModel(ref: KnownModelRef): Model<'openai-completions'> | Model<'openai-responses'> {
   // Model IDs can contain '/', so split only on the first separator.
   const slash = ref.indexOf('/')
   const providerId = ref.slice(0, slash) as KnownProviderId

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1,11 +1,24 @@
-import type { Model } from '@mariozechner/pi-ai'
+import type { Api, Model } from '@mariozechner/pi-ai'
 
+// Authentication mechanism a provider supports. `api-key` reads a static key
+// from .env (the original path); `oauth` runs a browser flow at init time and
+// stores rotating credentials in auth.json. The CLI picker uses this to ask
+// "API key or OAuth?" only when both are wired up.
+export type AuthMethod = 'api-key' | 'oauth'
+
+// `apiKeyEnv` and `oauthProviderId` are both always present on the literal
+// to keep `as const satisfies` narrowing easy on the consumer side; entries
+// that don't apply to a given provider are set to `null` rather than omitted.
+// Consumers check `auth.includes('api-key')` / `auth.includes('oauth')` to
+// decide which field to consult.
 type KnownProvider = {
   id: string
   name: string
   baseUrl: string
-  apiKeyEnv: string
-  models: Record<string, Model<'openai-completions'> | Model<'openai-responses'>>
+  auth: ReadonlyArray<AuthMethod>
+  apiKeyEnv: string | null
+  oauthProviderId: string | null
+  models: Record<string, Model<Api>>
 }
 
 // Curated allowlist of providers + models that are wired into the agent
@@ -21,9 +34,12 @@ type KnownProvider = {
 // Models" section). `setRuntimeApiKey(provider, key)` keys off the `provider`
 // field, so it MUST match the outer provider id.
 //
-// Adding a new provider: add a top-level entry. `apiKeyEnv` is the .env var
-// `typeclaw init` writes and `agent/auth.ts` reads at boot, so make it
-// match the upstream provider's standard env var (e.g. `OPENAI_API_KEY`).
+// Adding a new provider: add a top-level entry. Set `auth` to the supported
+// methods. For `api-key` providers, `apiKeyEnv` is the .env var typeclaw
+// writes at init and reads at boot (match the upstream provider's standard,
+// e.g. `OPENAI_API_KEY`). For `oauth` providers, `oauthProviderId` MUST match
+// a pi-ai OAuth provider id exactly, otherwise `authStorage.login()` will
+// throw "Unknown OAuth provider".
 export const KNOWN_PROVIDERS = {
   openai: {
     id: 'openai',
@@ -32,7 +48,9 @@ export const KNOWN_PROVIDERS = {
     // store it explicitly so the init wizard can show users which endpoint
     // their key will hit.
     baseUrl: 'https://api.openai.com/v1',
+    auth: ['api-key'],
     apiKeyEnv: 'OPENAI_API_KEY',
+    oauthProviderId: null,
     models: {
       // Default. Cheap, fast, broadly available across OpenAI account tiers.
       'gpt-5.4-nano': {
@@ -73,11 +91,61 @@ export const KNOWN_PROVIDERS = {
       },
     },
   },
+  // ChatGPT Plus/Pro subscription via the OAuth Codex backend. No API key
+  // path here on purpose — the Codex backend is OAuth-only upstream.
+  'openai-codex': {
+    id: 'openai-codex',
+    name: 'OpenAI Codex (ChatGPT Plus/Pro)',
+    baseUrl: 'https://chatgpt.com/backend-api',
+    auth: ['oauth'],
+    apiKeyEnv: null,
+    oauthProviderId: 'openai-codex',
+    models: {
+      'gpt-5.2-codex': {
+        id: 'gpt-5.2-codex',
+        name: 'GPT-5.2 Codex',
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        baseUrl: 'https://chatgpt.com/backend-api',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+        contextWindow: 272000,
+        maxTokens: 128000,
+      },
+      'gpt-5.1-codex-max': {
+        id: 'gpt-5.1-codex-max',
+        name: 'GPT-5.1 Codex Max',
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        baseUrl: 'https://chatgpt.com/backend-api',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 1.25, output: 10, cacheRead: 0.125, cacheWrite: 0 },
+        contextWindow: 272000,
+        maxTokens: 128000,
+      },
+      'gpt-5.1-codex-mini': {
+        id: 'gpt-5.1-codex-mini',
+        name: 'GPT-5.1 Codex Mini',
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        baseUrl: 'https://chatgpt.com/backend-api',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 0.25, output: 2, cacheRead: 0.025, cacheWrite: 0 },
+        contextWindow: 272000,
+        maxTokens: 128000,
+      },
+    },
+  },
   fireworks: {
     id: 'fireworks',
     name: 'Fireworks',
     baseUrl: 'https://api.fireworks.ai/inference/v1',
+    auth: ['api-key'],
     apiKeyEnv: 'FIREWORKS_API_KEY',
+    oauthProviderId: null,
     models: {
       // Kept available even though models.dev hasn't indexed it yet —
       // Fireworks ships this router as an alias to the latest k2.6 weights.
@@ -119,8 +187,24 @@ export function listKnownModelRefs(): KnownModelRef[] {
 export const DEFAULT_MODEL_REF: KnownModelRef = 'openai/gpt-5.4-nano'
 
 export function providerForModelRef(ref: KnownModelRef): KnownProviderId {
-  // KnownModelRef is `${provider}/${modelId}`, but model IDs themselves can
-  // contain '/' (Fireworks), so split on the FIRST slash only.
-  const slash = ref.indexOf('/')
-  return ref.slice(0, slash) as KnownProviderId
+  // KnownModelRef is `${provider}/${modelId}`, but provider IDs themselves can
+  // contain '-' and model IDs can contain '/' (Fireworks). We split on the
+  // first slash that follows a registered provider id.
+  for (const providerId of Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]) {
+    if (ref.startsWith(`${providerId}/`)) return providerId
+  }
+  throw new Error(`Unknown provider in model ref: ${ref}`)
+}
+
+// `as const satisfies` narrows each entry's `auth` to a tuple of its specific
+// literal values, which makes `provider.auth.includes('oauth')` fail to
+// compile on api-key-only entries (because TS thinks the array can never
+// contain 'oauth'). These accessors widen the membership check back to
+// AuthMethod so consumers can branch without per-provider casts.
+export function supportsApiKey(provider: { auth: ReadonlyArray<AuthMethod> }): boolean {
+  return (provider.auth as ReadonlyArray<AuthMethod>).includes('api-key')
+}
+
+export function supportsOAuth(provider: { auth: ReadonlyArray<AuthMethod> }): boolean {
+  return (provider.auth as ReadonlyArray<AuthMethod>).includes('oauth')
 }

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -51,8 +51,12 @@ export const KNOWN_PROVIDERS = {
     auth: ['api-key'],
     apiKeyEnv: 'OPENAI_API_KEY',
     oauthProviderId: null,
+    // Costs and context windows mirror models.dev as of 2026-05-10. When
+    // refreshing, also rerun `scripts/generate-schema.ts` so typeclaw.schema.json
+    // picks up new enum values.
     models: {
-      // Default. Cheap, fast, broadly available across OpenAI account tiers.
+      // Default. Cheapest tool-calling reasoning model in the family;
+      // available on every paid OpenAI account tier.
       'gpt-5.4-nano': {
         id: 'gpt-5.4-nano',
         name: 'GPT-5.4 nano',
@@ -61,7 +65,7 @@ export const KNOWN_PROVIDERS = {
         baseUrl: 'https://api.openai.com/v1',
         reasoning: true,
         input: ['text', 'image'],
-        cost: { input: 0.05, output: 0.4, cacheRead: 0.005, cacheWrite: 0 },
+        cost: { input: 0.2, output: 1.25, cacheRead: 0.02, cacheWrite: 0 },
         contextWindow: 400000,
         maxTokens: 128000,
       },
@@ -73,7 +77,7 @@ export const KNOWN_PROVIDERS = {
         baseUrl: 'https://api.openai.com/v1',
         reasoning: true,
         input: ['text', 'image'],
-        cost: { input: 0.25, output: 2, cacheRead: 0.025, cacheWrite: 0 },
+        cost: { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0 },
         contextWindow: 400000,
         maxTokens: 128000,
       },
@@ -85,7 +89,19 @@ export const KNOWN_PROVIDERS = {
         baseUrl: 'https://api.openai.com/v1',
         reasoning: true,
         input: ['text', 'image'],
-        cost: { input: 1.25, output: 10, cacheRead: 0.125, cacheWrite: 0 },
+        cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+        contextWindow: 1050000,
+        maxTokens: 128000,
+      },
+      'gpt-5.5': {
+        id: 'gpt-5.5',
+        name: 'GPT-5.5',
+        api: 'openai-responses',
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
         contextWindow: 1050000,
         maxTokens: 128000,
       },
@@ -93,6 +109,12 @@ export const KNOWN_PROVIDERS = {
   },
   // ChatGPT Plus/Pro subscription via the OAuth Codex backend. No API key
   // path here on purpose — the Codex backend is OAuth-only upstream.
+  //
+  // The model lineup is intersected with pi-ai's `openai-codex` provider
+  // bucket (see node_modules/@mariozechner/pi-ai/dist/models.generated.js):
+  // only models that ChatGPT exposes through `chatgpt.com/backend-api` work
+  // here. Notably `gpt-5.5` is api-key-only as of 2026-05-10 (not in pi-ai's
+  // codex bucket); add it here when pi-ai picks it up upstream.
   'openai-codex': {
     id: 'openai-codex',
     name: 'OpenAI Codex (ChatGPT Plus/Pro)',
@@ -101,9 +123,33 @@ export const KNOWN_PROVIDERS = {
     apiKeyEnv: null,
     oauthProviderId: 'openai-codex',
     models: {
-      'gpt-5.2-codex': {
-        id: 'gpt-5.2-codex',
-        name: 'GPT-5.2 Codex',
+      'gpt-5.4': {
+        id: 'gpt-5.4',
+        name: 'GPT-5.4',
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        baseUrl: 'https://chatgpt.com/backend-api',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+        contextWindow: 272000,
+        maxTokens: 128000,
+      },
+      'gpt-5.4-mini': {
+        id: 'gpt-5.4-mini',
+        name: 'GPT-5.4 mini',
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        baseUrl: 'https://chatgpt.com/backend-api',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0 },
+        contextWindow: 272000,
+        maxTokens: 128000,
+      },
+      'gpt-5.3-codex': {
+        id: 'gpt-5.3-codex',
+        name: 'GPT-5.3 Codex',
         api: 'openai-codex-responses',
         provider: 'openai-codex',
         baseUrl: 'https://chatgpt.com/backend-api',
@@ -113,28 +159,16 @@ export const KNOWN_PROVIDERS = {
         contextWindow: 272000,
         maxTokens: 128000,
       },
-      'gpt-5.1-codex-max': {
-        id: 'gpt-5.1-codex-max',
-        name: 'GPT-5.1 Codex Max',
+      'gpt-5.3-codex-spark': {
+        id: 'gpt-5.3-codex-spark',
+        name: 'GPT-5.3 Codex Spark',
         api: 'openai-codex-responses',
         provider: 'openai-codex',
         baseUrl: 'https://chatgpt.com/backend-api',
         reasoning: true,
-        input: ['text', 'image'],
-        cost: { input: 1.25, output: 10, cacheRead: 0.125, cacheWrite: 0 },
-        contextWindow: 272000,
-        maxTokens: 128000,
-      },
-      'gpt-5.1-codex-mini': {
-        id: 'gpt-5.1-codex-mini',
-        name: 'GPT-5.1 Codex Mini',
-        api: 'openai-codex-responses',
-        provider: 'openai-codex',
-        baseUrl: 'https://chatgpt.com/backend-api',
-        reasoning: true,
-        input: ['text', 'image'],
-        cost: { input: 0.25, output: 2, cacheRead: 0.025, cacheWrite: 0 },
-        contextWindow: 272000,
+        input: ['text'],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
         maxTokens: 128000,
       },
     },

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -5,20 +5,85 @@ type KnownProvider = {
   name: string
   baseUrl: string
   apiKeyEnv: string
-  models: Record<string, Model<'openai-completions'>>
+  models: Record<string, Model<'openai-completions'> | Model<'openai-responses'>>
 }
 
-// TODO: Temp
+// Curated allowlist of providers + models that are wired into the agent
+// runtime. The values here back the Zod enum on `configSchema.model`, so any
+// model the user can put in `typeclaw.json` MUST appear here verbatim. The
+// init-time picker may surface additional models from models.dev, but it
+// resolves them through this list before scaffolding (anything missing falls
+// back to a curated default).
+//
+// Adding a new model: append it to the matching provider's `models` map. Each
+// model object is the literal `Model<...>` that pi-ai consumes — keep it
+// faithful to https://github.com/mariozechner/pi-ai (the readme's "Custom
+// Models" section). `setRuntimeApiKey(provider, key)` keys off the `provider`
+// field, so it MUST match the outer provider id.
+//
+// Adding a new provider: add a top-level entry. `apiKeyEnv` is the .env var
+// `typeclaw init` writes and `agent/auth.ts` reads at boot, so make it
+// match the upstream provider's standard env var (e.g. `OPENAI_API_KEY`).
 export const KNOWN_PROVIDERS = {
+  openai: {
+    id: 'openai',
+    name: 'OpenAI',
+    // OpenAI's library auto-detects this from `provider: 'openai'`, but we
+    // store it explicitly so the init wizard can show users which endpoint
+    // their key will hit.
+    baseUrl: 'https://api.openai.com/v1',
+    apiKeyEnv: 'OPENAI_API_KEY',
+    models: {
+      // Default. Cheap, fast, broadly available across OpenAI account tiers.
+      'gpt-5.4-nano': {
+        id: 'gpt-5.4-nano',
+        name: 'GPT-5.4 nano',
+        api: 'openai-responses',
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 0.05, output: 0.4, cacheRead: 0.005, cacheWrite: 0 },
+        contextWindow: 400000,
+        maxTokens: 128000,
+      },
+      'gpt-5.4-mini': {
+        id: 'gpt-5.4-mini',
+        name: 'GPT-5.4 mini',
+        api: 'openai-responses',
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 0.25, output: 2, cacheRead: 0.025, cacheWrite: 0 },
+        contextWindow: 400000,
+        maxTokens: 128000,
+      },
+      'gpt-5.4': {
+        id: 'gpt-5.4',
+        name: 'GPT-5.4',
+        api: 'openai-responses',
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 1.25, output: 10, cacheRead: 0.125, cacheWrite: 0 },
+        contextWindow: 1050000,
+        maxTokens: 128000,
+      },
+    },
+  },
   fireworks: {
     id: 'fireworks',
     name: 'Fireworks',
     baseUrl: 'https://api.fireworks.ai/inference/v1',
     apiKeyEnv: 'FIREWORKS_API_KEY',
     models: {
+      // Kept available even though models.dev hasn't indexed it yet —
+      // Fireworks ships this router as an alias to the latest k2.6 weights.
       'accounts/fireworks/routers/kimi-k2p6-turbo': {
         id: 'accounts/fireworks/routers/kimi-k2p6-turbo',
-        name: 'Kimi K2.5 Turbo',
+        name: 'Kimi K2.6 Turbo',
         api: 'openai-completions',
         provider: 'fireworks',
         baseUrl: 'https://api.fireworks.ai/inference/v1',
@@ -46,4 +111,16 @@ export function listKnownModelRefs(): KnownModelRef[] {
     }
   }
   return refs as KnownModelRef[]
+}
+
+// The default we hand to scaffolded `typeclaw.json` and the schema's
+// `model.default`. Lives here (next to the provider table) so adding a model
+// can't drift from the field default — both come from the same module.
+export const DEFAULT_MODEL_REF: KnownModelRef = 'openai/gpt-5.4-nano'
+
+export function providerForModelRef(ref: KnownModelRef): KnownProviderId {
+  // KnownModelRef is `${provider}/${modelId}`, but model IDs themselves can
+  // contain '/' (Fireworks), so split on the FIRST slash only.
+  const slash = ref.indexOf('/')
+  return ref.slice(0, slash) as KnownProviderId
 }

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -110,11 +110,13 @@ export const KNOWN_PROVIDERS = {
   // ChatGPT Plus/Pro subscription via the OAuth Codex backend. No API key
   // path here on purpose — the Codex backend is OAuth-only upstream.
   //
-  // The model lineup is intersected with pi-ai's `openai-codex` provider
-  // bucket (see node_modules/@mariozechner/pi-ai/dist/models.generated.js):
-  // only models that ChatGPT exposes through `chatgpt.com/backend-api` work
-  // here. Notably `gpt-5.5` is api-key-only as of 2026-05-10 (not in pi-ai's
-  // codex bucket); add it here when pi-ai picks it up upstream.
+  // pi-ai 0.73.1's `openai-codex` bucket carries gpt-5.5 (and 5.4) against
+  // chatgpt.com/backend-api. We pin pi-coding-agent ^0.67.3 today, which
+  // ships pi-ai 0.67.3 and lacks those entries — but we hand pi-ai a
+  // freshly-constructed `Model<>` literal via resolveModel(), bypassing its
+  // built-in catalog entirely (same trick we use for kimi-k2p6-turbo). So
+  // these ids work end-to-end as long as the Codex backend itself accepts
+  // them, which it does for ChatGPT Plus/Pro accounts as of 2026-05-10.
   'openai-codex': {
     id: 'openai-codex',
     name: 'OpenAI Codex (ChatGPT Plus/Pro)',
@@ -123,18 +125,6 @@ export const KNOWN_PROVIDERS = {
     apiKeyEnv: null,
     oauthProviderId: 'openai-codex',
     models: {
-      'gpt-5.4': {
-        id: 'gpt-5.4',
-        name: 'GPT-5.4',
-        api: 'openai-codex-responses',
-        provider: 'openai-codex',
-        baseUrl: 'https://chatgpt.com/backend-api',
-        reasoning: true,
-        input: ['text', 'image'],
-        cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
-        contextWindow: 272000,
-        maxTokens: 128000,
-      },
       'gpt-5.4-mini': {
         id: 'gpt-5.4-mini',
         name: 'GPT-5.4 mini',
@@ -147,28 +137,28 @@ export const KNOWN_PROVIDERS = {
         contextWindow: 272000,
         maxTokens: 128000,
       },
-      'gpt-5.3-codex': {
-        id: 'gpt-5.3-codex',
-        name: 'GPT-5.3 Codex',
+      'gpt-5.4': {
+        id: 'gpt-5.4',
+        name: 'GPT-5.4',
         api: 'openai-codex-responses',
         provider: 'openai-codex',
         baseUrl: 'https://chatgpt.com/backend-api',
         reasoning: true,
         input: ['text', 'image'],
-        cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+        cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
         contextWindow: 272000,
         maxTokens: 128000,
       },
-      'gpt-5.3-codex-spark': {
-        id: 'gpt-5.3-codex-spark',
-        name: 'GPT-5.3 Codex Spark',
+      'gpt-5.5': {
+        id: 'gpt-5.5',
+        name: 'GPT-5.5',
         api: 'openai-codex-responses',
         provider: 'openai-codex',
         baseUrl: 'https://chatgpt.com/backend-api',
         reasoning: true,
-        input: ['text'],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 128000,
+        input: ['text', 'image'],
+        cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+        contextWindow: 272000,
         maxTokens: 128000,
       },
     },

--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -10,7 +10,7 @@ let root: string
 beforeEach(async () => {
   root = await mkdtemp(join(tmpdir(), 'typeclaw-add-channel-'))
   await scaffold(root)
-  await writeSecrets(root, { fireworksApiKey: 'fw_existing' })
+  await writeSecrets(root, { apiKey: 'fw_existing', model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
 })
 
 afterEach(async () => {

--- a/src/init/gitignore.ts
+++ b/src/init/gitignore.ts
@@ -14,6 +14,7 @@ export function buildGitignore(config: GitignoreConfig = { append: [] }): string
 # like node_modules/ — reproducible from source, not part of agent state.
 .env
 .env.local
+auth.json
 node_modules/
 packages/*/node_modules/
 workspace/

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -26,6 +26,7 @@ import {
   writeDockerAssets,
   writeSecrets,
 } from './index'
+import { makeFakeOAuthLoginRunner } from './oauth-login'
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
@@ -413,6 +414,83 @@ describe('runInit', () => {
     })
 
     expect(hatchingInvoked).toBe(false)
+  })
+
+  test('OAuth path: emits oauth-login step, omits API key from .env, calls login runner with chosen model', async () => {
+    const calls: Array<{ cwd: string; model: string; providerId: string }> = []
+    const fakeLogin = makeFakeOAuthLoginRunner({
+      onCalled: (opts) => {
+        calls.push({ cwd: opts.cwd, model: opts.model, providerId: opts.providerId })
+      },
+    })
+    const events: InitStepEvent[] = []
+
+    await runInit({
+      cwd: root,
+      model: 'openai-codex/gpt-5.2-codex',
+      llmAuth: { kind: 'oauth', runLogin: fakeLogin },
+      runHatching: okHatch,
+      dockerExec: okDocker,
+      onProgress: (e) => events.push(e),
+    })
+
+    expect(calls).toEqual([{ cwd: root, model: 'openai-codex/gpt-5.2-codex', providerId: 'openai-codex' }])
+    expect(events.map((e) => `${e.step}:${e.phase}`)).toEqual([
+      'preflight:start',
+      'preflight:done',
+      'oauth-login:start',
+      'oauth-login:done',
+      'scaffold:start',
+      'scaffold:done',
+      'install:start',
+      'install:done',
+      'dockerfile:start',
+      'dockerfile:done',
+      'git:start',
+      'git:done',
+      'hatching:start',
+      'hatching:done',
+    ])
+    // .env should be empty (no LLM key, no channel tokens) under OAuth.
+    expect(await readFile(join(root, '.env'), 'utf8')).toBe('')
+  })
+
+  test('OAuth path: aborts before scaffold when login fails (no half-init folder)', async () => {
+    const fakeLogin = makeFakeOAuthLoginRunner({ result: { ok: false, reason: 'browser closed' } })
+
+    await expect(
+      runInit({
+        cwd: root,
+        model: 'openai-codex/gpt-5.2-codex',
+        llmAuth: { kind: 'oauth', runLogin: fakeLogin },
+        runHatching: okHatch,
+        dockerExec: okDocker,
+      }),
+    ).rejects.toThrow(/OAuth login failed: browser closed/)
+
+    // Scaffold-side artifacts must not exist.
+    expect(existsSync(join(root, 'typeclaw.json'))).toBe(false)
+    expect(existsSync(join(root, '.env'))).toBe(false)
+  })
+
+  test('OAuth path: skips oauth-login step on api-key path', async () => {
+    const events: InitStepEvent[] = []
+
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      dockerExec: okDocker,
+      onProgress: (e) => events.push(e),
+    })
+
+    expect(events.some((e) => e.step === 'oauth-login')).toBe(false)
+  })
+
+  test('throws when neither apiKey nor llmAuth is provided', async () => {
+    await expect(runInit({ cwd: root, runHatching: okHatch, dockerExec: okDocker })).rejects.toThrow(
+      /requires either `llmAuth` or `apiKey`/,
+    )
   })
 })
 

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -427,14 +427,14 @@ describe('runInit', () => {
 
     await runInit({
       cwd: root,
-      model: 'openai-codex/gpt-5.3-codex',
+      model: 'openai-codex/gpt-5.5',
       llmAuth: { kind: 'oauth', runLogin: fakeLogin },
       runHatching: okHatch,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
     })
 
-    expect(calls).toEqual([{ cwd: root, model: 'openai-codex/gpt-5.3-codex', providerId: 'openai-codex' }])
+    expect(calls).toEqual([{ cwd: root, model: 'openai-codex/gpt-5.5', providerId: 'openai-codex' }])
     expect(events.map((e) => `${e.step}:${e.phase}`)).toEqual([
       'preflight:start',
       'preflight:done',
@@ -461,7 +461,7 @@ describe('runInit', () => {
     await expect(
       runInit({
         cwd: root,
-        model: 'openai-codex/gpt-5.3-codex',
+        model: 'openai-codex/gpt-5.5',
         llmAuth: { kind: 'oauth', runLogin: fakeLogin },
         runHatching: okHatch,
         dockerExec: okDocker,

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -135,7 +135,13 @@ describe('runInit', () => {
   })
 
   test('produces an initialized agent folder (config, secrets, markdown, git repo)', async () => {
-    await runInit({ cwd: root, apiKey: 'fw_integration_key', runHatching: okHatch, dockerExec: okDocker })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_integration_key',
+      model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+      runHatching: okHatch,
+      dockerExec: okDocker,
+    })
 
     expect(isInitialized(root)).toBe(true)
     expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_integration_key\n')
@@ -270,7 +276,13 @@ describe('runInit', () => {
   test('is idempotent: re-running after a failed hatching re-runs all steps without crashing', async () => {
     // given: a prior run where hatching failed (e.g. docker daemon was down).
     const failingHatch: HatchRunner = async () => ({ ok: false, reason: 'docker build failed' })
-    await runInit({ cwd: root, apiKey: 'fw_first_key', runHatching: failingHatch, dockerExec: okDocker })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_first_key',
+      model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+      runHatching: failingHatch,
+      dockerExec: okDocker,
+    })
     expect(isInitialized(root)).toBe(true)
     expect(await isHatched(root)).toBe(false)
 
@@ -279,6 +291,7 @@ describe('runInit', () => {
     await runInit({
       cwd: root,
       apiKey: 'fw_second_key',
+      model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
       runHatching: okHatch,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
@@ -538,7 +551,7 @@ describe('scaffold', () => {
     expect(raw.endsWith('\n')).toBe(true)
     expect(JSON.parse(raw)).toEqual({
       $schema: './node_modules/typeclaw/typeclaw.schema.json',
-      model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+      model: 'openai/gpt-5.4-nano',
     })
   })
 
@@ -799,7 +812,7 @@ describe('initGitRepo', () => {
 
   test('respects .gitignore (does not track .env)', async () => {
     await scaffold(root)
-    await writeSecrets(root, { fireworksApiKey: 'fw_test' })
+    await writeSecrets(root, { apiKey: 'fw_test', model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
 
     await initGitRepo(root)
 
@@ -1044,21 +1057,40 @@ describe('writeDockerAssets', () => {
 })
 
 describe('writeSecrets', () => {
-  test('writes FIREWORKS_API_KEY to .env', async () => {
-    await writeSecrets(root, { fireworksApiKey: 'fw_test_abc123' })
+  test('writes OPENAI_API_KEY to .env when model is an OpenAI model', async () => {
+    await writeSecrets(root, { apiKey: 'sk-test_abc123', model: 'openai/gpt-5.4-nano' })
+
+    expect(await readFile(join(root, '.env'), 'utf8')).toBe('OPENAI_API_KEY=sk-test_abc123\n')
+  })
+
+  test('writes FIREWORKS_API_KEY to .env when model is a Fireworks model', async () => {
+    await writeSecrets(root, {
+      apiKey: 'fw_test_abc123',
+      model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+    })
 
     expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_test_abc123\n')
   })
 
+  test('defaults to OPENAI_API_KEY when model is omitted (matches DEFAULT_MODEL_REF)', async () => {
+    await writeSecrets(root, { apiKey: 'sk-default' })
+
+    expect(await readFile(join(root, '.env'), 'utf8')).toBe('OPENAI_API_KEY=sk-default\n')
+  })
+
   test('overwrites an existing .env', async () => {
     await writeFile(join(root, '.env'), 'OLD=1\n')
-    await writeSecrets(root, { fireworksApiKey: 'fw_new' })
+    await writeSecrets(root, { apiKey: 'fw_new', model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
 
     expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_new\n')
   })
 
   test('appends TELEGRAM_BOT_TOKEN when telegramBotToken is provided', async () => {
-    await writeSecrets(root, { fireworksApiKey: 'fw_test', telegramBotToken: '1234567890:ABCdef' })
+    await writeSecrets(root, {
+      apiKey: 'fw_test',
+      model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+      telegramBotToken: '1234567890:ABCdef',
+    })
 
     expect(await readFile(join(root, '.env'), 'utf8')).toBe(
       'FIREWORKS_API_KEY=fw_test\nTELEGRAM_BOT_TOKEN=1234567890:ABCdef\n',
@@ -1066,7 +1098,11 @@ describe('writeSecrets', () => {
   })
 
   test('omits TELEGRAM_BOT_TOKEN when telegramBotToken is empty string', async () => {
-    await writeSecrets(root, { fireworksApiKey: 'fw_test', telegramBotToken: '' })
+    await writeSecrets(root, {
+      apiKey: 'fw_test',
+      model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+      telegramBotToken: '',
+    })
 
     expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_test\n')
   })

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -427,14 +427,14 @@ describe('runInit', () => {
 
     await runInit({
       cwd: root,
-      model: 'openai-codex/gpt-5.2-codex',
+      model: 'openai-codex/gpt-5.3-codex',
       llmAuth: { kind: 'oauth', runLogin: fakeLogin },
       runHatching: okHatch,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
     })
 
-    expect(calls).toEqual([{ cwd: root, model: 'openai-codex/gpt-5.2-codex', providerId: 'openai-codex' }])
+    expect(calls).toEqual([{ cwd: root, model: 'openai-codex/gpt-5.3-codex', providerId: 'openai-codex' }])
     expect(events.map((e) => `${e.step}:${e.phase}`)).toEqual([
       'preflight:start',
       'preflight:done',
@@ -461,7 +461,7 @@ describe('runInit', () => {
     await expect(
       runInit({
         cwd: root,
-        model: 'openai-codex/gpt-5.2-codex',
+        model: 'openai-codex/gpt-5.3-codex',
         llmAuth: { kind: 'oauth', runLogin: fakeLogin },
         runHatching: okHatch,
         dockerExec: okDocker,

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -4,6 +4,7 @@ import { basename, dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { config, configSchema, type Config } from '@/config'
+import { DEFAULT_MODEL_REF, KNOWN_PROVIDERS, providerForModelRef, type KnownModelRef } from '@/config/providers'
 import { checkDockerAvailable, type DockerAvailability, type DockerExec, start } from '@/container'
 import { createTui } from '@/tui'
 
@@ -61,6 +62,9 @@ export type KakaotalkAuthRunner = (options: { cwd: string }) => Promise<Kakaotal
 export type InitOptions = {
   cwd: string
   apiKey: string
+  // Selected `provider/model` ref written into typeclaw.json. Defaults to
+  // DEFAULT_MODEL_REF when callers (or older test fixtures) omit it.
+  model?: KnownModelRef
   discordBotToken?: string
   discordAllowAll?: boolean
   slackBotToken?: string
@@ -79,6 +83,7 @@ export type InitOptions = {
 export async function runInit({
   cwd,
   apiKey,
+  model = DEFAULT_MODEL_REF,
   discordBotToken,
   discordAllowAll = true,
   slackBotToken,
@@ -110,6 +115,7 @@ export async function runInit({
   const wantsTelegram = telegramBotToken !== undefined && telegramBotToken !== ''
   emit({ step: 'scaffold', phase: 'start' })
   await scaffold(cwd, {
+    model,
     withDiscord: wantsDiscord,
     discordAllowAll,
     withSlack: wantsSlack,
@@ -120,7 +126,8 @@ export async function runInit({
     kakaotalkAllowAll,
   })
   await writeSecrets(cwd, {
-    fireworksApiKey: apiKey,
+    model,
+    apiKey,
     discordBotToken,
     slackBotToken,
     slackAppToken,
@@ -261,6 +268,7 @@ export async function isHatched(dir: string): Promise<boolean> {
 }
 
 export type ScaffoldOptions = {
+  model?: KnownModelRef
   withDiscord?: boolean
   discordAllowAll?: boolean
   withSlack?: boolean
@@ -281,9 +289,6 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   // immediately populated, so packages/ is the only one that needs this.
   await writeFile(join(root, PACKAGES_DIR, GITKEEP_FILE), '', { flag: 'wx' }).catch(ignoreExists)
 
-  // TODO: hardcoded model. Mirror src/config/index.ts until the config loader
-  // and provider registry exist (TypeClaw.md Phase 1 + Phase 4).
-  //
   // Only fields without sensible defaults elsewhere are emitted. `mounts`
   // defaults to `[]` in configSchema, and the bundled memory plugin owns its
   // own defaults in plugins/memory/index.ts — re-emitting either here would
@@ -291,7 +296,7 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   // truth.
   const config: Record<string, unknown> = {
     $schema: './node_modules/typeclaw/typeclaw.schema.json',
-    model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+    model: options.model ?? DEFAULT_MODEL_REF,
   }
   const channels: Record<string, { allow: string[] }> = {}
   if (options.withDiscord) channels['discord-bot'] = { allow: options.discordAllowAll === false ? [] : ['*'] }
@@ -469,28 +474,31 @@ export async function initGitRepo(cwd: string): Promise<GitInitResult> {
   }
 }
 
-// TODO: generalize to arbitrary provider secrets and switch to secrets.json
-// (per TypeClaw.md spec) once the provider registry exists. Currently hardcoded
-// to FIREWORKS_API_KEY in .env to match src/agent/auth.ts. Optional channel
-// adapter tokens (DISCORD_BOT_TOKEN, SLACK_BOT_TOKEN, SLACK_APP_TOKEN,
-// TELEGRAM_BOT_TOKEN) are appended when provided.
+// Writes the LLM provider's API key (under its provider-specific env var,
+// e.g. OPENAI_API_KEY or FIREWORKS_API_KEY) plus any channel adapter tokens.
+// The provider env var is resolved from KNOWN_PROVIDERS via the model ref,
+// so adding a new provider only requires touching providers.ts.
 export async function writeSecrets(
   root: string,
   {
-    fireworksApiKey,
+    model = DEFAULT_MODEL_REF,
+    apiKey,
     discordBotToken,
     slackBotToken,
     slackAppToken,
     telegramBotToken,
   }: {
-    fireworksApiKey: string
+    model?: KnownModelRef
+    apiKey: string
     discordBotToken?: string
     slackBotToken?: string
     slackAppToken?: string
     telegramBotToken?: string
   },
 ): Promise<void> {
-  const lines = [`FIREWORKS_API_KEY=${fireworksApiKey}`]
+  const providerId = providerForModelRef(model)
+  const apiKeyEnv = KNOWN_PROVIDERS[providerId].apiKeyEnv
+  const lines = [`${apiKeyEnv}=${apiKey}`]
   if (discordBotToken !== undefined && discordBotToken !== '') {
     lines.push(`DISCORD_BOT_TOKEN=${discordBotToken}`)
   }

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -11,6 +11,7 @@ import { createTui } from '@/tui'
 import { buildDockerfile, DOCKERFILE } from './dockerfile'
 import { buildGitignore, GITIGNORE_FILE } from './gitignore'
 import { HATCHING_PROMPT } from './hatching'
+import type { OAuthLoginRunner, OAuthLoginResult } from './oauth-login'
 import { GITKEEP_FILE, PACKAGES_DIR } from './paths'
 
 export { GITKEEP_FILE, PACKAGES_DIR } from './paths'
@@ -35,13 +36,23 @@ export type GitInitResult = { ok: true; skipped: boolean } | { ok: false; reason
 export type DockerAssetsResult = { ok: true; devMode: boolean } | { ok: false; reason: string }
 export type HatchingResult = { ok: true } | { ok: false; reason: string }
 
-export type InitStep = 'preflight' | 'scaffold' | 'kakaotalk-auth' | 'install' | 'dockerfile' | 'git' | 'hatching'
+export type InitStep =
+  | 'preflight'
+  | 'oauth-login'
+  | 'scaffold'
+  | 'kakaotalk-auth'
+  | 'install'
+  | 'dockerfile'
+  | 'git'
+  | 'hatching'
 
 export type KakaotalkAuthResult = { ok: true } | { ok: false; reason: string }
 
 export type InitStepEvent =
   | { step: 'preflight'; phase: 'start' }
   | { step: 'preflight'; phase: 'done'; result: DockerAvailability }
+  | { step: 'oauth-login'; phase: 'start' }
+  | { step: 'oauth-login'; phase: 'done'; result: OAuthLoginResult }
   | { step: 'scaffold'; phase: 'start' }
   | { step: 'scaffold'; phase: 'done' }
   | { step: 'kakaotalk-auth'; phase: 'start' }
@@ -59,12 +70,23 @@ export type HatchRunner = (options: { cwd: string; port: number }) => Promise<Ha
 
 export type KakaotalkAuthRunner = (options: { cwd: string }) => Promise<KakaotalkAuthResult>
 
+// Discriminated by `kind` so the type system enforces "you can't pass an
+// API key to an OAuth provider, and you can't pass an OAuth runner to an
+// API-key provider". Optional model defaults to DEFAULT_MODEL_REF, which is
+// an OpenAI api-key provider — so test fixtures that omit both fields keep
+// working under the api-key path.
+export type LLMAuth = { kind: 'api-key'; apiKey: string } | { kind: 'oauth'; runLogin: OAuthLoginRunner }
+
 export type InitOptions = {
   cwd: string
-  apiKey: string
   // Selected `provider/model` ref written into typeclaw.json. Defaults to
   // DEFAULT_MODEL_REF when callers (or older test fixtures) omit it.
   model?: KnownModelRef
+  // How the agent will authenticate to the LLM provider. When omitted,
+  // defaults to the api-key path with `apiKey` (legacy field, still
+  // supported for backwards compat with the old `runInit` signature).
+  llmAuth?: LLMAuth
+  apiKey?: string
   discordBotToken?: string
   discordAllowAll?: boolean
   slackBotToken?: string
@@ -83,6 +105,7 @@ export type InitOptions = {
 export async function runInit({
   cwd,
   apiKey,
+  llmAuth,
   model = DEFAULT_MODEL_REF,
   discordBotToken,
   discordAllowAll = true,
@@ -110,6 +133,29 @@ export async function runInit({
   emit({ step: 'preflight', phase: 'done', result: preflight })
   if (!preflight.ok) return
 
+  // Resolve the auth contract: explicit `llmAuth` wins; otherwise, fall back
+  // to the legacy `apiKey` field (api-key path). Throwing here instead of
+  // proceeding with bad data prevents writing a half-initialized agent
+  // folder for a doomed config.
+  const resolvedAuth = resolveLLMAuth(llmAuth, apiKey)
+
+  // OAuth login runs BEFORE scaffold so a failed/aborted browser flow leaves
+  // the user's directory untouched (same rationale as the docker preflight).
+  // Same trap as kakaotalk-auth: scaffold-then-fail-auth would leave
+  // typeclaw.json without working credentials and the runtime would silently
+  // refuse to boot. The login itself doesn't need the agent folder to exist
+  // — pi-ai's OAuth helper just needs a writable path for auth.json, which
+  // we create on demand inside scaffold().
+  if (resolvedAuth.kind === 'oauth') {
+    emit({ step: 'oauth-login', phase: 'start' })
+    await mkdir(cwd, { recursive: true })
+    const result = await resolvedAuth.runLogin({ cwd, model })
+    emit({ step: 'oauth-login', phase: 'done', result })
+    if (!result.ok) {
+      throw new Error(`OAuth login failed: ${result.reason}`)
+    }
+  }
+
   const wantsDiscord = discordBotToken !== undefined && discordBotToken !== ''
   const wantsSlack = slackBotToken !== undefined && slackBotToken !== ''
   const wantsTelegram = telegramBotToken !== undefined && telegramBotToken !== ''
@@ -125,9 +171,12 @@ export async function runInit({
     withKakaotalk,
     kakaotalkAllowAll,
   })
+  // Only write the LLM API key on the api-key path. OAuth providers persist
+  // their credentials to auth.json (via the OAuth login step above); writing
+  // an empty FIREWORKS_API_KEY/OPENAI_API_KEY would just confuse users.
   await writeSecrets(cwd, {
     model,
-    apiKey,
+    apiKey: resolvedAuth.kind === 'api-key' ? resolvedAuth.apiKey : undefined,
     discordBotToken,
     slackBotToken,
     slackAppToken,
@@ -489,7 +538,9 @@ export async function writeSecrets(
     telegramBotToken,
   }: {
     model?: KnownModelRef
-    apiKey: string
+    // Omitted on the OAuth path — credentials live in auth.json instead. The
+    // .env file still gets written for any channel adapter tokens.
+    apiKey?: string
     discordBotToken?: string
     slackBotToken?: string
     slackAppToken?: string
@@ -498,7 +549,10 @@ export async function writeSecrets(
 ): Promise<void> {
   const providerId = providerForModelRef(model)
   const apiKeyEnv = KNOWN_PROVIDERS[providerId].apiKeyEnv
-  const lines = [`${apiKeyEnv}=${apiKey}`]
+  const lines: string[] = []
+  if (apiKey !== undefined && apiKeyEnv !== null) {
+    lines.push(`${apiKeyEnv}=${apiKey}`)
+  }
   if (discordBotToken !== undefined && discordBotToken !== '') {
     lines.push(`DISCORD_BOT_TOKEN=${discordBotToken}`)
   }
@@ -511,7 +565,16 @@ export async function writeSecrets(
   if (telegramBotToken !== undefined && telegramBotToken !== '') {
     lines.push(`TELEGRAM_BOT_TOKEN=${telegramBotToken}`)
   }
-  await writeFile(join(root, SECRETS_FILE), `${lines.join('\n')}\n`)
+  // Always write .env even when empty so existing callers that read it
+  // post-init (channel `add`, runtime startup) don't ENOENT-crash.
+  const body = lines.length > 0 ? `${lines.join('\n')}\n` : ''
+  await writeFile(join(root, SECRETS_FILE), body)
+}
+
+function resolveLLMAuth(llmAuth: LLMAuth | undefined, apiKey: string | undefined): LLMAuth {
+  if (llmAuth) return llmAuth
+  if (apiKey !== undefined) return { kind: 'api-key', apiKey }
+  throw new Error('runInit requires either `llmAuth` or `apiKey`')
 }
 
 function ignoreExists(error: NodeJS.ErrnoException): void {

--- a/src/init/models-dev.test.ts
+++ b/src/init/models-dev.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test'
+
+import { curatedOptions, fetchModelOptions } from './models-dev'
+
+describe('curatedOptions', () => {
+  test('returns one entry per (provider, model) pair in KNOWN_PROVIDERS', () => {
+    const options = curatedOptions()
+
+    expect(options.length).toBeGreaterThan(0)
+    expect(options.every((o) => o.curated)).toBe(true)
+    expect(options.some((o) => o.providerId === 'openai')).toBe(true)
+    expect(options.some((o) => o.providerId === 'fireworks')).toBe(true)
+  })
+
+  test('includes the kimi-k2p6-turbo router (curated, not on models.dev)', () => {
+    const options = curatedOptions()
+
+    const kimi = options.find((o) => o.modelId === 'accounts/fireworks/routers/kimi-k2p6-turbo')
+    expect(kimi).toBeDefined()
+    expect(kimi?.providerId).toBe('fireworks')
+  })
+})
+
+describe('fetchModelOptions', () => {
+  test('falls back to curated list when fetch throws', async () => {
+    // given: a fetch that always rejects (simulates offline init).
+    const fetchImpl = (async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+
+    const result = await fetchModelOptions({ fetchImpl })
+
+    expect(result.source).toBe('curated')
+    expect(result.warning).toContain('network down')
+    expect(result.options.length).toBeGreaterThan(0)
+  })
+
+  test('falls back to curated list on non-2xx response', async () => {
+    const fetchImpl = (async () => new Response('{}', { status: 502 })) as unknown as typeof fetch
+
+    const result = await fetchModelOptions({ fetchImpl })
+
+    expect(result.source).toBe('curated')
+    expect(result.warning).toContain('502')
+  })
+
+  test('merges live data with curated allowlist when fetch succeeds', async () => {
+    // given: a stub response with a richer name for one curated model.
+    const stub = {
+      openai: {
+        id: 'openai',
+        name: 'OpenAI',
+        models: {
+          'gpt-5.4-nano': {
+            id: 'gpt-5.4-nano',
+            name: 'GPT-5.4 nano (live)',
+            reasoning: true,
+            limit: { context: 400000 },
+          },
+        },
+      },
+      'fireworks-ai': {
+        id: 'fireworks-ai',
+        name: 'Fireworks AI',
+        models: {},
+      },
+    }
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify(stub), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    const result = await fetchModelOptions({ fetchImpl })
+
+    expect(result.source).toBe('models.dev')
+    const nano = result.options.find((o) => o.ref === 'openai/gpt-5.4-nano')
+    expect(nano?.modelName).toBe('GPT-5.4 nano (live)')
+    // kimi-k2p6-turbo is curated-only; must still appear even though models.dev didn't list it.
+    expect(result.options.some((o) => o.modelId === 'accounts/fireworks/routers/kimi-k2p6-turbo')).toBe(true)
+  })
+})

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -9,6 +9,10 @@ const REQUEST_TIMEOUT_MS = 10_000
 // helper in this file works in OUR namespace.
 const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string> = {
   openai: 'openai',
+  // openai-codex models live under the `openai` namespace on models.dev too
+  // (Codex is a backend, not a separate provider in their taxonomy). Curated
+  // entries are surfaced regardless of upstream membership.
+  'openai-codex': 'openai',
   fireworks: 'fireworks-ai',
 }
 

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -1,0 +1,126 @@
+import { KNOWN_PROVIDERS, type KnownModelRef, type KnownProviderId, listKnownModelRefs } from '@/config/providers'
+
+const MODELS_DEV_URL = 'https://models.dev/api.json'
+const REQUEST_TIMEOUT_MS = 10_000
+
+// models.dev keys providers by a string id that does NOT always match our
+// KnownProviderId. Specifically, they ship Fireworks under `fireworks-ai`.
+// This map is the single place that bridges the two namespaces; every other
+// helper in this file works in OUR namespace.
+const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string> = {
+  openai: 'openai',
+  fireworks: 'fireworks-ai',
+}
+
+export type ModelOption = {
+  ref: KnownModelRef
+  providerId: KnownProviderId
+  providerName: string
+  modelId: string
+  modelName: string
+  reasoning: boolean
+  contextWindow: number | null
+  curated: boolean
+}
+
+type ModelsDevModel = {
+  id?: string
+  name?: string
+  reasoning?: boolean
+  tool_call?: boolean
+  status?: string
+  release_date?: string
+  modalities?: { input?: string[]; output?: string[] }
+  limit?: { context?: number }
+}
+
+type ModelsDevProvider = {
+  id?: string
+  name?: string
+  models?: Record<string, ModelsDevModel>
+}
+
+export type FetchModelsResult = {
+  options: ModelOption[]
+  source: 'models.dev' | 'curated'
+  warning?: string
+}
+
+// Pulls the live model catalog from models.dev, intersects it with our
+// curated KNOWN_PROVIDERS allowlist, and returns one ModelOption per
+// (provider, model) pair the user is allowed to pick at init time.
+//
+// Falls back to the curated list alone if the network is unreachable, the
+// response is malformed, or any unexpected error fires — the wizard MUST
+// stay functional offline because `typeclaw init` is the very first thing a
+// user does on a fresh machine, often before networking is sorted.
+export async function fetchModelOptions(
+  options: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<FetchModelsResult> {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const timeoutMs = options.timeoutMs ?? REQUEST_TIMEOUT_MS
+  try {
+    const res = await fetchImpl(MODELS_DEV_URL, { signal: AbortSignal.timeout(timeoutMs) })
+    if (!res.ok) {
+      return { options: curatedOptions(), source: 'curated', warning: `models.dev returned ${res.status}` }
+    }
+    const data = (await res.json()) as Record<string, ModelsDevProvider>
+    return { options: mergeWithCurated(data), source: 'models.dev' }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    return { options: curatedOptions(), source: 'curated', warning: reason }
+  }
+}
+
+// The curated-only path: every model in KNOWN_PROVIDERS, sorted with the
+// default model first so the picker can use index-0 as `initialValue`.
+export function curatedOptions(): ModelOption[] {
+  const refs = listKnownModelRefs()
+  return refs.map((ref) => buildOption(ref, { curated: true }))
+}
+
+// `data` is the parsed models.dev JSON. We walk only the providers we care
+// about (openai, fireworks-ai) and only emit options for models that are
+// also in our curated allowlist — anything outside the allowlist would fail
+// schema validation when written to typeclaw.json. Curated entries that
+// models.dev doesn't list (e.g. kimi-k2p6-turbo) are still surfaced so the
+// user can pick them.
+function mergeWithCurated(data: Record<string, ModelsDevProvider>): ModelOption[] {
+  const out: ModelOption[] = []
+  for (const providerId of Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]) {
+    const known = KNOWN_PROVIDERS[providerId]
+    const upstream = data[PROVIDER_TO_MODELS_DEV[providerId]]
+    const upstreamModels = upstream?.models ?? {}
+    for (const modelId of Object.keys(known.models)) {
+      const upstreamModel = upstreamModels[modelId]
+      const ref = `${providerId}/${modelId}` as KnownModelRef
+      out.push(buildOption(ref, { curated: true, upstream: upstreamModel }))
+    }
+  }
+  return out
+}
+
+type BuildOptionOpts = {
+  curated: boolean
+  upstream?: ModelsDevModel
+}
+
+function buildOption(ref: KnownModelRef, opts: BuildOptionOpts): ModelOption {
+  const slash = ref.indexOf('/')
+  const providerId = ref.slice(0, slash) as KnownProviderId
+  const modelId = ref.slice(slash + 1)
+  const provider = KNOWN_PROVIDERS[providerId]
+  const curatedModel = (
+    provider.models as Record<string, { name: string; contextWindow?: number; reasoning?: boolean }>
+  )[modelId]
+  return {
+    ref,
+    providerId,
+    providerName: provider.name,
+    modelId,
+    modelName: opts.upstream?.name ?? curatedModel?.name ?? modelId,
+    reasoning: opts.upstream?.reasoning ?? curatedModel?.reasoning ?? false,
+    contextWindow: opts.upstream?.limit?.context ?? curatedModel?.contextWindow ?? null,
+    curated: opts.curated,
+  }
+}

--- a/src/init/oauth-login.test.ts
+++ b/src/init/oauth-login.test.ts
@@ -24,7 +24,7 @@ describe('makeFakeOAuthLoginRunner', () => {
       },
     })
 
-    const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.3-codex' })
+    const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.5' })
 
     expect(result).toEqual({ ok: true })
     expect(calls).toEqual([{ providerId: 'openai-codex', cwd: root }])
@@ -33,7 +33,7 @@ describe('makeFakeOAuthLoginRunner', () => {
   test('passes through a configured failure result', async () => {
     const runner = makeFakeOAuthLoginRunner({ result: { ok: false, reason: 'simulated cancel' } })
 
-    const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.3-codex' })
+    const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.5' })
 
     expect(result).toEqual({ ok: false, reason: 'simulated cancel' })
   })

--- a/src/init/oauth-login.test.ts
+++ b/src/init/oauth-login.test.ts
@@ -24,7 +24,7 @@ describe('makeFakeOAuthLoginRunner', () => {
       },
     })
 
-    const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.2-codex' })
+    const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.3-codex' })
 
     expect(result).toEqual({ ok: true })
     expect(calls).toEqual([{ providerId: 'openai-codex', cwd: root }])
@@ -33,7 +33,7 @@ describe('makeFakeOAuthLoginRunner', () => {
   test('passes through a configured failure result', async () => {
     const runner = makeFakeOAuthLoginRunner({ result: { ok: false, reason: 'simulated cancel' } })
 
-    const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.2-codex' })
+    const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.3-codex' })
 
     expect(result).toEqual({ ok: false, reason: 'simulated cancel' })
   })

--- a/src/init/oauth-login.test.ts
+++ b/src/init/oauth-login.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { makeFakeOAuthLoginRunner, makeOAuthLoginRunner, type OAuthCallbacks } from './oauth-login'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-oauth-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('makeFakeOAuthLoginRunner', () => {
+  test('reports the chosen provider id back via onCalled', async () => {
+    const calls: Array<{ providerId: string; cwd: string }> = []
+    const runner = makeFakeOAuthLoginRunner({
+      onCalled: ({ providerId, cwd }) => {
+        calls.push({ providerId, cwd })
+      },
+    })
+
+    const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.2-codex' })
+
+    expect(result).toEqual({ ok: true })
+    expect(calls).toEqual([{ providerId: 'openai-codex', cwd: root }])
+  })
+
+  test('passes through a configured failure result', async () => {
+    const runner = makeFakeOAuthLoginRunner({ result: { ok: false, reason: 'simulated cancel' } })
+
+    const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.2-codex' })
+
+    expect(result).toEqual({ ok: false, reason: 'simulated cancel' })
+  })
+})
+
+describe('makeOAuthLoginRunner', () => {
+  test('rejects providers that do not support OAuth before touching the network', async () => {
+    const callbacks: OAuthCallbacks = {
+      onAuth: () => {
+        throw new Error('onAuth should not have been called')
+      },
+      onPrompt: async () => {
+        throw new Error('onPrompt should not have been called')
+      },
+    }
+    const runner = makeOAuthLoginRunner(callbacks)
+
+    const result = await runner({ cwd: root, model: 'openai/gpt-5.4-nano' })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toContain('does not support OAuth')
+    }
+  })
+})

--- a/src/init/oauth-login.ts
+++ b/src/init/oauth-login.ts
@@ -1,0 +1,75 @@
+import { join } from 'node:path'
+
+import { AuthStorage } from '@mariozechner/pi-coding-agent'
+
+import {
+  KNOWN_PROVIDERS,
+  providerForModelRef,
+  supportsOAuth,
+  type KnownModelRef,
+  type KnownProviderId,
+} from '@/config/providers'
+
+export type OAuthLoginResult = { ok: true } | { ok: false; reason: string }
+
+export type OAuthLoginRunner = (options: { cwd: string; model: KnownModelRef }) => Promise<OAuthLoginResult>
+
+// Wrap pi-ai's OAuth callbacks so the CLI doesn't have to know about the
+// upstream callback shape. The CLI only sees three lifecycle events:
+// (1) onAuth(url) — print the URL the user must visit
+// (2) onProgress(message) — show waiting/finalizing status
+// (3) onPrompt(prompt) — ask the user for a manual code if the browser flow
+//     can't reach the local callback server. Most users won't see this; it
+//     fires when they paste the post-redirect URL by hand.
+export type OAuthCallbacks = {
+  onAuth: (url: string, instructions?: string) => void
+  onProgress?: (message: string) => void
+  onPrompt: (message: string, placeholder?: string) => Promise<string | null>
+}
+
+// Default runner: real OAuth flow against pi-ai. Tests inject a stub to skip
+// network entirely. The runner's only job is to log in, write to auth.json,
+// and report ok/error — it does NOT update typeclaw.json (the model ref is
+// already chosen by the caller and written by `scaffold`).
+export function makeOAuthLoginRunner(callbacks: OAuthCallbacks): OAuthLoginRunner {
+  return async ({ cwd, model }) => {
+    const providerId = providerForModelRef(model)
+    const provider = KNOWN_PROVIDERS[providerId]
+    if (!supportsOAuth(provider) || !provider.oauthProviderId) {
+      return { ok: false, reason: `Provider ${provider.name} does not support OAuth` }
+    }
+
+    try {
+      const authStorage = AuthStorage.create(join(cwd, 'auth.json'))
+      await authStorage.login(provider.oauthProviderId, {
+        onAuth: (info) => callbacks.onAuth(info.url, info.instructions),
+        onProgress: callbacks.onProgress,
+        onPrompt: async (prompt) => {
+          const value = await callbacks.onPrompt(prompt.message, prompt.placeholder)
+          if (value === null) {
+            throw new Error('Login cancelled by user')
+          }
+          return value
+        },
+      })
+      return { ok: true }
+    } catch (error) {
+      return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+    }
+  }
+}
+
+// Test seam: lets unit tests assert "OAuth login was invoked with these
+// params" without spinning up a real authStorage / browser callback server.
+export type FakeOAuthLoginRunnerOptions = {
+  result?: OAuthLoginResult
+  onCalled?: (options: { cwd: string; model: KnownModelRef; providerId: KnownProviderId }) => void
+}
+
+export function makeFakeOAuthLoginRunner(options: FakeOAuthLoginRunnerOptions = {}): OAuthLoginRunner {
+  return async ({ cwd, model }) => {
+    const providerId = providerForModelRef(model)
+    options.onCalled?.({ cwd, model, providerId })
+    return options.result ?? { ok: true }
+  }
+}

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -195,6 +195,117 @@ describe('createServer tool event forwarding', () => {
     expect(msg.error).toBe(true)
     ws.close()
   })
+
+  test('forwards assistant message_end with stopReason=error as a TUI error event (LLM-side failures like billing/rate-limit do not throw)', async () => {
+    const session = createFakeSession()
+    const { url } = await startWithSession(session)
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    session.emit({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [],
+        api: 'openai-responses',
+        provider: 'openai',
+        model: 'gpt-5.4-nano',
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'error',
+        errorMessage: 'Your account is not active, please check your billing details on our website.',
+        timestamp: Date.now(),
+      },
+    } as unknown as SessionEvent)
+
+    const msg = await waitFor((m) => m.type === 'error')
+    if (msg.type !== 'error') throw new Error('unreachable')
+    expect(msg.message).toBe('Your account is not active, please check your billing details on our website.')
+    ws.close()
+  })
+
+  test('falls back to a generic message when stopReason=error has no errorMessage', async () => {
+    const session = createFakeSession()
+    const { url } = await startWithSession(session)
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    session.emit({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [],
+        stopReason: 'error',
+        errorMessage: undefined,
+      },
+    } as unknown as SessionEvent)
+
+    const msg = await waitFor((m) => m.type === 'error')
+    if (msg.type !== 'error') throw new Error('unreachable')
+    expect(msg.message).toBe('LLM call failed')
+    ws.close()
+  })
+
+  test('does not surface an error event for non-assistant message_end (user/toolResult)', async () => {
+    const session = createFakeSession()
+    const { url } = await startWithSession(session)
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    let errorSeen = false
+    ws.addEventListener('message', (e) => {
+      const m = JSON.parse(String(e.data)) as ServerMessage
+      if (m.type === 'error') errorSeen = true
+    })
+
+    session.emit({
+      type: 'message_end',
+      message: { role: 'user', content: 'hello', timestamp: Date.now() },
+    } as unknown as SessionEvent)
+
+    // Sentinel: emit a tool_start so we have something to await on; if an
+    // error were fired for the user message it would arrive before this.
+    session.emit({ type: 'tool_execution_start', toolCallId: 'sentinel', toolName: 'Read', args: {} })
+    await waitFor((m) => m.type === 'tool_start')
+
+    expect(errorSeen).toBe(false)
+    ws.close()
+  })
+
+  test('does not surface an error event for stopReason=aborted (TUI shows abort feedback elsewhere)', async () => {
+    const session = createFakeSession()
+    const { url } = await startWithSession(session)
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    let errorSeen = false
+    ws.addEventListener('message', (e) => {
+      const m = JSON.parse(String(e.data)) as ServerMessage
+      if (m.type === 'error') errorSeen = true
+    })
+
+    session.emit({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [],
+        stopReason: 'aborted',
+        errorMessage: 'Request was aborted',
+      },
+    } as unknown as SessionEvent)
+
+    session.emit({ type: 'tool_execution_start', toolCallId: 'sentinel-2', toolName: 'Read', args: {} })
+    await waitFor((m) => m.type === 'tool_start')
+
+    expect(errorSeen).toBe(false)
+    ws.close()
+  })
 })
 
 describe('createServer abort handling (no stream — fallback path)', () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -274,6 +274,16 @@ function forwardSessionEvents(ws: Ws, session: AgentSession): void {
           send(ws, { type: 'text_delta', delta: event.assistantMessageEvent.delta })
         }
         break
+      case 'message_end':
+        // pi-coding-agent encodes upstream LLM failures (billing, rate limit,
+        // network, malformed response, etc.) in the assistant message itself
+        // rather than throwing — `stopReason: 'error'` with a populated
+        // `errorMessage`. Without this branch the user sees an empty turn
+        // because no text deltas were ever emitted, which looks like a freeze.
+        // The server's existing try/catch around `session.prompt()` only
+        // catches throws, so it never sees these.
+        forwardAssistantError(ws, event.message)
+        break
       case 'tool_execution_start':
         toolStartedAt.set(event.toolCallId, Date.now())
         send(ws, {
@@ -299,6 +309,18 @@ function forwardSessionEvents(ws: Ws, session: AgentSession): void {
       }
     }
   })
+}
+
+function forwardAssistantError(ws: Ws, message: unknown): void {
+  if (typeof message !== 'object' || message === null) return
+  const m = message as { role?: string; stopReason?: string; errorMessage?: string }
+  if (m.role !== 'assistant') return
+  if (m.stopReason !== 'error' && m.stopReason !== 'aborted') return
+  // 'aborted' is fired when the user hits Escape — don't surface it as an
+  // error message because the TUI already shows abort feedback elsewhere.
+  if (m.stopReason === 'aborted') return
+  const text = typeof m.errorMessage === 'string' && m.errorMessage.length > 0 ? m.errorMessage : 'LLM call failed'
+  send(ws, { type: 'error', message: text })
 }
 
 function enqueuePrompt(ws: Ws, state: SessionState, msg: StreamMessage): void {

--- a/src/skills/typeclaw-config/SKILL.md
+++ b/src/skills/typeclaw-config/SKILL.md
@@ -518,25 +518,33 @@ Do **not** invent plugin blocks; their existence is determined by the plugins li
 
 The model registry currently has these entries:
 
-| `model` value                                          | Display name    | Provider  | Notes                                                                        |
-| ------------------------------------------------------ | --------------- | --------- | ---------------------------------------------------------------------------- |
-| `openai/gpt-5.4-nano`                                  | GPT-5.4 nano    | OpenAI    | Default. Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context. |
-| `openai/gpt-5.4-mini`                                  | GPT-5.4 mini    | OpenAI    | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.          |
-| `openai/gpt-5.4`                                       | GPT-5.4         | OpenAI    | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 1.05M context.         |
-| `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` | Kimi K2.6 Turbo | Fireworks | Requires `FIREWORKS_API_KEY` in `.env`. Reasoning model, 256K context.       |
+| `model` value                                          | Display name       | Provider     | Auth                | Notes                                                                            |
+| ------------------------------------------------------ | ------------------ | ------------ | ------------------- | -------------------------------------------------------------------------------- |
+| `openai/gpt-5.4-nano`                                  | GPT-5.4 nano       | OpenAI       | API key             | Default. Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.     |
+| `openai/gpt-5.4-mini`                                  | GPT-5.4 mini       | OpenAI       | API key             | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.              |
+| `openai/gpt-5.4`                                       | GPT-5.4            | OpenAI       | API key             | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 1.05M context.             |
+| `openai-codex/gpt-5.2-codex`                           | GPT-5.2 Codex      | OpenAI Codex | OAuth (ChatGPT P/P) | Requires OAuth login at init. Persisted to `auth.json`. Reasoning, 272K context. |
+| `openai-codex/gpt-5.1-codex-max`                       | GPT-5.1 Codex Max  | OpenAI Codex | OAuth (ChatGPT P/P) | Requires OAuth login at init. Persisted to `auth.json`. Reasoning, 272K context. |
+| `openai-codex/gpt-5.1-codex-mini`                      | GPT-5.1 Codex Mini | OpenAI Codex | OAuth (ChatGPT P/P) | Requires OAuth login at init. Persisted to `auth.json`. Reasoning, 272K context. |
+| `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` | Kimi K2.6 Turbo    | Fireworks    | API key             | Requires `FIREWORKS_API_KEY` in `.env`. Reasoning model, 256K context.           |
 
 **Do not write any other value into `model`.** The schema enum will reject the file at load, and the runtime will refuse to boot the agent process. If the user names a model that isn't in this table — "use Claude", "switch to o3" — be honest:
 
-> "My registry has OpenAI's GPT-5.4 family and Fireworks' Kimi K2.6 Turbo. Other providers (Anthropic, etc.) aren't wired up yet — that needs a typeclaw release, not a config edit."
+> "My registry has OpenAI's GPT-5.4 family (API key), the Codex family via ChatGPT subscription (OAuth), and Fireworks' Kimi K2.6 Turbo. Other providers (Anthropic, etc.) aren't wired up yet — that needs a typeclaw release, not a config edit."
 
 Do **not** edit `typeclaw.json` to a model the registry doesn't know, even if the user insists. That bricks the agent on next restart.
 
 ## Provider credentials
 
-`typeclaw.json` does **not** hold API keys. Credentials live in `./.env` (gitignored). The required env var depends on which provider's model you've selected:
+`typeclaw.json` does **not** hold API keys or OAuth tokens. Credentials live in two gitignored files:
 
-- `OPENAI_API_KEY` — required for any `openai/...` model.
-- `FIREWORKS_API_KEY` — required for any `fireworks/...` model.
+- **`./.env`** (API key providers): the env var depends on which provider's model you've selected.
+  - `OPENAI_API_KEY` — required for any `openai/...` model.
+  - `FIREWORKS_API_KEY` — required for any `fireworks/...` model.
+- **`./auth.json`** (OAuth providers): structured JSON file managed by `pi-coding-agent`'s `AuthStorage`. Contains refresh + access tokens. The container refreshes tokens on its own with file locking; the host writes once at `typeclaw init` time when the user picks "OAuth (browser login)".
+  - `openai-codex/...` models — credentials persisted as `{ "openai-codex": { "type": "oauth", ... } }`.
+
+If a user wants to switch from API key to OAuth (or vice versa) for a provider that supports both, the easiest path is to delete the relevant entry from `.env` / `auth.json` and re-run `typeclaw init` from inside the agent folder — it'll prompt for the auth method again.
 
 If the user wants to rotate or change the key, edit `.env`, not `typeclaw.json`. After editing `.env`, the same restart rule applies: `typeclaw restart` on the host stage.
 

--- a/src/skills/typeclaw-config/SKILL.md
+++ b/src/skills/typeclaw-config/SKILL.md
@@ -518,19 +518,21 @@ Do **not** invent plugin blocks; their existence is determined by the plugins li
 
 The model registry currently has these entries:
 
-| `model` value                                          | Display name       | Provider     | Auth                | Notes                                                                            |
-| ------------------------------------------------------ | ------------------ | ------------ | ------------------- | -------------------------------------------------------------------------------- |
-| `openai/gpt-5.4-nano`                                  | GPT-5.4 nano       | OpenAI       | API key             | Default. Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.     |
-| `openai/gpt-5.4-mini`                                  | GPT-5.4 mini       | OpenAI       | API key             | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.              |
-| `openai/gpt-5.4`                                       | GPT-5.4            | OpenAI       | API key             | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 1.05M context.             |
-| `openai-codex/gpt-5.2-codex`                           | GPT-5.2 Codex      | OpenAI Codex | OAuth (ChatGPT P/P) | Requires OAuth login at init. Persisted to `auth.json`. Reasoning, 272K context. |
-| `openai-codex/gpt-5.1-codex-max`                       | GPT-5.1 Codex Max  | OpenAI Codex | OAuth (ChatGPT P/P) | Requires OAuth login at init. Persisted to `auth.json`. Reasoning, 272K context. |
-| `openai-codex/gpt-5.1-codex-mini`                      | GPT-5.1 Codex Mini | OpenAI Codex | OAuth (ChatGPT P/P) | Requires OAuth login at init. Persisted to `auth.json`. Reasoning, 272K context. |
-| `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` | Kimi K2.6 Turbo    | Fireworks    | API key             | Requires `FIREWORKS_API_KEY` in `.env`. Reasoning model, 256K context.           |
+| `model` value                                          | Display name        | Provider     | Auth                | Notes                                                                                 |
+| ------------------------------------------------------ | ------------------- | ------------ | ------------------- | ------------------------------------------------------------------------------------- |
+| `openai/gpt-5.4-nano`                                  | GPT-5.4 nano        | OpenAI       | API key             | Default. Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.          |
+| `openai/gpt-5.4-mini`                                  | GPT-5.4 mini        | OpenAI       | API key             | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.                   |
+| `openai/gpt-5.4`                                       | GPT-5.4             | OpenAI       | API key             | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 1.05M context.                  |
+| `openai/gpt-5.5`                                       | GPT-5.5             | OpenAI       | API key             | Flagship. Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 1.05M context.        |
+| `openai-codex/gpt-5.4`                                 | GPT-5.4             | OpenAI Codex | OAuth (ChatGPT P/P) | Codex flagship. Requires OAuth login at init. Persisted to `auth.json`. 272K context. |
+| `openai-codex/gpt-5.4-mini`                            | GPT-5.4 mini        | OpenAI Codex | OAuth (ChatGPT P/P) | Cheaper Codex tier. Requires OAuth login at init. Persisted to `auth.json`. 272K ctx. |
+| `openai-codex/gpt-5.3-codex`                           | GPT-5.3 Codex       | OpenAI Codex | OAuth (ChatGPT P/P) | Code-tuned. Requires OAuth login at init. Persisted to `auth.json`. 272K context.     |
+| `openai-codex/gpt-5.3-codex-spark`                     | GPT-5.3 Codex Spark | OpenAI Codex | OAuth (ChatGPT P/P) | Lightweight Codex variant. Requires OAuth login at init. 128K context, free tier.     |
+| `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` | Kimi K2.6 Turbo     | Fireworks    | API key             | Requires `FIREWORKS_API_KEY` in `.env`. Reasoning model, 256K context.                |
 
 **Do not write any other value into `model`.** The schema enum will reject the file at load, and the runtime will refuse to boot the agent process. If the user names a model that isn't in this table — "use Claude", "switch to o3" — be honest:
 
-> "My registry has OpenAI's GPT-5.4 family (API key), the Codex family via ChatGPT subscription (OAuth), and Fireworks' Kimi K2.6 Turbo. Other providers (Anthropic, etc.) aren't wired up yet — that needs a typeclaw release, not a config edit."
+> "My registry has OpenAI's GPT-5.4 / 5.5 family (API key), the GPT-5.4 / 5.3 Codex family via ChatGPT subscription (OAuth), and Fireworks' Kimi K2.6 Turbo. Other providers (Anthropic, etc.) aren't wired up yet — that needs a typeclaw release, not a config edit."
 
 Do **not** edit `typeclaw.json` to a model the registry doesn't know, even if the user insists. That bricks the agent on next restart.
 

--- a/src/skills/typeclaw-config/SKILL.md
+++ b/src/skills/typeclaw-config/SKILL.md
@@ -43,7 +43,7 @@ You yourself cannot run `typeclaw restart` — that is a host-stage command and 
 | ------------- | -------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `$schema`     | no       | string           | Path to `typeclaw.schema.json` for editor autocompletion. Scaffolded as `./node_modules/typeclaw/typeclaw.schema.json`. Leave it alone unless the user moves it.                                                                                                                                                                                                                                                                   |
 | `port`        | no       | integer          | 1–65535. Defaults to `8973` (T9 spelling of "TYPE"). Change only if the default collides with something on the user's host. **Restart-required.**                                                                                                                                                                                                                                                                                  |
-| `model`       | no       | string           | Must be one of the values listed in the **Allowed models** section below. Defaults to `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo`. **Live-reloadable.**                                                                                                                                                                                                                                                                 |
+| `model`       | no       | string           | Must be one of the values listed in the **Allowed models** section below. Defaults to `openai/gpt-5.4-nano`. **Live-reloadable.**                                                                                                                                                                                                                                                                                                  |
 | `mounts`      | no       | array of objects | Host directories bind-mounted into your container. Defaults to `[]` (no host paths exposed). Omitted from scaffolded `typeclaw.json` — add it only when the user wants host paths exposed. See **Mounts** section below. **Restart-required.**                                                                                                                                                                                     |
 | `plugins`     | no       | array of strings | Plugin package names loaded at server boot. Defaults to `[]`. **Restart-required.** Plugin-owned config blocks live alongside as additional top-level keys; see **Plugin config blocks**.                                                                                                                                                                                                                                          |
 | `alias`       | no       | array of strings | Additional names the agent answers to in channel engagement, on top of the implicit `basename(agentDir)`. Each entry is a non-empty trimmed string matched case-insensitively as a substring of the inbound text. Defaults to `[]`. Hatching populates this with the agent's chosen name. See **Alias** section below. **Live-reloadable.**                                                                                        |
@@ -61,7 +61,7 @@ A scaffolded `typeclaw.json` looks like:
 ```json
 {
   "$schema": "./node_modules/typeclaw/typeclaw.schema.json",
-  "model": "fireworks/accounts/fireworks/routers/kimi-k2p6-turbo"
+  "model": "openai/gpt-5.4-nano"
 }
 ```
 
@@ -93,7 +93,7 @@ Example with mounts:
 ```json
 {
   "$schema": "./node_modules/typeclaw/typeclaw.schema.json",
-  "model": "fireworks/accounts/fireworks/routers/kimi-k2p6-turbo",
+  "model": "openai/gpt-5.4-nano",
   "mounts": [
     { "name": "typeclaw", "path": "~/workspace/typeclaw", "description": "the typeclaw source repo" },
     { "name": "notes", "path": "~/notes", "readOnly": true, "description": "personal notes (read-only)" }
@@ -306,7 +306,7 @@ Default (no `portForward` field at all): forward every LISTEN.
 ```json
 {
   "$schema": "./node_modules/typeclaw/typeclaw.schema.json",
-  "model": "fireworks/accounts/fireworks/routers/kimi-k2p6-turbo"
+  "model": "openai/gpt-5.4-nano"
 }
 ```
 
@@ -516,22 +516,26 @@ Do **not** invent plugin blocks; their existence is determined by the plugins li
 
 ## Allowed models
 
-Today, the model registry contains exactly **one** entry:
+The model registry currently has these entries:
 
-| `model` value                                          | Display name    | Provider  | Notes                                                                  |
-| ------------------------------------------------------ | --------------- | --------- | ---------------------------------------------------------------------- |
-| `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` | Kimi K2.5 Turbo | Fireworks | Requires `FIREWORKS_API_KEY` in `.env`. Reasoning model, 256K context. |
+| `model` value                                          | Display name    | Provider  | Notes                                                                        |
+| ------------------------------------------------------ | --------------- | --------- | ---------------------------------------------------------------------------- |
+| `openai/gpt-5.4-nano`                                  | GPT-5.4 nano    | OpenAI    | Default. Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context. |
+| `openai/gpt-5.4-mini`                                  | GPT-5.4 mini    | OpenAI    | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.          |
+| `openai/gpt-5.4`                                       | GPT-5.4         | OpenAI    | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 1.05M context.         |
+| `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` | Kimi K2.6 Turbo | Fireworks | Requires `FIREWORKS_API_KEY` in `.env`. Reasoning model, 256K context.       |
 
-**Do not write any other value into `model`.** The schema enum will reject the file at load, and the runtime will refuse to boot the agent process. If the user names a model that isn't in this table — "switch me to GPT-5", "use Claude" — be honest:
+**Do not write any other value into `model`.** The schema enum will reject the file at load, and the runtime will refuse to boot the agent process. If the user names a model that isn't in this table — "use Claude", "switch to o3" — be honest:
 
-> "Right now my registry only has Kimi K2.5 Turbo on Fireworks. More providers are planned but not wired up yet. If you want a different model, that needs a typeclaw release, not a config edit."
+> "My registry has OpenAI's GPT-5.4 family and Fireworks' Kimi K2.6 Turbo. Other providers (Anthropic, etc.) aren't wired up yet — that needs a typeclaw release, not a config edit."
 
 Do **not** edit `typeclaw.json` to a model the registry doesn't know, even if the user insists. That bricks the agent on next restart.
 
 ## Provider credentials
 
-`typeclaw.json` does **not** hold API keys. Credentials live in `./.env` (gitignored). For the only currently-supported model:
+`typeclaw.json` does **not** hold API keys. Credentials live in `./.env` (gitignored). The required env var depends on which provider's model you've selected:
 
+- `OPENAI_API_KEY` — required for any `openai/...` model.
 - `FIREWORKS_API_KEY` — required for any `fireworks/...` model.
 
 If the user wants to rotate or change the key, edit `.env`, not `typeclaw.json`. After editing `.env`, the same restart rule applies: `typeclaw restart` on the host stage.
@@ -604,7 +608,7 @@ Never echo, log, or commit values from `.env`. `.env` is gitignored by default �
 
 1. **Read `typeclaw.json`.** Don't guess from prior conversation — the user may have changed it since you last looked.
 2. Report the `model` field verbatim, plus the human-readable name from the **Allowed models** table.
-3. If `model` is missing from the file, say so and report the default (`fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` → Kimi K2.5 Turbo).
+3. If `model` is missing from the file, say so and report the default (`openai/gpt-5.4-nano` → GPT-5.4 nano).
 
 ## When the user says "switch to <model>"
 

--- a/src/skills/typeclaw-config/SKILL.md
+++ b/src/skills/typeclaw-config/SKILL.md
@@ -518,21 +518,20 @@ Do **not** invent plugin blocks; their existence is determined by the plugins li
 
 The model registry currently has these entries:
 
-| `model` value                                          | Display name        | Provider     | Auth                | Notes                                                                                 |
-| ------------------------------------------------------ | ------------------- | ------------ | ------------------- | ------------------------------------------------------------------------------------- |
-| `openai/gpt-5.4-nano`                                  | GPT-5.4 nano        | OpenAI       | API key             | Default. Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.          |
-| `openai/gpt-5.4-mini`                                  | GPT-5.4 mini        | OpenAI       | API key             | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.                   |
-| `openai/gpt-5.4`                                       | GPT-5.4             | OpenAI       | API key             | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 1.05M context.                  |
-| `openai/gpt-5.5`                                       | GPT-5.5             | OpenAI       | API key             | Flagship. Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 1.05M context.        |
-| `openai-codex/gpt-5.4`                                 | GPT-5.4             | OpenAI Codex | OAuth (ChatGPT P/P) | Codex flagship. Requires OAuth login at init. Persisted to `auth.json`. 272K context. |
-| `openai-codex/gpt-5.4-mini`                            | GPT-5.4 mini        | OpenAI Codex | OAuth (ChatGPT P/P) | Cheaper Codex tier. Requires OAuth login at init. Persisted to `auth.json`. 272K ctx. |
-| `openai-codex/gpt-5.3-codex`                           | GPT-5.3 Codex       | OpenAI Codex | OAuth (ChatGPT P/P) | Code-tuned. Requires OAuth login at init. Persisted to `auth.json`. 272K context.     |
-| `openai-codex/gpt-5.3-codex-spark`                     | GPT-5.3 Codex Spark | OpenAI Codex | OAuth (ChatGPT P/P) | Lightweight Codex variant. Requires OAuth login at init. 128K context, free tier.     |
-| `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` | Kimi K2.6 Turbo     | Fireworks    | API key             | Requires `FIREWORKS_API_KEY` in `.env`. Reasoning model, 256K context.                |
+| `model` value                                          | Display name    | Provider     | Auth                | Notes                                                                                 |
+| ------------------------------------------------------ | --------------- | ------------ | ------------------- | ------------------------------------------------------------------------------------- |
+| `openai/gpt-5.4-nano`                                  | GPT-5.4 nano    | OpenAI       | API key             | Default. Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.          |
+| `openai/gpt-5.4-mini`                                  | GPT-5.4 mini    | OpenAI       | API key             | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 400K context.                   |
+| `openai/gpt-5.4`                                       | GPT-5.4         | OpenAI       | API key             | Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 1.05M context.                  |
+| `openai/gpt-5.5`                                       | GPT-5.5         | OpenAI       | API key             | Flagship. Requires `OPENAI_API_KEY` in `.env`. Reasoning model, 1.05M context.        |
+| `openai-codex/gpt-5.4-mini`                            | GPT-5.4 mini    | OpenAI Codex | OAuth (ChatGPT P/P) | Cheaper Codex tier. Requires OAuth login at init. Persisted to `auth.json`. 272K ctx. |
+| `openai-codex/gpt-5.4`                                 | GPT-5.4         | OpenAI Codex | OAuth (ChatGPT P/P) | Codex mid-tier. Requires OAuth login at init. Persisted to `auth.json`. 272K context. |
+| `openai-codex/gpt-5.5`                                 | GPT-5.5         | OpenAI Codex | OAuth (ChatGPT P/P) | Flagship Codex. Requires OAuth login at init. Persisted to `auth.json`. 272K context. |
+| `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` | Kimi K2.6 Turbo | Fireworks    | API key             | Requires `FIREWORKS_API_KEY` in `.env`. Reasoning model, 256K context.                |
 
 **Do not write any other value into `model`.** The schema enum will reject the file at load, and the runtime will refuse to boot the agent process. If the user names a model that isn't in this table — "use Claude", "switch to o3" — be honest:
 
-> "My registry has OpenAI's GPT-5.4 / 5.5 family (API key), the GPT-5.4 / 5.3 Codex family via ChatGPT subscription (OAuth), and Fireworks' Kimi K2.6 Turbo. Other providers (Anthropic, etc.) aren't wired up yet — that needs a typeclaw release, not a config edit."
+> "My registry has OpenAI's GPT-5.4 / 5.5 family (API key), the same family via ChatGPT subscription (OAuth Codex), and Fireworks' Kimi K2.6 Turbo. Other providers (Anthropic, etc.) aren't wired up yet — that needs a typeclaw release, not a config edit."
 
 Do **not** edit `typeclaw.json` to a model the registry doesn't know, even if the user insists. That bricks the agent on next restart.
 


### PR DESCRIPTION
## What

\`typeclaw init\` now asks two things before requesting credentials:

1. **Which LLM provider?** OpenAI (API key), OpenAI Codex (OAuth via ChatGPT Plus/Pro), or Fireworks (API key). More to come.
2. **Which model?** Live-fetched from [models.dev](https://models.dev/api.json), filtered to the provider's curated allowlist.

For providers that support both API key and OAuth, the wizard then asks \"API key or OAuth?\" before collecting credentials. OAuth-only providers (Codex) skip the API-key prompt entirely; API-key-only providers (OpenAI direct, Fireworks) keep the existing flow.

The Fireworks/Kimi default was always a dev-phase preset. Default is now \`openai/gpt-5.4-nano\`.

## Why

- Users coming to TypeClaw fresh almost always have an OpenAI key, not a Fireworks one. Forcing the Fireworks/Kimi default through \`init\` was friction with no upside.
- ChatGPT Plus/Pro subscribers can now use Codex models (\`gpt-5.2-codex\`, \`gpt-5.1-codex-max\`, \`gpt-5.1-codex-mini\`) without signing up for OpenAI's pay-per-token API.
- The provider abstraction now supports declaring \`auth: ['api-key']\`, \`auth: ['oauth']\`, or both per provider, so adding Anthropic / GitHub Copilot / Gemini-CLI in a follow-up PR is a single entry in \`providers.ts\` plus a new model block.

## How

### Provider registry (\`src/config/providers.ts\`)

Added an explicit \`auth: ReadonlyArray<AuthMethod>\` field per provider, plus \`apiKeyEnv\` (for the api-key path) and \`oauthProviderId\` (for the OAuth path, must match a pi-ai upstream id verbatim). Both fields are always present on the literal (with \`null\` when not applicable) so \`as const satisfies\` narrowing stays predictable; consumers branch on \`supportsApiKey()\` / \`supportsOAuth()\` helpers that widen the membership check back to \`AuthMethod\`.

New providers/models in this PR:
- \`openai\` (api-key): \`gpt-5.4-nano\` (default), \`gpt-5.4-mini\`, \`gpt-5.4\`
- \`openai-codex\` (oauth): \`gpt-5.2-codex\`, \`gpt-5.1-codex-max\`, \`gpt-5.1-codex-mini\` — all via the \`openai-codex-responses\` API
- \`fireworks\` (api-key): \`kimi-k2p6-turbo\` (kept; not on models.dev yet)

### Auth dispatch (\`src/agent/auth.ts\`)

A single \`getAuth()\` function handles both modes:
- For api-key providers, it reads \`process.env[provider.apiKeyEnv]\` and calls \`authStorage.setRuntimeApiKey()\`.
- For OAuth providers, it relies on \`AuthStorage.create(authJsonPath())\` loading credentials from \`auth.json\`. pi-coding-agent's storage layer handles refresh + file locking automatically — the container can refresh tokens that the host wrote at init, and concurrent processes (e.g. self-restart) won't race.

### Init pipeline (\`src/init/index.ts\`)

\`runInit\` now takes a discriminated \`llmAuth: { kind: 'api-key', apiKey } | { kind: 'oauth', runLogin }\`. The new \`oauth-login\` step runs **before** scaffold (same rationale as the docker-preflight and kakaotalk-auth ordering): a failed browser flow leaves the user's directory untouched. The legacy \`apiKey\` field is still accepted for back-compat with existing test fixtures.

### CLI (\`src/cli/init.ts\`)

\`collectLLMAuth(provider)\` decides between three branches based on the provider's declared \`auth\` array:
1. **api-key only** → \`password\` prompt, write to \`.env\`.
2. **oauth only** → run the browser flow inline, write to \`auth.json\`.
3. **both** (no provider ships this today; placeholder for Anthropic) → ask \"API key or OAuth?\" first.

The OAuth flow surfaces three clack callbacks: \`note(url)\` for the browser link, \`log.info(message)\` for progress, and a \`text()\` fallback for manual code paste. The clack \`spinner\` already covers the \"waiting for login\" period because the new \`oauth-login\` step plugs into the existing \`reportProgress\` machinery.

### Where credentials live

- **\`.env\`** (gitignored, truly-ignored): \`OPENAI_API_KEY\`, \`FIREWORKS_API_KEY\`, channel adapter tokens.
- **\`auth.json\`** (newly added to \`.gitignore\`'s truly-ignored category): structured JSON managed by \`pi-coding-agent\`'s \`AuthStorage\`. Holds OAuth refresh + access tokens with \`0600\` perms and atomic write-with-locking. Both host and container read/write the same file via the standard agent-folder mount.

## Notes for reviewers

- I left \`kimi-k2p6-turbo\` in the curated allowlist even though models.dev currently lists \`kimi-k2p5-turbo\` as the latest router — k2p6 is real, just not yet indexed upstream. The merge logic in \`models-dev.ts\` always surfaces curated entries.
- \`typeclaw.schema.json\` is gitignored at the repo root; it's regenerated by \`scripts/generate-schema.ts\` on demand and verified by the schema-drift test in CI.
- Container-side OAuth token refresh works out of the box with the existing agent-folder mount — no Dockerfile changes needed.
- No migration is needed for existing agent folders: the schema accepts both old and new model values, and \`agent/auth.ts\` resolves the right credential source dynamically.
- Followups: Anthropic Claude Pro/Max OAuth, GitHub Copilot OAuth, Gemini CLI OAuth, Antigravity OAuth — pi-ai supports all four already, each is a 1-2 line addition to \`KNOWN_PROVIDERS\` once we curate which models to expose.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean
- [x] \`bun run format\` — clean
- [x] \`bun test\` — 2334 pass, 0 fail (added 12 new tests covering OAuth login dispatch, the \`oauth-login\` pipeline step, .env emission on OAuth path, the both-paths providers branch, and the dummy-key test fallback)