### PR TITLE
Reuse existing init API keys

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test'
+
+import { KNOWN_PROVIDERS } from '@/config/providers'
+
+import { decideExistingApiKeyReuse } from './init'
+
+describe('decideExistingApiKeyReuse', () => {
+  test('reuses an existing API key when the user confirms', async () => {
+    const messages: string[] = []
+
+    const decision = await decideExistingApiKeyReuse(KNOWN_PROVIDERS.openai, 'openai-existing-key', async (message) => {
+      messages.push(message)
+      return true
+    })
+
+    expect(decision).toBe('reuse')
+    expect(messages).toEqual(['Reuse existing OPENAI_API_KEY from .env?'])
+  })
+
+  test('prompts for a new API key when the user declines reuse', async () => {
+    const decision = await decideExistingApiKeyReuse(KNOWN_PROVIDERS.fireworks, 'fw_existing', async () => false)
+
+    expect(decision).toBe('prompt')
+  })
+
+  test('skips the reuse question when there is no existing API key', async () => {
+    let asked = false
+
+    const decision = await decideExistingApiKeyReuse(KNOWN_PROVIDERS.openai, null, async () => {
+      asked = true
+      return true
+    })
+
+    expect(decision).toBe('prompt')
+    expect(asked).toBe(false)
+  })
+
+  test('skips the reuse question for OAuth-only providers', async () => {
+    let asked = false
+
+    const decision = await decideExistingApiKeyReuse(KNOWN_PROVIDERS['openai-codex'], 'unused-key', async () => {
+      asked = true
+      return true
+    })
+
+    expect(decision).toBe('prompt')
+    expect(asked).toBe(false)
+  })
+})

--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -14,7 +14,7 @@ describe('decideExistingApiKeyReuse', () => {
     })
 
     expect(decision).toBe('reuse')
-    expect(messages).toEqual(['Reuse existing OPENAI_API_KEY from .env?'])
+    expect(messages).toEqual(['Reuse existing OpenAI API key from secrets.json?'])
   })
 
   test('prompts for a new API key when the user declines reuse', async () => {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -69,7 +69,7 @@ export const init = defineCommand({
     const llmAuth = await collectLLMAuth(provider, existingApiKey)
 
     const channelChoice = await select({
-      message: 'Pick a channel to wire (you can add more later by editing typeclaw.json + .env)',
+      message: 'Pick a channel to wire (you can add more later by editing typeclaw.json + secrets.json)',
       options: [
         { value: 'slack', label: 'Slack' },
         { value: 'discord', label: 'Discord' },
@@ -437,7 +437,7 @@ function reportHatching(event: Extract<InitStepEvent, { step: 'hatching' }>): vo
 }
 
 // Resolves how the user wants to authenticate to the chosen provider:
-// - api-key only (e.g. Fireworks): prompt for the key, write to .env.
+// - api-key only (e.g. Fireworks): prompt for the key, write to secrets.json.
 // - oauth only (e.g. openai-codex): run the browser flow inline, write
 //   secrets.json. No API key prompt at all.
 // - both supported (no providers ship this today, but Anthropic will when
@@ -457,7 +457,7 @@ async function collectLLMAuth(
     process.exit(0)
   }
   if (existingKeyDecision === 'reuse' && existingApiKey !== null) {
-    log.info(`Using existing ${provider.apiKeyEnv} from .env.`)
+    log.info(`Using existing ${provider.name} API key from secrets.json.`)
     return { kind: 'api-key', apiKey: existingApiKey }
   }
 
@@ -466,7 +466,7 @@ async function collectLLMAuth(
     const choice = await select<'api-key' | 'oauth'>({
       message: `How do you want to authenticate to ${provider.name}?`,
       options: [
-        { value: 'api-key', label: 'API key', hint: `saved to .env as ${provider.apiKeyEnv}` },
+        { value: 'api-key', label: 'API key', hint: 'saved to secrets.json' },
         { value: 'oauth', label: 'OAuth (browser login)', hint: 'saved to secrets.json' },
       ],
       initialValue: 'api-key',
@@ -484,7 +484,7 @@ async function collectLLMAuth(
 
   if (method === 'api-key') {
     const apiKey = await password({
-      message: `Put your ${provider.name} API key (will be saved to .env as ${provider.apiKeyEnv})`,
+      message: `Put your ${provider.name} API key (will be saved to secrets.json)`,
       validate: (value) => (value && value.length > 0 ? undefined : 'API key is required'),
     })
     if (isCancel(apiKey)) {
@@ -504,7 +504,7 @@ export async function decideExistingApiKeyReuse(
 ): Promise<'reuse' | 'prompt' | 'cancel'> {
   if (!providerSupportsApiKey(provider) || existingApiKey === null) return 'prompt'
 
-  const reuse = await askReuse(`Reuse existing ${provider.apiKeyEnv} from .env?`)
+  const reuse = await askReuse(`Reuse existing ${provider.name} API key from secrets.json?`)
   if (isCancel(reuse)) return 'cancel'
   return reuse === true ? 'reuse' : 'prompt'
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -13,6 +13,7 @@ import {
   findAgentDir,
   isDirectoryNonEmpty,
   isHatched,
+  readExistingProviderApiKey,
   runInit,
   type InitStep,
   type InitStepEvent,
@@ -64,7 +65,8 @@ export const init = defineCommand({
     const selectedModel = await pickModel()
     const provider = KNOWN_PROVIDERS[selectedModel.providerId]
 
-    const llmAuth = await collectLLMAuth(provider)
+    const existingApiKey = await readExistingProviderApiKey(cwd, selectedModel.providerId)
+    const llmAuth = await collectLLMAuth(provider, existingApiKey)
 
     const channelChoice = await select({
       message: 'Pick a channel to wire (you can add more later by editing typeclaw.json + .env)',
@@ -440,9 +442,17 @@ function reportHatching(event: Extract<InitStepEvent, { step: 'hatching' }>): vo
 //   secrets.json. No API key prompt at all.
 // - both supported (no providers ship this today, but Anthropic will when
 //   wired): ask "API key or OAuth?" first, then dispatch to the chosen path.
-async function collectLLMAuth(provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]): Promise<LLMAuth> {
+async function collectLLMAuth(
+  provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+  existingApiKey: string | null,
+): Promise<LLMAuth> {
   const supportsApiKey = providerSupportsApiKey(provider)
   const supportsOAuth = providerSupportsOAuth(provider)
+
+  if (supportsApiKey && existingApiKey !== null) {
+    log.info(`Using existing ${provider.apiKeyEnv} from .env.`)
+    return { kind: 'api-key', apiKey: existingApiKey }
+  }
 
   let method: 'api-key' | 'oauth'
   if (supportsApiKey && supportsOAuth) {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -449,7 +449,14 @@ async function collectLLMAuth(
   const supportsApiKey = providerSupportsApiKey(provider)
   const supportsOAuth = providerSupportsOAuth(provider)
 
-  if (supportsApiKey && existingApiKey !== null) {
+  const existingKeyDecision = await decideExistingApiKeyReuse(provider, existingApiKey, (message) =>
+    confirm({ message, initialValue: true }),
+  )
+  if (existingKeyDecision === 'cancel') {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  if (existingKeyDecision === 'reuse' && existingApiKey !== null) {
     log.info(`Using existing ${provider.apiKeyEnv} from .env.`)
     return { kind: 'api-key', apiKey: existingApiKey }
   }
@@ -488,6 +495,18 @@ async function collectLLMAuth(
   }
 
   return { kind: 'oauth', runLogin: makeOAuthLoginRunner(buildOAuthCallbacks(provider.name)) }
+}
+
+export async function decideExistingApiKeyReuse(
+  provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+  existingApiKey: string | null,
+  askReuse: (message: string) => Promise<unknown>,
+): Promise<'reuse' | 'prompt' | 'cancel'> {
+  if (!providerSupportsApiKey(provider) || existingApiKey === null) return 'prompt'
+
+  const reuse = await askReuse(`Reuse existing ${provider.apiKeyEnv} from .env?`)
+  if (isCancel(reuse)) return 'cancel'
+  return reuse === true ? 'reuse' : 'prompt'
 }
 
 // Wraps the OAuth lifecycle into the same clack idiom the rest of the wizard

--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -25,19 +25,24 @@ async function readConfig(): Promise<{ channels?: Record<string, { allow: string
   }
 }
 
-async function readEnv(): Promise<string> {
-  return readFile(join(root, '.env'), 'utf8')
-}
-
-async function readSecretsChannels(): Promise<Record<string, Record<string, unknown>>> {
+async function readSecrets(): Promise<{
+  providers?: Record<string, unknown>
+  channels?: Record<string, Record<string, unknown>>
+}> {
   try {
     const raw = await readFile(join(root, 'secrets.json'), 'utf8')
-    const parsed = JSON.parse(raw) as { channels?: Record<string, Record<string, unknown>> }
-    return parsed.channels ?? {}
+    return JSON.parse(raw) as {
+      providers?: Record<string, unknown>
+      channels?: Record<string, Record<string, unknown>>
+    }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {}
     throw err
   }
+}
+
+async function readSecretsChannels(): Promise<Record<string, Record<string, unknown>>> {
+  return (await readSecrets()).channels ?? {}
 }
 
 describe('runAddChannel', () => {
@@ -60,14 +65,12 @@ describe('runAddChannel', () => {
     expect(cfg.channels?.['discord-bot']?.allow).toEqual([])
   })
 
-  test('saves discord-bot.token to secrets.json#channels without disturbing FIREWORKS_API_KEY in .env', async () => {
+  test('saves discord-bot.token to secrets.json#channels without disturbing the Fireworks provider key', async () => {
     await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-token-x' })
 
-    const env = await readEnv()
-    expect(env).toContain('FIREWORKS_API_KEY=fw_existing')
-    expect(env).not.toContain('DISCORD_BOT_TOKEN')
-    const channels = await readSecretsChannels()
-    expect(channels['discord-bot']).toEqual({ token: { value: 'discord-token-x' } })
+    const secrets = await readSecrets()
+    expect(secrets.providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_existing' } })
+    expect(secrets.channels?.['discord-bot']).toEqual({ token: { value: 'discord-token-x' } })
   })
 
   test('adds slack-bot with both bot+app tokens to secrets.json#channels.slack-bot', async () => {
@@ -85,9 +88,7 @@ describe('runAddChannel', () => {
       botToken: { value: 'xoxb-bot' },
       appToken: { value: 'xapp-app' },
     })
-    const env = await readEnv()
-    expect(env).not.toContain('SLACK_BOT_TOKEN')
-    expect(env).not.toContain('SLACK_APP_TOKEN')
+    expect((await readSecrets()).providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_existing' } })
   })
 
   test('adds telegram-bot config + secrets.json#channels.telegram-bot', async () => {
@@ -97,8 +98,7 @@ describe('runAddChannel', () => {
     expect(cfg.channels?.['telegram-bot']?.allow).toEqual(['*'])
     const channels = await readSecretsChannels()
     expect(channels['telegram-bot']).toEqual({ token: { value: '123:tg-secret' } })
-    const env = await readEnv()
-    expect(env).not.toContain('TELEGRAM_BOT_TOKEN')
+    expect((await readSecrets()).providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_existing' } })
   })
 
   test('adds kakaotalk with kakao:dm/* allow by default and runs auth runner', async () => {
@@ -115,7 +115,7 @@ describe('runAddChannel', () => {
     expect(authCalls).toEqual([root])
     const cfg = await readConfig()
     expect(cfg.channels?.kakaotalk?.allow).toEqual(['kakao:dm/*'])
-    expect(await readEnv()).toBe('FIREWORKS_API_KEY=fw_existing\n')
+    expect((await readSecrets()).providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_existing' } })
   })
 
   test('adds kakaotalk credentials to secrets.json instead of workspace credential files', async () => {
@@ -163,9 +163,9 @@ describe('runAddChannel', () => {
     expect(cfg.channels?.kakaotalk?.allow).toEqual(['kakao:*'])
   })
 
-  test('aborts and leaves typeclaw.json + .env untouched when kakaotalk auth fails', async () => {
+  test('aborts and leaves typeclaw.json + secrets.json untouched when kakaotalk auth fails', async () => {
     const beforeConfig = await readFile(join(root, 'typeclaw.json'), 'utf8')
-    const beforeEnv = await readEnv()
+    const beforeSecrets = await readFile(join(root, 'secrets.json'), 'utf8')
 
     await expect(
       runAddChannel({
@@ -176,7 +176,7 @@ describe('runAddChannel', () => {
     ).rejects.toThrow(/bad password/)
 
     expect(await readFile(join(root, 'typeclaw.json'), 'utf8')).toBe(beforeConfig)
-    expect(await readEnv()).toBe(beforeEnv)
+    expect(await readFile(join(root, 'secrets.json'), 'utf8')).toBe(beforeSecrets)
   })
 
   test('preserves an existing channel when adding a different one', async () => {

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -23,6 +23,7 @@ import {
   isDirectoryNonEmpty,
   isHatched,
   isInitialized,
+  readExistingProviderApiKey,
   runInit,
   scaffold,
   writeDockerAssets,
@@ -1235,11 +1236,36 @@ describe('writeSecrets', () => {
     expect(await readFile(join(root, '.env'), 'utf8')).toBe('OPENAI_API_KEY=sk-default\n')
   })
 
-  test('overwrites an existing .env', async () => {
-    await writeFile(join(root, '.env'), 'OLD=1\n')
+  test('updates the provider key while preserving existing .env entries', async () => {
+    await writeFile(join(root, '.env'), 'OLD=1\nFIREWORKS_API_KEY=fw_old\n')
     await writeSecrets(root, { apiKey: 'fw_new', model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
 
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_new\n')
+    expect(await readFile(join(root, '.env'), 'utf8')).toBe('OLD=1\nFIREWORKS_API_KEY=fw_new\n')
+  })
+
+  test('preserves an existing .env when no new provider key is provided', async () => {
+    await writeFile(join(root, '.env'), 'FIREWORKS_API_KEY=fw_existing\nCUSTOM=1\n')
+    await writeSecrets(root, { model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
+
+    expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_existing\nCUSTOM=1\n')
+  })
+
+  test('reads an existing provider API key from .env', async () => {
+    await writeFile(join(root, '.env'), '# local secrets\nOPENAI_API_KEY=openai-existing-key\n')
+
+    expect(await readExistingProviderApiKey(root, 'openai')).toBe('openai-existing-key')
+    expect(await readExistingProviderApiKey(root, 'fireworks')).toBe(null)
+  })
+
+  test('ignores blank provider API keys in .env', async () => {
+    await writeFile(join(root, '.env'), 'OPENAI_API_KEY=\nFIREWORKS_API_KEY=   \n')
+
+    expect(await readExistingProviderApiKey(root, 'openai')).toBe(null)
+    expect(await readExistingProviderApiKey(root, 'fireworks')).toBe(null)
+  })
+
+  test('returns null when reading a provider API key without .env', async () => {
+    expect(await readExistingProviderApiKey(root, 'openai')).toBe(null)
   })
 
   test('writes telegram-bot.token to secrets.json#channels (not .env) when telegramBotToken is provided', async () => {

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -76,6 +76,16 @@ async function runGit(cwd: string, args: string[]): Promise<string> {
   return out.trim()
 }
 
+async function readSecrets(root: string): Promise<{
+  providers?: Record<string, unknown>
+  channels?: Record<string, Record<string, unknown>>
+}> {
+  return JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+    providers?: Record<string, unknown>
+    channels?: Record<string, Record<string, unknown>>
+  }
+}
+
 describe('runInit', () => {
   test('runs scaffold, install, dockerfile, git, and hatching steps in order', async () => {
     const events: InitStepEvent[] = []
@@ -198,7 +208,10 @@ describe('runInit', () => {
     })
 
     expect(isInitialized(root)).toBe(true)
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_integration_key\n')
+    expect((await readSecrets(root)).providers?.fireworks).toEqual({
+      type: 'api_key',
+      key: { value: 'fw_integration_key' },
+    })
     expect(existsSync(join(root, 'AGENTS.md'))).toBe(true)
     expect(existsSync(join(root, '.git'))).toBe(true)
     expect(await runGit(root, ['log', '--oneline'])).toContain('Initial commit 🥚')
@@ -390,7 +403,7 @@ describe('runInit', () => {
       throw new Error('expected git:done with ok result')
     }
     expect(gitDone.result.skipped).toBe(true)
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_second_key\n')
+    expect((await readSecrets(root)).providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_second_key' } })
   })
 
   test('aborts before scaffolding when docker binary is missing', async () => {
@@ -491,7 +504,7 @@ describe('runInit', () => {
     expect(hatchingInvoked).toBe(false)
   })
 
-  test('OAuth path: emits oauth-login step, omits API key from .env, calls login runner with chosen model', async () => {
+  test('OAuth path: emits oauth-login step, omits API key credentials, calls login runner with chosen model', async () => {
     const calls: Array<{ cwd: string; model: string; providerId: string }> = []
     const fakeLogin = makeFakeOAuthLoginRunner({
       onCalled: (opts) => {
@@ -527,8 +540,8 @@ describe('runInit', () => {
       'hatching:start',
       'hatching:done',
     ])
-    // .env should be empty (no LLM key, no channel tokens) under OAuth.
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('')
+    expect(existsSync(join(root, '.env'))).toBe(false)
+    expect(existsSync(join(root, 'secrets.json'))).toBe(false)
   })
 
   test('OAuth path: aborts before scaffold when login fails (no half-init folder)', async () => {
@@ -1215,57 +1228,66 @@ describe('writeDockerAssets', () => {
 })
 
 describe('writeSecrets', () => {
-  test('writes OPENAI_API_KEY to .env when model is an OpenAI model', async () => {
-    await writeSecrets(root, { apiKey: 'sk-test_abc123', model: 'openai/gpt-5.4-nano' })
+  test('writes an OpenAI API key to secrets.json#providers when model is an OpenAI model', async () => {
+    await writeSecrets(root, { apiKey: 'openai-test-key', model: 'openai/gpt-5.4-nano' })
 
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('OPENAI_API_KEY=sk-test_abc123\n')
+    expect((await readSecrets(root)).providers?.openai).toEqual({ type: 'api_key', key: { value: 'openai-test-key' } })
   })
 
-  test('writes FIREWORKS_API_KEY to .env when model is a Fireworks model', async () => {
+  test('writes a Fireworks API key to secrets.json#providers when model is a Fireworks model', async () => {
     await writeSecrets(root, {
       apiKey: 'fw_test_abc123',
       model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
     })
 
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_test_abc123\n')
+    expect((await readSecrets(root)).providers?.fireworks).toEqual({
+      type: 'api_key',
+      key: { value: 'fw_test_abc123' },
+    })
   })
 
-  test('defaults to OPENAI_API_KEY when model is omitted (matches DEFAULT_MODEL_REF)', async () => {
-    await writeSecrets(root, { apiKey: 'sk-default' })
+  test('defaults to OpenAI provider when model is omitted (matches DEFAULT_MODEL_REF)', async () => {
+    await writeSecrets(root, { apiKey: 'openai-default-key' })
 
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('OPENAI_API_KEY=sk-default\n')
+    expect((await readSecrets(root)).providers?.openai).toEqual({
+      type: 'api_key',
+      key: { value: 'openai-default-key' },
+    })
   })
 
-  test('updates the provider key while preserving existing .env entries', async () => {
-    await writeFile(join(root, '.env'), 'OLD=1\nFIREWORKS_API_KEY=fw_old\n')
+  test('updates an existing provider API key in secrets.json', async () => {
+    await writeSecrets(root, { apiKey: 'fw_old', model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
     await writeSecrets(root, { apiKey: 'fw_new', model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
 
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('OLD=1\nFIREWORKS_API_KEY=fw_new\n')
+    expect((await readSecrets(root)).providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_new' } })
   })
 
-  test('preserves an existing .env when no new provider key is provided', async () => {
-    await writeFile(join(root, '.env'), 'FIREWORKS_API_KEY=fw_existing\nCUSTOM=1\n')
+  test('preserves an existing provider API key when no new provider key is provided', async () => {
+    await writeSecrets(root, { apiKey: 'fw_existing', model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
     await writeSecrets(root, { model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
 
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_existing\nCUSTOM=1\n')
+    expect((await readSecrets(root)).providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_existing' } })
   })
 
-  test('reads an existing provider API key from .env', async () => {
-    await writeFile(join(root, '.env'), '# local secrets\nOPENAI_API_KEY=openai-existing-key\n')
+  test('reads an existing provider API key from secrets.json', async () => {
+    await writeSecrets(root, { apiKey: 'openai-existing-key', model: 'openai/gpt-5.4-nano' })
 
     expect(await readExistingProviderApiKey(root, 'openai')).toBe('openai-existing-key')
     expect(await readExistingProviderApiKey(root, 'fireworks')).toBe(null)
   })
 
-  test('ignores blank provider API keys in .env', async () => {
-    await writeFile(join(root, '.env'), 'OPENAI_API_KEY=\nFIREWORKS_API_KEY=   \n')
+  test('ignores blank provider API keys in secrets.json', async () => {
+    await writeFile(
+      join(root, 'secrets.json'),
+      `${JSON.stringify({ version: 2, providers: { openai: { type: 'api_key', key: { value: '   ' } } }, channels: {} }, null, 2)}\n`,
+    )
 
     expect(await readExistingProviderApiKey(root, 'openai')).toBe(null)
-    expect(await readExistingProviderApiKey(root, 'fireworks')).toBe(null)
   })
 
-  test('returns null when reading a provider API key without .env', async () => {
+  test('returns null when reading a provider API key without secrets.json', async () => {
     expect(await readExistingProviderApiKey(root, 'openai')).toBe(null)
+    expect(existsSync(join(root, 'secrets.json'))).toBe(false)
   })
 
   test('writes telegram-bot.token to secrets.json#channels (not .env) when telegramBotToken is provided', async () => {
@@ -1275,34 +1297,28 @@ describe('writeSecrets', () => {
       telegramBotToken: '1234567890:ABCdef',
     })
 
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_test\n')
-    const secrets = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
-      channels?: Record<string, Record<string, unknown>>
-    }
+    const secrets = await readSecrets(root)
+    expect(secrets.providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_test' } })
     expect(secrets.channels?.['telegram-bot']).toEqual({ token: { value: '1234567890:ABCdef' } })
   })
 
   test('writes discord-bot.token to secrets.json#channels when discordBotToken is provided', async () => {
-    await writeSecrets(root, { apiKey: 'sk-x', model: 'openai/gpt-5.4-nano', discordBotToken: 'discord-tok' })
+    await writeSecrets(root, { apiKey: 'openai-key', model: 'openai/gpt-5.4-nano', discordBotToken: 'discord-tok' })
 
-    const secrets = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
-      channels?: Record<string, Record<string, unknown>>
-    }
+    const secrets = await readSecrets(root)
     expect(secrets.channels?.['discord-bot']).toEqual({ token: { value: 'discord-tok' } })
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('OPENAI_API_KEY=sk-x\n')
+    expect(secrets.providers?.openai).toEqual({ type: 'api_key', key: { value: 'openai-key' } })
   })
 
   test('merges botToken + appToken into the same slack-bot slot in secrets.json', async () => {
     await writeSecrets(root, {
-      apiKey: 'sk-x',
+      apiKey: 'openai-key',
       model: 'openai/gpt-5.4-nano',
       slackBotToken: 'xoxb-a',
       slackAppToken: 'xapp-b',
     })
 
-    const secrets = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
-      channels?: Record<string, Record<string, unknown>>
-    }
+    const secrets = await readSecrets(root)
     expect(secrets.channels?.['slack-bot']).toEqual({
       botToken: { value: 'xoxb-a' },
       appToken: { value: 'xapp-b' },
@@ -1316,8 +1332,8 @@ describe('writeSecrets', () => {
       telegramBotToken: '',
     })
 
-    expect(await readFile(join(root, '.env'), 'utf8')).toBe('FIREWORKS_API_KEY=fw_test\n')
-    expect(existsSync(join(root, 'secrets.json'))).toBe(false)
+    expect((await readSecrets(root)).providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_test' } })
+    expect((await readSecrets(root)).channels).toEqual({})
   })
 })
 

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -4,7 +4,13 @@ import { basename, dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { config, configSchema, migrateLegacyConfigShape, type Config } from '@/config'
-import { DEFAULT_MODEL_REF, KNOWN_PROVIDERS, providerForModelRef, type KnownModelRef } from '@/config/providers'
+import {
+  DEFAULT_MODEL_REF,
+  KNOWN_PROVIDERS,
+  providerForModelRef,
+  type KnownModelRef,
+  type KnownProviderId,
+} from '@/config/providers'
 import { checkDockerAvailable, type DockerAvailability, type DockerExec, start } from '@/container'
 import { type Channels, type Secret, SecretsBackend } from '@/secrets'
 import { createTui } from '@/tui'
@@ -590,12 +596,7 @@ export async function writeSecrets(
 ): Promise<void> {
   const providerId = providerForModelRef(model)
   const apiKeyEnv = KNOWN_PROVIDERS[providerId].apiKeyEnv
-  const lines: string[] = []
-  if (apiKey !== undefined && apiKeyEnv !== null) {
-    lines.push(`${apiKeyEnv}=${apiKey}`)
-  }
-  const body = lines.length > 0 ? `${lines.join('\n')}\n` : ''
-  await writeFile(join(root, SECRETS_FILE), body)
+  await writeEnvFile(root, apiKeyEnv === null || apiKey === undefined ? undefined : { name: apiKeyEnv, value: apiKey })
 
   const channelTokens: Record<string, Record<string, Secret>> = {}
   if (discordBotToken !== undefined && discordBotToken !== '') {
@@ -621,6 +622,64 @@ export async function writeSecrets(
     merged[adapterId] = priorSlot as Channels[string]
   }
   backend.writeChannelsSync(merged)
+}
+
+export async function readExistingProviderApiKey(root: string, providerId: KnownProviderId): Promise<string | null> {
+  const apiKeyEnv = KNOWN_PROVIDERS[providerId].apiKeyEnv
+  if (apiKeyEnv === null) return null
+  const env = await readEnvFile(root)
+  const value = env.values.get(apiKeyEnv)
+  return value !== undefined && value.trim() !== '' ? value : null
+}
+
+async function writeEnvFile(root: string, apiKey: { name: string; value: string } | undefined): Promise<void> {
+  const env = await readEnvFile(root)
+  if (apiKey === undefined) {
+    await writeFile(join(root, SECRETS_FILE), env.body)
+    return
+  }
+
+  const lines = env.lines.slice()
+  const existingLine = env.entries.get(apiKey.name)
+  if (existingLine !== undefined) {
+    lines[existingLine] = `${apiKey.name}=${apiKey.value}`
+  } else {
+    lines.push(`${apiKey.name}=${apiKey.value}`)
+  }
+  await writeFile(join(root, SECRETS_FILE), lines.length > 0 ? `${lines.join('\n')}\n` : '')
+}
+
+async function readEnvFile(
+  root: string,
+): Promise<{ body: string; lines: string[]; entries: Map<string, number>; values: Map<string, string> }> {
+  let body: string
+  try {
+    body = await readFile(join(root, SECRETS_FILE), 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    body = ''
+  }
+
+  const lines = body === '' ? [] : body.replace(/\n$/, '').split('\n')
+  const entries = new Map<string, number>()
+  const values = new Map<string, string>()
+  for (const [index, line] of lines.entries()) {
+    const parsed = parseEnvLine(line)
+    if (parsed === null) continue
+    entries.set(parsed.name, index)
+    values.set(parsed.name, parsed.value)
+  }
+  return { body, lines, entries, values }
+}
+
+function parseEnvLine(line: string): { name: string; value: string } | null {
+  const trimmed = line.trimStart()
+  if (trimmed === '' || trimmed.startsWith('#')) return null
+  const separator = line.indexOf('=')
+  if (separator <= 0) return null
+  const name = line.slice(0, separator).trim()
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) return null
+  return { name, value: line.slice(separator + 1) }
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -12,7 +12,7 @@ import {
   type KnownProviderId,
 } from '@/config/providers'
 import { checkDockerAvailable, type DockerAvailability, type DockerExec, start } from '@/container'
-import { type Channels, type Secret, SecretsBackend } from '@/secrets'
+import { createSecretsStoreForAgent, type Channels, type Secret, SecretsBackend } from '@/secrets'
 import { createTui } from '@/tui'
 
 import { resolveBaseImageVersion, resolveScaffoldVersion } from './cli-version'
@@ -29,7 +29,6 @@ export { GITKEEP_FILE, PACKAGES_DIR } from './paths'
 
 const CONFIG_FILE = 'typeclaw.json'
 const CRON_FILE = 'cron.json'
-const SECRETS_FILE = '.env'
 const PACKAGE_FILE = 'package.json'
 
 const MARKDOWN_FILES = ['AGENTS.md', 'IDENTITY.md', 'SOUL.md', 'USER.md'] as const
@@ -564,15 +563,10 @@ export async function initGitRepo(cwd: string): Promise<GitInitResult> {
   }
 }
 
-// Writes the LLM provider's API key to `.env` (under its provider-specific
-// env var, e.g. OPENAI_API_KEY or FIREWORKS_API_KEY) and the channel adapter
-// tokens to `secrets.json#channels`. Two stores on purpose: api-keys land in
-// `.env` to match the `--env-file .env` boot contract (env-wins: `auth.ts`
-// reads the value at runtime via `setRuntimeApiKey` and never persists it to
-// `secrets.json`, see `src/agent/auth.ts`); channel tokens skip the .env hop
-// entirely and land in `secrets.json#channels` as `{ value }` Secrets that
-// `hydrateChannelEnvFromSecrets` injects into `process.env` only when the
-// canonical env var is unset, see `src/secrets/hydrate.ts`.
+// Writes LLM provider API keys to `secrets.json#providers` and channel adapter
+// tokens to `secrets.json#channels`. Both paths go through the structured
+// v2 secrets envelope so reruns can reuse existing values without depending on
+// host-stage env files.
 export async function writeSecrets(
   root: string,
   {
@@ -584,9 +578,7 @@ export async function writeSecrets(
     telegramBotToken,
   }: {
     model?: KnownModelRef
-    // Omitted on the OAuth path — credentials live in secrets.json instead.
-    // The .env file still gets written (empty) so post-init callers that
-    // read it don't ENOENT-crash.
+    // Omitted on the OAuth path — credentials live in secrets.json via the OAuth runner.
     apiKey?: string
     discordBotToken?: string
     slackBotToken?: string
@@ -596,7 +588,9 @@ export async function writeSecrets(
 ): Promise<void> {
   const providerId = providerForModelRef(model)
   const apiKeyEnv = KNOWN_PROVIDERS[providerId].apiKeyEnv
-  await writeEnvFile(root, apiKeyEnv === null || apiKey === undefined ? undefined : { name: apiKeyEnv, value: apiKey })
+  if (apiKey !== undefined && apiKeyEnv !== null) {
+    createSecretsStoreForAgent(join(root, 'secrets.json')).set(providerId, { type: 'api_key', key: apiKey })
+  }
 
   const channelTokens: Record<string, Record<string, Secret>> = {}
   if (discordBotToken !== undefined && discordBotToken !== '') {
@@ -625,61 +619,9 @@ export async function writeSecrets(
 }
 
 export async function readExistingProviderApiKey(root: string, providerId: KnownProviderId): Promise<string | null> {
-  const apiKeyEnv = KNOWN_PROVIDERS[providerId].apiKeyEnv
-  if (apiKeyEnv === null) return null
-  const env = await readEnvFile(root)
-  const value = env.values.get(apiKeyEnv)
-  return value !== undefined && value.trim() !== '' ? value : null
-}
-
-async function writeEnvFile(root: string, apiKey: { name: string; value: string } | undefined): Promise<void> {
-  const env = await readEnvFile(root)
-  if (apiKey === undefined) {
-    await writeFile(join(root, SECRETS_FILE), env.body)
-    return
-  }
-
-  const lines = env.lines.slice()
-  const existingLine = env.entries.get(apiKey.name)
-  if (existingLine !== undefined) {
-    lines[existingLine] = `${apiKey.name}=${apiKey.value}`
-  } else {
-    lines.push(`${apiKey.name}=${apiKey.value}`)
-  }
-  await writeFile(join(root, SECRETS_FILE), lines.length > 0 ? `${lines.join('\n')}\n` : '')
-}
-
-async function readEnvFile(
-  root: string,
-): Promise<{ body: string; lines: string[]; entries: Map<string, number>; values: Map<string, string> }> {
-  let body: string
-  try {
-    body = await readFile(join(root, SECRETS_FILE), 'utf8')
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-    body = ''
-  }
-
-  const lines = body === '' ? [] : body.replace(/\n$/, '').split('\n')
-  const entries = new Map<string, number>()
-  const values = new Map<string, string>()
-  for (const [index, line] of lines.entries()) {
-    const parsed = parseEnvLine(line)
-    if (parsed === null) continue
-    entries.set(parsed.name, index)
-    values.set(parsed.name, parsed.value)
-  }
-  return { body, lines, entries, values }
-}
-
-function parseEnvLine(line: string): { name: string; value: string } | null {
-  const trimmed = line.trimStart()
-  if (trimmed === '' || trimmed.startsWith('#')) return null
-  const separator = line.indexOf('=')
-  if (separator <= 0) return null
-  const name = line.slice(0, separator).trim()
-  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) return null
-  return { name, value: line.slice(separator + 1) }
+  const provider = KNOWN_PROVIDERS[providerId]
+  if (provider.apiKeyEnv === null) return null
+  return new SecretsBackend(join(root, 'secrets.json')).tryReadProviderApiKeySync(providerId)
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {

--- a/src/secrets/storage.ts
+++ b/src/secrets/storage.ts
@@ -160,6 +160,21 @@ export class SecretsBackend implements AuthStorageBackend {
     }
   }
 
+  tryReadProviderApiKeySync(providerId: string, env: NodeJS.ProcessEnv = process.env): string | null {
+    if (!existsSync(this.secretsPath)) return null
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      const credential = this.readEnvelope().providers[providerId]
+      if (credential?.type !== 'api_key') return null
+      const resolved =
+        resolveSecret(credential.key, providerKeyDefaultEnv(providerId), env) ?? credential.key.value ?? ''
+      return resolved.trim() !== '' ? resolved : null
+    } finally {
+      release?.()
+    }
+  }
+
   writeChannelsSync(next: Channels): void {
     this.ensureParentDir()
     this.ensureFileExists()


### PR DESCRIPTION
## Summary
- Reuse existing provider API keys from `secrets.json#providers` during `typeclaw init` reruns after asking the user to confirm reuse.
- Save newly entered init API keys to the structured `secrets.json` provider store instead of writing `.env`.
- Add tests for provider-key storage, existing-key lookup, reuse confirmation, blank values, and channel-add preservation.

## Verification
- `bun test src/cli/init.test.ts src/init/index.test.ts src/secrets/storage.test.ts`
- `bun test src/init/add-channel.test.ts src/cli/init.test.ts src/init/index.test.ts src/secrets/storage.test.ts`
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run test`