### PR TITLE
channels/github: inject GH_TOKEN for gh CLI

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -57,7 +57,11 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     workspaceByChat.set(chat, workspace)
   }
 
-  const tokenFn = () => auth.token()
+  const tokenFn = async () => {
+    const t = await auth.token()
+    process.env.GH_TOKEN = t
+    return t
+  }
   const outbound = createGithubOutboundCallback({ token: tokenFn, logger, fetchImpl })
   const history = createGithubHistoryCallback({
     token: tokenFn,
@@ -115,10 +119,15 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         options.router.unregisterChannelNameResolver('github', channelNameResolver)
         options.router.unregisterFetchAttachment('github', fetchAttachment)
         await auth.dispose()
+        delete process.env.GH_TOKEN
         selfId = null
         selfLogin = null
         throw err
       }
+      // Seed GH_TOKEN so `gh` CLI calls in the container are pre-authenticated.
+      // tokenFn keeps it current on every adapter API call; App tokens refresh
+      // automatically when within 5 minutes of expiry.
+      process.env.GH_TOKEN = await auth.token()
       started = true
       logger.info(`[github] webhook listening on port ${options.configRef().webhookPort} as @${self.login}`)
     },
@@ -133,6 +142,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
       options.router.unregisterFetchAttachment('github', fetchAttachment)
       await server?.stop()
       await auth.dispose()
+      delete process.env.GH_TOKEN
       server = null
       selfId = null
       selfLogin = null

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typeclaw-channel-github
-description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `github`, AND before composing replies to GitHub-originated inbounds. GitHub renders **real markdown** — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and `inline code` all render natively. Use rich markdown freely. GitHub cannot send file attachments via API — do not call `channel_send` with attachments on github chats. GitHub has no typing indicator. PR review threads use `thread` keyed on the root comment id; reply to a thread to stay in it, or omit `thread` to post a top-level issue/PR comment. Read this skill before composing anything on GitHub.
+description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `github`, AND before composing replies to GitHub-originated inbounds, AND before opening new issues or PRs with `gh`. GitHub renders **real markdown** — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and `inline code` all render natively. Use rich markdown freely. GitHub cannot send file attachments via API — do not call `channel_send` with attachments on github chats. GitHub has no typing indicator. PR review threads use `thread` keyed on the root comment id; reply to a thread to stay in it, or omit `thread` to post a top-level issue/PR comment. To open new issues or PRs use the `gh` CLI — `GH_TOKEN` is pre-set by the adapter. Read this skill before composing anything on GitHub.
 ---
 
 GitHub renders normal Markdown in issues, PRs, discussions, and review comments. Use headings, lists, tables, fenced code blocks, links, and inline code when they improve clarity.
@@ -8,3 +8,17 @@ GitHub renders normal Markdown in issues, PRs, discussions, and review comments.
 - Do not send attachments on GitHub chats; the adapter rejects them.
 - There is no typing indicator.
 - For PR review threads, keep `thread` set to reply in-place. Omit `thread` for a top-level PR/issue comment.
+
+## Opening new issues and PRs
+
+The `gh` CLI is pre-authenticated via `GH_TOKEN` (injected by the adapter at startup). Use it to open new issues or PRs:
+
+```sh
+# Open a new issue
+gh issue create --repo owner/repo --title "Bug: ..." --body "..."
+
+# Open a new PR
+gh pr create --repo owner/repo --title "Fix: ..." --head my-branch --base main --body "..."
+```
+
+For App auth, `GH_TOKEN` is an installation access token that refreshes automatically — it stays current as long as the adapter is running.


### PR DESCRIPTION
## Summary

Injects `GH_TOKEN` into the container environment when the GitHub adapter starts, so the bundled `gh` CLI is pre-authenticated without any extra user configuration.

## How it works

- `tokenFn` (the wrapper around `auth.token()`) now side-effects `process.env.GH_TOKEN` on every call — so for App auth the token stays current as installation tokens refresh automatically
- `start()` seeds `GH_TOKEN` immediately after the initial `auth.token()` resolves
- `stop()` and the listener-failure rollback both `delete process.env.GH_TOKEN`

## Usage (documented in bundled skill)

```sh
gh issue create --repo owner/repo --title "..." --body "..."
gh pr create --repo owner/repo --title "..." --head branch --base main --body "..."
```

No `GH_TOKEN=...` prefix needed — it's already in the environment.

## Validation

```
bun run typecheck  — clean
bun run lint       — 0 errors  
bun run format     — clean
bun test           — 3712 / 3712 pass
```