### PR TITLE
Raise bun test timeout to 60s so runInit tests survive npm-fetch spikes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
 
       - name: Test
         # Bump per-test timeout from the 5s default: a handful of runInit tests
-        # shell out to a real `bun install` and run 4-5s on local hardware,
-        # which crosses 5s on the slower GitHub Actions runners.
-        run: bun test --timeout 30000
+        # shell out to a real `bun install` against a freshly-scaffolded agent
+        # folder with no lockfile, so each test pays full dependency resolution
+        # cost over the network. Locally that's 2-4s; on GHA runners it's
+        # usually 3-5s but spikes past 30s when the runner's network path to
+        # npm is congested (observed in run 25727348353). 60s leaves enough
+        # headroom for those spikes without hiding genuinely-stuck tests.
+        run: bun test --timeout 60000

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,9 @@ jobs:
           git config --global user.name "TypeClaw CI"
 
       - name: Test
-        # Bump per-test timeout from the 5s default: a handful of runInit tests
-        # shell out to a real `bun install` and run 4-5s on local hardware,
-        # which crosses 5s on the slower GitHub Actions runners.
-        run: bun test --timeout 30000
+        # See ci.yml for the rationale on the 60000ms timeout — same network-
+        # bound `runInit` tests; keep both workflows in sync.
+        run: bun test --timeout 60000
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

14 `runInit` tests in `src/init/index.test.ts` started timing out at exactly 30 000 ms on commit `a71fdaed`, the merge of PR #137. The diff between the last passing commit (`a160c151`) and `a71fdaed` is only `.github/workflows/release.yml` — a file CI never reads — so PR #137 is not the cause.

Investigation: same `ubuntu-24.04` runner image, same runner version, same `bun.lock`. The top-level `bun install` step finished in 4.85 s (vs 3.35 s on the prior passing run, ~45% slower), signalling a momentarily degraded network path to npm. The `runInit` tests scaffold a fresh agent folder with `typeclaw: file:../typeclaw` + `agent-browser: ^0.26.0` and then call `bun install` against it with no lockfile — so each test pays full dependency-resolution cost over the network. When the npm path slows down, 30 s is too tight a margin.

The fix raises `bun test --timeout` from 30 000 to 60 000 in both `ci.yml` and `release.yml`, and sharpens the inline comment from the vague "slower on GHA runners" phrasing to name the actual failure mode. 60 s leaves enough headroom for npm-fetch spikes while still catching genuinely-stuck tests.

Failing run: https://github.com/typeclaw/typeclaw/actions/runs/25727348353