### PR TITLE
Persist plugin subagent sessions so typeclaw usage can see their token cost

### DIFF
--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -165,11 +165,12 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
           sessionId,
           parentTranscriptPath: getTranscriptPath?.(),
           idleMs: 0,
+          ...(origin !== undefined ? { origin } : {}),
         })
       }
     } finally {
       if (hooks && sessionId !== undefined) {
-        await hooks.runSessionEnd({ sessionId })
+        await hooks.runSessionEnd({ sessionId, ...(origin !== undefined ? { origin } : {}) })
       }
       session.dispose()
       await dispose()

--- a/src/bundled-plugins/backup/runner.test.ts
+++ b/src/bundled-plugins/backup/runner.test.ts
@@ -94,6 +94,77 @@ describe('runBackup', () => {
     expect(addF?.args).toEqual(['add', '-f', '--', 'sessions/a.jsonl'])
   })
 
+  test('re-stages sessions/ paths that appeared during pickCommitMessage', async () => {
+    // given: pickCommitMessage simulates spawning a `backup-message` subagent
+    // that writes a NEW session JSONL into sessions/ after the initial status.
+    // The runner must capture that file with a second force-add pass; otherwise
+    // it sits dirty until the next backup cycle and creates a steady-state of
+    // one-cycle-behind orphan commits.
+    const cwd = await makeRepo()
+    await mkdir(join(cwd, 'sessions'))
+    await writeFile(join(cwd, 'sessions', 'pre.jsonl'), '{}')
+
+    const firstStatus = '?? sessions/pre.jsonl\n M src/foo.ts\n'
+    const secondStatus = '?? sessions/pre.jsonl\n?? sessions/late.jsonl\n M src/foo.ts\n'
+    let statusCalls = 0
+    let messagePicked = false
+
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') {
+        statusCalls += 1
+        return okResult(statusCalls === 1 ? firstStatus : secondStatus)
+      }
+      if (args[0] === 'add' && args[1] === '--') return okResult()
+      if (args[0] === 'add' && args[1] === '-f') return okResult()
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[2] === '--stat') return okResult('foo.ts | 1 +')
+      if (args[0] === 'commit') return okResult()
+      if (args[0] === 'rev-parse') return failResult('no upstream', 128)
+      return okResult()
+    })
+
+    const deps: BackupRunnerDeps = {
+      gitSpawn: spawn,
+      pickCommitMessage: async () => {
+        // when: simulate the late file appearing during message synthesis
+        await writeFile(join(cwd, 'sessions', 'late.jsonl'), '{}')
+        messagePicked = true
+        return 'chore: backup'
+      },
+    }
+
+    // when
+    const result = await runBackup({ cwd, pushToOrigin: true }, deps)
+
+    // then: backup completes, AND the late sessions/ file was force-added
+    expect(messagePicked).toBe(true)
+    expect(result).toEqual({ ok: true, kind: 'committed' })
+
+    const addFCalls = calls.filter((c) => c.args[0] === 'add' && c.args[1] === '-f')
+    expect(addFCalls).toHaveLength(2)
+    // first add-f stages the pre-existing file (from the initial status)
+    expect(addFCalls[0]?.args).toEqual(['add', '-f', '--', 'sessions/pre.jsonl'])
+    // second add-f (post-message) captures BOTH the pre-existing file and the
+    // late one. We don't care about ordering, only that both paths are present.
+    const lateAddPaths = addFCalls[1]?.args.slice(3) ?? []
+    expect(lateAddPaths).toContain('sessions/late.jsonl')
+    expect(lateAddPaths).toContain('sessions/pre.jsonl')
+
+    // and: there are exactly TWO status calls — one before staging, one after
+    // pickCommitMessage returns. Asserting the count keeps a future "optimize"
+    // pass from collapsing them back into one and reintroducing the bug.
+    expect(statusCalls).toBe(2)
+
+    // and: the second status happened AFTER pickCommitMessage returned.
+    // The relative ordering of git calls captures the load-bearing sequence.
+    const statusIndices = calls.flatMap((c, i) => (c.args[0] === 'status' ? [i] : []))
+    const addFIndices = calls.flatMap((c, i) => (c.args[0] === 'add' && c.args[1] === '-f' ? [i] : []))
+    const commitIdx = calls.findIndex((c) => c.args[0] === 'commit')
+    expect(statusIndices[1]).toBeGreaterThan(addFIndices[0]!)
+    expect(addFIndices[1]).toBeGreaterThan(statusIndices[1]!)
+    expect(commitIdx).toBeGreaterThan(addFIndices[1]!)
+  })
+
   test('skips push when there is no upstream', async () => {
     const cwd = await makeRepo()
     const { spawn, calls } = makeSpawn((args) => {

--- a/src/bundled-plugins/backup/runner.ts
+++ b/src/bundled-plugins/backup/runner.ts
@@ -84,6 +84,28 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
     diffstat: diffstat.stdout.slice(0, 4096),
   })
 
+  // `pickCommitMessage` may spawn a subagent (the backup plugin's
+  // `backup-message`) whose session JSONL lands under `sessions/` after we
+  // already staged. Without this second pass that file would sit dirty in
+  // the worktree until the NEXT backup cycle, which would then commit it
+  // and create another orphan via the same path — a steady-state of
+  // one-cycle-behind churn. Re-status, filter to `sessions/` additions
+  // only (don't accidentally stage user work that arrived during the
+  // window), and force-add anything new.
+  const reStatus = await deps.gitSpawn(['status', '--porcelain=v1', '--untracked-files=all'], {
+    cwd,
+    timeoutMs: COMMIT_TIMEOUT_MS,
+  })
+  if (reStatus.exitCode === 0) {
+    const lateForce = filterForceAdd(parsePorcelain(reStatus.stdout)).filter((p) => existsSync(join(cwd, p)))
+    if (lateForce.length > 0) {
+      const lateAdd = await deps.gitSpawn(['add', '-f', '--', ...lateForce], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+      if (lateAdd.exitCode !== 0) {
+        return { ok: false, kind: 'commit-failed', reason: `git add -f (post-message) failed: ${shortErr(lateAdd)}` }
+      }
+    }
+  }
+
   const safeMessage = sanitizeCommitMessage(message)
   const commit = await deps.gitSpawn(['commit', '-m', safeMessage], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
   if (commit.exitCode !== 0)

--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -232,6 +232,26 @@ describe('session.idle hook (debouncer)', () => {
 
     expect(spawned).toHaveLength(0)
   })
+
+  test('does NOT spawn for subagent-origin idle events (prevents memory-logger self-recursion)', async () => {
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 1000 })
+    const origin: SessionIdleEvent['origin'] = {
+      kind: 'subagent',
+      subagent: 'memory-logger',
+      parentSessionId: 'ses_parent',
+    }
+    const event: SessionIdleEvent = {
+      sessionId: 'ses_subagent',
+      parentTranscriptPath: '/tmp/subagent-transcript.jsonl',
+      idleMs: 0,
+      origin,
+    }
+    await exports.hooks!['session.idle']!(event, { agentDir, pluginName: 'memory', logger: createPluginLogger('m') })
+
+    await new Promise((r) => setTimeout(r, 1200))
+
+    expect(spawned).toHaveLength(0)
+  })
 })
 
 describe('session.end hook', () => {
@@ -253,6 +273,21 @@ describe('session.end hook', () => {
       pluginName: 'memory',
       logger: createPluginLogger('m'),
     })
+    expect(spawned).toHaveLength(0)
+  })
+
+  test('does NOT spawn for subagent-origin end events (prevents memory-logger self-recursion)', async () => {
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 10_000 })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+
+    await exports.hooks!['session.end']!(
+      {
+        sessionId: 'ses_subagent',
+        origin: { kind: 'subagent', subagent: 'memory-logger', parentSessionId: 'ses_parent' },
+      } as SessionEndEvent,
+      ctx,
+    )
+
     expect(spawned).toHaveLength(0)
   })
 

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -193,6 +193,7 @@ export default definePlugin({
         // grown by `bufferBytes` since the last run, so busy channel sessions
         // (which rarely go idle) still produce memory updates.
         'session.idle': async (event) => {
+          if (event.origin?.kind === 'subagent') return
           lastIdleEvent.set(event.sessionId, {
             parentTranscriptPath: event.parentTranscriptPath,
             ...(event.origin !== undefined ? { origin: event.origin } : {}),
@@ -214,6 +215,7 @@ export default definePlugin({
           }
         },
         'session.end': async (event) => {
+          if (event.origin?.kind === 'subagent') return
           cancelTimer(event.sessionId)
           await fireMemoryLogger(event.sessionId, 'session-end')
           lastIdleEvent.delete(event.sessionId)

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -147,11 +147,15 @@ async function runPrompt(
         sessionId: session.sessionId,
         parentTranscriptPath: session.getTranscriptPath?.(),
         idleMs: 0,
+        ...(session.origin !== undefined ? { origin: session.origin } : {}),
       })
     }
   } finally {
     if (session.hooks && session.sessionId !== undefined) {
-      await session.hooks.runSessionEnd({ sessionId: session.sessionId })
+      await session.hooks.runSessionEnd({
+        sessionId: session.sessionId,
+        ...(session.origin !== undefined ? { origin: session.origin } : {}),
+      })
     }
     session.dispose?.()
   }

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -89,6 +89,7 @@ export type SessionStartEvent = {
 
 export type SessionEndEvent = {
   sessionId: string
+  origin?: SessionOrigin
 }
 
 export type SessionIdleEvent = {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -158,7 +158,8 @@ export async function startAgent({
     const snap = pluginRuntime.get()
     const entry = snap.pluginSubagentByShim.get(subagent)
     if (entry) {
-      const sessionId = `subagent-${entry.pluginName}-${crypto.randomUUID()}`
+      const sessionManager = SessionManager.create(cwd, sessionFactory.sessionDir())
+      const sessionId = sessionManager.getSessionId()
       const origin: SessionOrigin = {
         kind: 'subagent' as const,
         subagent: subagentOptions?.name ?? entry.subagentName,
@@ -168,6 +169,7 @@ export async function startAgent({
       }
       const created = await createSessionWithDispose({
         systemPromptOverride: entry.pluginSubagent.systemPrompt,
+        sessionManager,
         channelRouter: channelManager.router,
         origin,
         permissions: pluginsLoaded.permissions,
@@ -190,6 +192,7 @@ export async function startAgent({
         sessionId,
         agentDir: cwd,
         origin,
+        getTranscriptPath: () => sessionManager.getSessionFile(),
       }
     }
     return defaultCreateSessionForSubagent(subagent, subagentOptions)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -299,7 +299,7 @@ export function createServer({
           state?.unsubPrompts?.()
           try {
             if (state && state.runtimeSnapshot !== null) {
-              await state.runtimeSnapshot.hooks.runSessionEnd({ sessionId: state.sessionFileId })
+              await state.runtimeSnapshot.hooks.runSessionEnd({ sessionId: state.sessionFileId, origin: state.origin })
             }
           } finally {
             if (state) {


### PR DESCRIPTION
## Problem

Plugin subagent sessions — memory-logger, dreaming, backup, backup-message, backup-diagnose, and every plugin-contributed subagent wired in `src/run/index.ts:169-186` — ran on `SessionManager.inMemory()` via the fallback in `src/agent/index.ts:168`. Their LLM calls were billed by Fireworks normally, but their transcripts existed only in process memory and produced zero `sessions/*.jsonl` rows, leaving `typeclaw usage` blind to the cost.

The concrete failure mode that motivated this fix: a 16-minute run on 2026-05-15 across two agent folders consumed ~13M billable tokens on `key_WjV15V46` (per the Fireworks dashboard) while `typeclaw usage` reported only ~2.8M total across both folders for the entire day. File mtimes during the window show three subagents ran — servant memory-logger at 15:25:25, kakao memory-logger at 15:31:35, kakao dreaming at 15:31:36 — each leaving zero JSONL on disk.

### What this does NOT explain

The token math (3 subagent runs × ~7 round trips × ~75K tokens ≈ 1.6M) does NOT fully account for the 13M-token Fireworks spike that motivated this work. In-memory subagents are A significant source of invisible LLM spend, not THE source. Once this lands and on-disk subagent JSONLs accumulate over a real agent run, we'll have the data to do a proper reconciliation. The PR's value is observability — making the missing billing measurable — not closing the spike investigation.

Refs #185.

## Fix

Four commits in dependency order — each is a precondition for the next.

**`44ffd95` — Plumb session origin into `runSessionEnd` and `runSessionIdle` hook events**

`SessionEndEvent` previously carried only `sessionId`, forcing hook consumers to make routing decisions without knowing whether the closing session was a TUI session, a channel turn, a cron job, or a short-lived subagent. `SessionIdleEvent` already carried an optional `origin` for this reason; `SessionEndEvent` now matches. The four call sites that fire the hooks are updated: `src/server/index.ts` (TUI close, reads `state.origin`), `src/cron/consumer.ts` (cron runner, reads `session.origin`), `src/agent/subagents.ts` (subagent runner, reads origin from normalize), and the channel router (already threads origin and is unchanged). This is a precondition for the memory-plugin guard in the next commit.

**`7377891` — Skip subagent-origin events in the memory plugin's idle/end hooks**

This commit is the load-bearing safety valve. Once plugin subagents persist to disk (next commit), they fire `session.idle` and `session.end` like any other session — which would feed back into the memory plugin's hooks and cause a memory-logger to spawn for the subagent it just finished writing. The per-`agentDir` `inFlight` key serializes the spawns but does not stop them; each new subagent transcript would trigger another memory-logger spawn indefinitely. The fix is an early-return on `event.origin?.kind === 'subagent'` in both hooks — one line each. The backup plugin already uses the equivalent guard (`isSelfInducedTurn`) on its turn-based hooks; this brings the memory plugin in line for the session-lifecycle hooks. Two new tests assert the guard: `session.idle` with a subagent origin does not spawn memory-logger; `session.end` with a subagent origin does not spawn memory-logger.

Without this commit, the persistence change in the next commit would introduce unbounded self-recursive memory-logger spawns. The commits must ship together.

**`4824431` — Persist plugin subagent sessions to disk so typeclaw usage can see them**

Changes `SessionManager.inMemory()` to the persistent session manager in the plugin subagent wiring in `src/run/index.ts`. The one-line change (plus a small supporting import) is intentionally small; all the complexity is in the two preceding commits. All five bundled plugin subagents — `memory-logger`, `dreaming`, `backup`, `backup-message`, and `backup-diagnose` — go through the same `pluginSubagentByShim` entry-found branch and are all persisted by this change.

**`f30fb0a` — Re-stage `sessions/` after `pickCommitMessage` to capture `backup-message` orphan**

Persisting `backup-message`'s subagent session means it writes a fresh `sessions/<ts>_<uuid>.jsonl` between the backup runner's initial `git status` + `git add -f sessions/...` pass and the final `git commit`. Without a re-stage step, that file sits dirty in the worktree and gets committed by the NEXT backup cycle — which then creates ANOTHER orphan via the same path — a permanent steady-state of one-cycle-behind churn in git history.

The fix inserts a second `git status` + filtered force-add between `pickCommitMessage()` and `git commit`. The filter is scoped to `FORCE_ADD_PREFIXES` (currently just `sessions/`) so user work landing during the window is not silently captured. Includes a regression test in `src/bundled-plugins/backup/runner.test.ts` that fakes a `pickCommitMessage` writing a new sessions file and asserts the file lands in the commit AND that the second `status`+`add-f` happens AFTER `pickCommitMessage` and BEFORE `commit` (ordering assertion prevents future "optimize the duplicate status" refactors from reintroducing the bug).

## Known tradeoffs

As the third commit message documents: `sessions/` will get busier once subagent sessions persist — the backup plugin will commit their JSONL files on the same schedule as human-turn sessions. `defaultCreateSessionForSubagent` (the non-plugin path in `src/agent/index.ts`) is intentionally left as `inMemory()` for now; that path is for ad-hoc subagent calls, not the plugin-scheduled ones that drove the billing discrepancy.

Issue #185 tracks the design pass for partitioning subagent JSONLs (subdirectory vs filename prefix) and the test-extraction work needed once the layout decision is made.

## Test plan

All four pre-commit checks pass as of commit `f30fb0a`:

```
bun run typecheck     # clean
bun run lint          # 8 pre-existing warnings (src/permissions/, untouched), 0 errors
bun run format:check  # clean
bun test              # 3230 pass, 0 fail (3227 baseline + 2 new memory plugin tests asserting the self-recursion guard + 1 new backup runner regression test)
```

## Stats

9 files changed, +143/-4.

- `src/plugin/types.ts` — `SessionEndEvent` gains optional `origin`
- `src/agent/subagents.ts` — pass origin to `runSessionEnd`
- `src/server/index.ts` — pass origin to `runSessionEnd`
- `src/cron/consumer.ts` — pass origin to `runSessionEnd`
- `src/bundled-plugins/memory/index.ts` — subagent-origin guard on idle/end hooks
- `src/bundled-plugins/memory/index.test.ts` — 2 new guard tests
- `src/run/index.ts` — flip plugin subagent sessions from `inMemory()` to persistent
- `src/bundled-plugins/backup/runner.ts` — re-stage `sessions/` after `pickCommitMessage`
- `src/bundled-plugins/backup/runner.test.ts` — 1 new regression test for the re-stage ordering

Once this lands, restart any active agent. The next `typeclaw usage` on each agent folder will start showing subagent rows; that data is what Issue #185's directory-layout decision needs.