### PR TITLE
Replace single `model` with `models` profile map and add look_at vision routing

### DIFF
--- a/src/agent/auth.test.ts
+++ b/src/agent/auth.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { __resetConfigForTesting, reloadConfig } from '@/config/config'
 import { parseSecretsFile } from '@/secrets/schema'
 
-import { getAuth, resetAuthForTesting } from './auth'
+import { getAuth, getAuthFor, resetAuthForTesting } from './auth'
 
 describe('getAuth', () => {
   let prevOpenai: string | undefined
@@ -54,7 +54,7 @@ describe('getAuth', () => {
   test('env-wins: FIREWORKS_API_KEY satisfies hasAuth without persisting to secrets.json', async () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),
-      JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' }),
+      JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
     )
     reloadConfig(cwd)
     process.env.FIREWORKS_API_KEY = 'fw_test'
@@ -71,7 +71,7 @@ describe('getAuth', () => {
   })
 
   test('env-wins: ZAI_API_KEY satisfies hasAuth for zai (paygo) without persisting to secrets.json', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'zai/glm-4.6' }))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'zai/glm-4.6' } }))
     reloadConfig(cwd)
     process.env.ZAI_API_KEY = 'zai_test'
 
@@ -86,7 +86,7 @@ describe('getAuth', () => {
   })
 
   test('env-wins: ZAI_CODING_API_KEY satisfies hasAuth for zai-coding (subscription) and does not bleed into zai', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'zai-coding/glm-5.1' }))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'zai-coding/glm-5.1' } }))
     reloadConfig(cwd)
     process.env.ZAI_CODING_API_KEY = 'zai_coding_test'
 
@@ -100,7 +100,7 @@ describe('getAuth', () => {
   })
 
   test('env-wins: OPENAI_API_KEY satisfies hasAuth without persisting to secrets.json', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'openai/gpt-5.4-nano' } }))
     reloadConfig(cwd)
     process.env.OPENAI_API_KEY = 'sk-test'
 
@@ -117,7 +117,7 @@ describe('getAuth', () => {
   test('env wins over file value when both are set', async () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),
-      JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' }),
+      JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
     )
     await writeFile(
       join(cwd, 'secrets.json'),
@@ -138,7 +138,7 @@ describe('getAuth', () => {
   test('file value is used when env var is unset', async () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),
-      JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' }),
+      JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
     )
     await writeFile(
       join(cwd, 'secrets.json'),
@@ -163,7 +163,7 @@ describe('getAuth', () => {
   test('does NOT strip .env after layering env-resolved api-key in-memory', async () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),
-      JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' }),
+      JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
     )
     const original = 'FIREWORKS_API_KEY=fw_from_env\nUNRELATED=keep-me\n'
     await writeFile(join(cwd, '.env'), original)
@@ -176,7 +176,7 @@ describe('getAuth', () => {
   })
 
   test('preserves an existing OAuth credential and ignores the .env key', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'openai/gpt-5.4-nano' } }))
     const oauthCredential = {
       type: 'oauth' as const,
       access_token: 'tok',
@@ -197,7 +197,7 @@ describe('getAuth', () => {
   })
 
   test('does not touch .env when an OAuth credential already owns the provider slot', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'openai/gpt-5.4-nano' } }))
     const oauthCredential = {
       type: 'oauth' as const,
       access_token: 'tok',
@@ -219,7 +219,7 @@ describe('getAuth', () => {
   })
 
   test('falls back to a dummy in-memory storage when the provider env var is missing under NODE_ENV=test', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'openai/gpt-5.4-nano' } }))
     reloadConfig(cwd)
     process.env.NODE_ENV = 'test'
 
@@ -230,7 +230,7 @@ describe('getAuth', () => {
   })
 
   test('caches the auth object across calls', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'openai/gpt-5.4-nano' } }))
     reloadConfig(cwd)
     process.env.OPENAI_API_KEY = 'sk-test'
 
@@ -243,7 +243,7 @@ describe('getAuth', () => {
   test('legacy v1 envelope is read on first boot (transparent upgrade)', async () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),
-      JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' }),
+      JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
     )
     await writeFile(
       join(cwd, 'secrets.json'),
@@ -259,7 +259,7 @@ describe('getAuth', () => {
   })
 
   test('migrates a legacy auth.json to secrets.json on first getAuth()', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'openai/gpt-5.4-nano' }))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'openai/gpt-5.4-nano' } }))
     await writeFile(
       join(cwd, 'auth.json'),
       JSON.stringify({
@@ -287,3 +287,113 @@ async function readSecretsFile(path: string): Promise<{ providers: Record<string
   if (!result.ok) throw new Error(`secrets.json failed to parse: ${result.reason}`)
   return result.file
 }
+
+describe('getAuthFor — per-provider lazy resolution', () => {
+  let prevOpenai: string | undefined
+  let prevFireworks: string | undefined
+  let prevNodeEnv: string | undefined
+  let prevCwd: string
+  let cwd: string
+
+  beforeEach(async () => {
+    prevOpenai = process.env.OPENAI_API_KEY
+    prevFireworks = process.env.FIREWORKS_API_KEY
+    prevNodeEnv = process.env.NODE_ENV
+    delete process.env.OPENAI_API_KEY
+    delete process.env.FIREWORKS_API_KEY
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-authfor-'))
+    prevCwd = process.cwd()
+    process.chdir(cwd)
+    resetAuthForTesting()
+  })
+
+  afterEach(async () => {
+    if (prevOpenai === undefined) delete process.env.OPENAI_API_KEY
+    else process.env.OPENAI_API_KEY = prevOpenai
+    if (prevFireworks === undefined) delete process.env.FIREWORKS_API_KEY
+    else process.env.FIREWORKS_API_KEY = prevFireworks
+    if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+    else process.env.NODE_ENV = prevNodeEnv
+    resetAuthForTesting()
+    __resetConfigForTesting()
+    process.chdir(prevCwd)
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  test('returns the requested provider when called with an explicit providerId', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        models: {
+          default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+          fast: 'openai/gpt-5.4-nano',
+        },
+      }),
+    )
+    reloadConfig(cwd)
+    process.env.FIREWORKS_API_KEY = 'fw_test'
+    process.env.OPENAI_API_KEY = 'sk_test'
+
+    const fireworksAuth = getAuthFor('fireworks')
+    const openaiAuth = getAuthFor('openai')
+
+    expect(fireworksAuth.authStorage.hasAuth('fireworks')).toBe(true)
+    expect(openaiAuth.authStorage.hasAuth('openai')).toBe(true)
+  })
+
+  test('caches per-provider so repeated calls return the same instance', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
+    )
+    reloadConfig(cwd)
+    process.env.FIREWORKS_API_KEY = 'fw_test'
+
+    const a = getAuthFor('fireworks')
+    const b = getAuthFor('fireworks')
+
+    expect(a).toBe(b)
+    expect(a.authStorage).toBe(b.authStorage)
+    expect(a.modelRegistry).toBe(b.modelRegistry)
+  })
+
+  test('different providers get separate Auth instances (independent caches)', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        models: {
+          default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+          fast: 'openai/gpt-5.4-nano',
+        },
+      }),
+    )
+    reloadConfig(cwd)
+    process.env.FIREWORKS_API_KEY = 'fw_test'
+    process.env.OPENAI_API_KEY = 'sk_test'
+
+    const fireworks = getAuthFor('fireworks')
+    const openai = getAuthFor('openai')
+
+    expect(fireworks).not.toBe(openai)
+    expect(fireworks.authStorage).not.toBe(openai.authStorage)
+  })
+
+  test('getAuth() back-compat shim resolves to the default profile provider', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        models: {
+          default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+          fast: 'openai/gpt-5.4-nano',
+        },
+      }),
+    )
+    reloadConfig(cwd)
+    process.env.FIREWORKS_API_KEY = 'fw_test'
+
+    const shimAuth = getAuth()
+    const direct = getAuthFor('fireworks')
+
+    expect(shimAuth).toBe(direct)
+  })
+})

--- a/src/agent/auth.ts
+++ b/src/agent/auth.ts
@@ -23,12 +23,18 @@ function secretsJsonPath(): string {
   return join(process.cwd(), 'secrets.json')
 }
 
-let cached: Auth | null = null
+// Per-provider cache. Sessions that use a profile mapped to provider X share
+// a single AuthStorage + ModelRegistry for that provider; first use of a new
+// provider lazily resolves its credentials. This replaces the singleton
+// `getAuth()` from before multi-model — the singleton couldn't represent
+// "auth for `default` is OpenAI, auth for `vision` is Fireworks" without
+// constructing both at boot.
+const cached = new Map<KnownProviderId, Auth>()
 
-export function getAuth(): Auth {
-  if (cached) return cached
+export function getAuthFor(providerId: KnownProviderId): Auth {
+  const existing = cached.get(providerId)
+  if (existing) return existing
 
-  const providerId = providerForModelRef(getConfig().model)
   const provider = KNOWN_PROVIDERS[providerId]
 
   if (process.env.NODE_ENV === 'test' && !hasAnyCredentialInEnv(provider.apiKeyEnv)) {
@@ -37,8 +43,9 @@ export function getAuth(): Auth {
       authStorage.setRuntimeApiKey(provider.id, TEST_DUMMY_API_KEY)
     }
     const modelRegistry = ModelRegistry.create(authStorage)
-    cached = { authStorage, modelRegistry }
-    return cached
+    const auth = { authStorage, modelRegistry }
+    cached.set(providerId, auth)
+    return auth
   }
 
   const authStorage = createSecretsStoreForAgent(secretsJsonPath())
@@ -53,16 +60,11 @@ export function getAuth(): Auth {
   // is set. OAuth credentials in the file still take precedence on read
   // because AuthStorage's hasAuth checks runtimeOverrides first only for
   // api-key-shaped credentials — OAuth on disk wins on its own.
-  //
-  // The previous code branch that wrote the env value into secrets.json and
-  // stripped the matching `.env` line has been removed. Env values stay in
-  // env; the file stays user-owned. See src/secrets/hydrate.ts for the same
-  // policy on the channels side.
   if (supportsApiKey(provider) && provider.apiKeyEnv) {
     const envKey = process.env[provider.apiKeyEnv]
     if (envKey !== undefined && envKey !== '') {
-      const existing = authStorage.get(provider.id)
-      if (existing === undefined || existing.type === 'api_key') {
+      const existingCred = authStorage.get(provider.id)
+      if (existingCred === undefined || existingCred.type === 'api_key') {
         authStorage.setRuntimeApiKey(provider.id, envKey)
       }
     }
@@ -74,12 +76,20 @@ export function getAuth(): Auth {
   }
 
   const modelRegistry = ModelRegistry.create(authStorage)
-  cached = { authStorage, modelRegistry }
-  return cached
+  const auth = { authStorage, modelRegistry }
+  cached.set(providerId, auth)
+  return auth
+}
+
+// Back-compat shim for callers that still want the `default` profile's auth
+// (the main session path). Equivalent to `getAuthFor(provider-of-default)`.
+export function getAuth(): Auth {
+  const defaultRef = getConfig().models.default
+  return getAuthFor(providerForModelRef(defaultRef))
 }
 
 export function resetAuthForTesting(): void {
-  cached = null
+  cached.clear()
 }
 
 function hasAnyCredentialInEnv(apiKeyEnv: string | null): boolean {
@@ -88,19 +98,32 @@ function hasAnyCredentialInEnv(apiKeyEnv: string | null): boolean {
 
 function missingCredentialMessage(providerId: KnownProviderId): string {
   const provider = KNOWN_PROVIDERS[providerId]
-  const ref = getConfig().model
-  const slash = ref.indexOf('/')
+  const defaultRef = getConfig().models.default
+  const defaultProviderId = providerForModelRef(defaultRef)
+  // For the `default` profile, name the model in the error message (matches
+  // pre-multi-model behavior). For any other profile, the user is mixing
+  // providers across profiles and the error must name the failing provider
+  // without claiming it's tied to the `default` model.
+  const isDefault = defaultProviderId === providerId
+  const ref = isDefault ? defaultRef : null
   const modelName =
-    (provider.models as Record<string, { name: string }>)[ref.slice(slash + 1)]?.name ?? ref.slice(slash + 1)
+    ref !== null
+      ? ((provider.models as Record<string, { name: string }>)[ref.slice(ref.indexOf('/') + 1)]?.name ??
+        ref.slice(ref.indexOf('/') + 1))
+      : null
 
   const oauthOnly = supportsOAuth(provider) && !supportsApiKey(provider)
   const apiKeyOnly = supportsApiKey(provider) && !supportsOAuth(provider)
 
   if (oauthOnly) {
-    return `No credentials for ${provider.name}. Run \`typeclaw init\` and pick "OAuth" to log in to ${modelName}.`
+    return modelName
+      ? `No credentials for ${provider.name}. Run \`typeclaw init\` and pick "OAuth" to log in to ${modelName}.`
+      : `No credentials for ${provider.name} (referenced by a non-default profile). Run \`typeclaw init\` and pick "OAuth" to log in.`
   }
   if (apiKeyOnly && provider.apiKeyEnv) {
-    return `Set ${provider.apiKeyEnv} in .env (or secrets.json#providers.${provider.id}.key.value) to use ${modelName} via ${provider.name}.`
+    return modelName
+      ? `Set ${provider.apiKeyEnv} in .env (or secrets.json#providers.${provider.id}.key.value) to use ${modelName} via ${provider.name}.`
+      : `Set ${provider.apiKeyEnv} in .env (or secrets.json#providers.${provider.id}.key.value) to use ${provider.name} (referenced by a non-default profile).`
   }
   return `No credentials for ${provider.name}. Either set ${provider.apiKeyEnv ?? '<api-key-env>'} in .env or run \`typeclaw init\` and pick "OAuth".`
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -24,6 +24,7 @@ import type { Stream } from '@/stream'
 import { getAuthFor } from './auth'
 import { createCompactionSettingsManager } from './compaction'
 import { renderGitNudge } from './git-nudge'
+import { lookAtTool } from './multimodal'
 import { resolveBuiltinToolRefs, wrapPluginTool, wrapSystemAgentTool, wrapSystemTool } from './plugin-tools'
 import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
@@ -187,6 +188,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
         : [
             websearchTool,
             webfetchTool,
+            lookAtTool,
             ...(options.reloadRegistry ? [createReloadTool({ registry: options.reloadRegistry })] : []),
             ...(options.stream ? [createStreamSnapshotTool({ stream: options.stream })] : []),
             ...buildChannelTools(options.channelRouter, options.origin),

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -6,7 +6,8 @@ import { createAgentSession, DefaultResourceLoader, SessionManager } from '@mari
 import type { AgentSession, ToolDefinition } from '@mariozechner/pi-coding-agent'
 
 import type { ChannelRouter } from '@/channels/router'
-import { getConfig, resolveModel } from '@/config'
+import { getConfig, resolveModel, resolveProfile } from '@/config'
+import { providerForModelRef } from '@/config/providers'
 import type { PermissionService } from '@/permissions'
 import type {
   BuiltinToolRef,
@@ -20,7 +21,7 @@ import { materializeSkills } from '@/plugin'
 import type { ReloadRegistry } from '@/reload'
 import type { Stream } from '@/stream'
 
-import { getAuth } from './auth'
+import { getAuthFor } from './auth'
 import { createCompactionSettingsManager } from './compaction'
 import { renderGitNudge } from './git-nudge'
 import { resolveBuiltinToolRefs, wrapPluginTool, wrapSystemAgentTool, wrapSystemTool } from './plugin-tools'
@@ -110,6 +111,13 @@ export type CreateSessionOptions = {
   // prompt is not regenerated; see `typeclaw-permissions` skill for how the
   // agent should interpret the snapshot on later turns.
   permissions?: PermissionService
+  // Model profile name. Resolved against `config.models` to pick the concrete
+  // model ref this session binds to. Unknown profile names fall back to
+  // `default` with a one-time console warning. Omitted → `default`. Threaded
+  // through from the caller (subagent declarations, future per-spawn tool
+  // overrides) so different sessions on the same agent can run different
+  // models without per-session config edits.
+  profile?: string
 }
 
 export type CreateSessionResult = {
@@ -123,7 +131,11 @@ export async function createSession(options: CreateSessionOptions = {}): Promise
 }
 
 export async function createSessionWithDispose(options: CreateSessionOptions = {}): Promise<CreateSessionResult> {
-  const { authStorage, modelRegistry } = getAuth()
+  const resolved = resolveProfile(getConfig().models, options.profile)
+  if (resolved.fellBackToDefault && options.profile !== undefined && options.profile !== 'default') {
+    warnProfileFallbackOnce(options.profile, resolved.ref)
+  }
+  const { authStorage, modelRegistry } = getAuthFor(providerForModelRef(resolved.ref))
 
   const materializedSkills =
     options.plugins && options.plugins.registry.skills.length > 0
@@ -190,7 +202,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
           ]
   const customTools = [...wrapSystemTools(customSystemTools, options.plugins, getOrigin), ...pluginCustomTools]
 
-  const model = resolveModel(getConfig().model)
+  const model = resolveModel(resolved.ref)
   const { session } = await createAgentSession({
     model,
     sessionManager,
@@ -530,4 +542,26 @@ function resolveRoleContext(
 
 export function getBundledSkillsDir(): string {
   return join(dirname(fileURLToPath(import.meta.url)), '..', 'skills')
+}
+
+// Profile-fallback warning is fired once per (profile, ref) pair per process.
+// Without rate-limiting, every memory-logger spawn (~every idle event) would
+// emit a fresh warning when the user has only `default` configured — tens of
+// warnings per channel session is noise the operator will learn to ignore.
+// The pair includes `ref` so a config reload that changes `default` re-warns.
+const profileFallbackWarned = new Set<string>()
+
+function warnProfileFallbackOnce(profile: string, ref: string): void {
+  const key = `${profile}\x00${ref}`
+  if (profileFallbackWarned.has(key)) return
+  profileFallbackWarned.add(key)
+  console.warn(
+    `[agent] unknown model profile "${profile}"; falling back to "default" (${ref}). Add it under \`models\` in typeclaw.json to remove this warning. (further occurrences suppressed)`,
+  )
+}
+
+// Test-only: clear the rate-limit cache so a test can assert the warning fires
+// once after rate-limit reset.
+export function __resetProfileFallbackWarningsForTesting(): void {
+  profileFallbackWarned.clear()
 }

--- a/src/agent/multimodal/index.ts
+++ b/src/agent/multimodal/index.ts
@@ -1,0 +1,12 @@
+export { lookAtTool } from './look-at'
+export {
+  buildMultimodalLookerSystemPrompt,
+  imageInputSchema,
+  multimodalLookerPayloadSchema,
+  resolveImage,
+  URL_FETCH_MAX_BYTES,
+  URL_FETCH_TIMEOUT_MS,
+  type ImageInput,
+  type MultimodalLookerPayload,
+  type ResolvedImage,
+} from './looker'

--- a/src/agent/multimodal/look-at.test.ts
+++ b/src/agent/multimodal/look-at.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test'
+
+import { lookAtTool } from './look-at'
+
+type ImageParam = { url?: string; path?: string; data?: string; mimeType?: string } | Record<string, never>
+
+async function execute(args: { images: ImageParam[]; prompt?: string }) {
+  // pi-coding-agent's `execute` signature is `(toolCallId, params, signal,
+  // onUpdate, ctx)`; for these validation-path tests the last three are
+  // unused (the tool fails fast in toImageInput before any LLM/IO).
+  // The cast is needed because the JSONSchema-derived Static<TParams> type
+  // differs from our type-level ImageParam shape.
+  return lookAtTool.execute(
+    'test-call-id',
+    args as unknown as Parameters<typeof lookAtTool.execute>[1],
+    undefined,
+    undefined,
+    {} as unknown as Parameters<typeof lookAtTool.execute>[4],
+  )
+}
+
+describe('lookAtTool — image source validation (no LLM call)', () => {
+  // All these tests should fail validation BEFORE attempting to spawn a
+  // multimodal-looker session. They prove the exactly-one-source rule from
+  // the self-review (Bug 3) is enforced regardless of what the model passes.
+
+  test('rejects mixing url and path', async () => {
+    const result = await execute({ images: [{ url: 'https://example.com/x.png', path: '/agent/x.png' }] })
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('exactly one') })
+    expect(result.details).toMatchObject({ error: expect.stringContaining('exactly one') })
+  })
+
+  test('rejects mixing url and data', async () => {
+    const result = await execute({
+      images: [{ url: 'https://example.com/x.png', data: 'aGk=', mimeType: 'image/png' }],
+    })
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('exactly one') })
+  })
+
+  test('rejects mixing path and data+mimeType', async () => {
+    const result = await execute({ images: [{ path: '/agent/x.png', data: 'aGk=', mimeType: 'image/png' }] })
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('exactly one') })
+  })
+
+  test('rejects empty image object', async () => {
+    const result = await execute({ images: [{}] })
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('exactly one') })
+  })
+
+  test('rejects data without mimeType (incomplete base64 spec)', async () => {
+    const result = await execute({ images: [{ data: 'aGk=' }] })
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('base64') })
+  })
+
+  test('rejects mimeType without data (incomplete base64 spec)', async () => {
+    const result = await execute({ images: [{ mimeType: 'image/png' }] })
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('base64') })
+  })
+
+  test('rejects relative file path', async () => {
+    const result = await execute({ images: [{ path: 'relative/x.png' }] })
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('absolute') })
+  })
+
+  test('rejects file with unsupported extension', async () => {
+    const result = await execute({ images: [{ path: '/tmp/x.bmp' }] })
+    expect(result.content[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringMatching(/unsupported|not found/),
+    })
+  })
+
+  test('rejects base64 with non-image mimeType', async () => {
+    const result = await execute({ images: [{ data: 'aGVsbG8=', mimeType: 'text/plain' }] })
+    expect(result.content[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('mimeType must be image/*'),
+    })
+  })
+})

--- a/src/agent/multimodal/look-at.ts
+++ b/src/agent/multimodal/look-at.ts
@@ -1,0 +1,185 @@
+import { Type } from '@mariozechner/pi-ai'
+import type { ImageContent } from '@mariozechner/pi-ai'
+import { defineTool } from '@mariozechner/pi-coding-agent'
+
+import { createSessionWithDispose, type SessionOrigin } from '@/agent'
+
+import { buildMultimodalLookerSystemPrompt, resolveImage, type ImageInput } from './looker'
+
+type ImageParam = { url: string } | { path: string } | { data: string; mimeType: string }
+
+type LookAtArgs = {
+  images: ImageParam[]
+  prompt?: string
+}
+
+type LookAtDetails = {
+  count: number
+  prompt?: string
+  text?: string
+  error?: string
+}
+
+// Routes an image-bearing turn to a vision-capable subagent so the main
+// session never sees the bytes. Saves main-agent context: when `models.default`
+// is text-only, this is the only way to get vision; when `models.default` IS
+// vision-capable, it still buys cheaper main-agent inference because the
+// image payload (which can be many KB after base64) only enters the vision
+// model's context.
+//
+// Output is the subagent's text response. The subagent itself decides whether
+// to answer the user's question (when `prompt` is supplied) or describe the
+// image (when `prompt` is omitted) via its dynamic system prompt.
+export const lookAtTool = defineTool({
+  name: 'look_at',
+  label: 'Look at images',
+  description:
+    'Route image(s) through a vision-capable subagent and get a text result. ' +
+    'Use this when you need to see an image: a screenshot the user shared, a diagram in a doc, a photo, a chart, etc. ' +
+    'Each image is specified by ONE of `url` (https://...), `path` (absolute filesystem path), or `data`+`mimeType` (base64). ' +
+    'The optional `prompt` is a question to ask about the image(s); without it, the subagent returns a faithful description. ' +
+    'The image bytes never enter your context — only the resulting text comes back.',
+  parameters: Type.Object({
+    images: Type.Array(
+      Type.Object({
+        url: Type.Optional(Type.String({ description: 'https:// URL to fetch the image from.' })),
+        path: Type.Optional(Type.String({ description: 'Absolute filesystem path (inside /agent or a mounted dir).' })),
+        data: Type.Optional(Type.String({ description: 'Base64-encoded image bytes (pair with mimeType).' })),
+        mimeType: Type.Optional(Type.String({ description: 'MIME type when using `data` (e.g. "image/png").' })),
+      }),
+      { minItems: 1, description: 'One or more images to look at.' },
+    ),
+    prompt: Type.Optional(
+      Type.String({
+        description:
+          'Optional question to ask about the image(s). When omitted, the subagent returns a faithful description.',
+      }),
+    ),
+  }),
+
+  async execute(_toolCallId, params, signal) {
+    const args = params as LookAtArgs
+    try {
+      const imageInputs = args.images.map(toImageInput)
+      const resolved = await Promise.all(imageInputs.map((i) => resolveImage(i, signal)))
+      const imageContents: ImageContent[] = resolved.map((r) => ({
+        type: 'image' as const,
+        data: r.data,
+        mimeType: r.mimeType,
+      }))
+
+      const systemPrompt = buildMultimodalLookerSystemPrompt(args.prompt)
+      const userText =
+        args.prompt !== undefined && args.prompt.trim() !== ''
+          ? args.prompt.trim()
+          : 'Please describe the attached image(s).'
+
+      const origin: SessionOrigin = {
+        kind: 'subagent',
+        subagent: 'multimodal-looker',
+        parentSessionId: '<look-at-tool>',
+      }
+
+      const { session, dispose } = await createSessionWithDispose({
+        systemPromptOverride: systemPrompt,
+        origin,
+        profile: 'vision',
+        // Both knobs are required to fully disarm the subagent's tool surface:
+        // `customTools: []` blocks typeclaw's system tools (websearch/webfetch/
+        // look_at/restart/...) — without it, the look_at tool would recurse
+        // into itself. `tools: []` blocks pi-coding-agent's defaults
+        // (read/bash/edit/write) — without it, a vision model could be talked
+        // into running shell commands or editing files inside its short-lived
+        // session. The looker should only describe images, not act.
+        tools: [],
+        customTools: [],
+      })
+
+      try {
+        await session.prompt(userText, { images: imageContents })
+        const text = extractLastAssistantText(session.messages)
+        if (text === null) {
+          return errorResult('multimodal-looker returned no text response', {
+            count: resolved.length,
+            prompt: args.prompt,
+          })
+        }
+        return successResult(text, { count: resolved.length, prompt: args.prompt })
+      } finally {
+        session.dispose()
+        await dispose()
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return errorResult(message, { count: args.images.length, prompt: args.prompt })
+    }
+  },
+})
+
+function toImageInput(p: ImageParam): ImageInput {
+  const hasUrl = 'url' in p && p.url !== undefined && p.url !== ''
+  const hasPath = 'path' in p && p.path !== undefined && p.path !== ''
+  const hasData = 'data' in p && p.data !== undefined && p.data !== ''
+  const hasMime = 'mimeType' in p && p.mimeType !== undefined && p.mimeType !== ''
+
+  // `data` and `mimeType` are paired — accept both as one source. `mimeType`
+  // alone with no `data` is rejected as an incomplete base64 spec.
+  const sources: string[] = []
+  if (hasUrl) sources.push('url')
+  if (hasPath) sources.push('path')
+  if (hasData || hasMime) sources.push('data+mimeType')
+
+  if (sources.length === 0) {
+    throw new Error('look_at: each image must specify exactly one of `url`, `path`, or `data`+`mimeType`')
+  }
+  if (sources.length > 1) {
+    throw new Error(
+      `look_at: each image must specify exactly one of \`url\`, \`path\`, or \`data\`+\`mimeType\` (got: ${sources.join(', ')})`,
+    )
+  }
+  if (hasUrl) return { kind: 'url', url: (p as { url: string }).url }
+  if (hasPath) return { kind: 'file', path: (p as { path: string }).path }
+  if (hasData && hasMime) {
+    return { kind: 'base64', data: (p as { data: string }).data, mimeType: (p as { mimeType: string }).mimeType }
+  }
+  throw new Error('look_at: base64 image requires both `data` and `mimeType`')
+}
+
+// Pulls the most recent assistant turn's text content. The subagent's reply
+// shows up here once `session.prompt()` resolves. Tool calls in the assistant
+// message are ignored — multimodal-looker's session has no tools wired in
+// (`tools: []` + `customTools: []` at session creation), so in practice this
+// is pure text plus optional thinking blocks (which we skip).
+function extractLastAssistantText(messages: ReadonlyArray<unknown>): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i] as { role?: unknown; content?: unknown } | undefined
+    if (msg === undefined || msg.role !== 'assistant') continue
+    const content = msg.content
+    if (!Array.isArray(content)) continue
+    const texts: string[] = []
+    for (const part of content) {
+      if (part !== null && typeof part === 'object' && (part as { type?: unknown }).type === 'text') {
+        const t = (part as { text?: unknown }).text
+        if (typeof t === 'string') texts.push(t)
+      }
+    }
+    if (texts.length > 0) return texts.join('\n').trim()
+  }
+  return null
+}
+
+function successResult(text: string, partial: Omit<LookAtDetails, 'text' | 'error'>) {
+  const details: LookAtDetails = { ...partial, text }
+  return {
+    content: [{ type: 'text' as const, text }],
+    details,
+  }
+}
+
+function errorResult(message: string, partial: Omit<LookAtDetails, 'text' | 'error'>) {
+  const details: LookAtDetails = { ...partial, error: message }
+  return {
+    content: [{ type: 'text' as const, text: `look_at failed: ${message}` }],
+    details,
+  }
+}

--- a/src/agent/multimodal/looker.test.ts
+++ b/src/agent/multimodal/looker.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { buildMultimodalLookerSystemPrompt, resolveImage } from './looker'
+
+describe('buildMultimodalLookerSystemPrompt', () => {
+  test('without prompt → describe-the-image instructions', () => {
+    const out = buildMultimodalLookerSystemPrompt(undefined)
+    expect(out).toContain('DESCRIBE the attached image(s)')
+    expect(out).not.toContain('Question:')
+  })
+
+  test('with prompt → focused answer instructions including the question', () => {
+    const out = buildMultimodalLookerSystemPrompt('What error message is shown?')
+    expect(out).toContain('ANSWER the question below')
+    expect(out).toContain('Question: What error message is shown?')
+  })
+
+  test('trims whitespace around the prompt', () => {
+    const out = buildMultimodalLookerSystemPrompt('  what is this?  ')
+    expect(out).toContain('Question: what is this?')
+  })
+
+  test('empty/whitespace prompt falls through to describe-the-image branch', () => {
+    const out = buildMultimodalLookerSystemPrompt('   ')
+    expect(out).toContain('DESCRIBE the attached image(s)')
+    expect(out).not.toContain('Question:')
+  })
+})
+
+describe('resolveImage', () => {
+  test('base64 input passes through verbatim', async () => {
+    const result = await resolveImage({ kind: 'base64', data: 'aGVsbG8=', mimeType: 'image/png' })
+    expect(result).toEqual({ data: 'aGVsbG8=', mimeType: 'image/png' })
+  })
+
+  test('base64 rejects non-image mimeType', async () => {
+    expect(resolveImage({ kind: 'base64', data: 'aGVsbG8=', mimeType: 'text/plain' })).rejects.toThrow(
+      /mimeType must be image/,
+    )
+  })
+
+  test('file input reads bytes and infers MIME from extension', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-looker-'))
+    try {
+      // 8-byte PNG signature header is enough to exercise the read path
+      const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      const path = join(cwd, 'pic.png')
+      await writeFile(path, png)
+
+      const result = await resolveImage({ kind: 'file', path })
+      expect(result.mimeType).toBe('image/png')
+      expect(Buffer.from(result.data, 'base64')).toEqual(png)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('file input infers image/jpeg from .jpg and .jpeg', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-looker-'))
+    try {
+      const bytes = Buffer.from([0xff, 0xd8, 0xff])
+      const jpg = join(cwd, 'a.jpg')
+      const jpeg = join(cwd, 'b.jpeg')
+      await writeFile(jpg, bytes)
+      await writeFile(jpeg, bytes)
+
+      const jpgResult = await resolveImage({ kind: 'file', path: jpg })
+      const jpegResult = await resolveImage({ kind: 'file', path: jpeg })
+      expect(jpgResult.mimeType).toBe('image/jpeg')
+      expect(jpegResult.mimeType).toBe('image/jpeg')
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('file input rejects relative paths', async () => {
+    expect(resolveImage({ kind: 'file', path: 'relative/pic.png' })).rejects.toThrow(/absolute/)
+  })
+
+  test('file input rejects missing files', async () => {
+    expect(resolveImage({ kind: 'file', path: '/nonexistent/path/pic.png' })).rejects.toThrow(/not found/)
+  })
+
+  test('file input rejects unsupported extensions', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-looker-'))
+    try {
+      const path = join(cwd, 'pic.bmp')
+      await writeFile(path, 'x')
+      expect(resolveImage({ kind: 'file', path })).rejects.toThrow(/unsupported image extension/)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/agent/multimodal/looker.ts
+++ b/src/agent/multimodal/looker.ts
@@ -1,0 +1,145 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { extname, isAbsolute } from 'node:path'
+
+import { z } from 'zod'
+
+const SUPPORTED_MIME_TYPES = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+} as const
+
+// Caps on URL-fetched images. The agent chooses URLs autonomously, so a
+// malicious or accidentally-large response could otherwise hang the tool
+// (no timeout) or fill memory (no size cap). 20 MB is well above any
+// reasonable screenshot/photo and well below container memory budgets;
+// 30 s is generous for a single HTTP image fetch over a slow link.
+export const URL_FETCH_TIMEOUT_MS = 30_000
+export const URL_FETCH_MAX_BYTES = 20 * 1024 * 1024
+
+type Mime = (typeof SUPPORTED_MIME_TYPES)[keyof typeof SUPPORTED_MIME_TYPES]
+
+export type ImageInput =
+  | { kind: 'url'; url: string }
+  | { kind: 'file'; path: string }
+  | { kind: 'base64'; data: string; mimeType: string }
+
+export const imageInputSchema = z.union([
+  z.object({ kind: z.literal('url'), url: z.string().url() }),
+  z.object({ kind: z.literal('file'), path: z.string().min(1) }),
+  z.object({ kind: z.literal('base64'), data: z.string().min(1), mimeType: z.string().min(1) }),
+])
+
+export const multimodalLookerPayloadSchema = z.object({
+  images: z.array(imageInputSchema).min(1),
+  prompt: z.string().min(1).optional(),
+})
+
+export type MultimodalLookerPayload = z.infer<typeof multimodalLookerPayloadSchema>
+
+// System prompt is built per-invocation so the agent sees the exact task. With
+// `prompt`: focused Q&A. Without: open-ended description. Tone the same in
+// both branches so callers can plug either form into the same downstream
+// pipeline (the look_at tool just relays the resulting text).
+export function buildMultimodalLookerSystemPrompt(prompt: string | undefined): string {
+  const base =
+    'You are a multimodal vision subagent. The user message contains one or more images attached to a short instruction.'
+  if (prompt !== undefined && prompt.trim() !== '') {
+    return [
+      base,
+      '',
+      'Your job is to ANSWER the question below using ONLY what is visible in the attached image(s). Be precise, concrete, and faithful to the visual content. If the image does not contain enough information to answer, say so explicitly.',
+      '',
+      `Question: ${prompt.trim()}`,
+      '',
+      'Reply with the answer directly. No preamble, no acknowledgement of the task, no markdown headings.',
+    ].join('\n')
+  }
+  return [
+    base,
+    '',
+    "Your job is to DESCRIBE the attached image(s) faithfully and in detail. Cover: subject(s), composition, colors, text content (transcribed verbatim if legible), notable visual details, and anything that would help a downstream reader who cannot see the image. Do not speculate beyond what's visible.",
+    '',
+    'Reply with the description directly. No preamble, no markdown headings, no bullet list unless multiple images.',
+  ].join('\n')
+}
+
+export type ResolvedImage = {
+  data: string
+  mimeType: string
+}
+
+// Materializes an ImageInput into the base64-encoded form pi-ai expects.
+// - `url`: passthrough; pi-ai's image content does not accept URLs, so we fetch
+//   the bytes and base64-encode here (lazy; only when the tool is invoked).
+// - `file`: read from disk, infer MIME from extension. Path must be absolute or
+//   resolvable against the caller's cwd (callers should normalize ahead of
+//   time; this function rejects relative paths to avoid ambiguity).
+// - `base64`: passthrough.
+export async function resolveImage(input: ImageInput, signal?: AbortSignal): Promise<ResolvedImage> {
+  if (input.kind === 'base64') {
+    if (!input.mimeType.startsWith('image/')) {
+      throw new Error(`look_at: base64 mimeType must be image/* (got "${input.mimeType}")`)
+    }
+    return { data: input.data, mimeType: input.mimeType }
+  }
+  if (input.kind === 'file') {
+    if (!isAbsolute(input.path)) {
+      throw new Error(`look_at: file path must be absolute (got "${input.path}")`)
+    }
+    if (!existsSync(input.path)) {
+      throw new Error(`look_at: file not found at ${input.path}`)
+    }
+    const ext = extname(input.path).toLowerCase() as keyof typeof SUPPORTED_MIME_TYPES
+    const mimeType = (SUPPORTED_MIME_TYPES[ext] ?? null) as Mime | null
+    if (mimeType === null) {
+      throw new Error(
+        `look_at: unsupported image extension "${ext}" for ${input.path} (supported: ${Object.keys(SUPPORTED_MIME_TYPES).join(', ')})`,
+      )
+    }
+    const bytes = readFileSync(input.path)
+    return { data: bytes.toString('base64'), mimeType }
+  }
+  // URL branch: independent timeout + size cap on top of any caller-provided
+  // signal. The two abort signals are merged so the tool's overall abort wins
+  // over our timeout AND vice versa.
+  const timeoutSignal = AbortSignal.timeout(URL_FETCH_TIMEOUT_MS)
+  const mergedSignal = signal !== undefined ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
+  const res = await fetch(input.url, { signal: mergedSignal })
+  if (!res.ok) {
+    throw new Error(`look_at: failed to fetch ${input.url}: HTTP ${res.status}`)
+  }
+  const mimeType = res.headers.get('content-type')?.split(';')[0]?.trim() ?? 'application/octet-stream'
+  if (!mimeType.startsWith('image/')) {
+    throw new Error(`look_at: ${input.url} did not return an image content-type (got "${mimeType}")`)
+  }
+  // Streaming size check: arrayBuffer() would read the whole body before we
+  // could enforce a cap. Read chunk-by-chunk and abort once we cross the
+  // limit. Content-Length is checked first when present, but absent or lying
+  // headers fall through to the streaming check.
+  const declared = Number(res.headers.get('content-length') ?? '')
+  if (Number.isFinite(declared) && declared > URL_FETCH_MAX_BYTES) {
+    throw new Error(`look_at: ${input.url} response too large (${declared} bytes > ${URL_FETCH_MAX_BYTES} cap)`)
+  }
+  const reader = res.body?.getReader()
+  if (reader === undefined) {
+    throw new Error(`look_at: ${input.url} returned an empty body`)
+  }
+  const chunks: Uint8Array[] = []
+  let total = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value === undefined) continue
+    total += value.byteLength
+    if (total > URL_FETCH_MAX_BYTES) {
+      await reader.cancel()
+      throw new Error(`look_at: ${input.url} response exceeded ${URL_FETCH_MAX_BYTES}-byte cap`)
+    }
+    chunks.push(value)
+  }
+  const buf = Buffer.concat(chunks)
+  return { data: buf.toString('base64'), mimeType }
+}

--- a/src/agent/profile-fallback-warning.test.ts
+++ b/src/agent/profile-fallback-warning.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { __resetConfigForTesting, reloadConfig } from '@/config/config'
+
+import { __resetProfileFallbackWarningsForTesting, createSessionWithDispose } from './index'
+
+describe('profile-fallback warning is rate-limited (Oracle review Bug 2 / Design 1)', () => {
+  let prevCwd: string
+  let prevNodeEnv: string | undefined
+  let prevOpenai: string | undefined
+  let cwd: string
+  let warnings: string[]
+  let originalWarn: typeof console.warn
+
+  beforeEach(async () => {
+    prevCwd = process.cwd()
+    prevNodeEnv = process.env.NODE_ENV
+    prevOpenai = process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_API_KEY
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-profile-warn-'))
+    process.chdir(cwd)
+    __resetProfileFallbackWarningsForTesting()
+    __resetConfigForTesting()
+    warnings = []
+    originalWarn = console.warn
+    console.warn = (msg: unknown) => {
+      warnings.push(String(msg))
+    }
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'openai/gpt-5.4-nano' } }))
+    reloadConfig(cwd)
+  })
+
+  afterEach(async () => {
+    console.warn = originalWarn
+    if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+    else process.env.NODE_ENV = prevNodeEnv
+    if (prevOpenai === undefined) delete process.env.OPENAI_API_KEY
+    else process.env.OPENAI_API_KEY = prevOpenai
+    __resetProfileFallbackWarningsForTesting()
+    __resetConfigForTesting()
+    process.chdir(prevCwd)
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  test('an unknown profile warns exactly once across repeated session creations', async () => {
+    const create = async () => {
+      const { session, dispose } = await createSessionWithDispose({ profile: 'nonexistent-profile' })
+      session.dispose()
+      await dispose()
+    }
+    await create()
+    await create()
+    await create()
+
+    const fallbackWarnings = warnings.filter(
+      (w) => w.includes('unknown model profile') && w.includes('nonexistent-profile'),
+    )
+    expect(fallbackWarnings.length).toBe(1)
+    expect(fallbackWarnings[0]).toContain('further occurrences suppressed')
+  })
+
+  test('distinct unknown profiles each warn once', async () => {
+    const create = async (profile: string) => {
+      const { session, dispose } = await createSessionWithDispose({ profile })
+      session.dispose()
+      await dispose()
+    }
+    await create('typo-one')
+    await create('typo-two')
+    await create('typo-one')
+
+    const one = warnings.filter((w) => w.includes('typo-one') && w.includes('unknown model profile'))
+    const two = warnings.filter((w) => w.includes('typo-two') && w.includes('unknown model profile'))
+    expect(one.length).toBe(1)
+    expect(two.length).toBe(1)
+  })
+
+  test('omitted profile (default) does not warn', async () => {
+    const { session, dispose } = await createSessionWithDispose({})
+    session.dispose()
+    await dispose()
+
+    const fallbackWarnings = warnings.filter((w) => w.includes('unknown model profile'))
+    expect(fallbackWarnings).toEqual([])
+  })
+
+  test('explicit "default" profile does not warn (it is by definition known)', async () => {
+    const { session, dispose } = await createSessionWithDispose({ profile: 'default' })
+    session.dispose()
+    await dispose()
+
+    const fallbackWarnings = warnings.filter((w) => w.includes('unknown model profile'))
+    expect(fallbackWarnings).toEqual([])
+  })
+})

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -19,6 +19,10 @@ export type RunSession = (override?: { userPrompt?: string }) => Promise<void>
 
 export type Subagent<P = unknown> = {
   systemPrompt: string
+  // Model profile this subagent prefers. Resolved against `config.models` at
+  // session construction. Unknown profile names fall back to `default` with
+  // a warning. See `Subagent` in `@/plugin/types` for the full contract.
+  profile?: string
   tools?: AgentSessionTools
   customTools?: ToolDefinition[]
   payloadSchema?: z.ZodType<P>
@@ -82,6 +86,7 @@ export const defaultCreateSessionForSubagent: CreateSessionForSubagent = (subage
     },
     ...(subagent.tools ? { tools: subagent.tools } : {}),
     customTools: subagent.customTools ?? [],
+    ...(subagent.profile !== undefined ? { profile: subagent.profile } : {}),
   })
 
 type NormalizedSubagentSession = {

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -541,6 +541,7 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
 
   return {
     systemPrompt: DREAMING_SYSTEM_PROMPT,
+    profile: 'deep',
     tools: [readTool, writeTool, lsTool],
     payloadSchema: dreamingPayloadSchema,
     inFlightKey: (payload) => payload.agentDir,

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -228,6 +228,7 @@ export function createMemoryLoggerSubagent(
   const logger = options.logger ?? consoleLogger
   return {
     systemPrompt: MEMORY_LOGGER_SYSTEM_PROMPT,
+    profile: 'fast',
     tools: [readTool],
     customTools: [appendTool],
     payloadSchema: memoryLoggerPayloadSchema,

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -13,28 +13,104 @@ import {
   loadPluginConfigsSync,
   migrateLegacyConfigShape,
   mountSchema,
+  resolveProfile,
   validateConfig,
   validateMount,
+  type Models,
 } from './config'
 
 const isRoot = typeof process.getuid === 'function' && process.getuid() === 0
 
 const VALID_MODEL = 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'
+const VALID_MODEL_2 = 'openai/gpt-5.4-nano'
+
+describe('configSchema models field', () => {
+  test('defaults to { default: <DEFAULT_MODEL_REF> } when omitted', () => {
+    const parsed = configSchema.parse({})
+    expect(parsed.models).toEqual({ default: 'openai/gpt-5.4-nano' })
+  })
+
+  test('accepts a single-key models map (just default)', () => {
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
+    expect(parsed.models).toEqual({ default: VALID_MODEL })
+  })
+
+  test('accepts multiple profiles', () => {
+    const parsed = configSchema.parse({
+      models: { default: VALID_MODEL, fast: VALID_MODEL_2, deep: VALID_MODEL, vision: VALID_MODEL_2 },
+    })
+    expect(parsed.models.default).toBe(VALID_MODEL)
+    expect(parsed.models.fast).toBe(VALID_MODEL_2)
+    expect(parsed.models.deep).toBe(VALID_MODEL)
+    expect(parsed.models.vision).toBe(VALID_MODEL_2)
+  })
+
+  test('accepts user-defined profile names alongside well-known ones', () => {
+    const parsed = configSchema.parse({
+      models: { default: VALID_MODEL, 'cheap-batch': VALID_MODEL_2 },
+    })
+    expect(parsed.models['cheap-batch']).toBe(VALID_MODEL_2)
+  })
+
+  test('rejects models map without default', () => {
+    expect(() => configSchema.parse({ models: { fast: VALID_MODEL } })).toThrow()
+  })
+
+  test('rejects unknown model refs', () => {
+    expect(() => configSchema.parse({ models: { default: 'not-a-real-model' } })).toThrow()
+  })
+
+  test('rejects empty profile names', () => {
+    expect(() => configSchema.parse({ models: { '': VALID_MODEL } })).toThrow()
+  })
+})
+
+describe('resolveProfile', () => {
+  const models: Models = { default: VALID_MODEL, fast: VALID_MODEL_2 }
+
+  test('returns the requested profile when present', () => {
+    const result = resolveProfile(models, 'fast')
+    expect(result.ref).toBe(VALID_MODEL_2)
+    expect(result.profile).toBe('fast')
+    expect(result.fellBackToDefault).toBe(false)
+  })
+
+  test('returns default when name is undefined', () => {
+    const result = resolveProfile(models, undefined)
+    expect(result.ref).toBe(VALID_MODEL)
+    expect(result.profile).toBe('default')
+    expect(result.fellBackToDefault).toBe(false)
+  })
+
+  test('returns default when name is "default"', () => {
+    const result = resolveProfile(models, 'default')
+    expect(result.ref).toBe(VALID_MODEL)
+    expect(result.profile).toBe('default')
+    expect(result.fellBackToDefault).toBe(false)
+  })
+
+  test('falls back to default when requested profile is missing, flagging the fallback', () => {
+    const result = resolveProfile(models, 'deep')
+    expect(result.ref).toBe(VALID_MODEL)
+    expect(result.profile).toBe('default')
+    expect(result.fellBackToDefault).toBe(true)
+  })
+})
 
 describe('configSchema', () => {
   test('defaults mounts to [] when omitted (predating the field is fine)', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
     expect(parsed.mounts).toEqual([])
   })
 
   test('accepts config with empty mounts array', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, mounts: [] })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, mounts: [] })
     expect(parsed.mounts).toEqual([])
   })
 
   test('accepts config with one mount, defaulting readOnly to false', () => {
     const parsed = configSchema.parse({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       mounts: [{ name: 'projects', path: '~/projects' }],
     })
     expect(parsed.mounts).toEqual([{ name: 'projects', path: '~/projects', readOnly: false }])
@@ -42,7 +118,7 @@ describe('configSchema', () => {
 
   test('preserves readOnly: true when provided', () => {
     const parsed = configSchema.parse({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       mounts: [{ name: 'notes', path: '~/notes', readOnly: true }],
     })
     expect(parsed.mounts[0]?.readOnly).toBe(true)
@@ -50,7 +126,7 @@ describe('configSchema', () => {
 
   test('preserves description when provided', () => {
     const parsed = configSchema.parse({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       mounts: [{ name: 'src', path: '~/src', description: 'monorepo' }],
     })
     expect(parsed.mounts[0]?.description).toBe('monorepo')
@@ -59,33 +135,33 @@ describe('configSchema', () => {
 
 describe('configSchema alias field', () => {
   test('defaults to [] when omitted', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
     expect(parsed.alias).toEqual([])
   })
 
   test('accepts a non-empty alias array', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, alias: ['bongbong', '봉봉'] })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, alias: ['bongbong', '봉봉'] })
     expect(parsed.alias).toEqual(['bongbong', '봉봉'])
   })
 
   test('trims surrounding whitespace from each entry', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, alias: ['  bongbong  ', '\t봉봉\n'] })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, alias: ['  bongbong  ', '\t봉봉\n'] })
     expect(parsed.alias).toEqual(['bongbong', '봉봉'])
   })
 
   test('rejects empty-string entries', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, alias: [''] })).toThrow()
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, alias: [''] })).toThrow()
   })
 
   test('rejects whitespace-only entries (would otherwise match every message after trim)', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, alias: ['   '] })).toThrow()
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, alias: ['   '] })).toThrow()
   })
 })
 
 describe('configSchema preserves unknown top-level keys (plugin config blocks)', () => {
   test('a top-level "memory" block survives the schema as unknown (consumed by the bundled memory plugin)', () => {
     const parsed = configSchema.parse({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       memory: { idleMs: 60_000, dreaming: { schedule: '30 3 * * *' } },
     })
     expect(parsed['memory']).toEqual({ idleMs: 60_000, dreaming: { schedule: '30 3 * * *' } })
@@ -93,7 +169,7 @@ describe('configSchema preserves unknown top-level keys (plugin config blocks)',
 
   test('agentBrowser is treated as plugin/user config instead of a core key', () => {
     const configs = extractPluginConfigs({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       agentBrowser: { dashboardProxy: false },
       customPlugin: { enabled: true },
     })
@@ -104,42 +180,47 @@ describe('configSchema preserves unknown top-level keys (plugin config blocks)',
 
 describe('portForwardSchema', () => {
   test('defaults to allow:* when omitted', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
     expect(parsed.portForward).toEqual({ allow: '*' })
   })
 
   test('accepts allow:* with no deny', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, portForward: { allow: '*' } })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, portForward: { allow: '*' } })
     expect(parsed.portForward).toEqual({ allow: '*' })
   })
 
   test('accepts allow:* with deny list', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, portForward: { allow: '*', deny: [9229, 9999] } })
+    const parsed = configSchema.parse({
+      models: { default: VALID_MODEL },
+      portForward: { allow: '*', deny: [9229, 9999] },
+    })
     expect(parsed.portForward).toEqual({ allow: '*', deny: [9229, 9999] })
   })
 
   test('accepts allow as number array (allowlist mode)', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, portForward: { allow: [3000, 5173] } })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, portForward: { allow: [3000, 5173] } })
     expect(parsed.portForward).toEqual({ allow: [3000, 5173] })
   })
 
   test('accepts allow:[] as off-switch', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, portForward: { allow: [] } })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, portForward: { allow: [] } })
     expect(parsed.portForward).toEqual({ allow: [] })
   })
 
   test('rejects deny combined with allow:number[] so user typos do not silently drop the deny rule', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, portForward: { allow: [3000], deny: [9000] } })).toThrow(
-      /portForward\.deny is only meaningful when allow is/,
-    )
+    expect(() =>
+      configSchema.parse({ models: { default: VALID_MODEL }, portForward: { allow: [3000], deny: [9000] } }),
+    ).toThrow(/portForward\.deny is only meaningful when allow is/)
   })
 
   test('rejects out-of-range port numbers in allow', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, portForward: { allow: [99999] } })).toThrow()
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, portForward: { allow: [99999] } })).toThrow()
   })
 
   test('rejects out-of-range port numbers in deny', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, portForward: { allow: '*', deny: [0] } })).toThrow()
+    expect(() =>
+      configSchema.parse({ models: { default: VALID_MODEL }, portForward: { allow: '*', deny: [0] } }),
+    ).toThrow()
   })
 })
 
@@ -147,78 +228,89 @@ describe('networkSchema', () => {
   const FULL_DEFAULTS = { blockInternal: true, autoAllowResolvers: true, allow: [] as string[] }
 
   test('defaults to blockInternal:true, autoAllowResolvers:true, allow:[] when omitted (egress filter on for every agent unless opted out)', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
     expect(parsed.network).toEqual(FULL_DEFAULTS)
   })
 
   test('accepts an empty network object, inheriting all field defaults', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, network: {} })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, network: {} })
     expect(parsed.network).toEqual(FULL_DEFAULTS)
   })
 
   test('preserves blockInternal:false when explicitly opted out', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, network: { blockInternal: false } })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, network: { blockInternal: false } })
     expect(parsed.network.blockInternal).toBe(false)
   })
 
   test('preserves blockInternal:true when explicitly set (redundant with default, but harmless)', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, network: { blockInternal: true } })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, network: { blockInternal: true } })
     expect(parsed.network.blockInternal).toBe(true)
   })
 
   test('rejects non-boolean blockInternal', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, network: { blockInternal: 'yes' } })).toThrow()
-    expect(() => configSchema.parse({ model: VALID_MODEL, network: { blockInternal: 1 } })).toThrow()
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, network: { blockInternal: 'yes' } })).toThrow()
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, network: { blockInternal: 1 } })).toThrow()
   })
 
   test('preserves autoAllowResolvers:false when explicitly opted out (closed filter for users who configure DNS via .env)', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, network: { autoAllowResolvers: false } })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, network: { autoAllowResolvers: false } })
     expect(parsed.network.autoAllowResolvers).toBe(false)
   })
 
   test('rejects non-boolean autoAllowResolvers', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, network: { autoAllowResolvers: 'yes' } })).toThrow()
+    expect(() =>
+      configSchema.parse({ models: { default: VALID_MODEL }, network: { autoAllowResolvers: 'yes' } }),
+    ).toThrow()
   })
 
   test('accepts bare IPv4 addresses in allow (single-host carve-out: AWS VPC DNS at 10.0.0.2, internal API server, etc.)', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, network: { allow: ['10.0.0.2', '10.210.1.42'] } })
+    const parsed = configSchema.parse({
+      models: { default: VALID_MODEL },
+      network: { allow: ['10.0.0.2', '10.210.1.42'] },
+    })
     expect(parsed.network.allow).toEqual(['10.0.0.2', '10.210.1.42'])
   })
 
   test('accepts IPv4 CIDR ranges in allow (VPC subnet, ECS task subnet, etc.)', () => {
     const parsed = configSchema.parse({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       network: { allow: ['10.210.0.0/16', '172.20.0.0/24', '192.168.42.0/28'] },
     })
     expect(parsed.network.allow).toEqual(['10.210.0.0/16', '172.20.0.0/24', '192.168.42.0/28'])
   })
 
   test('rejects non-IPv4 strings in allow (bare hostname, garbage, etc.)', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, network: { allow: ['not-a-cidr'] } })).toThrow()
-    expect(() => configSchema.parse({ model: VALID_MODEL, network: { allow: ['example.com'] } })).toThrow()
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, network: { allow: ['not-a-cidr'] } })).toThrow()
+    expect(() =>
+      configSchema.parse({ models: { default: VALID_MODEL }, network: { allow: ['example.com'] } }),
+    ).toThrow()
   })
 
   test('rejects out-of-range IPv4 octets in allow (typo guard)', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, network: { allow: ['10.0.0.300'] } })).toThrow()
-    expect(() => configSchema.parse({ model: VALID_MODEL, network: { allow: ['999.0.0.0/8'] } })).toThrow()
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, network: { allow: ['10.0.0.300'] } })).toThrow()
+    expect(() =>
+      configSchema.parse({ models: { default: VALID_MODEL }, network: { allow: ['999.0.0.0/8'] } }),
+    ).toThrow()
   })
 
   test('rejects out-of-range CIDR prefix lengths in allow', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, network: { allow: ['10.0.0.0/33'] } })).toThrow()
+    expect(() =>
+      configSchema.parse({ models: { default: VALID_MODEL }, network: { allow: ['10.0.0.0/33'] } }),
+    ).toThrow()
   })
 
   test('rejects IPv6 addresses in allow (scope is IPv4-only; IPv6 block list is not punched through)', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, network: { allow: ['fe80::1'] } })).toThrow()
-    expect(() => configSchema.parse({ model: VALID_MODEL, network: { allow: ['fc00::/7'] } })).toThrow()
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, network: { allow: ['fe80::1'] } })).toThrow()
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, network: { allow: ['fc00::/7'] } })).toThrow()
   })
 
   test('rejects non-array allow', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, network: { allow: '10.0.0.0/8' } })).toThrow()
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, network: { allow: '10.0.0.0/8' } })).toThrow()
   })
 
   test('does not leak into the plugin config map', () => {
     const plugins = extractPluginConfigs({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       network: { blockInternal: true, autoAllowResolvers: true, allow: [] },
       'my-plugin': { x: 1 },
     })
@@ -231,8 +323,8 @@ describe('docker.file schema', () => {
   const FULL_DEFAULTS = { ffmpeg: false, gh: true, python: true, tmux: true, append: [] }
 
   test('defaults to a fully-populated object when omitted (omitted == empty object)', () => {
-    const omitted = configSchema.parse({ model: VALID_MODEL })
-    const present = configSchema.parse({ model: VALID_MODEL, docker: { file: {} } })
+    const omitted = configSchema.parse({ models: { default: VALID_MODEL } })
+    const present = configSchema.parse({ models: { default: VALID_MODEL }, docker: { file: {} } })
 
     expect(omitted.docker.file).toEqual(FULL_DEFAULTS)
     expect(present.docker.file).toEqual(FULL_DEFAULTS)
@@ -240,7 +332,7 @@ describe('docker.file schema', () => {
 
   test('accepts custom Dockerfile lines in append order', () => {
     const parsed = configSchema.parse({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       docker: { file: { append: ['RUN apt-get update', 'ENV CUSTOM_TOOL=1'] } },
     })
     expect(parsed.docker.file.append).toEqual(['RUN apt-get update', 'ENV CUSTOM_TOOL=1'])
@@ -249,7 +341,7 @@ describe('docker.file schema', () => {
   test('rejects multiline append entries so each array item maps to one Dockerfile line', () => {
     expect(() =>
       configSchema.parse({
-        model: VALID_MODEL,
+        models: { default: VALID_MODEL },
         docker: { file: { append: ['RUN printf "one\ntwo"'] } },
       }),
     ).toThrow(/single Dockerfile lines/)
@@ -257,7 +349,7 @@ describe('docker.file schema', () => {
 
   test('feature toggles accept boolean and version-string forms; partial overrides preserve other defaults', () => {
     const parsed = configSchema.parse({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       docker: { file: { tmux: false, gh: '2.40.0', ffmpeg: true } },
     })
     expect(parsed.docker.file).toEqual({
@@ -270,52 +362,54 @@ describe('docker.file schema', () => {
   })
 
   test('python is boolean-only (string version is not a meaningful apt pin for the python3 meta-package)', () => {
-    expect(() => configSchema.parse({ model: VALID_MODEL, docker: { file: { python: '3.11' } } })).toThrow()
+    expect(() =>
+      configSchema.parse({ models: { default: VALID_MODEL }, docker: { file: { python: '3.11' } } }),
+    ).toThrow()
   })
 
   test('empty docker object resolves to defaulted docker.file', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, docker: {} })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, docker: {} })
     expect(parsed.docker.file).toEqual(FULL_DEFAULTS)
   })
 })
 
 describe('git.ignore schema', () => {
   test('defaults to an empty append array when omitted', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
     expect(parsed.git.ignore).toEqual({ append: [] })
   })
 
   test('accepts custom gitignore entries in append order', () => {
     const parsed = configSchema.parse({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       git: { ignore: { append: ['scratch/', '*.local.log'] } },
     })
     expect(parsed.git.ignore.append).toEqual(['scratch/', '*.local.log'])
   })
 
   test('defaults append to an empty array when git.ignore object is present', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, git: { ignore: {} } })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, git: { ignore: {} } })
     expect(parsed.git.ignore).toEqual({ append: [] })
   })
 
   test('rejects multiline append entries so each array item maps to one gitignore line', () => {
     expect(() =>
       configSchema.parse({
-        model: VALID_MODEL,
+        models: { default: VALID_MODEL },
         git: { ignore: { append: ['scratch/\n*.local.log'] } },
       }),
     ).toThrow(/single gitignore lines/)
   })
 
   test('empty git object resolves to defaulted git.ignore', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL, git: {} })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, git: {} })
     expect(parsed.git.ignore).toEqual({ append: [] })
   })
 })
 
 describe('migrateLegacyConfigShape', () => {
   test('returns input unchanged when neither legacy key is present', () => {
-    const input = { model: VALID_MODEL, port: 9001 }
+    const input = { models: { default: VALID_MODEL }, port: 9001 }
     const result = migrateLegacyConfigShape(input)
     expect(result.changed).toBe(false)
     expect(result.json).toBe(input)
@@ -323,37 +417,37 @@ describe('migrateLegacyConfigShape', () => {
 
   test('moves legacy dockerfile into docker.file', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       dockerfile: { ffmpeg: true, append: ['ENV X=1'] },
     })
     expect(result.changed).toBe(true)
     expect(result.json).toEqual({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       docker: { file: { ffmpeg: true, append: ['ENV X=1'] } },
     })
   })
 
   test('moves legacy gitignore into git.ignore', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       gitignore: { append: ['scratch/'] },
     })
     expect(result.changed).toBe(true)
     expect(result.json).toEqual({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       git: { ignore: { append: ['scratch/'] } },
     })
   })
 
   test('migrates both legacy keys in a single pass', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       dockerfile: { ffmpeg: true },
       gitignore: { append: ['scratch/'] },
     })
     expect(result.changed).toBe(true)
     expect(result.json).toEqual({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       docker: { file: { ffmpeg: true } },
       git: { ignore: { append: ['scratch/'] } },
     })
@@ -361,7 +455,7 @@ describe('migrateLegacyConfigShape', () => {
 
   test('migrated config parses cleanly through configSchema', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       dockerfile: { ffmpeg: true, append: ['ENV X=1'] },
       gitignore: { append: ['scratch/'] },
     })
@@ -373,39 +467,39 @@ describe('migrateLegacyConfigShape', () => {
 
   test('drops legacy dockerfile when new docker.file already present (new shape wins)', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       dockerfile: { ffmpeg: false, append: ['LEGACY'] },
       docker: { file: { ffmpeg: true, append: ['NEW'] } },
     })
     expect(result.changed).toBe(true)
     expect(result.json).toEqual({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       docker: { file: { ffmpeg: true, append: ['NEW'] } },
     })
   })
 
   test('drops legacy gitignore when new git.ignore already present (new shape wins)', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       gitignore: { append: ['LEGACY'] },
       git: { ignore: { append: ['NEW'] } },
     })
     expect(result.changed).toBe(true)
     expect(result.json).toEqual({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       git: { ignore: { append: ['NEW'] } },
     })
   })
 
   test('merges legacy dockerfile into existing docker namespace that lacks file', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       dockerfile: { ffmpeg: true },
       docker: { somethingElse: 'future' },
     })
     expect(result.changed).toBe(true)
     expect(result.json).toEqual({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       docker: { somethingElse: 'future', file: { ffmpeg: true } },
     })
   })
@@ -422,7 +516,7 @@ describe('migrateLegacyConfigShape', () => {
       await writeFile(
         join(cwd, 'typeclaw.json'),
         JSON.stringify({
-          model: VALID_MODEL,
+          models: { default: VALID_MODEL },
           dockerfile: { ffmpeg: true, append: ['ENV X=1'] },
           gitignore: { append: ['scratch/'] },
         }),
@@ -442,10 +536,27 @@ describe('migrateLegacyConfigShape', () => {
     }
   })
 
+  test('loadConfigSync rewrites typeclaw.json on disk when legacy `model` is present', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-migrate-model-'))
+    try {
+      await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: VALID_MODEL, port: 9001 }))
+
+      const cfg = loadConfigSync(cwd)
+      expect(cfg.models).toEqual({ default: VALID_MODEL })
+
+      const onDisk = JSON.parse(await Bun.file(join(cwd, 'typeclaw.json')).text())
+      expect(onDisk).not.toHaveProperty('model')
+      expect(onDisk.models).toEqual({ default: VALID_MODEL })
+      expect(onDisk.port).toBe(9001)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
   test('loadConfigSync does not touch the file when no legacy keys are present', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-migrate-noop-'))
     try {
-      const original = `${JSON.stringify({ model: VALID_MODEL, port: 9001 }, null, 4)}\n`
+      const original = `${JSON.stringify({ models: { default: VALID_MODEL }, port: 9001 }, null, 4)}\n`
       await writeFile(join(cwd, 'typeclaw.json'), original)
 
       loadConfigSync(cwd)
@@ -463,7 +574,7 @@ describe('migrateLegacyConfigShape', () => {
       await writeFile(
         join(cwd, 'typeclaw.json'),
         JSON.stringify({
-          model: VALID_MODEL,
+          models: { default: VALID_MODEL },
           dockerfile: { ffmpeg: true },
         }),
       )
@@ -481,7 +592,7 @@ describe('migrateLegacyConfigShape', () => {
 
   test('translates channels.<adapter>.allow into roles.member.match and strips the allow field', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       channels: {
         'slack-bot': { allow: ['team:T0123', '*'] },
         'discord-bot': { allow: ['guild:9999/1', 'dm:*'] },
@@ -498,7 +609,7 @@ describe('migrateLegacyConfigShape', () => {
 
   test('appends to an existing roles.member.match and deduplicates', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       channels: { 'slack-bot': { allow: ['team:T0123', '*'] } },
       roles: { member: { match: ['*', 'discord:9999'] } },
     })
@@ -509,7 +620,7 @@ describe('migrateLegacyConfigShape', () => {
 
   test('preserves kakao rules verbatim', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       channels: { kakaotalk: { allow: ['kakao:dm/*', 'kakao:12345'] } },
     })
     const json = result.json as Record<string, unknown>
@@ -521,7 +632,7 @@ describe('migrateLegacyConfigShape', () => {
 
   test('drops channel:<id> rules with a warning and keeps other rules', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       channels: { 'slack-bot': { allow: ['channel:C123', 'team:T0123'] } },
     })
     const json = result.json as Record<string, unknown>
@@ -531,7 +642,7 @@ describe('migrateLegacyConfigShape', () => {
 
   test('is idempotent: running twice produces the same shape as once', () => {
     const input = {
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       channels: { 'slack-bot': { allow: ['team:T0123'], engagement: { trigger: ['dm'] } } },
     }
     const first = migrateLegacyConfigShape(input)
@@ -542,7 +653,7 @@ describe('migrateLegacyConfigShape', () => {
 
   test('preserves adapter siblings (engagement/history/enabled) when stripping allow', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       channels: {
         'discord-bot': {
           allow: ['*'],
@@ -561,7 +672,7 @@ describe('migrateLegacyConfigShape', () => {
 
   test('migrated channels-allow config parses cleanly through configSchema', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       channels: { 'slack-bot': { allow: ['team:T0123'] } },
     })
     const parsed = configSchema.parse(result.json)
@@ -571,7 +682,7 @@ describe('migrateLegacyConfigShape', () => {
 
   test('strips permissions.gateChannelRespond when present', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       permissions: { gateChannelRespond: true },
     })
     expect(result.changed).toBe(true)
@@ -580,13 +691,13 @@ describe('migrateLegacyConfigShape', () => {
   })
 
   test('returns applied: [] when nothing migrated', () => {
-    const result = migrateLegacyConfigShape({ model: VALID_MODEL, port: 9001 })
+    const result = migrateLegacyConfigShape({ models: { default: VALID_MODEL }, port: 9001 })
     expect(result.applied).toEqual([])
   })
 
   test('names each applied step in order — drives commit-message body', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       dockerfile: { ffmpeg: true },
       gitignore: { append: ['scratch/'] },
       channels: { 'slack-bot': { allow: ['team:T0123'] } },
@@ -602,7 +713,7 @@ describe('migrateLegacyConfigShape', () => {
 
   test('channels-allow step carries translated rules and dropped warnings', () => {
     const result = migrateLegacyConfigShape({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       channels: { 'slack-bot': { allow: ['team:T0123', 'channel:C123'] } },
     })
     const step = result.applied.find((s) => s.kind === 'channels-allow-to-roles-member-match')
@@ -610,6 +721,43 @@ describe('migrateLegacyConfigShape', () => {
     expect(step.rules).toEqual(['slack:T0123'])
     expect(step.dropped.length).toBe(1)
     expect(step.dropped[0]).toContain('channel:C123')
+  })
+
+  test('lifts legacy top-level model into models.default', () => {
+    const result = migrateLegacyConfigShape({ model: VALID_MODEL, port: 9001 })
+    expect(result.changed).toBe(true)
+    const json = result.json as Record<string, unknown>
+    expect(json).not.toHaveProperty('model')
+    expect(json.models).toEqual({ default: VALID_MODEL })
+    expect(json.port).toBe(9001)
+    expect(result.applied).toEqual([{ kind: 'model-to-models', ref: VALID_MODEL }])
+  })
+
+  test('drops legacy `model` when `models` already exists (new shape wins) and records drop-stale-model step', () => {
+    const result = migrateLegacyConfigShape({
+      model: VALID_MODEL,
+      models: { default: VALID_MODEL_2, fast: VALID_MODEL },
+    })
+    expect(result.changed).toBe(true)
+    const json = result.json as Record<string, unknown>
+    expect(json).not.toHaveProperty('model')
+    expect(json.models).toEqual({ default: VALID_MODEL_2, fast: VALID_MODEL })
+    // drop-stale-model step is recorded so persistMigratedConfig commits the
+    // rewrite — without the step, applied: [] would silently dirty the worktree.
+    expect(result.applied).toEqual([{ kind: 'drop-stale-model', ref: VALID_MODEL }])
+  })
+
+  test('drop-stale-model commit message names the dropped ref so audit trail is clear', () => {
+    const msg = buildConfigMigrationCommitMessage([{ kind: 'drop-stale-model', ref: VALID_MODEL }])
+    expect(msg).not.toBeNull()
+    expect(msg).toContain('drop stale legacy model alongside models')
+    expect(msg).toContain(VALID_MODEL)
+  })
+
+  test('non-string legacy model values are ignored (schema will reject downstream)', () => {
+    const result = migrateLegacyConfigShape({ model: 123 })
+    expect(result.changed).toBe(false)
+    expect(result.applied).toEqual([])
   })
 })
 
@@ -671,7 +819,7 @@ describe('persistMigratedConfig commits the migration on every entry point', () 
     await gitInitForCommitTests(cwd)
     const legacyJson = `${JSON.stringify(
       {
-        model: VALID_MODEL,
+        models: { default: VALID_MODEL },
         channels: { 'slack-bot': { allow: ['team:T0123'] } },
       },
       null,
@@ -755,7 +903,7 @@ describe('persistMigratedConfig commits the migration on every entry point', () 
     const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-nogit-commit-'))
     try {
       const legacyJson = `${JSON.stringify(
-        { model: VALID_MODEL, channels: { 'slack-bot': { allow: ['team:T0123'] } } },
+        { models: { default: VALID_MODEL }, channels: { 'slack-bot': { allow: ['team:T0123'] } } },
         null,
         2,
       )}\n`
@@ -874,7 +1022,7 @@ describe('validateConfig', () => {
   })
 
   test('returns ok for a valid config', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: VALID_MODEL, mounts: [] }))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: VALID_MODEL }, mounts: [] }))
     const result = validateConfig(cwd)
     expect(result.ok).toBe(true)
   })
@@ -884,7 +1032,7 @@ describe('validateConfig', () => {
     await mkdir(mountDir)
     await writeFile(
       join(cwd, 'typeclaw.json'),
-      JSON.stringify({ model: VALID_MODEL, mounts: [{ name: 'projects', path: mountDir }] }),
+      JSON.stringify({ models: { default: VALID_MODEL }, mounts: [{ name: 'projects', path: mountDir }] }),
     )
     const result = validateConfig(cwd)
     expect(result.ok).toBe(true)
@@ -893,7 +1041,7 @@ describe('validateConfig', () => {
   test('fails when a mount path does not exist on the host', async () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),
-      JSON.stringify({ model: VALID_MODEL, mounts: [{ name: 'projects', path: join(cwd, 'missing') }] }),
+      JSON.stringify({ models: { default: VALID_MODEL }, mounts: [{ name: 'projects', path: join(cwd, 'missing') }] }),
     )
     const result = validateConfig(cwd)
     expect(result.ok).toBe(false)
@@ -907,7 +1055,7 @@ describe('validateConfig', () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),
       JSON.stringify({
-        model: VALID_MODEL,
+        models: { default: VALID_MODEL },
         mounts: [
           { name: 'first', path: join(cwd, 'missing-1') },
           { name: 'second', path: join(cwd, 'missing-2') },
@@ -933,7 +1081,7 @@ describe('validateConfig', () => {
   })
 
   test('returns ok when mounts is omitted (defaults to [])', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: VALID_MODEL }))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: VALID_MODEL } }))
     const result = validateConfig(cwd)
     expect(result.ok).toBe(true)
   })
@@ -941,7 +1089,7 @@ describe('validateConfig', () => {
   test('fails when a mount name violates the pattern', async () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),
-      JSON.stringify({ model: VALID_MODEL, mounts: [{ name: 'Bad Name', path: '/x' }] }),
+      JSON.stringify({ models: { default: VALID_MODEL }, mounts: [{ name: 'Bad Name', path: '/x' }] }),
     )
     const result = validateConfig(cwd)
     expect(result.ok).toBe(false)
@@ -951,7 +1099,10 @@ describe('validateConfig', () => {
   })
 
   test('fails when port is out of range', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: VALID_MODEL, mounts: [], port: 99999 }))
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({ models: { default: VALID_MODEL }, mounts: [], port: 99999 }),
+    )
     const result = validateConfig(cwd)
     expect(result.ok).toBe(false)
   })
@@ -1095,7 +1246,7 @@ describe('loadConfigSync', () => {
   })
 
   test('reads port from disk', async () => {
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: VALID_MODEL, port: 9999 }))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: VALID_MODEL }, port: 9999 }))
     const cfg = loadConfigSync(cwd)
     expect(cfg.port).toBe(9999)
   })
@@ -1105,11 +1256,11 @@ describe('loadConfigSync', () => {
     expect(() => loadConfigSync(cwd)).toThrow(/not valid JSON/)
   })
 
-  test('throws on schema-invalid config (e.g. invalid model name)', async () => {
+  test('throws on schema-invalid config (e.g. invalid model name in models.default)', async () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),
       JSON.stringify({
-        model: 'not-a-known-model',
+        models: { default: 'not-a-known-model' },
       }),
     )
     expect(() => loadConfigSync(cwd)).toThrow(/typeclaw\.json is invalid/)
@@ -1118,13 +1269,13 @@ describe('loadConfigSync', () => {
 
 describe('plugin config layout', () => {
   test('plugins defaults to [] when omitted', () => {
-    const parsed = configSchema.parse({ model: VALID_MODEL })
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
     expect(parsed.plugins).toEqual([])
   })
 
   test('plugins accepts an array of strings', () => {
     const parsed = configSchema.parse({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       plugins: ['typeclaw-plugin-foo', './plugins/local'],
     })
     expect(parsed.plugins).toEqual(['typeclaw-plugin-foo', './plugins/local'])
@@ -1132,7 +1283,7 @@ describe('plugin config layout', () => {
 
   test('catchall preserves unknown top-level keys (per-plugin config blocks)', () => {
     const parsed = configSchema.parse({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       plugins: ['typeclaw-plugin-standup-log'],
       'standup-log': { schedule: '0 17 * * 5' },
     }) as Record<string, unknown>
@@ -1143,7 +1294,7 @@ describe('plugin config layout', () => {
     const result = extractPluginConfigs({
       $schema: 'x',
       port: 1,
-      model: 'm',
+      models: { default: VALID_MODEL },
       mounts: [],
       plugins: [],
       memory: { idleMs: 5000 },
@@ -1157,7 +1308,7 @@ describe('plugin config layout', () => {
 
   test('extractPluginConfigs treats portForward, docker, and git as known top-level keys (not plugin blocks)', () => {
     const result = extractPluginConfigs({
-      model: VALID_MODEL,
+      models: { default: VALID_MODEL },
       portForward: { allow: '*' },
       docker: { file: { append: [] } },
       git: { ignore: { append: [] } },
@@ -1172,7 +1323,7 @@ describe('plugin config layout', () => {
       await writeFile(
         join(cwd, 'typeclaw.json'),
         JSON.stringify({
-          model: VALID_MODEL,
+          models: { default: VALID_MODEL },
           plugins: ['typeclaw-plugin-foo'],
           foo: { bar: 1 },
         }),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -205,11 +205,41 @@ export const networkSchema = z
 
 export type NetworkConfig = z.infer<typeof networkSchema>
 
+// `models` is a map from profile name to a single curated model ref. The
+// `default` profile is mandatory; every other profile is optional and falls
+// back to `default` at resolution time (see `resolveProfile`).
+//
+// Profile names are open strings; the runtime recognizes a handful of
+// well-known names by convention (`default`, `fast`, `deep`, `vision`) but
+// any string is valid. Subagents may declare a static profile preference;
+// callers may override per-spawn. Unknown profile names resolve to `default`
+// with a one-time warning at session construction.
+//
+// The pre-multi-model schema had a single `model: KnownModelRef` at the top
+// level. `migrateLegacyConfigShape` rewrites that to `models: { default: ... }`
+// on first load (and writes the result back to disk + commits via
+// `persistMigratedConfig`), so every downstream consumer sees the new shape.
+export const modelsSchema = z
+  .record(z.string().min(1), z.enum(knownModelRefs))
+  .refine((m) => 'default' in m, { message: 'models.default is required' })
+
+// Zod's `z.record(..., refine)` doesn't refine the inferred type — the inferred
+// shape is `Record<string, KnownModelRef>` where every access is `T | undefined`.
+// The runtime guarantee (the `refine` above) is that `default` is present, so
+// we narrow the type here. Every consumer (auth.ts, agent/index.ts,
+// resolveProfile) reads `models.default` on the hot path; without this
+// narrowing they all have to assert or `?? throw`, which is noise around an
+// invariant the schema already enforces.
+export type Models = Record<string, KnownModelRef> & { default: KnownModelRef }
+
 export const configSchema = z
   .object({
     $schema: z.string().optional(),
     port: z.number().int().min(1).max(65535).default(DEFAULT_PORT),
-    model: z.enum(knownModelRefs).default(DEFAULT_MODEL_REF),
+    // `default(() => ...)` ensures every parsed config has at least
+    // `models.default`. Direct `.default({ default: ... })` would short-circuit
+    // the refinement, so we lean on the lazy thunk form.
+    models: modelsSchema.default(() => ({ default: DEFAULT_MODEL_REF })) as unknown as z.ZodType<Models>,
     // Defaults to `[]` so the field can be omitted from `typeclaw.json` (no
     // host paths exposed) without failing the whole config load. `typeclaw
     // init` omits this field so users don't see noise for the empty case.
@@ -239,6 +269,28 @@ export function resolveModel(ref: KnownModelRef): Model<'openai-completions'> | 
   const providerId = ref.slice(0, slash) as KnownProviderId
   const modelId = ref.slice(slash + 1)
   return KNOWN_PROVIDERS[providerId].models[modelId as never]
+}
+
+// Resolves a profile name (e.g. `fast`, `deep`, `vision`) to a concrete model
+// ref. Unknown profiles fall back to `default` so callers can pass through
+// arbitrary subagent-declared or user-overridden strings without crashing.
+// Returns the resolved ref plus whether it came from the requested profile or
+// from the `default` fallback, so the caller can warn once per session
+// instead of every prompt.
+export type ResolvedProfile = {
+  ref: KnownModelRef
+  profile: string
+  fellBackToDefault: boolean
+}
+
+export function resolveProfile(models: Models, name: string | undefined): ResolvedProfile {
+  const requested = name ?? 'default'
+  const ref = models[requested]
+  if (ref !== undefined) {
+    return { ref, profile: requested, fellBackToDefault: false }
+  }
+  const fallback = models.default
+  return { ref: fallback, profile: 'default', fellBackToDefault: true }
 }
 
 // Resolves a mount's `path` field to an absolute host path, mirroring shell
@@ -309,7 +361,7 @@ export type FieldEffect = 'applied' | 'restart-required' | 'ignored'
 
 export const FIELD_EFFECTS: Record<string, FieldEffect> = {
   $schema: 'ignored',
-  model: 'applied',
+  models: 'applied',
   port: 'restart-required',
   mounts: 'restart-required',
   plugins: 'restart-required',
@@ -376,7 +428,7 @@ export function extractPluginConfigs(raw: unknown): Record<string, unknown> {
   const known = new Set([
     '$schema',
     'port',
-    'model',
+    'models',
     'mounts',
     'plugins',
     'alias',
@@ -468,6 +520,8 @@ export type MigrationStep =
   | { kind: 'gitignore-to-git-ignore' }
   | { kind: 'channels-allow-to-roles-member-match'; rules: string[]; dropped: string[] }
   | { kind: 'strip-permissions-gate-channel-respond' }
+  | { kind: 'model-to-models'; ref: string }
+  | { kind: 'drop-stale-model'; ref: string }
 
 export type MigrationResult = { json: unknown; changed: boolean; applied: MigrationStep[] }
 
@@ -481,7 +535,21 @@ export function migrateLegacyConfigShape(json: unknown): MigrationResult {
   const hasLegacyGitignore = 'gitignore' in obj
   const channelsAllowMigration = collectChannelsAllowMigration(obj)
   const hasLegacyGateChannelRespond = isPlainObject(obj.permissions) && 'gateChannelRespond' in obj.permissions
-  if (!hasLegacyDockerfile && !hasLegacyGitignore && !channelsAllowMigration.found && !hasLegacyGateChannelRespond) {
+  // The pre-multi-model schema had a top-level `model: KnownModelRef` and no
+  // `models` key. Detecting the legacy shape requires both: `model` present
+  // AND `models` absent. If both coexist (user hand-edited after auto-migrate
+  // but didn't delete the legacy key), `models` wins and `model` is dropped
+  // silently — same precedence rule as the dockerfile/gitignore migrations.
+  const hasLegacyModel = 'model' in obj && !('models' in obj) && typeof obj.model === 'string'
+  const hasStaleModelAlongsideModels = 'model' in obj && 'models' in obj
+  if (
+    !hasLegacyDockerfile &&
+    !hasLegacyGitignore &&
+    !channelsAllowMigration.found &&
+    !hasLegacyGateChannelRespond &&
+    !hasLegacyModel &&
+    !hasStaleModelAlongsideModels
+  ) {
     return { json, changed: false, applied: [] }
   }
 
@@ -524,6 +592,22 @@ export function migrateLegacyConfigShape(json: unknown): MigrationResult {
       next.permissions = perms
     }
     applied.push({ kind: 'strip-permissions-gate-channel-respond' })
+  }
+  if (hasLegacyModel) {
+    const ref = next.model as string
+    delete next.model
+    next.models = { default: ref }
+    applied.push({ kind: 'model-to-models', ref })
+  } else if (hasStaleModelAlongsideModels) {
+    // `models` wins (per the same precedence rule as dockerfile/gitignore), but
+    // the drop is still a tracked migration step so the disk rewrite gets a
+    // commit instead of silently dirtying the worktree. Without this, the
+    // file would be rewritten by persistMigratedConfig and no commit would
+    // fire (buildConfigMigrationCommitMessage returns null for empty applied
+    // lists), contradicting the invariant in persistMigratedConfig's comment.
+    const ref = typeof next.model === 'string' ? next.model : ''
+    delete next.model
+    applied.push({ kind: 'drop-stale-model', ref })
   }
   return { json: next, changed: true, applied }
 }
@@ -573,6 +657,10 @@ function shortStepLabel(step: MigrationStep): string {
       return 'lift channels.<adapter>.allow[] → roles.member.match[]'
     case 'strip-permissions-gate-channel-respond':
       return 'drop permissions.gateChannelRespond'
+    case 'model-to-models':
+      return 'lift model → models.default'
+    case 'drop-stale-model':
+      return 'drop stale legacy model alongside models'
   }
 }
 
@@ -590,6 +678,12 @@ function describeStep(step: MigrationStep): string {
     }
     case 'strip-permissions-gate-channel-respond':
       return 'drop permissions.gateChannelRespond (removed key)'
+    case 'model-to-models':
+      return `lift top-level model into models.default: ${step.ref}`
+    case 'drop-stale-model':
+      return step.ref !== ''
+        ? `drop stale top-level model (${step.ref}) — models block takes precedence`
+        : 'drop stale top-level model — models block takes precedence'
   }
 }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -12,10 +12,12 @@ export {
   loadConfigSync,
   loadPluginConfigsSync,
   migrateLegacyConfigShape,
+  modelsSchema,
   mountSchema,
   portForwardSchema,
   reloadConfig,
   resolveModel,
+  resolveProfile,
   validateConfig,
   validateMount,
   type Config,
@@ -27,8 +29,10 @@ export {
   type GitignoreConfig,
   type MigrationResult,
   type MigrationStep,
+  type Models,
   type Mount,
   type PortForward,
+  type ResolvedProfile,
   type ValidateConfigResult,
 } from './config'
 export { type KnownModelRef, type KnownProviderId } from './providers'

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -22,8 +22,9 @@ type KnownProvider = {
 }
 
 // Curated allowlist of providers + models that are wired into the agent
-// runtime. The values here back the Zod enum on `configSchema.model`, so any
-// model the user can put in `typeclaw.json` MUST appear here verbatim. The
+// runtime. The values here back the Zod enum on every entry in
+// `configSchema.models`, so any model the user can put in `typeclaw.json`
+// (under any profile name) MUST appear here verbatim. The
 // init-time picker may surface additional models from models.dev, but it
 // resolves them through this list before scaffolding (anything missing falls
 // back to a curated default).

--- a/src/config/reloadable.test.ts
+++ b/src/config/reloadable.test.ts
@@ -64,7 +64,10 @@ describe('createConfigReloadable', () => {
     const reloadable = createConfigReloadable({ cwd })
     await reloadable.reload()
 
-    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: 'not-a-known-model', port: 9999 }))
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({ models: { default: 'not-a-known-model' }, port: 9999 }),
+    )
     const result = await reloadable.reload()
 
     expect(result.ok).toBe(false)

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -72,7 +72,7 @@ type ScaffoldedConfig = {
 async function writeTypeclawConfig(dir: string, overrides: ScaffoldedConfig = {}): Promise<void> {
   const config = {
     $schema: './node_modules/typeclaw/typeclaw.schema.json',
-    model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+    models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
     mounts: overrides.mounts ?? [],
     ...(overrides.dockerfile ? { dockerfile: overrides.dockerfile } : {}),
     ...(overrides.gitignore ? { gitignore: overrides.gitignore } : {}),
@@ -428,7 +428,7 @@ describe('planStart mounts', () => {
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     await writeFile(
       join(root, 'typeclaw.json'),
-      `${JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })}\n`,
+      `${JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } })}\n`,
     )
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
@@ -1416,7 +1416,7 @@ describe('start (composition)', () => {
       join(root, 'typeclaw.json'),
       `${JSON.stringify(
         {
-          model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+          models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
           channels: { 'slack-bot': { allow: ['team:T0123'] } },
         },
         null,
@@ -1464,7 +1464,7 @@ describe('start (composition)', () => {
       join(root, 'typeclaw.json'),
       `${JSON.stringify(
         {
-          model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+          models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
           roles: { member: { match: ['slack:T0123'] } },
         },
         null,
@@ -1490,6 +1490,42 @@ describe('start (composition)', () => {
     expect(result.ok).toBe(true)
     const headAfter = await runGit(root, ['rev-parse', 'HEAD'])
     expect(headAfter).toBe(headBefore)
+  })
+
+  test('start auto-commits the typeclaw.json model→models.default migration (multi-model regression)', async () => {
+    // given: an agent folder with the legacy top-level `model` key, already committed
+    await gitInit(root)
+    await writeFile(join(root, '.gitignore'), buildGitignore())
+    await writeFile(join(root, 'Dockerfile'), buildDockerfile())
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeFile(
+      join(root, 'typeclaw.json'),
+      `${JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' }, null, 2)}\n`,
+    )
+    await runGit(root, ['add', '.gitignore', 'package.json', 'packages/.gitkeep', 'typeclaw.json'])
+    await runGit(root, ['commit', '-m', 'initial'])
+    const headBefore = await runGit(root, ['rev-parse', 'HEAD'])
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    const subjects = (await runGit(root, ['log', '--format=%s'])).split('\n')
+    expect(subjects).toContain('typeclaw.json: lift model → models.default')
+    const headAfter = await runGit(root, ['rev-parse', 'HEAD'])
+    expect(headAfter).not.toBe(headBefore)
+    const onDisk = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8'))
+    expect(onDisk).not.toHaveProperty('model')
+    expect(onDisk.models).toEqual({ default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
+    const tracked = JSON.parse(await runGit(root, ['show', 'HEAD:typeclaw.json']))
+    expect(tracked).toEqual(onDisk)
   })
 
   test('auto-commits bun.lock drift on start (e.g. after a typeclaw CLI upgrade rewrote it)', async () => {

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -35,6 +35,7 @@ export function buildStaticChecks(opts: { dockerExec?: DockerExec } = {}): Docto
     agentFolderNodeModules(),
     agentFolderGitRepo(),
     configValid(),
+    configBundledProfiles(),
     hostdHomeWritable(),
     hostdReachable(),
     hostdRegistration(),
@@ -209,6 +210,55 @@ function configValid(): DoctorCheck {
         status: 'error',
         message: result.reason,
         fix: { description: 'Edit typeclaw.json to resolve the validation error above.' },
+      }
+    },
+  }
+}
+
+// Warns (not errors) when a model profile that a bundled subagent prefers is
+// absent from `models`. Bundled subagents fall back to `default` silently
+// today, but the operator likely declared a `fast`/`deep`/`vision` model in
+// the design discussion's tier scheme expecting the bundled subagents to
+// pick them up. This check surfaces the gap once at `typeclaw doctor` time
+// instead of leaving it buried in container logs (where the rate-limited
+// fallback warning lives).
+//
+// We deliberately limit this to known bundled profiles (memory-logger=fast,
+// dreaming=deep, multimodal-looker=vision). Plugin-contributed subagents
+// would require loading the plugin registry — a heavyweight async path
+// that doesn't belong in doctor's static check surface.
+const BUNDLED_PROFILES: ReadonlyArray<{ profile: string; subagent: string }> = [
+  { profile: 'fast', subagent: 'memory-logger' },
+  { profile: 'deep', subagent: 'dreaming' },
+  { profile: 'vision', subagent: 'multimodal-looker (via look_at tool)' },
+]
+
+function configBundledProfiles(): DoctorCheck {
+  return {
+    name: 'config.bundled-profiles',
+    category: 'config',
+    description: 'bundled subagent profiles (`fast`, `deep`, `vision`) declared in models',
+    applies: (ctx) => ctx.hasAgentFolder,
+    async run(ctx) {
+      const validation = validateConfig(ctx.cwd)
+      if (!validation.ok) {
+        return { status: 'ok', message: 'skipped (config.valid will report the underlying error)' }
+      }
+      const config = loadConfigSync(ctx.cwd)
+      const declared = new Set(Object.keys(config.models))
+      const missing = BUNDLED_PROFILES.filter((p) => !declared.has(p.profile))
+      if (missing.length === 0) {
+        return { status: 'ok', message: 'all bundled subagent profiles declared' }
+      }
+      return {
+        status: 'warning',
+        message: `${missing.length} bundled profile(s) missing; will fall back to \`default\``,
+        details: missing.map(
+          (m) => `${m.profile}: used by ${m.subagent}; declare \`models.${m.profile}\` in typeclaw.json to override`,
+        ),
+        fix: {
+          description: 'Add the missing profile(s) under `models` in typeclaw.json. See the typeclaw-config skill.',
+        },
       }
     },
   }

--- a/src/doctor/config-bundled-profiles.test.ts
+++ b/src/doctor/config-bundled-profiles.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { buildStaticChecks } from './checks'
+import type { CheckContext } from './types'
+
+function findCheck() {
+  const checks = buildStaticChecks()
+  const check = checks.find((c) => c.name === 'config.bundled-profiles')
+  if (check === undefined) throw new Error('config.bundled-profiles check not registered')
+  return check
+}
+
+function makeCtx(cwd: string): CheckContext {
+  return { cwd, hasAgentFolder: true }
+}
+
+describe('config.bundled-profiles doctor check', () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-doctor-profiles-'))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  test('ok when fast/deep/vision are all declared', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        models: {
+          default: 'openai/gpt-5.4-nano',
+          fast: 'openai/gpt-5.4-nano',
+          deep: 'openai/gpt-5.5',
+          vision: 'openai/gpt-5.4',
+        },
+      }),
+    )
+    const result = await findCheck().run(makeCtx(cwd))
+    expect(result.status).toBe('ok')
+  })
+
+  test('warns when fast is missing', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({ models: { default: 'openai/gpt-5.4-nano', deep: 'openai/gpt-5.5', vision: 'openai/gpt-5.4' } }),
+    )
+    const result = await findCheck().run(makeCtx(cwd))
+    expect(result.status).toBe('warning')
+    expect(result.details?.some((d) => d.includes('fast:'))).toBe(true)
+    expect(result.details?.some((d) => d.includes('memory-logger'))).toBe(true)
+  })
+
+  test('warns when all three bundled profiles missing (only default)', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'openai/gpt-5.4-nano' } }))
+    const result = await findCheck().run(makeCtx(cwd))
+    expect(result.status).toBe('warning')
+    expect(result.message).toContain('3 bundled profile')
+    const detailKeys = result.details?.map((d) => d.split(':')[0]) ?? []
+    expect(detailKeys.sort()).toEqual(['deep', 'fast', 'vision'])
+  })
+
+  test('skips when validateConfig fails (config.valid will report the underlying error)', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), '{ not json')
+    const result = await findCheck().run(makeCtx(cwd))
+    expect(result.status).toBe('ok')
+    expect(result.message).toContain('skipped')
+  })
+})

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -713,14 +713,14 @@ describe('scaffold', () => {
     expect(existsSync(join(root, 'memory'))).toBe(false)
   })
 
-  test('writes typeclaw.json with only $schema and model (no defaults duplicated)', async () => {
+  test('writes typeclaw.json with only $schema and models.default (no defaults duplicated)', async () => {
     await scaffold(root)
 
     const raw = await readFile(join(root, 'typeclaw.json'), 'utf8')
     expect(raw.endsWith('\n')).toBe(true)
     expect(JSON.parse(raw)).toEqual({
       $schema: './node_modules/typeclaw/typeclaw.schema.json',
-      model: 'openai/gpt-5.4-nano',
+      models: { default: 'openai/gpt-5.4-nano' },
     })
   })
 

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -383,7 +383,7 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   // users would feel obligated to maintain values they never set.
   const config: Record<string, unknown> = {
     $schema: './node_modules/typeclaw/typeclaw.schema.json',
-    model: options.model ?? DEFAULT_MODEL_REF,
+    models: { default: options.model ?? DEFAULT_MODEL_REF },
   }
   const channels: Record<string, Record<string, never>> = {}
   if (options.withDiscord) channels['discord-bot'] = {}

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -41,6 +41,13 @@ export type RunSession = (override?: { userPrompt?: string }) => Promise<void>
 
 export type Subagent<P = unknown> = {
   systemPrompt: string
+  // Model profile this subagent prefers. Resolved against `models` in
+  // typeclaw.json at session construction. Unknown profile names fall back to
+  // `default` with a warning. Well-known names: `default`, `fast`, `deep`,
+  // `vision`. Subagents that want a specific tier (e.g. memory-logger wants
+  // `fast`, dreaming wants `deep`) declare it here so the user only has to
+  // map tier → model in config rather than wire each subagent individually.
+  profile?: string
   tools?: BuiltinToolRef[]
   customTools?: Tool<any>[]
   payloadSchema?: z.ZodType<P>

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -246,7 +246,7 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
     try {
       await Bun.write(
         join(agentDir, 'typeclaw.json'),
-        JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' }),
+        JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
       )
       const factoryCalls: Array<{ cwd: string; file: CronFile }> = []
       const createSchedulerFor: SchedulerFactory = (opts) => {
@@ -275,7 +275,7 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
       await Bun.write(
         join(agentDir, 'typeclaw.json'),
         JSON.stringify({
-          model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+          models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
           memory: { idleMs: 30000, dreaming: { schedule: '0 4 * * *' } },
         }),
       )
@@ -312,7 +312,7 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
       await Bun.write(
         join(agentDir, 'typeclaw.json'),
         JSON.stringify({
-          model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+          models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
           memory: { idleMs: 30000, dreaming: { schedule: '0 4 * * *' } },
         }),
       )
@@ -345,7 +345,7 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
       await Bun.write(
         join(agentDir, 'typeclaw.json'),
         JSON.stringify({
-          model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+          models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
           memory: { idleMs: 30000, dreaming: { schedule: '0 4 * * *' } },
         }),
       )

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -185,6 +185,7 @@ export async function startAgent({
           ...(entry.pluginSubagent.customTools ? { customTools: entry.pluginSubagent.customTools } : {}),
           toolNamePrefix: `__plugin_${entry.pluginName}_${entry.subagentName}`,
         },
+        ...(entry.pluginSubagent.profile !== undefined ? { profile: entry.pluginSubagent.profile } : {}),
       })
       return {
         ...created,

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -34,7 +34,7 @@ describe('startAgent + plugin loading', () => {
     await writeFile(
       join(agentDir, 'typeclaw.json'),
       JSON.stringify({
-        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
         plugins: ['./plugin.ts'],
       }),
     )
@@ -62,7 +62,7 @@ describe('startAgent + plugin loading', () => {
     await writeFile(
       join(agentDir, 'typeclaw.json'),
       JSON.stringify({
-        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
         plugins: ['./plugin.ts'],
       }),
     )
@@ -86,7 +86,7 @@ describe('startAgent + plugin loading', () => {
     await writeFile(
       join(agentDir, 'typeclaw.json'),
       JSON.stringify({
-        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
         plugins: ['./plugin.ts'],
       }),
     )
@@ -134,7 +134,7 @@ export default {
     await writeFile(
       join(agentDir, 'typeclaw.json'),
       JSON.stringify({
-        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
         plugins: ['./plugin.ts'],
       }),
     )
@@ -157,7 +157,7 @@ export default {
     agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
     await writeFile(
       join(agentDir, 'typeclaw.json'),
-      JSON.stringify({ model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' }),
+      JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
     )
 
     running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })
@@ -177,7 +177,7 @@ export default {
     await writeFile(
       join(agentDir, 'typeclaw.json'),
       JSON.stringify({
-        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
         plugins: ['./plugin.ts'],
       }),
     )
@@ -208,7 +208,7 @@ export default {
     await writeFile(
       join(agentDir, 'typeclaw.json'),
       JSON.stringify({
-        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
         plugins: ['./plugin.ts'],
       }),
     )
@@ -288,7 +288,7 @@ export default {
     await writeFile(
       join(agentDir, 'typeclaw.json'),
       JSON.stringify({
-        model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
         plugins: ['./plugin.ts'],
         plugin: { magicNumber: 7 },
       }),

--- a/src/skills/typeclaw-config/SKILL.md
+++ b/src/skills/typeclaw-config/SKILL.md
@@ -54,7 +54,7 @@ You yourself cannot run `typeclaw restart` — that is a host-stage command and 
 
 > **Top-level keys not in this table are not "ignored unknowns" anymore** — they are reserved for **plugin config blocks**. The schema's `catchall(z.unknown())` preserves them, and the plugin loader hands each block to its owning plugin's `configSchema` for validation. The bundled memory plugin owns `memory` at the top level — see the `typeclaw-memory` skill for that block's semantics. Do not write a top-level key unless you know which plugin owns it.
 
-Within the well-known ten (`$schema`, `port`, `model`, `mounts`, `plugins`, `alias`, `channels`, `portForward`, `docker`, `git`), **fields the schema doesn't predeclare are silently dropped**. Legacy top-level `dockerfile` and `gitignore` keys are migrated to `docker.file` / `git.ignore` automatically the first time the CLI loads the file — see **Legacy migration** below. Do not invent runtime fields like `provider`, `apiKey`, `temperature`, `maxTokens`, `systemPrompt`, `tools`, `timeout`, etc. — those are not plugin blocks, they are imaginary. If the user asks for one, say it is not yet supported and (if it makes sense) suggest they file a request.
+Within the well-known ten (`$schema`, `port`, `models`, `mounts`, `plugins`, `alias`, `channels`, `portForward`, `docker`, `git`), **fields the schema doesn't predeclare are silently dropped**. Legacy top-level `dockerfile` and `gitignore` keys are migrated to `docker.file` / `git.ignore` automatically the first time the CLI loads the file — see **Legacy migration** below. Do not invent runtime fields like `provider`, `apiKey`, `temperature`, `maxTokens`, `systemPrompt`, `tools`, `timeout`, etc. — those are not plugin blocks, they are imaginary. If the user asks for one, say it is not yet supported and (if it makes sense) suggest they file a request.
 
 A scaffolded `typeclaw.json` looks like:
 
@@ -491,7 +491,7 @@ What this means for you:
 
 ## Plugin config blocks
 
-Top-level keys in `typeclaw.json` that are **not** in the well-known ten (`$schema`, `port`, `model`, `mounts`, `plugins`, `alias`, `channels`, `portForward`, `docker`, `git`) are treated as plugin config blocks. The schema preserves them via `catchall(z.unknown())`, and `extractPluginConfigs` hands each block to the owning plugin's `configSchema` for validation at boot.
+Top-level keys in `typeclaw.json` that are **not** in the well-known ten (`$schema`, `port`, `models`, `mounts`, `plugins`, `alias`, `channels`, `portForward`, `docker`, `git`) are treated as plugin config blocks. The schema preserves them via `catchall(z.unknown())`, and `extractPluginConfigs` hands each block to the owning plugin's `configSchema` for validation at boot.
 
 This skill does **not** document individual plugin blocks. For schema, defaults, and reload semantics of a specific plugin's config, defer to that plugin's own skill:
 


### PR DESCRIPTION
## Summary

Replaces the single `model` field in `typeclaw.json` with a `models` profile map and adds a built-in `look_at` tool that routes images through a sandboxed vision subagent.

```jsonc
"models": {
  "default": "openai/gpt-5.4-mini",  // required, powers the main session
  "fast":    "openai/gpt-5.4-nano",  // memory-logger, frequent low-cost work
  "deep":    "openai/gpt-5.5",       // dreaming, once-daily consolidation
  "vision":  "openai/gpt-5.4"        // multimodal-looker via the look_at tool
}
```

- `default` is required; every other profile is optional.
- Subagents declare `profile?: string`. The runtime resolves it via `resolveProfile(models, name)` at session construction.
- Unknown profile names fall back to `default` with a one-time warning, rate-limited per `(profile, ref)` pair per process.
- Auth becomes lazy per-provider via `getAuthFor(providerId)`. A profile referencing a provider the user hasn't credentialed only fails when that profile is actually used. `getAuth()` is kept as a back-compat shim resolving to the `default` profile's provider.
- Bundled subagents annotated: `memory-logger` → `fast`, `dreaming` → `deep`.
- `FIELD_EFFECTS.models = 'applied'` (live-reloadable, same semantics as the old `model` field).

## The `look_at` tool

A built-in core tool that spawns a transient `multimodal-looker` session under `profile: 'vision'`. Image bytes never enter the main session's context — only the subagent's text response comes back.

- `look_at(images, prompt?)` accepts images as `url` (https), `path` (absolute filesystem), or `data`+`mimeType` (base64).
- With `prompt`: subagent answers the question. Without: faithful description.
- **Recursion guard + sandbox**: the looker is spawned with `tools: []` AND `customTools: []`, so it has zero tools — no recursion into `look_at`, no `read`/`bash`/`edit`/`write`. It can only produce text.
- **URL fetch hardening**: 30s timeout (merged with caller signal), 20 MB byte cap enforced via streaming reader (defeats lying Content-Length headers).
- **Image-source validation**: each image entry must specify exactly one of `url` / `path` / `data`+`mimeType`. Mixed shapes get a clean error, not silent first-wins.
- **File-path safety**: extension-checked against `.png`/`.jpg`/`.jpeg`/`.gif`/`.webp` before any read; non-image extensions never hit `readFileSync`.
- **Base64 MIME parity**: base64 inputs require `image/*` mimeType to match URL-fetch behavior.

## Auto-migration

Two new steps in `migrateLegacyConfigShape`:

1. **`model-to-models`** — lifts legacy top-level `model` into `models.default`. Written back to disk and committed via `persistMigratedConfig` with subject `typeclaw.json: lift model → models.default`.
2. **`drop-stale-model`** — handles the edge case where both `model` and `models` coexist (user hand-edited after auto-migration but forgot to delete the legacy key). The legacy field is dropped with its own tracked commit so the rewrite doesn't silently dirty the worktree.

Migrations run from every entry point that reads `typeclaw.json` (host CLI, hostd, container runtime).

## Doctor check

New `config.bundled-profiles` check warns (not errors) when one of `fast`, `deep`, or `vision` is missing from `models`. Surfaces the gap at `typeclaw doctor` time instead of leaving it buried in container logs.

## Self-review findings (addressed in this PR)

Before opening for human review, I ran the work through a focused self-review (Oracle + 2 Explore agents). Material findings were fixed in this PR rather than deferred:

| Finding | Severity | Fix |
|---|---|---|
| Looker session inherited pi-coding-agent's base tools (`read`/`bash`/`edit`/`write`) — only `customTools: []` was passed, leaving the session with file/shell access | 🔴 Bug | Pass `tools: []` alongside `customTools: []` |
| `model`+`models` coexistence rewrote `typeclaw.json` but produced no migration step, so `persistMigratedConfig` wrote to disk without a commit (silently dirty worktree) | 🔴 Bug | Added `drop-stale-model` migration step with its own commit subject |
| `look_at` tool schema accepted multiple image sources (`url` + `path`) and silently picked first | 🟡 Bug | Explicit exactly-one-source validation in `toImageInput` |
| Profile-fallback warning fired on every subagent spawn (would spam logs) | 🟠 Design | Rate-limit by `(profile, ref)` pair per process |
| URL image fetch had no timeout or size cap | 🟠 Design | 30s timeout + 20 MB streaming size cap |
| `getAuthFor` had zero direct tests (only the back-compat `getAuth` shim was covered) | 🟡 Coverage | Added 4 direct tests for per-provider caching, isolation, and shim equivalence |
| `look_at` tool had zero validation tests | 🟡 Coverage | Added 9 tests covering exactly-one-source rule, base64 MIME check, file-path safety |
| 13 test files wrote legacy `model:` in fixtures, exercising the migration path instead of the new schema | 🟡 Coverage | Bulk-updated fixtures to use `models: { default: ... }`; left explicit migration-regression tests on the legacy shape |
| Stale doc references in `typeclaw-config` SKILL.md and `providers.ts` comment | 🟡 Docs | Updated |

## What's NOT in this PR (deferred to follow-ups)

Per the design discussion:

- **Per-profile fallback chains.** Values are single `KnownModelRef`, not `KnownModelRef | KnownModelRef[]`. No construction-time cross-model fallback within a profile.
- **Same-model retry+backoff wrapper.** Orthogonal feature.
- **Generic `spawn_subagent` tool with explicit `profile` arg.** Static subagent declarations cover every bundled subagent today.

## Commits (3, split for review)

1. **`Replace single \`model\` with \`models\` profile map across the runtime`** — schema rename, migration, auth refactor, session profile threading, bundled subagent annotations, test-fixture cleanup, doc updates. The schema rename inherently cascades through every consumer of `config.model`; splitting it further produces intermediate states that fail typecheck or tests.
2. **`Add look_at core tool that routes images through a vision subagent`** — new `src/agent/multimodal/` module (looker subagent system prompt, image resolution, the tool itself) plus wiring into the agent's `customSystemTools` list.
3. **`Add config.bundled-profiles doctor check`** — surfaces missing bundled profiles at `typeclaw doctor` time.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 8 pre-existing warnings, 0 errors, 0 new warnings
- [x] `bun run format`
- [x] `bun test` — **3298 pass, 0 fail** (up from 3257 on main; +41 new tests across schema/profile resolution, auth, multimodal, doctor check, migration commits)
- [ ] Manual: run `typeclaw start` against a legacy agent folder; verify the `lift model → models.default` commit lands and the agent boots cleanly.
- [ ] Manual: edit `typeclaw.json` to declare `models.vision`; in the TUI, paste an image URL and ask the agent to use `look_at`; verify the looker routes to the vision model and returns text.
- [ ] Manual: configure a `models.fast` that points at a provider with no credentials; verify `typeclaw doctor` flags `config.bundled-profiles` as a warning AND that an actual memory-logger spawn fails cleanly with the per-provider auth error.

## Migration footprint for existing users

Zero manual work. The first `typeclaw start` (or any host-side path that reads `typeclaw.json`) auto-migrates the legacy `model` field and commits the rewrite. Existing agents work unchanged.