### PR TITLE
Add GitHub channel adapter (PAT auth)

### DIFF
--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -78,6 +78,7 @@ type PlatformInfo = {
 const PLATFORM_INFO: Record<AdapterId, PlatformInfo> = {
   'slack-bot': { displayName: 'Slack', mentionMode: 'angle-id' },
   'discord-bot': { displayName: 'Discord', mentionMode: 'angle-id' },
+  github: { displayName: 'GitHub', mentionMode: 'at-username' },
   'telegram-bot': { displayName: 'Telegram', mentionMode: 'at-username' },
   kakaotalk: { displayName: 'KakaoTalk', mentionMode: 'alias' },
 }

--- a/src/channels/adapters/github/auth-pat.test.ts
+++ b/src/channels/adapters/github/auth-pat.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test'
+
+import { PatAuthStrategy } from './auth-pat'
+
+describe('PatAuthStrategy', () => {
+  it('authenticates a PAT against /user', async () => {
+    let auth = ''
+    const strategy = new PatAuthStrategy({
+      token: { value: 'github_pat_test' },
+      fetchImpl: withPreconnect(async (_url, init) => {
+        auth = new Headers(init?.headers).get('authorization') ?? ''
+        return Response.json({ login: 'typeclaw-bot', id: 123 })
+      }),
+    })
+
+    const self = await strategy.getSelf()
+
+    expect(self).toEqual({ login: 'typeclaw-bot', id: 123 })
+    expect(auth).toBe('Bearer github_pat_test')
+  })
+
+  it('rejects a missing PAT', () => {
+    expect(() => new PatAuthStrategy({ token: {} })).toThrow(/missing/i)
+  })
+})
+
+function withPreconnect(fn: (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>): typeof fetch {
+  return Object.assign(fn, { preconnect: () => {} })
+}

--- a/src/channels/adapters/github/auth-pat.ts
+++ b/src/channels/adapters/github/auth-pat.ts
@@ -1,0 +1,44 @@
+import { resolveSecret, type Secret } from '@/secrets/resolve'
+
+import type { GithubAuthStrategy, GithubSelfUser } from './auth'
+
+export const GITHUB_API_BASE = 'https://api.github.com'
+
+export class PatAuthStrategy implements GithubAuthStrategy {
+  readonly token: string
+  private readonly fetchImpl: typeof fetch
+
+  constructor(options: { token: Secret; fetchImpl?: typeof fetch }) {
+    const token = resolveSecret(options.token, undefined, process.env)
+    if (token === undefined || token.trim() === '') throw new Error('GitHub PAT token is missing')
+    this.token = token
+    this.fetchImpl = options.fetchImpl ?? fetch
+  }
+
+  authHeaders(): HeadersInit {
+    return githubJsonHeaders(this.token)
+  }
+
+  async getSelf(): Promise<GithubSelfUser> {
+    const response = await this.fetchImpl(`${GITHUB_API_BASE}/user`, { headers: this.authHeaders() })
+    if (!response.ok) {
+      const body = await response.text().catch(() => '')
+      throw new Error(`GitHub PAT authentication failed: ${response.status}${body !== '' ? ` ${body}` : ''}`)
+    }
+    const raw = (await response.json()) as { login?: unknown; id?: unknown }
+    if (typeof raw.login !== 'string' || typeof raw.id !== 'number') {
+      throw new Error('GitHub /user response did not include login/id')
+    }
+    return { login: raw.login, id: raw.id }
+  }
+}
+
+export function githubJsonHeaders(token: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'Content-Type': 'application/json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'typeclaw-github-channel',
+  }
+}

--- a/src/channels/adapters/github/auth.ts
+++ b/src/channels/adapters/github/auth.ts
@@ -1,0 +1,18 @@
+import type { GithubPatAuthBlock } from '@/secrets/schema'
+
+import { PatAuthStrategy } from './auth-pat'
+
+export type GithubAuthStrategy = {
+  readonly token: string
+  authHeaders: () => HeadersInit
+  getSelf: () => Promise<GithubSelfUser>
+}
+
+export type GithubSelfUser = {
+  login: string
+  id: number
+}
+
+export function buildAuthStrategy(options: { auth: GithubPatAuthBlock; fetchImpl?: typeof fetch }): GithubAuthStrategy {
+  return new PatAuthStrategy({ token: options.auth.token, fetchImpl: options.fetchImpl })
+}

--- a/src/channels/adapters/github/channel-resolver.ts
+++ b/src/channels/adapters/github/channel-resolver.ts
@@ -1,0 +1,30 @@
+import type { ChannelNameResolver, ResolvedChannelNames } from '@/channels/types'
+
+import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
+import { parseChat, parseRepo } from './outbound'
+
+export function createGithubChannelNameResolver(options: {
+  token: string
+  fetchImpl?: typeof fetch
+}): ChannelNameResolver {
+  const fetchImpl = options.fetchImpl ?? fetch
+  return async (key): Promise<ResolvedChannelNames> => {
+    if (key.adapter !== 'github') return {}
+    const repo = parseRepo(key.workspace)
+    const chat = parseChat(key.chat)
+    if (repo === null || chat === null) return {}
+    const names: ResolvedChannelNames = { workspaceName: key.workspace }
+    if (chat.kind === 'discussion') return names
+    const path = chat.kind === 'issue' ? `issues/${chat.number}` : `pulls/${chat.number}`
+    try {
+      const response = await fetchImpl(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/${path}`, {
+        headers: githubJsonHeaders(options.token),
+      })
+      if (!response.ok) return names
+      const raw = (await response.json()) as { title?: string }
+      return raw.title !== undefined ? { ...names, chatName: raw.title } : names
+    } catch {
+      return names
+    }
+  }
+}

--- a/src/channels/adapters/github/dedup.test.ts
+++ b/src/channels/adapters/github/dedup.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'bun:test'
+
+import { createDeliveryDedup } from './dedup'
+
+describe('createDeliveryDedup', () => {
+  it('keeps recent deliveries and evicts least-recently inserted ids', () => {
+    const dedup = createDeliveryDedup(2)
+    dedup.add('a')
+    dedup.add('b')
+    expect(dedup.has('a')).toBe(true)
+    dedup.add('c')
+    expect(dedup.has('a')).toBe(false)
+    expect(dedup.has('b')).toBe(true)
+    expect(dedup.has('c')).toBe(true)
+    expect(dedup.size()).toBe(2)
+  })
+})

--- a/src/channels/adapters/github/dedup.ts
+++ b/src/channels/adapters/github/dedup.ts
@@ -1,0 +1,26 @@
+export type DeliveryDedup = {
+  has: (deliveryId: string) => boolean
+  add: (deliveryId: string) => void
+  size: () => number
+}
+
+export function createDeliveryDedup(limit = 1000): DeliveryDedup {
+  const seen = new Map<string, true>()
+  return {
+    has(deliveryId: string): boolean {
+      return seen.has(deliveryId)
+    },
+    add(deliveryId: string): void {
+      if (seen.has(deliveryId)) seen.delete(deliveryId)
+      seen.set(deliveryId, true)
+      while (seen.size > limit) {
+        const oldest = seen.keys().next().value
+        if (oldest === undefined) break
+        seen.delete(oldest)
+      }
+    },
+    size(): number {
+      return seen.size
+    },
+  }
+}

--- a/src/channels/adapters/github/event-allowlist.ts
+++ b/src/channels/adapters/github/event-allowlist.ts
@@ -1,0 +1,8 @@
+export function githubEventKey(event: string, action: unknown): string {
+  return typeof action === 'string' && action.length > 0 ? `${event}.${action}` : event
+}
+
+export function isGithubEventAllowed(allowlist: readonly string[], event: string, action: unknown): boolean {
+  const key = githubEventKey(event, action)
+  return allowlist.includes(key) || allowlist.includes(event)
+}

--- a/src/channels/adapters/github/fetch-attachment.ts
+++ b/src/channels/adapters/github/fetch-attachment.ts
@@ -1,0 +1,5 @@
+import type { FetchAttachmentCallback } from '@/channels/types'
+
+export function createGithubFetchAttachmentCallback(): FetchAttachmentCallback {
+  return async () => ({ ok: false, error: 'github-bot-does-not-support-attachments' })
+}

--- a/src/channels/adapters/github/history.test.ts
+++ b/src/channels/adapters/github/history.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test'
+
+import { createGithubHistoryCallback } from './history'
+
+describe('createGithubHistoryCallback', () => {
+  it('fetches issue comments for a remembered workspace', async () => {
+    const cb = createGithubHistoryCallback({
+      token: 'tok',
+      workspaceForChat: () => 'acme/project',
+      fetchImpl: Object.assign(
+        async () =>
+          Response.json([
+            { id: 1, body: 'hello', created_at: '2026-01-01T00:00:00Z', user: { id: 2, login: 'alice' } },
+          ]),
+        { preconnect: () => {} },
+      ),
+    })
+
+    const result = await cb({ chat: 'issue:5', thread: null, limit: 10 })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.messages[0]?.text).toBe('hello')
+  })
+})

--- a/src/channels/adapters/github/history.ts
+++ b/src/channels/adapters/github/history.ts
@@ -23,9 +23,12 @@ export function createGithubHistoryCallback(options: {
         : `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${chat.number}/comments`
     try {
       const cursor = args.cursor !== undefined && args.cursor !== '' ? `&page=${encodeURIComponent(args.cursor)}` : ''
-      const response = await fetchImpl(`${endpoint}?per_page=${Math.min(Math.max(args.limit, 1), 100)}${cursor}`, {
-        headers: githubJsonHeaders(options.token),
-      })
+      const response = await fetchImpl(
+        `${endpoint}?per_page=${Math.min(Math.max(args.limit, 1), 100)}&direction=desc${cursor}`,
+        {
+          headers: githubJsonHeaders(options.token),
+        },
+      )
       if (!response.ok) return { ok: false, error: `GitHub history ${response.status}` }
       const raw = (await response.json()) as GithubComment[]
       const link = response.headers.get('link') ?? ''

--- a/src/channels/adapters/github/history.ts
+++ b/src/channels/adapters/github/history.ts
@@ -1,0 +1,60 @@
+import type { ChannelHistoryMessage, FetchHistoryArgs, FetchHistoryResult, HistoryCallback } from '@/channels/types'
+
+import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
+import { parseChat, parseRepo } from './outbound'
+
+export function createGithubHistoryCallback(options: {
+  token: string
+  workspaceForChat: (chat: string) => string | null
+  fetchImpl?: typeof fetch
+}): HistoryCallback {
+  const fetchImpl = options.fetchImpl ?? fetch
+  return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
+    const workspace = options.workspaceForChat(args.chat)
+    if (workspace === null)
+      return { ok: false, error: 'github history unavailable until this chat receives an inbound' }
+    const repo = parseRepo(workspace)
+    const chat = parseChat(args.chat)
+    if (repo === null || chat === null) return { ok: false, error: 'invalid github history target' }
+    if (chat.kind === 'discussion') return { ok: false, error: 'github discussion history not supported yet' }
+    const endpoint =
+      chat.kind === 'pr' && args.thread !== null
+        ? `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${chat.number}/comments`
+        : `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${chat.number}/comments`
+    try {
+      const cursor = args.cursor !== undefined && args.cursor !== '' ? `&page=${encodeURIComponent(args.cursor)}` : ''
+      const response = await fetchImpl(`${endpoint}?per_page=${Math.min(Math.max(args.limit, 1), 100)}${cursor}`, {
+        headers: githubJsonHeaders(options.token),
+      })
+      if (!response.ok) return { ok: false, error: `GitHub history ${response.status}` }
+      const raw = (await response.json()) as GithubComment[]
+      const link = response.headers.get('link') ?? ''
+      const nextCursor = /[?&]page=(\d+)[^>]*>; rel="next"/.exec(link)?.[1]
+      return nextCursor !== undefined
+        ? { ok: true, messages: raw.map(mapComment), nextCursor }
+        : { ok: true, messages: raw.map(mapComment) }
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+}
+
+type GithubComment = {
+  id: number
+  body?: string
+  created_at?: string
+  user?: { id?: number; login?: string; type?: string }
+}
+
+function mapComment(comment: GithubComment): ChannelHistoryMessage {
+  const login = comment.user?.login ?? 'unknown'
+  return {
+    externalMessageId: String(comment.id),
+    authorId: String(comment.user?.id ?? login),
+    authorName: login,
+    text: comment.body ?? '',
+    ts: comment.created_at !== undefined ? Date.parse(comment.created_at) || 0 : 0,
+    isBot: comment.user?.type === 'Bot',
+    replyToBotMessageId: null,
+  }
+}

--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'bun:test'
+import { createHmac } from 'node:crypto'
+
+import type { InboundMessage } from '@/channels/types'
+
+import { createDeliveryDedup } from './dedup'
+import { classifyGithubInbound, createGithubWebhookHandler, verifySignature } from './inbound'
+
+const logger = { info: () => {}, warn: () => {}, error: () => {} }
+
+describe('verifySignature', () => {
+  it('accepts the GitHub docs test vector', async () => {
+    const ok = await verifySignature(
+      'Hello, World!',
+      "It's a Secret to Everybody",
+      'sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17',
+    )
+    expect(ok).toBe(true)
+  })
+})
+
+describe('classifyGithubInbound', () => {
+  it('classifies issue comments on pull requests as PR chats', () => {
+    const msg = classifyGithubInbound('issue_comment', issueCommentPayload({ pullRequest: true }), 'typeclaw-bot')
+    expect(msg?.workspace).toBe('acme/project')
+    expect(msg?.chat).toBe('pr:7')
+    expect(msg?.thread).toBe(null)
+    expect(msg?.authorName).toBe('alice')
+  })
+
+  it('classifies review comments into root-comment threads', () => {
+    const msg = classifyGithubInbound('pull_request_review_comment', reviewCommentPayload(), 'typeclaw-bot')
+    expect(msg?.chat).toBe('pr:7')
+    expect(msg?.thread).toBe('101')
+  })
+})
+
+describe('createGithubWebhookHandler', () => {
+  it('acks before the fire-and-forget route promise settles', async () => {
+    const routed: InboundMessage[] = []
+    const routeWait = Promise.withResolvers<void>()
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['issue_comment.created'],
+      selfLogin: () => 'typeclaw-bot',
+      logger,
+      route: async (msg) => {
+        routed.push(msg)
+        await routeWait.promise
+      },
+    })
+
+    const body = JSON.stringify(issueCommentPayload({ pullRequest: false }))
+    const response = await handler(signedRequest(body, 'issue_comment', 'delivery-1'))
+
+    expect(response.status).toBe(200)
+    expect(routed[0]?.chat).toBe('issue:7')
+    routeWait.resolve()
+  })
+
+  it('drops duplicate deliveries without routing twice', async () => {
+    let count = 0
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['issue_comment.created'],
+      selfLogin: () => 'typeclaw-bot',
+      logger,
+      route: async () => {
+        count++
+      },
+    })
+    const body = JSON.stringify(issueCommentPayload({ pullRequest: false }))
+
+    await handler(signedRequest(body, 'issue_comment', 'same-delivery'))
+    await handler(signedRequest(body, 'issue_comment', 'same-delivery'))
+
+    expect(count).toBe(1)
+  })
+})
+
+function signedRequest(body: string, event: string, delivery: string): Request {
+  const sig = `sha256=${createHmac('sha256', 'secret').update(body).digest('hex')}`
+  return new Request('https://example.com/github', {
+    method: 'POST',
+    headers: {
+      'x-hub-signature-256': sig,
+      'x-github-event': event,
+      'x-github-delivery': delivery,
+    },
+    body,
+  })
+}
+
+function repo(): Record<string, unknown> {
+  return { name: 'project', owner: { login: 'acme' } }
+}
+
+function user(): Record<string, unknown> {
+  return { login: 'alice', id: 10, type: 'User' }
+}
+
+function issueCommentPayload(options: { pullRequest: boolean }): Record<string, unknown> {
+  return {
+    action: 'created',
+    repository: repo(),
+    issue: { number: 7, ...(options.pullRequest ? { pull_request: {} } : {}) },
+    comment: { id: 99, body: '@typeclaw-bot hello', created_at: '2026-01-01T00:00:00Z', user: user() },
+  }
+}
+
+function reviewCommentPayload(): Record<string, unknown> {
+  return {
+    action: 'created',
+    repository: repo(),
+    pull_request: { number: 7 },
+    comment: { id: 102, in_reply_to_id: 101, body: 'review', created_at: '2026-01-01T00:00:00Z', user: user() },
+  }
+}

--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -43,11 +43,12 @@ describe('createGithubWebhookHandler', () => {
       webhookSecret: 'secret',
       dedup: createDeliveryDedup(),
       allowlist: () => ['issue_comment.created'],
+      selfId: () => '99',
       selfLogin: () => 'typeclaw-bot',
       logger,
-      route: async (msg) => {
+      route: (msg) => {
         routed.push(msg)
-        await routeWait.promise
+        void routeWait.promise
       },
     })
 
@@ -65,9 +66,10 @@ describe('createGithubWebhookHandler', () => {
       webhookSecret: 'secret',
       dedup: createDeliveryDedup(),
       allowlist: () => ['issue_comment.created'],
+      selfId: () => '99',
       selfLogin: () => 'typeclaw-bot',
       logger,
-      route: async () => {
+      route: () => {
         count++
       },
     })

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -1,0 +1,287 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+import type { InboundMessage } from '@/channels/types'
+
+import type { DeliveryDedup } from './dedup'
+import { isGithubEventAllowed } from './event-allowlist'
+
+export type GithubInboundLogger = { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void }
+
+export type GithubWebhookHandlerOptions = {
+  webhookSecret: string
+  dedup: DeliveryDedup
+  allowlist: () => readonly string[]
+  selfLogin: () => string | null
+  route: (message: InboundMessage) => Promise<void>
+  logger: GithubInboundLogger
+}
+
+export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions): (req: Request) => Promise<Response> {
+  return async (req: Request): Promise<Response> => {
+    if (req.method !== 'POST') return new Response('method not allowed', { status: 405 })
+    const body = await req.text()
+    const signature = req.headers.get('x-hub-signature-256') ?? ''
+    if (!(await verifySignature(body, options.webhookSecret, signature))) {
+      options.logger.warn('[github] webhook rejected: bad signature')
+      return new Response('bad signature', { status: 401 })
+    }
+
+    const delivery = req.headers.get('x-github-delivery') ?? ''
+    if (delivery !== '' && options.dedup.has(delivery)) {
+      options.logger.info(`[github] duplicate delivery ignored id=${delivery}`)
+      return ok()
+    }
+
+    const event = req.headers.get('x-github-event') ?? ''
+    const payload = parseJson(body)
+    if (payload === null) return ok()
+    const action = readString(payload, 'action')
+    if (!isGithubEventAllowed(options.allowlist(), event, action)) return ok()
+
+    const selfLogin = options.selfLogin()
+    const author = readAuthor(payload)
+    if (selfLogin !== null && author?.login === selfLogin) return ok()
+
+    const classified = classifyGithubInbound(event, payload, selfLogin)
+    if (classified === null) return ok()
+
+    if (delivery !== '') options.dedup.add(delivery)
+    void options.route(classified).catch((err) => {
+      options.logger.error(`[github] route failed delivery=${delivery || '?'}: ${describe(err)}`)
+    })
+    return ok()
+  }
+}
+
+export async function verifySignature(body: string, secret: string, sigHeader: string): Promise<boolean> {
+  const expected = `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`
+  const a = Buffer.from(expected)
+  const b = Buffer.from(sigHeader)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+export function classifyGithubInbound(
+  event: string,
+  payload: Record<string, unknown>,
+  selfLogin: string | null,
+): InboundMessage | null {
+  const repository = readRepository(payload)
+  if (repository === null) return null
+  const base = {
+    adapter: 'github' as const,
+    workspace: `${repository.owner}/${repository.name}`,
+    isDm: false,
+    mentionsOthers: false,
+    replyToOtherMessageId: null,
+  }
+
+  if (event === 'issue_comment') {
+    const issue = readRecord(payload.issue)
+    const comment = readRecord(payload.comment)
+    if (issue === null || comment === null) return null
+    const number = readNumber(issue, 'number')
+    const id = readNumber(comment, 'id')
+    if (number === null || id === null) return null
+    const isPullRequest = readRecord(issue.pull_request) !== null
+    const user = readUser(comment.user)
+    return buildInbound(
+      { ...base, chat: `${isPullRequest ? 'pr' : 'issue'}:${number}`, thread: null },
+      comment.body,
+      id,
+      user,
+      selfLogin,
+      comment.created_at,
+    )
+  }
+
+  if (event === 'pull_request_review_comment') {
+    const pr = readRecord(payload.pull_request)
+    const comment = readRecord(payload.comment)
+    if (pr === null || comment === null) return null
+    const number = readNumber(pr, 'number')
+    const id = readNumber(comment, 'id')
+    if (number === null || id === null) return null
+    const root = readNumber(comment, 'in_reply_to_id') ?? id
+    return buildInbound(
+      { ...base, chat: `pr:${number}`, thread: String(root) },
+      comment.body,
+      id,
+      readUser(comment.user),
+      selfLogin,
+      comment.created_at,
+    )
+  }
+
+  if (event === 'discussion_comment') {
+    const discussion = readRecord(payload.discussion)
+    const comment = readRecord(payload.comment)
+    if (discussion === null || comment === null) return null
+    const number = readNumber(discussion, 'number')
+    const id = readNumber(comment, 'id')
+    if (number === null || id === null) return null
+    return buildInbound(
+      { ...base, chat: `discussion:${number}`, thread: null },
+      comment.body,
+      id,
+      readUser(comment.user),
+      selfLogin,
+      comment.created_at,
+    )
+  }
+
+  if (event === 'issues') {
+    const issue = readRecord(payload.issue)
+    if (issue === null) return null
+    const number = readNumber(issue, 'number')
+    const id = readNumber(issue, 'id') ?? number
+    if (number === null || id === null) return null
+    return buildInbound(
+      { ...base, chat: `issue:${number}`, thread: null },
+      issue.body,
+      id,
+      readUser(issue.user),
+      selfLogin,
+      issue.created_at,
+    )
+  }
+
+  if (event === 'pull_request') {
+    const pr = readRecord(payload.pull_request)
+    if (pr === null) return null
+    const number = readNumber(pr, 'number')
+    const id = readNumber(pr, 'id') ?? number
+    if (number === null || id === null) return null
+    return buildInbound(
+      { ...base, chat: `pr:${number}`, thread: null },
+      pr.body,
+      id,
+      readUser(pr.user),
+      selfLogin,
+      pr.created_at,
+    )
+  }
+
+  if (event === 'pull_request_review') {
+    const pr = readRecord(payload.pull_request)
+    const review = readRecord(payload.review)
+    if (pr === null || review === null) return null
+    const number = readNumber(pr, 'number')
+    const id = readNumber(review, 'id')
+    if (number === null || id === null) return null
+    return buildInbound(
+      { ...base, chat: `pr:${number}`, thread: null },
+      review.body,
+      id,
+      readUser(review.user),
+      selfLogin,
+      review.submitted_at,
+    )
+  }
+
+  if (event === 'discussion') {
+    const discussion = readRecord(payload.discussion)
+    if (discussion === null) return null
+    const number = readNumber(discussion, 'number')
+    const id = readNumber(discussion, 'id') ?? number
+    if (number === null || id === null) return null
+    return buildInbound(
+      { ...base, chat: `discussion:${number}`, thread: null },
+      discussion.body,
+      id,
+      readUser(discussion.user),
+      selfLogin,
+      discussion.created_at,
+    )
+  }
+
+  return null
+}
+
+function buildInbound(
+  key: Pick<
+    InboundMessage,
+    'adapter' | 'workspace' | 'chat' | 'thread' | 'isDm' | 'mentionsOthers' | 'replyToOtherMessageId'
+  >,
+  rawText: unknown,
+  id: number,
+  user: GithubUser | null,
+  selfLogin: string | null,
+  rawTs: unknown,
+): InboundMessage | null {
+  if (user === null) return null
+  const text = typeof rawText === 'string' ? rawText : ''
+  return {
+    ...key,
+    text,
+    externalMessageId: String(id),
+    authorId: String(user.id),
+    authorName: user.login,
+    authorIsBot: user.type === 'Bot',
+    isBotMention: selfLogin !== null && text.includes(`@${selfLogin}`),
+    replyToBotMessageId: null,
+    ts: typeof rawTs === 'string' ? Date.parse(rawTs) || 0 : 0,
+  }
+}
+
+function readRepository(payload: Record<string, unknown>): { owner: string; name: string } | null {
+  const repository = readRecord(payload.repository)
+  const owner = readRecord(repository?.owner)
+  const ownerLogin = readString(owner, 'login')
+  const name = readString(repository, 'name')
+  if (ownerLogin === null || name === null) return null
+  return { owner: ownerLogin, name }
+}
+
+function readAuthor(payload: Record<string, unknown>): GithubUser | null {
+  const candidates = [payload.comment, payload.issue, payload.pull_request, payload.discussion, payload.review]
+  for (const candidate of candidates) {
+    const user = readUser(readRecord(candidate)?.user)
+    if (user !== null) return user
+  }
+  return null
+}
+
+type GithubUser = { login: string; id: number; type?: string }
+
+function readUser(value: unknown): GithubUser | null {
+  const user = readRecord(value)
+  const login = readString(user, 'login')
+  const id = readNumber(user, 'id')
+  if (login === null || id === null) return null
+  const type = readString(user, 'type') ?? undefined
+  return { login, id, ...(type !== undefined ? { type } : {}) }
+}
+
+function parseJson(body: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(body) as unknown
+    return readRecord(parsed)
+  } catch {
+    return null
+  }
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function readString(obj: Record<string, unknown> | null, key: string): string | null {
+  const value = obj?.[key]
+  return typeof value === 'string' ? value : null
+}
+
+function readNumber(obj: Record<string, unknown> | null, key: string): number | null {
+  const value = obj?.[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function ok(): Response {
+  return new Response('ok', { status: 200 })
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -11,8 +11,9 @@ export type GithubWebhookHandlerOptions = {
   webhookSecret: string
   dedup: DeliveryDedup
   allowlist: () => readonly string[]
+  selfId: () => string | null
   selfLogin: () => string | null
-  route: (message: InboundMessage) => Promise<void>
+  route: (message: InboundMessage) => void
   logger: GithubInboundLogger
 }
 
@@ -38,17 +39,15 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
     const action = readString(payload, 'action')
     if (!isGithubEventAllowed(options.allowlist(), event, action)) return ok()
 
-    const selfLogin = options.selfLogin()
+    const selfId = options.selfId()
     const author = readAuthor(payload)
-    if (selfLogin !== null && author?.login === selfLogin) return ok()
+    if (selfId !== null && author !== null && String(author.id) === selfId) return ok()
 
-    const classified = classifyGithubInbound(event, payload, selfLogin)
+    const classified = classifyGithubInbound(event, payload, options.selfLogin())
     if (classified === null) return ok()
 
     if (delivery !== '') options.dedup.add(delivery)
-    void options.route(classified).catch((err) => {
-      options.logger.error(`[github] route failed delivery=${delivery || '?'}: ${describe(err)}`)
-    })
+    options.route(classified)
     return ok()
   }
 }

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -48,6 +48,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
   if (webhookSecret === undefined || webhookSecret.trim() === '') throw new Error('GitHub webhookSecret is missing')
 
   let server: { stop: () => Promise<void> } | null = null
+  let selfId: string | null = null
   let selfLogin: string | null = null
   let started = false
   const workspaceByChat = new Map<string, string>()
@@ -65,16 +66,25 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
   const membership = createGithubMembershipResolver({ token: auth.token, fetchImpl })
   const channelNameResolver = createGithubChannelNameResolver({ token: auth.token, fetchImpl })
   const fetchAttachment = createGithubFetchAttachmentCallback()
+  // No-op typing callback: GitHub has no typing indicator API.
+  const typing = async (): Promise<void> => {}
   const dedup = createDeliveryDedup()
   const handler = createGithubWebhookHandler({
     webhookSecret,
     dedup,
     allowlist: () => options.configRef().eventAllowlist,
+    selfId: () => selfId,
     selfLogin: () => selfLogin,
     logger,
-    route: async (message) => {
+    route: (message) => {
       rememberWorkspace(message.workspace, message.chat)
-      await options.router.route(message)
+      // Ack-first: wrap in Promise.resolve so a synchronous throw inside
+      // router.route() cannot prevent the 200 response from being returned.
+      void Promise.resolve()
+        .then(() => options.router.route(message))
+        .catch((err: unknown) => {
+          logger.error(`[github] route failed: ${err instanceof Error ? err.message : String(err)}`)
+        })
     },
   })
 
@@ -82,13 +92,31 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     async start(): Promise<void> {
       if (started) return
       const self = await auth.getSelf()
+      selfId = String(self.id)
       selfLogin = self.login
+      // Register all callbacks before binding the HTTP listener so the router
+      // is fully wired before any webhook can arrive.
       options.router.registerOutbound('github', outbound)
+      options.router.registerTyping('github', typing)
       options.router.registerHistory('github', history)
       options.router.registerMembership('github', membership)
       options.router.registerChannelNameResolver('github', channelNameResolver)
       options.router.registerFetchAttachment('github', fetchAttachment)
-      server = (options.httpListenImpl ?? listenWithBun)(options.configRef().webhookPort, handler)
+      try {
+        server = (options.httpListenImpl ?? listenWithBun)(options.configRef().webhookPort, handler)
+      } catch (err) {
+        // Listener failed — roll back all registrations so stop() is a no-op
+        // and the manager can report the failure cleanly.
+        options.router.unregisterOutbound('github', outbound)
+        options.router.unregisterTyping('github', typing)
+        options.router.unregisterHistory('github', history)
+        options.router.unregisterMembership('github', membership)
+        options.router.unregisterChannelNameResolver('github', channelNameResolver)
+        options.router.unregisterFetchAttachment('github', fetchAttachment)
+        selfId = null
+        selfLogin = null
+        throw err
+      }
       started = true
       logger.info(`[github] webhook listening on port ${options.configRef().webhookPort} as @${self.login}`)
     },
@@ -96,12 +124,14 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
       if (!started) return
       started = false
       options.router.unregisterOutbound('github', outbound)
+      options.router.unregisterTyping('github', typing)
       options.router.unregisterHistory('github', history)
       options.router.unregisterMembership('github', membership)
       options.router.unregisterChannelNameResolver('github', channelNameResolver)
       options.router.unregisterFetchAttachment('github', fetchAttachment)
       await server?.stop()
       server = null
+      selfId = null
       selfLogin = null
     },
     isConnected(): boolean {

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -1,0 +1,116 @@
+import type { ChannelRouter } from '@/channels/router'
+import type { ChannelAdapterConfig, GithubAdapterConfig } from '@/channels/schema'
+import { resolveSecret } from '@/secrets/resolve'
+import type { GithubSecretsBlock } from '@/secrets/schema'
+
+import { buildAuthStrategy } from './auth'
+import { createGithubChannelNameResolver } from './channel-resolver'
+import { createDeliveryDedup } from './dedup'
+import { createGithubFetchAttachmentCallback } from './fetch-attachment'
+import { createGithubHistoryCallback } from './history'
+import { createGithubWebhookHandler } from './inbound'
+import { createGithubMembershipResolver } from './membership'
+import { createGithubOutboundCallback } from './outbound'
+
+export type GithubAdapterLogger = {
+  info: (m: string) => void
+  warn: (m: string) => void
+  error: (m: string) => void
+}
+
+export type GithubAdapterOptions = {
+  router: ChannelRouter
+  configRef: () => ChannelAdapterConfig & GithubAdapterConfig
+  secrets: GithubSecretsBlock
+  agentDir: string
+  logger?: GithubAdapterLogger
+  fetchImpl?: typeof fetch
+  httpListenImpl?: (port: number, handler: (req: Request) => Promise<Response>) => { stop: () => Promise<void> }
+}
+
+export type GithubAdapter = {
+  start: () => Promise<void>
+  stop: () => Promise<void>
+  isConnected: () => boolean
+}
+
+const consoleLogger: GithubAdapterLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+  error: (m) => console.error(m),
+}
+
+export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapter {
+  const logger = options.logger ?? consoleLogger
+  const fetchImpl = options.fetchImpl ?? fetch
+  const auth = buildAuthStrategy({ auth: options.secrets.auth, fetchImpl })
+  const webhookSecret = resolveSecret(options.secrets.webhookSecret, undefined, process.env)
+  if (webhookSecret === undefined || webhookSecret.trim() === '') throw new Error('GitHub webhookSecret is missing')
+
+  let server: { stop: () => Promise<void> } | null = null
+  let selfLogin: string | null = null
+  let started = false
+  const workspaceByChat = new Map<string, string>()
+
+  const rememberWorkspace = (workspace: string, chat: string): void => {
+    workspaceByChat.set(chat, workspace)
+  }
+
+  const outbound = createGithubOutboundCallback({ token: auth.token, logger, fetchImpl })
+  const history = createGithubHistoryCallback({
+    token: auth.token,
+    fetchImpl,
+    workspaceForChat: (chat) => workspaceByChat.get(chat) ?? null,
+  })
+  const membership = createGithubMembershipResolver({ token: auth.token, fetchImpl })
+  const channelNameResolver = createGithubChannelNameResolver({ token: auth.token, fetchImpl })
+  const fetchAttachment = createGithubFetchAttachmentCallback()
+  const dedup = createDeliveryDedup()
+  const handler = createGithubWebhookHandler({
+    webhookSecret,
+    dedup,
+    allowlist: () => options.configRef().eventAllowlist,
+    selfLogin: () => selfLogin,
+    logger,
+    route: async (message) => {
+      rememberWorkspace(message.workspace, message.chat)
+      await options.router.route(message)
+    },
+  })
+
+  return {
+    async start(): Promise<void> {
+      if (started) return
+      const self = await auth.getSelf()
+      selfLogin = self.login
+      options.router.registerOutbound('github', outbound)
+      options.router.registerHistory('github', history)
+      options.router.registerMembership('github', membership)
+      options.router.registerChannelNameResolver('github', channelNameResolver)
+      options.router.registerFetchAttachment('github', fetchAttachment)
+      server = (options.httpListenImpl ?? listenWithBun)(options.configRef().webhookPort, handler)
+      started = true
+      logger.info(`[github] webhook listening on port ${options.configRef().webhookPort} as @${self.login}`)
+    },
+    async stop(): Promise<void> {
+      if (!started) return
+      started = false
+      options.router.unregisterOutbound('github', outbound)
+      options.router.unregisterHistory('github', history)
+      options.router.unregisterMembership('github', membership)
+      options.router.unregisterChannelNameResolver('github', channelNameResolver)
+      options.router.unregisterFetchAttachment('github', fetchAttachment)
+      await server?.stop()
+      server = null
+      selfLogin = null
+    },
+    isConnected(): boolean {
+      return started && selfLogin !== null
+    },
+  }
+}
+
+function listenWithBun(port: number, handler: (req: Request) => Promise<Response>): { stop: () => Promise<void> } {
+  const server = Bun.serve({ port, fetch: handler })
+  return { stop: async () => server.stop() }
+}

--- a/src/channels/adapters/github/membership.test.ts
+++ b/src/channels/adapters/github/membership.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test'
+
+import { createGithubMembershipResolver } from './membership'
+
+describe('createGithubMembershipResolver', () => {
+  it('counts collaborator humans and bots', async () => {
+    const resolver = createGithubMembershipResolver({
+      token: 'tok',
+      fetchImpl: Object.assign(async () => Response.json([{ type: 'User' }, { type: 'Bot' }]), {
+        preconnect: () => {},
+      }),
+    })
+
+    const result = await resolver({ adapter: 'github', workspace: 'acme/project', chat: 'issue:1', thread: null })
+
+    expect(result).toMatchObject({ humans: 1, bots: 1, truncated: false })
+  })
+})

--- a/src/channels/adapters/github/membership.ts
+++ b/src/channels/adapters/github/membership.ts
@@ -1,0 +1,35 @@
+import type { MembershipResolver, MembershipResolverResult } from '@/channels/membership'
+
+import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
+import { parseRepo } from './outbound'
+
+export function createGithubMembershipResolver(options: {
+  token: string
+  fetchImpl?: typeof fetch
+}): MembershipResolver {
+  const fetchImpl = options.fetchImpl ?? fetch
+  return async (key): Promise<MembershipResolverResult> => {
+    if (key.adapter !== 'github') return { kind: 'permanent' }
+    const repo = parseRepo(key.workspace)
+    if (repo === null) return { kind: 'permanent' }
+    try {
+      const response = await fetchImpl(
+        `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/collaborators?per_page=100`,
+        {
+          headers: githubJsonHeaders(options.token),
+        },
+      )
+      if (!response.ok) return response.status >= 500 ? { kind: 'transient' } : { kind: 'permanent' }
+      const users = (await response.json()) as Array<{ type?: string }>
+      let bots = 0
+      let humans = 0
+      for (const user of users) {
+        if (user.type === 'Bot') bots++
+        else humans++
+      }
+      return { humans, bots, fetchedAt: Date.now(), truncated: users.length >= 100 }
+    } catch {
+      return { kind: 'transient' }
+    }
+  }
+}

--- a/src/channels/adapters/github/outbound.test.ts
+++ b/src/channels/adapters/github/outbound.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'bun:test'
+
+import { createGithubOutboundCallback } from './outbound'
+
+const logger = { info: () => {}, warn: () => {}, error: () => {} }
+
+const fakeFetch = (responses: Record<string, { status: number; body: unknown }>) =>
+  Object.assign(
+    async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const key = `${init?.method ?? 'GET'} ${String(url)}`
+      const resp = responses[key] ?? { status: 404, body: { message: 'Not Found' } }
+      return new Response(JSON.stringify(resp.body), { status: resp.status })
+    },
+    { preconnect: () => {} },
+  )
+
+describe('createGithubOutboundCallback', () => {
+  it('posts issue and top-level PR comments through the issues comments endpoint', async () => {
+    const cb = createGithubOutboundCallback({
+      token: 'tok',
+      logger,
+      fetchImpl: fakeFetch({
+        'POST https://api.github.com/repos/acme/project/issues/42/comments': { status: 201, body: { id: 1 } },
+      }),
+    })
+
+    const result = await cb({
+      adapter: 'github',
+      workspace: 'acme/project',
+      chat: 'pr:42',
+      thread: null,
+      text: 'hello',
+    })
+
+    expect(result).toEqual({ ok: true })
+  })
+
+  it('posts PR review thread replies through the pull comment replies endpoint', async () => {
+    const cb = createGithubOutboundCallback({
+      token: 'tok',
+      logger,
+      fetchImpl: fakeFetch({
+        'POST https://api.github.com/repos/acme/project/pulls/42/comments/99/replies': { status: 201, body: { id: 2 } },
+      }),
+    })
+
+    const result = await cb({
+      adapter: 'github',
+      workspace: 'acme/project',
+      chat: 'pr:42',
+      thread: '99',
+      text: 'reply',
+    })
+
+    expect(result).toEqual({ ok: true })
+  })
+
+  it('rejects attachments', async () => {
+    const cb = createGithubOutboundCallback({ token: 'tok', logger, fetchImpl: fakeFetch({}) })
+
+    const result = await cb({
+      adapter: 'github',
+      workspace: 'acme/project',
+      chat: 'issue:1',
+      text: 'x',
+      attachments: [{ path: '/tmp/file.txt' }],
+    })
+
+    expect(result).toEqual({ ok: false, error: 'github-bot-does-not-support-attachments' })
+  })
+})

--- a/src/channels/adapters/github/outbound.ts
+++ b/src/channels/adapters/github/outbound.ts
@@ -1,0 +1,145 @@
+import type { OutboundCallback, OutboundMessage, SendResult } from '@/channels/types'
+
+import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
+
+export type GithubOutboundLogger = { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void }
+
+export function createGithubOutboundCallback(deps: {
+  token: string
+  logger: GithubOutboundLogger
+  fetchImpl?: typeof fetch
+}): OutboundCallback {
+  const fetchImpl = deps.fetchImpl ?? fetch
+  return async (msg: OutboundMessage): Promise<SendResult> => {
+    if (msg.adapter !== 'github') return { ok: false, error: `unknown adapter: ${msg.adapter}` }
+    if ((msg.attachments ?? []).length > 0) return { ok: false, error: 'github-bot-does-not-support-attachments' }
+    const body = msg.text ?? ''
+    if (body === '') return { ok: false, error: 'message has neither text nor attachments' }
+
+    const repo = parseRepo(msg.workspace)
+    if (repo === null) return { ok: false, error: `invalid GitHub workspace: ${msg.workspace}` }
+    const target = parseChat(msg.chat)
+    if (target === null) return { ok: false, error: `invalid GitHub chat: ${msg.chat}` }
+
+    if (target.kind === 'discussion') {
+      return await postDiscussionComment({ ...deps, fetchImpl, repo, discussionNumber: target.number, body })
+    }
+
+    const endpoint =
+      target.kind === 'pr' && msg.thread !== null && msg.thread !== undefined && msg.thread !== ''
+        ? `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${target.number}/comments/${encodeURIComponent(msg.thread)}/replies`
+        : `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${target.number}/comments`
+    return await postJson(fetchImpl, deps.token, endpoint, { body })
+  }
+}
+
+async function postDiscussionComment(options: {
+  token: string
+  fetchImpl: typeof fetch
+  repo: RepoRef
+  discussionNumber: number
+  body: string
+}): Promise<SendResult> {
+  const discussionId = await fetchDiscussionId(options)
+  if (!discussionId.ok) return discussionId
+  const mutation = `mutation($discussionId:ID!,$body:String!){addDiscussionComment(input:{discussionId:$discussionId,body:$body}){comment{id}}}`
+  return await postGraphql(options.fetchImpl, options.token, mutation, {
+    discussionId: discussionId.id,
+    body: options.body,
+  })
+}
+
+async function fetchDiscussionId(options: {
+  token: string
+  fetchImpl: typeof fetch
+  repo: RepoRef
+  discussionNumber: number
+}): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const query = `query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){discussion(number:$number){id}}}`
+  const result = await graphql<{ repository?: { discussion?: { id?: string } | null } }>(
+    options.fetchImpl,
+    options.token,
+    query,
+    {
+      owner: options.repo.owner,
+      name: options.repo.name,
+      number: options.discussionNumber,
+    },
+  )
+  if (!result.ok) return result
+  const id = result.data.repository?.discussion?.id
+  return typeof id === 'string' && id !== '' ? { ok: true, id } : { ok: false, error: 'discussion not found' }
+}
+
+async function postGraphql(
+  fetchImpl: typeof fetch,
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<SendResult> {
+  const result = await graphql(fetchImpl, token, query, variables)
+  return result.ok ? { ok: true } : { ok: false, error: result.error }
+}
+
+async function graphql<T>(
+  fetchImpl: typeof fetch,
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<{ ok: true; data: T } | { ok: false; error: string }> {
+  try {
+    const response = await fetchImpl(`${GITHUB_API_BASE}/graphql`, {
+      method: 'POST',
+      headers: githubJsonHeaders(token),
+      body: JSON.stringify({ query, variables }),
+    })
+    const raw = (await response.json()) as { data?: T; errors?: Array<{ message?: string }> }
+    if (!response.ok || raw.errors !== undefined) {
+      return {
+        ok: false,
+        error: raw.errors?.map((e) => e.message ?? 'unknown').join('; ') ?? `HTTP ${response.status}`,
+      }
+    }
+    if (raw.data === undefined) return { ok: false, error: 'GraphQL response missing data' }
+    return { ok: true, data: raw.data }
+  } catch (err) {
+    return { ok: false, error: describe(err) }
+  }
+}
+
+async function postJson(fetchImpl: typeof fetch, token: string, url: string, payload: unknown): Promise<SendResult> {
+  try {
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: githubJsonHeaders(token),
+      body: JSON.stringify(payload),
+    })
+    if (response.ok) return { ok: true }
+    const text = await response.text().catch(() => '')
+    return { ok: false, error: `GitHub API ${response.status}${text !== '' ? `: ${text}` : ''}` }
+  } catch (err) {
+    return { ok: false, error: describe(err) }
+  }
+}
+
+type RepoRef = { owner: string; name: string }
+type ChatRef = { kind: 'issue' | 'pr' | 'discussion'; number: number }
+
+export function parseRepo(workspace: string): RepoRef | null {
+  const [owner, name, extra] = workspace.split('/')
+  if (!owner || !name || extra !== undefined) return null
+  return { owner, name }
+}
+
+export function parseChat(chat: string): ChatRef | null {
+  const [kind, rawNumber] = chat.split(':')
+  const number = Number(rawNumber)
+  if ((kind !== 'issue' && kind !== 'pr' && kind !== 'discussion') || !Number.isInteger(number) || number <= 0) {
+    return null
+  }
+  return { kind, number }
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -2,15 +2,23 @@ import { createHash } from 'node:crypto'
 import { join } from 'node:path'
 
 import type { PermissionService } from '@/permissions'
+import type { GithubSecretsBlock } from '@/secrets'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 import { SecretsBackend } from '@/secrets/storage'
 
 import { createDiscordBotAdapter, type DiscordBotAdapter } from './adapters/discord-bot'
+import { createGithubAdapter, type GithubAdapter } from './adapters/github'
 import { createKakaotalkAdapter, type KakaotalkAdapter } from './adapters/kakaotalk'
 import { createSlackBotAdapter, type SlackBotAdapter } from './adapters/slack-bot'
 import { createTelegramBotAdapter, type TelegramBotAdapter } from './adapters/telegram-bot'
 import { createChannelRouter, type ChannelRouter, type ClaimHandler, type CreateSessionForChannel } from './router'
-import { ADAPTER_IDS, type AdapterId, type ChannelAdapterConfig, type ChannelsConfig } from './schema'
+import {
+  ADAPTER_IDS,
+  type AdapterId,
+  type ChannelAdapterConfig,
+  type ChannelsConfig,
+  type GithubAdapterConfig,
+} from './schema'
 
 export type ChannelManagerLogger = {
   info: (msg: string) => void
@@ -48,6 +56,7 @@ export type ChannelManagerOptions = {
   createSessionForChannel?: CreateSessionForChannel
   // Test seams: let fake adapters replace the real adapter wiring per id.
   createDiscordAdapter?: typeof createDiscordBotAdapter
+  createGithubAdapter?: typeof createGithubAdapter
   createKakaotalkAdapter?: typeof createKakaotalkAdapter
   createSlackAdapter?: typeof createSlackBotAdapter
   createTelegramAdapter?: typeof createTelegramBotAdapter
@@ -71,7 +80,7 @@ export type ChannelManager = {
   reload: () => Promise<{ started: string[]; stopped: string[]; restartRequired: string[] }>
 }
 
-type AnyAdapter = DiscordBotAdapter | KakaotalkAdapter | SlackBotAdapter | TelegramBotAdapter
+type AnyAdapter = DiscordBotAdapter | GithubAdapter | KakaotalkAdapter | SlackBotAdapter | TelegramBotAdapter
 
 // Credential signature is the comparison key for credential-rotation
 // detection on reload. Discord and Telegram each use a single bot token;
@@ -98,6 +107,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     ...(options.claimHandler ? { claimHandler: options.claimHandler } : {}),
   })
   const createDiscordAdapter = options.createDiscordAdapter ?? createDiscordBotAdapter
+  const createGithub = options.createGithubAdapter ?? createGithubAdapter
   const createKakaotalk = options.createKakaotalkAdapter ?? createKakaotalkAdapter
   const createSlackAdapter = options.createSlackAdapter ?? createSlackBotAdapter
   const createTelegramAdapter = options.createTelegramAdapter ?? createTelegramBotAdapter
@@ -106,6 +116,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
 
   const buildCredentialSignature = (name: AdapterId): { signature: string; missing: string[] } => {
     if (name === 'kakaotalk') return buildKakaotalkSignature(options.agentDir)
+    if (name === 'github') return buildGithubSignature(options.agentDir)
     const requiredEnvs = TOKEN_ENV[name]
     const parts: string[] = []
     const missing: string[] = []
@@ -149,6 +160,17 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         logger,
         selfAliasesRef: () => router.getSelfAliases(),
         credentialsStore: createContainerKakaoCredentialStore(options.agentDir, env),
+      })
+    }
+    if (name === 'github') {
+      const secrets = readGithubSecrets(options.agentDir)
+      if (secrets === null) return null
+      return createGithub({
+        router,
+        configRef: () => (options.channelsConfigRef()[name] ?? cfg) as ChannelAdapterConfig & GithubAdapterConfig,
+        secrets,
+        agentDir: options.agentDir,
+        logger,
       })
     }
     if (name === 'telegram-bot') {
@@ -263,7 +285,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
 // Token-based adapters only. KakaoTalk's credentials live in
 // secrets.json#channels.kakaotalk, not in env, so it goes through
 // buildKakaotalkSignature instead.
-const TOKEN_ENV: Record<Exclude<AdapterId, 'kakaotalk'>, readonly string[]> = {
+const TOKEN_ENV: Record<Exclude<AdapterId, 'kakaotalk' | 'github'>, readonly string[]> = {
   'discord-bot': ['DISCORD_BOT_TOKEN'],
   'slack-bot': ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN'],
   'telegram-bot': ['TELEGRAM_BOT_TOKEN'],
@@ -299,6 +321,35 @@ function buildKakaotalkSignature(agentDir: string): { signature: string; missing
   } catch (err) {
     return { signature: '', missing: [`secrets.json#channels.kakaotalk (${describe(err)})`] }
   }
+}
+
+function buildGithubSignature(agentDir: string): { signature: string; missing: string[] } {
+  const block = readGithubSecrets(agentDir)
+  if (block === null) return { signature: '', missing: ['secrets.json#channels.github'] }
+  const digest = createHash('sha256').update(JSON.stringify(block)).digest('hex')
+  return { signature: `secrets.json#channels.github@sha256:${digest}`, missing: [] }
+}
+
+function readGithubSecrets(agentDir: string): GithubSecretsBlock | null {
+  const path = join(agentDir, 'secrets.json')
+  try {
+    const block = new SecretsBackend(path).tryReadChannelsSync()?.github
+    return isGithubSecretsBlock(block) ? block : null
+  } catch {
+    return null
+  }
+}
+
+function isGithubSecretsBlock(value: unknown): value is GithubSecretsBlock {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const record = value as Record<string, unknown>
+  const auth = record.auth
+  return (
+    typeof auth === 'object' &&
+    auth !== null &&
+    !Array.isArray(auth) &&
+    (auth as Record<string, unknown>).type === 'pat'
+  )
 }
 
 function isKakaoCredentialBlock(value: unknown): value is { accounts: Record<string, unknown> } {

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-export const ADAPTER_IDS = ['discord-bot', 'kakaotalk', 'slack-bot', 'telegram-bot'] as const
+export const ADAPTER_IDS = ['discord-bot', 'github', 'kakaotalk', 'slack-bot', 'telegram-bot'] as const
 
 export type AdapterId = (typeof ADAPTER_IDS)[number]
 
@@ -99,6 +99,22 @@ const adapterSchema = z.object({
   enabled: z.boolean().default(true),
 })
 
+export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [
+  'issue_comment.created',
+  'pull_request_review_comment.created',
+  'discussion_comment.created',
+  'issues.opened',
+  'pull_request.opened',
+  'discussion.created',
+  'pull_request_review.submitted',
+] as const
+
+const githubChannelSchema = adapterSchema.extend({
+  webhookUrl: z.string().url(),
+  webhookPort: z.number().int().positive().default(8975),
+  eventAllowlist: z.array(z.string()).default([...DEFAULT_GITHUB_EVENT_ALLOWLIST]),
+})
+
 // KakaoTalk uses the same shape as every other adapter. There used to be an
 // `autoMarkRead` opt-in here; the adapter now fires a LOCO NOTIREAD ack on
 // every inbound MSG event unconditionally (see kakaotalk.ts) so the sender's
@@ -112,6 +128,7 @@ const adapterSchema = z.object({
 export const channelsSchema = z
   .object({
     'discord-bot': adapterSchema.optional(),
+    github: githubChannelSchema.optional(),
     kakaotalk: adapterSchema.optional(),
     'slack-bot': adapterSchema.optional(),
     'telegram-bot': adapterSchema.optional(),
@@ -120,4 +137,5 @@ export const channelsSchema = z
 
 export type EngagementConfig = z.infer<typeof engagementSchema>
 export type ChannelAdapterConfig = z.infer<typeof adapterSchema>
+export type GithubAdapterConfig = z.infer<typeof githubChannelSchema>
 export type ChannelsConfig = z.infer<typeof channelsSchema>

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -414,9 +414,21 @@ async function promptGithubCredentials(): Promise<{
     cancel('Aborted.')
     process.exit(0)
   }
+  const resolvedSecret = secret.length > 0 ? secret : randomBytes(32).toString('hex')
+  if (secret.length === 0) {
+    note(
+      [
+        `Webhook secret: ${resolvedSecret}`,
+        '',
+        'Paste this into the "Secret" field when creating the GitHub webhook.',
+        'It will not be shown again.',
+      ].join('\n'),
+      'Generated webhook secret',
+    )
+  }
   return {
     githubPat: pat,
-    webhookSecret: secret.length > 0 ? secret : randomBytes(32).toString('hex'),
+    webhookSecret: resolvedSecret,
     webhookUrl,
     webhookPort: Number(port),
     repos: parseRepos(reposRaw),

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'node:crypto'
+
 import { cancel, confirm, intro, isCancel, log, note, password, select, spinner, text } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
@@ -23,6 +25,7 @@ const CHANNEL_LABELS: Record<ChannelKind, string> = {
   'discord-bot': 'Discord',
   'telegram-bot': 'Telegram',
   kakaotalk: 'KakaoTalk',
+  github: 'GitHub',
 }
 
 const addSub = defineCommand({
@@ -314,6 +317,14 @@ type CollectedCredentials =
   | { channel: 'slack-bot'; slackBotToken: string; slackAppToken: string }
   | { channel: 'telegram-bot'; telegramBotToken: string }
   | { channel: 'kakaotalk'; runKakaotalkAuth: (options: { cwd: string }) => Promise<KakaotalkAuthResult> }
+  | {
+      channel: 'github'
+      githubPat: string
+      webhookSecret: string
+      webhookUrl: string
+      webhookPort?: number
+      repos: string[]
+    }
 
 async function collectCredentials(channel: ChannelKind): Promise<CollectedCredentials> {
   switch (channel) {
@@ -338,6 +349,94 @@ async function collectCredentials(channel: ChannelKind): Promise<CollectedCreden
           }),
       }
     }
+    case 'github': {
+      const creds = await promptGithubCredentials()
+      return { channel, ...creds }
+    }
+  }
+}
+
+async function promptGithubCredentials(): Promise<{
+  githubPat: string
+  webhookSecret: string
+  webhookUrl: string
+  webhookPort?: number
+  repos: string[]
+}> {
+  note(
+    [
+      'Create a fine-grained PAT with access to the repositories TypeClaw should answer in.',
+      'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used), Metadata read.',
+      'Create a repository webhook pointing to the public webhook URL you enter below.',
+    ].join('\n'),
+    'Get GitHub credentials',
+  )
+  const webhookUrl = await text({
+    message: 'Public webhook URL (GitHub will POST events here)',
+    validate: (value) => validateUrl(value ?? '', 'Webhook URL is required'),
+  })
+  if (isCancel(webhookUrl)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  const port = await text({
+    message: 'Local webhook port inside the agent container',
+    initialValue: '8975',
+    validate: (value) => {
+      const parsed = Number(value)
+      return Number.isInteger(parsed) && parsed > 0 ? undefined : 'Port must be a positive integer'
+    },
+  })
+  if (isCancel(port)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  const secret = await password({
+    message: 'Webhook secret (leave blank to auto-generate)',
+  })
+  if (isCancel(secret)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  const pat = await password({
+    message: 'GitHub fine-grained PAT',
+    validate: (value) => (value && value.length > 0 ? undefined : 'PAT is required'),
+  })
+  if (isCancel(pat)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  const reposRaw = await text({
+    message: 'Repositories to allow (comma-separated owner/repo)',
+    validate: (value) => (parseRepos(value ?? '').length > 0 ? undefined : 'At least one owner/repo is required'),
+  })
+  if (isCancel(reposRaw)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return {
+    githubPat: pat,
+    webhookSecret: secret.length > 0 ? secret : randomBytes(32).toString('hex'),
+    webhookUrl,
+    webhookPort: Number(port),
+    repos: parseRepos(reposRaw),
+  }
+}
+
+function parseRepos(input: string): string[] {
+  return input
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => /^[^\s/]+\/[^\s/]+$/.test(v))
+}
+
+function validateUrl(value: string, requiredMessage: string): string | undefined {
+  if (!value || value.length === 0) return requiredMessage
+  try {
+    new URL(value)
+    return undefined
+  } catch {
+    return 'Must be a valid URL'
   }
 }
 

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -802,13 +802,19 @@ function ignoreExists(error: NodeJS.ErrnoException): void {
 // scaffold-test cases above demonstrates how easy it is to lose a single
 // behavior under a mode flag.
 
-export type ChannelKind = 'discord-bot' | 'slack-bot' | 'telegram-bot' | 'kakaotalk'
+export type ChannelKind = 'discord-bot' | 'slack-bot' | 'telegram-bot' | 'kakaotalk' | 'github'
 
 // Public adapter names match the typeclaw.json `channels.*` keys exactly.
 // The CLI takes these as the optional positional arg, the picker shows
 // these labels, and they're the keys we use to detect "already configured"
 // when reading typeclaw.json.
-export const CHANNEL_KINDS: ReadonlyArray<ChannelKind> = ['slack-bot', 'discord-bot', 'telegram-bot', 'kakaotalk']
+export const CHANNEL_KINDS: ReadonlyArray<ChannelKind> = [
+  'slack-bot',
+  'discord-bot',
+  'telegram-bot',
+  'kakaotalk',
+  'github',
+]
 
 export type AddChannelStep = 'kakaotalk-auth' | 'config' | 'secrets'
 
@@ -831,6 +837,14 @@ export type AddChannelOptions = {
   | { channel: 'slack-bot'; slackBotToken: string; slackAppToken: string }
   | { channel: 'telegram-bot'; telegramBotToken: string }
   | { channel: 'kakaotalk'; runKakaotalkAuth: KakaotalkAuthRunner }
+  | {
+      channel: 'github'
+      githubPat: string
+      webhookSecret: string
+      webhookUrl: string
+      webhookPort?: number
+      repos: string[]
+    }
 )
 
 export async function runAddChannel(options: AddChannelOptions): Promise<void> {
@@ -852,7 +866,7 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
   }
 
   emit({ step: 'config', phase: 'start' })
-  await mergeChannelIntoConfig(options.cwd, options.channel)
+  await mergeChannelIntoConfig(options.cwd, options)
   emit({ step: 'config', phase: 'done' })
 
   emit({ step: 'secrets', phase: 'start' })
@@ -860,7 +874,14 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
   if (Object.keys(tokens).length > 0) {
     await appendChannelSecrets(options.cwd, options.channel, tokens)
   }
+  if (options.channel === 'github') {
+    await appendGithubSecrets(options.cwd, options)
+  }
   emit({ step: 'secrets', phase: 'done' })
+
+  if (options.channel === 'github') {
+    await appendGithubMatchRules(options.cwd, options.repos)
+  }
 
   // Commit the typeclaw.json change so the agent folder isn't silently
   // dirty after `typeclaw channel add`. Same `commitSystemFile` contract as
@@ -881,6 +902,9 @@ function channelSecretsFromOptions(options: AddChannelOptions): ChannelSecrets {
     case 'kakaotalk':
       // KakaoTalk auth writes its structured multi-account block directly to
       // secrets.json#channels.kakaotalk before config mutation.
+      return {}
+    case 'github':
+      // GitHub stores a structured PAT + webhook secret block directly.
       return {}
   }
 }
@@ -908,7 +932,7 @@ export async function readConfiguredChannels(cwd: string): Promise<Set<ChannelKi
   return present
 }
 
-async function mergeChannelIntoConfig(cwd: string, channel: ChannelKind): Promise<void> {
+async function mergeChannelIntoConfig(cwd: string, options: AddChannelOptions): Promise<void> {
   const path = join(cwd, CONFIG_FILE)
   let parsed: Record<string, unknown>
   try {
@@ -928,19 +952,73 @@ async function mergeChannelIntoConfig(cwd: string, channel: ChannelKind): Promis
       ? (parsed.channels as Record<string, unknown>)
       : {}
 
-  if (channel in existingChannels) {
+  if (options.channel in existingChannels) {
     // Defense in depth — the CLI already filters configured channels out of
     // the picker and rejects them as the positional arg. Hitting this branch
     // means a programmatic caller passed a duplicate; better to fail loudly
     // than silently overwrite the user's existing config.
-    throw new Error(`Channel "${channel}" is already configured in ${CONFIG_FILE}.`)
+    throw new Error(`Channel "${options.channel}" is already configured in ${CONFIG_FILE}.`)
   }
+
+  const nextChannelConfig =
+    options.channel === 'github'
+      ? {
+          webhookUrl: options.webhookUrl,
+          webhookPort: options.webhookPort ?? 8975,
+          eventAllowlist: [
+            'issue_comment.created',
+            'pull_request_review_comment.created',
+            'discussion_comment.created',
+            'issues.opened',
+            'pull_request.opened',
+            'discussion.created',
+            'pull_request_review.submitted',
+          ],
+        }
+      : {}
 
   parsed.channels = {
     ...existingChannels,
-    [channel]: {},
+    [options.channel]: nextChannelConfig,
   }
 
+  await writeFile(path, `${JSON.stringify(parsed, null, 2)}\n`)
+}
+
+async function appendGithubSecrets(
+  cwd: string,
+  options: Extract<AddChannelOptions, { channel: 'github' }>,
+): Promise<void> {
+  if (!existsSync(join(cwd, CONFIG_FILE))) {
+    throw new Error(
+      `${CONFIG_FILE} not found at ${cwd}. Run \`typeclaw init\` before adding channels, or run this command from inside an agent folder.`,
+    )
+  }
+  const backend = new SecretsBackend(join(cwd, 'secrets.json'))
+  const channels: Record<string, unknown> = backend.readChannelsSync()
+  if (channels.github !== undefined) {
+    throw new Error(
+      'github is already set in secrets.json. Remove it before re-adding the channel, or edit it by hand.',
+    )
+  }
+  channels.github = {
+    auth: { type: 'pat', token: { value: options.githubPat } satisfies Secret },
+    webhookSecret: { value: options.webhookSecret } satisfies Secret,
+  }
+  backend.writeChannelsSync(channels as Channels)
+}
+
+async function appendGithubMatchRules(cwd: string, repos: readonly string[]): Promise<void> {
+  const path = join(cwd, CONFIG_FILE)
+  const parsed = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>
+  const roles = isObjectRecord(parsed.roles) ? { ...parsed.roles } : {}
+  const member = isObjectRecord(roles.member) ? { ...roles.member } : {}
+  const existing = Array.isArray(member.match) ? member.match.filter((v): v is string => typeof v === 'string') : []
+  const merged = new Set(existing)
+  for (const repo of repos) merged.add(`github:${repo}`)
+  member.match = Array.from(merged)
+  roles.member = member
+  parsed.roles = roles
   await writeFile(path, `${JSON.stringify(parsed, null, 2)}\n`)
 }
 

--- a/src/init/run-owner-claim.ts
+++ b/src/init/run-owner-claim.ts
@@ -8,6 +8,7 @@ import type { ChannelKind } from './index'
 const CHANNEL_LABELS: Record<ChannelKind, string> = {
   'slack-bot': 'Slack',
   'discord-bot': 'Discord',
+  github: 'GitHub',
   'telegram-bot': 'Telegram',
   kakaotalk: 'KakaoTalk',
 }

--- a/src/permissions/match-rule.test.ts
+++ b/src/permissions/match-rule.test.ts
@@ -34,6 +34,16 @@ describe('parseMatchRule — accepted forms', () => {
     { input: 'kakao:dm/*', expected: { kind: 'channel', platform: 'kakao', bucket: 'dm' } },
     { input: 'kakao:group/*', expected: { kind: 'channel', platform: 'kakao', bucket: 'group' } },
     { input: 'kakao:open/*', expected: { kind: 'channel', platform: 'kakao', bucket: 'open' } },
+    { input: 'github:acme/project', expected: { kind: 'channel', platform: 'github', workspace: 'acme/project' } },
+    {
+      input: 'github:acme/project/issue:42',
+      expected: { kind: 'channel', platform: 'github', workspace: 'acme/project', chat: 'issue:42' },
+    },
+    { input: 'github:acme/*', expected: { kind: 'channel', platform: 'github', workspace: 'acme' } },
+    {
+      input: 'github:acme/project author:12345',
+      expected: { kind: 'channel', platform: 'github', workspace: 'acme/project', author: '12345' },
+    },
   ]
   for (const { input, expected } of cases) {
     test(`parses '${input}'`, () => {
@@ -69,6 +79,8 @@ describe('parseMatchRule — rejected forms', () => {
     { input: '* author:U_ME', reason: /requires a specific channel scope/ },
     { input: 'discord:group/*', reason: /'group' is only valid for kakao/ },
     { input: 'discord:open/*', reason: /'open' is only valid for kakao/ },
+    { input: 'github:acme', reason: /owner\/repo/ },
+    { input: 'github:acme/project/issue:42/extra', reason: /single segment/ },
   ]
   for (const { input, reason } of cases) {
     test(`rejects '${input}'`, () => {

--- a/src/permissions/match-rule.test.ts
+++ b/src/permissions/match-rule.test.ts
@@ -39,7 +39,6 @@ describe('parseMatchRule — accepted forms', () => {
       input: 'github:acme/project/issue:42',
       expected: { kind: 'channel', platform: 'github', workspace: 'acme/project', chat: 'issue:42' },
     },
-    { input: 'github:acme/*', expected: { kind: 'channel', platform: 'github', workspace: 'acme' } },
     {
       input: 'github:acme/project author:12345',
       expected: { kind: 'channel', platform: 'github', workspace: 'acme/project', author: '12345' },
@@ -80,6 +79,7 @@ describe('parseMatchRule — rejected forms', () => {
     { input: 'discord:group/*', reason: /'group' is only valid for kakao/ },
     { input: 'discord:open/*', reason: /'open' is only valid for kakao/ },
     { input: 'github:acme', reason: /owner\/repo/ },
+    { input: 'github:acme/*', reason: /not supported/ },
     { input: 'github:acme/project/issue:42/extra', reason: /single segment/ },
   ]
   for (const { input, reason } of cases) {

--- a/src/permissions/match-rule.ts
+++ b/src/permissions/match-rule.ts
@@ -211,10 +211,10 @@ function parseGithubChannelScope(rest: string, author: string | undefined): Pars
     return { ok: false, error: "github scope requires 'owner/repo' format" }
   }
   if (repo === '*') {
-    if (chatParts.length > 0) {
-      return { ok: false, error: "github owner wildcard cannot be combined with a chat; use 'github:owner/*'" }
+    return {
+      ok: false,
+      error: `'github:${owner}/*' is not supported; use 'github:${owner}/repo' for a specific repo or 'github:*' for all github events`,
     }
-    return { ok: true, value: buildChannelRule('github', { workspace: owner, author }) }
   }
   const workspace = `${owner}/${repo}`
   if (chatParts.length === 0) return { ok: true, value: buildChannelRule('github', { workspace, author }) }

--- a/src/permissions/match-rule.ts
+++ b/src/permissions/match-rule.ts
@@ -16,7 +16,7 @@
 // error messages with typo suggestions; a single big regex would only ever
 // say "didn't match".
 
-export const PLATFORMS = ['slack', 'discord', 'telegram', 'kakao'] as const
+export const PLATFORMS = ['slack', 'discord', 'telegram', 'kakao', 'github'] as const
 export type Platform = (typeof PLATFORMS)[number]
 
 const SUBAGENT_NAME = /^[a-z][a-z0-9-]*$/
@@ -50,7 +50,7 @@ export type ParseMatchRuleResult = { ok: true; value: MatchRule } | { ok: false;
 // this to `author:` only, the JSON schema would reject typos with a generic
 // "did not match pattern" error and the user would lose the actionable hint.
 export const MATCH_RULE_REGEX_SOURCE =
-  '^(tui|cron|subagent(:[a-z][a-z0-9-]*)?|\\*|(slack|discord|telegram|kakao):[^\\s]+)(\\s+[a-zA-Z][a-zA-Z0-9_]*:[^\\s]+)*$'
+  '^(tui|cron|subagent(:[a-z][a-z0-9-]*)?|\\*|(slack|discord|telegram|kakao|github):[^\\s]+)(\\s+[a-zA-Z][a-zA-Z0-9_]*:[^\\s]+)*$'
 
 export function parseMatchRule(input: string): ParseMatchRuleResult {
   if (input !== input.trim() || input.length === 0) {
@@ -138,6 +138,8 @@ function parseChannelScope(platform: Platform, rest: string, author: string | un
     return { ok: true, value: buildChannelRule(platform, { author }) }
   }
 
+  if (platform === 'github') return parseGithubChannelScope(rest, author)
+
   // Bucket scopes: `dm/*`, `dm/<id>`, `group/*`, `open/*`. Slack's `im` is
   // renamed to `dm`; that mapping is enforced by the legacy-prefix table at
   // the top of parseMatchRule for unprefixed forms — here we just refuse the
@@ -201,6 +203,26 @@ function parseChannelScope(platform: Platform, rest: string, author: string | un
     return { ok: false, error: `bucket '${platform}:${rest}' requires a chat id or '*'` }
   }
   return { ok: true, value: buildChannelRule(platform, { workspace: rest, author }) }
+}
+
+function parseGithubChannelScope(rest: string, author: string | undefined): ParseMatchRuleResult {
+  const [owner, repo, ...chatParts] = rest.split('/')
+  if (owner === undefined || owner === '' || repo === undefined || repo === '') {
+    return { ok: false, error: "github scope requires 'owner/repo' format" }
+  }
+  if (repo === '*') {
+    if (chatParts.length > 0) {
+      return { ok: false, error: "github owner wildcard cannot be combined with a chat; use 'github:owner/*'" }
+    }
+    return { ok: true, value: buildChannelRule('github', { workspace: owner, author }) }
+  }
+  const workspace = `${owner}/${repo}`
+  if (chatParts.length === 0) return { ok: true, value: buildChannelRule('github', { workspace, author }) }
+  const chat = chatParts.join('/')
+  if (chat === '' || chat.includes('/')) {
+    return { ok: false, error: "github chat scope must be a single segment like 'issue:42'" }
+  }
+  return { ok: true, value: buildChannelRule('github', { workspace, chat, author }) }
 }
 
 function buildChannelRule(

--- a/src/permissions/resolve.ts
+++ b/src/permissions/resolve.ts
@@ -5,6 +5,7 @@ import type { MatchRule, Platform } from './match-rule'
 const ADAPTER_TO_PLATFORM: Record<AdapterId, Platform> = {
   'slack-bot': 'slack',
   'discord-bot': 'discord',
+  github: 'github',
   'telegram-bot': 'telegram',
   kakaotalk: 'kakao',
 }

--- a/src/role-claim/match-rule.ts
+++ b/src/role-claim/match-rule.ts
@@ -21,9 +21,10 @@ export type PartialChannelOrigin = {
   authorId: string
 }
 
-const ADAPTER_TO_PLATFORM: Record<ChannelKey['adapter'], 'slack' | 'discord' | 'telegram' | 'kakao'> = {
+const ADAPTER_TO_PLATFORM: Record<ChannelKey['adapter'], 'slack' | 'discord' | 'telegram' | 'kakao' | 'github'> = {
   'slack-bot': 'slack',
   'discord-bot': 'discord',
+  github: 'github',
   'telegram-bot': 'telegram',
   kakaotalk: 'kakao',
 }

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -1,4 +1,4 @@
-export { type Channels } from './schema'
+export { type Channels, type GithubSecretsBlock } from './schema'
 
 export { createSecretsStoreForAgent, SecretsBackend } from './storage'
 

--- a/src/secrets/schema.ts
+++ b/src/secrets/schema.ts
@@ -40,6 +40,16 @@ const telegramBotChannelSchema = z.object({
   token: secretFieldSchema.optional(),
 })
 
+const githubPatAuthSchema = z.object({
+  type: z.literal('pat'),
+  token: secretFieldSchema,
+})
+
+const githubChannelSchema = z.object({
+  auth: githubPatAuthSchema,
+  webhookSecret: secretFieldSchema,
+})
+
 // Encrypted password envelope produced by src/secrets/encryption.ts. Optional
 // in the schema because legacy v2 accounts (pre-renewal feature) don't have
 // one; the renewal cron treats a missing envelope as "reauth required" and
@@ -92,6 +102,7 @@ export const channelsSchema = z
   .object({
     'slack-bot': slackBotChannelSchema.optional(),
     'discord-bot': discordBotChannelSchema.optional(),
+    github: githubChannelSchema.optional(),
     'telegram-bot': telegramBotChannelSchema.optional(),
     kakaotalk: kakaoChannelBlockSchema.optional(),
   })
@@ -113,6 +124,8 @@ export const secretsFileSchema = z.object({
 export type ProviderCredential = z.infer<typeof providerCredentialSchema>
 export type Providers = z.infer<typeof providersSchema>
 export type Channels = z.infer<typeof channelsSchema>
+export type GithubPatAuthBlock = z.infer<typeof githubPatAuthSchema>
+export type GithubSecretsBlock = z.infer<typeof githubChannelSchema>
 export type KakaoAccountRecord = z.infer<typeof kakaoAccountRecordSchema>
 export type PendingLoginRecord = z.infer<typeof kakaoPendingLoginRecordSchema>
 export type KakaoChannelBlock = z.infer<typeof kakaoChannelBlockSchema>

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: typeclaw-channel-github
+description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `github`, AND before composing replies to GitHub-originated inbounds. GitHub renders **real markdown** — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and `inline code` all render natively. Use rich markdown freely. GitHub cannot send file attachments via API — do not call `channel_send` with attachments on github chats. GitHub has no typing indicator. PR review threads use `thread` keyed on the root comment id; reply to a thread to stay in it, or omit `thread` to post a top-level issue/PR comment. Read this skill before composing anything on GitHub.
+---
+
+GitHub renders normal Markdown in issues, PRs, discussions, and review comments. Use headings, lists, tables, fenced code blocks, links, and inline code when they improve clarity.
+
+- Do not send attachments on GitHub chats; the adapter rejects them.
+- There is no typing indicator.
+- For PR review threads, keep `thread` set to reply in-place. Omit `thread` for a top-level PR/issue comment.


### PR DESCRIPTION
## Summary

Adds a bidirectional GitHub channel adapter to TypeClaw. The agent can now receive webhook events from GitHub (issue comments, PR review comments, discussion comments, new issues/PRs) and reply via issue comments, PR comments, PR review thread replies, or GraphQL discussion comments.

Ships the full webhook listener + REST/GraphQL outbound using PAT authentication. GitHub App authentication (short-lived JWTs, per-installation tokens) is a follow-up.

## Changes

### src/channels/adapters/github/ (new — 11 source + 6 test files)

| File | Purpose |
|---|---|
| index.ts | Top-level `createGithubAdapter` factory — wires listener, auth, outbound, history, membership, channel-name-resolver, and fetch-attachment into the channel router |
| inbound.ts | Bun.serve webhook handler — HMAC-SHA256 signature verification, ack-first dispatch, self-author loop guard, event allowlist gate |
| outbound.ts | REST + GraphQL outbound — issue/PR comments, PR review thread replies, discussion comments via GraphQL |
| auth.ts | Auth strategy interface + factory |
| auth-pat.ts | PAT token strategy — `getSelf`, shared header builder |
| history.ts | Issue/PR comment history, Link-header pagination |
| membership.ts | Repo collaborator membership resolver |
| channel-resolver.ts | Resolves `owner/repo` to a human-readable channel name |
| fetch-attachment.ts | No-op (GitHub API has no attachment upload endpoints) |
| dedup.ts | In-memory LRU delivery dedup (prevents replay of re-delivered webhooks) |
| event-allowlist.ts | `isGithubEventAllowed` — parses event+action pairs against the configured allowlist |

### Central edits

**src/channels/schema.ts** — adds `github` to `ADAPTER_IDS`; adds `GithubAdapterConfig` with `webhookUrl`, `webhookPort` (default 8975), and `eventAllowlist` (sensible defaults).

**src/secrets/schema.ts** — adds `GithubSecretsBlock` with `auth: { type: 'pat', token: Secret }` and `webhookSecret: Secret`.

**src/permissions/match-rule.ts** — adds `github` to `PLATFORMS`; implements `parseGithubChannelScope` supporting `github:owner/repo`, `github:owner/repo/issue:42`, `github:owner/*`, and `author:` qualifiers.

**src/channels/manager.ts** — wires `createGithubAdapter` into the adapter lifecycle alongside existing adapters.

**src/init/index.ts** — adds GitHub to the `typeclaw channel add` flow: config block writes, `secrets.json` update.

**src/cli/channel.ts** — adds `promptGithubCredentials` interactive flow: webhook URL, port, secret (auto-generates a 32-byte random secret if left blank), fine-grained PAT, and comma-separated repo list.

### Bundled skill

**src/skills/typeclaw-channel-github/SKILL.md** — loaded before any `channel_reply` or `channel_send` on GitHub chats. Instructs the agent to use full Markdown freely (renders natively on GitHub), avoid attachments (not supported by the API), note that there is no typing indicator, and use the `thread` field to reply inside a PR review thread.

## Design decisions

**Ack-first pattern.** The webhook handler responds 200 OK before calling `router.route()`. GitHub closes a webhook delivery as failed after 10 seconds; routing into an LLM turn would exceed that budget. The route future is fire-and-forget with an error log on failure.

**HMAC-SHA256 hand-rolled.** Node's `crypto.createHmac` + `timingSafeEqual` avoids pulling in a new dependency for a one-function operation. Tests cover reject-on-bad-signature and reject-on-length-mismatch paths explicitly.

**LRU delivery dedup.** GitHub re-delivers failed webhooks. `DeliveryDedup` keeps the 1000 most-recent `X-GitHub-Delivery` IDs in a Map used as an LRU (insertion-order eviction). No disk persistence — a restart drops the cache, which is acceptable.

**Self-author loop guard.** On start, the adapter calls `getSelf` to fetch the authenticated user's login from `/user`. Inbound events whose `sender.login === selfLogin` are silently discarded.

**Chat key convention.** Issues use `issue:<number>`, PRs use `pr:<number>`, discussions use `discussion:<number>`. PR review thread comments use `pr:<number>` with `thread` set to the root comment ID.

**Match-rule DSL.** `github:owner/repo` matches all events in a repo. `github:owner/*` is the per-owner wildcard. `github:owner/repo/issue:42` scopes to one issue. `author:` qualifiers work on all three forms.

## Validation

```
bun run typecheck  — clean
bun run lint       — 0 errors
bun run format     — clean
bun test           — 3705 / 3705 pass
```