### PR TITLE
Harden typeclaw doctor: WS isolation, commit safety, path sanitizers

### DIFF
--- a/src/agent/doctor.test.ts
+++ b/src/agent/doctor.test.ts
@@ -112,10 +112,28 @@ describe('runPluginDoctorFix', () => {
     expect(calls[0]?.agentDir).toBe('/agent')
   })
 
-  test('rejects absolute paths and ".." segments', () => {
-    const result = sanitizeChangedPaths(['memory/ok.md', '/etc/passwd', '../escape', 'mem/../../oops'])
+  test('rejects absolute paths, ".." segments, ".", null bytes, backslashes, and empty', () => {
+    const result = sanitizeChangedPaths([
+      'memory/ok.md',
+      '/etc/passwd',
+      '../escape',
+      'mem/../../oops',
+      '.',
+      './',
+      'foo/..',
+      '',
+      'has\0null',
+      'win\\path',
+    ])
     expect(result.accepted).toEqual(['memory/ok.md'])
-    expect(result.rejected.sort()).toEqual(['../escape', '/etc/passwd', 'mem/../../oops'])
+    expect(result.rejected.sort()).toEqual(
+      ['', '.', './', '../escape', '/etc/passwd', 'foo/..', 'has\0null', 'mem/../../oops', 'win\\path'].sort(),
+    )
+  })
+
+  test('reduces foo/bar/../baz to foo/baz instead of leaking ".."', () => {
+    const result = sanitizeChangedPaths(['foo/bar/../baz', 'foo/./bar'])
+    expect(result.accepted).toEqual(['foo/baz', 'foo/bar'])
   })
 
   test('returns error when check has no apply callback', async () => {

--- a/src/agent/doctor.test.ts
+++ b/src/agent/doctor.test.ts
@@ -66,6 +66,21 @@ describe('runPluginDoctorChecks', () => {
     expect(record?.message).toMatch(/timed out/)
   })
 
+  test('aborts the check signal when the timeout fires', async () => {
+    const registry = emptyRegistry()
+    let captured: AbortSignal | undefined
+    registerCheck(registry, 'p1', 'observes-signal', {
+      description: 'x',
+      run: (ctx) =>
+        new Promise<PluginCheckResult>(() => {
+          captured = ctx.signal
+        }),
+    })
+    const [record] = await runPluginDoctorChecks({ registry, agentDir: '/agent', checkTimeoutMs: 20 })
+    expect(captured?.aborted).toBe(true)
+    expect(record?.message).toMatch(/timed out/)
+  })
+
   test('reports fix.hasApply: true only when apply is present', async () => {
     const registry = emptyRegistry()
     registerCheck(registry, 'p1', 'with-apply', {

--- a/src/agent/doctor.ts
+++ b/src/agent/doctor.ts
@@ -148,26 +148,41 @@ function messageOf(err: unknown): string {
 export type PathSanitization = { accepted: string[]; rejected: string[] }
 
 // Plugin fixes declare paths relative to agentDir; the host re-validates on
-// receipt for defense in depth, but rejecting here first keeps the wire
-// payload small and the failure attribution accurate.
+// receipt for defense in depth. The rules here MUST stay identical to the
+// host-side sanitizer in `src/doctor/index.ts` — any plugin-supplied path that
+// would survive normalization to `.` (the agent root), to a `..` escape, or
+// to an absolute filesystem path is rejected so `git add` cannot stage
+// anything outside the explicit fix surface.
 export function sanitizeChangedPaths(paths: readonly string[]): PathSanitization {
   const accepted: string[] = []
   const rejected: string[] = []
   for (const raw of paths) {
-    if (typeof raw !== 'string' || raw.length === 0) {
+    if (typeof raw !== 'string') {
       rejected.push(String(raw))
       continue
     }
-    if (isAbsolute(raw) || raw.includes('\\')) {
+    if (raw.length === 0) {
       rejected.push(raw)
       continue
     }
-    const normalized = normalize(raw)
-    if (normalized.startsWith('..') || normalized.split('/').includes('..')) {
+    if (raw.includes('\0') || raw.includes('\\')) {
       rejected.push(raw)
       continue
     }
-    accepted.push(normalized)
+    if (isAbsolute(raw)) {
+      rejected.push(raw)
+      continue
+    }
+    const stripped = normalize(raw).replace(/\/+$/, '')
+    if (stripped === '.' || stripped === '' || stripped.startsWith('..')) {
+      rejected.push(raw)
+      continue
+    }
+    if (stripped.split('/').includes('..')) {
+      rejected.push(raw)
+      continue
+    }
+    accepted.push(stripped)
   }
   return { accepted, rejected }
 }

--- a/src/agent/doctor.ts
+++ b/src/agent/doctor.ts
@@ -54,19 +54,27 @@ export async function runPluginDoctorFix(opts: RunPluginDoctorFixOptions): Promi
   const entry = opts.registry.doctorChecks.find((c) => checkId(c.pluginName, c.checkName) === opts.checkId)
   if (!entry) return { ok: false, error: `doctor check ${opts.checkId} is not registered` }
 
-  const ctx = buildPluginCtx(entry, opts.agentDir)
+  const checkController = new AbortController()
+  const checkCtx = buildPluginCtx(entry, opts.agentDir, checkController.signal)
   let result: PluginCheckResult
   try {
-    result = await raceWithTimeout(entry.check.run(ctx), opts.checkTimeoutMs ?? DEFAULT_CHECK_TIMEOUT_MS, 'check')
+    result = await raceWithTimeout(
+      entry.check.run(checkCtx),
+      opts.checkTimeoutMs ?? DEFAULT_CHECK_TIMEOUT_MS,
+      'check',
+      checkController,
+    )
   } catch (err) {
     return { ok: false, error: messageOf(err) }
   }
   const apply = result.fix?.apply
   if (!apply) return { ok: false, error: `${opts.checkId}: no auto-fix available` }
 
+  const fixController = new AbortController()
+  const fixCtx = buildPluginCtx(entry, opts.agentDir, fixController.signal)
   let fix: PluginFixResult
   try {
-    fix = await raceWithTimeout(apply(ctx), opts.fixTimeoutMs ?? DEFAULT_FIX_TIMEOUT_MS, 'fix')
+    fix = await raceWithTimeout(apply(fixCtx), opts.fixTimeoutMs ?? DEFAULT_FIX_TIMEOUT_MS, 'fix', fixController)
   } catch (err) {
     return { ok: false, error: messageOf(err) }
   }
@@ -86,9 +94,10 @@ async function runOneCheck(
   timeoutMs: number,
 ): Promise<PluginCheckRecord> {
   const id = checkId(entry.pluginName, entry.checkName)
-  const ctx = buildPluginCtx(entry, agentDir)
+  const controller = new AbortController()
+  const ctx = buildPluginCtx(entry, agentDir, controller.signal)
   try {
-    const result = await raceWithTimeout(entry.check.run(ctx), timeoutMs, 'check')
+    const result = await raceWithTimeout(entry.check.run(ctx), timeoutMs, 'check', controller)
     return buildRecord(entry, id, result)
   } catch (err) {
     return {
@@ -120,19 +129,28 @@ function buildRecord(entry: RegisteredDoctorCheck, id: string, result: PluginChe
   return record
 }
 
-function buildPluginCtx(entry: RegisteredDoctorCheck, agentDir: string): PluginDoctorContext {
+function buildPluginCtx(entry: RegisteredDoctorCheck, agentDir: string, signal: AbortSignal): PluginDoctorContext {
   return Object.freeze({
     pluginName: entry.pluginName,
     agentDir,
     config: entry.pluginConfig,
     logger: entry.logger,
+    signal,
   })
 }
 
-async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: 'check' | 'fix'): Promise<T> {
+async function raceWithTimeout<T>(
+  work: Promise<T>,
+  ms: number,
+  label: 'check' | 'fix',
+  controller: AbortController,
+): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | null = null
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`plugin doctor ${label} timed out after ${ms}ms`)), ms)
+    timer = setTimeout(() => {
+      controller.abort()
+      reject(new Error(`plugin doctor ${label} timed out after ${ms}ms`))
+    }, ms)
   })
   try {
     return await Promise.race([work, timeout])

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
-import { access, constants as fsConstants, mkdir, stat, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { access, constants as fsConstants, stat } from 'node:fs/promises'
+import { join } from 'node:path'
 
 import { CronExpressionParser } from 'cron-parser'
 import { z } from 'zod'
@@ -239,16 +239,9 @@ export default definePlugin({
             const abs = join(dctx.agentDir, rel)
             if (existsSync(abs)) return { status: 'ok', message: `${rel} present` }
             return {
-              status: 'warning',
+              status: 'info',
               message: `${rel} missing`,
-              fix: {
-                description: `Create empty ${rel} so memory-logger has a target.`,
-                apply: async () => {
-                  await mkdir(dirname(abs), { recursive: true })
-                  await writeFile(abs, '', 'utf8')
-                  return { summary: `created ${rel}`, changedPaths: [rel] }
-                },
-              },
+              details: ['memory-logger creates it on demand; this is informational only.'],
             }
           },
         },

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -45,8 +45,10 @@ export const doctorCommand = defineCommand({
 
 export function exitCodeFor(result: DoctorRunResult): number {
   const last = result.final ?? result.initial
-  if (last.ok) return 0
-  return 1
+  if (!last.ok) return 1
+  if (result.commit?.kind === 'failed') return 1
+  if (result.fixAttempts?.some((a) => a.ok === false)) return 1
+  return 0
 }
 
 function parseOnly(value: string | undefined): string[] | undefined {

--- a/src/compose/doctor.test.ts
+++ b/src/compose/doctor.test.ts
@@ -67,6 +67,25 @@ describe('composeDoctor', () => {
     expect(report.agents).toEqual([])
   })
 
+  test('reports ok=false when any agent has a failing internal check', async () => {
+    const root = makeTmpRoot()
+    makeAgent(root, 'alpha', { port: 8973 })
+    makeAgent(root, 'beta', { port: 9000 })
+
+    const report = await composeDoctor({
+      rootCwd: root,
+      runDoctorFn: async ({ cwd }) => {
+        const passing = passingResult(cwd as string)
+        if ((cwd as string).endsWith('/beta')) {
+          passing.initial.summary.error = 1
+          passing.initial.ok = false
+        }
+        return passing
+      },
+    })
+    expect(report.ok).toBe(false)
+  })
+
   test('runs per-agent doctor by default, skips it under --shallow', async () => {
     const root = makeTmpRoot()
     makeAgent(root, 'alpha', { port: 8973 })

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -115,16 +115,7 @@ function agentFolderRequiredDirs(): DoctorCheck {
         message: `${missing.length} required ${missing.length === 1 ? 'directory' : 'directories'} missing`,
         details: missing.map((d) => `missing: ${d}/`),
         fix: {
-          description: `Create the missing directories (${missing.map((d) => `${d}/`).join(', ')}).`,
-          autoFix: async () => {
-            for (const d of missing) {
-              mkdirSync(join(ctx.cwd, d), { recursive: true })
-            }
-            return {
-              summary: `created ${missing.map((d) => `${d}/`).join(', ')}`,
-              changedPaths: missing.map((d) => `${d}/`),
-            }
-          },
+          description: `Create the missing directories: ${missing.map((d) => `${d}/`).join(', ')}. Most are gitignored, so \`typeclaw doctor --fix\` does not auto-create them; \`typeclaw start\` will scaffold them on next run.`,
         },
       }
     },
@@ -146,16 +137,12 @@ function agentFolderDockerfileTemplate(): DoctorCheck {
       const actual = await safeRead(dockerfilePath)
       if (actual === expected) return { status: 'ok', message: 'Dockerfile matches template' }
       return {
-        status: 'warning',
+        status: 'info',
         message: actual === null ? 'Dockerfile missing' : 'Dockerfile diverges from template',
-        details: ['The Dockerfile is regenerated on every `typeclaw start`, so a divergent file will be overwritten.'],
-        fix: {
-          description: 'Regenerate the Dockerfile from the typeclaw template.',
-          autoFix: async () => {
-            await writeAtomic(dockerfilePath, expected)
-            return { summary: 'refreshed Dockerfile from template', changedPaths: [DOCKERFILE] }
-          },
-        },
+        details: [
+          'The Dockerfile is gitignored and regenerated on every `typeclaw start` from the template.',
+          'Run `typeclaw start --build` to refresh it now.',
+        ],
       }
     },
   }

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync } from 'node:fs'
+import { existsSync, mkdirSync, renameSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join, relative } from 'node:path'
@@ -405,7 +405,9 @@ async function safeRead(path: string): Promise<string | null> {
 }
 
 async function writeAtomic(path: string, content: string): Promise<void> {
-  await writeFile(path, content)
+  const tmp = `${path}.typeclaw-doctor.tmp`
+  await writeFile(tmp, content)
+  renameSync(tmp, path)
 }
 
 export function relativeToCwd(cwd: string, path: string): string {

--- a/src/doctor/commit.ts
+++ b/src/doctor/commit.ts
@@ -29,6 +29,14 @@ export async function commitAutoFixes(opts: CommitOptions): Promise<CommitOutcom
 
   const spawnGit = opts.spawnGit ?? defaultSpawnGit
 
+  const dirty = await spawnGit(['diff', '--cached', '--quiet'], opts.cwd)
+  if (dirty.exitCode !== 0) {
+    return {
+      kind: 'skipped',
+      reason: 'git index is not clean; refusing to mix doctor auto-fixes with unrelated staged changes',
+    }
+  }
+
   const add = await spawnGit(['add', '--', ...pathsStaged], opts.cwd)
   if (add.exitCode !== 0) {
     return { kind: 'failed', reason: `git add failed: ${add.stderr.trim() || `exit ${add.exitCode}`}` }

--- a/src/doctor/index.test.ts
+++ b/src/doctor/index.test.ts
@@ -260,6 +260,104 @@ test('report.entries preserves source distinction (static vs plugin)', async () 
   expect(sources).toEqual(['static', 'plugin'])
 })
 
+test('--only filter excludes static checks outside the allowlist', async () => {
+  const cwd = makeTmpAgentDir()
+  const result = await runDoctor({
+    cwd,
+    only: ['docker'],
+    staticChecks: [
+      { ...fakeCheck('docker.x', 'ok'), category: 'docker' },
+      { ...fakeCheck('config.x', 'warning'), category: 'config' },
+    ],
+    fetchPluginChecks: async () => ({ kind: 'ok', checks: [] }),
+  })
+  const names = result.initial.entries.map((e) => e.name)
+  expect(names).toEqual(['docker.x'])
+})
+
+test('--only filter keeps plugin checks when "plugin" is in the list', async () => {
+  const cwd = makeTmpAgentDir()
+  const result = await runDoctor({
+    cwd,
+    only: ['plugin'],
+    staticChecks: [{ ...fakeCheck('config.x', 'ok'), category: 'config' }],
+    fetchPluginChecks: async () => ({
+      kind: 'ok',
+      checks: [
+        {
+          id: 'm.y',
+          pluginName: 'm',
+          checkName: 'y',
+          description: 'y',
+          category: 'plugin:m',
+          status: 'ok',
+          message: 'ok',
+        },
+      ],
+    }),
+  })
+  const names = result.initial.entries.map((e) => e.name)
+  expect(names).toEqual(['y'])
+})
+
+test('records autoFix throws as a failed fix attempt and skips the commit', async () => {
+  const cwd = makeTmpAgentDir()
+  await initGitRepo(cwd)
+  const throwing: import('./types').DoctorCheck = {
+    name: 'throws',
+    category: 'config',
+    description: 'throws',
+    async run() {
+      return {
+        status: 'warning',
+        message: 'broken',
+        fix: {
+          description: 'will throw',
+          autoFix: async () => {
+            throw new Error('disk full')
+          },
+        },
+      }
+    },
+  }
+  const result = await runDoctor({
+    cwd,
+    fix: true,
+    staticChecks: [throwing],
+    fetchPluginChecks: async () => ({ kind: 'ok', checks: [] }),
+  })
+  expect(result.fixAttempts?.[0]).toMatchObject({ ok: false, name: 'throws', source: 'static' })
+  expect(result.commit?.kind).toBe('skipped')
+})
+
+test('skips commit when no fix produced any changedPaths', async () => {
+  const cwd = makeTmpAgentDir()
+  await initGitRepo(cwd)
+  const noPathFix: import('./types').DoctorCheck = {
+    name: 'no-paths',
+    category: 'config',
+    description: 'no paths',
+    async run() {
+      return {
+        status: 'warning',
+        message: 'x',
+        fix: {
+          description: 'no-op fix',
+          autoFix: async () => ({ summary: 'no-op', changedPaths: [] }),
+        },
+      }
+    },
+  }
+  const result = await runDoctor({
+    cwd,
+    fix: true,
+    staticChecks: [noPathFix],
+    fetchPluginChecks: async () => ({ kind: 'ok', checks: [] }),
+  })
+  expect(result.commit?.kind).toBe('skipped')
+  expect(result.commit?.kind === 'skipped' && result.commit.reason).toMatch(/no changed paths/)
+})
+
 test('refuses commit when git index already has unrelated staged changes', async () => {
   const cwd = makeTmpAgentDir()
   await initGitRepo(cwd)

--- a/src/doctor/index.test.ts
+++ b/src/doctor/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -236,7 +236,7 @@ test('buildCommitMessage formats subject + bullets', async () => {
   expect(msg).toContain('- [plugin] memory.daily-stream-current: created memory/2026-05-12.md')
 })
 
-test('readme example: report.entries preserves source distinction', async () => {
+test('report.entries preserves source distinction (static vs plugin)', async () => {
   const cwd = makeTmpAgentDir()
   const result = await runDoctor({
     cwd,
@@ -258,5 +258,17 @@ test('readme example: report.entries preserves source distinction', async () => 
   })
   const sources = result.initial.entries.map((e) => e.source)
   expect(sources).toEqual(['static', 'plugin'])
-  expect(readFileSync(join(cwd, 'typeclaw.json'), 'utf8')).toBeDefined()
+})
+
+test('reaches into agent folder when invoked from a subdir of the agent', async () => {
+  const cwd = makeTmpAgentDir()
+  const subdir = join(cwd, 'workspace')
+  mkdirSync(subdir, { recursive: true })
+  const result = await runDoctor({
+    cwd: subdir,
+    staticChecks: [fakeCheck('alpha', 'ok')],
+    fetchPluginChecks: async () => ({ kind: 'ok', checks: [] }),
+  })
+  expect(result.initial.hasAgentFolder).toBe(true)
+  expect(result.initial.cwd).toBe(cwd)
 })

--- a/src/doctor/index.test.ts
+++ b/src/doctor/index.test.ts
@@ -260,6 +260,26 @@ test('report.entries preserves source distinction (static vs plugin)', async () 
   expect(sources).toEqual(['static', 'plugin'])
 })
 
+test('refuses commit when git index already has unrelated staged changes', async () => {
+  const cwd = makeTmpAgentDir()
+  await initGitRepo(cwd)
+  writeFileSync(join(cwd, 'unrelated.txt'), 'user-staged change', 'utf8')
+  await run(['git', 'add', 'unrelated.txt'], cwd)
+
+  const result = await runDoctor({
+    cwd,
+    fix: true,
+    staticChecks: [fakeCheck('alpha', 'warning', { autoFix: true })],
+    fetchPluginChecks: async () => ({ kind: 'ok', checks: [] }),
+  })
+
+  expect(result.commit?.kind).toBe('skipped')
+  expect(result.commit?.kind === 'skipped' && result.commit.reason).toMatch(/index is not clean/)
+
+  const log = await run(['git', 'log', '--format=%s'], cwd)
+  expect(log.stdout.split('\n').filter(Boolean)).toEqual(['init'])
+})
+
 test('reaches into agent folder when invoked from a subdir of the agent', async () => {
   const cwd = makeTmpAgentDir()
   const subdir = join(cwd, 'workspace')

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -45,8 +45,10 @@ export type RunDoctorOptions = {
 }
 
 export async function runDoctor(opts: RunDoctorOptions = {}): Promise<DoctorRunResult> {
-  const cwd = opts.cwd ?? findAgentDir(process.cwd()) ?? process.cwd()
-  const hasAgentFolder = findAgentDir(cwd) === cwd
+  const startCwd = opts.cwd ?? process.cwd()
+  const agentDir = findAgentDir(startCwd)
+  const cwd = agentDir ?? startCwd
+  const hasAgentFolder = agentDir !== null
   const ctx: CheckContext = { cwd, hasAgentFolder }
 
   const staticChecks = (opts.staticChecks ?? buildStaticChecks()).filter((c) => isAllowed(c, opts.only, c.category))

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -272,16 +272,34 @@ async function runPluginFixes(
 
 // Defense in depth: even though the container-side runner sanitizes
 // changedPaths, re-validate on the host before `git add` so a future protocol
-// change cannot bypass the security boundary by accident.
+// change cannot bypass the security boundary by accident. The rules here MUST
+// stay identical to `sanitizeChangedPaths` in `src/agent/doctor.ts`.
 function sanitizeChangedPathsForHost(_cwd: string, paths: readonly string[]): string[] {
   const out: string[] = []
   for (const raw of paths) {
     if (typeof raw !== 'string' || raw.length === 0) continue
-    if (raw.startsWith('/') || raw.includes('\\')) continue
-    if (raw.split('/').includes('..')) continue
-    out.push(raw)
+    if (raw.includes('\0') || raw.includes('\\')) continue
+    if (raw.startsWith('/')) continue
+    const stripped = posixNormalize(raw).replace(/\/+$/, '')
+    if (stripped === '.' || stripped === '' || stripped.startsWith('..')) continue
+    if (stripped.split('/').includes('..')) continue
+    out.push(stripped)
   }
   return out
+}
+
+function posixNormalize(p: string): string {
+  const segments = p.split('/').filter((s) => s.length > 0 && s !== '.')
+  const stack: string[] = []
+  for (const seg of segments) {
+    if (seg === '..') {
+      if (stack.length === 0) return '..'
+      stack.pop()
+      continue
+    }
+    stack.push(seg)
+  }
+  return stack.join('/') || '.'
 }
 
 export type { Severity }

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -1,3 +1,7 @@
+import { join } from 'node:path'
+
+import lockfile from 'proper-lockfile'
+
 import { findAgentDir } from '@/init'
 import type { DoctorCheckPayload } from '@/shared'
 
@@ -63,20 +67,41 @@ export async function runDoctor(opts: RunDoctorOptions = {}): Promise<DoctorRunR
     return { initial }
   }
 
-  const fetchPluginFix = opts.fetchPluginFix ?? defaultFetchPluginDoctorFix
-  const attempts: FixAttempt[] = []
-  attempts.push(...(await runStaticFixes(staticResults, ctx)))
-  attempts.push(...(await runPluginFixes(pluginResults.entries, fetchPluginFix, ctx)))
+  const release = hasAgentFolder ? await acquireFixLock(cwd) : null
+  try {
+    const fetchPluginFix = opts.fetchPluginFix ?? defaultFetchPluginDoctorFix
+    const attempts: FixAttempt[] = []
+    attempts.push(...(await runStaticFixes(staticResults, ctx)))
+    attempts.push(...(await runPluginFixes(pluginResults.entries, fetchPluginFix, ctx)))
 
-  const commit = hasAgentFolder
-    ? await commitAutoFixes({ cwd, attempts, ...(opts.spawnGit !== undefined ? { spawnGit: opts.spawnGit } : {}) })
-    : { kind: 'skipped' as const, reason: 'no agent folder; nothing to commit' }
+    const commit = hasAgentFolder
+      ? await commitAutoFixes({
+          cwd,
+          attempts,
+          ...(opts.spawnGit !== undefined ? { spawnGit: opts.spawnGit } : {}),
+        })
+      : { kind: 'skipped' as const, reason: 'no agent folder; nothing to commit' }
 
-  const finalStaticResults = await runStaticChecks(staticChecks, ctx)
-  const finalPluginResults = await collectPluginChecks(fetchPluginChecks, ctx, opts.only)
-  const final = buildReport(ctx, finalStaticResults, finalPluginResults)
+    const finalStaticResults = await runStaticChecks(staticChecks, ctx)
+    const finalPluginResults = await collectPluginChecks(fetchPluginChecks, ctx, opts.only)
+    const final = buildReport(ctx, finalStaticResults, finalPluginResults)
 
-  return { initial, fixAttempts: attempts, commit, final }
+    return { initial, fixAttempts: attempts, commit, final }
+  } finally {
+    if (release !== null) {
+      try {
+        await release()
+      } catch {}
+    }
+  }
+}
+
+async function acquireFixLock(cwd: string): Promise<() => Promise<void>> {
+  const lockTarget = join(cwd, 'typeclaw.json')
+  return lockfile.lock(lockTarget, {
+    realpath: false,
+    retries: { retries: 5, factor: 2, minTimeout: 100, maxTimeout: 2000 },
+  })
 }
 
 type StaticResult = {

--- a/src/doctor/plugin-bridge.ts
+++ b/src/doctor/plugin-bridge.ts
@@ -88,9 +88,11 @@ async function dial(opts: PluginBridgeOptions): Promise<DialResult> {
   }
   const url = `${baseUrl.replace(/\/$/, '')}/doctor`
   const ws = new WebSocket(url)
+  let dialTimer: ReturnType<typeof setTimeout> | null = null
   try {
     await new Promise<void>((resolve, reject) => {
       const cleanup = () => {
+        if (dialTimer !== null) clearTimeout(dialTimer)
         ws.removeEventListener('open', onOpen)
         ws.removeEventListener('error', onError)
       }
@@ -102,6 +104,13 @@ async function dial(opts: PluginBridgeOptions): Promise<DialResult> {
         cleanup()
         reject(err instanceof Error ? err : new Error(`failed to connect to ${url}`))
       }
+      dialTimer = setTimeout(() => {
+        cleanup()
+        try {
+          ws.close()
+        } catch {}
+        reject(new Error(`dial timed out after ${timeoutMs}ms`))
+      }, timeoutMs)
       ws.addEventListener('open', onOpen, { once: true })
       ws.addEventListener('error', onError, { once: true })
     })

--- a/src/doctor/plugin-bridge.ts
+++ b/src/doctor/plugin-bridge.ts
@@ -36,6 +36,7 @@ export async function fetchPluginDoctorChecks(opts: PluginBridgeOptions): Promis
       requestId,
       (msg) => {
         if (msg.type === 'doctor_result' && msg.requestId === requestId) {
+          if (msg.error !== undefined) return { kind: 'error', reason: msg.error }
           return { kind: 'ok', checks: msg.checks }
         }
         return null
@@ -76,15 +77,16 @@ type DialResult = { kind: 'ok'; ws: WebSocket; timeoutMs: number } | { kind: 'un
 
 async function dial(opts: PluginBridgeOptions): Promise<DialResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
-  let url = opts.url
-  if (url === undefined) {
+  let baseUrl = opts.url
+  if (baseUrl === undefined) {
     try {
       const port = await resolveHostPort({ cwd: opts.cwd })
-      url = `ws://localhost:${port}`
+      baseUrl = `ws://localhost:${port}`
     } catch (err) {
       return { kind: 'unreachable', reason: err instanceof Error ? err.message : String(err) }
     }
   }
+  const url = `${baseUrl.replace(/\/$/, '')}/doctor`
   const ws = new WebSocket(url)
   try {
     await new Promise<void>((resolve, reject) => {
@@ -118,27 +120,31 @@ async function withRequest<R extends { kind: string }>(
 ): Promise<R | { kind: 'timeout' } | { kind: 'error'; reason: string }> {
   ws.send(JSON.stringify(outgoing))
   return new Promise((resolve) => {
-    const timer = setTimeout(() => {
+    const settle = (value: R | { kind: 'timeout' } | { kind: 'error'; reason: string }): void => {
+      clearTimeout(timer)
       ws.removeEventListener('message', onMessage)
-      resolve({ kind: 'timeout' })
-    }, timeoutMs)
-    const onMessage = (event: MessageEvent) => {
+      ws.removeEventListener('close', onClose)
+      ws.removeEventListener('error', onError)
+      resolve(value)
+    }
+    const timer = setTimeout(() => settle({ kind: 'timeout' }), timeoutMs)
+    const onMessage = (event: MessageEvent): void => {
       let msg: ServerMessage
       try {
         msg = JSON.parse(String(event.data)) as ServerMessage
       } catch (err) {
-        clearTimeout(timer)
-        ws.removeEventListener('message', onMessage)
-        resolve({ kind: 'error', reason: err instanceof Error ? err.message : String(err) })
+        settle({ kind: 'error', reason: err instanceof Error ? err.message : String(err) })
         return
       }
       const result = match(msg)
-      if (result === null) return
-      clearTimeout(timer)
-      ws.removeEventListener('message', onMessage)
-      resolve(result)
+      if (result !== null) settle(result)
     }
+    const onClose = (): void => settle({ kind: 'error', reason: 'doctor websocket closed before response' })
+    const onError = (err: unknown): void =>
+      settle({ kind: 'error', reason: err instanceof Error ? err.message : String(err) })
     ws.addEventListener('message', onMessage)
+    ws.addEventListener('close', onClose, { once: true })
+    ws.addEventListener('error', onError, { once: true })
   })
 }
 

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -183,6 +183,7 @@ export type PluginDoctorContext = {
   readonly agentDir: string
   readonly config: unknown
   readonly logger: PluginLogger
+  readonly signal: AbortSignal
 }
 
 export type PluginCheckStatus = 'ok' | 'warning' | 'error'

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -186,7 +186,7 @@ export type PluginDoctorContext = {
   readonly signal: AbortSignal
 }
 
-export type PluginCheckStatus = 'ok' | 'warning' | 'error'
+export type PluginCheckStatus = 'ok' | 'warning' | 'error' | 'info'
 
 export type PluginCheckResult = {
   status: PluginCheckStatus

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -993,3 +993,96 @@ describe('createServer scoped reload', () => {
     ws.close()
   })
 })
+
+describe('createServer doctor channel', () => {
+  test('/doctor path does not create an AgentSession or fire session hooks', async () => {
+    const session = createFakeSession()
+    let createCalls = 0
+    const built = createServer({
+      port: 0,
+      createSession: async () => {
+        createCalls++
+        return session
+      },
+    }).start()
+    server = built
+
+    const ws = new WebSocket(`ws://localhost:${built.port}/doctor`)
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener('open', () => resolve(), { once: true })
+      ws.addEventListener('error', (err) => reject(err), { once: true })
+    })
+
+    ws.send(JSON.stringify({ type: 'doctor', requestId: 'r1' }))
+    const reply = await new Promise<ServerMessage>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('timeout')), 1000)
+      ws.addEventListener(
+        'message',
+        (e) => {
+          clearTimeout(timer)
+          resolve(JSON.parse(String(e.data)) as ServerMessage)
+        },
+        { once: true },
+      )
+    })
+
+    expect(reply.type).toBe('doctor_result')
+    if (reply.type === 'doctor_result') {
+      expect(reply.requestId).toBe('r1')
+      expect(reply.checks).toEqual([])
+    }
+    expect(createCalls).toBe(0)
+    expect(session.disposeCalls).toBe(0)
+
+    ws.close()
+  })
+
+  test('/doctor returns checks from the plugin runtime', async () => {
+    const registry: PluginRegistry = {
+      tools: [],
+      subagents: [],
+      cronJobs: [],
+      skills: [],
+      skillsDirs: [],
+      doctorChecks: [
+        {
+          pluginName: 'memory',
+          checkName: 'ping',
+          pluginConfig: undefined,
+          logger: { info: () => {}, warn: () => {}, error: () => {} },
+          check: {
+            description: 'always ok',
+            run: async () => ({ status: 'ok', message: 'ok' }),
+          },
+        },
+      ],
+    }
+    const session = createFakeSession()
+    const { url } = await startWithSession(session, {
+      pluginRegistry: registry,
+      pluginHooks: (await import('@/plugin')).createHookBus(),
+      agentDir: '/agent',
+    })
+
+    const ws = new WebSocket(`${url}/doctor`)
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener('open', () => resolve(), { once: true })
+      ws.addEventListener('error', (err) => reject(err), { once: true })
+    })
+    ws.send(JSON.stringify({ type: 'doctor', requestId: 'r2' }))
+    const reply = await new Promise<ServerMessage>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('timeout')), 1000)
+      ws.addEventListener(
+        'message',
+        (e) => {
+          clearTimeout(timer)
+          resolve(JSON.parse(String(e.data)) as ServerMessage)
+        },
+        { once: true },
+      )
+    })
+    if (reply.type !== 'doctor_result') throw new Error('expected doctor_result')
+    expect(reply.checks.map((c) => c.id)).toEqual(['memory.ping'])
+    ws.close()
+  })
+})

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -41,7 +41,8 @@ export type ServerOptions = {
 export type Server = ReturnType<typeof createServer>
 
 type TuiWsData = { kind: 'tui'; sessionId: string }
-type WsData = TuiWsData | BrokerWsData
+type DoctorWsData = { kind: 'doctor' }
+type WsData = TuiWsData | DoctorWsData | BrokerWsData
 type Ws = ServerWebSocket<TuiWsData>
 
 type QueuedPrompt = {
@@ -97,6 +98,11 @@ export function createServer({
           if (server.upgrade(req, { data })) return
           return new Response('upgrade failed', { status: 400 })
         }
+        if (url.pathname === '/doctor') {
+          const data: DoctorWsData = { kind: 'doctor' }
+          if (server.upgrade(req, { data })) return
+          return new Response('upgrade failed', { status: 400 })
+        }
         const sessionId = crypto.randomUUID()
         const data: TuiWsData = { kind: 'tui', sessionId }
         if (server.upgrade(req, { data })) return
@@ -106,6 +112,9 @@ export function createServer({
         async open(rawWs) {
           if (rawWs.data.kind === 'portbroker') {
             containerBroker?.open(rawWs as ServerWebSocket<BrokerWsData>)
+            return
+          }
+          if (rawWs.data.kind === 'doctor') {
             return
           }
           const ws = rawWs as Ws
@@ -182,22 +191,19 @@ export function createServer({
             await containerBroker?.message(rawWs as ServerWebSocket<BrokerWsData>, raw as string | Buffer)
             return
           }
+          if (rawWs.data.kind === 'doctor') {
+            await handleDoctorMessage(rawWs as ServerWebSocket<DoctorWsData>, raw as string | Buffer, {
+              pluginRuntime,
+              agentDir,
+            })
+            return
+          }
           const ws = rawWs as Ws
           const msg = JSON.parse(String(raw)) as ClientMessage
           const state = sessionStates.get(ws)
 
           if (msg.type === 'reload') {
             await handleReload(ws, reloadAll, reloadRegistry, msg.scope)
-            return
-          }
-
-          if (msg.type === 'doctor') {
-            await handleDoctor(ws, msg.requestId, pluginRuntime, agentDir)
-            return
-          }
-
-          if (msg.type === 'doctor_fix') {
-            await handleDoctorFix(ws, msg.requestId, msg.checkId, pluginRuntime, agentDir)
             return
           }
 
@@ -246,6 +252,9 @@ export function createServer({
         async close(rawWs) {
           if (rawWs.data.kind === 'portbroker') {
             containerBroker?.close(rawWs as ServerWebSocket<BrokerWsData>)
+            return
+          }
+          if (rawWs.data.kind === 'doctor') {
             return
           }
           const ws = rawWs as Ws
@@ -404,38 +413,66 @@ function pushQueueState(ws: Ws, state: SessionState): void {
   send(ws, { type: 'queue_state', pending })
 }
 
-async function handleDoctor(
-  ws: Ws,
-  requestId: string,
-  pluginRuntime: PluginRuntime | undefined,
-  agentDir: string | undefined,
-): Promise<void> {
+type DoctorWs = ServerWebSocket<DoctorWsData>
+type DoctorMessageDeps = { pluginRuntime: PluginRuntime | undefined; agentDir: string | undefined }
+
+function sendDoctor(ws: DoctorWs, msg: ServerMessage): void {
+  ws.send(JSON.stringify(msg))
+}
+
+async function handleDoctorMessage(ws: DoctorWs, raw: string | Buffer, deps: DoctorMessageDeps): Promise<void> {
+  let msg: ClientMessage
+  try {
+    msg = JSON.parse(String(raw)) as ClientMessage
+  } catch (err) {
+    sendDoctor(ws, { type: 'error', message: err instanceof Error ? err.message : String(err) })
+    return
+  }
+
+  if (msg.type === 'doctor') {
+    await runDoctorRequest(ws, msg.requestId, deps)
+    return
+  }
+  if (msg.type === 'doctor_fix') {
+    await runDoctorFixRequest(ws, msg.requestId, msg.checkId, deps)
+    return
+  }
+  sendDoctor(ws, { type: 'error', message: `doctor channel: unsupported message type ${msg.type}` })
+}
+
+async function runDoctorRequest(ws: DoctorWs, requestId: string, deps: DoctorMessageDeps): Promise<void> {
+  const { pluginRuntime, agentDir } = deps
   if (pluginRuntime === undefined || agentDir === undefined) {
-    send(ws, { type: 'doctor_result', requestId, checks: [] })
+    sendDoctor(ws, { type: 'doctor_result', requestId, checks: [] })
     return
   }
   const snapshot = pluginRuntime.get()
   if (snapshot === undefined) {
-    send(ws, { type: 'doctor_result', requestId, checks: [] })
+    sendDoctor(ws, { type: 'doctor_result', requestId, checks: [] })
     return
   }
   try {
     const checks = await runPluginDoctorChecks({ registry: snapshot.registry, agentDir })
-    send(ws, { type: 'doctor_result', requestId, checks })
+    sendDoctor(ws, { type: 'doctor_result', requestId, checks })
   } catch (err) {
-    send(ws, { type: 'error', message: err instanceof Error ? err.message : String(err) })
+    sendDoctor(ws, {
+      type: 'doctor_result',
+      requestId,
+      checks: [],
+      error: err instanceof Error ? err.message : String(err),
+    })
   }
 }
 
-async function handleDoctorFix(
-  ws: Ws,
+async function runDoctorFixRequest(
+  ws: DoctorWs,
   requestId: string,
   checkId: string,
-  pluginRuntime: PluginRuntime | undefined,
-  agentDir: string | undefined,
+  deps: DoctorMessageDeps,
 ): Promise<void> {
+  const { pluginRuntime, agentDir } = deps
   if (pluginRuntime === undefined || agentDir === undefined) {
-    send(ws, {
+    sendDoctor(ws, {
       type: 'doctor_fix_result',
       requestId,
       result: { ok: false, checkId, error: 'plugin runtime not configured' },
@@ -444,7 +481,7 @@ async function handleDoctorFix(
   }
   const snapshot = pluginRuntime.get()
   if (snapshot === undefined) {
-    send(ws, {
+    sendDoctor(ws, {
       type: 'doctor_fix_result',
       requestId,
       result: { ok: false, checkId, error: 'plugin runtime not configured' },
@@ -456,7 +493,7 @@ async function handleDoctorFix(
     outcome.ok === true
       ? { ok: true as const, checkId, summary: outcome.summary, changedPaths: outcome.changedPaths }
       : { ok: false as const, checkId, error: outcome.error }
-  send(ws, { type: 'doctor_fix_result', requestId, result })
+  sendDoctor(ws, { type: 'doctor_fix_result', requestId, result })
 }
 
 async function handleReload(

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -43,5 +43,5 @@ export type ServerMessage =
   | { type: 'notification'; payload: unknown; replyTo?: string; meta?: Record<string, string> }
   | { type: 'queue_state'; pending: QueueStateItem[] }
   | { type: 'prompt_started'; messageId: string; text: string }
-  | { type: 'doctor_result'; requestId: DoctorRequestId; checks: DoctorCheckPayload[] }
+  | { type: 'doctor_result'; requestId: DoctorRequestId; checks: DoctorCheckPayload[]; error?: string }
   | { type: 'doctor_fix_result'; requestId: DoctorRequestId; result: DoctorFixPayload }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -12,7 +12,7 @@ export type DoctorCheckPayload = {
   checkName: string
   description: string
   category: string
-  status: 'ok' | 'warning' | 'error'
+  status: 'ok' | 'warning' | 'error' | 'info'
   message: string
   details?: string[]
   fix?: { description: string; hasApply: boolean }

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -160,6 +160,9 @@ export function createTui({
           updateQueuePanel(msg.pending)
           break
         }
+        default: {
+          break
+        }
       }
     })
 


### PR DESCRIPTION
## Summary

Self-review follow-up to #144. Three review passes (design/security, coverage gaps, test quality) surfaced 4 ship-blockers and 8 important issues in the `typeclaw doctor` / `compose doctor` implementation. This PR fixes all 12.

> **Stacked on #144.** Review and merge #144 first; this PR's base is `feat/doctor` and must be rebased/merged after #144 lands.

## Ship-blockers fixed

### B1 — WS isolation broken

Doctor requests piggybacked on the TUI `/` WebSocket path. Every `typeclaw doctor` call created an `AgentSession`, fired `session.start` / `session.end` hooks, and — via the memory plugin — spawned `memory-logger` subagents on every probe. Doctor now lives on a dedicated `/doctor` WS path with its own dispatcher; no `AgentSession` is created and no hooks fire. Verified by a new server-level test asserting that `/doctor` upgrade traffic never triggers session lifecycle events.

### B2 — `--fix` silently captured user's staged changes

`git commit` ran unconditionally. If the user had unrelated staged changes, `doctor --fix` silently included them in the auto-fix commit. `doctor/commit.ts` now runs `git diff --cached --quiet` first and refuses to commit when the index is dirty, leaving the user's staged changes untouched.

### B3 — Path sanitizers inconsistent and incomplete

The container-side (`src/agent/doctor.ts`) and host-side (`src/doctor/index.ts`) sanitizers diverged and both accepted `.`, `foo/..`, null bytes, and Windows backslashes. A malicious or buggy plugin returning `.` would have caused `git add -- .` to stage the entire repo. Both ends now share identical strict rules: reject absolute paths, null bytes, backslashes, and any path whose normalized form contains a `..` segment or collapses to `.`. Path-collapsing (`foo/bar/../baz` → `foo/baz`) is accepted. Sanitizer mutation tests cover every rejection vector on both ends.

### B4 — Auto-fix wrote gitignored / managed files

The Dockerfile-template fix and the memory plugin's daily-stream fix wrote files that `.gitignore` excludes — `git add` would error out and the fix would appear to succeed while nothing actually changed. The Dockerfile fix is now advisory-only ("run `typeclaw start --build`"); the memory plugin's daily-stream check is informational-only with no `fix.apply`.

## Important fixes

- **I1 — Exit code reflects fix failures.** `--fix` exits 1 when any fix attempt throws or `git commit` fails, even if subsequent checks somehow report passing.
- **I2 — WS dial is timeout-bounded.** The plugin bridge previously applied its timeout only to request-response, leaving the connect phase unbounded. Timeout now covers the full dial.
- **I3 — Doctor errors carry `requestId`.** The host bridge resolves immediately on container error / close rather than hanging until the full timeout when the container sends an error response.
- **I4 — `PluginDoctorContext` gains `signal: AbortSignal`.** Timed-out plugin checks and fixes receive an aborted signal so they can stop background work instead of leaking.
- **I5 — Per-agent lock around `--fix`.** `proper-lockfile` wraps the auto-fix+commit path, preventing two concurrent `doctor --fix` runs in the same agent folder from interleaving writes and commits.
- **I6 — `findAgentDir` consistency.** The `findAgentDir(cwd) === cwd` idiom was unprecedented. Doctor now reaches into the agent folder when invoked from a subdirectory, matching every other CLI command.
- **I7 — `writeAtomic` is actually atomic.** Was a misnamed `writeFile`. Now uses temp + rename.
- **I8 — TUI `switch` gets a `default:` branch.** Closes a non-exhaustive switch on `msg.type` so future protocol additions can't silently slip through without a handler.

## Tests

10 new tests (2662 total, up from 2652):

- Sanitizer mutation tests: `.`, `foo/..`, null bytes, backslashes, empty strings, absolute paths — both container and host ends.
- Path collapsing: `foo/bar/../baz` → `foo/baz` accepted.
- Abort signal propagates correctly on timeout.
- `--only` filtering for both static and plugin checks.
- `autoFix` throws → reported as failed attempt, no crash.
- Empty `changedPaths` from a successful fix → commit skipped with documented reason.
- Dirty git index → commit refused, user's staged changes untouched.
- Doctor invoked from a subdirectory → reaches into agent folder.
- `compose doctor` with a failing agent → `ok: false`.
- Server-level test: `/doctor` WS path never creates an `AgentSession` and never fires session hooks.

## Files

15 modified, 0 new:

```
src/agent/doctor.ts
src/agent/doctor.test.ts
src/bundled-plugins/memory/index.ts
src/cli/doctor.ts
src/compose/doctor.test.ts
src/doctor/checks.ts
src/doctor/commit.ts
src/doctor/index.ts
src/doctor/index.test.ts
src/doctor/plugin-bridge.ts
src/plugin/types.ts
src/server/index.ts
src/server/index.test.ts
src/shared/protocol.ts
src/tui/index.ts
```

## Verification

- `bun run typecheck` ✓
- `bun run lint` ✓ (0 warnings, 0 errors)
- `bun run format` ✓ (no changes)
- `bun test` ✓ (2662 pass, 0 fail, 160 files)