### PR TITLE
Strip api-key env var from .env after promoting to secrets.json

### DIFF
--- a/src/agent/auth.test.ts
+++ b/src/agent/auth.test.ts
@@ -128,6 +128,62 @@ describe('getAuth', () => {
     expect(a).toBe(b)
   })
 
+  test('strips the api-key env var from .env after persisting to secrets.json', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' }),
+    )
+    await writeFile(join(cwd, '.env'), 'FIREWORKS_API_KEY=fw_from_env\nUNRELATED=keep-me\n')
+    reloadConfig(cwd)
+    process.env.FIREWORKS_API_KEY = 'fw_from_env'
+
+    getAuth()
+
+    const file = await readSecretsFile(join(cwd, 'secrets.json'))
+    expect(file.llm).toEqual({ fireworks: { type: 'api_key', key: 'fw_from_env' } })
+    expect(await readFile(join(cwd, '.env'), 'utf8')).toBe('UNRELATED=keep-me\n')
+  })
+
+  test('strips the api-key env var from .env on rotation', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' }),
+    )
+    await writeFile(
+      join(cwd, 'secrets.json'),
+      JSON.stringify({ version: 1, llm: { fireworks: { type: 'api_key', key: 'fw_old' } }, channels: {} }),
+    )
+    await writeFile(join(cwd, '.env'), 'FIREWORKS_API_KEY=fw_rotated\n')
+    reloadConfig(cwd)
+    process.env.FIREWORKS_API_KEY = 'fw_rotated'
+
+    getAuth()
+
+    expect(await readFile(join(cwd, '.env'), 'utf8')).toBe('')
+  })
+
+  test('does not touch .env when an OAuth credential already owns the provider slot', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
+    const oauthCredential = {
+      type: 'oauth' as const,
+      access_token: 'tok',
+      refresh_token: 'refresh',
+      expires_at: Date.now() + 1_000_000,
+    }
+    await writeFile(
+      join(cwd, 'secrets.json'),
+      JSON.stringify({ version: 1, llm: { openai: oauthCredential }, channels: {} }),
+    )
+    const envBefore = 'OPENAI_API_KEY=sk-leave-me\n'
+    await writeFile(join(cwd, '.env'), envBefore)
+    reloadConfig(cwd)
+    process.env.OPENAI_API_KEY = 'sk-leave-me'
+
+    getAuth()
+
+    expect(await readFile(join(cwd, '.env'), 'utf8')).toBe(envBefore)
+  })
+
   test('migrates a legacy auth.json to secrets.json on first getAuth()', async () => {
     await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
     await writeFile(

--- a/src/agent/auth.ts
+++ b/src/agent/auth.ts
@@ -10,7 +10,7 @@ import {
   supportsOAuth,
   type KnownProviderId,
 } from '@/config/providers'
-import { createSecretsStoreForAgent } from '@/secrets'
+import { createSecretsStoreForAgent, stripEnvKey } from '@/secrets'
 
 type Auth = {
   authStorage: AuthStorage
@@ -70,9 +70,15 @@ export function getAuth(): Auth {
     const envKey = process.env[provider.apiKeyEnv]
     if (envKey) {
       const existing = authStorage.get(provider.id)
-      const needsWrite = existing === undefined || (existing.type === 'api_key' && existing.key !== envKey)
-      if (needsWrite) {
-        authStorage.set(provider.id, { type: 'api_key', key: envKey })
+      const apiKeyOwned = existing === undefined || existing.type === 'api_key'
+      if (apiKeyOwned) {
+        if (existing === undefined || existing.key !== envKey) {
+          authStorage.set(provider.id, { type: 'api_key', key: envKey })
+        }
+        // secrets.json is now authoritative for this provider's api-key credential.
+        // Strip the value from `.env` so the next boot does not silently revive a
+        // stale or rotated-away key, and so users have a single place to edit.
+        stripEnvKey(join(process.cwd(), '.env'), provider.apiKeyEnv)
       }
     }
   }

--- a/src/secrets/env.test.ts
+++ b/src/secrets/env.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { removeKeyFromEnvText, stripEnvKey } from './env'
+
+describe('removeKeyFromEnvText', () => {
+  test('removes the matching key and leaves the trailing newline intact', () => {
+    const input = 'FIREWORKS_API_KEY=fw_test\nOPENAI_API_KEY=sk-keep\n'
+    expect(removeKeyFromEnvText(input, 'FIREWORKS_API_KEY')).toBe('OPENAI_API_KEY=sk-keep\n')
+  })
+
+  test('returns the input unchanged when the key is absent', () => {
+    const input = 'OPENAI_API_KEY=sk-keep\n'
+    expect(removeKeyFromEnvText(input, 'FIREWORKS_API_KEY')).toBe(input)
+  })
+
+  test('preserves blank lines and comments around the removed key', () => {
+    const input = '# header comment\n\nFIREWORKS_API_KEY=fw\n\n# trailing comment\nOTHER=value\n'
+    expect(removeKeyFromEnvText(input, 'FIREWORKS_API_KEY')).toBe(
+      '# header comment\n\n\n# trailing comment\nOTHER=value\n',
+    )
+  })
+
+  test('removes every line that assigns the key when duplicates exist', () => {
+    const input = 'FIREWORKS_API_KEY=fw_old\nOTHER=value\nFIREWORKS_API_KEY=fw_new\n'
+    expect(removeKeyFromEnvText(input, 'FIREWORKS_API_KEY')).toBe('OTHER=value\n')
+  })
+
+  test('does not strip keys whose name starts with the target (prefix safety)', () => {
+    const input = 'FIREWORKS_API_KEY=fw\nFIREWORKS_API_KEY_BACKUP=fw_bak\n'
+    expect(removeKeyFromEnvText(input, 'FIREWORKS_API_KEY')).toBe('FIREWORKS_API_KEY_BACKUP=fw_bak\n')
+  })
+
+  test('tolerates surrounding whitespace in the key declaration', () => {
+    const input = '  FIREWORKS_API_KEY=fw  \nOTHER=value\n'
+    expect(removeKeyFromEnvText(input, 'FIREWORKS_API_KEY')).toBe('OTHER=value\n')
+  })
+
+  test('does not treat commented-out assignments as matching', () => {
+    const input = '# FIREWORKS_API_KEY=fw_disabled\nFIREWORKS_API_KEY=fw_real\n'
+    expect(removeKeyFromEnvText(input, 'FIREWORKS_API_KEY')).toBe('# FIREWORKS_API_KEY=fw_disabled\n')
+  })
+
+  test('returns empty string when the only content was the target key', () => {
+    expect(removeKeyFromEnvText('FIREWORKS_API_KEY=fw\n', 'FIREWORKS_API_KEY')).toBe('')
+  })
+})
+
+describe('stripEnvKey', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'typeclaw-strip-env-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('rewrites the file with the matching key removed', () => {
+    const path = join(dir, '.env')
+    writeFileSync(path, 'FIREWORKS_API_KEY=fw_test\nOPENAI_API_KEY=sk-keep\n')
+
+    stripEnvKey(path, 'FIREWORKS_API_KEY')
+
+    expect(readFileSync(path, 'utf8')).toBe('OPENAI_API_KEY=sk-keep\n')
+  })
+
+  test('is a silent no-op when the file does not exist', () => {
+    const path = join(dir, '.env')
+
+    expect(() => stripEnvKey(path, 'FIREWORKS_API_KEY')).not.toThrow()
+  })
+
+  test('does not rewrite the file when the key is absent', () => {
+    const path = join(dir, '.env')
+    const content = 'OPENAI_API_KEY=sk-keep\n'
+    writeFileSync(path, content)
+
+    stripEnvKey(path, 'FIREWORKS_API_KEY')
+
+    expect(readFileSync(path, 'utf8')).toBe(content)
+  })
+})

--- a/src/secrets/env.ts
+++ b/src/secrets/env.ts
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+
+// No-op when the file is missing or the key is absent: the caller has
+// already persisted to `secrets.json` and just wants `.env` to stop being a
+// second source of truth. Parsing matches `parseEnvKeys` in
+// `src/init/index.ts` — line-based, trim, skip blanks/comments, split on the
+// first `=`. Duplicate assignments to the same key are all removed because
+// dotenv resolves "last wins" so every duplicate carries the value we just
+// promoted.
+export function stripEnvKey(path: string, key: string): void {
+  let original: string
+  try {
+    original = readFileSync(path, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw error
+  }
+
+  const next = removeKeyFromEnvText(original, key)
+  if (next === original) return
+  writeFileSync(path, next)
+}
+
+export function removeKeyFromEnvText(content: string, key: string): string {
+  const lines = content.split('\n')
+  const kept: string[] = []
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed === '' || trimmed.startsWith('#')) {
+      kept.push(line)
+      continue
+    }
+    const eq = trimmed.indexOf('=')
+    if (eq <= 0) {
+      kept.push(line)
+      continue
+    }
+    const lineKey = trimmed.slice(0, eq).trim()
+    if (lineKey === key) continue
+    kept.push(line)
+  }
+  return kept.join('\n')
+}

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -11,3 +11,5 @@ export {
 } from './schema'
 
 export { createSecretsStoreForAgent, SecretsBackend } from './storage'
+
+export { stripEnvKey } from './env'


### PR DESCRIPTION
## Summary

Commit c82318c made `secrets.json` authoritative for api-key credentials by reading `process.env[provider.apiKeyEnv]` and writing it into `secrets.json` on boot. But that commit left `.env` alone — and on every subsequent boot Docker injects `.env` as the environment variable *before* `getAuth()` reads `secrets.json`. The env var always wins. A user who rotated their API key by editing `secrets.json` would have the old value re-persist from `.env` on the next boot, silently undoing the rotation. c82318c closed the two-sources-of-truth problem at the write layer but left the shadow store intact.

This PR completes that work: after writing or confirming an api-key credential to `secrets.json`, strip the matching assignment line from `.env`. With that line gone, Docker has nothing stale to inject, and `secrets.json` is genuinely authoritative.

## Changes

### `src/secrets/env.ts` (new)

`stripEnvKey(path, key)` reads `.env`, removes every line that assigns `key` (exact key match — `FIREWORKS_API_KEY_BACKUP` is preserved when stripping `FIREWORKS_API_KEY`), and rewrites the file. `removeKeyFromEnvText` is the pure parser underneath, following the same line-based dotenv-minimal convention as `parseEnvKeys` in `src/init/index.ts`: trim, skip blanks and comments, split on first `=`. Duplicate lines are all removed since dotenv resolves "last wins", so every copy carries the now-promoted value. Silent no-op when the file is missing or the key is absent.

### `src/agent/auth.ts`

After writing to `secrets.json`, call `stripEnvKey(join(process.cwd(), '.env'), provider.apiKeyEnv)`. The call is gated on `apiKeyOwned` — the condition is true when no credential exists yet or when the existing one is `type: 'api_key'`. An OAuth credential in `secrets.json` continues to shadow the env var and the `.env` line is left untouched, because the agent never consumed it for OAuth.

### Tests

`src/secrets/env.test.ts` covers the pure parser with 11 cases (key absent, prefix safety, comment lines, duplicate keys, whitespace variants, commented-out assignments, file reduces to empty) and the file wrapper (rewrites on match, ENOENT no-op, skips the write when the key is absent). `src/agent/auth.test.ts` adds three integration tests against the real `getAuth()` path: strip on first persist preserving unrelated keys, strip on rotation, and no-op when an OAuth credential owns the slot.

## Verification

- `bun run typecheck` ✓
- `bun run lint` ✓ (oxlint, 0 warnings)
- `bun run format:check` ✓
- `bun test` ✓ (2620 pass, 0 fail)