### PR TITLE
Let ESC walk back to the previous step during `typeclaw init`

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 
-import { KNOWN_PROVIDERS } from '@/config/providers'
+import { KNOWN_PROVIDERS, type KnownProviderId } from '@/config/providers'
+import type { LLMAuth } from '@/init'
+import type { ModelOption } from '@/init/models-dev'
 
-import { decideExistingApiKeyReuse } from './init'
+import { collectWizardInputs, decideExistingApiKeyReuse, type WizardPrompts } from './init'
 
 describe('decideExistingApiKeyReuse', () => {
   test('reuses an existing API key when the user confirms', async () => {
@@ -45,5 +47,348 @@ describe('decideExistingApiKeyReuse', () => {
 
     expect(decision).toBe('prompt')
     expect(asked).toBe(false)
+  })
+})
+
+describe('collectWizardInputs back-aware flow', () => {
+  const fireworksModel: ModelOption = {
+    providerId: 'fireworks',
+    providerName: 'Fireworks',
+    modelId: 'accounts/fireworks/routers/kimi-k2p6-turbo',
+    modelName: 'Kimi K2.6 Turbo',
+    ref: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+    contextWindow: 256000,
+    reasoning: true,
+    curated: true,
+  }
+  const openaiModel: ModelOption = {
+    providerId: 'openai',
+    providerName: 'OpenAI',
+    modelId: 'gpt-5.4-nano',
+    modelName: 'GPT-5.4 Nano',
+    ref: 'openai/gpt-5.4-nano',
+    contextWindow: 128000,
+    reasoning: false,
+    curated: true,
+  }
+  const codexModel: ModelOption = {
+    providerId: 'openai-codex',
+    providerName: 'OpenAI Codex',
+    modelId: 'gpt-5.4-mini',
+    modelName: 'GPT-5.4 Mini',
+    ref: 'openai-codex/gpt-5.4-mini',
+    contextWindow: 128000,
+    reasoning: true,
+    curated: true,
+  }
+
+  function makeRecorder(): { steps: string[]; record: (name: string) => void } {
+    const steps: string[] = []
+    return { steps, record: (name) => steps.push(name) }
+  }
+
+  function makePrompts(overrides: Partial<WizardPrompts> = {}): WizardPrompts {
+    return {
+      loadCatalog: async () => ({ options: [fireworksModel, openaiModel, codexModel], source: 'curated' }),
+      readExistingApiKey: async () => null,
+      pickProvider: async () => ({ kind: 'value', value: 'fireworks' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: fireworksModel }),
+      askReuseExistingKey: async () => ({ kind: 'value', value: 'prompt' }),
+      pickAuthMethod: async () => ({ kind: 'value', value: 'api-key' }),
+      askApiKey: async () => ({ kind: 'value', value: 'sk_test' }),
+      pickChannel: async () => ({ kind: 'value', value: 'none' }),
+      runChannelFlow: async () => ({ kind: 'value', value: {} }),
+      buildOAuthAuth: () => ({ kind: 'oauth', runLogin: async () => ({ ok: true }) }) as LLMAuth,
+      ...overrides,
+    }
+  }
+
+  test('happy path: walks every step in order and returns inputs', async () => {
+    const { steps, record } = makeRecorder()
+    const prompts = makePrompts({
+      loadCatalog: async () => {
+        record('load-catalog')
+        return { options: [fireworksModel], source: 'curated' }
+      },
+      pickProvider: async () => {
+        record('pick-provider')
+        return { kind: 'value', value: 'fireworks' as KnownProviderId }
+      },
+      pickModel: async () => {
+        record('pick-model')
+        return { kind: 'value', value: fireworksModel }
+      },
+      askReuseExistingKey: async () => {
+        record('reuse-existing-key')
+        return { kind: 'value', value: 'prompt' }
+      },
+      pickAuthMethod: async () => {
+        record('pick-auth-method')
+        return { kind: 'value', value: 'api-key' }
+      },
+      askApiKey: async () => {
+        record('enter-api-key')
+        return { kind: 'value', value: 'fw_test' }
+      },
+      pickChannel: async () => {
+        record('pick-channel')
+        return { kind: 'value', value: 'none' }
+      },
+      runChannelFlow: async () => {
+        record('channel-flow')
+        return { kind: 'value', value: {} }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(steps).toEqual([
+      'load-catalog',
+      'pick-provider',
+      'pick-model',
+      'reuse-existing-key',
+      'pick-auth-method',
+      'enter-api-key',
+      'pick-channel',
+      'channel-flow',
+    ])
+    expect(result).not.toBeNull()
+    expect(result!.model).toBe(fireworksModel)
+    expect(result!.llmAuth).toEqual({ kind: 'api-key', apiKey: 'fw_test' })
+    expect(result!.channelSecrets).toEqual({})
+  })
+
+  test('back from pick-provider aborts (returns null)', async () => {
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'back' }),
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(result).toBeNull()
+  })
+
+  test('back from pick-model returns to pick-provider, then advances', async () => {
+    const calls: string[] = []
+    let modelBacked = false
+    const prompts = makePrompts({
+      pickProvider: async () => {
+        calls.push('pick-provider')
+        return { kind: 'value', value: 'fireworks' as KnownProviderId }
+      },
+      pickModel: async () => {
+        calls.push('pick-model')
+        if (!modelBacked) {
+          modelBacked = true
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: fireworksModel }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual(['pick-provider', 'pick-model', 'pick-provider', 'pick-model'])
+    expect(result).not.toBeNull()
+  })
+
+  test('back from pick-channel returns to enter-api-key when api-key was chosen', async () => {
+    const calls: string[] = []
+    let channelBacked = false
+    const prompts = makePrompts({
+      pickAuthMethod: async () => {
+        calls.push('pick-auth-method')
+        return { kind: 'value', value: 'api-key' }
+      },
+      askApiKey: async () => {
+        calls.push('enter-api-key')
+        return { kind: 'value', value: 'sk_test' }
+      },
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        if (!channelBacked) {
+          channelBacked = true
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: 'none' }
+      },
+    })
+
+    await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual(['pick-auth-method', 'enter-api-key', 'pick-channel', 'enter-api-key', 'pick-channel'])
+  })
+
+  test('back from pick-channel returns to pick-auth-method when oauth was chosen', async () => {
+    const calls: string[] = []
+    let channelBacked = false
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: codexModel }),
+      pickAuthMethod: async () => {
+        calls.push('pick-auth-method')
+        return { kind: 'value', value: 'oauth' }
+      },
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        if (!channelBacked) {
+          channelBacked = true
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: 'none' }
+      },
+    })
+
+    await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual(['pick-auth-method', 'pick-channel', 'pick-auth-method', 'pick-channel'])
+  })
+
+  test('back from pick-channel returns to reuse-existing-key when reuse was chosen', async () => {
+    const calls: string[] = []
+    let channelBacked = false
+    const prompts = makePrompts({
+      readExistingApiKey: async () => 'sk_existing',
+      askReuseExistingKey: async () => {
+        calls.push('reuse-existing-key')
+        return { kind: 'value', value: 'reuse' }
+      },
+      pickAuthMethod: async () => {
+        calls.push('pick-auth-method')
+        return { kind: 'value', value: 'api-key' }
+      },
+      askApiKey: async () => {
+        calls.push('enter-api-key')
+        return { kind: 'value', value: 'fw_test' }
+      },
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        if (!channelBacked) {
+          channelBacked = true
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: 'none' }
+      },
+    })
+
+    await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual(['reuse-existing-key', 'pick-channel', 'reuse-existing-key', 'pick-channel'])
+    expect(calls).not.toContain('pick-auth-method')
+    expect(calls).not.toContain('enter-api-key')
+  })
+
+  test('changing provider clears the previously picked model so it is re-asked fresh', async () => {
+    let providerCallCount = 0
+    let reuseBacked = false
+    const modelInitials: (string | undefined)[] = []
+    const prompts = makePrompts({
+      pickProvider: async () => {
+        providerCallCount += 1
+        return { kind: 'value', value: (providerCallCount === 1 ? 'fireworks' : 'openai') as KnownProviderId }
+      },
+      pickModel: async (_options, providerId, initial) => {
+        modelInitials.push(initial)
+        return {
+          kind: 'value',
+          value: providerId === 'fireworks' ? fireworksModel : openaiModel,
+        }
+      },
+      askReuseExistingKey: async () => {
+        if (!reuseBacked) {
+          reuseBacked = true
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: 'prompt' }
+      },
+    })
+
+    await collectWizardInputs('/agent', prompts)
+
+    expect(providerCallCount).toBe(1)
+    expect(modelInitials.length).toBeGreaterThanOrEqual(2)
+    expect(modelInitials[1]).toBe(fireworksModel.ref)
+  })
+
+  test('picking a different provider on retry discards the prior model selection', async () => {
+    let providerCallCount = 0
+    let modelBackedOnce = false
+    const modelInitials: (string | undefined)[] = []
+    const prompts = makePrompts({
+      pickProvider: async () => {
+        providerCallCount += 1
+        return { kind: 'value', value: (providerCallCount === 1 ? 'fireworks' : 'openai') as KnownProviderId }
+      },
+      pickModel: async (_options, providerId, initial) => {
+        modelInitials.push(initial)
+        if (providerId === 'fireworks' && !modelBackedOnce) {
+          return { kind: 'value', value: fireworksModel }
+        }
+        if (providerId === 'fireworks') {
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: openaiModel }
+      },
+      askReuseExistingKey: async () => {
+        if (!modelBackedOnce) {
+          modelBackedOnce = true
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: 'prompt' }
+      },
+    })
+
+    await collectWizardInputs('/agent', prompts)
+
+    expect(providerCallCount).toBe(2)
+    expect(modelInitials[modelInitials.length - 1]).toBeUndefined()
+  })
+
+  test('catalog is loaded once even when stepping back across providers', async () => {
+    let catalogLoads = 0
+    let providerCallCount = 0
+    const prompts = makePrompts({
+      loadCatalog: async () => {
+        catalogLoads += 1
+        return { options: [fireworksModel], source: 'curated' }
+      },
+      pickProvider: async () => {
+        providerCallCount += 1
+        return { kind: 'value', value: 'fireworks' as KnownProviderId }
+      },
+      pickModel: async () => {
+        if (providerCallCount === 1) return { kind: 'back' }
+        return { kind: 'value', value: fireworksModel }
+      },
+    })
+
+    await collectWizardInputs('/agent', prompts)
+
+    expect(catalogLoads).toBe(1)
+    expect(providerCallCount).toBe(2)
+  })
+
+  test('back from channel-flow returns to pick-channel', async () => {
+    const calls: string[] = []
+    let flowBacked = false
+    const prompts = makePrompts({
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        return { kind: 'value', value: 'discord' }
+      },
+      runChannelFlow: async () => {
+        calls.push('channel-flow')
+        if (!flowBacked) {
+          flowBacked = true
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: { discordBotToken: 'tok' } }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual(['pick-channel', 'channel-flow', 'pick-channel', 'channel-flow'])
+    expect(result!.channelSecrets).toEqual({ discordBotToken: 'tok' })
   })
 })

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -26,6 +26,17 @@ import { makeOAuthLoginRunner } from '@/init/oauth-login'
 
 import { c, done, errorLine } from './ui'
 
+// ESC and Ctrl+C both produce clack's cancel symbol (the keypress layer
+// aliases both to the same "cancel" action — there's no way to tell them
+// apart through @clack/prompts). The wizard treats every cancel as "go
+// back to the previous step": each step that runs an interactive prompt
+// either advances with a value or rewinds. Rewinding past the first
+// interactive step aborts the init cleanly. Users who want to abort
+// mid-wizard can hit ESC repeatedly until they're back to the start.
+export type StepResult<T> = { kind: 'value'; value: T } | { kind: 'back' }
+const back = <T>(): StepResult<T> => ({ kind: 'back' })
+const value = <T>(v: T): StepResult<T> => ({ kind: 'value', value: v })
+
 export const init = defineCommand({
   meta: {
     name: 'init',
@@ -61,209 +72,17 @@ export const init = defineCommand({
     }
 
     intro('Initializing TypeClaw...')
+    log.info('Press ESC at any prompt to go back to the previous step.')
 
-    const selectedModel = await pickModel()
-    const provider = KNOWN_PROVIDERS[selectedModel.providerId]
-
-    const existingApiKey = await readExistingProviderApiKey(cwd, selectedModel.providerId)
-    const llmAuth = await collectLLMAuth(provider, existingApiKey)
-
-    const channelChoice = await select({
-      message: 'Pick a channel to wire (you can add more later by editing typeclaw.json + secrets.json)',
-      options: [
-        { value: 'slack', label: 'Slack' },
-        { value: 'discord', label: 'Discord' },
-        { value: 'telegram', label: 'Telegram' },
-        { value: 'kakaotalk', label: 'KakaoTalk' },
-        { value: 'none', label: 'Skip — no channel right now' },
-      ],
-      initialValue: 'slack' as const,
-    })
-    if (isCancel(channelChoice)) {
+    const collected = await collectWizardInputs(cwd, defaultWizardPrompts)
+    if (collected === null) {
       cancel('Aborted.')
       process.exit(0)
     }
 
-    let discordBotToken: string | undefined
-    let slackBotToken: string | undefined
-    let slackAppToken: string | undefined
-    let telegramBotToken: string | undefined
-    let kakaotalkEmail: string | undefined
-    let kakaotalkPassword: string | undefined
-
-    if (channelChoice === 'discord') {
-      note(
-        [
-          'https://discord.com/developers/applications',
-          'New Application → Bot tab → Reset Token.',
-          'Enable the MESSAGE CONTENT intent.',
-        ].join('\n'),
-        'Get a Discord bot token',
-      )
-      const token = await password({
-        message: 'Discord bot token',
-        validate: (value) => (value && value.length > 0 ? undefined : 'Token is required'),
-      })
-      if (isCancel(token)) {
-        cancel('Aborted.')
-        process.exit(0)
-      }
-      discordBotToken = token
-    }
-
-    if (channelChoice === 'kakaotalk') {
-      note(
-        [
-          'KakaoTalk authentication uses a personal account, registered as a',
-          'tablet sub-device. Messages will be sent and received under this',
-          'account. Use a non-primary account if possible.',
-          '',
-          'After you submit the password, KakaoTalk may ask you to confirm a',
-          'passcode on your phone. Watch the screen for the code.',
-        ].join('\n'),
-        'About to log in to KakaoTalk',
-      )
-      const email = await text({
-        message: 'KakaoTalk email',
-        validate: (value) => (value && value.length > 0 ? undefined : 'Email is required'),
-      })
-      if (isCancel(email)) {
-        cancel('Aborted.')
-        process.exit(0)
-      }
-      const pwd = await password({
-        message: 'KakaoTalk password',
-        validate: (value) => (value && value.length > 0 ? undefined : 'Password is required'),
-      })
-      if (isCancel(pwd)) {
-        cancel('Aborted.')
-        process.exit(0)
-      }
-      kakaotalkEmail = email
-      kakaotalkPassword = pwd
-    }
-
-    if (channelChoice === 'slack') {
-      note(
-        [
-          '1. https://api.slack.com/apps → Create New App → From a manifest.',
-          '   Pick your workspace, then paste this JSON manifest:',
-          '',
-          '   {',
-          '     "display_information": { "name": "TypeClaw" },',
-          '     "features": {',
-          '       "bot_user": { "display_name": "TypeClaw", "always_online": true }',
-          '     },',
-          '     "oauth_config": {',
-          '       "scopes": {',
-          '         "bot": [',
-          '           "app_mentions:read", "chat:write", "users:read", "files:read",',
-          '           "channels:history", "channels:read",',
-          '           "groups:history",   "groups:read",',
-          '           "im:history",       "im:read",',
-          '           "mpim:history",     "mpim:read"',
-          '         ]',
-          '       }',
-          '     },',
-          '     "settings": {',
-          '       "event_subscriptions": {',
-          '         "bot_events": [',
-          '           "app_mention",',
-          '           "message.channels", "message.groups",',
-          '           "message.im",       "message.mpim"',
-          '         ]',
-          '       },',
-          '       "socket_mode_enabled": true',
-          '     }',
-          '   }',
-          '',
-          '2. Install to Workspace, then OAuth & Permissions →',
-          '   copy the Bot User OAuth Token (xoxb-...).',
-          '3. Basic Information → App-Level Tokens → Generate Token and',
-          '   Scopes, add the connections:write scope, and copy the',
-          '   token (xapp-...). Socket Mode needs this; the manifest',
-          '   cannot grant it.',
-          '4. Invite the bot to any private channel or DM you want it in:',
-          '   /invite @TypeClaw',
-        ].join('\n'),
-        'Get a Slack bot',
-      )
-      const botToken = await password({
-        message: 'Slack bot token (xoxb-...)',
-        validate: (value) =>
-          value && value.length > 0
-            ? value.startsWith('xoxb-')
-              ? undefined
-              : 'Bot token must start with "xoxb-"'
-            : 'Token is required',
-      })
-      if (isCancel(botToken)) {
-        cancel('Aborted.')
-        process.exit(0)
-      }
-      slackBotToken = botToken
-      note(
-        [
-          'Slack does not accept connections:write inside the manifest, so',
-          'this token has to be generated by hand:',
-          '',
-          '1. Basic Information → App-Level Tokens → Generate Token and Scopes.',
-          '2. Token Name: anything (e.g. "socket-mode").',
-          '3. Add Scope → connections:write → Generate.',
-          '4. Copy the xapp-... token shown once on screen.',
-          '   (You cannot retrieve it later — only revoke and regenerate.)',
-        ].join('\n'),
-        'Generate the Slack app-level token',
-      )
-      const appToken = await password({
-        message: 'Slack app-level token (xapp-...) — Socket Mode requires this',
-        validate: (value) =>
-          value && value.length > 0
-            ? value.startsWith('xapp-')
-              ? undefined
-              : 'App-level token must start with "xapp-"'
-            : 'Token is required',
-      })
-      if (isCancel(appToken)) {
-        cancel('Aborted.')
-        process.exit(0)
-      }
-      slackAppToken = appToken
-    }
-
-    if (channelChoice === 'telegram') {
-      note(
-        [
-          'Open Telegram and message @BotFather.',
-          '/newbot → pick a name and username, copy the HTTP API token',
-          '  (looks like 1234567890:ABCdef...).',
-          'In @BotFather: /setprivacy → Disable, so the bot can see group messages.',
-        ].join('\n'),
-        'Get a Telegram bot token',
-      )
-      const token = await password({
-        message: 'Telegram bot token',
-        validate: (value) =>
-          value && value.length > 0
-            ? /^\d+:/.test(value)
-              ? undefined
-              : 'Bot token must look like "<digits>:<secret>" (from @BotFather)'
-            : 'Token is required',
-      })
-      if (isCancel(token)) {
-        cancel('Aborted.')
-        process.exit(0)
-      }
-      telegramBotToken = token
-      note(
-        [
-          'Open https://t.me/<your_bot_username> (the username you picked in /newbot, ends in "bot").',
-          'Tap Start in the chat — the agent will reply once it hatches.',
-          'For groups: add the bot to the group, then @mention it or reply to its messages.',
-        ].join('\n'),
-        'Send your first message',
-      )
-    }
+    const { model, llmAuth, channelSecrets } = collected
+    const { discordBotToken, slackBotToken, slackAppToken, telegramBotToken, kakaotalkEmail, kakaotalkPassword } =
+      channelSecrets
 
     // TODO: add remaining wizard steps from TypeClaw.md once their runtime lands:
     //   - git backup (url + PAT) — Phase 10
@@ -276,7 +95,7 @@ export const init = defineCommand({
       await runInit({
         cwd,
         llmAuth,
-        model: selectedModel.ref,
+        model: model.ref,
         cliEntry: process.argv[1],
         ...(discordBotToken !== undefined ? { discordBotToken } : {}),
         ...(slackBotToken !== undefined ? { slackBotToken, slackAppToken } : {}),
@@ -326,6 +145,508 @@ export const init = defineCommand({
     }
   },
 })
+
+interface WizardState {
+  catalog?: { options: ModelOption[]; source: 'models.dev' | 'curated'; warning?: string }
+  providerId?: KnownProviderId
+  model?: ModelOption
+  reuseExisting?: boolean
+  authMethod?: 'api-key' | 'oauth'
+  llmAuth?: LLMAuth
+  channelChoice?: ChannelChoice
+}
+
+type ChannelChoice = 'slack' | 'discord' | 'telegram' | 'kakaotalk' | 'none'
+
+interface CollectedInputs {
+  model: ModelOption
+  llmAuth: LLMAuth
+  channelSecrets: {
+    discordBotToken?: string
+    slackBotToken?: string
+    slackAppToken?: string
+    telegramBotToken?: string
+    kakaotalkEmail?: string
+    kakaotalkPassword?: string
+  }
+}
+
+type StepId =
+  | 'pick-provider'
+  | 'pick-model'
+  | 'reuse-existing-key'
+  | 'pick-auth-method'
+  | 'enter-api-key'
+  | 'pick-channel'
+  | 'channel-flow'
+
+export interface WizardPrompts {
+  loadCatalog: () => Promise<NonNullable<WizardState['catalog']>>
+  readExistingApiKey: (cwd: string, providerId: KnownProviderId) => Promise<string | null>
+  pickProvider: (options: ModelOption[], initial: KnownProviderId | undefined) => Promise<StepResult<KnownProviderId>>
+  pickModel: (
+    options: ModelOption[],
+    providerId: KnownProviderId,
+    initial: KnownModelRef | undefined,
+  ) => Promise<StepResult<ModelOption>>
+  askReuseExistingKey: (
+    provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+    existingApiKey: string | null,
+    initial: boolean | undefined,
+  ) => Promise<StepResult<'reuse' | 'prompt'>>
+  pickAuthMethod: (
+    provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+    initial: 'api-key' | 'oauth' | undefined,
+  ) => Promise<StepResult<'api-key' | 'oauth'>>
+  askApiKey: (provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]) => Promise<StepResult<string>>
+  pickChannel: (initial: ChannelChoice | undefined) => Promise<StepResult<ChannelChoice>>
+  runChannelFlow: (choice: ChannelChoice) => Promise<StepResult<CollectedInputs['channelSecrets']>>
+  buildOAuthAuth: (provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]) => LLMAuth
+}
+
+export const defaultWizardPrompts: WizardPrompts = {
+  loadCatalog,
+  readExistingApiKey: readExistingProviderApiKey,
+  pickProvider,
+  pickModel: pickModelForProvider,
+  askReuseExistingKey,
+  pickAuthMethod,
+  askApiKey,
+  pickChannel,
+  runChannelFlow,
+  buildOAuthAuth: (provider) => ({
+    kind: 'oauth',
+    runLogin: makeOAuthLoginRunner(buildOAuthCallbacks(provider.name)),
+  }),
+}
+
+export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): Promise<CollectedInputs | null> {
+  const catalog = await prompts.loadCatalog()
+  const state: WizardState = { catalog }
+  let step: StepId = 'pick-provider'
+
+  while (true) {
+    switch (step) {
+      case 'pick-provider': {
+        const result = await prompts.pickProvider(catalog.options, state.providerId)
+        if (result.kind === 'back') return null
+        if (state.providerId !== result.value) {
+          state.model = undefined
+          state.reuseExisting = undefined
+          state.authMethod = undefined
+          state.llmAuth = undefined
+        }
+        state.providerId = result.value
+        step = 'pick-model'
+        break
+      }
+
+      case 'pick-model': {
+        const result = await prompts.pickModel(catalog.options, state.providerId!, state.model?.ref)
+        if (result.kind === 'back') {
+          step = 'pick-provider'
+          break
+        }
+        state.model = result.value
+        step = 'reuse-existing-key'
+        break
+      }
+
+      case 'reuse-existing-key': {
+        const provider = KNOWN_PROVIDERS[state.providerId!]
+        const existingApiKey = await prompts.readExistingApiKey(cwd, state.providerId!)
+        const decision = await prompts.askReuseExistingKey(provider, existingApiKey, state.reuseExisting)
+        if (decision.kind === 'back') {
+          step = 'pick-model'
+          break
+        }
+        if (decision.value === 'reuse' && existingApiKey !== null) {
+          log.info(`Using existing ${provider.name} API key from secrets.json.`)
+          state.llmAuth = { kind: 'api-key', apiKey: existingApiKey }
+          state.reuseExisting = true
+          step = 'pick-channel'
+          break
+        }
+        state.reuseExisting = false
+        state.llmAuth = undefined
+        step = 'pick-auth-method'
+        break
+      }
+
+      case 'pick-auth-method': {
+        const provider = KNOWN_PROVIDERS[state.providerId!]
+        const result = await prompts.pickAuthMethod(provider, state.authMethod)
+        if (result.kind === 'back') {
+          step = 'reuse-existing-key'
+          break
+        }
+        state.authMethod = result.value
+        if (result.value === 'oauth') {
+          state.llmAuth = prompts.buildOAuthAuth(provider)
+          step = 'pick-channel'
+        } else {
+          step = 'enter-api-key'
+        }
+        break
+      }
+
+      case 'enter-api-key': {
+        const provider = KNOWN_PROVIDERS[state.providerId!]
+        const result = await prompts.askApiKey(provider)
+        if (result.kind === 'back') {
+          step = 'pick-auth-method'
+          break
+        }
+        state.llmAuth = { kind: 'api-key', apiKey: result.value }
+        step = 'pick-channel'
+        break
+      }
+
+      case 'pick-channel': {
+        const result = await prompts.pickChannel(state.channelChoice)
+        if (result.kind === 'back') {
+          if (state.reuseExisting === true) {
+            step = 'reuse-existing-key'
+          } else if (state.authMethod === 'api-key') {
+            step = 'enter-api-key'
+          } else {
+            step = 'pick-auth-method'
+          }
+          break
+        }
+        state.channelChoice = result.value
+        step = 'channel-flow'
+        break
+      }
+
+      case 'channel-flow': {
+        const result = await prompts.runChannelFlow(state.channelChoice!)
+        if (result.kind === 'back') {
+          step = 'pick-channel'
+          break
+        }
+        return {
+          model: state.model!,
+          llmAuth: state.llmAuth!,
+          channelSecrets: result.value,
+        }
+      }
+    }
+  }
+}
+
+async function loadCatalog(): Promise<NonNullable<WizardState['catalog']>> {
+  const s = spinner()
+  s.start('Loading model catalog from models.dev...')
+  const { options, source, warning } = await fetchModelOptions()
+  if (source === 'curated') {
+    s.stop(`Using built-in catalog (models.dev unavailable: ${warning ?? 'unknown'})`)
+  } else {
+    s.stop('Loaded model catalog.')
+  }
+  return warning !== undefined ? { options, source, warning } : { options, source }
+}
+
+async function pickProvider(
+  options: ModelOption[],
+  initial: KnownProviderId | undefined,
+): Promise<StepResult<KnownProviderId>> {
+  const providers = uniqueProviders(options)
+  const choice = await select({
+    message: 'Pick an LLM provider',
+    options: providers.map((id) => ({ value: id, label: KNOWN_PROVIDERS[id].name, hint: providerAuthHint(id) })),
+    initialValue: initial ?? providers[0],
+  })
+  if (isCancel(choice)) return back()
+  return value(choice)
+}
+
+async function pickModelForProvider(
+  options: ModelOption[],
+  providerId: KnownProviderId,
+  initial: KnownModelRef | undefined,
+): Promise<StepResult<ModelOption>> {
+  const candidates = options.filter((o) => o.providerId === providerId)
+  const choice = await select<KnownModelRef>({
+    message: `Pick a ${KNOWN_PROVIDERS[providerId].name} model`,
+    options: candidates.map((o) => ({
+      value: o.ref,
+      label: o.modelName,
+      hint: formatModelHint(o),
+    })),
+    initialValue: initial ?? candidates[0]?.ref,
+  })
+  if (isCancel(choice)) return back()
+  const picked = candidates.find((o) => o.ref === choice)
+  if (!picked) throw new Error(`Internal error: picked model ${choice} not in candidates`)
+  return value(picked)
+}
+
+async function askReuseExistingKey(
+  provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+  existingApiKey: string | null,
+  initial: boolean | undefined,
+): Promise<StepResult<'reuse' | 'prompt'>> {
+  if (!providerSupportsApiKey(provider) || existingApiKey === null) return value('prompt')
+  const reuse = await confirm({
+    message: `Reuse existing ${provider.name} API key from secrets.json?`,
+    initialValue: initial ?? true,
+  })
+  if (isCancel(reuse)) return back()
+  return value(reuse === true ? 'reuse' : 'prompt')
+}
+
+async function pickAuthMethod(
+  provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+  initial: 'api-key' | 'oauth' | undefined,
+): Promise<StepResult<'api-key' | 'oauth'>> {
+  const supportsApiKey = providerSupportsApiKey(provider)
+  const supportsOAuth = providerSupportsOAuth(provider)
+  if (supportsApiKey && supportsOAuth) {
+    const choice = await select<'api-key' | 'oauth'>({
+      message: `How do you want to authenticate to ${provider.name}?`,
+      options: [
+        { value: 'api-key', label: 'API key', hint: 'saved to secrets.json' },
+        { value: 'oauth', label: 'OAuth (browser login)', hint: 'saved to secrets.json' },
+      ],
+      initialValue: initial ?? 'api-key',
+    })
+    if (isCancel(choice)) return back()
+    return value(choice)
+  }
+  // Single-method providers: no prompt to back out of, so always advance.
+  return value(supportsOAuth ? 'oauth' : 'api-key')
+}
+
+async function askApiKey(provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]): Promise<StepResult<string>> {
+  const apiKey = await password({
+    message: `Put your ${provider.name} API key (will be saved to secrets.json)`,
+    validate: (v) => (v && v.length > 0 ? undefined : 'API key is required'),
+  })
+  if (isCancel(apiKey)) return back()
+  return value(apiKey)
+}
+
+async function pickChannel(initial: ChannelChoice | undefined): Promise<StepResult<ChannelChoice>> {
+  const choice = await select<ChannelChoice>({
+    message: 'Pick a channel to wire (you can add more later by editing typeclaw.json + secrets.json)',
+    options: [
+      { value: 'slack', label: 'Slack' },
+      { value: 'discord', label: 'Discord' },
+      { value: 'telegram', label: 'Telegram' },
+      { value: 'kakaotalk', label: 'KakaoTalk' },
+      { value: 'none', label: 'Skip — no channel right now' },
+    ],
+    initialValue: initial ?? 'slack',
+  })
+  if (isCancel(choice)) return back()
+  return value(choice)
+}
+
+async function runChannelFlow(choice: ChannelChoice): Promise<StepResult<CollectedInputs['channelSecrets']>> {
+  switch (choice) {
+    case 'none':
+      return value({})
+    case 'discord':
+      return runDiscordFlow()
+    case 'kakaotalk':
+      return runKakaotalkFlow()
+    case 'slack':
+      return runSlackFlow()
+    case 'telegram':
+      return runTelegramFlow()
+  }
+}
+
+async function runDiscordFlow(): Promise<StepResult<CollectedInputs['channelSecrets']>> {
+  note(
+    [
+      'https://discord.com/developers/applications',
+      'New Application → Bot tab → Reset Token.',
+      'Enable the MESSAGE CONTENT intent.',
+    ].join('\n'),
+    'Get a Discord bot token',
+  )
+  const token = await password({
+    message: 'Discord bot token',
+    validate: (v) => (v && v.length > 0 ? undefined : 'Token is required'),
+  })
+  if (isCancel(token)) return back()
+  return value({ discordBotToken: token })
+}
+
+async function runKakaotalkFlow(): Promise<StepResult<CollectedInputs['channelSecrets']>> {
+  // Sub-flow with its own back-aware loop: ESC on the password prompt
+  // returns to the email prompt; ESC on the email prompt unwinds to the
+  // channel picker.
+  type SubStep = 'email' | 'password'
+  let sub: SubStep = 'email'
+  let email: string | undefined
+  let pwd: string | undefined
+
+  note(
+    [
+      'KakaoTalk authentication uses a personal account, registered as a',
+      'tablet sub-device. Messages will be sent and received under this',
+      'account. Use a non-primary account if possible.',
+      '',
+      'After you submit the password, KakaoTalk may ask you to confirm a',
+      'passcode on your phone. Watch the screen for the code.',
+    ].join('\n'),
+    'About to log in to KakaoTalk',
+  )
+
+  while (true) {
+    if (sub === 'email') {
+      const input = await text({
+        message: 'KakaoTalk email',
+        ...(email !== undefined ? { initialValue: email } : {}),
+        validate: (v) => (v && v.length > 0 ? undefined : 'Email is required'),
+      })
+      if (isCancel(input)) return back()
+      email = input
+      sub = 'password'
+      continue
+    }
+    const input = await password({
+      message: 'KakaoTalk password',
+      validate: (v) => (v && v.length > 0 ? undefined : 'Password is required'),
+    })
+    if (isCancel(input)) {
+      sub = 'email'
+      continue
+    }
+    pwd = input
+    return value({ kakaotalkEmail: email, kakaotalkPassword: pwd })
+  }
+}
+
+async function runSlackFlow(): Promise<StepResult<CollectedInputs['channelSecrets']>> {
+  type SubStep = 'bot' | 'app'
+  let sub: SubStep = 'bot'
+  let botToken: string | undefined
+
+  note(
+    [
+      '1. https://api.slack.com/apps → Create New App → From a manifest.',
+      '   Pick your workspace, then paste this JSON manifest:',
+      '',
+      '   {',
+      '     "display_information": { "name": "TypeClaw" },',
+      '     "features": {',
+      '       "bot_user": { "display_name": "TypeClaw", "always_online": true }',
+      '     },',
+      '     "oauth_config": {',
+      '       "scopes": {',
+      '         "bot": [',
+      '           "app_mentions:read", "chat:write", "users:read", "files:read",',
+      '           "channels:history", "channels:read",',
+      '           "groups:history",   "groups:read",',
+      '           "im:history",       "im:read",',
+      '           "mpim:history",     "mpim:read"',
+      '         ]',
+      '       }',
+      '     },',
+      '     "settings": {',
+      '       "event_subscriptions": {',
+      '         "bot_events": [',
+      '           "app_mention",',
+      '           "message.channels", "message.groups",',
+      '           "message.im",       "message.mpim"',
+      '         ]',
+      '       },',
+      '       "socket_mode_enabled": true',
+      '     }',
+      '   }',
+      '',
+      '2. Install to Workspace, then OAuth & Permissions →',
+      '   copy the Bot User OAuth Token (xoxb-...).',
+      '3. Basic Information → App-Level Tokens → Generate Token and',
+      '   Scopes, add the connections:write scope, and copy the',
+      '   token (xapp-...). Socket Mode needs this; the manifest',
+      '   cannot grant it.',
+      '4. Invite the bot to any private channel or DM you want it in:',
+      '   /invite @TypeClaw',
+    ].join('\n'),
+    'Get a Slack bot',
+  )
+
+  while (true) {
+    if (sub === 'bot') {
+      const input = await password({
+        message: 'Slack bot token (xoxb-...)',
+        validate: (v) =>
+          v && v.length > 0
+            ? v.startsWith('xoxb-')
+              ? undefined
+              : 'Bot token must start with "xoxb-"'
+            : 'Token is required',
+      })
+      if (isCancel(input)) return back()
+      botToken = input
+      note(
+        [
+          'Slack does not accept connections:write inside the manifest, so',
+          'this token has to be generated by hand:',
+          '',
+          '1. Basic Information → App-Level Tokens → Generate Token and Scopes.',
+          '2. Token Name: anything (e.g. "socket-mode").',
+          '3. Add Scope → connections:write → Generate.',
+          '4. Copy the xapp-... token shown once on screen.',
+          '   (You cannot retrieve it later — only revoke and regenerate.)',
+        ].join('\n'),
+        'Generate the Slack app-level token',
+      )
+      sub = 'app'
+      continue
+    }
+    const input = await password({
+      message: 'Slack app-level token (xapp-...) — Socket Mode requires this',
+      validate: (v) =>
+        v && v.length > 0
+          ? v.startsWith('xapp-')
+            ? undefined
+            : 'App-level token must start with "xapp-"'
+          : 'Token is required',
+    })
+    if (isCancel(input)) {
+      sub = 'bot'
+      continue
+    }
+    return value({ slackBotToken: botToken!, slackAppToken: input })
+  }
+}
+
+async function runTelegramFlow(): Promise<StepResult<CollectedInputs['channelSecrets']>> {
+  note(
+    [
+      'Open Telegram and message @BotFather.',
+      '/newbot → pick a name and username, copy the HTTP API token',
+      '  (looks like 1234567890:ABCdef...).',
+      'In @BotFather: /setprivacy → Disable, so the bot can see group messages.',
+    ].join('\n'),
+    'Get a Telegram bot token',
+  )
+  const token = await password({
+    message: 'Telegram bot token',
+    validate: (v) =>
+      v && v.length > 0
+        ? /^\d+:/.test(v)
+          ? undefined
+          : 'Bot token must look like "<digits>:<secret>" (from @BotFather)'
+        : 'Token is required',
+  })
+  if (isCancel(token)) return back()
+  note(
+    [
+      'Open https://t.me/<your_bot_username> (the username you picked in /newbot, ends in "bot").',
+      'Tap Start in the chat — the agent will reply once it hatches.',
+      'For groups: add the bot to the group, then @mention it or reply to its messages.',
+    ].join('\n'),
+    'Send your first message',
+  )
+  return value({ telegramBotToken: token })
+}
 
 function reportProgress(
   onHatchingDone: (ok: boolean) => void,
@@ -436,67 +757,6 @@ function reportHatching(event: Extract<InitStepEvent, { step: 'hatching' }>): vo
   }
 }
 
-// Resolves how the user wants to authenticate to the chosen provider:
-// - api-key only (e.g. Fireworks): prompt for the key, write to secrets.json.
-// - oauth only (e.g. openai-codex): run the browser flow inline, write
-//   secrets.json. No API key prompt at all.
-// - both supported (no providers ship this today, but Anthropic will when
-//   wired): ask "API key or OAuth?" first, then dispatch to the chosen path.
-async function collectLLMAuth(
-  provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
-  existingApiKey: string | null,
-): Promise<LLMAuth> {
-  const supportsApiKey = providerSupportsApiKey(provider)
-  const supportsOAuth = providerSupportsOAuth(provider)
-
-  const existingKeyDecision = await decideExistingApiKeyReuse(provider, existingApiKey, (message) =>
-    confirm({ message, initialValue: true }),
-  )
-  if (existingKeyDecision === 'cancel') {
-    cancel('Aborted.')
-    process.exit(0)
-  }
-  if (existingKeyDecision === 'reuse' && existingApiKey !== null) {
-    log.info(`Using existing ${provider.name} API key from secrets.json.`)
-    return { kind: 'api-key', apiKey: existingApiKey }
-  }
-
-  let method: 'api-key' | 'oauth'
-  if (supportsApiKey && supportsOAuth) {
-    const choice = await select<'api-key' | 'oauth'>({
-      message: `How do you want to authenticate to ${provider.name}?`,
-      options: [
-        { value: 'api-key', label: 'API key', hint: 'saved to secrets.json' },
-        { value: 'oauth', label: 'OAuth (browser login)', hint: 'saved to secrets.json' },
-      ],
-      initialValue: 'api-key',
-    })
-    if (isCancel(choice)) {
-      cancel('Aborted.')
-      process.exit(0)
-    }
-    method = choice
-  } else if (supportsOAuth) {
-    method = 'oauth'
-  } else {
-    method = 'api-key'
-  }
-
-  if (method === 'api-key') {
-    const apiKey = await password({
-      message: `Put your ${provider.name} API key (will be saved to secrets.json)`,
-      validate: (value) => (value && value.length > 0 ? undefined : 'API key is required'),
-    })
-    if (isCancel(apiKey)) {
-      cancel('Aborted.')
-      process.exit(0)
-    }
-    return { kind: 'api-key', apiKey }
-  }
-
-  return { kind: 'oauth', runLogin: makeOAuthLoginRunner(buildOAuthCallbacks(provider.name)) }
-}
-
 export async function decideExistingApiKeyReuse(
   provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
   existingApiKey: string | null,
@@ -538,50 +798,6 @@ function buildOAuthCallbacks(providerName: string) {
       return value
     },
   }
-}
-
-// Two-step provider+model picker. We split it because most users have a key
-// for exactly one provider — asking them to scroll through a flat list of
-// every (provider, model) pair would surface options they can't use.
-async function pickModel(): Promise<ModelOption> {
-  const s = spinner()
-  s.start('Loading model catalog from models.dev...')
-  const { options, source, warning } = await fetchModelOptions()
-  if (source === 'curated') {
-    s.stop(`Using built-in catalog (models.dev unavailable: ${warning ?? 'unknown'})`)
-  } else {
-    s.stop('Loaded model catalog.')
-  }
-
-  const providers = uniqueProviders(options)
-  const providerChoice = await select({
-    message: 'Pick an LLM provider',
-    options: providers.map((id) => ({ value: id, label: KNOWN_PROVIDERS[id].name, hint: providerAuthHint(id) })),
-    initialValue: providers[0],
-  })
-  if (isCancel(providerChoice)) {
-    cancel('Aborted.')
-    process.exit(0)
-  }
-
-  const candidates = options.filter((o) => o.providerId === providerChoice)
-  const modelChoice = await select<KnownModelRef>({
-    message: `Pick a ${KNOWN_PROVIDERS[providerChoice].name} model`,
-    options: candidates.map((o) => ({
-      value: o.ref,
-      label: o.modelName,
-      hint: formatModelHint(o),
-    })),
-    initialValue: candidates[0]?.ref,
-  })
-  if (isCancel(modelChoice)) {
-    cancel('Aborted.')
-    process.exit(0)
-  }
-
-  const picked = candidates.find((o) => o.ref === modelChoice)
-  if (!picked) throw new Error(`Internal error: picked model ${modelChoice} not in candidates`)
-  return picked
 }
 
 function uniqueProviders(options: ModelOption[]): KnownProviderId[] {


### PR DESCRIPTION
## Problem

`typeclaw init` ran a linear sequence of clack prompts — model picker, auth method, channel picker, channel-specific sub-flows — and exited the whole process the moment any prompt returned clack's cancel symbol. The cancel symbol fires for **both** ESC and Ctrl+C; the keypress layer in `@clack/core` aliases them to the same `"cancel"` action, and `@clack/prompts` exposes no way to tell them apart.

The user-visible consequence: hit ESC after spending a minute pasting the Slack manifest (six prompts deep), and every prior answer evaporates. The only recovery is a fresh `typeclaw init`. There's no concept of "go back one step" — every cancel is a wizard-killer.

## Changes

Restructure the interactive flow in `src/cli/init.ts` into a back-aware state machine.

**Step machine.** `run()` now delegates to `collectWizardInputs(cwd, prompts)`, which walks a typed `StepId` union:

```
pick-provider → pick-model → reuse-existing-key → pick-auth-method
              → enter-api-key → pick-channel → channel-flow
```

Each prompt step returns `StepResult<T> = { kind: 'value', value: T } | { kind: 'back' }`. A `back` result rewinds to the prior step; a `value` result advances. Backing out past `pick-provider` returns `null`, which `run()` treats as a clean abort (same exit path as before, just opt-in instead of forced).

The back targets account for branches taken on the way in:

- `pick-channel` back → `reuse-existing-key` (if the user reused the existing key and skipped auth-method/api-key), `enter-api-key` (if they picked api-key), or `pick-auth-method` (oauth).
- `pick-auth-method` back → `reuse-existing-key`.
- Changing provider on the way back invalidates the previously picked model, reuse decision, auth method, and llmAuth, so the re-asked steps start fresh.

**Channel sub-flows.** Slack (bot token + app token) and KakaoTalk (email + password) carry their own internal back-loops: ESC on the second prompt rewinds to the first prompt of the same channel; ESC on the first prompt unwinds out to `pick-channel`. Discord and Telegram have a single prompt each and just bubble back to `pick-channel`.

**Testable seam.** The clack-talking prompt functions are gathered into a `WizardPrompts` interface, with `defaultWizardPrompts` wiring the real implementations. The state machine in `collectWizardInputs` is now pure-with-respect-to-prompts, so it can be pipeline-tested without mocking `@clack/prompts` (per AGENTS.md §5 — real implementations or hand-rolled fakes, not module mocks).

**User-facing hint.** `intro()` is now followed by `log.info('Press ESC at any prompt to go back to the previous step.')` so the new behavior is discoverable.

## Tradeoff: ESC vs Ctrl+C

Since `@clack/prompts` can't tell ESC from Ctrl+C, both keys now rewind one step. Users who want to abort mid-wizard hit ESC until they're back at the first step, where one more ESC aborts cleanly. The terminal's own Ctrl+C still kills the process when stdin is not in raw mode (e.g., during the non-interactive runInit phase), but during prompts both keys behave identically. This is acceptable because (a) the previous behavior was "any cancel = abort everything", so the worst case for an abort-seeker is one extra keypress per step, and (b) the much more common case — hit ESC, lose all progress — is now fixed.

## Verification

Added 10 pipeline tests in `src/cli/init.test.ts` exercising the state machine through the `WizardPrompts` seam. Each test verifies an observable behavior (step order, back target per branch, model invalidation on provider change, abort-on-first-back, sub-flow nesting). Per AGENTS.md §1 the tests were validated by mutation: commenting out the back-target lookup in `pick-channel` fails the reuse/oauth tests; removing the provider-change invalidation fails the "picking a different provider discards prior model" test; replacing `return null` in `pick-provider` back with a no-op fails the abort test. Each mutation produced a failing test for the right reason.

```
bun run typecheck   # clean
bun run lint        # 0 errors, 8 pre-existing warnings (unrelated, src/permissions/)
bun run format      # clean
bun test            # 3237 pass / 0 fail across 191 files
```

## Stats

2 files changed, 867 insertions(+), 306 deletions(−).