### PR TITLE
cli: add `deep` to `typeclaw model set` picker

### DIFF
--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -25,7 +25,7 @@ const ADD_PROVIDER_SENTINEL = '__add-provider__'
 const setSub = defineCommand({
   meta: {
     name: 'set',
-    description: 'set or update a model profile (default | fast | vision | <custom>)',
+    description: 'set or update a model profile (default | fast | deep | vision | <custom>)',
   },
   args: {
     profile: {
@@ -206,6 +206,7 @@ async function pickProfileName(): Promise<string> {
     options: [
       { value: 'default', label: 'default', hint: 'active model for new sessions' },
       { value: 'fast', label: 'fast', hint: 'optional alias used by some subagents' },
+      { value: 'deep', label: 'deep', hint: 'optional alias used by some subagents' },
       { value: 'vision', label: 'vision', hint: 'optional alias used by some subagents' },
     ],
     initialValue: 'default',


### PR DESCRIPTION
## What

Two minimal edits in `src/cli/model.ts`.

The `set` subcommand description string now includes "deep" in the profile list.

The interactive profile picker gains a fourth select option placed between "fast" and "vision":

```ts
{ value: 'deep', label: 'deep', hint: 'optional alias used by some subagents' }
```

Ordering follows the convention list in `config.ts` (line 306): default → fast → deep → vision.

## Why

`src/config/config.ts` documents four well-known profile names by convention (line 306):
default, fast, deep, and vision. The `resolveProfile` JSDoc (line 381) also lists all four.
The interactive picker exposed only three — "deep" was absent from the options.

Users could always supply the name positionally — `typeclaw model set deep <ref>` —
because profile names are open strings in the schema.
This PR adds the missing discoverability; it is not a capability change.

## What this is not

- Not a schema or migration change.
- Not a behavior change for non-interactive callers.
- Not a new runtime concept — "deep" was already a documented convention.

## Tests

`src/cli/model.ts` is a thin UI shell (AGENTS.md "Test at the right layer").
There is no model.test.ts in the codebase today.
The testable domain logic lives in `src/config/`
and is covered by `models-mutation.test.ts`.

Adding a test to verify a select-option label would require mocking `@clack/prompts`,
which AGENTS.md identifies as a refactoring smell:
"If a test requires mocking @clack/prompts just to exercise logic, refactor. Don't mock."

## Verification

```
bun run typecheck   ✓  clean
bun run lint        ✓  0 errors (17 pre-existing warnings, unrelated to src/cli/model.ts)
bun run format      ✓  clean
bun test            ✓  4322 pass / 0 fail across 250 files
git diff            ✓  +2 -1 lines in src/cli/model.ts
```