### PR TITLE
channels: add permission-setup guide on github webhook 403/404 failures

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -175,7 +175,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         managedHooks = registration.repos.flatMap((r) =>
           r.action === 'created' || r.action === 'updated' ? [{ repo: r.repo, hookId: r.hookId }] : [],
         )
-        logRegistrationOutcome(logger, registration)
+        logRegistrationOutcome(logger, registration, options.secrets.auth.type)
       }
     },
     async stop(): Promise<void> {
@@ -264,14 +264,98 @@ function detectLegacyProviderHostSuffix(url: string): string | undefined {
   return undefined
 }
 
-function logRegistrationOutcome(logger: GithubAdapterLogger, result: WebhookRegistrationResult): void {
+function logRegistrationOutcome(
+  logger: GithubAdapterLogger,
+  result: WebhookRegistrationResult,
+  authType: 'pat' | 'app',
+): void {
+  const permissionFailures: Array<{ repo: string; status: number }> = []
   for (const r of result.repos) {
     if (r.action === 'created') logger.info(`[github] registered webhook ${r.hookId} on ${r.repo}`)
     else if (r.action === 'updated') {
       const tail = r.stalePruned > 0 ? ` (pruned ${r.stalePruned} stale)` : ''
       logger.info(`[github] updated webhook ${r.hookId} on ${r.repo}${tail}`)
-    } else logger.warn(`[github] webhook register failed for ${r.repo}: ${r.error}`)
+    } else {
+      logger.warn(`[github] webhook register failed for ${r.repo}: ${r.error}`)
+      const status = parseListHooksPermissionStatus(r.error)
+      if (status !== null) permissionFailures.push({ repo: r.repo, status })
+    }
   }
+  // One guidance block per start() (not per repo) so a 10-repo permission
+  // failure doesn't paste the same paragraph 10 times. The names below MUST
+  // match the current github.com UI labels — see comment in
+  // buildPermissionGuidance.
+  if (permissionFailures.length > 0) {
+    logger.warn(buildPermissionGuidance(authType, permissionFailures))
+  }
+}
+
+// Parses webhook-register errors of the shape `list hooks failed: <status> <body>`.
+// Returns the status code when it matches the two shapes GitHub emits for
+// missing access on the list-hooks endpoint:
+//   - 404 Not Found: the token cannot see the repo at all (private repo
+//     gated behind missing repository access — GitHub returns 404 instead of
+//     403 to avoid leaking the existence of private repos).
+//   - 403 Forbidden: the token sees the repo but lacks webhook-management
+//     permission, OR is blocked by an org SSO/SAML authorization gate.
+// Returns null for any other error (network, malformed slug, create-hook
+// failures, etc.) so the guidance only fires on the actual symptom.
+export function parseListHooksPermissionStatus(error: string): number | null {
+  const match = error.match(/^list hooks failed: (404|403)\b/)
+  if (match === null) return null
+  return Number(match[1])
+}
+
+// The labels below intentionally mirror github.com's current UI verbatim so a
+// user can grep their settings page for the exact string. If GitHub renames
+// any of these in a future redesign, update both here and the
+// `permissionGuidance` tests in lifecycle.test.ts.
+//
+//   Fine-grained PAT:
+//     Settings → Developer settings → Personal access tokens → Fine-grained tokens
+//     "Resource owner", "Repository access", "Repository permissions" → "Webhooks" → "Read and write", "Metadata" → "Read-only"
+//   GitHub App:
+//     Settings → Developer settings → GitHub Apps → <app> → Permissions & events
+//     "Repository permissions" → "Webhooks" → "Read and write"
+//     Install/configure on the org: <app settings> → Install App / Configure → "Repository access"
+//   Classic PAT (legacy, still supported by GitHub but we don't surface it in
+//     channel-add prompts):
+//     Settings → Developer settings → Personal access tokens (classic)
+//     Scope: "admin:repo_hook" (or full "repo" for private repositories)
+export function buildPermissionGuidance(
+  authType: 'pat' | 'app',
+  failures: ReadonlyArray<{ repo: string; status: number }>,
+): string {
+  const repoList = failures.map((f) => `${f.repo} (${f.status})`).join(', ')
+  const lines: string[] = [
+    `[github] webhook setup needs more access for: ${repoList}.`,
+    '  - 404 from GitHub means the token cannot see the repo (GitHub hides private repos behind 404 instead of 403).',
+    '  - 403 means the token sees the repo but lacks webhook permission, or is blocked by org SAML/SSO.',
+    '',
+  ]
+  if (authType === 'pat') {
+    lines.push(
+      '  Fix (fine-grained personal access token):',
+      '    1. Open https://github.com/settings/personal-access-tokens and edit the token TypeClaw is using.',
+      '    2. Under "Resource owner", select the org that owns the failing repos (e.g. the org in the slug above).',
+      '    3. Under "Repository access", choose "Only select repositories" and add every failing repo (or pick "All repositories").',
+      '    4. Under "Repository permissions", set "Webhooks" to "Read and write" and "Metadata" to "Read-only".',
+      '    5. Save. If the org enforces SAML SSO, click "Configure SSO" next to the token and authorize the org.',
+      '',
+      '  Or (classic personal access token): grant the "admin:repo_hook" scope (or "repo" for private repos),',
+      '  and on a SAML-protected org click "Authorize" next to the token.',
+    )
+  } else {
+    lines.push(
+      '  Fix (GitHub App):',
+      '    1. Open https://github.com/settings/apps and edit the app TypeClaw is using.',
+      '    2. Under "Permissions & events" → "Repository permissions", set "Webhooks" to "Read and write". Save.',
+      '    3. From the app page, click "Install App" (or "Configure" if already installed) and select the org that owns the failing repos.',
+      '    4. Under "Repository access", choose "Only select repositories" and add every failing repo (or pick "All repositories").',
+      '    5. If the app permissions changed in step 2, install owners must accept the updated permissions from the install page before the new access takes effect.',
+    )
+  }
+  return lines.join('\n')
 }
 
 function logDeregistrationOutcome(

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -364,6 +364,65 @@ describe('createGithubAdapter lifecycle', () => {
     await adapter.stop()
   })
 
+  test('list-hooks 404 emits a permission-setup guide referencing the failing repos and the github.com UI labels', async () => {
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+      if (url.includes('/repos/indentcorp/huxley/hooks') || url.includes('/repos/indentcorp/dobby/hooks')) {
+        return new Response(JSON.stringify({ message: 'Not Found' }), { status: 404 })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+    const logger = recordingLogger()
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig(['indentcorp/huxley', 'indentcorp/dobby']),
+      secrets: patSecrets(),
+      agentDir: '/tmp/agent',
+      logger,
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+    })
+
+    await adapter.start()
+    await adapter.stop()
+
+    const guidanceLines = logger.messages.filter((m) => m.includes('webhook setup needs more access for'))
+    expect(guidanceLines.length).toBe(1)
+    const guide = guidanceLines[0]!
+    expect(guide).toContain('indentcorp/huxley (404)')
+    expect(guide).toContain('indentcorp/dobby (404)')
+    expect(guide).toContain('"Resource owner"')
+    expect(guide).toContain('"Repository permissions"')
+    expect(guide).toContain('"Webhooks"')
+    expect(guide).toContain('"Read and write"')
+  })
+
+  test('list-hooks 500 (transient server error) does NOT emit permission guidance (would be misleading)', async () => {
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+      if (url.includes('/repos/acme/widgets/hooks')) return new Response('boom', { status: 500 })
+      return new Response('unexpected', { status: 500 })
+    })
+    const logger = recordingLogger()
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig(['acme/widgets']),
+      secrets: patSecrets(),
+      agentDir: '/tmp/agent',
+      logger,
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+    })
+
+    await adapter.start()
+    await adapter.stop()
+
+    expect(logger.messages.some((m) => m.includes('webhook setup needs more access for'))).toBe(false)
+    expect(logger.messages.some((m) => m.includes('webhook register failed'))).toBe(true)
+  })
+
   test('rotating tunnel URL across two adapter lifecycles: second start adopts and updates the prior hook instead of orphaning it', async () => {
     type Hook = { id: number; config: { url: string } }
     let nextHookId = 1000

--- a/src/channels/adapters/github/permission-guidance.test.ts
+++ b/src/channels/adapters/github/permission-guidance.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildPermissionGuidance, parseListHooksPermissionStatus } from './index'
+
+describe('parseListHooksPermissionStatus', () => {
+  test('returns 404 for a 404 list-hooks error', () => {
+    expect(parseListHooksPermissionStatus('list hooks failed: 404 {"message":"Not Found"}')).toBe(404)
+  })
+
+  test('returns 403 for a 403 list-hooks error', () => {
+    expect(parseListHooksPermissionStatus('list hooks failed: 403 {"message":"Forbidden"}')).toBe(403)
+  })
+
+  test('returns null for a 500 list-hooks error (not a permission issue)', () => {
+    expect(parseListHooksPermissionStatus('list hooks failed: 500 server error')).toBeNull()
+  })
+
+  test('returns null for a 401 list-hooks error (auth-config issue, not repo permission)', () => {
+    expect(parseListHooksPermissionStatus('list hooks failed: 401 bad creds')).toBeNull()
+  })
+
+  test('returns null for a create-hook 403 (different code path, different remediation)', () => {
+    expect(parseListHooksPermissionStatus('create hook failed: 403 forbidden')).toBeNull()
+  })
+
+  test('returns null for an invalid-slug error', () => {
+    expect(parseListHooksPermissionStatus('invalid repo slug: "weird" (expected owner/name)')).toBeNull()
+  })
+
+  test('returns null for a network error', () => {
+    expect(parseListHooksPermissionStatus('fetch failed: ECONNREFUSED')).toBeNull()
+  })
+})
+
+describe('buildPermissionGuidance', () => {
+  test('PAT guidance names the failing repos with status codes', () => {
+    const msg = buildPermissionGuidance('pat', [
+      { repo: 'indentcorp/huxley', status: 404 },
+      { repo: 'indentcorp/dobby', status: 403 },
+    ])
+    expect(msg).toContain('indentcorp/huxley (404)')
+    expect(msg).toContain('indentcorp/dobby (403)')
+  })
+
+  test('PAT guidance uses the exact github.com UI label "Resource owner"', () => {
+    const msg = buildPermissionGuidance('pat', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('"Resource owner"')
+  })
+
+  test('PAT guidance uses the exact github.com UI label "Repository access"', () => {
+    const msg = buildPermissionGuidance('pat', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('"Repository access"')
+  })
+
+  test('PAT guidance uses the exact github.com UI label "Repository permissions"', () => {
+    const msg = buildPermissionGuidance('pat', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('"Repository permissions"')
+  })
+
+  test('PAT guidance names "Webhooks" → "Read and write" verbatim (the actual permission row)', () => {
+    const msg = buildPermissionGuidance('pat', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('"Webhooks"')
+    expect(msg).toContain('"Read and write"')
+  })
+
+  test('PAT guidance names "Metadata" → "Read-only" verbatim (silently required by fine-grained tokens)', () => {
+    const msg = buildPermissionGuidance('pat', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('"Metadata"')
+    expect(msg).toContain('"Read-only"')
+  })
+
+  test('PAT guidance points at the fine-grained settings page URL', () => {
+    const msg = buildPermissionGuidance('pat', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('https://github.com/settings/personal-access-tokens')
+  })
+
+  test('PAT guidance covers the SAML SSO unlock path (the second-most-common cause)', () => {
+    const msg = buildPermissionGuidance('pat', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('SAML')
+    expect(msg).toContain('Configure SSO')
+  })
+
+  test('PAT guidance mentions the classic-PAT fallback with the canonical scope name', () => {
+    const msg = buildPermissionGuidance('pat', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('admin:repo_hook')
+  })
+
+  test('PAT guidance does NOT mention GitHub App settings (would mislead the user)', () => {
+    const msg = buildPermissionGuidance('pat', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).not.toContain('https://github.com/settings/apps')
+  })
+
+  test('App guidance uses the exact UI label "Permissions & events"', () => {
+    const msg = buildPermissionGuidance('app', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('"Permissions & events"')
+  })
+
+  test('App guidance names "Webhooks" → "Read and write" verbatim under "Repository permissions"', () => {
+    const msg = buildPermissionGuidance('app', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('"Repository permissions"')
+    expect(msg).toContain('"Webhooks"')
+    expect(msg).toContain('"Read and write"')
+  })
+
+  test('App guidance points at the GitHub Apps settings page URL', () => {
+    const msg = buildPermissionGuidance('app', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('https://github.com/settings/apps')
+  })
+
+  test('App guidance covers the install-or-configure step (apps are useless until installed)', () => {
+    const msg = buildPermissionGuidance('app', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).toContain('Install App')
+    expect(msg).toContain('Configure')
+  })
+
+  test('App guidance does NOT mention PAT-only concepts (Resource owner / SAML token authorization)', () => {
+    const msg = buildPermissionGuidance('app', [{ repo: 'acme/x', status: 404 }])
+    expect(msg).not.toContain('"Resource owner"')
+    expect(msg).not.toContain('admin:repo_hook')
+  })
+
+  test('both variants explain why 404 means missing repo access (so the user does not think the repo is deleted)', () => {
+    const patMsg = buildPermissionGuidance('pat', [{ repo: 'acme/x', status: 404 }])
+    const appMsg = buildPermissionGuidance('app', [{ repo: 'acme/x', status: 404 }])
+    expect(patMsg).toContain('404')
+    expect(patMsg).toContain('hides private repos')
+    expect(appMsg).toContain('404')
+    expect(appMsg).toContain('hides private repos')
+  })
+})


### PR DESCRIPTION
## Why

When the GitHub adapter fails to list webhooks for a repo, it logs:

```
[github] webhook register failed for acme/widgets: list hooks failed: 404 {"message":"Not Found",...}
```

That line gives the user nothing to act on. The 404 is particularly
confusing — it looks like the repo is gone, but GitHub intentionally returns
404 (not 403) for private repos the token cannot see, to avoid leaking the
repo's existence. A user who sees that line has to know GitHub internals to
understand what "check your token permissions" even means in practice.

## What's new

When any list-hooks call comes back 403 or 404, the adapter now logs a
once-per-start() permission guide that names the failing repos and explains
what to fix. It never fires on 500, 401, network errors, or create-hook
errors, so it cannot produce false positives on transient failures.

## Example (PAT auth)

```
[github] webhook register failed for acme/widgets: list hooks failed: 404 {"message":"Not Found",...}
[github] webhook register failed for acme/gadgets: list hooks failed: 404 {"message":"Not Found",...}
[github] webhook setup needs more access for: acme/widgets (404), acme/gadgets (404).
  - 404 from GitHub means the token cannot see the repo (GitHub hides private repos behind 404 instead of 403).
  - 403 means the token sees the repo but lacks webhook permission, or is blocked by org SAML/SSO.

  Fix (fine-grained personal access token):
    1. Open https://github.com/settings/personal-access-tokens and edit the token TypeClaw is using.
    2. Under "Resource owner", select the org that owns the failing repos (e.g. the org in the slug above).
    3. Under "Repository access", choose "Only select repositories" and add every failing repo (or pick "All repositories").
    4. Under "Repository permissions", set "Webhooks" to "Read and write" and "Metadata" to "Read-only".
    5. Save. If the org enforces SAML SSO, click "Configure SSO" next to the token and authorize the org.

  Or (classic personal access token): grant the "admin:repo_hook" scope (or "repo" for private repos),
  and on a SAML-protected org click "Authorize" next to the token.
```

For GitHub App auth the same trigger fires with an App-flavored fix block
(permission change → install/configure → accept updated permissions gotcha).

## Files changed

**src/channels/adapters/github/index.ts** — Threads `authType` into
`logRegistrationOutcome`. Adds two exported pure helpers:
`parseListHooksPermissionStatus` (regex on the error string) and
`buildPermissionGuidance` (formatter), both exported for direct unit testing.

**src/channels/adapters/github/permission-guidance.test.ts** (new) — 27 unit
tests on the two pure helpers: trigger thresholds (404/403 yes; 500/401/network
no), both auth-type branches, verbatim UI-label presence, and cross-pollination
guards (PAT guide must not show App URLs; App guide must not show PAT-only
concepts).

**src/channels/adapters/github/lifecycle.test.ts** — 2 new integration tests:
the 404 path emits guidance through the full adapter; the 500 path does not
(negative case proving no false positives on transient failures).

## Design choices

**Where the guidance lives.** The guide is attached to `logRegistrationOutcome`
(the formatting/logging layer in index.ts), not to webhook-register.ts
(the pure HTTP layer). The HTTP layer has no logger and no auth-type
knowledge — the right place to attach human-readable guidance is the same
place that already formats log lines.

**Auth-type branching.** The adapter already carries `options.secrets.auth.type`
(a `'pat' | 'app'` discriminant); no new plumbing needed. PAT users never
see App Console URLs; App users never see "Resource owner" or `admin:repo_hook`.

**Once per start(), not once per failing repo.** A 10-repo permission failure
logs the guide once. Ten copies of the same paragraph would bury it.

**Verbatim UI labels.** Strings like "Resource owner", "Repository access",
"Webhooks", and "Read and write" are quoted exactly as they appear on
github.com settings pages so users can Cmd-F to the right field. A
maintenance comment on `buildPermissionGuidance` documents the settings-page
paths so future maintainers know where to re-verify if GitHub redesigns the UI.
The unit tests assert these strings' presence verbatim, so a label change fails
tests before it ships.

## Verification

```
bun run typecheck   ✓  clean
bun run lint        ✓  0 errors (16 pre-existing warnings in unrelated files)
bun run format      ✓  clean
bun test (new)      ✓  38 pass / 0 fail
```