### PR TITLE
Configure git identity in release.yml so tests with tmp git repos pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,14 @@ jobs:
       - name: Format check
         run: bun run format:check
 
+      - name: Configure git identity
+        # Several tests shell out to `git commit` against tmp repos. GitHub
+        # Actions runners have no global user.name/user.email, so the commits
+        # would silently fail and leave files staged. ci.yml does the same.
+        run: |
+          git config --global user.email "ci@typeclaw.dev"
+          git config --global user.name "TypeClaw CI"
+
       - name: Test
         # Bump per-test timeout from the 5s default: a handful of runInit tests
         # shell out to a real `bun install` and run 4-5s on local hardware,


### PR DESCRIPTION
## Summary

Copy the `Configure git identity` step from `ci.yml` (lines 38–44) into `release.yml`, placed immediately before the `Test` step. One 8-line YAML block, no production code touched.

## Why

Fresh GHA runners have no global `user.name`/`user.email`. Four tests shell out to `git commit` against tmp repos and fail with "Please tell me who you are" when that identity is absent. `ci.yml` already masks this with a `Configure git identity` step; `release.yml` was a fresh copy that omitted it.

The gap was invisible before today because all prior releases (including `0.1.0`) were published manually — `release.yml` had never actually run. The first `workflow_dispatch` (for `0.1.1`) hit the `Test` step and failed: https://github.com/typeclaw/typeclaw/actions/runs/25726632202

## Failing tests (all four require a global git identity to be configured)

- `isHatched > returns true once a Hatched 🐣 commit exists`
- `commitMemorySnapshot > first run: force-adds memory artifacts, commits, and sets skip-worktree on tracked files`
- `commitMemorySnapshot > subsequent edits to tracked memory files do not appear in git status`
- `commitMemorySnapshot > captures muscle-memory skills under memory/skills/<name>/SKILL.md`

These pass locally and in `ci.yml` runs; the only difference is the missing identity step in `release.yml`.

## Followup

Re-trigger the `Release` workflow with version `0.1.1` after merge.