### PR TITLE
Make ESC on the first init prompt a no-op instead of aborting

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -152,20 +152,25 @@ describe('collectWizardInputs back-aware flow', () => {
       'pick-channel',
       'channel-flow',
     ])
-    expect(result).not.toBeNull()
-    expect(result!.model).toBe(fireworksModel)
-    expect(result!.llmAuth).toEqual({ kind: 'api-key', apiKey: 'fw_test' })
-    expect(result!.channelSecrets).toEqual({})
+    expect(result.model).toBe(fireworksModel)
+    expect(result.llmAuth).toEqual({ kind: 'api-key', apiKey: 'fw_test' })
+    expect(result.channelSecrets).toEqual({})
   })
 
-  test('back from pick-provider aborts (returns null)', async () => {
+  test('back from pick-provider is a no-op that re-asks the same prompt', async () => {
+    let providerCalls = 0
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'back' }),
+      pickProvider: async () => {
+        providerCalls += 1
+        if (providerCalls < 3) return { kind: 'back' }
+        return { kind: 'value', value: 'fireworks' as KnownProviderId }
+      },
     })
 
     const result = await collectWizardInputs('/agent', prompts)
 
-    expect(result).toBeNull()
+    expect(providerCalls).toBe(3)
+    expect(result.model).toBe(fireworksModel)
   })
 
   test('back from pick-model returns to pick-provider, then advances', async () => {
@@ -186,10 +191,9 @@ describe('collectWizardInputs back-aware flow', () => {
       },
     })
 
-    const result = await collectWizardInputs('/agent', prompts)
+    await collectWizardInputs('/agent', prompts)
 
     expect(calls).toEqual(['pick-provider', 'pick-model', 'pick-provider', 'pick-model'])
-    expect(result).not.toBeNull()
   })
 
   test('back from pick-channel returns to enter-api-key when api-key was chosen', async () => {
@@ -389,6 +393,6 @@ describe('collectWizardInputs back-aware flow', () => {
     const result = await collectWizardInputs('/agent', prompts)
 
     expect(calls).toEqual(['pick-channel', 'channel-flow', 'pick-channel', 'channel-flow'])
-    expect(result!.channelSecrets).toEqual({ discordBotToken: 'tok' })
+    expect(result.channelSecrets).toEqual({ discordBotToken: 'tok' })
   })
 })

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -30,9 +30,12 @@ import { c, done, errorLine } from './ui'
 // aliases both to the same "cancel" action — there's no way to tell them
 // apart through @clack/prompts). The wizard treats every cancel as "go
 // back to the previous step": each step that runs an interactive prompt
-// either advances with a value or rewinds. Rewinding past the first
-// interactive step aborts the init cleanly. Users who want to abort
-// mid-wizard can hit ESC repeatedly until they're back to the start.
+// either advances with a value or rewinds. There is no "go back" target
+// on the very first step (pick-provider), so a `back` there is a no-op
+// that re-displays the same prompt rather than aborting. Users who want
+// to bail out of the wizard kill the process from outside (close the
+// terminal, send SIGTERM); inside an active clack prompt Ctrl+C is also
+// aliased to cancel, so there is no in-wizard abort hotkey.
 export type StepResult<T> = { kind: 'value'; value: T } | { kind: 'back' }
 const back = <T>(): StepResult<T> => ({ kind: 'back' })
 const value = <T>(v: T): StepResult<T> => ({ kind: 'value', value: v })
@@ -75,11 +78,6 @@ export const init = defineCommand({
     log.info('Press ESC at any prompt to go back to the previous step.')
 
     const collected = await collectWizardInputs(cwd, defaultWizardPrompts)
-    if (collected === null) {
-      cancel('Aborted.')
-      process.exit(0)
-    }
-
     const { model, llmAuth, channelSecrets } = collected
     const { discordBotToken, slackBotToken, slackAppToken, telegramBotToken, kakaotalkEmail, kakaotalkPassword } =
       channelSecrets
@@ -220,7 +218,7 @@ export const defaultWizardPrompts: WizardPrompts = {
   }),
 }
 
-export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): Promise<CollectedInputs | null> {
+export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): Promise<CollectedInputs> {
   const catalog = await prompts.loadCatalog()
   const state: WizardState = { catalog }
   let step: StepId = 'pick-provider'
@@ -229,7 +227,9 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
     switch (step) {
       case 'pick-provider': {
         const result = await prompts.pickProvider(catalog.options, state.providerId)
-        if (result.kind === 'back') return null
+        if (result.kind === 'back') {
+          break
+        }
         if (state.providerId !== result.value) {
           state.model = undefined
           state.reuseExisting = undefined


### PR DESCRIPTION
## Problem

PR #192 added a back-aware step machine to `typeclaw init` so ESC walks back one step instead of aborting. The on-screen hint reads "Press ESC at any prompt to go back to the previous step."

On the very first step (`pick-provider`) there is no previous step to rewind to. The original code handled `back` here by returning `null` from `collectWizardInputs`, which caused `run()` to call `cancel('Aborted.')` and exit — silently discarding the user's intent to stay in the wizard. The behaviour directly contradicted the hint the wizard displayed.

## Fix

Treat a `back` result on `pick-provider` as a no-op: `break` out of its `switch` arm so the outer `while (true)` loop re-enters the same step. The wizard now has no in-flow abort hotkey. Ctrl+C is aliased to cancel by clack just like ESC, so adding a Ctrl+C-aborts path would reintroduce the same problem. Users who want to bail kill the process from outside.

The `collectWizardInputs` return type changes from `Promise<CollectedInputs | null>` to `Promise<CollectedInputs>` to encode the new "wizard always completes" contract in TypeScript. The dead `if (collected === null) { cancel('Aborted.'); process.exit(0) }` branch in `run()` is removed, along with a handful of `result!` non-null assertions and `expect(result).not.toBeNull()` checks in the tests that were only needed to satisfy the old nullable type.

## Changes

**`src/cli/init.ts`**
- Doc comment at the top of the ESC/Ctrl+C aliasing section updated to describe the new no-op-on-first-step semantics.
- `pick-provider`'s `back` arm changed from `return null` to `break`.
- `collectWizardInputs` return type narrowed from `Promise<CollectedInputs | null>` to `Promise<CollectedInputs>`.
- Dead null-result branch removed from `run()`.

**`src/cli/init.test.ts`**
- `'back from pick-provider aborts (returns null)'` renamed and rewritten: `pickProvider` returns `back` for the first two calls, then a real provider on the third. Asserts `pickProvider` was called 3 times and the wizard completes normally.
- Mutation-verified: replacing the `break` with `throw new Error('should not abort')` makes the test fail with the expected message.
- Remaining `result!` non-null assertions and `expect(result).not.toBeNull()` checks removed where the type no longer requires them.

## Verification

```
bun run typecheck   # clean
bun run lint        # 8 pre-existing warnings (none in changed files), 0 errors
bun run format      # clean
bun test            # 3426 pass, 0 fail
```

## Stats

2 files changed, +24/−20 (`src/cli/init.ts`, `src/cli/init.test.ts`).