### PR TITLE
dockerfile: default cloudflared to true

### DIFF
--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -326,7 +326,7 @@ describe('docker.file schema', () => {
     python: true,
     tmux: true,
     cjkFonts: true,
-    cloudflared: false,
+    cloudflared: true,
     append: [],
   }
 
@@ -366,7 +366,7 @@ describe('docker.file schema', () => {
       python: true,
       tmux: false,
       cjkFonts: true,
-      cloudflared: false,
+      cloudflared: true,
       append: [],
     })
   })
@@ -391,9 +391,9 @@ describe('docker.file schema', () => {
     ).toThrow()
   })
 
-  test('cloudflared defaults to false so non-tunnel users skip the image layer', () => {
+  test('cloudflared defaults to true so cloudflare-quick tunnels work on the next start without a separate Dockerfile edit', () => {
     const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
-    expect(parsed.docker.file.cloudflared).toBe(false)
+    expect(parsed.docker.file.cloudflared).toBe(true)
   })
 
   test('cloudflared: true is honored and merges with other defaults', () => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -98,8 +98,11 @@ const dockerfileObjectSchema = z.object({
   // practical value.
   cjkFonts: z.boolean().default(true),
   // Opt into the cloudflared layer for `cloudflare-quick` tunnels. Default
-  // false so non-tunnel users pay zero image-size cost.
-  cloudflared: z.boolean().default(false),
+  // `true` so `tunnel add` / `channel add github` with the default Cloudflare
+  // Quick provider works on the next `start` without a separate Dockerfile
+  // edit. Opt-out with `cloudflared: false` to skip the ~35MB binary on
+  // agents that don't use tunnels.
+  cloudflared: z.boolean().default(true),
   append: z.array(dockerfileLineSchema).default([]),
 })
 

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -257,7 +257,14 @@ describe('cloudflared layer', () => {
     const out = buildDockerfile(dockerfileSchema.parse({ cloudflared: false }))
 
     expect(out).not.toContain('cloudflared-linux-')
-    expect(out).toBe(buildDockerfile())
+    expect(out).not.toContain('/usr/local/bin/cloudflared --version')
+  })
+
+  test('default config includes the cloudflared layer (default flipped to true so cloudflare-quick tunnels work out of the box)', () => {
+    const out = buildDockerfile()
+
+    expect(out).toContain(`${CLOUDFLARED_RELEASE_URL_BASE}/${CLOUDFLARED_VERSION}/cloudflared-linux-`)
+    expect(out).toContain('/usr/local/bin/cloudflared --version')
   })
 
   test('cloudflared layer appears after curl-impersonate and before the entrypoint shim', () => {
@@ -375,7 +382,10 @@ describe('versioned per-agent Dockerfile (base-image-pinning)', () => {
     const out = buildDockerfile(dockerfileSchema.parse({}), { baseImageVersion: '0.1.1' })
 
     // then: no curl-impersonate download, no agent-browser install, no Chrome download
-    expect(countRunBlocksMatching(out, /curl-impersonate|sha256sum/)).toBe(0)
+    // (cloudflared is intentionally NOT part of the prebuilt base image because it is
+    // gated by docker.file.cloudflared; the per-agent versioned Dockerfile still emits
+    // it when the toggle is on, so this regex deliberately excludes its sha256sum line)
+    expect(countRunBlocksMatching(out, /curl-impersonate/)).toBe(0)
     expect(countRunBlocksMatching(out, /bun install -g agent-browser/)).toBe(0)
     expect(countRunBlocksMatching(out, /agent-browser install --with-deps/)).toBe(0)
     expect(countRunBlocksMatching(out, /apt-keep-cache|Keep-Downloaded-Packages/)).toBe(0)

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -616,7 +616,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\
     fi`
 
 function defaultConfig(): DockerfileConfig {
-  return { ffmpeg: false, gh: true, python: true, tmux: true, cjkFonts: true, cloudflared: false, append: [] }
+  return { ffmpeg: false, gh: true, python: true, tmux: true, cjkFonts: true, cloudflared: true, append: [] }
 }
 
 function collectToggleAptArgs(config: DockerfileConfig): string[] {


### PR DESCRIPTION
## Summary

`docker.file.cloudflared` controls whether the per-agent Dockerfile gains a
cloudflared layer. It was introduced as an opt-in toggle (default `false`)
because `tunnel add` and `channel add github` with the Cloudflare Quick
provider already flip it to `true` before the next `typeclaw start`.

This PR flips the schema default to `true`.

## Why

Two gaps with the `false` default:

1. **Users who pick Cloudflare Quick** at a `tunnel add` / `channel add`
   prompt already get a correct image on the next `start` (the CLI writes
   `docker.file.cloudflared: true` to `typeclaw.json`). But they still see a
   Dockerfile rebuild step that is indistinguishable from the ordinary start
   rebuild.

2. **Hand-authored `typeclaw.json`** (adding `tunnels[]` directly without
   going through the CLI flow) gets a broken image on the first `start`
   because cloudflared is absent. The toggle has to be flipped manually before
   tunnels work.

Defaulting to `true` fixes both: cloudflared is present in the image from the
very first `start`, the CLI's explicit write-through is now redundant (but
still correct), and hand-authored tunnel configs work out of the box.

The ~35 MB image-size cost is the price of admission. Operators who don't use
tunnels and care about image size can opt out with `"docker.file.cloudflared": false` in `typeclaw.json`.

## Changes

| File | Change |
|------|--------|
| `src/config/config.ts` | Flip schema default to `true`; update inline rationale comment. |
| `src/init/dockerfile.ts` | Flip `defaultConfig()` constant to match the schema (used by code paths that bypass schema defaulting). |
| `src/config/config.test.ts` | Update `FULL_DEFAULTS` (two places); rename the `"defaults to false"` test to `"defaults to true"`. |
| `src/init/dockerfile.test.ts` | See note below. |

**`src/init/dockerfile.test.ts` details:**

- Replace the now-incorrect equality assertion (which assumed the default omitted the
  cloudflared layer) with a behavioral assertion that `cloudflared: false` omits the
  cloudflared verify line.
- Add a new test pinning the new default: `buildDockerfile()` with no args includes
  the cloudflared layer.
- Tighten the "heavy stack lives in the base image" regex from
  `/curl-impersonate|sha256sum/` to `/curl-impersonate/`. The cloudflared layer emits
  its own `sha256sum` verify line when the toggle is on, and this regex was the only
  test that broke on the flip.

`typeclaw.schema.json` is gitignored and regenerated by `postinstall`, so no
schema commit is needed; the existing drift-guard test in
`scripts/generate-schema.test.ts` continues to pass.

Three downstream assertions that already verify `cloudflared === true` after
the CLI flow (`src/init/add-channel.test.ts`, `src/init/index.test.ts`,
`src/cli/tunnel.test.ts`) remain green — they are now redundant with the
schema default but still correctly test the CLI's explicit write-through.

## Verification

```
bun run typecheck   ✓  clean
bun run lint        ✓  0 errors (16 pre-existing warnings, unrelated)
bun run format      ✓  clean
bun test            ✓  3978 pass / 0 fail  (was 3977 pass / 1 fail before the dockerfile.test.ts regex fix)
```