### PR TITLE
Pre-check the agent container is running before tui, reload, role claim

### DIFF
--- a/src/cli/reload.ts
+++ b/src/cli/reload.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 
-import { resolveHostPort, resolveTuiToken } from '@/container'
+import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/container'
 import { findAgentDir } from '@/init'
 import { requestReload, type ReloadResult } from '@/reload'
 
@@ -63,6 +63,11 @@ export const reload = defineCommand({
 
 async function defaultUrl(): Promise<string> {
   const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+  const precheck = await requireContainerRunning({ cwd })
+  if (!precheck.ok) {
+    console.error(errorLine(precheck.reason))
+    process.exit(1)
+  }
   const port = await resolveHostPort({ cwd })
   const token = await resolveTuiToken({ cwd })
   const url = new URL(`ws://127.0.0.1:${port}`)

--- a/src/cli/role.ts
+++ b/src/cli/role.ts
@@ -1,7 +1,7 @@
 import { intro, note, outro, spinner } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
-import { resolveHostPort, resolveTuiToken } from '@/container'
+import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/container'
 import { findAgentDir } from '@/init'
 import { runClaimSession } from '@/role-claim'
 
@@ -131,6 +131,11 @@ export const roleCommand = defineCommand({
 
 async function defaultUrl(): Promise<string> {
   const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+  const precheck = await requireContainerRunning({ cwd })
+  if (!precheck.ok) {
+    console.error(errorLine(precheck.reason))
+    process.exit(1)
+  }
   const port = await resolveHostPort({ cwd })
   const token = await resolveTuiToken({ cwd })
   const url = new URL(`ws://127.0.0.1:${port}`)

--- a/src/cli/tui.ts
+++ b/src/cli/tui.ts
@@ -1,8 +1,10 @@
 import { defineCommand } from 'citty'
 
-import { resolveHostPort, resolveTuiToken } from '@/container'
+import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/container'
 import { findAgentDir } from '@/init'
 import { createTui } from '@/tui'
+
+import { errorLine } from './ui'
 
 export const tui = defineCommand({
   meta: {
@@ -30,6 +32,11 @@ export const tui = defineCommand({
 
 async function defaultUrl(): Promise<string> {
   const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+  const precheck = await requireContainerRunning({ cwd })
+  if (!precheck.ok) {
+    console.error(errorLine(precheck.reason))
+    process.exit(1)
+  }
   const port = await resolveHostPort({ cwd })
   const token = await resolveTuiToken({ cwd })
   const url = new URL(`ws://127.0.0.1:${port}`)

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -1,5 +1,10 @@
 export { logs, planLogs, type LogsPlan, type LogsResult } from './logs'
 export { CONTAINER_PORT, TUI_TOKEN_LABEL, findFreePort, resolveHostPort, resolveTuiToken } from './port'
+export {
+  requireContainerRunning,
+  type RequireContainerRunningOptions,
+  type RequireContainerRunningResult,
+} from './require-running'
 export { planShell, shell, type ShellPlan, type ShellResult } from './shell'
 export { status, type ContainerStatus, type StatusOptions } from './status'
 export {

--- a/src/container/require-running.test.ts
+++ b/src/container/require-running.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { requireContainerRunning } from './require-running'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-require-running-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('requireContainerRunning', () => {
+  test('returns the canonical "not found" reason when the container is missing', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    const result = await requireContainerRunning({ cwd: folder }, { inspect: async () => ({ exists: false }) })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'Container coder not found. Run `typeclaw start` first.',
+    })
+  })
+
+  test('returns the canonical "not running" reason when the container is stopped', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    const result = await requireContainerRunning(
+      { cwd: folder },
+      { inspect: async () => ({ exists: true, running: false }) },
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'Container coder is not running. Run `typeclaw start` first.',
+    })
+  })
+
+  test('returns ok with the resolved container name when running', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    const result = await requireContainerRunning(
+      { cwd: folder },
+      { inspect: async () => ({ exists: true, running: true }) },
+    )
+
+    expect(result).toEqual({ ok: true, containerName: 'coder' })
+  })
+
+  test('passes the cwd-derived container name to inspect', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+    const inspected: string[] = []
+
+    await requireContainerRunning(
+      { cwd: folder },
+      {
+        inspect: async (name) => {
+          inspected.push(name)
+          return { exists: true, running: true }
+        },
+      },
+    )
+
+    expect(inspected).toEqual(['coder'])
+  })
+})

--- a/src/container/require-running.ts
+++ b/src/container/require-running.ts
@@ -1,0 +1,33 @@
+import { containerNameFromCwd, inspectContainer, type ContainerState } from './shared'
+
+export type RequireContainerRunningResult = { ok: true; containerName: string } | { ok: false; reason: string }
+
+export type RequireContainerRunningOptions = {
+  cwd: string
+}
+
+type RequireContainerRunningDeps = {
+  inspect?: (name: string) => Promise<ContainerState>
+}
+
+// Pre-flight for CLI commands that need to talk to a live agent (tui, reload,
+// role claim). Without this, `resolveHostPort` silently falls back to the
+// configured port when the container is missing/stopped and the caller hits
+// an opaque websocket "Connection refused" or fetch error several frames deep.
+// We probe with `inspectContainer` — the same helper `shell` and `start` use —
+// and surface the canonical "Run `typeclaw start` first." prose that matches
+// `src/container/shell.ts`'s wording.
+export async function requireContainerRunning(
+  { cwd }: RequireContainerRunningOptions,
+  deps: RequireContainerRunningDeps = {},
+): Promise<RequireContainerRunningResult> {
+  const containerName = containerNameFromCwd(cwd)
+  const state = await (deps.inspect ?? inspectContainer)(containerName)
+  if (!state.exists) {
+    return { ok: false, reason: `Container ${containerName} not found. Run \`typeclaw start\` first.` }
+  }
+  if (!state.running) {
+    return { ok: false, reason: `Container ${containerName} is not running. Run \`typeclaw start\` first.` }
+  }
+  return { ok: true, containerName }
+}


### PR DESCRIPTION
## Problem

`typeclaw tui`, `typeclaw reload`, and `typeclaw role claim` all resolve the WebSocket URL by calling `resolveHostPort`, which silently falls back to the configured port from `typeclaw.json` when the container is missing or stopped. The user then hits an opaque error several frames deep:

- **tui** — cryptic WebSocket stack trace with no guidance
- **reload** — `reload failed: fetch failed` with no indication the container isn't running
- **role claim** — same silent fallback, same opaque failure

`typeclaw shell` has this check inline already. `typeclaw logs` has an existence check. These three were left behind.

## Solution

Extract the inline check from `src/container/shell.ts` into a shared helper `requireContainerRunning({ cwd })` and wire it into the `defaultUrl()` step of each affected command — before `resolveHostPort`, which is where the silent fallback lives.

The helper returns `{ ok: true; containerName } | { ok: false; reason }`. Reason strings match `shell.ts` exactly:

- `Container <name> not found. Run `typeclaw start` first.`
- `Container <name> is not running. Run `typeclaw start` first.`

Each consumer follows the existing CLI convention (see `src/container/start.ts`, `restart.ts`, `shell.ts`): `console.error(errorLine(result.reason)); process.exit(1)`.

## Changes

**`src/container/require-running.ts`** (new) — the helper, 35 lines including a comment explaining why the check must happen before `resolveHostPort`.

**`src/container/require-running.test.ts`** (new) — 4 tests: missing container, stopped container, running container, and container-name derivation. Uses real tmpdir and injected `inspect` dependency, matching the pattern in `shell.test.ts`.

**`src/container/index.ts`** — exports `requireContainerRunning` and the `RequireContainerRunningResult` type.

**`src/cli/tui.ts`** — adds the pre-check and imports `errorLine` (this file had no error handling before).

**`src/cli/reload.ts`** — pre-check in `defaultUrl()`.

**`src/cli/role.ts`** — pre-check in `defaultUrl()`.

### Why these three specifically

- `tui` / `reload` / `role claim` — connect to the agent WebSocket and fail opaquely without a running container.
- **Not** `start` / `stop` / `restart` — those are the lifecycle commands.
- **Not** `status` / `doctor` / `usage` — diagnostic; work without a container by design.
- **Not** `logs` — already has an existence check; `docker logs` also works on stopped containers.
- **Not** `shell` — already has the check inline; this PR extracts it from there.
- **Not** `compose*` — subcommands handle their own container state.

## Verification

```
bun run typecheck   # clean
bun run lint        # 8 pre-existing warnings in unrelated files, 0 errors
bun run format      # clean
bun test            # 3379/3379 pass
```

6 files changed, +133/−3.