### PR TITLE
Retry docker run on Docker's name-reservation split-state race

### DIFF
--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -10,6 +10,7 @@ import {
   DOCKER_NOT_FOUND_STDERR,
   type DockerExec,
   imageTagFromCwd,
+  isContainerNameConflict,
   sanitizeDockerStderr,
   waitForRemoval,
 } from './shared'
@@ -145,6 +146,30 @@ describe('classifyRmStderr', () => {
     expect(classifyRmStderr('Error: No such container: x (removal of container x was already in progress)')).toBe(
       'gone',
     )
+  })
+})
+
+describe('isContainerNameConflict', () => {
+  test('detects the canonical "container name is already in use" error from docker run', () => {
+    const stderr =
+      'docker: Error response from daemon: Conflict. The container name "/anderson" is already in use by container "e8d39ae0eb16428c58b143b3a8ac60267ae87ce4fc0f2859022183b512287209". You have to remove (or rename) that container to be able to reuse that name.\n'
+    expect(isContainerNameConflict(stderr)).toBe(true)
+  })
+
+  test('is case-insensitive', () => {
+    expect(isContainerNameConflict('CONTAINER NAME "/x" IS ALREADY IN USE')).toBe(true)
+  })
+
+  test('returns false for unrelated docker run errors', () => {
+    expect(isContainerNameConflict('docker: Bind for :::8973 failed: port is already allocated')).toBe(false)
+    expect(isContainerNameConflict('permission denied')).toBe(false)
+    expect(isContainerNameConflict('Error response from daemon: image not found')).toBe(false)
+    expect(isContainerNameConflict('')).toBe(false)
+  })
+
+  test('requires BOTH "container name" and "is already in use" — neither alone is sufficient', () => {
+    expect(isContainerNameConflict('container name was rejected')).toBe(false)
+    expect(isContainerNameConflict('port is already in use')).toBe(false)
   })
 })
 

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -125,6 +125,35 @@ export function classifyRmStderr(stderr: string): BenignRmKind {
   return null
 }
 
+// Detects Docker's name-conflict response from `docker run --name <X>`:
+//   docker: Error response from daemon: Conflict. The container name
+//   "/<X>" is already in use by container "<id>". You have to remove
+//   (or rename) that container to be able to reuse that name.
+//
+// This is the user-visible failure mode behind `typeclaw compose restart`
+// even after stop()/start()'s preflight already waited for `docker inspect`
+// to report the container gone. Docker maintains TWO pieces of state for a
+// container name: the container record (visible to `inspect` / `ps -a`) and
+// a separate name-reservation entry checked by `docker run --name`. Under
+// load — most reliably reproduced on OrbStack with N parallel agents
+// restarting via `Promise.all` — those two drain at different times. The
+// container record drops first; the name reservation lingers tens to
+// hundreds of ms longer. `waitForRemoval` polls the container record, so
+// it can return "gone" while `docker run --name <same>` still loses on the
+// reservation.
+//
+// The robust signal is the operation we actually need to succeed: probe by
+// running `docker run` itself and retry on conflict. classifyRmStderr
+// covers `docker rm`'s benign cases; this helper covers `docker run`'s.
+//
+// Matches case-insensitively on the canonical phrasing across Docker
+// Engine, Docker Desktop, and OrbStack. The (or rename) clause is the
+// most stable substring across vendor message variants.
+export function isContainerNameConflict(stderr: string): boolean {
+  const lower = stderr.toLowerCase()
+  return lower.includes('container name') && lower.includes('is already in use')
+}
+
 // Polls `docker inspect` until the named container is gone or the deadline
 // elapses. Required after a `docker rm` that returned "removal of container
 // … is already in progress": Docker has committed to removal but has not
@@ -134,6 +163,11 @@ export function classifyRmStderr(stderr: string): BenignRmKind {
 // user-visible symptom under `typeclaw compose restart` and any restart of
 // a container that hostd's GC tick raced ahead on). Returns true if the
 // container disappeared before the deadline, false on timeout.
+//
+// NOTE: `inspect` reporting "gone" is necessary but NOT sufficient for
+// `docker run --name <same>` to succeed — Docker's name-reservation table
+// drains independently. waitForRemoval is the fast path; the retry on
+// `docker run` (see isContainerNameConflict) is the safety net.
 export async function waitForRemoval(
   exec: DockerExec,
   name: string,

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -1545,6 +1545,111 @@ describe('start (composition)', () => {
     if (!result.ok) expect(result.reason).toMatch(/exists but is not running/)
     expect(calls.find((c) => c.args[0] === 'run')).toBeUndefined()
   })
+
+  test('retries docker run when Docker returns "container name is already in use" despite inspect reporting gone (split-state race)', async () => {
+    // given: a fresh start. The preflight `docker inspect` reports the
+    // container is gone, so start() proceeds straight to `docker run`. But
+    // Docker's name-reservation table has not finished draining a prior
+    // removal, so the first two `docker run` attempts fail with the exact
+    // user-visible conflict error from typeclaw compose restart. The third
+    // attempt succeeds.
+    //
+    // Without the retry, the test fails with the production error string
+    // verbatim — that's the mutation check.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    let runAttempts = 0
+    const conflictStderr =
+      'docker: Error response from daemon: Conflict. The container name "/anderson" is already in use by container "e8d39ae0eb16428c58b143b3a8ac60267ae87ce4fc0f2859022183b512287209". You have to remove (or rename) that container to be able to reuse that name.'
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
+      if (args[0] === 'inspect') return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+      if (args[0] === 'run') {
+        runAttempts++
+        if (runAttempts <= 2) return { exitCode: 125, stdout: '', stderr: conflictStderr }
+        return { exitCode: 0, stdout: 'fake-id\n', stderr: '' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(runAttempts).toBe(3)
+  })
+
+  test('surfaces the docker run name-conflict error after exhausting retries', async () => {
+    // given: Docker keeps returning the name-conflict error on every
+    // attempt — e.g. a wedged corpse on a sick daemon that no amount of
+    // waiting will fix. start() must eventually give up and surface the
+    // error so the user can act (`docker rm -f <name>` or restart Docker)
+    // instead of silently hanging.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    let runAttempts = 0
+    const conflictStderr =
+      'docker: Error response from daemon: Conflict. The container name "/x" is already in use by container "abc". You have to remove (or rename) that container to be able to reuse that name.'
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
+      if (args[0] === 'inspect') return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+      if (args[0] === 'run') {
+        runAttempts++
+        return { exitCode: 125, stdout: '', stderr: conflictStderr }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/Conflict.*container name.*is already in use/)
+    expect(runAttempts).toBeGreaterThanOrEqual(2)
+  })
+
+  test('does NOT retry when docker run fails for a non-conflict reason (e.g. image pull error)', async () => {
+    // given: a non-conflict docker run failure. The conflict retry loop
+    // must not shadow the existing fast-fail behavior — the user sees the
+    // error immediately, exactly once.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    let runAttempts = 0
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
+      if (args[0] === 'inspect') return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+      if (args[0] === 'run') {
+        runAttempts++
+        return { exitCode: 125, stdout: '', stderr: 'docker: Error response from daemon: image not found' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(runAttempts).toBe(1)
+    if (!result.ok) expect(result.reason).toMatch(/image not found/)
+  })
 })
 
 describe('start (port allocation)', () => {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -18,8 +18,10 @@ import {
   containerNameFromCwd,
   defaultDockerExec,
   type DockerExec,
+  type DockerExecResult,
   getBun,
   imageTagFromCwd,
+  isContainerNameConflict,
   sanitizeDockerStderr,
   waitForRemoval,
 } from './shared'
@@ -233,7 +235,7 @@ export async function start({
       built = true
     }
 
-    let run = await exec(plan.runArgs, { cwd })
+    let run = await execRunWithConflictRetry(exec, plan.runArgs, cwd)
 
     // TOCTOU: another process may have grabbed the port between our probe and
     // `docker run`, or the kernel-assigned port may itself have been claimed.
@@ -247,7 +249,7 @@ export async function start({
         hostdControl = hostd.state === 'registered' ? hostd.control : undefined
       }
       plan = await planStart({ cwd, hostPort, imageExists: true, forceBuild: false, hostdControl })
-      run = await exec(plan.runArgs, { cwd })
+      run = await execRunWithConflictRetry(exec, plan.runArgs, cwd)
     }
 
     if (run.exitCode !== 0) {
@@ -416,6 +418,32 @@ async function inspectContainer(exec: DockerExec, name: string): Promise<Inspect
   const result = await exec(['inspect', '--format', '{{.State.Running}}', name])
   if (result.exitCode !== 0) return { exists: false }
   return { exists: true, running: result.stdout.trim() === 'true' }
+}
+
+// Cumulative budget ~2.7s. Five attempts is enough for the worst OrbStack-
+// under-load drain we've observed (a few hundred ms); the trailing 1200ms
+// step gives headroom for an unusually slow drain without ballooning the
+// budget on the genuinely-stuck case where the user needs to see the error.
+const RUN_RETRY_DELAYS_MS = [100, 200, 400, 800, 1200] as const
+
+// Retries `docker run` on name-conflict responses to handle Docker's split-
+// state race: `docker inspect <name>` can report "no such container" while
+// `docker run --name <same>` still rejects on the name-reservation table.
+// See isContainerNameConflict for the full failure-mode rationale.
+//
+// Only the name-conflict path retries — any other non-zero exit is returned
+// to the caller unchanged so the existing port-conflict TOCTOU retry and
+// permission-denied surfacing keep working without being shadowed by the
+// outer retry loop.
+async function execRunWithConflictRetry(exec: DockerExec, runArgs: string[], cwd: string): Promise<DockerExecResult> {
+  let last = await exec(runArgs, { cwd })
+  for (const delayMs of RUN_RETRY_DELAYS_MS) {
+    if (last.exitCode === 0) return last
+    if (!isContainerNameConflict(last.stderr)) return last
+    await new Promise((resolve) => setTimeout(resolve, delayMs))
+    last = await exec(runArgs, { cwd })
+  }
+  return last
 }
 
 // Idempotent path for `start()`: the named container is already up. Reflect


### PR DESCRIPTION
## Summary

`typeclaw compose restart` still fails with Docker name-conflict errors even after #120 was merged. #120's fix (waitForRemoval polling on `docker inspect`) was correct but insufficient: Docker maintains a separate name-reservation table that drains **after** the container record disappears from `inspect`/`ps -a`. So `docker run --name <X>` can still hit `Conflict. The container name is already in use by container <ID>` even when `inspect` already reports the container gone.

User-reported failure (post-#120):

\`\`\`
typeclaw compose restart
✖ [anderson] failed: docker run failed: Conflict. The container name \"/anderson\" is already in use by container \"e8d39ae0eb16428c58b143b3a8ac60267ae87ce4fc0f2859022183b512287209\". You have to remove (or rename) that container to be able to reuse that name.
✖ [ati] failed: docker run failed: Conflict. The container name \"/ati\" is already in use by container \"2ce93560df436ed0d00d14e91a3961f951c877d0487909eed08ed2d1485c5515\". You have to remove (or rename) that container to be able to reuse that name.
✔ [bongbong] restarted on host port 56381
✔ [pengpeng] restarted on host port 8973
✖ [yangyang] failed: docker run failed: Conflict. The container name \"/yangyang\" is already in use by container \"824e03e428f742c89eac1b2a21ed0edf68e20996320ab64bf65d91c01434371e\". You have to remove (or rename) that container to be able to reuse that name.
restarted 2/5 (3 failed)
\`\`\`

Most reproducible on OrbStack with N parallel agents via \`Promise.all\` in compose restart.

## Root cause

After #120 merged, for one failing agent:

1. \`stop(anderson)\` → \`docker stop\` → \`docker rm -f\` exit 0 → \`waitForRemoval\` polls \`inspect\` → exit 1 on first probe → \`stop()\` returns ok.
2. \`start(anderson)\` → \`inspectContainer\` returns \`{ exists: false }\` (inspect agrees the container is gone).
3. \`start()\` skips the \`if (state.exists)\` block entirely — no rm, no \`waitForRemoval\` in start.
4. \`start()\` does \`bun install\`, refreshes Dockerfile, allocates port, registers with hostd — tens to hundreds of ms.
5. \`start()\` fires \`docker run -d --name anderson ...\` → Docker's name-reservation table **still holds \`/anderson\`** → Conflict against the corpse ID we just rm'd.

The two pieces of Docker state (container record visible to \`inspect\`/\`ps\`, vs name reservation checked by \`run --name\`) drain at different times. \`inspect\` reporting \"gone\" is necessary but not sufficient for the name to be free. This matches the moby/moby#23371, #24706, #37698 family of patterns.

## Fix

**1. \`src/container/shared.ts\`** — new \`isContainerNameConflict(stderr)\` classifier matching the canonical Docker error (case-insensitive on \`container name\` + \`is already in use\`). Symmetric with \`classifyRmStderr\` which covers docker rm's benign cases.

**2. \`src/container/start.ts\`** — wrap the two \`docker run\` call sites (initial run + port-conflict TOCTOU retry) with \`execRunWithConflictRetry\`. Six total attempts (one initial + five retries) with 100/200/400/800/1200ms backoff (~2.7s cumulative sleep budget). Retries only on name-conflict — every other non-zero exit propagates unchanged so the existing port-conflict retry and permission-denied surfacing keep working. A \`runRetryDelaysMs\` test seam on \`StartOptions\` lets tests run the same six-attempt shape with zero wall time; production omits it and gets the default.

**3. No change to \`stop.ts\`.** \`stop()\`'s \`waitForRemoval\` still protects callers from the inspect-side drain on the rm path. The new retry handles the run-side drain on the daemon name-reservation table. The two are complementary: \`waitForRemoval\` is the fast path (one extra inspect on happy path), the retry is the safety net.

## Tests

**\`src/container/shared.test.ts\`** — 4 tests for \`isContainerNameConflict\`:

- Detects the canonical error from the user's bug report (verbatim string).
- Case-insensitive match.
- Returns false for unrelated docker run errors (port conflict, permission denied, image not found, empty).
- Requires BOTH \`\"container name\"\` AND \`\"is already in use\"\` — neither alone is sufficient (defensive against future substring drift).

**\`src/container/start.test.ts\`** — 3 tests for retry behavior:

- \`retries docker run when Docker returns \"container name is already in use\" despite inspect reporting gone (split-state race)\` — the critical mutation check. First two \`docker run\` attempts return the exact user-visible error string, third succeeds. Asserts \`result.ok && runAttempts === 3\`. **Mutation check verified**: with production fix reverted, this test fails with \`expect(result.ok).toBe(true) → Received: false\` — the production error string makes it all the way to \`start()\`'s return value.
- \`surfaces the docker run name-conflict error after exhausting all six attempts (initial + five retries)\` — daemon stuck forever. Asserts \`result.ok: false\` with reason matching the conflict error, AND \`runAttempts === 6\` exactly (locks in the documented retry budget so any future shrinkage/expansion must update the test explicitly).
- \`does NOT retry when docker run fails for a non-conflict reason (e.g. image pull error)\` — anti-regression: the conflict retry must not shadow other fast-fail paths. Asserts \`runAttempts === 1\`.

## Verification

\`\`\`
bun run typecheck     →  clean
bun run lint          →  0 warnings, 0 errors (340 files)
bun run format:check  →  clean (359 files)
bun test src/container/  →  163 pass, 0 fail (8 files, 2.85s — exhaustion test runs in 63ms via the runRetryDelaysMs seam)
\`\`\`

Full suite has 2 pre-existing failures in \`scripts/generate-schema.test.ts\` (secrets.schema.json regeneration) — unrelated to this PR, fails on main with this branch stashed.

## Diff scope

\`\`\`
src/container/shared.test.ts |  25 +++++++++
src/container/shared.ts      |  34 ++++++++++++
src/container/start.test.ts  | 111 +++++++++++++++++++++++++++++++++++
src/container/start.ts       |  46 ++++++++++++++-
4 files changed, 214 insertions(+), 2 deletions(-)
\`\`\`

Tightly scoped. No public API change (the \`runRetryDelaysMs\` field on \`StartOptions\` is an internal test seam consistent with the existing \`allocatePort\`/\`ensureDeps\`/\`verifyRunning\` pattern). No schema change, no Dockerfile change. compose, hostd, portbroker, CLI all unchanged.

## Relationship to prior PRs

- #118 fixed the in-progress (non-zero rm) drain race on the inspect side.
- #120 fixed the exit-0 rm drain race on the inspect side.
- This PR fixes the **name-reservation** drain race on the run side — the layer \`inspect\` cannot observe.

Together these three close every known path where \`start()\` races Docker's removal-drain.

## Manual recovery for users currently stuck

\`\`\`sh
docker rm -f <agent-name>
\`\`\`

then retry \`typeclaw compose restart\`. After this fix, the retry handles the daemon drain automatically.