### PR TITLE
Add typeclaw --version

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,9 +2,12 @@
 
 import { defineCommand, runMain } from 'citty'
 
+import { CLI_VERSION } from '../init/cli-version'
+
 const main = defineCommand({
   meta: {
     name: 'typeclaw',
+    version: CLI_VERSION,
     description: 'TypeClaw agent runtime',
   },
   subCommands: {


### PR DESCRIPTION
## Summary

`typeclaw --version` (and `-v`) now prints the installed CLI version. Wires the existing `CLI_VERSION` constant — already the single source of truth used by Dockerfile pinning in `src/init/cli-version.ts` — into the root `defineCommand`'s `meta`. citty handles the flag natively from there.

## Why

The CLI shipped without a `--version` flag, which is unusual enough that users assume it's broken or hunt through `package.json` instead. Adding it costs three lines and reuses the version source that already exists; no new file, no parallel constant to drift.

## Verification

```sh
$ bun src/cli/index.ts --version
0.1.2
$ bun src/cli/index.ts -v
0.1.2
```

Pre-commit (`typecheck`, `lint`, `format:check`) and `bun test src/cli/` all pass.