### PR TITLE
Fix stop() leaving a stale corpse when docker inspect exits non-zero with a non-fatal error

### DIFF
--- a/src/container/stop.test.ts
+++ b/src/container/stop.test.ts
@@ -32,6 +32,8 @@ type FakeOptions = {
   stopFails?: boolean
   rmStderr?: string
   rmExitCode?: number
+  inspectExitCode?: number
+  inspectStderr?: string
 }
 
 function fakeDockerExec(options: FakeOptions): { exec: DockerExec; calls: string[][] } {
@@ -40,6 +42,9 @@ function fakeDockerExec(options: FakeOptions): { exec: DockerExec; calls: string
   const exec: DockerExec = async (args): Promise<DockerExecResult> => {
     calls.push(args)
     if (args[0] === 'inspect') {
+      if (options.inspectExitCode !== undefined && options.inspectExitCode !== 0) {
+        return { exitCode: options.inspectExitCode, stdout: '', stderr: options.inspectStderr ?? '' }
+      }
       if (!scenario.exists) return { exitCode: 1, stdout: '', stderr: 'Error: No such container: x' }
       return { exitCode: 0, stdout: `${scenario.running}\n`, stderr: '' }
     }
@@ -86,7 +91,7 @@ describe('stop (composition)', () => {
     expect(rmIdx).toBeGreaterThan(stopIdx)
   })
 
-  test('skips docker stop but still issues docker rm when the container exists in stopped state (post-crash corpse)', async () => {
+  test('skips docker stop but still issues docker rm -f when the container exists in stopped state (post-crash corpse)', async () => {
     const { exec, calls } = fakeDockerExec({ scenario: { exists: true, running: false } })
 
     const result = await stop({ cwd: root, exec })
@@ -95,7 +100,7 @@ describe('stop (composition)', () => {
     if (!result.ok) return
     expect(result.running).toBe(false)
     expect(calls.find((c) => c[0] === 'stop')).toBeUndefined()
-    expect(calls.find((c) => c[0] === 'rm')).toBeDefined()
+    expect(calls.find((c) => c[0] === 'rm' && c[1] === '-f')).toBeDefined()
   })
 
   test('tolerates "no such container" from docker rm (user removed it out-of-band)', async () => {
@@ -136,5 +141,52 @@ describe('stop (composition)', () => {
     if (result.ok) throw new Error('expected failure')
     expect(result.reason).toMatch(/docker stop failed/)
     expect(calls.find((c) => c[0] === 'rm')).toBeUndefined()
+  })
+
+  test('force-removes the corpse when docker inspect fails with a non-"no such container" error', async () => {
+    const { exec, calls } = fakeDockerExec({
+      scenario: { exists: true, running: false },
+      inspectExitCode: 1,
+      inspectStderr: 'Error response from daemon: removal of container abc is already in progress',
+    })
+
+    const result = await stop({ cwd: root, exec })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.running).toBe(false)
+    expect(calls.find((c) => c[0] === 'rm' && c[1] === '-f')).toBeDefined()
+  })
+
+  test('short-circuits without docker rm when docker inspect reports the container truly does not exist', async () => {
+    const { exec, calls } = fakeDockerExec({
+      scenario: { exists: false },
+      inspectExitCode: 1,
+      inspectStderr: 'Error: No such container: anderson',
+    })
+
+    const result = await stop({ cwd: root, exec })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.running).toBe(false)
+    expect(calls.find((c) => c[0] === 'rm')).toBeUndefined()
+  })
+
+  test('surfaces a clear error when docker inspect fails AND the recovery docker rm -f also fails', async () => {
+    const { exec } = fakeDockerExec({
+      scenario: { exists: true, running: false },
+      inspectExitCode: 1,
+      inspectStderr: 'Error response from daemon: removal of container abc is already in progress',
+      rmExitCode: 1,
+      rmStderr: 'permission denied',
+    })
+
+    const result = await stop({ cwd: root, exec })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toMatch(/docker inspect failed/)
+    expect(result.reason).toMatch(/docker rm -f could not recover.*permission denied/)
   })
 })

--- a/src/container/stop.ts
+++ b/src/container/stop.ts
@@ -23,6 +23,22 @@ export async function stop({ cwd, exec = defaultDockerExec }: StopOptions): Prom
   try {
     const inspect = await exec(['inspect', '--format', '{{.State.Running}}', containerName], { cwd })
     if (inspect.exitCode !== 0) {
+      // `docker inspect` exits non-zero both when the container does not
+      // exist AND when it exists but is in a transient state docker cannot
+      // inspect (Removal In Progress, Dead, daemon hiccup). Discriminate by
+      // stderr — same approach used for `docker rm` below — and attempt a
+      // force-remove in the latter case so a corpse holding the name does
+      // not collide with the next `docker run --name <same>`.
+      if (inspect.stderr.toLowerCase().includes('no such container')) {
+        return { ok: true, containerName, running: false }
+      }
+      const recover = await exec(['rm', '-f', containerName], { cwd })
+      if (recover.exitCode !== 0 && !recover.stderr.toLowerCase().includes('no such container')) {
+        return {
+          ok: false,
+          reason: `docker inspect failed (${inspect.stderr.trim() || 'no stderr'}) and docker rm -f could not recover: ${recover.stderr.trim() || 'no stderr'}`,
+        }
+      }
       return { ok: true, containerName, running: false }
     }
     const running = inspect.stdout.trim() === 'true'
@@ -41,9 +57,12 @@ export async function stop({ cwd, exec = defaultDockerExec }: StopOptions): Prom
     // Containers run without `--rm`, so `docker stop` only stops them — the
     // record stays in `docker ps -a` until we remove it explicitly. Remove now
     // so a subsequent `docker run --name <same>` (e.g. from `typeclaw restart`)
-    // does not collide on the name. Tolerate "no such container" because the
-    // user may have removed it out-of-band between inspect and rm.
-    const rmResult = await exec(['rm', containerName], { cwd })
+    // does not collide on the name. Use `-f` for symmetry with the start.ts
+    // preflight and because `docker stop` occasionally returns exit 0 before
+    // the container is fully out of `Running` state on OrbStack under load —
+    // bare `docker rm` would then refuse a still-running container. Tolerate
+    // "no such container" because the user may have removed it out-of-band.
+    const rmResult = await exec(['rm', '-f', containerName], { cwd })
     if (rmResult.exitCode !== 0 && !rmResult.stderr.toLowerCase().includes('no such container')) {
       return { ok: false, reason: `docker rm failed: ${rmResult.stderr.trim() || 'no stderr'}` }
     }


### PR DESCRIPTION
## Summary

`typeclaw restart` (and any subsequent `typeclaw start`) could fail with a Docker name-conflict error even though `typeclaw stop` reported success:

```
$ typeclaw restart
Container anderson is not running.
...
docker: Error response from daemon: Conflict. The container name "/anderson" is already in use
by container "dcbdcaa9e9…". You have to remove (or rename) that container to be able to reuse that name.
```

The stale container was real — `docker ps -a` showed it in `Removal In Progress` or `Dead` state — but `typeclaw stop` reported it as cleanly gone, leaving a corpse that blocked every subsequent `docker run --name anderson`.

## Root cause

`stop()` in `src/container/stop.ts` uses `docker inspect` to determine whether the container is running before deciding to call `docker stop`. When `docker inspect` exits non-zero, the code short-circuited immediately:

```ts
if (inspect.exitCode !== 0) {
  return { ok: true, containerName, running: false }   // ← always, no discrimination
}
```

`docker inspect` exits non-zero in two distinct situations:

1. **Container does not exist.** Correct to short-circuit.
2. **Container exists but is in a transient/terminal state** Docker cannot represent as JSON (`Removal In Progress`, `Dead`, daemon hiccup). The container name is still held; the next `docker run --name <same>` will fail with a conflict.

The asymmetry was hiding in plain sight: the `docker rm` call a few lines below already discriminates by stderr — `stderr.toLowerCase().includes('no such container')` — to tolerate out-of-band removals. The inspect branch did not use the same pattern, so both failure modes collapsed into the same short-circuit.

This was introduced by PR #112 ("Stop passing `--rm` to docker run so crashed container logs survive"), which rewrote `stop()` to add an explicit `docker rm` after `docker stop`. The `docker rm` logic got the discriminating stderr check right; the `docker inspect` logic missed it.

## Fix

**1. Discriminate `docker inspect` failure by stderr** (`src/container/stop.ts`)

On non-zero exit from `docker inspect`:
- If stderr contains `"no such container"` → legitimate absence, short-circuit as before (behavior preserved).
- Otherwise → the container is present but uninspectable. Attempt `docker rm -f` as recovery. If recovery succeeds (including the container disappearing mid-rm, which is tolerated), return `ok: true`. If recovery also fails, return `ok: false` with a composite message that names both the inspect error and the rm error so the user can act on it.

**2. Upgrade post-`docker stop` cleanup to `docker rm -f`** (`src/container/stop.ts`)

The bare `docker rm` after a successful `docker stop` is promoted to `docker rm -f`, for two reasons:
- Symmetry with the `start.ts` preflight (line 160), which already uses `docker rm -f` to remove a pre-existing stopped container before `docker run`.
- OrbStack under load occasionally returns exit 0 from `docker stop` before the container is fully out of `Running` state. A bare `docker rm` would refuse a still-running container; `docker rm -f` covers this without introducing noise on the happy path.

## Test coverage

`src/container/stop.test.ts` extends the `fakeDockerExec` test helper with two new knobs (`inspectExitCode`, `inspectStderr`) that allow scripting the inspect failure path independently of the container scenario. Three regression tests added:

1. **Inspect failure with non-NSC stderr triggers `docker rm -f`.** Simulate `docker inspect` returning exit 1 with `"removal of container abc is already in progress"`. Assert `result.ok === true` and that `rm -f` was issued.
2. **Inspect failure with NSC stderr still short-circuits.** Simulate `docker inspect` returning exit 1 with `"No such container: anderson"`. Assert `result.ok === true` and that no `rm` call was made (the legitimate "doesn't exist" path is untouched).
3. **Inspect failure + recovery rm failure surfaces composite error.** Simulate inspect exit 1 (non-NSC) AND `docker rm -f` exit 1. Assert `result.ok === false` and that `result.reason` matches both `/docker inspect failed/` and `/docker rm -f could not recover.*<rm stderr>/`.

Existing corpse test updated to assert `-f` flag explicitly (`rm -f` instead of `rm`), locking in the post-`docker stop` upgrade.

## Manual recovery for affected users

If you are currently stuck with a stopped container blocking `typeclaw start`, run:

```sh
docker rm -f <agent-name>
typeclaw start
```

`typeclaw stop` after this fix handles the cleanup automatically on every subsequent call.

## Verification

```
bun run typecheck  →  clean
bun run lint       →  0 warnings, 0 errors (oxlint)
bun run format:check  →  clean (oxfmt)
bun test           →  2414 pass, 0 fail (10/10 in stop.test.ts)
```