### PR TITLE
Support exec → llm in cron prompt jobs (optional pre-LLM command)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -591,6 +591,30 @@ The TUI ↔ WS protocol depends on the stream-driven drain loop in two non-obvio
 
 This split means a long-running job no longer blocks subsequent ticks at the scheduler layer — the scheduler fires N times for N ticks, and any overlapping fires for the same job are dropped by the consumer with a warning. Same observable behavior as before, cleaner ownership.
 
+### Cron `prompt` job with `exec` (pre-LLM command)
+
+A `prompt`-kind cron job may optionally declare an `exec` array. When present, the consumer runs the command via `Bun.spawn` (cwd = agent dir) **before** firing the LLM, captures stdout / stderr / exitCode, truncates each to `execMaxOutputBytes` (default 64 KiB), and feeds the result into the LLM call:
+
+- **Without `subagent`:** stdout appended to the prompt text as a fenced block. Stderr appended as a second fenced block when non-empty. `exit code: N` line appended when non-zero. The session's default tool set is unchanged — which means `channel_send` works for "exec → reach out to a channel" flows out of the box.
+- **With `subagent`:** result merged into the new-session payload as `payload.exec = { stdin, stderr, exitCode }`. The subagent's `payloadSchema` should declare `exec: z.object({ stdin: z.string(), stderr: z.string(), exitCode: z.number() }).optional()` to opt in. Non-object original payloads are wrapped as `{ payload: <original>, exec }` to preserve data.
+
+The LLM runs **regardless of exit code** — the model sees the result (including failures) and decides what to do. For conditional firing, compose in the command itself: `["bash", "-c", "gh run list … | jq -e '.[].conclusion == \"failure\"' && echo failed"]` — empty stdout on success, output on failure, LLM decides what to summarize.
+
+Worked example (no subagent, posts to Slack on CI failure):
+
+```json
+{
+  "id": "ci-watcher",
+  "kind": "prompt",
+  "schedule": "*/10 * * * *",
+  "scheduledByRole": "owner",
+  "exec": ["gh", "run", "list", "--limit", "5", "--json", "conclusion,name,url"],
+  "prompt": "If any of the last 5 CI runs below failed, post to Slack workspace T0123 channel C0ENGR: 'CI broke: <name> <url>'. Otherwise stay silent (no tool calls)."
+}
+```
+
+Subagent-tool gotcha: subagents declared with an explicit `tools` field get only what they declared — channel tools must be opted in via `customTools` or by reusing the default tool set. The bundled `memory-logger` and `dreaming` subagents intentionally don't carry channel tools, which is why a "summarize and post" exec→llm flow should usually go through the no-subagent path unless you're authoring a plugin subagent that takes ownership of the routing.
+
 ### `stream_snapshot` agent tool
 
 `src/agent/tools/stream-snapshot.ts` exposes a read-only tool to the agent that reads from the broker's bounded ring buffer (default 1000 events). The agent can ask "what cron jobs fired in the last minute?" or "did any broadcasts arrive while I was thinking?" without any wire round-trip — the tool is in-process. Read-only by design: the agent cannot publish via this tool. Wired into `createSession` only when a `Stream` is injected.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ TypeClaw is the agent I wanted to use:
 - 🔌 **Plugin system** — plain TypeScript modules contribute tools, skills, subagents, channels, and typed config
 - 💬 **Multi-channel** — Slack, Discord, and a websocket TUI out of the box; one agent, many inboxes
 - 👥 **Group chat awareness** — knows who's in the room, distinguishes humans from bots, and stays engaged after a reply without re-mentioning
-- ⏰ **Cron** — schedule prompts or shell commands; per-job coalescing so slow jobs don't pile up
+- ⏰ **Cron** — schedule prompts or shell commands; prompts can pipe a shell command's output into the LLM (`exec → llm`); per-job coalescing so slow jobs don't pile up
 - 📚 **Skills on demand** — markdown procedures the agent loads only when relevant; zero token cost until used
 - 🌱 **Self-improving** — bundled memory plugin observes the agent's work and consolidates it into long-term memory (see below)
 - 🧠 **Muscle memory** — repeated procedures get distilled into reusable skills that the agent writes for itself

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -6,7 +6,15 @@ import { join } from 'node:path'
 import type { HookBus } from '@/plugin'
 import { createStream } from '@/stream'
 
-import { createCronConsumer, type CronConsumerLogger, type CronSession } from './consumer'
+import {
+  appendExecToPrompt,
+  createCronConsumer,
+  type CronConsumerLogger,
+  type CronSession,
+  type ExecResult,
+  mergeExecIntoPayload,
+  runExecForPrompt,
+} from './consumer'
 import type { CronJob, ExecJob, PromptJob } from './schema'
 
 function fakeHooks(events: string[]): HookBus {
@@ -545,6 +553,310 @@ describe('createCronConsumer', () => {
 
     // then
     expect(errors).toEqual([])
+
+    consumer.stop()
+  })
+})
+
+describe('runExecForPrompt', () => {
+  test('captures stdout, stderr, and exitCode from a successful command', async () => {
+    const job: PromptJob = {
+      id: 'j',
+      schedule: '* * * * *',
+      enabled: true,
+      kind: 'prompt',
+      prompt: 'p',
+      exec: ['sh', '-c', 'echo out; echo err 1>&2; exit 0'],
+    }
+    const result = await runExecForPrompt(job, root)
+    expect(result.stdin.trim()).toBe('out')
+    expect(result.stderr.trim()).toBe('err')
+    expect(result.exitCode).toBe(0)
+  })
+
+  test('captures non-zero exit code without throwing — LLM gets to see the failure', async () => {
+    const job: PromptJob = {
+      id: 'j',
+      schedule: '* * * * *',
+      enabled: true,
+      kind: 'prompt',
+      prompt: 'p',
+      exec: ['sh', '-c', 'echo last-out; echo last-err 1>&2; exit 7'],
+    }
+    const result = await runExecForPrompt(job, root)
+    expect(result.exitCode).toBe(7)
+    expect(result.stdin.trim()).toBe('last-out')
+    expect(result.stderr.trim()).toBe('last-err')
+  })
+
+  test('truncates stdout at execMaxOutputBytes with a marker', async () => {
+    const job: PromptJob = {
+      id: 'j',
+      schedule: '* * * * *',
+      enabled: true,
+      kind: 'prompt',
+      prompt: 'p',
+      exec: ['sh', '-c', 'printf "%0.s." {1..2000}'],
+      execMaxOutputBytes: 100,
+    }
+    const result = await runExecForPrompt(job, root)
+    expect(result.stdin.length).toBeGreaterThan(100)
+    expect(result.stdin).toContain('[truncated')
+    expect(result.stdin).toContain('1900 bytes]')
+  })
+
+  test('truncates stderr independently with the same cap', async () => {
+    const job: PromptJob = {
+      id: 'j',
+      schedule: '* * * * *',
+      enabled: true,
+      kind: 'prompt',
+      prompt: 'p',
+      exec: ['sh', '-c', 'printf "%0.s." {1..2000} 1>&2'],
+      execMaxOutputBytes: 50,
+    }
+    const result = await runExecForPrompt(job, root)
+    expect(result.stderr).toContain('[truncated')
+    expect(result.stderr).toContain('1950 bytes]')
+    expect(result.stdin).toBe('')
+  })
+
+  test('uses agent cwd so commands like `pwd` resolve to the agent folder', async () => {
+    const job: PromptJob = {
+      id: 'j',
+      schedule: '* * * * *',
+      enabled: true,
+      kind: 'prompt',
+      prompt: 'p',
+      exec: ['pwd'],
+    }
+    const result = await runExecForPrompt(job, root)
+    // On macOS, /tmp is a symlink to /private/tmp — accept either.
+    expect(result.stdin.trim().endsWith(root) || result.stdin.trim() === root).toBe(true)
+  })
+
+  test('rejects when exec is absent (caller bug)', async () => {
+    const job: PromptJob = { id: 'j', schedule: '* * * * *', enabled: true, kind: 'prompt', prompt: 'p' }
+    await expect(runExecForPrompt(job, root)).rejects.toThrow(/exec is required/)
+  })
+})
+
+describe('appendExecToPrompt', () => {
+  test('appends stdout as a fenced block under the prompt text', () => {
+    const exec: ExecResult = { stdin: 'hello\nworld', stderr: '', exitCode: 0 }
+    const result = appendExecToPrompt('Summarize:', exec)
+    expect(result).toBe('Summarize:\n\n```\nhello\nworld\n```')
+  })
+
+  test('omits stderr block when stderr is empty', () => {
+    const exec: ExecResult = { stdin: 'out', stderr: '', exitCode: 0 }
+    expect(appendExecToPrompt('p', exec)).not.toContain('stderr')
+  })
+
+  test('includes a stderr fenced block when stderr is non-empty', () => {
+    const exec: ExecResult = { stdin: 'out', stderr: 'warning: foo', exitCode: 0 }
+    const result = appendExecToPrompt('p', exec)
+    expect(result).toContain('stderr:')
+    expect(result).toContain('warning: foo')
+  })
+
+  test('appends "exit code: N" only when exitCode is non-zero', () => {
+    const ok: ExecResult = { stdin: 'out', stderr: '', exitCode: 0 }
+    expect(appendExecToPrompt('p', ok)).not.toContain('exit code')
+
+    const fail: ExecResult = { stdin: 'out', stderr: '', exitCode: 7 }
+    expect(appendExecToPrompt('p', fail)).toContain('exit code: 7')
+  })
+})
+
+describe('mergeExecIntoPayload', () => {
+  test('returns { exec } when no original payload', () => {
+    const exec: ExecResult = { stdin: 'x', stderr: '', exitCode: 0 }
+    expect(mergeExecIntoPayload(undefined, exec)).toEqual({ exec })
+  })
+
+  test('merges into an existing object payload without overwriting unrelated fields', () => {
+    const exec: ExecResult = { stdin: 'x', stderr: '', exitCode: 0 }
+    const merged = mergeExecIntoPayload({ branch: 'main', limit: 10 }, exec)
+    expect(merged).toEqual({ branch: 'main', limit: 10, exec })
+  })
+
+  test('overwrites a prior `exec` key — most-recent run wins', () => {
+    const exec: ExecResult = { stdin: 'fresh', stderr: '', exitCode: 0 }
+    const merged = mergeExecIntoPayload({ exec: { stdin: 'stale', stderr: '', exitCode: 99 } }, exec)
+    expect(merged).toEqual({ exec })
+  })
+
+  test('wraps non-object payload (string) under `payload` so it is preserved', () => {
+    const exec: ExecResult = { stdin: 'x', stderr: '', exitCode: 0 }
+    expect(mergeExecIntoPayload('a string', exec)).toEqual({ payload: 'a string', exec })
+  })
+
+  test('wraps array payload under `payload` (zod object schemas reject arrays anyway, but data is preserved)', () => {
+    const exec: ExecResult = { stdin: 'x', stderr: '', exitCode: 0 }
+    expect(mergeExecIntoPayload([1, 2, 3], exec)).toEqual({ payload: [1, 2, 3], exec })
+  })
+
+  test('wraps null payload (null is typeof object but should not be merged into)', () => {
+    const exec: ExecResult = { stdin: 'x', stderr: '', exitCode: 0 }
+    expect(mergeExecIntoPayload(null, exec)).toEqual({ payload: null, exec })
+  })
+})
+
+describe('cron prompt job with `exec` pre-LLM command', () => {
+  test('without subagent: appends exec stdout to the prompt text the session receives', async () => {
+    // given
+    const stream = createStream()
+    const factory = makeFakeSessionFactory()
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: factory.createSessionForCron,
+      logger: silentLogger,
+    })
+    consumer.start()
+
+    // when
+    publishCron(stream, {
+      id: 'with-exec',
+      schedule: '* * * * *',
+      enabled: true,
+      kind: 'prompt',
+      prompt: 'Summarize:',
+      exec: ['sh', '-c', 'echo from-exec'],
+    })
+    // exec spawning needs setTimeout, not setImmediate, to let the
+    // subprocess actually finish.
+    await new Promise((r) => setTimeout(r, 100))
+
+    // then
+    const calls = factory.callsByJob.get('with-exec')
+    if (!calls || calls.length === 0) throw new Error('expected a prompt call')
+    expect(calls[0]).toContain('Summarize:')
+    expect(calls[0]).toContain('from-exec')
+    expect(calls[0]).toContain('```')
+
+    consumer.stop()
+  })
+
+  test('without subagent: non-zero exit code is appended to the prompt', async () => {
+    const stream = createStream()
+    const factory = makeFakeSessionFactory()
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: factory.createSessionForCron,
+      logger: silentLogger,
+    })
+    consumer.start()
+
+    publishCron(stream, {
+      id: 'failing-exec',
+      schedule: '* * * * *',
+      enabled: true,
+      kind: 'prompt',
+      prompt: 'Investigate:',
+      exec: ['sh', '-c', 'echo did-something; exit 4'],
+    })
+    await new Promise((r) => setTimeout(r, 100))
+
+    const calls = factory.callsByJob.get('failing-exec')
+    if (!calls || calls.length === 0) throw new Error('expected a prompt call')
+    expect(calls[0]).toContain('did-something')
+    expect(calls[0]).toContain('exit code: 4')
+
+    consumer.stop()
+  })
+
+  test('with subagent: exec result is merged into the new-session payload', async () => {
+    const stream = createStream()
+    const factory = makeFakeSessionFactory()
+    const newSessionMessages: Array<{ subagent: string; payload: unknown }> = []
+    stream.subscribe({ target: { kind: 'new-session' } }, (msg) => {
+      const target = msg.target as { kind: 'new-session'; subagent: string }
+      newSessionMessages.push({ subagent: target.subagent, payload: msg.payload })
+    })
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: factory.createSessionForCron,
+      logger: silentLogger,
+    })
+    consumer.start()
+
+    publishCron(stream, {
+      id: 'sub-exec',
+      schedule: '* * * * *',
+      enabled: true,
+      kind: 'prompt',
+      prompt: 'fallback',
+      subagent: 'commit-summarizer',
+      payload: { branch: 'main' },
+      exec: ['sh', '-c', 'echo three-commits'],
+    })
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(newSessionMessages).toHaveLength(1)
+    const payload = newSessionMessages[0]?.payload as {
+      branch: string
+      exec: { stdin: string; stderr: string; exitCode: number }
+    }
+    expect(payload.branch).toBe('main')
+    expect(payload.exec.stdin.trim()).toBe('three-commits')
+    expect(payload.exec.exitCode).toBe(0)
+    expect(factory.callsByJob.size).toBe(0)
+
+    consumer.stop()
+  })
+
+  test('without exec: prompt and payload pass through unchanged (regression guard)', async () => {
+    const stream = createStream()
+    const factory = makeFakeSessionFactory()
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: factory.createSessionForCron,
+      logger: silentLogger,
+    })
+    consumer.start()
+
+    publishCron(stream, promptJob('no-exec', 'plain prompt'))
+    await new Promise((r) => setImmediate(r))
+
+    expect(factory.callsByJob.get('no-exec')).toEqual(['plain prompt'])
+
+    consumer.stop()
+  })
+
+  test('exec command spawn failure (ENOENT) is logged and does not crash the consumer', async () => {
+    const stream = createStream()
+    const factory = makeFakeSessionFactory()
+    const errors: string[] = []
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: factory.createSessionForCron,
+      logger: { ...silentLogger, error: (m) => errors.push(m) },
+    })
+    consumer.start()
+
+    publishCron(stream, {
+      id: 'enoent',
+      schedule: '* * * * *',
+      enabled: true,
+      kind: 'prompt',
+      prompt: 'p',
+      exec: ['no-such-binary-exists-12345'],
+    })
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(errors.length).toBeGreaterThan(0)
+    expect(factory.callsByJob.size).toBe(0)
+
+    // Consumer survives — a subsequent job runs normally.
+    publishCron(stream, promptJob('after', 'still alive'))
+    await new Promise((r) => setImmediate(r))
+    expect(factory.callsByJob.get('after')).toEqual(['still alive'])
 
     consumer.stop()
   })

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -4,7 +4,9 @@ import type { SessionOrigin } from '@/agent/session-origin'
 import type { HookBus } from '@/plugin'
 import type { Stream, Unsubscribe } from '@/stream'
 
-import type { CronJob, ExecJob, PromptJob } from './schema'
+import { DEFAULT_EXEC_MAX_OUTPUT_BYTES, type CronJob, type ExecJob, type PromptJob } from './schema'
+
+export type ExecResult = { stdin: string; stderr: string; exitCode: number }
 
 // `hooks`, `sessionId`, `agentDir`, and `getTranscriptPath` are optional so
 // test fakes can stay one-liners. When present, the consumer fires
@@ -80,7 +82,7 @@ export function createCronConsumer({
         inFlight.add(job.id)
         try {
           if (job.kind === 'prompt') {
-            await runPrompt(job, createSessionForCron, stream, logger)
+            await runPrompt(job, cwd, createSessionForCron, stream, logger)
           } else {
             await runExec(job, cwd)
           }
@@ -104,10 +106,15 @@ export function createCronConsumer({
 
 async function runPrompt(
   job: PromptJob,
+  cwd: string,
   createSessionForCron: (job: PromptJob) => Promise<CronSession>,
   stream: Stream,
   logger: CronConsumerLogger,
 ): Promise<void> {
+  const exec = job.exec !== undefined ? await runExecForPrompt(job, cwd) : undefined
+  const effectivePrompt = exec !== undefined ? appendExecToPrompt(job.prompt, exec) : job.prompt
+  const effectivePayload = exec !== undefined ? mergeExecIntoPayload(job.payload, exec) : job.payload
+
   if (job.subagent !== undefined) {
     // Propagate the cron job's role and origin into the spawned subagent.
     // Without this, every cron-triggered subagent (e.g. memory dreaming)
@@ -127,7 +134,7 @@ async function runPrompt(
         ...(job.scheduledByRole !== undefined ? { spawnedByRole: job.scheduledByRole } : {}),
         spawnedByOriginJson: JSON.stringify(parentOrigin),
       },
-      payload: job.payload,
+      payload: effectivePayload,
     })
     return
   }
@@ -151,7 +158,7 @@ async function runPrompt(
       await session.hooks.runSessionTurnStart(turnEvent)
     }
     try {
-      await session.prompt(job.prompt)
+      await session.prompt(effectivePrompt)
     } finally {
       if (session.hooks && turnEvent !== undefined) {
         await session.hooks.runSessionTurnEnd(turnEvent)
@@ -193,4 +200,59 @@ function isCronJob(value: unknown): value is CronJob {
   const v = value as { id?: unknown; kind?: unknown }
   if (typeof v.id !== 'string') return false
   return v.kind === 'prompt' || v.kind === 'exec'
+}
+
+export async function runExecForPrompt(job: PromptJob, cwd: string): Promise<ExecResult> {
+  if (job.exec === undefined || job.exec.length === 0) {
+    throw new Error(`prompt job ${job.id}: exec is required for runExecForPrompt`)
+  }
+  const [cmd, ...args] = job.exec
+  if (!cmd) throw new Error(`prompt job ${job.id}: empty exec command`)
+  const cap = job.execMaxOutputBytes ?? DEFAULT_EXEC_MAX_OUTPUT_BYTES
+  const proc = Bun.spawn({ cmd: [cmd, ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+  const [stdoutRaw, stderrRaw, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return {
+    stdin: truncateUtf8(stdoutRaw, cap),
+    stderr: truncateUtf8(stderrRaw, cap),
+    exitCode,
+  }
+}
+
+export function appendExecToPrompt(prompt: string, exec: ExecResult): string {
+  const parts = [prompt, '', '```', exec.stdin, '```']
+  if (exec.stderr.length > 0) {
+    parts.push('', 'stderr:', '```', exec.stderr, '```')
+  }
+  if (exec.exitCode !== 0) {
+    parts.push('', `exit code: ${exec.exitCode}`)
+  }
+  return parts.join('\n')
+}
+
+export function mergeExecIntoPayload(originalPayload: unknown, exec: ExecResult): unknown {
+  if (originalPayload === undefined) return { exec }
+  if (typeof originalPayload === 'object' && originalPayload !== null && !Array.isArray(originalPayload)) {
+    return { ...(originalPayload as Record<string, unknown>), exec }
+  }
+  // Non-object payload (string, array, number, etc.): wrap so the original
+  // value is preserved as `payload.payload` and exec sits alongside it. This
+  // is the conservative shape — subagents that declare object payloadSchemas
+  // never see this branch in practice.
+  return { payload: originalPayload, exec }
+}
+
+function truncateUtf8(s: string, maxBytes: number): string {
+  const encoder = new TextEncoder()
+  const bytes = encoder.encode(s)
+  if (bytes.length <= maxBytes) return s
+  // Decode the first `maxBytes` bytes with the streaming `fatal: false`
+  // decoder so a multi-byte boundary in the middle of a character degrades
+  // to U+FFFD instead of throwing.
+  const decoder = new TextDecoder('utf-8', { fatal: false })
+  const head = decoder.decode(bytes.subarray(0, maxBytes))
+  return `${head}\n[truncated ${bytes.length - maxBytes} bytes]`
 }

--- a/src/cron/schema.test.ts
+++ b/src/cron/schema.test.ts
@@ -106,6 +106,75 @@ describe('cronFileSchema', () => {
       }),
     ).toThrow()
   })
+
+  test('accepts a prompt job with an `exec` pre-LLM command', () => {
+    const parsed = cronFileSchema.parse({
+      jobs: [
+        {
+          id: 'morning-summary',
+          schedule: '0 9 * * *',
+          kind: 'prompt',
+          prompt: 'Summarize yesterday.',
+          exec: ['git', 'log', '--oneline', '--since=yesterday'],
+        },
+      ],
+    })
+    const job = parsed.jobs[0]
+    if (!job || job.kind !== 'prompt') throw new Error('expected a prompt job')
+    expect(job.exec).toEqual(['git', 'log', '--oneline', '--since=yesterday'])
+    expect(job.execMaxOutputBytes).toBeUndefined()
+  })
+
+  test('rejects a prompt job with an empty `exec` array', () => {
+    expect(() =>
+      cronFileSchema.parse({
+        jobs: [{ id: 'j', schedule: '* * * * *', kind: 'prompt', prompt: 'x', exec: [] }],
+      }),
+    ).toThrow()
+  })
+
+  test('rejects a prompt job with an empty string inside `exec`', () => {
+    expect(() =>
+      cronFileSchema.parse({
+        jobs: [{ id: 'j', schedule: '* * * * *', kind: 'prompt', prompt: 'x', exec: ['ls', ''] }],
+      }),
+    ).toThrow()
+  })
+
+  test('accepts `execMaxOutputBytes` as a positive integer', () => {
+    const parsed = cronFileSchema.parse({
+      jobs: [
+        {
+          id: 'capped',
+          schedule: '* * * * *',
+          kind: 'prompt',
+          prompt: 'x',
+          exec: ['echo', 'hi'],
+          execMaxOutputBytes: 1024,
+        },
+      ],
+    })
+    const job = parsed.jobs[0]
+    if (!job || job.kind !== 'prompt') throw new Error('expected a prompt job')
+    expect(job.execMaxOutputBytes).toBe(1024)
+  })
+
+  test('rejects `execMaxOutputBytes <= 0`', () => {
+    expect(() =>
+      cronFileSchema.parse({
+        jobs: [
+          {
+            id: 'j',
+            schedule: '* * * * *',
+            kind: 'prompt',
+            prompt: 'x',
+            exec: ['echo', 'hi'],
+            execMaxOutputBytes: 0,
+          },
+        ],
+      }),
+    ).toThrow()
+  })
 })
 
 describe('parseCronFile', () => {

--- a/src/cron/schema.ts
+++ b/src/cron/schema.ts
@@ -23,11 +23,30 @@ const baseJob = z.object({
   scheduledByOrigin: z.unknown().optional(),
 })
 
+// Default cap shared by stdout and stderr when a prompt job pipes an exec
+// command's output into the LLM. 64 KiB fits typical CLI output (e.g.
+// `git log --oneline -100` is ~5 KiB) while staying well under any model's
+// context window. Per-job override via `execMaxOutputBytes`.
+export const DEFAULT_EXEC_MAX_OUTPUT_BYTES = 65536
+
 const promptJob = baseJob.extend({
   kind: z.literal('prompt'),
   prompt: z.string().min(1),
   subagent: z.string().min(1).optional(),
   payload: z.unknown().optional(),
+  // Optional pre-LLM command. When present, the cron consumer spawns this
+  // command (cwd = agent dir) BEFORE invoking the LLM, captures
+  // stdout/stderr/exitCode, and feeds the result into the prompt (no
+  // subagent: appended as a fenced block) or the payload (with subagent:
+  // merged as `payload.exec = { stdin, stderr, exitCode }`). The LLM runs
+  // regardless of exit code — the model sees the result and decides what
+  // to do. For conditional firing, use shell composition in the command
+  // itself (`bash -c "cmd1 && cmd2"`).
+  exec: z.array(z.string().min(1)).min(1).optional(),
+  // Cap applied independently to stdout and stderr. Larger outputs are
+  // truncated with a `[truncated N bytes]` marker appended to the affected
+  // stream. Defaults to DEFAULT_EXEC_MAX_OUTPUT_BYTES.
+  execMaxOutputBytes: z.number().int().positive().optional(),
 })
 
 const execJob = baseJob.extend({


### PR DESCRIPTION
## Summary

- A `kind: 'prompt'` cron job can now declare an optional `exec` array. When set, the consumer runs the command via `Bun.spawn` (cwd = agent dir) **before** firing the LLM, captures stdout / stderr / exitCode, and feeds the result into the LLM call.
- Without `subagent`: stdout is appended to the prompt as a fenced block; stderr appended as a second block when non-empty; `exit code: N` appended when non-zero.
- With `subagent`: result merged into the new-session payload as `payload.exec = { stdin, stderr, exitCode }`.
- The LLM runs **regardless of exit code** — the model sees the result and decides what to do. Conditional firing is composed in the command itself (`bash -c "cmd && …"`), matching `kind: 'exec'`'s shape.

## Why

Today's cron schema supports `llm → exec` (a `prompt` job can ask the LLM to run a command) but not `exec → llm` (run a command, then have the LLM react to its output). The natural use cases are "CI failed → investigate" and "git status → commit yesterday's drift" — both want shell first, LLM second.

The simplest factoring keeps everything in-process: extend the existing `prompt` job kind with an optional pre-LLM `exec` field. No new `cron.json` `kind`, no new CLI surface, no new IPC. The consumer already owns the LLM session creation and the Stream; teaching `runPrompt` to spawn a subprocess first is a ~70-line addition.

## What changed

- **`src/cron/schema.ts`** — adds `exec: string[]` and `execMaxOutputBytes: number` to `promptJob`. Exports `DEFAULT_EXEC_MAX_OUTPUT_BYTES = 65536` for the consumer. Schema-only first commit so the contract is reviewable separately from the runtime change.
- **`src/cron/consumer.ts`** — `runPrompt` calls `runExecForPrompt` when `job.exec` is present, then `appendExecToPrompt` (no subagent) or `mergeExecIntoPayload` (with subagent). All three helpers are exported so unit tests hit them directly without spinning up a stream. UTF-8 truncation uses a non-fatal `TextDecoder` so a multi-byte boundary degrades to `U+FFFD` instead of throwing.
- **`AGENTS.md`** — new `### Cron prompt job with exec (pre-LLM command)` subsection under `## Message Stream`. Worked example, subagent-tools gotcha note, channel-send story.
- **`README.md`** — one-line bullet update.
- **Tests** — 22 new tests across schema (6) and consumer (16): real `Bun.spawn` invocation, stdout/stderr capture, non-zero exit, both truncations, cwd resolution, both merge shapes, regression guard for jobs without exec, ENOENT recovery, and the wrapping behavior for non-object payloads.

## Worked example

```json
{
  "id": "ci-watcher",
  "kind": "prompt",
  "schedule": "*/10 * * * *",
  "scheduledByRole": "owner",
  "exec": ["gh", "run", "list", "--limit", "5", "--json", "conclusion,name,url"],
  "prompt": "If any of the last 5 CI runs below failed, post to Slack workspace T0123 channel C0ENGR: 'CI broke: <name> <url>'. Otherwise stay silent (no tool calls)."
}
```

`channel_send` works out of the box for the no-subagent path because the default cron session inherits the agent's full tool set.

## Channel access

- **No subagent:** default cron session tools include `channel_send` and `channel_reply` whenever channels are configured. Nothing extra to wire.
- **With subagent:** subagents that declare an explicit `tools` field get only what they declared. Channel tools must be opted in via `customTools` (or by reusing the default tool set). The bundled `memory-logger` and `dreaming` subagents intentionally don't carry channel tools, so a "summarize and post" exec→llm flow should usually go through the no-subagent path unless you're authoring a plugin subagent that owns the routing. AGENTS.md spells this out.

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅ (no new warnings; 8 pre-existing on main, all unrelated)
- `bun run format` ✅
- `bun test` ✅ — 3712 tests pass (was 3690 on main)

## Commits

1. **Add exec and execMaxOutputBytes fields to cron prompt jobs** — schema only. Round-trips through `migrateLegacyCronShape` without change; backwards-compatible (both fields optional).
2. **Run optional exec command before LLM in cron prompt jobs** — consumer behavior + tests + docs.

## Risk / rollback

Low risk. Behavior change is gated entirely on `job.exec !== undefined`. Existing prompt jobs are unchanged (verified by the regression guard test "without exec: prompt and payload pass through unchanged"). To roll back, revert commit 2 — the schema fields in commit 1 become harmless declared-but-unused.

## Out of scope (deliberately punted)

- Container-stage CLI (`typeclaw prompt <text>` from inside bash) — discussed earlier but found to be solving a problem the existing in-process approach handles better. Can revisit if non-cron callers (bash skills, `typeclaw shell`) need the same shape.
- A new `kind: 'exec-then-prompt'` — would duplicate the consumer plumbing for no gain over an optional field.
- Conditional triggers (`triggerOn: 'success'` etc.) — composable via shell, so a field would be redundant. The LLM also gets exit code information and can choose to stay silent itself.
