### PR TITLE
Skip mount-path validation on container-side reload

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -881,7 +881,16 @@ export type ValidateConfigResult = { ok: true } | { ok: false; reason: string }
 // confusing path-sharing error (or, on some Linux setups, silently bind-mount
 // an empty auto-created directory). First-failure reporting matches the
 // schema-error path's shape; users fix one and re-run.
-export function validateConfig(cwd: string): ValidateConfigResult {
+export type ValidateConfigOptions = {
+  // Skip the mount-path accessibility check. Host-side callers leave this
+  // false (the default) so missing mount directories surface as a precise
+  // pre-`docker run` error. Container-side callers (the reload registry)
+  // set it true because mount paths in typeclaw.json are host paths and
+  // don't resolve inside the container's filesystem.
+  skipMounts?: boolean
+}
+
+export function validateConfig(cwd: string, options: ValidateConfigOptions = {}): ValidateConfigResult {
   let raw: string
   try {
     raw = readFileSync(join(cwd, CONFIG_FILE), 'utf8')
@@ -907,9 +916,11 @@ export function validateConfig(cwd: string): ValidateConfigResult {
     return { ok: false, reason: `${CONFIG_FILE} is invalid: ${formatZodError(result.error)}` }
   }
 
-  for (const mount of result.data.mounts) {
-    const check = validateMount(mount, cwd)
-    if (!check.ok) return check
+  if (!options.skipMounts) {
+    for (const mount of result.data.mounts) {
+      const check = validateMount(mount, cwd)
+      if (!check.ok) return check
+    }
   }
 
   return { ok: true }

--- a/src/config/reloadable.test.ts
+++ b/src/config/reloadable.test.ts
@@ -59,6 +59,66 @@ describe('createConfigReloadable', () => {
     expect(getConfig().port).toBe(9001)
   })
 
+  test('skipMountValidation: container-side reload ignores host-only mount paths', async () => {
+    // given: a config whose mount points at an absolute host path that does
+    // not resolve inside the container's filesystem (simulated by referencing
+    // a path under cwd that we never create).
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: VALID_MODEL_A, port: 9001, mounts: [] }))
+    const reloadable = createConfigReloadable({ cwd, skipMountValidation: true })
+    await reloadable.reload()
+
+    const missingPath = join(cwd, 'host-only-path')
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        model: VALID_MODEL_A,
+        port: 9001,
+        mounts: [{ name: 'host-only', path: missingPath }],
+      }),
+    )
+
+    // when: a container-side reload runs
+    const result = await reloadable.reload()
+
+    // then: it succeeds and reports `mounts` as restart-required even though
+    // the host path does not exist on the local filesystem.
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const diff = result.details as { restartRequired: { path: string }[] }
+    expect(diff.restartRequired.map((c) => c.path)).toEqual(['mounts'])
+  })
+
+  test('skipMountValidation defaults to false: host-side behavior unchanged', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: VALID_MODEL_A, port: 9001, mounts: [] }))
+    const reloadable = createConfigReloadable({ cwd })
+    await reloadable.reload()
+
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        model: VALID_MODEL_A,
+        port: 9001,
+        mounts: [{ name: 'gone', path: join(cwd, 'still-missing') }],
+      }),
+    )
+    const result = await reloadable.reload()
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain('mount "gone"')
+  })
+
+  test('skipMountValidation: schema errors still fail even when mount checks are skipped', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: VALID_MODEL_A, port: 9001 }))
+    const reloadable = createConfigReloadable({ cwd, skipMountValidation: true })
+    await reloadable.reload()
+
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'not-a-known-model' } }))
+    const result = await reloadable.reload()
+
+    expect(result.ok).toBe(false)
+    expect(getConfig().port).toBe(9001)
+  })
+
   test('atomicity: schema-invalid config leaves the live config untouched', async () => {
     await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: VALID_MODEL_A, port: 9001 }))
     const reloadable = createConfigReloadable({ cwd })

--- a/src/config/reloadable.ts
+++ b/src/config/reloadable.ts
@@ -11,24 +11,45 @@ export type CreateConfigReloadableOptions = {
   // hand-edits) take effect without a container restart. `roles.<name>.permissions`
   // changes still require a restart — see FIELD_EFFECTS in config.ts.
   permissions?: PermissionService
+  // Skip the mount-path accessibility check inside validateConfig. Mount paths
+  // in typeclaw.json are HOST paths (validated at `typeclaw start` time before
+  // `docker run`); inside the container they don't resolve, so the check would
+  // always fail on any agent that declares mounts. Reload runs container-side
+  // (via the agent's `reload` tool or the WS message from `typeclaw reload`),
+  // and `mounts` is `restart-required` anyway — there's nothing to validate
+  // against the live config pointer either way. Set this when wiring the
+  // reloadable from a container-stage context. See AGENTS.md § Stages.
+  skipMountValidation?: boolean
 }
 
-export function createConfigReloadable({ cwd, permissions }: CreateConfigReloadableOptions): Reloadable {
+export function createConfigReloadable({
+  cwd,
+  permissions,
+  skipMountValidation = false,
+}: CreateConfigReloadableOptions): Reloadable {
   return {
     scope: 'config',
     description: 'typeclaw.json runtime config',
-    reload: async () => doReload(cwd, permissions),
+    reload: async () => doReload(cwd, permissions, skipMountValidation),
   }
 }
 
-async function doReload(cwd: string, permissions: PermissionService | undefined): Promise<ReloadResult> {
+async function doReload(
+  cwd: string,
+  permissions: PermissionService | undefined,
+  skipMountValidation: boolean,
+): Promise<ReloadResult> {
   // Mount accessibility belongs to the validation surface, not loadConfigSync —
   // validateConfig is the single gate that every host-side caller goes through.
   // Run it before swapping the live config pointer so a mount that vanished
   // between starts surfaces as a reload failure (`mounts` is restart-required
   // anyway, so the user has to restart to pick up changes; better to flag the
   // problem now than to let restart fail later).
-  const validated = validateConfig(cwd)
+  //
+  // Container-side reload skips mount validation: mounts are host paths and
+  // statSync against them inside the container always fails. The host-side
+  // `start` / `restart` / doctor paths still gate on the full validateConfig.
+  const validated = validateConfig(cwd, { skipMounts: skipMountValidation })
   if (!validated.ok) {
     return { scope: 'config', ok: false, reason: validated.reason }
   }

--- a/src/config/reloadable.ts
+++ b/src/config/reloadable.ts
@@ -12,13 +12,10 @@ export type CreateConfigReloadableOptions = {
   // changes still require a restart — see FIELD_EFFECTS in config.ts.
   permissions?: PermissionService
   // Skip the mount-path accessibility check inside validateConfig. Mount paths
-  // in typeclaw.json are HOST paths (validated at `typeclaw start` time before
-  // `docker run`); inside the container they don't resolve, so the check would
-  // always fail on any agent that declares mounts. Reload runs container-side
-  // (via the agent's `reload` tool or the WS message from `typeclaw reload`),
-  // and `mounts` is `restart-required` anyway — there's nothing to validate
-  // against the live config pointer either way. Set this when wiring the
-  // reloadable from a container-stage context. See AGENTS.md § Stages.
+  // in typeclaw.json are host paths — they don't resolve inside the container,
+  // so the check would always fail on any agent that declares mounts. `mounts`
+  // is `restart-required` anyway, so reload never applies mount changes. Set
+  // this when wiring the reloadable from a container-stage context.
   skipMountValidation?: boolean
 }
 

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -392,6 +392,73 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
   })
 })
 
+describe('startAgent config reload wiring', () => {
+  test('config reload succeeds against missing host mount paths when running inside a container', async () => {
+    // given: an agent dir whose typeclaw.json declares a mount pointing at a
+    // path that does not exist on the local filesystem (simulates a host path
+    // that is not visible from inside the container's namespace).
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-mount-reload-'))
+    const originalContainerName = process.env.TYPECLAW_CONTAINER_NAME
+    process.env.TYPECLAW_CONTAINER_NAME = 'typeclaw-test'
+    try {
+      await Bun.write(
+        join(agentDir, 'typeclaw.json'),
+        JSON.stringify({
+          models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
+          mounts: [{ name: 'data', path: join(agentDir, 'this-path-never-exists') }],
+        }),
+      )
+
+      // when: startAgent wires the config reloadable and a reload runs
+      running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })
+      const { results } = await running.reloadRegistry.reloadAll()
+
+      // then: the config reload succeeds (mount validation is skipped because
+      // TYPECLAW_CONTAINER_NAME is set) — guards against regressions in the
+      // src/run/index.ts wiring of skipMountValidation.
+      const configResult = results.find((r) => r.scope === 'config')
+      expect(configResult).toBeDefined()
+      expect(configResult?.ok).toBe(true)
+    } finally {
+      if (originalContainerName === undefined) delete process.env.TYPECLAW_CONTAINER_NAME
+      else process.env.TYPECLAW_CONTAINER_NAME = originalContainerName
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('config reload fails on missing host mount paths when TYPECLAW_CONTAINER_NAME is unset (host-stage default)', async () => {
+    // given: same shape, but no container marker — simulates running outside
+    // the typeclaw container (e.g. ad-hoc `bun run typeclaw run` on the host).
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-mount-reload-host-'))
+    const originalContainerName = process.env.TYPECLAW_CONTAINER_NAME
+    delete process.env.TYPECLAW_CONTAINER_NAME
+    try {
+      await Bun.write(
+        join(agentDir, 'typeclaw.json'),
+        JSON.stringify({
+          models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
+          mounts: [{ name: 'data', path: join(agentDir, 'this-path-never-exists') }],
+        }),
+      )
+
+      // when
+      running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })
+      const { results } = await running.reloadRegistry.reloadAll()
+
+      // then: the host-stage default keeps the full mount accessibility gate.
+      const configResult = results.find((r) => r.scope === 'config')
+      expect(configResult).toBeDefined()
+      expect(configResult?.ok).toBe(false)
+      if (configResult && !configResult.ok) {
+        expect(configResult.reason).toContain('mount "data"')
+      }
+    } finally {
+      if (originalContainerName !== undefined) process.env.TYPECLAW_CONTAINER_NAME = originalContainerName
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('startAgent session persistence wiring', () => {
   let agentDir: string
 

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -105,7 +105,13 @@ export async function startAgent({
     ...(cwdConfig.roles !== undefined ? { roles: cwdConfig.roles } : {}),
   })
 
-  reloadRegistry.register(createConfigReloadable({ cwd, permissions: pluginsLoaded.permissions }))
+  reloadRegistry.register(
+    createConfigReloadable({
+      cwd,
+      permissions: pluginsLoaded.permissions,
+      skipMountValidation: containerName !== undefined,
+    }),
+  )
   const pluginRegistry = pluginsLoaded.registry
   const pluginHooks = pluginsLoaded.hooks
 


### PR DESCRIPTION
## Problem

`typeclaw reload` (and the agent's `reload` tool) was failing for any agent that declared mounts. `validateConfig` — the gate that runs before swapping the live config pointer — walks every `mounts` entry and calls `validateMount`, which calls `fs.statSync` on the host path. Inside the container, those paths don't exist. The host paths are bind-mounted at `docker run` time; they never appear in the container's filesystem.

Concrete error:

```
mount "data": path /Users/neo/workspace/typeclaw/data does not exist
```

`mounts` is `restart-required` anyway — reload never applies mount changes to the live config pointer. The "flag a problem early rather than at restart" rationale for the mount accessibility gate only holds host-side, where the paths actually exist.

## Fix

Three coordinated edits, all defaulting to the existing behavior so no host-side caller requires changes.

**`src/config/config.ts`** — adds `ValidateConfigOptions = { skipMounts?: boolean }` to `validateConfig`. When `skipMounts: true`, the `validateMount` loop is skipped. Schema validation (zod), JSON parse, and legacy-shape migration all still run. Default `false`.

**`src/config/reloadable.ts`** — adds `skipMountValidation?: boolean` on `CreateConfigReloadableOptions` and threads it through `doReload` to `validateConfig(cwd, { skipMounts: ... })`. Default `false`.

**`src/run/index.ts`** — the single production caller of `createConfigReloadable` now passes `skipMountValidation: containerName !== undefined`, where `containerName = process.env.TYPECLAW_CONTAINER_NAME`. This is the same env-var marker the `restart` tool already uses to detect container stage — `src/container/start.ts` sets it on `docker run`. Outside the container (tests, ad-hoc invocations), the env var is absent and the existing host-side mount validation path runs unchanged.

## Before / after

| Caller | Before | After |
|--------|--------|-------|
| `typeclaw start` / `restart` / `doctor` | `validateConfig` runs with full mount check | unchanged |
| hostd `restart` RPC | same | unchanged |
| Container-side reload (no mounts) | succeeds | succeeds |
| Container-side reload (any mount declared) | **fails** — `mount "X": path … does not exist` | succeeds — `mounts` reported as restart-required |
| Container-side reload with a schema error | fails | fails (skip applies only to mount accessibility, not schema) |

## Tests

Three new tests in `src/config/reloadable.test.ts`:

| Test | What it pins |
|------|-------------|
| `skipMountValidation: container-side reload ignores host-only mount paths` | Reload succeeds with a missing mount path; `mounts` appears in `restartRequired`. |
| `skipMountValidation defaults to false: host-side behavior unchanged` | Without the option, a missing mount path fails reload with the existing `mount "gone"` error message. |
| `skipMountValidation: schema errors still fail even when mount checks are skipped` | A Zod-invalid config still returns `ok: false` and leaves the live config pointer untouched. |

The pre-existing `atomicity: mount path that does not exist on host fails reload …` test keeps passing (host-side default, unaffected).

## Pre-commit checks

- `bun run typecheck` — clean
- `bun run lint` — 0 errors, 0 new warnings (8 pre-existing in `slack-bot.test.ts`, unrelated)
- `bun run format` — clean
- `bun test` — 3630 / 3630 pass