### PR TITLE
Fail typeclaw start when the container crashes immediately after docker run

### DIFF
--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -4,7 +4,7 @@ export type DockerExecResult = { exitCode: number; stdout: string; stderr: strin
 
 export type DockerExec = (
   args: string[],
-  options?: { cwd?: string; inheritStdio?: boolean },
+  options?: { cwd?: string; inheritStdio?: boolean; signal?: AbortSignal },
 ) => Promise<DockerExecResult>
 
 export const defaultDockerExec: DockerExec = async (args, options) => {
@@ -14,10 +14,17 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
   // $PATH (rather than returning a non-zero exit). Two overloads (pipe vs
   // inherit) so each spawn call site has the literal stdout/stderr type
   // attached — that's what lets `new Response(proc.stdout)` typecheck on
-  // the piped path.
+  // the piped path. `signal` is forwarded to Bun.spawn so callers can bound
+  // long-running docker subcommands (e.g. `docker logs` on a stuck daemon).
   if (options?.inheritStdio) {
     try {
-      const proc = bun.spawn({ cmd: ['docker', ...args], cwd: options.cwd, stdout: 'inherit', stderr: 'inherit' })
+      const proc = bun.spawn({
+        cmd: ['docker', ...args],
+        cwd: options.cwd,
+        stdout: 'inherit',
+        stderr: 'inherit',
+        signal: options.signal,
+      })
       return { exitCode: await proc.exited, stdout: '', stderr: '' }
     } catch (error) {
       if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
@@ -27,7 +34,13 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
     }
   }
   try {
-    const proc = bun.spawn({ cmd: ['docker', ...args], cwd: options?.cwd, stdout: 'pipe', stderr: 'pipe' })
+    const proc = bun.spawn({
+      cmd: ['docker', ...args],
+      cwd: options?.cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      signal: options?.signal,
+    })
     const exitCode = await proc.exited
     const stdout = await new Response(proc.stdout).text()
     const stderr = await new Response(proc.stderr).text()

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -80,6 +80,12 @@ const deterministicAllocator = async (preferred: number): Promise<number> => (pr
 // tests and would slow each one by ~hundreds of ms.
 const noEnsureDeps = async (): Promise<{ ok: true; installed: false }> => ({ ok: true, installed: false })
 
+// Bypasses the post-`docker run` verification window so happy-path tests don't
+// pay the production 1.5s wait. Verification has its own dedicated test file
+// (verify-running.test.ts); start.test.ts only proves start() routes a
+// failing verifier into the documented failure response.
+const bypassVerify = { verifyRunning: async () => ({ ok: true as const }) }
+
 function labelValue(runArgs: string[], key: string): string | undefined {
   for (let i = 0; i < runArgs.length - 1; i++) {
     if (runArgs[i] === '--label' && runArgs[i + 1]?.startsWith(`${key}=`)) {
@@ -709,6 +715,7 @@ function fakeDockerExec(scenario: { imageExists: boolean; container: ContainerSc
       return { exitCode: 0, stdout: '', stderr: '' }
     }
     if (args[0] === 'run') {
+      containerState = { exists: true, running: true }
       return { exitCode: 0, stdout: 'fake-container-id-abcdef\n', stderr: '' }
     }
     return { exitCode: 0, stdout: '', stderr: '' }
@@ -730,6 +737,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     // then: the Dockerfile on disk was refreshed even though docker build never ran
@@ -753,6 +761,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     // then
@@ -775,6 +784,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
@@ -796,6 +806,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
@@ -818,6 +829,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
@@ -842,6 +854,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
@@ -868,6 +881,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     // then: HEAD advanced and the new commit exists with the expected subject
@@ -897,6 +911,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     // then: HEAD did not move (no Dockerfile commit, no .gitignore commit)
@@ -925,6 +940,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     // then: no new commits were created
@@ -952,6 +968,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     // then: a new commit landed with the migration
@@ -985,6 +1002,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
     expect(first.ok).toBe(true)
     const headAfterFirst = await runGit(root, ['rev-parse', 'HEAD'])
@@ -996,6 +1014,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
     expect(second.ok).toBe(true)
     const headAfterSecond = await runGit(root, ['rev-parse', 'HEAD'])
@@ -1027,6 +1046,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     // then
@@ -1056,6 +1076,7 @@ describe('start (composition)', () => {
         ensureCalls.push(dir)
         return { ok: true, installed: false }
       },
+      ...bypassVerify,
     })
 
     // then: ensureDeps received the agent folder, AND it ran before docker run
@@ -1108,6 +1129,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
@@ -1137,6 +1159,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
@@ -1158,6 +1181,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
@@ -1184,6 +1208,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
@@ -1217,6 +1242,7 @@ describe('start (composition)', () => {
         cliEntry: '/nonexistent/newer-cli.ts',
         reuseCurrentHostDaemon: true,
         ensureDeps: noEnsureDeps,
+        ...bypassVerify,
       })
 
       expect(result.ok).toBe(true)
@@ -1242,6 +1268,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
@@ -1266,6 +1293,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     // then: success with alreadyRunning=true, no docker side effects, no template churn
@@ -1304,6 +1332,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(false)
@@ -1326,6 +1355,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     // then: rm was issued before run, and run proceeded
@@ -1350,6 +1380,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
@@ -1370,6 +1401,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(false)
@@ -1388,7 +1420,14 @@ describe('start (port allocation)', () => {
     const allocatePort = async () => 51234
 
     // when
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort, ensureDeps: noEnsureDeps })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
 
     // then: docker run gets `-p 127.0.0.1:<hostPort>:8973`, NOT `-p 8973:8973`
     expect(result.ok).toBe(true)
@@ -1412,6 +1451,7 @@ describe('start (port allocation)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     // then
@@ -1450,7 +1490,14 @@ describe('start (port allocation)', () => {
     const allocatePort = async (): Promise<number> => ports.shift() ?? 0
 
     // when
-    const result = await start({ cwd: root, preferredHostPort: 8973, exec, allocatePort, ensureDeps: noEnsureDeps })
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
 
     // then: the second run got a different host port and succeeded
     expect(result.ok).toBe(true)
@@ -1482,11 +1529,107 @@ describe('start (port allocation)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      ...bypassVerify,
     })
 
     expect(result.ok).toBe(false)
     expect(runAttempts).toBe(1)
     if (!result.ok) expect(result.reason).toMatch(/permission denied/)
+  })
+})
+
+// start.test.ts owns COMPOSITION: that start() invokes the verifier exactly
+// when docker run succeeds, routes a failing verifier into ok:false, and runs
+// cleanup. The behavior of the default verifier (transient statuses, daemon
+// errors, log capture, timeouts) lives in verify-running.test.ts.
+describe('start (post-run verification composition)', () => {
+  test('routes a failing verifier into ok:false with the verifier-supplied reason and runs hostd cleanup', async () => {
+    const previousHome = process.env.TYPECLAW_HOME
+    const home = await mkdtemp(join(tmpdir(), 'typeclaw-crash-hostd-'))
+    let daemon: Daemon | null = null
+    try {
+      process.env.TYPECLAW_HOME = home
+      await writeDockerfile(root)
+      await writePackageJson(root, { typeclaw: '^0.1.0' })
+      await writeTypeclawConfig(root)
+      daemon = await startDaemon({ version: 'v', gcIntervalMs: 1_000_000 })
+      const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+      const result = await start({
+        cwd: root,
+        preferredHostPort: 8973,
+        exec,
+        allocatePort: deterministicAllocator,
+        cliEntry: '/nonexistent/cli.ts',
+        reuseCurrentHostDaemon: true,
+        ensureDeps: noEnsureDeps,
+        verifyRunning: async () => ({
+          ok: false,
+          mode: 'removed',
+          logs: { ok: true, text: 'Cannot find package "missing"' },
+        }),
+      })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('expected failure')
+      expect(result.reason).toMatch(/exited and was auto-removed/)
+      expect(result.reason).toContain('Cannot find package "missing"')
+      expect(daemon.registered()).not.toContain(basename(root))
+    } finally {
+      if (daemon) await daemon.stop().catch(() => {})
+      if (previousHome === undefined) delete process.env.TYPECLAW_HOME
+      else process.env.TYPECLAW_HOME = previousHome
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  test('verifier runs AFTER docker run succeeds and BEFORE start returns success', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+    let verifierInvokedAfterRun = false
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      verifyRunning: async () => {
+        const runIdx = calls.findIndex((c) => c.args[0] === 'run')
+        verifierInvokedAfterRun = runIdx >= 0
+        return { ok: true }
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(verifierInvokedAfterRun).toBe(true)
+  })
+
+  test('does not invoke the verifier when docker run fails (no container to verify)', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
+      if (args[0] === 'inspect') return { exitCode: 1, stdout: '', stderr: 'No such container' }
+      if (args[0] === 'run') return { exitCode: 125, stdout: '', stderr: 'docker run failed for unrelated reason' }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+    let verifierCalled = false
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      verifyRunning: async () => {
+        verifierCalled = true
+        return { ok: true }
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(verifierCalled).toBe(false)
   })
 })
 

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -14,6 +14,7 @@ import { refreshPackageJson } from '@/init/packagejson'
 
 import { CONTAINER_PORT, findFreePort, isPortAllocatedError } from './port'
 import { containerNameFromCwd, defaultDockerExec, type DockerExec, getBun, imageTagFromCwd } from './shared'
+import { buildCrashReason, createVerifyRunning, type VerifyRunningFn } from './verify-running'
 
 const PACKAGE_FILE = 'package.json'
 const BUN_LOCK_FILE = 'bun.lock'
@@ -63,6 +64,15 @@ export type StartOptions = {
   // Reusing that daemon avoids a self-shutdown when disk source has drifted.
   reuseCurrentHostDaemon?: boolean
   ensureDeps?: (cwd: string) => Promise<EnsureDepsResult>
+  // Post-`docker run` verifier. `docker run -d` returns exit 0 the moment the
+  // container is created, even if its entrypoint crashes milliseconds later;
+  // with `--rm`, Docker then auto-removes the corpse, so `typeclaw logs`
+  // reports "not found" against a start() that claimed success. The default
+  // verifier polls `docker inspect` for 1.5s and converts crashes (or
+  // unrecoverable daemon errors) into start failures. Pass a custom function
+  // to override the wait window or to bypass verification entirely (e.g. a
+  // no-op `async () => ({ ok: true })` for unit tests that don't care).
+  verifyRunning?: VerifyRunningFn
 }
 
 export type HostDaemonStatus =
@@ -96,6 +106,7 @@ export async function start({
   cliEntry,
   reuseCurrentHostDaemon = false,
   ensureDeps = (dir) => ensureDepsInstalled({ cwd: dir }),
+  verifyRunning = createVerifyRunning({ exec }),
 }: StartOptions): Promise<StartResult> {
   try {
     const containerName = containerNameFromCwd(cwd)
@@ -204,10 +215,18 @@ export async function start({
       return { ok: false, reason: `docker run failed: ${run.stderr.trim() || 'no stderr'}` }
     }
 
+    const containerId = run.stdout.trim()
+
+    const verification = await verifyRunning(containerName)
+    if (!verification.ok) {
+      await cleanupHostDaemonRegistration(containerName, hostd)
+      return { ok: false, reason: buildCrashReason(containerName, verification) }
+    }
+
     return {
       ok: true,
       plan,
-      containerId: run.stdout.trim(),
+      containerId,
       built,
       hostPort,
       hostd: stripHostDaemonControl(hostd),

--- a/src/container/verify-running.test.ts
+++ b/src/container/verify-running.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { DockerExec, DockerExecResult } from './shared'
+import {
+  buildCrashReason,
+  createVerifyRunning,
+  probeContainer,
+  type ContainerLifeStatus,
+  type VerifyRunningResult,
+} from './verify-running'
+
+type ScriptedResponse = DockerExecResult | ((args: string[]) => DockerExecResult)
+
+function scriptedExec(script: Record<string, ScriptedResponse[]>): {
+  exec: DockerExec
+  calls: { args: string[]; signal?: AbortSignal }[]
+} {
+  const calls: { args: string[]; signal?: AbortSignal }[] = []
+  const cursors: Record<string, number> = {}
+  const exec: DockerExec = async (args, options) => {
+    calls.push({ args, signal: options?.signal })
+    const key = args[0] ?? ''
+    const queue = script[key]
+    if (!queue || queue.length === 0) {
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+    const idx = Math.min(cursors[key] ?? 0, queue.length - 1)
+    cursors[key] = (cursors[key] ?? 0) + 1
+    const response = queue[idx]!
+    return typeof response === 'function' ? response(args) : response
+  }
+  return { exec, calls }
+}
+
+const inspect = (status: ContainerLifeStatus): DockerExecResult => ({
+  exitCode: 0,
+  stdout: `${status}\n`,
+  stderr: '',
+})
+
+const inspectMissing: DockerExecResult = { exitCode: 1, stdout: '', stderr: 'Error: No such container: x' }
+const inspectDaemonError: DockerExecResult = {
+  exitCode: 1,
+  stdout: '',
+  stderr: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock',
+}
+
+function fakeClock() {
+  let t = 0
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms
+    },
+    advance: (ms: number) => {
+      t += ms
+    },
+  }
+}
+
+describe('probeContainer', () => {
+  test('reports the parsed status when docker inspect exits 0', async () => {
+    const { exec } = scriptedExec({ inspect: [inspect('running')] })
+
+    const result = await probeContainer(exec, 'agent')
+
+    expect(result).toEqual({ kind: 'status', status: 'running' })
+  })
+
+  test('reports missing only when stderr matches "no such container/object"', async () => {
+    const { exec } = scriptedExec({ inspect: [inspectMissing] })
+
+    const result = await probeContainer(exec, 'agent')
+
+    expect(result).toEqual({ kind: 'missing' })
+  })
+
+  test('reports daemon-error when docker inspect fails for ANY other reason', async () => {
+    const { exec } = scriptedExec({ inspect: [inspectDaemonError] })
+
+    const result = await probeContainer(exec, 'agent')
+
+    expect(result.kind).toBe('daemon-error')
+    if (result.kind !== 'daemon-error') throw new Error('expected daemon-error')
+    expect(result.detail).toContain('Cannot connect to the Docker daemon')
+  })
+
+  test('reports daemon-error when docker inspect returns an unrecognized status', async () => {
+    const { exec } = scriptedExec({
+      inspect: [{ exitCode: 0, stdout: 'transmogrified\n', stderr: '' }],
+    })
+
+    const result = await probeContainer(exec, 'agent')
+
+    expect(result.kind).toBe('daemon-error')
+    if (result.kind !== 'daemon-error') throw new Error('expected daemon-error')
+    expect(result.detail).toMatch(/unrecognized status/)
+  })
+})
+
+describe('createVerifyRunning', () => {
+  test('returns ok when the first poll already shows running', async () => {
+    const { exec } = scriptedExec({ inspect: [inspect('running')] })
+    const clock = fakeClock()
+    const verify = createVerifyRunning({ exec, timeoutMs: 1000, intervalMs: 100, now: clock.now, sleep: clock.sleep })
+
+    const result = await verify('agent')
+
+    expect(result).toEqual({ ok: true })
+  })
+
+  test('does NOT crash-classify a container that polls created then running (startup latency)', async () => {
+    // Reproduces the false-positive we were after: docker run -d has returned,
+    // the daemon flipped State.SetRunning, but State.Status still briefly
+    // reads 'created' on a loaded host. The old design treated this as a crash.
+    const { exec } = scriptedExec({
+      inspect: [inspect('created'), inspect('created'), inspect('running')],
+    })
+    const clock = fakeClock()
+    const verify = createVerifyRunning({ exec, timeoutMs: 1000, intervalMs: 50, now: clock.now, sleep: clock.sleep })
+
+    const result = await verify('agent')
+
+    expect(result).toEqual({ ok: true })
+  })
+
+  test('keeps polling through restarting status until it resolves', async () => {
+    const { exec } = scriptedExec({
+      inspect: [inspect('restarting'), inspect('running')],
+    })
+    const clock = fakeClock()
+    const verify = createVerifyRunning({ exec, timeoutMs: 1000, intervalMs: 50, now: clock.now, sleep: clock.sleep })
+
+    const result = await verify('agent')
+
+    expect(result).toEqual({ ok: true })
+  })
+
+  test('classifies exited as a crash and captures logs', async () => {
+    const { exec, calls } = scriptedExec({
+      inspect: [inspect('exited')],
+      logs: [{ exitCode: 0, stdout: 'Cannot find package "missing"\n', stderr: '' }],
+    })
+    const clock = fakeClock()
+    const verify = createVerifyRunning({ exec, timeoutMs: 1000, intervalMs: 50, now: clock.now, sleep: clock.sleep })
+
+    const result = await verify('agent')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.mode).toBe('exited')
+    if (result.mode !== 'exited') throw new Error('expected exited')
+    expect(result.status).toBe('exited')
+    expect(result.logs).toEqual({ ok: true, text: 'Cannot find package "missing"' })
+    expect(calls.some((c) => c.args[0] === 'logs')).toBe(true)
+  })
+
+  test('classifies a missing container as removed (auto-cleaned by --rm)', async () => {
+    const { exec } = scriptedExec({
+      inspect: [inspectMissing],
+      logs: [{ exitCode: 1, stdout: '', stderr: 'Error: No such container: logs' }],
+    })
+    const clock = fakeClock()
+    const verify = createVerifyRunning({ exec, timeoutMs: 1000, intervalMs: 50, now: clock.now, sleep: clock.sleep })
+
+    const result = await verify('agent')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.mode).toBe('removed')
+  })
+
+  test('surfaces a daemon error WITHOUT misclassifying it as a container crash', async () => {
+    // The pre-refactor bug: any non-zero exit from `inspect` was treated as
+    // "container missing" -> crash. A Docker hiccup (socket timeout, 500,
+    // daemon restart) therefore produced a confident "your container crashed"
+    // message. Now those produce a distinct daemon-error mode.
+    const { exec } = scriptedExec({ inspect: [inspectDaemonError] })
+    const clock = fakeClock()
+    const verify = createVerifyRunning({ exec, timeoutMs: 1000, intervalMs: 50, now: clock.now, sleep: clock.sleep })
+
+    const result = await verify('agent')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.mode).toBe('daemon-error')
+  })
+
+  test('returns ok when timeout elapses with the container always running (full stability window)', async () => {
+    let polls = 0
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'inspect') {
+        polls += 1
+        return inspect('running')
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+    const clock = fakeClock()
+    const verify = createVerifyRunning({ exec, timeoutMs: 1000, intervalMs: 100, now: clock.now, sleep: clock.sleep })
+
+    const result = await verify('agent')
+
+    expect(result).toEqual({ ok: true })
+    expect(polls).toBeGreaterThan(1)
+  })
+
+  test('returns ok immediately and does NOT call inspect when timeoutMs is 0', async () => {
+    const { exec, calls } = scriptedExec({ inspect: [inspect('running')] })
+    const clock = fakeClock()
+    const verify = createVerifyRunning({ exec, timeoutMs: 0, now: clock.now, sleep: clock.sleep })
+
+    const result = await verify('agent')
+
+    expect(result).toEqual({ ok: true })
+    expect(calls.length).toBe(0)
+  })
+
+  test('docker logs is invoked with a signal so a stuck daemon does not hang verification', async () => {
+    let observedSignal: AbortSignal | undefined
+    const exec: DockerExec = async (args, options) => {
+      if (args[0] === 'inspect') return inspect('exited')
+      if (args[0] === 'logs') {
+        observedSignal = options?.signal
+        return { exitCode: 0, stdout: 'crash output\n', stderr: '' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+    const clock = fakeClock()
+    const verify = createVerifyRunning({
+      exec,
+      timeoutMs: 1000,
+      intervalMs: 50,
+      logsTimeoutMs: 250,
+      now: clock.now,
+      sleep: clock.sleep,
+    })
+
+    await verify('agent')
+
+    expect(observedSignal).toBeInstanceOf(AbortSignal)
+  })
+
+  test('preserves partial log output when docker logs eventually fails', async () => {
+    const { exec } = scriptedExec({
+      inspect: [inspect('exited')],
+      logs: [{ exitCode: 1, stdout: 'partial output before crash', stderr: 'lost connection' }],
+    })
+    const clock = fakeClock()
+    const verify = createVerifyRunning({ exec, timeoutMs: 1000, intervalMs: 50, now: clock.now, sleep: clock.sleep })
+
+    const result = await verify('agent')
+
+    expect(result.ok).toBe(false)
+    if (result.ok || result.mode === 'daemon-error') throw new Error('expected crash mode')
+    expect(result.logs.ok).toBe(false)
+    if (result.logs.ok) throw new Error('expected logs.ok=false')
+    expect(result.logs.error).toContain('partial logs preserved')
+  })
+})
+
+describe('buildCrashReason', () => {
+  test('formats the removed mode with captured logs', () => {
+    const failure: VerifyRunningResult = {
+      ok: false,
+      mode: 'removed',
+      logs: { ok: true, text: 'error: bad config' },
+    }
+    if (failure.ok) throw new Error('unreachable')
+
+    const reason = buildCrashReason('agent', failure)
+
+    expect(reason).toContain('exited and was auto-removed')
+    expect(reason).toContain('error: bad config')
+  })
+
+  test('formats the exited mode with the observed terminal status', () => {
+    const failure: VerifyRunningResult = {
+      ok: false,
+      mode: 'exited',
+      status: 'dead',
+      logs: { ok: true, text: 'segfault' },
+    }
+    if (failure.ok) throw new Error('unreachable')
+
+    const reason = buildCrashReason('agent', failure)
+
+    expect(reason).toMatch(/stopped running.*dead/)
+    expect(reason).toContain('segfault')
+  })
+
+  test('says "produced no logs" when capture succeeded but the container was silent', () => {
+    const failure: VerifyRunningResult = {
+      ok: false,
+      mode: 'removed',
+      logs: { ok: true, text: '' },
+    }
+    if (failure.ok) throw new Error('unreachable')
+
+    const reason = buildCrashReason('agent', failure)
+
+    expect(reason).toMatch(/produced no logs/)
+  })
+
+  test('surfaces the log read error when capture failed (not "no logs were captured")', () => {
+    const failure: VerifyRunningResult = {
+      ok: false,
+      mode: 'removed',
+      logs: { ok: false, error: 'docker logs timed out after 500ms' },
+    }
+    if (failure.ok) throw new Error('unreachable')
+
+    const reason = buildCrashReason('agent', failure)
+
+    expect(reason).toMatch(/Could not read container logs/)
+    expect(reason).toContain('docker logs timed out')
+  })
+
+  test('formats daemon-error as a distinct "could not verify" message', () => {
+    const failure: VerifyRunningResult = {
+      ok: false,
+      mode: 'daemon-error',
+      detail: 'Cannot connect to the Docker daemon',
+    }
+    if (failure.ok) throw new Error('unreachable')
+
+    const reason = buildCrashReason('agent', failure)
+
+    expect(reason).toMatch(/Could not verify/)
+    expect(reason).toContain('Cannot connect to the Docker daemon')
+  })
+})

--- a/src/container/verify-running.ts
+++ b/src/container/verify-running.ts
@@ -1,0 +1,144 @@
+import type { DockerExec } from './shared'
+
+export type ContainerLifeStatus = 'running' | 'created' | 'restarting' | 'paused' | 'exited' | 'dead' | 'removing'
+
+export type ContainerProbeResult =
+  | { kind: 'missing' }
+  | { kind: 'status'; status: ContainerLifeStatus }
+  | { kind: 'daemon-error'; detail: string }
+
+export type CrashLogs = { ok: true; text: string } | { ok: false; error: string }
+
+export type VerifyRunningResult =
+  | { ok: true }
+  | { ok: false; mode: 'removed'; logs: CrashLogs }
+  | { ok: false; mode: 'exited'; status: ContainerLifeStatus; logs: CrashLogs }
+  | { ok: false; mode: 'daemon-error'; detail: string }
+
+export type VerifyRunningFn = (containerName: string) => Promise<VerifyRunningResult>
+
+export type VerifyRunningOptions = {
+  exec: DockerExec
+  timeoutMs?: number
+  intervalMs?: number
+  logsTimeoutMs?: number
+  now?: () => number
+  sleep?: (ms: number) => Promise<void>
+}
+
+// Docker reports container State.Status as one of: created, running, paused,
+// restarting, removing, exited, dead. `created`/`restarting` are transient and
+// must NOT be classified as crashes — `docker run -d` returns once the daemon
+// has fired off `tsk.Start()` and called State.SetRunning, but on slow hosts
+// (Docker Desktop on macOS, loaded swarm nodes) the in-memory transition can
+// briefly trail the API return. Treating either as a crash produces false
+// positives; we keep polling until the state resolves OR the deadline hits.
+const TRANSIENT_STATUSES: ReadonlySet<ContainerLifeStatus> = new Set(['created', 'restarting'])
+const TERMINAL_STATUSES: ReadonlySet<ContainerLifeStatus> = new Set(['exited', 'dead', 'removing'])
+
+// Matches the stderr Docker emits when `docker inspect <name>` finds nothing.
+// Everything else — 500s, socket errors, permission denied, daemon restart —
+// must surface as a daemon-error rather than be misclassified as
+// "container does not exist".
+const NO_SUCH_CONTAINER = /no such (?:container|object)/i
+
+export function createVerifyRunning(options: VerifyRunningOptions): VerifyRunningFn {
+  const timeoutMs = options.timeoutMs ?? 1_500
+  const intervalMs = options.intervalMs ?? 100
+  const logsTimeoutMs = options.logsTimeoutMs ?? 500
+  const now = options.now ?? Date.now
+  const sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+  return async (containerName) => {
+    if (timeoutMs <= 0) return { ok: true }
+    const deadline = now() + timeoutMs
+    while (now() < deadline) {
+      const probe = await probeContainer(options.exec, containerName)
+      if (probe.kind === 'daemon-error') {
+        return { ok: false, mode: 'daemon-error', detail: probe.detail }
+      }
+      if (probe.kind === 'missing') {
+        const logs = await captureCrashLogs(options.exec, containerName, logsTimeoutMs)
+        return { ok: false, mode: 'removed', logs }
+      }
+      if (probe.status === 'running' || probe.status === 'paused') {
+        await sleepRespectingDeadline(sleep, intervalMs, now, deadline)
+        continue
+      }
+      if (TRANSIENT_STATUSES.has(probe.status)) {
+        await sleepRespectingDeadline(sleep, intervalMs, now, deadline)
+        continue
+      }
+      if (TERMINAL_STATUSES.has(probe.status)) {
+        const logs = await captureCrashLogs(options.exec, containerName, logsTimeoutMs)
+        return { ok: false, mode: 'exited', status: probe.status, logs }
+      }
+      await sleepRespectingDeadline(sleep, intervalMs, now, deadline)
+    }
+    return { ok: true }
+  }
+}
+
+async function sleepRespectingDeadline(
+  sleep: (ms: number) => Promise<void>,
+  intervalMs: number,
+  now: () => number,
+  deadline: number,
+): Promise<void> {
+  const remaining = deadline - now()
+  if (remaining <= 0) return
+  await sleep(Math.min(intervalMs, remaining))
+}
+
+export async function probeContainer(exec: DockerExec, name: string): Promise<ContainerProbeResult> {
+  const result = await exec(['inspect', '--format', '{{.State.Status}}', name])
+  if (result.exitCode === 0) {
+    const raw = result.stdout.trim().toLowerCase()
+    if (isLifeStatus(raw)) return { kind: 'status', status: raw }
+    return { kind: 'daemon-error', detail: `docker inspect returned unrecognized status: ${raw || '<empty>'}` }
+  }
+  if (NO_SUCH_CONTAINER.test(result.stderr)) return { kind: 'missing' }
+  const detail = result.stderr.trim() || `docker inspect exited with code ${result.exitCode}`
+  return { kind: 'daemon-error', detail }
+}
+
+function isLifeStatus(value: string): value is ContainerLifeStatus {
+  return (
+    value === 'running' ||
+    value === 'created' ||
+    value === 'restarting' ||
+    value === 'paused' ||
+    value === 'exited' ||
+    value === 'dead' ||
+    value === 'removing'
+  )
+}
+
+async function captureCrashLogs(exec: DockerExec, name: string, timeoutMs: number): Promise<CrashLogs> {
+  const signal = AbortSignal.timeout(timeoutMs)
+  const result = await exec(['logs', '--tail', '50', name], { signal })
+  const combined = `${result.stdout}${result.stderr}`.trim()
+  if (result.exitCode === 0) return { ok: true, text: combined }
+  if (signal.aborted) return { ok: false, error: `docker logs timed out after ${timeoutMs}ms` }
+  // Docker writes container stdout/stderr to stdout/stderr respectively for
+  // `docker logs`. Partial output is worth surfacing even when the command
+  // ultimately fails (e.g. container removed mid-read), so we keep `combined`
+  // alongside the docker-level error rather than discarding it.
+  const dockerError = result.stderr.trim() || `docker logs exited with code ${result.exitCode}`
+  if (combined.length > 0) return { ok: false, error: `${dockerError} (partial logs preserved)` }
+  return { ok: false, error: dockerError }
+}
+
+export function buildCrashReason(name: string, failure: Extract<VerifyRunningResult, { ok: false }>): string {
+  if (failure.mode === 'daemon-error') {
+    return `Could not verify container ${name} stayed running: ${failure.detail}`
+  }
+  const headline =
+    failure.mode === 'removed'
+      ? `Container ${name} exited and was auto-removed by Docker (--rm) immediately after start.`
+      : `Container ${name} stopped running immediately after start (state: ${failure.status}).`
+  if (failure.logs.ok) {
+    if (failure.logs.text.length === 0) return `${headline} Container produced no logs.`
+    return `${headline} Last logs:\n${failure.logs.text}`
+  }
+  return `${headline} Could not read container logs: ${failure.logs.error}`
+}


### PR DESCRIPTION
## Summary

Real-world report: `typeclaw start` reports success, then every other verb says the container is missing.

```
$ typeclaw start
Container <name> started on host port 8973 (<short-id>).
Host daemon active.
Follow logs:  typeclaw logs -f
Attach TUI:   typeclaw tui
Stop:         typeclaw stop

$ typeclaw logs -f
Container <name> not found. Run `typeclaw start` first.
```

`typeclaw tui` shows the same shape.

## Root cause

`docker run -d --rm` returns exit 0 the instant Docker writes the container record. If the entrypoint then crashes — bad command, missing binary in the image, Bun parse error in `typeclaw run`, anything — the container exits and Docker asynchronously removes it because of `--rm`. The previous gate in `start()` was:

```ts
if (run.exitCode !== 0) {
  return { ok: false, ... }
}
return { ok: true, containerId: run.stdout.trim(), ... }
```

So `start()` had no concept of "container stayed alive past birth", and a successful start() silently leaked into a downstream "container not found" state with no error surface.

## Fix

Add a `verifyRunning` step in `start()` after `docker run` exits 0, implemented in a new `src/container/verify-running.ts` module. The default verifier polls `docker inspect --format '{{.State.Status}}'` for 1.5s (100ms interval) and classifies the result against Docker's real container state machine, not a naive boolean `Running` check:

| `State.Status` returned | Classification | Action |
|---|---|---|
| `running`, `paused` | healthy | keep polling for the stability window |
| `created`, `restarting` | **transient** | keep polling — do NOT treat as crash |
| `exited`, `dead`, `removing` | terminal | capture logs, fail |
| inspect fails, stderr matches `/no such (?:container|object)/i` | `--rm` cleaned up | capture logs, fail with `mode: 'removed'` |
| inspect fails for any OTHER reason (500, socket timeout, daemon restart) | **daemon error** | fail with `mode: 'daemon-error'` and a distinct "could not verify" message |

The transient-status handling matters: on slow hosts (Docker Desktop on macOS VM overhead, loaded swarm nodes) the daemon's in-memory `State.SetRunning` transition can briefly trail the API return that `docker run -d` rides on, and a naive `{{.State.Running}}` boolean check produces false-positive crash reports. The `created` → `running` test in `verify-running.test.ts` locks this in.

The daemon-error distinction matters: the pre-refactor code treated ANY non-zero exit from `docker inspect` as "container does not exist", so a Docker hiccup produced a confident "your container crashed" message at the worst possible time. Now those fail with `Could not verify container <name> stayed running: <docker error>` instead.

`captureCrashLogs` runs `docker logs --tail 50` under `AbortSignal.timeout(500ms)` so a stuck daemon cannot wedge `typeclaw start` indefinitely. When `docker logs` exits non-zero, partial stdout/stderr is preserved alongside the docker-level error rather than being discarded — the previous design returned `''` and said "No container logs were captured" even when the docker error message was the diagnostic the user needed.

## API surface

`StartOptions` exposes a single optional field:

```ts
verifyRunning?: VerifyRunningFn  // (containerName: string) => Promise<VerifyRunningResult>
```

Default: `createVerifyRunning({ exec })` (the 1.5s polling implementation). Tests inject a no-op `async () => ({ ok: true })` or a scripted verifier. The previous draft exposed `verifyRunningTimeoutMs` / `verifyRunningIntervalMs` directly and admitted in the docstring they were test plumbing; replacing both with a function slot removes the leak.

## Diff scope

```
 src/container/shared.ts              |  21 ++-      # DockerExec: optional signal
 src/container/start.ts               |  21 ++-     # wire verifyRunning into start()
 src/container/start.test.ts          | 147 +++++-- # composition tests + bypassVerify
 src/container/verify-running.ts      | 144 ++++    # new module
 src/container/verify-running.test.ts | 331 ++++++ # new unit tests
 5 files changed, 657 insertions(+), 7 deletions(-)
```

## Testing

**`verify-running.test.ts`** — 19 focused unit tests with an injectable fake clock and scripted `DockerExec`, ~7ms total. Covers:

- `probeContainer`: parsed status, missing-container detection, daemon-error detection, unrecognized status.
- `createVerifyRunning`: first-poll happy path; **the `created` → `running` startup-latency case** that the original draft would have crash-classified; restarting → running; exited classified as crash with captured logs; missing classified as removed; daemon errors NOT misclassified as crashes; full stability window; `timeoutMs: 0` short-circuit; `docker logs` invoked with an `AbortSignal`; partial logs preserved on `docker logs` failure.
- `buildCrashReason`: each failure mode (removed / exited with status / silent container / log read failure / daemon-error) produces the right human-readable reason.

**`start.test.ts`** — three composition tests in a new `start (post-run verification composition)` block:

1. A failing verifier is routed into `ok: false` with the verifier-supplied reason, AND hostd cleanup runs (next start() can register cleanly).
2. The verifier runs AFTER `docker run` succeeds (not before).
3. The verifier is NOT invoked when `docker run` itself fails (no container to verify).

Existing 26 `start()` composition tests switched from the old `fastVerify` poll-window override to `...bypassVerify` (a no-op verifier). Net effect: legacy tests are decoupled from verification behavior, and the file runs in 1.6s instead of 5.9s.

## Pre-commit gate

```
$ bun run typecheck    →  clean
$ bun run lint         →  Found 0 warnings and 0 errors.
$ bun run format       →  clean
$ bun test             →  2411 pass, 0 fail (146 files, 26s)
```

## Self-review history

This PR was rewritten after a parallel self-review by Oracle and two `explore` agents flagged three high-severity issues in the original draft (commit `f354254`):

1. `inspectContainer` conflated Docker daemon errors with "container missing" — flaky daemons would produce confident false-positive crash reports.
2. `captureCrashLogs` silently dropped stderr on `docker logs` failure, hiding the actual error from users.
3. No coverage for the `created` / `restarting` → `running` startup-latency window — the original `{{.State.Running}}` boolean check would misreport slow-starting containers as crashes.

Plus three medium-severity issues (test-leaky public API, no timeout on `docker logs`, an `if (timeoutMs <= 0)` guard that wasn't actually exercised by its own test). All six are resolved in the current version.

## Out of scope

- The pre-`docker run` "container already exists" branch in `start.ts` had its own cleanup path and is unchanged.
- The `reportAlreadyRunning` idempotent path skips verification — by definition the container was running when `start()` was invoked.
- `restart()` composes `stop() + start()`, so it picks up the new behavior transitively with no change to the restart code path.
- WS-level / app-readiness probing (waiting for `typeclaw run` to actually accept connections) is a separate health concern, not container-process survival.