### PR TITLE
Widen silent-turn detection to accept (NO_REPLY) and thinking-only turns

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -335,6 +335,21 @@ describe('createChannelReplyTool', () => {
       expect(calls).toHaveLength(1)
       expect(result.details).toEqual({ ok: true })
     })
+
+    test('blocks the parenthesized "(NO_REPLY)" form (mirrors router lenience)', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, { text: '(NO_REPLY)' })
+      expect(calls).toHaveLength(0)
+      expect(result.details).toMatchObject({ ok: false })
+      expect((result.details as { error: string }).error).toContain('silent-turn signal')
+    })
   })
 })
 

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -1,7 +1,7 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
-import type { ChannelRouter } from '@/channels/router'
+import { isNoReplySignal, type ChannelRouter } from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
 
 export type ChannelReplyOrigin = {
@@ -155,13 +155,15 @@ export function renderOutboundEcho(
   return '(empty)'
 }
 
-// Mirror of the same guard used by channel_send. Blocks the literal
-// `NO_REPLY` from being sent as a message body — same misuse, same denial,
-// regardless of which sending tool the model picked. Returns '' when text
-// is undefined (attachments-only reply, can't be misusing the signal).
+// Mirror of the same guard used by channel_send. Blocks any silent-turn
+// signal (per `isNoReplySignal`) from being sent as a message body — same
+// misuse, same denial, regardless of which sending tool the model picked.
+// Returns '' when text is undefined (attachments-only reply, can't be
+// misusing the signal) or when text is non-empty and not a signal.
 function noReplyMisuseError(text: string | undefined): string {
   if (text === undefined) return ''
-  if (text.trim() !== 'NO_REPLY') return ''
+  if (text.trim() === '') return ''
+  if (!isNoReplySignal(text)) return ''
   return (
     '`NO_REPLY` is the silent-turn signal, not a message body. ' +
     'To stay silent, end your turn with `NO_REPLY` as your entire visible response and NO channel tool call. ' +

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -409,5 +409,24 @@ describe('createChannelSendTool', () => {
       expect(calls).toHaveLength(1)
       expect(result.details).toEqual({ ok: true })
     })
+
+    test('blocks the parenthesized "(NO_REPLY)" form (mirrors router lenience)', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+      const result = await runTool(tool, {
+        adapter: 'slack-bot',
+        workspace: 'T0',
+        chat: 'C0',
+        text: '(NO_REPLY)',
+      })
+      expect(calls).toHaveLength(0)
+      expect(result.details).toMatchObject({ ok: false })
+      expect((result.details as { error: string }).error).toContain('silent-turn signal')
+    })
   })
 })

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -1,7 +1,7 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
-import type { ChannelRouter } from '@/channels/router'
+import { isNoReplySignal, type ChannelRouter } from '@/channels/router'
 import { ADAPTER_IDS, type AdapterId } from '@/channels/schema'
 
 import { renderOutboundEcho } from './channel-reply'
@@ -178,18 +178,18 @@ function threadMismatchHint(
   )
 }
 
-// Blocks a specific misuse: the model tried to send the literal string
-// `NO_REPLY` as a channel message. `NO_REPLY` is the silent-turn signal —
-// it belongs in the model's *visible response* when no channel tool is
-// called (see session-origin.ts and router.ts validateChannelTurn), NOT
-// in the body of a sent message. We short-circuit BEFORE router.send so
-// the literal "NO_REPLY" never reaches the chat. Detection mirrors the
-// router's exact-after-trim semantics. Returns the error message to use
-// in the denial, or '' if the text is fine (including when text is
-// undefined — an attachments-only send can't be misusing the signal).
+// Blocks a specific misuse: the model tried to send a silent-turn signal
+// (e.g. `NO_REPLY`, `(NO_REPLY)`) as a channel message. Those forms belong
+// in the model's *visible response* when no channel tool is called (see
+// session-origin.ts and router.ts validateChannelTurn), NOT in the body of
+// a sent message. We short-circuit BEFORE router.send so the signal never
+// reaches the chat. Detection delegates to `isNoReplySignal` so the router
+// and both tools stay in lockstep. Empty/undefined text is fine — that
+// means "attachments-only send", not a signal.
 function noReplyMisuseError(text: string | undefined): string {
   if (text === undefined) return ''
-  if (text.trim() !== 'NO_REPLY') return ''
+  if (text.trim() === '') return ''
+  if (!isNoReplySignal(text)) return ''
   return (
     '`NO_REPLY` is the silent-turn signal, not a message body. ' +
     'To stay silent, end your turn with `NO_REPLY` as your entire visible response and NO channel tool call. ' +

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -47,6 +47,10 @@ class FakeSession {
   setAssistantText(text: string): void {
     this.leafEntry = messageEntry(assistantMessage(text))
   }
+
+  setAssistantMessage(message: AssistantMessage): void {
+    this.leafEntry = messageEntry(message)
+  }
 }
 
 async function tempDir(): Promise<string> {
@@ -916,6 +920,66 @@ describe('ChannelRouter channel-turn protocol', () => {
 
     expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
     expect(logs.some((m) => m.includes('blocked assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('allows (NO_REPLY) with parens as a silent-turn signal', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'just FYI' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('(NO_REPLY)')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+    expect(sent).toHaveLength(0)
+  })
+
+  test('allows empty visible text (thinking-only response) as a silent-turn signal', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'just FYI' }))
+    sessions[0]!.onPrompt = () => {
+      // given: assistant message with only a thinking block, no visible text
+      // (e.g. Kimi-distilled models that end the turn after thinking)
+      sessions[0]!.setAssistantMessage({
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: 'no need to respond' }],
+        api: 'openai-completions',
+        provider: 'openai',
+        model: 'test-model',
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'stop',
+        timestamp: 1000,
+      })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+    expect(sent).toHaveLength(0)
   })
 
   test('recovers visible assistant text when no channel tool sent a message', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1224,7 +1224,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const assistantText = latestAssistantText(live.session)
     if (assistantText === null) return
 
-    if (assistantText.trim() === 'NO_REPLY') {
+    if (isNoReplySignal(assistantText)) {
       logger.info(`[channels] ${live.keyId} no_reply`)
       return
     }
@@ -1544,6 +1544,21 @@ function visibleAssistantText(message: AssistantMessage): string {
     .filter((block) => block.type === 'text')
     .map((block) => block.text)
     .join('')
+}
+
+// Lenient on purpose: distilled / smaller models routinely drift off the
+// documented `NO_REPLY` form. We additionally accept `(NO_REPLY)` (Claude-style
+// hedging) and empty visible text (e.g. Kimi-distilled models that emit only a
+// thinking block and end the turn) — without the empty case we'd recover an
+// empty string into the chat. The prompt contract still teaches the strict
+// literal; this just widens what we accept. Shared with channel_send /
+// channel_reply so all three call sites stay in lockstep.
+export function isNoReplySignal(text: string): boolean {
+  const trimmed = text.trim()
+  if (trimmed === '') return true
+  if (trimmed === 'NO_REPLY') return true
+  if (trimmed === '(NO_REPLY)') return true
+  return false
 }
 
 function describe(err: unknown): string {


### PR DESCRIPTION
## Summary

Two model output patterns that should be treated as silent turns were falling through the NO_REPLY guard in `validateChannelTurn` and hitting the recovery path: Claude-style `(NO_REPLY)` (the parenthesized form) and thinking-only responses where the model emits no visible text at all. Both patterns were observed in production and caused either a literal `(NO_REPLY)` string to be posted to chat, or an empty body sent to the channel adapter — silently failing without any error.

This PR centralizes the detection logic into an exported `isNoReplySignal(text)` predicate and routes all three call sites (`validateChannelTurn`, `noReplyMisuseError` in `channel-reply.ts`, `noReplyMisuseError` in `channel-send.ts`) through it so they stay in lockstep.

## The two failure modes

### 1. `(NO_REPLY)` with parentheses — Claude-style hedging

Distilled models trained on Claude conversations sometimes emit `(NO_REPLY)` rather than the bare `NO_REPLY` literal. The existing guard was:

```ts
if (assistantText.trim() === 'NO_REPLY') { … }
```

The parenthesized form does not match, so the turn falls through to the recovery path and calls `router.send` with the literal string `(NO_REPLY)` — which surfaces as a message in the chat.

### 2. Empty visible text — thinking-only response

A Kimi-distilled model was observed emitting `stop_reason: 'end_turn'` with only a `thinking` content block and no `text` block at all. After pi-ai normalization this becomes `stopReason: 'stop'` with zero text blocks. `visibleAssistantText()` filters for `type === 'text'` and returns `''`. With the old guard, an empty string is neither `'NO_REPLY'` nor `'(NO_REPLY)'`, so it falls through to `router.send('')` — an empty body delivered silently to the channel adapter.

## Implementation

### `src/channels/router.ts`

Added an exported predicate:

```ts
export function isNoReplySignal(text: string): boolean {
  const trimmed = text.trim()
  if (trimmed === '') return true
  if (trimmed === 'NO_REPLY') return true
  if (trimmed === '(NO_REPLY)') return true
  return false
}
```

`validateChannelTurn` in the same file now calls `isNoReplySignal(assistantText)` instead of the inline equality check.

### `src/agent/tools/channel-reply.ts` and `src/agent/tools/channel-send.ts`

Both tools have a `noReplyMisuseError` guard that fires before `router.send` to prevent models from sending the signal as a message body. Both were doing:

```ts
if (text.trim() !== 'NO_REPLY') return ''
```

Both now delegate to `isNoReplySignal`. Empty string and `undefined` text are explicitly excluded first — those represent attachments-only sends, which are not misuse. Non-signal non-empty text passes through normally. Only actual signal strings are blocked and return the misuse-denial message.

### Contract: system prompt intentionally unchanged

The system prompt in `src/agent/session-origin.ts` and the loop-guard prompt in `src/channels/router.ts` continue to teach the strict `NO_REPLY` literal. This PR only widens what is accepted on the receiving side. Advertising the lenient forms in the prompt would invite models to emit them deliberately and pollute transcripts.

## Tests

Tests are paired with the implementation files per AGENTS.md.

**`src/channels/router.test.ts`** — two new cases in `describe('ChannelRouter channel-turn protocol')`:

- `allows (NO_REPLY) with parens as a silent-turn signal` — sets the assistant text to `'(NO_REPLY)'`, flushes the debounce, and asserts the `no_reply` log fires, the recovery path does NOT fire, and nothing is sent to the outbound adapter.
- `allows empty visible text (thinking-only response) as a silent-turn signal` — uses a new `setAssistantMessage` helper on `FakeSession` to construct an `AssistantMessage` with only a `thinking` content block (`role: 'assistant', content: [{ type: 'thinking', thinking: '…' }]`). Asserts the same three outcomes.

**`src/agent/tools/channel-reply.test.ts`** — `blocks the parenthesized "(NO_REPLY)" form (mirrors router lenience)` — calls `createChannelReplyTool` with `text: '(NO_REPLY)'`, asserts no outbound calls are made and the result error contains `'silent-turn signal'`.

**`src/agent/tools/channel-send.test.ts`** — same as above for `channel_send`, supplying all required fields (`adapter`, `workspace`, `chat`, `text`).

## Mutation check

Disabled the two new branches inside `isNoReplySignal` (the `trimmed === ''` and `trimmed === '(NO_REPLY)'` returns) and confirmed the two new router tests fail. The original `'NO_REPLY'` test still passes — correct, because that branch was not touched. Restored and verified all tests pass.

## Verification

- `bun run typecheck` — clean.
- `bun run lint` — clean.
- `bun run format` — no diff.
- `bun test` — 2362 pass, 0 fail.

## Out of scope

- Whitespace-only text (e.g. `text: '   '`) reaching `router.send` at the tool level — separate concern, separate PR.
- System-prompt wording — intentionally left unchanged (see Contract above).

## Diff stat

```
src/agent/tools/channel-reply.test.ts | 15 ++++++++
src/agent/tools/channel-reply.ts      | 14 ++++----
src/agent/tools/channel-send.test.ts  | 19 +++++++++++
src/agent/tools/channel-send.ts       | 22 ++++++------
src/channels/router.test.ts           | 64 +++++++++++++++++++++++++++++++++++
src/channels/router.ts                | 17 +++++++++-
6 files changed, 133 insertions(+), 18 deletions(-)
```