### PR TITLE
init: seed roles.member.match with "*" when wiring a chat adapter (so freshly hatched agents respond)

### DIFF
--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -217,6 +217,46 @@ describe('runAddChannel', () => {
     expect(after.idleMs).toBe(60_000)
   })
 
+  test('writes roles.member.match: ["*"] when adding a chat adapter to a freshly scaffolded folder', async () => {
+    await runAddChannel({ cwd: root, channel: 'slack-bot', slackBotToken: 'xoxb', slackAppToken: 'xapp' })
+
+    const cfg = (await readConfig()) as { roles?: { member?: { match?: string[] } } }
+    expect(cfg.roles?.member?.match).toEqual(['*'])
+  })
+
+  test('does not duplicate the "*" entry when a second chat adapter is added later', async () => {
+    await runAddChannel({ cwd: root, channel: 'slack-bot', slackBotToken: 'xoxb', slackAppToken: 'xapp' })
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-x' })
+
+    const cfg = (await readConfig()) as { roles?: { member?: { match?: string[] } } }
+    expect(cfg.roles?.member?.match).toEqual(['*'])
+  })
+
+  test('preserves existing roles.member.match entries (set-union semantics, no clobber)', async () => {
+    const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as Record<string, unknown>
+    cfg.roles = { member: { match: ['slack:T0123 author:U_EXISTING'] } }
+    await writeFile(join(root, 'typeclaw.json'), `${JSON.stringify(cfg, null, 2)}\n`)
+
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-x' })
+
+    const after = (await readConfig()) as { roles?: { member?: { match?: string[] } } }
+    expect(after.roles?.member?.match).toEqual(['slack:T0123 author:U_EXISTING', '*'])
+  })
+
+  test('preserves existing roles.owner block (does not overwrite when adding a channel)', async () => {
+    const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as Record<string, unknown>
+    cfg.roles = { owner: { match: ['slack:@dm author:U_ME'] } }
+    await writeFile(join(root, 'typeclaw.json'), `${JSON.stringify(cfg, null, 2)}\n`)
+
+    await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-x' })
+
+    const after = (await readConfig()) as {
+      roles?: { owner?: { match?: string[] }; member?: { match?: string[] } }
+    }
+    expect(after.roles?.owner?.match).toEqual(['slack:@dm author:U_ME'])
+    expect(after.roles?.member?.match).toEqual(['*'])
+  })
+
   test('rejects re-adding an already-configured channel', async () => {
     await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-first' })
 

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -982,6 +982,38 @@ describe('scaffold', () => {
     }
     expect(cfg.channels).toEqual({ 'discord-bot': {} })
   })
+
+  // A freshly-hatched agent with no roles config silently drops every inbound
+  // chat message because no role's match[] covers the channel session, so the
+  // origin resolves to `guest` (no channel.respond). `roles.member.match: ["*"]`
+  // grants the built-in `member` role (which already carries channel.respond)
+  // to any channel origin, so the agent talks out of the box. The owner-claim
+  // flow is then a privilege upgrade (cron, security bypass) for one human,
+  // not a precondition for the agent to speak at all.
+  test('writes roles.member.match: ["*"] when any chat adapter is selected (so freshly hatched agents respond)', async () => {
+    await scaffold(root, { withSlack: true })
+
+    const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
+      roles?: { member?: { match?: string[] } }
+    }
+    expect(cfg.roles?.member?.match).toEqual(['*'])
+  })
+
+  test('writes roles.member.match: ["*"] exactly once when multiple chat adapters are selected', async () => {
+    await scaffold(root, { withDiscord: true, withSlack: true, withTelegram: true, withKakaotalk: true })
+
+    const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
+      roles?: { member?: { match?: string[] } }
+    }
+    expect(cfg.roles?.member?.match).toEqual(['*'])
+  })
+
+  test('omits roles block entirely when no chat adapter is selected (greenfield is silent until configured)', async () => {
+    await scaffold(root)
+
+    const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as Record<string, unknown>
+    expect(cfg.roles).toBeUndefined()
+  })
 })
 
 describe('initGitRepo', () => {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -37,6 +37,14 @@ const CONFIG_FILE = 'typeclaw.json'
 const CRON_FILE = 'cron.json'
 const PACKAGE_FILE = 'package.json'
 
+// Seeded into `typeclaw.json#roles.member.match[]` whenever a chat adapter
+// (slack-bot, discord-bot, telegram-bot, kakaotalk) is wired. The "*" rule
+// matches every channel session on every platform, so the built-in `member`
+// role (which already carries `channel.respond`) covers any inbound the
+// router sees. Without this, freshly-hatched agents silently drop every
+// chat message — see scaffold() and ensureDefaultChatMemberMatch() below.
+const DEFAULT_CHAT_MEMBER_MATCH_RULE = '*'
+
 const MARKDOWN_FILES = ['AGENTS.md', 'IDENTITY.md', 'SOUL.md', 'USER.md'] as const
 
 // `packages/` is a bun workspace root (see `workspaces` in buildPackageJson).
@@ -543,6 +551,11 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   if (options.withTelegram) channels['telegram-bot'] = {}
   if (options.withKakaotalk) channels.kakaotalk = {}
   if (Object.keys(channels).length > 0) config.channels = channels
+  // See DEFAULT_CHAT_MEMBER_MATCH_RULE for why this is here. GitHub is wired
+  // separately (writeGithubChannelForInit) and seeds per-repo member.match
+  // entries instead of the wildcard, so a github-only init stays scoped to
+  // the repos the operator opted in to.
+  if (Object.keys(channels).length > 0) config.roles = { member: { match: [DEFAULT_CHAT_MEMBER_MATCH_RULE] } }
   await writeFile(join(root, CONFIG_FILE), `${JSON.stringify(config, null, 2)}\n`)
 
   const cron = {
@@ -965,6 +978,8 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
   if (options.channel === 'github') {
     await appendGithubMatchRules(options.cwd, options.repos)
     await maybeInstallGithubWebhooks(options, emit)
+  } else {
+    await ensureDefaultChatMemberMatch(options.cwd)
   }
 
   // Commit the typeclaw.json change so the agent folder isn't silently
@@ -1204,6 +1219,24 @@ async function appendGithubMatchRules(cwd: string, repos: readonly string[]): Pr
   const merged = new Set(existing)
   for (const repo of repos) merged.add(`github:${repo}`)
   member.match = Array.from(merged)
+  roles.member = member
+  parsed.roles = roles
+  await writeFile(path, `${JSON.stringify(parsed, null, 2)}\n`)
+}
+
+// Chat-adapter counterpart of appendGithubMatchRules. See
+// DEFAULT_CHAT_MEMBER_MATCH_RULE for the rationale. Set-union semantics: re-
+// running `typeclaw channel add` for additional chat adapters is a no-op on
+// the match list, and any pre-existing rules the operator hand-authored
+// (e.g. owner-claim's per-author entry on `owner`) are left intact.
+async function ensureDefaultChatMemberMatch(cwd: string): Promise<void> {
+  const path = join(cwd, CONFIG_FILE)
+  const parsed = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>
+  const roles = isObjectRecord(parsed.roles) ? { ...parsed.roles } : {}
+  const member = isObjectRecord(roles.member) ? { ...roles.member } : {}
+  const existing = Array.isArray(member.match) ? member.match.filter((v): v is string => typeof v === 'string') : []
+  if (existing.includes(DEFAULT_CHAT_MEMBER_MATCH_RULE)) return
+  member.match = [...existing, DEFAULT_CHAT_MEMBER_MATCH_RULE]
   roles.member = member
   parsed.roles = roles
   await writeFile(path, `${JSON.stringify(parsed, null, 2)}\n`)


### PR DESCRIPTION
## Why

A freshly-hatched agent denies every inbound chat message until the operator runs the owner-claim flow, even though the agent was just set up with the right tokens and is fully online:

```
[channels] slack-bot:@dm:D0B524GS9MX:: denied by permissions (channel.respond) author=UDDLVQQ6Q id=1779267061.430149
```

The user's `typeclaw.json` at the time of the denial:

```json
{
  "channels": { "slack-bot": {} },
  "roles": {
    "owner": {
      "match": ["slack:@dm author:UDDLVQQ6Q"]
    }
  }
}
```

This rule matches that one author in DMs and grants `channel.respond` (it's correctly parsed by `parseMatchRule` and resolves correctly via `matchesChannel` — verified with a standalone repro against the live code, the rule does evaluate to `true` against the inbound origin). The actual problem: until owner-claim writes it (or the operator hand-edits), there is **no role whose `match[]` covers the channel session at all**. The router builds a partial origin from the inbound, walks every role's `match[]` in `resolveRole`, finds no hit, falls through to `guest`, and `guest` has no `channel.respond`. The router logs `denied by permissions (channel.respond)` and drops the message before any session work happens.

`typeclaw init` and `typeclaw channel add slack-bot` (and `discord-bot` / `telegram-bot` / `kakaotalk`) write the channel block to `typeclaw.json` but did NOT seed any `roles` block, so this silent-drop window opened on every fresh hatch. The owner-claim DM then narrowly authorized one human, leaving everyone else (including the agent's own retry attempts and any other workspace member) still denied.

The user's expectation, stated literally:

> I was expecting that the line below gets automatically inserted
>
> ```json
> "roles": {
>   "member": {
>     "match": ["*"]
>   }
> }
> ```

This PR makes that expectation true.

## What

`scaffold` and `runAddChannel` now seed `roles.member.match: ["*"]` whenever a chat adapter (`slack-bot`, `discord-bot`, `telegram-bot`, `kakaotalk`) is wired. The built-in `member` role already carries `channel.respond`, so the agent talks to anyone in any wired chat out of the box. Owner-claim becomes a privilege upgrade (`cron.schedule`, `security.bypass.medium`, `cron.modify`) for one human, not a precondition for the agent to speak at all.

- **`scaffold`** (`src/init/index.ts` line ~558): when `withDiscord | withSlack | withTelegram | withKakaotalk` selects at least one chat adapter, the rendered `typeclaw.json` includes `roles: { member: { match: ["*"] } }` alongside the `channels` block. No chat adapter selected → no `roles` block (a github-only or no-channel init stays scoped and silent, matching existing behavior).
- **`runAddChannel`** (`src/init/index.ts` line ~978): for chat adapters, calls a new `ensureDefaultChatMemberMatch(cwd)` that set-unions `"*"` into `roles.member.match[]`. Set semantics mean adding a second chat adapter later is a no-op on the list, and any pre-existing entries (e.g. owner-claim's per-author rule on `owner`, or hand-authored member rules) are preserved.

### Why `"*"` and not platform-scoped (`slack:*`, etc.)

`*` is the canonical "any channel" rule in the DSL (`parseMatchRule` line 111) and matches every channel session regardless of platform — exactly the behavior we want when an agent is wired with multiple chat adapters. Per-platform rules (`slack:*`, `discord:*`) would force `ensureDefaultChatMemberMatch` to grow N entries instead of 1, with no observable behavior change since `member` is granted on the first match.

### Why github is excluded

`writeGithubChannelForInit` (init path) and `appendGithubMatchRules` (channel-add path) already write per-repo `github:owner/repo` entries to `roles.member.match[]`. The whole point of those per-repo rules is to confine github webhook handling to the repos the operator explicitly opted in to. Adding `"*"` for github would silently authorize every repo with a webhook hitting the agent — a real expansion of authority, not a default. The asymmetry (`*` for chat, `github:<repo>` for github) is documented inline next to `DEFAULT_CHAT_MEMBER_MATCH_RULE`.

### Why this doesn't broaden authority compared to today's status quo

`member` carries exactly one permission: `channel.respond` (built-in default in `src/permissions/builtins.ts`). All elevated permissions — `cron.schedule`, `cron.modify`, `security.bypass.low`, `security.bypass.medium`, the security-bypass wildcard — live on `owner`, which is unchanged. So an unclaimed agent talks to everyone but still refuses to schedule cron, push to git, dump env, etc. Without claim, those guards remain firmly closed. Verified end-to-end:

```
slack DM random user: true
slack channel random user: true
discord DM: true
member has cron.schedule? (should be false): false
```

## Repro

Pre-PR:

1. `typeclaw init` → pick `slack-bot`, finish wizard, agent hatches.
2. DM the bot from Slack → `[channels] slack-bot:@dm:...: denied by permissions (channel.respond) author=...`
3. Workaround: complete `typeclaw role claim` DM handshake (writes the per-author rule to `owner.match`).

Post-PR:

1. `typeclaw init` → pick `slack-bot`, finish wizard, agent hatches.
2. DM the bot from Slack → router accepts; session created; agent replies.
3. `typeclaw role claim` (optional) still works exactly as before, upgrading the human to `owner` for cron/security-bypass-tier capabilities.

## Test plan

Six new tests:

**`src/init/index.test.ts` → `describe('scaffold', ...)`**:
- `writes roles.member.match: ["*"] when any chat adapter is selected (so freshly hatched agents respond)`
- `writes roles.member.match: ["*"] exactly once when multiple chat adapters are selected`
- `omits roles block entirely when no chat adapter is selected (greenfield is silent until configured)`

**`src/init/add-channel.test.ts` → `describe('runAddChannel', ...)`**:
- `writes roles.member.match: ["*"] when adding a chat adapter to a freshly scaffolded folder`
- `does not duplicate the "*" entry when a second chat adapter is added later`
- `preserves existing roles.member.match entries (set-union semantics, no clobber)`
- `preserves existing roles.owner block (does not overwrite when adding a channel)`

All tests start `red` (verified by running against the unmodified production code), then green after the implementation. The full suite stays green: **4332 / 4332 tests pass**.

## Pre-merge gates

- `bun run typecheck` — clean
- `bun run lint` — 0 errors, 17 pre-existing warnings unchanged (no new lint on touched files)
- `bun run format` — clean
- `bun test` — 4332 / 4332 pass

## Out of scope (intentionally)

While investigating, I noticed a separate latent bug: after a successful owner-claim grant, `controller.ts` calls `permissions.replaceRoles(rolesProvider())` where `rolesProvider = () => getConfig().roles`. But `getConfig()` returns the in-memory snapshot loaded at `typeclaw run` boot, NOT the freshly-written disk state — `grantRole` writes typeclaw.json directly without going through `reloadConfig`. So claim's `replaceRoles` rebuilds with stale roles, and the new rule only takes effect after a container restart. This is a separate fix and intentionally **not** addressed here so the diff stays focused on the user-reported expectation. Filed as a follow-up note in the work log.
