### PR TITLE
Filter model set picker to registered providers

### DIFF
--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -1,7 +1,13 @@
-import { cancel, intro, isCancel, select } from '@clack/prompts'
+import { cancel, intro, isCancel, log, select } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
-import { addProfile, listModelProfiles, removeProfile, setProfile } from '@/config/models-mutation'
+import {
+  addProfile,
+  listModelProfiles,
+  listRegisteredModelRefs,
+  removeProfile,
+  setProfile,
+} from '@/config/models-mutation'
 import {
   KNOWN_PROVIDERS,
   listKnownModelRefs,
@@ -11,7 +17,10 @@ import {
 } from '@/config/providers'
 import { findAgentDir, isInitialized } from '@/init'
 
+import { runProviderAddFlow } from './provider'
 import { c, done, errorLine } from './ui'
+
+const ADD_PROVIDER_SENTINEL = '__add-provider__'
 
 const setSub = defineCommand({
   meta: {
@@ -38,7 +47,7 @@ const setSub = defineCommand({
   async run({ args }) {
     const cwd = ensureAgentDir()
     const profile = args.profile ?? (await pickProfileName())
-    const ref = args.ref ?? (await pickModelRef())
+    const ref = args.ref ?? (await pickModelRef(cwd))
 
     intro(`Setting model profile: ${profile} → ${ref}`)
 
@@ -78,7 +87,7 @@ const addSub = defineCommand({
   },
   async run({ args }) {
     const cwd = ensureAgentDir()
-    const ref = args.ref ?? (await pickModelRef())
+    const ref = args.ref ?? (await pickModelRef(cwd))
 
     intro(`Adding model profile: ${args.profile} → ${ref}`)
 
@@ -198,22 +207,45 @@ async function pickProfileName(): Promise<string> {
   return choice
 }
 
-async function pickModelRef(): Promise<string> {
-  const refs = listKnownModelRefs()
-  const choice = await select<KnownModelRef>({
-    message: 'Pick a model',
-    options: refs.map((ref) => ({
-      value: ref,
-      label: describeRef(ref),
-      hint: ref,
-    })),
-    initialValue: refs[0],
-  })
-  if (isCancel(choice)) {
-    cancel('Aborted.')
-    process.exit(0)
+async function pickModelRef(cwd: string): Promise<string> {
+  while (true) {
+    const refs = listRegisteredModelRefs(cwd)
+    if (refs.length === 0) {
+      log.info("No provider credentials found. Let's add one first.")
+      const added = await runProviderAddFlow(cwd, {})
+      if (!added.ok) {
+        console.error(errorLine(added.reason))
+        process.exit(1)
+      }
+      continue
+    }
+    const choice = await select<KnownModelRef | typeof ADD_PROVIDER_SENTINEL>({
+      message: 'Pick a model',
+      options: [
+        ...refs.map((ref) => ({
+          value: ref,
+          label: describeRef(ref),
+          hint: ref,
+        })),
+        {
+          value: ADD_PROVIDER_SENTINEL,
+          label: c.cyan('+ add provider'),
+          hint: 'configure a new provider',
+        },
+      ],
+      initialValue: refs[0],
+    })
+    if (isCancel(choice)) {
+      cancel('Aborted.')
+      process.exit(0)
+    }
+    if (choice !== ADD_PROVIDER_SENTINEL) return choice
+    const added = await runProviderAddFlow(cwd, {})
+    if (!added.ok) {
+      console.error(errorLine(added.reason))
+      process.exit(1)
+    }
   }
-  return choice
 }
 
 function describeRef(ref: KnownModelRef): string {

--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -48,37 +48,51 @@ const addSub = defineCommand({
   },
   async run({ args }) {
     const cwd = ensureAgentDir()
-    const providerId = await resolveProviderForAdd(args.provider)
-    const provider = KNOWN_PROVIDERS[providerId]
-
-    intro(`Adding provider: ${provider.name}`)
-
-    const method = await resolveAuthMethod(provider, args)
-    if (method === 'oauth') {
-      const result = await runOAuthLogin(cwd, providerId)
-      if (!result.ok) {
-        console.error(errorLine(`OAuth login failed: ${result.reason}`))
-        process.exit(1)
-      }
-      done({
-        title: c.green(`Logged in to ${provider.name}.`),
-        hints: nextStepHints({ credentialChanged: true }),
-      })
-      return
-    }
-
-    const credential = await resolveApiKeyInputs(provider, args)
-    const result = addProvider(cwd, providerId, credential)
+    const result = await runProviderAddFlow(cwd, args)
     if (!result.ok) {
       console.error(errorLine(result.reason))
       process.exit(1)
     }
-    done({
-      title: c.green(`Added ${provider.name} credentials to secrets.json.`),
-      hints: nextStepHints({ credentialChanged: true }),
-    })
   },
 })
+
+export type ProviderAddFlowArgs = {
+  provider?: string | undefined
+  key?: string | undefined
+  env?: string | undefined
+  oauth?: boolean | undefined
+}
+
+export type ProviderAddFlowResult =
+  | { ok: true; providerId: KnownProviderId; method: 'api-key' | 'oauth' }
+  | { ok: false; reason: string }
+
+export async function runProviderAddFlow(cwd: string, args: ProviderAddFlowArgs): Promise<ProviderAddFlowResult> {
+  const providerId = await resolveProviderForAdd(args.provider)
+  const provider = KNOWN_PROVIDERS[providerId]
+
+  intro(`Adding provider: ${provider.name}`)
+
+  const method = await resolveAuthMethod(provider, args)
+  if (method === 'oauth') {
+    const result = await runOAuthLogin(cwd, providerId)
+    if (!result.ok) return { ok: false, reason: `OAuth login failed: ${result.reason}` }
+    done({
+      title: c.green(`Logged in to ${provider.name}.`),
+      hints: nextStepHints({ credentialChanged: true }),
+    })
+    return { ok: true, providerId, method: 'oauth' }
+  }
+
+  const credential = await resolveApiKeyInputs(provider, args)
+  const result = addProvider(cwd, providerId, credential)
+  if (!result.ok) return { ok: false, reason: result.reason }
+  done({
+    title: c.green(`Added ${provider.name} credentials to secrets.json.`),
+    hints: nextStepHints({ credentialChanged: true }),
+  })
+  return { ok: true, providerId, method: 'api-key' }
+}
 
 const setSub = defineCommand({
   meta: {

--- a/src/config/models-mutation.test.ts
+++ b/src/config/models-mutation.test.ts
@@ -10,6 +10,7 @@ import {
   isKnownModelRef,
   listAvailableModelRefs,
   listModelProfiles,
+  listRegisteredModelRefs,
   removeProfile,
   setProfile,
 } from './models-mutation'
@@ -41,6 +42,39 @@ describe('listAvailableModelRefs', () => {
     expect(refs).toContain('openai/gpt-5.4-nano')
     expect(refs).toContain('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
     expect(refs.length).toBeGreaterThan(5)
+  })
+})
+
+describe('listRegisteredModelRefs', () => {
+  test('returns only models whose providers have a secrets.json entry', () => {
+    const refs = listRegisteredModelRefs(root, {})
+    expect(refs).toEqual(['fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'])
+  })
+
+  test('includes models for providers configured purely via env var', () => {
+    const refs = listRegisteredModelRefs(root, { OPENAI_API_KEY: 'sk_test' })
+    expect(refs).toContain('openai/gpt-5.4-nano')
+    expect(refs).toContain('openai/gpt-5.4')
+    expect(refs).toContain('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    expect(refs.every((r) => r.startsWith('openai/') || r.startsWith('fireworks/'))).toBe(true)
+  })
+
+  test('returns empty when no provider is configured (file or env)', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'typeclaw-models-mutation-empty-'))
+    try {
+      await scaffold(empty, { model: 'openai/gpt-5.4-nano' })
+      expect(listRegisteredModelRefs(empty, {})).toEqual([])
+    } finally {
+      await rm(empty, { recursive: true, force: true })
+    }
+  })
+
+  test('preserves listKnownModelRefs declaration order', () => {
+    const refs = listRegisteredModelRefs(root, { OPENAI_API_KEY: 'sk_test', FIREWORKS_API_KEY: 'fw_test' })
+    const known = listAvailableModelRefs()
+    const indexed = refs.map((r) => known.indexOf(r))
+    const sorted = [...indexed].sort((a, b) => a - b)
+    expect(indexed).toEqual(sorted)
   })
 })
 

--- a/src/config/models-mutation.ts
+++ b/src/config/models-mutation.ts
@@ -11,7 +11,7 @@ import {
   type KnownModelRef,
   type KnownProviderId,
 } from './providers'
-import { isProviderConfigured } from './providers-mutation'
+import { isProviderConfigured, listConfiguredProviders } from './providers-mutation'
 
 const CONFIG_FILE = 'typeclaw.json'
 
@@ -49,6 +49,25 @@ export function listModelProfiles(cwd: string, env: NodeJS.ProcessEnv = process.
 
 export function listAvailableModelRefs(): KnownModelRef[] {
   return listKnownModelRefs()
+}
+
+// Subset of `listAvailableModelRefs()` filtered to providers with a usable
+// credential in this agent folder — either a `secrets.json#providers.<id>`
+// entry (api-key OR oauth) or a credential resolvable from the process env
+// via the provider's canonical env-var name. Used by `typeclaw model set`'s
+// interactive picker so users only see models they can actually run; the
+// CLI surfaces an explicit "add provider" sentinel when the result is empty
+// or when the user wants to wire a new one.
+//
+// Ordering preserves `listKnownModelRefs()` (provider-table declaration
+// order, then per-provider model order) so the picker reads stably across
+// invocations.
+export function listRegisteredModelRefs(cwd: string, env: NodeJS.ProcessEnv = process.env): KnownModelRef[] {
+  const registered = new Set<KnownProviderId>()
+  for (const entry of listConfiguredProviders(cwd, env)) {
+    if (entry.known) registered.add(entry.id as KnownProviderId)
+  }
+  return listKnownModelRefs().filter((ref) => registered.has(providerForModelRef(ref)))
 }
 
 export function isKnownModelRef(value: string): value is KnownModelRef {


### PR DESCRIPTION
## Summary

`typeclaw model set` (and `model add`) used to present every model across all 16 known providers in the interactive picker, including providers with no credentials. Users would pick a model and immediately hit `Provider "X" has no credentials. Run typeclaw provider add X first, or pass --force to write anyway.` — a confusing dead end with no escape from the picker. This PR filters the picker to only show models from providers that have a usable credential, and adds an inline `+ add provider` sentinel to wire up a new provider without leaving the flow.

## Example

Agent folder with only a `fireworks` credential in `secrets.json` and `OPENAI_API_KEY` set in the environment.

**Before** — every model in `KNOWN_PROVIDERS` shows up, including providers the user has no credentials for. Picking `zai/glm-4.7` exits the picker with a hard error.

```
$ typeclaw model set default
◆  Pick a model
│  ● OpenAI · GPT-5.4 nano (openai/gpt-5.4-nano)
│  ○ OpenAI · GPT-5.4 mini
│  ○ OpenAI · GPT-5.4
│  ○ OpenAI · GPT-5.5
│  ○ OpenAI Codex (ChatGPT Plus/Pro) · GPT-5.4 mini
│  ○ OpenAI Codex (ChatGPT Plus/Pro) · GPT-5.4
│  ○ OpenAI Codex (ChatGPT Plus/Pro) · GPT-5.5
│  ○ Fireworks · Kimi K2.6 Turbo
│  ○ Z.AI · GLM-4.5-Air
│  ○ Z.AI · GLM-4.6
│  ○ Z.AI · GLM-4.7
│  ○ Z.AI (GLM Coding Plan) · GLM-4.5-Air
│  ○ Z.AI (GLM Coding Plan) · GLM-4.7
│  ○ Z.AI (GLM Coding Plan) · GLM-5
│  ○ Z.AI (GLM Coding Plan) · GLM-5-Turbo
│  ○ Z.AI (GLM Coding Plan) · GLM-5.1
└

✖  Provider "zai" has no credentials. Run `typeclaw provider add zai` first,
   or pass --force to write anyway.
```

**After** — only models whose provider has a usable credential. The `+ add provider` sentinel kicks off `typeclaw provider add` inline, then re-renders the picker with the newly-registered models included.

```
$ typeclaw model set default
◆  Pick a model
│  ● OpenAI · GPT-5.4 nano (openai/gpt-5.4-nano)
│  ○ OpenAI · GPT-5.4 mini
│  ○ OpenAI · GPT-5.4
│  ○ OpenAI · GPT-5.5
│  ○ Fireworks · Kimi K2.6 Turbo
│  ○ + add provider  (configure a new provider)
└
```

Selecting `+ add provider` → runs the existing provider-add flow → returns to the model picker with the new provider's models now listed. Empty registered set (fresh agent, no env vars) skips the dropdown and jumps straight into the add-provider flow.

## What

- **New `listRegisteredModelRefs(cwd, env)`** in `src/config/models-mutation.ts`. Reuses `listConfiguredProviders` so the same file/env/OAuth resolution logic applies — no duplicated env-detection paths. Filters `listKnownModelRefs()` to providers whose `ConfiguredProvider.known === true`. Preserves declaration order from the provider table.

- **Extracted `runProviderAddFlow(cwd, args)`** in `src/cli/provider.ts` from the inline `addSub.run` body. Same behavior, same prompts — just callable from `model.ts` without duplication. The `typeclaw provider add` command now delegates to it.

- **Rewrote `pickModelRef(cwd)`** in `src/cli/model.ts`:
  - Loops: pick from the registered model refs, or pick the sentinel.
  - Sentinel `+ add provider` → calls `runProviderAddFlow`, then re-renders the picker with the now-larger registered set.
  - Empty registered set → jumps straight into the add-provider flow rather than rendering a dropdown with only the sentinel.

## Why

The picker is a guidance surface — it should only offer choices the user can actually complete. Showing all 16 providers when most have no credentials creates misleading affordances and a terminal error with no in-flow recovery. Filtering to configured providers makes the happy path correct by construction, and the sentinel preserves the "I want to add a provider right now" escape hatch without leaving the model-selection flow.

## Tests

Four new tests in `src/config/models-mutation.test.ts`, targeting the domain helper directly per AGENTS.md §2 ("test at the right layer"):

| Test | What it pins |
|---|---|
| Returns only models whose providers have a `secrets.json` entry | File-credential path |
| Includes models for providers configured purely via env var | Env-credential path (`OPENAI_API_KEY`) |
| Returns empty when no provider is configured | Empty-config sentinel |
| Preserves `listKnownModelRefs` declaration order | Stable picker ordering across runs |

Mutation check: replacing the filter body with `listKnownModelRefs()` directly breaks test 1 (returns 16 refs instead of 1).

```
bun run typecheck   # clean
bun run lint        # 8 pre-existing warnings, 0 errors (same as main, unrelated)
bun run format:check # clean
bun test            # 3549 pass / 0 fail / 7285 expect() calls
```

## Out of scope

- **Non-interactive form is unchanged.** `typeclaw model set default openai/gpt-5.4-nano` (positional args) is unaffected. The `--force` flag and the `setProfile` "Provider X has no credentials" error path remain the explicit contract for scripts and automation. The filter applies only to the interactive picker that was misleading users.

- **OAuth providers.** `listConfiguredProviders` already treats OAuth credentials as "configured", so OAuth-only providers appear in the picker once the user has logged in. No change needed.

- **Provider add/remove flows.** `typeclaw provider add/set/remove` writes to `secrets.json`, which is gitignored. Auto-commit is not applicable here.
