### PR TITLE
Add backup bundled plugin

### DIFF
--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -20,6 +20,8 @@ function makeFakeHookBus(events: string[]): HookBus {
       events.push(`idle:${e.sessionId}:${e.parentTranscriptPath ?? '-'}`)
     },
     runSessionPrompt: async () => {},
+    runSessionTurnStart: async () => {},
+    runSessionTurnEnd: async () => {},
     runToolBefore: async () => undefined,
     runToolAfter: async () => {},
     count: () => 0,

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -5,6 +5,7 @@ import type { HookBus } from '@/plugin'
 import type { Stream, Unsubscribe } from '@/stream'
 
 import { type AgentSession, createSession } from './index'
+import type { SessionOrigin } from './session-origin'
 
 type AgentSessionTools = NonNullable<Parameters<typeof createSession>[0]>['tools']
 
@@ -54,6 +55,8 @@ export type CreateSessionForSubagentResult = {
   dispose?: () => Promise<void>
   hooks?: HookBus
   sessionId?: string
+  agentDir?: string
+  origin?: SessionOrigin
   getTranscriptPath?: () => string | undefined
 }
 export type CreateSessionForSubagentOptions = {
@@ -82,6 +85,8 @@ type NormalizedSubagentSession = {
   dispose: () => Promise<void>
   hooks: HookBus | undefined
   sessionId: string | undefined
+  agentDir: string | undefined
+  origin: SessionOrigin | undefined
   getTranscriptPath: (() => string | undefined) | undefined
 }
 
@@ -92,6 +97,8 @@ function normalizeSubagentSession(result: AgentSession | CreateSessionForSubagen
       dispose: result.dispose ?? (async () => {}),
       hooks: result.hooks,
       sessionId: result.sessionId,
+      agentDir: result.agentDir,
+      origin: result.origin,
       getTranscriptPath: result.getTranscriptPath,
     }
   }
@@ -100,6 +107,8 @@ function normalizeSubagentSession(result: AgentSession | CreateSessionForSubagen
     dispose: async () => {},
     hooks: undefined,
     sessionId: undefined,
+    agentDir: undefined,
+    origin: undefined,
     getTranscriptPath: undefined,
   }
 }
@@ -125,11 +134,24 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
   }
 
   const runSession: RunSession = async (override) => {
-    const { session, dispose, hooks, sessionId, getTranscriptPath } = normalizeSubagentSession(
+    const { session, dispose, hooks, sessionId, agentDir, origin, getTranscriptPath } = normalizeSubagentSession(
       await createSessionForSubagent(subagent, sessionOptions),
     )
+    const turnEvent =
+      hooks && sessionId !== undefined && agentDir !== undefined
+        ? { sessionId, agentDir, ...(origin !== undefined ? { origin } : {}) }
+        : undefined
     try {
-      await session.prompt(override?.userPrompt ?? options.userPrompt)
+      if (hooks && turnEvent !== undefined) {
+        await hooks.runSessionTurnStart(turnEvent)
+      }
+      try {
+        await session.prompt(override?.userPrompt ?? options.userPrompt)
+      } finally {
+        if (hooks && turnEvent !== undefined) {
+          await hooks.runSessionTurnEnd(turnEvent)
+        }
+      }
       if (hooks && sessionId !== undefined) {
         await hooks.runSessionIdle({
           sessionId,

--- a/src/bundled-plugins/backup/README.md
+++ b/src/bundled-plugins/backup/README.md
@@ -1,0 +1,81 @@
+# typeclaw-plugin-backup
+
+The bundled backup plugin. Watches the agent folder for uncommitted work and commits + pushes it during quiet moments, with the LLM picking commit messages and diagnosing push/rebase failures. Replaces the previously documented-but-unimplemented "sessions/ via auto-backup" promise.
+
+This plugin is **auto-loaded** by every TypeClaw agent. There is no `plugins[]` entry to add and no opt-out short of `backup.enabled: false`. To configure it, add a `backup` block to `typeclaw.json`.
+
+## Config
+
+```json
+{
+  "backup": {
+    "enabled": true,
+    "idleMs": 30000,
+    "pushToOrigin": true
+  }
+}
+```
+
+| Field                     | Default | Effect                                                                                                                                                                                                                                                                                                                          |
+| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `backup.enabled`          | `true`  | Master switch. When `false`, all hooks no-op and the runner subagent is never spawned.                                                                                                                                                                                                                                          |
+| `backup.idleMs`           | `30000` | Debounce window after the agent goes idle (no in-flight prompt turns) before the backup runner fires. Resets on every new prompt. Minimum `1000`.                                                                                                                                                                               |
+| `backup.pushToOrigin`     | `true`  | When `true`, after committing, the runner attempts `git push`. On non-fast-forward, it `git fetch && git rebase` then re-pushes. On rebase conflict, it aborts the rebase and asks the diagnose subagent to write a human-readable report. Set `false` to commit-only (useful for offline workflows or repos without a remote). |
+| `backup.commitTimeoutMs`  | `30000` | Per-command wall clock for local git operations (status/add/commit/diff). Mostly an escape hatch — defaults are generous.                                                                                                                                                                                                       |
+| `backup.networkTimeoutMs` | `60000` | Per-command wall clock for network git operations (push/fetch/rebase). Bounds the failure mode where a stuck remote would otherwise hang the runner indefinitely. `GIT_TERMINAL_PROMPT=0` is also set so auth failures fail fast instead of prompting.                                                                          |
+
+All fields are **restart-required** — the plugin reads them once at boot.
+
+## How it triggers
+
+The backup plugin uses **`session.idle` with debounce** as its trigger, not a fixed cron schedule. This means backups fire only after meaningful agent activity has settled — sporadic agents that never go idle (e.g. long polling loops in tools) will not be backed up by this plugin alone.
+
+The fire path is gated by an **active-turn counter**: the plugin tracks `session.turn.start` / `session.turn.end` events from every prompt source (TUI, channel router, cron consumer, subagent invocations) and only fires when the count is zero. The plugin's own three subagents (`backup`, `backup-message`, `backup-diagnose`) are excluded from the count via `origin.kind === 'subagent' && origin.subagent` matching, so the backup never self-gates.
+
+If a new prompt arrives while the runner is in flight, the runner finishes its current commit-and-push cycle; the plugin then re-evaluates the gate. There is no preemption mid-commit — the unit of atomicity is one full backup pass.
+
+## What it commits
+
+The runner stages two categories of dirty paths:
+
+- **Tracked or untracked agent paths** (anything `git status --porcelain=v1 --untracked-files=all` reports), **except** paths under `memory/` — those are owned by the memory plugin's dreaming subagent.
+- **Force-added `sessions/`** — gitignored, but force-added so transcripts survive across restarts.
+
+Commit message comes from the `backup-message` subagent, which sees a truncated `git status` and `git diff --cached --stat` and writes a single conventional-ish commit message to a tmp file. On any failure the runner falls back to `chore: backup`.
+
+## What it pushes
+
+When `pushToOrigin: true` and the current branch has an upstream (`git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` succeeds), the runner runs `git push`. On non-fast-forward rejection, it runs `git fetch` then `git rebase <upstream>` then `git push` again.
+
+If any network step fails (rebase conflict, auth failure, network timeout), the runner aborts cleanly and spawns the `backup-diagnose` subagent. That subagent has `bash`, `read`, and `write` tools and writes a short human-readable report to `<agentDir>/sessions/backup-diagnostics.log`. The diagnose subagent is explicitly forbidden from force-pushing or resolving merge conflicts itself.
+
+## What it contributes
+
+| Kind     | Name                          | Notes                                                                                                                                                       |
+| -------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Subagent | `backup`                      | Runner orchestrator. No LLM call — `handler` directly invokes the deterministic `runBackup`. Coalesced per `agentDir`.                                      |
+| Subagent | `backup-message`              | Picks commit message from the diff. Has only the `write` tool. Coalesced per `agentDir`.                                                                    |
+| Subagent | `backup-diagnose`             | Diagnoses push/rebase failures. Has `bash`, `read`, `write`. Coalesced per `agentDir`.                                                                      |
+| Hook     | `session.turn.start` / `.end` | Maintains the active-turn counter. Excludes self-induced turns (the three subagents above) so the backup never gates against itself.                        |
+| Hook     | `session.idle`                | Debouncer (idleMs). Resets the timer on every event. On fire, checks the active-turn counter and spawns `backup` if zero.                                   |
+| Hook     | `session.end`                 | Removes the session from the active-turn set on session close. Defensive: if a session ends mid-turn (network drop), `session.turn.end` may not have fired. |
+
+## Files on disk
+
+- **`<agentDir>/.typeclaw/backup-message.tmp`** — ephemeral. Written by `backup-message` subagent, read and then deleted by the runner. The directory is created on demand. Not gitignored because it always cleans itself up before commit.
+- **`<agentDir>/sessions/backup-diagnostics.log`** — append-only log written by `backup-diagnose` when push/rebase fails. Lives under `sessions/` so it gets force-added by the next successful backup. Read this file when investigating why the backup plugin stopped working.
+
+## Why this design
+
+This feature came up as: "periodically check for dirty files and commit; LLM picks the message and handles failures." A pre-implementation Oracle review pushed back hard on two assumptions:
+
+1. **Don't make the core flow LLM-driven.** A subagent with `bash` orchestrating push/rebase/conflict recovery can hang on auth prompts, freestyle-mishandle conflicts, or burn an LLM call on every backup even when nothing went wrong. Instead, the deterministic runner owns the flow and only delegates two narrow tasks to LLMs: commit message synthesis (one short call, naturally bounded) and failure diagnosis (only fires on actual failures).
+
+2. **`session.start` / `session.end` is the wrong gate.** Long-lived TUI and channel sessions stay open for hours; counting open sessions would mean the backup never fires. The new `session.turn.start` / `session.turn.end` hooks bracket each `session.prompt(...)` call across all four call sites (TUI server, cron consumer, subagent runner, channel router), so the counter reflects "active work in progress" rather than "any session connected".
+
+`session.idle` (with debounce) was chosen over cron because it ties backup frequency to actual activity. There is no fixed `*/15 * * * *` schedule to misconfigure or re-explain. The tradeoff is the sporadic-agent case noted above.
+
+## Tests
+
+- `runner.test.ts` — deterministic runner unit tests (status parsing, force-add of `sessions/`, push-only-with-upstream, rebase-on-non-fast-forward, diagnose-on-rebase-conflict, advisory-throw isolation, sanitize-commit-message).
+- `index.test.ts` — plugin composition tests (subagent/hook surface, config schema defaults and validation, debounce, active-turn gating, self-induced-turn exclusion, coalescing).

--- a/src/bundled-plugins/backup/index.test.ts
+++ b/src/bundled-plugins/backup/index.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { PluginContext, PluginExports } from '@/plugin'
+
+import backupPlugin from './index'
+
+type SpawnCall = { name: string; payload: unknown }
+
+function makeCtx(overrides: { config: unknown }): {
+  ctx: PluginContext<any>
+  spawnCalls: SpawnCall[]
+} {
+  const spawnCalls: SpawnCall[] = []
+  const logs: string[] = []
+  const ctx: PluginContext<any> = {
+    name: 'backup',
+    version: undefined,
+    agentDir: '/agent',
+    config: overrides.config,
+    logger: {
+      info: (m) => logs.push(`info:${m}`),
+      warn: (m) => logs.push(`warn:${m}`),
+      error: (m) => logs.push(`error:${m}`),
+    },
+    spawnSubagent: async (name, payload) => {
+      spawnCalls.push({ name, payload })
+    },
+  }
+  return { ctx, spawnCalls }
+}
+
+async function loadPlugin(ctx: PluginContext<any>): Promise<PluginExports> {
+  return backupPlugin.plugin(ctx)
+}
+
+async function loadHooks(ctx: PluginContext<any>): Promise<{
+  turnStart: NonNullable<NonNullable<PluginExports['hooks']>['session.turn.start']>
+  turnEnd: NonNullable<NonNullable<PluginExports['hooks']>['session.turn.end']>
+  idle: NonNullable<NonNullable<PluginExports['hooks']>['session.idle']>
+  sessionEnd: NonNullable<NonNullable<PluginExports['hooks']>['session.end']>
+}> {
+  const exports = await loadPlugin(ctx)
+  const hooks = exports.hooks
+  if (!hooks) throw new Error('plugin returned no hooks')
+  const turnStart = hooks['session.turn.start']
+  const turnEnd = hooks['session.turn.end']
+  const idle = hooks['session.idle']
+  const sessionEnd = hooks['session.end']
+  if (!turnStart || !turnEnd || !idle || !sessionEnd) throw new Error('expected lifecycle hooks missing')
+  return { turnStart, turnEnd, idle, sessionEnd }
+}
+
+const tinyConfig = {
+  enabled: true,
+  idleMs: 25,
+  pushToOrigin: false,
+  commitTimeoutMs: 1000,
+  networkTimeoutMs: 1000,
+}
+
+describe('backup plugin', () => {
+  test('exposes the three subagents (runner, message, diagnose)', async () => {
+    const { ctx } = makeCtx({ config: tinyConfig })
+    const exports = await loadPlugin(ctx)
+    const subs = Object.keys(exports.subagents ?? {}).sort()
+    expect(subs).toEqual(['backup', 'backup-diagnose', 'backup-message'])
+  })
+
+  test('registers the four expected hooks', async () => {
+    const { ctx } = makeCtx({ config: tinyConfig })
+    const exports = await loadPlugin(ctx)
+    const hookNames = Object.keys(exports.hooks ?? {}).sort()
+    expect(hookNames).toEqual(['session.end', 'session.idle', 'session.turn.end', 'session.turn.start'])
+  })
+
+  test('config schema validates with all defaults', () => {
+    const parsed = backupPlugin.configSchema?.parse(undefined)
+    expect(parsed).toEqual({
+      enabled: true,
+      idleMs: 30_000,
+      pushToOrigin: true,
+      commitTimeoutMs: 30_000,
+      networkTimeoutMs: 60_000,
+    })
+  })
+
+  test('rejects idleMs below 1000ms', () => {
+    expect(() => backupPlugin.configSchema?.parse({ idleMs: 500 })).toThrow()
+  })
+
+  test('idle hook with no active turns spawns the runner after debounce', async () => {
+    const { ctx, spawnCalls } = makeCtx({ config: tinyConfig })
+    const { idle } = await loadHooks(ctx)
+    await idle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
+    await sleep(80)
+    expect(spawnCalls.map((c) => c.name)).toEqual(['backup'])
+    expect(spawnCalls[0]?.payload).toEqual({ agentDir: '/agent', pushToOrigin: false })
+  })
+
+  test('idle hook does not fire when an active turn is in progress', async () => {
+    const { ctx, spawnCalls } = makeCtx({ config: tinyConfig })
+    const { turnStart, idle } = await loadHooks(ctx)
+
+    await turnStart({ sessionId: 's1', agentDir: '/agent' }, hookCtx())
+    await idle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
+    await sleep(80)
+    expect(spawnCalls).toEqual([])
+  })
+
+  test('runner fires after the active turn ends and a fresh idle arrives', async () => {
+    const { ctx, spawnCalls } = makeCtx({ config: tinyConfig })
+    const { turnStart, turnEnd, idle } = await loadHooks(ctx)
+
+    await turnStart({ sessionId: 's1', agentDir: '/agent' }, hookCtx())
+    await idle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
+    await sleep(40)
+    expect(spawnCalls).toEqual([])
+
+    await turnEnd({ sessionId: 's1', agentDir: '/agent' }, hookCtx())
+    await idle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
+    await sleep(80)
+    expect(spawnCalls.map((c) => c.name)).toEqual(['backup'])
+  })
+
+  test('self-induced subagent turns do not count against the active-turn gate', async () => {
+    const { ctx, spawnCalls } = makeCtx({ config: tinyConfig })
+    const { turnStart, idle } = await loadHooks(ctx)
+
+    await turnStart(
+      {
+        sessionId: 'self',
+        agentDir: '/agent',
+        origin: { kind: 'subagent', subagent: 'backup-message', parentSessionId: 'p' },
+      },
+      hookCtx(),
+    )
+    await idle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
+    await sleep(80)
+    expect(spawnCalls.map((c) => c.name)).toEqual(['backup'])
+  })
+
+  test('debounce: rapid idle events coalesce into a single fire', async () => {
+    const { ctx, spawnCalls } = makeCtx({ config: tinyConfig })
+    const { idle } = await loadHooks(ctx)
+
+    for (let i = 0; i < 5; i++) {
+      await idle({ sessionId: 's', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
+      await sleep(5)
+    }
+    await sleep(80)
+    expect(spawnCalls.length).toBe(1)
+  })
+
+  test('disabled plugin never spawns the runner', async () => {
+    const { ctx, spawnCalls } = makeCtx({ config: { ...tinyConfig, enabled: false } })
+    const { idle } = await loadHooks(ctx)
+    await idle({ sessionId: 's', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
+    await sleep(80)
+    expect(spawnCalls).toEqual([])
+  })
+
+  test('session.end clears any in-flight active turn for that session', async () => {
+    const { ctx, spawnCalls } = makeCtx({ config: tinyConfig })
+    const { turnStart, sessionEnd, idle } = await loadHooks(ctx)
+
+    await turnStart({ sessionId: 's1', agentDir: '/agent' }, hookCtx())
+    await sessionEnd({ sessionId: 's1' }, hookCtx())
+    await idle({ sessionId: 's2', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
+    await sleep(80)
+    expect(spawnCalls.length).toBe(1)
+  })
+})
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+function hookCtx() {
+  return {
+    agentDir: '/agent',
+    pluginName: 'backup',
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  }
+}

--- a/src/bundled-plugins/backup/index.ts
+++ b/src/bundled-plugins/backup/index.ts
@@ -1,0 +1,209 @@
+import { z } from 'zod'
+
+import { definePlugin, type Subagent } from '@/plugin'
+
+import { COMMIT_TIMEOUT_MS, makeDefaultGitSpawn, NETWORK_TIMEOUT_MS, runBackup, type BackupResult } from './runner'
+import {
+  cleanupMessageFile,
+  type CommitMessagePayload,
+  createCommitMessageSubagent,
+  createDiagnoseFailureSubagent,
+  type DiagnoseFailurePayload,
+  ensureMessageDir,
+  messageFilePath,
+  readMessageFile,
+} from './subagents'
+
+const DEFAULT_IDLE_MS = 30_000
+const MIN_IDLE_MS = 1_000
+
+const SUBAGENT_BACKUP_RUNNER = 'backup'
+const SUBAGENT_COMMIT_MESSAGE = 'backup-message'
+const SUBAGENT_DIAGNOSE = 'backup-diagnose'
+
+const SELF_INDUCED_SUBAGENT_NAMES = new Set<string>([
+  SUBAGENT_BACKUP_RUNNER,
+  SUBAGENT_COMMIT_MESSAGE,
+  SUBAGENT_DIAGNOSE,
+])
+
+const backupConfigSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+    idleMs: z.number().int().min(MIN_IDLE_MS).default(DEFAULT_IDLE_MS),
+    pushToOrigin: z.boolean().default(true),
+    commitTimeoutMs: z.number().int().min(1).default(COMMIT_TIMEOUT_MS),
+    networkTimeoutMs: z.number().int().min(1).default(NETWORK_TIMEOUT_MS),
+  })
+  .default({
+    enabled: true,
+    idleMs: DEFAULT_IDLE_MS,
+    pushToOrigin: true,
+    commitTimeoutMs: COMMIT_TIMEOUT_MS,
+    networkTimeoutMs: NETWORK_TIMEOUT_MS,
+  })
+
+const runnerPayloadSchema = z.object({
+  agentDir: z.string(),
+  pushToOrigin: z.boolean(),
+})
+
+type RunnerPayload = z.infer<typeof runnerPayloadSchema>
+
+export default definePlugin({
+  configSchema: backupConfigSchema,
+  plugin: async (ctx) => {
+    const enabled = ctx.config.enabled
+    const idleMs = ctx.config.idleMs
+    const pushToOrigin = ctx.config.pushToOrigin
+
+    const activeTurns = new Set<string>()
+    let idleTimer: ReturnType<typeof setTimeout> | null = null
+    let pendingFire = false
+    let inFlight = false
+
+    const cancelTimer = (): void => {
+      if (idleTimer !== null) {
+        clearTimeout(idleTimer)
+        idleTimer = null
+      }
+    }
+
+    const fireIfQuiet = async (): Promise<void> => {
+      if (!enabled) return
+      if (inFlight) {
+        pendingFire = true
+        return
+      }
+      if (activeTurns.size > 0) return
+      inFlight = true
+      try {
+        await ctx.spawnSubagent(SUBAGENT_BACKUP_RUNNER, {
+          agentDir: ctx.agentDir,
+          pushToOrigin,
+        } satisfies RunnerPayload)
+      } catch (err) {
+        ctx.logger.error(`backup runner spawn failed: ${err instanceof Error ? err.message : String(err)}`)
+      } finally {
+        inFlight = false
+        if (pendingFire) {
+          pendingFire = false
+          if (activeTurns.size === 0) {
+            queueMicrotask(() => {
+              void fireIfQuiet()
+            })
+          }
+        }
+      }
+    }
+
+    const isSelfInducedTurn = (origin: { kind: string; subagent?: string } | undefined): boolean => {
+      if (origin?.kind !== 'subagent') return false
+      const sub = origin.subagent
+      return sub !== undefined && SELF_INDUCED_SUBAGENT_NAMES.has(sub)
+    }
+
+    const runnerSubagent: Subagent<RunnerPayload> = {
+      systemPrompt: '(backup runner — no LLM)',
+      payloadSchema: runnerPayloadSchema,
+      inFlightKey: (payload) => payload.agentDir,
+      handler: async (sctx) => {
+        const result = await runBackupOnce(sctx.payload, ctx)
+        const summary = describeResult(result)
+        ctx.logger.info(`[backup] ${summary}`)
+      },
+    }
+
+    return {
+      subagents: {
+        [SUBAGENT_BACKUP_RUNNER]: runnerSubagent,
+        [SUBAGENT_COMMIT_MESSAGE]: createCommitMessageSubagent(),
+        [SUBAGENT_DIAGNOSE]: createDiagnoseFailureSubagent(),
+      },
+      hooks: {
+        'session.turn.start': (event) => {
+          if (isSelfInducedTurn(event.origin)) return
+          activeTurns.add(event.sessionId)
+          cancelTimer()
+        },
+        'session.turn.end': (event) => {
+          if (isSelfInducedTurn(event.origin)) return
+          activeTurns.delete(event.sessionId)
+        },
+        'session.end': (event) => {
+          activeTurns.delete(event.sessionId)
+        },
+        'session.idle': () => {
+          if (!enabled) return
+          if (activeTurns.size > 0) return
+          cancelTimer()
+          idleTimer = setTimeout(() => {
+            idleTimer = null
+            void fireIfQuiet()
+          }, idleMs)
+        },
+      },
+    }
+  },
+})
+
+async function runBackupOnce(
+  payload: RunnerPayload,
+  ctx: {
+    agentDir: string
+    logger: { info: (m: string) => void; warn: (m: string) => void }
+    spawnSubagent: (name: string, payload?: unknown) => Promise<void>
+  },
+): Promise<BackupResult> {
+  const messagePath = messageFilePath(payload.agentDir)
+  await ensureMessageDir(messagePath)
+  await cleanupMessageFile(messagePath)
+
+  const result = await runBackup(
+    { cwd: payload.agentDir, pushToOrigin: payload.pushToOrigin },
+    {
+      gitSpawn: makeDefaultGitSpawn(),
+      pickCommitMessage: async ({ status, diffstat }) => {
+        await cleanupMessageFile(messagePath)
+        const messagePayload: CommitMessagePayload = {
+          agentDir: payload.agentDir,
+          status,
+          diffstat,
+          outputPath: messagePath,
+        }
+        try {
+          await ctx.spawnSubagent(SUBAGENT_COMMIT_MESSAGE, messagePayload)
+        } catch (err) {
+          ctx.logger.warn(
+            `${SUBAGENT_COMMIT_MESSAGE} subagent failed, using fallback: ${err instanceof Error ? err.message : String(err)}`,
+          )
+        }
+        const written = await readMessageFile(messagePath)
+        await cleanupMessageFile(messagePath)
+        return written ?? 'chore: backup'
+      },
+      diagnoseFailure: async (input) => {
+        const diagPayload: DiagnoseFailurePayload = {
+          agentDir: input.cwd,
+          stage: input.stage,
+          exitCode: input.exitCode,
+          stderr: input.stderr,
+          stdout: input.stdout,
+        }
+        try {
+          await ctx.spawnSubagent(SUBAGENT_DIAGNOSE, diagPayload)
+        } catch (err) {
+          ctx.logger.warn(`${SUBAGENT_DIAGNOSE} subagent failed: ${err instanceof Error ? err.message : String(err)}`)
+        }
+      },
+    },
+  )
+
+  await cleanupMessageFile(messagePath)
+  return result
+}
+
+function describeResult(r: BackupResult): string {
+  if (r.ok) return r.kind
+  return `failed (${r.kind}): ${r.reason}`
+}

--- a/src/bundled-plugins/backup/runner.test.ts
+++ b/src/bundled-plugins/backup/runner.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { type BackupRunnerDeps, type GitSpawn, type GitSpawnResult, parsePorcelain, runBackup } from './runner'
+
+const okResult = (stdout = ''): GitSpawnResult => ({ exitCode: 0, stdout, stderr: '', timedOut: false })
+const failResult = (stderr = 'boom', exit = 1): GitSpawnResult => ({
+  exitCode: exit,
+  stdout: '',
+  stderr,
+  timedOut: false,
+})
+
+type Call = { args: readonly string[]; cwd: string }
+
+function makeSpawn(handler: (args: readonly string[]) => GitSpawnResult): { spawn: GitSpawn; calls: Call[] } {
+  const calls: Call[] = []
+  const spawn: GitSpawn = async (args, { cwd }) => {
+    calls.push({ args, cwd })
+    return handler(args)
+  }
+  return { spawn, calls }
+}
+
+async function makeRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'autobackup-runner-'))
+  await mkdir(join(dir, '.git'))
+  return dir
+}
+
+const baseDeps = (spawn: GitSpawn, message = 'chore: test'): BackupRunnerDeps => ({
+  gitSpawn: spawn,
+  pickCommitMessage: async () => message,
+})
+
+describe('runBackup', () => {
+  test('returns no-repo when .git is missing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'autobackup-norepo-'))
+    const { spawn, calls } = makeSpawn(() => okResult())
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
+    expect(result).toEqual({ ok: true, kind: 'no-repo' })
+    expect(calls.length).toBe(0)
+  })
+
+  test('returns clean when status is empty', async () => {
+    const cwd = await makeRepo()
+    const { spawn } = makeSpawn(() => okResult(''))
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
+    expect(result).toEqual({ ok: true, kind: 'clean' })
+  })
+
+  test('skips committing memory/-prefixed paths but stages other dirty paths', async () => {
+    const cwd = await makeRepo()
+    const status = ' M src/foo.ts\n M memory/2026-04-27.md\n'
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(status)
+      if (args[0] === 'add') return okResult()
+      if (args[0] === 'diff' && args[1] === '--cached' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[1] === '--cached' && args[2] === '--stat') return okResult('foo.ts | 1 +')
+      if (args[0] === 'commit') return okResult()
+      if (args[0] === 'rev-parse') return failResult('no upstream', 128)
+      return okResult()
+    })
+    const deps = baseDeps(spawn, 'chore: bump foo')
+    const result = await runBackup({ cwd, pushToOrigin: true }, deps)
+
+    expect(result).toEqual({ ok: true, kind: 'committed' })
+    const addCall = calls.find((c) => c.args[0] === 'add' && c.args[1] === '--')
+    expect(addCall?.args).toEqual(['add', '--', 'src/foo.ts'])
+    const forceAdd = calls.find((c) => c.args[0] === 'add' && c.args[1] === '-f')
+    expect(forceAdd).toBeUndefined()
+  })
+
+  test('force-adds sessions/ paths alongside normal staging', async () => {
+    const cwd = await makeRepo()
+    await mkdir(join(cwd, 'sessions'))
+    await writeFile(join(cwd, 'sessions', 'a.jsonl'), '{}')
+    const status = '?? sessions/a.jsonl\n M src/foo.ts\n'
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(status)
+      if (args[0] === 'add' && args[1] === '--') return okResult()
+      if (args[0] === 'add' && args[1] === '-f') return okResult()
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[2] === '--stat') return okResult('foo.ts | 1 +')
+      if (args[0] === 'commit') return okResult()
+      if (args[0] === 'rev-parse') return failResult('no upstream', 128)
+      return okResult()
+    })
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
+    expect(result).toEqual({ ok: true, kind: 'committed' })
+    const addF = calls.find((c) => c.args[0] === 'add' && c.args[1] === '-f')
+    expect(addF?.args).toEqual(['add', '-f', '--', 'sessions/a.jsonl'])
+  })
+
+  test('skips push when there is no upstream', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'rev-parse') return failResult('not a tracking branch', 128)
+      return okResult()
+    })
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
+    expect(result).toEqual({ ok: true, kind: 'committed' })
+    expect(calls.find((c) => c.args[0] === 'push')).toBeUndefined()
+  })
+
+  test('pushes when upstream is configured', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'rev-parse') return okResult('origin/main\n')
+      if (args[0] === 'push') return okResult()
+      return okResult()
+    })
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
+    expect(result).toEqual({ ok: true, kind: 'pushed' })
+    expect(calls.find((c) => c.args[0] === 'push')).toBeDefined()
+  })
+
+  test('on non-fast-forward push, fetches, rebases, and re-pushes', async () => {
+    const cwd = await makeRepo()
+    let pushCount = 0
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'rev-parse') return okResult('origin/main\n')
+      if (args[0] === 'push') {
+        pushCount += 1
+        return pushCount === 1
+          ? failResult('! [rejected] main -> main (non-fast-forward)\nUpdates were rejected', 1)
+          : okResult()
+      }
+      if (args[0] === 'fetch') return okResult()
+      if (args[0] === 'rebase' && args[1] === 'origin/main') return okResult()
+      return okResult()
+    })
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
+    expect(result).toEqual({ ok: true, kind: 'rebased-and-pushed' })
+    expect(calls.filter((c) => c.args[0] === 'push').length).toBe(2)
+    expect(calls.find((c) => c.args[0] === 'rebase' && c.args[1] === 'origin/main')).toBeDefined()
+  })
+
+  test('on rebase conflict, aborts and calls diagnoseFailure', async () => {
+    const cwd = await makeRepo()
+    const diagnoseCalls: { stage: string; exit: number }[] = []
+    let pushCount = 0
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'rev-parse') return okResult('origin/main\n')
+      if (args[0] === 'push') {
+        pushCount += 1
+        return failResult('! [rejected] main -> main (non-fast-forward)', 1)
+      }
+      if (args[0] === 'fetch') return okResult()
+      if (args[0] === 'rebase' && args[1] === '--abort') return okResult()
+      if (args[0] === 'rebase') return failResult('CONFLICT (content): foo', 1)
+      return okResult()
+    })
+    const deps: BackupRunnerDeps = {
+      ...baseDeps(spawn),
+      diagnoseFailure: async (input) => {
+        diagnoseCalls.push({ stage: input.stage, exit: input.exitCode })
+      },
+    }
+    const result = await runBackup({ cwd, pushToOrigin: true }, deps)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.kind).toBe('rebase-failed')
+    expect(diagnoseCalls).toEqual([{ stage: 'rebase', exit: 1 }])
+    expect(calls.find((c) => c.args[0] === 'rebase' && c.args[1] === '--abort')).toBeDefined()
+    expect(pushCount).toBe(1)
+  })
+
+  test('diagnose-failure is advisory; its throw must not mask the original failure', async () => {
+    const cwd = await makeRepo()
+    const { spawn } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'rev-parse') return okResult('origin/main\n')
+      if (args[0] === 'push') return failResult('Authentication failed', 128)
+      return okResult()
+    })
+    const deps: BackupRunnerDeps = {
+      ...baseDeps(spawn),
+      diagnoseFailure: async () => {
+        throw new Error('diagnose blew up')
+      },
+    }
+    const result = await runBackup({ cwd, pushToOrigin: true }, deps)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.kind).toBe('push-failed')
+      expect(result.reason).toContain('Authentication failed')
+    }
+  })
+
+  test('does not push when pushToOrigin is false, even with upstream configured', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'rev-parse') return okResult('origin/main\n')
+      return okResult()
+    })
+    const result = await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))
+    expect(result).toEqual({ ok: true, kind: 'committed' })
+    expect(calls.find((c) => c.args[0] === 'push')).toBeUndefined()
+    expect(calls.find((c) => c.args[0] === 'rev-parse')).toBeUndefined()
+  })
+
+  test('returns clean when staged diff is empty after add (e.g. only memory/ paths dirty)', async () => {
+    const cwd = await makeRepo()
+    const { spawn } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M memory/foo.md\n')
+      return okResult()
+    })
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
+    expect(result).toEqual({ ok: true, kind: 'clean' })
+  })
+
+  test('sanitizes commit message: long subject is truncated, fallback on empty', async () => {
+    const cwd = await makeRepo()
+    let captured = ''
+    const { spawn } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'commit') {
+        captured = args[2] ?? ''
+        return okResult()
+      }
+      if (args[0] === 'rev-parse') return failResult('no upstream', 128)
+      return okResult()
+    })
+    const long = 'x'.repeat(500)
+    await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn, long))
+    expect(captured.length).toBeLessThanOrEqual(200)
+  })
+
+  test('falls back to "Backup" subject when picker returns empty', async () => {
+    const cwd = await makeRepo()
+    let captured = ''
+    const { spawn } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'commit') {
+        captured = args[2] ?? ''
+        return okResult()
+      }
+      if (args[0] === 'rev-parse') return failResult('no upstream', 128)
+      return okResult()
+    })
+    await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn, '   '))
+    expect(captured).toBe('Backup')
+  })
+})
+
+describe('parsePorcelain', () => {
+  test('parses standard modified/added lines', () => {
+    expect(parsePorcelain(' M src/foo.ts\n?? bar.ts\n')).toEqual(['src/foo.ts', 'bar.ts'])
+  })
+
+  test('returns the destination on rename lines', () => {
+    expect(parsePorcelain('R  old/path -> new/path\n')).toEqual(['new/path'])
+  })
+
+  test('skips empty and short lines', () => {
+    expect(parsePorcelain('\n  \nXY\n')).toEqual([])
+  })
+})

--- a/src/bundled-plugins/backup/runner.ts
+++ b/src/bundled-plugins/backup/runner.ts
@@ -1,0 +1,231 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const COMMIT_TIMEOUT_MS = 30_000
+export const NETWORK_TIMEOUT_MS = 60_000
+
+const RUNTIME_OWNED_PREFIXES = ['memory/'] as const
+const FORCE_ADD_PREFIXES = ['sessions/'] as const
+
+const NONINTERACTIVE_ENV = {
+  GIT_TERMINAL_PROMPT: '0',
+  GIT_PAGER: 'cat',
+  PAGER: 'cat',
+  GCM_INTERACTIVE: 'never',
+} as const
+
+export type GitSpawnResult = {
+  exitCode: number
+  stdout: string
+  stderr: string
+  timedOut: boolean
+}
+
+export type GitSpawn = (args: readonly string[], opts: { cwd: string; timeoutMs: number }) => Promise<GitSpawnResult>
+
+export type BackupRunnerDeps = {
+  gitSpawn: GitSpawn
+  pickCommitMessage: (input: { status: string; diffstat: string }) => Promise<string>
+  diagnoseFailure?: (input: BackupFailureInput) => Promise<void>
+  now?: () => number
+}
+
+export type BackupRunnerOptions = {
+  cwd: string
+  pushToOrigin: boolean
+}
+
+export type BackupFailureInput = {
+  cwd: string
+  stage: 'push' | 'rebase'
+  exitCode: number
+  stderr: string
+  stdout: string
+}
+
+export type BackupResult =
+  | { ok: true; kind: 'no-repo' | 'clean' | 'committed' | 'pushed' | 'rebased-and-pushed' }
+  | { ok: false; kind: 'commit-failed' | 'push-failed' | 'rebase-failed' | 'aborted'; reason: string }
+
+export async function runBackup(options: BackupRunnerOptions, deps: BackupRunnerDeps): Promise<BackupResult> {
+  const { cwd, pushToOrigin } = options
+
+  if (!existsSync(join(cwd, '.git'))) return { ok: true, kind: 'no-repo' }
+
+  const status = await deps.gitSpawn(['status', '--porcelain=v1', '--untracked-files=all'], {
+    cwd,
+    timeoutMs: COMMIT_TIMEOUT_MS,
+  })
+  if (status.exitCode !== 0) return { ok: false, kind: 'aborted', reason: `git status failed: ${shortErr(status)}` }
+  const dirty = filterAgentOwned(parsePorcelain(status.stdout))
+  const force = filterForceAdd(parsePorcelain(status.stdout))
+  if (dirty.length === 0 && force.length === 0) return { ok: true, kind: 'clean' }
+
+  if (dirty.length > 0) {
+    const add = await deps.gitSpawn(['add', '--', ...dirty], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+    if (add.exitCode !== 0) return { ok: false, kind: 'commit-failed', reason: `git add failed: ${shortErr(add)}` }
+  }
+  if (force.length > 0) {
+    const present = force.filter((p) => existsSync(join(cwd, p)))
+    if (present.length > 0) {
+      const addF = await deps.gitSpawn(['add', '-f', '--', ...present], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+      if (addF.exitCode !== 0) {
+        return { ok: false, kind: 'commit-failed', reason: `git add -f failed: ${shortErr(addF)}` }
+      }
+    }
+  }
+
+  const stagedCheck = await deps.gitSpawn(['diff', '--cached', '--quiet'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+  if (stagedCheck.exitCode === 0) return { ok: true, kind: 'clean' }
+
+  const diffstat = await deps.gitSpawn(['diff', '--cached', '--stat'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+  const message = await deps.pickCommitMessage({
+    status: status.stdout.slice(0, 4096),
+    diffstat: diffstat.stdout.slice(0, 4096),
+  })
+
+  const safeMessage = sanitizeCommitMessage(message)
+  const commit = await deps.gitSpawn(['commit', '-m', safeMessage], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+  if (commit.exitCode !== 0)
+    return { ok: false, kind: 'commit-failed', reason: `git commit failed: ${shortErr(commit)}` }
+
+  if (!pushToOrigin) return { ok: true, kind: 'committed' }
+
+  const upstream = await deps.gitSpawn(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], {
+    cwd,
+    timeoutMs: COMMIT_TIMEOUT_MS,
+  })
+  if (upstream.exitCode !== 0) return { ok: true, kind: 'committed' }
+
+  const upstreamRef = upstream.stdout.trim()
+  if (upstreamRef.length === 0) return { ok: true, kind: 'committed' }
+
+  const push = await deps.gitSpawn(['push'], { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  if (push.exitCode === 0) return { ok: true, kind: 'pushed' }
+
+  if (!isNonFastForward(push)) {
+    await maybeDiagnose(deps, { cwd, stage: 'push', exitCode: push.exitCode, stderr: push.stderr, stdout: push.stdout })
+    return { ok: false, kind: 'push-failed', reason: shortErr(push) }
+  }
+
+  const fetch = await deps.gitSpawn(['fetch'], { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  if (fetch.exitCode !== 0) {
+    await maybeDiagnose(deps, {
+      cwd,
+      stage: 'push',
+      exitCode: fetch.exitCode,
+      stderr: fetch.stderr,
+      stdout: fetch.stdout,
+    })
+    return { ok: false, kind: 'push-failed', reason: `git fetch failed: ${shortErr(fetch)}` }
+  }
+
+  const rebase = await deps.gitSpawn(['rebase', upstreamRef], { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  if (rebase.exitCode !== 0) {
+    await deps.gitSpawn(['rebase', '--abort'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+    await maybeDiagnose(deps, {
+      cwd,
+      stage: 'rebase',
+      exitCode: rebase.exitCode,
+      stderr: rebase.stderr,
+      stdout: rebase.stdout,
+    })
+    return { ok: false, kind: 'rebase-failed', reason: `git rebase failed: ${shortErr(rebase)}` }
+  }
+
+  const push2 = await deps.gitSpawn(['push'], { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  if (push2.exitCode !== 0) {
+    await maybeDiagnose(deps, {
+      cwd,
+      stage: 'push',
+      exitCode: push2.exitCode,
+      stderr: push2.stderr,
+      stdout: push2.stdout,
+    })
+    return { ok: false, kind: 'push-failed', reason: `git push (post-rebase) failed: ${shortErr(push2)}` }
+  }
+  return { ok: true, kind: 'rebased-and-pushed' }
+}
+
+async function maybeDiagnose(deps: BackupRunnerDeps, input: BackupFailureInput): Promise<void> {
+  if (!deps.diagnoseFailure) return
+  try {
+    await deps.diagnoseFailure(input)
+  } catch {
+    // Diagnosis is advisory; never let it mask the original failure.
+  }
+}
+
+function shortErr(r: GitSpawnResult): string {
+  if (r.timedOut) return `timed out (exit ${r.exitCode})`
+  const text = r.stderr.trim() || r.stdout.trim() || `exit ${r.exitCode}`
+  return text.length > 400 ? `${text.slice(0, 400)}…` : text
+}
+
+function isNonFastForward(r: GitSpawnResult): boolean {
+  const blob = `${r.stderr}\n${r.stdout}`.toLowerCase()
+  return blob.includes('non-fast-forward') || blob.includes('updates were rejected')
+}
+
+export function parsePorcelain(stdout: string): string[] {
+  const out: string[] = []
+  for (const raw of stdout.split('\n')) {
+    if (raw.length < 4) continue
+    const rest = raw.slice(3)
+    const arrowIdx = rest.indexOf(' -> ')
+    out.push(arrowIdx === -1 ? rest : rest.slice(arrowIdx + 4))
+  }
+  return out
+}
+
+function filterAgentOwned(paths: readonly string[]): string[] {
+  return paths.filter((p) => !RUNTIME_OWNED_PREFIXES.some((pre) => p.startsWith(pre)))
+}
+
+function filterForceAdd(paths: readonly string[]): string[] {
+  return paths.filter((p) => FORCE_ADD_PREFIXES.some((pre) => p.startsWith(pre)))
+}
+
+function sanitizeCommitMessage(raw: string): string {
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return 'Backup'
+  const subject = trimmed.split('\n')[0]?.slice(0, 200) ?? 'Backup'
+  const rest = trimmed.split('\n').slice(1).join('\n').trim()
+  return rest.length > 0 ? `${subject}\n\n${rest}` : subject
+}
+
+export function makeDefaultGitSpawn(): GitSpawn {
+  return async (args, { cwd, timeoutMs }) => {
+    const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+    if (!bun) {
+      return { exitCode: 127, stdout: '', stderr: 'Bun runtime not available', timedOut: false }
+    }
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const proc = bun.spawn({
+        cmd: ['git', ...args],
+        cwd,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: { ...process.env, ...NONINTERACTIVE_ENV },
+        signal: controller.signal,
+      })
+      const exitCode = await proc.exited
+      const stdout = await new Response(proc.stdout).text()
+      const stderr = await new Response(proc.stderr).text()
+      const timedOut = controller.signal.aborted
+      return { exitCode, stdout, stderr, timedOut }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: message,
+        timedOut: controller.signal.aborted,
+      }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/src/bundled-plugins/backup/subagents.ts
+++ b/src/bundled-plugins/backup/subagents.ts
@@ -1,0 +1,200 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { z } from 'zod'
+
+import { bashTool, readTool, type Subagent, writeTool } from '@/plugin'
+
+const messagePayloadSchema = z.object({
+  agentDir: z.string(),
+  status: z.string(),
+  diffstat: z.string(),
+  outputPath: z.string(),
+})
+
+export type CommitMessagePayload = z.infer<typeof messagePayloadSchema>
+
+const diagnosePayloadSchema = z.object({
+  agentDir: z.string(),
+  stage: z.enum(['push', 'rebase']),
+  exitCode: z.number(),
+  stderr: z.string(),
+  stdout: z.string(),
+})
+
+export type DiagnoseFailurePayload = z.infer<typeof diagnosePayloadSchema>
+
+export const COMMIT_MESSAGE_SYSTEM_PROMPT = `You are typeclaw's backup commit-message subagent.
+
+A periodic backup is about to commit dirty files in the agent folder. Your only job is to produce a clear, conventional commit message describing those changes.
+
+# Input
+
+The user message gives you:
+- The output of \`git status --porcelain=v1 --untracked-files=all\` (truncated)
+- The output of \`git diff --cached --stat\` (truncated)
+- An absolute file path you must write the commit message to
+
+# What to write
+
+A single commit message in conventional-commit-ish style:
+- Subject line under 72 characters, imperative mood, lowercase first word, no trailing period.
+- Pick a sensible prefix when one fits: \`docs:\`, \`test:\`, \`refactor:\`, \`chore:\`, \`fix:\`, \`feat:\`. Default to \`chore: backup\` if nothing fits.
+- Optionally a blank line and a short body (1-3 lines) summarizing what changed and why if the diff makes the why obvious.
+
+Examples:
+- \`docs: update setup instructions\`
+- \`feat: add user search endpoint\`
+- \`chore: backup workspace state\`
+
+# Hard rules
+
+1. **Write exactly one file.** Use the \`write\` tool with the absolute path the user gave you. Do not write anywhere else. Do not read other files. Do not run commands.
+2. **Output is the file contents only.** No prose to the user, no explanation, no apologies. The runner ignores everything except the file you wrote.
+3. **Be honest about uncertainty.** If the diff looks like a mix of unrelated changes, write \`chore: backup\` rather than guessing a misleading subject.
+4. **Never include secrets, API keys, or paths that would identify the user's machine.** Stick to repo-relative descriptions.
+5. **Stop when the file is written.** Do not continue after the \`write\` succeeds.`
+
+export const DIAGNOSE_FAILURE_SYSTEM_PROMPT = `You are typeclaw's backup failure-diagnosis subagent.
+
+The deterministic backup runner just hit a git failure (push or rebase). The runner has already aborted any half-done state. Your job is to look at the git repo, figure out what went wrong, and either FIX IT or write a clear human-readable explanation.
+
+# Input
+
+The user message gives you:
+- The agent folder absolute path
+- The stage that failed (\`push\` or \`rebase\`)
+- The git exit code, stderr, and stdout
+
+# Tools
+
+You have \`bash\`, \`read\`, and \`write\`. Use \`bash\` to inspect git state (\`git status\`, \`git remote -v\`, \`git log -5 --oneline\`, \`git config --get remote.origin.url\`).
+
+# Allowed actions
+
+You MAY:
+- Inspect git state (read-only commands).
+- Set up a missing upstream branch via \`git push -u origin <branch>\` if it's clear that's the only issue.
+- Retry \`git push\` once after fixing a clear, narrow issue.
+
+You MUST NOT:
+- Force-push (\`--force\`, \`--force-with-lease\`).
+- Resolve merge conflicts by editing files. If a rebase had conflicts, the runner already aborted it. Leave the repo as-is and explain.
+- Mutate \`.git/config\` for credentials, signing keys, or remote URLs.
+- Touch any file outside \`.git/\` housekeeping.
+
+# Output
+
+Write a brief diagnosis (3-8 lines) describing:
+1. What the actual cause was (e.g. "no upstream tracking branch", "remote is ahead and rebase conflicted", "auth failed").
+2. What you did about it (or why you didn't).
+3. What the user should do next, if anything.
+
+Append your diagnosis to \`<agentDir>/sessions/backup-diagnostics.log\` with a timestamp prefix. Keep it short — this log is for the human, not the model.
+
+# When in doubt
+
+Do nothing destructive. Write the diagnosis and stop. The user can recover manually.`
+
+export type CreateCommitMessageSubagentOptions = {
+  fallbackMessage?: string
+}
+
+export function createCommitMessageSubagent(
+  options: CreateCommitMessageSubagentOptions = {},
+): Subagent<CommitMessagePayload> {
+  const fallback = options.fallbackMessage ?? 'chore: backup'
+  return {
+    systemPrompt: COMMIT_MESSAGE_SYSTEM_PROMPT,
+    tools: [writeTool],
+    payloadSchema: messagePayloadSchema,
+    inFlightKey: (payload) => payload.agentDir,
+    handler: async (ctx, runSession) => {
+      const userPrompt = buildCommitMessagePrompt(ctx.payload)
+      try {
+        await runSession({ userPrompt })
+      } catch {
+        await writeFile(ctx.payload.outputPath, fallback, 'utf8').catch(() => undefined)
+      }
+    },
+  }
+}
+
+export function createDiagnoseFailureSubagent(): Subagent<DiagnoseFailurePayload> {
+  return {
+    systemPrompt: DIAGNOSE_FAILURE_SYSTEM_PROMPT,
+    tools: [bashTool, readTool, writeTool],
+    payloadSchema: diagnosePayloadSchema,
+    inFlightKey: (payload) => payload.agentDir,
+    handler: async (ctx, runSession) => {
+      const userPrompt = buildDiagnosePrompt(ctx.payload)
+      try {
+        await runSession({ userPrompt })
+      } catch {
+        // Diagnosis is advisory; failures here must not propagate.
+      }
+    },
+  }
+}
+
+function buildCommitMessagePrompt(p: CommitMessagePayload): string {
+  return [
+    `Agent folder: ${p.agentDir}`,
+    `Write the commit message to: ${p.outputPath}`,
+    '',
+    '## git status --porcelain=v1 --untracked-files=all',
+    '```',
+    p.status.trim() || '(empty)',
+    '```',
+    '',
+    '## git diff --cached --stat',
+    '```',
+    p.diffstat.trim() || '(empty)',
+    '```',
+    '',
+    'Write the commit message and stop.',
+  ].join('\n')
+}
+
+function buildDiagnosePrompt(p: DiagnoseFailurePayload): string {
+  return [
+    `Agent folder: ${p.agentDir}`,
+    `Failed stage: ${p.stage}`,
+    `Exit code: ${p.exitCode}`,
+    '',
+    '## stderr',
+    '```',
+    p.stderr.trim() || '(empty)',
+    '```',
+    '',
+    '## stdout',
+    '```',
+    p.stdout.trim() || '(empty)',
+    '```',
+    '',
+    'Inspect the repo, do the smallest safe action if any, and write your diagnosis to the log file.',
+  ].join('\n')
+}
+
+export async function readMessageFile(path: string): Promise<string | null> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    return raw.trim().length > 0 ? raw : null
+  } catch {
+    return null
+  }
+}
+
+export async function ensureMessageDir(outputPath: string): Promise<void> {
+  const dir = outputPath.slice(0, outputPath.lastIndexOf('/'))
+  if (dir.length === 0) return
+  await mkdir(dir, { recursive: true }).catch(() => undefined)
+}
+
+export async function cleanupMessageFile(path: string): Promise<void> {
+  await rm(path, { force: true }).catch(() => undefined)
+}
+
+export function messageFilePath(agentDir: string): string {
+  return join(agentDir, '.typeclaw', 'backup-message.tmp')
+}

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1513,6 +1513,8 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
         events.push(`idle:${e.sessionId}:${e.parentTranscriptPath ?? '-'}`)
       },
       runSessionPrompt: async () => {},
+      runSessionTurnStart: async () => {},
+      runSessionTurnEnd: async () => {},
       runToolBefore: async () => undefined,
       runToolAfter: async () => {},
       count: () => 0,
@@ -1566,6 +1568,8 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
         idleEvents.push(e)
       },
       runSessionPrompt: async () => {},
+      runSessionTurnStart: async () => {},
+      runSessionTurnEnd: async () => {},
       runToolBefore: async () => undefined,
       runToolAfter: async () => {},
       count: () => 0,
@@ -1639,6 +1643,8 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
         events.push(`idle:${e.sessionId}`)
       },
       runSessionPrompt: async () => {},
+      runSessionTurnStart: async () => {},
+      runSessionTurnEnd: async () => {},
       runToolBefore: async () => undefined,
       runToolAfter: async () => {},
       count: () => 0,
@@ -1702,6 +1708,8 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
       runSessionEnd: async () => {},
       runSessionIdle: () => new Promise(() => {}),
       runSessionPrompt: async () => {},
+      runSessionTurnStart: async () => {},
+      runSessionTurnEnd: async () => {},
       runToolBefore: async () => undefined,
       runToolAfter: async () => {},
       count: () => 0,
@@ -2568,6 +2576,8 @@ describe('ChannelRouter idle session GC', () => {
         events.push(`idle:${e.sessionId}`)
       },
       runSessionPrompt: async () => {},
+      runSessionTurnStart: async () => {},
+      runSessionTurnEnd: async () => {},
       runToolBefore: async () => undefined,
       runToolAfter: async () => {},
       count: () => 0,

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -776,6 +776,32 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
+  const fireSessionTurnStart = async (live: LiveSession): Promise<void> => {
+    if (!live.hooks) return
+    try {
+      await live.hooks.runSessionTurnStart({
+        sessionId: live.sessionId,
+        agentDir: options.agentDir,
+        origin: buildLiveOrigin(live),
+      })
+    } catch (err) {
+      logger.warn(`[channels] session.turn.start hook threw for ${live.keyId}: ${describe(err)}`)
+    }
+  }
+
+  const fireSessionTurnEnd = async (live: LiveSession): Promise<void> => {
+    if (!live.hooks) return
+    try {
+      await live.hooks.runSessionTurnEnd({
+        sessionId: live.sessionId,
+        agentDir: options.agentDir,
+        origin: buildLiveOrigin(live),
+      })
+    } catch (err) {
+      logger.warn(`[channels] session.turn.end hook threw for ${live.keyId}: ${describe(err)}`)
+    }
+  }
+
   const buildLiveOrigin = (live: LiveSession): SessionOrigin => {
     const membership = readMembership(live.key)
     return {
@@ -848,6 +874,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         logger.info(`[channels] ${live.keyId} prompting batch=${batch.length} text_len=${text.length}`)
         const promptStart = now()
         const successfulSendsBeforePrompt = live.successfulChannelSends
+        await fireSessionTurnStart(live)
         try {
           await live.session.prompt(text)
           await validateChannelTurn(live, successfulSendsBeforePrompt)
@@ -856,6 +883,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         } catch (err) {
           logger.warn(`[channels] ${live.keyId}: prompt threw: ${describe(err)}`)
           live.consecutiveSends.clear()
+        } finally {
+          await fireSessionTurnEnd(live)
         }
         await fireSessionIdle(live)
         live.lastTurnAuthorIds = new Set(live.currentTurnAuthorIds)

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -21,6 +21,8 @@ function fakeHooks(events: string[]): HookBus {
       events.push(`idle:${e.sessionId}:${e.parentTranscriptPath ?? '-'}`)
     },
     runSessionPrompt: async () => {},
+    runSessionTurnStart: async () => {},
+    runSessionTurnEnd: async () => {},
     runToolBefore: async () => undefined,
     runToolAfter: async () => {},
     count: () => 0,

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -1,20 +1,25 @@
+import type { SessionOrigin } from '@/agent/session-origin'
 import type { HookBus } from '@/plugin'
 import type { Stream, Unsubscribe } from '@/stream'
 
 import type { CronJob, ExecJob, PromptJob } from './schema'
 
-// `hooks`, `sessionId`, and `getTranscriptPath` are optional so test fakes can
-// stay one-liners. When present, the consumer fires `session.idle` after every
-// prompt completion and `session.end` on dispose, mirroring the lifecycle
-// signals the TUI server already emits in `src/server/index.ts`. Without this
-// the bundled memory plugin's debounced `memory-logger` never spawns for cron
-// prompt jobs because it only wakes on `session.idle`.
+// `hooks`, `sessionId`, `agentDir`, and `getTranscriptPath` are optional so
+// test fakes can stay one-liners. When present, the consumer fires
+// `session.turn.start`/`session.turn.end` around `prompt()`, then
+// `session.idle` after, then `session.end` on dispose — mirroring the
+// lifecycle signals the TUI server emits in `src/server/index.ts`. Without
+// this the bundled memory plugin's debounced `memory-logger` never spawns for
+// cron prompt jobs (it only wakes on `session.idle`), and the auto-backup
+// plugin's turn counter would miss cron-driven activity.
 export type CronSession = {
   prompt: (text: string) => Promise<void>
   dispose?: () => void
   hooks?: HookBus
   sessionId?: string
+  agentDir?: string
   getTranscriptPath?: () => string | undefined
+  origin?: SessionOrigin
 }
 
 export type CronConsumerLogger = {
@@ -102,8 +107,25 @@ async function runPrompt(
     return
   }
   const session = await createSessionForCron(job)
+  const turnEvent =
+    session.hooks && session.sessionId !== undefined && session.agentDir !== undefined
+      ? {
+          sessionId: session.sessionId,
+          agentDir: session.agentDir,
+          ...(session.origin !== undefined ? { origin: session.origin } : {}),
+        }
+      : undefined
   try {
-    await session.prompt(job.prompt)
+    if (session.hooks && turnEvent !== undefined) {
+      await session.hooks.runSessionTurnStart(turnEvent)
+    }
+    try {
+      await session.prompt(job.prompt)
+    } finally {
+      if (session.hooks && turnEvent !== undefined) {
+        await session.hooks.runSessionTurnEnd(turnEvent)
+      }
+    }
     if (session.hooks && session.sessionId !== undefined) {
       await session.hooks.runSessionIdle({
         sessionId: session.sessionId,

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -10,7 +10,7 @@ import type { CronJob, ExecJob, PromptJob } from './schema'
 // `session.idle` after, then `session.end` on dispose — mirroring the
 // lifecycle signals the TUI server emits in `src/server/index.ts`. Without
 // this the bundled memory plugin's debounced `memory-logger` never spawns for
-// cron prompt jobs (it only wakes on `session.idle`), and the auto-backup
+// cron prompt jobs (it only wakes on `session.idle`), and the bundled backup
 // plugin's turn counter would miss cron-driven activity.
 export type CronSession = {
   prompt: (text: string) => Promise<void>

--- a/src/plugin/hooks.ts
+++ b/src/plugin/hooks.ts
@@ -6,6 +6,8 @@ import type {
   SessionIdleEvent,
   SessionPromptEvent,
   SessionStartEvent,
+  SessionTurnEndEvent,
+  SessionTurnStartEvent,
   ToolAfterEvent,
   ToolBeforeEvent,
   ToolBeforeResult,
@@ -43,6 +45,8 @@ export type HookBus = {
   runSessionEnd: (event: SessionEndEvent) => Promise<void>
   runSessionIdle: (event: SessionIdleEvent) => Promise<void>
   runSessionPrompt: (event: SessionPromptEvent) => Promise<void>
+  runSessionTurnStart: (event: SessionTurnStartEvent) => Promise<void>
+  runSessionTurnEnd: (event: SessionTurnEndEvent) => Promise<void>
   runToolBefore: (event: ToolBeforeEvent) => Promise<{ block: true; reason: string } | undefined>
   runToolAfter: (event: ToolAfterEvent) => Promise<void>
   count: (name: keyof Hooks) => number
@@ -62,6 +66,8 @@ type Registries = {
   'session.end': RegisteredHook<'session.end'>[]
   'session.idle': RegisteredHook<'session.idle'>[]
   'session.prompt': RegisteredHook<'session.prompt'>[]
+  'session.turn.start': RegisteredHook<'session.turn.start'>[]
+  'session.turn.end': RegisteredHook<'session.turn.end'>[]
   'tool.before': RegisteredHook<'tool.before'>[]
   'tool.after': RegisteredHook<'tool.after'>[]
 }
@@ -74,6 +80,8 @@ export function createHookBus(options: CreateHookBusOptions = {}): HookBus {
     'session.end': [],
     'session.idle': [],
     'session.prompt': [],
+    'session.turn.start': [],
+    'session.turn.end': [],
     'tool.before': [],
     'tool.after': [],
   }
@@ -89,6 +97,8 @@ export function createHookBus(options: CreateHookBusOptions = {}): HookBus {
       if (hooks['session.end']) r['session.end'].push({ ...base, handler: hooks['session.end'] })
       if (hooks['session.idle']) r['session.idle'].push({ ...base, handler: hooks['session.idle'] })
       if (hooks['session.prompt']) r['session.prompt'].push({ ...base, handler: hooks['session.prompt'] })
+      if (hooks['session.turn.start']) r['session.turn.start'].push({ ...base, handler: hooks['session.turn.start'] })
+      if (hooks['session.turn.end']) r['session.turn.end'].push({ ...base, handler: hooks['session.turn.end'] })
       if (hooks['tool.before']) r['tool.before'].push({ ...base, handler: hooks['tool.before'] })
       if (hooks['tool.after']) r['tool.after'].push({ ...base, handler: hooks['tool.after'] })
     },
@@ -98,6 +108,8 @@ export function createHookBus(options: CreateHookBusOptions = {}): HookBus {
       r['session.end'] = r['session.end'].filter((h) => h.pluginName !== pluginName)
       r['session.idle'] = r['session.idle'].filter((h) => h.pluginName !== pluginName)
       r['session.prompt'] = r['session.prompt'].filter((h) => h.pluginName !== pluginName)
+      r['session.turn.start'] = r['session.turn.start'].filter((h) => h.pluginName !== pluginName)
+      r['session.turn.end'] = r['session.turn.end'].filter((h) => h.pluginName !== pluginName)
       r['tool.before'] = r['tool.before'].filter((h) => h.pluginName !== pluginName)
       r['tool.after'] = r['tool.after'].filter((h) => h.pluginName !== pluginName)
     },
@@ -146,6 +158,26 @@ export function createHookBus(options: CreateHookBusOptions = {}): HookBus {
           await reg.handler(event, ctx(reg))
         } catch (err) {
           reportHookError(reg, 'session.prompt', err)
+        }
+      }
+    },
+
+    async runSessionTurnStart(event) {
+      for (const reg of r['session.turn.start']) {
+        try {
+          await reg.handler(event, ctx(reg))
+        } catch (err) {
+          reportHookError(reg, 'session.turn.start', err)
+        }
+      }
+    },
+
+    async runSessionTurnEnd(event) {
+      for (const reg of r['session.turn.end']) {
+        try {
+          await reg.handler(event, ctx(reg))
+        } catch (err) {
+          reportHookError(reg, 'session.turn.end', err)
         }
       }
     },

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -102,7 +102,7 @@ export type SessionIdleEvent = {
 // long-lived TUI or channel sessions, which can sit idle between turns,
 // don't wedge a turn-counter forever. `origin` carries the session's origin
 // so observers can exclude their own induced turns when counting (e.g. the
-// auto-backup plugin excludes `subagent: 'auto-backup'` to avoid self-gating).
+// backup plugin excludes `subagent: 'backup'` to avoid self-gating).
 export type SessionTurnStartEvent = {
   sessionId: string
   agentDir: string

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -97,6 +97,24 @@ export type SessionIdleEvent = {
   origin?: SessionOrigin
 }
 
+// Brackets every `session.prompt(...)` invocation. Distinct from
+// `session.start`/`session.end` (which bracket session lifetime) so that
+// long-lived TUI or channel sessions, which can sit idle between turns,
+// don't wedge a turn-counter forever. `origin` carries the session's origin
+// so observers can exclude their own induced turns when counting (e.g. the
+// auto-backup plugin excludes `subagent: 'auto-backup'` to avoid self-gating).
+export type SessionTurnStartEvent = {
+  sessionId: string
+  agentDir: string
+  origin?: SessionOrigin
+}
+
+export type SessionTurnEndEvent = {
+  sessionId: string
+  agentDir: string
+  origin?: SessionOrigin
+}
+
 // Provider prompt caching requires byte-identical prefixes. Mutations near the
 // end of `event.prompt` preserve cache hits across sessions; mutations near
 // the start invalidate the cache on every LLM call.
@@ -136,6 +154,8 @@ export type Hooks = {
   'session.end'?: (event: SessionEndEvent, ctx: HookContext) => Promise<void> | void
   'session.idle'?: (event: SessionIdleEvent, ctx: HookContext) => Promise<void> | void
   'session.prompt'?: (event: SessionPromptEvent, ctx: HookContext) => Promise<void> | void
+  'session.turn.start'?: (event: SessionTurnStartEvent, ctx: HookContext) => Promise<void> | void
+  'session.turn.end'?: (event: SessionTurnEndEvent, ctx: HookContext) => Promise<void> | void
   'tool.before'?: (event: ToolBeforeEvent, ctx: HookContext) => Promise<ToolBeforeResult> | ToolBeforeResult
   'tool.after'?: (event: ToolAfterEvent, ctx: HookContext) => Promise<void> | void
 }

--- a/src/run/bundled-plugins.test.ts
+++ b/src/run/bundled-plugins.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, test } from 'bun:test'
 import { BUNDLED_PLUGINS } from './bundled-plugins'
 
 describe('BUNDLED_PLUGINS', () => {
-  test('contains exactly the four expected plugins in hook-precedence order', () => {
+  test('contains exactly the five expected plugins in hook-precedence order', () => {
     // Order is load-bearing: `security` must run before `guard` so its
-    // `tool.before` hook gets first refusal on overlapping policy. See the
+    // `tool.before` hook gets first refusal on overlapping policy. `memory`
+    // must run before `backup` because dreaming commits memory snapshots
+    // and any future overlap on git lock contention should be resolved in
+    // memory's favor (memory commits are smaller and more frequent). See the
     // header comment in bundled-plugins.ts.
-    expect(BUNDLED_PLUGINS.map((p) => p.name)).toEqual(['security', 'guard', 'memory', 'agent-browser'])
+    expect(BUNDLED_PLUGINS.map((p) => p.name)).toEqual(['security', 'guard', 'memory', 'backup', 'agent-browser'])
   })
 })

--- a/src/run/bundled-plugins.ts
+++ b/src/run/bundled-plugins.ts
@@ -1,4 +1,5 @@
 import agentBrowserPlugin from '@/bundled-plugins/agent-browser'
+import backupPlugin from '@/bundled-plugins/backup'
 import guardPlugin from '@/bundled-plugins/guard'
 import memoryPlugin from '@/bundled-plugins/memory'
 import securityPlugin from '@/bundled-plugins/security'
@@ -16,9 +17,16 @@ import type { ResolvedPlugin } from '@/plugin'
 // Letting `guard` run first would still work today since the two plugins
 // guard disjoint surfaces, but seeding the order now means future overlap
 // (e.g. a security policy on writes) blocks before guard's softer advice.
+//
+// `memory` is registered before `backup` so memory's dreaming commits always
+// land in the same git index window before backup's commit-and-push cycle.
+// They commit disjoint paths today (memory/ vs sessions/ + agent changes),
+// but if either ever holds .git/index.lock the deterministic order makes the
+// contention easier to reason about.
 export const BUNDLED_PLUGINS: ResolvedPlugin[] = [
   { name: 'security', version: undefined, source: '<bundled>', defined: securityPlugin },
   { name: 'guard', version: undefined, source: '<bundled>', defined: guardPlugin },
   { name: 'memory', version: undefined, source: '<bundled>', defined: memoryPlugin },
+  { name: 'backup', version: undefined, source: '<bundled>', defined: backupPlugin },
   { name: 'agent-browser', version: undefined, source: '<bundled>', defined: agentBrowserPlugin },
 ]

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -142,14 +142,15 @@ export async function startAgent({
     const entry = snap.pluginSubagentByShim.get(subagent)
     if (entry) {
       const sessionId = `subagent-${entry.pluginName}-${crypto.randomUUID()}`
+      const origin = {
+        kind: 'subagent' as const,
+        subagent: subagentOptions?.name ?? entry.subagentName,
+        parentSessionId: subagentOptions?.parentSessionId ?? '<unknown>',
+      }
       const created = await createSessionWithDispose({
         systemPromptOverride: entry.pluginSubagent.systemPrompt,
         channelRouter: channelManager.router,
-        origin: {
-          kind: 'subagent',
-          subagent: subagentOptions?.name ?? entry.subagentName,
-          parentSessionId: subagentOptions?.parentSessionId ?? '<unknown>',
-        },
+        origin,
         plugins: {
           registry: snap.registry,
           hooks: snap.hooks,
@@ -167,6 +168,8 @@ export async function startAgent({
         ...created,
         hooks: snap.hooks,
         sessionId,
+        agentDir: cwd,
+        origin,
       }
     }
     return defaultCreateSessionForSubagent(subagent, subagentOptions)
@@ -221,6 +224,8 @@ export async function startAgent({
         prompt: (text) => session.prompt(text),
         dispose: () => session.dispose(),
         sessionId,
+        agentDir: cwd,
+        origin: { kind: 'cron' as const, jobId: job.id, jobKind: 'prompt' as const },
         ...(snap.hasAnyPluginContent ? { hooks: snap.hooks } : {}),
         getTranscriptPath: () => sessionManager.getSessionFile(),
       }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -160,7 +160,7 @@ export function createServer({
 
           if (stream) {
             state.unsubPrompts = stream.subscribe({ target: { kind: 'session', sessionId: sessionFileId } }, (msg) =>
-              enqueuePrompt(ws, state, msg),
+              enqueuePrompt(ws, state, msg, agentDir),
             )
 
             state.unsubBroadcast = stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => {
@@ -226,13 +226,27 @@ export function createServer({
               return
             }
             send(ws, { type: 'prompt_started', messageId: `local-${crypto.randomUUID()}`, text: msg.text })
+            const fallbackHooks = state.runtimeSnapshot?.hooks
+            if (fallbackHooks !== undefined && agentDir !== undefined) {
+              await fallbackHooks.runSessionTurnStart({
+                sessionId: state.sessionFileId,
+                agentDir,
+                origin: state.origin,
+              })
+            }
             try {
               await state.session.prompt(msg.text)
               send(ws, { type: 'done' })
             } catch (err) {
               send(ws, { type: 'error', message: err instanceof Error ? err.message : String(err) })
             }
-            const fallbackHooks = state.runtimeSnapshot?.hooks
+            if (fallbackHooks !== undefined && agentDir !== undefined) {
+              await fallbackHooks.runSessionTurnEnd({
+                sessionId: state.sessionFileId,
+                agentDir,
+                origin: state.origin,
+              })
+            }
             if (fallbackHooks !== undefined) {
               await fallbackHooks.runSessionIdle({
                 sessionId: state.sessionFileId,
@@ -334,7 +348,7 @@ function forwardAssistantError(ws: Ws, message: unknown): void {
   send(ws, { type: 'error', message: text })
 }
 
-function enqueuePrompt(ws: Ws, state: SessionState, msg: StreamMessage): void {
+function enqueuePrompt(ws: Ws, state: SessionState, msg: StreamMessage, agentDir: string | undefined): void {
   const payload = msg.payload as { kind?: string; text?: string; delivery?: PromptDelivery }
   if (payload?.kind !== 'prompt' || typeof payload.text !== 'string') return
   const delivery: PromptDelivery = payload.delivery ?? 'queue'
@@ -350,7 +364,7 @@ function enqueuePrompt(ws: Ws, state: SessionState, msg: StreamMessage): void {
     ts: msg.ts,
   })
   pushQueueState(ws, state)
-  void drain(ws, state)
+  void drain(ws, state, agentDir)
 }
 
 // `session.idle` semantically means "the agent finished a prompt and is now
@@ -371,10 +385,26 @@ function makeIdleHookCaller(state: SessionState): () => Promise<void> {
   }
 }
 
-async function drain(ws: Ws, state: SessionState): Promise<void> {
+function makeTurnHookCallers(
+  state: SessionState,
+  agentDir: string | undefined,
+): { fireTurnStart: () => Promise<void>; fireTurnEnd: () => Promise<void> } {
+  const hooks: HookBus | undefined = state.runtimeSnapshot?.hooks
+  if (hooks === undefined || agentDir === undefined) {
+    return { fireTurnStart: async () => {}, fireTurnEnd: async () => {} }
+  }
+  const event = { sessionId: state.sessionFileId, agentDir, origin: state.origin }
+  return {
+    fireTurnStart: () => hooks.runSessionTurnStart(event),
+    fireTurnEnd: () => hooks.runSessionTurnEnd(event),
+  }
+}
+
+async function drain(ws: Ws, state: SessionState, agentDir: string | undefined): Promise<void> {
   if (state.draining) return
   state.draining = true
   const fireIdle = makeIdleHookCaller(state)
+  const { fireTurnStart, fireTurnEnd } = makeTurnHookCallers(state, agentDir)
   try {
     while (state.drainQueue.length > 0) {
       const item = state.drainQueue.shift()
@@ -382,12 +412,14 @@ async function drain(ws: Ws, state: SessionState): Promise<void> {
       pushQueueState(ws, state)
       send(ws, { type: 'prompt_started', messageId: item.streamMessageId, text: item.text })
 
+      await fireTurnStart()
       try {
         await state.session.prompt(item.text)
         send(ws, { type: 'done' })
       } catch (err) {
         send(ws, { type: 'error', message: err instanceof Error ? err.message : String(err) })
       }
+      await fireTurnEnd()
       await fireIdle()
     }
   } finally {


### PR DESCRIPTION
## Summary

Adds a bundled `backup` plugin that periodically commits dirty agent files (and force-adds `sessions/`) when the agent goes idle, then pushes to `origin` if configured. Replaces the previously documented-but-unimplemented "sessions/ via auto-backup" promise from `AGENTS.md`.

The implementation also adds two new core hook events — `session.turn.start` / `session.turn.end` — wired across all four `session.prompt()` call sites (TUI server, cron consumer, subagent runner, channel router). The backup plugin uses these to gate fires on "no in-flight work", but they're general enough that any future plugin needing the same signal can reuse them.

## Behavior

User asked for:

1. Periodically check for dirty files and commit; LLM identifies how to commit.
2. When git has origin, push to origin; on failure, let LLM handle.
3. When git has remote change, `pull --rebase origin main`; on failure, LLM handles.
4. Skip when an active session is in progress.

What this PR ships, after a pre-implementation Oracle review pushed back on a few assumptions:

- **Trigger**: `session.idle` (debounce, default 30s) — not a fixed cron schedule. Backups fire only after meaningful agent activity has settled. Tradeoff: agents that never go idle won't be backed up by this plugin alone (explicit non-goal for v1).
- **Active-session detection**: new `session.turn.start` / `session.turn.end` hooks count in-flight prompt turns, not open sessions. A long-lived TUI session sitting idle for hours is correctly treated as "quiet".
- **Self-induced turn exclusion**: the plugin's own three subagents (`backup`, `backup-message`, `backup-diagnose`) are excluded from the active-turn counter via `origin.subagent` matching, so the backup never gates against itself.
- **Execution model**: deterministic git runner — not a fully LLM-driven bash loop. The runner stages allowed paths, computes status+diffstat, delegates **only** the commit-message wording to an LLM subagent, then deterministically commits and (optionally) pushes. On non-fast-forward push the runner deterministically `fetch && rebase && push`. On rebase conflict or auth failure the runner aborts cleanly and spawns a diagnose subagent that writes a human-readable report to `sessions/backup-diagnostics.log` (forbidden from force-pushing or resolving conflicts itself).
- **Safety**: all git commands run with `GIT_TERMINAL_PROMPT=0` and per-command wall clocks (30s local, 60s network) so a stuck remote can't hang the runner.

## Why deterministic and not fully LLM-driven

Oracle pushed back on the original "subagent with bash orchestrates the whole flow" shape: it can hang on auth prompts, freestyle-mishandle merge conflicts, and burn an LLM call on every backup even when nothing went wrong. The LLM is reserved for the two narrow tasks where it adds value (commit-message wording, failure diagnosis); everything else is deterministic shell.

## Why session.idle and not cron

Tying backup frequency to actual activity removes the `*/15 * * * *` misconfiguration footgun and naturally skips quiet periods. Memory plugin's `memory-logger` already uses this exact pattern, so the runtime is well-trodden.

## Files committed by the backup plugin

- **Tracked or untracked agent paths** (anything `git status --porcelain=v1 --untracked-files=all` reports), **except** paths under `memory/` — those are owned by the memory plugin's dreaming subagent.
- **Force-added `sessions/`** — gitignored, but force-added so transcripts survive across restarts.

## Config

```json
{
  "backup": {
    "enabled": true,
    "idleMs": 30000,
    "pushToOrigin": true
  }
}
```

All fields are restart-required.

## Tests

- `runner.test.ts` — deterministic runner against an in-memory git-spawn fake. Covers: no-repo / clean / committed paths, memory/ exclusion, sessions/ force-add, no-upstream skip, push happy path, non-fast-forward → rebase → re-push, rebase conflict → abort + diagnose, advisory-throw isolation, push-disabled mode, sanitize-commit-message.
- `index.test.ts` — plugin composition: subagent/hook surface, config schema defaults and validation, debounce semantics, active-turn gating, self-induced-turn exclusion, coalescing, disabled-plugin no-op, session.end cleanup.
- `bundled-plugins.test.ts` — load-bearing plugin order updated (memory before backup; security still first).

Full suite: 2759 tests pass, 0 fail.

## Commits

1. `Add session.turn.start/end hooks for prompt-turn lifecycle` — the core hook infrastructure (HookBus types, runners, wiring at all four `session.prompt()` call sites, test-fake updates).
2. `Add backup bundled plugin to commit and push dirty work` — the plugin itself plus its registration.

## Note on branch name

The branch is `feat/auto-backup` (left as a historical artifact from an earlier name). The plugin and all identifiers were renamed to `backup` per request — see the changes in `src/bundled-plugins/backup/`. Pre-existing prose mentions of "auto-backup" in `AGENTS.md`, `README.md`, `gitignore.ts`, `system-prompt.ts`, and `typeclaw-git/SKILL.md` are intentionally left alone — they describe the runtime behavior accurately regardless of the plugin's identifier.

## Out of scope

- A safety-net cron for agents that never go idle. Add only if real usage shows the gap matters.
- Plugin-level retry queueing if a backup is dropped because the previous one is still running. The current behavior is "skip duplicate fire" via `inFlightKey: agentDir`; a queued-rerun-after-finish was deemed YAGNI for v1.
- LLM-driven merge-conflict resolution. Diagnose subagent is explicitly forbidden from this; users resolve conflicts manually.