### PR TITLE
Ship tsconfig.json so @/* path aliases resolve in published installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeclaw",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/typeclaw/typeclaw#readme",
   "bugs": {
     "url": "https://github.com/typeclaw/typeclaw/issues"
@@ -16,6 +16,7 @@
   "files": [
     "src",
     "scripts",
+    "tsconfig.json",
     "typeclaw.schema.json",
     "cron.schema.json",
     "secrets.schema.json",


### PR DESCRIPTION
## Summary

`typeclaw@0.1.0` from the npm registry is broken on every fresh install — **every** subcommand crashes with `Cannot find module '@/...'` the moment it touches a path-aliased import.

The user-visible report was:

```
$ typeclaw compose restart
error: Cannot find module '@/compose' from '/Users/neo/.bun/install/global/node_modules/typeclaw/src/cli/compose.ts'
```

…but `compose` is just the command they happened to run. `typeclaw init`, `start`, `tui`, etc. all import `@/config` or another `@/*` module and fail identically.

## Root cause

`@/*` is a TypeScript path alias mapped to `./src/*` in `tsconfig.json`. Bun honors this alias at runtime by walking up from the source file to find a `tsconfig.json` — but `tsconfig.json` wasn't in `package.json#files`, so it never made it into the published tarball.

Verified against the actual registry:

```
$ npm pack typeclaw@0.1.0 && tar -tzf typeclaw-0.1.0.tgz | grep -E '\.json$'
package/auth.schema.json
package/cron.schema.json
package/package.json
package/secrets.schema.json
package/typeclaw.schema.json     # ← no tsconfig.json
```

Dev installs masked this because `bun add -g` inside the workspace symlinks the global package back to the source tree, where `tsconfig.json` exists on disk. Anyone installing from npm got the broken tarball.

Same family of mistake as 70b974f ("Move bundled plugins under src/ so they ship in the npm tarball") — the published surface is narrower than what works in dev, and the gap isn't visible until someone runs the binary from a non-symlinked install.

## Fix

Add `tsconfig.json` to `package.json#files` and bump to `0.1.1`.

## Verification

Repacked locally (`npm pack`), extracted the tarball into a clean dir, and ran `bun src/cli/index.ts` end-to-end. `@/*` imports now resolve; `compose.ts` loads cleanly:

```
$ tar -tzf typeclaw-0.1.1.tgz | grep tsconfig
package/tsconfig.json
$ cd /tmp/extracted/package && bun -e "import('./src/cli/compose.ts').then(m => console.log('ok:', typeof m.composeCommand))"
ok: object
```

All pre-commit checks pass: `typecheck`, `lint`, `format:check`, `test` (2526/2526).

## Rollout

Publish `0.1.1` to npm; affected machines run `bun add -g typeclaw@0.1.1`.