### PR TITLE
Render run/init fatal errors through errorLine for consistent red prefix

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -753,7 +753,7 @@ function reportHatching(event: Extract<InitStepEvent, { step: 'hatching' }>): vo
   if (event.result.ok) {
     console.log('Hatched. 🐣')
   } else {
-    console.error(`Hatching failed: ${event.result.reason}`)
+    console.error(errorLine(`Hatching failed: ${event.result.reason}`))
   }
 }
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -4,6 +4,8 @@ import { CONTAINER_PORT } from '@/container'
 import { isInitialized } from '@/init'
 import { startAgent } from '@/run'
 
+import { errorLine } from './ui'
+
 export const run = defineCommand({
   meta: {
     name: 'run',
@@ -31,7 +33,7 @@ export const run = defineCommand({
   },
   async run({ args }) {
     if (!isInitialized(process.cwd())) {
-      console.error('TypeClaw config file not found. Run `typeclaw init` first.')
+      console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first.'))
       process.exit(1)
     }
 


### PR DESCRIPTION
## Problem

Two fatal error paths in the CLI emitted bare `console.error('...')` strings — no red `✖` prefix, no visual separation from ordinary output — while every other error-bearing command already used `errorLine()`.

1. **`src/cli/run.ts`** — \"TypeClaw config file not found. Run `typeclaw init` first.\" printed as plain text before `process.exit(1)`.
2. **`src/cli/init.ts`** — \"Hatching failed: {reason}\" printed as plain text inside `reportHatching` on a hatching failure.

Both are terminal, user-facing errors. The inconsistency was noticed when a user asked why error messages weren't red — they were for most commands but not these two.

## Solution

Route both through the existing `errorLine(reason)` helper in `src/cli/ui.ts`, which wraps the message with a `c.red('✖')` prefix. `c.red()` is already `NO_COLOR` / `FORCE_COLOR` / TTY-aware, so piped output stays plain text. No new infrastructure needed.

## Changes

- **`src/cli/run.ts`** — import `errorLine` from `./ui`; wrap the config-not-found message.
- **`src/cli/init.ts`** — wrap the hatching-failure message in `reportHatching`.

3 insertions, 2 deletions across 2 files.

## Testing

No new test files. `errorLine` itself is fully covered by `src/cli/ui.test.ts` (red `✖` under `FORCE_COLOR`, plain `✖ x` under `NO_COLOR`). Adding tests for the two call sites would only restate the literal — per AGENTS.md §6 these are two-line wiring changes that don't warrant new test files.

Pre-commit checks all pass:

```
bun run typecheck   # clean
bun run lint        # pre-existing warnings only, 0 in touched files
bun run format      # clean
bun test            # 3382/3382 pass
```