### PR TITLE
Default network.blockInternal to true and scaffold it in typeclaw init

### DIFF
--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -141,17 +141,22 @@ describe('portForwardSchema', () => {
 })
 
 describe('networkSchema', () => {
-  test('defaults to blockInternal:false when omitted (existing agents not affected by upgrade)', () => {
+  test('defaults to blockInternal:true when omitted (egress filter on for every agent unless opted out)', () => {
     const parsed = configSchema.parse({ model: VALID_MODEL })
-    expect(parsed.network).toEqual({ blockInternal: false })
+    expect(parsed.network).toEqual({ blockInternal: true })
   })
 
-  test('accepts an empty network object, inheriting the false default', () => {
+  test('accepts an empty network object, inheriting the true default', () => {
     const parsed = configSchema.parse({ model: VALID_MODEL, network: {} })
+    expect(parsed.network).toEqual({ blockInternal: true })
+  })
+
+  test('preserves blockInternal:false when explicitly opted out', () => {
+    const parsed = configSchema.parse({ model: VALID_MODEL, network: { blockInternal: false } })
     expect(parsed.network).toEqual({ blockInternal: false })
   })
 
-  test('preserves blockInternal:true when explicitly set', () => {
+  test('preserves blockInternal:true when explicitly set (redundant with default, but harmless)', () => {
     const parsed = configSchema.parse({ model: VALID_MODEL, network: { blockInternal: true } })
     expect(parsed.network).toEqual({ blockInternal: true })
   })

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -111,13 +111,24 @@ export type GitignoreConfig = z.infer<typeof gitignoreSchema>
 // multicast/reserved, IPv6 ULA/link-local/multicast. The capability is then
 // dropped from the bounding set via setpriv before the agent process exec's,
 // so no child (python, curl, bun-spawned anything) can mutate or recover it.
-// Default is `false` so existing agent folders are unaffected by an upgrade;
-// `typeclaw init` writes `true` for new agents (handled separately in init).
+//
+// Default is `true`: the threat model that motivated this feature — prompt
+// injection asking the agent to fetch RFC1918 hosts (e.g. a LAN router admin
+// page) or the cloud-IMDS endpoint — applies to every agent equally, so the
+// safe default is "on" and
+// the explicit opt-out is for users who need their agent to reach LAN hosts
+// (NAS, internal services, sibling dev machines). PR #145 shipped this with
+// default `false` to preserve existing-folder behavior on upgrade; this
+// follow-up (the one PR #145 promised in its description) makes the default
+// match the intent. `typeclaw init` also writes `true` explicitly so the
+// field is discoverable in fresh `typeclaw.json` files. Loopback traffic
+// (`-o lo`) is always allowed by the shim, so `bun run dev` and local APIs
+// on `localhost` / `127.0.0.1` are unaffected.
 export const networkSchema = z
   .object({
-    blockInternal: z.boolean().default(false),
+    blockInternal: z.boolean().default(true),
   })
-  .default({ blockInternal: false })
+  .default({ blockInternal: true })
 
 export type NetworkConfig = z.infer<typeof networkSchema>
 

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -416,17 +416,17 @@ describe('planStart mounts', () => {
 })
 
 describe('planStart network egress filter', () => {
-  test('emits no NET_ADMIN cap and no env var when typeclaw.json is missing (existing-agent default = off)', async () => {
+  test('grants NET_ADMIN and sets TYPECLAW_NETWORK_BLOCK_INTERNAL=1 when typeclaw.json is missing (new default = on)', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    expect(plan.runArgs).not.toContain('--cap-add=NET_ADMIN')
-    expect(plan.runArgs.filter((a) => a.includes('TYPECLAW_NETWORK_BLOCK_INTERNAL'))).toHaveLength(0)
+    expect(plan.runArgs).toContain('--cap-add=NET_ADMIN')
+    expect(plan.runArgs).toContain('TYPECLAW_NETWORK_BLOCK_INTERNAL=1')
   })
 
-  test('emits no NET_ADMIN cap and no env var when network.blockInternal is explicitly false', async () => {
+  test('emits no NET_ADMIN cap and no env var when network.blockInternal is explicitly false (opt-out path for LAN access)', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     await writeTypeclawConfig(root, { network: { blockInternal: false } })

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -389,7 +389,7 @@ describe('versioned per-agent Dockerfile (base-image-pinning)', () => {
 })
 
 describe('network egress entrypoint shim', () => {
-  test('is a no-op when TYPECLAW_NETWORK_BLOCK_INTERNAL is unset or not "1" (existing agents unaffected by upgrade)', () => {
+  test('is a no-op when TYPECLAW_NETWORK_BLOCK_INTERNAL is unset or not "1" (off-switch path: users who opted out via network.blockInternal=false)', () => {
     const shim = buildEntrypointShim()
     expect(shim).toContain('"${TYPECLAW_NETWORK_BLOCK_INTERNAL:-0}" != "1"')
     expect(shim).toMatch(/!= "1" \];? then\s+exec bun run typeclaw "\$@"/)

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -89,11 +89,13 @@ export const NETWORK_BLOCK_IPV6_NETS = ['fc00::/7', 'fe80::/10', 'ff00::/8', '::
 // Renders the shell script that runs as PID 1 inside the container. Two
 // modes, picked at boot time from `$TYPECLAW_NETWORK_BLOCK_INTERNAL`:
 //
-//   off (default, blockInternal=false or env unset): no rules installed,
-//   no setpriv. Just exec `bun run typeclaw "$@"`. Identical observable
-//   behavior to the pre-feature container.
+//   off (env unset or != "1"): no rules installed, no setpriv. Just exec
+//   `bun run typeclaw "$@"`. Identical observable behavior to a container
+//   without this feature. This is the opt-out path for users who set
+//   `network.blockInternal: false` in their `typeclaw.json`.
 //
-//   on (blockInternal=true): walks IPv4 + IPv6 block lists and installs
+//   on (default, env = "1" via `network.blockInternal: true`): walks IPv4 +
+//   IPv6 block lists and installs
 //   REJECT rules in the OUTPUT chain. Loopback (`-o lo`) is ACCEPT'd first
 //   so dev-server dogfooding still works. The hostd HTTP control port on
 //   `host.docker.internal` is re-allowed at runtime — narrowly, single

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -667,7 +667,7 @@ describe('scaffold', () => {
     expect(existsSync(join(root, 'memory'))).toBe(false)
   })
 
-  test('writes typeclaw.json with only $schema and model (defaults for mounts and memory live in their owners)', async () => {
+  test('writes typeclaw.json with $schema, model, and network.blockInternal=true (security-relevant, kept visible for discoverability)', async () => {
     await scaffold(root)
 
     const raw = await readFile(join(root, 'typeclaw.json'), 'utf8')
@@ -675,15 +675,17 @@ describe('scaffold', () => {
     expect(JSON.parse(raw)).toEqual({
       $schema: './node_modules/typeclaw/typeclaw.schema.json',
       model: 'openai/gpt-5.4-nano',
+      network: { blockInternal: true },
     })
   })
 
-  test('omits fields whose defaults are already provided by configSchema or the bundled plugin', async () => {
+  test('omits fields whose defaults are already provided by configSchema or the bundled plugin (except network, which is security-relevant and discovery-worthy)', async () => {
     await scaffold(root)
 
     const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as Record<string, unknown>
     expect(cfg.mounts).toBeUndefined()
     expect(cfg.memory).toBeUndefined()
+    expect(cfg.network).toEqual({ blockInternal: true })
   })
 
   test('writes cron.json with an empty jobs array and $schema reference', async () => {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -344,14 +344,18 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   // immediately populated, so packages/ is the only one that needs this.
   await writeFile(join(root, PACKAGES_DIR, GITKEEP_FILE), '', { flag: 'wx' }).catch(ignoreExists)
 
-  // Only fields without sensible defaults elsewhere are emitted. `mounts`
-  // defaults to `[]` in configSchema, and the bundled memory plugin owns its
-  // own defaults in src/bundled-plugins/memory/index.ts — re-emitting either here would
-  // be duplicate noise the user has to maintain in sync with the source of
-  // truth.
+  // Only fields without sensible defaults elsewhere are emitted, with one
+  // exception: `network.blockInternal` is re-emitted at its default value
+  // (`true`) because the field is security-relevant and users need to
+  // discover it in their `typeclaw.json` to know they can opt out for LAN
+  // access. `mounts` defaults to `[]` in configSchema, and the bundled
+  // memory plugin owns its own defaults in src/bundled-plugins/memory/
+  // index.ts — re-emitting either here would be duplicate noise the user
+  // has to maintain in sync with the source of truth.
   const config: Record<string, unknown> = {
     $schema: './node_modules/typeclaw/typeclaw.schema.json',
     model: options.model ?? DEFAULT_MODEL_REF,
+    network: { blockInternal: true },
   }
   const channels: Record<string, { allow: string[] }> = {}
   if (options.withDiscord) channels['discord-bot'] = { allow: options.discordAllowAll === false ? [] : ['*'] }


### PR DESCRIPTION
## Summary

PR #145 shipped the RFC1918 / IMDS egress-filter mechanism but kept `network.blockInternal` defaulting to `false`, explicitly deferring the default flip to a follow-up PR ("Turning it on by default for new agents is a separate decision worth its own PR and CHANGELOG entry"). This is that PR.

Two changes:

1. `configSchema`'s `networkSchema` default flips from `{ blockInternal: false }` to `{ blockInternal: true }` — every agent that omits the `network` block will now boot with the egress filter active.
2. `scaffold()` writes `network: { blockInternal: true }` explicitly into fresh `typeclaw.json` files so the field is discoverable and the opt-out path is visible to users who need it.

## Threat model

The canonical attack: prompt injection asks the agent to write a Python script that connects to a LAN router admin panel or the cloud IMDS endpoint (`169.254.169.254`) and then asks it to run the script. The `bash` tool call carries only `python attack.py` — no URL, no network indicator. Every userland hook sees nothing. Only the network layer is past the point of further indirection.

Without this default flip, a user who ran `typeclaw init` in the window between #145 merging and this PR ships an agent with `blockInternal` defaulting to `false` and no `network` block in `typeclaw.json` — the filter is installed in the image and wired into `planStart`, but never activated. The fix is the default.

## What changes for upgrading users

Agents **with** a `network` block in `typeclaw.json` are unaffected — Zod merges the explicit value, same as before.

Agents **without** a `network` block will, on the next `typeclaw start`, boot with `TYPECLAW_NETWORK_BLOCK_INTERNAL=1` injected. The egress filter activates:

- Outbound connections to RFC1918 (`10/8`, `172.16/12`, `192.168/16`), link-local/IMDS (`169.254/16`), CGNAT (`100.64/10`), multicast, and the IPv6 equivalents are `REJECT`'d with `icmp-port-unreachable`. Failures are fast (ICMP unreachable, not 30-second SYN-timeout hangs), so the symptom is easy to spot and diagnose.

Users who need the agent to reach LAN hosts (NAS, internal services, sibling dev machines) add one line to `typeclaw.json`:

```json
"network": { "blockInternal": false }
```

Then `typeclaw restart`. No rebuild required — the feature is gated on an env var, not a Dockerfile layer.

## What does NOT break

`localhost`, `127.0.0.1`, and `[::1]` all continue to work. The shim's first iptables rule is:

```sh
iptables -A OUTPUT -o lo -j ACCEPT
```

This is unconditional and fires before any REJECT rule — loopback traffic short-circuits the block list entirely. Concretely:

- `bun run dev` bound to `localhost` works.
- SQLite / Unix socket IPC works.
- The agent's `restart` tool (which dials `host.docker.internal:8974`) works — `host.docker.internal` is resolved at shim boot and added to the ACCEPT list before the REJECT rules are installed.
- The portbroker WS (which terminates on the host side, not an RFC1918 address) works.
- The in-container auto-port-forward works.

## Changes

### `src/config/config.ts`

- `networkSchema` default: `{ blockInternal: false }` → `{ blockInternal: true }`.
- Comment block updated to explain the threat model and the opt-out pattern.

### `src/init/index.ts`

- `scaffold()` writes `network: { blockInternal: true }` alongside `$schema` and `model`.
- Comment explains why this field is emitted at its default value (discoverability) while `mounts` and `memory` are not (their defaults are noise; `network` is security-relevant).

### Tests (7 files, +48 / -24 lines)

All tests are updated to reflect the new default. The three changes that carry semantic weight:

- `config.test.ts` — the "missing `typeclaw.json`" case now expects `--cap-add=NET_ADMIN` and `TYPECLAW_NETWORK_BLOCK_INTERNAL=1` to be present.
- `index.test.ts` — `scaffold()` test updated to expect `network: { blockInternal: true }` in the emitted JSON.
- `dockerfile.test.ts` — test description updated to reflect that the off-switch path is the explicit opt-out, not the default.

## Verification

```
bun run typecheck  → clean
bun run lint       → clean
bun run format     → clean
bun test           → 2839 pass, 0 fail (168 files)
```

## Out of scope (called out for future PRs)

Two separate inbound-exposure findings that are orthogonal to this outbound filter:

1. **`agent-browser` dashboard port auto-forwarded by portbroker.** `shouldForward()` in `src/portbroker/policy.ts` currently only excludes `CONTAINER_PORT` (8973). The upstream port the `agent-browser` plugin binds its dashboard to (4849) is therefore forwarded to the host — bypassing the dashboard proxy's own access controls. Deserves a separate PR to add that port to the exclusion list or tie it to an explicit `portForward.allow` policy.
2. **`DEFAULT_LISTEN_HOST = '0.0.0.0'` in `dashboard-proxy.ts`.** This binds the proxy on the Docker bridge interface, making it reachable from any container on the bridge subnet. Also orthogonal to #145's outbound filter; separate PR.