### PR TITLE
Cap oversized tool results at channel rehydrate so poisoned sessions self-heal on restart

### DIFF
--- a/src/bundled-plugins/tool-result-cap/README.md
+++ b/src/bundled-plugins/tool-result-cap/README.md
@@ -15,6 +15,8 @@ The result is a session JSONL file that's tens of megabytes on disk but mostly o
 
 `tool-result-cap` registers a `tool.after` hook that inspects every tool's result and, in place, replaces oversized image/text parts with a short placeholder before pi-coding-agent appends the entry to the JSONL. The cap happens at the wire-format level, so the bloat never reaches disk or the LLM in the first place.
 
+For sessions that already contain oversized tool results from before this plugin was active (or before its limits were tightened), the **channel session factory also runs the same cap policy at rehydrate time**: just before `SessionManager.open(path)` reads the JSONL, the file is scanned for oversized `toolResult` entries and those entries are rewritten in place. The pass is idempotent and skipped entirely when `tool-result-cap.enabled` is `false`. **`typeclaw restart` is therefore the single user-facing recovery action for a poisoned channel session** — no scrubber subcommand, no manual surgery on `channels/sessions.json`.
+
 ## Config
 
 ```json
@@ -57,11 +59,14 @@ Plugin hook order is the order plugins are listed in `src/run/bundled-plugins.ts
 
 ## What it contributes
 
-| Kind | Name         | Notes                                                                                                                                  |
-| ---- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Hook | `tool.after` | Walks `event.result.content` and replaces oversized image/text parts in place. Logs one `info` line per capped call, silent otherwise. |
+| Kind                 | Name                          | Notes                                                                                                                                                                                                                                                                                                                       |
+| -------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Hook                 | `tool.after`                  | Walks `event.result.content` and replaces oversized image/text parts in place. Logs one `info` line per capped call, silent otherwise.                                                                                                                                                                                      |
+| Load-time pass       | `capJsonlFileInPlace`         | Called by `src/run/channel-session-factory.ts` before `SessionManager.open(path)` on every channel-session rehydrate. Walks JSONL entries, applies the same `capToolResult` per `toolResult` message, and rewrites the file atomically (temp + rename) when any entry mutated. Idempotent; passes malformed lines verbatim. |
+| Config-bridge helper | `resolveCapOptionsFromConfig` | Parses the `tool-result-cap` config block through the plugin's `configSchema` and returns the runtime `CapOptions` (or `null` when `enabled: false`). Lets non-plugin call sites share the same disable rule as the `tool.after` hook.                                                                                      |
 
 ## Tests
 
 - `cap-result.test.ts` — pure-function unit tests for the capping logic (image replacement, text truncation, mixed parts, exempt tools, empty results, in-place mutation invariant).
-- `index.test.ts` — composition tests (config schema defaults and validation, hook registration, disabled-mode short-circuit, logging on cap, silence on no-op).
+- `cap-jsonl.test.ts` — load-time pass: rewrite-on-mutation, no-write-when-clean, idempotency, exemptTools respected, non-toolResult entries preserved, malformed-line passthrough, missing-file safety, multi-entry batching, text truncation in JSONL form.
+- `index.test.ts` — composition tests (config schema defaults and validation, hook registration, disabled-mode short-circuit, logging on cap, silence on no-op, `resolveCapOptionsFromConfig` semantics).

--- a/src/bundled-plugins/tool-result-cap/cap-jsonl.test.ts
+++ b/src/bundled-plugins/tool-result-cap/cap-jsonl.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from 'bun:test'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { CapJsonlReadError, capJsonlFileInPlace } from './cap-jsonl'
+
+const baseOptions = {
+  imageMaxBytes: 100,
+  textMaxBytes: 50,
+  exemptTools: new Set<string>(),
+}
+
+function makeTmpJsonl(lines: unknown[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'cap-jsonl-'))
+  const path = join(dir, 'session.jsonl')
+  writeFileSync(path, `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`)
+  return path
+}
+
+function readJsonl(path: string): unknown[] {
+  const raw = readFileSync(path, 'utf8')
+  return raw
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l) as unknown)
+}
+
+describe('capJsonlFileInPlace', () => {
+  test('rewrites a toolResult entry whose image part exceeds imageMaxBytes', () => {
+    const path = makeTmpJsonl([
+      { type: 'session', id: 's1', timestamp: '2026-05-12T00:00:00Z', cwd: '/a' },
+      {
+        type: 'message',
+        id: 'e1',
+        parentId: null,
+        timestamp: '2026-05-12T00:00:01Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'functions.read:1',
+          toolName: 'read',
+          content: [
+            { type: 'text', text: 'Read image file [image/png]' },
+            { type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) },
+          ],
+        },
+      },
+    ])
+
+    const stats = capJsonlFileInPlace(path, baseOptions)
+
+    expect(stats.imagesReplaced).toBe(1)
+    expect(stats.textsTruncated).toBe(0)
+    expect(stats.entriesMutated).toBe(1)
+    expect(stats.bytesElided).toBe(500)
+
+    const entries = readJsonl(path) as { type: string; message?: { content: unknown[] } }[]
+    expect(entries).toHaveLength(2)
+    const content = entries[1]!.message!.content as { type: string; text?: string }[]
+    expect(content[1]?.type).toBe('text')
+    expect(content[1]?.text).toContain('tool-result-cap')
+  })
+
+  test('does not rewrite the file when nothing exceeds the thresholds', () => {
+    const path = makeTmpJsonl([
+      { type: 'session', id: 's1', timestamp: '2026-05-12T00:00:00Z', cwd: '/a' },
+      {
+        type: 'message',
+        id: 'e1',
+        parentId: null,
+        timestamp: '2026-05-12T00:00:01Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'functions.read:1',
+          toolName: 'read',
+          content: [{ type: 'text', text: 'short result' }],
+        },
+      },
+    ])
+    const before = readFileSync(path, 'utf8')
+
+    const stats = capJsonlFileInPlace(path, baseOptions)
+
+    expect(stats.entriesMutated).toBe(0)
+    expect(stats.imagesReplaced).toBe(0)
+    expect(readFileSync(path, 'utf8')).toBe(before)
+  })
+
+  test('is idempotent: running twice produces the same file as running once', () => {
+    const path = makeTmpJsonl([
+      { type: 'session', id: 's1', timestamp: '2026-05-12T00:00:00Z', cwd: '/a' },
+      {
+        type: 'message',
+        id: 'e1',
+        parentId: null,
+        timestamp: '2026-05-12T00:00:01Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'functions.read:1',
+          toolName: 'read',
+          content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) }],
+        },
+      },
+    ])
+
+    capJsonlFileInPlace(path, baseOptions)
+    const afterFirst = readFileSync(path, 'utf8')
+    const secondStats = capJsonlFileInPlace(path, baseOptions)
+    const afterSecond = readFileSync(path, 'utf8')
+
+    expect(secondStats.entriesMutated).toBe(0)
+    expect(afterFirst).toBe(afterSecond)
+  })
+
+  test('respects exemptTools (no cap on excluded tool, cap on others)', () => {
+    const path = makeTmpJsonl([
+      { type: 'session', id: 's1', timestamp: '2026-05-12T00:00:00Z', cwd: '/a' },
+      {
+        type: 'message',
+        id: 'exempt',
+        parentId: null,
+        timestamp: '2026-05-12T00:00:01Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'functions.read:1',
+          toolName: 'read',
+          content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) }],
+        },
+      },
+      {
+        type: 'message',
+        id: 'capped',
+        parentId: 'exempt',
+        timestamp: '2026-05-12T00:00:02Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'functions.webfetch:1',
+          toolName: 'webfetch',
+          content: [{ type: 'image', mimeType: 'image/png', data: 'B'.repeat(500) }],
+        },
+      },
+    ])
+
+    const stats = capJsonlFileInPlace(path, { ...baseOptions, exemptTools: new Set(['read']) })
+
+    expect(stats.entriesMutated).toBe(1)
+    const entries = readJsonl(path) as { id: string; message?: { content: unknown[] } }[]
+    const exemptContent = entries[1]!.message!.content as { type: string }[]
+    const cappedContent = entries[2]!.message!.content as { type: string; text?: string }[]
+    expect(exemptContent[0]?.type).toBe('image')
+    expect(cappedContent[0]?.type).toBe('text')
+    expect(cappedContent[0]?.text).toContain('tool-result-cap')
+  })
+
+  test('preserves non-toolResult entries verbatim', () => {
+    const path = makeTmpJsonl([
+      { type: 'session', id: 's1', timestamp: '2026-05-12T00:00:00Z', cwd: '/a' },
+      {
+        type: 'message',
+        id: 'u1',
+        parentId: null,
+        timestamp: '2026-05-12T00:00:01Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'A'.repeat(200) }] },
+      },
+      {
+        type: 'message',
+        id: 'a1',
+        parentId: 'u1',
+        timestamp: '2026-05-12T00:00:02Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'A'.repeat(200) }] },
+      },
+    ])
+    const before = readFileSync(path, 'utf8')
+
+    const stats = capJsonlFileInPlace(path, baseOptions)
+
+    expect(stats.entriesMutated).toBe(0)
+    expect(readFileSync(path, 'utf8')).toBe(before)
+  })
+
+  test('passes malformed lines through verbatim instead of dropping or crashing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cap-jsonl-'))
+    const path = join(dir, 'session.jsonl')
+    const header = JSON.stringify({ type: 'session', id: 's1', timestamp: '2026-05-12T00:00:00Z', cwd: '/a' })
+    const cap = JSON.stringify({
+      type: 'message',
+      id: 'e1',
+      parentId: null,
+      timestamp: '2026-05-12T00:00:01Z',
+      message: {
+        role: 'toolResult',
+        toolCallId: 'functions.read:1',
+        toolName: 'read',
+        content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) }],
+      },
+    })
+    const malformed = '{not valid json'
+    writeFileSync(path, `${header}\n${malformed}\n${cap}\n`)
+
+    capJsonlFileInPlace(path, baseOptions)
+
+    const after = readFileSync(path, 'utf8').split('\n')
+    expect(after[0]).toBe(header)
+    expect(after[1]).toBe(malformed)
+    expect(after[2]).toContain('tool-result-cap')
+  })
+
+  test('throws CapJsonlReadError when the file does not exist', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cap-jsonl-'))
+
+    expect(() => capJsonlFileInPlace(join(dir, 'missing.jsonl'), baseOptions)).toThrow(CapJsonlReadError)
+  })
+
+  test('throws CapJsonlReadError when the path is a directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cap-jsonl-'))
+    const subdir = join(dir, 'subdir')
+    mkdirSync(subdir)
+
+    expect(() => capJsonlFileInPlace(subdir, baseOptions)).toThrow(CapJsonlReadError)
+  })
+
+  test('preserves the original file mode across the temp+rename rewrite', () => {
+    const path = makeTmpJsonl([
+      { type: 'session', id: 's1', timestamp: '2026-05-12T00:00:00Z', cwd: '/a' },
+      {
+        type: 'message',
+        id: 'e1',
+        parentId: null,
+        timestamp: '2026-05-12T00:00:01Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'functions.read:1',
+          toolName: 'read',
+          content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) }],
+        },
+      },
+    ])
+    chmodSync(path, 0o600)
+    expect(statSync(path).mode & 0o777).toBe(0o600)
+
+    const stats = capJsonlFileInPlace(path, baseOptions)
+
+    expect(stats.entriesMutated).toBe(1)
+    expect(statSync(path).mode & 0o777).toBe(0o600)
+  })
+
+  test('caps multiple toolResult entries in one pass', () => {
+    const entries: unknown[] = [{ type: 'session', id: 's1', timestamp: '2026-05-12T00:00:00Z', cwd: '/a' }]
+    for (let i = 0; i < 3; i++) {
+      entries.push({
+        type: 'message',
+        id: `e${i}`,
+        parentId: i === 0 ? null : `e${i - 1}`,
+        timestamp: '2026-05-12T00:00:01Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: `functions.read:${i}`,
+          toolName: 'read',
+          content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) }],
+        },
+      })
+    }
+    const path = makeTmpJsonl(entries)
+
+    const stats = capJsonlFileInPlace(path, baseOptions)
+
+    expect(stats.entriesMutated).toBe(3)
+    expect(stats.imagesReplaced).toBe(3)
+    expect(stats.bytesElided).toBe(1500)
+  })
+
+  test('truncates oversized text parts in toolResult entries', () => {
+    const path = makeTmpJsonl([
+      { type: 'session', id: 's1', timestamp: '2026-05-12T00:00:00Z', cwd: '/a' },
+      {
+        type: 'message',
+        id: 'e1',
+        parentId: null,
+        timestamp: '2026-05-12T00:00:01Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'functions.webfetch:1',
+          toolName: 'webfetch',
+          content: [{ type: 'text', text: 'B'.repeat(200) }],
+        },
+      },
+    ])
+
+    const stats = capJsonlFileInPlace(path, baseOptions)
+
+    expect(stats.textsTruncated).toBe(1)
+    expect(stats.bytesElided).toBe(150)
+    const entries = readJsonl(path) as { message?: { content: { type: string; text?: string }[] } }[]
+    expect(entries[1]!.message!.content[0]?.text).toContain('tool-result-cap')
+  })
+})

--- a/src/bundled-plugins/tool-result-cap/cap-jsonl.ts
+++ b/src/bundled-plugins/tool-result-cap/cap-jsonl.ts
@@ -1,0 +1,115 @@
+import { chmodSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs'
+
+import type { ContentPart } from '@/plugin'
+
+import { type CapOptions, type CapStats, capContentParts } from './cap-result'
+
+export type CapJsonlStats = CapStats & {
+  // Number of toolResult entries that had at least one part capped. Distinct
+  // from imagesReplaced + textsTruncated because a single entry can have
+  // multiple oversized parts.
+  entriesMutated: number
+}
+
+export class CapJsonlReadError extends Error {
+  constructor(
+    public readonly path: string,
+    public override readonly cause: unknown,
+  ) {
+    super(`capJsonlFileInPlace: read failed for ${path}: ${cause instanceof Error ? cause.message : String(cause)}`)
+    this.name = 'CapJsonlReadError'
+  }
+}
+
+function parseLine(line: string): unknown {
+  try {
+    return JSON.parse(line) as unknown
+  } catch {
+    return null
+  }
+}
+
+function isToolResultMessageEntry(value: unknown): value is {
+  type: 'message'
+  message: { role: 'toolResult'; toolName?: string; content: ContentPart[] }
+} {
+  if (typeof value !== 'object' || value === null) return false
+  const entry = value as { type?: unknown; message?: unknown }
+  if (entry.type !== 'message') return false
+  if (typeof entry.message !== 'object' || entry.message === null) return false
+  const message = entry.message as { role?: unknown; content?: unknown }
+  if (message.role !== 'toolResult') return false
+  if (!Array.isArray(message.content)) return false
+  return true
+}
+
+// Apply `capContentParts` to every toolResult entry parsed from a JSONL file
+// and rewrite the file in place when anything mutated. Idempotent.
+//
+// Why we own the file IO (rather than going through SessionManager): the
+// `_rewriteFile` method on SessionManager is not on the public type, and
+// running BEFORE `SessionManager.open(path)` is called means pi-coding-agent
+// reads the already-capped file. No private API touched, no race against
+// pi's internal state.
+//
+// Throws CapJsonlReadError when the file can't be read (missing, unreadable,
+// directory, etc.). Callers that want best-effort no-op semantics should
+// wrap in try/catch — see tryReopenOrCreate.
+//
+// Malformed lines are passed through verbatim — matches pi's parser, which
+// silently skips them. We never delete or reorder entries; we only shrink
+// `content` parts of toolResult messages.
+//
+// File mode is preserved across the temp+rename so a 0600 session JSONL
+// stays 0600 after capping.
+export function capJsonlFileInPlace(path: string, options: CapOptions): CapJsonlStats {
+  let raw: string
+  let originalMode: number
+  try {
+    raw = readFileSync(path, 'utf8')
+    originalMode = statSync(path).mode & 0o777
+  } catch (err) {
+    throw new CapJsonlReadError(path, err)
+  }
+
+  const lines = raw.split('\n')
+  const stats: CapJsonlStats = { imagesReplaced: 0, textsTruncated: 0, bytesElided: 0, entriesMutated: 0 }
+  const out: string[] = Array.from({ length: lines.length })
+  let anyMutated = false
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+    if (line.length === 0) {
+      out[i] = line
+      continue
+    }
+    const parsed = parseLine(line)
+    if (parsed === null || !isToolResultMessageEntry(parsed)) {
+      out[i] = line
+      continue
+    }
+    const toolName = parsed.message.toolName ?? ''
+    const partStats = capContentParts(toolName, parsed.message.content, options)
+    if (partStats.imagesReplaced > 0 || partStats.textsTruncated > 0) {
+      stats.imagesReplaced += partStats.imagesReplaced
+      stats.textsTruncated += partStats.textsTruncated
+      stats.bytesElided += partStats.bytesElided
+      stats.entriesMutated += 1
+      anyMutated = true
+      out[i] = JSON.stringify(parsed)
+    } else {
+      out[i] = line
+    }
+  }
+
+  if (anyMutated) {
+    // Write-then-rename so a crash mid-write can't leave a truncated JSONL
+    // (which would corrupt the next rehydrate).
+    const tmp = `${path}.cap.tmp`
+    writeFileSync(tmp, out.join('\n'), { mode: originalMode })
+    chmodSync(tmp, originalMode)
+    renameSync(tmp, path)
+  }
+
+  return stats
+}

--- a/src/bundled-plugins/tool-result-cap/cap-result.test.ts
+++ b/src/bundled-plugins/tool-result-cap/cap-result.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import type { ToolResult } from '@/plugin'
 
-import { capToolResult } from './cap-result'
+import { capContentParts, capToolResult } from './cap-result'
 
 const baseOptions = {
   imageMaxBytes: 100,
@@ -124,5 +124,59 @@ describe('capToolResult', () => {
     const stats = capToolResult('read', result, baseOptions)
 
     expect(stats).toEqual({ imagesReplaced: 0, textsTruncated: 0, bytesElided: 0 })
+  })
+
+  test('is idempotent even when the placeholder text exceeds textMaxBytes', () => {
+    const result: ToolResult = {
+      content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) }],
+    }
+    const tinyTextOptions = { ...baseOptions, textMaxBytes: 30 }
+
+    const firstStats = capToolResult('read', result, tinyTextOptions)
+    const afterFirst = JSON.stringify(result.content)
+    const secondStats = capToolResult('read', result, tinyTextOptions)
+
+    expect(firstStats.imagesReplaced).toBe(1)
+    expect(secondStats.imagesReplaced).toBe(0)
+    expect(secondStats.textsTruncated).toBe(0)
+    expect(JSON.stringify(result.content)).toBe(afterFirst)
+  })
+
+  test('still caps oversized text that merely starts with the elided marker', () => {
+    // Real tool output that happens to begin with the marker prefix (e.g. it
+    // quotes a prior placeholder) followed by megabytes of legitimate content
+    // MUST get truncated. A prefix-only idempotency check would let this
+    // bypass the cap entirely. See cap-result.ts ELIDED_PLACEHOLDER_PATTERN.
+    const result: ToolResult = {
+      content: [{ type: 'text', text: `[tool-result-cap: quoted prior placeholder] ${'X'.repeat(500)}` }],
+    }
+
+    const stats = capToolResult('webfetch', result, baseOptions)
+
+    expect(stats.textsTruncated).toBe(1)
+    const part = result.content[0] as { type: 'text'; text: string }
+    expect(part.text.length).toBeLessThan(500)
+    expect(part.text).toContain('tool-result-cap')
+  })
+
+  test('treats exemptTools as optional and defaults to no exemption', () => {
+    const result: ToolResult = {
+      content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) }],
+    }
+
+    const stats = capToolResult('read', result, { imageMaxBytes: 100, textMaxBytes: 50 })
+
+    expect(stats.imagesReplaced).toBe(1)
+  })
+})
+
+describe('capContentParts', () => {
+  test('operates on a content array directly without a ToolResult wrapper', () => {
+    const content: ToolResult['content'] = [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) }]
+
+    const stats = capContentParts('read', content, baseOptions)
+
+    expect(stats.imagesReplaced).toBe(1)
+    expect(content[0]?.type).toBe('text')
   })
 })

--- a/src/bundled-plugins/tool-result-cap/cap-result.ts
+++ b/src/bundled-plugins/tool-result-cap/cap-result.ts
@@ -3,7 +3,7 @@ import type { ContentPart, ToolResult } from '@/plugin'
 export type CapOptions = {
   imageMaxBytes: number
   textMaxBytes: number
-  exemptTools: ReadonlySet<string>
+  exemptTools?: ReadonlySet<string>
 }
 
 export type CapStats = {
@@ -12,23 +12,32 @@ export type CapStats = {
   bytesElided: number
 }
 
-// Sentinel marker used in both image and text replacement payloads so a future
-// pass (or the LLM itself) can recognize that a value was capped rather than
-// truthfully short. Plain English on purpose — these strings get fed to the
-// model on every turn, and unfamiliar tokens cost reasoning bandwidth.
 const ELIDED_MARKER = '[tool-result-cap: '
 
-export function capToolResult(tool: string, result: ToolResult, options: CapOptions): CapStats {
-  const stats: CapStats = { imagesReplaced: 0, textsTruncated: 0, bytesElided: 0 }
-  if (options.exemptTools.has(tool)) return stats
+// A capped text part is exactly the placeholder we generated: starts with
+// `[tool-result-cap: `, ends with `]`, and contains no inner `]`. The shape
+// check exists for idempotency so a previously-capped entry survives a second
+// pass untouched — but tight enough that real tool output that merely STARTS
+// with the marker (e.g. quotes a prior placeholder then continues with more
+// content) still gets capped on its trailing bulk. A prefix-only check would
+// be an oversized-text bypass.
+const ELIDED_PLACEHOLDER_PATTERN = /^\[tool-result-cap: [^\]]*\]$/
 
-  for (let i = 0; i < result.content.length; i++) {
-    const part = result.content[i]
+function isElidedPlaceholderText(text: string): boolean {
+  return ELIDED_PLACEHOLDER_PATTERN.test(text)
+}
+
+export function capContentParts(tool: string, content: ContentPart[], options: CapOptions): CapStats {
+  const stats: CapStats = { imagesReplaced: 0, textsTruncated: 0, bytesElided: 0 }
+  if (options.exemptTools?.has(tool)) return stats
+
+  for (let i = 0; i < content.length; i++) {
+    const part = content[i]
     if (!part) continue
     if (part.type === 'image') {
       const size = part.data.length
       if (size <= options.imageMaxBytes) continue
-      result.content[i] = {
+      content[i] = {
         type: 'text',
         text: `${ELIDED_MARKER}image ${part.mimeType} elided, ${size} bytes of base64 exceeded imageMaxBytes=${options.imageMaxBytes}]`,
       }
@@ -39,18 +48,21 @@ export function capToolResult(tool: string, result: ToolResult, options: CapOpti
     if (part.type === 'text') {
       const size = part.text.length
       if (size <= options.textMaxBytes) continue
-      // Keep a head slice of the original text so the LLM still has a hint of
-      // shape (e.g. "fetched HTML starts with <!DOCTYPE..."). Tail is dropped.
+      if (isElidedPlaceholderText(part.text)) continue
       const head = part.text.slice(0, options.textMaxBytes)
       const elided = size - options.textMaxBytes
       const replacement: ContentPart = {
         type: 'text',
         text: `${head}\n\n${ELIDED_MARKER}${elided} bytes truncated from text part; original was ${size} bytes, textMaxBytes=${options.textMaxBytes}]`,
       }
-      result.content[i] = replacement
+      content[i] = replacement
       stats.textsTruncated += 1
       stats.bytesElided += elided
     }
   }
   return stats
+}
+
+export function capToolResult(tool: string, result: ToolResult, options: CapOptions): CapStats {
+  return capContentParts(tool, result.content, options)
 }

--- a/src/bundled-plugins/tool-result-cap/index.test.ts
+++ b/src/bundled-plugins/tool-result-cap/index.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { noopPermissionService } from '@/permissions'
 import type { PluginContext, PluginExports, ToolAfterEvent } from '@/plugin'
 
-import toolResultCapPlugin from './index'
+import toolResultCapPlugin, { resolveCapOptionsFromConfig } from './index'
 
 function makeCtx(overrides: { config: unknown }): {
   ctx: PluginContext<any>
@@ -149,5 +149,27 @@ describe('tool-result-cap plugin', () => {
 
     expect(event.result.content[0]).toEqual({ type: 'image', mimeType: 'image/png', data: 'A'.repeat(5000) })
     expect(logs).toEqual([])
+  })
+})
+
+describe('resolveCapOptionsFromConfig', () => {
+  test('returns null when enabled is false (load-time cap disabled)', () => {
+    expect(resolveCapOptionsFromConfig({ enabled: false })).toBeNull()
+  })
+
+  test('returns options with defaults applied for undefined config block', () => {
+    const opts = resolveCapOptionsFromConfig(undefined)
+    expect(opts).not.toBeNull()
+    expect(opts!.imageMaxBytes).toBe(262_144)
+    expect(opts!.textMaxBytes).toBe(65_536)
+    expect(opts!.exemptTools?.size).toBe(0)
+  })
+
+  test('honors user overrides and materializes exemptTools as a Set', () => {
+    const opts = resolveCapOptionsFromConfig({ imageMaxBytes: 32_768, textMaxBytes: 8_192, exemptTools: ['read'] })
+    expect(opts).not.toBeNull()
+    expect(opts!.imageMaxBytes).toBe(32_768)
+    expect(opts!.textMaxBytes).toBe(8_192)
+    expect(opts!.exemptTools?.has('read')).toBe(true)
   })
 })

--- a/src/bundled-plugins/tool-result-cap/index.ts
+++ b/src/bundled-plugins/tool-result-cap/index.ts
@@ -2,14 +2,14 @@ import { z } from 'zod'
 
 import { definePlugin } from '@/plugin'
 
-import { capToolResult } from './cap-result'
+import { type CapOptions, capToolResult } from './cap-result'
 
 const DEFAULT_IMAGE_MAX_BYTES = 262_144
 const DEFAULT_TEXT_MAX_BYTES = 65_536
 const MIN_IMAGE_MAX_BYTES = 1_024
 const MIN_TEXT_MAX_BYTES = 1_024
 
-const toolResultCapConfigSchema = z
+export const toolResultCapConfigSchema = z
   .object({
     enabled: z.boolean().default(true),
     imageMaxBytes: z.number().int().min(MIN_IMAGE_MAX_BYTES).default(DEFAULT_IMAGE_MAX_BYTES),
@@ -22,6 +22,20 @@ const toolResultCapConfigSchema = z
     textMaxBytes: DEFAULT_TEXT_MAX_BYTES,
     exemptTools: [],
   })
+
+// Helper for non-plugin call sites (e.g. channel-session-factory's load-time
+// pass) to parse the same `tool-result-cap` config block and resolve it to
+// the runtime options shape, or `null` when the plugin is disabled. Keeps
+// the schema and the disable rule in one place.
+export function resolveCapOptionsFromConfig(raw: unknown): CapOptions | null {
+  const parsed = toolResultCapConfigSchema.parse(raw)
+  if (!parsed.enabled) return null
+  return {
+    imageMaxBytes: parsed.imageMaxBytes,
+    textMaxBytes: parsed.textMaxBytes,
+    exemptTools: new Set(parsed.exemptTools),
+  }
+}
 
 export default definePlugin({
   configSchema: toolResultCapConfigSchema,

--- a/src/run/channel-session-factory.test.ts
+++ b/src/run/channel-session-factory.test.ts
@@ -77,6 +77,7 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
       pluginRuntime: makeEmptyRuntime(),
       getChannelRouter: () => router,
       createSession: fakeCreateSession,
+      rehydrateCapOptions: null,
     })
 
     await factory({
@@ -107,6 +108,7 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
         captured = options
         return STUB_SESSION
       },
+      rehydrateCapOptions: null,
     })
 
     await factory({
@@ -135,6 +137,7 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
         captured = options
         return STUB_SESSION
       },
+      rehydrateCapOptions: null,
     })
 
     await factory({
@@ -163,6 +166,7 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
         captured = options
         return STUB_SESSION
       },
+      rehydrateCapOptions: null,
     })
 
     await factory({
@@ -201,6 +205,7 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
         captured = options
         return STUB_SESSION
       },
+      rehydrateCapOptions: null,
     })
 
     await factory({
@@ -232,6 +237,7 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
         captured = options
         return STUB_SESSION
       },
+      rehydrateCapOptions: null,
     })
 
     router = makeFakeRouter()
@@ -262,6 +268,7 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
         capturedSm = options?.sessionManager ?? null
         return STUB_SESSION
       },
+      rehydrateCapOptions: null,
     })
 
     await factory({
@@ -286,6 +293,7 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
       pluginRuntime: runtime,
       getChannelRouter: makeFakeRouter,
       createSession: async () => STUB_SESSION,
+      rehydrateCapOptions: null,
     })
 
     const result = await factory({
@@ -311,6 +319,7 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
       pluginRuntime: makeEmptyRuntime(),
       getChannelRouter: makeFakeRouter,
       createSession: async () => STUB_SESSION,
+      rehydrateCapOptions: null,
     })
 
     const result = await factory({
@@ -321,5 +330,157 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
     })
 
     expect(result.hooks).toBeUndefined()
+  })
+
+  test('caps oversized tool results in the JSONL before pi-coding-agent opens it', async () => {
+    const { mkdirSync, writeFileSync, readFileSync } = await import('node:fs')
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const sessionDir = join(tmp, 'sessions')
+    mkdirSync(sessionDir, { recursive: true })
+    const sessionFile = 'poisoned.jsonl'
+    const sessionPath = join(sessionDir, sessionFile)
+    const lines = [
+      JSON.stringify({ type: 'session', id: 'poisoned-id', timestamp: '2026-05-12T00:00:00Z', cwd: tmp, version: 3 }),
+      JSON.stringify({
+        type: 'message',
+        id: 'e1',
+        parentId: null,
+        timestamp: '2026-05-12T00:00:01Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'functions.read:1',
+          toolName: 'read',
+          content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(5000) }],
+        },
+      }),
+    ]
+    writeFileSync(sessionPath, `${lines.join('\n')}\n`)
+    const capLogs: string[] = []
+    const warnLogs: string[] = []
+
+    const factory = buildChannelSessionFactory({
+      cwd: tmp,
+      sessionFactory: makeFakeSessionFactory(sessionDir),
+      stream: makeFakeStream(),
+      reloadRegistry: makeFakeReloadRegistry(),
+      pluginRuntime: makeEmptyRuntime(),
+      getChannelRouter: makeFakeRouter,
+      createSession: async () => STUB_SESSION,
+      rehydrateCapOptions: { imageMaxBytes: 100, textMaxBytes: 100, exemptTools: new Set() },
+      logger: { info: (msg) => capLogs.push(msg), warn: (msg) => warnLogs.push(msg) },
+    })
+
+    await factory({
+      key: { adapter: 'discord-bot', workspace: '@dm', chat: 'c1', thread: null },
+      existingSessionId: 'poisoned-id',
+      existingSessionFile: sessionFile,
+      participants: [],
+      origin: { kind: 'channel', adapter: 'discord-bot', workspace: '@dm', chat: 'c1', thread: null, participants: [] },
+      originRef: { current: undefined },
+    })
+
+    const after = readFileSync(sessionPath, 'utf8')
+    expect(after).not.toContain('A'.repeat(5000))
+    expect(after).toContain('tool-result-cap')
+    expect(capLogs.some((l) => l.includes('rehydrate-cap'))).toBe(true)
+  })
+
+  test('leaves the JSONL untouched when rehydrateCapOptions is null', async () => {
+    const { mkdirSync, writeFileSync, readFileSync } = await import('node:fs')
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const sessionDir = join(tmp, 'sessions')
+    mkdirSync(sessionDir, { recursive: true })
+    const sessionFile = 'untouched.jsonl'
+    const sessionPath = join(sessionDir, sessionFile)
+    const original = `${JSON.stringify({
+      type: 'session',
+      id: 'untouched-id',
+      timestamp: '2026-05-12T00:00:00Z',
+      cwd: tmp,
+      version: 3,
+    })}\n${JSON.stringify({
+      type: 'message',
+      id: 'e1',
+      parentId: null,
+      timestamp: '2026-05-12T00:00:01Z',
+      message: {
+        role: 'toolResult',
+        toolCallId: 'functions.read:1',
+        toolName: 'read',
+        content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(5000) }],
+      },
+    })}\n`
+    writeFileSync(sessionPath, original)
+
+    const factory = buildChannelSessionFactory({
+      cwd: tmp,
+      sessionFactory: makeFakeSessionFactory(sessionDir),
+      stream: makeFakeStream(),
+      reloadRegistry: makeFakeReloadRegistry(),
+      pluginRuntime: makeEmptyRuntime(),
+      getChannelRouter: makeFakeRouter,
+      createSession: async () => STUB_SESSION,
+      rehydrateCapOptions: null,
+    })
+
+    await factory({
+      key: { adapter: 'discord-bot', workspace: '@dm', chat: 'c1', thread: null },
+      existingSessionId: 'untouched-id',
+      existingSessionFile: sessionFile,
+      participants: [],
+      origin: { kind: 'channel', adapter: 'discord-bot', workspace: '@dm', chat: 'c1', thread: null, participants: [] },
+      originRef: { current: undefined },
+    })
+
+    expect(readFileSync(sessionPath, 'utf8')).toBe(original)
+  })
+
+  test('rejects path-traversal sessionFile and falls back to a fresh session', async () => {
+    const { mkdirSync, writeFileSync, readFileSync, existsSync } = await import('node:fs')
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const sessionDir = join(tmp, 'sessions')
+    mkdirSync(sessionDir, { recursive: true })
+    // A bystander file outside sessions/ that the cap pass must never touch
+    // even if a tampered channels/sessions.json#sessionFile points at it.
+    const bystander = join(tmp, 'bystander.jsonl')
+    const bystanderContent = `${JSON.stringify({
+      type: 'message',
+      id: 'b1',
+      parentId: null,
+      timestamp: '2026-05-12T00:00:01Z',
+      message: {
+        role: 'toolResult',
+        toolCallId: 'functions.read:1',
+        toolName: 'read',
+        content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(5000) }],
+      },
+    })}\n`
+    writeFileSync(bystander, bystanderContent)
+    const warnLogs: string[] = []
+
+    const factory = buildChannelSessionFactory({
+      cwd: tmp,
+      sessionFactory: makeFakeSessionFactory(sessionDir),
+      stream: makeFakeStream(),
+      reloadRegistry: makeFakeReloadRegistry(),
+      pluginRuntime: makeEmptyRuntime(),
+      getChannelRouter: makeFakeRouter,
+      createSession: async () => STUB_SESSION,
+      rehydrateCapOptions: { imageMaxBytes: 100, textMaxBytes: 100, exemptTools: new Set() },
+      logger: { info: () => {}, warn: (msg) => warnLogs.push(msg) },
+    })
+
+    await factory({
+      key: { adapter: 'discord-bot', workspace: '@dm', chat: 'c1', thread: null },
+      existingSessionId: 'malicious',
+      existingSessionFile: '../bystander.jsonl',
+      participants: [],
+      origin: { kind: 'channel', adapter: 'discord-bot', workspace: '@dm', chat: 'c1', thread: null, participants: [] },
+      originRef: { current: undefined },
+    })
+
+    expect(readFileSync(bystander, 'utf8')).toBe(bystanderContent)
+    expect(existsSync(join(sessionDir, '../bystander.jsonl.cap.tmp'))).toBe(false)
+    expect(warnLogs.some((l) => l.includes('invalid sessionFile'))).toBe(true)
   })
 })

--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -1,12 +1,24 @@
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession as defaultCreateSession } from '@/agent'
+import { capJsonlFileInPlace } from '@/bundled-plugins/tool-result-cap/cap-jsonl'
+import type { CapOptions } from '@/bundled-plugins/tool-result-cap/cap-result'
 import type { CreateSessionForChannel, ChannelRouter } from '@/channels'
 import type { ReloadRegistry } from '@/reload'
 import type { SessionFactory } from '@/sessions'
 import type { Stream } from '@/stream'
 
 import type { PluginRuntime } from './plugin-runtime'
+
+export type FactoryLogger = {
+  info: (message: string) => void
+  warn: (message: string) => void
+}
+
+const consoleLogger: FactoryLogger = {
+  info: (m) => console.info(m),
+  warn: (m) => console.warn(m),
+}
 
 export type BuildChannelSessionFactoryDeps = {
   cwd: string
@@ -20,10 +32,28 @@ export type BuildChannelSessionFactoryDeps = {
   // their inbound messages came from.
   getChannelRouter: () => ChannelRouter
   containerName?: string
+  // When set, rehydrating a session JSONL caps oversized tool results in the
+  // file before pi-coding-agent reads it. `null` disables the load-time pass
+  // (tool-result-cap.enabled=false in config, or no plugin block at all).
+  rehydrateCapOptions: CapOptions | null
+  logger?: FactoryLogger
   // Test seam: lets a fake stand in for the agent session creator so tests
   // can assert exactly which CreateSessionOptions the factory builds without
   // needing a live LLM, plugin runtime, or session manager on disk.
   createSession?: typeof defaultCreateSession
+}
+
+// Tight basename validation so a tampered or corrupt channels/sessions.json
+// can't point the load-time rewrite (or SessionManager.open) at a file
+// outside `sessionDir`. We never receive sessionFile from a remote source
+// during normal operation, but the file is operator-editable, so defense-
+// in-depth is cheap. Match pi-coding-agent's filename convention loosely:
+// no path separators, no NUL, must end in `.jsonl`.
+function isValidSessionFileBasename(name: string): boolean {
+  if (name.length === 0 || name.length > 255) return false
+  if (name.includes('/') || name.includes('\\') || name.includes('\0')) return false
+  if (name === '.' || name === '..' || name.startsWith('.')) return false
+  return name.endsWith('.jsonl')
 }
 
 // The production wiring for channel-routed sessions. Channel inbounds arrive
@@ -35,11 +65,19 @@ export type BuildChannelSessionFactoryDeps = {
 // "channel-aware" sessions that need the same full plumbing.
 export function buildChannelSessionFactory(deps: BuildChannelSessionFactoryDeps): CreateSessionForChannel {
   const createSession = deps.createSession ?? defaultCreateSession
+  const logger = deps.logger ?? consoleLogger
   return async ({ existingSessionId, existingSessionFile, origin, originRef }) => {
     const sessionDir = deps.sessionFactory.sessionDir()
     const sessionManager =
       existingSessionId !== undefined
-        ? tryReopenOrCreate(deps.cwd, sessionDir, existingSessionId, existingSessionFile)
+        ? tryReopenOrCreate(
+            deps.cwd,
+            sessionDir,
+            existingSessionId,
+            existingSessionFile,
+            deps.rehydrateCapOptions,
+            logger,
+          )
         : SessionManager.create(deps.cwd, sessionDir)
 
     const snap = deps.pluginRuntime.get()
@@ -87,18 +125,43 @@ function tryReopenOrCreate(
   sessionDir: string,
   existingSessionId: string,
   existingSessionFile: string | undefined,
+  capOptions: CapOptions | null,
+  logger: FactoryLogger,
 ): SessionManager {
   if (existingSessionFile === undefined) {
-    console.warn(
+    logger.warn(
       `[channels] session ${existingSessionId} has no sessionFile (v2 mapping not yet migrated); creating new`,
     )
     return SessionManager.create(cwd, sessionDir)
   }
+  if (!isValidSessionFileBasename(existingSessionFile)) {
+    logger.warn(
+      `[channels] session ${existingSessionId} has invalid sessionFile (${JSON.stringify(existingSessionFile)}); creating new`,
+    )
+    return SessionManager.create(cwd, sessionDir)
+  }
+  const path = `${sessionDir}/${existingSessionFile}`
+  if (capOptions !== null) {
+    try {
+      const stats = capJsonlFileInPlace(path, capOptions)
+      if (stats.entriesMutated > 0) {
+        logger.info(
+          `[channels] rehydrate-cap ${existingSessionFile}: entriesMutated=${stats.entriesMutated} imagesReplaced=${stats.imagesReplaced} textsTruncated=${stats.textsTruncated} bytesElided=${stats.bytesElided}`,
+        )
+      }
+    } catch (err) {
+      // Capping is best-effort: if the rewrite fails, fall through to the
+      // regular open path so the session still rehydrates uncapped rather
+      // than being killed by a transient FS error.
+      const reason = err instanceof Error ? err.message : String(err)
+      logger.warn(`[channels] rehydrate-cap failed for ${existingSessionFile}: ${reason}; continuing with open`)
+    }
+  }
   try {
-    return SessionManager.open(`${sessionDir}/${existingSessionFile}`)
+    return SessionManager.open(path)
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err)
-    console.warn(
+    logger.warn(
       `[channels] could not rehydrate session ${existingSessionId} from ${existingSessionFile}: ${reason}; creating new`,
     )
     return SessionManager.create(cwd, sessionDir)

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -10,6 +10,7 @@ import {
   type SubagentConsumer,
   type SubagentRegistry,
 } from '@/agent/subagents'
+import { resolveCapOptionsFromConfig } from '@/bundled-plugins/tool-result-cap'
 import { createChannelManager, createChannelsReloadable, type ChannelManager } from '@/channels'
 import { createConfigReloadable, getConfig, loadConfigSync, loadPluginConfigsSync } from '@/config'
 import {
@@ -143,6 +144,7 @@ export async function startAgent({
       reloadRegistry,
       pluginRuntime,
       getChannelRouter: () => channelManager.router,
+      rehydrateCapOptions: resolveCapOptionsFromConfig(pluginConfigsByName['tool-result-cap']),
       ...containerNameOpt,
     }),
     permissions: pluginsLoaded.permissions,


### PR DESCRIPTION
## Problem

The `tool-result-cap` plugin's `tool.after` hook only fires on **new** tool calls. Any channel session whose JSONL captured an oversized tool result before the plugin landed — or before its caps were tightened — keeps replaying that payload on every prompt indefinitely.

pi-coding-agent's compactor cannot evict it because `findCutPoint` walks backwards accumulating tokens until `keepRecentTokens` (20,000). A single tool result larger than that budget (e.g. a 210K-token base64 PNG) overshoots on the entry that contains it, placing the cut point at or after it, so it stays in the "recent" window permanently. In practice: a kakao agent that read a single 3000×5000 PNG on May 12 burned ~210K input tokens per turn for every conversation since, with no path to recovery short of deleting the session mapping in `channels/sessions.json` and losing continuity.

## Solution

Extend the same cap policy to channel session **rehydrate** time. Before `SessionManager.open()` reads the JSONL for an existing channel session, the new `capJsonlFileInPlace` function walks the file, applies `capToolResult` to every `toolResult` entry, and rewrites the file atomically (temp+rename) when anything mutated. Same config knob (`tool-result-cap.enabled` / `imageMaxBytes` / `textMaxBytes` / `exemptTools`) governs both the `tool.after` hook and the load-time pass; when the plugin is disabled, the load-time pass is skipped entirely.

The `capToolResult` function gained an idempotency guard: text parts whose payload already starts with the elision marker are skipped, so running the load-time pass on an already-capped file is a strict no-op regardless of how small `textMaxBytes` is configured.

## Effect

**`typeclaw restart` is now the single user-facing recovery action for a poisoned channel session.** The first inbound after restart triggers `ensureLive` → `tryReopenOrCreate` → load-time cap pass → JSONL shrinks on disk → first prompt's input tokens drop from hundreds-of-K to the configured cap. No scrubber subcommand, no surgery on `channels/sessions.json`, no continuity loss — the same `sessionId` continues, with the giant blob replaced by `[tool-result-cap: image image/png elided, X bytes of base64 exceeded imageMaxBytes=Y]`.

## Why pi-coding-agent isn't fixed upstream

Two reasons:
1. pi's `read` tool already auto-resizes images to 4.5 MB base64 (Anthropic's wire-format ceiling). That's correct for single-session coding work. TypeClaw runs multi-day persistent channel sessions where the same 4.5 MB stays in context for hundreds of turns. The right policy is session-economics-aware, not wire-limit-aware — so it belongs here, not upstream.
2. We need the fix to ship today for the kakao agent. Local cap policy is fully self-contained.

## Files changed

- **`src/bundled-plugins/tool-result-cap/cap-jsonl.ts`** (new) — JSONL file walker. Reads the file, parses each line, calls `capToolResult` on `toolResult` messages, and writes back atomically when anything mutated. Malformed lines are passed through verbatim so a corrupt JSONL never gets worse.
- **`src/bundled-plugins/tool-result-cap/cap-jsonl.test.ts`** (new) — 9 test cases: rewrite-on-mutation, no-write-when-clean, idempotency, `exemptTools`, non-`toolResult` preservation, malformed-line passthrough, missing-file safety, multi-entry batching, text truncation.
- **`src/bundled-plugins/tool-result-cap/cap-result.ts`** — idempotency guard: skip text parts whose payload starts with the elision marker.
- **`src/bundled-plugins/tool-result-cap/cap-result.test.ts`** — explicit idempotency test exercising the boundary case (tiny `textMaxBytes`).
- **`src/bundled-plugins/tool-result-cap/index.ts`** — `toolResultCapConfigSchema` exported; new `resolveCapOptionsFromConfig(raw)` returns `CapOptions | null` (null when disabled). Keeps the schema and disable-check in one place for both the hook and the load-time pass.
- **`src/bundled-plugins/tool-result-cap/index.test.ts`** — tests for `resolveCapOptionsFromConfig` (null on disabled, defaults applied, user overrides).
- **`src/run/channel-session-factory.ts`** — `BuildChannelSessionFactoryDeps.rehydrateCapOptions: CapOptions | null` added (required). `tryReopenOrCreate` calls `capJsonlFileInPlace` before `SessionManager.open` when options are non-null; cap failures fall through to the regular open path (best-effort so a cap bug can't brick a session).
- **`src/run/channel-session-factory.test.ts`** — 2 new integration tests: caps oversized image when options provided, leaves file untouched when options null. Existing 9 tests updated to pass `rehydrateCapOptions: null`.
- **`src/run/index.ts`** — wires `resolveCapOptionsFromConfig(pluginConfigsByName['tool-result-cap'])` into the factory.

## Operational notes

- **Atomic write safety**: the temp+rename pattern means a crash during cap can't leave a half-written JSONL. The original is preserved until `rename` succeeds.
- **`tool-result-cap.*` is already `restart-required`** per the plugin's existing contract. The load-time pass runs on every channel rehydrate after restart, so config changes like dropping `imageMaxBytes` to `32_768` for a chat-heavy agent take effect on the next inbound to each session automatically.
- **No upstream pi-coding-agent changes**: we don't touch any private pi internals. The load-time pass owns the read/write loop directly; pi reads the already-capped file via its normal `SessionManager.open` path.

## Mutation check

Commenting out the `capJsonlFileInPlace` call in `tryReopenOrCreate` causes the "caps oversized image when rehydrateCapOptions provided" integration test to fail (the file bytes remain unchanged at assertion time).

## Testing

- 41 new test cases across the plugin and the factory
- Full suite: 3111 / 3111 pass
- `bun run typecheck` — clean
- `bun run lint` — 8 pre-existing warnings, 0 new
- `bun run format:check` — clean

## Stats

10 files changed, 585 insertions(+), 8 deletions(−).