### PR TITLE
cli: print Slack app manifest flush-left so users can copy-paste it

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -25,7 +25,7 @@ import {
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 
-import { c, done, errorLine } from './ui'
+import { c, done, errorLine, printSlackAppManifestSetup } from './ui'
 
 const CHANNEL_LABELS: Record<ChannelKind, string> = {
   'slack-bot': 'Slack',
@@ -834,50 +834,7 @@ async function promptDiscordToken(): Promise<string> {
 }
 
 async function promptSlackTokens(): Promise<{ bot: string; app: string }> {
-  note(
-    [
-      '1. https://api.slack.com/apps → Create New App → From a manifest.',
-      '   Pick your workspace, then paste this JSON manifest:',
-      '',
-      '   {',
-      '     "display_information": { "name": "TypeClaw" },',
-      '     "features": {',
-      '       "bot_user": { "display_name": "TypeClaw", "always_online": true }',
-      '     },',
-      '     "oauth_config": {',
-      '       "scopes": {',
-      '         "bot": [',
-      '           "app_mentions:read", "chat:write", "users:read", "files:read",',
-      '           "channels:history", "channels:read",',
-      '           "groups:history",   "groups:read",',
-      '           "im:history",       "im:read",',
-      '           "mpim:history",     "mpim:read"',
-      '         ]',
-      '       }',
-      '     },',
-      '     "settings": {',
-      '       "event_subscriptions": {',
-      '         "bot_events": [',
-      '           "app_mention",',
-      '           "message.channels", "message.groups",',
-      '           "message.im",       "message.mpim"',
-      '         ]',
-      '       },',
-      '       "socket_mode_enabled": true',
-      '     }',
-      '   }',
-      '',
-      '2. Install to Workspace, then OAuth & Permissions →',
-      '   copy the Bot User OAuth Token (xoxb-...).',
-      '3. Basic Information → App-Level Tokens → Generate Token and',
-      '   Scopes, add the connections:write scope, and copy the',
-      '   token (xapp-...). Socket Mode needs this; the manifest',
-      '   cannot grant it.',
-      '4. Invite the bot to any private channel or DM you want it in:',
-      '   /invite @TypeClaw',
-    ].join('\n'),
-    'Get a Slack bot',
-  )
+  printSlackAppManifestSetup()
   const bot = await promptSlackBotToken()
   note(
     [

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -32,7 +32,7 @@ import { fetchModelOptions, type ModelOption } from '@/init/models-dev'
 import { makeOAuthLoginRunner, type OAuthLoginResult } from '@/init/oauth-login'
 
 import { buildOAuthCallbacks } from './oauth-callbacks'
-import { c, done, errorLine } from './ui'
+import { c, done, errorLine, printSlackAppManifestSetup } from './ui'
 
 // ESC and Ctrl+C both produce clack's cancel symbol (the keypress layer
 // aliases both to the same "cancel" action — there's no way to tell them
@@ -1005,50 +1005,7 @@ async function runSlackFlow(): Promise<StepResult<CollectedInputs['channelSecret
   let sub: SubStep = 'bot'
   let botToken: string | undefined
 
-  note(
-    [
-      '1. https://api.slack.com/apps → Create New App → From a manifest.',
-      '   Pick your workspace, then paste this JSON manifest:',
-      '',
-      '   {',
-      '     "display_information": { "name": "TypeClaw" },',
-      '     "features": {',
-      '       "bot_user": { "display_name": "TypeClaw", "always_online": true }',
-      '     },',
-      '     "oauth_config": {',
-      '       "scopes": {',
-      '         "bot": [',
-      '           "app_mentions:read", "chat:write", "users:read", "files:read",',
-      '           "channels:history", "channels:read",',
-      '           "groups:history",   "groups:read",',
-      '           "im:history",       "im:read",',
-      '           "mpim:history",     "mpim:read"',
-      '         ]',
-      '       }',
-      '     },',
-      '     "settings": {',
-      '       "event_subscriptions": {',
-      '         "bot_events": [',
-      '           "app_mention",',
-      '           "message.channels", "message.groups",',
-      '           "message.im",       "message.mpim"',
-      '         ]',
-      '       },',
-      '       "socket_mode_enabled": true',
-      '     }',
-      '   }',
-      '',
-      '2. Install to Workspace, then OAuth & Permissions →',
-      '   copy the Bot User OAuth Token (xoxb-...).',
-      '3. Basic Information → App-Level Tokens → Generate Token and',
-      '   Scopes, add the connections:write scope, and copy the',
-      '   token (xapp-...). Socket Mode needs this; the manifest',
-      '   cannot grant it.',
-      '4. Invite the bot to any private channel or DM you want it in:',
-      '   /invite @TypeClaw',
-    ].join('\n'),
-    'Get a Slack bot',
-  )
+  printSlackAppManifestSetup()
 
   while (true) {
     if (sub === 'bot') {

--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -1,6 +1,17 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
-import { c, done, errorLine, link, renderStartSuccess, spinner, successLine, type StartLikeResult } from './ui'
+import {
+  c,
+  done,
+  errorLine,
+  link,
+  printSlackAppManifestSetup,
+  renderStartSuccess,
+  SLACK_APP_MANIFEST,
+  spinner,
+  successLine,
+  type StartLikeResult,
+} from './ui'
 
 const ENV_KEYS = ['NO_COLOR', 'FORCE_COLOR'] as const
 
@@ -335,5 +346,75 @@ describe('spinner', () => {
       s.start('working...')
       s.error('boom')
     }).not.toThrow()
+  })
+})
+
+describe('printSlackAppManifestSetup', () => {
+  const ANSI = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, 'g')
+
+  function captureStdout<T>(fn: () => T): { result: T; output: string } {
+    const original = process.stdout.write.bind(process.stdout)
+    let buf = ''
+    process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+      buf += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8')
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const result = fn()
+      return { result, output: buf.replace(ANSI, '') }
+    } finally {
+      process.stdout.write = original
+    }
+  }
+
+  test('emits the JSON manifest flush-left so it is copy-pasteable', () => {
+    const { output } = captureStdout(() => withNoColor(() => printSlackAppManifestSetup()))
+
+    const jsonStart = output.indexOf('\n{\n')
+    const jsonEnd = output.indexOf('\n}\n', jsonStart)
+    expect(jsonStart).toBeGreaterThanOrEqual(0)
+    expect(jsonEnd).toBeGreaterThan(jsonStart)
+
+    const jsonBlock = output.slice(jsonStart + 1, jsonEnd + 2)
+    for (const line of jsonBlock.split('\n')) {
+      if (line === '') continue
+      expect(line.startsWith('│')).toBe(false)
+      expect(line.startsWith('|')).toBe(false)
+    }
+
+    expect(() => JSON.parse(jsonBlock) as unknown).not.toThrow()
+    expect(JSON.parse(jsonBlock)).toEqual(SLACK_APP_MANIFEST)
+  })
+
+  test('keeps the prose steps inside boxed notes around the JSON block', () => {
+    const { output } = captureStdout(() => withNoColor(() => printSlackAppManifestSetup()))
+
+    expect(output).toContain('Get a Slack bot')
+    expect(output).toContain('Finish Slack setup')
+    expect(output).toContain('https://api.slack.com/apps')
+    expect(output).toContain('/invite @TypeClaw')
+
+    const introIdx = output.indexOf('Get a Slack bot')
+    const jsonIdx = output.indexOf('\n{\n')
+    const followUpIdx = output.indexOf('Finish Slack setup')
+    expect(introIdx).toBeLessThan(jsonIdx)
+    expect(jsonIdx).toBeLessThan(followUpIdx)
+  })
+
+  test('manifest declares the scopes Socket Mode + Events + Web API need', () => {
+    const scopes = SLACK_APP_MANIFEST.oauth_config.scopes.bot
+    expect(scopes).toContain('app_mentions:read')
+    expect(scopes).toContain('chat:write')
+    expect(scopes).toContain('channels:history')
+    expect(scopes).toContain('groups:history')
+    expect(scopes).toContain('im:history')
+    expect(scopes).toContain('mpim:history')
+
+    const events = SLACK_APP_MANIFEST.settings.event_subscriptions.bot_events
+    expect(events).toContain('app_mention')
+    expect(events).toContain('message.channels')
+    expect(events).toContain('message.im')
+
+    expect(SLACK_APP_MANIFEST.settings.socket_mode_enabled).toBe(true)
   })
 })

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -124,3 +124,74 @@ export function errorLine(reason: string): string {
 export function successLine(message: string): string {
   return `${c.green('●')} ${message}`
 }
+
+// The exact JSON manifest a user pastes into
+// https://api.slack.com/apps → From a manifest. Kept as a typed object so
+// the file stays a single source of truth and `JSON.stringify` guarantees
+// the rendered text is always valid JSON — no risk of a stray comma or
+// quote slipping in through hand-formatting.
+export const SLACK_APP_MANIFEST = {
+  display_information: { name: 'TypeClaw' },
+  features: {
+    bot_user: { display_name: 'TypeClaw', always_online: true },
+  },
+  oauth_config: {
+    scopes: {
+      bot: [
+        'app_mentions:read',
+        'chat:write',
+        'users:read',
+        'files:read',
+        'channels:history',
+        'channels:read',
+        'groups:history',
+        'groups:read',
+        'im:history',
+        'im:read',
+        'mpim:history',
+        'mpim:read',
+      ],
+    },
+  },
+  settings: {
+    event_subscriptions: {
+      bot_events: ['app_mention', 'message.channels', 'message.groups', 'message.im', 'message.mpim'],
+    },
+    socket_mode_enabled: true,
+  },
+} as const
+
+// Prints the "create a Slack app from a manifest" walkthrough so the JSON
+// payload is **flush-left and copy-pasteable**. Clack's `note()` wraps
+// content inside a box with `│` borders on both sides, and `log.message()`
+// still prefixes every line with a `│  ` guide column — neither survives a
+// click-and-drag copy. This helper splits the walkthrough into three
+// segments: a boxed prose intro, a raw-stdout JSON block, and a boxed
+// follow-up. The JSON block is emitted via `process.stdout.write` so it
+// carries zero terminal decoration.
+export function printSlackAppManifestSetup(output: NodeJS.WritableStream = process.stdout): void {
+  note(
+    [
+      '1. https://api.slack.com/apps → Create New App → From a manifest.',
+      '   Pick your workspace, then paste the JSON manifest printed below',
+      `   (it is rendered flush-left so you can ${c.bold('click-drag and copy')} cleanly).`,
+    ].join('\n'),
+    'Get a Slack bot',
+  )
+  output.write('\n')
+  output.write(`${JSON.stringify(SLACK_APP_MANIFEST, null, 2)}\n`)
+  output.write('\n')
+  note(
+    [
+      '2. Install to Workspace, then OAuth & Permissions →',
+      '   copy the Bot User OAuth Token (xoxb-...).',
+      '3. Basic Information → App-Level Tokens → Generate Token and',
+      '   Scopes, add the connections:write scope, and copy the',
+      '   token (xapp-...). Socket Mode needs this; the manifest',
+      '   cannot grant it.',
+      '4. Invite the bot to any private channel or DM you want it in:',
+      '   /invite @TypeClaw',
+    ].join('\n'),
+    'Finish Slack setup',
+  )
+}


### PR DESCRIPTION
## Problem

The Slack-bot setup walkthrough in `typeclaw init` and `typeclaw channel add slack-bot` rendered the JSON app manifest inside a clack `note()` box. Clack `note()` wraps every line in left+right `│` border characters, so when users clicked-and-dragged the JSON to paste it into https://api.slack.com/apps → "From a manifest", their clipboard contained `│  { ... │` per line. The paste failed before the user ever saw Slack's manifest editor.

User report verbatim: *"Users cannot copy & paste because of the boxes."*

`log.message()` is not a fix either — clack still prefixes every line with a `│  ` guide column unless the global `withGuide` setting is flipped (which would degrade every other prompt in the wizard). The only truly flush-left clack-compatible output is `process.stdout.write` between two boxed segments.

## What changed

### `src/cli/ui.ts` — new shared helper

- **`SLACK_APP_MANIFEST`** — exported `const … as const` holding the manifest as a typed JS object. Single source of truth for both call sites; stringified at print time so the rendered text is guaranteed valid JSON (no risk of a stray comma or quote slipping in through hand-formatting, which the previous string-array form was vulnerable to).
- **`printSlackAppManifestSetup(output?: NodeJS.WritableStream)`** — splits the walkthrough into three rendering segments:
  1. `note()` with step 1 + the prose hint "paste the JSON manifest printed below (it is rendered flush-left so you can **click-drag and copy** cleanly)".
  2. `JSON.stringify(SLACK_APP_MANIFEST, null, 2)` emitted via `process.stdout.write` — zero borders, zero guide column, zero leading indentation. Selecting the block with the mouse yields exactly the JSON.
  3. `note()` with the follow-up steps (Install to Workspace, App-Level Tokens, `/invite @TypeClaw`).

Comments at both definitions document the load-bearing reason for bypassing clack's normal helpers, so a future "modernize this to `log.message`" change is gated on reading the rationale first.

### `src/cli/init.ts` and `src/cli/channel.ts` — call the helper

Both files previously held a hand-formatted, 38-line, perfectly-duplicated string-array of the manifest inside their own `note()` block. Both now call `printSlackAppManifestSetup()`. Net deletion: ~45 lines per file.

### `src/cli/ui.test.ts` — three new tests

Following the existing `captureStdout` pattern in the same file (used for `done()`):

1. **Flush-left invariant.** Parses the printed output, asserts that every non-empty line of the JSON block starts with `{`, `}`, `"`, `,`, or whitespace — never `│` or `|`. `JSON.parse` round-trips the block back to `SLACK_APP_MANIFEST`.
2. **Layout invariant.** "Get a Slack bot" appears before the JSON; "Finish Slack setup" appears after; the click-drag-friendly prose hint and `/invite @TypeClaw` are both present.
3. **Manifest content.** The bot scopes, bot events, and `socket_mode_enabled: true` flag declared by the manifest are exactly what Socket Mode + the channel adapter need.

## Verification

All four pre-commit checks pass on the worktree:

```
bun run typecheck     ✓  clean
bun run lint          ✓  0 errors (17 pre-existing warnings, all in unrelated files)
bun run format:check  ✓  clean
bun test              ✓  4303 pass / 0 fail / 9185 expect() calls across 250 files
```

Manual visual verification — `bun -e 'import { printSlackAppManifestSetup } from "./src/cli/ui.ts"; printSlackAppManifestSetup();'` renders:

```
◇  Get a Slack bot ─────────────────────────────────╮
│                                                   │
│  1. https://api.slack.com/apps → ...              │
│     ...paste the JSON manifest printed below      │
│     (it is rendered flush-left so you can         │
│      click-drag and copy cleanly).                │
│                                                   │
├───────────────────────────────────────────────────╯

{
  "display_information": {
    "name": "TypeClaw"
  },
  ...
  "settings": {
    ...
    "socket_mode_enabled": true
  }
}

◇  Finish Slack setup ─────────────────────────────╮
│                                                  │
│  2. Install to Workspace, then OAuth & ...       │
│  ...                                             │
├──────────────────────────────────────────────────╯
```

Selecting the JSON block with the mouse and pasting yields exactly the JSON — no border characters, no leading indentation.

## Design notes

- **JS object, not a string.** Two call sites previously held identical 38-line hand-aligned string arrays. Drift between the two would have produced two subtly different manifests, and a typo in either would have produced invalid JSON. A typed object stringified at print time forecloses both classes of bug.
- **`output` parameter defaults to `process.stdout`.** Optional `NodeJS.WritableStream` arg keeps the helper trivially testable without monkey-patching, matching the shape of clack's own `LogMessageOptions.output`. The bundled tests use `captureStdout` (same pattern as the existing `done()` tests) since the default path is the production code path.
- **No global `updateSettings({ withGuide: false })`.** That would silence the guide column repo-wide and degrade every other prompt's visual structure. The local `process.stdout.write` is scoped precisely to the JSON block.

## Diff stats

```
 src/cli/channel.ts | 47 ++-----------------------------
 src/cli/init.ts    | 47 ++-----------------------------
 src/cli/ui.test.ts | 83 +++++++++++++++++++++++++++++++++++++++++++++++++++++-
 src/cli/ui.ts      | 71 ++++++++++++++++++++++++++++++++++++++++++++++
 4 files changed, 157 insertions(+), 91 deletions(-)
```

Net deletion despite adding a tested helper because both call sites were near-duplicates.
