### PR TITLE
Stop dropping KakaoTalk pushes from chats getChats omits

### DIFF
--- a/src/channels/adapters/kakaotalk-channel-resolver.test.ts
+++ b/src/channels/adapters/kakaotalk-channel-resolver.test.ts
@@ -115,6 +115,65 @@ describe('createKakaoChannelResolver', () => {
   })
 })
 
+describe('createKakaoChannelResolver — ingestProvisional', () => {
+  test('registers an unknown chat under the strictest bucket (@kakao-group)', () => {
+    const resolver = createKakaoChannelResolver({ client: fakeClient([]) })
+    expect(resolver.lookupChat('468625891988320')).toBeNull()
+
+    resolver.ingestProvisional('468625891988320')
+
+    expect(resolver.lookupChat('468625891988320')).toEqual({ workspace: '@kakao-group', isDm: false })
+  })
+
+  test('is a no-op when a real cache entry already exists', async () => {
+    const resolver = createKakaoChannelResolver({
+      client: fakeClient([dmChat('111', 'Alice')]),
+    })
+    await resolver.refresh()
+    expect(resolver.lookupChat('111')).toEqual({ workspace: '@kakao-dm', isDm: true })
+
+    // ingestProvisional must NOT overwrite the authoritative DM classification
+    // with the provisional @kakao-group fallback — otherwise a flap in
+    // getChats availability could downgrade a known DM to group bucket and
+    // silently change allow-rule semantics.
+    resolver.ingestProvisional('111')
+
+    expect(resolver.lookupChat('111')).toEqual({ workspace: '@kakao-dm', isDm: true })
+  })
+
+  test('subsequent refresh upgrades a provisional entry to its real kind', async () => {
+    let chats: KakaoChat[] = []
+    const resolver = createKakaoChannelResolver({
+      client: { getChats: async () => chats },
+    })
+
+    // Simulates the production failure mode: getChats({all:true}) initially
+    // does not return chat 468625891988320, but a push event from it arrives.
+    resolver.ingestProvisional('468625891988320')
+    expect(resolver.lookupChat('468625891988320')).toEqual({ workspace: '@kakao-group', isDm: false })
+
+    // Later, getChats catches up and starts returning it as a DM.
+    chats = [dmChat('468625891988320', 'Alice')]
+    await resolver.refresh()
+
+    expect(resolver.lookupChat('468625891988320')).toEqual({ workspace: '@kakao-dm', isDm: true })
+  })
+
+  test('respects TTL so provisional entries do not live forever', async () => {
+    let now = 1000
+    const resolver = createKakaoChannelResolver({
+      client: fakeClient([]),
+      now: () => now,
+      ttlMs: 100,
+    })
+    resolver.ingestProvisional('111')
+    expect(resolver.lookupChat('111')).toEqual({ workspace: '@kakao-group', isDm: false })
+
+    now += 200
+    expect(resolver.lookupChat('111')).toBeNull()
+  })
+})
+
 describe('kakaoWorkspaceForType', () => {
   test('maps each KakaoChatKind to its workspace label', () => {
     expect(kakaoWorkspaceForType('dm')).toBe('@kakao-dm')

--- a/src/channels/adapters/kakaotalk-channel-resolver.ts
+++ b/src/channels/adapters/kakaotalk-channel-resolver.ts
@@ -21,6 +21,14 @@ export type KakaoChannelResolver = {
   resolve: ChannelNameResolver
   lookupChat: (chatId: string) => KakaoChatLookupValue | null
   refresh: () => Promise<void>
+  // Register a chat we learned about from an inbound push event, used as a
+  // fallback when `refresh()` did not surface it (e.g. memo chats, certain
+  // open chats, or chats whose membership has not yet propagated to
+  // getChats({all:true})). Provisional entries default to @kakao-group —
+  // the strictest bucket, matching the history callback's existing fallback
+  // — so allow-rule enforcement stays strict. A subsequent real refresh
+  // upgrades the entry to its authoritative kind.
+  ingestProvisional: (chatId: string) => void
 }
 
 export type KakaoChannelResolverOptions = {
@@ -97,7 +105,18 @@ export function createKakaoChannelResolver(options: KakaoChannelResolverOptions)
     return { workspace: entry.workspace, isDm: entry.isDm }
   }
 
-  return { resolve, lookupChat, refresh }
+  const ingestProvisional = (chatId: string): void => {
+    const existing = cache.get(chatId)
+    if (existing !== undefined && existing.expiresAt > now()) return
+    cache.set(chatId, {
+      workspace: '@kakao-group',
+      isDm: false,
+      chatName: null,
+      expiresAt: now() + ttlMs,
+    })
+  }
+
+  return { resolve, lookupChat, refresh, ingestProvisional }
 }
 
 function describe(err: unknown): string {

--- a/src/channels/adapters/kakaotalk.test.ts
+++ b/src/channels/adapters/kakaotalk.test.ts
@@ -996,6 +996,51 @@ describe('createKakaotalkAdapter — inbound classification', () => {
     await adapter.stop()
     await router.stop()
   })
+
+  test('routes a message from a chat that getChats omits under @kakao-group instead of dropping unknown_chat', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const logs: string[] = []
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+      logger: {
+        info: (m) => logs.push(m),
+        warn: (m) => logs.push(m),
+        error: (m) => logs.push(m),
+      },
+    })
+    client.chats = []
+    await adapter.start()
+    listener.emit('connected', { userId: '999' })
+
+    listener.emit('message', {
+      type: 'MSG',
+      chat_id: '468625891988320',
+      log_id: 'L3838',
+      author_id: 24228244,
+      author_name: 'Alice',
+      message: 'hi',
+      message_type: 1,
+      attachment: null,
+      sent_at: 1_730_000_000_000,
+    })
+    await new Promise((r) => setTimeout(r, 10))
+
+    const dropped = logs.find((m) => m.includes('reason=unknown_chat'))
+    expect(dropped).toBeUndefined()
+    const routed = logs.find((m) => m.includes('routed log_id=L3838'))
+    expect(routed).toBeDefined()
+    expect(routed).toContain('bucket=@kakao-group')
+    const provisional = logs.find((m) => m.includes('provisional chat=468625891988320'))
+    expect(provisional).toBeDefined()
+
+    await adapter.stop()
+    await router.stop()
+  })
 })
 
 describe('createKakaotalkAdapter — mark read on every inbound', () => {

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -342,6 +342,19 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
     try {
       if (channelResolver.lookupChat(event.chat_id) === null) {
         await channelResolver.refresh()
+        if (channelResolver.lookupChat(event.chat_id) === null) {
+          // The push event itself proves the chat exists, even when
+          // getChats({all:true}) does not surface it (e.g. memo chats,
+          // certain open chats, recently-joined groups that haven't
+          // propagated). Register a provisional @kakao-group entry so the
+          // strictest allow rules still apply, but the message is no longer
+          // silently dropped as unknown_chat. The next real refresh
+          // upgrades the entry if the chat is actually a DM or open chat.
+          channelResolver.ingestProvisional(event.chat_id)
+          logger.warn(
+            `[kakaotalk] provisional chat=${event.chat_id} log_id=${event.log_id} bucket=@kakao-group reason=not_in_getchats`,
+          )
+        }
       }
 
       const inboundTag = await formatChannelTag(
@@ -643,7 +656,7 @@ function dropHint(
     case 'not_in_allow_list':
       return ` (add ${suggestedAllowPattern(bucket, chatId)} to channels.kakaotalk.allow to admit this chat)`
     case 'unknown_chat':
-      return ' (chat not in cache; resolver refresh may be lagging)'
+      return ' (chat not in cache after refresh and provisional registration; check earlier resolver-refresh-failed warnings)'
     case 'empty_text':
     case 'pre_connect':
     case 'self_author':


### PR DESCRIPTION
## Summary

- Inbound KakaoTalk push events from a chat that `getChats({ all: true })` does not surface were silently dropped as `unknown_chat`, even after the resolver refreshed. Production log of the bug:

  ```
  [kakaotalk] inbound log_id=3838994471641675777 author=24228244 bucket=@kakao-group chat=468625891988320 type=1 text_len=3
  [kakaotalk] dropped log_id=3838994471641675777 reason=unknown_chat (chat not in cache; resolver refresh may be lagging)
  ```

  The drop hint (`resolver refresh may be lagging`) was a guess. The actual situation is that the resolver had already refreshed and `getChats` still didn't return chat `468625891988320` — so a chat the user was actively receiving from was invisible to the resolver forever.

- The fix: when refresh still doesn't know the chat, register a **provisional** `@kakao-group` entry from the push event itself, so the message routes instead of dropping. The next real refresh upgrades the entry to its authoritative kind (DM/open) once `getChats` catches up.

## Why this is the right fix

The resolver only ever learns chats through one bulk call: `getChats({ all: true })`. Some categories of chat are demonstrably omitted from that call (memo / "me" chats, certain open chats, recently-joined groups whose membership hasn't propagated). For those chats, every inbound is forever `unknown_chat` no matter how many refreshes we run.

A push event is itself proof the chat exists. Using the event to seed the cache breaks the dependency on `getChats` being complete. Two design choices keep this safe:

1. **Provisional entries default to `@kakao-group`**, the strictest bucket. This matches the existing fallback the history callback already uses (`kakaotalk.ts` `createKakaoHistoryCallback`, line 224) when the resolver can't classify a chat. Allow-rule enforcement stays strict: a DM allowed only via `kakao:dm/*` will still be filtered out on first contact, not promoted to permissive bucketing.

2. **`ingestProvisional` is a no-op when a live entry exists.** A flap in `getChats` availability cannot downgrade a known `@kakao-dm` to `@kakao-group` and silently change allow-rule semantics. Only stale/missing entries get the provisional treatment.

## Tradeoff (documented, not addressed)

If the user is in a DM that `getChats` consistently omits, the first inbound is bucketed under `@kakao-group`. With `allow: ['kakao:dm/*']`, that first message gets dropped as `not_in_allow_list` instead of `unknown_chat`. Subsequent messages route correctly once `getChats` catches up. Strict-by-default beats permissive-by-default for allow rules — flipping that default would surprise users in the other direction.

The root cause (agent-messenger's `getChats({ all: true })` not actually returning all chats, and the lack of a public singular `getChatInfo` on `KakaoTalkClient`) is upstream and out of scope for typeclaw.

## Drop-hint correction

The `unknown_chat` hint used to read `(chat not in cache; resolver refresh may be lagging)`. By the time we emit `unknown_chat` now, we have already refreshed AND provisionally registered the chat, so "lag" is no longer plausible. New hint points at the real failure: an earlier `[kakaotalk] channel resolver refresh failed: ...` warn that swallowed the actual error.

## Tests

Four new resolver-level tests + one adapter-level integration test. The adapter test reproduces the exact production log line (chat `468625891988320`, log `L3838`, the same shape).

**Mutation check** (per `AGENTS.md` §5.1): commenting out the new `channelResolver.ingestProvisional(event.chat_id)` line causes the adapter test to fail with exactly the production-bug log:

```
Received: "[kakaotalk] dropped log_id=L3838 reason=unknown_chat ..."
```

So the test guards the production line, not a coincidence of internals.

## What is NOT changed

- **No new agent-messenger version.** This is a typeclaw-only fix. We can't target-fetch a single chat without `KakaoTalkClient` exposing `getChatInfo`, and that's a separate upstream issue.
- **No `getChats` retry / backoff change.** If `getChats` is rate-limited or fails, the existing warn-and-swallow behavior is unchanged. The provisional registration still kicks in and the new drop hint points the operator at the warn.
- **No new resolver TTL knob.** Provisional entries respect the same TTL as authoritative ones (5 minutes default), so they don't live forever if `getChats` permanently disowns a chat.

## Verification

- `bun run typecheck` ✓
- `bun run lint` ✓ (oxlint, 0 warnings, 355 files)
- `bun run format` ✓ (oxfmt, no changes after run)
- `bun test` ✓ (2625 pass, 0 fail, 156 files)
- Mutation check ✓ (commented-out `ingestProvisional` → new test reproduces production drop log; restored → test passes)

## Files

- `src/channels/adapters/kakaotalk-channel-resolver.ts` — `ingestProvisional` on the public type + implementation
- `src/channels/adapters/kakaotalk-channel-resolver.test.ts` — 4 new tests
- `src/channels/adapters/kakaotalk.ts` — wire `ingestProvisional` into `processInbound` after refresh-and-still-unknown; correct the `unknown_chat` drop hint
- `src/channels/adapters/kakaotalk.test.ts` — 1 new test reproducing the production log line