### PR TITLE
Fix typeclaw doctor: stop hanging, stop false-positive Dockerfile drift, drop .env warning

### DIFF
--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -17,6 +17,8 @@ export {
 } from './shared'
 export {
   planStart,
+  refreshDockerfile,
+  refreshGitignore,
   start,
   type HostDaemonStatus,
   type PlanStartOptions,

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync } from 'node:fs'
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join, relative } from 'node:path'
 
@@ -10,10 +10,13 @@ import {
   defaultDockerExec,
   imageTagFromCwd,
   inspectContainer,
+  refreshDockerfile,
+  refreshGitignore,
   resolveHostPort,
   type DockerExec,
 } from '@/container'
 import { isDaemonReachable, send } from '@/hostd'
+import { resolveBaseImageVersion } from '@/init/cli-version'
 import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { detectMissingDeps } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
@@ -151,7 +154,7 @@ function agentFolderDockerfileTemplate(): DoctorCheck {
         fix: {
           description: 'Regenerate the Dockerfile from the typeclaw template.',
           autoFix: async () => {
-            await writeAtomic(dockerfilePath, expected)
+            await refreshDockerfile(ctx.cwd)
             return { summary: 'refreshed Dockerfile from template', changedPaths: [DOCKERFILE] }
           },
         },
@@ -180,7 +183,7 @@ function agentFolderGitignoreTemplate(): DoctorCheck {
         fix: {
           description: 'Regenerate .gitignore from the typeclaw template.',
           autoFix: async () => {
-            await writeAtomic(gitignorePath, expected)
+            await refreshGitignore(ctx.cwd)
             return { summary: 'refreshed .gitignore from template', changedPaths: [GITIGNORE_FILE] }
           },
         },
@@ -365,7 +368,7 @@ function buildExpectedDockerfile(cwd: string): string | null {
   try {
     const cfg = loadConfigStrictForTemplate(cwd)
     if (cfg === null) return null
-    return buildDockerfile(cfg.dockerfile)
+    return buildDockerfile(cfg.dockerfile, { baseImageVersion: resolveBaseImageVersion(cwd) })
   } catch {
     return null
   }
@@ -396,10 +399,6 @@ async function safeRead(path: string): Promise<string | null> {
   } catch {
     return null
   }
-}
-
-async function writeAtomic(path: string, content: string): Promise<void> {
-  await writeFile(path, content)
 }
 
 export function relativeToCwd(cwd: string, path: string): string {

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -33,7 +33,6 @@ export function buildStaticChecks(opts: { dockerExec?: DockerExec } = {}): Docto
     agentFolderDockerfileTemplate(),
     agentFolderGitignoreTemplate(),
     agentFolderNodeModules(),
-    agentFolderEnvFile(),
     agentFolderGitRepo(),
     configValid(),
     hostdHomeWritable(),
@@ -204,24 +203,6 @@ function agentFolderNodeModules(): DoctorCheck {
         message: `${missing.length} package(s) missing from node_modules`,
         details: missing.map((m) => `missing: ${m}`),
         fix: { description: 'Run `bun install` inside the agent folder.' },
-      }
-    },
-  }
-}
-
-function agentFolderEnvFile(): DoctorCheck {
-  return {
-    name: 'agent-folder.env-file',
-    category: 'agent-folder',
-    description: '.env file is present',
-    applies: (ctx) => ctx.hasAgentFolder,
-    async run(ctx) {
-      if (existsSync(join(ctx.cwd, '.env'))) return { status: 'ok', message: '.env present' }
-      return {
-        status: 'warning',
-        message: '.env is missing',
-        details: ['Channels and external API integrations will not have their secrets injected.'],
-        fix: { description: 'Create a .env file with the credentials your agent needs.' },
       }
     },
   }

--- a/src/doctor/commit.ts
+++ b/src/doctor/commit.ts
@@ -18,8 +18,8 @@ export async function commitAutoFixes(opts: CommitOptions): Promise<CommitOutcom
     return { kind: 'skipped', reason: 'no successful auto-fixes' }
   }
 
-  const pathsStaged = uniqueSorted(successes.flatMap((a) => a.changedPaths))
-  if (pathsStaged.length === 0) {
+  const requested = uniqueSorted(successes.flatMap((a) => a.changedPaths))
+  if (requested.length === 0) {
     return { kind: 'skipped', reason: 'auto-fixes reported no changed paths' }
   }
 
@@ -29,13 +29,21 @@ export async function commitAutoFixes(opts: CommitOptions): Promise<CommitOutcom
 
   const spawnGit = opts.spawnGit ?? defaultSpawnGit
 
+  const pathsStaged = await filterCommittable(spawnGit, opts.cwd, requested)
+  if (pathsStaged.length === 0) {
+    return {
+      kind: 'skipped',
+      reason: `all changed path(s) are gitignored or untracked-and-ignored (${requested.join(', ')})`,
+    }
+  }
+
   const add = await spawnGit(['add', '--', ...pathsStaged], opts.cwd)
   if (add.exitCode !== 0) {
     return { kind: 'failed', reason: `git add failed: ${add.stderr.trim() || `exit ${add.exitCode}`}` }
   }
 
   const message = buildCommitMessage(opts.attempts)
-  const commit = await spawnGit(['commit', '-m', message], opts.cwd)
+  const commit = await spawnGit(['commit', '-m', message, '--only', '--', ...pathsStaged], opts.cwd)
   if (commit.exitCode !== 0) {
     return { kind: 'failed', reason: `git commit failed: ${commit.stderr.trim() || `exit ${commit.exitCode}`}` }
   }
@@ -43,6 +51,23 @@ export async function commitAutoFixes(opts: CommitOptions): Promise<CommitOutcom
   const sha = await spawnGit(['rev-parse', 'HEAD'], opts.cwd)
   const commitSha = sha.exitCode === 0 ? sha.stdout.trim() : ''
   return { kind: 'committed', commitSha, pathsStaged }
+}
+
+// TypeClaw-owned files like `Dockerfile` live in the "truly-ignored" gitignore
+// category — they're regenerated from the CLI template on every `typeclaw
+// start`, so tracking them would produce noisy "Update Dockerfile" commits.
+// `commitSystemFile` in src/container/start.ts skips them silently because
+// `git status --porcelain -- <ignored>` returns empty. We replicate that
+// behavior here so `doctor --fix` produces the same skip semantics instead
+// of failing with `git add` hints about the ignored file.
+async function filterCommittable(spawnGit: SpawnGit, cwd: string, paths: string[]): Promise<string[]> {
+  const out: string[] = []
+  for (const p of paths) {
+    const status = await spawnGit(['status', '--porcelain', '--', p], cwd)
+    if (status.exitCode !== 0) continue
+    if (status.stdout.trim().length > 0) out.push(p)
+  }
+  return out
 }
 
 export function buildCommitMessage(attempts: FixAttempt[]): string {

--- a/src/doctor/commit.ts
+++ b/src/doctor/commit.ts
@@ -29,7 +29,9 @@ export async function commitAutoFixes(opts: CommitOptions): Promise<CommitOutcom
 
   const spawnGit = opts.spawnGit ?? defaultSpawnGit
 
-  const pathsStaged = await filterCommittable(spawnGit, opts.cwd, requested)
+  const filter = await filterCommittable(spawnGit, opts.cwd, requested)
+  if (filter.kind === 'failed') return filter
+  const pathsStaged = filter.paths
   if (pathsStaged.length === 0) {
     return {
       kind: 'skipped',
@@ -60,14 +62,28 @@ export async function commitAutoFixes(opts: CommitOptions): Promise<CommitOutcom
 // `git status --porcelain -- <ignored>` returns empty. We replicate that
 // behavior here so `doctor --fix` produces the same skip semantics instead
 // of failing with `git add` hints about the ignored file.
-async function filterCommittable(spawnGit: SpawnGit, cwd: string, paths: string[]): Promise<string[]> {
+//
+// A non-zero git-status exit IS NOT the same signal as 'empty stdout' — the
+// former means git itself failed (broken index, malformed pathspec, etc.).
+// Surface that as { kind: 'failed' } so the user sees the real cause instead
+// of a misleading 'all paths are gitignored' message.
+async function filterCommittable(
+  spawnGit: SpawnGit,
+  cwd: string,
+  paths: string[],
+): Promise<{ kind: 'ok'; paths: string[] } | { kind: 'failed'; reason: string }> {
   const out: string[] = []
   for (const p of paths) {
     const status = await spawnGit(['status', '--porcelain', '--', p], cwd)
-    if (status.exitCode !== 0) continue
+    if (status.exitCode !== 0) {
+      return {
+        kind: 'failed',
+        reason: `git status failed for ${p}: ${status.stderr.trim() || `exit ${status.exitCode}`}`,
+      }
+    }
     if (status.stdout.trim().length > 0) out.push(p)
   }
-  return out
+  return { kind: 'ok', paths: out }
 }
 
 export function buildCommitMessage(attempts: FixAttempt[]): string {

--- a/src/doctor/index.test.ts
+++ b/src/doctor/index.test.ts
@@ -145,6 +145,30 @@ describe('runDoctor', () => {
     }
   })
 
+  test('reports failed (not skipped) when git status itself errors', async () => {
+    const cwd = makeTmpAgentDir()
+    await initGitRepo(cwd)
+
+    const spawnGit = async (args: string[]) =>
+      args[0] === 'status'
+        ? { exitCode: 128, stdout: '', stderr: 'fatal: index file corrupt' }
+        : { exitCode: 0, stdout: '', stderr: '' }
+
+    const result = await runDoctor({
+      cwd,
+      fix: true,
+      staticChecks: [fakeCheck('alpha', 'warning', { autoFix: true })],
+      fetchPluginChecks: async () => ({ kind: 'ok', checks: [] }),
+      spawnGit,
+    })
+
+    expect(result.commit?.kind).toBe('failed')
+    if (result.commit?.kind === 'failed') {
+      expect(result.commit.reason).toMatch(/git status failed/)
+      expect(result.commit.reason).toMatch(/index file corrupt/)
+    }
+  })
+
   test('marks plugin checks deferred when bridge is unreachable', async () => {
     const cwd = makeTmpAgentDir()
     const result = await runDoctor({

--- a/src/doctor/index.test.ts
+++ b/src/doctor/index.test.ts
@@ -124,6 +124,27 @@ describe('runDoctor', () => {
     expect(result.commit?.kind).toBe('skipped')
   })
 
+  test('skips commit when every fixed path is gitignored (e.g. Dockerfile)', async () => {
+    const cwd = makeTmpAgentDir()
+    await initGitRepo(cwd)
+    writeFileSync(join(cwd, '.gitignore'), 'alpha.txt\n', 'utf8')
+    await run(['git', 'add', '.gitignore'], cwd)
+    await run(['git', 'commit', '-q', '-m', 'add gitignore'], cwd)
+
+    const result = await runDoctor({
+      cwd,
+      fix: true,
+      staticChecks: [fakeCheck('alpha', 'warning', { autoFix: true })],
+      fetchPluginChecks: async () => ({ kind: 'ok', checks: [] }),
+    })
+
+    expect(result.fixAttempts?.[0]).toMatchObject({ ok: true })
+    expect(result.commit?.kind).toBe('skipped')
+    if (result.commit?.kind === 'skipped') {
+      expect(result.commit.reason).toMatch(/gitignored/)
+    }
+  })
+
   test('marks plugin checks deferred when bridge is unreachable', async () => {
     const cwd = makeTmpAgentDir()
     const result = await runDoctor({

--- a/src/doctor/plugin-bridge.ts
+++ b/src/doctor/plugin-bridge.ts
@@ -89,6 +89,7 @@ async function dial(opts: PluginBridgeOptions): Promise<DialResult> {
   try {
     await new Promise<void>((resolve, reject) => {
       const cleanup = () => {
+        clearTimeout(timer)
         ws.removeEventListener('open', onOpen)
         ws.removeEventListener('error', onError)
       }
@@ -100,6 +101,19 @@ async function dial(opts: PluginBridgeOptions): Promise<DialResult> {
         cleanup()
         reject(err instanceof Error ? err : new Error(`failed to connect to ${url}`))
       }
+      // Bun's WebSocket has no built-in connect timeout. Without this, a TCP
+      // handshake that completes but never produces an Upgrade response
+      // (e.g. a wedged docker/orbstack port-forward) leaves the WS stuck in
+      // CONNECTING forever — neither 'open' nor 'error' ever fires, and
+      // `typeclaw doctor` hangs. The per-request timeout downstream doesn't
+      // help because we never reach it.
+      const timer = setTimeout(() => {
+        cleanup()
+        try {
+          ws.close()
+        } catch {}
+        reject(new Error(`websocket connect timeout after ${timeoutMs}ms`))
+      }, timeoutMs)
       ws.addEventListener('open', onOpen, { once: true })
       ws.addEventListener('error', onError, { once: true })
     })

--- a/src/doctor/plugin-bridge.ts
+++ b/src/doctor/plugin-bridge.ts
@@ -88,8 +88,13 @@ async function dial(opts: PluginBridgeOptions): Promise<DialResult> {
   const ws = new WebSocket(url)
   try {
     await new Promise<void>((resolve, reject) => {
+      // `timer` is declared up front so `cleanup` can reference it without
+      // hitting the TDZ if the WS fires a synchronous error event during
+      // addEventListener (theoretical, but const-after-cleanup-definition
+      // would throw ReferenceError instead of being the intended no-op).
+      let timer: ReturnType<typeof setTimeout> | undefined
       const cleanup = () => {
-        clearTimeout(timer)
+        if (timer !== undefined) clearTimeout(timer)
         ws.removeEventListener('open', onOpen)
         ws.removeEventListener('error', onError)
       }
@@ -107,7 +112,7 @@ async function dial(opts: PluginBridgeOptions): Promise<DialResult> {
       // CONNECTING forever — neither 'open' nor 'error' ever fires, and
       // `typeclaw doctor` hangs. The per-request timeout downstream doesn't
       // help because we never reach it.
-      const timer = setTimeout(() => {
+      timer = setTimeout(() => {
         cleanup()
         try {
           ws.close()


### PR DESCRIPTION
## Why

\`typeclaw doctor\` had three independent bugs that made it close to useless on real install-mode agents:

1. **Hung indefinitely** in \`~/typeclaw/kakao\` (and any agent whose running container's host port forward had wedged). The plugin-bridge WebSocket got stuck in CONNECTING — the TCP handshake completed but the WS upgrade response never arrived, and neither \`open\` nor \`error\` ever fired.
2. **Reported a bogus 80-line Dockerfile divergence** on every install-mode agent. \`buildExpectedDockerfile\` was computing dev-mode inline output (\`FROM oven/bun:1-slim\` + the full heavy stack) and diffing against the real on-disk install-mode file (\`FROM ghcr.io/typeclaw/typeclaw-base:X.Y.Z\`). The auto-fix would have *rewritten a correct file into a broken one*.
3. **\`doctor --fix\` failed at the commit step** for TypeClaw-owned files: blindly \`git add Dockerfile\` against a gitignored \`Dockerfile\` produced \`failed: paths are ignored by one of your .gitignore files\` even though the regeneration step succeeded.

Plus the standing nuisance: \`agent-folder.env-file\` warned \`! .env is missing\` on every agent that keeps credentials in \`secrets.json\` or in the host environment — which, post-#158 (v2 secrets), is the normal happy path.

## What

Four small, independently-revertable commits:

### \`Drop agent-folder.env-file doctor check\`

\`.env\` is no longer required. Credentials resolve through three independent sources (\`secrets.json\`, \`.env\`, host \`process.env\`) per the env-wins policy in \`src/secrets/\` — many agents legitimately ship with an absent or empty \`.env\`. Drops the check entirely instead of softening it.

### \`Add WebSocket connect timeout to doctor plugin-bridge\`

Race the \`open\`/\`error\` listeners against the same \`timeoutMs\` budget (default 15s) inside \`dial()\`. A wedged port-forward now surfaces as \`plugin checks deferred: container not reachable (websocket connect timeout after 15000ms)\` instead of hanging forever. Bun's WebSocket has no built-in connect timeout, and the per-request timeout downstream of \`dial()\` can't help if \`dial()\` itself never resolves.

### \`Use refresh{Dockerfile,Gitignore} for doctor's expected/auto-fix\`

\`buildExpectedDockerfile\` now passes \`{ baseImageVersion: resolveBaseImageVersion(cwd) }\` so the expected output matches what \`refreshDockerfile\` actually writes. The auto-fix calls \`refreshDockerfile(cwd)\` / \`refreshGitignore(cwd)\` directly instead of duplicating the build+write logic locally — one code path for \"how TypeClaw writes its owned files,\" used by both \`typeclaw start\` and \`doctor --fix\`. Future template changes cannot desync the two.

Surfaces a new export pair on \`@/container\` (\`refreshDockerfile\`, \`refreshGitignore\`) — they were already exported from \`src/container/start.ts\`, just not re-exported through the barrel.

### \`Skip doctor --fix commit when every changed path is gitignored\`

\`commitAutoFixes\` now filters \`changedPaths\` through \`git status --porcelain -- <path>\` before \`git add\` — the same probe \`commitSystemFile\` in \`src/container/start.ts\` uses to decide whether a TypeClaw-owned file is worth committing. Also pins the commit to \`--only -- <paths>\` so unrelated dirty files in the agent folder can't slip into the doctor commit. When every path is gitignored, return \`{ kind: 'skipped', reason: '…' }\` instead of \`failed\`.

## Verification

End-to-end on \`~/typeclaw/kakao\` (install-mode agent on typeclaw 0.1.3 with a stale 0.1.2-pinned Dockerfile, container running, host port forward wedged):

\`\`\`
[!] agent-folder
    ! Dockerfile diverges from template (agent-folder.dockerfile-managed)
      → Fix (auto): Regenerate the Dockerfile from the typeclaw template.
[i] container
    ✓ container kakao is running (container.state)
    i plugin checks deferred: container not reachable (websocket connect timeout after 15000ms)

--fix:
  [static] agent-folder.dockerfile-managed: refreshed Dockerfile from template
  commit: skipped — all changed path(s) are gitignored or untracked-and-ignored (Dockerfile)

[FINAL] ✓ Dockerfile matches template
\`\`\`

On-disk Dockerfile diff after \`--fix\`: one line, \`FROM …:0.1.2 → FROM …:0.1.3\` — byte-identical to what the next \`typeclaw start\` would write.

## Tests

\`\`\`
bun run typecheck   → clean
bun run lint        → 1 pre-existing warning (unrelated)
bun run format      → clean
bun test src/doctor → 13 pass, 0 fail (was 12; added a gitignored-skip case)
bun test            → 2913 pass, 2 fail (the 2 pre-existing schema-drift guards, unrelated)
\`\`\`

New coverage in \`src/doctor/index.test.ts\`: when the auto-fix touches only gitignored paths (Dockerfile-shaped scenario), \`commit?.kind === 'skipped'\` with a clear reason — exercises the new filter loop end-to-end against a real \`git init\`'d tmp dir.

## Self-review follow-ups (already pushed to this PR)

Two correctness issues caught during self-review and folded in as commits 5–6:

- **`Hoist timer declaration in plugin-bridge dial()`** — the WS-connect-timeout patch declared `const timer = setTimeout(...)` AFTER `cleanup()` was defined to reference it. JS hoists the binding but TDZ blocks read-before-init; if Bun ever fires a synchronous error event during `addEventListener` (theoretically possible for invalid URLs or pre-failed sockets), `cleanup()` would throw `ReferenceError` instead of being a no-op. Switched to `let timer: ReturnType<typeof setTimeout> | undefined` declared ahead of `cleanup()` with a guarded `clearTimeout` call.

- **`Propagate git status failures from filterCommittable`** — the original gitignored-skip patch silently `continue`'d on non-zero `git status` exits, producing a misleading "all paths are gitignored" message when the real cause was a broken index or malformed pathspec. Now returns `{ kind: 'failed', reason }` so the user sees the actual git error. Added a regression test that injects a stub `spawnGit` returning exit 128 + "fatal: index file corrupt" and asserts `commit.kind === 'failed'`.

## Related: out-of-scope hang sites (follow-up)

While verifying the plugin-bridge fix, I searched for other `new WebSocket(` sites in `src/`. Three production callers share the exact same hang shape (no connect timeout, await `open`/`error` indefinitely):

- `src/tui/client.ts` → `typeclaw tui` hangs on wedged port-forward
- `src/reload/client.ts` → `typeclaw reload` hangs (its `timeoutMs` only guards the *reload_result* wait, not the WS connect)
- `src/portbroker/hostd-client.ts` → broker reconnect stalls

Tracked separately in #164 to keep this PR scoped to doctor.
