### PR TITLE
Drop the agent-folder.required-dirs doctor check

### DIFF
--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -23,8 +23,6 @@ import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 
 import type { DoctorCheck } from './types'
 
-const REQUIRED_DIRS = ['workspace', 'sessions', '.agents/skills', 'mounts', 'packages'] as const
-
 export function buildStaticChecks(opts: { dockerExec?: DockerExec } = {}): DoctorCheck[] {
   const dockerExec = opts.dockerExec ?? defaultDockerExec
 
@@ -32,7 +30,6 @@ export function buildStaticChecks(opts: { dockerExec?: DockerExec } = {}): Docto
     dockerDaemon(dockerExec),
     bunRuntime(),
     agentFolderInitialized(),
-    agentFolderRequiredDirs(),
     agentFolderDockerfileTemplate(),
     agentFolderGitignoreTemplate(),
     agentFolderNodeModules(),
@@ -98,36 +95,6 @@ function agentFolderInitialized(): DoctorCheck {
         message: 'no typeclaw.json found in or above current directory',
         details: ['Host-stage checks unrelated to the agent folder still ran.'],
         fix: { description: 'Run `typeclaw init` in the directory you want to use as an agent folder.' },
-      }
-    },
-  }
-}
-
-function agentFolderRequiredDirs(): DoctorCheck {
-  return {
-    name: 'agent-folder.required-dirs',
-    category: 'agent-folder',
-    description: 'required agent directories exist',
-    applies: (ctx) => ctx.hasAgentFolder,
-    async run(ctx) {
-      const missing = REQUIRED_DIRS.filter((d) => !existsSync(join(ctx.cwd, d)))
-      if (missing.length === 0) return { status: 'ok', message: 'all required directories present' }
-      return {
-        status: 'warning',
-        message: `${missing.length} required ${missing.length === 1 ? 'directory' : 'directories'} missing`,
-        details: missing.map((d) => `missing: ${d}/`),
-        fix: {
-          description: `Create the missing directories (${missing.map((d) => `${d}/`).join(', ')}).`,
-          autoFix: async () => {
-            for (const d of missing) {
-              mkdirSync(join(ctx.cwd, d), { recursive: true })
-            }
-            return {
-              summary: `created ${missing.map((d) => `${d}/`).join(', ')}`,
-              changedPaths: missing.map((d) => `${d}/`),
-            }
-          },
-        },
       }
     },
   }

--- a/src/doctor/index.test.ts
+++ b/src/doctor/index.test.ts
@@ -265,7 +265,13 @@ describe('runDoctor', () => {
 test('buildCommitMessage formats subject + bullets', async () => {
   const { buildCommitMessage } = await import('./commit')
   const msg = buildCommitMessage([
-    { name: 'agent-folder.required-dirs', source: 'static', ok: true, summary: 'created workspace/', changedPaths: [] },
+    {
+      name: 'agent-folder.dockerfile-managed',
+      source: 'static',
+      ok: true,
+      summary: 'refreshed Dockerfile from template',
+      changedPaths: [],
+    },
     {
       name: 'memory.daily-stream-current',
       source: 'plugin',
@@ -277,7 +283,7 @@ test('buildCommitMessage formats subject + bullets', async () => {
   ])
   const lines = msg.split('\n')
   expect(lines[0]).toBe('typeclaw doctor: auto-fix 2 issues')
-  expect(msg).toContain('- [static] agent-folder.required-dirs: created workspace/')
+  expect(msg).toContain('- [static] agent-folder.dockerfile-managed: refreshed Dockerfile from template')
   expect(msg).toContain('- [plugin] memory.daily-stream-current: created memory/2026-05-12.md')
 })
 


### PR DESCRIPTION
## Problem

`typeclaw doctor` included an `agent-folder.required-dirs` check that warned when any of `workspace/`, `sessions/`, `.agents/skills/`, `mounts/`, or `packages/` were missing from the agent folder, and offered an auto-fix to `mkdir` them.

The check was noise. Every one of these directories is either scaffolded at `typeclaw init` time or re-created on demand by the runtime code that actually uses it:

- `workspace/` — the agent's free-write zone; the agent creates files there ad-hoc.
- `sessions/` — created by the session JSONL writer before the first write.
- `.agents/skills/` — existence-gated in `src/agent/index.ts`'s `additionalSkillPaths`; the loader skips it silently when absent.
- `mounts/` and `packages/` — pure organizational scaffolding with no runtime branch tied to their existence.

The practical effect: an agent that had been running fine for weeks could earn a doctor warning the moment a user cleaned up an empty directory the runtime would just recreate silently anyway. Doctor's job is to surface real breakage.

## Changes

**`src/doctor/checks.ts`** — drops the `REQUIRED_DIRS` constant, the `agentFolderRequiredDirs()` check definition, and its entry in `buildStaticChecks()`. The `existsSync`/`mkdirSync` imports stay — they're still used by other checks.

**`src/doctor/index.test.ts`** — the `buildCommitMessage` test used `agent-folder.required-dirs` as a sample static-check name in its fixture. Swapped to `agent-folder.dockerfile-managed` (a still-existing check) so the test continues to exercise the formatter against a real check name. No production logic change.

## Verification

```
bun run typecheck   # clean
bun run lint        # 0 errors, 8 pre-existing warnings (unrelated, in src/permissions/)
bun run format      # clean
bun test            # 3227 pass / 0 fail across 191 files
```

## Stats

2 files changed, 8 insertions(+), 35 deletions(−).