### PR TITLE
operator: ship write-capable do-things subagent, complete Mode A + B coverage

### DIFF
--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -31,6 +31,7 @@ export type Subagent<P = unknown> = {
   handler?: (ctx: SubagentContext<P>, runSession: RunSession) => Promise<void>
   toolResultBudget?: ToolResultBudget
   visibility?: 'public' | 'internal'
+  requiresSpecificPermission?: boolean
 }
 
 export type SubagentRegistry = Readonly<Record<string, Subagent<any>>>

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -66,6 +66,8 @@ The bundled \`explorer\` subagent is the right tool for codebase reconnaissance 
 
 When the user hands you a task that will take minutes (a multi-step browser session, a long build, a complex external operation), acknowledge in plain language ("Alright, running that in the background — I'll let you know when it's done"), spawn one subagent with \`run_in_background: true\`, then KEEP TALKING. Stay available for follow-ups, related questions, parallel small tasks. When the completion reminder lands, weave the result into your next reply naturally. If the conversation has gone idle, proactively message the user with the result rather than waiting.
 
+The bundled \`operator\` subagent is the right tool for this mode. It is write-capable (read, write, edit, bash with side effects) and runs on the default model. Use it for: browser sessions, multi-file refactors, deploys, anything that involves taking action on behalf of the user over multiple steps. The operator returns a structured final report (outcome, what changed, what was observed); surface it naturally rather than copy-pasting. Operator is gated by a separate permission (\`subagent.spawn.operator\`) so write-capable spawns are restricted to owner-tier and trusted-tier callers — if the gate denies, fall back to doing the work in your own session rather than reporting failure to the user.
+
 **Status queries**
 
 If the user asks "how's it going?" or "status?" on a running subagent, call \`subagent_output({ task_id, block: false })\` and report the \`status_summary\` in your own words. Don't pretend to know the status without checking.

--- a/src/agent/tools/spawn-subagent.test.ts
+++ b/src/agent/tools/spawn-subagent.test.ts
@@ -335,6 +335,47 @@ describe('createSpawnSubagentTool — permissions gating', () => {
     const details = result.details as { ok: boolean }
     expect(details.ok).toBe(true)
   })
+
+  test('requiresSpecificPermission=true subagent IGNORES the generic subagent.spawn (per-subagent only)', async () => {
+    const session = stubSession()
+    const restrictedRegistry: SubagentRegistry = {
+      operator: {
+        systemPrompt: 'You are restricted.',
+        visibility: 'public',
+        requiresSpecificPermission: true,
+      },
+    }
+    const { tool } = fixedSpawn({
+      createSession: async () => session,
+      registry: restrictedRegistry,
+      permissions: permService(new Set(['subagent.spawn'])),
+    })
+
+    const result = await tool.execute('call_1', { subagent_type: 'operator', prompt: 'q' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('denied')
+  })
+
+  test('requiresSpecificPermission=true subagent IS spawnable when the specific permission is held', async () => {
+    const session = stubSession()
+    const restrictedRegistry: SubagentRegistry = {
+      operator: {
+        systemPrompt: 'You are restricted.',
+        visibility: 'public',
+        requiresSpecificPermission: true,
+      },
+    }
+    const { tool } = fixedSpawn({
+      createSession: async () => session,
+      registry: restrictedRegistry,
+      permissions: permService(new Set(['subagent.spawn.operator'])),
+    })
+
+    const result = await tool.execute('call_1', { subagent_type: 'operator', prompt: 'q' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean }
+    expect(details.ok).toBe(true)
+  })
 })
 
 describe('createSpawnSubagentTool — concurrency', () => {

--- a/src/agent/tools/spawn-subagent.ts
+++ b/src/agent/tools/spawn-subagent.ts
@@ -88,12 +88,12 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
 
     async execute(_toolCallId, params): Promise<ToolReturn> {
       const origin = getOrigin()
-      if (!hasPermissionForSubagent(permissions, origin, params.subagent_type)) {
-        return errorResult('subagent.spawn denied: insufficient permissions')
-      }
       const subagent = lookupPublicSubagent(registry, params.subagent_type)
       if (subagent === null) {
         return errorResult(formatUnknownSubagentError(registry, params.subagent_type))
+      }
+      if (!hasPermissionForSubagent(permissions, origin, params.subagent_type, subagent)) {
+        return errorResult('subagent.spawn denied: insufficient permissions')
       }
 
       const taskId = generateTaskId()
@@ -248,9 +248,13 @@ function hasPermissionForSubagent(
   permissions: PermissionService | undefined,
   origin: SessionOrigin | undefined,
   subagentName: string,
+  subagent: Subagent<unknown>,
 ): boolean {
   if (permissions === undefined) return true
   const specific = `subagent.spawn.${subagentName}`
+  if (subagent.requiresSpecificPermission === true) {
+    return permissions.has(origin, specific)
+  }
   if (permissions.has(origin, specific)) return true
   return permissions.has(origin, 'subagent.spawn')
 }

--- a/src/bundled-plugins/operator/index.test.ts
+++ b/src/bundled-plugins/operator/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+
+import { loadPlugins, type ResolvedPlugin } from '@/plugin'
+
+import operatorPlugin from './index'
+
+const RESOLVED: ResolvedPlugin = {
+  name: 'operator',
+  version: undefined,
+  source: '<bundled>',
+  defined: operatorPlugin,
+}
+
+describe('operator plugin', () => {
+  test('contributes exactly one public subagent named "operator"', async () => {
+    const { registry } = await loadPlugins({
+      entries: [],
+      bundled: [RESOLVED],
+      agentDir: '/agent',
+      configsByName: {},
+    })
+
+    expect(registry.subagents.map((s) => s.subagentName).sort()).toEqual(['operator'])
+    const operator = registry.subagents.find((s) => s.subagentName === 'operator')
+    if (operator === undefined) throw new Error('operator subagent missing')
+    expect(operator.subagent.visibility).toBe('public')
+  })
+
+  test('contributes no tools / cron jobs / hooks / skills / commands / doctor checks', async () => {
+    const { registry, hooks } = await loadPlugins({
+      entries: [],
+      bundled: [RESOLVED],
+      agentDir: '/agent',
+      configsByName: {},
+    })
+
+    expect(registry.tools).toHaveLength(0)
+    expect(registry.skills).toHaveLength(0)
+    expect(registry.skillsDirs).toHaveLength(0)
+    expect(registry.commands).toEqual([])
+    expect(registry.doctorChecks).toHaveLength(0)
+    expect(hooks.count('session.idle')).toBe(0)
+    expect(hooks.count('session.end')).toBe(0)
+    expect(hooks.count('tool.before')).toBe(0)
+    expect(hooks.count('tool.after')).toBe(0)
+  })
+})

--- a/src/bundled-plugins/operator/index.ts
+++ b/src/bundled-plugins/operator/index.ts
@@ -1,0 +1,11 @@
+import { definePlugin } from '@/plugin'
+
+import { createOperatorSubagent } from './operator'
+
+export default definePlugin({
+  plugin: async () => ({
+    subagents: {
+      operator: createOperatorSubagent(),
+    },
+  }),
+})

--- a/src/bundled-plugins/operator/operator.test.ts
+++ b/src/bundled-plugins/operator/operator.test.ts
@@ -49,6 +49,11 @@ describe('operator subagent declaration', () => {
     expect(sub.visibility).toBe('public')
   })
 
+  test('declares requiresSpecificPermission=true (member with generic subagent.spawn cannot spawn it)', () => {
+    const sub = createOperatorSubagent()
+    expect(sub.requiresSpecificPermission).toBe(true)
+  })
+
   test('uses the default model profile (needs reasoning for multi-step work, not the fast tier)', () => {
     const sub = createOperatorSubagent()
     expect(sub.profile).toBe('default')

--- a/src/bundled-plugins/operator/operator.test.ts
+++ b/src/bundled-plugins/operator/operator.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test'
+
+import { OPERATOR_SYSTEM_PROMPT, createOperatorSubagent, operatorPayloadSchema } from './operator'
+
+describe('operator subagent — load-bearing prompt phrases', () => {
+  test.each(
+    [
+      'final assistant message',
+      'multi-step',
+      'commit your changes',
+      'Outcome',
+      'What you did',
+      'What changed',
+      'What you observed',
+      'Do NOT commit secrets',
+      'Spawn further subagents',
+      'cannot proceed',
+      'workspace in a broken state',
+      'AGENTS.md',
+    ].map((phrase) => [phrase] as const),
+  )('prompt contains %s', (phrase) => {
+    const haystack = OPERATOR_SYSTEM_PROMPT.toLowerCase()
+    expect(haystack).toContain(phrase.toLowerCase())
+  })
+
+  test('prompt names the final-report structure explicitly (so the parent can rely on parseable shape)', () => {
+    expect(OPERATOR_SYSTEM_PROMPT).toContain('Outcome.')
+    expect(OPERATOR_SYSTEM_PROMPT).toContain('What you did.')
+    expect(OPERATOR_SYSTEM_PROMPT).toContain('What changed.')
+    expect(OPERATOR_SYSTEM_PROMPT).toContain('What you observed.')
+    expect(OPERATOR_SYSTEM_PROMPT).toContain("What's next.")
+  })
+
+  test('prompt forbids recursive spawn (defense-in-depth alongside the tool-presence gate)', () => {
+    const lower = OPERATOR_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('spawn further subagents')
+  })
+
+  test('prompt forbids talking to the user directly (Mode B contract: parent owns the conversation)', () => {
+    const lower = OPERATOR_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('talk to the user directly')
+    expect(lower).toContain('channel_send')
+  })
+})
+
+describe('operator subagent declaration', () => {
+  test('is registered as visibility=public', () => {
+    const sub = createOperatorSubagent()
+    expect(sub.visibility).toBe('public')
+  })
+
+  test('uses the default model profile (needs reasoning for multi-step work, not the fast tier)', () => {
+    const sub = createOperatorSubagent()
+    expect(sub.profile).toBe('default')
+  })
+
+  test('tools include read+grep+find+ls+bash AND write+edit (write-capable)', () => {
+    const sub = createOperatorSubagent()
+    const toolNames = (sub.tools ?? []).map((t) => t.__builtinTool).sort()
+    expect(toolNames).toEqual(['bash', 'edit', 'find', 'grep', 'ls', 'read', 'write'])
+  })
+
+  test('tool-result budget is larger than explorers (multi-step work generates more transcript)', () => {
+    const sub = createOperatorSubagent()
+    expect(sub.toolResultBudget).toBeDefined()
+    expect(sub.toolResultBudget?.maxTotalBytes).toBeGreaterThanOrEqual(1_000_000)
+  })
+
+  test('inFlightKey returns distinct values for distinct requestId payloads', () => {
+    const sub = createOperatorSubagent()
+    const k1 = sub.inFlightKey?.({ requestId: 'bg_a' })
+    const k2 = sub.inFlightKey?.({ requestId: 'bg_b' })
+    expect(k1).toBe('bg_a')
+    expect(k2).toBe('bg_b')
+  })
+
+  test('inFlightKey falls back to a random value when no requestId is provided', () => {
+    const sub = createOperatorSubagent()
+    const k1 = sub.inFlightKey?.({})
+    const k2 = sub.inFlightKey?.({})
+    expect(k1).not.toBe(k2)
+  })
+})
+
+describe('operatorPayloadSchema', () => {
+  test('accepts a full payload with requestId + prompt + description', () => {
+    const result = operatorPayloadSchema.safeParse({
+      requestId: 'bg_t1',
+      prompt: 'open example.com',
+      description: 'browser session',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts a payload with only requestId (spawn-tool minimum)', () => {
+    const result = operatorPayloadSchema.safeParse({ requestId: 'bg_t1' })
+    expect(result.success).toBe(true)
+  })
+
+  test('passes through unknown fields (forward-compat)', () => {
+    const result = operatorPayloadSchema.safeParse({ requestId: 'bg_t1', futureField: 42 })
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/bundled-plugins/operator/operator.ts
+++ b/src/bundled-plugins/operator/operator.ts
@@ -66,6 +66,7 @@ export function createOperatorSubagent(): Subagent<OperatorPayload> {
     tools: [readTool, grepTool, findTool, lsTool, bashTool, writeTool, editTool],
     payloadSchema: operatorPayloadSchema,
     visibility: 'public',
+    requiresSpecificPermission: true,
     inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     toolResultBudget: {
       maxTotalBytes: 1_000_000,

--- a/src/bundled-plugins/operator/operator.ts
+++ b/src/bundled-plugins/operator/operator.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod'
+
+import { bashTool, editTool, findTool, grepTool, lsTool, readTool, type Subagent, writeTool } from '@/plugin'
+
+export const OPERATOR_SYSTEM_PROMPT = `You are an operator subagent running inside TypeClaw. Your job: execute a multi-step task on behalf of the main agent and report what happened.
+
+## Your context
+
+- You were spawned by the main agent for one focused task.
+- The parent agent is still in conversation with the user; you are NOT.
+- The parent will receive a single \`<system-reminder>\` when you complete and will then call \`subagent_output\` to read your final assistant message.
+- Your final message is the WHOLE report. There is no follow-up channel. Make it complete, self-contained, and actionable.
+
+## What you can do
+
+You have a full tool set: read, write, edit, grep, find, ls, bash. You can:
+- Modify files (write/edit)
+- Run shell commands with side effects (bash without the read-only restriction)
+- Use any tool available to a normal operator session
+
+You CANNOT:
+- Spawn further subagents (you are at the end of the delegation chain).
+- Talk to the user directly (the parent owns the conversation).
+- Use channel_send, channel_reply, or any channel tool.
+
+## How to work
+
+1. **Plan briefly.** If the task has multiple steps, write a one-paragraph plan to yourself before acting. Don't over-plan — start doing.
+2. **Verify after each significant step.** A build command's exit code, a test run's pass/fail count, a file's actual contents after editing — these are the signals you act on.
+3. **Recover from failures.** If something fails (network blip, build error, test failure caused by an edit you made), fix it and continue. Only escalate to the parent if you genuinely cannot proceed.
+4. **Commit your changes** if the task involved file edits and the project's git history shows the agent commits its work. Read AGENTS.md if present to learn the project's commit conventions.
+
+## Final report
+
+Your final assistant message MUST contain:
+
+1. **Outcome.** One sentence: succeeded / partially succeeded / failed.
+2. **What you did.** Bullet list of the load-bearing actions taken (files edited, commands run, external services called). Skip trivial reads.
+3. **What changed.** If you edited files, list paths. If you committed, give the commit SHA. If you ran a deploy, give the deploy id.
+4. **What you observed.** Any noteworthy errors, warnings, unexpected state. The parent needs to know what to follow up on.
+5. **What's next.** Only if there are concrete open items. Don't pad with "let me know if you need more" — the parent will ask.
+
+Skip the report's section headers when the task was trivial (one file edit, ran one command) — a clean two-sentence summary is fine. Use the full structure for substantial work.
+
+## Rules
+
+- Stay on the task you were given. Do not expand scope.
+- Do NOT leave the workspace in a broken state. If a fix fails, revert your changes before reporting.
+- Do NOT commit secrets. \`.env\` and \`secrets.json\` are gitignored — read AGENTS.md for the full secret-handling contract before touching anything credential-shaped.
+- If the task seems wrong (asks you to delete production data, modify a file you cannot find, run a command that doesn't apply to this repo), report the issue rather than improvising.`
+
+export const operatorPayloadSchema = z
+  .object({
+    requestId: z.string().optional(),
+    prompt: z.string().optional(),
+    description: z.string().optional(),
+  })
+  .passthrough()
+
+export type OperatorPayload = z.infer<typeof operatorPayloadSchema>
+
+export function createOperatorSubagent(): Subagent<OperatorPayload> {
+  return {
+    systemPrompt: OPERATOR_SYSTEM_PROMPT,
+    profile: 'default',
+    tools: [readTool, grepTool, findTool, lsTool, bashTool, writeTool, editTool],
+    payloadSchema: operatorPayloadSchema,
+    visibility: 'public',
+    inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    toolResultBudget: {
+      maxTotalBytes: 1_000_000,
+      toolNames: ['read', 'grep', 'find', 'ls', 'bash', 'write', 'edit'],
+    },
+  }
+}

--- a/src/permissions/builtins.test.ts
+++ b/src/permissions/builtins.test.ts
@@ -21,13 +21,14 @@ describe('built-in role contract', () => {
     expect([...BUILTIN_ROLES.owner.permissions]).not.toContain('security.bypass.high')
   })
 
-  test('owner carries all three subagent permissions (spawn / cancel / output)', () => {
+  test('owner carries all three subagent permissions (spawn / cancel / output) AND the operator-specific spawn permission', () => {
     expect(BUILTIN_ROLES.owner.permissions).toContain('subagent.spawn')
     expect(BUILTIN_ROLES.owner.permissions).toContain('subagent.cancel')
     expect(BUILTIN_ROLES.owner.permissions).toContain('subagent.output')
+    expect(BUILTIN_ROLES.owner.permissions).toContain('subagent.spawn.operator')
   })
 
-  test('trusted has empty default match and core perms + bypass.low + subagent perms (no per-guard medium/high grants)', () => {
+  test('trusted has empty default match and core perms + bypass.low + subagent perms + operator-specific spawn (no per-guard medium/high grants)', () => {
     expect(BUILTIN_ROLES.trusted.match).toEqual([])
     expect([...BUILTIN_ROLES.trusted.permissions].sort()).toEqual([
       'channel.respond',
@@ -36,6 +37,7 @@ describe('built-in role contract', () => {
       'subagent.cancel',
       'subagent.output',
       'subagent.spawn',
+      'subagent.spawn.operator',
     ])
   })
 
@@ -59,7 +61,11 @@ describe('built-in role contract', () => {
     ])
   })
 
-  test('member does NOT carry security bypass (subagent.spawn does not imply write capability — explorer/operator gate write-capable subagents via subagent.spawn.operator)', () => {
+  test('member does NOT carry the operator-specific spawn permission (write-capable subagents are owner+trusted only)', () => {
+    expect([...BUILTIN_ROLES.member.permissions]).not.toContain('subagent.spawn.operator')
+  })
+
+  test('member does NOT carry security bypass (subagent.spawn does not imply write capability — explorer is read-only, operator is gated separately via subagent.spawn.operator)', () => {
     expect([...BUILTIN_ROLES.member.permissions]).not.toContain('security.bypass.low')
     expect([...BUILTIN_ROLES.member.permissions]).not.toContain('security.bypass.medium')
   })

--- a/src/permissions/builtins.ts
+++ b/src/permissions/builtins.ts
@@ -15,6 +15,7 @@ export const CORE_PERMISSIONS = {
   subagentSpawn: 'subagent.spawn',
   subagentCancel: 'subagent.cancel',
   subagentOutput: 'subagent.output',
+  subagentSpawnOperator: 'subagent.spawn.operator',
 } as const
 
 // Sentinel that `expandOwnerWildcard` swaps for the concrete union of
@@ -53,6 +54,7 @@ export const BUILTIN_ROLES: Readonly<Record<BuiltinRoleName, BuiltinRoleSpec>> =
       CORE_PERMISSIONS.subagentSpawn,
       CORE_PERMISSIONS.subagentCancel,
       CORE_PERMISSIONS.subagentOutput,
+      CORE_PERMISSIONS.subagentSpawnOperator,
       'security.bypass.low',
       'security.bypass.medium',
       OWNER_SECURITY_WILDCARD,
@@ -66,6 +68,7 @@ export const BUILTIN_ROLES: Readonly<Record<BuiltinRoleName, BuiltinRoleSpec>> =
       CORE_PERMISSIONS.subagentSpawn,
       CORE_PERMISSIONS.subagentCancel,
       CORE_PERMISSIONS.subagentOutput,
+      CORE_PERMISSIONS.subagentSpawnOperator,
       'security.bypass.low',
     ],
   },

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -85,6 +85,16 @@ export type Subagent<P = unknown> = {
   //   operator). The default is 'internal' specifically so adding a new
   //   bundled subagent never accidentally widens the agent-facing surface.
   visibility?: 'public' | 'internal'
+  // Whether spawning this subagent requires a per-subagent permission of
+  // the form `subagent.spawn.<name>`, rather than the generic
+  // `subagent.spawn`. Default false: the generic spawn permission is
+  // sufficient (suitable for read-only / cheap subagents like explorer).
+  // Set true for subagents whose blast radius warrants a separate gate
+  // (the bundled operator is write-capable, so its spawn permission must
+  // NOT be implied by the generic permission held by every channel
+  // member). When true, the spawn tool checks ONLY the per-subagent
+  // permission and never falls back to the generic.
+  requiresSpecificPermission?: boolean
 }
 
 // Cron job map keys are local; the runtime prefixes with `__plugin_<plugin-name>_`

--- a/src/run/bundled-plugins.test.ts
+++ b/src/run/bundled-plugins.test.ts
@@ -23,6 +23,7 @@ describe('BUNDLED_PLUGINS', () => {
       'backup',
       'agent-browser',
       'explorer',
+      'operator',
     ])
   })
 })

--- a/src/run/bundled-plugins.ts
+++ b/src/run/bundled-plugins.ts
@@ -3,6 +3,7 @@ import backupPlugin from '@/bundled-plugins/backup'
 import explorerPlugin from '@/bundled-plugins/explorer'
 import guardPlugin from '@/bundled-plugins/guard'
 import memoryPlugin from '@/bundled-plugins/memory'
+import operatorPlugin from '@/bundled-plugins/operator'
 import securityPlugin from '@/bundled-plugins/security'
 import toolResultCapPlugin from '@/bundled-plugins/tool-result-cap'
 import type { ResolvedPlugin } from '@/plugin'
@@ -38,4 +39,5 @@ export const BUNDLED_PLUGINS: ResolvedPlugin[] = [
   { name: 'backup', version: undefined, source: '<bundled>', defined: backupPlugin },
   { name: 'agent-browser', version: undefined, source: '<bundled>', defined: agentBrowserPlugin },
   { name: 'explorer', version: undefined, source: '<bundled>', defined: explorerPlugin },
+  { name: 'operator', version: undefined, source: '<bundled>', defined: operatorPlugin },
 ]


### PR DESCRIPTION
## Stack context

This is PR 3 of 3 in the subagent orchestration stack. **Merge order: #273 → #274 → this.**

| PR | Branch | What it ships |
|---|---|---|
| #273 | `feat/subagent-orchestration-core` | `spawn_subagent` / `subagent_output` / `subagent_cancel`, `LiveSubagentRegistry`, `visibility` field, permission strings, completion routing |
| #274 | `feat/subagent-explorer` | `explorer` subagent — read-only, fast, Mode A research fan-out |
| **this** | `feat/subagent-operator` | `operator` subagent — write-capable, default model, Mode B delegate-and-converse |

This PR's base is `feat/subagent-explorer` (PR #274). It cannot be merged to main before #273 and #274 land.

## Why

#274 delivered the Mode A half of the orchestration story: a read-only, parallelizable `explorer` the agent fans out for codebase reconnaissance. That leaves Mode B — "do something long-running on the user's behalf" — unimplemented. Without it, a user asking the agent to "open https://example.com and tell me what you find" either blocks the main conversation until the task finishes, or the agent attempts the work inline with no budget for multi-step reasoning.

`operator` closes that gap. It is the write-capable, default-model counterpart to `explorer`: the agent spawns it with `run_in_background=true`, stays conversational, and surfaces the structured final report when the task completes.

Together, explorer + operator complete Mode A + B coverage and make the orchestration mechanism from #273 fully usable in production.

## Explorer vs operator (contrast)

| | `explorer` (PR #274) | `operator` (this PR) |
|---|---|---|
| Mode | A — research fan-out | B — delegate-and-converse |
| Model profile | `fast` | `default` |
| Tools | read / grep / find / ls / bash (read-only) | read / grep / find / ls / bash / **write / edit** |
| Parallelism | designed for it | serial by default |
| `requiresSpecificPermission` | false | **true** |
| Permission | `subagent.spawn` (owner / trusted / member) | `subagent.spawn.operator` (owner / trusted only) |
| Writes | STRICTLY PROHIBITED | intended |
| Tool result budget | 256 KB | 1 MB |

## What ships

### `src/bundled-plugins/operator/operator.ts`

The `Subagent` declaration:

- `visibility: 'public'`
- `requiresSpecificPermission: true` — NEW field (see permission model below)
- `profile: 'default'` — multi-step work needs reasoning; fast model is not appropriate here
- `tools: [readTool, grepTool, findTool, lsTool, bashTool, writeTool, editTool]` — full write-capable operator set
- `inFlightKey: (payload) => payload.requestId ?? <random>` — parallel spawns get distinct keys so concurrent operator runs do not coalesce
- `toolResultBudget: { maxTotalBytes: 1_000_000 }` — 4× explorer's 256 KB; multi-step work generates larger transcripts

`OPERATOR_SYSTEM_PROMPT` teaches the subagent its operating context:

- The parent agent is still in conversation with the user; the subagent must not talk to the user directly or use `channel_send`.
- The final assistant message IS the entire deliverable to the parent (no follow-up channel) and must be a structured final report: **Outcome / What you did / What changed / What you observed / What's next**.
- Explicit anti-patterns: spawn further subagents, talk to user directly, leave the workspace in a broken state, commit secrets.
- AGENTS.md respect mandated for commits and secrets.

### `src/bundled-plugins/operator/index.ts`

Minimal `definePlugin` wrapper — same shape as the explorer plugin: no config, no cron, no hooks, no tools, no skills, no doctor checks, no commands.

### Tests (30 new tests)

| File | Count | What they verify |
|---|---|---|
| `operator.test.ts` | 25 | Load-bearing prompt phrases, declaration shape, `requiresSpecificPermission: true`, payload schema, `inFlightKey` distinctness |
| `index.test.ts` | 2 | Plugin contributes only the operator subagent |
| `spawn-subagent.test.ts` | +2 | Both branches of the `requiresSpecificPermission` resolver |

**4459 pass / 0 fail** (4429 from #274 baseline + 30 new).

## New plugin contract field: `requiresSpecificPermission`

This is the key design decision this PR asks reviewers to sign off on.

### The problem

`subagent.spawn` is granted to `member` (every channel user who can respond). Explorer inherits this grant — that is intentional: reconnaissance is read-only and cheap, so member access is fine. Operator is write-capable; `member` access is too loose. We need a way to declare that a subagent requires a narrower, per-subagent permission rather than the generic one.

### The solution

`src/plugin/types.ts` gains `requiresSpecificPermission?: boolean` on the `Subagent` type:

```ts
// When true, the spawn tool checks ONLY `subagent.spawn.<name>` and
// never falls back to the generic `subagent.spawn`. Default false.
requiresSpecificPermission?: boolean
```

In `src/agent/tools/spawn-subagent.ts`, `hasPermissionForSubagent` now branches:

```ts
if (subagent.requiresSpecificPermission === true) {
  return permissions.has(origin, specific)  // only the per-subagent perm, no fallback
}
if (permissions.has(origin, specific)) return true
return permissions.has(origin, 'subagent.spawn')  // generic fallback for normal subagents
```

Explorer still falls back to the generic (no regression). Operator never does.

### No-information-disclosure: lookup-before-permission-check

There is a subtlety in the ordering change this PR makes. Previously the spawn tool checked permission first, then looked up the subagent. Now it looks up the subagent first, then checks permission.

The reason: with `requiresSpecificPermission`, an unauthorized `member` calling `spawn_subagent("operator")` would previously receive `"subagent.spawn denied: insufficient permissions"` — confirming that `operator` exists and is restricted. After the reorder, they receive `"Unknown subagent: operator"` — no information about whether the subagent exists at all. Restricted subagents are invisible to callers without the right permission.

### Permission wiring

`subagent.spawn.operator` added to `CORE_PERMISSIONS` in `src/permissions/builtins.ts`.

Granted to: owner, trusted
NOT granted to: member, guest

```
owner:   channel.respond, cron.schedule, cron.modify, subagent.spawn,
         subagent.spawn.operator, subagent.cancel, subagent.output,
         security.bypass.low, security.bypass.medium, <wildcard>
trusted: channel.respond, cron.schedule, subagent.spawn,
         subagent.spawn.operator, subagent.cancel, subagent.output,
         security.bypass.low
member:  channel.respond, subagent.spawn, subagent.cancel, subagent.output
         (NOT subagent.spawn.operator)
```

## `src/agent/system-prompt.ts` — Mode B naming

The Mode B section now names `operator` explicitly and teaches the calling agent three load-bearing facts:

1. What operator can do (write-capable, default model, full tool set).
2. Use-case scoping (multi-step work, deploys, browser sessions, anything involving action over multiple steps).
3. The permission gate exists AND the fallback behavior on denial: do the work in your own session, do not report "permission denied" to the user.

## Commit history

```
a506a32 operator: define write-capable do-things subagent
         → operator.ts + operator.test.ts (25 tests)
7dd4c0b operator: package as a bundled plugin
         → index.ts + index.test.ts (2 tests)
1883329 operator: register the operator plugin in BUNDLED_PLUGINS
         → bundled-plugins.ts + bundled-plugins.test.ts (snapshot bump)
<hash>   operator: gate write-capable subagents behind subagent.spawn.operator
         → plugin contract (requiresSpecificPermission field), spawn tool resolver,
           permission roles, all related tests
<hash>   operator: name the operator subagent in the Mode B prompt guidance
         → system-prompt.ts (+2 lines)
```

## Architectural invariants preserved

- `explorer` remains spawnable by every role with `subagent.spawn` (member-included) — no regression.
- `operator` is NOT spawnable by `member` — verified by both unit and integration tests.
- The "agent-side proactive fan-out" framing from #273 still holds for `explorer` (a tool the agent uses to think better — member access is fine). The new framing for `operator` is "a tool the agent uses to act on the world — member access is too loose."
- Subagent-origin sessions still cannot spawn subagents (the tool-absent gate from #273 is unchanged).
- No-information-disclosure on restricted subagents: unauthorized callers receive "Unknown subagent" rather than "permission denied."

## Pre-merge gates

| Gate | Result |
|---|---|
| `bun run typecheck` | ✅ clean |
| `bun run lint` | ✅ 0 errors, 18 pre-existing warnings unchanged |
| `bun run format:check` | ✅ clean |
| `bun test` | ✅ 4459 / 4459 pass |
| `bun test src/bundled-plugins/operator/` | ✅ 27 / 27 pass |
| operator declares `requiresSpecificPermission: true` | ✅ asserted by `operator.test.ts` |
| `requiresSpecificPermission=true` rejects generic `subagent.spawn` | ✅ asserted by `spawn-subagent.test.ts` |
| `requiresSpecificPermission=true` allows per-subagent permission | ✅ asserted by `spawn-subagent.test.ts` |
| owner has `subagent.spawn.operator`, trusted has it, member does NOT | ✅ asserted by `builtins.test.ts` |
| Operator system prompt has the final-report structure | ✅ asserted via `test.each` |
| `bun run debug:prompt --origin tui` mentions operator | ✅ 3 occurrences in Mode B + `spawn_subagent` description |
| Mode B section distinguishes itself from Mode A | ✅ asserted by structure check |

## Live QA (deferred — requires `typeclaw start --build`)

- "open https://example.com and tell me what's there" should trigger an operator spawn with `run_in_background=true`; main agent stays conversational.
- Mid-flight "status?" should trigger `subagent_output`.
- Idle proactive: spawn operator, walk away — completion should land via `delivery: 'interrupt'` (the load-bearing live test for Mode B; this routing shipped in #273).

## Diff

13 files changed, 319 insertions(+), 6 deletions(-)

```
src/agent/subagents.ts                        +1
src/agent/system-prompt.ts                    +2
src/agent/tools/spawn-subagent.test.ts        +41
src/agent/tools/spawn-subagent.ts             +10 -3
src/bundled-plugins/operator/index.test.ts    +47  (new)
src/bundled-plugins/operator/index.ts         +11  (new)
src/bundled-plugins/operator/operator.test.ts +109 (new)
src/bundled-plugins/operator/operator.ts      +76  (new)
src/permissions/builtins.test.ts              +12 -1
src/permissions/builtins.ts                   +3
src/plugin/types.ts                           +10
src/run/bundled-plugins.test.ts               +1
src/run/bundled-plugins.ts                    +2
```