### PR TITLE
Fix model-set box layout when ref overflows terminal width

### DIFF
--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -57,7 +57,8 @@ const setSub = defineCommand({
       process.exit(1)
     }
     done({
-      title: c.green(`Profile "${profile}" set to ${ref}.`),
+      title: c.green(`Profile "${profile}" set.`),
+      details: `${profile} → ${ref}`,
       hints: [{ label: 'If the agent is running:', command: 'typeclaw reload' }],
     })
   },
@@ -97,7 +98,8 @@ const addSub = defineCommand({
       process.exit(1)
     }
     done({
-      title: c.green(`Profile "${args.profile}" → ${ref}.`),
+      title: c.green(`Profile "${args.profile}" added.`),
+      details: `${args.profile} → ${ref}`,
       hints: [{ label: 'If the agent is running:', command: 'typeclaw reload' }],
     })
   },

--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
-import { c, errorLine, link, renderStartSuccess, spinner, successLine, type StartLikeResult } from './ui'
+import { c, done, errorLine, link, renderStartSuccess, spinner, successLine, type StartLikeResult } from './ui'
 
 const ENV_KEYS = ['NO_COLOR', 'FORCE_COLOR'] as const
 
@@ -218,6 +218,94 @@ describe('errorLine / successLine', () => {
       expect(errorLine('x')).toBe('✖ x')
       expect(successLine('y')).toBe('● y')
     })
+  })
+})
+
+describe('done', () => {
+  const ANSI = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, 'g')
+
+  function captureStdout<T>(fn: () => T): { result: T; output: string } {
+    const original = process.stdout.write.bind(process.stdout)
+    let buf = ''
+    process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+      buf += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8')
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const result = fn()
+      return { result, output: buf.replace(ANSI, '') }
+    } finally {
+      process.stdout.write = original
+    }
+  }
+
+  test('renders a box whose width fits the terminal even when details is very long', () => {
+    const { output } = captureStdout(() =>
+      withNoColor(() =>
+        done({
+          title: 'Profile "default" set.',
+          details: 'default → fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+          hints: [{ label: 'If the agent is running:', command: 'typeclaw reload' }],
+        }),
+      ),
+    )
+
+    const widths = [...output.matchAll(/^[│├└][^\n]*$/gm)].map((m) => m[0].length)
+    const maxWidth = Math.max(0, ...widths)
+    expect(maxWidth).toBeLessThanOrEqual(80)
+    expect(output).toContain('Profile "default" set.')
+    expect(output).toContain('default → fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    expect(output).toContain('typeclaw reload')
+  })
+
+  test('renders only hints when details is omitted (back-compat)', () => {
+    const { output } = captureStdout(() =>
+      withNoColor(() =>
+        done({
+          title: 'Short title.',
+          hints: [{ label: 'Next:', command: 'typeclaw start' }],
+        }),
+      ),
+    )
+    expect(output).toContain('Short title.')
+    expect(output).toContain('typeclaw start')
+  })
+
+  test('places details ABOVE hints in the rendered body', () => {
+    const { output } = captureStdout(() =>
+      withNoColor(() =>
+        done({
+          title: 'Profile set.',
+          details: 'DETAILS_MARKER',
+          hints: [{ label: 'Hint:', command: 'HINTS_MARKER' }],
+        }),
+      ),
+    )
+    const detailsIdx = output.indexOf('DETAILS_MARKER')
+    const hintsIdx = output.indexOf('HINTS_MARKER')
+    expect(detailsIdx).toBeGreaterThanOrEqual(0)
+    expect(hintsIdx).toBeGreaterThan(detailsIdx)
+  })
+
+  test('treats empty details as omitted (same shape as missing details)', () => {
+    const withEmpty = captureStdout(() =>
+      withNoColor(() =>
+        done({
+          title: 'Profile set.',
+          details: '',
+          hints: [{ label: 'Hint:', command: 'typeclaw reload' }],
+        }),
+      ),
+    ).output
+    const without = captureStdout(() =>
+      withNoColor(() =>
+        done({
+          title: 'Profile set.',
+          hints: [{ label: 'Hint:', command: 'typeclaw reload' }],
+        }),
+      ),
+    ).output
+    expect(withEmpty).toBe(without)
   })
 })
 

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -106,9 +106,14 @@ export function renderStartSuccess(result: StartLikeResult): string {
 
 export type NextStepHint = { label: string; command: string }
 
-export function done(opts: { title: string; hints: NextStepHint[] }): void {
-  const body = opts.hints.map((h) => `${c.dim(h.label)}  ${c.cyan(h.command)}`).join('\n')
-  note(body, opts.title)
+// `details` goes into the body, not the title: clack's `note()` sizes the
+// box to the title's visual width and never wraps titles, so a long title
+// breaks the layout on narrow terminals. Body content is wrapped to fit.
+export function done(opts: { title: string; details?: string; hints: NextStepHint[] }): void {
+  const lines: string[] = []
+  if (opts.details !== undefined && opts.details !== '') lines.push(opts.details)
+  for (const h of opts.hints) lines.push(`${c.dim(h.label)}  ${c.cyan(h.command)}`)
+  note(lines.join('\n'), opts.title)
   outro(c.green('Done.'))
 }
 


### PR DESCRIPTION
## Summary

`typeclaw model set` (and `typeclaw model add`) render a broken box on terminals narrower than the model ref:

```
◇  Profile "default" set to fireworks/accounts/fireworks/routers/kimi-k2p6-turbo. ─╮
│                                                                                  │
│  If the agent is running:  typeclaw reload                                       │
                                                                                │                                                                                  │                                                                                ├──────────────────────────────────────────────────────────────────────────────────╯                                                                                │
└  Done.
```

## Root cause

Clack's `note()` sizes the box to the **title's visual width** and never wraps titles. (It does wrap the body to `terminal_columns − 6`.) The title `Profile "default" set to fireworks/accounts/fireworks/routers/kimi-k2p6-turbo.` is 79 characters, producing an 84-column box. When the terminal is narrower than that, the terminal-wrapped borders shred the layout — exactly what's pictured above.

## Fix

Move long, variable-length content out of the title and into the body, where clack already wraps gracefully.

- `done()` (`src/cli/ui.ts`) gains an optional `details?: string` parameter, rendered as the first body line above the hints.
- `typeclaw model set` and `typeclaw model add` (`src/cli/model.ts`) now pass a short, fixed title (`Profile "default" set.`) and put the long ref into `details` (`default → fireworks/.../kimi-k2p6-turbo`).
- Existing `done()` call sites that already use short titles are unchanged — `details` is optional and back-compat.

After the fix, the same call renders inside an 80-column terminal:

```
◇  Profile "default" set. ─────────────────────────────────────────╮
│                                                                  │
│  default → fireworks/accounts/fireworks/routers/kimi-k2p6-turbo  │
│  If the agent is running:  typeclaw reload                       │
│                                                                  │
├──────────────────────────────────────────────────────────────────╯
```

Max box width: 68 (was 84).

## Tests

Three new `describe('done', …)` cases in `src/cli/ui.test.ts`:

| Test | Asserts |
|---|---|
| `renders a box whose width fits the terminal …` | After stripping ANSI, every `│` / `├` / `└` line is ≤ 80 cols when `details` is long. Mutation-checked: passing the long ref in the title (the old buggy shape) produces a max width of 84, which fails this assertion. |
| `places details ABOVE hints in the rendered body` | Reading order is preserved (details first, then hint commands). |
| `treats empty details as omitted (same shape as missing details)` | `details: ''` produces byte-identical output to omitting the field. |

## Validation

```
$ bun run typecheck   # tsgo --noEmit, clean
$ bun run lint        # 14 pre-existing warnings, 0 errors, none on touched files
$ bun run format      # oxfmt --write, no diff
$ bun test            # 3754 pass / 0 fail / 7849 expect() calls
```