### PR TITLE
Re-emit entrypoint shim in versioned per-agent Dockerfile

### DIFF
--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -368,6 +368,14 @@ describe('versioned per-agent Dockerfile (base-image-pinning)', () => {
     expect(out.indexOf('ENV CUSTOM_TOOL=1')).toBeLessThan(out.indexOf('ENTRYPOINT'))
   })
 
+  test('emits the entrypoint shim install layer even though the base image already carries it (guards against older base images and shim source edits)', () => {
+    const out = buildDockerfile(dockerfileSchema.parse({}), { baseImageVersion: '0.1.1' })
+    const encoded = Buffer.from(buildEntrypointShim(), 'utf8').toString('base64')
+    expect(out).toContain(`echo "${encoded}" | base64 -d > ${TYPECLAW_ENTRYPOINT_PATH}`)
+    expect(out).toContain(`chmod +x ${TYPECLAW_ENTRYPOINT_PATH}`)
+    expect(out.indexOf(TYPECLAW_ENTRYPOINT_PATH)).toBeLessThan(out.indexOf('ENTRYPOINT'))
+  })
+
   test('explicit baseImageVersion: null is identical to the default (inline) form', () => {
     // when: caller explicitly passes null vs omits the option
     const inlineExplicit = buildDockerfile(dockerfileSchema.parse({}), { baseImageVersion: null })

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -282,8 +282,18 @@ CMD ["run"]
 // layers (apt baseline, Chrome runtime libs, curl-impersonate, agent-browser,
 // Chrome for Testing) are already in that image, so the per-agent head only
 // re-runs the toggle apt install and (optionally) the gh keyring bootstrap.
-// When no toggle adds packages, the head is empty after the FROM/WORKDIR/ARG
-// trio — rebuild cost ≈ zero for users who don't change typeclaw.json#dockerfile.
+//
+// The entrypoint shim is ALSO re-emitted here, even though the base image
+// already carries it. Two reasons: (1) older base images published before
+// the shim landed (or before a shim source edit) don't have the up-to-date
+// binary at TYPECLAW_ENTRYPOINT_PATH, and the per-agent ENTRYPOINT line
+// would crash on startup with `stat: no such file or directory`. Re-emitting
+// is ~1KB of image and keeps the contract local: whatever per-agent
+// Dockerfile we emit guarantees the shim path exists, regardless of which
+// base-image vintage we FROM. (2) Edits to `buildEntrypointShim()` ship via
+// npm + `typeclaw start --build` immediately, instead of being blocked on a
+// fresh base-image release. The base image's copy is harmlessly overwritten
+// by this RUN — same path, same chmod.
 function renderVersionedHead(baseImageVersion: string, ghKeyringLayer: string, toggleAptArgs: string[]): string {
   const toggleAptLayer = toggleAptArgs.length === 0 ? '' : `${renderToggleAptInstallLayer(toggleAptArgs)}\n\n`
   return `FROM ${GHCR_BASE_IMAGE_REPO}:${baseImageVersion}
@@ -292,7 +302,9 @@ WORKDIR /agent
 
 ARG TARGETARCH
 
-${ghKeyringLayer}${toggleAptLayer}`
+${ghKeyringLayer}${toggleAptLayer}${renderEntrypointShimLayer()}
+
+`
 }
 
 // FROMs oven/bun:1-slim and rebuilds the full heavy stack inline. Used by


### PR DESCRIPTION
## Summary

The versioned Dockerfile path (`renderVersionedHead`, used when typeclaw is installed as a release `X.Y.Z`) was skipping the entrypoint shim install layer on the assumption that `ghcr.io/typeclaw/typeclaw-base:X.Y.Z` already carried it. That assumption breaks in two real failure modes — both producing the same opaque crash on `typeclaw start`:

```
Hatching failed: docker run failed: ... exec: "/usr/local/bin/typeclaw-entrypoint": stat /usr/local/bin/typeclaw-entrypoint: no such file or directory
```

1. **Stale base image vintage.** Any `typeclaw-base:X.Y.Z` published before the shim layer was added to `buildBaseDockerfile()` has no `/usr/local/bin/typeclaw-entrypoint`. The per-agent `ENTRYPOINT ["/usr/local/bin/typeclaw-entrypoint"]` (set unconditionally by both paths) crashes on first `docker run`. Hit by a user on a `0.1.1`-pinned agent folder.
2. **Shim source edits couldn't ship via npm alone.** Even on a current base image, edits to `buildEntrypointShim()` only took effect after a fresh base-image release. `typeclaw start --build` with a new npm version was a silent no-op for shim changes.

## Changes

**`src/init/dockerfile.ts`** — `renderVersionedHead()` now appends `${renderEntrypointShimLayer()}` after the toggle apt layer, with a comment explaining the duplication is intentional.

**`src/init/dockerfile.test.ts`** — one regression test added to the `describe('versioned per-agent Dockerfile (base-image-pinning)')` block, asserting the shim install layer is present and ordered before `ENTRYPOINT`. Verified failing-first by reverting the source change locally.

## Why the duplication is intentional

Re-emitting `renderEntrypointShimLayer()` in `renderVersionedHead()` costs ~1KB and harmlessly overwrites whatever the base image had at the same path. The contract is now local: whichever path is taken, the emitted Dockerfile guarantees the shim binary exists at `TYPECLAW_ENTRYPOINT_PATH` before `ENTRYPOINT` runs.

Side benefit: shim source edits now ship via npm + `typeclaw start --build` immediately, decoupled from base-image release cadence.

`buildBaseDockerfile()` continues to emit the shim too — unchanged and correct. The per-agent layer now overwrites it with a possibly-fresher copy.

## Test gap that let this slip

The existing shim-install test in `dockerfile.test.ts` (line 468) only exercised `buildDockerfile()` (inline path). The `describe('versioned per-agent Dockerfile (base-image-pinning)')` block had every other invariant locked down — FROM tag interpolation, heavy-stack absence, toggle behavior, append ordering, ENTRYPOINT presence — but no shim assertion. The added test closes that gap.

## Verification

- `bun test src/init/dockerfile.test.ts` → 56 pass, 0 fail (new test included).
- `bun run typecheck` → clean.
- `bun run lint` → clean (1 pre-existing warning in `src/doctor/index.ts`, unrelated).
- `bun run format:check` → clean.
- `bun test` (full suite) → 2759 pass, 1 fail. The one failure (`typeclaw.schema.json > drift guard`) pre-exists on `main`.
- Manual: `typeclaw start --build` in an agent folder pinned to `typeclaw-base:0.1.1`. Before: container crashes with the entrypoint stat error. After: boots cleanly; `docker run --rm --entrypoint ls <agent-image> -la /usr/local/bin/typeclaw-entrypoint` confirms shim present.