### PR TITLE
Admit KakaoTalk chats under the global "*" allow wildcard

### DIFF
--- a/src/channels/schema.test.ts
+++ b/src/channels/schema.test.ts
@@ -76,9 +76,12 @@ describe('channelsSchema', () => {
 })
 
 describe('isAllowed', () => {
-  test('"*" matches every guild channel and every DM', () => {
+  test('"*" matches every guild channel, every DM, and every KakaoTalk chat', () => {
     expect(isAllowed(['*'], 'g1', 'c1')).toBe(true)
     expect(isAllowed(['*'], '@dm', 'd1')).toBe(true)
+    expect(isAllowed(['*'], '@kakao-dm', '12345')).toBe(true)
+    expect(isAllowed(['*'], '@kakao-group', '67890')).toBe(true)
+    expect(isAllowed(['*'], '@kakao-open', '11111')).toBe(true)
   })
 
   test('"guild:*" matches any guild channel but no DMs', () => {
@@ -217,20 +220,12 @@ describe('isAllowed', () => {
     expect(isAllowed(['kakao:*'], 'telegram', '12345')).toBe(false)
   })
 
-  test('non-kakao rules never admit kakao workspaces — including global "*"', () => {
+  test('adapter-specific non-kakao rules never admit kakao workspaces', () => {
     expect(isAllowed(['dm:*'], '@kakao-dm', '12345')).toBe(false)
     expect(isAllowed(['team:*'], '@kakao-group', '12345')).toBe(false)
     expect(isAllowed(['guild:*'], '@kakao-group', '12345')).toBe(false)
     expect(isAllowed(['im:*'], '@kakao-dm', '12345')).toBe(false)
     expect(isAllowed(['tg:*'], '@kakao-dm', '12345')).toBe(false)
-    // Privacy footgun prevention: `*` was the catch-all for Slack/Discord/
-    // Telegram before KakaoTalk landed, but we deliberately don't extend
-    // it to kakao workspaces because users with `*` configured for their
-    // bots didn't sign up for the bot to read their personal KakaoTalk
-    // chats.
-    expect(isAllowed(['*'], '@kakao-dm', '12345')).toBe(false)
-    expect(isAllowed(['*'], '@kakao-group', '67890')).toBe(false)
-    expect(isAllowed(['*'], '@kakao-open', '11111')).toBe(false)
   })
 
   test('kakao rules never admit non-kakao workspaces', () => {

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -213,16 +213,16 @@ export function isAllowed(rules: readonly AllowRule[], workspace: string, chat: 
 // as workspace coordinates so the bucket-* rules are pure prefix matches
 // against `workspace`.
 function matchRule(rule: string, workspace: string, chat: string): boolean {
-  // KakaoTalk workspaces require an explicit `kakao:*` rule. The global
-  // `*` catch-all is intentionally NOT extended to admit kakao chats:
-  // KakaoTalk authenticates as a personal user account, so a user who
-  // wrote `'*'` for their Slack/Discord bot doesn't expect that rule
-  // to also expose every personal KakaoTalk DM and group they're in.
-  // To admit kakao chats, the user must write `kakao:*` (or a narrower
-  // bucket rule) explicitly. Adapter-specific non-kakao rules
-  // (`team:*`, `guild:*`, `dm:*`, `im:*`) likewise never admit kakao
-  // workspaces — the matcher returns false before evaluating them.
+  // KakaoTalk workspaces accept the global `*` catch-all or any `kakao:`
+  // rule. Adapter-specific non-kakao rules (`team:*`, `guild:*`, `dm:*`,
+  // `im:*`, `tg:*`) never admit kakao workspaces — those are scoped to
+  // their own adapter's coordinate space and would be meaningless here.
+  // The init wizard still defaults kakaotalk to the narrower `kakao:dm/*`
+  // (group chats with personal accounts are sensitive — every member sees
+  // every reply), so opting into `*` is an explicit, per-adapter decision
+  // made in `channels.kakaotalk.allow`.
   if (KAKAO_WORKSPACES.has(workspace)) {
+    if (rule === '*') return true
     if (rule.startsWith('kakao:')) return matchKakaoRule(rule.slice(6), workspace, chat)
     return false
   }


### PR DESCRIPTION
## Summary

`channels.kakaotalk.allow: ["*"]` used to be silently treated as
"no kakao chats admitted", forcing users to write `kakao:*` instead.
This PR makes `*` a true catch-all that includes KakaoTalk workspaces.

## Why

The original behavior was a deliberate privacy guard (see the deleted
comment block in `schema.ts` and the deleted test in `schema.test.ts`):
KakaoTalk auths as a personal account, so a user who wrote `*` for
their Slack/Discord bot "didn't sign up" to expose their personal DMs.

The guard fires on the wrong layer:

- Opting into the kakaotalk adapter is **already** an explicit per-adapter
  decision. You have to write a `channels.kakaotalk` block. The `*` lives
  inside that block — `channels.kakaotalk.allow: ["*"]` is indistinguishable
  in intent from `["kakao:*"]`.
- The init wizard still defaults `kakaotalk` to the narrower `kakao:dm/*`
  (group chats with personal accounts are sensitive — every member sees
  every reply), so the safe default for new users is preserved. Only users
  who deliberately wrote `*` change behavior.
- The error path was confusing: setting `["*"]`, watching messages get
  dropped with `not_in_allow_list`, and finding the only fix in source-code
  comments is a worse UX than the privacy theater bought.

## What

- `matchRule` admits `*` for `@kakao-dm` / `@kakao-group` / `@kakao-open`
  workspaces, alongside the existing `kakao:` rules.
- Adapter-specific non-kakao rules (`team:*`, `guild:*`, `dm:*`, `im:*`,
  `tg:*`) still never admit kakao workspaces — those are scoped to their
  own coordinate space and would be meaningless on a kakao chat.
- Tests updated: the global-`*` case is moved from the
  "never admits kakao" assertion to the catch-all positive case; the
  remaining negative assertions only cover adapter-specific rules.

## Test plan

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run format` ✅
- `bun test` — **2517 pass / 0 fail**