### PR TITLE
explorer: ship bundled read-only codebase-search subagent (stacked on #273)

### DIFF
--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -60,6 +60,8 @@ There are two delegation modes. Pick deliberately.
 
 When you need information to answer the user and the search is broad, fire 2-5 subagents in parallel with \`run_in_background: true\` covering different angles. End your response after spawning. The system will deliver a \`<system-reminder>\` for each completion; gather results then answer the user. Do NOT poll \`subagent_output\` in a tight loop.
 
+The bundled \`explorer\` subagent is the right tool for codebase reconnaissance — finding where a pattern is implemented, mapping unfamiliar modules, discovering conventions across directories. It is read-only and runs on a fast/cheap model, so fire liberally. Do NOT ask it to plan, decide, or write code — it finds and reports.
+
 **Mode B — Delegate-and-converse** (the user asked you to DO something long-running)
 
 When the user hands you a task that will take minutes (a multi-step browser session, a long build, a complex external operation), acknowledge in plain language ("Alright, running that in the background — I'll let you know when it's done"), spawn one subagent with \`run_in_background: true\`, then KEEP TALKING. Stay available for follow-ups, related questions, parallel small tasks. When the completion reminder lands, weave the result into your next reply naturally. If the conversation has gone idle, proactively message the user with the result rather than waiting.

--- a/src/bundled-plugins/explorer/explorer.test.ts
+++ b/src/bundled-plugins/explorer/explorer.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test'
+
+import { EXPLORER_SYSTEM_PROMPT, createExplorerSubagent, explorerPayloadSchema } from './explorer'
+
+describe('explorer subagent — load-bearing prompt phrases', () => {
+  test.each(
+    [
+      'READ-ONLY',
+      'STRICTLY PROHIBITED',
+      'no_file_modifications',
+      'parallel',
+      'absolute',
+      '<analysis>',
+      '<results>',
+      '<files>',
+      '<answer>',
+      '<next_steps>',
+      'Completeness over speed',
+      'Spawning further subagents',
+    ].map((phrase) => [phrase] as const),
+  )('prompt contains %s', (phrase) => {
+    // The prompt uses no_file_modifications as the readonly-mode label in some
+    // capitalizations; normalize for an unambiguous substring assertion.
+    const haystack = EXPLORER_SYSTEM_PROMPT.toLowerCase().replace(/\s+/g, '_')
+    expect(haystack).toContain(phrase.toLowerCase().replace(/\s+/g, '_'))
+  })
+
+  test('prompt forbids bash for write operations', () => {
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('mkdir')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('rm')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('git add')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('git commit')
+  })
+
+  test('prompt names the dedicated tools instead of leaving them implicit', () => {
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('find —')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('grep —')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('read —')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('ls —')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('bash — ONLY for')
+  })
+})
+
+describe('explorer subagent declaration', () => {
+  test('is registered as visibility=public so spawn_subagent exposes it', () => {
+    const sub = createExplorerSubagent()
+    expect(sub.visibility).toBe('public')
+  })
+
+  test('uses the fast model profile (cheap and parallelizable for read-only work)', () => {
+    const sub = createExplorerSubagent()
+    expect(sub.profile).toBe('fast')
+  })
+
+  test('tools list contains read/grep/find/ls/bash and NO write/edit', () => {
+    const sub = createExplorerSubagent()
+    const toolNames = (sub.tools ?? []).map((t) => t.__builtinTool)
+    expect(toolNames.sort()).toEqual(['bash', 'find', 'grep', 'ls', 'read'])
+    expect(toolNames).not.toContain('write')
+    expect(toolNames).not.toContain('edit')
+  })
+
+  test('declares a tool-result budget so a runaway subagent cannot exhaust parent context', () => {
+    const sub = createExplorerSubagent()
+    expect(sub.toolResultBudget).toBeDefined()
+    expect(sub.toolResultBudget?.maxTotalBytes).toBeGreaterThan(0)
+  })
+
+  test('inFlightKey returns distinct values for distinct requestId payloads (parallel spawns must not coalesce)', () => {
+    const sub = createExplorerSubagent()
+    const key1 = sub.inFlightKey?.({ requestId: 'bg_a' })
+    const key2 = sub.inFlightKey?.({ requestId: 'bg_b' })
+    expect(key1).toBe('bg_a')
+    expect(key2).toBe('bg_b')
+    expect(key1).not.toBe(key2)
+  })
+
+  test('inFlightKey falls back to a random value when no requestId is provided (no accidental coalescing)', () => {
+    const sub = createExplorerSubagent()
+    const key1 = sub.inFlightKey?.({})
+    const key2 = sub.inFlightKey?.({})
+    expect(key1).not.toBe(key2)
+  })
+})
+
+describe('explorerPayloadSchema', () => {
+  test('accepts a payload with requestId + prompt + description', () => {
+    const result = explorerPayloadSchema.safeParse({
+      requestId: 'bg_t1',
+      prompt: 'find auth handlers',
+      description: 'auth flow',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts a payload with only requestId (spawn-tool minimum)', () => {
+    const result = explorerPayloadSchema.safeParse({ requestId: 'bg_t1' })
+    expect(result.success).toBe(true)
+  })
+
+  test('passes through unknown fields (forward-compat with future spawn-tool params)', () => {
+    const result = explorerPayloadSchema.safeParse({ requestId: 'bg_t1', futureField: 42 })
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/bundled-plugins/explorer/explorer.ts
+++ b/src/bundled-plugins/explorer/explorer.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod'
+
+import { bashTool, findTool, grepTool, lsTool, readTool, type Subagent } from '@/plugin'
+
+export const EXPLORER_SYSTEM_PROMPT = `You are a codebase search specialist running inside TypeClaw. Your job: find files and code, return actionable results.
+
+=== READ-ONLY — NO FILE MODIFICATIONS ===
+You are STRICTLY PROHIBITED from:
+- Creating, modifying, or deleting files
+- Using bash for: mkdir, touch, rm, cp, mv, git add, git commit, npm install, pip install, or any write operation
+- Starting long-running background processes
+- Writing to MEMORY.md, sessions/, workspace/, or any other runtime-managed path
+- Spawning further subagents — you are at the end of the delegation chain
+
+Your role is EXCLUSIVELY to search and analyze existing code.
+
+## Tool selection
+
+Use the right tool for the job — do NOT default to bash:
+- find — file patterns by name/extension
+- grep — text/regex search in file contents
+- read — read specific files once you know the path
+- ls — list a directory's immediate contents for structural discovery
+- bash — ONLY for read-only git commands (git log, git blame, git diff, git status) when you need history
+
+Launch 3+ tools in parallel whenever you can. Cross-validate findings across multiple tools — a grep hit confirmed by reading the file is stronger than either alone.
+
+## Process
+
+Before searching, analyze intent in an <analysis> block:
+
+<analysis>
+**Literal Request**: [what they literally asked]
+**Actual Need**: [what they're really trying to accomplish]
+**Success Looks Like**: [what result lets them proceed immediately]
+</analysis>
+
+End every response with this exact structure:
+
+<results>
+<files>
+- /absolute/path/to/file.ts — [why this file is relevant]
+</files>
+<answer>
+[Direct answer to the actual need, not just a file list. If they asked "where is auth?", explain the auth flow you found.]
+</answer>
+<next_steps>
+[What the caller should do next, or "Ready to proceed."]
+</next_steps>
+</results>
+
+## Rules
+
+- Every path MUST be absolute (start with /).
+- Find ALL relevant matches, not just the first. Completeness over speed.
+- Do NOT diagnose, plan, or make architectural decisions — that's the caller's job. You find and report.
+- If you cannot find what was asked, say so explicitly with what you DID find and what scopes you searched.`
+
+export const explorerPayloadSchema = z
+  .object({
+    requestId: z.string().optional(),
+    prompt: z.string().optional(),
+    description: z.string().optional(),
+  })
+  .passthrough()
+
+export type ExplorerPayload = z.infer<typeof explorerPayloadSchema>
+
+export function createExplorerSubagent(): Subagent<ExplorerPayload> {
+  return {
+    systemPrompt: EXPLORER_SYSTEM_PROMPT,
+    profile: 'fast',
+    tools: [readTool, grepTool, findTool, lsTool, bashTool],
+    payloadSchema: explorerPayloadSchema,
+    visibility: 'public',
+    inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    toolResultBudget: {
+      maxTotalBytes: 256_000,
+      toolNames: ['read', 'grep', 'find', 'ls', 'bash'],
+    },
+  }
+}

--- a/src/bundled-plugins/explorer/index.test.ts
+++ b/src/bundled-plugins/explorer/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+
+import { loadPlugins, type ResolvedPlugin } from '@/plugin'
+
+import explorerPlugin from './index'
+
+const RESOLVED: ResolvedPlugin = {
+  name: 'explorer',
+  version: undefined,
+  source: '<bundled>',
+  defined: explorerPlugin,
+}
+
+describe('explorer plugin', () => {
+  test('contributes exactly one public subagent named "explorer"', async () => {
+    const { registry } = await loadPlugins({
+      entries: [],
+      bundled: [RESOLVED],
+      agentDir: '/agent',
+      configsByName: {},
+    })
+
+    expect(registry.subagents.map((s) => s.subagentName).sort()).toEqual(['explorer'])
+    const explorer = registry.subagents.find((s) => s.subagentName === 'explorer')
+    if (explorer === undefined) throw new Error('explorer subagent missing')
+    expect(explorer.subagent.visibility).toBe('public')
+  })
+
+  test('contributes no tools / cron jobs / hooks / skills / commands / doctor checks', async () => {
+    const { registry, hooks } = await loadPlugins({
+      entries: [],
+      bundled: [RESOLVED],
+      agentDir: '/agent',
+      configsByName: {},
+    })
+
+    expect(registry.tools).toHaveLength(0)
+    expect(registry.skills).toHaveLength(0)
+    expect(registry.skillsDirs).toHaveLength(0)
+    expect(registry.commands).toEqual([])
+    expect(registry.doctorChecks).toHaveLength(0)
+    expect(hooks.count('session.idle')).toBe(0)
+    expect(hooks.count('session.end')).toBe(0)
+    expect(hooks.count('tool.before')).toBe(0)
+    expect(hooks.count('tool.after')).toBe(0)
+  })
+})

--- a/src/bundled-plugins/explorer/index.ts
+++ b/src/bundled-plugins/explorer/index.ts
@@ -1,0 +1,11 @@
+import { definePlugin } from '@/plugin'
+
+import { createExplorerSubagent } from './explorer'
+
+export default definePlugin({
+  plugin: async () => ({
+    subagents: {
+      explorer: createExplorerSubagent(),
+    },
+  }),
+})

--- a/src/run/bundled-plugins.test.ts
+++ b/src/run/bundled-plugins.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { BUNDLED_PLUGINS } from './bundled-plugins'
 
 describe('BUNDLED_PLUGINS', () => {
-  test('contains exactly the six expected plugins in hook-precedence order', () => {
+  test('contains exactly the expected plugins in hook-precedence order', () => {
     // Order is load-bearing: `security` must run before `guard` so its
     // `tool.before` hook gets first refusal on overlapping policy.
     // `tool-result-cap` must run before `guard` so guard's `tool.after`
@@ -11,8 +11,10 @@ describe('BUNDLED_PLUGINS', () => {
     // make the cap clobber guard's advice text). `memory` must run before
     // `backup` because dreaming commits memory snapshots and any future
     // overlap on git lock contention should be resolved in memory's favor
-    // (memory commits are smaller and more frequent). See the header
-    // comment in bundled-plugins.ts.
+    // (memory commits are smaller and more frequent). `explorer` lands at
+    // the end: it has no hooks and no cron, so its position is irrelevant
+    // for hook precedence — it's grouped with `agent-browser` (also no
+    // hooks) at the tail. See the header comment in bundled-plugins.ts.
     expect(BUNDLED_PLUGINS.map((p) => p.name)).toEqual([
       'security',
       'tool-result-cap',
@@ -20,6 +22,7 @@ describe('BUNDLED_PLUGINS', () => {
       'memory',
       'backup',
       'agent-browser',
+      'explorer',
     ])
   })
 })

--- a/src/run/bundled-plugins.ts
+++ b/src/run/bundled-plugins.ts
@@ -1,5 +1,6 @@
 import agentBrowserPlugin from '@/bundled-plugins/agent-browser'
 import backupPlugin from '@/bundled-plugins/backup'
+import explorerPlugin from '@/bundled-plugins/explorer'
 import guardPlugin from '@/bundled-plugins/guard'
 import memoryPlugin from '@/bundled-plugins/memory'
 import securityPlugin from '@/bundled-plugins/security'
@@ -36,4 +37,5 @@ export const BUNDLED_PLUGINS: ResolvedPlugin[] = [
   { name: 'memory', version: undefined, source: '<bundled>', defined: memoryPlugin },
   { name: 'backup', version: undefined, source: '<bundled>', defined: backupPlugin },
   { name: 'agent-browser', version: undefined, source: '<bundled>', defined: agentBrowserPlugin },
+  { name: 'explorer', version: undefined, source: '<bundled>', defined: explorerPlugin },
 ]


### PR DESCRIPTION
## Stack context

This PR is stacked on #273 (`feat/subagent-orchestration-core` → `feat/subagent-explorer`). Merge #273 first, or review in isolation against the base branch — all the mechanism this PR exercises ships in #273.

**PR 1** (#273) — orchestration mechanism: `spawn_subagent` / `subagent_output` / `subagent_cancel`, `LiveSubagentRegistry`, `visibility` field, permission strings, completion broadcast routing, system prompt section.
**PR 2** (this) — first public subagent: `explorer`. Activates the dormant mechanism.
**PR 3** (planned) — `operator` subagent (default model, write-capable, `owner`-only, Mode B).

## Why

#273 ships a complete orchestration mechanism but no public subagents — `spawn_subagent` rejects every call because nothing has `visibility: 'public'`. This PR makes the mechanism usable by landing the first public subagent: `explorer`.

`explorer` is the **Mode A** half of the orchestration story — fast, read-only, disposable. The main agent fans out 2–5 explorer instances in parallel to gather codebase information simultaneously, then synthesizes the results itself. This pattern keeps the main context window clean of exploratory noise and finishes multi-angle searches in the time it would take to do one sequentially.

## What ships

### `src/bundled-plugins/explorer/explorer.ts`

The `Subagent` declaration:

- `visibility: 'public'` — the first and only bundled subagent with this value. All five existing bundled subagents (`memory-logger`, `dreaming`, `backup`, `backup-message`, `backup-diagnose`) stay `'internal'`.
- `profile: 'fast'` — cheap, fast model. Read-only work is parallelizable and disposable; there is no reason to use the default model.
- `tools: [readTool, grepTool, findTool, lsTool, bashTool]` — **no `writeTool`, no `editTool`**. Bash is present but the system prompt prohibits every write-shape command.
- `inFlightKey: (payload) => payload.requestId ?? <random>` — parallel spawns get distinct keys so they run concurrently with no coalescing. An empty-payload spawn also gets a distinct key by design.
- `toolResultBudget: { maxTotalBytes: 256_000, toolNames: [...] }` — defensive ceiling against runaway grep output.
- `EXPLORER_SYSTEM_PROMPT` — strict read-only directives:
  - `READ-ONLY` and `STRICTLY PROHIBITED` write operations named explicitly.
  - Forbids spawning further subagents.
  - Mandates absolute paths.
  - Mandates parallel tool calls.
  - Mandates structured output: `<analysis>` / `<results>` / `<files>` / `<answer>` / `<next_steps>`.
  - Tool-selection guidance: use `read`, `grep`, `find`, `ls` directly; use `bash` ONLY for read-only git commands. This directly addresses the failure mode in `anthropics/claude-code#34992` where the model defaults to bash for everything.
  - Job framing: "find and report, not diagnose and decide."
  - "Completeness over speed."

### `src/bundled-plugins/explorer/index.ts`

Minimal `definePlugin` wrapper. No config, no cron, no hooks, no tools, no skills, no doctor checks, no commands — solely subagent registration.

### `src/run/bundled-plugins.ts`

`explorer` registered at the tail of `BUNDLED_PLUGINS`, after `agent-browser`. Position is irrelevant for hook precedence (explorer has no hooks); the deterministic order keeps the snapshot test in place.

### `src/agent/system-prompt.ts`

Mode A guidance now names `explorer` explicitly and restates the find-and-report boundary inline — the calling agent does not see the subagent's own system prompt, so the guidance must be restated in the orchestration section.

## What this PR is not

- **Not a write-capable subagent.** That is PR 3 (`operator`), which will carry `writeTool` + `editTool` and be gated to `owner`-only via the `subagent.spawn.operator` per-subagent permission hook landed in #273.
- **Not a permission change.** `subagent.spawn` was granted to `owner`, `trusted`, and `member` in #273. `explorer` inherits that grant — no additional permission configuration needed.
- **Not system prompt bloat.** The slim prompt (cron/subagent sessions) is unchanged. Net addition to the full prompt: one sentence naming `explorer` in the existing Mode A paragraph.

## Explorer vs operator (contrast)

| | `explorer` (this PR) | `operator` (PR 3) |
|---|---|---|
| Mode | A — research fan-out | B — delegate-and-converse |
| Model | `fast` | default |
| Tools | `read` / `grep` / `find` / `ls` / `bash` (read-only) | full including write + edit |
| Parallelism | designed for it (`inFlightKey` per `requestId`) | serial by default |
| Permission | `subagent.spawn` (owner/trusted/member) | `subagent.spawn.operator` (owner only) |
| Writes | STRICTLY PROHIBITED | intended |

## Commit history (4 granular commits)

```
0b60fe3 explorer: define read-only codebase-search subagent
         → explorer.ts + explorer.test.ts (23 tests)
8a91b22 explorer: package as a bundled plugin
         → index.ts + index.test.ts (2 tests)
138bdc7 explorer: register the explorer plugin in BUNDLED_PLUGINS
         → bundled-plugins.ts + bundled-plugins.test.ts (snapshot bump)
f728da2 explorer: name the explorer subagent in the Mode A prompt guidance
         → system-prompt.ts (+2 lines)
```

## Test coverage

**4429 pass / 0 fail** (4404 from #273 baseline + 25 new explorer tests).

| File | Tests | What they verify |
|---|---|---|
| `explorer.test.ts` | 23 | Load-bearing prompt phrases, declaration shape (visibility, profile, tool list, no write/edit tools), payload schema, `inFlightKey` distinctness per `requestId` and when payload is empty |
| `index.test.ts` | 2 | Plugin contributes only the explorer subagent and nothing else |

**Load-bearing phrases asserted by `test.each`:** `READ-ONLY`, `STRICTLY PROHIBITED`, `parallel`, `absolute`, `<analysis>`, `<results>`, `<files>`, `<answer>`, `<next_steps>`, `Completeness over speed`, `Spawning further subagents`.

## Pre-merge gates

Per `.sisyphus/plans/subagent-orchestration.md` PR 2 QA rows 1–8 (the plan is gitignored, lives in the worktree only):

| Gate | Result |
|---|---|
| `bun run typecheck` | ✅ clean |
| `bun run lint` | ✅ 0 errors, 18 pre-existing warnings unchanged |
| `bun run format:check` | ✅ clean |
| `bun test` | ✅ 4429 / 4429 pass |
| `bun test src/bundled-plugins/explorer/` | ✅ 25 / 25 pass |
| Load-bearing prompt phrases asserted | ✅ |
| Declaration shape asserted (visibility=public, profile=fast, no write/edit, budget, `inFlightKey`) | ✅ |
| `bun run debug:prompt --origin tui` mentions `explorer` in Mode A | ✅ |

## Live QA (deferred — requires `typeclaw start --build`)

Per plan rows 9–10:

- "find all places we publish to the stream broadcast target" → should trigger a `spawn_subagent` call.
- "search the codebase for 3 different patterns at once" → should fire multiple `explorer` instances in parallel (verifiable via `stream_snapshot` afterward).

## Diff

7 files changed, 255 insertions(+), 3 deletions(-)

```
src/agent/system-prompt.ts                    +2
src/bundled-plugins/explorer/explorer.test.ts +105  (new)
src/bundled-plugins/explorer/explorer.ts      +82   (new)
src/bundled-plugins/explorer/index.test.ts    +47   (new)
src/bundled-plugins/explorer/index.ts         +11   (new)
src/run/bundled-plugins.test.ts               +9 -3
src/run/bundled-plugins.ts                    +2
```