### PR TITLE
Drop network.blockInternal=true from init scaffold output

### DIFF
--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -713,7 +713,7 @@ describe('scaffold', () => {
     expect(existsSync(join(root, 'memory'))).toBe(false)
   })
 
-  test('writes typeclaw.json with $schema, model, and network.blockInternal=true (security-relevant, kept visible for discoverability)', async () => {
+  test('writes typeclaw.json with only $schema and model (no defaults duplicated)', async () => {
     await scaffold(root)
 
     const raw = await readFile(join(root, 'typeclaw.json'), 'utf8')
@@ -721,17 +721,16 @@ describe('scaffold', () => {
     expect(JSON.parse(raw)).toEqual({
       $schema: './node_modules/typeclaw/typeclaw.schema.json',
       model: 'openai/gpt-5.4-nano',
-      network: { blockInternal: true },
     })
   })
 
-  test('omits fields whose defaults are already provided by configSchema or the bundled plugin (except network, which is security-relevant and discovery-worthy)', async () => {
+  test('omits every field whose default is already provided by configSchema or a bundled plugin', async () => {
     await scaffold(root)
 
     const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as Record<string, unknown>
     expect(cfg.mounts).toBeUndefined()
     expect(cfg.memory).toBeUndefined()
-    expect(cfg.network).toEqual({ blockInternal: true })
+    expect(cfg.network).toBeUndefined()
   })
 
   test('writes cron.json with an empty jobs array and $schema reference', async () => {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -376,18 +376,14 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   // immediately populated, so packages/ is the only one that needs this.
   await writeFile(join(root, PACKAGES_DIR, GITKEEP_FILE), '', { flag: 'wx' }).catch(ignoreExists)
 
-  // Only fields without sensible defaults elsewhere are emitted, with one
-  // exception: `network.blockInternal` is re-emitted at its default value
-  // (`true`) because the field is security-relevant and users need to
-  // discover it in their `typeclaw.json` to know they can opt out for LAN
-  // access. `mounts` defaults to `[]` in configSchema, and the bundled
-  // memory plugin owns its own defaults in src/bundled-plugins/memory/
-  // index.ts — re-emitting either here would be duplicate noise the user
-  // has to maintain in sync with the source of truth.
+  // Only fields without sensible defaults elsewhere are emitted. Everything
+  // with a schema-provided default (e.g. `network.blockInternal`, `mounts`,
+  // `memory.*`) is omitted to keep the scaffold minimal — duplicating defaults
+  // here would mean every schema change has to be mirrored in two places, and
+  // users would feel obligated to maintain values they never set.
   const config: Record<string, unknown> = {
     $schema: './node_modules/typeclaw/typeclaw.schema.json',
     model: options.model ?? DEFAULT_MODEL_REF,
-    network: { blockInternal: true },
   }
   const channels: Record<string, Record<string, never>> = {}
   if (options.withDiscord) channels['discord-bot'] = {}


### PR DESCRIPTION
## Why

`scaffold()` was re-emitting \`network.blockInternal: true\` into every freshly-initialized \`typeclaw.json\`, even though \`configSchema\` already defaults it to \`true\` ([\`src/config/config.ts:200\`](../blob/main/src/config/config.ts#L200)). The justification on the line was "security-relevant, kept visible for discoverability", but:

- We don't duplicate any *other* security-relevant default the same way (egress allow-list, port-forwarding policy, mounts, dockerfile features), so the rule was inconsistent.
- Every agent folder ends up carrying a value the user never set and has to keep in sync with the schema by hand on every bump.
- Discoverability belongs in \`typeclaw.schema.json\` and docs, not in scaffolded literal values.

## What

- Remove the \`network: { blockInternal: true }\` line from \`scaffold()\`.
- Replace the comment that documented the exception with one that documents the *rule*: defaults provided by the schema or a bundled plugin are intentionally omitted.
- Update the two pinning tests (\`writes typeclaw.json with $schema, model, and network.blockInternal=true\` and \`omits fields whose defaults are already provided…\`) to reflect the new scaffold output.

## What's not changing

- The runtime default is unchanged — \`configSchema.network.blockInternal\` still defaults to \`true\`, so existing and newly-scaffolded agents still get the egress filter on by default.
- Channel blocks (e.g. \`channels: { "discord-bot": {} }\`) stay as-is. The \`{}\` is not a default value — it's the documented presence signal that enables an adapter at runtime (\`src/channels/manager.ts:206\` — \`if (adapterCfg !== undefined) await startAdapter(...)\`). Removing the key would silently disable opted-in channels.

## Verification

- \`bun run typecheck\` — clean
- \`bun run lint\` — 8 pre-existing warnings unrelated to this change
- \`bun run format\` — clean
- \`bun test\` — 3227/3227 pass