### PR TITLE
Wait for connected before sending claim_start in role-claim client

### DIFF
--- a/src/role-claim/client.test.ts
+++ b/src/role-claim/client.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import type { Server } from 'bun'
+
+import type { ClaimCompletedPayload, ClaimStartedPayload, ClientMessage, ServerMessage } from '@/shared'
+
+import { runClaimSession } from './client'
+
+type RaceServer = Server<{ ready: boolean }>
+let server: RaceServer | null = null
+
+afterEach(() => {
+  server?.stop(true)
+  server = null
+})
+
+type ServeOptions = {
+  openDelayMs: number
+  emitConnected?: boolean
+}
+
+function serveRaceProneClaim(opts: ServeOptions): RaceServer {
+  return Bun.serve<{ ready: boolean }>({
+    port: 0,
+    fetch(req, s) {
+      const data = { ready: false }
+      if (s.upgrade(req, { data })) return
+      return new Response('typeclaw agent', { status: 200 })
+    },
+    websocket: {
+      async open(ws) {
+        await new Promise((r) => setTimeout(r, opts.openDelayMs))
+        ws.data.ready = true
+        if (opts.emitConnected !== false) {
+          const msg: ServerMessage = { type: 'connected', sessionId: 'sid-test' }
+          ws.send(JSON.stringify(msg))
+        }
+      },
+      message(ws, raw) {
+        const parsed = JSON.parse(String(raw)) as ClientMessage
+        if (!ws.data.ready) return
+        handleClientMessage(ws, parsed)
+      },
+    },
+  })
+}
+
+function handleClientMessage(
+  ws: Parameters<NonNullable<Parameters<typeof Bun.serve>[0]['websocket']>['message']>[0] & {
+    data: { ready: boolean }
+  },
+  msg: ClientMessage,
+): void {
+  if (msg.type !== 'claim_start') return
+  const startedPayload: ClaimStartedPayload = {
+    code: msg.code,
+    role: msg.role,
+    expiresAt: Date.now() + msg.ttlMs,
+  }
+  ws.send(JSON.stringify({ type: 'claim_started', payload: startedPayload } satisfies ServerMessage))
+  const completedPayload: ClaimCompletedPayload = {
+    code: msg.code,
+    role: msg.role,
+    matchRule: 'discord:test',
+    adapter: 'discord-bot',
+    authorId: 'U_TEST',
+  }
+  ws.send(JSON.stringify({ type: 'claim_completed', payload: completedPayload } satisfies ServerMessage))
+}
+
+describe('runClaimSession', () => {
+  test("doesn't race with the server's slow open path", async () => {
+    // given: a server whose `open` takes 100ms (modeling createSession during
+    // hatching). Pre-`connected` messages are dropped, mirroring production.
+    server = serveRaceProneClaim({ openDelayMs: 100 })
+    const port = server.port
+
+    // when: client runs the full claim session
+    let onStartedFired = false
+    const result = await runClaimSession({
+      url: `ws://127.0.0.1:${port}`,
+      role: 'owner',
+      ttlMs: 500,
+      onStarted: () => {
+        onStartedFired = true
+      },
+    })
+
+    expect(onStartedFired).toBe(true)
+    expect(result.kind).toBe('completed')
+  })
+
+  test('times out the connect handshake if connected never arrives', async () => {
+    // given: a server that accepts the upgrade but never sends `connected`
+    server = serveRaceProneClaim({ openDelayMs: 0, emitConnected: false })
+    const port = server.port
+
+    // when: client runs with a short connect timeout
+    // then: the session rejects with a clear error rather than hanging on ttl
+    await expect(
+      runClaimSession({
+        url: `ws://127.0.0.1:${port}`,
+        role: 'owner',
+        ttlMs: 60_000,
+        connectTimeoutMs: 200,
+      }),
+    ).rejects.toThrow(/connected/i)
+  })
+})

--- a/src/role-claim/client.ts
+++ b/src/role-claim/client.ts
@@ -33,6 +33,7 @@ export async function runClaimSession(opts: ClaimSessionOptions): Promise<ClaimS
   const ws = new WebSocket(opts.url)
   const displayUrl = redactUrl(opts.url)
   await waitForOpen(ws, displayUrl, connectTimeoutMs)
+  await waitForConnected(ws, displayUrl, connectTimeoutMs)
 
   try {
     const request: ClientMessage = {
@@ -81,6 +82,51 @@ async function waitForOpen(ws: WebSocket, displayUrl: string, timeoutMs: number)
     }
     ws.addEventListener('open', onOpen, { once: true })
     ws.addEventListener('error', onError, { once: true })
+    ws.addEventListener('close', onClose, { once: true })
+  })
+}
+
+// The server's WS `open` handler is async (it awaits createSession) and only
+// registers per-ws state and sends `connected` after that resolves. Bun
+// delivers any client messages received before `open` completes, but the
+// server's `claim_start` handler silently drops messages when state is null.
+// Waiting here mirrors what the TUI client does (see src/tui/index.ts) and
+// fixes the hatching-time hang where the spinner stayed on "Generating your
+// claim code..." until the ttl expired.
+async function waitForConnected(ws: WebSocket, displayUrl: string, timeoutMs: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup()
+      ws.close()
+      reject(new Error(`timed out waiting for connected message from ${displayUrl} after ${timeoutMs}ms`))
+    }, timeoutMs)
+    const onMessage = (event: MessageEvent): void => {
+      let msg: ServerMessage
+      try {
+        msg = JSON.parse(String(event.data)) as ServerMessage
+      } catch {
+        return
+      }
+      if (msg.type === 'connected') {
+        cleanup()
+        resolve()
+        return
+      }
+      if (msg.type === 'error') {
+        cleanup()
+        reject(new Error(`server rejected connection to ${displayUrl}: ${msg.message}`))
+      }
+    }
+    const onClose = () => {
+      cleanup()
+      reject(new Error(`connection to ${displayUrl} closed before the session was ready`))
+    }
+    const cleanup = () => {
+      clearTimeout(timer)
+      ws.removeEventListener('message', onMessage)
+      ws.removeEventListener('close', onClose)
+    }
+    ws.addEventListener('message', onMessage)
     ws.addEventListener('close', onClose, { once: true })
   })
 }


### PR DESCRIPTION
## Summary

The owner-role claim during \`typeclaw init\` hatching could hang on the spinner \`Generating your claim code...\`, never advancing to the \"Code ready\" step where the user is told to DM the code to the bot.

## Root cause

The server's WS \`open\` handler (\`src/server/index.ts:138\`) is async — it \`await\`s \`createSession()\` and only registers per-ws state and sends \`{ type: 'connected' }\` after that resolves. Bun delivers any client messages that arrive before \`open\` completes, but the server's \`claim_start\` handler reads \`sessionStates.get(ws)\` and silently \`return\`s when state is \`null\` (\`src/server/index.ts:231\`).

\`runClaimSession\` opened the WS and sent \`claim_start\` the instant \`open\` fired, racing the slow open path. When the race lost, the message was dropped — the client never received \`claim_started\` nor \`claim_error\`, so the spinner stayed stuck until the ~10m+5s ttl timeout.

The TUI already handles this by waiting for the \`connected\` message after the WS opens (\`src/tui/index.ts:241\` \`waitForConnected\`). The role-claim client didn't.

## Fix

\`src/role-claim/client.ts\`: after \`waitForOpen\` resolves, also await a \`connected\` (or \`error\`) message from the server before sending \`claim_start\`. Uses \`connectTimeoutMs\` (default 30s) as the bound so a server that never sends \`connected\` surfaces a clear error instead of hanging on the ttl.

## Tests

New \`src/role-claim/client.test.ts\`:
- **\`doesn't race with the server's slow open path\`** — race-prone fake server with a 100ms \`open\` delay and production-style \"drop until ready\" message handling. Without the fix this resolves \`kind: 'timeout'\` after ttl+5s; with the fix the claim completes immediately once \`connected\` arrives.
- **\`times out the connect handshake if connected never arrives\`** — server upgrades but never emits \`connected\`. Without the fix the call hangs until ttl; with the fix it rejects within \`connectTimeoutMs\`.

Mutation check: both tests fail without the client.ts change. Full suite green (3428 pass).

## Pre-commit

- \`bun run typecheck\` ✅
- \`bun run lint\` ✅ (no new warnings)
- \`bun run format:check\` ✅
- \`bun test\` ✅ (3428 pass)