### PR TITLE
Allow ESTABLISHED,RELATED in egress shim so Docker port-forward replies survive RFC1918 REJECTs

### DIFF
--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -421,6 +421,21 @@ describe('network egress entrypoint shim', () => {
     expect(shim).toContain('ip6tables -A OUTPUT -o lo -j ACCEPT')
   })
 
+  test('allows ESTABLISHED,RELATED return traffic so Docker port-forward replies survive the RFC1918 REJECT', () => {
+    const shim = buildEntrypointShim()
+    expect(shim).toContain('iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT')
+    expect(shim).toContain('ip6tables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT')
+  })
+
+  test('ESTABLISHED,RELATED ACCEPT runs before the RFC1918 REJECTs (first-match-wins ordering)', () => {
+    const shim = buildEntrypointShim()
+    const ctstateIdx = shim.indexOf('--ctstate ESTABLISHED,RELATED -j ACCEPT')
+    const rejectIdx = shim.indexOf('192.168.0.0/16 -j REJECT')
+    expect(ctstateIdx).toBeGreaterThan(-1)
+    expect(rejectIdx).toBeGreaterThan(-1)
+    expect(ctstateIdx).toBeLessThan(rejectIdx)
+  })
+
   test('re-allows hostd narrowly: TCP, single port parsed from TYPECLAW_HOSTD_URL, IPv4-only', () => {
     const shim = buildEntrypointShim()
     expect(shim).toContain('TYPECLAW_HOSTD_URL')

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -136,14 +136,38 @@ export const NETWORK_BLOCK_IPV6_NETS = ['fc00::/7', 'fe80::/10', 'ff00::/8', '::
 // Carve-out ordering is load-bearing. iptables OUTPUT is first-match-wins,
 // and we use -A (append). So the order written into the shim is the order
 // rules will be evaluated:
-//   1. loopback ACCEPT
-//   2. hostd port ACCEPT (narrow: tcp + single dport on the host gateway)
-//   3. resolver ACCEPT (narrow: udp/tcp dport 53 to each /etc/resolv.conf
+//   1. ESTABLISHED,RELATED ACCEPT (return path for any connection initiated
+//      from outside the container — see comment block below)
+//   2. loopback ACCEPT
+//   3. hostd port ACCEPT (narrow: tcp + single dport on the host gateway)
+//   4. resolver ACCEPT (narrow: udp/tcp dport 53 to each /etc/resolv.conf
 //      nameserver) — gated on TYPECLAW_NETWORK_AUTO_ALLOW_RESOLVERS=1
-//   4. user-supplied allowlist ACCEPT (wholesale: -d <cidr>) — driven by
+//   5. user-supplied allowlist ACCEPT (wholesale: -d <cidr>) — driven by
 //      TYPECLAW_NETWORK_ALLOW comma-separated env
-//   5. RFC1918 + link-local + CGNAT + multicast + reserved REJECTs
-// A resolver at 10.0.0.2 hits (3) and ACCEPTs before (5) DROPs it.
+//   6. RFC1918 + link-local + CGNAT + multicast + reserved REJECTs
+// A resolver at 10.0.0.2 hits (4) and ACCEPTs before (6) DROPs it.
+//
+// Rule 1 (conntrack ESTABLISHED,RELATED) is what makes Docker port-forward
+// reply traffic survive the RFC1918 REJECT. On Docker Desktop and OrbStack
+// the bridge gateway is in 192.168.0.0/16 (OrbStack: 192.168.215.1 or
+// 192.168.139.1; Docker Desktop: 192.168.65.1). A host -> container request
+// via `docker run -p 127.0.0.1:HOST:CONTAINER` arrives at the container
+// from the bridge gateway IP. Without rule 1, the reply packets would
+// match rule 6 (192.168.0.0/16 REJECT) and never reach the host — TCP
+// handshake completes (kernel SYN/ACK is in INPUT, not OUTPUT), the
+// request body is delivered, but the agent's HTTP response is dropped at
+// OUTPUT. Symptom: `curl http://127.0.0.1:HOST` connects but receives
+// zero bytes and times out. Stateful inversion via conntrack is the
+// canonical fix: ESTABLISHED matches packets belonging to a connection
+// the kernel already tracks (including the inbound port-forward), and
+// RELATED covers ICMP error packets for those connections. No new
+// outbound capability is granted — a compromised agent still cannot
+// initiate connections to RFC1918, only respond to inbound ones.
+//
+// Requires the `xt_conntrack` kernel module (universal on Linux 2.6.20+
+// and on every Docker/OrbStack VM kernel) and the userspace iptables
+// `conntrack` match (shipped in the `iptables` Debian package on trixie
+// alongside the binary itself; no extra apt install needed).
 //
 // The resolver carve-out reads /etc/resolv.conf inside the container, NOT
 // on the host. Docker propagates the host's resolver into the container by
@@ -186,6 +210,7 @@ if [ "\${TYPECLAW_NETWORK_BLOCK_INTERNAL:-0}" != "1" ]; then
   exec bun run typeclaw "$@"
 fi
 
+iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -o lo -j ACCEPT
 
 # Hostd HTTP control carve-out: narrow ACCEPT, scoped to one TCP port on
@@ -222,6 +247,7 @@ if [ -n "\${TYPECLAW_NETWORK_ALLOW:-}" ]; then
 fi
 ${ipv4Rules.join('\n')}
 
+ip6tables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 ip6tables -A OUTPUT -o lo -j ACCEPT
 ${ipv6Rules.join('\n')}
 


### PR DESCRIPTION
## Bug

Since v0.1.3 (\`network.blockInternal\` defaults to \`true\`), Docker port forwarding silently fails on Docker Desktop and OrbStack. Symptom:

```
typeclaw init fails during hatching:
  timed out waiting for agent at http://localhost:<port>: The socket connection was closed unexpectedly

typeclaw tui hangs at:
  connecting to ws://127.0.0.1:<port>/?token=...
```

And from the host side:

```
$ curl -v http://127.0.0.1:<HOST_PORT>
* Connected to 127.0.0.1 (<HOST_PORT>) port <HOST_PORT>
> GET / HTTP/1.1
...
# hangs, eventually:
curl: (52) Empty reply from server
```

Root cause: the egress shim installs `iptables OUTPUT` rules that REJECT all outbound traffic to RFC1918 networks (including 192.168.0.0/16). On Docker Desktop the bridge gateway is `192.168.65.1`; on OrbStack it is `192.168.215.1` or `192.168.139.1` — both in `192.168.0.0/16`. When a host request arrives via `docker run -p 127.0.0.1:HOST:CONTAINER`, the TCP handshake completes at the kernel level (SYN/ACK lives in the INPUT chain, not OUTPUT), the request body is delivered and the agent's HTTP server sees it and generates a reply — but the **reply packet** has the bridge gateway as its destination, matches the RFC1918 REJECT rule, and is dropped before it reaches the host.

The commit that introduced the shim (`362f1fc`) and the one that flipped the default (`12098bd`) both predated this discovery. Containers started before May 12 (when the shim landed) appeared to work; they broke too once stopped and restarted with `--build`.

```
# iptables -L OUTPUT -n -v (inside the container, before this fix)
Chain OUTPUT (policy ACCEPT)
target     prot opt source        destination
ACCEPT     all  --  0.0.0.0/0     0.0.0.0/0
REJECT     all  --  0.0.0.0/0     192.168.0.0/16     reject-with icmp-port-unreachable
...

# counting rejected packets while a host curl sat waiting:
24 packets, 1440 bytes REJECTED to 192.168.0.0/16 — exact match for the response payload
```

## Fix

Add `iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT` (and its `ip6tables` counterpart) as the **first** rule in the OUTPUT chain. This is the canonical stateful-firewall pattern: conntrack ESTABLISHED matches reply packets for connections the kernel is already tracking (including inbound port-forwards), RELATED covers ICMP error traffic for those connections. The rule is installed first so it evaluates before the RFC1918 REJECTs.

Security property preserved: a compromised agent still cannot **initiate** new connections to RFC1918 — only respond to inbound ones it never chose.

```
# iptables -L OUTPUT -n -v (after the fix)
Chain OUTPUT (policy ACCEPT)
target     prot opt source        destination
ACCEPT     all  --  0.0.0.0/0     0.0.0.0/0            ctstate RELATED,ESTABLISHED
ACCEPT     all  --  0.0.0.0/0     0.0.0.0/0
REJECT     all  --  0.0.0.0/0     192.168.0.0/16     reject-with icmp-port-unreachable
...

$ curl http://127.0.0.1:<HOST_PORT>
typeclaw agent
```

`xt_conntrack` is universal on Linux 2.6.20+ and on every Docker/OrbStack VM kernel. The `conntrack` match is shipped in the `iptables` Debian package on trixie alongside the binary itself — no extra `apt install` needed.

## Changes

- `src/init/dockerfile.ts` — adds the conntrack ACCEPT rules for both IPv4 and IPv6, plus a 20-line comment block explaining the symptom, the fix, the kernel module dependency, and why this does not widen outbound capability. Renumbers the "carve-out ordering is load-bearing" comment to reflect the new rule 1.
- `src/init/dockerfile.test.ts` — two new tests: presence of the conntrack ACCEPT rule for both `iptables` and `ip6tables`, and ordering (ESTABLISHED,RELATED ACCEPT must appear before the first RFC1918 REJECT in the generated shim string).

## Verification

Built a fresh container on OrbStack with the fix applied:

1. Inspected the OUTPUT chain — ctstate ACCEPT at position 1, all REJECT rules below it.
2. `curl http://127.0.0.1:<port>` from host returns `typeclaw agent` (was timing out without the fix on the same OrbStack/Mac combination).
3. Disabled the fix on the same host — same probe timed out after 5 s.
4. Pre-commit checks:
   - `bun run typecheck` — clean
   - `bun run lint` — 0 errors (3 pre-existing warnings unrelated to this change)
   - `bun run format:check` — clean
   - `bun test` — 3149 pass / 0 fail