### PR TITLE
webfetch: route through curl-impersonate by default

### DIFF
--- a/src/agent/tools/curl-impersonate.test.ts
+++ b/src/agent/tools/curl-impersonate.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  CurlImpersonateError,
+  _resetAvailabilityCacheForTest,
+  _setCurlBinaryForTest,
+  curlImpersonate,
+  isCurlImpersonateAvailable,
+} from './curl-impersonate'
+
+const SENTINEL = '\n--TYPECLAW-CURL-META-9c3f5e4d2a1b4f8e9c7a6b5d4e3f2a1b0--\n'
+
+describe('curlImpersonate', () => {
+  let scratchDir: string
+
+  beforeEach(() => {
+    scratchDir = mkdtempSync(join(tmpdir(), 'curl-impersonate-test-'))
+    _resetAvailabilityCacheForTest()
+  })
+
+  afterEach(() => {
+    _setCurlBinaryForTest(null)
+    _resetAvailabilityCacheForTest()
+    rmSync(scratchDir, { recursive: true, force: true })
+  })
+
+  function installFakeBinary(script: string): void {
+    const path = join(scratchDir, 'fake-curl')
+    writeFileSync(path, `#!/bin/sh\n${script}\n`, 'utf8')
+    chmodSync(path, 0o755)
+    _setCurlBinaryForTest(path)
+  }
+
+  test('parses body, status, finalUrl, contentType from sentinel-separated stdout', async () => {
+    // given: fake binary that writes a body, then the sentinel, then metadata
+    installFakeBinary(
+      `printf '<html>hi</html>'; printf '${SENTINEL}200\nhttps://example.com/final\ntext/html; charset=utf-8\n14\n'`,
+    )
+
+    // when
+    const result = await curlImpersonate({ url: 'https://example.com' })
+
+    // then
+    expect(result.body).toBe('<html>hi</html>')
+    expect(result.httpStatus).toBe(200)
+    expect(result.finalUrl).toBe('https://example.com/final')
+    expect(result.contentType).toBe('text/html; charset=utf-8')
+    expect(result.bytesIn).toBe(14)
+  })
+
+  test('returns body verbatim with status=0 when sentinel is absent', async () => {
+    // given: legacy-style fake that emits only the body (e.g. very early abort)
+    installFakeBinary("printf 'raw body without metadata'")
+
+    // when
+    const result = await curlImpersonate({ url: 'https://example.com' })
+
+    // then
+    expect(result.body).toBe('raw body without metadata')
+    expect(result.httpStatus).toBe(0)
+    expect(result.finalUrl).toBe('')
+  })
+
+  test('preserves a 404 body and reports httpStatus=404 (does NOT throw)', async () => {
+    // given: server-emulating fake returns a 404-shaped response
+    installFakeBinary(`printf 'not found'; printf '${SENTINEL}404\nhttps://example.com/missing\ntext/plain\n9\n'`)
+
+    // when
+    const result = await curlImpersonate({ url: 'https://example.com/missing' })
+
+    // then: caller-decides-on-status policy
+    expect(result.httpStatus).toBe(404)
+    expect(result.body).toBe('not found')
+  })
+
+  test('throws CurlImpersonateError with stderr detail on non-zero exit', async () => {
+    // given
+    installFakeBinary('echo "tls handshake failed" >&2; exit 35')
+
+    // when / then
+    await expect(curlImpersonate({ url: 'https://example.com' })).rejects.toThrow(CurlImpersonateError)
+    await expect(curlImpersonate({ url: 'https://example.com' })).rejects.toThrow(/exited 35/)
+    await expect(curlImpersonate({ url: 'https://example.com' })).rejects.toThrow(/tls handshake failed/)
+  })
+
+  test('reports "no stderr" when the binary fails silently', async () => {
+    installFakeBinary('exit 7')
+
+    await expect(curlImpersonate({ url: 'https://example.com' })).rejects.toThrow(/exited 7.*no stderr/)
+  })
+
+  test('passes method, url, and form fields through argv', async () => {
+    // given: fake captures argv to a side file
+    const argvFile = join(scratchDir, 'argv.txt')
+    installFakeBinary(`printf '%s\\n' "$@" > ${argvFile}; printf ''`)
+
+    // when
+    await curlImpersonate({
+      url: 'https://example.com/search',
+      method: 'POST',
+      formFields: [
+        { name: 'q', value: 'hello world' },
+        { name: 'lang', value: 'en' },
+      ],
+    })
+
+    // then
+    const argv = (await Bun.file(argvFile).text()).split('\n')
+    expect(argv).toContain('-X')
+    expect(argv).toContain('POST')
+    expect(argv).toContain('--data-urlencode')
+    expect(argv).toContain('q=hello world')
+    expect(argv).toContain('lang=en')
+    expect(argv).toContain('https://example.com/search')
+  })
+
+  test('passes extra headers as -H arguments', async () => {
+    const argvFile = join(scratchDir, 'argv.txt')
+    installFakeBinary(`printf '%s\\n' "$@" > ${argvFile}; printf ''`)
+
+    await curlImpersonate({
+      url: 'https://example.com',
+      extraHeaders: { Authorization: 'Bearer abc', 'X-Trace': 'xyz' },
+    })
+
+    const argv = (await Bun.file(argvFile).text()).split('\n')
+    expect(argv).toContain('-H')
+    expect(argv).toContain('Authorization: Bearer abc')
+    expect(argv).toContain('X-Trace: xyz')
+  })
+
+  test('follows redirects by default (passes --location)', async () => {
+    const argvFile = join(scratchDir, 'argv.txt')
+    installFakeBinary(`printf '%s\\n' "$@" > ${argvFile}; printf ''`)
+
+    await curlImpersonate({ url: 'https://example.com' })
+
+    const argv = (await Bun.file(argvFile).text()).split('\n')
+    expect(argv).toContain('--location')
+    expect(argv).toContain('--max-redirs')
+  })
+
+  test('passes maxBytes as --max-filesize when provided', async () => {
+    const argvFile = join(scratchDir, 'argv.txt')
+    installFakeBinary(`printf '%s\\n' "$@" > ${argvFile}; printf ''`)
+
+    await curlImpersonate({ url: 'https://example.com', maxBytes: 5_000_000 })
+
+    const argv = (await Bun.file(argvFile).text()).split('\n')
+    const idx = argv.indexOf('--max-filesize')
+    expect(idx).toBeGreaterThanOrEqual(0)
+    expect(argv[idx + 1]).toBe('5000000')
+  })
+
+  test('aborts when the AbortSignal fires', async () => {
+    // given: fake binary sleeps long enough that we always abort first
+    installFakeBinary('sleep 30')
+    const controller = new AbortController()
+
+    // when
+    const promise = curlImpersonate({ url: 'https://example.com', signal: controller.signal })
+    setTimeout(() => controller.abort(), 50)
+
+    // then
+    await expect(promise).rejects.toThrow()
+  })
+})
+
+describe('isCurlImpersonateAvailable', () => {
+  beforeEach(() => {
+    _resetAvailabilityCacheForTest()
+  })
+
+  afterEach(() => {
+    _setCurlBinaryForTest(null)
+    _resetAvailabilityCacheForTest()
+  })
+
+  test('returns true when the binary exits 0 on --version', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'curl-available-test-'))
+    try {
+      const path = join(dir, 'fake-curl')
+      writeFileSync(path, '#!/bin/sh\necho "curl 8.x impersonate"\nexit 0\n', 'utf8')
+      chmodSync(path, 0o755)
+      _setCurlBinaryForTest(path)
+
+      const available = await isCurlImpersonateAvailable()
+
+      expect(available).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns false when the binary is missing', async () => {
+    _setCurlBinaryForTest('/nonexistent/path/to/curl_chrome136')
+
+    const available = await isCurlImpersonateAvailable()
+
+    expect(available).toBe(false)
+  })
+
+  test('caches the result for the life of the process', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'curl-cache-test-'))
+    try {
+      const path = join(dir, 'fake-curl')
+      writeFileSync(path, '#!/bin/sh\nexit 0\n', 'utf8')
+      chmodSync(path, 0o755)
+      _setCurlBinaryForTest(path)
+
+      const first = await isCurlImpersonateAvailable()
+      // Swap to a bad binary — cached result should still be true
+      _setCurlBinaryForTest('/nonexistent')
+      const second = await isCurlImpersonateAvailable()
+
+      expect(first).toBe(true)
+      expect(second).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/agent/tools/curl-impersonate.test.ts
+++ b/src/agent/tools/curl-impersonate.test.ts
@@ -8,16 +8,40 @@ import {
   _resetAvailabilityCacheForTest,
   _setCurlBinaryForTest,
   curlImpersonate,
+  isCurlExitFilesizeExceeded,
+  isCurlExitTimeout,
   isCurlImpersonateAvailable,
 } from './curl-impersonate'
 
-const SENTINEL = '\n--TYPECLAW-CURL-META-9c3f5e4d2a1b4f8e9c7a6b5d4e3f2a1b0--\n'
+// We can't predict the per-request random sentinel from the test, so the
+// fake binary reads it out of argv (the value following '-w') and renders
+// a fake metadata block back. See fetch.test.ts for the rationale on the
+// argv positional-access pattern.
+const FAKE_BINARY_BODY = (body: string, status = 200, finalUrl = 'https://example.com', contentType = 'text/html') => `
+ARGV_FILE="$SCRATCH_ARGV"
+printf '%s\\n' "$@" > "$ARGV_FILE"
+WTPL=""
+i=1
+for arg in "$@"; do
+  if [ "$arg" = "-w" ]; then
+    j=$((i + 1))
+    eval "WTPL=\\"\\\${$j}\\""
+    break
+  fi
+  i=$((i + 1))
+done
+RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/${status}/' -e 's|%{url_effective}|${finalUrl}|' -e 's|%{content_type}|${contentType}|' -e 's/%{size_download}/${body.length}/')
+printf '%s' '${body}'
+printf '%s' "$RENDERED"
+`
 
 describe('curlImpersonate', () => {
   let scratchDir: string
+  let argvFile: string
 
   beforeEach(() => {
     scratchDir = mkdtempSync(join(tmpdir(), 'curl-impersonate-test-'))
+    argvFile = join(scratchDir, 'argv.txt')
     _resetAvailabilityCacheForTest()
   })
 
@@ -29,61 +53,77 @@ describe('curlImpersonate', () => {
 
   function installFakeBinary(script: string): void {
     const path = join(scratchDir, 'fake-curl')
-    writeFileSync(path, `#!/bin/sh\n${script}\n`, 'utf8')
+    // --version short-circuit so that scripts which simulate an error-exit
+    // body don't also fail the isCurlImpersonateAvailable() probe.
+    writeFileSync(
+      path,
+      `#!/bin/sh\nSCRATCH_ARGV="${argvFile}"\nif [ "$1" = "--version" ]; then exit 0; fi\n${script}\n`,
+      'utf8',
+    )
     chmodSync(path, 0o755)
     _setCurlBinaryForTest(path)
   }
 
-  test('parses body, status, finalUrl, contentType from sentinel-separated stdout', async () => {
-    // given: fake binary that writes a body, then the sentinel, then metadata
-    installFakeBinary(
-      `printf '<html>hi</html>'; printf '${SENTINEL}200\nhttps://example.com/final\ntext/html; charset=utf-8\n14\n'`,
-    )
+  async function argv(): Promise<string[]> {
+    return (await Bun.file(argvFile).text()).split('\n')
+  }
 
-    // when
+  test('returns body, status, finalUrl, contentType when curl emits the requested sentinel', async () => {
+    installFakeBinary(FAKE_BINARY_BODY('<html>hi</html>', 200, 'https://example.com/final', 'text/html; charset=utf-8'))
+
     const result = await curlImpersonate({ url: 'https://example.com' })
 
-    // then
     expect(result.body).toBe('<html>hi</html>')
     expect(result.httpStatus).toBe(200)
     expect(result.finalUrl).toBe('https://example.com/final')
     expect(result.contentType).toBe('text/html; charset=utf-8')
-    expect(result.bytesIn).toBe(14)
-  })
-
-  test('returns body verbatim with status=0 when sentinel is absent', async () => {
-    // given: legacy-style fake that emits only the body (e.g. very early abort)
-    installFakeBinary("printf 'raw body without metadata'")
-
-    // when
-    const result = await curlImpersonate({ url: 'https://example.com' })
-
-    // then
-    expect(result.body).toBe('raw body without metadata')
-    expect(result.httpStatus).toBe(0)
-    expect(result.finalUrl).toBe('')
+    expect(result.bytesIn).toBe(15)
   })
 
   test('preserves a 404 body and reports httpStatus=404 (does NOT throw)', async () => {
-    // given: server-emulating fake returns a 404-shaped response
-    installFakeBinary(`printf 'not found'; printf '${SENTINEL}404\nhttps://example.com/missing\ntext/plain\n9\n'`)
+    installFakeBinary(FAKE_BINARY_BODY('not found', 404, 'https://example.com/missing', 'text/plain'))
 
-    // when
     const result = await curlImpersonate({ url: 'https://example.com/missing' })
 
-    // then: caller-decides-on-status policy
     expect(result.httpStatus).toBe(404)
     expect(result.body).toBe('not found')
   })
 
-  test('throws CurlImpersonateError with stderr detail on non-zero exit', async () => {
-    // given
+  test('throws when the sentinel is missing (no -w output at all)', async () => {
+    // given: fake that emits only a body, no sentinel, no metadata
+    installFakeBinary("printf 'raw body without metadata'")
+
+    await expect(curlImpersonate({ url: 'https://example.com' })).rejects.toThrow(/sentinel missing/)
+  })
+
+  test('is not spoofable: body containing a literal old-style sentinel does not corrupt parsing', async () => {
+    // given: body contains the legacy hard-coded sentinel string (which a
+    // malicious page could include verbatim). The real sentinel is now
+    // per-request random, and we anchor on the LAST occurrence, so the
+    // injected one is treated as part of the body.
+    const evilBody = 'attacker\n--TYPECLAW-CURL-META-FAKEFAKEFAKE--\n999\nhttps://evil/\ntext/x\n8\nlegitimate'
+    installFakeBinary(FAKE_BINARY_BODY(evilBody, 200, 'https://example.com/real', 'text/html'))
+
+    const result = await curlImpersonate({ url: 'https://example.com' })
+
+    expect(result.httpStatus).toBe(200)
+    expect(result.finalUrl).toBe('https://example.com/real')
+    expect(result.body).toBe(evilBody)
+  })
+
+  test('throws CurlImpersonateError with exitCode and stderr on non-zero exit', async () => {
     installFakeBinary('echo "tls handshake failed" >&2; exit 35')
 
-    // when / then
-    await expect(curlImpersonate({ url: 'https://example.com' })).rejects.toThrow(CurlImpersonateError)
-    await expect(curlImpersonate({ url: 'https://example.com' })).rejects.toThrow(/exited 35/)
-    await expect(curlImpersonate({ url: 'https://example.com' })).rejects.toThrow(/tls handshake failed/)
+    try {
+      await curlImpersonate({ url: 'https://example.com' })
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(CurlImpersonateError)
+      const err = error as CurlImpersonateError
+      expect(err.exitCode).toBe(35)
+      expect(err.stderr).toContain('tls handshake failed')
+      expect(err.message).toMatch(/exited 35/)
+    }
   })
 
   test('reports "no stderr" when the binary fails silently', async () => {
@@ -93,11 +133,8 @@ describe('curlImpersonate', () => {
   })
 
   test('passes method, url, and form fields through argv', async () => {
-    // given: fake captures argv to a side file
-    const argvFile = join(scratchDir, 'argv.txt')
-    installFakeBinary(`printf '%s\\n' "$@" > ${argvFile}; printf ''`)
+    installFakeBinary(FAKE_BINARY_BODY('ok'))
 
-    // when
     await curlImpersonate({
       url: 'https://example.com/search',
       method: 'POST',
@@ -107,65 +144,114 @@ describe('curlImpersonate', () => {
       ],
     })
 
-    // then
-    const argv = (await Bun.file(argvFile).text()).split('\n')
-    expect(argv).toContain('-X')
-    expect(argv).toContain('POST')
-    expect(argv).toContain('--data-urlencode')
-    expect(argv).toContain('q=hello world')
-    expect(argv).toContain('lang=en')
-    expect(argv).toContain('https://example.com/search')
+    const a = await argv()
+    expect(a).toContain('-X')
+    expect(a).toContain('POST')
+    expect(a).toContain('--data-urlencode')
+    expect(a).toContain('q=hello world')
+    expect(a).toContain('lang=en')
+    expect(a).toContain('https://example.com/search')
   })
 
-  test('passes extra headers as -H arguments', async () => {
-    const argvFile = join(scratchDir, 'argv.txt')
-    installFakeBinary(`printf '%s\\n' "$@" > ${argvFile}; printf ''`)
-
-    await curlImpersonate({
-      url: 'https://example.com',
-      extraHeaders: { Authorization: 'Bearer abc', 'X-Trace': 'xyz' },
-    })
-
-    const argv = (await Bun.file(argvFile).text()).split('\n')
-    expect(argv).toContain('-H')
-    expect(argv).toContain('Authorization: Bearer abc')
-    expect(argv).toContain('X-Trace: xyz')
-  })
-
-  test('follows redirects by default (passes --location)', async () => {
-    const argvFile = join(scratchDir, 'argv.txt')
-    installFakeBinary(`printf '%s\\n' "$@" > ${argvFile}; printf ''`)
+  test('passes --disable as the first argument (suppresses .curlrc)', async () => {
+    installFakeBinary(FAKE_BINARY_BODY('ok'))
 
     await curlImpersonate({ url: 'https://example.com' })
 
-    const argv = (await Bun.file(argvFile).text()).split('\n')
-    expect(argv).toContain('--location')
-    expect(argv).toContain('--max-redirs')
+    const a = await argv()
+    // argv[0] inside the wrapper is the first option curl sees (argv[0] of
+    // the spawned process is the binary itself, not visible to the shell's $@).
+    expect(a[0]).toBe('--disable')
+  })
+
+  test('passes --proto =http,https and --proto-redir =http,https (blocks redirect-to-ftp)', async () => {
+    installFakeBinary(FAKE_BINARY_BODY('ok'))
+
+    await curlImpersonate({ url: 'https://example.com' })
+
+    const a = await argv()
+    const protoIdx = a.indexOf('--proto')
+    const redirIdx = a.indexOf('--proto-redir')
+    expect(protoIdx).toBeGreaterThanOrEqual(0)
+    expect(a[protoIdx + 1]).toBe('=http,https')
+    expect(redirIdx).toBeGreaterThanOrEqual(0)
+    expect(a[redirIdx + 1]).toBe('=http,https')
+  })
+
+  test('passes -- before the URL so a URL beginning with - is not parsed as a flag', async () => {
+    installFakeBinary(FAKE_BINARY_BODY('ok'))
+
+    await curlImpersonate({ url: 'https://example.com' })
+
+    const a = await argv()
+    const dashIdx = a.indexOf('--')
+    expect(dashIdx).toBeGreaterThanOrEqual(0)
+    expect(a[dashIdx + 1]).toBe('https://example.com')
+  })
+
+  test('follows redirects by default (passes --location)', async () => {
+    installFakeBinary(FAKE_BINARY_BODY('ok'))
+
+    await curlImpersonate({ url: 'https://example.com' })
+
+    const a = await argv()
+    expect(a).toContain('--location')
+    expect(a).toContain('--max-redirs')
   })
 
   test('passes maxBytes as --max-filesize when provided', async () => {
-    const argvFile = join(scratchDir, 'argv.txt')
-    installFakeBinary(`printf '%s\\n' "$@" > ${argvFile}; printf ''`)
+    installFakeBinary(FAKE_BINARY_BODY('ok'))
 
     await curlImpersonate({ url: 'https://example.com', maxBytes: 5_000_000 })
 
-    const argv = (await Bun.file(argvFile).text()).split('\n')
-    const idx = argv.indexOf('--max-filesize')
+    const a = await argv()
+    const idx = a.indexOf('--max-filesize')
     expect(idx).toBeGreaterThanOrEqual(0)
-    expect(argv[idx + 1]).toBe('5000000')
+    expect(a[idx + 1]).toBe('5000000')
   })
 
   test('aborts when the AbortSignal fires', async () => {
-    // given: fake binary sleeps long enough that we always abort first
     installFakeBinary('sleep 30')
     const controller = new AbortController()
 
-    // when
     const promise = curlImpersonate({ url: 'https://example.com', signal: controller.signal })
     setTimeout(() => controller.abort(), 50)
 
-    // then
     await expect(promise).rejects.toThrow()
+  })
+})
+
+describe('isCurlExitTimeout / isCurlExitFilesizeExceeded', () => {
+  test('exit 28 = timeout', () => {
+    const err = new CurlImpersonateError('curl-impersonate exited 28: Operation timed out', 28, 'Operation timed out')
+    expect(isCurlExitTimeout(err)).toBe(true)
+    expect(isCurlExitFilesizeExceeded(err)).toBe(false)
+  })
+
+  test('exit 63 = filesize exceeded (content-length precheck)', () => {
+    const err = new CurlImpersonateError('curl-impersonate exited 63', 63, 'Maximum file size exceeded')
+    expect(isCurlExitFilesizeExceeded(err)).toBe(true)
+    expect(isCurlExitTimeout(err)).toBe(false)
+  })
+
+  test('exit 56 + "maximum allowed file size" stderr = filesize exceeded (transfer-time)', () => {
+    const err = new CurlImpersonateError(
+      'curl-impersonate exited 56',
+      56,
+      'Exceeded the maximum allowed file size (1) with 1 bytes',
+    )
+    expect(isCurlExitFilesizeExceeded(err)).toBe(true)
+  })
+
+  test('exit 56 WITHOUT filesize stderr = generic recv failure, not filesize', () => {
+    const err = new CurlImpersonateError('curl-impersonate exited 56', 56, 'Recv failure: Connection reset by peer')
+    expect(isCurlExitFilesizeExceeded(err)).toBe(false)
+  })
+
+  test('other exit codes = neither', () => {
+    const err = new CurlImpersonateError('curl-impersonate exited 35', 35, 'TLS handshake failed')
+    expect(isCurlExitTimeout(err)).toBe(false)
+    expect(isCurlExitFilesizeExceeded(err)).toBe(false)
   })
 })
 
@@ -212,7 +298,6 @@ describe('isCurlImpersonateAvailable', () => {
       _setCurlBinaryForTest(path)
 
       const first = await isCurlImpersonateAvailable()
-      // Swap to a bad binary — cached result should still be true
       _setCurlBinaryForTest('/nonexistent')
       const second = await isCurlImpersonateAvailable()
 

--- a/src/agent/tools/curl-impersonate.ts
+++ b/src/agent/tools/curl-impersonate.ts
@@ -1,0 +1,264 @@
+// Shared curl-impersonate spawn primitive.
+//
+// Why this exists: by 2026, every non-trivial public site (DDG, Reuters via
+// Akamai, MarketWatch via Cloudflare, etc.) fingerprints incoming traffic at
+// the TLS handshake (JA3/JA4) and HTTP/2 SETTINGS frame BEFORE any HTTP header
+// is read. Bun's native fetch cannot match Chrome's handshake (upstream issue
+// #11368), so outbound requests get gated by anomaly checks regardless of
+// headers, body shape, or pacing. The fix is to shell out to curl-impersonate
+// (lexiforest fork), which replays Chrome's exact TLS handshake, HTTP/2
+// settings, and header ordering. Pinned by the typeclaw Dockerfile at
+// /usr/local/bin/curl_chrome136 — see src/init/dockerfile.ts for the version
+// and SHA pin.
+//
+// The original site of this code was ddg.ts; this file is the extraction so
+// webfetch can share it. AGENTS.md explicitly warns against adding `-H`
+// overrides because the curl_chrome wrapper already sends the full Chrome
+// header set (correct ordering, sec-ch-ua, sec-fetch-*, accept-encoding,
+// etc.) and any custom header corrupts the impersonation. The optional
+// headers passed here are layered ON TOP of curl_chrome's defaults via `-H`,
+// so use it ONLY for things curl can't infer (e.g. an explicit Authorization
+// token, a custom API key). Don't override User-Agent, Accept, sec-* headers,
+// or anything in curl_chrome's standard set.
+//
+// AGENTS.md §"Web search" describes why the spawn path is load-bearing for
+// the DDG-specific case; the same reasoning applies to webfetch.
+
+import { spawn } from 'bun'
+
+export const CURL_IMPERSONATE_BINARY = 'curl_chrome136'
+export const DEFAULT_TIMEOUT_SECONDS = 30
+
+let curlBinary: string = CURL_IMPERSONATE_BINARY
+
+// Test-only seam: lets *.test.ts point the spawn at a fake `curl_chrome136`
+// script in a tmpdir so we exercise the real Bun.spawn path without depending
+// on a curl-impersonate install on the test host. Production code never calls
+// this — the module-level default above is what production sees.
+export function _setCurlBinaryForTest(binary: string | null): void {
+  curlBinary = binary ?? CURL_IMPERSONATE_BINARY
+}
+
+export type CurlImpersonateRequest = {
+  url: string
+  method?: 'GET' | 'POST' | 'HEAD'
+  // Form-urlencoded body fields for POST. Each entry is passed as a separate
+  // --data-urlencode argument so curl handles the encoding. Required if
+  // method is 'POST' and you want a body.
+  formFields?: Array<{ name: string; value: string }>
+  // Extra headers layered on top of curl_chrome's Chrome 136 defaults. Use
+  // sparingly — see the file header for the "don't override standard headers"
+  // rule. Each entry becomes `-H "<name>: <value>"`.
+  extraHeaders?: Record<string, string>
+  // Hard cap on bytes accepted from the response (passed as --max-filesize).
+  // The actual buffer is still bounded by the caller; this just makes curl
+  // bail early instead of streaming gigabytes.
+  maxBytes?: number
+  timeoutSeconds?: number
+  signal?: AbortSignal
+}
+
+export type CurlImpersonateResponse = {
+  // Decoded response body. `--compressed` is always passed so we receive
+  // plain bytes regardless of what content-encoding the server negotiated.
+  body: string
+  // Final URL after redirects (curl `-w '%{url_effective}'`).
+  finalUrl: string
+  // HTTP status of the final response (curl `-w '%{http_code}'`).
+  httpStatus: number
+  // Content-Type of the final response, lowercased and trimmed.
+  contentType: string
+  // Raw byte length of the body buffer (pre-decode).
+  bytesIn: number
+}
+
+export class CurlImpersonateError extends Error {
+  constructor(
+    message: string,
+    public readonly exitCode: number | null,
+    public readonly stderr: string,
+  ) {
+    super(message)
+    this.name = 'CurlImpersonateError'
+  }
+}
+
+// `-w` write-out template. We emit a sentinel followed by status, final URL,
+// content-type, and size, each on its own line, AFTER the body. This is the
+// standard pattern for getting metadata back from curl without parsing
+// response headers ourselves.
+//
+// The sentinel must be (a) extremely unlikely to appear in a real HTML/JSON
+// response body, and (b) free of null bytes (Bun's spawn rejects argv
+// entries with NULs). We pick a long ASCII tag with a UUID-shaped suffix:
+// the chance of this exact 56-byte string appearing in a fetched page is
+// vanishingly small in practice.
+const METADATA_SENTINEL = '\n--TYPECLAW-CURL-META-9c3f5e4d2a1b4f8e9c7a6b5d4e3f2a1b0--\n'
+const WRITE_OUT_TEMPLATE = `${METADATA_SENTINEL}%{http_code}\n%{url_effective}\n%{content_type}\n%{size_download}\n`
+
+export async function curlImpersonate(req: CurlImpersonateRequest): Promise<CurlImpersonateResponse> {
+  const timeoutSeconds = req.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS
+  const method = req.method ?? 'GET'
+
+  const cmd: string[] = [
+    curlBinary,
+    '--silent',
+    '--show-error',
+    // `--fail-with-body` makes curl exit non-zero on >=400 BUT still write
+    // the body — so consumers see what the server actually said (useful for
+    // 403/404 debugging) while still being able to detect failure via exit
+    // code. We override exit-code handling below: we want callers to inspect
+    // httpStatus themselves, so we DO NOT pass --fail-with-body here. Curl
+    // exits 0 on a 404 with body, and the caller decides what to do.
+    '--compressed',
+    '--location', // follow redirects (essential for Akamai's _abck dance)
+    '--max-redirs',
+    '10',
+    '--max-time',
+    String(timeoutSeconds),
+    '-w',
+    WRITE_OUT_TEMPLATE,
+    '-X',
+    method,
+  ]
+
+  if (req.maxBytes !== undefined) {
+    cmd.push('--max-filesize', String(req.maxBytes))
+  }
+
+  if (req.formFields) {
+    for (const field of req.formFields) {
+      cmd.push('--data-urlencode', `${field.name}=${field.value}`)
+    }
+  }
+
+  if (req.extraHeaders) {
+    for (const [name, value] of Object.entries(req.extraHeaders)) {
+      cmd.push('-H', `${name}: ${value}`)
+    }
+  }
+
+  cmd.push(req.url)
+
+  // Spawn detached so the child becomes the leader of its own process group.
+  // The curl-impersonate wrappers (curl_chrome136 et al.) are bash scripts
+  // that call the real curl-impersonate binary WITHOUT `exec` — meaning the
+  // wrapper is the parent and curl-impersonate is its child. On a plain
+  // SIGKILL to the wrapper PID, the curl child becomes orphaned and keeps
+  // the stdout pipe open until --max-time fires, turning a 50ms abort into
+  // a 30s hang. process.kill(-pid) addresses the negative PID, which signals
+  // the entire process group, killing both atomically. detached: true makes
+  // the child the pgid leader so -pid is well-defined.
+  const proc = spawn({
+    cmd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    detached: true,
+  })
+
+  const onAbort = () => {
+    try {
+      process.kill(-proc.pid, 'SIGKILL')
+    } catch {
+      proc.kill('SIGKILL')
+    }
+  }
+  req.signal?.addEventListener('abort', onAbort, { once: true })
+
+  try {
+    const [stdoutBuf, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).arrayBuffer(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    if (req.signal?.aborted) {
+      throw new CurlImpersonateError('aborted', exitCode, stderr)
+    }
+
+    if (exitCode !== 0) {
+      const detail = stderr.trim() || 'no stderr'
+      throw new CurlImpersonateError(`curl-impersonate exited ${exitCode}: ${detail}`, exitCode, stderr)
+    }
+
+    return parseCurlOutput(stdoutBuf)
+  } finally {
+    req.signal?.removeEventListener('abort', onAbort)
+  }
+}
+
+// Split the curl stdout into body + write-out metadata at the sentinel.
+// The sentinel is appended AFTER curl finishes writing the body, so the
+// split is unambiguous in well-formed output. If the sentinel doesn't appear
+// at all (curl failed to emit -w, e.g. on a very early abort), we treat the
+// whole buffer as the body with status 0.
+function parseCurlOutput(buf: ArrayBuffer): CurlImpersonateResponse {
+  const sentinelBytes = new TextEncoder().encode(METADATA_SENTINEL)
+  const bytes = new Uint8Array(buf)
+
+  const sentinelIndex = indexOfBytes(bytes, sentinelBytes)
+  if (sentinelIndex < 0) {
+    return {
+      body: new TextDecoder('utf-8', { fatal: false }).decode(bytes),
+      finalUrl: '',
+      httpStatus: 0,
+      contentType: '',
+      bytesIn: bytes.byteLength,
+    }
+  }
+
+  const bodyBytes = bytes.subarray(0, sentinelIndex)
+  const metaBytes = bytes.subarray(sentinelIndex + sentinelBytes.byteLength)
+  const meta = new TextDecoder('utf-8', { fatal: false }).decode(metaBytes).split('\n')
+
+  const httpStatus = Number(meta[0]?.trim() ?? '0') || 0
+  const finalUrl = (meta[1] ?? '').trim()
+  const contentType = (meta[2] ?? '').trim().toLowerCase()
+  const declaredBytes = Number(meta[3]?.trim() ?? '0') || bodyBytes.byteLength
+
+  const body = new TextDecoder('utf-8', { fatal: false }).decode(bodyBytes)
+
+  return {
+    body,
+    finalUrl,
+    httpStatus,
+    contentType,
+    bytesIn: declaredBytes,
+  }
+}
+
+function indexOfBytes(haystack: Uint8Array, needle: Uint8Array): number {
+  if (needle.byteLength === 0) return 0
+  const end = haystack.byteLength - needle.byteLength
+  outer: for (let i = 0; i <= end; i++) {
+    for (let j = 0; j < needle.byteLength; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer
+    }
+    return i
+  }
+  return -1
+}
+
+// Detect whether curl-impersonate is available on PATH. Used by fetch.ts to
+// decide between the impersonating transport (production: container has the
+// binary pinned in the image) and a Bun.fetch fallback (test/dev: no binary
+// installed). The check is best-effort and cheap — we spawn `--version`
+// and look at exit code. Cached per-process: the binary doesn't appear or
+// disappear at runtime.
+let availabilityCache: boolean | undefined
+
+export async function isCurlImpersonateAvailable(): Promise<boolean> {
+  if (availabilityCache !== undefined) return availabilityCache
+  try {
+    const proc = spawn({ cmd: [curlBinary, '--version'], stdout: 'ignore', stderr: 'ignore' })
+    const code = await proc.exited
+    availabilityCache = code === 0
+  } catch {
+    availabilityCache = false
+  }
+  return availabilityCache
+}
+
+export function _resetAvailabilityCacheForTest(): void {
+  availabilityCache = undefined
+}

--- a/src/agent/tools/curl-impersonate.ts
+++ b/src/agent/tools/curl-impersonate.ts
@@ -11,18 +11,14 @@
 // /usr/local/bin/curl_chrome136 — see src/init/dockerfile.ts for the version
 // and SHA pin.
 //
-// The original site of this code was ddg.ts; this file is the extraction so
-// webfetch can share it. AGENTS.md explicitly warns against adding `-H`
-// overrides because the curl_chrome wrapper already sends the full Chrome
-// header set (correct ordering, sec-ch-ua, sec-fetch-*, accept-encoding,
-// etc.) and any custom header corrupts the impersonation. The optional
-// headers passed here are layered ON TOP of curl_chrome's defaults via `-H`,
-// so use it ONLY for things curl can't infer (e.g. an explicit Authorization
-// token, a custom API key). Don't override User-Agent, Accept, sec-* headers,
-// or anything in curl_chrome's standard set.
-//
-// AGENTS.md §"Web search" describes why the spawn path is load-bearing for
-// the DDG-specific case; the same reasoning applies to webfetch.
+// AGENTS.md explicitly warns against adding `-H` overrides because the
+// curl_chrome wrapper already sends the full Chrome header set (correct
+// ordering, sec-ch-ua, sec-fetch-*, accept-encoding, etc.) and any custom
+// header corrupts the impersonation. We therefore expose NO header-override
+// surface from this primitive; add one only when a real caller needs it AND
+// the override is something curl_chrome can't be told to send another way.
+
+import { randomBytes } from 'node:crypto'
 
 import { spawn } from 'bun'
 
@@ -41,15 +37,11 @@ export function _setCurlBinaryForTest(binary: string | null): void {
 
 export type CurlImpersonateRequest = {
   url: string
-  method?: 'GET' | 'POST' | 'HEAD'
+  method?: 'GET' | 'POST'
   // Form-urlencoded body fields for POST. Each entry is passed as a separate
   // --data-urlencode argument so curl handles the encoding. Required if
   // method is 'POST' and you want a body.
   formFields?: Array<{ name: string; value: string }>
-  // Extra headers layered on top of curl_chrome's Chrome 136 defaults. Use
-  // sparingly — see the file header for the "don't override standard headers"
-  // rule. Each entry becomes `-H "<name>: <value>"`.
-  extraHeaders?: Record<string, string>
   // Hard cap on bytes accepted from the response (passed as --max-filesize).
   // The actual buffer is still bounded by the caller; this just makes curl
   // bail early instead of streaming gigabytes.
@@ -59,18 +51,27 @@ export type CurlImpersonateRequest = {
 }
 
 export type CurlImpersonateResponse = {
-  // Decoded response body. `--compressed` is always passed so we receive
-  // plain bytes regardless of what content-encoding the server negotiated.
   body: string
-  // Final URL after redirects (curl `-w '%{url_effective}'`).
   finalUrl: string
-  // HTTP status of the final response (curl `-w '%{http_code}'`).
   httpStatus: number
-  // Content-Type of the final response, lowercased and trimmed.
   contentType: string
-  // Raw byte length of the body buffer (pre-decode).
   bytesIn: number
 }
+
+// Specific curl exit codes we map to typed errors. The full list is in
+// `man curl` § "EXIT CODES"; these are the only ones we translate at the
+// primitive layer. Everything else surfaces as a generic CurlImpersonateError
+// with stderr attached for caller-side diagnostics.
+export const CURL_EXIT_TIMEOUT = 28
+export const CURL_EXIT_MAX_FILESIZE_PRECHECK = 63
+// Observed empirically (and corroborated by Oracle review): curl returns
+// exit 56 with stderr `Exceeded the maximum allowed file size (...)` when
+// --max-filesize is hit at TRANSFER time (e.g. server omitted Content-Length
+// and curl discovered the overflow mid-stream). The Linux man page lists 56
+// as the more general "Failure in receiving network data," so we additionally
+// gate on a stderr match to avoid mis-classifying real network drops as
+// size-exceeded.
+export const CURL_EXIT_RECV_FAILURE_OR_FILESIZE = 56
 
 export class CurlImpersonateError extends Error {
   constructor(
@@ -83,41 +84,70 @@ export class CurlImpersonateError extends Error {
   }
 }
 
-// `-w` write-out template. We emit a sentinel followed by status, final URL,
-// content-type, and size, each on its own line, AFTER the body. This is the
-// standard pattern for getting metadata back from curl without parsing
-// response headers ourselves.
-//
-// The sentinel must be (a) extremely unlikely to appear in a real HTML/JSON
-// response body, and (b) free of null bytes (Bun's spawn rejects argv
-// entries with NULs). We pick a long ASCII tag with a UUID-shaped suffix:
-// the chance of this exact 56-byte string appearing in a fetched page is
-// vanishingly small in practice.
-const METADATA_SENTINEL = '\n--TYPECLAW-CURL-META-9c3f5e4d2a1b4f8e9c7a6b5d4e3f2a1b0--\n'
-const WRITE_OUT_TEMPLATE = `${METADATA_SENTINEL}%{http_code}\n%{url_effective}\n%{content_type}\n%{size_download}\n`
+export function isCurlExitFilesizeExceeded(error: CurlImpersonateError): boolean {
+  if (error.exitCode === CURL_EXIT_MAX_FILESIZE_PRECHECK) return true
+  if (error.exitCode === CURL_EXIT_RECV_FAILURE_OR_FILESIZE && /maximum.{0,30}file size/i.test(error.stderr)) {
+    return true
+  }
+  return false
+}
+
+export function isCurlExitTimeout(error: CurlImpersonateError): boolean {
+  return error.exitCode === CURL_EXIT_TIMEOUT
+}
 
 export async function curlImpersonate(req: CurlImpersonateRequest): Promise<CurlImpersonateResponse> {
   const timeoutSeconds = req.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS
   const method = req.method ?? 'GET'
 
+  // Per-request random sentinel + UTF-8-safe parsing. The static sentinel
+  // approach (previous revision) had a hardening hole: webfetch reads
+  // attacker-controlled pages, and a static sentinel is a public, fixed
+  // string. A page could include the sentinel byte sequence plus fabricated
+  // metadata before the real write-out tail and `indexOf` would split at
+  // the attacker-controlled occurrence. Per-request randomness (96 bits)
+  // removes the attacker's ability to predict the sentinel, and the parser
+  // anchors on the LAST occurrence (curl writes `-w` after the body, so the
+  // real metadata block is always last). Both defenses are needed: random
+  // alone fails if the attacker can read the sentinel from a previous
+  // response and replay it; last-match alone fails if the attacker can
+  // append text after curl's write-out (they can't, but defense in depth).
+  const sentinel = generateSentinel()
+  const writeOutTemplate = `${sentinel}%{http_code}\n%{url_effective}\n%{content_type}\n%{size_download}\n`
+
   const cmd: string[] = [
     curlBinary,
+    // `--disable` (alias -q) MUST be the first argument to suppress reading
+    // ~/.curlrc and /etc/curlrc. Without it, a user or attacker-controlled
+    // curlrc could inject --proxy, --header, --resolve, --no-location, etc.,
+    // silently subverting both the Chrome impersonation contract and the
+    // protocol restrictions below. Order is load-bearing: curl ignores
+    // --disable if it appears after any other flag.
+    '--disable',
     '--silent',
     '--show-error',
-    // `--fail-with-body` makes curl exit non-zero on >=400 BUT still write
-    // the body — so consumers see what the server actually said (useful for
-    // 403/404 debugging) while still being able to detect failure via exit
-    // code. We override exit-code handling below: we want callers to inspect
-    // httpStatus themselves, so we DO NOT pass --fail-with-body here. Curl
-    // exits 0 on a 404 with body, and the caller decides what to do.
+    // Protocol allowlist. curl-impersonate supports many protocols by default
+    // (ftp, file, dict, etc.). normalizeUrl() already rejects non-http(s) at
+    // the call-site, but redirects are followed by curl after that gate fires
+    // and a 301/302 to ftp://... would otherwise be silently honored. The
+    // `=http,https` syntax means "ONLY these two" rather than "add these to
+    // defaults." --proto-redir governs the redirect chain specifically.
+    '--proto',
+    '=http,https',
+    '--proto-redir',
+    '=http,https',
+    // `--fail-with-body` would make curl exit non-zero on >=400 but still
+    // write the body. We intentionally DO NOT pass it: callers (webfetch,
+    // ddg) want to inspect httpStatus themselves and decide. Curl exits 0
+    // on a 404-with-body in this mode, which matches our contract.
     '--compressed',
-    '--location', // follow redirects (essential for Akamai's _abck dance)
+    '--location',
     '--max-redirs',
     '10',
     '--max-time',
     String(timeoutSeconds),
     '-w',
-    WRITE_OUT_TEMPLATE,
+    writeOutTemplate,
     '-X',
     method,
   ]
@@ -132,13 +162,10 @@ export async function curlImpersonate(req: CurlImpersonateRequest): Promise<Curl
     }
   }
 
-  if (req.extraHeaders) {
-    for (const [name, value] of Object.entries(req.extraHeaders)) {
-      cmd.push('-H', `${name}: ${value}`)
-    }
-  }
-
-  cmd.push(req.url)
+  // `--` terminates option parsing so a URL beginning with `-` (e.g. an
+  // attacker-supplied "-K /etc/passwd" sneaking through normalizeUrl as
+  // "https://-K /etc/passwd") cannot be reinterpreted as a curl option.
+  cmd.push('--', req.url)
 
   // Spawn detached so the child becomes the leader of its own process group.
   // The curl-impersonate wrappers (curl_chrome136 et al.) are bash scripts
@@ -181,30 +208,36 @@ export async function curlImpersonate(req: CurlImpersonateRequest): Promise<Curl
       throw new CurlImpersonateError(`curl-impersonate exited ${exitCode}: ${detail}`, exitCode, stderr)
     }
 
-    return parseCurlOutput(stdoutBuf)
+    return parseCurlOutput(stdoutBuf, sentinel, stderr)
   } finally {
     req.signal?.removeEventListener('abort', onAbort)
   }
 }
 
-// Split the curl stdout into body + write-out metadata at the sentinel.
-// The sentinel is appended AFTER curl finishes writing the body, so the
-// split is unambiguous in well-formed output. If the sentinel doesn't appear
-// at all (curl failed to emit -w, e.g. on a very early abort), we treat the
-// whole buffer as the body with status 0.
-function parseCurlOutput(buf: ArrayBuffer): CurlImpersonateResponse {
-  const sentinelBytes = new TextEncoder().encode(METADATA_SENTINEL)
+// Generates a per-request sentinel. Format: `\n--TYPECLAW-CURL-META-<hex>--\n`.
+// 24 hex chars = 96 bits of entropy, plenty to defeat any attempt by an
+// attacker-controlled response body to inject a colliding marker. ASCII-only
+// + leading/trailing newlines means it's unambiguous in textual responses
+// and free of NUL bytes (Bun's spawn rejects NULs in argv).
+function generateSentinel(): string {
+  const hex = randomBytes(12).toString('hex')
+  return `\n--TYPECLAW-CURL-META-${hex}--\n`
+}
+
+function parseCurlOutput(buf: ArrayBuffer, sentinel: string, stderr: string): CurlImpersonateResponse {
+  const sentinelBytes = new TextEncoder().encode(sentinel)
   const bytes = new Uint8Array(buf)
 
-  const sentinelIndex = indexOfBytes(bytes, sentinelBytes)
+  // Anchor on the LAST occurrence (defense in depth alongside the random
+  // sentinel). curl writes the `-w` output strictly AFTER the body, so the
+  // real metadata block is always the trailing one.
+  const sentinelIndex = lastIndexOfBytes(bytes, sentinelBytes)
   if (sentinelIndex < 0) {
-    return {
-      body: new TextDecoder('utf-8', { fatal: false }).decode(bytes),
-      finalUrl: '',
-      httpStatus: 0,
-      contentType: '',
-      bytesIn: bytes.byteLength,
-    }
+    throw new CurlImpersonateError(
+      'curl-impersonate produced no metadata block (sentinel missing). Wrapper or output corruption suspected.',
+      0,
+      stderr,
+    )
   }
 
   const bodyBytes = bytes.subarray(0, sentinelIndex)
@@ -227,14 +260,17 @@ function parseCurlOutput(buf: ArrayBuffer): CurlImpersonateResponse {
   }
 }
 
-function indexOfBytes(haystack: Uint8Array, needle: Uint8Array): number {
-  if (needle.byteLength === 0) return 0
-  const end = haystack.byteLength - needle.byteLength
-  outer: for (let i = 0; i <= end; i++) {
+function lastIndexOfBytes(haystack: Uint8Array, needle: Uint8Array): number {
+  if (needle.byteLength === 0) return haystack.byteLength
+  for (let i = haystack.byteLength - needle.byteLength; i >= 0; i--) {
+    let matched = true
     for (let j = 0; j < needle.byteLength; j++) {
-      if (haystack[i + j] !== needle[j]) continue outer
+      if (haystack[i + j] !== needle[j]) {
+        matched = false
+        break
+      }
     }
-    return i
+    if (matched) return i
   }
   return -1
 }

--- a/src/agent/tools/ddg.test.ts
+++ b/src/agent/tools/ddg.test.ts
@@ -149,9 +149,28 @@ describe('fetchDdgHtml', () => {
     _setCurlBinaryForTest(path)
   }
 
+  // The fake binary must round-trip the per-request random sentinel from
+  // curl's `-w` argument back to stdout (otherwise the primitive rejects
+  // the output as corrupted). See fetch.test.ts for the rationale.
+  const FAKE_CURL_BODY = (body: string) => `
+WTPL=""
+i=1
+for arg in "$@"; do
+  if [ "$arg" = "-w" ]; then
+    j=$((i + 1))
+    eval "WTPL=\\"\\\${$j}\\""
+    break
+  fi
+  i=$((i + 1))
+done
+RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/200/' -e 's|%{url_effective}|https://lite.duckduckgo.com/lite/|' -e 's|%{content_type}|text/html|' -e 's/%{size_download}/${body.length}/')
+printf '%s' '${body}'
+printf '%s' "$RENDERED"
+`
+
   test('returns stdout verbatim on exit 0', async () => {
-    // given: fake binary that prints a fixed HTML body
-    installFakeBinary("printf '<html>hello world</html>'")
+    // given: fake binary that prints a fixed HTML body + the sentinel
+    installFakeBinary(FAKE_CURL_BODY('<html>hello world</html>'))
 
     // when
     const html = await fetchDdgHtml('ignored')
@@ -178,9 +197,9 @@ describe('fetchDdgHtml', () => {
   })
 
   test('passes query as POST form data with --data-urlencode', async () => {
-    // given: fake binary records argv to a side file then prints empty body
+    // given: fake binary records argv AND emits the required sentinel
     const argvFile = join(scratchDir, 'argv.txt')
-    installFakeBinary(`printf '%s\\n' "$@" > ${argvFile}; printf ''`)
+    installFakeBinary(`printf '%s\\n' "$@" > ${argvFile}\n${FAKE_CURL_BODY('')}`)
 
     // when
     await fetchDdgHtml('hello world')

--- a/src/agent/tools/ddg.ts
+++ b/src/agent/tools/ddg.ts
@@ -12,7 +12,7 @@
 // TLS handshake + HTTP/2 settings + header ordering. See that file's header
 // for the full rationale and AGENTS.md §"Web search" for the original story.
 
-import { CurlImpersonateError, curlImpersonate } from './curl-impersonate'
+import { curlImpersonate } from './curl-impersonate'
 
 export { _setCurlBinaryForTest } from './curl-impersonate'
 
@@ -40,20 +40,13 @@ export class DdgCaptchaError extends Error {
 }
 
 export async function fetchDdgHtml(query: string, signal?: AbortSignal): Promise<string> {
-  try {
-    const response = await curlImpersonate({
-      url: DDG_LITE_URL,
-      method: 'POST',
-      formFields: [{ name: 'q', value: query }],
-      signal,
-    })
-    return response.body
-  } catch (error) {
-    if (error instanceof CurlImpersonateError) {
-      throw new Error(error.message)
-    }
-    throw error
-  }
+  const response = await curlImpersonate({
+    url: DDG_LITE_URL,
+    method: 'POST',
+    formFields: [{ name: 'q', value: query }],
+    signal,
+  })
+  return response.body
 }
 
 // The `lite` endpoint's CAPTCHA page is plainer than `html`'s anomaly-modal:

--- a/src/agent/tools/ddg.ts
+++ b/src/agent/tools/ddg.ts
@@ -7,40 +7,16 @@
 // single bad fingerprint match. `lite` exists for non-browser clients (text
 // browsers, accessibility tools) and historically gates less aggressively —
 // but as of 2026 it ALSO fingerprints at the TLS layer (JA3/JA4) and the
-// HTTP/2 SETTINGS frame, well before any HTTP header is read. Bun's native
-// fetch cannot match Chrome's handshake (upstream issue #11368), so requests
-// from `fetch()` get gated regardless of headers, body shape, or pacing —
-// confirmed empirically over a multi-hour session against a single home IP
-// where real Chromium succeeded continuously while every fetch variant got
-// 202 anomaly-modal or HTTP-200-with-anomaly responses.
-//
-// The fix is to shell out to `curl-impersonate` (lexiforest fork), which
-// replays Chrome's exact TLS handshake + HTTP/2 settings + header ordering.
-// The binary is installed by the typeclaw Dockerfile (see
-// src/init/dockerfile.ts CURL_IMPERSONATE_* constants) at /usr/local/bin/
-// and invoked via the version-pinned wrapper `curl_chrome136`.
-//
-// Why no `-H` overrides: curl_chrome136 already sends the full Chrome 136
-// header set with correct ordering, sec-ch-ua values, etc. Adding our own
-// headers would corrupt the impersonation. The previous code's
-// BROWSER_HEADERS const has been removed for the same reason.
+// HTTP/2 SETTINGS frame, well before any HTTP header is read. The shared
+// curl-impersonate primitive (./curl-impersonate.ts) replays Chrome's exact
+// TLS handshake + HTTP/2 settings + header ordering. See that file's header
+// for the full rationale and AGENTS.md §"Web search" for the original story.
 
-import { spawn } from 'bun'
+import { CurlImpersonateError, curlImpersonate } from './curl-impersonate'
+
+export { _setCurlBinaryForTest } from './curl-impersonate'
 
 const DDG_LITE_URL = 'https://lite.duckduckgo.com/lite/'
-const CURL_IMPERSONATE_BINARY = 'curl_chrome136'
-const REQUEST_TIMEOUT_SECONDS = 30
-
-let curlBinary = CURL_IMPERSONATE_BINARY
-
-// Test-only seam: lets ddg.test.ts and websearch.test.ts point the spawn
-// at a fake `curl_chrome136` script in a tmpdir so we exercise the real
-// Bun.spawn path without depending on a curl-impersonate install on the
-// test host. Production code never calls this — the const-import default
-// above is what production sees.
-export function _setCurlBinaryForTest(binary: string | null): void {
-  curlBinary = binary ?? CURL_IMPERSONATE_BINARY
-}
 
 export type DdgResult = {
   title: string
@@ -64,63 +40,19 @@ export class DdgCaptchaError extends Error {
 }
 
 export async function fetchDdgHtml(query: string, signal?: AbortSignal): Promise<string> {
-  // Spawn detached so the child becomes the leader of its own process group.
-  // The curl-impersonate wrappers (curl_chrome136 et al.) are bash scripts
-  // that call the real curl-impersonate binary WITHOUT `exec` — meaning the
-  // wrapper is the parent and curl-impersonate is its child. On a plain
-  // SIGKILL to the wrapper PID, the curl child becomes orphaned and keeps
-  // the stdout pipe open until --max-time fires (30s default), turning a
-  // 50ms abort into a 30s hang. process.kill(-pid) addresses the negative
-  // PID, which signals the entire process group, killing both the wrapper
-  // and the inner curl atomically. detached: true is what makes the child
-  // the pgid leader so -pid is well-defined; without it, the child shares
-  // our pgid and we'd nuke our own process.
-  const proc = spawn({
-    cmd: [
-      curlBinary,
-      '--silent',
-      '--show-error',
-      '--fail-with-body',
-      '--compressed',
-      '--max-time',
-      String(REQUEST_TIMEOUT_SECONDS),
-      '-X',
-      'POST',
-      '--data-urlencode',
-      `q=${query}`,
-      DDG_LITE_URL,
-    ],
-    stdout: 'pipe',
-    stderr: 'pipe',
-    detached: true,
-  })
-
-  const onAbort = () => {
-    try {
-      process.kill(-proc.pid, 'SIGKILL')
-    } catch {
-      proc.kill('SIGKILL')
-    }
-  }
-  signal?.addEventListener('abort', onAbort, { once: true })
-
   try {
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ])
-
-    if (signal?.aborted) {
-      throw new Error('aborted')
+    const response = await curlImpersonate({
+      url: DDG_LITE_URL,
+      method: 'POST',
+      formFields: [{ name: 'q', value: query }],
+      signal,
+    })
+    return response.body
+  } catch (error) {
+    if (error instanceof CurlImpersonateError) {
+      throw new Error(error.message)
     }
-    if (exitCode !== 0) {
-      const detail = stderr.trim() || 'no stderr'
-      throw new Error(`curl-impersonate exited ${exitCode}: ${detail}`)
-    }
-    return stdout
-  } finally {
-    signal?.removeEventListener('abort', onAbort)
+    throw error
   }
 }
 

--- a/src/agent/tools/webfetch/fetch.test.ts
+++ b/src/agent/tools/webfetch/fetch.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
-import { fetchWithLimits, normalizeUrl, parseMimeType, WebfetchError } from './fetch'
+import { _resetAvailabilityCacheForTest, _setCurlBinaryForTest } from '../curl-impersonate'
+import { _setForceFallbackForTest, fetchWithLimits, normalizeUrl, parseMimeType, WebfetchError } from './fetch'
 
 type FetchInput = Parameters<typeof fetch>[0]
 type FetchArgs = { url: string; init: RequestInit | undefined }
@@ -8,6 +12,8 @@ type FetchArgs = { url: string; init: RequestInit | undefined }
 let fetchCalls: FetchArgs[]
 let fetchResponse: (args: FetchArgs) => Response | Promise<Response>
 const originalFetch = globalThis.fetch
+
+const CURL_META_SENTINEL = '\n--TYPECLAW-CURL-META-9c3f5e4d2a1b4f8e9c7a6b5d4e3f2a1b0--\n'
 
 beforeEach(() => {
   fetchCalls = []
@@ -17,10 +23,18 @@ beforeEach(() => {
     fetchCalls.push(args)
     return fetchResponse(args)
   }) as typeof fetch
+  // Default mode: force the Bun.fetch fallback so existing assertions on
+  // mocked `globalThis.fetch` keep working. The impersonate-path tests
+  // below opt into the curl path explicitly.
+  _setForceFallbackForTest(true)
+  _resetAvailabilityCacheForTest()
 })
 
 afterEach(() => {
   globalThis.fetch = originalFetch
+  _setForceFallbackForTest(false)
+  _setCurlBinaryForTest(null)
+  _resetAvailabilityCacheForTest()
 })
 
 describe('normalizeUrl', () => {
@@ -54,7 +68,7 @@ describe('parseMimeType', () => {
   })
 })
 
-describe('fetchWithLimits', () => {
+describe('fetchWithLimits — Bun.fetch fallback path', () => {
   test('returns body, content-type, status, and final URL on success', async () => {
     fetchResponse = () => new Response('hello', { status: 200, headers: { 'content-type': 'text/plain' } })
 
@@ -104,12 +118,79 @@ describe('fetchWithLimits', () => {
     await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/Fetch failed: ECONNREFUSED/)
   })
 
-  test('sends typeclaw User-Agent', async () => {
+  test('sends typeclaw User-Agent on the fallback path', async () => {
     fetchResponse = () => new Response('ok', { status: 200 })
 
     await fetchWithLimits('https://example.com', 30)
 
     const headers = fetchCalls[0]?.init?.headers as Record<string, string> | undefined
     expect(headers?.['User-Agent']).toContain('typeclaw')
+  })
+})
+
+describe('fetchWithLimits — curl-impersonate path', () => {
+  let scratchDir: string
+
+  beforeEach(() => {
+    scratchDir = mkdtempSync(join(tmpdir(), 'webfetch-curl-test-'))
+    // Opt back into the real availability check (one of the tests below
+    // installs a fake binary; another asserts the fallback fires when no
+    // binary exists).
+    _setForceFallbackForTest(false)
+  })
+
+  afterEach(() => {
+    rmSync(scratchDir, { recursive: true, force: true })
+  })
+
+  function installFakeBinary(script: string): void {
+    const path = join(scratchDir, 'fake-curl')
+    writeFileSync(path, `#!/bin/sh\n${script}\n`, 'utf8')
+    chmodSync(path, 0o755)
+    _setCurlBinaryForTest(path)
+    _resetAvailabilityCacheForTest()
+  }
+
+  test('uses curl-impersonate when the binary is available', async () => {
+    // given: fake binary that emits a body + the metadata sentinel
+    installFakeBinary(
+      `printf '<html>ok</html>'; printf '${CURL_META_SENTINEL}200\nhttps://example.com/final\ntext/html; charset=utf-8\n15\n'`,
+    )
+
+    // when
+    const result = await fetchWithLimits('https://example.com', 30)
+
+    // then: the result came from curl, NOT from globalThis.fetch
+    expect(result.body).toBe('<html>ok</html>')
+    expect(result.contentType).toBe('text/html; charset=utf-8')
+    expect(result.httpStatus).toBe(200)
+    expect(result.finalUrl).toBe('https://example.com/final')
+    expect(fetchCalls).toHaveLength(0)
+  })
+
+  test('translates curl non-2xx response into WebfetchError matching the fallback contract', async () => {
+    // given: fake binary that emits a 403-shaped response (Akamai-style block)
+    installFakeBinary(
+      `printf '<html>blocked</html>'; printf '${CURL_META_SENTINEL}403\nhttps://example.com\ntext/html\n20\n'`,
+    )
+
+    // when / then
+    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(WebfetchError)
+    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 403/)
+  })
+
+  test('falls back to Bun.fetch when curl-impersonate is not installed', async () => {
+    // given: point the curl resolver at a path that doesn't exist, and have
+    // globalThis.fetch ready to serve a known body
+    _setCurlBinaryForTest('/nonexistent/curl_chrome136')
+    _resetAvailabilityCacheForTest()
+    fetchResponse = () => new Response('fallback body', { status: 200, headers: { 'content-type': 'text/plain' } })
+
+    // when
+    const result = await fetchWithLimits('https://example.com', 30)
+
+    // then: globalThis.fetch was the actual transport
+    expect(result.body).toBe('fallback body')
+    expect(fetchCalls).toHaveLength(1)
   })
 })

--- a/src/agent/tools/webfetch/fetch.test.ts
+++ b/src/agent/tools/webfetch/fetch.test.ts
@@ -13,7 +13,33 @@ let fetchCalls: FetchArgs[]
 let fetchResponse: (args: FetchArgs) => Response | Promise<Response>
 const originalFetch = globalThis.fetch
 
-const CURL_META_SENTINEL = '\n--TYPECLAW-CURL-META-9c3f5e4d2a1b4f8e9c7a6b5d4e3f2a1b0--\n'
+// Fake-curl shell-script template. We read the -w arg value (the curl
+// write-out template containing the per-request random sentinel) directly
+// out of argv by index — `printf '%s\\n' "$@"` collapses multi-line argv
+// values into adjacent lines, but Bun spawns each argv element as a
+// separate process argument, so positional `$N` accessors preserve the
+// raw value verbatim. We find the position of '-w' via a small loop and
+// emit `$N+1` as the template. Then substitute curl's %{...} codes for
+// our static body. Same pattern as curl-impersonate.test.ts.
+const FAKE_CURL = (body: string, status: number, finalUrl: string, contentType: string) => `
+ARGV_FILE="\${SCRATCH_ARGV:-/tmp/argv.txt}"
+printf '%s\\n' "$@" > "$ARGV_FILE"
+WTPL=""
+i=1
+for arg in "$@"; do
+  if [ "$arg" = "-w" ]; then
+    j=$((i + 1))
+    eval "WTPL=\\"\\\${$j}\\""
+    break
+  fi
+  i=$((i + 1))
+done
+# WTPL is e.g. "\\n--TYPECLAW-CURL-META-<hex>--\\n%{http_code}\\n..."
+# Replace curl's %{...} codes by hand.
+RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/${status}/' -e 's|%{url_effective}|${finalUrl}|' -e 's|%{content_type}|${contentType}|' -e 's/%{size_download}/${body.length}/')
+printf '%s' '${body}'
+printf '%s' "$RENDERED"
+`
 
 beforeEach(() => {
   fetchCalls = []
@@ -145,17 +171,24 @@ describe('fetchWithLimits — curl-impersonate path', () => {
 
   function installFakeBinary(script: string): void {
     const path = join(scratchDir, 'fake-curl')
-    writeFileSync(path, `#!/bin/sh\n${script}\n`, 'utf8')
+    const argvPath = join(scratchDir, 'argv.txt')
+    // Short-circuit --version (the availability probe) to exit 0 regardless
+    // of what the script body does on real invocations. Otherwise tests
+    // that simulate an error exit (e.g. exit 56) would also fail the
+    // availability check, silently falling through to the Bun.fetch path.
+    writeFileSync(
+      path,
+      `#!/bin/sh\nSCRATCH_ARGV="${argvPath}"\nif [ "$1" = "--version" ]; then exit 0; fi\n${script}\n`,
+      'utf8',
+    )
     chmodSync(path, 0o755)
     _setCurlBinaryForTest(path)
     _resetAvailabilityCacheForTest()
   }
 
   test('uses curl-impersonate when the binary is available', async () => {
-    // given: fake binary that emits a body + the metadata sentinel
-    installFakeBinary(
-      `printf '<html>ok</html>'; printf '${CURL_META_SENTINEL}200\nhttps://example.com/final\ntext/html; charset=utf-8\n15\n'`,
-    )
+    // given: fake binary that round-trips the per-request sentinel
+    installFakeBinary(FAKE_CURL('<html>ok</html>', 200, 'https://example.com/final', 'text/html; charset=utf-8'))
 
     // when
     const result = await fetchWithLimits('https://example.com', 30)
@@ -170,13 +203,40 @@ describe('fetchWithLimits — curl-impersonate path', () => {
 
   test('translates curl non-2xx response into WebfetchError matching the fallback contract', async () => {
     // given: fake binary that emits a 403-shaped response (Akamai-style block)
-    installFakeBinary(
-      `printf '<html>blocked</html>'; printf '${CURL_META_SENTINEL}403\nhttps://example.com\ntext/html\n20\n'`,
-    )
+    installFakeBinary(FAKE_CURL('<html>blocked</html>', 403, 'https://example.com', 'text/html'))
 
     // when / then
     await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(WebfetchError)
     await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 403/)
+  })
+
+  test('translates curl exit 28 (timeout) into a timeout-specific WebfetchError', async () => {
+    // given: fake binary that exits with code 28 (Operation timeout)
+    installFakeBinary('echo "Operation timed out after 30000 milliseconds" >&2; exit 28')
+
+    // when / then
+    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/timed out after 30s/)
+  })
+
+  test('translates curl exit 63 (content-length filesize overflow) into a too-large WebfetchError', async () => {
+    installFakeBinary('echo "Maximum file size exceeded" >&2; exit 63')
+
+    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/Response too large/)
+  })
+
+  test('translates curl exit 56 + filesize stderr into a too-large WebfetchError', async () => {
+    // given: fake emits the transfer-time variant Oracle verified empirically
+    installFakeBinary('echo "Exceeded the maximum allowed file size (1) with 1 bytes" >&2; exit 56')
+
+    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/Response too large/)
+  })
+
+  test('does NOT misclassify generic exit 56 (recv failure) as filesize exceeded', async () => {
+    installFakeBinary('echo "Recv failure: Connection reset by peer" >&2; exit 56')
+
+    // when / then: it's a generic Fetch failed:, not "Response too large"
+    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/Fetch failed.*exited 56/)
+    await expect(fetchWithLimits('https://example.com', 30)).rejects.not.toThrow(/Response too large/)
   })
 
   test('falls back to Bun.fetch when curl-impersonate is not installed', async () => {

--- a/src/agent/tools/webfetch/fetch.ts
+++ b/src/agent/tools/webfetch/fetch.ts
@@ -1,3 +1,27 @@
+// Webfetch's HTTP transport.
+//
+// Production path (container, curl-impersonate available): we shell out to
+// `curl_chrome136` so outbound requests carry Chrome 136's TLS handshake
+// (JA3/JA4), HTTP/2 SETTINGS frame, and full header set. This is what gets
+// us past the modern bot-detection stacks on Cloudflare/Akamai-protected
+// sites (Reuters, MarketWatch, etc.) when the agent is running from the
+// user's home network — the IP is already residential, so impersonating
+// the browser is the only remaining missing piece. See AGENTS.md §"Web
+// search" and src/agent/tools/curl-impersonate.ts for the full story.
+//
+// Test/dev fallback (curl_chrome136 not on PATH): we transparently fall
+// back to Bun's native `fetch()` with a static User-Agent. This keeps unit
+// tests on developer macOS machines working without forcing every contributor
+// to install curl-impersonate locally. Production runs always have the binary
+// because the typeclaw Dockerfile pins it.
+//
+// Best-effort doctrine: this transport does NOT guarantee the fetch succeeds.
+// Bot-detected sites can still serve 403/CAPTCHA pages. We surface what we
+// got (status, body, final URL) and let the caller decide. The webfetch tool
+// translates non-2xx into a tool-level error message that's useful to the
+// model.
+
+import { CurlImpersonateError, curlImpersonate, isCurlImpersonateAvailable } from '../curl-impersonate'
 import { MAX_RESPONSE_BYTES } from './types'
 
 export type FetchResult = {
@@ -15,7 +39,7 @@ export class WebfetchError extends Error {
   }
 }
 
-const DEFAULT_HEADERS: Record<string, string> = {
+const FALLBACK_HEADERS: Record<string, string> = {
   'User-Agent': 'typeclaw/0 (+https://github.com/code-yeongyu/typeclaw)',
   Accept: 'text/html,application/xhtml+xml,application/json;q=0.9,text/plain;q=0.8,*/*;q=0.1',
   'Accept-Language': 'en-US,en;q=0.9',
@@ -32,7 +56,84 @@ export function normalizeUrl(input: string): string {
   return `https://${trimmed}`
 }
 
+// Test-only seam: forces fetchWithLimits to use the native-fetch fallback
+// even when curl-impersonate is detected. Used by fetch.test.ts to keep its
+// existing mocked-fetch contract working without the test having to install
+// a fake curl binary. Production code never calls this.
+let forceFallbackForTest = false
+
+export function _setForceFallbackForTest(value: boolean): void {
+  forceFallbackForTest = value
+}
+
 export async function fetchWithLimits(
+  url: string,
+  timeoutSeconds: number,
+  parentSignal?: AbortSignal,
+): Promise<FetchResult> {
+  const useImpersonate = !forceFallbackForTest && (await isCurlImpersonateAvailable())
+  if (useImpersonate) {
+    return fetchWithCurlImpersonate(url, timeoutSeconds, parentSignal)
+  }
+  return fetchWithBunFetch(url, timeoutSeconds, parentSignal)
+}
+
+async function fetchWithCurlImpersonate(
+  url: string,
+  timeoutSeconds: number,
+  parentSignal?: AbortSignal,
+): Promise<FetchResult> {
+  let response
+  try {
+    response = await curlImpersonate({
+      url,
+      method: 'GET',
+      timeoutSeconds,
+      maxBytes: MAX_RESPONSE_BYTES,
+      signal: parentSignal,
+    })
+  } catch (error) {
+    if (parentSignal?.aborted) {
+      throw new WebfetchError('Request aborted')
+    }
+    if (error instanceof CurlImpersonateError) {
+      if (/max-time/i.test(error.stderr) || /timed? out/i.test(error.stderr)) {
+        throw new WebfetchError(`Request timed out after ${timeoutSeconds}s`)
+      }
+      // curl --max-filesize trips exit 63
+      if (error.exitCode === 63 || /maximum file size/i.test(error.stderr)) {
+        throw new WebfetchError(`Response too large (exceeds ${formatBytes(MAX_RESPONSE_BYTES)} limit)`)
+      }
+      throw new WebfetchError(`Fetch failed: ${error.message}`)
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    throw new WebfetchError(`Fetch failed: ${message}`)
+  }
+
+  if (response.httpStatus === 0) {
+    throw new WebfetchError('Fetch failed: no HTTP status returned')
+  }
+  if (response.httpStatus < 200 || response.httpStatus >= 300) {
+    throw new WebfetchError(`Fetch failed: HTTP ${response.httpStatus}`)
+  }
+
+  const bodyByteLength = new TextEncoder().encode(response.body).byteLength
+  if (bodyByteLength > MAX_RESPONSE_BYTES) {
+    throw new WebfetchError(
+      `Response too large (${formatBytes(bodyByteLength)} exceeds ${formatBytes(MAX_RESPONSE_BYTES)} limit)`,
+    )
+  }
+
+  return {
+    body: response.body,
+    contentType: response.contentType,
+    finalUrl: response.finalUrl || url,
+    httpStatus: response.httpStatus,
+    bytesIn: bodyByteLength,
+  }
+}
+
+async function fetchWithBunFetch(
   url: string,
   timeoutSeconds: number,
   parentSignal?: AbortSignal,
@@ -43,7 +144,7 @@ export async function fetchWithLimits(
   parentSignal?.addEventListener('abort', onAbort, { once: true })
 
   try {
-    const response = await fetch(url, { headers: DEFAULT_HEADERS, signal: controller.signal, redirect: 'follow' })
+    const response = await fetch(url, { headers: FALLBACK_HEADERS, signal: controller.signal, redirect: 'follow' })
     if (!response.ok) {
       throw new WebfetchError(`Fetch failed: HTTP ${response.status} ${response.statusText}`)
     }

--- a/src/agent/tools/webfetch/fetch.ts
+++ b/src/agent/tools/webfetch/fetch.ts
@@ -21,7 +21,13 @@
 // translates non-2xx into a tool-level error message that's useful to the
 // model.
 
-import { CurlImpersonateError, curlImpersonate, isCurlImpersonateAvailable } from '../curl-impersonate'
+import {
+  CurlImpersonateError,
+  curlImpersonate,
+  isCurlExitFilesizeExceeded,
+  isCurlExitTimeout,
+  isCurlImpersonateAvailable,
+} from '../curl-impersonate'
 import { MAX_RESPONSE_BYTES } from './types'
 
 export type FetchResult = {
@@ -97,11 +103,10 @@ async function fetchWithCurlImpersonate(
       throw new WebfetchError('Request aborted')
     }
     if (error instanceof CurlImpersonateError) {
-      if (/max-time/i.test(error.stderr) || /timed? out/i.test(error.stderr)) {
+      if (isCurlExitTimeout(error)) {
         throw new WebfetchError(`Request timed out after ${timeoutSeconds}s`)
       }
-      // curl --max-filesize trips exit 63
-      if (error.exitCode === 63 || /maximum file size/i.test(error.stderr)) {
+      if (isCurlExitFilesizeExceeded(error)) {
         throw new WebfetchError(`Response too large (exceeds ${formatBytes(MAX_RESPONSE_BYTES)} limit)`)
       }
       throw new WebfetchError(`Fetch failed: ${error.message}`)
@@ -110,9 +115,6 @@ async function fetchWithCurlImpersonate(
     throw new WebfetchError(`Fetch failed: ${message}`)
   }
 
-  if (response.httpStatus === 0) {
-    throw new WebfetchError('Fetch failed: no HTTP status returned')
-  }
   if (response.httpStatus < 200 || response.httpStatus >= 300) {
     throw new WebfetchError(`Fetch failed: HTTP ${response.httpStatus}`)
   }

--- a/src/agent/tools/webfetch/tool.test.ts
+++ b/src/agent/tools/webfetch/tool.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
+import { _setForceFallbackForTest } from './fetch'
 import { webfetchTool } from './tool'
 import type { WebfetchDetails } from './types'
 
@@ -18,10 +19,15 @@ beforeEach(() => {
     fetchCalls.push(args)
     return fetchResponse(args)
   }) as typeof fetch
+  // Force the Bun.fetch fallback transport so these tool-level tests don't
+  // accidentally hit a real curl-impersonate binary on dev/CI environments
+  // where it happens to be installed. fetch.test.ts owns curl-path coverage.
+  _setForceFallbackForTest(true)
 })
 
 afterEach(() => {
   globalThis.fetch = originalFetch
+  _setForceFallbackForTest(false)
 })
 
 const ctx = {} as Parameters<typeof webfetchTool.execute>[4]

--- a/src/agent/tools/webfetch/tool.ts
+++ b/src/agent/tools/webfetch/tool.ts
@@ -24,6 +24,10 @@ export const webfetchTool = defineTool({
   description:
     'Fetch a single HTTP(S) URL and return the body, optionally compacted by a strategy. ' +
     'Use this when the user references a specific URL or when websearch surfaced a result you need to read in full. ' +
+    'Outbound requests impersonate Chrome 136 at the TLS, HTTP/2, and header layers ' +
+    '(via curl-impersonate), which clears most TLS/header fingerprint gates (Cloudflare, Akamai). ' +
+    'Behavioural/JS challenges and IP reputation are still out of scope — a 403 from a site that requires JS execution ' +
+    'or fingerprints the client beyond the TLS layer is expected and unrecoverable from this tool. ' +
     'Strategy guide:\n' +
     '- "readability": extract article content as markdown (blogs, docs, news). Default for HTML.\n' +
     '- "jq": query JSON APIs (npm registry, GitHub API). Pass `query` (e.g. ".items[].name").\n' +

--- a/src/agent/tools/webfetch/tool.ts
+++ b/src/agent/tools/webfetch/tool.ts
@@ -25,9 +25,9 @@ export const webfetchTool = defineTool({
     'Fetch a single HTTP(S) URL and return the body, optionally compacted by a strategy. ' +
     'Use this when the user references a specific URL or when websearch surfaced a result you need to read in full. ' +
     'Outbound requests impersonate Chrome 136 at the TLS, HTTP/2, and header layers ' +
-    '(via curl-impersonate), which clears most TLS/header fingerprint gates (Cloudflare, Akamai). ' +
-    'Behavioural/JS challenges and IP reputation are still out of scope — a 403 from a site that requires JS execution ' +
-    'or fingerprints the client beyond the TLS layer is expected and unrecoverable from this tool. ' +
+    '(via curl-impersonate), which helps with TLS/header fingerprint gates on sites behind Cloudflare/Akamai. ' +
+    'It does NOT solve JavaScript challenges, behavioural fingerprinting (mouse/scroll/timing), interactive CAPTCHAs, ' +
+    'or IP-reputation blocks — a 403 from those layers is expected and unrecoverable from this tool. ' +
     'Strategy guide:\n' +
     '- "readability": extract article content as markdown (blogs, docs, news). Default for HTML.\n' +
     '- "jq": query JSON APIs (npm registry, GitHub API). Pass `query` (e.g. ".items[].name").\n' +

--- a/src/agent/tools/websearch.test.ts
+++ b/src/agent/tools/websearch.test.ts
@@ -57,8 +57,28 @@ describe('websearch tool: web (DuckDuckGo)', () => {
     _setCurlBinaryForTest(path)
   }
 
+  // Emits a body plus the per-request random sentinel + fake metadata,
+  // mirroring how a real curl-impersonate response is shaped. The sentinel
+  // is round-tripped from argv (the value of -w) because we can't predict
+  // its random value. See fetch.test.ts for the full rationale.
   function installFakePrintingBinary(body: string): void {
-    installFakeBinary(`cat <<'TYPECLAW_EOF'\n${body}\nTYPECLAW_EOF`)
+    installFakeBinary(`
+WTPL=""
+i=1
+for arg in "$@"; do
+  if [ "$arg" = "-w" ]; then
+    j=$((i + 1))
+    eval "WTPL=\\"\\\${$j}\\""
+    break
+  fi
+  i=$((i + 1))
+done
+RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/200/' -e 's|%{url_effective}|https://lite.duckduckgo.com/lite/|' -e 's|%{content_type}|text/html|' -e 's/%{size_download}/0/')
+cat <<'TYPECLAW_EOF'
+${body}
+TYPECLAW_EOF
+printf '%s' "$RENDERED"
+`)
   }
 
   test('parses DuckDuckGo HTML and returns formatted results', async () => {


### PR DESCRIPTION
## Why

`webfetch` was sending every outbound HTTP request through Bun's native `fetch()` with a static `User-Agent: typeclaw/0`. That's two layers wrong against the 2026 bot-detection stack:

1. **TLS fingerprint.** Bun can't match Chrome's TLS handshake (upstream issue [oven-sh/bun#11368](https://github.com/oven-sh/bun/issues/11368)). Cloudflare and Akamai fingerprint the handshake (JA3/JA4) and the HTTP/2 SETTINGS frame *before any HTTP header is read* — so the request is gated on Layer 1 regardless of what `User-Agent` we send.
2. **Self-outing User-Agent.** `typeclaw/0` is a confession that this is a bot.

Empirically this manifests as 401/403 on Reuters, MarketWatch, and similar sites — exactly the sites a user would naturally ask the agent to read.

The agent already runs from the user's home network, so the outbound IP is residential — the resource managed scrapers charge $10/GB for. The only missing piece is making the request *look like Chrome at every layer*. We were already doing that for DuckDuckGo via `curl-impersonate` (lexiforest fork) — pinned in the Dockerfile, wired into `ddg.ts`. This PR extracts that into a shared primitive and routes `webfetch` through it.

This is explicitly **best-effort, no browser**. JavaScript-gated or behavioural-fingerprint sites (Bloomberg's Custom WAF, Cloudflare Enterprise's interactive challenges) are still out of scope — solving those needs a stealth browser, which is a much bigger architectural shift. The tool description tells the model this so it doesn't waste turns retrying unrecoverable 403s.

## What

### New: `src/agent/tools/curl-impersonate.ts`

Shared spawn-out-to-`curl_chrome136` primitive. Single entry point `curlImpersonate(req)` that returns `{ body, finalUrl, httpStatus, contentType, bytesIn }`. Owns:

- The `Bun.spawn(['curl_chrome136', ...])` call with the same `detached: true` + negative-PID kill choreography that `ddg.ts` already did (without it, SIGKILL on the wrapper script orphans the curl child and `--max-time` takes 30s to fire).
- Out-of-band metadata retrieval via curl's `-w` write-out template. We append a sentinel-prefixed metadata block (`status\nfinal_url\ncontent_type\nsize\n`) after the body, then split at the sentinel. The sentinel is a long ASCII tag with a UUID-shaped suffix — null-byte-free because Bun's spawn rejects NULs in argv.
- Caller-decides-on-status policy. `--fail-with-body` is deliberately *not* passed: curl exits 0 on a 404 with body, and callers (`webfetch`, `ddg`) translate that into their own error shapes.
- `isCurlImpersonateAvailable()` runtime detection, cached per-process. Used by `fetch.ts` to fall back to Bun.fetch when the binary isn't installed (test/dev environments).

### Refactored: `src/agent/tools/ddg.ts`

Now a thin wrapper over `curlImpersonate`. All the spawn / process-group / sentinel logic moves into the shared module; `ddg.ts` keeps only the DDG-specific concerns (lite endpoint URL, query encoding, CAPTCHA detection, SERP parsing, redirect-URL unwrap). Re-exports `_setCurlBinaryForTest` so `ddg.test.ts`'s existing test seam keeps working — no test changes needed.

### Rewritten: `src/agent/tools/webfetch/fetch.ts`

`fetchWithLimits` now dispatches between two paths based on `isCurlImpersonateAvailable()`:

- **Production** (container, binary on PATH): goes through `curlImpersonate`. Maps curl errors back into the existing `WebfetchError` contract — `--max-time` stderr becomes `"Request timed out after Xs"`, exit 63 (`--max-filesize` overflow) becomes `"Response too large …"`, non-2xx becomes `"Fetch failed: HTTP NNN"`. Existing callers see no behaviour change other than success rate going up.
- **Test/dev** (binary missing): falls back to the original Bun-fetch path, untouched. This keeps unit tests on developer macOS machines working without forcing every contributor to install curl-impersonate locally.

A test-only seam `_setForceFallbackForTest(true)` lets `fetch.test.ts` keep its existing mocked-`globalThis.fetch` contract for the 7 fallback-path tests, while a new 3-test block exercises the curl path end-to-end with a fake-binary script in `mkdtemp` (same pattern as `ddg.test.ts`, per AGENTS.md §5 "Real implementations with controlled inputs").

### Updated: `src/agent/tools/webfetch/tool.ts`

Tool description now mentions Chrome 136 impersonation and the load-bearing caveat: behavioural / JS-gated sites are unrecoverable. This is what stops the model from burning turns retrying a Bloomberg 403.

## Scope

- 2 new files (`curl-impersonate.ts` + its test).
- 4 modified files (`ddg.ts` slims down, `webfetch/fetch.{ts,test.ts}`, `webfetch/tool.ts`).
- No changes to: the Dockerfile (curl-impersonate was already pinned), the SSRF policy (runs at tool-args level, transport-agnostic), the channel adapters (they own their own auth and stay separate per AGENTS.md), or any other tool.
- No new dependencies. No new config knobs.

## Verification

```
bun run typecheck   ✓  clean
bun run lint        ✓  0 errors (17 pre-existing warnings in unrelated files)
bun run format      ✓  clean
bun test            ✓  4194 pass / 0 fail (was 4178 pre-PR)
```

The 16 new tests:

- `curl-impersonate.test.ts` — 13 tests covering sentinel parsing, sentinel-absent fallback, 404-with-body, exit-code propagation, argv shape (method/form/headers/redirects/max-bytes), abort, and availability caching.
- `webfetch/fetch.test.ts` — 3 new tests in a "curl-impersonate path" block: success path, non-2xx translation, fallback-when-missing. Plus the existing 7 fallback-path tests still green.

`ddg.test.ts` is unchanged — the refactor preserves its public contract (re-exports `_setCurlBinaryForTest`, `fetchDdgHtml` returns the same string shape).

## Honest tradeoffs

1. **Best-effort, not bulletproof.** Cloudflare and Akamai update detection models every 2–4 weeks. The Chrome 136 fingerprint that works today will eventually drift. Mitigation: `CURL_IMPERSONATE_VERSION` / `CURL_IMPERSONATE_PROFILE` already exist as Dockerfile constants — bumping the pinned version is a one-line change that auto-rebuilds via the existing `refreshDockerfile` content-diff check.

2. **JS-gated sites are unrecoverable from this tool.** Bloomberg's Custom WAF, Cloudflare Enterprise's interactive challenges, anything that requires canvas/WebGL fingerprinting — `webfetch` will get a 403 and surface it. The tool description warns the model so it doesn't retry. Solving that needs a stealth browser (Camoufox/Patchright + residential sticky proxies), which is a separate architectural conversation.

3. **The two-path dispatch is a real branch in production behaviour.** `isCurlImpersonateAvailable()` is cached per-process — if the binary disappears mid-run (e.g. mid-flight `apt remove`), we'll keep using the stale `true` and start failing all webfetches. This is acceptable because (a) the binary is installed by the Dockerfile and lives in the read-only image layer, (b) production containers don't mutate it, and (c) the failure mode is "every webfetch errors clearly" not "every webfetch hangs."

4. **No header / cookie state across requests.** This PR does not add a cross-request cookie jar. Akamai's `_abck` cookie dance works *within* a single redirect chain (curl's `-L` handles that), but multi-step authenticated flows would need a persistent jar — out of scope here, additive later if a real need shows up.

5. **No proxy rotation.** Discussed and explicitly deferred. The residential-IP-from-home assumption removes the *need* for rotation for the target sites, and rotating *would* break Akamai's session continuity (a single home IP across a session beats N random residential IPs from a pool for the `_abck` use case). If a future user wants to BYO proxy, the natural seam is a single env var / config field on the `curl-impersonate` primitive, additive.

## Out of scope

- Stealth browser fallback for Bloomberg.
- Cross-request cookie persistence.
- BYO proxy support.
- Header / Accept-Language tuning based on user locale.
- Migrating `wikipedia.ts` and `multimodal/looker.ts` (the other Bun.fetch callers) onto the same primitive — they hit well-behaved APIs that don't fingerprint, so the cost/benefit isn't there. The primitive is now available if that changes.