### PR TITLE
Mark KakaoTalk inbound messages read unconditionally

### DIFF
--- a/src/channels/adapters/kakaotalk.test.ts
+++ b/src/channels/adapters/kakaotalk.test.ts
@@ -137,7 +137,6 @@ const adapterCfg = (over: Partial<KakaotalkAdapterConfig> = {}): KakaotalkAdapte
     stickiness: { perReply: { window: 300_000 } },
   },
   history: defaultHistoryConfig(),
-  autoMarkRead: false,
   ...over,
 })
 
@@ -762,7 +761,7 @@ describe('createKakaotalkAdapter — inbound classification', () => {
   })
 })
 
-describe('createKakaotalkAdapter — auto mark read', () => {
+describe('createKakaotalkAdapter — mark read on every inbound', () => {
   const dmChat = (id: string): KakaoChat => ({
     chat_id: id,
     type: 0,
@@ -804,37 +803,7 @@ describe('createKakaotalkAdapter — auto mark read', () => {
     sent_at: 1_730_000_000_000,
   })
 
-  test('fires markRead after route resolves when autoMarkRead is true', async () => {
-    const client = new FakeClient()
-    const listener = new FakeListener()
-    const cfg = adapterCfg({ autoMarkRead: true })
-    const router = createChannelRouter({ agentDir, configForAdapter: () => cfg })
-    const logs: string[] = []
-    const adapter = createKakaotalkAdapter({
-      router,
-      configRef: () => cfg,
-      client,
-      listenerFactory: () => listener,
-      logger: {
-        info: (m) => logs.push(m),
-        warn: (m) => logs.push(m),
-        error: (m) => logs.push(m),
-      },
-    })
-    client.chats = [dmChat('111')]
-    await adapter.start()
-    listener.emit('connected', { userId: '999' })
-
-    listener.emit('message', accepted('111', 'L42'))
-    await new Promise((r) => setTimeout(r, 50))
-
-    expect(client.markReadCalls).toEqual([{ chatId: '111', logId: 'L42' }])
-
-    await adapter.stop()
-    await router.stop()
-  })
-
-  test('does not fire markRead when autoMarkRead is false (default)', async () => {
+  test('fires markRead for a routed inbound', async () => {
     const client = new FakeClient()
     const listener = new FakeListener()
     const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
@@ -849,22 +818,21 @@ describe('createKakaotalkAdapter — auto mark read', () => {
     listener.emit('connected', { userId: '999' })
 
     listener.emit('message', accepted('111', 'L42'))
-    await new Promise((r) => setTimeout(r, 10))
+    await new Promise((r) => setTimeout(r, 50))
 
-    expect(client.markReadCalls).toHaveLength(0)
+    expect(client.markReadCalls).toEqual([{ chatId: '111', logId: 'L42' }])
 
     await adapter.stop()
     await router.stop()
   })
 
-  test('does not fire markRead for dropped messages even when autoMarkRead is true', async () => {
+  test('still fires markRead when classification drops the message (self-author, not-in-allow, etc.)', async () => {
     const client = new FakeClient()
     const listener = new FakeListener()
-    const cfg = adapterCfg({ autoMarkRead: true })
-    const router = createChannelRouter({ agentDir, configForAdapter: () => cfg })
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
     const adapter = createKakaotalkAdapter({
       router,
-      configRef: () => cfg,
+      configRef: () => adapterCfg(),
       client,
       listenerFactory: () => listener,
     })
@@ -872,10 +840,14 @@ describe('createKakaotalkAdapter — auto mark read', () => {
     await adapter.start()
     listener.emit('connected', { userId: '999' })
 
+    // authorId 999 matches the fake profile's user_id → self_author drop.
+    // The contract changed: we still want the unread "1" to clear, so
+    // markRead must fire even though the message never reaches the router.
     listener.emit('message', accepted('111', 'L42', 999))
-    await new Promise((r) => setTimeout(r, 10))
+    await new Promise((r) => setTimeout(r, 50))
 
-    expect(client.markReadCalls).toHaveLength(0)
+    expect(client.markReadCalls).toEqual([{ chatId: '111', logId: 'L42' }])
+    expect(client.sendMessageCalls).toHaveLength(0)
 
     await adapter.stop()
     await router.stop()
@@ -884,7 +856,7 @@ describe('createKakaotalkAdapter — auto mark read', () => {
   test('skips markRead for open-chat bucket (linkId not yet wired through resolver)', async () => {
     const client = new FakeClient()
     const listener = new FakeListener()
-    const cfg = adapterCfg({ allow: ['kakao:open/*'], autoMarkRead: true })
+    const cfg = adapterCfg({ allow: ['kakao:open/*'] })
     const router = createChannelRouter({ agentDir, configForAdapter: () => cfg })
     const logs: string[] = []
     const adapter = createKakaotalkAdapter({
@@ -906,9 +878,7 @@ describe('createKakaotalkAdapter — auto mark read', () => {
     await new Promise((r) => setTimeout(r, 50))
 
     expect(client.markReadCalls).toHaveLength(0)
-    const skipped = logs.find(
-      (m) => m.includes('auto-mark-read skipped') && m.includes('open_chat_link_id_unsupported'),
-    )
+    const skipped = logs.find((m) => m.includes('mark-read skipped') && m.includes('open_chat_link_id_unsupported'))
     expect(skipped).toBeDefined()
 
     await adapter.stop()
@@ -919,7 +889,7 @@ describe('createKakaotalkAdapter — auto mark read', () => {
     const client = new FakeClient()
     const listener = new FakeListener()
     client.markReadError = new Error('LOCO packet timeout')
-    const cfg = adapterCfg({ allow: ['kakao:group/*'], autoMarkRead: true })
+    const cfg = adapterCfg({ allow: ['kakao:group/*'] })
     const router = createChannelRouter({ agentDir, configForAdapter: () => cfg })
     const logs: string[] = []
     const adapter = createKakaotalkAdapter({
@@ -941,7 +911,7 @@ describe('createKakaotalkAdapter — auto mark read', () => {
     await new Promise((r) => setTimeout(r, 50))
 
     expect(client.markReadCalls).toHaveLength(1)
-    const failure = logs.find((m) => m.includes('auto-mark-read failed') && m.includes('LOCO packet timeout'))
+    const failure = logs.find((m) => m.includes('mark-read failed') && m.includes('LOCO packet timeout'))
     expect(failure).toBeDefined()
 
     await adapter.stop()
@@ -952,7 +922,7 @@ describe('createKakaotalkAdapter — auto mark read', () => {
     const client = new FakeClient()
     const listener = new FakeListener()
     client.markReadResult = { success: false, status_code: -500, chat_id: '222', watermark: 'L11' }
-    const cfg = adapterCfg({ allow: ['kakao:group/*'], autoMarkRead: true })
+    const cfg = adapterCfg({ allow: ['kakao:group/*'] })
     const router = createChannelRouter({ agentDir, configForAdapter: () => cfg })
     const logs: string[] = []
     const adapter = createKakaotalkAdapter({
@@ -973,7 +943,7 @@ describe('createKakaotalkAdapter — auto mark read', () => {
     listener.emit('message', accepted('222', 'L11'))
     await new Promise((r) => setTimeout(r, 50))
 
-    const nonSuccess = logs.find((m) => m.includes('auto-mark-read non-success') && m.includes('status_code=-500'))
+    const nonSuccess = logs.find((m) => m.includes('mark-read non-success') && m.includes('status_code=-500'))
     expect(nonSuccess).toBeDefined()
 
     await adapter.stop()

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -327,6 +327,15 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
         `[kakaotalk] inbound log_id=${event.log_id} author=${event.author_id} ${inboundTag} text_len=${event.message.length}`,
       )
 
+      // Ack the message BEFORE classify/route so the sender's unread "1"
+      // (노란숫자) clears even when we drop the message (self-author,
+      // not-in-allow, empty text, etc.). The receiver of a kakao adapter is
+      // expected to behave like a "read it as soon as it arrives" client —
+      // the agent has observed the bytes, so the user should see the read
+      // acknowledgement regardless of what we decide to do with the message
+      // downstream. Open-chat skip is enforced inside markReadIfSupported.
+      markReadIfSupported({ client, event, channelResolver, logger })
+
       const verdict = classifyInbound(event, options.configRef(), {
         selfUserId,
         lookupChat: (id) => channelResolver.lookupChat(id),
@@ -350,9 +359,6 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
         `[kakaotalk] routed log_id=${event.log_id} ${inboundTag} mention=${enriched.isBotMention} dm=${enriched.isDm}`,
       )
       await options.router.route(enriched)
-      if (options.configRef().autoMarkRead) {
-        autoMarkRead({ client, event, channelResolver, logger })
-      }
     } catch (err) {
       logger.error(`[kakaotalk] handleInbound failed: ${describe(err)}`)
     } finally {
@@ -554,7 +560,7 @@ function describe(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
-function autoMarkRead(deps: {
+function markReadIfSupported(deps: {
   client: Pick<KakaoTalkClient, 'markRead'>
   event: KakaoTalkPushMessageEvent
   channelResolver: Pick<KakaoChannelResolver, 'lookupChat'>
@@ -568,7 +574,7 @@ function autoMarkRead(deps: {
     // surface linkId today, so rather than send a doomed ack we skip and
     // log once. Wiring linkId through the resolver is a follow-up.
     logger.info(
-      `[kakaotalk] auto-mark-read skipped chat=${event.chat_id} log=${event.log_id} reason=open_chat_link_id_unsupported`,
+      `[kakaotalk] mark-read skipped chat=${event.chat_id} log=${event.log_id} reason=open_chat_link_id_unsupported`,
     )
     return
   }
@@ -576,12 +582,12 @@ function autoMarkRead(deps: {
     (result) => {
       if (!result.success) {
         logger.warn(
-          `[kakaotalk] auto-mark-read non-success status_code=${result.status_code} chat=${event.chat_id} log=${event.log_id}`,
+          `[kakaotalk] mark-read non-success status_code=${result.status_code} chat=${event.chat_id} log=${event.log_id}`,
         )
       }
     },
     (err) => {
-      logger.warn(`[kakaotalk] auto-mark-read failed: ${describe(err)} chat=${event.chat_id} log=${event.log_id}`)
+      logger.warn(`[kakaotalk] mark-read failed: ${describe(err)} chat=${event.chat_id} log=${event.log_id}`)
     },
   )
 }

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -54,7 +54,6 @@ const enabledAdapterCfg = () => ({
     stickiness: { perReply: { window: 300_000 } },
   },
   history: defaultHistoryConfig(),
-  autoMarkRead: false,
 })
 
 describe('channel manager — slack adapter lifecycle', () => {

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -127,10 +127,9 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       })
     }
     if (name === 'kakaotalk') {
-      const kakaoFallback = { ...cfg, autoMarkRead: false }
       return createKakaotalk({
         router,
-        configRef: () => options.channelsConfigRef()[name] ?? kakaoFallback,
+        configRef: () => options.channelsConfigRef()[name] ?? cfg,
         logger,
         selfAliasesRef: () => router.getSelfAliases(),
         credentialsDir: resolveKakaoConfigDir(options.agentDir, env),

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -99,21 +99,20 @@ const adapterSchema = z.object({
   enabled: z.boolean().default(true),
 })
 
-// KakaoTalk adds `autoMarkRead`: when true, after the adapter delivers an
-// inbound message to the router it fires a LOCO NOTIREAD ack so the sender's
-// unread "1" (노란숫자) clears. Off by default — auto-acking every received
-// message is a distinct behavioral fingerprint vs a human, and KakaoTalk's
-// abuse detection may flag accounts that ack rapidly and unconditionally.
-// Enable only on dedicated agent accounts you can afford to lose. Lives on
-// the KakaoTalk slot only so other adapters' config shape is unchanged.
-const kakaotalkAdapterSchema = adapterSchema.extend({
-  autoMarkRead: z.boolean().default(false),
-})
-
+// KakaoTalk uses the same shape as every other adapter. There used to be an
+// `autoMarkRead` opt-in here; the adapter now fires a LOCO NOTIREAD ack on
+// every inbound MSG event unconditionally (see kakaotalk.ts) so the sender's
+// unread "1" (노란숫자) clears as soon as the agent observes the message.
+// Existing configs with `autoMarkRead: <bool>` continue to parse — Zod's
+// default `.object()` strips unknown keys silently — but the field has no
+// effect. Risk note: auto-acking every received message is a distinct
+// behavioral fingerprint vs a human, so KakaoTalk's abuse detection may
+// flag accounts that ack rapidly and unconditionally. Run typeclaw with the
+// kakaotalk adapter only on dedicated agent accounts you can afford to lose.
 export const channelsSchema = z
   .object({
     'discord-bot': adapterSchema.optional(),
-    kakaotalk: kakaotalkAdapterSchema.optional(),
+    kakaotalk: adapterSchema.optional(),
     'slack-bot': adapterSchema.optional(),
     'telegram-bot': adapterSchema.optional(),
   })
@@ -122,7 +121,7 @@ export const channelsSchema = z
 export type AllowRule = string
 export type EngagementConfig = z.infer<typeof engagementSchema>
 export type ChannelAdapterConfig = z.infer<typeof adapterSchema>
-export type KakaotalkAdapterConfig = z.infer<typeof kakaotalkAdapterSchema>
+export type KakaotalkAdapterConfig = ChannelAdapterConfig
 export type ChannelsConfig = z.infer<typeof channelsSchema>
 
 // Discord IDs are numeric snowflakes; Slack IDs start with a single uppercase

--- a/src/skills/typeclaw-channel-kakaotalk/SKILL.md
+++ b/src/skills/typeclaw-channel-kakaotalk/SKILL.md
@@ -61,18 +61,18 @@ If you find yourself NOT receiving messages you expect to, the most likely cause
 
 The init wizard's default is `kakao:dm/*` because group chats with personal accounts are sensitive — every member sees every reply. Only broaden the allow list when the user explicitly asks.
 
-## Auto mark read (opt-in)
+## Mark read on every inbound
 
-If `channels.kakaotalk.autoMarkRead` is `true` in `typeclaw.json`, the adapter sends a LOCO `NOTIREAD` ack to KakaoTalk after every inbound message it delivers to the router. The sender's unread "1" (노란숫자) clears in their client as soon as you receive it. Off by default.
+The adapter sends a LOCO `NOTIREAD` ack to KakaoTalk for every inbound message event it observes. The sender's unread "1" (노란숫자) clears in their client as soon as the agent's container receives the bytes. This is always-on — there is no config flag to turn it off short of editing the source. (An earlier `channels.kakaotalk.autoMarkRead` opt-in field was removed; existing configs still parse but the field is ignored.)
 
-Trade-off you should know about before enabling it:
+Things to know about this behavior:
 
-- Auto-acking every received message is a distinct behavioral fingerprint compared to a human. A human reads messages when they open the chat; this setting acks every received message instantly, even ones you never reply to. KakaoTalk's abuse detection may flag accounts that ack rapidly and unconditionally. Enable only on dedicated agent accounts you can afford to lose.
-- Dropped messages (your own self-sent, empty text, sender not in `allow`) are not acked — only routed messages.
-- Open chats (오픈채팅) are skipped: the LOCO `NOTIREAD` packet needs a `linkId` for open chats and the adapter doesn't surface it yet. Unread counters in open chats will not decrement even with `autoMarkRead: true`.
+- Auto-acking every received message is a distinct behavioral fingerprint compared to a human. A human reads messages when they open the chat; this adapter acks every received message instantly, even ones you never reply to. KakaoTalk's abuse detection may flag accounts that ack rapidly and unconditionally. **Run the kakaotalk adapter only on dedicated agent accounts you can afford to lose.**
+- Dropped messages are still acked. If classify drops the message (your own self-sent loopback, empty text, sender not in `allow`), the unread "1" still clears — the agent has observed the bytes, so the read indicator should match.
+- Open chats (오픈채팅) are skipped: the LOCO `NOTIREAD` packet needs a `linkId` for open chats and the adapter doesn't surface it yet. Unread counters in open chats will not decrement.
 - The phone's home-screen OS unread badge may lag until the phone client foregrounds; the in-chat counter and other participants' indicators update immediately. KakaoTalk client quirk, not a typeclaw bug.
 
-If a markRead call fails (network blip, non-success status from the server, container shutdown), it is logged at warn level and silently moves on — message delivery is never blocked by an ack failure.
+If a markRead call fails (network blip, non-success status from the server, container shutdown), it is logged at warn level (`[kakaotalk] mark-read failed: ...`) and silently moves on — message delivery is never blocked by an ack failure.
 
 ## Self-loop guard
 


### PR DESCRIPTION
## Summary

The KakaoTalk adapter now fires a LOCO `NOTIREAD` ack on every inbound MSG event the listener emits, including events that classify-as-drop (self-author, not-in-allow-list, empty-text, pre-connect). Previously the ack was opt-in via `channels.kakaotalk.autoMarkRead` (default `false`) and only fired after `router.route()` resolved — so any non-routed sender kept seeing an unread "1" (노란숫자) in their KakaoTalk client even though the agent had already processed the bytes.

`channels.kakaotalk.autoMarkRead` is removed from the schema. Existing `typeclaw.json` files that still carry the field keep parsing (Zod strips unknown keys silently); the field is silently ignored. There is no way to disable the ack short of removing the kakaotalk adapter block entirely.

## Why

The previous design tied read-receipt semantics to the agent's routing decision, which leaked an implementation detail into the sender's UX. The agent observes every inbound message at the listener layer — the acknowledgement should reflect that, not whether the message cleared the allow list or self-author filter downstream.

The earlier `autoMarkRead: false` default was added specifically because of the abuse-detection risk: rapid unconditional acks are a non-human behavioral fingerprint that may flag the account with KakaoTalk's anomaly detection. That risk is now baked into the runtime rather than gated behind a flag, because running the kakaotalk adapter at all carries the same fingerprint footprint as `autoMarkRead: true` did. The risk note has been promoted from the schema comment (which users rarely read) to the kakaotalk `SKILL.md` so the agent surfaces it when a user wires the adapter.

**Run the kakaotalk adapter only on dedicated agent accounts you can afford to lose.** This was true of `autoMarkRead: true` before; it is now true of using the adapter at all.

Open chats (`@kakao-open`) are still skipped: LOCO `NOTIREAD` requires a `linkId` for open chats that the resolver does not surface yet. Behavior is unchanged from before.

## Changes

### `src/channels/adapters/kakaotalk.ts`

- `autoMarkRead` helper renamed to `markReadIfSupported`.
- Moved before classify/route; called unconditionally — no longer gated by `options.configRef().autoMarkRead`.
- Open-chat skip preserved.
- Log namespace updated: `auto-mark-read {failed,non-success,skipped}` → `mark-read {failed,non-success,skipped}`.

### `src/channels/schema.ts`

- `kakaotalkAdapterSchema` (which extended `adapterSchema` with `autoMarkRead: z.boolean().default(false)`) removed. Kakao now uses plain `adapterSchema`.
- `KakaotalkAdapterConfig` kept as a public alias of `ChannelAdapterConfig` for type-stability of internal callers.
- The abuse-detection risk comment moved to `SKILL.md`.

### `src/channels/manager.ts`

- `const kakaoFallback = { ...cfg, autoMarkRead: false }` shim removed. Kakao uses the same fallback shape as every other adapter.

### `src/channels/adapters/kakaotalk.test.ts`

- `adapterCfg` helper: `autoMarkRead: false` dropped.
- "auto mark read" suite rewritten:
  - Removed "does not fire markRead when autoMarkRead is false (default)".
  - Renamed "fires markRead after route resolves when autoMarkRead is true" → "fires markRead for a routed inbound".
  - Flipped "does not fire markRead for dropped messages even when autoMarkRead is true" into "still fires markRead when classification drops the message (self-author, not-in-allow, etc.)" — the regression anchor for the behavior change.
  - Log-string assertions updated from `auto-mark-read` → `mark-read`.

### `src/channels/manager.test.ts`

- `enabledAdapterCfg`: `autoMarkRead: false` dropped (no longer in type).

### `src/skills/typeclaw-channel-kakaotalk/SKILL.md`

- "Auto mark read (opt-in)" section rewritten as "Mark read on every inbound".
- Abuse-detection risk note moved here verbatim from the schema comment so the agent and humans both see it during setup.

## Verification

- `bun run lint` — 0 warnings, 0 errors
- `bun run format` — all files conform
- `bun run typecheck` — clean
- `bun test` — 2516 pass / 0 fail / 5084 expects across 151 files