### PR TITLE
Wait for Docker to drain even when docker rm -f returns exit 0

### DIFF
--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -740,7 +740,14 @@ function fakeDockerExec(scenario: { imageExists: boolean; container: ContainerSc
         }
         return { exitCode: 1, stdout: '', stderr }
       }
-      containerState = { exists: false }
+      // Exit 0 from `docker rm -f` does NOT mean the name is free under
+      // OrbStack load — the daemon acknowledges the rm before draining. The
+      // inspect block above already advances containerState to "gone" after
+      // drainAfterInspectCalls post-rm probes, so leaving the state alone
+      // here lets exit-0 tests exercise the same drain window the
+      // "in-progress" tests do. drainAfterInspectCalls === 0 (the default
+      // for existing tests) still flips state on the very next inspect, so
+      // the pre-existing happy-path tests continue to see immediate "gone".
       return { exitCode: 0, stdout: '', stderr: '' }
     }
     if (args[0] === 'build') {
@@ -1462,6 +1469,52 @@ describe('start (composition)', () => {
 
     // then: start succeeded, docker run ran AGAINST A GONE CONTAINER, and
     // we made at least one inspect call after rm to verify removal
+    expect(result.ok).toBe(true)
+    const rmIdx = calls.findIndex((c) => c.args[0] === 'rm')
+    const runIdx = calls.findIndex((c) => c.args[0] === 'run')
+    expect(rmIdx).toBeGreaterThanOrEqual(0)
+    expect(runIdx).toBeGreaterThan(rmIdx)
+    const inspectsBetween = calls.slice(rmIdx + 1, runIdx).filter((c) => c.args[0] === 'inspect')
+    expect(inspectsBetween.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test('waits for Docker to finish removal when rm returns exit 0 but container is still draining (OrbStack under load)', async () => {
+    // given: a stopped corpse. The preflight `docker rm -f` returns exit 0
+    // — i.e. Docker acknowledged the request — but the daemon has not yet
+    // finished draining. `inspect` still sees the container for two more
+    // probes after rm. This is the canonical failure mode behind the
+    // user-visible `typeclaw compose restart` bug: stop()'s rm returns 0,
+    // start()'s preflight sees the corpse, start()'s rm returns 0, but
+    // docker run --name fires before the drain completes and hits
+    // "Conflict. The container name is already in use by container <ID>".
+    //
+    // The fake's docker-run path returns the real name-conflict error
+    // when the container is still present, so without the waitForRemoval
+    // on the exit-0 path, this test fails with exactly the user-visible
+    // error message.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec, calls } = fakeDockerExec({
+      imageExists: true,
+      container: {
+        exists: true,
+        running: false,
+        drainAfterInspectCalls: 2,
+      },
+    })
+
+    // when
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    // then: start succeeded (docker run did not race the drain), and we
+    // made at least one inspect call between rm and run to verify removal
     expect(result.ok).toBe(true)
     const rmIdx = calls.findIndex((c) => c.args[0] === 'rm')
     const runIdx = calls.findIndex((c) => c.args[0] === 'run')

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -169,6 +169,20 @@ export async function start({
       // still draining a prior removal and we must wait it out before docker
       // run, or we'd hit `Conflict. The container name "/<name>" is already
       // in use` even though our rm "succeeded".
+      //
+      // Even when `docker rm -f` returns exit 0 we MUST wait for the inspect
+      // probe to confirm the name is free. On OrbStack (and occasionally
+      // Docker Desktop) under concurrent load — the canonical case being
+      // `typeclaw compose restart`, which fires N parallel stop→start pairs
+      // — `rm -f` acknowledges the request before the daemon has finished
+      // draining the removal. The container is still listed by `docker ps -a`
+      // (with the same ID Docker reports back in the "Conflict. The container
+      // name … is already in use by container <ID>" error) for tens to
+      // hundreds of milliseconds, and `docker run --name <same>` issued
+      // inside that window deterministically loses the race. waitForRemoval
+      // returns on the first inspect probe in the happy path (one extra
+      // `docker inspect` per start when there was a corpse), so the cost
+      // here is bounded and small.
       const rm = await exec(['rm', '-f', containerName])
       if (rm.exitCode !== 0) {
         const kind = classifyRmStderr(rm.stderr)
@@ -183,6 +197,11 @@ export async function start({
             ok: false,
             reason: `Container ${containerName} is still being removed by docker after 10s; refusing to docker run --name to avoid a name conflict.`,
           }
+        }
+      } else if (!(await waitForRemoval(exec, containerName))) {
+        return {
+          ok: false,
+          reason: `Container ${containerName} is still being removed by docker after 10s; refusing to docker run --name to avoid a name conflict.`,
         }
       }
     }

--- a/src/container/stop.test.ts
+++ b/src/container/stop.test.ts
@@ -34,14 +34,15 @@ type FakeOptions = {
   rmExitCode?: number
   inspectExitCode?: number
   inspectStderr?: string
-  // Models Docker's async removal-drain: after `docker rm` returns with the
-  // "in-progress" stderr (rmExitCode=1, rmStderr matching), the container
+  // Models Docker's async removal-drain after `docker rm`. The container
   // does NOT immediately disappear from `docker inspect`. It only transitions
   // to "no such container" after the inspect probe has been called this
   // many times (simulating the drain completing). Default 0 — no drain
   // delay — i.e. inspect reports "gone" the very next call. Set to a
   // positive integer to exercise waitForRemoval's polling loop; set high
   // enough to exhaust the configured timeout to exercise the timeout branch.
+  // Applies BOTH to the "in-progress" non-zero rm and to the exit-0 rm
+  // (OrbStack/Docker Desktop under load acknowledge the rm before draining).
   drainAfterInspectCalls?: number
 }
 
@@ -74,7 +75,13 @@ function fakeDockerExec(options: FakeOptions): { exec: DockerExec; calls: string
       const exitCode = options.rmExitCode ?? 0
       const stderr = options.rmStderr ?? ''
       rmReturned = true
-      if (exitCode === 0) scenario = { exists: false }
+      // Exit 0 from `docker rm -f` does NOT mean the container is gone on
+      // OrbStack under load — the daemon acknowledges the rm before
+      // draining. Defer the scenario transition to the inspect drain logic
+      // above so tests with drainAfterInspectCalls > 0 model the real race
+      // window. drainAfterInspectCalls === 0 (the default) still flips
+      // scenario on the very next inspect probe, so existing exit-0 tests
+      // continue to see "gone" immediately.
       return { exitCode, stdout: '', stderr }
     }
     return { exitCode: 0, stdout: '', stderr: '' }
@@ -155,6 +162,30 @@ describe('stop (composition)', () => {
       .filter(({ c }) => c[0] === 'inspect')
       .filter(({ i }) => i > calls.findIndex((cc) => cc[0] === 'rm'))
     expect(inspectAfterRm.length).toBeGreaterThanOrEqual(2)
+  })
+
+  test('waits for the drain when docker rm returns exit 0 but the container is still in inspect (OrbStack under load)', async () => {
+    // given: a running container. `docker rm -f` returns exit 0 but Docker
+    // has not yet finished draining — `inspect` still sees the container
+    // for two more probes. This is the canonical OrbStack-under-load
+    // failure mode behind `typeclaw compose restart`'s "Conflict. The
+    // container name is already in use" — stop() returning before the
+    // drain completes lets the subsequent start() race the daemon.
+    const { exec, calls } = fakeDockerExec({
+      scenario: { exists: true, running: true },
+      rmExitCode: 0,
+      drainAfterInspectCalls: 2,
+    })
+
+    // when
+    const result = await stop({ cwd: root, exec })
+
+    // then: stop reports success only AFTER inspect confirmed the name is
+    // free — at least one inspect probe must run between rm and return.
+    expect(result.ok).toBe(true)
+    const rmIdx = calls.findIndex((c) => c[0] === 'rm')
+    const inspectAfterRm = calls.slice(rmIdx + 1).filter((c) => c[0] === 'inspect')
+    expect(inspectAfterRm.length).toBeGreaterThanOrEqual(1)
   })
 
   test('surfaces a clear error when docker rm fails for a non-recoverable reason', async () => {

--- a/src/container/stop.ts
+++ b/src/container/stop.ts
@@ -80,6 +80,16 @@ export async function stop({ cwd, exec = defaultDockerExec }: StopOptions): Prom
     // classifyRmStderr for the benign-failure contract; when 'in-progress',
     // wait for the drain so stop()'s ok-return actually means "name is free"
     // (which compose's restart and any subsequent start() depend on).
+    //
+    // Same waitForRemoval call on the exit-0 path for the same reason as the
+    // start.ts preflight: OrbStack and Docker Desktop under load acknowledge
+    // `rm -f` before the daemon has finished draining the removal, so an
+    // immediate `docker run --name <same>` (from `typeclaw compose restart`,
+    // which fires stop→start sequentially per agent) races the drain and
+    // fails with "Conflict. The container name … is already in use by
+    // container <ID>". stop()'s contract is that the name is free on return,
+    // and the only way to honor that against Docker's async removal is to
+    // poll inspect until the container actually disappears.
     const rmResult = await exec(['rm', '-f', containerName], { cwd })
     if (rmResult.exitCode !== 0) {
       const kind = classifyRmStderr(rmResult.stderr)
@@ -91,6 +101,11 @@ export async function stop({ cwd, exec = defaultDockerExec }: StopOptions): Prom
           ok: false,
           reason: `Container ${containerName} is still being removed by docker after 10s.`,
         }
+      }
+    } else if (!(await waitForRemoval(exec, containerName))) {
+      return {
+        ok: false,
+        reason: `Container ${containerName} is still being removed by docker after 10s.`,
       }
     }
 


### PR DESCRIPTION
## Summary

`typeclaw compose restart` still fails with name conflicts on a subset of agents — even after #118, which was supposed to be the definitive fix for this class of bug:

```
✖ [anderson] failed: docker run failed: Conflict. The container name "/anderson" is already in use by container "940c7aa778bf...". You have to remove (or rename) that container to be able to reuse that name.
✔ [ati] restarted on host port 56003
✖ [bongbong] failed: docker run failed: Conflict. The container name "/bongbong" is already in use by container "702e17bd7906...". You have to remove (or rename) that container to be able to reuse that name.
✔ [pengpeng] restarted on host port 56004
✔ [yangyang] restarted on host port 8973
```

Same error string as #118's report, same intermittent pattern (some succeed, others fail), same `compose restart` trigger.

## Root cause

#118 wired `waitForRemoval` into every `docker rm -f` site whose stderr classified as `'in-progress'`. The mental model was: _Docker either fully removes the container before `rm` returns (exit 0), or returns the in-progress stderr (non-zero) and we wait._ The fix held that bet.

It turns out OrbStack (and Docker Desktop under load) has a third state: **`docker rm -f` returns exit 0 with empty stderr, but the container is still listed by `docker inspect` for tens to hundreds of milliseconds afterward.** The daemon acknowledges the rm before it has finished draining. We've been reproducing this in `compose restart` because the parallel `Promise.all` over agents bursts enough simultaneous docker requests at the daemon to push the drain off the synchronous path.

Concretely, for one of the failing agents in the report above:

1. `stop()` runs `docker rm -f anderson` → exit 0, empty stderr → returns `{ ok: true }`
2. `compose restart` proceeds to `start({ cwd: anderson })` for the same agent
3. `start()`'s preflight inspect sees the container still present (drain still queued)
4. `start()` runs `docker rm -f anderson` → exit 0, empty stderr again → falls through the `if (rm.exitCode !== 0)` guard entirely
5. `start()` does `bun install`, `refreshDockerfile`, port allocation, hostd register — milliseconds, sometimes hundreds of them
6. `start()` fires `docker run --name anderson …` → daemon has _still_ not drained → `Conflict. The container name "/anderson" is already in use by container "940c7aa778bf…"`

The container ID in the error message is the exact corpse we just `rm -f`'d. The daemon knows it's being removed; it just hasn't gotten there yet.

The exit-0 path was untested for this case because the test fakes assumed `rm exitCode === 0 ⇒ container is gone`. That assumption modeled "fully synchronous Docker" — which is not what either OrbStack or Docker Desktop deliver under concurrent load.

## Fix

Two production changes, symmetric to #118's design:

**1. `src/container/start.ts` — `else if` branch in the preflight rm**

After `exec(['rm', '-f', containerName])` returns exit 0 in the `state.exists` preflight, call `waitForRemoval` and refuse to proceed if it times out. The error message is identical to the in-progress timeout error so users see a coherent failure mode regardless of which branch they hit.

**2. `src/container/stop.ts` — `else if` branch on the outer rm**

Same change at the rm site that follows `docker stop`. This is the call `compose restart` depends on for its contract: when `stop()` returns `{ ok: true }`, the next `start()` must be able to `docker run --name <same>` without colliding.

The happy-path cost is **one extra `docker inspect`** per rm call. `waitForRemoval` polls every 100ms with `docker inspect`; on the truly-gone fast path the first probe returns non-zero immediately and the function returns `true`. No additional latency vs the pre-#118 baseline on machines where Docker is genuinely synchronous.

## Tests

**`src/container/stop.test.ts` — 1 new test, 1 fake-helper change:**

- `waits for the drain when docker rm returns exit 0 but the container is still in inspect (OrbStack under load)` — drives `fakeDockerExec` with `rmExitCode: 0, drainAfterInspectCalls: 2`. Asserts that at least one inspect call appears between `rm` and `stop()` returning.
- Fake helper: removed the `if (exitCode === 0) scenario = { exists: false }` short-circuit in the rm branch. The inspect block already advances `scenario` after `drainAfterInspectCalls` post-rm probes, so the fake now models the real OrbStack race. `drainAfterInspectCalls === 0` (the default) still flips state on the very next inspect, so every pre-existing exit-0 test continues to see immediate "gone".

**`src/container/start.test.ts` — 1 new test, 1 fake-helper change:**

- `waits for Docker to finish removal when rm returns exit 0 but container is still draining (OrbStack under load)` — same shape as the stop.test.ts test, but driving `start()`'s preflight. The fake's `docker run` path returns the **real** name-conflict error string when the container is still present, so without `waitForRemoval` on the exit-0 path, this test fails with exactly the user-visible bug (`result.ok === false` with `reason` matching the production error).
- Fake helper: same change as stop.test.ts, with the same backwards-compat property for existing tests.

**Mutation check (per AGENTS.md §5)** — verified by stashing both production-code edits and re-running:

```
src/container/stop.test.ts > waits for the drain when docker rm returns exit 0 …
  → Expected: >= 1 / Received: 0  (no inspect probe ran between rm and return)

src/container/start.test.ts > waits for Docker to finish removal when rm returns exit 0 …
  → Expected: true / Received: false  (docker run failed with the Conflict error)
```

Both new tests fail without the fix; both pass with it. The Conflict error in the start.test.ts failure is the same string the user reported. The pre-existing `force-removes a stale stopped container with the same name and proceeds to docker run` test also picked up the fake-helper change, which is the intended cross-check: it exercises the same `state.exists ⇒ rm ⇒ run` path and now requires production to wait for the drain instead of trusting `rm exitCode === 0`.

## Verification

```
bun run typecheck     →  clean (tsgo --noEmit)
bun run lint          →  0 warnings, 0 errors (oxlint, 340 files)
bun run format:check  →  all files use the correct format (oxfmt, 359 files)
bun test              →  2465 pass, 0 fail (147 files)
```

## Diff scope

```
src/container/start.test.ts | 55 ++++++++++++++++++++++++++++++++++++++++++++-
src/container/start.ts      | 19 ++++++++++++++++
src/container/stop.test.ts  | 37 +++++++++++++++++++++++++++---
src/container/stop.ts       | 15 +++++++++++++
4 files changed, 122 insertions(+), 4 deletions(-)
```

Tightly scoped to `src/container/start.ts`, `src/container/stop.ts`, and their test files. No public API change; no schema change; no Dockerfile change. The CLI, compose, hostd, and portbroker layers are all unchanged.

## Relationship to #118

#118 fixed the in-progress (non-zero rm) race. This PR fixes the exit-0 rm race using the same `waitForRemoval` helper and the same timeout error message. Together they close every known path where `start()` can fire `docker run --name <same>` against a still-draining container.

## Manual recovery for users currently stuck

If you hit a name conflict before this fix lands:

```sh
docker rm -f <agent-name>
```

then retry `typeclaw compose restart`. After this fix, `stop()` + `start()` handle the drain automatically regardless of how Docker chose to acknowledge the rm.