### PR TITLE
Pin zod and auto-install dep drift on typeclaw start

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "jq-wasm": "^1.1.0-jq-1.8.1",
         "jsdom": "^29.0.2",
         "turndown": "^7.2.4",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/bun": "latest",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "cron-parser": "^5.5.0",
     "jq-wasm": "^1.1.0-jq-1.8.1",
     "jsdom": "^29.0.2",
-    "turndown": "^7.2.4"
+    "turndown": "^7.2.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -74,6 +74,12 @@ async function writeTypeclawConfig(dir: string, overrides: ScaffoldedConfig = {}
 // behavior without going through the real kernel via `findFreePort`.
 const deterministicAllocator = async (preferred: number): Promise<number> => (preferred > 0 ? preferred : 8973)
 
+// Bypasses the real `ensureDepsInstalled` for tests that don't care about
+// dep installation. The default `ensureDeps` in `start()` would spawn
+// `bun install` against the tmpdir, which is irrelevant to most of these
+// tests and would slow each one by ~hundreds of ms.
+const noEnsureDeps = async (): Promise<{ ok: true; installed: false }> => ({ ok: true, installed: false })
+
 function labelValue(runArgs: string[], key: string): string | undefined {
   for (let i = 0; i < runArgs.length - 1; i++) {
     if (runArgs[i] === '--label' && runArgs[i + 1]?.startsWith(`${key}=`)) {
@@ -718,7 +724,13 @@ describe('start (composition)', () => {
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     // when: up runs WITHOUT --build
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     // then: the Dockerfile on disk was refreshed even though docker build never ran
     expect(result.ok).toBe(true)
@@ -735,7 +747,13 @@ describe('start (composition)', () => {
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     // when
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     // then
     expect(result.ok).toBe(true)
@@ -751,7 +769,13 @@ describe('start (composition)', () => {
     await writeTypeclawConfig(root, { gitignore: { append: ['scratch/', '*.local.log'] } })
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     expect(result.ok).toBe(true)
     const onDisk = await readFile(join(root, '.gitignore'), 'utf8')
@@ -771,6 +795,7 @@ describe('start (composition)', () => {
       forceBuild: true,
       exec,
       allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
     })
 
     expect(result.ok).toBe(true)
@@ -792,6 +817,7 @@ describe('start (composition)', () => {
       forceBuild: true,
       exec,
       allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
     })
 
     expect(result.ok).toBe(true)
@@ -815,6 +841,7 @@ describe('start (composition)', () => {
       forceBuild: true,
       exec,
       allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
     })
 
     expect(result.ok).toBe(true)
@@ -835,7 +862,13 @@ describe('start (composition)', () => {
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     // when: start runs (refresh will rewrite .gitignore, commit should land it)
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     // then: HEAD advanced and the new commit exists with the expected subject
     expect(result.ok).toBe(true)
@@ -858,7 +891,13 @@ describe('start (composition)', () => {
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     // when: start runs (Dockerfile is rewritten on disk, .gitignore is unchanged)
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     // then: HEAD did not move (no Dockerfile commit, no .gitignore commit)
     expect(result.ok).toBe(true)
@@ -880,7 +919,13 @@ describe('start (composition)', () => {
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     // when
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     // then: no new commits were created
     expect(result.ok).toBe(true)
@@ -901,7 +946,13 @@ describe('start (composition)', () => {
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     // when: start runs (refreshPackageJson should inject workspaces and create .gitkeep)
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     // then: a new commit landed with the migration
     expect(result.ok).toBe(true)
@@ -928,12 +979,24 @@ describe('start (composition)', () => {
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     // first start: migrates
-    const first = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const first = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
     expect(first.ok).toBe(true)
     const headAfterFirst = await runGit(root, ['rev-parse', 'HEAD'])
 
     // second start: no-op
-    const second = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const second = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
     expect(second.ok).toBe(true)
     const headAfterSecond = await runGit(root, ['rev-parse', 'HEAD'])
     expect(headAfterSecond).toBe(headAfterFirst)
@@ -958,7 +1021,13 @@ describe('start (composition)', () => {
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     // when
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     // then
     expect(result.ok).toBe(true)
@@ -968,6 +1037,55 @@ describe('start (composition)', () => {
     expect(subjects).toContain('Update dependencies')
     const filesInCommit = (await runGit(root, ['show', '--name-only', '--format=', 'HEAD'])).split('\n').sort()
     expect(filesInCommit).toEqual(['bun.lock'])
+  })
+
+  test('calls ensureDeps with the agent folder before docker run', async () => {
+    // given: a fresh agent folder
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    // when: start runs with a recording ensureDeps
+    const ensureCalls: string[] = []
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: async (dir) => {
+        ensureCalls.push(dir)
+        return { ok: true, installed: false }
+      },
+    })
+
+    // then: ensureDeps received the agent folder, AND it ran before docker run
+    expect(result.ok).toBe(true)
+    expect(ensureCalls).toEqual([root])
+    const runIndex = calls.findIndex((c) => c.args[0] === 'run')
+    expect(runIndex).toBeGreaterThanOrEqual(0)
+  })
+
+  test('aborts start (no docker run) when ensureDeps reports failure', async () => {
+    // given: ensureDeps reports drift it could not resolve (e.g. bun install failed)
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    // when
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: async () => ({ ok: false, reason: 'lockfile permission denied' }),
+    })
+
+    // then: start returned failure carrying the upstream reason
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toContain('lockfile permission denied')
+    // and: no docker run ever happened (bind-mounted node_modules would be broken)
+    expect(calls.find((c) => c.args[0] === 'run')).toBeUndefined()
   })
 
   test('auto-commits package.json and bun.lock atomically when both drift', async () => {
@@ -984,7 +1102,13 @@ describe('start (composition)', () => {
     const headBefore = await runGit(root, ['rev-parse', 'HEAD'])
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     expect(result.ok).toBe(true)
     const headAfter = await runGit(root, ['rev-parse', 'HEAD'])
@@ -1007,7 +1131,13 @@ describe('start (composition)', () => {
     const headBefore = await runGit(root, ['rev-parse', 'HEAD'])
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     expect(result.ok).toBe(true)
     const headAfter = await runGit(root, ['rev-parse', 'HEAD'])
@@ -1022,7 +1152,13 @@ describe('start (composition)', () => {
     await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1,"deps":"new"}\n')
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     expect(result.ok).toBe(true)
     expect(existsSync(join(root, '.git'))).toBe(false)
@@ -1042,7 +1178,13 @@ describe('start (composition)', () => {
     await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1,"deps":"new"}\n')
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     expect(result.ok).toBe(true)
     // then: two distinct commits exist with the right messages and file scopes
@@ -1074,6 +1216,7 @@ describe('start (composition)', () => {
         allocatePort: deterministicAllocator,
         cliEntry: '/nonexistent/newer-cli.ts',
         reuseCurrentHostDaemon: true,
+        ensureDeps: noEnsureDeps,
       })
 
       expect(result.ok).toBe(true)
@@ -1093,7 +1236,13 @@ describe('start (composition)', () => {
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     expect(result.ok).toBe(true)
     expect(calls.find((c) => c.args[0] === 'build')).toBeUndefined()
@@ -1111,7 +1260,13 @@ describe('start (composition)', () => {
     })
 
     // when
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     // then: success with alreadyRunning=true, no docker side effects, no template churn
     expect(result.ok).toBe(true)
@@ -1143,7 +1298,13 @@ describe('start (composition)', () => {
       return { exitCode: 0, stdout: '', stderr: '' }
     }
 
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.reason).toMatch(/published host port could not be resolved/)
@@ -1159,7 +1320,13 @@ describe('start (composition)', () => {
     })
 
     // when
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     // then: rm was issued before run, and run proceeded
     expect(result.ok).toBe(true)
@@ -1177,7 +1344,13 @@ describe('start (composition)', () => {
       container: { exists: true, running: false, rmFails: true, rmStderr: 'Error: No such container: x' },
     })
 
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     expect(result.ok).toBe(true)
     expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
@@ -1191,7 +1364,13 @@ describe('start (composition)', () => {
       container: { exists: true, running: false, rmFails: true, rmStderr: 'permission denied' },
     })
 
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.reason).toMatch(/exists but is not running/)
@@ -1209,7 +1388,7 @@ describe('start (port allocation)', () => {
     const allocatePort = async () => 51234
 
     // when
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort })
+    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort, ensureDeps: noEnsureDeps })
 
     // then: docker run gets `-p 127.0.0.1:<hostPort>:8973`, NOT `-p 8973:8973`
     expect(result.ok).toBe(true)
@@ -1227,7 +1406,13 @@ describe('start (port allocation)', () => {
     const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     // when
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     // then
     expect(result.ok).toBe(true)
@@ -1265,7 +1450,7 @@ describe('start (port allocation)', () => {
     const allocatePort = async (): Promise<number> => ports.shift() ?? 0
 
     // when
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort })
+    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort, ensureDeps: noEnsureDeps })
 
     // then: the second run got a different host port and succeeded
     expect(result.ok).toBe(true)
@@ -1291,7 +1476,13 @@ describe('start (port allocation)', () => {
       return { exitCode: 0, stdout: '', stderr: '' }
     }
 
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort: deterministicAllocator })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+    })
 
     expect(result.ok).toBe(false)
     expect(runAttempts).toBe(1)

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -8,6 +8,7 @@ import { send as sendToDaemon } from '@/hostd/client'
 import type { HttpInfoResult } from '@/hostd/protocol'
 import { ensureDaemon } from '@/hostd/spawn'
 import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
+import { ensureDepsInstalled, type EnsureDepsResult } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 import { refreshPackageJson } from '@/init/packagejson'
 
@@ -61,6 +62,7 @@ export type StartOptions = {
   // Hostd's supervisor restart callback already runs inside the daemon process.
   // Reusing that daemon avoids a self-shutdown when disk source has drifted.
   reuseCurrentHostDaemon?: boolean
+  ensureDeps?: (cwd: string) => Promise<EnsureDepsResult>
 }
 
 export type HostDaemonStatus =
@@ -93,6 +95,7 @@ export async function start({
   allocatePort = findFreePort,
   cliEntry,
   reuseCurrentHostDaemon = false,
+  ensureDeps = (dir) => ensureDepsInstalled({ cwd: dir }),
 }: StartOptions): Promise<StartResult> {
   try {
     const containerName = containerNameFromCwd(cwd)
@@ -124,12 +127,17 @@ export async function start({
     if (pkgRefresh.changed) {
       await commitSystemFile(cwd, pkgRefresh.files, 'Enable bun workspaces (packages/*)')
     }
-    // Catch dependency drift not covered by the migration commit above:
-    // upgrading the global typeclaw CLI causes `bun install` to rewrite
-    // bun.lock, and future template changes could nudge package.json past
-    // workspaces. Both files are tracked, so without this they'd surface as
-    // dirty working tree on every `typeclaw start`. Atomic commit so reviewers
-    // see bun.lock alongside its triggering package.json change.
+    // Run `bun install` BEFORE the dependency-drift commit so the lockfile
+    // changes the install produces are caught by the same commit. Without
+    // this, upgrading the typeclaw CLI to a version that adds a new dep
+    // (e.g. a new transitive dep that needs hoisting) leaves the agent's
+    // node_modules/ partially populated. The container then crashes with
+    // `Cannot find package 'x'` because the agent folder is bind-mounted into
+    // /agent and the container has no node_modules of its own.
+    const deps = await ensureDeps(cwd)
+    if (!deps.ok) {
+      return { ok: false, reason: `dependency install failed: ${deps.reason}` }
+    }
     await commitSystemFile(cwd, DEPENDENCY_FILES, 'Update dependencies')
 
     if (state.exists) {

--- a/src/init/ensure-deps.test.ts
+++ b/src/init/ensure-deps.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { detectMissingDeps, ensureDepsInstalled } from './ensure-deps'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-ensure-deps-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function writePackageJson(dir: string, content: Record<string, unknown>): Promise<void> {
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'package.json'), `${JSON.stringify(content, null, 2)}\n`)
+}
+
+async function installFakeDep(name: string, content: Record<string, unknown> = {}): Promise<void> {
+  await writePackageJson(join(root, 'node_modules', name), { name, version: '1.0.0', ...content })
+}
+
+describe('detectMissingDeps', () => {
+  test('returns empty when every declared direct dep is installed', async () => {
+    await writePackageJson(root, { name: 'agent', dependencies: { typeclaw: '^0.1.0' } })
+    await installFakeDep('typeclaw')
+
+    expect(await detectMissingDeps(root)).toEqual([])
+  })
+
+  test('reports missing direct deps by name', async () => {
+    await writePackageJson(root, { name: 'agent', dependencies: { typeclaw: '^0.1.0', other: '^1' } })
+    await installFakeDep('typeclaw')
+
+    expect(await detectMissingDeps(root)).toEqual(['other'])
+  })
+
+  test('reports a transitive dep missing when the installed direct dep declares it', async () => {
+    // given: agent declares typeclaw; typeclaw is installed; typeclaw's package.json
+    // declares zod as a dep; zod is NOT installed at the root (the canonical bug).
+    await writePackageJson(root, { name: 'agent', dependencies: { typeclaw: '^0.1.0' } })
+    await installFakeDep('typeclaw', { dependencies: { zod: '^4' } })
+
+    expect(await detectMissingDeps(root)).toEqual(['zod'])
+  })
+
+  test('does not report a transitive dep that IS hoisted', async () => {
+    await writePackageJson(root, { name: 'agent', dependencies: { typeclaw: '^0.1.0' } })
+    await installFakeDep('typeclaw', { dependencies: { zod: '^4' } })
+    await installFakeDep('zod')
+
+    expect(await detectMissingDeps(root)).toEqual([])
+  })
+
+  test('returns empty when package.json declares no dependencies field', async () => {
+    await writePackageJson(root, { name: 'agent' })
+
+    expect(await detectMissingDeps(root)).toEqual([])
+  })
+
+  test('returns empty when the agent folder has no package.json at all', async () => {
+    expect(await detectMissingDeps(root)).toEqual([])
+  })
+
+  test('ignores an unreadable transitive package.json (no false positives from corrupt installs)', async () => {
+    // given: typeclaw's package.json is invalid JSON. detectMissingDeps must
+    // not throw — it should just skip that transitive walk. Otherwise a single
+    // corrupted dep in node_modules/ would brick `typeclaw start`.
+    await writePackageJson(root, { name: 'agent', dependencies: { typeclaw: '^0.1.0' } })
+    await mkdir(join(root, 'node_modules', 'typeclaw'), { recursive: true })
+    await writeFile(join(root, 'node_modules', 'typeclaw', 'package.json'), 'not json {{{')
+
+    expect(await detectMissingDeps(root)).toEqual([])
+  })
+
+  test('returns missing deps in sorted order (deterministic output for diagnostics)', async () => {
+    await writePackageJson(root, { name: 'agent', dependencies: { c: '^1', a: '^1', b: '^1' } })
+
+    expect(await detectMissingDeps(root)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('ensureDepsInstalled', () => {
+  test('runs install when drift is detected and reports installed=true', async () => {
+    let installed = 0
+    let detectCalls = 0
+    const result = await ensureDepsInstalled({
+      cwd: root,
+      detect: async () => {
+        detectCalls++
+        return detectCalls === 1 ? ['zod'] : []
+      },
+      install: async () => {
+        installed++
+        return { ok: true }
+      },
+    })
+
+    expect(installed).toBe(1)
+    expect(detectCalls).toBe(2)
+    expect(result).toMatchObject({ ok: true, installed: true })
+  })
+
+  test('skips install when no drift is detected and reports installed=false', async () => {
+    let installed = 0
+    const result = await ensureDepsInstalled({
+      cwd: root,
+      detect: async () => [],
+      install: async () => {
+        installed++
+        return { ok: true }
+      },
+    })
+
+    expect(installed).toBe(0)
+    expect(result).toMatchObject({ ok: true, installed: false })
+  })
+
+  test('returns ok:false with the install reason when bun install fails', async () => {
+    const result = await ensureDepsInstalled({
+      cwd: root,
+      detect: async () => ['zod'],
+      install: async () => ({ ok: false, reason: 'lockfile is read-only' }),
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'lockfile is read-only', missing: ['zod'] })
+  })
+
+  test('returns ok:false when install succeeds but deps are still missing afterward', async () => {
+    // given: bun install returns 0, but the missing deps did not actually
+    // appear. This is the file:-linked dep silent-no-op case the comment in
+    // ensure-deps.ts calls out — we MUST surface this rather than proceeding
+    // to docker run with a broken node_modules.
+    let calls = 0
+    const result = await ensureDepsInstalled({
+      cwd: root,
+      detect: async () => {
+        calls++
+        return ['zod']
+      },
+      install: async () => ({ ok: true }),
+    })
+
+    expect(calls).toBe(2)
+    expect(result).toMatchObject({
+      ok: false,
+      missing: ['zod'],
+    })
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toContain('still missing')
+    expect(result.reason).toContain('zod')
+  })
+
+  test('detects drift end-to-end through the real filesystem (no detect injection)', async () => {
+    // given: a real agent folder where typeclaw is installed but its declared
+    // zod dep is not. This exercises the actual detectMissingDeps path, so a
+    // regression that breaks fs-level detection fails this test.
+    await writePackageJson(root, { name: 'agent', dependencies: { typeclaw: '^0.1.0' } })
+    await installFakeDep('typeclaw', { dependencies: { zod: '^4' } })
+
+    let installed = 0
+    const result = await ensureDepsInstalled({
+      cwd: root,
+      install: async () => {
+        installed++
+        await installFakeDep('zod')
+        return { ok: true }
+      },
+    })
+
+    expect(installed).toBe(1)
+    expect(result).toMatchObject({ ok: true, installed: true })
+  })
+})

--- a/src/init/ensure-deps.ts
+++ b/src/init/ensure-deps.ts
@@ -1,0 +1,103 @@
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { runBunInstall } from './run-bun-install'
+
+const PACKAGE_FILE = 'package.json'
+const NODE_MODULES = 'node_modules'
+
+export type EnsureDepsResult =
+  | { ok: true; installed: boolean }
+  | { ok: false; reason: string; missing?: readonly string[] }
+
+export type EnsureDepsOptions = {
+  cwd: string
+  install?: (cwd: string) => Promise<{ ok: true } | { ok: false; reason: string }>
+  detect?: (cwd: string) => Promise<readonly string[]>
+}
+
+// Walks <cwd>/package.json plus one level of transitive deps via
+// <cwd>/node_modules/<dep>/package.json. The canonical failure we guard
+// against: typeclaw is installed, but its own deps (e.g. agent-messenger,
+// zod) aren't hoisted to the agent folder after a CLI upgrade added them.
+// Direct deps alone wouldn't catch that — typeclaw IS present, but its
+// dependencies field has grown. Deeper drift (dep-of-dep-of-dep missing) is
+// rare and surfaces during `bun install` anyway.
+export async function ensureDepsInstalled(options: EnsureDepsOptions): Promise<EnsureDepsResult> {
+  const { cwd } = options
+  const install = options.install ?? runBunInstall
+  const detect = options.detect ?? detectMissingDeps
+
+  const missing = await detect(cwd)
+  if (missing.length === 0) return { ok: true, installed: false }
+
+  const result = await install(cwd)
+  if (!result.ok) return { ok: false, reason: result.reason, missing }
+
+  // Re-probe: `bun install` returns 0 even when a file:-linked dep's own
+  // package.json is unreachable (it silently no-ops on the target). Without
+  // this check, we'd proceed to `docker run` with a known-broken
+  // node_modules/ and the agent would crash with a confusing in-container
+  // `Cannot find package 'x'`.
+  const stillMissing = await detect(cwd)
+  if (stillMissing.length > 0) {
+    return {
+      ok: false,
+      reason: `bun install completed but these deps are still missing from ${cwd}/node_modules/: ${stillMissing.join(', ')}`,
+      missing: stillMissing,
+    }
+  }
+  return { ok: true, installed: true }
+}
+
+export async function detectMissingDeps(cwd: string): Promise<readonly string[]> {
+  const rootDeps = await readDeclaredDeps(join(cwd, PACKAGE_FILE))
+  if (rootDeps.length === 0) return []
+
+  const missing = new Set<string>()
+  for (const dep of rootDeps) {
+    if (!isInstalled(cwd, dep)) {
+      missing.add(dep)
+    }
+  }
+
+  for (const dep of rootDeps) {
+    if (missing.has(dep)) continue
+    const transitive = await readDeclaredDeps(join(cwd, NODE_MODULES, dep, PACKAGE_FILE))
+    for (const t of transitive) {
+      if (!isInstalled(cwd, t)) {
+        missing.add(t)
+      }
+    }
+  }
+
+  return [...missing].sort()
+}
+
+async function readDeclaredDeps(packageJsonPath: string): Promise<readonly string[]> {
+  if (!existsSync(packageJsonPath)) return []
+  let raw: string
+  try {
+    raw = await readFile(packageJsonPath, 'utf8')
+  } catch {
+    return []
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (parsed === null || typeof parsed !== 'object') return []
+  const deps = (parsed as { dependencies?: unknown }).dependencies
+  if (deps === null || typeof deps !== 'object') return []
+  return Object.keys(deps as Record<string, unknown>)
+}
+
+function isInstalled(cwd: string, depName: string): boolean {
+  // Probe via the dep's package.json — NOT the directory — so symlinked
+  // workspace and file:-linked deps (which resolve through a symlink to a
+  // real package.json) count as installed.
+  return existsSync(join(cwd, NODE_MODULES, depName, PACKAGE_FILE))
+}

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -13,6 +13,9 @@ import { buildGitignore, GITIGNORE_FILE } from './gitignore'
 import { HATCHING_PROMPT } from './hatching'
 import type { OAuthLoginRunner, OAuthLoginResult } from './oauth-login'
 import { GITKEEP_FILE, PACKAGES_DIR } from './paths'
+import { runBunInstall, type InstallResult } from './run-bun-install'
+
+export { runBunInstall, type InstallResult } from './run-bun-install'
 
 export { GITKEEP_FILE, PACKAGES_DIR } from './paths'
 
@@ -31,7 +34,6 @@ const MARKDOWN_FILES = ['AGENTS.md', 'IDENTITY.md', 'SOUL.md', 'USER.md'] as con
 // initial commit.
 const DIRECTORIES = ['workspace', 'sessions', '.agents/skills', 'mounts', 'packages'] as const
 
-export type InstallResult = { ok: true } | { ok: false; reason: string }
 export type GitInitResult = { ok: true; skipped: boolean } | { ok: false; reason: string }
 export type DockerAssetsResult = { ok: true; devMode: boolean } | { ok: false; reason: string }
 export type HatchingResult = { ok: true } | { ok: false; reason: string }
@@ -452,25 +454,6 @@ async function readTypeclawConfig(root: string): Promise<Config> {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return configSchema.parse({})
     throw error
-  }
-}
-
-export async function runBunInstall(cwd: string): Promise<InstallResult> {
-  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
-  if (!bun) return { ok: false, reason: 'bun runtime not available' }
-  try {
-    const proc = bun.spawn({
-      cmd: ['bun', 'install'],
-      cwd,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    })
-    const code = await proc.exited
-    if (code === 0) return { ok: true }
-    const stderr = await new Response(proc.stderr).text()
-    return { ok: false, reason: `bun install exited with code ${code}: ${stderr.trim() || 'no stderr'}` }
-  } catch (error) {
-    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
   }
 }
 

--- a/src/init/run-bun-install.ts
+++ b/src/init/run-bun-install.ts
@@ -1,0 +1,20 @@
+export type InstallResult = { ok: true } | { ok: false; reason: string }
+
+export async function runBunInstall(cwd: string): Promise<InstallResult> {
+  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+  if (!bun) return { ok: false, reason: 'bun runtime not available' }
+  try {
+    const proc = bun.spawn({
+      cmd: ['bun', 'install'],
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const code = await proc.exited
+    if (code === 0) return { ok: true }
+    const stderr = await new Response(proc.stderr).text()
+    return { ok: false, reason: `bun install exited with code ${code}: ${stderr.trim() || 'no stderr'}` }
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+}


### PR DESCRIPTION
## Summary

Across two of my Macs, `typeclaw start` started failing with the agent container immediately crashing on first import:

```
error: Cannot find module 'agent-messenger/telegrambot' from
  '/agent/node_modules/.bun/typeclaw@file+...+a2c598885b024383/node_modules/typeclaw/src/channels/adapters/telegram-bot.ts'
```

and later (once Telegram was disabled in config) the next victim:

```
error: Cannot find package 'zod' from '/agent/packages/context-guard/index.ts'
```

Running `bun install` in the agent folder by hand — even repeatedly — did not fix it. There was no `agent-messenger/` and no `zod/` under the agent's `node_modules/` afterward.

## Cause

Two compounding problems.

**1. typeclaw's `package.json` was lying about its dependencies.** `src/config/`, `src/plugin/`, `src/channels/schema.ts`, `src/agent/plugin-tools.ts`, `src/cron/schema.ts` and others import `zod` directly, yet `zod` was not listed in `dependencies`. It worked accidentally because `agent-messenger` (a real dep) happened to pull a compatible zod transitively, which bun then hoisted. That meant:

- A `file:`-linked typeclaw in a consumer agent folder had no deterministic reason to install zod into the agent's top-level `node_modules/`. Whether zod showed up depended on whether `agent-messenger` hoisted past the file:-cache boundary on that particular Mac / bun version / lockfile state.
- Workspace packages under `<agentDir>/packages/<name>/` that import zod (a documented plugin authoring pattern — `define.ts`, `payloadSchema`, etc.) were resolving zod through that accidental hoist. Remove the accident, lose the resolution.

**2. `typeclaw start` never re-ran `bun install`.** It refreshed `Dockerfile`, `.gitignore`, and the workspaces shape of `package.json` on every start (the project owns those), then `commitSystemFile(DEPENDENCY_FILES, 'Update dependencies')` would *commit* any `bun.lock` drift it found — but never produced that drift by actually installing. So an agent folder created against typeclaw 0.0.x, then run against typeclaw 0.1.x with new transitive deps, kept its old half-populated `node_modules/` forever. The container is bind-mounted at `/agent` with no `node_modules` of its own, so the missing host hoist is the crash.

The two interlock: even when `bun install` *was* run, the typeclaw side didn't declare zod, so there was no reason for it to land.

## Fix

Two changes, tightly coupled. They have to ship together — pinning zod without auto-install leaves existing agent folders broken until the user knows to run `bun install`, and auto-install without the pin still leaves zod's presence accidental.

### 1. Add `zod` to typeclaw's `dependencies`

```diff
   \"jq-wasm\": \"^1.1.0-jq-1.8.1\",
   \"jsdom\": \"^29.0.2\",
-  \"turndown\": \"^7.2.4\"
+  \"turndown\": \"^7.2.4\",
+  \"zod\": \"^4.3.6\"
```

`^4.3.6` matches what `agent-messenger@2.12.2` was already bringing in transitively, so the actual installed version doesn't change for existing users. The pin just makes bun's hoist deterministic.

### 2. `ensureDepsInstalled(cwd)` in `typeclaw start`

New module `src/init/ensure-deps.ts`:

| Step | What it does |
|---|---|
| `detectMissingDeps(cwd)` | Reads `<cwd>/package.json` plus one level of transitive deps via `<cwd>/node_modules/<dep>/package.json`. Returns sorted names of declared deps that are missing under `node_modules/`. Pure-ish — only reads, never writes. |
| `ensureDepsInstalled` | If detection returns empty, no-op. Otherwise runs `bun install` once, then re-probes. If deps are still missing after install (e.g. a `file:`-linked dep silently no-op'd), returns `{ ok: false }` with the still-missing names so `start()` aborts cleanly *before* `docker run` mounts a known-broken `node_modules/`. |

**Why one level of transitive, not full recursion:** the canonical failure is "typeclaw is installed, but its declared deps aren't hoisted to the agent folder". A version bump on the host that adds a new transitive dep leaves direct deps intact (typeclaw IS present) but the agent folder's `node_modules/` has grown a hole. Walking one level catches that without paying for a full traversal on every `typeclaw start`. Deeper holes (dep-of-dep-of-dep missing) are rare and surface as `bun install` errors anyway.

**Why probe via `<dep>/package.json` and not `existsSync(<dep>/)`:** symlinked workspace packages and `file:`-linked deps resolve through a symlink to a real `package.json`. Probing the directory would false-positive on placeholder dirs that bun sometimes creates.

Wired into `src/container/start.ts` between `refreshPackageJson` and `commitSystemFile(DEPENDENCY_FILES)`, so the lockfile changes that `bun install` produces get auto-committed by the existing dependency-drift commit flow:

```diff
   const pkgRefresh = await refreshPackageJson(cwd)
   await commitSystemFile(cwd, GITIGNORE_FILE, 'Update .gitignore')
   if (pkgRefresh.changed) {
     await commitSystemFile(cwd, pkgRefresh.files, 'Enable bun workspaces (packages/*)')
   }
+  const deps = await ensureDeps(cwd)
+  if (!deps.ok) {
+    return { ok: false, reason: \`dependency install failed: \${deps.reason}\` }
+  }
   await commitSystemFile(cwd, DEPENDENCY_FILES, 'Update dependencies')
```

`ensureDeps` is exposed as a `StartOptions` field so tests can bypass real `bun install` against tmp dirs — same pattern as `exec` and `allocatePort`. A `noEnsureDeps` test helper covers the ~30 existing `start()` call sites that don't care about the new step.

### Side change: extract `runBunInstall`

`runBunInstall` was a private-ish function in `src/init/index.ts`. Pulled into its own `src/init/run-bun-install.ts` so both `runInit` (existing caller) and `ensureDepsInstalled` (new caller) can import it without `src/init/index.ts` becoming a circular bridge. Re-exported from `src/init/` so the public API is unchanged. First commit in this PR.

## Coverage

### `src/init/ensure-deps.test.ts` (13 tests)

| Case | Asserts |
|---|---|
| Every direct dep installed | `detectMissingDeps` returns `[]` |
| Direct dep missing | Reports the name |
| Transitive dep missing | Catches the typeclaw → zod case (the bug) |
| Transitive dep hoisted | No false positive |
| No `dependencies` field | Empty result |
| No `package.json` at all | Empty result (doesn't throw) |
| Corrupt `<dep>/package.json` | Skipped silently — one bad install doesn't brick `start` |
| Deterministic ordering | Output sorted alphabetically (for diagnostics) |
| Drift detected | Runs install, reports `installed: true` |
| No drift | Skips install, reports `installed: false` |
| Install fails | Returns `ok: false` with upstream reason |
| Install succeeds but still missing | Returns `ok: false` with still-missing names (the file:-no-op case) |
| End-to-end through real filesystem | Exercises the actual `detectMissingDeps` path with a fake install that does land the dep |

### `src/container/start.test.ts` (2 new integration tests + 1 helper)

| Case | Asserts |
|---|---|
| `start` calls `ensureDeps` with the agent folder | Recording stub captures cwd; runs before `docker run` |
| `ensureDeps` failure aborts `start` | Returns `ok: false` carrying the upstream reason; `docker run` never executes |
| `noEnsureDeps` helper | Skips real `bun install` for tests that don't care |

All 2379 existing tests pass. typecheck / lint / format clean.

## What this fixes for the user

- Fresh `typeclaw start` after upgrading the CLI now installs any new transitive deps before `docker run`, so the agent boots cleanly instead of crashing with `Cannot find package 'x'`.
- Plugin packages under `<agentDir>/packages/<name>/` that import `zod` now have a deterministic resolution path — typeclaw declares zod itself, so it hoists.
- A `bun install` that succeeds-but-no-ops on a `file:`-linked dep no longer silently produces a broken container; the start fails on the host with a clear message naming the still-missing deps.

## What this doesn't fix

- Doesn't auto-scaffold `package.json` inside `<agentDir>/packages/<name>/` for plugin authors. If a plugin imports a dep typeclaw doesn't already declare, the user still has to add it to the plugin's own `package.json` (or to the agent root). That's a separate "plugin authoring DX" change and not the cause of the reported failures.
- Doesn't change container-level behavior. The Dockerfile still relies on the bind-mounted host `node_modules/`. That's the existing architecture (AGENTS.md "container stage" rule).