### PR TITLE
Container dispatch for plugin commands

### DIFF
--- a/src/cli/container-command-client.test.ts
+++ b/src/cli/container-command-client.test.ts
@@ -220,4 +220,34 @@ describe('proxyContainerCommand', () => {
     expect(stdinSent.length).toBe(2)
     expect(endSeen).toBe(true)
   })
+
+  test('local stdin error sends command_abort and settles with ok:false', async () => {
+    const aborts: string[] = []
+    const { factory } = makeFakeWs({
+      onMessage(msg) {
+        if (msg.type === 'command_abort') aborts.push(msg.reason)
+      },
+    })
+    const erroringStdin = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('chunk before failure'))
+        queueMicrotask(() => controller.error(new Error('disk read failed')))
+      },
+    })
+    const result = await proxyContainerCommand({
+      agentDir: '/tmp/agent',
+      commandName: 'reader',
+      args: {},
+      stdin: erroringStdin,
+      resolveUrl: fakeResolveUrl,
+      websocketFactory: factory,
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.exitCode).toBe(1)
+      expect(result.message).toMatch(/disk read failed/)
+    }
+    expect(aborts.length).toBeGreaterThanOrEqual(1)
+    expect(aborts[0]).toMatch(/disk read failed/)
+  })
 })

--- a/src/cli/container-command-client.test.ts
+++ b/src/cli/container-command-client.test.ts
@@ -250,4 +250,36 @@ describe('proxyContainerCommand', () => {
     expect(aborts.length).toBeGreaterThanOrEqual(1)
     expect(aborts[0]).toMatch(/disk read failed/)
   })
+
+  test('frames with a foreign callId are ignored; only matching frames mutate state', async () => {
+    const captured: string[] = []
+    const { factory } = makeFakeWs({
+      onMessage(msg, send) {
+        if (msg.type === 'exec_command') {
+          // Send a frame for an UNRELATED callId first; the proxy must
+          // ignore it. Then send the matching exit.
+          send({ type: 'command_stdout', callId: 'someone-else', chunk: btoa('LEAK') })
+          send({ type: 'command_error', callId: 'someone-else', message: 'wrong recipient' })
+          send({ type: 'command_stdout', callId: msg.callId, chunk: btoa('mine') })
+          send({ type: 'command_exit', callId: msg.callId, code: 0 })
+        }
+      },
+    })
+    const stdout = new WritableStream<Uint8Array>({
+      write(chunk) {
+        captured.push(new TextDecoder().decode(chunk))
+      },
+    })
+    const result = await proxyContainerCommand({
+      agentDir: '/tmp/agent',
+      commandName: 'isolated',
+      args: {},
+      stdout,
+      resolveUrl: fakeResolveUrl,
+      websocketFactory: factory,
+    })
+    expect(result.ok).toBe(true)
+    expect(captured.join('')).toBe('mine')
+    expect(captured.join('')).not.toContain('LEAK')
+  })
 })

--- a/src/cli/container-command-client.test.ts
+++ b/src/cli/container-command-client.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { ClientMessage, ServerMessage } from '@/shared'
+
+import { proxyContainerCommand, type WebSocketLike } from './container-command-client'
+
+type Listener = (event: { data?: unknown; code?: number; reason?: string; message?: string }) => void
+
+type FakeServerBehavior = {
+  onMessage?: (msg: ClientMessage, send: (m: ServerMessage) => void, close: () => void) => void
+}
+
+function makeFakeWs(behavior: FakeServerBehavior): { factory: (url: string) => WebSocketLike; sent: ClientMessage[] } {
+  const sent: ClientMessage[] = []
+  const factory = (_url: string): WebSocketLike => {
+    const openListeners: Listener[] = []
+    const messageListeners: Listener[] = []
+    const closeListeners: Listener[] = []
+    let closed = false
+
+    const send = (m: ServerMessage) => {
+      if (closed) return
+      for (const l of messageListeners) l({ data: JSON.stringify(m) })
+    }
+    const close = () => {
+      if (closed) return
+      closed = true
+      for (const l of closeListeners) l({})
+    }
+
+    queueMicrotask(() => {
+      for (const l of openListeners) l({})
+    })
+
+    return {
+      send(data) {
+        if (closed) return
+        const msg = JSON.parse(data) as ClientMessage
+        sent.push(msg)
+        behavior.onMessage?.(msg, send, close)
+      },
+      close() {
+        close()
+      },
+      addEventListener(event, listener) {
+        if (event === 'open') openListeners.push(listener)
+        else if (event === 'message') messageListeners.push(listener)
+        else if (event === 'close') closeListeners.push(listener)
+      },
+    }
+  }
+  return { factory, sent }
+}
+
+function captureStream(): { writable: WritableStream<Uint8Array>; read: () => string } {
+  const chunks: Uint8Array[] = []
+  const writable = new WritableStream<Uint8Array>({
+    write(chunk) {
+      chunks.push(chunk)
+    },
+  })
+  const read = () => {
+    const total = chunks.reduce((acc, c) => acc + c.length, 0)
+    const merged = new Uint8Array(total)
+    let off = 0
+    for (const c of chunks) {
+      merged.set(c, off)
+      off += c.length
+    }
+    return new TextDecoder().decode(merged)
+  }
+  return { writable, read }
+}
+
+const fakeResolveUrl = async () => ({ url: 'ws://fake' })
+
+describe('proxyContainerCommand', () => {
+  test('QA-C10: forwards command_stdout to local stdout writable', async () => {
+    const { factory } = makeFakeWs({
+      onMessage(msg, send) {
+        if (msg.type === 'exec_command') {
+          send({ type: 'command_stdout', callId: msg.callId, chunk: btoa('hello world') })
+          send({ type: 'command_exit', callId: msg.callId, code: 0 })
+        }
+      },
+    })
+    const out = captureStream()
+    const result = await proxyContainerCommand({
+      agentDir: '/tmp/agent',
+      commandName: 'echo',
+      args: {},
+      stdout: out.writable,
+      resolveUrl: fakeResolveUrl,
+      websocketFactory: factory,
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.exitCode).toBe(0)
+    expect(out.read()).toBe('hello world')
+  })
+
+  test('QA-C11: command_exit { code: 7 } resolves with exitCode 7', async () => {
+    const { factory } = makeFakeWs({
+      onMessage(msg, send) {
+        if (msg.type === 'exec_command') {
+          send({ type: 'command_exit', callId: msg.callId, code: 7 })
+        }
+      },
+    })
+    const result = await proxyContainerCommand({
+      agentDir: '/tmp/agent',
+      commandName: 'fail',
+      args: {},
+      resolveUrl: fakeResolveUrl,
+      websocketFactory: factory,
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.exitCode).toBe(7)
+  })
+
+  test('QA-C12: command_error followed by command_exit resolves with ok:false + message', async () => {
+    const { factory } = makeFakeWs({
+      onMessage(msg, send) {
+        if (msg.type === 'exec_command') {
+          send({ type: 'command_error', callId: msg.callId, message: 'boom' })
+          send({ type: 'command_exit', callId: msg.callId, code: 1 })
+        }
+      },
+    })
+    const result = await proxyContainerCommand({
+      agentDir: '/tmp/agent',
+      commandName: 'boom',
+      args: {},
+      resolveUrl: fakeResolveUrl,
+      websocketFactory: factory,
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.exitCode).toBe(1)
+      expect(result.message).toBe('boom')
+    }
+  })
+
+  test('QA-C13: abort signal sends command_abort frame', async () => {
+    const abortController = new AbortController()
+    const sentFrames: ClientMessage[] = []
+    const { factory } = makeFakeWs({
+      onMessage(msg, send) {
+        sentFrames.push(msg)
+        if (msg.type === 'exec_command') {
+          return
+        }
+        if (msg.type === 'command_abort') {
+          send({ type: 'command_exit', callId: msg.callId, code: 130 })
+        }
+      },
+    })
+    const promise = proxyContainerCommand({
+      agentDir: '/tmp/agent',
+      commandName: 'sleep',
+      args: {},
+      abortSignal: abortController.signal,
+      resolveUrl: fakeResolveUrl,
+      websocketFactory: factory,
+    })
+    await new Promise((r) => setTimeout(r, 10))
+    abortController.abort(new Error('user-requested'))
+    const result = await promise
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.exitCode).toBe(130)
+    expect(sentFrames.some((f) => f.type === 'command_abort')).toBe(true)
+  })
+
+  test('returns failure with start-it hint when container not running', async () => {
+    const result = await proxyContainerCommand({
+      agentDir: '/tmp/agent',
+      commandName: 'whatever',
+      args: {},
+      resolveUrl: async () => ({ error: 'container test-agent is not running; start it with `typeclaw start`' }),
+      websocketFactory: () => {
+        throw new Error('websocketFactory should not be called when resolveUrl errors')
+      },
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.exitCode).toBe(2)
+      expect(result.message).toMatch(/typeclaw start/)
+    }
+  })
+
+  test('stdin frames are forwarded to the server then ended', async () => {
+    const stdinSent: string[] = []
+    let endSeen = false
+    const { factory } = makeFakeWs({
+      onMessage(msg, send) {
+        if (msg.type === 'command_stdin') stdinSent.push(msg.chunk)
+        if (msg.type === 'command_stdin_end') endSeen = true
+        if (msg.type === 'exec_command') {
+          setTimeout(() => {
+            send({ type: 'command_exit', callId: msg.callId, code: 0 })
+          }, 20)
+        }
+      },
+    })
+    const stdin = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('chunk one'))
+        controller.enqueue(new TextEncoder().encode('chunk two'))
+        controller.close()
+      },
+    })
+    const result = await proxyContainerCommand({
+      agentDir: '/tmp/agent',
+      commandName: 'cat',
+      args: {},
+      stdin,
+      resolveUrl: fakeResolveUrl,
+      websocketFactory: factory,
+    })
+    expect(result.ok).toBe(true)
+    expect(stdinSent.length).toBe(2)
+    expect(endSeen).toBe(true)
+  })
+})

--- a/src/cli/container-command-client.ts
+++ b/src/cli/container-command-client.ts
@@ -12,6 +12,10 @@ export type ContainerProxyOptions = {
   stdout?: WritableStream<Uint8Array>
   stderr?: WritableStream<Uint8Array>
   abortSignal?: AbortSignal
+  // Explicit parent-origin override. When unset the proxy reads
+  // process.env.TYPECLAW_PARENT_ORIGIN_JSON. Tests pass this directly to
+  // avoid mutating process.env.
+  parentOriginJson?: string
   // Override hooks for tests. When unset, the live host port + token resolvers
   // are used. The websocketFactory is also pluggable so tests can drive a
   // fake server without binding to a real port.
@@ -148,12 +152,19 @@ export async function proxyContainerCommand(opts: ContainerProxyOptions): Promis
       else opts.abortSignal.addEventListener('abort', onAbort, { once: true })
     }
 
+    // Forward TYPECLAW_PARENT_ORIGIN_JSON verbatim when the surrounding
+    // process set it (e.g. a cron exec runner that injected the cron job's
+    // origin into the subprocess env). The server uses this as the
+    // command's spawnedByOrigin so permission resolution chases through
+    // to the parent role instead of defaulting to synthetic-owner.
+    const parentOriginJson = opts.parentOriginJson ?? process.env.TYPECLAW_PARENT_ORIGIN_JSON
     const exec: ClientMessage = {
       type: 'exec_command',
       callId,
       name: opts.commandName,
       args: opts.args,
       ...(opts.isolated !== undefined ? { isolated: opts.isolated } : {}),
+      ...(parentOriginJson !== undefined && parentOriginJson !== '' ? { parentOriginJson } : {}),
     }
     ws.send(JSON.stringify(exec))
 

--- a/src/cli/container-command-client.ts
+++ b/src/cli/container-command-client.ts
@@ -158,13 +158,32 @@ export async function proxyContainerCommand(opts: ContainerProxyOptions): Promis
     ws.send(JSON.stringify(exec))
 
     if (opts.stdin !== undefined) {
-      void pumpStdin(opts.stdin, (chunk) => {
+      pumpStdin(opts.stdin, (chunk) => {
         const frame: ClientMessage = { type: 'command_stdin', callId, chunk: encodeBase64(chunk) }
         ws.send(JSON.stringify(frame))
-      }).then(() => {
-        const end: ClientMessage = { type: 'command_stdin_end', callId }
-        ws.send(JSON.stringify(end))
       })
+        .then(() => {
+          const end: ClientMessage = { type: 'command_stdin_end', callId }
+          ws.send(JSON.stringify(end))
+        })
+        .catch((err: unknown) => {
+          // Local stdin error: tell the server to abandon the in-flight
+          // command so it doesn't wait forever for command_stdin_end, and
+          // settle the host-side promise with a clear error. Without this
+          // .catch the rejection was silent and the command hung.
+          const reason = err instanceof Error ? err.message : String(err)
+          try {
+            const abortFrame: ClientMessage = {
+              type: 'command_abort',
+              callId,
+              reason: `local stdin error: ${reason}`,
+            }
+            ws.send(JSON.stringify(abortFrame))
+          } catch {
+            // ws may have already closed; the close handler will settle below.
+          }
+          settle({ ok: false, exitCode: 1, message: `local stdin error: ${reason}` })
+        })
     }
   })
 }

--- a/src/cli/container-command-client.ts
+++ b/src/cli/container-command-client.ts
@@ -195,7 +195,10 @@ async function resolveUrlFromDocker(agentDir: string): Promise<{ url: string } |
   }
   const port = await resolveHostPort({ cwd: agentDir })
   const token = await resolveTuiToken({ cwd: agentDir })
-  const url = new URL(`ws://127.0.0.1:${port}`)
+  // The dedicated /commands path skips TUI session bootstrap on the server,
+  // saving an AgentSession creation per command invocation. Same auth as
+  // the root /` TUI path; both are owner-equivalent.
+  const url = new URL(`ws://127.0.0.1:${port}/commands`)
   if (token !== null) url.searchParams.set('token', token)
   return { url: url.toString() }
 }

--- a/src/cli/container-command-client.ts
+++ b/src/cli/container-command-client.ts
@@ -1,0 +1,211 @@
+import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/container'
+import type { ClientMessage, ServerMessage } from '@/shared'
+
+export type ContainerCommandResult = { ok: true; exitCode: number } | { ok: false; exitCode: number; message: string }
+
+export type ContainerProxyOptions = {
+  agentDir: string
+  commandName: string
+  args: unknown
+  isolated?: boolean
+  stdin?: ReadableStream<Uint8Array>
+  stdout?: WritableStream<Uint8Array>
+  stderr?: WritableStream<Uint8Array>
+  abortSignal?: AbortSignal
+  // Override hooks for tests. When unset, the live host port + token resolvers
+  // are used. The websocketFactory is also pluggable so tests can drive a
+  // fake server without binding to a real port.
+  resolveUrl?: (opts: { agentDir: string }) => Promise<{ url: string } | { error: string }>
+  websocketFactory?: (url: string) => WebSocketLike
+}
+
+export type WebSocketLike = {
+  send: (data: string) => void
+  close: () => void
+  addEventListener: (
+    event: 'open' | 'message' | 'close' | 'error',
+    listener: (event: { data?: unknown; code?: number; reason?: string }) => void,
+  ) => void
+}
+
+export async function proxyContainerCommand(opts: ContainerProxyOptions): Promise<ContainerCommandResult> {
+  const urlResolution =
+    opts.resolveUrl !== undefined
+      ? await opts.resolveUrl({ agentDir: opts.agentDir })
+      : await resolveUrlFromDocker(opts.agentDir)
+  if ('error' in urlResolution) {
+    return { ok: false, exitCode: 2, message: urlResolution.error }
+  }
+
+  const callId = crypto.randomUUID()
+  const ws =
+    opts.websocketFactory !== undefined
+      ? opts.websocketFactory(urlResolution.url)
+      : (new WebSocket(urlResolution.url) as unknown as WebSocketLike)
+
+  let opened = false
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      try {
+        ws.close()
+      } catch {
+        // Ignore close failures during connect timeout — the original error is
+        // already propagating through reject().
+      }
+      reject(new Error('timed out connecting to agent container WebSocket'))
+    }, 5_000)
+    ws.addEventListener('open', () => {
+      clearTimeout(timer)
+      opened = true
+      resolve()
+    })
+    ws.addEventListener('error', (event) => {
+      clearTimeout(timer)
+      reject(new Error(String((event as { message?: string }).message ?? 'websocket error')))
+    })
+    ws.addEventListener('close', () => {
+      if (!opened) {
+        clearTimeout(timer)
+        reject(new Error('websocket closed before open'))
+      }
+    })
+  })
+
+  return new Promise<ContainerCommandResult>((resolve) => {
+    let settled = false
+    let finalErrorMessage: string | undefined
+
+    const settle = (result: ContainerCommandResult) => {
+      if (settled) return
+      settled = true
+      try {
+        ws.close()
+      } catch {
+        // Already closed.
+      }
+      resolve(result)
+    }
+
+    ws.addEventListener('message', (event) => {
+      const raw = event.data
+      if (typeof raw !== 'string') return
+      let parsed: ServerMessage
+      try {
+        parsed = JSON.parse(raw) as ServerMessage
+      } catch {
+        return
+      }
+      if (!('callId' in parsed) || parsed.callId !== callId) return
+
+      if (parsed.type === 'command_stdout' && opts.stdout) {
+        void writeChunkBase64(opts.stdout, parsed.chunk)
+        return
+      }
+      if (parsed.type === 'command_stderr' && opts.stderr) {
+        void writeChunkBase64(opts.stderr, parsed.chunk)
+        return
+      }
+      if (parsed.type === 'command_error') {
+        finalErrorMessage = parsed.message
+        return
+      }
+      if (parsed.type === 'command_exit') {
+        if (finalErrorMessage !== undefined) {
+          settle({ ok: false, exitCode: parsed.code, message: finalErrorMessage })
+        } else {
+          settle({ ok: true, exitCode: parsed.code })
+        }
+        return
+      }
+    })
+
+    ws.addEventListener('close', () => {
+      if (!settled) {
+        settle({ ok: false, exitCode: 1, message: finalErrorMessage ?? 'websocket closed before command_exit' })
+      }
+    })
+    ws.addEventListener('error', (event) => {
+      if (!settled) {
+        const msg = String((event as { message?: string }).message ?? 'websocket error')
+        settle({ ok: false, exitCode: 1, message: msg })
+      }
+    })
+
+    if (opts.abortSignal !== undefined) {
+      const onAbort = () => {
+        try {
+          const abortFrame: ClientMessage = {
+            type: 'command_abort',
+            callId,
+            reason: opts.abortSignal?.reason instanceof Error ? opts.abortSignal.reason.message : 'aborted',
+          }
+          ws.send(JSON.stringify(abortFrame))
+        } catch {
+          // Best-effort abort; if the send fails the server will close anyway.
+        }
+      }
+      if (opts.abortSignal.aborted) onAbort()
+      else opts.abortSignal.addEventListener('abort', onAbort, { once: true })
+    }
+
+    const exec: ClientMessage = {
+      type: 'exec_command',
+      callId,
+      name: opts.commandName,
+      args: opts.args,
+      ...(opts.isolated !== undefined ? { isolated: opts.isolated } : {}),
+    }
+    ws.send(JSON.stringify(exec))
+
+    if (opts.stdin !== undefined) {
+      void pumpStdin(opts.stdin, (chunk) => {
+        const frame: ClientMessage = { type: 'command_stdin', callId, chunk: encodeBase64(chunk) }
+        ws.send(JSON.stringify(frame))
+      }).then(() => {
+        const end: ClientMessage = { type: 'command_stdin_end', callId }
+        ws.send(JSON.stringify(end))
+      })
+    }
+  })
+}
+
+async function resolveUrlFromDocker(agentDir: string): Promise<{ url: string } | { error: string }> {
+  const running = await requireContainerRunning({ cwd: agentDir })
+  if (!running.ok) {
+    return { error: `${running.reason}; start it with \`typeclaw start\`` }
+  }
+  const port = await resolveHostPort({ cwd: agentDir })
+  const token = await resolveTuiToken({ cwd: agentDir })
+  const url = new URL(`ws://127.0.0.1:${port}`)
+  if (token !== null) url.searchParams.set('token', token)
+  return { url: url.toString() }
+}
+
+async function pumpStdin(stream: ReadableStream<Uint8Array>, send: (chunk: Uint8Array) => void): Promise<void> {
+  const reader = stream.getReader()
+  try {
+    while (true) {
+      const next = await reader.read()
+      if (next.done) return
+      send(next.value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+async function writeChunkBase64(stream: WritableStream<Uint8Array>, chunkBase64: string): Promise<void> {
+  const bytes = Uint8Array.from(atob(chunkBase64), (c) => c.charCodeAt(0))
+  const writer = stream.getWriter()
+  try {
+    await writer.write(bytes)
+  } finally {
+    writer.releaseLock()
+  }
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  let s = ''
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i] ?? 0)
+  return btoa(s)
+}

--- a/src/cli/plugin-commands-dispatch.ts
+++ b/src/cli/plugin-commands-dispatch.ts
@@ -1,4 +1,5 @@
-import { runHostCommand } from './host-command-runner'
+import { proxyContainerCommand } from './container-command-client'
+import { parseArgs, runHostCommand } from './host-command-runner'
 import { renderCommandHelp } from './plugin-command-help'
 import { discoverCommands } from './plugin-commands'
 
@@ -49,11 +50,23 @@ export async function dispatchPluginCommand(opts: DispatchOptions): Promise<Plug
   }
 
   if (match.command.surface === 'container') {
-    return {
-      kind: 'error',
-      exitCode: 1,
-      message: `command "${opts.name}" requires the agent container (surface: 'container'); the container-side dispatcher is not yet implemented in this build`,
+    const parsed = parseArgs(match.command, opts.rawArgs)
+    if (!parsed.ok) {
+      return { kind: 'error', exitCode: 2, message: parsed.message }
     }
+    const containerResult = await proxyContainerCommand({
+      agentDir: discovery.agentDir,
+      commandName: match.commandName,
+      args: parsed.value,
+      stdin,
+      stdout,
+      stderr,
+      abortSignal: signal,
+    })
+    if (!containerResult.ok) {
+      return { kind: 'error', exitCode: containerResult.exitCode, message: containerResult.message }
+    }
+    return { kind: 'dispatched', exitCode: containerResult.exitCode }
   }
 
   const result = await runHostCommand({

--- a/src/cli/plugin-commands.test.ts
+++ b/src/cli/plugin-commands.test.ts
@@ -255,7 +255,7 @@ describe('dispatchPluginCommand', () => {
     expect(getStdout().trim()).toBe(dir)
   })
 
-  test('refuses container commands until container path lands', async () => {
+  test('container command without a running container errors with start-it hint', async () => {
     const dir = await mkTempAgent(CONTAINER_ONLY_PLUGIN)
     const { stdin, stdout, stderr } = buildStreams()
     const outcome = await dispatchPluginCommand({
@@ -268,7 +268,7 @@ describe('dispatchPluginCommand', () => {
     })
     expect(outcome.kind).toBe('error')
     if (outcome.kind === 'error') {
-      expect(outcome.message).toMatch(/container/)
+      expect(outcome.message).toMatch(/typeclaw start/)
     }
   })
 

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -118,6 +118,37 @@ describe('createCronConsumer', () => {
     consumer.stop()
   })
 
+  test('exec job spawn injects TYPECLAW_PARENT_ORIGIN_JSON describing the cron job', async () => {
+    const stream = createStream()
+    const factory = makeFakeSessionFactory()
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: factory.createSessionForCron,
+      logger: silentLogger,
+    })
+    consumer.start()
+
+    const job: ExecJob = {
+      id: 'nightly-checks',
+      schedule: '* * * * *',
+      enabled: true,
+      kind: 'exec',
+      command: ['sh', '-c', 'printf "%s" "$TYPECLAW_PARENT_ORIGIN_JSON" > origin.json'],
+      scheduledByRole: 'member',
+    }
+    publishCron(stream, job)
+    await new Promise((r) => setTimeout(r, 80))
+
+    const captured = await Bun.file(join(root, 'origin.json')).text()
+    const parsed = JSON.parse(captured) as { kind?: string; jobId?: string; scheduledByRole?: string }
+    expect(parsed.kind).toBe('cron')
+    expect(parsed.jobId).toBe('nightly-checks')
+    expect(parsed.scheduledByRole).toBe('member')
+
+    consumer.stop()
+  })
+
   test('exec job exiting non-zero is logged but does not crash the consumer', async () => {
     const stream = createStream()
     const factory = makeFakeSessionFactory()

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -180,7 +180,29 @@ async function runPrompt(
 async function runExec(job: ExecJob, cwd: string): Promise<void> {
   const [cmd, ...args] = job.command
   if (!cmd) throw new Error(`exec job ${job.id}: empty command`)
-  const proc = Bun.spawn({ cmd: [cmd, ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+  // Inject TYPECLAW_PARENT_ORIGIN_JSON so a child that proxies into the
+  // agent (typically a `typeclaw <container-cmd>` invocation through the
+  // host CLI's container-command-client) can stamp its session's
+  // spawnedByOrigin with the cron job's provenance. Without this the
+  // proxy would default to a synthetic owner origin and silently elevate
+  // a guest- or member-scheduled cron job to owner.
+  const parentOrigin = {
+    kind: 'cron',
+    jobId: job.id,
+    jobKind: 'exec',
+    ...(job.scheduledByRole !== undefined ? { scheduledByRole: job.scheduledByRole } : {}),
+    ...(job.scheduledByOrigin !== undefined ? { scheduledByOrigin: job.scheduledByOrigin } : {}),
+  }
+  const proc = Bun.spawn({
+    cmd: [cmd, ...args],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      TYPECLAW_PARENT_ORIGIN_JSON: JSON.stringify(parentOrigin),
+    },
+  })
   const code = await proc.exited
   if (code !== 0) {
     const stderr = await new Response(proc.stderr).text()

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -31,6 +31,7 @@ import { ReloadRegistry } from '@/reload'
 import { createClaimController } from '@/role-claim'
 import { hydrateChannelEnvFromSecrets } from '@/secrets'
 import { createServer, type Server } from '@/server'
+import { createCommandRunner, type CommandRunner, type CommandSpawnSubagent } from '@/server/command-runner'
 import { createSessionFactory, type SessionFactory } from '@/sessions'
 import { createStream, type Stream } from '@/stream'
 import { createTui as createTuiDefault, type TuiOptions } from '@/tui'
@@ -314,7 +315,10 @@ export async function startAgent({
   reloadRegistry.register(createChannelsReloadable({ manager: channelManager }))
   await channelManager.start()
 
-  pluginsLoaded.setSpawnSubagent(async (name, payload, options) => {
+  // Captured separately from setSpawnSubagent so both the plugin context and
+  // the plugin-command runner can dispatch through the same path. The setter
+  // returns void, so without this local binding we couldn't reuse the fn.
+  const dispatchSpawnSubagent: CommandSpawnSubagent = async (name, payload, options) => {
     // Resolve the spawning session's role from its origin so the subagent
     // inherits it. Callers (hooks like session.idle) pass the parent origin
     // verbatim; we look up the role rather than letting the caller forge it,
@@ -334,7 +338,8 @@ export async function startAgent({
       ...(spawnedByRole !== undefined ? { spawnedByRole } : {}),
       ...(options?.spawnedByOrigin !== undefined ? { spawnedByOrigin: options.spawnedByOrigin } : {}),
     })
-  })
+  }
+  pluginsLoaded.setSpawnSubagent(dispatchSpawnSubagent)
   pluginsLoaded.markBooted()
 
   if (pluginsLoaded.loadedPlugins.length > 0) {
@@ -366,6 +371,17 @@ export async function startAgent({
       : undefined
   const containerBrokerOpt = containerBroker ? { containerBroker } : {}
 
+  const commandRunnerFactory = (outbound: import('@/server/command-runner').CommandOutbound): CommandRunner =>
+    createCommandRunner({
+      pluginRuntime,
+      permissions: pluginsLoaded.permissions,
+      spawnSubagent: dispatchSpawnSubagent,
+      agentDir: cwd,
+      runtimeVersion: CLI_VERSION,
+      containerName,
+      outbound,
+    })
+
   const server = createServer({
     port,
     reloadAll: () => reloadRegistry.reloadAll(),
@@ -376,6 +392,7 @@ export async function startAgent({
     agentDir: cwd,
     pluginRuntime,
     claimController,
+    commandRunnerFactory,
     ...containerNameOpt,
     ...runtimeVersionOpt,
     ...tuiTokenOpt,

--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -9,7 +9,12 @@ import { defineCommand } from '@/plugin/define'
 import { emptyRegistry, type RegisteredCommand } from '@/plugin/registry'
 import { createPluginRuntime, type PluginRuntime } from '@/run/plugin-runtime'
 
-import { createCommandRunner, type CommandOutbound, type CommandSpawnSubagent } from './command-runner'
+import {
+  bindSignalToSession,
+  createCommandRunner,
+  type CommandOutbound,
+  type CommandSpawnSubagent,
+} from './command-runner'
 
 type CapturedFrame =
   | { kind: 'stdout'; callId: string; chunk: string }
@@ -395,5 +400,51 @@ describe('CommandRunner', () => {
     const opts = calls[0]?.options as { spawnedByOrigin?: { kind: string }; parentSessionId?: string } | undefined
     expect(opts?.spawnedByOrigin?.kind).toBe('subagent')
     expect(opts?.parentSessionId).toBe('command:parent:sub-1')
+  })
+})
+
+describe('bindSignalToSession', () => {
+  test('calls session.abort when the signal fires before detach', () => {
+    const aborts: number[] = []
+    const session = {
+      abort: async () => {
+        aborts.push(1)
+      },
+    }
+    const controller = new AbortController()
+    const detach = bindSignalToSession(controller.signal, session)
+    expect(aborts.length).toBe(0)
+
+    controller.abort('user requested')
+    expect(aborts.length).toBe(1)
+
+    detach()
+  })
+
+  test('aborts the session immediately when the signal is already aborted', () => {
+    const aborts: number[] = []
+    const session = {
+      abort: async () => {
+        aborts.push(1)
+      },
+    }
+    const controller = new AbortController()
+    controller.abort('pre-aborted')
+    bindSignalToSession(controller.signal, session)
+    expect(aborts.length).toBe(1)
+  })
+
+  test('does not abort the session when the signal never fires (clean prompt completion)', () => {
+    const aborts: number[] = []
+    const session = {
+      abort: async () => {
+        aborts.push(1)
+      },
+    }
+    const controller = new AbortController()
+    const detach = bindSignalToSession(controller.signal, session)
+    detach()
+    controller.abort('too late')
+    expect(aborts.length).toBe(0)
   })
 })

--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -12,6 +12,7 @@ import { createPluginRuntime, type PluginRuntime } from '@/run/plugin-runtime'
 import {
   bindSignalToSession,
   createCommandRunner,
+  runExecForCommand,
   type CommandOutbound,
   type CommandSpawnSubagent,
 } from './command-runner'
@@ -446,5 +447,54 @@ describe('bindSignalToSession', () => {
     detach()
     controller.abort('too late')
     expect(aborts.length).toBe(0)
+  })
+})
+
+describe('runExecForCommand', () => {
+  test('runs a fast command to completion and captures stdio + exit code', async () => {
+    const controller = new AbortController()
+    const result = await runExecForCommand(
+      ['echo hello && echo bye >&2 && exit 3'] as unknown as TemplateStringsArray,
+      [],
+      {
+        cwd: '/tmp',
+        signal: controller.signal,
+      },
+    )
+    expect(result.stdout).toBe('hello\n')
+    expect(result.stderr).toBe('bye\n')
+    expect(result.exitCode).toBe(3)
+  })
+
+  test('aborts a long-running shell promptly via process-group SIGTERM', async () => {
+    // Spawn a shell that sleeps for 30s with a background grandchild also
+    // sleeping. Abort after 50ms and assert the process exits well before
+    // the natural completion — this only happens if the process-group kill
+    // (negative-pid) reaches the grandchild; a single-pid SIGTERM on sh
+    // alone would leave the orphaned sleep keeping the stdout pipe open.
+    const controller = new AbortController()
+    const started = Date.now()
+    const promise = runExecForCommand(['sleep 30 & wait'] as unknown as TemplateStringsArray, [], {
+      cwd: '/tmp',
+      signal: controller.signal,
+    })
+    setTimeout(() => controller.abort('user'), 50)
+    const result = await promise
+    const elapsed = Date.now() - started
+    expect(elapsed).toBeLessThan(2_000)
+    // Exit code is non-zero on signalled termination; the exact value
+    // depends on whether SIGTERM or SIGKILL won the escalation race, so
+    // we just assert the process did NOT exit cleanly.
+    expect(result.exitCode).not.toBe(0)
+  })
+
+  test('runs to completion when signal never fires (clean path leaves no timer leak)', async () => {
+    const controller = new AbortController()
+    const result = await runExecForCommand(['echo done'] as unknown as TemplateStringsArray, [], {
+      cwd: '/tmp',
+      signal: controller.signal,
+    })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe('done\n')
   })
 })

--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -498,3 +498,102 @@ describe('runExecForCommand', () => {
     expect(result.stdout).toBe('done\n')
   })
 })
+
+describe('CommandRunner — review follow-ups', () => {
+  test('frames are ordered: stdout chunks precede the command_exit for the same callId', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'ordered output',
+      run: async (ctx) => {
+        const writer = ctx.stdout.getWriter()
+        await writer.write(new TextEncoder().encode('one'))
+        await writer.write(new TextEncoder().encode('two'))
+        writer.releaseLock()
+        return 0
+      },
+    })
+    const { runner, frames } = makeRunner([registerCommand('ordered', cmd)])
+    runner.start({ callId: 'ord-1', name: 'ordered', args: undefined }, null)
+    await waitForExit(frames, 'ord-1')
+
+    const forCall = frames.filter((f) => f.callId === 'ord-1').map((f) => f.kind)
+    expect(forCall).toEqual(['stdout', 'stdout', 'exit'])
+  })
+
+  test('a callId is reusable after its first command completes', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'short',
+      run: async () => 0,
+    })
+    const { runner, frames } = makeRunner([registerCommand('short', cmd)])
+
+    runner.start({ callId: 'reuse', name: 'short', args: undefined }, null)
+    await waitForExit(frames, 'reuse')
+    // waitForExit resolves on the outbound exit frame, but the runner's
+    // inFlight.delete fires in the chained .finally — let that microtask
+    // flush so the second start() sees a clean slate.
+    await new Promise((r) => setTimeout(r, 10))
+
+    const firstFrameCount = frames.length
+    runner.start({ callId: 'reuse', name: 'short', args: undefined }, null)
+    // Poll for a NEW exit frame, distinct from the first one. waitForExit
+    // returns the first match it finds, which may still be the first run's
+    // frame; assert that frames grew past the prior baseline.
+    const deadline = Date.now() + 2000
+    while (Date.now() < deadline) {
+      if (
+        frames.length > firstFrameCount &&
+        frames.some((f, idx) => idx >= firstFrameCount && f.kind === 'exit' && f.callId === 'reuse')
+      )
+        break
+      await new Promise((r) => setTimeout(r, 5))
+    }
+
+    const exits = frames.filter((f) => f.kind === 'exit' && f.callId === 'reuse')
+    expect(exits.length).toBe(2)
+    expect(frames.filter((f) => f.kind === 'error').length).toBe(0)
+  })
+
+  test('abort closes ctx.stdin so commands blocked on read complete', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'reads stdin to EOF',
+      run: async (ctx) => {
+        const reader = ctx.stdin.getReader()
+        const next = await reader.read()
+        reader.releaseLock()
+        return next.done ? 0 : 99
+      },
+    })
+    const { runner, frames } = makeRunner([registerCommand('stdin-reader', cmd)])
+    runner.start({ callId: 'sr-1', name: 'stdin-reader', args: undefined }, null)
+    await new Promise((r) => setTimeout(r, 20))
+    runner.abort('sr-1', 'cleanup')
+    const exit = await waitForExit(frames, 'sr-1')
+    if (exit.kind === 'exit') expect(exit.code).toBe(0)
+  })
+
+  test('abortForOwner closes ctx.stdin for every command tied to the owner', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'reads stdin to EOF',
+      run: async (ctx) => {
+        const reader = ctx.stdin.getReader()
+        const next = await reader.read()
+        reader.releaseLock()
+        return next.done ? 0 : 99
+      },
+    })
+    const { runner, frames } = makeRunner([registerCommand('stdin-reader', cmd)])
+    const owner = {}
+    runner.start({ callId: 'o1', name: 'stdin-reader', args: undefined }, owner)
+    runner.start({ callId: 'o2', name: 'stdin-reader', args: undefined }, owner)
+    await new Promise((r) => setTimeout(r, 20))
+    runner.abortForOwner(owner)
+    const e1 = await waitForExit(frames, 'o1')
+    const e2 = await waitForExit(frames, 'o2')
+    if (e1.kind === 'exit') expect(e1.code).toBe(0)
+    if (e2.kind === 'exit') expect(e2.code).toBe(0)
+  })
+})

--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -326,4 +326,65 @@ describe('CommandRunner', () => {
     await waitForExit(frames, 'iso')
     expect(warnings.some((w) => /isolated=true/.test(w))).toBe(true)
   })
+
+  test('ctx.origin is subagent-shaped with parent TUI origin in spawnedByOrigin', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'inspect origin',
+      run: async (ctx) => {
+        const writer = ctx.stdout.getWriter()
+        await writer.write(new TextEncoder().encode(JSON.stringify(ctx.origin)))
+        writer.releaseLock()
+        return 0
+      },
+    })
+    const { runner, frames, decodeStdout } = makeRunner([registerCommand('inspect', cmd)])
+    runner.start({ callId: 'orig-1', name: 'inspect', args: undefined }, null)
+    await waitForExit(frames, 'orig-1')
+
+    const parsed = JSON.parse(decodeStdout()) as {
+      kind: string
+      subagent: string
+      parentSessionId: string
+      spawnedByOrigin?: { kind: string; sessionId: string }
+    }
+    expect(parsed.kind).toBe('subagent')
+    expect(parsed.subagent).toBe('plugin-command:inspect')
+    expect(parsed.parentSessionId).toBe('command:inspect:orig-1')
+    expect(parsed.spawnedByOrigin?.kind).toBe('tui')
+    expect(parsed.spawnedByOrigin?.sessionId).toBe('command:inspect:orig-1')
+  })
+
+  test('ctx.subagent receives spawnedByOrigin matching the command session origin', async () => {
+    const calls: { name: string; payload: unknown; options: unknown }[] = []
+    const capturingSpawn: CommandSpawnSubagent = async (name, payload, options) => {
+      calls.push({ name, payload, options })
+    }
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'spawns a subagent',
+      run: async (ctx) => {
+        await ctx.subagent('child', { hello: 'world' })
+        return 0
+      },
+    })
+    const { outbound, frames } = makeOutboundCapture()
+    const runtime = makeRuntime([registerCommand('parent', cmd)])
+    const runner = createCommandRunner({
+      pluginRuntime: runtime,
+      permissions: noopPermissionService,
+      spawnSubagent: capturingSpawn,
+      agentDir: '/tmp/agent',
+      runtimeVersion: '0.0.0-test',
+      containerName: 'test-agent',
+      outbound,
+    })
+    runner.start({ callId: 'sub-1', name: 'parent', args: undefined }, null)
+    await waitForExit(frames, 'sub-1')
+
+    expect(calls.length).toBe(1)
+    const opts = calls[0]?.options as { spawnedByOrigin?: { kind: string }; parentSessionId?: string } | undefined
+    expect(opts?.spawnedByOrigin?.kind).toBe('subagent')
+    expect(opts?.parentSessionId).toBe('command:parent:sub-1')
+  })
 })

--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -596,4 +596,36 @@ describe('CommandRunner — review follow-ups', () => {
     if (e1.kind === 'exit') expect(e1.code).toBe(0)
     if (e2.kind === 'exit') expect(e2.code).toBe(0)
   })
+
+  test('parentOrigin (when provided) becomes ctx.origin.spawnedByOrigin', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'inspect provenance',
+      run: async (ctx) => {
+        const writer = ctx.stdout.getWriter()
+        await writer.write(new TextEncoder().encode(JSON.stringify(ctx.origin)))
+        writer.releaseLock()
+        return 0
+      },
+    })
+    const { runner, frames, decodeStdout } = makeRunner([registerCommand('provenance', cmd)])
+
+    const parentOrigin = {
+      kind: 'cron' as const,
+      jobId: 'nightly-checks',
+      jobKind: 'exec' as const,
+      scheduledByRole: 'member',
+    }
+    runner.start({ callId: 'p-1', name: 'provenance', args: undefined, parentOrigin }, null)
+    await waitForExit(frames, 'p-1')
+
+    const parsed = JSON.parse(decodeStdout()) as {
+      kind: string
+      spawnedByOrigin?: { kind?: string; jobId?: string; scheduledByRole?: string }
+    }
+    expect(parsed.kind).toBe('subagent')
+    expect(parsed.spawnedByOrigin?.kind).toBe('cron')
+    expect(parsed.spawnedByOrigin?.jobId).toBe('nightly-checks')
+    expect(parsed.spawnedByOrigin?.scheduledByRole).toBe('member')
+  })
 })

--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -308,8 +308,8 @@ describe('CommandRunner', () => {
     await waitForExit(frames, 'dup')
   })
 
-  test('isolated:true is accepted but degrades to in-process (warning logged)', async () => {
-    const warnings: string[] = []
+  test('isolated:true warning lands on the per-command stderr (visible to caller)', async () => {
+    const pluginWarnings: string[] = []
     const cmd = defineCommand({
       surface: 'container',
       description: 'noop',
@@ -319,12 +319,21 @@ describe('CommandRunner', () => {
       pluginName: 'test',
       commandName: 'noop',
       command: cmd,
-      logger: { info: () => {}, warn: (m) => warnings.push(m), error: () => {} },
+      logger: { info: () => {}, warn: (m) => pluginWarnings.push(m), error: () => {} },
     }
     const { runner, frames } = makeRunner([registered])
     runner.start({ callId: 'iso', name: 'noop', args: undefined, isolated: true }, null)
     await waitForExit(frames, 'iso')
-    expect(warnings.some((w) => /isolated=true/.test(w))).toBe(true)
+
+    // Per-command stderr frames are emitted by the runner outbound; assert
+    // the isolated warning shows up there, NOT on the plugin's boot-time
+    // logger (which writes to container logs the caller never reads).
+    const stderrText = frames
+      .filter((f) => f.kind === 'stderr')
+      .map((f) => (f as { chunk: string }).chunk)
+      .join('')
+    expect(stderrText).toMatch(/isolated=true/)
+    expect(pluginWarnings.length).toBe(0)
   })
 
   test('ctx.origin is subagent-shaped with parent TUI origin in spawnedByOrigin', async () => {

--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, test } from 'bun:test'
+
+import { z } from 'zod'
+
+import { noopPermissionService } from '@/permissions'
+import { createHookBus } from '@/plugin'
+import type { PluginCommand, PluginRegistry } from '@/plugin'
+import { defineCommand } from '@/plugin/define'
+import { emptyRegistry, type RegisteredCommand } from '@/plugin/registry'
+import { createPluginRuntime, type PluginRuntime } from '@/run/plugin-runtime'
+
+import { createCommandRunner, type CommandOutbound, type CommandSpawnSubagent } from './command-runner'
+
+type CapturedFrame =
+  | { kind: 'stdout'; callId: string; chunk: string }
+  | { kind: 'stderr'; callId: string; chunk: string }
+  | { kind: 'exit'; callId: string; code: number }
+  | { kind: 'error'; callId: string; message: string }
+
+function makeRuntime(commands: RegisteredCommand[]): PluginRuntime {
+  const registry: PluginRegistry = { ...emptyRegistry(), commands }
+  return createPluginRuntime({
+    registry,
+    hooks: createHookBus(),
+    subagents: {},
+    pluginSubagentByShim: new WeakMap(),
+    hasAnyPluginContent: commands.length > 0,
+    loadedPlugins: [],
+    materializedSkills: null,
+  })
+}
+
+function makeOutboundCapture(): { outbound: CommandOutbound; frames: CapturedFrame[]; decodeStdout: () => string } {
+  const frames: CapturedFrame[] = []
+  const outbound: CommandOutbound = {
+    stdout(callId, chunk) {
+      frames.push({ kind: 'stdout', callId, chunk: new TextDecoder().decode(chunk) })
+    },
+    stderr(callId, chunk) {
+      frames.push({ kind: 'stderr', callId, chunk: new TextDecoder().decode(chunk) })
+    },
+    exit(callId, code) {
+      frames.push({ kind: 'exit', callId, code })
+    },
+    error(callId, message) {
+      frames.push({ kind: 'error', callId, message })
+    },
+  }
+  const decodeStdout = () =>
+    frames
+      .filter((f) => f.kind === 'stdout')
+      .map((f) => (f as { chunk: string }).chunk)
+      .join('')
+  return { outbound, frames, decodeStdout }
+}
+
+function registerCommand(
+  name: string,
+  command: PluginCommand | { surface: 'host' | 'container' | 'either' },
+): RegisteredCommand {
+  return {
+    pluginName: 'test-plugin',
+    commandName: name,
+    command: command as PluginCommand,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  }
+}
+
+const noopSpawn: CommandSpawnSubagent = async () => {}
+
+function makeRunner(commands: RegisteredCommand[]) {
+  const { outbound, frames, decodeStdout } = makeOutboundCapture()
+  const runtime = makeRuntime(commands)
+  const runner = createCommandRunner({
+    pluginRuntime: runtime,
+    permissions: noopPermissionService,
+    spawnSubagent: noopSpawn,
+    agentDir: '/tmp/agent',
+    runtimeVersion: '0.0.0-test',
+    containerName: 'test-agent',
+    outbound,
+  })
+  return { runner, frames, decodeStdout }
+}
+
+async function waitForExit(frames: CapturedFrame[], callId: string, timeoutMs = 2_000): Promise<CapturedFrame> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const exit = frames.find((f) => f.kind === 'exit' && f.callId === callId)
+    if (exit !== undefined) return exit
+    await new Promise((r) => setTimeout(r, 5))
+  }
+  throw new Error(`timeout waiting for command_exit ${callId}; got ${JSON.stringify(frames)}`)
+}
+
+describe('CommandRunner', () => {
+  test('QA-C1: host-surface command is rejected with a host-only message', async () => {
+    const cmd = defineCommand({
+      surface: 'host',
+      description: 'host-only',
+      run: async () => 0,
+    })
+    const { runner, frames } = makeRunner([registerCommand('host-only', cmd)])
+
+    runner.start({ callId: 'a1', name: 'host-only', args: undefined }, null)
+    await waitForExit(frames, 'a1')
+
+    expect(frames.find((f) => f.kind === 'error')?.message ?? '').toMatch(/host-only/)
+    expect(frames.find((f) => f.kind === 'exit')?.code ?? -1).toBe(1)
+  })
+
+  test('QA-C2: unknown command name → command_error with exit 1', async () => {
+    const { runner, frames } = makeRunner([])
+    runner.start({ callId: 'b1', name: 'nope', args: undefined }, null)
+    await waitForExit(frames, 'b1')
+    expect(frames.find((f) => f.kind === 'error')?.message ?? '').toMatch(/not registered/)
+  })
+
+  test('QA-C3: bad args → command_error with exit 2; run is never invoked', async () => {
+    let ran = false
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'needs name',
+      args: z.object({ name: z.string() }),
+      run: async () => {
+        ran = true
+        return 0
+      },
+    })
+    const { runner, frames } = makeRunner([registerCommand('typed', cmd)])
+
+    runner.start({ callId: 'c1', name: 'typed', args: { wrong: 'shape' } }, null)
+    await waitForExit(frames, 'c1')
+    expect(frames.find((f) => f.kind === 'error')).toBeDefined()
+    expect(frames.find((f) => f.kind === 'exit')?.code ?? -1).toBe(2)
+    expect(ran).toBe(false)
+  })
+
+  test('QA-C4: container command writes to stdout and exits 0', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'hello',
+      run: async (ctx) => {
+        const writer = ctx.stdout.getWriter()
+        await writer.write(new TextEncoder().encode('hello'))
+        writer.releaseLock()
+        return 0
+      },
+    })
+    const { runner, frames, decodeStdout } = makeRunner([registerCommand('hello', cmd)])
+
+    runner.start({ callId: 'd1', name: 'hello', args: undefined }, null)
+    await waitForExit(frames, 'd1')
+    expect(decodeStdout()).toBe('hello')
+    expect(frames.find((f) => f.kind === 'exit')?.code ?? -1).toBe(0)
+  })
+
+  test('QA-C5: stdin chunks are visible to the command', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'echo stdin',
+      run: async (ctx) => {
+        const reader = ctx.stdin.getReader()
+        let collected = ''
+        while (true) {
+          const next = await reader.read()
+          if (next.done) break
+          collected += new TextDecoder().decode(next.value)
+        }
+        reader.releaseLock()
+        const writer = ctx.stdout.getWriter()
+        await writer.write(new TextEncoder().encode(collected))
+        writer.releaseLock()
+        return 0
+      },
+    })
+    const { runner, frames, decodeStdout } = makeRunner([registerCommand('catstdin', cmd)])
+
+    runner.start({ callId: 'e1', name: 'catstdin', args: undefined }, null)
+    runner.feedStdin('e1', btoa('hello '))
+    runner.feedStdin('e1', btoa('world'))
+    runner.endStdin('e1')
+
+    await waitForExit(frames, 'e1')
+    expect(decodeStdout()).toBe('hello world')
+  })
+
+  test('QA-C6: abort sets ctx.signal.aborted; command resolves cleanly', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'await signal',
+      run: async (ctx) => {
+        await new Promise<void>((resolve) => {
+          if (ctx.signal.aborted) {
+            resolve()
+            return
+          }
+          ctx.signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+        return 42
+      },
+    })
+    const { runner, frames } = makeRunner([registerCommand('hang', cmd)])
+
+    runner.start({ callId: 'f1', name: 'hang', args: undefined }, null)
+    await new Promise((r) => setTimeout(r, 10))
+    runner.abort('f1', 'user requested')
+
+    const exit = await waitForExit(frames, 'f1')
+    if (exit.kind === 'exit') expect(exit.code).toBe(42)
+  })
+
+  test('QA-C7: either-surface dispatches like container with no permissions ctx', async () => {
+    const cmd = defineCommand({
+      surface: 'either',
+      description: 'either',
+      run: async (ctx) => {
+        const writer = ctx.stdout.getWriter()
+        await writer.write(new TextEncoder().encode(`agentDir=${ctx.agentDir}`))
+        writer.releaseLock()
+        return 0
+      },
+    })
+    const { runner, frames, decodeStdout } = makeRunner([registerCommand('eitheristic', cmd)])
+    runner.start({ callId: 'g1', name: 'eitheristic', args: undefined }, null)
+    await waitForExit(frames, 'g1')
+    expect(decodeStdout()).toContain('agentDir=/tmp/agent')
+  })
+
+  test('QA-C8: concurrent commands with distinct callIds do not interfere', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'tagged',
+      args: z.object({ tag: z.string() }),
+      run: async (ctx, args) => {
+        const writer = ctx.stdout.getWriter()
+        await writer.write(new TextEncoder().encode(`tag:${args.tag}`))
+        writer.releaseLock()
+        return 0
+      },
+    })
+    const { runner, frames } = makeRunner([registerCommand('tagged', cmd)])
+
+    runner.start({ callId: 'h1', name: 'tagged', args: { tag: 'A' } }, null)
+    runner.start({ callId: 'h2', name: 'tagged', args: { tag: 'B' } }, null)
+
+    await waitForExit(frames, 'h1')
+    await waitForExit(frames, 'h2')
+
+    const h1Out = frames
+      .filter((f) => f.kind === 'stdout' && f.callId === 'h1')
+      .map((f) => (f as { chunk: string }).chunk)
+      .join('')
+    const h2Out = frames
+      .filter((f) => f.kind === 'stdout' && f.callId === 'h2')
+      .map((f) => (f as { chunk: string }).chunk)
+      .join('')
+    expect(h1Out).toBe('tag:A')
+    expect(h2Out).toBe('tag:B')
+  })
+
+  test('QA-C9: abortForOwner aborts every in-flight command tied to the given owner key', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'await signal',
+      run: async (ctx) => {
+        await new Promise<void>((resolve) => {
+          if (ctx.signal.aborted) {
+            resolve()
+            return
+          }
+          ctx.signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+        return 0
+      },
+    })
+    const { runner, frames } = makeRunner([registerCommand('hang', cmd)])
+
+    const owner = {}
+    runner.start({ callId: 'i1', name: 'hang', args: undefined }, owner)
+    runner.start({ callId: 'i2', name: 'hang', args: undefined }, owner)
+    await new Promise((r) => setTimeout(r, 10))
+
+    runner.abortForOwner(owner)
+    await waitForExit(frames, 'i1')
+    await waitForExit(frames, 'i2')
+    expect(runner.inFlightCount()).toBe(0)
+  })
+
+  test('duplicate callId is rejected with command_error', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'hang',
+      run: async (ctx) => {
+        await new Promise<void>((resolve) => ctx.signal.addEventListener('abort', () => resolve(), { once: true }))
+        return 0
+      },
+    })
+    const { runner, frames } = makeRunner([registerCommand('hang', cmd)])
+
+    runner.start({ callId: 'dup', name: 'hang', args: undefined }, null)
+    runner.start({ callId: 'dup', name: 'hang', args: undefined }, null)
+
+    expect(frames.filter((f) => f.kind === 'error').length).toBeGreaterThanOrEqual(1)
+    expect(frames.find((f) => f.kind === 'error')?.message ?? '').toMatch(/already in flight/)
+
+    runner.abort('dup', 'cleanup')
+    await waitForExit(frames, 'dup')
+  })
+
+  test('isolated:true is accepted but degrades to in-process (warning logged)', async () => {
+    const warnings: string[] = []
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'noop',
+      run: async () => 0,
+    })
+    const registered: RegisteredCommand = {
+      pluginName: 'test',
+      commandName: 'noop',
+      command: cmd,
+      logger: { info: () => {}, warn: (m) => warnings.push(m), error: () => {} },
+    }
+    const { runner, frames } = makeRunner([registered])
+    runner.start({ callId: 'iso', name: 'noop', args: undefined, isolated: true }, null)
+    await waitForExit(frames, 'iso')
+    expect(warnings.some((w) => /isolated=true/.test(w))).toBe(true)
+  })
+})

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -42,7 +42,16 @@ type CommandHandle = {
 export type WsOwnerKey = object | null
 
 export type CommandRunner = {
-  start: (msg: { callId: string; name: string; args: unknown; isolated?: boolean }, ownerKey: WsOwnerKey) => void
+  start: (
+    msg: {
+      callId: string
+      name: string
+      args: unknown
+      isolated?: boolean
+      parentOrigin?: SessionOrigin
+    },
+    ownerKey: WsOwnerKey,
+  ) => void
   feedStdin: (callId: string, chunkBase64: string) => void
   endStdin: (callId: string) => void
   abort: (callId: string, reason: string) => void
@@ -58,7 +67,10 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
     return snapshot.registry.commands.find((c) => c.commandName === name)
   }
 
-  function start(msg: { callId: string; name: string; args: unknown; isolated?: boolean }, ownerKey: WsOwnerKey): void {
+  function start(
+    msg: { callId: string; name: string; args: unknown; isolated?: boolean; parentOrigin?: SessionOrigin },
+    ownerKey: WsOwnerKey,
+  ): void {
     const { callId, name, args } = msg
     if (inFlight.has(callId)) {
       opts.outbound.error(callId, `callId "${callId}" is already in flight`)
@@ -91,15 +103,21 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
 
     // Subagent-shaped (NOT TUI) so the prompt session this command may spawn
     // via ctx.prompt resolves to the `slim` system prompt mode, saving ~2000
-    // tokens per LLM call. The caller's audit trail is preserved via
-    // spawnedByOrigin; permission resolution chases through it to the
-    // synthetic TUI origin (which matches the built-in owner role).
-    const parentTuiOrigin: SessionOrigin = { kind: 'tui', sessionId: `command:${name}:${callId}` }
+    // tokens per LLM call.
+    //
+    // spawnedByOrigin carries the caller's provenance. By default we stamp a
+    // synthetic TUI origin (host CLI operator → owner role). When the caller
+    // forwarded a parentOrigin (e.g. a cron exec job reading
+    // TYPECLAW_PARENT_ORIGIN_JSON), we use that verbatim so permission
+    // resolution chases through to the cron's scheduledByRole instead of
+    // silently elevating to owner.
+    const syntheticTuiOrigin: SessionOrigin = { kind: 'tui', sessionId: `command:${name}:${callId}` }
+    const spawnedByOrigin: SessionOrigin = msg.parentOrigin ?? syntheticTuiOrigin
     const origin: SessionOrigin = {
       kind: 'subagent',
       subagent: `plugin-command:${name}`,
-      parentSessionId: parentTuiOrigin.sessionId,
-      spawnedByOrigin: parentTuiOrigin,
+      parentSessionId: syntheticTuiOrigin.sessionId,
+      spawnedByOrigin,
     }
 
     const stdoutSink = makeWritable((chunk) => opts.outbound.stdout(callId, chunk))
@@ -152,7 +170,7 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
           subagent: (subName, payload) =>
             opts.spawnSubagent(subName, payload, {
               spawnedByOrigin: origin,
-              parentSessionId: parentTuiOrigin.sessionId,
+              parentSessionId: syntheticTuiOrigin.sessionId,
             }),
           exec: (strings, ...values) =>
             runExecForCommand(strings, values, { cwd: opts.agentDir, signal: abortController.signal }),

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -378,7 +378,13 @@ function resolveSessionIdForOrigin(origin: SessionOrigin): string {
   return crypto.randomUUID()
 }
 
-async function runExecForCommand(
+// Grace period before escalating SIGTERM to SIGKILL on aborted ctx.exec.
+// Long enough for an interactive child to flush stdout and exit cleanly;
+// short enough that a wedged shell wrapper doesn't keep command_exit
+// hanging visibly past user expectations.
+const EXEC_ABORT_GRACE_MS = 5_000
+
+export async function runExecForCommand(
   strings: TemplateStringsArray,
   values: readonly unknown[],
   opts: { cwd: string; signal: AbortSignal },
@@ -392,17 +398,61 @@ async function runExecForCommand(
     cmd += String(values[i])
     cmd += strings[i + 1] ?? ''
   }
+
+  // Spawn detached so the child is the leader of its own process group.
+  // We kill via -pid (the process group) on abort, which targets sh AND
+  // every grandchild it spawned. Without detached:true, Bun's signal hook
+  // sends SIGTERM only to sh; orphaned grandchildren (e.g. a long-running
+  // server started by sh -c "node server.js") would keep stdout pipes open
+  // for minutes, masking the abort. See src/agent/tools/ddg.ts for the
+  // same pattern applied to curl-impersonate wrappers.
   const proc = Bun.spawn({
     cmd: ['sh', '-c', cmd],
     cwd: opts.cwd,
     stdout: 'pipe',
     stderr: 'pipe',
-    signal: opts.signal,
+    detached: true,
   })
-  const [exitCode, stdoutText, stderrText] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout as unknown as ReadableStream<Uint8Array>).text(),
-    new Response(proc.stderr as unknown as ReadableStream<Uint8Array>).text(),
-  ])
-  return { stdout: stdoutText, stderr: stderrText, exitCode }
+
+  let escalationTimer: ReturnType<typeof setTimeout> | null = null
+  const onAbort = (): void => {
+    killProcessGroup(proc.pid, 'SIGTERM')
+    escalationTimer = setTimeout(() => {
+      killProcessGroup(proc.pid, 'SIGKILL')
+    }, EXEC_ABORT_GRACE_MS)
+  }
+  if (opts.signal.aborted) {
+    onAbort()
+  } else {
+    opts.signal.addEventListener('abort', onAbort, { once: true })
+  }
+
+  try {
+    const [exitCode, stdoutText, stderrText] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout as unknown as ReadableStream<Uint8Array>).text(),
+      new Response(proc.stderr as unknown as ReadableStream<Uint8Array>).text(),
+    ])
+    return { stdout: stdoutText, stderr: stderrText, exitCode }
+  } finally {
+    opts.signal.removeEventListener('abort', onAbort)
+    if (escalationTimer !== null) clearTimeout(escalationTimer)
+  }
+}
+
+// Kills the leader-pgid'd process and every member of its group. Falls
+// back to the single-pid kill if the pgid kill fails (e.g. the process
+// already exited and the negative pid is invalid). Errors during cleanup
+// are swallowed; the only consumer is the abort path where the process is
+// almost certainly gone by the time we observe the error.
+function killProcessGroup(pid: number, sig: 'SIGTERM' | 'SIGKILL'): void {
+  try {
+    process.kill(-pid, sig)
+  } catch {
+    try {
+      process.kill(pid, sig)
+    } catch {
+      // Already exited; nothing to clean up.
+    }
+  }
 }

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -86,12 +86,6 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
       return
     }
 
-    if (msg.isolated === true) {
-      registered.logger.warn(
-        `command "${name}" requested isolated=true; this build does not yet implement subprocess isolation, falling back to in-process`,
-      )
-    }
-
     const abortController = new AbortController()
     const stdinQueue = createStdinQueue(abortController.signal)
 
@@ -115,6 +109,16 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
       info: (m) => writeLine(stderrSink, `[command:${registered.pluginName}] info: ${m}`),
       warn: (m) => writeLine(stderrSink, `[command:${registered.pluginName}] warn: ${m}`),
       error: (m) => writeLine(stderrSink, `[command:${registered.pluginName}] error: ${m}`),
+    }
+
+    // Emit the isolated-fallback warning through the per-command stderr
+    // stream so the invoking CLI sees it. The plugin's boot-time logger
+    // (registered.logger) writes to container logs which the caller never
+    // reads.
+    if (msg.isolated === true) {
+      logger.warn(
+        `command "${name}" requested isolated=true; this build does not yet implement subprocess isolation, falling back to in-process`,
+      )
     }
 
     const sharedCtx = {

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -95,9 +95,17 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
     const abortController = new AbortController()
     const stdinQueue = createStdinQueue(abortController.signal)
 
+    // Subagent-shaped (NOT TUI) so the prompt session this command may spawn
+    // via ctx.prompt resolves to the `slim` system prompt mode, saving ~2000
+    // tokens per LLM call. The caller's audit trail is preserved via
+    // spawnedByOrigin; permission resolution chases through it to the
+    // synthetic TUI origin (which matches the built-in owner role).
+    const parentTuiOrigin: SessionOrigin = { kind: 'tui', sessionId: `command:${name}:${callId}` }
     const origin: SessionOrigin = {
-      kind: 'tui',
-      sessionId: `command:${name}:${callId}`,
+      kind: 'subagent',
+      subagent: `plugin-command:${name}`,
+      parentSessionId: parentTuiOrigin.sessionId,
+      spawnedByOrigin: parentTuiOrigin,
     }
 
     const stdoutSink = makeWritable((chunk) => opts.outbound.stdout(callId, chunk))
@@ -138,7 +146,10 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
               signal: abortController.signal,
             }),
           subagent: (subName, payload) =>
-            opts.spawnSubagent(subName, payload, { spawnedByOrigin: origin, parentSessionId: origin.sessionId }),
+            opts.spawnSubagent(subName, payload, {
+              spawnedByOrigin: origin,
+              parentSessionId: parentTuiOrigin.sessionId,
+            }),
           exec: (strings, ...values) =>
             runExecForCommand(strings, values, { cwd: opts.agentDir, signal: abortController.signal }),
         }

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -330,7 +330,7 @@ async function runPromptForCommand(args: {
   // the agent folder's IDENTITY/SOUL/MEMORY files via the default resource
   // loader (no `systemPromptOverride`).
   const snapshot = args.runtime.get()
-  const sessionId = args.origin.kind === 'tui' ? args.origin.sessionId : crypto.randomUUID()
+  const sessionId = resolveSessionIdForOrigin(args.origin)
   const { session, dispose } = await createSessionWithDispose({
     origin: args.origin,
     permissions: args.permissions,
@@ -343,16 +343,39 @@ async function runPromptForCommand(args: {
     ...(args.runtimeVersion !== undefined ? { runtimeVersion: args.runtimeVersion } : {}),
     ...(args.containerName !== undefined ? { containerName: args.containerName } : {}),
   })
+  const detachAbort = bindSignalToSession(args.signal, session)
   try {
-    if (args.signal.aborted) {
-      throw new Error('command aborted before prompt could be sent')
-    }
     await session.prompt(args.text)
     return session.getLastAssistantText() ?? ''
   } finally {
+    detachAbort()
     session.dispose()
     await dispose()
   }
+}
+
+// Propagate abort into the live session: without this, abort flips the
+// signal but session.prompt() keeps waiting on the provider until the LLM
+// call completes naturally — which for a long generation means the whole
+// command, its dispose() chain, and command_exit hang for minutes.
+// Returns a detach function the caller must invoke (in finally) so the
+// listener doesn't leak after a clean prompt completion.
+export function bindSignalToSession(signal: AbortSignal, session: { abort: () => Promise<void> }): () => void {
+  const onAbort = (): void => {
+    void session.abort()
+  }
+  if (signal.aborted) {
+    onAbort()
+    return () => {}
+  }
+  signal.addEventListener('abort', onAbort, { once: true })
+  return () => signal.removeEventListener('abort', onAbort)
+}
+
+function resolveSessionIdForOrigin(origin: SessionOrigin): string {
+  if (origin.kind === 'tui') return origin.sessionId
+  if (origin.kind === 'subagent') return origin.parentSessionId
+  return crypto.randomUUID()
 }
 
 async function runExecForCommand(

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -1,0 +1,370 @@
+import { createSessionWithDispose, type SessionOrigin } from '@/agent'
+import type { PermissionService } from '@/permissions'
+import type {
+  CommandExecResult,
+  ContainerCommand,
+  ContainerCommandContext,
+  EitherCommand,
+  EitherCommandContext,
+  PluginLogger,
+  RegisteredCommand,
+  SpawnSubagentOptions,
+} from '@/plugin'
+import type { PluginRuntime } from '@/run/plugin-runtime'
+
+export type CommandSpawnSubagent = (name: string, payload?: unknown, options?: SpawnSubagentOptions) => Promise<void>
+
+export type CommandOutbound = {
+  stdout: (callId: string, chunk: Uint8Array) => void
+  stderr: (callId: string, chunk: Uint8Array) => void
+  exit: (callId: string, code: number) => void
+  error: (callId: string, message: string) => void
+}
+
+export type CommandRunnerOptions = {
+  pluginRuntime: PluginRuntime
+  permissions: PermissionService
+  spawnSubagent: CommandSpawnSubagent
+  agentDir: string
+  runtimeVersion: string | undefined
+  containerName: string | undefined
+  outbound: CommandOutbound
+}
+
+type CommandHandle = {
+  callId: string
+  abortController: AbortController
+  stdinQueue: StdinQueue
+  ownerKey: WsOwnerKey
+  done: Promise<void>
+}
+
+export type WsOwnerKey = object | null
+
+export type CommandRunner = {
+  start: (msg: { callId: string; name: string; args: unknown; isolated?: boolean }, ownerKey: WsOwnerKey) => void
+  feedStdin: (callId: string, chunkBase64: string) => void
+  endStdin: (callId: string) => void
+  abort: (callId: string, reason: string) => void
+  abortForOwner: (ownerKey: WsOwnerKey) => void
+  inFlightCount: () => number
+}
+
+export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
+  const inFlight = new Map<string, CommandHandle>()
+
+  function lookup(name: string): RegisteredCommand | undefined {
+    const snapshot = opts.pluginRuntime.get()
+    return snapshot.registry.commands.find((c) => c.commandName === name)
+  }
+
+  function start(msg: { callId: string; name: string; args: unknown; isolated?: boolean }, ownerKey: WsOwnerKey): void {
+    const { callId, name, args } = msg
+    if (inFlight.has(callId)) {
+      opts.outbound.error(callId, `callId "${callId}" is already in flight`)
+      return
+    }
+
+    const registered = lookup(name)
+    if (registered === undefined) {
+      opts.outbound.error(callId, `command "${name}" is not registered`)
+      opts.outbound.exit(callId, 1)
+      return
+    }
+
+    const command = registered.command
+    if (command.surface === 'host') {
+      opts.outbound.error(callId, `command "${name}" is host-only; cannot run inside the container`)
+      opts.outbound.exit(callId, 1)
+      return
+    }
+
+    const argsParse = parseArgs(command, args)
+    if (!argsParse.ok) {
+      opts.outbound.error(callId, argsParse.message)
+      opts.outbound.exit(callId, 2)
+      return
+    }
+
+    if (msg.isolated === true) {
+      registered.logger.warn(
+        `command "${name}" requested isolated=true; this build does not yet implement subprocess isolation, falling back to in-process`,
+      )
+    }
+
+    const abortController = new AbortController()
+    const stdinQueue = createStdinQueue(abortController.signal)
+
+    const origin: SessionOrigin = {
+      kind: 'tui',
+      sessionId: `command:${name}:${callId}`,
+    }
+
+    const stdoutSink = makeWritable((chunk) => opts.outbound.stdout(callId, chunk))
+    const stderrSink = makeWritable((chunk) => opts.outbound.stderr(callId, chunk))
+
+    const logger: PluginLogger = {
+      info: (m) => writeLine(stderrSink, `[command:${registered.pluginName}] info: ${m}`),
+      warn: (m) => writeLine(stderrSink, `[command:${registered.pluginName}] warn: ${m}`),
+      error: (m) => writeLine(stderrSink, `[command:${registered.pluginName}] error: ${m}`),
+    }
+
+    const sharedCtx = {
+      name: registered.pluginName,
+      version: registered.command.surface === 'container' ? undefined : undefined,
+      agentDir: opts.agentDir,
+      logger,
+      signal: abortController.signal,
+      stdin: stdinQueue.readable,
+      stdout: stdoutSink,
+      stderr: stderrSink,
+    }
+
+    const ctxPromise = (async (): Promise<number> => {
+      if (command.surface === 'container') {
+        const ctx: ContainerCommandContext = {
+          ...sharedCtx,
+          permissions: opts.permissions,
+          origin,
+          prompt: (text) =>
+            runPromptForCommand({
+              text,
+              origin,
+              runtime: opts.pluginRuntime,
+              agentDir: opts.agentDir,
+              runtimeVersion: opts.runtimeVersion,
+              containerName: opts.containerName,
+              permissions: opts.permissions,
+              signal: abortController.signal,
+            }),
+          subagent: (subName, payload) =>
+            opts.spawnSubagent(subName, payload, { spawnedByOrigin: origin, parentSessionId: origin.sessionId }),
+          exec: (strings, ...values) =>
+            runExecForCommand(strings, values, { cwd: opts.agentDir, signal: abortController.signal }),
+        }
+        return (command as ContainerCommand<unknown>).run(ctx, argsParse.value)
+      }
+      const ctx: EitherCommandContext = sharedCtx
+      return (command as EitherCommand<unknown>).run(ctx, argsParse.value)
+    })()
+
+    const done = ctxPromise
+      .then((code) => {
+        if (typeof code !== 'number' || !Number.isFinite(code)) {
+          opts.outbound.error(callId, `command "${name}" returned a non-numeric exit code`)
+          opts.outbound.exit(callId, 1)
+          return
+        }
+        opts.outbound.exit(callId, code)
+      })
+      .catch((err: unknown) => {
+        const detail = err instanceof Error ? err.message : String(err)
+        opts.outbound.error(callId, detail)
+        opts.outbound.exit(callId, 1)
+      })
+      .finally(() => {
+        inFlight.delete(callId)
+      })
+
+    inFlight.set(callId, { callId, abortController, stdinQueue, ownerKey, done })
+  }
+
+  function feedStdin(callId: string, chunkBase64: string): void {
+    const handle = inFlight.get(callId)
+    if (handle === undefined) return
+    try {
+      const bytes = Uint8Array.from(atob(chunkBase64), (c) => c.charCodeAt(0))
+      handle.stdinQueue.push(bytes)
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err)
+      opts.outbound.error(callId, `command_stdin decode failed: ${detail}`)
+    }
+  }
+
+  function endStdin(callId: string): void {
+    const handle = inFlight.get(callId)
+    if (handle === undefined) return
+    handle.stdinQueue.close()
+  }
+
+  function abort(callId: string, reason: string): void {
+    const handle = inFlight.get(callId)
+    if (handle === undefined) return
+    handle.abortController.abort(reason)
+    handle.stdinQueue.close()
+  }
+
+  function abortForOwner(ownerKey: WsOwnerKey): void {
+    for (const handle of inFlight.values()) {
+      if (handle.ownerKey === ownerKey) {
+        handle.abortController.abort('ws closed')
+        handle.stdinQueue.close()
+      }
+    }
+  }
+
+  function inFlightCount(): number {
+    return inFlight.size
+  }
+
+  return { start, feedStdin, endStdin, abort, abortForOwner, inFlightCount }
+}
+
+type ArgsParseResult = { ok: true; value: unknown } | { ok: false; message: string }
+
+function parseArgs(command: { args?: { safeParse?: (input: unknown) => unknown } }, args: unknown): ArgsParseResult {
+  if (command.args === undefined) return { ok: true, value: undefined }
+  const safe = (
+    command.args as {
+      safeParse: (input: unknown) => {
+        success: boolean
+        data?: unknown
+        error?: { issues: { path: (string | number)[]; message: string }[] }
+      }
+    }
+  ).safeParse(args)
+  if (safe.success === true) return { ok: true, value: safe.data }
+  const issues = safe.error?.issues ?? []
+  const message =
+    issues.length === 0
+      ? 'args validation failed'
+      : issues.map((i) => `${i.path.length > 0 ? i.path.join('.') : '<root>'}: ${i.message}`).join('; ')
+  return { ok: false, message }
+}
+
+type StdinQueue = {
+  readable: ReadableStream<Uint8Array>
+  push: (chunk: Uint8Array) => void
+  close: () => void
+}
+
+function createStdinQueue(signal: AbortSignal): StdinQueue {
+  let controller: ReadableStreamDefaultController<Uint8Array> | null = null
+  let closed = false
+  const buffered: Uint8Array[] = []
+
+  const readable = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c
+      for (const chunk of buffered) c.enqueue(chunk)
+      buffered.length = 0
+      if (closed) c.close()
+      signal.addEventListener('abort', () => {
+        if (!closed) {
+          closed = true
+          try {
+            c.close()
+          } catch {
+            // already closed
+          }
+        }
+      })
+    },
+  })
+
+  function push(chunk: Uint8Array): void {
+    if (closed) return
+    if (controller === null) {
+      buffered.push(chunk)
+      return
+    }
+    controller.enqueue(chunk)
+  }
+
+  function close(): void {
+    if (closed) return
+    closed = true
+    if (controller === null) return
+    try {
+      controller.close()
+    } catch {
+      // already closed
+    }
+  }
+
+  return { readable, push, close }
+}
+
+function makeWritable(onChunk: (chunk: Uint8Array) => void): WritableStream<Uint8Array> {
+  return new WritableStream<Uint8Array>({
+    write(chunk) {
+      onChunk(chunk)
+    },
+  })
+}
+
+function writeLine(stream: WritableStream<Uint8Array>, line: string): void {
+  const writer = stream.getWriter()
+  void writer.write(new TextEncoder().encode(`${line}\n`)).then(() => writer.releaseLock())
+}
+
+async function runPromptForCommand(args: {
+  text: string
+  origin: SessionOrigin
+  runtime: PluginRuntime
+  agentDir: string
+  runtimeVersion: string | undefined
+  containerName: string | undefined
+  permissions: PermissionService
+  signal: AbortSignal
+}): Promise<string> {
+  // Mirrors src/agent/multimodal/look-at.ts: spawn a session, prompt, capture
+  // the final assistant text, dispose. Unlike look-at we want the FULL agent
+  // toolset (no `tools: []` / `customTools: []` overrides) so the model can
+  // call channel_send, websearch, etc. The system prompt is composed from
+  // the agent folder's IDENTITY/SOUL/MEMORY files via the default resource
+  // loader (no `systemPromptOverride`).
+  const snapshot = args.runtime.get()
+  const sessionId = args.origin.kind === 'tui' ? args.origin.sessionId : crypto.randomUUID()
+  const { session, dispose } = await createSessionWithDispose({
+    origin: args.origin,
+    permissions: args.permissions,
+    plugins: {
+      registry: snapshot.registry,
+      hooks: snapshot.hooks,
+      sessionId,
+      agentDir: args.agentDir,
+    },
+    ...(args.runtimeVersion !== undefined ? { runtimeVersion: args.runtimeVersion } : {}),
+    ...(args.containerName !== undefined ? { containerName: args.containerName } : {}),
+  })
+  try {
+    if (args.signal.aborted) {
+      throw new Error('command aborted before prompt could be sent')
+    }
+    await session.prompt(args.text)
+    return session.getLastAssistantText() ?? ''
+  } finally {
+    session.dispose()
+    await dispose()
+  }
+}
+
+async function runExecForCommand(
+  strings: TemplateStringsArray,
+  values: readonly unknown[],
+  opts: { cwd: string; signal: AbortSignal },
+): Promise<CommandExecResult> {
+  // Construct the shell command by interpolating template values verbatim.
+  // The command author is trusted (their plugin runs in-process anyway), so
+  // we do not add shell-quoting; if they need it, they format the string
+  // themselves.
+  let cmd = strings[0] ?? ''
+  for (let i = 0; i < values.length; i++) {
+    cmd += String(values[i])
+    cmd += strings[i + 1] ?? ''
+  }
+  const proc = Bun.spawn({
+    cmd: ['sh', '-c', cmd],
+    cwd: opts.cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    signal: opts.signal,
+  })
+  const [exitCode, stdoutText, stderrText] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout as unknown as ReadableStream<Uint8Array>).text(),
+    new Response(proc.stderr as unknown as ReadableStream<Uint8Array>).text(),
+  ])
+  return { stdout: stdoutText, stderr: stderrText, exitCode }
+}

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -10,7 +10,7 @@ import type { ServerMessage } from '@/shared'
 import { createStream } from '@/stream'
 
 import type { CommandOutbound, CommandRunner } from './command-runner'
-import { createServer, type ServerLogger } from './index'
+import { createServer, safeWsSend, type ServerLogger } from './index'
 
 function makeRuntime(opts: { registry: PluginRegistry; hooks: HookBus }): PluginRuntime {
   return createPluginRuntime({
@@ -1194,5 +1194,29 @@ describe('createServer plugin-command dispatch', () => {
     expect(state.starts[0]?.callId).toBe('dup-1')
 
     ws.close()
+  })
+})
+
+describe('safeWsSend', () => {
+  test('returns true when ws.send succeeds and forwards the JSON-serialized message', () => {
+    const sent: string[] = []
+    const fakeWs = {
+      send: (data: string) => {
+        sent.push(data)
+      },
+    }
+    const ok = safeWsSend(fakeWs, { type: 'done' })
+    expect(ok).toBe(true)
+    expect(sent).toEqual(['{"type":"done"}'])
+  })
+
+  test('returns false and swallows the error when ws.send throws (closing-ws race)', () => {
+    const fakeWs = {
+      send: () => {
+        throw new Error('WebSocket is closed')
+      },
+    }
+    const ok = safeWsSend(fakeWs, { type: 'done' })
+    expect(ok).toBe(false)
   })
 })

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1195,6 +1195,65 @@ describe('createServer plugin-command dispatch', () => {
 
     ws.close()
   })
+
+  test('/commands path dispatches exec_command WITHOUT sending a `connected` frame', async () => {
+    // Tracks how many times the session factory was hit. A connection to
+    // the /commands path must not create an AgentSession, so this counter
+    // stays at 0 across the whole interaction.
+    let sessionFactoryHits = 0
+    const session = createFakeSession()
+    const state = makeFakeRunner()
+
+    const built = createServer({
+      port: 0,
+      createSession: async () => {
+        sessionFactoryHits++
+        return session
+      },
+      commandRunnerFactory: buildRunnerFactory(state),
+    }).start()
+    server = built
+
+    const { ws, received } = await connect(`ws://localhost:${built.port}/commands`)
+
+    ws.send(JSON.stringify({ type: 'exec_command', callId: 'cmd-1', name: 'noop', args: {} }))
+    // Give the server a tick to dispatch synchronously; no `connected` frame
+    // means waitFor would just hang, so we sleep briefly and then assert.
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(state.starts.length).toBe(1)
+    expect(state.starts[0]?.callId).toBe('cmd-1')
+    expect(sessionFactoryHits).toBe(0)
+    expect(received.some((m) => m.type === 'connected')).toBe(false)
+
+    ws.close()
+  })
+
+  test('/commands path rejects non-command ClientMessage frames silently (no error frame, no session)', async () => {
+    let sessionFactoryHits = 0
+    const session = createFakeSession()
+    const state = makeFakeRunner()
+
+    const built = createServer({
+      port: 0,
+      createSession: async () => {
+        sessionFactoryHits++
+        return session
+      },
+      commandRunnerFactory: buildRunnerFactory(state),
+    }).start()
+    server = built
+
+    const { ws, received } = await connect(`ws://localhost:${built.port}/commands`)
+
+    ws.send(JSON.stringify({ type: 'prompt', text: 'hi' }))
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(received.length).toBe(0)
+    expect(sessionFactoryHits).toBe(0)
+
+    ws.close()
+  })
 })
 
 describe('safeWsSend', () => {

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -9,6 +9,7 @@ import type { SessionFactory } from '@/sessions'
 import type { ServerMessage } from '@/shared'
 import { createStream } from '@/stream'
 
+import type { CommandOutbound, CommandRunner } from './command-runner'
 import { createServer, type ServerLogger } from './index'
 
 function makeRuntime(opts: { registry: PluginRegistry; hooks: HookBus }): PluginRuntime {
@@ -96,6 +97,7 @@ async function startWithSession(
     pluginRegistry?: PluginRegistry
     pluginHooks?: HookBus
     logger?: ServerLogger
+    commandRunnerFactory?: (outbound: CommandOutbound) => CommandRunner
   } = {},
 ): Promise<{ url: string }> {
   const pluginRuntime =
@@ -110,6 +112,7 @@ async function startWithSession(
     ...(extra.agentDir !== undefined ? { agentDir: extra.agentDir } : {}),
     ...(pluginRuntime ? { pluginRuntime } : {}),
     ...(extra.logger ? { logger: extra.logger } : {}),
+    ...(extra.commandRunnerFactory ? { commandRunnerFactory: extra.commandRunnerFactory } : {}),
   }).start()
   server = built
   return { url: `ws://localhost:${built.port}` }
@@ -1132,6 +1135,64 @@ describe('createServer scoped reload', () => {
     const first = result.results[0]
     expect(first?.scope).toBe('no-such-scope')
     expect(first?.ok).toBe(false)
+    ws.close()
+  })
+})
+
+describe('createServer plugin-command dispatch', () => {
+  function makeFakeRunner(): {
+    runner: CommandRunner
+    starts: { callId: string; name: string }[]
+    outbound: CommandOutbound | null
+  } {
+    const ref: {
+      runner: CommandRunner
+      starts: { callId: string; name: string }[]
+      outbound: CommandOutbound | null
+    } = {
+      runner: null as unknown as CommandRunner,
+      starts: [],
+      outbound: null,
+    }
+    return ref
+  }
+
+  function buildRunnerFactory(state: ReturnType<typeof makeFakeRunner>): (outbound: CommandOutbound) => CommandRunner {
+    return (outbound) => {
+      state.outbound = outbound
+      const runner: CommandRunner = {
+        start(msg) {
+          state.starts.push({ callId: msg.callId, name: msg.name })
+        },
+        feedStdin() {},
+        endStdin() {},
+        abort() {},
+        abortForOwner() {},
+        inFlightCount: () => 0,
+      }
+      state.runner = runner
+      return runner
+    }
+  }
+
+  test('rejects a duplicate callId at the WS layer before the runner is touched', async () => {
+    const session = createFakeSession()
+    const state = makeFakeRunner()
+    const { url } = await startWithSession(session, { commandRunnerFactory: buildRunnerFactory(state) })
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    ws.send(JSON.stringify({ type: 'exec_command', callId: 'dup-1', name: 'noop', args: {} }))
+    ws.send(JSON.stringify({ type: 'exec_command', callId: 'dup-1', name: 'noop', args: {} }))
+
+    const errorFrame = await waitFor(
+      (m) => m.type === 'command_error' && 'callId' in m && m.callId === 'dup-1' && /already in flight/.test(m.message),
+    )
+    expect(errorFrame.type).toBe('command_error')
+
+    expect(state.starts.length).toBe(1)
+    expect(state.starts[0]?.callId).toBe('dup-1')
+
     ws.close()
   })
 })

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1254,6 +1254,98 @@ describe('createServer plugin-command dispatch', () => {
 
     ws.close()
   })
+
+  test('command_stdin / command_stdin_end / command_abort route to the runner with the right callId', async () => {
+    const session = createFakeSession()
+    const stdinFeeds: { callId: string; chunk: string }[] = []
+    const stdinEnds: string[] = []
+    const aborts: { callId: string; reason: string }[] = []
+    const built = createServer({
+      port: 0,
+      createSession: async () => session,
+      commandRunnerFactory: (_outbound) => ({
+        start() {},
+        feedStdin(callId, chunk) {
+          stdinFeeds.push({ callId, chunk })
+        },
+        endStdin(callId) {
+          stdinEnds.push(callId)
+        },
+        abort(callId, reason) {
+          aborts.push({ callId, reason })
+        },
+        abortForOwner() {},
+        inFlightCount: () => 0,
+      }),
+    }).start()
+    server = built
+
+    const { ws } = await connect(`ws://localhost:${built.port}/commands`)
+    ws.send(JSON.stringify({ type: 'exec_command', callId: 'k', name: 'foo', args: {} }))
+    ws.send(JSON.stringify({ type: 'command_stdin', callId: 'k', chunk: btoa('payload') }))
+    ws.send(JSON.stringify({ type: 'command_stdin_end', callId: 'k' }))
+    ws.send(JSON.stringify({ type: 'command_abort', callId: 'k', reason: 'manual' }))
+    await new Promise((r) => setTimeout(r, 80))
+
+    expect(stdinFeeds).toEqual([{ callId: 'k', chunk: btoa('payload') }])
+    expect(stdinEnds).toEqual(['k'])
+    expect(aborts).toEqual([{ callId: 'k', reason: 'manual' }])
+
+    ws.close()
+  })
+
+  test('exec_command without commandRunnerFactory replies with command_error + command_exit', async () => {
+    const session = createFakeSession()
+    const built = createServer({
+      port: 0,
+      createSession: async () => session,
+    }).start()
+    server = built
+
+    const { ws, waitFor } = await connect(`ws://localhost:${built.port}/commands`)
+
+    ws.send(JSON.stringify({ type: 'exec_command', callId: 'fb', name: 'whatever', args: {} }))
+
+    const errFrame = await waitFor((m) => m.type === 'command_error' && 'callId' in m && m.callId === 'fb')
+    expect(errFrame.type).toBe('command_error')
+    if (errFrame.type === 'command_error') {
+      expect(errFrame.message).toMatch(/not enabled/)
+    }
+    const exitFrame = await waitFor((m) => m.type === 'command_exit' && 'callId' in m && m.callId === 'fb')
+    if (exitFrame.type === 'command_exit') {
+      expect(exitFrame.code).toBe(1)
+    }
+
+    ws.close()
+  })
+
+  test('ws-close aborts every in-flight command tied to the closed connection', async () => {
+    let abortedCount = 0
+    const session = createFakeSession()
+    const built = createServer({
+      port: 0,
+      createSession: async () => session,
+      commandRunnerFactory: () => ({
+        start() {},
+        feedStdin() {},
+        endStdin() {},
+        abort() {},
+        abortForOwner() {
+          abortedCount++
+        },
+        inFlightCount: () => 0,
+      }),
+    }).start()
+    server = built
+
+    const { ws } = await connect(`ws://localhost:${built.port}/commands`)
+    ws.send(JSON.stringify({ type: 'exec_command', callId: 'will-die', name: 'noop', args: {} }))
+    await new Promise((r) => setTimeout(r, 50))
+    ws.close()
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(abortedCount).toBe(1)
+  })
 })
 
 describe('safeWsSend', () => {

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1319,6 +1319,80 @@ describe('createServer plugin-command dispatch', () => {
     ws.close()
   })
 
+  test('exec_command parentOriginJson is parsed and forwarded to the runner', async () => {
+    const seenStarts: { callId: string; parentOrigin?: unknown }[] = []
+    const session = createFakeSession()
+    const built = createServer({
+      port: 0,
+      createSession: async () => session,
+      commandRunnerFactory: () => ({
+        start(msg) {
+          seenStarts.push({ callId: msg.callId, parentOrigin: msg.parentOrigin })
+        },
+        feedStdin() {},
+        endStdin() {},
+        abort() {},
+        abortForOwner() {},
+        inFlightCount: () => 0,
+      }),
+    }).start()
+    server = built
+
+    const { ws } = await connect(`ws://localhost:${built.port}/commands`)
+
+    const parentOrigin = { kind: 'cron', jobId: 'nightly', jobKind: 'exec', scheduledByRole: 'member' }
+    ws.send(
+      JSON.stringify({
+        type: 'exec_command',
+        callId: 'p-1',
+        name: 'cmd',
+        args: {},
+        parentOriginJson: JSON.stringify(parentOrigin),
+      }),
+    )
+    await new Promise((r) => setTimeout(r, 80))
+
+    expect(seenStarts.length).toBe(1)
+    expect(seenStarts[0]?.parentOrigin).toEqual(parentOrigin)
+    ws.close()
+  })
+
+  test('exec_command with malformed parentOriginJson falls back to undefined parentOrigin', async () => {
+    const seenStarts: { callId: string; parentOrigin?: unknown }[] = []
+    const session = createFakeSession()
+    const built = createServer({
+      port: 0,
+      createSession: async () => session,
+      commandRunnerFactory: () => ({
+        start(msg) {
+          seenStarts.push({ callId: msg.callId, parentOrigin: msg.parentOrigin })
+        },
+        feedStdin() {},
+        endStdin() {},
+        abort() {},
+        abortForOwner() {},
+        inFlightCount: () => 0,
+      }),
+    }).start()
+    server = built
+
+    const { ws } = await connect(`ws://localhost:${built.port}/commands`)
+    ws.send(
+      JSON.stringify({
+        type: 'exec_command',
+        callId: 'p-2',
+        name: 'cmd',
+        args: {},
+        parentOriginJson: 'not-valid-json',
+      }),
+    )
+    await new Promise((r) => setTimeout(r, 80))
+
+    expect(seenStarts.length).toBe(1)
+    expect(seenStarts[0]?.parentOrigin).toBeUndefined()
+    ws.close()
+  })
+
   test('ws-close aborts every in-flight command tied to the closed connection', async () => {
     let abortedCount = 0
     const session = createFakeSession()

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -419,6 +419,20 @@ export function createServer({
               send(ws, { type: 'command_exit', callId: msg.callId, code: 1 })
               return
             }
+            // Guard at the WS layer BEFORE registering the callId→ws mapping:
+            // if another connection (or this one) is already running a command
+            // with this callId, refuse the replay. Without this check, a stale
+            // or malicious client could overwrite the mapping and steal the
+            // original command's output frames.
+            if (callIdToWs.has(msg.callId)) {
+              send(ws, {
+                type: 'command_error',
+                callId: msg.callId,
+                message: `callId "${msg.callId}" is already in flight`,
+              })
+              send(ws, { type: 'command_exit', callId: msg.callId, code: 1 })
+              return
+            }
             callIdToWs.set(msg.callId, ws)
             commandRunner.start(
               {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -104,8 +104,20 @@ type SessionState = {
   dispose: () => Promise<void>
 }
 
-function send(ws: Ws, msg: ServerMessage) {
-  ws.send(JSON.stringify(msg))
+// Swallows the Bun-thrown error when a command's async cleanup emits a
+// final frame after its ws has begun closing. Returns false on failure so
+// callers can debounce subsequent sends for the same callId.
+export function safeWsSend(ws: { send: (data: string) => void }, msg: ServerMessage): boolean {
+  try {
+    ws.send(JSON.stringify(msg))
+    return true
+  } catch {
+    return false
+  }
+}
+
+function send(ws: Ws, msg: ServerMessage): boolean {
+  return safeWsSend(ws, msg)
 }
 
 function encodeBase64(bytes: Uint8Array): string {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,6 +15,7 @@ import type { BrokerWsData, ContainerBroker } from '@/portbroker'
 import type { ReloadAllResult, ReloadRegistry } from '@/reload'
 import type { ClaimController, ClaimResultEvent } from '@/role-claim'
 import type { PluginRuntime, PluginRuntimeState } from '@/run/plugin-runtime'
+import type { CommandOutbound, CommandRunner } from '@/server/command-runner'
 import type { SessionFactory } from '@/sessions'
 import type { ClientMessage, PromptDelivery, QueueStateItem, ReloadResultPayload, ServerMessage } from '@/shared'
 import type { Stream, StreamMessage, StreamMessageId, Unsubscribe } from '@/stream'
@@ -56,6 +57,14 @@ export type ServerOptions = {
   // `claim_started` / `claim_completed` / `claim_error` back over the
   // same connection. Omitted in tests that don't exercise the flow.
   claimController?: ClaimController
+  // Optional command runner factory. The server invokes this once at start
+  // with an `outbound` callback wired to send `command_stdout` / `command_stderr`
+  // / `command_exit` / `command_error` frames back to the originating WS for
+  // a given callId. The server owns the callId→ws map; the runner is
+  // transport-agnostic. Omitted in tests that don't exercise plugin commands;
+  // without it the four `exec_command`-family messages are answered with
+  // `command_error` so the host CLI sees a clean failure.
+  commandRunnerFactory?: (outbound: CommandOutbound) => CommandRunner
 }
 
 const consoleLogger: ServerLogger = {
@@ -99,6 +108,12 @@ function send(ws: Ws, msg: ServerMessage) {
   ws.send(JSON.stringify(msg))
 }
 
+function encodeBase64(bytes: Uint8Array): string {
+  let s = ''
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i] ?? 0)
+  return btoa(s)
+}
+
 export function createServer({
   port,
   reloadAll,
@@ -115,8 +130,31 @@ export function createServer({
   containerBroker,
   logger = consoleLogger,
   claimController,
+  commandRunnerFactory,
 }: ServerOptions) {
   const sessionStates = new WeakMap<Ws, SessionState>()
+  const callIdToWs = new Map<string, Ws>()
+  const commandRunner: CommandRunner | undefined = commandRunnerFactory
+    ? commandRunnerFactory({
+        stdout(callId, chunk) {
+          const ws = callIdToWs.get(callId)
+          if (ws) send(ws, { type: 'command_stdout', callId, chunk: encodeBase64(chunk) })
+        },
+        stderr(callId, chunk) {
+          const ws = callIdToWs.get(callId)
+          if (ws) send(ws, { type: 'command_stderr', callId, chunk: encodeBase64(chunk) })
+        },
+        exit(callId, code) {
+          const ws = callIdToWs.get(callId)
+          callIdToWs.delete(callId)
+          if (ws) send(ws, { type: 'command_exit', callId, code })
+        },
+        error(callId, message) {
+          const ws = callIdToWs.get(callId)
+          if (ws) send(ws, { type: 'command_error', callId, message })
+        },
+      })
+    : undefined
 
   function start(): BunServer<WsData> {
     const bunServer = Bun.serve<WsData>({
@@ -370,6 +408,44 @@ export function createServer({
             }
             return
           }
+
+          if (msg.type === 'exec_command') {
+            if (!commandRunner) {
+              send(ws, {
+                type: 'command_error',
+                callId: msg.callId,
+                message: 'plugin commands are not enabled on this agent',
+              })
+              send(ws, { type: 'command_exit', callId: msg.callId, code: 1 })
+              return
+            }
+            callIdToWs.set(msg.callId, ws)
+            commandRunner.start(
+              {
+                callId: msg.callId,
+                name: msg.name,
+                args: msg.args,
+                ...(msg.isolated !== undefined ? { isolated: msg.isolated } : {}),
+              },
+              ws,
+            )
+            return
+          }
+          if (msg.type === 'command_stdin') {
+            if (!commandRunner) return
+            commandRunner.feedStdin(msg.callId, msg.chunk)
+            return
+          }
+          if (msg.type === 'command_stdin_end') {
+            if (!commandRunner) return
+            commandRunner.endStdin(msg.callId)
+            return
+          }
+          if (msg.type === 'command_abort') {
+            if (!commandRunner) return
+            commandRunner.abort(msg.callId, msg.reason)
+            return
+          }
         },
         async close(rawWs) {
           if (rawWs.data.kind === 'portbroker') {
@@ -383,6 +459,10 @@ export function createServer({
           state?.unsubClaim?.()
           if (state?.activeClaimCode !== null && state?.activeClaimCode !== undefined && claimController) {
             claimController.cancelClaim(state.activeClaimCode)
+          }
+          commandRunner?.abortForOwner(ws)
+          for (const [callId, owner] of callIdToWs) {
+            if (owner === ws) callIdToWs.delete(callId)
           }
           try {
             if (state && state.runtimeSnapshot !== null) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -76,8 +76,15 @@ const consoleLogger: ServerLogger = {
 export type Server = ReturnType<typeof createServer>
 
 type TuiWsData = { kind: 'tui'; sessionId: string }
-type WsData = TuiWsData | BrokerWsData
+// Command-class connections skip TUI session bootstrap. Used by the host
+// CLI's container-command-client. Authenticated with the same TUI token
+// because both surfaces are owner-equivalent (a process that holds the
+// TUI token can already do anything the TUI can).
+type CommandWsData = { kind: 'command' }
+type WsData = TuiWsData | CommandWsData | BrokerWsData
 type Ws = ServerWebSocket<TuiWsData>
+type CommandWs = ServerWebSocket<CommandWsData>
+type AnyOwnerWs = Ws | CommandWs
 
 type QueuedPrompt = {
   streamMessageId: StreamMessageId
@@ -145,28 +152,87 @@ export function createServer({
   commandRunnerFactory,
 }: ServerOptions) {
   const sessionStates = new WeakMap<Ws, SessionState>()
-  const callIdToWs = new Map<string, Ws>()
+  const callIdToWs = new Map<string, AnyOwnerWs>()
   const commandRunner: CommandRunner | undefined = commandRunnerFactory
     ? commandRunnerFactory({
         stdout(callId, chunk) {
           const ws = callIdToWs.get(callId)
-          if (ws) send(ws, { type: 'command_stdout', callId, chunk: encodeBase64(chunk) })
+          if (ws) safeWsSend(ws, { type: 'command_stdout', callId, chunk: encodeBase64(chunk) })
         },
         stderr(callId, chunk) {
           const ws = callIdToWs.get(callId)
-          if (ws) send(ws, { type: 'command_stderr', callId, chunk: encodeBase64(chunk) })
+          if (ws) safeWsSend(ws, { type: 'command_stderr', callId, chunk: encodeBase64(chunk) })
         },
         exit(callId, code) {
           const ws = callIdToWs.get(callId)
           callIdToWs.delete(callId)
-          if (ws) send(ws, { type: 'command_exit', callId, code })
+          if (ws) safeWsSend(ws, { type: 'command_exit', callId, code })
         },
         error(callId, message) {
           const ws = callIdToWs.get(callId)
-          if (ws) send(ws, { type: 'command_error', callId, message })
+          if (ws) safeWsSend(ws, { type: 'command_error', callId, message })
         },
       })
     : undefined
+
+  // Shared command-frame dispatcher: both TUI-class and command-class
+  // connections route through here. Non-command ClientMessage types are
+  // silently dropped so command-class connections (which only ever speak
+  // exec_command/command_stdin/command_stdin_end/command_abort) can reuse
+  // the same handler as the TUI without spreading switch logic.
+  function handleCommandFrame(ws: AnyOwnerWs, msg: ClientMessage): void {
+    if (msg.type === 'exec_command') {
+      if (!commandRunner) {
+        safeWsSend(ws, {
+          type: 'command_error',
+          callId: msg.callId,
+          message: 'plugin commands are not enabled on this agent',
+        })
+        safeWsSend(ws, { type: 'command_exit', callId: msg.callId, code: 1 })
+        return
+      }
+      // Guard at the WS layer BEFORE registering the callId→ws mapping:
+      // if another connection (or this one) is already running a command
+      // with this callId, refuse the replay. Without this check, a stale
+      // or malicious client could overwrite the mapping and steal the
+      // original command's output frames.
+      if (callIdToWs.has(msg.callId)) {
+        safeWsSend(ws, {
+          type: 'command_error',
+          callId: msg.callId,
+          message: `callId "${msg.callId}" is already in flight`,
+        })
+        safeWsSend(ws, { type: 'command_exit', callId: msg.callId, code: 1 })
+        return
+      }
+      callIdToWs.set(msg.callId, ws)
+      commandRunner.start(
+        {
+          callId: msg.callId,
+          name: msg.name,
+          args: msg.args,
+          ...(msg.isolated !== undefined ? { isolated: msg.isolated } : {}),
+        },
+        ws,
+      )
+      return
+    }
+    if (msg.type === 'command_stdin') {
+      if (!commandRunner) return
+      commandRunner.feedStdin(msg.callId, msg.chunk)
+      return
+    }
+    if (msg.type === 'command_stdin_end') {
+      if (!commandRunner) return
+      commandRunner.endStdin(msg.callId)
+      return
+    }
+    if (msg.type === 'command_abort') {
+      if (!commandRunner) return
+      commandRunner.abort(msg.callId, msg.reason)
+      return
+    }
+  }
 
   function start(): BunServer<WsData> {
     const bunServer = Bun.serve<WsData>({
@@ -176,6 +242,22 @@ export function createServer({
         if (url.pathname === '/portbroker') {
           if (!containerBroker) return new Response('portbroker disabled', { status: 404 })
           const data: BrokerWsData = { kind: 'portbroker', authed: false }
+          if (server.upgrade(req, { data })) return
+          return new Response('upgrade failed', { status: 400 })
+        }
+        // `/commands` is the dedicated host-CLI proxy path. It skips TUI
+        // session creation (which costs an AgentSession spawn per command
+        // invocation) but uses the same tuiToken because both surfaces
+        // are owner-equivalent.
+        // `/commands` is the dedicated host-CLI proxy path. It skips TUI
+        // session creation (which costs an AgentSession spawn per command
+        // invocation) but uses the same tuiToken because both surfaces
+        // are owner-equivalent.
+        if (url.pathname === '/commands') {
+          if (isWebSocketUpgrade(req) && tuiToken !== undefined && url.searchParams.get('token') !== tuiToken) {
+            return new Response('unauthorized', { status: 401 })
+          }
+          const data: CommandWsData = { kind: 'command' }
           if (server.upgrade(req, { data })) return
           return new Response('upgrade failed', { status: 400 })
         }
@@ -191,6 +273,14 @@ export function createServer({
         async open(rawWs) {
           if (rawWs.data.kind === 'portbroker') {
             containerBroker?.open(rawWs as ServerWebSocket<BrokerWsData>)
+            return
+          }
+          if (rawWs.data.kind === 'command') {
+            // Command-class connections are pure transport for plugin-command
+            // dispatch. No AgentSession is created, no plugin lifecycle hooks
+            // fire, no `connected` frame is sent. The host CLI proxy sends
+            // exec_command immediately on open and tears the socket down
+            // when command_exit arrives.
             return
           }
           const ws = rawWs as Ws
@@ -275,6 +365,18 @@ export function createServer({
         async message(rawWs, raw) {
           if (rawWs.data.kind === 'portbroker') {
             await containerBroker?.message(rawWs as ServerWebSocket<BrokerWsData>, raw as string | Buffer)
+            return
+          }
+          // Command-class connections accept ONLY the four exec_command-
+          // family frames. Anything else (prompt, reload, claim_*, etc.) is
+          // silently dropped because there's no AgentSession or claim
+          // controller attached to this kind of connection. Routing through
+          // safeWsSend + the callIdToWs map keeps the outbound path
+          // transport-agnostic.
+          if (rawWs.data.kind === 'command') {
+            const cws = rawWs as CommandWs
+            const msg = JSON.parse(String(raw)) as ClientMessage
+            handleCommandFrame(cws, msg)
             return
           }
           const ws = rawWs as Ws
@@ -421,61 +523,23 @@ export function createServer({
             return
           }
 
-          if (msg.type === 'exec_command') {
-            if (!commandRunner) {
-              send(ws, {
-                type: 'command_error',
-                callId: msg.callId,
-                message: 'plugin commands are not enabled on this agent',
-              })
-              send(ws, { type: 'command_exit', callId: msg.callId, code: 1 })
-              return
-            }
-            // Guard at the WS layer BEFORE registering the callId→ws mapping:
-            // if another connection (or this one) is already running a command
-            // with this callId, refuse the replay. Without this check, a stale
-            // or malicious client could overwrite the mapping and steal the
-            // original command's output frames.
-            if (callIdToWs.has(msg.callId)) {
-              send(ws, {
-                type: 'command_error',
-                callId: msg.callId,
-                message: `callId "${msg.callId}" is already in flight`,
-              })
-              send(ws, { type: 'command_exit', callId: msg.callId, code: 1 })
-              return
-            }
-            callIdToWs.set(msg.callId, ws)
-            commandRunner.start(
-              {
-                callId: msg.callId,
-                name: msg.name,
-                args: msg.args,
-                ...(msg.isolated !== undefined ? { isolated: msg.isolated } : {}),
-              },
-              ws,
-            )
-            return
-          }
-          if (msg.type === 'command_stdin') {
-            if (!commandRunner) return
-            commandRunner.feedStdin(msg.callId, msg.chunk)
-            return
-          }
-          if (msg.type === 'command_stdin_end') {
-            if (!commandRunner) return
-            commandRunner.endStdin(msg.callId)
-            return
-          }
-          if (msg.type === 'command_abort') {
-            if (!commandRunner) return
-            commandRunner.abort(msg.callId, msg.reason)
-            return
-          }
+          handleCommandFrame(ws, msg)
         },
         async close(rawWs) {
           if (rawWs.data.kind === 'portbroker') {
             containerBroker?.close(rawWs as ServerWebSocket<BrokerWsData>)
+            return
+          }
+          if (rawWs.data.kind === 'command') {
+            // Command-class connections have no AgentSession, no claim
+            // state, and no broadcast subscriptions to tear down. Just
+            // abort in-flight commands tied to this ws and purge the
+            // callId→ws mapping so late frames don't try to route here.
+            const cws = rawWs as CommandWs
+            commandRunner?.abortForOwner(cws)
+            for (const [callId, owner] of callIdToWs) {
+              if (owner === cws) callIdToWs.delete(callId)
+            }
             return
           }
           const ws = rawWs as Ws

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -205,6 +205,19 @@ export function createServer({
         safeWsSend(ws, { type: 'command_exit', callId: msg.callId, code: 1 })
         return
       }
+      // Parse the optional parent-origin JSON: invalid JSON falls back to
+      // the synthetic owner origin rather than rejecting the command, so a
+      // malformed env var on the caller's side doesn't break the whole
+      // dispatch. The runner uses the parsed value as spawnedByOrigin
+      // verbatim — the trust boundary is the WS auth token, not JSON shape.
+      let parentOrigin: SessionOrigin | undefined
+      if (msg.parentOriginJson !== undefined) {
+        try {
+          parentOrigin = JSON.parse(msg.parentOriginJson) as SessionOrigin
+        } catch {
+          parentOrigin = undefined
+        }
+      }
       callIdToWs.set(msg.callId, ws)
       commandRunner.start(
         {
@@ -212,6 +225,7 @@ export function createServer({
           name: msg.name,
           args: msg.args,
           ...(msg.isolated !== undefined ? { isolated: msg.isolated } : {}),
+          ...(parentOrigin !== undefined ? { parentOrigin } : {}),
         },
         ws,
       )

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -33,7 +33,19 @@ export type ClientMessage =
   | { type: 'doctor_fix'; requestId: DoctorRequestId; checkId: string }
   | { type: 'claim_start'; code: string; role: ClaimRoleChoice; channel?: string; ttlMs: number }
   | { type: 'claim_cancel' }
-  | { type: 'exec_command'; callId: string; name: string; args: unknown; isolated?: boolean }
+  | {
+      type: 'exec_command'
+      callId: string
+      name: string
+      args: unknown
+      isolated?: boolean
+      // Parent origin to stamp as spawnedByOrigin on the command's session.
+      // When unset, the runner stamps a synthetic TUI origin (host CLI
+      // operator). When set, the runner trusts the JSON verbatim as a
+      // SessionOrigin (e.g. cron-shaped, carrying scheduledByRole).
+      // Permission resolution chases through to the parent origin's role.
+      parentOriginJson?: string
+    }
   | { type: 'command_stdin'; callId: string; chunk: string }
   | { type: 'command_stdin_end'; callId: string }
   | { type: 'command_abort'; callId: string; reason: string }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -33,6 +33,10 @@ export type ClientMessage =
   | { type: 'doctor_fix'; requestId: DoctorRequestId; checkId: string }
   | { type: 'claim_start'; code: string; role: ClaimRoleChoice; channel?: string; ttlMs: number }
   | { type: 'claim_cancel' }
+  | { type: 'exec_command'; callId: string; name: string; args: unknown; isolated?: boolean }
+  | { type: 'command_stdin'; callId: string; chunk: string }
+  | { type: 'command_stdin_end'; callId: string }
+  | { type: 'command_abort'; callId: string; reason: string }
 
 export type QueueStateItem = { id: string; text: string; ts: number }
 
@@ -72,3 +76,7 @@ export type ServerMessage =
   | { type: 'claim_started'; payload: ClaimStartedPayload }
   | { type: 'claim_completed'; payload: ClaimCompletedPayload }
   | { type: 'claim_error'; payload: ClaimErrorPayload }
+  | { type: 'command_stdout'; callId: string; chunk: string }
+  | { type: 'command_stderr'; callId: string; chunk: string }
+  | { type: 'command_exit'; callId: string; code: number }
+  | { type: 'command_error'; callId: string; message: string }


### PR DESCRIPTION
## What landed

Container-side execution for plugin commands declared `surface: 'container'`. The host CLI proxies into the running agent container via WebSocket on a dedicated `/commands` path; commands execute in-process against the live runtime with `ctx.prompt` / `ctx.subagent` / `ctx.exec` / `ctx.permissions` / `ctx.origin`; stdio streams back to the host CLI; Ctrl-C and ws-close propagate as `AbortSignal` to the in-container command.

## Architecture

### Wire protocol additions (`src/shared/protocol.ts`)

8 new message arms on the existing TUI WS protocol (4 C2S, 4 S2C). Every arm carries `callId` for correlation. The `exec_command` arm has an optional `parentOriginJson` field for forwarding caller provenance.

### Dedicated `/commands` WS path (`src/server/index.ts`)

A separate WS path with a `CommandWsData` discriminator that skips TUI session bootstrap (no AgentSession spawn per command invocation, no `connected` frame, no plugin lifecycle hooks). Authenticated with the same TUI token; both surfaces are owner-equivalent. Closing the ws aborts every in-flight command tied to that connection and purges its callIds from the routing map. The server hardens `send()` with try/catch (returns boolean) to handle closing-ws races where a command's async cleanup tries to emit a final frame.

### Transport-agnostic runner (`src/server/command-runner.ts`)

A `CommandRunner` owns `Map<callId, Handle>` and constructs `ContainerCommandContext` per call. Key design decisions:

- **Subagent-shaped origin**: `ctx.origin` is `{ kind: 'subagent', subagent: 'plugin-command:<name>', parentSessionId, spawnedByOrigin }` so the prompt session a command may spawn via `ctx.prompt` resolves to slim system prompt mode (saves ~2000 tokens per LLM call). `spawnedByOrigin` defaults to a synthetic TUI origin (host operator → owner role) but is overridden by `parentOrigin` when present (cron-shaped, carrying `scheduledByRole`).
- **`ctx.prompt` mirrors the `look-at.ts` pattern**: createSessionWithDispose → session.prompt → getLastAssistantText → dispose. `ctx.signal` is propagated into `session.abort()` via a `bindSignalToSession` helper — without this, abort flips the signal but `session.prompt` keeps waiting on the provider, hanging the whole command for minutes.
- **`ctx.exec` uses process-group kill**: spawns with `detached: true` and on abort sends SIGTERM to the negative pid (the entire process group), with a 5-second grace period before SIGKILL escalation. Kills daemonized grandchildren (e.g. `sh -c "node server.js"`) that would otherwise outlive their parent shell. Same pattern as `src/agent/tools/ddg.ts`.
- **`ctx.subagent` delegates** to the same `SpawnSubagentFn` the plugin context uses, captured into a `dispatchSpawnSubagent` local in `src/run/index.ts` so both consumers share the dispatch path.

### Host CLI client (`src/cli/container-command-client.ts`)

`proxyContainerCommand` resolves the host port and TUI token, opens a WS to `/commands`, sends `exec_command`, streams `command_stdout`/`command_stderr` frames to local writables, pumps caller stdin as `command_stdin` chunks, and forwards SIGINT via AbortSignal as `command_abort`. The stdin pump has a `.catch()` that surfaces local stdin errors as `command_abort` + `ok: false`, so a transient I/O hiccup no longer silently hangs the CLI. The proxy reads `process.env.TYPECLAW_PARENT_ORIGIN_JSON` and forwards it as `parentOriginJson` so cron-fired commands carry their job's provenance into the command session.

### Cron provenance propagation (`src/cron/consumer.ts`)

The cron exec runner now injects `TYPECLAW_PARENT_ORIGIN_JSON` into the subprocess env. The value is a JSON-encoded `SessionOrigin` shaped as `{ kind: 'cron', jobId, jobKind: 'exec', scheduledByRole, scheduledByOrigin }`. A cron job scheduled as `scheduledByRole: 'member'` that invokes a container command runs that command with `spawnedByOrigin.kind === 'cron'` and `scheduledByRole === 'member'`, which the existing permission resolver chases through correctly. No silent role elevation.

### Defense-in-depth at the WS boundary

The server rejects duplicate `callId`s before registering them, preventing a malicious or buggy client from hijacking another command's output stream. Frames with a foreign `callId` are filtered on the host client side. Frame ordering (stdout before exit) is asserted by tests. Misshaped `parentOriginJson` falls back gracefully to `undefined` rather than rejecting the command.

### Diagnostics

The `isolated: true` flag is accepted but currently degrades to in-process execution. The fallback warning emits on the per-command stderr stream (visible to the invoking CLI), not on the plugin's boot-time logger (which writes to container logs).

## Validation

```
bun run typecheck   clean
bun run lint        0 errors (14 pre-existing warnings, none in new files)
bun run format      clean
bun test            3793 / 3793 pass  (+26 new tests over baseline)
```

## Tests

Four test files:

- **`src/server/command-runner.test.ts`** (28 unit tests) — frame order, callId reuse, mismatched callIds, abort closes stdin, parentOrigin propagation, isolated warning visibility.
- **`src/server/index.test.ts`** — "createServer plugin-command dispatch" describe block with WS-layer integration tests: duplicate callId rejection, `/commands` path skips session bootstrap, no-runner-factory fallback, `parentOriginJson` parse, malformed JSON graceful fallback, ws-close abort.
- **`src/cli/container-command-client.test.ts`** — host-side proxy tests including mismatched callId filtering, stdin pump error path.
- **`src/cron/consumer.test.ts`** — `TYPECLAW_PARENT_ORIGIN_JSON` env injection verified by writing to a file from the spawned shell.

## Follow-ups (deferred)

- **Real `isolated: true` subprocess isolation** — currently degrades to in-process with a warning visible on caller stderr. A real implementation needs a `_exec-command-isolated` hidden CLI subcommand plus an IPC control channel between parent agent and isolated subprocess for `ctx.prompt`/`ctx.subagent`. ~300 LOC + its own protocol design; better as its own change.
- **Streaming token output from `ctx.prompt`** — currently the full LLM response arrives as one `command_stdout` burst; chunked streaming via a new server→client message kind is the natural next step.