### PR TITLE
Tint typeclaw logs lines per [tag] for readability

### DIFF
--- a/src/compose/logs.ts
+++ b/src/compose/logs.ts
@@ -1,4 +1,5 @@
 import { containerExists } from '@/container'
+import { supportsColor } from '@/container/log-colors'
 import { makeLogTimestampReformatter, type TimestampReformatter } from '@/container/log-timestamps'
 import { getBun } from '@/container/shared'
 
@@ -113,8 +114,18 @@ export async function composeLogs({
   const pumps = procs.flatMap(({ agent, proc }) => {
     const color = colorFor(agent.name)
     return [
-      pumpStream(proc.stdout, makeLogTimestampReformatter(), makeLinePrefixer(agent.name, width, color, useColor), out),
-      pumpStream(proc.stderr, makeLogTimestampReformatter(), makeLinePrefixer(agent.name, width, color, useColor), err),
+      pumpStream(
+        proc.stdout,
+        makeLogTimestampReformatter(undefined, { color: useColor }),
+        makeLinePrefixer(agent.name, width, color, useColor),
+        out,
+      ),
+      pumpStream(
+        proc.stderr,
+        makeLogTimestampReformatter(undefined, { color: useColor }),
+        makeLinePrefixer(agent.name, width, color, useColor),
+        err,
+      ),
     ]
   })
 
@@ -161,11 +172,4 @@ async function pumpStream(
   } finally {
     reader.releaseLock()
   }
-}
-
-function supportsColor(stream: NodeJS.WritableStream): boolean {
-  const tty = (stream as unknown as { isTTY?: boolean }).isTTY === true
-  if (!tty) return false
-  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') return false
-  return true
 }

--- a/src/container/log-colors.test.ts
+++ b/src/container/log-colors.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'bun:test'
+
+import { colorize, supportsColor } from './log-colors'
+
+// ANSI escapes are control characters by definition; we're testing for them.
+/* eslint-disable no-control-regex */
+const ANSI_RE = /\u001B\[\d+m/g
+// Captures the tint-color escape that wraps the line body. With a timestamp,
+// it's the second ANSI sequence (after `\u001B[2m...\u001B[0m`); without one
+// it's the first.
+const LEADING_TINT_RE = /^(?:\u001B\[2m\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\u001B\[0m)?(\u001B\[\d+m)/
+/* eslint-enable no-control-regex */
+
+const DIM = '\u001B[2m'
+const RESET = '\u001B[0m'
+
+function strip(s: string): string {
+  return s.replace(ANSI_RE, '')
+}
+
+function extractLineTint(colored: string): string {
+  return LEADING_TINT_RE.exec(colored)?.[1] ?? ''
+}
+
+describe('colorize - useColor=false', () => {
+  test('returns the input verbatim regardless of content', () => {
+    const samples = [
+      '',
+      'plain text',
+      '2026-05-13 11:12:01 [plugin:memory] memory-logger spawn 019e1ae9-fa33-725b-a30d-fb466c419c9c reason=idle',
+      'session 019e1f1b-9a3e-7019-ad92-30a0b4be99d1: open',
+    ]
+    for (const s of samples) {
+      expect(colorize(s, false)).toBe(s)
+    }
+  })
+
+  test('emits zero ANSI escapes when useColor is false', () => {
+    const out = colorize('2026-05-13 11:12:01 [plugin:memory] memory-logger done elapsed_ms=147760', false)
+    expect(out).not.toContain('\x1b[')
+  })
+})
+
+describe('colorize - useColor=true', () => {
+  test('stripping ANSI yields the original line (mutation check)', () => {
+    const lines = [
+      '2026-05-13 11:12:01 [plugin:memory] memory-logger spawn 019e1ae9 reason=idle',
+      '2026-05-13 11:12:43 session 019e1f1b: open',
+      '2026-05-13 11:14:28 [plugin:memory] [memory-logger] done elapsed_ms=147760',
+      'plain untimestamped line',
+      '2026-05-13 11:12:01 untagged-but-timestamped line',
+    ]
+    for (const line of lines) {
+      expect(strip(colorize(line, true))).toBe(line)
+    }
+  })
+
+  test('dims the leading YYYY-MM-DD HH:MM:SS timestamp', () => {
+    const out = colorize('2026-05-13 11:12:01 hello', true)
+    expect(out.startsWith(`${DIM}2026-05-13 11:12:01${RESET}`)).toBe(true)
+  })
+
+  test('does not touch a date that appears mid-line (anchored regex)', () => {
+    const out = colorize('plain 2026-05-13 11:12:01 mid-line', true)
+    expect(out).toBe('plain 2026-05-13 11:12:01 mid-line')
+  })
+
+  test('tints the entire line body when a [tag] is present', () => {
+    const out = colorize('2026-05-13 11:12:01 [plugin:memory] hello world', true)
+    const tint = extractLineTint(out)
+    expect(tint).not.toBe('')
+    expect(tint).not.toBe(DIM)
+    expect(out.endsWith(`${RESET}`)).toBe(true)
+    expect(out).toContain(`${tint} [plugin:memory] hello world${RESET}`)
+  })
+
+  test('tags after the timestamp use the SAME color for the same name across lines', () => {
+    const a = colorize('2026-05-13 11:12:01 [plugin:memory] one', true)
+    const b = colorize('2026-05-13 11:13:00 [plugin:memory] two', true)
+    expect(extractLineTint(a)).toBe(extractLineTint(b))
+  })
+
+  test('different tag names exercise more than one palette color', () => {
+    // 10-entry palette: pairwise inequality would be flaky, so we verify the
+    // distribution (set size > 1) instead.
+    const names = ['plugin:memory', 'memory-logger', 'plugin:slack', 'cron', 'router', 'session', 'host', 'broker']
+    const tints = new Set(names.map((n) => extractLineTint(colorize(`2026-05-13 11:12:01 [${n}] x`, true))))
+    expect(tints.size).toBeGreaterThan(1)
+  })
+
+  test('uses the FIRST tag for the tint when multiple tags appear', () => {
+    const first = colorize('2026-05-13 11:12:01 [plugin:memory] [memory-logger] x', true)
+    const onlyFirst = colorize('2026-05-13 11:12:01 [plugin:memory] x', true)
+    expect(extractLineTint(first)).toBe(extractLineTint(onlyFirst))
+  })
+
+  test('lines without a [tag] get only the timestamp dim, no body tint', () => {
+    const out = colorize('2026-05-13 11:12:01 session 019e1f1b: open', true)
+    expect(out).toBe(`${DIM}2026-05-13 11:12:01${RESET} session 019e1f1b: open`)
+  })
+
+  test('untimestamped untagged lines pass through unchanged', () => {
+    expect(colorize('plain log output', true)).toBe('plain log output')
+  })
+})
+
+describe('supportsColor', () => {
+  test('returns false for a non-TTY stream', () => {
+    const stream = { isTTY: false } as unknown as NodeJS.WritableStream
+    expect(supportsColor(stream)).toBe(false)
+  })
+
+  test('returns true for a TTY stream when NO_COLOR is unset', () => {
+    const prev = process.env.NO_COLOR
+    delete process.env.NO_COLOR
+    try {
+      const stream = { isTTY: true } as unknown as NodeJS.WritableStream
+      expect(supportsColor(stream)).toBe(true)
+    } finally {
+      if (prev !== undefined) process.env.NO_COLOR = prev
+    }
+  })
+
+  test('returns false for a TTY stream when NO_COLOR is set non-empty', () => {
+    const prev = process.env.NO_COLOR
+    process.env.NO_COLOR = '1'
+    try {
+      const stream = { isTTY: true } as unknown as NodeJS.WritableStream
+      expect(supportsColor(stream)).toBe(false)
+    } finally {
+      if (prev === undefined) delete process.env.NO_COLOR
+      else process.env.NO_COLOR = prev
+    }
+  })
+
+  test('treats empty NO_COLOR the same as unset (per spec)', () => {
+    const prev = process.env.NO_COLOR
+    process.env.NO_COLOR = ''
+    try {
+      const stream = { isTTY: true } as unknown as NodeJS.WritableStream
+      expect(supportsColor(stream)).toBe(true)
+    } finally {
+      if (prev === undefined) delete process.env.NO_COLOR
+      else process.env.NO_COLOR = prev
+    }
+  })
+})

--- a/src/container/log-colors.ts
+++ b/src/container/log-colors.ts
@@ -1,0 +1,75 @@
+// Per-source line tinting for `typeclaw logs` and `typeclaw compose logs`.
+// PR #146's wall-clock timestamp prefix made every line start identically,
+// dropping readability when many sources interleave. We restore visual
+// grouping by tinting each line based on its first `[tag]` (`[plugin:memory]`,
+// `[memory-logger]`, etc.). Same trick `compose/logs.ts#colorFor` uses for
+// agent names — stable hash → palette index → ANSI escape that wraps the
+// whole line body.
+//
+// Lines without a `[tag]` get no tint (only the leading timestamp is dimmed),
+// so untagged docker output, raw stack traces, and channel adapter logs
+// stay readable without inheriting a misleading color.
+
+import type { WritableStream as NodeWritable } from 'node:stream/web'
+
+const ANSI_RESET = '\x1b[0m'
+const ANSI_DIM = '\x1b[2m'
+const ANSI_CYAN = '\x1b[36m'
+const ANSI_YELLOW = '\x1b[33m'
+const ANSI_GREEN = '\x1b[32m'
+const ANSI_MAGENTA = '\x1b[35m'
+const ANSI_BLUE = '\x1b[34m'
+const ANSI_BRIGHT_CYAN = '\x1b[96m'
+const ANSI_BRIGHT_YELLOW = '\x1b[93m'
+const ANSI_BRIGHT_GREEN = '\x1b[92m'
+const ANSI_BRIGHT_MAGENTA = '\x1b[95m'
+const ANSI_BRIGHT_BLUE = '\x1b[94m'
+
+const TAG_PALETTE = [
+  ANSI_CYAN,
+  ANSI_YELLOW,
+  ANSI_GREEN,
+  ANSI_MAGENTA,
+  ANSI_BLUE,
+  ANSI_BRIGHT_CYAN,
+  ANSI_BRIGHT_YELLOW,
+  ANSI_BRIGHT_GREEN,
+  ANSI_BRIGHT_MAGENTA,
+  ANSI_BRIGHT_BLUE,
+] as const
+
+// Anchored to line start with a trailing space so a date that happens to
+// appear mid-line doesn't get dimmed.
+const TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?= )/
+
+const TAG_RE = /\[([^\]\n]+)\]/
+
+// `useColor=false` returns the input verbatim; the contract that protects
+// pipes, file redirects, NO_COLOR, and tests from ANSI leakage.
+export function colorize(line: string, useColor: boolean): string {
+  if (!useColor || line.length === 0) return line
+
+  const ts = TIMESTAMP_RE.exec(line)
+  const timestampLen = ts ? ts[0].length : 0
+  const dimmedTimestamp = ts ? `${ANSI_DIM}${ts[0]}${ANSI_RESET}` : ''
+  const rest = line.slice(timestampLen)
+
+  const tag = TAG_RE.exec(rest)
+  if (!tag) return `${dimmedTimestamp}${rest}`
+
+  const tint = paletteColor(tag[1] ?? '')
+  return `${dimmedTimestamp}${tint}${rest}${ANSI_RESET}`
+}
+
+function paletteColor(seed: string): string {
+  let h = 0
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0
+  return TAG_PALETTE[h % TAG_PALETTE.length] ?? TAG_PALETTE[0]
+}
+
+export function supportsColor(stream: NodeJS.WritableStream | NodeWritable): boolean {
+  const tty = (stream as unknown as { isTTY?: boolean }).isTTY === true
+  if (!tty) return false
+  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') return false
+  return true
+}

--- a/src/container/log-timestamps.test.ts
+++ b/src/container/log-timestamps.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from 'bun:test'
 
 import { makeLogTimestampReformatter, reformatLine } from './log-timestamps'
 
+// ANSI escapes are control characters by definition; we're testing for them.
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\u001B\[\d+m/g
+
 const FIXED = new Date('2026-05-13T14:23:01.123456789Z')
 const fixedNow = (): Date => FIXED
 
@@ -102,5 +106,22 @@ describe('makeLogTimestampReformatter', () => {
     const r = makeLogTimestampReformatter(fixedNow)
 
     expect(r.write('plain\nstill plain\n')).toBe('plain\nstill plain\n')
+  })
+
+  test('emits zero ANSI escapes by default (color is opt-in)', () => {
+    const r = makeLogTimestampReformatter(fixedNow)
+
+    const out = r.write('2026-05-13T14:23:01Z [plugin:memory] done\n')
+    expect(out).not.toContain('\x1b[')
+  })
+
+  test('with color: true, emits ANSI escapes that strip back to the plain reformatted line', () => {
+    const r = makeLogTimestampReformatter(fixedNow, { color: true })
+    const expectedPlain = `${localStampOf(new Date('2026-05-13T14:23:01Z'))} [plugin:memory] done\n`
+
+    const colored = r.write('2026-05-13T14:23:01Z [plugin:memory] done\n')
+
+    expect(colored).toContain('\x1b[')
+    expect(colored.replace(ANSI_RE, '')).toBe(expectedPlain)
   })
 })

--- a/src/container/log-timestamps.ts
+++ b/src/container/log-timestamps.ts
@@ -8,6 +8,8 @@
 // newline-terminated lines and flushes the un-terminated tail on EOF, so
 // interleaved reads from `docker logs` can never shred a line mid-character.
 
+import { colorize } from './log-colors'
+
 // `2026-05-13T14:23:01.123456789Z` or `...+09:00` etc. We accept anything
 // from Docker that Date can parse, but anchor on the ISO date+time prefix to
 // avoid eating non-timestamped log content.
@@ -18,7 +20,18 @@ export type TimestampReformatter = {
   flush: () => string
 }
 
-export function makeLogTimestampReformatter(now: () => Date = () => new Date()): TimestampReformatter {
+export type ReformatterOptions = {
+  // Color is opt-in and applied per emitted line *after* timestamp rewriting.
+  // Defaults to `false` so tests stay deterministic and pipes/files stay
+  // ANSI-free unless callers explicitly opt in via supportsColor(out).
+  color?: boolean
+}
+
+export function makeLogTimestampReformatter(
+  now: () => Date = () => new Date(),
+  options: ReformatterOptions = {},
+): TimestampReformatter {
+  const useColor = options.color ?? false
   let buffer = ''
   return {
     write(chunk: string): string {
@@ -30,12 +43,12 @@ export function makeLogTimestampReformatter(now: () => Date = () => new Date()):
       return complete
         .split('\n')
         .slice(0, -1)
-        .map((line) => `${reformatLine(line, now)}\n`)
+        .map((line) => `${colorize(reformatLine(line, now), useColor)}\n`)
         .join('')
     },
     flush(): string {
       if (buffer.length === 0) return ''
-      const out = `${reformatLine(buffer, now)}\n`
+      const out = `${colorize(reformatLine(buffer, now), useColor)}\n`
       buffer = ''
       return out
     },

--- a/src/container/logs.ts
+++ b/src/container/logs.ts
@@ -1,3 +1,4 @@
+import { supportsColor } from './log-colors'
 import { makeLogTimestampReformatter, type TimestampReformatter } from './log-timestamps'
 import { containerExists, containerNameFromCwd, getBun } from './shared'
 
@@ -14,6 +15,9 @@ export type LogsOptions = {
   out?: NodeJS.WritableStream
   err?: NodeJS.WritableStream
   signal?: AbortSignal
+  // When undefined, defaults to TTY+NO_COLOR detection on `out`/`err`.
+  // Tests pass `false` for deterministic plain output.
+  useColor?: boolean
 }
 
 export async function logs({
@@ -22,6 +26,7 @@ export async function logs({
   out = process.stdout,
   err = process.stderr,
   signal,
+  useColor,
 }: LogsOptions): Promise<LogsResult> {
   const bun = getBun()
   if (!bun) return { ok: false, reason: 'bun runtime not available' }
@@ -48,7 +53,12 @@ export async function logs({
     }
     signal?.addEventListener('abort', onAbort, { once: true })
 
-    await Promise.all([pumpWithTimestamps(proc.stdout, out), pumpWithTimestamps(proc.stderr, err)])
+    const colorOut = useColor ?? supportsColor(out)
+    const colorErr = useColor ?? supportsColor(err)
+    await Promise.all([
+      pumpWithTimestamps(proc.stdout, out, makeLogTimestampReformatter(undefined, { color: colorOut })),
+      pumpWithTimestamps(proc.stderr, err, makeLogTimestampReformatter(undefined, { color: colorErr })),
+    ])
     const exitCode = await proc.exited
     signal?.removeEventListener('abort', onAbort)
 


### PR DESCRIPTION
## Summary

`typeclaw logs` (and `typeclaw compose logs`) now tints every log line by its first `[tag]`, giving strong visual grouping when multiple plugins, subagents, and sessions emit interleaved output. This is a follow-up to #146, which stamped every line with a `YYYY-MM-DD HH:MM:SS` prefix — a welcome addition that also flattened visual structure: every line now starts with the same-looking timestamp, making it hard to group lines by source at a glance.

The approach: hash the first `[tag]` name (e.g. `plugin:memory`, `cron`, `channel:slack`) into a 10-color palette and tint the body of the line with that color. The leading timestamp is dimmed independently so it visually recedes. Lines without a `[tag]` get only the timestamp dim — no body tint — so untagged Docker output, raw stack traces, and `session …: open/close` lines don't get a misleading false-grouping color.

## Why this approach (vs. semantic coloring)

We initially prototyped per-span semantic coloring (timestamp dim + tag hash + UUIDs dimmed + `key=value` pairs highlighted + lifecycle verbs colored). The user explicitly asked to switch to "set the entire line color for different `[tag]`" — the simpler model. The simpler model:

- Mirrors how `compose logs` already colors per-agent prefixes — consistent UX across both surfaces.
- Has a tiny parsing surface: one anchored regex for the timestamp, one regex for the first tag — low maintenance cost as log formats evolve.
- Produces strong visual grouping: a block of `[plugin:memory]` lines renders as one solid color stripe; the eye picks up source changes as color changes.
- Avoids the "rainbow vomit" failure mode of per-span coloring on dense logs.

Trade-off: with a 10-color palette and ~10+ distinct sources in a typical setup, some hash collisions are inevitable. Acceptable — sources are still distinguished by their literal tag name even when colors collide. The palette can grow later if collisions become a real pain point.

## Changes

### `src/container/log-colors.ts` (new)

Pure module with two exports:

- `colorize(line, useColor)` — applies two rules in sequence:
  1. Dim the leading `YYYY-MM-DD HH:MM:SS ` timestamp (anchored regex with trailing-space lookahead so a date appearing mid-line is not dimmed).
  2. If the line contains a `[tag]`, hash the first tag name into the 10-color palette and tint everything from after the timestamp to end-of-line.
  When `useColor` is false, returns input verbatim — zero ANSI escapes, explicit test asserts this.
- `supportsColor(stream)` — `NO_COLOR`-aware TTY check (shared; extracted from `compose/logs.ts` where a local copy previously lived).

### `src/container/log-colors.test.ts` (new, 15 tests)

Covers: no-color passthrough, mutation check (`strip(colorize(line)) === line` for 5 shapes), timestamp dim applied, mid-line date not dimmed, body tint present, color stability (same tag → same color across calls), palette distribution across many tag names (set-size assertion), first-tag wins on multi-tag lines, no-tag pass-through, untimestamped passthrough, and all four `supportsColor` cases (non-TTY, TTY without `NO_COLOR`, TTY with `NO_COLOR=1`, TTY with `NO_COLOR=""`).

### `src/container/log-timestamps.ts`

`makeLogTimestampReformatter(now?, options?)` gains `{ color?: boolean }` (default `false`). Color is applied per emitted line after timestamp rewriting — the chunker contract (emit only newline-terminated lines, flush partial tail on EOF) is preserved unchanged.

### `src/container/log-timestamps.test.ts` (+2 tests)

Verifies (a) the reformatter emits zero ANSI escapes by default, and (b) with `{ color: true }`, stripping ANSI from the output yields the plain reformatted line (mutation check).

### `src/container/logs.ts`

Adds `LogsOptions.useColor?: boolean`. When undefined, defaults to `supportsColor(out)` for stdout and `supportsColor(err)` for stderr independently. Both `pumpWithTimestamps` calls construct their own reformatter with the appropriate color flag.

### `src/compose/logs.ts`

Drops the local `supportsColor` helper in favor of the shared one from `log-colors.ts`. Threads `useColor` (already computed for the per-agent color prefix) into both `makeLogTimestampReformatter` calls. Both log surfaces now share one TTY/`NO_COLOR` detection function.

## Anti-overlap with #146

The reformatter chunker contract is unchanged — same emit boundaries, same flush-tail behavior, byte-by-byte feed test still passes. Color is applied as a post-step inside the existing `.map((line) => …)` and `flush()` paths. No protocol-level changes; old containers with the new CLI work fine (the CLI re-formats on receive).

## Verification

- `bun run typecheck` ✓
- `bun run lint` ✓ (1 pre-existing warning in `src/doctor/index.ts` — unrelated, present on `main`)
- `bun run format` ✓ (oxfmt clean)
- `bun test`: 43 tests across the 4 directly-touched test files all pass (15 new in `log-colors.test.ts`, 13 existing + 2 new in `log-timestamps.test.ts`, 2 in `logs.test.ts`, 11 in `compose/logs.test.ts`). The single suite-wide failure (`scripts/generate-schema.test.ts` — `network.blockInternal` schema drift) pre-exists on `main`; verified via `git stash && bun test scripts/generate-schema.test.ts` showing the same failure on a clean tree.

## Out of scope

- No README / AGENTS.md update — UX polish on top of #146's docs, not a new feature surface to document.
- No `--color always|never|auto` CLI flag — `NO_COLOR` covers the "never" case and TTY detection handles "auto". Will add `--color` if someone needs to force colors through a non-TTY pipe.
- No palette growth — revisit if hash collisions become a real pain point.