### PR TITLE
usage: scale summary sparkline by tokens instead of cost

### DIFF
--- a/src/usage/index.test.ts
+++ b/src/usage/index.test.ts
@@ -655,7 +655,7 @@ describe('formatReport origin view', () => {
     ])
     const report = await runUsage({ agentDir })
     const out = formatReport(report, { view: 'summary' })
-    expect(out).toMatch(/Trend \(cost\):/)
+    expect(out).toMatch(/Trend \(tokens\):/)
     expect(out).toMatch(/[▁▂▃▄▅▆▇█]/)
   })
 
@@ -666,7 +666,7 @@ describe('formatReport origin view', () => {
     ])
     const report = await runUsage({ agentDir })
     const out = formatReport(report, { view: 'summary' })
-    expect(out).not.toMatch(/Trend \(cost\):/)
+    expect(out).not.toMatch(/Trend \(tokens\):/)
   })
 
   test('session view prepends an origin glyph to each row label', async () => {

--- a/src/usage/report.ts
+++ b/src/usage/report.ts
@@ -145,27 +145,30 @@ function renderOriginLabel(kind: OriginKind, ctx: RenderCtx): string {
   }
 }
 
-// Sparkline trend across the full byDay range, scaled to the row's max cost.
-// Returns null when there are fewer than 2 days (a single point conveys no
-// trend information). The 8-level Unicode block scale `▁▂▃▄▅▆▇█` lets us
-// pack ~80 days into a one-line glance — wider than any table-based view
-// could fit at terminal widths under ~160 columns.
+// Sparkline trend across the full byDay range, scaled to the row's max token
+// count. Tokens (not cost) drive the chart because they're the load-bearing
+// usage signal — model price changes and free-tier credits shouldn't flatten
+// or distort the visible workload pattern. Returns null when there are fewer
+// than 2 days (a single point conveys no trend information). The 8-level
+// Unicode block scale `▁▂▃▄▅▆▇█` lets us pack ~80 days into a one-line glance
+// — wider than any table-based view could fit at terminal widths under ~160
+// columns.
 const SPARK_GLYPHS = '▁▂▃▄▅▆▇█'
 
-function renderDailyTrend(byDay: readonly { date: string; cost: number }[], ctx: RenderCtx): string | null {
+function renderDailyTrend(byDay: readonly { date: string; totalTokens: number }[], ctx: RenderCtx): string | null {
   if (byDay.length < 2) return null
-  const costs = byDay.map((d) => d.cost)
-  const max = costs.reduce((m, c) => Math.max(m, c), 0)
+  const tokens = byDay.map((d) => d.totalTokens)
+  const max = tokens.reduce((m, t) => Math.max(m, t), 0)
   if (max <= 0) return null
-  const spark = costs
-    .map((c) => {
-      const idx = Math.min(SPARK_GLYPHS.length - 1, Math.max(0, Math.round((c / max) * (SPARK_GLYPHS.length - 1))))
+  const spark = tokens
+    .map((t) => {
+      const idx = Math.min(SPARK_GLYPHS.length - 1, Math.max(0, Math.round((t / max) * (SPARK_GLYPHS.length - 1))))
       return SPARK_GLYPHS[idx]!
     })
     .join('')
   const first = byDay[0]!.date
   const last = byDay[byDay.length - 1]!.date
-  return `${dim('Trend (cost):', ctx)} ${color('cyan', spark, ctx)}  ${dim(`${first} → ${last}`, ctx)}`
+  return `${dim('Trend (tokens):', ctx)} ${color('cyan', spark, ctx)}  ${dim(`${first} → ${last}`, ctx)}`
 }
 
 function renderDaily(report: UsageReport, ctx: RenderCtx, limit: number | undefined): string {


### PR DESCRIPTION
## What

The one-line daily trend chart in the `typeclaw usage` summary view (the sparkline below the aggregate totals) now scales its bars to **total tokens per day** instead of cost per day. The label changes from "Trend (cost):" to "Trend (tokens):".

The change is confined to the summary sparkline renderer. Every table in the full usage views (daily, session, models, origin) still shows dollar figures in a Cost column unchanged.

## Why

Tokens are the load-bearing usage signal: they measure actual model workload, stay proportional across a day's activity, and are stable over time.

Cost is misleading as a trend indicator for two reasons:

- **Model price changes flatten the chart.** When a provider cuts prices (or a session shifts to a cheaper model mid-week), the cost line drops even if the agent did just as much work. The chart appears to show reduced activity when it actually shows a price change.
- **Free-tier credits mask real usage.** Credits absorb cost to zero for stretches of heavy use, making those days look idle in the trend while tokens would show the true load.

Switching to tokens makes the trend chart reflect genuine workload — the pattern you actually care about when deciding whether the agent is being used effectively.

## Scope

Two files changed:

- `src/usage/report.ts` — the daily sparkline renderer now reads daily token totals instead of cost. Label text and comment updated.
- `src/usage/index.test.ts` — two assertions updated to match the new "Trend (tokens):" label.

No other files are touched. Cost display in every table view is unaffected.

## Verification

```
bun run typecheck   ✓  clean
bun run lint        ✓  0 errors (17 pre-existing warnings in unrelated channel adapters)
bun run format      ✓  clean
bun test src/usage/ ✓  50 pass / 0 fail
```