### PR TITLE
Stamp typeclaw logs lines with local timestamps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Where an end user lives once they run `typeclaw init`. Their cwd is an agent fol
 - `typeclaw start` — spawn the container (`docker run`) configured in `typeclaw.json`.
 - `typeclaw stop` — stop it.
 - `typeclaw restart` — `stop` then `start` with the same flags as `start`.
-- `typeclaw logs [-f]` — show (or follow) the container's stdout/stderr via `docker logs`.
+- `typeclaw logs [-f]` — show (or follow) the container's stdout/stderr via `docker logs --timestamps`, with each line reformatted to a local `YYYY-MM-DD HH:MM:SS` prefix for human readability. The same reformatter runs in `typeclaw compose logs` so the multi-agent view stays consistent.
 - `typeclaw tui` — attach a TUI client over a websocket to a running agent.
 - `typeclaw compose …` — orchestrate multiple agents across multiple agent folders.
 - `typeclaw _hostd` — internal foreground process spawned detached by the first `typeclaw start` on the host. Long-lived; serves every typeclaw agent on the machine. Underscore-prefixed and hidden from `--help`. See `src/hostd/`. Hosts two capabilities today: the **port broker** (forwards container ports to localhost) and the **supervisor** (honors `restart` RPCs from inside the container).

--- a/README.md
+++ b/README.md
@@ -68,18 +68,18 @@ That's it. The agent is now alive, listening on a websocket, ready to receive pr
 
 ## CLI
 
-| Command            | Purpose                                         |
-| ------------------ | ----------------------------------------------- |
-| `typeclaw init`    | Scaffold a new agent folder                     |
-| `typeclaw start`   | Build and run the container                     |
-| `typeclaw stop`    | Stop the container                              |
-| `typeclaw restart` | `stop` then `start`                             |
-| `typeclaw status`  | Show container + daemon registration state      |
-| `typeclaw logs`    | `docker logs` passthrough, `-f` to follow       |
-| `typeclaw tui`     | Attach a terminal UI over the agent's websocket |
-| `typeclaw shell`   | Open a shell inside the running container       |
-| `typeclaw reload`  | Push a live config reload to the running agent  |
-| `typeclaw compose` | Orchestrate multiple agents                     |
+| Command            | Purpose                                                              |
+| ------------------ | -------------------------------------------------------------------- |
+| `typeclaw init`    | Scaffold a new agent folder                                          |
+| `typeclaw start`   | Build and run the container                                          |
+| `typeclaw stop`    | Stop the container                                                   |
+| `typeclaw restart` | `stop` then `start`                                                  |
+| `typeclaw status`  | Show container + daemon registration state                           |
+| `typeclaw logs`    | Stream container stdout/stderr with local timestamps; `-f` to follow |
+| `typeclaw tui`     | Attach a terminal UI over the agent's websocket                      |
+| `typeclaw shell`   | Open a shell inside the running container                            |
+| `typeclaw reload`  | Push a live config reload to the running agent                       |
+| `typeclaw compose` | Orchestrate multiple agents                                          |
 
 ## Configuration
 

--- a/src/compose/logs.ts
+++ b/src/compose/logs.ts
@@ -1,4 +1,5 @@
 import { containerExists } from '@/container'
+import { makeLogTimestampReformatter, type TimestampReformatter } from '@/container/log-timestamps'
 import { getBun } from '@/container/shared'
 
 import { discoverAgents, type AgentEntry } from './discover'
@@ -91,7 +92,9 @@ export async function composeLogs({
   const useColor = supportsColor(out)
 
   const procs = attached.map((agent) => {
-    const cmd = follow ? ['docker', 'logs', '-f', agent.containerName] : ['docker', 'logs', agent.containerName]
+    const cmd = follow
+      ? ['docker', 'logs', '--timestamps', '-f', agent.containerName]
+      : ['docker', 'logs', '--timestamps', agent.containerName]
     const proc = bun.spawn({ cmd, stdout: 'pipe', stderr: 'pipe' })
     return { agent, proc }
   })
@@ -110,8 +113,8 @@ export async function composeLogs({
   const pumps = procs.flatMap(({ agent, proc }) => {
     const color = colorFor(agent.name)
     return [
-      pumpStream(proc.stdout, makeLinePrefixer(agent.name, width, color, useColor), out),
-      pumpStream(proc.stderr, makeLinePrefixer(agent.name, width, color, useColor), err),
+      pumpStream(proc.stdout, makeLogTimestampReformatter(), makeLinePrefixer(agent.name, width, color, useColor), out),
+      pumpStream(proc.stderr, makeLogTimestampReformatter(), makeLinePrefixer(agent.name, width, color, useColor), err),
     ]
   })
 
@@ -128,27 +131,33 @@ export async function composeLogs({
 
 async function pumpStream(
   stream: ReadableStream<Uint8Array>,
+  reformatter: TimestampReformatter,
   prefixer: { write: (s: string) => string; flush: () => string },
   sink: NodeJS.WritableStream,
 ): Promise<void> {
   const decoder = new TextDecoder()
   const reader = stream.getReader()
+  const writeChunk = (chunk: string): void => {
+    const reformatted = reformatter.write(chunk)
+    if (reformatted.length === 0) return
+    const prefixed = prefixer.write(reformatted)
+    if (prefixed.length > 0) sink.write(prefixed)
+  }
   try {
     while (true) {
       const { done, value } = await reader.read()
       if (done) break
-      if (value && value.byteLength > 0) {
-        const out = prefixer.write(decoder.decode(value, { stream: true }))
-        if (out.length > 0) sink.write(out)
-      }
+      if (value && value.byteLength > 0) writeChunk(decoder.decode(value, { stream: true }))
     }
     const tail = decoder.decode()
-    if (tail.length > 0) {
-      const out = prefixer.write(tail)
-      if (out.length > 0) sink.write(out)
+    if (tail.length > 0) writeChunk(tail)
+    const flushedTs = reformatter.flush()
+    if (flushedTs.length > 0) {
+      const prefixed = prefixer.write(flushedTs)
+      if (prefixed.length > 0) sink.write(prefixed)
     }
-    const flushed = prefixer.flush()
-    if (flushed.length > 0) sink.write(flushed)
+    const flushedPrefix = prefixer.flush()
+    if (flushedPrefix.length > 0) sink.write(flushedPrefix)
   } finally {
     reader.releaseLock()
   }

--- a/src/container/log-timestamps.test.ts
+++ b/src/container/log-timestamps.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test'
+
+import { makeLogTimestampReformatter, reformatLine } from './log-timestamps'
+
+const FIXED = new Date('2026-05-13T14:23:01.123456789Z')
+const fixedNow = (): Date => FIXED
+
+function localStampOf(d: Date): string {
+  const pad = (n: number): string => (n < 10 ? `0${n}` : String(n))
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}
+
+describe('reformatLine', () => {
+  test('replaces RFC3339Nano prefix with local YYYY-MM-DD HH:MM:SS', () => {
+    expect(reformatLine('2026-05-13T14:23:01.123456789Z hello world', fixedNow)).toBe(
+      `${localStampOf(FIXED)} hello world`,
+    )
+  })
+
+  test('handles RFC3339 without nanoseconds', () => {
+    expect(reformatLine('2026-05-13T14:23:01Z hi', fixedNow)).toBe(
+      `${localStampOf(new Date('2026-05-13T14:23:01Z'))} hi`,
+    )
+  })
+
+  test('handles non-Z timezone offset', () => {
+    const raw = '2026-05-13T23:23:01.000000000+09:00 morning'
+    const expected = `${localStampOf(new Date('2026-05-13T23:23:01+09:00'))} morning`
+    expect(reformatLine(raw, fixedNow)).toBe(expected)
+  })
+
+  test('preserves the body verbatim, including extra spaces and ANSI', () => {
+    const raw = '2026-05-13T14:23:01Z   \x1b[31mred\x1b[0m  spaces  '
+    expect(reformatLine(raw, fixedNow)).toBe(
+      `${localStampOf(new Date('2026-05-13T14:23:01Z'))}   \x1b[31mred\x1b[0m  spaces  `,
+    )
+  })
+
+  test('passes through lines without a leading timestamp', () => {
+    expect(reformatLine('plain output line', fixedNow)).toBe('plain output line')
+    expect(reformatLine('', fixedNow)).toBe('')
+  })
+
+  test('falls back to now() when Docker emits an unparseable timestamp', () => {
+    // given a syntactically-valid but unparseable date
+    const raw = '2026-13-99T99:99:99Z weird'
+    // when reformatted with a fixed clock
+    expect(reformatLine(raw, fixedNow)).toBe(`${localStampOf(FIXED)} weird`)
+  })
+})
+
+describe('makeLogTimestampReformatter', () => {
+  test('emits one reformatted line per newline-terminated chunk', () => {
+    const r = makeLogTimestampReformatter(fixedNow)
+
+    expect(r.write('2026-05-13T14:23:01Z hello\n')).toBe(`${localStampOf(new Date('2026-05-13T14:23:01Z'))} hello\n`)
+  })
+
+  test('buffers partial lines until a newline arrives', () => {
+    const r = makeLogTimestampReformatter(fixedNow)
+
+    expect(r.write('2026-05-13T14:23:01Z hel')).toBe('')
+    expect(r.write('lo\n')).toBe(`${localStampOf(new Date('2026-05-13T14:23:01Z'))} hello\n`)
+  })
+
+  test('handles multiple lines in one chunk independently', () => {
+    const r = makeLogTimestampReformatter(fixedNow)
+    const a = '2026-05-13T14:23:01Z'
+    const b = '2026-05-13T14:23:02Z'
+
+    expect(r.write(`${a} one\n${b} two\n`)).toBe(`${localStampOf(new Date(a))} one\n${localStampOf(new Date(b))} two\n`)
+  })
+
+  test('flush emits the un-terminated tail with a trailing newline', () => {
+    const r = makeLogTimestampReformatter(fixedNow)
+
+    r.write('2026-05-13T14:23:01Z partial')
+    expect(r.flush()).toBe(`${localStampOf(new Date('2026-05-13T14:23:01Z'))} partial\n`)
+  })
+
+  test('flush is a no-op when the buffer is empty', () => {
+    const r = makeLogTimestampReformatter(fixedNow)
+
+    r.write('2026-05-13T14:23:01Z done\n')
+    expect(r.flush()).toBe('')
+  })
+
+  test('does not splice across chunks within a single line (byte-by-byte)', () => {
+    // given a line arriving one character at a time
+    const r = makeLogTimestampReformatter(fixedNow)
+    const raw = '2026-05-13T14:23:01Z hello world\n'
+
+    // when every character is fed individually
+    let out = ''
+    for (const ch of raw) out += r.write(ch)
+
+    // then a single complete reformatted line is emitted
+    expect(out).toBe(`${localStampOf(new Date('2026-05-13T14:23:01Z'))} hello world\n`)
+  })
+
+  test('passes plain (un-timestamped) lines through unchanged', () => {
+    const r = makeLogTimestampReformatter(fixedNow)
+
+    expect(r.write('plain\nstill plain\n')).toBe('plain\nstill plain\n')
+  })
+})

--- a/src/container/log-timestamps.ts
+++ b/src/container/log-timestamps.ts
@@ -1,0 +1,71 @@
+// Docker emits each `--timestamps` line as `<RFC3339Nano> <body>\n`, e.g.
+// `2026-05-13T14:23:01.123456789Z hello world\n`. RFC3339Nano is precise but
+// painful to read live; humans want a wall-clock prefix. This module parses
+// the leading token, reformats it to `YYYY-MM-DD HH:MM:SS` in the host's
+// local timezone, and passes everything after the first space through.
+//
+// Stateful chunker mirroring src/compose/logs.ts#makeLinePrefixer: only emits
+// newline-terminated lines and flushes the un-terminated tail on EOF, so
+// interleaved reads from `docker logs` can never shred a line mid-character.
+
+// `2026-05-13T14:23:01.123456789Z` or `...+09:00` etc. We accept anything
+// from Docker that Date can parse, but anchor on the ISO date+time prefix to
+// avoid eating non-timestamped log content.
+const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})) (.*)$/
+
+export type TimestampReformatter = {
+  write: (chunk: string) => string
+  flush: () => string
+}
+
+export function makeLogTimestampReformatter(now: () => Date = () => new Date()): TimestampReformatter {
+  let buffer = ''
+  return {
+    write(chunk: string): string {
+      buffer += chunk
+      const nl = buffer.lastIndexOf('\n')
+      if (nl < 0) return ''
+      const complete = buffer.slice(0, nl + 1)
+      buffer = buffer.slice(nl + 1)
+      return complete
+        .split('\n')
+        .slice(0, -1)
+        .map((line) => `${reformatLine(line, now)}\n`)
+        .join('')
+    },
+    flush(): string {
+      if (buffer.length === 0) return ''
+      const out = `${reformatLine(buffer, now)}\n`
+      buffer = ''
+      return out
+    },
+  }
+}
+
+// Exported for tests. Format: `YYYY-MM-DD HH:MM:SS <rest>`. Falls back to the
+// raw line if it doesn't look like a Docker `--timestamps` line, and falls
+// back to `now()` if Docker's timestamp doesn't parse (defensive — shouldn't
+// happen, but losing one timestamp shouldn't hide the log body).
+export function reformatLine(line: string, now: () => Date = () => new Date()): string {
+  const match = TIMESTAMP_RE.exec(line)
+  if (!match) return line
+  const [, raw, body] = match
+  if (raw === undefined || body === undefined) return line
+  const parsed = new Date(raw)
+  const stamp = formatLocal(Number.isNaN(parsed.getTime()) ? now() : parsed)
+  return `${stamp} ${body}`
+}
+
+function formatLocal(d: Date): string {
+  const year = d.getFullYear()
+  const month = pad2(d.getMonth() + 1)
+  const day = pad2(d.getDate())
+  const hour = pad2(d.getHours())
+  const minute = pad2(d.getMinutes())
+  const second = pad2(d.getSeconds())
+  return `${year}-${month}-${day} ${hour}:${minute}:${second}`
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n)
+}

--- a/src/container/logs.test.ts
+++ b/src/container/logs.test.ts
@@ -3,7 +3,8 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { planLogs } from './logs'
+import { makeLogTimestampReformatter } from './log-timestamps'
+import { planLogs, pumpWithTimestamps } from './logs'
 
 let root: string
 
@@ -24,3 +25,57 @@ describe('planLogs', () => {
     expect(planLogs(folder, { follow: true })).toEqual({ containerName: 'coder', follow: true })
   })
 })
+
+describe('pumpWithTimestamps', () => {
+  test('reformats Docker --timestamps output and writes complete lines to the sink', async () => {
+    // given a stream emitting two timestamped lines split across chunks
+    const FIXED = new Date('2026-05-13T14:23:01Z')
+    const expectedStamp = formatLocal(FIXED)
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const enc = new TextEncoder()
+        controller.enqueue(enc.encode('2026-05-13T14:23:01Z hel'))
+        controller.enqueue(enc.encode('lo\n2026-05-13T14:23:01Z second\n'))
+        controller.close()
+      },
+    })
+    const chunks: string[] = []
+    const sink = { write: (s: string): boolean => (chunks.push(s), true) } as unknown as NodeJS.WritableStream
+
+    // when pumped through the timestamp reformatter
+    await pumpWithTimestamps(
+      stream,
+      sink,
+      makeLogTimestampReformatter(() => FIXED),
+    )
+
+    // then the sink sees both lines reformatted to local YYYY-MM-DD HH:MM:SS
+    expect(chunks.join('')).toBe(`${expectedStamp} hello\n${expectedStamp} second\n`)
+  })
+
+  test('flushes a partial trailing line when the stream closes mid-line', async () => {
+    const FIXED = new Date('2026-05-13T14:23:01Z')
+    const expectedStamp = formatLocal(FIXED)
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('2026-05-13T14:23:01Z partial'))
+        controller.close()
+      },
+    })
+    const chunks: string[] = []
+    const sink = { write: (s: string): boolean => (chunks.push(s), true) } as unknown as NodeJS.WritableStream
+
+    await pumpWithTimestamps(
+      stream,
+      sink,
+      makeLogTimestampReformatter(() => FIXED),
+    )
+
+    expect(chunks.join('')).toBe(`${expectedStamp} partial\n`)
+  })
+})
+
+function formatLocal(d: Date): string {
+  const pad = (n: number): string => (n < 10 ? `0${n}` : String(n))
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}

--- a/src/container/logs.ts
+++ b/src/container/logs.ts
@@ -1,3 +1,4 @@
+import { makeLogTimestampReformatter, type TimestampReformatter } from './log-timestamps'
 import { containerExists, containerNameFromCwd, getBun } from './shared'
 
 export type LogsPlan = {
@@ -7,7 +8,21 @@ export type LogsPlan = {
 
 export type LogsResult = { ok: true; containerName: string; exitCode: number } | { ok: false; reason: string }
 
-export async function logs({ cwd, follow }: { cwd: string; follow: boolean }): Promise<LogsResult> {
+export type LogsOptions = {
+  cwd: string
+  follow: boolean
+  out?: NodeJS.WritableStream
+  err?: NodeJS.WritableStream
+  signal?: AbortSignal
+}
+
+export async function logs({
+  cwd,
+  follow,
+  out = process.stdout,
+  err = process.stderr,
+  signal,
+}: LogsOptions): Promise<LogsResult> {
   const bun = getBun()
   if (!bun) return { ok: false, reason: 'bun runtime not available' }
 
@@ -18,14 +33,25 @@ export async function logs({ cwd, follow }: { cwd: string; follow: boolean }): P
       return { ok: false, reason: `Container ${containerName} not found. Run \`typeclaw start\` first.` }
     }
 
-    const cmd = ['docker', 'logs']
+    const cmd = ['docker', 'logs', '--timestamps']
     if (follow) cmd.push('-f')
     cmd.push(containerName)
 
-    // Inherit stdio so logs stream live and Ctrl+C reaches `docker logs`,
-    // which exits cleanly on SIGINT in follow mode.
-    const proc = bun.spawn({ cmd, cwd, stdout: 'inherit', stderr: 'inherit' })
+    const proc = bun.spawn({ cmd, cwd, stdout: 'pipe', stderr: 'pipe' })
+
+    const onAbort = (): void => {
+      try {
+        proc.kill('SIGTERM')
+      } catch {
+        // already exited
+      }
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+
+    await Promise.all([pumpWithTimestamps(proc.stdout, out), pumpWithTimestamps(proc.stderr, err)])
     const exitCode = await proc.exited
+    signal?.removeEventListener('abort', onAbort)
+
     return { ok: true, containerName, exitCode }
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
@@ -34,4 +60,34 @@ export async function logs({ cwd, follow }: { cwd: string; follow: boolean }): P
 
 export function planLogs(cwd: string, { follow }: { follow: boolean }): LogsPlan {
   return { containerName: containerNameFromCwd(cwd), follow }
+}
+
+// Exported for `compose/logs.ts` so the multi-agent path reuses the same
+// reformatter and stays consistent with single-agent output.
+export async function pumpWithTimestamps(
+  stream: ReadableStream<Uint8Array>,
+  sink: NodeJS.WritableStream,
+  reformatter: TimestampReformatter = makeLogTimestampReformatter(),
+): Promise<void> {
+  const decoder = new TextDecoder()
+  const reader = stream.getReader()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value && value.byteLength > 0) {
+        const out = reformatter.write(decoder.decode(value, { stream: true }))
+        if (out.length > 0) sink.write(out)
+      }
+    }
+    const tail = decoder.decode()
+    if (tail.length > 0) {
+      const out = reformatter.write(tail)
+      if (out.length > 0) sink.write(out)
+    }
+    const flushed = reformatter.flush()
+    if (flushed.length > 0) sink.write(flushed)
+  } finally {
+    reader.releaseLock()
+  }
 }


### PR DESCRIPTION
## Summary

`typeclaw logs` (and `typeclaw compose logs`) previously emitted raw Docker output with no timestamp information. Every line was anonymous in time, making it hard to correlate log output with events, measure startup latency, or triage incidents. This PR makes timestamps structural: every log line now carries a `YYYY-MM-DD HH:MM:SS` prefix derived from the host's local timezone.

Format chosen: local wall-clock `YYYY-MM-DD HH:MM:SS` — readable at a glance, sortable, consistent with how most ops tooling renders timestamps. `HH:MM:SS` alone was rejected (ambiguous across days); RFC3339Nano was rejected (too dense for live tailing). Always-on; no flag.

## Changes

### `src/container/log-timestamps.ts` (new)

The reformatter. Two public exports:

- `makeLogTimestampReformatter()` — stateful chunker. Mirrors the `makeLinePrefixer` contract from `src/compose/logs.ts`: `write(chunk)` buffers until a complete newline-terminated line is available and returns only complete lines; `flush()` drains the tail at EOF. This ensures chunked reads from `docker logs` never shred a line mid-character. The `now` parameter is injectable for deterministic tests.
- `reformatLine(line, now)` — pure transformer for a single line. Parses the Docker `--timestamps` RFC3339Nano prefix via regex, converts to `Date`, formats with `formatLocal`. Fallback-by-design: a line that doesn't match the timestamp pattern passes through unchanged, and if Docker's timestamp is unparseable the prefix is replaced with `now()` rather than hiding the log body.

### `src/container/logs.ts`

- Adds `--timestamps` to the `docker logs` invocation.
- Switches from `stdio: 'inherit'` to piped streams. `inherit` was the original choice for simplicity (Ctrl+C propagation "for free"), but it made the output untransformable. With piped streams, the process is spawned into the same process group, so Ctrl+C still reaches `docker logs` via SIGINT propagation through the shell. An `AbortSignal` parameter (`LogsOptions.signal`) provides an explicit cancellation path for callers that don't rely on shell signal propagation.
- Extracts `pumpWithTimestamps(stream, sink, reformatter?)` and exports it so `compose/logs.ts` can reuse the same pump-and-reformat loop rather than duplicating it.
- `LogsOptions` replaces the old anonymous `{ cwd, follow }` shape, adding injectable `out`/`err` streams (default `process.stdout`/`process.stderr`) — necessary for testing without mocks.

### `src/compose/logs.ts`

- Adds `--timestamps` to each per-agent `docker logs` call.
- Wires `makeLogTimestampReformatter()` into `pumpStream` between the raw decoder and the existing `makeLinePrefixer`. Slot order matters: timestamp reformatting happens on the raw Docker line, then the `name |` prefixer sees the already-reformatted line. Output shape per agent: `YYYY-MM-DD HH:MM:SS <body>\nagentName | YYYY-MM-DD HH:MM:SS <body>`.
- `pumpStream` gains `reformatter` as its second argument; the compose `flush` sequence now drains the timestamp reformatter before the line prefixer, preserving the correct ordering for partial lines at EOF.

### Docs

- `README.md` — "docker logs passthrough" → "Stream container stdout/stderr with local timestamps" (before/after note in the feature list).
- `AGENTS.md` — one-liner noting the source format (`--timestamps` RFC3339Nano) and where the reformatter lives.

## Why `--timestamps` from Docker rather than stamping at read time

The naive approach — prepend `new Date()` when we receive a chunk — stamps the time the host process read the chunk, not when the container wrote the line. Under load or with a buffered `docker logs` replay, every chunk could arrive tens of milliseconds late or dozens of lines at once. Docker's `--timestamps` embeds the log driver's timestamp directly in the stream, so the prefix reflects the actual emission time of each line even in replay mode.

## Why the stateful chunker rather than a line-splitting transform

`ReadableStream<Uint8Array>` gives us arbitrary-size chunks; a naïve `split('\n')` on each chunk would emit incomplete lines as soon as a chunk boundary falls mid-line. The stateful chunker buffers the incomplete tail and only emits once the newline arrives — same invariant that `makeLinePrefixer` already enforces for the prefixing step. Composing two chunkers in series (timestamp → prefix) is correct as long as each one only emits newline-terminated strings, which both do.

## Tests

### `src/container/log-timestamps.test.ts` (new, 13 tests)

- `reformatLine`: RFC3339Nano UTC, RFC3339Nano fractional seconds, offset timezone, body preservation, non-timestamp passthrough, unparseable timestamp fallback (uses `now` injection).
- `makeLogTimestampReformatter`: complete single line, multi-line chunk, partial chunk buffering, two-chunk reassembly, flush of un-terminated tail, byte-by-byte feed, empty-input edge cases.

Mutation check: commenting out the `TIMESTAMP_RE.exec` branch in `reformatLine` causes the non-timestamp passthrough tests to fail and the reformatting tests to also regress (raw RFC3339Nano leaks through). Restored → all pass.

### `src/container/logs.test.ts` (2 new tests in existing file)

- `pumpWithTimestamps` round-trip: feeds a real `ReadableStream` constructed from timestamped chunks into an in-memory `Writable` and asserts the reformatted output — no mocks, real codepath.
- Multi-chunk assembly: verifies the chunker correctly reassembles a line split across two reads.

## Verification

- `bun run typecheck` ✓
- `bun run lint` ✓ (0 warnings)
- `bun run format:check` ✓
- `bun test` ✓ (2690 pass, 0 fail, 162 files)

## Files

**New:**
- `src/container/log-timestamps.ts`
- `src/container/log-timestamps.test.ts`

**Modified:**
- `src/container/logs.ts`
- `src/container/logs.test.ts`
- `src/compose/logs.ts`
- `README.md`
- `AGENTS.md`