### PR TITLE
init: run OAuth login the moment the user picks it

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1013,4 +1013,81 @@ describe('collectWizardInputs back-aware flow', () => {
     // never reaches runOAuthLogin.
     expect(calls).toEqual(['pick-auth-method:zai', 'pick-auth-method:openai-codex', 'run-oauth-login', 'pick-channel'])
   })
+
+  test('oauth path: stale pendingBackOrigin from a pre-OAuth back is cleared by recovery prompt', async () => {
+    // Regression for the bug surfaced by self-review: a back press from
+    // enter-api-key (which sets pendingBackOrigin = 'enter-api-key') followed
+    // by an autoValue OAuth attempt + OAuth failure + recovery=api-key would
+    // route back to enter-api-key. The user's first back press there would
+    // see the stale pendingBackOrigin and spuriously abort the wizard.
+    let askApiKeyCalls = 0
+    let askApiKeyBackCount = 0
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'value', value: 'openai' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: openaiModel }),
+      pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
+      runOAuthLogin: async () => ({ ok: false, reason: 'failed' }),
+      askOAuthFailureRecovery: async () => 'api-key',
+      askApiKey: async () => {
+        askApiKeyCalls += 1
+        if (askApiKeyCalls === 1) {
+          askApiKeyBackCount += 1
+          return { kind: 'back' }
+        }
+        return { kind: 'value', value: 'sk_recovered' }
+      },
+      pickChannel: async () => ({ kind: 'value', value: 'none' }),
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    // The single back press at enter-api-key must NOT abort — pendingBackOrigin
+    // was reset by the recovery prompt, so this is treated as a first-back.
+    expect(askApiKeyBackCount).toBe(1)
+    expect(result.llmAuth).toEqual({ kind: 'api-key', apiKey: 'sk_recovered' })
+  })
+
+  test('oauth path: WizardAbortedError carries oauthCredentialsSaved=true after a successful OAuth', async () => {
+    // Successful OAuth, then user aborts later (double-back from pick-channel).
+    // The wizard must surface that credentials were already written so the CLI
+    // can warn the user instead of exiting silently.
+    let channelBacks = 0
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: codexModel }),
+      pickAuthMethod: async () => ({ kind: 'value', value: 'oauth', auto: true }),
+      runOAuthLogin: async () => ({ ok: true }),
+      pickChannel: async () => {
+        channelBacks += 1
+        return { kind: 'back' }
+      },
+    })
+
+    try {
+      await collectWizardInputs('/agent', prompts)
+      throw new Error('expected WizardAbortedError')
+    } catch (error) {
+      expect(error).toBeInstanceOf(WizardAbortedError)
+      expect((error as WizardAbortedError).oauthCredentialsSaved).toBe(true)
+    }
+    expect(channelBacks).toBeGreaterThanOrEqual(1)
+  })
+
+  test('oauth path: WizardAbortedError.oauthCredentialsSaved is false when OAuth never succeeded', async () => {
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: codexModel }),
+      pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
+      runOAuthLogin: async () => ({ ok: false, reason: 'nope' }),
+      askOAuthFailureRecovery: async () => 'abort',
+    })
+
+    try {
+      await collectWizardInputs('/agent', prompts)
+      throw new Error('expected WizardAbortedError')
+    } catch (error) {
+      expect(error).toBeInstanceOf(WizardAbortedError)
+      expect((error as WizardAbortedError).oauthCredentialsSaved).toBe(false)
+    }
+  })
 })

--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -116,6 +116,7 @@ describe('collectWizardInputs back-aware flow', () => {
       askReuseExistingChannel: async () => ({ kind: 'value', value: 'prompt' }),
       runChannelFlow: async () => ({ kind: 'value', value: {} }),
       runOAuthLogin: async () => ({ ok: true }),
+      askOAuthFailureRecovery: async () => 'abort',
       ...overrides,
     }
   }
@@ -844,7 +845,7 @@ describe('collectWizardInputs back-aware flow', () => {
     expect(result.llmAuth).toEqual({ kind: 'oauth-completed' })
   })
 
-  test('oauth path: login failure keeps user on pick-auth-method for retry', async () => {
+  test('oauth path: login failure prompts recovery; user picks retry and succeeds', async () => {
     const calls: string[] = []
     let loginAttempt = 0
     let authMethodCalls = 0
@@ -862,6 +863,10 @@ describe('collectWizardInputs back-aware flow', () => {
         if (loginAttempt === 1) return { ok: false, reason: 'browser closed' }
         return { ok: true }
       },
+      askOAuthFailureRecovery: async (provider, reason) => {
+        calls.push(`recovery:${provider.id}:${reason}`)
+        return 'retry'
+      },
       pickChannel: async () => {
         calls.push('pick-channel')
         return { kind: 'value', value: 'none' }
@@ -873,11 +878,103 @@ describe('collectWizardInputs back-aware flow', () => {
     expect(calls).toEqual([
       'pick-auth-method:1',
       'run-oauth-login:1',
+      'recovery:openai-codex:browser closed',
       'pick-auth-method:2',
       'run-oauth-login:2',
       'pick-channel',
     ])
     expect(result.llmAuth).toEqual({ kind: 'oauth-completed' })
+  })
+
+  test('oauth path: login failure → user picks api-key fallback routes to enter-api-key', async () => {
+    const calls: string[] = []
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'value', value: 'openai' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: openaiModel }),
+      pickAuthMethod: async () => {
+        calls.push('pick-auth-method')
+        return { kind: 'value', value: 'oauth' }
+      },
+      runOAuthLogin: async () => {
+        calls.push('run-oauth-login')
+        return { ok: false, reason: 'token revoked' }
+      },
+      askOAuthFailureRecovery: async (_provider, _reason, apiKeyAvailable) => {
+        calls.push(`recovery:apiKeyAvailable=${apiKeyAvailable}`)
+        return 'api-key'
+      },
+      askApiKey: async () => {
+        calls.push('enter-api-key')
+        return { kind: 'value', value: 'sk_fallback' }
+      },
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        return { kind: 'value', value: 'none' }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual([
+      'pick-auth-method',
+      'run-oauth-login',
+      'recovery:apiKeyAvailable=true',
+      'enter-api-key',
+      'pick-channel',
+    ])
+    expect(result.llmAuth).toEqual({ kind: 'api-key', apiKey: 'sk_fallback' })
+  })
+
+  test('oauth path: login failure → user picks abort throws WizardAbortedError', async () => {
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: codexModel }),
+      pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
+      runOAuthLogin: async () => ({ ok: false, reason: 'cancelled' }),
+      askOAuthFailureRecovery: async () => 'abort',
+    })
+
+    await expect(collectWizardInputs('/agent', prompts)).rejects.toThrow(WizardAbortedError)
+  })
+
+  test('oauth path: oauth-only provider gets apiKeyAvailable=false in recovery prompt', async () => {
+    let apiKeyAvailableSeen: boolean | undefined
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: codexModel }),
+      pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
+      runOAuthLogin: async () => ({ ok: false, reason: 'whatever' }),
+      askOAuthFailureRecovery: async (_provider, _reason, apiKeyAvailable) => {
+        apiKeyAvailableSeen = apiKeyAvailable
+        return 'abort'
+      },
+    })
+
+    await expect(collectWizardInputs('/agent', prompts)).rejects.toThrow(WizardAbortedError)
+    expect(apiKeyAvailableSeen).toBe(false)
+  })
+
+  test('oauth path: runner that throws is coerced to a failure recovery prompt (init never crashes)', async () => {
+    const calls: string[] = []
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: codexModel }),
+      pickAuthMethod: async () => {
+        calls.push('pick-auth-method')
+        return { kind: 'value', value: 'oauth' }
+      },
+      runOAuthLogin: async () => {
+        calls.push('run-oauth-login')
+        throw new Error('unexpected runner crash')
+      },
+      askOAuthFailureRecovery: async (_provider, reason) => {
+        calls.push(`recovery:${reason}`)
+        return 'abort'
+      },
+    })
+
+    await expect(collectWizardInputs('/agent', prompts)).rejects.toThrow(WizardAbortedError)
+    expect(calls).toEqual(['pick-auth-method', 'run-oauth-login', 'recovery:unexpected runner crash'])
   })
 
   test('oauth path: vision profile also runs login inside the wizard when provider differs', async () => {

--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test'
 
 import { KNOWN_PROVIDERS, type KnownProviderId } from '@/config/providers'
-import type { LLMAuth } from '@/init'
 import type { ModelOption } from '@/init/models-dev'
 
 import { collectWizardInputs, decideExistingApiKeyReuse, WizardAbortedError, type WizardPrompts } from './init'
@@ -116,7 +115,7 @@ describe('collectWizardInputs back-aware flow', () => {
       hasExistingChannelSecrets: async () => false,
       askReuseExistingChannel: async () => ({ kind: 'value', value: 'prompt' }),
       runChannelFlow: async () => ({ kind: 'value', value: {} }),
-      buildOAuthAuth: () => ({ kind: 'oauth', runLogin: async () => ({ ok: true }) }) as LLMAuth,
+      runOAuthLogin: async () => ({ ok: true }),
       ...overrides,
     }
   }
@@ -813,5 +812,108 @@ describe('collectWizardInputs back-aware flow', () => {
         auth: { type: 'pat', pat: 'ghp_test' },
       },
     })
+  })
+
+  test('oauth path: runs login inside the wizard, before pick-channel', async () => {
+    const calls: string[] = []
+    const loginCalls: Array<{ cwd: string; model: string; providerName: string }> = []
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: codexModel }),
+      pickAuthMethod: async () => {
+        calls.push('pick-auth-method')
+        return { kind: 'value', value: 'oauth' }
+      },
+      runOAuthLogin: async (provider, cwd, model) => {
+        loginCalls.push({ cwd, model, providerName: provider.name })
+        calls.push('run-oauth-login')
+        return { ok: true }
+      },
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        return { kind: 'value', value: 'none' }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(loginCalls).toEqual([
+      { cwd: '/agent', model: codexModel.ref, providerName: KNOWN_PROVIDERS['openai-codex'].name },
+    ])
+    expect(calls).toEqual(['pick-auth-method', 'run-oauth-login', 'pick-channel'])
+    expect(result.llmAuth).toEqual({ kind: 'oauth-completed' })
+  })
+
+  test('oauth path: login failure keeps user on pick-auth-method for retry', async () => {
+    const calls: string[] = []
+    let loginAttempt = 0
+    let authMethodCalls = 0
+    const prompts = makePrompts({
+      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: codexModel }),
+      pickAuthMethod: async () => {
+        authMethodCalls += 1
+        calls.push(`pick-auth-method:${authMethodCalls}`)
+        return { kind: 'value', value: 'oauth' }
+      },
+      runOAuthLogin: async () => {
+        loginAttempt += 1
+        calls.push(`run-oauth-login:${loginAttempt}`)
+        if (loginAttempt === 1) return { ok: false, reason: 'browser closed' }
+        return { ok: true }
+      },
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        return { kind: 'value', value: 'none' }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(calls).toEqual([
+      'pick-auth-method:1',
+      'run-oauth-login:1',
+      'pick-auth-method:2',
+      'run-oauth-login:2',
+      'pick-channel',
+    ])
+    expect(result.llmAuth).toEqual({ kind: 'oauth-completed' })
+  })
+
+  test('oauth path: vision profile also runs login inside the wizard when provider differs', async () => {
+    const calls: string[] = []
+    const loginCalls: Array<{ cwd: string; model: string; providerName: string }> = []
+    const prompts = makePrompts({
+      loadCatalog: async () => ({ options: [zaiTextOnlyModel, codexModel], source: 'curated' }),
+      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
+      askApiKey: async () => ({ kind: 'value', value: 'zai_key' }),
+      pickVisionProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVisionModel: async () => ({ kind: 'value', value: codexModel }),
+      pickAuthMethod: async (provider) => {
+        calls.push(`pick-auth-method:${provider.id}`)
+        return { kind: 'value', value: provider.id === 'openai-codex' ? 'oauth' : 'api-key' }
+      },
+      runOAuthLogin: async (provider, cwd, model) => {
+        loginCalls.push({ cwd, model, providerName: provider.name })
+        calls.push('run-oauth-login')
+        return { ok: true }
+      },
+      pickChannel: async () => {
+        calls.push('pick-channel')
+        return { kind: 'value', value: 'none' }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(loginCalls).toEqual([
+      { cwd: '/agent', model: codexModel.ref, providerName: KNOWN_PROVIDERS['openai-codex'].name },
+    ])
+    expect(result.vision?.llmAuth).toEqual({ kind: 'oauth-completed' })
+    // OAuth login runs immediately after the vision provider's auth method is
+    // picked — before pick-channel. The default provider (Z.AI, api-key only)
+    // never reaches runOAuthLogin.
+    expect(calls).toEqual(['pick-auth-method:zai', 'pick-auth-method:openai-codex', 'run-oauth-login', 'pick-channel'])
   })
 })

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -55,9 +55,15 @@ import { c, done, errorLine } from './ui'
 // a clean exit. Inside an active clack prompt Ctrl+C is still aliased to
 // cancel, so the abort hotkey is "cancel twice in a row".
 export class WizardAbortedError extends Error {
-  constructor() {
+  // When the wizard ran a successful eager OAuth login before aborting, the
+  // resulting credentials are already on disk at `<cwd>/secrets.json`. The
+  // CLI surfaces this on abort so the user knows to either re-run init in
+  // the same directory (the credentials will be reused) or delete the file.
+  readonly oauthCredentialsSaved: boolean
+  constructor(options: { oauthCredentialsSaved?: boolean } = {}) {
     super('Wizard aborted by user')
     this.name = 'WizardAbortedError'
+    this.oauthCredentialsSaved = options.oauthCredentialsSaved === true
   }
 }
 
@@ -124,6 +130,16 @@ export const init = defineCommand({
       collected = await collectWizardInputs(cwd, defaultWizardPrompts)
     } catch (error) {
       if (error instanceof WizardAbortedError) {
+        if (error.oauthCredentialsSaved) {
+          note(
+            [
+              'OAuth credentials were saved to `secrets.json` before you aborted.',
+              'Re-run `typeclaw init` here to pick up where you left off (the credentials',
+              'will be reused), or delete `secrets.json` if you want a clean restart.',
+            ].join('\n'),
+            'Saved OAuth credentials',
+          )
+        }
         cancel('Aborted.')
         process.exit(0)
       }
@@ -367,10 +383,15 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
   const state: WizardState = { catalog }
   let step: StepId = 'pick-provider'
   let pendingBackOrigin: StepId | null = null
+  let oauthCredentialsSaved = false
+
+  const abort = (): never => {
+    throw new WizardAbortedError({ oauthCredentialsSaved })
+  }
 
   const onResult = <T>(currentStep: StepId, result: StepResult<T>): StepResult<T> => {
     if (result.kind === 'back') {
-      if (pendingBackOrigin === currentStep) throw new WizardAbortedError()
+      if (pendingBackOrigin === currentStep) abort()
       pendingBackOrigin = currentStep
     } else if (!result.auto) {
       pendingBackOrigin = null
@@ -452,12 +473,19 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
               login.reason,
               providerSupportsApiKey(provider),
             )
-            if (recovery === 'abort') throw new WizardAbortedError()
+            // The recovery prompt is a fresh user decision, so it must clear
+            // any back-token left over from an earlier step. Without this, a
+            // sequence like `enter-api-key → back → autoValue('oauth') →
+            // OAuth fails → recovery=api-key → enter-api-key` would treat the
+            // user's NEXT back press as a double-back and abort the wizard.
+            pendingBackOrigin = null
+            if (recovery === 'abort') abort()
             state.authMethod = recovery === 'api-key' ? 'api-key' : undefined
             state.llmAuth = undefined
             step = recovery === 'api-key' ? 'enter-api-key' : 'pick-auth-method'
             break
           }
+          oauthCredentialsSaved = true
           state.llmAuth = { kind: 'oauth-completed' }
           step = stepAfterDefaultAuth(state)
         } else {
@@ -554,12 +582,16 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
               login.reason,
               providerSupportsApiKey(provider),
             )
-            if (recovery === 'abort') throw new WizardAbortedError()
+            // See the matching pendingBackOrigin reset in the default-provider
+            // branch above — same reasoning applies to vision auth recovery.
+            pendingBackOrigin = null
+            if (recovery === 'abort') abort()
             state.visionAuthMethod = recovery === 'api-key' ? 'api-key' : undefined
             state.visionLlmAuth = undefined
             step = recovery === 'api-key' ? 'enter-vision-api-key' : 'pick-vision-auth-method'
             break
           }
+          oauthCredentialsSaved = true
           state.visionLlmAuth = { kind: 'oauth-completed' }
           step = 'pick-channel'
         } else {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -331,7 +331,18 @@ export interface WizardPrompts {
     cwd: string,
     model: KnownModelRef,
   ) => Promise<OAuthLoginResult>
+  // Asked after a failed OAuth login. `apiKeyAvailable` is true when the
+  // provider also supports api-key auth (so the wizard can offer a fallback
+  // path); false for OAuth-only providers like openai-codex, where the only
+  // options are retry or abort.
+  askOAuthFailureRecovery: (
+    provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+    reason: string,
+    apiKeyAvailable: boolean,
+  ) => Promise<OAuthFailureRecovery>
 }
+
+export type OAuthFailureRecovery = 'retry' | 'api-key' | 'abort'
 
 export const defaultWizardPrompts: WizardPrompts = {
   loadCatalog,
@@ -348,6 +359,7 @@ export const defaultWizardPrompts: WizardPrompts = {
   askReuseExistingChannel,
   runChannelFlow,
   runOAuthLogin: (provider, cwd, model) => makeOAuthLoginRunner(buildOAuthCallbacks(provider.name))({ cwd, model }),
+  askOAuthFailureRecovery,
 }
 
 export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): Promise<CollectedInputs> {
@@ -430,13 +442,20 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
         if (result.value === 'oauth') {
           // Run the browser login eagerly so the user sees the OAuth URL the
           // moment they pick "OAuth (browser login)" — not at the end of the
-          // wizard. On failure we stay on this step so the user can retry or
-          // fall back to API key without losing the rest of their inputs.
-          const login = await prompts.runOAuthLogin(provider, cwd, state.model!.ref)
+          // wizard. On failure we ask the user how to recover (retry / fall
+          // back to API key / abort) instead of dumping them back into the
+          // auth method picker with no guidance.
+          const login = await runOAuthLoginSafely(prompts, provider, cwd, state.model!.ref)
           if (!login.ok) {
-            log.error(`OAuth login failed: ${login.reason}`)
-            state.authMethod = undefined
+            const recovery = await prompts.askOAuthFailureRecovery(
+              provider,
+              login.reason,
+              providerSupportsApiKey(provider),
+            )
+            if (recovery === 'abort') throw new WizardAbortedError()
+            state.authMethod = recovery === 'api-key' ? 'api-key' : undefined
             state.llmAuth = undefined
+            step = recovery === 'api-key' ? 'enter-api-key' : 'pick-auth-method'
             break
           }
           state.llmAuth = { kind: 'oauth-completed' }
@@ -527,12 +546,18 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
         }
         state.visionAuthMethod = result.value
         if (result.value === 'oauth') {
-          // Same eager-login rationale as the default-provider branch above.
-          const login = await prompts.runOAuthLogin(provider, cwd, state.visionModel!.ref)
+          // Same eager-login + recovery-prompt rationale as the default-provider branch above.
+          const login = await runOAuthLoginSafely(prompts, provider, cwd, state.visionModel!.ref)
           if (!login.ok) {
-            log.error(`OAuth login failed: ${login.reason}`)
-            state.visionAuthMethod = undefined
+            const recovery = await prompts.askOAuthFailureRecovery(
+              provider,
+              login.reason,
+              providerSupportsApiKey(provider),
+            )
+            if (recovery === 'abort') throw new WizardAbortedError()
+            state.visionAuthMethod = recovery === 'api-key' ? 'api-key' : undefined
             state.visionLlmAuth = undefined
+            step = recovery === 'api-key' ? 'enter-vision-api-key' : 'pick-vision-auth-method'
             break
           }
           state.visionLlmAuth = { kind: 'oauth-completed' }
@@ -604,6 +629,25 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
         return finalize(state, result.value)
       }
     }
+  }
+}
+
+// Belt-and-suspenders wrapper: `makeOAuthLoginRunner` already catches the
+// upstream pi-ai login flow and returns `{ ok: false, reason }`, but the
+// wizard cannot afford ANY uncaught throw from a custom runner (test seam,
+// future plugin-contributed runner) — it would bubble out of
+// `collectWizardInputs` and exit the whole init. Coerce unexpected throws to
+// the normal failure path so the recovery prompt always fires.
+async function runOAuthLoginSafely(
+  prompts: WizardPrompts,
+  provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+  cwd: string,
+  model: KnownModelRef,
+): Promise<OAuthLoginResult> {
+  try {
+    return await prompts.runOAuthLogin(provider, cwd, model)
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
   }
 }
 
@@ -803,6 +847,28 @@ async function askApiKey(provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]): P
   })
   if (isCancel(apiKey)) return back()
   return value(apiKey)
+}
+
+async function askOAuthFailureRecovery(
+  provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+  reason: string,
+  apiKeyAvailable: boolean,
+): Promise<OAuthFailureRecovery> {
+  note(reason, `${provider.name} OAuth login failed`)
+  const options: Array<{ value: OAuthFailureRecovery; label: string; hint?: string }> = [
+    { value: 'retry', label: 'Retry OAuth login' },
+  ]
+  if (apiKeyAvailable) {
+    options.push({ value: 'api-key', label: `Use a ${provider.name} API key instead` })
+  }
+  options.push({ value: 'abort', label: 'Abort init', hint: 'you can re-run `typeclaw init` later' })
+  const choice = await select<OAuthFailureRecovery>({
+    message: 'What next?',
+    options,
+    initialValue: 'retry',
+  })
+  if (isCancel(choice)) return 'abort'
+  return choice
 }
 
 async function pickChannel(initial: ChannelChoice | undefined): Promise<StepResult<ChannelChoice>> {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -11,7 +11,7 @@ import {
   type KnownModelRef,
   type KnownProviderId,
 } from '@/config/providers'
-import type { DockerAvailability } from '@/container'
+import { checkDockerAvailable, type DockerAvailability } from '@/container'
 import {
   findAgentDir,
   formatEagerGithubWebhookInstallResult,
@@ -29,7 +29,7 @@ import {
 } from '@/init'
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { fetchModelOptions, type ModelOption } from '@/init/models-dev'
-import { makeOAuthLoginRunner } from '@/init/oauth-login'
+import { makeOAuthLoginRunner, type OAuthLoginResult } from '@/init/oauth-login'
 
 import { buildOAuthCallbacks } from './oauth-callbacks'
 import { c, done, errorLine } from './ui'
@@ -102,6 +102,22 @@ export const init = defineCommand({
 
     intro('Initializing TypeClaw...')
     log.info('Press ESC at any prompt to go back. Press ESC twice in a row to abort.')
+
+    // Docker preflight runs BEFORE the wizard so an OAuth login (which the
+    // wizard fires the moment the user picks "OAuth (browser login)") doesn't
+    // burn a real browser flow on an agent folder we can't actually start.
+    // `runInit` re-runs the preflight as a defense-in-depth gate, but
+    // surfacing the failure here lets the user fix Docker without re-doing
+    // every wizard step.
+    const preflightSpinner = spinner()
+    preflightSpinner.start('Checking Docker...')
+    const preflight = await checkDockerAvailable()
+    if (!preflight.ok) {
+      preflightSpinner.error(preflightFailureSummary(preflight))
+      note(preflightFailureGuidance(preflight).join('\n'), 'Docker check failed')
+      process.exit(1)
+    }
+    preflightSpinner.stop('Docker is reachable.')
 
     let collected: CollectedInputs
     try {
@@ -310,7 +326,11 @@ export interface WizardPrompts {
   hasExistingChannelSecrets: (cwd: string, channel: Exclude<ChannelChoice, 'none'>) => Promise<boolean>
   askReuseExistingChannel: (channel: Exclude<ChannelChoice, 'none'>) => Promise<StepResult<'reuse' | 'prompt'>>
   runChannelFlow: (choice: ChannelChoice) => Promise<StepResult<CollectedInputs['channelSecrets']>>
-  buildOAuthAuth: (provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]) => LLMAuth
+  runOAuthLogin: (
+    provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
+    cwd: string,
+    model: KnownModelRef,
+  ) => Promise<OAuthLoginResult>
 }
 
 export const defaultWizardPrompts: WizardPrompts = {
@@ -327,10 +347,7 @@ export const defaultWizardPrompts: WizardPrompts = {
   hasExistingChannelSecrets,
   askReuseExistingChannel,
   runChannelFlow,
-  buildOAuthAuth: (provider) => ({
-    kind: 'oauth',
-    runLogin: makeOAuthLoginRunner(buildOAuthCallbacks(provider.name)),
-  }),
+  runOAuthLogin: (provider, cwd, model) => makeOAuthLoginRunner(buildOAuthCallbacks(provider.name))({ cwd, model }),
 }
 
 export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): Promise<CollectedInputs> {
@@ -411,7 +428,18 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
         }
         state.authMethod = result.value
         if (result.value === 'oauth') {
-          state.llmAuth = prompts.buildOAuthAuth(provider)
+          // Run the browser login eagerly so the user sees the OAuth URL the
+          // moment they pick "OAuth (browser login)" — not at the end of the
+          // wizard. On failure we stay on this step so the user can retry or
+          // fall back to API key without losing the rest of their inputs.
+          const login = await prompts.runOAuthLogin(provider, cwd, state.model!.ref)
+          if (!login.ok) {
+            log.error(`OAuth login failed: ${login.reason}`)
+            state.authMethod = undefined
+            state.llmAuth = undefined
+            break
+          }
+          state.llmAuth = { kind: 'oauth-completed' }
           step = stepAfterDefaultAuth(state)
         } else {
           step = 'enter-api-key'
@@ -499,7 +527,15 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
         }
         state.visionAuthMethod = result.value
         if (result.value === 'oauth') {
-          state.visionLlmAuth = prompts.buildOAuthAuth(provider)
+          // Same eager-login rationale as the default-provider branch above.
+          const login = await prompts.runOAuthLogin(provider, cwd, state.visionModel!.ref)
+          if (!login.ok) {
+            log.error(`OAuth login failed: ${login.reason}`)
+            state.visionAuthMethod = undefined
+            state.visionLlmAuth = undefined
+            break
+          }
+          state.visionLlmAuth = { kind: 'oauth-completed' }
           step = 'pick-channel'
         } else {
           step = 'enter-vision-api-key'

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -595,6 +595,25 @@ describe('runInit', () => {
     expect(events.some((e) => e.step === 'oauth-login')).toBe(false)
   })
 
+  test('oauth-completed: skips the oauth-login step and writes no API key', async () => {
+    const events: InitStepEvent[] = []
+
+    await runInit({
+      cwd: root,
+      model: 'openai-codex/gpt-5.5',
+      llmAuth: { kind: 'oauth-completed' },
+      runHatching: okHatch,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+      onProgress: (e) => events.push(e),
+    })
+
+    expect(events.some((e) => e.step === 'oauth-login')).toBe(false)
+    expect(events.map((e) => `${e.step}:${e.phase}`)).toContain('scaffold:done')
+    expect(existsSync(join(root, '.env'))).toBe(false)
+    expect(existsSync(join(root, 'secrets.json'))).toBe(false)
+  })
+
   test('throws when neither apiKey nor llmAuth is provided', async () => {
     await expect(
       runInit({ cwd: root, runHatching: okHatch, runBunInstall: okInstall, dockerExec: okDocker }),

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -614,6 +614,29 @@ describe('runInit', () => {
     expect(existsSync(join(root, 'secrets.json'))).toBe(false)
   })
 
+  test('oauth-completed (vision): different provider with oauth-completed skips oauth-login, no vision API key', async () => {
+    const events: InitStepEvent[] = []
+
+    await runInit({
+      cwd: root,
+      model: 'zai/glm-4.6',
+      apiKey: 'zai_test_key',
+      visionModel: 'openai-codex/gpt-5.5',
+      visionAuth: { kind: 'oauth-completed' },
+      runHatching: okHatch,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+      onProgress: (e) => events.push(e),
+    })
+
+    expect(events.some((e) => e.step === 'oauth-login')).toBe(false)
+    expect(events.map((e) => `${e.step}:${e.phase}`)).toContain('scaffold:done')
+
+    const secrets = await readSecrets(root)
+    expect(secrets.providers?.zai).toBeDefined()
+    expect(secrets.providers?.['openai-codex']).toBeUndefined()
+  })
+
   test('throws when neither apiKey nor llmAuth is provided', async () => {
     await expect(
       runInit({ cwd: root, runHatching: okHatch, runBunInstall: okInstall, dockerExec: okDocker }),

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -234,8 +234,8 @@ export async function runInit({
   // Same trap as kakaotalk-auth: scaffold-then-fail-auth would leave
   // typeclaw.json without working credentials and the runtime would silently
   // refuse to boot. The login itself doesn't need the agent folder to exist
-  // — pi-ai's OAuth helper just needs a writable path for secrets.json, which
-  // we create on demand inside scaffold().
+  // — pi-ai's OAuth helper just needs a writable path for secrets.json, and
+  // the `mkdir` below creates it on demand before the login runs.
   if (resolvedAuth.kind === 'oauth') {
     emit({ step: 'oauth-login', phase: 'start' })
     await mkdir(cwd, { recursive: true })

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -121,7 +121,18 @@ export type KakaotalkAuthRunner = (options: { cwd: string }) => Promise<Kakaotal
 // API-key provider". Optional model defaults to DEFAULT_MODEL_REF, which is
 // an OpenAI api-key provider — so test fixtures that omit both fields keep
 // working under the api-key path.
-export type LLMAuth = { kind: 'api-key'; apiKey: string } | { kind: 'oauth'; runLogin: OAuthLoginRunner }
+//
+// `oauth-completed` is the CLI wizard's signal that the browser login already
+// happened up-front (right after the user picked the auth method) and the
+// resulting credentials are already in `secrets.json`. `runInit` then skips
+// the `oauth-login` step but still treats this as an OAuth provider (no API
+// key written, etc.). The wizard runs OAuth eagerly so the browser opens the
+// moment the user picks "OAuth (browser login)" instead of waiting until the
+// end of the wizard — see `collectWizardInputs` in `src/cli/init.ts`.
+export type LLMAuth =
+  | { kind: 'api-key'; apiKey: string }
+  | { kind: 'oauth'; runLogin: OAuthLoginRunner }
+  | { kind: 'oauth-completed' }
 
 export type InitOptions = {
   cwd: string


### PR DESCRIPTION
## Why

During init, selecting "OAuth (browser login)" set a lazy runner in wizard state instead of opening the browser immediately. The wizard kept asking about vision profiles, channels, and channel secrets — the browser only opened once `runInit` reached its oauth-login step, after Docker preflight. The gap could span a dozen more prompts, and any answers the user gave after the auth pick were at risk if they bailed mid-OAuth.

The same problem affected the vision profile path: picking OAuth for a separate vision provider also deferred the browser flow to the very end.

## What changed

### Eager OAuth inside the wizard (`src/cli/init.ts`)

The WizardPrompts interface drops buildOAuthAuth (which returned a lazy auth object) in favour of runOAuthLogin, which fires the browser flow immediately and returns an OAuthLoginResult. The two step handlers — pick-auth-method and pick-vision-auth-method — call it directly the moment the user selects `oauth`.
On success they materialize the oauth-completed auth kind and advance. On failure they surface the error and stay on the same step, so the user can retry or fall back to api-key without losing any other wizard inputs.

### The oauth-completed LLMAuth variant (`src/init/index.ts`)

LLMAuth gains a third discriminant: `{ kind: 'oauth-completed' }`. It signals that the browser flow already happened and credentials are in secrets.json, so runInit skips its own oauth-login step.
runInit still treats the provider as OAuth — no API key is written and no env var is emitted. The existing check for the plain `oauth` kind naturally doesn't match the new variant, so no further changes in runInit were needed.

### Docker preflight moves above the wizard (`src/cli/init.ts`)

With OAuth firing eagerly inside the wizard, discovering a broken Docker install only at the end of runInit would burn a real browser login on an agent folder that can never start. The preflight now runs before the wizard opens. `runInit` still re-runs it as a defense-in-depth gate, so users only fix Docker once instead of redoing every wizard step after a real OAuth exchange.

## Tests

157 pass / 0 fail in the affected files. 4 263 pass / 0 fail across the full suite.

New case in `src/init/index.test.ts`:
- The oauth-completed variant skips the oauth-login step and writes no API key.

New cases in `src/cli/init.test.ts`:
- Happy path — step order is pick-auth-method → runOAuthLogin → pick-channel; result carries `{ kind: 'oauth-completed' }`.
- Failure-then-retry — first attempt fails; wizard stays on pick-auth-method; second attempt succeeds.
- Vision profile — when the vision provider differs and is OAuth-capable, runOAuthLogin fires for that provider too; the default provider path is unaffected.

All existing tests still pass. The only test-side breaking change was renaming buildOAuthAuth to runOAuthLogin in the default makePrompts builder, applied mechanically.