### PR TITLE
Add tool-result-cap bundled plugin to bound oversized tool outputs

### DIFF
--- a/src/bundled-plugins/tool-result-cap/README.md
+++ b/src/bundled-plugins/tool-result-cap/README.md
@@ -1,0 +1,67 @@
+# typeclaw-plugin-tool-result-cap
+
+The bundled tool-result-cap plugin. Caps the size of `tool.after` results before they get persisted to the session JSONL, so a single oversized tool output cannot bloat the transcript and force the full payload to round-trip to the LLM on every subsequent turn.
+
+This plugin is **auto-loaded** by every TypeClaw agent. There is no `plugins[]` entry to add and no opt-out short of `tool-result-cap.enabled: false`. To configure it, add a `tool-result-cap` block to `typeclaw.json`.
+
+## Why it exists
+
+`pi-coding-agent`'s built-in tools occasionally return very large payloads that the model only needed once. Two empirically observed cases:
+
+1. **`read` on an image file** returns the base64-encoded image inline (e.g. `{type:"image", data:"<3.2MB of base64>"}`). The model uses it on the turn it was asked for, then sees the same 3.2MB of base64 as conversation context on every subsequent prompt — until compaction fires (which is token-driven, not byte-driven, so a single fat blob may sit in context for many turns before compaction is triggered).
+2. **`webfetch` on a binary URL** (PNG, ZIP, etc.) receives the raw response body, treats it as text, and stores raw binary as a JSON-encoded string. Same effect: 100KB+ of mojibake sits in the transcript permanently.
+
+The result is a session JSONL file that's tens of megabytes on disk but mostly one or two giant tool results, plus 3-minute first-prompt latencies after container restart because the full transcript gets re-shipped to the LLM as context.
+
+`tool-result-cap` registers a `tool.after` hook that inspects every tool's result and, in place, replaces oversized image/text parts with a short placeholder before pi-coding-agent appends the entry to the JSONL. The cap happens at the wire-format level, so the bloat never reaches disk or the LLM in the first place.
+
+## Config
+
+```json
+{
+  "tool-result-cap": {
+    "enabled": true,
+    "imageMaxBytes": 262144,
+    "textMaxBytes": 65536,
+    "exemptTools": []
+  }
+}
+```
+
+| Field                           | Default  | Effect                                                                                                                                                                                                                                                                                   |
+| ------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tool-result-cap.enabled`       | `true`   | Master switch. When `false`, the plugin returns no hooks at all and tool results pass through untouched.                                                                                                                                                                                 |
+| `tool-result-cap.imageMaxBytes` | `262144` | Maximum size (in bytes of the base64 string, not the decoded binary) for any `{type:"image"}` part in a tool result. Parts above this are replaced with a short text placeholder naming the original mime type and size. Default is ~256KB of base64 ≈ ~190KB of binary. Minimum `1024`. |
+| `tool-result-cap.textMaxBytes`  | `65536`  | Maximum length (in characters) for any `{type:"text"}` part. Parts above this are truncated: the first `textMaxBytes` characters are kept (so the LLM sees the shape of the output), and an elision marker is appended naming the byte count dropped. Minimum `1024`.                    |
+| `tool-result-cap.exemptTools`   | `[]`     | List of tool names to skip entirely. Use when a specific tool genuinely needs to return large payloads and you can absorb the per-turn cost.                                                                                                                                             |
+
+All fields are **restart-required** — the plugin reads them once at boot.
+
+## How it works
+
+The plugin registers a single `tool.after` hook. The hook receives `event.result: ToolResult` by reference, walks `result.content`, and replaces each `ContentPart` in place when it exceeds its corresponding threshold. Mutation order is unspecified across plugins, but because the wrapper in `src/agent/plugin-tools.ts` reads the same `hookResult.content` reference after the hook chain finishes, mutations are seen by pi-coding-agent and persisted to JSONL.
+
+The cap is per-part, not per-result, so a result with one small text part and one giant image is partly preserved (small text untouched, image elided).
+
+Placeholders carry the literal substring `tool-result-cap:` so future agents (or human operators inspecting a session) can grep for them and recognize that the original payload was intentionally elided rather than truncated by some other layer.
+
+## What's not capped
+
+- `details` on tool results (an opaque structured payload provider-specific to each tool — generally small, and mutating it risks breaking tool-specific telemetry).
+- Tool calls themselves (`assistant` messages with `toolUse` content). These are bounded by the LLM's own output limits.
+- User messages and system prompts.
+
+## Ordering against other bundled plugins
+
+Plugin hook order is the order plugins are listed in `src/run/bundled-plugins.ts`. `tool-result-cap` is registered **before** `guard` so guard's `tool.after` advice (the uncommitted-changes warning) appends to the already-capped content. This means a guard advice that fires on the same call sees a small text part and a placeholder, never the original oversized payload — keeping the advice text immediately legible in the JSONL.
+
+## What it contributes
+
+| Kind | Name         | Notes                                                                                                                                  |
+| ---- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Hook | `tool.after` | Walks `event.result.content` and replaces oversized image/text parts in place. Logs one `info` line per capped call, silent otherwise. |
+
+## Tests
+
+- `cap-result.test.ts` — pure-function unit tests for the capping logic (image replacement, text truncation, mixed parts, exempt tools, empty results, in-place mutation invariant).
+- `index.test.ts` — composition tests (config schema defaults and validation, hook registration, disabled-mode short-circuit, logging on cap, silence on no-op).

--- a/src/bundled-plugins/tool-result-cap/cap-result.test.ts
+++ b/src/bundled-plugins/tool-result-cap/cap-result.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { ToolResult } from '@/plugin'
+
+import { capToolResult } from './cap-result'
+
+const baseOptions = {
+  imageMaxBytes: 100,
+  textMaxBytes: 50,
+  exemptTools: new Set<string>(),
+}
+
+describe('capToolResult', () => {
+  test('replaces an oversized image with a text placeholder', () => {
+    const result: ToolResult = {
+      content: [
+        { type: 'text', text: 'Read image file [image/png]' },
+        { type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) },
+      ],
+    }
+
+    const stats = capToolResult('read', result, baseOptions)
+
+    expect(stats.imagesReplaced).toBe(1)
+    expect(stats.textsTruncated).toBe(0)
+    expect(stats.bytesElided).toBe(500)
+    expect(result.content).toHaveLength(2)
+    expect(result.content[0]).toEqual({ type: 'text', text: 'Read image file [image/png]' })
+    expect(result.content[1]?.type).toBe('text')
+    const replacement = result.content[1] as { type: 'text'; text: string }
+    expect(replacement.text).toContain('tool-result-cap')
+    expect(replacement.text).toContain('image/png')
+    expect(replacement.text).toContain('500')
+  })
+
+  test('leaves images at or below the threshold untouched', () => {
+    const result: ToolResult = {
+      content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(100) }],
+    }
+
+    const stats = capToolResult('read', result, baseOptions)
+
+    expect(stats.imagesReplaced).toBe(0)
+    expect(result.content[0]).toEqual({ type: 'image', mimeType: 'image/png', data: 'A'.repeat(100) })
+  })
+
+  test('truncates oversized text and appends an elision marker', () => {
+    const result: ToolResult = {
+      content: [{ type: 'text', text: 'A'.repeat(200) }],
+    }
+
+    const stats = capToolResult('webfetch', result, baseOptions)
+
+    expect(stats.imagesReplaced).toBe(0)
+    expect(stats.textsTruncated).toBe(1)
+    expect(stats.bytesElided).toBe(150)
+    const part = result.content[0] as { type: 'text'; text: string }
+    expect(part.text.startsWith('A'.repeat(50))).toBe(true)
+    expect(part.text).toContain('tool-result-cap')
+    expect(part.text).toContain('150')
+    expect(part.text).toContain('textMaxBytes=50')
+  })
+
+  test('leaves text at or below the threshold untouched', () => {
+    const result: ToolResult = {
+      content: [{ type: 'text', text: 'A'.repeat(50) }],
+    }
+
+    const stats = capToolResult('webfetch', result, baseOptions)
+
+    expect(stats.textsTruncated).toBe(0)
+    expect(result.content[0]).toEqual({ type: 'text', text: 'A'.repeat(50) })
+  })
+
+  test('caps each part independently when the result mixes media types', () => {
+    const result: ToolResult = {
+      content: [
+        { type: 'text', text: 'short ok' },
+        { type: 'text', text: 'A'.repeat(200) },
+        { type: 'image', mimeType: 'image/jpeg', data: 'B'.repeat(50) },
+        { type: 'image', mimeType: 'image/png', data: 'C'.repeat(500) },
+      ],
+    }
+
+    const stats = capToolResult('read', result, baseOptions)
+
+    expect(stats.textsTruncated).toBe(1)
+    expect(stats.imagesReplaced).toBe(1)
+    expect(stats.bytesElided).toBe(150 + 500)
+    expect((result.content[0] as { text: string }).text).toBe('short ok')
+    expect((result.content[1] as { text: string }).text).toContain('tool-result-cap')
+    expect(result.content[2]).toEqual({ type: 'image', mimeType: 'image/jpeg', data: 'B'.repeat(50) })
+    expect((result.content[3] as { text: string }).text).toContain('tool-result-cap')
+  })
+
+  test('skips capping when the tool is exempt', () => {
+    const result: ToolResult = {
+      content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) }],
+    }
+
+    const stats = capToolResult('read', result, {
+      ...baseOptions,
+      exemptTools: new Set(['read']),
+    })
+
+    expect(stats.imagesReplaced).toBe(0)
+    expect(stats.bytesElided).toBe(0)
+    expect(result.content[0]).toEqual({ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) })
+  })
+
+  test('mutates the original content array in place', () => {
+    const originalContent: ToolResult['content'] = [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) }]
+    const result: ToolResult = { content: originalContent }
+
+    capToolResult('read', result, baseOptions)
+
+    expect(result.content).toBe(originalContent)
+    expect(originalContent[0]?.type).toBe('text')
+  })
+
+  test('returns zero stats for an empty result', () => {
+    const result: ToolResult = { content: [] }
+
+    const stats = capToolResult('read', result, baseOptions)
+
+    expect(stats).toEqual({ imagesReplaced: 0, textsTruncated: 0, bytesElided: 0 })
+  })
+})

--- a/src/bundled-plugins/tool-result-cap/cap-result.ts
+++ b/src/bundled-plugins/tool-result-cap/cap-result.ts
@@ -1,0 +1,56 @@
+import type { ContentPart, ToolResult } from '@/plugin'
+
+export type CapOptions = {
+  imageMaxBytes: number
+  textMaxBytes: number
+  exemptTools: ReadonlySet<string>
+}
+
+export type CapStats = {
+  imagesReplaced: number
+  textsTruncated: number
+  bytesElided: number
+}
+
+// Sentinel marker used in both image and text replacement payloads so a future
+// pass (or the LLM itself) can recognize that a value was capped rather than
+// truthfully short. Plain English on purpose — these strings get fed to the
+// model on every turn, and unfamiliar tokens cost reasoning bandwidth.
+const ELIDED_MARKER = '[tool-result-cap: '
+
+export function capToolResult(tool: string, result: ToolResult, options: CapOptions): CapStats {
+  const stats: CapStats = { imagesReplaced: 0, textsTruncated: 0, bytesElided: 0 }
+  if (options.exemptTools.has(tool)) return stats
+
+  for (let i = 0; i < result.content.length; i++) {
+    const part = result.content[i]
+    if (!part) continue
+    if (part.type === 'image') {
+      const size = part.data.length
+      if (size <= options.imageMaxBytes) continue
+      result.content[i] = {
+        type: 'text',
+        text: `${ELIDED_MARKER}image ${part.mimeType} elided, ${size} bytes of base64 exceeded imageMaxBytes=${options.imageMaxBytes}]`,
+      }
+      stats.imagesReplaced += 1
+      stats.bytesElided += size
+      continue
+    }
+    if (part.type === 'text') {
+      const size = part.text.length
+      if (size <= options.textMaxBytes) continue
+      // Keep a head slice of the original text so the LLM still has a hint of
+      // shape (e.g. "fetched HTML starts with <!DOCTYPE..."). Tail is dropped.
+      const head = part.text.slice(0, options.textMaxBytes)
+      const elided = size - options.textMaxBytes
+      const replacement: ContentPart = {
+        type: 'text',
+        text: `${head}\n\n${ELIDED_MARKER}${elided} bytes truncated from text part; original was ${size} bytes, textMaxBytes=${options.textMaxBytes}]`,
+      }
+      result.content[i] = replacement
+      stats.textsTruncated += 1
+      stats.bytesElided += elided
+    }
+  }
+  return stats
+}

--- a/src/bundled-plugins/tool-result-cap/index.test.ts
+++ b/src/bundled-plugins/tool-result-cap/index.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { PluginContext, PluginExports, ToolAfterEvent } from '@/plugin'
+
+import toolResultCapPlugin from './index'
+
+function makeCtx(overrides: { config: unknown }): {
+  ctx: PluginContext<any>
+  logs: string[]
+} {
+  const logs: string[] = []
+  const ctx: PluginContext<any> = {
+    name: 'tool-result-cap',
+    version: undefined,
+    agentDir: '/agent',
+    config: overrides.config,
+    logger: {
+      info: (m) => logs.push(`info:${m}`),
+      warn: (m) => logs.push(`warn:${m}`),
+      error: (m) => logs.push(`error:${m}`),
+    },
+    spawnSubagent: async () => {},
+  }
+  return { ctx, logs }
+}
+
+async function loadPlugin(ctx: PluginContext<any>): Promise<PluginExports> {
+  return toolResultCapPlugin.plugin(ctx)
+}
+
+function hookCtx(pluginName = 'tool-result-cap') {
+  return {
+    agentDir: '/agent',
+    pluginName,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  }
+}
+
+function defaultEvent(overrides: Partial<ToolAfterEvent>): ToolAfterEvent {
+  return {
+    tool: 'read',
+    sessionId: 'sess-1',
+    callId: 'call-1',
+    result: { content: [{ type: 'text', text: 'ok' }] },
+    ...overrides,
+  }
+}
+
+describe('tool-result-cap plugin', () => {
+  test('config schema validates with all defaults when no block is provided', () => {
+    const parsed = toolResultCapPlugin.configSchema?.parse(undefined)
+    expect(parsed).toEqual({
+      enabled: true,
+      imageMaxBytes: 262_144,
+      textMaxBytes: 65_536,
+      exemptTools: [],
+    })
+  })
+
+  test('rejects imageMaxBytes below 1024', () => {
+    expect(() => toolResultCapPlugin.configSchema?.parse({ imageMaxBytes: 100 })).toThrow()
+  })
+
+  test('rejects textMaxBytes below 1024', () => {
+    expect(() => toolResultCapPlugin.configSchema?.parse({ textMaxBytes: 100 })).toThrow()
+  })
+
+  test('registers exactly the tool.after hook by default', async () => {
+    const config = toolResultCapPlugin.configSchema?.parse(undefined)
+    const { ctx } = makeCtx({ config })
+    const exports = await loadPlugin(ctx)
+    expect(Object.keys(exports.hooks ?? {})).toEqual(['tool.after'])
+  })
+
+  test('returns empty exports when disabled', async () => {
+    const config = toolResultCapPlugin.configSchema?.parse({ enabled: false })
+    const { ctx } = makeCtx({ config })
+    const exports = await loadPlugin(ctx)
+    expect(exports).toEqual({})
+  })
+
+  test('mutates oversized image results in-place', async () => {
+    const config = toolResultCapPlugin.configSchema?.parse({ imageMaxBytes: 1024, textMaxBytes: 1024 })
+    const { ctx } = makeCtx({ config })
+    const exports = await loadPlugin(ctx)
+    const hook = exports.hooks?.['tool.after']
+    if (!hook) throw new Error('tool.after hook missing')
+
+    const event = defaultEvent({
+      result: { content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(5000) }] },
+    })
+
+    await hook(event, hookCtx())
+
+    expect(event.result.content[0]?.type).toBe('text')
+    expect((event.result.content[0] as { text: string }).text).toContain('tool-result-cap')
+  })
+
+  test('logs a summary line on every capped tool call', async () => {
+    const config = toolResultCapPlugin.configSchema?.parse({ imageMaxBytes: 1024, textMaxBytes: 1024 })
+    const { ctx, logs } = makeCtx({ config })
+    const exports = await loadPlugin(ctx)
+    const hook = exports.hooks?.['tool.after']
+    if (!hook) throw new Error('tool.after hook missing')
+
+    await hook(
+      defaultEvent({
+        result: { content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(5000) }] },
+      }),
+      hookCtx(),
+    )
+
+    const info = logs.find((l) => l.startsWith('info:[tool-result-cap]'))
+    expect(info).toContain('imagesReplaced=1')
+    expect(info).toContain('bytesElided=5000')
+  })
+
+  test('stays silent when nothing exceeds the thresholds', async () => {
+    const config = toolResultCapPlugin.configSchema?.parse(undefined)
+    const { ctx, logs } = makeCtx({ config })
+    const exports = await loadPlugin(ctx)
+    const hook = exports.hooks?.['tool.after']
+    if (!hook) throw new Error('tool.after hook missing')
+
+    await hook(defaultEvent({ result: { content: [{ type: 'text', text: 'short' }] } }), hookCtx())
+
+    expect(logs).toEqual([])
+  })
+
+  test('skips tools listed in exemptTools', async () => {
+    const config = toolResultCapPlugin.configSchema?.parse({
+      imageMaxBytes: 1024,
+      textMaxBytes: 1024,
+      exemptTools: ['read'],
+    })
+    const { ctx, logs } = makeCtx({ config })
+    const exports = await loadPlugin(ctx)
+    const hook = exports.hooks?.['tool.after']
+    if (!hook) throw new Error('tool.after hook missing')
+
+    const event = defaultEvent({
+      tool: 'read',
+      result: { content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(5000) }] },
+    })
+
+    await hook(event, hookCtx())
+
+    expect(event.result.content[0]).toEqual({ type: 'image', mimeType: 'image/png', data: 'A'.repeat(5000) })
+    expect(logs).toEqual([])
+  })
+})

--- a/src/bundled-plugins/tool-result-cap/index.ts
+++ b/src/bundled-plugins/tool-result-cap/index.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod'
+
+import { definePlugin } from '@/plugin'
+
+import { capToolResult } from './cap-result'
+
+const DEFAULT_IMAGE_MAX_BYTES = 262_144
+const DEFAULT_TEXT_MAX_BYTES = 65_536
+const MIN_IMAGE_MAX_BYTES = 1_024
+const MIN_TEXT_MAX_BYTES = 1_024
+
+const toolResultCapConfigSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+    imageMaxBytes: z.number().int().min(MIN_IMAGE_MAX_BYTES).default(DEFAULT_IMAGE_MAX_BYTES),
+    textMaxBytes: z.number().int().min(MIN_TEXT_MAX_BYTES).default(DEFAULT_TEXT_MAX_BYTES),
+    exemptTools: z.array(z.string()).default([]),
+  })
+  .default({
+    enabled: true,
+    imageMaxBytes: DEFAULT_IMAGE_MAX_BYTES,
+    textMaxBytes: DEFAULT_TEXT_MAX_BYTES,
+    exemptTools: [],
+  })
+
+export default definePlugin({
+  configSchema: toolResultCapConfigSchema,
+  plugin: async (ctx) => {
+    const { enabled, imageMaxBytes, textMaxBytes, exemptTools } = ctx.config
+    if (!enabled) return {}
+
+    const options = {
+      imageMaxBytes,
+      textMaxBytes,
+      exemptTools: new Set(exemptTools),
+    }
+
+    return {
+      hooks: {
+        'tool.after': (event) => {
+          const stats = capToolResult(event.tool, event.result, options)
+          if (stats.imagesReplaced > 0 || stats.textsTruncated > 0) {
+            ctx.logger.info(
+              `[tool-result-cap] capped ${event.tool} call=${event.callId}: imagesReplaced=${stats.imagesReplaced} textsTruncated=${stats.textsTruncated} bytesElided=${stats.bytesElided}`,
+            )
+          }
+        },
+      },
+    }
+  },
+})

--- a/src/run/bundled-plugins.test.ts
+++ b/src/run/bundled-plugins.test.ts
@@ -3,13 +3,23 @@ import { describe, expect, test } from 'bun:test'
 import { BUNDLED_PLUGINS } from './bundled-plugins'
 
 describe('BUNDLED_PLUGINS', () => {
-  test('contains exactly the five expected plugins in hook-precedence order', () => {
+  test('contains exactly the six expected plugins in hook-precedence order', () => {
     // Order is load-bearing: `security` must run before `guard` so its
-    // `tool.before` hook gets first refusal on overlapping policy. `memory`
-    // must run before `backup` because dreaming commits memory snapshots
-    // and any future overlap on git lock contention should be resolved in
-    // memory's favor (memory commits are smaller and more frequent). See the
-    // header comment in bundled-plugins.ts.
-    expect(BUNDLED_PLUGINS.map((p) => p.name)).toEqual(['security', 'guard', 'memory', 'backup', 'agent-browser'])
+    // `tool.before` hook gets first refusal on overlapping policy.
+    // `tool-result-cap` must run before `guard` so guard's `tool.after`
+    // advice appends to already-capped content (reversing the order would
+    // make the cap clobber guard's advice text). `memory` must run before
+    // `backup` because dreaming commits memory snapshots and any future
+    // overlap on git lock contention should be resolved in memory's favor
+    // (memory commits are smaller and more frequent). See the header
+    // comment in bundled-plugins.ts.
+    expect(BUNDLED_PLUGINS.map((p) => p.name)).toEqual([
+      'security',
+      'tool-result-cap',
+      'guard',
+      'memory',
+      'backup',
+      'agent-browser',
+    ])
   })
 })

--- a/src/run/bundled-plugins.ts
+++ b/src/run/bundled-plugins.ts
@@ -3,6 +3,7 @@ import backupPlugin from '@/bundled-plugins/backup'
 import guardPlugin from '@/bundled-plugins/guard'
 import memoryPlugin from '@/bundled-plugins/memory'
 import securityPlugin from '@/bundled-plugins/security'
+import toolResultCapPlugin from '@/bundled-plugins/tool-result-cap'
 import type { ResolvedPlugin } from '@/plugin'
 
 // Consumed by both `startAgent` (auto-loaded before user plugins) AND
@@ -18,6 +19,11 @@ import type { ResolvedPlugin } from '@/plugin'
 // guard disjoint surfaces, but seeding the order now means future overlap
 // (e.g. a security policy on writes) blocks before guard's softer advice.
 //
+// `tool-result-cap` is registered before `guard` so guard's `tool.after`
+// advice (uncommitted-changes warning) appends to already-capped content.
+// Reversing this order would make guard advise on the full oversized payload
+// and then tool-result-cap would clobber the advice text along with the rest.
+//
 // `memory` is registered before `backup` so memory's dreaming commits always
 // land in the same git index window before backup's commit-and-push cycle.
 // They commit disjoint paths today (memory/ vs sessions/ + agent changes),
@@ -25,6 +31,7 @@ import type { ResolvedPlugin } from '@/plugin'
 // contention easier to reason about.
 export const BUNDLED_PLUGINS: ResolvedPlugin[] = [
   { name: 'security', version: undefined, source: '<bundled>', defined: securityPlugin },
+  { name: 'tool-result-cap', version: undefined, source: '<bundled>', defined: toolResultCapPlugin },
   { name: 'guard', version: undefined, source: '<bundled>', defined: guardPlugin },
   { name: 'memory', version: undefined, source: '<bundled>', defined: memoryPlugin },
   { name: 'backup', version: undefined, source: '<bundled>', defined: backupPlugin },


### PR DESCRIPTION
## Why

While debugging a 3-minute first-response latency on a kakao channel agent after `typeclaw restart`, I tracked the cause to a single 3.2MB `toolResult` entry in the session JSONL: the agent had called `read` on an iPhone photo and the upstream `pi-coding-agent` `read` tool returned the full PNG as base64 inline (`[{type:'text',...},{type:'image',data:'<3.2MB>',mimeType}]`).

Once that entry was persisted to JSONL, `buildSessionContext()` re-shipped it as conversation context on every subsequent prompt. Fireworks reported `cacheRead: 73984` per turn, so ~75K tokens of the 256K context window were permanently occupied by that one image.

The same shape applies to `webfetch` on a binary URL (PNG bytes JSON-encoded as text, ~138KB per call), and to any future tool that produces large opaque outputs.

`pi-coding-agent`'s auto-compaction is token-driven, not byte-driven. A single fat blob can sit at ~75K tokens — below the 80% trigger on a 256K window — for the entire session lifetime. Compaction never fires; the bloat never goes away.

## What

A new bundled plugin `tool-result-cap` (auto-loaded, no opt-in required) that registers a single `tool.after` hook and rewrites oversized `ContentPart`s in place before pi-coding-agent appends the result to the JSONL:

- **Images** with base64 payload > `imageMaxBytes` (default 262144 = 256KB ≈ ~190KB binary) become a short text placeholder naming the original mime type and size.
- **Text** parts longer than `textMaxBytes` (default 65536 = 64KB) are truncated: the head slice is kept (so the LLM still sees output shape) and an elision marker is appended.
- Placeholder strings contain the literal `tool-result-cap:` so they're greppable by humans and recognizable by future agents.

The cap happens at the wire-format level via in-place mutation of `event.result.content`. There is existing precedent for this pattern in `src/bundled-plugins/guard/policies/uncommitted-changes.ts` (the `appendAdviceToContent` helper).

## Config

```json
{
  "tool-result-cap": {
    "enabled": true,
    "imageMaxBytes": 262144,
    "textMaxBytes": 65536,
    "exemptTools": []
  }
}
```

All fields restart-required (plugin reads them once at boot). Sensible defaults; `exemptTools` is the escape hatch for tools that genuinely need to return large payloads.

## Ordering

Registered **before** `guard` in `BUNDLED_PLUGINS` so guard's `tool.after` uncommitted-changes advice appends to already-capped content. Reversing the order would make the cap clobber guard's advice text. The composition test in `bundled-plugins.test.ts` is updated to assert the new six-plugin order and the comment documents the invariant.

## Limits

- This is a **forward-only** fix. Existing oversized entries already in JSONL files stay there; only new tool results get capped. Retroactive cleanup of a contaminated session JSONL is a separate operation (manual surgery or a one-shot script).
- Token math: the per-turn savings depend on the per-call payload size. For the kakao case (3.2MB base64 → ~256KB cap), that's ~80% of the wire bytes for that entry and a similar fraction of the tokens.
- The plugin does not touch `details` (an opaque tool-specific structured field), tool calls themselves, or non-tool messages.

## Tests

- `cap-result.test.ts` — pure-function tests for the cap logic: image replacement, text truncation, mixed parts, exempt tools, empty results, in-place mutation invariant.
- `index.test.ts` — composition tests: config schema defaults/validation, hook registration, disabled-mode short-circuit, logging on cap, silence on no-op.
- Updated `src/run/bundled-plugins.test.ts` to assert the new plugin lands in the correct position relative to `guard`.

Full suite: 2874 pass, 0 fail. Typecheck, lint, format all clean.

## Follow-ups (separate PRs)

- Compaction threshold tune (`COMPACTION_TRIGGER_PERCENT`) — independent safety net for the case where many normal turns accumulate. Coming in a separate PR because the failure modes are different (this PR fixes single-fat-blob; compaction fixes gradual accumulation).
- Retroactive cleanup helper for existing bloated JSONLs — not in scope here.