### PR TITLE
Prompt for a vision-capable model when the init default is text-only

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -60,6 +60,7 @@ describe('collectWizardInputs back-aware flow', () => {
     contextWindow: 256000,
     reasoning: true,
     curated: true,
+    supportsVision: true,
   }
   const openaiModel: ModelOption = {
     providerId: 'openai',
@@ -70,6 +71,7 @@ describe('collectWizardInputs back-aware flow', () => {
     contextWindow: 128000,
     reasoning: false,
     curated: true,
+    supportsVision: true,
   }
   const codexModel: ModelOption = {
     providerId: 'openai-codex',
@@ -80,6 +82,18 @@ describe('collectWizardInputs back-aware flow', () => {
     contextWindow: 128000,
     reasoning: true,
     curated: true,
+    supportsVision: true,
+  }
+  const zaiTextOnlyModel: ModelOption = {
+    providerId: 'zai',
+    providerName: 'Z.AI',
+    modelId: 'glm-4.6',
+    modelName: 'GLM-4.6',
+    ref: 'zai/glm-4.6',
+    contextWindow: 200000,
+    reasoning: true,
+    curated: true,
+    supportsVision: false,
   }
 
   function makeRecorder(): { steps: string[]; record: (name: string) => void } {
@@ -96,6 +110,8 @@ describe('collectWizardInputs back-aware flow', () => {
       askReuseExistingKey: async () => ({ kind: 'value', value: 'prompt' }),
       pickAuthMethod: async () => ({ kind: 'value', value: 'api-key' }),
       askApiKey: async () => ({ kind: 'value', value: 'sk_test' }),
+      pickVisionProvider: async () => ({ kind: 'value', value: 'skip' }),
+      pickVisionModel: async () => ({ kind: 'value', value: openaiModel }),
       pickChannel: async () => ({ kind: 'value', value: 'none' }),
       runChannelFlow: async () => ({ kind: 'value', value: {} }),
       buildOAuthAuth: () => ({ kind: 'oauth', runLogin: async () => ({ ok: true }) }) as LLMAuth,
@@ -370,6 +386,159 @@ describe('collectWizardInputs back-aware flow', () => {
 
     expect(catalogLoads).toBe(1)
     expect(providerCallCount).toBe(2)
+  })
+
+  test('text-only default model: vision picker runs after auth, before pick-channel', async () => {
+    const calls: string[] = []
+    const prompts = makePrompts({
+      loadCatalog: async () => ({ options: [zaiTextOnlyModel, openaiModel], source: 'curated' }),
+      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
+      askApiKey: async () => {
+        calls.push('enter-api-key')
+        return { kind: 'value', value: 'zai_key' }
+      },
+      pickVisionProvider: async (options) => {
+        calls.push('pick-vision-provider')
+        // Vision picker MUST be fed only vision-capable models.
+        expect(options.every((o) => o.supportsVision)).toBe(true)
+        expect(options.some((o) => o.ref === zaiTextOnlyModel.ref)).toBe(false)
+        return { kind: 'value', value: 'openai' as KnownProviderId }
+      },
+      pickVisionModel: async () => {
+        calls.push('pick-vision-model')
+        return { kind: 'value', value: openaiModel }
+      },
+      pickAuthMethod: async (_provider, _initial) => {
+        calls.push('pick-auth-method')
+        return { kind: 'value', value: 'api-key' }
+      },
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        return { kind: 'value', value: 'none' }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual([
+      'pick-auth-method',
+      'enter-api-key',
+      'pick-vision-provider',
+      'pick-vision-model',
+      'pick-auth-method',
+      'enter-api-key',
+      'pick-channel',
+    ])
+    expect(result!.vision?.model.ref).toBe(openaiModel.ref)
+    expect(result!.vision?.llmAuth).toEqual({ kind: 'api-key', apiKey: 'zai_key' })
+  })
+
+  test('vision-capable default model: vision picker is skipped entirely', async () => {
+    const calls: string[] = []
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'value', value: 'fireworks' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: fireworksModel }),
+      pickVisionProvider: async () => {
+        calls.push('pick-vision-provider')
+        return { kind: 'value', value: 'skip' }
+      },
+      pickVisionModel: async () => {
+        calls.push('pick-vision-model')
+        return { kind: 'value', value: openaiModel }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual([])
+    expect(result!.vision).toBeUndefined()
+  })
+
+  test('vision skip returns no vision profile', async () => {
+    const prompts = makePrompts({
+      loadCatalog: async () => ({ options: [zaiTextOnlyModel, openaiModel], source: 'curated' }),
+      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
+      pickVisionProvider: async () => ({ kind: 'value', value: 'skip' }),
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(result!.vision).toBeUndefined()
+  })
+
+  test('vision provider matches default provider: reuses default credentials, no auth prompt', async () => {
+    const calls: string[] = []
+    const visionOpenAI: ModelOption = { ...openaiModel, ref: 'openai/gpt-5.4', modelId: 'gpt-5.4' }
+    const prompts = makePrompts({
+      loadCatalog: async () => ({ options: [zaiTextOnlyModel, visionOpenAI], source: 'curated' }),
+      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
+      askApiKey: async () => {
+        calls.push('enter-api-key')
+        return { kind: 'value', value: 'zai_key' }
+      },
+      pickVisionProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickVisionModel: async () => ({ kind: 'value', value: { ...zaiTextOnlyModel, supportsVision: true } }),
+      pickAuthMethod: async () => {
+        calls.push('pick-auth-method')
+        return { kind: 'value', value: 'api-key' }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual(['pick-auth-method', 'enter-api-key'])
+    expect(result!.vision?.llmAuth).toEqual({ kind: 'api-key', apiKey: 'zai_key' })
+  })
+
+  test('vision provider with existing key in secrets.json: reuses without re-prompting', async () => {
+    const calls: string[] = []
+    const prompts = makePrompts({
+      loadCatalog: async () => ({ options: [zaiTextOnlyModel, openaiModel], source: 'curated' }),
+      readExistingApiKey: async (_cwd, providerId) => (providerId === 'openai' ? 'sk_existing_openai' : null),
+      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
+      askApiKey: async () => ({ kind: 'value', value: 'zai_key' }),
+      pickVisionProvider: async () => ({ kind: 'value', value: 'openai' as KnownProviderId }),
+      pickVisionModel: async () => ({ kind: 'value', value: openaiModel }),
+      pickAuthMethod: async () => {
+        calls.push('pick-auth-method')
+        return { kind: 'value', value: 'api-key' }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual(['pick-auth-method'])
+    expect(result!.vision?.llmAuth).toEqual({ kind: 'api-key', apiKey: 'sk_existing_openai' })
+  })
+
+  test('back from pick-vision-provider returns to the auth-finalizing step', async () => {
+    const calls: string[] = []
+    let backed = false
+    const prompts = makePrompts({
+      loadCatalog: async () => ({ options: [zaiTextOnlyModel, openaiModel], source: 'curated' }),
+      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
+      askApiKey: async () => {
+        calls.push('enter-api-key')
+        return { kind: 'value', value: 'zai_key' }
+      },
+      pickVisionProvider: async () => {
+        calls.push('pick-vision-provider')
+        if (!backed) {
+          backed = true
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: 'skip' }
+      },
+    })
+
+    await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual(['enter-api-key', 'pick-vision-provider', 'enter-api-key', 'pick-vision-provider'])
   })
 
   test('back from channel-flow returns to pick-channel', async () => {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -78,7 +78,7 @@ export const init = defineCommand({
     log.info('Press ESC at any prompt to go back to the previous step.')
 
     const collected = await collectWizardInputs(cwd, defaultWizardPrompts)
-    const { model, llmAuth, channelSecrets } = collected
+    const { model, llmAuth, vision, channelSecrets } = collected
     const { discordBotToken, slackBotToken, slackAppToken, telegramBotToken, kakaotalkEmail, kakaotalkPassword } =
       channelSecrets
 
@@ -94,6 +94,7 @@ export const init = defineCommand({
         cwd,
         llmAuth,
         model: model.ref,
+        ...(vision !== undefined ? { visionModel: vision.model.ref, visionAuth: vision.llmAuth } : {}),
         cliEntry: process.argv[1],
         ...(discordBotToken !== undefined ? { discordBotToken } : {}),
         ...(slackBotToken !== undefined ? { slackBotToken, slackAppToken } : {}),
@@ -151,6 +152,11 @@ interface WizardState {
   reuseExisting?: boolean
   authMethod?: 'api-key' | 'oauth'
   llmAuth?: LLMAuth
+  visionProviderId?: KnownProviderId
+  visionModel?: ModelOption
+  visionReuseExisting?: boolean
+  visionAuthMethod?: 'api-key' | 'oauth'
+  visionLlmAuth?: LLMAuth
   channelChoice?: ChannelChoice
 }
 
@@ -159,6 +165,14 @@ type ChannelChoice = 'slack' | 'discord' | 'telegram' | 'kakaotalk' | 'none'
 interface CollectedInputs {
   model: ModelOption
   llmAuth: LLMAuth
+  // Set only when the default model is text-only and the user picked a
+  // vision-capable model for the `vision` profile. `llmAuth` is reused from
+  // the default provider's credentials when the vision provider matches, so
+  // tests can still mint a single auth object and have it cover both.
+  vision?: {
+    model: ModelOption
+    llmAuth: LLMAuth
+  }
   channelSecrets: {
     discordBotToken?: string
     slackBotToken?: string
@@ -175,6 +189,10 @@ type StepId =
   | 'reuse-existing-key'
   | 'pick-auth-method'
   | 'enter-api-key'
+  | 'pick-vision-provider'
+  | 'pick-vision-model'
+  | 'pick-vision-auth-method'
+  | 'enter-vision-api-key'
   | 'pick-channel'
   | 'channel-flow'
 
@@ -197,6 +215,15 @@ export interface WizardPrompts {
     initial: 'api-key' | 'oauth' | undefined,
   ) => Promise<StepResult<'api-key' | 'oauth'>>
   askApiKey: (provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]) => Promise<StepResult<string>>
+  pickVisionProvider: (
+    options: ModelOption[],
+    initial: KnownProviderId | undefined,
+  ) => Promise<StepResult<KnownProviderId | 'skip'>>
+  pickVisionModel: (
+    options: ModelOption[],
+    providerId: KnownProviderId,
+    initial: KnownModelRef | undefined,
+  ) => Promise<StepResult<ModelOption>>
   pickChannel: (initial: ChannelChoice | undefined) => Promise<StepResult<ChannelChoice>>
   runChannelFlow: (choice: ChannelChoice) => Promise<StepResult<CollectedInputs['channelSecrets']>>
   buildOAuthAuth: (provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]) => LLMAuth
@@ -210,6 +237,8 @@ export const defaultWizardPrompts: WizardPrompts = {
   askReuseExistingKey,
   pickAuthMethod,
   askApiKey,
+  pickVisionProvider,
+  pickVisionModel,
   pickChannel,
   runChannelFlow,
   buildOAuthAuth: (provider) => ({
@@ -264,7 +293,7 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
           log.info(`Using existing ${provider.name} API key from secrets.json.`)
           state.llmAuth = { kind: 'api-key', apiKey: existingApiKey }
           state.reuseExisting = true
-          step = 'pick-channel'
+          step = stepAfterDefaultAuth(state)
           break
         }
         state.reuseExisting = false
@@ -283,7 +312,7 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
         state.authMethod = result.value
         if (result.value === 'oauth') {
           state.llmAuth = prompts.buildOAuthAuth(provider)
-          step = 'pick-channel'
+          step = stepAfterDefaultAuth(state)
         } else {
           step = 'enter-api-key'
         }
@@ -298,6 +327,91 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
           break
         }
         state.llmAuth = { kind: 'api-key', apiKey: result.value }
+        step = stepAfterDefaultAuth(state)
+        break
+      }
+
+      case 'pick-vision-provider': {
+        const visionOptions = catalog.options.filter((o) => o.supportsVision)
+        const result = await prompts.pickVisionProvider(visionOptions, state.visionProviderId)
+        if (result.kind === 'back') {
+          step = stepBeforeVision(state)
+          break
+        }
+        if (result.value === 'skip') {
+          state.visionProviderId = undefined
+          state.visionModel = undefined
+          state.visionLlmAuth = undefined
+          state.visionReuseExisting = undefined
+          state.visionAuthMethod = undefined
+          step = 'pick-channel'
+          break
+        }
+        if (state.visionProviderId !== result.value) {
+          state.visionModel = undefined
+          state.visionReuseExisting = undefined
+          state.visionAuthMethod = undefined
+          state.visionLlmAuth = undefined
+        }
+        state.visionProviderId = result.value
+        step = 'pick-vision-model'
+        break
+      }
+
+      case 'pick-vision-model': {
+        const visionOptions = catalog.options.filter((o) => o.supportsVision)
+        const result = await prompts.pickVisionModel(visionOptions, state.visionProviderId!, state.visionModel?.ref)
+        if (result.kind === 'back') {
+          step = 'pick-vision-provider'
+          break
+        }
+        state.visionModel = result.value
+        if (state.visionProviderId === state.providerId) {
+          log.info(`Using ${KNOWN_PROVIDERS[state.providerId!].name} credentials for the vision profile.`)
+          state.visionLlmAuth = state.llmAuth
+          state.visionReuseExisting = true
+          step = 'pick-channel'
+          break
+        }
+        const existingVisionKey = await prompts.readExistingApiKey(cwd, state.visionProviderId!)
+        if (existingVisionKey !== null) {
+          log.info(`Using existing ${KNOWN_PROVIDERS[state.visionProviderId!].name} API key from secrets.json.`)
+          state.visionLlmAuth = { kind: 'api-key', apiKey: existingVisionKey }
+          state.visionReuseExisting = true
+          step = 'pick-channel'
+          break
+        }
+        state.visionReuseExisting = false
+        state.visionLlmAuth = undefined
+        step = 'pick-vision-auth-method'
+        break
+      }
+
+      case 'pick-vision-auth-method': {
+        const provider = KNOWN_PROVIDERS[state.visionProviderId!]
+        const result = await prompts.pickAuthMethod(provider, state.visionAuthMethod)
+        if (result.kind === 'back') {
+          step = 'pick-vision-model'
+          break
+        }
+        state.visionAuthMethod = result.value
+        if (result.value === 'oauth') {
+          state.visionLlmAuth = prompts.buildOAuthAuth(provider)
+          step = 'pick-channel'
+        } else {
+          step = 'enter-vision-api-key'
+        }
+        break
+      }
+
+      case 'enter-vision-api-key': {
+        const provider = KNOWN_PROVIDERS[state.visionProviderId!]
+        const result = await prompts.askApiKey(provider)
+        if (result.kind === 'back') {
+          step = 'pick-vision-auth-method'
+          break
+        }
+        state.visionLlmAuth = { kind: 'api-key', apiKey: result.value }
         step = 'pick-channel'
         break
       }
@@ -305,13 +419,7 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
       case 'pick-channel': {
         const result = await prompts.pickChannel(state.channelChoice)
         if (result.kind === 'back') {
-          if (state.reuseExisting === true) {
-            step = 'reuse-existing-key'
-          } else if (state.authMethod === 'api-key') {
-            step = 'enter-api-key'
-          } else {
-            step = 'pick-auth-method'
-          }
+          step = stepBeforePickChannel(state)
           break
         }
         state.channelChoice = result.value
@@ -328,11 +436,36 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
         return {
           model: state.model!,
           llmAuth: state.llmAuth!,
+          ...(state.visionModel !== undefined && state.visionLlmAuth !== undefined
+            ? { vision: { model: state.visionModel, llmAuth: state.visionLlmAuth } }
+            : {}),
           channelSecrets: result.value,
         }
       }
     }
   }
+}
+
+function stepAfterDefaultAuth(state: WizardState): StepId {
+  return state.model?.supportsVision === false ? 'pick-vision-provider' : 'pick-channel'
+}
+
+function stepBeforeVision(state: WizardState): StepId {
+  if (state.reuseExisting === true) return 'reuse-existing-key'
+  if (state.authMethod === 'api-key') return 'enter-api-key'
+  return 'pick-auth-method'
+}
+
+function stepBeforePickChannel(state: WizardState): StepId {
+  if (state.visionModel !== undefined) {
+    if (state.visionProviderId === state.providerId) return 'pick-vision-model'
+    if (state.visionReuseExisting === true) return 'pick-vision-model'
+    if (state.visionAuthMethod === 'api-key') return 'enter-vision-api-key'
+    if (state.visionAuthMethod === 'oauth') return 'pick-vision-auth-method'
+    return 'pick-vision-model'
+  }
+  if (state.model?.supportsVision === false) return 'pick-vision-provider'
+  return stepBeforeVision(state)
 }
 
 async function loadCatalog(): Promise<NonNullable<WizardState['catalog']>> {
@@ -416,6 +549,52 @@ async function pickAuthMethod(
   }
   // Single-method providers: no prompt to back out of, so always advance.
   return value(supportsOAuth ? 'oauth' : 'api-key')
+}
+
+async function pickVisionProvider(
+  options: ModelOption[],
+  initial: KnownProviderId | undefined,
+): Promise<StepResult<KnownProviderId | 'skip'>> {
+  const providers = uniqueProviders(options)
+  if (providers.length === 0) {
+    log.warn('No vision-capable models available; skipping vision profile.')
+    return value('skip')
+  }
+  const choice = await select<KnownProviderId | 'skip'>({
+    message: 'Your model is text-only. Pick a provider for the `vision` profile (used for image input)',
+    options: [
+      ...providers.map((id) => ({
+        value: id as KnownProviderId | 'skip',
+        label: KNOWN_PROVIDERS[id].name,
+        hint: providerAuthHint(id),
+      })),
+      { value: 'skip', label: 'Skip — no vision support', hint: 'add later with `typeclaw model set vision <ref>`' },
+    ],
+    initialValue: initial ?? providers[0],
+  })
+  if (isCancel(choice)) return back()
+  return value(choice)
+}
+
+async function pickVisionModel(
+  options: ModelOption[],
+  providerId: KnownProviderId,
+  initial: KnownModelRef | undefined,
+): Promise<StepResult<ModelOption>> {
+  const candidates = options.filter((o) => o.providerId === providerId)
+  const choice = await select<KnownModelRef>({
+    message: `Pick a vision-capable ${KNOWN_PROVIDERS[providerId].name} model`,
+    options: candidates.map((o) => ({
+      value: o.ref,
+      label: o.modelName,
+      hint: formatModelHint(o),
+    })),
+    initialValue: initial ?? candidates[0]?.ref,
+  })
+  if (isCancel(choice)) return back()
+  const picked = candidates.find((o) => o.ref === choice)
+  if (!picked) throw new Error(`Internal error: picked vision model ${choice} not in candidates`)
+  return value(picked)
 }
 
 async function askApiKey(provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]): Promise<StepResult<string>> {

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -724,6 +724,15 @@ describe('scaffold', () => {
     })
   })
 
+  test('writes models.vision when visionModel is passed alongside the default model', async () => {
+    await scaffold(root, { model: 'zai/glm-4.6', visionModel: 'openai/gpt-5.4-nano' })
+
+    const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
+      models: Record<string, string>
+    }
+    expect(cfg.models).toEqual({ default: 'zai/glm-4.6', vision: 'openai/gpt-5.4-nano' })
+  })
+
   test('omits every field whose default is already provided by configSchema or a bundled plugin', async () => {
     await scaffold(root)
 
@@ -1208,6 +1217,33 @@ describe('writeSecrets', () => {
     expect((await readSecrets(root)).providers?.openai).toEqual({
       type: 'api_key',
       key: { value: 'openai-default-key' },
+    })
+  })
+
+  test('writes a second provider API key when vision profile uses a different provider', async () => {
+    await writeSecrets(root, {
+      apiKey: 'zai_key',
+      model: 'zai/glm-4.6',
+      visionModel: 'openai/gpt-5.4-nano',
+      visionApiKey: 'openai_vision_key',
+    })
+
+    const providers = (await readSecrets(root)).providers
+    expect(providers?.zai).toEqual({ type: 'api_key', key: { value: 'zai_key' } })
+    expect(providers?.openai).toEqual({ type: 'api_key', key: { value: 'openai_vision_key' } })
+  })
+
+  test('does NOT write a second provider key when vision provider matches the default provider', async () => {
+    await writeSecrets(root, {
+      apiKey: 'openai_key',
+      model: 'openai/gpt-5.4-nano',
+      visionModel: 'openai/gpt-5.4',
+      visionApiKey: 'should_not_overwrite',
+    })
+
+    expect((await readSecrets(root)).providers?.openai).toEqual({
+      type: 'api_key',
+      key: { value: 'openai_key' },
     })
   })
 

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -109,6 +109,13 @@ export type InitOptions = {
   // defaults to the api-key path with `apiKey` (legacy field, still
   // supported for backwards compat with the old `runInit` signature).
   llmAuth?: LLMAuth
+  // Optional second model + auth, written as `models.vision` when the
+  // default model is text-only. Auth is reused from the default path
+  // when both refer to the same provider; the wizard enforces this
+  // pairing rule, so by the time we get here `visionAuth` is either
+  // (a) absent, or (b) the right auth for `visionModel`'s provider.
+  visionModel?: KnownModelRef
+  visionAuth?: LLMAuth
   apiKey?: string
   discordBotToken?: string
   slackBotToken?: string
@@ -133,6 +140,8 @@ export async function runInit({
   apiKey,
   llmAuth,
   model = DEFAULT_MODEL_REF,
+  visionModel,
+  visionAuth,
   discordBotToken,
   slackBotToken,
   slackAppToken,
@@ -180,12 +189,32 @@ export async function runInit({
     }
   }
 
+  // When the vision profile uses a different provider than the default, its
+  // OAuth login runs here too, before any file write. Same-provider vision
+  // reuses the default auth (no separate login). API-key vision auth is
+  // captured in memory and persisted by writeSecrets() below.
+  if (
+    visionAuth !== undefined &&
+    visionAuth.kind === 'oauth' &&
+    visionModel !== undefined &&
+    providerForModelRef(visionModel) !== providerForModelRef(model)
+  ) {
+    emit({ step: 'oauth-login', phase: 'start' })
+    await mkdir(cwd, { recursive: true })
+    const result = await visionAuth.runLogin({ cwd, model: visionModel })
+    emit({ step: 'oauth-login', phase: 'done', result })
+    if (!result.ok) {
+      throw new Error(`OAuth login failed: ${result.reason}`)
+    }
+  }
+
   const wantsDiscord = discordBotToken !== undefined && discordBotToken !== ''
   const wantsSlack = slackBotToken !== undefined && slackBotToken !== ''
   const wantsTelegram = telegramBotToken !== undefined && telegramBotToken !== ''
   emit({ step: 'scaffold', phase: 'start' })
   await scaffold(cwd, {
     model,
+    ...(visionModel !== undefined ? { visionModel } : {}),
     withDiscord: wantsDiscord,
     withSlack: wantsSlack,
     withTelegram: wantsTelegram,
@@ -197,6 +226,9 @@ export async function runInit({
   await writeSecrets(cwd, {
     model,
     apiKey: resolvedAuth.kind === 'api-key' ? resolvedAuth.apiKey : undefined,
+    ...(visionModel !== undefined && visionAuth?.kind === 'api-key'
+      ? { visionModel, visionApiKey: visionAuth.apiKey }
+      : {}),
     discordBotToken,
     slackBotToken,
     slackAppToken,
@@ -395,6 +427,7 @@ export async function isHatched(dir: string): Promise<boolean> {
 
 export type ScaffoldOptions = {
   model?: KnownModelRef
+  visionModel?: KnownModelRef
   withDiscord?: boolean
   withSlack?: boolean
   withTelegram?: boolean
@@ -416,9 +449,11 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   // `memory.*`) is omitted to keep the scaffold minimal — duplicating defaults
   // here would mean every schema change has to be mirrored in two places, and
   // users would feel obligated to maintain values they never set.
+  const models: Record<string, KnownModelRef> = { default: options.model ?? DEFAULT_MODEL_REF }
+  if (options.visionModel !== undefined) models.vision = options.visionModel
   const config: Record<string, unknown> = {
     $schema: './node_modules/typeclaw/typeclaw.schema.json',
-    models: { default: options.model ?? DEFAULT_MODEL_REF },
+    models,
   }
   const channels: Record<string, Record<string, never>> = {}
   if (options.withDiscord) channels['discord-bot'] = {}
@@ -587,6 +622,8 @@ export async function writeSecrets(
   {
     model = DEFAULT_MODEL_REF,
     apiKey,
+    visionModel,
+    visionApiKey,
     discordBotToken,
     slackBotToken,
     slackAppToken,
@@ -595,6 +632,8 @@ export async function writeSecrets(
     model?: KnownModelRef
     // Omitted on the OAuth path — credentials live in secrets.json via the OAuth runner.
     apiKey?: string
+    visionModel?: KnownModelRef
+    visionApiKey?: string
     discordBotToken?: string
     slackBotToken?: string
     slackAppToken?: string
@@ -603,8 +642,20 @@ export async function writeSecrets(
 ): Promise<void> {
   const providerId = providerForModelRef(model)
   const apiKeyEnv = KNOWN_PROVIDERS[providerId].apiKeyEnv
-  if (apiKey !== undefined && apiKeyEnv !== null) {
-    createSecretsStoreForAgent(join(root, 'secrets.json')).set(providerId, { type: 'api_key', key: apiKey })
+  const wantsDefaultKey = apiKey !== undefined && apiKeyEnv !== null
+  const visionProviderId = visionModel !== undefined ? providerForModelRef(visionModel) : null
+  const wantsVisionKey =
+    visionModel !== undefined &&
+    visionApiKey !== undefined &&
+    visionProviderId !== providerId &&
+    visionProviderId !== null &&
+    KNOWN_PROVIDERS[visionProviderId].apiKeyEnv !== null
+  if (wantsDefaultKey || wantsVisionKey) {
+    const secretsStore = createSecretsStoreForAgent(join(root, 'secrets.json'))
+    if (wantsDefaultKey) secretsStore.set(providerId, { type: 'api_key', key: apiKey! })
+    if (wantsVisionKey) {
+      secretsStore.set(visionProviderId, { type: 'api_key', key: visionApiKey! })
+    }
   }
 
   const channelTokens: Record<string, Record<string, Secret>> = {}

--- a/src/init/models-dev.test.ts
+++ b/src/init/models-dev.test.ts
@@ -19,6 +19,15 @@ describe('curatedOptions', () => {
     expect(kimi).toBeDefined()
     expect(kimi?.providerId).toBe('fireworks')
   })
+
+  test('flags supportsVision based on curated input modality', () => {
+    const options = curatedOptions()
+
+    const openaiNano = options.find((o) => o.ref === 'openai/gpt-5.4-nano')
+    expect(openaiNano?.supportsVision).toBe(true)
+    const glm = options.find((o) => o.ref === 'zai/glm-4.6')
+    expect(glm?.supportsVision).toBe(false)
+  })
 })
 
 describe('fetchModelOptions', () => {

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -30,6 +30,13 @@ export type ModelOption = {
   reasoning: boolean
   contextWindow: number | null
   curated: boolean
+  // True iff the model accepts image input. Sourced from the curated
+  // `Model.input` array (which is the source of truth — pi-ai consumes it
+  // directly) with a fallback to models.dev's `modalities.input` when the
+  // curated entry omits the field. The init wizard uses this to decide
+  // whether to prompt for a separate `vision` profile after the user picks
+  // a text-only `default` model.
+  supportsVision: boolean
 }
 
 type ModelsDevModel = {
@@ -120,7 +127,10 @@ function buildOption(ref: KnownModelRef, opts: BuildOptionOpts): ModelOption {
   const modelId = ref.slice(slash + 1)
   const provider = KNOWN_PROVIDERS[providerId]
   const curatedModel = (
-    provider.models as Record<string, { name: string; contextWindow?: number; reasoning?: boolean }>
+    provider.models as Record<
+      string,
+      { name: string; contextWindow?: number; reasoning?: boolean; input?: ReadonlyArray<string> }
+    >
   )[modelId]
   return {
     ref,
@@ -131,5 +141,15 @@ function buildOption(ref: KnownModelRef, opts: BuildOptionOpts): ModelOption {
     reasoning: opts.upstream?.reasoning ?? curatedModel?.reasoning ?? false,
     contextWindow: opts.upstream?.limit?.context ?? curatedModel?.contextWindow ?? null,
     curated: opts.curated,
+    supportsVision: resolveSupportsVision(curatedModel?.input, opts.upstream?.modalities?.input),
   }
+}
+
+function resolveSupportsVision(
+  curatedInput: ReadonlyArray<string> | undefined,
+  upstreamInput: ReadonlyArray<string> | undefined,
+): boolean {
+  if (curatedInput !== undefined) return curatedInput.includes('image')
+  if (upstreamInput !== undefined) return upstreamInput.includes('image')
+  return false
 }


### PR DESCRIPTION
## Summary

When a user picks a text-only default model during \`typeclaw init\` (e.g. any \`zai\` or \`zai-coding\` GLM model — all of which advertise \`input: ['text']\`), the wizard now runs a second provider+model round to populate \`models.vision\` in \`typeclaw.json\`. Without this, \`look_at\` and every image-bearing inbound silently fall through to the text-only default and the image payload is dropped on the floor.

Credential reuse is the load-bearing UX choice: the goal is one extra picker, not one extra full auth flow.

- **Same provider as default** → reuse the auth captured for the default profile, no further prompt.
- **Different provider, key already in \`secrets.json\`** → log "Using existing X API key" and move on.
- **New provider** → run the same reuse / api-key / oauth sub-flow the default path uses.
- **Skip** → omit \`models.vision\` entirely; user can wire it later via \`typeclaw model set vision <ref>\`.

The vision picker is only shown for vision-capable models (\`supportsVision\` derived from the curated \`Model.input\` array, with a models.dev \`modalities.input\` fallback). Vision-capable defaults bypass the whole flow.

## Why

Today nothing prevents an init wizard run from leaving the agent unable to handle images. The doctor check (\`src/doctor/config-bundled-profiles.test.ts\`) already flags missing bundled profiles after the fact, and \`look_at\` only exists because text-only defaults are a supported configuration — closing the loop at init is the natural place.

## Changes

- \`src/init/models-dev.ts\` — add \`supportsVision: boolean\` to \`ModelOption\`, derived from curated \`Model.input\` with upstream \`modalities.input\` fallback.
- \`src/cli/init.ts\` — extend the back-aware state machine with \`pick-vision-provider\`, \`pick-vision-model\`, \`pick-vision-auth-method\`, \`enter-vision-api-key\`. Vision picker enters after auth-finalize on a text-only default and exits to \`pick-channel\`. ESC walks back through the new steps the same way the default path supports.
- \`src/init/index.ts\` — \`runInit\` accepts \`visionModel\` + \`visionAuth\`; \`scaffold\` writes \`models.vision\`; \`writeSecrets\` writes a second provider's API key only when it differs from the default and the user supplied one. OAuth for a cross-provider vision runs before scaffold (same "no half-init folder" rule).
- Tests: scaffold writes \`models.vision\`; \`writeSecrets\` writes / skips the cross-provider key correctly; wizard goes through vision picker for text-only default; vision-capable default skips it; same-provider reuses auth; existing key in \`secrets.json\` skips re-prompt; skip option works; ESC walks back.

## Test plan

\`\`\`sh
bun run typecheck     # 0 errors
bun run lint          # 8 pre-existing warnings, 0 errors
bun run format:check  # clean
bun test              # 3436 pass / 0 fail
\`\`\`

The vision-related tests cover both branches of the modality classifier and every credential-reuse path. Unit tests use real \`ModelOption\` fixtures rather than mocks, and exercise the full \`collectWizardInputs\` state machine end-to-end (no UI mocking — the seam is the \`WizardPrompts\` interface, which was already designed for this).