### PR TITLE
Render the correct platform name and mention syntax per adapter

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -517,4 +517,101 @@ describe('renderSessionOrigin', () => {
     const withoutCtx = renderSessionOrigin({ kind: 'cron', jobId: 'job-x', jobKind: 'prompt' })
     expect(withoutCtx).not.toContain('Your role in this session')
   })
+
+  test('Slack channel origin names Slack as the platform and teaches angle-id mention syntax', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: null,
+    })
+    expect(out).toContain('Slack channel session')
+    expect(out).toContain('Slack syntax `<@USER_ID>`')
+    expect(out).not.toContain('Discord channel session')
+    expect(out).not.toContain('Telegram syntax')
+    expect(out).not.toContain('KakaoTalk has no in-band')
+  })
+
+  test('Discord channel origin names Discord and teaches angle-id mention syntax', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'discord-bot',
+      workspace: '111',
+      chat: '222',
+      thread: null,
+    })
+    expect(out).toContain('Discord channel session')
+    expect(out).toContain('Discord syntax `<@USER_ID>`')
+    expect(out).not.toContain('Slack channel session')
+  })
+
+  test('Telegram channel origin names Telegram and teaches @username mention syntax (NOT angle-id)', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'telegram-bot',
+      workspace: '-100123',
+      chat: '-100123',
+      thread: null,
+    })
+    expect(out).toContain('Telegram channel session')
+    expect(out).toContain('Telegram syntax `@username`')
+    expect(out).not.toContain('Discord channel session')
+    expect(out).not.toContain('Slack syntax')
+    expect(out).not.toContain('Discord syntax')
+    expect(out).toContain('do not echo them back as outbound mentions')
+  })
+
+  test('KakaoTalk channel origin names KakaoTalk and teaches alias/display-name mention (NOT angle-id)', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'kakaotalk',
+      workspace: '@kakao-group',
+      chat: '123',
+      thread: null,
+    })
+    expect(out).toContain('KakaoTalk channel session')
+    expect(out).toContain('KakaoTalk has no in-band mention syntax')
+    expect(out).not.toContain('Discord channel session')
+    expect(out).not.toContain('Slack syntax')
+    expect(out).not.toContain('Discord syntax')
+    expect(out).not.toContain('Telegram syntax')
+    expect(out).toContain('do not echo them back as outbound mentions')
+  })
+
+  test('non-angle-id adapters do not include the angle-id worked example anchored on a real participant', () => {
+    // given: a real peer bot participant whose authorId would otherwise be
+    // rendered as `<@999> hello` for angle-id adapters
+    const now = Date.now()
+    const participants: ChannelParticipant[] = [
+      {
+        authorId: '999',
+        authorName: 'Winky',
+        firstMessageAt: now - 1000,
+        lastMessageAt: now - 1000,
+        messageCount: 5,
+        isBot: true,
+      },
+    ]
+
+    // when: KakaoTalk session with the same participant set
+    const kakao = renderSessionOrigin(
+      { kind: 'channel', adapter: 'kakaotalk', workspace: '@kakao-group', chat: '123', thread: null, participants },
+      now,
+    )
+
+    // then: the model is told NOT to emit `<@999> hello` and is given KakaoTalk-specific guidance
+    expect(kakao).not.toContain('<@999> hello')
+    expect(kakao).toContain('KakaoTalk has no in-band mention syntax')
+
+    // when: Telegram session with the same participant set
+    const telegram = renderSessionOrigin(
+      { kind: 'channel', adapter: 'telegram-bot', workspace: '-100', chat: '-100', thread: null, participants },
+      now,
+    )
+
+    // then: the model is told NOT to emit `<@999> hello` and is given Telegram-specific guidance
+    expect(telegram).not.toContain('<@999> hello')
+    expect(telegram).toContain('@username')
+  })
 })

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -52,6 +52,40 @@ export type SessionOrigin =
 export const PARTICIPANTS_TOP_K = 10
 export const PARTICIPANTS_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 
+// Each adapter renders mentions differently and the model has to copy the
+// exact shape to actually notify a peer. Until this table existed, the
+// channel origin block hardcoded Discord syntax (`<@USER_ID>`) for every
+// non-Slack adapter, which silently misled KakaoTalk and Telegram sessions
+// into emitting addressing tokens that the platform doesn't recognise. The
+// participants block kept rendering `<@authorId> (name)` lines for the
+// same reason — see `renderParticipants`.
+//
+// `mentionMode` semantics:
+//   - 'angle-id'     — Slack/Discord: `<@USER_ID>` where USER_ID is the
+//                      raw `authorId` we already surface in participants.
+//   - 'at-username'  — Telegram: `@username` plain text. The numeric
+//                      `authorId` is NOT what gets mentioned; usernames are
+//                      a separate field that not every user has.
+//   - 'alias'        — KakaoTalk: type the bot's alias as plain text. The
+//                      adapter's classifier (`kakaotalk-classify.ts`) does
+//                      a substring match against configured aliases; there
+//                      is no in-band syntax to copy.
+type PlatformInfo = {
+  displayName: string
+  mentionMode: 'angle-id' | 'at-username' | 'alias'
+}
+
+const PLATFORM_INFO: Record<AdapterId, PlatformInfo> = {
+  'slack-bot': { displayName: 'Slack', mentionMode: 'angle-id' },
+  'discord-bot': { displayName: 'Discord', mentionMode: 'angle-id' },
+  'telegram-bot': { displayName: 'Telegram', mentionMode: 'at-username' },
+  kakaotalk: { displayName: 'KakaoTalk', mentionMode: 'alias' },
+}
+
+function getPlatformInfo(adapter: AdapterId): PlatformInfo {
+  return PLATFORM_INFO[adapter]
+}
+
 // Compact description of the role the runtime resolved for this session at
 // creation time. Rendered as a single block under the origin text for
 // non-TUI sessions so the agent knows what it can and cannot do without
@@ -171,11 +205,11 @@ function renderChannelOrigin(
   // only `text` and pulls addressing from this origin. We point the model at
   // it as the default, and keep channel_send as the escape hatch for posting
   // elsewhere (different chat, breaking out of the thread on purpose, etc.).
-  const platform = origin.adapter === 'slack-bot' ? 'Slack' : 'Discord'
+  const platformInfo = getPlatformInfo(origin.adapter)
   const lines: string[] = [
     '## Session origin',
     '',
-    `You are responding inside a ${platform} channel session. There is no human`,
+    `You are responding inside a ${platformInfo.displayName} channel session. There is no human`,
     'attached to a console here — your only way to communicate with the user',
     'is a tool call. Plain-text output is invisible.',
   ]
@@ -210,8 +244,7 @@ function renderChannelOrigin(
     "matching the channel's `allow` rules are accepted (the tool returns",
     '`{ ok: false }` otherwise).',
     '',
-    `To mention someone in your reply, use ${platform} syntax \`<@USER_ID>\`.`,
-    ...renderMentionExample(origin.participants ?? [], platform, now),
+    ...renderMentionGuidance(platformInfo, origin.participants ?? [], now),
   )
 
   const participantsBlock = renderParticipants(origin.participants ?? [], now)
@@ -242,23 +275,11 @@ function renderMembershipSummary(
   return `This channel has approximately ${total} members (about ${membership.humans} humans, ${membership.bots} bots — the bot count is approximate, the full member list was not enumerated because it exceeds the 50-member cap).${caveat} The 10 most recent speakers are listed below.`
 }
 
-function renderMentionExample(
+function renderMentionGuidance(
+  platformInfo: PlatformInfo,
   participants: readonly ChannelParticipant[],
-  platform: 'Discord' | 'Slack',
   now: number,
 ): string[] {
-  // Concrete worked example anchored on a REAL participant when possible.
-  // Models reliably copy concrete examples; abstract `<@USER_ID>` placeholders
-  // get treated as generic instructions and ignored. Prefer a peer bot for
-  // the example because that's the addressing case where plain-text names
-  // silently fail (the human path is forgiving — humans see their name and
-  // respond regardless of mention syntax). Fall back to any non-self
-  // participant, then to a generic placeholder if the channel is brand new.
-  //
-  // Apply the SAME staleness cutoff as `renderParticipants` so we never name
-  // someone in the example who isn't shown in the participants block — that
-  // would surface a "ghost" name from >7d ago and confuse the model about
-  // who is actually around.
   const cutoff = now - PARTICIPANTS_MAX_AGE_MS
   const fresh = [...participants]
     .filter((p) => p.lastMessageAt >= cutoff)
@@ -267,11 +288,32 @@ function renderMentionExample(
   const anyPeer = peerBot ?? fresh[0]
   const exampleId = anyPeer?.authorId ?? '123456789'
   const exampleName = anyPeer?.authorName ?? 'PeerBot'
-  return [
-    `For example, to address ${exampleName} in this conversation, write \`<@${exampleId}> hello\` —`,
-    `**not** "${exampleName} hello". Plain-text names do not notify the recipient on ${platform},`,
-    'and other bots in this channel will not see the message as addressed to them.',
-  ]
+
+  switch (platformInfo.mentionMode) {
+    case 'angle-id':
+      return [
+        `To mention someone in your reply, use ${platformInfo.displayName} syntax \`<@USER_ID>\`.`,
+        `For example, to address ${exampleName} in this conversation, write \`<@${exampleId}> hello\` —`,
+        `**not** "${exampleName} hello". Plain-text names do not notify the recipient on ${platformInfo.displayName},`,
+        'and other bots in this channel will not see the message as addressed to them.',
+      ]
+    case 'at-username':
+      return [
+        `To mention someone in your reply, use Telegram syntax \`@username\` in plain text.`,
+        `Telegram usernames are a SEPARATE field from \`authorId\`. The \`<@id>\` tokens you see in the participants`,
+        'block below are a typeclaw convention for parsing inbound mentions — do not echo them back as outbound mentions.',
+        'If you only know an author by their display name and they have no `@username`, address them by display name',
+        'and they will see the message via the reply context.',
+      ]
+    case 'alias':
+      return [
+        'KakaoTalk has no in-band mention syntax. To address someone, just type their display name as plain text;',
+        "the participants block below shows display names. To get the BOT's attention from outside this session,",
+        "a user types one of the bot's configured aliases — they do not need to copy any token from the participants list.",
+        `The \`<@id>\` tokens in the participants block below are a typeclaw convention for parsing inbound mentions —`,
+        'do not echo them back as outbound mentions; KakaoTalk would render them as literal text.',
+      ]
+  }
 }
 
 function renderConversationLine(origin: {


### PR DESCRIPTION
## Problem

`session-origin.ts` hardcoded `platform = adapter === 'slack-bot' ? 'Slack' : 'Discord'`, so any non-Slack adapter — KakaoTalk, Telegram, Discord — resolved through the else-branch. KakaoTalk and Telegram sessions were told they were running on Discord and instructed to use Discord's `<@USER_ID>` mention syntax.

Two concrete failure modes:

- **KakaoTalk**: has no in-band mention syntax. The adapter classifier in `src/channels/adapters/kakaotalk-classify.ts` does substring matching against configured aliases — not `<@id>` tokens. The model was told to produce a syntax that the classifier never sees and that KakaoTalk cannot render.
- **Telegram**: uses `@username` plain text. The numeric `authorId` the model was handed is not the username; `<@authorId>` would be a meaningless string to a real Telegram client.

Beyond the wrong syntax, the Discord-specific instructions add ~30 lines of irrelevant guidance to every KakaoTalk and Telegram session system prompt, bloating input tokens on every turn.

## Fix

Replace the binary `Slack`/`Discord` choice with a per-adapter `PlatformInfo` table keyed on all four `AdapterId` values:

```ts
const PLATFORM_INFO: Record<AdapterId, PlatformInfo> = {
  'slack-bot':    { displayName: 'Slack',    mentionMode: 'angle-id'    },
  'discord-bot':  { displayName: 'Discord',  mentionMode: 'angle-id'    },
  'telegram-bot': { displayName: 'Telegram', mentionMode: 'at-username' },
  'kakaotalk':    { displayName: 'KakaoTalk', mentionMode: 'alias'      },
};
```

`renderMentionExample(participants, platform, now)` becomes `renderMentionGuidance(platformInfo, participants, now)` with a switch over `mentionMode`:

- `angle-id` → existing `<@authorId>` prose (Discord, Slack unchanged)
- `at-username` → `@username` prose with an explicit note that the numeric id in the participants block is NOT the mention handle
- `alias` → prose pointing to configured aliases; explicitly instructs the model not to emit `<@...>` tokens

`renderChannelOrigin` reads `platformInfo.displayName` for the header line instead of the binary ternary.

The participants block format (`<@authorId> (name)`) is **intentionally unchanged** — it is a typeclaw-internal convention for inbound mention parsing (see comment at `session-origin.ts:302-310`). The new guidance prose explicitly tells the model not to echo those tokens on `at-username`/`alias` platforms.

## Files changed

**`src/agent/session-origin.ts`** (+65/−23)
- `PlatformInfo` type and `PLATFORM_INFO` table
- `renderMentionGuidance` replacing `renderMentionExample`
- `renderChannelOrigin` reads `platformInfo.displayName`

**`src/agent/session-origin.test.ts`** (+97/+0, 5 new tests, 39 total)
- Platform name assertion for all four adapters
- Mention syntax assertions: `angle-id` present for Discord/Slack, absent for KakaoTalk/Telegram; `at-username` present for Telegram; alias guidance present for KakaoTalk

## Test plan

All four pre-commit checks pass as of commit `98670d4`:

```
bun run typecheck     # clean
bun run lint          # 8 warnings (all pre-existing in src/permissions/, untouched), 0 errors
bun run format:check  # clean
bun test              # 3212 pass, 0 fail
```

## Context

This is one of two PRs addressing system-prompt bloat findings from a recent token-usage audit. The other PR will cover the security plugin's prompt-injection defense regex and its hit-rate characteristics under normal channel traffic.

The in-memory poisoning case — sessions that accumulate oversized tool-result blobs mid-run and persist them across restarts — is tracked separately as an issue.