### PR TITLE
Auto-commit typeclaw.json after model and channel CLI mutations

### DIFF
--- a/src/config/models-mutation.test.ts
+++ b/src/config/models-mutation.test.ts
@@ -177,3 +177,64 @@ describe('listModelProfiles', () => {
     expect(vision?.credentialStatus).toBe('available')
   })
 })
+
+describe('auto-commit on success', () => {
+  async function runGit(cwd: string, args: string[]): Promise<string> {
+    const proc = Bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+    await proc.exited
+    return (await new Response(proc.stdout).text()).trim()
+  }
+
+  async function initGit(cwd: string): Promise<void> {
+    for (const cmd of [
+      ['init', '-b', 'main'],
+      ['config', 'user.name', 'Test User'],
+      ['config', 'user.email', 'test@example.com'],
+      ['add', '.'],
+      ['commit', '-m', 'initial'],
+    ]) {
+      const proc = Bun.spawn({ cmd: ['git', ...cmd], cwd, stdout: 'pipe', stderr: 'pipe' })
+      await proc.exited
+    }
+  }
+
+  test('setProfile commits typeclaw.json with a "model: set" subject', async () => {
+    await initGit(root)
+    const result = setProfile(root, 'default', 'openai/gpt-5.4-nano', { env: { OPENAI_API_KEY: 'x' } })
+    expect(result.ok).toBe(true)
+    expect(await runGit(root, ['log', '-1', '--format=%s'])).toBe('model: set default → openai/gpt-5.4-nano')
+    expect(await runGit(root, ['show', '--name-only', '--format=', 'HEAD'])).toBe('typeclaw.json')
+  })
+
+  test('addProfile commits typeclaw.json with a "model: add" subject', async () => {
+    await initGit(root)
+    const result = addProfile(root, 'fast', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    expect(result.ok).toBe(true)
+    expect(await runGit(root, ['log', '-1', '--format=%s'])).toBe(
+      'model: add fast → fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+    )
+  })
+
+  test('removeProfile commits typeclaw.json with a "model: remove" subject', async () => {
+    addProfile(root, 'fast', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    await initGit(root)
+    const result = removeProfile(root, 'fast')
+    expect(result.ok).toBe(true)
+    expect(await runGit(root, ['log', '-1', '--format=%s'])).toBe('model: remove fast')
+  })
+
+  test('no-ops when the folder is not a git repo (mutation-check anchor for the commit call)', async () => {
+    const before = await readFile(join(root, 'typeclaw.json'), 'utf8')
+    const result = setProfile(root, 'default', 'openai/gpt-5.4-nano', { env: { OPENAI_API_KEY: 'x' } })
+    expect(result.ok).toBe(true)
+    expect(await readFile(join(root, 'typeclaw.json'), 'utf8')).not.toBe(before)
+  })
+
+  test('failed mutation does not produce a commit', async () => {
+    await initGit(root)
+    const head = await runGit(root, ['rev-parse', 'HEAD'])
+    const result = setProfile(root, 'default', 'mystery/model')
+    expect(result.ok).toBe(false)
+    expect(await runGit(root, ['rev-parse', 'HEAD'])).toBe(head)
+  })
+})

--- a/src/config/models-mutation.ts
+++ b/src/config/models-mutation.ts
@@ -1,6 +1,8 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { commitSystemFileSync } from '@/git/system-commit'
+
 import { configSchema, loadConfigSync, validateConfig } from './config'
 import {
   KNOWN_PROVIDERS,
@@ -87,7 +89,9 @@ export function setProfile(
     }
   }
 
-  return writeProfile(cwd, trimmed, ref)
+  const existingBefore = readModelsRaw(cwd)
+  const verb = existingBefore !== null && trimmed in existingBefore ? 'set' : 'add'
+  return writeProfile(cwd, trimmed, ref, `model: ${verb} ${trimmed} → ${ref}`)
 }
 
 // `add` is just `set` with a uniqueness guard; users who want "update" should
@@ -130,19 +134,19 @@ export function removeProfile(cwd: string, profile: string): ModelMutationResult
   }
   const next = { ...existing }
   delete next[profile]
-  return writeModels(cwd, next)
+  return writeModels(cwd, next, `model: remove ${profile}`)
 }
 
-function writeProfile(cwd: string, profile: string, ref: KnownModelRef): ModelMutationResult {
+function writeProfile(cwd: string, profile: string, ref: KnownModelRef, message: string): ModelMutationResult {
   const existing = readModelsRaw(cwd)
   const next = existing === null ? { default: ref } : { ...existing, [profile]: ref }
   if (existing === null && profile !== 'default') {
     next.default = ref
   }
-  return writeModels(cwd, next)
+  return writeModels(cwd, next, message)
 }
 
-function writeModels(cwd: string, models: Record<string, string>): ModelMutationResult {
+function writeModels(cwd: string, models: Record<string, string>, commitMessage: string): ModelMutationResult {
   const path = join(cwd, CONFIG_FILE)
   let parsed: Record<string, unknown>
   try {
@@ -176,6 +180,11 @@ function writeModels(cwd: string, models: Record<string, string>): ModelMutation
   if (!validation.ok) {
     return { ok: false, reason: validation.reason }
   }
+  // Auto-commit so the agent folder is never silently dirty after a CLI
+  // config mutation. Same pattern as `persistMigratedConfig` and cron
+  // migrations: `commitSystemFileSync` no-ops on non-git folders, missing
+  // Bun, and clean files, so callers outside a git repo pay zero cost.
+  commitSystemFileSync(cwd, CONFIG_FILE, commitMessage)
   return { ok: true }
 }
 

--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -260,6 +260,50 @@ describe('runAddChannel', () => {
   })
 })
 
+describe('auto-commit on success', () => {
+  async function runGit(cwd: string, args: string[]): Promise<string> {
+    const proc = Bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+    await proc.exited
+    return (await new Response(proc.stdout).text()).trim()
+  }
+
+  async function initGit(cwd: string): Promise<void> {
+    for (const cmd of [
+      ['init', '-b', 'main'],
+      ['config', 'user.name', 'Test User'],
+      ['config', 'user.email', 'test@example.com'],
+      ['add', '.'],
+      ['commit', '-m', 'initial'],
+    ]) {
+      const proc = Bun.spawn({ cmd: ['git', ...cmd], cwd, stdout: 'pipe', stderr: 'pipe' })
+      await proc.exited
+    }
+  }
+
+  test('commits typeclaw.json with a "channel: add <kind>" subject', async () => {
+    await initGit(root)
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-x' })
+
+    expect(await runGit(root, ['log', '-1', '--format=%s'])).toBe('channel: add discord-bot')
+    expect(await runGit(root, ['show', '--name-only', '--format=', 'HEAD'])).toBe('typeclaw.json')
+  })
+
+  test('failed channel add (kakaotalk auth rejects) does NOT produce a commit', async () => {
+    await initGit(root)
+    const head = await runGit(root, ['rev-parse', 'HEAD'])
+
+    await expect(
+      runAddChannel({
+        cwd: root,
+        channel: 'kakaotalk',
+        runKakaotalkAuth: async () => ({ ok: false, reason: 'nope' }),
+      }),
+    ).rejects.toThrow(/nope/)
+
+    expect(await runGit(root, ['rev-parse', 'HEAD'])).toBe(head)
+  })
+})
+
 describe('readConfiguredChannels', () => {
   test('returns empty set when no channels are configured', async () => {
     const present = await readConfiguredChannels(root)

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -12,6 +12,7 @@ import {
   type KnownProviderId,
 } from '@/config/providers'
 import { checkDockerAvailable, type DockerAvailability, type DockerExec, start } from '@/container'
+import { commitSystemFile } from '@/git/system-commit'
 import { createSecretsStoreForAgent, type Channels, type Secret, SecretsBackend } from '@/secrets'
 import { createTui } from '@/tui'
 
@@ -860,6 +861,13 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
     await appendChannelSecrets(options.cwd, options.channel, tokens)
   }
   emit({ step: 'secrets', phase: 'done' })
+
+  // Commit the typeclaw.json change so the agent folder isn't silently
+  // dirty after `typeclaw channel add`. Same `commitSystemFile` contract as
+  // every other host-side rewrite: no-op outside a git repo, when Bun is
+  // unavailable, or when the file is clean. secrets.json is gitignored, so
+  // only typeclaw.json is named here.
+  await commitSystemFile(options.cwd, CONFIG_FILE, `channel: add ${options.channel}`)
 }
 
 function channelSecretsFromOptions(options: AddChannelOptions): ChannelSecrets {


### PR DESCRIPTION
## Summary

- `typeclaw model set/add/remove` and `typeclaw channel add` left `typeclaw.json` dirty in git, so user-driven model and channel changes silently mixed into unrelated commits or required a manual `git add` step. This PR closes that gap by auto-committing the file immediately after each successful mutation.
- The "never silently dirty" invariant is already enforced for `typeclaw.json` migrations (`persistMigratedConfig`) and `cron.json` migrations. This PR extends the same discipline to the interactive CLI mutation surface, making the policy consistent across every code path that writes `typeclaw.json`.
- Auto-commit is a no-op outside a git repo, when Bun is unavailable, or when the file is already clean, so the behavior is additive and safe for non-git agent folders.

## What changes

| File | Description |
|---|---|
| `src/config/models-mutation.ts` | Thread the commit subject through `writeProfile`/`writeModels` and call `commitSystemFileSync` on success |
| `src/config/models-mutation.test.ts` | New auto-commit suite: `setProfile`, `addProfile`, `removeProfile` subjects; no-git no-op; failure-doesn't-commit |
| `src/init/index.ts` | Call `commitSystemFile` at the end of `runAddChannel` with subject `channel: add <kind>` |
| `src/init/add-channel.test.ts` | New auto-commit suite: discord-bot subject shape; failed KakaoTalk auth doesn't commit |

## Why not provider or role?

`typeclaw provider add/set/remove` writes to `secrets.json`, which is gitignored — there is nothing to commit. `typeclaw role claim` writes `typeclaw.json` from inside the running container via an agent tool, not from the host CLI; the host-side `commitSystemFileSync` primitive is not available in that execution context, and the container's git environment is a separate concern. Both cases are intentionally out of scope for this PR.

## Test plan

New tests are in `src/config/models-mutation.test.ts` (auto-commit suite) and `src/init/add-channel.test.ts` (auto-commit suite). Coverage includes:

- Correct commit subject for each verb: `model: set <profile> → <ref>`, `model: add <profile> → <ref>`, `model: remove <profile>`, `channel: add <kind>`
- No commit is issued when the mutation itself fails (e.g. failed KakaoTalk auth)
- No commit is issued when the working directory is not a git repo (`commitSystemFileSync` no-ops)

```sh
bun run typecheck     # clean
bun run lint          # 8 pre-existing warnings, 0 errors (same as main)
bun run format:check  # clean
bun test              # 3542 pass, 0 fail
```