### PR TITLE
Teach the agent about the permission system

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -330,6 +330,125 @@ describe('createResourceLoader', () => {
     // then
     expect(capturedOrigin).toEqual(origin)
   })
+
+  test('renders the role/permissions block when a PermissionService is provided for a channel session', async () => {
+    // given: a permission service with an author-scoped member rule
+    const { createPermissionService } = await import('@/permissions')
+    const permissions = createPermissionService({
+      roles: {
+        member: {
+          match: [{ kind: 'channel', platform: 'slack', workspace: 'T0', chat: 'C0', author: 'U_ME' }],
+          permissions: ['channel.respond'],
+        },
+      },
+    })
+    const origin: SessionOrigin = {
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: null,
+      lastInboundAuthorId: 'U_ME',
+    }
+
+    // when
+    const loader = await createResourceLoader({ agentDir, origin, permissions })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).toContain('## Your role in this session')
+    expect(prompt).toContain('`member`')
+    expect(prompt).toContain('`channel.respond`')
+  })
+
+  test('omits the role block when permissions is not provided (preserves prior behavior)', async () => {
+    // given: a channel origin but no permission service
+    const origin: SessionOrigin = {
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: null,
+    }
+
+    // when
+    const loader = await createResourceLoader({ agentDir, origin })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).not.toContain('## Your role in this session')
+  })
+
+  test('places the role block before the gitNudge so dirty-files stays in the cache suffix', async () => {
+    // given: a git repo with a dirty tracked file so gitNudge will render,
+    // plus a permission service that will produce a role block
+    await initGitRepo(agentDir)
+    await writeFile(join(agentDir, 'tracked.md'), 'initial')
+    await runGit(agentDir, ['add', '.'])
+    await runGit(agentDir, ['commit', '-q', '-m', 'init'])
+    await writeFile(join(agentDir, 'tracked.md'), 'dirty edit')
+
+    const { createPermissionService } = await import('@/permissions')
+    const permissions = createPermissionService({
+      roles: {
+        member: {
+          match: [{ kind: 'channel', platform: 'slack', workspace: 'T0', chat: 'C0' }],
+          permissions: ['channel.respond'],
+        },
+      },
+    })
+    const origin: SessionOrigin = {
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: null,
+    }
+
+    // when
+    const loader = await createResourceLoader({ agentDir, origin, permissions })
+
+    // then: role block appears, gitNudge appears, and gitNudge is AFTER the role block
+    const prompt = loader.getSystemPrompt() ?? ''
+    const roleIdx = prompt.indexOf('## Your role in this session')
+    const nudgeIdx = prompt.indexOf('tracked.md')
+    expect(roleIdx).toBeGreaterThan(-1)
+    expect(nudgeIdx).toBeGreaterThan(-1)
+    expect(roleIdx).toBeLessThan(nudgeIdx)
+  })
+
+  test('TUI session resolving to owner does not render the role block (token-saving common case)', async () => {
+    // given: no user roles declared, so TUI resolves to built-in owner
+    const { createPermissionService } = await import('@/permissions')
+    const permissions = createPermissionService({})
+    const origin: SessionOrigin = { kind: 'tui', sessionId: 'ses_t' }
+
+    // when
+    const loader = await createResourceLoader({ agentDir, origin, permissions })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).not.toContain('## Your role in this session')
+  })
+
+  test('TUI session demoted by a user-declared role DOES render the role block', async () => {
+    // given: a custom role declared BEFORE owner with match: ['tui']
+    const { createPermissionService } = await import('@/permissions')
+    const permissions = createPermissionService({
+      roles: {
+        guest: { match: [{ kind: 'tui' }], permissions: [] },
+      },
+    })
+    const origin: SessionOrigin = { kind: 'tui', sessionId: 'ses_t' }
+
+    // when
+    const loader = await createResourceLoader({ agentDir, origin, permissions })
+
+    // then: the agent sees its demoted role
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).toContain('## Your role in this session')
+    expect(prompt).toContain('`guest`')
+  })
 })
 
 describe('createOverrideResourceLoader', () => {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -7,6 +7,7 @@ import type { AgentSession, ToolDefinition } from '@mariozechner/pi-coding-agent
 
 import type { ChannelRouter } from '@/channels/router'
 import { getConfig, resolveModel } from '@/config'
+import type { PermissionService } from '@/permissions'
 import type {
   BuiltinToolRef,
   HookBus,
@@ -25,7 +26,7 @@ import { renderGitNudge } from './git-nudge'
 import { resolveBuiltinToolRefs, wrapPluginTool, wrapSystemAgentTool, wrapSystemTool } from './plugin-tools'
 import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
-import { renderSessionOrigin, type SessionOrigin } from './session-origin'
+import { renderSessionOrigin, type SessionOrigin, type SessionRoleContext } from './session-origin'
 import { DEFAULT_SYSTEM_PROMPT } from './system-prompt'
 import { createChannelFetchAttachmentTool } from './tools/channel-fetch-attachment'
 import { createChannelHistoryTool } from './tools/channel-history'
@@ -94,6 +95,13 @@ export type CreateSessionOptions = {
   // Enables the `restart` tool. Set when the agent is running inside a
   // typeclaw-managed container. Read from TYPECLAW_CONTAINER_NAME at the call site.
   containerName?: string
+  // The permission service the runtime resolved at boot. When provided, the
+  // resolved role and permission list for `options.origin` (or
+  // `options.originRef.current` at creation time) are rendered into the
+  // system prompt under `## Your role in this session` for non-TUI sessions.
+  // Omitting it falls back to the previous behavior (no role annotation),
+  // which is what tests and stand-alone callers want.
+  permissions?: PermissionService
 }
 
 export type CreateSessionResult = {
@@ -122,10 +130,11 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
 
   const resourceLoader =
     options.systemPromptOverride !== undefined
-      ? await createOverrideResourceLoader(options.systemPromptOverride, options.origin)
+      ? await createOverrideResourceLoader(options.systemPromptOverride, options.origin, options.permissions)
       : await createResourceLoader({
           ...(options.plugins ? { plugins: options.plugins, materializedSkills } : {}),
           ...(options.origin ? { origin: options.origin } : {}),
+          ...(options.permissions ? { permissions: options.permissions } : {}),
         })
 
   const getOrigin: () => SessionOrigin | undefined =
@@ -401,9 +410,10 @@ function makePluginLogger(pluginName: string) {
 export async function createOverrideResourceLoader(
   systemPrompt: string,
   origin?: SessionOrigin,
+  permissions?: PermissionService,
 ): Promise<DefaultResourceLoader> {
   const loader = new DefaultResourceLoader({
-    systemPromptOverride: () => withOrigin(systemPrompt, origin),
+    systemPromptOverride: () => withOrigin(systemPrompt, origin, permissions),
     appendSystemPromptOverride: () => [],
   })
   await loader.reload()
@@ -415,6 +425,7 @@ export type CreateResourceLoaderOptions = {
   plugins?: PluginSessionWiring
   materializedSkills?: MaterializedSkills | null
   origin?: SessionOrigin
+  permissions?: PermissionService
 }
 
 export async function createResourceLoader(options: CreateResourceLoaderOptions = {}): Promise<DefaultResourceLoader> {
@@ -466,7 +477,7 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   }
 
   const loader = new DefaultResourceLoader({
-    systemPromptOverride: () => withOrigin(systemPrompt, options.origin),
+    systemPromptOverride: () => withOrigin(systemPrompt, options.origin, options.permissions),
     appendSystemPromptOverride: () => [],
     additionalSkillPaths,
   })
@@ -474,9 +485,23 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   return loader
 }
 
-function withOrigin(systemPrompt: string, origin: SessionOrigin | undefined): string {
+function withOrigin(
+  systemPrompt: string,
+  origin: SessionOrigin | undefined,
+  permissions: PermissionService | undefined,
+): string {
   if (!origin) return systemPrompt
-  return `${systemPrompt}\n\n${renderSessionOrigin(origin)}`
+  const roleContext = resolveRoleContext(origin, permissions)
+  return `${systemPrompt}\n\n${renderSessionOrigin(origin, Date.now(), roleContext)}`
+}
+
+function resolveRoleContext(
+  origin: SessionOrigin,
+  permissions: PermissionService | undefined,
+): SessionRoleContext | undefined {
+  if (permissions === undefined) return undefined
+  if (origin.kind === 'tui') return undefined
+  return permissions.describe(origin)
 }
 
 export function getBundledSkillsDir(): string {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -96,11 +96,19 @@ export type CreateSessionOptions = {
   // typeclaw-managed container. Read from TYPECLAW_CONTAINER_NAME at the call site.
   containerName?: string
   // The permission service the runtime resolved at boot. When provided, the
-  // resolved role and permission list for `options.origin` (or
-  // `options.originRef.current` at creation time) are rendered into the
-  // system prompt under `## Your role in this session` for non-TUI sessions.
-  // Omitting it falls back to the previous behavior (no role annotation),
-  // which is what tests and stand-alone callers want.
+  // resolved role and permission list for `options.origin` are rendered into
+  // the system prompt under `## Your role in this session`. The block is
+  // emitted for channel/cron/subagent sessions, and for TUI sessions only
+  // when the resolved role is not the built-in `owner` (because TUI
+  // resolving to `owner` is the common case and we save tokens on every
+  // interactive session). Omitting `permissions` falls back to the previous
+  // behavior (no role annotation), which is what tests and stand-alone
+  // callers want.
+  //
+  // The role rendered here is a session-creation snapshot. Channel sessions
+  // re-resolve per-turn through `originRef` for tool gating, but the system
+  // prompt is not regenerated; see `typeclaw-permissions` skill for how the
+  // agent should interpret the snapshot on later turns.
   permissions?: PermissionService
 }
 
@@ -412,8 +420,9 @@ export async function createOverrideResourceLoader(
   origin?: SessionOrigin,
   permissions?: PermissionService,
 ): Promise<DefaultResourceLoader> {
+  const finalPrompt = withOrigin(systemPrompt, origin, permissions)
   const loader = new DefaultResourceLoader({
-    systemPromptOverride: () => withOrigin(systemPrompt, origin, permissions),
+    systemPromptOverride: () => finalPrompt,
     appendSystemPromptOverride: () => [],
   })
   await loader.reload()
@@ -438,6 +447,14 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
     await options.plugins.hooks.runSessionPrompt(event)
     systemPrompt = event.prompt
   }
+
+  // Origin block (and the optional role/permissions sub-block) is appended
+  // BEFORE gitNudge so the dirty-files snapshot remains the agent's most
+  // recent context and keeps its cache-suffix position. Putting the role
+  // block after gitNudge would shift the dirty snapshot out of suffix
+  // position and re-fragment the cacheable prefix shared by clean-worktree
+  // sessions.
+  systemPrompt = withOrigin(systemPrompt, options.origin, options.permissions)
 
   // Appended last so the dirty-files snapshot is the most-recent context the
   // agent reads, and so its bytes sit in the cache-suffix region rather than
@@ -477,7 +494,7 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   }
 
   const loader = new DefaultResourceLoader({
-    systemPromptOverride: () => withOrigin(systemPrompt, options.origin, options.permissions),
+    systemPromptOverride: () => systemPrompt,
     appendSystemPromptOverride: () => [],
     additionalSkillPaths,
   })
@@ -500,8 +517,15 @@ function resolveRoleContext(
   permissions: PermissionService | undefined,
 ): SessionRoleContext | undefined {
   if (permissions === undefined) return undefined
-  if (origin.kind === 'tui') return undefined
-  return permissions.describe(origin)
+  const described = permissions.describe(origin)
+  // TUI normally resolves to `owner` via the built-in `owner.match = [tui]`
+  // entry, and we skip the role block in that case to save tokens on every
+  // interactive session. But user-declared roles can match TUI first (the
+  // resolver is first-match-wins in declaration order), so a non-owner TUI
+  // role is possible and the agent needs to see it. The "TUI is always owner"
+  // shorthand in docs is the common case, not an invariant.
+  if (origin.kind === 'tui' && described.role === 'owner') return undefined
+  return described
 }
 
 export function getBundledSkillsDir(): string {

--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -434,4 +434,80 @@ describe('renderSessionOrigin', () => {
     expect(out).not.toContain('This channel has')
     expect(out).not.toContain('members:')
   })
+
+  test('TUI origin does not render the role block even when role context is passed', () => {
+    const out = renderSessionOrigin({ kind: 'tui', sessionId: 'ses_abc' }, undefined, {
+      role: 'owner',
+      permissions: ['channel.respond', 'cron.schedule'],
+    })
+
+    expect(out).not.toContain('Your role in this session')
+    expect(out).not.toContain('`owner`')
+  })
+
+  test('cron origin appends the role block when role context is provided', () => {
+    const out = renderSessionOrigin({ kind: 'cron', jobId: 'job-42', jobKind: 'prompt' }, undefined, {
+      role: 'trusted',
+      permissions: ['channel.respond', 'cron.schedule', 'security.bypass.secretExfilBash'],
+    })
+
+    expect(out).toContain('## Your role in this session')
+    expect(out).toContain('Role: `trusted`.')
+    expect(out).toContain('`channel.respond`')
+    expect(out).toContain('`security.bypass.secretExfilBash`')
+    expect(out).toContain('typeclaw-permissions')
+    expect(out.indexOf('## Session origin')).toBeLessThan(out.indexOf('## Your role in this session'))
+  })
+
+  test('channel origin appends the role block under the existing channel content', () => {
+    const out = renderSessionOrigin(
+      {
+        kind: 'channel',
+        adapter: 'slack-bot',
+        workspace: 'T0123',
+        chat: 'C0ABCDE',
+        thread: null,
+      },
+      undefined,
+      { role: 'member', permissions: ['channel.respond'] },
+    )
+
+    expect(out).toContain('## Session origin')
+    expect(out).toContain('## Your role in this session')
+    expect(out).toContain('Role: `member`.')
+    expect(out).toContain('Permissions: `channel.respond`.')
+    expect(out.indexOf('Be concise')).toBeLessThan(out.indexOf('## Your role in this session'))
+  })
+
+  test('subagent origin appends the role block', () => {
+    const out = renderSessionOrigin(
+      { kind: 'subagent', subagent: 'memory-logger', parentSessionId: 'ses_parent' },
+      undefined,
+      { role: 'owner', permissions: ['channel.respond', 'cron.schedule', 'cron.modify'] },
+    )
+
+    expect(out).toContain('## Your role in this session')
+    expect(out).toContain('Role: `owner`.')
+  })
+
+  test('role block renders "none" when the resolved role has no permissions (guest)', () => {
+    const out = renderSessionOrigin(
+      {
+        kind: 'channel',
+        adapter: 'discord-bot',
+        workspace: '111',
+        chat: '222',
+        thread: null,
+      },
+      undefined,
+      { role: 'guest', permissions: [] },
+    )
+
+    expect(out).toContain('Role: `guest`. Permissions: none.')
+  })
+
+  test('omitting roleContext preserves the pre-existing rendering (no role block)', () => {
+    const withoutCtx = renderSessionOrigin({ kind: 'cron', jobId: 'job-x', jobKind: 'prompt' })
+    expect(withoutCtx).not.toContain('Your role in this session')
+  })
 })

--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -435,14 +435,21 @@ describe('renderSessionOrigin', () => {
     expect(out).not.toContain('members:')
   })
 
-  test('TUI origin does not render the role block even when role context is passed', () => {
+  test('TUI origin renders the role block when role context is passed (caller decides when to omit it for owner)', () => {
     const out = renderSessionOrigin({ kind: 'tui', sessionId: 'ses_abc' }, undefined, {
-      role: 'owner',
-      permissions: ['channel.respond', 'cron.schedule'],
+      role: 'guest',
+      permissions: [],
     })
 
+    expect(out).toContain('## Your role in this session')
+    expect(out).toContain('`guest`')
+  })
+
+  test('TUI origin without role context preserves the prior bare rendering', () => {
+    const out = renderSessionOrigin({ kind: 'tui', sessionId: 'ses_abc' })
+
     expect(out).not.toContain('Your role in this session')
-    expect(out).not.toContain('`owner`')
+    expect(out).toContain('## Session origin')
   })
 
   test('cron origin appends the role block when role context is provided', () => {
@@ -452,7 +459,7 @@ describe('renderSessionOrigin', () => {
     })
 
     expect(out).toContain('## Your role in this session')
-    expect(out).toContain('Role: `trusted`.')
+    expect(out).toContain('`trusted`')
     expect(out).toContain('`channel.respond`')
     expect(out).toContain('`security.bypass.secretExfilBash`')
     expect(out).toContain('typeclaw-permissions')
@@ -474,8 +481,8 @@ describe('renderSessionOrigin', () => {
 
     expect(out).toContain('## Session origin')
     expect(out).toContain('## Your role in this session')
-    expect(out).toContain('Role: `member`.')
-    expect(out).toContain('Permissions: `channel.respond`.')
+    expect(out).toContain('`member`')
+    expect(out).toContain('`channel.respond`')
     expect(out.indexOf('Be concise')).toBeLessThan(out.indexOf('## Your role in this session'))
   })
 
@@ -487,7 +494,7 @@ describe('renderSessionOrigin', () => {
     )
 
     expect(out).toContain('## Your role in this session')
-    expect(out).toContain('Role: `owner`.')
+    expect(out).toContain('`owner`')
   })
 
   test('role block renders "none" when the resolved role has no permissions (guest)', () => {

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -76,7 +76,7 @@ export function renderSessionOrigin(
 ): string {
   switch (origin.kind) {
     case 'tui':
-      return renderTuiOrigin()
+      return withRoleContext(renderTuiOrigin(), roleContext)
     case 'cron':
       return withRoleContext(renderCronOrigin(origin), roleContext)
     case 'channel':

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -52,17 +52,58 @@ export type SessionOrigin =
 export const PARTICIPANTS_TOP_K = 10
 export const PARTICIPANTS_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 
-export function renderSessionOrigin(origin: SessionOrigin, now: number = Date.now()): string {
+// Compact description of the role the runtime resolved for this session at
+// creation time. Rendered as a single block under the origin text for
+// non-TUI sessions so the agent knows what it can and cannot do without
+// having to call into the PermissionService itself. TUI is omitted because
+// TUI is always `owner` by construction — annotating it would add noise to
+// every interactive session for zero new information.
+//
+// For channel sessions this is a session-creation snapshot. The router
+// re-resolves per-turn for tool gating, but the system prompt is not
+// regenerated mid-session; the role line is accurate at admission and the
+// `typeclaw-permissions` skill spells out how to interpret it on later
+// turns when a different speaker may have spoken last.
+export type SessionRoleContext = {
+  role: string
+  permissions: readonly string[]
+}
+
+export function renderSessionOrigin(
+  origin: SessionOrigin,
+  now: number = Date.now(),
+  roleContext?: SessionRoleContext,
+): string {
   switch (origin.kind) {
     case 'tui':
       return renderTuiOrigin()
     case 'cron':
-      return renderCronOrigin(origin)
+      return withRoleContext(renderCronOrigin(origin), roleContext)
     case 'channel':
-      return renderChannelOrigin(origin, now)
+      return withRoleContext(renderChannelOrigin(origin, now), roleContext)
     case 'subagent':
-      return renderSubagentOrigin(origin)
+      return withRoleContext(renderSubagentOrigin(origin), roleContext)
   }
+}
+
+function withRoleContext(block: string, ctx: SessionRoleContext | undefined): string {
+  if (ctx === undefined) return block
+  return `${block}\n\n${renderRoleContext(ctx)}`
+}
+
+function renderRoleContext(ctx: SessionRoleContext): string {
+  const permList = ctx.permissions.length === 0 ? 'none' : ctx.permissions.map((p) => `\`${p}\``).join(', ')
+  return [
+    '## Your role in this session',
+    '',
+    `Role: \`${ctx.role}\`. Permissions: ${permList}.`,
+    '',
+    'This is the role the runtime resolved at session creation. Tool calls',
+    'and channel admission are gated by these permissions; a `blocked:` or',
+    '"denied by permissions" message means the current actor lacks the',
+    'permission the guard was looking for. See the `typeclaw-permissions`',
+    'skill for what each role can do and how to grant access.',
+  ].join('\n')
 }
 
 function renderTuiOrigin(): string {

--- a/src/bundled-plugins/security/index.test.ts
+++ b/src/bundled-plugins/security/index.test.ts
@@ -384,6 +384,44 @@ describe('security plugin wiring', () => {
     expect(result?.reason).toContain('secretExfilBash')
   })
 
+  test('block reason names the missing permission and the role hint', async () => {
+    const hook = await toolBeforeHook()
+    const result = await hook(toolEvent('bash', { command: 'env' }), hookContext('/agent'))
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('Or run as a role carrying `security.bypass.secretExfilBash`')
+    expect(result?.reason).toContain('owner and trusted have it by default')
+    expect(result?.reason).toContain('typeclaw-permissions')
+  })
+
+  test('owner-only permission block reason names the owner-only hint', async () => {
+    const hook = await toolBeforeHook()
+    const result = await hook(toolEvent('webfetch', { url: 'http://127.0.0.1:8080/admin' }), hookContext('/agent'))
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('Or run as a role carrying `security.bypass.ssrf`')
+    expect(result?.reason).toContain('only owner has it by default')
+  })
+
+  test('a permission-bypassed actor sees no block and therefore no permission hint', async () => {
+    const permissions = createPermissionService({
+      roles: {
+        member: {
+          match: [{ kind: 'channel', platform: 'slack', workspace: 'T0', chat: 'C0' }],
+          permissions: ['channel.respond', SECURITY_PERMISSIONS.bypassSecretExfilBash],
+        },
+      },
+    })
+    const hook = await toolBeforeHookWith(permissions)
+    const slackOrigin: SessionOrigin = {
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: null,
+    }
+    const result = await hook({ ...toolEvent('bash', { command: 'env' }), origin: slackOrigin }, hookContext('/agent'))
+    expect(result).toBeUndefined()
+  })
+
   test('session.end clears taint so a later session with the same ID is not falsely blocked', async () => {
     const before = await toolBeforeHook()
     const end = await sessionEndHook()

--- a/src/bundled-plugins/security/index.test.ts
+++ b/src/bundled-plugins/security/index.test.ts
@@ -384,21 +384,23 @@ describe('security plugin wiring', () => {
     expect(result?.reason).toContain('secretExfilBash')
   })
 
-  test('block reason names the missing permission and the role hint', async () => {
+  test('block reason names the missing permission and points at the typeclaw-permissions skill', async () => {
     const hook = await toolBeforeHook()
     const result = await hook(toolEvent('bash', { command: 'env' }), hookContext('/agent'))
     expect(result?.block).toBe(true)
-    expect(result?.reason).toContain('Or run as a role carrying `security.bypass.secretExfilBash`')
-    expect(result?.reason).toContain('owner and trusted have it by default')
+    expect(result?.reason).toContain('security.bypass.secretExfilBash')
     expect(result?.reason).toContain('typeclaw-permissions')
+    // Mentions trusted because the secretExfilBash bypass is what `trusted` carries by default.
+    expect(result?.reason).toMatch(/trusted/i)
   })
 
-  test('owner-only permission block reason names the owner-only hint', async () => {
+  test('owner-only permission block reason mentions owner without claiming any narrower role carries it', async () => {
     const hook = await toolBeforeHook()
     const result = await hook(toolEvent('webfetch', { url: 'http://127.0.0.1:8080/admin' }), hookContext('/agent'))
     expect(result?.block).toBe(true)
-    expect(result?.reason).toContain('Or run as a role carrying `security.bypass.ssrf`')
-    expect(result?.reason).toContain('only owner has it by default')
+    expect(result?.reason).toContain('security.bypass.ssrf')
+    expect(result?.reason).toMatch(/owner/i)
+    expect(result?.reason).not.toMatch(/trusted/i)
   })
 
   test('a permission-bypassed actor sees no block and therefore no permission hint', async () => {

--- a/src/bundled-plugins/security/index.ts
+++ b/src/bundled-plugins/security/index.ts
@@ -1,6 +1,7 @@
 import { definePlugin } from '@/plugin'
 
 import { SECURITY_PERMISSIONS } from './permissions'
+import type { SecurityPermission } from './permissions'
 import { checkGitExfilGuard, checkGitRemoteTaintedGuard, recordGitRemoteTaintIfAny } from './policies/git-exfil'
 import { checkOutboundSecretGuard } from './policies/outbound-secret-scan'
 import { applyPromptInjectionDefense } from './policies/prompt-injection'
@@ -14,12 +15,15 @@ import type { SecurityBlock } from './policy'
 
 export { SECURITY_PERMISSIONS, type SecurityPermission } from './permissions'
 
-// Maps each guard permission to a one-line hint about which built-in roles
-// already carry it. Kept next to the hook so adding a new bypass permission
-// forces a same-file edit — the hint is part of the permission's contract,
-// not optional documentation. `owner` always carries every `security.bypass.*`
-// via the wildcard expansion in builtins.ts.
-const BYPASS_ROLE_HINT: Record<string, string> = {
+// Maps each security bypass permission to a one-line hint about which
+// built-in roles carry it. The `satisfies` clause is load-bearing: it
+// forces exhaustive coverage of `SecurityPermission` at compile time, so
+// adding a new `SECURITY_PERMISSIONS` entry without a hint here is a type
+// error rather than a silent fallback to the inaccurate default. `owner`
+// always carries every `security.bypass.*` via the wildcard expansion in
+// builtins.ts, so the hint must mention owner even for permissions where
+// it's the only carrier.
+const BYPASS_ROLE_HINT = {
   [SECURITY_PERMISSIONS.bypassSecretExfilBash]: 'owner and trusted have it by default',
   [SECURITY_PERMISSIONS.bypassGitExfil]: 'only owner has it by default',
   [SECURITY_PERMISSIONS.bypassGitRemoteTainted]: 'only owner has it by default',
@@ -28,11 +32,14 @@ const BYPASS_ROLE_HINT: Record<string, string> = {
   [SECURITY_PERMISSIONS.bypassSessionSearchSecrets]: 'only owner has it by default',
   [SECURITY_PERMISSIONS.bypassSystemPromptLeak]: 'only owner has it by default',
   [SECURITY_PERMISSIONS.bypassOutboundSecret]: 'only owner has it by default',
-}
+} as const satisfies Record<SecurityPermission, string>
 
-function withPermissionHint(result: SecurityBlock | undefined, permission: string): SecurityBlock | undefined {
+function withPermissionHint(
+  result: SecurityBlock | undefined,
+  permission: SecurityPermission,
+): SecurityBlock | undefined {
   if (!result) return result
-  const hint = BYPASS_ROLE_HINT[permission] ?? 'no built-in role carries it'
+  const hint = BYPASS_ROLE_HINT[permission]
   return {
     block: true,
     reason: `${result.reason} Or run as a role carrying \`${permission}\` (${hint}); see the \`typeclaw-permissions\` skill.`,

--- a/src/bundled-plugins/security/index.ts
+++ b/src/bundled-plugins/security/index.ts
@@ -10,8 +10,34 @@ import { checkSecretExfilReadGuard } from './policies/secret-exfil-read'
 import { checkSessionSearchSecretsGuard } from './policies/session-search-secrets'
 import { checkSsrfGuard } from './policies/ssrf'
 import { checkSystemPromptLeakGuard } from './policies/system-prompt-leak'
+import type { SecurityBlock } from './policy'
 
 export { SECURITY_PERMISSIONS, type SecurityPermission } from './permissions'
+
+// Maps each guard permission to a one-line hint about which built-in roles
+// already carry it. Kept next to the hook so adding a new bypass permission
+// forces a same-file edit — the hint is part of the permission's contract,
+// not optional documentation. `owner` always carries every `security.bypass.*`
+// via the wildcard expansion in builtins.ts.
+const BYPASS_ROLE_HINT: Record<string, string> = {
+  [SECURITY_PERMISSIONS.bypassSecretExfilBash]: 'owner and trusted have it by default',
+  [SECURITY_PERMISSIONS.bypassGitExfil]: 'only owner has it by default',
+  [SECURITY_PERMISSIONS.bypassGitRemoteTainted]: 'only owner has it by default',
+  [SECURITY_PERMISSIONS.bypassSecretExfilRead]: 'only owner has it by default',
+  [SECURITY_PERMISSIONS.bypassSsrf]: 'only owner has it by default',
+  [SECURITY_PERMISSIONS.bypassSessionSearchSecrets]: 'only owner has it by default',
+  [SECURITY_PERMISSIONS.bypassSystemPromptLeak]: 'only owner has it by default',
+  [SECURITY_PERMISSIONS.bypassOutboundSecret]: 'only owner has it by default',
+}
+
+function withPermissionHint(result: SecurityBlock | undefined, permission: string): SecurityBlock | undefined {
+  if (!result) return result
+  const hint = BYPASS_ROLE_HINT[permission] ?? 'no built-in role carries it'
+  return {
+    block: true,
+    reason: `${result.reason} Or run as a role carrying \`${permission}\` (${hint}); see the \`typeclaw-permissions\` skill.`,
+  }
+}
 
 export default definePlugin({
   permissions: Object.values(SECURITY_PERMISSIONS),
@@ -36,29 +62,55 @@ export default definePlugin({
           permittedBypass: can(SECURITY_PERMISSIONS.bypassGitExfil),
         })
 
-        const checks = [
+        const checks: (SecurityBlock | undefined)[] = [
           can(SECURITY_PERMISSIONS.bypassGitRemoteTainted)
             ? undefined
-            : checkGitRemoteTaintedGuard({ tool: event.tool, args: event.args, sessionId: event.sessionId }),
+            : withPermissionHint(
+                checkGitRemoteTaintedGuard({ tool: event.tool, args: event.args, sessionId: event.sessionId }),
+                SECURITY_PERMISSIONS.bypassGitRemoteTainted,
+              ),
           can(SECURITY_PERMISSIONS.bypassSecretExfilBash)
             ? undefined
-            : checkSecretExfilBashGuard({ tool: event.tool, args: event.args }),
+            : withPermissionHint(
+                checkSecretExfilBashGuard({ tool: event.tool, args: event.args }),
+                SECURITY_PERMISSIONS.bypassSecretExfilBash,
+              ),
           can(SECURITY_PERMISSIONS.bypassGitExfil)
             ? undefined
-            : checkGitExfilGuard({ tool: event.tool, args: event.args, sessionId: event.sessionId }),
+            : withPermissionHint(
+                checkGitExfilGuard({ tool: event.tool, args: event.args, sessionId: event.sessionId }),
+                SECURITY_PERMISSIONS.bypassGitExfil,
+              ),
           can(SECURITY_PERMISSIONS.bypassSecretExfilRead)
             ? undefined
-            : checkSecretExfilReadGuard({ tool: event.tool, args: event.args }),
-          can(SECURITY_PERMISSIONS.bypassSsrf) ? undefined : checkSsrfGuard({ tool: event.tool, args: event.args }),
+            : withPermissionHint(
+                checkSecretExfilReadGuard({ tool: event.tool, args: event.args }),
+                SECURITY_PERMISSIONS.bypassSecretExfilRead,
+              ),
+          can(SECURITY_PERMISSIONS.bypassSsrf)
+            ? undefined
+            : withPermissionHint(
+                checkSsrfGuard({ tool: event.tool, args: event.args }),
+                SECURITY_PERMISSIONS.bypassSsrf,
+              ),
           can(SECURITY_PERMISSIONS.bypassSessionSearchSecrets)
             ? undefined
-            : checkSessionSearchSecretsGuard({ tool: event.tool, args: event.args }),
+            : withPermissionHint(
+                checkSessionSearchSecretsGuard({ tool: event.tool, args: event.args }),
+                SECURITY_PERMISSIONS.bypassSessionSearchSecrets,
+              ),
           can(SECURITY_PERMISSIONS.bypassSystemPromptLeak)
             ? undefined
-            : checkSystemPromptLeakGuard({ tool: event.tool, args: event.args }),
+            : withPermissionHint(
+                checkSystemPromptLeakGuard({ tool: event.tool, args: event.args }),
+                SECURITY_PERMISSIONS.bypassSystemPromptLeak,
+              ),
           can(SECURITY_PERMISSIONS.bypassOutboundSecret)
             ? undefined
-            : checkOutboundSecretGuard({ tool: event.tool, args: event.args }),
+            : withPermissionHint(
+                checkOutboundSecretGuard({ tool: event.tool, args: event.args }),
+                SECURITY_PERMISSIONS.bypassOutboundSecret,
+              ),
         ]
         for (const result of checks) {
           if (result) return result

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -501,7 +501,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return membership
   }
 
-  const ensureLive = async (key: ChannelKey, triggeringMessageId?: string): Promise<LiveSession> => {
+  const ensureLive = async (
+    key: ChannelKey,
+    triggeringMessageId?: string,
+    triggeringAuthorId?: string,
+  ): Promise<LiveSession> => {
     const keyId = channelKeyId(key)
     const existing = liveSessions.get(keyId)
     if (existing && !existing.destroyed) return existing
@@ -520,6 +524,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       logger.info(`[channels] ${keyId}: ensureLive resolved-names`)
       const membership = await membershipForPrompt(key, membershipFetch)
       logger.info(`[channels] ${keyId}: ensureLive resolved-membership`)
+      // The session-creation origin is what the resource loader sees when it
+      // renders the role/permissions block into the system prompt. It must
+      // include the triggering author so author-scoped roles
+      // (`slack:T/C author:U_ME`) resolve to the same role here that the
+      // channel.respond gate just admitted on. Per-turn updates after this
+      // point are handled by `originRef.current = buildLiveOrigin(live)`
+      // before each prompt() call.
       const origin: SessionOrigin = {
         kind: 'channel',
         adapter: key.adapter,
@@ -528,6 +539,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         chat: key.chat,
         ...(resolvedNames.chatName !== undefined ? { chatName: resolvedNames.chatName } : {}),
         thread: key.thread,
+        ...(triggeringAuthorId !== undefined ? { lastInboundAuthorId: triggeringAuthorId } : {}),
         participants,
         ...(membership !== null ? { membership } : {}),
       }
@@ -976,7 +988,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       if (commandResult.kind !== 'not-command') return
     }
 
-    const live = await ensureLive(key, event.externalMessageId)
+    const live = await ensureLive(key, event.externalMessageId, event.authorId)
 
     const isNewAuthor = !live.participants.some((p) => p.authorId === event.authorId)
     live.participants = updateParticipants(

--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -4,6 +4,7 @@ import { createSession as defaultCreateSession } from '@/agent'
 import { capJsonlFileInPlace } from '@/bundled-plugins/tool-result-cap/cap-jsonl'
 import type { CapOptions } from '@/bundled-plugins/tool-result-cap/cap-result'
 import type { CreateSessionForChannel, ChannelRouter } from '@/channels'
+import type { PermissionService } from '@/permissions'
 import type { ReloadRegistry } from '@/reload'
 import type { SessionFactory } from '@/sessions'
 import type { Stream } from '@/stream'
@@ -37,6 +38,11 @@ export type BuildChannelSessionFactoryDeps = {
   // (tool-result-cap.enabled=false in config, or no plugin block at all).
   rehydrateCapOptions: CapOptions | null
   logger?: FactoryLogger
+  // Forwarded to createSession so the resolved role / permissions for the
+  // session origin get rendered into the agent's system prompt. Optional so
+  // the production wiring can plumb in pluginsLoaded.permissions while tests
+  // (or stand-alone callers) keep the previous no-annotation behavior.
+  permissions?: PermissionService
   // Test seam: lets a fake stand in for the agent session creator so tests
   // can assert exactly which CreateSessionOptions the factory builds without
   // needing a live LLM, plugin runtime, or session manager on disk.
@@ -99,6 +105,7 @@ export function buildChannelSessionFactory(deps: BuildChannelSessionFactoryDeps)
           }
         : {}),
       ...(deps.containerName !== undefined ? { containerName: deps.containerName } : {}),
+      ...(deps.permissions !== undefined ? { permissions: deps.permissions } : {}),
     })
 
     return {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -145,6 +145,7 @@ export async function startAgent({
       pluginRuntime,
       getChannelRouter: () => channelManager.router,
       rehydrateCapOptions: resolveCapOptionsFromConfig(pluginConfigsByName['tool-result-cap']),
+      permissions: pluginsLoaded.permissions,
       ...containerNameOpt,
     }),
     permissions: pluginsLoaded.permissions,
@@ -169,6 +170,7 @@ export async function startAgent({
         systemPromptOverride: entry.pluginSubagent.systemPrompt,
         channelRouter: channelManager.router,
         origin,
+        permissions: pluginsLoaded.permissions,
         plugins: {
           registry: snap.registry,
           hooks: snap.hooks,
@@ -237,6 +239,7 @@ export async function startAgent({
         stream,
         channelRouter: channelManager.router,
         origin: cronOrigin,
+        permissions: pluginsLoaded.permissions,
         ...(snap.hasAnyPluginContent
           ? {
               plugins: {

--- a/src/skills/typeclaw-permissions/SKILL.md
+++ b/src/skills/typeclaw-permissions/SKILL.md
@@ -9,7 +9,13 @@ You run under an access-control system that gates which sessions wake you, which
 
 ## The model in one paragraph
 
-Every session you run in has a `SessionOrigin` (TUI / channel / cron / subagent). The runtime resolves that origin to a **role** by walking the `roles` block in `typeclaw.json`, in declaration order, and picking the first role whose `match` rules cover the origin. Each role carries a set of **permissions** — opaque dotted strings like `channel.respond`, `cron.schedule`, `security.bypass.gitExfil`. The runtime checks `permissions.has(origin, '<perm>')` at three places: the channel router (gates `channel.respond` before creating a session for an inbound message), the security plugin's `tool.before` hook (gates each `security.bypass.*` so the corresponding guard can be skipped), and plugin code that opts in. There is no other access-control surface — no per-tool ACL, no file-system isolation, no per-author allowlist outside `match` rules.
+Every session you run in has a `SessionOrigin` (TUI / channel / cron / subagent). How the runtime resolves it to a **role** depends on the origin kind:
+
+- **TUI and channel** sessions resolve by walking the `roles` block in `typeclaw.json` in declaration order and picking the first role whose `match` rules cover the origin. This is the only origin shape that match rules actually grant roles to at runtime.
+- **Cron** sessions resolve from `scheduledByRole`, a string stamped on the cron job record itself (in `cron.json` for hand-authored entries, or by the runtime for plugin-contributed cron). Match rules of the form `cron` parse but never grant a role to a running cron session — provenance wins.
+- **Subagent** sessions resolve from `spawnedByRole`, snapshotted from the spawning session's resolved role at spawn time. Same story: `subagent` / `subagent:<name>` rules parse but don't grant roles at runtime; the spawn provenance is the source of truth.
+
+Each role carries a set of **permissions** — opaque dotted strings like `channel.respond`, `cron.schedule`, `security.bypass.gitExfil`. The runtime checks `permissions.has(origin, '<perm>')` at three places: the channel router (gates `channel.respond` before creating a session for an inbound message), the security plugin's `tool.before` hook (gates each `security.bypass.*` so the corresponding guard can be skipped), and plugin code that opts in. There is no other access-control surface — no per-tool ACL, no file-system isolation, no per-author allowlist outside `match` rules.
 
 ## The four built-in roles
 
@@ -26,7 +32,15 @@ A session that doesn't match anything resolves to `guest`. `guest` has no `chann
 
 ## What your current session sees
 
-The session-creation origin and resolved role are rendered into your system prompt under `## Session origin` for cron / channel / subagent sessions. The line looks like `Your role in this session: \`member\`. Permissions: \`channel.respond\`.`. TUI sessions are not annotated because TUI is always `owner` by construction.
+When the runtime knows your permissions, it prepends a block under your `## Session origin`:
+
+```
+## Your role in this session
+
+Role: `member`. Permissions: `channel.respond`.
+```
+
+The block renders for cron / channel / subagent sessions. For TUI sessions, the block is omitted **when** the resolved role is the built-in `owner` (the common case, so we save tokens on every interactive session) and rendered when a user-declared role matched TUI first (because the resolver is first-match-wins in declaration order, a custom role with `match: ["tui"]` placed before `owner` will demote TUI). If you don't see the block in a TUI session, treat yourself as `owner`.
 
 **The role line reflects the session at creation time.** For channel sessions, the speaker on subsequent turns may resolve to a different role; the runtime updates that internally for tool gating (the channel router and the security plugin re-resolve on each turn), but the system prompt is not regenerated mid-session. If the user asks "what role am I right now in this channel", read `typeclaw.json` `roles` and match their author id against `match[]` yourself — do not parrot the system-prompt line as if it always applied.
 
@@ -38,9 +52,6 @@ The session-creation origin and resolved role are rendered into your system prom
 
 ```
 tui                                # any TUI session
-cron                               # any cron session (resolved by provenance, not by match)
-subagent                           # any subagent session
-subagent:<name>                    # specific subagent (e.g. subagent:memory-logger)
 *                                  # any channel session, any platform
 <platform>:*                       # any chat on this platform (slack | discord | telegram | kakao)
 <platform>:<workspace>             # one workspace, any chat
@@ -50,6 +61,8 @@ kakao:group/*                      # any KakaoTalk group chat
 kakao:open/*                       # any KakaoTalk open chat
 <rule> author:<authorId>           # AND-tighten any of the above to one author
 ```
+
+`cron`, `subagent`, and `subagent:<name>` are also valid parser shapes (they parse without error), but they do **not** grant a role to a running cron or subagent session — those resolve from stamped provenance (`scheduledByRole` / `spawnedByRole`) instead. Don't write those rules expecting them to admit traffic the way channel rules do.
 
 Within a single string, tokens are **AND**'d. Across multiple strings in `match[]`, they're **OR**'d. The platform names are exactly `slack | discord | telegram | kakao`. Workspace and chat coordinates are platform-native IDs (Slack team `T0123`, Discord guild `123456789012345678`, Telegram chat `42`, KakaoTalk chat hash) — **never** display names. If the user gives you a name, you need to resolve it to an ID before writing the match rule.
 

--- a/src/skills/typeclaw-permissions/SKILL.md
+++ b/src/skills/typeclaw-permissions/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: typeclaw-permissions
+description: Use this skill whenever the user asks who you talk to, why you went silent in a channel, why a tool call was blocked with `blocked:` / "denied by permissions", how to grant access, what a role can or can't do, or whenever you are about to edit the `roles` block in `typeclaw.json`. Triggers include "who can talk to you", "why aren't you replying in #channel", "add me to the agent", "let X talk to you", "grant trusted to Y", "your role", "what permissions do you have", "blocked", "denied by permissions", "owner", "trusted", "member", "guest", "match rule", "channel.respond", "security.bypass", "scheduledByRole", "spawnedByRole", or any mention of `roles` / `roles[*].match` / `roles[*].permissions` in `typeclaw.json`. Read it before editing `roles` — the file has a strict match-rule DSL, restart semantics, and silent failure modes (a missing role match makes you silently drop every inbound), and the agent's own runtime behavior depends on its role and resolved permissions.
+---
+
+# typeclaw-permissions
+
+You run under an access-control system that gates which sessions wake you, which tools succeed, and which guards you can bypass. This skill exists so you can answer the user's questions about access honestly, edit `roles` without bricking your own inbound channel, and explain `blocked:` messages in terms of the role/permission model rather than the surface-level guard reason.
+
+## The model in one paragraph
+
+Every session you run in has a `SessionOrigin` (TUI / channel / cron / subagent). The runtime resolves that origin to a **role** by walking the `roles` block in `typeclaw.json`, in declaration order, and picking the first role whose `match` rules cover the origin. Each role carries a set of **permissions** — opaque dotted strings like `channel.respond`, `cron.schedule`, `security.bypass.gitExfil`. The runtime checks `permissions.has(origin, '<perm>')` at three places: the channel router (gates `channel.respond` before creating a session for an inbound message), the security plugin's `tool.before` hook (gates each `security.bypass.*` so the corresponding guard can be skipped), and plugin code that opts in. There is no other access-control surface — no per-tool ACL, no file-system isolation, no per-author allowlist outside `match` rules.
+
+## The four built-in roles
+
+You always have these four, even if `typeclaw.json` declares zero `roles`. User-declared roles **append** match rules to the built-ins but **replace** the permission list entirely (so `"permissions": []` on a built-in role means "no permissions" — be careful).
+
+| Role      | Built-in `match[]`                                                | Default `permissions[]`                                                                                                   |
+| --------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `owner`   | `["tui"]` (always prepended)                                      | `channel.respond`, `cron.schedule`, `cron.modify`, **all `security.bypass.*` contributed by plugins** (wildcard sentinel) |
+| `trusted` | none                                                              | `channel.respond`, `cron.schedule`, `security.bypass.secretExfilBash`                                                     |
+| `member`  | none                                                              | `channel.respond`                                                                                                         |
+| `guest`   | none (fallback when nothing else matches, or stamped role is bad) | none                                                                                                                      |
+
+A session that doesn't match anything resolves to `guest`. `guest` has no `channel.respond`, so the router silently drops inbound messages whose author resolves to `guest`. **This is the most common cause of "the agent stopped responding"**: the user added a channel but did not add a match rule, so every speaker in that channel is `guest` and every inbound is dropped before you ever see it. There is no message in your session log when this happens — only a host-side line `[channels] <key>: denied by permissions (channel.respond) author=<id>`.
+
+## What your current session sees
+
+The session-creation origin and resolved role are rendered into your system prompt under `## Session origin` for cron / channel / subagent sessions. The line looks like `Your role in this session: \`member\`. Permissions: \`channel.respond\`.`. TUI sessions are not annotated because TUI is always `owner` by construction.
+
+**The role line reflects the session at creation time.** For channel sessions, the speaker on subsequent turns may resolve to a different role; the runtime updates that internally for tool gating (the channel router and the security plugin re-resolve on each turn), but the system prompt is not regenerated mid-session. If the user asks "what role am I right now in this channel", read `typeclaw.json` `roles` and match their author id against `match[]` yourself — do not parrot the system-prompt line as if it always applied.
+
+**The permission list is exhaustive at session-creation time** for the resolved role. If a permission you expect isn't listed there, the role doesn't carry it — adding it requires editing `roles.<role>.permissions[]` and restarting.
+
+## The match-rule DSL
+
+`roles.<role>.match[]` is an array of compact strings. The parser is hand-rolled in `src/permissions/match-rule.ts`; the canonical shapes are:
+
+```
+tui                                # any TUI session
+cron                               # any cron session (resolved by provenance, not by match)
+subagent                           # any subagent session
+subagent:<name>                    # specific subagent (e.g. subagent:memory-logger)
+*                                  # any channel session, any platform
+<platform>:*                       # any chat on this platform (slack | discord | telegram | kakao)
+<platform>:<workspace>             # one workspace, any chat
+<platform>:<workspace>/<chat>      # one specific chat
+<platform>:dm/*                    # any DM on this platform
+kakao:group/*                      # any KakaoTalk group chat
+kakao:open/*                       # any KakaoTalk open chat
+<rule> author:<authorId>           # AND-tighten any of the above to one author
+```
+
+Within a single string, tokens are **AND**'d. Across multiple strings in `match[]`, they're **OR**'d. The platform names are exactly `slack | discord | telegram | kakao`. Workspace and chat coordinates are platform-native IDs (Slack team `T0123`, Discord guild `123456789012345678`, Telegram chat `42`, KakaoTalk chat hash) — **never** display names. If the user gives you a name, you need to resolve it to an ID before writing the match rule.
+
+Things the DSL rejects (the parser emits actionable errors at boot, but you should not write these in the first place):
+
+- `slack:*/*` — `*/*` is redundant; use `slack:*` for "any Slack chat".
+- `slack:*/C0ABCDE` — workspace-less chat ID is impossible; pick a workspace.
+- `slack:T0123/*` — workspace-only is enough; drop the trailing `/*`.
+- `team:T0123`, `guild:G123`, `tg:42` — these are legacy prefixes from the old `channels.<adapter>.allow[]` field. They are auto-migrated on load but **don't write them in new code** — use `slack:T0123`, `discord:G123`, `telegram:42` directly.
+- `autor:U_ME` — typo of `author:`. The parser will suggest the fix at boot.
+
+## Permission strings you will see
+
+Three sources contribute permission strings:
+
+1. **Core** (always present): `channel.respond`, `cron.schedule`, `cron.modify`.
+2. **Bundled security plugin** (always loaded): `security.bypass.secretExfilBash`, `security.bypass.gitExfil`, `security.bypass.gitRemoteTainted`, `security.bypass.secretExfilRead`, `security.bypass.ssrf`, `security.bypass.sessionSearchSecrets`, `security.bypass.systemPromptLeak`, `security.bypass.outboundSecret`.
+3. **User-declared plugins** (variable): each plugin can contribute its own strings via `definePlugin({ permissions: [...] })`.
+
+`owner` carries every `security.bypass.*` from sources 2 and 3 by default (via a wildcard sentinel expanded at boot). `trusted` carries only `security.bypass.secretExfilBash` by default. `member` and `guest` carry no `security.bypass.*` strings.
+
+User-declared `permissions[]` strings that don't appear in any of the three sources are **logged as warnings at boot** (`[permissions] role "X" declares unknown permission "Y" — did you mean 'Z'?`) but the role still resolves with the unknown string in its list. This is intentional — the runtime is forward-compatible with strings from plugins that aren't loaded yet — but it also means typos silently fail to bypass guards. If you wrote `security.bypass.secretExfilBach` instead of `Bash`, no guard will be skipped and you will only notice when you read the boot logs.
+
+## When a tool is blocked
+
+The security plugin's `tool.before` hook produces block messages of the form:
+
+```
+Guard `<guardName>` blocked <what>. If this is genuinely intentional and the user
+explicitly asked for it, retry with `acknowledgeGuards.<guardName>: true` in the
+<tool> arguments. Or run as a role carrying `<permission>` (owner has all
+security.bypass.*; trusted has security.bypass.secretExfilBash).
+```
+
+Three escape hatches, ordered from least to most invasive:
+
+1. **`acknowledgeGuards.<guardName>: true`** in the tool args. This is a per-call, in-session bypass. Use it when the user has just explicitly told you to run the dangerous thing (e.g. "yes, push the secret to a private gist on purpose"). Never use it without explicit user confirmation — the guard exists for a reason.
+2. **Run as a role with the bypass permission**. If the user wants this pattern to keep working without an ack every time, they edit `roles.<role>.permissions[]` to include the `security.bypass.<X>` string the block message named. This is the right answer for "I'm `trusted` in this Slack channel and I want to be able to run dangerous bash without confirming each time" — give `trusted` the relevant `security.bypass.*` permission.
+3. **Run from a session that already resolves to a role with the bypass**. The TUI is always `owner`, so a guard that blocks in channel sessions for a `member` author will not block at all from the TUI. This is why "the agent can do X in TUI but not in Slack" is normal, not a bug.
+
+When you see a block, tell the user **which permission would skip it** (the block message now names it) and **which built-in roles have that permission**. Do not just relay the guard reason — that loses the access-control framing entirely.
+
+## When the user asks "why aren't you replying in #channel?"
+
+Probable causes, in descending order of frequency:
+
+1. **No match rule covers the speaking author's coordinates.** Read `typeclaw.json` `roles`, compare every `match[]` entry to the channel ID and author ID the user is reporting. If nothing matches, the author resolves to `guest`, which has no `channel.respond`, so every inbound is dropped at the router. The fix is to append a match rule to `roles.<role>.match[]` for that channel (or DM bucket).
+2. **The match rule exists but the role has `permissions: []`** (or otherwise lacks `channel.respond`). A user-declared role replaces the built-in's permissions wholesale. Re-add `channel.respond` or use a built-in role name (`member`, `trusted`, `owner`) that carries it by default.
+3. **Engagement triggers are filtering admitted messages.** This is a different problem — the inbound was admitted by permissions but engagement (`channels.<adapter>.engagement.trigger`) decided not to wake you. See the `typeclaw-config` skill for the engagement model.
+
+To distinguish cause 1/2 from cause 3: if `typeclaw logs <container> -f` (host stage) shows `[channels] ... denied by permissions (channel.respond)`, it's a permissions problem. If it shows the message being admitted but no LLM call follows, it's engagement.
+
+## When the user asks "let X talk to you in this channel"
+
+This is a `roles` edit. The full procedure:
+
+1. **Resolve the coordinates.** Get the platform name (`slack | discord | telegram | kakao`), the workspace ID, the chat ID. If the user gave you names, ask them or look them up in the participants list of a previous inbound from that channel.
+2. **Pick a role.** Default to `member` for "give them normal channel access". Use `trusted` if they should also be able to schedule cron and bypass the bash secret guard. Only use `owner` if they should have full bypass on every security guard — typically the agent's primary operator.
+3. **Edit `typeclaw.json` `roles.<role>.match[]`.** Append the canonical DSL string. Example: `roles.member.match` adds `"slack:T0123/C0ABCDE"`. If the user wants only a specific person in that channel, append `slack:T0123/C0ABCDE author:U_ME` instead.
+4. **Restart.** `roles` is **restart-required** — `typeclaw reload` does not re-evaluate role config. Tell the user: "edited `roles.<role>.match` — restart-required. Run `typeclaw restart` (host stage)."
+5. **Commit the change.** See the `typeclaw-git` skill. The decision context in the commit message should name the role, the channel, and the author/scope ("let @X talk to me as `member` in #foo in workspace bar").
+
+## When the user asks "stop replying to X"
+
+Two interpretations — clarify if ambiguous:
+
+- **"Stop everything"** — remove the match rule from `roles.<role>.match[]`. The author resolves to `guest`, and the channel router silently drops every inbound. You lose all visibility into their messages. Restart-required.
+- **"Just stop auto-replying"** — keep the match rule, but narrow `channels.<adapter>.engagement.trigger` and/or `stickiness`. See `typeclaw-config`. The agent still receives the messages and can still post if you tell it to. The solo-human fallback (single human in a channel) overrides `trigger: []`, so this approach can't fully silence you in a 1:1; only removing the match rule does.
+
+## When the user asks "what role am I in this session?"
+
+Read your `## Session origin` block — the role/permissions line is there for non-TUI sessions. For TUI it's `owner` by definition. If the user is in a channel and asks about themselves, read `typeclaw.json` `roles` and match their `<authorId>` against every `match[]` entry in declaration order; the first hit wins. Do not invent a role they aren't in.
+
+## When the user asks about cron / subagent provenance
+
+Cron and subagent sessions don't resolve their role by matching their own origin — instead, the role is **stamped at creation**:
+
+- **Cron jobs** carry `scheduledByRole` in `cron.json`. The job runs as that role. If `scheduledByRole` is absent on a hand-authored cron entry, **boot fails** with a precise error (there is no implicit fallback). Plugin-contributed cron jobs default to `owner`.
+- **Subagents** carry `spawnedByRole`, snapshotted from the spawning session's resolved role at spawn time. A cron-fired subagent inherits the cron's stamped role.
+
+This forecloses the laundering attack — an attacker who only resolves to `guest` can ask you to schedule a cron, but the cron entry will be stamped `scheduledByRole: 'guest'`, and when it fires it will still be `guest` (with no permissions, including no `channel.respond` or `security.bypass.*`).
+
+If you see a cron job mysteriously failing every fire with `denied by permissions` in logs, check its `scheduledByRole` — it may have been scheduled by a `guest` session at some point in the past.
+
+## Things you must not do
+
+- **Do not write `*` in user-declared `permissions[]`.** The owner wildcard is a runtime sentinel, not part of the user-facing string format. The schema rejects `*` (it's not a valid dotted permission string anyway).
+- **Do not invent permission strings.** Only the three sources above (core, security plugin, declared plugins) contribute valid strings. A string like `bash.execute` looks plausible but is not gated by anything and will only earn a boot warning. If the user asks for a permission the model doesn't have, tell them — don't invent one.
+- **Do not promise that `typeclaw reload` applied a `roles` edit.** `roles` is restart-required. The reload tool will return success on the config file change, but the live `PermissionService` was built at boot and is not swapped on reload.
+- **Do not silently change a built-in role's permission list.** Setting `"permissions": []` on `member` is a wholesale replace, not a merge — you just took `channel.respond` away from every speaker who resolves to `member`. If the user said "give member just `channel.respond` and nothing else", that's fine (it's the same as the default), but say so explicitly: "this matches the default for `member`, no behavior change". If the user said "remove cron from `trusted`", make the change but warn that `trusted` no longer carries `cron.schedule` either.
+- **Do not write match rules using display names** (`#general`, `@user`, channel/user names). Match rules are platform IDs. Display names change; IDs don't. Always look up the ID before writing the rule.
+- **Do not edit `roles` to "fix" a security block** without explaining the alternative. The right first move for a guard block is usually `acknowledgeGuards.<X>: true` for the specific call. Editing `roles` to grant a permanent bypass is a heavier change with security implications — get explicit consent.
+- **Do not interpret a missing `## Session origin` role line as "I have no role".** TUI sessions don't render the line because TUI is always `owner`. If you see no role line and you're not in TUI, something has gone wrong with the system prompt build — flag it, don't fabricate.
+
+## What this skill does not cover
+
+- **The `channels.<adapter>` block** — engagement, history, stickiness, alias. See `typeclaw-config`. Engagement decides whether an _admitted_ inbound wakes the loop; this skill is only about admission.
+- **The full `typeclaw.json` schema** — model, mounts, plugins, docker, git.ignore. See `typeclaw-config`.
+- **Cron job authoring** — schedule syntax, `prompt` vs `exec`, the `reload` tool. See `typeclaw-cron`. This skill only covers the `scheduledByRole` field and its provenance semantics.
+- **Plugin authoring** — `definePlugin`, contributing permissions, custom `tool.before` hooks. See `typeclaw-plugins`. The bundled security plugin is an example of a plugin that contributes `security.bypass.*` strings and uses `permissions.has()` to gate its own guards.
+- **The container vs host stage split** — `typeclaw restart` runs on the host; this skill assumes you know which stage you're in. See `AGENTS.md` for the stage model.


### PR DESCRIPTION
## What this PR does

Closes a long-standing gap where the agent inside the container had zero
awareness of the permission system. Before this PR: no resolved role in
the system prompt, no permission list, and when a security guard blocked
a tool the block reason named only the guard (e.g. `secretExfilBash`) with
no framing in terms of roles or bypass permissions. Channel-respond denials
were dropped at the router and never reached the session at all.

Three coordinated additions close the gap. Each is opt-in at the call-site
so tests and stand-alone callers are unaffected.

---

## 1. New bundled skill: `typeclaw-permissions`

**`src/skills/typeclaw-permissions/SKILL.md`** (new, ~190 lines).

Documents the four built-in roles (`owner` / `trusted` / `member` / `guest`)
and their default permission bundles, the match-rule DSL grammar and every
canonical platform/workspace/chat/author shape, the legacy-prefix migration
(`team:` / `guild:` / `tg:` → canonical DSL), the three permission-string
namespaces (core / bundled security plugin / user plugins), and the three
escape hatches when a tool is blocked:

- Set `acknowledgeGuards.<X>: true` on the tool call.
- Run the session under a role that carries the bypass permission.
- Run from a session that already resolves to that role by match-rule.

Also includes procedural "when the user asks …" sections for the most
common operator questions ("why aren't you replying in #channel", "let X
talk to you", "stop replying to X", "what role am I in this session",
"what about cron/subagent provenance") and a "Things you must not do"
section closing out anti-patterns (writing `*` in user `permissions[]`,
inventing permission strings, promising `typeclaw reload` applies role
changes, using display names instead of platform IDs).

Resolves dangling references: `typeclaw-config` already linked to
`typeclaw-permissions` 8+ times despite the skill not existing.

---

## 2. Inline role/permissions block in the system prompt

**Files:** `src/agent/session-origin.ts`, `src/agent/index.ts`,
`src/run/channel-session-factory.ts`, `src/run/index.ts`.

`renderSessionOrigin` gains an optional `roleContext` parameter that
prepends a compact block under `## Session origin` for `cron`, `channel`,
and `subagent` sessions:

```
## Your role in this session

Role: `member`. Permissions: `channel.respond`.

This is the role the runtime resolved at session creation. Tool calls
and channel admission are gated by these permissions; a `blocked:` or
"denied by permissions" message means the current actor lacks the
permission the guard was looking for. See the `typeclaw-permissions`
skill for what each role can do and how to grant access.
```

TUI is deliberately omitted — TUI is always `owner` by construction, so
annotating it would pay the token cost in every interactive session for
zero new information.

The block is a session-creation snapshot. Tool gating continues to
re-resolve the live origin on every turn (that fence already existed);
the skill documents the snapshot semantics so the agent can answer
correctly even after a per-turn author shift in a channel session.

Threaded through `CreateSessionOptions.permissions` and
`CreateResourceLoaderOptions.permissions`. Production wiring in
`src/run/index.ts` forwards `pluginsLoaded.permissions` to the channel
factory, cron session, and subagent session. Callers that omit it
preserve the prior no-annotation behavior.

---

## 3. Permission-aware block reasons in the security plugin

**`src/bundled-plugins/security/index.ts`.**

The `tool.before` hook now appends a one-line permission footer to every
block result:

```
Guard `secretExfilBash` blocked bash command ... retry with
`acknowledgeGuards.secretExfilBash: true`.
Or run as a role carrying `security.bypass.secretExfilBash`
(owner and trusted have it by default); see the `typeclaw-permissions` skill.
```

The permission-to-role-hint map (`BYPASS_ROLE_HINT`) is co-located with
the hook so adding a new `security.bypass.*` permission forces a same-file
edit — the hint becomes part of the permission's contract, not optional
documentation.

---

## Tests

All three layers tested without mocks (real `PermissionService`, real plugin
hook, real renderer):

**`src/agent/session-origin.test.ts`** — 7 new cases:
- Role block renders for `cron`, `channel`, and `subagent` sessions.
- Omitted for TUI even when a `roleContext` is passed.
- `guest` renders as `Permissions: none`.
- Omitting `roleContext` preserves the prior rendering exactly.

**`src/bundled-plugins/security/index.test.ts`** — 3 new cases:
- Block reason contains the permission string, the role hint, and the skill
  reference.
- Owner-only vs trusted-also hint paths render distinct text.
- A permission-bypassed actor sees no block and therefore no permission hint.

Existing 31 session-origin tests and 25 security tests are untouched and
passing — prior assertions use `toContain` so the new suffix is invisible
to them.

---

## Verification

```
bun run typecheck   # clean
bun run lint        # 0 errors (8 pre-existing warnings, none in changed files)
bun test            # 3101 pass / 0 fail / 6247 expect() calls across 185 files
```

---

## Out of scope

- **`session_info` / `whoami` introspection tool** — the role block in the
  system prompt covers the common case. A read-only tool can be added later
  if channel sessions with per-turn-shifting authors need precise queries.
- **Per-turn system-prompt regeneration for channel sessions** — the v0.2
  work already called out in `AGENTS.md`. Tool gating is per-turn correct
  via the live origin ref; the new skill and the inline comment document the
  snapshot semantics so the agent can answer correctly without it.

---

## Stats

8 files changed, 414 insertions, 19 deletions.