### PR TITLE
Drop stale allow-list references in channel_send tool and kakaotalk comments

### DIFF
--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -33,9 +33,8 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
       'Post a message to an external messenger channel. Specify adapter, workspace, chat, and text. ' +
       'For Discord guild channels, workspace is the guild id; for Slack team channels, workspace is ' +
       'the team id (e.g. "T0ACME"). For DMs on either platform, workspace is the literal "@dm". ' +
-      'The runtime checks the channel allow rules before delivering — if the target chat is not in ' +
-      'the configured allow list, the call fails with { ok: false, error }. There is no auto-reply: ' +
-      'the only way for an agent to post is via this tool.',
+      'On failure (no adapter registered, or the adapter-level send failed), the call returns ' +
+      '{ ok: false, error }. There is no auto-reply: the only way for an agent to post is via this tool.',
     parameters: Type.Object({
       adapter: Type.Union(
         ADAPTER_IDS.map((a) => Type.Literal(a)),

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -317,7 +317,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
     // Stickers arrive on a separate listener event in agent-messenger
     // 2.15.0 and have no `message` field. We wrap them into the same
     // MSG-shaped payload classifyInbound expects so the engagement /
-    // allow-list / self-author rules apply identically across plain
+    // self-author / unknown-chat rules apply identically across plain
     // messages and stickers — there is no second classifier to keep in
     // sync.
     await processInbound(emoticonEventToMessageEvent(event))
@@ -332,10 +332,11 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
           // The push event itself proves the chat exists, even when
           // getChats({all:true}) does not surface it (e.g. memo chats,
           // certain open chats, recently-joined groups that haven't
-          // propagated). Register a provisional @kakao-group entry so the
-          // strictest allow rules still apply, but the message is no longer
-          // silently dropped as unknown_chat. The next real refresh
-          // upgrades the entry if the chat is actually a DM or open chat.
+          // propagated). Register a provisional @kakao-group entry (the
+          // strictest workspace bucket — narrowest engagement assumptions)
+          // so the message is no longer silently dropped as unknown_chat.
+          // The next real refresh upgrades the entry if the chat is
+          // actually a DM or open chat.
           channelResolver.ingestProvisional(event.chat_id)
           logger.warn(
             `[kakaotalk] provisional chat=${event.chat_id} log_id=${event.log_id} bucket=@kakao-group reason=not_in_getchats`,
@@ -353,7 +354,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
 
       // Ack the message BEFORE classify/route so the sender's unread "1"
       // (노란숫자) clears even when we drop the message (self-author,
-      // not-in-allow, empty text, etc.). The receiver of a kakao adapter is
+      // unknown chat, empty text, etc.). The receiver of a kakao adapter is
       // expected to behave like a "read it as soon as it arrives" client —
       // the agent has observed the bytes, so the user should see the read
       // acknowledgement regardless of what we decide to do with the message


### PR DESCRIPTION
## Summary

Phase 3 of the permissions migration (commit 8d1ec19, "Drop channels.<adapter>.allow[] from schema and adapter defense-in-depth checks") removed the per-adapter `channels.<adapter>.allow[]` config field and the `not_in_allow_list` drop reason from every adapter classifier. Wake-up gating moved to `permissions.has(origin, 'channel.respond')` at the channel router. Three stale references to the removed mechanism survived that cleanup and are fixed here.

## Fixed locations

**`src/agent/tools/channel-send.ts` lines 36–37** (LLM-visible tool description)

The description claimed "The runtime checks the channel allow rules before delivering — if the target chat is not in the configured allow list, the call fails". This is wrong: `router.send` only checks for a missing adapter registration and propagates adapter callback errors. There is no allow-list check on outbound. Replaced with the accurate failure-mode description.

**`src/channels/adapters/kakaotalk.ts` line 320** (sticker-event wrapper comment)

Listed `allow-list / self-author` as the rule set applied identically to plain messages and stickers. The kakaotalk classifier never had allow-list rules — only `self_author`, `empty_text`, `unknown_chat`, and `pre_connect`. Fixed to `self-author / unknown-chat`.

**`src/channels/adapters/kakaotalk.ts` line 336** (provisional-chat-registration comment)

Said "strictest allow rules still apply". Allow rules are gone; the strictness is the `@kakao-group` workspace bucket's narrow engagement assumptions. Reworded to reflect the actual invariant without the deprecated terminology.

**`src/channels/adapters/kakaotalk.ts` line 356** (ack-before-classify rationale)

Listed `not-in-allow` as a drop reason alongside `self-author` and `empty text`. Changed to `unknown chat`.

## Out of scope

- **Test fixture strings** — `router.test.ts`, `channel-send.test.ts`, `channel-reply.test.ts`, and `channel-tool-logging.test.ts` reference `'denied by allow rules'` as an opaque fake-router error string injected to verify that the tool propagates router errors verbatim. Not user-facing; no change needed.
- **Test name** in `router.test.ts:726` — "empty allow rules + observed-only burst" is stale terminology in a test name, but the body tests observed-only burst throttling. Renaming is cosmetic and out of scope.
- **Correctly-historical references** in `src/config/config.ts`, `AGENTS.md`, and the typeclaw-permissions skill — these describe the legacy field as deprecated/migrated and should stay.

## Diff stats

2 files changed, 9 insertions(+), 9 deletions(-) across 4 hunks.

## Verification

```
bun run typecheck   # clean
bun run lint        # 8 pre-existing warnings, 0 errors (unrelated)
bun run format      # clean
bun test src/agent/tools/channel-send.test.ts src/channels/adapters/kakaotalk.test.ts
# 54 pass / 0 fail
```