### PR TITLE
cli: widen Slack manifest scopes and configure App Home tabs

### DIFF
--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -417,4 +417,32 @@ describe('printSlackAppManifestSetup', () => {
 
     expect(SLACK_APP_MANIFEST.settings.socket_mode_enabled).toBe(true)
   })
+
+  test('manifest grants write scopes for replies, attachments, pins, and reactions', () => {
+    const scopes = SLACK_APP_MANIFEST.oauth_config.scopes.bot
+    expect(scopes).toContain('channels:join')
+    expect(scopes).toContain('files:write')
+    expect(scopes).toContain('groups:write')
+    expect(scopes).toContain('im:write')
+    expect(scopes).toContain('mpim:write')
+    expect(scopes).toContain('pins:read')
+    expect(scopes).toContain('pins:write')
+    expect(scopes).toContain('reactions:read')
+    expect(scopes).toContain('reactions:write')
+    expect(scopes).toContain('emoji:read')
+  })
+
+  test('manifest scope list is alphabetically sorted so diffs stay stable', () => {
+    const scopes: readonly string[] = SLACK_APP_MANIFEST.oauth_config.scopes.bot
+    const sorted = [...scopes].sort()
+    expect([...scopes]).toEqual(sorted)
+  })
+
+  test('app_home enables the Messages tab and hides the unused Home tab', () => {
+    expect(SLACK_APP_MANIFEST.features.app_home).toEqual({
+      home_tab_enabled: false,
+      messages_tab_enabled: true,
+      messages_tab_read_only_enabled: false,
+    })
+  })
 })

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -134,22 +134,46 @@ export const SLACK_APP_MANIFEST = {
   display_information: { name: 'TypeClaw' },
   features: {
     bot_user: { display_name: 'TypeClaw', always_online: true },
+    // Enable the Messages tab so users can DM the bot from its app profile,
+    // and disable the Home tab — TypeClaw does not publish a custom App Home
+    // view, and leaving it enabled would surface an empty default tab.
+    app_home: {
+      home_tab_enabled: false,
+      messages_tab_enabled: true,
+      messages_tab_read_only_enabled: false,
+    },
   },
   oauth_config: {
     scopes: {
+      // Ordered alphabetically so the manifest stays a stable diff target.
+      // Read scopes cover every conversation type the agent might observe;
+      // write scopes (chat, files, im/mpim/groups, pins, reactions) let the
+      // agent post replies, upload attachments, open DMs, pin messages, and
+      // react to messages. `channels:join` lets the bot self-join public
+      // channels it's invited to discuss in.
       bot: [
         'app_mentions:read',
-        'chat:write',
-        'users:read',
-        'files:read',
         'channels:history',
+        'channels:join',
         'channels:read',
+        'chat:write',
+        'emoji:read',
+        'files:read',
+        'files:write',
         'groups:history',
         'groups:read',
+        'groups:write',
         'im:history',
         'im:read',
+        'im:write',
         'mpim:history',
         'mpim:read',
+        'mpim:write',
+        'pins:read',
+        'pins:write',
+        'reactions:read',
+        'reactions:write',
+        'users:read',
       ],
     },
   },


### PR DESCRIPTION
## Summary

The bundled Slack app manifest printed by `typeclaw channel add slack-bot` / `typeclaw init` was missing a dozen scopes the channel adapter actually exercises — pins, reactions, file uploads, opening DMs, writing to groups. Every fresh Slack install required hand-editing the manifest in Slack's dashboard before the bot could do anything beyond reply-by-mention. This PR expands the scope list to cover the full read/write surface, alphabetises it (so future additions land as small reviewable diffs), and adds an explicit `app_home` block to declare sane tab defaults rather than relying on Slack to pick them.

## Changes

### `src/cli/ui.ts` — expand `SLACK_APP_MANIFEST`

**New bot scopes (10 added, now 22 total, sorted alphabetically):**
- `channels:join` — lets the bot self-join public channels without a separate OAuth roundtrip.
- `emoji:read` — read workspace emoji for reactions.
- `files:write` — upload attachments and files.
- `groups:write` — post and manage content in private channels.
- `im:write` — open direct message conversations.
- `mpim:write` — open multi-party DMs.
- `pins:read`, `pins:write` — read and manage pinned items.
- `reactions:read`, `reactions:write` — read and add emoji reactions.

The existing 12 scopes are preserved; their order changes because the full list is now sorted alphabetically. The alphabetical invariant is covered by a new test.

**New `features.app_home` block:**
```json
"app_home": {
  "home_tab_enabled": false,
  "messages_tab_enabled": true,
  "messages_tab_read_only_enabled": false
}
```

TypeClaw does not publish a custom App Home view, so `home_tab_enabled` is set to `false` to prevent users from landing on an empty default tab. `messages_tab_enabled` is `true` so users can DM the bot from its profile page; `messages_tab_read_only_enabled` is `false` to keep the tab interactive.

### `src/cli/ui.test.ts` — three new test cases

1. **Write-scope coverage** — asserts every newly added scope is present in the manifest.
2. **Alphabetical-sort invariant** — asserts the scope array equals its sorted copy, so future contributors can't group scopes by category and produce noisy diffs.
3. **`app_home` config** — asserts the exact tab configuration matches the chosen defaults.

## Why each scope was added

| Scope | Reason |
|---|---|
| `channels:join` | Bot can self-join after an `/invite` without a separate OAuth step. |
| `emoji:read` | Required by the reactions path in the Slack Web API. |
| `files:write` | Lets the agent upload files and attachments via `files.upload`. |
| `groups:write` | Required for write operations in private channels. |
| `im:write` | Required to open DMs via `conversations.open`. |
| `mpim:write` | Required to open multi-party DMs. |
| `pins:read`, `pins:write` | Required for `pins.add`, `pins.remove`, `pins.list`. |
| `reactions:read`, `reactions:write` | Required for `reactions.add`, `reactions.remove`, `reactions.get`. |

## Context

The manifest is the sole onboarding artefact — operators paste it into Slack's "From a manifest" flow once, at setup time. Scopes that are missing at setup require re-installing the app (or at minimum re-authorising) to add later, which is disruptive for deployed agents. Better to declare the full surface upfront.

The `app_home` omission was a simpler bug: Slack's defaults include an active Home tab with an empty view, which confuses users who expect to interact with the agent via DM. Declaring the block explicitly suppresses the empty tab and surfaces the Messages tab.

## Verification

```
bun run typecheck     ✓  clean
bun run lint          ✓  0 errors (17 pre-existing warnings, all in unrelated files)
bun run format:check  ✓  clean
bun test src/cli/ui.test.ts  ✓  34 pass / 0 fail
```