### PR TITLE
Rename typeclaw compose up/down to start/stop

### DIFF
--- a/src/cli/compose.ts
+++ b/src/cli/compose.ts
@@ -1,18 +1,18 @@
 import { defineCommand } from 'citty'
 
 import {
-  composeDown,
   composeLogs,
   composePs,
   composeRestart,
-  composeUp,
+  composeStart,
+  composeStop,
   type AgentResult,
   type AgentStatus,
 } from '@/compose'
 import { config } from '@/config'
 
-const upSub = defineCommand({
-  meta: { name: 'up', description: 'start every agent in immediate subdirectories of cwd' },
+const startSub = defineCommand({
+  meta: { name: 'start', description: 'start every agent in immediate subdirectories of cwd' },
   args: {
     port: {
       type: 'string',
@@ -26,7 +26,7 @@ const upSub = defineCommand({
     },
   },
   async run({ args }) {
-    const { agents, results } = await composeUp({
+    const { agents, results } = await composeStart({
       rootCwd: process.cwd(),
       preferredHostPort: Number(args.port),
       forceBuild: args.build,
@@ -46,15 +46,15 @@ const upSub = defineCommand({
         console.error(`[${r.name}] failed: ${r.reason}`)
       }
     }
-    summarize(results, 'up', failed)
+    summarize(results, 'started', failed)
     if (failed > 0) process.exit(1)
   },
 })
 
-const downSub = defineCommand({
-  meta: { name: 'down', description: 'stop every agent in immediate subdirectories of cwd' },
+const stopSub = defineCommand({
+  meta: { name: 'stop', description: 'stop every agent in immediate subdirectories of cwd' },
   async run() {
-    const { agents, results } = await composeDown(process.cwd())
+    const { agents, results } = await composeStop(process.cwd())
     if (agents.length === 0) {
       console.log('No typeclaw agents found in immediate subdirectories of cwd.')
       return
@@ -164,8 +164,8 @@ export const composeCommand = defineCommand({
     description: 'orchestrate every typeclaw agent in immediate subdirectories of cwd',
   },
   subCommands: {
-    up: upSub,
-    down: downSub,
+    start: startSub,
+    stop: stopSub,
     restart: restartSub,
     ps: psSub,
     logs: logsSub,

--- a/src/compose/index.ts
+++ b/src/compose/index.ts
@@ -1,6 +1,12 @@
 export { discoverAgents, type AgentEntry } from './discover'
-export { composeDown, type ComposeDownResult, type StopSuccess } from './down'
 export { colorFor, composeLogs, makeLinePrefixer, type ComposeLogsOptions, type ComposeLogsResult } from './logs'
 export { composePs, type AgentStatus, type AgentStatusEntry, type ComposePsResult } from './ps'
 export { composeRestart, type ComposeRestartOptions, type ComposeRestartResult, type RestartData } from './restart'
-export { composeUp, type AgentResult, type ComposeUpOptions, type ComposeUpResult, type StartSuccess } from './up'
+export {
+  composeStart,
+  type AgentResult,
+  type ComposeStartOptions,
+  type ComposeStartResult,
+  type StartSuccess,
+} from './start'
+export { composeStop, type ComposeStopResult, type StopSuccess } from './stop'

--- a/src/compose/restart.ts
+++ b/src/compose/restart.ts
@@ -2,8 +2,8 @@ import { validateConfig } from '@/config'
 import { start, stop } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
-import type { StopSuccess } from './down'
-import type { AgentResult, StartSuccess } from './up'
+import type { AgentResult, StartSuccess } from './start'
+import type { StopSuccess } from './stop'
 
 export type RestartData = { stop: StopSuccess; start: StartSuccess }
 

--- a/src/compose/start.ts
+++ b/src/compose/start.ts
@@ -7,24 +7,24 @@ export type AgentResult<T> = { name: string; ok: true; data: T } | { name: strin
 
 export type StartSuccess = Extract<StartResult, { ok: true }>
 
-export type ComposeUpOptions = {
+export type ComposeStartOptions = {
   rootCwd: string
   preferredHostPort: number
   forceBuild?: boolean
   cliEntry?: string
 }
 
-export type ComposeUpResult = {
+export type ComposeStartResult = {
   agents: AgentEntry[]
   results: AgentResult<StartSuccess>[]
 }
 
-export async function composeUp({
+export async function composeStart({
   rootCwd,
   preferredHostPort,
   forceBuild = false,
   cliEntry,
-}: ComposeUpOptions): Promise<ComposeUpResult> {
+}: ComposeStartOptions): Promise<ComposeStartResult> {
   const agents = discoverAgents(rootCwd)
   const results = await Promise.all(
     agents.map(async (agent): Promise<AgentResult<StartSuccess>> => {

--- a/src/compose/stop.ts
+++ b/src/compose/stop.ts
@@ -1,16 +1,16 @@
 import { stop, type StopResult } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
-import type { AgentResult } from './up'
+import type { AgentResult } from './start'
 
 export type StopSuccess = Extract<StopResult, { ok: true }>
 
-export type ComposeDownResult = {
+export type ComposeStopResult = {
   agents: AgentEntry[]
   results: AgentResult<StopSuccess>[]
 }
 
-export async function composeDown(rootCwd: string): Promise<ComposeDownResult> {
+export async function composeStop(rootCwd: string): Promise<ComposeStopResult> {
   const agents = discoverAgents(rootCwd)
   const results = await Promise.all(
     agents.map(async (agent): Promise<AgentResult<StopSuccess>> => {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -115,7 +115,7 @@ export async function start({
     // Probe container state BEFORE refreshing Dockerfile/.gitignore: when the
     // container is already running, start() is a no-op and must not produce
     // side effects (template writes, .gitignore commits, package.json migration)
-    // that would surprise a user invoking `compose up` against a partially-up
+    // that would surprise a user invoking `compose start` against a partially-up
     // tree.
     const state = await inspectContainer(exec, containerName)
     if (state.exists && state.running) {


### PR DESCRIPTION
## Why

The top-level CLI already speaks \`start\`/\`stop\`/\`restart\` (see \`AGENTS.md\` → "Stages" → host stage). \`typeclaw compose\` was the lone outlier with \`up\`/\`down\`, lifted from \`docker compose\`. But typeclaw compose isn't docker compose — it's a multi-folder fan-out of the same host-stage launchers. Carrying the docker vocabulary just forced users to translate verbs between layers.

After this PR, every host-stage launcher uses the same verbs:

| Before                  | After                      |
| ----------------------- | -------------------------- |
| \`typeclaw compose up\`   | \`typeclaw compose start\`   |
| \`typeclaw compose down\` | \`typeclaw compose stop\`    |
| \`typeclaw compose restart\` | (unchanged) |
| \`typeclaw compose ps\`   | (unchanged) |
| \`typeclaw compose logs\` | (unchanged) |

## What changed

- \`src/compose/up.ts\` → \`src/compose/start.ts\`. \`composeUp\` → \`composeStart\`; \`ComposeUpOptions\` / \`ComposeUpResult\` → \`ComposeStartOptions\` / \`ComposeStartResult\`. \`AgentResult\` / \`StartSuccess\` exports preserved at the same module.
- \`src/compose/down.ts\` → \`src/compose/stop.ts\`. \`composeDown\` → \`composeStop\`; \`ComposeDownResult\` → \`ComposeStopResult\`. \`StopSuccess\` export preserved at the same module.
- \`src/compose/index.ts\` re-exports updated; \`src/compose/restart.ts\` import paths updated.
- \`src/cli/compose.ts\` subcommand keys \`up\` / \`down\` → \`start\` / \`stop\`, descriptions and the \`up\` summary verb (\`'up'\` → \`'started'\`) updated.
- \`src/container/start.ts:117\` comment reference \`\\\`compose up\\\`\` → \`\\\`compose start\\\`\`. The \`docker compose up\` reference at \`:434\` is intentionally left alone — that names Docker's CLI, not ours.
- No production code outside of these files referenced \`composeUp\` / \`composeDown\` or the old subcommand names; \`README.md\` only mentions \`typeclaw compose\` umbrella-level.

## Verification

- \`bun run typecheck\` — clean (\`tsgo --noEmit\`)
- \`bun run lint\` — 0 warnings, 0 errors (oxlint, 336 files)
- \`bun run format\` — applied (oxfmt, 355 files; no diff after rewrite)
- \`bun test\` — 2408 pass / 0 fail across 145 files

## Breaking change

This is a user-facing CLI rename with no alias for the old verbs. Anyone running \`typeclaw compose up\` from a script will get the citty \"unknown subcommand\" error. Given typeclaw's pre-1.0 status and the small surface area, I left it as a clean break — easy to add aliases later if it bites. Happy to add them now if you'd prefer.