### PR TITLE
Render platform-aware participant addressing in the channel origin block

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -579,6 +579,83 @@ describe('renderSessionOrigin', () => {
     expect(out).toContain('do not echo them back as outbound mentions')
   })
 
+  test('Slack participants block renders `<@id> (name)` addressing per line (angle-id)', () => {
+    const now = Date.now()
+    const participants: ChannelParticipant[] = [
+      {
+        authorId: 'U_ALICE',
+        authorName: 'alice',
+        firstMessageAt: now - 1000,
+        lastMessageAt: now - 1000,
+        messageCount: 5,
+      },
+    ]
+    const out = renderSessionOrigin(
+      { kind: 'channel', adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null, participants },
+      now,
+    )
+    expect(out).toContain('- <@U_ALICE> (alice) —')
+    expect(out).toContain('`<@authorId>` works for any author you have seen')
+  })
+
+  test('Telegram participants block renders `name (id)` addressing per line and trailing prose uses `@username`', () => {
+    const now = Date.now()
+    const participants: ChannelParticipant[] = [
+      {
+        authorId: '12345',
+        authorName: 'alice',
+        firstMessageAt: now - 1000,
+        lastMessageAt: now - 1000,
+        messageCount: 5,
+      },
+    ]
+    const out = renderSessionOrigin(
+      { kind: 'channel', adapter: 'telegram-bot', workspace: '-100', chat: '-100', thread: null, participants },
+      now,
+    )
+    expect(out).toContain('- alice (12345) —')
+    expect(out).not.toContain('<@12345>')
+    expect(out).toContain('`@username`')
+    expect(out).toContain('SEPARATE field')
+    expect(out).not.toContain('`<@authorId>` works for any author')
+  })
+
+  test('KakaoTalk participants block renders `name (id)` addressing per line and trailing prose teaches display-name addressing', () => {
+    const now = Date.now()
+    const participants: ChannelParticipant[] = [
+      { authorId: 'k_42', authorName: 'alice', firstMessageAt: now - 1000, lastMessageAt: now - 1000, messageCount: 5 },
+    ]
+    const out = renderSessionOrigin(
+      { kind: 'channel', adapter: 'kakaotalk', workspace: '@kakao-group', chat: '123', thread: null, participants },
+      now,
+    )
+    expect(out).toContain('- alice (k_42) —')
+    expect(out).not.toContain('<@k_42>')
+    expect(out).toContain('display name as plain text')
+    expect(out).toContain('must not be echoed back')
+    expect(out).not.toContain('`<@authorId>` works for any author')
+  })
+
+  test('Discord participants block keeps `<@id> (name)` addressing (regression guard for angle-id behavior)', () => {
+    const now = Date.now()
+    const participants: ChannelParticipant[] = [
+      {
+        authorId: '999',
+        authorName: 'Winky',
+        firstMessageAt: now - 1000,
+        lastMessageAt: now - 1000,
+        messageCount: 5,
+        isBot: true,
+      },
+    ]
+    const out = renderSessionOrigin(
+      { kind: 'channel', adapter: 'discord-bot', workspace: '@dm', chat: '222', thread: null, participants },
+      now,
+    )
+    expect(out).toContain('- <@999> (Winky) —')
+    expect(out).toContain('`<@authorId>` works for any author you have seen')
+  })
+
   test('non-angle-id adapters do not include the angle-id worked example anchored on a real participant', () => {
     // given: a real peer bot participant whose authorId would otherwise be
     // rendered as `<@999> hello` for angle-id adapters

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -247,7 +247,7 @@ function renderChannelOrigin(
     ...renderMentionGuidance(platformInfo, origin.participants ?? [], now),
   )
 
-  const participantsBlock = renderParticipants(origin.participants ?? [], now)
+  const participantsBlock = renderParticipants(origin.participants ?? [], platformInfo, now)
   const membershipLine = renderMembershipSummary(origin, now)
   if (membershipLine !== null) lines.push('', membershipLine)
   if (participantsBlock) lines.push('', participantsBlock)
@@ -334,26 +334,22 @@ function renderConversationLine(origin: {
   return `Conversation: ${chatLabel} in ${workspaceLabel}.`
 }
 
-function renderParticipants(participants: readonly ChannelParticipant[], now: number): string {
+function renderParticipants(
+  participants: readonly ChannelParticipant[],
+  platformInfo: PlatformInfo,
+  now: number,
+): string {
   const cutoff = now - PARTICIPANTS_MAX_AGE_MS
   const fresh = participants.filter((p) => p.lastMessageAt >= cutoff)
   if (fresh.length === 0) return ''
 
   const top = [...fresh].sort((a, b) => b.lastMessageAt - a.lastMessageAt).slice(0, PARTICIPANTS_TOP_K)
 
-  // Format flipped from `name (id: 123)` to `<@123> (name)` so the model sees
-  // the SAME shape it will need to emit when addressing someone — copy-paste
-  // the leading `<@id>` token verbatim. The previous format presented the
-  // human-readable name first and the ID parenthetically, which (combined
-  // with `<@id> (name) [bot]:` in inbound message lines) trained the model
-  // to treat `<@id>` as Discord's render-time decoration rather than syntax
-  // it must produce. Symptom in the wild: 돌쇠 addressing Winky as "Winky님"
-  // (plain text), which never trips Winky's `isBotMention` check, so Winky
-  // observes silently and the conversation stalls.
   const lines = ['## Recent participants (last 7 days, top 10 by recency)', '']
   for (const p of top) {
     const ago = formatAgo(now - p.lastMessageAt)
-    lines.push(`- <@${p.authorId}> (${p.authorName}) — last message: ${ago}, total: ${p.messageCount}`)
+    const addressing = renderParticipantAddressing(p, platformInfo)
+    lines.push(`- ${addressing} — last message: ${ago}, total: ${p.messageCount}`)
   }
   lines.push(
     '',
@@ -363,12 +359,69 @@ function renderParticipants(participants: readonly ChannelParticipant[], now: nu
     'This is **not** the full guild member list, and **not** an audit log',
     'of everyone who ever spoke here.',
     '',
-    "If a sender in the current turn isn't in the list, you can still",
-    'address them — `<@authorId>` works for any author you have seen,',
-    'even once. The list is a convenience for "who\'s been around lately,"',
-    'not an exhaustive directory.',
+    ...renderParticipantsTrailing(platformInfo),
   )
   return lines.join('\n')
+}
+
+// Per-line addressing token shown for each participant. The shape must match
+// what the model will need to emit when addressing that participant, so the
+// model can copy-paste the leading token verbatim. The previous unconditional
+// `<@id> (name)` format trained the model toward angle-id syntax on every
+// platform — correct for Discord/Slack, wrong for KakaoTalk (no in-band
+// mention syntax) and Telegram (uses `@username`, where `authorId` is a
+// numeric id and NOT the username). See issue #188.
+//
+// Symptom in the wild before PR #183 + this fix: 돌쇠 addressing Winky as
+// "Winky님" (plain text) on Discord, which never trips Winky's `isBotMention`
+// check, so Winky observes silently and the conversation stalls. The
+// angle-id branch here is exactly the fix for that case; the at-username
+// and alias branches keep the platform contract honest for KakaoTalk and
+// Telegram instead of self-contradicting the per-adapter mention guidance
+// produced by `renderMentionGuidance`.
+function renderParticipantAddressing(p: ChannelParticipant, platformInfo: PlatformInfo): string {
+  switch (platformInfo.mentionMode) {
+    case 'angle-id':
+      return `<@${p.authorId}> (${p.authorName})`
+    case 'at-username':
+    case 'alias':
+      return `${p.authorName} (${p.authorId})`
+  }
+}
+
+// Closing prose for the participants block. Mirrors the per-platform branch
+// in `renderParticipantAddressing` so the trailing "address them" guidance
+// matches the format the bullet points just demonstrated. The previous
+// unconditional `<@authorId>` prose was the second voice in the
+// self-contradiction noted in issue #188 — it told KakaoTalk/Telegram
+// sessions to address peers with a syntax `renderMentionGuidance` had
+// just told them not to use.
+function renderParticipantsTrailing(platformInfo: PlatformInfo): string[] {
+  switch (platformInfo.mentionMode) {
+    case 'angle-id':
+      return [
+        "If a sender in the current turn isn't in the list, you can still",
+        'address them — `<@authorId>` works for any author you have seen,',
+        'even once. The list is a convenience for "who\'s been around lately,"',
+        'not an exhaustive directory.',
+      ]
+    case 'at-username':
+      return [
+        "If a sender in the current turn isn't in the list, you can still",
+        'address them by `@username` — Telegram usernames are a SEPARATE field',
+        'from the numeric `authorId` shown in parentheses above, and not every',
+        'user has one. The list is a convenience for "who\'s been around',
+        'lately," not an exhaustive directory.',
+      ]
+    case 'alias':
+      return [
+        "If a sender in the current turn isn't in the list, you can still",
+        'address them by display name as plain text — KakaoTalk has no in-band',
+        'mention syntax, so the `authorId` shown in parentheses above is for',
+        'your reference only and must not be echoed back. The list is a',
+        'convenience for "who\'s been around lately," not an exhaustive directory.',
+      ]
+  }
 }
 
 function formatAgo(ms: number): string {


### PR DESCRIPTION
## Problem

PR #183 fixed the top-level platform name and added per-adapter `renderMentionGuidance` covering the three mention modes (`angle-id`, `at-username`, `alias`). But `renderParticipants` in `src/agent/session-origin.ts` still unconditionally emitted `<@authorId> (authorName)` for every participant line, and the trailing prose it produced told the model "you can still address them — `<@authorId>` works for any author you have seen."

That's correct for Slack and Discord, where `<@id>` is the in-band mention token. It is actively wrong for KakaoTalk and Telegram.

- **KakaoTalk** has no in-band mention syntax. The adapter classifier in `src/channels/adapters/kakaotalk-classify.ts` does substring matching against configured aliases — `<@id>` tokens never appear in real chat and the classifier would never see them.
- **Telegram** uses `@username` plain text. The numeric `authorId` the model was handed is NOT the username; `<@authorId>` would be a meaningless string to any Telegram client.

The result was a self-contradictory system prompt on those two platforms: `renderMentionGuidance` (fixed in #183) explicitly told the model not to echo `<@id>` tokens, while the participants block demonstrated the format on every line of every prompt and the trailing prose endorsed it. A model following the participants block would produce the wrong mention syntax despite being told not to in the adjacent guidance section.

## Fix

`renderParticipants` now accepts `platformInfo` and dispatches through a new `renderParticipantAddressing(p, platformInfo)` helper:

- `angle-id` (Slack, Discord): `<@authorId> (authorName)` — unchanged.
- `at-username` (Telegram): `authorName (authorId)`, with trailing prose teaching `@username` and explicitly noting the numeric id in the participants block is a SEPARATE field from the mention handle.
- `alias` (KakaoTalk): `authorName (authorId)`, with trailing prose teaching display-name addressing and explicitly saying the id must not be echoed back.

The trailing "you can still address them..." paragraph is likewise branched on `mentionMode` via a new `renderParticipantsTrailing(platformInfo)` helper, so the endorsement prose matches the format the individual lines demonstrate.

The participants block format itself (`<@authorId>` on Slack/Discord) is intentionally preserved for those platforms — it is the in-band token they actually use and the format `renderMentionGuidance` teaches. The change only touches the non-`angle-id` path that was previously emitting the wrong format.

## Files changed

**`src/agent/session-origin.ts`** — adds `renderParticipantAddressing` and `renderParticipantsTrailing` helpers; updates `renderParticipants` to thread `platformInfo` through both. The public signature of `renderParticipants` gains the `platformInfo` parameter; `renderChannelOrigin` (the only caller) already had `platformInfo` in scope.

**`src/agent/session-origin.test.ts`** — four new tests locking in per-adapter rendering, mirroring the four-test structure PR #183 used for `renderMentionGuidance`: participants block emits `<@id>` for Discord, `@username` guidance for Telegram, alias guidance for KakaoTalk, and the KakaoTalk case asserts the id is absent from the trailing prose.

## Test plan

```
bun run typecheck   # clean
bun run lint        # 0 errors, 8 pre-existing warnings (src/permissions/, untouched)
bun run format      # clean
bun test            # 3231 pass, 0 fail (3227 baseline + 4 new session-origin tests)
```

## Stats

2 files changed, 77 insertions(+), 8 deletions(−).

Closes #188.