### PR TITLE
Log LLM prompt failures via server logger so typeclaw logs surfaces them

### DIFF
--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -9,7 +9,7 @@ import type { SessionFactory } from '@/sessions'
 import type { ServerMessage } from '@/shared'
 import { createStream } from '@/stream'
 
-import { createServer } from './index'
+import { createServer, type ServerLogger } from './index'
 
 function makeRuntime(opts: { registry: PluginRegistry; hooks: HookBus }): PluginRuntime {
   return createPluginRuntime({
@@ -95,6 +95,7 @@ async function startWithSession(
     agentDir?: string
     pluginRegistry?: PluginRegistry
     pluginHooks?: HookBus
+    logger?: ServerLogger
   } = {},
 ): Promise<{ url: string }> {
   const pluginRuntime =
@@ -108,6 +109,7 @@ async function startWithSession(
     ...(extra.sessionFactory ? { sessionFactory: extra.sessionFactory } : {}),
     ...(extra.agentDir !== undefined ? { agentDir: extra.agentDir } : {}),
     ...(pluginRuntime ? { pluginRuntime } : {}),
+    ...(extra.logger ? { logger: extra.logger } : {}),
   }).start()
   server = built
   return { url: `ws://localhost:${built.port}` }
@@ -820,6 +822,112 @@ describe('createServer fires session.idle hook after every prompt completion', (
     const done = await waitFor((m) => m.type === 'done')
 
     expect(done.type).toBe('done')
+    ws.close()
+  })
+})
+
+describe('createServer surfaces LLM errors to logger', () => {
+  function stubSessionFactory(): SessionFactory {
+    return {
+      sessionDir: () => '/tmp/test-sessions',
+      createPersisted: () =>
+        ({
+          getSessionId: () => 'ses_fake',
+          getSessionFile: () => undefined,
+        }) as unknown as SessionManager,
+    }
+  }
+
+  const silentLogger: ServerLogger = { info: () => {}, warn: () => {}, error: () => {} }
+
+  test('logs to logger.error when session.prompt() throws in the drain-loop path (so typeclaw logs surfaces the failure)', async () => {
+    const errors: string[] = []
+    const session = createFakeSession()
+    const stream = createStream()
+
+    const { url } = await startWithSession(session, {
+      stream,
+      sessionFactory: stubSessionFactory(),
+      logger: { ...silentLogger, error: (m) => errors.push(m) },
+    })
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    stream.publish({
+      target: { kind: 'session', sessionId: 'ses_fake' },
+      payload: { kind: 'prompt', text: 'hi', delivery: 'queue' },
+    })
+    await new Promise((r) => setTimeout(r, 10))
+    session.rejectPrompt(new Error('llm boom'))
+    const errFrame = await waitFor((m) => m.type === 'error')
+
+    if (errFrame.type !== 'error') throw new Error('unreachable')
+    expect(errFrame.message).toBe('llm boom')
+    expect(errors.some((e) => /\[server\] ses_fake: prompt failed: llm boom/.test(e))).toBe(true)
+    ws.close()
+  })
+
+  test('logs to logger.error when session.prompt() throws in the fallback path (no stream)', async () => {
+    const errors: string[] = []
+    const session = createFakeSession()
+
+    const { url } = await startWithSession(session, {
+      logger: { ...silentLogger, error: (m) => errors.push(m) },
+    })
+    const { ws, waitFor } = await connect(url)
+    const opened = await waitFor((m) => m.type === 'connected')
+    if (opened.type !== 'connected') throw new Error('unreachable')
+
+    ws.send(JSON.stringify({ type: 'prompt', text: 'hello' }))
+    await new Promise((r) => setTimeout(r, 10))
+    session.rejectPrompt(new Error('fallback boom'))
+    const errFrame = await waitFor((m) => m.type === 'error')
+
+    if (errFrame.type !== 'error') throw new Error('unreachable')
+    expect(errFrame.message).toBe('fallback boom')
+    expect(errors.some((e) => /\[server\] .+: prompt failed: fallback boom/.test(e))).toBe(true)
+    ws.close()
+  })
+
+  test('logs to logger.error when the assistant message ends with stopReason: error (non-throwing upstream LLM failure)', async () => {
+    const errors: string[] = []
+    const session = createFakeSession()
+
+    const { url } = await startWithSession(session, {
+      logger: { ...silentLogger, error: (m) => errors.push(m) },
+    })
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    session.emit({
+      type: 'message_end',
+      message: { role: 'assistant', stopReason: 'error', errorMessage: 'billing: account inactive' },
+    } as unknown as Parameters<typeof session.emit>[0])
+
+    const errFrame = await waitFor((m) => m.type === 'error')
+    if (errFrame.type !== 'error') throw new Error('unreachable')
+    expect(errFrame.message).toBe('billing: account inactive')
+    expect(errors.some((e) => /\[server\] .+: LLM call failed: billing: account inactive/.test(e))).toBe(true)
+    ws.close()
+  })
+
+  test('does not log when the assistant message ends with stopReason: aborted (user pressed Escape)', async () => {
+    const errors: string[] = []
+    const session = createFakeSession()
+
+    const { url } = await startWithSession(session, {
+      logger: { ...silentLogger, error: (m) => errors.push(m) },
+    })
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    session.emit({
+      type: 'message_end',
+      message: { role: 'assistant', stopReason: 'aborted' },
+    } as unknown as Parameters<typeof session.emit>[0])
+
+    await new Promise((r) => setTimeout(r, 20))
+    expect(errors).toEqual([])
     ws.close()
   })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -20,6 +20,12 @@ import type { Stream, StreamMessage, StreamMessageId, Unsubscribe } from '@/stre
 export type ReloadAllFn = () => Promise<ReloadAllResult>
 export type CreateSessionFn = (options?: CreateSessionOptions) => Promise<AgentSession | CreateSessionResult>
 
+export type ServerLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
 export type ServerOptions = {
   port: number
   reloadAll?: ReloadAllFn
@@ -37,6 +43,16 @@ export type ServerOptions = {
   // sessions. Omit to keep TUI-only behavior (used by tests + non-container
   // dev runs).
   containerBroker?: ContainerBroker
+  // Optional logger for server-side events. Defaults to `consoleLogger`
+  // which writes to stdout/stderr so `typeclaw logs` surfaces every event.
+  // Tests inject a fake logger to assert on captured output.
+  logger?: ServerLogger
+}
+
+const consoleLogger: ServerLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+  error: (m) => console.error(m),
 }
 
 export type Server = ReturnType<typeof createServer>
@@ -85,6 +101,7 @@ export function createServer({
   containerName,
   tuiToken,
   containerBroker,
+  logger = consoleLogger,
 }: ServerOptions) {
   const sessionStates = new WeakMap<Ws, SessionState>()
 
@@ -162,11 +179,11 @@ export function createServer({
               await runtimeSnapshot.hooks.runSessionStart({ sessionId: sessionFileId, agentDir })
             }
 
-            forwardSessionEvents(ws, session)
+            forwardSessionEvents(ws, session, logger, sessionFileId)
 
             if (stream) {
               state.unsubPrompts = stream.subscribe({ target: { kind: 'session', sessionId: sessionFileId } }, (msg) =>
-                enqueuePrompt(ws, state, msg, agentDir),
+                enqueuePrompt(ws, state, msg, agentDir, logger),
               )
 
               state.unsubBroadcast = stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => {
@@ -250,7 +267,9 @@ export function createServer({
               await state.session.prompt(msg.text)
               send(ws, { type: 'done' })
             } catch (err) {
-              send(ws, { type: 'error', message: err instanceof Error ? err.message : String(err) })
+              const message = err instanceof Error ? err.message : String(err)
+              logger.error(`[server] ${state.sessionFileId}: prompt failed: ${message}`)
+              send(ws, { type: 'error', message })
             }
             if (fallbackHooks !== undefined && agentDir !== undefined) {
               await fallbackHooks.runSessionTurnEnd({
@@ -305,7 +324,7 @@ function isWebSocketUpgrade(req: Request): boolean {
   return req.headers.get('upgrade')?.toLowerCase() === 'websocket'
 }
 
-function forwardSessionEvents(ws: Ws, session: AgentSession): void {
+function forwardSessionEvents(ws: Ws, session: AgentSession, logger: ServerLogger, sessionFileId: string): void {
   const toolStartedAt = new Map<string, number>()
 
   session.subscribe((event) => {
@@ -323,7 +342,7 @@ function forwardSessionEvents(ws: Ws, session: AgentSession): void {
         // because no text deltas were ever emitted, which looks like a freeze.
         // The server's existing try/catch around `session.prompt()` only
         // catches throws, so it never sees these.
-        forwardAssistantError(ws, event.message)
+        forwardAssistantError(ws, event.message, logger, sessionFileId)
         break
       case 'tool_execution_start':
         toolStartedAt.set(event.toolCallId, Date.now())
@@ -352,7 +371,7 @@ function forwardSessionEvents(ws: Ws, session: AgentSession): void {
   })
 }
 
-function forwardAssistantError(ws: Ws, message: unknown): void {
+function forwardAssistantError(ws: Ws, message: unknown, logger: ServerLogger, sessionFileId: string): void {
   if (typeof message !== 'object' || message === null) return
   const m = message as { role?: string; stopReason?: string; errorMessage?: string }
   if (m.role !== 'assistant') return
@@ -361,10 +380,17 @@ function forwardAssistantError(ws: Ws, message: unknown): void {
   // error message because the TUI already shows abort feedback elsewhere.
   if (m.stopReason === 'aborted') return
   const text = typeof m.errorMessage === 'string' && m.errorMessage.length > 0 ? m.errorMessage : 'LLM call failed'
+  logger.error(`[server] ${sessionFileId}: LLM call failed: ${text}`)
   send(ws, { type: 'error', message: text })
 }
 
-function enqueuePrompt(ws: Ws, state: SessionState, msg: StreamMessage, agentDir: string | undefined): void {
+function enqueuePrompt(
+  ws: Ws,
+  state: SessionState,
+  msg: StreamMessage,
+  agentDir: string | undefined,
+  logger: ServerLogger,
+): void {
   const payload = msg.payload as { kind?: string; text?: string; delivery?: PromptDelivery }
   if (payload?.kind !== 'prompt' || typeof payload.text !== 'string') return
   const delivery: PromptDelivery = payload.delivery ?? 'queue'
@@ -380,7 +406,7 @@ function enqueuePrompt(ws: Ws, state: SessionState, msg: StreamMessage, agentDir
     ts: msg.ts,
   })
   pushQueueState(ws, state)
-  void drain(ws, state, agentDir)
+  void drain(ws, state, agentDir, logger)
 }
 
 // `session.idle` semantically means "the agent finished a prompt and is now
@@ -416,7 +442,7 @@ function makeTurnHookCallers(
   }
 }
 
-async function drain(ws: Ws, state: SessionState, agentDir: string | undefined): Promise<void> {
+async function drain(ws: Ws, state: SessionState, agentDir: string | undefined, logger: ServerLogger): Promise<void> {
   if (state.draining) return
   state.draining = true
   const fireIdle = makeIdleHookCaller(state)
@@ -433,7 +459,9 @@ async function drain(ws: Ws, state: SessionState, agentDir: string | undefined):
         await state.session.prompt(item.text)
         send(ws, { type: 'done' })
       } catch (err) {
-        send(ws, { type: 'error', message: err instanceof Error ? err.message : String(err) })
+        const message = err instanceof Error ? err.message : String(err)
+        logger.error(`[server] ${state.sessionFileId}: prompt failed: ${message}`)
+        send(ws, { type: 'error', message })
       }
       await fireTurnEnd()
       await fireIdle()


### PR DESCRIPTION
## Summary

When a TUI or channel websocket session's `session.prompt()` threw — or when `pi-coding-agent` encoded an upstream LLM failure as an assistant message with `stopReason: 'error'` — the server caught the failure but only sent it over the websocket. The container's stdout/stderr never saw it, so `typeclaw logs` (which streams `docker logs --timestamps`) showed nothing. Diagnosing a silent agent required attaching a TUI and waiting for the next failure to appear live.

Cron and subagent paths already log to `console.error` via their injected logger (`CronConsumerLogger` / equivalent), and the channel router logs via `logger.warn`. Only the TUI/server path was silent.

## Why now

The three places that swallow prompt failures in `src/server/index.ts` — the fallback no-stream catch (line ~250), the drain-loop catch (line ~433), and `forwardAssistantError` (line ~355) — all called `send(ws, { type: 'error', message })` without any matching `console.error`. `typeclaw logs` is the first thing a user reaches for when an agent stops responding; it should surface LLM errors without requiring a live TUI session.

## What this PR does

- Adds a `ServerLogger` type (`info / warn / error`) to `src/server/index.ts`, mirroring `CronConsumerLogger`.
- Adds an optional `logger?: ServerLogger` field to `ServerOptions`, defaulting to a `consoleLogger` that writes to `console.log / console.warn / console.error`.
- Threads `logger` (plus `sessionFileId` where needed) through `forwardSessionEvents`, `forwardAssistantError`, `enqueuePrompt`, and `drain`.
- Calls `logger.error('[server] <sessionId>: prompt failed: <message>')` in both prompt-throw catch blocks.
- Calls `logger.error('[server] <sessionId>: LLM call failed: <text>')` inside `forwardAssistantError` (handles the non-throwing `stopReason: 'error'` case).

The `[server]` tag matches the existing `[cron]` / `[subagent]` / `[channels]` convention. The websocket protocol is unchanged — TUI clients receive identical error frames. The `'aborted'` branch is unchanged: no log on user Escape.

## Mutation check (AGENTS.md §3)

Commenting out each new `logger.error(...)` line causes the corresponding new test to fail. Verified.

## Testing

Four new tests in `src/server/index.test.ts` under a new `describe('createServer surfaces LLM errors to logger', ...)` block:

1. **Drain-loop prompt throw** — verifies both the websocket error frame AND that the injected logger captured `[server] ses_fake: prompt failed: llm boom`.
2. **Fallback no-stream prompt throw** — verifies both surfaces.
3. **Non-throwing upstream LLM failure (`stopReason: 'error'`)** — verifies `[server] <id>: LLM call failed: <text>` is logged.
4. **`stopReason: 'aborted'` does NOT log** — guards against false positives on user Escape.

All tests follow the codebase convention: real WebSocket via `Bun.serve`, fake `AgentSession` via `createFakeSession()` with `resolvePrompt()` / `rejectPrompt()`, and an injected logger that captures errors into an array. No `jest.spyOn` or console rebinding.

## Risk and rollback

Risk is minimal. The `logger` defaults to `console.log / console.warn / console.error`, which is the same output channel the rest of the runtime uses. Existing `ServerOptions` callers that don't pass `logger` get identical behavior plus the new error lines on failure paths. The websocket protocol is untouched.

Rollback: revert the merged PR. No schema changes, no config fields, no on-disk state.

## Verification

```
bun run typecheck     # passes
bun run lint          # 8 pre-existing warnings on main, 0 errors, 0 new warnings on touched files
bun run format:check  # passes
bun test --timeout 30000  # 3096 pass, 0 fail across 185 files
```

## Stats

2 files changed, 147 insertions(+), 11 deletions(−).

## Out of scope

- The `abort()` `.catch()` at the top of `enqueuePrompt` (abort-RPC failures, not LLM errors) is left alone.
- Lifecycle `console.log` calls (session open/close, "typeclaw agent listening") are not converted — informational, not error-related.