### PR TITLE
Add GitHub App authentication

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -57,7 +57,11 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     workspaceByChat.set(chat, workspace)
   }
 
-  const tokenFn = () => auth.token()
+  const tokenFn = async () => {
+    const t = await auth.token()
+    process.env.GH_TOKEN = t
+    return t
+  }
   const outbound = createGithubOutboundCallback({ token: tokenFn, logger, fetchImpl })
   const history = createGithubHistoryCallback({
     token: tokenFn,
@@ -115,10 +119,15 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         options.router.unregisterChannelNameResolver('github', channelNameResolver)
         options.router.unregisterFetchAttachment('github', fetchAttachment)
         await auth.dispose()
+        delete process.env.GH_TOKEN
         selfId = null
         selfLogin = null
         throw err
       }
+      // Seed GH_TOKEN so `gh` CLI calls in the container are pre-authenticated.
+      // tokenFn keeps it current on every adapter API call; App tokens refresh
+      // automatically when within 5 minutes of expiry.
+      process.env.GH_TOKEN = await auth.token()
       started = true
       logger.info(`[github] webhook listening on port ${options.configRef().webhookPort} as @${self.login}`)
     },
@@ -133,6 +142,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
       options.router.unregisterFetchAttachment('github', fetchAttachment)
       await server?.stop()
       await auth.dispose()
+      delete process.env.GH_TOKEN
       server = null
       selfId = null
       selfLogin = null

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typeclaw-channel-github
-description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `github`, AND before composing replies to GitHub-originated inbounds. GitHub renders **real markdown** — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and `inline code` all render natively. Use rich markdown freely. GitHub cannot send file attachments via API — do not call `channel_send` with attachments on github chats. GitHub has no typing indicator. PR review threads use `thread` keyed on the root comment id; reply to a thread to stay in it, or omit `thread` to post a top-level issue/PR comment. Read this skill before composing anything on GitHub.
+description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `github`, AND before composing replies to GitHub-originated inbounds, AND before opening new issues or PRs with `gh`. GitHub renders **real markdown** — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and `inline code` all render natively. Use rich markdown freely. GitHub cannot send file attachments via API — do not call `channel_send` with attachments on github chats. GitHub has no typing indicator. PR review threads use `thread` keyed on the root comment id; reply to a thread to stay in it, or omit `thread` to post a top-level issue/PR comment. To open new issues or PRs use the `gh` CLI — `GH_TOKEN` is pre-set by the adapter. Read this skill before composing anything on GitHub.
 ---
 
 GitHub renders normal Markdown in issues, PRs, discussions, and review comments. Use headings, lists, tables, fenced code blocks, links, and inline code when they improve clarity.
@@ -8,3 +8,17 @@ GitHub renders normal Markdown in issues, PRs, discussions, and review comments.
 - Do not send attachments on GitHub chats; the adapter rejects them.
 - There is no typing indicator.
 - For PR review threads, keep `thread` set to reply in-place. Omit `thread` for a top-level PR/issue comment.
+
+## Opening new issues and PRs
+
+The `gh` CLI is pre-authenticated via `GH_TOKEN` (injected by the adapter at startup). Use it to open new issues or PRs:
+
+```sh
+# Open a new issue
+gh issue create --repo owner/repo --title "Bug: ..." --body "..."
+
+# Open a new PR
+gh pr create --repo owner/repo --title "Fix: ..." --head my-branch --base main --body "..."
+```
+
+For App auth, `GH_TOKEN` is an installation access token that refreshes automatically — it stays current as long as the adapter is running.


### PR DESCRIPTION
## Summary

Adds GitHub App authentication to the GitHub channel adapter. Agents can now authenticate as a GitHub App installation — posting as `<app-slug>[bot]` — instead of a personal account. Also injects `GH_TOKEN` into the container environment so the bundled `gh` CLI is pre-authenticated for opening issues and PRs.

Builds on the PAT adapter from #226.

## Changes

### Token interface made async (`channels/github: change token to async method`)

`GithubAuthStrategy.token` changed from `readonly string` to `token(): Promise<string>`. PAT wraps the resolved string in a resolved promise. App returns a cached installation token, refreshing when within 5 minutes of expiry. All four callback factories updated to `await token()` before each request.

### `AppAuthStrategy` (`channels/github: add App auth strategy`)

Hand-rolled RS256 JWT minting via `crypto.subtle` — no new dependencies.

1. Mint a 10-minute JWT (`iat = now - 60`, `exp = iat + 600`, `iss = appId`, RS256)
2. Exchange for an installation access token via `POST /app/installations/{id}/access_tokens`
3. Cache the token; refresh when `expiresAt - 5min` is reached
4. `getSelf()` resolves the bot user via `GET /app` → slug → `GET /users/{slug}%5Bbot%5D`

Installation ID is optional — auto-discovered from `GET /app/installations` (fails clearly when 0 or 2+ installations exist).

### Secrets schema (`secrets: add github App auth schema branch`)

```json
{
  "channels": {
    "github": {
      "auth": {
        "type": "app",
        "appId": 12345,
        "privateKey": { "value": "-----BEGIN RSA PRIVATE KEY-----\n..." },
        "installationId": 67890
      },
      "webhookSecret": { "value": "..." }
    }
  }
}
```

`installationId` is optional. `secrets.schema.json` and `auth.schema.json` regenerated.

### CLI (`cli: add github App auth prompts`)

`typeclaw channel add github` now prompts for auth type (PAT or App). App path collects App ID, private key, and optional installation ID.

### `GH_TOKEN` injection (`channels/github: inject GH_TOKEN for gh CLI; document in skill`)

The adapter injects `GH_TOKEN` into `process.env` at `start()` and clears it at `stop()`. The `tokenFn` wrapper keeps it current on every adapter API call — for App auth this means the token refreshes automatically before it expires. The bundled skill documents `gh issue create` / `gh pr create` as the way to open new issues and PRs.

## Validation

```
bun run typecheck  — clean
bun run lint       — 0 errors
bun run format     — clean
bun test           — 3712 / 3712 pass
```