### PR TITLE
Add GitHub App authentication

### DIFF
--- a/src/channels/adapters/github/auth-app.test.ts
+++ b/src/channels/adapters/github/auth-app.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { createVerify, generateKeyPairSync } from 'node:crypto'
+
+import { AppAuthStrategy } from './auth-app'
+
+const fixedNow = Date.parse('2026-05-18T12:00:00Z')
+
+let privateKeyPem = ''
+let publicKeyPem = ''
+let originalNow: () => number
+
+beforeAll(() => {
+  const pair = generateKeyPairSync('rsa', { modulusLength: 2048 })
+  privateKeyPem = pair.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString()
+  publicKeyPem = pair.publicKey.export({ type: 'spki', format: 'pem' }).toString()
+})
+
+beforeEach(() => {
+  originalNow = Date.now
+  Date.now = () => fixedNow
+})
+
+afterEach(() => {
+  Date.now = originalNow
+})
+
+describe('AppAuthStrategy', () => {
+  it('mints a verifiable RS256 JWT with GitHub App claims', async () => {
+    let jwt = ''
+    const strategy = new AppAuthStrategy({
+      appId: 12345,
+      privateKey: { value: privateKeyPem },
+      installationId: 67890,
+      fetchImpl: fakeFetch(async (_url, init) => {
+        jwt = bearerToken(init)
+        return Response.json({ token: 'installation-token', expires_at: '2026-05-18T13:00:00Z' })
+      }),
+    })
+
+    await strategy.token()
+
+    const decoded = decodeJwt(jwt)
+    expect(decoded.header).toEqual({ alg: 'RS256', typ: 'JWT' })
+    expect(decoded.payload).toEqual({ iat: fixedNow / 1000 - 60, exp: fixedNow / 1000 + 540, iss: 12345 })
+    expect(verifyJwtSignature(jwt)).toBe(true)
+  })
+
+  it('mints and caches installation tokens for configured installations', async () => {
+    const calls: string[] = []
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: privateKeyPem },
+      installationId: 99,
+      fetchImpl: fakeFetch(async (url) => {
+        calls.push(String(url))
+        return Response.json({ token: 'cached-token', expires_at: '2026-05-18T13:00:00Z' })
+      }),
+    })
+
+    await expect(strategy.token()).resolves.toBe('cached-token')
+    await expect(strategy.token()).resolves.toBe('cached-token')
+
+    expect(calls).toEqual(['https://api.github.com/app/installations/99/access_tokens'])
+  })
+
+  it('refreshes cached installation tokens inside the five-minute boundary', async () => {
+    const tokens = ['first-token', 'second-token']
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: privateKeyPem },
+      installationId: 99,
+      fetchImpl: fakeFetch(async () =>
+        Response.json({ token: tokens.shift() ?? 'extra-token', expires_at: '2026-05-18T13:00:00Z' }),
+      ),
+    })
+
+    await expect(strategy.token()).resolves.toBe('first-token')
+    Date.now = () => Date.parse('2026-05-18T12:56:00Z')
+
+    await expect(strategy.token()).resolves.toBe('second-token')
+  })
+
+  it('auto-discovers a single installation id', async () => {
+    const calls: string[] = []
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: privateKeyPem },
+      fetchImpl: fakeFetch(async (url) => {
+        calls.push(String(url))
+        if (String(url).endsWith('/app/installations')) return Response.json([{ id: 777 }])
+        return Response.json({ token: 'auto-token', expires_at: '2026-05-18T13:00:00Z' })
+      }),
+    })
+
+    await expect(strategy.token()).resolves.toBe('auto-token')
+
+    expect(calls).toEqual([
+      'https://api.github.com/app/installations',
+      'https://api.github.com/app/installations/777/access_tokens',
+    ])
+  })
+
+  it('rejects apps without installations', async () => {
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: privateKeyPem },
+      fetchImpl: fakeFetch(async () => Response.json([])),
+    })
+
+    await expect(strategy.token()).rejects.toThrow(/no installations/i)
+  })
+
+  it('rejects ambiguous installation auto-discovery with listed ids', async () => {
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: privateKeyPem },
+      fetchImpl: fakeFetch(async () => Response.json([{ id: 11 }, { id: 22 }])),
+    })
+
+    await expect(strategy.token()).rejects.toThrow(/multiple installations \(11, 22\)/i)
+  })
+
+  it('resolves and caches the GitHub App bot user', async () => {
+    const calls: string[] = []
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: privateKeyPem },
+      fetchImpl: fakeFetch(async (url) => {
+        calls.push(String(url))
+        if (String(url).endsWith('/app')) return Response.json({ slug: 'typeclaw' })
+        return Response.json({ id: 42, login: 'typeclaw[bot]' })
+      }),
+    })
+
+    await expect(strategy.getSelf()).resolves.toEqual({ id: 42, login: 'typeclaw[bot]' })
+    await expect(strategy.getSelf()).resolves.toEqual({ id: 42, login: 'typeclaw[bot]' })
+
+    expect(calls).toEqual(['https://api.github.com/app', 'https://api.github.com/users/typeclaw%5Bbot%5D'])
+  })
+})
+
+function fakeFetch(handler: (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>): typeof fetch {
+  return Object.assign(handler, { preconnect: () => {} })
+}
+
+function bearerToken(init: RequestInit | undefined): string {
+  return new Headers(init?.headers).get('authorization')?.replace(/^Bearer /, '') ?? ''
+}
+
+function decodeJwt(jwt: string): { header: unknown; payload: unknown } {
+  const [header, payload] = jwt.split('.')
+  return { header: parseBase64urlJson(header ?? ''), payload: parseBase64urlJson(payload ?? '') }
+}
+
+function parseBase64urlJson(value: string): unknown {
+  return JSON.parse(Buffer.from(value.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'))
+}
+
+function verifyJwtSignature(jwt: string): boolean {
+  const [header, payload, signature] = jwt.split('.')
+  const verify = createVerify('RSA-SHA256')
+  verify.update(`${header}.${payload}`)
+  verify.end()
+  return verify.verify(publicKeyPem, Buffer.from((signature ?? '').replace(/-/g, '+').replace(/_/g, '/'), 'base64'))
+}

--- a/src/channels/adapters/github/auth-app.ts
+++ b/src/channels/adapters/github/auth-app.ts
@@ -1,0 +1,120 @@
+import { resolveSecret, type Secret } from '@/secrets/resolve'
+
+import type { GithubAuthStrategy, GithubSelfUser } from './auth'
+import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
+
+export class AppAuthStrategy implements GithubAuthStrategy {
+  private readonly appId: number
+  private readonly privateKeyPem: string
+  private readonly installationId: number | null
+  private readonly fetchImpl: typeof fetch
+  private cachedToken: { value: string; expiresAt: number } | null = null
+  private resolvedInstallationId: number | null = null
+  private _selfUser: GithubSelfUser | null = null
+
+  constructor(options: { appId: number; privateKey: Secret; installationId?: number; fetchImpl?: typeof fetch }) {
+    const privateKeyPem = resolveSecret(options.privateKey, undefined, process.env)
+    if (privateKeyPem === undefined || privateKeyPem.trim() === '') throw new Error('GitHub App private key is missing')
+    this.appId = options.appId
+    this.privateKeyPem = privateKeyPem
+    this.installationId = options.installationId ?? null
+    this.fetchImpl = options.fetchImpl ?? fetch
+  }
+
+  async token(): Promise<string> {
+    if (this.cachedToken && Date.now() < this.cachedToken.expiresAt - 5 * 60 * 1000) {
+      return this.cachedToken.value
+    }
+    const jwt = await this.mintJwt()
+    const installId = await this.resolveInstallationId(jwt)
+    const response = await this.fetchImpl(`${GITHUB_API_BASE}/app/installations/${installId}/access_tokens`, {
+      method: 'POST',
+      headers: githubJsonHeaders(jwt),
+    })
+    if (!response.ok) throw new Error(`GitHub App token mint failed: ${response.status}`)
+    const raw = (await response.json()) as { token?: unknown; expires_at?: unknown }
+    if (typeof raw.token !== 'string') throw new Error('GitHub App token response missing token')
+    const expiresAt = typeof raw.expires_at === 'string' ? Date.parse(raw.expires_at) : Date.now() + 60 * 60 * 1000
+    this.cachedToken = { value: raw.token, expiresAt }
+    return raw.token
+  }
+
+  async authHeaders(): Promise<HeadersInit> {
+    return githubJsonHeaders(await this.token())
+  }
+
+  async getSelf(): Promise<GithubSelfUser> {
+    if (this._selfUser) return this._selfUser
+    const jwt = await this.mintJwt()
+    const appResponse = await this.fetchImpl(`${GITHUB_API_BASE}/app`, { headers: githubJsonHeaders(jwt) })
+    if (!appResponse.ok) throw new Error(`GitHub App preflight failed: ${appResponse.status}`)
+    const app = (await appResponse.json()) as { slug?: unknown }
+    if (typeof app.slug !== 'string') throw new Error('GitHub /app response missing slug')
+
+    const botLogin = `${app.slug}[bot]`
+    const userResponse = await this.fetchImpl(`${GITHUB_API_BASE}/users/${encodeURIComponent(botLogin)}`, {
+      headers: githubJsonHeaders(jwt),
+    })
+    if (!userResponse.ok) throw new Error(`GitHub bot user lookup failed: ${userResponse.status}`)
+    const user = (await userResponse.json()) as { id?: unknown; login?: unknown }
+    if (typeof user.id !== 'number' || typeof user.login !== 'string') {
+      throw new Error('GitHub bot user response missing id/login')
+    }
+    this._selfUser = { id: user.id, login: user.login }
+    return this._selfUser
+  }
+
+  async dispose(): Promise<void> {
+    this.cachedToken = null
+  }
+
+  private async mintJwt(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000)
+    const iat = now - 60
+    const exp = iat + 600
+    const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }))
+    const payload = base64url(JSON.stringify({ iat, exp, iss: this.appId }))
+    const signingInput = `${header}.${payload}`
+    const key = await importRsaPrivateKey(this.privateKeyPem)
+    const signature = await crypto.subtle.sign(
+      { name: 'RSASSA-PKCS1-v1_5' },
+      key,
+      new TextEncoder().encode(signingInput),
+    )
+    return `${signingInput}.${base64url(Buffer.from(signature))}`
+  }
+
+  private async resolveInstallationId(jwt: string): Promise<number> {
+    if (this.resolvedInstallationId !== null) return this.resolvedInstallationId
+    if (this.installationId !== null) {
+      this.resolvedInstallationId = this.installationId
+      return this.installationId
+    }
+    const response = await this.fetchImpl(`${GITHUB_API_BASE}/app/installations`, { headers: githubJsonHeaders(jwt) })
+    if (!response.ok) throw new Error(`GitHub App installations fetch failed: ${response.status}`)
+    const list = (await response.json()) as Array<{ id?: unknown }>
+    if (list.length === 0) throw new Error('GitHub App has no installations')
+    if (list.length > 1) {
+      const ids = list.map((installation) => installation.id).join(', ')
+      throw new Error(`GitHub App has multiple installations (${ids}); set installationId in secrets.json`)
+    }
+    const id = list[0]?.id
+    if (typeof id !== 'number') throw new Error('GitHub App installation missing id')
+    this.resolvedInstallationId = id
+    return id
+  }
+}
+
+function base64url(input: string | Buffer): string {
+  const buf = typeof input === 'string' ? Buffer.from(input) : input
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+
+async function importRsaPrivateKey(pem: string): Promise<CryptoKey> {
+  const b64 = pem
+    .replace(/-----BEGIN [^-]+-----/, '')
+    .replace(/-----END [^-]+-----/, '')
+    .replace(/\s/g, '')
+  const der = Buffer.from(b64, 'base64')
+  return await crypto.subtle.importKey('pkcs8', der, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign'])
+}

--- a/src/channels/adapters/github/auth-pat.ts
+++ b/src/channels/adapters/github/auth-pat.ts
@@ -5,22 +5,26 @@ import type { GithubAuthStrategy, GithubSelfUser } from './auth'
 export const GITHUB_API_BASE = 'https://api.github.com'
 
 export class PatAuthStrategy implements GithubAuthStrategy {
-  readonly token: string
+  private readonly _token: string
   private readonly fetchImpl: typeof fetch
 
   constructor(options: { token: Secret; fetchImpl?: typeof fetch }) {
     const token = resolveSecret(options.token, undefined, process.env)
     if (token === undefined || token.trim() === '') throw new Error('GitHub PAT token is missing')
-    this.token = token
+    this._token = token
     this.fetchImpl = options.fetchImpl ?? fetch
   }
 
-  authHeaders(): HeadersInit {
-    return githubJsonHeaders(this.token)
+  async token(): Promise<string> {
+    return this._token
+  }
+
+  async authHeaders(): Promise<HeadersInit> {
+    return githubJsonHeaders(this._token)
   }
 
   async getSelf(): Promise<GithubSelfUser> {
-    const response = await this.fetchImpl(`${GITHUB_API_BASE}/user`, { headers: this.authHeaders() })
+    const response = await this.fetchImpl(`${GITHUB_API_BASE}/user`, { headers: await this.authHeaders() })
     if (!response.ok) {
       const body = await response.text().catch(() => '')
       throw new Error(`GitHub PAT authentication failed: ${response.status}${body !== '' ? ` ${body}` : ''}`)
@@ -31,6 +35,8 @@ export class PatAuthStrategy implements GithubAuthStrategy {
     }
     return { login: raw.login, id: raw.id }
   }
+
+  async dispose(): Promise<void> {}
 }
 
 export function githubJsonHeaders(token: string): HeadersInit {

--- a/src/channels/adapters/github/auth.ts
+++ b/src/channels/adapters/github/auth.ts
@@ -3,9 +3,10 @@ import type { GithubPatAuthBlock } from '@/secrets/schema'
 import { PatAuthStrategy } from './auth-pat'
 
 export type GithubAuthStrategy = {
-  readonly token: string
-  authHeaders: () => HeadersInit
+  token: () => Promise<string>
+  authHeaders: () => Promise<HeadersInit>
   getSelf: () => Promise<GithubSelfUser>
+  dispose: () => Promise<void>
 }
 
 export type GithubSelfUser = {

--- a/src/channels/adapters/github/auth.ts
+++ b/src/channels/adapters/github/auth.ts
@@ -1,5 +1,6 @@
-import type { GithubPatAuthBlock } from '@/secrets/schema'
+import type { GithubAppAuthBlock, GithubPatAuthBlock } from '@/secrets/schema'
 
+import { AppAuthStrategy } from './auth-app'
 import { PatAuthStrategy } from './auth-pat'
 
 export type GithubAuthStrategy = {
@@ -14,6 +15,19 @@ export type GithubSelfUser = {
   id: number
 }
 
-export function buildAuthStrategy(options: { auth: GithubPatAuthBlock; fetchImpl?: typeof fetch }): GithubAuthStrategy {
-  return new PatAuthStrategy({ token: options.auth.token, fetchImpl: options.fetchImpl })
+export function buildAuthStrategy(options: {
+  auth: GithubPatAuthBlock | GithubAppAuthBlock
+  fetchImpl?: typeof fetch
+}): GithubAuthStrategy {
+  switch (options.auth.type) {
+    case 'pat':
+      return new PatAuthStrategy({ token: options.auth.token, fetchImpl: options.fetchImpl })
+    case 'app':
+      return new AppAuthStrategy({
+        appId: options.auth.appId,
+        privateKey: options.auth.privateKey,
+        installationId: options.auth.installationId,
+        fetchImpl: options.fetchImpl,
+      })
+  }
 }

--- a/src/channels/adapters/github/channel-resolver.ts
+++ b/src/channels/adapters/github/channel-resolver.ts
@@ -4,7 +4,7 @@ import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 import { parseChat, parseRepo } from './outbound'
 
 export function createGithubChannelNameResolver(options: {
-  token: string
+  token: () => Promise<string>
   fetchImpl?: typeof fetch
 }): ChannelNameResolver {
   const fetchImpl = options.fetchImpl ?? fetch
@@ -18,7 +18,7 @@ export function createGithubChannelNameResolver(options: {
     const path = chat.kind === 'issue' ? `issues/${chat.number}` : `pulls/${chat.number}`
     try {
       const response = await fetchImpl(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/${path}`, {
-        headers: githubJsonHeaders(options.token),
+        headers: githubJsonHeaders(await options.token()),
       })
       if (!response.ok) return names
       const raw = (await response.json()) as { title?: string }

--- a/src/channels/adapters/github/history.test.ts
+++ b/src/channels/adapters/github/history.test.ts
@@ -5,7 +5,7 @@ import { createGithubHistoryCallback } from './history'
 describe('createGithubHistoryCallback', () => {
   it('fetches issue comments for a remembered workspace', async () => {
     const cb = createGithubHistoryCallback({
-      token: 'tok',
+      token: async () => 'tok',
       workspaceForChat: () => 'acme/project',
       fetchImpl: Object.assign(
         async () =>

--- a/src/channels/adapters/github/history.ts
+++ b/src/channels/adapters/github/history.ts
@@ -4,7 +4,7 @@ import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 import { parseChat, parseRepo } from './outbound'
 
 export function createGithubHistoryCallback(options: {
-  token: string
+  token: () => Promise<string>
   workspaceForChat: (chat: string) => string | null
   fetchImpl?: typeof fetch
 }): HistoryCallback {
@@ -26,7 +26,7 @@ export function createGithubHistoryCallback(options: {
       const response = await fetchImpl(
         `${endpoint}?per_page=${Math.min(Math.max(args.limit, 1), 100)}&direction=desc${cursor}`,
         {
-          headers: githubJsonHeaders(options.token),
+          headers: githubJsonHeaders(await options.token()),
         },
       )
       if (!response.ok) return { ok: false, error: `GitHub history ${response.status}` }

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -113,6 +113,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         options.router.unregisterMembership('github', membership)
         options.router.unregisterChannelNameResolver('github', channelNameResolver)
         options.router.unregisterFetchAttachment('github', fetchAttachment)
+        await auth.dispose()
         selfId = null
         selfLogin = null
         throw err
@@ -130,6 +131,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
       options.router.unregisterChannelNameResolver('github', channelNameResolver)
       options.router.unregisterFetchAttachment('github', fetchAttachment)
       await server?.stop()
+      await auth.dispose()
       server = null
       selfId = null
       selfLogin = null

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -57,14 +57,15 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     workspaceByChat.set(chat, workspace)
   }
 
-  const outbound = createGithubOutboundCallback({ token: auth.token, logger, fetchImpl })
+  const tokenFn = () => auth.token()
+  const outbound = createGithubOutboundCallback({ token: tokenFn, logger, fetchImpl })
   const history = createGithubHistoryCallback({
-    token: auth.token,
+    token: tokenFn,
     fetchImpl,
     workspaceForChat: (chat) => workspaceByChat.get(chat) ?? null,
   })
-  const membership = createGithubMembershipResolver({ token: auth.token, fetchImpl })
-  const channelNameResolver = createGithubChannelNameResolver({ token: auth.token, fetchImpl })
+  const membership = createGithubMembershipResolver({ token: tokenFn, fetchImpl })
+  const channelNameResolver = createGithubChannelNameResolver({ token: tokenFn, fetchImpl })
   const fetchAttachment = createGithubFetchAttachmentCallback()
   // No-op typing callback: GitHub has no typing indicator API.
   const typing = async (): Promise<void> => {}

--- a/src/channels/adapters/github/membership.test.ts
+++ b/src/channels/adapters/github/membership.test.ts
@@ -5,7 +5,7 @@ import { createGithubMembershipResolver } from './membership'
 describe('createGithubMembershipResolver', () => {
   it('counts collaborator humans and bots', async () => {
     const resolver = createGithubMembershipResolver({
-      token: 'tok',
+      token: async () => 'tok',
       fetchImpl: Object.assign(async () => Response.json([{ type: 'User' }, { type: 'Bot' }]), {
         preconnect: () => {},
       }),

--- a/src/channels/adapters/github/membership.ts
+++ b/src/channels/adapters/github/membership.ts
@@ -4,7 +4,7 @@ import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 import { parseRepo } from './outbound'
 
 export function createGithubMembershipResolver(options: {
-  token: string
+  token: () => Promise<string>
   fetchImpl?: typeof fetch
 }): MembershipResolver {
   const fetchImpl = options.fetchImpl ?? fetch
@@ -16,7 +16,7 @@ export function createGithubMembershipResolver(options: {
       const response = await fetchImpl(
         `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/collaborators?per_page=100`,
         {
-          headers: githubJsonHeaders(options.token),
+          headers: githubJsonHeaders(await options.token()),
         },
       )
       if (!response.ok) return response.status >= 500 ? { kind: 'transient' } : { kind: 'permanent' }

--- a/src/channels/adapters/github/outbound.test.ts
+++ b/src/channels/adapters/github/outbound.test.ts
@@ -17,7 +17,7 @@ const fakeFetch = (responses: Record<string, { status: number; body: unknown }>)
 describe('createGithubOutboundCallback', () => {
   it('posts issue and top-level PR comments through the issues comments endpoint', async () => {
     const cb = createGithubOutboundCallback({
-      token: 'tok',
+      token: async () => 'tok',
       logger,
       fetchImpl: fakeFetch({
         'POST https://api.github.com/repos/acme/project/issues/42/comments': { status: 201, body: { id: 1 } },
@@ -37,7 +37,7 @@ describe('createGithubOutboundCallback', () => {
 
   it('posts PR review thread replies through the pull comment replies endpoint', async () => {
     const cb = createGithubOutboundCallback({
-      token: 'tok',
+      token: async () => 'tok',
       logger,
       fetchImpl: fakeFetch({
         'POST https://api.github.com/repos/acme/project/pulls/42/comments/99/replies': { status: 201, body: { id: 2 } },
@@ -56,7 +56,7 @@ describe('createGithubOutboundCallback', () => {
   })
 
   it('rejects attachments', async () => {
-    const cb = createGithubOutboundCallback({ token: 'tok', logger, fetchImpl: fakeFetch({}) })
+    const cb = createGithubOutboundCallback({ token: async () => 'tok', logger, fetchImpl: fakeFetch({}) })
 
     const result = await cb({
       adapter: 'github',

--- a/src/channels/adapters/github/outbound.ts
+++ b/src/channels/adapters/github/outbound.ts
@@ -5,7 +5,7 @@ import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 export type GithubOutboundLogger = { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void }
 
 export function createGithubOutboundCallback(deps: {
-  token: string
+  token: () => Promise<string>
   logger: GithubOutboundLogger
   fetchImpl?: typeof fetch
 }): OutboundCallback {
@@ -29,12 +29,12 @@ export function createGithubOutboundCallback(deps: {
       target.kind === 'pr' && msg.thread !== null && msg.thread !== undefined && msg.thread !== ''
         ? `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${target.number}/comments/${encodeURIComponent(msg.thread)}/replies`
         : `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${target.number}/comments`
-    return await postJson(fetchImpl, deps.token, endpoint, { body })
+    return await postJson(fetchImpl, await deps.token(), endpoint, { body })
   }
 }
 
 async function postDiscussionComment(options: {
-  token: string
+  token: () => Promise<string>
   fetchImpl: typeof fetch
   repo: RepoRef
   discussionNumber: number
@@ -43,14 +43,14 @@ async function postDiscussionComment(options: {
   const discussionId = await fetchDiscussionId(options)
   if (!discussionId.ok) return discussionId
   const mutation = `mutation($discussionId:ID!,$body:String!){addDiscussionComment(input:{discussionId:$discussionId,body:$body}){comment{id}}}`
-  return await postGraphql(options.fetchImpl, options.token, mutation, {
+  return await postGraphql(options.fetchImpl, await options.token(), mutation, {
     discussionId: discussionId.id,
     body: options.body,
   })
 }
 
 async function fetchDiscussionId(options: {
-  token: string
+  token: () => Promise<string>
   fetchImpl: typeof fetch
   repo: RepoRef
   discussionNumber: number
@@ -58,7 +58,7 @@ async function fetchDiscussionId(options: {
   const query = `query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){discussion(number:$number){id}}}`
   const result = await graphql<{ repository?: { discussion?: { id?: string } | null } }>(
     options.fetchImpl,
-    options.token,
+    await options.token(),
     query,
     {
       owner: options.repo.owner,

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
 
 import { cancel, confirm, intro, isCancel, log, note, password, select, spinner, text } from '@clack/prompts'
 import { defineCommand } from 'citty'
@@ -319,11 +320,11 @@ type CollectedCredentials =
   | { channel: 'kakaotalk'; runKakaotalkAuth: (options: { cwd: string }) => Promise<KakaotalkAuthResult> }
   | {
       channel: 'github'
-      githubPat: string
       webhookSecret: string
       webhookUrl: string
       webhookPort?: number
       repos: string[]
+      auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string; installationId?: number }
     }
 
 async function collectCredentials(channel: ChannelKind): Promise<CollectedCredentials> {
@@ -357,20 +358,31 @@ async function collectCredentials(channel: ChannelKind): Promise<CollectedCreden
 }
 
 async function promptGithubCredentials(): Promise<{
-  githubPat: string
   webhookSecret: string
   webhookUrl: string
   webhookPort?: number
   repos: string[]
+  auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string; installationId?: number }
 }> {
   note(
     [
-      'Create a fine-grained PAT with access to the repositories TypeClaw should answer in.',
+      'Choose PAT auth for a quick setup, or GitHub App auth for expiring installation tokens.',
       'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used), Metadata read.',
       'Create a repository webhook pointing to the public webhook URL you enter below.',
     ].join('\n'),
     'Get GitHub credentials',
   )
+  const authType = await select({
+    message: 'GitHub authentication type',
+    options: [
+      { value: 'pat', label: 'Fine-grained personal access token' },
+      { value: 'app', label: 'GitHub App installation token' },
+    ],
+  })
+  if (isCancel(authType)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
   const webhookUrl = await text({
     message: 'Public webhook URL (GitHub will POST events here)',
     validate: (value) => validateUrl(value ?? '', 'Webhook URL is required'),
@@ -398,14 +410,7 @@ async function promptGithubCredentials(): Promise<{
     cancel('Aborted.')
     process.exit(0)
   }
-  const pat = await password({
-    message: 'GitHub fine-grained PAT',
-    validate: (value) => (value && value.length > 0 ? undefined : 'PAT is required'),
-  })
-  if (isCancel(pat)) {
-    cancel('Aborted.')
-    process.exit(0)
-  }
+  const auth = authType === 'pat' ? await promptGithubPatAuth() : await promptGithubAppAuth()
   const reposRaw = await text({
     message: 'Repositories to allow (comma-separated owner/repo)',
     validate: (value) => (parseRepos(value ?? '').length > 0 ? undefined : 'At least one owner/repo is required'),
@@ -427,12 +432,70 @@ async function promptGithubCredentials(): Promise<{
     )
   }
   return {
-    githubPat: pat,
     webhookSecret: resolvedSecret,
     webhookUrl,
     webhookPort: Number(port),
     repos: parseRepos(reposRaw),
+    auth,
   }
+}
+
+async function promptGithubPatAuth(): Promise<{ type: 'pat'; pat: string }> {
+  const pat = await password({
+    message: 'GitHub fine-grained PAT',
+    validate: (value) => (value && value.length > 0 ? undefined : 'PAT is required'),
+  })
+  if (isCancel(pat)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return { type: 'pat', pat }
+}
+
+async function promptGithubAppAuth(): Promise<{
+  type: 'app'
+  appId: number
+  privateKey: string
+  installationId?: number
+}> {
+  const appId = await text({
+    message: 'GitHub App ID',
+    validate: (value) => validatePositiveInteger(value ?? '', 'App ID is required'),
+  })
+  if (isCancel(appId)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  const privateKeyInput = await text({
+    message: 'GitHub App private key PEM, escaped PEM, or path to .pem file',
+    validate: (value) => (value && value.length > 0 ? undefined : 'Private key is required'),
+  })
+  if (isCancel(privateKeyInput)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  const installationId = await text({
+    message: 'Installation ID (optional; leave blank to auto-discover)',
+    validate: (value) =>
+      value === undefined || value === '' ? undefined : validatePositiveInteger(value, 'Installation ID is required'),
+  })
+  if (isCancel(installationId)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  const parsedInstallationId = installationId === '' ? undefined : Number(installationId)
+  return {
+    type: 'app',
+    appId: Number(appId),
+    privateKey: await resolvePrivateKeyInput(privateKeyInput),
+    ...(parsedInstallationId !== undefined ? { installationId: parsedInstallationId } : {}),
+  }
+}
+
+async function resolvePrivateKeyInput(input: string): Promise<string> {
+  const normalized = input.replace(/\\n/g, '\n')
+  if (normalized.includes('-----BEGIN') && normalized.includes('PRIVATE KEY-----')) return normalized
+  return await readFile(input, 'utf8')
 }
 
 function parseRepos(input: string): string[] {
@@ -450,6 +513,12 @@ function validateUrl(value: string, requiredMessage: string): string | undefined
   } catch {
     return 'Must be a valid URL'
   }
+}
+
+function validatePositiveInteger(value: string, requiredMessage: string): string | undefined {
+  if (!value || value.length === 0) return requiredMessage
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? undefined : 'Must be a positive integer'
 }
 
 async function promptDiscordToken(): Promise<string> {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -839,11 +839,11 @@ export type AddChannelOptions = {
   | { channel: 'kakaotalk'; runKakaotalkAuth: KakaotalkAuthRunner }
   | {
       channel: 'github'
-      githubPat: string
       webhookSecret: string
       webhookUrl: string
       webhookPort?: number
       repos: string[]
+      auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string; installationId?: number }
     }
 )
 
@@ -1002,7 +1002,15 @@ async function appendGithubSecrets(
     )
   }
   channels.github = {
-    auth: { type: 'pat', token: { value: options.githubPat } satisfies Secret },
+    auth:
+      options.auth.type === 'pat'
+        ? { type: 'pat', token: { value: options.auth.pat } satisfies Secret }
+        : {
+            type: 'app',
+            appId: options.auth.appId,
+            privateKey: { value: options.auth.privateKey } satisfies Secret,
+            ...(options.auth.installationId !== undefined ? { installationId: options.auth.installationId } : {}),
+          },
     webhookSecret: { value: options.webhookSecret } satisfies Secret,
   }
   backend.writeChannelsSync(channels as Channels)

--- a/src/secrets/schema.ts
+++ b/src/secrets/schema.ts
@@ -45,8 +45,15 @@ const githubPatAuthSchema = z.object({
   token: secretFieldSchema,
 })
 
+const githubAppAuthSchema = z.object({
+  type: z.literal('app'),
+  appId: z.number().int().positive(),
+  privateKey: secretFieldSchema,
+  installationId: z.number().int().positive().optional(),
+})
+
 const githubChannelSchema = z.object({
-  auth: githubPatAuthSchema,
+  auth: z.discriminatedUnion('type', [githubPatAuthSchema, githubAppAuthSchema]),
   webhookSecret: secretFieldSchema,
 })
 
@@ -125,6 +132,7 @@ export type ProviderCredential = z.infer<typeof providerCredentialSchema>
 export type Providers = z.infer<typeof providersSchema>
 export type Channels = z.infer<typeof channelsSchema>
 export type GithubPatAuthBlock = z.infer<typeof githubPatAuthSchema>
+export type GithubAppAuthBlock = z.infer<typeof githubAppAuthSchema>
 export type GithubSecretsBlock = z.infer<typeof githubChannelSchema>
 export type KakaoAccountRecord = z.infer<typeof kakaoAccountRecordSchema>
 export type PendingLoginRecord = z.infer<typeof kakaoPendingLoginRecordSchema>


### PR DESCRIPTION
## Summary

Adds GitHub App authentication to the GitHub channel adapter, alongside the existing PAT support. Agents can now authenticate as a GitHub App installation — posting as `<app-slug>[bot]` — instead of a personal account.

Builds on the PAT adapter merged in #226. The two auth modes are a discriminated union on `secrets.json#channels.github.auth.type`.

## Changes

### Token interface made async

`GithubAuthStrategy.token` changed from `readonly string` to `token(): Promise<string>`. PAT wraps the resolved string in a resolved promise (zero overhead). App returns a cached installation token, refreshing it when within 5 minutes of expiry. All four callback factories (`outbound`, `history`, `membership`, `channel-resolver`) updated to `await token()` before each request.

### `AppAuthStrategy` (`src/channels/adapters/github/auth-app.ts`)

Hand-rolled RS256 JWT minting via `crypto.subtle` — no new dependencies. Flow:

1. Mint a 10-minute JWT (`iat = now - 60`, `exp = iat + 600`, `iss = appId`, RS256)
2. Exchange for an installation access token via `POST /app/installations/{id}/access_tokens`
3. Cache the token; refresh when `expiresAt - 5min` is reached
4. `getSelf()` calls `GET /app` → slug → `GET /users/{slug}%5Bbot%5D` to resolve the bot user id and login

Installation ID is optional: if omitted, auto-discovered from `GET /app/installations` (fails clearly when 0 or 2+ installations exist).

### Secrets schema (`src/secrets/schema.ts`)

Added `githubAppAuthSchema` branch to the `auth` discriminated union:

```json
{
  "channels": {
    "github": {
      "auth": {
        "type": "app",
        "appId": 12345,
        "privateKey": { "value": "-----BEGIN RSA PRIVATE KEY-----\n..." },
        "installationId": 67890
      },
      "webhookSecret": { "value": "..." }
    }
  }
}
```

`installationId` is optional (auto-discovered if omitted). `secrets.schema.json` and `auth.schema.json` regenerated.

### CLI (`src/cli/channel.ts`, `src/init/index.ts`)

`typeclaw channel add github` now prompts for auth type (PAT or App). App path collects App ID, private key (paste or file path), and optional installation ID.

## Validation

```
bun run typecheck  — clean
bun run lint       — 0 errors
bun run format     — clean
bun test           — 3712 / 3712 pass
```