### PR TITLE
Strip migrated channel env vars from .env after promoting to secrets.json

### DIFF
--- a/src/secrets/migrate-channel-env.test.ts
+++ b/src/secrets/migrate-channel-env.test.ts
@@ -108,4 +108,72 @@ describe('promoteChannelEnvIntoSecrets', () => {
 
     expect(readChannels()['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'd-tok' })
   })
+
+  test('removes every promoted key from .env, preserving other lines and comments', () => {
+    writeFileSync(
+      join(root, '.env'),
+      [
+        '# user secrets',
+        'OPENAI_API_KEY=sk-keep',
+        'DISCORD_BOT_TOKEN=d-tok',
+        'SLACK_BOT_TOKEN=xoxb-a',
+        'SLACK_APP_TOKEN=xapp-b',
+        'UNRELATED=keep-me',
+        '',
+      ].join('\n'),
+    )
+    const env: NodeJS.ProcessEnv = {
+      DISCORD_BOT_TOKEN: 'd-tok',
+      SLACK_BOT_TOKEN: 'xoxb-a',
+      SLACK_APP_TOKEN: 'xapp-b',
+    }
+
+    promoteChannelEnvIntoSecrets({ agentDir: root, env })
+
+    const envText = readFileSync(join(root, '.env'), 'utf8')
+    expect(envText).not.toContain('DISCORD_BOT_TOKEN')
+    expect(envText).not.toContain('SLACK_BOT_TOKEN')
+    expect(envText).not.toContain('SLACK_APP_TOKEN')
+    expect(envText).toContain('# user secrets')
+    expect(envText).toContain('OPENAI_API_KEY=sk-keep')
+    expect(envText).toContain('UNRELATED=keep-me')
+  })
+
+  test('does not touch .env when the slot was already populated (no promotion = no strip)', () => {
+    writeFileSync(
+      join(root, 'secrets.json'),
+      JSON.stringify({
+        version: 1,
+        llm: {},
+        channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'manually-set' } },
+      }),
+    )
+    const original = 'DISCORD_BOT_TOKEN=from-env\n'
+    writeFileSync(join(root, '.env'), original)
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'from-env' }
+
+    promoteChannelEnvIntoSecrets({ agentDir: root, env })
+
+    expect(readFileSync(join(root, '.env'), 'utf8')).toBe(original)
+  })
+
+  test('is a no-op on .env when the file does not exist', () => {
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'd-tok' }
+
+    promoteChannelEnvIntoSecrets({ agentDir: root, env })
+
+    expect(existsSync(join(root, '.env'))).toBe(false)
+    expect(readChannels()['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'd-tok' })
+  })
+
+  test('mutation check: removing the stripEnvKey loop leaves .env unchanged', () => {
+    // Acceptance bar from AGENTS.md §3: commenting out the strip loop fails
+    // this test because the migrated key would still be sitting in .env.
+    writeFileSync(join(root, '.env'), 'DISCORD_BOT_TOKEN=d-tok\n')
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'd-tok' }
+
+    promoteChannelEnvIntoSecrets({ agentDir: root, env })
+
+    expect(readFileSync(join(root, '.env'), 'utf8')).not.toContain('DISCORD_BOT_TOKEN')
+  })
 })

--- a/src/secrets/migrate-channel-env.ts
+++ b/src/secrets/migrate-channel-env.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 
+import { stripEnvKey } from './env'
 import { migrateLegacyAuthJson } from './migrate'
 import { SecretsBackend } from './storage'
 
@@ -7,18 +8,27 @@ import { SecretsBackend } from './storage'
 // pre-date the channel-tokens-in-secrets.json migration. For every (adapter,
 // env-var) pair declared in CHANNEL_ENV_VARS, if the value is present in
 // `process.env` but the corresponding slot in `secrets.json#channels` is
-// missing, copy it into secrets.json. The `.env` strip is owned by
-// `hydrateChannelEnvFromSecrets`, called immediately after this in the boot
-// sequence, so the two phases together form the full migration:
+// missing, copy it into secrets.json AND strip the matching line from `.env`
+// so secrets.json becomes the single source of truth in one atomic step:
 //
 //   pre-boot:      .env has {DISCORD_BOT_TOKEN=...}, secrets.json#channels={}
-//   promote step:  .env unchanged, secrets.json#channels.discord-bot={DISCORD_BOT_TOKEN=...}
-//   hydrate step:  process.env populated from secrets.json (no-op when env
-//                  already has the value via --env-file), .env stripped.
+//   promote step:  .env no longer carries DISCORD_BOT_TOKEN,
+//                  secrets.json#channels.discord-bot={DISCORD_BOT_TOKEN=...}
+//   hydrate step:  process.env already populated for this boot (--env-file
+//                  ran before promote), and on the NEXT boot hydrate is what
+//                  injects the value from secrets.json into process.env.
 //
-// Idempotent: the promotion only fires when the secrets.json slot is empty,
-// so re-running on an already-migrated agent does nothing. Running on every
-// boot is intentional — no flag file needed.
+// The `.env` strip is owned here, not in `hydrateChannelEnvFromSecrets`,
+// because hydrate only knows about keys it `applied` (process.env was empty)
+// — the migration case is exactly the opposite: process.env DOES have the
+// value (it came from --env-file), so hydrate skips it and would leave the
+// `.env` line dangling. Mirrors the api-key migration in `src/agent/auth.ts`,
+// which strips `.env` at the same moment it writes to secrets.json.
+//
+// Only keys we actually wrote to secrets.json on THIS call are stripped — if
+// the slot was already populated (manual edit wins, see test), `.env` stays
+// untouched because no migration happened. Idempotent: re-running on an
+// already-migrated agent promotes nothing and strips nothing.
 export const CHANNEL_ENV_VARS: Record<string, readonly string[]> = {
   'discord-bot': ['DISCORD_BOT_TOKEN'],
   'slack-bot': ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN'],
@@ -57,6 +67,12 @@ export function promoteChannelEnvIntoSecrets(options: { agentDir: string; env?: 
 
   if (Object.keys(promoted).length > 0) {
     backend.writeChannelsSync(channels)
+    const envPath = join(options.agentDir, '.env')
+    for (const keys of Object.values(promoted)) {
+      for (const key of keys) {
+        stripEnvKey(envPath, key)
+      }
+    }
   }
   return { promoted }
 }


### PR DESCRIPTION
## Summary

`promoteChannelEnvIntoSecrets` copied `*_BOT_TOKEN` values from `.env` into `secrets.json#channels` but left the matching `.env` lines in place, creating two sources of truth for channel tokens after migration.

The root cause: the header comment claimed `hydrateChannelEnvFromSecrets` would clean up the migrated keys. But hydrate only strips keys it `applied` — those where `process.env` was empty and got populated from `secrets.json`. In the migration case, `process.env` already had the value (injected by `docker run --env-file .env`), so hydrate pushed the key into `skipped` and never called `stripEnvKey`. The `.env` line dangled indefinitely.

## Changes

### `src/secrets/migrate-channel-env.ts`

- After `backend.writeChannelsSync(channels)`, iterate the `promoted` map and call `stripEnvKey(envPath, key)` for every key written in this call.
- Only newly-promoted keys are stripped — if the slot was already populated (no migration happened), `.env` is left untouched.
- `stripEnvKey` is ENOENT-safe, so a missing `.env` is a no-op.
- Mirrors the existing api-key migration pattern in `src/agent/auth.ts` (line 81), which strips `.env` at the same moment it writes to `secrets.json`.
- Header comment rewritten to document the corrected ownership: the strip lives in `promote`, not `hydrate`, with an explanation of why hydrate cannot own it.

## Testing

Four new tests added to `src/secrets/migrate-channel-env.test.ts`:

- **Strips every promoted key, preserves unrelated lines** — verifies `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` are removed from `.env` while `OPENAI_API_KEY`, `UNRELATED`, and comments survive.
- **No-op when slot already populated** — when `secrets.json` already has a non-empty slot, no migration fires and `.env` is untouched.
- **No-op when `.env` does not exist** — ENOENT-safe path.
- **Mutation check** — asserting that the migrated key is absent from `.env` after `promoteChannelEnvIntoSecrets`; this test fails if the strip loop is commented out (per AGENTS.md §3 acceptance bar).

```
bun test src/secrets/ → 58 pass, 0 fail
bun run typecheck     → clean
bun run lint          → clean (1 pre-existing warning in src/doctor/index.ts, unrelated)
bun run format        → clean
```

## Review Notes

The fix is intentionally narrow: only `promoted` keys (those written to `secrets.json` on this call) are stripped. Keys already in `secrets.json` before this run are unaffected. This matches the semantics of `promoteChannelEnvIntoSecrets` itself — idempotent, manual edits win, no side effects on already-migrated agents.