### PR TITLE
Fix memory-logger schema bug and add defensive tool-result byte budget for subagents

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -31,6 +31,12 @@ import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
 import { renderSessionOrigin, type SessionOrigin, type SessionRoleContext } from './session-origin'
 import { DEFAULT_SYSTEM_PROMPT } from './system-prompt'
+import {
+  createBudgetState,
+  type ToolResultBudget,
+  wrapAgentToolWithBudget,
+  wrapToolDefinitionWithBudget,
+} from './tool-result-budget'
 import { createChannelFetchAttachmentTool } from './tools/channel-fetch-attachment'
 import { createChannelHistoryTool } from './tools/channel-history'
 import { createChannelReplyTool } from './tools/channel-reply'
@@ -120,6 +126,19 @@ export type CreateSessionOptions = {
   // overrides) so different sessions on the same agent can run different
   // models without per-session config edits.
   profile?: string
+  // Defensive ceiling on cumulative bytes of tool-result text per session,
+  // applied to the named tools only. See `src/agent/tool-result-budget.ts`
+  // for the rationale. Intended for subagents that read large files
+  // (memory-logger, dreaming); leaving this undefined disables the budget
+  // entirely, which is the right default for TUI / channel / plugin-tool
+  // sessions where the human (or hooks) bound tool-result size.
+  toolResultBudget?: ToolResultBudget
+  // Optional override for the message returned to the agent once
+  // `toolResultBudget` is exhausted. Subagents whose recovery path differs
+  // from the default ("advance the watermark from a recent id you have
+  // already seen") provide their own here. See `ToolResultBudget` for the
+  // shared shape.
+  toolResultBudgetMessage?: ToolResultBudget['exhaustedMessage']
 }
 
 export type CreateSessionResult = {
@@ -169,11 +188,29 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     ? wrapSubagentCustomTools(options.pluginSubagent, options.plugins, getOrigin)
     : wrapRegistryTools(options.plugins, getOrigin)
 
-  const tools = wrapSystemAgentTools(
+  // Per-run budget state for the tool-result byte ceiling. Allocated once per
+  // session creation and threaded into every wrapped tool so they share the
+  // same counter. Only used when the session declares a budget; the wrappers
+  // pass non-listed tools through unchanged, so the counter stays at zero for
+  // sessions without a budget configured.
+  const sessionBudget: ToolResultBudget | undefined = options.toolResultBudget
+    ? options.toolResultBudgetMessage !== undefined
+      ? { ...options.toolResultBudget, exhaustedMessage: options.toolResultBudgetMessage }
+      : options.toolResultBudget
+    : undefined
+  const sessionBudgetState = sessionBudget ? createBudgetState() : undefined
+
+  const hookWrappedTools = wrapSystemAgentTools(
     options.tools ?? (subagentBuiltinTools as AgentSessionTools | undefined),
     options.plugins,
     getOrigin,
   )
+  const tools =
+    sessionBudget && sessionBudgetState && hookWrappedTools
+      ? (hookWrappedTools.map((t) =>
+          wrapAgentToolWithBudget(t, sessionBudget, sessionBudgetState),
+        ) as typeof hookWrappedTools)
+      : hookWrappedTools
 
   // Hoisted above tool construction so the restart tool can be wired with the
   // session's stable identity (sessionManager.getSessionId()). Subscribers use
@@ -203,7 +240,11 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
                 ]
               : []),
           ]
-  const customTools = [...wrapSystemTools(customSystemTools, options.plugins, getOrigin), ...pluginCustomTools]
+  const customToolsPreBudget = [...wrapSystemTools(customSystemTools, options.plugins, getOrigin), ...pluginCustomTools]
+  const customTools =
+    sessionBudget && sessionBudgetState
+      ? customToolsPreBudget.map((t) => wrapToolDefinitionWithBudget(t, sessionBudget, sessionBudgetState))
+      : customToolsPreBudget
 
   const model = resolveModel(resolved.ref)
   const { session } = await createAgentSession({

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -27,6 +27,42 @@ describe('zodToToolParameters', () => {
     expect(json.properties).toHaveProperty('name')
     expect(json.properties).toHaveProperty('age')
   })
+
+  test('strips the $schema URI so Ajv (used by pi-ai) can compile the result', async () => {
+    const schema = z.object({ path: z.string(), entryId: z.string().min(1) })
+    const json = zodToToolParameters(schema) as Record<string, unknown>
+    expect(json.$schema).toBeUndefined()
+
+    const AjvModule = await import('ajv')
+    const Ajv = (AjvModule as unknown as { default?: typeof AjvModule.default }).default ?? AjvModule
+    const ajv = new (Ajv as new (...args: unknown[]) => { compile: (s: unknown) => unknown })({
+      allErrors: true,
+      strict: false,
+      coerceTypes: true,
+    })
+    expect(() => ajv.compile(json)).not.toThrow()
+  })
+
+  test('preserves field-level constraints (format, pattern, minLength) after stripping $schema', () => {
+    const schema = z.object({
+      email: z.string().email(),
+      id: z.string().uuid(),
+      slug: z.string().min(1),
+      pattern: z.string().regex(/^[a-z]+$/),
+    })
+    const json = zodToToolParameters(schema) as unknown as {
+      properties: {
+        email: { format?: string }
+        id: { format?: string }
+        slug: { minLength?: number }
+        pattern: { pattern?: string }
+      }
+    }
+    expect(json.properties.email.format).toBe('email')
+    expect(json.properties.id.format).toBe('uuid')
+    expect(json.properties.slug.minLength).toBe(1)
+    expect(json.properties.pattern.pattern).toBe('^[a-z]+$')
+  })
 })
 
 describe('wrapPluginTool', () => {

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -88,8 +88,24 @@ export type WrapSystemToolOptions = {
   getOrigin?: () => SessionOrigin | undefined
 }
 
+// Zod 4 emits a top-level `"$schema": "https://json-schema.org/draft/2020-12/schema"`
+// pointer on every converted schema. Ajv v8 (used by pi-ai's runtime tool-argument
+// validator and by ModelRegistry's models.json validator) is configured for
+// Draft 7 and rejects unknown `$schema` URIs with:
+//
+//   no schema with key or ref "https://json-schema.org/draft/2020-12/schema"
+//
+// That error is raised before the tool's execute is even invoked, so the model
+// sees the failure as a tool-call result and reacts by retrying or falling back
+// to other tools. In the memory-logger / dreaming subagents this meant the
+// `find_entry` tool was permanently broken: the subagent kept falling back to
+// `read(offset=1, limit=2000)` and chunked through entire multi-hundred-KB
+// transcripts on every channel turn. Stripping `$schema` is the minimal,
+// converter-version-independent fix; it leaves the actual JSON-schema body
+// untouched and lets Ajv use its default draft.
 export function zodToToolParameters(schema: z.ZodType<unknown>): TSchema {
-  const json = z.toJSONSchema(schema, { io: 'input', reused: 'inline' })
+  const json = z.toJSONSchema(schema, { io: 'input', reused: 'inline' }) as Record<string, unknown>
+  delete json.$schema
   return json as unknown as TSchema
 }
 

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -6,6 +6,7 @@ import type { Stream, Unsubscribe } from '@/stream'
 
 import { type AgentSession, createSession } from './index'
 import type { SessionOrigin } from './session-origin'
+import type { ToolResultBudget } from './tool-result-budget'
 
 type AgentSessionTools = NonNullable<Parameters<typeof createSession>[0]>['tools']
 
@@ -27,6 +28,7 @@ export type Subagent<P = unknown> = {
   customTools?: ToolDefinition[]
   payloadSchema?: z.ZodType<P>
   handler?: (ctx: SubagentContext<P>, runSession: RunSession) => Promise<void>
+  toolResultBudget?: ToolResultBudget
 }
 
 export type SubagentRegistry = Readonly<Record<string, Subagent<any>>>
@@ -87,6 +89,7 @@ export const defaultCreateSessionForSubagent: CreateSessionForSubagent = (subage
     ...(subagent.tools ? { tools: subagent.tools } : {}),
     customTools: subagent.customTools ?? [],
     ...(subagent.profile !== undefined ? { profile: subagent.profile } : {}),
+    ...(subagent.toolResultBudget !== undefined ? { toolResultBudget: subagent.toolResultBudget } : {}),
   })
 
 type NormalizedSubagentSession = {

--- a/src/agent/tool-result-budget.test.ts
+++ b/src/agent/tool-result-budget.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from 'bun:test'
+
+import { defineTool as definePiTool } from '@mariozechner/pi-coding-agent'
+import { Type } from '@sinclair/typebox'
+
+import { createBudgetState, wrapAgentToolWithBudget, wrapToolDefinitionWithBudget } from './tool-result-budget'
+
+type CapturedCall = { id: string; size: number }
+
+function makeAgentTool(name: string, bytesPerCall: number, captured: CapturedCall[]) {
+  return {
+    name,
+    label: name,
+    description: 'test tool',
+    parameters: Type.Object({}),
+    async execute(toolCallId: string) {
+      captured.push({ id: toolCallId, size: bytesPerCall })
+      return {
+        content: [{ type: 'text' as const, text: 'x'.repeat(bytesPerCall) }],
+        details: undefined,
+      }
+    },
+    renderCall: () => ({}) as never,
+    renderResult: () => ({}) as never,
+  }
+}
+
+describe('wrapAgentToolWithBudget', () => {
+  test('passes through tools whose name is not in the budget list', async () => {
+    const captured: CapturedCall[] = []
+    const tool = makeAgentTool('other', 1024, captured)
+    const state = createBudgetState()
+    const wrapped = wrapAgentToolWithBudget(tool, { maxTotalBytes: 10, toolNames: ['read'] }, state)
+
+    expect(wrapped).toBe(tool)
+    const result = await wrapped.execute('c1', {} as never, undefined, () => {})
+    expect((result.content[0] as { text: string }).text.length).toBe(1024)
+    expect(state.used).toBe(0)
+  })
+
+  test('counts bytes of text content against the shared budget', async () => {
+    const captured: CapturedCall[] = []
+    const tool = makeAgentTool('read', 1000, captured)
+    const state = createBudgetState()
+    const wrapped = wrapAgentToolWithBudget(tool, { maxTotalBytes: 5000, toolNames: ['read'] }, state)
+
+    await wrapped.execute('c1', {} as never, undefined, () => {})
+    expect(state.used).toBe(1000)
+    expect(state.exhausted).toBe(false)
+
+    await wrapped.execute('c2', {} as never, undefined, () => {})
+    expect(state.used).toBe(2000)
+  })
+
+  test('short-circuits subsequent calls once budget is exhausted', async () => {
+    const captured: CapturedCall[] = []
+    const tool = makeAgentTool('read', 3000, captured)
+    const state = createBudgetState()
+    const wrapped = wrapAgentToolWithBudget(tool, { maxTotalBytes: 5000, toolNames: ['read'] }, state)
+
+    await wrapped.execute('c1', {} as never, undefined, () => {})
+    await wrapped.execute('c2', {} as never, undefined, () => {})
+    expect(state.exhausted).toBe(true)
+    expect(captured).toHaveLength(2)
+
+    const result = await wrapped.execute('c3', {} as never, undefined, () => {})
+    expect(captured).toHaveLength(2)
+    expect((result.content[0] as { text: string }).text).toContain('budget exhausted')
+    expect((result.details as unknown as { budgetExhausted?: boolean } | undefined)?.budgetExhausted).toBe(true)
+  })
+
+  test('multiple tools wrapped with the same state share the budget', async () => {
+    const captured: CapturedCall[] = []
+    const tool1 = makeAgentTool('read', 2000, captured)
+    const tool2 = makeAgentTool('read2', 2000, captured)
+    const state = createBudgetState()
+    const budget = { maxTotalBytes: 5000, toolNames: ['read', 'read2'] as const }
+    const wrapped1 = wrapAgentToolWithBudget(tool1, budget, state)
+    const wrapped2 = wrapAgentToolWithBudget(tool2, budget, state)
+
+    await wrapped1.execute('a1', {} as never, undefined, () => {})
+    await wrapped2.execute('a2', {} as never, undefined, () => {})
+    await wrapped1.execute('a3', {} as never, undefined, () => {})
+    expect(state.exhausted).toBe(true)
+
+    const result = await wrapped2.execute('a4', {} as never, undefined, () => {})
+    expect((result.content[0] as { text: string }).text).toContain('budget exhausted')
+  })
+
+  test('counts UTF-8 byte length, not JS string length, so Korean text is accounted for correctly', async () => {
+    // 한 = 3 bytes UTF-8, so 100 chars of Korean = 300 bytes (not 100).
+    const korean = '한'.repeat(100)
+    expect(korean.length).toBe(100)
+    expect(Buffer.byteLength(korean, 'utf8')).toBe(300)
+    const tool = {
+      name: 'read',
+      label: 'read',
+      description: 't',
+      parameters: Type.Object({}),
+      async execute() {
+        return { content: [{ type: 'text' as const, text: korean }], details: undefined }
+      },
+      renderCall: () => ({}) as never,
+      renderResult: () => ({}) as never,
+    }
+    const state = createBudgetState()
+    const wrapped = wrapAgentToolWithBudget(tool, { maxTotalBytes: 500, toolNames: ['read'] }, state)
+    await wrapped.execute('c1', {} as never, undefined, () => {})
+    expect(state.used).toBe(300)
+  })
+
+  test('non-text content parts (images) are not counted against the byte budget', async () => {
+    const tool = {
+      name: 'read',
+      label: 'read',
+      description: 't',
+      parameters: Type.Object({}),
+      async execute() {
+        return {
+          content: [
+            { type: 'text' as const, text: 'tiny' },
+            { type: 'image' as const, data: 'A'.repeat(50000), mimeType: 'image/png' },
+          ],
+          details: undefined,
+        }
+      },
+      renderCall: () => ({}) as never,
+      renderResult: () => ({}) as never,
+    }
+    const state = createBudgetState()
+    const wrapped = wrapAgentToolWithBudget(tool, { maxTotalBytes: 1000, toolNames: ['read'] }, state)
+    await wrapped.execute('c1', {} as never, undefined, () => {})
+    expect(state.used).toBe(4)
+  })
+
+  test('preserves non-undefined details on healthy (non-exhausted) calls', async () => {
+    const tool = {
+      name: 'read',
+      label: 'read',
+      description: 't',
+      parameters: Type.Object({}),
+      async execute() {
+        return {
+          content: [{ type: 'text' as const, text: 'ok' }],
+          details: { custom: 42 },
+        }
+      },
+      renderCall: () => ({}) as never,
+      renderResult: () => ({}) as never,
+    }
+    const state = createBudgetState()
+    const wrapped = wrapAgentToolWithBudget(tool, { maxTotalBytes: 1000, toolNames: ['read'] }, state)
+    const result = await wrapped.execute('c1', {} as never, undefined, () => {})
+    expect((result.details as { custom: number }).custom).toBe(42)
+  })
+
+  test('uses a custom exhaustedMessage when the budget supplies one', async () => {
+    const tool = {
+      name: 'read',
+      label: 'read',
+      description: 't',
+      parameters: Type.Object({}),
+      async execute() {
+        return { content: [{ type: 'text' as const, text: 'x'.repeat(2000) }], details: undefined }
+      },
+      renderCall: () => ({}) as never,
+      renderResult: () => ({}) as never,
+    }
+    const state = createBudgetState()
+    const wrapped = wrapAgentToolWithBudget(
+      tool,
+      { maxTotalBytes: 1000, toolNames: ['read'], exhaustedMessage: () => 'CUSTOM-EXHAUSTED-MARKER' },
+      state,
+    )
+    await wrapped.execute('c1', {} as never, undefined, () => {})
+    const result = await wrapped.execute('c2', {} as never, undefined, () => {})
+    expect((result.content[0] as { text: string }).text).toBe('CUSTOM-EXHAUSTED-MARKER')
+  })
+})
+
+describe('wrapToolDefinitionWithBudget', () => {
+  test('wraps custom ToolDefinition execute and enforces budget', async () => {
+    const calls: string[] = []
+    const tool = definePiTool({
+      name: 'read',
+      label: 'read',
+      description: 'test',
+      parameters: Type.Object({}),
+      async execute(toolCallId) {
+        calls.push(toolCallId)
+        return { content: [{ type: 'text' as const, text: 'y'.repeat(2500) }], details: undefined }
+      },
+    })
+    const state = createBudgetState()
+    const wrapped = wrapToolDefinitionWithBudget(tool, { maxTotalBytes: 4000, toolNames: ['read'] }, state)
+
+    await wrapped.execute('c1', {} as never, undefined, () => {}, {} as never)
+    await wrapped.execute('c2', {} as never, undefined, () => {}, {} as never)
+    expect(state.exhausted).toBe(true)
+    expect(calls).toHaveLength(2)
+
+    const result = await wrapped.execute('c3', {} as never, undefined, () => {}, {} as never)
+    expect(calls).toHaveLength(2)
+    expect((result.content[0] as { text: string }).text).toContain('budget exhausted')
+  })
+
+  test('returns the underlying tool unchanged when the name is not budgeted', async () => {
+    const tool = definePiTool({
+      name: 'append',
+      label: 'append',
+      description: 'test',
+      parameters: Type.Object({}),
+      async execute() {
+        return { content: [{ type: 'text' as const, text: 'ok' }], details: undefined }
+      },
+    })
+    const state = createBudgetState()
+    const wrapped = wrapToolDefinitionWithBudget(tool, { maxTotalBytes: 10, toolNames: ['read'] }, state)
+
+    expect(wrapped).toBe(tool)
+  })
+})

--- a/src/agent/tool-result-budget.ts
+++ b/src/agent/tool-result-budget.ts
@@ -1,0 +1,121 @@
+import type { AgentTool } from '@mariozechner/pi-agent-core'
+import type { ToolDefinition } from '@mariozechner/pi-coding-agent'
+import type { TSchema } from '@sinclair/typebox'
+
+// Subagents that read large files (memory-logger and dreaming each read parent
+// session transcripts that can run hundreds of KB) are vulnerable to a class
+// of bug where a single tool malfunction — a broken `find_entry`, a missing
+// watermark, a transcript that no longer contains the watermark id — causes
+// the agent to fall back to scanning the file in 50KB chunks. Every chunk
+// stays in the subagent's conversation history and gets re-sent to the model
+// on every turn until the subagent stops, so a 1MB transcript can balloon a
+// memory-logger run from ~10K input tokens to several hundred thousand.
+//
+// The budget here is a fail-safe ceiling on the total bytes of tool-result
+// text a subagent run is allowed to accumulate from a chosen set of tools.
+// Once exhausted, subsequent calls to those tools short-circuit with a
+// constant-size message that tells the agent to advance the watermark to the
+// latest entry and exit. The budget is per-run (one BudgetState per session)
+// and tracked only for the named tools; tools like `append` (which write,
+// not read) are unaffected.
+
+export type ToolResultBudget = {
+  maxTotalBytes: number
+  toolNames: readonly string[]
+  exhaustedMessage?: (used: number, max: number) => string
+}
+
+export type BudgetState = {
+  used: number
+  exhausted: boolean
+}
+
+export function createBudgetState(): BudgetState {
+  return { used: 0, exhausted: false }
+}
+
+function defaultExhaustedMessage(used: number, max: number): string {
+  const usedKb = Math.round(used / 1024)
+  const maxKb = Math.round(max / 1024)
+  return [
+    `[tool-result budget exhausted: used ${usedKb}KB of ${maxKb}KB this run]`,
+    '',
+    'Stop reading. This session has consumed its byte budget across calls to',
+    'this tool. Do not call this tool again. Stop and exit; future runs will',
+    'continue from wherever your normal end-of-run bookkeeping left off.',
+  ].join('\n')
+}
+
+function bytesOfContent(content: { type: string; text?: string }[] | undefined): number {
+  if (!content) return 0
+  let total = 0
+  for (const part of content) {
+    if (part.type === 'text' && typeof part.text === 'string') {
+      total += Buffer.byteLength(part.text, 'utf8')
+    }
+  }
+  return total
+}
+
+function buildExhaustedResult(budget: ToolResultBudget, state: BudgetState) {
+  const text = (budget.exhaustedMessage ?? defaultExhaustedMessage)(state.used, budget.maxTotalBytes)
+  return {
+    content: [{ type: 'text' as const, text }],
+    details: { budgetExhausted: true, used: state.used, max: budget.maxTotalBytes },
+  }
+}
+
+// Wraps an AgentTool's execute so that returned text content is counted against
+// `state` and the tool short-circuits once `budget.maxTotalBytes` is exceeded.
+// Tools whose name is not in `budget.toolNames` are returned unchanged so the
+// caller can pass an entire `tools` array through and only the tracked tools
+// are affected. The original tool object is preserved by spreading; only
+// `execute` is replaced.
+export function wrapAgentToolWithBudget<TParams extends TSchema, TDetails = unknown>(
+  tool: AgentTool<TParams, TDetails>,
+  budget: ToolResultBudget,
+  state: BudgetState,
+): AgentTool<TParams, TDetails> {
+  if (!budget.toolNames.includes(tool.name)) return tool
+  const originalExecute = tool.execute.bind(tool)
+  return {
+    ...tool,
+    async execute(toolCallId, args, signal, onUpdate) {
+      if (state.exhausted) {
+        return buildExhaustedResult(budget, state) as Awaited<ReturnType<typeof originalExecute>>
+      }
+      const result = await originalExecute(toolCallId, args, signal, onUpdate)
+      state.used += bytesOfContent(result.content as { type: string; text?: string }[] | undefined)
+      if (state.used >= budget.maxTotalBytes) {
+        state.exhausted = true
+      }
+      return result
+    },
+  }
+}
+
+// Same wrapper for ToolDefinition (the customTools surface). Identical
+// semantics; ToolDefinition's execute has an extra `onUpdate` callback and a
+// `ctx` argument that we forward verbatim.
+export function wrapToolDefinitionWithBudget<TParams extends TSchema, TDetails = unknown, TState = unknown>(
+  tool: ToolDefinition<TParams, TDetails, TState>,
+  budget: ToolResultBudget,
+  state: BudgetState,
+): ToolDefinition<TParams, TDetails, TState> {
+  if (!budget.toolNames.includes(tool.name)) return tool
+  const originalExecute = tool.execute.bind(tool)
+  return {
+    ...tool,
+    async execute(toolCallId, args, signal, onUpdate, ctx) {
+      if (state.exhausted) {
+        return buildExhaustedResult(budget, state) as Awaited<ReturnType<typeof originalExecute>>
+      }
+      const result = await originalExecute(toolCallId, args, signal, onUpdate, ctx)
+      state.used += bytesOfContent(result.content as { type: string; text?: string }[] | undefined)
+      if (state.used >= budget.maxTotalBytes) {
+        state.exhausted = true
+      }
+      return result
+    },
+  }
+}

--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -95,6 +95,18 @@ describe('dreaming subagent declarations', () => {
     expect(sub.customTools).toBeUndefined()
   })
 
+  test('declares a defensive tool-result byte budget on the read tool so a runaway multi-day stream read cannot balloon subagent token cost', () => {
+    const sub = createDreamingSubagent()
+    expect(sub.toolResultBudget).toBeDefined()
+    expect(sub.toolResultBudget!.maxTotalBytes).toBeGreaterThanOrEqual(128 * 1024)
+    expect(sub.toolResultBudget!.maxTotalBytes).toBeLessThanOrEqual(2 * 1024 * 1024)
+  })
+
+  test('budgets ONLY the read tool so write/ls stay unaffected when the budget exhausts', () => {
+    const sub = createDreamingSubagent()
+    expect([...sub.toolResultBudget!.toolNames]).toEqual(['read'])
+  })
+
   test('teaches the dreaming session about muscle memory in the system prompt', () => {
     const sub = createDreamingSubagent()
     expect(sub.systemPrompt).toContain('Muscle memory')

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -545,6 +545,7 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
     tools: [readTool, writeTool, lsTool],
     payloadSchema: dreamingPayloadSchema,
     inFlightKey: (payload) => payload.agentDir,
+    toolResultBudget: { maxTotalBytes: 512 * 1024, toolNames: ['read'] },
     handler: async (ctx, runSession) => {
       await ensureMemoryFiles(ctx.payload.agentDir)
       const state = await loadDreamingState(ctx.payload.agentDir)

--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -208,6 +208,23 @@ describe('memoryLoggerSubagent', () => {
     expect(descriptions.some((d) => d.includes('Append content to a file'))).toBe(true)
   })
 
+  test('declares a defensive tool-result byte budget on the read tool so a malfunctioning find_entry cannot cause unbounded chunked reads', () => {
+    expect(memoryLoggerSubagent.toolResultBudget).toBeDefined()
+    expect(memoryLoggerSubagent.toolResultBudget!.maxTotalBytes).toBeGreaterThanOrEqual(64 * 1024)
+    expect(memoryLoggerSubagent.toolResultBudget!.maxTotalBytes).toBeLessThanOrEqual(1024 * 1024)
+  })
+
+  test('budgets ONLY the read tool so the append / find_entry recovery path stays open after exhaustion', () => {
+    expect([...memoryLoggerSubagent.toolResultBudget!.toolNames]).toEqual(['read'])
+  })
+
+  test('exhausted-budget message tells the subagent to exit silently when no transcript content was read (never invent a watermark)', () => {
+    const msg = memoryLoggerSubagent.toolResultBudget!.exhaustedMessage!(256 * 1024, 256 * 1024)
+    expect(msg).toContain('exit immediately')
+    expect(msg).toContain('WITHOUT writing a watermark')
+    expect(msg).toContain('Do not invent or reuse a watermark id')
+  })
+
   test('declares an inFlightKey that keys on agentDir (so two concurrent sessions for the same agent serialize)', () => {
     expect(memoryLoggerSubagent.inFlightKey).toBeDefined()
     const key = memoryLoggerSubagent.inFlightKey!({

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -17,6 +17,39 @@ export const memoryLoggerPayloadSchema = z.object({
   origin: z.custom<SessionOrigin>().optional(),
 })
 
+// Recovery message for the read-budget short-circuit. The watermark contract
+// in MEMORY_LOGGER_SYSTEM_PROMPT requires a trailing watermark marker on every
+// run, but once read is short-circuited the subagent cannot keep scanning to
+// pick a "latest evaluated entry id". `find_entry` and `append` are not
+// budgeted, so the recovery is: call find_entry on the transcript to learn
+// `totalLines` without re-reading content, then append a watermark pointing
+// at any entry id the subagent already saw earlier in the run. When zero
+// transcript content has been read (budget consumed entirely on MEMORY.md or
+// the stream file), no advancement is possible and the run should exit
+// silently — that is the explicit second branch below. Both branches are
+// safer than the prior generic "advance to the latest id you have seen"
+// hint, which was self-contradictory in the zero-content case.
+export function memoryLoggerExhaustedMessage(used: number, max: number): string {
+  const usedKb = Math.round(used / 1024)
+  const maxKb = Math.round(max / 1024)
+  return [
+    `[read budget exhausted: used ${usedKb}KB of ${maxKb}KB this run]`,
+    '',
+    'Stop reading. The session has consumed its byte budget across read calls.',
+    'Do not call `read` again — every subsequent call will return this same notice.',
+    '',
+    'Recovery (in order):',
+    '1. If you already saw at least one transcript entry id in earlier read output,',
+    '   call `append` to write `<!-- watermark source=<sessionId> entry=<that id> -->`',
+    '   as the last line of the daily stream, then exit.',
+    '2. If you saw NO transcript entries (the budget was consumed on MEMORY.md and',
+    '   the daily stream file before you reached the transcript), exit immediately',
+    '   WITHOUT writing a watermark. The next run will retry from the same point.',
+    '',
+    'Do not invent or reuse a watermark id. Do not call `read` again.',
+  ].join('\n')
+}
+
 export type MemoryLoggerPayload = z.infer<typeof memoryLoggerPayloadSchema>
 
 export function isMemoryLoggerPayload(value: unknown): value is MemoryLoggerPayload {
@@ -247,6 +280,11 @@ export function createMemoryLoggerSubagent(
     customTools: [findEntryTool, appendTool],
     payloadSchema: memoryLoggerPayloadSchema,
     inFlightKey: (payload) => payload.agentDir,
+    toolResultBudget: {
+      maxTotalBytes: 256 * 1024,
+      toolNames: ['read'],
+      exhaustedMessage: memoryLoggerExhaustedMessage,
+    },
     handler: async (ctx, runSession) => {
       const today = formatLocalDate()
       const streamFile = join(ctx.payload.agentDir, 'memory', `${today}.md`)

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod'
 
 import type { SessionOrigin } from '@/agent/session-origin'
+import type { ToolResultBudget } from '@/agent/tool-result-budget'
 import type { PermissionService } from '@/permissions'
 
 export type ContentPart = { type: 'text'; text: string } | { type: 'image'; mimeType: string; data: string }
@@ -58,6 +59,16 @@ export type Subagent<P = unknown> = {
   // parentSessionId so different parent sessions run in parallel while
   // duplicate runs against the same session deduplicate.
   inFlightKey?: (payload: P) => string
+  // Defensive ceiling on cumulative bytes of tool-result text per subagent
+  // run, applied to the named tools only. Once exceeded, subsequent calls to
+  // those tools short-circuit with a fixed message instructing the agent to
+  // stop reading. See `src/agent/tool-result-budget.ts` for the full
+  // rationale; the short version is: a single broken tool (e.g. find_entry
+  // failing because of a schema mismatch) can cause an agent to fall back to
+  // chunked reads of huge files, ballooning subagent token cost. The budget
+  // bounds the blast radius without changing per-call semantics for healthy
+  // runs.
+  toolResultBudget?: ToolResultBudget
 }
 
 // Cron job map keys are local; the runtime prefixes with `__plugin_<plugin-name>_`

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -195,6 +195,9 @@ export async function startAgent({
           toolNamePrefix: `__plugin_${entry.pluginName}_${entry.subagentName}`,
         },
         ...(entry.pluginSubagent.profile !== undefined ? { profile: entry.pluginSubagent.profile } : {}),
+        ...(entry.pluginSubagent.toolResultBudget !== undefined
+          ? { toolResultBudget: entry.pluginSubagent.toolResultBudget }
+          : {}),
       })
       return {
         ...created,


### PR DESCRIPTION
## Problem

A user reported that his TypeClaw agent (`돌쇠`, running on Kimi via Fireworks) was burning ~15K input tokens for trivial Discord messages like "굿" or "돌쇠야". Three-message conversation = ~200K tokens. Cache hit rate had dropped from the historical 85-89% to 64-69%.

Tracing the session JSONL transcripts revealed the actual cost driver: the **memory-logger subagent was firing on every channel turn and reading multi-hundred-KB parent transcripts in 50KB chunks**. Single subagent runs would accumulate 800KB+ of duplicated transcript content in their conversation history.

Root cause: every call to the `find_entry` tool was failing with:

```
no schema with key or ref "https://json-schema.org/draft/2020-12/schema"
```

This is Ajv (used by pi-ai's runtime tool-argument validator) rejecting a `$schema` URI it does not recognize. Zod 4's `z.toJSONSchema(...)` emits `"$schema": "https://json-schema.org/draft/2020-12/schema"` on every converted schema; Ajv v8 defaults to Draft 7 and refuses to compile schemas pointing at an unknown draft.

The failure surfaces as a tool-call error before `find_entry.execute` is ever invoked, so the subagent falls back to `read(offset=1, limit=2000)` on the full transcript and chunks through it, ballooning input-token usage on every channel turn.

Bug was 100% reproducible: `5 × schema errors` in every memory-logger session JSONL on the affected day, with session sizes of 700K–1.5MB each.

## Fix

Two commits, each addressing the issue at a different layer.

### Commit 1 — Strip `$schema` from Zod-converted tool parameters so Ajv can compile them

`src/agent/plugin-tools.ts:zodToToolParameters` now deletes the top-level `$schema` key after `z.toJSONSchema()`. The JSON-schema body (types, properties, formats, patterns, min/max constraints) is left untouched and Ajv falls back to its default draft.

Verified manually that `email`, `uuid`, `pattern`, and `minLength` constraints all survive the strip; a regression test now pins this.

### Commit 2 — Cap cumulative tool-result bytes per subagent run as a defensive ceiling

Even with `find_entry` working, a future tool malfunction or a missing watermark can cause the same class of failure (unbounded chunked reads). New module `src/agent/tool-result-budget.ts` adds a per-run byte ceiling:

- `ToolResultBudget = { maxTotalBytes, toolNames, exhaustedMessage? }` is a new option on `CreateSessionOptions` and on both `Subagent` types (the plugin surface and the agent runtime surface).
- `wrapAgentToolWithBudget` / `wrapToolDefinitionWithBudget` wrap a tool's `execute` to count UTF-8 bytes of returned text content (images and non-text parts are not counted). Tools whose name is not in `toolNames` are passed through unchanged.
- Once `maxTotalBytes` is exceeded, subsequent calls to budgeted tools short-circuit with a fixed message — by default, "stop reading, exit"; subagents can override per-context (memory-logger does).
- Wiring lives in `createSessionWithDispose`. Both internal-Subagent (`defaultCreateSessionForSubagent`) and plugin-Subagent paths (`run/index.ts`) forward the budget through.

Defaults wired on the two subagents that actually read large files:

| Subagent | `maxTotalBytes` | `toolNames` | Custom exhausted message |
|---|---|---|---|
| `memory-logger` | 256 KB | `['read']` only | yes — explicit zero-content-seen branch so the agent never invents a watermark |
| `dreaming` | 512 KB | `['read']` only | no — uses default |

Healthy runs stay well under the ceiling (typical memory-logger runs finish under 100 KB). Write tools (`append`, `write`) are intentionally NOT budgeted, so the watermark-write recovery path always stays open even after exhaustion.

## Self-review (Oracle)

An Oracle pre-review caught several issues that have since been fixed in this PR (not deferred):

- **BLOCKER (now resolved):** the original branch was based on a stale `main` and would have reverted `eea0037 Wait for connected before sending claim_start in role-claim client` and deleted `src/role-claim/client.test.ts`. Rebased onto current `origin/main` before push; the diff is now clean.
- **HIGH:** internal `Subagent` type in `src/agent/subagents.ts` did not carry `toolResultBudget`, only the plugin one did. Fixed: budget is now a `CreateSessionOptions` field, both `Subagent` types reference the same `ToolResultBudget` type, and `defaultCreateSessionForSubagent` forwards it. Symmetric across both code paths.
- **MEDIUM:** original default exhausted message told the agent to "use a recent id you have already seen", which is impossible if the budget exhausts before the first transcript read. Fixed: default message is now neutral ("stop reading, exit") and `memory-logger` ships its own message with an explicit "exit immediately WITHOUT writing a watermark" branch for the zero-content-seen case.
- **MEDIUM:** original `memory-logger` / `dreaming` tests asserted `toolNames` *contains* `'read'`, which would silently allow a future `['read', 'append']` regression that bricks the watermark-write recovery path. Tightened to `toEqual(['read'])`.
- **LOW:** budget wrapper tests now cover UTF-8 (Korean text counts as bytes, not chars), image-content (ignored), preserved `details` on healthy calls, and custom `exhaustedMessage`.
- **LOW:** `$schema` test now also asserts `email` / `uuid` / `minLength` / `pattern` survive the strip.

## Tests

- `src/agent/plugin-tools.test.ts` — `+2` tests: `$schema` is stripped + Ajv compiles, field-level constraints (`format`, `pattern`, `minLength`) survive.
- `src/agent/tool-result-budget.test.ts` — `+10` tests: pass-through for non-budgeted tools, byte counting, exhaustion short-circuit, multi-tool shared budget, **UTF-8 Korean accounting**, image content ignored, details preserved on healthy calls, custom `exhaustedMessage`, `ToolDefinition` wrapper variant.
- `src/bundled-plugins/memory/memory-logger.test.ts` — `+3` tests: budget declared, **`toolNames` exactly `['read']`** (so accidentally adding `append` later fails CI), exhausted message instructs zero-content-seen exit.
- `src/bundled-plugins/memory/dreaming.test.ts` — `+2` tests: budget declared, **`toolNames` exactly `['read']`**.

## Expected impact

For "굿"-class channel turns, the bottleneck shifts from "memory-logger pulls 800KB of transcript per turn" to "memory-logger does one `find_entry` + one targeted `read`". Predicted input-token reduction: **~15K → ~3-4K per turn** (4-5x). Cache hit rate should recover to the 85%+ range as the daily-stream tail stops being clobbered by huge subagent transcripts.

## Verification

```
$ bun run check
✓ tsgo --noEmit
✓ oxlint    Found 8 warnings and 0 errors  (pre-existing, unrelated)
✓ oxfmt --check    All matched files use the correct format

$ bun test
3445 pass · 0 fail · 7032 expect() calls
Ran 3445 tests across 206 files
```

(+18 new tests vs. base: 2 schema, 10 budget wrapper, 3 memory-logger, 2 dreaming, 1 plugin-tools format-preservation.)

## Caveats

- The budget is a defensive ceiling, not a primary correctness mechanism. The schema fix is what restores normal behavior; the budget bounds the blast radius of any future class-of-bug regression in the same shape.
- `find_entry` and `append` are intentionally NOT budgeted in memory-logger so the watermark-write recovery path always stays open. If a future change adds them to `toolNames`, tests will fail loudly.
- Budget counting uses `Buffer.byteLength(text, 'utf8')`, so 100 chars of Korean = 300 bytes (correct for prompt-cost accounting).
