### PR TITLE
Reuse existing channel credentials when re-running init in a pre-existing directory

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, mock, test } from 'bun:test'
 
 import { KNOWN_PROVIDERS, type KnownProviderId } from '@/config/providers'
 import type { LLMAuth } from '@/init'
@@ -113,6 +113,8 @@ describe('collectWizardInputs back-aware flow', () => {
       pickVisionProvider: async () => ({ kind: 'value', value: 'skip' }),
       pickVisionModel: async () => ({ kind: 'value', value: openaiModel }),
       pickChannel: async () => ({ kind: 'value', value: 'none' }),
+      hasExistingChannelSecrets: async () => false,
+      askReuseExistingChannel: async () => ({ kind: 'value', value: 'prompt' }),
       runChannelFlow: async () => ({ kind: 'value', value: {} }),
       buildOAuthAuth: () => ({ kind: 'oauth', runLogin: async () => ({ ok: true }) }) as LLMAuth,
       ...overrides,
@@ -563,5 +565,169 @@ describe('collectWizardInputs back-aware flow', () => {
 
     expect(calls).toEqual(['pick-channel', 'channel-flow', 'pick-channel', 'channel-flow'])
     expect(result.channelSecrets).toEqual({ discordBotToken: 'tok' })
+  })
+
+  test('existing channel secrets: prompts to reuse and skips channel-flow on accept', async () => {
+    const calls: string[] = []
+    const prompts = makePrompts({
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        return { kind: 'value', value: 'discord' }
+      },
+      hasExistingChannelSecrets: async (_cwd, channel) => channel === 'discord',
+      askReuseExistingChannel: async () => {
+        calls.push('reuse-existing-channel')
+        return { kind: 'value', value: 'reuse' }
+      },
+      runChannelFlow: async () => {
+        calls.push('channel-flow')
+        return { kind: 'value', value: { discordBotToken: 'tok' } }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual(['pick-channel', 'reuse-existing-channel'])
+    expect(calls).not.toContain('channel-flow')
+    expect(result.reuseExistingChannel).toBe(true)
+    expect(result.channelChoice).toBe('discord')
+    expect(result.channelSecrets).toEqual({})
+  })
+
+  test('existing channel secrets: declining reuse falls through to channel-flow', async () => {
+    const calls: string[] = []
+    const prompts = makePrompts({
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        return { kind: 'value', value: 'discord' }
+      },
+      hasExistingChannelSecrets: async () => true,
+      askReuseExistingChannel: async () => {
+        calls.push('reuse-existing-channel')
+        return { kind: 'value', value: 'prompt' }
+      },
+      runChannelFlow: async () => {
+        calls.push('channel-flow')
+        return { kind: 'value', value: { discordBotToken: 'new-tok' } }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual(['pick-channel', 'reuse-existing-channel', 'channel-flow'])
+    expect(result.reuseExistingChannel).toBe(false)
+    expect(result.channelSecrets).toEqual({ discordBotToken: 'new-tok' })
+  })
+
+  test('no existing channel secrets: reuse prompt is suppressed entirely', async () => {
+    const calls: string[] = []
+    const askReuse = mock(async () => ({ kind: 'value' as const, value: 'reuse' as const }))
+    const prompts = makePrompts({
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        return { kind: 'value', value: 'discord' }
+      },
+      hasExistingChannelSecrets: async () => false,
+      askReuseExistingChannel: askReuse,
+      runChannelFlow: async () => {
+        calls.push('channel-flow')
+        return { kind: 'value', value: { discordBotToken: 'tok' } }
+      },
+    })
+
+    await collectWizardInputs('/agent', prompts)
+
+    expect(askReuse).not.toHaveBeenCalled()
+    expect(calls).toEqual(['pick-channel', 'channel-flow'])
+  })
+
+  test('back from reuse-existing-channel returns to pick-channel', async () => {
+    const calls: string[] = []
+    let reuseBacked = false
+    const prompts = makePrompts({
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        return { kind: 'value', value: 'discord' }
+      },
+      hasExistingChannelSecrets: async () => true,
+      askReuseExistingChannel: async () => {
+        calls.push('reuse-existing-channel')
+        if (!reuseBacked) {
+          reuseBacked = true
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: 'reuse' }
+      },
+    })
+
+    await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual(['pick-channel', 'reuse-existing-channel', 'pick-channel', 'reuse-existing-channel'])
+  })
+
+  test('back from channel-flow returns to reuse-existing-channel when reuse was offered', async () => {
+    const calls: string[] = []
+    let flowBacked = false
+    const prompts = makePrompts({
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        return { kind: 'value', value: 'discord' }
+      },
+      hasExistingChannelSecrets: async () => true,
+      askReuseExistingChannel: async () => {
+        calls.push('reuse-existing-channel')
+        return { kind: 'value', value: 'prompt' }
+      },
+      runChannelFlow: async () => {
+        calls.push('channel-flow')
+        if (!flowBacked) {
+          flowBacked = true
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: { discordBotToken: 'tok' } }
+      },
+    })
+
+    await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual([
+      'pick-channel',
+      'reuse-existing-channel',
+      'channel-flow',
+      'reuse-existing-channel',
+      'channel-flow',
+    ])
+  })
+
+  test('changing channel after declining reuse clears the offered state so telegram skips reuse prompt', async () => {
+    const calls: string[] = []
+    let pickCount = 0
+    let reuseBacked = false
+    const prompts = makePrompts({
+      pickChannel: async () => {
+        pickCount += 1
+        calls.push(`pick-channel:${pickCount}`)
+        return { kind: 'value', value: pickCount === 1 ? 'discord' : 'telegram' }
+      },
+      hasExistingChannelSecrets: async (_cwd, channel) => channel === 'discord',
+      askReuseExistingChannel: async () => {
+        calls.push('reuse-existing-channel')
+        if (!reuseBacked) {
+          reuseBacked = true
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: 'prompt' }
+      },
+      runChannelFlow: async (choice) => {
+        calls.push(`channel-flow:${choice}`)
+        return { kind: 'value', value: choice === 'telegram' ? { telegramBotToken: 'tg' } : { discordBotToken: 'd' } }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(result.channelChoice).toBe('telegram')
+    expect(result.channelSecrets).toEqual({ telegramBotToken: 'tg' })
+    expect(calls).toEqual(['pick-channel:1', 'reuse-existing-channel', 'pick-channel:2', 'channel-flow:telegram'])
   })
 })

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -11,6 +11,7 @@ import {
 import type { DockerAvailability } from '@/container'
 import {
   findAgentDir,
+  hasExistingChannelSecrets,
   isDirectoryNonEmpty,
   isHatched,
   readExistingProviderApiKey,
@@ -78,7 +79,7 @@ export const init = defineCommand({
     log.info('Press ESC at any prompt to go back to the previous step.')
 
     const collected = await collectWizardInputs(cwd, defaultWizardPrompts)
-    const { model, llmAuth, vision, channelSecrets } = collected
+    const { model, llmAuth, vision, channelChoice, reuseExistingChannel, channelSecrets } = collected
     const { discordBotToken, slackBotToken, slackAppToken, telegramBotToken, kakaotalkEmail, kakaotalkPassword } =
       channelSecrets
 
@@ -86,7 +87,16 @@ export const init = defineCommand({
     //   - git backup (url + PAT) — Phase 10
     //   - cron.json scaffolding — Phase 9
     //   - compose.yml registration in $HOME/.typeclaw — Phase 12
-    const wantsKakaotalk = kakaotalkEmail !== undefined && kakaotalkPassword !== undefined
+
+    // Reuse means: wire the adapter in typeclaw.json but skip the prompt for
+    // fresh tokens / fresh kakaotalk login. `with<Adapter>` flags carry that
+    // intent down to scaffold(); writeSecrets / runKakaotalkAuth see no new
+    // input and leave the existing secrets.json slot untouched.
+    const reuseDiscord = reuseExistingChannel && channelChoice === 'discord'
+    const reuseSlack = reuseExistingChannel && channelChoice === 'slack'
+    const reuseTelegram = reuseExistingChannel && channelChoice === 'telegram'
+    const reuseKakaotalk = reuseExistingChannel && channelChoice === 'kakaotalk'
+    const wantsKakaotalk = (kakaotalkEmail !== undefined && kakaotalkPassword !== undefined) || reuseKakaotalk
     let hatchingOk = false
     let preflightFailure: Extract<DockerAvailability, { ok: false }> | null = null
     try {
@@ -99,18 +109,25 @@ export const init = defineCommand({
         ...(discordBotToken !== undefined ? { discordBotToken } : {}),
         ...(slackBotToken !== undefined ? { slackBotToken, slackAppToken } : {}),
         ...(telegramBotToken !== undefined ? { telegramBotToken } : {}),
+        ...(reuseDiscord ? { withDiscord: true } : {}),
+        ...(reuseSlack ? { withSlack: true } : {}),
+        ...(reuseTelegram ? { withTelegram: true } : {}),
         ...(wantsKakaotalk
           ? {
               withKakaotalk: true,
-              runKakaotalkAuth: ({ cwd: agentDir }) =>
-                runKakaotalkBootstrap({
-                  email: kakaotalkEmail!,
-                  password: kakaotalkPassword!,
-                  agentDir,
-                  callbacks: {
-                    onPasscode: (code) => log.info(`Confirm this passcode on your phone: ${code}`),
-                  },
-                }),
+              ...(reuseKakaotalk
+                ? {}
+                : {
+                    runKakaotalkAuth: ({ cwd: agentDir }) =>
+                      runKakaotalkBootstrap({
+                        email: kakaotalkEmail!,
+                        password: kakaotalkPassword!,
+                        agentDir,
+                        callbacks: {
+                          onPasscode: (code) => log.info(`Confirm this passcode on your phone: ${code}`),
+                        },
+                      }),
+                  }),
             }
           : {}),
         onProgress: reportProgress(
@@ -158,6 +175,8 @@ interface WizardState {
   visionAuthMethod?: 'api-key' | 'oauth'
   visionLlmAuth?: LLMAuth
   channelChoice?: ChannelChoice
+  channelReuseOffered?: boolean
+  channelReuseExisting?: boolean
 }
 
 type ChannelChoice = 'slack' | 'discord' | 'telegram' | 'kakaotalk' | 'none'
@@ -173,6 +192,8 @@ interface CollectedInputs {
     model: ModelOption
     llmAuth: LLMAuth
   }
+  channelChoice: ChannelChoice
+  reuseExistingChannel: boolean
   channelSecrets: {
     discordBotToken?: string
     slackBotToken?: string
@@ -194,6 +215,7 @@ type StepId =
   | 'pick-vision-auth-method'
   | 'enter-vision-api-key'
   | 'pick-channel'
+  | 'reuse-existing-channel'
   | 'channel-flow'
 
 export interface WizardPrompts {
@@ -225,6 +247,8 @@ export interface WizardPrompts {
     initial: KnownModelRef | undefined,
   ) => Promise<StepResult<ModelOption>>
   pickChannel: (initial: ChannelChoice | undefined) => Promise<StepResult<ChannelChoice>>
+  hasExistingChannelSecrets: (cwd: string, channel: Exclude<ChannelChoice, 'none'>) => Promise<boolean>
+  askReuseExistingChannel: (channel: Exclude<ChannelChoice, 'none'>) => Promise<StepResult<'reuse' | 'prompt'>>
   runChannelFlow: (choice: ChannelChoice) => Promise<StepResult<CollectedInputs['channelSecrets']>>
   buildOAuthAuth: (provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]) => LLMAuth
 }
@@ -240,6 +264,8 @@ export const defaultWizardPrompts: WizardPrompts = {
   pickVisionProvider,
   pickVisionModel,
   pickChannel,
+  hasExistingChannelSecrets,
+  askReuseExistingChannel,
   runChannelFlow,
   buildOAuthAuth: (provider) => ({
     kind: 'oauth',
@@ -422,7 +448,36 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
           step = stepBeforePickChannel(state)
           break
         }
+        if (state.channelChoice !== result.value) {
+          state.channelReuseOffered = undefined
+          state.channelReuseExisting = undefined
+        }
         state.channelChoice = result.value
+        step = result.value === 'none' ? 'channel-flow' : 'reuse-existing-channel'
+        break
+      }
+
+      case 'reuse-existing-channel': {
+        const choice = state.channelChoice as Exclude<ChannelChoice, 'none'>
+        const present = await prompts.hasExistingChannelSecrets(cwd, choice)
+        if (!present) {
+          state.channelReuseOffered = false
+          state.channelReuseExisting = false
+          step = 'channel-flow'
+          break
+        }
+        state.channelReuseOffered = true
+        const decision = await prompts.askReuseExistingChannel(choice)
+        if (decision.kind === 'back') {
+          step = 'pick-channel'
+          break
+        }
+        if (decision.value === 'reuse') {
+          log.info(`Using existing ${channelDisplayName(choice)} credentials from secrets.json.`)
+          state.channelReuseExisting = true
+          return finalize(state, {})
+        }
+        state.channelReuseExisting = false
         step = 'channel-flow'
         break
       }
@@ -430,19 +485,38 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
       case 'channel-flow': {
         const result = await prompts.runChannelFlow(state.channelChoice!)
         if (result.kind === 'back') {
-          step = 'pick-channel'
+          step = state.channelReuseOffered === true ? 'reuse-existing-channel' : 'pick-channel'
           break
         }
-        return {
-          model: state.model!,
-          llmAuth: state.llmAuth!,
-          ...(state.visionModel !== undefined && state.visionLlmAuth !== undefined
-            ? { vision: { model: state.visionModel, llmAuth: state.visionLlmAuth } }
-            : {}),
-          channelSecrets: result.value,
-        }
+        return finalize(state, result.value)
       }
     }
+  }
+}
+
+function finalize(state: WizardState, channelSecrets: CollectedInputs['channelSecrets']): CollectedInputs {
+  return {
+    model: state.model!,
+    llmAuth: state.llmAuth!,
+    ...(state.visionModel !== undefined && state.visionLlmAuth !== undefined
+      ? { vision: { model: state.visionModel, llmAuth: state.visionLlmAuth } }
+      : {}),
+    channelChoice: state.channelChoice ?? 'none',
+    reuseExistingChannel: state.channelReuseExisting === true,
+    channelSecrets,
+  }
+}
+
+function channelDisplayName(choice: Exclude<ChannelChoice, 'none'>): string {
+  switch (choice) {
+    case 'slack':
+      return 'Slack'
+    case 'discord':
+      return 'Discord'
+    case 'telegram':
+      return 'Telegram'
+    case 'kakaotalk':
+      return 'KakaoTalk'
   }
 }
 
@@ -524,6 +598,17 @@ async function askReuseExistingKey(
   const reuse = await confirm({
     message: `Reuse existing ${provider.name} API key from secrets.json?`,
     initialValue: initial ?? true,
+  })
+  if (isCancel(reuse)) return back()
+  return value(reuse === true ? 'reuse' : 'prompt')
+}
+
+async function askReuseExistingChannel(
+  channel: Exclude<ChannelChoice, 'none'>,
+): Promise<StepResult<'reuse' | 'prompt'>> {
+  const reuse = await confirm({
+    message: `Reuse existing ${channelDisplayName(channel)} credentials from secrets.json?`,
+    initialValue: true,
   })
   if (isCancel(reuse)) return back()
   return value(reuse === true ? 'reuse' : 'prompt')

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -15,6 +15,7 @@ import { buildGitignore } from './gitignore'
 import {
   defaultRunHatching,
   findAgentDir,
+  hasExistingChannelSecrets,
   type HatchingResult,
   type HatchRunner,
   initGitRepo,
@@ -1326,6 +1327,203 @@ describe('writeSecrets', () => {
 
     expect((await readSecrets(root)).providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_test' } })
     expect((await readSecrets(root)).channels).toEqual({})
+  })
+})
+
+describe('hasExistingChannelSecrets', () => {
+  async function seedChannels(channels: Record<string, unknown>): Promise<void> {
+    await writeFile(join(root, 'secrets.json'), `${JSON.stringify({ version: 2, providers: {}, channels }, null, 2)}\n`)
+  }
+
+  test('returns false when secrets.json does not exist', async () => {
+    expect(await hasExistingChannelSecrets(root, 'discord')).toBe(false)
+    expect(await hasExistingChannelSecrets(root, 'slack')).toBe(false)
+    expect(await hasExistingChannelSecrets(root, 'telegram')).toBe(false)
+    expect(await hasExistingChannelSecrets(root, 'kakaotalk')).toBe(false)
+  })
+
+  test('returns true when discord-bot.token is present', async () => {
+    await seedChannels({ 'discord-bot': { token: { value: 'discord-existing' } } })
+    expect(await hasExistingChannelSecrets(root, 'discord')).toBe(true)
+  })
+
+  test('accepts the string-shorthand Secret shape', async () => {
+    await seedChannels({ 'discord-bot': { token: 'discord-shorthand' } })
+    expect(await hasExistingChannelSecrets(root, 'discord')).toBe(true)
+  })
+
+  test('returns true when slack-bot has BOTH botToken and appToken', async () => {
+    await seedChannels({
+      'slack-bot': { botToken: { value: 'xoxb-1' }, appToken: { value: 'xapp-1' } },
+    })
+    expect(await hasExistingChannelSecrets(root, 'slack')).toBe(true)
+  })
+
+  test('returns false when slack-bot has only botToken (partial slot)', async () => {
+    await seedChannels({ 'slack-bot': { botToken: { value: 'xoxb-1' } } })
+    expect(await hasExistingChannelSecrets(root, 'slack')).toBe(false)
+  })
+
+  test('returns true when telegram-bot.token is present', async () => {
+    await seedChannels({ 'telegram-bot': { token: { value: '123:abc' } } })
+    expect(await hasExistingChannelSecrets(root, 'telegram')).toBe(true)
+  })
+
+  test('returns false when the relevant slot is empty', async () => {
+    await seedChannels({ 'discord-bot': {} })
+    expect(await hasExistingChannelSecrets(root, 'discord')).toBe(false)
+  })
+
+  test('returns true when kakaotalk has currentAccount with a matching accounts entry', async () => {
+    await seedChannels({
+      kakaotalk: {
+        currentAccount: 'acc-1',
+        accounts: {
+          'acc-1': {
+            account_id: 'acc-1',
+            oauth_token: 'tok',
+            user_id: 'u1',
+            device_uuid: 'd1',
+            device_type: 'tablet',
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        },
+      },
+    })
+    expect(await hasExistingChannelSecrets(root, 'kakaotalk')).toBe(true)
+  })
+
+  test('returns false when kakaotalk currentAccount is null or missing from accounts', async () => {
+    await seedChannels({ kakaotalk: { currentAccount: null, accounts: {} } })
+    expect(await hasExistingChannelSecrets(root, 'kakaotalk')).toBe(false)
+
+    await seedChannels({ kakaotalk: { currentAccount: 'acc-missing', accounts: {} } })
+    expect(await hasExistingChannelSecrets(root, 'kakaotalk')).toBe(false)
+  })
+})
+
+describe('channel secret reuse (init re-run preserves existing tokens)', () => {
+  test('omitting discordBotToken on a re-run preserves the existing slot', async () => {
+    await writeSecrets(root, { apiKey: 'fw1', discordBotToken: 'discord-old' })
+    await writeSecrets(root, { apiKey: 'fw2' })
+
+    const secrets = await readSecrets(root)
+    expect(secrets.channels?.['discord-bot']).toEqual({ token: { value: 'discord-old' } })
+  })
+
+  test('omitting slack tokens on a re-run preserves both botToken and appToken', async () => {
+    await writeSecrets(root, { apiKey: 'fw1', slackBotToken: 'xoxb-old', slackAppToken: 'xapp-old' })
+    await writeSecrets(root, { apiKey: 'fw2' })
+
+    const secrets = await readSecrets(root)
+    expect(secrets.channels?.['slack-bot']).toEqual({
+      botToken: { value: 'xoxb-old' },
+      appToken: { value: 'xapp-old' },
+    })
+  })
+
+  test('omitting telegramBotToken on a re-run preserves the existing slot', async () => {
+    await writeSecrets(root, { apiKey: 'fw1', telegramBotToken: '111:old' })
+    await writeSecrets(root, { apiKey: 'fw2' })
+
+    const secrets = await readSecrets(root)
+    expect(secrets.channels?.['telegram-bot']).toEqual({ token: { value: '111:old' } })
+  })
+
+  test('runInit with withDiscord=true and no token wires the adapter in typeclaw.json without overwriting the existing slot', async () => {
+    await writeSecrets(root, { apiKey: 'fw_seed', discordBotToken: 'discord-existing' })
+
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_seed',
+      withDiscord: true,
+      runHatching: okHatch,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+    })
+
+    const config = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
+      channels?: Record<string, unknown>
+    }
+    expect(config.channels?.['discord-bot']).toEqual({})
+
+    const secrets = await readSecrets(root)
+    expect(secrets.channels?.['discord-bot']).toEqual({ token: { value: 'discord-existing' } })
+  })
+
+  test('runInit with withSlack=true and no tokens wires slack without disturbing existing botToken/appToken', async () => {
+    await writeSecrets(root, { apiKey: 'fw_seed', slackBotToken: 'xoxb-existing', slackAppToken: 'xapp-existing' })
+
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_seed',
+      withSlack: true,
+      runHatching: okHatch,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+    })
+
+    const config = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
+      channels?: Record<string, unknown>
+    }
+    expect(config.channels?.['slack-bot']).toEqual({})
+
+    const secrets = await readSecrets(root)
+    expect(secrets.channels?.['slack-bot']).toEqual({
+      botToken: { value: 'xoxb-existing' },
+      appToken: { value: 'xapp-existing' },
+    })
+  })
+
+  test('runInit with withKakaotalk=true and no runKakaotalkAuth wires kakaotalk without re-authenticating', async () => {
+    await writeFile(
+      join(root, 'secrets.json'),
+      `${JSON.stringify(
+        {
+          version: 2,
+          providers: { fireworks: { type: 'api_key', key: { value: 'fw_seed' } } },
+          channels: {
+            kakaotalk: {
+              currentAccount: 'acc-1',
+              accounts: {
+                'acc-1': {
+                  account_id: 'acc-1',
+                  oauth_token: 'tok',
+                  user_id: 'u1',
+                  device_uuid: 'd1',
+                  device_type: 'tablet',
+                  created_at: '2026-01-01T00:00:00Z',
+                  updated_at: '2026-01-01T00:00:00Z',
+                },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_seed',
+      withKakaotalk: true,
+      runHatching: okHatch,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+    })
+
+    const config = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
+      channels?: Record<string, unknown>
+    }
+    expect(config.channels?.kakaotalk).toEqual({})
+
+    const secrets = await readSecrets(root)
+    expect(secrets.channels?.kakaotalk).toMatchObject({
+      currentAccount: 'acc-1',
+      accounts: { 'acc-1': { oauth_token: 'tok' } },
+    })
   })
 })
 

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1374,7 +1374,56 @@ describe('hasExistingChannelSecrets', () => {
     expect(await hasExistingChannelSecrets(root, 'discord')).toBe(false)
   })
 
-  test('returns true when kakaotalk has currentAccount with a matching accounts entry', async () => {
+  test('returns true when env-bound Secret is recorded under the field', async () => {
+    await seedChannels({ 'discord-bot': { token: { env: 'CUSTOM_DISCORD_ENV' } } })
+    expect(await hasExistingChannelSecrets(root, 'discord')).toBe(true)
+  })
+
+  test('returns true when slack-bot has BOTH fields env-bound', async () => {
+    await seedChannels({
+      'slack-bot': { botToken: { env: 'MY_SLACK_BOT' }, appToken: { env: 'MY_SLACK_APP' } },
+    })
+    expect(await hasExistingChannelSecrets(root, 'slack')).toBe(true)
+  })
+
+  test('returns true when slack-bot mixes value-bound and env-bound fields', async () => {
+    await seedChannels({
+      'slack-bot': { botToken: { value: 'xoxb-1' }, appToken: { env: 'MY_SLACK_APP' } },
+    })
+    expect(await hasExistingChannelSecrets(root, 'slack')).toBe(true)
+  })
+
+  test('returns true when kakaotalk has a full account record with renewal fields (email + encryptedPassword)', async () => {
+    await seedChannels({
+      kakaotalk: {
+        currentAccount: 'acc-1',
+        accounts: {
+          'acc-1': {
+            account_id: 'acc-1',
+            oauth_token: 'tok',
+            user_id: 'u1',
+            device_uuid: 'd1',
+            device_type: 'tablet',
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+            email: 'user@example.com',
+            encryptedPassword: {
+              v: 1,
+              alg: 'AES-256-GCM',
+              kid: 'k1',
+              iv: 'iv1',
+              ciphertext: 'ct1',
+              authTag: 'tag1',
+              createdAt: '2026-01-01T00:00:00Z',
+            },
+          },
+        },
+      },
+    })
+    expect(await hasExistingChannelSecrets(root, 'kakaotalk')).toBe(true)
+  })
+
+  test('returns false when kakaotalk account lacks renewal fields (legacy block, no unattended renewal possible)', async () => {
     await seedChannels({
       kakaotalk: {
         currentAccount: 'acc-1',
@@ -1391,7 +1440,7 @@ describe('hasExistingChannelSecrets', () => {
         },
       },
     })
-    expect(await hasExistingChannelSecrets(root, 'kakaotalk')).toBe(true)
+    expect(await hasExistingChannelSecrets(root, 'kakaotalk')).toBe(false)
   })
 
   test('returns false when kakaotalk currentAccount is null or missing from accounts', async () => {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -702,18 +702,22 @@ export async function readExistingProviderApiKey(root: string, providerId: Known
 }
 
 // Detects whether the requested channel already has usable credentials in
-// `secrets.json#channels`, so the init wizard can offer to reuse them instead
-// of re-prompting for tokens. Mirrors `readExistingProviderApiKey`: returns
-// `true` only when ALL fields required to wire the adapter are present and
-// non-empty. Partial slots (e.g. `slack-bot` with `botToken` but no
-// `appToken`) return `false` so the wizard falls through to the normal
-// prompts and the missing field gets filled in.
+// `secrets.json#channels`, so the init wizard can offer to reuse them
+// instead of re-prompting for tokens. Mirrors `readExistingProviderApiKey`:
+// returns `true` only when ALL fields the adapter needs are present in a
+// shape `hydrateChannelEnvFromSecrets` would inject at runtime — both the
+// `{ value }` form and the `{ env }` env-binding form count, matching the
+// runtime resolution rules in `src/secrets/resolve.ts`. Partial slots (e.g.
+// `slack-bot` with `botToken` but no `appToken`) return `false` so the
+// missing field gets filled in by the normal prompt.
 //
-// KakaoTalk is structured differently: a usable block requires a non-null
-// `currentAccount` with a matching entry in `accounts`. The token-renewal
-// pipeline can mint a fresh access_token from those without re-running
-// `attemptLogin`, so we treat any complete block as reusable regardless of
-// the `oauth_token`'s freshness.
+// KakaoTalk reuse is stricter: a usable block requires both a complete
+// account (currentAccount + matching entry in accounts) AND the renewal
+// fields (email + encryptedPassword) the hostd renewal cron needs to mint
+// fresh tokens unattended (`src/secrets/kakao-renewal.ts`). Without those,
+// the saved `oauth_token` will work only until KakaoTalk's ~7-day TTL
+// expires, after which the user has to run `typeclaw channel reauth
+// kakaotalk` anyway — better to re-auth now during init.
 export async function hasExistingChannelSecrets(
   root: string,
   channel: 'discord' | 'slack' | 'telegram' | 'kakaotalk',
@@ -722,14 +726,11 @@ export async function hasExistingChannelSecrets(
   if (channels === null) return false
   switch (channel) {
     case 'discord':
-      return resolvedSecretValue(channels['discord-bot'], 'token') !== null
+      return hasSecretField(channels['discord-bot'], 'token')
     case 'slack':
-      return (
-        resolvedSecretValue(channels['slack-bot'], 'botToken') !== null &&
-        resolvedSecretValue(channels['slack-bot'], 'appToken') !== null
-      )
+      return hasSecretField(channels['slack-bot'], 'botToken') && hasSecretField(channels['slack-bot'], 'appToken')
     case 'telegram':
-      return resolvedSecretValue(channels['telegram-bot'], 'token') !== null
+      return hasSecretField(channels['telegram-bot'], 'token')
     case 'kakaotalk': {
       const block = channels.kakaotalk
       if (!isObjectRecord(block)) return false
@@ -737,25 +738,31 @@ export async function hasExistingChannelSecrets(
       if (typeof current !== 'string' || current.length === 0) return false
       const accounts = (block as { accounts?: unknown }).accounts
       if (!isObjectRecord(accounts)) return false
-      return current in accounts
+      const account = accounts[current]
+      if (!isObjectRecord(account)) return false
+      const email = (account as { email?: unknown }).email
+      const encryptedPassword = (account as { encryptedPassword?: unknown }).encryptedPassword
+      return typeof email === 'string' && email.length > 0 && isObjectRecord(encryptedPassword)
     }
   }
 }
 
-// Returns the resolved Secret value (string shorthand or `{ value }` object)
-// from a channel slot, or null when the field is missing or empty. Empty
-// strings count as missing — same policy as resolveSecret's env-wins layer,
-// applied to the on-disk value alone (env resolution is not relevant at
-// init-time, where we're checking whether to re-prompt the user).
-function resolvedSecretValue(slot: unknown, field: string): string | null {
-  if (!isObjectRecord(slot)) return null
+// Accepts either the `{ value }` form (resolves to a literal at runtime) or
+// the `{ env }` form (resolves at runtime by reading `process.env[<env>]`).
+// String shorthand is sugar for `{ value }`. The schema already rejects
+// empty strings via `z.string().min(1)`, so the length checks here are
+// defense-in-depth against forward-compat shape drift.
+function hasSecretField(slot: unknown, field: string): boolean {
+  if (!isObjectRecord(slot)) return false
   const secret = slot[field]
-  if (typeof secret === 'string') return secret.length > 0 ? secret : null
+  if (typeof secret === 'string') return secret.length > 0
   if (isObjectRecord(secret)) {
     const value = (secret as { value?: unknown }).value
-    if (typeof value === 'string' && value.length > 0) return value
+    if (typeof value === 'string' && value.length > 0) return true
+    const env = (secret as { env?: unknown }).env
+    if (typeof env === 'string' && env.length > 0) return true
   }
-  return null
+  return false
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -121,6 +121,14 @@ export type InitOptions = {
   slackBotToken?: string
   slackAppToken?: string
   telegramBotToken?: string
+  // When reusing existing channel credentials from a pre-init `secrets.json`,
+  // the CLI passes `with<Adapter>: true` without a corresponding token so the
+  // scaffolded `typeclaw.json` wires the adapter while `writeSecrets` leaves
+  // the existing slot in `secrets.json#channels` untouched. Defaults below
+  // mirror the legacy derivation (`<token> !== undefined && !== ''`).
+  withDiscord?: boolean
+  withSlack?: boolean
+  withTelegram?: boolean
   withKakaotalk?: boolean
   runKakaotalkAuth?: KakaotalkAuthRunner
   onProgress?: (event: InitStepEvent) => void
@@ -146,6 +154,9 @@ export async function runInit({
   slackBotToken,
   slackAppToken,
   telegramBotToken,
+  withDiscord,
+  withSlack,
+  withTelegram,
   withKakaotalk = false,
   runKakaotalkAuth,
   onProgress,
@@ -208,9 +219,9 @@ export async function runInit({
     }
   }
 
-  const wantsDiscord = discordBotToken !== undefined && discordBotToken !== ''
-  const wantsSlack = slackBotToken !== undefined && slackBotToken !== ''
-  const wantsTelegram = telegramBotToken !== undefined && telegramBotToken !== ''
+  const wantsDiscord = withDiscord ?? (discordBotToken !== undefined && discordBotToken !== '')
+  const wantsSlack = withSlack ?? (slackBotToken !== undefined && slackBotToken !== '')
+  const wantsTelegram = withTelegram ?? (telegramBotToken !== undefined && telegramBotToken !== '')
   emit({ step: 'scaffold', phase: 'start' })
   await scaffold(cwd, {
     model,
@@ -688,6 +699,63 @@ export async function readExistingProviderApiKey(root: string, providerId: Known
   const provider = KNOWN_PROVIDERS[providerId]
   if (provider.apiKeyEnv === null) return null
   return new SecretsBackend(join(root, 'secrets.json')).tryReadProviderApiKeySync(providerId)
+}
+
+// Detects whether the requested channel already has usable credentials in
+// `secrets.json#channels`, so the init wizard can offer to reuse them instead
+// of re-prompting for tokens. Mirrors `readExistingProviderApiKey`: returns
+// `true` only when ALL fields required to wire the adapter are present and
+// non-empty. Partial slots (e.g. `slack-bot` with `botToken` but no
+// `appToken`) return `false` so the wizard falls through to the normal
+// prompts and the missing field gets filled in.
+//
+// KakaoTalk is structured differently: a usable block requires a non-null
+// `currentAccount` with a matching entry in `accounts`. The token-renewal
+// pipeline can mint a fresh access_token from those without re-running
+// `attemptLogin`, so we treat any complete block as reusable regardless of
+// the `oauth_token`'s freshness.
+export async function hasExistingChannelSecrets(
+  root: string,
+  channel: 'discord' | 'slack' | 'telegram' | 'kakaotalk',
+): Promise<boolean> {
+  const channels = new SecretsBackend(join(root, 'secrets.json')).tryReadChannelsSync()
+  if (channels === null) return false
+  switch (channel) {
+    case 'discord':
+      return resolvedSecretValue(channels['discord-bot'], 'token') !== null
+    case 'slack':
+      return (
+        resolvedSecretValue(channels['slack-bot'], 'botToken') !== null &&
+        resolvedSecretValue(channels['slack-bot'], 'appToken') !== null
+      )
+    case 'telegram':
+      return resolvedSecretValue(channels['telegram-bot'], 'token') !== null
+    case 'kakaotalk': {
+      const block = channels.kakaotalk
+      if (!isObjectRecord(block)) return false
+      const current = (block as { currentAccount?: unknown }).currentAccount
+      if (typeof current !== 'string' || current.length === 0) return false
+      const accounts = (block as { accounts?: unknown }).accounts
+      if (!isObjectRecord(accounts)) return false
+      return current in accounts
+    }
+  }
+}
+
+// Returns the resolved Secret value (string shorthand or `{ value }` object)
+// from a channel slot, or null when the field is missing or empty. Empty
+// strings count as missing — same policy as resolveSecret's env-wins layer,
+// applied to the on-disk value alone (env resolution is not relevant at
+// init-time, where we're checking whether to re-prompt the user).
+function resolvedSecretValue(slot: unknown, field: string): string | null {
+  if (!isObjectRecord(slot)) return null
+  const secret = slot[field]
+  if (typeof secret === 'string') return secret.length > 0 ? secret : null
+  if (isObjectRecord(secret)) {
+    const value = (secret as { value?: unknown }).value
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return null
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

`typeclaw init` already detects an existing provider API key in `secrets.json` and offers to reuse it instead of re-prompting. This PR extends the same behavior to channel credentials so a user who re-runs init in an agent folder that already has Slack / Discord / Telegram / KakaoTalk wired up doesn't have to re-enter tokens or re-authenticate KakaoTalk.

## Behavior

After picking a channel, the wizard checks `secrets.json#channels` for a **complete** slot:

| Channel | Required field(s) |
|---|---|
| discord | `discord-bot.token` |
| slack | `slack-bot.botToken` **and** `slack-bot.appToken` |
| telegram | `telegram-bot.token` |
| kakaotalk | `kakaotalk.currentAccount` resolves to an entry in `kakaotalk.accounts` |

When present, the wizard asks ``Reuse existing X credentials from secrets.json?``:
- **Accept** → skips the channel sub-flow entirely; the existing slot in `secrets.json` is left untouched, and the wizard wires the adapter into the freshly-scaffolded `typeclaw.json` via new ``with<Adapter>`` flags on ``runInit``.
- **Decline** → falls through to the normal token prompts (re-overwrites the slot).
- **No usable slot present** → the reuse prompt is suppressed entirely; flow matches today's behavior exactly.

For KakaoTalk specifically, ``runKakaotalkAuth`` is **omitted** on the reuse path so the renewal cron can mint a fresh ``access_token`` from the saved ``device_uuid`` + ``encryptedPassword`` instead of replaying ``attemptLogin`` during init. Partial slack-bot slots (e.g. ``botToken`` set but no ``appToken``) are treated as "not reusable" so the missing field gets filled in by the normal prompt.

## Design notes

- ``writeSecrets`` already preserves existing channel fields when no new token is passed — that "no token = leave slot untouched" merge does the heavy lifting on the ``secrets.json`` side. The only structural change is decoupling the **"wire this adapter in ``typeclaw.json``"** decision from **"do I have a fresh token to write"**: ``runInit`` gains explicit ``withDiscord`` / ``withSlack`` / ``withTelegram`` options, defaulting to the legacy ``<token> !== undefined && !== ''`` derivation so existing callers (incl. tests) are unaffected.
- The wizard tracks ``channelReuseOffered`` separately from ``channelReuseExisting`` so back-navigation from ``channel-flow`` doesn't infinite-loop through an auto-skipped ``reuse-existing-channel`` step when no reuse was available.
- New ``hasExistingChannelSecrets(root, channel)`` helper mirrors ``readExistingProviderApiKey``: read-only, defensive (returns ``false`` when ``secrets.json`` doesn't exist), and the only consumer is the wizard.

## Test plan

- **New wizard tests** in ``src/cli/init.test.ts`` cover the reuse-accept / reuse-decline / no-reuse-available / back-from-reuse / back-from-channel-flow / channel-change-clears-state matrix.
- **New helper tests** in ``src/init/index.test.ts`` cover ``hasExistingChannelSecrets`` for every channel type, including the partial-slack-slot edge case and the kakaotalk ``currentAccount``-must-exist-in-``accounts`` invariant.
- **New pipeline tests** prove that ``runInit({ withDiscord: true })`` (no ``discordBotToken``) writes ``channels.discord-bot: {}`` into ``typeclaw.json`` while leaving ``secrets.json#channels.discord-bot.token`` exactly as it was. Same for slack and kakaotalk.
- **Mutation check passes:** reverting the new ``withDiscord ??`` derivation in ``runInit`` breaks the "wires the adapter without overwriting" test.
- All 3476 existing tests still pass; typecheck, lint (0 errors, 8 pre-existing warnings in unrelated files), and format are clean.