### PR TITLE
permissions: trusted carries security.bypass.gitExfil by default

### DIFF
--- a/src/bundled-plugins/security/index.ts
+++ b/src/bundled-plugins/security/index.ts
@@ -25,8 +25,9 @@ export { SECURITY_PERMISSIONS, type SecurityPermission } from './permissions'
 // it's the only carrier.
 const BYPASS_ROLE_HINT = {
   [SECURITY_PERMISSIONS.bypassSecretExfilBash]: 'owner and trusted have it by default',
-  [SECURITY_PERMISSIONS.bypassGitExfil]: 'only owner has it by default',
-  [SECURITY_PERMISSIONS.bypassGitRemoteTainted]: 'only owner has it by default',
+  [SECURITY_PERMISSIONS.bypassGitExfil]: 'owner and trusted have it by default',
+  [SECURITY_PERMISSIONS.bypassGitRemoteTainted]:
+    'only owner has it by default (trusted intentionally does not, so the two-step taint defense still fires)',
   [SECURITY_PERMISSIONS.bypassSecretExfilRead]: 'only owner has it by default',
   [SECURITY_PERMISSIONS.bypassSsrf]: 'only owner has it by default',
   [SECURITY_PERMISSIONS.bypassSessionSearchSecrets]: 'only owner has it by default',

--- a/src/permissions/builtins.test.ts
+++ b/src/permissions/builtins.test.ts
@@ -20,8 +20,13 @@ describe('built-in role contract', () => {
     expect([...BUILTIN_ROLES.trusted.permissions].sort()).toEqual([
       'channel.respond',
       'cron.schedule',
+      'security.bypass.gitExfil',
       'security.bypass.secretExfilBash',
     ])
+  })
+
+  test('trusted does NOT carry security.bypass.gitRemoteTainted (two-step defense stays for trusted)', () => {
+    expect([...BUILTIN_ROLES.trusted.permissions]).not.toContain('security.bypass.gitRemoteTainted')
   })
 
   test('member has empty default match and only channel.respond', () => {

--- a/src/permissions/builtins.ts
+++ b/src/permissions/builtins.ts
@@ -37,7 +37,12 @@ export const BUILTIN_ROLES: Readonly<Record<BuiltinRoleName, BuiltinRoleSpec>> =
   },
   trusted: {
     match: [],
-    permissions: [CORE_PERMISSIONS.channelRespond, CORE_PERMISSIONS.cronSchedule, 'security.bypass.secretExfilBash'],
+    permissions: [
+      CORE_PERMISSIONS.channelRespond,
+      CORE_PERMISSIONS.cronSchedule,
+      'security.bypass.secretExfilBash',
+      'security.bypass.gitExfil',
+    ],
   },
   member: {
     match: [],

--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -61,7 +61,7 @@ describe('PermissionService — defaults', () => {
 })
 
 describe('PermissionService — user-declared roles', () => {
-  test('trusted role with channel match grants channel.respond + the trusted bypass', () => {
+  test('trusted role with channel match grants channel.respond + the trusted bypasses', () => {
     const roles = parseRoles({
       trusted: { match: ['slack:T0123 author:U_ME'] },
     })
@@ -69,7 +69,8 @@ describe('PermissionService — user-declared roles', () => {
     expect(svc.resolveRole(slackOwnerChat)).toBe('trusted')
     expect(svc.has(slackOwnerChat, 'channel.respond')).toBe(true)
     expect(svc.has(slackOwnerChat, 'security.bypass.secretExfilBash')).toBe(true)
-    expect(svc.has(slackOwnerChat, 'security.bypass.gitExfil')).toBe(false)
+    expect(svc.has(slackOwnerChat, 'security.bypass.gitExfil')).toBe(true)
+    expect(svc.has(slackOwnerChat, 'security.bypass.gitRemoteTainted')).toBe(false)
   })
 
   test('stranger in same chat does not match author rule → guest', () => {

--- a/src/skills/typeclaw-permissions/SKILL.md
+++ b/src/skills/typeclaw-permissions/SKILL.md
@@ -24,7 +24,7 @@ You always have these four, even if `typeclaw.json` declares zero `roles`. User-
 | Role      | Built-in `match[]`                                                | Default `permissions[]`                                                                                                   |
 | --------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `owner`   | `["tui"]` (always prepended)                                      | `channel.respond`, `cron.schedule`, `cron.modify`, **all `security.bypass.*` contributed by plugins** (wildcard sentinel) |
-| `trusted` | none                                                              | `channel.respond`, `cron.schedule`, `security.bypass.secretExfilBash`                                                     |
+| `trusted` | none                                                              | `channel.respond`, `cron.schedule`, `security.bypass.secretExfilBash`, `security.bypass.gitExfil`                         |
 | `member`  | none                                                              | `channel.respond`                                                                                                         |
 | `guest`   | none (fallback when nothing else matches, or stamped role is bad) | none                                                                                                                      |
 
@@ -82,7 +82,7 @@ Three sources contribute permission strings:
 2. **Bundled security plugin** (always loaded): `security.bypass.secretExfilBash`, `security.bypass.gitExfil`, `security.bypass.gitRemoteTainted`, `security.bypass.secretExfilRead`, `security.bypass.ssrf`, `security.bypass.sessionSearchSecrets`, `security.bypass.systemPromptLeak`, `security.bypass.outboundSecret`.
 3. **User-declared plugins** (variable): each plugin can contribute its own strings via `definePlugin({ permissions: [...] })`.
 
-`owner` carries every `security.bypass.*` from sources 2 and 3 by default (via a wildcard sentinel expanded at boot). `trusted` carries only `security.bypass.secretExfilBash` by default. `member` and `guest` carry no `security.bypass.*` strings.
+`owner` carries every `security.bypass.*` from sources 2 and 3 by default (via a wildcard sentinel expanded at boot). `trusted` carries `security.bypass.secretExfilBash` and `security.bypass.gitExfil` by default (so a trusted actor can run dangerous bash and `git push` without per-call acks) but **deliberately not** `security.bypass.gitRemoteTainted` — the two-step social-attack defense (re-point remote, then push to it) still fires for trusted, so a prompt-injection mid-session that swaps the remote URL still blocks the eventual push. `member` and `guest` carry no `security.bypass.*` strings.
 
 User-declared `permissions[]` strings that don't appear in any of the three sources are **logged as warnings at boot** (`[permissions] role "X" declares unknown permission "Y" — did you mean 'Z'?`) but the role still resolves with the unknown string in its list. This is intentional — the runtime is forward-compatible with strings from plugins that aren't loaded yet — but it also means typos silently fail to bypass guards. If you wrote `security.bypass.secretExfilBach` instead of `Bash`, no guard will be skipped and you will only notice when you read the boot logs.
 
@@ -94,7 +94,8 @@ The security plugin's `tool.before` hook produces block messages of the form:
 Guard `<guardName>` blocked <what>. If this is genuinely intentional and the user
 explicitly asked for it, retry with `acknowledgeGuards.<guardName>: true` in the
 <tool> arguments. Or run as a role carrying `<permission>` (owner has all
-security.bypass.*; trusted has security.bypass.secretExfilBash).
+security.bypass.*; trusted has security.bypass.secretExfilBash and
+security.bypass.gitExfil — but not gitRemoteTainted).
 ```
 
 Three escape hatches, ordered from least to most invasive:
@@ -120,7 +121,7 @@ To distinguish cause 1/2 from cause 3: if `typeclaw logs <container> -f` (host s
 This is a `roles` edit. The full procedure:
 
 1. **Resolve the coordinates.** Get the platform name (`slack | discord | telegram | kakao`), the workspace ID, the chat ID. If the user gave you names, ask them or look them up in the participants list of a previous inbound from that channel.
-2. **Pick a role.** Default to `member` for "give them normal channel access". Use `trusted` if they should also be able to schedule cron and bypass the bash secret guard. Only use `owner` if they should have full bypass on every security guard — typically the agent's primary operator.
+2. **Pick a role.** Default to `member` for "give them normal channel access". Use `trusted` if they should also be able to schedule cron, bypass the bash secret guard, and run `git push` / `git remote add` / `git add -f` without per-call acks (the two-step taint defense still fires for trusted so a mid-session remote re-point still blocks the eventual push). Only use `owner` if they should have full bypass on every security guard, including the taint defense — typically the agent's primary operator.
 3. **Edit `typeclaw.json` `roles.<role>.match[]`.** Append the canonical DSL string. Example: `roles.member.match` adds `"slack:T0123/C0ABCDE"`. If the user wants only a specific person in that channel, append `slack:T0123/C0ABCDE author:U_ME` instead.
 4. **Restart.** `roles` is **restart-required** — `typeclaw reload` does not re-evaluate role config. Tell the user: "edited `roles.<role>.match` — restart-required. Run `typeclaw restart` (host stage)."
 5. **Commit the change.** See the `typeclaw-git` skill. The decision context in the commit message should name the role, the channel, and the author/scope ("let @X talk to me as `member` in #foo in workspace bar").


### PR DESCRIPTION
## Summary

Earlier conversation history: the `gitExfil` guard (added before the permission system existed) blocks `git push`, `git remote set-url`, `git add -f`, `gh repo create --push`, etc. with a per-call `acknowledgeGuards.gitExfil: true` escape hatch. That escape hatch is **agent-self-acked**: a prompt-injected channel message can talk the LLM into setting the flag, which is the original breach shape. Adding another bit to the bash args adds no human in the loop.

The permission system that landed later is the right control surface. It gates by **actor origin**, stamped from the inbound coordinates before any LLM token runs — prompt injection cannot acquire a permission the origin doesn't carry. Today the built-in roles distribute `security.bypass.*` like this:

- `owner` — wildcard, everything (TUI is owner by default, so the guards never fire for the operator at the keyboard).
- `trusted` — `security.bypass.secretExfilBash` only.
- `member` — nothing.
- `guest` — nothing.

So a trusted Slack author can `cat .env` and `env | grep KEY` (which leaks plaintext API keys), but cannot `git push` (which leaks gitignore-filtered tracked content). That's inconsistent — pushing a repo is *less* dangerous than dumping env vars — and the inconsistency manifests as constant per-call ack noise in trusted DMs.

This PR adds `security.bypass.gitExfil` to the `trusted` role's default permission list. Operators opt a channel author or DM into `trusted` by adding a match rule to `roles.trusted.match[]` in `typeclaw.json`. No new role, no new permission string, no code in `git-exfil.ts`.

## Why not `security.bypass.gitRemoteTainted` too?

The two-step social-attack defense (re-point remote, then push to the re-pointed remote — each step looks reasonable in isolation) is the load-bearing piece of the guard. Trusted is trusted enough to push, but not trusted enough to escape a mid-session prompt-injection that swaps the remote URL. So `trusted` deliberately carries `bypassGitExfil` but **not** `bypassGitRemoteTainted` — a re-point inside a trusted session still records taint, and the subsequent push still blocks.

This asymmetry is already covered by an existing regression test in `src/bundled-plugins/security/index.test.ts:310` (`permissions: actor with bypassGitExfil but NOT bypassGitRemoteTainted still has taint recorded and is caught on step 2`). That test was aspirational; it now describes a default.

## Changes

| File | Change |
|------|--------|
| `src/permissions/builtins.ts` | Add `'security.bypass.gitExfil'` to `BUILTIN_ROLES.trusted.permissions`. |
| `src/permissions/builtins.test.ts` | Update the `trusted` permissions assertion; add a pin asserting `gitRemoteTainted` is NOT included (defends the two-step-defense invariant against future "consolidate the bypass set" PRs). |
| `src/permissions/permissions.test.ts` | Invert the assertion at line 72 (`bypassGitExfil` is now expected `true` for trusted); add a sibling assertion that `bypassGitRemoteTainted` is still `false`. |
| `src/bundled-plugins/security/index.ts` | Update the `BYPASS_ROLE_HINT` strings for `gitExfil` ("owner and trusted have it by default") and `gitRemoteTainted` ("only owner has it by default (trusted intentionally does not, so the two-step taint defense still fires)") so the block-message text matches reality. |
| `src/skills/typeclaw-permissions/SKILL.md` | Update the role table, the per-permission-string defaults paragraph, the canned block-message example, and the "Pick a role" guidance. |

Diff stat: 5 files, +22/-9.

## What this PR is NOT doing

- Not adding a new permission string. `security.bypass.gitExfil` already exists; it's just being granted to a role that didn't previously carry it.
- Not adding a new role. `trusted` is one of the four built-ins.
- Not changing `git-exfil.ts` at all. The guard logic, the taint store, the per-segment shell walker, the URL sanitization — all untouched.
- Not loosening anything for `member`, `guest`, or unmatched authors. Those still block on `gitExfil` exactly as before. The change is opt-in via `roles.trusted.match[]`.

## Pre-commit checks (verified, all clean)

- `bun run typecheck` — 0 errors
- `bun run lint` — 0 errors (16 pre-existing warnings, all unrelated)
- `bun run format` — clean
- `bun test` — 3896 pass / 0 fail across 232 files

## Relationship to #238

#238 (now closed) tried to scope the loosening to a target directory (`/agent/workspace/`, `/agent/mounts/`) via a `cd` / `git -C` walker. That was the wrong axis — see the close comment on #238 for the threat-model explanation. This PR replaces the directory-based loosening with a role-based one.
