### PR TITLE
agent-browser: auto-inject default User-Agent in shim

### DIFF
--- a/src/bundled-plugins/agent-browser/shim.test.ts
+++ b/src/bundled-plugins/agent-browser/shim.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from 'bun:test'
 
-import { classifyDashboardCommand, rewriteDashboardArgs, runShim } from './shim'
+import {
+  DEFAULT_USER_AGENT,
+  USER_AGENT_ENV,
+  classifyDashboardCommand,
+  hasUserAgentFlag,
+  injectUserAgentEnv,
+  rewriteDashboardArgs,
+  runShim,
+} from './shim'
 
 describe('classifyDashboardCommand', () => {
   test.each([
@@ -152,5 +160,108 @@ describe('runShim', () => {
     })
 
     expect(exit).toBe(42)
+  })
+
+  test('injects default user-agent env when caller passes neither flag nor env', async () => {
+    const env: Record<string, string | undefined> = {}
+
+    await runShim({
+      argv: ['open', 'https://example.com'],
+      realBin: '/stub/agent-browser',
+      env,
+      spawn: () => ({ exited: Promise.resolve(0) }),
+    })
+
+    expect(env[USER_AGENT_ENV]).toBe(DEFAULT_USER_AGENT)
+  })
+
+  test('respects an explicit --user-agent flag: leaves env unset', async () => {
+    const env: Record<string, string | undefined> = {}
+
+    await runShim({
+      argv: ['open', 'https://example.com', '--user-agent', 'CustomBot/1.0'],
+      realBin: '/stub/agent-browser',
+      env,
+      spawn: () => ({ exited: Promise.resolve(0) }),
+    })
+
+    expect(env[USER_AGENT_ENV]).toBeUndefined()
+  })
+
+  test('respects a pre-set AGENT_BROWSER_USER_AGENT env: does not overwrite', async () => {
+    const env: Record<string, string | undefined> = { [USER_AGENT_ENV]: 'OperatorOverride/1.0' }
+
+    await runShim({
+      argv: ['open', 'https://example.com'],
+      realBin: '/stub/agent-browser',
+      env,
+      spawn: () => ({ exited: Promise.resolve(0) }),
+    })
+
+    expect(env[USER_AGENT_ENV]).toBe('OperatorOverride/1.0')
+  })
+
+  test('injection applies to dashboard subcommands too', async () => {
+    const env: Record<string, string | undefined> = {}
+
+    await runShim({
+      argv: ['dashboard'],
+      realBin: '/stub/agent-browser',
+      env,
+      spawn: () => ({ exited: Promise.resolve(0) }),
+    })
+
+    expect(env[USER_AGENT_ENV]).toBe(DEFAULT_USER_AGENT)
+  })
+})
+
+describe('hasUserAgentFlag', () => {
+  test.each([
+    [['--user-agent', 'foo'], true],
+    [['--user-agent=foo'], true],
+    [['open', 'https://example.com', '--user-agent', 'foo'], true],
+    [['open', 'https://example.com'], false],
+    [[], false],
+    [['--user-agent-extra', 'foo'], false],
+  ] as [string[], boolean][])('%j → %s', (argv, expected) => {
+    expect(hasUserAgentFlag(argv)).toBe(expected)
+  })
+})
+
+describe('injectUserAgentEnv', () => {
+  test('sets env when neither flag nor env is present', () => {
+    const env: Record<string, string | undefined> = {}
+    injectUserAgentEnv(['open', 'https://example.com'], env)
+    expect(env[USER_AGENT_ENV]).toBe(DEFAULT_USER_AGENT)
+  })
+
+  test('skips when --user-agent flag is present', () => {
+    const env: Record<string, string | undefined> = {}
+    injectUserAgentEnv(['open', '--user-agent', 'Bot/1.0'], env)
+    expect(env[USER_AGENT_ENV]).toBeUndefined()
+  })
+
+  test('skips when --user-agent=value form is present', () => {
+    const env: Record<string, string | undefined> = {}
+    injectUserAgentEnv(['open', '--user-agent=Bot/1.0'], env)
+    expect(env[USER_AGENT_ENV]).toBeUndefined()
+  })
+
+  test('skips when env is already set', () => {
+    const env: Record<string, string | undefined> = { [USER_AGENT_ENV]: 'Existing/1.0' }
+    injectUserAgentEnv(['open'], env)
+    expect(env[USER_AGENT_ENV]).toBe('Existing/1.0')
+  })
+
+  test('overwrites when env is set to empty string (treated as unset)', () => {
+    const env: Record<string, string | undefined> = { [USER_AGENT_ENV]: '' }
+    injectUserAgentEnv(['open'], env)
+    expect(env[USER_AGENT_ENV]).toBe(DEFAULT_USER_AGENT)
+  })
+
+  test('accepts a custom default for testing', () => {
+    const env: Record<string, string | undefined> = {}
+    injectUserAgentEnv(['open'], env, 'CustomDefault/2.0')
+    expect(env[USER_AGENT_ENV]).toBe('CustomDefault/2.0')
   })
 })

--- a/src/bundled-plugins/agent-browser/shim.test.ts
+++ b/src/bundled-plugins/agent-browser/shim.test.ts
@@ -215,6 +215,19 @@ describe('runShim', () => {
   })
 })
 
+describe('DEFAULT_USER_AGENT', () => {
+  test('advertises Linux x86_64 to match the container runtime', () => {
+    // The shim only runs inside the TypeClaw Linux container. A macOS or
+    // Windows UA would create a platform mismatch that stricter bot detectors
+    // (Cloudflare, Akamai) flag as suspicious. Linux UA is also correct on
+    // linux/arm64 containers because Chrome does not expose ARM in the UA.
+    expect(DEFAULT_USER_AGENT).toContain('X11; Linux x86_64')
+    expect(DEFAULT_USER_AGENT).not.toContain('Macintosh')
+    expect(DEFAULT_USER_AGENT).not.toContain('Windows')
+    expect(DEFAULT_USER_AGENT).not.toContain('HeadlessChrome')
+  })
+})
+
 describe('hasUserAgentFlag', () => {
   test.each([
     [['--user-agent', 'foo'], true],

--- a/src/bundled-plugins/agent-browser/shim.ts
+++ b/src/bundled-plugins/agent-browser/shim.ts
@@ -17,6 +17,43 @@ import { AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT } from './dashboard-proxy'
 
 export const REAL_BIN_ENV = 'TYPECLAW_AGENT_BROWSER_REAL_BIN'
 
+// Recent desktop Chrome on macOS. The upstream binary defaults to a UA that
+// includes "HeadlessChrome" / a stale Chromium build, which is widely
+// fingerprinted as a bot and silently triggers CAPTCHAs, 403s, blank pages,
+// and A/B-test misrouting. Bump on Chrome major releases — same hygiene as
+// the curl-impersonate pin in src/init/dockerfile.ts.
+export const DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+
+export const USER_AGENT_ENV = 'AGENT_BROWSER_USER_AGENT'
+
+export function hasUserAgentFlag(argv: readonly string[]): boolean {
+  // Matches both `--user-agent <val>` and `--user-agent=<val>`. The upstream
+  // CLI does not document a short alias for --user-agent today (verified via
+  // `agent-browser --help`), so we only check the long form.
+  for (const arg of argv) {
+    if (arg === '--user-agent' || arg.startsWith('--user-agent=')) return true
+  }
+  return false
+}
+
+export function injectUserAgentEnv(
+  argv: readonly string[],
+  env: Record<string, string | undefined>,
+  defaultUa: string = DEFAULT_USER_AGENT,
+): void {
+  // Upstream's precedence is CLI flag > env > default. We only inject the
+  // env when BOTH layers above it are absent so:
+  //   - explicit `--user-agent foo` wins (mobile testing, intentional bot UA)
+  //   - operator-set AGENT_BROWSER_USER_AGENT wins (per-shell override)
+  //   - default UA fills the otherwise-empty slot
+  // `set device "iPhone 14"` is unaffected: it sets UA via CDP at runtime,
+  // not through this env var, so our injection doesn't fight device emulation.
+  if (env[USER_AGENT_ENV] !== undefined && env[USER_AGENT_ENV] !== '') return
+  if (hasUserAgentFlag(argv)) return
+  env[USER_AGENT_ENV] = defaultUa
+}
+
 export type DashboardIntent = 'start' | 'stop' | 'other'
 
 export function classifyDashboardCommand(argv: readonly string[]): DashboardIntent {
@@ -111,6 +148,7 @@ export type ShimOptions = {
   realBin?: string
   upstreamPort?: number
   spawn?: (cmd: string[]) => { exited: Promise<number> }
+  env?: Record<string, string | undefined>
 }
 
 export async function runShim(opts: ShimOptions = {}): Promise<number> {
@@ -118,6 +156,9 @@ export async function runShim(opts: ShimOptions = {}): Promise<number> {
   const realBin = opts.realBin ?? resolveRealAgentBrowserBin()
   const upstreamPort = opts.upstreamPort ?? AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT
   const spawn = opts.spawn ?? defaultSpawn
+  const env = opts.env ?? process.env
+
+  injectUserAgentEnv(argv, env)
 
   const intent = classifyDashboardCommand(argv)
   if (intent !== 'start') {

--- a/src/bundled-plugins/agent-browser/shim.ts
+++ b/src/bundled-plugins/agent-browser/shim.ts
@@ -17,13 +17,19 @@ import { AGENT_BROWSER_DASHBOARD_UPSTREAM_PORT } from './dashboard-proxy'
 
 export const REAL_BIN_ENV = 'TYPECLAW_AGENT_BROWSER_REAL_BIN'
 
-// Recent desktop Chrome on macOS. The upstream binary defaults to a UA that
-// includes "HeadlessChrome" / a stale Chromium build, which is widely
-// fingerprinted as a bot and silently triggers CAPTCHAs, 403s, blank pages,
-// and A/B-test misrouting. Bump on Chrome major releases — same hygiene as
-// the curl-impersonate pin in src/init/dockerfile.ts.
+// Recent desktop Chrome on Linux x86_64. The shim runs inside the TypeClaw
+// container (always Linux), so a macOS or Windows UA would mismatch the TCP
+// fingerprint, Accept-Language, and JS-side platform — itself a bot signal on
+// stricter sites (Cloudflare, Akamai, PerimeterX). `X11; Linux x86_64` is
+// also correct on linux/arm64 hosts: Chrome on Linux does not expose ARM in
+// the UA string at all (verified against current Chrome 131 releases).
+// The upstream binary defaults to a UA that includes "HeadlessChrome" /
+// a stale Chromium build, which is widely fingerprinted as a bot and
+// silently triggers CAPTCHAs, 403s, blank pages, and A/B-test misrouting.
+// Bump on Chrome major releases — same hygiene as the curl-impersonate pin
+// in src/init/dockerfile.ts.
 export const DEFAULT_USER_AGENT =
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
 
 export const USER_AGENT_ENV = 'AGENT_BROWSER_USER_AGENT'
 


### PR DESCRIPTION
## Problem

The upstream `agent-browser` binary defaults to a User-Agent containing `HeadlessChrome` or a stale Chromium build string — widely fingerprinted by bot-detection stacks at the TLS-handshake layer, before any HTTP header is read. The result is silent degradation: CAPTCHAs, 403s, blank pages, A/B routing to bot-only experiences. The failure is slow to diagnose because the page loads "fine" from the agent's perspective.

The previous mitigation was prose in a personal skill file outside this repo: tell the LLM to pass `--user-agent` on every invocation. Three failure modes:

- The model forgets.
- Sub-process calls the model doesn't control (e.g. `agent-browser chat` spawning its own internal LLM) bypass it entirely.
- Scripts and tools that shell out to `agent-browser` without going through the model get no coverage at all.

## Why the shim is the right injection layer

`shim.ts` PATH-shadows the upstream binary inside every TypeClaw container. Every caller — the model, a script the model wrote, any subcommand's internal invocation — routes through here. Same layer where `--port` rewriting for the dashboard subcommand already lives. The shim is the only point that catches them all without any caller cooperation.

## What changed

### `shim.ts` (+41 lines)

Three new exports and one `ShimOptions` field:

- `DEFAULT_USER_AGENT` — current desktop Chrome 131 UA string. Bump on Chrome major releases, same hygiene as the `curl-impersonate` pin in `src/init/dockerfile.ts`.
- `USER_AGENT_ENV` — the env var name (`AGENT_BROWSER_USER_AGENT`) the upstream CLI reads.
- `hasUserAgentFlag(argv)` — pure helper; detects both `--user-agent <val>` and `--user-agent=<val>` forms.
- `injectUserAgentEnv(argv, env, defaultUa?)` — sets the env var only when neither a CLI flag nor a non-empty env var is already present.
- `env?` added to `ShimOptions` (defaults to `process.env`) so tests can inject an isolated env map.

`runShim` calls `injectUserAgentEnv` before dispatching, so injection applies uniformly to every subcommand: `open`, `snapshot`, `batch`, `chat`, `dashboard`, and any future additions.

### `shim.test.ts` (+112 lines, 16 new tests)

Four describe blocks:

- **runShim** (4 new): injects when no flag or env is set; skips when `--user-agent` flag is present; skips when env is pre-set; applies to dashboard subcommands.
- **hasUserAgentFlag** (6 test.each): both flag forms, with and without leading args, empty argv, and a similar-but-non-matching flag.
- **injectUserAgentEnv** (6): inject when clean; skip on flag; skip on `--user-agent=value` form; skip on pre-set env; treat empty-string env as unset; custom default arg.

All 68 plugin tests pass. Mutation check: commenting out the `injectUserAgentEnv` call in `runShim` fails 4 tests.

## Design decisions

**Inject only when the caller didn't provide one.** All override paths are preserved:

- `--user-agent` flag wins (mobile testing, intentional bot UA, user's real Chrome via `--auto-connect`).
- Operator-set `AGENT_BROWSER_USER_AGENT` wins (per-shell or per-container override).
- Empty-string env is treated as unset — avoids a silent no-op from `ENV AGENT_BROWSER_USER_AGENT=` in a Dockerfile.

**Hardcoded constant in `shim.ts`, not config.** Matches the existing precedent of the `curl-impersonate` pin in `src/init/dockerfile.ts` (AGENTS.md §"Web search" documents this bump-on-Chrome-major pattern). Adding schema surface and reload semantics for a value most operators will never touch is over-engineering.

**Env injection, not argv rewriting.** Works uniformly across every subcommand without needing to know each command's arg shape. The upstream CLI reads `AGENT_BROWSER_USER_AGENT` with CLI-flag > env > default precedence, so a caller's flag still wins without any argv parsing or stripping on our side.

**`set device` interaction is safe.** Device emulation sets UA via CDP at runtime, not through the env var, so mobile testing flows are unaffected.