### PR TITLE
Force-remove failed-run corpses instead of sleeping on the conflict

### DIFF
--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import {
   checkDockerAvailable,
   classifyRmStderr,
+  cleanupRunCorpse,
   containerNameFromCwd,
   DOCKER_NOT_FOUND_STDERR,
   type DockerExec,
@@ -217,6 +218,127 @@ describe('waitForRemoval', () => {
     await waitForRemoval(exec, 'anderson', { timeoutMs: 100, intervalMs: 10 })
 
     expect(seen[0]).toEqual(['inspect', '--format', '{{.State.Running}}', 'anderson'])
+  })
+})
+
+describe('cleanupRunCorpse', () => {
+  test('returns "gone" when inspect reports no such container (no rm issued)', async () => {
+    let rmIssued = false
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'inspect') return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+      if (args[0] === 'rm') {
+        rmIssued = true
+        return { exitCode: 0, stdout: '', stderr: '' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    expect(await cleanupRunCorpse(exec, 'x')).toBe('gone')
+    expect(rmIssued).toBe(false)
+  })
+
+  test('returns "removed" after force-removing a non-running corpse and waiting for the drain', async () => {
+    // The probe uses `{{.Id}}|{{.State.Running}}` so cleanupRunCorpse can
+    // issue rm by ID (closes the TOCTOU window where a peer might create
+    // a different live container with the same name between probe and rm).
+    let rmCalls = 0
+    let inspectCalls = 0
+    let rmDone = false
+    let rmTarget: string | undefined
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'inspect') {
+        inspectCalls++
+        if (!rmDone) return { exitCode: 0, stdout: 'corpse-id-abc|false\n', stderr: '' }
+        return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+      }
+      if (args[0] === 'rm') {
+        rmCalls++
+        rmTarget = args[args.length - 1]
+        rmDone = true
+        return { exitCode: 0, stdout: '', stderr: '' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    expect(await cleanupRunCorpse(exec, 'x')).toBe('removed')
+    expect(rmCalls).toBe(1)
+    // rm MUST target the probed ID, not the name — otherwise a same-name
+    // peer created between probe and rm would be killed.
+    expect(rmTarget).toBe('corpse-id-abc')
+    // probe inspect + at least one waitForRemoval inspect = 2+
+    expect(inspectCalls).toBeGreaterThanOrEqual(2)
+  })
+
+  test('returns "running" and does NOT issue rm when the named container is currently running', async () => {
+    let rmIssued = false
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'inspect') return { exitCode: 0, stdout: 'live-id-abc|true\n', stderr: '' }
+      if (args[0] === 'rm') {
+        rmIssued = true
+        return { exitCode: 0, stdout: '', stderr: '' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    expect(await cleanupRunCorpse(exec, 'x')).toBe('running')
+    expect(rmIssued).toBe(false)
+  })
+
+  test('returns "removed" when rm reports "in-progress" and inspect later confirms removal', async () => {
+    let rmDone = false
+    let postRmInspects = 0
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'inspect') {
+        if (!rmDone) return { exitCode: 0, stdout: 'corpse-id|false\n', stderr: '' }
+        postRmInspects++
+        if (postRmInspects <= 1) return { exitCode: 0, stdout: 'false\n', stderr: '' }
+        return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+      }
+      if (args[0] === 'rm') {
+        rmDone = true
+        return {
+          exitCode: 1,
+          stdout: '',
+          stderr: 'Error response from daemon: removal of container x is already in progress',
+        }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    expect(await cleanupRunCorpse(exec, 'x')).toBe('removed')
+    expect(postRmInspects).toBeGreaterThanOrEqual(2)
+  })
+
+  test('returns "gone" when rm reports the container is already gone', async () => {
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'inspect') return { exitCode: 0, stdout: 'corpse-id|false\n', stderr: '' }
+      if (args[0] === 'rm') return { exitCode: 1, stdout: '', stderr: 'Error: No such container: x' }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    expect(await cleanupRunCorpse(exec, 'x')).toBe('gone')
+  })
+
+  test('returns "stuck" when rm fails with a non-benign error', async () => {
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'inspect') return { exitCode: 0, stdout: 'corpse-id|false\n', stderr: '' }
+      if (args[0] === 'rm') return { exitCode: 1, stdout: '', stderr: 'permission denied' }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    expect(await cleanupRunCorpse(exec, 'x')).toBe('stuck')
+  })
+
+  test('returns "stuck" when probe stdout is malformed (no ID, defensive)', async () => {
+    // Defensive: a daemon hiccup returning exit 0 with empty stdout
+    // should not let us issue rm without an ID — we'd fall back to
+    // killing by name and that's the very TOCTOU we're closing.
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'inspect') return { exitCode: 0, stdout: '\n', stderr: '' }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    expect(await cleanupRunCorpse(exec, 'x')).toBe('stuck')
   })
 })
 

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -130,21 +130,23 @@ export function classifyRmStderr(stderr: string): BenignRmKind {
 //   "/<X>" is already in use by container "<id>". You have to remove
 //   (or rename) that container to be able to reuse that name.
 //
-// This is the user-visible failure mode behind `typeclaw compose restart`
-// even after stop()/start()'s preflight already waited for `docker inspect`
-// to report the container gone. Docker maintains TWO pieces of state for a
-// container name: the container record (visible to `inspect` / `ps -a`) and
-// a separate name-reservation entry checked by `docker run --name`. Under
-// load — most reliably reproduced on OrbStack with N parallel agents
-// restarting via `Promise.all` — those two drain at different times. The
-// container record drops first; the name reservation lingers tens to
-// hundreds of ms longer. `waitForRemoval` polls the container record, so
-// it can return "gone" while `docker run --name <same>` still loses on the
-// reservation.
+// The dominant cause of this error in `typeclaw compose restart` is NOT a
+// transient name-reservation drain (PR #121's hypothesis) but a concrete
+// corpse left behind by an earlier `docker run` in the same start() call
+// that failed AFTER Docker created the container record. The canonical
+// path: compose restart fires N agents in parallel via Promise.all; they
+// race for the preferred host port; the loser's `docker run -p <busy>:...`
+// fails with "port is already allocated", and depending on the daemon
+// version Docker may have already created the container record before the
+// port bind failed. start()'s port-TOCTOU retry then re-runs `docker run`
+// with a fresh ephemeral port but the SAME --name, and hits this conflict
+// against the corpse from the previous attempt. The corpse is stable —
+// sleep-only retries cannot make it go away.
 //
-// The robust signal is the operation we actually need to succeed: probe by
-// running `docker run` itself and retry on conflict. classifyRmStderr
-// covers `docker rm`'s benign cases; this helper covers `docker run`'s.
+// The fix is destructive: when this error fires for a non-running same-name
+// container, force-remove it before retrying. See cleanupRunCorpse for the
+// safety contract (only force-remove containers that are NOT running, so a
+// concurrent legitimate start of the same name is never killed).
 //
 // Matches case-insensitively on the canonical phrasing across Docker
 // Engine, Docker Desktop, and OrbStack. The (or rename) clause is the
@@ -152,6 +154,54 @@ export function classifyRmStderr(stderr: string): BenignRmKind {
 export function isContainerNameConflict(stderr: string): boolean {
   const lower = stderr.toLowerCase()
   return lower.includes('container name') && lower.includes('is already in use')
+}
+
+// Result of probing whether a previous `docker run --name <X>` left a corpse
+// blocking the next run:
+//   - 'gone'     — no container with that name. Safe to `docker run --name`.
+//   - 'removed'  — corpse existed and was force-removed (and waitForRemoval
+//                  confirmed it disappeared). Safe to `docker run --name`.
+//   - 'running'  — a container with that name is currently RUNNING. We did
+//                  NOT remove it. Caller must NOT proceed with `docker run
+//                  --name <same>`: that would either fail again or imply a
+//                  concurrent legitimate start that we should not kill.
+//   - 'stuck'    — corpse existed but did not disappear within waitForRemoval
+//                  budget. Caller should surface a clear error rather than
+//                  loop forever.
+export type CorpseCleanupOutcome = 'gone' | 'removed' | 'running' | 'stuck'
+
+// Inspects the named container; if a non-running corpse is holding the
+// name (the failure mode behind `typeclaw compose restart`'s persistent
+// Conflict errors), force-removes it and waits for the removal to drain.
+// Explicitly refuses to touch a RUNNING container so that a concurrent
+// legitimate start of the same name (or a foreign-but-named container the
+// user wants kept alive) is never killed by this cleanup path. Errors from
+// the rm itself are folded into 'stuck' so the caller can surface a single
+// "still here" reason rather than chase docker stderr variants.
+//
+// The rm is keyed on the container ID we read from the same inspect call,
+// NOT on the name. This closes the TOCTOU window where another process
+// could create a live container with the same name between our inspect
+// (saw a non-running corpse with ID A) and our rm: removing by name would
+// kill the new live container with ID B, but removing by ID A targets the
+// specific corpse we measured. If ID A is already gone by the time rm
+// fires (e.g. a concurrent cleanup beat us), the rm returns "No such
+// container" which classifyRmStderr folds into 'gone'. waitForRemoval
+// is still keyed on name because that's what the caller's next
+// `docker run --name <name>` will actually collide on.
+export async function cleanupRunCorpse(exec: DockerExec, name: string): Promise<CorpseCleanupOutcome> {
+  const probe = await exec(['inspect', '--format', '{{.Id}}|{{.State.Running}}', name])
+  if (probe.exitCode !== 0) return 'gone'
+  const [id = '', running = ''] = probe.stdout.trim().split('|')
+  if (running === 'true') return 'running'
+  if (id === '') return 'stuck'
+  const rm = await exec(['rm', '-f', id])
+  if (rm.exitCode !== 0) {
+    const kind = classifyRmStderr(rm.stderr)
+    if (kind === 'gone') return 'gone'
+    if (kind === null) return 'stuck'
+  }
+  return (await waitForRemoval(exec, name)) ? 'removed' : 'stuck'
 }
 
 // Polls `docker inspect` until the named container is gone or the deadline

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -1546,27 +1546,62 @@ describe('start (composition)', () => {
     expect(calls.find((c) => c.args[0] === 'run')).toBeUndefined()
   })
 
-  test('retries docker run when Docker returns "container name is already in use" despite inspect reporting gone (split-state race)', async () => {
-    // given: a fresh start. The preflight `docker inspect` reports the
-    // container is gone, so start() proceeds straight to `docker run`. But
-    // Docker's name-reservation table has not finished draining a prior
-    // removal, so the first two `docker run` attempts fail with the exact
-    // user-visible conflict error from typeclaw compose restart. The third
-    // attempt succeeds.
+  test('retries docker run after force-removing the non-running corpse that holds the name', async () => {
+    // given: the preflight `docker inspect` says the name is free, so
+    // start() proceeds to `docker run`. The first run fails with the
+    // user-visible name-conflict error referencing a concrete corpse ID —
+    // exactly the failure mode behind the reported `typeclaw compose
+    // restart` bug. Once the retry path force-removes the corpse, the
+    // next `docker run --name <same>` succeeds.
     //
-    // Without the retry, the test fails with the production error string
-    // verbatim — that's the mutation check.
+    // Mutation check: revert the cleanupRunCorpse call inside
+    // execRunWithConflictRetry to a passive setTimeout and this test fails
+    // — the fake's `docker run` keeps returning conflict until something
+    // flips containerExists to false, and only the rm path does that.
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     let runAttempts = 0
-    const conflictStderr =
-      'docker: Error response from daemon: Conflict. The container name "/anderson" is already in use by container "e8d39ae0eb16428c58b143b3a8ac60267ae87ce4fc0f2859022183b512287209". You have to remove (or rename) that container to be able to reuse that name.'
+    let rmAttempts = 0
+    // Models the moby#51758 / moby#8294 bug: docker create succeeds and
+    // reserves the name, but `docker run -p <busy>:...` later fails with
+    // port-allocated and leaves the corpse in `docker ps -a`. In this test
+    // start()'s preflight inspect runs BEFORE the corpse is created, so it
+    // sees "no such container" and skips the preflight rm — exactly the
+    // race the production fix must handle inside execRunWithConflictRetry.
+    let corpseExists = false
+    let rmTarget: string | undefined
+    const corpseId = 'e8d39ae0eb16428c58b143b3a8ac60267ae87ce4fc0f2859022183b512287209'
+    const conflictStderr = `docker: Error response from daemon: Conflict. The container name "/anderson" is already in use by container "${corpseId}". You have to remove (or rename) that container to be able to reuse that name.`
+    const calls: { args: string[] }[] = []
     const exec: DockerExec = async (args) => {
+      calls.push({ args })
       if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
-      if (args[0] === 'inspect') return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+      if (args[0] === 'inspect') {
+        if (!corpseExists) return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+        // cleanupRunCorpse asks for `{{.Id}}|{{.State.Running}}`; everything
+        // else (preflight, waitForRemoval) only asks for State.Running. Both
+        // formats are emitted here — the production parser ignores the
+        // extra field, and the cleanupRunCorpse parser splits on '|'.
+        if (args.includes('{{.Id}}|{{.State.Running}}')) {
+          return { exitCode: 0, stdout: `${corpseId}|false\n`, stderr: '' }
+        }
+        return { exitCode: 0, stdout: 'false\n', stderr: '' }
+      }
+      if (args[0] === 'rm') {
+        rmAttempts++
+        rmTarget = args[args.length - 1]
+        corpseExists = false
+        return { exitCode: 0, stdout: '', stderr: '' }
+      }
       if (args[0] === 'run') {
         runAttempts++
-        if (runAttempts <= 2) return { exitCode: 125, stdout: '', stderr: conflictStderr }
+        if (runAttempts === 1) {
+          // Simulate Docker creating the named container before failing
+          // the actual run; surface the conflict against that corpse.
+          corpseExists = true
+          return { exitCode: 125, stdout: '', stderr: conflictStderr }
+        }
+        if (corpseExists) return { exitCode: 125, stdout: '', stderr: conflictStderr }
         return { exitCode: 0, stdout: 'fake-id\n', stderr: '' }
       }
       return { exitCode: 0, stdout: '', stderr: '' }
@@ -1582,15 +1617,337 @@ describe('start (composition)', () => {
     })
 
     expect(result.ok).toBe(true)
-    expect(runAttempts).toBe(3)
+    expect(runAttempts).toBe(2)
+    expect(rmAttempts).toBe(1)
+    // The rm MUST target the corpse ID parsed from the inspect probe,
+    // NOT the container name. Targeting by name is the TOCTOU race where
+    // a same-name peer container spun up between probe and rm gets killed.
+    expect(rmTarget).toBe(corpseId)
+    const firstRunIdx = calls.findIndex((c) => c.args[0] === 'run')
+    const rmIdx = calls.findIndex((c) => c.args[0] === 'rm')
+    const lastRunIdx = calls.length - 1 - [...calls].reverse().findIndex((c) => c.args[0] === 'run')
+    expect(rmIdx).toBeGreaterThan(firstRunIdx)
+    expect(rmIdx).toBeLessThan(lastRunIdx)
   })
 
-  test('surfaces the docker run name-conflict error after exhausting retries', async () => {
-    // given: Docker keeps returning the name-conflict error on every
-    // attempt — e.g. a wedged corpse on a sick daemon that no amount of
-    // waiting will fix. start() must eventually give up and surface the
-    // error so the user can act (`docker rm -f <name>` or restart Docker)
-    // instead of silently hanging.
+  test('does NOT force-remove a RUNNING same-name container when docker run reports conflict', async () => {
+    // given: a docker run hits a name conflict but the named container is
+    // currently RUNNING. The destructive retry path MUST refuse to kill a
+    // live container — that would either murder a concurrent legitimate
+    // start of the same name OR a foreign container the user wants alive.
+    // start() must surface the conflict error untouched.
+    //
+    // Mutation check: drop the running-check from cleanupRunCorpse and
+    // this test fails — rmAttempts becomes 1 and the live container is
+    // killed.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    let runAttempts = 0
+    let rmAttempts = 0
+    let probeAttempts = 0
+    const conflictStderr =
+      'docker: Error response from daemon: Conflict. The container name "/x" is already in use by container "abc". You have to remove (or rename) that container to be able to reuse that name.'
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
+      if (args[0] === 'inspect') {
+        probeAttempts++
+        // First inspect (start's preflight) reports gone so we proceed to docker run.
+        if (probeAttempts === 1) return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+        // Subsequent inspect (the retry-path corpse probe) reports running=true.
+        // cleanupRunCorpse uses `{{.Id}}|{{.State.Running}}`; non-cleanupRunCorpse
+        // callers use just State.Running. Emit both formats so either parser works.
+        if (args.includes('{{.Id}}|{{.State.Running}}')) {
+          return { exitCode: 0, stdout: 'live-id|true\n', stderr: '' }
+        }
+        return { exitCode: 0, stdout: 'true\n', stderr: '' }
+      }
+      if (args[0] === 'rm') {
+        rmAttempts++
+        return { exitCode: 0, stdout: '', stderr: '' }
+      }
+      if (args[0] === 'run') {
+        runAttempts++
+        return { exitCode: 125, stdout: '', stderr: conflictStderr }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/Conflict.*container name.*is already in use/)
+    expect(rmAttempts).toBe(0)
+    expect(runAttempts).toBe(1)
+  })
+
+  test('cleans up the failed-run corpse before retrying with a new port (TOCTOU + port-bind-after-create)', async () => {
+    // given: the first `docker run -p 8973:...` fails because another
+    // process claimed 8973 between our probe and the run, AND Docker
+    // already created the named container record before the port bind
+    // failed. The port-TOCTOU retry must force-remove the corpse before
+    // re-running `docker run --name <same>` with the new port, or the
+    // retry hits the user-visible Conflict error against its own corpse
+    // — exactly the bug `typeclaw compose restart` was hitting.
+    //
+    // Mutation check: remove the cleanupRunCorpse call in the port-retry
+    // branch and this test fails — the second `docker run` returns
+    // conflict against the corpse left by the first run.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    let runAttempts = 0
+    let rmAttempts = 0
+    let corpseExists = false
+    const calls: { args: string[] }[] = []
+    const portStderr = 'docker: Bind for :::8973 failed: port is already allocated'
+    const conflictStderr =
+      'docker: Error response from daemon: Conflict. The container name "/x" is already in use by container "deadbeef". You have to remove (or rename) that container to be able to reuse that name.'
+    const exec: DockerExec = async (args) => {
+      calls.push({ args })
+      if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
+      if (args[0] === 'inspect') {
+        if (!corpseExists) return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+        if (args.includes('{{.Id}}|{{.State.Running}}')) {
+          return { exitCode: 0, stdout: 'deadbeef|false\n', stderr: '' }
+        }
+        return { exitCode: 0, stdout: 'false\n', stderr: '' }
+      }
+      if (args[0] === 'rm') {
+        rmAttempts++
+        corpseExists = false
+        return { exitCode: 0, stdout: '', stderr: '' }
+      }
+      if (args[0] === 'run') {
+        runAttempts++
+        if (runAttempts === 1) {
+          // Docker created the container before failing the port bind.
+          corpseExists = true
+          return { exitCode: 125, stdout: '', stderr: portStderr }
+        }
+        if (corpseExists) return { exitCode: 125, stdout: '', stderr: conflictStderr }
+        return { exitCode: 0, stdout: 'fake-id\n', stderr: '' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    const ports = [8973, 49160]
+    const allocatePort = async (): Promise<number> => ports.shift() ?? 0
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(runAttempts).toBe(2)
+    expect(rmAttempts).toBe(1)
+    // The cleanup rm must happen BETWEEN the two docker run calls so the
+    // second run sees a free name.
+    const firstRunIdx = calls.findIndex((c) => c.args[0] === 'run')
+    const rmIdx = calls.findIndex((c) => c.args[0] === 'rm')
+    const lastRunIdx = calls.length - 1 - [...calls].reverse().findIndex((c) => c.args[0] === 'run')
+    expect(rmIdx).toBeGreaterThan(firstRunIdx)
+    expect(rmIdx).toBeLessThan(lastRunIdx)
+    // The retry used the new port.
+    const runCalls = calls.filter((c) => c.args[0] === 'run')
+    expect(runCalls[0]!.args).toContain('127.0.0.1:8973:8973')
+    expect(runCalls[1]!.args).toContain('127.0.0.1:49160:8973')
+  })
+
+  test('waits for "removal in progress" to drain during conflict-retry cleanup', async () => {
+    // given: docker run reports name conflict; the retry path calls
+    // `docker rm -f` which itself returns "removal of container … is
+    // already in progress". The cleanup must call waitForRemoval to
+    // confirm the container actually disappears before retrying
+    // `docker run`, or the retry races the drain and fails again.
+    //
+    // Mutation check: revert cleanupRunCorpse to skip waitForRemoval on
+    // the "in-progress" rm-stderr path and this test fails — the second
+    // docker run fires while inspect still reports the corpse, returning
+    // conflict.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    let inspectsBeforeRm = 0
+    let inspectAfterRm = 0
+    let rmReturned = false
+    let runAttempts = 0
+    const conflictStderr =
+      'docker: Error response from daemon: Conflict. The container name "/x" is already in use by container "abc". You have to remove (or rename) that container to be able to reuse that name.'
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
+      if (args[0] === 'inspect') {
+        if (!rmReturned) {
+          inspectsBeforeRm++
+          // First inspect is start's preflight (name is free); second is
+          // cleanupRunCorpse's pre-rm probe AFTER the failed docker run
+          // has populated the corpse — it must see the corpse to issue rm.
+          if (inspectsBeforeRm === 1) return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+          if (args.includes('{{.Id}}|{{.State.Running}}')) {
+            return { exitCode: 0, stdout: 'abc|false\n', stderr: '' }
+          }
+          return { exitCode: 0, stdout: 'false\n', stderr: '' }
+        }
+        inspectAfterRm++
+        // Container keeps showing up for 2 post-rm probes, then drains.
+        if (inspectAfterRm <= 2) return { exitCode: 0, stdout: 'false\n', stderr: '' }
+        return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+      }
+      if (args[0] === 'rm') {
+        rmReturned = true
+        return {
+          exitCode: 1,
+          stdout: '',
+          stderr: 'Error response from daemon: removal of container x is already in progress',
+        }
+      }
+      if (args[0] === 'run') {
+        runAttempts++
+        // Until cleanup actually waits for the drain, every retry hits
+        // conflict — that's the regression this test guards against.
+        if (!rmReturned || inspectAfterRm <= 2) return { exitCode: 125, stdout: '', stderr: conflictStderr }
+        return { exitCode: 0, stdout: 'fake-id\n', stderr: '' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    // Cleanup probed inspect post-rm at least once (waitForRemoval).
+    expect(inspectAfterRm).toBeGreaterThanOrEqual(1)
+    // docker run must have been retried at least once after the failed
+    // initial attempt — otherwise the test never exercised the drain path.
+    expect(runAttempts).toBeGreaterThanOrEqual(2)
+  })
+
+  test('backs off between conflict retries when cleanup reports gone but the name still conflicts', async () => {
+    // given: Docker's name-reservation table is draining independently of
+    // `docker inspect`. cleanupRunCorpse's probe returns 'gone' (inspect
+    // says the corpse is removed), but the very next `docker run --name`
+    // still hits a Conflict because the reservation hasn't released. The
+    // production fix's bounded backoff (100/200/400ms) covers exactly
+    // this residual race — without it, three rapid-fire retries all
+    // happen inside the same drain window and exhaust uselessly.
+    //
+    // Mutation check: delete the `await setTimeout(backoffMs)` from
+    // execRunWithConflictRetry and this test fails — runAttempts hits 4
+    // immediately and result.ok is false because the drain never
+    // completes between attempts.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    let runAttempts = 0
+    const drainStart = Date.now()
+    const drainMs = 150
+    const conflictStderr =
+      'docker: Error response from daemon: Conflict. The container name "/x" is already in use by container "abc". You have to remove (or rename) that container to be able to reuse that name.'
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
+      // inspect always reports 'gone' — modeling the daemon's split-state:
+      // the container record disappears from inspect/ps but the name
+      // reservation lingers a bit longer.
+      if (args[0] === 'inspect') return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+      if (args[0] === 'run') {
+        runAttempts++
+        // Returns conflict until enough wall time has elapsed for the
+        // name reservation to drain.
+        if (Date.now() - drainStart < drainMs) {
+          return { exitCode: 125, stdout: '', stderr: conflictStderr }
+        }
+        return { exitCode: 0, stdout: 'fake-id\n', stderr: '' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    // The backoff between retries gives the daemon time to drain. With
+    // the bug (no sleep), all four attempts would fire within ms.
+    expect(runAttempts).toBeGreaterThanOrEqual(2)
+  })
+
+  test('removes the corpse by ID, not by name, to avoid killing a same-name peer (TOCTOU)', async () => {
+    // given: cleanupRunCorpse's inspect probe sees a non-running corpse
+    // with ID "corpse-A". Between probe and rm, a concurrent peer starts
+    // a NEW live container with the same name (ID "live-B"). If our rm
+    // targets the name, we'd kill live-B. If our rm targets the probed
+    // ID "corpse-A", we remove only the corpse we measured.
+    //
+    // This test asserts the rm command is invoked with the corpse ID, not
+    // the container name. Mutation check: switch rm back to `rm -f <name>`
+    // and this assertion fails directly.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const corpseId = 'corpse-A-1234'
+    const containerName = basename(root)
+    let rmTarget: string | undefined
+    let runAttempts = 0
+    const conflictStderr = `docker: Error response from daemon: Conflict. The container name "/${containerName}" is already in use by container "${corpseId}". You have to remove (or rename) that container to be able to reuse that name.`
+    const exec: DockerExec = async (args) => {
+      if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
+      if (args[0] === 'inspect') {
+        if (args.includes('{{.Id}}|{{.State.Running}}')) {
+          return { exitCode: 0, stdout: `${corpseId}|false\n`, stderr: '' }
+        }
+        return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+      }
+      if (args[0] === 'rm') {
+        rmTarget = args[args.length - 1]
+        return { exitCode: 0, stdout: '', stderr: '' }
+      }
+      if (args[0] === 'run') {
+        runAttempts++
+        if (runAttempts === 1) return { exitCode: 125, stdout: '', stderr: conflictStderr }
+        return { exitCode: 0, stdout: 'fake-id\n', stderr: '' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(rmTarget).toBe(corpseId)
+    expect(rmTarget).not.toBe(containerName)
+  })
+
+  test('surfaces the docker run name-conflict error when cleanup cannot free the name', async () => {
+    // given: Docker keeps returning the name-conflict error AND the
+    // cleanup `docker rm -f` cannot complete — a wedged daemon or a
+    // protected container that no amount of cleanup-then-retry will fix.
+    // start() must eventually give up and surface the original error so
+    // the user can act (`docker rm -f <name>` manually, restart Docker)
+    // instead of looping forever.
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     let runAttempts = 0

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -15,6 +15,7 @@ import { refreshPackageJson } from '@/init/packagejson'
 import { CONTAINER_PORT, findFreePort, isPortAllocatedError } from './port'
 import {
   classifyRmStderr,
+  cleanupRunCorpse,
   containerNameFromCwd,
   defaultDockerExec,
   type DockerExec,
@@ -235,21 +236,45 @@ export async function start({
       built = true
     }
 
-    let run = await execRunWithConflictRetry(exec, plan.runArgs, cwd)
+    let run = await execRunWithConflictRetry(exec, plan.runArgs, cwd, containerName)
 
     // TOCTOU: another process may have grabbed the port between our probe and
     // `docker run`, or the kernel-assigned port may itself have been claimed.
     // Treat docker as the authority and retry once with a fresh ephemeral port.
     // Skip rebuild on retry: the image is already on disk from the first attempt.
     // Re-register so the daemon's broker resolver returns the new port.
+    //
+    // Failed `docker run -p` calls can leave a created-but-not-running
+    // container record behind: depending on daemon version, Docker creates
+    // the container before binding the port, so the bind failure aborts
+    // start but leaves the corpse holding the name. The port-TOCTOU retry
+    // would then re-run `docker run --name <same>` and hit a name conflict
+    // against that corpse. Clean it up before the retry so the new run sees
+    // a free name. cleanupRunCorpse is safe (only force-removes non-running
+    // same-name containers) and a no-op when the name is already free.
     if (run.exitCode !== 0 && isPortAllocatedError(run.stderr)) {
+      const cleanup = await cleanupRunCorpse(exec, containerName)
+      if (cleanup === 'running') {
+        await cleanupHostDaemonRegistration(containerName, hostd)
+        return {
+          ok: false,
+          reason: `docker run failed (port bind) but cleanup found ${containerName} now running — refusing to retry against a live container.`,
+        }
+      }
+      if (cleanup === 'stuck') {
+        await cleanupHostDaemonRegistration(containerName, hostd)
+        return {
+          ok: false,
+          reason: `docker run failed (${sanitizeDockerStderr(run.stderr) || 'port bind'}) and the failed-run corpse for ${containerName} did not disappear within 10s; refusing to retry.`,
+        }
+      }
       hostPort = await allocatePort(0)
       if (cliEntry) {
         hostd = await registerWithDaemon({ cwd, containerName, cliEntry, hostPort, reuseCurrentHostDaemon })
         hostdControl = hostd.state === 'registered' ? hostd.control : undefined
       }
       plan = await planStart({ cwd, hostPort, imageExists: true, forceBuild: false, hostdControl })
-      run = await execRunWithConflictRetry(exec, plan.runArgs, cwd)
+      run = await execRunWithConflictRetry(exec, plan.runArgs, cwd, containerName)
     }
 
     if (run.exitCode !== 0) {
@@ -420,31 +445,52 @@ async function inspectContainer(exec: DockerExec, name: string): Promise<Inspect
   return { exists: true, running: result.stdout.trim() === 'true' }
 }
 
-// Cumulative budget ~2.7s. Five attempts is enough for the worst OrbStack-
-// under-load drain we've observed (a few hundred ms); the trailing 1200ms
-// step gives headroom for an unusually slow drain without ballooning the
-// budget on the genuinely-stuck case where the user needs to see the error.
-const RUN_RETRY_DELAYS_MS = [100, 200, 400, 800, 1200] as const
-
-// Retries `docker run` on name-conflict responses to handle Docker's split-
-// state race: `docker inspect <name>` can report "no such container" while
-// `docker run --name <same>` still rejects on the name-reservation table.
-// See isContainerNameConflict for the full failure-mode rationale.
+// Retries `docker run` on name-conflict responses by FIRST force-removing
+// the non-running same-name corpse that's blocking the name. Sleep-only
+// retries (PR #121's earlier approach) cannot recover when the corpse is
+// stable — see isContainerNameConflict's comment for why corpses survive
+// the preflight (port-bind-after-create leaves a created-but-not-running
+// container record behind, and start()'s own port-TOCTOU retry triggers
+// this path against that corpse).
 //
-// Only the name-conflict path retries — any other non-zero exit is returned
-// to the caller unchanged so the existing port-conflict TOCTOU retry and
-// permission-denied surfacing keep working without being shadowed by the
-// outer retry loop.
-async function execRunWithConflictRetry(exec: DockerExec, runArgs: string[], cwd: string): Promise<DockerExecResult> {
+// cleanupRunCorpse refuses to touch a running container, so a concurrent
+// legitimate start of the same name (or a foreign-but-named container the
+// user wants alive) is surfaced as a hard failure rather than silently
+// killed. 'stuck' likewise surfaces — a wedged daemon that won't drain a
+// removal needs the user to act (`docker rm -f <name>` manually, or restart
+// Docker) instead of looping forever.
+//
+// A small bounded backoff (100/200/400ms) follows each cleanup before the
+// next `docker run`. waitForRemoval polls `docker inspect`, which can
+// report the container gone BEFORE Docker's internal name-reservation
+// table has fully released the name. Without the backoff, the three
+// retries can all fire inside the same daemon drain window and exhaust
+// uselessly. The cumulative ~700ms is small next to the docker run RTT
+// itself and dwarfed by the user-visible cost of a failed start.
+//
+// Only the name-conflict path engages this destructive retry. Any other
+// non-zero exit (port-allocated, image-not-found, permission-denied) is
+// returned unchanged so the existing port-conflict TOCTOU retry and
+// surfacing keep working without being shadowed.
+async function execRunWithConflictRetry(
+  exec: DockerExec,
+  runArgs: string[],
+  cwd: string,
+  containerName: string,
+): Promise<DockerExecResult> {
   let last = await exec(runArgs, { cwd })
-  for (const delayMs of RUN_RETRY_DELAYS_MS) {
+  for (const backoffMs of CONFLICT_RETRY_BACKOFFS_MS) {
     if (last.exitCode === 0) return last
     if (!isContainerNameConflict(last.stderr)) return last
-    await new Promise((resolve) => setTimeout(resolve, delayMs))
+    const outcome = await cleanupRunCorpse(exec, containerName)
+    if (outcome === 'running' || outcome === 'stuck') return last
+    await new Promise((resolve) => setTimeout(resolve, backoffMs))
     last = await exec(runArgs, { cwd })
   }
   return last
 }
+
+const CONFLICT_RETRY_BACKOFFS_MS = [100, 200, 400] as const
 
 // Idempotent path for `start()`: the named container is already up. Reflect
 // the live container's identity (id) and host port in the result so callers


### PR DESCRIPTION
## Summary

`typeclaw compose restart` still fails with Docker name-conflict errors after #121. #121 hypothesized that Docker's name-reservation table drains independently of `docker inspect` — i.e. that the corpse referenced in Conflict errors is *transient* — and that sleeping ~2.7s would clear it. That model is wrong, and the sleep-only retry never recovered in practice.

User-reported failure (post-#121):

```
typeclaw compose restart
✔ [anderson] restarted on host port 8973
✖ [ati] failed: docker run failed: Conflict. The container name "/ati" is already in use by container "8fa7336a...". You have to remove (or rename) that container to be able to reuse that name.
✖ [bongbong] failed: docker run failed: Conflict. The container name "/bongbong" is already in use by container "121fe5b4...". You have to remove (or rename) that container to be able to reuse that name.
✖ [pengpeng] failed: docker run failed: Conflict. The container name "/pengpeng" is already in use by container "1987e52c...". You have to remove (or rename) that container to be able to reuse that name.
✔ [yangyang] restarted on host port 57235
restarted 2/5 (3 failed)
```

## Root Cause

The actual cause is upstream-documented Docker behavior (moby/moby#51758, moby/moby#8294): when `docker run -p <busy>:...` loses the host-port race, Docker has **already CREATED the named container** before the port bind fails. The corpse is stable in `docker ps -a` — sleeping cannot clear it.

Concrete failure sequence for the three failing agents above:

1. `compose restart` fires 5 agents in parallel via `Promise.all`.
2. All 5 race for preferred host port 8973. `anderson` wins.
3. `ati`/`bongbong`/`pengpeng` lose the TOCTOU: their host-side `findFreePort(8973)` returned 8973, but `docker run -p 8973:...` fails with port-allocated. Docker has already created the named container record before the bind failed.
4. `start()`'s port-TOCTOU retry fires `docker run --name <same>` with a fresh ephemeral port. Hits Conflict against the corpse from step 3.
5. #121's `execRunWithConflictRetry` sleeps and retries. The corpse is stable; no recovery.

`yangyang` succeeded with 57235 because its first `findFreePort(8973)` saw 8973 already bound by `anderson` and returned an ephemeral port up front — never entered the TOCTOU branch, never created a corpse.

## Fix

### `src/container/shared.ts` — new `cleanupRunCorpse(exec, name)`

Inspects the named container and takes one of three paths:

- `docker inspect` exits 1 → `'gone'` — name is already free, no rm needed.
- Container is running → `'running'` — **not removed**; caller surfaces conflict as a hard error. This protects concurrent legitimate starts and foreign-but-named containers from being killed.
- Container exists and is stopped → `docker rm -f` + `waitForRemoval` → `'removed'` (or `'stuck'` on timeout).

### `src/container/start.ts` — wired in two places

1. **Port-TOCTOU retry branch** — cleanup runs before the second `docker run` with the new ephemeral port. This is the path that creates the stable corpse in the user-reported bug.
2. **`execRunWithConflictRetry`** — replaces #121's sleep loop with cleanup-then-retry. Same safety invariants; no more burning 2.7s against a corpse that will never drain on its own.

## Self-Review Hardening

After shipping the original commit, a hostile second-opinion review surfaced three production-grade gaps. All three are addressed in the amended commit.

### 1. Remove by ID, not by name (TOCTOU)

The original `cleanupRunCorpse` inspected by name, then called `docker rm -f <name>`. Between those two calls, a concurrent peer process could legitimately create a live container with the same name — e.g. `typeclaw start <agent>` running while `typeclaw compose restart` is in flight, or hostd's `supervisor.restart` racing. Force-removing by name would have killed the live peer.

**Fix:** probe with `inspect --format '{{.Id}}|{{.State.Running}}'` to capture both fields in one call, then `docker rm -f <ID>`. The ID identifies the specific corpse we measured; removing by ID can only target that container, never a successor. `waitForRemoval` still uses the name (because that's what the next `docker run --name <name>` collides on).

### 2. Bounded backoff between cleanup and conflict retry

The original `execRunWithConflictRetry` had zero sleep between retries — relying entirely on `cleanupRunCorpse` to free the name. But Docker's internal name-reservation table can drain independently of `docker inspect` (the half of #121's hypothesis that IS real). `cleanupRunCorpse` + `waitForRemoval` can return successfully while the reservation still lingers for tens-to-hundreds of ms. Without backoff, all three retries could fire inside the same drain window and exhaust uselessly.

**Fix:** 100ms / 200ms / 400ms backoffs between cleanup and the next `docker run` (cumulative ~700ms, small next to docker run RTT).

### 3. Defensive `'stuck'` on malformed probe

If inspect returns exit 0 with malformed stdout (e.g. a daemon hiccup returning empty output), the original code would have fallen back to issuing `rm` without a proper ID — either no-op or worse, a by-name rm that reopens the TOCTOU.

**Fix:** explicit `if (id === '') return 'stuck'` check refuses to rm without a measured ID.

## Tests

**`src/container/shared.test.ts`** — grew from 6 → 7 cases for `cleanupRunCorpse`:

- `gone` path — inspect exits 1, no rm issued.
- `removed` path — stopped corpse, `docker rm -f <ID>` + `waitForRemoval` drain. Gains `rmTarget === corpseId` assertion (mutation: switch rm back to by-name → fails).
- `running` safety — running container is left untouched, returns `'running'`.
- `drain-handling` — removal-in-progress drain correctly awaited.
- `rm-says-gone` — `docker rm` exits non-zero with "no such container" → treated as `'removed'`.
- `stuck` on rm failure — `waitForRemoval` times out → returns `'stuck'`.
- `stuck` on malformed probe — inspect returns exit 0 with empty stdout → returns `'stuck'`, no rm issued. (new)

**`src/container/start.test.ts`** — grew from 5 → 7 integration tests:

- Corpse cleanup before conflict retry.
- Running-container safety (no force-remove).
- Port-TOCTOU + port-bind-after-create end-to-end.
- Removal-in-progress drain inside cleanup.
- Exhaustion (wedged daemon) surfaces the error.
- "Backs off between conflict retries when cleanup reports gone but the name still conflicts" — mutation: delete the `setTimeout` → fails because retries exhaust before the drain window closes. (new)
- "Removes the corpse by ID, not by name, to avoid killing a same-name peer (TOCTOU)" — mutation: switch rm to by-name → `expect(rmTarget).toBe(corpseId)` fails directly. (new)

## Verification

```
bun run typecheck         →  clean
bun run lint              →  0 warnings, 0 errors (340 files)
bun run format            →  clean (359 files)
bun test src/container/   →  175 pass, 0 fail  (was 172 before the hardening)
bun test                  →  2484 pass, 0 fail  (was 2481 before the hardening)
```

## Diff Scope

```
src/container/shared.test.ts | 122 +++++++++++++
src/container/shared.ts      |  78 +++++++--
src/container/start.test.ts  | 393 ++++++++++++++++++++++++++++++++++++++++++--
src/container/start.ts       |  84 ++++++---
4 files changed, 626 insertions(+), 51 deletions(-)
```

No public API change. No schema change. No Dockerfile change. compose, hostd, portbroker, CLI all unchanged.

## Relationship to Prior PRs

- #118 — fixed the in-progress (non-zero rm) drain race on the inspect side of `start()`'s preflight.
- #120 — fixed the exit-0 rm drain race on the inspect side.
- #121 — added a sleep-only retry on `docker run` name-conflict, based on a misdiagnosis that the corpse was transient. The retry harmlessly burned ~2.7s of sleep against stable corpses without recovering.
- **This PR** — identifies the actual cause (port-bind-after-create leaves a stable corpse) and replaces the sleep retry with destructive cleanup that targets the corpse by ID.

## Deferred

Considered but out of scope for this fix:

- **Per-agent host-side lock** around stop/start/restart to fully eliminate overlapping-start races. Significant new infrastructure; adds complexity that warrants a dedicated PR.
- **Tokened hostd deregistration** so one start's failure can't deregister another's valid registration. Same scope concern.
- **Classifying inspect-failure stderr** in `cleanupRunCorpse` (currently treats any inspect failure as `'gone'`). Matches existing patterns in the codebase (`inspectContainer`, `waitForRemoval` both do the same).

## Manual Recovery for Users Currently Stuck

```sh
docker rm -f <agent-name>
```

then retry `typeclaw compose restart`. After this fix, the retry handles the corpse automatically.

## Upstream References

- moby/moby#51758 — "docker start ignores conflicting ports for 'created' containers"
- moby/moby#8294 — "docker container might stuck at CREATE state and never run"