### PR TITLE
Move KakaoTalk credentials to secrets.json as single source of truth

### DIFF
--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -11,6 +11,7 @@ import {
   type KakaoTalkPushEmoticonEvent,
   type KakaoTalkPushMessageEvent,
 } from 'agent-messenger/kakaotalk'
+import type { KakaoAccountCredentials, KakaoConfig, PendingLoginState } from 'agent-messenger/kakaotalk'
 
 import type { ChannelRouter } from '@/channels/router'
 import { isAllowed, type ChannelAdapterConfig, type KakaotalkAdapterConfig } from '@/channels/schema'
@@ -75,6 +76,19 @@ export interface KakaoTalkListener {
   ): this
 }
 
+export type KakaoCredentialStore = {
+  load(): Promise<KakaoConfig>
+  save(config: KakaoConfig): Promise<void>
+  getAccount(id?: string): Promise<KakaoAccountCredentials | null>
+  setAccount(account: KakaoAccountCredentials): Promise<void>
+  removeAccount(id: string): Promise<void>
+  listAccounts(): Promise<Array<KakaoAccountCredentials & { is_current: boolean }>>
+  setCurrentAccount(id: string): Promise<void>
+  savePendingLogin(state: PendingLoginState): Promise<void>
+  loadPendingLogin(): Promise<PendingLoginState | null>
+  clearPendingLogin(): Promise<void>
+}
+
 const KakaoTalkClient = RealKakaoTalkClient as unknown as new () => KakaoTalkClient
 const KakaoTalkListener = RealKakaoTalkListener as unknown as new (client: KakaoTalkClient) => KakaoTalkListener
 
@@ -95,13 +109,9 @@ export type KakaotalkAdapterOptions = {
   configRef: () => KakaotalkAdapterConfig
   logger?: KakaotalkAdapterLogger
   selfAliasesRef?: () => readonly string[]
-  // When set, the adapter loads KakaoTalk credentials from this directory
-  // (via KakaoCredentialManager(credentialsDir)) instead of relying on
-  // the SDK's AGENT_MESSENGER_CONFIG_DIR env-var fallback. Production
-  // wiring in src/channels/manager.ts passes the agent-folder workspace
-  // path here so the adapter's credential resolution does NOT depend on
-  // process.env state — easier to test, and removes a hidden coupling
-  // with whatever set the env var (Dockerfile, CLI shell, etc.).
+  credentialsStore?: KakaoCredentialStore
+  // Deprecated compatibility path for old tests/callers. Production uses
+  // credentialsStore so secrets.json remains the credential source of truth.
   credentialsDir?: string
   client?: KakaoTalkClient
   listenerFactory?: (client: KakaoTalkClient) => KakaoTalkListener
@@ -416,17 +426,16 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       lastConnectedAt = null
       resetRecoveryEpisode()
       try {
-        if (options.credentialsDir !== undefined) {
-          // Explicit credential path: read the file ourselves and pass the
-          // tokens directly to client.login(). This bypasses the SDK's
-          // ensureKakaoAuth() (which reads AGENT_MESSENGER_CONFIG_DIR or
-          // ~/.config/agent-messenger), making the adapter independent of
-          // process.env state.
-          const credManager = new KakaoCredentialManager(options.credentialsDir)
-          const account = await credManager.getAccount()
+        const credentialStore =
+          options.credentialsStore ??
+          (options.credentialsDir !== undefined ? new KakaoCredentialManager(options.credentialsDir) : null)
+        if (credentialStore !== null) {
+          const account = await credentialStore.getAccount()
           if (account === null) {
             throw new Error(
-              `no KakaoTalk account in ${options.credentialsDir}/kakaotalk-credentials.json (run typeclaw init to authenticate)`,
+              options.credentialsDir !== undefined
+                ? `no KakaoTalk account in ${options.credentialsDir}/kakaotalk-credentials.json (run typeclaw init to authenticate)`
+                : 'no KakaoTalk account in secrets.json#channels.kakaotalk (run typeclaw init to authenticate)',
             )
           }
           await client.login({

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -395,8 +395,8 @@ describe('channel manager — kakaotalk credential preflight', () => {
     await writeFile(
       path,
       JSON.stringify({
-        version: 1,
-        llm: {},
+        version: 2,
+        providers: {},
         channels: {
           kakaotalk: {
             currentAccount: accountId,
@@ -484,7 +484,7 @@ describe('channel manager — kakaotalk credential preflight', () => {
     await mgr.start()
     expect(fake.startCalls).toBe(1)
 
-    await writeFile(path, JSON.stringify({ version: 1, llm: {}, channels: {} }))
+    await writeFile(path, JSON.stringify({ version: 2, providers: {}, channels: {} }))
 
     const result = await mgr.reload()
     expect(result.stopped).toContain('kakaotalk')

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -446,6 +447,25 @@ describe('channel manager — kakaotalk credential preflight', () => {
 
     await mgr.start()
     expect(fake.startCalls).toBe(0)
+
+    await mgr.stop()
+  })
+
+  test('missing kakaotalk credentials preflight does not create secrets.json', async () => {
+    cfg.kakaotalk = enabledAdapterCfg()
+    const secretsPath = join(agentDir, 'secrets.json')
+    const fake = makeFakeAdapter()
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: {},
+      createKakaotalkAdapter: () => fake,
+    })
+
+    await mgr.start()
+
+    expect(fake.startCalls).toBe(0)
+    expect(existsSync(secretsPath)).toBe(false)
 
     await mgr.stop()
   })

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -383,22 +383,48 @@ describe('channel manager — telegram adapter lifecycle', () => {
 })
 
 describe('channel manager — kakaotalk credential preflight', () => {
-  const writeCredentialsFile = async (dir: string): Promise<string> => {
-    const credDir = join(dir, 'workspace', '.agent-messenger')
-    await mkdir(credDir, { recursive: true })
-    const path = join(credDir, 'kakaotalk-credentials.json')
-    await writeFile(path, JSON.stringify({ current_account: 'a1', accounts: {} }))
+  const kakaoEnv: NodeJS.ProcessEnv = {
+    TYPECLAW_HOSTD_URL: 'http://host.docker.internal:8974',
+    TYPECLAW_HOSTD_TOKEN: 'restart-token',
+    TYPECLAW_CONTAINER_NAME: 'typeclaw-test',
+  }
+
+  const writeKakaoSecrets = async (dir: string, accountId = 'a1'): Promise<string> => {
+    const path = join(dir, 'secrets.json')
+    await writeFile(
+      path,
+      JSON.stringify({
+        version: 1,
+        llm: {},
+        channels: {
+          kakaotalk: {
+            currentAccount: accountId,
+            accounts: {
+              [accountId]: {
+                account_id: accountId,
+                oauth_token: `oauth-${accountId}`,
+                user_id: accountId,
+                device_uuid: `device-${accountId}`,
+                device_type: 'tablet',
+                created_at: '2026-01-01T00:00:00.000Z',
+                updated_at: '2026-01-01T00:00:00.000Z',
+              },
+            },
+          },
+        },
+      }),
+    )
     return path
   }
 
-  test('starts kakaotalk adapter when credentials file exists at workspace/.agent-messenger/', async () => {
+  test('starts kakaotalk adapter when credentials exist in secrets.json', async () => {
     cfg.kakaotalk = enabledAdapterCfg()
-    await writeCredentialsFile(agentDir)
+    await writeKakaoSecrets(agentDir)
     const fake = makeFakeAdapter()
     const mgr = createChannelManager({
       agentDir,
       channelsConfigRef: () => cfg,
-      env: {},
+      env: kakaoEnv,
       createKakaotalkAdapter: () => fake,
     })
 
@@ -408,7 +434,7 @@ describe('channel manager — kakaotalk credential preflight', () => {
     await mgr.stop()
   })
 
-  test('does not start kakaotalk adapter when credentials file is missing', async () => {
+  test('does not start kakaotalk adapter when secrets.json lacks kakaotalk credentials', async () => {
     cfg.kakaotalk = enabledAdapterCfg()
     const fake = makeFakeAdapter()
     const mgr = createChannelManager({
@@ -424,66 +450,40 @@ describe('channel manager — kakaotalk credential preflight', () => {
     await mgr.stop()
   })
 
-  test('honors AGENT_MESSENGER_CONFIG_DIR override for credential lookup', async () => {
+  test('reload stops kakaotalk adapter when credentials are removed from secrets.json', async () => {
     cfg.kakaotalk = enabledAdapterCfg()
-    const overrideDir = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-override-'))
-    try {
-      const credPath = join(overrideDir, 'kakaotalk-credentials.json')
-      await writeFile(credPath, '{}')
-      const fake = makeFakeAdapter()
-      const mgr = createChannelManager({
-        agentDir,
-        channelsConfigRef: () => cfg,
-        env: { AGENT_MESSENGER_CONFIG_DIR: overrideDir },
-        createKakaotalkAdapter: () => fake,
-      })
-
-      await mgr.start()
-      expect(fake.startCalls).toBe(1)
-      await mgr.stop()
-    } finally {
-      await rm(overrideDir, { recursive: true, force: true })
-    }
-  })
-
-  test('reload stops kakaotalk adapter when credentials file is removed', async () => {
-    cfg.kakaotalk = enabledAdapterCfg()
-    const path = await writeCredentialsFile(agentDir)
+    const path = await writeKakaoSecrets(agentDir)
     const fake = makeFakeAdapter()
     const mgr = createChannelManager({
       agentDir,
       channelsConfigRef: () => cfg,
-      env: {},
+      env: kakaoEnv,
       createKakaotalkAdapter: () => fake,
     })
 
     await mgr.start()
     expect(fake.startCalls).toBe(1)
 
-    await rm(path)
+    await writeFile(path, JSON.stringify({ version: 1, llm: {}, channels: {} }))
 
     const result = await mgr.reload()
     expect(result.stopped).toContain('kakaotalk')
     expect(fake.stopCalls).toBe(1)
   })
 
-  test('reload reports credential rotation (not stop) when file content changes', async () => {
+  test('reload reports credential rotation (not stop) when secrets kakaotalk block changes', async () => {
     cfg.kakaotalk = enabledAdapterCfg()
-    const path = await writeCredentialsFile(agentDir)
+    await writeKakaoSecrets(agentDir)
     const fake = makeFakeAdapter()
     const mgr = createChannelManager({
       agentDir,
       channelsConfigRef: () => cfg,
-      env: {},
+      env: kakaoEnv,
       createKakaotalkAdapter: () => fake,
     })
 
     await mgr.start()
-    // Different JSON content → different SHA-256 → credential rotation
-    // detected. Per fix #7, we hash the file rather than relying on
-    // mtime/size, so writing back identical bytes would correctly NOT
-    // trigger a rotation (asserted by the negative case below).
-    await writeFile(path, JSON.stringify({ current_account: 'a2', accounts: {} }))
+    await writeKakaoSecrets(agentDir, 'a2')
 
     const result = await mgr.reload()
     expect(result.stopped).not.toContain('kakaotalk')
@@ -492,21 +492,19 @@ describe('channel manager — kakaotalk credential preflight', () => {
     await mgr.stop()
   })
 
-  test('reload does not report rotation when file is rewritten with identical bytes', async () => {
+  test('reload does not report rotation when secrets kakaotalk block is unchanged', async () => {
     cfg.kakaotalk = enabledAdapterCfg()
-    const path = await writeCredentialsFile(agentDir)
+    await writeKakaoSecrets(agentDir)
     const fake = makeFakeAdapter()
     const mgr = createChannelManager({
       agentDir,
       channelsConfigRef: () => cfg,
-      env: {},
+      env: kakaoEnv,
       createKakaotalkAdapter: () => fake,
     })
 
     await mgr.start()
-    // Re-write the same JSON. mtime+size would have flagged this; content
-    // hash correctly recognizes it as a no-op.
-    await writeFile(path, JSON.stringify({ current_account: 'a1', accounts: {} }))
+    await writeKakaoSecrets(agentDir)
 
     const result = await mgr.reload()
     expect(result.restartRequired).not.toContain('kakaotalk (credential rotation)')

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -276,7 +276,7 @@ function createContainerKakaoCredentialStore(agentDir: string, env: NodeJS.Proce
 function buildKakaotalkSignature(agentDir: string): { signature: string; missing: string[] } {
   const path = join(agentDir, 'secrets.json')
   try {
-    const block = new SecretsBackend(path).readChannelsSync().kakaotalk
+    const block = new SecretsBackend(path).tryReadChannelsSync()?.kakaotalk
     if (!isKakaoCredentialBlock(block)) {
       return { signature: '', missing: ['secrets.json#channels.kakaotalk'] }
     }

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -2,6 +2,8 @@ import { createHash } from 'node:crypto'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
+
 import { createDiscordBotAdapter, type DiscordBotAdapter } from './adapters/discord-bot'
 import { createKakaotalkAdapter, type KakaotalkAdapter } from './adapters/kakaotalk'
 import { createSlackBotAdapter, type SlackBotAdapter } from './adapters/slack-bot'
@@ -132,7 +134,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         logger,
         selfAliasesRef: () => router.getSelfAliases(),
-        credentialsDir: resolveKakaoConfigDir(options.agentDir, env),
+        credentialsStore: createContainerKakaoCredentialStore(options.agentDir, env),
       })
     }
     if (name === 'telegram-bot') {
@@ -264,6 +266,24 @@ function resolveKakaoConfigDir(agentDir: string, env: NodeJS.ProcessEnv): string
 
 function resolveKakaoCredentialsPath(agentDir: string, env: NodeJS.ProcessEnv): string {
   return join(resolveKakaoConfigDir(agentDir, env), KAKAO_CREDENTIALS_FILE)
+}
+
+function createContainerKakaoCredentialStore(agentDir: string, env: NodeJS.ProcessEnv): SecretsKakaoCredentialStore {
+  const hostdUrl = env.TYPECLAW_HOSTD_URL
+  const restartToken = env.TYPECLAW_HOSTD_TOKEN
+  const containerName = env.TYPECLAW_CONTAINER_NAME
+  if (!hostdUrl || !restartToken || !containerName) {
+    throw new Error(
+      'KakaoTalk credentials require TYPECLAW_HOSTD_URL, TYPECLAW_HOSTD_TOKEN, and TYPECLAW_CONTAINER_NAME',
+    )
+  }
+  return new SecretsKakaoCredentialStore({
+    mode: 'container',
+    secretsPath: join(agentDir, 'secrets.json'),
+    hostdUrl,
+    restartToken,
+    containerName,
+  })
 }
 
 function buildKakaotalkSignature(agentDir: string, env: NodeJS.ProcessEnv): { signature: string; missing: string[] } {

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -1,8 +1,8 @@
 import { createHash } from 'node:crypto'
-import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
+import { SecretsBackend } from '@/secrets/storage'
 
 import { createDiscordBotAdapter, type DiscordBotAdapter } from './adapters/discord-bot'
 import { createKakaotalkAdapter, type KakaotalkAdapter } from './adapters/kakaotalk'
@@ -64,10 +64,10 @@ type AnyAdapter = DiscordBotAdapter | KakaotalkAdapter | SlackBotAdapter | Teleg
 // Credential signature is the comparison key for credential-rotation
 // detection on reload. Discord and Telegram each use a single bot token;
 // Slack needs both a bot token and an app-level token (Socket Mode);
-// KakaoTalk authenticates via a credentials file under
-// AGENT_MESSENGER_CONFIG_DIR (workspace/), so its signature is the file's
-// content hash. The "credential" naming (vs "token") generalizes across the
-// env-var-based adapters and KakaoTalk's file-based credential pathway.
+// KakaoTalk authenticates via a structured multi-account block in
+// secrets.json#channels.kakaotalk, so its signature is that block's content
+// hash. The "credential" naming (vs "token") generalizes across the
+// env-var-based adapters and KakaoTalk's account credential pathway.
 type AdapterEntry = {
   adapter: AnyAdapter
   credentialSignature: string
@@ -91,7 +91,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
   const live = new Map<AdapterId, AdapterEntry>()
 
   const buildCredentialSignature = (name: AdapterId): { signature: string; missing: string[] } => {
-    if (name === 'kakaotalk') return buildKakaotalkSignature(options.agentDir, env)
+    if (name === 'kakaotalk') return buildKakaotalkSignature(options.agentDir)
     const requiredEnvs = TOKEN_ENV[name]
     const parts: string[] = []
     const missing: string[] = []
@@ -225,7 +225,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
           const { signature, missing } = buildCredentialSignature(name)
           if (missing.length > 0) {
             // Required credentials disappeared (env vars removed from .env, or
-            // KakaoTalk credentials file deleted). Continuing to use the
+            // KakaoTalk credentials removed from secrets.json). Continuing to use the
             // in-memory credentials would silently honor a credential the
             // operator explicitly removed, so stop the adapter instead of
             // waiting for a manual restart.
@@ -246,26 +246,13 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
   }
 }
 
-// Token-based adapters only. KakaoTalk's credentials live in a file under
-// AGENT_MESSENGER_CONFIG_DIR (workspace/.agent-messenger/), not in env, so
-// it goes through buildKakaotalkSignature instead.
+// Token-based adapters only. KakaoTalk's credentials live in
+// secrets.json#channels.kakaotalk, not in env, so it goes through
+// buildKakaotalkSignature instead.
 const TOKEN_ENV: Record<Exclude<AdapterId, 'kakaotalk'>, readonly string[]> = {
   'discord-bot': ['DISCORD_BOT_TOKEN'],
   'slack-bot': ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN'],
   'telegram-bot': ['TELEGRAM_BOT_TOKEN'],
-}
-
-const KAKAO_DEFAULT_SUBDIR = '.agent-messenger'
-const KAKAO_CREDENTIALS_FILE = 'kakaotalk-credentials.json'
-
-function resolveKakaoConfigDir(agentDir: string, env: NodeJS.ProcessEnv): string {
-  const override = env.AGENT_MESSENGER_CONFIG_DIR
-  if (override !== undefined && override.trim() !== '') return override
-  return join(agentDir, 'workspace', KAKAO_DEFAULT_SUBDIR)
-}
-
-function resolveKakaoCredentialsPath(agentDir: string, env: NodeJS.ProcessEnv): string {
-  return join(resolveKakaoConfigDir(agentDir, env), KAKAO_CREDENTIALS_FILE)
 }
 
 function createContainerKakaoCredentialStore(agentDir: string, env: NodeJS.ProcessEnv): SecretsKakaoCredentialStore {
@@ -286,25 +273,27 @@ function createContainerKakaoCredentialStore(agentDir: string, env: NodeJS.Proce
   })
 }
 
-function buildKakaotalkSignature(agentDir: string, env: NodeJS.ProcessEnv): { signature: string; missing: string[] } {
-  const path = resolveKakaoCredentialsPath(agentDir, env)
-  if (!existsSync(path)) {
-    return { signature: '', missing: [`kakaotalk credentials file at ${path}`] }
-  }
+function buildKakaotalkSignature(agentDir: string): { signature: string; missing: string[] } {
+  const path = join(agentDir, 'secrets.json')
   try {
-    // Content hash, not mtime+size: KakaoTalk's credential file is small
-    // (a few hundred bytes of JSON) and is rewritten on every OAuth token
-    // refresh. Hashing avoids two failure modes mtime+size could miss:
-    //   (a) a refresh that produces byte-identical content (rare but
-    //       possible when nothing actually rotated) — we correctly skip;
-    //   (b) a refresh that lands on the same mtime due to FS resolution
-    //       (some host filesystems quantize to seconds).
-    const buf = readFileSync(path)
-    const digest = createHash('sha256').update(buf).digest('hex')
-    return { signature: `${path}@sha256:${digest}`, missing: [] }
+    const block = new SecretsBackend(path).readChannelsSync().kakaotalk
+    if (!isKakaoCredentialBlock(block)) {
+      return { signature: '', missing: ['secrets.json#channels.kakaotalk'] }
+    }
+    const digest = createHash('sha256').update(JSON.stringify(block)).digest('hex')
+    return { signature: `secrets.json#channels.kakaotalk@sha256:${digest}`, missing: [] }
   } catch (err) {
-    return { signature: '', missing: [`kakaotalk credentials file at ${path} (${describe(err)})`] }
+    return { signature: '', missing: [`secrets.json#channels.kakaotalk (${describe(err)})`] }
   }
+}
+
+function isKakaoCredentialBlock(value: unknown): value is { accounts: Record<string, unknown> } {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  if (!('accounts' in value)) return false
+  const accounts = value.accounts
+  return (
+    typeof accounts === 'object' && accounts !== null && !Array.isArray(accounts) && Object.keys(accounts).length > 0
+  )
 }
 
 function describe(err: unknown): string {

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -349,7 +349,7 @@ const START_MESSAGES: Record<AddChannelStepEvent['step'], string> = {
 }
 
 function reportKakaotalkAuth(result: KakaotalkAuthResult): string {
-  if (result.ok) return 'KakaoTalk credentials saved to workspace/.agent-messenger/.'
+  if (result.ok) return 'KakaoTalk credentials saved to secrets.json.'
   return `KakaoTalk login failed: ${result.reason}`
 }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -415,7 +415,7 @@ function preflightFailureGuidance(result: Extract<DockerAvailability, { ok: fals
 }
 
 function reportKakaotalkAuth(result: KakaotalkAuthResult): string {
-  if (result.ok) return 'KakaoTalk credentials saved to workspace/.agent-messenger/.'
+  if (result.ok) return 'KakaoTalk credentials saved to secrets.json.'
   return `KakaoTalk login failed: ${result.reason}`
 }
 

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -916,6 +916,80 @@ describe('start (composition)', () => {
     expect(onDisk).not.toContain('FROM stale')
   })
 
+  test('promotes legacy KakaoTalk credential files into secrets.json before container start', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await mkdir(join(root, 'workspace', '.agent-messenger'), { recursive: true })
+    const legacyDir = join(root, 'workspace', '.agent-messenger')
+    await writeFile(
+      join(legacyDir, 'kakaotalk-credentials.json'),
+      JSON.stringify({
+        current_account: 'user-1',
+        accounts: {
+          'user-1': {
+            account_id: 'user-1',
+            oauth_token: 'oauth-user-1',
+            user_id: 'user-1',
+            refresh_token: 'refresh-user-1',
+            device_uuid: 'device-user-1',
+            device_type: 'tablet',
+            auth_method: 'login',
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      }),
+    )
+    await writeFile(
+      join(legacyDir, 'kakaotalk-pending-login.json'),
+      JSON.stringify({
+        device_uuid: 'pending-device',
+        device_type: 'tablet',
+        email: 'user@example.com',
+        created_at: '2026-01-01T00:00:00.000Z',
+      }),
+    )
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    const secrets = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels: {
+        kakaotalk?: { currentAccount: string | null; accounts: Record<string, unknown>; pendingLogin?: unknown }
+      }
+    }
+    expect(secrets.channels.kakaotalk?.currentAccount).toBe('user-1')
+    expect(secrets.channels.kakaotalk?.accounts['user-1']).toBeDefined()
+    expect(secrets.channels.kakaotalk?.pendingLogin).toEqual({
+      device_uuid: 'pending-device',
+      device_type: 'tablet',
+      email: 'user@example.com',
+      created_at: '2026-01-01T00:00:00.000Z',
+    })
+    expect(existsSync(join(legacyDir, 'kakaotalk-credentials.json'))).toBe(false)
+    expect(existsSync(join(legacyDir, 'kakaotalk-credentials.json.migrated'))).toBe(true)
+    expect(existsSync(join(legacyDir, 'kakaotalk-pending-login.json.migrated'))).toBe(true)
+
+    const second = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+    expect(second.ok).toBe(true)
+    expect(JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8'))).toEqual(secrets)
+  })
+
   test('refreshes .gitignore from the template on every start', async () => {
     // given: a stale .gitignore and an existing image
     await writeFile(join(root, '.gitignore'), '# stale\nold-entry\n')

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -20,6 +20,7 @@ import { ensureDepsInstalled, type EnsureDepsResult } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 import { refreshPackageJson } from '@/init/packagejson'
 import { runBunUpdate, type UpdateRunner } from '@/init/run-bun-install'
+import { migrateKakaotalkCredentials } from '@/secrets'
 
 import { CONTAINER_PORT, findFreePort, isPortAllocatedError } from './port'
 import {
@@ -233,6 +234,7 @@ export async function start({
     // ensures the base image's CLI version matches the runtime the
     // container will actually load.
     await refreshDockerfile(cwd)
+    await migrateKakaotalkCredentials(cwd)
 
     if (state.exists) {
       // Container holds the name but is not running. Without `--rm`, this is

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -403,7 +403,7 @@ describe('startDaemon', () => {
     try {
       await writeFile(
         join(agentDir, 'secrets.json'),
-        JSON.stringify({ version: 1, llm: {}, channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'keep' } } }),
+        JSON.stringify({ version: 2, providers: {}, channels: { 'discord-bot': { token: { value: 'keep' } } } }),
       )
       daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000 })
       const info = await send({ kind: 'http-info' })
@@ -427,7 +427,7 @@ describe('startDaemon', () => {
       const raw = JSON.parse(await readFile(join(agentDir, 'secrets.json'), 'utf8')) as {
         channels: Record<string, unknown>
       }
-      expect(raw.channels['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'keep' })
+      expect(raw.channels['discord-bot']).toEqual({ token: { value: 'keep' } })
       const kakao = raw.channels.kakaotalk as KakaoChannelBlock
       expect([kakaoBlock('user-1'), kakaoBlock('user-2')]).toContainEqual(kakao)
     } finally {

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import type { DockerExec } from '@/container'
+import type { KakaoChannelBlock } from '@/secrets/schema'
 
 import { send, sendHttp } from './client'
 import { startDaemon, type Daemon, type PortbrokerCallbacks, type PortbrokerStartInput } from './daemon'
@@ -38,6 +39,25 @@ function fakeExec(alive: Set<string> = new Set()): DockerExec {
       return { exitCode: 0, stdout: alive.has(name) ? `${name}\n` : '', stderr: '' }
     }
     return { exitCode: 1, stdout: '', stderr: 'unknown command' }
+  }
+}
+
+function kakaoBlock(accountId: string): KakaoChannelBlock {
+  return {
+    currentAccount: accountId,
+    accounts: {
+      [accountId]: {
+        account_id: accountId,
+        oauth_token: `oauth-${accountId}`,
+        user_id: accountId,
+        refresh_token: `refresh-${accountId}`,
+        device_uuid: `device-${accountId}`,
+        device_type: 'tablet',
+        auth_method: 'login',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    },
   }
 }
 
@@ -324,6 +344,95 @@ describe('startDaemon', () => {
     expect(ack.ok).toBe(false)
     if (ack.ok) return
     expect(ack.reason).toContain('invalid restart token')
+  })
+
+  test('HTTP secrets-patch writes kakaotalk secrets for the registered container', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-daemon-agent-'))
+    try {
+      daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000 })
+      const info = await send({ kind: 'http-info' })
+      expect(info.ok).toBe(true)
+      if (!info.ok) return
+      await send({ kind: 'register', containerName: 'coder', cwd: agentDir, restartToken: 'secret' })
+
+      const ack = await sendHttp(
+        { kind: 'secrets-patch', containerName: 'coder', patch: { channels: { kakaotalk: kakaoBlock('user-1') } } },
+        { url: `http://127.0.0.1:${(info.result as HttpInfoResult).port}`, token: 'secret' },
+      )
+
+      expect(ack.ok).toBe(true)
+      const raw = JSON.parse(await readFile(join(agentDir, 'secrets.json'), 'utf8')) as {
+        channels: Record<string, unknown>
+      }
+      expect(raw.channels.kakaotalk).toEqual(kakaoBlock('user-1'))
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('HTTP secrets-patch rejects unregistered containers and wrong tokens', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-daemon-agent-'))
+    try {
+      daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000 })
+      const info = await send({ kind: 'http-info' })
+      expect(info.ok).toBe(true)
+      if (!info.ok) return
+      const url = `http://127.0.0.1:${(info.result as HttpInfoResult).port}`
+
+      const unregistered = await sendHttp(
+        { kind: 'secrets-patch', containerName: 'missing', patch: { channels: { kakaotalk: kakaoBlock('user-1') } } },
+        { url, token: 'secret' },
+      )
+      expect(unregistered.ok).toBe(false)
+
+      await send({ kind: 'register', containerName: 'coder', cwd: agentDir, restartToken: 'secret' })
+      const wrongToken = await sendHttp(
+        { kind: 'secrets-patch', containerName: 'coder', patch: { channels: { kakaotalk: kakaoBlock('user-1') } } },
+        { url, token: 'wrong' },
+      )
+      expect(wrongToken.ok).toBe(false)
+      if (wrongToken.ok) return
+      expect(wrongToken.reason).toContain('invalid restart token')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('HTTP secrets-patch preserves other channels and serializes concurrent patches', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-daemon-agent-'))
+    try {
+      await writeFile(
+        join(agentDir, 'secrets.json'),
+        JSON.stringify({ version: 1, llm: {}, channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'keep' } } }),
+      )
+      daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000 })
+      const info = await send({ kind: 'http-info' })
+      expect(info.ok).toBe(true)
+      if (!info.ok) return
+      const url = `http://127.0.0.1:${(info.result as HttpInfoResult).port}`
+      await send({ kind: 'register', containerName: 'coder', cwd: agentDir, restartToken: 'secret' })
+
+      const replies = await Promise.all([
+        sendHttp(
+          { kind: 'secrets-patch', containerName: 'coder', patch: { channels: { kakaotalk: kakaoBlock('user-1') } } },
+          { url, token: 'secret' },
+        ),
+        sendHttp(
+          { kind: 'secrets-patch', containerName: 'coder', patch: { channels: { kakaotalk: kakaoBlock('user-2') } } },
+          { url, token: 'secret' },
+        ),
+      ])
+
+      expect(replies.every((reply) => reply.ok)).toBe(true)
+      const raw = JSON.parse(await readFile(join(agentDir, 'secrets.json'), 'utf8')) as {
+        channels: Record<string, unknown>
+      }
+      expect(raw.channels['discord-bot']).toEqual({ DISCORD_BOT_TOKEN: 'keep' })
+      const kakao = raw.channels.kakaotalk as KakaoChannelBlock
+      expect([kakaoBlock('user-1'), kakaoBlock('user-2')]).toContainEqual(kakao)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
   })
 
   test('HTTP restart rejects oversized unauthenticated requests before parsing JSON', async () => {

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -7,6 +7,8 @@ import type { Socket, UnixSocketListener } from 'bun'
 import type { PortForward } from '@/config'
 import { defaultDockerExec, type DockerExec } from '@/container'
 import type { PortForwardEvent } from '@/portbroker'
+import { kakaoChannelBlockSchema } from '@/secrets/schema'
+import { SecretsBackend } from '@/secrets/storage'
 
 import { isDaemonReachable } from './client'
 import { ensureDirs, registrationFilePath, registrationsDir, socketPath } from './paths'
@@ -16,6 +18,7 @@ import type {
   Request,
   Response as RpcResponse,
   RestartResult,
+  SecretsPatchResult,
   ShutdownResult,
   StatusResult,
   VersionResult,
@@ -351,6 +354,26 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     return { ok: true, result }
   }
 
+  const handleSecretsPatch = async (req: {
+    containerName: string
+    patch: { channels: { kakaotalk: unknown } }
+  }): Promise<RpcResponse> =>
+    runSerially(req.containerName, async () => {
+      const cwd = cwds.get(req.containerName)
+      if (!cwd) return { ok: false, reason: `not registered: ${req.containerName}` }
+      const parsed = kakaoChannelBlockSchema.safeParse(req.patch?.channels?.kakaotalk)
+      if (!parsed.success) {
+        return { ok: false, reason: parsed.error.issues.map((issue) => issue.message).join('; ') }
+      }
+      const backend = new SecretsBackend(join(cwd, 'secrets.json'))
+      await backend.updateChannelsAsync(async (channels) => ({
+        result: undefined,
+        next: { ...channels, kakaotalk: parsed.data },
+      }))
+      const result: SecretsPatchResult = { containerName: req.containerName, patched: true }
+      return { ok: true, result }
+    })
+
   const handleHttpInfo = (): RpcResponse => {
     const result: HttpInfoResult = { port: httpPort }
     return { ok: true, result }
@@ -392,6 +415,8 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
         return handleStatus(req)
       case 'restart':
         return handleRestart(req)
+      case 'secrets-patch':
+        return handleSecretsPatch(req)
       case 'http-info':
         return handleHttpInfo()
       case 'version':
@@ -454,13 +479,13 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     } catch {
       return json({ ok: false, reason: 'invalid request json' }, 400)
     }
-    if (rpc.kind !== 'restart') {
-      return json({ ok: false, reason: 'http transport only supports restart' }, 403)
+    if (rpc.kind !== 'restart' && rpc.kind !== 'secrets-patch') {
+      return json({ ok: false, reason: 'http transport only supports restart and secrets-patch' }, 403)
     }
     if (restartTokens.get(rpc.containerName) !== token) {
       return json({ ok: false, reason: 'invalid restart token' }, 403)
     }
-    return json(await handleRestart(rpc))
+    return json(rpc.kind === 'restart' ? await handleRestart(rpc) : await handleSecretsPatch(rpc))
   }
 
   const httpHostname = opts.httpHost ?? '0.0.0.0'

--- a/src/hostd/protocol.ts
+++ b/src/hostd/protocol.ts
@@ -1,4 +1,5 @@
 import type { PortForward } from '@/config'
+import type { KakaoChannelBlock } from '@/secrets/schema'
 
 export type Request =
   | {
@@ -14,6 +15,7 @@ export type Request =
   | { kind: 'list' }
   | { kind: 'status'; containerName: string }
   | { kind: 'restart'; containerName: string; build?: boolean }
+  | { kind: 'secrets-patch'; containerName: string; patch: { channels: { kakaotalk: KakaoChannelBlock } } }
   | { kind: 'http-info' }
   | { kind: 'version' }
   | { kind: 'shutdown' }
@@ -33,6 +35,11 @@ export type StatusResult = {
 export type RestartResult = {
   containerName: string
   scheduled: true
+}
+
+export type SecretsPatchResult = {
+  containerName: string
+  patched: true
 }
 
 export type HttpInfoResult = {

--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { type AddChannelStepEvent, readConfiguredChannels, runAddChannel, scaffold, writeSecrets } from './index'
+import { runKakaotalkBootstrap } from './kakaotalk-auth'
 
 let root: string
 
@@ -114,6 +116,39 @@ describe('runAddChannel', () => {
     const cfg = await readConfig()
     expect(cfg.channels?.kakaotalk?.allow).toEqual(['kakao:dm/*'])
     expect(await readEnv()).toBe('FIREWORKS_API_KEY=fw_existing\n')
+  })
+
+  test('adds kakaotalk credentials to secrets.json instead of workspace credential files', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'kakaotalk',
+      runKakaotalkAuth: async ({ cwd }) =>
+        runKakaotalkBootstrap({
+          email: 'user@example.com',
+          password: 'secret',
+          agentDir: cwd,
+          callbacks: { onPasscode: () => {} },
+          loginFlow: async () => ({
+            authenticated: true,
+            credentials: {
+              access_token: 'oauth-abc',
+              refresh_token: 'refresh-xyz',
+              user_id: 'user-1',
+              device_uuid: 'uuid-1',
+              device_type: 'tablet',
+            },
+          }),
+        }),
+    })
+
+    const channels = await readSecretsChannels()
+    const kakao = channels.kakaotalk as unknown as {
+      currentAccount: string
+      accounts: Record<string, { oauth_token: string }>
+    }
+    expect(kakao.currentAccount).toBe('user-1')
+    expect(kakao.accounts['user-1']?.oauth_token).toBe('oauth-abc')
+    expect(existsSync(join(root, 'workspace', '.agent-messenger', 'kakaotalk-credentials.json'))).toBe(false)
   })
 
   test('kakaotalk with allowAll=true broadens allow to kakao:*', async () => {

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -266,13 +266,10 @@ ${fromAndHeavyLayers}
 
 ENV NODE_ENV=production
 
-# Pin agent-messenger's config dir into the agent's workspace/ so KakaoTalk
-# (and any future agent-messenger-backed channel) reads/writes credentials
-# inside the bind-mounted agent folder. Without this, the SDK would default
-# to /root/.config/agent-messenger inside the container, which doesn't
-# survive container restarts and isn't visible from the host. The agent
-# folder's bind-mount maps /agent → host's agent dir, so the credentials
-# end up at <agentDir>/workspace/.agent-messenger/ on the host.
+# Keep agent-messenger's fallback config dir inside workspace/ for any future
+# SDK fallback paths. TypeClaw's KakaoTalk adapter does not write there:
+# credentials live in secrets.json#channels.kakaotalk and container writes go
+# through hostd's secrets-patch RPC.
 ENV AGENT_MESSENGER_CONFIG_DIR=/agent/workspace/.agent-messenger
 
 ${customLines}ENTRYPOINT ["${TYPECLAW_ENTRYPOINT_PATH}"]

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -698,7 +698,7 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
   //
   // We run KakaoTalk auth FIRST so a failed login leaves typeclaw.json and
   // .env untouched. The runtime treats `channels.kakaotalk` without a
-  // credentials file as "missing credentials, skip adapter", which silently
+  // secrets.json#channels.kakaotalk block as "missing credentials, skip adapter", which silently
   // drops messages — the same trap `runInit` already guards against. Aborting
   // before any file write means the user's next `typeclaw channel add
   // kakaotalk` retry has no half-applied state to clean up.

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -738,8 +738,8 @@ function channelSecretsFromOptions(options: AddChannelOptions): ChannelSecrets {
     case 'telegram-bot':
       return { token: options.telegramBotToken }
     case 'kakaotalk':
-      // KakaoTalk credentials live in `workspace/.agent-messenger/`, written
-      // by the auth runner above. Nothing to record in secrets.json.
+      // KakaoTalk auth writes its structured multi-account block directly to
+      // secrets.json#channels.kakaotalk before config mutation.
       return {}
   }
 }

--- a/src/init/kakaotalk-auth.test.ts
+++ b/src/init/kakaotalk-auth.test.ts
@@ -139,8 +139,8 @@ describe('runKakaotalkBootstrap', () => {
       await writeFile(
         kakaotalkSecretsPath(agentDir),
         JSON.stringify({
-          version: 1,
-          llm: {},
+          version: 2,
+          providers: {},
           channels: {
             kakaotalk: {
               currentAccount: null,

--- a/src/init/kakaotalk-auth.test.ts
+++ b/src/init/kakaotalk-auth.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 
 import {
   kakaotalkConfigDir,
+  kakaotalkSecretsPath,
   type LoginFlowFn,
   type LoginFlowOptions,
   type LoginFlowResult,
@@ -49,14 +50,18 @@ describe('runKakaotalkBootstrap', () => {
         loginFlow: fake,
       })
       expect(result).toEqual({ ok: true })
-      const credPath = join(kakaotalkConfigDir(agentDir), 'kakaotalk-credentials.json')
-      const stored = JSON.parse(await readFile(credPath, 'utf8')) as {
-        current_account: string
-        accounts: Record<string, { user_id: string; auth_method: string; oauth_token: string }>
+      const stored = JSON.parse(await readFile(kakaotalkSecretsPath(agentDir), 'utf8')) as {
+        channels: {
+          kakaotalk: {
+            currentAccount: string
+            accounts: Record<string, { user_id: string; auth_method: string; oauth_token: string }>
+          }
+        }
       }
-      expect(stored.current_account).toBe('user-1')
-      expect(stored.accounts['user-1']?.oauth_token).toBe('oauth-abc')
-      expect(stored.accounts['user-1']?.auth_method).toBe('login')
+      expect(stored.channels.kakaotalk.currentAccount).toBe('user-1')
+      expect(stored.channels.kakaotalk.accounts['user-1']?.oauth_token).toBe('oauth-abc')
+      expect(stored.channels.kakaotalk.accounts['user-1']?.auth_method).toBe('login')
+      await expect(readFile(join(kakaotalkConfigDir(agentDir), 'kakaotalk-credentials.json'), 'utf8')).rejects.toThrow()
     } finally {
       await rm(agentDir, { recursive: true, force: true })
     }
@@ -130,15 +135,24 @@ describe('runKakaotalkBootstrap', () => {
   test('reuses savedDeviceUuid from prior pending login', async () => {
     const agentDir = await tmp()
     try {
-      const configDir = kakaotalkConfigDir(agentDir)
-      await mkdir(configDir, { recursive: true })
+      await mkdir(agentDir, { recursive: true })
       await writeFile(
-        join(configDir, 'kakaotalk-pending-login.json'),
+        kakaotalkSecretsPath(agentDir),
         JSON.stringify({
-          device_uuid: 'previous-uuid',
-          device_type: 'tablet',
-          email: 'u@e.com',
-          created_at: new Date().toISOString(),
+          version: 1,
+          llm: {},
+          channels: {
+            kakaotalk: {
+              currentAccount: null,
+              accounts: {},
+              pendingLogin: {
+                device_uuid: 'previous-uuid',
+                device_type: 'tablet',
+                email: 'u@e.com',
+                created_at: new Date().toISOString(),
+              },
+            },
+          },
         }),
       )
       let received: string | undefined
@@ -180,9 +194,10 @@ describe('runKakaotalkBootstrap', () => {
         loginFlow: fake,
       })
       expect(result).toEqual({ ok: true })
-      const credPath = join(kakaotalkConfigDir(agentDir), 'kakaotalk-credentials.json')
-      const stored = JSON.parse(await readFile(credPath, 'utf8')) as { current_account: string }
-      expect(stored.current_account).toBe('default')
+      const stored = JSON.parse(await readFile(kakaotalkSecretsPath(agentDir), 'utf8')) as {
+        channels: { kakaotalk: { currentAccount: string } }
+      }
+      expect(stored.channels.kakaotalk.currentAccount).toBe('default')
     } finally {
       await rm(agentDir, { recursive: true, force: true })
     }

--- a/src/init/kakaotalk-auth.ts
+++ b/src/init/kakaotalk-auth.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module'
 import { join } from 'node:path'
 
-import { KakaoCredentialManager } from 'agent-messenger/kakaotalk'
+import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 
 export type KakaotalkBootstrapStatus = { ok: true } | { ok: false; reason: string }
 
@@ -50,11 +50,17 @@ export function kakaotalkConfigDir(agentDir: string): string {
   return join(agentDir, 'workspace', '.agent-messenger')
 }
 
+export function kakaotalkSecretsPath(agentDir: string): string {
+  return join(agentDir, 'secrets.json')
+}
+
 export async function runKakaotalkBootstrap(input: KakaotalkLoginInput): Promise<KakaotalkBootstrapStatus> {
-  const configDir = kakaotalkConfigDir(input.agentDir)
   try {
     const loginFlow = input.loginFlow ?? (await resolveLoginFlow())
-    const credManager = new KakaoCredentialManager(configDir)
+    const credManager = new SecretsKakaoCredentialStore({
+      mode: 'host',
+      secretsPath: kakaotalkSecretsPath(input.agentDir),
+    })
     const pending = await credManager.loadPendingLogin()
     const existing = await credManager.getAccount()
     const savedDeviceUuid =

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -5,3 +5,5 @@ export { createSecretsStoreForAgent, SecretsBackend } from './storage'
 export { type Secret } from './resolve'
 
 export { hydrateChannelEnvFromSecrets } from './hydrate'
+
+export { migrateKakaotalkCredentials } from './migrate-kakaotalk'

--- a/src/secrets/kakao-store.container-mode.test.ts
+++ b/src/secrets/kakao-store.container-mode.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { KakaoAccountCredentials } from 'agent-messenger/kakaotalk'
+
+import type { Request, Response } from '@/hostd/protocol'
+
+import { SecretsKakaoCredentialStore } from './kakao-store'
+import { kakaoChannelBlockSchema } from './schema'
+import { SecretsBackend } from './storage'
+
+const servers: Array<ReturnType<typeof Bun.serve>> = []
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop(true)
+})
+
+function account(id: string, overrides: Partial<KakaoAccountCredentials> = {}): KakaoAccountCredentials {
+  return {
+    account_id: id,
+    oauth_token: `oauth-${id}`,
+    user_id: id,
+    refresh_token: `refresh-${id}`,
+    device_uuid: `device-${id}`,
+    device_type: 'tablet',
+    auth_method: 'login',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function startFakeHostd(
+  secretsPath: string,
+  token: string,
+  containerName: string,
+): { url: string; patches: Request[] } {
+  const patches: Request[] = []
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      if (req.headers.get('authorization') !== `Bearer ${token}`) {
+        return json({ ok: false, reason: 'invalid restart token' }, 403)
+      }
+      const rpc = (await req.json()) as Request
+      patches.push(rpc)
+      if (rpc.kind !== 'secrets-patch') return json({ ok: false, reason: 'unsupported' }, 403)
+      if (rpc.containerName !== containerName) return json({ ok: false, reason: 'not registered' }, 403)
+      const block = kakaoChannelBlockSchema.parse(rpc.patch.channels.kakaotalk)
+      await new SecretsBackend(secretsPath).updateChannelsAsync(async (channels) => ({
+        result: undefined,
+        next: { ...channels, kakaotalk: block },
+      }))
+      return json({ ok: true, result: { containerName, patched: true } })
+    },
+  })
+  servers.push(server)
+  return { url: `http://127.0.0.1:${server.port}`, patches }
+}
+
+describe('SecretsKakaoCredentialStore container mode', () => {
+  test('routes writes through secrets-patch and reads the updated local envelope', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-store-container-'))
+    try {
+      const secretsPath = join(root, 'secrets.json')
+      new SecretsBackend(secretsPath).writeChannelsSync({})
+      const hostd = startFakeHostd(secretsPath, 'secret', 'coder')
+      const store = new SecretsKakaoCredentialStore({
+        mode: 'container',
+        secretsPath,
+        hostdUrl: hostd.url,
+        restartToken: 'secret',
+        containerName: 'coder',
+      })
+
+      await store.setAccount(account('user-1'))
+
+      expect(hostd.patches).toHaveLength(1)
+      expect(hostd.patches[0]?.kind).toBe('secrets-patch')
+      expect(await store.getAccount()).toEqual(account('user-1'))
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('surfaces hostd write failures', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-store-container-'))
+    try {
+      const secretsPath = join(root, 'secrets.json')
+      new SecretsBackend(secretsPath).writeChannelsSync({})
+      const hostd = startFakeHostd(secretsPath, 'secret', 'coder')
+      const store = new SecretsKakaoCredentialStore({
+        mode: 'container',
+        secretsPath,
+        hostdUrl: hostd.url,
+        restartToken: 'wrong',
+        containerName: 'coder',
+      })
+
+      await expect(store.setAccount(account('user-1'))).rejects.toThrow(/secrets-patch failed/)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+function json(response: Response, status = 200): globalThis.Response {
+  return new Response(JSON.stringify(response), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}

--- a/src/secrets/kakao-store.container-mode.test.ts
+++ b/src/secrets/kakao-store.container-mode.test.ts
@@ -85,6 +85,29 @@ describe('SecretsKakaoCredentialStore container mode', () => {
     }
   })
 
+  test('serializes concurrent writes before sending full-block patches', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-store-container-'))
+    try {
+      const secretsPath = join(root, 'secrets.json')
+      new SecretsBackend(secretsPath).writeChannelsSync({})
+      const hostd = startFakeHostd(secretsPath, 'secret', 'coder')
+      const store = new SecretsKakaoCredentialStore({
+        mode: 'container',
+        secretsPath,
+        hostdUrl: hostd.url,
+        restartToken: 'secret',
+        containerName: 'coder',
+      })
+
+      await Promise.all([store.setAccount(account('user-1')), store.setAccount(account('user-2'))])
+
+      const loaded = await store.load()
+      expect(Object.keys(loaded.accounts).sort()).toEqual(['user-1', 'user-2'])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test('surfaces hostd write failures', async () => {
     const root = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-store-container-'))
     try {

--- a/src/secrets/kakao-store.container-mode.test.ts
+++ b/src/secrets/kakao-store.container-mode.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -61,6 +62,25 @@ function startFakeHostd(
 }
 
 describe('SecretsKakaoCredentialStore container mode', () => {
+  test('reads an absent secrets.json as empty without creating it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-store-container-'))
+    try {
+      const secretsPath = join(root, 'secrets.json')
+      const store = new SecretsKakaoCredentialStore({
+        mode: 'container',
+        secretsPath,
+        hostdUrl: 'http://127.0.0.1:1',
+        restartToken: 'secret',
+        containerName: 'coder',
+      })
+
+      expect(await store.load()).toEqual({ current_account: null, accounts: {} })
+      expect(existsSync(secretsPath)).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test('routes writes through secrets-patch and reads the updated local envelope', async () => {
     const root = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-store-container-'))
     try {

--- a/src/secrets/kakao-store.test.ts
+++ b/src/secrets/kakao-store.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { KakaoAccountCredentials, PendingLoginState } from 'agent-messenger/kakaotalk'
+
+import { SecretsKakaoCredentialStore } from './kakao-store'
+
+async function withStore<T>(fn: (store: SecretsKakaoCredentialStore, secretsPath: string) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-store-'))
+  try {
+    const secretsPath = join(root, 'secrets.json')
+    return await fn(new SecretsKakaoCredentialStore({ mode: 'host', secretsPath }), secretsPath)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+function account(id: string, overrides: Partial<KakaoAccountCredentials> = {}): KakaoAccountCredentials {
+  return {
+    account_id: id,
+    oauth_token: `oauth-${id}`,
+    user_id: id,
+    refresh_token: `refresh-${id}`,
+    device_uuid: `device-${id}`,
+    device_type: 'tablet',
+    auth_method: 'login',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('SecretsKakaoCredentialStore host mode', () => {
+  test('round-trips setAccount through secrets.json', async () => {
+    await withStore(async (store, secretsPath) => {
+      await store.setAccount(account('user-1'))
+
+      expect(await store.getAccount()).toEqual(account('user-1'))
+      const raw = JSON.parse(await readFile(secretsPath, 'utf8')) as { channels: Record<string, unknown> }
+      expect(raw.channels.kakaotalk).toEqual({ currentAccount: 'user-1', accounts: { 'user-1': account('user-1') } })
+    })
+  })
+
+  test('supports multiple accounts and current account switching', async () => {
+    await withStore(async (store) => {
+      await store.setAccount(account('user-1'))
+      await store.setAccount(account('user-2'))
+      await store.setCurrentAccount('user-2')
+
+      expect(await store.getAccount()).toEqual(account('user-2'))
+      expect(await store.getAccount('user-1')).toEqual(account('user-1'))
+      expect(await store.listAccounts()).toEqual([
+        { ...account('user-1'), is_current: false },
+        { ...account('user-2'), is_current: true },
+      ])
+    })
+  })
+
+  test('removeAccount deletes the account and picks a replacement current account', async () => {
+    await withStore(async (store) => {
+      await store.setAccount(account('user-1'))
+      await store.setAccount(account('user-2'))
+      await store.removeAccount('user-1')
+
+      expect(await store.getAccount('user-1')).toBeNull()
+      expect((await store.load()).current_account).toBe('user-2')
+    })
+  })
+
+  test('round-trips pending login state', async () => {
+    await withStore(async (store) => {
+      const pending: PendingLoginState = {
+        device_uuid: 'pending-device',
+        device_type: 'tablet',
+        email: 'user@example.com',
+        created_at: '2026-01-01T00:00:00.000Z',
+      }
+
+      await store.savePendingLogin(pending)
+      expect(await store.loadPendingLogin()).toEqual(pending)
+      await store.clearPendingLogin()
+      expect(await store.loadPendingLogin()).toBeNull()
+    })
+  })
+
+  test('serializes concurrent setAccount calls without losing accounts', async () => {
+    await withStore(async (store) => {
+      await Promise.all([store.setAccount(account('user-1')), store.setAccount(account('user-2'))])
+
+      const loaded = await store.load()
+      expect(Object.keys(loaded.accounts).sort()).toEqual(['user-1', 'user-2'])
+    })
+  })
+})

--- a/src/secrets/kakao-store.ts
+++ b/src/secrets/kakao-store.ts
@@ -79,7 +79,9 @@ export class SecretsKakaoCredentialStore {
   }
 
   private readBlock(): KakaoChannelBlock {
-    const raw = this.backend.readChannelsSync().kakaotalk
+    const channels =
+      this.options.mode === 'container' ? this.backend.tryReadChannelsSync() : this.backend.readChannelsSync()
+    const raw = channels?.kakaotalk
     return parseBlock(raw)
   }
 

--- a/src/secrets/kakao-store.ts
+++ b/src/secrets/kakao-store.ts
@@ -1,10 +1,14 @@
 import type { KakaoAccountCredentials, KakaoConfig } from 'agent-messenger/kakaotalk'
 import type { PendingLoginState } from 'agent-messenger/kakaotalk'
 
+import { sendHttp } from '@/hostd/client'
+
 import { type KakaoChannelBlock, kakaoChannelBlockSchema } from './schema'
 import { SecretsBackend } from './storage'
 
-export type SecretsKakaoCredentialStoreOptions = { mode: 'host'; secretsPath: string }
+export type SecretsKakaoCredentialStoreOptions =
+  | { mode: 'host'; secretsPath: string }
+  | { mode: 'container'; secretsPath: string; hostdUrl: string; restartToken: string; containerName: string }
 
 const EMPTY_BLOCK: KakaoChannelBlock = { currentAccount: null, accounts: {} }
 
@@ -79,6 +83,16 @@ export class SecretsKakaoCredentialStore {
   }
 
   private async writeBlock(update: (current: KakaoChannelBlock) => KakaoChannelBlock): Promise<void> {
+    if (this.options.mode === 'container') {
+      const next = update(this.readBlock())
+      const response = await sendHttp(
+        { kind: 'secrets-patch', containerName: this.options.containerName, patch: { channels: { kakaotalk: next } } },
+        { url: this.options.hostdUrl, token: this.options.restartToken },
+      )
+      if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+      return
+    }
+
     await this.backend.updateChannelsAsync(async (channels) => {
       const next = { ...channels, kakaotalk: update(parseBlock(channels.kakaotalk)) }
       return { result: undefined, next }

--- a/src/secrets/kakao-store.ts
+++ b/src/secrets/kakao-store.ts
@@ -1,0 +1,100 @@
+import type { KakaoAccountCredentials, KakaoConfig } from 'agent-messenger/kakaotalk'
+import type { PendingLoginState } from 'agent-messenger/kakaotalk'
+
+import { type KakaoChannelBlock, kakaoChannelBlockSchema } from './schema'
+import { SecretsBackend } from './storage'
+
+export type SecretsKakaoCredentialStoreOptions = { mode: 'host'; secretsPath: string }
+
+const EMPTY_BLOCK: KakaoChannelBlock = { currentAccount: null, accounts: {} }
+
+export class SecretsKakaoCredentialStore {
+  private readonly backend: SecretsBackend
+
+  constructor(private readonly options: SecretsKakaoCredentialStoreOptions) {
+    this.backend = new SecretsBackend(options.secretsPath)
+  }
+
+  async load(): Promise<KakaoConfig> {
+    return toKakaoConfig(this.readBlock())
+  }
+
+  async save(config: KakaoConfig): Promise<void> {
+    await this.writeBlock(() => fromKakaoConfig(config))
+  }
+
+  async getAccount(id?: string): Promise<KakaoAccountCredentials | null> {
+    const config = await this.load()
+    if (id) return config.accounts[id] ?? null
+    if (!config.current_account) return null
+    return config.accounts[config.current_account] ?? null
+  }
+
+  async setAccount(account: KakaoAccountCredentials): Promise<void> {
+    await this.writeBlock((block) => {
+      const accounts = { ...block.accounts, [account.account_id]: account }
+      return { ...block, currentAccount: block.currentAccount ?? account.account_id, accounts }
+    })
+  }
+
+  async removeAccount(id: string): Promise<void> {
+    await this.writeBlock((block) => {
+      const accounts = { ...block.accounts }
+      delete accounts[id]
+      const currentAccount = block.currentAccount === id ? (Object.keys(accounts)[0] ?? null) : block.currentAccount
+      return { ...block, currentAccount, accounts }
+    })
+  }
+
+  async listAccounts(): Promise<Array<KakaoAccountCredentials & { is_current: boolean }>> {
+    const config = await this.load()
+    return Object.values(config.accounts).map((account) => ({
+      ...account,
+      is_current: account.account_id === config.current_account,
+    }))
+  }
+
+  async setCurrentAccount(id: string): Promise<void> {
+    await this.writeBlock((block) => ({ ...block, currentAccount: id }))
+  }
+
+  async savePendingLogin(state: PendingLoginState): Promise<void> {
+    await this.writeBlock((block) => ({ ...block, pendingLogin: state }))
+  }
+
+  async loadPendingLogin(): Promise<PendingLoginState | null> {
+    return this.readBlock().pendingLogin ?? null
+  }
+
+  async clearPendingLogin(): Promise<void> {
+    await this.writeBlock((block) => {
+      const { pendingLogin: _pendingLogin, ...next } = block
+      return next
+    })
+  }
+
+  private readBlock(): KakaoChannelBlock {
+    const raw = this.backend.readChannelsSync().kakaotalk
+    return parseBlock(raw)
+  }
+
+  private async writeBlock(update: (current: KakaoChannelBlock) => KakaoChannelBlock): Promise<void> {
+    await this.backend.updateChannelsAsync(async (channels) => {
+      const next = { ...channels, kakaotalk: update(parseBlock(channels.kakaotalk)) }
+      return { result: undefined, next }
+    })
+  }
+}
+
+function parseBlock(value: unknown): KakaoChannelBlock {
+  if (value === undefined) return EMPTY_BLOCK
+  return kakaoChannelBlockSchema.parse(value)
+}
+
+function toKakaoConfig(block: KakaoChannelBlock): KakaoConfig {
+  return { current_account: block.currentAccount, accounts: block.accounts }
+}
+
+function fromKakaoConfig(config: KakaoConfig): KakaoChannelBlock {
+  return { currentAccount: config.current_account, accounts: config.accounts }
+}

--- a/src/secrets/kakao-store.ts
+++ b/src/secrets/kakao-store.ts
@@ -14,6 +14,7 @@ const EMPTY_BLOCK: KakaoChannelBlock = { currentAccount: null, accounts: {} }
 
 export class SecretsKakaoCredentialStore {
   private readonly backend: SecretsBackend
+  private writeChain: Promise<void> = Promise.resolve()
 
   constructor(private readonly options: SecretsKakaoCredentialStoreOptions) {
     this.backend = new SecretsBackend(options.secretsPath)
@@ -83,20 +84,32 @@ export class SecretsKakaoCredentialStore {
   }
 
   private async writeBlock(update: (current: KakaoChannelBlock) => KakaoChannelBlock): Promise<void> {
-    if (this.options.mode === 'container') {
-      const next = update(this.readBlock())
-      const response = await sendHttp(
-        { kind: 'secrets-patch', containerName: this.options.containerName, patch: { channels: { kakaotalk: next } } },
-        { url: this.options.hostdUrl, token: this.options.restartToken },
-      )
-      if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
-      return
-    }
+    return this.enqueueWrite(async () => {
+      if (this.options.mode === 'container') {
+        const next = update(this.readBlock())
+        const response = await sendHttp(
+          {
+            kind: 'secrets-patch',
+            containerName: this.options.containerName,
+            patch: { channels: { kakaotalk: next } },
+          },
+          { url: this.options.hostdUrl, token: this.options.restartToken },
+        )
+        if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+        return
+      }
 
-    await this.backend.updateChannelsAsync(async (channels) => {
-      const next = { ...channels, kakaotalk: update(parseBlock(channels.kakaotalk)) }
-      return { result: undefined, next }
+      await this.backend.updateChannelsAsync(async (channels) => {
+        const next = { ...channels, kakaotalk: update(parseBlock(channels.kakaotalk)) }
+        return { result: undefined, next }
+      })
     })
+  }
+
+  private enqueueWrite(op: () => Promise<void>): Promise<void> {
+    const next = this.writeChain.then(op, op)
+    this.writeChain = next.catch(() => {})
+    return next
   }
 }
 

--- a/src/secrets/migrate-kakaotalk.test.ts
+++ b/src/secrets/migrate-kakaotalk.test.ts
@@ -98,7 +98,7 @@ describe('migrateKakaotalkCredentials', () => {
       }
       await writeFile(
         join(root, 'secrets.json'),
-        JSON.stringify({ version: 1, llm: {}, channels: { kakaotalk: existing } }),
+        JSON.stringify({ version: 2, providers: {}, channels: { kakaotalk: existing } }),
       )
 
       const result = await migrateKakaotalkCredentials(root)
@@ -143,7 +143,7 @@ describe('migrateKakaotalkCredentials', () => {
       }
       await writeFile(
         join(root, 'secrets.json'),
-        JSON.stringify({ version: 1, llm: {}, channels: { kakaotalk: existing } }),
+        JSON.stringify({ version: 2, providers: {}, channels: { kakaotalk: existing } }),
       )
 
       const result = await migrateKakaotalkCredentials(root)

--- a/src/secrets/migrate-kakaotalk.test.ts
+++ b/src/secrets/migrate-kakaotalk.test.ts
@@ -103,12 +103,63 @@ describe('migrateKakaotalkCredentials', () => {
 
       const result = await migrateKakaotalkCredentials(root)
 
-      expect(result.promoted).toBe(false)
+      expect(result.promoted).toBe(true)
       const secrets = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
-        channels: { kakaotalk: unknown }
+        channels: { kakaotalk: { pendingLogin?: unknown } }
       }
-      expect(secrets.channels.kakaotalk).toEqual(existing)
+      expect(secrets.channels.kakaotalk).toEqual({
+        ...existing,
+        pendingLogin: {
+          device_uuid: 'pending-device',
+          device_type: 'tablet',
+          email: 'user@example.com',
+          created_at: '2026-01-01T00:00:00.000Z',
+        },
+      })
       expect(existsSync(join(legacyDir, 'kakaotalk-credentials.json'))).toBe(true)
+      expect(existsSync(join(legacyDir, 'kakaotalk-pending-login.json'))).toBe(false)
+      expect(existsSync(join(legacyDir, 'kakaotalk-pending-login.json.migrated'))).toBe(true)
+    })
+  })
+
+  test('resumes a partial migration by importing only leftover pending login state', async () => {
+    await withAgent(async (root, legacyDir) => {
+      await writeLegacyFiles(legacyDir)
+      const existing = {
+        currentAccount: 'user-1',
+        accounts: {
+          'user-1': {
+            account_id: 'user-1',
+            oauth_token: 'oauth-user-1',
+            user_id: 'user-1',
+            refresh_token: 'refresh-user-1',
+            device_uuid: 'device-user-1',
+            device_type: 'tablet',
+            auth_method: 'login',
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      }
+      await writeFile(
+        join(root, 'secrets.json'),
+        JSON.stringify({ version: 1, llm: {}, channels: { kakaotalk: existing } }),
+      )
+
+      const result = await migrateKakaotalkCredentials(root)
+
+      expect(result.promoted).toBe(true)
+      const secrets = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+        channels: { kakaotalk: { pendingLogin?: unknown } }
+      }
+      expect(secrets.channels.kakaotalk.pendingLogin).toEqual({
+        device_uuid: 'pending-device',
+        device_type: 'tablet',
+        email: 'user@example.com',
+        created_at: '2026-01-01T00:00:00.000Z',
+      })
+      expect(existsSync(join(legacyDir, 'kakaotalk-credentials.json'))).toBe(true)
+      expect(existsSync(join(legacyDir, 'kakaotalk-pending-login.json'))).toBe(false)
     })
   })
 })

--- a/src/secrets/migrate-kakaotalk.test.ts
+++ b/src/secrets/migrate-kakaotalk.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { migrateKakaotalkCredentials } from './migrate-kakaotalk'
+
+async function withAgent<T>(fn: (root: string, legacyDir: string) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), 'typeclaw-kakao-migrate-'))
+  try {
+    const legacyDir = join(root, 'workspace', '.agent-messenger')
+    await mkdir(legacyDir, { recursive: true })
+    return await fn(root, legacyDir)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+async function writeLegacyFiles(legacyDir: string): Promise<void> {
+  await writeFile(
+    join(legacyDir, 'kakaotalk-credentials.json'),
+    JSON.stringify({
+      current_account: 'user-1',
+      accounts: {
+        'user-1': {
+          account_id: 'user-1',
+          oauth_token: 'oauth-user-1',
+          user_id: 'user-1',
+          refresh_token: 'refresh-user-1',
+          device_uuid: 'device-user-1',
+          device_type: 'tablet',
+          auth_method: 'login',
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    }),
+  )
+  await writeFile(
+    join(legacyDir, 'kakaotalk-pending-login.json'),
+    JSON.stringify({
+      device_uuid: 'pending-device',
+      device_type: 'tablet',
+      email: 'user@example.com',
+      created_at: '2026-01-01T00:00:00.000Z',
+    }),
+  )
+}
+
+describe('migrateKakaotalkCredentials', () => {
+  test('promotes legacy files into secrets.json and renames the sources', async () => {
+    await withAgent(async (root, legacyDir) => {
+      await writeLegacyFiles(legacyDir)
+
+      const result = await migrateKakaotalkCredentials(root)
+
+      expect(result.promoted).toBe(true)
+      const secrets = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+        channels: {
+          kakaotalk?: { currentAccount: string | null; accounts: Record<string, unknown>; pendingLogin?: unknown }
+        }
+      }
+      expect(secrets.channels.kakaotalk?.currentAccount).toBe('user-1')
+      expect(secrets.channels.kakaotalk?.accounts['user-1']).toBeDefined()
+      expect(secrets.channels.kakaotalk?.pendingLogin).toEqual({
+        device_uuid: 'pending-device',
+        device_type: 'tablet',
+        email: 'user@example.com',
+        created_at: '2026-01-01T00:00:00.000Z',
+      })
+      expect(existsSync(join(legacyDir, 'kakaotalk-credentials.json'))).toBe(false)
+      expect(existsSync(join(legacyDir, 'kakaotalk-credentials.json.migrated'))).toBe(true)
+      expect(existsSync(join(legacyDir, 'kakaotalk-pending-login.json.migrated'))).toBe(true)
+
+      const second = await migrateKakaotalkCredentials(root)
+      expect(second.promoted).toBe(false)
+      expect(JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8'))).toEqual(secrets)
+    })
+  })
+
+  test('does not overwrite an existing kakaotalk secrets block', async () => {
+    await withAgent(async (root, legacyDir) => {
+      await writeLegacyFiles(legacyDir)
+      const existing = {
+        currentAccount: 'existing-user',
+        accounts: {
+          'existing-user': {
+            account_id: 'existing-user',
+            oauth_token: 'keep',
+            user_id: 'existing-user',
+            device_uuid: 'existing-device',
+            device_type: 'tablet',
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      }
+      await writeFile(
+        join(root, 'secrets.json'),
+        JSON.stringify({ version: 1, llm: {}, channels: { kakaotalk: existing } }),
+      )
+
+      const result = await migrateKakaotalkCredentials(root)
+
+      expect(result.promoted).toBe(false)
+      const secrets = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+        channels: { kakaotalk: unknown }
+      }
+      expect(secrets.channels.kakaotalk).toEqual(existing)
+      expect(existsSync(join(legacyDir, 'kakaotalk-credentials.json'))).toBe(true)
+    })
+  })
+})

--- a/src/secrets/migrate-kakaotalk.ts
+++ b/src/secrets/migrate-kakaotalk.ts
@@ -1,0 +1,56 @@
+import { existsSync } from 'node:fs'
+import { rename } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { KakaoCredentialManager } from 'agent-messenger/kakaotalk'
+
+import { SecretsKakaoCredentialStore } from './kakao-store'
+import { type KakaoChannelBlock, kakaoChannelBlockSchema } from './schema'
+import { SecretsBackend } from './storage'
+
+const KAKAO_CONFIG_DIR = join('workspace', '.agent-messenger')
+const CREDENTIALS_FILE = 'kakaotalk-credentials.json'
+const PENDING_LOGIN_FILE = 'kakaotalk-pending-login.json'
+
+export type KakaotalkCredentialMigrationResult = { promoted: boolean }
+
+export async function migrateKakaotalkCredentials(agentDir: string): Promise<KakaotalkCredentialMigrationResult> {
+  const configDir = join(agentDir, KAKAO_CONFIG_DIR)
+  const credentialsPath = join(configDir, CREDENTIALS_FILE)
+  const pendingLoginPath = join(configDir, PENDING_LOGIN_FILE)
+  if (!existsSync(credentialsPath) && !existsSync(pendingLoginPath)) return { promoted: false }
+
+  const secretsPath = join(agentDir, 'secrets.json')
+  const existing = parseExistingBlock(new SecretsBackend(secretsPath).readChannelsSync().kakaotalk)
+  if (!isEmptyBlock(existing)) return { promoted: false }
+
+  const legacy = new KakaoCredentialManager(configDir)
+  const config = await legacy.load()
+  const pendingLogin = await legacy.loadPendingLogin()
+  if (Object.keys(config.accounts).length === 0 && pendingLogin === null) return { promoted: false }
+
+  const store = new SecretsKakaoCredentialStore({ mode: 'host', secretsPath })
+  await store.save(config)
+  if (pendingLogin) await store.savePendingLogin(pendingLogin)
+
+  await renameIfPresent(credentialsPath, `${credentialsPath}.migrated`)
+  await renameIfPresent(pendingLoginPath, `${pendingLoginPath}.migrated`)
+  return { promoted: true }
+}
+
+function parseExistingBlock(value: unknown): KakaoChannelBlock | null {
+  if (value === undefined) return null
+  return kakaoChannelBlockSchema.parse(value)
+}
+
+function isEmptyBlock(block: KakaoChannelBlock | null): boolean {
+  return (
+    block === null ||
+    (block.currentAccount === null && Object.keys(block.accounts).length === 0 && block.pendingLogin === undefined)
+  )
+}
+
+async function renameIfPresent(from: string, to: string): Promise<void> {
+  if (!existsSync(from)) return
+  await rename(from, to)
+}

--- a/src/secrets/migrate-kakaotalk.ts
+++ b/src/secrets/migrate-kakaotalk.ts
@@ -3,8 +3,8 @@ import { rename } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { KakaoCredentialManager } from 'agent-messenger/kakaotalk'
+import type { KakaoConfig, PendingLoginState } from 'agent-messenger/kakaotalk'
 
-import { SecretsKakaoCredentialStore } from './kakao-store'
 import { type KakaoChannelBlock, kakaoChannelBlockSchema } from './schema'
 import { SecretsBackend } from './storage'
 
@@ -21,20 +21,30 @@ export async function migrateKakaotalkCredentials(agentDir: string): Promise<Kak
   if (!existsSync(credentialsPath) && !existsSync(pendingLoginPath)) return { promoted: false }
 
   const secretsPath = join(agentDir, 'secrets.json')
-  const existing = parseExistingBlock(new SecretsBackend(secretsPath).readChannelsSync().kakaotalk)
-  if (!isEmptyBlock(existing)) return { promoted: false }
-
   const legacy = new KakaoCredentialManager(configDir)
   const config = await legacy.load()
   const pendingLogin = await legacy.loadPendingLogin()
   if (Object.keys(config.accounts).length === 0 && pendingLogin === null) return { promoted: false }
 
-  const store = new SecretsKakaoCredentialStore({ mode: 'host', secretsPath })
-  await store.save(config)
-  if (pendingLogin) await store.savePendingLogin(pendingLogin)
+  const backend = new SecretsBackend(secretsPath)
+  const result = await backend.updateChannelsAsync(async (channels) => {
+    const existing = parseExistingBlock(channels.kakaotalk)
+    const next = mergeLegacyBlock(existing, config, pendingLogin)
+    if (next === existing) return { result: { promoted: false, renameCredentials: false, renamePending: false } }
 
-  await renameIfPresent(credentialsPath, `${credentialsPath}.migrated`)
-  await renameIfPresent(pendingLoginPath, `${pendingLoginPath}.migrated`)
+    return {
+      result: {
+        promoted: true,
+        renameCredentials: isEmptyBlock(existing) && Object.keys(config.accounts).length > 0,
+        renamePending: pendingLogin !== null && existing?.pendingLogin === undefined,
+      },
+      next: { ...channels, kakaotalk: next },
+    }
+  })
+  if (!result.promoted) return { promoted: false }
+
+  if (result.renameCredentials) await renameIfPresent(credentialsPath, `${credentialsPath}.migrated`)
+  if (result.renamePending) await renameIfPresent(pendingLoginPath, `${pendingLoginPath}.migrated`)
   return { promoted: true }
 }
 
@@ -48,6 +58,22 @@ function isEmptyBlock(block: KakaoChannelBlock | null): boolean {
     block === null ||
     (block.currentAccount === null && Object.keys(block.accounts).length === 0 && block.pendingLogin === undefined)
   )
+}
+
+function mergeLegacyBlock(
+  existing: KakaoChannelBlock | null,
+  config: KakaoConfig,
+  pendingLogin: PendingLoginState | null,
+): KakaoChannelBlock | null {
+  if (existing === null || isEmptyBlock(existing)) {
+    return {
+      currentAccount: config.current_account,
+      accounts: config.accounts,
+      ...(pendingLogin ? { pendingLogin } : {}),
+    }
+  }
+  if (pendingLogin === null || existing.pendingLogin !== undefined) return existing
+  return { ...existing, pendingLogin }
 }
 
 async function renameIfPresent(from: string, to: string): Promise<void> {

--- a/src/secrets/schema.test.ts
+++ b/src/secrets/schema.test.ts
@@ -61,6 +61,80 @@ describe('parseSecretsFile (v2 envelope)', () => {
     expect(result.file.channels['discord-bot']).toEqual({ token: { env: 'CUSTOM_DISCORD' } })
   })
 
+  test('accepts channels.kakaotalk credential block', () => {
+    const result = parseSecretsFile({
+      version: 2,
+      channels: {
+        kakaotalk: {
+          currentAccount: 'user-1',
+          accounts: {
+            'user-1': {
+              account_id: 'user-1',
+              oauth_token: 'oauth-token',
+              user_id: 'user-1',
+              refresh_token: 'refresh-token',
+              device_uuid: 'device-uuid',
+              device_type: 'tablet',
+              auth_method: 'login',
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
+          },
+          pendingLogin: {
+            device_uuid: 'pending-device',
+            device_type: 'tablet',
+            email: 'user@example.com',
+            created_at: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.file.channels.kakaotalk?.currentAccount).toBe('user-1')
+    expect(result.file.channels.kakaotalk?.accounts['user-1']?.oauth_token).toBe('oauth-token')
+    expect(result.file.channels.kakaotalk?.pendingLogin?.email).toBe('user@example.com')
+  })
+
+  test('accepts empty channels.kakaotalk block', () => {
+    const result = parseSecretsFile({ version: 2, channels: { kakaotalk: { currentAccount: null, accounts: {} } } })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.file.channels.kakaotalk).toEqual({ currentAccount: null, accounts: {} })
+  })
+
+  test('rejects malformed channels.kakaotalk account block', () => {
+    const result = parseSecretsFile({
+      version: 2,
+      channels: {
+        kakaotalk: {
+          currentAccount: 'user-1',
+          accounts: {
+            'user-1': { account_id: 'user-1', oauth_token: 'oauth-token' },
+          },
+        },
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('channels.kakaotalk.accounts.user-1.user_id')
+  })
+
+  test('upgrades legacy flat shape with at least one credential', () => {
+    const result = parseSecretsFile({
+      openai: { type: 'api_key', key: 'sk-test' },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.file.version).toBe(SECRETS_FILE_VERSION)
+    expect(result.file.providers.openai).toEqual({ type: 'api_key', key: { value: 'sk-test' } })
+    expect(result.file.channels).toEqual({})
+  })
+
   test('preserves passthrough fields on OAuth credentials so upstream additions survive', () => {
     const result = parseSecretsFile({
       version: 2,

--- a/src/secrets/schema.ts
+++ b/src/secrets/schema.ts
@@ -40,11 +40,37 @@ const telegramBotChannelSchema = z.object({
   token: secretFieldSchema.optional(),
 })
 
+export const kakaoAccountRecordSchema = z.object({
+  account_id: z.string(),
+  oauth_token: z.string(),
+  user_id: z.string(),
+  refresh_token: z.string().optional(),
+  device_uuid: z.string(),
+  device_type: z.union([z.literal('pc'), z.literal('tablet')]),
+  auth_method: z.union([z.literal('login'), z.literal('extract')]).optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export const kakaoPendingLoginRecordSchema = z.object({
+  device_uuid: z.string(),
+  device_type: z.union([z.literal('pc'), z.literal('tablet')]),
+  email: z.string(),
+  created_at: z.string(),
+})
+
+export const kakaoChannelBlockSchema = z.object({
+  currentAccount: z.string().nullable(),
+  accounts: z.record(z.string(), kakaoAccountRecordSchema),
+  pendingLogin: kakaoPendingLoginRecordSchema.optional(),
+})
+
 export const channelsSchema = z
   .object({
     'slack-bot': slackBotChannelSchema.optional(),
     'discord-bot': discordBotChannelSchema.optional(),
     'telegram-bot': telegramBotChannelSchema.optional(),
+    kakaotalk: kakaoChannelBlockSchema.optional(),
   })
   .catchall(z.unknown())
 
@@ -64,6 +90,9 @@ export const secretsFileSchema = z.object({
 export type ProviderCredential = z.infer<typeof providerCredentialSchema>
 export type Providers = z.infer<typeof providersSchema>
 export type Channels = z.infer<typeof channelsSchema>
+export type KakaoAccountRecord = z.infer<typeof kakaoAccountRecordSchema>
+export type PendingLoginRecord = z.infer<typeof kakaoPendingLoginRecordSchema>
+export type KakaoChannelBlock = z.infer<typeof kakaoChannelBlockSchema>
 export type SecretsFile = z.infer<typeof secretsFileSchema>
 
 export type ParseSecretsResult = { ok: true; file: SecretsFile } | { ok: false; reason: string }

--- a/src/secrets/storage.ts
+++ b/src/secrets/storage.ts
@@ -149,6 +149,17 @@ export class SecretsBackend implements AuthStorageBackend {
     }
   }
 
+  tryReadChannelsSync(): Channels | null {
+    if (!existsSync(this.secretsPath)) return null
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      return this.readEnvelope().channels
+    } finally {
+      release?.()
+    }
+  }
+
   writeChannelsSync(next: Channels): void {
     this.ensureParentDir()
     this.ensureFileExists()

--- a/src/secrets/storage.ts
+++ b/src/secrets/storage.ts
@@ -168,6 +168,50 @@ export class SecretsBackend implements AuthStorageBackend {
     }
   }
 
+  async updateChannelsAsync<T>(
+    fn: (current: Record<string, unknown>) => Promise<{ result: T; next?: Record<string, unknown> }>,
+  ): Promise<T> {
+    this.ensureParentDir()
+    this.ensureFileExists()
+    let release: (() => Promise<void>) | undefined
+    let lockCompromised = false
+    let lockCompromisedError: Error | undefined
+    const throwIfCompromised = (): void => {
+      if (lockCompromised) {
+        throw lockCompromisedError ?? new Error('Secrets store lock was compromised')
+      }
+    }
+    try {
+      release = await lockfile.lock(this.secretsPath, {
+        ...ASYNC_LOCK_OPTIONS,
+        onCompromised: (err: Error) => {
+          lockCompromised = true
+          lockCompromisedError = err
+        },
+      })
+      throwIfCompromised()
+      const envelope = this.readEnvelope()
+      const { result, next } = await fn(envelope.channels as Record<string, unknown>)
+      throwIfCompromised()
+      if (next !== undefined) {
+        const merged: SecretsFile = {
+          ...envelope,
+          $schema: envelope.$schema ?? SCHEMA_REL,
+          channels: next as SecretsFile['channels'],
+        }
+        this.writeEnvelopeAtomic(merged)
+      }
+      throwIfCompromised()
+      return result
+    } finally {
+      if (release) {
+        try {
+          await release()
+        } catch {}
+      }
+    }
+  }
+
   private ensureParentDir(): void {
     const dir = dirname(this.secretsPath)
     if (!existsSync(dir)) {


### PR DESCRIPTION
## Why

KakaoTalk credentials lived in `workspace/.agent-messenger/kakaotalk-credentials.json`, outside TypeClaw's structured channel-secret storage. That made KakaoTalk the one bundled channel whose login state was not visible in `secrets.json`, so operators inspecting or backing up `secrets.json` could silently miss the account tokens needed to run the adapter.

This PR makes `secrets.json#channels.kakaotalk` the production source of truth while preserving the existing KakaoTalk client contract and a rollback-friendly migration path.

## What

### `secrets.json#channels.kakaotalk` block

Adds a structured KakaoTalk channel block to the existing secrets envelope:

```json
{
  "version": 1,
  "channels": {
    "kakaotalk": {
      "currentAccount": "user-1",
      "accounts": {
        "user-1": { "account_id": "user-1", "oauth_token": "..." }
      },
      "pendingLogin": { "device_uuid": "..." }
    }
  }
}
```

The block mirrors `agent-messenger`'s `KakaoConfig`/`KakaoAccountCredentials` shape at the method boundary; TypeClaw translates `currentAccount` ⇄ `current_account` inside `SecretsKakaoCredentialStore`.

### `SecretsKakaoCredentialStore`

Adds a TypeClaw-backed store with the same public method surface as `agent-messenger`'s `KakaoCredentialManager`:

- `load` / `save`
- `getAccount` / `setAccount` / `removeAccount` / `listAccounts` / `setCurrentAccount`
- `savePendingLogin` / `loadPendingLogin` / `clearPendingLogin`

Modes:

- **host** — used by init/channel-add bootstrap; writes directly through `SecretsBackend.updateChannelsAsync`.
- **container** — used by the running adapter; non-mutating local reads, writes through hostd `secrets-patch`.

Container writes are serialized in-process before being sent as full-block patches so concurrent writes cannot lose updates.

### `secrets-patch` hostd RPC

Adds a narrow RPC for the running container to patch its own KakaoTalk channel block:

```ts
{ kind: 'secrets-patch', containerName, patch: { channels: { kakaotalk } } }
```

The HTTP control surface gates it the same way as `restart`: the request must include the container's registered `TYPECLAW_HOSTD_TOKEN`, and the daemon verifies the token against `containerName` before applying the patch. Hostd validates the Kakao block with Zod and writes through `SecretsBackend.updateChannelsAsync`.

### Legacy migration

`typeclaw start` now runs `migrateKakaotalkCredentials(cwd)` before launching the container:

1. Reads legacy `workspace/.agent-messenger/kakaotalk-credentials.json` and `kakaotalk-pending-login.json` via the upstream `KakaoCredentialManager`.
2. Merges them into `secrets.json#channels.kakaotalk` in one atomic channels update.
3. Renames migrated legacy files to `*.migrated` instead of deleting them, preserving rollback artifacts without leaving them active.

The migration is idempotent and resume-safe: if accounts already migrated but pending-login state did not, a later run imports only the missing pending-login state.

### Runtime wiring

- `typeclaw init` / `typeclaw channel add kakaotalk` write KakaoTalk auth state to `secrets.json`.
- `createChannelManager` preflights and hashes `secrets.json#channels.kakaotalk` for reload credential-rotation detection.
- The production adapter receives `credentialsStore`; the old `credentialsDir` path remains as a deprecated direct/test fallback.
- `AGENT_MESSENGER_CONFIG_DIR` remains set for upstream non-credential sync-state files and fallback compatibility. Production credentials do not use it after migration.

## Review notes

- Upstream `agent-messenger` does not currently rotate/persist Kakao OAuth tokens during normal `KakaoTalkClient` runtime. `SecretsKakaoCredentialStore.setAccount()` supports the manager interface and future store-backed writes, but this PR should not be read as adding a runtime OAuth refresh mechanism upstream does not have today.
- Migrated `*.migrated` files can still contain secret bytes as inert rollback artifacts. They are no longer read by the production adapter, but a future cleanup/doctor check could surface or remove them.
- A first self-review/Oracle pass found two blockers; both are fixed here:
  - runtime reads/signature checks no longer create `secrets.json`
  - migration is atomic and resume-safe for pending-login state

## Testing

```sh
bun run typecheck
bun run lint
bun run format
bun test   # 2877 pass, 0 fail
```

New/expanded coverage includes:

- schema parsing for `channels.kakaotalk`
- host-mode and container-mode `SecretsKakaoCredentialStore`
- hostd `secrets-patch` auth/scoping/preservation/concurrency
- legacy migration, idempotency, and partial-migration resume
- channel manager KakaoTalk credential preflight/signature/reload behavior
- `typeclaw start` migration integration