### PR TITLE
cli: extract shared OAuth callbacks helper + simplify pi-ai spread

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -31,6 +31,7 @@ import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { fetchModelOptions, type ModelOption } from '@/init/models-dev'
 import { makeOAuthLoginRunner } from '@/init/oauth-login'
 
+import { buildOAuthCallbacks } from './oauth-callbacks'
 import { c, done, errorLine } from './ui'
 
 // ESC and Ctrl+C both produce clack's cancel symbol (the keypress layer
@@ -1259,51 +1260,6 @@ export async function decideExistingApiKeyReuse(
   const reuse = await askReuse(`Reuse existing ${provider.name} API key from secrets.json?`)
   if (isCancel(reuse)) return 'cancel'
   return reuse === true ? 'reuse' : 'prompt'
-}
-
-// Wraps the OAuth lifecycle into the same clack idiom the rest of the wizard
-// uses: a spinner over the "waiting for login" period, with onAuth printing
-// the URL the user needs to open and onPrompt falling back to a `text`
-// prompt for the manual code path. The spinner is started by onAuth and
-// stopped by the caller (runInit) — we don't try to manage it here because
-// the spinner lifecycle has to span emit('start') -> emit('done').
-function buildOAuthCallbacks(providerName: string) {
-  return {
-    onAuth: (url: string, instructions?: string) => {
-      // Don't put the URL inside note(): clack wraps long lines with the box
-      // border `│` on each wrapped segment, which corrupts the URL when the
-      // user copy-pastes it. Keep instructional text in the box, but print
-      // the URL itself as a bare console.log line that any terminal will
-      // hyperlink intact.
-      const preamble = [
-        `Open this URL in your browser to sign in to ${providerName}.`,
-        '',
-        'If your browser shows "this site can\'t be reached" after you sign in,',
-        'copy the full address from the top of the browser and paste it below.',
-      ]
-      if (instructions) preamble.push('', instructions)
-      note(preamble.join('\n'), 'Browser login')
-      console.log(url)
-      console.log('')
-    },
-    onProgress: (message: string) => {
-      log.info(message)
-    },
-    onPrompt: async (message: string, placeholder?: string): Promise<string | null> => {
-      const value = await text({ message, ...(placeholder !== undefined ? { placeholder } : {}) })
-      if (isCancel(value)) return null
-      return value
-    },
-    onManualCodeInput: async (): Promise<string> => {
-      const value = await text({
-        message:
-          'If your browser shows "this site can\'t be reached" after you sign in, copy the full address from the top of the browser and paste it here:',
-        placeholder: 'http://localhost:1455/auth/callback?code=...&state=...',
-      })
-      if (isCancel(value)) throw new Error('Login cancelled by user')
-      return value
-    },
-  }
 }
 
 function uniqueProviders(options: ModelOption[]): KnownProviderId[] {

--- a/src/cli/oauth-callbacks.test.ts
+++ b/src/cli/oauth-callbacks.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildOAuthCallbacks } from './oauth-callbacks'
+
+describe('buildOAuthCallbacks', () => {
+  test('provides every callback the OAuth runner forwards to pi-ai, including onManualCodeInput', () => {
+    const callbacks = buildOAuthCallbacks('Test Provider')
+
+    expect(typeof callbacks.onAuth).toBe('function')
+    expect(typeof callbacks.onProgress).toBe('function')
+    expect(typeof callbacks.onPrompt).toBe('function')
+    expect(typeof callbacks.onManualCodeInput).toBe('function')
+  })
+})

--- a/src/cli/oauth-callbacks.ts
+++ b/src/cli/oauth-callbacks.ts
@@ -1,0 +1,49 @@
+import { isCancel, log, note, text } from '@clack/prompts'
+
+import type { OAuthCallbacks } from '@/init/oauth-login'
+
+// Shared between `typeclaw init` (src/cli/init.ts) and `typeclaw provider
+// add/set` (src/cli/provider.ts). Both call into the same OAuth runner, so
+// they need to render the same UX: a note() box with the URL + cross-device
+// guidance, a `text()` prompt for the post-callback manual fallback, and a
+// concurrent `onManualCodeInput` prompt for users whose browser is on a
+// different host than the CLI. See src/init/oauth-login.ts for the contract
+// on each callback and why onManualCodeInput is required for cross-device.
+export function buildOAuthCallbacks(providerName: string): OAuthCallbacks {
+  return {
+    onAuth: (url, instructions) => {
+      // Don't put the URL inside note(): clack wraps long lines with the box
+      // border `│` on each wrapped segment, which corrupts the URL when the
+      // user copy-pastes it. Keep instructional text in the box, but print
+      // the URL itself as a bare console.log line that any terminal will
+      // hyperlink intact.
+      const preamble = [
+        `Open this URL in your browser to sign in to ${providerName}.`,
+        '',
+        'If your browser shows "this site can\'t be reached" after you sign in,',
+        'copy the full address from the top of the browser and paste it below.',
+      ]
+      if (instructions) preamble.push('', instructions)
+      note(preamble.join('\n'), 'Browser login')
+      console.log(url)
+      console.log('')
+    },
+    onProgress: (message) => {
+      log.info(message)
+    },
+    onPrompt: async (message, placeholder) => {
+      const value = await text({ message, ...(placeholder !== undefined ? { placeholder } : {}) })
+      if (isCancel(value)) return null
+      return value
+    },
+    onManualCodeInput: async () => {
+      const value = await text({
+        message:
+          'If your browser shows "this site can\'t be reached" after you sign in, copy the full address from the top of the browser and paste it here:',
+        placeholder: 'http://localhost:1455/auth/callback?code=...&state=...',
+      })
+      if (isCancel(value)) throw new Error('Login cancelled by user')
+      return value
+    },
+  }
+}

--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -1,4 +1,4 @@
-import { cancel, intro, isCancel, log, note, password, select, text } from '@clack/prompts'
+import { cancel, intro, isCancel, log, password, select } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import {
@@ -17,6 +17,7 @@ import {
 import { findAgentDir, isInitialized } from '@/init'
 import { makeOAuthLoginRunner } from '@/init/oauth-login'
 
+import { buildOAuthCallbacks } from './oauth-callbacks'
 import { c, done, errorLine } from './ui'
 
 const addSub = defineCommand({
@@ -366,39 +367,7 @@ async function runOAuthLogin(cwd: string, providerId: KnownProviderId): Promise<
   }
   const modelRef = `${providerId}/${ref}` as const
 
-  const callbacks = {
-    onAuth: (url: string, instructions?: string) => {
-      const preamble = [
-        `Open this URL in your browser to sign in to ${provider.name}.`,
-        '',
-        'If your browser shows "this site can\'t be reached" after you sign in,',
-        'copy the full address from the top of the browser and paste it below.',
-      ]
-      if (instructions) preamble.push('', instructions)
-      note(preamble.join('\n'), 'Browser login')
-      console.log(url)
-      console.log('')
-    },
-    onProgress: (message: string) => {
-      log.info(message)
-    },
-    onPrompt: async (message: string, placeholder?: string): Promise<string | null> => {
-      const value = await text({ message, ...(placeholder !== undefined ? { placeholder } : {}) })
-      if (isCancel(value)) return null
-      return value
-    },
-    onManualCodeInput: async (): Promise<string> => {
-      const value = await text({
-        message:
-          'If your browser shows "this site can\'t be reached" after you sign in, copy the full address from the top of the browser and paste it here:',
-        placeholder: 'http://localhost:1455/auth/callback?code=...&state=...',
-      })
-      if (isCancel(value)) throw new Error('Login cancelled by user')
-      return value
-    },
-  }
-
-  const runner = makeOAuthLoginRunner(callbacks)
+  const runner = makeOAuthLoginRunner(buildOAuthCallbacks(provider.name))
   const result = await runner({ cwd, model: modelRef as Parameters<typeof runner>[0]['model'] })
   if (!result.ok) return { ok: false, reason: result.reason }
   return { ok: true }

--- a/src/init/oauth-login.ts
+++ b/src/init/oauth-login.ts
@@ -63,7 +63,7 @@ export function makeOAuthLoginRunner(callbacks: OAuthCallbacks): OAuthLoginRunne
           }
           return value
         },
-        ...(callbacks.onManualCodeInput ? { onManualCodeInput: callbacks.onManualCodeInput } : {}),
+        onManualCodeInput: callbacks.onManualCodeInput,
       })
       return { ok: true }
     } catch (error) {


### PR DESCRIPTION
## What

Follow-up to #252 addressing three non-blocking findings from the post-implementation review:

1. **Duplication**: extract the OAuth callback construction (shared between `typeclaw init` and `typeclaw provider add/set`) into `src/cli/oauth-callbacks.ts`.
2. **Conditional spread**: simplify `src/init/oauth-login.ts` now that we've verified upstream uses a truthy check.
3. **Test gap**: add a helper-level test that catches removal of `onManualCodeInput` from the CLI surface — covering both entry points via the single shared definition.

Stacked on `fix/oauth-cross-device-manual-paste`. Rebase onto `main` once #252 lands.

## Changes

| File | Change |
|------|--------|
| `src/cli/oauth-callbacks.ts` | **NEW** — shared `buildOAuthCallbacks(providerName)`. Byte-identical UX to #252. |
| `src/cli/oauth-callbacks.test.ts` | **NEW** — mutation-check guard: asserts every forwarded callback is provided, including `onManualCodeInput`. |
| `src/cli/init.ts` | Drop inline `buildOAuthCallbacks`, import from `./oauth-callbacks`. |
| `src/cli/provider.ts` | Same — also drops unused `note` / `text` imports. |
| `src/init/oauth-login.ts` | Replace `...(callbacks.onManualCodeInput ? { onManualCodeInput: ... } : {})` with `onManualCodeInput: callbacks.onManualCodeInput`. |

Net change: 5 files, **-79 / +69** lines (net **-10**, plus a new test).

## Why no behavioral change

- **Shared helper is a textual extract.** The rendered `note()` box, the `onPrompt` fallback, and the `onManualCodeInput` race prompt produce byte-identical output to #252.
- **Spread simplification is verified safe.** I checked the installed upstream — `@mariozechner/pi-ai/dist/utils/oauth/openai-codex.js:249` uses `if (options.onManualCodeInput)`. A truthy check treats absent and `undefined`-valued fields identically. The existing "backwards compat" test (`omitting onManualCodeInput leaves the upstream field unset`) still passes because `received?.onManualCodeInput` is undefined either way.

## Testing

Mutation check on the new helper test: rename `onManualCodeInput` to `_mutated_disabled` in `oauth-callbacks.ts`, run `bun test src/cli/oauth-callbacks.test.ts` — fails with `expect(received).toBe(expected)`. Restore — passes.

```
bun run typecheck   ✓ clean
bun run lint        ✓ 17 warnings, 0 errors (all pre-existing, none in changed files)
bun run format      ✓ clean
bun test            ✓ 4095 pass / 0 fail (1 more than #252's 4094 — the new helper test)
```

## Why this is its own PR

#252 ships the bug fix and is the cherry-pick-able commit a user with a cross-device hang needs. This refactor is quality-only — separating it keeps `git blame` honest about what fixed the bug vs what was code-style cleanup.

Closes the three quality findings from the #252 self-review. Doesn't address the ESC-kills-login UX trap documented in #252's "Known UX trap" section — that needs a real UX decision (swallow ESC vs delay the prompt) and belongs in its own PR.
