### PR TITLE
docs(agents): name the audience and split dev guidance from architecture reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # Agent Guidelines
 
+> **Audience.** This file is for the AI assistant (or human contributor) working on the typeclaw source tree in this repo — the **dev stage** in `## Stages` below. It is **NOT** the runtime prompt for typeclaw agents (the in-container `typeclaw run` process). That prompt is composed in `src/agent/index.ts` via `composeSystemPrompt` and can be dumped with `bun run debug:prompt`. When sections below describe runtime behavior (secrets, permissions, hostd, etc.), they are describing what the code in `src/` does — not handing instructions to the runtime agent.
+>
+> The file is split into two parts:
+>
+> 1. **Part 1 — For you (the dev-stage assistant)**: scope, pre-commit, testing philosophy, file layout, where to put new code. Read top to bottom on first session.
+> 2. **Part 2 — Architecture reference**: stages, hostd, stream, secrets, permissions, tunnels, websearch, Xvfb. Long-form notes on what the runtime does and where it lives in the source tree. Consult on demand.
+
+# Part 1 — For you (the dev-stage assistant)
+
 ## Default scope
 
 If the user asks something, it's always about the typeclaw project itself until the user specifies another scope. Don't drift into upstream/downstream projects (agent-messenger, plugins consumed via npm, etc.) just because the conversation mentions them — answer in terms of typeclaw, and only switch scope when the user explicitly redirects you.
@@ -232,6 +241,10 @@ Domain logic lives in `src/<domain>/`. Examples: `src/init/`, `src/config/`, `sr
 - `src/cli/` is **UI only** — citty commands, clack prompts, spinners, `process.exit`. Delegate to `src/<domain>/` for anything testable.
 - Tests live next to code as `<file>.test.ts`.
 - Domain entry points are `src/<domain>/index.ts`. Split into multiple files only when a single file gets complex.
+
+# Part 2 — Architecture reference
+
+> The sections below describe what the runtime does and where it lives in the source tree. Use them as a map when working on a specific subsystem; you don't need to read them all on first session. When a section says "the agent," it means the **runtime typeclaw agent** (the in-container `typeclaw run` process), not you.
 
 ## Skills
 


### PR DESCRIPTION
## What

`AGENTS.md` was conflating two audiences — the dev-stage assistant working on the typeclaw source tree, and the in-container runtime agent. This commit names the audience at the top of the file and splits the body into two clearly labelled parts. No section content is moved or rewritten.

## Why

The file serves two very different readers:

1. **Dev-stage assistant** (the AI working on this repo). It needs commit conventions, pre-commit checks, the stage mental model, testing philosophy, and file layout — guidance that governs how source code is written and reviewed.
2. **Runtime agent** (the `typeclaw run` process inside the container). It reads a *different* `AGENTS.md`: the one in the operator's agent folder. `typeclaw init` scaffolds that file empty (`src/init/index.test.ts` line 812 asserts it is `''`), and the hatching flow in `src/init/hatching.ts` fills it in via a short user-driven conversation. The runtime agent's actual system prompt is composed in `composeSystemPrompt` in `src/agent/index.ts` and is inspectable via `bun run debug:prompt`.

The back half of the file (Skills, Secrets, Permissions, Host daemon, Tunnels, Message Stream, Web search, Xvfb) accurately describes what the runtime does, but the framing implies it is *instructions to the runtime* rather than *architecture reference for a developer*. That framing is wrong, and it creates a subtle risk: a future contributor reading the file could mistake operational runtime prose for dev-stage guidance and vice versa.

## How

Three additive edits, total +13 / -0:

1. **Top-of-file preamble** inserted after the `# Agent Guidelines` H1, before `## Default scope`. Names audience #1 explicitly, points at `composeSystemPrompt` and `bun run debug:prompt` for the runtime contract, and lists the two parts.
2. **Part 1 header** (`# Part 1 — For you (the dev-stage assistant)`) inserted before `## Default scope`. Covers: Default scope, Pre-commit checks, Debugging the system prompt, Release, Vocabulary, Stages, Testing Philosophy, File Layout.
3. **Part 2 header** (`# Part 2 — Architecture reference`) inserted before `## Skills`, with a one-line reframe noting that "the agent" in this part means the in-container runtime agent. Covers: Skills, Secrets, Permissions, Host daemon (hostd), Tunnels, Message Stream, Web search, Headed browser (Xvfb).

**Section boundary rationale.** `## Stages` stays in Part 1 because it is the foundational mental model every contributor needs when reading or writing code in this repo, and the preamble references the dev stage section as an anchor. `## Skills` opens Part 2 because its primary subject is runtime skill-discovery paths inside agent folders, which are purely a runtime concern.

## Why minimal-diff over rewrite

- **git blame survives.** Every existing line keeps its original commit and author. A structural rewrite would orphan several months of carefully attributed history across the file.
- **Cross-references survive.** `README.md` deep-links to `AGENTS.md#secrets`; several `src/` files reference the testing-philosophy and permissions sections by heading name. GitHub generates anchors from heading text only, so `#secrets`, `#testing-philosophy`, and `#permissions` all resolve correctly under any parent H1. None of these references break with additive-only edits.

## Verification

```
bun run typecheck   pass
bun run lint        pass  (17 pre-existing warnings, identical count and files vs main — none introduced by this change)
bun run format      pass  (only modified file: AGENTS.md)
bun test src/init/index.test.ts   124 pass — includes the assertion that init scaffolds an empty AGENTS.md, confirming this file is not what gets copied into agent folders
```

## Follow-up (optional)

If the audience-mixing concern persists after this lands and a structural fix is wanted, the natural next step is to lift Part 2 into `docs/architecture/` files, leaving a roughly 150-line `AGENTS.md`. This PR is the minimal framing fix.