### PR TITLE
Auto-upgrade agent typeclaw dep on start to match CLI

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -123,5 +123,6 @@ function startOk(opts: StartOptions): StartResult {
     hostPort: opts.preferredHostPort,
     hostd: { state: 'registered' },
     alreadyRunning: false,
+    autoUpgrade: { kind: 'skipped-no-dep' },
   }
 }

--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -140,6 +140,62 @@ describe('renderStartSuccess', () => {
     expect(out).toContain('\u001b[32m8973')
     expect(out).toContain('\u001b[36mcoder')
   })
+
+  test('omits any auto-upgrade line on no-op outcomes (silent on no-op)', () => {
+    for (const upgrade of [
+      { kind: 'up-to-date', installedVersion: '0.1.2' } as const,
+      { kind: 'skipped-dev-mode' } as const,
+      { kind: 'skipped-no-dep' } as const,
+      { kind: 'skipped-already-running' } as const,
+      { kind: 'skipped-non-release-spec', declared: 'latest' } as const,
+    ]) {
+      const out = withNoColor(() => renderStartSuccess(baseResult({ autoUpgrade: upgrade })))
+      expect(out).not.toContain('Upgrading')
+      expect(out).not.toContain('exact-pinned')
+    }
+  })
+
+  test('renders the cyan upgrade line on spec-rewritten', () => {
+    const out = withForcedColor(() =>
+      renderStartSuccess(
+        baseResult({ autoUpgrade: { kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0', cliVersion: '0.2.0' } }),
+      ),
+    )
+    expect(out).toContain('Upgrading agent typeclaw ^0.1.0')
+    expect(out).toContain('^0.2.0')
+    expect(out).toContain('\u001b[36m')
+  })
+
+  test('renders the cyan upgrade line on reinstall-needed', () => {
+    const out = withForcedColor(() =>
+      renderStartSuccess(baseResult({ autoUpgrade: { kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' } })),
+    )
+    expect(out).toContain('Upgrading agent typeclaw 0.1.0 → 0.1.2')
+    expect(out).toContain('\u001b[36m')
+  })
+
+  test('renders the yellow warning line on exact-pin-respected', () => {
+    const out = withForcedColor(() =>
+      renderStartSuccess(
+        baseResult({ autoUpgrade: { kind: 'exact-pin-respected', declared: '0.1.0', cliVersion: '0.1.2' } }),
+      ),
+    )
+    expect(out).toContain('exact-pinned to 0.1.0')
+    expect(out).toContain('CLI is 0.1.2')
+    expect(out).toContain('\u001b[33m')
+  })
+
+  test('places the upgrade line ABOVE the "started on host port" line', () => {
+    const out = withNoColor(() =>
+      renderStartSuccess(
+        baseResult({ autoUpgrade: { kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0', cliVersion: '0.2.0' } }),
+      ),
+    )
+    const upgradeIdx = out.indexOf('Upgrading')
+    const startedIdx = out.indexOf('started on host port')
+    expect(upgradeIdx).toBeGreaterThanOrEqual(0)
+    expect(startedIdx).toBeGreaterThan(upgradeIdx)
+  })
 })
 
 describe('errorLine / successLine', () => {

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -2,6 +2,8 @@ import { styleText } from 'node:util'
 
 import { cancel, intro, isCancel, log, note, outro, spinner as clackSpinner } from '@clack/prompts'
 
+import { type AutoUpgradeOutcome, describeAutoUpgrade } from '@/init/auto-upgrade'
+
 export { cancel, intro, isCancel, log, note, outro }
 
 function colorize(modifier: Parameters<typeof styleText>[0], s: string): string {
@@ -62,12 +64,21 @@ export type StartLikeResult = {
   hostPort: number
   containerId: string
   hostd: { state: 'registered' } | { state: 'unavailable'; reason: string } | { state: 'disabled' }
+  autoUpgrade?: AutoUpgradeOutcome
 }
 
 export function renderStartSuccess(result: StartLikeResult): string {
   const lines: string[] = []
   const name = c.cyan(result.plan.containerName)
   const port = c.green(String(result.hostPort))
+
+  if (result.autoUpgrade) {
+    const message = describeAutoUpgrade(result.autoUpgrade)
+    if (message.length > 0) {
+      const tint = result.autoUpgrade.kind === 'exact-pin-respected' ? c.yellow : c.cyan
+      lines.push(tint(message))
+    }
+  }
 
   if (result.alreadyRunning) {
     lines.push(`${c.green('●')} ${name} is already running on host port ${port}.`)

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -2370,3 +2370,182 @@ describe('planStart port mapping', () => {
     expect(plan.hostPort).toBe(49160)
   })
 })
+
+describe('start autoUpgrade integration', () => {
+  test('forces bun install when autoUpgrade reports spec-rewritten, even when ensureDeps would short-circuit', async () => {
+    // given: an agent folder where ensureDeps would consider every dep present
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.2.0' })
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    // when: autoUpgrade reports a spec rewrite
+    const installCalls: string[] = []
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: async () => ({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' }),
+      forceBunInstall: async (dir) => {
+        installCalls.push(dir)
+        return { ok: true }
+      },
+      ...bypassVerify,
+    })
+
+    // then: forceBunInstall was called with the agent folder
+    expect(result.ok).toBe(true)
+    expect(installCalls).toEqual([root])
+    // and: the upgrade outcome is surfaced on the result
+    if (!result.ok) throw new Error('expected success')
+    expect(result.autoUpgrade).toEqual({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' })
+  })
+
+  test('forces bun install when autoUpgrade reports reinstall-needed', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const installCalls: string[] = []
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: async () => ({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' }),
+      forceBunInstall: async (dir) => {
+        installCalls.push(dir)
+        return { ok: true }
+      },
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(installCalls).toEqual([root])
+  })
+
+  test('does NOT force bun install for no-op outcomes (up-to-date, dev mode, exact pin)', async () => {
+    for (const upgrade of [
+      { kind: 'up-to-date', installedVersion: '0.1.2' } as const,
+      { kind: 'skipped-dev-mode' } as const,
+      { kind: 'skipped-no-dep' } as const,
+      { kind: 'exact-pin-respected', declared: '0.1.0', cliVersion: '0.1.2' } as const,
+    ]) {
+      await writeDockerfile(root)
+      await writePackageJson(root, { typeclaw: '^0.1.0' })
+      const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+      const installCalls: string[] = []
+      const result = await start({
+        cwd: root,
+        preferredHostPort: 8973,
+        exec,
+        allocatePort: deterministicAllocator,
+        ensureDeps: noEnsureDeps,
+        autoUpgrade: async () => upgrade,
+        forceBunInstall: async (dir) => {
+          installCalls.push(dir)
+          return { ok: true }
+        },
+        ...bypassVerify,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(installCalls).toEqual([])
+    }
+  })
+
+  test('aborts start (no docker run) when forceBunInstall reports failure', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: async () => ({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' }),
+      forceBunInstall: async () => ({ ok: false, reason: 'registry timeout' }),
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toContain('registry timeout')
+    expect(result.reason).toContain('auto-upgrade')
+    // and: no docker run happened — the partial install would crash the container
+    expect(calls.find((c) => c.args[0] === 'run')).toBeUndefined()
+  })
+
+  test('commits package.json + bun.lock under "Upgrade typeclaw to X.Y.Z" message when autoUpgrade rewrote spec', async () => {
+    // given: an initialized git repo with a tracked package.json and bun.lock
+    await gitInit(root)
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1}\n')
+    await runGit(root, ['add', '.gitignore', 'package.json', 'packages/.gitkeep', 'bun.lock'])
+    await runGit(root, ['commit', '-m', 'initial'])
+    // and: forceBunInstall mutates package.json + bun.lock as a real install would
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: async () => ({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' }),
+      forceBunInstall: async (dir) => {
+        // Simulate `bun install` writing the new spec + a refreshed lockfile.
+        await writePackageJson(dir, { typeclaw: '^0.2.0' })
+        await writeFile(join(dir, 'bun.lock'), '{"lockfileVersion":1,"deps":"upgraded"}\n')
+        return { ok: true }
+      },
+      ...bypassVerify,
+    })
+
+    // then: the commit message names the upgrade target, not the generic "Update dependencies"
+    expect(result.ok).toBe(true)
+    const subjects = (await runGit(root, ['log', '--format=%s'])).split('\n')
+    expect(subjects).toContain('Upgrade typeclaw to ^0.2.0')
+    expect(subjects).not.toContain('Update dependencies')
+    // and: both files are in the same commit
+    const filesInCommit = (await runGit(root, ['show', '--name-only', '--format=', 'HEAD'])).split('\n').sort()
+    expect(filesInCommit).toEqual(['bun.lock', 'package.json'])
+  })
+
+  test('uses "Update dependencies" when autoUpgrade is a no-op (no commit attribution to upgrade)', async () => {
+    // given: a clean git repo where ensureDeps will trigger a generic dep update
+    await gitInit(root)
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1}\n')
+    await runGit(root, ['add', '.gitignore', 'package.json', 'packages/.gitkeep', 'bun.lock'])
+    await runGit(root, ['commit', '-m', 'initial'])
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: async (dir) => {
+        // Pretend ensureDeps installed and the lockfile drifted.
+        await writeFile(join(dir, 'bun.lock'), '{"lockfileVersion":1,"deps":"new"}\n')
+        return { ok: true, installed: true }
+      },
+      autoUpgrade: async () => ({ kind: 'up-to-date', installedVersion: '0.1.2' }),
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    const subjects = (await runGit(root, ['log', '--format=%s'])).split('\n')
+    expect(subjects).toContain('Update dependencies')
+    expect(subjects.filter((s) => s.startsWith('Upgrade typeclaw'))).toEqual([])
+  })
+})

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -2372,42 +2372,40 @@ describe('planStart port mapping', () => {
 })
 
 describe('start autoUpgrade integration', () => {
-  test('forces bun install when autoUpgrade reports spec-rewritten, even when ensureDeps would short-circuit', async () => {
-    // given: an agent folder where ensureDeps would consider every dep present
+  test('forces bun update typeclaw when autoUpgrade reports spec-rewritten', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.2.0' })
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
-    // when: autoUpgrade reports a spec rewrite
-    const installCalls: string[] = []
+    const updateCalls: Array<{ cwd: string; pkg: string }> = []
     const result = await start({
       cwd: root,
       preferredHostPort: 8973,
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
-      autoUpgrade: async () => ({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' }),
-      forceBunInstall: async (dir) => {
-        installCalls.push(dir)
+      autoUpgrade: async () => ({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0', cliVersion: '0.2.0' }),
+      forceBunUpdate: async (cwd, pkg) => {
+        updateCalls.push({ cwd, pkg })
         return { ok: true }
       },
+      readInstalledVersion: () => '0.2.0',
       ...bypassVerify,
     })
 
-    // then: forceBunInstall was called with the agent folder
     expect(result.ok).toBe(true)
-    expect(installCalls).toEqual([root])
-    // and: the upgrade outcome is surfaced on the result
+    // and: bun update was called with the agent folder AND the typeclaw package name
+    expect(updateCalls).toEqual([{ cwd: root, pkg: 'typeclaw' }])
     if (!result.ok) throw new Error('expected success')
-    expect(result.autoUpgrade).toEqual({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' })
+    expect(result.autoUpgrade).toEqual({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0', cliVersion: '0.2.0' })
   })
 
-  test('forces bun install when autoUpgrade reports reinstall-needed', async () => {
+  test('forces bun update typeclaw when autoUpgrade reports reinstall-needed', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
-    const installCalls: string[] = []
+    const updateCalls: Array<{ cwd: string; pkg: string }> = []
     const result = await start({
       cwd: root,
       preferredHostPort: 8973,
@@ -2415,29 +2413,32 @@ describe('start autoUpgrade integration', () => {
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
       autoUpgrade: async () => ({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' }),
-      forceBunInstall: async (dir) => {
-        installCalls.push(dir)
+      forceBunUpdate: async (cwd, pkg) => {
+        updateCalls.push({ cwd, pkg })
         return { ok: true }
       },
+      readInstalledVersion: () => '0.1.2',
       ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
-    expect(installCalls).toEqual([root])
+    expect(updateCalls).toEqual([{ cwd: root, pkg: 'typeclaw' }])
   })
 
-  test('does NOT force bun install for no-op outcomes (up-to-date, dev mode, exact pin)', async () => {
+  test('does NOT call forceBunUpdate for no-op outcomes (up-to-date, dev mode, exact pin, already running, etc.)', async () => {
     for (const upgrade of [
       { kind: 'up-to-date', installedVersion: '0.1.2' } as const,
       { kind: 'skipped-dev-mode' } as const,
       { kind: 'skipped-no-dep' } as const,
+      { kind: 'skipped-already-running' } as const,
+      { kind: 'skipped-non-release-spec', declared: 'file:../typeclaw' } as const,
       { kind: 'exact-pin-respected', declared: '0.1.0', cliVersion: '0.1.2' } as const,
     ]) {
       await writeDockerfile(root)
       await writePackageJson(root, { typeclaw: '^0.1.0' })
       const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
-      const installCalls: string[] = []
+      const updateCalls: Array<{ cwd: string; pkg: string }> = []
       const result = await start({
         cwd: root,
         preferredHostPort: 8973,
@@ -2445,19 +2446,19 @@ describe('start autoUpgrade integration', () => {
         allocatePort: deterministicAllocator,
         ensureDeps: noEnsureDeps,
         autoUpgrade: async () => upgrade,
-        forceBunInstall: async (dir) => {
-          installCalls.push(dir)
+        forceBunUpdate: async (cwd, pkg) => {
+          updateCalls.push({ cwd, pkg })
           return { ok: true }
         },
         ...bypassVerify,
       })
 
       expect(result.ok).toBe(true)
-      expect(installCalls).toEqual([])
+      expect(updateCalls).toEqual([])
     }
   })
 
-  test('aborts start (no docker run) when forceBunInstall reports failure', async () => {
+  test('aborts start (no docker run) when forceBunUpdate reports failure', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
@@ -2469,27 +2470,50 @@ describe('start autoUpgrade integration', () => {
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
       autoUpgrade: async () => ({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' }),
-      forceBunInstall: async () => ({ ok: false, reason: 'registry timeout' }),
+      forceBunUpdate: async () => ({ ok: false, reason: 'registry timeout' }),
     })
 
     expect(result.ok).toBe(false)
     if (result.ok) throw new Error('expected failure')
     expect(result.reason).toContain('registry timeout')
     expect(result.reason).toContain('auto-upgrade')
-    // and: no docker run happened — the partial install would crash the container
     expect(calls.find((c) => c.args[0] === 'run')).toBeUndefined()
   })
 
-  test('commits package.json + bun.lock under "Upgrade typeclaw to X.Y.Z" message when autoUpgrade rewrote spec', async () => {
-    // given: an initialized git repo with a tracked package.json and bun.lock
-    await gitInit(root)
-    await writeFile(join(root, '.gitignore'), buildGitignore())
-    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+  test('aborts start when bun update succeeds but installed version is still stale (verification gate)', async () => {
+    // Oracle's BLOCKING #5: bun update can exit 0 but resolve to an older version
+    // than expected. Without verification, refreshDockerfile would pin a stale base
+    // image. This test guards the verification step.
+    await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
-    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1}\n')
-    await runGit(root, ['add', '.gitignore', 'package.json', 'packages/.gitkeep', 'bun.lock'])
-    await runGit(root, ['commit', '-m', 'initial'])
-    // and: forceBunInstall mutates package.json + bun.lock as a real install would
+    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: async () => ({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' }),
+      forceBunUpdate: async () => ({ ok: true }),
+      readInstalledVersion: () => '0.1.0',
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toContain('verification failed')
+    expect(result.reason).toContain('0.1.0')
+    expect(result.reason).toContain('0.1.2')
+    expect(calls.find((c) => c.args[0] === 'run')).toBeUndefined()
+  })
+
+  test('verification passes when installed reaches OR EXCEEDS the upgrade target', async () => {
+    // The registry may resolve a caret range to a higher patch than we asked for
+    // (e.g. expected 0.1.2 but got 0.1.5 because the lockfile no longer pinned it).
+    // Treat "ahead" as success — we only fail when installed is BEHIND target.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     const result = await start({
@@ -2498,28 +2522,129 @@ describe('start autoUpgrade integration', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
-      autoUpgrade: async () => ({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' }),
-      forceBunInstall: async (dir) => {
-        // Simulate `bun install` writing the new spec + a refreshed lockfile.
-        await writePackageJson(dir, { typeclaw: '^0.2.0' })
-        await writeFile(join(dir, 'bun.lock'), '{"lockfileVersion":1,"deps":"upgraded"}\n')
-        return { ok: true }
+      autoUpgrade: async () => ({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' }),
+      forceBunUpdate: async () => ({ ok: true }),
+      readInstalledVersion: () => '0.1.5',
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+  })
+
+  test('autoUpgrade runs BEFORE ensureDeps (load-bearing order)', async () => {
+    // The whole feature breaks if ensureDeps runs first: ensureDeps short-circuits
+    // on "every declared dep exists" and skips the install that auto-upgrade depends
+    // on. Test by recording call order in a shared array.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const order: string[] = []
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      autoUpgrade: async () => {
+        order.push('autoUpgrade')
+        return { kind: 'skipped-no-dep' }
+      },
+      ensureDeps: async () => {
+        order.push('ensureDeps')
+        return { ok: true, installed: false }
       },
       ...bypassVerify,
     })
 
-    // then: the commit message names the upgrade target, not the generic "Update dependencies"
+    expect(result.ok).toBe(true)
+    expect(order).toEqual(['autoUpgrade', 'ensureDeps'])
+  })
+
+  test('alreadyRunning short-circuit surfaces autoUpgrade: skipped-already-running', async () => {
+    // When the container is already up, start() returns without checking auto-upgrade.
+    // The outcome must reflect that honestly, not pretend we checked and found no dep.
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: true, running: true } })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected success')
+    expect(result.alreadyRunning).toBe(true)
+    expect(result.autoUpgrade).toEqual({ kind: 'skipped-already-running' })
+  })
+
+  test('commits package.json + bun.lock under "Upgrade typeclaw to X.Y.Z" when autoUpgrade rewrote spec', async () => {
+    await gitInit(root)
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1}\n')
+    await runGit(root, ['add', '.gitignore', 'package.json', 'packages/.gitkeep', 'bun.lock'])
+    await runGit(root, ['commit', '-m', 'initial'])
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: async () => ({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0', cliVersion: '0.2.0' }),
+      forceBunUpdate: async (dir) => {
+        await writePackageJson(dir, { typeclaw: '^0.2.0' })
+        await writeFile(join(dir, 'bun.lock'), '{"lockfileVersion":1,"deps":"upgraded"}\n')
+        return { ok: true }
+      },
+      readInstalledVersion: () => '0.2.0',
+      ...bypassVerify,
+    })
+
     expect(result.ok).toBe(true)
     const subjects = (await runGit(root, ['log', '--format=%s'])).split('\n')
     expect(subjects).toContain('Upgrade typeclaw to ^0.2.0')
     expect(subjects).not.toContain('Update dependencies')
-    // and: both files are in the same commit
     const filesInCommit = (await runGit(root, ['show', '--name-only', '--format=', 'HEAD'])).split('\n').sort()
     expect(filesInCommit).toEqual(['bun.lock', 'package.json'])
   })
 
-  test('uses "Update dependencies" when autoUpgrade is a no-op (no commit attribution to upgrade)', async () => {
-    // given: a clean git repo where ensureDeps will trigger a generic dep update
+  test('commits under "Upgrade typeclaw to X.Y.Z" for reinstall-needed (not just spec-rewritten)', async () => {
+    await gitInit(root)
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeFile(join(root, 'bun.lock'), '{"lockfileVersion":1}\n')
+    await runGit(root, ['add', '.gitignore', 'package.json', 'packages/.gitkeep', 'bun.lock'])
+    await runGit(root, ['commit', '-m', 'initial'])
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: async () => ({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' }),
+      forceBunUpdate: async (dir) => {
+        await writeFile(join(dir, 'bun.lock'), '{"lockfileVersion":1,"deps":"upgraded"}\n')
+        return { ok: true }
+      },
+      readInstalledVersion: () => '0.1.2',
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    const subjects = (await runGit(root, ['log', '--format=%s'])).split('\n')
+    expect(subjects).toContain('Upgrade typeclaw to 0.1.2')
+  })
+
+  test('uses "Update dependencies" when autoUpgrade is a no-op (no upgrade attribution)', async () => {
     await gitInit(root)
     await writeFile(join(root, '.gitignore'), buildGitignore())
     await writeFile(join(root, 'Dockerfile'), buildDockerfile())
@@ -2535,7 +2660,6 @@ describe('start autoUpgrade integration', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: async (dir) => {
-        // Pretend ensureDeps installed and the lockfile drifted.
         await writeFile(join(dir, 'bun.lock'), '{"lockfileVersion":1,"deps":"new"}\n')
         return { ok: true, installed: true }
       },

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -7,13 +7,19 @@ import { configSchema, expandMountPath, type Config } from '@/config/config'
 import { send as sendToDaemon } from '@/hostd/client'
 import type { HttpInfoResult } from '@/hostd/protocol'
 import { ensureDaemon } from '@/hostd/spawn'
-import { autoUpgradeTypeclawDep, type AutoUpgradeOutcome, outcomeForcesInstall } from '@/init/auto-upgrade'
+import {
+  autoUpgradeTypeclawDep,
+  type AutoUpgradeOutcome,
+  expectedInstalledAfterUpgrade,
+  outcomeForcesInstall,
+  readInstalledTypeclawVersionFromAgent,
+} from '@/init/auto-upgrade'
 import { resolveBaseImageVersion } from '@/init/cli-version'
 import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { ensureDepsInstalled, type EnsureDepsResult } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 import { refreshPackageJson } from '@/init/packagejson'
-import { type InstallRunner, runBunInstall } from '@/init/run-bun-install'
+import { runBunUpdate, type UpdateRunner } from '@/init/run-bun-install'
 
 import { CONTAINER_PORT, findFreePort, isPortAllocatedError } from './port'
 import {
@@ -84,9 +90,20 @@ export type StartOptions = {
   // package.json). Tests inject a stub to simulate `bun -g update typeclaw`
   // having bumped the CLI without touching the agent folder.
   autoUpgrade?: (cwd: string) => Promise<AutoUpgradeOutcome>
-  // Test seam for the auto-upgrade-triggered `bun install`. Defaults to the
-  // same runBunInstall the ensureDeps codepath uses.
-  forceBunInstall?: InstallRunner
+  // Test seam for the auto-upgrade-triggered registry resolution. Defaults
+  // to `bun update typeclaw --latest`. Cannot be `runBunInstall` — see the
+  // module header in src/init/auto-upgrade.ts for why install doesn't move
+  // an already-locked in-range dep.
+  forceBunUpdate?: UpdateRunner
+  // Test seam for the post-install verification. Reads the version actually
+  // present in <agent>/node_modules/typeclaw/package.json after the upgrade
+  // install completes. Defaults to readInstalledTypeclawVersionFromAgent.
+  // Verification is mandatory: `bun update` can succeed (exit 0) but still
+  // resolve to an older version than expected if the registry has issues
+  // or the spec resolution surprises us; we MUST refuse to proceed to
+  // refreshDockerfile in that case, otherwise the Dockerfile pins a stale
+  // base image and the build either fails or runs against the wrong runtime.
+  readInstalledVersion?: (cwd: string) => string | null
   // Post-`docker run` verifier. `docker run -d` returns exit 0 the moment the
   // container is created, even if its entrypoint crashes milliseconds later.
   // The default verifier polls `docker inspect` for 1.5s and converts crashes
@@ -130,7 +147,8 @@ export async function start({
   reuseCurrentHostDaemon = false,
   ensureDeps = (dir) => ensureDepsInstalled({ cwd: dir }),
   autoUpgrade = (dir) => autoUpgradeTypeclawDep({ cwd: dir }),
-  forceBunInstall = runBunInstall,
+  forceBunUpdate = runBunUpdate,
+  readInstalledVersion = readInstalledTypeclawVersionFromAgent,
   verifyRunning = createVerifyRunning({ exec }),
 }: StartOptions): Promise<StartResult> {
   try {
@@ -169,15 +187,32 @@ export async function start({
     // stays pinned to whatever was installed at init time. refreshDockerfile
     // then pins FROM ghcr/typeclaw-base:<old-version> and the docker build
     // either fails (image never published) or runs against a stale runtime.
-    // When the spec is rewritten or installed < CLI, ensureDeps may consider
-    // every declared dep already present and short-circuit — force the
-    // install here so the new typeclaw version actually lands in node_modules.
+    //
+    // We use `bun update typeclaw --latest` (NOT `bun install`) because plain
+    // install honors the lockfile and is a no-op when the lockfile already
+    // satisfies the declared spec — which is the canonical regression case
+    // (lockfile pins 0.1.0, spec says ^0.1.0, CLI is 0.1.2; install does
+    // nothing, update force-resolves to 0.1.2).
+    //
+    // After the update we MUST verify the installed version actually matches
+    // the upgrade target. `bun update` can exit 0 but resolve to a stale
+    // version (registry hiccups, surprising spec resolution). If verification
+    // fails we abort before refreshDockerfile so we never pin a stale base
+    // image to a fresh container build.
     const upgrade = await autoUpgrade(cwd)
     const upgradeCommitMessage = commitMessageForAutoUpgrade(upgrade)
     if (outcomeForcesInstall(upgrade)) {
-      const forced = await forceBunInstall(cwd)
+      const forced = await forceBunUpdate(cwd, 'typeclaw')
       if (!forced.ok) {
         return { ok: false, reason: `typeclaw auto-upgrade install failed: ${forced.reason}` }
+      }
+      const expected = expectedInstalledAfterUpgrade(upgrade)
+      const installedAfter = readInstalledVersion(cwd)
+      if (expected !== null && (installedAfter === null || !installedReachesTarget(installedAfter, expected))) {
+        return {
+          ok: false,
+          reason: `typeclaw auto-upgrade verification failed: bun update reported success but <agent>/node_modules/typeclaw is ${installedAfter ?? 'missing'} (expected >= ${expected}). Refusing to build a Docker image against a stale runtime.`,
+        }
       }
     }
 
@@ -346,6 +381,18 @@ function commitMessageForAutoUpgrade(outcome: AutoUpgradeOutcome): string | null
   if (outcome.kind === 'spec-rewritten') return `Upgrade typeclaw to ${outcome.to}`
   if (outcome.kind === 'reinstall-needed') return `Upgrade typeclaw to ${outcome.to}`
   return null
+}
+
+function installedReachesTarget(installed: string, target: string): boolean {
+  const ai = installed.match(/^(\d+)\.(\d+)\.(\d+)$/)
+  const at = target.match(/^(\d+)\.(\d+)\.(\d+)$/)
+  if (!ai || !at) return false
+  for (let i = 1; i <= 3; i++) {
+    const a = Number.parseInt(ai[i]!, 10)
+    const t = Number.parseInt(at[i]!, 10)
+    if (a !== t) return a > t
+  }
+  return true
 }
 
 export async function planStart({
@@ -576,7 +623,7 @@ async function reportAlreadyRunning(exec: DockerExec, cwd: string, containerName
     hostPort,
     hostd: { state: 'disabled' },
     alreadyRunning: true,
-    autoUpgrade: { kind: 'skipped-no-dep' },
+    autoUpgrade: { kind: 'skipped-already-running' },
   }
 }
 

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -7,11 +7,13 @@ import { configSchema, expandMountPath, type Config } from '@/config/config'
 import { send as sendToDaemon } from '@/hostd/client'
 import type { HttpInfoResult } from '@/hostd/protocol'
 import { ensureDaemon } from '@/hostd/spawn'
+import { autoUpgradeTypeclawDep, type AutoUpgradeOutcome, outcomeForcesInstall } from '@/init/auto-upgrade'
 import { resolveBaseImageVersion } from '@/init/cli-version'
 import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { ensureDepsInstalled, type EnsureDepsResult } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 import { refreshPackageJson } from '@/init/packagejson'
+import { type InstallRunner, runBunInstall } from '@/init/run-bun-install'
 
 import { CONTAINER_PORT, findFreePort, isPortAllocatedError } from './port'
 import {
@@ -77,6 +79,14 @@ export type StartOptions = {
   // Reusing that daemon avoids a self-shutdown when disk source has drifted.
   reuseCurrentHostDaemon?: boolean
   ensureDeps?: (cwd: string) => Promise<EnsureDepsResult>
+  // Test seam for the typeclaw-version auto-upgrade. Production callers omit
+  // this and get the real autoUpgradeTypeclawDep (which reads the CLI's own
+  // package.json). Tests inject a stub to simulate `bun -g update typeclaw`
+  // having bumped the CLI without touching the agent folder.
+  autoUpgrade?: (cwd: string) => Promise<AutoUpgradeOutcome>
+  // Test seam for the auto-upgrade-triggered `bun install`. Defaults to the
+  // same runBunInstall the ensureDeps codepath uses.
+  forceBunInstall?: InstallRunner
   // Post-`docker run` verifier. `docker run -d` returns exit 0 the moment the
   // container is created, even if its entrypoint crashes milliseconds later.
   // The default verifier polls `docker inspect` for 1.5s and converts crashes
@@ -106,6 +116,7 @@ export type StartResult =
       // every fresh launch, including the post-stale-corpse `--rm` recovery
       // path — that one rebuilds the container from scratch.
       alreadyRunning: boolean
+      autoUpgrade: AutoUpgradeOutcome
     }
   | { ok: false; reason: string }
 
@@ -118,6 +129,8 @@ export async function start({
   cliEntry,
   reuseCurrentHostDaemon = false,
   ensureDeps = (dir) => ensureDepsInstalled({ cwd: dir }),
+  autoUpgrade = (dir) => autoUpgradeTypeclawDep({ cwd: dir }),
+  forceBunInstall = runBunInstall,
   verifyRunning = createVerifyRunning({ exec }),
 }: StartOptions): Promise<StartResult> {
   try {
@@ -149,6 +162,25 @@ export async function start({
     if (pkgRefresh.changed) {
       await commitSystemFile(cwd, pkgRefresh.files, 'Enable bun workspaces (packages/*)')
     }
+
+    // Align the agent's typeclaw dep with the global CLI version BEFORE
+    // ensureDeps runs. The classic regression this prevents: `bun -g update
+    // typeclaw` bumps the global CLI but the agent's node_modules/typeclaw
+    // stays pinned to whatever was installed at init time. refreshDockerfile
+    // then pins FROM ghcr/typeclaw-base:<old-version> and the docker build
+    // either fails (image never published) or runs against a stale runtime.
+    // When the spec is rewritten or installed < CLI, ensureDeps may consider
+    // every declared dep already present and short-circuit — force the
+    // install here so the new typeclaw version actually lands in node_modules.
+    const upgrade = await autoUpgrade(cwd)
+    const upgradeCommitMessage = commitMessageForAutoUpgrade(upgrade)
+    if (outcomeForcesInstall(upgrade)) {
+      const forced = await forceBunInstall(cwd)
+      if (!forced.ok) {
+        return { ok: false, reason: `typeclaw auto-upgrade install failed: ${forced.reason}` }
+      }
+    }
+
     // Run `bun install` BEFORE the dependency-drift commit so the lockfile
     // changes the install produces are caught by the same commit. Without
     // this, upgrading the typeclaw CLI to a version that adds a new dep
@@ -160,7 +192,7 @@ export async function start({
     if (!deps.ok) {
       return { ok: false, reason: `dependency install failed: ${deps.reason}` }
     }
-    await commitSystemFile(cwd, DEPENDENCY_FILES, 'Update dependencies')
+    await commitSystemFile(cwd, DEPENDENCY_FILES, upgradeCommitMessage ?? 'Update dependencies')
     // Dockerfile refresh AFTER ensureDeps so the version pin in the FROM
     // line resolves against the agent's installed node_modules/typeclaw —
     // ensures the base image's CLI version matches the runtime the
@@ -303,10 +335,17 @@ export async function start({
       hostPort,
       hostd: stripHostDaemonControl(hostd),
       alreadyRunning: false,
+      autoUpgrade: upgrade,
     }
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
   }
+}
+
+function commitMessageForAutoUpgrade(outcome: AutoUpgradeOutcome): string | null {
+  if (outcome.kind === 'spec-rewritten') return `Upgrade typeclaw to ${outcome.to}`
+  if (outcome.kind === 'reinstall-needed') return `Upgrade typeclaw to ${outcome.to}`
+  return null
 }
 
 export async function planStart({
@@ -537,6 +576,7 @@ async function reportAlreadyRunning(exec: DockerExec, cwd: string, containerName
     hostPort,
     hostd: { state: 'disabled' },
     alreadyRunning: true,
+    autoUpgrade: { kind: 'skipped-no-dep' },
   }
 }
 

--- a/src/init/auto-upgrade.test.ts
+++ b/src/init/auto-upgrade.test.ts
@@ -3,7 +3,13 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { autoUpgradeTypeclawDep, describeAutoUpgrade, outcomeForcesInstall } from './auto-upgrade'
+import {
+  autoUpgradeTypeclawDep,
+  describeAutoUpgrade,
+  expectedInstalledAfterUpgrade,
+  outcomeForcesInstall,
+  readInstalledTypeclawVersionFromAgent,
+} from './auto-upgrade'
 
 let root: string
 
@@ -30,7 +36,7 @@ async function readPackageJson(): Promise<Record<string, unknown>> {
   return JSON.parse(raw) as Record<string, unknown>
 }
 
-describe('autoUpgradeTypeclawDep', () => {
+describe('autoUpgradeTypeclawDep — skipped outcomes', () => {
   test('returns skipped-dev-mode when scaffold version is null (running from typeclaw source repo)', async () => {
     await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
 
@@ -45,7 +51,23 @@ describe('autoUpgradeTypeclawDep', () => {
     expect(outcome).toEqual({ kind: 'skipped-no-dep' })
   })
 
-  test('returns skipped-no-dep when package.json has no typeclaw dependency', async () => {
+  test('returns skipped-no-dep when package.json has no dependencies field at all', async () => {
+    await writePackageJson({ name: 'foo' })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'skipped-no-dep' })
+  })
+
+  test('returns skipped-no-dep when typeclaw is in devDependencies only (not dependencies)', async () => {
+    await writePackageJson({ devDependencies: { typeclaw: '^0.1.0' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'skipped-no-dep' })
+  })
+
+  test('returns skipped-no-dep when package.json has dependencies but no typeclaw key', async () => {
     await writePackageJson({ dependencies: { other: '^1.0.0' } })
 
     const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
@@ -53,8 +75,34 @@ describe('autoUpgradeTypeclawDep', () => {
     expect(outcome).toEqual({ kind: 'skipped-no-dep' })
   })
 
-  test('returns skipped-non-release-spec for file: / link: / dist-tag specs', async () => {
-    for (const spec of ['file:../typeclaw', 'link:../typeclaw', 'latest', 'workspace:*', 'npm:typeclaw@0.1.0']) {
+  test('returns skipped-no-dep for an array-typed package.json (parses as JSON but is not an object)', async () => {
+    await writeFile(join(root, 'package.json'), '[]')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'skipped-no-dep' })
+  })
+
+  test('returns skipped-no-dep for corrupt JSON (never throws)', async () => {
+    await writeFile(join(root, 'package.json'), '{ "name": "broken", "dependencies":')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'skipped-no-dep' })
+  })
+
+  test('returns skipped-non-release-spec for file: / link: / dist-tag / range / glob / github: specs', async () => {
+    for (const spec of [
+      'file:../typeclaw',
+      'link:../typeclaw',
+      'latest',
+      'workspace:*',
+      'npm:typeclaw@0.1.0',
+      '>=0.1.0',
+      '*',
+      '0.1.x',
+      'github:typeclaw/typeclaw',
+    ]) {
       await writePackageJson({ dependencies: { typeclaw: spec } })
 
       const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
@@ -62,17 +110,21 @@ describe('autoUpgradeTypeclawDep', () => {
       expect(outcome).toEqual({ kind: 'skipped-non-release-spec', declared: spec })
     }
   })
+})
 
-  test('returns up-to-date when installed version matches CLI version (caret range)', async () => {
+describe('autoUpgradeTypeclawDep — upgrade-only invariant', () => {
+  test('installed > CLI and range satisfies CLI → up-to-date (never downgrades)', async () => {
+    // given: installed 0.1.5, spec ^0.1.0 (includes CLI 0.1.2), CLI 0.1.2
     await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
-    await writeInstalledTypeclaw('0.1.2')
+    await writeInstalledTypeclaw('0.1.5')
 
     const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
 
-    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.2' })
+    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.5' })
   })
 
-  test('returns up-to-date when installed version is AHEAD of CLI (never downgrades)', async () => {
+  test('installed > CLI and range does NOT satisfy CLI → up-to-date (never downgrades)', async () => {
+    // given: installed 0.1.5, spec ^0.1.5 (excludes CLI 0.1.2), CLI 0.1.2
     await writePackageJson({ dependencies: { typeclaw: '^0.1.5' } })
     await writeInstalledTypeclaw('0.1.5')
 
@@ -81,66 +133,86 @@ describe('autoUpgradeTypeclawDep', () => {
     expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.5' })
   })
 
-  test('returns reinstall-needed when installed is older than CLI but spec range allows CLI', async () => {
-    // given: agent was bun-installed against typeclaw 0.1.0; CLI bumped to 0.1.2;
-    //        the existing `^0.1.0` already permits 0.1.2 so no spec rewrite is needed.
+  test('installed == CLI → up-to-date', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
+    await writeInstalledTypeclaw('0.1.2')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.2' })
+  })
+
+  test('installed < CLI but range satisfies CLI → reinstall-needed (the in-range upgrade case)', async () => {
+    // The canonical regression: `bun -g update typeclaw` moved the global CLI from 0.1.0
+    // to 0.1.2, the agent's package.json says `^0.1.0` which still permits 0.1.2, but
+    // node_modules/typeclaw is still 0.1.0 because `bun install` honors the lockfile.
+    // We MUST force a `bun update`, not just `bun install`.
     await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
     await writeInstalledTypeclaw('0.1.0')
 
     const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
 
     expect(outcome).toEqual({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' })
-
-    // and: package.json was NOT modified (range still permits the new CLI)
+    // and: package.json is NOT modified — the existing range still permits the new CLI.
     const pkg = await readPackageJson()
     expect((pkg.dependencies as Record<string, string>).typeclaw).toBe('^0.1.0')
   })
 
-  test('rewrites spec when CLI version is OUT of range (pre-1.0 minor bump)', async () => {
-    // given: agent pinned to ^0.1.0 (>=0.1.0 <0.2.0); CLI moved to 0.2.0
+  test('installed < CLI and range does NOT satisfy CLI → spec-rewritten (pre-1.0 minor bump)', async () => {
+    // given: pre-1.0 caret ^0.1.0 excludes 0.2.0 (the entire bug class auto-upgrade fixes).
     await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
     await writeInstalledTypeclaw('0.1.2')
 
     const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.2.0' })
 
-    expect(outcome).toEqual({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' })
-
-    // and: package.json was rewritten with the new spec
+    expect(outcome).toEqual({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0', cliVersion: '0.2.0' })
     const pkg = await readPackageJson()
     expect((pkg.dependencies as Record<string, string>).typeclaw).toBe('^0.2.0')
   })
 
-  test('rewrites spec when CLI crosses a major from ^1.x', async () => {
+  test('spec-rewritten across a major boundary (^1.x → ^2.x)', async () => {
     await writePackageJson({ dependencies: { typeclaw: '^1.5.0' } })
     await writeInstalledTypeclaw('1.5.0')
 
     const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^2.0.0' })
 
-    expect(outcome).toEqual({ kind: 'spec-rewritten', from: '^1.5.0', to: '^2.0.0' })
+    expect(outcome).toEqual({ kind: 'spec-rewritten', from: '^1.5.0', to: '^2.0.0', cliVersion: '2.0.0' })
   })
 
-  test('respects exact pin (no operator) without rewriting when CLI version differs', async () => {
-    await writePackageJson({ dependencies: { typeclaw: '0.1.0' } })
-    await writeInstalledTypeclaw('0.1.0')
+  test('half-applied rewrite recovery: package.json points ahead but node_modules is stale → reinstall-needed', async () => {
+    // Scenario: a previous `typeclaw start` rewrote package.json to ^0.2.0 but the
+    // subsequent `bun update` failed. We must not treat the declared spec as ground
+    // truth; the installed version is the source of truth. Otherwise the next start
+    // would silently believe everything is fine and pin a stale Dockerfile.
+    await writePackageJson({ dependencies: { typeclaw: '^0.2.0' } })
+    await writeInstalledTypeclaw('0.1.2')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.2.0' })
+
+    expect(outcome).toEqual({ kind: 'reinstall-needed', from: '0.1.2', to: '0.2.0' })
+  })
+
+  test('fresh agent (no node_modules) with in-range spec → up-to-date (ensureDeps installs separately)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '^0.1.2' } })
 
     const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
 
-    expect(outcome).toEqual({ kind: 'exact-pin-respected', declared: '0.1.0', cliVersion: '0.1.2' })
-
-    // and: spec was preserved exactly
-    const pkg = await readPackageJson()
-    expect((pkg.dependencies as Record<string, string>).typeclaw).toBe('0.1.0')
+    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.2' })
   })
 
-  test('treats `=X.Y.Z` as an exact pin', async () => {
-    await writePackageJson({ dependencies: { typeclaw: '=0.1.0' } })
+  test('fresh agent (no node_modules) with range floor > CLI → up-to-date with floor as installedVersion', async () => {
+    // Per "never downgrade": when nothing is installed, the declared floor is our best
+    // estimate of "what would land if bun install ran." If that's already >= CLI, no-op.
+    await writePackageJson({ dependencies: { typeclaw: '^0.1.5' } })
 
     const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
 
-    expect(outcome).toEqual({ kind: 'exact-pin-respected', declared: '=0.1.0', cliVersion: '0.1.2' })
+    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.5' })
   })
+})
 
-  test('exact pin matching CLI version → up-to-date (no warning, no rewrite)', async () => {
+describe('autoUpgradeTypeclawDep — exact pin handling', () => {
+  test('exact pin matching CLI, installed also matches → up-to-date', async () => {
     await writePackageJson({ dependencies: { typeclaw: '0.1.2' } })
     await writeInstalledTypeclaw('0.1.2')
 
@@ -149,27 +221,69 @@ describe('autoUpgradeTypeclawDep', () => {
     expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.2' })
   })
 
-  test('returns up-to-date when fresh agent has no node_modules yet but spec is in-range', async () => {
-    // given: package.json exists, but bun install never ran. ensureDeps will
-    //        install for the missing-dep reason — auto-upgrade has nothing to add.
-    await writePackageJson({ dependencies: { typeclaw: '^0.1.2' } })
+  test('exact pin matching CLI but installed is stale → reinstall-needed (this is BLOCKING regression #3)', async () => {
+    // Without this branch, the original production bug would still bite: a user who
+    // pins exactly to 0.1.2 but has 0.1.0 in node_modules would see refreshDockerfile
+    // pin :0.1.0 from resolveBaseImageVersion.
+    await writePackageJson({ dependencies: { typeclaw: '0.1.2' } })
+    await writeInstalledTypeclaw('0.1.0')
 
     const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
 
-    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.2' })
+    expect(outcome).toEqual({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' })
   })
 
-  test('tilde range that excludes CLI version triggers a rewrite', async () => {
-    // given: ~0.1.2 → >=0.1.2 <0.2.0. CLI moved to 0.2.0 → out of range.
-    await writePackageJson({ dependencies: { typeclaw: '~0.1.2' } })
+  test('exact pin matching CLI with no node_modules → reinstall-needed', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '0.1.2' } })
 
-    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.2.0' })
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
 
-    expect(outcome).toEqual({ kind: 'spec-rewritten', from: '~0.1.2', to: '^0.2.0' })
+    expect(outcome).toEqual({ kind: 'reinstall-needed', from: '<missing>', to: '0.1.2' })
   })
 
-  test('tilde range that includes CLI version is treated like any in-range case', async () => {
-    // given: ~0.1.0 → >=0.1.0 <0.2.0. CLI moved to 0.1.5 (still in range).
+  test('exact pin LOWER than CLI → exact-pin-respected (user wants the older version)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '0.1.0' } })
+    await writeInstalledTypeclaw('0.1.0')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'exact-pin-respected', declared: '0.1.0', cliVersion: '0.1.2' })
+    const pkg = await readPackageJson()
+    expect((pkg.dependencies as Record<string, string>).typeclaw).toBe('0.1.0')
+  })
+
+  test('exact pin HIGHER than CLI → up-to-date (never downgrade — installed > CLI wins)', async () => {
+    // Symmetric to "lower". The user pinned to a newer version than the global CLI;
+    // installed matches the pin and is ahead of CLI, so the upgrade-only check
+    // returns up-to-date before we ever reach the exact-pin branch.
+    await writePackageJson({ dependencies: { typeclaw: '0.1.5' } })
+    await writeInstalledTypeclaw('0.1.5')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.5' })
+  })
+
+  test('exact pin HIGHER than CLI, no node_modules → exact-pin-respected (no on-disk version to defer to)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '0.1.5' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'exact-pin-respected', declared: '0.1.5', cliVersion: '0.1.2' })
+  })
+
+  test('treats =X.Y.Z as exact pin', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '=0.1.0' } })
+    await writeInstalledTypeclaw('0.1.0')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'exact-pin-respected', declared: '=0.1.0', cliVersion: '0.1.2' })
+  })
+})
+
+describe('autoUpgradeTypeclawDep — tilde ranges and other range parsers', () => {
+  test('~0.1.0 includes CLI 0.1.5 → reinstall-needed', async () => {
     await writePackageJson({ dependencies: { typeclaw: '~0.1.0' } })
     await writeInstalledTypeclaw('0.1.0')
 
@@ -178,9 +292,17 @@ describe('autoUpgradeTypeclawDep', () => {
     expect(outcome).toEqual({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.5' })
   })
 
-  test('preserves package.json formatting (key order, indentation) when rewriting spec', async () => {
-    // Hand-craft a package.json with a specific layout and confirm the rewrite
-    // touches ONLY the typeclaw spec value, leaving everything else byte-identical.
+  test('~0.1.2 excludes CLI 0.2.0 → spec-rewritten', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '~0.1.2' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.2.0' })
+
+    expect(outcome).toEqual({ kind: 'spec-rewritten', from: '~0.1.2', to: '^0.2.0', cliVersion: '0.2.0' })
+  })
+})
+
+describe('writeDepSpec via autoUpgradeTypeclawDep — formatting and scope', () => {
+  test('preserves user formatting (2-space, key order, trailing newline)', async () => {
     const original = `{
   "name": "my-agent",
   "type": "module",
@@ -206,43 +328,121 @@ describe('autoUpgradeTypeclawDep', () => {
 `)
   })
 
-  test('rejects a corrupt package.json by returning skipped-no-dep (never throws)', async () => {
-    await writeFile(join(root, 'package.json'), '{ "name": "broken", "dependencies":')
+  test('preserves 4-space indentation', async () => {
+    const original = `{
+    "name": "my-agent",
+    "dependencies": {
+        "typeclaw": "^0.1.0"
+    }
+}
+`
+    await writeFile(join(root, 'package.json'), original)
 
-    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+    await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.2.0' })
 
-    expect(outcome).toEqual({ kind: 'skipped-no-dep' })
+    const after = await readFile(join(root, 'package.json'), 'utf8')
+    expect(after).toContain('"typeclaw": "^0.2.0"')
+    // and: the 4-space indent inside dependencies is preserved exactly
+    expect(after).toContain('        "typeclaw": "^0.2.0"')
   })
 
-  test('ignores an installed typeclaw whose version is a prerelease tag', async () => {
-    // given: node_modules/typeclaw/package.json has 0.2.0-beta.1; spec is ^0.1.0;
-    //        CLI is 0.1.2 (in range). The prerelease cannot be compared against
-    //        the CLI as a release version — treat installed as absent.
+  test('preserves tab indentation', async () => {
+    const original = '{\n\t"name": "my-agent",\n\t"dependencies": {\n\t\t"typeclaw": "^0.1.0"\n\t}\n}\n'
+    await writeFile(join(root, 'package.json'), original)
+
+    await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.2.0' })
+
+    const after = await readFile(join(root, 'package.json'), 'utf8')
+    expect(after).toContain('\t\t"typeclaw": "^0.2.0"')
+  })
+
+  test('does NOT rewrite devDependencies.typeclaw when it appears before dependencies.typeclaw', async () => {
+    // Regression guard for the BLOCKING bug Oracle caught: the original unscoped regex
+    // would silently rewrite the FIRST occurrence of `"typeclaw": "..."` in the file,
+    // even if that's in devDependencies. The scoped tokenizer must edit only inside
+    // the dependencies object.
+    const original = `{
+  "name": "my-agent",
+  "devDependencies": {
+    "typeclaw": "0.1.0"
+  },
+  "dependencies": {
+    "typeclaw": "^0.1.0"
+  }
+}
+`
+    await writeFile(join(root, 'package.json'), original)
+
+    await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.2.0' })
+
+    const after = await readFile(join(root, 'package.json'), 'utf8')
+    expect(after).toContain('"devDependencies": {\n    "typeclaw": "0.1.0"\n  }')
+    expect(after).toContain('"dependencies": {\n    "typeclaw": "^0.2.0"\n  }')
+  })
+
+  test('handles minified package.json (no whitespace) without corrupting other keys', async () => {
+    const original = `{"name":"my-agent","dependencies":{"typeclaw":"^0.1.0","zod":"^4.0.0"}}`
+    await writeFile(join(root, 'package.json'), original)
+
+    await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.2.0' })
+
+    const pkg = await readPackageJson()
+    expect((pkg.dependencies as Record<string, string>).typeclaw).toBe('^0.2.0')
+    expect((pkg.dependencies as Record<string, string>).zod).toBe('^4.0.0')
+  })
+
+  test('rejects an installed-typeclaw with a non-release version (prerelease tag)', async () => {
     await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
     await writeInstalledTypeclaw('0.2.0-beta.1')
 
     const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
 
+    // and: prerelease installed is treated as "not a release we can compare," so
+    // we fall back to the declared range floor for the up-to-date check.
     expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.2' })
   })
 })
 
 describe('outcomeForcesInstall', () => {
-  test('returns true only for outcomes that change what bun install must do', () => {
-    expect(outcomeForcesInstall({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' })).toBe(true)
+  test('returns true only for outcomes that mutate node_modules', () => {
+    expect(outcomeForcesInstall({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0', cliVersion: '0.2.0' })).toBe(
+      true,
+    )
     expect(outcomeForcesInstall({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' })).toBe(true)
 
     expect(outcomeForcesInstall({ kind: 'up-to-date', installedVersion: '0.1.2' })).toBe(false)
     expect(outcomeForcesInstall({ kind: 'skipped-dev-mode' })).toBe(false)
     expect(outcomeForcesInstall({ kind: 'skipped-no-dep' })).toBe(false)
     expect(outcomeForcesInstall({ kind: 'skipped-non-release-spec', declared: 'latest' })).toBe(false)
+    expect(outcomeForcesInstall({ kind: 'skipped-already-running' })).toBe(false)
     expect(outcomeForcesInstall({ kind: 'exact-pin-respected', declared: '0.1.0', cliVersion: '0.1.2' })).toBe(false)
+  })
+})
+
+describe('expectedInstalledAfterUpgrade', () => {
+  test('returns the CLI version for spec-rewritten (the post-install verification target)', () => {
+    expect(
+      expectedInstalledAfterUpgrade({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0', cliVersion: '0.2.0' }),
+    ).toBe('0.2.0')
+  })
+
+  test('returns the target version for reinstall-needed', () => {
+    expect(expectedInstalledAfterUpgrade({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' })).toBe('0.1.2')
+  })
+
+  test('returns null for outcomes that did not trigger an install', () => {
+    expect(expectedInstalledAfterUpgrade({ kind: 'up-to-date', installedVersion: '0.1.2' })).toBeNull()
+    expect(expectedInstalledAfterUpgrade({ kind: 'skipped-dev-mode' })).toBeNull()
+    expect(expectedInstalledAfterUpgrade({ kind: 'skipped-no-dep' })).toBeNull()
+    expect(
+      expectedInstalledAfterUpgrade({ kind: 'exact-pin-respected', declared: '0.1.0', cliVersion: '0.1.2' }),
+    ).toBeNull()
   })
 })
 
 describe('describeAutoUpgrade', () => {
   test('returns the upgrade line for spec-rewritten and reinstall-needed', () => {
-    expect(describeAutoUpgrade({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' })).toBe(
+    expect(describeAutoUpgrade({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0', cliVersion: '0.2.0' })).toBe(
       'Upgrading agent typeclaw ^0.1.0 → ^0.2.0 to match CLI',
     )
     expect(describeAutoUpgrade({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' })).toBe(
@@ -256,10 +456,29 @@ describe('describeAutoUpgrade', () => {
     )
   })
 
-  test('returns empty string for no-op outcomes', () => {
+  test('returns empty string for no-op outcomes (silent on no-op)', () => {
     expect(describeAutoUpgrade({ kind: 'up-to-date', installedVersion: '0.1.2' })).toBe('')
     expect(describeAutoUpgrade({ kind: 'skipped-dev-mode' })).toBe('')
     expect(describeAutoUpgrade({ kind: 'skipped-no-dep' })).toBe('')
+    expect(describeAutoUpgrade({ kind: 'skipped-already-running' })).toBe('')
     expect(describeAutoUpgrade({ kind: 'skipped-non-release-spec', declared: 'latest' })).toBe('')
+  })
+})
+
+describe('readInstalledTypeclawVersionFromAgent (post-install verification helper)', () => {
+  test('returns the version when node_modules/typeclaw/package.json carries a release version', async () => {
+    await writeInstalledTypeclaw('0.1.2')
+
+    expect(readInstalledTypeclawVersionFromAgent(root)).toBe('0.1.2')
+  })
+
+  test('returns null when node_modules/typeclaw is missing', async () => {
+    expect(readInstalledTypeclawVersionFromAgent(root)).toBeNull()
+  })
+
+  test('returns null for a prerelease version (cannot map to a GHCR release tag)', async () => {
+    await writeInstalledTypeclaw('0.2.0-beta.1')
+
+    expect(readInstalledTypeclawVersionFromAgent(root)).toBeNull()
   })
 })

--- a/src/init/auto-upgrade.test.ts
+++ b/src/init/auto-upgrade.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { autoUpgradeTypeclawDep, describeAutoUpgrade, outcomeForcesInstall } from './auto-upgrade'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-auto-upgrade-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function writePackageJson(content: Record<string, unknown>): Promise<void> {
+  await writeFile(join(root, 'package.json'), `${JSON.stringify(content, null, 2)}\n`)
+}
+
+async function writeInstalledTypeclaw(version: string): Promise<void> {
+  const installDir = join(root, 'node_modules', 'typeclaw')
+  await mkdir(installDir, { recursive: true })
+  await writeFile(join(installDir, 'package.json'), JSON.stringify({ name: 'typeclaw', version }))
+}
+
+async function readPackageJson(): Promise<Record<string, unknown>> {
+  const raw = await readFile(join(root, 'package.json'), 'utf8')
+  return JSON.parse(raw) as Record<string, unknown>
+}
+
+describe('autoUpgradeTypeclawDep', () => {
+  test('returns skipped-dev-mode when scaffold version is null (running from typeclaw source repo)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: null })
+
+    expect(outcome).toEqual({ kind: 'skipped-dev-mode' })
+  })
+
+  test('returns skipped-no-dep when package.json is absent', async () => {
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'skipped-no-dep' })
+  })
+
+  test('returns skipped-no-dep when package.json has no typeclaw dependency', async () => {
+    await writePackageJson({ dependencies: { other: '^1.0.0' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'skipped-no-dep' })
+  })
+
+  test('returns skipped-non-release-spec for file: / link: / dist-tag specs', async () => {
+    for (const spec of ['file:../typeclaw', 'link:../typeclaw', 'latest', 'workspace:*', 'npm:typeclaw@0.1.0']) {
+      await writePackageJson({ dependencies: { typeclaw: spec } })
+
+      const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+      expect(outcome).toEqual({ kind: 'skipped-non-release-spec', declared: spec })
+    }
+  })
+
+  test('returns up-to-date when installed version matches CLI version (caret range)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
+    await writeInstalledTypeclaw('0.1.2')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.2' })
+  })
+
+  test('returns up-to-date when installed version is AHEAD of CLI (never downgrades)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '^0.1.5' } })
+    await writeInstalledTypeclaw('0.1.5')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.5' })
+  })
+
+  test('returns reinstall-needed when installed is older than CLI but spec range allows CLI', async () => {
+    // given: agent was bun-installed against typeclaw 0.1.0; CLI bumped to 0.1.2;
+    //        the existing `^0.1.0` already permits 0.1.2 so no spec rewrite is needed.
+    await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
+    await writeInstalledTypeclaw('0.1.0')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' })
+
+    // and: package.json was NOT modified (range still permits the new CLI)
+    const pkg = await readPackageJson()
+    expect((pkg.dependencies as Record<string, string>).typeclaw).toBe('^0.1.0')
+  })
+
+  test('rewrites spec when CLI version is OUT of range (pre-1.0 minor bump)', async () => {
+    // given: agent pinned to ^0.1.0 (>=0.1.0 <0.2.0); CLI moved to 0.2.0
+    await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
+    await writeInstalledTypeclaw('0.1.2')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.2.0' })
+
+    expect(outcome).toEqual({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' })
+
+    // and: package.json was rewritten with the new spec
+    const pkg = await readPackageJson()
+    expect((pkg.dependencies as Record<string, string>).typeclaw).toBe('^0.2.0')
+  })
+
+  test('rewrites spec when CLI crosses a major from ^1.x', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '^1.5.0' } })
+    await writeInstalledTypeclaw('1.5.0')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^2.0.0' })
+
+    expect(outcome).toEqual({ kind: 'spec-rewritten', from: '^1.5.0', to: '^2.0.0' })
+  })
+
+  test('respects exact pin (no operator) without rewriting when CLI version differs', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '0.1.0' } })
+    await writeInstalledTypeclaw('0.1.0')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'exact-pin-respected', declared: '0.1.0', cliVersion: '0.1.2' })
+
+    // and: spec was preserved exactly
+    const pkg = await readPackageJson()
+    expect((pkg.dependencies as Record<string, string>).typeclaw).toBe('0.1.0')
+  })
+
+  test('treats `=X.Y.Z` as an exact pin', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '=0.1.0' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'exact-pin-respected', declared: '=0.1.0', cliVersion: '0.1.2' })
+  })
+
+  test('exact pin matching CLI version → up-to-date (no warning, no rewrite)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '0.1.2' } })
+    await writeInstalledTypeclaw('0.1.2')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.2' })
+  })
+
+  test('returns up-to-date when fresh agent has no node_modules yet but spec is in-range', async () => {
+    // given: package.json exists, but bun install never ran. ensureDeps will
+    //        install for the missing-dep reason — auto-upgrade has nothing to add.
+    await writePackageJson({ dependencies: { typeclaw: '^0.1.2' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.2' })
+  })
+
+  test('tilde range that excludes CLI version triggers a rewrite', async () => {
+    // given: ~0.1.2 → >=0.1.2 <0.2.0. CLI moved to 0.2.0 → out of range.
+    await writePackageJson({ dependencies: { typeclaw: '~0.1.2' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.2.0' })
+
+    expect(outcome).toEqual({ kind: 'spec-rewritten', from: '~0.1.2', to: '^0.2.0' })
+  })
+
+  test('tilde range that includes CLI version is treated like any in-range case', async () => {
+    // given: ~0.1.0 → >=0.1.0 <0.2.0. CLI moved to 0.1.5 (still in range).
+    await writePackageJson({ dependencies: { typeclaw: '~0.1.0' } })
+    await writeInstalledTypeclaw('0.1.0')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.5' })
+
+    expect(outcome).toEqual({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.5' })
+  })
+
+  test('preserves package.json formatting (key order, indentation) when rewriting spec', async () => {
+    // Hand-craft a package.json with a specific layout and confirm the rewrite
+    // touches ONLY the typeclaw spec value, leaving everything else byte-identical.
+    const original = `{
+  "name": "my-agent",
+  "type": "module",
+  "dependencies": {
+    "typeclaw": "^0.1.0",
+    "zod": "^4.0.0"
+  }
+}
+`
+    await writeFile(join(root, 'package.json'), original)
+
+    await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.2.0' })
+
+    const after = await readFile(join(root, 'package.json'), 'utf8')
+    expect(after).toBe(`{
+  "name": "my-agent",
+  "type": "module",
+  "dependencies": {
+    "typeclaw": "^0.2.0",
+    "zod": "^4.0.0"
+  }
+}
+`)
+  })
+
+  test('rejects a corrupt package.json by returning skipped-no-dep (never throws)', async () => {
+    await writeFile(join(root, 'package.json'), '{ "name": "broken", "dependencies":')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'skipped-no-dep' })
+  })
+
+  test('ignores an installed typeclaw whose version is a prerelease tag', async () => {
+    // given: node_modules/typeclaw/package.json has 0.2.0-beta.1; spec is ^0.1.0;
+    //        CLI is 0.1.2 (in range). The prerelease cannot be compared against
+    //        the CLI as a release version — treat installed as absent.
+    await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
+    await writeInstalledTypeclaw('0.2.0-beta.1')
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.1.2' })
+
+    expect(outcome).toEqual({ kind: 'up-to-date', installedVersion: '0.1.2' })
+  })
+})
+
+describe('outcomeForcesInstall', () => {
+  test('returns true only for outcomes that change what bun install must do', () => {
+    expect(outcomeForcesInstall({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' })).toBe(true)
+    expect(outcomeForcesInstall({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' })).toBe(true)
+
+    expect(outcomeForcesInstall({ kind: 'up-to-date', installedVersion: '0.1.2' })).toBe(false)
+    expect(outcomeForcesInstall({ kind: 'skipped-dev-mode' })).toBe(false)
+    expect(outcomeForcesInstall({ kind: 'skipped-no-dep' })).toBe(false)
+    expect(outcomeForcesInstall({ kind: 'skipped-non-release-spec', declared: 'latest' })).toBe(false)
+    expect(outcomeForcesInstall({ kind: 'exact-pin-respected', declared: '0.1.0', cliVersion: '0.1.2' })).toBe(false)
+  })
+})
+
+describe('describeAutoUpgrade', () => {
+  test('returns the upgrade line for spec-rewritten and reinstall-needed', () => {
+    expect(describeAutoUpgrade({ kind: 'spec-rewritten', from: '^0.1.0', to: '^0.2.0' })).toBe(
+      'Upgrading agent typeclaw ^0.1.0 → ^0.2.0 to match CLI',
+    )
+    expect(describeAutoUpgrade({ kind: 'reinstall-needed', from: '0.1.0', to: '0.1.2' })).toBe(
+      'Upgrading agent typeclaw 0.1.0 → 0.1.2 to match CLI',
+    )
+  })
+
+  test('returns the warning line for exact-pin-respected', () => {
+    expect(describeAutoUpgrade({ kind: 'exact-pin-respected', declared: '0.1.0', cliVersion: '0.1.2' })).toContain(
+      'exact-pinned',
+    )
+  })
+
+  test('returns empty string for no-op outcomes', () => {
+    expect(describeAutoUpgrade({ kind: 'up-to-date', installedVersion: '0.1.2' })).toBe('')
+    expect(describeAutoUpgrade({ kind: 'skipped-dev-mode' })).toBe('')
+    expect(describeAutoUpgrade({ kind: 'skipped-no-dep' })).toBe('')
+    expect(describeAutoUpgrade({ kind: 'skipped-non-release-spec', declared: 'latest' })).toBe('')
+  })
+})

--- a/src/init/auto-upgrade.ts
+++ b/src/init/auto-upgrade.ts
@@ -7,21 +7,28 @@ import { resolveScaffoldVersion } from './cli-version'
 const PACKAGE_FILE = 'package.json'
 const TYPECLAW = 'typeclaw'
 
-// Pre-1.0 caret semantics are the whole reason this module exists:
-//   `^0.1.0` resolves to >=0.1.0 <0.2.0 (minor pins the range, not major).
-// So a CLI bump from 0.1.x to 0.2.0 falls OUT of the agent's existing
-// `^0.1.x` range — bun install would refuse to upgrade. We have to rewrite
-// the spec for those crossings. In-range drift (0.1.0 → 0.1.2) only needs
-// a `bun install` re-run. Exact pins (`0.1.0` without `^`/`~`) are user
-// intent and never auto-rewritten — see exact-pin branch below.
+// Two semver quirks drive every branch in this module:
+//
+// 1. Pre-1.0 caret: `^0.1.0` resolves to `>=0.1.0 <0.2.0`. A CLI bump from
+//    0.1.x to 0.2.0 falls OUT of the agent's range, so we must rewrite the
+//    spec for those crossings.
+//
+// 2. `bun install` honors the lockfile: when the lockfile entry already
+//    satisfies the declared spec, `bun install` is a no-op even if a newer
+//    in-range version exists upstream. To actually upgrade an in-range dep
+//    we MUST use `bun update <pkg> --latest`. See src/init/run-bun-install.ts.
+//
+// The decision matrix anchors on the INSTALLED version (the truth), not the
+// declared range floor (a promise the agent may not yet have kept).
 
 export type AutoUpgradeOutcome =
   | { kind: 'skipped-dev-mode' }
   | { kind: 'skipped-no-dep' }
   | { kind: 'skipped-non-release-spec'; declared: string }
+  | { kind: 'skipped-already-running' }
   | { kind: 'up-to-date'; installedVersion: string }
   | { kind: 'exact-pin-respected'; declared: string; cliVersion: string }
-  | { kind: 'spec-rewritten'; from: string; to: string }
+  | { kind: 'spec-rewritten'; from: string; to: string; cliVersion: string }
   | { kind: 'reinstall-needed'; from: string; to: string }
 
 export type AutoUpgradeOptions = {
@@ -52,34 +59,50 @@ export async function autoUpgradeTypeclawDep(options: AutoUpgradeOptions): Promi
 
   const installed = readInstalledTypeclawVersion(cwd)
 
-  // Exact pin: silently rewriting violates user intent (they wrote `0.1.0`
-  // with no operator deliberately — testing a held-back version, debugging
-  // a regression, etc). Surface the divergence as a warning and proceed.
-  if (declaredKind.kind === 'exact') {
-    const declaredVersion = formatTriple(declaredKind.version)
-    if (declaredVersion === cliVersion) {
-      return { kind: 'up-to-date', installedVersion: installed ?? cliVersion }
+  // "Upgrade only, never downgrade" — anchored on the INSTALLED version
+  // (the truth), with the declared range floor used ONLY when nothing is
+  // installed yet (best proxy for "what would land if bun install ran").
+  //
+  // Anchoring on `installed` first closes the half-applied-rewrite hole:
+  // a previous start may have written ^0.2.0 to package.json but failed
+  // its install, leaving node_modules at 0.1.x. The declared floor would
+  // wrongly say "up-to-date"; the installed version correctly says "retry."
+  if (installed !== null && compareReleaseVersions(installed, cliVersion) >= 0) {
+    return { kind: 'up-to-date', installedVersion: installed }
+  }
+  if (installed === null && declaredKind.kind !== 'exact') {
+    const declaredFloor = formatTriple(declaredKind.version)
+    if (compareReleaseVersions(declaredFloor, cliVersion) >= 0) {
+      return { kind: 'up-to-date', installedVersion: declaredFloor }
     }
-    return { kind: 'exact-pin-respected', declared, cliVersion }
   }
 
-  // "Upgrade only, never downgrade." The agent's effective version is the
-  // max of (installed copy, declared range floor). If that already meets or
-  // exceeds the CLI, leave everything alone — even when the range itself
-  // does not include the CLI version (e.g. `^0.1.5` against CLI 0.1.2).
-  const declaredFloor = formatTriple(declaredKind.version)
-  const effective =
-    installed !== null && compareReleaseVersions(installed, declaredFloor) > 0 ? installed : declaredFloor
-  if (compareReleaseVersions(effective, cliVersion) >= 0) {
-    return { kind: 'up-to-date', installedVersion: installed ?? declaredFloor }
+  if (declaredKind.kind === 'exact') {
+    const declaredVersion = formatTriple(declaredKind.version)
+    // Exact pin matches CLI but installed is stale (or missing): we still
+    // need to install. The user wrote the right spec — they just haven't
+    // materialized it yet. Return reinstall-needed; caller will run
+    // `bun update typeclaw --latest` against that exact spec.
+    if (declaredVersion === cliVersion) {
+      return { kind: 'reinstall-needed', from: installed ?? '<missing>', to: cliVersion }
+    }
+    // Exact pin diverges from CLI. User intent wins; we warn but never
+    // rewrite. If installed is ALSO ahead of CLI (e.g. exact pin 0.1.5,
+    // CLI 0.1.2), the up-to-date check above already returned.
+    return { kind: 'exact-pin-respected', declared, cliVersion }
   }
 
   if (!rangeSatisfies(declaredKind, cliVersion)) {
     const newSpec = `^${cliVersion}`
     await writeDepSpec(cwd, pkg.raw, pkg.parsed, newSpec)
-    return { kind: 'spec-rewritten', from: declared, to: newSpec }
+    return { kind: 'spec-rewritten', from: declared, to: newSpec, cliVersion }
   }
 
+  // Declared range includes CLI. Three sub-cases:
+  //   - installed === null: fresh agent, nothing on disk yet. ensureDeps
+  //     will install for the missing-dep reason; nothing for us to add.
+  //   - installed > CLI but in range: we already returned up-to-date above.
+  //   - installed < CLI: force an upgrade via `bun update typeclaw --latest`.
   if (installed === null) {
     return { kind: 'up-to-date', installedVersion: cliVersion }
   }
@@ -90,9 +113,21 @@ export function outcomeForcesInstall(outcome: AutoUpgradeOutcome): boolean {
   return outcome.kind === 'spec-rewritten' || outcome.kind === 'reinstall-needed'
 }
 
+// The version we expect to find in node_modules/typeclaw after the
+// auto-upgrade-triggered install completes. Callers use this to verify
+// the install actually moved the on-disk version (not just resolved the
+// lockfile). Returns null when no install was forced — verification is
+// skipped on no-op outcomes.
+export function expectedInstalledAfterUpgrade(outcome: AutoUpgradeOutcome): string | null {
+  if (outcome.kind === 'spec-rewritten') return outcome.cliVersion
+  if (outcome.kind === 'reinstall-needed') return outcome.to
+  return null
+}
+
 export function describeAutoUpgrade(outcome: AutoUpgradeOutcome): string {
   switch (outcome.kind) {
     case 'spec-rewritten':
+      return `Upgrading agent typeclaw ${outcome.from} → ${outcome.to} to match CLI`
     case 'reinstall-needed':
       return `Upgrading agent typeclaw ${outcome.from} → ${outcome.to} to match CLI`
     case 'exact-pin-respected':
@@ -100,6 +135,10 @@ export function describeAutoUpgrade(outcome: AutoUpgradeOutcome): string {
     default:
       return ''
   }
+}
+
+export function readInstalledTypeclawVersionFromAgent(cwd: string): string | null {
+  return readInstalledTypeclawVersion(cwd)
 }
 
 type ParsedPackage = {
@@ -247,20 +286,83 @@ function isReleaseVersion(version: string): boolean {
 }
 
 async function writeDepSpec(cwd: string, raw: string, parsed: ParsedPackage['parsed'], newSpec: string): Promise<void> {
-  // Preserve user formatting (indentation, trailing newline, key order) by
-  // editing the raw string. Round-tripping through JSON.stringify would
-  // reorder keys and erase user-applied whitespace choices. Fallback below
-  // only kicks in for pathological package.json shapes where the regex
-  // can't anchor on the typeclaw key.
-  const replaced = raw.replace(
-    /("typeclaw"\s*:\s*)"[^"]+"/,
-    (_match, prefix: string) => `${prefix}${JSON.stringify(newSpec)}`,
-  )
-  if (replaced !== raw) {
-    await writeFile(join(cwd, PACKAGE_FILE), replaced)
-    return
+  // Scoped edit: replace the typeclaw spec ONLY inside the dependencies
+  // object. The previous implementation used `raw.replace(/"typeclaw":.../)`
+  // unscoped, which would silently rewrite devDependencies.typeclaw if it
+  // appeared before dependencies.typeclaw in the file (the original spec
+  // never moves). We slice the dependencies object's textual range, edit
+  // inside it, then splice back to preserve whitespace, key order, and
+  // trailing newline. If the slice fails (unusual JSON shape), fall back
+  // to a full JSON round-trip — formatting churn is acceptable; silently
+  // updating the wrong key is not.
+  const scoped = sliceDependenciesRange(raw, parsed)
+  if (scoped !== null) {
+    const { start, end } = scoped
+    const block = raw.slice(start, end)
+    const replaced = block.replace(
+      /("typeclaw"\s*:\s*)"[^"]+"/,
+      (_m, prefix: string) => `${prefix}${JSON.stringify(newSpec)}`,
+    )
+    if (replaced !== block) {
+      await writeFile(join(cwd, PACKAGE_FILE), `${raw.slice(0, start)}${replaced}${raw.slice(end)}`)
+      return
+    }
   }
   const deps = { ...parsed.dependencies, [TYPECLAW]: newSpec }
   const next = { ...parsed, dependencies: deps }
-  await writeFile(join(cwd, PACKAGE_FILE), `${JSON.stringify(next, null, 2)}\n`)
+  const indent = detectIndent(raw)
+  await writeFile(join(cwd, PACKAGE_FILE), `${JSON.stringify(next, null, indent)}\n`)
+}
+
+// Returns the [start, end) byte range of the "dependencies" object's value
+// in `raw`, or null if it can't be located unambiguously. Uses a brace-
+// counting tokenizer that respects string literals so a `dependencies` key
+// inside a string value (e.g. inside a `description`) cannot fool it.
+function sliceDependenciesRange(raw: string, parsed: ParsedPackage['parsed']): { start: number; end: number } | null {
+  if (parsed.dependencies === undefined || parsed.dependencies === null) return null
+  const keyMatch = raw.match(/"dependencies"\s*:\s*\{/)
+  if (!keyMatch || keyMatch.index === undefined) return null
+  const startOfOpenBrace = keyMatch.index + keyMatch[0].length - 1
+  const closeBrace = findMatchingCloseBrace(raw, startOfOpenBrace)
+  if (closeBrace === null) return null
+  return { start: startOfOpenBrace, end: closeBrace + 1 }
+}
+
+function findMatchingCloseBrace(raw: string, openIndex: number): number | null {
+  let depth = 0
+  let inString = false
+  let escape = false
+  for (let i = openIndex; i < raw.length; i++) {
+    const ch = raw[i]
+    if (escape) {
+      escape = false
+      continue
+    }
+    if (inString) {
+      if (ch === '\\') escape = true
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') {
+      inString = true
+      continue
+    }
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return null
+}
+
+function detectIndent(raw: string): number | string {
+  // Default to 2 — matches `JSON.stringify(_, _, 2)` behavior and the
+  // project's existing scaffold style. Only override when we can see a
+  // clear non-2 indent on the first indented line.
+  const match = raw.match(/\n([\t ]+)\S/)
+  if (!match) return 2
+  const sample = match[1]!
+  if (sample.startsWith('\t')) return '\t'
+  return sample.length
 }

--- a/src/init/auto-upgrade.ts
+++ b/src/init/auto-upgrade.ts
@@ -1,0 +1,266 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { resolveScaffoldVersion } from './cli-version'
+
+const PACKAGE_FILE = 'package.json'
+const TYPECLAW = 'typeclaw'
+
+// Pre-1.0 caret semantics are the whole reason this module exists:
+//   `^0.1.0` resolves to >=0.1.0 <0.2.0 (minor pins the range, not major).
+// So a CLI bump from 0.1.x to 0.2.0 falls OUT of the agent's existing
+// `^0.1.x` range — bun install would refuse to upgrade. We have to rewrite
+// the spec for those crossings. In-range drift (0.1.0 → 0.1.2) only needs
+// a `bun install` re-run. Exact pins (`0.1.0` without `^`/`~`) are user
+// intent and never auto-rewritten — see exact-pin branch below.
+
+export type AutoUpgradeOutcome =
+  | { kind: 'skipped-dev-mode' }
+  | { kind: 'skipped-no-dep' }
+  | { kind: 'skipped-non-release-spec'; declared: string }
+  | { kind: 'up-to-date'; installedVersion: string }
+  | { kind: 'exact-pin-respected'; declared: string; cliVersion: string }
+  | { kind: 'spec-rewritten'; from: string; to: string }
+  | { kind: 'reinstall-needed'; from: string; to: string }
+
+export type AutoUpgradeOptions = {
+  cwd: string
+  // Test seam: lets tests simulate dev-mode (null) and arbitrary release
+  // versions without depending on the test runner's actual CLI version.
+  scaffoldVersion?: string | null
+}
+
+export async function autoUpgradeTypeclawDep(options: AutoUpgradeOptions): Promise<AutoUpgradeOutcome> {
+  const { cwd } = options
+  const scaffold = options.scaffoldVersion !== undefined ? options.scaffoldVersion : resolveScaffoldVersion()
+  if (scaffold === null) return { kind: 'skipped-dev-mode' }
+
+  const cliVersion = stripCaret(scaffold)
+  if (cliVersion === null) return { kind: 'skipped-dev-mode' }
+
+  const pkg = await readAgentPackageJson(cwd)
+  if (pkg === null) return { kind: 'skipped-no-dep' }
+
+  const declared = pkg.parsed.dependencies?.[TYPECLAW]
+  if (typeof declared !== 'string') return { kind: 'skipped-no-dep' }
+
+  const declaredKind = classifyDepSpec(declared)
+  if (declaredKind.kind === 'non-release') {
+    return { kind: 'skipped-non-release-spec', declared }
+  }
+
+  const installed = readInstalledTypeclawVersion(cwd)
+
+  // Exact pin: silently rewriting violates user intent (they wrote `0.1.0`
+  // with no operator deliberately — testing a held-back version, debugging
+  // a regression, etc). Surface the divergence as a warning and proceed.
+  if (declaredKind.kind === 'exact') {
+    const declaredVersion = formatTriple(declaredKind.version)
+    if (declaredVersion === cliVersion) {
+      return { kind: 'up-to-date', installedVersion: installed ?? cliVersion }
+    }
+    return { kind: 'exact-pin-respected', declared, cliVersion }
+  }
+
+  // "Upgrade only, never downgrade." The agent's effective version is the
+  // max of (installed copy, declared range floor). If that already meets or
+  // exceeds the CLI, leave everything alone — even when the range itself
+  // does not include the CLI version (e.g. `^0.1.5` against CLI 0.1.2).
+  const declaredFloor = formatTriple(declaredKind.version)
+  const effective =
+    installed !== null && compareReleaseVersions(installed, declaredFloor) > 0 ? installed : declaredFloor
+  if (compareReleaseVersions(effective, cliVersion) >= 0) {
+    return { kind: 'up-to-date', installedVersion: installed ?? declaredFloor }
+  }
+
+  if (!rangeSatisfies(declaredKind, cliVersion)) {
+    const newSpec = `^${cliVersion}`
+    await writeDepSpec(cwd, pkg.raw, pkg.parsed, newSpec)
+    return { kind: 'spec-rewritten', from: declared, to: newSpec }
+  }
+
+  if (installed === null) {
+    return { kind: 'up-to-date', installedVersion: cliVersion }
+  }
+  return { kind: 'reinstall-needed', from: installed, to: cliVersion }
+}
+
+export function outcomeForcesInstall(outcome: AutoUpgradeOutcome): boolean {
+  return outcome.kind === 'spec-rewritten' || outcome.kind === 'reinstall-needed'
+}
+
+export function describeAutoUpgrade(outcome: AutoUpgradeOutcome): string {
+  switch (outcome.kind) {
+    case 'spec-rewritten':
+    case 'reinstall-needed':
+      return `Upgrading agent typeclaw ${outcome.from} → ${outcome.to} to match CLI`
+    case 'exact-pin-respected':
+      return `Agent typeclaw is exact-pinned to ${outcome.declared}; CLI is ${outcome.cliVersion}. Not upgrading (remove the exact pin to allow auto-upgrade).`
+    default:
+      return ''
+  }
+}
+
+type ParsedPackage = {
+  raw: string
+  parsed: { dependencies?: Record<string, string> } & Record<string, unknown>
+}
+
+async function readAgentPackageJson(cwd: string): Promise<ParsedPackage | null> {
+  const path = join(cwd, PACKAGE_FILE)
+  if (!existsSync(path)) return null
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch {
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+  return { raw, parsed: parsed as ParsedPackage['parsed'] }
+}
+
+function readInstalledTypeclawVersion(cwd: string): string | null {
+  const path = join(cwd, 'node_modules', TYPECLAW, PACKAGE_FILE)
+  if (!existsSync(path)) return null
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(raw) as { version?: string }
+    if (typeof parsed.version === 'string' && isReleaseVersion(parsed.version)) return parsed.version
+  } catch {}
+  return null
+}
+
+type DepSpecKind =
+  | { kind: 'exact'; version: [number, number, number]; raw: string }
+  | { kind: 'caret'; version: [number, number, number] }
+  | { kind: 'tilde'; version: [number, number, number] }
+  | { kind: 'non-release' }
+
+function classifyDepSpec(spec: string): DepSpecKind {
+  const trimmed = spec.trim()
+  const exactMatch = trimmed.match(/^=?(\d+)\.(\d+)\.(\d+)$/)
+  if (exactMatch) {
+    const [, a, b, c] = exactMatch
+    return { kind: 'exact', version: parseTriple(a!, b!, c!), raw: trimmed }
+  }
+  const caretMatch = trimmed.match(/^\^(\d+)\.(\d+)\.(\d+)$/)
+  if (caretMatch) {
+    const [, a, b, c] = caretMatch
+    return { kind: 'caret', version: parseTriple(a!, b!, c!) }
+  }
+  const tildeMatch = trimmed.match(/^~(\d+)\.(\d+)\.(\d+)$/)
+  if (tildeMatch) {
+    const [, a, b, c] = tildeMatch
+    return { kind: 'tilde', version: parseTriple(a!, b!, c!) }
+  }
+  return { kind: 'non-release' }
+}
+
+function parseTriple(a: string, b: string, c: string): [number, number, number] {
+  return [Number.parseInt(a, 10), Number.parseInt(b, 10), Number.parseInt(c, 10)]
+}
+
+function formatTriple(v: [number, number, number]): string {
+  return `${v[0]}.${v[1]}.${v[2]}`
+}
+
+// npm/bun caret+tilde semantics, narrowed to plain X.Y.Z bases:
+//   ^0.1.2 → >=0.1.2 <0.2.0   (pre-1.0 caret pins minor — the bug we fix)
+//   ^1.2.3 → >=1.2.3 <2.0.0
+//   ~0.1.2 → >=0.1.2 <0.2.0
+//   ~1.2.3 → >=1.2.3 <1.3.0
+function rangeSatisfies(range: Exclude<DepSpecKind, { kind: 'exact' | 'non-release' }>, version: string): boolean {
+  const v = parseVersion(version)
+  if (v === null) return false
+  const [base, ceiling] = rangeBounds(range)
+  return compareTriples(v, base) >= 0 && compareTriples(v, ceiling) < 0
+}
+
+function rangeBounds(
+  range: Exclude<DepSpecKind, { kind: 'exact' | 'non-release' }>,
+): [[number, number, number], [number, number, number]] {
+  const [maj, min, pat] = range.version
+  if (range.kind === 'caret') {
+    if (maj > 0)
+      return [
+        [maj, min, pat],
+        [maj + 1, 0, 0],
+      ]
+    if (min > 0)
+      return [
+        [maj, min, pat],
+        [maj, min + 1, 0],
+      ]
+    return [
+      [maj, min, pat],
+      [maj, min, pat + 1],
+    ]
+  }
+  return [
+    [maj, min, pat],
+    [maj, min + 1, 0],
+  ]
+}
+
+function parseVersion(version: string): [number, number, number] | null {
+  const m = version.match(/^(\d+)\.(\d+)\.(\d+)$/)
+  if (!m) return null
+  const [, a, b, c] = m
+  return parseTriple(a!, b!, c!)
+}
+
+function compareTriples(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) {
+    const ai = a[i]!
+    const bi = b[i]!
+    if (ai !== bi) return ai - bi
+  }
+  return 0
+}
+
+function compareReleaseVersions(a: string, b: string): number {
+  const av = parseVersion(a)
+  const bv = parseVersion(b)
+  if (av === null || bv === null) return 0
+  return compareTriples(av, bv)
+}
+
+function stripCaret(scaffold: string): string | null {
+  const m = scaffold.match(/^\^?(\d+\.\d+\.\d+)$/)
+  return m ? (m[1] ?? null) : null
+}
+
+function isReleaseVersion(version: string): boolean {
+  return /^\d+\.\d+\.\d+$/.test(version)
+}
+
+async function writeDepSpec(cwd: string, raw: string, parsed: ParsedPackage['parsed'], newSpec: string): Promise<void> {
+  // Preserve user formatting (indentation, trailing newline, key order) by
+  // editing the raw string. Round-tripping through JSON.stringify would
+  // reorder keys and erase user-applied whitespace choices. Fallback below
+  // only kicks in for pathological package.json shapes where the regex
+  // can't anchor on the typeclaw key.
+  const replaced = raw.replace(
+    /("typeclaw"\s*:\s*)"[^"]+"/,
+    (_match, prefix: string) => `${prefix}${JSON.stringify(newSpec)}`,
+  )
+  if (replaced !== raw) {
+    await writeFile(join(cwd, PACKAGE_FILE), replaced)
+    return
+  }
+  const deps = { ...parsed.dependencies, [TYPECLAW]: newSpec }
+  const next = { ...parsed, dependencies: deps }
+  await writeFile(join(cwd, PACKAGE_FILE), `${JSON.stringify(next, null, 2)}\n`)
+}

--- a/src/init/run-bun-install.ts
+++ b/src/init/run-bun-install.ts
@@ -34,3 +34,37 @@ export async function runBunInstall(cwd: string): Promise<InstallResult> {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
   }
 }
+
+// Signature for the function that re-resolves a SINGLE dep against its
+// current spec. Distinct from InstallRunner because the auto-upgrade path
+// MUST force re-resolution against the registry (lockfile-honoring `bun
+// install` would no-op when the existing lockfile entry already satisfies
+// an in-range spec — which is the exact regression auto-upgrade exists to
+// prevent).
+export type UpdateRunner = (cwd: string, pkg: string) => Promise<InstallResult>
+
+export async function runBunUpdate(cwd: string, pkg: string): Promise<InstallResult> {
+  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+  if (!bun) return { ok: false, reason: 'bun runtime not available' }
+  try {
+    const proc = bun.spawn({
+      // `bun update <pkg> --latest` re-resolves <pkg> against the registry,
+      // capped by the spec in package.json. For a caret/tilde range this
+      // pulls the highest in-range version (the case `bun install` won't
+      // upgrade because the lockfile already satisfies the spec). For an
+      // exact pin it's effectively a force re-fetch of that exact version.
+      // `--linker=hoisted` for the same Bun 1.3.x deadlock reason as
+      // runBunInstall above.
+      cmd: ['bun', 'update', pkg, '--latest', '--linker=hoisted'],
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const code = await proc.exited
+    if (code === 0) return { ok: true }
+    const stderr = await new Response(proc.stderr).text()
+    return { ok: false, reason: `bun update ${pkg} exited with code ${code}: ${stderr.trim() || 'no stderr'}` }
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+}


### PR DESCRIPTION
## What and why

Users who run `bun -g update typeclaw` to upgrade their global CLI then hit this on the next `typeclaw start --build` or `typeclaw compose restart`:

```
ERROR [internal] load metadata for ghcr.io/typeclaw/typeclaw-base:0.1.0
Dockerfile:7
   7 | >>> FROM ghcr.io/typeclaw/typeclaw-base:0.1.0
ERROR: ghcr.io/typeclaw/typeclaw-base:0.1.0: not found
```

Root cause: `refreshDockerfile` pins the FROM tag by reading `<agentDir>/node_modules/typeclaw/package.json#version`. The global CLI updated (0.1.0 → 0.1.2), but the agent's `node_modules` hadn't been touched since `typeclaw init`. The old version was never published as a base image (first release was 0.1.1), so the build errored.

The fix: `typeclaw start` now calls `autoUpgradeTypeclawDep` between `refreshPackageJson` and `ensureDeps`. When the agent's installed typeclaw is behind the global CLI, it bumps the dep and runs `bun update typeclaw --latest` so that by the time `refreshDockerfile` reads `node_modules/typeclaw/package.json`, the version is current.

No opt-out flag — exact pins are the escape hatch.

---

## Decision matrix

| Situation | Outcome | Action |
|---|---|---|
| CLI is a dev/source checkout | `skipped-dev-mode` | No-op |
| No `package.json` or no `dependencies.typeclaw` | `skipped-no-dep` | No-op |
| `file:` / `link:` / `latest` / `>=` / `0.1.x` / `*` / `github:` spec | `skipped-non-release-spec` | No-op |
| Container already running at call time | `skipped-already-running` | No-op |
| Installed ≥ CLI | `up-to-date` | No-op (upgrade only, never downgrade) |
| Exact pin (`"0.1.0"`) diverges from CLI | `exact-pin-respected` | Yellow warning, no rewrite — user intent wins |
| Exact pin matches CLI but installed is stale | `reinstall-needed` | `bun update typeclaw --latest` |
| Range includes CLI but installed is older | `reinstall-needed` | `bun update typeclaw --latest` |
| Range excludes CLI (pre-1.0 caret quirk: `^0.1.x` vs CLI `0.2.0`) | `spec-rewritten` | Rewrite spec to `^<CLI>`, then `bun update typeclaw --latest` |

---

## UX

```
$ typeclaw compose restart
◇  Stopping container...
◇  Starting container...

Upgrading agent typeclaw 0.1.0 → 0.1.2 to match CLI
● coder started on host port 8973 (a3f8b21c9d4e).
Host daemon active.
```

Silent on no-op. Cyan notice when an upgrade happens. Yellow warning on exact-pin divergence. The upgrade line renders above the started-on-port line.

The bump lands as an auto-commit in the agent folder: `Upgrade typeclaw to 0.1.2`, staging `package.json` + `bun.lock` together.

---

## Self-review found 3 BLOCKING bugs before merge — fixed and regression-guarded

The first three commits were initial delivery. After running Oracle + two explore agents, three correctness bugs and one data-corruption bug were found. The final commit (`5ef38c9`) fixes all of them, and each has a named regression test.

| # | Severity | Bug | Fix |
|---|---|---|---|
| 1 | **BLOCKING** | `bun install` honors the lockfile — when lockfile satisfies the spec (locked at `0.1.0`, spec is `^0.1.0`, CLI is `0.1.2`), install is a no-op. The canonical regression case was a no-op on first delivery. | New `runBunUpdate(cwd, pkg)` calls `bun update typeclaw --latest` to force registry re-resolution. |
| 2 | **BLOCKING** | `up-to-date` anchored on `max(installed, declaredFloor)`. If `writeDepSpec` bumped `package.json` to `^0.2.0` but install then failed, the next start would see `declaredFloor=0.2.0` and return `up-to-date` even with `node_modules` still at `0.1.x`. The "promise" of the rewrite was being treated as truth. | Anchor `up-to-date` on the **installed** version only; `declaredFloor` is consulted only when nothing is installed yet. |
| 3 | **BLOCKING** | Exact pin matching CLI (`"0.1.2"`) with stale `node_modules` (`0.1.0`) → old code returned `up-to-date`. Container would still build against the old base image. | Exact-pin path returns `reinstall-needed` when declared matches CLI but installed is stale. |
| 4 | **MAJOR** | `writeDepSpec` regex `/("typeclaw"\s*:\s*)"[^"]+"/` matched the **first** occurrence in the raw file — including `devDependencies.typeclaw` before the real one. Spec rewrite would silently land on the wrong key. | Brace-counting tokenizer that locates the `dependencies` object's exact textual range. Edits only inside that range. JSON-round-trip fallback detects existing indent (2-space / 4-space / tabs). |
| 5 | **MAJOR** | No post-install verification. `bun update` can exit 0 but resolve to a stale version. `refreshDockerfile` would then pin a stale base image — back to the original bug class. | Post-install gate re-reads `node_modules/typeclaw/package.json` after `runBunUpdate`. Aborts with a clear error if installed is still behind target. "Installed exceeds target" counts as success. |
| 6 | **MINOR** | `skipped-no-dep` was used as a placeholder return in `reportAlreadyRunning` — a lie, since deps were never checked in that path. | Dedicated `skipped-already-running` variant. |

---

## Architecture

Three new pieces, one wiring point:

- **`src/init/auto-upgrade.ts`** — pure decision module. Exports `autoUpgradeTypeclawDep(cwd)`, `outcomeForcesInstall`, `expectedInstalledAfterUpgrade`, `describeAutoUpgrade`, `readInstalledTypeclawVersionFromAgent`. Also owns the scoped `writeDepSpec` brace-counting tokenizer, keeping the decision matrix and its user-facing wording in one file.
- **`src/init/run-bun-install.ts`** — new `runBunUpdate(cwd, pkg)` helper, sister of `runBunInstall`. Uses `bun update <pkg> --latest --linker=hoisted`. Distinct because plain `bun install` is lockfile-honoring and is therefore a no-op for in-range upgrades.
- **`src/container/start.ts`** — call site is after `refreshPackageJson` and before `ensureDeps`. Test-injectable via `autoUpgrade`, `forceBunUpdate`, `readInstalledVersion` options on `StartOptions`. Auto-commits under `Upgrade typeclaw to X.Y.Z`.
- **`src/cli/ui.ts`** — `renderStartSuccess` extended to print the cyan upgrade line / yellow warning from the new `autoUpgrade` field on `StartResult`.

---

## Test coverage

2817 pass / 0 fail (up from 2787 on `main`). 30 new tests across `src/init/auto-upgrade.test.ts`, `src/container/start.test.ts`, and `src/cli/ui.test.ts`.

Coverage includes:
- All 6 self-review findings above (each test comment names the bug it guards so institutional memory survives future "simplifications").
- All branches of the decision matrix: dev-mode skip, no-dep skip, non-release-spec skip, already-running skip, up-to-date no-op, exact-pin-respected warn, reinstall-needed, spec-rewritten.
- `autoUpgrade`-before-`ensureDeps` ordering verified in the start pipeline test.
- `devDependencies`-only, no-`dependencies`-field, array-typed `package.json`.
- 4-space / tab indent preservation; minified `package.json`; scoped-vs-unscoped rewrite isolation.
- Post-install verification failure path and the "installed exceeds target" success path.
- Commit-message attribution for both `reinstall-needed` and `spec-rewritten` outcomes.
- `renderStartSuccess` all three autoUpgrade display branches.

---

## Out of scope

One MINOR Oracle finding was acknowledged but not addressed in this PR: when the agent folder already has uncommitted changes at upgrade time, the auto-commit for `Upgrade typeclaw to X.Y.Z` will also capture those unrelated dirty files. The fix (stash dirty files around the upgrade commit) adds meaningful complexity and the scenario is uncommon — deferred to a follow-up.