### PR TITLE
Default dreaming to every 30 minutes for sporadic agents

### DIFF
--- a/plugins/memory/README.md
+++ b/plugins/memory/README.md
@@ -11,17 +11,17 @@ This plugin is **auto-loaded** by every TypeClaw agent. There is no `plugins[]` 
   "memory": {
     "idleMs": 10000,
     "bufferBytes": 100000,
-    "dreaming": { "schedule": "0 4 * * *" }
+    "dreaming": { "schedule": "*/30 * * * *" }
   }
 }
 ```
 
-| Field                      | Default            | Effect                                                                                                                                                                                    |
-| -------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `memory.idleMs`            | `10000`            | Debounce window before `memory-logger` spawns after a prompt completes. Minimum `1000`.                                                                                                   |
-| `memory.bufferBytes`       | `100000`           | Size-based ceiling: spawns `memory-logger` when the transcript grows by this many bytes since the last run, even during continuous activity. `0` disables. Minimum `10000` when non-zero. |
-| `memory.dreaming`          | `{}` (cron job on) | Dreaming cron job is always registered. Override `schedule` to change when it fires.                                                                                                      |
-| `memory.dreaming.schedule` | `"0 4 * * *"`      | Five-field cron expression. Applies whether `memory.dreaming` is omitted, empty, or explicitly set. Second-level schedules are rejected to avoid noisy no-op dreaming loops.              |
+| Field                      | Default            | Effect                                                                                                                                                                                                                                                                                                                                                             |
+| -------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `memory.idleMs`            | `10000`            | Debounce window before `memory-logger` spawns after a prompt completes. Minimum `1000`.                                                                                                                                                                                                                                                                            |
+| `memory.bufferBytes`       | `100000`           | Size-based ceiling: spawns `memory-logger` when the transcript grows by this many bytes since the last run, even during continuous activity. `0` disables. Minimum `10000` when non-zero.                                                                                                                                                                          |
+| `memory.dreaming`          | `{}` (cron job on) | Dreaming cron job is always registered. Override `schedule` to change when it fires.                                                                                                                                                                                                                                                                               |
+| `memory.dreaming.schedule` | `"*/30 * * * *"`   | Five-field cron expression. Defaults to every 30 minutes; fires short-circuit with zero LLM cost when nothing sits past the watermark, so frequent no-op fires are cheap and let sporadic agents still consolidate while alive (`src/cron/scheduler.ts` has no catchup for missed fires). Second-level schedules are rejected to avoid noisy no-op dreaming loops. |
 
 All fields are **restart-required** — the plugin reads them once at boot.
 

--- a/plugins/memory/index.test.ts
+++ b/plugins/memory/index.test.ts
@@ -96,15 +96,15 @@ describe('memory plugin shape', () => {
 
   test('registers the dreaming cron job with the default schedule when dreaming is not configured', async () => {
     const { exports } = await bootMemoryPlugin(agentDir, { idleMs: 5000 })
-    expect(exports.cronJobs?.dreaming?.schedule).toBe('0 4 * * *')
+    expect(exports.cronJobs?.dreaming?.schedule).toBe('*/30 * * * *')
   })
 
   test('default config injects an idleMs of 10 seconds and a default dreaming schedule', async () => {
     const { exports: noDream } = await bootMemoryPlugin(agentDir, {})
-    expect(noDream.cronJobs?.dreaming?.schedule).toBe('0 4 * * *')
+    expect(noDream.cronJobs?.dreaming?.schedule).toBe('*/30 * * * *')
 
     const { exports: withDream } = await bootMemoryPlugin(agentDir, { dreaming: {} })
-    expect(withDream.cronJobs?.dreaming?.schedule).toBe('0 4 * * *')
+    expect(withDream.cronJobs?.dreaming?.schedule).toBe('*/30 * * * *')
   })
 
   test('rejects invalid cron expression in dreaming.schedule', async () => {

--- a/plugins/memory/index.ts
+++ b/plugins/memory/index.ts
@@ -13,7 +13,12 @@ import { createMemoryLoggerSubagent, type MemoryLoggerPayload } from './memory-l
 const DEFAULT_IDLE_MS = 10_000
 const DEFAULT_BUFFER_BYTES = 100_000
 const MIN_BUFFER_BYTES = 10_000
-const DEFAULT_DREAMING_SCHEDULE = '0 4 * * *'
+// 30-minute default. Fires short-circuit before any LLM call when nothing
+// sits past the watermark (`dreaming.ts` handler returns when
+// `snapshots.undreamed.length === 0`), so frequent no-op fires are cheap.
+// The scheduler has no catchup for missed fires; a daily default would starve
+// sporadic agents entirely. Operators can override via `memory.dreaming.schedule`.
+const DEFAULT_DREAMING_SCHEDULE = '*/30 * * * *'
 
 // Hard ceiling on a single memory-logger spawn. The chain serializes spawns
 // per agent, so a non-settling spawn would otherwise wedge every subsequent

--- a/src/skills/typeclaw-memory/SKILL.md
+++ b/src/skills/typeclaw-memory/SKILL.md
@@ -38,7 +38,7 @@ The Claim/Evidence/Implication structure is **required** and the bar is intentio
 
 ### Stage 2: dreaming (offline, scheduled)
 
-The dreaming subagent runs on cron, configured under `memory.dreaming.schedule` (default `"0 4 * * *"` — 4 AM in the agent's timezone). Multiple runs per day are fine. The cron job id is `__plugin_memory_dreaming` (you cannot list it via the user-facing cron tools — it is plugin-owned).
+The dreaming subagent runs on cron, configured under `memory.dreaming.schedule` (default `"*/30 * * * *"` — every 30 minutes). Multiple runs per day are the norm, not the exception; a fire with nothing past the watermark short-circuits before any LLM call, so most fires cost only a filesystem scan. The cron job id is `__plugin_memory_dreaming` (you cannot list it via the user-facing cron tools — it is plugin-owned).
 
 When dreaming fires, it reads:
 
@@ -116,7 +116,7 @@ You cannot remove a fragment cleanly. The right response depends on what X is:
 ## When the user asks "what did you dream?" / "when do you dream next?"
 
 1. **What you dreamed**: read the most recent `Dream` git commit on your agent folder (`git log --grep='^Dream' -1`) and show the diff against `MEMORY.md` if useful. The commit timestamp tells you when dreaming last ran. If the answer is "no `Dream` commits yet", say that — `MEMORY.md` may exist but be the auto-created empty file from the first dreaming attempt.
-2. **When you dream next**: read `memory.dreaming.schedule` from `typeclaw.json` (default `"0 4 * * *"`). Translate the cron expression to a wall-clock time in the agent's `TZ`. If `memory.dreaming` is omitted from the config, the cron job is **not registered** — dreaming will not fire on a schedule, only if the user explicitly publishes a `new-session` for the `dreaming` subagent (rare). Tell the user honestly if the schedule is missing.
+2. **When you dream next**: read `memory.dreaming.schedule` from `typeclaw.json` (default `"*/30 * * * *"` — every 30 minutes). Translate the cron expression to a wall-clock time in the agent's `TZ`. The dreaming cron job is **always registered** even when `memory.dreaming` is omitted; the default schedule applies. Tell the user honestly when the next fire is in the agent's local time.
 
 ## When the user asks "what's a daily stream?" / "where is your memory stored?"
 
@@ -139,16 +139,16 @@ These are the only two configurable knobs. They live in the `memory` block of `t
 {
   "memory": {
     "idleMs": 10000,
-    "dreaming": { "schedule": "0 4 * * *" }
+    "dreaming": { "schedule": "*/30 * * * *" }
   }
 }
 ```
 
-| Field                      | Default               | Effect                                                                              | Reload class      |
-| -------------------------- | --------------------- | ----------------------------------------------------------------------------------- | ----------------- |
-| `memory.idleMs`            | `10000` (min `1000`)  | Debounce window before `memory-logger` spawns after a prompt completes.             | Restart-required. |
-| `memory.dreaming`          | omitted → no cron job | When present, registers the dreaming cron job.                                      | Restart-required. |
-| `memory.dreaming.schedule` | `"0 4 * * *"`         | Cron expression. Parsed via `cron-parser`; an invalid expression fails config load. | Restart-required. |
+| Field                      | Default              | Effect                                                                                                                                                                                                        | Reload class      |
+| -------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `memory.idleMs`            | `10000` (min `1000`) | Debounce window before `memory-logger` spawns after a prompt completes.                                                                                                                                       | Restart-required. |
+| `memory.dreaming`          | `{}` (cron job on)   | Dreaming cron job is always registered. Override `schedule` to change when it fires.                                                                                                                          | Restart-required. |
+| `memory.dreaming.schedule` | `"*/30 * * * *"`     | Cron expression. Parsed via `cron-parser`; an invalid expression fails config load. Fires with nothing past the watermark short-circuit before any LLM call, so frequent no-op fires are intentionally cheap. | Restart-required. |
 
 Both fields are restart-required because plugin config is read once at boot. After editing them, tell the user: "Edited `memory.<field>` — restart-required. Run `typeclaw restart` (host stage) to pick up the change." The bundled plugin's config schema is merged into `typeclaw.schema.json`, so editor autocomplete will validate these fields, but a `reload` will not re-instantiate the plugin.
 


### PR DESCRIPTION
## Summary

- Change `DEFAULT_DREAMING_SCHEDULE` from `'0 4 * * *'` to `'*/30 * * * *'` so the dreaming subagent fires every 30 minutes while the agent is alive.
- Update the three docs/tests that referenced the old default verbatim: `plugins/memory/README.md`, `plugins/memory/index.test.ts`, and `src/skills/typeclaw-memory/SKILL.md`. Test fixtures that use `'0 4 * * *'` as an arbitrary explicit schedule (not testing the default) are intentionally left untouched.
- Add a brief comment next to the constant pointing at the short-circuit in `dreaming.ts` and the catchup gap in `scheduler.ts` so the value isn't reverted in a future cleanup.

## Why

The cron scheduler in `src/cron/scheduler.ts` only ever schedules the **next** fire from \"now\" — there is no anacron-style catchup for missed fires. Combined with the previous daily default, this meant any agent that isn't running at 4 AM (test agents, weekend-only agents, agents bounced before the fire) would never dream. Daily streams would accumulate unconsolidated, and on the next session the agent would eventually hit `memory-logger`'s 50s spawn ceiling when a `buffer-trip` handed `kimi-k2p6-turbo` (or whichever model) a multi-day undreamed transcript to digest.

The 30-minute cadence relies on the existing short-circuit in `plugins/memory/dreaming.ts` (`createDreamingSubagent.handler` at L436-439): when no daily-stream lines sit past their watermark, the handler returns before `runSession`, so there is no LLM round-trip, no `MEMORY.md` rewrite, and no `Dream` commit. Frequent no-op fires cost only a directory scan and a few small reads. The watermark also makes the new cadence safe — once dreaming consolidates lines 1-50 of today's stream, the next fire only sees lines 51+ as undreamed; no double-paying is possible.

Operators who want the legacy single-daily cadence (e.g. for tight LLM-budget control on always-on agents) can still set `memory.dreaming.schedule` in `typeclaw.json`.

## Verification

- \`bun run lint\` — 0 warnings, 0 errors
- \`bun run format:check\` — clean
- \`bun run typecheck\` — clean
- \`bun run test\` — 2517 pass / 0 fail (151 files)

## Notes for the reviewer

- The skill at `src/skills/typeclaw-memory/SKILL.md` had stale guidance from before the dreaming cron became unconditional (it claimed dreaming wouldn't fire when `memory.dreaming` was omitted, but `plugins/memory/index.ts` always registers the cron job today). I fixed that drift in the same edit since it was right next to the default-value mention and would have been confusing otherwise. If you'd rather split that into a separate PR, happy to do it — it's two lines on SKILL.md.
- I considered hourly (`0 * * * *`) and 15-min (`*/15 * * * *`) as alternatives. 30-min is the sweet spot for the typical sporadic-agent test session (tens of minutes), and it bounds the worst-case `loadMemory` undreamed-tail surface at ~30 minutes of memory-logger output. Open to feedback if a different cadence would be more aligned with how the codebase thinks about cost.