### PR TITLE
memory: compute per-topic strength signals and inject them into the dreaming prompt

### DIFF
--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -341,6 +341,46 @@ describe('dreaming subagent (orchestration)', () => {
     expect(prompts[0]).not.toMatch(/total file lines/)
   })
 
+  test('omits the strength-signals block entirely when MEMORY.md is missing or has no topics', async () => {
+    await writeFile(join(agentDir, 'memory', '2026-04-27.jsonl'), fragmentLine('only'))
+
+    const { prompts } = await invokeDreaming(agentDir)
+
+    expect(prompts[0]).not.toContain('topic strengths')
+    expect(prompts[0]).not.toContain('| topic | cites |')
+  })
+
+  test('injects a per-topic strength table when MEMORY.md already has topics with citations', async () => {
+    await writeFile(
+      join(agentDir, 'MEMORY.md'),
+      [
+        '# Memory',
+        '',
+        '## Strong topic',
+        'Conclusion.',
+        '',
+        'fragments:',
+        '- memory/2026-04-25#f-cite1',
+        '- memory/2026-04-26#f-cite2',
+        '- memory/2026-04-27#f-cite3',
+        '',
+        '## Weak topic',
+        'Conclusion.',
+        '',
+        'fragments:',
+        '- memory/2026-04-20#f-old',
+      ].join('\n'),
+    )
+    await writeFile(join(agentDir, 'memory', '2026-04-27.jsonl'), fragmentLine('new'))
+
+    const { prompts } = await invokeDreaming(agentDir)
+
+    expect(prompts[0]).toContain('| topic | cites | days | last reinforced | age (d) |')
+    expect(prompts[0]).toMatch(/\| Strong topic \| 3 \| 3 \| 2026-04-27 \|/)
+    expect(prompts[0]).toMatch(/\| Weak topic \| 1 \| 1 \| 2026-04-20 \|/)
+    expect(prompts[0]).toContain('Existing MEMORY.md topic strengths')
+  })
+
   test('adds every undreamed fragment id to the dreamed-id set after a successful run', async () => {
     await writeFile(
       join(agentDir, 'memory', '2026-04-27.jsonl'),

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -19,6 +19,7 @@ import {
 } from './dreaming-state'
 import type { StreamEvent } from './stream-events'
 import { readEvents, writeEventsAtomic } from './stream-io'
+import { computeTopicStrengths, renderTopicStrengthsTable, type TopicStrength } from './strength'
 
 const STREAM_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2})\.jsonl$/
 
@@ -632,7 +633,7 @@ Do not suggest CLIs or plugins speculatively. The same recurrence + generalizabi
 
 If the undreamed tails contain only watermarks, or every new fragment is already represented in MEMORY.md and no procedure clears the muscle-memory bar, do not rewrite MEMORY.md and do not write a skill just to touch something. Stop without writing. The point of dreaming is consolidation, not activity. The runtime advances the watermark either way.`
 
-function buildInitialPrompt(payload: DreamingPayload, snapshots: StreamSnapshot[]): string {
+function buildInitialPrompt(payload: DreamingPayload, snapshots: StreamSnapshot[], strengths: TopicStrength[]): string {
   const today = formatLocalDate()
   const memoryFile = join(payload.agentDir, 'MEMORY.md')
   const memoryDir = join(payload.agentDir, 'memory')
@@ -642,9 +643,22 @@ function buildInitialPrompt(payload: DreamingPayload, snapshots: StreamSnapshot[
     `Daily stream directory: ${memoryDir}`,
     `Today's local date: ${today}`,
     `Dreaming state: ${join(payload.agentDir, DREAMING_STATE_FILE)}`,
+  ]
+
+  const strengthTable = renderTopicStrengthsTable(strengths)
+  if (strengthTable.length > 0) {
+    lines.push(
+      '',
+      'Existing MEMORY.md topic strengths (computed from current citations — `cites` is total citation count, `days` is the number of distinct calendar days those citations span, `last reinforced` is the most recent citation date, `age (d)` is whole days since `last reinforced` relative to today). These numbers describe how reinforced each existing topic is; the dreaming system prompt explains how to use them.',
+      '',
+      strengthTable,
+    )
+  }
+
+  lines.push(
     '',
     'Undreamed fragments to consolidate. Each entry lists the daily JSONL file and the ids of fragments in that file you have not yet consolidated into MEMORY.md. Read the file, locate each id, and decide what (if anything) belongs in MEMORY.md. Cite by id (memory/yyyy-MM-dd#<id>), not by line number.',
-  ]
+  )
   for (const snap of snapshots) {
     lines.push('', `- memory/${snap.filename}:`)
     for (const id of snap.undreamedIds) lines.push(`    - ${id}`)
@@ -654,6 +668,15 @@ function buildInitialPrompt(payload: DreamingPayload, snapshots: StreamSnapshot[
     'Dream now. Read MEMORY.md and the listed fragments. Consolidate them into long-term memory and write the full new MEMORY.md if anything changed. If nothing meets the bar, stop without writing — the runtime advances the dreamed-id set either way so you will not see these fragments again on the next run.',
   )
   return lines.join('\n')
+}
+
+async function loadTopicStrengths(agentDir: string): Promise<TopicStrength[]> {
+  try {
+    const raw = await readFile(join(agentDir, 'MEMORY.md'), 'utf8')
+    return computeTopicStrengths(raw, formatLocalDate())
+  } catch {
+    return []
+  }
 }
 
 export type CreateDreamingSubagentOptions = {
@@ -690,9 +713,10 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
 
       const memoryFilePath = join(ctx.payload.agentDir, 'MEMORY.md')
       const memoryHashBefore = await safeContentHash(memoryFilePath)
+      const strengths = await loadTopicStrengths(ctx.payload.agentDir)
 
       try {
-        await runSession({ userPrompt: buildInitialPrompt(ctx.payload, snapshots.undreamed) })
+        await runSession({ userPrompt: buildInitialPrompt(ctx.payload, snapshots.undreamed, strengths) })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         logger.warn(`[dreaming] run threw: ${message} elapsed_ms=${Date.now() - start}`)

--- a/src/bundled-plugins/memory/strength.test.ts
+++ b/src/bundled-plugins/memory/strength.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'bun:test'
+
+import { computeTopicStrengths, renderTopicStrengthsTable } from './strength'
+
+const ID_A = '019e2eca-6fc5-71ef-add9-67a0955a4b35'
+const ID_B = '019e2ecf-f2d5-70ee-83f6-005fb5451c51'
+const ID_C = '019e2ee8-bcc4-772f-8821-876162c5e601'
+const ID_D = '019e2ef0-aaaa-77ef-bbbb-cccccccccccc'
+
+describe('computeTopicStrengths', () => {
+  test('returns an empty list for an empty MEMORY.md', () => {
+    expect(computeTopicStrengths('', '2026-05-20')).toEqual([])
+    expect(computeTopicStrengths('# Memory\n', '2026-05-20')).toEqual([])
+  })
+
+  test('counts citations and distinct days per topic', () => {
+    const text = [
+      '## Burst',
+      `- memory/2026-05-15#${ID_A}`,
+      `- memory/2026-05-15#${ID_B}`,
+      `- memory/2026-05-15#${ID_C}`,
+      '',
+      '## Spread',
+      `- memory/2026-05-13#${ID_A}`,
+      `- memory/2026-05-15#${ID_B}`,
+      `- memory/2026-05-18#${ID_C}`,
+    ].join('\n')
+
+    const result = computeTopicStrengths(text, '2026-05-20')
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({ heading: 'Burst', citationCount: 3, distinctDays: 1 })
+    expect(result[1]).toMatchObject({ heading: 'Spread', citationCount: 3, distinctDays: 3 })
+  })
+
+  test('reports lastReinforcedDate as the most recent citation date', () => {
+    const text = [
+      '## Topic',
+      `- memory/2026-05-13#${ID_A}`,
+      `- memory/2026-05-18#${ID_B}`,
+      `- memory/2026-05-15#${ID_C}`,
+    ].join('\n')
+
+    const [topic] = computeTopicStrengths(text, '2026-05-20')
+
+    expect(topic?.lastReinforcedDate).toBe('2026-05-18')
+    expect(topic?.daysSinceLastReinforced).toBe(2)
+  })
+
+  test('daysSinceLastReinforced is 0 on the same day', () => {
+    const text = ['## Today', `- memory/2026-05-20#${ID_A}`].join('\n')
+
+    const [topic] = computeTopicStrengths(text, '2026-05-20')
+
+    expect(topic?.daysSinceLastReinforced).toBe(0)
+  })
+
+  test('reports null lastReinforcedDate for a topic with zero citations', () => {
+    const [topic] = computeTopicStrengths('## Empty\nno citations here', '2026-05-20')
+
+    expect(topic).toMatchObject({
+      heading: 'Empty',
+      citationCount: 0,
+      distinctDays: 0,
+      lastReinforcedDate: null,
+      daysSinceLastReinforced: null,
+    })
+  })
+
+  test('clamps a future-dated citation to 0 days (clock-skew defense, not punishment)', () => {
+    const text = ['## Time traveler', `- memory/2026-05-25#${ID_A}`].join('\n')
+
+    const [topic] = computeTopicStrengths(text, '2026-05-20')
+
+    expect(topic?.daysSinceLastReinforced).toBe(0)
+  })
+
+  test('handles month and year boundaries correctly (UTC arithmetic, no DST drift)', () => {
+    const text = ['## Old', `- memory/2025-12-31#${ID_A}`].join('\n')
+
+    const [topic] = computeTopicStrengths(text, '2026-01-02')
+
+    expect(topic?.daysSinceLastReinforced).toBe(2)
+  })
+
+  test('preserves topic order (the dreaming subagent sees topics in MEMORY.md write order)', () => {
+    const text = ['## First', `- memory/2026-05-15#${ID_A}`, '', '## Second', `- memory/2026-05-15#${ID_B}`].join('\n')
+
+    const result = computeTopicStrengths(text, '2026-05-20')
+
+    expect(result.map((t) => t.heading)).toEqual(['First', 'Second'])
+  })
+
+  test('dedupes distinctDays per citation date, not per fragment id', () => {
+    const text = [
+      '## Topic',
+      `- memory/2026-05-15#${ID_A}`,
+      `- memory/2026-05-15#${ID_B}`,
+      `- memory/2026-05-15#${ID_C}`,
+      `- memory/2026-05-16#${ID_D}`,
+    ].join('\n')
+
+    const [topic] = computeTopicStrengths(text, '2026-05-20')
+
+    expect(topic?.citationCount).toBe(4)
+    expect(topic?.distinctDays).toBe(2)
+  })
+})
+
+describe('renderTopicStrengthsTable', () => {
+  test('returns an empty string when no topics exist', () => {
+    expect(renderTopicStrengthsTable([])).toBe('')
+  })
+
+  test('renders a 5-column markdown table with one row per topic', () => {
+    const out = renderTopicStrengthsTable([
+      {
+        heading: 'Strong',
+        citationCount: 8,
+        distinctDays: 6,
+        lastReinforcedDate: '2026-05-18',
+        daysSinceLastReinforced: 2,
+      },
+      {
+        heading: 'Weak',
+        citationCount: 1,
+        distinctDays: 1,
+        lastReinforcedDate: '2026-02-01',
+        daysSinceLastReinforced: 108,
+      },
+    ])
+
+    expect(out).toContain('| topic | cites | days | last reinforced | age (d) |')
+    expect(out).toContain('| Strong | 8 | 6 | 2026-05-18 | 2 |')
+    expect(out).toContain('| Weak | 1 | 1 | 2026-02-01 | 108 |')
+  })
+
+  test("renders em-dash for a never-reinforced topic's last/age columns", () => {
+    const out = renderTopicStrengthsTable([
+      {
+        heading: 'No cites',
+        citationCount: 0,
+        distinctDays: 0,
+        lastReinforcedDate: null,
+        daysSinceLastReinforced: null,
+      },
+    ])
+
+    expect(out).toContain('| No cites | 0 | 0 | — | — |')
+  })
+
+  test('escapes pipe characters in headings so they do not break the table', () => {
+    const out = renderTopicStrengthsTable([
+      {
+        heading: 'foo | bar',
+        citationCount: 1,
+        distinctDays: 1,
+        lastReinforcedDate: '2026-05-20',
+        daysSinceLastReinforced: 0,
+      },
+    ])
+
+    expect(out).toContain('| foo \\| bar | 1 | 1 | 2026-05-20 | 0 |')
+  })
+
+  test('truncates very long headings with an ellipsis (keeps numbers honest)', () => {
+    const longHeading = 'a'.repeat(200)
+    const out = renderTopicStrengthsTable([
+      {
+        heading: longHeading,
+        citationCount: 99,
+        distinctDays: 9,
+        lastReinforcedDate: '2026-05-20',
+        daysSinceLastReinforced: 0,
+      },
+    ])
+
+    expect(out).toContain('…')
+    expect(out).toContain('| 99 | 9 | 2026-05-20 | 0 |')
+  })
+
+  test('replaces an empty heading with (untitled) so the row still reads cleanly', () => {
+    const out = renderTopicStrengthsTable([
+      { heading: '', citationCount: 1, distinctDays: 1, lastReinforcedDate: '2026-05-20', daysSinceLastReinforced: 0 },
+    ])
+
+    expect(out).toContain('| (untitled) | 1 | 1 | 2026-05-20 | 0 |')
+  })
+})

--- a/src/bundled-plugins/memory/strength.ts
+++ b/src/bundled-plugins/memory/strength.ts
@@ -1,0 +1,127 @@
+// Strength signals for MEMORY.md topics, derived mechanically from citations.
+//
+// What "strength" means here is structural, not semantic — we measure how
+// many times and over how many distinct days a topic has been reinforced by
+// observation fragments. The reasoning lives in dreaming.ts's system prompt;
+// this file only produces the numbers the prompt will reference.
+//
+// Why distinct days matters more than raw citation count: five fragments on
+// one day == one debugging session that mentioned the same thing five times
+// (a transient burst). Five fragments across five days == a recurring fact
+// the user keeps coming back to (a stable signal). The promotion ladder in
+// the dreaming subagent's prompt is gated on distinct-days, not count, for
+// exactly this reason — see the "spacing effect" note in the PR description.
+//
+// All numbers here are deterministic. The same MEMORY.md parsed against the
+// same `today` always yields the same TopicStrength list. There is no LLM
+// involvement at this layer; the subagent receives these numbers as ground
+// truth and uses them to decide what to merge or demote.
+
+import { parseTopics, type Topic } from './topics'
+
+export type TopicStrength = {
+  heading: string
+  citationCount: number
+  distinctDays: number
+  // ISO date (yyyy-MM-dd) of the most recent citation, or null when the
+  // topic has zero citations. Null is distinct from "very old": a topic with
+  // no citations at all is a different shape than one whose last citation
+  // was a year ago, and the subagent should treat them differently (the
+  // former is a typo or a manual edit; the latter is a decayed-but-real
+  // topic).
+  lastReinforcedDate: string | null
+  // Whole-day delta from today to lastReinforcedDate. Null when
+  // lastReinforcedDate is null. Negative values are clamped to 0 (a citation
+  // dated in the future is treated as "today" — the only way this happens
+  // is a clock skew between memory-logger and the dreaming run, and the
+  // subagent shouldn't be punished for the runtime's confusion).
+  daysSinceLastReinforced: number | null
+}
+
+export function computeTopicStrengths(memoryText: string, today: string): TopicStrength[] {
+  const topics = parseTopics(memoryText)
+  return topics.map((topic) => computeOneTopicStrength(topic, today))
+}
+
+function computeOneTopicStrength(topic: Topic, today: string): TopicStrength {
+  const citationCount = topic.citations.length
+  const distinctDates = new Set(topic.citations.map((c) => c.date))
+  const distinctDays = distinctDates.size
+  const lastReinforcedDate = pickLatestDate([...distinctDates])
+  const daysSinceLastReinforced = lastReinforcedDate ? daysBetween(today, lastReinforcedDate) : null
+  return {
+    heading: topic.heading,
+    citationCount,
+    distinctDays,
+    lastReinforcedDate,
+    daysSinceLastReinforced,
+  }
+}
+
+function pickLatestDate(dates: readonly string[]): string | null {
+  if (dates.length === 0) return null
+  let latest = dates[0]!
+  for (let i = 1; i < dates.length; i++) {
+    const candidate = dates[i]!
+    if (candidate.localeCompare(latest) > 0) latest = candidate
+  }
+  return latest
+}
+
+// Whole-day delta in UTC between two yyyy-MM-dd strings. Date.UTC parses each
+// date as midnight UTC, so the difference is always an integer count of
+// 86_400_000ms windows regardless of timezone or DST. Returns 0 for invalid
+// inputs (treats the topic as "fresh" rather than throwing — defensive
+// because both inputs are produced by the runtime, but a corrupted MEMORY.md
+// citation date is the kind of thing we want to fail open on).
+function daysBetween(today: string, earlier: string): number {
+  const todayMs = parseIsoDateUtc(today)
+  const earlierMs = parseIsoDateUtc(earlier)
+  if (todayMs === null || earlierMs === null) return 0
+  const deltaDays = Math.floor((todayMs - earlierMs) / 86_400_000)
+  return deltaDays < 0 ? 0 : deltaDays
+}
+
+function parseIsoDateUtc(date: string): number | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date)
+  if (!match) return null
+  const year = Number.parseInt(match[1]!, 10)
+  const month = Number.parseInt(match[2]!, 10)
+  const day = Number.parseInt(match[3]!, 10)
+  const ms = Date.UTC(year, month - 1, day)
+  return Number.isFinite(ms) ? ms : null
+}
+
+// Render the strength signals as a markdown table the dreaming subagent can
+// read at the top of its user prompt. Returns an empty string when the
+// topic list is empty so the caller can prepend it unconditionally.
+//
+// Column choices: heading first because it's the human-recognizable handle;
+// `cites` and `days` are short enough to align nicely; `last` carries the
+// date itself so the subagent can compare to today without re-doing the
+// arithmetic. Headings are truncated to keep the table readable when a
+// topic was given a long sentence-shaped heading — the citation count is
+// still accurate, only the display label is shortened.
+export function renderTopicStrengthsTable(strengths: readonly TopicStrength[]): string {
+  if (strengths.length === 0) return ''
+  const rows = strengths.map((s) => ({
+    heading: truncateHeading(s.heading || '(untitled)'),
+    cites: String(s.citationCount),
+    days: String(s.distinctDays),
+    last: s.lastReinforcedDate ?? '—',
+    ageDays: s.daysSinceLastReinforced === null ? '—' : String(s.daysSinceLastReinforced),
+  }))
+  const lines = ['| topic | cites | days | last reinforced | age (d) |', '| --- | ---: | ---: | --- | ---: |']
+  for (const row of rows) {
+    lines.push(`| ${row.heading} | ${row.cites} | ${row.days} | ${row.last} | ${row.ageDays} |`)
+  }
+  return lines.join('\n')
+}
+
+const HEADING_MAX_CHARS = 60
+
+function truncateHeading(heading: string): string {
+  const escaped = heading.replace(/\|/g, '\\|')
+  if (escaped.length <= HEADING_MAX_CHARS) return escaped
+  return `${escaped.slice(0, HEADING_MAX_CHARS - 1)}…`
+}

--- a/src/bundled-plugins/memory/topics.test.ts
+++ b/src/bundled-plugins/memory/topics.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test'
+
+import { parseTopics } from './topics'
+
+const ID_A = '019e2eca-6fc5-71ef-add9-67a0955a4b35'
+const ID_B = '019e2ecf-f2d5-70ee-83f6-005fb5451c51'
+const ID_C = '019e2ee8-bcc4-772f-8821-876162c5e601'
+
+describe('parseTopics', () => {
+  test('returns an empty list when MEMORY.md has no level-2 headings', () => {
+    expect(parseTopics('# Memory\n')).toEqual([])
+    expect(parseTopics('')).toEqual([])
+    expect(parseTopics('just some prose without headings')).toEqual([])
+  })
+
+  test('splits on `## ` headings and attributes the heading text to each topic', () => {
+    const text = ['# Memory', '', '## First', 'body of first', '', '## Second', 'body of second'].join('\n')
+
+    const topics = parseTopics(text)
+
+    expect(topics.map((t) => t.heading)).toEqual(['First', 'Second'])
+  })
+
+  test("attaches each topic's citations from its body, not the global file", () => {
+    const text = [
+      '# Memory',
+      '',
+      '## Topic A',
+      'Conclusion for A.',
+      '',
+      'fragments:',
+      `- memory/2026-05-16#${ID_A}`,
+      `- memory/2026-05-15#${ID_B}`,
+      '',
+      '## Topic B',
+      'Conclusion for B.',
+      '',
+      'fragments:',
+      `- memory/2026-05-16#${ID_C}`,
+    ].join('\n')
+
+    const topics = parseTopics(text)
+
+    expect(topics).toHaveLength(2)
+    expect(topics[0]?.heading).toBe('Topic A')
+    expect(topics[0]?.citations).toEqual([
+      { date: '2026-05-16', fragmentId: ID_A },
+      { date: '2026-05-15', fragmentId: ID_B },
+    ])
+    expect(topics[1]?.heading).toBe('Topic B')
+    expect(topics[1]?.citations).toEqual([{ date: '2026-05-16', fragmentId: ID_C }])
+  })
+
+  test('preserves heading order even when topics share a date', () => {
+    const text = ['## Older', `- memory/2026-05-15#${ID_A}`, '', '## Newer', `- memory/2026-05-15#${ID_B}`].join('\n')
+
+    const topics = parseTopics(text)
+    expect(topics.map((t) => t.heading)).toEqual(['Older', 'Newer'])
+  })
+
+  test('emits an empty citations array for a topic that has none', () => {
+    const text = ['## Empty topic', '', 'No fragments cited yet.'].join('\n')
+
+    const topics = parseTopics(text)
+
+    expect(topics).toEqual([{ heading: 'Empty topic', citations: [] }])
+  })
+
+  test('drops citations that appear in the preamble above the first h2 (they belong to no topic)', () => {
+    const text = [
+      '# Memory',
+      `see memory/2026-05-16#${ID_A} for context`,
+      '',
+      '## Real topic',
+      `- memory/2026-05-15#${ID_B}`,
+    ].join('\n')
+
+    const topics = parseTopics(text)
+
+    expect(topics).toHaveLength(1)
+    expect(topics[0]?.heading).toBe('Real topic')
+    expect(topics[0]?.citations).toEqual([{ date: '2026-05-15', fragmentId: ID_B }])
+  })
+
+  test('trims surrounding whitespace from the heading text', () => {
+    const text = '##    Spaced out    \n\nbody'
+    expect(parseTopics(text)).toEqual([{ heading: 'Spaced out', citations: [] }])
+  })
+
+  test('keeps an empty-string heading rather than dropping the topic (subagent can see and clean it)', () => {
+    const text = ['## ', `- memory/2026-05-16#${ID_A}`].join('\n')
+
+    const topics = parseTopics(text)
+
+    expect(topics).toHaveLength(1)
+    expect(topics[0]?.heading).toBe('')
+    expect(topics[0]?.citations).toEqual([{ date: '2026-05-16', fragmentId: ID_A }])
+  })
+
+  test('counts inline-prose citations toward the topic, not only fragments: bullets', () => {
+    const text = ['## Inline citer', `mentioned in memory/2026-05-16#${ID_A} earlier`].join('\n')
+
+    const topics = parseTopics(text)
+
+    expect(topics[0]?.citations).toEqual([{ date: '2026-05-16', fragmentId: ID_A }])
+  })
+
+  test('ignores h3+ headings (they belong to the surrounding h2 topic)', () => {
+    const text = ['## Parent', '### Subheading', `- memory/2026-05-16#${ID_A}`].join('\n')
+
+    const topics = parseTopics(text)
+
+    expect(topics).toHaveLength(1)
+    expect(topics[0]?.heading).toBe('Parent')
+    expect(topics[0]?.citations).toEqual([{ date: '2026-05-16', fragmentId: ID_A }])
+  })
+})

--- a/src/bundled-plugins/memory/topics.ts
+++ b/src/bundled-plugins/memory/topics.ts
@@ -1,0 +1,73 @@
+// Topic-aware parser for MEMORY.md. The dreaming subagent writes MEMORY.md as
+// a flat list of level-2 topic headings (`## <topic>`), each followed by a
+// conclusion paragraph and a `fragments:` bullet list of citations. The
+// citation parser in citations.ts is global (every citation in the file);
+// this module attributes citations to their owning topic so the dreaming
+// subagent can see per-topic strength signals (citation count, distinct
+// reinforcement days, recency) on its next run.
+//
+// Format assumptions match what dreaming.ts's DREAMING_SYSTEM_PROMPT teaches:
+//   - First line is `# Memory` (an h1). Treated as a non-topic header.
+//   - Topics are h2s (`## <topic>`). Anything below an h2 and above the next
+//     h2 (or EOF) belongs to that topic.
+//   - Citations in a topic's body — wherever they appear, bullet-list or
+//     inline prose — count toward that topic's strength.
+//   - Content above the first h2 (e.g. preamble after `# Memory`) is
+//     attributed to no topic and its citations are dropped from the per-topic
+//     aggregation. parseCitations from citations.ts still picks them up if
+//     anything downstream needs the global view.
+//
+// The parser is intentionally permissive: it never throws on malformed
+// MEMORY.md. A subagent that writes a header with no body or a topic with no
+// citations still parses cleanly with an empty `citations` array. The
+// strength layer then treats those topics as "weak" — which is the right
+// behavior, since they ARE weak.
+
+import { type Citation, parseCitations } from './citations'
+
+export type Topic = {
+  // The heading text after `## ` with surrounding whitespace trimmed. Empty
+  // string is allowed (`## ` with no title) so a malformed write still
+  // round-trips through the parser; the strength layer surfaces empty
+  // headings as themselves so the subagent can clean them up.
+  heading: string
+  // Citations in order of appearance. Duplicates within one topic ARE
+  // preserved here (callers that want unique ids should dedupe) because the
+  // subagent may legitimately cite the same fragment in both the inline
+  // prose and the fragments: block.
+  citations: Citation[]
+}
+
+const HEADING_LEVEL_2 = /^##\s+(.*)$/
+
+// Split MEMORY.md into ordered topics with their citations attached. Returns
+// an empty array when no `## ` heading appears.
+export function parseTopics(text: string): Topic[] {
+  const lines = text.split('\n')
+  const topics: Topic[] = []
+  let current: { heading: string; body: string[] } | undefined
+
+  const flush = (): void => {
+    if (!current) return
+    const bodyText = current.body.join('\n')
+    const grouped = parseCitations(bodyText)
+    const citations: Citation[] = []
+    for (const [date, ids] of grouped) {
+      for (const fragmentId of ids) citations.push({ date, fragmentId })
+    }
+    topics.push({ heading: current.heading, citations })
+  }
+
+  for (const line of lines) {
+    const match = HEADING_LEVEL_2.exec(line)
+    if (match) {
+      flush()
+      current = { heading: (match[1] ?? '').trim(), body: [] }
+      continue
+    }
+    if (current) current.body.push(line)
+  }
+  flush()
+
+  return topics
+}


### PR DESCRIPTION
## Why

Long-term memory (`MEMORY.md`) grows monotonically today. The dreaming subagent's system prompt says "do not silently drop existing entries" (rule 5), so every consolidated topic survives forever and topics accumulate citations across days. MEMORY.md is injected into every session's system prompt, so unbounded growth is unbounded prompt cost on every turn of every session.

The current shape has no LTP/LTD analogue — no reinforcement signal that says "this topic keeps coming back, treat it as core" and no decay signal that says "this topic was a one-off three months ago, demote it." We want a real biological-memory model: repetition strengthens, lack of repetition saturates.

This PR is the first of two coordinated changes. It ships the **mechanical strength signals** the second PR will use to drive behavior. Splitting the work lets us see real strength distributions on existing MEMORY.md files before committing to a policy that depends on them.

## What this PR does (and doesn't)

**Does**: derives per-topic numbers from MEMORY.md's existing citations, renders them as a table at the top of the dreaming subagent's user prompt.

**Doesn't**: change the dreaming subagent's system prompt, change what the subagent writes, change MEMORY.md, change the daily-stream GC, or persist any state. Strength is recomputed on every dreaming run from MEMORY.md alone — no sidecar file, no schema version, no migration.

The subagent will see the strength table but its instructions still say "consolidate, do not drop existing entries." PR 2 will rewrite the rules to teach the subagent how to *use* the numbers (promotion ladder, historical-observations bucket, citation-superset safety net).

## Implementation

Two new modules under `src/bundled-plugins/memory/`:

### `topics.ts` — citation-attributing parser

Splits MEMORY.md on `## ` headings, attaches every citation in a topic's body (bullet-list or inline prose) to that topic. Permissive: never throws, empty headings are preserved (the subagent can clean them up), citations above the first `## ` belong to no topic and are dropped from the per-topic view. The existing `parseCitations` is unchanged — it still returns the global citations-per-date map that `compactDailyStreams` depends on.

### `strength.ts` — signal derivation

Per topic:

| Field | Meaning |
|---|---|
| `citationCount` | total citations (preserves duplicates within a topic) |
| `distinctDays` | size of the Set of citation dates |
| `lastReinforcedDate` | max citation date (yyyy-MM-dd), or `null` if zero citations |
| `daysSinceLastReinforced` | whole UTC days from today to lastReinforcedDate, or `null` |

Design decisions:

- **`distinctDays` over `citationCount` is the load-bearing signal**. Five fragments on one day == one debugging session that mentioned the same thing five times (a transient burst). Five fragments across five days == a recurring fact (a stable signal). PR 2's promotion ladder is gated on distinct-days for this reason.
- **UTC arithmetic in `daysBetween`** so DST and timezone differences don't skew age counts. The runtime fixes "today" once at the start of the dreaming run (`formatLocalDate()` from the existing shared helper), so the result is stable for the duration of the run.
- **`null` lastReinforcedDate is distinct from "very old"**. A topic with zero citations is a typo or manual edit; a topic whose last citation was a year ago is decayed-but-real. The strength table renders `—` for both columns so the subagent can see the difference.
- **Future-dated citations clamp to 0 days** (clock-skew defense). The only way this happens is memory-logger and the dreaming run disagreeing about the wall clock; the subagent shouldn't be punished for the runtime's confusion.

### `dreaming.ts` — prompt injection

`buildInitialPrompt` now takes a `TopicStrength[]` argument and prepends a markdown table when non-empty. The handler reads MEMORY.md once, runs `computeTopicStrengths(text, today)`, passes the result through. When MEMORY.md is missing or has no topics, the block is omitted entirely (zero-cost when not applicable).

The injected block looks like this (illustrative):

```
Existing MEMORY.md topic strengths (computed from current citations …)

| topic | cites | days | last reinforced | age (d) |
| --- | ---: | ---: | --- | ---: |
| pre-commit checks must pass before push | 12 | 9 | 2026-05-18 | 2 |
| Korean greeting preferences | 4 | 4 | 2026-05-12 | 8 |
| stale notion-toml debugging session from April | 5 | 1 | 2026-04-03 | 47 |
```

The dreaming system prompt does not yet reference this table; the subagent will see it but use its existing "consolidate, don't drop" rules. That's PR 2.

## Test coverage

New: `topics.test.ts` (10 tests), `strength.test.ts` (13 tests). Extended: `dreaming.test.ts` (2 new tests — omitted when no topics, present when topics exist with expected row contents).

| Scenario | Covered |
|---|---|
| Empty MEMORY.md / missing file / `# Memory` only | ✓ |
| Citations grouped per topic, not globally | ✓ |
| Preamble citations (above first h2) attributed to no topic | ✓ |
| Inline-prose citations count toward the topic | ✓ |
| h3+ headings belong to surrounding h2 | ✓ |
| Empty-string heading preserved (subagent can clean up) | ✓ |
| distinctDays correctly dedupes per-date | ✓ |
| Burst (5 cites / 1 day) vs spread (3 cites / 3 days) | ✓ |
| daysSinceLastReinforced across month/year boundaries | ✓ |
| Future-dated citation clamps to 0 days | ✓ |
| `null` lastReinforcedDate for zero-citation topic | ✓ |
| Pipe escape in headings | ✓ |
| Long heading truncated with ellipsis | ✓ |
| Empty heading rendered as `(untitled)` | ✓ |
| Strength block omitted when MEMORY.md has no topics | ✓ |
| Strength block present + accurate when topics exist | ✓ |

Pre-commit gates:

```
bun run typecheck   ✓  clean
bun run lint        ✓  0 errors (17 pre-existing warnings in unrelated files)
bun run format      ✓  clean
bun test            ✓  4128 pass / 0 fail
```

## Out of scope (deferred to PR 2)

- Rewriting `DREAMING_SYSTEM_PROMPT`'s rule 5 from "preserve existing entries" to "rebalance — strengthen the strong, demote the weak, preserve every cited id."
- Promotion ladder (`1 day = mentioned`, `3+ distinct days = consistently`, `7+ distinct days = always`).
- Historical-observations bucket convention for decayed topics.
- Citation-superset commit check (refuse commit + revert MEMORY.md + advance dreamed-ids if the subagent's rewrite drops a previously-cited id).
- Historical-bucket overflow synthesis policy.

PR 2 will land on top of this branch.
