### PR TITLE
Collapse multi-line docker stderr into a single-line reason

### DIFF
--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -10,6 +10,7 @@ import {
   DOCKER_NOT_FOUND_STDERR,
   type DockerExec,
   imageTagFromCwd,
+  sanitizeDockerStderr,
   waitForRemoval,
 } from './shared'
 
@@ -191,5 +192,46 @@ describe('waitForRemoval', () => {
     await waitForRemoval(exec, 'anderson', { timeoutMs: 100, intervalMs: 10 })
 
     expect(seen[0]).toEqual(['inspect', '--format', '{{.State.Running}}', 'anderson'])
+  })
+})
+
+describe('sanitizeDockerStderr', () => {
+  test('strips the trailing "Run docker ... --help" line and surrounding blank lines', () => {
+    const stderr =
+      'docker: Error response from daemon: Conflict. The container name "/anderson" is already in use by container "3d54c2b59b822a611703889f0b2e2c5805889653335a99eaaecb4d090dc5e2bf". You have to remove (or rename) that container to be able to reuse that name.\n\nRun \'docker run --help\' for more information\n'
+
+    expect(sanitizeDockerStderr(stderr)).toBe(
+      'Conflict. The container name "/anderson" is already in use by container "3d54c2b59b822a611703889f0b2e2c5805889653335a99eaaecb4d090dc5e2bf". You have to remove (or rename) that container to be able to reuse that name.',
+    )
+  })
+
+  test('handles --help variants for other subcommands (build, stop, rm)', () => {
+    const stderr = "some build error\n\nRun 'docker build --help' for more information\n"
+    expect(sanitizeDockerStderr(stderr)).toBe('some build error')
+  })
+
+  test('collapses internal newlines to "; " so the result fits on one line', () => {
+    const stderr = 'first detail line\nsecond detail line\nthird detail line'
+    expect(sanitizeDockerStderr(stderr)).toBe('first detail line; second detail line; third detail line')
+  })
+
+  test('preserves the daemon error body when it stands alone (no docker: prefix)', () => {
+    const stderr = 'Error response from daemon: removal of container abc is already in progress\n'
+    expect(sanitizeDockerStderr(stderr)).toBe('removal of container abc is already in progress')
+  })
+
+  test('preserves substrings that downstream tests assert on (permission denied, etc.)', () => {
+    expect(sanitizeDockerStderr('permission denied')).toBe('permission denied')
+    expect(sanitizeDockerStderr('docker: permission denied\n')).toBe('permission denied')
+  })
+
+  test('returns empty string for empty / whitespace-only input (callers fall back to their own sentinel)', () => {
+    expect(sanitizeDockerStderr('')).toBe('')
+    expect(sanitizeDockerStderr('   \n\n  ')).toBe('')
+    expect(sanitizeDockerStderr("\n\nRun 'docker run --help' for more information\n")).toBe('')
+  })
+
+  test('leaves an already-clean single-line message untouched', () => {
+    expect(sanitizeDockerStderr('some plain error')).toBe('some plain error')
   })
 })

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -58,6 +58,27 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
 // "binary missing" from "daemon down".
 export const DOCKER_NOT_FOUND_STDERR = 'docker: command not found in $PATH'
 
+// Collapse a multi-line `docker` CLI stderr into a single readable clause
+// suitable for inline `reason:` strings. The motivating case is `compose
+// restart`, which prints one row per agent — raw stderr from a failed
+// `docker run` is 3-5 lines (leading `docker: ` prefix, daemon error body,
+// blank line, "Run 'docker run --help' for more information" tail) and
+// turns each failing row into an ASCII wall. Strip the boilerplate, drop
+// the help-pointer tail (it's noise in a programmatic context — users who
+// hit it can run `docker run --help` themselves), and join any remaining
+// detail lines with "; " so the result fits on the same row as the
+// `✖ [name] failed:` prefix that wraps it.
+export function sanitizeDockerStderr(stderr: string): string {
+  const withoutHelpTail = stderr.replace(/\n*\s*Run '[^']+--help' for more information\s*\n?/g, '')
+  const lines = withoutHelpTail
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.replace(/^docker:\s*/, '').replace(/^Error response from daemon:\s*/, ''))
+    .filter((line) => line.length > 0)
+  return lines.join('; ')
+}
+
 export type DockerAvailability = { ok: true } | { ok: false; reason: 'binary-missing' | 'daemon-down'; detail: string }
 
 // `docker info --format {{.ServerVersion}}` is the probe of choice because it

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -20,6 +20,7 @@ import {
   type DockerExec,
   getBun,
   imageTagFromCwd,
+  sanitizeDockerStderr,
   waitForRemoval,
 } from './shared'
 import { buildCrashReason, createVerifyRunning, type VerifyRunningFn } from './verify-running'
@@ -174,7 +175,7 @@ export async function start({
         if (kind === null) {
           return {
             ok: false,
-            reason: `Container ${containerName} exists but is not running, and could not be removed: ${rm.stderr.trim() || 'no stderr'}`,
+            reason: `Container ${containerName} exists but is not running, and could not be removed: ${sanitizeDockerStderr(rm.stderr) || 'no stderr'}`,
           }
         }
         if (kind === 'in-progress' && !(await waitForRemoval(exec, containerName))) {
@@ -232,7 +233,7 @@ export async function start({
 
     if (run.exitCode !== 0) {
       await cleanupHostDaemonRegistration(containerName, hostd)
-      return { ok: false, reason: `docker run failed: ${run.stderr.trim() || 'no stderr'}` }
+      return { ok: false, reason: `docker run failed: ${sanitizeDockerStderr(run.stderr) || 'no stderr'}` }
     }
 
     const containerId = run.stdout.trim()

--- a/src/container/stop.ts
+++ b/src/container/stop.ts
@@ -1,6 +1,13 @@
 import { isDaemonReachable, send as sendToDaemon } from '@/hostd/client'
 
-import { classifyRmStderr, containerNameFromCwd, defaultDockerExec, type DockerExec, waitForRemoval } from './shared'
+import {
+  classifyRmStderr,
+  containerNameFromCwd,
+  defaultDockerExec,
+  type DockerExec,
+  sanitizeDockerStderr,
+  waitForRemoval,
+} from './shared'
 
 export type StopPlan = {
   containerName: string
@@ -38,7 +45,7 @@ export async function stop({ cwd, exec = defaultDockerExec }: StopOptions): Prom
         if (kind === null) {
           return {
             ok: false,
-            reason: `docker inspect failed (${inspect.stderr.trim() || 'no stderr'}) and docker rm -f could not recover: ${recover.stderr.trim() || 'no stderr'}`,
+            reason: `docker inspect failed (${sanitizeDockerStderr(inspect.stderr) || 'no stderr'}) and docker rm -f could not recover: ${sanitizeDockerStderr(recover.stderr) || 'no stderr'}`,
           }
         }
         if (kind === 'in-progress' && !(await waitForRemoval(exec, containerName))) {
@@ -59,7 +66,7 @@ export async function stop({ cwd, exec = defaultDockerExec }: StopOptions): Prom
     if (running) {
       const stopResult = await exec(['stop', containerName], { cwd })
       if (stopResult.exitCode !== 0) {
-        return { ok: false, reason: `docker stop failed: ${stopResult.stderr.trim() || 'no stderr'}` }
+        return { ok: false, reason: `docker stop failed: ${sanitizeDockerStderr(stopResult.stderr) || 'no stderr'}` }
       }
     }
 
@@ -77,7 +84,7 @@ export async function stop({ cwd, exec = defaultDockerExec }: StopOptions): Prom
     if (rmResult.exitCode !== 0) {
       const kind = classifyRmStderr(rmResult.stderr)
       if (kind === null) {
-        return { ok: false, reason: `docker rm failed: ${rmResult.stderr.trim() || 'no stderr'}` }
+        return { ok: false, reason: `docker rm failed: ${sanitizeDockerStderr(rmResult.stderr) || 'no stderr'}` }
       }
       if (kind === 'in-progress' && !(await waitForRemoval(exec, containerName))) {
         return {


### PR DESCRIPTION
## Summary

Docker CLI errors span 3–5 lines: a prefixed header, detail lines, and a trailing `Run 'docker <cmd> --help' for more information` footer. When `typeclaw compose restart` encounters several failing agents simultaneously, the combined output becomes an unreadable wall of text.

This PR adds a `sanitizeDockerStderr()` helper and wires it into every call site that previously interpolated raw stderr into error `reason:` strings, collapsing each agent's failure to a single readable line.

## Before / After

**Before** — 4 failing agents in `compose restart` produced ~20 lines:

```
✖ [anderson] failed: docker run failed: docker: Error response from daemon: Conflict. The container name "/anderson" is already in use by container "3d54c2b5...". You have to remove (or rename) that container to be able to reuse that name.

Run 'docker run --help' for more information.
✖ [bernhardt] failed: docker run failed: docker: Error response from daemon: Conflict. …

Run 'docker run --help' for more information.
…
```

**After** — one line per agent:

```
✖ [anderson] failed: docker run failed: Conflict. The container name "/anderson" is already in use by container "3d54c2b5...". You have to remove (or rename) that container to be able to reuse that name.
✖ [bernhardt] failed: docker run failed: Conflict. …
```

## Changes

### `src/container/shared.ts` — new helper

`sanitizeDockerStderr(stderr: string)`:
- Strips the trailing `Run 'docker <subcmd> --help' for more information` boilerplate line (handles `--help` and `-h` variants).
- Strips leading `docker: ` and `Error response from daemon: ` prefixes from each line.
- Joins remaining detail lines with `; ` so multi-line errors read as one clause.
- Returns `""` on whitespace-only or help-only input so the existing `|| 'no stderr'` sentinel fires as before.

### `src/container/start.ts` — 2 call sites

- `docker run` failure reason.
- `docker inspect` failure reason (in the container-exists-but-not-running path).

### `src/container/stop.ts` — 3 call sites

- `docker stop` failure reason.
- `docker rm` failure reason.
- `docker inspect` failure reason.

## Context

The underlying name-conflict race that triggered this UX issue was already fixed upstream by commits 52b4163 (`Wait for Docker to finish removing the container before docker run`) and b1b0348 (`Tolerate "removal already in progress" from docker rm in stop and start`). This PR is purely output-cosmetic and fully complementary — the sanitizer wraps the stderr strings that surface within those already-classified error paths.

Scope is intentionally narrow: no behavior change for any caller that doesn't parse `reason:` for substrings. The TUI prints it; tests grep for fragments (`permission denied`, `docker stop failed`, etc.) that the sanitizer preserves.

## Testing

- `bun test src/container/` → **154 pass / 0 fail**
- `bun test` (full suite) → **2451 pass / 0 fail**
- `bun run typecheck`, `bun run lint`, `bun run format` — all clean.

7 new unit tests in `src/container/shared.test.ts` (`describe('sanitizeDockerStderr', ...)`) cover:
1. Help-tail stripping (`--help` variant).
2. Multiple `--help` / `-h` variants.
3. Newline collapse across multiple detail lines.
4. Prefix stripping when the prefix is the only content.
5. Downstream-substring preservation (`permission denied`, etc.).
6. Empty / whitespace-only input → empty string.
7. Clean input passthrough (no mutation when no boilerplate present).

All existing assertions in `stop.test.ts` and `start.test.ts` that match `/permission denied/`, `/docker stop failed/`, `/docker inspect failed/` continue to pass because the sanitizer preserves those load-bearing substrings.