### PR TITLE
Wait for Docker to finish removing the container before docker run --name

### DIFF
--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -5,10 +5,12 @@ import { join } from 'node:path'
 
 import {
   checkDockerAvailable,
+  classifyRmStderr,
   containerNameFromCwd,
   DOCKER_NOT_FOUND_STDERR,
   type DockerExec,
   imageTagFromCwd,
+  waitForRemoval,
 } from './shared'
 
 let root: string
@@ -112,5 +114,82 @@ describe('checkDockerAvailable', () => {
     await checkDockerAvailable(exec)
 
     expect(calls).toEqual([['info', '--format', '{{.ServerVersion}}']])
+  })
+})
+
+describe('classifyRmStderr', () => {
+  test('returns "gone" for "No such container" (case-insensitive)', () => {
+    expect(classifyRmStderr('Error: No such container: ati')).toBe('gone')
+    expect(classifyRmStderr('error: no such container: ati')).toBe('gone')
+  })
+
+  test('returns "in-progress" for "removal of container … is already in progress" (case-insensitive)', () => {
+    expect(classifyRmStderr('Error response from daemon: removal of container ati is already in progress')).toBe(
+      'in-progress',
+    )
+    expect(classifyRmStderr('REMOVAL OF CONTAINER X IS ALREADY IN PROGRESS')).toBe('in-progress')
+  })
+
+  test('returns null for other stderr (non-benign failures)', () => {
+    expect(classifyRmStderr('permission denied')).toBeNull()
+    expect(classifyRmStderr('')).toBeNull()
+    expect(classifyRmStderr('docker: command not found')).toBeNull()
+  })
+
+  test('"no such container" takes precedence when both substrings somehow appear', () => {
+    // given: a synthetic stderr that contains both phrases (defensive — we
+    // have not seen Docker emit this, but the helper's contract should be
+    // total). The 'gone' state is strictly cheaper for callers than
+    // 'in-progress', so prefer it when ambiguous.
+    expect(classifyRmStderr('Error: No such container: x (removal of container x was already in progress)')).toBe(
+      'gone',
+    )
+  })
+})
+
+describe('waitForRemoval', () => {
+  test('returns true as soon as docker inspect reports the container gone', async () => {
+    // given: an exec that returns "exists" twice then "no such container"
+    let calls = 0
+    const exec: DockerExec = async () => {
+      calls += 1
+      if (calls >= 3) return { exitCode: 1, stdout: '', stderr: 'Error: No such container: x' }
+      return { exitCode: 0, stdout: 'false\n', stderr: '' }
+    }
+
+    // when
+    const ok = await waitForRemoval(exec, 'x', { timeoutMs: 1_000, intervalMs: 10 })
+
+    // then
+    expect(ok).toBe(true)
+    expect(calls).toBe(3)
+  })
+
+  test('returns false on timeout when the container is still present', async () => {
+    // given: an exec that always reports the container exists
+    let calls = 0
+    const exec: DockerExec = async () => {
+      calls += 1
+      return { exitCode: 0, stdout: 'false\n', stderr: '' }
+    }
+
+    // when: a short timeout
+    const ok = await waitForRemoval(exec, 'x', { timeoutMs: 50, intervalMs: 10 })
+
+    // then
+    expect(ok).toBe(false)
+    expect(calls).toBeGreaterThanOrEqual(2)
+  })
+
+  test('issues docker inspect with the configured name', async () => {
+    const seen: string[][] = []
+    const exec: DockerExec = async (args) => {
+      seen.push(args)
+      return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+    }
+
+    await waitForRemoval(exec, 'anderson', { timeoutMs: 100, intervalMs: 10 })
+
+    expect(seen[0]).toEqual(['inspect', '--format', '{{.State.Running}}', 'anderson'])
   })
 })

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -81,18 +81,53 @@ export function containerNameFromCwd(cwd: string): string {
   return sanitizeContainerName(basename(resolve(cwd)))
 }
 
-// `docker rm` failures we treat as success because they leave the name free
-// for the next `docker run --name <same>`, which is the post-state every
-// caller is trying to achieve:
-//   - "No such container" — removed out-of-band between our inspect and rm
-//     (peer `typeclaw stop`, manual `docker rm`, or async post-stop cleanup).
-//   - "removal of container … is already in progress" — Docker accepted a
-//     prior remove and is still draining it. start.ts's preflight re-runs
-//     `rm -f` with the same tolerance and Docker serializes, so the name is
-//     free by the time `docker run` fires.
-export function isBenignRmStderr(stderr: string): boolean {
+// `docker rm` failures we treat as recoverable. The kind matters for the
+// caller's next step:
+//   - 'gone'        — "No such container". The container is already removed
+//                     (peer `typeclaw stop`, manual `docker rm`, or async
+//                     post-stop cleanup that finished first). The name is
+//                     free to reuse immediately.
+//   - 'in-progress' — "removal of container … is already in progress". Docker
+//                     accepted a prior remove and is still draining it. The
+//                     container is STILL PRESENT in `docker inspect` until
+//                     the drain completes, so a `docker run --name <same>`
+//                     fired right now would collide. Callers that follow
+//                     `rm` with `run` MUST wait for the container to
+//                     actually disappear — see waitForRemoval.
+//   - null          — non-benign failure; surface as an error.
+export type BenignRmKind = 'gone' | 'in-progress' | null
+
+export function classifyRmStderr(stderr: string): BenignRmKind {
   const lower = stderr.toLowerCase()
-  return lower.includes('no such container') || lower.includes('removal of container')
+  if (lower.includes('no such container')) return 'gone'
+  if (lower.includes('removal of container')) return 'in-progress'
+  return null
+}
+
+// Polls `docker inspect` until the named container is gone or the deadline
+// elapses. Required after a `docker rm` that returned "removal of container
+// … is already in progress": Docker has committed to removal but has not
+// finished, so the name is briefly still taken. Without this wait, the
+// caller's subsequent `docker run --name <same>` races the daemon's
+// removal-drain and intermittently fails with a name conflict (the
+// user-visible symptom under `typeclaw compose restart` and any restart of
+// a container that hostd's GC tick raced ahead on). Returns true if the
+// container disappeared before the deadline, false on timeout.
+export async function waitForRemoval(
+  exec: DockerExec,
+  name: string,
+  options: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<boolean> {
+  const timeoutMs = options.timeoutMs ?? 10_000
+  const intervalMs = options.intervalMs ?? 100
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const result = await exec(['inspect', '--format', '{{.State.Running}}', name])
+    if (result.exitCode !== 0) return true
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  const final = await exec(['inspect', '--format', '{{.State.Running}}', name])
+  return final.exitCode !== 0
 }
 
 export function imageTagFromCwd(cwd: string): string {

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -665,7 +665,21 @@ describe('commitSystemFile', () => {
 
 type RecordedCall = { args: string[]; dockerfileSnapshot: string | null }
 
-type ContainerScenario = { exists: false } | { exists: true; running: boolean; rmFails?: boolean; rmStderr?: string }
+type ContainerScenario =
+  | { exists: false }
+  | {
+      exists: true
+      running: boolean
+      rmFails?: boolean
+      rmStderr?: string
+      // Models Docker's async removal-drain after a `docker rm` that
+      // returned with "removal in progress" stderr: the container keeps
+      // showing up in `inspect` until N post-rm inspect probes have run,
+      // then transitions to "no such container". Default 0 — inspect
+      // reports "gone" the very next call. See stop.test.ts for the
+      // full rationale.
+      drainAfterInspectCalls?: number
+    }
 
 function fakeDockerExec(scenario: { imageExists: boolean; container: ContainerScenario }): {
   exec: DockerExec
@@ -673,6 +687,8 @@ function fakeDockerExec(scenario: { imageExists: boolean; container: ContainerSc
 } {
   const calls: RecordedCall[] = []
   let containerState = scenario.container
+  let rmReturned = false
+  let inspectsAfterRm = 0
   const exec: DockerExec = async (args, options) => {
     let dockerfileSnapshot: string | null = null
     if (options?.cwd) {
@@ -688,6 +704,13 @@ function fakeDockerExec(scenario: { imageExists: boolean; container: ContainerSc
       return { exitCode: scenario.imageExists ? 0 : 1, stdout: '', stderr: '' }
     }
     if (args[0] === 'inspect') {
+      if (rmReturned && containerState.exists) {
+        inspectsAfterRm += 1
+        const drainAfter = containerState.drainAfterInspectCalls ?? 0
+        if (inspectsAfterRm > drainAfter) {
+          containerState = { exists: false }
+        }
+      }
       if (!containerState.exists) return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
       // The idempotent path probes `inspect --format {{.Id}}` after seeing
       // the container is up; mirror that here so the fake stays sufficient.
@@ -702,11 +725,20 @@ function fakeDockerExec(scenario: { imageExists: boolean; container: ContainerSc
       return { exitCode: 0, stdout: '0.0.0.0:8973\n', stderr: '' }
     }
     if (args[0] === 'rm') {
+      rmReturned = true
       if (!containerState.exists) {
         return { exitCode: 1, stdout: '', stderr: 'Error: No such container: x' }
       }
       if (containerState.rmFails) {
-        return { exitCode: 1, stdout: '', stderr: containerState.rmStderr ?? 'rm failed' }
+        const stderr = containerState.rmStderr ?? 'rm failed'
+        // "No such container" rm-failures mean the container is in fact gone
+        // — Docker just learned of it a step before we did. Reflect that in
+        // the fake's state so a subsequent `docker run` sees a free name.
+        // "Removal in progress" leaves the container present (drain pending).
+        if (stderr.toLowerCase().includes('no such container')) {
+          containerState = { exists: false }
+        }
+        return { exitCode: 1, stdout: '', stderr }
       }
       containerState = { exists: false }
       return { exitCode: 0, stdout: '', stderr: '' }
@@ -715,6 +747,13 @@ function fakeDockerExec(scenario: { imageExists: boolean; container: ContainerSc
       return { exitCode: 0, stdout: '', stderr: '' }
     }
     if (args[0] === 'run') {
+      if (containerState.exists) {
+        return {
+          exitCode: 1,
+          stdout: '',
+          stderr: `docker: Error response from daemon: Conflict. The container name "/x" is already in use by container "abc".`,
+        }
+      }
       containerState = { exists: true, running: true }
       return { exitCode: 0, stdout: 'fake-container-id-abcdef\n', stderr: '' }
     }
@@ -1387,9 +1426,17 @@ describe('start (composition)', () => {
     expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
   })
 
-  test('tolerates "removal already in progress" from docker rm (concurrent cleanup raced ahead)', async () => {
-    // given: a stopped corpse, and rm fails because docker is already removing
-    // the container — symmetric with stop.ts's tolerance for the same error.
+  test('waits for Docker to finish the in-progress removal before docker run, avoiding a name conflict', async () => {
+    // given: a stopped corpse held by an in-progress async removal. The
+    // preflight rm reports "removal of container x is already in progress",
+    // and inspect keeps reporting the container as still present for two
+    // more probes before the drain completes.
+    //
+    // This test ALSO depends on the fake's docker-run path returning the
+    // real name-conflict error string when the container is still present
+    // — so if start() forgot to wait, docker run would fail with exactly
+    // the user-visible bug ("Conflict. The container name is already in
+    // use") and the test would catch it.
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     const { exec, calls } = fakeDockerExec({
@@ -1399,6 +1446,7 @@ describe('start (composition)', () => {
         running: false,
         rmFails: true,
         rmStderr: 'Error response from daemon: removal of container x is already in progress',
+        drainAfterInspectCalls: 2,
       },
     })
 
@@ -1412,9 +1460,15 @@ describe('start (composition)', () => {
       ...bypassVerify,
     })
 
-    // then: preflight treats it as success and proceeds to docker run
+    // then: start succeeded, docker run ran AGAINST A GONE CONTAINER, and
+    // we made at least one inspect call after rm to verify removal
     expect(result.ok).toBe(true)
-    expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
+    const rmIdx = calls.findIndex((c) => c.args[0] === 'rm')
+    const runIdx = calls.findIndex((c) => c.args[0] === 'run')
+    expect(rmIdx).toBeGreaterThanOrEqual(0)
+    expect(runIdx).toBeGreaterThan(rmIdx)
+    const inspectsBetween = calls.slice(rmIdx + 1, runIdx).filter((c) => c.args[0] === 'inspect')
+    expect(inspectsBetween.length).toBeGreaterThanOrEqual(1)
   })
 
   test('reports a clear error when docker rm fails for a non-recoverable reason', async () => {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -14,12 +14,13 @@ import { refreshPackageJson } from '@/init/packagejson'
 
 import { CONTAINER_PORT, findFreePort, isPortAllocatedError } from './port'
 import {
+  classifyRmStderr,
   containerNameFromCwd,
   defaultDockerExec,
   type DockerExec,
   getBun,
   imageTagFromCwd,
-  isBenignRmStderr,
+  waitForRemoval,
 } from './shared'
 import { buildCrashReason, createVerifyRunning, type VerifyRunningFn } from './verify-running'
 
@@ -162,13 +163,25 @@ export async function start({
       // now the normal post-stop / post-crash state: the corpse stays around
       // for `docker logs` so users can debug a crashed agent. Force-remove
       // before `docker run --name <same>` so the new launch doesn't collide
-      // on the name. Treat benign rm failures as success — see
-      // isBenignRmStderr for the contract.
+      // on the name. See classifyRmStderr for the benign-failure contract:
+      // 'gone' means the name is already free; 'in-progress' means Docker is
+      // still draining a prior removal and we must wait it out before docker
+      // run, or we'd hit `Conflict. The container name "/<name>" is already
+      // in use` even though our rm "succeeded".
       const rm = await exec(['rm', '-f', containerName])
-      if (rm.exitCode !== 0 && !isBenignRmStderr(rm.stderr)) {
-        return {
-          ok: false,
-          reason: `Container ${containerName} exists but is not running, and could not be removed: ${rm.stderr.trim() || 'no stderr'}`,
+      if (rm.exitCode !== 0) {
+        const kind = classifyRmStderr(rm.stderr)
+        if (kind === null) {
+          return {
+            ok: false,
+            reason: `Container ${containerName} exists but is not running, and could not be removed: ${rm.stderr.trim() || 'no stderr'}`,
+          }
+        }
+        if (kind === 'in-progress' && !(await waitForRemoval(exec, containerName))) {
+          return {
+            ok: false,
+            reason: `Container ${containerName} is still being removed by docker after 10s; refusing to docker run --name to avoid a name conflict.`,
+          }
         }
       }
     }

--- a/src/container/stop.test.ts
+++ b/src/container/stop.test.ts
@@ -34,15 +34,32 @@ type FakeOptions = {
   rmExitCode?: number
   inspectExitCode?: number
   inspectStderr?: string
+  // Models Docker's async removal-drain: after `docker rm` returns with the
+  // "in-progress" stderr (rmExitCode=1, rmStderr matching), the container
+  // does NOT immediately disappear from `docker inspect`. It only transitions
+  // to "no such container" after the inspect probe has been called this
+  // many times (simulating the drain completing). Default 0 — no drain
+  // delay — i.e. inspect reports "gone" the very next call. Set to a
+  // positive integer to exercise waitForRemoval's polling loop; set high
+  // enough to exhaust the configured timeout to exercise the timeout branch.
+  drainAfterInspectCalls?: number
 }
 
 function fakeDockerExec(options: FakeOptions): { exec: DockerExec; calls: string[][] } {
   const calls: string[][] = []
   let scenario = options.scenario
+  let inspectsAfterRm = 0
+  let rmReturned = false
   const exec: DockerExec = async (args): Promise<DockerExecResult> => {
     calls.push(args)
     if (args[0] === 'inspect') {
-      if (options.inspectExitCode !== undefined && options.inspectExitCode !== 0) {
+      if (rmReturned) {
+        inspectsAfterRm += 1
+        if (inspectsAfterRm > (options.drainAfterInspectCalls ?? 0)) {
+          scenario = { exists: false }
+        }
+      }
+      if (options.inspectExitCode !== undefined && options.inspectExitCode !== 0 && !rmReturned) {
         return { exitCode: options.inspectExitCode, stdout: '', stderr: options.inspectStderr ?? '' }
       }
       if (!scenario.exists) return { exitCode: 1, stdout: '', stderr: 'Error: No such container: x' }
@@ -56,6 +73,7 @@ function fakeDockerExec(options: FakeOptions): { exec: DockerExec; calls: string
     if (args[0] === 'rm') {
       const exitCode = options.rmExitCode ?? 0
       const stderr = options.rmStderr ?? ''
+      rmReturned = true
       if (exitCode === 0) scenario = { exists: false }
       return { exitCode, stdout: '', stderr }
     }
@@ -115,23 +133,28 @@ describe('stop (composition)', () => {
     expect(result.ok).toBe(true)
   })
 
-  test('tolerates "removal already in progress" from docker rm (concurrent cleanup raced ahead)', async () => {
-    // given: docker stop succeeded, but between our stop and rm something else
-    // (peer typeclaw stop / OrbStack async cleanup) already started removing
-    // the container. Docker reports "removal of container <name> is already in
-    // progress" — a different failure shape from "no such container" but
-    // functionally equivalent: the name will be free for the next docker run.
-    const { exec } = fakeDockerExec({
+  test('waits for the drain when docker rm returns "removal already in progress" and succeeds', async () => {
+    // given: docker stop succeeded, but rm finds the container is being
+    // removed by something else (peer typeclaw stop / OrbStack async cleanup
+    // / hostd GC). Docker will finish the drain a few hundred ms later.
+    const { exec, calls } = fakeDockerExec({
       scenario: { exists: true, running: true },
       rmExitCode: 1,
       rmStderr: 'Error response from daemon: removal of container vanished is already in progress',
+      drainAfterInspectCalls: 2,
     })
 
     // when
     const result = await stop({ cwd: root, exec })
 
-    // then: stop reports success — `typeclaw restart` should not abort here
+    // then: stop reports success, AND we polled inspect at least until the
+    // container actually disappeared — caller can safely docker run --name
     expect(result.ok).toBe(true)
+    const inspectAfterRm = calls
+      .map((c, i) => ({ c, i }))
+      .filter(({ c }) => c[0] === 'inspect')
+      .filter(({ i }) => i > calls.findIndex((cc) => cc[0] === 'rm'))
+    expect(inspectAfterRm.length).toBeGreaterThanOrEqual(2)
   })
 
   test('surfaces a clear error when docker rm fails for a non-recoverable reason', async () => {

--- a/src/container/stop.ts
+++ b/src/container/stop.ts
@@ -1,6 +1,6 @@
 import { isDaemonReachable, send as sendToDaemon } from '@/hostd/client'
 
-import { containerNameFromCwd, defaultDockerExec, type DockerExec, isBenignRmStderr } from './shared'
+import { classifyRmStderr, containerNameFromCwd, defaultDockerExec, type DockerExec, waitForRemoval } from './shared'
 
 export type StopPlan = {
   containerName: string
@@ -33,10 +33,19 @@ export async function stop({ cwd, exec = defaultDockerExec }: StopOptions): Prom
         return { ok: true, containerName, running: false }
       }
       const recover = await exec(['rm', '-f', containerName], { cwd })
-      if (recover.exitCode !== 0 && !isBenignRmStderr(recover.stderr)) {
-        return {
-          ok: false,
-          reason: `docker inspect failed (${inspect.stderr.trim() || 'no stderr'}) and docker rm -f could not recover: ${recover.stderr.trim() || 'no stderr'}`,
+      if (recover.exitCode !== 0) {
+        const kind = classifyRmStderr(recover.stderr)
+        if (kind === null) {
+          return {
+            ok: false,
+            reason: `docker inspect failed (${inspect.stderr.trim() || 'no stderr'}) and docker rm -f could not recover: ${recover.stderr.trim() || 'no stderr'}`,
+          }
+        }
+        if (kind === 'in-progress' && !(await waitForRemoval(exec, containerName))) {
+          return {
+            ok: false,
+            reason: `Container ${containerName} is still being removed by docker after 10s.`,
+          }
         }
       }
       return { ok: true, containerName, running: false }
@@ -60,11 +69,22 @@ export async function stop({ cwd, exec = defaultDockerExec }: StopOptions): Prom
     // does not collide on the name. Use `-f` for symmetry with the start.ts
     // preflight and because `docker stop` occasionally returns exit 0 before
     // the container is fully out of `Running` state on OrbStack under load —
-    // bare `docker rm` would then refuse a still-running container. Treat
-    // benign rm failures as success — see isBenignRmStderr for the contract.
+    // bare `docker rm` would then refuse a still-running container. See
+    // classifyRmStderr for the benign-failure contract; when 'in-progress',
+    // wait for the drain so stop()'s ok-return actually means "name is free"
+    // (which compose's restart and any subsequent start() depend on).
     const rmResult = await exec(['rm', '-f', containerName], { cwd })
-    if (rmResult.exitCode !== 0 && !isBenignRmStderr(rmResult.stderr)) {
-      return { ok: false, reason: `docker rm failed: ${rmResult.stderr.trim() || 'no stderr'}` }
+    if (rmResult.exitCode !== 0) {
+      const kind = classifyRmStderr(rmResult.stderr)
+      if (kind === null) {
+        return { ok: false, reason: `docker rm failed: ${rmResult.stderr.trim() || 'no stderr'}` }
+      }
+      if (kind === 'in-progress' && !(await waitForRemoval(exec, containerName))) {
+        return {
+          ok: false,
+          reason: `Container ${containerName} is still being removed by docker after 10s.`,
+        }
+      }
     }
 
     return { ok: true, containerName, running }


### PR DESCRIPTION
## Summary

`typeclaw compose restart` fails with name conflicts immediately after `typeclaw stop` reports success:

```
✔ [anderson] restarted on host port 8973
✖ [ati] failed: docker run failed: docker: Error response from daemon: Conflict. The container name "/ati" is already in use by container "be6085bd...". You have to remove (or rename) that container to be able to reuse that name.
✖ [bongbong] failed: docker run failed: docker: Error response from daemon: Conflict. The container name "/bongbong" is already in use by container "17f24542...". You have to remove (or rename) that container to be able to reuse that name.
```

Two of three agents fail; `stop()` returned `ok: true` for all of them. This is a follow-up to #117, which fixed the wrong layer.

## Root cause

PR #117 introduced `isBenignRmStderr` and taught `stop()` and `start()`'s preflight to tolerate `"removal of container <name> is already in progress"` from `docker rm -f`. The semantic judgment was correct — that stderr should not abort the operation. But the implementation was incomplete.

When Docker emits `"removal … is already in progress"`, it means a prior `docker rm` (by a concurrent `typeclaw stop`, a manual `docker rm`, or the hostd GC tick in `src/hostd/daemon.ts`) has been _accepted_ but not yet _drained_. The container is **still present** in `docker inspect` until the daemon finishes the async drain. `docker run --name <same>`, fired immediately after our `rm` returns that error, sees the still-present name and fails with the Conflict error above.

PR #117's comment said "Docker correctly serializes" — that is true for _removes_, but `docker run --name` does not wait for an in-progress removal. The race window is typically a few hundred milliseconds but is reliably blown wide by concurrent `compose restart` (the original report) or the hostd GC tick racing a simultaneous stop.

## Fix

Three coordinated changes, all in `src/container/`:

**1. `shared.ts` — replace `isBenignRmStderr` (boolean) with `classifyRmStderr` (kind)**

```ts
export type BenignRmKind = 'gone' | 'in-progress' | null

export function classifyRmStderr(stderr: string): BenignRmKind {
  const lower = stderr.toLowerCase()
  if (lower.includes('no such container')) return 'gone'        // name already free
  if (lower.includes('removal of container')) return 'in-progress'  // name still taken
  return null  // non-benign — surface as error
}
```

The distinction is load-bearing: `'gone'` means the name is immediately reusable; `'in-progress'` means it is not yet.

**2. `shared.ts` — resurrect `waitForRemoval(exec, name, options?)`**

Polls `docker inspect` until the named container disappears or a deadline elapses (default 10s / 100ms interval). This is a controlled resurrection of the helper deleted in commit 1578c20 — it was removed when `--rm` was dropped (PR #112) because there was no longer a caller. The same polling shape solves this different race:

```ts
export async function waitForRemoval(exec, name, options = {}): Promise<boolean>
```

Parameterized on `exec` so tests can drive it deterministically.

**3. `start.ts` and `stop.ts` — wire `waitForRemoval` at all three benign-rm call sites**

- `src/container/stop.ts:69` — outer post-`docker stop` rm (the path in the original bug report)
- `src/container/stop.ts:35` — recover-from-inspect-fail rm
- `src/container/start.ts:163` — preflight rm before `docker run --name`

On `'in-progress'`, each call site now waits for the drain. On timeout, it surfaces a clear error (`Container <name> is still being removed by docker after 10s`) rather than letting `docker run` fail with the confusing Conflict cascade.

## Tests

**`src/container/shared.test.ts` — 7 new unit tests:**
- `classifyRmStderr` returns `'gone'` / `'in-progress'` / `null` for their respective inputs (case-insensitive)
- `classifyRmStderr` prefers `'gone'` when both substrings appear (defensive)
- `waitForRemoval` returns `true` as soon as inspect reports the container gone
- `waitForRemoval` returns `false` on timeout when the container is still present
- `waitForRemoval` issues the right `docker inspect` invocation

**`src/container/stop.test.ts` — updated composition test:**

Replaces PR #117's now-stale `"tolerates removal already in progress"` test with one that asserts the drain is _waited for_. Uses a new `drainAfterInspectCalls: 2` knob on the fake: the container keeps reporting present in inspect until N post-rm probes have run, then transitions to gone. Asserts that at least 2 inspect calls appeared after the `rm` call.

**`src/container/start.test.ts` — updated composition test:**

Replaces PR #117's now-stale test with one that asserts wait-then-run ordering. The fake's `docker run` path now emits the real name-conflict error string when the container is still present — so any test that skips the wait fails with exactly the user-visible bug. Asserts: inspect probes appear between `rm` and `run`.

**Mutation check (per AGENTS.md §5):** Patching out the `if (kind === 'in-progress' && !(await waitForRemoval(...)))` branch in `start.ts` makes the start composition test fail with `docker run failed: docker: Error response from daemon: Conflict. The container name "/x" is already in use` — the exact production bug. The same patch in `stop.ts` makes the stop composition test fail with `Expected: >= 2 / Received: 0` post-rm inspect calls. All 2442 other tests pass with either mutation, confirming the new tests guard the fix and are not vacuous.

## Verification

```
bun run typecheck    →  clean (tsgo --noEmit)
bun run lint         →  0 warnings, 0 errors (oxlint, 338 files)
bun run format:check →  all files use the correct format (oxfmt, 357 files)
bun test             →  2444 pass, 0 fail (146 files)
```

## Diff scope

```
src/container/shared.test.ts |  79 ++++++++++++++++++++++++++++  (new classifyRmStderr + waitForRemoval unit tests)
src/container/shared.ts      |  57 ++++++++++++++++++---  (classifyRmStderr + waitForRemoval resurrected)
src/container/start.test.ts  |  68 +++++++++++++++++++---  (drain knob + updated composition test)
src/container/start.ts       |  27 +++++++++++---  (wait-on-in-progress at preflight rm)
src/container/stop.test.ts   |  41 ++++++++++++++---  (drain knob + updated composition test)
src/container/stop.ts        |  38 ++++++++++++++---  (wait-on-in-progress at both rm sites)
6 files changed, 267 insertions(+), 43 deletions(-)
```

## Manual recovery for users currently stuck

If you hit a name conflict before this fix lands:

```sh
docker rm -f <agent-name>
```

and retry. With this fix, `stop()` + `start()` handle the drain automatically.