### PR TITLE
Log channel_* tool failures via the shared [channels] prefix

### DIFF
--- a/src/agent/tools/channel-fetch-attachment.ts
+++ b/src/agent/tools/channel-fetch-attachment.ts
@@ -7,6 +7,8 @@ import { defineTool } from '@mariozechner/pi-coding-agent'
 import type { ChannelRouter } from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
 
+import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
+
 export type ChannelFetchAttachmentOrigin = {
   adapter: AdapterId
 }
@@ -15,6 +17,7 @@ export type CreateChannelFetchAttachmentToolOptions = {
   router: ChannelRouter
   origin: ChannelFetchAttachmentOrigin
   inboxDir?: string
+  logger?: ChannelToolLogger
 }
 
 export const DEFAULT_INBOX_DIR = '/agent/workspace/inbox'
@@ -23,6 +26,7 @@ export function createChannelFetchAttachmentTool({
   router,
   origin,
   inboxDir,
+  logger = consoleChannelLogger,
 }: CreateChannelFetchAttachmentToolOptions) {
   const baseDir = inboxDir ?? DEFAULT_INBOX_DIR
   const adapter = origin.adapter
@@ -60,6 +64,7 @@ export function createChannelFetchAttachmentTool({
         ...(params.filename !== undefined ? { filename: params.filename } : {}),
       })
       if (!result.ok) {
+        logger.warn(formatChannelToolFailure('channel_fetch_attachment', `${adapter}: ${result.error}`))
         const text = `channel_fetch_attachment error: ${result.error}`
         const details: Details = { ok: false, error: result.error }
         return { content: [{ type: 'text' as const, text }], details }
@@ -74,6 +79,7 @@ export function createChannelFetchAttachmentTool({
         await writeFile(targetPath, result.buffer)
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
+        logger.warn(formatChannelToolFailure('channel_fetch_attachment', `${adapter}: write failed: ${message}`))
         const text = `channel_fetch_attachment error: write failed: ${message}`
         const details: Details = { ok: false, error: `write failed: ${message}` }
         return { content: [{ type: 'text' as const, text }], details }

--- a/src/agent/tools/channel-history.ts
+++ b/src/agent/tools/channel-history.ts
@@ -5,6 +5,8 @@ import type { ChannelRouter } from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
 import type { ChannelHistoryMessage } from '@/channels/types'
 
+import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
+
 export type ChannelHistoryOrigin = {
   adapter: AdapterId
   workspace: string
@@ -15,6 +17,7 @@ export type ChannelHistoryOrigin = {
 export type CreateChannelHistoryToolOptions = {
   router: ChannelRouter
   origin: ChannelHistoryOrigin
+  logger?: ChannelToolLogger
 }
 
 // channel_history is a lazy "look back" capability for channel-routed
@@ -27,7 +30,11 @@ export type CreateChannelHistoryToolOptions = {
 // `scope` defaults to thread when the origin has one, channel otherwise.
 // Thread scope on a channel-root session is rejected rather than silently
 // downgraded so the agent doesn't conflate the two views.
-export function createChannelHistoryTool({ router, origin }: CreateChannelHistoryToolOptions) {
+export function createChannelHistoryTool({
+  router,
+  origin,
+  logger = consoleChannelLogger,
+}: CreateChannelHistoryToolOptions) {
   return defineTool({
     name: 'channel_history',
     label: 'Channel History',
@@ -64,6 +71,7 @@ export function createChannelHistoryTool({ router, origin }: CreateChannelHistor
       type Details = { ok: boolean; error?: string; count?: number; nextCursor?: string }
 
       if (scope === 'thread' && origin.thread === null) {
+        logger.warn(formatChannelToolFailure('channel_history', 'thread-scope-requires-thread-session'))
         const text =
           'channel_history error: thread-scope-requires-thread-session — this session is not in a thread; pass `scope: "channel"` instead.'
         const details: Details = { ok: false, error: 'thread-scope-requires-thread-session' }
@@ -78,6 +86,7 @@ export function createChannelHistoryTool({ router, origin }: CreateChannelHistor
       })
 
       if (!result.ok) {
+        logger.warn(formatChannelToolFailure('channel_history', `${origin.adapter}:${origin.chat}: ${result.error}`))
         const details: Details = { ok: false, error: result.error }
         return {
           content: [{ type: 'text' as const, text: `channel_history error: ${result.error}` }],

--- a/src/agent/tools/channel-log.ts
+++ b/src/agent/tools/channel-log.ts
@@ -1,0 +1,32 @@
+// Shared logger surface for the channel_* agent tools.
+//
+// Until now, channel_send / channel_reply / channel_history /
+// channel_fetch_attachment swallowed every failure into the model-visible
+// tool result and emitted nothing to the container's stdout/stderr. That
+// made operator-side debugging blind: a Slack send that 403'd, a
+// `thread-scope-requires-thread-session` denial, or a Discord attachment
+// fetch that timed out left no trace in `typeclaw logs`. The router layer
+// logs some of these (e.g. `fetchHistory` warns on caught exceptions) but
+// does NOT log `router.send` rejections, and pre-router validation errors
+// inside the tools (missing text, NO_REPLY misuse, thread-scope mismatch,
+// local write failures) never reached the router in the first place.
+//
+// One injectable logger per tool keeps the existing fake-router test
+// pattern intact: tests pass an array-collecting logger to assert the log
+// line, production code defaults to `consoleChannelLogger` which routes to
+// `console.warn` so it lands in `typeclaw logs` alongside the existing
+// `[channels]` lines from manager.ts / router.ts.
+export type ChannelToolLogger = {
+  warn: (msg: string) => void
+}
+
+export const consoleChannelLogger: ChannelToolLogger = {
+  warn: (m) => console.warn(m),
+}
+
+// Format a failure log line. Keeps the `[channels]` prefix used by
+// manager.ts and router.ts so operators can `grep '\[channels\]'` and see
+// the full stack of channel-related warnings in one pass.
+export function formatChannelToolFailure(tool: string, error: string): string {
+  return `[channels] ${tool} failed: ${error}`
+}

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -4,6 +4,8 @@ import { defineTool } from '@mariozechner/pi-coding-agent'
 import { isNoReplySignal, type ChannelRouter } from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
 
+import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
+
 export type ChannelReplyOrigin = {
   adapter: AdapterId
   workspace: string
@@ -14,6 +16,7 @@ export type ChannelReplyOrigin = {
 export type CreateChannelReplyToolOptions = {
   router: ChannelRouter
   origin: ChannelReplyOrigin
+  logger?: ChannelToolLogger
 }
 
 // channel_reply is the happy-path companion to channel_send for channel-routed
@@ -25,7 +28,11 @@ export type CreateChannelReplyToolOptions = {
 // channel_reply takes only `text` and addresses the message from the origin.
 // channel_send remains for posting somewhere else (different chat, breaking
 // out of a thread, sending DMs from a channel session, etc.).
-export function createChannelReplyTool({ router, origin }: CreateChannelReplyToolOptions) {
+export function createChannelReplyTool({
+  router,
+  origin,
+  logger = consoleChannelLogger,
+}: CreateChannelReplyToolOptions) {
   return defineTool({
     name: 'channel_reply',
     label: 'Channel Reply',
@@ -64,6 +71,7 @@ export function createChannelReplyTool({ router, origin }: CreateChannelReplyToo
       const text = params.text
       const attachments = params.attachments
       if ((text === undefined || text === '') && (attachments === undefined || attachments.length === 0)) {
+        logger.warn(formatChannelToolFailure('channel_reply', 'missing text and attachments'))
         return {
           content: [
             { type: 'text' as const, text: 'channel_reply denied: must provide `text`, `attachments`, or both.' },
@@ -74,6 +82,7 @@ export function createChannelReplyTool({ router, origin }: CreateChannelReplyToo
 
       const noReplyError = noReplyMisuseError(text)
       if (noReplyError) {
+        logger.warn(formatChannelToolFailure('channel_reply', noReplyError))
         return {
           content: [{ type: 'text' as const, text: `channel_reply denied: ${noReplyError}` }],
           details: { ok: false, error: noReplyError },
@@ -89,6 +98,14 @@ export function createChannelReplyTool({ router, origin }: CreateChannelReplyToo
         ...(attachments !== undefined ? { attachments } : {}),
       })
 
+      if (!result.ok) {
+        logger.warn(
+          formatChannelToolFailure(
+            'channel_reply',
+            `${origin.adapter}:${origin.workspace}/${origin.chat}: ${result.error}`,
+          ),
+        )
+      }
       const details: { ok: boolean; error?: string } = result.ok ? { ok: true } : { ok: false, error: result.error }
       // Echo the delivered text back to the model. The adapter classifier
       // drops self-authored messages on the inbound path (`self_author`),

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -4,6 +4,7 @@ import { defineTool } from '@mariozechner/pi-coding-agent'
 import { isNoReplySignal, type ChannelRouter } from '@/channels/router'
 import { ADAPTER_IDS, type AdapterId } from '@/channels/schema'
 
+import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
 import { renderOutboundEcho } from './channel-reply'
 
 export type ChannelSendOrigin = {
@@ -21,9 +22,10 @@ export type CreateChannelSendToolOptions = {
   // the model can self-correct on its next turn. Absent for sessions whose
   // origin isn't a channel (e.g. cron prompts that send to channels).
   origin?: ChannelSendOrigin
+  logger?: ChannelToolLogger
 }
 
-export function createChannelSendTool({ router, origin }: CreateChannelSendToolOptions) {
+export function createChannelSendTool({ router, origin, logger = consoleChannelLogger }: CreateChannelSendToolOptions) {
   return defineTool({
     name: 'channel_send',
     label: 'Channel Send',
@@ -93,6 +95,7 @@ export function createChannelSendTool({ router, origin }: CreateChannelSendToolO
       const bodyText = params.text
       const attachments = params.attachments
       if ((bodyText === undefined || bodyText === '') && (attachments === undefined || attachments.length === 0)) {
+        logger.warn(formatChannelToolFailure('channel_send', 'missing text and attachments'))
         return {
           content: [
             { type: 'text' as const, text: 'channel_send denied: must provide `text`, `attachments`, or both.' },
@@ -103,6 +106,7 @@ export function createChannelSendTool({ router, origin }: CreateChannelSendToolO
 
       const noReplyError = noReplyMisuseError(bodyText)
       if (noReplyError) {
+        logger.warn(formatChannelToolFailure('channel_send', noReplyError))
         return {
           content: [{ type: 'text' as const, text: `channel_send denied: ${noReplyError}` }],
           details: { ok: false, error: noReplyError },
@@ -118,6 +122,14 @@ export function createChannelSendTool({ router, origin }: CreateChannelSendToolO
         ...(attachments !== undefined ? { attachments } : {}),
       })
 
+      if (!result.ok) {
+        logger.warn(
+          formatChannelToolFailure(
+            'channel_send',
+            `${params.adapter}:${params.workspace}/${params.chat}: ${result.error}`,
+          ),
+        )
+      }
       const details: { ok: boolean; error?: string } = result.ok ? { ok: true } : { ok: false, error: result.error }
       const echo = renderOutboundEcho(bodyText, attachments)
       const baseText = result.ok

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { ChannelRouter } from '@/channels/router'
+import type { FetchAttachmentResult, FetchHistoryResult, OutboundMessage, SendResult } from '@/channels/types'
+
+import { createChannelFetchAttachmentTool } from './channel-fetch-attachment'
+import { createChannelHistoryTool } from './channel-history'
+import type { ChannelToolLogger } from './channel-log'
+import { createChannelReplyTool } from './channel-reply'
+import { createChannelSendTool } from './channel-send'
+
+type CapturedLogger = ChannelToolLogger & { warnings: string[] }
+
+function captureLogger(): CapturedLogger {
+  const warnings: string[] = []
+  return {
+    warnings,
+    warn: (m) => {
+      warnings.push(m)
+    },
+  }
+}
+
+type RouterOverrides = {
+  send?: (msg: OutboundMessage) => Promise<SendResult>
+  fetchHistory?: () => Promise<FetchHistoryResult>
+  fetchAttachment?: () => Promise<FetchAttachmentResult>
+}
+
+function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
+  return {
+    route: async () => {},
+    send: overrides.send ?? (async () => ({ ok: true })),
+    getConsecutiveSendCount: () => 0,
+    registerOutbound: () => {},
+    unregisterOutbound: () => {},
+    registerTyping: () => {},
+    unregisterTyping: () => {},
+    registerChannelNameResolver: () => {},
+    unregisterChannelNameResolver: () => {},
+    registerMembership: () => {},
+    unregisterMembership: () => {},
+    registerHistory: () => {},
+    unregisterHistory: () => {},
+    fetchHistory: overrides.fetchHistory ?? (async () => ({ ok: false, error: 'history-not-supported' })),
+    registerFetchAttachment: () => {},
+    unregisterFetchAttachment: () => {},
+    fetchAttachment: overrides.fetchAttachment ?? (async () => ({ ok: false, error: 'no callback' })),
+    getSelfAliases: () => [],
+    stop: async () => {},
+    liveCount: () => 0,
+  }
+}
+
+const fakeCtx = {} as Parameters<ReturnType<typeof createChannelSendTool>['execute']>[4]
+
+describe('channel_send failure logging', () => {
+  test('logs router.send rejection with adapter+chat context', async () => {
+    const logger = captureLogger()
+    const tool = createChannelSendTool({
+      router: fakeRouter({ send: async () => ({ ok: false, error: 'denied by allow rules' }) }),
+      logger,
+    })
+    await tool.execute(
+      'id',
+      { adapter: 'slack-bot', workspace: 'T0', chat: 'C-blocked', text: 'no' },
+      undefined,
+      undefined,
+      fakeCtx,
+    )
+    expect(logger.warnings).toEqual(['[channels] channel_send failed: slack-bot:T0/C-blocked: denied by allow rules'])
+  })
+
+  test('logs the early validation failure when text and attachments are both missing', async () => {
+    const logger = captureLogger()
+    const tool = createChannelSendTool({ router: fakeRouter(), logger })
+    await tool.execute('id', { adapter: 'discord-bot', workspace: 'g1', chat: 'c1' }, undefined, undefined, fakeCtx)
+    expect(logger.warnings).toEqual(['[channels] channel_send failed: missing text and attachments'])
+  })
+
+  test('logs the NO_REPLY misuse denial before any router.send call', async () => {
+    const logger = captureLogger()
+    const calls: OutboundMessage[] = []
+    const tool = createChannelSendTool({
+      router: fakeRouter({
+        send: async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        },
+      }),
+      logger,
+    })
+    await tool.execute(
+      'id',
+      { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', text: 'NO_REPLY' },
+      undefined,
+      undefined,
+      fakeCtx,
+    )
+    expect(calls).toHaveLength(0)
+    expect(logger.warnings).toHaveLength(1)
+    expect(logger.warnings[0]).toContain('[channels] channel_send failed:')
+    expect(logger.warnings[0]).toContain('silent-turn signal')
+  })
+
+  test('does NOT log on a successful send', async () => {
+    const logger = captureLogger()
+    const tool = createChannelSendTool({ router: fakeRouter({ send: async () => ({ ok: true }) }), logger })
+    await tool.execute(
+      'id',
+      { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', text: 'hi' },
+      undefined,
+      undefined,
+      fakeCtx,
+    )
+    expect(logger.warnings).toEqual([])
+  })
+})
+
+describe('channel_reply failure logging', () => {
+  const origin = { adapter: 'slack-bot' as const, workspace: 'T0', chat: 'C0', thread: '1700000000.0001' }
+
+  test('logs router.send rejection with origin context', async () => {
+    const logger = captureLogger()
+    const tool = createChannelReplyTool({
+      router: fakeRouter({ send: async () => ({ ok: false, error: 'channel_not_found' }) }),
+      origin,
+      logger,
+    })
+    await tool.execute('id', { text: 'hi' }, undefined, undefined, fakeCtx)
+    expect(logger.warnings).toEqual(['[channels] channel_reply failed: slack-bot:T0/C0: channel_not_found'])
+  })
+
+  test('logs early validation when text and attachments are both missing', async () => {
+    const logger = captureLogger()
+    const tool = createChannelReplyTool({ router: fakeRouter(), origin, logger })
+    await tool.execute('id', {}, undefined, undefined, fakeCtx)
+    expect(logger.warnings).toEqual(['[channels] channel_reply failed: missing text and attachments'])
+  })
+
+  test('does NOT log on a successful reply', async () => {
+    const logger = captureLogger()
+    const tool = createChannelReplyTool({ router: fakeRouter({ send: async () => ({ ok: true }) }), origin, logger })
+    await tool.execute('id', { text: 'ok' }, undefined, undefined, fakeCtx)
+    expect(logger.warnings).toEqual([])
+  })
+})
+
+describe('channel_history failure logging', () => {
+  test('logs fetchHistory upstream errors with adapter+chat context', async () => {
+    const logger = captureLogger()
+    const tool = createChannelHistoryTool({
+      router: fakeRouter({ fetchHistory: async () => ({ ok: false, error: 'rate_limited' }) }),
+      origin: { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null },
+      logger,
+    })
+    await tool.execute('id', { scope: 'channel' }, undefined, undefined, fakeCtx)
+    expect(logger.warnings).toEqual(['[channels] channel_history failed: slack-bot:C0: rate_limited'])
+  })
+
+  test('logs the thread-scope-on-channel-root denial without calling fetchHistory', async () => {
+    const logger = captureLogger()
+    let called = false
+    const tool = createChannelHistoryTool({
+      router: fakeRouter({
+        fetchHistory: async () => {
+          called = true
+          return { ok: true, messages: [] }
+        },
+      }),
+      origin: { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null },
+      logger,
+    })
+    await tool.execute('id', { scope: 'thread' }, undefined, undefined, fakeCtx)
+    expect(called).toBe(false)
+    expect(logger.warnings).toEqual(['[channels] channel_history failed: thread-scope-requires-thread-session'])
+  })
+
+  test('does NOT log on a successful fetchHistory', async () => {
+    const logger = captureLogger()
+    const tool = createChannelHistoryTool({
+      router: fakeRouter({ fetchHistory: async () => ({ ok: true, messages: [] }) }),
+      origin: { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null },
+      logger,
+    })
+    await tool.execute('id', { scope: 'channel' }, undefined, undefined, fakeCtx)
+    expect(logger.warnings).toEqual([])
+  })
+})
+
+describe('channel_fetch_attachment failure logging', () => {
+  let inboxDir: string
+
+  beforeEach(async () => {
+    inboxDir = await mkdtemp(join(tmpdir(), 'channel-fetch-log-'))
+  })
+
+  afterEach(async () => {
+    await rm(inboxDir, { recursive: true, force: true })
+  })
+
+  test('logs fetchAttachment upstream errors', async () => {
+    const logger = captureLogger()
+    const tool = createChannelFetchAttachmentTool({
+      router: fakeRouter({ fetchAttachment: async () => ({ ok: false, error: 'file_not_found' }) }),
+      origin: { adapter: 'slack-bot' },
+      inboxDir,
+      logger,
+    })
+    await tool.execute('id', { ref: 'Fxxx' }, undefined, undefined, fakeCtx)
+    expect(logger.warnings).toEqual(['[channels] channel_fetch_attachment failed: slack-bot: file_not_found'])
+  })
+
+  test('logs local write failures separately from upstream errors', async () => {
+    const logger = captureLogger()
+    const tool = createChannelFetchAttachmentTool({
+      router: fakeRouter({
+        fetchAttachment: async () => ({
+          ok: true,
+          filename: 'note.txt',
+          buffer: Buffer.from([1, 2, 3]),
+          size: 3,
+          mimetype: 'text/plain',
+        }),
+      }),
+      origin: { adapter: 'slack-bot' },
+      // Pointing at a path that exists as a FILE forces mkdir(recursive) to throw ENOTDIR.
+      // This exercises the write-failure branch without mocking node:fs.
+      inboxDir: '/dev/null/not-a-dir',
+      logger,
+    })
+    await tool.execute('id', { ref: 'Fxxx' }, undefined, undefined, fakeCtx)
+    expect(logger.warnings).toHaveLength(1)
+    expect(logger.warnings[0]).toContain('[channels] channel_fetch_attachment failed:')
+    expect(logger.warnings[0]).toContain('write failed:')
+  })
+
+  test('does NOT log on a successful fetch+write', async () => {
+    const logger = captureLogger()
+    const tool = createChannelFetchAttachmentTool({
+      router: fakeRouter({
+        fetchAttachment: async () => ({
+          ok: true,
+          filename: 'note.txt',
+          buffer: Buffer.from([1, 2, 3]),
+          size: 3,
+          mimetype: 'text/plain',
+        }),
+      }),
+      origin: { adapter: 'slack-bot' },
+      inboxDir,
+      logger,
+    })
+    await tool.execute('id', { ref: 'Fxxx' }, undefined, undefined, fakeCtx)
+    expect(logger.warnings).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

The four `channel_*` agent tools (`channel_send`, `channel_reply`, `channel_history`, `channel_fetch_attachment`) swallowed every failure into the model-visible tool result and emitted nothing to the container's `stdout`/`stderr`. Operators using `typeclaw logs` had no visibility into Slack 403s, Discord CDN expirations, thread-scope-on-channel-root denials, `NO_REPLY` misuse, or local write failures. This PR closes that observability gap by wiring a structured logger through all four tools.

## Changes

### `src/agent/tools/channel-log.ts` (new, 30 lines)

Exposes three things: the `ChannelToolLogger` type (a single `warn(msg: string)` surface), `consoleChannelLogger` (default — calls `console.warn`), and `formatChannelToolFailure(tool, error)` for consistent message shaping. Keeping this minimal means callers can substitute a capturing logger in tests without mocking `console`.

### `src/agent/tools/channel-send.ts` / `channel-reply.ts` / `channel-history.ts` / `channel-fetch-attachment.ts`

Each factory gains an optional `logger?: ChannelToolLogger` parameter defaulting to `consoleChannelLogger`. Every failure branch now calls `logger.warn(...)`:

- **Pre-router validation**: missing text/attachments, `NO_REPLY` misuse, thread-scope-on-channel-root denials.
- **Router rejections**: `router.send`, `router.fetchHistory`, `router.fetchAttachment` errors.
- **Local filesystem failures**: `mkdir` / `writeFile` errors on attachment inbox writes.

Log lines use the `[channels]` prefix — same as `src/channels/manager.ts` and `src/channels/router.ts` — so `grep '\[channels\]'` in `typeclaw logs` surfaces the full stack of channel-related warnings in a single pass. Format: `[channels] <tool_name> failed: <error context>`, with `adapter:workspace/chat` included where available.

### `src/agent/tools/channel-tool-logging.test.ts` (new, 260 lines)

Exercises each tool's failure paths with a capturing `ChannelToolLogger` and asserts no `warn` calls on success paths. Uses real filesystem fixtures (`mkdtemp` + `rm` in `beforeEach`/`afterEach`) per AGENTS.md §5. The write-failure test uses `/dev/null/not-a-dir` as `inboxDir` to force a real `ENOTDIR` from `mkdir({ recursive: true })` without mocking `node:fs`.

## Design decisions

**Tool layer, not router layer.** Some failure modes never reach the router (early validation, `NO_REPLY` misuse, thread-scope-mismatch), and the tool layer has richer context (tool name + parameters) than `router.send`. The router's existing `RouterLogger` is unchanged.

**Injectable logger, `consoleChannelLogger` default.** The four existing test files (`channel-send.test.ts`, etc.) don't pass a logger; their failure-path tests now emit `[channels]` lines to stdout during `bun test`. This is intentional — it proves the default plumbing works in real callers. All existing tests continue to pass unchanged.

**`[channels]` prefix shared with manager and router.** Operators already know to `grep '\[channels\]'` for channel-adapter noise. Tool-level failures landing under the same prefix means one filter shows the complete picture, from adapter initialization through send execution through tool invocation.

## Verification

```
bun run typecheck  → clean
bun run lint       → clean
bun run format     → clean
bun test           → 2851 pass, 0 fail
```