### PR TITLE
Break `typeclaw usage` tokens down by session origin (tui/cron/channel/subagent)

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -29,6 +29,7 @@ import { lookAtTool } from './multimodal'
 import { resolveBuiltinToolRefs, wrapPluginTool, wrapSystemAgentTool, wrapSystemTool } from './plugin-tools'
 import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
+import { SESSION_META_CUSTOM_TYPE, sessionMetaPayload } from './session-meta'
 import { renderSessionOrigin, type SessionOrigin, type SessionRoleContext } from './session-origin'
 import { DEFAULT_SYSTEM_PROMPT, renderRuntimeBlock } from './system-prompt'
 import {
@@ -230,6 +231,25 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
   // that ID to distinguish the originating session from siblings on the
   // container-restarting broadcast.
   const sessionManager = options.sessionManager ?? SessionManager.inMemory()
+
+  // Stamp a one-shot custom entry naming the session's origin kind so
+  // `typeclaw usage` can bucket tokens by tui/cron/channel/subagent. Pi's
+  // `appendCustomEntry` is the blessed extension point: the entry persists
+  // into the session JSONL alongside messages, does NOT participate in LLM
+  // context, and pi handles file-creation timing — the entry lands after the
+  // session header on first flush, so `SessionManager.open()` keeps reading
+  // a canonical session file. Skipped for reopened sessions (a prior stamp
+  // is already in `getEntries()`) so usage attribution stays stable across
+  // restarts. Also skipped when origin is unknown (inMemory subagents) or
+  // when the manager is not persisted.
+  if (options.origin !== undefined && sessionManager.getSessionFile() !== undefined) {
+    const alreadyStamped = sessionManager
+      .getEntries()
+      .some((e) => e.type === 'custom' && e.customType === SESSION_META_CUSTOM_TYPE)
+    if (!alreadyStamped) {
+      sessionManager.appendCustomEntry(SESSION_META_CUSTOM_TYPE, sessionMetaPayload(options.origin))
+    }
+  }
 
   const customSystemTools =
     options.customTools !== undefined

--- a/src/agent/session-meta.test.ts
+++ b/src/agent/session-meta.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { SessionManager } from '@mariozechner/pi-coding-agent'
+
+import { createSessionFactory } from '@/sessions'
+
+import { SESSION_META_CUSTOM_TYPE, sessionMetaPayload } from './session-meta'
+import type { SessionOrigin } from './session-origin'
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-session-meta-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('sessionMetaPayload (minimal projection)', () => {
+  test('tui origin keeps only kind', () => {
+    const out = sessionMetaPayload({ kind: 'tui', sessionId: 'ses_abc' })
+    expect(out).toEqual({ origin: { kind: 'tui' } })
+  })
+
+  test('cron origin keeps jobId and jobKind, drops scheduledByOrigin', () => {
+    const origin: SessionOrigin = {
+      kind: 'cron',
+      jobId: 'daily-dream',
+      jobKind: 'prompt',
+      scheduledByRole: 'owner',
+      scheduledByOrigin: { kind: 'tui', sessionId: 'parent' },
+    }
+    expect(sessionMetaPayload(origin)).toEqual({
+      origin: { kind: 'cron', jobId: 'daily-dream', jobKind: 'prompt' },
+    })
+  })
+
+  test('channel origin keeps addressing ids, drops participants/membership/names', () => {
+    const origin: SessionOrigin = {
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0123',
+      workspaceName: 'Acme Corp',
+      chat: 'C0ABC',
+      chatName: '#general',
+      thread: '1234.567',
+      lastInboundAuthorId: 'U_SECRET',
+      participants: [{ authorId: 'U1', authorName: 'Alice', firstMessageAt: 0, lastMessageAt: 0, messageCount: 1 }],
+    }
+    expect(sessionMetaPayload(origin)).toEqual({
+      origin: {
+        kind: 'channel',
+        adapter: 'slack-bot',
+        workspace: 'T0123',
+        chat: 'C0ABC',
+        thread: '1234.567',
+      },
+    })
+  })
+
+  test('subagent origin keeps subagent name and parentSessionId, drops spawnedByOrigin', () => {
+    const origin: SessionOrigin = {
+      kind: 'subagent',
+      subagent: 'memory-logger',
+      parentSessionId: 'ses_parent',
+      spawnedByRole: 'owner',
+      spawnedByOrigin: { kind: 'tui', sessionId: 'parent' },
+    }
+    expect(sessionMetaPayload(origin)).toEqual({
+      origin: { kind: 'subagent', subagent: 'memory-logger', parentSessionId: 'ses_parent' },
+    })
+  })
+
+  test('does not include any field that would leak workspace/user names to disk', () => {
+    const origin: SessionOrigin = {
+      kind: 'channel',
+      adapter: 'discord-bot',
+      workspace: '9999',
+      workspaceName: 'Sensitive Org Name',
+      chat: '8888',
+      chatName: 'secret-channel',
+      thread: null,
+      lastInboundAuthorId: 'U_SENSITIVE',
+      participants: [
+        { authorId: 'U1', authorName: 'Real Person Name', firstMessageAt: 0, lastMessageAt: 0, messageCount: 5 },
+      ],
+    }
+    const stamped = JSON.stringify(sessionMetaPayload(origin))
+    expect(stamped).not.toContain('Sensitive Org Name')
+    expect(stamped).not.toContain('secret-channel')
+    expect(stamped).not.toContain('Real Person Name')
+    expect(stamped).not.toContain('U_SENSITIVE')
+  })
+})
+
+describe('session-meta integration with pi-coding-agent', () => {
+  // given: a fresh persisted SessionManager from typeclaw's session factory
+  function freshSessionManager() {
+    const factory = createSessionFactory({ agentDir })
+    return factory.createPersisted()
+  }
+
+  test('appendCustomEntry on a fresh session does not crash and survives a first turn', () => {
+    // given
+    const sm = freshSessionManager()
+    const origin: SessionOrigin = { kind: 'tui', sessionId: 'ses_test' }
+
+    // when: stamp before first message, then complete a turn
+    sm.appendCustomEntry(SESSION_META_CUSTOM_TYPE, sessionMetaPayload(origin))
+    const now = Date.now()
+    sm.appendMessage({ role: 'user', content: 'hi', timestamp: now })
+    sm.appendMessage({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'hello' }],
+      api: 'fake',
+      provider: 'fake',
+      model: 'fake',
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 },
+      },
+      stopReason: 'stop',
+      timestamp: now + 1,
+    })
+
+    // then
+    const entries = sm.getEntries()
+    const meta = entries.find((e) => e.type === 'custom' && e.customType === SESSION_META_CUSTOM_TYPE)
+    expect(meta).toBeDefined()
+    if (meta?.type !== 'custom') throw new Error('unreachable')
+    expect(meta.data).toEqual({ origin: { kind: 'tui' } })
+  })
+
+  test('stamped session file is still readable by SessionManager.open()', async () => {
+    // given
+    const sm = freshSessionManager()
+    const file = sm.getSessionFile()
+    if (!file) throw new Error('expected persisted session file')
+
+    // when: stamp + turn → flush
+    sm.appendCustomEntry(SESSION_META_CUSTOM_TYPE, sessionMetaPayload({ kind: 'cron', jobId: 'j1', jobKind: 'prompt' }))
+    const now = Date.now()
+    sm.appendMessage({ role: 'user', content: 'hi', timestamp: now })
+    sm.appendMessage({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'reply' }],
+      api: 'fake',
+      provider: 'fake',
+      model: 'fake',
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 },
+      },
+      stopReason: 'stop',
+      timestamp: now + 1,
+    })
+
+    // when: reopen
+    const reopened = SessionManager.open(file)
+
+    // then: SessionManager.open does not return [] (would mean broken file)
+    const entries = reopened.getEntries()
+    expect(entries.length).toBeGreaterThan(0)
+    const messages = entries.filter((e) => e.type === 'message')
+    expect(messages).toHaveLength(2)
+    const meta = entries.find((e) => e.type === 'custom' && e.customType === SESSION_META_CUSTOM_TYPE)
+    expect(meta).toBeDefined()
+  })
+
+  test('first JSONL line on disk remains the session header (pi invariant)', async () => {
+    // given
+    const sm = freshSessionManager()
+    const file = sm.getSessionFile()
+    if (!file) throw new Error('expected persisted session file')
+
+    // when
+    sm.appendCustomEntry(SESSION_META_CUSTOM_TYPE, sessionMetaPayload({ kind: 'tui', sessionId: 'ses_x' }))
+    const now = Date.now()
+    sm.appendMessage({ role: 'user', content: 'hi', timestamp: now })
+    sm.appendMessage({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'r' }],
+      api: 'fake',
+      provider: 'fake',
+      model: 'fake',
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 },
+      },
+      stopReason: 'stop',
+      timestamp: now + 1,
+    })
+
+    // then
+    const content = await readFile(file, 'utf8')
+    const firstLine = content.split('\n')[0]!
+    const firstEntry = JSON.parse(firstLine)
+    expect(firstEntry.type).toBe('session')
+  })
+})

--- a/src/agent/session-meta.ts
+++ b/src/agent/session-meta.ts
@@ -1,0 +1,43 @@
+import type { SessionOrigin } from './session-origin'
+
+export const SESSION_META_CUSTOM_TYPE = 'typeclaw.session-meta'
+
+export type SessionMetaPayload = {
+  origin: MinimalSessionOrigin
+}
+
+export type MinimalSessionOrigin =
+  | { kind: 'tui' }
+  | { kind: 'cron'; jobId: string; jobKind: 'prompt' | 'exec' | 'subagent' }
+  | { kind: 'channel'; adapter: string; workspace: string; chat: string; thread: string | null }
+  | { kind: 'subagent'; subagent: string; parentSessionId: string }
+
+// Reduce a full SessionOrigin to the minimum projection persisted to disk.
+// Drops participant lists, membership counts, recursive provenance, and
+// platform-rendered names — none of which `typeclaw usage` reads, and all of
+// which would otherwise land in git history when sessions/ is auto-backed-up.
+// Kept as a separate function so the boundary between "data the LLM sees in
+// the system prompt" (full origin) and "data persisted for usage reporting"
+// (this projection) stays explicit.
+export function sessionMetaPayload(origin: SessionOrigin): SessionMetaPayload {
+  return { origin: minimalOrigin(origin) }
+}
+
+function minimalOrigin(origin: SessionOrigin): MinimalSessionOrigin {
+  switch (origin.kind) {
+    case 'tui':
+      return { kind: 'tui' }
+    case 'cron':
+      return { kind: 'cron', jobId: origin.jobId, jobKind: origin.jobKind }
+    case 'channel':
+      return {
+        kind: 'channel',
+        adapter: origin.adapter,
+        workspace: origin.workspace,
+        chat: origin.chat,
+        thread: origin.thread,
+      }
+    case 'subagent':
+      return { kind: 'subagent', subagent: origin.subagent, parentSessionId: origin.parentSessionId }
+  }
+}

--- a/src/cli/compose-usage.test.ts
+++ b/src/cli/compose-usage.test.ts
@@ -23,13 +23,14 @@ function report(opts: {
     firstAt: 0,
     lastAt: 0,
     models: [],
+    originKind: 'unknown' as const,
   }))
   return {
     generatedAt: 0,
     agentDir: opts.agentDir,
     range: { since: null, until: null },
     timezone: 'UTC',
-    aggregation: { total, byDay: [], byModel: [], bySession },
+    aggregation: { total, byDay: [], byModel: [], bySession, byOrigin: [] },
     warnings: opts.warnings ?? [],
   }
 }

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -6,7 +6,7 @@ import { formatJson, formatReport } from '@/usage/report'
 
 import { parseSince, parseUntil, USAGE_COMMON_ARGS } from './usage-args'
 
-const SUBCOMMANDS = ['daily', 'session', 'models'] as const
+const SUBCOMMANDS = ['daily', 'session', 'models', 'origin'] as const
 type Subcommand = (typeof SUBCOMMANDS)[number]
 type View = 'summary' | Subcommand
 
@@ -18,6 +18,13 @@ const COMMON_ARGS = {
   },
 }
 
+// Captured by the parent's `setup` hook (which citty runs BEFORE the matched
+// subcommand's `run`, with the full parent-level argv parsed). Subcommands
+// read this in their own `run` to recover global options like `--since` that
+// appeared before the subcommand name. Single-instance CLI processes only —
+// no concurrency.
+let parentRunArgs: Record<string, unknown> | undefined
+
 const subcommand = (view: View, description: string) =>
   defineCommand({
     meta: { name: view, description },
@@ -26,7 +33,7 @@ const subcommand = (view: View, description: string) =>
       ...(view === 'session' ? { limit: { type: 'string' as const, description: 'max sessions (default 20)' } } : {}),
     },
     async run({ args }) {
-      await emit(view, args)
+      await emit(view, mergeParentArgs(args))
     },
   })
 
@@ -36,10 +43,14 @@ export const usageCommand = defineCommand({
     description: 'report LLM token usage and cost for this agent folder',
   },
   args: COMMON_ARGS,
+  setup({ args }) {
+    parentRunArgs = args as unknown as Record<string, unknown>
+  },
   subCommands: {
     daily: subcommand('daily', 'one row per calendar day'),
     session: subcommand('session', 'top sessions by cost'),
     models: subcommand('models', 'one row per provider/model'),
+    origin: subcommand('origin', 'one row per session origin (tui/cron/channel/subagent)'),
   },
   async run({ args }) {
     // citty invokes both the matched subcommand's `run` and the parent's
@@ -49,6 +60,23 @@ export const usageCommand = defineCommand({
     await emit('summary', args)
   },
 })
+
+// citty's subcommand `run` only sees args that came AFTER the subcommand
+// name (the child's rawArgs is pre-sliced), so `usage --since=X origin` would
+// silently drop `--since` despite the help text advertising it as a global
+// option. The parent's `setup` runs first with the full parent-level parse
+// (which includes everything: global options + subcommand options merged),
+// so we capture it there and merge it as a fallback under any explicitly-set
+// child arg. Child-wins so `usage --since=A origin --since=B` still honours B.
+function mergeParentArgs(childArgs: Record<string, unknown>): Record<string, unknown> {
+  if (parentRunArgs === undefined) return childArgs
+  const merged: Record<string, unknown> = { ...parentRunArgs }
+  for (const key of Object.keys(childArgs)) {
+    const v = childArgs[key]
+    if (v !== undefined && v !== '' && v !== false) merged[key] = v
+  }
+  return merged
+}
 
 async function emit(view: View, args: Record<string, unknown>): Promise<void> {
   const cwdArg = typeof args.cwd === 'string' && args.cwd.length > 0 ? args.cwd : process.cwd()

--- a/src/usage/aggregate.ts
+++ b/src/usage/aggregate.ts
@@ -1,4 +1,5 @@
-import type { AssistantRow } from './scan'
+import type { AssistantRow, OriginKind } from './scan'
+import { ORIGIN_KINDS } from './scan'
 
 export type UsageTotals = {
   messageCount: number
@@ -18,13 +19,16 @@ export type SessionUsage = UsageTotals & {
   firstAt: number
   lastAt: number
   models: string[]
+  originKind: OriginKind
 }
+export type OriginUsage = UsageTotals & { originKind: OriginKind; sessionCount: number }
 
 export type Aggregation = {
   total: UsageTotals
   byDay: DailyUsage[]
   byModel: ModelUsage[]
   bySession: SessionUsage[]
+  byOrigin: OriginUsage[]
 }
 
 export async function aggregate(rows: AsyncIterable<AssistantRow>): Promise<Aggregation> {
@@ -32,6 +36,7 @@ export async function aggregate(rows: AsyncIterable<AssistantRow>): Promise<Aggr
   const byDay = new Map<string, DailyUsage & { _sessionIds: Set<string> }>()
   const byModel = new Map<string, ModelUsage>()
   const bySession = new Map<string, SessionUsage & { _modelSet: Set<string> }>()
+  const byOrigin = new Map<OriginKind, OriginUsage & { _sessionIds: Set<string> }>()
 
   for await (const row of rows) {
     addInto(total, row)
@@ -66,6 +71,7 @@ export async function aggregate(rows: AsyncIterable<AssistantRow>): Promise<Aggr
       lastAt: row.timestamp,
       models: [],
       _modelSet: new Set<string>(),
+      originKind: row.originKind,
     }
     addInto(sessionBucket, row)
     sessionBucket.firstAt = Math.min(sessionBucket.firstAt, row.timestamp)
@@ -73,6 +79,17 @@ export async function aggregate(rows: AsyncIterable<AssistantRow>): Promise<Aggr
     sessionBucket._modelSet.add(modelKey)
     sessionBucket.models = [...sessionBucket._modelSet]
     bySession.set(sessionKey, sessionBucket)
+
+    const originBucket = byOrigin.get(row.originKind) ?? {
+      ...emptyTotals(),
+      originKind: row.originKind,
+      sessionCount: 0,
+      _sessionIds: new Set<string>(),
+    }
+    addInto(originBucket, row)
+    originBucket._sessionIds.add(sessionKey)
+    originBucket.sessionCount = originBucket._sessionIds.size
+    byOrigin.set(row.originKind, originBucket)
   }
 
   return {
@@ -80,7 +97,19 @@ export async function aggregate(rows: AsyncIterable<AssistantRow>): Promise<Aggr
     byDay: [...byDay.values()].map(({ _sessionIds: _, ...rest }) => rest).sort((a, b) => a.date.localeCompare(b.date)),
     byModel: [...byModel.values()].sort((a, b) => b.cost - a.cost),
     bySession: [...bySession.values()].map(({ _modelSet: _, ...rest }) => rest).sort((a, b) => b.cost - a.cost),
+    byOrigin: [...byOrigin.values()]
+      .map(({ _sessionIds: _, ...rest }) => rest)
+      .sort((a, b) => originSortIndex(a.originKind) - originSortIndex(b.originKind)),
   }
+}
+
+// Stable presentation order for the byOrigin table. Matches ORIGIN_KINDS so
+// the renderer doesn't need to know about ordering. 'unknown' is pinned last
+// because it represents legacy/malformed data the user probably cares about
+// least.
+function originSortIndex(kind: OriginKind): number {
+  const idx = (ORIGIN_KINDS as readonly OriginKind[]).indexOf(kind)
+  return idx === -1 ? Number.MAX_SAFE_INTEGER : idx
 }
 
 function emptyTotals(): UsageTotals {

--- a/src/usage/index.test.ts
+++ b/src/usage/index.test.ts
@@ -457,6 +457,267 @@ describe('formatReport cache hit rate column', () => {
   /* eslint-enable no-control-regex */
 })
 
+describe('runUsage origin attribution (typeclaw.session-meta custom entry)', () => {
+  // given: helper that writes a pi-shaped session JSONL whose first non-header
+  // entry is a typeclaw.session-meta custom entry. Mirrors the on-disk format
+  // produced by sessionManager.appendCustomEntry('typeclaw.session-meta', ...).
+  async function writeWithOrigin(sessionId: string, originKind: string, lines: object[]): Promise<void> {
+    const sessionsDir = join(agentDir, 'sessions')
+    await mkdir(sessionsDir, { recursive: true })
+    const ts = new Date('2026-05-10T00:00:00Z').toISOString().replace(/[:.]/g, '-')
+    const file = join(sessionsDir, `${ts}_${sessionId}.jsonl`)
+    const sessionHeader = { type: 'session', version: 3, id: sessionId, timestamp: ts, cwd: agentDir }
+    const meta = {
+      type: 'custom',
+      customType: 'typeclaw.session-meta',
+      data: { origin: { kind: originKind } },
+      id: `meta-${sessionId}`,
+      parentId: null,
+      timestamp: ts,
+    }
+    await writeFile(file, [sessionHeader, meta, ...lines].map((l) => JSON.stringify(l)).join('\n'))
+  }
+
+  test('attributes tokens to the origin kind from the session-meta line', async () => {
+    const ts = new Date('2026-05-10T10:00:00').getTime()
+    await writeWithOrigin('tui00001', 'tui', [
+      assistantEntry({ id: 'm1', ts, provider: 'p', model: 'x', input: 100, output: 10, cost: 0.01 }),
+    ])
+    await writeWithOrigin('cron0001', 'cron', [
+      assistantEntry({ id: 'm2', ts, provider: 'p', model: 'x', input: 200, output: 20, cost: 0.02 }),
+    ])
+    await writeWithOrigin('chan0001', 'channel', [
+      assistantEntry({ id: 'm3', ts, provider: 'p', model: 'x', input: 300, output: 30, cost: 0.03 }),
+    ])
+    await writeWithOrigin('suba0001', 'subagent', [
+      assistantEntry({ id: 'm4', ts, provider: 'p', model: 'x', input: 50, output: 5, cost: 0.005 }),
+    ])
+    // legacy file with no session-meta
+    await writeSessionFile('lega0001', [
+      assistantEntry({ id: 'm5', ts, provider: 'p', model: 'x', input: 10, output: 1, cost: 0.001 }),
+    ])
+
+    const report = await runUsage({ agentDir })
+    const byOrigin = Object.fromEntries(report.aggregation.byOrigin.map((o) => [o.originKind, o]))
+    expect(byOrigin.tui?.cost).toBeCloseTo(0.01, 5)
+    expect(byOrigin.cron?.cost).toBeCloseTo(0.02, 5)
+    expect(byOrigin.channel?.cost).toBeCloseTo(0.03, 5)
+    expect(byOrigin.subagent?.cost).toBeCloseTo(0.005, 5)
+    expect(byOrigin.unknown?.cost).toBeCloseTo(0.001, 5)
+  })
+
+  test('session-meta with unknown kind falls back to unknown bucket', async () => {
+    const ts = new Date('2026-05-10T10:00:00').getTime()
+    await writeWithOrigin('weird001', 'mystery-future-kind', [
+      assistantEntry({ id: 'm1', ts, provider: 'p', model: 'x', input: 10, output: 1, cost: 0.001 }),
+    ])
+    const report = await runUsage({ agentDir })
+    const buckets = report.aggregation.byOrigin.map((o) => o.originKind)
+    expect(buckets).toEqual(['unknown'])
+  })
+
+  test('first-stamp-wins: a later session-meta in the same file is ignored', async () => {
+    // given: a file with two session-meta entries (rare, but possible if a
+    // session is somehow re-stamped) — first one should win to keep
+    // attribution stable across session resumes
+    const sessionsDir = join(agentDir, 'sessions')
+    await mkdir(sessionsDir, { recursive: true })
+    const ts = new Date('2026-05-10T10:00:00').getTime()
+    const isoTs = new Date('2026-05-10T00:00:00Z').toISOString().replace(/[:.]/g, '-')
+    const file = join(sessionsDir, `${isoTs}_doublest.jsonl`)
+    const header = { type: 'session', version: 3, id: 'doublest', timestamp: isoTs, cwd: agentDir }
+    const meta1 = {
+      type: 'custom',
+      customType: 'typeclaw.session-meta',
+      data: { origin: { kind: 'tui' } },
+      id: 'm1',
+      parentId: null,
+      timestamp: isoTs,
+    }
+    const meta2 = {
+      type: 'custom',
+      customType: 'typeclaw.session-meta',
+      data: { origin: { kind: 'cron' } },
+      id: 'm2',
+      parentId: 'm1',
+      timestamp: isoTs,
+    }
+    const assistant = assistantEntry({ id: 'a1', ts, provider: 'p', model: 'x', input: 100, output: 10, cost: 0.05 })
+    await writeFile(file, [header, meta1, meta2, assistant].map((l) => JSON.stringify(l)).join('\n'))
+
+    const report = await runUsage({ agentDir })
+    expect(report.aggregation.byOrigin).toHaveLength(1)
+    expect(report.aggregation.byOrigin[0]?.originKind).toBe('tui')
+  })
+
+  test('stamps originKind onto bySession rows for downstream rendering', async () => {
+    const ts = new Date('2026-05-10T10:00:00').getTime()
+    await writeWithOrigin('tui99999', 'tui', [
+      assistantEntry({ id: 'm1', ts, provider: 'p', model: 'x', input: 1000, output: 100, cost: 0.5 }),
+    ])
+    const report = await runUsage({ agentDir })
+    expect(report.aggregation.bySession[0]?.originKind).toBe('tui')
+  })
+
+  test('honors since/until window for origin aggregation', async () => {
+    const tEarly = new Date('2026-05-01T00:00:00').getTime()
+    const tLate = new Date('2026-05-20T00:00:00').getTime()
+    await writeWithOrigin('range002', 'channel', [
+      assistantEntry({ id: 'm1', ts: tEarly, provider: 'p', model: 'x', input: 100, output: 10, cost: 0.01 }),
+      assistantEntry({ id: 'm2', ts: tLate, provider: 'p', model: 'x', input: 200, output: 20, cost: 0.02 }),
+    ])
+    const inRange = await runUsage({ agentDir, since: tLate })
+    expect(inRange.aggregation.byOrigin).toHaveLength(1)
+    expect(inRange.aggregation.byOrigin[0]?.originKind).toBe('channel')
+    expect(inRange.aggregation.byOrigin[0]?.cost).toBeCloseTo(0.02, 5)
+  })
+
+  test('session counts per origin bucket dedupe by session id', async () => {
+    const ts = new Date('2026-05-10T10:00:00').getTime()
+    await writeWithOrigin('chan_a01', 'channel', [
+      assistantEntry({ id: 'm1', ts, provider: 'p', model: 'x', input: 10, output: 1, cost: 0.001 }),
+      assistantEntry({ id: 'm2', ts: ts + 1, provider: 'p', model: 'x', input: 10, output: 1, cost: 0.001 }),
+    ])
+    await writeWithOrigin('chan_b01', 'channel', [
+      assistantEntry({ id: 'm3', ts, provider: 'p', model: 'x', input: 10, output: 1, cost: 0.001 }),
+    ])
+    const report = await runUsage({ agentDir })
+    const channel = report.aggregation.byOrigin.find((o) => o.originKind === 'channel')!
+    expect(channel.messageCount).toBe(3)
+    expect(channel.sessionCount).toBe(2)
+  })
+})
+
+describe('formatReport origin view', () => {
+  async function writeWithOrigin(sessionId: string, originKind: string, lines: object[]): Promise<void> {
+    const sessionsDir = join(agentDir, 'sessions')
+    await mkdir(sessionsDir, { recursive: true })
+    const ts = new Date('2026-05-10T00:00:00Z').toISOString().replace(/[:.]/g, '-')
+    const file = join(sessionsDir, `${ts}_${sessionId}.jsonl`)
+    const sessionHeader = { type: 'session', version: 3, id: sessionId, timestamp: ts, cwd: agentDir }
+    const meta = {
+      type: 'custom',
+      customType: 'typeclaw.session-meta',
+      data: { origin: { kind: originKind } },
+      id: `meta-${sessionId}`,
+      parentId: null,
+      timestamp: ts,
+    }
+    await writeFile(file, [sessionHeader, meta, ...lines].map((l) => JSON.stringify(l)).join('\n'))
+  }
+
+  test('origin view renders a header and origin labels', async () => {
+    const ts = new Date('2026-05-10T10:00:00').getTime()
+    await writeWithOrigin('tui_a', 'tui', [
+      assistantEntry({ id: 'm1', ts, provider: 'p', model: 'x', input: 100, output: 10, cost: 0.01 }),
+    ])
+    await writeWithOrigin('cron_a', 'cron', [
+      assistantEntry({ id: 'm2', ts, provider: 'p', model: 'x', input: 200, output: 20, cost: 0.02 }),
+    ])
+    const report = await runUsage({ agentDir })
+    const out = formatReport(report, { view: 'origin' })
+    expect(out).toMatch(/USAGE BY ORIGIN/)
+    expect(out).toMatch(/tui/)
+    expect(out).toMatch(/cron/)
+  })
+
+  test('origin view renders a Sessions column with per-row counts (no decorative bar)', async () => {
+    const ts = new Date('2026-05-10T10:00:00').getTime()
+    await writeWithOrigin('tui_b', 'tui', [
+      assistantEntry({ id: 'm1', ts, provider: 'p', model: 'x', input: 100, output: 10, cost: 0.5 }),
+    ])
+    await writeWithOrigin('cron_b', 'cron', [
+      assistantEntry({ id: 'm2', ts, provider: 'p', model: 'x', input: 200, output: 20, cost: 0.05 }),
+    ])
+    const report = await runUsage({ agentDir })
+    const out = formatReport(report, { view: 'origin' })
+    expect(out).toMatch(/Sessions/)
+    expect(out).not.toMatch(/Cost share/)
+    expect(out).not.toMatch(/▰|▱/)
+  })
+
+  test('summary view includes a By origin section when origin data is present', async () => {
+    const ts = new Date('2026-05-10T10:00:00').getTime()
+    await writeWithOrigin('chan_c', 'channel', [
+      assistantEntry({ id: 'm1', ts, provider: 'p', model: 'x', input: 100, output: 10, cost: 0.01 }),
+    ])
+    const report = await runUsage({ agentDir })
+    const out = formatReport(report, { view: 'summary' })
+    expect(out).toMatch(/By origin/)
+  })
+
+  test('summary view renders a daily sparkline trend when ≥2 days are present', async () => {
+    const ts1 = new Date('2026-05-10T10:00:00').getTime()
+    const ts2 = new Date('2026-05-11T10:00:00').getTime()
+    await writeWithOrigin('trend_a', 'tui', [
+      assistantEntry({ id: 'm1', ts: ts1, provider: 'p', model: 'x', input: 100, output: 10, cost: 0.01 }),
+      assistantEntry({ id: 'm2', ts: ts2, provider: 'p', model: 'x', input: 500, output: 50, cost: 0.5 }),
+    ])
+    const report = await runUsage({ agentDir })
+    const out = formatReport(report, { view: 'summary' })
+    expect(out).toMatch(/Trend \(cost\):/)
+    expect(out).toMatch(/[▁▂▃▄▅▆▇█]/)
+  })
+
+  test('summary view omits the sparkline when only a single day of data exists', async () => {
+    const ts = new Date('2026-05-10T10:00:00').getTime()
+    await writeWithOrigin('trend_b', 'tui', [
+      assistantEntry({ id: 'm1', ts, provider: 'p', model: 'x', input: 100, output: 10, cost: 0.01 }),
+    ])
+    const report = await runUsage({ agentDir })
+    const out = formatReport(report, { view: 'summary' })
+    expect(out).not.toMatch(/Trend \(cost\):/)
+  })
+
+  test('session view prepends an origin glyph to each row label', async () => {
+    const ts = new Date('2026-05-10T10:00:00').getTime()
+    // Session id must not contain underscores: sessionIdFromBasename splits on
+    // the last `_`, so `tui_glyph` would collapse into `glyph` and collide.
+    await writeWithOrigin('tuiglyph', 'tui', [
+      assistantEntry({ id: 'm1', ts, provider: 'p', model: 'x', input: 100, output: 10, cost: 0.5 }),
+    ])
+    await writeWithOrigin('cronglyph', 'cron', [
+      assistantEntry({ id: 'm2', ts, provider: 'p', model: 'x', input: 200, output: 20, cost: 0.4 }),
+    ])
+    const report = await runUsage({ agentDir })
+    const out = formatReport(report, { view: 'session' })
+    expect(out).toMatch(/▶/)
+    expect(out).toMatch(/⏱/)
+  })
+
+  test('empty-state origin view renders an explicit message', async () => {
+    const report = await runUsage({ agentDir })
+    const out = formatReport(report, { view: 'origin' })
+    expect(out).toMatch(/USAGE BY ORIGIN/)
+    expect(out).toMatch(/No assistant turns/i)
+  })
+
+  test('origin view fits within narrow terminals (no bar to drop, rows stay compact)', async () => {
+    const ts = new Date('2026-05-10T10:00:00').getTime()
+    await writeWithOrigin('narr_a', 'tui', [
+      assistantEntry({ id: 'm1', ts, provider: 'p', model: 'x', input: 100, output: 10, cost: 0.5 }),
+    ])
+    await writeWithOrigin('narr_b', 'cron', [
+      assistantEntry({ id: 'm2', ts, provider: 'p', model: 'x', input: 200, output: 20, cost: 0.1 }),
+    ])
+    const report = await runUsage({ agentDir })
+    const narrow = formatReport(report, { view: 'origin', terminalWidth: 60 })
+    // Table rows (Item/header/data/Total) — stripped of ANSI — must fit
+    // within terminalWidth. The leading section title line is excluded:
+    // titles include the full agentDir path, which the renderer is not
+    // expected to truncate (a TTY wraps it naturally on display).
+    /* eslint-disable no-control-regex -- ANSI escape sequences are deliberately matched here. */
+    const tableLines = narrow
+      .replace(/\u001b\[[0-9;]*m/g, '')
+      .split('\n')
+      .filter((l) => /^(Item|▶|⏱|#|↳|\?|Total)/.test(l))
+    /* eslint-enable no-control-regex */
+    expect(tableLines.length).toBeGreaterThan(0)
+    const maxLen = Math.max(...tableLines.map((l) => l.length))
+    expect(maxLen).toBeLessThanOrEqual(60)
+  })
+})
+
 describe('formatReport Sent column (provider-billed volume = input + cacheRead)', () => {
   const ts = new Date('2026-05-10T10:00:00').getTime()
 

--- a/src/usage/index.ts
+++ b/src/usage/index.ts
@@ -4,8 +4,9 @@ import type { Aggregation } from './aggregate'
 import { aggregate } from './aggregate'
 import { scanAssistantRows } from './scan'
 
-export type { Aggregation, DailyUsage, ModelUsage, SessionUsage, UsageTotals } from './aggregate'
-export type { AssistantRow } from './scan'
+export type { Aggregation, DailyUsage, ModelUsage, OriginUsage, SessionUsage, UsageTotals } from './aggregate'
+export type { AssistantRow, OriginKind } from './scan'
+export { ORIGIN_KINDS } from './scan'
 
 export type UsageReport = {
   generatedAt: number

--- a/src/usage/report.ts
+++ b/src/usage/report.ts
@@ -1,12 +1,13 @@
 import { styleText } from 'node:util'
 
-import type { ModelUsage, UsageTotals } from './aggregate'
+import type { ModelUsage, OriginUsage, UsageTotals } from './aggregate'
 import { formatCacheHitRate, formatCost, formatTokens, isoDay } from './format'
 import type { UsageReport } from './index'
+import type { OriginKind } from './scan'
 
 export type FormatOptions = {
   useColor?: boolean
-  view?: 'summary' | 'daily' | 'session' | 'models'
+  view?: 'summary' | 'daily' | 'session' | 'models' | 'origin'
   limit?: number
   // Terminal width hint used to size the elastic Item column. Omit to render
   // without truncation (tests, piped output where columns is undefined).
@@ -26,6 +27,8 @@ export function formatReport(report: UsageReport, opts: FormatOptions = {}): str
       return renderSessions(report, ctx, opts.limit ?? 20)
     case 'models':
       return renderModels(report, ctx, opts.limit)
+    case 'origin':
+      return renderOrigin(report, ctx)
   }
 }
 
@@ -58,10 +61,18 @@ function renderSummary(report: UsageReport, ctx: RenderCtx): string {
 
   if (aggregation.byDay.length > 0) {
     sections.push('')
+    const trend = renderDailyTrend(aggregation.byDay, ctx)
+    if (trend !== null) sections.push(trend, '')
     sections.push(header('By day (most recent first)', ctx))
     const recent = aggregation.byDay.slice(-7).reverse()
     const dayRows = recent.map((d) => ({ label: d.date, totals: d as UsageTotals }))
     sections.push(renderTotalsTable(dayRows, ctx, { total: totalOfRows(dayRows) }))
+  }
+
+  if (aggregation.byOrigin.length > 0) {
+    sections.push('')
+    sections.push(header('By origin', ctx))
+    sections.push(renderOriginTable(aggregation.byOrigin, ctx))
   }
 
   if (aggregation.byModel.length > 0) {
@@ -84,6 +95,79 @@ function renderSummary(report: UsageReport, ctx: RenderCtx): string {
   return sections.join('\n')
 }
 
+function renderOrigin(report: UsageReport, ctx: RenderCtx): string {
+  const sections: string[] = [sectionTitle('USAGE BY ORIGIN', report.agentDir, ctx)]
+  if (report.aggregation.byOrigin.length === 0) {
+    sections.push(dim('No assistant turns recorded yet.', ctx))
+    return sections.join('\n')
+  }
+  sections.push(renderOriginTable(report.aggregation.byOrigin, ctx))
+  return sections.join('\n')
+}
+
+// Single source of truth for the origin breakdown table used by both the
+// summary view and the dedicated `usage origin` subcommand. Matches the
+// column shape of renderTotalsTable's other callers (byDay, byModel) plus
+// one extra column for session count — deliberately plain numbers rather
+// than a proportional bar, since the Cost column already lets the eye sort
+// rows by spend and an extra "share of max" bar adds no information that
+// isn't already in the report.
+function renderOriginTable(byOrigin: readonly OriginUsage[], ctx: RenderCtx): string {
+  const rows = byOrigin.map((o) => ({
+    label: renderOriginLabel(o.originKind, ctx),
+    totals: o as UsageTotals,
+    extra: String(o.sessionCount),
+    extraTruncatable: false,
+  }))
+  return renderTotalsTable(rows, ctx, {
+    extraHeader: 'Sessions',
+    total: totalOfRows(rows),
+  })
+}
+
+// Glyph + colored label for each origin kind. The glyphs are chosen to be
+// instantly readable in a dense table: ▶ for TUI (interactive), ⏱ for cron
+// (time-triggered), # for channel (chat-room sigil), ↳ for subagent (child),
+// ? for unknown. ASCII fallbacks are not provided — the codebase already
+// requires unicode for `…` `●` `✓` etc. on other commands.
+function renderOriginLabel(kind: OriginKind, ctx: RenderCtx): string {
+  switch (kind) {
+    case 'tui':
+      return `${color('cyan', '▶', ctx)} ${'tui'}`
+    case 'cron':
+      return `${color('magenta', '⏱', ctx)} ${'cron'}`
+    case 'channel':
+      return `${color('green', '#', ctx)} ${'channel'}`
+    case 'subagent':
+      return `${color('yellow', '↳', ctx)} ${'subagent'}`
+    case 'unknown':
+      return `${dim('?', ctx)} ${dim('unknown', ctx)}`
+  }
+}
+
+// Sparkline trend across the full byDay range, scaled to the row's max cost.
+// Returns null when there are fewer than 2 days (a single point conveys no
+// trend information). The 8-level Unicode block scale `▁▂▃▄▅▆▇█` lets us
+// pack ~80 days into a one-line glance — wider than any table-based view
+// could fit at terminal widths under ~160 columns.
+const SPARK_GLYPHS = '▁▂▃▄▅▆▇█'
+
+function renderDailyTrend(byDay: readonly { date: string; cost: number }[], ctx: RenderCtx): string | null {
+  if (byDay.length < 2) return null
+  const costs = byDay.map((d) => d.cost)
+  const max = costs.reduce((m, c) => Math.max(m, c), 0)
+  if (max <= 0) return null
+  const spark = costs
+    .map((c) => {
+      const idx = Math.min(SPARK_GLYPHS.length - 1, Math.max(0, Math.round((c / max) * (SPARK_GLYPHS.length - 1))))
+      return SPARK_GLYPHS[idx]!
+    })
+    .join('')
+  const first = byDay[0]!.date
+  const last = byDay[byDay.length - 1]!.date
+  return `${dim('Trend (cost):', ctx)} ${color('cyan', spark, ctx)}  ${dim(`${first} → ${last}`, ctx)}`
+}
+
 function renderDaily(report: UsageReport, ctx: RenderCtx, limit: number | undefined): string {
   const days = limit !== undefined ? report.aggregation.byDay.slice(-limit) : report.aggregation.byDay
   if (days.length === 0) return dim('No usage in range.', ctx)
@@ -100,8 +184,9 @@ function renderSessions(report: UsageReport, ctx: RenderCtx, limit: number): str
   const rows = sessions.map((s) => {
     const firstModel = s.models[0]
     const extra = s.models.length > 1 ? `${s.models.length} models` : modelIdFromKey(firstModel)
+    const originGlyph = originGlyphOnly(s.originKind, ctx)
     return {
-      label: `${color('magenta', s.sessionId.slice(0, 12), ctx)}  ${dim(isoDay(s.firstAt), ctx)}`,
+      label: `${originGlyph}  ${color('magenta', s.sessionId.slice(0, 12), ctx)}  ${dim(isoDay(s.firstAt), ctx)}`,
       totals: s as UsageTotals,
       extra,
       extraTruncatable: s.models.length === 1,
@@ -111,6 +196,21 @@ function renderSessions(report: UsageReport, ctx: RenderCtx, limit: number): str
     sectionTitle(`USAGE BY SESSION`, report.agentDir, ctx, `(top ${limit} by cost)`),
     renderTotalsTable(rows, ctx, { extraHeader: 'Model', total: totalOfRows(rows) }),
   ].join('\n')
+}
+
+function originGlyphOnly(kind: OriginKind, ctx: RenderCtx): string {
+  switch (kind) {
+    case 'tui':
+      return color('cyan', '▶', ctx)
+    case 'cron':
+      return color('magenta', '⏱', ctx)
+    case 'channel':
+      return color('green', '#', ctx)
+    case 'subagent':
+      return color('yellow', '↳', ctx)
+    case 'unknown':
+      return dim('?', ctx)
+  }
 }
 
 function renderModels(report: UsageReport, ctx: RenderCtx, limit: number | undefined): string {

--- a/src/usage/scan.ts
+++ b/src/usage/scan.ts
@@ -1,6 +1,14 @@
 import { readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 
+// Recognised origin kinds. Keep aligned with SessionOrigin's discriminator in
+// src/agent/session-origin.ts. The 'unknown' bucket catches sessions written
+// before origin stamping landed AND sessions whose session-meta line is
+// malformed or missing — surfacing them under one explicit label is more
+// honest than silently dropping them.
+export const ORIGIN_KINDS = ['tui', 'cron', 'channel', 'subagent', 'unknown'] as const
+export type OriginKind = (typeof ORIGIN_KINDS)[number]
+
 // Narrow projection: session files can grow into tens of MB on long-lived
 // agents, so we deliberately drop content/tool blocks before aggregation.
 export type AssistantRow = {
@@ -15,6 +23,7 @@ export type AssistantRow = {
   cacheWrite: number
   totalTokens: number
   cost: number
+  originKind: OriginKind
 }
 
 export type ScanOptions = {
@@ -66,6 +75,13 @@ async function* readSessionFile(file: string, opts: ScanOptions): AsyncGenerator
   }
   const decoder = new TextDecoder()
   let buf = ''
+  // First-stamp-wins per file. Once a `typeclaw.session-meta` custom entry
+  // pins the origin, later entries with the same customType are ignored —
+  // session-resume code paths may legitimately re-stamp on reopen, and the
+  // earliest one is the authoritative one for the session's first turn.
+  // Stays 'unknown' for legacy files (no stamp at all) so usage attribution
+  // surfaces them as a distinct bucket rather than dropping the rows.
+  const ctx: ParseCtx = { originKind: 'unknown', originPinned: false }
   try {
     for await (const chunk of stream) {
       buf += decoder.decode(chunk, { stream: true })
@@ -73,7 +89,7 @@ async function* readSessionFile(file: string, opts: ScanOptions): AsyncGenerator
       while (nl !== -1) {
         const line = buf.slice(0, nl)
         buf = buf.slice(nl + 1)
-        const row = parseLine(line, file, basename, opts)
+        const row = parseLine(line, file, basename, opts, ctx)
         if (row !== null) yield row
         nl = buf.indexOf('\n')
       }
@@ -86,17 +102,20 @@ async function* readSessionFile(file: string, opts: ScanOptions): AsyncGenerator
   // half-written record from a live writer is silently skipped (parseLine
   // returns null and does NOT warn for the tail).
   if (buf.length > 0) {
-    const row = parseLine(buf, file, basename, opts, { isTail: true })
+    const row = parseLine(buf, file, basename, opts, ctx, { isTail: true })
     if (row !== null) yield row
   }
 }
+
+type ParseCtx = { originKind: OriginKind; originPinned: boolean }
 
 function parseLine(
   line: string,
   file: string,
   basename: string,
   opts: ScanOptions,
-  ctx: { isTail?: boolean } = {},
+  ctx: ParseCtx,
+  flags: { isTail?: boolean } = {},
 ): AssistantRow | null {
   const trimmed = line.trim()
   if (trimmed === '') return null
@@ -106,7 +125,18 @@ function parseLine(
     entry = JSON.parse(trimmed)
   } catch {
     // Silently skip the trailing tail: a live writer may be mid-append.
-    if (ctx.isTail !== true) opts.onWarn?.(`skipping malformed JSONL line in ${basename}`)
+    if (flags.isTail !== true) opts.onWarn?.(`skipping malformed JSONL line in ${basename}`)
+    return null
+  }
+
+  if (isSessionMetaCustomEntry(entry)) {
+    if (!ctx.originPinned) {
+      const kind = entry.data.origin.kind
+      if ((ORIGIN_KINDS as readonly string[]).includes(kind)) {
+        ctx.originKind = kind as OriginKind
+        ctx.originPinned = true
+      }
+    }
     return null
   }
 
@@ -134,7 +164,32 @@ function parseLine(
     cacheWrite: numberOrZero(u.cacheWrite),
     totalTokens: numberOrZero(u.totalTokens),
     cost: numberOrZero(u.cost?.total),
+    originKind: ctx.originKind,
   }
+}
+
+// Pi-coding-agent persists `appendCustomEntry(customType, data)` calls as
+// `{type:"custom", customType, data, id, parentId, timestamp}` lines. We
+// stamp our origin block with customType `typeclaw.session-meta` (constant
+// kept in src/agent/session-meta.ts; duplicated as a literal here to keep
+// the usage subsystem free of agent-stack imports — a Grep across the repo
+// is the chosen drift guard).
+type SessionMetaCustomEntry = {
+  type: 'custom'
+  customType: 'typeclaw.session-meta'
+  data: { origin: { kind: string } }
+}
+
+function isSessionMetaCustomEntry(value: unknown): value is SessionMetaCustomEntry {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  if (v.type !== 'custom') return false
+  if (v.customType !== 'typeclaw.session-meta') return false
+  if (typeof v.data !== 'object' || v.data === null) return false
+  const d = v.data as Record<string, unknown>
+  if (typeof d.origin !== 'object' || d.origin === null) return false
+  const o = d.origin as Record<string, unknown>
+  return typeof o.kind === 'string'
 }
 
 type MessageEntry = { type: 'message'; message: { role: string; [k: string]: unknown } }


### PR DESCRIPTION
## Why

Today `typeclaw usage` only knows four buckets: total, byDay, byModel, bySession. It cannot answer "is my cron eating all my Fireworks credits?" or "how much does the dreaming subagent actually cost per night?". The session-origin signal exists at runtime (`SessionOrigin` discriminated union: tui / cron / channel / subagent) but is never persisted, so the usage scanner is blind to it.

This PR persists origin alongside session content and adds it as a 5th aggregation dimension. Closes the subagent-usage visibility gap motivated by #185 / followed up in #186.

## What the user sees

```
USAGE — /tmp/typeclaw-usage-demo
Timezone: Asia/Seoul
Sessions: 5  Messages: 5  In: 3.9k  Out: 670  Sent: 17k  Cost: $0.240

Trend (cost): █▂▆  2026-05-16 → 2026-05-18

By day (most recent first)
Item        Msgs    In  Out  Sent  Cache %    Cost
2026-05-18     2  1.3k  250  6.3k      79%  $0.095
2026-05-17     1   500  100   500       0%  $0.020
2026-05-16     2  2.1k  320   10k      79%  $0.125
Total          5  3.9k  670   17k      77%  $0.240

By origin
Item        Msgs    In  Out  Sent  Cache %     Cost  Sessions
▶ tui          1  2.0k  300   10k      80%   $0.120         1
⏱ cron         1   500  100   500       0%   $0.020         1
# channel      1  1.0k  200  6.0k      83%   $0.080         1
↳ subagent     1   300   50   300       0%   $0.015         1
? unknown      1   100   20   100       0%  $0.0050         1
Total          5  3.9k  670   17k      77%   $0.240
```

A new `typeclaw usage origin` subcommand renders the origin breakdown standalone. The existing `typeclaw usage session` view prepends an origin glyph (▶/⏱/#/↳/?) to every row. Global `--since/--until` work whether placed before OR after the subcommand name.

The origin table matches the column shape of the existing `byDay` and `byModel` tables (Item / Msgs / In / Out / Sent / Cache % / Cost) plus one extra `Sessions` column — deliberately plain numbers rather than a proportional bar, since the Cost column already lets the eye sort rows by spend.

## How it works

The signal is plumbed through pi-coding-agent's blessed extension API — not by writing a raw JSONL line.

**Writer side**: in `createSessionWithDispose`, immediately after `sessionManager` is resolved:

```ts
if (options.origin !== undefined && sessionManager.getSessionFile() !== undefined) {
  const alreadyStamped = sessionManager
    .getEntries()
    .some((e) => e.type === 'custom' && e.customType === SESSION_META_CUSTOM_TYPE)
  if (!alreadyStamped) {
    sessionManager.appendCustomEntry(SESSION_META_CUSTOM_TYPE, sessionMetaPayload(options.origin))
  }
}
```

pi persists this as `{type:"custom", customType:"typeclaw.session-meta", data:{origin:{...}}, id, parentId, timestamp}`. Three properties make this the right insertion point:

1. **The session header (`{type:"session", version:3, ...}`) stays at offset 0** because pi appends our custom entry after it. `SessionManager.open()` keeps working — channel rehydrate, fork, resume all unaffected.
2. **`type:"custom"` is ignored by `buildSessionContext()`** (verified in `node_modules/@mariozechner/pi-coding-agent/dist/core/session-manager.js`'s message-builder switch), so the origin block never lands in the LLM prompt. Pure side-channel metadata.
3. **pi handles file-creation timing**. pi defers the first write until the first assistant message arrives; our `appendCustomEntry` call goes into in-memory `fileEntries` and flushes alongside the first assistant turn. No `fs.stat`-based gating needed — and crucially, no ENOENT race.

The stamped payload is a **minimal projection** of `SessionOrigin`: just `kind` plus the drill-down ids the scanner could plausibly need later (cron jobId/jobKind, channel adapter/workspace/chat/thread, subagent name/parentSessionId). Participants lists, membership counts, recursive provenance, and platform-rendered names are dropped — those already live in the session-prompt system message for the LLM, but persisting them again as machine-parseable JSONL would inflate the security footprint of auto-backed-up session files for zero usage-reporting gain.

**Reader side**: `scan.ts` walks each session JSONL line by line. When it encounters a `custom` entry with `customType:"typeclaw.session-meta"` and a valid `data.origin.kind`, it pins that as the file's origin **first-stamp-wins** (later stamps in the same file are ignored, so session resume keeps stable attribution). Every `AssistantRow` emitted from that file carries `originKind`. Legacy session files written before this commit have no stamp and fall into an explicit `unknown` bucket rather than being dropped.

**Aggregator**: `aggregate.ts` adds a fifth `byOrigin: OriginUsage[]` bucket to `Aggregation` with per-kind totals, cost, and deduped session count. `SessionUsage` gains an `originKind` field so the session view can render glyphs without a second lookup.

**Renderer**: new `renderOrigin` view, `renderOriginTable` (one extra Sessions column on top of the existing `renderTotalsTable` shape), `renderDailyTrend` (sparkline `▁▂▃▄▅▆▇█` requiring ≥2 days), `renderOriginLabel` / `originGlyphOnly` for glyphs. New `origin` subcommand wired into `cli/usage.ts` alongside `daily`/`session`/`models`. Global `--since/--until` are recovered via the parent's `setup` hook because citty's subcommand `rawArgs` only contains post-subcommand args.

## What changed during review

The first iteration of this PR stamped a top-level `{type:"session-meta", ...}` JSONL line and gated the write on `fs.stat(path).size === 0`. A 5-agent parallel review (oracle goal-verifier, oracle code-quality, oracle security, hands-on QA, context-mining) flagged two blockers in 3 of 5 verdicts:

1. pi-coding-agent defers file creation until the first assistant message arrives, so `fs.stat` returned ENOENT for every fresh session — the stamp was silently skipped and every real session aggregated as `unknown`. Tests passed only because every fixture pre-created the empty file via `writeFile(file, '')`, missing the real pi timing.
2. `loadEntriesFromFile()` validates that the first JSONL line is `{type:"session", ...}` — a `session-meta` line at offset 0 would have broken `SessionManager.open()` and every consumer that depends on it (channel rehydrate at `src/channels/persistence.ts`, fork/resume).

The fix in this revision: switch to `appendCustomEntry` (pi's documented extension API), drop the `fs.stat` gate entirely, and add a real `createSessionFactory() → appendMessage → SessionManager.open()` round-trip test that pins all three invariants — header at offset 0, custom stamp reachable via `getEntries()`, file still parseable after reopen. QA also surfaced two P1 UX bugs (global `--since` before subcommand was dropped; narrow-terminal rows overflowed); both fixed here.

A follow-up review of the rendered output flagged the cost-share `▰▱` bar column as ambiguous (`▰▰▰▰▰▰▰▰▰▰  179` — the bar means "share of max in this report", the number means "session count" — two semantically distinct things sharing one column). Replaced with a plain `Sessions` column that matches the column shape of every other table in the codebase. The bar added no information that the `Cost` numeric column doesn't already carry.

## File-by-file summary

| File | Change |
|---|---|
| `src/agent/session-meta.ts` (new) | `SESSION_META_CUSTOM_TYPE` constant + `sessionMetaPayload()` minimizer |
| `src/agent/session-meta.test.ts` (new) | 9 tests including integration tests using real `createSessionFactory()` + `SessionManager.open()` round-trip |
| `src/agent/index.ts` | Calls `sessionManager.appendCustomEntry(...)` in `createSessionWithDispose` after `sessionManager` resolution, with double-stamp guard via `getEntries()` |
| `src/usage/scan.ts` | `ORIGIN_KINDS` constant + `OriginKind` type; recognises `type:"custom"` + `customType:"typeclaw.session-meta"`; first-stamp-wins per file via `ParseCtx.originPinned`; carries `originKind` on every `AssistantRow` |
| `src/usage/aggregate.ts` | New `OriginUsage` type + `byOrigin` bucket; `originKind` on `SessionUsage`; stable presentation order via `originSortIndex` |
| `src/usage/index.ts` | Re-exports `OriginUsage`, `OriginKind`, `ORIGIN_KINDS` |
| `src/usage/report.ts` | `renderOrigin` view, `renderOriginTable` with plain Sessions column, `renderDailyTrend` sparkline, glyph helpers; `By origin` section in summary; glyph prefix in session view |
| `src/cli/usage.ts` | `origin` added to `SUBCOMMANDS`; `setup` hook captures parent args; `mergeParentArgs` merges them into subcommand calls (child-wins) |
| `src/cli/compose-usage.test.ts` | Fixture updated for `originKind` and `byOrigin: []` |
| `src/usage/index.test.ts` | 13 new tests covering attribution paths, unknown fallback, since/until windowing, dedup-by-session-id, first-stamp-wins, narrow-terminal layout, sparkline threshold, session glyphs |

## Tests

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (8 pre-existing warnings in `slack-bot.test.ts`, untouched)
- `bun run format` — clean
- `bun test` — **3649 / 3649 passing** (20+ new origin-attribution + integration tests)

The integration tests are the load-bearing addition: without them, the writer path could have been silently broken (and was, in the first revision — see "What changed during review" above).

## Backwards compatibility

Pre-stamp session files are not modified or migrated. They show up under the `? unknown` origin glyph in every view. No re-indexing, no on-disk migration, no schema version bump. Adding new `SessionOrigin` kinds in the future requires extending the `ORIGIN_KINDS` tuple in `scan.ts` and adding a switch case to `renderOriginLabel` / `originGlyphOnly` — both exhaustive-by-type so the compiler flags missing branches.

## What was considered and rejected

- **Top-level `session-meta` JSONL line at offset 0** — first iteration. Broke pi's "first line is session header" invariant and tripped over pi's lazy-write timing. Replaced with `appendCustomEntry`.
- **Sidecar `.meta.json` file alongside the JSONL** — workable but doubles file count in `sessions/`, ignores pi's blessed extension API, and adds a parallel lifecycle to manage. Lost out to `appendCustomEntry` on simplicity.
- **`appendCustomMessageEntry` instead of `appendCustomEntry`** — would have silently injected the origin block into every LLM prompt (`buildSessionContext` picks up `custom_message` entries). `appendCustomEntry` is the type that explicitly does NOT participate in LLM context.
- **Cost-share `▰▱` bars** — second iteration. Visually duplicated information already in the `Cost` column, and the bar's "share of max in this report" semantics made the trailing session count ambiguous (`▰▰▰▰▰▰▰▰▰▰  179` parses two ways). Replaced with a plain `Sessions` column.
- **Backfilling origin onto legacy sessions** — would require inferring origin from filenames, fragile. `? unknown` is more honest.
- **Stamping the full `SessionOrigin`** — first iteration, flagged by the security review. Replaced with a minimal projection that drops participants/membership/recursive provenance.
- **A web dashboard (`typeclaw usage --serve`)** — out of scope; CLI is where the data plumbing matters first.