### PR TITLE
channels: make github webhook registration eager and observable

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -28,6 +28,12 @@ export type GithubAdapterOptions = {
   fetchImpl?: typeof fetch
   httpListenImpl?: (port: number, handler: (req: Request) => Promise<Response>) => { stop: () => Promise<void> }
   tunnelUrl?: () => string | null
+  // Whether a channel-bound tunnel exists in typeclaw.json#tunnels[] for the
+  // github channel. Used to distinguish "no tunnel configured (operator opted
+  // out)" from "tunnel configured but not producing a URL (something is
+  // wrong)" so the skip-registration log can be precise and actionable.
+  // Optional so tests that don't exercise the tunnel-status path can omit it.
+  tunnelConfiguredForChannel?: () => boolean
 }
 
 export type GithubAdapter = {
@@ -145,9 +151,10 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
       }
       const effectiveUrl = cfg.webhookUrl ?? tunnelUrl
       if (effectiveUrl === null) {
-        logger.info(
-          '[github] no webhookUrl configured and no tunnel URL available; channel is up but webhook registration is skipped',
-        )
+        logSkippedRegistration(logger, {
+          tunnelConfigured: options.tunnelConfiguredForChannel?.() ?? false,
+          reposCount: repos.length,
+        })
       } else if (repos.length > 0) {
         const registration = await registerGithubWebhooks({
           token: tokenFn,
@@ -201,6 +208,29 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
 function listenWithBun(port: number, handler: (req: Request) => Promise<Response>): { stop: () => Promise<void> } {
   const server = Bun.serve({ port, fetch: handler })
   return { stop: async () => server.stop() }
+}
+
+function logSkippedRegistration(
+  logger: GithubAdapterLogger,
+  context: { tunnelConfigured: boolean; reposCount: number },
+): void {
+  if (context.reposCount === 0) {
+    logger.info('[github] no repos[] configured; webhook registration skipped')
+    return
+  }
+  if (context.tunnelConfigured) {
+    logger.warn(
+      '[github] webhook registration SKIPPED: a tunnel is configured for this channel but produced no URL yet. ' +
+        "Check `typeclaw tunnel status` for the tunnel's health (cloudflared binary missing, " +
+        'auth failure, network issue). Webhook delivery will not work until the tunnel produces a public URL.',
+    )
+    return
+  }
+  logger.warn(
+    '[github] webhook registration SKIPPED: no `channels.github.webhookUrl` set and no `tunnels[]` entry ' +
+      'binds a public URL to this channel. Add an entry to `tunnels[]` (e.g. `provider: "cloudflare-quick"`) ' +
+      'or set `channels.github.webhookUrl` to a public URL to enable webhook delivery.',
+  )
 }
 
 function logRegistrationOutcome(logger: GithubAdapterLogger, result: WebhookRegistrationResult): void {

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -204,7 +204,7 @@ describe('createGithubAdapter lifecycle', () => {
     )
   })
 
-  test('start() skips webhook registration when no effective URL is available', async () => {
+  test('start() skips webhook registration (no tunnel configured) with an actionable WARN, not a quiet INFO', async () => {
     const logger = recordingLogger()
     const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
       if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
@@ -219,15 +219,73 @@ describe('createGithubAdapter lifecycle', () => {
       logger,
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      tunnelConfiguredForChannel: () => false,
     })
 
     await adapter.start()
     await adapter.stop()
 
     expect(calls.some((c) => c.url.includes('/hooks'))).toBe(false)
-    expect(logger.messages).toContain(
-      'info:[github] no webhookUrl configured and no tunnel URL available; channel is up but webhook registration is skipped',
-    )
+    const skipMsg = logger.messages.find((m) => m.includes('webhook registration SKIPPED'))
+    expect(skipMsg).toBeDefined()
+    expect(skipMsg).toContain('warn:')
+    expect(skipMsg).toContain('no `channels.github.webhookUrl` set and no `tunnels[]` entry')
+    expect(skipMsg).toContain('cloudflare-quick')
+  })
+
+  test('start() skips webhook registration (tunnel configured but URL not ready) names the tunnel as the failure surface', async () => {
+    const logger = recordingLogger()
+    const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
+      if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig(['acme/widgets'], null),
+      secrets: patSecrets(),
+      agentDir: '/tmp/agent',
+      logger,
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      tunnelUrl: () => null,
+      tunnelConfiguredForChannel: () => true,
+    })
+
+    await adapter.start()
+    await adapter.stop()
+
+    expect(calls.some((c) => c.url.includes('/hooks'))).toBe(false)
+    const skipMsg = logger.messages.find((m) => m.includes('webhook registration SKIPPED'))
+    expect(skipMsg).toBeDefined()
+    expect(skipMsg).toContain('warn:')
+    expect(skipMsg).toContain('tunnel is configured for this channel but produced no URL yet')
+    expect(skipMsg).toContain('typeclaw tunnel status')
+  })
+
+  test('start() emits a quiet INFO (not WARN) when no repos are configured — there is nothing to register', async () => {
+    const logger = recordingLogger()
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig([], null),
+      secrets: patSecrets(),
+      agentDir: '/tmp/agent',
+      logger,
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      tunnelConfiguredForChannel: () => true,
+    })
+
+    await adapter.start()
+    await adapter.stop()
+
+    expect(logger.messages).toContain('info:[github] no repos[] configured; webhook registration skipped')
+    expect(logger.messages.some((m) => m.includes('warn:[github] webhook registration SKIPPED'))).toBe(false)
   })
 
   test('stop() deletes every hook registered by start() (detach on close)', async () => {

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -286,6 +286,61 @@ describe('channel manager — restartAdapter serialization', () => {
     expect(captured?.tunnelUrl?.()).toBe('https://x.trycloudflare.com')
     await mgr.stop()
   })
+
+  test('passes tunnelConfiguredForChannel through to the github adapter', async () => {
+    cfg.github = enabledGithubCfg()
+    await writeGithubSecrets(agentDir)
+    let captured: { tunnelConfiguredForChannel?: () => boolean } | undefined
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      tunnelConfiguredForChannel: (name) => name === 'github',
+      createGithubAdapter: (opts) => {
+        captured = opts
+        return makeFakeAdapter()
+      },
+    })
+
+    await mgr.start()
+
+    expect(captured?.tunnelConfiguredForChannel?.()).toBe(true)
+    await mgr.stop()
+  })
+
+  test("accepts GitHub App auth in secrets.json (regression: runtime guard previously rejected type: 'app')", async () => {
+    cfg.github = enabledGithubCfg()
+    await writeFile(
+      join(agentDir, 'secrets.json'),
+      JSON.stringify({
+        version: 2,
+        providers: {},
+        channels: {
+          github: {
+            auth: {
+              type: 'app',
+              appId: 12345,
+              privateKey: { value: '-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----' },
+            },
+            webhookSecret: { value: 'wh-secret' },
+          },
+        },
+      }),
+    )
+    let constructed = false
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      createGithubAdapter: () => {
+        constructed = true
+        return makeFakeAdapter()
+      },
+    })
+
+    await mgr.start()
+
+    expect(constructed).toBe(true)
+    await mgr.stop()
+  })
 })
 
 describe('channel manager — slack adapter lifecycle', () => {

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -72,6 +72,12 @@ export type ChannelManagerOptions = {
   // src/run/index.ts). Tests typically omit it.
   claimHandler?: ClaimHandler
   tunnelUrlForChannel?: (channelName: string) => string | null
+  // Whether the user declared a `tunnels[]` entry bound to this channel.
+  // Lets channel-bound adapters distinguish "operator opted out of public
+  // webhook delivery" from "operator opted in but the tunnel never produced
+  // a URL" so error logs can be precise. Same shape as
+  // `tunnelUrlForChannel` for consistency. Optional for tests.
+  tunnelConfiguredForChannel?: (channelName: string) => boolean
 }
 
 export type ChannelManager = {
@@ -185,6 +191,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         agentDir: options.agentDir,
         logger,
         tunnelUrl: () => options.tunnelUrlForChannel?.('github') ?? null,
+        tunnelConfiguredForChannel: () => options.tunnelConfiguredForChannel?.('github') ?? false,
       })
     }
     if (name === 'telegram-bot') {
@@ -374,12 +381,9 @@ function isGithubSecretsBlock(value: unknown): value is GithubSecretsBlock {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
   const record = value as Record<string, unknown>
   const auth = record.auth
-  return (
-    typeof auth === 'object' &&
-    auth !== null &&
-    !Array.isArray(auth) &&
-    (auth as Record<string, unknown>).type === 'pat'
-  )
+  if (typeof auth !== 'object' || auth === null || Array.isArray(auth)) return false
+  const authType = (auth as Record<string, unknown>).type
+  return authType === 'pat' || authType === 'app'
 }
 
 function isKakaoCredentialBlock(value: unknown): value is { accounts: Record<string, unknown> } {

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -9,6 +9,7 @@ import { start, status, stop } from '@/container'
 import {
   CHANNEL_KINDS,
   findAgentDir,
+  formatEagerGithubWebhookInstallResult,
   isInitialized,
   readConfiguredChannels,
   runAddChannel,
@@ -736,6 +737,9 @@ function reportProgress(events: AddChannelStepEvent[]): (event: AddChannelStepEv
       case 'secrets':
         s.stop('Saved credentials to secrets.json.')
         break
+      case 'github-webhooks':
+        s.stop(formatEagerGithubWebhookInstallResult(event.result))
+        break
     }
   }
 }
@@ -744,6 +748,7 @@ const START_MESSAGES: Record<AddChannelStepEvent['step'], string> = {
   'kakaotalk-auth': 'Logging in to KakaoTalk...',
   config: 'Updating typeclaw.json...',
   secrets: 'Saving credentials to secrets.json...',
+  'github-webhooks': 'Installing GitHub repository webhooks...',
 }
 
 function reportKakaotalkAuth(result: KakaotalkAuthResult): string {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -14,6 +14,7 @@ import {
 import type { DockerAvailability } from '@/container'
 import {
   findAgentDir,
+  formatEagerGithubWebhookInstallResult,
   hasExistingChannelSecrets,
   isDirectoryNonEmpty,
   isHatched,
@@ -1174,6 +1175,9 @@ function reportProgress(
       case 'kakaotalk-auth':
         s.stop(reportKakaotalkAuth(event.result))
         break
+      case 'github-webhooks':
+        s.stop(formatEagerGithubWebhookInstallResult(event.result))
+        break
       case 'oauth-login':
         s.stop(event.result.ok ? 'Logged in.' : `OAuth login failed: ${event.result.reason}`)
         break
@@ -1320,6 +1324,7 @@ const START_MESSAGES: Record<Exclude<InitStep, 'hatching'>, string> = {
   'oauth-login': 'Waiting for browser login...',
   scaffold: 'Laying the egg...',
   'kakaotalk-auth': 'Logging in to KakaoTalk...',
+  'github-webhooks': 'Installing GitHub repository webhooks...',
   install: 'Installing dependencies with bun...',
   dockerfile: 'Writing Dockerfile...',
   git: 'Initializing git repository...',

--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -45,6 +45,40 @@ async function readSecretsChannels(): Promise<Record<string, Record<string, unkn
   return (await readSecrets()).channels ?? {}
 }
 
+type RecordedCall = { url: string; method: string; body?: string }
+
+type RecordingGithubFetchOptions = {
+  onHookList?: (url: string) => Response
+  onHookCreate?: (url: string, body: string | undefined, index: number) => Response
+}
+
+function recordingGithubFetch(options: RecordingGithubFetchOptions = {}): {
+  fn: typeof fetch
+  calls: RecordedCall[]
+} {
+  const calls: RecordedCall[] = []
+  let createIndex = 0
+  const handler = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    const method = init?.method ?? 'GET'
+    const body = typeof init?.body === 'string' ? init.body : undefined
+    calls.push(body !== undefined ? { url, method, body } : { url, method })
+
+    if (url === 'https://api.github.com/user' && method === 'GET') {
+      return Response.json({ login: 'test-bot', id: 1 })
+    }
+    if (/\/repos\/[^/]+\/[^/]+\/hooks(\?|$)/.test(url) && method === 'GET') {
+      return options.onHookList ? options.onHookList(url) : Response.json([])
+    }
+    if (/\/repos\/[^/]+\/[^/]+\/hooks$/.test(url) && method === 'POST') {
+      if (options.onHookCreate) return options.onHookCreate(url, body, createIndex++)
+      return Response.json({ id: 100 + createIndex++ }, { status: 201 })
+    }
+    return new Response('unexpected', { status: 500 })
+  }
+  return { fn: Object.assign(handler, { preconnect: () => {} }) as typeof fetch, calls }
+}
+
 describe('runAddChannel', () => {
   test('adds discord-bot to typeclaw.json as an empty block (no allow field)', async () => {
     await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-token-x' })
@@ -240,8 +274,9 @@ describe('runAddChannel', () => {
     ])
   })
 
-  test('adds github channel: writes typeclaw.json (incl. repos[] and event allowlist), secrets.json, and match rules — no webhook side effect at add time', async () => {
+  test('adds github channel: writes typeclaw.json (incl. repos[] and event allowlist), secrets.json, and match rules', async () => {
     const events: AddChannelStepEvent[] = []
+    const fetchImpl = recordingGithubFetch()
 
     await runAddChannel({
       cwd: root,
@@ -252,6 +287,7 @@ describe('runAddChannel', () => {
       webhookUrl: 'https://agent.example.com/gh',
       webhookPort: 8975,
       repos: ['acme/widgets'],
+      fetchImpl: fetchImpl.fn,
       onProgress: (e) => events.push(e),
     })
 
@@ -289,7 +325,131 @@ describe('runAddChannel', () => {
       'config:done',
       'secrets:start',
       'secrets:done',
+      'github-webhooks:start',
+      'github-webhooks:done',
     ])
+  })
+
+  test('adds github channel (external): eagerly registers webhook with the github API using the provided URL and secret', async () => {
+    const events: AddChannelStepEvent[] = []
+    const fetchImpl = recordingGithubFetch()
+
+    await runAddChannel({
+      cwd: root,
+      channel: 'github',
+      auth: { type: 'pat', pat: 'ghp_test' },
+      webhookSecret: 'wh-secret-xyz',
+      tunnelProvider: 'external',
+      webhookUrl: 'https://agent.example.com/gh',
+      webhookPort: 8975,
+      repos: ['acme/widgets', 'acme/gadgets'],
+      fetchImpl: fetchImpl.fn,
+      onProgress: (e) => events.push(e),
+    })
+
+    const posts = fetchImpl.calls.filter((c) => c.method === 'POST' && c.url.endsWith('/hooks'))
+    expect(posts.map((p) => p.url)).toEqual([
+      'https://api.github.com/repos/acme/widgets/hooks',
+      'https://api.github.com/repos/acme/gadgets/hooks',
+    ])
+    for (const post of posts) {
+      const body = JSON.parse(post.body ?? '{}') as {
+        config?: { url?: string; secret?: string; content_type?: string }
+        events?: string[]
+        active?: boolean
+      }
+      expect(body.config?.url).toBe('https://agent.example.com/gh')
+      expect(body.config?.secret).toBe('wh-secret-xyz')
+      expect(body.config?.content_type).toBe('json')
+      expect(body.active).toBe(true)
+      expect(body.events).toContain('issue_comment')
+    }
+
+    const doneEvent = events.find(
+      (e): e is Extract<AddChannelStepEvent, { step: 'github-webhooks'; phase: 'done' }> =>
+        e.step === 'github-webhooks' && e.phase === 'done',
+    )
+    expect(doneEvent).toBeDefined()
+    expect(doneEvent!.result).toEqual({
+      repos: [
+        { repo: 'acme/widgets', action: 'created', hookId: 100 },
+        { repo: 'acme/gadgets', action: 'created', hookId: 101 },
+      ],
+    })
+  })
+
+  test('adds github channel (cloudflare-quick): does NOT eagerly register webhooks (URL is unknown until cloudflared boots)', async () => {
+    const events: AddChannelStepEvent[] = []
+    const fetchImpl = recordingGithubFetch()
+
+    await runAddChannel({
+      cwd: root,
+      channel: 'github',
+      auth: { type: 'pat', pat: 'ghp_test' },
+      webhookSecret: 'wh-secret',
+      tunnelProvider: 'cloudflare-quick',
+      webhookPort: 8975,
+      repos: ['acme/widgets'],
+      fetchImpl: fetchImpl.fn,
+      onProgress: (e) => events.push(e),
+    })
+
+    expect(fetchImpl.calls).toEqual([])
+    expect(events.some((e) => e.step === 'github-webhooks')).toBe(false)
+  })
+
+  test('adds github channel (none): does NOT eagerly register webhooks (no URL configured)', async () => {
+    const events: AddChannelStepEvent[] = []
+    const fetchImpl = recordingGithubFetch()
+
+    await runAddChannel({
+      cwd: root,
+      channel: 'github',
+      auth: { type: 'pat', pat: 'ghp_test' },
+      webhookSecret: 'wh-secret',
+      tunnelProvider: 'none',
+      webhookPort: 8975,
+      repos: ['acme/widgets'],
+      fetchImpl: fetchImpl.fn,
+      onProgress: (e) => events.push(e),
+    })
+
+    expect(fetchImpl.calls).toEqual([])
+    expect(events.some((e) => e.step === 'github-webhooks')).toBe(false)
+  })
+
+  test('github eager webhook install failure surfaces as a structured event but does NOT roll back the config/secrets writes', async () => {
+    const events: AddChannelStepEvent[] = []
+    const fetchImpl = recordingGithubFetch({
+      onHookList: () => new Response('forbidden', { status: 403 }),
+    })
+
+    await runAddChannel({
+      cwd: root,
+      channel: 'github',
+      auth: { type: 'pat', pat: 'ghp_test' },
+      webhookSecret: 'wh-secret',
+      tunnelProvider: 'external',
+      webhookUrl: 'https://agent.example.com/gh',
+      webhookPort: 8975,
+      repos: ['acme/widgets'],
+      fetchImpl: fetchImpl.fn,
+      onProgress: (e) => events.push(e),
+    })
+
+    const cfg = (await readConfig()) as { channels?: { github?: { repos?: string[] } } }
+    expect(cfg.channels?.github?.repos).toEqual(['acme/widgets'])
+    const secrets = await readSecretsChannels()
+    expect((secrets.github as { auth: { type: string } }).auth.type).toBe('pat')
+
+    const doneEvent = events.find(
+      (e): e is Extract<AddChannelStepEvent, { step: 'github-webhooks'; phase: 'done' }> =>
+        e.step === 'github-webhooks' && e.phase === 'done',
+    )
+    expect(doneEvent).toBeDefined()
+    expect('error' in doneEvent!.result).toBe(false)
+    if ('error' in doneEvent!.result) throw new Error('unreachable')
+    expect(doneEvent!.result.repos).toEqual([expect.objectContaining({ repo: 'acme/widgets', action: 'failed' })])
   })
 
   test('adds github channel with a cloudflare-quick tunnel and cloudflared Dockerfile toggle', async () => {

--- a/src/init/github-webhook-install.test.ts
+++ b/src/init/github-webhook-install.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatEagerGithubWebhookInstallResult, installGithubWebhooksEagerly } from './github-webhook-install'
+
+type RecordedCall = { url: string; method: string; body?: string }
+
+function fakeGithubFetch(handler: (url: string, method: string) => Response): {
+  fn: typeof fetch
+  calls: RecordedCall[]
+} {
+  const calls: RecordedCall[] = []
+  const fn = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    const method = init?.method ?? 'GET'
+    const body = typeof init?.body === 'string' ? init.body : undefined
+    calls.push(body !== undefined ? { url, method, body } : { url, method })
+    return handler(url, method)
+  }
+  return { fn: Object.assign(fn, { preconnect: () => {} }) as typeof fetch, calls }
+}
+
+describe('installGithubWebhooksEagerly', () => {
+  test('registers a webhook per repo and returns a structured result', async () => {
+    let nextId = 100
+    const { fn, calls } = fakeGithubFetch((url, method) => {
+      if (/\/hooks(\?|$)/.test(url) && method === 'GET') return Response.json([])
+      if (url.endsWith('/hooks') && method === 'POST') return Response.json({ id: nextId++ }, { status: 201 })
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const result = await installGithubWebhooksEagerly({
+      webhookUrl: 'https://agent.example.com/gh',
+      webhookSecret: 'wh-secret',
+      repos: ['acme/widgets', 'acme/gadgets'],
+      auth: { type: 'pat', pat: 'ghp_test' },
+      fetchImpl: fn,
+    })
+
+    expect('error' in result).toBe(false)
+    if ('error' in result) throw new Error('unreachable')
+    expect(result.repos).toEqual([
+      { repo: 'acme/widgets', action: 'created', hookId: 100 },
+      { repo: 'acme/gadgets', action: 'created', hookId: 101 },
+    ])
+    expect(calls.filter((c) => c.method === 'POST').map((c) => c.url)).toEqual([
+      'https://api.github.com/repos/acme/widgets/hooks',
+      'https://api.github.com/repos/acme/gadgets/hooks',
+    ])
+  })
+
+  test('updates an existing webhook (PATCH) when one with the same URL already exists', async () => {
+    const { fn, calls } = fakeGithubFetch((url, method) => {
+      if (/\/hooks(\?|$)/.test(url) && method === 'GET') {
+        return Response.json([{ id: 999, config: { url: 'https://agent.example.com/gh' } }])
+      }
+      if (url.endsWith('/hooks/999') && method === 'PATCH') return new Response('', { status: 200 })
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const result = await installGithubWebhooksEagerly({
+      webhookUrl: 'https://agent.example.com/gh',
+      webhookSecret: 'wh-secret',
+      repos: ['acme/widgets'],
+      auth: { type: 'pat', pat: 'ghp_test' },
+      fetchImpl: fn,
+    })
+
+    expect('error' in result).toBe(false)
+    if ('error' in result) throw new Error('unreachable')
+    expect(result.repos).toEqual([{ repo: 'acme/widgets', action: 'updated', hookId: 999 }])
+    expect(calls.some((c) => c.method === 'PATCH' && c.url.endsWith('/hooks/999'))).toBe(true)
+  })
+
+  test('repos[] empty returns an empty result and makes no HTTP calls', async () => {
+    const { fn, calls } = fakeGithubFetch(() => new Response('unexpected', { status: 500 }))
+
+    const result = await installGithubWebhooksEagerly({
+      webhookUrl: 'https://agent.example.com/gh',
+      webhookSecret: 'wh-secret',
+      repos: [],
+      auth: { type: 'pat', pat: 'ghp_test' },
+      fetchImpl: fn,
+    })
+
+    expect(result).toEqual({ repos: [] })
+    expect(calls).toEqual([])
+  })
+
+  test('per-repo 4xx is surfaced as { action: failed } rather than throwing', async () => {
+    const { fn } = fakeGithubFetch((url, method) => {
+      if (url.endsWith('acme/widgets/hooks?per_page=100') && method === 'GET') {
+        return new Response('forbidden', { status: 403 })
+      }
+      if (/\/hooks(\?|$)/.test(url) && method === 'GET') return Response.json([])
+      if (url.endsWith('/hooks') && method === 'POST') return Response.json({ id: 1 }, { status: 201 })
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const result = await installGithubWebhooksEagerly({
+      webhookUrl: 'https://agent.example.com/gh',
+      webhookSecret: 'wh-secret',
+      repos: ['acme/widgets', 'acme/gadgets'],
+      auth: { type: 'pat', pat: 'ghp_test' },
+      fetchImpl: fn,
+    })
+
+    expect('error' in result).toBe(false)
+    if ('error' in result) throw new Error('unreachable')
+    expect(result.repos[0]).toMatchObject({ repo: 'acme/widgets', action: 'failed' })
+    expect(result.repos[1]).toMatchObject({ repo: 'acme/gadgets', action: 'created' })
+  })
+
+  test('invalid auth (missing PAT) is surfaced as a top-level error, not a throw', async () => {
+    const { fn } = fakeGithubFetch(() => new Response('unexpected', { status: 500 }))
+
+    const result = await installGithubWebhooksEagerly({
+      webhookUrl: 'https://agent.example.com/gh',
+      webhookSecret: 'wh-secret',
+      repos: ['acme/widgets'],
+      auth: { type: 'pat', pat: '' },
+      fetchImpl: fn,
+    })
+
+    expect('error' in result).toBe(true)
+    if (!('error' in result)) throw new Error('unreachable')
+    expect(result.error).toContain('GitHub PAT token is missing')
+  })
+})
+
+describe('formatEagerGithubWebhookInstallResult', () => {
+  test('summarizes created and updated counts', () => {
+    expect(
+      formatEagerGithubWebhookInstallResult({
+        repos: [
+          { repo: 'a/b', action: 'created', hookId: 1 },
+          { repo: 'a/c', action: 'updated', hookId: 2 },
+        ],
+      }),
+    ).toBe('GitHub webhooks: 1 created, 1 updated.')
+  })
+
+  test('includes per-repo error tail when some hooks failed', () => {
+    expect(
+      formatEagerGithubWebhookInstallResult({
+        repos: [
+          { repo: 'a/b', action: 'created', hookId: 1 },
+          { repo: 'a/c', action: 'failed', error: '403 forbidden' },
+        ],
+      }),
+    ).toBe('GitHub webhooks: 1 created, 1 failed. (a/c: 403 forbidden)')
+  })
+
+  test('reports the strategy-level error when auth setup itself failed', () => {
+    expect(formatEagerGithubWebhookInstallResult({ error: 'GitHub PAT token is missing', repos: [] })).toBe(
+      'GitHub webhook install failed: GitHub PAT token is missing',
+    )
+  })
+
+  test('reports "no repos" on an empty result', () => {
+    expect(formatEagerGithubWebhookInstallResult({ repos: [] })).toBe('GitHub webhooks: no repos.')
+  })
+})

--- a/src/init/github-webhook-install.ts
+++ b/src/init/github-webhook-install.ts
@@ -1,0 +1,96 @@
+import { buildAuthStrategy } from '@/channels/adapters/github/auth'
+import { registerGithubWebhooks, type WebhookRegistrationResult } from '@/channels/adapters/github/webhook-register'
+import { DEFAULT_GITHUB_EVENT_ALLOWLIST } from '@/channels/schema'
+
+import type { GithubInitCredentials } from './index'
+
+// Host-side webhook install for `typeclaw channel add github` (and the
+// init-time GitHub branch). The container-side adapter still re-runs this on
+// every start so a missing/rotated tunnel URL eventually catches up, but
+// doing it eagerly here means the user sees the install succeed at CLI
+// time — no more "I added the channel, why isn't GitHub delivering events?"
+// when the URL is already known (external provider, or a user-set
+// webhookUrl).
+//
+// Only fires when an effective webhook URL is known up front: external
+// tunnel provider, or an explicit `webhookUrl`. Cloudflare quick tunnels
+// don't resolve until cloudflared boots inside the container, so they
+// stay on the existing deferred (tunnel-bridge → restartAdapter) path.
+
+export type EagerGithubWebhookInstallOptions = {
+  webhookUrl: string
+  webhookSecret: string
+  repos: readonly string[]
+  events?: readonly string[]
+  auth: GithubInitCredentials['auth']
+  fetchImpl?: typeof fetch
+}
+
+export type EagerGithubWebhookInstallResult = WebhookRegistrationResult | { error: string; repos: [] }
+
+export async function installGithubWebhooksEagerly(
+  options: EagerGithubWebhookInstallOptions,
+): Promise<EagerGithubWebhookInstallResult> {
+  if (options.repos.length === 0) return { repos: [] }
+
+  let strategy: ReturnType<typeof buildAuthStrategy>
+  try {
+    strategy = buildAuthStrategy({
+      auth: authToSecretBlock(options.auth),
+      ...(options.fetchImpl !== undefined ? { fetchImpl: options.fetchImpl } : {}),
+    })
+  } catch (err) {
+    return { error: describe(err), repos: [] }
+  }
+
+  try {
+    const result = await registerGithubWebhooks({
+      token: () => strategy.token(),
+      webhookUrl: options.webhookUrl,
+      webhookSecret: options.webhookSecret,
+      repos: options.repos,
+      events: options.events ?? DEFAULT_GITHUB_EVENT_ALLOWLIST,
+      ...(options.fetchImpl !== undefined ? { fetchImpl: options.fetchImpl } : {}),
+    })
+    return result
+  } finally {
+    // PatAuthStrategy.dispose() is a no-op and AppAuthStrategy clears its
+    // cached installation token. Either way, releasing it here keeps the
+    // host CLI from holding onto credentials longer than needed.
+    await strategy.dispose().catch(() => {})
+  }
+}
+
+// Bridge the wizard/CLI's plaintext credentials union into the Secret-wrapped
+// shape buildAuthStrategy expects. Plain strings are wrapped as `{ value }`
+// so the underlying PatAuthStrategy resolver doesn't try (and fail) to read
+// from process.env.
+function authToSecretBlock(auth: GithubInitCredentials['auth']) {
+  if (auth.type === 'pat') {
+    return { type: 'pat' as const, token: { value: auth.pat } }
+  }
+  return {
+    type: 'app' as const,
+    appId: auth.appId,
+    privateKey: { value: auth.privateKey },
+    ...(auth.installationId !== undefined ? { installationId: auth.installationId } : {}),
+  }
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+export function formatEagerGithubWebhookInstallResult(result: EagerGithubWebhookInstallResult): string {
+  if ('error' in result) return `GitHub webhook install failed: ${result.error}`
+  const created = result.repos.filter((r) => r.action === 'created').length
+  const updated = result.repos.filter((r) => r.action === 'updated').length
+  const failed = result.repos.filter((r) => r.action === 'failed')
+  const parts: string[] = []
+  if (created > 0) parts.push(`${created} created`)
+  if (updated > 0) parts.push(`${updated} updated`)
+  if (failed.length > 0) parts.push(`${failed.length} failed`)
+  const summary = parts.length > 0 ? parts.join(', ') : 'no repos'
+  const tail = failed.length > 0 ? ` (${failed.map((f) => `${f.repo}: ${f.error}`).join('; ')})` : ''
+  return `GitHub webhooks: ${summary}.${tail}`
+}

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -57,6 +57,22 @@ const okDocker: DockerExec = async () => ({ exitCode: 0, stdout: '29.4.0\n', std
 // own InstallRunner.
 const okInstall: InstallRunner = async () => ({ ok: true })
 
+// Hermetic stub for the eager github webhook install path. Returns empty
+// hook lists and successful POSTs so runInit's github branch never reaches
+// the real api.github.com. Tests that assert webhook side effects use a
+// recording variant instead.
+const okGithubFetch: typeof fetch = (() => {
+  let nextId = 100
+  const handler = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    const method = init?.method ?? 'GET'
+    if (/\/hooks(\?|$)/.test(url) && method === 'GET') return Response.json([])
+    if (url.endsWith('/hooks') && method === 'POST') return Response.json({ id: nextId++ }, { status: 201 })
+    return new Response('unexpected', { status: 500 })
+  }
+  return Object.assign(handler, { preconnect: () => {} }) as typeof fetch
+})()
+
 function captureHatch(): { runner: HatchRunner; calls: Array<{ cwd: string; port: number; cliEntry?: string }> } {
   const calls: Array<{ cwd: string; port: number; cliEntry?: string }> = []
   const runner: HatchRunner = async (options) => {
@@ -1588,6 +1604,7 @@ describe('channel secret reuse (init re-run preserves existing tokens)', () => {
         repos: ['acme/repo-a'],
         auth: { type: 'pat', pat: 'ghp_test' },
       },
+      githubFetchImpl: okGithubFetch,
       runHatching: okHatch,
       runBunInstall: okInstall,
       dockerExec: okDocker,
@@ -1669,6 +1686,7 @@ describe('channel secret reuse (init re-run preserves existing tokens)', () => {
         repos: ['acme/repo-b'],
         auth: { type: 'pat', pat: 'new_pat' },
       },
+      githubFetchImpl: okGithubFetch,
       runHatching: okHatch,
       runBunInstall: okInstall,
       dockerExec: okDocker,
@@ -1693,6 +1711,7 @@ describe('channel secret reuse (init re-run preserves existing tokens)', () => {
   })
 
   test('runInit with github cloudflare-quick credentials writes tunnel config without webhookUrl', async () => {
+    const events: InitStepEvent[] = []
     await runInit({
       cwd: root,
       apiKey: 'fw_test_key',
@@ -1704,6 +1723,7 @@ describe('channel secret reuse (init re-run preserves existing tokens)', () => {
         repos: ['acme/repo-a'],
         auth: { type: 'pat', pat: 'ghp_test' },
       },
+      onProgress: (e) => events.push(e),
       runHatching: okHatch,
       runBunInstall: okInstall,
       dockerExec: okDocker,
@@ -1719,6 +1739,57 @@ describe('channel secret reuse (init re-run preserves existing tokens)', () => {
     expect(config.tunnels).toEqual([
       { name: 'github-webhook', provider: 'cloudflare-quick', for: { kind: 'channel', name: 'github' } },
     ])
+    expect(events.some((e) => e.step === 'github-webhooks')).toBe(false)
+  })
+
+  test('runInit eagerly installs github webhooks when the credentials carry a known webhookUrl', async () => {
+    const events: InitStepEvent[] = []
+    const calls: Array<{ url: string; method: string; body?: string }> = []
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      const method = init?.method ?? 'GET'
+      const body = typeof init?.body === 'string' ? init.body : undefined
+      calls.push(body !== undefined ? { url, method, body } : { url, method })
+      if (/\/hooks(\?|$)/.test(url) && method === 'GET') return Response.json([])
+      if (url.endsWith('/hooks') && method === 'POST') return Response.json({ id: 777 }, { status: 201 })
+      return new Response('unexpected', { status: 500 })
+    }) as unknown as typeof fetch as typeof fetch
+
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      withGithub: true,
+      githubCredentials: {
+        webhookSecret: 'whsec_init',
+        tunnelProvider: 'external',
+        webhookUrl: 'https://init.example.com/hook',
+        webhookPort: 8975,
+        repos: ['acme/repo-a'],
+        auth: { type: 'pat', pat: 'ghp_test' },
+      },
+      githubFetchImpl: fetchImpl,
+      onProgress: (e) => events.push(e),
+      runHatching: okHatch,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+    })
+
+    const post = calls.find((c) => c.method === 'POST' && c.url.endsWith('/hooks'))
+    expect(post?.url).toBe('https://api.github.com/repos/acme/repo-a/hooks')
+    const body = JSON.parse(post?.body ?? '{}') as { config?: { url?: string; secret?: string } }
+    expect(body.config?.url).toBe('https://init.example.com/hook')
+    expect(body.config?.secret).toBe('whsec_init')
+
+    const doneEvent = events.find(
+      (e): e is Extract<InitStepEvent, { step: 'github-webhooks'; phase: 'done' }> =>
+        e.step === 'github-webhooks' && e.phase === 'done',
+    )
+    expect(doneEvent).toBeDefined()
+    if (doneEvent && !('error' in doneEvent.result)) {
+      expect(doneEvent.result.repos).toEqual([{ repo: 'acme/repo-a', action: 'created', hookId: 777 }])
+    } else {
+      throw new Error('expected structured success result, got error or no event')
+    }
   })
 })
 

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -19,6 +19,7 @@ import { createTui } from '@/tui'
 
 import { resolveBaseImageVersion, resolveScaffoldVersion } from './cli-version'
 import { buildDockerfile, DOCKERFILE } from './dockerfile'
+import { installGithubWebhooksEagerly, type EagerGithubWebhookInstallResult } from './github-webhook-install'
 import { buildGitignore, GITIGNORE_FILE } from './gitignore'
 import { HATCHING_PROMPT } from './hatching'
 import type { OAuthLoginRunner, OAuthLoginResult } from './oauth-login'
@@ -26,6 +27,9 @@ import { GITKEEP_FILE, PACKAGES_DIR } from './paths'
 import { type InstallResult, type InstallRunner, runBunInstall } from './run-bun-install'
 
 export { type InstallResult, type InstallRunner, runBunInstall } from './run-bun-install'
+
+export type { EagerGithubWebhookInstallResult } from './github-webhook-install'
+export { formatEagerGithubWebhookInstallResult, installGithubWebhooksEagerly } from './github-webhook-install'
 
 export { GITKEEP_FILE, PACKAGES_DIR } from './paths'
 
@@ -52,6 +56,7 @@ export type InitStep =
   | 'oauth-login'
   | 'scaffold'
   | 'kakaotalk-auth'
+  | 'github-webhooks'
   | 'install'
   | 'dockerfile'
   | 'git'
@@ -82,6 +87,8 @@ export type InitStepEvent =
   | { step: 'scaffold'; phase: 'done' }
   | { step: 'kakaotalk-auth'; phase: 'start' }
   | { step: 'kakaotalk-auth'; phase: 'done'; result: KakaotalkAuthResult }
+  | { step: 'github-webhooks'; phase: 'start' }
+  | { step: 'github-webhooks'; phase: 'done'; result: EagerGithubWebhookInstallResult }
   | { step: 'install'; phase: 'start' }
   | { step: 'install'; phase: 'done'; result: InstallResult }
   | { step: 'dockerfile'; phase: 'start' }
@@ -152,6 +159,10 @@ export type InitOptions = {
   // `withGithub` is true, the existing secrets.json#channels.github block is
   // reused as-is (the wizard's "reuse existing credentials" path).
   githubCredentials?: GithubInitCredentials
+  // Test seam for the eager-webhook-install path that fires after the github
+  // channel block is written. Production callers leave this undefined so the
+  // global `fetch` is used.
+  githubFetchImpl?: typeof fetch
   onProgress?: (event: InitStepEvent) => void
   runHatching?: HatchRunner
   runBunInstall?: InstallRunner
@@ -182,6 +193,7 @@ export async function runInit({
   withGithub = false,
   runKakaotalkAuth,
   githubCredentials,
+  githubFetchImpl,
   onProgress,
   runHatching = defaultRunHatching,
   runBunInstall: installRunner = runBunInstall,
@@ -295,6 +307,17 @@ export async function runInit({
   // bot-token adapters all support.
   if (withGithub && githubCredentials !== undefined) {
     await writeGithubChannelForInit(cwd, githubCredentials)
+    if (githubCredentials.webhookUrl !== undefined && githubCredentials.repos.length > 0) {
+      emit({ step: 'github-webhooks', phase: 'start' })
+      const result = await installGithubWebhooksEagerly({
+        webhookUrl: githubCredentials.webhookUrl,
+        webhookSecret: githubCredentials.webhookSecret,
+        repos: githubCredentials.repos,
+        auth: githubCredentials.auth,
+        ...(githubFetchImpl !== undefined ? { fetchImpl: githubFetchImpl } : {}),
+      })
+      emit({ step: 'github-webhooks', phase: 'done', result })
+    }
   }
 
   emit({ step: 'install', phase: 'start' })
@@ -860,7 +883,7 @@ export const CHANNEL_KINDS: ReadonlyArray<ChannelKind> = [
   'github',
 ]
 
-export type AddChannelStep = 'kakaotalk-auth' | 'config' | 'secrets'
+export type AddChannelStep = 'kakaotalk-auth' | 'config' | 'secrets' | 'github-webhooks'
 
 export type AddChannelStepEvent =
   | { step: 'config'; phase: 'start' }
@@ -869,6 +892,8 @@ export type AddChannelStepEvent =
   | { step: 'kakaotalk-auth'; phase: 'done'; result: KakaotalkAuthResult }
   | { step: 'secrets'; phase: 'start' }
   | { step: 'secrets'; phase: 'done' }
+  | { step: 'github-webhooks'; phase: 'start' }
+  | { step: 'github-webhooks'; phase: 'done'; result: EagerGithubWebhookInstallResult }
 
 // Discriminated union per channel so the type system enforces "you must pass
 // the right credentials for the channel you're adding". The CLI builds these
@@ -889,6 +914,7 @@ export type AddChannelOptions = {
       webhookPort?: number
       repos: string[]
       auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string; installationId?: number }
+      fetchImpl?: typeof fetch
     }
 )
 
@@ -926,6 +952,7 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
 
   if (options.channel === 'github') {
     await appendGithubMatchRules(options.cwd, options.repos)
+    await maybeInstallGithubWebhooks(options, emit)
   }
 
   // Commit the typeclaw.json change so the agent folder isn't silently
@@ -934,6 +961,29 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
   // unavailable, or when the file is clean. secrets.json is gitignored, so
   // only typeclaw.json is named here.
   await commitSystemFile(options.cwd, CONFIG_FILE, `channel: add ${options.channel}`)
+}
+
+// Eager webhook registration is best-effort: a failure here MUST NOT roll
+// back the typeclaw.json / secrets.json writes. The container-side adapter
+// re-runs registration on every start, so a missing PAT scope or a transient
+// 5xx today gets retried automatically on the next `typeclaw start`. We
+// surface the per-repo outcome as a structured event so the CLI can render
+// it, but we never throw.
+async function maybeInstallGithubWebhooks(
+  options: Extract<AddChannelOptions, { channel: 'github' }>,
+  emit: (event: AddChannelStepEvent) => void,
+): Promise<void> {
+  if (options.webhookUrl === undefined) return
+  if (options.repos.length === 0) return
+  emit({ step: 'github-webhooks', phase: 'start' })
+  const result = await installGithubWebhooksEagerly({
+    webhookUrl: options.webhookUrl,
+    webhookSecret: options.webhookSecret,
+    repos: options.repos,
+    auth: options.auth,
+    ...(options.fetchImpl !== undefined ? { fetchImpl: options.fetchImpl } : {}),
+  })
+  emit({ step: 'github-webhooks', phase: 'done', result })
 }
 
 function channelSecretsFromOptions(options: AddChannelOptions): ChannelSecrets {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -181,6 +181,7 @@ export async function startAgent({
     channelsConfigRef: () => getConfig().channels,
     aliasesRef: () => getConfig().alias,
     tunnelUrlForChannel: (name) => resolveTunnelUrlForChannel(name, tunnelManager),
+    tunnelConfiguredForChannel: (name) => isTunnelConfiguredForChannel(name),
     createSessionForChannel: buildChannelSessionFactory({
       cwd,
       sessionFactory,
@@ -536,6 +537,10 @@ function buildLocalTuiUrl(port: number, token: string | null): string {
 function resolveTunnelUrlForChannel(channelName: string, tunnelManager: TunnelManager): string | null {
   const tunnel = getConfig().tunnels.find((entry) => entry.for.kind === 'channel' && entry.for.name === channelName)
   return tunnel ? tunnelManager.urlFor(tunnel.name) : null
+}
+
+function isTunnelConfiguredForChannel(channelName: string): boolean {
+  return getConfig().tunnels.some((entry) => entry.for.kind === 'channel' && entry.for.name === channelName)
 }
 
 async function disposeMaterializedSkills(pluginRuntime: PluginRuntime): Promise<void> {


### PR DESCRIPTION
## Summary

Two complementary improvements to GitHub webhook registration reliability, landed together because they address the same real-world failure mode from opposite directions.

**EAGER**: when a `webhookUrl` is known at `channel add` / `init` time (the `external` tunnel provider, where the URL is hand-supplied), register webhooks immediately from the host before the CLI exits — instead of deferring silently to the first container start.

**OBSERVABLE**: when the container-side `createGithubAdapter#start()` has to skip registration because no URL is available yet, escalate from a quiet INFO line to an actionable WARN that names exactly which knob the operator needs to turn. Also fixes a silent App-auth runtime guard bug that caused GitHub adapters with `auth.type === 'app'` to be silently dropped at boot.

## Why

The real-world failure mode that motivated commit 3: a `cloudflare-quick` user's agent booted, `typeclaw status` showed the github channel as `started`, but GitHub deliveries never arrived. The container had logged two lines:

```
[tunnels] github-webhook: start failed: Executable not found in $PATH: "cloudflared"
[github] no webhookUrl configured and no tunnel URL available; channel is up but webhook registration is skipped
```

The first was buried in `typeclaw logs`. The second was INFO — easy to miss, and it didn't name the tunnel or point at `typeclaw tunnel status` as the diagnostic command. The operator had to grep logs to find an underlying cause the adapter already knew about.

The eager-install improvement (commits 1–2) addresses the complementary gap for `external` tunnel users: the URL is known before the CLI exits, so deferring to a container start is unnecessary and surprising.

## Changes

### Commit 1 — `ab386bc`: host-side webhook install helper (no callers yet)

| File | Change |
|------|--------|
| `src/init/github-webhook-install.ts` | New `installGithubWebhooksEagerly` helper. Wraps `registerGithubWebhooks` + `buildAuthStrategy` in a host-friendly entry point; returns a structured result or error string. Auth strategy bridges the wizard's plaintext-credential union to the Secret-wrapped shape so `PatAuthStrategy` doesn't fall through to `process.env`; disposed in a `finally` block so cached App tokens are dropped before the CLI exits. |
| `src/init/github-webhook-install.test.ts` | 9 unit tests: create, update, failed, empty repo list, auth-missing, format cases. |

Standalone module with no callers yet — lets a reviewer evaluate the primitive before reviewing the integration.

### Commit 2 — `121a2d7`: wire eager install into `runAddChannel` + `runInit`

| File | Change |
|------|--------|
| `src/init/index.ts` | Adds `github-webhooks` to `AddChannelStepEvent` + `InitStepEvent`; wires eager install into `runAddChannel` and `runInit`; threads `githubFetchImpl` test seam. |
| `src/init/add-channel.test.ts` | Updates existing GitHub test to assert eager install fires; 4 new tests covering external / cloudflare-quick / none / failure; `recordingGithubFetch` helper. |
| `src/init/index.test.ts` | Threads hermetic `okGithubFetch` stub into existing init+GitHub tests; new test asserting eager install fires from `runInit`. |
| `src/cli/channel.ts` | Spinner case for `github-webhooks` + `START_MESSAGES` entry. |
| `src/cli/init.ts` | Same wiring as `cli/channel.ts` for the init wizard reporter. |

Best-effort by design: a 403 from a misconfigured PAT or a network glitch surfaces as a `github-webhooks` event with per-repo `action: 'failed'` but does NOT roll back `typeclaw.json` / `secrets.json`. Container-side registration on `start()` remains the recovery path and is not removed.

`cloudflare-quick` intentionally keeps the deferred registration path — no URL exists until cloudflared boots inside the container.

### Commit 3 — `27d2e55`: surface skip as actionable warning; fix App-auth runtime guard

| File | Change |
|------|--------|
| `src/channels/adapters/github/index.ts` | Adds optional `tunnelConfiguredForChannel?: () => boolean` to `GithubAdapterOptions`. New `logSkippedRegistration` helper: WARN (not INFO) when repos are configured but no URL is available; branches on whether a tunnel is configured — names the tunnel and points at `typeclaw tunnel status` — vs. neither tunnel nor URL configured — names both knobs the operator can set. INFO kept for the no-repos case (benign). |
| `src/channels/manager.ts` | Adds `tunnelConfiguredForChannel?: (channelName: string) => boolean` to `ChannelManagerOptions`; wires it through `buildAdapter` for github. Fixes `isGithubSecretsBlock` to accept `auth.type === 'app'` in addition to `'pat'` — App-authenticated github setups were previously silently dropped at boot with `adapter "github" could not be constructed`. |
| `src/run/index.ts` | Adds `isTunnelConfiguredForChannel(channelName)` helper; passes it through to the channel manager. |
| `src/channels/adapters/github/lifecycle.test.ts` | Rewrites the existing skip-registration test to assert the new actionable WARN; adds 2 new tests (tunnel-configured-but-broken branch; no-repos quiet-INFO branch). |
| `src/channels/manager.test.ts` | 2 new tests: `tunnelConfiguredForChannel` is plumbed through to the adapter; regression test that App-authenticated `secrets.json` constructs the adapter (was silently dropped before). |

## Verification

```
bun run typecheck   ✓
bun run lint        ✓
bun run format      ✓
bun test            3995 pass / 0 fail (240 files)
```