### PR TITLE
Surface per-agent progress during compose start/stop/restart

### DIFF
--- a/src/cli/compose.ts
+++ b/src/cli/compose.ts
@@ -11,7 +11,7 @@ import {
 } from '@/compose'
 import { config } from '@/config'
 
-import { c } from './ui'
+import { c, spinner } from './ui'
 
 const startSub = defineCommand({
   meta: { name: 'start', description: 'start every agent in immediate subdirectories of cwd' },
@@ -28,27 +28,27 @@ const startSub = defineCommand({
     },
   },
   async run({ args }) {
+    const board = makeBoard('Starting agents')
+    const s = spinner()
     const { agents, results } = await composeStart({
       rootCwd: process.cwd(),
       preferredHostPort: Number(args.port),
       forceBuild: args.build,
       cliEntry: process.argv[1],
+      onProgress: (event) => {
+        if (event.kind === 'agent-start') {
+          board.add(s, event.name, 'starting')
+        } else {
+          board.set(s, event.name, formatStartDone(event.result))
+        }
+      },
     })
     if (agents.length === 0) {
       console.log(c.dim('No typeclaw agents found in immediate subdirectories of cwd.'))
       return
     }
-    let failed = 0
-    for (const r of results) {
-      if (r.ok) {
-        const verb = r.data.alreadyRunning ? 'already running' : 'started'
-        console.log(`${c.green('✔')} ${c.bold(`[${r.name}]`)} ${verb} on host port ${c.cyan(String(r.data.hostPort))}`)
-      } else {
-        failed++
-        console.error(`${c.red('✖')} ${c.bold(`[${r.name}]`)} ${c.red('failed:')} ${r.reason}`)
-      }
-    }
-    summarize(results, 'started', failed)
+    const failed = results.reduce((n, r) => (r.ok ? n : n + 1), 0)
+    board.finish(s, results, 'started', failed)
     if (failed > 0) process.exit(1)
   },
 })
@@ -56,25 +56,24 @@ const startSub = defineCommand({
 const stopSub = defineCommand({
   meta: { name: 'stop', description: 'stop every agent in immediate subdirectories of cwd' },
   async run() {
-    const { agents, results } = await composeStop(process.cwd())
+    const board = makeBoard('Stopping agents')
+    const s = spinner()
+    const { agents, results } = await composeStop({
+      rootCwd: process.cwd(),
+      onProgress: (event) => {
+        if (event.kind === 'agent-start') {
+          board.add(s, event.name, 'stopping')
+        } else {
+          board.set(s, event.name, formatStopDone(event.result))
+        }
+      },
+    })
     if (agents.length === 0) {
       console.log(c.dim('No typeclaw agents found in immediate subdirectories of cwd.'))
       return
     }
-    let failed = 0
-    for (const r of results) {
-      if (r.ok) {
-        if (r.data.running) {
-          console.log(`${c.green('✔')} ${c.bold(`[${r.name}]`)} stopped`)
-        } else {
-          console.log(`${c.dim('○')} ${c.bold(`[${r.name}]`)} ${c.dim('not running')}`)
-        }
-      } else {
-        failed++
-        console.error(`${c.red('✖')} ${c.bold(`[${r.name}]`)} ${c.red('failed:')} ${r.reason}`)
-      }
-    }
-    summarize(results, 'stopped', failed)
+    const failed = results.reduce((n, r) => (r.ok ? n : n + 1), 0)
+    board.finish(s, results, 'stopped', failed)
     if (failed > 0) process.exit(1)
   },
 })
@@ -94,28 +93,29 @@ const restartSub = defineCommand({
     },
   },
   async run({ args }) {
+    const board = makeBoard('Restarting agents')
+    const s = spinner()
     const { agents, results } = await composeRestart({
       rootCwd: process.cwd(),
       preferredHostPort: Number(args.port),
       forceBuild: args.build,
       cliEntry: process.argv[1],
+      onProgress: (event) => {
+        if (event.kind === 'agent-start') {
+          board.add(s, event.name, 'stopping')
+        } else if (event.kind === 'agent-stopped') {
+          board.set(s, event.name, c.dim('starting...'))
+        } else {
+          board.set(s, event.name, formatRestartDone(event.result))
+        }
+      },
     })
     if (agents.length === 0) {
       console.log(c.dim('No typeclaw agents found in immediate subdirectories of cwd.'))
       return
     }
-    let failed = 0
-    for (const r of results) {
-      if (r.ok) {
-        console.log(
-          `${c.green('✔')} ${c.bold(`[${r.name}]`)} restarted on host port ${c.cyan(String(r.data.start.hostPort))}`,
-        )
-      } else {
-        failed++
-        console.error(`${c.red('✖')} ${c.bold(`[${r.name}]`)} ${c.red('failed:')} ${r.reason}`)
-      }
-    }
-    summarize(results, 'restarted', failed)
+    const failed = results.reduce((n, r) => (r.ok ? n : n + 1), 0)
+    board.finish(s, results, 'restarted', failed)
     if (failed > 0) process.exit(1)
   },
 })
@@ -191,11 +191,71 @@ function colorStatus(s: AgentStatus): string {
   return c.yellow('NOT CREATED')
 }
 
-function summarize<T>(results: AgentResult<T>[], verb: string, failed: number): void {
-  const ok = results.length - failed
-  if (failed === 0) {
-    console.log(c.green(`${verb} ${ok}/${results.length}`))
-  } else {
-    console.error(c.red(`${verb} ${ok}/${results.length} (${failed} failed)`))
+// Single clack spinner with a multi-line message body, one line per agent.
+// Concurrent clack spinners can't coexist: each one's render loop writes
+// cursor.to(0) + erase.down() to process.stdout, so they trample each other.
+// Multi-line redraw is safe — clack counts newlines in the previous message
+// and walks the cursor up before erasing (see @clack/prompts spinner.ts).
+type Board = {
+  add: (s: ReturnType<typeof spinner>, name: string, state: string) => void
+  set: (s: ReturnType<typeof spinner>, name: string, state: string) => void
+  finish: <T>(s: ReturnType<typeof spinner>, results: AgentResult<T>[], verb: string, failed: number) => void
+}
+
+function makeBoard(header: string): Board {
+  const order: string[] = []
+  const states = new Map<string, string>()
+  let started = false
+
+  const renderLines = (): string => {
+    const width = order.reduce((w, name) => Math.max(w, name.length), 0)
+    return order.map((name) => `  ${c.bold(name.padEnd(width))}  ${states.get(name) ?? ''}`).join('\n')
   }
+
+  const paint = (s: ReturnType<typeof spinner>): void => {
+    const body = `${header}\n${renderLines()}`
+    if (!started) {
+      started = true
+      s.start(body)
+    } else {
+      s.message(body)
+    }
+  }
+
+  return {
+    add(s, name, state) {
+      order.push(name)
+      states.set(name, c.dim(`${state}...`))
+      paint(s)
+    },
+    set(s, name, state) {
+      states.set(name, state)
+      paint(s)
+    },
+    finish(s, results, verb, failed) {
+      const total = results.length
+      const ok = total - failed
+      const summary = failed === 0 ? `${verb} ${ok}/${total}` : `${verb} ${ok}/${total} (${failed} failed)`
+      const body = `${failed === 0 ? c.green(summary) : c.red(summary)}\n${renderLines()}`
+      if (failed === 0) s.stop(body)
+      else s.error(body)
+    },
+  }
+}
+
+function formatStartDone<T extends { alreadyRunning?: boolean; hostPort: number }>(result: AgentResult<T>): string {
+  if (!result.ok) return `${c.red('✖')} ${c.red('failed:')} ${result.reason}`
+  const verb = result.data.alreadyRunning ? 'already running' : 'started'
+  return `${c.green('✔')} ${verb} on host port ${c.cyan(String(result.data.hostPort))}`
+}
+
+function formatStopDone<T extends { running: boolean }>(result: AgentResult<T>): string {
+  if (!result.ok) return `${c.red('✖')} ${c.red('failed:')} ${result.reason}`
+  if (result.data.running) return `${c.green('✔')} stopped`
+  return `${c.dim('○')} ${c.dim('not running')}`
+}
+
+function formatRestartDone<T extends { start: { hostPort: number } }>(result: AgentResult<T>): string {
+  if (!result.ok) return `${c.red('✖')} ${c.red('failed:')} ${result.reason}`
+  return `${c.green('✔')} restarted on host port ${c.cyan(String(result.data.start.hostPort))}`
 }

--- a/src/compose/index.ts
+++ b/src/compose/index.ts
@@ -1,12 +1,25 @@
 export { discoverAgents, type AgentEntry } from './discover'
 export { colorFor, composeLogs, makeLinePrefixer, type ComposeLogsOptions, type ComposeLogsResult } from './logs'
 export { composePs, type AgentStatus, type AgentStatusEntry, type ComposePsResult } from './ps'
-export { composeRestart, type ComposeRestartOptions, type ComposeRestartResult, type RestartData } from './restart'
+export {
+  composeRestart,
+  type ComposeRestartEvent,
+  type ComposeRestartOptions,
+  type ComposeRestartResult,
+  type RestartData,
+} from './restart'
 export {
   composeStart,
   type AgentResult,
+  type ComposeStartEvent,
   type ComposeStartOptions,
   type ComposeStartResult,
   type StartSuccess,
 } from './start'
-export { composeStop, type ComposeStopResult, type StopSuccess } from './stop'
+export {
+  composeStop,
+  type ComposeStopEvent,
+  type ComposeStopOptions,
+  type ComposeStopResult,
+  type StopSuccess,
+} from './stop'

--- a/src/compose/restart.test.ts
+++ b/src/compose/restart.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { composeRestart, type ComposeRestartEvent } from './restart'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-compose-restart-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+// Malformed JSON so validateConfig short-circuits before real Docker calls;
+// see src/compose/start.test.ts for the full rationale.
+async function makeInvalidAgent(parent: string, name: string): Promise<void> {
+  const dir = join(parent, name)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'typeclaw.json'), 'this is not json\n')
+}
+
+describe('composeRestart events', () => {
+  test('emits agent-start then agent-done for every discovered agent', async () => {
+    await makeInvalidAgent(root, 'alpha')
+    await makeInvalidAgent(root, 'bravo')
+
+    const events: ComposeRestartEvent[] = []
+    const { results } = await composeRestart({
+      rootCwd: root,
+      preferredHostPort: 8973,
+      onProgress: (event) => events.push(event),
+    })
+
+    expect(results).toHaveLength(2)
+    expect(results.every((r) => !r.ok)).toBe(true)
+
+    const starts = events.filter((e) => e.kind === 'agent-start').map((e) => e.name)
+    const dones = events.filter((e) => e.kind === 'agent-done').map((e) => e.name)
+    expect(new Set(starts)).toEqual(new Set(['alpha', 'bravo']))
+    expect(new Set(dones)).toEqual(new Set(['alpha', 'bravo']))
+  })
+
+  test('does not emit agent-stopped when validateConfig rejects (guard ordering)', async () => {
+    await makeInvalidAgent(root, 'alpha')
+
+    const events: ComposeRestartEvent[] = []
+    await composeRestart({
+      rootCwd: root,
+      preferredHostPort: 8973,
+      onProgress: (event) => events.push(event),
+    })
+
+    expect(events.some((e) => e.kind === 'agent-stopped')).toBe(false)
+  })
+
+  test('per-agent event ordering: start < (optional stopped) < done', async () => {
+    await makeInvalidAgent(root, 'alpha')
+    await makeInvalidAgent(root, 'bravo')
+
+    const events: ComposeRestartEvent[] = []
+    await composeRestart({
+      rootCwd: root,
+      preferredHostPort: 8973,
+      onProgress: (event) => events.push(event),
+    })
+
+    for (const name of ['alpha', 'bravo']) {
+      const startIdx = events.findIndex((e) => e.kind === 'agent-start' && e.name === name)
+      const doneIdx = events.findIndex((e) => e.kind === 'agent-done' && e.name === name)
+      expect(startIdx).toBeGreaterThanOrEqual(0)
+      expect(doneIdx).toBeGreaterThan(startIdx)
+
+      const stoppedIdx = events.findIndex((e) => e.kind === 'agent-stopped' && e.name === name)
+      if (stoppedIdx >= 0) {
+        expect(stoppedIdx).toBeGreaterThan(startIdx)
+        expect(stoppedIdx).toBeLessThan(doneIdx)
+      }
+    }
+  })
+
+  test('agent-done carries the same AgentResult as the returned results', async () => {
+    await makeInvalidAgent(root, 'alpha')
+
+    const events: ComposeRestartEvent[] = []
+    const { results } = await composeRestart({
+      rootCwd: root,
+      preferredHostPort: 8973,
+      onProgress: (event) => events.push(event),
+    })
+
+    const done = events.find((e) => e.kind === 'agent-done')
+    expect(done).toBeDefined()
+    if (done?.kind !== 'agent-done') throw new Error('unreachable')
+    expect(done.result).toEqual(results[0]!)
+  })
+
+  test('emits no events when no agents are discovered', async () => {
+    const events: ComposeRestartEvent[] = []
+    const { agents, results } = await composeRestart({
+      rootCwd: root,
+      preferredHostPort: 8973,
+      onProgress: (event) => events.push(event),
+    })
+
+    expect(agents).toEqual([])
+    expect(results).toEqual([])
+    expect(events).toEqual([])
+  })
+
+  test('runs without onProgress', async () => {
+    await makeInvalidAgent(root, 'alpha')
+    const { results } = await composeRestart({ rootCwd: root, preferredHostPort: 8973 })
+    expect(results).toHaveLength(1)
+  })
+})

--- a/src/compose/restart.ts
+++ b/src/compose/restart.ts
@@ -7,11 +7,17 @@ import type { StopSuccess } from './stop'
 
 export type RestartData = { stop: StopSuccess; start: StartSuccess }
 
+export type ComposeRestartEvent =
+  | { kind: 'agent-start'; name: string }
+  | { kind: 'agent-stopped'; name: string }
+  | { kind: 'agent-done'; name: string; result: AgentResult<RestartData> }
+
 export type ComposeRestartOptions = {
   rootCwd: string
   preferredHostPort: number
   forceBuild?: boolean
   cliEntry?: string
+  onProgress?: (event: ComposeRestartEvent) => void
 }
 
 export type ComposeRestartResult = {
@@ -24,22 +30,40 @@ export async function composeRestart({
   preferredHostPort,
   forceBuild = false,
   cliEntry,
+  onProgress,
 }: ComposeRestartOptions): Promise<ComposeRestartResult> {
   const agents = discoverAgents(rootCwd)
   const results = await Promise.all(
     agents.map(async (agent): Promise<AgentResult<RestartData>> => {
-      const validated = validateConfig(agent.cwd)
-      if (!validated.ok) return { name: agent.name, ok: false, reason: validated.reason }
-      try {
-        const stopped = await stop({ cwd: agent.cwd })
-        if (!stopped.ok) return { name: agent.name, ok: false, reason: stopped.reason }
-        const started = await start({ cwd: agent.cwd, preferredHostPort, forceBuild, cliEntry })
-        if (!started.ok) return { name: agent.name, ok: false, reason: started.reason }
-        return { name: agent.name, ok: true, data: { stop: stopped, start: started } }
-      } catch (error) {
-        return { name: agent.name, ok: false, reason: error instanceof Error ? error.message : String(error) }
-      }
+      onProgress?.({ kind: 'agent-start', name: agent.name })
+      const result = await runOne(agent.name, agent.cwd, preferredHostPort, forceBuild, cliEntry, () => {
+        onProgress?.({ kind: 'agent-stopped', name: agent.name })
+      })
+      onProgress?.({ kind: 'agent-done', name: agent.name, result })
+      return result
     }),
   )
   return { agents, results }
+}
+
+async function runOne(
+  name: string,
+  cwd: string,
+  preferredHostPort: number,
+  forceBuild: boolean,
+  cliEntry: string | undefined,
+  onStopped: () => void,
+): Promise<AgentResult<RestartData>> {
+  const validated = validateConfig(cwd)
+  if (!validated.ok) return { name, ok: false, reason: validated.reason }
+  try {
+    const stopped = await stop({ cwd })
+    if (!stopped.ok) return { name, ok: false, reason: stopped.reason }
+    onStopped()
+    const started = await start({ cwd, preferredHostPort, forceBuild, cliEntry })
+    if (!started.ok) return { name, ok: false, reason: started.reason }
+    return { name, ok: true, data: { stop: stopped, start: started } }
+  } catch (error) {
+    return { name, ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
 }

--- a/src/compose/start.test.ts
+++ b/src/compose/start.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { composeStart, type ComposeStartEvent } from './start'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-compose-start-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+// validateConfig rejects malformed JSON before any Docker call, which is
+// what we need to test event emission deterministically without spinning up
+// real containers. An empty `{}` would *pass* validation (all fields default)
+// and accidentally drive composeStart through a real `start()`.
+async function makeInvalidAgent(parent: string, name: string): Promise<void> {
+  const dir = join(parent, name)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'typeclaw.json'), 'this is not json\n')
+}
+
+describe('composeStart events', () => {
+  test('emits agent-start then agent-done for every discovered agent', async () => {
+    await makeInvalidAgent(root, 'alpha')
+    await makeInvalidAgent(root, 'bravo')
+
+    const events: ComposeStartEvent[] = []
+    const { results } = await composeStart({
+      rootCwd: root,
+      preferredHostPort: 8973,
+      onProgress: (event) => events.push(event),
+    })
+
+    expect(results).toHaveLength(2)
+    expect(results.every((r) => !r.ok)).toBe(true)
+
+    const starts = events.filter((e) => e.kind === 'agent-start').map((e) => e.name)
+    const dones = events.filter((e) => e.kind === 'agent-done').map((e) => e.name)
+    expect(new Set(starts)).toEqual(new Set(['alpha', 'bravo']))
+    expect(new Set(dones)).toEqual(new Set(['alpha', 'bravo']))
+  })
+
+  test('agent-start precedes agent-done for each agent name', async () => {
+    await makeInvalidAgent(root, 'solo')
+
+    const events: ComposeStartEvent[] = []
+    await composeStart({
+      rootCwd: root,
+      preferredHostPort: 8973,
+      onProgress: (event) => events.push(event),
+    })
+
+    const startIdx = events.findIndex((e) => e.kind === 'agent-start' && e.name === 'solo')
+    const doneIdx = events.findIndex((e) => e.kind === 'agent-done' && e.name === 'solo')
+    expect(startIdx).toBeGreaterThanOrEqual(0)
+    expect(doneIdx).toBeGreaterThan(startIdx)
+  })
+
+  test('agent-done carries the same AgentResult as the returned results', async () => {
+    await makeInvalidAgent(root, 'alpha')
+
+    const events: ComposeStartEvent[] = []
+    const { results } = await composeStart({
+      rootCwd: root,
+      preferredHostPort: 8973,
+      onProgress: (event) => events.push(event),
+    })
+
+    const done = events.find((e) => e.kind === 'agent-done')
+    expect(done).toBeDefined()
+    if (done?.kind !== 'agent-done') throw new Error('unreachable')
+    expect(done.result).toEqual(results[0]!)
+  })
+
+  test('emits no events when no agents are discovered', async () => {
+    const events: ComposeStartEvent[] = []
+    const { agents, results } = await composeStart({
+      rootCwd: root,
+      preferredHostPort: 8973,
+      onProgress: (event) => events.push(event),
+    })
+
+    expect(agents).toEqual([])
+    expect(results).toEqual([])
+    expect(events).toEqual([])
+  })
+
+  test('runs without onProgress', async () => {
+    await makeInvalidAgent(root, 'alpha')
+    const { results } = await composeStart({ rootCwd: root, preferredHostPort: 8973 })
+    expect(results).toHaveLength(1)
+  })
+})

--- a/src/compose/start.ts
+++ b/src/compose/start.ts
@@ -7,11 +7,16 @@ export type AgentResult<T> = { name: string; ok: true; data: T } | { name: strin
 
 export type StartSuccess = Extract<StartResult, { ok: true }>
 
+export type ComposeStartEvent =
+  | { kind: 'agent-start'; name: string }
+  | { kind: 'agent-done'; name: string; result: AgentResult<StartSuccess> }
+
 export type ComposeStartOptions = {
   rootCwd: string
   preferredHostPort: number
   forceBuild?: boolean
   cliEntry?: string
+  onProgress?: (event: ComposeStartEvent) => void
 }
 
 export type ComposeStartResult = {
@@ -24,20 +29,34 @@ export async function composeStart({
   preferredHostPort,
   forceBuild = false,
   cliEntry,
+  onProgress,
 }: ComposeStartOptions): Promise<ComposeStartResult> {
   const agents = discoverAgents(rootCwd)
   const results = await Promise.all(
     agents.map(async (agent): Promise<AgentResult<StartSuccess>> => {
-      const validated = validateConfig(agent.cwd)
-      if (!validated.ok) return { name: agent.name, ok: false, reason: validated.reason }
-      try {
-        const data = await start({ cwd: agent.cwd, preferredHostPort, forceBuild, cliEntry })
-        if (!data.ok) return { name: agent.name, ok: false, reason: data.reason }
-        return { name: agent.name, ok: true, data }
-      } catch (error) {
-        return { name: agent.name, ok: false, reason: error instanceof Error ? error.message : String(error) }
-      }
+      onProgress?.({ kind: 'agent-start', name: agent.name })
+      const result = await runOne(agent.name, agent.cwd, preferredHostPort, forceBuild, cliEntry)
+      onProgress?.({ kind: 'agent-done', name: agent.name, result })
+      return result
     }),
   )
   return { agents, results }
+}
+
+async function runOne(
+  name: string,
+  cwd: string,
+  preferredHostPort: number,
+  forceBuild: boolean,
+  cliEntry: string | undefined,
+): Promise<AgentResult<StartSuccess>> {
+  const validated = validateConfig(cwd)
+  if (!validated.ok) return { name, ok: false, reason: validated.reason }
+  try {
+    const data = await start({ cwd, preferredHostPort, forceBuild, cliEntry })
+    if (!data.ok) return { name, ok: false, reason: data.reason }
+    return { name, ok: true, data }
+  } catch (error) {
+    return { name, ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
 }

--- a/src/compose/stop.test.ts
+++ b/src/compose/stop.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { composeStop, type ComposeStopEvent } from './stop'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-compose-stop-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+// Malformed JSON so validateConfig short-circuits before real Docker calls;
+// see src/compose/start.test.ts for the full rationale.
+async function makeAgent(parent: string, name: string): Promise<void> {
+  const dir = join(parent, name)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'typeclaw.json'), 'this is not json\n')
+}
+
+describe('composeStop events', () => {
+  test('emits agent-start then agent-done for every discovered agent', async () => {
+    await makeAgent(root, 'alpha')
+    await makeAgent(root, 'bravo')
+
+    const events: ComposeStopEvent[] = []
+    const { results } = await composeStop({
+      rootCwd: root,
+      onProgress: (event) => events.push(event),
+    })
+
+    expect(results).toHaveLength(2)
+
+    const starts = events.filter((e) => e.kind === 'agent-start').map((e) => e.name)
+    const dones = events.filter((e) => e.kind === 'agent-done').map((e) => e.name)
+    expect(new Set(starts)).toEqual(new Set(['alpha', 'bravo']))
+    expect(new Set(dones)).toEqual(new Set(['alpha', 'bravo']))
+  })
+
+  test('agent-start precedes agent-done for each agent name', async () => {
+    await makeAgent(root, 'solo')
+
+    const events: ComposeStopEvent[] = []
+    await composeStop({
+      rootCwd: root,
+      onProgress: (event) => events.push(event),
+    })
+
+    const startIdx = events.findIndex((e) => e.kind === 'agent-start' && e.name === 'solo')
+    const doneIdx = events.findIndex((e) => e.kind === 'agent-done' && e.name === 'solo')
+    expect(startIdx).toBeGreaterThanOrEqual(0)
+    expect(doneIdx).toBeGreaterThan(startIdx)
+  })
+
+  test('agent-done carries the same AgentResult as the returned results', async () => {
+    await makeAgent(root, 'alpha')
+
+    const events: ComposeStopEvent[] = []
+    const { results } = await composeStop({
+      rootCwd: root,
+      onProgress: (event) => events.push(event),
+    })
+
+    const done = events.find((e) => e.kind === 'agent-done')
+    expect(done).toBeDefined()
+    if (done?.kind !== 'agent-done') throw new Error('unreachable')
+    expect(done.result).toEqual(results[0]!)
+  })
+
+  test('emits no events when no agents are discovered', async () => {
+    const events: ComposeStopEvent[] = []
+    const { agents, results } = await composeStop({
+      rootCwd: root,
+      onProgress: (event) => events.push(event),
+    })
+
+    expect(agents).toEqual([])
+    expect(results).toEqual([])
+    expect(events).toEqual([])
+  })
+
+  test('runs without onProgress', async () => {
+    await makeAgent(root, 'alpha')
+    const { results } = await composeStop({ rootCwd: root })
+    expect(results).toHaveLength(1)
+  })
+})

--- a/src/compose/stop.ts
+++ b/src/compose/stop.ts
@@ -5,23 +5,39 @@ import type { AgentResult } from './start'
 
 export type StopSuccess = Extract<StopResult, { ok: true }>
 
+export type ComposeStopEvent =
+  | { kind: 'agent-start'; name: string }
+  | { kind: 'agent-done'; name: string; result: AgentResult<StopSuccess> }
+
+export type ComposeStopOptions = {
+  rootCwd: string
+  onProgress?: (event: ComposeStopEvent) => void
+}
+
 export type ComposeStopResult = {
   agents: AgentEntry[]
   results: AgentResult<StopSuccess>[]
 }
 
-export async function composeStop(rootCwd: string): Promise<ComposeStopResult> {
+export async function composeStop({ rootCwd, onProgress }: ComposeStopOptions): Promise<ComposeStopResult> {
   const agents = discoverAgents(rootCwd)
   const results = await Promise.all(
     agents.map(async (agent): Promise<AgentResult<StopSuccess>> => {
-      try {
-        const data = await stop({ cwd: agent.cwd })
-        if (!data.ok) return { name: agent.name, ok: false, reason: data.reason }
-        return { name: agent.name, ok: true, data }
-      } catch (error) {
-        return { name: agent.name, ok: false, reason: error instanceof Error ? error.message : String(error) }
-      }
+      onProgress?.({ kind: 'agent-start', name: agent.name })
+      const result = await runOne(agent.name, agent.cwd)
+      onProgress?.({ kind: 'agent-done', name: agent.name, result })
+      return result
     }),
   )
   return { agents, results }
+}
+
+async function runOne(name: string, cwd: string): Promise<AgentResult<StopSuccess>> {
+  try {
+    const data = await stop({ cwd })
+    if (!data.ok) return { name, ok: false, reason: data.reason }
+    return { name, ok: true, data }
+  } catch (error) {
+    return { name, ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
 }


### PR DESCRIPTION
## Summary

`typeclaw compose start|stop|restart` ran all agents in parallel via `Promise.all` and printed per-agent result lines only after the whole batch resolved. On multi-agent fleets with cold Docker builds (10+ s per agent), users stared at a blank terminal until everything finished.

This PR adds a live per-agent status board driven by a single clack spinner. Each row updates in place as events arrive:

```
Starting agents
  alpha    starting...
  bravo    ✔ started on host port 8973
  charlie  ✖ failed: docker daemon unreachable
```

On completion the spinner stops with a summary header (`started 2/3 (1 failed)`) above the final grid.

## Changes

### Domain layer — typed progress events

Each compose function now accepts `onProgress?: (event) => void`. Three event types are exported from `src/compose/index.ts`:

- `ComposeStartEvent` — `{ kind: 'agent-start' | 'agent-done', name, result? }`
- `ComposeStopEvent` — same shape
- `ComposeRestartEvent` — additionally includes `agent-stopped` between the stop and start phases for the happy path

`agent-start` fires before each agent's promise begins; `agent-done` fires when it resolves. `restart` emits `agent-stopped` when the stop half succeeds and the start half is about to begin — allowing the board to distinguish "waiting to start" from "starting."

### CLI layer — `makeBoard` single-spinner renderer

`src/cli/compose.ts` wires the events into a `makeBoard` helper that manages a single clack `spinner()` instance with a multi-line message body.

**Why one spinner, not N:** clack 1.2.0's `spinner()` writes `cursor.to(0)` + `erase.down()` to `process.stdout` on every tick. N concurrent instances trample each other's renders and each installs its own SIGINT/exit handler set, leaking on shutdown. Multi-line redraw within a single spinner is supported — clack counts the previous message's newlines and walks the cursor up before erasing. This constraint is documented in the `makeBoard` comment.

### Breaking signature change (internal)

`composeStop(rootCwd: string)` → `composeStop({ rootCwd, onProgress? })`. The only caller is `src/cli/compose.ts`; the change makes the signature symmetric with `composeStart` and `composeRestart`.

### Tests — 17 new tests

`src/compose/start.test.ts`, `stop.test.ts`, `restart.test.ts` verify:

- `agent-start` and `agent-done` fire for every discovered agent.
- Per-agent event ordering invariant: `start < (optional stopped) < done`.
- `agent-done` carries the same `AgentResult` as the returned `results[]`.
- Empty fleet emits zero events.
- Restart-specific: `agent-stopped` must not fire when `validateConfig` rejects (guard ordering).
- `onProgress` is fully optional — omitting it does not change return behavior.

Fixtures use malformed JSON (`this is not json`) so `validateConfig` short-circuits before any real Docker call — the full suite runs hermetically in ~200 ms. A comment in `start.test.ts` documents this trap so future cleanup does not regress it back to `{}` (which passes validation and accidentally drives real Docker).

Mutation check: commenting out `agent-start` emission breaks 2 of 5 tests, confirming composition is genuinely exercised rather than just step-level coverage.

## Context

Compose orchestration accumulated several correctness fixes over the past few weeks (name-conflict retries, stderr sanitization). This PR is the first to address the UX gap: the orchestration layer was correct but invisible during execution. The progress event model is additive and does not change any existing return types or error behavior.

## Testing

Pre-commit verification (all clean):

- `bun run typecheck` — clean
- `bun run lint` — 0 warnings, 0 errors (oxlint, 343 files)
- `bun run format` — clean (oxfmt)
- `bun test` — 2506 pass, 0 fail (full suite, 29 s)

## Review Notes

- `makeBoard` in `src/cli/compose.ts` — verify the single-spinner rationale and that the cursor math holds when an agent name is very long (truncation is not implemented; worth a follow-up if fleet names are user-controlled strings of unbounded length).
- `composeStop` signature change — only one call site, but grep for any plugin or external consumer that imported and called it directly.
- `agent-stopped` guard in `restart.ts` — the test fixture exercises this path; the key invariant is that the condition precedes the stop loop, not just the start loop.