### PR TITLE
Block agent-browser from navigating to LAN, loopback, and cloud-metadata hosts

### DIFF
--- a/src/bundled-plugins/security/index.test.ts
+++ b/src/bundled-plugins/security/index.test.ts
@@ -81,6 +81,35 @@ describe('security plugin wiring', () => {
     expect(result).toBeUndefined()
   })
 
+  test('tool.before blocks the home-router agent-browser scenario', async () => {
+    const hook = await toolBeforeHook()
+    const result = await hook(
+      toolEvent('bash', { command: 'agent-browser navigate http://192.168.0.1' }),
+      hookContext('/agent'),
+    )
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('agentBrowserSsrf')
+  })
+
+  test('tool.before blocks agent-browser invoked via bunx with a bare LAN IP', async () => {
+    const hook = await toolBeforeHook()
+    const result = await hook(
+      toolEvent('bash', { command: 'bunx agent-browser navigate 10.0.0.1' }),
+      hookContext('/agent'),
+    )
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('agentBrowserSsrf')
+  })
+
+  test('tool.before allows agent-browser navigation to a public site', async () => {
+    const hook = await toolBeforeHook()
+    const result = await hook(
+      toolEvent('bash', { command: 'agent-browser navigate https://example.com/login' }),
+      hookContext('/agent'),
+    )
+    expect(result).toBeUndefined()
+  })
+
   test('tool.before blocks channel_send carrying GitHub PAT', async () => {
     const hook = await toolBeforeHook()
     const fixture = 'gh' + 'p' + '_' + 'X'.repeat(36)
@@ -199,6 +228,15 @@ describe('security plugin wiring', () => {
     expect(
       await hook(
         toolEvent('webfetch', { url: 'http://127.0.0.1/dev', acknowledgeGuards: { ssrf: true } }),
+        hookContext('/agent'),
+      ),
+    ).toBeUndefined()
+    expect(
+      await hook(
+        toolEvent('bash', {
+          command: 'agent-browser navigate http://192.168.0.1',
+          acknowledgeGuards: { agentBrowserSsrf: true },
+        }),
         hookContext('/agent'),
       ),
     ).toBeUndefined()

--- a/src/bundled-plugins/security/index.ts
+++ b/src/bundled-plugins/security/index.ts
@@ -1,5 +1,6 @@
 import { definePlugin } from '@/plugin'
 
+import { checkAgentBrowserSsrfGuard } from './policies/agent-browser-ssrf'
 import { checkGitExfilGuard } from './policies/git-exfil'
 import { checkOutboundSecretGuard } from './policies/outbound-secret-scan'
 import { applyPromptInjectionDefense } from './policies/prompt-injection'
@@ -22,6 +23,7 @@ export default definePlugin({
           checkGitExfilGuard({ tool: event.tool, args: event.args, sessionId: event.sessionId }),
           checkSecretExfilReadGuard({ tool: event.tool, args: event.args }),
           checkSsrfGuard({ tool: event.tool, args: event.args }),
+          checkAgentBrowserSsrfGuard({ tool: event.tool, args: event.args }),
           checkSessionSearchSecretsGuard({ tool: event.tool, args: event.args }),
           checkSystemPromptLeakGuard({ tool: event.tool, args: event.args }),
           checkOutboundSecretGuard({ tool: event.tool, args: event.args }),

--- a/src/bundled-plugins/security/policies/agent-browser-ssrf.test.ts
+++ b/src/bundled-plugins/security/policies/agent-browser-ssrf.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'bun:test'
+
+import { GUARD_AGENT_BROWSER_SSRF, checkAgentBrowserSsrfGuard } from './agent-browser-ssrf'
+
+function check(command: string, extra: Record<string, unknown> = {}) {
+  return checkAgentBrowserSsrfGuard({ tool: 'bash', args: { command, ...extra } })
+}
+
+describe('agent-browser SSRF guard', () => {
+  test('blocks the canonical home-router scenario (192.168.x.x)', () => {
+    const result = check('agent-browser navigate http://192.168.0.1')
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('private_ipv4')
+    expect(result?.reason).toContain(GUARD_AGENT_BROWSER_SSRF)
+  })
+
+  test('blocks bare-IP navigation without an http:// scheme', () => {
+    expect(check('agent-browser navigate 192.168.0.1')?.block).toBe(true)
+    expect(check('agent-browser navigate 10.0.0.1:8080/admin')?.block).toBe(true)
+  })
+
+  test('blocks loopback in every encoding the SSRF classifier knows', () => {
+    expect(check('agent-browser navigate http://127.0.0.1/')?.block).toBe(true)
+    expect(check('agent-browser navigate http://localhost/')?.block).toBe(true)
+    expect(check('agent-browser navigate http://2130706433/')?.block).toBe(true)
+    expect(check('agent-browser navigate http://0x7f000001/')?.block).toBe(true)
+    expect(check('agent-browser navigate http://[::1]/')?.block).toBe(true)
+  })
+
+  test('blocks cloud metadata endpoints', () => {
+    expect(check('agent-browser navigate http://169.254.169.254/latest/meta-data/iam/')?.block).toBe(true)
+    expect(check('agent-browser navigate http://metadata.google.internal/computeMetadata/v1/')?.block).toBe(true)
+  })
+
+  test('blocks RFC1918 across 10/8 and 172.16/12', () => {
+    expect(check('agent-browser navigate http://10.0.0.1')?.block).toBe(true)
+    expect(check('agent-browser navigate http://172.20.1.1')?.block).toBe(true)
+  })
+
+  test('blocks reserved-suffix hostnames a curious agent might try', () => {
+    expect(check('agent-browser navigate http://printer.local')?.block).toBe(true)
+    expect(check('agent-browser navigate http://nas.home/files')?.block).toBe(true)
+    expect(check('agent-browser navigate http://service.internal')?.block).toBe(true)
+  })
+
+  test('allows navigation to public sites', () => {
+    expect(check('agent-browser navigate https://example.com')).toBeUndefined()
+    expect(check('agent-browser navigate https://news.ycombinator.com')).toBeUndefined()
+    expect(check('agent-browser navigate http://1.1.1.1')).toBeUndefined()
+  })
+
+  test('sees through single quotes, double quotes, and backticks', () => {
+    expect(check(`agent-browser navigate 'http://192.168.0.1'`)?.block).toBe(true)
+    expect(check(`agent-browser navigate "http://10.0.0.1"`)?.block).toBe(true)
+    expect(check('agent-browser navigate `http://172.16.0.1`')?.block).toBe(true)
+  })
+
+  test('catches the URL when it hides later in a chained command', () => {
+    expect(check('cd /tmp && agent-browser navigate http://192.168.0.1')?.block).toBe(true)
+    expect(check('agent-browser dashboard start && agent-browser navigate http://192.168.0.1')?.block).toBe(true)
+  })
+
+  test('catches the URL when wrapped through bunx/npx', () => {
+    expect(check('bunx agent-browser navigate http://192.168.0.1')?.block).toBe(true)
+    expect(check('npx agent-browser navigate http://192.168.0.1')?.block).toBe(true)
+    expect(check('npx --yes agent-browser navigate http://192.168.0.1')?.block).toBe(true)
+    expect(check('npx --package=foo --yes agent-browser navigate http://192.168.0.1')?.block).toBe(true)
+  })
+
+  test('catches the URL when called by absolute path', () => {
+    expect(check('/usr/local/bin/agent-browser navigate http://192.168.0.1')?.block).toBe(true)
+    expect(check('./node_modules/.bin/agent-browser navigate http://192.168.0.1')?.block).toBe(true)
+  })
+
+  test('does not match unrelated scripts that happen to contain the substring', () => {
+    expect(check('echo my-agent-browser-helper http://192.168.0.1')).toBeUndefined()
+    expect(check('cat /tmp/agent-browser-notes.txt')).toBeUndefined()
+  })
+
+  test('does not apply to non-bash tools', () => {
+    expect(
+      checkAgentBrowserSsrfGuard({
+        tool: 'webfetch',
+        args: { url: 'http://192.168.0.1', command: 'agent-browser navigate http://192.168.0.1' },
+      }),
+    ).toBeUndefined()
+  })
+
+  test('handles non-string commands gracefully', () => {
+    expect(checkAgentBrowserSsrfGuard({ tool: 'bash', args: { command: 42 } })).toBeUndefined()
+    expect(checkAgentBrowserSsrfGuard({ tool: 'bash', args: {} })).toBeUndefined()
+  })
+
+  test('respects acknowledgeGuards opt-out', () => {
+    expect(
+      check('agent-browser navigate http://192.168.0.1', {
+        acknowledgeGuards: { [GUARD_AGENT_BROWSER_SSRF]: true },
+      }),
+    ).toBeUndefined()
+  })
+
+  test('does not opt out on an unrelated guard ack', () => {
+    expect(
+      check('agent-browser navigate http://192.168.0.1', {
+        acknowledgeGuards: { ssrf: true },
+      })?.block,
+    ).toBe(true)
+  })
+
+  test('reason text spells out the prompt-injection threat model', () => {
+    const result = check('agent-browser navigate http://192.168.0.1')
+    expect(result?.reason).toContain('prompt injection')
+  })
+
+  test('exposes guard name constant', () => {
+    expect(GUARD_AGENT_BROWSER_SSRF).toBe('agentBrowserSsrf')
+  })
+
+  test('skips clean dashboard/skills/version subcommands', () => {
+    expect(check('agent-browser dashboard start')).toBeUndefined()
+    expect(check('agent-browser skills get core')).toBeUndefined()
+    expect(check('agent-browser --version')).toBeUndefined()
+  })
+})

--- a/src/bundled-plugins/security/policies/agent-browser-ssrf.ts
+++ b/src/bundled-plugins/security/policies/agent-browser-ssrf.ts
@@ -1,0 +1,74 @@
+import { ACKNOWLEDGE_GUARDS, type SecurityBlock, isGuardAcknowledged } from '../policy'
+import { classifyUrl, type SsrfClassification } from './ssrf'
+
+export const GUARD_AGENT_BROWSER_SSRF = 'agentBrowserSsrf'
+
+// Covers the bare binary, the bunx/npx wrappers documented in the skill's
+// `allowed-tools` frontmatter, and an absolute-path call into node_modules.
+// The leading boundary keeps `my-agent-browser-script.sh` from matching.
+const AGENT_BROWSER_INVOCATION =
+  /(^|[\s;|&(`$])(?:(?:bunx|npx)\s+(?:--?[A-Za-z][A-Za-z0-9-]*\s+)*)?(?:[^\s;|&`'"]*\/)?agent-browser([\s;|&)`]|$)/
+
+const URL_TOKEN = /\bhttps?:\/\/[^\s'"`)]+/gi
+
+// agent-browser accepts host:port without a scheme; Chrome prepends http://
+// internally. We scan for bare IPv4 and bracketed IPv6 literals and re-feed
+// them with an http:// prefix so classifyUrl sees the same shape it does for
+// scheme'd URLs. Bare DNS-style hostnames are not matched here — the SSRF
+// classifier only blocks literal IPs and reserved suffixes, so a bare token
+// like `router` could not be classified anyway.
+const BARE_IPV4_TOKEN = /(?<![A-Za-z0-9._-])(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?(?![A-Za-z0-9._-])/g
+const BARE_IPV6_TOKEN = /\[[0-9A-Fa-f:]+\](?::\d{1,5})?/g
+
+export function checkAgentBrowserSsrfGuard(options: {
+  tool: string
+  args: Record<string, unknown>
+}): SecurityBlock | undefined {
+  const { tool, args } = options
+  if (tool !== 'bash') return undefined
+
+  const command = args.command
+  if (typeof command !== 'string') return undefined
+  if (!AGENT_BROWSER_INVOCATION.test(command)) return undefined
+  if (isGuardAcknowledged(args, GUARD_AGENT_BROWSER_SSRF)) return undefined
+
+  const blocked = findFirstBlockedTarget(command)
+  if (!blocked) return undefined
+
+  return {
+    block: true,
+    reason: [
+      `Guard \`${GUARD_AGENT_BROWSER_SSRF}\` blocked an agent-browser command targeting a non-public destination (${blocked.classification.category ?? 'unknown'}): ${blocked.classification.reason ?? 'classified as internal'}.`,
+      'A browser inside the container can reach the host LAN, cloud-metadata endpoints, and reserved internal hostnames — letting the agent navigate there exposes routers, IoT/admin panels, and the metadata service to whoever wrote the prompt (including indirect prompt injection through page content).',
+      `If the user explicitly asked for this and you trust the destination, retry with \`${ACKNOWLEDGE_GUARDS}.${GUARD_AGENT_BROWSER_SSRF}: true\` in the bash arguments.`,
+    ].join(' '),
+  }
+}
+
+type BlockedTarget = { url: string; classification: SsrfClassification }
+
+function findFirstBlockedTarget(command: string): BlockedTarget | undefined {
+  for (const url of extractUrlCandidates(command)) {
+    const classification = classifyUrl(url)
+    if (classification.blocked) return { url, classification }
+  }
+  return undefined
+}
+
+function* extractUrlCandidates(command: string): Generator<string> {
+  // No real shell parsing — we just neutralize quote characters so they
+  // can't hide a URL from the regex (`'http://192.168.0.1'` would otherwise
+  // be a single token ending at the closing quote, which matches anyway,
+  // but stripping makes failure-mode reasoning trivial).
+  const stripped = command.replace(/['"`]/g, ' ')
+
+  for (const match of stripped.matchAll(URL_TOKEN)) {
+    yield match[0]
+  }
+  for (const match of stripped.matchAll(BARE_IPV4_TOKEN)) {
+    yield `http://${match[0]}`
+  }
+  for (const match of stripped.matchAll(BARE_IPV6_TOKEN)) {
+    yield `http://${match[0]}`
+  }
+}


### PR DESCRIPTION
## Summary

A user (or attacker via indirect prompt injection) could say \"open http://192.168.0.1\" followed by \"type admin\" and reach the host's router, NAS, or any internal admin panel — the browser runs inside the container but the container's network is bridged to the host LAN. The existing SSRF guard in the security plugin only covers the `webfetch` tool; `agent-browser` is invoked through `Bash` and slipped past it entirely.

This PR closes that gap by adding a `tool.before` policy that inspects every `Bash` command containing an `agent-browser` invocation, extracts both scheme'd URLs and bare IPv4/IPv6 literals (since agent-browser accepts scheme-less hosts and Chrome prepends `http://`), and runs each through the existing `classifyUrl` from `ssrf.ts`. No classification logic is duplicated — it reuses the battle-tested classifier already protecting `webfetch`.

## Threat model

The container's bridge network can reach:

- **RFC1918 LAN hosts** — home/office routers, NAS devices, and internal admin panels (often with default credentials)
- **Loopback in every encoding** — `127.0.0.1`, `::1`, decimal-packed (`2130706433`), hex-packed (`0x7f000001`), IPv4-mapped IPv6
- **Cloud metadata endpoints** — `169.254.169.254` (AWS/GCP/Azure IMDSv1) and `metadata.google.internal`; navigating there returns short-lived IAM credentials in page content
- **CGNAT range** — `100.64.0.0/10` (carrier-side network, reachable in some topologies)
- **Reserved-suffix hostnames** — `*.local`, `*.internal`, `*.corp`, `*.home`

**This is also a prompt-injection surface, not just a "user typed the wrong thing" concern.** A page the agent already loaded can contain instructions to navigate elsewhere. Indirect-injection defense is one of the explicit jobs of this plugin (see the `prompt-injection.ts` sibling policy). The block reason string therefore mentions "prompt injection" explicitly so the agent can communicate the risk back to the user.

## Changes

### `src/bundled-plugins/security/policies/agent-browser-ssrf.ts` (new)

Defines `GUARD_AGENT_BROWSER_SSRF = 'agentBrowserSsrf'` and `checkAgentBrowserSsrfGuard`. Detects agent-browser in:

- Bare binary: `agent-browser navigate http://192.168.0.1`
- bunx/npx wrappers with arbitrary flags: `bunx --bun agent-browser navigate ...`
- Absolute-path calls: `/usr/local/bin/agent-browser navigate ...`

Extracts `http(s)://` URLs and bare IPv4/IPv6 tokens, classifies each via `classifyUrl`, blocks on private result. Honors `acknowledgeGuards.agentBrowserSsrf: true`, matching every other guard in this plugin.

### `src/bundled-plugins/security/policies/agent-browser-ssrf.test.ts` (new)

19 unit tests covering:

- Canonical home-router scenario (`192.168.0.1`)
- Bare-IP navigation and every loopback encoding
- Cloud metadata (`169.254.169.254`, `metadata.google.internal`)
- RFC1918 ranges and reserved-suffix hostnames (`.local`, `.home`, `.internal`, `.corp`)
- Public URL allowance
- Quote stripping (single, double, backtick)
- Chained commands and bunx/npx variants with flags
- Absolute-path calls
- False-positive resistance (`my-agent-browser-helper`, `cat /tmp/agent-browser-notes.txt`)
- Non-bash tool isolation; non-string arg safety
- Acknowledgement bypass and ack scoping (`ssrf` ack does NOT silence `agentBrowserSsrf`)
- Reason text must mention "prompt injection"
- URL-free subcommands (`dashboard`, `skills`, `version`) pass through without a block

### `src/bundled-plugins/security/index.ts` (+2 lines)

Adds `checkAgentBrowserSsrfGuard` to the `tool.before` hook chain immediately after `checkSsrfGuard`, since they are conceptual siblings protecting the same threat category.

### `src/bundled-plugins/security/index.test.ts` (+4 wiring tests)

End-to-end flow through the plugin: blocks home-router scenario, blocks bunx + bare IP, allows public URLs, acknowledgement bypass works. Also adds `agentBrowserSsrf` to the existing "honors acknowledgement for each guard independently" test.

## Non-goals (explicit)

- **Does not block DNS hostnames that resolve to private IPs.** `my-router.example.com` pointing at `192.168.1.1` is a network-level egress problem, not a string-level filter problem. It is out of scope for a `tool.before` check. Network egress policy belongs at the container/firewall layer.
- **Does not block the `type 'admin'` step on its own.** That step has no URL context. Blocking the `navigate` call is the chokepoint — if the agent never reaches the admin panel, the credential-entry step never runs.

## Verification

- `bun run lint` — 0 warnings, 0 errors
- `bun run format:check` — clean
- `bun run typecheck` (tsgo --noEmit) — clean
- `bun test` — 2647 pass, 0 fail across 157 files