### PR TITLE
memory: reduce memory-logger spawn cadence and tighten capture bias

### DIFF
--- a/src/bundled-plugins/memory/README.md
+++ b/src/bundled-plugins/memory/README.md
@@ -9,8 +9,8 @@ This plugin is **auto-loaded** by every TypeClaw agent. There is no `plugins[]` 
 ```json
 {
   "memory": {
-    "idleMs": 10000,
-    "bufferBytes": 100000,
+    "idleMs": 60000,
+    "bufferBytes": 500000,
     "dreaming": { "schedule": "*/30 * * * *" }
   }
 }
@@ -18,8 +18,8 @@ This plugin is **auto-loaded** by every TypeClaw agent. There is no `plugins[]` 
 
 | Field                      | Default            | Effect                                                                                                                                                                                                                                                                                                                                                             |
 | -------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `memory.idleMs`            | `10000`            | Debounce window before `memory-logger` spawns after a prompt completes. Minimum `1000`.                                                                                                                                                                                                                                                                            |
-| `memory.bufferBytes`       | `100000`           | Size-based ceiling: spawns `memory-logger` when the transcript grows by this many bytes since the last run, even during continuous activity. `0` disables. Minimum `10000` when non-zero.                                                                                                                                                                          |
+| `memory.idleMs`            | `60000`            | Debounce window before `memory-logger` spawns after a prompt completes. Minimum `1000`. Default bumped from `10000` to `60000` to reduce spawn churn during conversational sessions where the agent goes idle for short periods between rapid back-and-forth turns.                                                                                                |
+| `memory.bufferBytes`       | `500000`           | Size-based ceiling: spawns `memory-logger` when the transcript grows by this many bytes since the last run, even during continuous activity. `0` disables. Minimum `10000` when non-zero. Default bumped from `100000` to `500000` so a single conversational session stays within one memory-logger run unless it grows past ~half a megabyte of transcript.      |
 | `memory.dreaming`          | `{}` (cron job on) | Dreaming cron job is always registered. Override `schedule` to change when it fires.                                                                                                                                                                                                                                                                               |
 | `memory.dreaming.schedule` | `"*/30 * * * *"`   | Five-field cron expression. Defaults to every 30 minutes; fires short-circuit with zero LLM cost when nothing sits past the watermark, so frequent no-op fires are cheap and let sporadic agents still consolidate while alive (`src/cron/scheduler.ts` has no catchup for missed fires). Second-level schedules are rejected to avoid noisy no-op dreaming loops. |
 

--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -119,7 +119,13 @@ describe('memory plugin shape', () => {
     expect(exports.cronJobs?.dreaming?.schedule).toBe('*/30 * * * *')
   })
 
-  test('default config injects an idleMs of 10 seconds and a default dreaming schedule', async () => {
+  test('default config injects an idleMs of 60 seconds and a default dreaming schedule', async () => {
+    const parsed = memoryPlugin.configSchema!.safeParse({})
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect((parsed.data as { idleMs: number }).idleMs).toBe(60_000)
+    }
+
     const { exports: noDream } = await bootMemoryPlugin(agentDir, {})
     expect(noDream.cronJobs?.dreaming?.schedule).toBe('*/30 * * * *')
 
@@ -320,11 +326,11 @@ describe('session.end hook', () => {
 })
 
 describe('bufferBytes config', () => {
-  test('defaults to 100_000 when omitted', async () => {
+  test('defaults to 500_000 when omitted', async () => {
     const parsed = memoryPlugin.configSchema!.safeParse({})
     expect(parsed.success).toBe(true)
     if (parsed.success) {
-      expect((parsed.data as { bufferBytes: number }).bufferBytes).toBe(100_000)
+      expect((parsed.data as { bufferBytes: number }).bufferBytes).toBe(500_000)
     }
   })
 

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -12,8 +12,8 @@ import { createDreamingSubagent, type DreamingPayload } from './dreaming'
 import { createMemoryLoggerSubagent, type MemoryLoggerPayload } from './memory-logger'
 import { runMigration } from './migration'
 
-const DEFAULT_IDLE_MS = 10_000
-const DEFAULT_BUFFER_BYTES = 100_000
+const DEFAULT_IDLE_MS = 60_000
+const DEFAULT_BUFFER_BYTES = 500_000
 const MIN_BUFFER_BYTES = 10_000
 // 30-minute default. Fires short-circuit before any LLM call when nothing
 // sits past the watermark (`dreaming.ts` handler returns when

--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -113,10 +113,17 @@ describe('MEMORY_LOGGER_SYSTEM_PROMPT', () => {
     expect(MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()).toContain('under-writing')
   })
 
-  test('declares a "when in doubt, capture" capture philosophy (no behavior-change gate)', () => {
+  test('declares a "when in doubt, SKIP" capture philosophy biased toward low fragment counts', () => {
     const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
-    expect(lower).toContain('when in doubt')
-    expect(lower).toMatch(/lean toward capture|err on writing it|cheaper than a missed/)
+    expect(lower).toContain('when in doubt, skip')
+    expect(lower).toMatch(/zero or one fragment|recurrence|skipping costs nothing/)
+  })
+
+  test('lists chat-mechanical anti-patterns explicitly so the subagent stops recording them', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('conversational mechanics')
+    expect(lower).toContain('group-chat membership events')
+    expect(lower).toMatch(/single-occurrence|one event produces at most one fragment/)
   })
 
   test('does not require fragments to articulate a future behavior change', () => {

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -58,9 +58,9 @@ export function isMemoryLoggerPayload(value: unknown): value is MemoryLoggerPayl
 
 export const MEMORY_LOGGER_SYSTEM_PROMPT = `You are typeclaw's memory-extraction subagent.
 
-Your job is to read a session transcript and capture, as fragments, everything memorable about what happened — facts about the user, the project, decisions made, explicit user preferences, patterns, surprises, anything that could plausibly matter to a future agent in a future session. You write zero or more fragments to today's memory stream file. Then you exit.
+Your job is to read a session transcript and capture, as fragments, only the durable operational facts a future agent in a future session would concretely need — explicit user instructions, stable identity/role/tool facts, decisions with reasoning, reproducible workarounds, contradictions or violations of existing memory. You write zero or more fragments to today's memory stream file. Then you exit. Most runs produce zero or one fragment; that is the expected output, not a failure.
 
-A separate \`dreaming\` subagent runs later. It consolidates your fragments into long-term memory, dedupes, drops near-duplicates, resolves contradictions, and decides what generalizes. **You are the additive layer; dreaming is the filter.** This division of labor is the whole point: capture broadly here, and let dreaming throw away what doesn't last.
+A separate \`dreaming\` subagent runs later. It consolidates your fragments into long-term memory, dedupes, drops near-duplicates, resolves contradictions, and decides what generalizes. **Dreaming is downstream filtering, not an excuse to over-capture upstream.** Writing five low-signal fragments and trusting dreaming to throw four away wastes tokens at both layers and pollutes MEMORY.md in the interim. Be selective here.
 
 You have exactly four tools: \`read\`, \`find_entry\`, \`append\`, and the watermark-advance tool. You cannot run shell commands, overwrite files, or edit existing content.
 
@@ -78,41 +78,52 @@ Typical flow with a watermark:
 
 Never write the same watermark id you were given as input. If the transcript has no new entries past the watermark, evaluate the entries you can see, then advance the watermark to the latest \`id\` in the transcript (which is on line \`totalLines\` from \`find_entry\`'s reply). The whole point of the watermark is to move forward each run.
 
-# Capture philosophy: when in doubt, capture
+# Capture philosophy: when in doubt, SKIP
 
-The cost of a missing memory is high — a future agent repeats a mistake, asks a question already answered, or violates a commitment it should have inherited. The cost of a redundant memory is low — dreaming will collapse it.
+Most transcript content is **not** memorable. Conversations, group chat banter, casual reactions, one-off questions, and routine tool usage are the substrate of a session — they are not facts a future agent needs to inherit. The default is to skip.
 
-So: when in doubt, capture. A slightly redundant fragment is far cheaper than a missed one.
+Most runs should produce **zero or one** fragment. Two or more fragments is the exception, justified only when the transcript actually contains multiple unrelated durable facts. A run that produces five-plus fragments is almost always over-writing.
 
-You do **not** need to articulate, before writing a fragment, exactly how a future agent will use it. Useful patterns often only become visible after dreaming has seen the same thing twice. Your job is to make that pattern detection possible by writing the first occurrence down.
+The watermark advances even with zero fragments via the watermark-advance tool, so skipping costs nothing. A wrong-skip is recoverable: if the same fact recurs in a later session, you will see it again and can capture it then — recurrence is itself the strongest signal that something is worth remembering.
+
+You do **not** need to articulate how a future agent will use a fragment. But you DO need to be able to name a concrete future situation where ignoring this fragment would cause a real problem. If you cannot name that situation in one sentence, skip.
 
 The two failure modes:
 
-- **Under-writing.** Skipping fragments because you couldn't articulate their future utility, or because you held the bar too high. The agent repeats mistakes that the transcript could have prevented.
-- **Over-writing into pure noise.** Recording trivially re-derivable facts (e.g. "the user pressed enter"), session-mechanical chatter ("the agent acknowledged the message"), or restating things every prompt already includes. This bloats the daily stream and makes dreaming's job harder, not impossible.
+- **Over-writing into noise.** Recording chat-mechanical observations ("X asked Y a question", "Z said ㅋㅋㅋ", "new participant introduced", "user observed agent has personality"), single-occurrence quotes with no operational consequence, or paraphrases of conversation flow. This is the dominant failure mode in practice. It bloats the daily stream, drowns dreaming in low-signal noise, and pollutes MEMORY.md.
+- **Under-writing.** Skipping a fragment that names an explicit user instruction, a stable identity/role/tool fact, a violated commitment, or a reproducible workaround. Rare in practice; the bar to capture these is whether the fact is durable AND operational, not whether you can imagine some future use.
 
-Aim well clear of pure noise; otherwise lean toward capture.
+When unsure, skip. Recurrence will surface real patterns.
 
 # What to capture
 
-Anything from the transcript that fits one of these is worth a fragment. This is a starting list, not a closed set:
+The bar is high. A fragment is worth writing only when ALL of these hold:
 
-- **Stable facts about the user, project, or environment.** Names, roles, tools, conventions, dependencies, deadlines, constraints, paths, configurations, account/team/repo names. Even ones mentioned in passing.
-- **Decisions and their reasoning.** "We chose X over Y because Z." The why is often more valuable than the what.
-- **Explicit commitments and operating rules.** Things the user directly told the agent to always/never do. Style guides. Workflow preferences. House conventions. Do not infer new standing duties from events; record the event or preference instead.
-- **Patterns that recurred or were named.** "We always do this" / "this is the third time we've hit this bug" / "this is how the team works."
-- **Contradictions of existing memory.** The user changed their mind, the project changed direction, an old commitment no longer applies. Write the new state and name the prior memory it supersedes.
-- **Violations of existing memory.** If the agent just did something that prior memory said not to do — that violation is itself a high-value fragment. Capture it.
-- **Surprises and corrections.** Places where the user pushed back, where the agent's mental model was wrong, where something didn't work the way it "should" have.
-- **Observable user reactions, framed as observations.** It's fine to note that the user expressed frustration, satisfaction, urgency, or reluctance — capture it as something observed, with the evidence ("user said: '...'"). Don't claim to know motives; just record what was visible. Dreaming decides if a pattern is real.
-- **Reusable knowledge produced this session.** A non-trivial debugging insight, a workaround, a configuration that finally worked, a procedure the user walked the agent through.
+1. The fact is **durable** — it will still be true in a future session, not a one-off event.
+2. The fact is **operational** — a future agent acting without this knowledge would do something concretely wrong (give wrong answer, repeat a fixed mistake, violate an instruction, reinvent a workaround).
+3. The evidence is **explicit** in the transcript — a direct quote, a code change, a configuration, a documented decision.
 
-# What to skip
+Capture-worthy categories:
 
-- **Mechanical session noise.** Tool acknowledgments, "ok," "thanks," progress chatter, the agent narrating its own steps.
-- **Things every session prompt already includes.** Don't re-record what's in MEMORY.md verbatim, what's in AGENTS.md, or what's hardcoded into the agent's system prompt.
-- **Trivially re-derivable facts.** "User used a Mac" if the transcript shows them running \`brew install\` is fine to skip — the next session will see the same signal.
-- **Pure speculation untethered to evidence.** If you can't point at the transcript for what makes this true, don't write it.
+- **Explicit operating rules the user just gave the agent.** "Always X." "Never Y." "From now on do Z." Direct instructions to the agent itself, not statements about other people.
+- **Stable identity/role/tool facts that will keep mattering.** "User's project repo is X." "User runs Y on Z." Skip casual employment history, casual social-graph trivia, and "this person joined the chat" events — those are derivable from current context when needed.
+- **Decisions with reasoning.** "We chose X over Y because Z" — when X is something the agent will need to honor in a future session.
+- **Reproducible workarounds and non-trivial debugging insights.** Configuration that finally worked, a flag combination that bypassed a known block, a procedure with concrete steps.
+- **Contradictions of existing memory.** The user changed their mind, an old commitment no longer applies. Name the prior memory that is superseded.
+- **Violations of existing memory.** The agent just broke an existing commitment — capture the violation itself.
+- **Corrections the user made to the agent.** Specifically when the agent confidently asserted something false and the user corrected it, in a way that a future session would likely also get wrong.
+
+# What to skip (anti-patterns — these come up constantly)
+
+- **Conversational mechanics.** "X asked Y a question." "Z said hello." "Participant A reacted with ㅋㅋㅋ / 👍 / lol." "User tested the agent's response time." None of this is memory.
+- **Single-occurrence casual reactions.** "User observed the agent has personality." "Group chat member is amused by the bot." Wait for recurrence; if it never recurs, it was never memory.
+- **Group-chat membership events.** "X invited Y to chat Z." "New participant joined." This is derivable from the current channel context and changes constantly.
+- **Casual social-graph trivia.** "X used to work at Y." "Z is a friend of W." Skip unless the user explicitly says it will matter ("remember, X is the one who built our Y").
+- **Latency / performance pings.** "User asked how fast the agent responded." Not memory.
+- **The agent's own first-person observations.** "The agent admitted it does not know its model." "The agent replied in character." Skip — the agent is not memorable to itself.
+- **Re-derivable facts.** Anything obvious from the current session's system prompt, MEMORY.md, AGENTS.md, or the channel context.
+- **Speculation untethered to a quote.** If you cannot point at a specific transcript line, do not write it.
+- **Multi-fragment expansions of one event.** One event produces at most one fragment. Splitting one introduction into "new chat", "new participant", "new participant's job", "new participant's reaction" is over-writing.
 
 # Never quote secret values
 
@@ -135,7 +146,7 @@ Before reading the transcript, read \`MEMORY.md\` and the current \`memory/yyyy-
 - **Notice violations.** If existing memory contains a commitment the agent just broke, that's a high-value fragment.
 - **Avoid pure restatement.** If a fact is already in MEMORY.md word-for-word, don't write the same fragment again. But: if the transcript shows the same fact occurring a second time, that recurrence is itself worth a fragment — dreaming uses repetition to decide what's stable.
 
-Light dedup, not strict dedup. When unsure whether something is "already known," err on writing it. Dreaming will collapse duplicates.
+Strict dedup. If a fact is already in MEMORY.md or today's stream, do not re-record it just because it came up again. The exception is recurrence that itself is the news: write a new fragment only when the recurrence shifts the fact's status (e.g. a tentative pattern is now confirmed across multiple days, or an old commitment was just violated).
 
 The \`append\` tool refuses byte-equivalent fragments within the same daily stream — if your fragment's topic+body is identical to one already in today's file (modulo whitespace), the tool will reject it and you must rewrite. Two reasonable rewrites: (1) skip the fragment entirely, (2) frame the new occurrence explicitly as "this is the second time today" with a different topic. Do not retry an identical fragment with a different \`entry=\` hoping it will land — content-equality, not marker-equality, is what's checked.
 

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -100,7 +100,7 @@ When unsure, skip. Recurrence will surface real patterns.
 The bar is high. A fragment is worth writing only when ALL of these hold:
 
 1. The fact is **durable** — it will still be true in a future session, not a one-off event.
-2. The fact is **operational** — a future agent acting without this knowledge would do something concretely wrong (give wrong answer, repeat a fixed mistake, violate an instruction, reinvent a workaround).
+2. The fact is **actionable context** — a future agent acting without this knowledge would likely do something worse: give a wrong answer, violate a stated preference, repeat a fixed mistake, miss relevant context, or reinvent a workaround. Stable preferences ("user prefers tabs over spaces") count even though they are not "operational" in a strict procedural sense.
 3. The evidence is **explicit** in the transcript — a direct quote, a code change, a configuration, a documented decision.
 
 Capture-worthy categories:
@@ -146,7 +146,7 @@ Before reading the transcript, read \`MEMORY.md\` and the current \`memory/yyyy-
 - **Notice violations.** If existing memory contains a commitment the agent just broke, that's a high-value fragment.
 - **Avoid pure restatement.** If a fact is already in MEMORY.md word-for-word, don't write the same fragment again. But: if the transcript shows the same fact occurring a second time, that recurrence is itself worth a fragment — dreaming uses repetition to decide what's stable.
 
-Strict dedup. If a fact is already in MEMORY.md or today's stream, do not re-record it just because it came up again. The exception is recurrence that itself is the news: write a new fragment only when the recurrence shifts the fact's status (e.g. a tentative pattern is now confirmed across multiple days, or an old commitment was just violated).
+Dedup byte-equivalent restatements, not meaningful recurrence. Do not write a fragment that is a near-copy of one already in MEMORY.md or today's stream. But when the transcript shows the same durable preference, pattern, workaround, or commitment recurring in a NEW session or on a NEW day, write a concise recurrence fragment anchored to the new evidence — even if the underlying fact is already known. The dreaming subagent uses distinct-day recurrence to promote tentative facts to confident ones; refusing to write the second or third occurrence starves that signal. The bar is "did the recurrence happen in a meaningfully new context", not "is the fact already on disk".
 
 The \`append\` tool refuses byte-equivalent fragments within the same daily stream — if your fragment's topic+body is identical to one already in today's file (modulo whitespace), the tool will reject it and you must rewrite. Two reasonable rewrites: (1) skip the fragment entirely, (2) frame the new occurrence explicitly as "this is the second time today" with a different topic. Do not retry an identical fragment with a different \`entry=\` hoping it will land — content-equality, not marker-equality, is what's checked.
 
@@ -280,8 +280,16 @@ export function createMemoryLoggerSubagent(
     customTools: [findEntryTool, appendTool, advanceWatermarkTool],
     payloadSchema: memoryLoggerPayloadSchema,
     inFlightKey: (payload) => payload.agentDir,
+    // 768 KB read budget. Sized to cover one full buffer-trip cycle:
+    // ~30 KB MEMORY.md + ~50 KB today's stream + up to `DEFAULT_BUFFER_BYTES`
+    // (500 KB) of unread transcript chunk, with margin for re-reads. A
+    // smaller budget (the prior 256 KB) systematically exhausted on
+    // buffer-trip spawns once `bufferBytes` exceeded ~200 KB — the
+    // subagent would advance `bytesAtLastRun` to the full transcript size
+    // on completion, orphaning the unread tail until another full
+    // `bufferBytes` of growth arrived.
     toolResultBudget: {
-      maxTotalBytes: 256 * 1024,
+      maxTotalBytes: 768 * 1024,
       toolNames: ['read'],
       exhaustedMessage: memoryLoggerExhaustedMessage,
     },

--- a/src/skills/typeclaw-memory/SKILL.md
+++ b/src/skills/typeclaw-memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typeclaw-memory
-description: Use this skill whenever the user asks what you remember, what you forgot, what you dreamed, why a fact is or isn't in your memory, when memory consolidation happens, or whenever you are about to read or write `MEMORY.md`, anything under `memory/`, or `memory/skills/`. Triggers include "what do you remember", "do you remember X", "forget that", "what did you dream", "when do you dream next", "why did you forget X", "edit MEMORY.md", "add to memory", "your daily streams", "memory-logger", "dreaming", "muscle memory", or any mention of `memory.idleMs` / `memory.dreaming.schedule` in `typeclaw.json`. Read it before you touch any memory file — `MEMORY.md` and `memory/yyyy-MM-dd.jsonl` are runtime-owned, hand-edits are easy to do wrong, and the user almost always means something more specific than "edit memory" when they say it.
+description: Use this skill whenever the user asks what you remember, what you forgot, what you dreamed, why a fact is or isn't in your memory, when memory consolidation happens, or whenever you are about to read or write `MEMORY.md`, anything under `memory/`, or `memory/skills/`. Triggers include "what do you remember", "do you remember X", "forget that", "what did you dream", "when do you dream next", "why did you forget X", "edit MEMORY.md", "add to memory", "your daily streams", "memory-logger", "dreaming", "muscle memory", or any mention of `memory.idleMs` / `memory.bufferBytes` / `memory.dreaming.schedule` in `typeclaw.json`. Read it before you touch any memory file — `MEMORY.md` and `memory/yyyy-MM-dd.jsonl` are runtime-owned, hand-edits are easy to do wrong, and the user almost always means something more specific than "edit memory" when they say it.
 ---
 
 # typeclaw-memory
@@ -139,24 +139,26 @@ Stay concrete. Use this map:
 
 `typeclaw init` does **not** scaffold any of these. They appear when needed — `MEMORY.md` and `memory/` are created by the first dreaming run; daily streams appear when the first memory-logger fires.
 
-## When the user asks about `memory.idleMs` or `memory.dreaming.schedule`
+## When the user asks about `memory.idleMs`, `memory.bufferBytes`, or `memory.dreaming.schedule`
 
-These are the only two configurable knobs. They live in the `memory` block of `typeclaw.json`:
+These are the configurable knobs. They live in the `memory` block of `typeclaw.json`:
 
 ```json
 {
   "memory": {
     "idleMs": 60000,
+    "bufferBytes": 500000,
     "dreaming": { "schedule": "*/30 * * * *" }
   }
 }
 ```
 
-| Field                      | Default              | Effect                                                                                                                                                                                                        | Reload class      |
-| -------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `memory.idleMs`            | `60000` (min `1000`) | Debounce window before `memory-logger` spawns after a prompt completes.                                                                                                                                       | Restart-required. |
-| `memory.dreaming`          | `{}` (cron job on)   | Dreaming cron job is always registered. Override `schedule` to change when it fires.                                                                                                                          | Restart-required. |
-| `memory.dreaming.schedule` | `"*/30 * * * *"`     | Cron expression. Parsed via `cron-parser`; an invalid expression fails config load. Fires with nothing past the watermark short-circuit before any LLM call, so frequent no-op fires are intentionally cheap. | Restart-required. |
+| Field                      | Default               | Effect                                                                                                                                                                                                                                                                              | Reload class      |
+| -------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `memory.idleMs`            | `60000` (min `1000`)  | Debounce window before `memory-logger` spawns after a prompt completes.                                                                                                                                                                                                             | Restart-required. |
+| `memory.bufferBytes`       | `500000` (0 disables) | Size-based ceiling. Spawns `memory-logger` immediately when the transcript has grown by this many bytes since the last run, regardless of `idleMs`. Lets busy channel sessions still produce memory updates without waiting for a full quiet window. Minimum `10000` when non-zero. | Restart-required. |
+| `memory.dreaming`          | `{}` (cron job on)    | Dreaming cron job is always registered. Override `schedule` to change when it fires.                                                                                                                                                                                                | Restart-required. |
+| `memory.dreaming.schedule` | `"*/30 * * * *"`      | Cron expression. Parsed via `cron-parser`; an invalid expression fails config load. Fires with nothing past the watermark short-circuit before any LLM call, so frequent no-op fires are intentionally cheap.                                                                       | Restart-required. |
 
 Both fields are restart-required because plugin config is read once at boot. After editing them, tell the user: "Edited `memory.<field>` — restart-required. Run `typeclaw restart` (host stage) to pick up the change." The bundled plugin's config schema is merged into `typeclaw.schema.json`, so editor autocomplete will validate these fields, but a `reload` will not re-instantiate the plugin.
 

--- a/src/skills/typeclaw-memory/SKILL.md
+++ b/src/skills/typeclaw-memory/SKILL.md
@@ -13,7 +13,7 @@ This skill exists so you can answer the user's questions about your own memory h
 
 ### Stage 1: memory-logger (online, per-session)
 
-After every prompt completes, the runtime fires the `session.idle` hook. The memory plugin starts a debounce timer (`memory.idleMs`, default `10_000` ms; minimum `1000`). Every subsequent prompt completion resets the timer. When the user has been quiet for `idleMs`, the plugin spawns the **memory-logger** subagent for the current session. It also fires immediately on `session.end` (websocket close) so the final transcript never gets lost.
+After every prompt completes, the runtime fires the `session.idle` hook. The memory plugin starts a debounce timer (`memory.idleMs`, default `60_000` ms; minimum `1000`). Every subsequent prompt completion resets the timer. When the user has been quiet for `idleMs`, the plugin spawns the **memory-logger** subagent for the current session. It also fires immediately on `session.end` (websocket close) so the final transcript never gets lost.
 
 The memory-logger reads:
 
@@ -146,7 +146,7 @@ These are the only two configurable knobs. They live in the `memory` block of `t
 ```json
 {
   "memory": {
-    "idleMs": 10000,
+    "idleMs": 60000,
     "dreaming": { "schedule": "*/30 * * * *" }
   }
 }
@@ -154,7 +154,7 @@ These are the only two configurable knobs. They live in the `memory` block of `t
 
 | Field                      | Default              | Effect                                                                                                                                                                                                        | Reload class      |
 | -------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `memory.idleMs`            | `10000` (min `1000`) | Debounce window before `memory-logger` spawns after a prompt completes.                                                                                                                                       | Restart-required. |
+| `memory.idleMs`            | `60000` (min `1000`) | Debounce window before `memory-logger` spawns after a prompt completes.                                                                                                                                       | Restart-required. |
 | `memory.dreaming`          | `{}` (cron job on)   | Dreaming cron job is always registered. Override `schedule` to change when it fires.                                                                                                                          | Restart-required. |
 | `memory.dreaming.schedule` | `"*/30 * * * *"`     | Cron expression. Parsed via `cron-parser`; an invalid expression fails config load. Fires with nothing past the watermark short-circuit before any LLM call, so frequent no-op fires are intentionally cheap. | Restart-required. |
 


### PR DESCRIPTION
## Problem

The memory-logger subagent was spawning too aggressively on short conversational pauses (idleMs default: 10s) and on every 100KB of mixed transcript noise (bufferBytes default: 100KB). Its system prompt defaulted to "when in doubt, capture", which produced a flood of low-signal fragments in real production sessions.

Evidence from live channel sessions (specific contents are private):

- Conversational mechanics stored as facts (turn-by-turn exchange structure, e.g. "X asked Y a question")
- Single-occurrence casual reactions stored as durable observations (e.g. "Z said [casual reaction]")
- Group-chat membership and introduction events split into 3–4 fragments each
- Latency pings and response-time tests stored as memories
- Casual social-graph trivia (e.g. "A is a friend of B", "B introduced C")
- Agent first-person observations stored as user facts
- Dedup too lenient: repeated facts were re-fragmented every session
- One event split across multiple fragments where a single fragment was appropriate

The net effect was MEMORY.md growing with noise on every short session, burying the few durable facts worth keeping.

## Solution

Two coupled changes:

### 1. Cadence defaults (idleMs 10s → 60s, bufferBytes 100KB → 500KB)

Raises the spawning threshold so conversational sessions don't trigger memory-logger on every short pause or every 100KB of tool/chat noise. Most conversational sessions should now produce zero memory-logger runs; longer working sessions still trigger it when genuinely significant activity has accumulated.

### 2. Capture-bias flip: "when in doubt, capture" → "when in doubt, SKIP"

Rewrites `MEMORY_LOGGER_SYSTEM_PROMPT` with an explicit default-SKIP bias and adds concrete anti-patterns drawn from the production failure modes above:

- Conversational mechanics ("X asked Y a question", "Z said [casual reaction]")
- Single-occurrence casual reactions (one-time observations about a participant's personality or mood)
- Group-chat membership and introduction events
- Casual social-graph trivia ("A is a friend of B")
- Latency pings and response-time tests
- The agent's own first-person observations (not durable facts about the user)
- Multi-fragment expansions of one event (write one fragment, not three)

Dedup is tightened from "light, err on writing" to "dedup byte-equivalent restatements, not meaningful recurrence" — if a fact is substantially already in MEMORY.md, skip it. The exact wording and rationale are in commit 2.

## Self-review fixes (second commit)

Three fixes surfaced by oracle/explore self-review after the first commit:

1. **Read budget 256 KB → 768 KB** to match the new 500 KB bufferBytes default. The prior 256 KB ceiling would systematically exhaust on buffer-trip spawns once the unread transcript chunk exceeded ~200 KB. The plugin advances bytesAtLastRun to the full transcript size on completion, so an exhaustion would orphan the unread tail until another full bufferBytes of growth arrived.

2. **"Strict dedup" → "dedup byte-equivalent restatements, not meaningful recurrence"** in `MEMORY_LOGGER_SYSTEM_PROMPT`. The dreaming subagent uses distinct-day recurrence as its core promotion signal (tentative → confident at days ≥ 3, per the saturation policy in AGENTS.md). Refusing to write the second or third occurrence of a durable fact starves that signal.

3. **"Operational" → "actionable context"** in the capture bar, with an explicit note that stable preferences (e.g. "user prefers tabs over spaces") count even though they aren't operational in a strict procedural sense.

Also added: `memory.bufferBytes` was previously undocumented in `src/skills/typeclaw-memory/SKILL.md`. This PR adds it so the agent can answer user questions about it.

## Docs and tests updated

- `src/bundled-plugins/memory/README.md` — updated default table and capture-bias description
- `src/skills/typeclaw-memory/SKILL.md` — updated to reflect new defaults, SKIP bias, and bufferBytes field documentation
- `src/bundled-plugins/memory/index.test.ts` — updated default assertions (idleMs, bufferBytes)
- `src/bundled-plugins/memory/memory-logger.test.ts` — updated prompt content assertions

`typeclaw.schema.json` picks up the new defaults automatically via postinstall and is not tracked.

## Verification

```
bun run typecheck   ✓  clean
bun run lint        ✓  clean on changed files (17 pre-existing warnings in unrelated files)
bun run format      ✓  clean
bun test            ✓  4256/4256 pass
```

## Out of scope

Host-side log verbosity (the `[memory]` lines hostd emits when the daemon handles per-agent state) is intentionally untouched — the user clarified that the verbosity concern is about subagent capture behavior, not host-side logging.