### PR TITLE
Give memory-logger a find_entry tool to advance the watermark

### DIFF
--- a/src/bundled-plugins/memory/find-entry-tool.test.ts
+++ b/src/bundled-plugins/memory/find-entry-tool.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { ToolContext } from '@/plugin'
+
+import { findEntryTool } from './find-entry-tool'
+
+const ctx: ToolContext = {
+  signal: undefined,
+  sessionId: 'test',
+  agentDir: '/tmp',
+  logger: { info: () => {}, warn: () => {}, error: () => {} },
+}
+
+function tmpRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'memory-find-entry-'))
+}
+
+function writeJsonl(path: string, lines: object[]): void {
+  writeFileSync(path, `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`, 'utf8')
+}
+
+describe('findEntryTool', () => {
+  test('reports line number, total lines, and next offset for a found entry', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'transcript.jsonl')
+    writeJsonl(path, [
+      { type: 'session', id: 'aaa' },
+      { type: 'message', id: 'b1e2dbf1' },
+      { type: 'message', id: '79867453' },
+      { type: 'message', id: '09260992', parentId: '79867453' },
+    ])
+
+    const result = await findEntryTool.execute({ path, entryId: '79867453' }, ctx)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+
+    expect(text).toContain('found')
+    expect(text).toContain('line=3')
+    expect(text).toContain('totalLines=4')
+    expect(text).toContain('offset=4')
+  })
+
+  test('reports not found when no line carries the entry id', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'transcript.jsonl')
+    writeJsonl(path, [
+      { type: 'message', id: 'aaaa1111' },
+      { type: 'message', id: 'bbbb2222' },
+    ])
+
+    const result = await findEntryTool.execute({ path, entryId: 'no-such-id' }, ctx)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+
+    expect(text).toContain('not found')
+    expect(text).toContain('totalLines=2')
+  })
+
+  test('locates the entry by its own id, ignoring later parentId references to the same id', async () => {
+    // The id '79867453' appears twice: once as line 1's own id, and again as line 2's parentId.
+    // The watermark always names an entry's own id, so the tool must match `"id":"<entryId>"`
+    // exactly and ignore `"parentId":"<entryId>"`. A naive substring search would pick line 2.
+    const root = tmpRoot()
+    const path = join(root, 'transcript.jsonl')
+    writeJsonl(path, [
+      { type: 'message', id: '79867453', parentId: 'older' },
+      { type: 'message', id: '09260992', parentId: '79867453' },
+      { type: 'message', id: 'xxxxxxxx', parentId: '09260992' },
+    ])
+
+    const result = await findEntryTool.execute({ path, entryId: '79867453' }, ctx)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+
+    expect(text).toContain('line=1')
+  })
+
+  test('skips malformed JSON lines instead of throwing', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'transcript.jsonl')
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({ type: 'message', id: 'aaaa1111' }),
+        '{ not valid json',
+        JSON.stringify({ type: 'message', id: 'bbbb2222' }),
+      ].join('\n'),
+      'utf8',
+    )
+
+    const result = await findEntryTool.execute({ path, entryId: 'bbbb2222' }, ctx)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+
+    expect(text).toContain('line=3')
+  })
+
+  test('throws when the file does not exist', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'does-not-exist.jsonl')
+
+    await expect(findEntryTool.execute({ path, entryId: 'whatever' }, ctx)).rejects.toThrow(/does-not-exist/)
+  })
+
+  test('rejects empty entryId so the agent cannot accidentally scan for "" ', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'transcript.jsonl')
+    writeJsonl(path, [{ type: 'message', id: 'aaaa1111' }])
+
+    await expect(findEntryTool.execute({ path, entryId: '' }, ctx)).rejects.toThrow()
+  })
+
+  test('counts the final line even when the file has no trailing newline', async () => {
+    const root = tmpRoot()
+    const path = join(root, 'transcript.jsonl')
+    writeFileSync(
+      path,
+      [JSON.stringify({ type: 'message', id: 'aaaa1111' }), JSON.stringify({ type: 'message', id: 'bbbb2222' })].join(
+        '\n',
+      ),
+      'utf8',
+    )
+
+    const result = await findEntryTool.execute({ path, entryId: 'bbbb2222' }, ctx)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+
+    expect(text).toContain('line=2')
+    expect(text).toContain('totalLines=2')
+  })
+})

--- a/src/bundled-plugins/memory/find-entry-tool.ts
+++ b/src/bundled-plugins/memory/find-entry-tool.ts
@@ -1,0 +1,62 @@
+import { readFile } from 'node:fs/promises'
+
+import { z } from 'zod'
+
+import { defineTool } from '@/plugin'
+
+export const findEntryTool = defineTool({
+  description:
+    'Locate a session-transcript entry by its `id` field and report the 1-indexed line number. ' +
+    'Use this BEFORE calling `read` on a large transcript so you can pass `offset=<lineNumber>+1` ' +
+    'and resume reading right after the watermark, instead of scanning the file from the top in 50KB chunks. ' +
+    "Matches the entry's own `id` field only, not `parentId` references. Returns the line number, total " +
+    'line count, and a suggested next offset for `read`. Returns a "not found" string (does not throw) ' +
+    'when no entry carries the id, so the caller can decide whether to start from line 1 or stop.',
+  parameters: z.object({
+    path: z.string().describe('Path to the JSONL transcript file to scan.'),
+    entryId: z
+      .string()
+      .min(1)
+      .describe('The entry id to locate (matches the JSONL row whose own `id` field equals this value).'),
+  }),
+  async execute({ path, entryId }) {
+    if (entryId.length === 0) {
+      throw new Error('find_entry requires a non-empty entryId; an empty needle would match every line.')
+    }
+    const raw = await readFile(path, 'utf8')
+    const lines = raw.length === 0 ? [] : raw.split('\n')
+    const totalLines = lines.length > 0 && lines[lines.length - 1] === '' ? lines.length - 1 : lines.length
+
+    const needle = `"id":"${entryId}"`
+    let foundLine: number | null = null
+    for (let i = 0; i < totalLines; i++) {
+      if (lines[i]?.includes(needle)) {
+        foundLine = i + 1
+        break
+      }
+    }
+
+    if (foundLine === null) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `entryId=${entryId} not found in ${path} (totalLines=${totalLines}). The watermark may point at an entry that has since been removed (e.g. compaction). Consider starting from offset=1 or skip this run.`,
+          },
+        ],
+        details: { path, entryId, found: false, totalLines },
+      }
+    }
+
+    const nextOffset = foundLine + 1
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `entryId=${entryId} found at line=${foundLine} of totalLines=${totalLines}. Use read(path="${path}", offset=${nextOffset}) to resume past this entry.`,
+        },
+      ],
+      details: { path, entryId, found: true, line: foundLine, totalLines, nextOffset },
+    }
+  },
+})

--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -176,6 +176,21 @@ describe('MEMORY_LOGGER_SYSTEM_PROMPT', () => {
     expect(lower).toMatch(/byte-equivalent|content-equality|same daily stream/)
     expect(lower).toMatch(/refuse.*fragment|reject.*fragment/)
   })
+
+  test('teaches the subagent to use find_entry to jump past the watermark instead of scrolling from line 1', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('find_entry')
+    expect(lower).toMatch(/before .*read|use find_entry before|find_entry.*then.*read/)
+  })
+
+  test('explains the read tool truncates large files so scrolling from line 1 is expensive', () => {
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/truncat\w+.*(50 ?KB|2000 lines)/i)
+  })
+
+  test('forbids re-emitting the input watermark id as the new watermark id', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toMatch(/never write the same watermark id|advance the watermark|move forward each run/)
+  })
 })
 
 describe('memoryLoggerSubagent', () => {
@@ -183,11 +198,14 @@ describe('memoryLoggerSubagent', () => {
     expect(memoryLoggerSubagent.systemPrompt).toBe(MEMORY_LOGGER_SYSTEM_PROMPT)
   })
 
-  test('declares one built-in tool (read) and one custom tool (append)', () => {
+  test('declares one built-in tool (read) and two custom tools (find_entry, append)', () => {
     expect(memoryLoggerSubagent.tools).toBeDefined()
     expect(memoryLoggerSubagent.tools!.length).toBe(1)
     expect(memoryLoggerSubagent.customTools).toBeDefined()
-    expect(memoryLoggerSubagent.customTools!.length).toBe(1)
+    expect(memoryLoggerSubagent.customTools!.length).toBe(2)
+    const descriptions = memoryLoggerSubagent.customTools!.map((t) => t.description)
+    expect(descriptions.some((d) => d.includes('Locate a session-transcript entry'))).toBe(true)
+    expect(descriptions.some((d) => d.includes('Append content to a file'))).toBe(true)
   })
 
   test('declares an inFlightKey that keys on agentDir (so two concurrent sessions for the same agent serialize)', () => {

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -7,6 +7,7 @@ import { type Subagent, readTool } from '@/plugin'
 import { formatLocalDate } from '@/shared'
 
 import { appendTool } from './append-tool'
+import { findEntryTool } from './find-entry-tool'
 import { readWatermark } from './watermark'
 
 export const memoryLoggerPayloadSchema = z.object({
@@ -28,7 +29,21 @@ Your job is to read a session transcript and capture, as fragments, everything m
 
 A separate \`dreaming\` subagent runs later. It consolidates your fragments into long-term memory, dedupes, drops near-duplicates, resolves contradictions, and decides what generalizes. **You are the additive layer; dreaming is the filter.** This division of labor is the whole point: capture broadly here, and let dreaming throw away what doesn't last.
 
-You have exactly two tools: \`read\` and \`append\`. You cannot run shell commands, overwrite files, or edit existing content.
+You have exactly three tools: \`read\`, \`find_entry\`, and \`append\`. You cannot run shell commands, overwrite files, or edit existing content.
+
+# Reading the transcript past the watermark
+
+Session transcripts are JSONL files where each line is an entry with an \`id\` field. They are often large (hundreds of KB). The \`read\` tool truncates output to 50 KB or 2000 lines, whichever comes first, and tells you the line range it returned plus the offset to continue. If you start \`read\` at \`offset=1\` on a 500 KB transcript, the first call returns roughly the first 10% of the file, the next call (\`offset=<next>\`) returns the following slice, and so on. Scrolling through a long prefix that you've already consolidated past is wasted tokens.
+
+**Always use \`find_entry\` before \`read\` when a watermark is set.** It scans the JSONL file for the line whose own \`id\` field equals a given entry id and returns the line number, the total line count, and the offset to pass to \`read\` so you resume immediately after the watermark. It matches \`"id":"<entryId>"\` exactly, so \`parentId\` references to the same id do not confuse it. It returns a "not found" string (no throw) when the watermark id is not in the file — that can happen if a parent session was compacted; treat it as "start from offset=1" or, if the transcript is huge and obviously unrelated, write the watermark forward and skip the run.
+
+Typical flow with a watermark:
+
+1. \`find_entry(path=<transcript>, entryId=<watermark>)\` → returns \`line=N, totalLines=T, offset=N+1\`.
+2. \`read(path=<transcript>, offset=N+1)\` → returns the chunk starting AT the first unread entry. Repeat with the next offset until the read tool's continuation notice stops appearing.
+3. As you read, track the most recent \`id\` you see. That is your new watermark value — write it into the trailing watermark marker at the end of your appended output.
+
+Never write the same watermark id you were given as input. If the transcript has no new entries past the watermark, evaluate the entries you can see, then advance the watermark to the latest \`id\` in the transcript (which is on line \`totalLines\` from \`find_entry\`'s reply). The whole point of the watermark is to move forward each run.
 
 # Capture philosophy: when in doubt, capture
 
@@ -228,9 +243,8 @@ export function createMemoryLoggerSubagent(
   const logger = options.logger ?? consoleLogger
   return {
     systemPrompt: MEMORY_LOGGER_SYSTEM_PROMPT,
-    profile: 'fast',
     tools: [readTool],
-    customTools: [appendTool],
+    customTools: [findEntryTool, appendTool],
     payloadSchema: memoryLoggerPayloadSchema,
     inFlightKey: (payload) => payload.agentDir,
     handler: async (ctx, runSession) => {


### PR DESCRIPTION
## Problem

The memory-logger subagent locates its place in a parent transcript by scrolling forward from line 1 using the built-in `read` tool, which truncates at 2000 lines or 50 KB per call. For multi-hundred-KB channel transcripts the watermark entry can sit deep in the file, forcing the agent to issue N consecutive `read` calls just to reach it. In practice the agent gives up before the end of the file and writes the input watermark id back as the new watermark — so the next spawn starts at exactly the same position and the same trap repeats.

**Production case:** parent session `019de9c6` grew to 766 KB / 559 lines with the live watermark at line 512. Two consecutive memory-logger runs each consumed five `read` calls (~300 KB billed) without reaching lines 513–559, then re-stamped `entry=79867453`. The watermark never advanced; the same bytes were paid twice. The user's `typeclaw usage` showed cache-hit ratio drop from 89% to 67–70% on 2026-05-15, a direct consequence of the repeated reads.

The watermark code in `watermark.ts` is correct. The bug is a tool-surface mismatch: with only `read` + `append`, the only way to reach a known entry id is brute-force scrolling under the truncation limit.

## Fix

Add a `find_entry` custom tool to the bundled memory plugin. The tool takes `(path, entryId)`, scans the JSONL line by line, and returns the line number, total line count, and the `offset` argument to feed directly to `read`. Cost drops from N×50 KB reads to a single ~1 KB tool call, and the agent lands at exactly the first unread line.

Implementation details:

- Matches `"id":"X"` literally (not a looser substring match) so `parentId` references to the same id do not produce false positives.
- Returns a non-throw "not found" string when the watermark id is absent — e.g. after compaction moved entries — so the agent can handle that case without an exception.
- Rejects empty `entryId` (would match every line).
- Handles malformed JSON lines without throwing.
- Counts the last line correctly when the file has no trailing newline.

`find_entry` is wired into `memoryLoggerSubagent.customTools` alongside `appendTool` in `memory-logger.ts`.

The `MEMORY_LOGGER_SYSTEM_PROMPT` gains a "Reading the transcript past the watermark" section that:

- Explains that `read` truncates at 50 KB / 2000 lines and scrolling from line 1 is wasteful on large transcripts.
- Instructs the agent to call `find_entry` **before** `read` whenever a watermark is set.
- Documents the flow: `find_entry` → `read(offset=N+1)` → track the latest id seen → write that as the new watermark.
- Explicitly forbids re-emitting the input watermark id ("Never write the same watermark id you were given as input").

## Tests

`find-entry-tool.test.ts` (new, 7 tests): happy path, not-found, `parentId` disambiguation, malformed lines, missing file, empty `entryId`, no trailing newline.

`memory-logger.test.ts` (updated): adjusts the custom-tools count assertion (1 → 2), adds 3 assertions on the new prompt section content.

## Verification

```
bun run typecheck   # clean
bun run lint        # 8 pre-existing warnings, 0 new
bun run format      # clean
bun test            # 3330 pass, 0 fail (203 in src/bundled-plugins/memory/)
```

## Known related issue (out of scope)

A parallel investigation found two independent explanations for why the parent session above never compacted:

1. Compaction triggers at 80% of context window. For Kimi K2.6 Turbo's 256K window that is ~204,800 tokens; a 766 KB JSONL may simply have never crossed that threshold.
2. If `typeclaw.json` still references the removed `kimi-k2p5-turbo` model id, `resolveModel` returns `undefined` and compaction is silently broken.

Neither is addressed here. Both warrant a follow-up investigation in the affected agent folder.

## Stats

4 files changed, +228/−5.

- `src/bundled-plugins/memory/find-entry-tool.ts` (new, ~62 lines)
- `src/bundled-plugins/memory/find-entry-tool.test.ts` (new, 7 tests)
- `src/bundled-plugins/memory/memory-logger.ts` — wire `find_entry` into `customTools`, add watermark-reading section to system prompt
- `src/bundled-plugins/memory/memory-logger.test.ts` — update custom-tools count, add 3 prompt-content assertions