### PR TITLE
Lazy-import CLI subcommand modules to cut host-stage startup to ~60ms

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,39 +2,25 @@
 
 import { defineCommand, runMain } from 'citty'
 
-import { channelCommand } from './channel'
-import { composeCommand } from './compose'
-import { hostdCommand } from './hostd'
-import { init } from './init'
-import { logsCommand } from './logs'
-import { reload } from './reload'
-import { restartCommand } from './restart'
-import { run } from './run'
-import { shellCommand } from './shell'
-import { startCommand } from './start'
-import { statusCommand } from './status'
-import { stopCommand } from './stop'
-import { tui } from './tui'
-
 const main = defineCommand({
   meta: {
     name: 'typeclaw',
     description: 'TypeClaw agent runtime',
   },
   subCommands: {
-    init,
-    run,
-    tui,
-    start: startCommand,
-    stop: stopCommand,
-    restart: restartCommand,
-    status: statusCommand,
-    reload,
-    logs: logsCommand,
-    shell: shellCommand,
-    compose: composeCommand,
-    channel: channelCommand,
-    _hostd: hostdCommand,
+    init: () => import('./init').then((m) => m.init),
+    run: () => import('./run').then((m) => m.run),
+    tui: () => import('./tui').then((m) => m.tui),
+    start: () => import('./start').then((m) => m.startCommand),
+    stop: () => import('./stop').then((m) => m.stopCommand),
+    restart: () => import('./restart').then((m) => m.restartCommand),
+    status: () => import('./status').then((m) => m.statusCommand),
+    reload: () => import('./reload').then((m) => m.reload),
+    logs: () => import('./logs').then((m) => m.logsCommand),
+    shell: () => import('./shell').then((m) => m.shellCommand),
+    compose: () => import('./compose').then((m) => m.composeCommand),
+    channel: () => import('./channel').then((m) => m.channelCommand),
+    _hostd: () => import('./hostd').then((m) => m.hostdCommand),
   },
 })
 


### PR DESCRIPTION
## Summary

Every `typeclaw status`, `typeclaw logs`, `typeclaw stop`, and similar host-stage commands were paying the full transitive import cost of every subcommand module, including `run.ts` (~232ms — the agent runtime, server, plugin loader, and cheerio/jsdom/jq-wasm stack) and `init.ts` (~175ms — kakaotalk-auth, oauth-login, models-dev, and @clack/prompts). None of that code is reachable on a `status` call.

The fix converts all 13 entries in `src/cli/index.ts`'s `subCommands` map from static top-level imports to lazy thunks (`() => import('./x').then(m => m.x)`). citty's `Resolvable<CommandDef>` already accepts this shape (`node_modules/citty/dist/index.d.mts:81`), and `_findSubCommand` early-returns on a direct name match (`index.mjs:259`), so the hot path loads only the matched subcommand's module graph.

## Results

Wall-clock on macOS arm64, bun 1.3.13, 3 runs each:

| Command | Before | After | Speedup |
|---|---|---|---|
| `typeclaw status` | 490ms | 60ms | 8.2× |
| `typeclaw logs` | 490ms | 60ms | 8.2× |
| `typeclaw stop` | 520ms | 80ms | 6.5× |
| `typeclaw reload` | 2050ms | 1640ms | CLI overhead cut; remainder is the WS round-trip |

`--help` is unchanged (~450ms) because citty's `renderUsage` iterates every subcommand to build the commands table, so the full set is still resolved there. That is a human-facing path; the trade-off is fine.

## Tradeoffs and non-obvious details

**citty compatibility** — `Resolvable<T>` is defined as `T | Promise<T> | (() => T) | (() => Promise<T>)` in citty's published types. The lazy-thunk shape sits squarely in the third/fourth branch. The alias-search loop (which does iterate all subcommands) only activates for unknown command names; it is not on any hot path.

**hostd drift** — `src/hostd/version.ts` fingerprints `src/**/*.ts` for drift detection. Any running daemon will detect the diff on the first `typeclaw start` after this lands and self-respawn once. That is the designed drift-respawn flow documented in AGENTS.md, not a regression.

**No behavior change.** All 2517 tests pass. Diff is +13/−27 in a single file.