### PR TITLE
Add `Sent` column to `typeclaw usage` showing provider-billed token volume

### DIFF
--- a/src/usage/index.test.ts
+++ b/src/usage/index.test.ts
@@ -456,3 +456,82 @@ describe('formatReport cache hit rate column', () => {
   })
   /* eslint-enable no-control-regex */
 })
+
+describe('formatReport Sent column (provider-billed volume = input + cacheRead)', () => {
+  const ts = new Date('2026-05-10T10:00:00').getTime()
+
+  async function reportWithCache(input: number, cacheRead: number) {
+    await writeSessionFile(`sent-${input}-${cacheRead}`, [
+      {
+        type: 'message',
+        id: 'm1',
+        parentId: null,
+        timestamp: new Date(ts).toISOString(),
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'hi' }],
+          api: 'fake',
+          provider: 'p',
+          model: 'x',
+          usage: {
+            input,
+            output: 50,
+            cacheRead,
+            cacheWrite: 0,
+            totalTokens: input + 50 + cacheRead,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.01 },
+          },
+          stopReason: 'stop',
+          timestamp: ts,
+        },
+      },
+    ])
+    return runUsage({ agentDir })
+  }
+
+  test('renders a `Sent` column in tabular views', async () => {
+    const report = await reportWithCache(900, 100)
+    const out = formatReport(report, { view: 'models' })
+    expect(out).toMatch(/Sent/)
+  })
+
+  test('Sent equals input + cacheRead for a row (warm session: small input, large cache)', async () => {
+    // given: a warm session that shipped 84,000 tokens of context per turn,
+    // 99% of which hit the prompt cache. The dashboard bills this as 84k
+    // (volume shipped); the In column alone shows only 1k (cache misses).
+    const report = await reportWithCache(1_000, 83_000)
+    const out = formatReport(report, { view: 'models' })
+
+    // then: the Sent column must reflect the true 84k volume so a user
+    // reading the report sees the same magnitude their provider invoice does.
+    expect(out).toMatch(/\b84k\b/)
+    expect(out).toMatch(/99%/)
+  })
+
+  test('Sent equals input on cold-start turns (no cache reads)', async () => {
+    // given: a cold-start turn where the full prompt was billed fresh
+    const report = await reportWithCache(82_697, 0)
+    const out = formatReport(report, { view: 'models' })
+
+    // then: Sent matches input verbatim. We assert presence rather than
+    // exact ordering because both `In` and `Sent` show the same magnitude
+    // for cold-start rows.
+    expect(out).toMatch(/83k/)
+    expect(out).toMatch(/0%/)
+  })
+
+  test('summary headline includes Sent total', async () => {
+    const report = await reportWithCache(1_000, 99_000)
+    const out = formatReport(report, { view: 'summary' })
+    expect(out).toMatch(/Sent:/)
+    // 1k + 99k = 100k; format rounds to "100k"
+    expect(out).toMatch(/Sent:\s*100k/)
+  })
+
+  test('Sent appears in the daily view footer Total row', async () => {
+    const report = await reportWithCache(500, 9_500)
+    const out = formatReport(report, { view: 'daily' })
+    // 500 + 9500 = 10000 = "10k"
+    expect(out).toMatch(/\b10k\b/)
+  })
+})

--- a/src/usage/report.ts
+++ b/src/usage/report.ts
@@ -52,6 +52,7 @@ function renderSummary(report: UsageReport, ctx: RenderCtx): string {
       `  ${dim('Messages:', ctx)} ${color('cyan', String(total.messageCount), ctx)}` +
       `  ${dim('In:', ctx)} ${formatTokens(total.input)}` +
       `  ${dim('Out:', ctx)} ${formatTokens(total.output)}` +
+      `  ${dim('Sent:', ctx)} ${formatTokens(total.input + total.cacheRead)}` +
       `  ${dim('Cost:', ctx)} ${formatCost(total.cost)}`,
   )
 
@@ -191,13 +192,14 @@ function renderTotalsTable(
   opts: { extraHeader?: string; total?: UsageTotals } = {},
 ): string {
   const hasExtra = opts.extraHeader !== undefined
-  const headers = ['Item', 'Msgs', 'In', 'Out', 'Cache %', 'Cost', ...(hasExtra ? [opts.extraHeader!] : [])]
+  const headers = ['Item', 'Msgs', 'In', 'Out', 'Sent', 'Cache %', 'Cost', ...(hasExtra ? [opts.extraHeader!] : [])]
 
   const dataCells: string[][] = rows.map((r) => [
     r.label,
     String(r.totals.messageCount),
     formatTokens(r.totals.input),
     formatTokens(r.totals.output),
+    formatTokens(r.totals.input + r.totals.cacheRead),
     formatCacheHitRate(r.totals.input, r.totals.cacheRead),
     formatCost(r.totals.cost),
     ...(hasExtra ? [r.extra ?? ''] : []),
@@ -210,6 +212,7 @@ function renderTotalsTable(
           String(opts.total.messageCount),
           formatTokens(opts.total.input),
           formatTokens(opts.total.output),
+          formatTokens(opts.total.input + opts.total.cacheRead),
           formatCacheHitRate(opts.total.input, opts.total.cacheRead),
           formatCost(opts.total.cost),
           ...(hasExtra ? [''] : []),


### PR DESCRIPTION
## Problem

`typeclaw usage` displayed `In` (input tokens, cache-miss only) but never the absolute volume of tokens *shipped* to the provider per turn, which is `input + cacheRead`. For an agent with warm prompt cache — Kimi K2.6 Turbo hits 95–99% cache on follow-up messages within the 5-minute TTL — the `In` column can be 50–100× smaller than what Fireworks actually bills.

Concrete example from a real kakao agent: lifetime `In` reads 2.8M tokens; lifetime `Sent` is 12M — a 4.3× understatement. On May 12 alone, the agent shipped 7.6M tokens while `In` showed only 1.4M.

## How it was discovered

A token-spike investigation: the Fireworks dashboard showed a 13M-token jump on a single API key over a 16-minute window, while `typeclaw usage` reported only ~2.8M total for the day across both affected agent folders. PR #186 (subagent persistence) and PR #183 (KakaoTalk system-prompt bloat) addressed structural issues but the gap in the headline number persisted. A controlled experiment — one 5-character KakaoTalk message to a cold session — produced a clean 82,697-token assistant turn with `cacheRead: 0`, confirming the raw data was correct all along. The report was simply hiding the column that mattered.

## Fix

Add a `Sent` column (`input + cacheRead`) to every tabular view (`summary`, `daily`, `session`, `models`) and a `Sent:` total to the headline summary line. Positioned between `Out` and `Cache %` so the reading order is: input-side breakdown → output → total shipped → what % of shipped was cached → cost.

`Cache %` is kept — it remains the right view for understanding hit rate. `Sent` is the absolute number that pairs with it, and the one that reconciles with the Fireworks billing dashboard on first look.

## Sample output (real data, kakao agent)

```
USAGE — /path/to/kakao
Sessions: 9  Messages: 316  In: 2.8M  Out: 102k  Sent: 12M  Cost: $0.00

By day (most recent first)
Item        Msgs    In   Out  Sent  Cache %   Cost
2026-05-15    53  461k   11k  2.0M      77%  $0.00
2026-05-13    37  722k  8.1k  2.3M      69%  $0.00
2026-05-12   194  1.4M   73k  7.6M      81%  $0.00
Total        316  2.8M  102k   12M      78%  $0.00
```

## Backwards compatibility

Purely additive. The 31 existing usage tests pass unchanged because they assert on content patterns (`/Cache %/`, model names, percentages) rather than column count or order. The headline summary line gets `Sent:` inserted before `Cost:` — nothing is replaced.

## Test plan

- `bun run typecheck` — clean
- `bun run lint` — 8 pre-existing warnings (untouched), 0 errors
- `bun run format:check` — clean
- `bun test` — 3235 pass, 0 fail (3230 baseline + 5 new tests in a dedicated `formatReport Sent column` describe block covering: column presence, warm-row arithmetic, cold-start arithmetic, headline summary line, daily-view Total footer)
- Manual smoke: ran against a real kakao agent folder and confirmed the rendered output matches the sample above.

## Context

Surfaced from the same investigation that produced PR #183 (KakaoTalk system-prompt bloat) and PR #186 (invisible subagent persistence). Those PRs addressed structural causes of the billing gap; this PR addresses the reporting blind spot that was masking the real magnitude of agent token spend. No issue to close.

## Stats

2 files changed, +83/−1.

- `src/usage/report.ts` — `Sent` column in the headline summary line + every `renderTotalsTable` invocation
- `src/usage/index.test.ts` — 5 new tests in a dedicated describe block