### PR TITLE
Stub bun install in runInit pipeline tests to dodge Bun 1.3 linker deadlock

### DIFF
--- a/src/init/ensure-deps.ts
+++ b/src/init/ensure-deps.ts
@@ -2,7 +2,7 @@ import { existsSync, realpathSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { dirname, join, parse as parsePath } from 'node:path'
 
-import { runBunInstall } from './run-bun-install'
+import { type InstallRunner, runBunInstall } from './run-bun-install'
 
 const PACKAGE_FILE = 'package.json'
 const NODE_MODULES = 'node_modules'
@@ -13,7 +13,7 @@ export type EnsureDepsResult =
 
 export type EnsureDepsOptions = {
   cwd: string
-  install?: (cwd: string) => Promise<{ ok: true } | { ok: false; reason: string }>
+  install?: InstallRunner
   detect?: (cwd: string) => Promise<readonly string[]>
 }
 

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -18,6 +18,7 @@ import {
   type HatchRunner,
   initGitRepo,
   type InitStepEvent,
+  type InstallRunner,
   isDirectoryNonEmpty,
   isHatched,
   isInitialized,
@@ -42,6 +43,16 @@ const okHatch: HatchRunner = async () => ({ ok: true }) as HatchingResult
 // is reachable. Tests that exercise the preflight failure path override this
 // with their own DockerExec to simulate ENOENT or daemon-down conditions.
 const okDocker: DockerExec = async () => ({ exitCode: 0, stdout: '29.4.0\n', stderr: '' })
+
+// Default install stub for tests: pretends `bun install` succeeded without
+// shelling out. The real installer fans 500+ HTTP requests at npm with no
+// lockfile, which both wastes ~5s per test and exposes us to the Bun 1.3.x
+// isolated-linker fetch deadlock (oven-sh/bun#26341). The runInit pipeline
+// tests verify composition — step ordering, event emission, failure
+// propagation — not the install primitive itself, so we never need a real
+// install here. Tests that exercise the failure path override this with their
+// own InstallRunner.
+const okInstall: InstallRunner = async () => ({ ok: true })
 
 function captureHatch(): { runner: HatchRunner; calls: Array<{ cwd: string; port: number }> } {
   const calls: Array<{ cwd: string; port: number }> = []
@@ -71,6 +82,7 @@ describe('runInit', () => {
       cwd: root,
       apiKey: 'fw_test_key',
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
     })
@@ -101,7 +113,7 @@ describe('runInit', () => {
       return { ok: true }
     }
 
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching, dockerExec: okDocker })
+    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching, runBunInstall: okInstall, dockerExec: okDocker })
 
     expect(seenAt).toEqual([{ hasGit: true, hasDockerfile: true }])
   })
@@ -109,7 +121,13 @@ describe('runInit', () => {
   test('hatching receives the init cwd and the configured port', async () => {
     const { runner, calls } = captureHatch()
 
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: runner, dockerExec: okDocker })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: runner,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+    })
 
     expect(calls).toHaveLength(1)
     expect(calls[0]?.cwd).toBe(root)
@@ -124,6 +142,7 @@ describe('runInit', () => {
       cwd: root,
       apiKey: 'fw_test_key',
       runHatching,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
     })
@@ -141,6 +160,7 @@ describe('runInit', () => {
       apiKey: 'fw_integration_key',
       model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
     })
 
@@ -152,7 +172,13 @@ describe('runInit', () => {
   })
 
   test('git step sees scaffolded files (step ordering)', async () => {
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch, dockerExec: okDocker })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+    })
 
     const tracked = (await runGit(root, ['ls-files'])).split('\n')
     expect(tracked).toContain('typeclaw.json')
@@ -176,6 +202,7 @@ describe('runInit', () => {
       cwd: root,
       apiKey: 'fw_test_key',
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
     })
@@ -194,6 +221,7 @@ describe('runInit', () => {
       cwd: root,
       apiKey: 'fw_test_key',
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
       onProgress: () => {},
     })
@@ -209,6 +237,7 @@ describe('runInit', () => {
       cwd: root,
       apiKey: 'fw_test_key',
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
     })
@@ -228,6 +257,7 @@ describe('runInit', () => {
       cwd: root,
       apiKey: 'fw_test_key',
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
     })
@@ -250,6 +280,7 @@ describe('runInit', () => {
       cwd: root,
       apiKey: 'fw_test_key',
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
     })
@@ -269,7 +300,13 @@ describe('runInit', () => {
   })
 
   test('works without onProgress callback', async () => {
-    await runInit({ cwd: root, apiKey: 'fw_test_key', runHatching: okHatch, dockerExec: okDocker })
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+    })
 
     expect(isInitialized(root)).toBe(true)
   })
@@ -282,6 +319,7 @@ describe('runInit', () => {
       apiKey: 'fw_first_key',
       model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
       runHatching: failingHatch,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
     })
     expect(isInitialized(root)).toBe(true)
@@ -294,6 +332,7 @@ describe('runInit', () => {
       apiKey: 'fw_second_key',
       model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
     })
@@ -336,6 +375,7 @@ describe('runInit', () => {
       cwd: root,
       apiKey: 'fw_test_key',
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: missingDocker,
       onProgress: (e) => events.push(e),
     })
@@ -377,6 +417,7 @@ describe('runInit', () => {
       cwd: root,
       apiKey: 'fw_test_key',
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: daemonDown,
       onProgress: (e) => events.push(e),
     })
@@ -410,6 +451,7 @@ describe('runInit', () => {
       cwd: root,
       apiKey: 'fw_test_key',
       runHatching: trackingHatch,
+      runBunInstall: okInstall,
       dockerExec: missingDocker,
     })
 
@@ -430,6 +472,7 @@ describe('runInit', () => {
       model: 'openai-codex/gpt-5.5',
       llmAuth: { kind: 'oauth', runLogin: fakeLogin },
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
     })
@@ -464,6 +507,7 @@ describe('runInit', () => {
         model: 'openai-codex/gpt-5.5',
         llmAuth: { kind: 'oauth', runLogin: fakeLogin },
         runHatching: okHatch,
+        runBunInstall: okInstall,
         dockerExec: okDocker,
       }),
     ).rejects.toThrow(/OAuth login failed: browser closed/)
@@ -480,6 +524,7 @@ describe('runInit', () => {
       cwd: root,
       apiKey: 'fw_test_key',
       runHatching: okHatch,
+      runBunInstall: okInstall,
       dockerExec: okDocker,
       onProgress: (e) => events.push(e),
     })
@@ -488,9 +533,9 @@ describe('runInit', () => {
   })
 
   test('throws when neither apiKey nor llmAuth is provided', async () => {
-    await expect(runInit({ cwd: root, runHatching: okHatch, dockerExec: okDocker })).rejects.toThrow(
-      /requires either `llmAuth` or `apiKey`/,
-    )
+    await expect(
+      runInit({ cwd: root, runHatching: okHatch, runBunInstall: okInstall, dockerExec: okDocker }),
+    ).rejects.toThrow(/requires either `llmAuth` or `apiKey`/)
   })
 })
 

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -13,9 +13,9 @@ import { buildGitignore, GITIGNORE_FILE } from './gitignore'
 import { HATCHING_PROMPT } from './hatching'
 import type { OAuthLoginRunner, OAuthLoginResult } from './oauth-login'
 import { GITKEEP_FILE, PACKAGES_DIR } from './paths'
-import { runBunInstall, type InstallResult } from './run-bun-install'
+import { type InstallResult, type InstallRunner, runBunInstall } from './run-bun-install'
 
-export { runBunInstall, type InstallResult } from './run-bun-install'
+export { type InstallResult, type InstallRunner, runBunInstall } from './run-bun-install'
 
 export { GITKEEP_FILE, PACKAGES_DIR } from './paths'
 
@@ -101,6 +101,7 @@ export type InitOptions = {
   runKakaotalkAuth?: KakaotalkAuthRunner
   onProgress?: (event: InitStepEvent) => void
   runHatching?: HatchRunner
+  runBunInstall?: InstallRunner
   dockerExec?: DockerExec
 }
 
@@ -121,6 +122,7 @@ export async function runInit({
   runKakaotalkAuth,
   onProgress,
   runHatching = defaultRunHatching,
+  runBunInstall: installRunner = runBunInstall,
   dockerExec,
 }: InitOptions): Promise<void> {
   const emit = onProgress ?? (() => {})
@@ -202,7 +204,7 @@ export async function runInit({
   }
 
   emit({ step: 'install', phase: 'start' })
-  const install = await runBunInstall(cwd)
+  const install = await installRunner(cwd)
   emit({ step: 'install', phase: 'done', result: install })
 
   emit({ step: 'dockerfile', phase: 'start' })

--- a/src/init/run-bun-install.ts
+++ b/src/init/run-bun-install.ts
@@ -1,11 +1,27 @@
 export type InstallResult = { ok: true } | { ok: false; reason: string }
 
+// Signature for the function `runInit` uses to materialize the agent folder's
+// dependencies. Exposed as a named type so callers (and tests) can pass their
+// own stub without re-declaring the shape, mirroring `HatchRunner` and
+// `KakaotalkAuthRunner` in `./index.ts`.
+export type InstallRunner = (cwd: string) => Promise<InstallResult>
+
 export async function runBunInstall(cwd: string): Promise<InstallResult> {
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) return { ok: false, reason: 'bun runtime not available' }
   try {
     const proc = bun.spawn({
-      cmd: ['bun', 'install'],
+      // `--linker=hoisted` sidesteps a deadlock in Bun 1.3.x's isolated linker
+      // (the default since 1.3.0). When any single package fetch fails — 401,
+      // SHA-512 mismatch, transient registry 5xx, the kind of flake that's
+      // routine on GitHub Actions shared-IP runners — the isolated linker
+      // hangs the process indefinitely instead of erroring out
+      // (oven-sh/bun#26341, oven-sh/bun#29646). `bun install` runs here over
+      // ~500 transitive packages with no lockfile, so the odds of triggering
+      // the bug are non-trivial. Hoisted is the fallback strategy bun shipped
+      // before 1.3 — slightly slower for huge monorepos, indistinguishable
+      // for an agent folder, and not affected by the bug.
+      cmd: ['bun', 'install', '--linker=hoisted'],
       cwd,
       stdout: 'pipe',
       stderr: 'pipe',


### PR DESCRIPTION
## Summary

The `runInit` tests in `src/init/index.test.ts` started timing out on every CI run starting with commit `a71fdae`. PR #140 attributed the failures to npm-fetch spikes and bumped the timeout from 30s to 60s. The symptom returned immediately at exactly 60s — each of the 14 tests consuming the full ceiling before being killed with \"killed 1 dangling process\". That's a deadlock signature, not a slowness one.

This PR fixes the actual root cause and replaces #140's bandaid with a proper fix.

## Root Cause

Bun 1.3.x's isolated linker (the default since 1.3.0) has a known deadlock bug tracked at [oven-sh/bun#26341](https://github.com/oven-sh/bun/issues/26341) and [oven-sh/bun#29646](https://github.com/oven-sh/bun/issues/29646): when any single package fetch fails — 401, SHA-512 mismatch, transient registry 5xx — the linker hangs the process indefinitely instead of exiting with a non-zero code. GitHub Actions shared-IP runners hit routine npm registry flake under load. The `runInit` tests scaffold a fresh tmpdir with no lockfile and fan ~500 transitive package fetches at npm on every test run, making the odds of triggering the bug non-trivial under CI load.

PR #140's timeout comparison was invalid: the top-level `bun install --frozen-lockfile` step in the same CI run uses the repo's pinned `bun.lock` and short-circuits resolution entirely. Comparing its 3–5s wall time to a fresh-tmpdir install with no lockfile tells you nothing about network spikes.

Locally the same tests passed in under 300ms because the bun cache (`~/.bun/install/cache`) was warm and no fetch hit the network — masking the bug entirely during development.

## Changes

### 1. `runBunInstall` is now injectable on `InitOptions`

The `runInit` pipeline tests already verify _composition_ — step ordering, event emission, and failure propagation between steps — not the install primitive itself. There's no reason for them to fan 500 HTTP requests at npm just to assert that the `install:start` event fires before `install:done`.

`runBunInstall` is now injectable via `InitOptions.runBunInstall`, mirroring the existing `runHatching` / `runKakaotalkAuth` / `dockerExec` injection pattern the rest of the pipeline already uses. Every test call site now injects an `okInstall: InstallRunner = async () => ({ ok: true })` stub alongside the existing `okHatch` and `okDocker` stubs.

### 2. The real `runBunInstall` now passes `--linker=hoisted`

Even after stubbing tests, real `typeclaw init` still fans ~500 fetches at npm on user machines with potentially flaky networks. Hoisted is the pre-1.3 default linker — slightly slower for large monorepos, indistinguishable for an agent folder, and not affected by the isolated-linker deadlock bug. Comments in `run-bun-install.ts` cite both upstream issue numbers so future maintainers can verify whether the bug has been fixed upstream before considering reverting the flag.

### 3. `InstallRunner` type is now exported from `run-bun-install.ts`

`ensure-deps.ts` previously had an inline duplicate of the same function signature. The shared export eliminates the duplication.

## Why #140 Is the Wrong Fix

- **Timeout bump doesn't fix the hang.** The process is deadlocked. With a 30s ceiling every test burns 30s; with a 60s ceiling every test burns 60s. The only difference is how much CI time gets wasted before the suite is declared failed.
- **The slowness evidence was comparing incomparable operations.** A frozen-lockfile install that hits local cache vs. a cold install that resolves 500 packages from scratch against npm.
- **It left the two real problems untouched**: (a) the test suite performing real network operations it doesn't need to, and (b) real user installs still hanging against the isolated linker on flaky networks.

## Verification

- `bun run typecheck` — ✅
- `bun run lint` — ✅ (0 warnings, 0 errors)
- `bun run format:check` — ✅
- `bun test src/init/index.test.ts` — **91/91 pass in 1.2s** (before: 14 tests × 60s timeout = 14 minutes of CI burn before failure)
- `bun test` — **2620/2620 pass in 28.95s**, no regressions

## Failing CI runs

- First failure (30s timeout): https://github.com/typeclaw/typeclaw/actions/runs/25727348353
- PR #140 failure (60s timeout, same deadlock): https://github.com/typeclaw/typeclaw/actions/runs/25729377610

Closes #140