### PR TITLE
Add `typeclaw provider` and `typeclaw model` CLI commands for post-init mutation

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,8 @@ const main = defineCommand({
     compose: () => import('./compose').then((m) => m.composeCommand),
     channel: () => import('./channel').then((m) => m.channelCommand),
     role: () => import('./role').then((m) => m.roleCommand),
+    provider: () => import('./provider').then((m) => m.providerCommand),
+    model: () => import('./model').then((m) => m.modelCommand),
     doctor: () => import('./doctor').then((m) => m.doctorCommand),
     usage: () => import('./usage').then((m) => m.usageCommand),
     _hostd: () => import('./hostd').then((m) => m.hostdCommand),

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -1,0 +1,244 @@
+import { cancel, intro, isCancel, select } from '@clack/prompts'
+import { defineCommand } from 'citty'
+
+import { addProfile, listModelProfiles, removeProfile, setProfile } from '@/config/models-mutation'
+import {
+  KNOWN_PROVIDERS,
+  listKnownModelRefs,
+  providerForModelRef,
+  type KnownModelRef,
+  type KnownProviderId,
+} from '@/config/providers'
+import { findAgentDir, isInitialized } from '@/init'
+
+import { c, done, errorLine } from './ui'
+
+const setSub = defineCommand({
+  meta: {
+    name: 'set',
+    description: 'set or update a model profile (default | fast | vision | <custom>)',
+  },
+  args: {
+    profile: {
+      type: 'positional',
+      description: 'profile name (typically `default`); omit to pick interactively',
+      required: false,
+    },
+    ref: {
+      type: 'positional',
+      description: '<provider>/<model> ref; omit to pick interactively',
+      required: false,
+    },
+    force: {
+      type: 'boolean',
+      description: 'write even when the target provider has no credentials configured',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = ensureAgentDir()
+    const profile = args.profile ?? (await pickProfileName())
+    const ref = args.ref ?? (await pickModelRef())
+
+    intro(`Setting model profile: ${profile} → ${ref}`)
+
+    const result = setProfile(cwd, profile, ref, { force: args.force === true })
+    if (!result.ok) {
+      console.error(errorLine(result.reason))
+      process.exit(1)
+    }
+    done({
+      title: c.green(`Profile "${profile}" set to ${ref}.`),
+      hints: [{ label: 'If the agent is running:', command: 'typeclaw reload' }],
+    })
+  },
+})
+
+const addSub = defineCommand({
+  meta: {
+    name: 'add',
+    description: 'create a new (non-default) model profile; refuses when the profile already exists',
+  },
+  args: {
+    profile: {
+      type: 'positional',
+      description: 'profile name (must not already exist)',
+      required: true,
+    },
+    ref: {
+      type: 'positional',
+      description: '<provider>/<model> ref; omit to pick interactively',
+      required: false,
+    },
+    force: {
+      type: 'boolean',
+      description: 'write even when the target provider has no credentials configured',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = ensureAgentDir()
+    const ref = args.ref ?? (await pickModelRef())
+
+    intro(`Adding model profile: ${args.profile} → ${ref}`)
+
+    const result = addProfile(cwd, args.profile, ref, { force: args.force === true })
+    if (!result.ok) {
+      console.error(errorLine(result.reason))
+      process.exit(1)
+    }
+    done({
+      title: c.green(`Profile "${args.profile}" → ${ref}.`),
+      hints: [{ label: 'If the agent is running:', command: 'typeclaw reload' }],
+    })
+  },
+})
+
+const removeSub = defineCommand({
+  meta: {
+    name: 'remove',
+    description: 'remove a non-default model profile (cannot remove `default`)',
+  },
+  args: {
+    profile: {
+      type: 'positional',
+      description: 'profile name to remove',
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const cwd = ensureAgentDir()
+    intro(`Removing model profile: ${args.profile}`)
+    const result = removeProfile(cwd, args.profile)
+    if (!result.ok) {
+      console.error(errorLine(result.reason))
+      process.exit(1)
+    }
+    done({
+      title: c.green(`Profile "${args.profile}" removed.`),
+      hints: [{ label: 'If the agent is running:', command: 'typeclaw reload' }],
+    })
+  },
+})
+
+const listSub = defineCommand({
+  meta: {
+    name: 'list',
+    description: 'list configured model profiles (or all known model refs with --available)',
+  },
+  args: {
+    available: {
+      type: 'boolean',
+      description: 'list every <provider>/<model> ref typeclaw recognizes (not just configured profiles)',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    if (args.available === true) {
+      printAvailableRefs()
+      return
+    }
+    const cwd = ensureAgentDir()
+    const entries = listModelProfiles(cwd)
+    if (entries.length === 0) {
+      console.log(c.dim('No models configured.'))
+      return
+    }
+
+    const profileWidth = Math.max(7, ...entries.map((e) => e.profile.length))
+    const refWidth = Math.max(3, ...entries.map((e) => e.ref.length))
+
+    const header = `${'PROFILE'.padEnd(profileWidth)}  ${'REF'.padEnd(refWidth)}  PROVIDER  STATUS`
+    console.log(c.dim(header))
+    for (const e of entries) {
+      const star = e.isDefault ? c.cyan('*') : ' '
+      const status = e.credentialStatus === 'available' ? c.green('ok') : c.yellow('missing-credentials')
+      const line = `${star}${e.profile.padEnd(profileWidth - 1)}  ${e.ref.padEnd(refWidth)}  ${e.providerId.padEnd(12)}  ${status}`
+      console.log(line)
+    }
+  },
+})
+
+export const modelCommand = defineCommand({
+  meta: {
+    name: 'model',
+    description: 'manage model profiles in typeclaw.json (models.default, models.fast, …)',
+  },
+  subCommands: {
+    set: setSub,
+    add: addSub,
+    remove: removeSub,
+    list: listSub,
+  },
+})
+
+function ensureAgentDir(): string {
+  const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+  if (!isInitialized(cwd)) {
+    console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first, or cd into an agent folder.'))
+    process.exit(1)
+  }
+  return cwd
+}
+
+async function pickProfileName(): Promise<string> {
+  const choice = await select<string>({
+    message: 'Pick a profile to set',
+    options: [
+      { value: 'default', label: 'default', hint: 'active model for new sessions' },
+      { value: 'fast', label: 'fast', hint: 'optional alias used by some subagents' },
+      { value: 'vision', label: 'vision', hint: 'optional alias used by some subagents' },
+    ],
+    initialValue: 'default',
+  })
+  if (isCancel(choice)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return choice
+}
+
+async function pickModelRef(): Promise<string> {
+  const refs = listKnownModelRefs()
+  const choice = await select<KnownModelRef>({
+    message: 'Pick a model',
+    options: refs.map((ref) => ({
+      value: ref,
+      label: describeRef(ref),
+      hint: ref,
+    })),
+    initialValue: refs[0],
+  })
+  if (isCancel(choice)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return choice
+}
+
+function describeRef(ref: KnownModelRef): string {
+  const providerId = providerForModelRef(ref)
+  const modelId = ref.slice(providerId.length + 1)
+  const provider = KNOWN_PROVIDERS[providerId]
+  const model = (provider.models as Record<string, { name: string }>)[modelId]
+  return model ? `${provider.name} · ${model.name}` : ref
+}
+
+function printAvailableRefs(): void {
+  const refs = listKnownModelRefs()
+  if (refs.length === 0) {
+    console.log(c.dim('No models registered.'))
+    return
+  }
+  console.log(c.dim('Use `typeclaw model set <profile> <ref>` to apply.'))
+  let lastProvider: KnownProviderId | null = null
+  for (const ref of refs) {
+    const providerId = providerForModelRef(ref)
+    if (providerId !== lastProvider) {
+      console.log('')
+      console.log(c.cyan(KNOWN_PROVIDERS[providerId].name))
+      lastProvider = providerId
+    }
+    console.log(`  ${ref}`)
+  }
+}

--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -1,0 +1,404 @@
+import { cancel, intro, isCancel, log, note, password, select, text } from '@clack/prompts'
+import { defineCommand } from 'citty'
+
+import {
+  KNOWN_PROVIDERS,
+  supportsApiKey as providerSupportsApiKey,
+  supportsOAuth as providerSupportsOAuth,
+  type KnownProviderId,
+} from '@/config/providers'
+import {
+  addProvider,
+  listConfiguredProviders,
+  removeProvider,
+  setProvider,
+  type CredentialSource,
+} from '@/config/providers-mutation'
+import { findAgentDir, isInitialized } from '@/init'
+import { makeOAuthLoginRunner } from '@/init/oauth-login'
+
+import { c, done, errorLine } from './ui'
+
+const addSub = defineCommand({
+  meta: {
+    name: 'add',
+    description: 'add LLM provider credentials (api key or OAuth) to an existing agent',
+  },
+  args: {
+    provider: {
+      type: 'positional',
+      description: `provider id (${Object.keys(KNOWN_PROVIDERS).join(' | ')}); omit to pick interactively`,
+      required: false,
+    },
+    key: {
+      type: 'string',
+      description: 'api key value (non-interactive); incompatible with --oauth',
+      required: false,
+    },
+    env: {
+      type: 'string',
+      description: 'bind to a custom env-var name (writes { env: NAME } into secrets.json)',
+      required: false,
+    },
+    oauth: {
+      type: 'boolean',
+      description: 'force OAuth flow (browser login) for providers that support both methods',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = ensureAgentDir()
+    const providerId = await resolveProviderForAdd(args.provider)
+    const provider = KNOWN_PROVIDERS[providerId]
+
+    intro(`Adding provider: ${provider.name}`)
+
+    const method = await resolveAuthMethod(provider, args)
+    if (method === 'oauth') {
+      const result = await runOAuthLogin(cwd, providerId)
+      if (!result.ok) {
+        console.error(errorLine(`OAuth login failed: ${result.reason}`))
+        process.exit(1)
+      }
+      done({
+        title: c.green(`Logged in to ${provider.name}.`),
+        hints: nextStepHints({ credentialChanged: true }),
+      })
+      return
+    }
+
+    const credential = await resolveApiKeyInputs(provider, args)
+    const result = addProvider(cwd, providerId, credential)
+    if (!result.ok) {
+      console.error(errorLine(result.reason))
+      process.exit(1)
+    }
+    done({
+      title: c.green(`Added ${provider.name} credentials to secrets.json.`),
+      hints: nextStepHints({ credentialChanged: true }),
+    })
+  },
+})
+
+const setSub = defineCommand({
+  meta: {
+    name: 'set',
+    description: 'rotate/update credentials for an already-configured provider',
+  },
+  args: {
+    provider: {
+      type: 'positional',
+      description: `provider id (${Object.keys(KNOWN_PROVIDERS).join(' | ')})`,
+      required: true,
+    },
+    key: {
+      type: 'string',
+      description: 'new api key value (non-interactive); incompatible with --oauth',
+      required: false,
+    },
+    env: {
+      type: 'string',
+      description: 'bind to a custom env-var name (writes { env: NAME } into secrets.json)',
+      required: false,
+    },
+    oauth: {
+      type: 'boolean',
+      description: 're-run OAuth flow (browser login)',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = ensureAgentDir()
+    const providerId = validateKnownProvider(args.provider)
+    const provider = KNOWN_PROVIDERS[providerId]
+
+    intro(`Updating provider: ${provider.name}`)
+
+    const method = await resolveAuthMethod(provider, args)
+    if (method === 'oauth') {
+      const result = await runOAuthLogin(cwd, providerId)
+      if (!result.ok) {
+        console.error(errorLine(`OAuth login failed: ${result.reason}`))
+        process.exit(1)
+      }
+      done({
+        title: c.green(`Refreshed OAuth credentials for ${provider.name}.`),
+        hints: nextStepHints({ credentialChanged: true }),
+      })
+      return
+    }
+
+    const credential = await resolveApiKeyInputs(provider, args)
+    const result = setProvider(cwd, providerId, credential)
+    if (!result.ok) {
+      console.error(errorLine(result.reason))
+      process.exit(1)
+    }
+    done({
+      title: c.green(`Updated ${provider.name} credentials in secrets.json.`),
+      hints: nextStepHints({ credentialChanged: true }),
+    })
+  },
+})
+
+const removeSub = defineCommand({
+  meta: {
+    name: 'remove',
+    description: 'remove a provider entry from secrets.json (refuses when a model profile references it)',
+  },
+  args: {
+    provider: {
+      type: 'positional',
+      description: 'provider id to remove',
+      required: true,
+    },
+    force: {
+      type: 'boolean',
+      description: 'remove even when a model profile references this provider',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = ensureAgentDir()
+    const providerId = args.provider
+    const provider = providerId in KNOWN_PROVIDERS ? KNOWN_PROVIDERS[providerId as KnownProviderId] : null
+    const label = provider?.name ?? providerId
+
+    intro(`Removing provider: ${label}`)
+
+    const result = removeProvider(cwd, providerId, { force: args.force === true })
+    if (!result.ok) {
+      const list = result.profiles.join(', ')
+      console.error(
+        errorLine(
+          `Cannot remove "${providerId}": referenced by model profile(s) [${list}]. Update those profiles first, or rerun with --force.`,
+        ),
+      )
+      process.exit(1)
+    }
+    if (!result.existed) {
+      log.info(`No "${providerId}" entry in secrets.json — nothing to remove.`)
+    }
+    done({
+      title: c.green(`Removed ${label} from secrets.json.`),
+      hints: nextStepHints({ credentialChanged: true }),
+    })
+  },
+})
+
+const listSub = defineCommand({
+  meta: {
+    name: 'list',
+    description: 'show configured providers and how each credential resolves (file / env / oauth)',
+  },
+  async run() {
+    const cwd = ensureAgentDir()
+    const entries = listConfiguredProviders(cwd)
+    if (entries.length === 0) {
+      console.log(c.dim('No providers configured. Run `typeclaw provider add <id>` to wire one up.'))
+      return
+    }
+
+    const rows = entries.map((entry) => {
+      const refs =
+        entry.referencedByProfiles.length === 0 ? c.dim('(no profile)') : entry.referencedByProfiles.join(',')
+      const name = entry.id in KNOWN_PROVIDERS ? KNOWN_PROVIDERS[entry.id as KnownProviderId].name : entry.id
+      return {
+        id: entry.id,
+        name,
+        type: entry.type,
+        source: describeSource(entry.source),
+        refs,
+      }
+    })
+
+    const idWidth = Math.max(2, ...rows.map((r) => r.id.length))
+    const typeWidth = Math.max(4, ...rows.map((r) => r.type.length))
+    const sourceWidth = Math.max(6, ...rows.map((r) => r.source.length))
+
+    const header = `${'ID'.padEnd(idWidth)}  ${'TYPE'.padEnd(typeWidth)}  ${'SOURCE'.padEnd(sourceWidth)}  PROFILES`
+    console.log(c.dim(header))
+    for (const r of rows) {
+      const line = `${r.id.padEnd(idWidth)}  ${r.type.padEnd(typeWidth)}  ${r.source.padEnd(sourceWidth)}  ${r.refs}  ${c.dim(`(${r.name})`)}`
+      console.log(line)
+    }
+  },
+})
+
+export const providerCommand = defineCommand({
+  meta: {
+    name: 'provider',
+    description: 'manage LLM provider credentials in secrets.json',
+  },
+  subCommands: {
+    add: addSub,
+    set: setSub,
+    remove: removeSub,
+    list: listSub,
+  },
+})
+
+function ensureAgentDir(): string {
+  const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+  if (!isInitialized(cwd)) {
+    console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first, or cd into an agent folder.'))
+    process.exit(1)
+  }
+  return cwd
+}
+
+function validateKnownProvider(input: string): KnownProviderId {
+  if (input in KNOWN_PROVIDERS) return input as KnownProviderId
+  console.error(errorLine(`Unknown provider "${input}". Available: ${Object.keys(KNOWN_PROVIDERS).join(', ')}.`))
+  process.exit(1)
+}
+
+async function resolveProviderForAdd(input: string | undefined): Promise<KnownProviderId> {
+  if (input !== undefined) return validateKnownProvider(input)
+  const ids = Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]
+  const choice = await select<KnownProviderId>({
+    message: 'Pick a provider to add',
+    options: ids.map((id) => ({
+      value: id,
+      label: KNOWN_PROVIDERS[id].name,
+      hint: authHint(id),
+    })),
+    initialValue: ids[0],
+  })
+  if (isCancel(choice)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return choice
+}
+
+type AuthArgs = { oauth?: boolean | undefined; key?: string | undefined; env?: string | undefined }
+
+async function resolveAuthMethod(
+  provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+  args: AuthArgs,
+): Promise<'api-key' | 'oauth'> {
+  const apiKeyOk = providerSupportsApiKey(provider)
+  const oauthOk = providerSupportsOAuth(provider)
+  if (args.oauth === true) {
+    if (!oauthOk) {
+      console.error(errorLine(`Provider ${provider.name} does not support OAuth.`))
+      process.exit(1)
+    }
+    return 'oauth'
+  }
+  if (args.key !== undefined || args.env !== undefined) {
+    if (!apiKeyOk) {
+      console.error(errorLine(`Provider ${provider.name} does not support api-key auth. Re-run with --oauth instead.`))
+      process.exit(1)
+    }
+    return 'api-key'
+  }
+  if (apiKeyOk && oauthOk) {
+    const choice = await select<'api-key' | 'oauth'>({
+      message: `How do you want to authenticate to ${provider.name}?`,
+      options: [
+        { value: 'api-key', label: 'API key', hint: 'saved to secrets.json' },
+        { value: 'oauth', label: 'OAuth (browser login)', hint: 'saved to secrets.json' },
+      ],
+      initialValue: 'api-key',
+    })
+    if (isCancel(choice)) {
+      cancel('Aborted.')
+      process.exit(0)
+    }
+    return choice
+  }
+  return oauthOk ? 'oauth' : 'api-key'
+}
+
+async function resolveApiKeyInputs(
+  provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+  args: AuthArgs,
+): Promise<
+  { type: 'api_key'; key: string; envBinding?: string | undefined } | { type: 'env-binding'; envBinding: string }
+> {
+  if (args.env !== undefined && args.key === undefined) {
+    return { type: 'env-binding', envBinding: args.env }
+  }
+  if (args.key !== undefined) {
+    const result: { type: 'api_key'; key: string; envBinding?: string } = { type: 'api_key', key: args.key }
+    if (args.env !== undefined) result.envBinding = args.env
+    return result
+  }
+  return { type: 'api_key', key: await promptApiKey(provider) }
+}
+
+async function promptApiKey(provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]): Promise<string> {
+  const value = await password({
+    message: `Put your ${provider.name} API key (will be saved to secrets.json)`,
+    validate: (v) => (v && v.length > 0 ? undefined : 'API key is required'),
+  })
+  if (isCancel(value)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return value
+}
+
+async function runOAuthLogin(cwd: string, providerId: KnownProviderId): Promise<{ ok: boolean; reason?: string }> {
+  const provider = KNOWN_PROVIDERS[providerId]
+  // Pick any model ref for the provider; OAuth login only uses the ref to
+  // discover the provider's `oauthProviderId`, which is the same regardless
+  // of which model the user later selects via `typeclaw model set`.
+  const ref = Object.keys(provider.models)[0]
+  if (ref === undefined) {
+    return { ok: false, reason: `Provider ${provider.name} has no registered models.` }
+  }
+  const modelRef = `${providerId}/${ref}` as const
+
+  const callbacks = {
+    onAuth: (url: string, instructions?: string) => {
+      const preamble = [`Open this URL in your browser to authorize ${provider.name}.`]
+      if (instructions) preamble.push('', instructions)
+      note(preamble.join('\n'), 'Browser login')
+      console.log(url)
+      console.log('')
+    },
+    onProgress: (message: string) => {
+      log.info(message)
+    },
+    onPrompt: async (message: string, placeholder?: string): Promise<string | null> => {
+      const value = await text({ message, ...(placeholder !== undefined ? { placeholder } : {}) })
+      if (isCancel(value)) return null
+      return value
+    },
+  }
+
+  const runner = makeOAuthLoginRunner(callbacks)
+  const result = await runner({ cwd, model: modelRef as Parameters<typeof runner>[0]['model'] })
+  if (!result.ok) return { ok: false, reason: result.reason }
+  return { ok: true }
+}
+
+function authHint(id: KnownProviderId): string {
+  const provider = KNOWN_PROVIDERS[id]
+  const apiKey = providerSupportsApiKey(provider)
+  const oauth = providerSupportsOAuth(provider)
+  if (apiKey && oauth) return 'API key or OAuth'
+  if (oauth) return 'OAuth only'
+  return 'API key'
+}
+
+function describeSource(source: CredentialSource): string {
+  switch (source.kind) {
+    case 'file':
+      return 'file'
+    case 'env-only':
+      return `env (${source.envName})`
+    case 'env-overridden':
+      return `env (${source.envName}, overrides file)`
+    case 'oauth':
+      return 'oauth'
+  }
+}
+
+function nextStepHints(opts: { credentialChanged: boolean }): { label: string; command: string }[] {
+  if (!opts.credentialChanged) return []
+  return [{ label: 'If the agent is running:', command: 'typeclaw reload' }]
+}

--- a/src/config/models-mutation.test.ts
+++ b/src/config/models-mutation.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { readFile, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { scaffold, writeSecrets } from '@/init'
+
+import {
+  addProfile,
+  isKnownModelRef,
+  listAvailableModelRefs,
+  listModelProfiles,
+  removeProfile,
+  setProfile,
+} from './models-mutation'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-models-mutation-'))
+  await scaffold(root, { model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
+  await writeSecrets(root, {
+    model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+    apiKey: 'fw_initial',
+  })
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function readModels(): Promise<Record<string, string>> {
+  const raw = await readFile(join(root, 'typeclaw.json'), 'utf8')
+  const parsed = JSON.parse(raw) as { models?: Record<string, string> }
+  return parsed.models ?? {}
+}
+
+describe('listAvailableModelRefs', () => {
+  test('returns all KNOWN_PROVIDERS model refs', () => {
+    const refs = listAvailableModelRefs()
+    expect(refs).toContain('openai/gpt-5.4-nano')
+    expect(refs).toContain('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    expect(refs.length).toBeGreaterThan(5)
+  })
+})
+
+describe('isKnownModelRef', () => {
+  test('accepts canonical refs', () => {
+    expect(isKnownModelRef('openai/gpt-5.4-nano')).toBe(true)
+  })
+
+  test('rejects unknown refs', () => {
+    expect(isKnownModelRef('mystery/model')).toBe(false)
+    expect(isKnownModelRef('')).toBe(false)
+    expect(isKnownModelRef('fireworks')).toBe(false)
+  })
+})
+
+describe('setProfile', () => {
+  test('updates the default profile when credentials are present', async () => {
+    const result = setProfile(root, 'default', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    expect(result.ok).toBe(true)
+    expect((await readModels()).default).toBe('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+  })
+
+  test('creates a new profile beside default', async () => {
+    setProfile(root, 'default', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    const result = setProfile(root, 'fast', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    expect(result.ok).toBe(true)
+    expect((await readModels()).fast).toBe('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+  })
+
+  test('refuses unknown model refs', () => {
+    const result = setProfile(root, 'default', 'mystery/model')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('Unknown model')
+  })
+
+  test('refuses empty profile names', () => {
+    const result = setProfile(root, '   ', 'openai/gpt-5.4-nano', { env: { OPENAI_API_KEY: 'x' } })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('Profile name')
+  })
+
+  test('refuses when target provider has no credentials', () => {
+    const env: NodeJS.ProcessEnv = {}
+    const result = setProfile(root, 'default', 'openai/gpt-5.4-nano', { env })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('has no credentials')
+    expect(result.reason).toContain('typeclaw provider add openai')
+    expect(result.reason).toContain('--force')
+  })
+
+  test('proceeds when target provider credentials come from env', () => {
+    const env: NodeJS.ProcessEnv = { OPENAI_API_KEY: 'sk-from-env' }
+    const result = setProfile(root, 'default', 'openai/gpt-5.4-nano', { env })
+    expect(result.ok).toBe(true)
+  })
+
+  test('force=true writes even without credentials', () => {
+    const env: NodeJS.ProcessEnv = {}
+    const result = setProfile(root, 'default', 'openai/gpt-5.4-nano', { env, force: true })
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('addProfile', () => {
+  test('refuses to overwrite an existing profile', () => {
+    const result = addProfile(root, 'default', 'openai/gpt-5.4-nano', { env: { OPENAI_API_KEY: 'x' } })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('already exists')
+    expect(result.reason).toContain('typeclaw model set')
+  })
+
+  test('creates a fresh profile', async () => {
+    const result = addProfile(root, 'fast', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    expect(result.ok).toBe(true)
+    expect((await readModels()).fast).toBe('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+  })
+})
+
+describe('removeProfile', () => {
+  test('refuses to remove the default profile', () => {
+    const result = removeProfile(root, 'default')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('Cannot remove')
+    expect(result.reason).toContain('model set default')
+  })
+
+  test('removes a non-default profile', async () => {
+    addProfile(root, 'fast', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    const result = removeProfile(root, 'fast')
+    expect(result.ok).toBe(true)
+    const models = await readModels()
+    expect(models).not.toHaveProperty('fast')
+    expect(models.default).toBeDefined()
+  })
+
+  test('errors when profile does not exist', () => {
+    const result = removeProfile(root, 'nonexistent')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('not found')
+  })
+})
+
+describe('listModelProfiles', () => {
+  test('lists default first, then alphabetical', () => {
+    addProfile(root, 'zeta', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    addProfile(root, 'alpha', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    const entries = listModelProfiles(root)
+    expect(entries.map((e) => e.profile)).toEqual(['default', 'alpha', 'zeta'])
+    expect(entries[0]?.isDefault).toBe(true)
+    expect(entries[1]?.isDefault).toBe(false)
+  })
+
+  test('marks profiles with missing credentials', () => {
+    addProfile(root, 'vision', 'openai/gpt-5.4-mini', { force: true })
+    const env: NodeJS.ProcessEnv = {}
+    const entries = listModelProfiles(root, env)
+    const vision = entries.find((e) => e.profile === 'vision')
+    expect(vision?.credentialStatus).toBe('missing-credentials')
+    const dflt = entries.find((e) => e.profile === 'default')
+    expect(dflt?.credentialStatus).toBe('available')
+  })
+
+  test('credentialStatus uses env override when set', () => {
+    addProfile(root, 'vision', 'openai/gpt-5.4-mini', { force: true })
+    const env: NodeJS.ProcessEnv = { OPENAI_API_KEY: 'sk-x' }
+    const entries = listModelProfiles(root, env)
+    const vision = entries.find((e) => e.profile === 'vision')
+    expect(vision?.credentialStatus).toBe('available')
+  })
+})

--- a/src/config/models-mutation.ts
+++ b/src/config/models-mutation.ts
@@ -1,0 +1,200 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { configSchema, loadConfigSync, validateConfig } from './config'
+import {
+  KNOWN_PROVIDERS,
+  listKnownModelRefs,
+  providerForModelRef,
+  type KnownModelRef,
+  type KnownProviderId,
+} from './providers'
+import { isProviderConfigured } from './providers-mutation'
+
+const CONFIG_FILE = 'typeclaw.json'
+
+export type ModelProfileEntry = {
+  profile: string
+  ref: KnownModelRef
+  providerId: KnownProviderId
+  isDefault: boolean
+  credentialStatus: 'available' | 'missing-credentials'
+}
+
+export type ModelMutationResult = { ok: true } | { ok: false; reason: string }
+
+export function listModelProfiles(cwd: string, env: NodeJS.ProcessEnv = process.env): ModelProfileEntry[] {
+  const models = loadConfigSync(cwd).models
+  const out: ModelProfileEntry[] = []
+  for (const [profile, ref] of Object.entries(models)) {
+    const providerId = providerForModelRef(ref)
+    out.push({
+      profile,
+      ref,
+      providerId,
+      isDefault: profile === 'default',
+      credentialStatus: hasUsableCredential(cwd, providerId, env) ? 'available' : 'missing-credentials',
+    })
+  }
+  // `default` always first; remaining profiles alphabetical so output is stable.
+  out.sort((a, b) => {
+    if (a.isDefault) return -1
+    if (b.isDefault) return 1
+    return a.profile.localeCompare(b.profile)
+  })
+  return out
+}
+
+export function listAvailableModelRefs(): KnownModelRef[] {
+  return listKnownModelRefs()
+}
+
+export function isKnownModelRef(value: string): value is KnownModelRef {
+  return (listKnownModelRefs() as ReadonlyArray<string>).includes(value)
+}
+
+// `set` is the canonical mutation for both creating a new profile and updating
+// an existing one (mirrors how `models.<profile>` works in the schema).
+// Refuses unknown model refs and providers without credentials (unless
+// `force: true`) so a write can't leave the agent in a state where the next
+// session start crashes with a missing-credential error.
+export type SetProfileOptions = {
+  force?: boolean
+  env?: NodeJS.ProcessEnv
+}
+
+export function setProfile(
+  cwd: string,
+  profile: string,
+  ref: string,
+  options: SetProfileOptions = {},
+): ModelMutationResult {
+  const trimmed = profile.trim()
+  if (trimmed.length === 0) {
+    return { ok: false, reason: 'Profile name cannot be empty.' }
+  }
+  if (!isKnownModelRef(ref)) {
+    return {
+      ok: false,
+      reason: `Unknown model "${ref}". Run \`typeclaw model list --available\` to see valid options.`,
+    }
+  }
+  const providerId = providerForModelRef(ref)
+  if (options.force !== true && !hasUsableCredential(cwd, providerId, options.env ?? process.env)) {
+    return {
+      ok: false,
+      reason: `Provider "${providerId}" has no credentials. Run \`typeclaw provider add ${providerId}\` first, or pass --force to write anyway.`,
+    }
+  }
+
+  return writeProfile(cwd, trimmed, ref)
+}
+
+// `add` is just `set` with a uniqueness guard; users who want "update" should
+// reach for `set`. Keeping it separate so the CLI can route distinct error
+// messages without leaking force-overwrite as a happy path.
+export function addProfile(
+  cwd: string,
+  profile: string,
+  ref: string,
+  options: SetProfileOptions = {},
+): ModelMutationResult {
+  const existing = readModelsRaw(cwd)
+  if (existing !== null && profile in existing) {
+    return {
+      ok: false,
+      reason: `Profile "${profile}" already exists. Use \`typeclaw model set ${profile} ${ref}\` to update it.`,
+    }
+  }
+  return setProfile(cwd, profile, ref, options)
+}
+
+// `default` is required by the schema (`modelsSchema.refine`). Removing it
+// would make the file unparseable, so we reject with a precise hint instead of
+// letting the next `validateConfig` failure confuse the user. To change the
+// default model, the user runs `typeclaw model set default <ref>`.
+export function removeProfile(cwd: string, profile: string): ModelMutationResult {
+  if (profile === 'default') {
+    return {
+      ok: false,
+      reason:
+        'Cannot remove the `default` profile. Use `typeclaw model set default <ref>` to change the default model.',
+    }
+  }
+  const existing = readModelsRaw(cwd)
+  if (existing === null) {
+    return { ok: false, reason: `${CONFIG_FILE} not found at ${cwd}. Run \`typeclaw init\` first.` }
+  }
+  if (!(profile in existing)) {
+    return { ok: false, reason: `Profile "${profile}" not found in ${CONFIG_FILE}.` }
+  }
+  const next = { ...existing }
+  delete next[profile]
+  return writeModels(cwd, next)
+}
+
+function writeProfile(cwd: string, profile: string, ref: KnownModelRef): ModelMutationResult {
+  const existing = readModelsRaw(cwd)
+  const next = existing === null ? { default: ref } : { ...existing, [profile]: ref }
+  if (existing === null && profile !== 'default') {
+    next.default = ref
+  }
+  return writeModels(cwd, next)
+}
+
+function writeModels(cwd: string, models: Record<string, string>): ModelMutationResult {
+  const path = join(cwd, CONFIG_FILE)
+  let parsed: Record<string, unknown>
+  try {
+    const raw = readFileSync(path, 'utf8')
+    parsed = JSON.parse(raw) as Record<string, unknown>
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { ok: false, reason: `${CONFIG_FILE} not found at ${cwd}. Run \`typeclaw init\` first.` }
+    }
+    return { ok: false, reason: `Failed to read ${CONFIG_FILE}: ${(error as Error).message}` }
+  }
+  parsed.models = models
+  const check = configSchema.safeParse(parsed)
+  if (!check.success) {
+    return {
+      ok: false,
+      reason: `models block would be invalid: ${check.error.issues.map((i) => i.message).join('; ')}`,
+    }
+  }
+  try {
+    writeFileSync(path, `${JSON.stringify(parsed, null, 2)}\n`)
+  } catch (error) {
+    return { ok: false, reason: `Failed to write ${CONFIG_FILE}: ${(error as Error).message}` }
+  }
+  // Final schema-pass for parity with every other host-side mutation that runs
+  // through validateConfig. Mount checks etc. should never fail here because
+  // we only touched `models`, but if the file was already in a bad state we
+  // want to surface that instead of leaving the user wondering why `reload`
+  // fails.
+  const validation = validateConfig(cwd)
+  if (!validation.ok) {
+    return { ok: false, reason: validation.reason }
+  }
+  return { ok: true }
+}
+
+function readModelsRaw(cwd: string): Record<string, string> | null {
+  try {
+    const raw = readFileSync(join(cwd, CONFIG_FILE), 'utf8')
+    const parsed = JSON.parse(raw) as { models?: Record<string, string> }
+    return parsed.models ?? null
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+}
+
+function hasUsableCredential(cwd: string, providerId: KnownProviderId, env: NodeJS.ProcessEnv): boolean {
+  const provider = KNOWN_PROVIDERS[providerId]
+  if (provider.apiKeyEnv !== null) {
+    const fromEnv = env[provider.apiKeyEnv]
+    if (fromEnv !== undefined && fromEnv !== '') return true
+  }
+  return isProviderConfigured(cwd, providerId)
+}

--- a/src/config/providers-mutation.test.ts
+++ b/src/config/providers-mutation.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { readFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { scaffold, writeSecrets } from '@/init'
+
+import {
+  addProvider,
+  findModelsReferencingProvider,
+  isProviderConfigured,
+  listConfiguredProviders,
+  removeProvider,
+  setProvider,
+} from './providers-mutation'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-providers-mutation-'))
+  await scaffold(root, { model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
+  await writeSecrets(root, {
+    model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+    apiKey: 'fw_initial',
+  })
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function readSecretsProviders(): Promise<Record<string, unknown>> {
+  const raw = await readFile(join(root, 'secrets.json'), 'utf8')
+  const parsed = JSON.parse(raw) as { providers?: Record<string, unknown> }
+  return parsed.providers ?? {}
+}
+
+describe('isProviderConfigured', () => {
+  test('returns true for a provider with a file entry', () => {
+    expect(isProviderConfigured(root, 'fireworks')).toBe(true)
+  })
+
+  test('returns false for a provider without a file entry, even if known', () => {
+    expect(isProviderConfigured(root, 'openai')).toBe(false)
+  })
+})
+
+describe('addProvider', () => {
+  test('writes a fresh api_key credential to secrets.json#providers.<id>', () => {
+    const result = addProvider(root, 'openai', { type: 'api_key', key: 'sk-new' })
+    expect(result.ok).toBe(true)
+  })
+
+  test('refuses when the provider already has an entry', () => {
+    const result = addProvider(root, 'fireworks', { type: 'api_key', key: 'fw_other' })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('already configured')
+    expect(result.reason).toContain('provider set')
+  })
+
+  test('refuses oauth-only providers on the api-key path', () => {
+    const result = addProvider(root, 'openai-codex', { type: 'api_key', key: 'sk-codex' })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('does not support api-key authentication')
+  })
+
+  test('writes an env-binding without a value when type=env-binding', async () => {
+    addProvider(root, 'openai', { type: 'env-binding', envBinding: 'MY_OPENAI' })
+    const providers = await readSecretsProviders()
+    expect(providers.openai).toEqual({ type: 'api_key', key: { env: 'MY_OPENAI' } })
+  })
+
+  test('writes value+env when both are provided', async () => {
+    addProvider(root, 'openai', { type: 'api_key', key: 'sk-x', envBinding: 'MY_OPENAI' })
+    const providers = await readSecretsProviders()
+    expect(providers.openai).toEqual({ type: 'api_key', key: { value: 'sk-x', env: 'MY_OPENAI' } })
+  })
+})
+
+describe('setProvider', () => {
+  test('rotates an existing api_key credential', async () => {
+    setProvider(root, 'fireworks', { type: 'api_key', key: 'fw_rotated' })
+    const providers = await readSecretsProviders()
+    expect(providers.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_rotated' } })
+  })
+
+  test('creates the entry when missing (same as addProvider for fresh providers)', async () => {
+    setProvider(root, 'openai', { type: 'api_key', key: 'sk-new' })
+    expect(isProviderConfigured(root, 'openai')).toBe(true)
+  })
+})
+
+describe('findModelsReferencingProvider', () => {
+  test('returns the profile names that reference a provider', async () => {
+    const configPath = join(root, 'typeclaw.json')
+    const cfg = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, unknown>
+    cfg.models = {
+      default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+      fast: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+      vision: 'openai/gpt-5.4-mini',
+    }
+    await writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`)
+
+    expect(findModelsReferencingProvider(root, 'fireworks').sort()).toEqual(['default', 'fast'])
+    expect(findModelsReferencingProvider(root, 'openai')).toEqual(['vision'])
+    expect(findModelsReferencingProvider(root, 'zai')).toEqual([])
+  })
+})
+
+describe('removeProvider', () => {
+  test('refuses when any model profile references the provider', () => {
+    const result = removeProvider(root, 'fireworks')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('referenced')
+    expect(result.profiles).toEqual(['default'])
+  })
+
+  test('removes when no profile references the provider', async () => {
+    addProvider(root, 'openai', { type: 'api_key', key: 'sk-x' })
+    const result = removeProvider(root, 'openai')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.existed).toBe(true)
+    expect(await readSecretsProviders()).not.toHaveProperty('openai')
+  })
+
+  test('reports existed=false when called on an absent provider', () => {
+    const result = removeProvider(root, 'zai')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.existed).toBe(false)
+  })
+
+  test('force=true bypasses the model-reference check', async () => {
+    const result = removeProvider(root, 'fireworks', { force: true })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.existed).toBe(true)
+    expect(await readSecretsProviders()).not.toHaveProperty('fireworks')
+  })
+})
+
+describe('listConfiguredProviders', () => {
+  test('reports file-backed providers with kind=file', () => {
+    const env: NodeJS.ProcessEnv = {}
+    const entries = listConfiguredProviders(root, env)
+    const fireworks = entries.find((e) => e.id === 'fireworks')
+    expect(fireworks).toBeDefined()
+    expect(fireworks?.source).toEqual({ kind: 'file' })
+    expect(fireworks?.referencedByProfiles).toEqual(['default'])
+  })
+
+  test('reports env-overridden when both file and env are set', () => {
+    const env: NodeJS.ProcessEnv = { FIREWORKS_API_KEY: 'fw_from_env' }
+    const entries = listConfiguredProviders(root, env)
+    const fireworks = entries.find((e) => e.id === 'fireworks')
+    expect(fireworks?.source).toEqual({ kind: 'env-overridden', envName: 'FIREWORKS_API_KEY' })
+  })
+
+  test('reports env-only when env is set but no file entry exists', () => {
+    const env: NodeJS.ProcessEnv = { OPENAI_API_KEY: 'sk-from-env' }
+    const entries = listConfiguredProviders(root, env)
+    const openai = entries.find((e) => e.id === 'openai')
+    expect(openai).toBeDefined()
+    expect(openai?.source).toEqual({ kind: 'env-only', envName: 'OPENAI_API_KEY' })
+  })
+
+  test('omits known providers with no env and no file entry', () => {
+    const env: NodeJS.ProcessEnv = {}
+    const entries = listConfiguredProviders(root, env)
+    expect(entries.find((e) => e.id === 'openai')).toBeUndefined()
+    expect(entries.find((e) => e.id === 'zai')).toBeUndefined()
+  })
+
+  test('respects explicit env binding over the canonical env var', () => {
+    setProvider(root, 'fireworks', { type: 'env-binding', envBinding: 'MY_FW' })
+    const env: NodeJS.ProcessEnv = { FIREWORKS_API_KEY: 'should-be-ignored', MY_FW: 'fw_real' }
+    const entries = listConfiguredProviders(root, env)
+    const fireworks = entries.find((e) => e.id === 'fireworks')
+    expect(fireworks?.envName).toBe('MY_FW')
+    expect(fireworks?.source).toEqual({ kind: 'env-only', envName: 'MY_FW' })
+  })
+})

--- a/src/config/providers-mutation.ts
+++ b/src/config/providers-mutation.ts
@@ -1,0 +1,250 @@
+import { join } from 'node:path'
+
+import { SecretsBackend, type Secret } from '@/secrets'
+import { providerKeyDefaultEnv } from '@/secrets/defaults'
+import type { ProviderCredential, Providers } from '@/secrets/schema'
+
+import { type Models, loadConfigSync } from './config'
+import { KNOWN_PROVIDERS, type KnownModelRef, type KnownProviderId, providerForModelRef } from './providers'
+
+// Where a configured credential resolves from at runtime. Reported by
+// `typeclaw provider list` so users can tell whether their key is coming from
+// `secrets.json#providers.<id>.key.value`, from `process.env.<API_KEY_ENV>`, or
+// from an explicit `{ env: 'CUSTOM_NAME' }` binding. Drives the post-mutation
+// hints (e.g. "key is env-overridden — `provider remove` will not unset env").
+export type CredentialSource =
+  | { kind: 'file' }
+  | { kind: 'env-only'; envName: string }
+  | { kind: 'env-overridden'; envName: string }
+  | { kind: 'oauth' }
+
+export type ConfiguredProvider = {
+  id: KnownProviderId | string
+  known: boolean
+  type: 'api_key' | 'oauth' | 'unknown'
+  source: CredentialSource
+  envName: string | undefined
+  referencedByProfiles: string[]
+}
+
+export type ProviderAddCredential =
+  | { type: 'api_key'; key: string; envBinding?: string | undefined }
+  | { type: 'env-binding'; envBinding: string }
+
+export type ProviderMutationResult = { ok: true } | { ok: false; reason: string }
+
+const SECRETS_FILE = 'secrets.json'
+
+export function listConfiguredProviders(cwd: string, env: NodeJS.ProcessEnv = process.env): ConfiguredProvider[] {
+  const backend = new SecretsBackend(join(cwd, SECRETS_FILE))
+  const providers = backend.tryReadProvidersSync()
+  const models = readModelsOrNull(cwd)
+  const referencedByProfiles = buildProviderReferenceMap(models)
+
+  const ids = new Set<string>([...Object.keys(providers), ...Object.keys(KNOWN_PROVIDERS)])
+  const out: ConfiguredProvider[] = []
+  for (const id of ids) {
+    const credential = providers[id]
+    const known = id in KNOWN_PROVIDERS
+    if (credential === undefined) {
+      // Known provider with no file entry. Surface it only when an env var
+      // makes it usable; otherwise it's not "configured" and shouldn't appear
+      // in the list (would clutter output for the 5+ known providers users
+      // haven't touched).
+      const envName = providerKeyDefaultEnv(id)
+      if (envName !== undefined && readEnvKey(env, envName) !== undefined) {
+        out.push({
+          id: id as KnownProviderId,
+          known,
+          type: 'api_key',
+          source: { kind: 'env-only', envName },
+          envName,
+          referencedByProfiles: referencedByProfiles.get(id) ?? [],
+        })
+      }
+      continue
+    }
+    out.push({
+      id,
+      known,
+      type: credentialType(credential),
+      source: credentialSource(id, credential, env),
+      envName: effectiveEnvName(id, credential),
+      referencedByProfiles: referencedByProfiles.get(id) ?? [],
+    })
+  }
+  out.sort((a, b) => a.id.localeCompare(b.id))
+  return out
+}
+
+export function isProviderConfigured(cwd: string, providerId: string): boolean {
+  const backend = new SecretsBackend(join(cwd, SECRETS_FILE))
+  return providerId in backend.tryReadProvidersSync()
+}
+
+// Refuses to overwrite an existing provider — callers must use `setProvider`
+// for the rotate path. Keeps the "I'm adding fresh credentials" intent
+// distinct from the "I'm rotating an existing key" intent at the file-write
+// boundary, so an `add` typo can't silently displace a working key.
+export function addProvider(
+  cwd: string,
+  providerId: KnownProviderId,
+  credential: ProviderAddCredential,
+): ProviderMutationResult {
+  if (isProviderConfigured(cwd, providerId)) {
+    return {
+      ok: false,
+      reason: `Provider "${providerId}" is already configured in secrets.json. Use \`typeclaw provider set\` to rotate its credentials.`,
+    }
+  }
+  return writeApiKeyCredential(cwd, providerId, credential)
+}
+
+export function setProvider(
+  cwd: string,
+  providerId: KnownProviderId,
+  credential: ProviderAddCredential,
+): ProviderMutationResult {
+  return writeApiKeyCredential(cwd, providerId, credential)
+}
+
+// Refuses removal when any model profile in typeclaw.json references the
+// provider — clearing the credential out from under an active profile would
+// crash the next session start with a missing-credential error. Returns the
+// list of offending profiles so the CLI can name them in the error message.
+export type ProviderRemovalResult =
+  | { ok: true; existed: boolean }
+  | { ok: false; reason: 'referenced'; profiles: string[] }
+
+export function removeProvider(
+  cwd: string,
+  providerId: string,
+  options: { force?: boolean } = {},
+): ProviderRemovalResult {
+  if (options.force !== true) {
+    const profiles = findModelsReferencingProvider(cwd, providerId)
+    if (profiles.length > 0) {
+      return { ok: false, reason: 'referenced', profiles }
+    }
+  }
+  const backend = new SecretsBackend(join(cwd, SECRETS_FILE))
+  const existed = backend.removeProviderCredentialSync(providerId)
+  return { ok: true, existed }
+}
+
+export function findModelsReferencingProvider(cwd: string, providerId: string): string[] {
+  const models = readModelsOrNull(cwd)
+  if (models === null) return []
+  const out: string[] = []
+  for (const [profile, ref] of Object.entries(models)) {
+    if (refTargetsProvider(ref, providerId)) out.push(profile)
+  }
+  return out
+}
+
+function writeApiKeyCredential(
+  cwd: string,
+  providerId: KnownProviderId,
+  credential: ProviderAddCredential,
+): ProviderMutationResult {
+  if (!(providerId in KNOWN_PROVIDERS)) {
+    return { ok: false, reason: `Unknown provider "${providerId}".` }
+  }
+  const provider = KNOWN_PROVIDERS[providerId]
+  if (provider.apiKeyEnv === null) {
+    return {
+      ok: false,
+      reason: `Provider "${providerId}" does not support api-key authentication. Use \`typeclaw provider add ${providerId} --oauth\` instead.`,
+    }
+  }
+  const secret = buildSecret(credential)
+  if (secret === null) {
+    return { ok: false, reason: 'API key cannot be empty.' }
+  }
+  const backend = new SecretsBackend(join(cwd, SECRETS_FILE))
+  backend.writeProviderCredentialSync(providerId, { type: 'api_key', key: secret })
+  return { ok: true }
+}
+
+function buildSecret(credential: ProviderAddCredential): Secret | null {
+  if (credential.type === 'env-binding') {
+    return { env: credential.envBinding }
+  }
+  if (credential.key.length === 0) return null
+  if (credential.envBinding !== undefined && credential.envBinding.length > 0) {
+    return { value: credential.key, env: credential.envBinding }
+  }
+  return { value: credential.key }
+}
+
+function credentialType(credential: ProviderCredential): 'api_key' | 'oauth' | 'unknown' {
+  if (credential.type === 'api_key') return 'api_key'
+  if (credential.type === 'oauth') return 'oauth'
+  return 'unknown'
+}
+
+function credentialSource(
+  providerId: string,
+  credential: ProviderCredential,
+  env: NodeJS.ProcessEnv,
+): CredentialSource {
+  if (credential.type === 'oauth') return { kind: 'oauth' }
+  if (credential.type !== 'api_key') return { kind: 'file' }
+  const envName = credential.key.env ?? providerKeyDefaultEnv(providerId)
+  if (envName !== undefined && readEnvKey(env, envName) !== undefined) {
+    if (credential.key.value === undefined) return { kind: 'env-only', envName }
+    return { kind: 'env-overridden', envName }
+  }
+  return { kind: 'file' }
+}
+
+function effectiveEnvName(providerId: string, credential: ProviderCredential): string | undefined {
+  if (credential.type !== 'api_key') return undefined
+  return credential.key.env ?? providerKeyDefaultEnv(providerId)
+}
+
+function readEnvKey(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[key]
+  if (value === undefined || value === '') return undefined
+  return value
+}
+
+function buildProviderReferenceMap(models: Models | null): Map<string, string[]> {
+  const out = new Map<string, string[]>()
+  if (models === null) return out
+  for (const [profile, ref] of Object.entries(models)) {
+    const providerId = safeProviderForRef(ref)
+    if (providerId === null) continue
+    const existing = out.get(providerId) ?? []
+    existing.push(profile)
+    out.set(providerId, existing)
+  }
+  return out
+}
+
+function refTargetsProvider(ref: string, providerId: string): boolean {
+  return ref.startsWith(`${providerId}/`)
+}
+
+function safeProviderForRef(ref: KnownModelRef): KnownProviderId | null {
+  try {
+    return providerForModelRef(ref)
+  } catch {
+    return null
+  }
+}
+
+function readModelsOrNull(cwd: string): Models | null {
+  try {
+    return loadConfigSync(cwd).models
+  } catch {
+    return null
+  }
+}
+
+export type ProviderListEntry = ConfiguredProvider
+
+export type ProvidersSnapshot = {
+  providers: Providers
+  configuredIds: string[]
+}

--- a/src/secrets/storage.ts
+++ b/src/secrets/storage.ts
@@ -175,6 +175,74 @@ export class SecretsBackend implements AuthStorageBackend {
     }
   }
 
+  // Returns a shallow snapshot of the `providers` slice. Used by post-init CLI
+  // commands (`typeclaw provider list/remove`, `typeclaw model list`) that need
+  // to inspect what's on disk without forcing AuthStorage's env-wins flatten —
+  // we want to show users which providers are file-backed vs env-overridden,
+  // and the flatten path collapses that distinction.
+  tryReadProvidersSync(): Providers {
+    if (!existsSync(this.secretsPath)) return {}
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      return { ...this.readEnvelope().providers }
+    } finally {
+      release?.()
+    }
+  }
+
+  // Atomic provider credential write. Idempotent at the type level: callers
+  // pass the full `ProviderCredential` (api_key or oauth), and the entry is
+  // merged into `providers.<id>` verbatim — same shape the schema accepts on
+  // read. Used by `typeclaw provider add/set` to write api-key credentials
+  // without going through AuthStorage's flatten/unflatten round-trip.
+  // OAuth flows MUST continue to go through `AuthStorage.login()` so refresh
+  // tokens land in the correct shape; this method is api-key oriented.
+  writeProviderCredentialSync(providerId: string, credential: ProviderCredential): void {
+    this.ensureParentDir()
+    this.ensureFileExists()
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      const envelope = this.readEnvelope()
+      const next: SecretsFile = {
+        ...envelope,
+        $schema: envelope.$schema ?? SCHEMA_REL,
+        version: SECRETS_FILE_VERSION,
+        providers: { ...envelope.providers, [providerId]: credential },
+      }
+      this.writeEnvelopeAtomic(next)
+    } finally {
+      release?.()
+    }
+  }
+
+  // Removes `providers.<id>` from the envelope. Returns `true` when the
+  // provider was present and removed, `false` when nothing changed (idempotent
+  // on the CLI side — `provider remove fireworks` twice should not error on
+  // the second call). The file is rewritten only when something changed so
+  // canonical-shape reads pay zero cost.
+  removeProviderCredentialSync(providerId: string): boolean {
+    if (!existsSync(this.secretsPath)) return false
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      const envelope = this.readEnvelope()
+      if (!(providerId in envelope.providers)) return false
+      const { [providerId]: _removed, ...rest } = envelope.providers
+      const next: SecretsFile = {
+        ...envelope,
+        $schema: envelope.$schema ?? SCHEMA_REL,
+        version: SECRETS_FILE_VERSION,
+        providers: rest,
+      }
+      this.writeEnvelopeAtomic(next)
+      return true
+    } finally {
+      release?.()
+    }
+  }
+
   writeChannelsSync(next: Channels): void {
     this.ensureParentDir()
     this.ensureFileExists()


### PR DESCRIPTION
## Problem

Until now, the only way to add a provider or change the active model after `typeclaw init` was to hand-edit `secrets.json` and `typeclaw.json`. That works, but loses every guard the init wizard had: provider-id validation, model-ref typo catching, and the refusal to clear credentials that are still referenced by a profile.

## Solution

Two new top-level commands following the existing `channel add` pattern:

```
typeclaw provider add <id> [--key | --env | --oauth]
typeclaw provider set <id> [--key | --env | --oauth]
typeclaw provider remove <id> [--force]
typeclaw provider list

typeclaw model set <profile> <ref> [--force]
typeclaw model add <profile> <ref> [--force]
typeclaw model remove <profile>
typeclaw model list [--available]
```

### Key invariants enforced

- **`provider remove` refuses** when any model profile references the provider, naming the offending profiles in the error. `--force` bypasses.
- **`model set` refuses** when the target provider has no credentials (file or env), pointing at `typeclaw provider add <id>` as the remediation path. `--force` bypasses.
- **`model remove default` always refuses** — `default` is schema-required. The error names `model set default <ref>` as the canonical replacement.
- **`provider add` refuses to overwrite** an existing entry; `provider set` is the explicit rotate path.
- **`provider list` reports per-credential source** (file / env-only / env-overridden / oauth) so users see the env-wins resolution at a glance.

## Changes

**`src/cli/provider.ts`** (new) — citty command with `add`, `set`, `remove`, and `list` subcommands. Stays thin: prompt collection via clack, all logic delegated to the mutation module.

**`src/cli/model.ts`** (new) — citty command with `set`, `add`, `remove`, and `list` subcommands. Same pattern.

**`src/cli/index.ts`** — wires both new commands.

**`src/config/providers-mutation.ts`** (new) — pure domain mutations for `secrets.json#providers`. Owns the provider-referenced-by-model guard, the env-overridden source classification, and the refusal to overwrite via `add`. No I/O outside of the explicit `agentDir` arg.

**`src/config/models-mutation.ts`** (new) — pure domain mutations for `typeclaw.json#models`. Owns the provider-has-credentials check (resolves via the same `resolveSecret` path the session uses), the `default`-removal guard, and model-ref validation against `KNOWN_MODELS`.

**`src/secrets/storage.ts`** — adds three sync helpers to `SecretsBackend`:

- `tryReadProvidersSync` — returns the unflattened providers slice so `provider list` can distinguish env-overridden entries from file-only ones.
- `writeProviderCredentialSync` — direct targeted write that bypasses the AuthStorage full-slice rewrite for the api-key path.
- `removeProviderCredentialSync` — symmetric direct remove.

OAuth credentials still go through `createSecretsStoreForAgent().login()` so refresh tokens land in the correct shape and the upstream renewal cron stays coherent.

### Architecture notes

Following AGENTS.md §2 ("Test at the right layer"), the CLI files are UI-only (citty + clack) and the mutation modules are the primary test surface. The three sync helpers on `SecretsBackend` bypass the AuthStorage flatten path deliberately — the unflattened view is what makes `provider list`'s source classification possible without a separate file read, and direct writes avoid unnecessarily rewriting every provider credential on each `add` or `remove`.

No schema changes: `models` is already classified as `applied` in `FIELD_EFFECTS`, so model mutations pick up via `typeclaw reload` without a container restart. Secrets are read lazily per session, so credential mutations apply on the next session creation.

## Verification

```
bun run typecheck   # clean
bun run lint        # 8 pre-existing warnings (unrelated), 0 errors
bun run format      # clean
bun test            # 3367 pass, 0 fail (37 new + 3330 existing)
```

End-to-end smoke test against a hand-rolled tmp agent dir: all four refusal paths fired correctly — `provider remove` with a live model reference, `model set` against an uncredentialed provider, `model remove default`, and `provider add` on a duplicate.

## Stats

8 files changed, +1533/−0.

- `src/cli/provider.ts` (new, 404 lines)
- `src/cli/model.ts` (new, 244 lines)
- `src/config/providers-mutation.ts` (new, 250 lines)
- `src/config/providers-mutation.test.ts` (new, 186 lines — 17 tests, real tmp dirs, no mocks)
- `src/config/models-mutation.ts` (new, 200 lines)
- `src/config/models-mutation.test.ts` (new, 179 lines — 20 tests, real tmp dirs, no mocks)
- `src/secrets/storage.ts` (+68 lines — 3 sync helpers)
- `src/cli/index.ts` (+2 lines — wiring)