### PR TITLE
channels: cap per-turn sends, dedupe, and structure send telemetry

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -19,6 +19,7 @@ function fakeRouter(
     route: async () => {},
     send: handler,
     getConsecutiveSendCount: () => options.consecutiveCount ?? 0,
+    getSendRate: () => ({ count: 0, windowMs: 5_000 }),
     registerOutbound: () => {},
     unregisterOutbound: () => {},
     registerTyping: () => {},
@@ -349,6 +350,32 @@ describe('createChannelReplyTool', () => {
       expect(calls).toHaveLength(0)
       expect(result.details).toMatchObject({ ok: false })
       expect((result.details as { error: string }).error).toContain('silent-turn signal')
+    })
+  })
+
+  describe('structured router failures surface as denials', () => {
+    test('duplicate code from router renders as channel_reply denied with router error text', async () => {
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async () => ({ ok: false, error: 'Duplicate not sent. ...', code: 'duplicate' })),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, { text: 'same body' })
+      expect(result.details).toEqual({ ok: false, error: 'Duplicate not sent. ...' })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toContain('channel_reply denied')
+      expect(text).toContain('Duplicate not sent')
+      expect(text).not.toContain('posted to')
+    })
+
+    test('turn-cap code from router renders as channel_reply denied', async () => {
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async () => ({ ok: false, error: 'Send-cap reached for this turn ...', code: 'turn-cap' })),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, { text: 'eleventh message' })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toContain('channel_reply denied')
+      expect(text).toContain('Send-cap reached')
     })
   })
 })

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -13,6 +13,7 @@ function fakeRouter(
     route: async () => {},
     send: handler,
     getConsecutiveSendCount: () => options.consecutiveCount ?? 0,
+    getSendRate: () => ({ count: 0, windowMs: 5_000 }),
     registerOutbound: () => {},
     unregisterOutbound: () => {},
     registerTyping: () => {},
@@ -427,6 +428,39 @@ describe('createChannelSendTool', () => {
       expect(calls).toHaveLength(0)
       expect(result.details).toMatchObject({ ok: false })
       expect((result.details as { error: string }).error).toContain('silent-turn signal')
+    })
+  })
+
+  describe('structured router failures surface as denials', () => {
+    test('duplicate code from router renders as channel_send denied with router error text', async () => {
+      const tool = createChannelSendTool({
+        router: fakeRouter(async () => ({ ok: false, error: 'Duplicate not sent. ...', code: 'duplicate' })),
+      })
+      const result = await runTool(tool, {
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        text: 'same body',
+      })
+      expect(result.details).toEqual({ ok: false, error: 'Duplicate not sent. ...' })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toContain('channel_send denied')
+      expect(text).toContain('Duplicate not sent')
+    })
+
+    test('turn-cap code from router renders as channel_send denied', async () => {
+      const tool = createChannelSendTool({
+        router: fakeRouter(async () => ({ ok: false, error: 'Send-cap reached for this turn ...', code: 'turn-cap' })),
+      })
+      const result = await runTool(tool, {
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        text: 'eleventh',
+      })
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toContain('channel_send denied')
+      expect(text).toContain('Send-cap reached')
     })
   })
 })

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -35,6 +35,7 @@ function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
     route: async () => {},
     send: overrides.send ?? (async () => ({ ok: true })),
     getConsecutiveSendCount: () => 0,
+    getSendRate: () => ({ count: 0, windowMs: 5_000 }),
     registerOutbound: () => {},
     unregisterOutbound: () => {},
     registerTyping: () => {},

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -33,6 +33,7 @@ function fakeRouter(handler: (msg: OutboundMessage) => Promise<SendResult>): Cha
     route: async () => {},
     send: handler,
     getConsecutiveSendCount: () => 0,
+    getSendRate: () => ({ count: 0, windowMs: 5_000 }),
     registerOutbound: () => {},
     unregisterOutbound: () => {},
     registerTyping: () => {},

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -14,11 +14,16 @@ import type { HookBus, SessionIdleEvent } from '@/plugin'
 import { channelsSessionsPath, loadChannelSessions, saveChannelSessions } from './persistence'
 import {
   createChannelRouter,
+  DUPLICATE_SEND_ERROR,
+  MAX_CHANNEL_SENDS_PER_TURN,
   MAX_TYPING_HEARTBEAT_MS,
+  SEND_RATE_WARN_THRESHOLD,
+  SEND_RATE_WINDOW_MS,
   SESSION_GC_INTERVAL_MS,
   SESSION_FRESHNESS_TTL_MS,
   SESSION_IDLE_MS,
   sliceHeadTail,
+  TURN_CAP_ERROR,
   type ChannelRouter,
   type ClaimHandler,
 } from './router'
@@ -1294,6 +1299,418 @@ describe('ChannelRouter consecutive-send accounting', () => {
     expect(router.getConsecutiveSendCount({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-B' })).toBe(
       1,
     )
+  })
+})
+
+describe('ChannelRouter duplicate-send guard', () => {
+  test('first send delivers; second identical send is blocked with code=duplicate', async () => {
+    const dir = await tempDir()
+    let delivered = 0
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => {
+      delivered++
+      return { ok: true }
+    })
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    const first = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'hello' })
+    expect(first).toEqual({ ok: true })
+
+    const second = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'hello' })
+    expect(second).toEqual({ ok: false, error: DUPLICATE_SEND_ERROR, code: 'duplicate' })
+    expect(delivered).toBe(1)
+  })
+
+  test('lets a different body through after a recent dup', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'first' })
+    const second = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'second' })
+    expect(second).toEqual({ ok: true })
+  })
+
+  test('failed delivery does not reserve a dup slot — retry with same text succeeds', async () => {
+    const dir = await tempDir()
+    let attempts = 0
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => {
+      attempts++
+      return attempts === 1 ? { ok: false, error: 'transient' } : { ok: true }
+    })
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    const first = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'flaky' })
+    expect(first.ok).toBe(false)
+    const retry = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'flaky' })
+    expect(retry).toEqual({ ok: true })
+  })
+
+  test('resets on the next user batch so across-turn repeats are not blocked', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const a = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'yes I am here' })
+    expect(a).toEqual({ ok: true })
+
+    await router.route(inbound({ externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+    const b = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'yes I am here' })
+    expect(b).toEqual({ ok: true })
+  })
+
+  test('scopes per (chat:thread): same text to a different thread is not flagged', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound({ thread: 't-A', externalMessageId: 'mA' }))
+    await router.__testing!.flushDebounce({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-A' })
+    await router.route(inbound({ thread: 't-B', externalMessageId: 'mB' }))
+    await router.__testing!.flushDebounce({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-B' })
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-A', text: 'shared' })
+    const b = await router.send({
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      thread: 't-B',
+      text: 'shared',
+    })
+    expect(b).toEqual({ ok: true })
+  })
+
+  test('attachments-only sends (text undefined) do not poison the dup tracker', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    await router.send({
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      attachments: [{ path: '/agent/file.png' }],
+    })
+    await router.send({
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      attachments: [{ path: '/agent/file2.png' }],
+    })
+    // Both succeed; empty-string normalization means attachments-only never sets lastSentText.
+    expect(router.getConsecutiveSendCount({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1' })).toBe(2)
+  })
+
+  test('empty string text is normalized — does not block a follow-up empty-text send', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    await router.send({
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      text: '',
+      attachments: [{ path: '/agent/a.png' }],
+    })
+    const second = await router.send({
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      text: '',
+      attachments: [{ path: '/agent/b.png' }],
+    })
+    expect(second).toEqual({ ok: true })
+  })
+
+  test('parallel router.send for same text — only one delivers, the rest are duplicate-denied', async () => {
+    const dir = await tempDir()
+    let delivered = 0
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => {
+      // simulate a tiny adapter latency so all 10 sends are in flight at the same time
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      delivered++
+      return { ok: true }
+    })
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    const N = 10
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'same-text' }),
+      ),
+    )
+    const okCount = results.filter((r) => r.ok).length
+    const dupCount = results.filter((r) => !r.ok && r.code === 'duplicate').length
+    expect(okCount).toBe(1)
+    expect(dupCount).toBe(N - 1)
+    expect(delivered).toBe(1)
+  })
+
+  test('system-source send bypasses the duplicate guard (recovery path)', async () => {
+    const dir = await tempDir()
+    let delivered = 0
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => {
+      delivered++
+      return { ok: true }
+    })
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'hello' })
+    const sys = await router.send(
+      { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'hello' },
+      { source: 'system' },
+    )
+    expect(sys).toEqual({ ok: true })
+    expect(delivered).toBe(2)
+  })
+})
+
+describe('ChannelRouter per-turn send cap', () => {
+  test('blocks the (cap+1)th tool send with code=turn-cap', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    for (let i = 0; i < MAX_CHANNEL_SENDS_PER_TURN; i++) {
+      const r = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: `msg-${i}` })
+      expect(r).toEqual({ ok: true })
+    }
+    const overflow = await router.send({
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      text: `msg-${MAX_CHANNEL_SENDS_PER_TURN}`,
+    })
+    expect(overflow).toEqual({ ok: false, error: TURN_CAP_ERROR, code: 'turn-cap' })
+  })
+
+  test('cap resets on the next user batch', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    for (let i = 0; i < MAX_CHANNEL_SENDS_PER_TURN; i++) {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: `pre-${i}` })
+    }
+    await router.route(inbound({ externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const fresh = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'post' })
+    expect(fresh).toEqual({ ok: true })
+  })
+
+  test('system-source bypasses the cap', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    for (let i = 0; i < MAX_CHANNEL_SENDS_PER_TURN; i++) {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: `t-${i}` })
+    }
+    const sys = await router.send(
+      { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'recovery' },
+      { source: 'system' },
+    )
+    expect(sys).toEqual({ ok: true })
+  })
+
+  test('parallel router.send for distinct text — at most cap deliveries; the rest turn-capped', async () => {
+    const dir = await tempDir()
+    let delivered = 0
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      delivered++
+      return { ok: true }
+    })
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    const N = MAX_CHANNEL_SENDS_PER_TURN + 5
+    const results = await Promise.all(
+      Array.from({ length: N }, (_v, i) =>
+        router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: `distinct-${i}` }),
+      ),
+    )
+    const okCount = results.filter((r) => r.ok).length
+    const capCount = results.filter((r) => !r.ok && r.code === 'turn-cap').length
+    expect(okCount).toBe(MAX_CHANNEL_SENDS_PER_TURN)
+    expect(capCount).toBe(N - MAX_CHANNEL_SENDS_PER_TURN)
+    expect(delivered).toBe(MAX_CHANNEL_SENDS_PER_TURN)
+  })
+})
+
+describe('ChannelRouter getSendRate', () => {
+  test('reports zero with no active session for the target', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    expect(router.getSendRate({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1' })).toEqual({
+      count: 0,
+      windowMs: SEND_RATE_WINDOW_MS,
+    })
+  })
+
+  test('counts every send inside the rolling window', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'a' })
+    nowRef.value += 100
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'b' })
+    nowRef.value += 100
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'c' })
+    expect(router.getSendRate({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1' }).count).toBe(3)
+  })
+
+  test('prunes timestamps older than the window on every read', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'a' })
+    nowRef.value += SEND_RATE_WINDOW_MS + 1
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'b' })
+    expect(router.getSendRate({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1' }).count).toBe(1)
+  })
+
+  test('survives turn boundaries: rate is wall-clock, not turn-clock', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'a' })
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'b' })
+    expect(router.getSendRate({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1' }).count).toBe(2)
+
+    nowRef.value += 500
+    await router.route(inbound({ externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(router.getSendRate({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1' }).count).toBe(2)
+  })
+
+  test('scopes per (chat:thread): different threads count independently', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound({ thread: 't-A', externalMessageId: 'mA' }))
+    await router.__testing!.flushDebounce({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-A' })
+    await router.route(inbound({ thread: 't-B', externalMessageId: 'mB' }))
+    await router.__testing!.flushDebounce({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-B' })
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-A', text: 'a1' })
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-A', text: 'a2' })
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-B', text: 'b1' })
+
+    expect(router.getSendRate({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-A' }).count).toBe(2)
+    expect(router.getSendRate({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-B' }).count).toBe(1)
+  })
+
+  test('emits a structured per-send log line for every successful send', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'hello' })
+
+    const sendLog = logs.find((m) => m.includes('[channels]') && m.includes(': send source='))
+    expect(sendLog).toBeDefined()
+    expect(sendLog).toContain('source=tool')
+    expect(sendLog).toContain('turn=1')
+    expect(sendLog).toContain('rate=1/')
+    expect(sendLog).toContain('text_len=5')
+  })
+
+  test('flags a burst with send_rate_warning once rate crosses the warn threshold', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const { router } = makeRouter(dir, { nowRef, logs })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    for (let i = 0; i < SEND_RATE_WARN_THRESHOLD - 1; i++) {
+      nowRef.value += 50
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: `pre-${i}` })
+    }
+    expect(logs.some((m) => m.includes('send_rate_warning'))).toBe(false)
+
+    nowRef.value += 50
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'burst' })
+
+    const warn = logs.find((m) => m.startsWith('warn:') && m.includes('send_rate_warning'))
+    expect(warn).toBeDefined()
+    expect(warn).toContain(`rate=${SEND_RATE_WARN_THRESHOLD}/${SEND_RATE_WINDOW_MS}ms`)
+  })
+
+  test('system-source sends are logged with source=system', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'recovery' }, { source: 'system' })
+    const sysLog = logs.find((m) => m.includes(': send source=system'))
+    expect(sysLog).toBeDefined()
+  })
+})
+
+describe('ChannelRouter cross-tool sharing', () => {
+  test('first send via channel_reply blocks a follow-up channel_send with the same text', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    let delivered = 0
+    router.registerOutbound('discord-bot', async () => {
+      delivered++
+      return { ok: true }
+    })
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    const first = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'shared' })
+    expect(first).toEqual({ ok: true })
+
+    const second = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'shared' })
+    expect(second.ok).toBe(false)
+    if (!second.ok) expect(second.code).toBe('duplicate')
+    expect(delivered).toBe(1)
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -78,6 +78,24 @@ export const MAX_TYPING_HEARTBEAT_MS = 2 * 60 * 1000
 export const SESSION_IDLE_MS = 30 * 60 * 1000
 export const SESSION_GC_INTERVAL_MS = 60 * 1000
 
+// Hard cap on tool-initiated outbound sends per (chat:thread) per turn.
+// The original loop-incident emitted ~50 sends in one turn; even
+// legitimate split replies rarely cross 8. 10 leaves headroom for
+// genuine multi-part answers while definitively stopping runaway loops.
+// Enforced inside router.send for `source: 'tool'` callers; system
+// recovery paths (`source: 'system'`) bypass.
+export const MAX_CHANNEL_SENDS_PER_TURN = 10
+// Rolling window for outbound send-rate telemetry. 5s matches Discord's
+// rate-limit shape (5 msg / 5 s / channel) and comfortably covers Slack's
+// 1 msg/s sustained. The window is observational; exceeding the burst
+// threshold below escalates the per-send log to a warning.
+export const SEND_RATE_WINDOW_MS = 5_000
+// Above this in-window count, the per-send log line escalates to a
+// `send_rate_warning` so a burst stands out in the log stream. Every
+// send still emits a structured log line regardless of rate — this
+// constant only controls when the warning marker appears.
+export const SEND_RATE_WARN_THRESHOLD = 3
+
 /**
  * Maximum age of the last engaged inbound before the next inbound triggers a fresh session.
  * Set to the LLM provider's KV-cache TTL (5 min) so the new session's system prompt is
@@ -244,6 +262,26 @@ type LiveSession = {
   // router.send so the hint reflects the position of the about-to-happen send
   // (n-th in a row), nudging the model to yield without forcing it to.
   consecutiveSends: Map<string, number>
+  // Per-(chat:thread) text of the last reserved bot send. Set
+  // SYNCHRONOUSLY inside router.send before the outbound callback awaits,
+  // so two concurrent `router.send` calls for the same target cannot both
+  // pass the duplicate guard. Cleared on every new prompt batch (same
+  // lifecycle as `consecutiveSends`). The scope is "last 1 send within
+  // this turn" so legitimate multi-part replies (different bodies) and
+  // across-turn callbacks ("yes, I'm here" twice) are not blocked. Empty
+  // strings are normalized to undefined before storage so attachments-only
+  // sends never poison the tracker. The fuzzy-match upgrade is intentionally
+  // deferred — exact-match has zero false-positive risk by construction.
+  lastSentText: Map<string, string>
+  // Per-(chat:thread) ring of send timestamps (epoch ms) within the rolling
+  // SEND_RATE_WINDOW_MS window. Append-on-send, prune-on-read. Lifecycle is
+  // wall-clock (NOT cleared on new prompt batches) because rate is a
+  // property of the channel over time, not the agent's turn structure — a
+  // burst that straddles two adjacent turns is still a burst from the chat
+  // platform's POV. Telemetry-only today; the rate is logged when count
+  // crosses SEND_RATE_LOG_THRESHOLD so production data can inform a
+  // future hard cap without picking a threshold out of thin air.
+  sendTimestamps: Map<string, number[]>
   successfulChannelSends: number
   // Loop-guard state. See PEER_BOT_TURNS_WINDOW_MS / MAX_* constants
   // above. Updated in route() on every engaged peer-bot inbound, reset on
@@ -264,15 +302,35 @@ type ChannelCommandContext = {
   event: InboundMessage
 }
 
+export type SendSource = 'tool' | 'system'
+
+export type SendOptions = {
+  source?: SendSource
+}
+
+export const DUPLICATE_SEND_ERROR =
+  'Duplicate not sent. Do not call channel_send/channel_reply again this turn. ' +
+  'End with NO_REPLY unless you have genuinely new, non-redundant information.'
+
+export const TURN_CAP_ERROR =
+  `Send-cap reached for this turn (${MAX_CHANNEL_SENDS_PER_TURN} messages already sent to this conversation). ` +
+  'End your turn now. The user can prompt you again for more output.'
+
 export type ChannelRouter = {
   route: (event: InboundMessage) => Promise<void>
-  send: (msg: OutboundMessage) => Promise<SendResult>
+  send: (msg: OutboundMessage, opts?: SendOptions) => Promise<SendResult>
   getConsecutiveSendCount: (target: {
     adapter: ChannelKey['adapter']
     workspace: string
     chat: string
     thread?: string | null
   }) => number
+  getSendRate: (target: {
+    adapter: ChannelKey['adapter']
+    workspace: string
+    chat: string
+    thread?: string | null
+  }) => { count: number; windowMs: number }
   registerOutbound: (adapter: ChannelKey['adapter'], cb: OutboundCallback) => void
   unregisterOutbound: (adapter: ChannelKey['adapter'], cb: OutboundCallback) => void
   registerTyping: (adapter: ChannelKey['adapter'], cb: TypingCallback) => void
@@ -719,6 +777,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         lastTurnAuthorIds: new Set(),
         consecutiveAborts: 0,
         consecutiveSends: new Map(),
+        lastSentText: new Map(),
+        sendTimestamps: new Map(),
         successfulChannelSends: 0,
         recentEngagedPeerBotTurns: [],
         consecutiveEngagedPeerBotTurns: 0,
@@ -1011,7 +1071,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
         live.currentTurnAuthorId = batch.length > 0 ? batch[batch.length - 1]!.authorId : null
         live.currentTurnAuthorIds = new Set(batch.map((m) => m.authorId))
-        if (batch.length > 0) live.consecutiveSends.clear()
+        if (batch.length > 0) {
+          live.consecutiveSends.clear()
+          live.lastSentText.clear()
+        }
 
         // Update the live origin holder so this turn's tool.before events
         // carry the current actor's id. The DefaultResourceLoader still
@@ -1036,6 +1099,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         } catch (err) {
           logger.error(`[channels] ${live.keyId}: prompt threw: ${describe(err)}`)
           live.consecutiveSends.clear()
+          live.lastSentText.clear()
         } finally {
           await fireSessionTurnEnd(live)
         }
@@ -1108,13 +1172,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         logger.info(
           `[channels] ${channelKeyId(key)}: claim ${outcome.kind} author=${event.authorId} id=${event.externalMessageId}`,
         )
-        await send({
-          adapter: event.adapter,
-          workspace: event.workspace,
-          chat: event.chat,
-          thread: event.thread,
-          text: outcome.reply,
-        })
+        await send(
+          {
+            adapter: event.adapter,
+            workspace: event.workspace,
+            chat: event.chat,
+            thread: event.thread,
+            text: outcome.reply,
+          },
+          { source: 'system' },
+        )
         return
       }
     }
@@ -1421,10 +1488,52 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return lastError
   }
 
-  const send = async (msg: OutboundMessage): Promise<SendResult> => {
+  const send = async (msg: OutboundMessage, opts?: SendOptions): Promise<SendResult> => {
+    const source: SendSource = opts?.source ?? 'tool'
     const callbacks = outboundCallbacks.get(msg.adapter)
     if (!callbacks || callbacks.size === 0) {
-      return { ok: false, error: `no adapter registered for "${msg.adapter}"` }
+      return { ok: false, error: `no adapter registered for "${msg.adapter}"`, code: 'no-adapter' }
+    }
+
+    const keyId = channelKeyId({
+      adapter: msg.adapter,
+      workspace: msg.workspace,
+      chat: msg.chat,
+      thread: msg.thread ?? null,
+    })
+    const live = liveSessions.get(keyId)
+    const sendKey = consecutiveSendKey(msg.chat, msg.thread)
+    const text = normalizeSendText(msg.text)
+
+    // Central enforcement. Tool-initiated sends are subject to two policies:
+    // a per-turn count cap (kills runaway loops regardless of content) and
+    // an exact-duplicate guard (kills the byte-identical-spam sub-mode).
+    // Both checks AND the state mutations they consult happen synchronously
+    // before any `await`, so two concurrent `router.send` calls for the same
+    // target (the parallel-tool-execution race) cannot both pass: the
+    // second observer sees the first one's increment / lastSentText write.
+    // System sources (validateChannelTurn recovery, role-claim reply) bypass
+    // — those are one-shot paths the policy doesn't apply to.
+    let priorLastSentText: string | undefined
+    let reserved = false
+    if (live && source === 'tool') {
+      const currentCount = live.consecutiveSends.get(sendKey) ?? 0
+      if (currentCount >= MAX_CHANNEL_SENDS_PER_TURN) {
+        return { ok: false, error: TURN_CAP_ERROR, code: 'turn-cap' }
+      }
+      if (text !== undefined && live.lastSentText.get(sendKey) === text) {
+        return { ok: false, error: DUPLICATE_SEND_ERROR, code: 'duplicate' }
+      }
+      // Reserve the slot before awaiting. If the callback rejects we roll
+      // back below; if it succeeds we keep the increment. The slot reserve
+      // is what makes parallel tool calls safe. We also snapshot the prior
+      // lastSentText so a transient delivery failure can be retried with
+      // the same text — the dup-guard exists to stop runaway loops, not to
+      // strand the model on a flaky adapter.
+      priorLastSentText = live.lastSentText.get(sendKey)
+      live.consecutiveSends.set(sendKey, currentCount + 1)
+      if (text !== undefined) live.lastSentText.set(sendKey, text)
+      reserved = true
     }
 
     // Snapshot the callbacks before iterating so a callback that mutates the
@@ -1443,16 +1552,20 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
 
     if (!delivered) {
-      return { ok: false, error: lastError ?? 'no callback accepted the outbound' }
+      // Roll back the slot reservation so a failed send doesn't burn cap
+      // budget or poison the dup-guard. Restoring lastSentText to its
+      // prior value (which may be undefined) lets a legitimate retry of
+      // the same text succeed — the dup-guard is for loops, not flake.
+      if (live && reserved) {
+        const after = (live.consecutiveSends.get(sendKey) ?? 1) - 1
+        if (after <= 0) live.consecutiveSends.delete(sendKey)
+        else live.consecutiveSends.set(sendKey, after)
+        if (priorLastSentText === undefined) live.lastSentText.delete(sendKey)
+        else live.lastSentText.set(sendKey, priorLastSentText)
+      }
+      return { ok: false, error: lastError ?? 'no callback accepted the outbound', code: 'callback-rejected' }
     }
 
-    const keyId = channelKeyId({
-      adapter: msg.adapter,
-      workspace: msg.workspace,
-      chat: msg.chat,
-      thread: msg.thread ?? null,
-    })
-    const live = liveSessions.get(keyId)
     if (live) {
       live.successfulChannelSends++
       // Don't stop the heartbeat here: the agent may still be mid-turn and
@@ -1477,8 +1590,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           grantStickyForReplyTargets(stickyLedger, keyId, targetIds, adapterConfig.engagement, now())
         }
       }
-      const sendKey = consecutiveSendKey(msg.chat, msg.thread)
-      live.consecutiveSends.set(sendKey, (live.consecutiveSends.get(sendKey) ?? 0) + 1)
+      const turnCount = live.consecutiveSends.get(sendKey) ?? 0
+      const rateCount = recordSendTimestamp(live, sendKey, now())
+      const level = rateCount >= SEND_RATE_WARN_THRESHOLD ? 'warn' : 'info'
+      const warn = rateCount >= SEND_RATE_WARN_THRESHOLD ? ' send_rate_warning' : ''
+      const textLen = text !== undefined ? text.length : 0
+      const fields = `source=${source} turn=${turnCount} rate=${rateCount}/${SEND_RATE_WINDOW_MS}ms text_len=${textLen}`
+      logger[level](`[channels] ${live.keyId} send ${fields}${warn}`)
     }
 
     return { ok: true }
@@ -1498,13 +1616,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     logger.warn(
       `[channels] ${live.keyId}: recovering assistant_text_without_channel_tool text_len=${assistantText.length}`,
     )
-    const result = await send({
-      adapter: live.key.adapter,
-      workspace: live.key.workspace,
-      chat: live.key.chat,
-      thread: live.key.thread,
-      text: assistantText,
-    })
+    const result = await send(
+      {
+        adapter: live.key.adapter,
+        workspace: live.key.workspace,
+        chat: live.key.chat,
+        thread: live.key.thread,
+        text: assistantText,
+      },
+      { source: 'system' },
+    )
     if (!result.ok) {
       logger.warn(`[channels] ${live.keyId}: recovery send failed: ${result.error}`)
     }
@@ -1525,6 +1646,30 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const live = liveSessions.get(keyId)
     if (!live) return 0
     return live.consecutiveSends.get(consecutiveSendKey(target.chat, target.thread)) ?? 0
+  }
+
+  const getSendRate = (target: {
+    adapter: ChannelKey['adapter']
+    workspace: string
+    chat: string
+    thread?: string | null
+  }): { count: number; windowMs: number } => {
+    const keyId = channelKeyId({
+      adapter: target.adapter,
+      workspace: target.workspace,
+      chat: target.chat,
+      thread: target.thread ?? null,
+    })
+    const live = liveSessions.get(keyId)
+    if (!live) return { count: 0, windowMs: SEND_RATE_WINDOW_MS }
+    const sendKey = consecutiveSendKey(target.chat, target.thread)
+    const buf = live.sendTimestamps.get(sendKey)
+    if (!buf || buf.length === 0) return { count: 0, windowMs: SEND_RATE_WINDOW_MS }
+    const cutoff = now() - SEND_RATE_WINDOW_MS
+    let i = 0
+    while (i < buf.length && buf[i]! <= cutoff) i++
+    if (i > 0) buf.splice(0, i)
+    return { count: buf.length, windowMs: SEND_RATE_WINDOW_MS }
   }
 
   const tearDownLive = async (live: LiveSession): Promise<void> => {
@@ -1585,6 +1730,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     route,
     send,
     getConsecutiveSendCount,
+    getSendRate,
     registerOutbound,
     unregisterOutbound,
     registerTyping,
@@ -1757,6 +1903,26 @@ function tryOpenSessionManager(
 
 function consecutiveSendKey(chat: string, thread: string | null | undefined): string {
   return `${chat}:${thread ?? ''}`
+}
+
+function normalizeSendText(text: string | undefined): string | undefined {
+  if (text === undefined) return undefined
+  if (text === '') return undefined
+  return text
+}
+
+function recordSendTimestamp(live: LiveSession, sendKey: string, ts: number): number {
+  const buf = live.sendTimestamps.get(sendKey)
+  const cutoff = ts - SEND_RATE_WINDOW_MS
+  if (!buf) {
+    live.sendTimestamps.set(sendKey, [ts])
+    return 1
+  }
+  let i = 0
+  while (i < buf.length && buf[i]! <= cutoff) i++
+  if (i > 0) buf.splice(0, i)
+  buf.push(ts)
+  return buf.length
 }
 
 function dmMembership(fetchedAt: number): MembershipCount {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -84,7 +84,9 @@ export type OutboundMessage = {
   attachments?: OutboundAttachment[]
 }
 
-export type SendResult = { ok: true } | { ok: false; error: string }
+export type SendErrorCode = 'duplicate' | 'turn-cap' | 'no-adapter' | 'callback-rejected'
+
+export type SendResult = { ok: true } | { ok: false; error: string; code?: SendErrorCode }
 
 export type OutboundCallback = (msg: OutboundMessage) => Promise<SendResult>
 


### PR DESCRIPTION
Closes #13

## Why

Production incident: the agent emitted ~50 outbound messages in a single `session.prompt()` turn in a Discord channel. Every outbound came back through the gateway as a self-author inbound and was correctly dropped before re-prompting — the loop was not self-triggered. It was the LLM calling `channel_send` / `channel_reply` repeatedly within one turn while the existing `consecutiveSendHint` (a text-in-tool-result nudge) was ignored under load.

This PR satisfies the acceptance criteria from issue #13 (per-turn cap in the shared router, `SendResult.code: 'turn-cap'`, default cap of 10, per-channel/thread scoping, and cross-turn reset), while shipping rate telemetry as observability rather than a hard rate-limit enforcement pending production data.

This PR is a force-push rewrite of an initial attempt that a self-review found to have three structural holes. All three are now closed. The original was caught and fixed inside the same PR — what ships is a complete production fix, not a partial mitigation.

### The three holes the original had

1. **Parallel tool execution defeated the tool-layer guard.** `pi-agent-core` defaults to `toolExecution: 'parallel'`. `executeToolCallsParallel` calls each tool's `execute()` synchronously inside a `.map()`, so two concurrent `channel_send` calls with identical bodies would both read `lastSentText` before either `router.send` awaited. Both saw the slot empty, both passed, both sent. Silent bypass.

2. **Wrong layer.** State lived in `router.ts`; enforcement lived in the two tool files. Any future caller of `router.send` (cron-from-channel, `validateChannelTurn` recovery, plugin-contributed sends) silently inherited the gap.

3. **Exact-match only catches one sub-mode.** The incident's first ~8 messages had varying lengths — a legitimate split reply. Distinct-but-meaningless variants ("sorry / sorry! / sorry!!") and 50 distinct paraphrased chunks bypass exact-dup matching entirely. Exact-match alone was insufficient for the observed loop.

---

## Changes

The fix is centralized in `router.send()` with two distinct policies and a structured result type.

### 1. Hard per-turn send cap

`MAX_CHANNEL_SENDS_PER_TURN = 10` enforced inside `router.send()` for `source='tool'`. Kills every loop mode regardless of content — duplicates, distinct chunks, paraphrases. The incident's legitimate split-reply portion was ~8 messages; 10 leaves headroom while definitively stopping 50+ runaways. Counter shares lifecycle with `consecutiveSends` and clears on each new prompt batch.

### 2. Duplicate-send guard, centrally enforced with slot reservation

`router.send()` checks `lastSentText` for tool-source sends. On a non-duplicate, non-cap path it **reserves the slot synchronously** — increments `consecutiveSends` and writes `lastSentText` — **before** awaiting the outbound callback. This closes the parallel-tool-call TOCTOU: two concurrent `router.send` calls for the same target cannot both reserve the slot. The first synchronously reserves; the second synchronously sees the reservation and returns `code: 'duplicate'` before its callback ever fires.

Failed deliveries roll back the reservation — including restoring the prior `lastSentText` snapshot — so a transient adapter failure can be retried with the same text. The dup-guard exists for loops, not flake.

### 3. Structured `SendResult` error codes

`SendResult` gains an optional discriminator: `code: 'duplicate' | 'turn-cap' | 'no-adapter' | 'callback-rejected'`. The tool layer surfaces `result.error` verbatim as `channel_send denied: ...` / `channel_reply denied: ...`. The tool-layer `wasJustSent` checks are removed entirely — the tools no longer need to know about the guard.

### 4. Explicit `SendOptions.source`

`source: 'tool' | 'system'` distinguishes the enforcement boundary. `validateChannelTurn`'s recovery send and the role-claim reply pass `source: 'system'` to bypass both the dup-guard and the cap. The bypass is explicit at every call site rather than implicit by using a lower-level API.

### 5. Error wording rewritten

`DUPLICATE_SEND_ERROR` no longer says "send something different" — the prior phrasing invited the model to mutate one character and retry, defeating exact matching. New text: `Duplicate not sent. Do not call channel_send/channel_reply again this turn. End with NO_REPLY unless you have genuinely new, non-redundant information.` `TURN_CAP_ERROR` likewise points the model at `NO_REPLY`.

### 6. Per-send structured telemetry

Every successful `router.send` emits a single structured log line:

```
[channels] <keyId> send source=tool turn=K rate=N/5000ms text_len=L
```

A `send_rate_warning` suffix flags bursts when the rate crosses `SEND_RATE_WARN_THRESHOLD = 3`. This replaces the previous threshold-gated `send_rate` log so incident triage has full visibility from the first send, not from the burst marker. The gated log missed the first 2–3 messages of the incident's slow-burn pattern.

### 7. Empty-text normalization

`router.send()` normalizes `text: ''` to `undefined` for dup-tracking purposes so attachments-only sends never poison the tracker.

---

## Concurrency note

The slot-reservation pattern is load-bearing. The check (`lastSentText.get === text`) and the mutation (`lastSentText.set(text)`) happen inside the same synchronous block before any `await`. JavaScript's single-threaded execution does not interrupt synchronous blocks, so two concurrent `router.send` calls cannot both pass the check. The first synchronously reserves; the second synchronously sees the reservation and returns `code: 'duplicate'` before its callback fires. This is what makes the parallel-tool-execution path safe — the original PR's check-then-await-then-mutate pattern was the bug.

---

## Files changed

| File | Change |
|------|--------|
| `src/channels/router.ts` | Heavy edits to `send()`; new constants (`MAX_CHANNEL_SENDS_PER_TURN`, `SEND_RATE_WARN_THRESHOLD` renamed from `_LOG_`); new types (`SendSource`, `SendOptions`); new exported error constants (`DUPLICATE_SEND_ERROR`, `TURN_CAP_ERROR`); `wasJustSent` method removed; `validateChannelTurn` and role-claim reply updated to pass `source: 'system'`. |
| `src/channels/types.ts` | `SendResult` discriminator + `SendErrorCode` type. |
| `src/channels/router.test.ts` | Replaced `wasJustSent` describe with central-guard tests + per-turn cap suite + cross-tool sharing test + parallel-execution tests. |
| `src/agent/tools/channel-reply.ts` | Removed tool-layer `wasJustSent` check and `DUPLICATE_SEND_ERROR` export. |
| `src/agent/tools/channel-send.ts` | Removed tool-layer `wasJustSent` check. |
| `src/agent/tools/channel-{send,reply}.test.ts` | Rewrote duplicate-send-guard describe → structured-router-failures-surface-as-denials. |
| `src/agent/tools/channel-tool-logging.test.ts`, `src/channels/adapters/github/line-comment-thread.test.ts` | Drop `wasJustSent` from `fakeRouter` stubs. |

---

## Test coverage

**Duplicate-send guard (router level):**

| Scenario | Covered |
|---|---|
| First send delivers; second identical is blocked with `code='duplicate'` | ✓ |
| Different body after a recent dup passes | ✓ |
| Failed delivery rolls back reservation — retry with same text succeeds | ✓ |
| Across-turn reset (new user batch clears state) | ✓ |
| Per `(chat:thread)` scope — same text to a different thread allowed | ✓ |
| Attachments-only sends don't poison the tracker | ✓ |
| Empty-string text normalized — does not block a follow-up empty-text send | ✓ |
| 10 concurrent `router.send` for same text → exactly 1 delivery + 9 duplicate denials | ✓ |
| System-source send bypasses the dup guard | ✓ |

**Per-turn send cap:**

| Scenario | Covered |
|---|---|
| Blocks the (MAX+1)th tool send with `code='turn-cap'` | ✓ |
| Cap resets on the next user batch | ✓ |
| System-source bypasses the cap | ✓ |
| MAX+5 concurrent distinct-text sends → exactly MAX deliveries + 5 turn-cap denials | ✓ |

**Telemetry:**

| Scenario | Covered |
|---|---|
| Per-send structured log line for every successful send (source, turn, rate, text_len) | ✓ |
| Burst gets `send_rate_warning` suffix when rate crosses threshold | ✓ |
| System-source sends logged with `source=system` | ✓ |

**Cross-tool:**

| Scenario | Covered |
|---|---|
| First send via one tool blocks a follow-up via the other tool with the same text | ✓ |

**Tool-layer translation:**

| Scenario | Covered |
|---|---|
| `duplicate`/`turn-cap` codes from router render as `channel_reply` / `channel_send` denied with the router's error text | ✓ |

Pre-commit gates:

```
bun run typecheck   ✓  clean
bun run lint        ✓  0 errors (17 pre-existing warnings in unrelated files)
bun run format      ✓  clean
bun test            ✓  4127 pass / 0 fail
```

---

## Out of scope

- **Fuzzy-similarity duplicate match.** Exact-match plus the per-turn cap covers the observed incident comprehensively. Fuzzy adds threshold-tuning forever and has false-positive risk on common short replies. Wait for production data showing the combo is insufficient before adding fuzzy.
- **Model-facing rate hint inside `consecutiveSendHint`.** Telemetry-only is sufficient until production data shows the rate signal would change model behavior.