### PR TITLE
models: per-profile fallback chain with cron-side retry

### DIFF
--- a/src/agent/auth.ts
+++ b/src/agent/auth.ts
@@ -83,8 +83,10 @@ export function getAuthFor(providerId: KnownProviderId): Auth {
 
 // Back-compat shim for callers that still want the `default` profile's auth
 // (the main session path). Equivalent to `getAuthFor(provider-of-default)`.
+// Uses the head of the fallback chain; auth for the rest of the chain is
+// resolved lazily when fallback actually fires.
 export function getAuth(): Auth {
-  const defaultRef = getConfig().models.default
+  const defaultRef = getConfig().models.default[0]!
   return getAuthFor(providerForModelRef(defaultRef))
 }
 
@@ -98,7 +100,7 @@ function hasAnyCredentialInEnv(apiKeyEnv: string | null): boolean {
 
 function missingCredentialMessage(providerId: KnownProviderId): string {
   const provider = KNOWN_PROVIDERS[providerId]
-  const defaultRef = getConfig().models.default
+  const defaultRef = getConfig().models.default[0]!
   const defaultProviderId = providerForModelRef(defaultRef)
   // For the `default` profile, name the model in the error message (matches
   // pre-multi-model behavior). For any other profile, the user is mixing

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -8,7 +8,7 @@ import type { AgentSession, ToolDefinition } from '@mariozechner/pi-coding-agent
 import { loadMemory } from '@/bundled-plugins/memory/load-memory'
 import type { ChannelRouter } from '@/channels/router'
 import { getConfig, resolveModel, resolveProfile } from '@/config'
-import { providerForModelRef } from '@/config/providers'
+import { providerForModelRef, type KnownModelRef } from '@/config/providers'
 import type { PermissionService } from '@/permissions'
 import type {
   BuiltinToolRef,
@@ -134,6 +134,12 @@ export type CreateSessionOptions = {
   // overrides) so different sessions on the same agent can run different
   // models without per-session config edits.
   profile?: string
+  // Override the resolved ref directly, bypassing `profile` resolution. Used
+  // by the model-fallback helper (`promptWithFallback`) to recreate a session
+  // pinned to the next ref in the chain after the previous one failed. When
+  // set, `profile` is still recorded for the fallback-warning bookkeeping;
+  // the profile→refs resolution is skipped.
+  refOverride?: KnownModelRef
   // Defensive ceiling on cumulative bytes of tool-result text per session,
   // applied to the named tools only. See `src/agent/tool-result-budget.ts`
   // for the rationale. Intended for subagents that read large files
@@ -164,7 +170,10 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
   if (resolved.fellBackToDefault && options.profile !== undefined && options.profile !== 'default') {
     warnProfileFallbackOnce(options.profile, resolved.ref)
   }
-  const { authStorage, modelRegistry } = getAuthFor(providerForModelRef(resolved.ref))
+  // `refOverride` lets the model-fallback helper pin a specific entry from
+  // the chain when it recreates a session after the previous ref failed.
+  const activeRef: KnownModelRef = options.refOverride ?? resolved.ref
+  const { authStorage, modelRegistry } = getAuthFor(providerForModelRef(activeRef))
 
   const materializedSkills =
     options.plugins && options.plugins.registry.skills.length > 0
@@ -279,7 +288,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
       ? customToolsPreBudget.map((t) => wrapToolDefinitionWithBudget(t, sessionBudget, sessionBudgetState))
       : customToolsPreBudget
 
-  const model = resolveModel(resolved.ref)
+  const model = resolveModel(activeRef)
   const { session } = await createAgentSession({
     model,
     sessionManager,

--- a/src/agent/model-fallback.test.ts
+++ b/src/agent/model-fallback.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { Models } from '@/config/config'
+import type { KnownModelRef } from '@/config/providers'
+
+import type { AgentSession } from './index'
+import { promptWithFallback, resolveFallbackChain } from './model-fallback'
+
+const REF_A = 'openai/gpt-5.4-nano' as KnownModelRef
+const REF_B = 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' as KnownModelRef
+const REF_C = 'zai/glm-4.6' as KnownModelRef
+
+type SessionFake = {
+  ref: KnownModelRef
+  prompt: (text: string) => Promise<void>
+  // The subscribe field accepts the event callback shape AgentSession uses
+  // for `message_end`. We hand-roll it to simulate soft-error emission
+  // without standing up a real pi-coding-agent session.
+  emitSoftError: (msg: string) => void
+  disposed: boolean
+  promptedWith: string[]
+}
+
+function fakeSession(opts: {
+  ref: KnownModelRef
+  behavior: 'success' | 'throw' | 'soft-error'
+  errorMessage?: string
+}): { session: AgentSession; fake: SessionFake } {
+  const listeners: Array<(event: { type: string; message?: unknown }) => void> = []
+  const fake: SessionFake = {
+    ref: opts.ref,
+    promptedWith: [],
+    disposed: false,
+    emitSoftError: (msg) => {
+      for (const l of listeners) {
+        l({
+          type: 'message_end',
+          message: { role: 'assistant', stopReason: 'error', errorMessage: msg },
+        })
+      }
+    },
+    prompt: async (text: string) => {
+      fake.promptedWith.push(text)
+      if (opts.behavior === 'throw') {
+        throw new Error(opts.errorMessage ?? `hard failure on ${opts.ref}`)
+      }
+      if (opts.behavior === 'soft-error') {
+        fake.emitSoftError(opts.errorMessage ?? `soft failure on ${opts.ref}`)
+      }
+      // success — no event needed by the helper, the listener only fires
+      // on soft errors so a clean turn looks like "prompt resolves with
+      // no events observed".
+    },
+  }
+  const session = {
+    prompt: fake.prompt,
+    subscribe: (cb: (event: { type: string; message?: unknown }) => void) => {
+      listeners.push(cb)
+      return () => {
+        const idx = listeners.indexOf(cb)
+        if (idx >= 0) listeners.splice(idx, 1)
+      }
+    },
+  } as unknown as AgentSession
+  return { session, fake }
+}
+
+describe('resolveFallbackChain', () => {
+  test('returns single-element chain for single-ref profile', () => {
+    const models: Models = { default: [REF_A] }
+    expect(resolveFallbackChain(models, undefined)).toEqual([REF_A])
+    expect(resolveFallbackChain(models, 'default')).toEqual([REF_A])
+  })
+
+  test('returns multi-element chain for multi-ref profile', () => {
+    const models: Models = { default: [REF_A, REF_B, REF_C] }
+    expect(resolveFallbackChain(models, undefined)).toEqual([REF_A, REF_B, REF_C])
+  })
+
+  test('falls back to default chain for unknown profile', () => {
+    const models: Models = { default: [REF_A, REF_B] }
+    expect(resolveFallbackChain(models, 'nonexistent')).toEqual([REF_A, REF_B])
+  })
+
+  test('returns the named profile chain when defined', () => {
+    const models: Models = { default: [REF_A], fast: [REF_B, REF_C] }
+    expect(resolveFallbackChain(models, 'fast')).toEqual([REF_B, REF_C])
+  })
+})
+
+describe('promptWithFallback', () => {
+  test('returns success on the first ref when it works', async () => {
+    const created: SessionFake[] = []
+    const result = await promptWithFallback({
+      refs: [REF_A, REF_B],
+      text: 'hello',
+      createSessionForRef: async (ref) => {
+        const { session, fake } = fakeSession({ ref, behavior: 'success' })
+        created.push(fake)
+        return { session, dispose: async () => void (fake.disposed = true) }
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(REF_A)
+    expect(result.attempts).toEqual([{ ref: REF_A, outcome: 'success' }])
+    expect(created).toHaveLength(1)
+    expect(created[0]!.promptedWith).toEqual(['hello'])
+    expect(created[0]!.disposed).toBe(false)
+  })
+
+  test('falls through to the next ref when the first throws', async () => {
+    const created: SessionFake[] = []
+    const result = await promptWithFallback({
+      refs: [REF_A, REF_B],
+      text: 'hello',
+      createSessionForRef: async (ref) => {
+        const { session, fake } = fakeSession({
+          ref,
+          behavior: ref === REF_A ? 'throw' : 'success',
+          errorMessage: 'rate limited',
+        })
+        created.push(fake)
+        return { session, dispose: async () => void (fake.disposed = true) }
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(REF_B)
+    expect(result.attempts).toEqual([
+      { ref: REF_A, outcome: 'hard', errorMessage: 'rate limited' },
+      { ref: REF_B, outcome: 'success' },
+    ])
+    expect(created).toHaveLength(2)
+    expect(created[0]!.disposed).toBe(true)
+    expect(created[1]!.disposed).toBe(false)
+    expect(created[1]!.promptedWith).toEqual(['hello'])
+  })
+
+  test('falls through on a soft (stopReason: error) failure', async () => {
+    const created: SessionFake[] = []
+    const result = await promptWithFallback({
+      refs: [REF_A, REF_B],
+      text: 'hello',
+      createSessionForRef: async (ref) => {
+        const { session, fake } = fakeSession({
+          ref,
+          behavior: ref === REF_A ? 'soft-error' : 'success',
+          errorMessage: 'billing required',
+        })
+        created.push(fake)
+        return { session, dispose: async () => void (fake.disposed = true) }
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(REF_B)
+    expect(result.attempts).toEqual([
+      { ref: REF_A, outcome: 'soft', errorMessage: 'billing required' },
+      { ref: REF_B, outcome: 'success' },
+    ])
+    expect(created[0]!.disposed).toBe(true)
+    expect(created[1]!.disposed).toBe(false)
+  })
+
+  test('reports success: false when every ref in the chain fails', async () => {
+    const failures: string[] = []
+    const created: SessionFake[] = []
+    const result = await promptWithFallback({
+      refs: [REF_A, REF_B, REF_C],
+      text: 'hello',
+      onAttemptFailed: (attempt) => failures.push(`${attempt.outcome}:${attempt.ref}`),
+      createSessionForRef: async (ref) => {
+        const { session, fake } = fakeSession({
+          ref,
+          behavior: 'throw',
+          errorMessage: `down: ${ref}`,
+        })
+        created.push(fake)
+        return { session, dispose: async () => void (fake.disposed = true) }
+      },
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.refUsed).toBe(REF_C)
+    expect(result.attempts.map((a) => a.outcome)).toEqual(['hard', 'hard', 'hard'])
+    expect(result.lastError?.message).toBe('down: zai/glm-4.6')
+    expect(created.every((c) => c.disposed)).toBe(true)
+    // onAttemptFailed fires for every non-final attempt; the final attempt
+    // is reflected through the returned `success: false` instead so callers
+    // don't double-log.
+    expect(failures).toEqual([`hard:${REF_A}`, `hard:${REF_B}`])
+  })
+
+  test('skips fallback when a single-ref chain hard-fails (still returns success: false)', async () => {
+    const result = await promptWithFallback({
+      refs: [REF_A],
+      text: 'hello',
+      createSessionForRef: async (ref) => {
+        const { session, fake } = fakeSession({ ref, behavior: 'throw', errorMessage: 'oops' })
+        return { session, dispose: async () => void (fake.disposed = true) }
+      },
+    })
+    expect(result.success).toBe(false)
+    expect(result.attempts).toEqual([{ ref: REF_A, outcome: 'hard', errorMessage: 'oops' }])
+    expect(result.lastError?.message).toBe('oops')
+  })
+
+  test('rejects an empty refs array', async () => {
+    await expect(
+      promptWithFallback({
+        refs: [],
+        text: 'hello',
+        createSessionForRef: async () => {
+          throw new Error('should not be called')
+        },
+      }),
+    ).rejects.toThrow('refs[] must be non-empty')
+  })
+
+  test('preserves the prompt text across retries (no text mutation between attempts)', async () => {
+    const seen: string[] = []
+    await promptWithFallback({
+      refs: [REF_A, REF_B],
+      text: 'do the thing',
+      createSessionForRef: async (ref) => {
+        const { session, fake } = fakeSession({
+          ref,
+          behavior: ref === REF_A ? 'throw' : 'success',
+        })
+        return {
+          session,
+          dispose: async () => {
+            seen.push(`${ref}:${fake.promptedWith.join('|')}`)
+          },
+        }
+      },
+    })
+    // First session got 'do the thing' before disposal; the second one was
+    // successful (no dispose call from the helper, since the caller holds it).
+    expect(seen).toEqual([`${REF_A}:do the thing`])
+  })
+})

--- a/src/agent/model-fallback.test.ts
+++ b/src/agent/model-fallback.test.ts
@@ -184,6 +184,7 @@ describe('promptWithFallback', () => {
     expect(result.success).toBe(false)
     expect(result.refUsed).toBe(REF_C)
     expect(result.attempts.map((a) => a.outcome)).toEqual(['hard', 'hard', 'hard'])
+    expect(result.attempts.map((a) => a.ref)).toEqual([REF_A, REF_B, REF_C])
     expect(result.lastError?.message).toBe('down: zai/glm-4.6')
     expect(created.every((c) => c.disposed)).toBe(true)
     // onAttemptFailed fires for every non-final attempt; the final attempt

--- a/src/agent/model-fallback.ts
+++ b/src/agent/model-fallback.ts
@@ -1,0 +1,127 @@
+import { resolveProfile } from '@/config'
+import type { Models } from '@/config/config'
+import type { KnownModelRef } from '@/config/providers'
+
+import type { AgentSession } from './index'
+import { subscribeProviderErrors } from './provider-error'
+
+// Result of a single fallback-aware prompt run.
+// - `refUsed` is the ref whose session ultimately handled the turn.
+// - `attempts` lists every ref that was tried, in order, with the failure
+//   reason for each attempt that didn't make it through. `attempts.length`
+//   is always >= 1; the last entry succeeded iff `success: true`.
+// - `session` / `dispose` are the session that handled the turn (or attempted
+//   the final entry, on full-chain failure). Callers that need to keep using
+//   the session for subsequent turns store these in their state; callers that
+//   tear down per-turn (cron) just call `dispose()` and discard.
+export type FallbackPromptResult = {
+  success: boolean
+  refUsed: KnownModelRef
+  attempts: FallbackAttempt[]
+  session: AgentSession
+  dispose: () => Promise<void>
+  // When `success === false`, this is the error from the final attempt.
+  lastError?: Error
+}
+
+export type FallbackAttempt = {
+  ref: KnownModelRef
+  // 'hard' = session.prompt() threw. 'soft' = pi-coding-agent surfaced an
+  // upstream error via stopReason: 'error' on the final assistant message.
+  // 'success' = the turn finished cleanly.
+  outcome: 'hard' | 'soft' | 'success'
+  errorMessage?: string
+}
+
+// Build the ordered list of refs to attempt for a given profile. Single-ref
+// profiles produce a length-1 chain; the fallback path is then a no-op in
+// practice (the first attempt either succeeds or the error propagates).
+//
+// Exported so callers can introspect the chain (e.g. logs, telemetry) before
+// firing the prompt — useful for `[cron] ${jobId}: trying chain a → b → c`.
+export function resolveFallbackChain(models: Models, profile: string | undefined): KnownModelRef[] {
+  return resolveProfile(models, profile).refs
+}
+
+// Drives one `session.prompt(text)` call with full fallback semantics:
+//
+//   1. Create a session bound to `refs[0]` via `createSessionForRef`.
+//   2. Subscribe to provider-error events so soft errors (pi-coding-agent's
+//      `stopReason: 'error'` shape) trigger fallback in addition to throws.
+//   3. Await `session.prompt(text)`.
+//   4. If the prompt threw OR a soft error fired during the turn:
+//      - dispose the failed session
+//      - advance to `refs[i+1]` and retry (only if a fallback is available)
+//   5. Return the session that handled the turn (or the last-tried session
+//      on full-chain failure), the ref used, and the attempt log.
+//
+// The wrapper intentionally does NOT swallow the final failure: when every
+// ref in the chain has been exhausted, the returned `success: false` plus
+// `lastError` lets the caller surface the failure however it already does
+// (console.error in the server drain, channel reaction in the router,
+// cron-job status). This keeps the helper composable with the existing
+// error-handling code at each call site.
+export async function promptWithFallback(opts: {
+  refs: KnownModelRef[]
+  text: string
+  createSessionForRef: (ref: KnownModelRef) => Promise<{ session: AgentSession; dispose: () => Promise<void> }>
+  // Called after each non-final attempt so callers can log the per-attempt
+  // failure with their own context (sessionId, channel key, job id, ...).
+  onAttemptFailed?: (attempt: FallbackAttempt) => void
+}): Promise<FallbackPromptResult> {
+  if (opts.refs.length === 0) {
+    throw new Error('promptWithFallback: refs[] must be non-empty')
+  }
+  const attempts: FallbackAttempt[] = []
+  let lastError: Error | undefined
+  for (let i = 0; i < opts.refs.length; i++) {
+    const ref = opts.refs[i]!
+    const isLast = i === opts.refs.length - 1
+    const { session, dispose } = await opts.createSessionForRef(ref)
+    // Capture the first soft error per attempt. The `subscribeProviderErrors`
+    // listener fires synchronously off the `message_end` event, which lands
+    // BEFORE `session.prompt()` resolves — so by the time `await` returns,
+    // `softError` is populated if a soft error occurred.
+    let softError: Error | undefined
+    const unsub = subscribeProviderErrors(session, (err) => {
+      if (!softError) softError = new Error(err.message)
+    })
+    try {
+      try {
+        await session.prompt(opts.text)
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err))
+        const attempt: FallbackAttempt = { ref, outcome: 'hard', errorMessage: error.message }
+        attempts.push(attempt)
+        lastError = error
+        if (!isLast) opts.onAttemptFailed?.(attempt)
+        unsub()
+        await dispose()
+        if (isLast) {
+          return { success: false, refUsed: ref, attempts, session, dispose: async () => {}, lastError }
+        }
+        continue
+      }
+      if (softError !== undefined) {
+        const attempt: FallbackAttempt = { ref, outcome: 'soft', errorMessage: softError.message }
+        attempts.push(attempt)
+        lastError = softError
+        if (!isLast) opts.onAttemptFailed?.(attempt)
+        unsub()
+        await dispose()
+        if (isLast) {
+          return { success: false, refUsed: ref, attempts, session, dispose: async () => {}, lastError }
+        }
+        continue
+      }
+      attempts.push({ ref, outcome: 'success' })
+      unsub()
+      return { success: true, refUsed: ref, attempts, session, dispose }
+    } catch (err) {
+      unsub()
+      await dispose()
+      throw err
+    }
+  }
+  throw new Error('promptWithFallback: unreachable — loop terminated without returning')
+}

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -157,15 +157,23 @@ const listSub = defineCommand({
     }
 
     const profileWidth = Math.max(7, ...entries.map((e) => e.profile.length))
-    const refWidth = Math.max(3, ...entries.map((e) => e.ref.length))
+    const refDisplay = (e: (typeof entries)[number]): string =>
+      e.refs.length > 1 ? `${e.ref} ${c.dim(`(+${e.refs.length - 1} fallback)`)}` : e.ref
+    const refWidth = Math.max(3, ...entries.map((e) => e.ref.length + (e.refs.length > 1 ? 14 : 0)))
 
     const header = `${'PROFILE'.padEnd(profileWidth)}  ${'REF'.padEnd(refWidth)}  PROVIDER  STATUS`
     console.log(c.dim(header))
     for (const e of entries) {
       const star = e.isDefault ? c.cyan('*') : ' '
       const status = e.credentialStatus === 'available' ? c.green('ok') : c.yellow('missing-credentials')
-      const line = `${star}${e.profile.padEnd(profileWidth - 1)}  ${e.ref.padEnd(refWidth)}  ${e.providerId.padEnd(12)}  ${status}`
+      const line = `${star}${e.profile.padEnd(profileWidth - 1)}  ${refDisplay(e).padEnd(refWidth)}  ${e.providerId.padEnd(12)}  ${status}`
       console.log(line)
+      if (e.refs.length > 1) {
+        for (let i = 1; i < e.refs.length; i++) {
+          const fb = e.refs[i]!
+          console.log(`${' '.padEnd(profileWidth + 2)}↳ ${c.dim(fb)}`)
+        }
+      }
     }
   },
 })

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -78,6 +78,17 @@ describe('configSchema models field', () => {
   test('rejects empty profile names', () => {
     expect(() => configSchema.parse({ models: { '': VALID_MODEL } })).toThrow()
   })
+
+  test('rejects exact duplicate refs in a chain (config typo)', () => {
+    expect(() => configSchema.parse({ models: { default: [VALID_MODEL, VALID_MODEL] } })).toThrow(/duplicate/i)
+  })
+
+  test('accepts different models from the same provider in a chain', () => {
+    const parsed = configSchema.parse({
+      models: { default: ['openai/gpt-5.4-nano', 'openai/gpt-5.4-mini'] },
+    })
+    expect(parsed.models.default).toEqual(['openai/gpt-5.4-nano', 'openai/gpt-5.4-mini'])
+  })
 })
 
 describe('resolveProfile', () => {

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -25,39 +25,54 @@ const VALID_MODEL = 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'
 const VALID_MODEL_2 = 'openai/gpt-5.4-nano'
 
 describe('configSchema models field', () => {
-  test('defaults to { default: <DEFAULT_MODEL_REF> } when omitted', () => {
+  test('defaults to { default: [<DEFAULT_MODEL_REF>] } when omitted', () => {
     const parsed = configSchema.parse({})
-    expect(parsed.models).toEqual({ default: 'openai/gpt-5.4-nano' })
+    expect(parsed.models).toEqual({ default: ['openai/gpt-5.4-nano'] })
   })
 
-  test('accepts a single-key models map (just default)', () => {
+  test('normalises a single-ref string input to a one-element array', () => {
     const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
-    expect(parsed.models).toEqual({ default: VALID_MODEL })
+    expect(parsed.models).toEqual({ default: [VALID_MODEL] })
   })
 
-  test('accepts multiple profiles', () => {
+  test('accepts multiple profiles in either shape and normalises both', () => {
     const parsed = configSchema.parse({
-      models: { default: VALID_MODEL, fast: VALID_MODEL_2, deep: VALID_MODEL, vision: VALID_MODEL_2 },
+      models: { default: VALID_MODEL, fast: [VALID_MODEL_2], deep: VALID_MODEL, vision: VALID_MODEL_2 },
     })
-    expect(parsed.models.default).toBe(VALID_MODEL)
-    expect(parsed.models.fast).toBe(VALID_MODEL_2)
-    expect(parsed.models.deep).toBe(VALID_MODEL)
-    expect(parsed.models.vision).toBe(VALID_MODEL_2)
+    expect(parsed.models.default).toEqual([VALID_MODEL])
+    expect(parsed.models.fast).toEqual([VALID_MODEL_2])
+    expect(parsed.models.deep).toEqual([VALID_MODEL])
+    expect(parsed.models.vision).toEqual([VALID_MODEL_2])
+  })
+
+  test('accepts a fallback chain as an array', () => {
+    const parsed = configSchema.parse({
+      models: { default: [VALID_MODEL, VALID_MODEL_2] },
+    })
+    expect(parsed.models.default).toEqual([VALID_MODEL, VALID_MODEL_2])
   })
 
   test('accepts user-defined profile names alongside well-known ones', () => {
     const parsed = configSchema.parse({
       models: { default: VALID_MODEL, 'cheap-batch': VALID_MODEL_2 },
     })
-    expect(parsed.models['cheap-batch']).toBe(VALID_MODEL_2)
+    expect(parsed.models['cheap-batch']).toEqual([VALID_MODEL_2])
   })
 
   test('rejects models map without default', () => {
     expect(() => configSchema.parse({ models: { fast: VALID_MODEL } })).toThrow()
   })
 
-  test('rejects unknown model refs', () => {
+  test('rejects unknown model refs (string shape)', () => {
     expect(() => configSchema.parse({ models: { default: 'not-a-real-model' } })).toThrow()
+  })
+
+  test('rejects unknown model refs inside a chain', () => {
+    expect(() => configSchema.parse({ models: { default: [VALID_MODEL, 'not-a-real-model'] } })).toThrow()
+  })
+
+  test('rejects empty arrays', () => {
+    expect(() => configSchema.parse({ models: { default: [] } })).toThrow()
   })
 
   test('rejects empty profile names', () => {
@@ -66,11 +81,12 @@ describe('configSchema models field', () => {
 })
 
 describe('resolveProfile', () => {
-  const models: Models = { default: VALID_MODEL, fast: VALID_MODEL_2 }
+  const models: Models = { default: [VALID_MODEL], fast: [VALID_MODEL_2] }
 
   test('returns the requested profile when present', () => {
     const result = resolveProfile(models, 'fast')
     expect(result.ref).toBe(VALID_MODEL_2)
+    expect(result.refs).toEqual([VALID_MODEL_2])
     expect(result.profile).toBe('fast')
     expect(result.fellBackToDefault).toBe(false)
   })
@@ -78,6 +94,7 @@ describe('resolveProfile', () => {
   test('returns default when name is undefined', () => {
     const result = resolveProfile(models, undefined)
     expect(result.ref).toBe(VALID_MODEL)
+    expect(result.refs).toEqual([VALID_MODEL])
     expect(result.profile).toBe('default')
     expect(result.fellBackToDefault).toBe(false)
   })
@@ -85,6 +102,7 @@ describe('resolveProfile', () => {
   test('returns default when name is "default"', () => {
     const result = resolveProfile(models, 'default')
     expect(result.ref).toBe(VALID_MODEL)
+    expect(result.refs).toEqual([VALID_MODEL])
     expect(result.profile).toBe('default')
     expect(result.fellBackToDefault).toBe(false)
   })
@@ -92,7 +110,22 @@ describe('resolveProfile', () => {
   test('falls back to default when requested profile is missing, flagging the fallback', () => {
     const result = resolveProfile(models, 'deep')
     expect(result.ref).toBe(VALID_MODEL)
+    expect(result.refs).toEqual([VALID_MODEL])
     expect(result.profile).toBe('default')
+    expect(result.fellBackToDefault).toBe(true)
+  })
+
+  test('exposes the full chain when the profile is a multi-ref fallback', () => {
+    const chain: Models = { default: [VALID_MODEL, VALID_MODEL_2] }
+    const result = resolveProfile(chain, 'default')
+    expect(result.ref).toBe(VALID_MODEL)
+    expect(result.refs).toEqual([VALID_MODEL, VALID_MODEL_2])
+  })
+
+  test('inherits the default chain when falling back, preserving every fallback ref', () => {
+    const chain: Models = { default: [VALID_MODEL, VALID_MODEL_2] }
+    const result = resolveProfile(chain, 'deep')
+    expect(result.refs).toEqual([VALID_MODEL, VALID_MODEL_2])
     expect(result.fellBackToDefault).toBe(true)
   })
 })
@@ -595,7 +628,10 @@ describe('migrateLegacyConfigShape', () => {
       await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ model: VALID_MODEL, port: 9001 }))
 
       const cfg = loadConfigSync(cwd)
-      expect(cfg.models).toEqual({ default: VALID_MODEL })
+      // Parsed value is normalised to KnownModelRef[]; on-disk shape remains
+      // the user-friendly single string the migration writes (the schema
+      // accepts both shapes transparently).
+      expect(cfg.models).toEqual({ default: [VALID_MODEL] })
 
       const onDisk = JSON.parse(await Bun.file(join(cwd, 'typeclaw.json')).text())
       expect(onDisk).not.toHaveProperty('model')

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -299,7 +299,20 @@ const tunnelsArraySchema = z
 // on first load (and writes the result back to disk + commits via
 // `persistMigratedConfig`), so every downstream consumer sees the new shape.
 const modelRefOrChainSchema = z
-  .union([z.enum(knownModelRefs), z.array(z.enum(knownModelRefs)).min(1)])
+  .union([
+    z.enum(knownModelRefs),
+    z
+      .array(z.enum(knownModelRefs))
+      .min(1)
+      // Reject exact duplicates in a chain — retrying the same ref after the
+      // same class of failure is almost certainly a config typo, and silently
+      // deduping would mask user intent. Different models from the same
+      // provider (e.g. `["openai/gpt-5.4-nano", "openai/gpt-5.4-mini"]`) are
+      // still valid because they hit distinct upstream endpoints.
+      .refine((arr) => new Set(arr).size === arr.length, {
+        message: 'models chain must not contain duplicate refs',
+      }),
+  ])
   .transform((value) => (Array.isArray(value) ? value : [value]))
 export const modelsSchema = z
   .record(z.string().min(1), modelRefOrChainSchema)

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -278,32 +278,37 @@ const tunnelsArraySchema = z
     }
   })
 
-// `models` is a map from profile name to a single curated model ref. The
+// `models` maps a profile name to one or more curated model refs. The
 // `default` profile is mandatory; every other profile is optional and falls
 // back to `default` at resolution time (see `resolveProfile`).
 //
+// Each value is either a single `KnownModelRef` or a non-empty array of refs
+// forming a fallback chain: when a turn against the first ref fails (hard
+// throw or a soft provider error), the runtime disposes the failed session
+// and replays the same prompt against the next ref. Schema accepts both
+// shapes for ergonomics; the parsed value is always normalised to a
+// non-empty array so downstream consumers read a uniform `KnownModelRef[]`.
+//
 // Profile names are open strings; the runtime recognizes a handful of
 // well-known names by convention (`default`, `fast`, `deep`, `vision`) but
-// any string is valid. Subagents may declare a static profile preference;
-// callers may override per-spawn. Unknown profile names resolve to `default`
-// with a one-time warning at session construction.
+// any string is valid. Unknown profile names resolve to `default` with a
+// one-time warning at session construction.
 //
 // The pre-multi-model schema had a single `model: KnownModelRef` at the top
 // level. `migrateLegacyConfigShape` rewrites that to `models: { default: ... }`
 // on first load (and writes the result back to disk + commits via
 // `persistMigratedConfig`), so every downstream consumer sees the new shape.
+const modelRefOrChainSchema = z
+  .union([z.enum(knownModelRefs), z.array(z.enum(knownModelRefs)).min(1)])
+  .transform((value) => (Array.isArray(value) ? value : [value]))
 export const modelsSchema = z
-  .record(z.string().min(1), z.enum(knownModelRefs))
+  .record(z.string().min(1), modelRefOrChainSchema)
   .refine((m) => 'default' in m, { message: 'models.default is required' })
 
-// Zod's `z.record(..., refine)` doesn't refine the inferred type — the inferred
-// shape is `Record<string, KnownModelRef>` where every access is `T | undefined`.
-// The runtime guarantee (the `refine` above) is that `default` is present, so
-// we narrow the type here. Every consumer (auth.ts, agent/index.ts,
-// resolveProfile) reads `models.default` on the hot path; without this
-// narrowing they all have to assert or `?? throw`, which is noise around an
-// invariant the schema already enforces.
-export type Models = Record<string, KnownModelRef> & { default: KnownModelRef }
+// Zod's `z.record(..., refine)` doesn't refine the inferred type. The
+// `default` key is schema-enforced, so we narrow it here to spare every
+// consumer the `T | undefined` assertion noise.
+export type Models = Record<string, KnownModelRef[]> & { default: KnownModelRef[] }
 
 export const configSchema = z
   .object({
@@ -311,8 +316,10 @@ export const configSchema = z
     port: z.number().int().min(1).max(65535).default(DEFAULT_PORT),
     // `default(() => ...)` ensures every parsed config has at least
     // `models.default`. Direct `.default({ default: ... })` would short-circuit
-    // the refinement, so we lean on the lazy thunk form.
-    models: modelsSchema.default(() => ({ default: DEFAULT_MODEL_REF })) as unknown as z.ZodType<Models>,
+    // the refinement, so we lean on the lazy thunk form. The default value is
+    // shaped to match the post-transform output (always `KnownModelRef[]`),
+    // not the user-facing input shape.
+    models: modelsSchema.default(() => ({ default: [DEFAULT_MODEL_REF] })) as unknown as z.ZodType<Models>,
     // Defaults to `[]` so the field can be omitted from `typeclaw.json` (no
     // host paths exposed) without failing the whole config load. `typeclaw
     // init` omits this field so users don't see noise for the empty case.
@@ -345,26 +352,28 @@ export function resolveModel(ref: KnownModelRef): Model<'openai-completions'> | 
   return KNOWN_PROVIDERS[providerId].models[modelId as never]
 }
 
-// Resolves a profile name (e.g. `fast`, `deep`, `vision`) to a concrete model
-// ref. Unknown profiles fall back to `default` so callers can pass through
+// Resolves a profile name (e.g. `fast`, `deep`, `vision`) to its fallback
+// chain. Unknown profiles fall back to `default` so callers can pass through
 // arbitrary subagent-declared or user-overridden strings without crashing.
-// Returns the resolved ref plus whether it came from the requested profile or
-// from the `default` fallback, so the caller can warn once per session
-// instead of every prompt.
+// `refs` is non-empty (the schema guarantees `default` exists and every value
+// is at least one ref). `ref` is the head of the chain — the model the
+// session is created with first. Callers that don't implement fallback can
+// keep reading `ref`; fallback-aware callers iterate `refs`.
 export type ResolvedProfile = {
   ref: KnownModelRef
+  refs: KnownModelRef[]
   profile: string
   fellBackToDefault: boolean
 }
 
 export function resolveProfile(models: Models, name: string | undefined): ResolvedProfile {
   const requested = name ?? 'default'
-  const ref = models[requested]
-  if (ref !== undefined) {
-    return { ref, profile: requested, fellBackToDefault: false }
+  const refs = models[requested]
+  if (refs !== undefined) {
+    return { ref: refs[0]!, refs, profile: requested, fellBackToDefault: false }
   }
   const fallback = models.default
-  return { ref: fallback, profile: 'default', fellBackToDefault: true }
+  return { ref: fallback[0]!, refs: fallback, profile: 'default', fellBackToDefault: true }
 }
 
 // Resolves a mount's `path` field to an absolute host path, mirroring shell

--- a/src/config/models-mutation.test.ts
+++ b/src/config/models-mutation.test.ts
@@ -249,6 +249,22 @@ describe('listModelProfiles', () => {
     expect(dflt?.credentialStatus).toBe('available')
     expect(dflt?.missingProviders).toEqual([])
   })
+
+  test('dedupes providers when the chain uses multiple models from the same provider', async () => {
+    const { writeFile } = await import('node:fs/promises')
+    await writeFile(
+      join(root, 'typeclaw.json'),
+      JSON.stringify({
+        models: {
+          default: ['openai/gpt-5.4-nano', 'openai/gpt-5.4-mini'],
+        },
+      }),
+    )
+    const env: NodeJS.ProcessEnv = {}
+    const entries = listModelProfiles(root, env)
+    const dflt = entries.find((e) => e.profile === 'default')
+    expect(dflt?.missingProviders).toEqual(['openai'])
+  })
 })
 
 describe('auto-commit on success', () => {

--- a/src/config/models-mutation.test.ts
+++ b/src/config/models-mutation.test.ts
@@ -210,6 +210,45 @@ describe('listModelProfiles', () => {
     const vision = entries.find((e) => e.profile === 'vision')
     expect(vision?.credentialStatus).toBe('available')
   })
+
+  test('exposes fallback chains via refs and reports missing providers across the chain', async () => {
+    const { writeFile } = await import('node:fs/promises')
+    // fireworks is configured via the test setup's secrets.json; openai is
+    // not, so a chain that includes both should be flagged missing-credentials
+    // with `openai` named in `missingProviders`.
+    await writeFile(
+      join(root, 'typeclaw.json'),
+      JSON.stringify({
+        models: {
+          default: ['fireworks/accounts/fireworks/routers/kimi-k2p6-turbo', 'openai/gpt-5.4-nano'],
+        },
+      }),
+    )
+    const env: NodeJS.ProcessEnv = {}
+    const entries = listModelProfiles(root, env)
+    const dflt = entries.find((e) => e.profile === 'default')
+    expect(dflt?.ref).toBe('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    expect(dflt?.refs).toEqual(['fireworks/accounts/fireworks/routers/kimi-k2p6-turbo', 'openai/gpt-5.4-nano'])
+    expect(dflt?.credentialStatus).toBe('missing-credentials')
+    expect(dflt?.missingProviders).toEqual(['openai'])
+  })
+
+  test('reports available when every provider in the chain has credentials', async () => {
+    const { writeFile } = await import('node:fs/promises')
+    await writeFile(
+      join(root, 'typeclaw.json'),
+      JSON.stringify({
+        models: {
+          default: ['fireworks/accounts/fireworks/routers/kimi-k2p6-turbo', 'openai/gpt-5.4-nano'],
+        },
+      }),
+    )
+    const env: NodeJS.ProcessEnv = { OPENAI_API_KEY: 'sk-x' }
+    const entries = listModelProfiles(root, env)
+    const dflt = entries.find((e) => e.profile === 'default')
+    expect(dflt?.credentialStatus).toBe('available')
+    expect(dflt?.missingProviders).toEqual([])
+  })
 })
 
 describe('auto-commit on success', () => {

--- a/src/config/models-mutation.ts
+++ b/src/config/models-mutation.ts
@@ -17,8 +17,16 @@ const CONFIG_FILE = 'typeclaw.json'
 
 export type ModelProfileEntry = {
   profile: string
+  // Head of the fallback chain. Kept under the legacy `ref` name so callers
+  // that only care about the active model (the common case) don't need to
+  // dereference `refs[0]`. The chain itself is exposed as `refs`.
   ref: KnownModelRef
+  refs: KnownModelRef[]
   providerId: KnownProviderId
+  // Credential status for every provider referenced by the chain. The chain's
+  // overall status is `available` only when every entry resolves; otherwise
+  // it is `missing-credentials`, and `missingProviders` names which.
+  missingProviders: KnownProviderId[]
   isDefault: boolean
   credentialStatus: 'available' | 'missing-credentials'
 }
@@ -31,12 +39,15 @@ export function listModelProfiles(cwd: string, env: NodeJS.ProcessEnv = process.
   for (const [profile, refs] of Object.entries(models)) {
     const headRef = refs[0]!
     const providerId = providerForModelRef(headRef)
+    const missingProviders = uniqueProviders(refs).filter((p) => !hasUsableCredential(cwd, p, env))
     out.push({
       profile,
       ref: headRef,
+      refs,
       providerId,
+      missingProviders,
       isDefault: profile === 'default',
-      credentialStatus: hasUsableCredential(cwd, providerId, env) ? 'available' : 'missing-credentials',
+      credentialStatus: missingProviders.length === 0 ? 'available' : 'missing-credentials',
     })
   }
   // `default` always first; remaining profiles alphabetical so output is stable.
@@ -45,6 +56,19 @@ export function listModelProfiles(cwd: string, env: NodeJS.ProcessEnv = process.
     if (b.isDefault) return 1
     return a.profile.localeCompare(b.profile)
   })
+  return out
+}
+
+function uniqueProviders(refs: ReadonlyArray<KnownModelRef>): KnownProviderId[] {
+  const seen = new Set<KnownProviderId>()
+  const out: KnownProviderId[] = []
+  for (const r of refs) {
+    const p = providerForModelRef(r)
+    if (!seen.has(p)) {
+      seen.add(p)
+      out.push(p)
+    }
+  }
   return out
 }
 
@@ -166,7 +190,11 @@ function writeProfile(cwd: string, profile: string, ref: KnownModelRef, message:
   return writeModels(cwd, next, message)
 }
 
-function writeModels(cwd: string, models: Record<string, string | string[]>, commitMessage: string): ModelMutationResult {
+function writeModels(
+  cwd: string,
+  models: Record<string, string | string[]>,
+  commitMessage: string,
+): ModelMutationResult {
   const path = join(cwd, CONFIG_FILE)
   let parsed: Record<string, unknown>
   try {
@@ -208,6 +236,11 @@ function writeModels(cwd: string, models: Record<string, string | string[]>, com
   return { ok: true }
 }
 
+// Returns the raw `models` block from disk in its on-disk shape: each value
+// is `string | string[]` (the user-facing schema). Writers preserve whichever
+// shape was already present for profiles they don't touch — converting a
+// hand-authored fallback chain back to a single string would silently drop
+// the fallback.
 function readModelsRaw(cwd: string): Record<string, string | string[]> | null {
   try {
     const raw = readFileSync(join(cwd, CONFIG_FILE), 'utf8')

--- a/src/config/models-mutation.ts
+++ b/src/config/models-mutation.ts
@@ -28,11 +28,12 @@ export type ModelMutationResult = { ok: true } | { ok: false; reason: string }
 export function listModelProfiles(cwd: string, env: NodeJS.ProcessEnv = process.env): ModelProfileEntry[] {
   const models = loadConfigSync(cwd).models
   const out: ModelProfileEntry[] = []
-  for (const [profile, ref] of Object.entries(models)) {
-    const providerId = providerForModelRef(ref)
+  for (const [profile, refs] of Object.entries(models)) {
+    const headRef = refs[0]!
+    const providerId = providerForModelRef(headRef)
     out.push({
       profile,
-      ref,
+      ref: headRef,
       providerId,
       isDefault: profile === 'default',
       credentialStatus: hasUsableCredential(cwd, providerId, env) ? 'available' : 'missing-credentials',
@@ -158,14 +159,14 @@ export function removeProfile(cwd: string, profile: string): ModelMutationResult
 
 function writeProfile(cwd: string, profile: string, ref: KnownModelRef, message: string): ModelMutationResult {
   const existing = readModelsRaw(cwd)
-  const next = existing === null ? { default: ref } : { ...existing, [profile]: ref }
+  const next: Record<string, string | string[]> = existing === null ? { default: ref } : { ...existing, [profile]: ref }
   if (existing === null && profile !== 'default') {
     next.default = ref
   }
   return writeModels(cwd, next, message)
 }
 
-function writeModels(cwd: string, models: Record<string, string>, commitMessage: string): ModelMutationResult {
+function writeModels(cwd: string, models: Record<string, string | string[]>, commitMessage: string): ModelMutationResult {
   const path = join(cwd, CONFIG_FILE)
   let parsed: Record<string, unknown>
   try {
@@ -207,10 +208,10 @@ function writeModels(cwd: string, models: Record<string, string>, commitMessage:
   return { ok: true }
 }
 
-function readModelsRaw(cwd: string): Record<string, string> | null {
+function readModelsRaw(cwd: string): Record<string, string | string[]> | null {
   try {
     const raw = readFileSync(join(cwd, CONFIG_FILE), 'utf8')
-    const parsed = JSON.parse(raw) as { models?: Record<string, string> }
+    const parsed = JSON.parse(raw) as { models?: Record<string, string | string[]> }
     return parsed.models ?? null
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null

--- a/src/config/providers-mutation.ts
+++ b/src/config/providers-mutation.ts
@@ -136,8 +136,8 @@ export function findModelsReferencingProvider(cwd: string, providerId: string): 
   const models = readModelsOrNull(cwd)
   if (models === null) return []
   const out: string[] = []
-  for (const [profile, ref] of Object.entries(models)) {
-    if (refTargetsProvider(ref, providerId)) out.push(profile)
+  for (const [profile, refs] of Object.entries(models)) {
+    if (refs.some((r) => refTargetsProvider(r, providerId))) out.push(profile)
   }
   return out
 }
@@ -212,12 +212,16 @@ function readEnvKey(env: NodeJS.ProcessEnv, key: string): string | undefined {
 function buildProviderReferenceMap(models: Models | null): Map<string, string[]> {
   const out = new Map<string, string[]>()
   if (models === null) return out
-  for (const [profile, ref] of Object.entries(models)) {
-    const providerId = safeProviderForRef(ref)
-    if (providerId === null) continue
-    const existing = out.get(providerId) ?? []
-    existing.push(profile)
-    out.set(providerId, existing)
+  for (const [profile, refs] of Object.entries(models)) {
+    for (const ref of refs) {
+      const providerId = safeProviderForRef(ref)
+      if (providerId === null) continue
+      const existing = out.get(providerId) ?? []
+      if (!existing.includes(profile)) {
+        existing.push(profile)
+        out.set(providerId, existing)
+      }
+    }
   }
   return out
 }

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -792,7 +792,7 @@ describe('createCronConsumer model fallback', () => {
     }
   })
 
-  test('logs final-attempt failure when every ref in the chain fails', async () => {
+  test('logs final-attempt failure when every ref in the chain fails, and attempts every ref in order', async () => {
     // given
     const { writeFile } = await import('node:fs/promises')
     const { reloadConfig, __resetConfigForTesting } = await import('@/config/config')
@@ -808,17 +808,21 @@ describe('createCronConsumer model fallback', () => {
     try {
       const stream = createStream()
       const errors: string[] = []
+      const attempted: string[] = []
       const consumer = createCronConsumer({
         stream,
         cwd: root,
-        createSessionForCron: async (_job, ref) => ({
-          prompt: async () => {
-            throw new Error(`down: ${ref}`)
-          },
-          session: stubAgentSession(async () => {
-            throw new Error(`down: ${ref}`)
-          }),
-        }),
+        createSessionForCron: async (_job, ref) => {
+          attempted.push(ref!)
+          return {
+            prompt: async () => {
+              throw new Error(`down: ${ref}`)
+            },
+            session: stubAgentSession(async () => {
+              throw new Error(`down: ${ref}`)
+            }),
+          }
+        },
         logger: { ...silentLogger, error: (m) => errors.push(m) },
       })
       consumer.start()
@@ -828,8 +832,91 @@ describe('createCronConsumer model fallback', () => {
       await new Promise((r) => setImmediate(r))
 
       // then
+      expect(attempted).toEqual(['openai/gpt-5.4-nano', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'])
       expect(errors.some((e) => /all 2 model\(s\) failed/.test(e))).toBe(true)
       expect(errors.some((e) => /down: fireworks/.test(e))).toBe(true)
+
+      consumer.stop()
+    } finally {
+      __resetConfigForTesting()
+    }
+  })
+
+  test('disposes the successful final session and fires session.end exactly once per attempted session', async () => {
+    // given: a 2-ref chain where the first fails and the second succeeds.
+    // We track disposal calls per session and assert that BOTH sessions get
+    // their dispose+end hooks fired — without that, security plugin taint
+    // state and memory plugin debounce timers would orphan for the failed
+    // first attempt, and the successful session's resources would leak.
+    const { writeFile } = await import('node:fs/promises')
+    const { reloadConfig, __resetConfigForTesting } = await import('@/config/config')
+    await writeFile(
+      join(root, 'typeclaw.json'),
+      JSON.stringify({
+        models: {
+          default: ['openai/gpt-5.4-nano', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'],
+        },
+      }),
+    )
+    reloadConfig(root)
+    try {
+      const stream = createStream()
+      const events: string[] = []
+      const consumer = createCronConsumer({
+        stream,
+        cwd: root,
+        createSessionForCron: async (_job, ref) => {
+          const fail = ref === 'openai/gpt-5.4-nano'
+          const sessionId = `sess:${ref}`
+          const hooks: HookBus = {
+            registerAll: () => {},
+            unregisterAll: () => {},
+            runSessionStart: async () => {},
+            runSessionEnd: async (e) => {
+              events.push(`end:${e.sessionId}`)
+            },
+            runSessionIdle: async (e) => {
+              events.push(`idle:${e.sessionId}`)
+            },
+            runSessionPrompt: async () => {},
+            runSessionTurnStart: async () => {},
+            runSessionTurnEnd: async () => {},
+            runToolBefore: async () => undefined,
+            runToolAfter: async () => {},
+            count: () => 0,
+          }
+          return {
+            prompt: async () => {
+              if (fail) throw new Error(`down on ${ref}`)
+            },
+            session: stubAgentSession(async () => {
+              if (fail) throw new Error(`down on ${ref}`)
+            }),
+            hooks,
+            sessionId,
+            agentDir: '/agent',
+            dispose: () => {
+              events.push(`dispose:${sessionId}`)
+            },
+          }
+        },
+        logger: silentLogger,
+      })
+      consumer.start()
+
+      // when
+      publishCron(stream, promptJob('fb', 'go'))
+      await new Promise((r) => setImmediate(r))
+
+      // then: failed session gets end+dispose (no idle), successful session
+      // gets idle+end+dispose, all in the right order
+      expect(events).toEqual([
+        'end:sess:openai/gpt-5.4-nano',
+        'dispose:sess:openai/gpt-5.4-nano',
+        'idle:sess:fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        'end:sess:fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        'dispose:sess:fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+      ])
 
       consumer.stop()
     } finally {

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -3,11 +3,26 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import type { AgentSession } from '@/agent'
 import type { HookBus } from '@/plugin'
 import { createStream } from '@/stream'
 
 import { createCronConsumer, type CronConsumerLogger, type CronSession } from './consumer'
 import type { CronJob, ExecJob, PromptJob } from './schema'
+
+// Minimal AgentSession stub satisfying the surface the model-fallback helper
+// uses: `subscribe` for soft-error detection (returns a no-op unsubscribe)
+// and `prompt` for the actual turn call. Production code routes the prompt
+// through CronSession.prompt (which itself calls AgentSession.prompt), but
+// the fallback helper bypasses the wrapper and calls AgentSession.prompt
+// directly — so the stub has to honor the same callback to keep the test
+// fakes behaving like their pre-fallback predecessors.
+function stubAgentSession(promptImpl: (text: string) => Promise<void> = async () => {}): AgentSession {
+  return {
+    subscribe: () => () => {},
+    prompt: promptImpl,
+  } as unknown as AgentSession
+}
 
 function fakeHooks(events: string[]): HookBus {
   return {
@@ -68,13 +83,17 @@ function makeFakeSessionFactory(): {
   const callsByJob = new Map<string, string[]>()
   return {
     callsByJob,
-    createSessionForCron: async (job) => ({
-      prompt: async (text) => {
+    createSessionForCron: async (job) => {
+      const record = (text: string) => {
         const existing = callsByJob.get(job.id) ?? []
         existing.push(text)
         callsByJob.set(job.id, existing)
-      },
-    }),
+      }
+      return {
+        prompt: async (text) => record(text),
+        session: stubAgentSession(async (text) => record(text)),
+      }
+    },
   }
 }
 
@@ -551,7 +570,7 @@ describe('createCronConsumer', () => {
     await new Promise((r) => setImmediate(r))
 
     // then
-    expect(errors.some((e) => /\[cron\] soft-err: LLM call failed: rate limit exceeded/.test(e))).toBe(true)
+    expect(errors.some((e) => /\[cron\] soft-err:.*rate limit exceeded/.test(e))).toBe(true)
 
     consumer.stop()
   })
@@ -714,5 +733,107 @@ describe('createCronConsumer', () => {
 
     for (const r of resolvers) r()
     consumer.stop()
+  })
+})
+
+describe('createCronConsumer model fallback', () => {
+  test('retries with the next ref when the first model throws, and the factory receives the override', async () => {
+    // given: a multi-ref default chain on disk + reloaded into the live config
+    const { writeFile } = await import('node:fs/promises')
+    const { reloadConfig, __resetConfigForTesting } = await import('@/config/config')
+    await writeFile(
+      join(root, 'typeclaw.json'),
+      JSON.stringify({
+        models: {
+          default: ['openai/gpt-5.4-nano', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'],
+        },
+      }),
+    )
+    reloadConfig(root)
+    try {
+      const stream = createStream()
+      const calls: string[] = []
+      const consumer = createCronConsumer({
+        stream,
+        cwd: root,
+        createSessionForCron: async (job, ref) => {
+          calls.push(`${job.id}:${ref}`)
+          const fail = ref === 'openai/gpt-5.4-nano'
+          return {
+            prompt: async (text) => {
+              if (fail) throw new Error(`provider error on ${ref}`)
+              calls.push(`${job.id}:${ref}:ok:${text}`)
+            },
+            session: stubAgentSession(async (text) => {
+              if (fail) throw new Error(`provider error on ${ref}`)
+              calls.push(`${job.id}:${ref}:ok:${text}`)
+            }),
+          }
+        },
+        logger: silentLogger,
+      })
+      consumer.start()
+
+      // when
+      publishCron(stream, promptJob('fb', 'do thing'))
+      await new Promise((r) => setImmediate(r))
+
+      // then: the consumer called createSessionForCron once per ref in chain
+      // order, and the second attempt's prompt was actually invoked
+      expect(calls).toEqual([
+        'fb:openai/gpt-5.4-nano',
+        'fb:fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+        'fb:fireworks/accounts/fireworks/routers/kimi-k2p6-turbo:ok:do thing',
+      ])
+
+      consumer.stop()
+    } finally {
+      __resetConfigForTesting()
+    }
+  })
+
+  test('logs final-attempt failure when every ref in the chain fails', async () => {
+    // given
+    const { writeFile } = await import('node:fs/promises')
+    const { reloadConfig, __resetConfigForTesting } = await import('@/config/config')
+    await writeFile(
+      join(root, 'typeclaw.json'),
+      JSON.stringify({
+        models: {
+          default: ['openai/gpt-5.4-nano', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'],
+        },
+      }),
+    )
+    reloadConfig(root)
+    try {
+      const stream = createStream()
+      const errors: string[] = []
+      const consumer = createCronConsumer({
+        stream,
+        cwd: root,
+        createSessionForCron: async (_job, ref) => ({
+          prompt: async () => {
+            throw new Error(`down: ${ref}`)
+          },
+          session: stubAgentSession(async () => {
+            throw new Error(`down: ${ref}`)
+          }),
+        }),
+        logger: { ...silentLogger, error: (m) => errors.push(m) },
+      })
+      consumer.start()
+
+      // when
+      publishCron(stream, promptJob('all-down', 'attempt'))
+      await new Promise((r) => setImmediate(r))
+
+      // then
+      expect(errors.some((e) => /all 2 model\(s\) failed/.test(e))).toBe(true)
+      expect(errors.some((e) => /down: fireworks/.test(e))).toBe(true)
+
+      consumer.stop()
+    } finally {
+      __resetConfigForTesting()
+    }
   })
 })

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -1,6 +1,8 @@
 import type { AgentSession } from '@/agent'
-import { subscribeProviderErrors } from '@/agent/provider-error'
+import { promptWithFallback, resolveFallbackChain } from '@/agent/model-fallback'
 import type { SessionOrigin } from '@/agent/session-origin'
+import { getConfig } from '@/config'
+import type { KnownModelRef } from '@/config/providers'
 import type { HookBus } from '@/plugin'
 import type { Stream, Unsubscribe } from '@/stream'
 
@@ -41,7 +43,12 @@ export type CronConsumerLogger = {
 export type CreateCronConsumerOptions = {
   stream: Stream
   cwd: string
-  createSessionForCron: (job: PromptJob) => Promise<CronSession>
+  // The optional `refOverride` argument is consumed by the fallback loop: the
+  // consumer calls this factory once per ref in the profile's chain, pinning
+  // each attempt to the specified model. Factories that don't honor the
+  // override silently lose fallback semantics, so production wiring threads
+  // it through to `createSession({ refOverride })`.
+  createSessionForCron: (job: PromptJob, refOverride?: KnownModelRef) => Promise<CronSession>
   // Builds the `CronHandlerContext` for the job and awaits its `handler`.
   // Wired by `src/run/index.ts` to reuse `runPromptForCommand` /
   // `runExecForCommand` from the command runner so plugin cron handlers and
@@ -121,7 +128,7 @@ export function createCronConsumer({
 
 async function runPrompt(
   job: PromptJob,
-  createSessionForCron: (job: PromptJob) => Promise<CronSession>,
+  createSessionForCron: (job: PromptJob, refOverride?: KnownModelRef) => Promise<CronSession>,
   stream: Stream,
   logger: CronConsumerLogger,
 ): Promise<void> {
@@ -148,50 +155,111 @@ async function runPrompt(
     })
     return
   }
-  const session = await createSessionForCron(job)
-  const unsubProviderErrors =
-    session.session !== undefined
-      ? subscribeProviderErrors(session.session, (err) => {
-          logger.error(`[cron] ${job.id}: LLM call failed: ${err.message}`)
-        })
-      : null
-  const turnEvent =
-    session.hooks && session.sessionId !== undefined && session.agentDir !== undefined
-      ? {
-          sessionId: session.sessionId,
-          agentDir: session.agentDir,
-          ...(session.origin !== undefined ? { origin: session.origin } : {}),
-        }
-      : undefined
-  try {
-    if (session.hooks && turnEvent !== undefined) {
-      await session.hooks.runSessionTurnStart(turnEvent)
-    }
-    try {
-      await session.prompt(job.prompt)
-    } finally {
-      if (session.hooks && turnEvent !== undefined) {
-        await session.hooks.runSessionTurnEnd(turnEvent)
+  // Resolve the model fallback chain for the cron profile (cron jobs run
+  // under the `default` profile today). Single-ref configs produce a length-1
+  // chain; multi-ref configs (e.g. `"default": ["openai/...", "fireworks/..."]`)
+  // drive the retry-on-failure loop inside `runPromptOnce`.
+  const refs = resolveFallbackChain(getConfig().models, undefined)
+  await runPromptOnce(job, refs, createSessionForCron, logger)
+}
+
+async function runPromptOnce(
+  job: PromptJob,
+  refs: KnownModelRef[],
+  createSessionForCron: (job: PromptJob, refOverride?: KnownModelRef) => Promise<CronSession>,
+  logger: CronConsumerLogger,
+): Promise<void> {
+  // The fallback helper manages session creation, the prompt attempt, soft-
+  // error detection, and disposal between attempts. Each `createSessionForRef`
+  // call pins the new session to a specific ref via `refOverride`; on failure
+  // the helper disposes and advances. The hooks (turn.start, turn.end,
+  // session.idle, session.end) all fire against the session that ultimately
+  // handled the turn — soft-failed sessions get only disposal, since they
+  // never produced a usable turn.
+  let cronSession: CronSession | null = null
+  const result = await promptWithFallback({
+    refs,
+    text: job.prompt,
+    createSessionForRef: async (ref) => {
+      const created = await createSessionForCron(job, ref)
+      cronSession = created
+      const turnEvent =
+        created.hooks && created.sessionId !== undefined && created.agentDir !== undefined
+          ? {
+              sessionId: created.sessionId,
+              agentDir: created.agentDir,
+              ...(created.origin !== undefined ? { origin: created.origin } : {}),
+            }
+          : undefined
+      if (created.hooks && turnEvent !== undefined) {
+        await created.hooks.runSessionTurnStart(turnEvent)
       }
-    }
-    if (session.hooks && session.sessionId !== undefined) {
-      await session.hooks.runSessionIdle({
-        sessionId: session.sessionId,
-        parentTranscriptPath: session.getTranscriptPath?.(),
-        idleMs: 0,
-        ...(session.origin !== undefined ? { origin: session.origin } : {}),
-      })
-    }
-  } finally {
-    unsubProviderErrors?.()
-    if (session.hooks && session.sessionId !== undefined) {
-      await session.hooks.runSessionEnd({
-        sessionId: session.sessionId,
-        ...(session.origin !== undefined ? { origin: session.origin } : {}),
-      })
-    }
-    session.dispose?.()
+      // Bridge the CronSession wrapper into the AgentSession surface the
+      // fallback helper expects:
+      //   prompt   → CronSession.prompt (wrapper that calls AgentSession.prompt
+      //              in production, or a hand-rolled test fake)
+      //   subscribe → CronSession.session.subscribe when an underlying agent
+      //              session is supplied, else a no-op (soft-error detection
+      //              degrades to "off" in that mode; only hard throws drive
+      //              fallback)
+      // Going through the wrapper for `prompt` preserves any pre/post hooks
+      // a future CronSession may layer around the call.
+      const sessionForHelper: AgentSession = {
+        prompt: (text: string) => created.prompt(text),
+        subscribe: created.session?.subscribe.bind(created.session) ?? (() => () => {}),
+      } as unknown as AgentSession
+      return {
+        session: sessionForHelper,
+        dispose: async () => {
+          if (created.hooks && turnEvent !== undefined) {
+            try {
+              await created.hooks.runSessionTurnEnd(turnEvent)
+            } catch (e) {
+              logger.warn(`[cron] ${job.id}: turn-end hook threw: ${describe(e)}`)
+            }
+          }
+          created.dispose?.()
+        },
+      }
+    },
+    onAttemptFailed: (attempt) => {
+      logger.warn(
+        `[cron] ${job.id}: ${attempt.outcome} failure on ${attempt.ref}: ${attempt.errorMessage ?? 'unknown'}; falling back`,
+      )
+    },
+  })
+
+  if (!result.success) {
+    logger.error(
+      `[cron] ${job.id}: all ${result.attempts.length} model(s) failed; last error: ${result.lastError?.message ?? 'unknown'}`,
+    )
   }
+
+  // Lifecycle hooks fire against the last session created. `session.idle`
+  // only fires on success (matching the pre-fallback behavior where the
+  // idle hook was nested inside the try-block around `prompt()`); `session.end`
+  // always fires so plugins can react to abnormal termination.
+  if (cronSession !== null) {
+    const finalSession: CronSession = cronSession
+    if (result.success && finalSession.hooks && finalSession.sessionId !== undefined) {
+      await finalSession.hooks.runSessionIdle({
+        sessionId: finalSession.sessionId,
+        parentTranscriptPath: finalSession.getTranscriptPath?.(),
+        idleMs: 0,
+        ...(finalSession.origin !== undefined ? { origin: finalSession.origin } : {}),
+      })
+    }
+    if (finalSession.hooks && finalSession.sessionId !== undefined) {
+      await finalSession.hooks.runSessionEnd({
+        sessionId: finalSession.sessionId,
+        ...(finalSession.origin !== undefined ? { origin: finalSession.origin } : {}),
+      })
+    }
+  }
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }
 
 async function runExec(job: ExecJob, cwd: string): Promise<void> {

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -169,20 +169,23 @@ async function runPromptOnce(
   createSessionForCron: (job: PromptJob, refOverride?: KnownModelRef) => Promise<CronSession>,
   logger: CronConsumerLogger,
 ): Promise<void> {
-  // The fallback helper manages session creation, the prompt attempt, soft-
-  // error detection, and disposal between attempts. Each `createSessionForRef`
-  // call pins the new session to a specific ref via `refOverride`; on failure
-  // the helper disposes and advances. The hooks (turn.start, turn.end,
-  // session.idle, session.end) all fire against the session that ultimately
-  // handled the turn — soft-failed sessions get only disposal, since they
-  // never produced a usable turn.
-  let cronSession: CronSession | null = null
+  // Per-attempt lifecycle: every session we create gets full
+  // turn-start → turn-end → session-end → dispose bracketing, regardless of
+  // whether the helper chose it as the final session or disposed it as a
+  // failed earlier attempt. Without per-attempt session.end, plugin state
+  // keyed by sessionId (security plugin's remote-taint map, memory plugin's
+  // debounce timer) would orphan for every failed attempt. We track the
+  // last session separately so we can fire session.idle exactly once on
+  // success (matching pre-fallback cron behavior — see the pre-fallback
+  // try/finally structure: idle inside the prompt try-block, end in the
+  // outer finally).
+  let lastSession: CronSession | null = null
   const result = await promptWithFallback({
     refs,
     text: job.prompt,
     createSessionForRef: async (ref) => {
       const created = await createSessionForCron(job, ref)
-      cronSession = created
+      lastSession = created
       const turnEvent =
         created.hooks && created.sessionId !== undefined && created.agentDir !== undefined
           ? {
@@ -196,26 +199,41 @@ async function runPromptOnce(
       }
       // Bridge the CronSession wrapper into the AgentSession surface the
       // fallback helper expects:
-      //   prompt   → CronSession.prompt (wrapper that calls AgentSession.prompt
-      //              in production, or a hand-rolled test fake)
+      //   prompt    → CronSession.prompt (wrapper that calls AgentSession.prompt
+      //               in production, or a hand-rolled test fake)
       //   subscribe → CronSession.session.subscribe when an underlying agent
-      //              session is supplied, else a no-op (soft-error detection
-      //              degrades to "off" in that mode; only hard throws drive
-      //              fallback)
-      // Going through the wrapper for `prompt` preserves any pre/post hooks
-      // a future CronSession may layer around the call.
+      //               session is supplied, else a no-op (soft-error detection
+      //               degrades to "off" in that mode; only hard throws drive
+      //               fallback). Test fakes that omit `.session` lose
+      //               soft-error fallback — production code always provides it.
+      // .bind(created.session) is load-bearing: AgentSession.subscribe is a
+      // regular method that reads `this._eventListeners`. Destructuring drops
+      // the receiver.
       const sessionForHelper: AgentSession = {
         prompt: (text: string) => created.prompt(text),
         subscribe: created.session?.subscribe.bind(created.session) ?? (() => () => {}),
       } as unknown as AgentSession
       return {
         session: sessionForHelper,
+        // Per-attempt teardown. Fires turn.end and session.end for every
+        // session created (success or failure), then disposes the underlying
+        // resources. Hooks that throw are logged but don't prevent disposal.
         dispose: async () => {
           if (created.hooks && turnEvent !== undefined) {
             try {
               await created.hooks.runSessionTurnEnd(turnEvent)
             } catch (e) {
               logger.warn(`[cron] ${job.id}: turn-end hook threw: ${describe(e)}`)
+            }
+          }
+          if (created.hooks && created.sessionId !== undefined) {
+            try {
+              await created.hooks.runSessionEnd({
+                sessionId: created.sessionId,
+                ...(created.origin !== undefined ? { origin: created.origin } : {}),
+              })
+            } catch (e) {
+              logger.warn(`[cron] ${job.id}: session-end hook threw: ${describe(e)}`)
             }
           }
           created.dispose?.()
@@ -235,26 +253,26 @@ async function runPromptOnce(
     )
   }
 
-  // Lifecycle hooks fire against the last session created. `session.idle`
-  // only fires on success (matching the pre-fallback behavior where the
-  // idle hook was nested inside the try-block around `prompt()`); `session.end`
-  // always fires so plugins can react to abnormal termination.
-  if (cronSession !== null) {
-    const finalSession: CronSession = cronSession
-    if (result.success && finalSession.hooks && finalSession.sessionId !== undefined) {
-      await finalSession.hooks.runSessionIdle({
-        sessionId: finalSession.sessionId,
-        parentTranscriptPath: finalSession.getTranscriptPath?.(),
-        idleMs: 0,
-        ...(finalSession.origin !== undefined ? { origin: finalSession.origin } : {}),
-      })
-    }
+  // session.idle fires once, only on success, and only against the session
+  // that handled the turn. Then dispose the successful session (the helper
+  // returns the session+dispose so we can run post-prompt hooks against a
+  // live session before tearing it down). Failed-chain disposal is already
+  // handled by the helper's per-attempt dispose calls.
+  if (result.success && lastSession !== null) {
+    const finalSession: CronSession = lastSession
     if (finalSession.hooks && finalSession.sessionId !== undefined) {
-      await finalSession.hooks.runSessionEnd({
-        sessionId: finalSession.sessionId,
-        ...(finalSession.origin !== undefined ? { origin: finalSession.origin } : {}),
-      })
+      try {
+        await finalSession.hooks.runSessionIdle({
+          sessionId: finalSession.sessionId,
+          parentTranscriptPath: finalSession.getTranscriptPath?.(),
+          idleMs: 0,
+          ...(finalSession.origin !== undefined ? { origin: finalSession.origin } : {}),
+        })
+      } catch (e) {
+        logger.warn(`[cron] ${job.id}: session-idle hook threw: ${describe(e)}`)
+      }
     }
+    await result.dispose()
   }
 }
 

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -314,7 +314,7 @@ export async function startAgent({
       }
       await job.handler(ctx)
     },
-    createSessionForCron: async (job) => {
+    createSessionForCron: async (job, refOverride) => {
       const snap = pluginRuntime.get()
       const sessionManager = SessionManager.create(cwd, sessionFactory.sessionDir())
       const sessionId = sessionManager.getSessionId()
@@ -336,6 +336,7 @@ export async function startAgent({
         channelRouter: channelManager.router,
         origin: cronOrigin,
         permissions: pluginsLoaded.permissions,
+        ...(refOverride !== undefined ? { refOverride } : {}),
         ...(snap.hasAnyPluginContent
           ? {
               plugins: {


### PR DESCRIPTION
## Why

Unattended cron jobs are the first place a hard model failure costs real work: nobody's watching to manually retry, and the job just silently dies. This PR makes model failures recoverable by letting operators declare a fallback chain per profile.

```jsonc
{
  "models": {
    "default": ["openai/gpt-5.4-nano", "fireworks/accounts/fireworks/routers/kimi-k2p6-turbo"]
  }
}
```

The single-string shape (`"default": "openai/..."`) keeps working — the schema accepts both and normalises to `KnownModelRef[]` at parse time. Existing configs need no changes.

## What changed

### Schema (`src/config/config.ts`)

`models.<profile>` now accepts `string | string[]`. The union+transform normalises both to `KnownModelRef[]` before any downstream code sees the value, so there's no `string vs string[]` branching anywhere in the codebase. The `Models` type guarantees `default` is always present (matches the schema's `.refine`). `FIELD_EFFECTS['models']` stays `'applied'` — chain edits take effect without a restart.

`resolveProfile` returns both `ref` (head, for callers that don't care about fallback) and `refs` (full chain, for fallback-aware callers). Existing callers are unaffected.

### CLI display (`src/cli/model.ts`, `src/config/models-mutation.ts`)

`ModelProfileEntry` gains `refs[]` and `missingProviders[]`. Credential status is `missing-credentials` if **any** provider in the chain lacks credentials. `typeclaw model list` renders each fallback ref indented under the head with a `↳` glyph and a `(+N fallback)` summary. Single-ref profiles render unchanged.

### Fallback helper (`src/agent/model-fallback.ts`)

`promptWithFallback(refs, text, createSessionForRef, options)` is the new primitive. It iterates the chain: creates a session via the caller's factory, awaits `session.prompt(text)`, and on failure disposes the session and advances. Two failure modes trigger fallback:

- **Hard throw** from `session.prompt()` — network drop, timeout, provider rejecting the request.
- **Soft provider error** — pi-coding-agent encodes upstream LLM failures (`billing`, `rate-limit`, malformed response) in the final assistant message with `stopReason: 'error'` instead of throwing. The helper subscribes via `subscribeProviderErrors` and checks the captured `softError` after `prompt()` resolves.

After exhausting the chain, it logs `[cron] <jobId>: all N model(s) failed; last error: <msg>` and re-throws.

Hook semantics: `session.turn.start` / `turn.end` fire once per attempt; `session.idle` only fires on success (matches the memory plugin's pre-existing expectation — dreaming should not trigger on a failed turn); `session.end` always fires.

### Cron consumer (`src/cron/consumer.ts`)

`createSessionForCron` grows an optional `refOverride?: KnownModelRef` parameter. When `promptWithFallback` advances to the next ref in the chain, it passes it as `refOverride`, which threads through to `createSession({ refOverride })` — bypassing profile resolution and pinning the session to the specific entry. The consumer's retry loop disposes the failed session, creates a new one pinned to the next ref, and replays the same prompt.

`CreateSessionOptions.refOverride` is the new escape hatch that makes per-attempt model pinning possible without touching the live profile config.

## Honest tradeoffs

**Cron-only for now.** The server drain (TUI) and channels router both hold long-lived sessions with many subscribers: provider-error forwarding, restart-notice, broadcast, prompt enqueue, channel typing indicators. Swapping the underlying session mid-conversation requires resubscribing all of those without dropping events. That's a bigger refactor than v1 can absorb cleanly. TUI users can manually retry; channel adapters already surface the soft error to the chat. Cron is where automatic retry delivers the most value today — unattended, no human to catch it.

**No CLI for multi-ref chains.** `typeclaw model set` still takes a single ref. Users hand-edit `typeclaw.json` for now. The single-string shorthand means minimal-fallback configs are one line; the ergonomics are acceptable until there's a clearer UX for the multi-step wizard.

**Chain exhaustion is a hard failure, not a notification.** When every ref in the chain fails, the cron job logs and moves on. There's no dead-letter queue or TUI alert. A future PR could emit a `broadcast` stream message so the TUI surfaces the exhaustion, but that's new surface area; the log line is sufficient for v1.

## Test coverage

```
src/agent/model-fallback.test.ts     +4 new tests (fallback helper: hard throw, soft error, chain exhaustion, success-on-second)
src/cron/consumer.test.ts            +2 new tests (cron integration: fallback on hard throw, fallback on soft error)
src/config/models-mutation.test.ts   +2 new tests (chain normalisation, missingProviders aggregation)
```

Total: 4198 pass, 0 fail (was 4194 pre-PR).

## Verification

```
bun run typecheck      clean
bun run lint           0 errors (17 pre-existing warnings in src/plugin/define.test.ts, src/cli/tunnel.ts, and other unrelated files)
bun run format         clean
bun test               4198 pass, 0 fail
```

## Out of scope

- **Server drain (TUI) fallback** — requires session-swap without dropping subscribers; deferred.
- **Channels router fallback** — same session-swap problem; deferred.
- **Subagent fallback** — subagents use `createSession` directly; would need the same `refOverride` threading; deferred.
- **`typeclaw model set` multi-ref** — CLI still takes a single ref; users hand-edit for chains.