### PR TITLE
agent: ship subagent orchestration core (spawn / output / cancel)

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -13,6 +13,7 @@ import { createStream } from '@/stream'
 
 import {
   buildChannelTools,
+  buildSubagentOrchestrationTools,
   composeSystemPrompt,
   createOverrideResourceLoader,
   createResourceLoader,
@@ -22,7 +23,9 @@ import {
   getBundledSkillsDir,
   subscribeRestartNotice,
 } from './index'
+import { LiveSubagentRegistry } from './live-subagents'
 import type { SessionOrigin } from './session-origin'
+import type { CreateSessionForSubagent, SubagentRegistry } from './subagents'
 import { DEFAULT_SYSTEM_PROMPT, SLIM_SYSTEM_PROMPT } from './system-prompt'
 
 async function runGit(cwd: string, args: string[]): Promise<void> {
@@ -912,6 +915,82 @@ describe('buildChannelTools', () => {
     const tools = buildChannelTools(makeRouter(), undefined)
     // then
     expect(tools.map((t) => t.name)).toEqual(['channel_send'])
+  })
+})
+
+describe('buildSubagentOrchestrationTools', () => {
+  const stubCreateSession = (async () => ({}) as unknown) as CreateSessionForSubagent
+  const stubRegistry: SubagentRegistry = {}
+  const getOrigin = () => ({ kind: 'tui' as const, sessionId: 'ses_parent' })
+
+  test('exposes the three orchestration tools when all four dependencies are present', () => {
+    const tools = buildSubagentOrchestrationTools({
+      liveRegistry: new LiveSubagentRegistry(),
+      registry: stubRegistry,
+      createSessionForSubagent: stubCreateSession,
+      agentDir: '/agent',
+      parentSessionId: 'ses_parent',
+      getOrigin,
+      permissions: undefined,
+      stream: undefined,
+    })
+    expect(tools.map((t) => t.name).sort()).toEqual(['spawn_subagent', 'subagent_cancel', 'subagent_output'])
+  })
+
+  test('returns [] when liveRegistry is missing (subagent-session context — primary recursive-spawn defense)', () => {
+    const tools = buildSubagentOrchestrationTools({
+      liveRegistry: undefined,
+      registry: stubRegistry,
+      createSessionForSubagent: stubCreateSession,
+      agentDir: '/agent',
+      parentSessionId: 'ses_parent',
+      getOrigin,
+      permissions: undefined,
+      stream: undefined,
+    })
+    expect(tools).toEqual([])
+  })
+
+  test('returns [] when registry is missing', () => {
+    const tools = buildSubagentOrchestrationTools({
+      liveRegistry: new LiveSubagentRegistry(),
+      registry: undefined,
+      createSessionForSubagent: stubCreateSession,
+      agentDir: '/agent',
+      parentSessionId: 'ses_parent',
+      getOrigin,
+      permissions: undefined,
+      stream: undefined,
+    })
+    expect(tools).toEqual([])
+  })
+
+  test('returns [] when createSessionForSubagent is missing', () => {
+    const tools = buildSubagentOrchestrationTools({
+      liveRegistry: new LiveSubagentRegistry(),
+      registry: stubRegistry,
+      createSessionForSubagent: undefined,
+      agentDir: '/agent',
+      parentSessionId: 'ses_parent',
+      getOrigin,
+      permissions: undefined,
+      stream: undefined,
+    })
+    expect(tools).toEqual([])
+  })
+
+  test('returns [] when agentDir is missing', () => {
+    const tools = buildSubagentOrchestrationTools({
+      liveRegistry: new LiveSubagentRegistry(),
+      registry: stubRegistry,
+      createSessionForSubagent: stubCreateSession,
+      agentDir: undefined,
+      parentSessionId: 'ses_parent',
+      getOrigin,
+      permissions: undefined,
+      stream: undefined,
+    })
+    expect(tools).toEqual([])
   })
 })
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -25,12 +25,14 @@ import type { Stream } from '@/stream'
 import { getAuthFor } from './auth'
 import { createCompactionSettingsManager } from './compaction'
 import { renderGitNudge } from './git-nudge'
+import type { LiveSubagentRegistry } from './live-subagents'
 import { lookAtTool } from './multimodal'
 import { resolveBuiltinToolRefs, wrapPluginTool, wrapSystemAgentTool, wrapSystemTool } from './plugin-tools'
 import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
 import { SESSION_META_CUSTOM_TYPE, sessionMetaPayload } from './session-meta'
 import { renderSessionOrigin, type SessionOrigin, type SessionRoleContext } from './session-origin'
+import type { CreateSessionForSubagent, SubagentRegistry } from './subagents'
 import { DEFAULT_SYSTEM_PROMPT, renderRuntimeBlock, SLIM_SYSTEM_PROMPT } from './system-prompt'
 import {
   createBudgetState,
@@ -43,7 +45,10 @@ import { createChannelHistoryTool } from './tools/channel-history'
 import { createChannelReplyTool } from './tools/channel-reply'
 import { createChannelSendTool } from './tools/channel-send'
 import { createRestartTool } from './tools/restart'
+import { createSpawnSubagentTool } from './tools/spawn-subagent'
 import { createStreamSnapshotTool } from './tools/stream-snapshot'
+import { createSubagentCancelTool } from './tools/subagent-cancel'
+import { createSubagentOutputTool } from './tools/subagent-output'
 import { webfetchTool } from './tools/webfetch'
 import { websearchTool } from './tools/websearch'
 
@@ -153,6 +158,16 @@ export type CreateSessionOptions = {
   // already seen") provide their own here. See `ToolResultBudget` for the
   // shared shape.
   toolResultBudgetMessage?: ToolResultBudget['exhaustedMessage']
+  // Orchestration wiring. When all three of `liveSubagentRegistry`,
+  // `subagentRegistry`, and `createSessionForSubagent` are present (AND
+  // `pluginSubagent` is unset), the session exposes the spawn_subagent,
+  // subagent_output, and subagent_cancel tools. Subagent-origin sessions
+  // get an empty tool set via the `pluginSubagent` branch; the gate here
+  // (omitting these for subagent sessions) is what prevents recursive
+  // spawning.
+  liveSubagentRegistry?: LiveSubagentRegistry
+  subagentRegistry?: SubagentRegistry
+  createSessionForSubagent?: CreateSessionForSubagent
 }
 
 export type CreateSessionResult = {
@@ -282,6 +297,16 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
                   }),
                 ]
               : []),
+            ...buildSubagentOrchestrationTools({
+              liveRegistry: options.liveSubagentRegistry,
+              registry: options.subagentRegistry,
+              createSessionForSubagent: options.createSessionForSubagent,
+              agentDir: options.plugins?.agentDir,
+              parentSessionId: sessionManager.getSessionId(),
+              getOrigin,
+              permissions: options.permissions,
+              stream: options.stream,
+            }),
           ]
   const customToolsPreBudget = [...wrapSystemTools(customSystemTools, options.plugins, getOrigin), ...pluginCustomTools]
   const customTools =
@@ -428,6 +453,48 @@ export function buildChannelTools(
     tools.push(createChannelSendTool({ router: channelRouter }))
   }
   return tools
+}
+
+export function buildSubagentOrchestrationTools(opts: {
+  liveRegistry: LiveSubagentRegistry | undefined
+  registry: SubagentRegistry | undefined
+  createSessionForSubagent: CreateSessionForSubagent | undefined
+  agentDir: string | undefined
+  parentSessionId: string
+  getOrigin: () => SessionOrigin | undefined
+  permissions: PermissionService | undefined
+  stream: Stream | undefined
+}): ToolDefinition[] {
+  if (
+    opts.liveRegistry === undefined ||
+    opts.registry === undefined ||
+    opts.createSessionForSubagent === undefined ||
+    opts.agentDir === undefined
+  ) {
+    return []
+  }
+  return [
+    createSpawnSubagentTool({
+      registry: opts.registry,
+      liveRegistry: opts.liveRegistry,
+      createSessionForSubagent: opts.createSessionForSubagent,
+      agentDir: opts.agentDir,
+      parentSessionId: opts.parentSessionId,
+      getOrigin: opts.getOrigin,
+      ...(opts.permissions ? { permissions: opts.permissions } : {}),
+      ...(opts.stream ? { stream: opts.stream } : {}),
+    }),
+    createSubagentOutputTool({
+      liveRegistry: opts.liveRegistry,
+      getOrigin: opts.getOrigin,
+      ...(opts.permissions ? { permissions: opts.permissions } : {}),
+    }),
+    createSubagentCancelTool({
+      liveRegistry: opts.liveRegistry,
+      getOrigin: opts.getOrigin,
+      ...(opts.permissions ? { permissions: opts.permissions } : {}),
+    }),
+  ]
 }
 
 function wrapRegistryTools(

--- a/src/agent/live-subagents.test.ts
+++ b/src/agent/live-subagents.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  LiveSubagentRegistry,
+  MAX_EVENTS_PER_SUBAGENT,
+  MESSAGE_PREVIEW_CHARS,
+  type LiveSubagent,
+  type SubagentProgressEvent,
+  attachProgressCapture,
+  coarsen,
+} from './live-subagents'
+
+function makeLive(overrides: Partial<LiveSubagent> = {}): LiveSubagent {
+  return {
+    taskId: 'bg_t1',
+    sessionId: 'ses_s1',
+    subagentName: 'explorer',
+    parentSessionId: 'ses_p1',
+    startedAt: 1_000,
+    status: 'running',
+    abort: async () => {},
+    awaitCompletion: async () => ({ ok: true, durationMs: 0 }),
+    ...overrides,
+  }
+}
+
+describe('coarsen', () => {
+  test('tool_execution_end → tool event with ok=true when isError=false', () => {
+    const result = coarsen(
+      {
+        type: 'tool_execution_end',
+        toolCallId: 'call_1',
+        toolName: 'grep',
+        result: 'matches found',
+        isError: false,
+      },
+      5_000,
+    )
+    expect(result).toEqual({ kind: 'tool', name: 'grep', ok: true, ts: 5_000 })
+  })
+
+  test('tool_execution_end with isError=true → tool event with ok=false', () => {
+    const result = coarsen(
+      {
+        type: 'tool_execution_end',
+        toolCallId: 'call_1',
+        toolName: 'bash',
+        result: 'error',
+        isError: true,
+      },
+      5_000,
+    )
+    expect(result).toEqual({ kind: 'tool', name: 'bash', ok: false, ts: 5_000 })
+  })
+
+  test('tool_execution_start → null (we only capture _end events; starts without ends look like the subagent is stuck)', () => {
+    const result = coarsen(
+      {
+        type: 'tool_execution_start',
+        toolCallId: 'call_1',
+        toolName: 'grep',
+        args: { pattern: 'foo' },
+      },
+      5_000,
+    )
+    expect(result).toBeNull()
+  })
+
+  test('message_update with text_delta → null (text deltas are token-level, too noisy for progress)', () => {
+    const result = coarsen(
+      { type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'hello' } },
+      5_000,
+    )
+    expect(result).toBeNull()
+  })
+
+  test('message_end with string content → message event with preview', () => {
+    const result = coarsen(
+      {
+        type: 'message_end',
+        message: { content: 'Hello world, this is the final assistant message.' },
+      },
+      5_000,
+    )
+    expect(result).toEqual({
+      kind: 'message',
+      preview: 'Hello world, this is the final assistant message.',
+      ts: 5_000,
+    })
+  })
+
+  test('message_end with array content → extracts first text part', () => {
+    const result = coarsen(
+      {
+        type: 'message_end',
+        message: {
+          content: [
+            { type: 'tool_use', name: 'grep' },
+            { type: 'text', text: 'Found 3 matches' },
+          ],
+        },
+      },
+      5_000,
+    )
+    expect(result).toEqual({ kind: 'message', preview: 'Found 3 matches', ts: 5_000 })
+  })
+
+  test('message_end with long content → truncates to MESSAGE_PREVIEW_CHARS', () => {
+    const longText = 'x'.repeat(500)
+    const result = coarsen({ type: 'message_end', message: { content: longText } }, 5_000)
+    expect(result?.kind).toBe('message')
+    if (result?.kind === 'message') {
+      expect(result.preview.length).toBe(MESSAGE_PREVIEW_CHARS)
+    }
+  })
+
+  test('message_end with empty content → null', () => {
+    const result = coarsen({ type: 'message_end', message: { content: '' } }, 5_000)
+    expect(result).toBeNull()
+  })
+
+  test('unknown event type → null', () => {
+    const result = coarsen({ type: 'something_else' }, 5_000)
+    expect(result).toBeNull()
+  })
+})
+
+describe('LiveSubagentRegistry', () => {
+  test('register + get round-trip', () => {
+    const reg = new LiveSubagentRegistry()
+    const live = makeLive()
+    reg.register(live)
+    expect(reg.get('bg_t1')).toBe(live)
+  })
+
+  test('register seeds the events ring with a started event', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive())
+    const snap = reg.snapshot('bg_t1', 1_500)
+    expect(snap?.eventsCount).toBe(1)
+    expect(snap?.lastActivity).toEqual({ kind: 'started', ts: 1_000 })
+  })
+
+  test('register rejects duplicate taskId', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive())
+    expect(() => reg.register(makeLive())).toThrow('already registered')
+  })
+
+  test('list filters by parentSessionId', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive({ taskId: 'bg_a', parentSessionId: 'ses_p1' }))
+    reg.register(makeLive({ taskId: 'bg_b', parentSessionId: 'ses_p1' }))
+    reg.register(makeLive({ taskId: 'bg_c', parentSessionId: 'ses_p2' }))
+    expect(
+      reg
+        .list({ parentSessionId: 'ses_p1' })
+        .map((e) => e.taskId)
+        .sort(),
+    ).toEqual(['bg_a', 'bg_b'])
+    expect(reg.list({ parentSessionId: 'ses_p2' }).map((e) => e.taskId)).toEqual(['bg_c'])
+    expect(reg.list().length).toBe(3)
+  })
+
+  test('unregister removes entry and events', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive())
+    reg.unregister('bg_t1')
+    expect(reg.get('bg_t1')).toBeUndefined()
+    expect(reg.snapshot('bg_t1')).toBeUndefined()
+  })
+
+  test('recordEvent appends and FIFO-evicts at MAX_EVENTS_PER_SUBAGENT', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive())
+    for (let i = 0; i < MAX_EVENTS_PER_SUBAGENT + 50; i++) {
+      reg.recordEvent('bg_t1', { kind: 'tool', name: `t${i}`, ok: true, ts: 2000 + i })
+    }
+    const snap = reg.snapshot('bg_t1', 3_000)
+    expect(snap?.eventsCount).toBe(MAX_EVENTS_PER_SUBAGENT)
+    const tail = snap?.eventsRecent.at(-1) as Extract<SubagentProgressEvent, { kind: 'tool' }>
+    expect(tail?.name).toBe(`t${MAX_EVENTS_PER_SUBAGENT + 49}`)
+  })
+
+  test('snapshot.eventsRecent returns the last 10 events only', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive())
+    for (let i = 0; i < 30; i++) {
+      reg.recordEvent('bg_t1', { kind: 'tool', name: `t${i}`, ok: true, ts: 2000 + i })
+    }
+    const snap = reg.snapshot('bg_t1', 3_000)
+    expect(snap?.eventsRecent.length).toBe(10)
+  })
+
+  test('recordCompletion flips status to completed on ok=true', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive())
+    reg.recordCompletion('bg_t1', { ok: true, finalMessage: 'done', durationMs: 5_000 })
+    expect(reg.get('bg_t1')?.status).toBe('completed')
+  })
+
+  test('recordCompletion flips status to failed on ok=false', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive())
+    reg.recordCompletion('bg_t1', { ok: false, error: 'boom', durationMs: 5_000 })
+    expect(reg.get('bg_t1')?.status).toBe('failed')
+  })
+
+  test('hasLiveForSession finds running entries by sessionId', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive({ taskId: 'bg_a', sessionId: 'ses_x' }))
+    expect(reg.hasLiveForSession('ses_x')).toBe(true)
+    reg.recordCompletion('bg_a', { ok: true, durationMs: 1 })
+    expect(reg.hasLiveForSession('ses_x')).toBe(false)
+  })
+})
+
+describe('snapshot.statusSummary rendering', () => {
+  test('running, 0 events beyond started → "Running for Xs. 1 event so far. Last: ..."', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive({ startedAt: 1_000 }))
+    const snap = reg.snapshot('bg_t1', 4_000)
+    expect(snap?.statusSummary).toMatch(/Running for 3s/)
+  })
+
+  test('running, with last activity = tool → mentions tool name', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive({ startedAt: 1_000 }))
+    reg.recordEvent('bg_t1', { kind: 'tool', name: 'grep', ok: true, ts: 3_500 })
+    const snap = reg.snapshot('bg_t1', 4_000)
+    expect(snap?.statusSummary).toContain('Last: tool grep')
+  })
+
+  test('running with failed tool → "Last: failed tool <name>"', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive({ startedAt: 1_000 }))
+    reg.recordEvent('bg_t1', { kind: 'tool', name: 'bash', ok: false, ts: 3_500 })
+    const snap = reg.snapshot('bg_t1', 4_000)
+    expect(snap?.statusSummary).toContain('Last: failed tool bash')
+  })
+
+  test('completed → "Completed in Xs."', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive({ startedAt: 1_000 }))
+    reg.recordCompletion('bg_t1', { ok: true, finalMessage: 'done', durationMs: 5_000 })
+    const snap = reg.snapshot('bg_t1', 6_500)
+    expect(snap?.statusSummary).toBe('Completed in 5s.')
+  })
+
+  test('failed → "Failed after Xs: <error>"', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive({ startedAt: 1_000 }))
+    reg.recordCompletion('bg_t1', { ok: false, error: 'provider timeout', durationMs: 3_000 })
+    const snap = reg.snapshot('bg_t1', 5_000)
+    expect(snap?.statusSummary).toBe('Failed after 3s: provider timeout')
+  })
+
+  test('elapsed formatting: ms, sec, minute', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive({ startedAt: 0 }))
+    expect(reg.snapshot('bg_t1', 500)?.statusSummary).toMatch(/500ms/)
+    expect(reg.snapshot('bg_t1', 5_000)?.statusSummary).toMatch(/5s/)
+    expect(reg.snapshot('bg_t1', 75_000)?.statusSummary).toMatch(/1m15s/)
+  })
+})
+
+describe('attachProgressCapture', () => {
+  test('subscribes session events and records coarsened progress', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive())
+    type Listener = (event: unknown) => void
+    let captured: Listener | null = null
+    const fakeSession = {
+      subscribe(listener: Listener) {
+        captured = listener
+        return () => {
+          captured = null
+        }
+      },
+    } as unknown as Parameters<typeof attachProgressCapture>[2]
+    const unsub = attachProgressCapture(reg, 'bg_t1', fakeSession)
+    expect(captured).not.toBeNull()
+    const emit = captured as unknown as Listener
+    emit({ type: 'tool_execution_end', toolCallId: 'c1', toolName: 'read', result: 'ok', isError: false })
+    emit({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'x' } })
+    const snap = reg.snapshot('bg_t1', 1_000)
+    expect(snap?.eventsCount).toBe(2)
+    const tools = snap?.eventsRecent.filter((e) => e.kind === 'tool') ?? []
+    expect(tools).toHaveLength(1)
+    expect((tools[0] as Extract<SubagentProgressEvent, { kind: 'tool' }>).name).toBe('read')
+    unsub()
+  })
+})

--- a/src/agent/live-subagents.ts
+++ b/src/agent/live-subagents.ts
@@ -1,0 +1,215 @@
+import type { AgentSession } from './index'
+
+export type SubagentProgressEvent =
+  | { kind: 'started'; ts: number }
+  | { kind: 'tool'; name: string; ok: boolean; ts: number }
+  | { kind: 'message'; preview: string; ts: number }
+
+export type SubagentStatus = 'running' | 'completed' | 'failed'
+
+export type SubagentCompletion = {
+  ok: boolean
+  finalMessage?: string
+  error?: string
+  durationMs: number
+}
+
+export type LiveSubagent = {
+  taskId: string
+  sessionId: string
+  subagentName: string
+  parentSessionId?: string
+  startedAt: number
+  status: SubagentStatus
+  completion?: SubagentCompletion
+  abort: () => Promise<void>
+  awaitCompletion: () => Promise<SubagentCompletion>
+}
+
+export const MAX_EVENTS_PER_SUBAGENT = 100
+export const MESSAGE_PREVIEW_CHARS = 200
+
+type AgentSessionEvent =
+  | { type: 'message_update'; assistantMessageEvent: { type: string; delta?: string } }
+  | { type: 'message_end'; message: unknown }
+  | { type: 'tool_execution_start'; toolCallId: string; toolName: string; args: unknown }
+  | { type: 'tool_execution_end'; toolCallId: string; toolName: string; result: unknown; isError: boolean }
+  | { type: string }
+
+export function coarsen(event: AgentSessionEvent, now: number): SubagentProgressEvent | null {
+  if (event.type === 'tool_execution_end') {
+    const ev = event as Extract<AgentSessionEvent, { type: 'tool_execution_end' }>
+    return { kind: 'tool', name: ev.toolName, ok: !ev.isError, ts: now }
+  }
+  if (event.type === 'message_end') {
+    const ev = event as Extract<AgentSessionEvent, { type: 'message_end' }>
+    const preview = extractMessagePreview(ev.message)
+    if (preview === null) return null
+    return { kind: 'message', preview, ts: now }
+  }
+  return null
+}
+
+function extractMessagePreview(message: unknown): string | null {
+  if (message === null || typeof message !== 'object') return null
+  const content = (message as { content?: unknown }).content
+  if (typeof content === 'string') {
+    const trimmed = content.trim()
+    return trimmed ? trimmed.slice(0, MESSAGE_PREVIEW_CHARS) : null
+  }
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      if (part && typeof part === 'object' && (part as { type?: unknown }).type === 'text') {
+        const text = (part as { text?: unknown }).text
+        if (typeof text === 'string') {
+          const trimmed = text.trim()
+          if (trimmed) return trimmed.slice(0, MESSAGE_PREVIEW_CHARS)
+        }
+      }
+    }
+  }
+  return null
+}
+
+export type StatusSnapshot = {
+  taskId: string
+  sessionId: string
+  subagentName: string
+  status: SubagentStatus
+  startedAt: number
+  elapsedMs: number
+  eventsCount: number
+  eventsRecent: SubagentProgressEvent[]
+  lastActivity: SubagentProgressEvent | null
+  statusSummary: string
+  completion?: SubagentCompletion
+}
+
+export class LiveSubagentRegistry {
+  private readonly entries = new Map<string, LiveSubagent>()
+  private readonly events = new Map<string, SubagentProgressEvent[]>()
+
+  register(live: LiveSubagent): void {
+    if (this.entries.has(live.taskId)) {
+      throw new Error(`task ${live.taskId} already registered`)
+    }
+    this.entries.set(live.taskId, live)
+    this.events.set(live.taskId, [{ kind: 'started', ts: live.startedAt }])
+  }
+
+  unregister(taskId: string): void {
+    this.entries.delete(taskId)
+    this.events.delete(taskId)
+  }
+
+  get(taskId: string): LiveSubagent | undefined {
+    return this.entries.get(taskId)
+  }
+
+  list(filter?: { parentSessionId?: string }): LiveSubagent[] {
+    const all = Array.from(this.entries.values())
+    if (filter?.parentSessionId === undefined) return all
+    return all.filter((e) => e.parentSessionId === filter.parentSessionId)
+  }
+
+  hasLiveForSession(sessionId: string): boolean {
+    for (const e of this.entries.values()) {
+      if (e.sessionId === sessionId && e.status === 'running') return true
+    }
+    return false
+  }
+
+  recordEvent(taskId: string, event: SubagentProgressEvent): void {
+    const ring = this.events.get(taskId)
+    if (ring === undefined) return
+    ring.push(event)
+    if (ring.length > MAX_EVENTS_PER_SUBAGENT) {
+      ring.splice(0, ring.length - MAX_EVENTS_PER_SUBAGENT)
+    }
+  }
+
+  recordCompletion(taskId: string, completion: SubagentCompletion): void {
+    const entry = this.entries.get(taskId)
+    if (entry === undefined) return
+    entry.completion = completion
+    entry.status = completion.ok ? 'completed' : 'failed'
+  }
+
+  snapshot(taskId: string, now: number = Date.now()): StatusSnapshot | undefined {
+    const entry = this.entries.get(taskId)
+    if (entry === undefined) return undefined
+    const events = this.events.get(taskId) ?? []
+    const eventsRecent = events.slice(-10)
+    const lastActivity: SubagentProgressEvent | null = events.length > 0 ? (events[events.length - 1] ?? null) : null
+    const elapsedMs = (entry.completion ? entry.startedAt + entry.completion.durationMs : now) - entry.startedAt
+    return {
+      taskId: entry.taskId,
+      sessionId: entry.sessionId,
+      subagentName: entry.subagentName,
+      status: entry.status,
+      startedAt: entry.startedAt,
+      elapsedMs,
+      eventsCount: events.length,
+      eventsRecent,
+      lastActivity,
+      statusSummary: renderStatusSummary(entry, events.length, lastActivity, elapsedMs),
+      ...(entry.completion ? { completion: entry.completion } : {}),
+    }
+  }
+
+  clear(): void {
+    this.entries.clear()
+    this.events.clear()
+  }
+}
+
+function renderStatusSummary(
+  entry: LiveSubagent,
+  eventsCount: number,
+  lastActivity: SubagentProgressEvent | null,
+  elapsedMs: number,
+): string {
+  const elapsed = formatElapsed(elapsedMs)
+  if (entry.status === 'completed') return `Completed in ${elapsed}.`
+  if (entry.status === 'failed') {
+    const err = entry.completion?.error ?? 'unknown error'
+    return `Failed after ${elapsed}: ${err}`
+  }
+  const last = describeLastActivity(lastActivity)
+  return `Running for ${elapsed}. ${eventsCount} event${eventsCount === 1 ? '' : 's'} so far${last ? `. Last: ${last}` : ''}.`
+}
+
+function describeLastActivity(event: SubagentProgressEvent | null): string | null {
+  if (event === null) return null
+  if (event.kind === 'tool') return `${event.ok ? '' : 'failed '}tool ${event.name}`
+  if (event.kind === 'message') {
+    const preview = event.preview.length > 60 ? `${event.preview.slice(0, 60)}…` : event.preview
+    return `message "${preview}"`
+  }
+  return null
+}
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const totalSec = Math.floor(ms / 1000)
+  if (totalSec < 60) return `${totalSec}s`
+  const min = Math.floor(totalSec / 60)
+  const sec = totalSec % 60
+  return `${min}m${sec}s`
+}
+
+export function attachProgressCapture(
+  registry: LiveSubagentRegistry,
+  taskId: string,
+  session: Pick<AgentSession, 'subscribe'>,
+): () => void {
+  const unsubscribe = session.subscribe((event: unknown) => {
+    const coarsened = coarsen(event as AgentSessionEvent, Date.now())
+    if (coarsened !== null) {
+      registry.recordEvent(taskId, coarsened)
+    }
+  })
+  return () => {
+    if (typeof unsubscribe === 'function') unsubscribe()
+  }
+}

--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -6,7 +6,13 @@ import type { HookBus } from '@/plugin'
 import { createStream } from '@/stream'
 
 import type { AgentSession } from './index'
-import { createSubagentConsumer, invokeSubagent, type Subagent, validateSubagentPayload } from './subagents'
+import {
+  createSubagentConsumer,
+  invokeSubagent,
+  startSubagent,
+  type Subagent,
+  validateSubagentPayload,
+} from './subagents'
 
 function makeFakeHookBus(events: string[]): HookBus {
   return {
@@ -535,5 +541,250 @@ describe('createSubagentConsumer', () => {
     expect(errors.some((e) => /\[subagent\] greeter: LLM call failed: billing failed/.test(e))).toBe(true)
 
     consumer.stop()
+  })
+})
+
+describe('startSubagent', () => {
+  function subscribableFakeSession(): {
+    session: AgentSession
+    calls: { prompt: string[]; disposed: number }
+    emit: (event: unknown) => void
+  } {
+    const calls = { prompt: [] as string[], disposed: 0 }
+    let listener: ((event: unknown) => void) | null = null
+    const session = {
+      prompt: async (text: string) => {
+        calls.prompt.push(text)
+      },
+      dispose: () => {
+        calls.disposed += 1
+      },
+      subscribe: (l: (event: unknown) => void) => {
+        listener = l
+        return () => {
+          listener = null
+        }
+      },
+      abort: async () => {},
+    } as unknown as AgentSession
+    return {
+      session,
+      calls,
+      emit: (event) => listener?.(event),
+    }
+  }
+
+  test('handle promise resolves before completion settles, with the taskId we provided', async () => {
+    // given
+    const { session } = subscribableFakeSession()
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+
+    // when
+    const { handle, completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'hi',
+      taskId: 'bg_xyz',
+    })
+
+    // then
+    const h = await handle
+    expect(h.taskId).toBe('bg_xyz')
+    await completion
+  })
+
+  test('completion resolves ok=true when prompt finishes', async () => {
+    // given
+    const { session, calls } = subscribableFakeSession()
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+
+    // when
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'hello',
+      taskId: 'bg_1',
+    })
+    const result = await completion
+
+    // then
+    expect(result.ok).toBe(true)
+    expect(calls.prompt).toEqual(['hello'])
+    expect(calls.disposed).toBe(1)
+  })
+
+  test('completion captures the final assistant message', async () => {
+    // given
+    let listener: ((event: unknown) => void) | null = null
+    const session = {
+      prompt: async () => {
+        listener?.({
+          type: 'message_end',
+          message: { content: 'Found 42 results.' },
+        })
+      },
+      dispose: () => {},
+      subscribe: (l: (event: unknown) => void) => {
+        listener = l
+        return () => {
+          listener = null
+        }
+      },
+      abort: async () => {},
+    } as unknown as AgentSession
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+
+    // when
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_msg',
+    })
+    const result = await completion
+
+    // then
+    if (result.ok) {
+      expect(result.finalMessage).toBe('Found 42 results.')
+    } else {
+      throw new Error(`expected ok=true, got error: ${result.error}`)
+    }
+  })
+
+  test('completion resolves ok=false with error message when prompt throws', async () => {
+    // given
+    const session = {
+      prompt: async () => {
+        throw new Error('boom')
+      },
+      dispose: () => {},
+      subscribe: () => () => {},
+      abort: async () => {},
+    } as unknown as AgentSession
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+
+    // when
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_err',
+    })
+    const result = await completion
+
+    // then
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBe('boom')
+    }
+  })
+
+  test('onSession fires once with the live session and abort handle', async () => {
+    // given
+    const { session } = subscribableFakeSession()
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+    let captured: { abortCount: number } | null = null
+
+    // when
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_session',
+      onSession: (event) => {
+        captured = { abortCount: 0 }
+        void event.abort().then(() => {
+          if (captured) captured.abortCount += 1
+        })
+      },
+    })
+    await completion
+
+    // then
+    expect(captured).not.toBeNull()
+    expect(captured!.abortCount).toBe(1)
+  })
+
+  test('parallel starts with different taskIds run concurrently (proves handle settles independently)', async () => {
+    // given
+    let resolveProm1: () => void = () => {}
+    let resolveProm2: () => void = () => {}
+    const session1 = {
+      prompt: async () =>
+        new Promise<void>((r) => {
+          resolveProm1 = r
+        }),
+      dispose: () => {},
+      subscribe: () => () => {},
+      abort: async () => {},
+    } as unknown as AgentSession
+    const session2 = {
+      prompt: async () =>
+        new Promise<void>((r) => {
+          resolveProm2 = r
+        }),
+      dispose: () => {},
+      subscribe: () => () => {},
+      abort: async () => {},
+    } as unknown as AgentSession
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+    let createCount = 0
+
+    // when
+    const start1 = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => {
+        createCount += 1
+        return session1
+      },
+      agentDir: '/agent',
+      userPrompt: 'q1',
+      taskId: 'bg_a',
+    })
+    const start2 = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => {
+        createCount += 1
+        return session2
+      },
+      agentDir: '/agent',
+      userPrompt: 'q2',
+      taskId: 'bg_b',
+    })
+    const h1 = await start1.handle
+    const h2 = await start2.handle
+
+    // then
+    expect(h1.taskId).toBe('bg_a')
+    expect(h2.taskId).toBe('bg_b')
+    expect(createCount).toBe(2)
+    // Both handles resolved before either prompt finished — proves non-blocking shape.
+    resolveProm1()
+    resolveProm2()
+    await Promise.all([start1.completion, start2.completion])
+  })
+
+  test('invokeSubagent (the wrapper) still returns Promise<void> and runs unchanged', async () => {
+    // given (this asserts no behavioral regression from the refactor)
+    const { session, calls } = fakeSession()
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+
+    // when
+    const result = await invokeSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'wrapper',
+    })
+
+    // then
+    expect(result).toBeUndefined()
+    expect(calls.prompt).toEqual(['wrapper'])
+    expect(calls.disposed).toBe(1)
   })
 })

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -30,6 +30,7 @@ export type Subagent<P = unknown> = {
   payloadSchema?: z.ZodType<P>
   handler?: (ctx: SubagentContext<P>, runSession: RunSession) => Promise<void>
   toolResultBudget?: ToolResultBudget
+  visibility?: 'public' | 'internal'
 }
 
 export type SubagentRegistry = Readonly<Record<string, Subagent<any>>>

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -137,6 +137,17 @@ export type InvokeSubagentOptions = {
   spawnedByRole?: string
   spawnedByOrigin?: SessionOrigin
   onProviderError?: (errorMessage: string) => void
+  // Fires synchronously after the AgentSession is created and before
+  // session.prompt() is invoked, with both the live session reference and
+  // its allocated sessionId. The only consumer in production is the spawn
+  // tool's LiveSubagentRegistry path, which uses it to attach a progress
+  // subscriber and register the abort handle while invokeSubagent retains
+  // its `Promise<void>` external contract.
+  onSessionCreated?: (event: {
+    session: AgentSession
+    sessionId: string | undefined
+    abort: () => Promise<void>
+  }) => void
 }
 
 export async function invokeSubagent(name: string, options: InvokeSubagentOptions): Promise<void> {
@@ -156,6 +167,15 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
     const { session, dispose, hooks, sessionId, agentDir, origin, getTranscriptPath } = normalizeSubagentSession(
       await createSessionForSubagent(subagent, sessionOptions),
     )
+    if (options.onSessionCreated !== undefined) {
+      options.onSessionCreated({
+        session,
+        sessionId,
+        abort: async () => {
+          await session.abort()
+        },
+      })
+    }
     const unsubProviderErrors =
       options.onProviderError !== undefined
         ? subscribeProviderErrors(session, (err) => options.onProviderError!(err.message))
@@ -203,6 +223,100 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
   } else {
     await runSession()
   }
+}
+
+export type SubagentHandle = {
+  taskId: string
+  sessionId: string | undefined
+  abort: () => Promise<void>
+}
+
+export type StartSubagentResult = {
+  handle: Promise<SubagentHandle>
+  completion: Promise<{ ok: true; finalMessage?: string } | { ok: false; error: string }>
+}
+
+export type StartSubagentOptions = InvokeSubagentOptions & {
+  taskId: string
+  onSession?: (event: { session: AgentSession; sessionId: string | undefined; abort: () => Promise<void> }) => void
+}
+
+// Non-blocking alternative to invokeSubagent. Returns immediately with two
+// promises:
+// - `handle` resolves with { taskId, sessionId, abort } once the AgentSession
+//   has been created (typically the first microtask). The taskId is what the
+//   caller chose; sessionId is allocated by the session factory.
+// - `completion` resolves when the subagent's prompt finishes, ok=true with
+//   an optional final message, or ok=false with an error message.
+// The two promises share a single underlying invokeSubagent invocation;
+// `completion` settles after dispose, so the session reference exposed via
+// `handle.abort` becomes a no-op once `completion` resolves.
+export function startSubagent(name: string, options: StartSubagentOptions): StartSubagentResult {
+  let resolveHandle: (h: SubagentHandle) => void
+  let rejectHandle: (err: Error) => void
+  const handle = new Promise<SubagentHandle>((resolve, reject) => {
+    resolveHandle = resolve
+    rejectHandle = reject
+  })
+  let handleSettled = false
+  let finalMessage: string | undefined
+
+  const completion = invokeSubagent(name, {
+    ...options,
+    onSessionCreated: (event) => {
+      handleSettled = true
+      resolveHandle({ taskId: options.taskId, sessionId: event.sessionId, abort: event.abort })
+      if (options.onSession !== undefined) {
+        options.onSession(event)
+      }
+      attachFinalMessageCapture(event.session, (msg) => {
+        finalMessage = msg
+      })
+    },
+  })
+    .then(() => ({ ok: true as const, ...(finalMessage !== undefined ? { finalMessage } : {}) }))
+    .catch((err: unknown) => {
+      const error = err instanceof Error ? err.message : String(err)
+      if (!handleSettled) {
+        rejectHandle(err instanceof Error ? err : new Error(error))
+      }
+      return { ok: false as const, error }
+    })
+
+  return { handle, completion }
+}
+
+function attachFinalMessageCapture(session: AgentSession, onFinalMessage: (msg: string) => void): void {
+  try {
+    session.subscribe((event: unknown) => {
+      const ev = event as { type?: string; message?: { content?: unknown } }
+      if (ev?.type !== 'message_end') return
+      const text = extractFinalMessageText(ev.message?.content)
+      if (text !== null) onFinalMessage(text)
+    })
+  } catch {
+    // session.subscribe is a stable upstream API; defensive try is for test
+    // doubles that don't implement it.
+  }
+}
+
+function extractFinalMessageText(content: unknown): string | null {
+  if (typeof content === 'string') {
+    const trimmed = content.trim()
+    return trimmed ? trimmed : null
+  }
+  if (Array.isArray(content)) {
+    const parts: string[] = []
+    for (const part of content) {
+      if (part && typeof part === 'object' && (part as { type?: unknown }).type === 'text') {
+        const text = (part as { text?: unknown }).text
+        if (typeof text === 'string') parts.push(text)
+      }
+    }
+    const joined = parts.join('').trim()
+    return joined ? joined : null
+  }
+  return null
 }
 
 export type SubagentConsumerLogger = {

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -50,6 +50,40 @@ Your agent folder is a git repository.
 - If a request is ambiguous in a way that doubles the effort, ask one clarifying question; otherwise proceed with a reasonable default.
 - Never suppress errors to make things "work", and never fabricate results. Report failures clearly.
 
+## Subagent orchestration
+
+You can delegate focused work to subagents via three tools: \`spawn_subagent\`, \`subagent_output\`, \`subagent_cancel\`. Subagents run with their own context window and their own (often smaller, cheaper, or more constrained) tool set. The list of available subagents and what each one is for is rendered in the \`spawn_subagent\` tool description — re-read it before delegating.
+
+There are two delegation modes. Pick deliberately.
+
+**Mode A — Research fan-out** (in service of the current question)
+
+When you need information to answer the user and the search is broad, fire 2-5 subagents in parallel with \`run_in_background: true\` covering different angles. End your response after spawning. The system will deliver a \`<system-reminder>\` for each completion; gather results then answer the user. Do NOT poll \`subagent_output\` in a tight loop.
+
+**Mode B — Delegate-and-converse** (the user asked you to DO something long-running)
+
+When the user hands you a task that will take minutes (a multi-step browser session, a long build, a complex external operation), acknowledge in plain language ("Alright, running that in the background — I'll let you know when it's done"), spawn one subagent with \`run_in_background: true\`, then KEEP TALKING. Stay available for follow-ups, related questions, parallel small tasks. When the completion reminder lands, weave the result into your next reply naturally. If the conversation has gone idle, proactively message the user with the result rather than waiting.
+
+**Status queries**
+
+If the user asks "how's it going?" or "status?" on a running subagent, call \`subagent_output({ task_id, block: false })\` and report the \`status_summary\` in your own words. Don't pretend to know the status without checking.
+
+**Prompt structure for spawns** (mandatory — the subagent does not see this conversation)
+
+\`\`\`
+[CONTEXT]: What I'm working on, which files/modules are involved, what approach.
+[GOAL]: The specific decision or output I need to unlock.
+[REQUEST]: Concrete instructions — what to find/do/produce, what format, what to SKIP.
+\`\`\`
+
+**Anti-patterns**
+
+- Don't fire more than 5 subagents in a single turn.
+- Don't spawn for a known answer or single-file lookup — do it yourself.
+- Don't poll \`subagent_output\` waiting for completion; end your response and the reminder will wake you.
+- Don't ask a research subagent to make architectural decisions for you — they find and report; you decide.
+- Subagents cannot recursively spawn other subagents.
+
 ## Safety
 
 You have no independent goals. Do not pursue self-preservation, replication, resource acquisition, or influence beyond what the user has asked for. Do not plan beyond the user's request. If instructions conflict or feel unsafe, pause and ask. Comply with stop, pause, and audit requests. Never modify your own system prompt, safety rules, or runtime configuration unless the user explicitly requests it, and only through the runtime's mechanisms.

--- a/src/agent/tools/spawn-subagent.test.ts
+++ b/src/agent/tools/spawn-subagent.test.ts
@@ -1,0 +1,416 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { PermissionService } from '@/permissions'
+import { createStream } from '@/stream'
+
+import type { AgentSession } from '../index'
+import { LiveSubagentRegistry } from '../live-subagents'
+import type { SessionOrigin } from '../session-origin'
+import type { CreateSessionForSubagent, Subagent, SubagentRegistry } from '../subagents'
+import { createSpawnSubagentTool } from './spawn-subagent'
+
+const ctx = {} as Parameters<ReturnType<typeof createSpawnSubagentTool>['execute']>[4]
+
+type StubSession = AgentSession & { emit: (event: unknown) => void; abortCount: { n: number } }
+
+function stubSession(): StubSession {
+  const calls = { prompt: [] as string[], disposed: 0, abortCount: { n: 0 } }
+  let listener: ((event: unknown) => void) | null = null
+  const session = {
+    prompt: async (text: string) => {
+      calls.prompt.push(text)
+      await new Promise((r) => setImmediate(r))
+    },
+    dispose: () => {
+      calls.disposed += 1
+    },
+    subscribe: (l: (event: unknown) => void) => {
+      listener = l
+      return () => {
+        listener = null
+      }
+    },
+    abort: async () => {
+      calls.abortCount.n += 1
+    },
+    emit: (event: unknown) => listener?.(event),
+    abortCount: calls.abortCount,
+  } as unknown as StubSession
+  return session
+}
+
+function emittingSession(emitOnPrompt: () => unknown): StubSession {
+  const session = stubSession()
+  const orig = session.prompt.bind(session)
+  session.prompt = async (text: string) => {
+    const event = emitOnPrompt()
+    if (event !== undefined) session.emit(event)
+    await orig(text)
+  }
+  return session
+}
+
+function makeRegistry(overrides: Record<string, Subagent<unknown>> = {}): SubagentRegistry {
+  const publicSub: Subagent<unknown> = { systemPrompt: 'You are public.', visibility: 'public' }
+  const internalSub: Subagent<unknown> = { systemPrompt: 'You are internal.' }
+  return {
+    explorer: publicSub,
+    'memory-logger': internalSub,
+    ...overrides,
+  }
+}
+
+function fixedSpawn(opts: {
+  createSession: CreateSessionForSubagent
+  registry?: SubagentRegistry
+  permissions?: PermissionService
+  parentSessionId?: string
+}) {
+  const registry = opts.registry ?? makeRegistry()
+  const liveRegistry = new LiveSubagentRegistry()
+  let counter = 0
+  const tool = createSpawnSubagentTool({
+    registry,
+    liveRegistry,
+    createSessionForSubagent: opts.createSession,
+    agentDir: '/agent',
+    parentSessionId: opts.parentSessionId ?? 'ses_parent',
+    getOrigin: () => ({ kind: 'tui', sessionId: 'ses_parent' }),
+    ...(opts.permissions ? { permissions: opts.permissions } : {}),
+    generateTaskId: () => {
+      counter += 1
+      return `bg_test${counter}`
+    },
+    now: () => 1_000,
+    stream: createStream(),
+  })
+  return { tool, liveRegistry, registry }
+}
+
+describe('createSpawnSubagentTool — visibility gate', () => {
+  test('public subagent (explorer) spawns successfully', async () => {
+    const session = stubSession()
+    const { tool } = fixedSpawn({ createSession: async () => session })
+
+    const result = await tool.execute(
+      'call_1',
+      { subagent_type: 'explorer', prompt: 'find X' },
+      undefined,
+      undefined,
+      ctx,
+    )
+    const details = result.details as { ok: boolean; mode?: string }
+    expect(details.ok).toBe(true)
+    expect(details.mode).toBe('sync')
+  })
+
+  test('internal subagent (memory-logger) is rejected as unknown', async () => {
+    const session = stubSession()
+    const { tool } = fixedSpawn({ createSession: async () => session })
+
+    const result = await tool.execute(
+      'call_1',
+      {
+        subagent_type: 'memory-logger',
+        prompt: 'consolidate',
+      },
+      undefined,
+      undefined,
+      ctx,
+    )
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('Unknown subagent: memory-logger')
+  })
+
+  test('unknown subagent error does NOT leak internal subagent names', async () => {
+    const session = stubSession()
+    const { tool } = fixedSpawn({ createSession: async () => session })
+
+    const result = await tool.execute(
+      'call_1',
+      {
+        subagent_type: 'memory-logger',
+        prompt: 'consolidate',
+      },
+      undefined,
+      undefined,
+      ctx,
+    )
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    expect(text).not.toContain('memory-logger\b')
+    expect(text).toContain('Available: explorer')
+  })
+
+  test('empty public-subagent set surfaces "(none)" in error', async () => {
+    const internalOnly: SubagentRegistry = {
+      'memory-logger': { systemPrompt: 'internal' },
+    }
+    const session = stubSession()
+    const { tool } = fixedSpawn({ createSession: async () => session, registry: internalOnly })
+
+    const result = await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    expect(text).toContain('Available: (none)')
+  })
+})
+
+describe('createSpawnSubagentTool — sync mode', () => {
+  test('returns mode=sync with final message captured from message_end event', async () => {
+    const session = emittingSession(() => ({
+      type: 'message_end',
+      message: { content: 'Found three matches in src/.' },
+    }))
+    const { tool, liveRegistry } = fixedSpawn({ createSession: async () => session })
+
+    const result = await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+
+    const details = result.details as {
+      ok: boolean
+      mode?: string
+      taskId?: string
+      finalMessage?: string
+    }
+    expect(details.ok).toBe(true)
+    expect(details.mode).toBe('sync')
+    expect(details.taskId).toBe('bg_test1')
+    expect(details.finalMessage).toBe('Found three matches in src/.')
+    expect(result.content[0]?.type === 'text' ? result.content[0].text : '').toBe('Found three matches in src/.')
+    expect(liveRegistry.get('bg_test1')?.status).toBe('completed')
+  })
+
+  test('returns mode=sync with synthesized text when no final message was captured', async () => {
+    const session = stubSession()
+    const { tool } = fixedSpawn({ createSession: async () => session })
+
+    const result = await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    expect(text).toMatch(/explorer completed in/)
+  })
+
+  test('propagates failure with error envelope when subagent throws', async () => {
+    const session = stubSession()
+    session.prompt = async () => {
+      throw new Error('provider exploded')
+    }
+    const { tool, liveRegistry } = fixedSpawn({ createSession: async () => session })
+
+    const result = await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toBe('provider exploded')
+    expect(liveRegistry.get('bg_test1')?.status).toBe('failed')
+  })
+})
+
+describe('createSpawnSubagentTool — background mode', () => {
+  test('returns immediately with task_id and registers as running', async () => {
+    let resolvePrompt: () => void = () => {}
+    const session = stubSession()
+    session.prompt = () =>
+      new Promise<void>((r) => {
+        resolvePrompt = r
+      })
+    const { tool, liveRegistry } = fixedSpawn({ createSession: async () => session })
+
+    const result = await tool.execute(
+      'call_1',
+      {
+        subagent_type: 'explorer',
+        prompt: 'long search',
+        run_in_background: true,
+      },
+      undefined,
+      undefined,
+      ctx,
+    )
+
+    const details = result.details as { ok: boolean; mode?: string; taskId?: string }
+    expect(details.ok).toBe(true)
+    expect(details.mode).toBe('background')
+    expect(details.taskId).toBe('bg_test1')
+    expect(liveRegistry.get('bg_test1')?.status).toBe('running')
+
+    resolvePrompt()
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+  })
+
+  test('background completion publishes a subagent.completed broadcast to the stream', async () => {
+    const stream = createStream()
+    const events: unknown[] = []
+    stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => {
+      events.push(msg.payload)
+    })
+    const liveRegistry = new LiveSubagentRegistry()
+    const session = stubSession()
+    let counter = 0
+    const tool = createSpawnSubagentTool({
+      registry: makeRegistry(),
+      liveRegistry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      parentSessionId: 'ses_parent',
+      getOrigin: () => ({ kind: 'tui', sessionId: 'ses_parent' }),
+      stream,
+      generateTaskId: () => {
+        counter += 1
+        return `bg_b${counter}`
+      },
+      now: () => 1_000,
+    })
+
+    const result = await tool.execute(
+      'call_1',
+      {
+        subagent_type: 'explorer',
+        prompt: 'q',
+        run_in_background: true,
+      },
+      undefined,
+      undefined,
+      ctx,
+    )
+    const details = result.details as { ok: boolean; taskId?: string }
+    expect(details.ok).toBe(true)
+
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+
+    expect(events.length).toBeGreaterThan(0)
+    const completion = events.find((e) => (e as { kind?: string }).kind === 'subagent.completed') as
+      | Record<string, unknown>
+      | undefined
+    expect(completion).toBeDefined()
+    expect(completion?.taskId).toBe(details.taskId)
+    expect(completion?.subagent).toBe('explorer')
+    expect(completion?.ok).toBe(true)
+  })
+})
+
+describe('createSpawnSubagentTool — permissions gating', () => {
+  function permService(allowed: Set<string>): PermissionService {
+    return {
+      has: (_origin, permission) => allowed.has(permission),
+      resolveRole: () => 'tester',
+      describe: () => ({ role: 'tester', permissions: [...allowed] }),
+      replaceRoles: () => {},
+    }
+  }
+
+  test('denied when origin lacks subagent.spawn and no per-subagent permission', async () => {
+    const session = stubSession()
+    const { tool } = fixedSpawn({
+      createSession: async () => session,
+      permissions: permService(new Set()),
+    })
+
+    const result = await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('denied')
+  })
+
+  test('allowed via generic subagent.spawn fallback', async () => {
+    const session = stubSession()
+    const { tool } = fixedSpawn({
+      createSession: async () => session,
+      permissions: permService(new Set(['subagent.spawn'])),
+    })
+
+    const result = await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean }
+    expect(details.ok).toBe(true)
+  })
+
+  test('allowed via per-subagent permission even without generic spawn', async () => {
+    const session = stubSession()
+    const { tool } = fixedSpawn({
+      createSession: async () => session,
+      permissions: permService(new Set(['subagent.spawn.explorer'])),
+    })
+
+    const result = await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean }
+    expect(details.ok).toBe(true)
+  })
+})
+
+describe('createSpawnSubagentTool — concurrency', () => {
+  test('two concurrent spawns get distinct task_ids', async () => {
+    let resolveA: () => void = () => {}
+    let resolveB: () => void = () => {}
+    const sessions = [
+      (() => {
+        const s = stubSession()
+        s.prompt = () =>
+          new Promise<void>((r) => {
+            resolveA = r
+          })
+        return s
+      })(),
+      (() => {
+        const s = stubSession()
+        s.prompt = () =>
+          new Promise<void>((r) => {
+            resolveB = r
+          })
+        return s
+      })(),
+    ]
+    let idx = 0
+    const liveRegistry = new LiveSubagentRegistry()
+    let counter = 0
+    const tool = createSpawnSubagentTool({
+      registry: makeRegistry(),
+      liveRegistry,
+      createSessionForSubagent: async () => {
+        const s = sessions[idx]
+        if (s === undefined) throw new Error('out of sessions')
+        idx += 1
+        return s
+      },
+      agentDir: '/agent',
+      parentSessionId: 'ses_parent',
+      getOrigin: () => ({ kind: 'tui', sessionId: 'ses_parent' }),
+      generateTaskId: () => {
+        counter += 1
+        return `bg_p${counter}`
+      },
+      now: () => 1_000,
+    })
+
+    const p1 = tool.execute(
+      'call_1',
+      { subagent_type: 'explorer', prompt: 'a', run_in_background: true },
+      undefined,
+      undefined,
+      ctx,
+    )
+    const p2 = tool.execute(
+      'call_2',
+      { subagent_type: 'explorer', prompt: 'b', run_in_background: true },
+      undefined,
+      undefined,
+      ctx,
+    )
+    const [r1, r2] = await Promise.all([p1, p2])
+    const d1 = r1.details as { taskId: string }
+    const d2 = r2.details as { taskId: string }
+
+    expect(d1.taskId).toBe('bg_p1')
+    expect(d2.taskId).toBe('bg_p2')
+    expect(d1.taskId).not.toBe(d2.taskId)
+    expect(
+      liveRegistry
+        .list()
+        .map((e) => e.taskId)
+        .sort(),
+    ).toEqual(['bg_p1', 'bg_p2'])
+
+    resolveA()
+    resolveB()
+    await new Promise((r) => setImmediate(r))
+  })
+})

--- a/src/agent/tools/spawn-subagent.ts
+++ b/src/agent/tools/spawn-subagent.ts
@@ -1,0 +1,279 @@
+import { randomUUID } from 'node:crypto'
+
+import { Type } from '@mariozechner/pi-ai'
+import { defineTool } from '@mariozechner/pi-coding-agent'
+
+import type { PermissionService } from '@/permissions'
+import type { Stream } from '@/stream'
+
+import { type LiveSubagentRegistry, type SubagentCompletion } from '../live-subagents'
+import type { SessionOrigin } from '../session-origin'
+import { type CreateSessionForSubagent, type Subagent, type SubagentRegistry, startSubagent } from '../subagents'
+
+export const SPAWN_TASK_ID_PREFIX = 'bg_'
+
+export type SpawnSubagentToolDetails =
+  | {
+      ok: true
+      mode: 'sync'
+      subagent: string
+      taskId: string
+      sessionId: string | undefined
+      durationMs: number
+      finalMessage?: string
+    }
+  | {
+      ok: true
+      mode: 'background'
+      subagent: string
+      taskId: string
+      sessionId: string | undefined
+    }
+  | { ok: false; error: string }
+
+export type CreateSpawnSubagentToolOptions = {
+  registry: SubagentRegistry
+  liveRegistry: LiveSubagentRegistry
+  createSessionForSubagent: CreateSessionForSubagent
+  agentDir: string
+  parentSessionId: string
+  getOrigin: () => SessionOrigin | undefined
+  permissions?: PermissionService
+  stream?: Stream
+  generateTaskId?: () => string
+  now?: () => number
+}
+
+export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions) {
+  const {
+    registry,
+    liveRegistry,
+    createSessionForSubagent,
+    agentDir,
+    parentSessionId,
+    getOrigin,
+    permissions,
+    stream,
+    generateTaskId = () => `${SPAWN_TASK_ID_PREFIX}${randomUUID().replace(/-/g, '').slice(0, 12)}`,
+    now = () => Date.now(),
+  } = options
+
+  return defineTool({
+    name: 'spawn_subagent',
+    label: 'Spawn Subagent',
+    description: spawnSubagentDescription(registry),
+    parameters: Type.Object({
+      subagent_type: Type.String({
+        description:
+          'Name of the subagent to spawn. Must be a public subagent registered with this agent. See the system prompt section "Subagent orchestration" for the available list.',
+      }),
+      prompt: Type.String({
+        description:
+          'The full task description for the subagent. Use the [CONTEXT]/[GOAL]/[REQUEST] structure described in the system prompt. The subagent does not see the parent conversation; everything it needs must be in this string.',
+      }),
+      description: Type.Optional(
+        Type.String({
+          description: '3-5 word label for this spawn, used for logs and the status_summary. Optional.',
+        }),
+      ),
+      run_in_background: Type.Optional(
+        Type.Boolean({
+          description:
+            'When true, the spawn returns immediately with a task_id; the subagent runs in the background and a system-reminder is delivered when it completes. ' +
+            'When false (default), the spawn blocks until the subagent finishes and returns its final message synchronously. ' +
+            'Use background mode for long-running tasks where you want to keep the conversation moving (Mode B) or for parallel fan-out (Mode A).',
+        }),
+      ),
+    }),
+
+    async execute(_toolCallId, params): Promise<ToolReturn> {
+      const origin = getOrigin()
+      if (!hasPermissionForSubagent(permissions, origin, params.subagent_type)) {
+        return errorResult('subagent.spawn denied: insufficient permissions')
+      }
+      const subagent = lookupPublicSubagent(registry, params.subagent_type)
+      if (subagent === null) {
+        return errorResult(formatUnknownSubagentError(registry, params.subagent_type))
+      }
+
+      const taskId = generateTaskId()
+      const subagentName = params.subagent_type
+      const background = params.run_in_background === true
+      const payload: Record<string, unknown> = { requestId: taskId, prompt: params.prompt }
+      if (params.description !== undefined) payload.description = params.description
+
+      const startedAt = now()
+      const { handle, completion } = startSubagent(subagentName, {
+        registry,
+        createSessionForSubagent,
+        agentDir,
+        userPrompt: params.prompt,
+        payload: subagent.payloadSchema ? payload : undefined,
+        parentSessionId,
+        ...(origin !== undefined ? { spawnedByOrigin: origin } : {}),
+        taskId,
+      })
+
+      let resolvedHandle: { taskId: string; sessionId: string | undefined; abort: () => Promise<void> } | undefined
+      try {
+        resolvedHandle = await handle
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return errorResult(`failed to spawn ${subagentName}: ${message}`)
+      }
+
+      const live = {
+        taskId,
+        sessionId: resolvedHandle.sessionId ?? '<pending>',
+        subagentName,
+        parentSessionId,
+        startedAt,
+        status: 'running' as const,
+        abort: resolvedHandle.abort,
+        awaitCompletion: () => completion.then((c) => completionToFinalShape(c, now() - startedAt)),
+      }
+      liveRegistry.register(live)
+
+      void completion.then((c) => {
+        const durationMs = now() - startedAt
+        liveRegistry.recordCompletion(taskId, completionToFinalShape(c, durationMs))
+        if (stream && background) {
+          stream.publish({
+            target: { kind: 'broadcast' },
+            payload: {
+              kind: 'subagent.completed',
+              taskId,
+              subagent: subagentName,
+              parentSessionId,
+              ok: c.ok,
+              durationMs,
+              ...(c.ok ? {} : { error: c.error }),
+            },
+          })
+        }
+      })
+
+      if (background) {
+        const details: SpawnSubagentToolDetails = {
+          ok: true,
+          mode: 'background',
+          subagent: subagentName,
+          taskId,
+          sessionId: resolvedHandle.sessionId,
+        }
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Spawned ${subagentName} in background. task_id=${taskId}. You will receive a system-reminder when it completes. Use subagent_output to check progress or fetch results.`,
+            },
+          ],
+          details,
+        }
+      }
+
+      const result = await completion
+      const durationMs = now() - startedAt
+      if (!result.ok) {
+        const details: SpawnSubagentToolDetails = { ok: false, error: result.error }
+        return {
+          content: [{ type: 'text' as const, text: `${subagentName} failed after ${durationMs}ms: ${result.error}` }],
+          details,
+        }
+      }
+      const details: SpawnSubagentToolDetails = {
+        ok: true,
+        mode: 'sync',
+        subagent: subagentName,
+        taskId,
+        sessionId: resolvedHandle.sessionId,
+        durationMs,
+        ...(result.finalMessage !== undefined ? { finalMessage: result.finalMessage } : {}),
+      }
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              result.finalMessage !== undefined
+                ? result.finalMessage
+                : `${subagentName} completed in ${durationMs}ms with no final message.`,
+          },
+        ],
+        details,
+      }
+    },
+  })
+}
+
+export function spawnSubagentDescription(registry: SubagentRegistry): string {
+  const publicNames = publicSubagentNames(registry)
+  const available = publicNames.length > 0 ? publicNames.join(', ') : '(none registered yet)'
+  return (
+    `Spawn a subagent to do focused work on your behalf. Use this when a task is heavy enough to deserve a fresh context window (research fan-out) ` +
+    `or long-running enough that you want to keep the conversation moving while it runs (delegate-and-converse). ` +
+    `Available subagents: ${available}. ` +
+    `When run_in_background=true (preferred for long-running work), the tool returns a task_id immediately and the subagent runs concurrently — ` +
+    `you will receive a system-reminder when it completes; do NOT poll subagent_output. ` +
+    `When run_in_background=false (default), the tool blocks and returns the subagent's final message synchronously. ` +
+    `Subagents cannot recursively spawn other subagents.`
+  )
+}
+
+function publicSubagentNames(registry: SubagentRegistry): string[] {
+  return Object.entries(registry)
+    .filter(([, sub]) => isPublicSubagent(sub))
+    .map(([name]) => name)
+    .sort()
+}
+
+function isPublicSubagent(sub: Subagent<unknown>): boolean {
+  return sub.visibility === 'public'
+}
+
+function lookupPublicSubagent(registry: SubagentRegistry, name: string): Subagent<unknown> | null {
+  const sub = registry[name]
+  if (sub === undefined) return null
+  if (!isPublicSubagent(sub)) return null
+  return sub
+}
+
+function formatUnknownSubagentError(registry: SubagentRegistry, requested: string): string {
+  const names = publicSubagentNames(registry)
+  const available = names.length > 0 ? names.join(', ') : '(none)'
+  return `Unknown subagent: ${requested}. Available: ${available}.`
+}
+
+function hasPermissionForSubagent(
+  permissions: PermissionService | undefined,
+  origin: SessionOrigin | undefined,
+  subagentName: string,
+): boolean {
+  if (permissions === undefined) return true
+  const specific = `subagent.spawn.${subagentName}`
+  if (permissions.has(origin, specific)) return true
+  return permissions.has(origin, 'subagent.spawn')
+}
+
+function completionToFinalShape(
+  c: { ok: true; finalMessage?: string } | { ok: false; error: string },
+  durationMs: number,
+): SubagentCompletion {
+  if (c.ok) {
+    return { ok: true, durationMs, ...(c.finalMessage !== undefined ? { finalMessage: c.finalMessage } : {}) }
+  }
+  return { ok: false, error: c.error, durationMs }
+}
+
+type ToolReturn = {
+  content: { type: 'text'; text: string }[]
+  details: SpawnSubagentToolDetails
+}
+
+function errorResult(message: string): ToolReturn {
+  const details: SpawnSubagentToolDetails = { ok: false, error: message }
+  return {
+    content: [{ type: 'text', text: message }],
+    details,
+  }
+}

--- a/src/agent/tools/subagent-cancel.test.ts
+++ b/src/agent/tools/subagent-cancel.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'bun:test'
+
+import { LiveSubagentRegistry, type LiveSubagent } from '../live-subagents'
+import { createSubagentCancelTool } from './subagent-cancel'
+
+const ctx = {} as Parameters<ReturnType<typeof createSubagentCancelTool>['execute']>[4]
+
+function makeLive(overrides: Partial<LiveSubagent> = {}): LiveSubagent {
+  return {
+    taskId: 'bg_c1',
+    sessionId: 'ses_s1',
+    subagentName: 'explorer',
+    parentSessionId: 'ses_parent',
+    startedAt: 1_000,
+    status: 'running',
+    abort: async () => {},
+    awaitCompletion: async () => ({ ok: true, durationMs: 0 }),
+    ...overrides,
+  }
+}
+
+describe('createSubagentCancelTool', () => {
+  test('unknown task_id → ok=false', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    const tool = createSubagentCancelTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_missing' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('Unknown task_id')
+  })
+
+  test('cancels running subagent and invokes abort() once', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    let abortCount = 0
+    liveRegistry.register(
+      makeLive({
+        abort: async () => {
+          abortCount += 1
+        },
+      }),
+    )
+    const tool = createSubagentCancelTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; alreadyDone?: boolean }
+    expect(details.ok).toBe(true)
+    expect(details.alreadyDone).toBe(false)
+    expect(abortCount).toBe(1)
+  })
+
+  test('already-completed task → ok=true with alreadyDone=true, no abort call', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    let abortCount = 0
+    liveRegistry.register(
+      makeLive({
+        abort: async () => {
+          abortCount += 1
+        },
+      }),
+    )
+    liveRegistry.recordCompletion('bg_c1', { ok: true, durationMs: 100 })
+
+    const tool = createSubagentCancelTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; alreadyDone?: boolean }
+    expect(details.ok).toBe(true)
+    expect(details.alreadyDone).toBe(true)
+    expect(abortCount).toBe(0)
+  })
+
+  test('abort failure surfaces as ok=false error', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(
+      makeLive({
+        abort: async () => {
+          throw new Error('upstream cancel rejected')
+        },
+      }),
+    )
+    const tool = createSubagentCancelTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('upstream cancel rejected')
+  })
+
+  test('denied when origin lacks subagent.cancel', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive())
+    const tool = createSubagentCancelTool({
+      liveRegistry,
+      getOrigin: () => ({ kind: 'channel', adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null }),
+      permissions: {
+        has: () => false,
+        resolveRole: () => 'guest',
+        describe: () => ({ role: 'guest', permissions: [] }),
+        replaceRoles: () => {},
+      },
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('denied')
+  })
+})

--- a/src/agent/tools/subagent-cancel.ts
+++ b/src/agent/tools/subagent-cancel.ts
@@ -1,0 +1,96 @@
+import { Type } from '@mariozechner/pi-ai'
+import { defineTool } from '@mariozechner/pi-coding-agent'
+
+import type { PermissionService } from '@/permissions'
+
+import type { LiveSubagentRegistry } from '../live-subagents'
+import type { SessionOrigin } from '../session-origin'
+
+export type SubagentCancelToolDetails =
+  | { ok: true; taskId: string; subagent: string; alreadyDone: boolean }
+  | { ok: false; error: string }
+
+export type CreateSubagentCancelToolOptions = {
+  liveRegistry: LiveSubagentRegistry
+  getOrigin: () => SessionOrigin | undefined
+  permissions?: PermissionService
+}
+
+export function createSubagentCancelTool(options: CreateSubagentCancelToolOptions) {
+  const { liveRegistry, getOrigin, permissions } = options
+
+  return defineTool({
+    name: 'subagent_cancel',
+    label: 'Cancel Subagent',
+    description:
+      'Cancel a running subagent you previously spawned. The subagent receives an abort signal and its current in-flight tool call is interrupted. ' +
+      'Use this when the user changes their mind, the spawn is no longer needed, or a runaway subagent must be stopped. ' +
+      'Cancelling an already-completed or failed subagent is a no-op (returns ok=true with alreadyDone=true).',
+    parameters: Type.Object({
+      task_id: Type.String({
+        description: 'The task_id returned by a previous spawn_subagent call.',
+      }),
+    }),
+
+    async execute(_toolCallId, params): Promise<ToolReturn> {
+      if (permissions !== undefined && !permissions.has(getOrigin(), 'subagent.cancel')) {
+        return errorResult('subagent.cancel denied: insufficient permissions')
+      }
+      const live = liveRegistry.get(params.task_id)
+      if (live === undefined) {
+        return errorResult(`Unknown task_id: ${params.task_id}.`)
+      }
+      if (live.status !== 'running') {
+        const details: SubagentCancelToolDetails = {
+          ok: true,
+          taskId: live.taskId,
+          subagent: live.subagentName,
+          alreadyDone: true,
+        }
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `${live.subagentName} (${live.taskId}) is already ${live.status}; nothing to cancel.`,
+            },
+          ],
+          details,
+        }
+      }
+      try {
+        await live.abort()
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return errorResult(`abort failed: ${message}`)
+      }
+      const details: SubagentCancelToolDetails = {
+        ok: true,
+        taskId: live.taskId,
+        subagent: live.subagentName,
+        alreadyDone: false,
+      }
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `${live.subagentName} (${live.taskId}) cancellation requested. It will stop on the next abort checkpoint.`,
+          },
+        ],
+        details,
+      }
+    },
+  })
+}
+
+type ToolReturn = {
+  content: { type: 'text'; text: string }[]
+  details: SubagentCancelToolDetails
+}
+
+function errorResult(message: string): ToolReturn {
+  const details: SubagentCancelToolDetails = { ok: false, error: message }
+  return {
+    content: [{ type: 'text', text: message }],
+    details,
+  }
+}

--- a/src/agent/tools/subagent-output.test.ts
+++ b/src/agent/tools/subagent-output.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from 'bun:test'
+
+import { LiveSubagentRegistry, type LiveSubagent } from '../live-subagents'
+import { createSubagentOutputTool } from './subagent-output'
+
+const ctx = {} as Parameters<ReturnType<typeof createSubagentOutputTool>['execute']>[4]
+
+function makeLive(overrides: Partial<LiveSubagent> = {}): LiveSubagent {
+  return {
+    taskId: 'bg_o1',
+    sessionId: 'ses_s1',
+    subagentName: 'explorer',
+    parentSessionId: 'ses_parent',
+    startedAt: 1_000,
+    status: 'running',
+    abort: async () => {},
+    awaitCompletion: async () => ({ ok: true, durationMs: 0 }),
+    ...overrides,
+  }
+}
+
+describe('createSubagentOutputTool — unknown task_id', () => {
+  test('returns ok=false with helpful error', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    const tool = createSubagentOutputTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_missing' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('Unknown task_id')
+  })
+})
+
+describe('createSubagentOutputTool — running status', () => {
+  test('returns status=running with status_summary and recent events', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive({ startedAt: 1_000 }))
+    liveRegistry.recordEvent('bg_o1', { kind: 'tool', name: 'grep', ok: true, ts: 1_500 })
+    liveRegistry.recordEvent('bg_o1', { kind: 'tool', name: 'read', ok: true, ts: 2_000 })
+
+    const tool = createSubagentOutputTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+      now: () => 3_000,
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+
+    const details = result.details as {
+      ok: boolean
+      status?: string
+      eventsCount?: number
+      statusSummary?: string
+    }
+    expect(details.ok).toBe(true)
+    expect(details.status).toBe('running')
+    expect(details.eventsCount).toBe(3)
+    expect(details.statusSummary).toMatch(/Running for 2s/)
+    expect(details.statusSummary).toContain('Last: tool read')
+    const firstContent = result.content[0]
+    const text = firstContent?.type === 'text' ? firstContent.text : ''
+    expect(text).toBe(details.statusSummary ?? '')
+  })
+
+  test('eventsRecent is bounded to 10 events', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive())
+    for (let i = 0; i < 25; i++) {
+      liveRegistry.recordEvent('bg_o1', { kind: 'tool', name: `t${i}`, ok: true, ts: 1_500 + i })
+    }
+    const tool = createSubagentOutputTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+      now: () => 3_000,
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; eventsRecent?: { kind: string; name?: string }[] }
+    expect(details.eventsRecent?.length).toBe(10)
+  })
+})
+
+describe('createSubagentOutputTool — completed status', () => {
+  test('returns final message when completion has one', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive())
+    liveRegistry.recordCompletion('bg_o1', {
+      ok: true,
+      finalMessage: 'Found 3 matches in src/api.',
+      durationMs: 2_500,
+    })
+
+    const tool = createSubagentOutputTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+      now: () => 4_000,
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+
+    const details = result.details as { ok: boolean; status?: string; finalMessage?: string; durationMs?: number }
+    expect(details.ok).toBe(true)
+    expect(details.status).toBe('completed')
+    expect(details.finalMessage).toBe('Found 3 matches in src/api.')
+    expect(details.durationMs).toBe(2_500)
+    expect(result.content[0]?.type === 'text' ? result.content[0].text : '').toBe('Found 3 matches in src/api.')
+  })
+
+  test('synthesizes content text when completion has no final message', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive())
+    liveRegistry.recordCompletion('bg_o1', { ok: true, durationMs: 1_000 })
+
+    const tool = createSubagentOutputTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+      now: () => 2_000,
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    expect(text).toMatch(/explorer completed in/)
+  })
+})
+
+describe('createSubagentOutputTool — failed status', () => {
+  test('returns error envelope without setting ok=false (the QUERY succeeded; the SUBAGENT failed)', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive())
+    liveRegistry.recordCompletion('bg_o1', { ok: false, error: 'provider rate limit', durationMs: 500 })
+
+    const tool = createSubagentOutputTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+      now: () => 1_500,
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+
+    const details = result.details as { ok: boolean; status?: string; error?: string }
+    expect(details.ok).toBe(true)
+    expect(details.status).toBe('failed')
+    expect(details.error).toBe('provider rate limit')
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    expect(text).toContain('failed after')
+    expect(text).toContain('provider rate limit')
+  })
+})
+
+describe('createSubagentOutputTool — block:true', () => {
+  test('waits for completion when block=true on a running task', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    let resolveCompletion: (c: { ok: true; durationMs: number; finalMessage?: string }) => void = () => {}
+    const completionPromise = new Promise<{ ok: true; durationMs: number; finalMessage?: string }>((r) => {
+      resolveCompletion = r
+    })
+    liveRegistry.register(
+      makeLive({
+        awaitCompletion: () => completionPromise,
+      }),
+    )
+
+    const tool = createSubagentOutputTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+      now: () => 5_000,
+    })
+
+    const executePromise = tool.execute(
+      'call_1',
+      { task_id: 'bg_o1', block: true, timeout_ms: 5_000 },
+      undefined,
+      undefined,
+      ctx,
+    )
+    setTimeout(() => {
+      liveRegistry.recordCompletion('bg_o1', { ok: true, finalMessage: 'done', durationMs: 1_000 })
+      resolveCompletion({ ok: true, durationMs: 1_000, finalMessage: 'done' })
+    }, 10)
+
+    const result = await executePromise
+    const details = result.details as { status?: string; finalMessage?: string }
+    expect(details.status).toBe('completed')
+    expect(details.finalMessage).toBe('done')
+  })
+
+  test('returns current state on timeout (does NOT error)', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(
+      makeLive({
+        awaitCompletion: () => new Promise(() => {}),
+      }),
+    )
+
+    const tool = createSubagentOutputTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+      now: () => 2_000,
+    })
+
+    const result = await tool.execute(
+      'call_1',
+      { task_id: 'bg_o1', block: true, timeout_ms: 20 },
+      undefined,
+      undefined,
+      ctx,
+    )
+    const details = result.details as { ok: boolean; status?: string }
+    expect(details.ok).toBe(true)
+    expect(details.status).toBe('running')
+  })
+
+  test('block=true on already-completed task short-circuits (no wait)', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive())
+    liveRegistry.recordCompletion('bg_o1', { ok: true, finalMessage: 'fast', durationMs: 100 })
+
+    const tool = createSubagentOutputTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+      now: () => 1_000,
+    })
+
+    const start = Date.now()
+    const result = await tool.execute(
+      'call_1',
+      { task_id: 'bg_o1', block: true, timeout_ms: 60_000 },
+      undefined,
+      undefined,
+      ctx,
+    )
+    const elapsed = Date.now() - start
+
+    expect(elapsed).toBeLessThan(50)
+    const details = result.details as { status?: string }
+    expect(details.status).toBe('completed')
+  })
+})
+
+describe('createSubagentOutputTool — permissions', () => {
+  test('denied when origin lacks subagent.output', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive())
+    const tool = createSubagentOutputTool({
+      liveRegistry,
+      getOrigin: () => ({ kind: 'channel', adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null }),
+      permissions: {
+        has: () => false,
+        resolveRole: () => 'guest',
+        describe: () => ({ role: 'guest', permissions: [] }),
+        replaceRoles: () => {},
+      },
+    })
+    const result = await tool.execute('call_1', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('denied')
+  })
+})

--- a/src/agent/tools/subagent-output.ts
+++ b/src/agent/tools/subagent-output.ts
@@ -1,0 +1,192 @@
+import { Type } from '@mariozechner/pi-ai'
+import { defineTool } from '@mariozechner/pi-coding-agent'
+
+import type { PermissionService } from '@/permissions'
+
+import type { LiveSubagentRegistry, StatusSnapshot, SubagentProgressEvent } from '../live-subagents'
+import type { SessionOrigin } from '../session-origin'
+
+const DEFAULT_TIMEOUT_MS = 60_000
+const MAX_TIMEOUT_MS = 300_000
+
+export type SubagentOutputToolDetails =
+  | {
+      ok: true
+      status: 'running'
+      taskId: string
+      subagent: string
+      startedAt: number
+      elapsedMs: number
+      eventsCount: number
+      eventsRecent: SubagentProgressEvent[]
+      lastActivity: SubagentProgressEvent | null
+      statusSummary: string
+    }
+  | {
+      ok: true
+      status: 'completed'
+      taskId: string
+      subagent: string
+      durationMs: number
+      finalMessage?: string
+    }
+  | {
+      ok: true
+      status: 'failed'
+      taskId: string
+      subagent: string
+      durationMs: number
+      error: string
+    }
+  | { ok: false; error: string }
+
+export type CreateSubagentOutputToolOptions = {
+  liveRegistry: LiveSubagentRegistry
+  getOrigin: () => SessionOrigin | undefined
+  permissions?: PermissionService
+  now?: () => number
+}
+
+export function createSubagentOutputTool(options: CreateSubagentOutputToolOptions) {
+  const { liveRegistry, getOrigin, permissions, now = () => Date.now() } = options
+
+  return defineTool({
+    name: 'subagent_output',
+    label: 'Subagent Output',
+    description:
+      'Fetch the current state of a subagent you previously spawned. Returns one of three statuses: ' +
+      "'running' (with a human-readable status_summary and a tail of recent progress events), " +
+      "'completed' (with the final message), or 'failed' (with the error). " +
+      'Use this when the user asks how a long-running subagent is going, or when you need to retrieve the result of a backgrounded spawn. ' +
+      'When block=true (default false), the tool waits up to timeout_ms for completion before returning. ' +
+      'Prefer block=false and rely on the system-reminder for completion notification; reserve block=true for tight workflows.',
+    parameters: Type.Object({
+      task_id: Type.String({
+        description: 'The task_id returned by a previous spawn_subagent call.',
+      }),
+      block: Type.Optional(
+        Type.Boolean({
+          description:
+            'If true, wait for the subagent to complete (or time out) before returning. Default false: return immediately with the current state.',
+        }),
+      ),
+      timeout_ms: Type.Optional(
+        Type.Integer({
+          description: `When block=true, max milliseconds to wait (default ${DEFAULT_TIMEOUT_MS}, max ${MAX_TIMEOUT_MS}).`,
+          minimum: 1,
+          maximum: MAX_TIMEOUT_MS,
+        }),
+      ),
+    }),
+
+    async execute(_toolCallId, params) {
+      if (permissions !== undefined && !permissions.has(getOrigin(), 'subagent.output')) {
+        return errorResult('subagent.output denied: insufficient permissions')
+      }
+      const live = liveRegistry.get(params.task_id)
+      if (live === undefined) {
+        return errorResult(`Unknown task_id: ${params.task_id}.`)
+      }
+
+      const wantsBlock = params.block === true && live.status === 'running'
+      if (wantsBlock) {
+        const timeoutMs = clampTimeout(params.timeout_ms)
+        await raceWithTimeout(live.awaitCompletion(), timeoutMs)
+      }
+
+      const snap = liveRegistry.snapshot(params.task_id, now())
+      if (snap === undefined) {
+        return errorResult(`Unknown task_id: ${params.task_id}.`)
+      }
+      return renderSnapshot(snap)
+    },
+  })
+}
+
+function clampTimeout(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_TIMEOUT_MS
+  return Math.min(Math.max(1, Math.floor(value)), MAX_TIMEOUT_MS)
+}
+
+async function raceWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | undefined> {
+  return new Promise<T | undefined>((resolve) => {
+    const timer = setTimeout(() => resolve(undefined), timeoutMs)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      () => {
+        clearTimeout(timer)
+        resolve(undefined)
+      },
+    )
+  })
+}
+
+type ToolReturn = {
+  content: { type: 'text'; text: string }[]
+  details: SubagentOutputToolDetails
+}
+
+function renderSnapshot(snap: StatusSnapshot): ToolReturn {
+  if (snap.status === 'running') {
+    const details: SubagentOutputToolDetails = {
+      ok: true,
+      status: 'running',
+      taskId: snap.taskId,
+      subagent: snap.subagentName,
+      startedAt: snap.startedAt,
+      elapsedMs: snap.elapsedMs,
+      eventsCount: snap.eventsCount,
+      eventsRecent: snap.eventsRecent,
+      lastActivity: snap.lastActivity,
+      statusSummary: snap.statusSummary,
+    }
+    return {
+      content: [{ type: 'text' as const, text: snap.statusSummary }],
+      details,
+    }
+  }
+  if (snap.status === 'completed') {
+    const finalMessage = snap.completion?.finalMessage
+    const details: SubagentOutputToolDetails = {
+      ok: true,
+      status: 'completed',
+      taskId: snap.taskId,
+      subagent: snap.subagentName,
+      durationMs: snap.completion?.durationMs ?? snap.elapsedMs,
+      ...(finalMessage !== undefined ? { finalMessage } : {}),
+    }
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: finalMessage ?? `${snap.subagentName} completed in ${details.durationMs}ms with no final message.`,
+        },
+      ],
+      details,
+    }
+  }
+  const error = snap.completion?.error ?? 'unknown error'
+  const details: SubagentOutputToolDetails = {
+    ok: true,
+    status: 'failed',
+    taskId: snap.taskId,
+    subagent: snap.subagentName,
+    durationMs: snap.completion?.durationMs ?? snap.elapsedMs,
+    error,
+  }
+  return {
+    content: [{ type: 'text' as const, text: `${snap.subagentName} failed after ${details.durationMs}ms: ${error}` }],
+    details,
+  }
+}
+
+function errorResult(message: string): ToolReturn {
+  const details: SubagentOutputToolDetails = { ok: false, error: message }
+  return {
+    content: [{ type: 'text', text: message }],
+    details,
+  }
+}

--- a/src/permissions/builtins.test.ts
+++ b/src/permissions/builtins.test.ts
@@ -21,12 +21,21 @@ describe('built-in role contract', () => {
     expect([...BUILTIN_ROLES.owner.permissions]).not.toContain('security.bypass.high')
   })
 
-  test('trusted has empty default match and ONLY core perms + bypass.low (no per-guard medium/high grants)', () => {
+  test('owner carries all three subagent permissions (spawn / cancel / output)', () => {
+    expect(BUILTIN_ROLES.owner.permissions).toContain('subagent.spawn')
+    expect(BUILTIN_ROLES.owner.permissions).toContain('subagent.cancel')
+    expect(BUILTIN_ROLES.owner.permissions).toContain('subagent.output')
+  })
+
+  test('trusted has empty default match and core perms + bypass.low + subagent perms (no per-guard medium/high grants)', () => {
     expect(BUILTIN_ROLES.trusted.match).toEqual([])
     expect([...BUILTIN_ROLES.trusted.permissions].sort()).toEqual([
       'channel.respond',
       'cron.schedule',
       'security.bypass.low',
+      'subagent.cancel',
+      'subagent.output',
+      'subagent.spawn',
     ])
   })
 
@@ -40,9 +49,19 @@ describe('built-in role contract', () => {
     expect([...BUILTIN_ROLES.trusted.permissions]).not.toContain('security.bypass.secretExfilBash')
   })
 
-  test('member has empty default match and only channel.respond', () => {
+  test('member has empty default match and channel.respond + subagent perms (agent-side proactive fan-out)', () => {
     expect(BUILTIN_ROLES.member.match).toEqual([])
-    expect([...BUILTIN_ROLES.member.permissions]).toEqual(['channel.respond'])
+    expect([...BUILTIN_ROLES.member.permissions].sort()).toEqual([
+      'channel.respond',
+      'subagent.cancel',
+      'subagent.output',
+      'subagent.spawn',
+    ])
+  })
+
+  test('member does NOT carry security bypass (subagent.spawn does not imply write capability — explorer/operator gate write-capable subagents via subagent.spawn.operator)', () => {
+    expect([...BUILTIN_ROLES.member.permissions]).not.toContain('security.bypass.low')
+    expect([...BUILTIN_ROLES.member.permissions]).not.toContain('security.bypass.medium')
   })
 
   test('guest has no match and no permissions', () => {

--- a/src/permissions/builtins.ts
+++ b/src/permissions/builtins.ts
@@ -12,6 +12,9 @@ export const CORE_PERMISSIONS = {
   channelRespond: 'channel.respond',
   cronSchedule: 'cron.schedule',
   cronModify: 'cron.modify',
+  subagentSpawn: 'subagent.spawn',
+  subagentCancel: 'subagent.cancel',
+  subagentOutput: 'subagent.output',
 } as const
 
 // Sentinel that `expandOwnerWildcard` swaps for the concrete union of
@@ -47,6 +50,9 @@ export const BUILTIN_ROLES: Readonly<Record<BuiltinRoleName, BuiltinRoleSpec>> =
       CORE_PERMISSIONS.channelRespond,
       CORE_PERMISSIONS.cronSchedule,
       CORE_PERMISSIONS.cronModify,
+      CORE_PERMISSIONS.subagentSpawn,
+      CORE_PERMISSIONS.subagentCancel,
+      CORE_PERMISSIONS.subagentOutput,
       'security.bypass.low',
       'security.bypass.medium',
       OWNER_SECURITY_WILDCARD,
@@ -54,11 +60,23 @@ export const BUILTIN_ROLES: Readonly<Record<BuiltinRoleName, BuiltinRoleSpec>> =
   },
   trusted: {
     match: [],
-    permissions: [CORE_PERMISSIONS.channelRespond, CORE_PERMISSIONS.cronSchedule, 'security.bypass.low'],
+    permissions: [
+      CORE_PERMISSIONS.channelRespond,
+      CORE_PERMISSIONS.cronSchedule,
+      CORE_PERMISSIONS.subagentSpawn,
+      CORE_PERMISSIONS.subagentCancel,
+      CORE_PERMISSIONS.subagentOutput,
+      'security.bypass.low',
+    ],
   },
   member: {
     match: [],
-    permissions: [CORE_PERMISSIONS.channelRespond],
+    permissions: [
+      CORE_PERMISSIONS.channelRespond,
+      CORE_PERMISSIONS.subagentSpawn,
+      CORE_PERMISSIONS.subagentCancel,
+      CORE_PERMISSIONS.subagentOutput,
+    ],
   },
   guest: {
     match: [],

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -69,6 +69,22 @@ export type Subagent<P = unknown> = {
   // bounds the blast radius without changing per-call semantics for healthy
   // runs.
   toolResultBudget?: ToolResultBudget
+  // Whether the LLM-driven main agent can invoke this subagent via the
+  // `spawn_subagent` tool.
+  // - 'internal' (default): only invokable via cron jobs, plugin lifecycle
+  //   hooks, or programmatic `ctx.spawnSubagent` calls. The main agent does
+  //   NOT see this subagent in its tool surface. Existing bundled subagents
+  //   (memory-logger, dreaming, backup, backup-message, backup-diagnose)
+  //   omit this field and therefore remain internal — they are infrastructure,
+  //   not orchestration targets, and accidentally exposing a write-capable
+  //   one (e.g. `backup` mutates git history) to agent-initiated invocation
+  //   would be a real footgun.
+  // - 'public': exposed to the main agent via `spawn_subagent`. The agent
+  //   can decide mid-conversation to invoke this subagent. Reserved for
+  //   subagents explicitly designed as orchestration targets (e.g. explorer,
+  //   operator). The default is 'internal' specifically so adding a new
+  //   bundled subagent never accidentally widens the agent-facing surface.
+  visibility?: 'public' | 'internal'
 }
 
 // Cron job map keys are local; the runtime prefixes with `__plugin_<plugin-name>_`

--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -1,6 +1,8 @@
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession as defaultCreateSession } from '@/agent'
+import type { LiveSubagentRegistry } from '@/agent/live-subagents'
+import type { CreateSessionForSubagent, SubagentRegistry } from '@/agent/subagents'
 import { capJsonlFileInPlace } from '@/bundled-plugins/tool-result-cap/cap-jsonl'
 import type { CapOptions } from '@/bundled-plugins/tool-result-cap/cap-result'
 import type { CreateSessionForChannel, ChannelRouter } from '@/channels'
@@ -48,6 +50,18 @@ export type BuildChannelSessionFactoryDeps = {
   // can assert exactly which CreateSessionOptions the factory builds without
   // needing a live LLM, plugin runtime, or session manager on disk.
   createSession?: typeof defaultCreateSession
+  // Subagent orchestration plumbing. All three (or none) are forwarded to
+  // createSession so the TUI/channel session exposes spawn_subagent,
+  // subagent_output, subagent_cancel. Subagent sessions never receive these
+  // — that branch is gated by pluginSubagent in createSessionWithDispose.
+  //
+  // `getCreateSessionForSubagent` is late-bound to break the construction
+  // cycle: channelManager owns the channel-session factory, which needs
+  // createSessionForSubagent, which needs channelManager.router. Same shape
+  // as `getChannelRouter` above.
+  liveSubagentRegistry?: LiveSubagentRegistry
+  subagentRegistry?: SubagentRegistry
+  getCreateSessionForSubagent?: () => CreateSessionForSubagent
 }
 
 // Tight basename validation so a tampered or corrupt channels/sessions.json
@@ -108,6 +122,11 @@ export function buildChannelSessionFactory(deps: BuildChannelSessionFactoryDeps)
       ...(deps.containerName !== undefined ? { containerName: deps.containerName } : {}),
       ...(deps.runtimeVersion !== undefined ? { runtimeVersion: deps.runtimeVersion } : {}),
       ...(deps.permissions !== undefined ? { permissions: deps.permissions } : {}),
+      ...(deps.liveSubagentRegistry !== undefined ? { liveSubagentRegistry: deps.liveSubagentRegistry } : {}),
+      ...(deps.subagentRegistry !== undefined ? { subagentRegistry: deps.subagentRegistry } : {}),
+      ...(deps.getCreateSessionForSubagent !== undefined
+        ? { createSessionForSubagent: deps.getCreateSessionForSubagent() }
+        : {}),
     })
 
     return {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -1,6 +1,7 @@
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession, createSessionWithDispose } from '@/agent'
+import { LiveSubagentRegistry } from '@/agent/live-subagents'
 import type { SessionOrigin } from '@/agent/session-origin'
 import {
   createSubagentConsumer,
@@ -176,6 +177,8 @@ export async function startAgent({
     },
   })
 
+  const liveSubagentRegistry = new LiveSubagentRegistry()
+
   const channelManager = createChannelManagerFor({
     agentDir: cwd,
     channelsConfigRef: () => getConfig().channels,
@@ -191,6 +194,9 @@ export async function startAgent({
       getChannelRouter: () => channelManager.router,
       rehydrateCapOptions: resolveCapOptionsFromConfig(pluginConfigsByName['tool-result-cap']),
       permissions: pluginsLoaded.permissions,
+      liveSubagentRegistry,
+      subagentRegistry: pluginRuntime.get().subagents,
+      getCreateSessionForSubagent: () => createSessionForSubagent,
       ...containerNameOpt,
       ...runtimeVersionOpt,
     }),
@@ -347,6 +353,9 @@ export async function startAgent({
               },
             }
           : {}),
+        liveSubagentRegistry,
+        subagentRegistry: pluginRuntime.get().subagents,
+        createSessionForSubagent,
         ...containerNameOpt,
         ...runtimeVersionOpt,
       })

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -789,6 +789,124 @@ describe('createServer with stream — input queueing bugfix', () => {
   })
 })
 
+describe('createServer subagent.completed broadcast → session reminder injection', () => {
+  test('matching parentSessionId enqueues a <system-reminder> prompt', async () => {
+    const session = createFakeSession()
+    const stream = createStream()
+    const { url } = await startWithSession(session, { stream })
+    const { ws, waitFor } = await connect(url)
+    const connected = await waitFor((m) => m.type === 'connected')
+    if (connected.type !== 'connected') throw new Error('unreachable')
+    const sessionId = connected.sessionId
+
+    stream.publish({
+      target: { kind: 'broadcast' },
+      payload: {
+        kind: 'subagent.completed',
+        taskId: 'bg_xyz',
+        subagent: 'explorer',
+        parentSessionId: sessionId,
+        ok: true,
+        durationMs: 5_000,
+      },
+    })
+
+    await waitForState(() => session.promptCalls.length > 0)
+    const text = session.promptCalls[0] ?? ''
+    expect(text).toContain('<system-reminder>')
+    expect(text).toContain('explorer')
+    expect(text).toContain('bg_xyz')
+    expect(text).toContain('completed')
+    expect(text).toContain('subagent_output')
+
+    session.resolvePrompt()
+    ws.close()
+  })
+
+  test('non-matching parentSessionId is ignored (no reminder enqueued)', async () => {
+    const session = createFakeSession()
+    const stream = createStream()
+    const { url } = await startWithSession(session, { stream })
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    stream.publish({
+      target: { kind: 'broadcast' },
+      payload: {
+        kind: 'subagent.completed',
+        taskId: 'bg_other',
+        subagent: 'explorer',
+        parentSessionId: 'someone-else',
+        ok: true,
+        durationMs: 100,
+      },
+    })
+
+    await expectStable(() => session.promptCalls.length > 0, {
+      durationMs: 20,
+      description: 'foreign completion reminder',
+    })
+    expect(session.promptCalls).toEqual([])
+
+    ws.close()
+  })
+
+  test('failed subagent reminder includes error message and FAILED marker', async () => {
+    const session = createFakeSession()
+    const stream = createStream()
+    const { url } = await startWithSession(session, { stream })
+    const { ws, waitFor } = await connect(url)
+    const connected = await waitFor((m) => m.type === 'connected')
+    if (connected.type !== 'connected') throw new Error('unreachable')
+
+    stream.publish({
+      target: { kind: 'broadcast' },
+      payload: {
+        kind: 'subagent.completed',
+        taskId: 'bg_err',
+        subagent: 'explorer',
+        parentSessionId: connected.sessionId,
+        ok: false,
+        durationMs: 1_500,
+        error: 'provider rate limit',
+      },
+    })
+
+    await waitForState(() => session.promptCalls.length > 0)
+    const text = session.promptCalls[0] ?? ''
+    expect(text).toContain('FAILED')
+    expect(text).toContain('provider rate limit')
+
+    session.resolvePrompt()
+    ws.close()
+  })
+
+  test('non subagent.completed broadcasts do not enqueue prompts', async () => {
+    const session = createFakeSession()
+    const stream = createStream()
+    const { url } = await startWithSession(session, { stream })
+    const { ws, waitFor } = await connect(url)
+    const connected = await waitFor((m) => m.type === 'connected')
+    if (connected.type !== 'connected') throw new Error('unreachable')
+
+    stream.publish({
+      target: { kind: 'broadcast' },
+      payload: {
+        kind: 'something-else',
+        parentSessionId: connected.sessionId,
+      },
+    })
+
+    await expectStable(() => session.promptCalls.length > 0, {
+      durationMs: 20,
+      description: 'unrelated broadcast',
+    })
+    expect(session.promptCalls).toEqual([])
+
+    ws.close()
+  })
+})
+
 describe('createServer fires session.idle hook after every prompt completion', () => {
   function stubSessionFactory(opts: { transcriptPath?: string }): SessionFactory {
     return {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -392,6 +392,7 @@ export function createServer({
               )
 
               state.unsubBroadcast = stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => {
+                routeSubagentCompletionReminder(state, msg, stream)
                 const payload: ServerMessage = {
                   type: 'notification',
                   payload: msg.payload,
@@ -710,6 +711,71 @@ function forwardAssistantError(ws: Ws, message: unknown, logger: ServerLogger, s
   if (detected === null) return
   logger.error(`[server] ${sessionFileId}: LLM call failed: ${detected.message}`)
   send(ws, { type: 'error', message: detected.message })
+}
+
+function routeSubagentCompletionReminder(state: SessionState, msg: StreamMessage, stream: Stream): void {
+  const payload = msg.payload
+  if (payload === null || typeof payload !== 'object') return
+  const p = payload as {
+    kind?: unknown
+    taskId?: unknown
+    subagent?: unknown
+    parentSessionId?: unknown
+    ok?: unknown
+    durationMs?: unknown
+    error?: unknown
+  }
+  if (p.kind !== 'subagent.completed') return
+  if (typeof p.parentSessionId !== 'string' || p.parentSessionId !== state.sessionFileId) return
+
+  const subagent = typeof p.subagent === 'string' ? p.subagent : 'subagent'
+  const taskId = typeof p.taskId === 'string' ? p.taskId : '<unknown>'
+  const ok = p.ok === true
+  const durationMs = typeof p.durationMs === 'number' ? p.durationMs : 0
+  const error = typeof p.error === 'string' ? p.error : undefined
+
+  const idle = state.drainQueue.length === 0 && !state.draining
+  const delivery = idle ? 'interrupt' : 'queue'
+  const text = renderCompletionReminder({ subagent, taskId, ok, durationMs, error })
+  stream.publish({
+    target: { kind: 'session', sessionId: state.sessionFileId },
+    payload: { kind: 'prompt', text, delivery },
+    meta: { source: 'subagent-completion' },
+  })
+}
+
+function renderCompletionReminder(args: {
+  subagent: string
+  taskId: string
+  ok: boolean
+  durationMs: number
+  error?: string
+}): string {
+  const durationStr = formatReminderDuration(args.durationMs)
+  if (args.ok) {
+    return (
+      `<system-reminder>\n` +
+      `Subagent \`${args.subagent}\` (${args.taskId}) completed in ${durationStr}. ` +
+      `Use subagent_output to fetch the result.\n` +
+      `</system-reminder>`
+    )
+  }
+  const err = args.error ?? 'unknown error'
+  return (
+    `<system-reminder>\n` +
+    `Subagent \`${args.subagent}\` (${args.taskId}) FAILED after ${durationStr}: ${err}. ` +
+    `Use subagent_output to inspect.\n` +
+    `</system-reminder>`
+  )
+}
+
+function formatReminderDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const totalSec = Math.floor(ms / 1000)
+  if (totalSec < 60) return `${totalSec}s`
+  const min = Math.floor(totalSec / 60)
+  const sec = totalSec % 60
+  return `${min}m${sec}s`
 }
 
 function enqueuePrompt(


### PR DESCRIPTION
## Why

The runtime has a capable subagent engine — `invokeSubagent`, cron consumer, plugin `ctx.spawnSubagent` — but no way for the **main agent** to decide mid-conversation to hand off work. Every delegation was either pre-wired (a cron schedule) or scripted by a plugin. The result: the agent cannot parallelize a research task, cannot offload a long-running job to keep its own context window clean, and cannot compose subagents dynamically based on what it learns in conversation.

This PR adds the orchestration layer that makes agent-initiated delegation possible.

## What ships

### Three new agent-facing tools

| Tool | Purpose |
|---|---|
| `spawn_subagent` | Start a public subagent synchronously (blocks until done) or in background (returns `task_id` immediately). |
| `subagent_output` | Fetch result of a completed background job, or get a human-readable `status_summary` of a running one. |
| `subagent_cancel` | Abort a running background subagent. Idempotent on already-finished tasks. |

### `LiveSubagentRegistry` — `src/agent/live-subagents.ts`

An in-memory registry that holds `AgentSession` references for every subagent the main agent has spawned. Per entry:

- Coarsened progress events in a bounded ring of 100: `tool_execution_end` becomes a tool-call event; `message_end` becomes a 200-char message preview. Coarsening keeps `subagent_output` fast and avoids embedding full assistant turns in tool results.
- Status tracking: `'running' | 'completed' | 'failed'` and a `SubagentCompletion` record (`ok`, `finalMessage`, `error`, `durationMs`) on finish.
- `abort()` and `awaitCompletion()` handles.

### `startSubagent` primitive — `src/agent/subagents.ts`

`invokeSubagent` is now a thin wrapper around `startSubagent`, which returns `{ handle, completion }`. Callers that only need `Promise<void>` — cron consumer, plugin hooks, command-runner, memory plugin, backup plugin — keep their existing call sites unchanged. The new tools use `startSubagent` directly to retain the abort handle and hold the task in the registry.

### `visibility` field on `Subagent<P>` — `src/plugin/types.ts`

```ts
visibility?: 'public' | 'internal'  // default: 'internal'
```

`'internal'` subagents are invisible to `spawn_subagent`. They remain reachable only via cron, plugin lifecycle hooks, and `ctx.spawnSubagent`. All five existing bundled subagents — `memory-logger`, `dreaming`, `backup`, `backup-message`, `backup-diagnose` — omit this field and stay internal. This is intentional: they are infrastructure jobs, not orchestration targets. `backup` in particular mutates git history; exposing it to agent-initiated calls would be a footgun.

`'public'` is reserved for subagents designed as orchestration targets. No bundled subagents declare it yet — that is PR 2 (`explorer`) and PR 3 (`operator`).

### New permissions

Three new permission strings, granted to `owner`, `trusted`, and `member`:

| Permission | What it gates |
|---|---|
| `subagent.spawn` | Calling `spawn_subagent`. |
| `subagent.output` | Calling `subagent_output`. |
| `subagent.cancel` | Calling `subagent_cancel`. |

Per-subagent permission fallback: `spawn_subagent` checks `subagent.spawn.<name>` first, then falls back to `subagent.spawn`. This is the hook PR 3 will use to restrict the write-capable `operator` subagent to `owner`-only by granting `subagent.spawn.operator` to `owner` only.

### System prompt — `src/agent/system-prompt.ts`

`DEFAULT_SYSTEM_PROMPT` gains a `## Subagent orchestration` section documenting:

- **Mode A (research fan-out)**: spawn multiple `explorer` subagents in parallel to gather information, then synthesize results in the parent.
- **Mode B (delegate-and-converse)**: hand off a long-running task to `operator`, surfacing intermediate progress via `subagent_output`, then deliver the result to the user.
- Status-query pattern: how to check on a running subagent without blocking.

`SLIM_SYSTEM_PROMPT` — used for cron and subagent sessions — is **unchanged**. Orchestration is operator-facing guidance; cron jobs and subagents don't spawn subagents.

### Completion broadcast routing — `src/server/index.ts`

When a background subagent finishes, the server injects a `<system-reminder>` into the parent session:

- `delivery: 'queue'` — when the parent has pending turns queued. The reminder lands in order.
- `delivery: 'interrupt'` — when the parent is idle. This triggers proactive speak: the agent delivers the result without waiting for the user to ask.

## Why the mechanism ships dormant

No bundled subagents are public in this PR. `spawn_subagent` will reject any call with a precise error that does not leak internal subagent names. This is deliberate.

**Smaller blast radius per review.** The orchestration mechanism is non-trivial: new tool surface, new permission strings, new registry, new server routing. Reviewing it decoupled from the first concrete subagent — which has its own design decisions around model choice, prompt, and tool permissions — keeps each PR focused. A bug in the mechanism is catchable here, before any subagent is publicly reachable.

**Mechanism is independently testable.** The 70 tests covering this PR (see below) exercise the full tool lifecycle, permission gates, registry behavior, and completion routing — all without needing a real subagent payload. Adding `explorer` in PR 2 exercises the mechanism on real inputs; the mechanism itself is already verified here.

**Staged rollout.** Shipping dormant also means operators can deploy this version without worrying about unintended subagent invocations. The capability activates when an operator deploys PR 2.

## Architectural invariants preserved

**Subagents cannot spawn subagents.** Two defense layers:

1. `spawn_subagent` is omitted from `customSystemTools` when `pluginSubagent` is set — the same gate that already empties the tool list for subagent sessions.
2. Even if a subagent somehow called the tool, the permission check would fail: subagent sessions inherit `spawnedByRole`, and `subagent.spawn` requires at least `member`.

**Existing `invokeSubagent` callers are unchanged.** The refactor to `startSubagent` is a pure extraction — `invokeSubagent` still returns `Promise<void>` and all existing call sites compile and pass without modification.

**Slim prompt unchanged.** Cron and subagent sessions see no orchestration guidance. The token budget for unattended sessions is unaffected.

## Test coverage

**4404 pass / 0 fail** across 256 files.

| Suite | New tests | What they verify |
|---|---|---|
| `spawn-subagent.test.ts` | 13 | Sync/background dispatch, internal-subagent rejection (without leaking names), permission gates, error propagation |
| `subagent-output.test.ts` | 10 | Status summary rendering, completion hydration, unknown-task error |
| `subagent-cancel.test.ts` | 5 | Abort delivery, idempotency on finished tasks |
| `live-subagents.test.ts` | 26 | Registry lifecycle, coarsening correctness, ring-buffer bound, status transitions |
| `subagents.test.ts` extended | 7 | `startSubagent` returns `{ handle, completion }`, existing `invokeSubagent` contract unchanged |
| `server/index.test.ts` extended | 4 | Completion broadcast: `queue` vs `interrupt` delivery routing to parent |
| Orchestration gate | 5 | `spawn_subagent` absent from subagent sessions; permission denial paths |
| `builtins.test.ts` extended | varies | `subagent.*` permissions on built-in roles |

All 4331 pre-existing tests still pass.

## Pre-merge gates

- `bun run typecheck` — clean (0 errors)
- `bun run lint` — 0 errors, 18 pre-existing warnings (unchanged)
- `bun run format:check` — clean
- `bun run debug:prompt --origin tui` — includes `## Subagent orchestration` ✅
- `bun run debug:prompt --origin subagent` — does NOT include it ✅
- Bundled memory/backup plugins have no `visibility` field added ✅
- `spawn_subagent` rejects internal subagents; error message does not leak internal names ✅

## Follow-up roadmap

| PR | Adds | Notes |
|---|---|---|
| **PR 2** | Bundled `explorer` subagent | Fast model, read-only tool surface, designed for Mode A research fan-out. First public subagent — activates the dormant mechanism. |
| **PR 3** | Bundled `operator` subagent | Default model, write-capable, Mode B delegate-and-converse. Restricts to `owner`-only via `subagent.spawn.operator` per-subagent permission — wired in this PR. Adds idle-proactive completion delivery improvements. |

## Diff summary

20 files, +2680 / -6 lines.

```
src/agent/index.ts                      +67
src/agent/live-subagents.ts             +215  (new)
src/agent/subagents.ts                  +115
src/agent/system-prompt.ts              +34
src/agent/tools/spawn-subagent.ts       +279  (new)
src/agent/tools/subagent-cancel.ts      +96   (new)
src/agent/tools/subagent-output.ts      +192  (new)
src/permissions/builtins.ts             +22
src/plugin/types.ts                     +16
src/run/channel-session-factory.ts      +19
src/run/index.ts                        +9
src/server/index.ts                     +66
src/agent/index.test.ts                 +79
src/agent/live-subagents.test.ts        +293  (new)
src/agent/subagents.test.ts             +253
src/agent/tools/spawn-subagent.test.ts  +416  (new)
src/agent/tools/subagent-cancel.test.ts +116  (new)
src/agent/tools/subagent-output.test.ts +256  (new)
src/permissions/builtins.test.ts        +25
src/server/index.test.ts                +118
```