### PR TITLE
cli: surface host/agent version mismatch to users

### DIFF
--- a/src/cli/tui.ts
+++ b/src/cli/tui.ts
@@ -2,7 +2,8 @@ import { defineCommand } from 'citty'
 
 import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/container'
 import { findAgentDir } from '@/init'
-import { createTui } from '@/tui'
+import { CLI_VERSION } from '@/init/cli-version'
+import { createTui, formatVersionMismatchWarning } from '@/tui'
 
 import { errorLine } from './ui'
 
@@ -25,7 +26,14 @@ export const tui = defineCommand({
   },
   async run({ args }) {
     const url = args.url ?? (await defaultUrl())
-    const tui = createTui({ url, initialPrompt: args.prompt })
+    const tui = createTui({
+      url,
+      ...(args.prompt !== undefined ? { initialPrompt: args.prompt } : {}),
+      expectedVersion: CLI_VERSION,
+      onVersionMismatch: (info) => {
+        process.stderr.write(`${formatVersionMismatchWarning(info)}\n`)
+      },
+    })
     await tui.run()
   },
 })

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -105,6 +105,7 @@ async function startWithSession(
     logger?: ServerLogger
     commandRunnerFactory?: (outbound: CommandOutbound) => CommandRunner
     tunnelManager?: TunnelManager
+    runtimeVersion?: string
   } = {},
 ): Promise<{ url: string }> {
   const pluginRuntime =
@@ -121,6 +122,7 @@ async function startWithSession(
     ...(extra.logger ? { logger: extra.logger } : {}),
     ...(extra.commandRunnerFactory ? { commandRunnerFactory: extra.commandRunnerFactory } : {}),
     ...(extra.tunnelManager ? { tunnelManager: extra.tunnelManager } : {}),
+    ...(extra.runtimeVersion !== undefined ? { runtimeVersion: extra.runtimeVersion } : {}),
   }).start()
   server = built
   return { url: `ws://localhost:${built.port}` }
@@ -516,6 +518,38 @@ describe('createServer session persistence wiring', () => {
     if (connected.type !== 'connected') throw new Error('unreachable')
     expect(connected.sessionId).toBeDefined()
     expect(connected.sessionId.length).toBeGreaterThan(0)
+
+    ws.close()
+  })
+
+  test('connected message carries the configured runtimeVersion as serverVersion', async () => {
+    // given
+    const session = createFakeSession()
+    const { url } = await startWithSession(session, { runtimeVersion: '9.9.9-test' })
+
+    // when
+    const { ws, waitFor } = await connect(url)
+    const connected = await waitFor((m) => m.type === 'connected')
+
+    // then
+    if (connected.type !== 'connected') throw new Error('unreachable')
+    expect(connected.serverVersion).toBe('9.9.9-test')
+
+    ws.close()
+  })
+
+  test('connected message omits serverVersion when runtimeVersion is not configured', async () => {
+    // given
+    const session = createFakeSession()
+    const { url } = await startWithSession(session)
+
+    // when
+    const { ws, waitFor } = await connect(url)
+    const connected = await waitFor((m) => m.type === 'connected')
+
+    // then
+    if (connected.type !== 'connected') throw new Error('unreachable')
+    expect(connected.serverVersion).toBeUndefined()
 
     ws.close()
   })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -402,7 +402,11 @@ export function createServer({
               })
             }
 
-            send(ws, { type: 'connected', sessionId: sessionFileId })
+            send(ws, {
+              type: 'connected',
+              sessionId: sessionFileId,
+              ...(runtimeVersion !== undefined ? { serverVersion: runtimeVersion } : {}),
+            })
             console.log(`session ${sessionFileId}: open`)
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err)

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -119,7 +119,11 @@ export type ClaimErrorPayload = {
 }
 
 export type ServerMessage =
-  | { type: 'connected'; sessionId: string }
+  // serverVersion is optional so an old CLI talking to a new server still
+  // parses cleanly. The server impl always emits it; consumers that care
+  // about host/agent skew (the TUI command in particular) read it to warn
+  // the user when their CLI is on a different version than the container.
+  | { type: 'connected'; sessionId: string; serverVersion?: string }
   | { type: 'text_delta'; delta: string }
   | { type: 'tool_start'; toolCallId: string; name: string; args: unknown }
   | { type: 'tool_end'; toolCallId: string; name: string; error: boolean; result: unknown; durationMs: number }

--- a/src/tui/index.test.ts
+++ b/src/tui/index.test.ts
@@ -5,7 +5,7 @@ import type { Terminal } from '@mariozechner/pi-tui'
 import type { ClientMessage, ServerMessage } from '@/shared'
 
 import { type Client } from './client'
-import { createTui } from './index'
+import { createTui, formatVersionMismatchWarning, type VersionMismatch } from './index'
 
 // oxlint-disable-next-line no-control-regex -- intentionally strips ESC and BEL from rendered ANSI/APC sequences
 const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, '').replace(/\x1b_[^\x07]*\x07/g, '')
@@ -642,5 +642,108 @@ describe('createTui queue panel', () => {
 
     client.triggerClose()
     await runPromise
+  })
+
+  test('invokes onVersionMismatch and renders a warning when serverVersion differs from expectedVersion', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-mismatch', serverVersion: '0.3.1' })
+    const seen: VersionMismatch[] = []
+
+    // when
+    const tui = createTui({
+      url: 'ws://ignored',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+      expectedVersion: '0.3.2',
+      onVersionMismatch: (info) => seen.push(info),
+    })
+    const runPromise = tui.run()
+    await flush()
+    client.triggerClose()
+    await runPromise
+
+    // then
+    expect(seen).toEqual([{ expected: '0.3.2', actual: '0.3.1' }])
+    expect(terminal.visible()).toContain('host CLI is v0.3.2, agent container is v0.3.1')
+    expect(terminal.visible()).toContain('typeclaw restart --build')
+  })
+
+  test('skips the version warning when expectedVersion matches serverVersion', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-match', serverVersion: '0.3.2' })
+    const seen: VersionMismatch[] = []
+
+    // when
+    const tui = createTui({
+      url: 'ws://ignored',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+      expectedVersion: '0.3.2',
+      onVersionMismatch: (info) => seen.push(info),
+    })
+    const runPromise = tui.run()
+    await flush()
+    client.triggerClose()
+    await runPromise
+
+    // then
+    expect(seen).toEqual([])
+    expect(terminal.visible()).not.toContain('host CLI is v')
+  })
+
+  test('skips the version warning when the server omits serverVersion (old server)', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-old' })
+    const seen: VersionMismatch[] = []
+
+    // when
+    const tui = createTui({
+      url: 'ws://ignored',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+      expectedVersion: '0.3.2',
+      onVersionMismatch: (info) => seen.push(info),
+    })
+    const runPromise = tui.run()
+    await flush()
+    client.triggerClose()
+    await runPromise
+
+    // then
+    expect(seen).toEqual([])
+    expect(terminal.visible()).not.toContain('host CLI is v')
+  })
+
+  test('skips the version warning when expectedVersion is not configured (container-side local TUI)', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-noexpect', serverVersion: '0.3.1' })
+
+    // when
+    const tui = createTui({
+      url: 'ws://ignored',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+    })
+    const runPromise = tui.run()
+    await flush()
+    client.triggerClose()
+    await runPromise
+
+    // then
+    expect(terminal.visible()).not.toContain('host CLI is v')
+  })
+
+  test('formatVersionMismatchWarning renders the expected one-line warning', () => {
+    expect(formatVersionMismatchWarning({ expected: '1.2.3', actual: '1.2.0' })).toBe(
+      'WARN: host CLI is v1.2.3, agent container is v1.2.0. Some commands may hang or fail. Try `typeclaw restart --build`.',
+    )
   })
 })

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -9,6 +9,8 @@ export type TerminalFactory = () => Terminal
 
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 30_000
 
+export type VersionMismatch = { expected: string; actual: string }
+
 export type TuiOptions = {
   url: string
   initialPrompt?: string
@@ -16,6 +18,13 @@ export type TuiOptions = {
   createTerminal?: TerminalFactory
   handshakeTimeoutMs?: number
   exit?: (code: number) => void
+  // Locally-known typeclaw version the host CLI is running. When provided
+  // and the connected frame's serverVersion is defined and differs,
+  // onVersionMismatch is invoked AND a yellow warning line is rendered
+  // into the TUI history. The container-side local TUI omits this so no
+  // mismatch check fires when client and server are guaranteed in lockstep.
+  expectedVersion?: string
+  onVersionMismatch?: (info: VersionMismatch) => void
 }
 
 export function createTui({
@@ -25,6 +34,8 @@ export function createTui({
   createTerminal = () => new ProcessTerminal(),
   handshakeTimeoutMs = DEFAULT_HANDSHAKE_TIMEOUT_MS,
   exit = process.exit.bind(process),
+  expectedVersion,
+  onVersionMismatch,
 }: TuiOptions) {
   async function run(): Promise<void> {
     const terminal = createTerminal()
@@ -44,7 +55,7 @@ export function createTui({
       throw err
     })
 
-    const sessionId = await waitForConnected(client, displayUrl, handshakeTimeoutMs).catch((err) => {
+    const handshake = await waitForConnected(client, displayUrl, handshakeTimeoutMs).catch((err) => {
       status.setText(colors.red(`connection error: ${err instanceof Error ? err.message : String(err)}`))
       tui.requestRender()
       client.close()
@@ -52,6 +63,7 @@ export function createTui({
       exit(1)
       throw err
     })
+    const { sessionId, serverVersion } = handshake
     status.setText(colors.dim(`session: ${sessionId}`))
     tui.requestRender()
 
@@ -217,6 +229,14 @@ export function createTui({
     tui.setFocus(editor)
     tui.requestRender()
 
+    if (expectedVersion !== undefined && serverVersion !== undefined && serverVersion !== expectedVersion) {
+      const mismatch: VersionMismatch = { expected: expectedVersion, actual: serverVersion }
+      const warning = formatVersionMismatchWarning(mismatch)
+      appendHistory(new Text(colors.yellow(warning), 0, 0))
+      tui.requestRender()
+      onVersionMismatch?.(mismatch)
+    }
+
     if (initialPrompt) {
       await send(initialPrompt)
     }
@@ -238,8 +258,12 @@ function redactUrl(url: string): string {
   }
 }
 
-async function waitForConnected(client: Client, url: string, timeoutMs: number): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
+async function waitForConnected(
+  client: Client,
+  url: string,
+  timeoutMs: number,
+): Promise<{ sessionId: string; serverVersion?: string }> {
+  return await new Promise<{ sessionId: string; serverVersion?: string }>((resolve, reject) => {
     const timer = setTimeout(() => {
       cleanup()
       reject(new Error(`timed out waiting for connected message from ${url} after ${timeoutMs}ms`))
@@ -253,7 +277,10 @@ async function waitForConnected(client: Client, url: string, timeoutMs: number):
       client.onMessage((msg) => {
         if (msg.type === 'connected') {
           cleanup()
-          resolve(msg.sessionId)
+          resolve({
+            sessionId: msg.sessionId,
+            ...(msg.serverVersion !== undefined ? { serverVersion: msg.serverVersion } : {}),
+          })
         }
         if (msg.type === 'error') {
           cleanup()
@@ -274,4 +301,8 @@ async function waitForConnected(client: Client, url: string, timeoutMs: number):
       }),
     )
   })
+}
+
+export function formatVersionMismatchWarning({ expected, actual }: VersionMismatch): string {
+  return `WARN: host CLI is v${expected}, agent container is v${actual}. Some commands may hang or fail. Try \`typeclaw restart --build\`.`
 }


### PR DESCRIPTION
## The trap

During PR #243 ("tunnels: cloudflare-quick provider") dogfooding, `typeclaw tunnel list` hung silently for 15 seconds. The running container had stale typeclaw source — Bun's `file:`-dep install treats name+version as a cache hit even when source changes, so the in-container server didn't have the new `tunnel_list_request` handler. The message hit the server's switch-default and was dropped. The CLI waited for a response that would never arrive.

Any CLI command added across a version boundary hits the same trap. PR B (forthcoming) fixes the underlying cache-bust; this PR makes the symptom obvious instead of mysterious.

## Design

**Protocol (`src/shared/protocol.ts`):** `serverVersion: string` added to the `connected` frame as an optional field. Old CLIs talking to new servers still parse cleanly; the field is just absent to them.

**Server (`src/server/index.ts`):** When `runtimeVersion` is configured (always in production, wired from `CLI_VERSION` in `src/run/index.ts`), the server spreads it into the `connected` payload. Tests that omit `runtimeVersion` continue to emit a valid frame without the field — no existing test sites broken.

**TUI (`src/tui/index.ts`):** `createTui` accepts opt-in `expectedVersion` + `onVersionMismatch`. On mismatch: a yellow warning line lands in TUI history ("WARN: host CLI is vX, agent container is vY. Some commands may hang or fail. Try `typeclaw restart --build`.") and `onVersionMismatch` fires. `waitForConnected`'s return type is widened to expose `serverVersion` to callers without breaking any of the 18 existing `fakeClient` emit sites.

**CLI (`src/cli/tui.ts`):** `typeclaw tui` passes `CLI_VERSION` as `expectedVersion` and wires `onVersionMismatch` to a stderr write. The container-side local TUI in `src/run/index.ts` deliberately omits the option — client and server are always in lockstep there, and we don't want false-positive warnings.

## Why only `typeclaw tui` for now

Only `typeclaw tui` awaits the `connected` frame. Other CLI commands (`tunnel list/status/logs`, `cron list`, `doctor`, `shell`) fire typed request/response RPCs and never see the handshake. Teaching each call site to await it first would be a larger refactor. The TUI is the most common interactive entry point and the natural home for this check. `formatVersionMismatchWarning` is exported so other commands can grow handshake awareness later.

## Verification

```
bun run typecheck   clean
bun run lint        0 errors
bun run format      clean
bun test            3984 pass / 0 fail
```

2 new server tests (emits configured `runtimeVersion`; omits when unset), 5 new TUI tests (mismatch → warning + callback; match → silent; missing `serverVersion` → silent; no `expectedVersion` → silent; format shape). 51 server tests and 20 TUI tests pass.

## Follow-up

PR B will address the root cause: `typeclaw start` with a `file:`/`link:` typeclaw dep will force-reinstall to bust Bun's version-cache. Once that lands, the scenario that motivated this warning becomes uncommon in practice.