### PR TITLE
Polish host-stage CLI output with shared color/spinner helpers

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -15,6 +15,8 @@ import {
 } from '@/init'
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 
+import { c, done, errorLine } from './ui'
+
 const CHANNEL_LABELS: Record<ChannelKind, string> = {
   'slack-bot': 'Slack',
   'discord-bot': 'Discord',
@@ -38,7 +40,7 @@ const addSub = defineCommand({
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
 
     if (!isInitialized(cwd)) {
-      console.error('TypeClaw config file not found. Run `typeclaw init` first, or cd into an agent folder.')
+      console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first, or cd into an agent folder.'))
       process.exit(1)
     }
 
@@ -58,11 +60,11 @@ const addSub = defineCommand({
         onProgress: reportProgress(events),
       })
     } catch (error) {
-      console.error(error instanceof Error ? error.message : String(error))
+      console.error(errorLine(error instanceof Error ? error.message : String(error)))
       process.exit(1)
     }
 
-    await maybePromptRestart(cwd)
+    await maybePromptRestart(cwd, channel)
   },
 })
 
@@ -78,12 +80,14 @@ export const channelCommand = defineCommand({
 
 function validateAdapterArg(adapter: string, configured: Set<ChannelKind>): ChannelKind {
   if (!isChannelKind(adapter)) {
-    console.error(`Unknown adapter "${adapter}". Expected one of: ${CHANNEL_KINDS.join(', ')}.`)
+    console.error(errorLine(`Unknown adapter "${adapter}". Expected one of: ${CHANNEL_KINDS.join(', ')}.`))
     process.exit(1)
   }
   if (configured.has(adapter)) {
     console.error(
-      `${CHANNEL_LABELS[adapter]} ("${adapter}") is already configured in typeclaw.json. Edit the file directly to change its allow list.`,
+      errorLine(
+        `${CHANNEL_LABELS[adapter]} ("${adapter}") is already configured in typeclaw.json. Edit the file directly to change its allow list.`,
+      ),
     )
     process.exit(1)
   }
@@ -97,7 +101,7 @@ function isChannelKind(value: string): value is ChannelKind {
 async function pickChannel(configured: Set<ChannelKind>): Promise<ChannelKind> {
   const available = CHANNEL_KINDS.filter((kind) => !configured.has(kind))
   if (available.length === 0) {
-    console.error('All supported channel adapters are already configured in typeclaw.json. Nothing to add.')
+    console.error(errorLine('All supported channel adapters are already configured in typeclaw.json. Nothing to add.'))
     process.exit(0)
   }
 
@@ -349,10 +353,17 @@ function reportKakaotalkAuth(result: KakaotalkAuthResult): string {
   return `KakaoTalk login failed: ${result.reason}`
 }
 
-async function maybePromptRestart(cwd: string): Promise<void> {
+async function maybePromptRestart(cwd: string, channel: ChannelKind): Promise<void> {
+  const label = CHANNEL_LABELS[channel]
   const current = await status({ cwd }).catch(() => null)
   if (current === null || current.kind !== 'running') {
-    console.log('Channel added. Run `typeclaw start` (or `typeclaw restart`) to apply the change.')
+    done({
+      title: c.green(`${label} channel added.`),
+      hints: [
+        { label: 'Start the agent:', command: 'typeclaw start' },
+        { label: 'Then check status:', command: 'typeclaw status' },
+      ],
+    })
     return
   }
 
@@ -362,19 +373,31 @@ async function maybePromptRestart(cwd: string): Promise<void> {
     initialValue: true,
   })
   if (isCancel(restartNow) || !restartNow) {
-    console.log('Channel added. Run `typeclaw restart` when you want the new channel to come online.')
+    done({
+      title: c.green(`${label} channel added.`),
+      hints: [
+        { label: 'Apply later:', command: 'typeclaw restart' },
+        { label: 'Check status:', command: 'typeclaw status' },
+      ],
+    })
     return
   }
 
   const stopped = await stop({ cwd })
   if (!stopped.ok) {
-    console.error(`Restart failed during stop: ${stopped.reason}`)
+    console.error(errorLine(`Restart failed during stop: ${stopped.reason}`))
     process.exit(1)
   }
   const started = await start({ cwd, preferredHostPort: config.port, cliEntry: process.argv[1] })
   if (!started.ok) {
-    console.error(`Restart failed during start: ${started.reason}`)
+    console.error(errorLine(`Restart failed during start: ${started.reason}`))
     process.exit(1)
   }
-  console.log(`Restarted ${started.plan.containerName} on host port ${started.hostPort}.`)
+  done({
+    title: c.green(`${label} channel added. Restarted ${started.plan.containerName} on host port ${started.hostPort}.`),
+    hints: [
+      { label: 'Attach TUI:', command: 'typeclaw tui' },
+      { label: 'Follow logs:', command: 'typeclaw logs -f' },
+    ],
+  })
 }

--- a/src/cli/compose.ts
+++ b/src/cli/compose.ts
@@ -11,6 +11,8 @@ import {
 } from '@/compose'
 import { config } from '@/config'
 
+import { c } from './ui'
+
 const startSub = defineCommand({
   meta: { name: 'start', description: 'start every agent in immediate subdirectories of cwd' },
   args: {
@@ -33,17 +35,17 @@ const startSub = defineCommand({
       cliEntry: process.argv[1],
     })
     if (agents.length === 0) {
-      console.log('No typeclaw agents found in immediate subdirectories of cwd.')
+      console.log(c.dim('No typeclaw agents found in immediate subdirectories of cwd.'))
       return
     }
     let failed = 0
     for (const r of results) {
       if (r.ok) {
         const verb = r.data.alreadyRunning ? 'already running' : 'started'
-        console.log(`[${r.name}] ${verb} on host port ${r.data.hostPort}`)
+        console.log(`${c.green('✔')} ${c.bold(`[${r.name}]`)} ${verb} on host port ${c.cyan(String(r.data.hostPort))}`)
       } else {
         failed++
-        console.error(`[${r.name}] failed: ${r.reason}`)
+        console.error(`${c.red('✖')} ${c.bold(`[${r.name}]`)} ${c.red('failed:')} ${r.reason}`)
       }
     }
     summarize(results, 'started', failed)
@@ -56,16 +58,20 @@ const stopSub = defineCommand({
   async run() {
     const { agents, results } = await composeStop(process.cwd())
     if (agents.length === 0) {
-      console.log('No typeclaw agents found in immediate subdirectories of cwd.')
+      console.log(c.dim('No typeclaw agents found in immediate subdirectories of cwd.'))
       return
     }
     let failed = 0
     for (const r of results) {
       if (r.ok) {
-        console.log(r.data.running ? `[${r.name}] stopped` : `[${r.name}] not running`)
+        if (r.data.running) {
+          console.log(`${c.green('✔')} ${c.bold(`[${r.name}]`)} stopped`)
+        } else {
+          console.log(`${c.dim('○')} ${c.bold(`[${r.name}]`)} ${c.dim('not running')}`)
+        }
       } else {
         failed++
-        console.error(`[${r.name}] failed: ${r.reason}`)
+        console.error(`${c.red('✖')} ${c.bold(`[${r.name}]`)} ${c.red('failed:')} ${r.reason}`)
       }
     }
     summarize(results, 'stopped', failed)
@@ -95,16 +101,18 @@ const restartSub = defineCommand({
       cliEntry: process.argv[1],
     })
     if (agents.length === 0) {
-      console.log('No typeclaw agents found in immediate subdirectories of cwd.')
+      console.log(c.dim('No typeclaw agents found in immediate subdirectories of cwd.'))
       return
     }
     let failed = 0
     for (const r of results) {
       if (r.ok) {
-        console.log(`[${r.name}] restarted on host port ${r.data.start.hostPort}`)
+        console.log(
+          `${c.green('✔')} ${c.bold(`[${r.name}]`)} restarted on host port ${c.cyan(String(r.data.start.hostPort))}`,
+        )
       } else {
         failed++
-        console.error(`[${r.name}] failed: ${r.reason}`)
+        console.error(`${c.red('✖')} ${c.bold(`[${r.name}]`)} ${c.red('failed:')} ${r.reason}`)
       }
     }
     summarize(results, 'restarted', failed)
@@ -117,14 +125,14 @@ const psSub = defineCommand({
   async run() {
     const { entries } = await composePs(process.cwd())
     if (entries.length === 0) {
-      console.log('No typeclaw agents found in immediate subdirectories of cwd.')
+      console.log(c.dim('No typeclaw agents found in immediate subdirectories of cwd.'))
       return
     }
     const nameW = entries.reduce((w, e) => Math.max(w, e.name.length), 'NAME'.length)
     const containerW = entries.reduce((w, e) => Math.max(w, e.containerName.length), 'CONTAINER'.length)
-    console.log(`${'NAME'.padEnd(nameW)}  ${'CONTAINER'.padEnd(containerW)}  STATUS`)
+    console.log(`${c.bold('NAME'.padEnd(nameW))}  ${c.bold('CONTAINER'.padEnd(containerW))}  ${c.bold('STATUS')}`)
     for (const e of entries) {
-      console.log(`${e.name.padEnd(nameW)}  ${e.containerName.padEnd(containerW)}  ${labelStatus(e.status)}`)
+      console.log(`${e.name.padEnd(nameW)}  ${e.containerName.padEnd(containerW)}  ${colorStatus(e.status)}`)
     }
   },
 })
@@ -145,9 +153,14 @@ const logsSub = defineCommand({
     process.once('SIGINT', onSig)
     process.once('SIGTERM', onSig)
     try {
+      if (args.follow) {
+        console.log(c.cyan('Streaming logs for all agents...'))
+      } else {
+        console.log(c.dim('Showing logs for all agents.'))
+      }
       const result = await composeLogs({ rootCwd: process.cwd(), follow: args.follow, signal: controller.signal })
       if (result.agents.length === 0) {
-        console.log('No typeclaw agents found in immediate subdirectories of cwd.')
+        console.log(c.dim('No typeclaw agents found in immediate subdirectories of cwd.'))
         return
       }
       if (result.exitCode !== 0) process.exit(result.exitCode)
@@ -172,17 +185,17 @@ export const composeCommand = defineCommand({
   },
 })
 
-function labelStatus(s: AgentStatus): string {
-  if (s === 'running') return 'RUNNING'
-  if (s === 'stopped') return 'STOPPED'
-  return 'NOT CREATED'
+function colorStatus(s: AgentStatus): string {
+  if (s === 'running') return c.green('RUNNING')
+  if (s === 'stopped') return c.dim('STOPPED')
+  return c.yellow('NOT CREATED')
 }
 
 function summarize<T>(results: AgentResult<T>[], verb: string, failed: number): void {
   const ok = results.length - failed
   if (failed === 0) {
-    console.log(`${verb} ${ok}/${results.length}`)
+    console.log(c.green(`${verb} ${ok}/${results.length}`))
   } else {
-    console.error(`${verb} ${ok}/${results.length} (${failed} failed)`)
+    console.error(c.red(`${verb} ${ok}/${results.length} (${failed} failed)`))
   }
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -23,6 +23,8 @@ import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { fetchModelOptions, type ModelOption } from '@/init/models-dev'
 import { makeOAuthLoginRunner } from '@/init/oauth-login'
 
+import { c, done, errorLine } from './ui'
+
 export const init = defineCommand({
   meta: {
     name: 'init',
@@ -34,13 +36,15 @@ export const init = defineCommand({
     const existingAgent = findAgentDir(cwd)
     if (existingAgent !== null && existingAgent !== cwd) {
       console.error(
-        `Refusing to init: a TypeClaw agent already exists at ${existingAgent}. Nested agents are not supported.`,
+        errorLine(
+          `Refusing to init: a TypeClaw agent already exists at ${existingAgent}. Nested agents are not supported.`,
+        ),
       )
       process.exit(1)
     }
 
     if (await isHatched(cwd)) {
-      console.error(`TypeClaw has already hatched in ${cwd}.`)
+      console.error(errorLine(`TypeClaw has already hatched in ${cwd}.`))
       process.exit(1)
     }
 
@@ -298,7 +302,7 @@ export const init = defineCommand({
         ),
       })
     } catch (error) {
-      console.error(error)
+      console.error(errorLine(error instanceof Error ? error.message : String(error)))
       process.exit(1)
     }
 
@@ -308,7 +312,14 @@ export const init = defineCommand({
     }
 
     if (hatchingOk) {
-      console.log('\nContainer is still running. Run `typeclaw tui` to reattach or `typeclaw stop` to stop.')
+      done({
+        title: c.green('Hatched. Your agent is ready.'),
+        hints: [
+          { label: 'Attach TUI:', command: 'typeclaw tui' },
+          { label: 'Follow logs:', command: 'typeclaw logs -f' },
+          { label: 'Stop:', command: 'typeclaw stop' },
+        ],
+      })
     }
   },
 })

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -3,6 +3,8 @@ import { defineCommand } from 'citty'
 import { logs } from '@/container'
 import { findAgentDir } from '@/init'
 
+import { c, errorLine } from './ui'
+
 export const logsCommand = defineCommand({
   meta: {
     name: 'logs',
@@ -19,9 +21,15 @@ export const logsCommand = defineCommand({
   async run({ args }) {
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
 
+    if (args.follow) {
+      console.log(c.cyan('Streaming container logs...'))
+    } else {
+      console.log(c.dim('Showing container logs.'))
+    }
+
     const result = await logs({ cwd, follow: args.follow })
     if (!result.ok) {
-      console.error(result.reason)
+      console.error(errorLine(result.reason))
       process.exit(1)
     }
 

--- a/src/cli/reload.ts
+++ b/src/cli/reload.ts
@@ -4,6 +4,8 @@ import { resolveHostPort } from '@/container'
 import { findAgentDir } from '@/init'
 import { requestReload, type ReloadResult } from '@/reload'
 
+import { c, errorLine, spinner } from './ui'
+
 export const reload = defineCommand({
   meta: {
     name: 'reload',
@@ -23,26 +25,33 @@ export const reload = defineCommand({
   },
   async run({ args }) {
     const url = args.url ?? (await defaultUrl())
+
+    const s = spinner()
+    s.start('Reloading...')
     let results: ReloadResult[]
     try {
       results = await requestReload({ url, timeoutMs: Number(args.timeout) })
     } catch (err) {
-      console.error(`reload failed: ${err instanceof Error ? err.message : String(err)}`)
+      s.error(`reload failed: ${err instanceof Error ? err.message : String(err)}`)
       process.exit(1)
     }
 
     if (results.length === 0) {
-      console.log('Nothing to reload.')
+      s.stop(c.dim('Nothing to reload.'))
       return
     }
 
     let failed = 0
     for (const r of results) {
+      if (!r.ok) failed++
+    }
+    s.stop(failed === 0 ? `Reloaded ${results.length} scope(s).` : `Reloaded with ${failed} failure(s).`)
+
+    for (const r of results) {
       if (r.ok) {
-        console.log(`[${r.scope}] ok: ${r.summary}`)
+        console.log(`${c.green('●')} ${c.bold(`[${r.scope}]`)} ${r.summary}`)
       } else {
-        failed++
-        console.error(`[${r.scope}] failed: ${r.reason}`)
+        console.error(`${c.red('●')} ${c.bold(`[${r.scope}]`)} ${errorLine(r.reason)}`)
       }
     }
 

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -4,6 +4,8 @@ import { config, validateConfig } from '@/config'
 import { start, stop } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
+import { c, errorLine, renderStartSuccess, spinner } from './ui'
+
 export const restartCommand = defineCommand({
   meta: {
     name: 'restart',
@@ -26,25 +28,27 @@ export const restartCommand = defineCommand({
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
 
     if (!isInitialized(cwd)) {
-      console.error('TypeClaw config file not found. Run `typeclaw init` first.')
+      console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first.'))
       process.exit(1)
     }
 
     const validated = validateConfig(cwd)
     if (!validated.ok) {
-      console.error(validated.reason)
+      console.error(errorLine(validated.reason))
       process.exit(1)
     }
 
+    const stopSpin = spinner()
+    stopSpin.start('Stopping container...')
     const stopped = await stop({ cwd })
     if (!stopped.ok) {
-      console.error(stopped.reason)
+      stopSpin.error(stopped.reason)
       process.exit(1)
     }
-    if (stopped.running) {
-      console.log(`Stopped ${stopped.containerName}.`)
-    }
+    stopSpin.stop(stopped.running ? `Stopped ${c.cyan(stopped.containerName)}.` : 'Already stopped.')
 
+    const startSpin = spinner()
+    startSpin.start('Starting container...')
     const started = await start({
       cwd,
       preferredHostPort: Number(args.port),
@@ -52,23 +56,11 @@ export const restartCommand = defineCommand({
       cliEntry: process.argv[1],
     })
     if (!started.ok) {
-      console.error(started.reason)
+      startSpin.error(started.reason)
       process.exit(1)
     }
+    startSpin.stop('Started.')
 
-    if (started.built) {
-      console.log(`Built image ${started.plan.imageTag}.`)
-    }
-    console.log(
-      `Container ${started.plan.containerName} started on host port ${started.hostPort} (${started.containerId.slice(0, 12)}).`,
-    )
-    if (started.hostd.state === 'registered') {
-      console.log(`Host daemon active.`)
-    } else if (started.hostd.state === 'unavailable') {
-      console.warn(`Host daemon unavailable: ${started.hostd.reason}`)
-    }
-    console.log(`Follow logs:  typeclaw logs -f`)
-    console.log(`Attach TUI:   typeclaw tui`)
-    console.log(`Stop:         typeclaw stop`)
+    console.log(renderStartSuccess(started))
   },
 })

--- a/src/cli/shell.ts
+++ b/src/cli/shell.ts
@@ -3,6 +3,8 @@ import { defineCommand } from 'citty'
 import { shell } from '@/container'
 import { findAgentDir } from '@/init'
 
+import { c, errorLine } from './ui'
+
 export const shellCommand = defineCommand({
   meta: {
     name: 'shell',
@@ -18,9 +20,11 @@ export const shellCommand = defineCommand({
   async run({ args }) {
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
 
+    console.log(c.cyan(`Attaching ${args.shell} inside the container...`))
+
     const result = await shell({ cwd, shell: args.shell })
     if (!result.ok) {
-      console.error(result.reason)
+      console.error(errorLine(result.reason))
       process.exit(1)
     }
 

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -4,6 +4,8 @@ import { config, validateConfig } from '@/config'
 import { start } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
+import { errorLine, renderStartSuccess, spinner } from './ui'
+
 export const startCommand = defineCommand({
   meta: {
     name: 'start',
@@ -26,16 +28,18 @@ export const startCommand = defineCommand({
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
 
     if (!isInitialized(cwd)) {
-      console.error('TypeClaw config file not found. Run `typeclaw init` first.')
+      console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first.'))
       process.exit(1)
     }
 
     const validated = validateConfig(cwd)
     if (!validated.ok) {
-      console.error(validated.reason)
+      console.error(errorLine(validated.reason))
       process.exit(1)
     }
 
+    const s = spinner()
+    s.start('Starting container...')
     const result = await start({
       cwd,
       preferredHostPort: Number(args.port),
@@ -43,27 +47,11 @@ export const startCommand = defineCommand({
       cliEntry: process.argv[1],
     })
     if (!result.ok) {
-      console.error(result.reason)
+      s.error(result.reason)
       process.exit(1)
     }
+    s.stop(result.alreadyRunning ? 'Already running.' : 'Started.')
 
-    if (result.alreadyRunning) {
-      console.log(`Container ${result.plan.containerName} is already running on host port ${result.hostPort}.`)
-    } else {
-      if (result.built) {
-        console.log(`Built image ${result.plan.imageTag}.`)
-      }
-      console.log(
-        `Container ${result.plan.containerName} started on host port ${result.hostPort} (${result.containerId.slice(0, 12)}).`,
-      )
-      if (result.hostd.state === 'registered') {
-        console.log(`Host daemon active.`)
-      } else if (result.hostd.state === 'unavailable') {
-        console.warn(`Host daemon unavailable: ${result.hostd.reason}`)
-      }
-    }
-    console.log(`Follow logs:  typeclaw logs -f`)
-    console.log(`Attach TUI:   typeclaw tui`)
-    console.log(`Stop:         typeclaw stop`)
+    console.log(renderStartSuccess(result))
   },
 })

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -121,10 +121,11 @@ describe('formatStatus', () => {
   test('useColor=true wraps section headers with ANSI escapes', () => {
     const out = formatStatus(baseReport(), { useColor: true })
     const ESC = '\u001b'
+    const BOLD = `${ESC}[1m`
 
-    expect(out).toContain(`${ESC}[1mContainer${ESC}[0m`)
-    expect(out).toContain(`${ESC}[1mHost daemon${ESC}[0m`)
-    expect(out).toContain(`${ESC}[1mPort forwarding${ESC}[0m`)
+    expect(out).toContain(`${BOLD}Container`)
+    expect(out).toContain(`${BOLD}Host daemon`)
+    expect(out).toContain(`${BOLD}Port forwarding`)
   })
 
   test('renders empty forwarding hint when daemon omits forwardedPorts (drift)', () => {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,3 +1,5 @@
+import { styleText } from 'node:util'
+
 import { defineCommand } from 'citty'
 
 import { status as containerStatus, type ContainerStatus } from '@/container'
@@ -58,94 +60,110 @@ export function parseStatusResult(value: unknown): StatusResult | null {
 
 export type FormatOptions = { useColor?: boolean }
 
-const ANSI = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  green: '\x1b[32m',
-  yellow: '\x1b[33m',
-  red: '\x1b[31m',
-  cyan: '\x1b[36m',
+type ColorFn = (s: string) => string
+type Palette = {
+  bold: ColorFn
+  dim: ColorFn
+  green: ColorFn
+  yellow: ColorFn
+  red: ColorFn
+  cyan: ColorFn
+}
+
+const identity: ColorFn = (s) => s
+const NO_PALETTE: Palette = {
+  bold: identity,
+  dim: identity,
+  green: identity,
+  yellow: identity,
+  red: identity,
+  cyan: identity,
+}
+
+const COLOR_PALETTE: Palette = {
+  bold: (s) => styleText('bold', s),
+  dim: (s) => styleText('dim', s),
+  green: (s) => styleText('green', s),
+  yellow: (s) => styleText('yellow', s),
+  red: (s) => styleText('red', s),
+  cyan: (s) => styleText('cyan', s),
 }
 
 export function formatStatus(report: StatusReport, opts: FormatOptions = {}): string {
   const useColor = opts.useColor ?? false
-  const style = useColor ? ANSI : (Object.fromEntries(Object.keys(ANSI).map((k) => [k, ''])) as typeof ANSI)
+  const p: Palette = useColor ? COLOR_PALETTE : NO_PALETTE
 
   const lines: string[] = []
-  appendContainerSection(lines, report, style)
+  appendContainerSection(lines, report, p)
   lines.push('')
-  appendHostdSection(lines, report, style)
+  appendHostdSection(lines, report, p)
   lines.push('')
-  appendForwardingSection(lines, report, style)
+  appendForwardingSection(lines, report, p)
   while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
   return lines.join('\n')
 }
 
-function appendContainerSection(lines: string[], report: StatusReport, s: typeof ANSI): void {
-  const c = report.container
-  lines.push(`${s.bold}Container${s.reset}  ${c.containerName}`)
+function appendContainerSection(lines: string[], report: StatusReport, p: Palette): void {
+  const container = report.container
+  lines.push(`${p.bold('Container')}  ${container.containerName}`)
   lines.push(row('cwd', report.cwd))
-  lines.push(row('image', c.imageTag))
+  lines.push(row('image', container.imageTag))
 
-  if (c.kind === 'missing') {
-    lines.push(row('state', badge(s, 'missing', s.dim)))
+  if (container.kind === 'missing') {
+    lines.push(row('state', p.dim('missing')))
     return
   }
 
-  const stateLabel = c.kind === 'running' ? badge(s, 'running', s.green) : badge(s, 'stopped', s.yellow)
+  const stateLabel = container.kind === 'running' ? p.green('running') : p.yellow('stopped')
   lines.push(row('state', stateLabel))
-  lines.push(row('id', shortId(c.containerId)))
+  lines.push(row('id', shortId(container.containerId)))
 
-  if (c.kind === 'running') {
-    const port = c.hostPort === null ? `${s.dim}unknown${s.reset}` : formatHostMapping(c.hostBindAddr, c.hostPort, s)
+  if (container.kind === 'running') {
+    const port =
+      container.hostPort === null ? p.dim('unknown') : formatHostMapping(container.hostBindAddr, container.hostPort, p)
     lines.push(row('port', port))
   }
 }
 
-function appendHostdSection(lines: string[], report: StatusReport, s: typeof ANSI): void {
-  lines.push(`${s.bold}Host daemon${s.reset}`)
+function appendHostdSection(lines: string[], report: StatusReport, p: Palette): void {
+  lines.push(p.bold('Host daemon'))
 
   switch (report.hostd.kind) {
     case 'unreachable':
-      lines.push(row('state', badge(s, 'unreachable', s.dim)))
-      lines.push(`  ${s.dim}Daemon is not running. \`typeclaw start\` will spawn one.${s.reset}`)
+      lines.push(row('state', p.dim('unreachable')))
+      lines.push(`  ${p.dim('Daemon is not running. `typeclaw start` will spawn one.')}`)
       return
     case 'not-registered':
-      lines.push(row('state', badge(s, 'not registered', s.yellow)))
+      lines.push(row('state', p.yellow('not registered')))
       lines.push(row('reason', report.hostd.reason))
       return
     case 'registered':
-      lines.push(row('state', badge(s, 'registered', s.green)))
+      lines.push(row('state', p.green('registered')))
       return
   }
 }
 
-function appendForwardingSection(lines: string[], report: StatusReport, s: typeof ANSI): void {
-  lines.push(`${s.bold}Port forwarding${s.reset}`)
+function appendForwardingSection(lines: string[], report: StatusReport, p: Palette): void {
+  lines.push(p.bold('Port forwarding'))
 
   if (report.hostd.kind !== 'registered') {
-    lines.push(`  ${s.dim}requires the host daemon${s.reset}`)
+    lines.push(`  ${p.dim('requires the host daemon')}`)
     return
   }
 
   const ports = report.hostd.forwardedPorts
   if (ports.length === 0) {
-    lines.push(`  ${s.dim}no ports currently forwarded${s.reset}`)
+    lines.push(`  ${p.dim('no ports currently forwarded')}`)
     return
   }
 
   for (const port of [...ports].sort((a, b) => a - b)) {
-    lines.push(`  ${s.cyan}127.0.0.1:${port}${s.reset} ${s.dim}->${s.reset} container:${port}`)
+    lines.push(`  ${p.cyan(`127.0.0.1:${port}`)} ${p.dim('->')} container:${port}`)
   }
 }
 
 function row(label: string, value: string): string {
   return `  ${label.padEnd(8)}${value}`
-}
-
-function badge(s: typeof ANSI, text: string, color: string): string {
-  return `${color}${text}${s.reset}`
 }
 
 function shortId(id: string): string {
@@ -154,7 +172,7 @@ function shortId(id: string): string {
   return trimmed.slice(0, 12)
 }
 
-function formatHostMapping(bindAddr: string | null, port: number, s: typeof ANSI): string {
+function formatHostMapping(bindAddr: string | null, port: number, p: Palette): string {
   const bind = bindAddr ?? '127.0.0.1'
-  return `${s.cyan}${bind}:${port}${s.reset} ${s.dim}->${s.reset} container:${port}`
+  return `${p.cyan(`${bind}:${port}`)} ${p.dim('->')} container:${port}`
 }

--- a/src/cli/stop.ts
+++ b/src/cli/stop.ts
@@ -3,6 +3,8 @@ import { defineCommand } from 'citty'
 import { stop } from '@/container'
 import { findAgentDir } from '@/init'
 
+import { c, spinner } from './ui'
+
 export const stopCommand = defineCommand({
   meta: {
     name: 'stop',
@@ -10,17 +12,20 @@ export const stopCommand = defineCommand({
   },
   async run() {
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+
+    const s = spinner()
+    s.start('Stopping container...')
     const result = await stop({ cwd })
 
     if (!result.ok) {
-      console.error(result.reason)
+      s.error(result.reason)
       process.exit(1)
     }
 
     if (result.running) {
-      console.log(`Stopped ${result.containerName}.`)
+      s.stop(`Stopped ${c.cyan(result.containerName)}.`)
     } else {
-      console.log(`Container ${result.containerName} is not running.`)
+      s.stop(c.dim(`Container ${result.containerName} is not running.`))
     }
   },
 })

--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { c, errorLine, link, renderStartSuccess, spinner, successLine, type StartLikeResult } from './ui'
+
+const ENV_KEYS = ['NO_COLOR', 'FORCE_COLOR'] as const
+
+function withForcedColor<T>(fn: () => T): T {
+  const prev: Record<string, string | undefined> = {}
+  for (const k of ENV_KEYS) prev[k] = process.env[k]
+  process.env.NO_COLOR = ''
+  process.env.FORCE_COLOR = '1'
+  try {
+    return fn()
+  } finally {
+    for (const k of ENV_KEYS) {
+      if (prev[k] === undefined) delete process.env[k]
+      else process.env[k] = prev[k]
+    }
+  }
+}
+
+function withNoColor<T>(fn: () => T): T {
+  const prev: Record<string, string | undefined> = {}
+  for (const k of ENV_KEYS) prev[k] = process.env[k]
+  process.env.NO_COLOR = '1'
+  delete process.env.FORCE_COLOR
+  try {
+    return fn()
+  } finally {
+    for (const k of ENV_KEYS) {
+      if (prev[k] === undefined) delete process.env[k]
+      else process.env[k] = prev[k]
+    }
+  }
+}
+
+describe('c.*', () => {
+  test('wraps text with cyan ANSI when colors are forced', () => {
+    const out = withForcedColor(() => c.cyan('hello'))
+    expect(out).toContain('hello')
+    expect(out).toContain('\u001b[36m')
+  })
+
+  test('returns the raw string when NO_COLOR is set', () => {
+    const out = withNoColor(() => c.cyan('hello'))
+    expect(out).toBe('hello')
+  })
+
+  test('every color helper preserves the input text', () => {
+    withForcedColor(() => {
+      for (const key of ['cyan', 'green', 'red', 'yellow', 'dim', 'gray', 'magenta', 'bold'] as const) {
+        expect(c[key]('PAYLOAD')).toContain('PAYLOAD')
+      }
+    })
+  })
+
+  test('bold uses the bold ANSI code under forced color', () => {
+    const out = withForcedColor(() => c.bold('X'))
+    expect(out).toContain('\u001b[1m')
+  })
+})
+
+describe('link', () => {
+  test('emits OSC 8 sequence around the text when colors are on', () => {
+    const out = withForcedColor(() => link('Docs', 'https://example.com'))
+    expect(out).toContain('Docs')
+    expect(out).toContain('https://example.com')
+    expect(out).toContain('\u001b]8;;')
+  })
+
+  test('falls back to "text (url)" when NO_COLOR is set', () => {
+    const out = withNoColor(() => link('Docs', 'https://example.com'))
+    expect(out).toBe('Docs (https://example.com)')
+  })
+})
+
+describe('renderStartSuccess', () => {
+  function baseResult(overrides: Partial<StartLikeResult> = {}): StartLikeResult {
+    return {
+      built: false,
+      plan: { containerName: 'coder', imageTag: 'typeclaw-coder' },
+      hostPort: 8973,
+      containerId: 'abcdef0123456789',
+      hostd: { state: 'registered' },
+      ...overrides,
+    }
+  }
+
+  test('renders the "started" path with container name, port, and short id', () => {
+    const out = withNoColor(() => renderStartSuccess(baseResult()))
+    expect(out).toContain('coder')
+    expect(out).toContain('started on host port 8973')
+    expect(out).toContain('abcdef012345')
+    expect(out).not.toContain('abcdef0123456789')
+  })
+
+  test('renders the "already running" path with the same name + port', () => {
+    const out = withNoColor(() => renderStartSuccess(baseResult({ alreadyRunning: true })))
+    expect(out).toContain('coder')
+    expect(out).toContain('is already running on host port 8973')
+    expect(out).not.toContain('started on host port')
+  })
+
+  test('renders a "Built image" line only when built is true', () => {
+    const builtOut = withNoColor(() => renderStartSuccess(baseResult({ built: true })))
+    expect(builtOut).toContain('Built image typeclaw-coder.')
+
+    const unbuiltOut = withNoColor(() => renderStartSuccess(baseResult({ built: false })))
+    expect(unbuiltOut).not.toContain('Built image')
+  })
+
+  test('renders "Host daemon active." when hostd is registered', () => {
+    const out = withNoColor(() => renderStartSuccess(baseResult()))
+    expect(out).toContain('Host daemon active.')
+  })
+
+  test('renders a yellow warning line when hostd is unavailable', () => {
+    const out = withForcedColor(() =>
+      renderStartSuccess(baseResult({ hostd: { state: 'unavailable', reason: 'socket missing' } })),
+    )
+    expect(out).toContain('Host daemon unavailable:')
+    expect(out).toContain('socket missing')
+    expect(out).toContain('\u001b[33m')
+  })
+
+  test('omits the hostd line entirely when hostd is disabled', () => {
+    const out = withNoColor(() => renderStartSuccess(baseResult({ hostd: { state: 'disabled' } })))
+    expect(out).not.toContain('Host daemon')
+  })
+
+  test('always includes the three next-step command hints', () => {
+    const out = withNoColor(() => renderStartSuccess(baseResult()))
+    expect(out).toContain('typeclaw logs -f')
+    expect(out).toContain('typeclaw tui')
+    expect(out).toContain('typeclaw stop')
+  })
+
+  test('color-wraps the port number under forced color', () => {
+    const out = withForcedColor(() => renderStartSuccess(baseResult()))
+    expect(out).toContain('\u001b[32m8973')
+    expect(out).toContain('\u001b[36mcoder')
+  })
+})
+
+describe('errorLine / successLine', () => {
+  test('errorLine prefixes with a red ✖', () => {
+    const out = withForcedColor(() => errorLine('something broke'))
+    expect(out).toContain('something broke')
+    expect(out).toContain('✖')
+    expect(out).toContain('\u001b[31m')
+  })
+
+  test('successLine prefixes with a green ●', () => {
+    const out = withForcedColor(() => successLine('did the thing'))
+    expect(out).toContain('did the thing')
+    expect(out).toContain('●')
+    expect(out).toContain('\u001b[32m')
+  })
+
+  test('neither emits color escapes under NO_COLOR', () => {
+    withNoColor(() => {
+      expect(errorLine('x')).toBe('✖ x')
+      expect(successLine('y')).toBe('● y')
+    })
+  })
+})
+
+describe('spinner', () => {
+  const originalIsTTY = process.stdout.isTTY
+
+  beforeEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, configurable: true })
+  })
+
+  test('start/stop/message/error do not throw on a non-TTY stdout', () => {
+    const s = spinner()
+    expect(() => {
+      s.start('working...')
+      s.message('still working')
+      s.stop('done')
+    }).not.toThrow()
+  })
+
+  test('error() finalizes the spinner with a non-zero code', () => {
+    const s = spinner()
+    expect(() => {
+      s.start('working...')
+      s.error('boom')
+    }).not.toThrow()
+  })
+})

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -1,0 +1,110 @@
+import { styleText } from 'node:util'
+
+import { cancel, intro, isCancel, log, note, outro, spinner as clackSpinner } from '@clack/prompts'
+
+export { cancel, intro, isCancel, log, note, outro }
+
+function colorize(modifier: Parameters<typeof styleText>[0], s: string): string {
+  if (!colorsEnabled()) return s
+  return styleText(modifier, s)
+}
+
+// Re-evaluated per call so tests can mutate NO_COLOR / FORCE_COLOR between
+// cases without stale module-load caching.
+function colorsEnabled(): boolean {
+  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') return false
+  if (process.env.FORCE_COLOR === '0') return false
+  if (process.env.FORCE_COLOR) return true
+  return Boolean(process.stdout.isTTY)
+}
+
+export const c = {
+  cyan: (s: string) => colorize('cyan', s),
+  green: (s: string) => colorize('green', s),
+  red: (s: string) => colorize('red', s),
+  yellow: (s: string) => colorize('yellow', s),
+  dim: (s: string) => colorize('dim', s),
+  gray: (s: string) => colorize('gray', s),
+  magenta: (s: string) => colorize('magenta', s),
+  bold: (s: string) => colorize('bold', s),
+}
+
+// OSC 8 hyperlink with plain fallback when colors are off so piped output
+// and non-OSC-8 terminals stay readable.
+export function link(text: string, url: string): string {
+  if (!colorsEnabled()) return `${text} (${url})`
+  return `\u001b]8;;${url}\u0007${text}\u001b]8;;\u0007`
+}
+
+export type Spinner = {
+  start: (msg?: string) => void
+  stop: (msg?: string) => void
+  error: (msg?: string) => void
+  cancel: (msg?: string) => void
+  message: (msg?: string) => void
+}
+
+export function spinner(): Spinner {
+  const s = clackSpinner()
+  return {
+    start: (msg) => s.start(msg),
+    stop: (msg) => s.stop(msg),
+    error: (msg) => s.error(msg),
+    cancel: (msg) => s.cancel(msg),
+    message: (msg) => s.message(msg),
+  }
+}
+
+export type StartLikeResult = {
+  alreadyRunning?: boolean
+  built: boolean
+  plan: { containerName: string; imageTag: string }
+  hostPort: number
+  containerId: string
+  hostd: { state: 'registered' } | { state: 'unavailable'; reason: string } | { state: 'disabled' }
+}
+
+export function renderStartSuccess(result: StartLikeResult): string {
+  const lines: string[] = []
+  const name = c.cyan(result.plan.containerName)
+  const port = c.green(String(result.hostPort))
+
+  if (result.alreadyRunning) {
+    lines.push(`${c.green('●')} ${name} is already running on host port ${port}.`)
+  } else {
+    if (result.built) {
+      lines.push(`Built image ${c.cyan(result.plan.imageTag)}.`)
+    }
+    const shortId = result.containerId.slice(0, 12)
+    lines.push(`${c.green('●')} ${name} started on host port ${port} ${c.dim(`(${shortId})`)}.`)
+  }
+
+  if (result.hostd.state === 'registered') {
+    lines.push(c.dim('Host daemon active.'))
+  } else if (result.hostd.state === 'unavailable') {
+    lines.push(`${c.yellow('Host daemon unavailable:')} ${result.hostd.reason}`)
+  }
+
+  lines.push('')
+  lines.push(`${c.dim('Follow logs:')}  ${c.cyan('typeclaw logs -f')}`)
+  lines.push(`${c.dim('Attach TUI:')}   ${c.cyan('typeclaw tui')}`)
+  lines.push(`${c.dim('Stop:')}         ${c.cyan('typeclaw stop')}`)
+
+  return lines.join('\n')
+}
+
+export type NextStepHint = { label: string; command: string }
+
+export function done(opts: { title: string; hints: NextStepHint[] }): void {
+  const body = opts.hints.map((h) => `${c.dim(h.label)}  ${c.cyan(h.command)}`).join('\n')
+  note(body, opts.title)
+  outro(c.green('Done.'))
+}
+
+export function errorLine(reason: string): string {
+  return `${c.red('✖')} ${reason}`
+}
+
+export function successLine(message: string): string {
+  return `${c.green('●')} ${message}`
+}


### PR DESCRIPTION
## Summary

Every host-stage `typeclaw` command except `status` was rendering monochrome `console.log` lines with no progress indication. Two wizards (`init`, `channel add`) opened a `@clack/prompts` session with `intro()` but never closed it. `start` and `restart` copy-pasted an identical 10-line success block. There was no consistent error style, no spinner during the slow Docker build, and no visual hierarchy on the next-steps command lists.

This PR introduces a small `src/cli/ui.ts` foundation and routes every host-stage command through it. The visible result is a Vercel/Bun-style aesthetic: cyan command names, green status bullets, yellow warnings, red error markers (`✖`), dim metadata, and consistent spinners around every slow operation.

## Examples (before → after)

### `typeclaw start` (fresh start)

Before:
```
Built image typeclaw-coder.
Container coder started on host port 8973 (abcdef012345).
Host daemon active.
Follow logs:  typeclaw logs -f
Attach TUI:   typeclaw tui
Stop:         typeclaw stop
```

After (spinner runs during build, then renders this; coder/8973/typeclaw-coder/command names are cyan, the ● and 8973 are green, the short id and labels are dim):
```
◇  Started.
Built image typeclaw-coder.
● coder started on host port 8973 (abcdef012345).
Host daemon active.

Follow logs:  typeclaw logs -f
Attach TUI:   typeclaw tui
Stop:         typeclaw stop
```

### `typeclaw start` (hostd unavailable)

Before:
```
Container coder started on host port 8973 (abcdef012345).
Host daemon unavailable: socket missing
Follow logs:  typeclaw logs -f
Attach TUI:   typeclaw tui
Stop:         typeclaw stop
```

After (the "Host daemon unavailable:" prefix is yellow so the warning is scannable; the rest is colored as above):
```
◇  Started.
● coder started on host port 8973 (abcdef012345).
Host daemon unavailable: socket missing

Follow logs:  typeclaw logs -f
Attach TUI:   typeclaw tui
Stop:         typeclaw stop
```

### `typeclaw start` (error path)

Before:
```
TypeClaw config file not found. Run `typeclaw init` first.
```

After (✖ in red):
```
✖ TypeClaw config file not found. Run `typeclaw init` first.
```

### `typeclaw stop`

Before:
```
Stopped coder.
```

After (spinner runs during docker stop; on completion the green ◇ is from clack, the cyan "coder" is from c.cyan):
```
◇  Stopped coder.
```

If the container wasn't running, the message is dim instead of full-strength because it's a no-op, not a win:
```
◇  Container coder is not running.
```

### `typeclaw restart`

Before:
```
Stopped coder.
Container coder started on host port 8973 (abcdef012345).
Host daemon active.
Follow logs:  typeclaw logs -f
Attach TUI:   typeclaw tui
Stop:         typeclaw stop
```

After (two sequential spinners, then renderStartSuccess):
```
◇  Stopped coder.
◇  Started.
● coder started on host port 8973 (abcdef012345).
Host daemon active.

Follow logs:  typeclaw logs -f
Attach TUI:   typeclaw tui
Stop:         typeclaw stop
```

### `typeclaw logs -f`

Before: (silent until docker logs starts streaming)
```
2026-05-11T10:30:00.000Z agent boot ok
...
```

After (cyan banner so the user knows the stream attached):
```
Streaming container logs...
2026-05-11T10:30:00.000Z agent boot ok
...
```

### `typeclaw shell`

Before: (silent — shell just appears)
```
root@coder:/agent#
```

After:
```
Attaching /bin/bash inside the container...
root@coder:/agent#
```

### `typeclaw reload`

Before:
```
[cron] ok: 3 jobs reloaded
[channels] failed: socket closed
```

After (the ● is green/red, the [scope] is bold, the ✖ on the failed scope is red):
```
◇  Reloaded with 1 failure(s).
● [cron] 3 jobs reloaded
● [channels] ✖ socket closed
```

### `typeclaw status`

Before (status was the only command that already had color — section headers were bold, states colored):
```
Container  coder
  cwd     /agents/coder
  image   typeclaw-coder
  state   running
  id      abcdef012345
  port    127.0.0.1:51234 -> container:51234

Host daemon
  state   registered

Port forwarding
  127.0.0.1:3000 -> container:3000
  127.0.0.1:5173 -> container:5173
  127.0.0.1:8080 -> container:8080
```

After: same output, same colors. Just refactored to use the shared `styleText`-backed palette so every other command can pick up the same conventions. Bold reset is now `\u001b[22m` instead of `\u001b[0m`, otherwise byte-identical.

### `typeclaw compose start`

Before:
```
[coder] started on host port 8973
[reviewer] started on host port 8974
[scribe] failed: docker: image not found
started 2/3 (1 failed)
```

After (✔ green, ✖ red, [name] bold, port number cyan, summary green or red):
```
✔ [coder] started on host port 8973
✔ [reviewer] started on host port 8974
✖ [scribe] failed: docker: image not found
started 2/3 (1 failed)
```

### `typeclaw compose ps`

Before:
```
NAME      CONTAINER         STATUS
coder     typeclaw-coder    RUNNING
reviewer  typeclaw-reviewer STOPPED
scribe    typeclaw-scribe   NOT CREATED
```

After (NAME/CONTAINER/STATUS bold headers; RUNNING green, STOPPED dim, NOT CREATED yellow; padding applied before color so columns stay aligned):
```
NAME      CONTAINER          STATUS
coder     typeclaw-coder     RUNNING
reviewer  typeclaw-reviewer  STOPPED
scribe    typeclaw-scribe    NOT CREATED
```

### `typeclaw init` (final success)

Before (a single dense line that was easy to miss):
```
Container is still running. Run `typeclaw tui` to reattach or `typeclaw stop` to stop.
```

After (next-step commands inside a clack note() with cyan command names under dim labels, then a green outro):
```
┌  Initializing TypeClaw...
│
... (existing wizard steps) ...
│
◆  Hatched. Your agent is ready.
│  Attach TUI:    typeclaw tui
│  Follow logs:   typeclaw logs -f
│  Stop:          typeclaw stop
│
└  Done.
```

### `typeclaw channel add` (final success)

Before:
```
Channel added. Run `typeclaw start` (or `typeclaw restart`) to apply the change.
```

After (adapts to whether the agent is running, the restart was deferred, or the channel was applied immediately):
```
┌  Adding channel: Slack
│
... (existing prompts and spinners) ...
│
◆  Slack channel added.
│  Start the agent:     typeclaw start
│  Then check status:   typeclaw status
│
└  Done.
```

## Foundation: `src/cli/ui.ts`

- Uses `node:util` `styleText` directly — **zero new dependencies** (Bun ≥ 1.1 ships it, and `@clack/prompts` v1.1+ uses it itself).
- `c.*` color helpers (cyan, green, red, yellow, dim, gray, magenta, bold) gated on `NO_COLOR` / `FORCE_COLOR` / `isTTY`.
- `spinner()` wrapper over `@clack/prompts.spinner()` so callers import a single CLI primitive.
- `renderStartSuccess(result)` — pure function shared by `start` and `restart` (eliminates the duplicated success block).
- `done({title, hints})` — renders next-step commands inside a clack `note()` then `outro()`, closing the previously-unterminated wizard sessions.
- `link(text, url)` — OSC 8 hyperlink with plain-text fallback.
- `errorLine` / `successLine` for consistent inline status rendering.

## Test plan

- `bun run typecheck` — exit 0
- `bun run lint` — exit 0, 0 warnings, 0 errors
- `bun run format:check` — clean
- `bun test` — **2433 pass, 0 fail** (19 new tests in `ui.test.ts` exercise the helpers with forced/no-color toggles plus a mutation check on the hostd-unavailable yellow wrap)
- Manual QA: ran `status`, `start` (no-init error path), `stop` (no daemon), `compose start`, `compose ps` against an empty directory and verified colors render correctly in TTY mode

## Commits

Six atomic commits, each individually passing all pre-commit checks:

1. `Add shared src/cli/ui helpers for colored output and reusable spinners` — foundation only
2. `Hoist status's inline ANSI table into a Palette and use styleText` — earliest consumer, also the one with test churn
3. `Wrap start and restart in spinners and share a success renderer` — paired so `git bisect` stays meaningful
4. `Polish the small host-stage commands: stop, logs, shell, reload` — bundled because each is <30 LOC of changes
5. `Color compose's per-agent results, summary, and ps STATUS column` — distinct subsystem
6. `Close the init and channel-add wizards with outro + next-steps note` — bundled because the pattern is identical

## Invariants verified

- Zero changes to `package.json` or `bun.lock` (no new deps)
- `useColor=false` invariant in `status` still holds (zero ANSI escapes in piped output)
- All existing `status.test.ts` plain-text assertions unchanged
- The 19 new tests in `ui.test.ts` use real implementations (per AGENTS.md §5 "test doubles sparingly") — no `@clack/prompts` mocks
