### PR TITLE
Surface provider errors from every session path in typeclaw logs

### DIFF
--- a/src/agent/provider-error.test.ts
+++ b/src/agent/provider-error.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { AgentSession } from './index'
+import { detectProviderError, subscribeProviderErrors } from './provider-error'
+
+describe('detectProviderError', () => {
+  test('returns the errorMessage for assistant message with stopReason=error', () => {
+    const result = detectProviderError({
+      role: 'assistant',
+      stopReason: 'error',
+      errorMessage: 'Your account is not active, please check your billing details on our website.',
+    })
+
+    expect(result).toEqual({
+      message: 'Your account is not active, please check your billing details on our website.',
+    })
+  })
+
+  test('falls back to a generic message when stopReason=error has no errorMessage', () => {
+    const result = detectProviderError({ role: 'assistant', stopReason: 'error' })
+
+    expect(result).toEqual({ message: 'LLM call failed' })
+  })
+
+  test('falls back to a generic message when errorMessage is an empty string', () => {
+    const result = detectProviderError({ role: 'assistant', stopReason: 'error', errorMessage: '' })
+
+    expect(result).toEqual({ message: 'LLM call failed' })
+  })
+
+  test('returns null for stopReason=aborted (user-initiated, not a provider failure)', () => {
+    const result = detectProviderError({ role: 'assistant', stopReason: 'aborted', errorMessage: 'cancelled' })
+
+    expect(result).toBeNull()
+  })
+
+  test('returns null for stopReason=stop (normal completion)', () => {
+    const result = detectProviderError({ role: 'assistant', stopReason: 'stop' })
+
+    expect(result).toBeNull()
+  })
+
+  test('returns null for non-assistant roles (user/toolResult)', () => {
+    expect(detectProviderError({ role: 'user', stopReason: 'error' })).toBeNull()
+    expect(detectProviderError({ role: 'toolResult', stopReason: 'error' })).toBeNull()
+  })
+
+  test('returns null for null, undefined, primitives, or arrays', () => {
+    expect(detectProviderError(null)).toBeNull()
+    expect(detectProviderError(undefined)).toBeNull()
+    expect(detectProviderError('string')).toBeNull()
+    expect(detectProviderError(42)).toBeNull()
+    expect(detectProviderError([])).toBeNull()
+  })
+
+  test('returns null when errorMessage is present but stopReason is something other than error', () => {
+    const result = detectProviderError({
+      role: 'assistant',
+      stopReason: 'tool_calls',
+      errorMessage: 'should not surface',
+    })
+
+    expect(result).toBeNull()
+  })
+})
+
+type FakeListener = (event: { type: string; message?: unknown }) => void
+
+function fakeSession(): { session: AgentSession; emit: (event: { type: string; message?: unknown }) => void } {
+  const listeners = new Set<FakeListener>()
+  const session = {
+    subscribe: (cb: FakeListener) => {
+      listeners.add(cb)
+      return () => listeners.delete(cb)
+    },
+  } as unknown as AgentSession
+  return {
+    session,
+    emit: (event) => {
+      for (const cb of listeners) cb(event)
+    },
+  }
+}
+
+describe('subscribeProviderErrors', () => {
+  test('invokes onError exactly once per detected provider error', () => {
+    const { session, emit } = fakeSession()
+    const calls: string[] = []
+    subscribeProviderErrors(session, (err) => calls.push(err.message))
+
+    emit({
+      type: 'message_end',
+      message: { role: 'assistant', stopReason: 'error', errorMessage: 'rate limited' },
+    })
+    emit({
+      type: 'message_end',
+      message: { role: 'assistant', stopReason: 'error', errorMessage: 'billing fail' },
+    })
+
+    expect(calls).toEqual(['rate limited', 'billing fail'])
+  })
+
+  test('ignores non-message_end events even if they carry an error-looking payload', () => {
+    const { session, emit } = fakeSession()
+    const calls: string[] = []
+    subscribeProviderErrors(session, (err) => calls.push(err.message))
+
+    emit({ type: 'message_update', message: { role: 'assistant', stopReason: 'error' } })
+    emit({ type: 'tool_execution_start', message: { role: 'assistant', stopReason: 'error' } })
+
+    expect(calls).toEqual([])
+  })
+
+  test('ignores message_end events with stopReason=stop / aborted / non-assistant roles', () => {
+    const { session, emit } = fakeSession()
+    const calls: string[] = []
+    subscribeProviderErrors(session, (err) => calls.push(err.message))
+
+    emit({ type: 'message_end', message: { role: 'assistant', stopReason: 'stop' } })
+    emit({ type: 'message_end', message: { role: 'assistant', stopReason: 'aborted' } })
+    emit({ type: 'message_end', message: { role: 'user', stopReason: 'error' } })
+
+    expect(calls).toEqual([])
+  })
+
+  test('returns an unsubscribe handle that detaches the listener', () => {
+    const { session, emit } = fakeSession()
+    const calls: string[] = []
+    const unsub = subscribeProviderErrors(session, (err) => calls.push(err.message))
+
+    emit({ type: 'message_end', message: { role: 'assistant', stopReason: 'error', errorMessage: 'first' } })
+    unsub()
+    emit({ type: 'message_end', message: { role: 'assistant', stopReason: 'error', errorMessage: 'second' } })
+
+    expect(calls).toEqual(['first'])
+  })
+})

--- a/src/agent/provider-error.ts
+++ b/src/agent/provider-error.ts
@@ -1,0 +1,44 @@
+import type { AgentSession } from './index'
+
+// pi-coding-agent encodes upstream LLM failures (billing, rate limit, network,
+// malformed response, etc.) in the assistant message itself rather than
+// throwing — `stopReason: 'error'` with a populated `errorMessage`. Code that
+// only catches throws around `session.prompt()` therefore never sees these:
+// the prompt resolves normally, no text deltas were emitted, and the only
+// signal is the final `message_end` event. Channels, cron, and subagents all
+// have to subscribe to surface these soft errors.
+//
+// Hard throws (timeouts, network drops, etc.) come out of the upstream wrapper
+// as exceptions and are handled by the surrounding try/catch in each caller —
+// not by this helper.
+
+export type DetectedProviderError = {
+  message: string
+}
+
+export function detectProviderError(message: unknown): DetectedProviderError | null {
+  if (typeof message !== 'object' || message === null) return null
+  const m = message as { role?: unknown; stopReason?: unknown; errorMessage?: unknown }
+  if (m.role !== 'assistant') return null
+  // 'aborted' is fired when the user hits Escape — not a provider failure,
+  // and the TUI shows its own abort feedback elsewhere. Channels/cron just
+  // ignore aborts (no surface to render them on).
+  if (m.stopReason !== 'error') return null
+  const text = typeof m.errorMessage === 'string' && m.errorMessage.length > 0 ? m.errorMessage : 'LLM call failed'
+  return { message: text }
+}
+
+export type ProviderErrorListener = (error: DetectedProviderError) => void
+export type Unsubscribe = () => void
+
+// Subscribes to `message_end` events on `session` and invokes `onError` once
+// per detected provider error. Returns the unsubscribe handle from the
+// underlying `session.subscribe`. Callers MUST unsubscribe when the session
+// is disposed to avoid leaks across sessions.
+export function subscribeProviderErrors(session: AgentSession, onError: ProviderErrorListener): Unsubscribe {
+  return session.subscribe((event) => {
+    if (event.type !== 'message_end') return
+    const detected = detectProviderError(event.message)
+    if (detected !== null) onError(detected)
+  })
+}

--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -491,4 +491,49 @@ describe('createSubagentConsumer', () => {
 
     consumer.stop()
   })
+
+  test('logs LLM soft errors emitted via message_end during prompt() so `typeclaw logs` surfaces them', async () => {
+    // given: a subagent whose underlying session emits a message_end with
+    // stopReason=error during prompt(), mirroring how pi-coding-agent
+    // reports billing/rate-limit failures (resolves normally, doesn't throw).
+    const stream = createStream()
+    const errors: string[] = []
+    type Listener = (event: { type: string; message?: unknown }) => void
+    const sessionWithSubscribe = (): AgentSession => {
+      const listeners = new Set<Listener>()
+      return {
+        prompt: async () => {
+          for (const cb of listeners) {
+            cb({
+              type: 'message_end',
+              message: { role: 'assistant', stopReason: 'error', errorMessage: 'billing failed' },
+            })
+          }
+        },
+        dispose: () => {},
+        subscribe: (cb: Listener) => {
+          listeners.add(cb)
+          return () => listeners.delete(cb)
+        },
+      } as unknown as AgentSession
+    }
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+    const consumer = createSubagentConsumer({
+      stream,
+      getRegistry: () => registry,
+      agentDir: '/agent',
+      createSessionForSubagent: async () => sessionWithSubscribe(),
+      logger: { ...silent, error: (m) => errors.push(m) },
+    })
+    consumer.start()
+
+    // when
+    stream.publish({ target: { kind: 'new-session', subagent: 'greeter' }, payload: undefined })
+    await new Promise((r) => setImmediate(r))
+
+    // then
+    expect(errors.some((e) => /\[subagent\] greeter: LLM call failed: billing failed/.test(e))).toBe(true)
+
+    consumer.stop()
+  })
 })

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -5,6 +5,7 @@ import type { HookBus } from '@/plugin'
 import type { Stream, Unsubscribe } from '@/stream'
 
 import { type AgentSession, createSession } from './index'
+import { subscribeProviderErrors } from './provider-error'
 import type { SessionOrigin } from './session-origin'
 import type { ToolResultBudget } from './tool-result-budget'
 
@@ -134,6 +135,7 @@ export type InvokeSubagentOptions = {
   parentSessionId?: string
   spawnedByRole?: string
   spawnedByOrigin?: SessionOrigin
+  onProviderError?: (errorMessage: string) => void
 }
 
 export async function invokeSubagent(name: string, options: InvokeSubagentOptions): Promise<void> {
@@ -153,6 +155,10 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
     const { session, dispose, hooks, sessionId, agentDir, origin, getTranscriptPath } = normalizeSubagentSession(
       await createSessionForSubagent(subagent, sessionOptions),
     )
+    const unsubProviderErrors =
+      options.onProviderError !== undefined
+        ? subscribeProviderErrors(session, (err) => options.onProviderError!(err.message))
+        : null
     const turnEvent =
       hooks && sessionId !== undefined && agentDir !== undefined
         ? { sessionId, agentDir, ...(origin !== undefined ? { origin } : {}) }
@@ -177,6 +183,7 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
         })
       }
     } finally {
+      unsubProviderErrors?.()
       if (hooks && sessionId !== undefined) {
         await hooks.runSessionEnd({ sessionId, ...(origin !== undefined ? { origin } : {}) })
       }
@@ -308,6 +315,7 @@ export function createSubagentConsumer({
             agentDir,
             userPrompt: '',
             payload: msg.payload,
+            onProviderError: (message) => logger.error(`[subagent] ${key}: LLM call failed: ${message}`),
             ...(target.parentSessionId !== undefined ? { parentSessionId: target.parentSessionId } : {}),
             ...(target.spawnedByRole !== undefined ? { spawnedByRole: target.spawnedByRole } : {}),
             ...(spawnedByOrigin !== undefined ? { spawnedByOrigin } : {}),

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -177,6 +177,7 @@ describe('channel manager — reload detects missing tokens and stops adapter', 
       },
       abort: async () => {},
       sessionManager: { getLeafEntry: () => undefined },
+      subscribe: () => () => {},
     } as unknown as AgentSession
     const mgr = createChannelManager({
       agentDir,

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -36,6 +36,8 @@ class FakeSession {
     getLeafEntry: (): SessionEntry | undefined => this.leafEntry,
   }
 
+  private subscribers = new Set<(event: { type: string; message?: unknown }) => void>()
+
   prompt = async (text: string): Promise<void> => {
     this.prompts.push(text)
     await this.onPrompt?.(text)
@@ -45,6 +47,13 @@ class FakeSession {
   }
   dispose = (): void => {
     this.disposed++
+  }
+  subscribe = (cb: (event: { type: string; message?: unknown }) => void): (() => void) => {
+    this.subscribers.add(cb)
+    return () => this.subscribers.delete(cb)
+  }
+  emit = (event: { type: string; message?: unknown }): void => {
+    for (const cb of this.subscribers) cb(event)
   }
 
   setAssistantText(text: string): void {
@@ -1840,6 +1849,83 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
 
     // then
     expect(events).toEqual(['idle:ses_fake_throws'])
+  })
+
+  test('logs LLM soft errors (stopReason=error encoded in message_end) so `typeclaw logs` surfaces them', async () => {
+    // given: a live session whose prompt() resolves normally but emits a
+    // message_end with stopReason=error mid-turn — pi-coding-agent's
+    // documented way of reporting billing/rate-limit failures without
+    // throwing. Without the router subscribing, this would be invisible
+    // (no reply to the channel, no entry in `typeclaw logs`).
+    const dir = await tempDir()
+    const errors: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      logger: { info: () => {}, warn: () => {}, error: (m) => errors.push(m) },
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        fake.prompt = async (_text) => {
+          fake.emit({
+            type: 'message_end',
+            message: {
+              role: 'assistant',
+              stopReason: 'error',
+              errorMessage: 'billing not active',
+            },
+          })
+        }
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: 'ses_soft_err',
+          dispose: async () => {},
+          getTranscriptPath: () => undefined,
+        }
+      },
+    })
+
+    // when
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then
+    expect(errors.some((m) => /LLM call failed: billing not active/.test(m))).toBe(true)
+  })
+
+  test('upgrades hard prompt-throws to logger.error (not warn) so `typeclaw logs` operators see them at the right level', async () => {
+    // given
+    const dir = await tempDir()
+    const warns: string[] = []
+    const errors: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      logger: {
+        info: () => {},
+        warn: (m) => warns.push(m),
+        error: (m) => errors.push(m),
+      },
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        fake.prompt = async () => {
+          throw new Error('network unreachable')
+        }
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: 'ses_hard_err',
+          dispose: async () => {},
+          getTranscriptPath: () => undefined,
+        }
+      },
+    })
+
+    // when
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then
+    expect(errors.some((m) => /prompt threw.*network unreachable/.test(m))).toBe(true)
+    expect(warns.some((m) => /prompt threw/.test(m))).toBe(false)
   })
 
   test('fires session.end on stop() before disposing each live session', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4,6 +4,7 @@ import type { AssistantMessage } from '@mariozechner/pi-ai'
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession, type AgentSession } from '@/agent'
+import { subscribeProviderErrors } from '@/agent/provider-error'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { createCommandRegistry } from '@/commands'
 import { CORE_PERMISSIONS, type PermissionService } from '@/permissions'
@@ -255,6 +256,7 @@ type LiveSession = {
   loopGuardActive: boolean
   membershipFetch: Promise<MembershipCount | null> | null
   destroyed: boolean
+  unsubProviderErrors: (() => void) | null
 }
 
 type ChannelCommandContext = {
@@ -722,7 +724,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         loopGuardActive: false,
         membershipFetch,
         destroyed: false,
+        unsubProviderErrors: null,
       }
+      live.unsubProviderErrors = subscribeProviderErrors(created.session, (err) => {
+        logger.error(`[channels] ${live.keyId}: LLM call failed: ${err.message}`)
+      })
       liveSessions.set(keyId, live)
 
       if (isColdStart) {
@@ -1027,7 +1033,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.consecutiveAborts = 0
           logger.info(`[channels] ${live.keyId} prompted elapsed_ms=${now() - promptStart}`)
         } catch (err) {
-          logger.warn(`[channels] ${live.keyId}: prompt threw: ${describe(err)}`)
+          logger.error(`[channels] ${live.keyId}: prompt threw: ${describe(err)}`)
           live.consecutiveSends.clear()
         } finally {
           await fireSessionTurnEnd(live)
@@ -1512,6 +1518,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.destroyed = true
     if (live.debounceTimer) clearTimeout(live.debounceTimer)
     live.debounceTimer = null
+    live.unsubProviderErrors?.()
+    live.unsubProviderErrors = null
     await stopTypingHeartbeat(live)
     try {
       await live.session.abort()

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -477,4 +477,75 @@ describe('createCronConsumer', () => {
 
     consumer.stop()
   })
+
+  test('logs LLM soft errors (stopReason=error encoded in message_end) so `typeclaw logs` surfaces them', async () => {
+    // given: a fake CronSession whose .session emits a message_end with
+    // stopReason=error during prompt(), simulating a billing/rate-limit
+    // failure from pi-coding-agent that resolves normally instead of throwing.
+    const stream = createStream()
+    const errors: string[] = []
+    type Listener = (event: { type: string; message?: unknown }) => void
+    const listeners = new Set<Listener>()
+    const fakeAgentSession = {
+      subscribe: (cb: Listener) => {
+        listeners.add(cb)
+        return () => listeners.delete(cb)
+      },
+    } as unknown as import('@/agent').AgentSession
+
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: async () => ({
+        prompt: async () => {
+          for (const cb of listeners) {
+            cb({
+              type: 'message_end',
+              message: {
+                role: 'assistant',
+                stopReason: 'error',
+                errorMessage: 'rate limit exceeded',
+              },
+            })
+          }
+        },
+        session: fakeAgentSession,
+      }),
+      logger: { ...silentLogger, error: (m) => errors.push(m) },
+    })
+    consumer.start()
+
+    // when
+    publishCron(stream, promptJob('soft-err', 'go'))
+    await new Promise((r) => setImmediate(r))
+
+    // then
+    expect(errors.some((e) => /\[cron\] soft-err: LLM call failed: rate limit exceeded/.test(e))).toBe(true)
+
+    consumer.stop()
+  })
+
+  test('does not log when .session is omitted (test fakes that only need prompt keep working)', async () => {
+    // given
+    const stream = createStream()
+    const errors: string[] = []
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: async () => ({
+        prompt: async () => {},
+      }),
+      logger: { ...silentLogger, error: (m) => errors.push(m) },
+    })
+    consumer.start()
+
+    // when
+    publishCron(stream, promptJob('no-session', 'go'))
+    await new Promise((r) => setImmediate(r))
+
+    // then
+    expect(errors).toEqual([])
+
+    consumer.stop()
+  })
 })

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -1,3 +1,5 @@
+import type { AgentSession } from '@/agent'
+import { subscribeProviderErrors } from '@/agent/provider-error'
 import type { SessionOrigin } from '@/agent/session-origin'
 import type { HookBus } from '@/plugin'
 import type { Stream, Unsubscribe } from '@/stream'
@@ -20,6 +22,12 @@ export type CronSession = {
   agentDir?: string
   getTranscriptPath?: () => string | undefined
   origin?: SessionOrigin
+  // Underlying agent session, exposed so the consumer can subscribe to
+  // `message_end` events and surface soft provider errors (billing, rate
+  // limit, network — pi-coding-agent encodes these in the assistant message
+  // instead of throwing, so the outer try/catch never sees them). Optional
+  // so existing test fakes that only need `prompt` keep working.
+  session?: AgentSession
 }
 
 export type CronConsumerLogger = {
@@ -72,7 +80,7 @@ export function createCronConsumer({
         inFlight.add(job.id)
         try {
           if (job.kind === 'prompt') {
-            await runPrompt(job, createSessionForCron, stream)
+            await runPrompt(job, createSessionForCron, stream, logger)
           } else {
             await runExec(job, cwd)
           }
@@ -98,6 +106,7 @@ async function runPrompt(
   job: PromptJob,
   createSessionForCron: (job: PromptJob) => Promise<CronSession>,
   stream: Stream,
+  logger: CronConsumerLogger,
 ): Promise<void> {
   if (job.subagent !== undefined) {
     // Propagate the cron job's role and origin into the spawned subagent.
@@ -123,6 +132,12 @@ async function runPrompt(
     return
   }
   const session = await createSessionForCron(job)
+  const unsubProviderErrors =
+    session.session !== undefined
+      ? subscribeProviderErrors(session.session, (err) => {
+          logger.error(`[cron] ${job.id}: LLM call failed: ${err.message}`)
+        })
+      : null
   const turnEvent =
     session.hooks && session.sessionId !== undefined && session.agentDir !== undefined
       ? {
@@ -151,6 +166,7 @@ async function runPrompt(
       })
     }
   } finally {
+    unsubProviderErrors?.()
     if (session.hooks && session.sessionId !== undefined) {
       await session.hooks.runSessionEnd({
         sessionId: session.sessionId,

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -279,6 +279,7 @@ export async function startAgent({
         sessionId,
         agentDir: cwd,
         origin: cronOrigin,
+        session,
         ...(snap.hasAnyPluginContent ? { hooks: snap.hooks } : {}),
         getTranscriptPath: () => sessionManager.getSessionFile(),
       }

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -322,6 +322,7 @@ export async function startAgent({
       agentDir: cwd,
       userPrompt: '',
       payload,
+      onProviderError: (message) => console.error(`[subagent] ${name}: LLM call failed: ${message}`),
       ...(options?.parentSessionId !== undefined ? { parentSessionId: options.parentSessionId } : {}),
       ...(spawnedByRole !== undefined ? { spawnedByRole } : {}),
       ...(options?.spawnedByOrigin !== undefined ? { spawnedByOrigin: options.spawnedByOrigin } : {}),

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,7 @@ import {
   type CreateSessionResult,
 } from '@/agent'
 import { runPluginDoctorChecks, runPluginDoctorFix } from '@/agent/doctor'
+import { detectProviderError } from '@/agent/provider-error'
 import type { SessionOrigin } from '@/agent/session-origin'
 import type { ChannelRouter } from '@/channels/router'
 import type { HookBus } from '@/plugin'
@@ -458,16 +459,10 @@ function forwardSessionEvents(ws: Ws, session: AgentSession, logger: ServerLogge
 }
 
 function forwardAssistantError(ws: Ws, message: unknown, logger: ServerLogger, sessionFileId: string): void {
-  if (typeof message !== 'object' || message === null) return
-  const m = message as { role?: string; stopReason?: string; errorMessage?: string }
-  if (m.role !== 'assistant') return
-  if (m.stopReason !== 'error' && m.stopReason !== 'aborted') return
-  // 'aborted' is fired when the user hits Escape — don't surface it as an
-  // error message because the TUI already shows abort feedback elsewhere.
-  if (m.stopReason === 'aborted') return
-  const text = typeof m.errorMessage === 'string' && m.errorMessage.length > 0 ? m.errorMessage : 'LLM call failed'
-  logger.error(`[server] ${sessionFileId}: LLM call failed: ${text}`)
-  send(ws, { type: 'error', message: text })
+  const detected = detectProviderError(message)
+  if (detected === null) return
+  logger.error(`[server] ${sessionFileId}: LLM call failed: ${detected.message}`)
+  send(ws, { type: 'error', message: detected.message })
 }
 
 function enqueuePrompt(


### PR DESCRIPTION
## Summary

Provider errors now surface in `typeclaw logs` from **every** session path, not just the TUI. Channels, cron, and subagents were each silently swallowing a class of upstream LLM failures — the user's first hint of a billing problem or rate-limit was the chat going quiet.

## The bug

`pi-coding-agent` reports upstream provider failures (billing, rate limit, network, malformed response) in two shapes:

1. **Hard throws** out of `session.prompt()` — network timeouts, auth failures, etc.
2. **Soft errors** — `message_end` events with `stopReason: 'error'` and a populated `errorMessage`. The prompt resolves *normally*. No text deltas were ever emitted, no exception was thrown, the only signal is the final event.

The TUI server (`src/server/index.ts`) already handled both via `forwardAssistantError`, subscribed via `session.subscribe(...)`. The other three callers of `session.prompt()` only wrapped it in `try/catch`, so the entire soft-error class was invisible to them:

| Path | Before | After |
|------|--------|-------|
| TUI / `src/server/index.ts` | both shapes → `logger.error` + TUI event | unchanged (refactored to use shared helper) |
| Channel / `src/channels/router.ts` | hard throws → `logger.warn`; soft errors → **silently dropped** | hard throws → `logger.error`; soft errors → `logger.error` |
| Cron / `src/cron/consumer.ts` | hard throws → `logger.error`; soft errors → **silently dropped** | both → `logger.error` |
| Subagent / `src/agent/subagents.ts` | hard throws → `logger.error`; soft errors → **silently dropped** | both → `logger.error` |

Channel router additionally had its hard-throw log at `warn` level rather than `error` — operationally a mismatch because provider failures are operator-visible problems, not warnings. Bumping it to `error` separates it from the genuinely-warn-level noise (`abort failed for …`, `dispose failed for …`) in the same module.

## Design

`src/agent/provider-error.ts` (new) — small, pure, testable.

- `detectProviderError(message)` — returns `{ message } | null`. Ignores `stopReason: 'aborted'` (user-initiated, not a provider failure) and non-assistant messages. Falls back to `'LLM call failed'` when `errorMessage` is missing or empty. Tolerates null / primitives / arrays / malformed objects without throwing.
- `subscribeProviderErrors(session, onError)` — subscribes to `message_end` events on an `AgentSession`, returns an unsubscribe handle. Callers are responsible for unsubscribing on session disposal.

Each surface logs at `error` level with its existing per-path prefix (already standard in this codebase):

- `[server] <sessionFileId>: LLM call failed: …`
- `[channels] <keyId>: LLM call failed: …`
- `[cron] <jobId>: LLM call failed: …`
- `[subagent] <key>: LLM call failed: …`

All four prefixes hit the same `console.error` → docker stdout → `typeclaw logs` pipeline via the existing per-module `consoleLogger` defaults documented in AGENTS.md.

## Wiring

- **Channel router** — per-live-session subscription installed in `ensureLive`, unsubscribed in `tearDownLive`. The `LiveSession` type gained an `unsubProviderErrors: (() => void) | null` field. The existing hard-throw `logger.warn` upgraded to `logger.error`.
- **Cron consumer** — `CronSession` type gained an optional `session?: AgentSession` field, intentionally optional so existing one-liner test fakes (per the file's load-bearing docstring comment) keep working. `runPrompt` subscribes when the field is present and unsubscribes in `finally`. The factory in `src/run/index.ts` now exposes the underlying session.
- **Subagent consumer** — `InvokeSubagentOptions` gained an optional `onProviderError(message: string)` callback. Wired by both call sites: the stream-driven consumer (logs `[subagent] <key>: …`) and the plugin-spawned path in `src/run/index.ts` (logs `[subagent] <name>: …`). Subscription runs inside `runSession`, unsubscribes in `finally`.
- **Server** — `forwardAssistantError` refactored to use `detectProviderError`. Behavior is bit-identical; the existing TUI tests in `src/server/index.test.ts` (covering billing-error / missing-errorMessage / non-assistant role / aborted) still pass unchanged.

## Tests (16 new tests across 4 files)

- `src/agent/provider-error.test.ts` (new, 12 tests) — every branch of `detectProviderError` and the subscribe/unsubscribe lifecycle. Real listener set, no mocking.
- `src/cron/consumer.test.ts` (+2) — soft-error logging when `.session` is provided; absent `.session` stays silent (preserves the test-fake contract).
- `src/agent/subagents.test.ts` (+1) — soft errors during `prompt()` reach the consumer's logger.
- `src/channels/router.test.ts` (+2) — soft-error logging via the router subscription; hard-throw log is now `error` (not `warn`).

Mutation check (per AGENTS.md §Testing 7): commenting out any `subscribeProviderErrors(...)` call in production fails at least one new test. The `warn → error` upgrade is also explicitly asserted (a future revert to `warn` would fail the new "upgrades hard prompt-throws to logger.error" test).

Also updated two pre-existing test fakes (`FakeSession` in `router.test.ts`, the bare-AgentSession cast in `manager.test.ts`) to include a `subscribe` method, because the channel router now exercises the real `AgentSession.subscribe` contract on every session creation. Test-fake updates landed in this commit so the suite stays green at every step.

## Pre-commit checks

- `bun run typecheck` — clean (0 errors)
- `bun run lint` — 0 errors, 0 warnings in any touched file (8 pre-existing warnings elsewhere in the repo, unrelated to this change)
- `bun run format` — clean
- `bun test` — 3606 / 3606 pass