### PR TITLE
Surface typeclaw runtime version in the agent system prompt

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -152,6 +152,47 @@ describe('createResourceLoader', () => {
     expect(nudgeIdx).toBeLessThan(memoryIdx)
   })
 
+  test('omits the runtime block when runtimeVersion is not provided', async () => {
+    // given: no runtimeVersion option
+
+    // when
+    const loader = await createResourceLoader({ agentDir })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).not.toContain('## Runtime')
+    expect(prompt).not.toContain('TypeClaw runtime version')
+  })
+
+  test('renders the runtime block under "## Runtime" when runtimeVersion is provided', async () => {
+    // when
+    const loader = await createResourceLoader({ agentDir, runtimeVersion: '9.9.9' })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).toContain('## Runtime')
+    expect(prompt).toContain('TypeClaw runtime version: 9.9.9.')
+  })
+
+  test('runtime block sits BEFORE the origin block so version stays in the cache prefix relative to per-session origin churn', async () => {
+    // given: an origin (which renders the origin block via withOrigin) AND a
+    // runtimeVersion. The cache-suffix invariant requires the runtime block to
+    // precede the origin block — version changes are rarer than origin changes,
+    // and the cache hits up to the first byte that differs.
+    const origin: SessionOrigin = { kind: 'tui', sessionId: 'sess-runtime-order' }
+
+    // when
+    const loader = await createResourceLoader({ agentDir, origin, runtimeVersion: '9.9.9' })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    const runtimeIdx = prompt.indexOf('TypeClaw runtime version: 9.9.9.')
+    const originIdx = prompt.indexOf('## Session origin')
+    expect(runtimeIdx).toBeGreaterThan(-1)
+    expect(originIdx).toBeGreaterThan(-1)
+    expect(runtimeIdx).toBeLessThan(originIdx)
+  })
+
   test('full cache-suffix ordering: role block < gitNudge < memory section, when all three render', async () => {
     // given: dirty git repo (gitNudge renders), populated MEMORY.md (memory
     // section renders), and a channel origin with a permission service that

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -30,7 +30,7 @@ import { resolveBuiltinToolRefs, wrapPluginTool, wrapSystemAgentTool, wrapSystem
 import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
 import { renderSessionOrigin, type SessionOrigin, type SessionRoleContext } from './session-origin'
-import { DEFAULT_SYSTEM_PROMPT } from './system-prompt'
+import { DEFAULT_SYSTEM_PROMPT, renderRuntimeBlock } from './system-prompt'
 import {
   createBudgetState,
   type ToolResultBudget,
@@ -104,6 +104,13 @@ export type CreateSessionOptions = {
   // Enables the `restart` tool. Set when the agent is running inside a
   // typeclaw-managed container. Read from TYPECLAW_CONTAINER_NAME at the call site.
   containerName?: string
+  // The typeclaw runtime version (`package.json#version` of the executing
+  // CLI) to surface in the system prompt under `## Runtime`. Threaded from
+  // `startAgent` via `CLI_VERSION` so every session — TUI, channel, cron,
+  // plugin subagent — sees the same value. Omitted in stand-alone test
+  // callers, in which case the runtime block is skipped (no token cost, no
+  // misleading "unknown" value).
+  runtimeVersion?: string
   // The permission service the runtime resolved at boot. When provided, the
   // resolved role and permission list for `options.origin` are rendered into
   // the system prompt under `## Your role in this session`. The block is
@@ -171,11 +178,17 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
 
   const resourceLoader =
     options.systemPromptOverride !== undefined
-      ? await createOverrideResourceLoader(options.systemPromptOverride, options.origin, options.permissions)
+      ? await createOverrideResourceLoader(
+          options.systemPromptOverride,
+          options.origin,
+          options.permissions,
+          options.runtimeVersion,
+        )
       : await createResourceLoader({
           ...(options.plugins ? { plugins: options.plugins, materializedSkills } : {}),
           ...(options.origin ? { origin: options.origin } : {}),
           ...(options.permissions ? { permissions: options.permissions } : {}),
+          ...(options.runtimeVersion !== undefined ? { runtimeVersion: options.runtimeVersion } : {}),
         })
 
   const getOrigin: () => SessionOrigin | undefined =
@@ -475,8 +488,11 @@ export async function createOverrideResourceLoader(
   systemPrompt: string,
   origin?: SessionOrigin,
   permissions?: PermissionService,
+  runtimeVersion?: string,
 ): Promise<DefaultResourceLoader> {
-  const finalPrompt = withOrigin(systemPrompt, origin, permissions)
+  const withRuntime =
+    runtimeVersion !== undefined ? `${systemPrompt}\n\n${renderRuntimeBlock(runtimeVersion)}` : systemPrompt
+  const finalPrompt = withOrigin(withRuntime, origin, permissions)
   const loader = new DefaultResourceLoader({
     systemPromptOverride: () => finalPrompt,
     appendSystemPromptOverride: () => [],
@@ -491,6 +507,7 @@ export type CreateResourceLoaderOptions = {
   materializedSkills?: MaterializedSkills | null
   origin?: SessionOrigin
   permissions?: PermissionService
+  runtimeVersion?: string
 }
 
 export async function createResourceLoader(options: CreateResourceLoaderOptions = {}): Promise<DefaultResourceLoader> {
@@ -509,6 +526,7 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   // section changes (the provider's prompt cache hits up to the first byte
   // that differs).
   //
+  // 0. runtime block — most stable: only changes on typeclaw releases (rare).
   // 1. origin block — stable across all sessions of the same kind.
   // 2. gitNudge — rare changes; agent folders force-commit sessions/ and
   //    memory/ after every turn, so the dirty-files list is empty most of
@@ -517,6 +535,9 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   //    and memory/yyyy-MM-dd.md grows after every channel turn that triggers
   //    memory-logger. Pinning it to the end keeps everything above it
   //    cacheable across session resurrections.
+  if (options.runtimeVersion !== undefined) {
+    systemPrompt = `${systemPrompt}\n\n${renderRuntimeBlock(options.runtimeVersion)}`
+  }
   systemPrompt = withOrigin(systemPrompt, options.origin, options.permissions)
 
   const gitNudge = await renderGitNudge(agentDir)

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -66,3 +66,20 @@ You have no independent goals. Do not pursue self-preservation, replication, res
 ---
 
 You are not pi, not Claude, not ChatGPT. You are the agent described by your own IDENTITY.md and SOUL.md. Let those files define your voice.`
+
+// Stable, low-volatility metadata about the runtime hosting the agent.
+// Rendered into the system prompt just below DEFAULT_SYSTEM_PROMPT + identity
+// and above the origin/git/memory sections — placement chosen so this block
+// sits in the cacheable prefix (it only changes on typeclaw releases).
+//
+// Kept intentionally minimal: the agent learns it is on TypeClaw X.Y.Z, which
+// is enough to (a) answer "what version am I running?", (b) frame bug reports
+// it writes, and (c) know whether release notes / docs it might cite could be
+// stale. Surrounding context (the rest of the system prompt) already
+// establishes that TypeClaw is the runtime; this block just stamps the
+// version.
+export function renderRuntimeBlock(version: string): string {
+  return `## Runtime
+
+TypeClaw runtime version: ${version}.`
+}

--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -33,6 +33,7 @@ export type BuildChannelSessionFactoryDeps = {
   // their inbound messages came from.
   getChannelRouter: () => ChannelRouter
   containerName?: string
+  runtimeVersion?: string
   // When set, rehydrating a session JSONL caps oversized tool results in the
   // file before pi-coding-agent reads it. `null` disables the load-time pass
   // (tool-result-cap.enabled=false in config, or no plugin block at all).
@@ -105,6 +106,7 @@ export function buildChannelSessionFactory(deps: BuildChannelSessionFactoryDeps)
           }
         : {}),
       ...(deps.containerName !== undefined ? { containerName: deps.containerName } : {}),
+      ...(deps.runtimeVersion !== undefined ? { runtimeVersion: deps.runtimeVersion } : {}),
       ...(deps.permissions !== undefined ? { permissions: deps.permissions } : {}),
     })
 

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -24,6 +24,7 @@ import {
   loadCron as loadCronDefault,
   type Scheduler,
 } from '@/cron'
+import { CLI_VERSION } from '@/init/cli-version'
 import { loadPlugins, type LoadPluginsResult, pluginCronJobs, type PluginRegistry, summarizeLoaded } from '@/plugin'
 import { createContainerBroker, publishForwardResult } from '@/portbroker'
 import { ReloadRegistry } from '@/reload'
@@ -90,6 +91,7 @@ export async function startAgent({
   // which is what we want, since there is no host daemon to honor it anyway.
   const containerName = process.env.TYPECLAW_CONTAINER_NAME
   const containerNameOpt = containerName !== undefined ? { containerName } : {}
+  const runtimeVersionOpt = { runtimeVersion: CLI_VERSION }
   const tuiToken = process.env.TYPECLAW_TUI_TOKEN
   const tuiTokenOpt = tuiToken !== undefined && tuiToken !== '' ? { tuiToken } : {}
 
@@ -155,6 +157,7 @@ export async function startAgent({
       rehydrateCapOptions: resolveCapOptionsFromConfig(pluginConfigsByName['tool-result-cap']),
       permissions: pluginsLoaded.permissions,
       ...containerNameOpt,
+      ...runtimeVersionOpt,
     }),
     permissions: pluginsLoaded.permissions,
     claimHandler: claimController.claimHandler,
@@ -198,6 +201,7 @@ export async function startAgent({
         ...(entry.pluginSubagent.toolResultBudget !== undefined
           ? { toolResultBudget: entry.pluginSubagent.toolResultBudget }
           : {}),
+        ...runtimeVersionOpt,
       })
       return {
         ...created,
@@ -267,6 +271,7 @@ export async function startAgent({
             }
           : {}),
         ...containerNameOpt,
+        ...runtimeVersionOpt,
       })
       return {
         prompt: (text) => session.prompt(text),
@@ -363,6 +368,7 @@ export async function startAgent({
     pluginRuntime,
     claimController,
     ...containerNameOpt,
+    ...runtimeVersionOpt,
     ...tuiTokenOpt,
     ...containerBrokerOpt,
   }).start()

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -38,6 +38,7 @@ export type ServerOptions = {
   agentDir?: string
   pluginRuntime?: PluginRuntime
   containerName?: string
+  runtimeVersion?: string
   tuiToken?: string
   // Optional in-process portbroker handler. When provided, requests to the
   // /portbroker WS path are routed to it instead of being treated as TUI
@@ -108,6 +109,7 @@ export function createServer({
   agentDir,
   pluginRuntime,
   containerName,
+  runtimeVersion,
   tuiToken,
   containerBroker,
   logger = consoleLogger,
@@ -167,6 +169,7 @@ export function createServer({
               ...(channelRouter ? { channelRouter } : {}),
               ...(pluginsWiring ? { plugins: pluginsWiring } : {}),
               ...(containerName !== undefined ? { containerName } : {}),
+              ...(runtimeVersion !== undefined ? { runtimeVersion } : {}),
             })
             const session = 'session' in result ? result.session : result
             const dispose = 'session' in result && result.dispose ? result.dispose : async () => {}


### PR DESCRIPTION
## Why

The agent inside the container has no way to know what version of typeclaw is hosting it. Concretely that means:

- It can't answer \"what version of typeclaw am I running on?\" without inventing the answer.
- When it writes a bug report or surfaces a release-notes question, it has nothing to anchor the report to.
- It can't notice when its own internal docs / muscle-memory skills cite behavior from a different release.

Today the version is in three places (`CLI_VERSION`, the agent folder's `node_modules/typeclaw/package.json`, the dep-spec fallback) and **none** of them reach the LLM — there's no env var, no system-prompt line, no tool.

## What

Thread `CLI_VERSION` (the running CLI's `package.json#version`, already the single source of truth used by `--version` and the GHCR base-image pin) through every `createSession*` entry point and render it as a small **`## Runtime`** block in the system prompt:

\`\`\`
## Runtime

TypeClaw runtime version: 0.2.0.
\`\`\`

Placement matters for prompt caching. The new block sits **between** the identity / plugin-mutated prompt and `withOrigin`, which makes the cache-suffix ordering:

\`\`\`
0. runtime block   ← release-cadence (rare)
1. origin block    ← per session-kind
2. gitNudge        ← per turn (mostly empty thanks to force-commit)
3. memory section  ← most volatile (grows every dream + memory-logger turn)
\`\`\`

Version bumps are by far the rarest of these, so the runtime block keeps the cacheable prefix as large as possible.

## Surface

- New optional field on \`CreateSessionOptions\` (\`runtimeVersion?: string\`).
- New optional field on \`CreateResourceLoaderOptions\` and the override loader (\`createOverrideResourceLoader\`) so subagent sessions get the same block.
- \`runtimeVersionOpt\` plumbed through \`startAgent\` in \`src/run/index.ts\` and spread into every internal call site: the TUI server, \`buildChannelSessionFactory\`, the cron session factory, and the plugin-subagent path.
- New \`renderRuntimeBlock(version)\` helper colocated with \`DEFAULT_SYSTEM_PROMPT\` in \`src/agent/system-prompt.ts\`.

The field is **optional on purpose**. Stand-alone test callers and the \`createResourceLoader\` test fixtures don't get a misleading \"unknown\" value injected — the block is simply skipped when omitted, matching the existing pattern used by \`containerName\`, \`tuiToken\`, and \`permissions\`.

## Tests

Three new tests in \`src/agent/index.test.ts\` pin the contract:

- \`omits the runtime block when runtimeVersion is not provided\` — protects the no-version test path.
- \`renders the runtime block under \"## Runtime\" when runtimeVersion is provided\` — verifies the happy path.
- \`runtime block sits BEFORE the origin block …\` — pins the cache-suffix invariant so a future contributor who moves the block silently invalidates the cacheable prefix sees this assertion fail.

Mutation check (per AGENTS.md §1): commenting out either the \`renderRuntimeBlock\` call in \`createResourceLoader\` OR the call in \`createOverrideResourceLoader\` will break at least one of these tests.

\`\`\`
3545 pass / 0 fail / 7278 expect() calls
\`\`\`

## Notes for reviewers

- The runtime block follows the exact same precedent as \`withOrigin\`: rendering session-creation-time metadata into the prompt as a small markdown block.
- I deliberately did **not** add a \`TYPECLAW_VERSION\` env var or a \`typeclaw_version\` agent tool. Both were considered; the system-prompt line was picked as the simplest path that makes the version ambient on every turn without forcing the LLM to know it can ask. If we later want the value visible to plugins or in-container shell scripts, a follow-up can add the env var without rework.
- No \`AGENTS.md\` updates needed: the field's invariants are documented at the type-declaration site and pinned by tests, which is where future contributors will look first.