### PR TITLE
Look up memory-logger watermark across prior daily streams

### DIFF
--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -341,6 +341,38 @@ describe('memoryLoggerSubagent', () => {
     expect(runSessionCalls[0]!.userPrompt!).toContain('watermrk')
   })
 
+  test("handler picks up YESTERDAY'S watermark when today's stream is missing (midnight-rollover case)", async () => {
+    const agentDir = makeAgentDir()
+    const transcript = join(agentDir, 'sessions', 'ses_abc.jsonl')
+    writeFileSync(transcript, '')
+    const today = formatLocalDate()
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    const yyyy = yesterday.getFullYear()
+    const mm = String(yesterday.getMonth() + 1).padStart(2, '0')
+    const dd = String(yesterday.getDate()).padStart(2, '0')
+    const yesterdayName = `${yyyy}-${mm}-${dd}.md`
+    expect(yesterdayName).not.toBe(`${today}.md`)
+    writeFileSync(
+      join(agentDir, 'memory', yesterdayName),
+      [
+        '<!-- fragment source=ses_abc entry=yesterday-morning -->',
+        '## body',
+        '',
+        '<!-- watermark source=ses_abc entry=yesterday-evening -->',
+        '',
+      ].join('\n'),
+    )
+
+    const { runSessionCalls } = await invokeWith(
+      { parentSessionId: 'ses_abc', parentTranscriptPath: transcript, agentDir },
+      agentDir,
+    )
+
+    const prompt = runSessionCalls[0]!.userPrompt!
+    expect(prompt).toContain('yesterday-evening')
+    expect(prompt).not.toContain('Watermark: none')
+  })
+
   test('handler instructs the subagent to write a trailing watermark marker on every run', async () => {
     const agentDir = makeAgentDir()
     const transcript = join(agentDir, 'sessions', 'ses_abc.jsonl')

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -8,7 +8,7 @@ import { formatLocalDate } from '@/shared'
 
 import { appendTool } from './append-tool'
 import { findEntryTool } from './find-entry-tool'
-import { readWatermark } from './watermark'
+import { readLatestWatermark } from './watermark'
 
 export const memoryLoggerPayloadSchema = z.object({
   parentSessionId: z.string().min(1),
@@ -287,8 +287,9 @@ export function createMemoryLoggerSubagent(
     },
     handler: async (ctx, runSession) => {
       const today = formatLocalDate()
-      const streamFile = join(ctx.payload.agentDir, 'memory', `${today}.md`)
-      const watermark = readWatermark(streamFile, ctx.payload.parentSessionId)
+      const memoryDir = join(ctx.payload.agentDir, 'memory')
+      const streamFile = join(memoryDir, `${today}.md`)
+      const watermark = readLatestWatermark(memoryDir, ctx.payload.parentSessionId)
       const start = Date.now()
       logger.info(
         `[memory-logger] ${ctx.payload.parentSessionId} start stream=${today}.md watermark=${watermark ?? 'none'}`,

--- a/src/bundled-plugins/memory/watermark.test.ts
+++ b/src/bundled-plugins/memory/watermark.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { readWatermark } from './watermark'
+import { readLatestWatermark, readWatermarkFromFile } from './watermark'
 
 function tmpFile(content: string): string {
   const dir = mkdtempSync(join(tmpdir(), 'memory-watermark-'))
@@ -12,24 +12,30 @@ function tmpFile(content: string): string {
   return path
 }
 
-describe('readWatermark', () => {
+function tmpMemoryDir(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'memory-dir-'))
+  for (const [name, content] of Object.entries(files)) writeFileSync(join(dir, name), content)
+  return dir
+}
+
+describe('readWatermarkFromFile', () => {
   test('returns null when the file does not exist', () => {
-    expect(readWatermark(join(tmpdir(), 'does-not-exist-xyz.md'), 'ses_abc')).toBeNull()
+    expect(readWatermarkFromFile(join(tmpdir(), 'does-not-exist-xyz.md'), 'ses_abc')).toBeNull()
   })
 
   test('returns null when the file has no fragment markers', () => {
     const path = tmpFile('# 2026-04-27\n\nsome notes\n')
-    expect(readWatermark(path, 'ses_abc')).toBeNull()
+    expect(readWatermarkFromFile(path, 'ses_abc')).toBeNull()
   })
 
   test('returns null when markers exist only for a different session', () => {
     const path = tmpFile(['<!-- fragment source=ses_xyz entry=11111111 -->', '## something', 'content', ''].join('\n'))
-    expect(readWatermark(path, 'ses_abc')).toBeNull()
+    expect(readWatermarkFromFile(path, 'ses_abc')).toBeNull()
   })
 
   test('returns the entry id when a single matching marker exists', () => {
     const path = tmpFile(['<!-- fragment source=ses_abc entry=a3f9c2d1 -->', '## topic', 'body', ''].join('\n'))
-    expect(readWatermark(path, 'ses_abc')).toBe('a3f9c2d1')
+    expect(readWatermarkFromFile(path, 'ses_abc')).toBe('a3f9c2d1')
   })
 
   test('returns the LAST entry id when multiple markers for the same session exist', () => {
@@ -49,17 +55,17 @@ describe('readWatermark', () => {
         '',
       ].join('\n'),
     )
-    expect(readWatermark(path, 'ses_abc')).toBe('33333333')
+    expect(readWatermarkFromFile(path, 'ses_abc')).toBe('33333333')
   })
 
   test('does not match when source value is a prefix of the requested session id', () => {
     const path = tmpFile(['<!-- fragment source=ses_a entry=00000001 -->', '## prefix', ''].join('\n'))
-    expect(readWatermark(path, 'ses_abc')).toBeNull()
+    expect(readWatermarkFromFile(path, 'ses_abc')).toBeNull()
   })
 
   test('recognizes a bare watermark marker (no fragment body) as a valid watermark', () => {
     const path = tmpFile('<!-- watermark source=ses_abc entry=quietday -->\n')
-    expect(readWatermark(path, 'ses_abc')).toBe('quietday')
+    expect(readWatermarkFromFile(path, 'ses_abc')).toBe('quietday')
   })
 
   test('the latest marker wins regardless of whether it is a fragment or a bare watermark', () => {
@@ -77,7 +83,7 @@ describe('readWatermark', () => {
         '',
       ].join('\n'),
     )
-    expect(readWatermark(path, 'ses_abc')).toBe('33333333')
+    expect(readWatermarkFromFile(path, 'ses_abc')).toBe('33333333')
   })
 
   test('fragment markers with a trailing certainty attribute still match', () => {
@@ -86,6 +92,105 @@ describe('readWatermark', () => {
         '\n',
       ),
     )
-    expect(readWatermark(path, 'ses_abc')).toBe('cert0001')
+    expect(readWatermarkFromFile(path, 'ses_abc')).toBe('cert0001')
+  })
+})
+
+describe('readLatestWatermark', () => {
+  test('returns null when the memory dir does not exist', () => {
+    expect(readLatestWatermark(join(tmpdir(), 'no-such-memory-dir-xyz'), 'ses_abc')).toBeNull()
+  })
+
+  test('returns null when the memory dir is empty', () => {
+    const dir = tmpMemoryDir({})
+    expect(readLatestWatermark(dir, 'ses_abc')).toBeNull()
+  })
+
+  test("returns today's watermark when today's stream exists with a marker", () => {
+    const dir = tmpMemoryDir({
+      '2026-05-16.md': '<!-- watermark source=ses_abc entry=today-id -->\n',
+    })
+    expect(readLatestWatermark(dir, 'ses_abc')).toBe('today-id')
+  })
+
+  test("returns YESTERDAY'S watermark when today's stream does not exist (the midnight-rollover case)", () => {
+    const dir = tmpMemoryDir({
+      '2026-05-15.md': [
+        '<!-- fragment source=ses_abc entry=morning-id -->',
+        '## body',
+        '',
+        '<!-- watermark source=ses_abc entry=evening-id -->',
+        '',
+      ].join('\n'),
+    })
+    expect(readLatestWatermark(dir, 'ses_abc')).toBe('evening-id')
+  })
+
+  test("returns yesterday's watermark when today's stream exists but has none for this session", () => {
+    const dir = tmpMemoryDir({
+      '2026-05-15.md': '<!-- watermark source=ses_abc entry=yesterday-id -->\n',
+      '2026-05-16.md': '<!-- watermark source=ses_other entry=different-session -->\n',
+    })
+    expect(readLatestWatermark(dir, 'ses_abc')).toBe('yesterday-id')
+  })
+
+  test("prefers today's watermark over yesterday's when both contain markers for the session", () => {
+    const dir = tmpMemoryDir({
+      '2026-05-15.md': '<!-- watermark source=ses_abc entry=yesterday-id -->\n',
+      '2026-05-16.md': '<!-- watermark source=ses_abc entry=today-id -->\n',
+    })
+    expect(readLatestWatermark(dir, 'ses_abc')).toBe('today-id')
+  })
+
+  test('walks back past empty / unrelated daily streams until it finds a matching marker', () => {
+    const dir = tmpMemoryDir({
+      '2026-05-13.md': '<!-- watermark source=ses_abc entry=oldest -->\n',
+      '2026-05-14.md': '# nothing for us today\n',
+      '2026-05-15.md': '<!-- watermark source=ses_other entry=different-session -->\n',
+      '2026-05-16.md': '',
+    })
+    expect(readLatestWatermark(dir, 'ses_abc')).toBe('oldest')
+  })
+
+  test('returns null when no daily stream contains a marker for this session', () => {
+    const dir = tmpMemoryDir({
+      '2026-05-14.md': '<!-- watermark source=ses_other entry=different-session -->\n',
+      '2026-05-15.md': '# unrelated content\n',
+    })
+    expect(readLatestWatermark(dir, 'ses_abc')).toBeNull()
+  })
+
+  test('ignores non-YYYY-MM-DD markdown files in memory/', () => {
+    const dir = tmpMemoryDir({
+      'README.md': '<!-- watermark source=ses_abc entry=should-be-ignored -->\n',
+      'notes.md': '<!-- watermark source=ses_abc entry=also-ignored -->\n',
+      '2026-05-15.md': '<!-- watermark source=ses_abc entry=picked -->\n',
+    })
+    expect(readLatestWatermark(dir, 'ses_abc')).toBe('picked')
+  })
+
+  test('ignores non-markdown files and subdirectories in memory/', () => {
+    const dir = tmpMemoryDir({
+      '.dreaming-state.json': '{"days":{"2026-05-15":42}}',
+      '2026-05-15.md': '<!-- watermark source=ses_abc entry=found -->\n',
+    })
+    mkdirSync(join(dir, 'skills'))
+    writeFileSync(join(dir, 'skills', 'something.md'), '<!-- watermark source=ses_abc entry=in-subdir -->\n')
+    expect(readLatestWatermark(dir, 'ses_abc')).toBe('found')
+  })
+
+  test("uses the LAST marker within a file once it picks that file (so today's last is preferred to today's first)", () => {
+    const dir = tmpMemoryDir({
+      '2026-05-16.md': [
+        '<!-- fragment source=ses_abc entry=morning -->',
+        '## a',
+        '',
+        '<!-- fragment source=ses_abc entry=midday -->',
+        '## b',
+        '',
+        '<!-- watermark source=ses_abc entry=latest -->',
+      ].join('\n'),
+    })
+    expect(readLatestWatermark(dir, 'ses_abc')).toBe('latest')
   })
 })

--- a/src/bundled-plugins/memory/watermark.ts
+++ b/src/bundled-plugins/memory/watermark.ts
@@ -1,8 +1,14 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
 const WATERMARK_MARKER = /<!--\s*(?:fragment|watermark)\s+source=(\S+)\s+entry=(\S+)(?:\s+\S+=\S+)*\s*-->/g
 
-export function readWatermark(streamFilePath: string, parentSessionId: string): string | null {
+// Daily stream files are named `YYYY-MM-DD.md` (see `formatLocalDate` in
+// `src/shared`). The cross-day lookup ignores any other `.md` file the user
+// or a plugin may have dropped into `memory/`.
+const DAILY_STREAM_NAME = /^\d{4}-\d{2}-\d{2}\.md$/
+
+export function readWatermarkFromFile(streamFilePath: string, parentSessionId: string): string | null {
   if (!existsSync(streamFilePath)) return null
   const content = readFileSync(streamFilePath, 'utf8')
 
@@ -12,4 +18,39 @@ export function readWatermark(streamFilePath: string, parentSessionId: string): 
     if (source === parentSessionId) lastEntryId = entry ?? null
   }
   return lastEntryId
+}
+
+// Returns the latest watermark entry id for `parentSessionId` across all
+// `YYYY-MM-DD.md` daily-stream files under `memoryDir`, walking newest-first
+// (by filename, which is equivalent to chronological order). Short-circuits
+// on the first file that contains a matching marker — for the common case
+// where memory-logger ran yesterday, this reads exactly one file.
+//
+// Why cross-day: channel sessions (Slack, Discord, KakaoTalk) routinely
+// survive the midnight rollover because the same human keeps the same
+// session alive across days. If `readWatermark` only looked at today's
+// stream file, every midnight would force a full transcript reread for
+// every long-lived session — burning ~135k input tokens per memory-logger
+// run on a 762KB transcript (observed on a real Discord agent: PR #207).
+//
+// The append target stays today's file; only the lookup crosses the day
+// boundary. This means yesterday's stream is treated as read-only history,
+// which it already is by construction (dreaming snapshots full days, never
+// touches in-progress days).
+export function readLatestWatermark(memoryDir: string, parentSessionId: string): string | null {
+  if (!existsSync(memoryDir)) return null
+  let entries: string[]
+  try {
+    entries = readdirSync(memoryDir)
+  } catch {
+    return null
+  }
+  const dailyStreams = entries
+    .filter((name) => DAILY_STREAM_NAME.test(name))
+    .sort((a, b) => (a < b ? 1 : a > b ? -1 : 0))
+  for (const name of dailyStreams) {
+    const watermark = readWatermarkFromFile(join(memoryDir, name), parentSessionId)
+    if (watermark !== null) return watermark
+  }
+  return null
 }


### PR DESCRIPTION
## Problem

PR #206 fixed two real bugs in the memory-logger stack — the `$schema` Ajv rejection that broke `find_entry`, and the missing byte-budget ceiling that let a single run balloon to 800 KB of transcript. Those fixes restored normal behavior for in-day sessions. But after #206 landed, the user's `servant` Discord agent still burned $0.376 over 36 messages with only 75% cache hit rate during the 2026-05-16 00:00 KST day rollover. Two memory-logger runs spawned within 53 seconds of each other for the same 2026-05-02 session, each burning ~135K input tokens before the 256 KB budget short-circuited. Neither run wrote a fragment or watermark before exiting.

**#206 fixed two bugs but the user's pain wasn't fully resolved. This PR fixes the third bug that was masked by the first two.**

## Root cause

`src/bundled-plugins/memory/watermark.ts:readWatermark()` only ever scanned today's `memory/YYYY-MM-DD.md` file. For channel sessions (Slack/Discord/KakaoTalk) that survive midnight rollover — and the same human keeping a Discord channel alive across days IS the common case, not the edge case — today's stream file does not exist yet when the first memory-logger run of the new day fires. The lookup returns `null`, the initial prompt tells the subagent `"Watermark: none — read the transcript from the start"`, and the subagent reads the entire parent transcript in 50 KB chunks until the 256 KB tool-result budget (added in #206) short-circuits it.

## Observed evidence

At 2026-05-16 00:00 KST rollover on agent `servant`: two memory-logger runs spawned within 53 seconds of each other for the same 2026-05-02 channel session `019de9c6-7d97-7052-91c8-0520b0db5b17` (still active in Discord, 762 KB transcript). Both with "Watermark: none". Each burned ~135K input tokens across 9 chunked reads before the 256 KB budget short-circuited. **Neither run wrote a fragment or watermark before exiting**, so the next channel turn and the next midnight repeat the exact same waste.

The latest watermark we needed was one file away: yesterday's `memory/2026-05-15.md` had 13 watermarks for that session, the most recent being `entry=c251a198`.

## Why #206 didn't catch this

- The `$schema` fix lets `find_entry` compile, but `find_entry` is only called *if the subagent receives a watermark to seek to*. On day rollover it does not.
- The 256 KB byte budget is a blast-radius cap, not a low-token guarantee. Exhaustion is checked **after** a result is returned (`src/agent/tool-result-budget.ts:87-92`), so the budget overshoots by one chunk. Earlier tool results stay in conversation history and are re-sent on every later turn, so by the time the budget short-circuits on chunk 7, the model has already paid to re-send chunks 1-6 in turns 6-13.

## The fix

Replace single-file `readWatermark` with two functions:

```ts
readWatermarkFromFile(streamFilePath, parentSessionId): string | null
readLatestWatermark(memoryDir, parentSessionId):       string | null
```

`readLatestWatermark` lists `memoryDir`, keeps only `^\d{4}-\d{2}-\d{2}\.md$` files, sorts newest-first by filename (equivalent to chronological order because ISO dates sort lexicographically), walks them calling `readWatermarkFromFile` until it gets a non-null result. **Short-circuits on the first hit, so the common case reads exactly one file (yesterday's stream).** `memory-logger.ts` switches its single call site. The append target is unchanged — fragments still land in today's `memory/<today>.md`. Only the *lookup* crosses the day boundary.

## Why this is safe

- Yesterday's stream is already read-only by construction. `dreaming` snapshots whole days; nothing rewrites a closed day.
- Dreaming's per-day state in `memory/.dreaming-state.json` is independent and unchanged. It tracks line counts within each day, not entry ids of parent sessions. Verified by reading `src/bundled-plugins/memory/dreaming-state.ts` and `dreaming.ts`.
- The `^\d{4}-\d{2}-\d{2}\.md$` filter defends against user-dropped `.md` files (e.g. personal `NOTES.md`) and the `skills/` subdirectory.
- No walk-back horizon. Short-circuits on first hit, so typical cost is O(1) file reads regardless of how long the agent has been alive.

## Self-review (Oracle)

I ran the oracle subagent against my diagnosis before writing the fix. Oracle confirmed: (1) diagnosis correct, day-scoped lookup is the primary cost driver, (2) walking back across daily-stream files does not break dreaming, (3) flagged a separate bug worth filing as a follow-up — `raceSpawn`'s 50s timeout in `src/bundled-plugins/memory/index.ts:24-36, 284-294` detaches the chain without cancelling the underlying subagent, which is why two parallel memory-logger runs were observed for the same session rather than one, (4) the budget code is structurally correct, no bug there.

## Tests

- `src/bundled-plugins/memory/watermark.test.ts` — **+12** new tests for `readLatestWatermark` covering: missing dir, empty dir, today-only, yesterday-only (rollover), today-empty fallback, today-vs-yesterday precedence, walking past empty/unrelated streams, no-match-anywhere, ignoring non-`YYYY-MM-DD` `.md` files (e.g. `README.md`, `notes.md`), ignoring `.dreaming-state.json` and `skills/` subdir, picking the last marker within a file. All existing single-file tests preserved under the new `readWatermarkFromFile` name.
- `src/bundled-plugins/memory/memory-logger.test.ts` — **+1** integration test: seeds yesterday's stream with a watermark, leaves today's stream missing, asserts the handler's initial prompt contains the yesterday entry id and does NOT contain "Watermark: none".

Net **+22** tests vs base (3445 → 3467 pass).

## Manual QA

I ran an out-of-tree script against the actual production data shape (real session id `019de9c6-7d97-7052-91c8-0520b0db5b17`, real watermark `c251a198` from the user's `2026-05-15.md`). All four scenarios pass:

```
watermark after midnight rollover (no today.md): c251a198    PASS
watermark when today has its own marker:         todays-new  PASS
watermark when today is empty:                   c251a198    PASS
watermark for unknown session:                   null        PASS
```

## Verification

```
$ bun run check
✓ tsgo --noEmit
✓ oxlint  Found 8 warnings and 0 errors  (pre-existing, unrelated)
✓ oxfmt --check  All matched files use the correct format

$ bun test
3467 pass · 0 fail · 7065 expect() calls
Ran 3467 tests across 206 files
```

## Expected impact

For long-lived channel sessions crossing midnight, the bottleneck shifts from "memory-logger rereads 762 KB parent transcript in 9 chunks" to "memory-logger does one `find_entry` + one targeted `read` from yesterday's known watermark". Predicted input-token reduction for the rollover-window memory-logger run: **~135K → ~3-5K**, matching the in-day steady state.

## Out of scope (follow-ups)

- **Spawn-chain orphan detachment (oracle Q3 finding).** `raceSpawn`'s 50s timeout in `src/bundled-plugins/memory/index.ts` detaches the chain without cancelling the LLM stream, so two memory-logger runs can be in flight for the same session. Today this is why ONE bad rollover produced TWO runaway runs. Worth a separate PR — fix needs cancellation plumbing through `ctx.spawnSubagent` and `pi-coding-agent`'s `session.prompt`, both upstream-shaped.
- **`memoryLoggerExhaustedMessage` recovery path.** When budget exhausts after some content was seen, the subagent CAN write a watermark, but observed runs took the silent-exit path. Once this PR lands, this case becomes much rarer (you only hit the budget when the watermark is genuinely far behind), but the recovery message could be tightened.