### PR TITLE
channels: stop github webhook orphans from accumulating across tunnel URL rotation

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -161,6 +161,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
           reposCount: repos.length,
         })
       } else if (repos.length > 0) {
+        const legacyProviderHostSuffix = detectLegacyProviderHostSuffix(effectiveUrl)
         const registration = await registerGithubWebhooks({
           token: tokenFn,
           webhookUrl: effectiveUrl,
@@ -168,6 +169,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
           repos,
           events: cfg.eventAllowlist,
           managedPath,
+          ...(legacyProviderHostSuffix !== undefined ? { legacyProviderHostSuffix } : {}),
           fetchImpl,
         })
         managedHooks = registration.repos.flatMap((r) =>
@@ -237,6 +239,29 @@ function logSkippedRegistration(
       'binds a public URL to this channel. Add an entry to `tunnels[]` (e.g. `provider: "cloudflare-quick"`) ' +
       'or set `channels.github.webhookUrl` to a public URL to enable webhook delivery.',
   )
+}
+
+// Known tunnel-provider host suffixes whose hostnames rotate per container.
+// A pre-marker hook on one of these is unambiguously a typeclaw orphan from
+// this agent's prior runs (cloudflare-quick is per-container, the host
+// changes every restart, so a stale unmarked *.trycloudflare.com hook
+// pointing at a now-dead host cannot belong to any live service).
+// Extending: add the host suffix here AND verify that hooks on the new
+// provider always look unmarked (no operator-supplied path) before the
+// marker was introduced.
+const LEGACY_TUNNEL_PROVIDER_HOSTS: readonly string[] = ['.trycloudflare.com']
+
+function detectLegacyProviderHostSuffix(url: string): string | undefined {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return undefined
+  }
+  for (const suffix of LEGACY_TUNNEL_PROVIDER_HOSTS) {
+    if (parsed.host.endsWith(suffix)) return suffix
+  }
+  return undefined
 }
 
 function logRegistrationOutcome(logger: GithubAdapterLogger, result: WebhookRegistrationResult): void {

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -9,6 +9,7 @@ import { createDeliveryDedup } from './dedup'
 import { createGithubFetchAttachmentCallback } from './fetch-attachment'
 import { createGithubHistoryCallback } from './history'
 import { createGithubWebhookHandler } from './inbound'
+import { applyManagedPath, buildManagedPath, resolveAgentId } from './managed-path'
 import { createGithubMembershipResolver } from './membership'
 import { createGithubOutboundCallback } from './outbound'
 import { deregisterGithubWebhooks, registerGithubWebhooks, type WebhookRegistrationResult } from './webhook-register'
@@ -149,7 +150,11 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
       if (cfg.webhookUrl !== undefined && tunnelUrl !== null) {
         logger.warn('[github] webhookUrl configured; ignoring tunnel URL for webhook registration')
       }
-      const effectiveUrl = cfg.webhookUrl ?? tunnelUrl
+      const rawUrl = cfg.webhookUrl ?? tunnelUrl
+      const managedPath = buildManagedPath(
+        resolveAgentId({ containerName: process.env.TYPECLAW_CONTAINER_NAME, agentDir: options.agentDir }),
+      )
+      const effectiveUrl = rawUrl === null ? null : applyManagedPath(rawUrl, managedPath)
       if (effectiveUrl === null) {
         logSkippedRegistration(logger, {
           tunnelConfigured: options.tunnelConfiguredForChannel?.() ?? false,
@@ -162,6 +167,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
           webhookSecret,
           repos,
           events: cfg.eventAllowlist,
+          managedPath,
           fetchImpl,
         })
         managedHooks = registration.repos.flatMap((r) =>
@@ -236,8 +242,10 @@ function logSkippedRegistration(
 function logRegistrationOutcome(logger: GithubAdapterLogger, result: WebhookRegistrationResult): void {
   for (const r of result.repos) {
     if (r.action === 'created') logger.info(`[github] registered webhook ${r.hookId} on ${r.repo}`)
-    else if (r.action === 'updated') logger.info(`[github] updated webhook ${r.hookId} on ${r.repo}`)
-    else logger.warn(`[github] webhook register failed for ${r.repo}: ${r.error}`)
+    else if (r.action === 'updated') {
+      const tail = r.stalePruned > 0 ? ` (pruned ${r.stalePruned} stale)` : ''
+      logger.info(`[github] updated webhook ${r.hookId} on ${r.repo}${tail}`)
+    } else logger.warn(`[github] webhook register failed for ${r.repo}: ${r.error}`)
   }
 }
 

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -364,6 +364,68 @@ describe('createGithubAdapter lifecycle', () => {
     await adapter.stop()
   })
 
+  test('rotating tunnel URL across two adapter lifecycles: second start adopts and updates the prior hook instead of orphaning it', async () => {
+    type Hook = { id: number; config: { url: string } }
+    let nextHookId = 1000
+    const repoHooks: Hook[] = []
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') return Response.json(repoHooks)
+      if (url.endsWith('/repos/acme/widgets/hooks') && method === 'POST') {
+        const hook = { id: nextHookId++, config: { url: 'pending' } }
+        repoHooks.push(hook)
+        return Response.json({ id: hook.id }, { status: 201 })
+      }
+      const idMatch = url.match(/\/repos\/acme\/widgets\/hooks\/(\d+)$/)
+      if (idMatch && method === 'PATCH') return Response.json({ id: Number(idMatch[1]) })
+      if (idMatch && method === 'DELETE') {
+        const id = Number(idMatch[1])
+        const idx = repoHooks.findIndex((h) => h.id === id)
+        if (idx >= 0) repoHooks.splice(idx, 1)
+        return new Response('', { status: 204 })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    let currentTunnelUrl = 'https://first.trycloudflare.com'
+    const router1 = freshRouter()
+    const adapter1 = createGithubAdapter({
+      router: router1,
+      configRef: () => githubConfig(['acme/widgets'], null),
+      secrets: patSecrets(),
+      agentDir: '/tmp/coder',
+      logger: silentLogger(),
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      tunnelUrl: () => currentTunnelUrl,
+    })
+    await adapter1.start()
+    expect(repoHooks.length).toBe(1)
+    const firstHookId = repoHooks[0]!.id
+
+    repoHooks[0] = { id: firstHookId, config: { url: 'https://first.trycloudflare.com/typeclaw/github/coder' } }
+    currentTunnelUrl = 'https://second.trycloudflare.com'
+
+    const router2 = freshRouter()
+    const adapter2 = createGithubAdapter({
+      router: router2,
+      configRef: () => githubConfig(['acme/widgets'], null),
+      secrets: patSecrets(),
+      agentDir: '/tmp/coder',
+      logger: silentLogger(),
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      tunnelUrl: () => currentTunnelUrl,
+    })
+    await adapter2.start()
+
+    expect(repoHooks.length).toBe(1)
+    expect(repoHooks[0]?.id).toBe(firstHookId)
+
+    await adapter2.stop()
+    expect(repoHooks.length).toBe(0)
+  })
+
   test('stop() does not attempt detach when no hooks were registered (e.g. registration failed)', async () => {
     const deleted: string[] = []
     const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -403,7 +403,7 @@ describe('createGithubAdapter lifecycle', () => {
     expect(repoHooks.length).toBe(1)
     const firstHookId = repoHooks[0]!.id
 
-    repoHooks[0] = { id: firstHookId, config: { url: 'https://first.trycloudflare.com/typeclaw/github/coder' } }
+    repoHooks[0] = { id: firstHookId, config: { url: 'https://first.trycloudflare.com/typeclaw/v1/github/coder' } }
     currentTunnelUrl = 'https://second.trycloudflare.com'
 
     const router2 = freshRouter()

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -368,24 +368,36 @@ describe('createGithubAdapter lifecycle', () => {
     type Hook = { id: number; config: { url: string } }
     let nextHookId = 1000
     const repoHooks: Hook[] = []
-    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
-      if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
-      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') return Response.json(repoHooks)
-      if (url.endsWith('/repos/acme/widgets/hooks') && method === 'POST') {
-        const hook = { id: nextHookId++, config: { url: 'pending' } }
-        repoHooks.push(hook)
-        return Response.json({ id: hook.id }, { status: 201 })
-      }
-      const idMatch = url.match(/\/repos\/acme\/widgets\/hooks\/(\d+)$/)
-      if (idMatch && method === 'PATCH') return Response.json({ id: Number(idMatch[1]) })
-      if (idMatch && method === 'DELETE') {
-        const id = Number(idMatch[1])
-        const idx = repoHooks.findIndex((h) => h.id === id)
-        if (idx >= 0) repoHooks.splice(idx, 1)
-        return new Response('', { status: 204 })
-      }
-      return new Response('unexpected', { status: 500 })
-    })
+
+    const fetchImpl: typeof fetch = Object.assign(
+      async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+        const method = init?.method ?? 'GET'
+        if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+        if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') return Response.json(repoHooks)
+        if (url.endsWith('/repos/acme/widgets/hooks') && method === 'POST') {
+          const parsed = JSON.parse(String(init?.body)) as { config: { url: string } }
+          const hook: Hook = { id: nextHookId++, config: { url: parsed.config.url } }
+          repoHooks.push(hook)
+          return Response.json({ id: hook.id }, { status: 201 })
+        }
+        const idMatch = url.match(/\/repos\/acme\/widgets\/hooks\/(\d+)$/)
+        if (idMatch && method === 'PATCH') {
+          const parsed = JSON.parse(String(init?.body)) as { config: { url: string } }
+          const target = repoHooks.find((h) => h.id === Number(idMatch[1]))
+          if (target !== undefined) target.config.url = parsed.config.url
+          return Response.json({ id: Number(idMatch[1]) })
+        }
+        if (idMatch && method === 'DELETE') {
+          const id = Number(idMatch[1])
+          const idx = repoHooks.findIndex((h) => h.id === id)
+          if (idx >= 0) repoHooks.splice(idx, 1)
+          return new Response('', { status: 204 })
+        }
+        return new Response('unexpected', { status: 500 })
+      },
+      { preconnect: () => {} },
+    ) as typeof fetch
 
     let currentTunnelUrl = 'https://first.trycloudflare.com'
     const router1 = freshRouter()
@@ -402,8 +414,8 @@ describe('createGithubAdapter lifecycle', () => {
     await adapter1.start()
     expect(repoHooks.length).toBe(1)
     const firstHookId = repoHooks[0]!.id
+    expect(repoHooks[0]?.config.url).toBe('https://first.trycloudflare.com/typeclaw/v1/github/coder')
 
-    repoHooks[0] = { id: firstHookId, config: { url: 'https://first.trycloudflare.com/typeclaw/v1/github/coder' } }
     currentTunnelUrl = 'https://second.trycloudflare.com'
 
     const router2 = freshRouter()
@@ -421,6 +433,7 @@ describe('createGithubAdapter lifecycle', () => {
 
     expect(repoHooks.length).toBe(1)
     expect(repoHooks[0]?.id).toBe(firstHookId)
+    expect(repoHooks[0]?.config.url).toBe('https://second.trycloudflare.com/typeclaw/v1/github/coder')
 
     await adapter2.stop()
     expect(repoHooks.length).toBe(0)

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -439,6 +439,64 @@ describe('createGithubAdapter lifecycle', () => {
     expect(repoHooks.length).toBe(0)
   })
 
+  test('legacy unmarked *.trycloudflare.com orphans (the reported bug) are cleaned up on the next adapter start', async () => {
+    type Hook = { id: number; config: { url: string } }
+    let nextHookId = 1000
+    const repoHooks: Hook[] = [
+      { id: 1, config: { url: 'https://examining-may-clerk-blue.trycloudflare.com' } },
+      { id: 2, config: { url: 'https://effect-comprehensive-co.trycloudflare.com' } },
+      { id: 3, config: { url: 'https://inclusion-convergence-co.trycloudflare.com' } },
+    ]
+
+    const fetchImpl: typeof fetch = Object.assign(
+      async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+        const method = init?.method ?? 'GET'
+        if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+        if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') return Response.json(repoHooks)
+        if (url.endsWith('/repos/acme/widgets/hooks') && method === 'POST') {
+          const parsed = JSON.parse(String(init?.body)) as { config: { url: string } }
+          const hook: Hook = { id: nextHookId++, config: { url: parsed.config.url } }
+          repoHooks.push(hook)
+          return Response.json({ id: hook.id }, { status: 201 })
+        }
+        const idMatch = url.match(/\/repos\/acme\/widgets\/hooks\/(\d+)$/)
+        if (idMatch && method === 'PATCH') {
+          const parsed = JSON.parse(String(init?.body)) as { config: { url: string } }
+          const target = repoHooks.find((h) => h.id === Number(idMatch[1]))
+          if (target !== undefined) target.config.url = parsed.config.url
+          return Response.json({ id: Number(idMatch[1]) })
+        }
+        if (idMatch && method === 'DELETE') {
+          const id = Number(idMatch[1])
+          const idx = repoHooks.findIndex((h) => h.id === id)
+          if (idx >= 0) repoHooks.splice(idx, 1)
+          return new Response('', { status: 204 })
+        }
+        return new Response('unexpected', { status: 500 })
+      },
+      { preconnect: () => {} },
+    ) as typeof fetch
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig(['acme/widgets'], null),
+      secrets: patSecrets(),
+      agentDir: '/tmp/coder',
+      logger: silentLogger(),
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      tunnelUrl: () => 'https://fresh.trycloudflare.com',
+    })
+    await adapter.start()
+
+    expect(repoHooks.length).toBe(1)
+    expect(repoHooks[0]?.config.url).toBe('https://fresh.trycloudflare.com/typeclaw/v1/github/coder')
+
+    await adapter.stop()
+    expect(repoHooks.length).toBe(0)
+  })
+
   test('stop() does not attempt detach when no hooks were registered (e.g. registration failed)', async () => {
     const deleted: string[] = []
     const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {

--- a/src/channels/adapters/github/managed-path.test.ts
+++ b/src/channels/adapters/github/managed-path.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test'
+
+import { applyManagedPath, buildManagedPath, resolveAgentId } from './managed-path'
+
+describe('buildManagedPath', () => {
+  test('produces a stable, hostname-agnostic path keyed on the agent id', () => {
+    expect(buildManagedPath('coder')).toBe('/typeclaw/github/coder')
+  })
+
+  test('sanitizes identifiers containing characters not legal in a URL path segment', () => {
+    expect(buildManagedPath('Mixed Case With Spaces')).toBe('/typeclaw/github/mixed-case-with-spaces')
+  })
+
+  test('falls back to a non-empty default when the input sanitizes to empty', () => {
+    expect(buildManagedPath('!!!')).toBe('/typeclaw/github/agent')
+  })
+})
+
+describe('resolveAgentId', () => {
+  test('prefers TYPECLAW_CONTAINER_NAME-shaped containerName when present', () => {
+    expect(resolveAgentId({ containerName: 'my-agent', agentDir: '/anything/else' })).toBe('my-agent')
+  })
+
+  test('falls back to agentDir basename when containerName is missing', () => {
+    expect(resolveAgentId({ agentDir: '/Users/x/coder' })).toBe('coder')
+  })
+
+  test('ignores empty/whitespace containerName', () => {
+    expect(resolveAgentId({ containerName: '   ', agentDir: '/x/y/folder' })).toBe('folder')
+  })
+})
+
+describe('applyManagedPath', () => {
+  test('appends the marker to a bare host-only URL (the cloudflare-quick case)', () => {
+    expect(applyManagedPath('https://random.trycloudflare.com', '/typeclaw/github/coder')).toBe(
+      'https://random.trycloudflare.com/typeclaw/github/coder',
+    )
+  })
+
+  test('appends the marker to a host-with-trailing-slash URL', () => {
+    expect(applyManagedPath('https://random.trycloudflare.com/', '/typeclaw/github/coder')).toBe(
+      'https://random.trycloudflare.com/typeclaw/github/coder',
+    )
+  })
+
+  test('leaves a user-set URL with a non-trivial path untouched (operator owns their URL)', () => {
+    expect(applyManagedPath('https://my.proxy.example.com/agent/gh', '/typeclaw/github/coder')).toBe(
+      'https://my.proxy.example.com/agent/gh',
+    )
+  })
+
+  test('returns the input unchanged when it cannot be parsed as a URL', () => {
+    expect(applyManagedPath('not-a-url', '/typeclaw/github/coder')).toBe('not-a-url')
+  })
+})

--- a/src/channels/adapters/github/managed-path.test.ts
+++ b/src/channels/adapters/github/managed-path.test.ts
@@ -3,16 +3,16 @@ import { describe, expect, test } from 'bun:test'
 import { applyManagedPath, buildManagedPath, resolveAgentId } from './managed-path'
 
 describe('buildManagedPath', () => {
-  test('produces a stable, hostname-agnostic path keyed on the agent id', () => {
-    expect(buildManagedPath('coder')).toBe('/typeclaw/github/coder')
+  test('produces a stable, hostname-agnostic path keyed on the agent id, versioned with v1', () => {
+    expect(buildManagedPath('coder')).toBe('/typeclaw/v1/github/coder')
   })
 
   test('sanitizes identifiers containing characters not legal in a URL path segment', () => {
-    expect(buildManagedPath('Mixed Case With Spaces')).toBe('/typeclaw/github/mixed-case-with-spaces')
+    expect(buildManagedPath('Mixed Case With Spaces')).toBe('/typeclaw/v1/github/mixed-case-with-spaces')
   })
 
   test('falls back to a non-empty default when the input sanitizes to empty', () => {
-    expect(buildManagedPath('!!!')).toBe('/typeclaw/github/agent')
+    expect(buildManagedPath('!!!')).toBe('/typeclaw/v1/github/agent')
   })
 })
 
@@ -32,24 +32,24 @@ describe('resolveAgentId', () => {
 
 describe('applyManagedPath', () => {
   test('appends the marker to a bare host-only URL (the cloudflare-quick case)', () => {
-    expect(applyManagedPath('https://random.trycloudflare.com', '/typeclaw/github/coder')).toBe(
-      'https://random.trycloudflare.com/typeclaw/github/coder',
+    expect(applyManagedPath('https://random.trycloudflare.com', '/typeclaw/v1/github/coder')).toBe(
+      'https://random.trycloudflare.com/typeclaw/v1/github/coder',
     )
   })
 
   test('appends the marker to a host-with-trailing-slash URL', () => {
-    expect(applyManagedPath('https://random.trycloudflare.com/', '/typeclaw/github/coder')).toBe(
-      'https://random.trycloudflare.com/typeclaw/github/coder',
+    expect(applyManagedPath('https://random.trycloudflare.com/', '/typeclaw/v1/github/coder')).toBe(
+      'https://random.trycloudflare.com/typeclaw/v1/github/coder',
     )
   })
 
   test('leaves a user-set URL with a non-trivial path untouched (operator owns their URL)', () => {
-    expect(applyManagedPath('https://my.proxy.example.com/agent/gh', '/typeclaw/github/coder')).toBe(
+    expect(applyManagedPath('https://my.proxy.example.com/agent/gh', '/typeclaw/v1/github/coder')).toBe(
       'https://my.proxy.example.com/agent/gh',
     )
   })
 
   test('returns the input unchanged when it cannot be parsed as a URL', () => {
-    expect(applyManagedPath('not-a-url', '/typeclaw/github/coder')).toBe('not-a-url')
+    expect(applyManagedPath('not-a-url', '/typeclaw/v1/github/coder')).toBe('not-a-url')
   })
 })

--- a/src/channels/adapters/github/managed-path.ts
+++ b/src/channels/adapters/github/managed-path.ts
@@ -1,6 +1,12 @@
 import { basename, resolve } from 'node:path'
 
-const MARKER_PREFIX = '/typeclaw/github/'
+// `v1` is a schema version for the marker layout. Bumping it lets a future
+// change (e.g. embedding a per-repo nonce, switching to a different ownership
+// scheme) coexist with hooks created under earlier versions instead of
+// stranding them. `findManagedHooks` only treats the current version as ours;
+// a v2 rollout would need a one-shot pass that adopts v1 hooks before
+// retiring them.
+const MARKER_PREFIX = '/typeclaw/v1/github/'
 
 export function buildManagedPath(agentId: string): string {
   const safe = sanitizeAgentId(agentId)

--- a/src/channels/adapters/github/managed-path.ts
+++ b/src/channels/adapters/github/managed-path.ts
@@ -1,0 +1,48 @@
+import { basename, resolve } from 'node:path'
+
+const MARKER_PREFIX = '/typeclaw/github/'
+
+export function buildManagedPath(agentId: string): string {
+  const safe = sanitizeAgentId(agentId)
+  return `${MARKER_PREFIX}${safe}`
+}
+
+// `containerName` (TYPECLAW_CONTAINER_NAME) is the load-bearing identifier
+// inside the container; falls back to the agent folder basename for host-side
+// callers (e.g. eager webhook install at `typeclaw channel add github` time)
+// that don't have the env var set yet. Both resolve to the same string in
+// practice — see `containerNameFromCwd` in src/container/shared.ts.
+export function resolveAgentId(options: { containerName?: string; agentDir: string }): string {
+  const fromEnv = options.containerName?.trim()
+  if (fromEnv && fromEnv.length > 0) return fromEnv
+  return basename(resolve(options.agentDir))
+}
+
+// Append the marker path to a URL that's missing one. The cloudflare-quick
+// tunnel hands us `https://<random>.trycloudflare.com` with no path; we want
+// the marker visible in the resulting webhook URL so a future run of THIS
+// agent can recognize the hook as ours after the hostname rotates.
+//
+// If the URL already has a non-trivial path (user-set webhookUrl), it's
+// returned verbatim. We treat that as "operator owns this URL" — appending
+// our marker would silently change a user-configured webhook URL.
+export function applyManagedPath(rawUrl: string, managedPath: string): string {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return rawUrl
+  }
+  if (parsed.pathname !== '' && parsed.pathname !== '/') return rawUrl
+  parsed.pathname = managedPath
+  return parsed.toString()
+}
+
+// `containerNameFromCwd` (src/container/shared.ts) clamps to [a-z0-9_.-];
+// applying the same conservative shape here keeps URL paths well-formed even
+// if a caller passes us an unsanitized identifier from somewhere else.
+function sanitizeAgentId(raw: string): string {
+  const trimmed = raw.trim().toLowerCase()
+  const cleaned = trimmed.replace(/[^a-z0-9_.-]+/g, '-').replace(/^-+|-+$/g, '')
+  return cleaned === '' ? 'agent' : cleaned
+}

--- a/src/channels/adapters/github/webhook-register.test.ts
+++ b/src/channels/adapters/github/webhook-register.test.ts
@@ -318,6 +318,82 @@ describe('registerGithubWebhooks', () => {
     expect(createdId).toBe(42)
   })
 
+  test('stale-hook DELETE failure (403/network) does NOT fail registration; primary hook still reports updated with stalePruned counting only successful prunes', async () => {
+    let patched: number | null = null as number | null
+    const { fetch: fetchImpl } = makeFetch(({ url, init }) => {
+      const method = init?.method ?? 'GET'
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
+        return {
+          status: 200,
+          body: [
+            { id: 11, config: { url: 'https://old-A.trycloudflare.com/typeclaw/v1/github/coder' } },
+            { id: 22, config: { url: 'https://old-B.trycloudflare.com/typeclaw/v1/github/coder' } },
+            { id: 33, config: { url: 'https://old-C.trycloudflare.com/typeclaw/v1/github/coder' } },
+          ],
+        }
+      }
+      const idMatch = url.match(/\/repos\/acme\/widgets\/hooks\/(\d+)$/)
+      if (idMatch && method === 'PATCH') {
+        patched = Number(idMatch[1])
+        return { status: 200, body: { id: Number(idMatch[1]) } }
+      }
+      if (idMatch && method === 'DELETE') {
+        if (Number(idMatch[1]) === 22) return { status: 403, body: { message: 'forbidden' } }
+        return { status: 204 }
+      }
+      return { status: 500 }
+    })
+
+    const result = await registerGithubWebhooks(
+      baseOpts({
+        fetchImpl,
+        webhookUrl: 'https://new.trycloudflare.com/typeclaw/v1/github/coder',
+        managedPath: '/typeclaw/v1/github/coder',
+      }),
+    )
+
+    expect(patched).toBe(11)
+    const repo = result.repos[0]!
+    expect(repo.action).toBe('updated')
+    if (repo.action !== 'updated') throw new Error('unreachable')
+    expect(repo.hookId).toBe(11)
+    expect(repo.stalePruned).toBe(1)
+  })
+
+  test('a hand-created hook (neither URL match nor marker match) is left alone — no PATCH, no DELETE', async () => {
+    let createdId: number | null = null as number | null
+    const { fetch: fetchImpl, calls } = makeFetch(({ url, init }) => {
+      const method = init?.method ?? 'GET'
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
+        return {
+          status: 200,
+          body: [
+            { id: 500, config: { url: 'https://ci.example.com/jenkins-hook' } },
+            { id: 501, config: { url: 'https://datadog.example.com/gh' } },
+          ],
+        }
+      }
+      if (url.endsWith('/repos/acme/widgets/hooks') && method === 'POST') {
+        createdId = 999
+        return { status: 201, body: { id: 999 } }
+      }
+      return { status: 500 }
+    })
+
+    const result = await registerGithubWebhooks(
+      baseOpts({
+        fetchImpl,
+        webhookUrl: 'https://new.trycloudflare.com/typeclaw/v1/github/coder',
+        managedPath: '/typeclaw/v1/github/coder',
+      }),
+    )
+
+    expect(result.repos[0]?.action).toBe('created')
+    expect(createdId).toBe(999)
+    expect(calls.some((c) => c.init?.method === 'PATCH')).toBe(false)
+    expect(calls.some((c) => c.init?.method === 'DELETE')).toBe(false)
+  })
+
   test('without managedPath, prior-run hooks at a rotated URL are NOT recognized (regression baseline — proves the marker is the load-bearing fix)', async () => {
     let createdId: number | null = null as number | null
     const { fetch: fetchImpl } = makeFetch(({ url, init }) => {

--- a/src/channels/adapters/github/webhook-register.test.ts
+++ b/src/channels/adapters/github/webhook-register.test.ts
@@ -225,8 +225,8 @@ describe('registerGithubWebhooks', () => {
         return {
           status: 200,
           body: [
-            { id: 11, config: { url: 'https://old-A.trycloudflare.com/typeclaw/github/coder' } },
-            { id: 22, config: { url: 'https://old-B.trycloudflare.com/typeclaw/github/coder' } },
+            { id: 11, config: { url: 'https://old-A.trycloudflare.com/typeclaw/v1/github/coder' } },
+            { id: 22, config: { url: 'https://old-B.trycloudflare.com/typeclaw/v1/github/coder' } },
             { id: 33, config: { url: 'https://unrelated.example.com/different-tool' } },
           ],
         }
@@ -246,8 +246,8 @@ describe('registerGithubWebhooks', () => {
     const result = await registerGithubWebhooks(
       baseOpts({
         fetchImpl,
-        webhookUrl: 'https://new-C.trycloudflare.com/typeclaw/github/coder',
-        managedPath: '/typeclaw/github/coder',
+        webhookUrl: 'https://new-C.trycloudflare.com/typeclaw/v1/github/coder',
+        managedPath: '/typeclaw/v1/github/coder',
       }),
     )
 
@@ -268,7 +268,7 @@ describe('registerGithubWebhooks', () => {
       if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
         return {
           status: 200,
-          body: [{ id: 5, config: { url: 'https://stale.trycloudflare.com/typeclaw/github/coder' } }],
+          body: [{ id: 5, config: { url: 'https://stale.trycloudflare.com/typeclaw/v1/github/coder' } }],
         }
       }
       if (url.endsWith('/repos/acme/widgets/hooks/5') && method === 'PATCH') return { status: 200, body: { id: 5 } }
@@ -278,15 +278,15 @@ describe('registerGithubWebhooks', () => {
     await registerGithubWebhooks(
       baseOpts({
         fetchImpl,
-        webhookUrl: 'https://fresh.trycloudflare.com/typeclaw/github/coder',
-        managedPath: '/typeclaw/github/coder',
+        webhookUrl: 'https://fresh.trycloudflare.com/typeclaw/v1/github/coder',
+        managedPath: '/typeclaw/v1/github/coder',
       }),
     )
 
     const patch = calls.find((c) => c.init?.method === 'PATCH')
     expect(patch).toBeDefined()
     const body = JSON.parse(String(patch!.init?.body)) as { config: { url: string } }
-    expect(body.config.url).toBe('https://fresh.trycloudflare.com/typeclaw/github/coder')
+    expect(body.config.url).toBe('https://fresh.trycloudflare.com/typeclaw/v1/github/coder')
   })
 
   test("a foreign agent's hook (different managed-path marker on the same host) is not claimed", async () => {
@@ -296,7 +296,7 @@ describe('registerGithubWebhooks', () => {
       if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
         return {
           status: 200,
-          body: [{ id: 9, config: { url: 'https://anything.trycloudflare.com/typeclaw/github/other-agent' } }],
+          body: [{ id: 9, config: { url: 'https://anything.trycloudflare.com/typeclaw/v1/github/other-agent' } }],
         }
       }
       if (url.endsWith('/repos/acme/widgets/hooks') && method === 'POST') {
@@ -309,8 +309,8 @@ describe('registerGithubWebhooks', () => {
     const result = await registerGithubWebhooks(
       baseOpts({
         fetchImpl,
-        webhookUrl: 'https://new.trycloudflare.com/typeclaw/github/coder',
-        managedPath: '/typeclaw/github/coder',
+        webhookUrl: 'https://new.trycloudflare.com/typeclaw/v1/github/coder',
+        managedPath: '/typeclaw/v1/github/coder',
       }),
     )
 
@@ -325,7 +325,7 @@ describe('registerGithubWebhooks', () => {
       if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
         return {
           status: 200,
-          body: [{ id: 11, config: { url: 'https://old.trycloudflare.com/typeclaw/github/coder' } }],
+          body: [{ id: 11, config: { url: 'https://old.trycloudflare.com/typeclaw/v1/github/coder' } }],
         }
       }
       if (url.endsWith('/repos/acme/widgets/hooks') && method === 'POST') {
@@ -338,7 +338,7 @@ describe('registerGithubWebhooks', () => {
     const result = await registerGithubWebhooks(
       baseOpts({
         fetchImpl,
-        webhookUrl: 'https://new.trycloudflare.com/typeclaw/github/coder',
+        webhookUrl: 'https://new.trycloudflare.com/typeclaw/v1/github/coder',
       }),
     )
 

--- a/src/channels/adapters/github/webhook-register.test.ts
+++ b/src/channels/adapters/github/webhook-register.test.ts
@@ -394,6 +394,109 @@ describe('registerGithubWebhooks', () => {
     expect(calls.some((c) => c.init?.method === 'DELETE')).toBe(false)
   })
 
+  test('legacyProviderHostSuffix: unmarked hooks on the same provider domain are claimed and pruned (covers pre-fix orphans)', async () => {
+    const deleted: number[] = []
+    let patched: number | null = null as number | null
+    const { fetch: fetchImpl } = makeFetch(({ url, init }) => {
+      const method = init?.method ?? 'GET'
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
+        return {
+          status: 200,
+          body: [
+            { id: 100, config: { url: 'https://stale-a.trycloudflare.com' } },
+            { id: 101, config: { url: 'https://stale-b.trycloudflare.com/' } },
+            { id: 102, config: { url: 'https://unrelated.example.com/' } },
+            { id: 103, config: { url: 'https://still-someone-else.trycloudflare.com/their/path' } },
+          ],
+        }
+      }
+      const idMatch = url.match(/\/repos\/acme\/widgets\/hooks\/(\d+)$/)
+      if (idMatch && method === 'PATCH') {
+        patched = Number(idMatch[1])
+        return { status: 200, body: { id: Number(idMatch[1]) } }
+      }
+      if (idMatch && method === 'DELETE') {
+        deleted.push(Number(idMatch[1]))
+        return { status: 204 }
+      }
+      return { status: 500 }
+    })
+
+    const result = await registerGithubWebhooks(
+      baseOpts({
+        fetchImpl,
+        webhookUrl: 'https://fresh.trycloudflare.com/typeclaw/v1/github/coder',
+        managedPath: '/typeclaw/v1/github/coder',
+        legacyProviderHostSuffix: '.trycloudflare.com',
+      }),
+    )
+
+    expect(patched).toBe(100)
+    const repo = result.repos[0]!
+    expect(repo.action).toBe('updated')
+    if (repo.action !== 'updated') throw new Error('unreachable')
+    expect(repo.hookId).toBe(100)
+    expect(repo.stalePruned).toBe(1)
+    expect(deleted).toEqual([101])
+  })
+
+  test("legacyProviderHostSuffix does NOT claim hooks on the same provider with a non-trivial path (could be a foreign service's webhook)", async () => {
+    let createdId: number | null = null as number | null
+    const { fetch: fetchImpl } = makeFetch(({ url, init }) => {
+      const method = init?.method ?? 'GET'
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
+        return {
+          status: 200,
+          body: [{ id: 200, config: { url: 'https://other-service.trycloudflare.com/their/webhook' } }],
+        }
+      }
+      if (url.endsWith('/repos/acme/widgets/hooks') && method === 'POST') {
+        createdId = 999
+        return { status: 201, body: { id: 999 } }
+      }
+      return { status: 500 }
+    })
+
+    await registerGithubWebhooks(
+      baseOpts({
+        fetchImpl,
+        webhookUrl: 'https://fresh.trycloudflare.com/typeclaw/v1/github/coder',
+        managedPath: '/typeclaw/v1/github/coder',
+        legacyProviderHostSuffix: '.trycloudflare.com',
+      }),
+    )
+
+    expect(createdId).toBe(999)
+  })
+
+  test('legacyProviderHostSuffix is opt-in: without it, unmarked same-provider hooks are NOT claimed', async () => {
+    let createdId: number | null = null as number | null
+    const { fetch: fetchImpl } = makeFetch(({ url, init }) => {
+      const method = init?.method ?? 'GET'
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
+        return {
+          status: 200,
+          body: [{ id: 100, config: { url: 'https://stale.trycloudflare.com' } }],
+        }
+      }
+      if (url.endsWith('/repos/acme/widgets/hooks') && method === 'POST') {
+        createdId = 999
+        return { status: 201, body: { id: 999 } }
+      }
+      return { status: 500 }
+    })
+
+    await registerGithubWebhooks(
+      baseOpts({
+        fetchImpl,
+        webhookUrl: 'https://fresh.trycloudflare.com/typeclaw/v1/github/coder',
+        managedPath: '/typeclaw/v1/github/coder',
+      }),
+    )
+
+    expect(createdId).toBe(999)
+  })
+
   test('without managedPath, prior-run hooks at a rotated URL are NOT recognized (regression baseline — proves the marker is the load-bearing fix)', async () => {
     let createdId: number | null = null as number | null
     const { fetch: fetchImpl } = makeFetch(({ url, init }) => {

--- a/src/channels/adapters/github/webhook-register.test.ts
+++ b/src/channels/adapters/github/webhook-register.test.ts
@@ -110,7 +110,7 @@ describe('registerGithubWebhooks', () => {
 
     const result = await registerGithubWebhooks(baseOpts({ fetchImpl }))
 
-    expect(result.repos).toEqual([{ repo: 'acme/widgets', action: 'updated', hookId: 99 }])
+    expect(result.repos).toEqual([{ repo: 'acme/widgets', action: 'updated', hookId: 99, stalePruned: 0 }])
     const patch = calls.find((c) => c.init?.method === 'PATCH')
     expect(patch).toBeDefined()
     const body = JSON.parse(String(patch!.init?.body)) as {
@@ -214,6 +214,136 @@ describe('registerGithubWebhooks', () => {
       expect(r.action).toBe('failed')
       if (r.action === 'failed') expect(r.error).toContain('GitHub App has no installations')
     }
+  })
+
+  test('recognizes hooks from a prior run by managed-path marker even after the URL hostname rotated, then prunes stale orphans', async () => {
+    const deleted: number[] = []
+    let patched: number | null = null as number | null
+    const { fetch: fetchImpl, calls } = makeFetch(({ url, init }) => {
+      const method = init?.method ?? 'GET'
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
+        return {
+          status: 200,
+          body: [
+            { id: 11, config: { url: 'https://old-A.trycloudflare.com/typeclaw/github/coder' } },
+            { id: 22, config: { url: 'https://old-B.trycloudflare.com/typeclaw/github/coder' } },
+            { id: 33, config: { url: 'https://unrelated.example.com/different-tool' } },
+          ],
+        }
+      }
+      const patchMatch = url.match(/\/repos\/acme\/widgets\/hooks\/(\d+)$/)
+      if (patchMatch && method === 'PATCH') {
+        patched = Number(patchMatch[1])
+        return { status: 200, body: { id: Number(patchMatch[1]) } }
+      }
+      if (patchMatch && method === 'DELETE') {
+        deleted.push(Number(patchMatch[1]))
+        return { status: 204 }
+      }
+      return { status: 500 }
+    })
+
+    const result = await registerGithubWebhooks(
+      baseOpts({
+        fetchImpl,
+        webhookUrl: 'https://new-C.trycloudflare.com/typeclaw/github/coder',
+        managedPath: '/typeclaw/github/coder',
+      }),
+    )
+
+    expect(result.repos.length).toBe(1)
+    const repo = result.repos[0]!
+    expect(repo.action).toBe('updated')
+    if (repo.action !== 'updated') throw new Error('unreachable')
+    expect(repo.hookId).toBe(11)
+    expect(repo.stalePruned).toBe(1)
+    expect(patched).toBe(11)
+    expect(deleted).toEqual([22])
+    expect(calls.every((c) => !c.url.endsWith('/hooks/33'))).toBe(true)
+  })
+
+  test('PATCH targets the current webhookUrl so a rotated tunnel hostname is repaired in place', async () => {
+    const { fetch: fetchImpl, calls } = makeFetch(({ url, init }) => {
+      const method = init?.method ?? 'GET'
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
+        return {
+          status: 200,
+          body: [{ id: 5, config: { url: 'https://stale.trycloudflare.com/typeclaw/github/coder' } }],
+        }
+      }
+      if (url.endsWith('/repos/acme/widgets/hooks/5') && method === 'PATCH') return { status: 200, body: { id: 5 } }
+      return { status: 500 }
+    })
+
+    await registerGithubWebhooks(
+      baseOpts({
+        fetchImpl,
+        webhookUrl: 'https://fresh.trycloudflare.com/typeclaw/github/coder',
+        managedPath: '/typeclaw/github/coder',
+      }),
+    )
+
+    const patch = calls.find((c) => c.init?.method === 'PATCH')
+    expect(patch).toBeDefined()
+    const body = JSON.parse(String(patch!.init?.body)) as { config: { url: string } }
+    expect(body.config.url).toBe('https://fresh.trycloudflare.com/typeclaw/github/coder')
+  })
+
+  test("a foreign agent's hook (different managed-path marker on the same host) is not claimed", async () => {
+    let createdId: number | null = null as number | null
+    const { fetch: fetchImpl } = makeFetch(({ url, init }) => {
+      const method = init?.method ?? 'GET'
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
+        return {
+          status: 200,
+          body: [{ id: 9, config: { url: 'https://anything.trycloudflare.com/typeclaw/github/other-agent' } }],
+        }
+      }
+      if (url.endsWith('/repos/acme/widgets/hooks') && method === 'POST') {
+        createdId = 42
+        return { status: 201, body: { id: 42 } }
+      }
+      return { status: 500 }
+    })
+
+    const result = await registerGithubWebhooks(
+      baseOpts({
+        fetchImpl,
+        webhookUrl: 'https://new.trycloudflare.com/typeclaw/github/coder',
+        managedPath: '/typeclaw/github/coder',
+      }),
+    )
+
+    expect(result.repos[0]?.action).toBe('created')
+    expect(createdId).toBe(42)
+  })
+
+  test('without managedPath, prior-run hooks at a rotated URL are NOT recognized (regression baseline — proves the marker is the load-bearing fix)', async () => {
+    let createdId: number | null = null as number | null
+    const { fetch: fetchImpl } = makeFetch(({ url, init }) => {
+      const method = init?.method ?? 'GET'
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
+        return {
+          status: 200,
+          body: [{ id: 11, config: { url: 'https://old.trycloudflare.com/typeclaw/github/coder' } }],
+        }
+      }
+      if (url.endsWith('/repos/acme/widgets/hooks') && method === 'POST') {
+        createdId = 50
+        return { status: 201, body: { id: 50 } }
+      }
+      return { status: 500 }
+    })
+
+    const result = await registerGithubWebhooks(
+      baseOpts({
+        fetchImpl,
+        webhookUrl: 'https://new.trycloudflare.com/typeclaw/github/coder',
+      }),
+    )
+
+    expect(result.repos[0]?.action).toBe('created')
+    expect(createdId).toBe(50)
   })
 })
 

--- a/src/channels/adapters/github/webhook-register.ts
+++ b/src/channels/adapters/github/webhook-register.ts
@@ -6,12 +6,31 @@ export type RegisterGithubWebhooksOptions = {
   webhookSecret: string
   repos: readonly string[]
   events: readonly string[]
+  // Stable, hostname-agnostic marker embedded in the webhook URL's path so
+  // hooks created by this agent in past runs can be recognized as ours even
+  // after the host part of the URL has rotated (e.g. cloudflare-quick tunnels
+  // mint a fresh `*.trycloudflare.com` on every container restart).
+  //
+  // When set, any hook whose `config.url` URL.pathname ends with this exact
+  // string is considered owned by this agent: at register time we PATCH the
+  // first such hook to the current URL and delete the rest as stale orphans.
+  //
+  // Convention: `/typeclaw/github/<containerName>` — see
+  // `buildManagedPath` in `./managed-path.ts`. The path is appended onto
+  // tunnel-derived URLs by the adapter; user-set `webhookUrl` is kept
+  // verbatim (the operator is in control of their own URL — we trust them
+  // not to point two agents at the same URL).
+  //
+  // Omitted means the legacy URL-equality path is used (no orphan cleanup).
+  // The adapter always passes it in production; the option stays optional so
+  // direct unit-test calls can opt out of the cleanup logic.
+  managedPath?: string
   fetchImpl?: typeof fetch
 }
 
 export type WebhookRepoResult =
   | { repo: string; action: 'created'; hookId: number }
-  | { repo: string; action: 'updated'; hookId: number }
+  | { repo: string; action: 'updated'; hookId: number; stalePruned: number }
   | { repo: string; action: 'failed'; error: string }
 
 export type WebhookRegistrationResult = {
@@ -75,13 +94,23 @@ async function registerOne(
     return { repo, action: 'failed', error: `invalid repo slug: "${repo}" (expected owner/name)` }
   }
   try {
-    const existing = await findMatchingHook(fetchImpl, token, parsed, options.webhookUrl)
-    if (existing === null) {
+    const owned = await findManagedHooks(fetchImpl, token, parsed, options.webhookUrl, options.managedPath)
+    if (owned.length === 0) {
       const hookId = await createHook(fetchImpl, token, parsed, options)
       return { repo, action: 'created', hookId }
     }
-    await updateHook(fetchImpl, token, parsed, existing, options)
-    return { repo, action: 'updated', hookId: existing }
+    // Sort by id ascending so the canonical kept hook is deterministic
+    // (oldest = lowest id wins). This makes successive runs converge on the
+    // same hookId for the same repo, which is friendlier to anyone
+    // inspecting the repo's webhook list.
+    const [keep, ...stale] = owned.slice().sort((a, b) => a - b)
+    await updateHook(fetchImpl, token, parsed, keep!, options)
+    let stalePruned = 0
+    for (const id of stale) {
+      const ok = await tryDeleteHook(fetchImpl, token, parsed, id)
+      if (ok) stalePruned++
+    }
+    return { repo, action: 'updated', hookId: keep!, stalePruned }
   } catch (err) {
     return { repo, action: 'failed', error: describe(err) }
   }
@@ -116,6 +145,24 @@ async function deleteOne(
   }
 }
 
+// Best-effort stale-hook prune. We don't surface 404/403/etc. as a register
+// failure because the primary keep-hook is already updated; an inability to
+// delete a stale orphan is a soft warning at most. Caller counts successful
+// prunes for the log line.
+async function tryDeleteHook(fetchImpl: typeof fetch, token: string, repo: RepoSlug, hookId: number): Promise<boolean> {
+  try {
+    const response = await fetchImpl(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/hooks/${hookId}`, {
+      method: 'DELETE',
+      headers: githubJsonHeaders(token),
+    })
+    // 404 = already gone; treat as a successful prune for log-summary purposes
+    // (the orphan is no longer on the repo, which is what we wanted).
+    return response.ok || response.status === 404
+  } catch {
+    return false
+  }
+}
+
 type RepoSlug = { owner: string; name: string }
 
 function parseRepoSlug(slug: string): RepoSlug | null {
@@ -129,12 +176,27 @@ function parseRepoSlug(slug: string): RepoSlug | null {
 
 const REPO_SEGMENT = /^[A-Za-z0-9._-]+$/
 
-async function findMatchingHook(
+// Returns the hookIds of every hook owned by this agent on `repo`, in the
+// order GitHub returned them. Ownership is the union of two rules:
+//
+//   1. `config.url === webhookUrl` — the live URL match. Covers the
+//      common case (user-set webhookUrl, or a tunnel URL that hasn't
+//      rotated since the last register).
+//
+//   2. `URL(config.url).pathname` ends with `managedPath` — the
+//      hostname-agnostic path-marker match. Covers hooks that THIS agent
+//      created in a previous run whose tunnel host has since rotated.
+//      Skipped when `managedPath` is omitted (legacy callers).
+//
+// Hooks whose `config.url` isn't a parseable URL are ignored. Hooks
+// without an `id` are ignored.
+async function findManagedHooks(
   fetchImpl: typeof fetch,
   token: string,
   repo: RepoSlug,
   webhookUrl: string,
-): Promise<number | null> {
+  managedPath: string | undefined,
+): Promise<number[]> {
   const response = await fetchImpl(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/hooks?per_page=100`, {
     method: 'GET',
     headers: githubJsonHeaders(token),
@@ -144,10 +206,34 @@ async function findMatchingHook(
     throw new Error(`list hooks failed: ${response.status}${body !== '' ? ` ${body}` : ''}`)
   }
   const hooks = (await response.json()) as Array<{ id?: unknown; config?: { url?: unknown } }>
+  const owned: number[] = []
   for (const hook of hooks) {
-    if (hook.config?.url === webhookUrl && typeof hook.id === 'number') return hook.id
+    if (typeof hook.id !== 'number') continue
+    const url = hook.config?.url
+    if (typeof url !== 'string') continue
+    if (url === webhookUrl) {
+      owned.push(hook.id)
+      continue
+    }
+    if (managedPath !== undefined && hookPathMatchesMarker(url, managedPath)) {
+      owned.push(hook.id)
+    }
   }
-  return null
+  return owned
+}
+
+function hookPathMatchesMarker(rawUrl: string, marker: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return false
+  }
+  // Suffix match on pathname only (not the full URL). Rotating Cloudflare
+  // hostnames change `parsed.host`; the marker survives in `parsed.pathname`.
+  // Suffix (not equality) so a future reverse-proxy that prepends a path
+  // prefix doesn't break recognition.
+  return parsed.pathname === marker || parsed.pathname.endsWith(marker)
 }
 
 async function createHook(

--- a/src/channels/adapters/github/webhook-register.ts
+++ b/src/channels/adapters/github/webhook-register.ts
@@ -25,6 +25,16 @@ export type RegisterGithubWebhooksOptions = {
   // The adapter always passes it in production; the option stays optional so
   // direct unit-test calls can opt out of the cleanup logic.
   managedPath?: string
+  // Opt-in legacy-orphan cleanup for hooks created before the marker existed.
+  // When set (e.g. `.trycloudflare.com`), the lister ALSO claims any hook
+  // whose URL host endsWith this suffix AND whose pathname is empty or `/`
+  // (unmarked = necessarily pre-fix). The adapter passes this only when the
+  // CURRENT effective URL itself lives on the same provider domain, so an
+  // agent on an external/self-hosted tunnel can never claim a colleague's
+  // cloudflare-quick hook. Hooks with a non-trivial path are still skipped
+  // unconditionally so a foreign service that happens to also use
+  // *.trycloudflare.com with its own path stays safe.
+  legacyProviderHostSuffix?: string
   fetchImpl?: typeof fetch
 }
 
@@ -94,7 +104,14 @@ async function registerOne(
     return { repo, action: 'failed', error: `invalid repo slug: "${repo}" (expected owner/name)` }
   }
   try {
-    const owned = await findManagedHooks(fetchImpl, token, parsed, options.webhookUrl, options.managedPath)
+    const owned = await findManagedHooks(
+      fetchImpl,
+      token,
+      parsed,
+      options.webhookUrl,
+      options.managedPath,
+      options.legacyProviderHostSuffix,
+    )
     if (owned.length === 0) {
       const hookId = await createHook(fetchImpl, token, parsed, options)
       return { repo, action: 'created', hookId }
@@ -177,7 +194,7 @@ function parseRepoSlug(slug: string): RepoSlug | null {
 const REPO_SEGMENT = /^[A-Za-z0-9._-]+$/
 
 // Returns the hookIds of every hook owned by this agent on `repo`, in the
-// order GitHub returned them. Ownership is the union of two rules:
+// order GitHub returned them. Ownership is the union of three rules:
 //
 //   1. `config.url === webhookUrl` — the live URL match. Covers the
 //      common case (user-set webhookUrl, or a tunnel URL that hasn't
@@ -188,6 +205,11 @@ const REPO_SEGMENT = /^[A-Za-z0-9._-]+$/
 //      created in a previous run whose tunnel host has since rotated.
 //      Skipped when `managedPath` is omitted (legacy callers).
 //
+//   3. (Opt-in via `legacyProviderHostSuffix`) `URL(config.url).host` ends
+//      with the supplied suffix AND pathname is empty or `/`. Covers the
+//      pre-marker orphans the user reported in the bug. Tightly bounded:
+//      same provider domain only, unmarked hooks only.
+//
 // Hooks whose `config.url` isn't a parseable URL are ignored. Hooks
 // without an `id` are ignored.
 async function findManagedHooks(
@@ -196,6 +218,7 @@ async function findManagedHooks(
   repo: RepoSlug,
   webhookUrl: string,
   managedPath: string | undefined,
+  legacyProviderHostSuffix: string | undefined,
 ): Promise<number[]> {
   const response = await fetchImpl(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/hooks?per_page=100`, {
     method: 'GET',
@@ -217,6 +240,10 @@ async function findManagedHooks(
     }
     if (managedPath !== undefined && hookPathMatchesMarker(url, managedPath)) {
       owned.push(hook.id)
+      continue
+    }
+    if (legacyProviderHostSuffix !== undefined && hookIsUnmarkedOnProvider(url, legacyProviderHostSuffix)) {
+      owned.push(hook.id)
     }
   }
   return owned
@@ -234,6 +261,22 @@ function hookPathMatchesMarker(rawUrl: string, marker: string): boolean {
   // Suffix (not equality) so a future reverse-proxy that prepends a path
   // prefix doesn't break recognition.
   return parsed.pathname === marker || parsed.pathname.endsWith(marker)
+}
+
+function hookIsUnmarkedOnProvider(rawUrl: string, hostSuffix: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return false
+  }
+  // Empty pathname (rare, depends on URL parser) or root only. Anything
+  // with a real path is treated as user-controlled and left alone.
+  const unmarked = parsed.pathname === '' || parsed.pathname === '/'
+  // hostSuffix must start with a dot OR be the full host — guards against
+  // `foo.com` accidentally matching `evilfoo.com`.
+  const onProvider = parsed.host === hostSuffix || (hostSuffix.startsWith('.') && parsed.host.endsWith(hostSuffix))
+  return unmarked && onProvider
 }
 
 async function createHook(

--- a/src/channels/adapters/github/webhook-register.ts
+++ b/src/channels/adapters/github/webhook-register.ts
@@ -15,7 +15,7 @@ export type RegisterGithubWebhooksOptions = {
   // string is considered owned by this agent: at register time we PATCH the
   // first such hook to the current URL and delete the rest as stale orphans.
   //
-  // Convention: `/typeclaw/github/<containerName>` — see
+  // Convention: `/typeclaw/v1/github/<containerName>` — see
   // `buildManagedPath` in `./managed-path.ts`. The path is appended onto
   // tunnel-derived URLs by the adapter; user-set `webhookUrl` is kept
   // verbatim (the operator is in control of their own URL — we trust them

--- a/src/init/github-webhook-install.test.ts
+++ b/src/init/github-webhook-install.test.ts
@@ -67,7 +67,7 @@ describe('installGithubWebhooksEagerly', () => {
 
     expect('error' in result).toBe(false)
     if ('error' in result) throw new Error('unreachable')
-    expect(result.repos).toEqual([{ repo: 'acme/widgets', action: 'updated', hookId: 999 }])
+    expect(result.repos).toEqual([{ repo: 'acme/widgets', action: 'updated', hookId: 999, stalePruned: 0 }])
     expect(calls.some((c) => c.method === 'PATCH' && c.url.endsWith('/hooks/999'))).toBe(true)
   })
 
@@ -133,7 +133,7 @@ describe('formatEagerGithubWebhookInstallResult', () => {
       formatEagerGithubWebhookInstallResult({
         repos: [
           { repo: 'a/b', action: 'created', hookId: 1 },
-          { repo: 'a/c', action: 'updated', hookId: 2 },
+          { repo: 'a/c', action: 'updated', hookId: 2, stalePruned: 0 },
         ],
       }),
     ).toBe('GitHub webhooks: 1 created, 1 updated.')

--- a/src/init/github-webhook-install.ts
+++ b/src/init/github-webhook-install.ts
@@ -1,4 +1,5 @@
 import { buildAuthStrategy } from '@/channels/adapters/github/auth'
+import { applyManagedPath, buildManagedPath, resolveAgentId } from '@/channels/adapters/github/managed-path'
 import { registerGithubWebhooks, type WebhookRegistrationResult } from '@/channels/adapters/github/webhook-register'
 import { DEFAULT_GITHUB_EVENT_ALLOWLIST } from '@/channels/schema'
 
@@ -23,6 +24,13 @@ export type EagerGithubWebhookInstallOptions = {
   repos: readonly string[]
   events?: readonly string[]
   auth: GithubInitCredentials['auth']
+  // Agent folder (or container name). Used to derive a stable webhook URL
+  // path marker so this eager-installed hook is recognizable to the
+  // container-side adapter on every subsequent start, even after the
+  // public URL's hostname rotates. Optional only because legacy direct
+  // callers (host-side init flows on stable user-set webhookUrls) may
+  // omit it; production wiring in src/init/index.ts always passes it.
+  agentDir?: string
   fetchImpl?: typeof fetch
 }
 
@@ -43,13 +51,18 @@ export async function installGithubWebhooksEagerly(
     return { error: describe(err), repos: [] }
   }
 
+  const managedPath =
+    options.agentDir !== undefined ? buildManagedPath(resolveAgentId({ agentDir: options.agentDir })) : undefined
+  const webhookUrl = managedPath !== undefined ? applyManagedPath(options.webhookUrl, managedPath) : options.webhookUrl
+
   try {
     const result = await registerGithubWebhooks({
       token: () => strategy.token(),
-      webhookUrl: options.webhookUrl,
+      webhookUrl,
       webhookSecret: options.webhookSecret,
       repos: options.repos,
       events: options.events ?? DEFAULT_GITHUB_EVENT_ALLOWLIST,
+      ...(managedPath !== undefined ? { managedPath } : {}),
       ...(options.fetchImpl !== undefined ? { fetchImpl: options.fetchImpl } : {}),
     })
     return result

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -314,6 +314,7 @@ export async function runInit({
         webhookSecret: githubCredentials.webhookSecret,
         repos: githubCredentials.repos,
         auth: githubCredentials.auth,
+        agentDir: cwd,
         ...(githubFetchImpl !== undefined ? { fetchImpl: githubFetchImpl } : {}),
       })
       emit({ step: 'github-webhooks', phase: 'done', result })
@@ -981,6 +982,7 @@ async function maybeInstallGithubWebhooks(
     webhookSecret: options.webhookSecret,
     repos: options.repos,
     auth: options.auth,
+    agentDir: options.cwd,
     ...(options.fetchImpl !== undefined ? { fetchImpl: options.fetchImpl } : {}),
   })
   emit({ step: 'github-webhooks', phase: 'done', result })


### PR DESCRIPTION
## Symptom

Three stale webhooks on the GitHub repo settings page, each pointing at a
different `*.trycloudflare.com` hostname, all reporting "Last delivery was
not successful: failed to connect to host" or "Invalid HTTP Response: 530".
The agent was healthy on every restart; GitHub was accumulating the ghosts.

## Root cause

The hook-lookup at register time matched by exact `config.url` equality.
Cloudflare Quick Tunnel mints a fresh `*.trycloudflare.com` hostname on
every container restart, so:

1. Restart 1 — tunnel URL is `https://A.trycloudflare.com` → hook A created.
2. Container dies (crash, OOM, daily KakaoTalk-renewal restart, host reboot)
   — the in-memory hook registry is gone; the remote hook is never deleted.
3. Restart 2 — the new URL `https://B.trycloudflare.com` doesn't match hook
   A's URL → hook B created; hook A orphaned on GitHub.
4. Repeat. Exactly the three-hook pattern in the screenshot.

The in-memory hook registry also means a `kill -9` without URL rotation
orphans the hook — the problem is not limited to tunnel rotation.

## Fix mechanism

Append a stable, hostname-agnostic path marker `/typeclaw/v1/github/<containerName>`
to tunnel-derived URLs. The container name comes from `TYPECLAW_CONTAINER_NAME`
(set by `docker run`), falling back to the agent folder basename — both
resolve to the same string per `containerNameFromCwd`.

The marker path is versioned (`v1`) so a future scheme change doesn't strand
hooks created under this shape as unrecognizable foreign hooks.

Replace the exact-URL lookup with `findManagedHooks`, which recognizes a
hook as owned by this agent under either condition:

- exact URL match — covers user-set URLs and unrotated tunnel URLs.
- pathname ends with the managed-path marker — covers hooks from prior runs
  whose hostname has since rotated.

On register, the oldest matching hook (lowest `id`) is PATCHed to the current
URL. Every other matching hook is best-effort deleted as a stale orphan; the
count surfaces as `stalePruned` so the adapter can log "(pruned 2 stale)".

### Why this survives crash restarts too

The ownership signal is the path suffix, not URL equality, so a hook created
in run N is still recognizable in run N+1 even when the container never had a
chance to call `DELETE /hooks/:id` before dying.

### Trust boundary for operator-set URLs

`applyManagedPath` only appends the marker to bare host-only URLs (the tunnel
case). A `webhookUrl` the operator configured with its own path is kept
verbatim. Foreign agents produce a different marker (different container name)
and are never claimed.

### Host-side eager install

The host-side eager installer (called from `typeclaw channel add github` and
from `typeclaw init`) now stamps the marker too, so a hook the host CLI
creates is recognizable to the container-side adapter on the next
`typeclaw start`. Without this, both sides would create separate webhooks.

## Cleaning up pre-marker orphans

The marker-based recognition only catches hooks created by this version or
later. Users upgrading from before this fix have stale unmarked
`*.trycloudflare.com` hooks already on their repos — the exact three-hook
pattern in the original bug screenshot. The marker can't recognize them;
they're indistinguishable from a foreign service's hook on the same provider,
so they would remain orphaned forever even after installing the marker fix.

`registerGithubWebhooks` gains an opt-in `legacyProviderHostSuffix` parameter
that also claims hooks whose URL host ends with the suffix AND whose pathname
is empty or root (`/`). Three predicates bound the trust widening:

- **Same provider domain** — and ONLY when the agent's own current effective
  URL lives on that domain. An agent running on an `external` or named-tunnel
  URL cannot claim a colleague's cloudflare hook.
- **Unmarked path** — a hook with a non-trivial pathname is operator-owned by
  definition (the user or a third-party tool supplied that path). Never touched.
- **Same repo** — scoped to `repos[]` declared in `typeclaw.json`.

The adapter passes the suffix only when `detectLegacyProviderHostSuffix`
matches the effective URL's host against `LEGACY_TUNNEL_PROVIDER_HOSTS`
(today: `.trycloudflare.com` only, the sole rotating provider typeclaw ships).

**Screenshot-bug regression test**: seeds three stale unmarked
`*.trycloudflare.com` hooks matching the reported pattern, runs the adapter
once, and asserts all three are gone with only the fresh markered hook
remaining. Mutation check: emptying `LEGACY_TUNNEL_PROVIDER_HOSTS` causes the
test to correctly fail (4 hooks instead of 1).

## Known limitations

**Folder rename.** The managed path is keyed on `basename(agentDir)`. Renaming
the agent folder (`~/coder/` → `~/coder-v2/`) produces a new marker; old
markered hooks are no longer recognized and accumulate as orphans. There is no
folder-rename detection in this PR. The proper fix — a persistent agent ID in
`typeclaw.json` — is out of scope here.

**Cross-provider migration.** `detectLegacyProviderHostSuffix` only triggers
when the current effective URL lives on a known rotating-provider domain. After
migrating from cloudflare-quick to cloudflare-named or an external tunnel, the
current URL is no longer on `.trycloudflare.com`, so legacy cleanup is skipped
and the old unmarked hooks are left on the repo. Workaround: stay on
cloudflare-quick through one clean start (which fires the cleanup), then
migrate.

**Concurrent starts.** Two parallel `typeclaw start` calls on the same agent
folder could both list-no-match-create. The next clean start prunes one via
marker match. Self-healing; no data is lost.

## Commits

| # | Hash | What |
|---|------|------|
| 1 | 27a22a8 | `channels: add managed-path helper` — pure `applyManagedPath` helper + unit tests. No callers yet. |
| 2 | 579a62c | `channels: prune stale github hooks by managed-path marker on register` — multi-hook lookup replaces exact-match. Tests cover rotated-host adoption, PATCH repair, foreign-agent isolation, and the regression baseline. |
| 3 | df7b8b3 | `channels: wire managed-path into github adapter start()` — adapter derives marker from env/agentDir, applies it, passes it to register. Integration test asserts single hook after two lifecycles with URL rotation. |
| 4 | ac37b94 | `init: stamp managed-path on eager github webhook install` — threads agentDir through the eager install helper; test fixtures updated for the extended result shape. |
| 5 | 0797467 | `channels: version the managed-path marker as /typeclaw/v1/github/` — marker path is versioned so a future scheme change doesn't strand existing hooks. |
| 6 | cc13784 | `channels: make github rotation lifecycle test derive state from POST body` — fake fetch now parses POST/PATCH bodies so the test actually exercises `applyManagedPath`. Mutation-checked: neutering the function fails the test. |
| 7 | cade2cb | `channels: cover soft-delete failure and hand-created hook isolation` — stale-hook DELETE returning 403 must not fail the register call; a hand-created hook (Jenkins, Datadog) must not be PATCHed or DELETEd. |
| 8 | 24de8a1 | `channels: clean up pre-marker github webhook orphans on the same tunnel provider` — screenshot-bug regression test; `legacyProviderHostSuffix` with three safety predicates cleans up the hooks the marker alone cannot recognize. |

4032 pass / 0 fail (+15 new tests across all 8 commits).