### PR TITLE
Lower COMPACTION_TRIGGER_PERCENT from 0.8 to 0.7

### DIFF
--- a/src/agent/compaction.test.ts
+++ b/src/agent/compaction.test.ts
@@ -35,7 +35,7 @@ describe('reserveTokensForModel', () => {
 
     // then
     expect(reserve).toBe(Math.round(window * (1 - COMPACTION_TRIGGER_PERCENT)))
-    expect(reserve).toBe(51_200)
+    expect(reserve).toBe(76_800)
   })
 
   test('scales with the model context window so trigger fraction stays constant', () => {

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -11,7 +11,21 @@ import { SettingsManager } from '@mariozechner/pi-coding-agent'
 // that's ~6% headroom (94% trigger), at 1M it's ~1.6% (98% trigger). A
 // percentage-derived reserve trips at the same fraction regardless of
 // model, which is what we actually want.
-export const COMPACTION_TRIGGER_PERCENT = 0.8
+//
+// 0.7 (was 0.8) lowers the trigger from 80% to 70% of the window. The
+// previous 80% setting waited until very close to context exhaustion before
+// compacting, which meant a long-lived channel session that gradually
+// accumulated many normal turns would spend a meaningful chunk of its life
+// shipping a near-maximum context to the LLM on every prompt. Empirically:
+// a kakao session that had only ~75K tokens (29% of 256K) but 3.5MB on disk
+// — bloated by one oversized tool result — could not be helped by
+// compaction because the token threshold wasn't reached. That specific
+// shape is handled by the tool-result-cap plugin. This change addresses
+// the orthogonal "many normal turns" case: at 70% we compact 10 percentage
+// points earlier, freeing context bandwidth for the upcoming turn's
+// thinking + tool calls without sacrificing recent history (which is still
+// preserved verbatim per COMPACTION_KEEP_RECENT_TOKENS).
+export const COMPACTION_TRIGGER_PERCENT = 0.7
 
 // Tokens to keep in the recent window after compaction. Fixed (not a
 // percentage) because "recent context" is a property of conversation


### PR DESCRIPTION
## Why

While diagnosing a slow-first-prompt on a kakao channel agent, I noticed two distinct failure modes for transcript bloat:

1. **One oversized tool result** (e.g. `read` returning a 3.2MB base64 image inline) — structural fix handled by the `tool-result-cap` bundled plugin in #159.
2. **Gradual accumulation** of many normal turns into a long context — this PR.

`pi-coding-agent`'s auto-compaction fires when `contextTokens > contextWindow - reserveTokens`. TypeClaw derives `reserveTokens` from `model.contextWindow * (1 - COMPACTION_TRIGGER_PERCENT)`, so the constant is the trigger fraction.

At `0.8` (the previous value), a long-lived channel session running on a 256K model compacts only after crossing ~204K tokens. That's late — for most of the session's life, the LLM call is processing a near-maximum context, even though most of that context is no longer relevant to the current turn. The cost is per-turn latency and provider spend that scale with how close we sit to the edge.

## What

Lower the trigger from 80% to 70%. On a 256K model:

| Setting | Trigger threshold (tokens) | Reserve (tokens) |
|---|---|---|
| Before (0.8) | 204,800 | 51,200 |
| After (0.7) | 179,200 | 76,800 |

`keepRecentTokens` stays at 20,000 — that's a property of conversation shape, not capacity, so it doesn't move with the trigger. After compaction, the model still sees a summary + the most recent ~20K tokens verbatim, regardless of whether the session was 200K or 1M before.

The math automatically applies per-model:
- 200K Claude: trigger at 140K (was 160K)
- 256K Kimi: trigger at 179K (was 205K)
- 1M Gemini: trigger at 700K (was 800K)

## What this is NOT

This change does **not** help sessions where a single tool result has bloated the JSONL while the token count stays low. That shape requires structural intervention at the wire-format level, which is what the `tool-result-cap` plugin (#159) addresses. Compaction is token-driven; if the token count never crosses the threshold, compaction never fires.

The kakao session that motivated this work was at ~75K tokens (29% of 256K) but 3.5MB on disk — entirely because of one oversized `read` tool result. Lowering the trigger to any value below 100% would not have helped that case; only the cap plugin can.

This PR is the safety net for the orthogonal case: an agent that has been answering normal turns for weeks, slowly accumulating useful context, and would benefit from compacting a little earlier so the LLM has more thinking headroom on each turn.

## Tests

- `compaction.test.ts` already computes most assertions from `COMPACTION_TRIGGER_PERCENT` dynamically — those scale-invariant tests need no change.
- Updated the one hard-coded assertion (`expect(reserve).toBe(51_200)` → `76_800`) to match the new value on the canonical 256K case.

Full suite: 2857 pass, 0 fail. Typecheck, lint, format all clean.

## Tradeoffs

The honest argument *against* this change is "less context for the LLM on the post-compaction turn". I think that's fine because:

- `keepRecentTokens` is unchanged, so the LLM still sees the same amount of recent verbatim conversation.
- The pre-compaction summary is an LLM-generated abstract of what was lost, which is usually denser than the raw history.
- Most of the lost density is old tool calls and intermediate scratch work that has no bearing on the current turn anyway.

If 0.7 turns out to be too aggressive in practice, the path to revert is a single-character edit; the magic number is documented in the file comment so any future "why this value" question is answered without a `git blame` round trip.