### PR TITLE
oauth: fix cross-device ChatGPT OAuth hanging at "Waiting for browser login..."

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1275,7 +1275,12 @@ function buildOAuthCallbacks(providerName: string) {
       // user copy-pastes it. Keep instructional text in the box, but print
       // the URL itself as a bare console.log line that any terminal will
       // hyperlink intact.
-      const preamble = [`Open this URL in your browser to authorize ${providerName}.`]
+      const preamble = [
+        `Open this URL in your browser to sign in to ${providerName}.`,
+        '',
+        'If your browser shows "this site can\'t be reached" after you sign in,',
+        'copy the full address from the top of the browser and paste it below.',
+      ]
       if (instructions) preamble.push('', instructions)
       note(preamble.join('\n'), 'Browser login')
       console.log(url)
@@ -1287,6 +1292,15 @@ function buildOAuthCallbacks(providerName: string) {
     onPrompt: async (message: string, placeholder?: string): Promise<string | null> => {
       const value = await text({ message, ...(placeholder !== undefined ? { placeholder } : {}) })
       if (isCancel(value)) return null
+      return value
+    },
+    onManualCodeInput: async (): Promise<string> => {
+      const value = await text({
+        message:
+          'If your browser shows "this site can\'t be reached" after you sign in, copy the full address from the top of the browser and paste it here:',
+        placeholder: 'http://localhost:1455/auth/callback?code=...&state=...',
+      })
+      if (isCancel(value)) throw new Error('Login cancelled by user')
       return value
     },
   }

--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -368,7 +368,12 @@ async function runOAuthLogin(cwd: string, providerId: KnownProviderId): Promise<
 
   const callbacks = {
     onAuth: (url: string, instructions?: string) => {
-      const preamble = [`Open this URL in your browser to authorize ${provider.name}.`]
+      const preamble = [
+        `Open this URL in your browser to sign in to ${provider.name}.`,
+        '',
+        'If your browser shows "this site can\'t be reached" after you sign in,',
+        'copy the full address from the top of the browser and paste it below.',
+      ]
       if (instructions) preamble.push('', instructions)
       note(preamble.join('\n'), 'Browser login')
       console.log(url)
@@ -380,6 +385,15 @@ async function runOAuthLogin(cwd: string, providerId: KnownProviderId): Promise<
     onPrompt: async (message: string, placeholder?: string): Promise<string | null> => {
       const value = await text({ message, ...(placeholder !== undefined ? { placeholder } : {}) })
       if (isCancel(value)) return null
+      return value
+    },
+    onManualCodeInput: async (): Promise<string> => {
+      const value = await text({
+        message:
+          'If your browser shows "this site can\'t be reached" after you sign in, copy the full address from the top of the browser and paste it here:',
+        placeholder: 'http://localhost:1455/auth/callback?code=...&state=...',
+      })
+      if (isCancel(value)) throw new Error('Login cancelled by user')
       return value
     },
   }

--- a/src/init/oauth-login.test.ts
+++ b/src/init/oauth-login.test.ts
@@ -3,6 +3,14 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import {
+  getOAuthProvider,
+  registerOAuthProvider,
+  unregisterOAuthProvider,
+  type OAuthLoginCallbacks,
+  type OAuthProviderInterface,
+} from '@mariozechner/pi-ai/oauth'
+
 import { makeFakeOAuthLoginRunner, makeOAuthLoginRunner, type OAuthCallbacks } from './oauth-login'
 
 let root: string
@@ -57,5 +65,68 @@ describe('makeOAuthLoginRunner', () => {
     if (!result.ok) {
       expect(result.reason).toContain('does not support OAuth')
     }
+  })
+
+  // Swap pi-ai's real openai-codex OAuth provider for a capture-only fake so
+  // we can assert what callback shape typeclaw hands to upstream — specifically
+  // that onManualCodeInput is forwarded when supplied. Real bug this guards:
+  // without this wiring, cross-device login (browser on a different machine
+  // than the CLI) hangs forever because waitForCode never resolves and the
+  // onPrompt fallback never fires either.
+  describe('forwards onManualCodeInput to pi-ai when provided', () => {
+    let original: OAuthProviderInterface | undefined
+    let received: OAuthLoginCallbacks | undefined
+
+    beforeEach(() => {
+      received = undefined
+      original = getOAuthProvider('openai-codex')
+      registerOAuthProvider({
+        id: 'openai-codex',
+        name: 'fake openai-codex for tests',
+        usesCallbackServer: true,
+        login: async (callbacks) => {
+          received = callbacks
+          return { access: 'a', refresh: 'r', expires: Date.now() + 60_000 }
+        },
+        refreshToken: async () => {
+          throw new Error('refresh not used in this test')
+        },
+        getApiKey: (c) => c.access,
+      })
+    })
+
+    afterEach(() => {
+      unregisterOAuthProvider('openai-codex')
+      if (original) registerOAuthProvider(original)
+    })
+
+    test('onManualCodeInput is wired through and returns the value the CLI provides', async () => {
+      const callbacks: OAuthCallbacks = {
+        onAuth: () => {},
+        onPrompt: async () => null,
+        onManualCodeInput: async () => 'pasted-by-user',
+      }
+      const runner = makeOAuthLoginRunner(callbacks)
+
+      const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.5' })
+
+      expect(result).toEqual({ ok: true })
+      expect(received?.onManualCodeInput).toBeDefined()
+      const value = await received?.onManualCodeInput?.()
+      expect(value).toBe('pasted-by-user')
+    })
+
+    test('omitting onManualCodeInput leaves the upstream field unset (backwards compat)', async () => {
+      const callbacks: OAuthCallbacks = {
+        onAuth: () => {},
+        onPrompt: async () => null,
+      }
+      const runner = makeOAuthLoginRunner(callbacks)
+
+      const result = await runner({ cwd: root, model: 'openai-codex/gpt-5.5' })
+
+      expect(result).toEqual({ ok: true })
+      expect(received?.onManualCodeInput).toBeUndefined()
+    })
   })
 })

--- a/src/init/oauth-login.ts
+++ b/src/init/oauth-login.ts
@@ -14,16 +14,29 @@ export type OAuthLoginResult = { ok: true } | { ok: false; reason: string }
 export type OAuthLoginRunner = (options: { cwd: string; model: KnownModelRef }) => Promise<OAuthLoginResult>
 
 // Wrap pi-ai's OAuth callbacks so the CLI doesn't have to know about the
-// upstream callback shape. The CLI only sees three lifecycle events:
+// upstream callback shape. The CLI sees four lifecycle events:
 // (1) onAuth(url) — print the URL the user must visit
 // (2) onProgress(message) — show waiting/finalizing status
 // (3) onPrompt(prompt) — ask the user for a manual code if the browser flow
-//     can't reach the local callback server. Most users won't see this; it
-//     fires when they paste the post-redirect URL by hand.
+//     can't reach the local callback server. Fires only after the local
+//     server gave up (bind error -> waitForCode resolves null).
+// (4) onManualCodeInput() — concurrent paste input that RACES the local
+//     callback server. Required for cross-device flows: pi-ai's openai-codex
+//     OAuth hardcodes redirect_uri=http://localhost:1455/auth/callback, which
+//     resolves to the *browser's* machine. When the user runs `typeclaw init`
+//     over SSH or on a remote dev box and completes login on a different
+//     laptop, the browser callback never reaches the CLI's local server and
+//     waitForCode() hangs forever — so onPrompt would never fire either.
+//     onManualCodeInput is the upstream-supported escape hatch: it shows a
+//     paste field IMMEDIATELY alongside the URL, and whichever path lands a
+//     code first wins. parseAuthorizationInput on the upstream side accepts
+//     the full redirect URL, the bare `code=...&state=...` query string, or
+//     just the code value.
 export type OAuthCallbacks = {
   onAuth: (url: string, instructions?: string) => void
   onProgress?: (message: string) => void
   onPrompt: (message: string, placeholder?: string) => Promise<string | null>
+  onManualCodeInput?: () => Promise<string>
 }
 
 // Default runner: real OAuth flow against pi-ai. Tests inject a stub to skip
@@ -50,6 +63,7 @@ export function makeOAuthLoginRunner(callbacks: OAuthCallbacks): OAuthLoginRunne
           }
           return value
         },
+        ...(callbacks.onManualCodeInput ? { onManualCodeInput: callbacks.onManualCodeInput } : {}),
       })
       return { ok: true }
     } catch (error) {


### PR DESCRIPTION
## Problem

Running `typeclaw init` on a remote machine (SSH, cloud dev box) and completing OAuth in a local browser causes the spinner to hang indefinitely at "Waiting for browser login...". The session never completes.

## Root cause

OpenAI's OAuth client hardcodes `redirect_uri=http://localhost:1455/auth/callback`. After the user signs in at auth.openai.com, the browser redirects to `localhost:1455` — but that is the **browser machine's** localhost, not the CLI machine's. The local callback server typeclaw starts never receives the redirect and blocks forever.

The upstream `@mariozechner/pi-ai/oauth` API exposes `onManualCodeInput` — a callback that races the local server — but typeclaw never wired it. Without it there is no fallback path for the cross-device case.

## Fix

Wire `onManualCodeInput` in both `init` and `provider` OAuth flows. The upstream `loginOpenAICodex` races both paths; whichever produces a code first wins:

- **Same-device (unchanged):** browser auto-redirects → `server.waitForCode()` resolves as before.
- **Cross-device:** browser shows "this site can't be reached" → user copies the full address bar URL (contains `?code=...&state=...`) → pastes into the new prompt → upstream parses and validates code + state, then exchanges for tokens.

**Why not Cloudflare tunnels?** OAuth 2.0 requires the `redirect_uri` at token exchange to exactly match the value sent at authorize time. OpenAI only whitelists `http://localhost:1455/auth/callback`. A public tunnel URL always fails with `redirect_uri_mismatch`.

## Changes

| File | Change |
|------|--------|
| `src/init/oauth-login.ts` | Add optional `onManualCodeInput` to `OAuthCallbacks`; thread through to `secrets.login()` via conditional spread. |
| `src/cli/init.ts` | Extend `note()` preamble with cross-device guidance; add `onManualCodeInput` clack prompt. |
| `src/cli/provider.ts` | Same treatment — covers `typeclaw provider add` and `provider set`. |
| `src/init/oauth-login.test.ts` | Two new tests (details below). |

## Testing

Tests follow AGENTS.md §5 (real implementations, controlled inputs). `registerOAuthProvider` swaps a capture-only fake for `openai-codex` — no mocks.

- **`onManualCodeInput` wired and returns the CLI's value** — asserts the upstream callback fires and the return value reaches the caller.
- **Omitting `onManualCodeInput` leaves the upstream field unset** — asserts the conditional spread preserves the absent-field semantic (backwards compat).

Mutation check: commenting out the spread in `oauth-login.ts` fails the first test.

```
bun run typecheck          ✓ clean
bun run lint               ✓ 17 warnings, 0 errors (all pre-existing, none in changed files)
bun run format             ✓ clean
bun test oauth-login       ✓ 5 pass / 0 fail (3 existing + 2 new)
bun test src/init/ src/cli/ src/secrets/  ✓ 655 pass / 0 fail
```

## Known UX trap (deferred)

On the same-device happy path, the manual paste prompt is visible while the browser callback is in flight. If the user hits ESC on that prompt thinking they're "dismissing" it, our `onManualCodeInput` callback throws — which upstream `loginOpenAICodex` (`openai-codex.js:259-266`) catches, calls `server.cancelWait()`, and re-throws as the login error. **Result: the user kills their own in-progress OAuth.** This is more than cosmetic.

Mitigations to consider in a follow-up:
- Swallow ESC on `onManualCodeInput` (resolve a never-completing promise rather than throw), so cancellation requires an explicit user action like Ctrl-C on the parent spinner.
- Display the prompt only after a short delay, so the same-device happy path completes silently before the prompt appears.

Not addressed here to keep the cross-device fix isolated.

## Out of scope

- Auto-opening the browser (typeclaw still prints the URL only).
- Port-1455-already-in-use case falls to the `onPrompt` fallback; works but UX is suboptimal.
- Refactor the duplicated callback construction in `init.ts` and `provider.ts` into a shared helper. Tracked as a follow-up.
