### PR TITLE
Tolerate "removal already in progress" from docker rm so typeclaw restart survives a concurrent cleanup race

### DIFF
--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -81,6 +81,20 @@ export function containerNameFromCwd(cwd: string): string {
   return sanitizeContainerName(basename(resolve(cwd)))
 }
 
+// `docker rm` failures we treat as success because they leave the name free
+// for the next `docker run --name <same>`, which is the post-state every
+// caller is trying to achieve:
+//   - "No such container" — removed out-of-band between our inspect and rm
+//     (peer `typeclaw stop`, manual `docker rm`, or async post-stop cleanup).
+//   - "removal of container … is already in progress" — Docker accepted a
+//     prior remove and is still draining it. start.ts's preflight re-runs
+//     `rm -f` with the same tolerance and Docker serializes, so the name is
+//     free by the time `docker run` fires.
+export function isBenignRmStderr(stderr: string): boolean {
+  const lower = stderr.toLowerCase()
+  return lower.includes('no such container') || lower.includes('removal of container')
+}
+
 export function imageTagFromCwd(cwd: string): string {
   return `typeclaw-${containerNameFromCwd(cwd)}`
 }

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -1387,6 +1387,36 @@ describe('start (composition)', () => {
     expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
   })
 
+  test('tolerates "removal already in progress" from docker rm (concurrent cleanup raced ahead)', async () => {
+    // given: a stopped corpse, and rm fails because docker is already removing
+    // the container — symmetric with stop.ts's tolerance for the same error.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec, calls } = fakeDockerExec({
+      imageExists: true,
+      container: {
+        exists: true,
+        running: false,
+        rmFails: true,
+        rmStderr: 'Error response from daemon: removal of container x is already in progress',
+      },
+    })
+
+    // when
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    // then: preflight treats it as success and proceeds to docker run
+    expect(result.ok).toBe(true)
+    expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
+  })
+
   test('reports a clear error when docker rm fails for a non-recoverable reason', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -13,7 +13,14 @@ import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 import { refreshPackageJson } from '@/init/packagejson'
 
 import { CONTAINER_PORT, findFreePort, isPortAllocatedError } from './port'
-import { containerNameFromCwd, defaultDockerExec, type DockerExec, getBun, imageTagFromCwd } from './shared'
+import {
+  containerNameFromCwd,
+  defaultDockerExec,
+  type DockerExec,
+  getBun,
+  imageTagFromCwd,
+  isBenignRmStderr,
+} from './shared'
 import { buildCrashReason, createVerifyRunning, type VerifyRunningFn } from './verify-running'
 
 const PACKAGE_FILE = 'package.json'
@@ -155,10 +162,10 @@ export async function start({
       // now the normal post-stop / post-crash state: the corpse stays around
       // for `docker logs` so users can debug a crashed agent. Force-remove
       // before `docker run --name <same>` so the new launch doesn't collide
-      // on the name. Tolerate "no such container" because the user (or an
-      // out-of-band cleanup) may have removed it between our inspect and rm.
+      // on the name. Treat benign rm failures as success — see
+      // isBenignRmStderr for the contract.
       const rm = await exec(['rm', '-f', containerName])
-      if (rm.exitCode !== 0 && !rm.stderr.toLowerCase().includes('no such container')) {
+      if (rm.exitCode !== 0 && !isBenignRmStderr(rm.stderr)) {
         return {
           ok: false,
           reason: `Container ${containerName} exists but is not running, and could not be removed: ${rm.stderr.trim() || 'no stderr'}`,

--- a/src/container/stop.test.ts
+++ b/src/container/stop.test.ts
@@ -115,6 +115,25 @@ describe('stop (composition)', () => {
     expect(result.ok).toBe(true)
   })
 
+  test('tolerates "removal already in progress" from docker rm (concurrent cleanup raced ahead)', async () => {
+    // given: docker stop succeeded, but between our stop and rm something else
+    // (peer typeclaw stop / OrbStack async cleanup) already started removing
+    // the container. Docker reports "removal of container <name> is already in
+    // progress" — a different failure shape from "no such container" but
+    // functionally equivalent: the name will be free for the next docker run.
+    const { exec } = fakeDockerExec({
+      scenario: { exists: true, running: true },
+      rmExitCode: 1,
+      rmStderr: 'Error response from daemon: removal of container vanished is already in progress',
+    })
+
+    // when
+    const result = await stop({ cwd: root, exec })
+
+    // then: stop reports success — `typeclaw restart` should not abort here
+    expect(result.ok).toBe(true)
+  })
+
   test('surfaces a clear error when docker rm fails for a non-recoverable reason', async () => {
     const { exec } = fakeDockerExec({
       scenario: { exists: true, running: false },

--- a/src/container/stop.ts
+++ b/src/container/stop.ts
@@ -1,6 +1,6 @@
 import { isDaemonReachable, send as sendToDaemon } from '@/hostd/client'
 
-import { containerNameFromCwd, defaultDockerExec, type DockerExec } from './shared'
+import { containerNameFromCwd, defaultDockerExec, type DockerExec, isBenignRmStderr } from './shared'
 
 export type StopPlan = {
   containerName: string
@@ -33,7 +33,7 @@ export async function stop({ cwd, exec = defaultDockerExec }: StopOptions): Prom
         return { ok: true, containerName, running: false }
       }
       const recover = await exec(['rm', '-f', containerName], { cwd })
-      if (recover.exitCode !== 0 && !recover.stderr.toLowerCase().includes('no such container')) {
+      if (recover.exitCode !== 0 && !isBenignRmStderr(recover.stderr)) {
         return {
           ok: false,
           reason: `docker inspect failed (${inspect.stderr.trim() || 'no stderr'}) and docker rm -f could not recover: ${recover.stderr.trim() || 'no stderr'}`,
@@ -60,10 +60,10 @@ export async function stop({ cwd, exec = defaultDockerExec }: StopOptions): Prom
     // does not collide on the name. Use `-f` for symmetry with the start.ts
     // preflight and because `docker stop` occasionally returns exit 0 before
     // the container is fully out of `Running` state on OrbStack under load —
-    // bare `docker rm` would then refuse a still-running container. Tolerate
-    // "no such container" because the user may have removed it out-of-band.
+    // bare `docker rm` would then refuse a still-running container. Treat
+    // benign rm failures as success — see isBenignRmStderr for the contract.
     const rmResult = await exec(['rm', '-f', containerName], { cwd })
-    if (rmResult.exitCode !== 0 && !rmResult.stderr.toLowerCase().includes('no such container')) {
+    if (rmResult.exitCode !== 0 && !isBenignRmStderr(rmResult.stderr)) {
       return { ok: false, reason: `docker rm failed: ${rmResult.stderr.trim() || 'no stderr'}` }
     }
 


### PR DESCRIPTION
## Summary

`typeclaw restart` aborts with the following error when a concurrent cleanup has raced ahead of the internal `docker rm`:

```
docker rm failed: Error response from daemon: removal of container <name> is already in progress
```

The name is seconds away from being free — Docker is already committing to exactly the post-state `stop()` intended — but the old guard rejected the intermediate stderr and propagated it as a hard failure.

## Root cause

`stop()` in `src/container/stop.ts` (lines 65–68 before this fix) guarded `docker rm -f` output with a single tolerated substring:

```ts
const rmResult = await exec(['rm', '-f', containerName], { cwd })
if (rmResult.exitCode !== 0 && !rmResult.stderr.toLowerCase().includes('no such container')) {
  return { ok: false, reason: `docker rm failed: ${rmResult.stderr.trim() || 'no stderr'}` }
}
```

`docker rm -f` can exit non-zero with `"Error response from daemon: removal of container <name> is already in progress"` when something else — a peer `typeclaw stop`, OrbStack's async post-stop cleanup, or a manual `docker rm` — raced ahead between our `docker stop` and our `docker rm`. Both `"no such container"` and `"removal already in progress"` have the same semantics: the name will shortly be free for the next `docker run --name <same>`. The old code treated one as success and the other as failure.

The asymmetry was visible in the same file: the `docker inspect` recovery branch (introduced in #114) already tolerated `"removal in progress"` by routing through `docker rm -f`, and `stop.test.ts` covered that case. Only the outer post-`docker stop` rm (and, symmetrically, the `start()` preflight rm at `src/container/start.ts:160`) lacked the same tolerance.

## Fix

Extract `isBenignRmStderr(stderr)` into `src/container/shared.ts` matching both substrings (case-insensitive):

```ts
// "no such container"  – already gone; the name is free.
// "removal of container" – removal in progress; the name will be free shortly.
// Both represent the post-state we wanted: the container name is available
// for the next `docker run --name <same>`.
export function isBenignRmStderr(stderr: string): boolean {
  const s = stderr.toLowerCase()
  return s.includes('no such container') || s.includes('removal of container')
}
```

Use it from three call sites:

- **`src/container/stop.ts` (outer post-`docker stop` rm)** — the user-visible failure path; this is the fix.
- **`src/container/stop.ts` (recover-from-failed-inspect rm)** — already correct for the `"removal in progress"` case (the calling branch checked for it), but switches to the shared helper for consistency.
- **`src/container/start.ts` (preflight rm before `docker run --name <same>`)** — symmetric fix; the same race can in principle hit here too if an agent was still being removed when a rapid `typeclaw start` was issued.

## Tests

Two new BDD-style regression tests:

**`src/container/stop.test.ts`** — `tolerates "removal already in progress" from docker rm (concurrent cleanup raced ahead)`

Mirrors the existing `"no such container"` test but feeds the new stderr substring. Asserts `result.ok === true`.

**`src/container/start.test.ts`** — same test on the preflight rm path.

Both use real fake-`exec` fixtures (no mocks), per AGENTS.md §5. Mutation-checked: commenting out the `'removal of container'` branch in `isBenignRmStderr` makes both new tests fail (`Expected: true / Received: false`) while all 2433 other tests continue to pass — confirming the tests guard the production change and are not vacuous.

## Verification

```
bun run typecheck    →  clean (tsgo --noEmit)
bun run lint         →  0 warnings, 0 errors (oxlint, 338 files)
bun run format:check →  all files use the correct format (oxfmt, 357 files)
bun test             →  2435 pass, 0 fail (146 files)
```

## Diff scope

```
src/container/shared.ts     | 14 ++++++++++++++   (new isBenignRmStderr helper + "why" comment)
src/container/start.test.ts | 30 ++++++++++++++++++++++++++++++   (regression test)
src/container/start.ts      | 15 +++++++++++----   (use helper at preflight rm)
src/container/stop.test.ts  | 19 +++++++++++++++++++   (regression test)
src/container/stop.ts       | 10 +++++-----   (use helper at recover-rm and outer rm)
5 files changed, 79 insertions(+), 9 deletions(-)
```

## Manual recovery for users currently stuck

If you hit this error before the fix lands, wait a few seconds and retry — Docker drains the in-progress removal asynchronously, after which `typeclaw restart` succeeds on its own. Or run `docker rm -f <agent-name>` to clear the corpse immediately, then `typeclaw start`.