### PR TITLE
Keep channel typing heartbeat alive across mid-turn sends

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1629,7 +1629,7 @@ describe('ChannelRouter typing indicator', () => {
     await draining
   })
 
-  test('a successful channel send stops typing immediately', async () => {
+  test('a successful mid-turn channel send keeps typing active so the agent can send again', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
     const phases: Array<'tick' | 'stop'> = []
@@ -1649,12 +1649,44 @@ describe('ChannelRouter typing indicator', () => {
     const draining = router.__testing!.flushDebounce(KEY)
     await waitFor(() => releasePrompt !== undefined)
 
-    expect(phases).toEqual(['tick', 'stop'])
-    expect(router.__testing!.isTypingActive(KEY)).toBe(false)
+    expect(phases).toEqual(['tick'])
+    expect(router.__testing!.isTypingActive(KEY)).toBe(true)
 
     releasePrompt!()
     await draining
     expect(phases).toEqual(['tick', 'stop'])
+    expect(router.__testing!.isTypingActive(KEY)).toBe(false)
+  })
+
+  test('typing heartbeat keeps ticking across two mid-turn channel sends', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const phases: Array<'tick' | 'stop'> = []
+    let releasePrompt: (() => void) | undefined
+    router.registerTyping('discord-bot', async (target) => {
+      phases.push(target.phase)
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ text: 'long task' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'okay, checking' })
+      await router.__testing!.fireTypingInterval(KEY)
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here is what I got' })
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => releasePrompt !== undefined)
+
+    expect(phases).toEqual(['tick', 'tick'])
+    expect(router.__testing!.isTypingActive(KEY)).toBe(true)
+
+    releasePrompt!()
+    await draining
+    expect(phases).toEqual(['tick', 'tick', 'stop'])
+    expect(router.__testing!.isTypingActive(KEY)).toBe(false)
   })
 
   test('phase=stop carries the same chat/thread coordinates as ticks', async () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1649,12 +1649,12 @@ describe('ChannelRouter typing indicator', () => {
     const draining = router.__testing!.flushDebounce(KEY)
     await waitFor(() => releasePrompt !== undefined)
 
-    expect(phases).toEqual(['tick'])
+    expect(phases).toEqual(['tick', 'tick'])
     expect(router.__testing!.isTypingActive(KEY)).toBe(true)
 
     releasePrompt!()
     await draining
-    expect(phases).toEqual(['tick', 'stop'])
+    expect(phases).toEqual(['tick', 'tick', 'stop'])
     expect(router.__testing!.isTypingActive(KEY)).toBe(false)
   })
 
@@ -1680,13 +1680,77 @@ describe('ChannelRouter typing indicator', () => {
     const draining = router.__testing!.flushDebounce(KEY)
     await waitFor(() => releasePrompt !== undefined)
 
-    expect(phases).toEqual(['tick', 'tick'])
+    expect(phases).toEqual(['tick', 'tick', 'tick', 'tick'])
     expect(router.__testing!.isTypingActive(KEY)).toBe(true)
 
     releasePrompt!()
     await draining
-    expect(phases).toEqual(['tick', 'tick', 'stop'])
+    expect(phases).toEqual(['tick', 'tick', 'tick', 'tick', 'stop'])
     expect(router.__testing!.isTypingActive(KEY)).toBe(false)
+  })
+
+  test('a successful mid-turn send fires a fresh tick after the outbound completes', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const events: string[] = []
+    let releasePrompt: (() => void) | undefined
+    router.registerTyping('discord-bot', async (target) => {
+      events.push(`typing:${target.phase}`)
+    })
+    router.registerOutbound('discord-bot', async () => {
+      events.push('outbound:cb')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'long task' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply' })
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => releasePrompt !== undefined)
+
+    expect(events).toEqual(['typing:tick', 'outbound:cb', 'typing:tick'])
+
+    releasePrompt!()
+    await draining
+  })
+
+  test('mid-turn re-arm tick is suppressed when the heartbeat was stopped during the outbound', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const phases: Array<'tick' | 'stop'> = []
+    let releasePrompt: (() => void) | undefined
+    router.registerTyping('discord-bot', async (target) => {
+      phases.push(target.phase)
+    })
+    router.registerOutbound('discord-bot', async (_msg) => {
+      // simulate teardown happening during the outbound: the heartbeat is
+      // stopped after the adapter accepted the send but before send()
+      // returns. The re-arm guard must suppress the post-send tick so we
+      // don't resurrect typing.
+      await router.__testing!.stopTyping(KEY)
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'long task' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply' })
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => releasePrompt !== undefined)
+
+    // initial route() tick + stopTyping's 'stop'. No extra 'tick' after the send.
+    expect(phases).toEqual(['tick', 'stop'])
+    expect(router.__testing!.isTypingActive(KEY)).toBe(false)
+
+    releasePrompt!()
+    await draining
   })
 
   test('phase=stop carries the same chat/thread coordinates as ticks', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -299,6 +299,7 @@ export type ChannelRouter = {
     fireTypingHeartbeat: (key: ChannelKey, phase?: 'tick' | 'stop') => Promise<void>
     fireTypingInterval: (key: ChannelKey) => Promise<void>
     isTypingActive: (key: ChannelKey) => boolean
+    stopTyping: (key: ChannelKey) => Promise<void>
     runIdleGc: () => Promise<void>
   }
 }
@@ -1455,10 +1456,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (live) {
       live.successfulChannelSends++
       // Don't stop the heartbeat here: the agent may still be mid-turn and
-      // about to send another reply. drain()'s finally block stops typing
-      // when the turn actually ends. Per-send indicator clearing (e.g.
-      // Slack's setStatus("") on postMessage) belongs in the adapter
-      // outbound callback, not in the router.
+      // about to send another reply. drain()'s finally block owns turn-end
+      // stop. But Slack's adapter outbound callback explicitly clears
+      // platform-side typing after every successful postMessage (to defeat
+      // the heartbeat-vs-postMessage race fixed in PR #52), so a fresh
+      // 'tick' must land in the FIFO right after that clear — otherwise
+      // the indicator stays cleared until the next 8s interval, leaving a
+      // visible idle gap between mid-turn sends on Slack. The await on
+      // cb(msg) above already drained the outbound callback's clearAfterSend
+      // through the per-(chat,thread) FIFO, so this tick is guaranteed to
+      // land after it. Discord and Telegram treat the extra tick as a
+      // no-op refresh of their already-armed (auto-expiring) indicators.
+      if (live.typingTimer) void fireTyping(live, 'tick')
       const adapterConfig = options.configForAdapter(msg.adapter)
       if (adapterConfig) {
         const targetIds = Array.from(
@@ -1627,6 +1636,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       isTypingActive: (key: ChannelKey) => {
         const live = liveSessions.get(channelKeyId(key))
         return live?.typingTimer !== null && live?.typingTimer !== undefined
+      },
+      stopTyping: async (key: ChannelKey) => {
+        const live = liveSessions.get(channelKeyId(key))
+        if (!live) return
+        await stopTypingHeartbeat(live)
       },
       runIdleGc,
     },

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1454,7 +1454,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const live = liveSessions.get(keyId)
     if (live) {
       live.successfulChannelSends++
-      await stopTypingHeartbeat(live)
+      // Don't stop the heartbeat here: the agent may still be mid-turn and
+      // about to send another reply. drain()'s finally block stops typing
+      // when the turn actually ends. Per-send indicator clearing (e.g.
+      // Slack's setStatus("") on postMessage) belongs in the adapter
+      // outbound callback, not in the router.
       const adapterConfig = options.configForAdapter(msg.adapter)
       if (adapterConfig) {
         const targetIds = Array.from(


### PR DESCRIPTION
> **Updated after self-review:** a follow-up commit (`c7b39ba`) landed after the original review window to close a Slack-specific gap. See "Root cause" below for the two-part diagnosis.

## Problem

When an agent sends two replies in the same turn, the typing indicator disappears between the first and second sends. The user sees:

```
(typing...)
"okay, I will check this out"
(idle — no typing indicator)
"here's what I've got: ..."
```

The expected behavior:

```
(typing...)
"okay, I will check this out"
(typing...)
"here's what I've got: ..."
```

## Root cause

Two distinct mechanisms conspired to kill the indicator, addressed by the two commits on this branch.

**Part 1 — router kills the heartbeat interval (commit `23795a7`).**
`router.send()` in `src/channels/router.ts` called `stopTypingHeartbeat` after every successful outbound message. This killed the `setInterval` heartbeat that is supposed to live for the full duration of `session.prompt()`.

The heartbeat lifecycle is owned by `drain()`:
- Line 1006: `startTypingHeartbeat` fires before `session.prompt()`
- Line 1048: `stopTypingHeartbeat` fires in the `finally` block when the turn ends

Stopping it inside `send()` preempted that contract: after the first reply, the interval was dead and no more `'tick'` phases fired for the rest of the turn.

**Part 2 — Slack's per-send `clearAfterSend` plus up-to-8s tick latency (commit `c7b39ba`).**
Even with Part 1 fixed, Slack had a residual gap. The slack-bot outbound callback at `src/channels/adapters/slack-bot.ts:538` and `:571` calls `typingTracker.clearAfterSend(...)` after every successful `postMessage`/`uploadFile`. That clear (added by PR #52, commit `bb78998`) defeats the heartbeat-vs-postMessage race — but it also means the platform-side indicator is cleared on each send, and the next heartbeat tick is up to `TYPING_HEARTBEAT_MS` (8s) away. A user receiving two replies within 8s on Slack would still see an idle gap.

Discord and Telegram are unaffected: their `'stop'` phase is a no-op (no per-send clearing), and platform auto-expiry (~10s for Discord, ~5s for Telegram) is longer than the 8s heartbeat.

## Fix

**Commit `23795a7`:** Removed the `stopTypingHeartbeat` call from `router.send()` and added a comment explaining why this site intentionally does not stop typing (lifecycle owned by `drain()` finally; per-send clearing owned by adapter outbound callbacks).

**Commit `c7b39ba`:** Added `if (live.typingTimer) void fireTyping(live, 'tick')` immediately after a successful `send()`. Since the outbound callback's `clearAfterSend` is awaited inside `cb(msg)`, by the time `send()` returns the clear has already been queued in Slack's per-(chat,thread) FIFO — the re-arm tick lands strictly after it. The `live.typingTimer` guard prevents resurrecting typing after an interleaved `'stop'` phase (e.g. a `/stop` or teardown between `cb(msg)` start and end), preserving the race fix from commit `5cffb0d`. A small test seam `__testing.stopTyping` was added so the guard is unit-testable deterministically.

## Per-adapter impact

| Adapter | Before this PR | After this PR (both commits) |
|---|---|---|
| `slack-bot` | Indicator killed at first send, gone until next inbound | Indicator briefly clears on each send (FIFO `clearAfterSend`), then re-arms immediately via the new tick; visible as continuous typing across all mid-turn sends |
| `discord-bot` | Interval killed at first send, indicator auto-expires ~10s later | Interval stays alive; re-arm tick is a no-op refresh; typing visible across whole turn |
| `telegram-bot` | Same as Discord but ~5s auto-expiry | Same as Discord |
| `kakaotalk` | No typing callback registered | Unchanged |

## Tests

4 typing tests in total across the two commits, all mutation-verified:

- **2 updated from commit 1** — `'a successful mid-turn channel send keeps typing active'` and `'typing heartbeat keeps ticking across two mid-turn channel sends'` updated to expect the new re-arm tick in their phase sequences.
- **2 new in commit 2:**
  - `'a successful mid-turn send fires a fresh tick after the outbound completes'` — pins the exact ordering `['typing:tick', 'outbound:cb', 'typing:tick']`, which is the FIFO contract Slack depends on.
  - `'mid-turn re-arm tick is suppressed when the heartbeat was stopped during the outbound'` — exercises the `live.typingTimer` guard via the `__testing.stopTyping` seam.

Mutation check: removing the re-arm line fails 3 of 4 mid-turn typing tests; removing the `live.typingTimer` guard fails the suppress test.

19/19 typing-indicator tests pass. Full suite: 3652 pass, 0 fail.

## Files changed

- `src/channels/router.ts` (+18 -4)
- `src/channels/router.test.ts` (+68 -4)

Total: +86 -8 across 2 commits.