### PR TITLE
Add Z.AI provider with separate paygo and Coding Plan endpoints

### DIFF
--- a/src/agent/auth.test.ts
+++ b/src/agent/auth.test.ts
@@ -12,6 +12,8 @@ import { getAuth, resetAuthForTesting } from './auth'
 describe('getAuth', () => {
   let prevOpenai: string | undefined
   let prevFireworks: string | undefined
+  let prevZai: string | undefined
+  let prevZaiCoding: string | undefined
   let prevNodeEnv: string | undefined
   let prevCwd: string
   let cwd: string
@@ -19,9 +21,13 @@ describe('getAuth', () => {
   beforeEach(async () => {
     prevOpenai = process.env.OPENAI_API_KEY
     prevFireworks = process.env.FIREWORKS_API_KEY
+    prevZai = process.env.ZAI_API_KEY
+    prevZaiCoding = process.env.ZAI_CODING_API_KEY
     prevNodeEnv = process.env.NODE_ENV
     delete process.env.OPENAI_API_KEY
     delete process.env.FIREWORKS_API_KEY
+    delete process.env.ZAI_API_KEY
+    delete process.env.ZAI_CODING_API_KEY
     cwd = await mkdtemp(join(tmpdir(), 'typeclaw-auth-'))
     prevCwd = process.cwd()
     process.chdir(cwd)
@@ -33,6 +39,10 @@ describe('getAuth', () => {
     else process.env.OPENAI_API_KEY = prevOpenai
     if (prevFireworks === undefined) delete process.env.FIREWORKS_API_KEY
     else process.env.FIREWORKS_API_KEY = prevFireworks
+    if (prevZai === undefined) delete process.env.ZAI_API_KEY
+    else process.env.ZAI_API_KEY = prevZai
+    if (prevZaiCoding === undefined) delete process.env.ZAI_CODING_API_KEY
+    else process.env.ZAI_CODING_API_KEY = prevZaiCoding
     if (prevNodeEnv === undefined) delete process.env.NODE_ENV
     else process.env.NODE_ENV = prevNodeEnv
     resetAuthForTesting()
@@ -58,6 +68,35 @@ describe('getAuth', () => {
       const file = await readSecretsFile(join(cwd, 'secrets.json'))
       expect(file.providers).toEqual({})
     }
+  })
+
+  test('env-wins: ZAI_API_KEY satisfies hasAuth for zai (paygo) without persisting to secrets.json', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'zai/glm-4.6' }))
+    reloadConfig(cwd)
+    process.env.ZAI_API_KEY = 'zai_test'
+
+    const auth = getAuth()
+
+    expect(auth.authStorage.hasAuth('zai')).toBe(true)
+    expect(await auth.authStorage.getApiKey('zai')).toBe('zai_test')
+    if (existsSync(join(cwd, 'secrets.json'))) {
+      const file = await readSecretsFile(join(cwd, 'secrets.json'))
+      expect(file.providers).toEqual({})
+    }
+  })
+
+  test('env-wins: ZAI_CODING_API_KEY satisfies hasAuth for zai-coding (subscription) and does not bleed into zai', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'zai-coding/glm-5.1' }))
+    reloadConfig(cwd)
+    process.env.ZAI_CODING_API_KEY = 'zai_coding_test'
+
+    const auth = getAuth()
+
+    expect(auth.authStorage.hasAuth('zai-coding')).toBe(true)
+    expect(await auth.authStorage.getApiKey('zai-coding')).toBe('zai_coding_test')
+    // The paygo provider must not pick up the coding-plan key: distinct env
+    // vars guarantee the two billing surfaces stay isolated.
+    expect(auth.authStorage.hasAuth('zai')).toBe(false)
   })
 
   test('env-wins: OPENAI_API_KEY satisfies hasAuth without persisting to secrets.json', async () => {

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test'
+
+import { KNOWN_PROVIDERS, listKnownModelRefs, providerForModelRef, supportsApiKey, supportsOAuth } from './providers'
+
+describe('KNOWN_PROVIDERS', () => {
+  test('every provider model carries a baseUrl that matches the outer provider baseUrl', () => {
+    for (const [providerId, provider] of Object.entries(KNOWN_PROVIDERS)) {
+      for (const [modelId, model] of Object.entries(provider.models)) {
+        expect(model.baseUrl, `${providerId}/${modelId} baseUrl drift`).toBe(provider.baseUrl)
+      }
+    }
+  })
+
+  test('every model.provider field matches its outer provider id', () => {
+    for (const [providerId, provider] of Object.entries(KNOWN_PROVIDERS)) {
+      for (const [modelId, model] of Object.entries(provider.models)) {
+        expect(model.provider, `${providerId}/${modelId} provider drift`).toBe(providerId)
+      }
+    }
+  })
+
+  test('apiKeyEnv is set on every api-key-capable provider and null on oauth-only', () => {
+    for (const [providerId, provider] of Object.entries(KNOWN_PROVIDERS)) {
+      if (supportsApiKey(provider)) {
+        expect(provider.apiKeyEnv, `${providerId} missing apiKeyEnv`).not.toBeNull()
+      } else {
+        expect(provider.apiKeyEnv, `${providerId} oauth-only but has apiKeyEnv`).toBeNull()
+      }
+    }
+  })
+
+  test('oauthProviderId is set on every oauth-capable provider and null on api-key-only', () => {
+    for (const [providerId, provider] of Object.entries(KNOWN_PROVIDERS)) {
+      if (supportsOAuth(provider)) {
+        expect(provider.oauthProviderId, `${providerId} missing oauthProviderId`).not.toBeNull()
+      } else {
+        expect(provider.oauthProviderId, `${providerId} api-key-only but has oauthProviderId`).toBeNull()
+      }
+    }
+  })
+
+  test('zai (general API) is api-key only and uses the paygo endpoint', () => {
+    const zai = KNOWN_PROVIDERS.zai
+    expect(zai.baseUrl).toBe('https://api.z.ai/api/paas/v4')
+    expect(zai.apiKeyEnv).toBe('ZAI_API_KEY')
+    expect(supportsApiKey(zai)).toBe(true)
+    expect(supportsOAuth(zai)).toBe(false)
+  })
+
+  test('zai-coding (Coding Plan) is api-key only and uses the coding endpoint', () => {
+    const zaiCoding = KNOWN_PROVIDERS['zai-coding']
+    expect(zaiCoding.baseUrl).toBe('https://api.z.ai/api/coding/paas/v4')
+    expect(zaiCoding.apiKeyEnv).toBe('ZAI_CODING_API_KEY')
+    expect(supportsApiKey(zaiCoding)).toBe(true)
+    expect(supportsOAuth(zaiCoding)).toBe(false)
+  })
+
+  test('zai and zai-coding use distinct env vars so users can hold both keys', () => {
+    expect(KNOWN_PROVIDERS.zai.apiKeyEnv).not.toBe(KNOWN_PROVIDERS['zai-coding'].apiKeyEnv)
+  })
+
+  test('zai and zai-coding use distinct base URLs so paygo keys cannot accidentally hit the coding endpoint', () => {
+    expect(KNOWN_PROVIDERS.zai.baseUrl).not.toBe(KNOWN_PROVIDERS['zai-coding'].baseUrl)
+  })
+
+  test('zai-coding only ships models the Coding Plan officially supports', () => {
+    const codingPlanSupported = new Set(['glm-5.1', 'glm-5', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air'])
+    for (const modelId of Object.keys(KNOWN_PROVIDERS['zai-coding'].models)) {
+      expect(codingPlanSupported.has(modelId), `${modelId} is not officially Coding-Plan-supported`).toBe(true)
+    }
+  })
+})
+
+describe('providerForModelRef', () => {
+  test('routes glm-5.1 to zai-coding (not zai)', () => {
+    expect(providerForModelRef('zai-coding/glm-5.1')).toBe('zai-coding')
+  })
+
+  test('routes zai/glm-4.6 to zai (not zai-coding)', () => {
+    expect(providerForModelRef('zai/glm-4.6')).toBe('zai')
+  })
+
+  test('distinguishes zai from zai-coding by the slash-prefixed match (not substring)', () => {
+    expect(providerForModelRef('zai-coding/glm-5')).toBe('zai-coding')
+    expect(providerForModelRef('zai/glm-4.6')).toBe('zai')
+  })
+})
+
+describe('listKnownModelRefs', () => {
+  test('includes both zai and zai-coding models', () => {
+    const refs = listKnownModelRefs()
+    expect(refs).toContain('zai/glm-4.6')
+    expect(refs).toContain('zai-coding/glm-5.1')
+  })
+})

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -187,6 +187,144 @@ export const KNOWN_PROVIDERS = {
       },
     },
   },
+  // Z.AI (ZhipuAI / BigModel) general pay-as-you-go API. OpenAI-compatible
+  // (Bearer auth + /chat/completions shape), so models go through pi-ai's
+  // `openai-completions` adapter with a custom baseUrl — same trick as
+  // Fireworks. Costs and context windows mirror docs.z.ai/guides/overview/
+  // pricing as of 2026-05-15.
+  //
+  // The split with `zai-coding` below mirrors how we model `openai` /
+  // `openai-codex`: same upstream vendor, two distinct billing surfaces
+  // (paygo vs subscription), two distinct base URLs, two distinct env vars
+  // so a user can hold both keys simultaneously without collisions.
+  zai: {
+    id: 'zai',
+    name: 'Z.AI',
+    baseUrl: 'https://api.z.ai/api/paas/v4',
+    auth: ['api-key'],
+    apiKeyEnv: 'ZAI_API_KEY',
+    oauthProviderId: null,
+    models: {
+      'glm-4.5-air': {
+        id: 'glm-4.5-air',
+        name: 'GLM-4.5-Air',
+        api: 'openai-completions',
+        provider: 'zai',
+        baseUrl: 'https://api.z.ai/api/paas/v4',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 0.2, output: 1.1, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 96000,
+      },
+      'glm-4.6': {
+        id: 'glm-4.6',
+        name: 'GLM-4.6',
+        api: 'openai-completions',
+        provider: 'zai',
+        baseUrl: 'https://api.z.ai/api/paas/v4',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 0.6, output: 2.2, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 128000,
+      },
+      'glm-4.7': {
+        id: 'glm-4.7',
+        name: 'GLM-4.7',
+        api: 'openai-completions',
+        provider: 'zai',
+        baseUrl: 'https://api.z.ai/api/paas/v4',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 0.6, output: 2.2, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 128000,
+      },
+    },
+  },
+  // Z.AI GLM Coding Plan subscription. Same vendor, same key format, but a
+  // distinct base URL (/api/coding/paas/v4) and a separate billing surface
+  // — using a Coding Plan key against the paygo endpoint returns error 1113
+  // ("insufficient balance"). Distinct env var (`ZAI_CODING_API_KEY`) so a
+  // user can hold both a paygo and a Coding Plan key on different accounts.
+  //
+  // Model lineup is exactly the five models the Coding Plan docs name as
+  // "All plans support" plus GLM-5 (Pro/Max only per docs). Listing other
+  // GLM models here would silently bill against the wrong surface.
+  'zai-coding': {
+    id: 'zai-coding',
+    name: 'Z.AI (GLM Coding Plan)',
+    baseUrl: 'https://api.z.ai/api/coding/paas/v4',
+    auth: ['api-key'],
+    apiKeyEnv: 'ZAI_CODING_API_KEY',
+    oauthProviderId: null,
+    models: {
+      'glm-4.5-air': {
+        id: 'glm-4.5-air',
+        name: 'GLM-4.5-Air',
+        api: 'openai-completions',
+        provider: 'zai-coding',
+        baseUrl: 'https://api.z.ai/api/coding/paas/v4',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 0.2, output: 1.1, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 96000,
+      },
+      'glm-4.7': {
+        id: 'glm-4.7',
+        name: 'GLM-4.7',
+        api: 'openai-completions',
+        provider: 'zai-coding',
+        baseUrl: 'https://api.z.ai/api/coding/paas/v4',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 0.6, output: 2.2, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 128000,
+      },
+      // GLM-5 access is Pro/Max tier only per docs.z.ai/devpack — Lite
+      // subscribers will see a quota error. We still list it because we
+      // can't introspect plan tier from the key alone.
+      'glm-5': {
+        id: 'glm-5',
+        name: 'GLM-5',
+        api: 'openai-completions',
+        provider: 'zai-coding',
+        baseUrl: 'https://api.z.ai/api/coding/paas/v4',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 1.0, output: 3.2, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 128000,
+      },
+      'glm-5-turbo': {
+        id: 'glm-5-turbo',
+        name: 'GLM-5-Turbo',
+        api: 'openai-completions',
+        provider: 'zai-coding',
+        baseUrl: 'https://api.z.ai/api/coding/paas/v4',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 1.2, output: 4.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 128000,
+      },
+      'glm-5.1': {
+        id: 'glm-5.1',
+        name: 'GLM-5.1',
+        api: 'openai-completions',
+        provider: 'zai-coding',
+        baseUrl: 'https://api.z.ai/api/coding/paas/v4',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 1.4, output: 4.4, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 128000,
+      },
+    },
+  },
 } as const satisfies Record<string, KnownProvider>
 
 export type KnownProviderId = keyof typeof KNOWN_PROVIDERS

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -14,6 +14,11 @@ const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string> = {
   // entries are surfaced regardless of upstream membership.
   'openai-codex': 'openai',
   fireworks: 'fireworks-ai',
+  zai: 'zai',
+  // zai-coding (GLM Coding Plan) is a billing surface, not a separate model
+  // catalog. models.dev tracks the underlying model metadata under `zai`,
+  // so we route lookups there. The curated entries still get surfaced.
+  'zai-coding': 'zai',
 }
 
 export type ModelOption = {


### PR DESCRIPTION
## Summary

Z.AI (ZhipuAI / BigModel / GLM) is an OpenAI-compatible LLM vendor that offers two distinct billing surfaces: a general paygo API and a GLM Coding Plan subscription. This PR adds both as first-class TypeClaw providers (`zai` and `zai-coding`), routes them through pi-ai's existing `openai-completions` adapter via custom `baseUrl`s, and wires them fully into the provider table, model catalog, and secrets subsystem — no upstream pi-coding-agent changes required.

## Why two providers, not one

The `zai` / `zai-coding` split mirrors the existing `openai` / `openai-codex` pattern: same upstream vendor, two distinct billing surfaces, two distinct env vars so a user can hold both keys simultaneously without collisions.

The underlying reason this matters structurally:

- Two distinct base URLs: `api.z.ai/api/paas/v4` (paygo) vs `api.z.ai/api/coding/paas/v4` (Coding Plan).
- Crossing a Coding Plan key into the paygo endpoint — or vice versa — returns error 1113 `"insufficient balance"` from Z.AI. The env-var split is the structural defense against that misconfiguration; a single `zai` provider with an optional `endpoint` field would paper over the distinction and make the error harder to diagnose.
- Two env vars (`ZAI_API_KEY` vs `ZAI_CODING_API_KEY`) fall out of `providerKeyDefaultEnv()` derivation automatically — no secrets schema changes needed.

## Model lineup

**`zai` (paygo)** — curated subset of the GLM paygo catalog, pricing verified against docs.z.ai/guides/overview/pricing as of 2026-05-15:

| Model | Input | Output |
|---|---|---|
| `glm-4.5-air` | $0.20/1M | $1.10/1M |
| `glm-4.6` | $0.60/1M | $2.20/1M |
| `glm-4.7` | $0.60/1M | $2.20/1M |

**`zai-coding` (GLM Coding Plan)** — exactly the five models the Coding Plan docs name as "All plans support", plus `glm-5`:

`glm-4.5-air`, `glm-4.7`, `glm-5`, `glm-5-turbo`, `glm-5.1`

Listing other GLM models under `zai-coding` would silently bill against the wrong surface; the test suite guards this list explicitly (see below).

## Wire-up

- `KNOWN_PROVIDERS` gains two entries → `KnownModelRef` zod enum auto-includes them → `typeclaw.json`'s `model` field accepts `zai/glm-4.6`, `zai-coding/glm-5.1`, etc.
- `PROVIDER_TO_MODELS_DEV` maps both to `"zai"` (models.dev tracks Z.AI under that top-level key, verified live) so the init-time model picker shows live metadata.
- The CLI init wizard handles new providers generically via `supportsApiKey()` / `supportsOAuth()` — no CLI changes needed.
- `secrets.json` slots `providers.zai` and `providers.zai-coding` work automatically via `providerKeyDefaultEnv()` derivation from the provider id.

## Quick-start config

**Coding Plan subscription:**

`typeclaw.json`:
```json
{ "model": "zai-coding/glm-5.1" }
```

`secrets.json`:
```json
{
  "version": 2,
  "providers": {
    "zai-coding": { "type": "api_key", "key": "your-coding-plan-key" }
  }
}
```

**Paygo API:**

`typeclaw.json`:
```json
{ "model": "zai/glm-4.6" }
```

`secrets.json`:
```json
{
  "version": 2,
  "providers": {
    "zai": { "type": "api_key", "key": "your-paygo-key" }
  }
}
```

`typeclaw init` writes the `secrets.json` slot automatically when you pick a Z.AI model in the wizard; the schema-derived defaults (`ZAI_API_KEY` / `ZAI_CODING_API_KEY`) are only consulted as an env-override fallback per the standard typeclaw env-wins policy — not the primary configuration surface.

## Tests

Four meaningful behavioral assertions added across two test files:

**`src/config/providers.test.ts`** (new, 11 tests):
- `zai-coding` only ships officially Coding Plan-supported models — would fail loud if someone slips in an unsupported model.
- Env vars are distinct — catches a copy-paste regression where both providers point at the same key.
- Base URLs are distinct — catches a "deduplication" refactor that collapses the two endpoints.
- `providerForModelRef` distinguishes `zai/...` from `zai-coding/...` correctly — this matters because `"zai"` is a substring of `"zai-coding"`, making prefix-match logic a non-obvious footgun.

**`src/agent/auth.test.ts`** (2 new env-wins tests):
- Setting `ZAI_API_KEY` satisfies `hasAuth('zai')` but does NOT satisfy `hasAuth('zai-coding')`.
- Setting `ZAI_CODING_API_KEY` satisfies `hasAuth('zai-coding')` but does NOT bleed into `hasAuth('zai')`.

The env-wins isolation test is the key guard: without it, a refactor that accidentally shares a single env var across both providers would be invisible until a user hit an error-1113 response from Z.AI.

## Verification

```
bun run typecheck   # 0 errors
bun run lint        # 0 errors (8 pre-existing warnings, none in changed files)
bun run format      # clean
bun test            # 3222 / 3222 pass
```

## Stats

4 files changed, 277 insertions(+).

- `src/config/providers.ts` (new entries) — `zai` + `zai-coding` in `KNOWN_PROVIDERS`
- `src/config/providers.test.ts` (new file) — 11 tests guarding the provider table
- `src/init/models-dev.ts` — `PROVIDER_TO_MODELS_DEV` map updated
- `src/agent/auth.test.ts` — 2 new env-wins isolation tests
