### PR TITLE
Add role claim handshake to bootstrap channel permissions

### DIFF
--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -2,6 +2,9 @@ export { createChannelManager, type ChannelManager, type ChannelManagerOptions }
 export {
   createChannelRouter,
   type ChannelRouter,
+  type ClaimHandler,
+  type ClaimHandlerInput,
+  type ClaimHandlerOutcome,
   type CreateChannelRouterOptions,
   type CreateSessionForChannel,
 } from './router'

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -9,7 +9,7 @@ import { createDiscordBotAdapter, type DiscordBotAdapter } from './adapters/disc
 import { createKakaotalkAdapter, type KakaotalkAdapter } from './adapters/kakaotalk'
 import { createSlackBotAdapter, type SlackBotAdapter } from './adapters/slack-bot'
 import { createTelegramBotAdapter, type TelegramBotAdapter } from './adapters/telegram-bot'
-import { createChannelRouter, type ChannelRouter, type CreateSessionForChannel } from './router'
+import { createChannelRouter, type ChannelRouter, type ClaimHandler, type CreateSessionForChannel } from './router'
 import { ADAPTER_IDS, type AdapterId, type ChannelAdapterConfig, type ChannelsConfig } from './schema'
 
 export type ChannelManagerLogger = {
@@ -58,6 +58,10 @@ export type ChannelManagerOptions = {
   // passes `pluginsLoaded.permissions`. Omitting it falls through to the
   // router's grant-all default — see CreateChannelRouterOptions.
   permissions?: PermissionService
+  // Forwarded to the router; intercepts DM inbounds carrying a role-claim
+  // code. Production wiring sets this from the role-claim subsystem (see
+  // src/run/index.ts). Tests typically omit it.
+  claimHandler?: ClaimHandler
 }
 
 export type ChannelManager = {
@@ -91,6 +95,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     ...(options.aliasesRef ? { configuredAliases: options.aliasesRef } : {}),
     ...(options.createSessionForChannel ? { createSessionForChannel: options.createSessionForChannel } : {}),
     ...(options.permissions ? { permissions: options.permissions } : {}),
+    ...(options.claimHandler ? { claimHandler: options.claimHandler } : {}),
   })
   const createDiscordAdapter = options.createDiscordAdapter ?? createDiscordBotAdapter
   const createKakaotalk = options.createKakaotalkAdapter ?? createKakaotalkAdapter

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -19,6 +19,7 @@ import {
   SESSION_IDLE_MS,
   sliceHeadTail,
   type ChannelRouter,
+  type ClaimHandler,
 } from './router'
 import { defaultHistoryConfig, type ChannelAdapterConfig } from './schema'
 import type { ChannelHistoryMessage, ChannelKey, FetchHistoryArgs, HistoryCallback, InboundMessage } from './types'
@@ -107,6 +108,7 @@ const grantAllPermissions: PermissionService = {
   has: () => true,
   resolveRole: () => 'owner',
   describe: () => ({ role: 'owner', permissions: ['channel.respond'] }),
+  replaceRoles: () => {},
 }
 
 function makeRouter(
@@ -122,6 +124,7 @@ function makeRouter(
     configuredAliases?: () => readonly string[]
     ensureLiveTimeoutMs?: number
     permissions?: PermissionService
+    claimHandler?: ClaimHandler
   } = {},
 ): { router: ChannelRouter; sessions: FakeSession[]; origins: SessionOrigin[] } {
   const sessions: FakeSession[] = options.sessions ?? []
@@ -132,6 +135,7 @@ function makeRouter(
     configForAdapter: () => options.config ?? baseConfig,
     ...(options.configuredAliases !== undefined ? { configuredAliases: options.configuredAliases } : {}),
     ...(options.ensureLiveTimeoutMs !== undefined ? { ensureLiveTimeoutMs: options.ensureLiveTimeoutMs } : {}),
+    ...(options.claimHandler !== undefined ? { claimHandler: options.claimHandler } : {}),
     permissions: options.permissions ?? grantAllPermissions,
     now: () => nowRef.value,
     logger: {
@@ -2732,6 +2736,7 @@ describe('ChannelRouter channel.respond gate', () => {
     },
     resolveRole: () => 'guest',
     describe: () => ({ role: 'guest', permissions: [] }),
+    replaceRoles: () => {},
   })
 
   test('author has channel.respond → routes through normally', async () => {
@@ -2781,6 +2786,7 @@ describe('ChannelRouter channel.respond gate', () => {
       has: () => false,
       resolveRole: () => 'guest',
       describe: () => ({ role: 'guest', permissions: [] }),
+      replaceRoles: () => {},
     }
     const { router, sessions } = makeRouter(dir, { permissions })
 
@@ -2789,5 +2795,130 @@ describe('ChannelRouter channel.respond gate', () => {
 
     expect(sessions).toHaveLength(0)
     expect(router.liveCount()).toBe(0)
+  })
+})
+
+describe('ChannelRouter role-claim bypass', () => {
+  type SentMsg = { adapter: string; chat: string; text: string | undefined }
+
+  const denyAllPermissions: PermissionService = {
+    has: () => false,
+    resolveRole: () => 'guest',
+    describe: () => ({ role: 'guest', permissions: [] }),
+    replaceRoles: () => {},
+  }
+
+  test('DM with claim code → handler is invoked, reply sent, no session created, gate bypassed', async () => {
+    const dir = await tempDir()
+    const sent: SentMsg[] = []
+    let calls = 0
+    const claimHandler: ClaimHandler = async (input) => {
+      calls++
+      expect(input.isDm).toBe(true)
+      expect(input.text).toContain('claim-')
+      return { kind: 'consumed', reply: 'Welcome owner!' }
+    }
+    const { router, sessions } = makeRouter(dir, {
+      permissions: denyAllPermissions,
+      claimHandler,
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ adapter: msg.adapter, chat: msg.chat, text: msg.text })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ isDm: true, text: 'here you go: claim-AAAA-BBBB' }))
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(calls).toBe(1)
+    expect(sent).toEqual([{ adapter: 'discord-bot', chat: 'c1', text: 'Welcome owner!' }])
+    expect(sessions).toHaveLength(0)
+    expect(router.liveCount()).toBe(0)
+  })
+
+  test('non-DM with claim code → handler NOT invoked, falls through to gate (denied)', async () => {
+    const dir = await tempDir()
+    let calls = 0
+    const claimHandler: ClaimHandler = async () => {
+      calls++
+      return { kind: 'consumed', reply: 'x' }
+    }
+    const { router, sessions } = makeRouter(dir, {
+      permissions: denyAllPermissions,
+      claimHandler,
+    })
+
+    await router.route(inbound({ isDm: false, text: 'claim-AAAA-BBBB' }))
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(calls).toBe(0)
+    expect(sessions).toHaveLength(0)
+  })
+
+  test('DM without a claim code → handler NOT invoked, falls through to gate (denied)', async () => {
+    const dir = await tempDir()
+    let calls = 0
+    const claimHandler: ClaimHandler = async () => {
+      calls++
+      return { kind: 'consumed', reply: 'x' }
+    }
+    const { router, sessions } = makeRouter(dir, {
+      permissions: denyAllPermissions,
+      claimHandler,
+    })
+
+    await router.route(inbound({ isDm: true, text: 'hi there' }))
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(calls).toBe(0)
+    expect(sessions).toHaveLength(0)
+  })
+
+  test('handler returns fallthrough → message proceeds to normal gate (denied here)', async () => {
+    const dir = await tempDir()
+    const claimHandler: ClaimHandler = async () => ({ kind: 'fallthrough' })
+    const { router, sessions } = makeRouter(dir, {
+      permissions: denyAllPermissions,
+      claimHandler,
+    })
+
+    await router.route(inbound({ isDm: true, text: 'claim-AAAA-BBBB' }))
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(sessions).toHaveLength(0)
+  })
+
+  test('handler returns fail → reply sent, no session created', async () => {
+    const dir = await tempDir()
+    const sent: SentMsg[] = []
+    const claimHandler: ClaimHandler = async () => ({
+      kind: 'fail',
+      reply: 'This claim has expired. Run typeclaw role claim again.',
+    })
+    const { router, sessions } = makeRouter(dir, {
+      permissions: denyAllPermissions,
+      claimHandler,
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ adapter: msg.adapter, chat: msg.chat, text: msg.text })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ isDm: true, text: 'claim-AAAA-BBBB' }))
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('expired')
+    expect(sessions).toHaveLength(0)
+  })
+
+  test('no claimHandler registered → claim DMs are dropped by the channel.respond gate', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir, { permissions: denyAllPermissions })
+
+    await router.route(inbound({ isDm: true, text: 'claim-AAAA-BBBB' }))
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(sessions).toHaveLength(0)
   })
 })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -8,6 +8,7 @@ import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { createCommandRegistry } from '@/commands'
 import { CORE_PERMISSIONS, type PermissionService } from '@/permissions'
 import type { HookBus } from '@/plugin'
+import { extractClaimCode } from '@/role-claim'
 
 import { decideEngagement, grantStickyForReplyTargets, StickyLedger, type EngagementDecision } from './engagement'
 import {
@@ -325,12 +326,37 @@ export type CreateChannelRouterOptions = {
   // injection is enforced; direct-router tests opt into gate semantics by
   // passing their own service.
   permissions?: PermissionService
+  // Optional role-claim handler. When set, the router intercepts DM
+  // inbounds whose text contains a claim code BEFORE the channel.respond
+  // gate, hands the inbound to the handler, and short-circuits the normal
+  // route path (no session creation, no permission check, no engagement
+  // pipeline). The handler returns the reply text the router should send
+  // back over the same chat, or null to fall through to normal routing
+  // when no pending claim window matches.
+  claimHandler?: ClaimHandler
 }
+
+export type ClaimHandlerInput = {
+  adapter: ChannelKey['adapter']
+  workspace: string
+  chat: string
+  isDm: boolean
+  authorId: string
+  text: string
+}
+
+export type ClaimHandlerOutcome =
+  | { kind: 'consumed'; reply: string }
+  | { kind: 'fail'; reply: string }
+  | { kind: 'fallthrough' }
+
+export type ClaimHandler = (input: ClaimHandlerInput) => Promise<ClaimHandlerOutcome>
 
 const GRANT_ALL_PERMISSIONS: PermissionService = {
   has: () => true,
   resolveRole: () => 'owner',
   describe: () => ({ role: 'owner', permissions: [CORE_PERMISSIONS.channelRespond] }),
+  replaceRoles: () => {},
 }
 
 export function createChannelRouter(options: CreateChannelRouterOptions): ChannelRouter {
@@ -341,6 +367,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const fetchHistoryTimeoutMs = options.fetchHistoryTimeoutMs ?? FETCH_HISTORY_TIMEOUT_MS
   const sessionIdleTimeoutMs = options.sessionIdleTimeoutMs ?? SESSION_IDLE_TIMEOUT_MS
   const permissions = options.permissions ?? GRANT_ALL_PERMISSIONS
+  const claimHandler = options.claimHandler
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
   const outboundCallbacks = new Map<ChannelKey['adapter'], Set<OutboundCallback>>()
@@ -963,6 +990,35 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       workspace: event.workspace,
       chat: event.chat,
       thread: event.thread,
+    }
+
+    // Role-claim intercept runs BEFORE the channel.respond gate so the
+    // operator can bootstrap permissions on a fresh agent that has no
+    // role match rules yet. Cheap pre-check: only DMs whose text contains
+    // a `claim-` prefix can be claim attempts, and only when a handler
+    // is registered. Everything else falls straight through to the gate.
+    if (claimHandler !== undefined && event.isDm && extractClaimCode(event.text) !== null) {
+      const outcome = await claimHandler({
+        adapter: event.adapter,
+        workspace: event.workspace,
+        chat: event.chat,
+        isDm: event.isDm,
+        authorId: event.authorId,
+        text: event.text,
+      })
+      if (outcome.kind !== 'fallthrough') {
+        logger.info(
+          `[channels] ${channelKeyId(key)}: claim ${outcome.kind} author=${event.authorId} id=${event.externalMessageId}`,
+        )
+        await send({
+          adapter: event.adapter,
+          workspace: event.workspace,
+          chat: event.chat,
+          thread: event.thread,
+          text: outcome.reply,
+        })
+        return
+      }
     }
 
     if (isChannelRespondDenied(event)) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@ const main = defineCommand({
     shell: () => import('./shell').then((m) => m.shellCommand),
     compose: () => import('./compose').then((m) => m.composeCommand),
     channel: () => import('./channel').then((m) => m.channelCommand),
+    role: () => import('./role').then((m) => m.roleCommand),
     doctor: () => import('./doctor').then((m) => m.doctorCommand),
     usage: () => import('./usage').then((m) => m.usageCommand),
     _hostd: () => import('./hostd').then((m) => m.hostdCommand),

--- a/src/cli/role.ts
+++ b/src/cli/role.ts
@@ -1,0 +1,151 @@
+import { intro, note, outro, spinner } from '@clack/prompts'
+import { defineCommand } from 'citty'
+
+import { resolveHostPort, resolveTuiToken } from '@/container'
+import { findAgentDir } from '@/init'
+import { runClaimSession } from '@/role-claim'
+
+import { c, errorLine } from './ui'
+
+const claimSub = defineCommand({
+  meta: {
+    name: 'claim',
+    description:
+      'claim a channel identity (Slack/Discord/etc.) for a role on this agent. Sends a code via the host CLI; you DM that code back to the bot to prove control of the channel account.',
+  },
+  args: {
+    as: {
+      type: 'string',
+      description: 'which role to claim (owner | member | trusted | <custom>)',
+      default: 'owner',
+    },
+    channel: {
+      type: 'string',
+      description: 'restrict the claim to one channel adapter (slack-bot | discord-bot | telegram-bot | kakaotalk)',
+    },
+    ttl: {
+      type: 'string',
+      description: 'how long the code stays valid, in milliseconds',
+      default: '600000',
+    },
+    url: {
+      type: 'string',
+      description: 'agent websocket url (defaults to ws://127.0.0.1:<host port> discovered from the running container)',
+    },
+  },
+  async run({ args }) {
+    const url = args.url ?? (await defaultUrl())
+    const ttlMs = Number(args.ttl)
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+      console.error(errorLine(`--ttl must be a positive integer (milliseconds); got "${args.ttl}"`))
+      process.exit(1)
+    }
+
+    intro(`Claiming "${args.as}" role`)
+
+    const s = spinner()
+    s.start('Waiting for code...')
+
+    let started = false
+    const result = await runClaimSession({
+      url,
+      role: args.as,
+      ttlMs,
+      ...(args.channel !== undefined ? { channel: args.channel } : {}),
+      onStarted: (payload) => {
+        started = true
+        s.stop('Ready.')
+        const expiresInSec = Math.max(0, Math.round((payload.expiresAt - Date.now()) / 1000))
+        const lines = [
+          `Send this message to your bot as a DM:`,
+          '',
+          `  ${c.bold(payload.code)}`,
+          '',
+          `(expires in ${formatDuration(expiresInSec)})`,
+        ]
+        note(lines.join('\n'), 'Claim code')
+        const waitMsg =
+          payload.channel !== undefined ? `Listening on ${payload.channel}...` : 'Listening on all wired channels...'
+        s.start(waitMsg)
+      },
+    })
+
+    if (!started) {
+      s.stop('Failed to start claim session.')
+    }
+
+    if (result.kind === 'completed') {
+      s.stop(c.green(`Paired as ${result.payload.role}.`))
+      outro(`Match rule added: ${c.bold(result.payload.matchRule)}`)
+      return
+    }
+    if (result.kind === 'error') {
+      s.stop(c.red(`Claim failed: ${result.payload.reason}`))
+      process.exit(1)
+    }
+    s.stop(c.red(`Claim timed out. Run "typeclaw role claim" again to retry.`))
+    process.exit(1)
+  },
+})
+
+const listSub = defineCommand({
+  meta: {
+    name: 'list',
+    description: 'show the roles declared on this agent (typeclaw.json#roles)',
+  },
+  async run() {
+    const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+    const { loadConfigSync } = await import('@/config')
+    const config = loadConfigSync(cwd)
+    if (!config.roles || Object.keys(config.roles).length === 0) {
+      console.log(c.dim('No roles declared. Run `typeclaw role claim` to add one, or edit typeclaw.json by hand.'))
+      return
+    }
+    for (const [name, role] of Object.entries(config.roles)) {
+      console.log(c.bold(name))
+      if (role.match.length === 0) {
+        console.log(`  ${c.dim('(no match rules)')}`)
+      }
+      for (const rule of role.match) {
+        console.log(`  match: ${describeRule(rule)}`)
+      }
+      if (role.permissions !== undefined) {
+        for (const perm of role.permissions) {
+          console.log(`  permission: ${perm}`)
+        }
+      }
+    }
+  },
+})
+
+export const roleCommand = defineCommand({
+  meta: {
+    name: 'role',
+    description: 'manage role memberships on this agent',
+  },
+  subCommands: {
+    claim: () => Promise.resolve(claimSub),
+    list: () => Promise.resolve(listSub),
+  },
+})
+
+async function defaultUrl(): Promise<string> {
+  const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+  const port = await resolveHostPort({ cwd })
+  const token = await resolveTuiToken({ cwd })
+  const url = new URL(`ws://127.0.0.1:${port}`)
+  if (token !== null) url.searchParams.set('token', token)
+  return url.toString()
+}
+
+function formatDuration(sec: number): string {
+  if (sec < 60) return `${sec}s`
+  const m = Math.floor(sec / 60)
+  const s = sec % 60
+  if (s === 0) return `${m}m`
+  return `${m}m ${s}s`
+}
+
+function describeRule(rule: unknown): string {
+  return JSON.stringify(rule)
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -319,7 +319,16 @@ export const FIELD_EFFECTS: Record<string, FieldEffect> = {
   network: 'restart-required',
   'docker.file': 'restart-required',
   'git.ignore': 'restart-required',
-  roles: 'restart-required',
+  // Split: `match` lists are reload-safe (typeclaw role claim, hand-edits
+  // adding/removing match rules apply without a container restart);
+  // `permissions` lists are restart-required (changing what a role can DO
+  // is a bigger deal than changing WHO fills it, and several consumers —
+  // plugin contexts, the security plugin guards — capture the permissions
+  // contract at boot). The diff machinery in diffConfig() understands
+  // `roles.match` and `roles.permissions` as virtual paths and compares
+  // the corresponding projections of the whole `roles` block.
+  'roles.match': 'applied',
+  'roles.permissions': 'restart-required',
 }
 
 // Stable JSON for value comparison. Fields are small JSON-shaped objects, so
@@ -358,12 +367,27 @@ function diffConfig(before: Config, after: Config): ConfigReloadDiff {
 }
 
 function readPath(obj: unknown, path: string): unknown {
+  if (path === 'roles.match') return projectRoles(obj, 'match')
+  if (path === 'roles.permissions') return projectRoles(obj, 'permissions')
   let cur: unknown = obj
   for (const part of path.split('.')) {
     if (cur === null || cur === undefined) return undefined
     cur = (cur as Record<string, unknown>)[part]
   }
   return cur
+}
+
+function projectRoles(obj: unknown, field: 'match' | 'permissions'): unknown {
+  if (typeof obj !== 'object' || obj === null) return undefined
+  const roles = (obj as Record<string, unknown>).roles
+  if (typeof roles !== 'object' || roles === null) return undefined
+  const projection: Record<string, unknown> = {}
+  for (const [roleName, roleVal] of Object.entries(roles as Record<string, unknown>)) {
+    if (typeof roleVal !== 'object' || roleVal === null) continue
+    const val = (roleVal as Record<string, unknown>)[field]
+    if (val !== undefined) projection[roleName] = val
+  }
+  return projection
 }
 
 // Plugin configs live at the top level of typeclaw.json keyed by plugin name

--- a/src/config/reloadable.roles.test.ts
+++ b/src/config/reloadable.roles.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { createPermissionService, type RolesConfig } from '@/permissions'
+
+import { __resetConfigForTesting, reloadConfig } from './config'
+import { createConfigReloadable } from './reloadable'
+
+afterEach(() => {
+  __resetConfigForTesting()
+})
+
+function freshAgentDir(initial: Record<string, unknown>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'typeclaw-reload-roles-'))
+  writeFileSync(join(dir, 'typeclaw.json'), `${JSON.stringify(initial, null, 2)}\n`)
+  return dir
+}
+
+describe('config reload: roles split between match (applied) and permissions (restart-required)', () => {
+  test('changing only roles.<name>.match → reported as applied and permissions.replaceRoles is called', async () => {
+    const cwd = freshAgentDir({
+      model: 'openai/gpt-5.4-mini',
+      roles: { owner: { match: ['tui'] } },
+    })
+    reloadConfig(cwd)
+
+    const initialRoles: RolesConfig = { owner: { match: [{ kind: 'tui' }] } }
+    const permissions = createPermissionService({ roles: initialRoles })
+    expect(permissions.has({ kind: 'tui', sessionId: 's1' }, 'channel.respond')).toBe(true)
+    expect(
+      permissions.has(
+        {
+          kind: 'channel',
+          adapter: 'slack-bot',
+          workspace: 'T0123',
+          chat: 'C0',
+          thread: null,
+          lastInboundAuthorId: 'U_ME',
+        },
+        'channel.respond',
+      ),
+    ).toBe(false)
+
+    writeFileSync(
+      join(cwd, 'typeclaw.json'),
+      `${JSON.stringify(
+        {
+          model: 'openai/gpt-5.4-mini',
+          roles: { owner: { match: ['tui', 'slack:T0123 author:U_ME'] } },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    const reloadable = createConfigReloadable({ cwd, permissions })
+    const result = await reloadable.reload()
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.details).toBeDefined()
+    const details = result.details as { applied: { path: string }[]; restartRequired: { path: string }[] }
+    expect(details.applied.map((c) => c.path)).toContain('roles.match')
+    expect(details.restartRequired.map((c) => c.path)).not.toContain('roles.permissions')
+
+    expect(
+      permissions.has(
+        {
+          kind: 'channel',
+          adapter: 'slack-bot',
+          workspace: 'T0123',
+          chat: 'C0',
+          thread: null,
+          lastInboundAuthorId: 'U_ME',
+        },
+        'channel.respond',
+      ),
+    ).toBe(true)
+  })
+
+  test('changing roles.<name>.permissions → reported as restart-required', async () => {
+    const cwd = freshAgentDir({
+      model: 'openai/gpt-5.4-mini',
+      roles: { member: { match: ['slack:T0123'], permissions: ['channel.respond'] } },
+    })
+    reloadConfig(cwd)
+
+    writeFileSync(
+      join(cwd, 'typeclaw.json'),
+      `${JSON.stringify(
+        {
+          model: 'openai/gpt-5.4-mini',
+          roles: {
+            member: {
+              match: ['slack:T0123'],
+              permissions: ['channel.respond', 'cron.schedule'],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    const reloadable = createConfigReloadable({ cwd })
+    const result = await reloadable.reload()
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const details = result.details as { applied: { path: string }[]; restartRequired: { path: string }[] }
+    expect(details.restartRequired.map((c) => c.path)).toContain('roles.permissions')
+    expect(details.applied.map((c) => c.path)).not.toContain('roles.permissions')
+  })
+})

--- a/src/config/reloadable.test.ts
+++ b/src/config/reloadable.test.ts
@@ -230,4 +230,4 @@ function shouldRecurse(path: string): boolean {
   return path === 'docker' || path === 'git' || path === 'permissions'
 }
 
-const KNOWN_OPTIONAL_PATHS = new Set<string>(['roles'])
+const KNOWN_OPTIONAL_PATHS = new Set<string>(['roles.match', 'roles.permissions'])

--- a/src/config/reloadable.ts
+++ b/src/config/reloadable.ts
@@ -1,20 +1,27 @@
+import type { PermissionService } from '@/permissions'
 import type { Reloadable, ReloadResult } from '@/reload'
 
-import { type ConfigReloadDiff, reloadConfig, validateConfig } from './config'
+import { getConfig, type ConfigReloadDiff, reloadConfig, validateConfig } from './config'
 
 export type CreateConfigReloadableOptions = {
   cwd: string
+  // Optional hook fired after a successful reload so the live permission
+  // service can rebuild its resolved role table from the new roles config.
+  // This is what makes `roles.<name>.match` edits (typeclaw role claim,
+  // hand-edits) take effect without a container restart. `roles.<name>.permissions`
+  // changes still require a restart — see FIELD_EFFECTS in config.ts.
+  permissions?: PermissionService
 }
 
-export function createConfigReloadable({ cwd }: CreateConfigReloadableOptions): Reloadable {
+export function createConfigReloadable({ cwd, permissions }: CreateConfigReloadableOptions): Reloadable {
   return {
     scope: 'config',
     description: 'typeclaw.json runtime config',
-    reload: async () => doReload(cwd),
+    reload: async () => doReload(cwd, permissions),
   }
 }
 
-async function doReload(cwd: string): Promise<ReloadResult> {
+async function doReload(cwd: string, permissions: PermissionService | undefined): Promise<ReloadResult> {
   // Mount accessibility belongs to the validation surface, not loadConfigSync —
   // validateConfig is the single gate that every host-side caller goes through.
   // Run it before swapping the live config pointer so a mount that vanished
@@ -32,6 +39,10 @@ async function doReload(cwd: string): Promise<ReloadResult> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     return { scope: 'config', ok: false, reason: message }
+  }
+
+  if (permissions !== undefined && diff.applied.some((c) => c.path === 'roles.match')) {
+    permissions.replaceRoles(getConfig().roles)
   }
 
   return {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -81,7 +81,15 @@ export type InitStepEvent =
 // portbroker — same path `typeclaw start` takes. When omitted (test fixtures,
 // programmatic callers that never want a daemon), `start()` skips the daemon
 // path entirely and the container runs unmanaged.
-export type HatchRunner = (options: { cwd: string; port: number; cliEntry?: string }) => Promise<HatchingResult>
+export type HatchRunner = (options: {
+  cwd: string
+  port: number
+  cliEntry?: string
+  // Set when the wizard wired at least one channel adapter, so the runner
+  // can offer to run `typeclaw role claim` after the container is ready.
+  // Empty / undefined means "no channels — skip the claim flow".
+  configuredChannels?: readonly ChannelKind[]
+}) => Promise<HatchingResult>
 
 export type KakaotalkAuthRunner = (options: { cwd: string }) => Promise<KakaotalkAuthResult>
 
@@ -223,8 +231,19 @@ export async function runInit({
   const git = await initGitRepo(cwd)
   emit({ step: 'git', phase: 'done', result: git })
 
+  const configuredChannels: ChannelKind[] = []
+  if (wantsDiscord) configuredChannels.push('discord-bot')
+  if (wantsSlack) configuredChannels.push('slack-bot')
+  if (wantsTelegram) configuredChannels.push('telegram-bot')
+  if (withKakaotalk) configuredChannels.push('kakaotalk')
+
   emit({ step: 'hatching', phase: 'start' })
-  const hatching = await runHatching({ cwd, port: config.port, ...(cliEntry !== undefined ? { cliEntry } : {}) })
+  const hatching = await runHatching({
+    cwd,
+    port: config.port,
+    ...(cliEntry !== undefined ? { cliEntry } : {}),
+    ...(configuredChannels.length > 0 ? { configuredChannels } : {}),
+  })
   emit({ step: 'hatching', phase: 'done', result: hatching })
 }
 
@@ -238,16 +257,20 @@ export async function defaultRunHatching({
   cwd,
   port,
   cliEntry,
+  configuredChannels,
   startContainer = start,
   tui: tuiFactory = createTui,
   waitForAgent: waitForAgentFn = waitForAgent,
+  runClaim = defaultRunClaim,
 }: {
   cwd: string
   port: number
   cliEntry?: string
+  configuredChannels?: readonly ChannelKind[]
   startContainer?: typeof start
   tui?: typeof createTui
   waitForAgent?: typeof waitForAgent
+  runClaim?: ClaimRunner
 }): Promise<HatchingResult> {
   try {
     const launch = await startContainer({
@@ -264,6 +287,11 @@ export async function defaultRunHatching({
 
     await waitForAgentFn(`http://127.0.0.1:${hostPort}`, { timeoutMs: 30_000 })
 
+    if (configuredChannels !== undefined && configuredChannels.length > 0) {
+      const url = buildTuiUrl(hostPort, launch.tuiToken)
+      await runClaim({ url, configuredChannels })
+    }
+
     const tui = tuiFactory({
       url: buildTuiUrl(hostPort, launch.tuiToken),
       initialPrompt: HATCHING_PROMPT,
@@ -273,6 +301,13 @@ export async function defaultRunHatching({
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
   }
+}
+
+export type ClaimRunner = (options: { url: string; configuredChannels: readonly ChannelKind[] }) => Promise<void>
+
+const defaultRunClaim: ClaimRunner = async ({ url, configuredChannels }) => {
+  const { runOwnerClaim } = await import('./run-owner-claim')
+  await runOwnerClaim({ url, configuredChannels })
 }
 
 function buildTuiUrl(hostPort: number, token: string | null): string {

--- a/src/init/run-owner-claim.ts
+++ b/src/init/run-owner-claim.ts
@@ -1,0 +1,77 @@
+import { confirm, isCancel, log, note, spinner } from '@clack/prompts'
+
+import { c } from '@/cli/ui'
+import { runClaimSession } from '@/role-claim'
+
+import type { ChannelKind } from './index'
+
+const CHANNEL_LABELS: Record<ChannelKind, string> = {
+  'slack-bot': 'Slack',
+  'discord-bot': 'Discord',
+  'telegram-bot': 'Telegram',
+  kakaotalk: 'KakaoTalk',
+}
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000
+
+export type RunOwnerClaimOptions = {
+  url: string
+  configuredChannels: readonly ChannelKind[]
+}
+
+// Drives the post-hatching claim flow: ask the operator whether to pair now,
+// run the claim handshake against the running container, print the result.
+// Aborts (kind: 'cancel' or a clack cancel) drop straight back into the
+// normal hatching path so the TUI still opens — the operator can run
+// `typeclaw role claim` later.
+export async function runOwnerClaim({ url, configuredChannels }: RunOwnerClaimOptions): Promise<void> {
+  if (configuredChannels.length === 0) return
+
+  const channelList = configuredChannels.map((c) => CHANNEL_LABELS[c] ?? c).join(', ')
+
+  const proceed = await confirm({
+    message: `Claim owner role on ${channelList} now?`,
+    initialValue: true,
+  })
+  if (isCancel(proceed) || proceed === false) {
+    log.info(`Skipping. Run ${c.bold('typeclaw role claim')} later when you're ready.`)
+    return
+  }
+
+  const s = spinner()
+  s.start('Generating your claim code...')
+
+  const result = await runClaimSession({
+    url,
+    role: 'owner',
+    ttlMs: DEFAULT_TTL_MS,
+    onStarted: (payload) => {
+      const expiresInMin = Math.max(1, Math.round((payload.expiresAt - Date.now()) / 60_000))
+      s.stop('Code ready.')
+      note(
+        [
+          `Open ${channelList} and DM your bot with this code:`,
+          '',
+          `  ${c.bold(payload.code)}`,
+          '',
+          `(expires in ~${expiresInMin}m)`,
+        ].join('\n'),
+        'Claim your owner role',
+      )
+      s.start('Waiting for your DM...')
+    },
+  })
+
+  if (result.kind === 'completed') {
+    s.stop(c.green(`Paired as owner.`))
+    log.info(`Match rule added to typeclaw.json#roles.owner.match: ${c.bold(result.payload.matchRule)}`)
+    return
+  }
+  if (result.kind === 'error') {
+    s.stop(c.red(`Claim failed: ${result.payload.reason}`))
+    log.info(`You can retry with ${c.bold('typeclaw role claim')} anytime.`)
+    return
+  }
+  s.stop(c.yellow(`Claim timed out — no DM received within the window.`))
+  log.info(`Run ${c.bold('typeclaw role claim')} when you're ready.`)
+}

--- a/src/permissions/grant.test.ts
+++ b/src/permissions/grant.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { grantRole } from './grant'
+
+function freshAgentDir(initialConfig: Record<string, unknown> = {}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'typeclaw-grant-test-'))
+  writeFileSync(join(dir, 'typeclaw.json'), `${JSON.stringify(initialConfig, null, 2)}\n`)
+  return dir
+}
+
+function readConfig(dir: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(dir, 'typeclaw.json'), 'utf8'))
+}
+
+describe('grantRole', () => {
+  test('appends to roles.<name>.match, creating the block when missing', () => {
+    const dir = freshAgentDir({ model: 'openai/gpt-4o-mini' })
+    const result = grantRole({ cwd: dir, roleName: 'owner', matchRule: 'slack:T0123 author:U_ME' })
+    expect(result).toEqual({ ok: true, added: true })
+
+    const config = readConfig(dir)
+    expect(config.roles).toEqual({
+      owner: { match: ['slack:T0123 author:U_ME'] },
+    })
+    expect(config.model).toBe('openai/gpt-4o-mini')
+  })
+
+  test('idempotent: re-granting same rule returns added: false', () => {
+    const dir = freshAgentDir({
+      roles: { owner: { match: ['slack:T0123 author:U_ME'] } },
+    })
+    const result = grantRole({ cwd: dir, roleName: 'owner', matchRule: 'slack:T0123 author:U_ME' })
+    expect(result).toEqual({ ok: true, added: false })
+  })
+
+  test('appends to existing match list without duplicating', () => {
+    const dir = freshAgentDir({
+      roles: { owner: { match: ['tui'] } },
+    })
+    const result = grantRole({ cwd: dir, roleName: 'owner', matchRule: 'slack:T0123 author:U_ME' })
+    expect(result).toEqual({ ok: true, added: true })
+
+    const config = readConfig(dir) as { roles: { owner: { match: string[] } } }
+    expect(config.roles.owner.match).toEqual(['tui', 'slack:T0123 author:U_ME'])
+  })
+
+  test('creates new role block when the role is not yet declared', () => {
+    const dir = freshAgentDir({})
+    const result = grantRole({ cwd: dir, roleName: 'member', matchRule: 'slack:T0123 author:U_BOB' })
+    expect(result).toEqual({ ok: true, added: true })
+
+    const config = readConfig(dir) as { roles: { member: { match: string[] } } }
+    expect(config.roles.member.match).toEqual(['slack:T0123 author:U_BOB'])
+  })
+
+  test('rejects malformed match rules', () => {
+    const dir = freshAgentDir({})
+    const result = grantRole({ cwd: dir, roleName: 'owner', matchRule: 'team:T0123' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toContain("legacy prefix 'team'")
+    }
+  })
+
+  test('rejects missing typeclaw.json', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'typeclaw-grant-test-'))
+    const result = grantRole({ cwd: dir, roleName: 'owner', matchRule: 'tui' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toContain('not found')
+    }
+  })
+
+  test('rejects invalid JSON', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'typeclaw-grant-test-'))
+    writeFileSync(join(dir, 'typeclaw.json'), '{ not valid json')
+    const result = grantRole({ cwd: dir, roleName: 'owner', matchRule: 'tui' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toContain('not valid JSON')
+    }
+  })
+
+  test('preserves unrelated fields and existing roles', () => {
+    const dir = freshAgentDir({
+      model: 'openai/gpt-4o-mini',
+      channels: { 'slack-bot': {} },
+      roles: {
+        owner: { match: ['tui'] },
+        member: { match: ['slack:T0123'] },
+      },
+    })
+    grantRole({ cwd: dir, roleName: 'owner', matchRule: 'slack:T0123 author:U_ME' })
+
+    const config = readConfig(dir) as {
+      model: string
+      channels: Record<string, unknown>
+      roles: Record<string, { match: string[] } | undefined>
+    }
+    expect(config.model).toBe('openai/gpt-4o-mini')
+    expect(config.channels).toEqual({ 'slack-bot': {} })
+    expect(config.roles.owner?.match).toEqual(['tui', 'slack:T0123 author:U_ME'])
+    expect(config.roles.member?.match).toEqual(['slack:T0123'])
+  })
+})

--- a/src/permissions/grant.ts
+++ b/src/permissions/grant.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { parseMatchRule } from './match-rule'
+
+// Appends `rule` to `typeclaw.json#roles.<name>.match`, creating the role
+// block when missing. Idempotent: re-granting the same rule is a no-op.
+// Atomic: writes via temp+rename so a crashed write never leaves a partial
+// JSON file that would brick the next `typeclaw start`.
+//
+// Used by the role-claim flow (after a successful handshake) and by any
+// future operator-direct grant command. The match rule is validated
+// against the same parser that runs at config load, so a malformed rule
+// fails here instead of bricking the next start.
+
+const CONFIG_FILE = 'typeclaw.json'
+
+export type GrantResult = { ok: true; added: boolean } | { ok: false; reason: string }
+
+export type GrantOptions = {
+  cwd: string
+  roleName: string
+  matchRule: string
+}
+
+export function grantRole(opts: GrantOptions): GrantResult {
+  const validation = parseMatchRule(opts.matchRule)
+  if (!validation.ok) {
+    return { ok: false, reason: `invalid match rule '${opts.matchRule}': ${validation.error}` }
+  }
+
+  const path = join(opts.cwd, CONFIG_FILE)
+  if (!existsSync(path)) {
+    return { ok: false, reason: `${CONFIG_FILE} not found at ${opts.cwd}` }
+  }
+
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch (error) {
+    return { ok: false, reason: `failed to read ${CONFIG_FILE}: ${describeError(error)}` }
+  }
+
+  let json: unknown
+  try {
+    json = JSON.parse(raw)
+  } catch (error) {
+    return { ok: false, reason: `${CONFIG_FILE} is not valid JSON: ${describeError(error)}` }
+  }
+
+  if (typeof json !== 'object' || json === null || Array.isArray(json)) {
+    return { ok: false, reason: `${CONFIG_FILE} must be a JSON object` }
+  }
+
+  const obj = json as Record<string, unknown>
+  const roles = isPlainObject(obj.roles) ? { ...obj.roles } : {}
+  const role = isPlainObject(roles[opts.roleName]) ? { ...(roles[opts.roleName] as Record<string, unknown>) } : {}
+  const existingMatch = Array.isArray(role.match) ? [...(role.match as unknown[])] : []
+
+  // Dedup by exact string equality — match rules canonicalize during load,
+  // and a literal duplicate in the file is a noise source the schema doesn't
+  // currently dedupe for us.
+  if (existingMatch.includes(opts.matchRule)) {
+    return { ok: true, added: false }
+  }
+
+  role.match = [...existingMatch, opts.matchRule]
+  roles[opts.roleName] = role
+  obj.roles = roles
+
+  try {
+    writeAtomic(path, `${JSON.stringify(obj, null, 2)}\n`)
+  } catch (error) {
+    return { ok: false, reason: `failed to write ${CONFIG_FILE}: ${describeError(error)}` }
+  }
+
+  return { ok: true, added: true }
+}
+
+function writeAtomic(path: string, content: string): void {
+  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`
+  writeFileSync(tmp, content)
+  try {
+    renameSync(tmp, path)
+  } catch (error) {
+    try {
+      unlinkSync(tmp)
+    } catch {}
+    throw error
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -24,5 +24,6 @@ export {
   type PermissionService,
   type UnknownPermissionWarning,
 } from './permissions'
+export { grantRole, type GrantOptions, type GrantResult } from './grant'
 export { matchesOrigin, type MatchableOrigin } from './resolve'
 export { MATCH_RULE_JSON_SCHEMA_PATTERN, rolesConfigSchema, type RoleConfig, type RolesConfig } from './schema'

--- a/src/permissions/permissions.ts
+++ b/src/permissions/permissions.ts
@@ -9,6 +9,11 @@ export type PermissionService = {
   has(origin: SessionOrigin | undefined, permission: string): boolean
   resolveRole(origin: SessionOrigin | undefined): string
   describe(origin: SessionOrigin | undefined): { role: string; permissions: readonly string[] }
+  // Rebuilds the resolved role table from the given roles config, preserving
+  // the same plugin-permission set captured at construction time. Used by
+  // the config reloadable so role match-rule edits (typeclaw role claim,
+  // hand-edits to typeclaw.json) take effect without a container restart.
+  replaceRoles(roles: RolesConfig | undefined): void
 }
 
 export type UnknownPermissionWarning = {
@@ -21,6 +26,7 @@ export const noopPermissionService: PermissionService = {
   has: () => false,
   resolveRole: () => 'guest',
   describe: () => ({ role: 'guest', permissions: [] }),
+  replaceRoles: () => {},
 }
 
 type ResolvedRole = {
@@ -90,8 +96,9 @@ function levenshtein(a: string, b: string): number {
 }
 
 export function createPermissionService(opts: CreatePermissionServiceOptions = {}): PermissionService {
-  const resolved = buildRoleTable(opts.roles ?? {}, opts.pluginPermissions ?? [])
-  const byName = new Map(resolved.map((r) => [r.name, r]))
+  const pluginPermissions = opts.pluginPermissions ?? []
+  let resolved = buildRoleTable(opts.roles ?? {}, pluginPermissions)
+  let byName = new Map(resolved.map((r) => [r.name, r]))
 
   function resolveRole(origin: SessionOrigin | undefined): string {
     if (origin === undefined) return 'guest'
@@ -130,6 +137,10 @@ export function createPermissionService(opts: CreatePermissionServiceOptions = {
       const name = resolveRole(origin)
       const role = byName.get(name)
       return { role: name, permissions: role?.permissions ?? [] }
+    },
+    replaceRoles(roles) {
+      resolved = buildRoleTable(roles ?? {}, pluginPermissions)
+      byName = new Map(resolved.map((r) => [r.name, r]))
     },
   }
 }

--- a/src/role-claim/client.ts
+++ b/src/role-claim/client.ts
@@ -1,0 +1,136 @@
+import type {
+  ClaimCompletedPayload,
+  ClaimErrorPayload,
+  ClaimStartedPayload,
+  ClientMessage,
+  ServerMessage,
+} from '@/shared'
+
+import { generateClaimCode } from './code'
+
+export type ClaimSessionOptions = {
+  url: string
+  role: string
+  channel?: string
+  ttlMs?: number
+  connectTimeoutMs?: number
+  onStarted?: (payload: ClaimStartedPayload) => void
+}
+
+export type ClaimSessionResult =
+  | { kind: 'completed'; payload: ClaimCompletedPayload }
+  | { kind: 'error'; payload: ClaimErrorPayload }
+  | { kind: 'timeout' }
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000
+const DEFAULT_CONNECT_TIMEOUT_MS = 30_000
+
+export async function runClaimSession(opts: ClaimSessionOptions): Promise<ClaimSessionResult> {
+  const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS
+  const connectTimeoutMs = opts.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS
+  const code = generateClaimCode()
+
+  const ws = new WebSocket(opts.url)
+  const displayUrl = redactUrl(opts.url)
+  await waitForOpen(ws, displayUrl, connectTimeoutMs)
+
+  try {
+    const request: ClientMessage = {
+      type: 'claim_start',
+      code,
+      role: opts.role,
+      ttlMs,
+      ...(opts.channel !== undefined ? { channel: opts.channel } : {}),
+    }
+    ws.send(JSON.stringify(request))
+
+    return await waitForOutcome(ws, code, ttlMs, opts.onStarted)
+  } finally {
+    try {
+      const cancel: ClientMessage = { type: 'claim_cancel' }
+      ws.send(JSON.stringify(cancel))
+    } catch {}
+    ws.close()
+  }
+}
+
+async function waitForOpen(ws: WebSocket, displayUrl: string, timeoutMs: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup()
+      ws.close()
+      reject(new Error(`timed out connecting to ${displayUrl} after ${timeoutMs}ms`))
+    }, timeoutMs)
+    const onOpen = () => {
+      cleanup()
+      resolve()
+    }
+    const onError = (err: unknown) => {
+      cleanup()
+      reject(new Error(`failed to connect to ${displayUrl}: ${err instanceof Error ? err.message : String(err)}`))
+    }
+    const onClose = () => {
+      cleanup()
+      reject(new Error(`connection to ${displayUrl} closed before opening`))
+    }
+    const cleanup = () => {
+      clearTimeout(timer)
+      ws.removeEventListener('open', onOpen)
+      ws.removeEventListener('error', onError)
+      ws.removeEventListener('close', onClose)
+    }
+    ws.addEventListener('open', onOpen, { once: true })
+    ws.addEventListener('error', onError, { once: true })
+    ws.addEventListener('close', onClose, { once: true })
+  })
+}
+
+async function waitForOutcome(
+  ws: WebSocket,
+  code: string,
+  ttlMs: number,
+  onStarted?: (payload: ClaimStartedPayload) => void,
+): Promise<ClaimSessionResult> {
+  return new Promise<ClaimSessionResult>((resolve) => {
+    const timer = setTimeout(() => {
+      ws.removeEventListener('message', onMessage)
+      resolve({ kind: 'timeout' })
+    }, ttlMs + 5_000)
+
+    const onMessage = (event: MessageEvent): void => {
+      let msg: ServerMessage
+      try {
+        msg = JSON.parse(String(event.data)) as ServerMessage
+      } catch {
+        return
+      }
+      if (msg.type === 'claim_started' && msg.payload.code === code) {
+        onStarted?.(msg.payload)
+        return
+      }
+      if (msg.type === 'claim_completed' && msg.payload.code === code) {
+        clearTimeout(timer)
+        ws.removeEventListener('message', onMessage)
+        resolve({ kind: 'completed', payload: msg.payload })
+        return
+      }
+      if (msg.type === 'claim_error' && msg.payload.code === code) {
+        clearTimeout(timer)
+        ws.removeEventListener('message', onMessage)
+        resolve({ kind: 'error', payload: msg.payload })
+        return
+      }
+    }
+    ws.addEventListener('message', onMessage)
+  })
+}
+
+function redactUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    if (parsed.searchParams.has('token')) parsed.searchParams.set('token', '<redacted>')
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}

--- a/src/role-claim/code.test.ts
+++ b/src/role-claim/code.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test'
+
+import { CLAIM_CODE_PREFIX, extractClaimCode, generateClaimCode, normalizeClaimCode } from './code'
+
+describe('generateClaimCode', () => {
+  test('emits the canonical shape', () => {
+    const code = generateClaimCode()
+    expect(code).toMatch(/^claim-[0-9A-HJ-NP-TV-Z]{4}-[0-9A-HJ-NP-TV-Z]{4}$/)
+  })
+
+  test('is statistically unique across many invocations', () => {
+    const seen = new Set<string>()
+    for (let i = 0; i < 100; i++) seen.add(generateClaimCode())
+    expect(seen.size).toBe(100)
+  })
+
+  test('starts with the documented prefix', () => {
+    expect(generateClaimCode().startsWith(CLAIM_CODE_PREFIX)).toBe(true)
+  })
+})
+
+describe('extractClaimCode', () => {
+  test('extracts a bare code', () => {
+    expect(extractClaimCode('claim-7K9M-2X3R')).toBe('claim-7K9M-2X3R')
+  })
+
+  test('extracts with surrounding text', () => {
+    expect(extractClaimCode('here you go: claim-7K9M-2X3R!')).toBe('claim-7K9M-2X3R')
+  })
+
+  test('extracts from backticks/quotes', () => {
+    expect(extractClaimCode('`claim-7K9M-2X3R`')).toBe('claim-7K9M-2X3R')
+    expect(extractClaimCode('"claim-7K9M-2X3R"')).toBe('claim-7K9M-2X3R')
+  })
+
+  test('normalizes lowercase to uppercase', () => {
+    expect(extractClaimCode('claim-7k9m-2x3r')).toBe('claim-7K9M-2X3R')
+  })
+
+  test('returns null for no match', () => {
+    expect(extractClaimCode('hello there')).toBeNull()
+    expect(extractClaimCode('claim-toolong-2x3r')).toBeNull()
+    expect(extractClaimCode('claim-7K9M')).toBeNull()
+  })
+})
+
+describe('normalizeClaimCode', () => {
+  test('uppercases the body, preserves prefix', () => {
+    expect(normalizeClaimCode('claim-abcd-1234')).toBe('claim-ABCD-1234')
+  })
+
+  test('trims whitespace', () => {
+    expect(normalizeClaimCode('  claim-ABCD-1234  ')).toBe('claim-ABCD-1234')
+  })
+})

--- a/src/role-claim/code.ts
+++ b/src/role-claim/code.ts
@@ -1,0 +1,53 @@
+import { randomBytes } from 'node:crypto'
+
+// Role-claim codes are short, human-typeable tokens the operator sends from
+// their host CLI to the bot via a channel DM to prove ownership of that
+// channel identity. Shape: `claim-XXXX-YYYY` where each block is 4 chars
+// from a Crockford-style base32 alphabet (0-9 + A-Z minus I, L, O, U to
+// dodge OCR-confusable / profane shapes). 8 chars * 5 bits = 40 bits of
+// entropy, which is overkill for a TTL'd in-memory window but cheap to
+// display and dictate over voice.
+//
+// The `claim-` prefix lets the channel router recognize potential claim
+// attempts in a DM body without scanning the whole text for hex blocks,
+// and distinguishes claim DMs from normal first-message text like "hi"
+// which would otherwise need a regex of its own to disambiguate.
+
+export const CLAIM_CODE_PREFIX = 'claim-'
+
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+const BLOCK_SIZE = 4
+const BLOCK_COUNT = 2
+
+export function generateClaimCode(): string {
+  const bytes = randomBytes(BLOCK_SIZE * BLOCK_COUNT)
+  const chars: string[] = []
+  for (let i = 0; i < bytes.length; i++) {
+    chars.push(ALPHABET[bytes[i]! % ALPHABET.length]!)
+  }
+  const blocks: string[] = []
+  for (let b = 0; b < BLOCK_COUNT; b++) {
+    blocks.push(chars.slice(b * BLOCK_SIZE, (b + 1) * BLOCK_SIZE).join(''))
+  }
+  return `${CLAIM_CODE_PREFIX}${blocks.join('-')}`
+}
+
+// Extracts the first claim-code-shaped token from inbound text. Returns
+// the canonical-case (upper) code, or null. Tolerates surrounding
+// whitespace, punctuation, and case — chat clients may auto-correct case
+// or surround pastes with quotes/backticks.
+export function extractClaimCode(text: string): string | null {
+  const pattern = new RegExp(
+    `${CLAIM_CODE_PREFIX}([0-9a-zA-Z]{${BLOCK_SIZE}}(?:-[0-9a-zA-Z]{${BLOCK_SIZE}}){${BLOCK_COUNT - 1}})`,
+    'i',
+  )
+  const match = pattern.exec(text)
+  if (!match) return null
+  return `${CLAIM_CODE_PREFIX}${match[1]!.toUpperCase()}`
+}
+
+export function normalizeClaimCode(code: string): string {
+  const trimmed = code.trim()
+  if (!trimmed.toLowerCase().startsWith(CLAIM_CODE_PREFIX)) return trimmed.toUpperCase()
+  return `${CLAIM_CODE_PREFIX}${trimmed.slice(CLAIM_CODE_PREFIX.length).toUpperCase()}`
+}

--- a/src/role-claim/controller.test.ts
+++ b/src/role-claim/controller.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { PermissionService, RolesConfig } from '@/permissions'
+
+import { createClaimController, type ClaimResultEvent } from './controller'
+
+function makePermissions(): { service: PermissionService; lastReplacement: RolesConfig | undefined } {
+  let lastReplacement: RolesConfig | undefined
+  const service: PermissionService = {
+    has: () => false,
+    resolveRole: () => 'guest',
+    describe: () => ({ role: 'guest', permissions: [] }),
+    replaceRoles: (roles) => {
+      lastReplacement = roles
+    },
+  }
+  return {
+    service,
+    get lastReplacement() {
+      return lastReplacement
+    },
+  } as unknown as { service: PermissionService; lastReplacement: RolesConfig | undefined }
+}
+
+describe('ClaimController', () => {
+  test('full happy path: start → handler matches → grant + replaceRoles + completed event', async () => {
+    const grants: { role: string; rule: string }[] = []
+    const events: ClaimResultEvent[] = []
+    const provided: RolesConfig = { owner: { match: [] } }
+
+    const { service } = makePermissions()
+    let replaceArg: RolesConfig | undefined
+    service.replaceRoles = (roles) => {
+      replaceArg = roles
+    }
+
+    const controller = createClaimController({
+      cwd: '/nonexistent',
+      permissions: service,
+      rolesProvider: () => provided,
+      grant: (role, rule) => {
+        grants.push({ role, rule })
+        return { ok: true, added: true }
+      },
+      now: () => 1_000_000,
+    })
+
+    controller.onResult((e) => events.push(e))
+
+    const start = controller.startClaim({ code: 'claim-AAAA-BBBB', role: 'owner', ttlMs: 600_000 })
+    expect(start.ok).toBe(true)
+
+    const outcome = await controller.claimHandler({
+      adapter: 'slack-bot',
+      workspace: 'T0123',
+      chat: 'D0',
+      isDm: true,
+      authorId: 'U_ME',
+      text: 'claim-AAAA-BBBB',
+    })
+
+    expect(outcome.kind).toBe('consumed')
+    expect(grants).toEqual([{ role: 'owner', rule: 'slack:T0123 author:U_ME' }])
+    expect(replaceArg).toBe(provided)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.kind).toBe('completed')
+    if (events[0]!.kind === 'completed') {
+      expect(events[0]!.role).toBe('owner')
+      expect(events[0]!.matchRule).toBe('slack:T0123 author:U_ME')
+      expect(events[0]!.authorId).toBe('U_ME')
+    }
+  })
+
+  test('no pending claim → fallthrough, no grant, no event', async () => {
+    const grants: { role: string; rule: string }[] = []
+    const events: ClaimResultEvent[] = []
+    const { service } = makePermissions()
+    const controller = createClaimController({
+      cwd: '/x',
+      permissions: service,
+      rolesProvider: () => ({}),
+      grant: (role, rule) => {
+        grants.push({ role, rule })
+        return { ok: true, added: true }
+      },
+    })
+    controller.onResult((e) => events.push(e))
+
+    const outcome = await controller.claimHandler({
+      adapter: 'slack-bot',
+      workspace: 'T0123',
+      chat: 'D0',
+      isDm: true,
+      authorId: 'U_ME',
+      text: 'claim-AAAA-BBBB',
+    })
+
+    expect(outcome).toEqual({ kind: 'fallthrough' })
+    expect(grants).toEqual([])
+    expect(events).toEqual([])
+  })
+
+  test('wrong code with active pending → fallthrough (preserves pending)', async () => {
+    const events: ClaimResultEvent[] = []
+    const { service } = makePermissions()
+    const controller = createClaimController({
+      cwd: '/x',
+      permissions: service,
+      rolesProvider: () => ({}),
+      grant: () => ({ ok: true, added: true }),
+      now: () => 1_000_000,
+    })
+    controller.onResult((e) => events.push(e))
+
+    controller.startClaim({ code: 'claim-AAAA-BBBB', role: 'owner', ttlMs: 600_000 })
+
+    const outcome = await controller.claimHandler({
+      adapter: 'slack-bot',
+      workspace: 'T0123',
+      chat: 'D0',
+      isDm: true,
+      authorId: 'U_ME',
+      text: 'claim-WRONG-CODE',
+    })
+
+    expect(outcome).toEqual({ kind: 'fallthrough' })
+    expect(controller.current()?.code).toBe('claim-AAAA-BBBB')
+  })
+
+  test('channel-scoped pending rejects inbound from other adapter', async () => {
+    const events: ClaimResultEvent[] = []
+    const { service } = makePermissions()
+    const controller = createClaimController({
+      cwd: '/x',
+      permissions: service,
+      rolesProvider: () => ({}),
+      grant: () => ({ ok: true, added: true }),
+      now: () => 1_000_000,
+    })
+    controller.onResult((e) => events.push(e))
+
+    controller.startClaim({
+      code: 'claim-AAAA-BBBB',
+      role: 'owner',
+      channel: 'slack-bot',
+      ttlMs: 600_000,
+    })
+
+    const outcome = await controller.claimHandler({
+      adapter: 'discord-bot',
+      workspace: 'g',
+      chat: 'c',
+      isDm: true,
+      authorId: 'U',
+      text: 'claim-AAAA-BBBB',
+    })
+
+    expect(outcome.kind).toBe('fail')
+    expect(events).toHaveLength(1)
+    expect(events[0]!.kind).toBe('error')
+  })
+
+  test('grant failure surfaces an error event and a fail reply', async () => {
+    const events: ClaimResultEvent[] = []
+    const { service } = makePermissions()
+    const controller = createClaimController({
+      cwd: '/x',
+      permissions: service,
+      rolesProvider: () => ({}),
+      grant: () => ({ ok: false, reason: 'disk full' }),
+      now: () => 1_000_000,
+    })
+    controller.onResult((e) => events.push(e))
+    controller.startClaim({ code: 'claim-AAAA-BBBB', role: 'owner', ttlMs: 600_000 })
+
+    const outcome = await controller.claimHandler({
+      adapter: 'slack-bot',
+      workspace: 'T0123',
+      chat: 'D0',
+      isDm: true,
+      authorId: 'U_ME',
+      text: 'claim-AAAA-BBBB',
+    })
+
+    expect(outcome.kind).toBe('fail')
+    if (outcome.kind === 'fail') {
+      expect(outcome.reply).toContain('disk full')
+    }
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({ kind: 'error', code: 'claim-AAAA-BBBB', reason: 'disk full' })
+  })
+
+  test('rejects unknown role names at startClaim', () => {
+    const { service } = makePermissions()
+    const controller = createClaimController({
+      cwd: '/x',
+      permissions: service,
+      rolesProvider: () => ({}),
+      grant: () => ({ ok: true, added: true }),
+    })
+
+    const result = controller.startClaim({ code: 'claim-AAAA-BBBB', role: 'guest', ttlMs: 600_000 })
+    expect(result.ok).toBe(false)
+  })
+
+  test('cancelClaim emits cancelled and clears pending', () => {
+    const events: ClaimResultEvent[] = []
+    const { service } = makePermissions()
+    const controller = createClaimController({
+      cwd: '/x',
+      permissions: service,
+      rolesProvider: () => ({}),
+      grant: () => ({ ok: true, added: true }),
+      now: () => 1_000_000,
+    })
+    controller.onResult((e) => events.push(e))
+
+    controller.startClaim({ code: 'claim-AAAA-BBBB', role: 'owner', ttlMs: 600_000 })
+    expect(controller.cancelClaim('claim-AAAA-BBBB')).toBe(true)
+    expect(controller.current()).toBeNull()
+    expect(events).toEqual([{ kind: 'cancelled', code: 'claim-AAAA-BBBB' }])
+
+    expect(controller.cancelClaim('claim-OTHER-CODE')).toBe(false)
+  })
+})

--- a/src/role-claim/controller.ts
+++ b/src/role-claim/controller.ts
@@ -1,0 +1,194 @@
+import type { ClaimHandler } from '@/channels/router'
+import { grantRole, type PermissionService } from '@/permissions'
+
+import { extractClaimCode } from './code'
+import { formatClaimMatchRule } from './match-rule'
+import { createPendingClaimRegistry, type PendingClaim, type PendingClaimRegistry } from './pending'
+
+// ClaimController is the runtime singleton that ties the four moving parts
+// of the role-claim flow together:
+//
+//   1. The host CLI (typeclaw role claim) opens a WS and sends `claim_start`.
+//   2. The WS server forwards that to controller.startClaim().
+//   3. The channel router's claimHandler (also wired here) intercepts DMs
+//      bearing the code and calls controller.tryConsumeInbound().
+//   4. On consume, the controller writes to typeclaw.json#roles.<role>.match
+//      via grantRole, then reloads the live PermissionService so the new
+//      match rule takes effect without a container restart.
+//
+// Result events (completed / error / cancelled) are pushed to subscribers
+// the WS server registers, so the host CLI's open WS receives the outcome
+// over the same connection.
+
+export type ClaimCompletedEvent = {
+  kind: 'completed'
+  code: string
+  role: string
+  matchRule: string
+  adapter: string
+  authorId: string
+}
+
+export type ClaimErrorEvent = {
+  kind: 'error'
+  code: string
+  reason: string
+}
+
+export type ClaimCancelledEvent = {
+  kind: 'cancelled'
+  code: string
+}
+
+export type ClaimResultEvent = ClaimCompletedEvent | ClaimErrorEvent | ClaimCancelledEvent
+
+export type ClaimController = {
+  startClaim: (input: { code: string; role: string; channel?: string; ttlMs: number }) =>
+    | {
+        ok: true
+        expiresAt: number
+      }
+    | { ok: false; reason: string }
+  cancelClaim: (code: string) => boolean
+  current: () => PendingClaim | null
+  onResult: (subscriber: (event: ClaimResultEvent) => void) => () => void
+  claimHandler: ClaimHandler
+}
+
+export type CreateClaimControllerOptions = {
+  cwd: string
+  permissions: PermissionService
+  rolesProvider: () => import('@/permissions').RolesConfig | undefined
+  now?: () => number
+  registry?: PendingClaimRegistry
+  // Test seam: injectable role granter so tests don't touch disk. Production
+  // wires the real `grantRole` from src/permissions/grant.ts.
+  grant?: (roleName: string, matchRule: string) => { ok: true; added: boolean } | { ok: false; reason: string }
+  logger?: { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void }
+}
+
+const KNOWN_BUILT_IN_ROLES = new Set(['owner', 'member', 'trusted'])
+
+export function createClaimController(opts: CreateClaimControllerOptions): ClaimController {
+  const now = opts.now ?? Date.now
+  const registry = opts.registry ?? createPendingClaimRegistry({ now })
+  const grant =
+    opts.grant ?? ((roleName: string, matchRule: string) => grantRole({ cwd: opts.cwd, roleName, matchRule }))
+  const logger = opts.logger ?? defaultLogger
+  const subscribers = new Set<(event: ClaimResultEvent) => void>()
+
+  const emit = (event: ClaimResultEvent): void => {
+    for (const sub of subscribers) {
+      try {
+        sub(event)
+      } catch (err) {
+        logger.warn(`[role-claim] subscriber threw: ${describe(err)}`)
+      }
+    }
+  }
+
+  const startClaim: ClaimController['startClaim'] = ({ code, role, channel, ttlMs }) => {
+    if (!isValidRoleName(role)) {
+      return { ok: false, reason: `unknown role '${role}' — built-in roles are owner, member, trusted` }
+    }
+    const startedAt = now()
+    const pending: PendingClaim = {
+      code,
+      role,
+      ttlMs,
+      startedAt,
+      expiresAt: startedAt + ttlMs,
+      ...(channel !== undefined ? { channel } : {}),
+    }
+    registry.start(pending)
+    return { ok: true, expiresAt: pending.expiresAt }
+  }
+
+  const claimHandler: ClaimHandler = async (input) => {
+    const code = extractClaimCode(input.text)
+    if (code === null) return { kind: 'fallthrough' }
+
+    const result = registry.tryConsume(
+      code,
+      {
+        adapter: input.adapter,
+        workspace: input.workspace,
+        chat: input.chat,
+        isDm: input.isDm,
+        authorId: input.authorId,
+      },
+      formatClaimMatchRule,
+    )
+
+    if (result.kind === 'no-pending') return { kind: 'fallthrough' }
+    if (result.kind === 'no-match') return { kind: 'fallthrough' }
+    if (result.kind === 'wrong-channel') {
+      const reply = `That claim is for a different channel — please run typeclaw role claim again on this one.`
+      emit({ kind: 'error', code, reason: 'wrong-channel' })
+      return { kind: 'fail', reply }
+    }
+    if (result.kind === 'expired') {
+      const reply = `That claim code has expired. Run typeclaw role claim again to start a new one.`
+      emit({ kind: 'error', code, reason: 'expired' })
+      return { kind: 'fail', reply }
+    }
+
+    const granted = grant(result.role, result.matchRule)
+    if (!granted.ok) {
+      const reply = `Sorry, I couldn't save your role: ${granted.reason}`
+      emit({ kind: 'error', code, reason: granted.reason })
+      return { kind: 'fail', reply }
+    }
+
+    try {
+      opts.permissions.replaceRoles(opts.rolesProvider())
+    } catch (err) {
+      logger.warn(`[role-claim] replaceRoles failed after grant: ${describe(err)}`)
+    }
+
+    emit({
+      kind: 'completed',
+      code,
+      role: result.role,
+      matchRule: result.matchRule,
+      adapter: result.origin.adapter,
+      authorId: result.origin.authorId,
+    })
+
+    const noteAdded = granted.added ? '' : ' (already on file)'
+    const reply = `You're paired as ${result.role}${noteAdded}. Welcome aboard!`
+    return { kind: 'consumed', reply }
+  }
+
+  return {
+    startClaim,
+    cancelClaim: (code) => {
+      const cancelled = registry.cancel(code)
+      if (cancelled) emit({ kind: 'cancelled', code })
+      return cancelled
+    },
+    current: () => registry.current(),
+    onResult: (sub) => {
+      subscribers.add(sub)
+      return () => {
+        subscribers.delete(sub)
+      }
+    },
+    claimHandler,
+  }
+}
+
+function isValidRoleName(role: string): boolean {
+  if (KNOWN_BUILT_IN_ROLES.has(role)) return true
+  return /^[a-z][a-z0-9-]*$/.test(role) && role !== 'guest'
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+const defaultLogger = {
+  info: (m: string) => console.log(m),
+  warn: (m: string) => console.warn(m),
+  error: (m: string) => console.error(m),
+}

--- a/src/role-claim/index.ts
+++ b/src/role-claim/index.ts
@@ -1,0 +1,19 @@
+export { runClaimSession, type ClaimSessionOptions, type ClaimSessionResult } from './client'
+export { CLAIM_CODE_PREFIX, extractClaimCode, generateClaimCode, normalizeClaimCode } from './code'
+export {
+  createClaimController,
+  type ClaimCancelledEvent,
+  type ClaimCompletedEvent,
+  type ClaimController,
+  type ClaimErrorEvent,
+  type ClaimResultEvent,
+  type CreateClaimControllerOptions,
+} from './controller'
+export { formatClaimMatchRule, type PartialChannelOrigin } from './match-rule'
+export {
+  createPendingClaimRegistry,
+  type ClaimResult,
+  type PendingClaim,
+  type PendingClaimRegistry,
+  type PendingClaimRegistryOptions,
+} from './pending'

--- a/src/role-claim/match-rule.ts
+++ b/src/role-claim/match-rule.ts
@@ -1,0 +1,43 @@
+// Builds a canonical match-rule DSL string from an inbound channel origin,
+// for the role table. Output shapes:
+//
+//   slack:T0123 author:U_ALICE
+//   discord:9999 author:U_ALICE
+//   telegram:42 author:U_ALICE
+//   kakao:dm/<chatId> author:<authorId>
+//
+// The author qualifier is always emitted so a claim grants the specific
+// human, not the whole workspace. To grant the whole workspace, the
+// operator edits typeclaw.json by hand or runs a future `typeclaw role grant`
+// without --claim.
+
+import type { ChannelKey } from '@/channels/types'
+
+export type PartialChannelOrigin = {
+  adapter: ChannelKey['adapter']
+  workspace: string
+  chat: string
+  isDm: boolean
+  authorId: string
+}
+
+const ADAPTER_TO_PLATFORM: Record<ChannelKey['adapter'], 'slack' | 'discord' | 'telegram' | 'kakao'> = {
+  'slack-bot': 'slack',
+  'discord-bot': 'discord',
+  'telegram-bot': 'telegram',
+  kakaotalk: 'kakao',
+}
+
+export function formatClaimMatchRule(origin: PartialChannelOrigin): string {
+  const platform = ADAPTER_TO_PLATFORM[origin.adapter]
+  const authorQual = ` author:${origin.authorId}`
+  if (origin.adapter === 'kakaotalk') {
+    // Kakao has no workspace; routes use dm/group/open buckets. We can't
+    // know which bucket from a partial origin alone (adapter-side classifies
+    // it), so claim flows are restricted to DM and we emit the specific
+    // chat-id form so the rule grants only this 1:1 conversation, not every
+    // DM the agent is in.
+    return `${platform}:dm/${origin.chat}${authorQual}`
+  }
+  return `${platform}:${origin.workspace}${authorQual}`
+}

--- a/src/role-claim/pending.test.ts
+++ b/src/role-claim/pending.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatClaimMatchRule, type PartialChannelOrigin } from './match-rule'
+import { createPendingClaimRegistry } from './pending'
+
+const aliceOnSlack: PartialChannelOrigin = {
+  adapter: 'slack-bot',
+  workspace: 'T0123',
+  chat: 'D0ALICE',
+  isDm: true,
+  authorId: 'U_ALICE',
+}
+
+const bobOnDiscord: PartialChannelOrigin = {
+  adapter: 'discord-bot',
+  workspace: '9999',
+  chat: '8888',
+  isDm: true,
+  authorId: 'U_BOB',
+}
+
+describe('PendingClaimRegistry', () => {
+  test('no pending → tryConsume returns no-pending', () => {
+    const reg = createPendingClaimRegistry()
+    expect(reg.tryConsume('claim-AAAA-BBBB', aliceOnSlack, formatClaimMatchRule)).toEqual({ kind: 'no-pending' })
+  })
+
+  test('consume matching code → returns consumed and clears registry', () => {
+    let nowMs = 1_000_000
+    const reg = createPendingClaimRegistry({ now: () => nowMs })
+    reg.start({
+      code: 'claim-AAAA-BBBB',
+      role: 'owner',
+      ttlMs: 600_000,
+      startedAt: nowMs,
+      expiresAt: nowMs + 600_000,
+    })
+    expect(reg.size()).toBe(1)
+    const result = reg.tryConsume('claim-AAAA-BBBB', aliceOnSlack, formatClaimMatchRule)
+    expect(result).toEqual({
+      kind: 'consumed',
+      code: 'claim-AAAA-BBBB',
+      role: 'owner',
+      matchRule: 'slack:T0123 author:U_ALICE',
+      origin: aliceOnSlack,
+    })
+    expect(reg.size()).toBe(0)
+    expect(reg.tryConsume('claim-AAAA-BBBB', aliceOnSlack, formatClaimMatchRule)).toEqual({ kind: 'no-pending' })
+  })
+
+  test('wrong code returns no-match without clearing the pending claim', () => {
+    let nowMs = 1_000_000
+    const reg = createPendingClaimRegistry({ now: () => nowMs })
+    reg.start({
+      code: 'claim-AAAA-BBBB',
+      role: 'owner',
+      ttlMs: 600_000,
+      startedAt: nowMs,
+      expiresAt: nowMs + 600_000,
+    })
+    const result = reg.tryConsume('claim-WRONG-CODE', aliceOnSlack, formatClaimMatchRule)
+    expect(result).toEqual({ kind: 'no-match' })
+    expect(reg.size()).toBe(1)
+  })
+
+  test('channel-scoped pending rejects inbound from other adapter', () => {
+    let nowMs = 1_000_000
+    const reg = createPendingClaimRegistry({ now: () => nowMs })
+    reg.start({
+      code: 'claim-AAAA-BBBB',
+      role: 'owner',
+      channel: 'slack-bot',
+      ttlMs: 600_000,
+      startedAt: nowMs,
+      expiresAt: nowMs + 600_000,
+    })
+    const result = reg.tryConsume('claim-AAAA-BBBB', bobOnDiscord, formatClaimMatchRule)
+    expect(result).toEqual({ kind: 'wrong-channel' })
+    expect(reg.size()).toBe(1)
+  })
+
+  test('TTL expiry: consume after expiresAt returns expired and clears', () => {
+    let nowMs = 1_000_000
+    const reg = createPendingClaimRegistry({ now: () => nowMs })
+    reg.start({
+      code: 'claim-AAAA-BBBB',
+      role: 'owner',
+      ttlMs: 100,
+      startedAt: nowMs,
+      expiresAt: nowMs + 100,
+    })
+    nowMs += 200
+    const result = reg.tryConsume('claim-AAAA-BBBB', aliceOnSlack, formatClaimMatchRule)
+    expect(result).toEqual({ kind: 'expired' })
+    expect(reg.size()).toBe(0)
+  })
+
+  test('cancel matching code returns true and clears', () => {
+    const nowMs = 1_000_000
+    const reg = createPendingClaimRegistry({ now: () => nowMs })
+    reg.start({
+      code: 'claim-AAAA-BBBB',
+      role: 'owner',
+      ttlMs: 600_000,
+      startedAt: nowMs,
+      expiresAt: nowMs + 600_000,
+    })
+    expect(reg.cancel('claim-AAAA-BBBB')).toBe(true)
+    expect(reg.size()).toBe(0)
+  })
+
+  test('cancel non-matching code returns false and preserves pending', () => {
+    const nowMs = 1_000_000
+    const reg = createPendingClaimRegistry({ now: () => nowMs })
+    reg.start({
+      code: 'claim-AAAA-BBBB',
+      role: 'owner',
+      ttlMs: 600_000,
+      startedAt: nowMs,
+      expiresAt: nowMs + 600_000,
+    })
+    expect(reg.cancel('claim-OTHER-CODE')).toBe(false)
+    expect(reg.size()).toBe(1)
+  })
+
+  test('second start replaces the prior pending', () => {
+    const nowMs = 1_000_000
+    const reg = createPendingClaimRegistry({ now: () => nowMs })
+    reg.start({
+      code: 'claim-AAAA-BBBB',
+      role: 'owner',
+      ttlMs: 600_000,
+      startedAt: nowMs,
+      expiresAt: nowMs + 600_000,
+    })
+    reg.start({
+      code: 'claim-CCCC-DDDD',
+      role: 'member',
+      ttlMs: 600_000,
+      startedAt: nowMs,
+      expiresAt: nowMs + 600_000,
+    })
+    expect(reg.current()?.code).toBe('claim-CCCC-DDDD')
+    expect(reg.current()?.role).toBe('member')
+  })
+})
+
+describe('formatClaimMatchRule', () => {
+  test('slack uses workspace + author', () => {
+    expect(formatClaimMatchRule(aliceOnSlack)).toBe('slack:T0123 author:U_ALICE')
+  })
+
+  test('discord uses guild + author', () => {
+    expect(formatClaimMatchRule(bobOnDiscord)).toBe('discord:9999 author:U_BOB')
+  })
+
+  test('kakao uses dm/<chat> bucket form', () => {
+    expect(
+      formatClaimMatchRule({
+        adapter: 'kakaotalk',
+        workspace: '',
+        chat: '42',
+        isDm: true,
+        authorId: 'kakao_user_x',
+      }),
+    ).toBe('kakao:dm/42 author:kakao_user_x')
+  })
+
+  test('telegram uses chat workspace + author', () => {
+    expect(
+      formatClaimMatchRule({
+        adapter: 'telegram-bot',
+        workspace: '42',
+        chat: '42',
+        isDm: true,
+        authorId: 'tg_user',
+      }),
+    ).toBe('telegram:42 author:tg_user')
+  })
+})

--- a/src/role-claim/pending.ts
+++ b/src/role-claim/pending.ts
@@ -1,0 +1,100 @@
+import type { PartialChannelOrigin } from './match-rule'
+
+export type PendingClaim = {
+  code: string
+  role: string
+  channel?: string
+  ttlMs: number
+  startedAt: number
+  expiresAt: number
+}
+
+export type ClaimResult =
+  | { kind: 'consumed'; code: string; role: string; matchRule: string; origin: PartialChannelOrigin }
+  | { kind: 'no-pending' }
+  | { kind: 'no-match' }
+  | { kind: 'expired' }
+  | { kind: 'wrong-channel' }
+
+export type PendingClaimRegistry = {
+  start: (claim: PendingClaim) => void
+  cancel: (code: string) => boolean
+  current: () => PendingClaim | null
+  // Snapshot of consumption result without actually committing the grant.
+  // The router calls this on every DM-shaped inbound; the grant only fires
+  // when the result is 'consumed'.
+  tryConsume: (
+    code: string,
+    origin: PartialChannelOrigin,
+    formatMatchRule: (origin: PartialChannelOrigin) => string,
+  ) => ClaimResult
+  size: () => number
+}
+
+export type PendingClaimRegistryOptions = {
+  now?: () => number
+}
+
+// Single-claim-at-a-time registry. A second `start` while one is pending
+// replaces the prior code (cancels it implicitly): the operator running
+// `typeclaw role claim` twice from two terminals expects the second invocation
+// to take over, not error.
+//
+// Stored in-memory only — claim sessions are short-lived (default 10 min)
+// and a container restart legitimately invalidates any pending window.
+export function createPendingClaimRegistry(opts: PendingClaimRegistryOptions = {}): PendingClaimRegistry {
+  const now = opts.now ?? Date.now
+  let pending: PendingClaim | null = null
+
+  type ExpiryCheck = { live: PendingClaim } | { live: null; reason: 'no-pending' | 'expired' }
+
+  const expireIfDue = (): ExpiryCheck => {
+    if (pending === null) return { live: null, reason: 'no-pending' }
+    if (now() >= pending.expiresAt) {
+      pending = null
+      return { live: null, reason: 'expired' }
+    }
+    return { live: pending }
+  }
+
+  return {
+    start(claim) {
+      pending = { ...claim }
+    },
+    cancel(code) {
+      if (pending !== null && pending.code === code) {
+        pending = null
+        return true
+      }
+      return false
+    },
+    current() {
+      const check = expireIfDue()
+      return check.live
+    },
+    tryConsume(code, origin, formatMatchRule) {
+      const check = expireIfDue()
+      if (check.live === null) {
+        return { kind: check.reason }
+      }
+      const live = check.live
+      if (code !== live.code) return { kind: 'no-match' }
+      if (live.channel !== undefined && live.channel !== origin.adapter) {
+        return { kind: 'wrong-channel' }
+      }
+      const matchRule = formatMatchRule(origin)
+      const consumed: ClaimResult = {
+        kind: 'consumed',
+        code: live.code,
+        role: live.role,
+        matchRule,
+        origin,
+      }
+      pending = null
+      return consumed
+    },
+    size() {
+      return expireIfDue().live === null ? 0 : 1
+    },
+  }
+}

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -27,6 +27,7 @@ import {
 import { loadPlugins, type LoadPluginsResult, pluginCronJobs, type PluginRegistry, summarizeLoaded } from '@/plugin'
 import { createContainerBroker, publishForwardResult } from '@/portbroker'
 import { ReloadRegistry } from '@/reload'
+import { createClaimController } from '@/role-claim'
 import { hydrateChannelEnvFromSecrets } from '@/secrets'
 import { createServer, type Server } from '@/server'
 import { createSessionFactory, type SessionFactory } from '@/sessions'
@@ -91,7 +92,6 @@ export async function startAgent({
   const containerNameOpt = containerName !== undefined ? { containerName } : {}
   const tuiToken = process.env.TYPECLAW_TUI_TOKEN
   const tuiTokenOpt = tuiToken !== undefined && tuiToken !== '' ? { tuiToken } : {}
-  reloadRegistry.register(createConfigReloadable({ cwd }))
 
   const pluginConfigsByName = loadPluginConfigsSync(cwd)
   const cwdConfig = loadConfigSync(cwd)
@@ -102,6 +102,8 @@ export async function startAgent({
     bundled: BUNDLED_PLUGINS,
     ...(cwdConfig.roles !== undefined ? { roles: cwdConfig.roles } : {}),
   })
+
+  reloadRegistry.register(createConfigReloadable({ cwd, permissions: pluginsLoaded.permissions }))
   const pluginRegistry = pluginsLoaded.registry
   const pluginHooks = pluginsLoaded.hooks
 
@@ -133,6 +135,12 @@ export async function startAgent({
   // stay in env, the file stays user-owned. See src/secrets/hydrate.ts.
   hydrateChannelEnvFromSecrets({ agentDir: cwd })
 
+  const claimController = createClaimController({
+    cwd,
+    permissions: pluginsLoaded.permissions,
+    rolesProvider: () => getConfig().roles,
+  })
+
   const channelManager = createChannelManager({
     agentDir: cwd,
     channelsConfigRef: () => getConfig().channels,
@@ -149,6 +157,7 @@ export async function startAgent({
       ...containerNameOpt,
     }),
     permissions: pluginsLoaded.permissions,
+    claimHandler: claimController.claimHandler,
   })
 
   const createSessionForSubagent: import('@/agent/subagents').CreateSessionForSubagent = async (
@@ -348,6 +357,7 @@ export async function startAgent({
     channelRouter: channelManager.router,
     agentDir: cwd,
     pluginRuntime,
+    claimController,
     ...containerNameOpt,
     ...tuiTokenOpt,
     ...containerBrokerOpt,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import type { ChannelRouter } from '@/channels/router'
 import type { HookBus } from '@/plugin'
 import type { BrokerWsData, ContainerBroker } from '@/portbroker'
 import type { ReloadAllResult, ReloadRegistry } from '@/reload'
+import type { ClaimController, ClaimResultEvent } from '@/role-claim'
 import type { PluginRuntime, PluginRuntimeState } from '@/run/plugin-runtime'
 import type { SessionFactory } from '@/sessions'
 import type { ClientMessage, PromptDelivery, QueueStateItem, ReloadResultPayload, ServerMessage } from '@/shared'
@@ -47,6 +48,12 @@ export type ServerOptions = {
   // which writes to stdout/stderr so `typeclaw logs` surfaces every event.
   // Tests inject a fake logger to assert on captured output.
   logger?: ServerLogger
+  // Optional role-claim controller. When set, the server accepts
+  // `claim_start` / `claim_cancel` from TUI-class WS clients (the host
+  // CLI's `typeclaw role claim` command in particular), and pushes
+  // `claim_started` / `claim_completed` / `claim_error` back over the
+  // same connection. Omitted in tests that don't exercise the flow.
+  claimController?: ClaimController
 }
 
 const consoleLogger: ServerLogger = {
@@ -77,6 +84,8 @@ type SessionState = {
   draining: boolean
   unsubBroadcast: Unsubscribe | null
   unsubPrompts: Unsubscribe | null
+  unsubClaim: Unsubscribe | null
+  activeClaimCode: string | null
   // Captured at session open so close-time hooks fire against the same
   // generation that ran session.start. A plugin reload mid-connection does
   // not re-target this session's lifecycle hooks.
@@ -102,6 +111,7 @@ export function createServer({
   tuiToken,
   containerBroker,
   logger = consoleLogger,
+  claimController,
 }: ServerOptions) {
   const sessionStates = new WeakMap<Ws, SessionState>()
 
@@ -170,6 +180,8 @@ export function createServer({
               draining: false,
               unsubBroadcast: null,
               unsubPrompts: null,
+              unsubClaim: null,
+              activeClaimCode: null,
               runtimeSnapshot: runtimeSnapshot ?? null,
               dispose,
             }
@@ -214,6 +226,73 @@ export function createServer({
           const ws = rawWs as Ws
           const msg = JSON.parse(String(raw)) as ClientMessage
           const state = sessionStates.get(ws)
+
+          if (msg.type === 'claim_start') {
+            if (!state) return
+            if (!claimController) {
+              send(ws, {
+                type: 'claim_error',
+                payload: { code: msg.code, reason: 'role-claim is not enabled on this agent' },
+              })
+              return
+            }
+            if (state.unsubClaim) {
+              state.unsubClaim()
+              state.unsubClaim = null
+            }
+            const result = claimController.startClaim({
+              code: msg.code,
+              role: msg.role,
+              ttlMs: msg.ttlMs,
+              ...(msg.channel !== undefined ? { channel: msg.channel } : {}),
+            })
+            if (!result.ok) {
+              send(ws, { type: 'claim_error', payload: { code: msg.code, reason: result.reason } })
+              return
+            }
+            state.activeClaimCode = msg.code
+            state.unsubClaim = claimController.onResult((event: ClaimResultEvent) => {
+              if (event.kind === 'completed' && event.code === msg.code) {
+                send(ws, {
+                  type: 'claim_completed',
+                  payload: {
+                    code: event.code,
+                    role: event.role,
+                    matchRule: event.matchRule,
+                    adapter: event.adapter,
+                    authorId: event.authorId,
+                  },
+                })
+              } else if (event.kind === 'error' && event.code === msg.code) {
+                send(ws, { type: 'claim_error', payload: { code: event.code, reason: event.reason } })
+              } else if (event.kind === 'cancelled' && event.code === msg.code) {
+                send(ws, { type: 'claim_error', payload: { code: event.code, reason: 'cancelled' } })
+              }
+            })
+            send(ws, {
+              type: 'claim_started',
+              payload: {
+                code: msg.code,
+                role: msg.role,
+                ...(msg.channel !== undefined ? { channel: msg.channel } : {}),
+                expiresAt: result.expiresAt,
+              },
+            })
+            return
+          }
+
+          if (msg.type === 'claim_cancel') {
+            if (!state || !claimController) return
+            if (state.activeClaimCode !== null) {
+              claimController.cancelClaim(state.activeClaimCode)
+              state.activeClaimCode = null
+            }
+            if (state.unsubClaim) {
+              state.unsubClaim()
+              state.unsubClaim = null
+            }
+            return
+          }
 
           if (msg.type === 'reload') {
             await handleReload(ws, reloadAll, reloadRegistry, msg.scope)
@@ -297,6 +376,10 @@ export function createServer({
           const state = sessionStates.get(ws)
           state?.unsubBroadcast?.()
           state?.unsubPrompts?.()
+          state?.unsubClaim?.()
+          if (state?.activeClaimCode !== null && state?.activeClaimCode !== undefined && claimController) {
+            claimController.cancelClaim(state.activeClaimCode)
+          }
           try {
             if (state && state.runtimeSnapshot !== null) {
               await state.runtimeSnapshot.hooks.runSessionEnd({ sessionId: state.sessionFileId, origin: state.origin })

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,4 +1,8 @@
 export {
+  type ClaimCompletedPayload,
+  type ClaimErrorPayload,
+  type ClaimRoleChoice,
+  type ClaimStartedPayload,
   type ClientMessage,
   type DoctorCheckPayload,
   type DoctorFixPayload,

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -22,6 +22,8 @@ export type DoctorFixPayload =
   | { ok: true; checkId: string; summary: string; changedPaths: string[] }
   | { ok: false; checkId: string; error: string }
 
+export type ClaimRoleChoice = 'owner' | 'member' | 'trusted' | (string & {})
+
 export type ClientMessage =
   | { type: 'prompt'; text: string; delivery?: PromptDelivery }
   | { type: 'reload'; scope?: string }
@@ -29,8 +31,30 @@ export type ClientMessage =
   | { type: 'queue_cancel'; messageId: string }
   | { type: 'doctor'; requestId: DoctorRequestId }
   | { type: 'doctor_fix'; requestId: DoctorRequestId; checkId: string }
+  | { type: 'claim_start'; code: string; role: ClaimRoleChoice; channel?: string; ttlMs: number }
+  | { type: 'claim_cancel' }
 
 export type QueueStateItem = { id: string; text: string; ts: number }
+
+export type ClaimStartedPayload = {
+  code: string
+  role: string
+  channel?: string
+  expiresAt: number
+}
+
+export type ClaimCompletedPayload = {
+  code: string
+  role: string
+  matchRule: string
+  adapter: string
+  authorId: string
+}
+
+export type ClaimErrorPayload = {
+  code: string
+  reason: string
+}
 
 export type ServerMessage =
   | { type: 'connected'; sessionId: string }
@@ -45,3 +69,6 @@ export type ServerMessage =
   | { type: 'prompt_started'; messageId: string; text: string }
   | { type: 'doctor_result'; requestId: DoctorRequestId; checks: DoctorCheckPayload[] }
   | { type: 'doctor_fix_result'; requestId: DoctorRequestId; result: DoctorFixPayload }
+  | { type: 'claim_started'; payload: ClaimStartedPayload }
+  | { type: 'claim_completed'; payload: ClaimCompletedPayload }
+  | { type: 'claim_error'; payload: ClaimErrorPayload }


### PR DESCRIPTION
## Problem

Fresh agents with wired channels are **silently non-responsive** out of the box. Every inbound message resolves to `guest` because no `roles.<name>.match` rules exist at init time — and `guest` lacks `channel.respond`, so the router drops every message before any prompt is queued. The only workaround was hand-editing `typeclaw.json` and restarting (since `roles` was `restart-required`). There was no obvious path for an operator to claim channel ownership from inside their Slack/Discord/Telegram/KakaoTalk account.

## Solution

A short-code handshake closes the loop:

1. `typeclaw role claim [--as <role>]` generates a `claim-XXXX-YYYY` code and sends it to the running container over the WS via a new `claim_start` message.
2. The operator DMs the bot with the code from inside their wired channel account.
3. The channel router intercepts the DM **before** the `channel.respond` gate (so the bootstrap window doesn't need its own permission — solving the chicken-and-egg).
4. A `ClaimController` validates the code against the TTL'd in-memory pending registry, writes the sender's identity to `roles.<role>.match` via the new atomic `grantRole`, and calls `PermissionService.replaceRoles()` to make the change live **without a container restart**.
5. A confirmation reply goes back over the channel; a `claim_completed` event comes back to the CLI.
6. `typeclaw init`'s post-hatching step automatically offers to run the claim flow when at least one channel was wired in the wizard — so fresh agents are usable out of the box without a second command.

## Changes

### New: `src/role-claim/`

The core handshake subsystem.

- `code.ts` — generates `claim-XXXX-YYYY` codes (40 bits of entropy from `crypto.getRandomValues`).
- `pending.ts` — TTL'd, channel-scoped in-memory registry. Supports cancel, replace (re-running `role claim` resets the window), and per-channel isolation (a code issued for Slack cannot be consumed by a Discord DM).
- `match-rule.ts` — adapter origin → canonical match-rule string. Emits `<platform>:<workspace> author:<authorId>` for Slack/Discord/Telegram and `kakao:dm/<chat> author:<authorId>` for KakaoTalk (no workspace concept on Kakao).
- `controller.ts` — runtime glue: validates code, calls `grantRole`, calls `replaceRoles`, sends channel reply and `claim_completed` event.
- `client.ts` — WS client used by the CLI to drive `claim_start` / `claim_cancel` and await `claim_completed` / `claim_error`.
- `index.ts` — public re-exports.
- Tests for each module: code generation, registry TTL/channel-scope/cancel/replace, match-rule formatting per adapter, controller happy/error paths.

### New: `src/permissions/grant.ts`

Atomic writer for `typeclaw.json#roles.<name>.match`. Validates the new match rule through the same parser used at config load (so a malformed rule fails at grant time, not on next start), then appends idempotently. Full test coverage including round-trip idempotency, concurrent-write safety, and malformed-rule rejection.

### Modified: `src/permissions/permissions.ts`

`PermissionService` gains a `replaceRoles(roles)` method that rebuilds the resolved role table in place from a new config without a process restart. All existing test fakes updated.

### Modified: `src/config/config.ts`

Splits the old `roles: 'restart-required'` in `FIELD_EFFECTS` into two virtual paths:

- `roles.match` → `'applied'` (live-reloadable via `replaceRoles`)
- `roles.permissions` → `'restart-required'` (changing a role's permission set still needs a restart)

`readPath` understands these as projections over `config.roles`.

### New: `src/config/reloadable.roles.test.ts`

Guards the split so a future change to `FIELD_EFFECTS` that collapses these back into a single key fails fast.

### Modified: `src/config/reloadable.ts`

Accepts an optional `permissions` injection so it can call `replaceRoles` when a `roles.match` diff fires.

### Modified: `src/channels/router.ts`

Adds an optional `claimHandler` option. The handler runs **before** the `channel.respond` gate, gated by a cheap precheck (`isDm && extractClaimCode(text)`). Returns `'handled'` or `'fallthrough'`; a wrong code on a live pending returns `'fallthrough'` so the regular gate still drops the message — no implicit grant.

Exports `ClaimHandler`, `ClaimHandlerInput`, `ClaimHandlerOutcome` for downstream wiring.

### Modified: `src/channels/manager.ts` + `src/channels/index.ts`

Plumbs `claimHandler` through to the router.

### New: `src/channels/router.test.ts` describe block

`describe('ChannelRouter role-claim bypass')` — 6 tests covering: DM with valid code is intercepted before the permission gate, DM with wrong code falls through to the gate, non-DM with valid code falls through, expired code falls through, handled DM does not trigger a session, and `claimHandler: undefined` leaves behavior unchanged.

### Modified: `src/shared/protocol.ts`

Client messages: `claim_start`, `claim_cancel`.
Server messages: `claim_started`, `claim_completed`, `claim_error`.

### Modified: `src/server/index.ts`

Accepts optional `claimController`. Dispatches `claim_start` and `claim_cancel` messages, tracks per-WS subscriptions in `SessionState`, and cleans up on close.

### Modified: `src/run/index.ts`

Builds the `ClaimController` (with `rolesProvider: () => getConfig().roles`), passes its `claimHandler` to the channel manager and the controller itself to the server. Also moves `createConfigReloadable` registration to after `loadPlugins` so `pluginsLoaded.permissions` can be plumbed for the reload-safety wiring.

### New: `src/cli/role.ts`

```
typeclaw role claim [--as owner|member|trusted|<custom>] [--channel <adapter>] [--ttl <ms>] [--url <ws>]
typeclaw role list
```

### Modified: `src/cli/index.ts`

Registers the new `role` subcommand.

### Modified: `src/init/index.ts` + new `src/init/run-owner-claim.ts`

Threads `configuredChannels` through `runInit → HatchRunner → defaultRunHatching`. Calls `runOwnerClaim` between "container ready" and "open TUI" when at least one channel was wired in the wizard. `run-owner-claim.ts` owns the post-hatching prompt and claim-session orchestrator.

## Naming

`typeclaw role` (noun) + `claim` (verb), not `pair`. `pair` was rejected as Bluetooth-derived and a poor fit for the identity-claim semantic. The chosen surface generalizes for future siblings like `role grant <match-rule>` and `role revoke`.

## Key Invariants

- **Claim bypass is before `channel.respond`** — required to break the chicken-and-egg: you can't grant yourself the permission needed to talk to the bot via the bot.
- **Codes are in-memory only** — a container restart invalidates every pending window. No persistence, no replay.
- **`roles.match` is live-reloadable; `roles.permissions` is restart-required** — `replaceRoles` is the seam. The config reload diff fires it when `roles.match` changes.
- **Wrong code → fallthrough, not error** — the `channel.respond` gate still drops the message for unrecognized codes. No implicit grant path.
- **`claimHandler` is optional on the router** — existing router users and direct tests are unaffected. Production wires it via `src/run/index.ts`.

## Testing

- **3294 pass, 0 fail** across 196 files (`bun test`)
- `bun run typecheck` — clean
- `bun run lint` — 8 warnings, all pre-existing on `main` (verified by stashing this branch and re-running lint). 0 errors introduced.
- `bun run format:check` — clean

## Security Notes

- The bypass is opt-in; `claimHandler` defaults to `undefined`.
- Each inbound hitting the bypass must be: DM-shaped, contain the `claim-` prefix, AND match a live pending claim. Wrong code returns `'fallthrough'` — no implicit grant.
- Codes carry 40 bits of entropy, are TTL'd (default 10 min), and are scoped per channel adapter.
- The `grant` step validates the match rule through the same parser used at config load.
- A container restart invalidates all pending codes.

## Stats

29 files changed, +1968/−12 lines.