### PR TITLE
Let the agent fetch KakaoTalk inbound attachments

### DIFF
--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -204,6 +204,9 @@ describe('channel_fetch_attachment', () => {
 
     const result = await runTool(tool, { ref: 'F1' })
 
-    expect(result.details).toEqual({ ok: false, error: 'fetch-attachment-not-supported' })
+    expect(result.details).toEqual({
+      ok: false,
+      error: 'no fetchAttachment callback registered for "slack-bot"',
+    })
   })
 })

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -32,7 +32,7 @@ function fakeRouter(
     fetchHistory: async () => ({ ok: false, error: 'history-not-supported' }),
     registerFetchAttachment: () => {},
     unregisterFetchAttachment: () => {},
-    fetchAttachment: async () => ({ ok: false, error: 'fetch-attachment-not-supported' }),
+    fetchAttachment: async () => ({ ok: false, error: 'no fetchAttachment callback registered for "slack-bot"' }),
     getSelfAliases: () => [],
     stop: async () => {},
     liveCount: () => 0,

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -26,7 +26,7 @@ function fakeRouter(
     fetchHistory: async () => ({ ok: false, error: 'history-not-supported' }),
     registerFetchAttachment: () => {},
     unregisterFetchAttachment: () => {},
-    fetchAttachment: async () => ({ ok: false, error: 'fetch-attachment-not-supported' }),
+    fetchAttachment: async () => ({ ok: false, error: 'no fetchAttachment callback registered for "slack-bot"' }),
     getSelfAliases: () => [],
     stop: async () => {},
     liveCount: () => 0,

--- a/src/channels/adapters/kakaotalk-attachment.test.ts
+++ b/src/channels/adapters/kakaotalk-attachment.test.ts
@@ -86,23 +86,28 @@ describe('formatInboundText', () => {
     expect(text).toBe('[KakaoTalk message with file keys=[other,weirdField]]')
   })
 
-  test('video (type=3) renders the generic shape with a keys preview', () => {
+  test('video (type=3) surfaces the url alongside the keys preview so the agent has a fetchable ref', () => {
     const text = formatInboundText({
       message: '',
       message_type: 3,
       attachment: { url: 'https://example.com/v.mp4', dur: 5000 },
     })
-    expect(text).toBe('[KakaoTalk message with video keys=[dur,url]]')
+    expect(text).toBe('[KakaoTalk message with video (keys=[dur,url]) https://example.com/v.mp4]')
   })
 
-  test('audio (type=5) renders the generic shape', () => {
+  test('audio (type=5) surfaces the url alongside the keys preview', () => {
     const text = formatInboundText({ message: '', message_type: 5, attachment: { url: 'https://example.com/a.m4a' } })
-    expect(text).toBe('[KakaoTalk message with audio keys=[url]]')
+    expect(text).toBe('[KakaoTalk message with audio (keys=[url]) https://example.com/a.m4a]')
   })
 
-  test('multiphoto (type=27) renders the generic shape', () => {
+  test('multiphoto (type=27) without a url falls back to a keys-only preview', () => {
     const text = formatInboundText({ message: '', message_type: 27, attachment: { kl: ['a', 'b', 'c'] } })
     expect(text).toBe('[KakaoTalk message with multiphoto keys=[kl]]')
+  })
+
+  test('video without a url falls back to a keys-only preview rather than fabricating a ref', () => {
+    const text = formatInboundText({ message: '', message_type: 3, attachment: { dur: 5000 } })
+    expect(text).toBe('[KakaoTalk message with video keys=[dur]]')
   })
 
   test('unknown non-text type with empty message returns empty text so classifyInbound can drop it as noise', () => {

--- a/src/channels/adapters/kakaotalk-attachment.ts
+++ b/src/channels/adapters/kakaotalk-attachment.ts
@@ -135,6 +135,14 @@ function summarizeFile(attachment: Record<string, unknown> | null): string {
 
 function summarizeGeneric(label: string, attachment: Record<string, unknown> | null): string {
   if (attachment === null) return label
+  // Prefer a dereferenceable URL over a keys-only preview: the agent uses
+  // the URL as the `ref` for channel_fetch_attachment, so making it visible
+  // in the placeholder is what turns video/audio/multiphoto from
+  // "described" into "fetchable". When the SDK hands us an opaque payload
+  // with no `url` (the documented case for these types), fall back to
+  // listing the available keys so we never lie about what arrived.
+  const url = stringField(attachment, 'url')
+  if (url !== null) return `${label} (${attachmentKeysSummary(attachment)}) ${url}`
   return `${label} ${attachmentKeysSummary(attachment)}`
 }
 

--- a/src/channels/adapters/kakaotalk-fetch-attachment.test.ts
+++ b/src/channels/adapters/kakaotalk-fetch-attachment.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { KakaotalkAdapterLogger } from './kakaotalk'
+import { createFetchAttachmentCallback } from './kakaotalk-fetch-attachment'
+
+function recordingLogger(): KakaotalkAdapterLogger & {
+  infos: string[]
+  warns: string[]
+  errors: string[]
+} {
+  const infos: string[] = []
+  const warns: string[] = []
+  const errors: string[] = []
+  return {
+    info: (m) => {
+      infos.push(m)
+    },
+    warn: (m) => {
+      warns.push(m)
+    },
+    error: (m) => {
+      errors.push(m)
+    },
+    infos,
+    warns,
+    errors,
+  }
+}
+
+function fakeFetch(responder: (url: string, init?: RequestInit) => Promise<Response> | Response): typeof fetch {
+  return ((url: string | URL | Request, init?: RequestInit) =>
+    Promise.resolve(responder(typeof url === 'string' ? url : url.toString(), init))) as typeof fetch
+}
+
+const PHOTO_URL =
+  'https://talk.kakaocdn.net/dna/byIE58/o3aSU13aSL/8O1voiq1dHdBlurQGOEWl4/i_e6095af16199.png?credential=zf3biCPbmWRjbqf40YGePFLewdou7TIK&expires=1778834720&signature=W%2BlSZ2yZvmKY5OrvQ%2B4H%2FTIUguc%3D'
+
+describe('kakaotalk createFetchAttachmentCallback', () => {
+  test('downloads from talk.kakaocdn.net without auth headers (the URL is pre-signed)', async () => {
+    const seen: Array<{ url: string; headers: Headers }> = []
+    const cb = createFetchAttachmentCallback({
+      logger: recordingLogger(),
+      fetchImpl: fakeFetch((url, init) => {
+        seen.push({ url, headers: new Headers(init?.headers) })
+        return new Response('kakao-bytes', {
+          status: 200,
+          headers: { 'content-type': 'image/png' },
+        })
+      }),
+    })
+
+    const result = await cb({ ref: PHOTO_URL })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.filename).toBe('i_e6095af16199.png')
+    expect(result.mimetype).toBe('image/png')
+    expect(result.size).toBe(11)
+    expect(result.buffer.toString('utf8')).toBe('kakao-bytes')
+    // given KakaoCDN URLs carry their auth in query params, no
+    // Authorization header should be sent — adding one would be
+    // wasted noise and risks fingerprinting the agent.
+    expect(seen[0]?.headers.get('Authorization')).toBeNull()
+  })
+
+  test('accepts every *.kakaocdn.net subdomain because file/video/audio land on different hosts', async () => {
+    const cb = createFetchAttachmentCallback({
+      logger: recordingLogger(),
+      fetchImpl: fakeFetch(() => new Response('ok', { status: 200, headers: { 'content-type': 'application/pdf' } })),
+    })
+
+    const result = await cb({
+      ref: 'https://dn-l-talk.kakaocdn.net/talkm/abc123/spec.pdf?credential=x&expires=1&signature=y',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.filename).toBe('spec.pdf')
+    expect(result.mimetype).toBe('application/pdf')
+  })
+
+  test('refuses non-kakaocdn hosts so the callback cannot be repurposed as a generic fetch', async () => {
+    let fetchCalled = false
+    const cb = createFetchAttachmentCallback({
+      logger: recordingLogger(),
+      fetchImpl: fakeFetch(() => {
+        fetchCalled = true
+        return new Response('should not happen', { status: 200 })
+      }),
+    })
+
+    const result = await cb({ ref: 'https://evil.example.com/steal' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected error')
+    expect(result.error).toContain('not a KakaoTalk CDN URL')
+    expect(fetchCalled).toBe(false)
+  })
+
+  test('refuses lookalike hosts that suffix-match without a dot (evilkakaocdn.net)', async () => {
+    let fetchCalled = false
+    const cb = createFetchAttachmentCallback({
+      logger: recordingLogger(),
+      fetchImpl: fakeFetch(() => {
+        fetchCalled = true
+        return new Response('', { status: 200 })
+      }),
+    })
+
+    const result = await cb({ ref: 'https://evilkakaocdn.net/abc' })
+
+    expect(result.ok).toBe(false)
+    expect(fetchCalled).toBe(false)
+  })
+
+  test('refuses http:// (only signed https URLs are minted by LOCO)', async () => {
+    let fetchCalled = false
+    const cb = createFetchAttachmentCallback({
+      logger: recordingLogger(),
+      fetchImpl: fakeFetch(() => {
+        fetchCalled = true
+        return new Response('', { status: 200 })
+      }),
+    })
+
+    const result = await cb({ ref: 'http://talk.kakaocdn.net/anything' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected error')
+    expect(result.error).toContain('https')
+    expect(fetchCalled).toBe(false)
+  })
+
+  test('rejects malformed URLs without dispatching a fetch', async () => {
+    let fetchCalled = false
+    const cb = createFetchAttachmentCallback({
+      logger: recordingLogger(),
+      fetchImpl: fakeFetch(() => {
+        fetchCalled = true
+        return new Response('', { status: 200 })
+      }),
+    })
+
+    const result = await cb({ ref: 'not-a-url' })
+
+    expect(result.ok).toBe(false)
+    expect(fetchCalled).toBe(false)
+  })
+
+  test('surfaces 403 with the expiry hint so the agent can tell the user to re-share the photo', async () => {
+    const logger = recordingLogger()
+    const cb = createFetchAttachmentCallback({
+      logger,
+      fetchImpl: fakeFetch(() => new Response('expired', { status: 403, statusText: 'Forbidden' })),
+    })
+
+    const result = await cb({ ref: PHOTO_URL })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected error')
+    expect(result.error).toContain('403')
+    expect(result.error).toContain('expired pre-signed URL')
+    expect(result.error).toContain('re-share')
+    expect(logger.errors[0]).toContain('fetchAttachment failed')
+  })
+
+  test('surfaces non-403 errors verbatim without injecting the expiry hint', async () => {
+    const cb = createFetchAttachmentCallback({
+      logger: recordingLogger(),
+      fetchImpl: fakeFetch(() => new Response('boom', { status: 500, statusText: 'Internal Server Error' })),
+    })
+
+    const result = await cb({ ref: PHOTO_URL })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected error')
+    expect(result.error).toContain('500')
+    expect(result.error).not.toContain('expired pre-signed URL')
+  })
+
+  test('respects an explicit filename override even when the URL has its own basename', async () => {
+    const cb = createFetchAttachmentCallback({
+      logger: recordingLogger(),
+      fetchImpl: fakeFetch(() => new Response('z', { status: 200, headers: { 'content-type': 'text/plain' } })),
+    })
+
+    const result = await cb({ ref: PHOTO_URL, filename: 'screenshot.png' })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.filename).toBe('screenshot.png')
+  })
+
+  test('falls back to "attachment" when the URL has no usable basename', async () => {
+    const cb = createFetchAttachmentCallback({
+      logger: recordingLogger(),
+      fetchImpl: fakeFetch(() => new Response('z', { status: 200 })),
+    })
+
+    const result = await cb({ ref: 'https://talk.kakaocdn.net/' })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.filename).toBe('attachment')
+  })
+
+  test('returns a structured error when fetch itself throws (network failure)', async () => {
+    const logger = recordingLogger()
+    const cb = createFetchAttachmentCallback({
+      logger,
+      fetchImpl: fakeFetch(() => {
+        throw new Error('ENETUNREACH')
+      }),
+    })
+
+    const result = await cb({ ref: PHOTO_URL })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected error')
+    expect(result.error).toBe('ENETUNREACH')
+    expect(logger.errors[0]).toContain('fetchAttachment failed')
+  })
+})

--- a/src/channels/adapters/kakaotalk-fetch-attachment.ts
+++ b/src/channels/adapters/kakaotalk-fetch-attachment.ts
@@ -1,0 +1,91 @@
+import type { FetchAttachmentCallback } from '@/channels/types'
+
+import type { KakaotalkAdapterLogger } from './kakaotalk'
+
+// KakaoCDN hosts that the LOCO push payload mints pre-signed URLs against.
+// Photos hit `talk.kakaocdn.net` (verified empirically; the `credential`,
+// `expires`, and `signature` query params ARE the auth — no session
+// cookie, no Authorization header, no client-cert needed). File / video /
+// audio types reach the agent as `dn-l-talk.kakaocdn.net` or its peers in
+// the same domain, but in every case we've observed the hostname stays
+// under `*.kakaocdn.net`. We keep the allowlist strict (suffix match on
+// `.kakaocdn.net` only) so the agent cannot use this callback as a
+// generic credentialed fetch — the duck-type intent mirrors Discord and
+// Telegram, both of which lock their fetchAttachment to platform CDN
+// hosts for the same reason.
+const KAKAO_CDN_HOST_SUFFIX = '.kakaocdn.net'
+
+export function createFetchAttachmentCallback(deps: {
+  logger: KakaotalkAdapterLogger
+  fetchImpl?: typeof fetch
+}): FetchAttachmentCallback {
+  const { logger } = deps
+  const fetchImpl = deps.fetchImpl ?? fetch
+  return async ({ ref, filename }) => {
+    let url: URL
+    try {
+      url = new URL(ref)
+    } catch {
+      return { ok: false, error: `invalid KakaoTalk attachment URL: ${ref}` }
+    }
+    if (url.protocol !== 'https:') {
+      return { ok: false, error: `KakaoTalk attachment URL must be https: ${url.protocol}` }
+    }
+    if (!isKakaoCdnHost(url.hostname)) {
+      return { ok: false, error: `not a KakaoTalk CDN URL: ${url.hostname}` }
+    }
+    try {
+      const res = await fetchImpl(url.toString())
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        // 403 from kakaocdn almost always means the pre-signed URL expired
+        // (the `expires=` query param has a fixed TTL — empirically ~3
+        // days from the push event). Surfacing that distinction lets the
+        // agent give the user actionable feedback ("the photo link
+        // expired — ask them to send it again") instead of a bare HTTP
+        // code that looks like a transient failure.
+        const hint = res.status === 403 ? ' (likely an expired pre-signed URL; ask the sender to re-share)' : ''
+        const message = `kakaotalk cdn fetch ${res.status} ${res.statusText}${hint}${body ? `: ${body.slice(0, 200)}` : ''}`
+        logger.error(`[kakaotalk] fetchAttachment failed for ${url.toString()}: ${message}`)
+        return { ok: false, error: message }
+      }
+      const arrayBuffer = await res.arrayBuffer()
+      const buffer = Buffer.from(arrayBuffer)
+      const inferredFilename = filename ?? deriveFilename(url) ?? 'attachment'
+      const contentType = res.headers.get('content-type') ?? undefined
+      logger.info(
+        `[kakaotalk] downloaded url=${url.toString()} name=${inferredFilename} size=${buffer.length}${contentType ? ` type=${contentType}` : ''}`,
+      )
+      return {
+        ok: true,
+        buffer,
+        filename: inferredFilename,
+        ...(contentType !== undefined ? { mimetype: contentType } : {}),
+        size: buffer.length,
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error(`[kakaotalk] fetchAttachment failed for ${url.toString()}: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
+function isKakaoCdnHost(hostname: string): boolean {
+  const lower = hostname.toLowerCase()
+  // Exact match on the apex is allowed too; suffix match alone would
+  // accept "evilkakaocdn.net" without a leading dot. The bare-apex case
+  // is unusual for KakaoCDN traffic (real URLs are always subdomains)
+  // but keeping it permitted is harmless and matches the literal "any
+  // host under kakaocdn.net" intent.
+  return lower === 'kakaocdn.net' || lower.endsWith(KAKAO_CDN_HOST_SUFFIX)
+}
+
+function deriveFilename(url: URL): string | null {
+  // KakaoCDN paths look like `/dna/<segments>/i_<id>.png?credential=...`.
+  // The basename of `pathname` (ignoring the query string) is the most
+  // informative file label available to us.
+  const basename = url.pathname.split('/').pop()
+  if (basename === undefined || basename === '') return null
+  return basename
+}

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -29,6 +29,7 @@ import { emoticonEventToMessageEvent, formatHistoryText, formatInboundText } fro
 import { createKakaoAuthorResolver, type KakaoAuthorResolver } from './kakaotalk-author-resolver'
 import { createKakaoChannelResolver, type KakaoChannelResolver } from './kakaotalk-channel-resolver'
 import { classifyInbound, type InboundDropReason } from './kakaotalk-classify'
+import { createFetchAttachmentCallback } from './kakaotalk-fetch-attachment'
 
 // Inlined locally because agent-messenger/kakaotalk's index does not
 // re-export KakaoMarkReadResult even though client.markRead returns it
@@ -314,6 +315,8 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
     formatChannelTag,
   })
 
+  const fetchAttachmentCallback = createFetchAttachmentCallback({ logger })
+
   const handleMessageEvent = async (event: KakaoTalkPushMessageEvent): Promise<void> => {
     // Synthesize the displayed text BEFORE classify so attachments
     // (photo, file, video, ...) survive classifyInbound's empty_text
@@ -560,6 +563,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       options.router.registerOutbound('kakaotalk', outboundCallback)
       options.router.registerChannelNameResolver('kakaotalk', channelResolver.resolve)
       options.router.registerHistory('kakaotalk', historyCallback)
+      options.router.registerFetchAttachment('kakaotalk', fetchAttachmentCallback)
     },
 
     async stop(): Promise<void> {
@@ -568,6 +572,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       options.router.unregisterOutbound('kakaotalk', outboundCallback)
       options.router.unregisterChannelNameResolver('kakaotalk', channelResolver.resolve)
       options.router.unregisterHistory('kakaotalk', historyCallback)
+      options.router.unregisterFetchAttachment('kakaotalk', fetchAttachmentCallback)
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {
           stopWaiters.push(resolve)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1155,10 +1155,19 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   ): Promise<FetchAttachmentResult> => {
     const callbacks = fetchAttachmentCallbacks.get(adapter)
     if (!callbacks || callbacks.size === 0) {
-      return { ok: false, error: 'fetch-attachment-not-supported' }
+      return { ok: false, error: `no fetchAttachment callback registered for "${adapter}"` }
     }
     const snapshot = Array.from(callbacks)
-    let lastError: FetchAttachmentResult & { ok: false } = { ok: false, error: 'fetch-attachment-not-supported' }
+    // Initialized only so TypeScript can prove the variable is assigned
+    // before return. The loop body always overwrites it on the failure
+    // path (we just returned on the success path), so this string is
+    // unreachable at runtime — kept as a clearly-tagged sentinel rather
+    // than a non-null assertion so a future loop refactor that breaks
+    // this invariant surfaces a recognizable error string.
+    let lastError: FetchAttachmentResult & { ok: false } = {
+      ok: false,
+      error: `fetchAttachment for "${adapter}" returned no result (router bug)`,
+    }
     for (const cb of snapshot) {
       const result = await cb(args)
       if (result.ok) return result

--- a/src/skills/typeclaw-channel-kakaotalk/SKILL.md
+++ b/src/skills/typeclaw-channel-kakaotalk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typeclaw-channel-kakaotalk
-description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `kakaotalk`. KakaoTalk renders messages as plain text — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and other markdown all appear literally. There is no `@mention` syntax, no message threads, no replies-with-quote, and no outbound file attachments or stickers (inbound attachments and stickers ARE surfaced — see below). Read it before composing anything for KakaoTalk so you don't dump markdown into a chat window.
+description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `kakaotalk`, AND before calling `channel_fetch_attachment` against a KakaoTalk URL. KakaoTalk renders messages as plain text — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and other markdown all appear literally. There is no `@mention` syntax, no message threads, no replies-with-quote, and no outbound file attachments or stickers. Inbound photos / files / video / audio CAN be downloaded via `channel_fetch_attachment` (the placeholder text includes the URL); inbound stickers are metadata-only and cannot be fetched. URLs expire ~3 days after the message arrives. Read this skill before composing or fetching anything on KakaoTalk.
 ---
 
 # typeclaw-channel-kakaotalk
@@ -38,11 +38,19 @@ Even though you cannot SEND attachments or stickers, you DO receive them. The ad
 - A photo (with no caption): `[KakaoTalk message with photo 1320x2868 (image/jpeg) https://talk.kakaocdn.net/...]`
 - A photo with a caption: `look at this\n[KakaoTalk message with photo 1320x2868 (image/jpeg) https://...]`
 - A file: `[KakaoTalk message with file spec.pdf (application/pdf) size=12345 https://...]`
-- A video / audio: `[KakaoTalk message with video keys=[...]]` (the SDK leaves the payload opaque for these types, so we list the keys that were present rather than fabricating fields)
+- A video / audio (with a usable URL): `[KakaoTalk message with video (keys=[dur,url]) https://talk.kakaocdn.net/...]`. The SDK leaves video / audio / multiphoto payloads opaque, so we list the keys that were present alongside the URL when one exists; when no URL is present the placeholder is just `[KakaoTalk message with video keys=[...]]` and there is nothing for you to fetch.
 - A sticker / emoticon: `[KakaoTalk message with sticker (sticker) pack=4412724 path=4412724.emot_001.webp]`
 - An animated sticker: `[KakaoTalk message with sticker (sticker_ani) pack=... path=...]`
 
-Treat the placeholder as describing what the user sent. **You cannot fetch the photo bytes or play the audio** — `channel_fetch_attachment` is not wired for KakaoTalk, and the placeholder's fields (dimensions, MIME type, URL, sticker pack id) describe the envelope, NOT the content. Do not describe what a photo "depicts", what a sticker "looks like", or what an audio file "says" — you cannot see, read, or hear any of it. Acknowledge that something was sent ("Got the photo", "Cute sticker") and ask the user to describe it if you need more detail to respond meaningfully.
+### Fetching attachment bytes
+
+For photos, files, and any video / audio / multiphoto whose placeholder includes a `https://...kakaocdn.net/...` URL, call `channel_fetch_attachment` with that URL as the `ref` to download the bytes. The adapter validates the host (only `*.kakaocdn.net` is accepted — you cannot use this tool as a generic web fetcher) and returns the raw buffer plus mimetype.
+
+Use this when you actually need to look at the content — e.g. the user sends a screenshot and asks "what's in this?". The download lands in your inbox directory and you can pass it to a vision-capable inspection tool or read it directly depending on the file type.
+
+**Expiry caveat**: KakaoCDN URLs are pre-signed with an `expires=` timestamp baked into the query string — empirically ~3 days after the message arrived. Fetch promptly. If the URL has expired you will get a `403` error with the hint _"likely an expired pre-signed URL; ask the sender to re-share"_ — relay that to the user verbatim rather than guessing the cause.
+
+**Stickers cannot be fetched** as bytes through this tool. The sticker placeholder carries `pack=` and `path=` identifiers (KakaoTalk sticker pack metadata), not a downloadable URL. Treat stickers as descriptive metadata only — acknowledge them ("cute sticker") without trying to "see" them.
 
 If the inbound text is JUST a sticker (no accompanying text), the agent still gets a routed event — stickers count as engagement under `reply` and `dm` triggers (group chats with only sticker activity will not trigger `mention` because aliases require text matching).
 


### PR DESCRIPTION
## Summary

- The KakaoTalk channel adapter now registers a `fetchAttachment` callback with the router, so `channel_fetch_attachment` works against inbound KakaoTalk photos, files, and any video/audio/multiphoto whose attachment payload carries a `kakaocdn.net` URL. Previously the agent saw `[KakaoTalk message with photo ...]` placeholders but had no way to read the bytes — the gap a user just hit while trying to make the agent receive a screenshot.
- The router's `'fetch-attachment-not-supported'` sentinel is replaced with `'no fetchAttachment callback registered for \"<adapter>\"'`, mirroring the equivalent phrasing in `router.send`. With every shipped adapter now wiring a callback, the only path to that branch is a register/unregister race during adapter shutdown — which deserves an error that names the adapter, not a "this feature doesn't exist" lie.

## Why a typeclaw-only change

A `talk.kakaocdn.net` URL from a real photo, fetched with plain `curl` and no auth state, returns `200 OK` and a valid PNG body. The `credential` / `expires` / `signature` query params on the URL ARE the auth — they're pre-signed by the LOCO server when it builds the push event, and any client that received the URL can dereference it until expiry. No agent-messenger SDK change is required, and the SDK does not expose a `downloadAttachment` method on `KakaoTalkClient` anyway, so this is the only place the work can land.

## Security posture

- **Strict host allowlist.** Only `*.kakaocdn.net` (suffix match on `.kakaocdn.net` with explicit apex handling so `evilkakaocdn.net` does not slip through). `https://` only.
- **No Authorization header.** KakaoCDN URLs carry their auth in the query string. Sending a header would be useless noise and risks fingerprinting the agent. The test asserts the absence.
- **Not a generic credentialed fetch.** Same shape as Discord/Telegram's existing `createFetchAttachmentCallback`: the agent gets exactly one capability — turn a KakaoCDN URL the adapter already gave it into bytes.

## Expiry UX

Pre-signed URLs have an empirical ~3-day TTL via the `expires=` query param. On a `403` response, the callback's error string surfaces an actionable hint (\`likely an expired pre-signed URL; ask the sender to re-share\`) instead of a bare HTTP code, so the agent can relay the right ask to the user rather than guessing the cause. The SKILL.md update documents this caveat in the agent-facing surface.

## Placeholder update

`summarizeGeneric` (video/audio/multiphoto) now surfaces the `url` field when present:

\`\`\`
before: [KakaoTalk message with video keys=[dur,url]]
after:  [KakaoTalk message with video (keys=[dur,url]) https://talk.kakaocdn.net/...]
\`\`\`

Without this, video/audio/multiphoto attachments have no fetchable ref the agent can pass to `channel_fetch_attachment` — the URL was silently dropped into the keys preview. Payloads without a URL still fall back to the keys-only preview because the SDK leaves those types opaque and we never want to fabricate a ref. Photo/file behavior is unchanged.

## What is NOT covered

- **Stickers.** Sticker placeholders carry `pack=` and `path=` identifiers (KakaoTalk sticker pack metadata), not a downloadable URL. SKILL.md is explicit that stickers remain metadata-only.
- **Outbound attachments.** The SDK has no upload API and the adapter continues to reject outbound attachments with `ok: false`. This PR is inbound-only.
- **Auto-prefetch.** The agent must explicitly call `channel_fetch_attachment` to fetch bytes; the adapter does not pre-download every photo. Keeps the cost model predictable.

## Verification

- `bun run typecheck` ✓
- `bun run lint` ✓ (oxlint, 0 warnings, 353 files)
- `bun run format` ✓ (oxfmt, no changes after run)
- `bun test` ✓ (2606 pass, 0 fail, 155 files)
- Empirical CDN probe: `curl -I` on a real `talk.kakaocdn.net` photo URL → `200 OK`, valid PNG, no auth state needed.

## Commits

1. `Name the adapter in router.fetchAttachment race errors` — router sentinel rename, 4 files
2. `Let the agent fetch KakaoTalk inbound attachments` — feature, 6 files (2 new)