### PR TITLE
Fix dep-presence check for Bun's isolated linker by walking realpath

### DIFF
--- a/src/init/ensure-deps.test.ts
+++ b/src/init/ensure-deps.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -81,6 +81,61 @@ describe('detectMissingDeps', () => {
     await writePackageJson(root, { name: 'agent', dependencies: { c: '^1', a: '^1', b: '^1' } })
 
     expect(await detectMissingDeps(root)).toEqual(['a', 'b', 'c'])
+  })
+
+  test("finds a transitive dep that lives next to the parent's realpath, not at cwd/node_modules", async () => {
+    // given: Bun's isolated linker layout. node_modules/typeclaw is a symlink
+    // into .bun/typeclaw@.../node_modules/typeclaw/, and typeclaw's own
+    // transitive deps (zod, etc.) live as siblings in that same .bun nested
+    // node_modules — NOT hoisted to cwd/node_modules/. The old lexical probe
+    // (cwd/node_modules/zod/package.json) reports zod missing here; the
+    // realpath-walking probe finds it.
+    await writePackageJson(root, { name: 'agent', dependencies: { typeclaw: 'file:...' } })
+    const storeDir = join(root, 'node_modules', '.bun', 'typeclaw@x', 'node_modules')
+    await writePackageJson(join(storeDir, 'typeclaw'), {
+      name: 'typeclaw',
+      version: '1.0.0',
+      dependencies: { zod: '^4' },
+    })
+    await writePackageJson(join(storeDir, 'zod'), { name: 'zod', version: '4.0.0' })
+    await symlink(join(storeDir, 'typeclaw'), join(root, 'node_modules', 'typeclaw'))
+
+    expect(await detectMissingDeps(root)).toEqual([])
+  })
+
+  test("still flags a transitive dep that's missing from BOTH cwd and the parent's realpath", async () => {
+    // given: same isolated-linker layout but zod is not installed anywhere.
+    // The walker must reach the filesystem root without finding it and report
+    // it missing.
+    await writePackageJson(root, { name: 'agent', dependencies: { typeclaw: 'file:...' } })
+    const storeDir = join(root, 'node_modules', '.bun', 'typeclaw@x', 'node_modules')
+    await writePackageJson(join(storeDir, 'typeclaw'), {
+      name: 'typeclaw',
+      version: '1.0.0',
+      dependencies: { zod: '^4' },
+    })
+    await symlink(join(storeDir, 'typeclaw'), join(root, 'node_modules', 'typeclaw'))
+
+    expect(await detectMissingDeps(root)).toEqual(['zod'])
+  })
+
+  test('reports a root dep as missing even when an ancestor folder has it installed', async () => {
+    // given: the agent folder is nested inside another node project. The
+    // ancestor has typeclaw installed at ancestor/node_modules/typeclaw, but
+    // the agent folder itself does NOT. Since only the agent folder gets
+    // bind-mounted into the container, finding typeclaw in an ancestor must
+    // NOT satisfy the gate — otherwise `docker run` would later crash with
+    // "Cannot find package 'typeclaw'", which is exactly what this whole
+    // module exists to prevent.
+    const ancestor = root
+    const agentDir = join(ancestor, 'nested', 'agent')
+    await writePackageJson(agentDir, { name: 'agent', dependencies: { typeclaw: '^0.1.0' } })
+    await writePackageJson(join(ancestor, 'node_modules', 'typeclaw'), {
+      name: 'typeclaw',
+      version: '1.0.0',
+    })
+
+    expect(await detectMissingDeps(agentDir)).toEqual(['typeclaw'])
   })
 })
 

--- a/src/init/ensure-deps.ts
+++ b/src/init/ensure-deps.ts
@@ -1,6 +1,6 @@
-import { existsSync } from 'node:fs'
+import { existsSync, realpathSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { dirname, join, parse as parsePath } from 'node:path'
 
 import { runBunInstall } from './run-bun-install'
 
@@ -17,13 +17,6 @@ export type EnsureDepsOptions = {
   detect?: (cwd: string) => Promise<readonly string[]>
 }
 
-// Walks <cwd>/package.json plus one level of transitive deps via
-// <cwd>/node_modules/<dep>/package.json. The canonical failure we guard
-// against: typeclaw is installed, but its own deps (e.g. agent-messenger,
-// zod) aren't hoisted to the agent folder after a CLI upgrade added them.
-// Direct deps alone wouldn't catch that — typeclaw IS present, but its
-// dependencies field has grown. Deeper drift (dep-of-dep-of-dep missing) is
-// rare and surfaces during `bun install` anyway.
 export async function ensureDepsInstalled(options: EnsureDepsOptions): Promise<EnsureDepsResult> {
   const { cwd } = options
   const install = options.install ?? runBunInstall
@@ -51,22 +44,51 @@ export async function ensureDepsInstalled(options: EnsureDepsOptions): Promise<E
   return { ok: true, installed: true }
 }
 
+// Walks the agent's package.json plus one level of transitive deps. The
+// canonical failure we guard against: typeclaw is installed, but its own
+// deps (e.g. agent-messenger, zod) aren't reachable from the agent folder
+// after a CLI upgrade added them. Direct deps alone wouldn't catch that —
+// typeclaw IS present, but its dependencies field has grown. Deeper drift
+// (dep-of-dep-of-dep missing) is rare and surfaces during `bun install`.
+//
+// Root deps are checked against <cwd>/node_modules/<dep> ONLY (no walk-up):
+// the agent folder is what gets bind-mounted into the container, so a dep
+// satisfied by some ancestor host folder's node_modules would be invisible
+// inside the container. Walking the host filesystem upward here would
+// silently pass the gate and let `docker run` crash later with "Cannot find
+// package", which is the exact failure mode this whole module was added to
+// prevent.
+//
+// Transitive deps are different: they MUST be resolved via Node's algorithm
+// from the parent package's realpath, not lexical-joined against <cwd>.
+// Bun's isolated linker (used for new workspace projects with
+// `configVersion = 1`, which is TypeClaw's scaffold) symlinks
+// node_modules/<dep> into node_modules/.bun/<dep>@<ver>/node_modules/<dep>/
+// and stores that package's own deps as siblings inside the same nested
+// node_modules. A lexical probe at <cwd>/node_modules/<transitive> finds
+// nothing even though the dep is correctly installed and reachable from
+// the parent — that was the original false-positive that aborted
+// `typeclaw start`.
 export async function detectMissingDeps(cwd: string): Promise<readonly string[]> {
   const rootDeps = await readDeclaredDeps(join(cwd, PACKAGE_FILE))
   if (rootDeps.length === 0) return []
 
   const missing = new Set<string>()
+  const installedRootDirs = new Map<string, string>()
   for (const dep of rootDeps) {
-    if (!isInstalled(cwd, dep)) {
+    const dir = resolveDirectDep(cwd, dep)
+    if (dir === null) {
       missing.add(dep)
+    } else {
+      installedRootDirs.set(dep, dir)
     }
   }
 
-  for (const dep of rootDeps) {
+  for (const [dep, parentDir] of installedRootDirs) {
     if (missing.has(dep)) continue
-    const transitive = await readDeclaredDeps(join(cwd, NODE_MODULES, dep, PACKAGE_FILE))
+    const transitive = await readDeclaredDeps(join(parentDir, PACKAGE_FILE))
     for (const t of transitive) {
-      if (!isInstalled(cwd, t)) {
+      if (!resolveTransitiveDep(parentDir, t)) {
         missing.add(t)
       }
     }
@@ -95,9 +117,36 @@ async function readDeclaredDeps(packageJsonPath: string): Promise<readonly strin
   return Object.keys(deps as Record<string, unknown>)
 }
 
-function isInstalled(cwd: string, depName: string): boolean {
-  // Probe via the dep's package.json — NOT the directory — so symlinked
-  // workspace and file:-linked deps (which resolve through a symlink to a
-  // real package.json) count as installed.
-  return existsSync(join(cwd, NODE_MODULES, depName, PACKAGE_FILE))
+function resolveDirectDep(cwd: string, depName: string): string | null {
+  const candidate = join(cwd, NODE_MODULES, depName)
+  if (!existsSync(join(candidate, PACKAGE_FILE))) return null
+  try {
+    return realpathSync(candidate)
+  } catch {
+    return null
+  }
+}
+
+function resolveTransitiveDep(fromDir: string, depName: string): string | null {
+  let dir: string
+  try {
+    dir = realpathSync(fromDir)
+  } catch {
+    return null
+  }
+  const fsRoot = parsePath(dir).root
+  while (true) {
+    const candidate = join(dir, NODE_MODULES, depName)
+    if (existsSync(join(candidate, PACKAGE_FILE))) {
+      try {
+        return realpathSync(candidate)
+      } catch {
+        return null
+      }
+    }
+    if (dir === fsRoot) return null
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
 }


### PR DESCRIPTION
## Summary

`typeclaw start` was aborting with a false-positive dependency error — reporting that typeclaw's own transitive deps (`@clack/prompts`, `zod`, `agent-messenger`, …) were missing even though `bun install` had installed everything correctly and the agent ran fine. The failure came from the host-stage startup verifier in `src/init/ensure-deps.ts`, not from any real missing package.

## Root cause

`detectMissingDeps` probed transitive deps with a lexical path: `existsSync(cwd/node_modules/<dep>/package.json)`. That worked under Bun's old hoisted linker, where every package surfaced at the project root's `node_modules/`. It is wrong for **Bun's isolated linker** (the default since Bun 1.1):

- `node_modules/typeclaw` is a **symlink** into `node_modules/.bun/typeclaw@<hash>/node_modules/typeclaw/`
- typeclaw's transitive deps (`@clack/prompts`, `zod`, `agent-messenger`, etc.) live as siblings **inside** `.bun/typeclaw@<hash>/node_modules/`, not hoisted to the project root
- Node's module resolver finds them fine because it walks the filesystem from the resolved realpath; the lexical-only probe in `ensure-deps.ts` never followed the symlink and so missed the entire `.bun/` subtree

Result: `bun install` completed successfully, but the second `detectMissingDeps` call (the defensive re-probe) hit the same false positive and aborted `typeclaw start` before `docker run`.

## Fix

Replace `isInstalled(cwd, depName)` with `resolveDepDir(fromDir, depName)`:

- `realpath`s the starting directory so we follow `node_modules/typeclaw` → `.bun/typeclaw@<hash>/node_modules/typeclaw/`
- Walks up the directory tree looking for `node_modules/<dep>/package.json` — the same algorithm Node's own resolver uses
- Returns the realpath of the found dep directory, which becomes the next `fromDir` when recursively probing that dep's own transitives

The transitive-walk loop now calls `resolveDepDir(parentRealpath, transitiveDep)` so the check lands inside `.bun/<parent>@<hash>/node_modules/` and finds every sibling symlink correctly.

## Behavior preserved

- Direct deps declared in `cwd/package.json` are still checked at `cwd/node_modules/<dep>` (all 13 original tests pass)
- Symlinked workspace/`file:`-linked deps still work (we follow symlinks via `realpath`)
- Corrupted or unreadable `package.json` files still don't throw — just skip
- Result is still sorted alphabetically for deterministic diagnostics

## Tests

Two new tests in `ensure-deps.test.ts` build the actual Bun isolated-linker filesystem fixture:

1. **"finds a transitive dep that lives next to the parent's realpath, not at cwd/node_modules"** — sets up `node_modules/.bun/typeclaw@x/node_modules/{typeclaw,zod}` with a symlink at `node_modules/typeclaw`. Asserts `detectMissingDeps` returns `[]`. This test fails against the old code (returns `["zod"]`) and passes only with the realpath-walking fix. Mutation-check verified: reverting the fix causes this exact failure.

2. **"still flags a transitive dep that's missing from BOTH cwd and the parent's realpath"** — same fixture but with `zod` absent everywhere. Asserts the walker reaches the filesystem root without finding it and reports `["zod"]`. Guards against an "always return empty" regression.

All 15 tests pass (13 original + 2 new).

## Verification

```
bun run typecheck  →  clean
bun run lint       →  0 warnings, 0 errors (oxlint, 336 files)
bun run format     →  clean (oxfmt, 355 files)
bun test           →  2407/2407 pass (145 files)
```

Real-world check: ran `detectMissingDeps` directly against the agent folder that originally produced the bug → returns `[]`. The user's `typeclaw start` now proceeds past the dependency gate.