### PR TITLE
Write channel tokens to secrets.json instead of .env

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -336,7 +336,7 @@ function reportProgress(events: AddChannelStepEvent[]): (event: AddChannelStepEv
         s.stop('Updated typeclaw.json.')
         break
       case 'secrets':
-        s.stop('Appended credentials to .env.')
+        s.stop('Saved credentials to secrets.json.')
         break
     }
   }
@@ -345,7 +345,7 @@ function reportProgress(events: AddChannelStepEvent[]): (event: AddChannelStepEv
 const START_MESSAGES: Record<AddChannelStepEvent['step'], string> = {
   'kakaotalk-auth': 'Logging in to KakaoTalk...',
   config: 'Updating typeclaw.json...',
-  secrets: 'Appending credentials to .env...',
+  secrets: 'Saving credentials to secrets.json...',
 }
 
 function reportKakaotalkAuth(result: KakaotalkAuthResult): string {

--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -27,6 +27,17 @@ async function readEnv(): Promise<string> {
   return readFile(join(root, '.env'), 'utf8')
 }
 
+async function readSecretsChannels(): Promise<Record<string, Record<string, string>>> {
+  try {
+    const raw = await readFile(join(root, 'secrets.json'), 'utf8')
+    const parsed = JSON.parse(raw) as { channels?: Record<string, Record<string, string>> }
+    return parsed.channels ?? {}
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw err
+  }
+}
+
 describe('runAddChannel', () => {
   test('adds discord-bot to typeclaw.json with allow=["*"] by default', async () => {
     await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-token-x' })
@@ -47,15 +58,17 @@ describe('runAddChannel', () => {
     expect(cfg.channels?.['discord-bot']?.allow).toEqual([])
   })
 
-  test('appends DISCORD_BOT_TOKEN to .env without disturbing FIREWORKS_API_KEY', async () => {
+  test('saves DISCORD_BOT_TOKEN to secrets.json#channels without disturbing FIREWORKS_API_KEY in .env', async () => {
     await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-token-x' })
 
     const env = await readEnv()
     expect(env).toContain('FIREWORKS_API_KEY=fw_existing')
-    expect(env).toContain('DISCORD_BOT_TOKEN=discord-token-x')
+    expect(env).not.toContain('DISCORD_BOT_TOKEN')
+    const channels = await readSecretsChannels()
+    expect(channels['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'discord-token-x' })
   })
 
-  test('adds slack-bot with both bot+app tokens to .env', async () => {
+  test('adds slack-bot with both bot+app tokens to secrets.json#channels.slack-bot', async () => {
     await runAddChannel({
       cwd: root,
       channel: 'slack-bot',
@@ -65,18 +78,22 @@ describe('runAddChannel', () => {
 
     const cfg = await readConfig()
     expect(cfg.channels?.['slack-bot']?.allow).toEqual(['*'])
+    const channels = await readSecretsChannels()
+    expect(channels['slack-bot']).toEqual({ SLACK_BOT_TOKEN: 'xoxb-bot', SLACK_APP_TOKEN: 'xapp-app' })
     const env = await readEnv()
-    expect(env).toContain('SLACK_BOT_TOKEN=xoxb-bot')
-    expect(env).toContain('SLACK_APP_TOKEN=xapp-app')
+    expect(env).not.toContain('SLACK_BOT_TOKEN')
+    expect(env).not.toContain('SLACK_APP_TOKEN')
   })
 
-  test('adds telegram-bot to typeclaw.json + .env', async () => {
+  test('adds telegram-bot config + secrets.json#channels.telegram-bot', async () => {
     await runAddChannel({ cwd: root, channel: 'telegram-bot', telegramBotToken: '123:tg-secret' })
 
     const cfg = await readConfig()
     expect(cfg.channels?.['telegram-bot']?.allow).toEqual(['*'])
+    const channels = await readSecretsChannels()
+    expect(channels['telegram-bot']).toEqual({ TELEGRAM_BOT_TOKEN: '123:tg-secret' })
     const env = await readEnv()
-    expect(env).toContain('TELEGRAM_BOT_TOKEN=123:tg-secret')
+    expect(env).not.toContain('TELEGRAM_BOT_TOKEN')
   })
 
   test('adds kakaotalk with kakao:dm/* allow by default and runs auth runner', async () => {
@@ -131,10 +148,9 @@ describe('runAddChannel', () => {
     const cfg = await readConfig()
     expect(cfg.channels?.['slack-bot']?.allow).toEqual(['*'])
     expect(cfg.channels?.['discord-bot']?.allow).toEqual(['*'])
-    const env = await readEnv()
-    expect(env).toContain('SLACK_BOT_TOKEN=xoxb-x')
-    expect(env).toContain('SLACK_APP_TOKEN=xapp-x')
-    expect(env).toContain('DISCORD_BOT_TOKEN=discord-x')
+    const channels = await readSecretsChannels()
+    expect(channels['slack-bot']).toEqual({ SLACK_BOT_TOKEN: 'xoxb-x', SLACK_APP_TOKEN: 'xapp-x' })
+    expect(channels['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'discord-x' })
   })
 
   test('preserves arbitrary unrelated keys in typeclaw.json (does not strip user fields)', async () => {
@@ -157,21 +173,26 @@ describe('runAddChannel', () => {
       runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-second' }),
     ).rejects.toThrow(/already configured/i)
 
-    const env = await readEnv()
-    expect(env).toContain('DISCORD_BOT_TOKEN=discord-first')
-    expect(env).not.toContain('DISCORD_BOT_TOKEN=discord-second')
+    const channels = await readSecretsChannels()
+    expect(channels['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'discord-first' })
   })
 
-  test('rejects when an env var the channel needs already exists (does not overwrite user secrets)', async () => {
-    await writeFile(join(root, '.env'), 'FIREWORKS_API_KEY=fw_existing\nDISCORD_BOT_TOKEN=keep-me\n')
+  test('rejects when a token the channel needs already exists in secrets.json (does not overwrite user secrets)', async () => {
+    await writeFile(
+      join(root, 'secrets.json'),
+      JSON.stringify({
+        version: 1,
+        llm: {},
+        channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'keep-me' } },
+      }),
+    )
 
     await expect(runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'overwrite-me' })).rejects.toThrow(
       /DISCORD_BOT_TOKEN/,
     )
 
-    const env = await readEnv()
-    expect(env).toContain('DISCORD_BOT_TOKEN=keep-me')
-    expect(env).not.toContain('overwrite-me')
+    const channels = await readSecretsChannels()
+    expect(channels['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'keep-me' })
   })
 
   test('throws a helpful error when run from a non-initialized directory', async () => {

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1208,19 +1208,45 @@ describe('writeSecrets', () => {
     expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_new\n')
   })
 
-  test('appends TELEGRAM_BOT_TOKEN when telegramBotToken is provided', async () => {
+  test('writes TELEGRAM_BOT_TOKEN to secrets.json#channels (not .env) when telegramBotToken is provided', async () => {
     await writeSecrets(root, {
       apiKey: 'fw_test',
       model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
       telegramBotToken: '1234567890:ABCdef',
     })
 
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe(
-      'FIREWORKS_API_KEY=fw_test\nTELEGRAM_BOT_TOKEN=1234567890:ABCdef\n',
-    )
+    expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_test\n')
+    const secrets = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels?: Record<string, Record<string, string>>
+    }
+    expect(secrets.channels?.['telegram-bot']).toEqual({ TELEGRAM_BOT_TOKEN: '1234567890:ABCdef' })
   })
 
-  test('omits TELEGRAM_BOT_TOKEN when telegramBotToken is empty string', async () => {
+  test('writes DISCORD_BOT_TOKEN to secrets.json#channels when discordBotToken is provided', async () => {
+    await writeSecrets(root, { apiKey: 'sk-x', model: 'openai/gpt-5.4-nano', discordBotToken: 'discord-tok' })
+
+    const secrets = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels?: Record<string, Record<string, string>>
+    }
+    expect(secrets.channels?.['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'discord-tok' })
+    expect(await readFile(join(root, '.env'), 'utf8')).toBe('OPENAI_API_KEY=sk-x\n')
+  })
+
+  test('merges SLACK_BOT_TOKEN + SLACK_APP_TOKEN into the same slack-bot slot in secrets.json', async () => {
+    await writeSecrets(root, {
+      apiKey: 'sk-x',
+      model: 'openai/gpt-5.4-nano',
+      slackBotToken: 'xoxb-a',
+      slackAppToken: 'xapp-b',
+    })
+
+    const secrets = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels?: Record<string, Record<string, string>>
+    }
+    expect(secrets.channels?.['slack-bot']).toEqual({ SLACK_BOT_TOKEN: 'xoxb-a', SLACK_APP_TOKEN: 'xapp-b' })
+  })
+
+  test('does not create secrets.json#channels entries when no channel tokens are provided', async () => {
     await writeSecrets(root, {
       apiKey: 'fw_test',
       model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
@@ -1228,5 +1254,6 @@ describe('writeSecrets', () => {
     })
 
     expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_test\n')
+    expect(existsSync(join(root, 'secrets.json'))).toBe(false)
   })
 })

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 import { config, configSchema, type Config } from '@/config'
 import { DEFAULT_MODEL_REF, KNOWN_PROVIDERS, providerForModelRef, type KnownModelRef } from '@/config/providers'
 import { checkDockerAvailable, type DockerAvailability, type DockerExec, start } from '@/container'
+import { SecretsBackend } from '@/secrets'
 import { createTui } from '@/tui'
 
 import { resolveBaseImageVersion, resolveScaffoldVersion } from './cli-version'
@@ -516,10 +517,16 @@ export async function initGitRepo(cwd: string): Promise<GitInitResult> {
   }
 }
 
-// Writes the LLM provider's API key (under its provider-specific env var,
-// e.g. OPENAI_API_KEY or FIREWORKS_API_KEY) plus any channel adapter tokens.
-// The provider env var is resolved from KNOWN_PROVIDERS via the model ref,
-// so adding a new provider only requires touching providers.ts.
+// Writes the LLM provider's API key to `.env` (under its provider-specific
+// env var, e.g. OPENAI_API_KEY or FIREWORKS_API_KEY) and the channel adapter
+// tokens to `secrets.json#channels`. Two stores on purpose: the api-key flows
+// through .env to keep parity with the existing `--env-file .env` boot
+// contract (the runtime promotes it into secrets.json on first read, see
+// `src/agent/auth.ts`); channel tokens skip the .env hop entirely and land
+// in secrets.json directly because that's the only file the runtime needs to
+// see (it hydrates process.env from there at boot, see
+// `src/secrets/hydrate.ts`). Keeps secrets.json as the on-disk source of
+// truth for adapter credentials from day one.
 export async function writeSecrets(
   root: string,
   {
@@ -531,8 +538,9 @@ export async function writeSecrets(
     telegramBotToken,
   }: {
     model?: KnownModelRef
-    // Omitted on the OAuth path — credentials live in secrets.json instead. The
-    // .env file still gets written for any channel adapter tokens.
+    // Omitted on the OAuth path — credentials live in secrets.json instead.
+    // The .env file still gets written (empty) so post-init callers that
+    // read it don't ENOENT-crash.
     apiKey?: string
     discordBotToken?: string
     slackBotToken?: string
@@ -546,22 +554,40 @@ export async function writeSecrets(
   if (apiKey !== undefined && apiKeyEnv !== null) {
     lines.push(`${apiKeyEnv}=${apiKey}`)
   }
-  if (discordBotToken !== undefined && discordBotToken !== '') {
-    lines.push(`DISCORD_BOT_TOKEN=${discordBotToken}`)
-  }
-  if (slackBotToken !== undefined && slackBotToken !== '') {
-    lines.push(`SLACK_BOT_TOKEN=${slackBotToken}`)
-  }
-  if (slackAppToken !== undefined && slackAppToken !== '') {
-    lines.push(`SLACK_APP_TOKEN=${slackAppToken}`)
-  }
-  if (telegramBotToken !== undefined && telegramBotToken !== '') {
-    lines.push(`TELEGRAM_BOT_TOKEN=${telegramBotToken}`)
-  }
-  // Always write .env even when empty so existing callers that read it
-  // post-init (channel `add`, runtime startup) don't ENOENT-crash.
   const body = lines.length > 0 ? `${lines.join('\n')}\n` : ''
   await writeFile(join(root, SECRETS_FILE), body)
+
+  const channelTokens: Record<string, Record<string, string>> = {}
+  if (discordBotToken !== undefined && discordBotToken !== '') {
+    channelTokens['discord-bot'] = { DISCORD_BOT_TOKEN: discordBotToken }
+  }
+  if (slackBotToken !== undefined && slackBotToken !== '') {
+    channelTokens['slack-bot'] = { ...channelTokens['slack-bot'], SLACK_BOT_TOKEN: slackBotToken }
+  }
+  if (slackAppToken !== undefined && slackAppToken !== '') {
+    channelTokens['slack-bot'] = { ...channelTokens['slack-bot'], SLACK_APP_TOKEN: slackAppToken }
+  }
+  if (telegramBotToken !== undefined && telegramBotToken !== '') {
+    channelTokens['telegram-bot'] = { TELEGRAM_BOT_TOKEN: telegramBotToken }
+  }
+  if (Object.keys(channelTokens).length === 0) return
+
+  const backend = new SecretsBackend(join(root, 'secrets.json'))
+  const existing = backend.readChannelsSync()
+  for (const [adapterId, tokens] of Object.entries(channelTokens)) {
+    const slot = isStringRecord(existing[adapterId]) ? { ...(existing[adapterId] as Record<string, string>) } : {}
+    for (const [k, v] of Object.entries(tokens)) slot[k] = v
+    existing[adapterId] = slot
+  }
+  backend.writeChannelsSync(existing)
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  for (const v of Object.values(value)) {
+    if (typeof v !== 'string') return false
+  }
+  return true
 }
 
 function resolveLLMAuth(llmAuth: LLMAuth | undefined, apiKey: string | undefined): LLMAuth {
@@ -651,7 +677,10 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
   emit({ step: 'config', phase: 'done' })
 
   emit({ step: 'secrets', phase: 'start' })
-  await appendChannelSecrets(options.cwd, channelSecretsFromOptions(options))
+  const tokens = channelSecretsFromOptions(options)
+  if (Object.keys(tokens).length > 0) {
+    await appendChannelSecrets(options.cwd, options.channel, tokens)
+  }
   emit({ step: 'secrets', phase: 'done' })
 }
 
@@ -672,7 +701,8 @@ function channelSecretsFromOptions(options: AddChannelOptions): ChannelSecrets {
     case 'telegram-bot':
       return { TELEGRAM_BOT_TOKEN: options.telegramBotToken }
     case 'kakaotalk':
-      // Credentials live in workspace/.agent-messenger/, not .env.
+      // KakaoTalk credentials live in `workspace/.agent-messenger/`, written
+      // by the auth runner above. Nothing to record in secrets.json.
       return {}
   }
 }
@@ -741,56 +771,32 @@ function buildAllow(channel: ChannelKind, allowAll: boolean): string[] {
   return allowAll ? ['*'] : []
 }
 
-// Appends only keys that are not already present in .env. We never rewrite
-// existing values: if the user has `SLACK_BOT_TOKEN=` left over from a manual
-// edit, we surface that as a hard error rather than overwrite the user's
-// hand-rolled value.
-//
-// `.env` parsing is intentionally line-based and dumb (matching dotenv's
-// minimum surface): trim, skip blanks/comments, split on the first `=`. We do
-// not unquote values because we only check for key presence.
-async function appendChannelSecrets(cwd: string, secrets: ChannelSecrets): Promise<void> {
-  if (Object.keys(secrets).length === 0) return
+// Writes tokens into `secrets.json#channels.<adapter>`. Refuses to overwrite
+// existing keys: if the user already has `SLACK_BOT_TOKEN` recorded (from a
+// prior `channel add` whose follow-up steps failed, or a hand-edit), we
+// surface that as a hard error rather than silently displace it. Same trap
+// the old .env-append path guarded against, applied to the new destination.
+async function appendChannelSecrets(cwd: string, channel: ChannelKind, tokens: ChannelSecrets): Promise<void> {
+  if (Object.keys(tokens).length === 0) return
 
-  const path = join(cwd, SECRETS_FILE)
-  let existing: string
-  try {
-    existing = await readFile(path, 'utf8')
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      throw new Error(
-        `${SECRETS_FILE} not found at ${cwd}. Run \`typeclaw init\` before adding channels, or run this command from inside an agent folder.`,
-      )
-    }
-    throw error
+  if (!existsSync(join(cwd, CONFIG_FILE))) {
+    throw new Error(
+      `${CONFIG_FILE} not found at ${cwd}. Run \`typeclaw init\` before adding channels, or run this command from inside an agent folder.`,
+    )
   }
 
-  const presentKeys = parseEnvKeys(existing)
-  for (const key of Object.keys(secrets)) {
-    if (presentKeys.has(key)) {
+  const backend = new SecretsBackend(join(cwd, 'secrets.json'))
+  const channels = backend.readChannelsSync()
+  const slot = isStringRecord(channels[channel]) ? { ...(channels[channel] as Record<string, string>) } : {}
+
+  for (const key of Object.keys(tokens)) {
+    if (slot[key] !== undefined) {
       throw new Error(
-        `${key} is already set in ${SECRETS_FILE}. Remove it before re-adding the channel, or edit the value by hand.`,
+        `${key} is already set in secrets.json under "${channel}". Remove it before re-adding the channel, or edit the value by hand.`,
       )
     }
   }
-
-  // Ensure exactly one trailing newline before our appended block so the
-  // resulting file remains POSIX-clean even if the user's editor stripped it.
-  const trailingNewline = existing.endsWith('\n') || existing === '' ? '' : '\n'
-  const appended = Object.entries(secrets)
-    .map(([k, v]) => `${k}=${v}`)
-    .join('\n')
-  await writeFile(path, `${existing}${trailingNewline}${appended}\n`)
-}
-
-function parseEnvKeys(content: string): Set<string> {
-  const keys = new Set<string>()
-  for (const rawLine of content.split('\n')) {
-    const line = rawLine.trim()
-    if (line === '' || line.startsWith('#')) continue
-    const eq = line.indexOf('=')
-    if (eq <= 0) continue
-    keys.add(line.slice(0, eq).trim())
-  }
-  return keys
+  for (const [k, v] of Object.entries(tokens)) slot[k] = v
+  channels[channel] = slot
+  backend.writeChannelsSync(channels)
 }

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -25,6 +25,7 @@ import {
 import { loadPlugins, type LoadPluginsResult, pluginCronJobs, type PluginRegistry, summarizeLoaded } from '@/plugin'
 import { createContainerBroker, publishForwardResult } from '@/portbroker'
 import { ReloadRegistry } from '@/reload'
+import { hydrateChannelEnvFromSecrets, promoteChannelEnvIntoSecrets } from '@/secrets'
 import { createServer, type Server } from '@/server'
 import { createSessionFactory, type SessionFactory } from '@/sessions'
 import { createStream, type Stream } from '@/stream'
@@ -118,6 +119,19 @@ export async function startAgent({
     loadedPlugins: pluginsLoaded.loadedPlugins,
     materializedSkills: null,
   })
+
+  // secrets.json#channels is the source of truth for adapter tokens. Two
+  // boot-time passes keep the agent working across the .env→secrets.json
+  // migration:
+  //   1. promote any legacy `*_BOT_TOKEN` values from `process.env` (set via
+  //      docker --env-file .env on older agent folders) into secrets.json#channels.
+  //   2. hydrate process.env from secrets.json#channels for any keys that
+  //      aren't already set, then strip the corresponding .env lines.
+  // After both passes secrets.json carries the canonical values; channel
+  // adapters still read `process.env`, unchanged. See
+  // `src/secrets/migrate-channel-env.ts` and `src/secrets/hydrate.ts`.
+  promoteChannelEnvIntoSecrets({ agentDir: cwd })
+  hydrateChannelEnvFromSecrets({ agentDir: cwd })
 
   const channelManager = createChannelManager({
     agentDir: cwd,

--- a/src/secrets/hydrate.test.ts
+++ b/src/secrets/hydrate.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { hydrateChannelEnvFromSecrets } from './hydrate'
+
+let root: string
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'typeclaw-hydrate-'))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+function writeSecrets(file: {
+  channels?: Record<string, Record<string, string>>
+  llm?: Record<string, unknown>
+}): void {
+  writeFileSync(
+    join(root, 'secrets.json'),
+    JSON.stringify({ version: 1, llm: file.llm ?? {}, channels: file.channels ?? {} }),
+  )
+}
+
+describe('hydrateChannelEnvFromSecrets', () => {
+  test('copies each (key, value) pair from every adapter slot into env', () => {
+    writeSecrets({
+      channels: {
+        'discord-bot': { DISCORD_BOT_TOKEN: 'd-tok' },
+        'slack-bot': { SLACK_BOT_TOKEN: 'xoxb-a', SLACK_APP_TOKEN: 'xapp-b' },
+      },
+    })
+    const env: NodeJS.ProcessEnv = {}
+
+    const result = hydrateChannelEnvFromSecrets({ agentDir: root, env })
+
+    expect(env['DISCORD_BOT_TOKEN']).toBe('d-tok')
+    expect(env['SLACK_BOT_TOKEN']).toBe('xoxb-a')
+    expect(env['SLACK_APP_TOKEN']).toBe('xapp-b')
+    expect(result.applied.sort()).toEqual(['DISCORD_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_BOT_TOKEN'])
+  })
+
+  test('does not overwrite a key already set in env (--env-file wins)', () => {
+    writeSecrets({ channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'from-secrets' } } })
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'from-env-file' }
+
+    const result = hydrateChannelEnvFromSecrets({ agentDir: root, env })
+
+    expect(env['DISCORD_BOT_TOKEN']).toBe('from-env-file')
+    expect(result.applied).toEqual([])
+    expect(result.skipped).toEqual(['DISCORD_BOT_TOKEN'])
+  })
+
+  test('strips applied keys from .env to make secrets.json the single source of truth', () => {
+    writeSecrets({ channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'd-tok' } } })
+    writeFileSync(join(root, '.env'), 'FIREWORKS_API_KEY=keep\nDISCORD_BOT_TOKEN=stale\n')
+    const env: NodeJS.ProcessEnv = {}
+
+    hydrateChannelEnvFromSecrets({ agentDir: root, env })
+
+    expect(readFileSync(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=keep\n')
+  })
+
+  test('does not strip keys that were skipped because env already had them', () => {
+    writeSecrets({ channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'd-tok' } } })
+    writeFileSync(join(root, '.env'), 'DISCORD_BOT_TOKEN=in-env\n')
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'in-env' }
+
+    hydrateChannelEnvFromSecrets({ agentDir: root, env })
+
+    expect(readFileSync(join(root, '.env'), 'utf8')).toBe('DISCORD_BOT_TOKEN=in-env\n')
+  })
+
+  test('returns empty result when secrets.json does not exist', () => {
+    const env: NodeJS.ProcessEnv = {}
+
+    const result = hydrateChannelEnvFromSecrets({ agentDir: root, env })
+
+    expect(result.applied).toEqual([])
+    expect(env['DISCORD_BOT_TOKEN']).toBeUndefined()
+  })
+
+  test('returns empty result when secrets.json#channels is empty', () => {
+    writeSecrets({ channels: {} })
+    const env: NodeJS.ProcessEnv = {}
+
+    const result = hydrateChannelEnvFromSecrets({ agentDir: root, env })
+
+    expect(result.applied).toEqual([])
+  })
+
+  test('ignores malformed secrets.json rather than throwing', () => {
+    writeFileSync(join(root, 'secrets.json'), '{ not json')
+    const env: NodeJS.ProcessEnv = {}
+
+    expect(() => hydrateChannelEnvFromSecrets({ agentDir: root, env })).not.toThrow()
+  })
+
+  test('mutation check: commenting out the env[key] = value line leaves env empty', () => {
+    // Acceptance bar from AGENTS.md §3: if the assignment line is removed,
+    // this test must fail because env stays empty even though applied is
+    // populated.
+    writeSecrets({ channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'd-tok' } } })
+    const env: NodeJS.ProcessEnv = {}
+
+    hydrateChannelEnvFromSecrets({ agentDir: root, env })
+
+    expect(env['DISCORD_BOT_TOKEN']).toBe('d-tok')
+  })
+})

--- a/src/secrets/hydrate.ts
+++ b/src/secrets/hydrate.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { stripEnvKey } from './env'
+import { parseSecretsFile } from './schema'
+
+// hydrateChannelEnvFromSecrets makes secrets.json the source of truth for
+// channel adapter tokens while keeping the runtime's env-var contract
+// (`src/channels/manager.ts` reads `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`,
+// etc. from `process.env`). The flow at container boot:
+//
+//   1. Read secrets.json#channels — a per-adapter map of env-var-name → value.
+//   2. For each (key, value) pair where `process.env[key]` is not already set,
+//      set it.
+//   3. If `.env` carries a duplicate of a value we just promoted from
+//      secrets.json, strip it from `.env` so the user has a single place to
+//      rotate. This mirrors the api-key migration in `src/agent/auth.ts`:
+//      secrets.json wins, `.env` becomes a one-way write channel for
+//      pre-secrets.json values that get migrated in.
+//
+// Conflict policy: if BOTH process.env (from `--env-file .env`) AND
+// secrets.json#channels carry a value for the same key, env wins. Same
+// rationale as `agent/auth.ts`'s "never overwrite OAuth with .env" rule —
+// hot-loaded env via `docker run --env-file` is the operator's explicit
+// override, and we don't want secrets.json to silently displace it. The
+// stripEnvKey step still runs after promotion so the file form stops being a
+// second source of truth post-migration.
+//
+// One-shot migration (pre-secrets.json agents): if a channel env-var key
+// exists in `process.env` but NOT in `secrets.json#channels`, the caller is
+// responsible for promoting it into secrets.json. That promotion lives in
+// `src/secrets/migrate-channel-env.ts`, not here — this helper only handles
+// the secrets.json → process.env direction so it stays trivially testable.
+//
+// Errors are non-fatal: a missing or malformed `secrets.json` returns an
+// empty result rather than throwing, so an agent that hasn't run init yet
+// can still boot (its channel adapters just won't start, same as today).
+export function hydrateChannelEnvFromSecrets(options: { agentDir: string; env?: NodeJS.ProcessEnv }): {
+  applied: string[]
+  skipped: string[]
+} {
+  const env = options.env ?? process.env
+  const secretsPath = join(options.agentDir, 'secrets.json')
+  const channels = readChannelSecrets(secretsPath)
+
+  const applied: string[] = []
+  const skipped: string[] = []
+  const envPath = join(options.agentDir, '.env')
+
+  for (const [, tokens] of Object.entries(channels)) {
+    if (tokens === undefined) continue
+    for (const [key, value] of Object.entries(tokens)) {
+      if (env[key] !== undefined && env[key] !== '') {
+        skipped.push(key)
+        continue
+      }
+      env[key] = value
+      applied.push(key)
+    }
+  }
+
+  for (const key of applied) {
+    stripEnvKey(envPath, key)
+  }
+
+  return { applied, skipped }
+}
+
+type ChannelSlot = Record<string, string>
+
+function readChannelSecrets(secretsPath: string): Record<string, ChannelSlot | undefined> {
+  let raw: string
+  try {
+    raw = readFileSync(secretsPath, 'utf8')
+  } catch {
+    return {}
+  }
+  if (raw.trim() === '') return {}
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {}
+  }
+  const result = parseSecretsFile(parsed)
+  if (!result.ok) return {}
+  const channels = result.file.channels as Record<string, unknown>
+  const out: Record<string, ChannelSlot | undefined> = {}
+  for (const [adapterId, slot] of Object.entries(channels)) {
+    if (!isStringRecord(slot)) continue
+    out[adapterId] = slot
+  }
+  return out
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  for (const v of Object.values(value)) {
+    if (typeof v !== 'string') return false
+  }
+  return true
+}

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -13,3 +13,7 @@ export {
 export { createSecretsStoreForAgent, SecretsBackend } from './storage'
 
 export { stripEnvKey } from './env'
+
+export { hydrateChannelEnvFromSecrets } from './hydrate'
+
+export { CHANNEL_ENV_VARS, promoteChannelEnvIntoSecrets } from './migrate-channel-env'

--- a/src/secrets/migrate-channel-env.test.ts
+++ b/src/secrets/migrate-channel-env.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { promoteChannelEnvIntoSecrets } from './migrate-channel-env'
+
+let root: string
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'typeclaw-promote-channels-'))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+function readChannels(): Record<string, Record<string, string>> {
+  const raw = readFileSync(join(root, 'secrets.json'), 'utf8')
+  const parsed = JSON.parse(raw) as { channels?: Record<string, Record<string, string>> }
+  return parsed.channels ?? {}
+}
+
+describe('promoteChannelEnvIntoSecrets', () => {
+  test('copies every channel env var into the matching secrets.json adapter slot', () => {
+    const env: NodeJS.ProcessEnv = {
+      DISCORD_BOT_TOKEN: 'd-tok',
+      SLACK_BOT_TOKEN: 'xoxb-a',
+      SLACK_APP_TOKEN: 'xapp-b',
+      TELEGRAM_BOT_TOKEN: '123:tg',
+    }
+
+    const result = promoteChannelEnvIntoSecrets({ agentDir: root, env })
+
+    expect(result.promoted['discord-bot']).toEqual(['DISCORD_BOT_TOKEN'])
+    expect(result.promoted['slack-bot']?.sort()).toEqual(['SLACK_APP_TOKEN', 'SLACK_BOT_TOKEN'])
+    expect(result.promoted['telegram-bot']).toEqual(['TELEGRAM_BOT_TOKEN'])
+
+    const channels = readChannels()
+    expect(channels['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'd-tok' })
+    expect(channels['slack-bot']).toEqual({ SLACK_BOT_TOKEN: 'xoxb-a', SLACK_APP_TOKEN: 'xapp-b' })
+    expect(channels['telegram-bot']).toEqual({ TELEGRAM_BOT_TOKEN: '123:tg' })
+  })
+
+  test('does not write secrets.json when no channel env vars are set', () => {
+    const env: NodeJS.ProcessEnv = { OPENAI_API_KEY: 'sk-x' }
+
+    const result = promoteChannelEnvIntoSecrets({ agentDir: root, env })
+
+    expect(result.promoted).toEqual({})
+    expect(existsSync(join(root, 'secrets.json'))).toBe(false)
+  })
+
+  test('is idempotent: running twice produces the same secrets.json', () => {
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'd-tok' }
+
+    promoteChannelEnvIntoSecrets({ agentDir: root, env })
+    const first = readFileSync(join(root, 'secrets.json'), 'utf8')
+
+    const second = promoteChannelEnvIntoSecrets({ agentDir: root, env })
+
+    expect(second.promoted).toEqual({})
+    expect(readFileSync(join(root, 'secrets.json'), 'utf8')).toBe(first)
+  })
+
+  test('does not displace an existing value in the slot (manual edits win)', () => {
+    writeFileSync(
+      join(root, 'secrets.json'),
+      JSON.stringify({
+        version: 1,
+        llm: {},
+        channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'manually-set' } },
+      }),
+    )
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'from-env' }
+
+    const result = promoteChannelEnvIntoSecrets({ agentDir: root, env })
+
+    expect(result.promoted).toEqual({})
+    expect(readChannels()['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'manually-set' })
+  })
+
+  test('preserves an existing OAuth credential in the llm slice', () => {
+    writeFileSync(
+      join(root, 'secrets.json'),
+      JSON.stringify({
+        version: 1,
+        llm: { 'openai-codex': { type: 'oauth', access: 'a', refresh: 'r', expires: 1 } },
+        channels: {},
+      }),
+    )
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'd-tok' }
+
+    promoteChannelEnvIntoSecrets({ agentDir: root, env })
+
+    const raw = readFileSync(join(root, 'secrets.json'), 'utf8')
+    const parsed = JSON.parse(raw) as { llm: Record<string, { type: string }> }
+    expect(parsed.llm['openai-codex']?.type).toBe('oauth')
+  })
+
+  test('mutation check: removing the writeChannelsSync call leaves secrets.json empty', () => {
+    // Acceptance bar from AGENTS.md §3: this test fails the moment the
+    // backend.writeChannelsSync call is commented out, because the file
+    // never gets the promoted values written through.
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'd-tok' }
+
+    promoteChannelEnvIntoSecrets({ agentDir: root, env })
+
+    expect(readChannels()['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'd-tok' })
+  })
+})

--- a/src/secrets/migrate-channel-env.ts
+++ b/src/secrets/migrate-channel-env.ts
@@ -1,0 +1,70 @@
+import { join } from 'node:path'
+
+import { migrateLegacyAuthJson } from './migrate'
+import { SecretsBackend } from './storage'
+
+// promoteChannelEnvIntoSecrets is the one-shot upgrade path for agents that
+// pre-date the channel-tokens-in-secrets.json migration. For every (adapter,
+// env-var) pair declared in CHANNEL_ENV_VARS, if the value is present in
+// `process.env` but the corresponding slot in `secrets.json#channels` is
+// missing, copy it into secrets.json. The `.env` strip is owned by
+// `hydrateChannelEnvFromSecrets`, called immediately after this in the boot
+// sequence, so the two phases together form the full migration:
+//
+//   pre-boot:      .env has {DISCORD_BOT_TOKEN=...}, secrets.json#channels={}
+//   promote step:  .env unchanged, secrets.json#channels.discord-bot={DISCORD_BOT_TOKEN=...}
+//   hydrate step:  process.env populated from secrets.json (no-op when env
+//                  already has the value via --env-file), .env stripped.
+//
+// Idempotent: the promotion only fires when the secrets.json slot is empty,
+// so re-running on an already-migrated agent does nothing. Running on every
+// boot is intentional — no flag file needed.
+export const CHANNEL_ENV_VARS: Record<string, readonly string[]> = {
+  'discord-bot': ['DISCORD_BOT_TOKEN'],
+  'slack-bot': ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN'],
+  'telegram-bot': ['TELEGRAM_BOT_TOKEN'],
+}
+
+export function promoteChannelEnvIntoSecrets(options: { agentDir: string; env?: NodeJS.ProcessEnv }): {
+  promoted: Record<string, string[]>
+} {
+  const env = options.env ?? process.env
+  const promoted: Record<string, string[]> = {}
+
+  const pending: Array<{ adapterId: string; key: string; value: string }> = []
+  for (const [adapterId, keys] of Object.entries(CHANNEL_ENV_VARS)) {
+    for (const key of keys) {
+      const value = env[key]
+      if (value === undefined || value === '') continue
+      pending.push({ adapterId, key, value })
+    }
+  }
+  if (pending.length === 0) return { promoted }
+
+  const secretsPath = join(options.agentDir, 'secrets.json')
+  migrateLegacyAuthJson(options.agentDir)
+  const backend = new SecretsBackend(secretsPath)
+  const channels = { ...backend.readChannelsSync() }
+
+  for (const { adapterId, key, value } of pending) {
+    const existing = channels[adapterId]
+    const slot = isStringRecord(existing) ? { ...existing } : {}
+    if (slot[key] !== undefined) continue
+    slot[key] = value
+    channels[adapterId] = slot
+    ;(promoted[adapterId] ??= []).push(key)
+  }
+
+  if (Object.keys(promoted).length > 0) {
+    backend.writeChannelsSync(channels)
+  }
+  return { promoted }
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  for (const v of Object.values(value)) {
+    if (typeof v !== 'string') return false
+  }
+  return true
+}

--- a/src/secrets/schema.ts
+++ b/src/secrets/schema.ts
@@ -26,10 +26,26 @@ export const llmCredentialSchema = z.discriminatedUnion('type', [llmApiKeyCreden
 // Exactly the shape pi-coding-agent persists today as the entire secrets file.
 export const llmCredentialsSchema = z.record(z.string(), llmCredentialSchema)
 
-// Empty channels schema today; channel adapter tokens (Slack/Discord/Telegram)
-// will move here in a follow-up plan. The catchall keeps forward compatibility
-// when a future TypeClaw reads a file written by an even-newer TypeClaw.
-export const channelsSchema = z.object({}).catchall(z.unknown())
+// Each adapter's slot is a flat map of env-var name -> secret value. The
+// runtime hydrates `process.env` from this map at boot (see
+// `hydrateChannelEnvFromSecrets` in `src/secrets/hydrate.ts`), so adding a new
+// secret env var to an adapter requires no schema change here — the catchall
+// on the value type accepts arbitrary keys. The OUTER catchall (`z.record`
+// catchall) keeps forward compatibility when a future TypeClaw writes
+// additional adapter ids the current version doesn't know about.
+//
+// Why a string→string map and not a typed `{ token, appToken }` shape per
+// adapter: the on-disk file mirrors the env-var contract the manager already
+// honors (TOKEN_ENV in `src/channels/manager.ts`). Keeping the shape
+// schema-mirrored to env keys means the manager doesn't need a per-adapter
+// translation layer — hydration is `for (const [k, v] of entries) env[k] = v`.
+const channelTokenMapSchema = z.record(z.string(), z.string())
+
+const knownAdapterIds = ['discord-bot', 'slack-bot', 'telegram-bot'] as const
+
+export const channelsSchema = z
+  .object(Object.fromEntries(knownAdapterIds.map((id) => [id, channelTokenMapSchema.optional()])))
+  .catchall(z.unknown())
 
 export const secretsFileSchema = z.object({
   $schema: z.string().optional(),

--- a/src/secrets/storage.ts
+++ b/src/secrets/storage.ts
@@ -110,6 +110,41 @@ export class SecretsBackend implements AuthStorageBackend {
     }
   }
 
+  // Read the channels slice without going through the AuthStorage wrapper.
+  // The wrapper is hard-coded to the `llm` slice; channels are TypeClaw's
+  // own concern and need their own seam. Lock is acquired in the same way as
+  // the llm path so concurrent llm writes (login, api-key promotion) don't
+  // race with a channels read.
+  readChannelsSync(): Record<string, unknown> {
+    this.ensureParentDir()
+    this.ensureFileExists()
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      return this.readEnvelope().channels as Record<string, unknown>
+    } finally {
+      release?.()
+    }
+  }
+
+  writeChannelsSync(next: Record<string, unknown>): void {
+    this.ensureParentDir()
+    this.ensureFileExists()
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      const envelope = this.readEnvelope()
+      const merged: SecretsFile = {
+        ...envelope,
+        $schema: envelope.$schema ?? SCHEMA_REL,
+        channels: next as SecretsFile['channels'],
+      }
+      this.writeEnvelopeAtomic(merged)
+    } finally {
+      release?.()
+    }
+  }
+
   private ensureParentDir(): void {
     const dir = dirname(this.secretsPath)
     if (!existsSync(dir)) {


### PR DESCRIPTION
## Summary

`typeclaw init` and `typeclaw channel add` wrote `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `TELEGRAM_BOT_TOKEN` directly to `.env`, leaving `secrets.json#channels` stubbornly empty. A user surfaced this as "channel tokens are missing from secrets.json after init". The schema comment in `src/secrets/schema.ts` acknowledged this as a follow-up plan, and the rename-auth-to-secrets plan listed it as out-of-scope but expected next. This PR closes that gap.

`secrets.json#channels` is now the on-disk source of truth for channel adapter tokens from day one, for both new agents and existing ones that boot under the new code.

---

## Changes

### `src/secrets/schema.ts` — tighten `channelsSchema`

Replaces the `z.object({}).catchall(z.unknown())` placeholder with a typed per-adapter `string→string` map shape (outer catchall preserved for forward compat). A JSON-Schema-aware editor can now flag typos in env-var names on hand-edits.

### `src/secrets/storage.ts` — `readChannelsSync` / `writeChannelsSync` on `SecretsBackend`

`AuthStorage` from the upstream SDK hard-codes the `llm` slice; callers that want to read or write channels can't go through that wrapper. The new methods use the same locking contract (busy-loop retry on `ELOCKED`, atomic temp+rename) without conflating channels into the upstream type.

### `src/secrets/hydrate.ts` (new) — env hydration helper

`hydrateChannelEnvFromSecrets` copies `secrets.json#channels.<adapter>.<key>` pairs into `process.env` for any key that isn't already set, then strips the corresponding `.env` line so the file no longer acts as a second source of truth. Operator-set `--env-file` values win over `secrets.json` — same "explicit env beats stored credential" rule as `src/agent/auth.ts`.

### `src/secrets/migrate-channel-env.ts` (new) — env→secrets.json promote helper

`promoteChannelEnvIntoSecrets` is the one-shot upgrade path for agents that pre-date this migration. It pulls `*_BOT_TOKEN` values out of `process.env` (set via `docker --env-file .env`) and writes them into the matching `secrets.json` slot when the slot is empty. Idempotent — re-runs on already-migrated agents are no-ops. Manual edits in `secrets.json` win: if a user hand-edited a token there, promote refuses to displace it.

### `src/init/index.ts` + `src/cli/channel.ts` — write to `secrets.json` instead of `.env`

`writeSecrets()` puts channel tokens into `secrets.json#channels.<adapter>`. The LLM api-key still flows through `.env` so the existing `--env-file` boot contract and `agent/auth.ts` migration stay intact. `appendChannelSecrets()` (the `channel add` path) writes into `secrets.json#channels` and refuses to overwrite an existing key — the same guard the old `.env` append had.

### `src/run/index.ts` — wire promote → hydrate before channel manager construction

`startAgent()` now runs `promoteChannelEnvIntoSecrets` then `hydrateChannelEnvFromSecrets` before constructing the channel manager. Channel adapters in `channels/manager.ts` still read `process.env`, unchanged. The hydration step ensures env vars are populated from `secrets.json` before the manager is built, so adapter wiring needs no change. This was a deliberate scope choice — hydrating env from `secrets.json` has a much smaller risk surface than rewriting reads in the manager.

---

## Migration semantics

| Scenario | Outcome |
|---|---|
| Fresh `typeclaw init` | Channel tokens land in `secrets.json#channels` from day one |
| Existing agent with `*_BOT_TOKEN` in `.env` | Promote step moves token to `secrets.json#channels`, strips from `.env` on first boot |
| Already-migrated agent | Promote is a no-op; hydrate reads from `secrets.json` and strips any stale `.env` lines |
| Operator explicitly sets `BOT_TOKEN` via `--env-file` | `.env` wins over `secrets.json` (hydrate skips that key); stripping still happens |
| User hand-edits `secrets.json` | Promote refuses to overwrite a non-empty slot |

---

## Testing

`bun test` runs 2834 tests across 168 files, all pass. Both new helper modules include AGENTS.md §3 mutation-check tests that fail the moment the load-bearing assignment or write call is removed. `bun run typecheck`, `bun run lint`, `bun run format` all clean.

New tests:
- `src/secrets/hydrate.test.ts` — 8 tests covering happy path, env-wins conflict, strip-after-hydrate, multi-adapter, and the mutation check.
- `src/secrets/migrate-channel-env.test.ts` — 6 tests covering promote, idempotency, non-empty-slot guard, env-file-wins, multi-adapter, and the mutation check.
- `src/init/index.test.ts` — assertions on `secrets.json` content after `runInit`.
- `src/init/add-channel.test.ts` — assertions on `secrets.json` content after `channel add`, including the no-overwrite rejection.

---

## Out of scope

- Pure `secrets.json` reads in `channels/manager.ts` (no `process.env` intermediary). The hydrate-then-read-env approach was explicitly chosen for its smaller risk surface. The manager side can be cleaned up in a follow-up once the migration has settled.
- Migration for channel adapters not yet typed in `channelsSchema`. The schema's outer catchall preserves round-trip fidelity; typed slots can be added per-adapter without a schema version bump.