### PR TITLE
channels: add `channel set` to rotate credentials of configured channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,22 +69,23 @@ That's it. The agent is now alive, listening on a websocket, ready to receive pr
 
 ## CLI
 
-| Command                             | Purpose                                                                            |
-| ----------------------------------- | ---------------------------------------------------------------------------------- |
-| `typeclaw init`                     | Scaffold a new agent folder                                                        |
-| `typeclaw start`                    | Build and run the container                                                        |
-| `typeclaw stop`                     | Stop the container                                                                 |
-| `typeclaw restart`                  | `stop` then `start`                                                                |
-| `typeclaw status`                   | Show container + daemon registration state                                         |
-| `typeclaw logs`                     | Stream container stdout/stderr with local timestamps; `-f` to follow               |
-| `typeclaw tui`                      | Attach a terminal UI over the agent's websocket                                    |
-| `typeclaw shell`                    | Open a shell inside the running container                                          |
-| `typeclaw reload`                   | Push a live config reload to the running agent                                     |
-| `typeclaw compose`                  | Orchestrate multiple agents                                                        |
-| `typeclaw cron list`                | List every cron job registered in the running agent (user `cron.json` + plugins)   |
-| `typeclaw channel add <kind>`       | Wire a new channel adapter (Slack, Discord, Telegram, KakaoTalk)                   |
-| `typeclaw channel reauth kakaotalk` | Re-authenticate KakaoTalk after a stale-token 401 or to rotate the stored password |
-| `typeclaw tunnel ...`               | Add/list/status/remove public tunnels and inspect tunnel logs                      |
+| Command                             | Purpose                                                                             |
+| ----------------------------------- | ----------------------------------------------------------------------------------- |
+| `typeclaw init`                     | Scaffold a new agent folder                                                         |
+| `typeclaw start`                    | Build and run the container                                                         |
+| `typeclaw stop`                     | Stop the container                                                                  |
+| `typeclaw restart`                  | `stop` then `start`                                                                 |
+| `typeclaw status`                   | Show container + daemon registration state                                          |
+| `typeclaw logs`                     | Stream container stdout/stderr with local timestamps; `-f` to follow                |
+| `typeclaw tui`                      | Attach a terminal UI over the agent's websocket                                     |
+| `typeclaw shell`                    | Open a shell inside the running container                                           |
+| `typeclaw reload`                   | Push a live config reload to the running agent                                      |
+| `typeclaw compose`                  | Orchestrate multiple agents                                                         |
+| `typeclaw cron list`                | List every cron job registered in the running agent (user `cron.json` + plugins)    |
+| `typeclaw channel add <kind>`       | Wire a new channel adapter (Slack, Discord, Telegram, KakaoTalk, GitHub)            |
+| `typeclaw channel set <kind>`       | Rotate the credentials of an already-configured channel (bot/app tokens, PAT, etc.) |
+| `typeclaw channel reauth kakaotalk` | Re-authenticate KakaoTalk after a stale-token 401 or to rotate the stored password  |
+| `typeclaw tunnel ...`               | Add/list/status/remove public tunnels and inspect tunnel logs                       |
 
 ## Configuration
 

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -12,9 +12,13 @@ import {
   formatEagerGithubWebhookInstallResult,
   isInitialized,
   readConfiguredChannels,
+  readGithubAuthType,
   runAddChannel,
+  setChannelSecrets,
+  setGithubSecrets,
   type AddChannelStepEvent,
   type ChannelKind,
+  type GithubCredentialPatch,
   type GithubTunnelProvider,
   type KakaotalkAuthResult,
 } from '@/init'
@@ -80,11 +84,58 @@ const addSub = defineCommand({
   },
 })
 
-// Only adapters with an interactive credential flow appear here. Bot tokens
-// (Discord/Slack/Telegram) are rotated by editing secrets.json or .env
-// directly — they don't need a guided CLI flow because there's no
-// passcode-on-phone equivalent. KakaoTalk is the only adapter that does, so
-// it's the only adapter that needs `reauth`.
+// Adapters whose credentials are rotated via the generic `channel set` flow:
+// one or more named token fields, no passcode-on-phone, no encryption envelope.
+// KakaoTalk is excluded by design — it has its own `channel reauth` flow that
+// replays the full interactive login (see REAUTHABLE_ADAPTERS below). GitHub
+// is included here but routed through its own prompt path because it has
+// three independent secrets (PAT or App private key + webhook secret) and a
+// structural auth-type flip is forbidden during rotation.
+const SETTABLE_ADAPTERS = ['slack-bot', 'discord-bot', 'telegram-bot', 'github'] as const
+type SettableAdapter = (typeof SETTABLE_ADAPTERS)[number]
+
+const setSub = defineCommand({
+  meta: {
+    name: 'set',
+    description: 'rotate credentials of an already-configured channel adapter (symmetric with `typeclaw provider set`)',
+  },
+  args: {
+    adapter: {
+      type: 'positional',
+      description: `which adapter to rotate (${SETTABLE_ADAPTERS.join(' | ')}); omit to pick interactively`,
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+
+    if (!isInitialized(cwd)) {
+      console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first, or cd into an agent folder.'))
+      process.exit(1)
+    }
+
+    const configured = await readConfiguredChannels(cwd)
+
+    if (args.adapter === 'kakaotalk') {
+      console.error(
+        errorLine(
+          'KakaoTalk uses an interactive auth flow (phone passcode + device_uuid). Use `typeclaw channel reauth kakaotalk` to rotate its credentials.',
+        ),
+      )
+      process.exit(1)
+    }
+
+    const adapter =
+      args.adapter === undefined
+        ? await pickSettableAdapter(configured)
+        : validateSetAdapterArg(args.adapter, configured)
+
+    intro(`Rotating credentials for: ${CHANNEL_LABELS[adapter]}`)
+
+    await runSet(cwd, adapter)
+  },
+})
+
 const REAUTHABLE_ADAPTERS = ['kakaotalk'] as const
 type ReauthableAdapter = (typeof REAUTHABLE_ADAPTERS)[number]
 
@@ -125,6 +176,7 @@ export const channelCommand = defineCommand({
   },
   subCommands: {
     add: addSub,
+    set: setSub,
     reauth: reauthSub,
   },
 })
@@ -231,11 +283,18 @@ async function readExistingKakaotalkEmail(cwd: string): Promise<string | undefin
 // We can't reliably distinguish the last two cases from outside the container
 // without calling reload first, so the next-step hints surface both paths.
 async function maybePromptReauthRefresh(cwd: string, adapter: ReauthableAdapter): Promise<void> {
-  const label = CHANNEL_LABELS[adapter]
+  await maybePromptCredentialRefresh(cwd, CHANNEL_LABELS[adapter], 're-authenticated')
+}
+
+async function maybePromptCredentialRefresh(
+  cwd: string,
+  label: string,
+  verbPast: 're-authenticated' | 'credentials updated',
+): Promise<void> {
   const current = await status({ cwd }).catch(() => null)
   if (current === null || current.kind !== 'running') {
     done({
-      title: c.green(`${label} re-authenticated.`),
+      title: c.green(`${label} ${verbPast}.`),
       hints: [
         { label: 'Start the agent:', command: 'typeclaw start' },
         { label: 'Then check status:', command: 'typeclaw status' },
@@ -251,7 +310,7 @@ async function maybePromptReauthRefresh(cwd: string, adapter: ReauthableAdapter)
   })
   if (isCancel(restartNow) || !restartNow) {
     done({
-      title: c.green(`${label} re-authenticated.`),
+      title: c.green(`${label} ${verbPast}.`),
       hints: [
         { label: 'Try a live reload first:', command: 'typeclaw reload' },
         { label: 'If reload reports restart-required:', command: 'typeclaw restart' },
@@ -271,9 +330,7 @@ async function maybePromptReauthRefresh(cwd: string, adapter: ReauthableAdapter)
     process.exit(1)
   }
   done({
-    title: c.green(
-      `${label} re-authenticated. Restarted ${started.plan.containerName} on host port ${started.hostPort}.`,
-    ),
+    title: c.green(`${label} ${verbPast}. Restarted ${started.plan.containerName} on host port ${started.hostPort}.`),
     hints: [
       { label: 'Attach TUI:', command: 'typeclaw tui' },
       { label: 'Follow logs:', command: 'typeclaw logs -f' },
@@ -318,6 +375,192 @@ async function pickChannel(configured: Set<ChannelKind>): Promise<ChannelKind> {
     process.exit(0)
   }
   return selected
+}
+
+function isSettableAdapter(value: string): value is SettableAdapter {
+  return (SETTABLE_ADAPTERS as ReadonlyArray<string>).includes(value)
+}
+
+function validateSetAdapterArg(adapter: string, configured: Set<ChannelKind>): SettableAdapter {
+  if (!isSettableAdapter(adapter)) {
+    if (isChannelKind(adapter)) {
+      console.error(
+        errorLine(
+          `Adapter "${adapter}" does not support \`channel set\`. Use \`typeclaw channel reauth ${adapter}\` instead.`,
+        ),
+      )
+    } else {
+      console.error(errorLine(`Unknown adapter "${adapter}". Expected one of: ${SETTABLE_ADAPTERS.join(', ')}.`))
+    }
+    process.exit(1)
+  }
+  if (!configured.has(adapter)) {
+    console.error(
+      errorLine(
+        `${CHANNEL_LABELS[adapter]} ("${adapter}") is not configured in typeclaw.json. Run \`typeclaw channel add ${adapter}\` first.`,
+      ),
+    )
+    process.exit(1)
+  }
+  return adapter
+}
+
+async function pickSettableAdapter(configured: Set<ChannelKind>): Promise<SettableAdapter> {
+  const available = SETTABLE_ADAPTERS.filter((kind) => configured.has(kind))
+  if (available.length === 0) {
+    console.error(
+      errorLine(
+        'No rotatable channels are configured. Run `typeclaw channel add <adapter>` first, or use `typeclaw channel reauth kakaotalk` for KakaoTalk.',
+      ),
+    )
+    process.exit(1)
+  }
+  if (available.length === 1) return available[0]!
+
+  const selected = await select<SettableAdapter>({
+    message: 'Pick a channel to rotate credentials for',
+    options: available.map((kind) => ({ value: kind, label: CHANNEL_LABELS[kind] })),
+    initialValue: available[0],
+  })
+  if (isCancel(selected)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return selected
+}
+
+async function runSet(cwd: string, adapter: SettableAdapter): Promise<void> {
+  switch (adapter) {
+    case 'discord-bot':
+      await runSetDiscord(cwd)
+      break
+    case 'telegram-bot':
+      await runSetTelegram(cwd)
+      break
+    case 'slack-bot':
+      await runSetSlack(cwd)
+      break
+    case 'github':
+      await runSetGithub(cwd)
+      break
+  }
+}
+
+async function runSetDiscord(cwd: string): Promise<void> {
+  const token = await promptDiscordToken()
+  const result = await setChannelSecrets(cwd, 'discord-bot', { token })
+  if (!result.ok) {
+    console.error(errorLine(result.reason))
+    process.exit(1)
+  }
+  await maybePromptCredentialRefresh(cwd, CHANNEL_LABELS['discord-bot'], 'credentials updated')
+}
+
+async function runSetTelegram(cwd: string): Promise<void> {
+  const token = await promptTelegramToken()
+  const result = await setChannelSecrets(cwd, 'telegram-bot', { token })
+  if (!result.ok) {
+    console.error(errorLine(result.reason))
+    process.exit(1)
+  }
+  await maybePromptCredentialRefresh(cwd, CHANNEL_LABELS['telegram-bot'], 'credentials updated')
+}
+
+type SlackSetChoice = 'bot' | 'app' | 'both'
+
+async function runSetSlack(cwd: string): Promise<void> {
+  const choice = await select<SlackSetChoice>({
+    message: 'Which Slack token do you want to rotate?',
+    options: [
+      { value: 'bot', label: 'Bot user token (xoxb-...)' },
+      { value: 'app', label: 'App-level token (xapp-...)' },
+      { value: 'both', label: 'Both' },
+    ],
+    initialValue: 'bot',
+  })
+  if (isCancel(choice)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+
+  const tokens: Record<string, string> = {}
+  if (choice === 'bot' || choice === 'both') tokens.botToken = await promptSlackBotToken()
+  if (choice === 'app' || choice === 'both') tokens.appToken = await promptSlackAppToken()
+
+  const result = await setChannelSecrets(cwd, 'slack-bot', tokens)
+  if (!result.ok) {
+    console.error(errorLine(result.reason))
+    process.exit(1)
+  }
+  await maybePromptCredentialRefresh(cwd, CHANNEL_LABELS['slack-bot'], 'credentials updated')
+}
+
+type GithubSetChoice = 'auth' | 'webhook' | 'both'
+
+async function runSetGithub(cwd: string): Promise<void> {
+  const authType = readGithubAuthType(cwd)
+  if (authType === null) {
+    console.error(
+      errorLine(
+        'GitHub auth block is missing or malformed in secrets.json. Run `typeclaw channel add github` first, or fix the file by hand.',
+      ),
+    )
+    process.exit(1)
+  }
+  const choice = await select<GithubSetChoice>({
+    message: 'Which GitHub secret do you want to rotate?',
+    options: [
+      {
+        value: 'auth',
+        label: authType === 'pat' ? 'Personal access token (PAT)' : 'GitHub App private key',
+      },
+      { value: 'webhook', label: 'Webhook secret' },
+      { value: 'both', label: 'Both' },
+    ],
+    initialValue: 'auth',
+  })
+  if (isCancel(choice)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+
+  const patch: GithubCredentialPatch = {}
+
+  if (choice === 'auth' || choice === 'both') {
+    if (authType === 'pat') {
+      const { pat } = await promptGithubPatAuth()
+      patch.auth = { type: 'pat', pat }
+    } else {
+      const privateKeyInput = await text({
+        message: 'New GitHub App private key PEM, escaped PEM, or path to .pem file',
+        validate: (value) => (value && value.length > 0 ? undefined : 'Private key is required'),
+      })
+      if (isCancel(privateKeyInput)) {
+        cancel('Aborted.')
+        process.exit(0)
+      }
+      patch.auth = { type: 'app', privateKey: await resolvePrivateKeyInput(privateKeyInput) }
+    }
+  }
+
+  if (choice === 'webhook' || choice === 'both') {
+    const secret = await password({
+      message: 'New webhook secret (leave blank to auto-generate)',
+    })
+    if (isCancel(secret)) {
+      cancel('Aborted.')
+      process.exit(0)
+    }
+    const enteredSecret = typeof secret === 'string' ? secret : ''
+    patch.webhookSecret = enteredSecret.length > 0 ? enteredSecret : randomBytes(32).toString('hex')
+  }
+
+  const result = await setGithubSecrets(cwd, patch)
+  if (!result.ok) {
+    console.error(errorLine(result.reason))
+    process.exit(1)
+  }
+  await maybePromptCredentialRefresh(cwd, CHANNEL_LABELS.github, 'credentials updated')
 }
 
 type CollectedCredentials =
@@ -609,19 +852,7 @@ async function promptSlackTokens(): Promise<{ bot: string; app: string }> {
     ].join('\n'),
     'Get a Slack bot',
   )
-  const botToken = await password({
-    message: 'Slack bot token (xoxb-...)',
-    validate: (value) =>
-      value && value.length > 0
-        ? value.startsWith('xoxb-')
-          ? undefined
-          : 'Bot token must start with "xoxb-"'
-        : 'Token is required',
-  })
-  if (isCancel(botToken)) {
-    cancel('Aborted.')
-    process.exit(0)
-  }
+  const bot = await promptSlackBotToken()
   note(
     [
       'Slack does not accept connections:write inside the manifest, so',
@@ -635,6 +866,28 @@ async function promptSlackTokens(): Promise<{ bot: string; app: string }> {
     ].join('\n'),
     'Generate the Slack app-level token',
   )
+  const app = await promptSlackAppToken()
+  return { bot, app }
+}
+
+async function promptSlackBotToken(): Promise<string> {
+  const botToken = await password({
+    message: 'Slack bot token (xoxb-...)',
+    validate: (value) =>
+      value && value.length > 0
+        ? value.startsWith('xoxb-')
+          ? undefined
+          : 'Bot token must start with "xoxb-"'
+        : 'Token is required',
+  })
+  if (isCancel(botToken)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return botToken
+}
+
+async function promptSlackAppToken(): Promise<string> {
   const appToken = await password({
     message: 'Slack app-level token (xapp-...) — Socket Mode requires this',
     validate: (value) =>
@@ -648,7 +901,7 @@ async function promptSlackTokens(): Promise<{ bot: string; app: string }> {
     cancel('Aborted.')
     process.exit(0)
   }
-  return { bot: botToken, app: appToken }
+  return appToken
 }
 
 async function promptTelegramToken(): Promise<string> {

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -130,7 +130,7 @@ const setSub = defineCommand({
         ? await pickSettableAdapter(configured)
         : validateSetAdapterArg(args.adapter, configured)
 
-    intro(`Rotating credentials for: ${CHANNEL_LABELS[adapter]}`)
+    intro(`Rotating channel: ${CHANNEL_LABELS[adapter]}`)
 
     await runSet(cwd, adapter)
   },
@@ -469,12 +469,21 @@ async function runSetTelegram(cwd: string): Promise<void> {
 type SlackSetChoice = 'bot' | 'app' | 'both'
 
 async function runSetSlack(cwd: string): Promise<void> {
+  note(
+    [
+      'Rotate at https://api.slack.com/apps → your app:',
+      '  Bot token  (xoxb-...) — OAuth & Permissions → Reset Token.',
+      '  App-level token (xapp-...) — Basic Information → App-Level Tokens → Revoke and regenerate.',
+      'Slack only shows the app-level token once on screen — copy it before closing.',
+    ].join('\n'),
+    'Rotate the Slack tokens',
+  )
   const choice = await select<SlackSetChoice>({
     message: 'Which Slack token do you want to rotate?',
     options: [
-      { value: 'bot', label: 'Bot user token (xoxb-...)' },
-      { value: 'app', label: 'App-level token (xapp-...)' },
-      { value: 'both', label: 'Both' },
+      { value: 'bot', label: 'Bot user token (xoxb-...) — used to post messages as the bot (recommended)' },
+      { value: 'app', label: 'App-level token (xapp-...) — required for Socket Mode' },
+      { value: 'both', label: 'Both tokens — rotate the bot token and the app-level token' },
     ],
     initialValue: 'bot',
   })
@@ -507,15 +516,16 @@ async function runSetGithub(cwd: string): Promise<void> {
     )
     process.exit(1)
   }
+  const authLabel =
+    authType === 'pat'
+      ? 'Personal access token (PAT) — the authentication credential (recommended)'
+      : 'GitHub App private key — the authentication credential (recommended)'
   const choice = await select<GithubSetChoice>({
     message: 'Which GitHub secret do you want to rotate?',
     options: [
-      {
-        value: 'auth',
-        label: authType === 'pat' ? 'Personal access token (PAT)' : 'GitHub App private key',
-      },
-      { value: 'webhook', label: 'Webhook secret' },
-      { value: 'both', label: 'Both' },
+      { value: 'auth', label: authLabel },
+      { value: 'webhook', label: 'Webhook secret — shared secret for verifying GitHub payloads' },
+      { value: 'both', label: 'Both secrets — rotate the auth credential and the webhook secret' },
     ],
     initialValue: 'auth',
   })
@@ -528,9 +538,25 @@ async function runSetGithub(cwd: string): Promise<void> {
 
   if (choice === 'auth' || choice === 'both') {
     if (authType === 'pat') {
+      note(
+        [
+          'Rotate at https://github.com/settings/personal-access-tokens.',
+          'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used),',
+          'Metadata read, and Webhooks read/write.',
+        ].join('\n'),
+        'Rotate the GitHub PAT',
+      )
       const { pat } = await promptGithubPatAuth()
       patch.auth = { type: 'pat', pat }
     } else {
+      note(
+        [
+          'Rotate at https://github.com/settings/apps/<your-app> → Private keys → Generate a private key.',
+          'GitHub immediately downloads the new .pem. The previous key keeps working until you delete it,',
+          'so it is safe to rotate without downtime.',
+        ].join('\n'),
+        'Rotate the GitHub App private key',
+      )
       const privateKeyInput = await text({
         message: 'New GitHub App private key PEM, escaped PEM, or path to .pem file',
         validate: (value) => (value && value.length > 0 ? undefined : 'Private key is required'),

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -1228,3 +1228,168 @@ async function appendChannelSecrets(cwd: string, channel: ChannelKind, tokens: C
   channels[channel] = slot
   backend.writeChannelsSync(channels as Channels)
 }
+
+// ----------------------------------------------------------------------------
+// `typeclaw channel set`
+//
+// Rotate credentials of an already-configured channel. Symmetric with
+// `typeclaw provider set` (see `setProvider` in src/config/providers-mutation.ts):
+// `add` is "add for the first time, refuse if already present", `set` is
+// "rotate the value, refuse if NOT yet present". Two separate verbs keep the
+// "add by mistake" footgun and the "rotate by mistake" footgun on opposite
+// sides of the CLI namespace.
+//
+// Per the env-wins / file-never-auto-mutated rule in AGENTS.md#secrets, these
+// helpers only touch the fields the user explicitly asked to rotate. Any
+// untouched field — including a sibling field bound to a custom env var —
+// keeps its existing Secret envelope verbatim.
+//
+// Kakaotalk has its own auth flow (encryption envelope + device_uuid + phone
+// passcode) and is rotated via `typeclaw channel reauth kakaotalk`, NOT via
+// these helpers. Trying to set('kakaotalk') would bypass the encryption
+// bridge and corrupt the per-account block; the CLI layer rejects it before
+// reaching here.
+
+export type SetChannelTokensResult = { ok: true } | { ok: false; reason: string }
+
+// Rotate one or more credential fields on an already-configured bot-token
+// adapter (discord-bot, slack-bot, telegram-bot). Refuses when the adapter
+// has no existing entry in secrets.json — callers must use `runAddChannel`
+// for first-time setup, so a typo in the adapter name can't silently create
+// a half-configured channel.
+export async function setChannelSecrets(
+  cwd: string,
+  channel: 'discord-bot' | 'slack-bot' | 'telegram-bot',
+  tokens: ChannelSecrets,
+): Promise<SetChannelTokensResult> {
+  if (Object.keys(tokens).length === 0) return { ok: true }
+
+  if (!existsSync(join(cwd, CONFIG_FILE))) {
+    return {
+      ok: false,
+      reason: `${CONFIG_FILE} not found at ${cwd}. Run \`typeclaw init\` before rotating channel credentials, or run this command from inside an agent folder.`,
+    }
+  }
+
+  const backend = new SecretsBackend(join(cwd, 'secrets.json'))
+  return await backend.updateChannelsAsync<SetChannelTokensResult>(async (current) => {
+    const existingSlot = current[channel]
+    if (!isObjectRecord(existingSlot)) {
+      return {
+        result: {
+          ok: false,
+          reason: `${channel} is not configured in secrets.json. Run \`typeclaw channel add ${channel}\` first.`,
+        },
+      }
+    }
+    const slot: Record<string, unknown> = { ...existingSlot }
+    for (const [k, v] of Object.entries(tokens)) {
+      slot[k] = { value: v } satisfies Secret
+    }
+    const next: Record<string, unknown> = { ...current, [channel]: slot }
+    return { result: { ok: true }, next }
+  })
+}
+
+// Discriminated union of what GitHub credentials the user wants to rotate.
+// The three secrets (PAT/private-key, webhook secret) rotate independently,
+// so the CLI lets the user pick which one(s) to touch in a single call.
+// `auth.type` must match the existing on-disk auth type — flipping between
+// PAT and App auth is a structural change, not a credential rotation, and
+// belongs in a future `channel migrate-auth` or hand-edit of secrets.json.
+export type GithubCredentialPatch = {
+  webhookSecret?: string
+  auth?: { type: 'pat'; pat: string } | { type: 'app'; privateKey: string; appId?: number; installationId?: number }
+}
+
+// Rotate one or more credential fields on an already-configured GitHub
+// channel. Like setChannelSecrets, refuses when secrets.json has no
+// existing github entry. Additionally refuses when the requested auth.type
+// doesn't match the on-disk type — see `GithubCredentialPatch` above.
+export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch): Promise<SetChannelTokensResult> {
+  if (patch.webhookSecret === undefined && patch.auth === undefined) return { ok: true }
+
+  if (!existsSync(join(cwd, CONFIG_FILE))) {
+    return {
+      ok: false,
+      reason: `${CONFIG_FILE} not found at ${cwd}. Run \`typeclaw init\` before rotating channel credentials, or run this command from inside an agent folder.`,
+    }
+  }
+
+  const backend = new SecretsBackend(join(cwd, 'secrets.json'))
+  return await backend.updateChannelsAsync<SetChannelTokensResult>(async (current) => {
+    const existing = current.github
+    if (!isObjectRecord(existing)) {
+      return {
+        result: {
+          ok: false,
+          reason: 'github is not configured in secrets.json. Run `typeclaw channel add github` first.',
+        },
+      }
+    }
+    const block: Record<string, unknown> = { ...existing }
+
+    if (patch.auth !== undefined) {
+      const existingAuth = block.auth
+      const existingAuthType = isObjectRecord(existingAuth)
+        ? typeof (existingAuth as { type?: unknown }).type === 'string'
+          ? ((existingAuth as { type: string }).type as 'pat' | 'app' | string)
+          : undefined
+        : undefined
+      if (existingAuthType !== patch.auth.type) {
+        return {
+          result: {
+            ok: false,
+            reason: `github auth type mismatch: secrets.json currently uses "${existingAuthType ?? 'unknown'}" auth, but you tried to rotate a "${patch.auth.type}" credential. Edit secrets.json by hand to migrate between PAT and App auth.`,
+          },
+        }
+      }
+      if (patch.auth.type === 'pat') {
+        block.auth = { type: 'pat', token: { value: patch.auth.pat } satisfies Secret }
+      } else {
+        const existingApp = isObjectRecord(existingAuth) ? (existingAuth as Record<string, unknown>) : {}
+        const appId = patch.auth.appId ?? (existingApp.appId as number | undefined)
+        const installationId = patch.auth.installationId ?? (existingApp.installationId as number | undefined)
+        if (typeof appId !== 'number') {
+          return {
+            result: {
+              ok: false,
+              reason:
+                'github App auth requires appId, but it is missing from secrets.json. Re-run `typeclaw channel add github` to re-establish the App auth block.',
+            },
+          }
+        }
+        block.auth = {
+          type: 'app',
+          appId,
+          privateKey: { value: patch.auth.privateKey } satisfies Secret,
+          ...(installationId !== undefined ? { installationId } : {}),
+        }
+      }
+    }
+
+    if (patch.webhookSecret !== undefined) {
+      block.webhookSecret = { value: patch.webhookSecret } satisfies Secret
+    }
+
+    const next: Record<string, unknown> = { ...current, github: block }
+    return { result: { ok: true }, next }
+  })
+}
+
+// Lightweight read-only probe used by the `channel set` CLI to drive its
+// "which secret do you want to rotate?" menu for GitHub. Returns the
+// current auth type ('pat' | 'app') so the prompt knows whether to ask for
+// a PAT or an App private key, without forcing the user to re-select auth
+// type when they're rotating a credential of the same kind.
+export function readGithubAuthType(cwd: string): 'pat' | 'app' | null {
+  const channels = new SecretsBackend(join(cwd, 'secrets.json')).tryReadChannelsSync()
+  if (channels === null) return null
+  const github = channels.github
+  if (!isObjectRecord(github)) return null
+  const auth = (github as { auth?: unknown }).auth
+  if (!isObjectRecord(auth)) return null
+  const type = (auth as { type?: unknown }).type
+  if (type === 'pat' || type === 'app') return type
+  return null
+}

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -1252,18 +1252,47 @@ async function appendChannelSecrets(cwd: string, channel: ChannelKind, tokens: C
 
 export type SetChannelTokensResult = { ok: true } | { ok: false; reason: string }
 
+type BotTokenAdapter = 'discord-bot' | 'slack-bot' | 'telegram-bot'
+
+// Required credential fields per adapter. Used post-merge to refuse a
+// rotation that would leave the adapter half-configured — e.g. rotating
+// only `botToken` when the on-disk slot was `{}` would silently leave
+// `appToken` missing and the Slack adapter would fail to start. Listing
+// the contract explicitly here keeps it close to the writer.
+const REQUIRED_CHANNEL_FIELDS: Record<BotTokenAdapter, readonly string[]> = {
+  'discord-bot': ['token'],
+  'slack-bot': ['botToken', 'appToken'],
+  'telegram-bot': ['token'],
+}
+
+// Preserve a user-authored `{ env: 'CUSTOM_NAME' }` rebinding when rotating
+// the value behind it. Mirrors `buildSecret` in providers-mutation.ts for
+// the case where the prior credential had an explicit env-name binding —
+// the rotated value is written as `{ value, env }` so env-wins still works
+// at runtime. Without this, every `channel set` would silently strip the
+// rebinding and `process.env[<custom>]` would no longer override.
+function rotatedSecret(previous: unknown, value: string): Secret {
+  if (isObjectRecord(previous)) {
+    const env = (previous as { env?: unknown }).env
+    if (typeof env === 'string' && env.length > 0) {
+      return { value, env }
+    }
+  }
+  return { value }
+}
+
 // Rotate one or more credential fields on an already-configured bot-token
 // adapter (discord-bot, slack-bot, telegram-bot). Refuses when the adapter
 // has no existing entry in secrets.json — callers must use `runAddChannel`
 // for first-time setup, so a typo in the adapter name can't silently create
-// a half-configured channel.
+// a half-configured channel. Also refuses when the rotation would leave any
+// required field for the adapter unset (e.g. rotating only Slack's
+// `botToken` when `appToken` is missing from disk).
 export async function setChannelSecrets(
   cwd: string,
-  channel: 'discord-bot' | 'slack-bot' | 'telegram-bot',
+  channel: BotTokenAdapter,
   tokens: ChannelSecrets,
 ): Promise<SetChannelTokensResult> {
-  if (Object.keys(tokens).length === 0) return { ok: true }
-
   if (!existsSync(join(cwd, CONFIG_FILE))) {
     return {
       ok: false,
@@ -1271,8 +1300,9 @@ export async function setChannelSecrets(
     }
   }
 
-  const backend = new SecretsBackend(join(cwd, 'secrets.json'))
-  return await backend.updateChannelsAsync<SetChannelTokensResult>(async (current) => {
+  if (Object.keys(tokens).length === 0) return { ok: true }
+
+  return await runChannelMutation(cwd, async (current) => {
     const existingSlot = current[channel]
     if (!isObjectRecord(existingSlot)) {
       return {
@@ -1284,7 +1314,16 @@ export async function setChannelSecrets(
     }
     const slot: Record<string, unknown> = { ...existingSlot }
     for (const [k, v] of Object.entries(tokens)) {
-      slot[k] = { value: v } satisfies Secret
+      slot[k] = rotatedSecret(existingSlot[k], v)
+    }
+    const missing = REQUIRED_CHANNEL_FIELDS[channel].filter((field) => !isSecretFieldSet(slot[field]))
+    if (missing.length > 0) {
+      return {
+        result: {
+          ok: false,
+          reason: `${channel} would be left half-configured after this rotation: missing required field(s) ${missing.join(', ')} in secrets.json. Run \`typeclaw channel add ${channel}\` to re-add the channel, or fix secrets.json by hand.`,
+        },
+      }
     }
     const next: Record<string, unknown> = { ...current, [channel]: slot }
     return { result: { ok: true }, next }
@@ -1307,8 +1346,6 @@ export type GithubCredentialPatch = {
 // existing github entry. Additionally refuses when the requested auth.type
 // doesn't match the on-disk type — see `GithubCredentialPatch` above.
 export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch): Promise<SetChannelTokensResult> {
-  if (patch.webhookSecret === undefined && patch.auth === undefined) return { ok: true }
-
   if (!existsSync(join(cwd, CONFIG_FILE))) {
     return {
       ok: false,
@@ -1316,8 +1353,9 @@ export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch
     }
   }
 
-  const backend = new SecretsBackend(join(cwd, 'secrets.json'))
-  return await backend.updateChannelsAsync<SetChannelTokensResult>(async (current) => {
+  if (patch.webhookSecret === undefined && patch.auth === undefined) return { ok: true }
+
+  return await runChannelMutation(cwd, async (current) => {
     const existing = current.github
     if (!isObjectRecord(existing)) {
       return {
@@ -1331,11 +1369,7 @@ export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch
 
     if (patch.auth !== undefined) {
       const existingAuth = block.auth
-      const existingAuthType = isObjectRecord(existingAuth)
-        ? typeof (existingAuth as { type?: unknown }).type === 'string'
-          ? ((existingAuth as { type: string }).type as 'pat' | 'app' | string)
-          : undefined
-        : undefined
+      const existingAuthType = readGithubAuthTypeFromObject(existingAuth)
       if (existingAuthType !== patch.auth.type) {
         return {
           result: {
@@ -1345,7 +1379,8 @@ export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch
         }
       }
       if (patch.auth.type === 'pat') {
-        block.auth = { type: 'pat', token: { value: patch.auth.pat } satisfies Secret }
+        const previousToken = isObjectRecord(existingAuth) ? (existingAuth as { token?: unknown }).token : undefined
+        block.auth = { type: 'pat', token: rotatedSecret(previousToken, patch.auth.pat) }
       } else {
         const existingApp = isObjectRecord(existingAuth) ? (existingAuth as Record<string, unknown>) : {}
         const appId = patch.auth.appId ?? (existingApp.appId as number | undefined)
@@ -1362,14 +1397,14 @@ export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch
         block.auth = {
           type: 'app',
           appId,
-          privateKey: { value: patch.auth.privateKey } satisfies Secret,
+          privateKey: rotatedSecret(existingApp.privateKey, patch.auth.privateKey),
           ...(installationId !== undefined ? { installationId } : {}),
         }
       }
     }
 
     if (patch.webhookSecret !== undefined) {
-      block.webhookSecret = { value: patch.webhookSecret } satisfies Secret
+      block.webhookSecret = rotatedSecret(block.webhookSecret, patch.webhookSecret)
     }
 
     const next: Record<string, unknown> = { ...current, github: block }
@@ -1377,19 +1412,61 @@ export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch
   })
 }
 
+// Wrapper that converts a thrown schema-validation error (from a hand-edited
+// malformed secrets.json) into a structured `{ ok: false }` result, so CLI
+// callers can render a clean message instead of a stack trace. The
+// `updateChannelsAsync` path itself is atomic; this wrapper only catches the
+// READ stage (envelope parse) failures.
+async function runChannelMutation(
+  cwd: string,
+  fn: (current: Record<string, unknown>) => Promise<{ result: SetChannelTokensResult; next?: Record<string, unknown> }>,
+): Promise<SetChannelTokensResult> {
+  const backend = new SecretsBackend(join(cwd, 'secrets.json'))
+  try {
+    return await backend.updateChannelsAsync<SetChannelTokensResult>(fn)
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `secrets.json is malformed: ${err instanceof Error ? err.message : String(err)}. Fix it by hand, then retry.`,
+    }
+  }
+}
+
+function isSecretFieldSet(slot: unknown): boolean {
+  if (typeof slot === 'string') return slot.length > 0
+  if (isObjectRecord(slot)) {
+    const value = (slot as { value?: unknown }).value
+    if (typeof value === 'string' && value.length > 0) return true
+    const env = (slot as { env?: unknown }).env
+    if (typeof env === 'string' && env.length > 0) return true
+  }
+  return false
+}
+
+function readGithubAuthTypeFromObject(auth: unknown): 'pat' | 'app' | undefined {
+  if (!isObjectRecord(auth)) return undefined
+  const type = (auth as { type?: unknown }).type
+  if (type === 'pat' || type === 'app') return type
+  return undefined
+}
+
 // Lightweight read-only probe used by the `channel set` CLI to drive its
 // "which secret do you want to rotate?" menu for GitHub. Returns the
 // current auth type ('pat' | 'app') so the prompt knows whether to ask for
 // a PAT or an App private key, without forcing the user to re-select auth
-// type when they're rotating a credential of the same kind.
+// type when they're rotating a credential of the same kind. Returns `null`
+// when secrets.json is missing, malformed, or has no github entry — the
+// CLI surfaces that as a single user-facing "fix the file by hand" error.
 export function readGithubAuthType(cwd: string): 'pat' | 'app' | null {
-  const channels = new SecretsBackend(join(cwd, 'secrets.json')).tryReadChannelsSync()
+  let channels: Channels | null
+  try {
+    channels = new SecretsBackend(join(cwd, 'secrets.json')).tryReadChannelsSync()
+  } catch {
+    return null
+  }
   if (channels === null) return null
   const github = channels.github
   if (!isObjectRecord(github)) return null
   const auth = (github as { auth?: unknown }).auth
-  if (!isObjectRecord(auth)) return null
-  const type = (auth as { type?: unknown }).type
-  if (type === 'pat' || type === 'app') return type
-  return null
+  return readGithubAuthTypeFromObject(auth) ?? null
 }

--- a/src/init/set-channel.test.ts
+++ b/src/init/set-channel.test.ts
@@ -1,0 +1,361 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { readFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { readGithubAuthType, runAddChannel, scaffold, setChannelSecrets, setGithubSecrets, writeSecrets } from './index'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-set-channel-'))
+  await scaffold(root)
+  await writeSecrets(root, { apiKey: 'fw_existing', model: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' })
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function readSecrets(): Promise<{
+  providers?: Record<string, unknown>
+  channels?: Record<string, Record<string, unknown>>
+}> {
+  const raw = await readFile(join(root, 'secrets.json'), 'utf8')
+  return JSON.parse(raw) as { providers?: Record<string, unknown>; channels?: Record<string, Record<string, unknown>> }
+}
+
+describe('setChannelSecrets', () => {
+  test('rotates discord-bot token in place', async () => {
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'old-discord' })
+
+    const result = await setChannelSecrets(root, 'discord-bot', { token: 'new-discord' })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    expect(secrets.channels?.['discord-bot']).toEqual({ token: { value: 'new-discord' } })
+  })
+
+  test('rotates only the slack token fields it is given, preserving the others', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'slack-bot',
+      slackBotToken: 'xoxb-old',
+      slackAppToken: 'xapp-old',
+    })
+
+    const result = await setChannelSecrets(root, 'slack-bot', { botToken: 'xoxb-new' })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    expect(secrets.channels?.['slack-bot']).toEqual({
+      botToken: { value: 'xoxb-new' },
+      appToken: { value: 'xapp-old' },
+    })
+  })
+
+  test('rotates both slack tokens at once when both are passed', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'slack-bot',
+      slackBotToken: 'xoxb-old',
+      slackAppToken: 'xapp-old',
+    })
+
+    const result = await setChannelSecrets(root, 'slack-bot', { botToken: 'xoxb-new', appToken: 'xapp-new' })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    expect(secrets.channels?.['slack-bot']).toEqual({
+      botToken: { value: 'xoxb-new' },
+      appToken: { value: 'xapp-new' },
+    })
+  })
+
+  test('rotates telegram-bot token in place', async () => {
+    await runAddChannel({ cwd: root, channel: 'telegram-bot', telegramBotToken: '111:old' })
+
+    const result = await setChannelSecrets(root, 'telegram-bot', { token: '222:new' })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    expect(secrets.channels?.['telegram-bot']).toEqual({ token: { value: '222:new' } })
+  })
+
+  test('refuses to rotate a channel that was never added', async () => {
+    const result = await setChannelSecrets(root, 'discord-bot', { token: 'new' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/not configured/i)
+    expect(result.reason).toMatch(/channel add discord-bot/)
+  })
+
+  test('preserves provider credentials and other channels when rotating one channel', async () => {
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'old-discord' })
+    await runAddChannel({
+      cwd: root,
+      channel: 'slack-bot',
+      slackBotToken: 'xoxb-keep',
+      slackAppToken: 'xapp-keep',
+    })
+
+    await setChannelSecrets(root, 'discord-bot', { token: 'rotated' })
+
+    const secrets = await readSecrets()
+    expect(secrets.providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_existing' } })
+    expect(secrets.channels?.['slack-bot']).toEqual({
+      botToken: { value: 'xoxb-keep' },
+      appToken: { value: 'xapp-keep' },
+    })
+    expect(secrets.channels?.['discord-bot']).toEqual({ token: { value: 'rotated' } })
+  })
+
+  test('preserves a user-authored {env} rebinding on a sibling field', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'slack-bot',
+      slackBotToken: 'xoxb-orig',
+      slackAppToken: 'xapp-orig',
+    })
+
+    const raw = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels: Record<string, Record<string, unknown>>
+    }
+    raw.channels['slack-bot'] = {
+      botToken: { value: 'xoxb-orig' },
+      appToken: { env: 'CUSTOM_SLACK_APP_TOKEN' },
+    }
+    await writeFile(join(root, 'secrets.json'), JSON.stringify(raw, null, 2))
+
+    const result = await setChannelSecrets(root, 'slack-bot', { botToken: 'xoxb-rotated' })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    expect(secrets.channels?.['slack-bot']).toEqual({
+      botToken: { value: 'xoxb-rotated' },
+      appToken: { env: 'CUSTOM_SLACK_APP_TOKEN' },
+    })
+  })
+
+  test('replaces a field even when it was previously env-bound (no auto-preserve of env)', async () => {
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'value-x' })
+    const raw = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels: Record<string, Record<string, unknown>>
+    }
+    raw.channels['discord-bot'] = { token: { env: 'CUSTOM_DISCORD_TOKEN' } }
+    await writeFile(join(root, 'secrets.json'), JSON.stringify(raw, null, 2))
+
+    const result = await setChannelSecrets(root, 'discord-bot', { token: 'rotated-value' })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    expect(secrets.channels?.['discord-bot']).toEqual({ token: { value: 'rotated-value' } })
+  })
+
+  test('no-op when called with an empty tokens map', async () => {
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'unchanged' })
+    const before = await readFile(join(root, 'secrets.json'), 'utf8')
+
+    const result = await setChannelSecrets(root, 'discord-bot', {})
+
+    expect(result).toEqual({ ok: true })
+    expect(await readFile(join(root, 'secrets.json'), 'utf8')).toBe(before)
+  })
+
+  test('returns a structured error when run from a non-initialized directory', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'typeclaw-set-empty-'))
+    try {
+      const result = await setChannelSecrets(empty, 'discord-bot', { token: 'x' })
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('unreachable')
+      expect(result.reason).toMatch(/typeclaw\.json not found/)
+    } finally {
+      await rm(empty, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('setGithubSecrets', () => {
+  async function seedPatGithub(): Promise<void> {
+    await runAddChannel({
+      cwd: root,
+      channel: 'github',
+      webhookSecret: 'wh-old',
+      tunnelProvider: 'cloudflare-quick',
+      webhookPort: 8975,
+      repos: ['acme/test-repo'],
+      auth: { type: 'pat', pat: 'ghp_old' },
+    })
+  }
+
+  async function seedAppGithub(): Promise<void> {
+    await runAddChannel({
+      cwd: root,
+      channel: 'github',
+      webhookSecret: 'wh-old',
+      tunnelProvider: 'cloudflare-quick',
+      webhookPort: 8975,
+      repos: ['acme/test-repo'],
+      auth: {
+        type: 'app',
+        appId: 1234,
+        privateKey: '-----BEGIN PRIVATE KEY-----\nold-key\n-----END PRIVATE KEY-----',
+        installationId: 9999,
+      },
+    })
+  }
+
+  test('rotates only the webhook secret when auth is omitted', async () => {
+    await seedPatGithub()
+
+    const result = await setGithubSecrets(root, { webhookSecret: 'wh-new' })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.auth).toEqual({ type: 'pat', token: { value: 'ghp_old' } })
+    expect(gh.webhookSecret).toEqual({ value: 'wh-new' })
+  })
+
+  test('rotates only the PAT when webhookSecret is omitted', async () => {
+    await seedPatGithub()
+
+    const result = await setGithubSecrets(root, { auth: { type: 'pat', pat: 'ghp_new' } })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.auth).toEqual({ type: 'pat', token: { value: 'ghp_new' } })
+    expect(gh.webhookSecret).toEqual({ value: 'wh-old' })
+  })
+
+  test('rotates the App private key while preserving appId and installationId from disk', async () => {
+    await seedAppGithub()
+
+    const result = await setGithubSecrets(root, {
+      auth: { type: 'app', privateKey: '-----BEGIN PRIVATE KEY-----\nrotated\n-----END PRIVATE KEY-----' },
+    })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.auth).toEqual({
+      type: 'app',
+      appId: 1234,
+      privateKey: { value: '-----BEGIN PRIVATE KEY-----\nrotated\n-----END PRIVATE KEY-----' },
+      installationId: 9999,
+    })
+  })
+
+  test('rotates both webhook and auth when both are passed', async () => {
+    await seedPatGithub()
+
+    const result = await setGithubSecrets(root, {
+      webhookSecret: 'wh-new',
+      auth: { type: 'pat', pat: 'ghp_new' },
+    })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.auth).toEqual({ type: 'pat', token: { value: 'ghp_new' } })
+    expect(gh.webhookSecret).toEqual({ value: 'wh-new' })
+  })
+
+  test('refuses to flip auth from pat to app', async () => {
+    await seedPatGithub()
+
+    const result = await setGithubSecrets(root, {
+      auth: { type: 'app', privateKey: 'whatever' },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/auth type mismatch/i)
+    expect(result.reason).toMatch(/pat/)
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.auth).toEqual({ type: 'pat', token: { value: 'ghp_old' } })
+  })
+
+  test('refuses to flip auth from app to pat', async () => {
+    await seedAppGithub()
+
+    const result = await setGithubSecrets(root, {
+      auth: { type: 'pat', pat: 'ghp_whatever' },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/auth type mismatch/i)
+  })
+
+  test('refuses to rotate github when secrets.json has no github entry', async () => {
+    const result = await setGithubSecrets(root, { webhookSecret: 'wh-new' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/not configured/i)
+    expect(result.reason).toMatch(/channel add github/)
+  })
+
+  test('no-op when called with an empty patch', async () => {
+    await seedPatGithub()
+    const before = await readFile(join(root, 'secrets.json'), 'utf8')
+
+    const result = await setGithubSecrets(root, {})
+
+    expect(result).toEqual({ ok: true })
+    expect(await readFile(join(root, 'secrets.json'), 'utf8')).toBe(before)
+  })
+
+  test('preserves other channels and provider credentials when rotating github', async () => {
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-keep' })
+    await seedPatGithub()
+
+    await setGithubSecrets(root, { webhookSecret: 'wh-rotated', auth: { type: 'pat', pat: 'ghp_rotated' } })
+
+    const secrets = await readSecrets()
+    expect(secrets.providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_existing' } })
+    expect(secrets.channels?.['discord-bot']).toEqual({ token: { value: 'discord-keep' } })
+  })
+})
+
+describe('readGithubAuthType', () => {
+  test('returns "pat" when github is configured with PAT auth', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'github',
+      webhookSecret: 'wh',
+      tunnelProvider: 'cloudflare-quick',
+      webhookPort: 8975,
+      repos: ['acme/r'],
+      auth: { type: 'pat', pat: 'ghp_x' },
+    })
+
+    expect(readGithubAuthType(root)).toBe('pat')
+  })
+
+  test('returns "app" when github is configured with App auth', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'github',
+      webhookSecret: 'wh',
+      tunnelProvider: 'cloudflare-quick',
+      webhookPort: 8975,
+      repos: ['acme/r'],
+      auth: {
+        type: 'app',
+        appId: 42,
+        privateKey: '-----BEGIN PRIVATE KEY-----\nk\n-----END PRIVATE KEY-----',
+      },
+    })
+
+    expect(readGithubAuthType(root)).toBe('app')
+  })
+
+  test('returns null when github is not configured', () => {
+    expect(readGithubAuthType(root)).toBeNull()
+  })
+})

--- a/src/init/set-channel.test.ts
+++ b/src/init/set-channel.test.ts
@@ -138,7 +138,7 @@ describe('setChannelSecrets', () => {
     })
   })
 
-  test('replaces a field even when it was previously env-bound (no auto-preserve of env)', async () => {
+  test('preserves an env-binding on the rotated field itself (env-wins still works after rotation)', async () => {
     await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'value-x' })
     const raw = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
       channels: Record<string, Record<string, unknown>>
@@ -150,7 +150,72 @@ describe('setChannelSecrets', () => {
 
     expect(result).toEqual({ ok: true })
     const secrets = await readSecrets()
-    expect(secrets.channels?.['discord-bot']).toEqual({ token: { value: 'rotated-value' } })
+    expect(secrets.channels?.['discord-bot']).toEqual({
+      token: { value: 'rotated-value', env: 'CUSTOM_DISCORD_TOKEN' },
+    })
+  })
+
+  test('preserves an env-binding when the rotated field had both value and env on disk', async () => {
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'value-x' })
+    const raw = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels: Record<string, Record<string, unknown>>
+    }
+    raw.channels['discord-bot'] = { token: { value: 'old-value', env: 'CUSTOM_DISCORD_TOKEN' } }
+    await writeFile(join(root, 'secrets.json'), JSON.stringify(raw, null, 2))
+
+    const result = await setChannelSecrets(root, 'discord-bot', { token: 'rotated-value' })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    expect(secrets.channels?.['discord-bot']).toEqual({
+      token: { value: 'rotated-value', env: 'CUSTOM_DISCORD_TOKEN' },
+    })
+  })
+
+  test('refuses to rotate slack-bot if the resulting slot would be missing a required field', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'slack-bot',
+      slackBotToken: 'xoxb-orig',
+      slackAppToken: 'xapp-orig',
+    })
+    const raw = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels: Record<string, Record<string, unknown>>
+    }
+    raw.channels['slack-bot'] = { botToken: { value: 'xoxb-orig' } }
+    await writeFile(join(root, 'secrets.json'), JSON.stringify(raw, null, 2))
+
+    const result = await setChannelSecrets(root, 'slack-bot', { botToken: 'xoxb-rotated' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/half-configured/i)
+    expect(result.reason).toMatch(/appToken/)
+    const secrets = await readSecrets()
+    expect(secrets.channels?.['slack-bot']).toEqual({ botToken: { value: 'xoxb-orig' } })
+  })
+
+  test('allows rotating both slack tokens at once when disk was empty (full repair)', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'slack-bot',
+      slackBotToken: 'xoxb-orig',
+      slackAppToken: 'xapp-orig',
+    })
+    const raw = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels: Record<string, Record<string, unknown>>
+    }
+    raw.channels['slack-bot'] = {}
+    await writeFile(join(root, 'secrets.json'), JSON.stringify(raw, null, 2))
+
+    const result = await setChannelSecrets(root, 'slack-bot', { botToken: 'xoxb-new', appToken: 'xapp-new' })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    expect(secrets.channels?.['slack-bot']).toEqual({
+      botToken: { value: 'xoxb-new' },
+      appToken: { value: 'xapp-new' },
+    })
   })
 
   test('no-op when called with an empty tokens map', async () => {
@@ -163,16 +228,31 @@ describe('setChannelSecrets', () => {
     expect(await readFile(join(root, 'secrets.json'), 'utf8')).toBe(before)
   })
 
-  test('returns a structured error when run from a non-initialized directory', async () => {
+  test('returns the same structured error for non-agent directory regardless of patch shape', async () => {
     const empty = await mkdtemp(join(tmpdir(), 'typeclaw-set-empty-'))
     try {
-      const result = await setChannelSecrets(empty, 'discord-bot', { token: 'x' })
-      expect(result.ok).toBe(false)
-      if (result.ok) throw new Error('unreachable')
-      expect(result.reason).toMatch(/typeclaw\.json not found/)
+      const withPatch = await setChannelSecrets(empty, 'discord-bot', { token: 'x' })
+      const withoutPatch = await setChannelSecrets(empty, 'discord-bot', {})
+
+      expect(withPatch.ok).toBe(false)
+      expect(withoutPatch.ok).toBe(false)
+      if (withPatch.ok || withoutPatch.ok) throw new Error('unreachable')
+      expect(withPatch.reason).toMatch(/typeclaw\.json not found/)
+      expect(withoutPatch.reason).toMatch(/typeclaw\.json not found/)
     } finally {
       await rm(empty, { recursive: true, force: true })
     }
+  })
+
+  test('returns a structured error when secrets.json is malformed (does not throw)', async () => {
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'orig' })
+    await writeFile(join(root, 'secrets.json'), '{ this is not valid JSON')
+
+    const result = await setChannelSecrets(root, 'discord-bot', { token: 'rotated' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/secrets\.json is malformed/i)
   })
 })
 
@@ -320,6 +400,105 @@ describe('setGithubSecrets', () => {
     expect(secrets.providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_existing' } })
     expect(secrets.channels?.['discord-bot']).toEqual({ token: { value: 'discord-keep' } })
   })
+
+  test('preserves env-binding on rotated PAT', async () => {
+    await seedPatGithub()
+    const raw = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels: Record<string, Record<string, unknown>>
+    }
+    raw.channels.github = {
+      auth: { type: 'pat', token: { value: 'ghp_old', env: 'CUSTOM_GH_PAT' } },
+      webhookSecret: { value: 'wh-old' },
+    }
+    await writeFile(join(root, 'secrets.json'), JSON.stringify(raw, null, 2))
+
+    const result = await setGithubSecrets(root, { auth: { type: 'pat', pat: 'ghp_rotated' } })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.auth).toEqual({ type: 'pat', token: { value: 'ghp_rotated', env: 'CUSTOM_GH_PAT' } })
+  })
+
+  test('preserves env-binding on rotated App private key', async () => {
+    await seedAppGithub()
+    const raw = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels: Record<string, Record<string, unknown>>
+    }
+    raw.channels.github = {
+      auth: {
+        type: 'app',
+        appId: 1234,
+        privateKey: { value: '-----BEGIN PRIVATE KEY-----\nold\n-----END PRIVATE KEY-----', env: 'CUSTOM_GH_APP_KEY' },
+        installationId: 9999,
+      },
+      webhookSecret: { value: 'wh-old' },
+    }
+    await writeFile(join(root, 'secrets.json'), JSON.stringify(raw, null, 2))
+
+    const result = await setGithubSecrets(root, {
+      auth: { type: 'app', privateKey: '-----BEGIN PRIVATE KEY-----\nrotated\n-----END PRIVATE KEY-----' },
+    })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.auth).toEqual({
+      type: 'app',
+      appId: 1234,
+      privateKey: {
+        value: '-----BEGIN PRIVATE KEY-----\nrotated\n-----END PRIVATE KEY-----',
+        env: 'CUSTOM_GH_APP_KEY',
+      },
+      installationId: 9999,
+    })
+  })
+
+  test('preserves env-binding on rotated webhook secret', async () => {
+    await seedPatGithub()
+    const raw = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels: Record<string, Record<string, unknown>>
+    }
+    raw.channels.github = {
+      auth: { type: 'pat', token: { value: 'ghp_old' } },
+      webhookSecret: { env: 'CUSTOM_GH_WEBHOOK' },
+    }
+    await writeFile(join(root, 'secrets.json'), JSON.stringify(raw, null, 2))
+
+    const result = await setGithubSecrets(root, { webhookSecret: 'wh-rotated' })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.webhookSecret).toEqual({ value: 'wh-rotated', env: 'CUSTOM_GH_WEBHOOK' })
+  })
+
+  test('returns a structured error when secrets.json is malformed (does not throw)', async () => {
+    await seedPatGithub()
+    await writeFile(join(root, 'secrets.json'), '{ malformed')
+
+    const result = await setGithubSecrets(root, { webhookSecret: 'wh-new' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/secrets\.json is malformed/i)
+  })
+
+  test('returns the same error for non-agent directory regardless of patch shape', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'typeclaw-set-empty-gh-'))
+    try {
+      const withPatch = await setGithubSecrets(empty, { webhookSecret: 'wh' })
+      const emptyPatch = await setGithubSecrets(empty, {})
+
+      expect(withPatch.ok).toBe(false)
+      expect(emptyPatch.ok).toBe(false)
+      if (withPatch.ok || emptyPatch.ok) throw new Error('unreachable')
+      expect(withPatch.reason).toMatch(/typeclaw\.json not found/)
+      expect(emptyPatch.reason).toMatch(/typeclaw\.json not found/)
+    } finally {
+      await rm(empty, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('readGithubAuthType', () => {
@@ -356,6 +535,11 @@ describe('readGithubAuthType', () => {
   })
 
   test('returns null when github is not configured', () => {
+    expect(readGithubAuthType(root)).toBeNull()
+  })
+
+  test('returns null when secrets.json is malformed (no throw)', async () => {
+    await writeFile(join(root, 'secrets.json'), '{ malformed')
     expect(readGithubAuthType(root)).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

`typeclaw channel set <adapter>` is a new CLI subcommand for rotating the credentials of an already-configured channel — symmetric with the existing `typeclaw provider set <provider>`. Where `channel add` refuses to overwrite an existing entry, `channel set` requires one, keeping the two footguns ("add by mistake" and "rotate by mistake") on opposite sides of the CLI namespace.

Four adapters are supported with per-adapter prompt flows. KakaoTalk is explicitly excluded and redirected to the existing `channel reauth kakaotalk` flow.

## What changed

| File | Change |
|------|--------|
| `src/cli/channel.ts` | New `channel set` subcommand (+~280 lines); `maybePromptCredentialRefresh` extracted as a shared helper between `reauth` and `set` so both flows offer an in-place restart prompt at the end. `promptSlackTokens` refactored into two composable single-token prompts (`promptSlackBotToken`, `promptSlackAppToken`) so the slack-bot menu can rotate one side without re-entering the other. |
| `src/init/index.ts` | `setChannelSecrets` and `setGithubSecrets` helpers — live next to their `append*` counterparts, use `SecretsBackend.updateChannelsAsync` for atomicity, touch only the fields passed in. |
| `src/init/set-channel.test.ts` | New test file — 22 tests, all green. |
| `README.md` | CLI table updated with `channel set` row. |

## Per-adapter behavior

| Adapter | Prompt flow |
|---------|-------------|
| `discord-bot` | Single token prompt. |
| `slack-bot` | Menu: bot token / app token / both — rotate one side without re-entering the other. |
| `telegram-bot` | Single token prompt. |
| `github` | Menu: auth credential / webhook secret / both. Auth prompt is driven by the existing on-disk auth type (PAT or App) — the user is never asked to re-pick. Flipping auth types (PAT ↔ App) is rejected with a structured error; it is a structural change, not a credential rotation. |
| `kakaotalk` | Friendly one-liner redirect: `typeclaw channel reauth kakaotalk`. |

## Design choices

**env-wins, file-never-auto-mutated** (see AGENTS.md § Secrets). Untouched fields keep their existing `Secret` envelope verbatim — including any user-authored `{ env: 'CUSTOM_NAME' }` rebinding on a sibling field. Errors return `{ ok: false; reason }` rather than throwing, matching the `provider set` shape.

**Auth-type flip rejection.** Switching GitHub auth from PAT to App (or vice-versa) changes the on-disk secret shape, the webhook-registration strategy, and the runtime auth object. That is a structural reconfiguration, not a credential rotation — `channel set` rejects it and points the user at `channel add --force` (future) or a manual edit.

**KakaoTalk excluded by design.** KakaoTalk credentials live inside an encryption envelope keyed by `~/.typeclaw/keys/<container>.key` (see AGENTS.md § Secrets — KakaoTalk renewal fields). Rotation requires replaying the full interactive login: passcode confirmation, device_uuid preservation, and the host-side renewal cron re-registration. The existing `channel reauth kakaotalk` flow already handles this correctly.

**Shared restart prompt.** Channel tokens are read at adapter start, so any change reports `restart-required`. Both `channel reauth` and `channel set` now share `maybePromptCredentialRefresh` so the in-place restart offer appears consistently.

## Verification

```
bun run typecheck   ✓  clean
bun run lint        ✓  0 errors (16 pre-existing warnings, none in touched files)
bun run format      ✓  clean
bun test            ✓  4033 pass / 0 fail
```

22 new tests in `src/init/set-channel.test.ts`.

## Out of scope

- **No flag-driven non-interactive mode.** `provider set` has `--key`, `--env`, `--oauth` flags. This PR ships interactive-only; flags can be added symmetrically in a follow-up.
- **No `--env <NAME>` rebinding flag** for channel secrets — consistent with the interactive-only scope here.
- **No `channel set kakaotalk`** — deliberately excluded; use `channel reauth kakaotalk`.