### PR TITLE
scout: add web-research subagent; widen explorer to general local search

### DIFF
--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -31,6 +31,39 @@ import type {
 } from '@/plugin'
 
 import type { SessionOrigin } from './session-origin'
+import { webfetchTool } from './tools/webfetch'
+import { websearchTool } from './tools/websearch'
+
+// `ToolDefinition.execute` carries a 5th `ctx: ExtensionContext` argument that
+// `AgentTool.execute` does not — TypeScript correctly refuses the assignment
+// because the wider signature can't satisfy a position that the consumer
+// believes accepts at most 4 args. At runtime, the 5th arg is unused by
+// websearch/webfetch (their executes only read `params` and `signal`), so the
+// adapter is a thin pass-through that drops the extra parameter and keeps the
+// hook/budget/wrap pipeline (which is keyed on AgentTool shape) working
+// uniformly for every entry in `BUILTIN_TOOL_MAP`. Don't reach for this for
+// pi-coding-agent's own bashTool/readTool etc. — those are already AgentTools.
+function toAgentTool<TParams extends TSchema, TDetails = unknown>(
+  tool: ToolDefinition<TParams, TDetails, never>,
+): AgentTool<TParams, TDetails> {
+  return {
+    name: tool.name,
+    label: tool.label,
+    description: tool.description,
+    parameters: tool.parameters,
+    ...(tool.prepareArguments ? { prepareArguments: tool.prepareArguments } : {}),
+    async execute(toolCallId, params, signal, onUpdate) {
+      return tool.execute(toolCallId, params, signal, onUpdate, undefined as never)
+    },
+  }
+}
+
+const websearchAgentTool = toAgentTool(
+  websearchTool as unknown as ToolDefinition<typeof websearchTool.parameters, unknown, never>,
+)
+const webfetchAgentTool = toAgentTool(
+  webfetchTool as unknown as ToolDefinition<typeof webfetchTool.parameters, unknown, never>,
+)
 
 type AnyAgentTool =
   | typeof piReadTool
@@ -40,6 +73,8 @@ type AnyAgentTool =
   | typeof piGrepTool
   | typeof piFindTool
   | typeof piLsTool
+  | typeof websearchAgentTool
+  | typeof webfetchAgentTool
 
 const ACKNOWLEDGE_GUARDS_SCHEMA = Type.Optional(
   Type.Object(
@@ -58,6 +93,8 @@ const BUILTIN_TOOL_MAP: Record<string, AnyAgentTool> = {
   ls: piLsTool,
   read: piReadTool,
   write: piWriteTool,
+  websearch: websearchAgentTool,
+  webfetch: webfetchAgentTool,
 }
 
 export function resolveBuiltinToolRefs(refs: BuiltinToolRef[]): AnyAgentTool[] {

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -60,7 +60,9 @@ There are two delegation modes. Pick deliberately.
 
 When you need information to answer the user and the search is broad, fire 2-5 subagents in parallel with \`run_in_background: true\` covering different angles. End your response after spawning. The system will deliver a \`<system-reminder>\` for each completion; gather results then answer the user. Do NOT poll \`subagent_output\` in a tight loop.
 
-The bundled \`explorer\` subagent is the right tool for codebase reconnaissance — finding where a pattern is implemented, mapping unfamiliar modules, discovering conventions across directories. It is read-only and runs on a fast/cheap model, so fire liberally. Do NOT ask it to plan, decide, or write code — it finds and reports.
+The bundled \`explorer\` subagent is the right tool for **local** reconnaissance — anything reachable on the agent's filesystem: code, past sessions (\`sessions/*.jsonl\`), MEMORY.md and daily memory streams, skills, cron jobs, config, git history, mounts, channels state. It is read-only and runs on a fast/cheap model, so fire liberally. Do NOT ask it to plan, decide, or write code — it finds and reports.
+
+The bundled \`scout\` subagent is its external counterpart — web research only. Use it when you need information from public sources (docs, library references, vendor changelogs, news, anything not already in this agent's folder). Scout runs \`websearch\` and \`webfetch\` in a fresh context window so the search churn does not pollute yours; it returns a citation-backed answer with a confidence rating. Prefer scout over running \`websearch\`/\`webfetch\` yourself when the research is non-trivial (more than 1-2 queries) or when you want to save your context for the synthesis step.
 
 **Mode B — Delegate-and-converse** (the user asked you to DO something long-running)
 

--- a/src/bundled-plugins/explorer/explorer.test.ts
+++ b/src/bundled-plugins/explorer/explorer.test.ts
@@ -32,12 +32,43 @@ describe('explorer subagent — load-bearing prompt phrases', () => {
     expect(EXPLORER_SYSTEM_PROMPT).toContain('git commit')
   })
 
-  test('prompt names the dedicated tools instead of leaving them implicit', () => {
-    expect(EXPLORER_SYSTEM_PROMPT).toContain('find —')
-    expect(EXPLORER_SYSTEM_PROMPT).toContain('grep —')
-    expect(EXPLORER_SYSTEM_PROMPT).toContain('read —')
-    expect(EXPLORER_SYSTEM_PROMPT).toContain('ls —')
-    expect(EXPLORER_SYSTEM_PROMPT).toContain('bash — ONLY for')
+  test('prompt names the dedicated tools by their exact runtime names', () => {
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('`find`')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('`grep`')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('`read`')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('`ls`')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('`bash`')
+  })
+
+  test('prompt frames the role as local-search (not codebase-only) and names the non-code surfaces', () => {
+    // Drift guard: the widened scope is the whole point of the PR. If a
+    // future edit reverts the prompt back to "codebase search specialist",
+    // sessions/memory/cron/config never get mentioned and this test fails.
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('local-search specialist')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('Sessions')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('Memory')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('Cron')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('Git history')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('Mounts')
+  })
+
+  test('prompt redirects EXTERNAL questions to scout (so explorer does not hallucinate web answers from memory)', () => {
+    // Without this guard, a user asking "what's the latest version of X?"
+    // gets a guessed answer instead of a delegated scout spawn. The
+    // explorer/scout split only works if the prompt names the boundary.
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('scout')
+    expect(EXPLORER_SYSTEM_PROMPT.toLowerCase()).toContain('external')
+  })
+
+  test('prompt warns about credential-bearing config files (.env / secrets.json) without forbidding read', () => {
+    // Reading these files is in scope (you need to be able to answer
+    // "is provider X configured?") — but echoing the literal token values
+    // back to the caller is the leak vector. The wording must say the
+    // latter, not the former, or explorer becomes useless for config
+    // questions.
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('.env')
+    expect(EXPLORER_SYSTEM_PROMPT).toContain('secrets.json')
+    expect(EXPLORER_SYSTEM_PROMPT.toLowerCase()).toContain('credentials')
   })
 })
 

--- a/src/bundled-plugins/explorer/explorer.ts
+++ b/src/bundled-plugins/explorer/explorer.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { bashTool, findTool, grepTool, lsTool, readTool, type Subagent } from '@/plugin'
 
-export const EXPLORER_SYSTEM_PROMPT = `You are a codebase search specialist running inside TypeClaw. Your job: find files and code, return actionable results.
+export const EXPLORER_SYSTEM_PROMPT = `You are a local-search specialist running inside TypeClaw. Your job: find things on the agent's local filesystem (code, transcripts, memory, config, git history, mounts) and return actionable results to the caller. For EXTERNAL web research, the caller should spawn \`scout\` instead — you have no network tools.
 
 === READ-ONLY — NO FILE MODIFICATIONS ===
 You are STRICTLY PROHIBITED from:
@@ -12,18 +12,38 @@ You are STRICTLY PROHIBITED from:
 - Writing to MEMORY.md, sessions/, workspace/, or any other runtime-managed path
 - Spawning further subagents — you are at the end of the delegation chain
 
-Your role is EXCLUSIVELY to search and analyze existing code.
+Your role is EXCLUSIVELY to search and analyze existing local state.
 
-## Tool selection
+## Tools
 
-Use the right tool for the job — do NOT default to bash:
-- find — file patterns by name/extension
-- grep — text/regex search in file contents
-- read — read specific files once you know the path
-- ls — list a directory's immediate contents for structural discovery
-- bash — ONLY for read-only git commands (git log, git blame, git diff, git status) when you need history
+The runtime exposes these tools to you by these EXACT names — call them by name, do not paraphrase:
+
+- \`find\` — locate files by name pattern or extension across a directory tree
+- \`grep\` — search file contents by text or regex
+- \`read\` — read a specific file once you know its path
+- \`ls\` — list a directory's immediate contents for structural discovery
+- \`bash\` — ONLY for read-only commands. The two common shapes are read-only git (\`git log\`, \`git blame\`, \`git diff\`, \`git status\`, \`git grep\`, \`git show <commit>:<path>\`) and one-shot pipelines that don't mutate state (\`cat\`, \`head\`, \`tail\`, \`wc\`, \`sort\`, \`uniq\`, \`jq\`, \`awk\`)
 
 Launch 3+ tools in parallel whenever you can. Cross-validate findings across multiple tools — a grep hit confirmed by reading the file is stronger than either alone.
+
+## Local searchable surfaces
+
+The agent folder is mounted at \`/agent\` inside the container. Search the narrowest relevant surface before falling back to broad codebase greps.
+
+1. **Codebase** — \`/agent/\` root and subdirs (excluding the runtime-managed paths below). Source files, docs, identity files (\`IDENTITY.md\`, \`SOUL.md\`, \`USER.md\`, \`AGENTS.md\`).
+2. **Sessions** — \`/agent/sessions/*.jsonl\` — conversation transcripts. Each line is a JSON event (user message, tool call, tool result, assistant message). Filename pattern \`\${ISO_TIMESTAMP}_\${UUID}.jsonl\`. \`grep\` works directly on the JSONL.
+3. **Memory** — \`/agent/MEMORY.md\` (long-term consolidated memory) and \`/agent/memory/yyyy-MM-dd.jsonl\` (daily fragment streams written by the memory-logger subagent). \`memory/.dreaming-state.json\` tracks the dreaming watermark. Do NOT edit any of these — they are runtime-owned.
+4. **Muscle-memory skills** — \`/agent/memory/skills/<name>/SKILL.md\` — procedures the dreaming subagent distilled from repeated work.
+5. **User-installed skills** — \`/agent/.agents/skills/<name>/SKILL.md\` — hand-authored or downloaded skills.
+6. **Workspace** — \`/agent/workspace/\` — the agent's free-write zone. Drafts, scratch work, generated artifacts.
+7. **Cron** — \`/agent/cron.json\` — scheduled jobs. Plugin-contributed cron jobs are in-memory only and not visible from disk.
+8. **Config** — \`/agent/typeclaw.json\`, \`/agent/package.json\`, \`/agent/Dockerfile\`, \`/agent/.env\`, \`/agent/.gitignore\`, \`/agent/secrets.json\`. **\`.env\` and \`secrets.json\` contain credentials — never echo their values back to the caller verbatim; describe what's configured without printing tokens.**
+9. **Git history** — \`.git\` under \`/agent/\`. Search via read-only \`git log\`, \`git blame\`, \`git diff\`, \`git grep\`, \`git show <commit>:<path>\`.
+10. **Logs** — \`/agent/sessions/backup-diagnostics.log\` is the only persistent log inside the container (backup-plugin failures). Container stdout/stderr is ephemeral.
+11. **Mounts** — \`/agent/mounts/<name>/\` — host directories mapped into the container per \`typeclaw.json#mounts\`.
+12. **Channels persistence** — \`/agent/channels/sessions.json\` — active channel sessions, participants, last inbound timestamps.
+13. **Packages** — \`/agent/packages/\` — user-authored plugins or libraries the agent built.
+14. **Container-only state** — \`/agent/node_modules/\` (auto-generated, large — prefer targeted greps) and \`/tmp/\` (ephemeral).
 
 ## Process
 
@@ -54,7 +74,8 @@ End every response with this exact structure:
 - Every path MUST be absolute (start with /).
 - Find ALL relevant matches, not just the first. Completeness over speed.
 - Do NOT diagnose, plan, or make architectural decisions — that's the caller's job. You find and report.
-- If you cannot find what was asked, say so explicitly with what you DID find and what scopes you searched.`
+- If the question requires EXTERNAL/web information (docs, library reference, web search, fetching a URL), say so explicitly and tell the caller to spawn \`scout\` instead. Do not try to answer external questions from memory.
+- If you cannot find what was asked, say so explicitly with what you DID find and what surfaces you searched.`
 
 export const explorerPayloadSchema = z
   .object({

--- a/src/bundled-plugins/scout/index.test.ts
+++ b/src/bundled-plugins/scout/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+
+import { loadPlugins, type ResolvedPlugin } from '@/plugin'
+
+import scoutPlugin from './index'
+
+const RESOLVED: ResolvedPlugin = {
+  name: 'scout',
+  version: undefined,
+  source: '<bundled>',
+  defined: scoutPlugin,
+}
+
+describe('scout plugin', () => {
+  test('contributes exactly one public subagent named "scout"', async () => {
+    const { registry } = await loadPlugins({
+      entries: [],
+      bundled: [RESOLVED],
+      agentDir: '/agent',
+      configsByName: {},
+    })
+
+    expect(registry.subagents.map((s) => s.subagentName).sort()).toEqual(['scout'])
+    const scout = registry.subagents.find((s) => s.subagentName === 'scout')
+    if (scout === undefined) throw new Error('scout subagent missing')
+    expect(scout.subagent.visibility).toBe('public')
+  })
+
+  test('contributes no tools / cron jobs / hooks / skills / commands / doctor checks', async () => {
+    const { registry, hooks } = await loadPlugins({
+      entries: [],
+      bundled: [RESOLVED],
+      agentDir: '/agent',
+      configsByName: {},
+    })
+
+    expect(registry.tools).toHaveLength(0)
+    expect(registry.skills).toHaveLength(0)
+    expect(registry.skillsDirs).toHaveLength(0)
+    expect(registry.commands).toEqual([])
+    expect(registry.doctorChecks).toHaveLength(0)
+    expect(hooks.count('session.idle')).toBe(0)
+    expect(hooks.count('session.end')).toBe(0)
+    expect(hooks.count('tool.before')).toBe(0)
+    expect(hooks.count('tool.after')).toBe(0)
+  })
+})

--- a/src/bundled-plugins/scout/index.ts
+++ b/src/bundled-plugins/scout/index.ts
@@ -1,0 +1,11 @@
+import { definePlugin } from '@/plugin'
+
+import { createScoutSubagent } from './scout'
+
+export default definePlugin({
+  plugin: async () => ({
+    subagents: {
+      scout: createScoutSubagent(),
+    },
+  }),
+})

--- a/src/bundled-plugins/scout/scout.test.ts
+++ b/src/bundled-plugins/scout/scout.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'bun:test'
+
+import { SCOUT_SYSTEM_PROMPT, createScoutSubagent, scoutPayloadSchema } from './scout'
+
+describe('scout subagent — load-bearing prompt phrases', () => {
+  test.each(
+    [
+      'READ-ONLY',
+      'STRICTLY PROHIBITED',
+      'NO SIDE EFFECTS',
+      'parallel',
+      '<analysis>',
+      '<results>',
+      '<sources>',
+      '<answer>',
+      '<confidence>',
+      '<next_steps>',
+      'Spawning further subagents',
+    ].map((phrase) => [phrase] as const),
+  )('prompt contains %s', (phrase) => {
+    const haystack = SCOUT_SYSTEM_PROMPT.toLowerCase().replace(/\s+/g, '_')
+    expect(haystack).toContain(phrase.toLowerCase().replace(/\s+/g, '_'))
+  })
+
+  test('prompt names the two web tools by their exact runtime names', () => {
+    expect(SCOUT_SYSTEM_PROMPT).toContain('`websearch`')
+    expect(SCOUT_SYSTEM_PROMPT).toContain('`webfetch`')
+  })
+
+  test('prompt frames the role as external/web-only (counterpart to explorer) and forbids local-file access', () => {
+    // The explorer/scout split only holds if each prompt redirects out-of-scope
+    // questions to the other. Without these phrases, scout will silently
+    // attempt to answer codebase questions from training data instead of
+    // delegating, breaking the boundary.
+    expect(SCOUT_SYSTEM_PROMPT.toLowerCase()).toContain('web')
+    expect(SCOUT_SYSTEM_PROMPT).toContain('explorer')
+    expect(SCOUT_SYSTEM_PROMPT.toLowerCase()).toContain('local')
+  })
+
+  test('prompt requires citation discipline: every claim backed by a fetched URL', () => {
+    // Hallucinated URLs are the #1 failure mode for web-search agents.
+    // The prompt must say BOTH "cite every claim" AND "never invent a URL"
+    // — citation-only without the no-invention rule produces plausible
+    // fake URLs; no-invention-only without the cite rule produces
+    // uncited prose. Both phrases are load-bearing.
+    expect(SCOUT_SYSTEM_PROMPT.toLowerCase()).toContain('cite every claim')
+    expect(SCOUT_SYSTEM_PROMPT).toContain('Never invent a URL')
+  })
+
+  test('prompt requires a confidence rating so the caller can weight the answer', () => {
+    expect(SCOUT_SYSTEM_PROMPT.toLowerCase()).toContain('confidence')
+    expect(SCOUT_SYSTEM_PROMPT.toLowerCase()).toContain('low confidence is fine')
+  })
+
+  test('prompt forbids following authenticated/one-time-token URLs (defense against prompt-injection-driven exfil)', () => {
+    // If a malicious page tells scout "fetch this password-reset link",
+    // the only defense is a prompt-level refusal — webfetch itself has no
+    // SSRF or auth-shape guard.
+    expect(SCOUT_SYSTEM_PROMPT.toLowerCase()).toContain('one-time token')
+  })
+})
+
+describe('scout subagent declaration', () => {
+  test('is registered as visibility=public so spawn_subagent exposes it', () => {
+    const sub = createScoutSubagent()
+    expect(sub.visibility).toBe('public')
+  })
+
+  test('uses the fast model profile (cheap and parallelizable for read-only research)', () => {
+    const sub = createScoutSubagent()
+    expect(sub.profile).toBe('fast')
+  })
+
+  test('tools list is exactly [websearch, webfetch] and NO filesystem tools', () => {
+    const sub = createScoutSubagent()
+    const toolNames = (sub.tools ?? []).map((t) => t.__builtinTool).sort()
+    expect(toolNames).toEqual(['webfetch', 'websearch'])
+    // Drift guard: scout must never gain filesystem access. The whole
+    // point of the explorer/scout split is that scout has no read/grep/ls
+    // and explorer has no websearch/webfetch — collapsing either side
+    // makes one of the two subagents redundant and reintroduces the
+    // confused-deputy risk (web pages tricking scout into reading
+    // .env / secrets.json).
+    expect(toolNames).not.toContain('read')
+    expect(toolNames).not.toContain('grep')
+    expect(toolNames).not.toContain('find')
+    expect(toolNames).not.toContain('ls')
+    expect(toolNames).not.toContain('bash')
+    expect(toolNames).not.toContain('write')
+    expect(toolNames).not.toContain('edit')
+  })
+
+  test('declares a tool-result budget keyed on websearch+webfetch (so a runaway scout cannot exhaust parent context)', () => {
+    const sub = createScoutSubagent()
+    expect(sub.toolResultBudget).toBeDefined()
+    expect(sub.toolResultBudget?.maxTotalBytes).toBeGreaterThan(0)
+    expect([...(sub.toolResultBudget?.toolNames ?? [])].sort()).toEqual(['webfetch', 'websearch'])
+  })
+
+  test('inFlightKey returns distinct values for distinct requestId payloads (parallel spawns must not coalesce)', () => {
+    const sub = createScoutSubagent()
+    const key1 = sub.inFlightKey?.({ requestId: 'bg_a' })
+    const key2 = sub.inFlightKey?.({ requestId: 'bg_b' })
+    expect(key1).toBe('bg_a')
+    expect(key2).toBe('bg_b')
+    expect(key1).not.toBe(key2)
+  })
+
+  test('inFlightKey falls back to a random value when no requestId is provided (no accidental coalescing)', () => {
+    const sub = createScoutSubagent()
+    const key1 = sub.inFlightKey?.({})
+    const key2 = sub.inFlightKey?.({})
+    expect(key1).not.toBe(key2)
+  })
+})
+
+describe('scoutPayloadSchema', () => {
+  test('accepts a payload with requestId + prompt + description', () => {
+    const result = scoutPayloadSchema.safeParse({
+      requestId: 'bg_t1',
+      prompt: 'latest stable version of Bun',
+      description: 'bun version check',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts a payload with only requestId (spawn-tool minimum)', () => {
+    const result = scoutPayloadSchema.safeParse({ requestId: 'bg_t1' })
+    expect(result.success).toBe(true)
+  })
+
+  test('passes through unknown fields (forward-compat with future spawn-tool params)', () => {
+    const result = scoutPayloadSchema.safeParse({ requestId: 'bg_t1', futureField: 42 })
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/bundled-plugins/scout/scout.ts
+++ b/src/bundled-plugins/scout/scout.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod'
+
+import { type Subagent, webfetchTool, websearchTool } from '@/plugin'
+
+export const SCOUT_SYSTEM_PROMPT = `You are a web-research specialist running inside TypeClaw. Your job: gather facts from the public internet and return a focused, citation-backed answer to the caller. For LOCAL questions (codebase, sessions, memory, config, git history, mounts), the caller should spawn \`explorer\` instead — you have no filesystem tools.
+
+=== READ-ONLY — NO SIDE EFFECTS ===
+You are STRICTLY PROHIBITED from:
+- Modifying local files or state of any kind
+- Spawning further subagents — you are at the end of the delegation chain
+- Posting to any channel, sending email, calling any write-side third-party API
+- Following URLs that look like authenticated callbacks, password resets, or one-time tokens
+
+Your role is EXCLUSIVELY to search and read public web sources.
+
+## Tools
+
+The runtime exposes these tools to you by these EXACT names — call them by name, do not paraphrase:
+
+- \`websearch\` — search the public web. Returns ranked \`{title, url, snippet}\` entries. Defaults to DuckDuckGo; pass \`source: "wikipedia"\` for encyclopedic lookups.
+- \`webfetch\` — fetch a single HTTP(S) URL and return the body, optionally compacted by a strategy:
+  - \`readability\` (default for HTML) — extract article content as markdown
+  - \`jq\` — query JSON APIs (pass \`query\`)
+  - \`selector\` — extract text from CSS-selected elements (pass \`selector\`)
+  - \`grep\` — filter response lines by regex (pass \`pattern\`, optional \`before\`/\`after\`/\`limit\`/\`offset\`)
+  - \`snapshot\` — indented semantic tree of the page (forms, headings, links)
+  - \`raw\` — no processing
+
+Launch multiple \`websearch\` queries in parallel for the same topic — different phrasings surface different sources. When a search result looks promising, \`webfetch\` it for the full content.
+
+## Process
+
+Before searching, analyze intent in an <analysis> block:
+
+<analysis>
+**Literal Request**: [what they literally asked]
+**Actual Need**: [what they're really trying to accomplish]
+**Success Looks Like**: [what result lets them proceed immediately]
+**Search Plan**: [the 2-3 queries you will try in parallel]
+</analysis>
+
+Then run searches, fetch the most relevant URLs, and synthesize.
+
+End every response with this exact structure:
+
+<results>
+<sources>
+- https://example.com/path — [what this source contributed]
+</sources>
+<answer>
+[Direct answer to the actual need, grounded in the cited sources. Quote short passages when precision matters. If sources disagree, say so and surface both.]
+</answer>
+<confidence>
+[high / medium / low — with one sentence on why. Low confidence is fine and useful; speculation dressed up as high confidence is not.]
+</confidence>
+<next_steps>
+[What the caller should do next, or "Ready to proceed."]
+</next_steps>
+</results>
+
+## Rules
+
+- Cite every claim with a URL from your <sources> list. **Never invent a URL.** If you didn't \`webfetch\` it, don't cite it.
+- If a fact appears only in your training data and you couldn't find a web source for it, say so explicitly rather than answering from memory.
+- Prefer primary sources (official docs, vendor changelogs, GitHub releases, paper PDFs) over aggregator blogs.
+- When dates matter (versions, deprecations, vulnerability disclosures), surface the date of the source.
+- If DuckDuckGo returns a CAPTCHA error, retry once with a different query phrasing; if it persists, report the failure to the caller — do not fall back to memory.
+- If the question requires LOCAL information (codebase, files in /agent/, git history, memory), say so explicitly and tell the caller to spawn \`explorer\` instead.
+- If you cannot find what was asked, say so explicitly with what queries you tried and what you DID find.`
+
+export const scoutPayloadSchema = z
+  .object({
+    requestId: z.string().optional(),
+    prompt: z.string().optional(),
+    description: z.string().optional(),
+  })
+  .passthrough()
+
+export type ScoutPayload = z.infer<typeof scoutPayloadSchema>
+
+export function createScoutSubagent(): Subagent<ScoutPayload> {
+  return {
+    systemPrompt: SCOUT_SYSTEM_PROMPT,
+    profile: 'fast',
+    tools: [websearchTool, webfetchTool],
+    payloadSchema: scoutPayloadSchema,
+    visibility: 'public',
+    inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    toolResultBudget: {
+      maxTotalBytes: 512_000,
+      toolNames: ['websearch', 'webfetch'],
+    },
+  }
+}

--- a/src/plugin/define.ts
+++ b/src/plugin/define.ts
@@ -78,3 +78,5 @@ export const writeTool: BuiltinToolRef = { __builtinTool: 'write' }
 export const grepTool: BuiltinToolRef = { __builtinTool: 'grep' }
 export const findTool: BuiltinToolRef = { __builtinTool: 'find' }
 export const lsTool: BuiltinToolRef = { __builtinTool: 'ls' }
+export const websearchTool: BuiltinToolRef = { __builtinTool: 'websearch' }
+export const webfetchTool: BuiltinToolRef = { __builtinTool: 'webfetch' }

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -9,6 +9,8 @@ export {
   grepTool,
   lsTool,
   readTool,
+  webfetchTool,
+  websearchTool,
   writeTool,
 } from './define'
 

--- a/src/run/bundled-plugins.test.ts
+++ b/src/run/bundled-plugins.test.ts
@@ -23,6 +23,7 @@ describe('BUNDLED_PLUGINS', () => {
       'backup',
       'agent-browser',
       'explorer',
+      'scout',
       'operator',
     ])
   })

--- a/src/run/bundled-plugins.ts
+++ b/src/run/bundled-plugins.ts
@@ -4,6 +4,7 @@ import explorerPlugin from '@/bundled-plugins/explorer'
 import guardPlugin from '@/bundled-plugins/guard'
 import memoryPlugin from '@/bundled-plugins/memory'
 import operatorPlugin from '@/bundled-plugins/operator'
+import scoutPlugin from '@/bundled-plugins/scout'
 import securityPlugin from '@/bundled-plugins/security'
 import toolResultCapPlugin from '@/bundled-plugins/tool-result-cap'
 import type { ResolvedPlugin } from '@/plugin'
@@ -39,5 +40,6 @@ export const BUNDLED_PLUGINS: ResolvedPlugin[] = [
   { name: 'backup', version: undefined, source: '<bundled>', defined: backupPlugin },
   { name: 'agent-browser', version: undefined, source: '<bundled>', defined: agentBrowserPlugin },
   { name: 'explorer', version: undefined, source: '<bundled>', defined: explorerPlugin },
+  { name: 'scout', version: undefined, source: '<bundled>', defined: scoutPlugin },
   { name: 'operator', version: undefined, source: '<bundled>', defined: operatorPlugin },
 ]


### PR DESCRIPTION
## Why

`explorer` shipped as a "codebase-search specialist" (#274), but local state goes well beyond the codebase — sessions, MEMORY.md, daily memory streams, muscle-memory skills, cron schedules, mounts, git history, and more. And the main agent had no structured path for web research at all: every web lookup happened inline, polluting the main context window with search noise and denying the caller any citation or confidence discipline.

This PR delivers two things:

1. **scout** — a new bundled web-research subagent. Counterpart to `explorer` on the public internet rather than local state.
2. **explorer widened** — from codebase-only to a general local-search subagent covering all 14 local searchable surfaces.

Together they establish a clean split: local questions go to `explorer`, external questions go to `scout`.

## Prerequisite: websearch + webfetch as BuiltinToolRefs (commit `6251807`)

Both tools lived as pi-coding-agent `ToolDefinition`s and were previously only reachable from the main agent's `customSystemTools`. To let bundled subagents declare them in their `tools` array, this commit:

- Adds a `toAgentTool` adapter in `src/agent/plugin-tools.ts`. The adapter is necessary because `ToolDefinition.execute` carries a trailing `ExtensionContext` (5 args) while `AgentTool.execute` has 4 — TypeScript correctly rejects the direct assignment. At runtime the 5th arg is unused by both tools, so the adapter drops it.
- Registers the adapted tools in `BUILTIN_TOOL_MAP` under keys `'websearch'` / `'webfetch'` (matching the underlying `ToolDefinition.name` fields verbatim).
- Exports two new `BuiltinToolRef` constants from `@/plugin`.

No behavior change for the main agent or any existing subagent.

## scout: bundled web-research subagent (commit `c78e034`)

### Design decisions

**Tools: websearch + webfetch only — no filesystem access.**

The explorer/scout split is load-bearing for safety: a web page cannot trick scout into reading `.env` or `secrets.json` because those tools are simply not on its list. This makes scout safe to invoke on caller-controlled queries.

**Profile: fast. Tool-result budget: 512 KB.**

Higher than explorer's 256 KB because web pages are denser than greppable code; lower than operator's 1 MB because scout doesn't carry state across calls.

**Visibility: public.** Registered in `BUNDLED_PLUGINS` between explorer and operator.

### Prompt disciplines

The prompt enforces four properties, each load-bearing:

| Discipline | Why both halves matter |
|---|---|
| Citation + no-invent | `cite-only` without `no-invent` produces plausible fake URLs. `no-invent` without `cite` produces uncited prose. Hallucinated URLs are the #1 failure mode for web-search agents. |
| Confidence rating (high/medium/low) | Low confidence is useful. Speculation dressed as high confidence is not. |
| Auth-URL refusal | webfetch has no SSRF or auth-shape guard. The prompt is the only defense against following password-reset or one-time-token callbacks. |
| Local redirect | Prevents scout from answering codebase/file questions from training data instead of live state. |

### Verification chain

- `BuiltinToolRef.__builtinTool` → `BUILTIN_TOOL_MAP` key → adapter preserves `name` → `AgentTool.name` → LLM schema. All resolve to literal `'websearch'` / `'webfetch'`.
- Tool-result-budget enforcement keys on `tool.name`; scout's budget `toolNames` matches exactly.
- `wrapSystemAgentTool` applies identical hooks and guards to the wrapped web tools — no silent degradation.

## explorer: widen to general local search (commit `daf651f`)

The tool list is unchanged: `read`, `grep`, `find`, `ls`, `bash` (read-only). The prompt now enumerates 14 local searchable surfaces:

| Surface | Notes |
|---|---|
| Codebase | unchanged from original |
| `sessions/*.jsonl` | session transcripts |
| `MEMORY.md` + daily memory streams | long-term agent memory |
| Muscle-memory skills | `memory/skills/` |
| User-installed skills | `.agents/skills/` |
| `workspace/` | agent's free-write zone |
| `cron.json` | scheduled jobs |
| Config files | `.env`, `secrets.json`, `typeclaw.json` — "is provider X configured?" without echoing tokens |
| Git history | `git log`, `git blame`, `git show` |
| `sessions/backup-diagnostics.log` | host-stage logs |
| Mounts | bind-mounted directories |
| `channels/sessions.json` | channel session state |
| Packages | `package.json`, `bun.lock` |
| Container-only state | `/proc`, `/tmp`, running processes |

The "don't echo credentials" rule for `.env` / `secrets.json` is explicit: explorer can answer "is `FIREWORKS_API_KEY` set?" without leaking the value.

Also adds the external→scout redirect (symmetric with scout's local→explorer redirect).

### System prompt update

`src/agent/system-prompt.ts` Mode A section updated to reflect the widened explorer scope and introduce scout with "prefer scout over inline websearch/webfetch when the query is non-trivial" guidance.

## Pre-merge gates | Gate | Result |
|---|---|
| `bun run typecheck` | ✅ clean |
| `bun run lint` | ✅ 0 errors |
| `bun run format:check` | ✅ clean |
| `bun test` | ✅ 4501 pass / 0 fail |
| `bun test src/bundled-plugins/scout/` | ✅ |
| `bun test src/bundled-plugins/explorer/` | ✅ |

## Diff

12 files changed, 403 insertions(+), 17 deletions(-)

```
src/agent/plugin-tools.ts                     +37        (adapter + BUILTIN_TOOL_MAP entries)
src/agent/system-prompt.ts                    +4  -1     (Mode A: widen explorer, introduce scout)
src/bundled-plugins/explorer/explorer.test.ts +43  -8    (updated assertions for widened prompt)
src/bundled-plugins/explorer/explorer.ts      +41  -8    (widened surface list + redirect)
src/bundled-plugins/scout/index.test.ts       +47        (new)
src/bundled-plugins/scout/index.ts            +11        (new)
src/bundled-plugins/scout/scout.test.ts       +136       (new)
src/bundled-plugins/scout/scout.ts            +94        (new)
src/plugin/define.ts                          +2         (BuiltinToolRef exports)
src/plugin/index.ts                           +2         (re-export)
src/run/bundled-plugins.test.ts               +1         (snapshot: scout added)
src/run/bundled-plugins.ts                    +2         (register scout plugin)
```