### PR TITLE
channels: suppress upstream thinking-block sentinel before it reaches channel readers

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -353,6 +353,44 @@ describe('createChannelReplyTool', () => {
     })
   })
 
+  describe('upstream empty-response sentinel guard', () => {
+    test('blocks `(Empty response: {...stop_reason...})` so thinking content + signature never reach the channel', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, {
+        text:
+          "(Empty response: {'content': [{'type': 'thinking', 'thinking': 'leak', " +
+          "'signature': 'EpQC...'}], 'stop_reason': 'end_turn'})",
+      })
+      expect(calls).toHaveLength(0)
+      expect(result.details).toMatchObject({ ok: false })
+      expect((result.details as { error: string }).error).toContain('Empty response')
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toContain('channel_reply denied')
+      expect(text).not.toContain('posted to')
+    })
+
+    test('does NOT block legit prose mentioning "Empty response" without the python-dict shape', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, { text: 'Empty response from the cache layer; retrying now.' })
+      expect(calls).toHaveLength(1)
+      expect(result.details).toEqual({ ok: true })
+    })
+  })
+
   describe('structured router failures surface as denials', () => {
     test('duplicate code from router renders as channel_reply denied with router error text', async () => {
       const tool = createChannelReplyTool({

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -1,7 +1,7 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
-import { isNoReplySignal, type ChannelRouter } from '@/channels/router'
+import { isNoReplySignal, isUpstreamEmptyResponseSentinel, type ChannelRouter } from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
 
 import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
@@ -86,6 +86,15 @@ export function createChannelReplyTool({
         return {
           content: [{ type: 'text' as const, text: `channel_reply denied: ${noReplyError}` }],
           details: { ok: false, error: noReplyError },
+        }
+      }
+
+      const upstreamSentinelError = upstreamEmptyResponseSentinelError(text)
+      if (upstreamSentinelError) {
+        logger.warn(formatChannelToolFailure('channel_reply', upstreamSentinelError))
+        return {
+          content: [{ type: 'text' as const, text: `channel_reply denied: ${upstreamSentinelError}` }],
+          details: { ok: false, error: upstreamSentinelError },
         }
       }
 
@@ -185,6 +194,20 @@ function noReplyMisuseError(text: string | undefined): string {
     '`NO_REPLY` is the silent-turn signal, not a message body. ' +
     'To stay silent, end your turn with `NO_REPLY` as your entire visible response and NO channel tool call. ' +
     'To send an actual reply, call this tool again with different text.'
+  )
+}
+
+// Mirror of the same guard used by channel_send. Blocks the upstream
+// `(Empty response: ...)` debug sentinel from being sent verbatim — that
+// payload carries the model's thinking content and signature, never a
+// real user-facing message.
+function upstreamEmptyResponseSentinelError(text: string | undefined): string {
+  if (text === undefined) return ''
+  if (!isUpstreamEmptyResponseSentinel(text)) return ''
+  return (
+    'refusing to forward an upstream `(Empty response: ...)` sentinel; ' +
+    "that string is a provider-SDK debug dump containing the model's thinking content and signature, " +
+    'not a message body. End your turn silently (visible text empty or `NO_REPLY`) instead.'
   )
 }
 

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -431,6 +431,68 @@ describe('createChannelSendTool', () => {
     })
   })
 
+  describe('upstream empty-response sentinel guard', () => {
+    test('blocks `(Empty response: {...stop_reason...})` so thinking content + signature never reach the channel', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+      const result = await runTool(tool, {
+        adapter: 'slack-bot',
+        workspace: 'T0',
+        chat: 'C0',
+        text:
+          "(Empty response: {'content': [{'type': 'thinking', 'thinking': 'leak', " +
+          "'signature': 'EpQC...'}], 'stop_reason': 'end_turn'})",
+      })
+      expect(calls).toHaveLength(0)
+      expect(result.details).toMatchObject({ ok: false })
+      expect((result.details as { error: string }).error).toContain('Empty response')
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toContain('channel_send denied')
+      expect(text).not.toContain('posted to')
+    })
+
+    test('does NOT block legit prose mentioning "Empty response" without the python-dict shape', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+      const result = await runTool(tool, {
+        adapter: 'slack-bot',
+        workspace: 'T0',
+        chat: 'C0',
+        text: 'Empty response from the cache layer; retrying now.',
+      })
+      expect(calls).toHaveLength(1)
+      expect(result.details).toEqual({ ok: true })
+    })
+
+    test('does NOT block when the sentinel substring appears mid-message', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+      const result = await runTool(tool, {
+        adapter: 'slack-bot',
+        workspace: 'T0',
+        chat: 'C0',
+        text: "I saw the line `(Empty response: {'stop_reason': 'end_turn'})` in the logs; investigating.",
+      })
+      expect(calls).toHaveLength(1)
+      expect(result.details).toEqual({ ok: true })
+    })
+  })
+
   describe('structured router failures surface as denials', () => {
     test('duplicate code from router renders as channel_send denied with router error text', async () => {
       const tool = createChannelSendTool({

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -1,7 +1,7 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
-import { isNoReplySignal, type ChannelRouter } from '@/channels/router'
+import { isNoReplySignal, isUpstreamEmptyResponseSentinel, type ChannelRouter } from '@/channels/router'
 import { ADAPTER_IDS, type AdapterId } from '@/channels/schema'
 
 import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
@@ -112,6 +112,15 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
         }
       }
 
+      const upstreamSentinelError = upstreamEmptyResponseSentinelError(bodyText)
+      if (upstreamSentinelError) {
+        logger.warn(formatChannelToolFailure('channel_send', upstreamSentinelError))
+        return {
+          content: [{ type: 'text' as const, text: `channel_send denied: ${upstreamSentinelError}` }],
+          details: { ok: false, error: upstreamSentinelError },
+        }
+      }
+
       const result = await router.send({
         adapter,
         workspace: params.workspace,
@@ -205,6 +214,22 @@ function noReplyMisuseError(text: string | undefined): string {
     '`NO_REPLY` is the silent-turn signal, not a message body. ' +
     'To stay silent, end your turn with `NO_REPLY` as your entire visible response and NO channel tool call. ' +
     'To send an actual reply, call this tool again with different text.'
+  )
+}
+
+// Defense-in-depth mirror of the recovery-path guard in router.ts. Blocks
+// the upstream "(Empty response: {...})" sentinel from being sent verbatim
+// as a channel message — the body of that sentinel carries the model's
+// thinking content and Anthropic's tamper-proof signature, which must
+// never reach a channel reader. Shape detection lives in
+// `isUpstreamEmptyResponseSentinel` so all call sites stay in lockstep.
+function upstreamEmptyResponseSentinelError(text: string | undefined): string {
+  if (text === undefined) return ''
+  if (!isUpstreamEmptyResponseSentinel(text)) return ''
+  return (
+    'refusing to forward an upstream `(Empty response: ...)` sentinel; ' +
+    "that string is a provider-SDK debug dump containing the model's thinking content and signature, " +
+    'not a message body. End your turn silently (visible text empty or `NO_REPLY`) instead.'
   )
 }
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1162,6 +1162,55 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sent).toHaveLength(0)
   })
 
+  test('suppresses upstream `(Empty response: ...)` sentinel instead of leaking thinking/signature', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      // given: the upstream provider SDK fabricated a single text block whose
+      // body is a Python-repr dump of the raw API response (observed shape
+      // verbatim from the 2026-05-21 production leak — thinking content +
+      // Anthropic signature inlined).
+      sessions[0]!.setAssistantText(
+        "(Empty response: {'content': [{'type': 'thinking', 'thinking': 'no need', " +
+          "'signature': 'EpQCCkYI...'}], 'stop_reason': 'end_turn', 'model': 'claude-opus-4-5'})",
+      )
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('suppressed upstream_empty_response_sentinel'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('still recovers legit prose that happens to mention "Empty response" without the python-dict shape', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('Empty response from the cache layer, retrying.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toEqual([{ text: 'Empty response from the cache layer, retrying.' }])
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(true)
+    expect(logs.some((m) => m.includes('suppressed upstream_empty_response_sentinel'))).toBe(false)
+  })
+
   test('recovers visible assistant text when no channel tool sent a message', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1613,6 +1613,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return
     }
 
+    if (isUpstreamEmptyResponseSentinel(assistantText)) {
+      logger.warn(
+        `[channels] ${live.keyId}: suppressed upstream_empty_response_sentinel text_len=${assistantText.length}`,
+      )
+      return
+    }
+
     logger.warn(
       `[channels] ${live.keyId}: recovering assistant_text_without_channel_tool text_len=${assistantText.length}`,
     )
@@ -1998,6 +2005,31 @@ export function isNoReplySignal(text: string): boolean {
   if (trimmed === 'NO_REPLY') return true
   if (trimmed === '(NO_REPLY)') return true
   return false
+}
+
+// Detects the upstream "empty response" debug sentinel: when the LLM ends a
+// turn with only a `thinking` block, some provider SDK paths (observed
+// against claude-opus-4-5 via pi-ai) fabricate a single text block whose
+// body is a Python-repr dump of the raw API response — including the
+// model's thinking content and Anthropic's tamper-proof signature. The
+// recovery path in validateChannelTurn would otherwise post that sentinel
+// straight to the channel (production: signature leaked into a public
+// Slack channel on 2026-05-21).
+//
+// Kept separate from isNoReplySignal on purpose: that helper is the agent's
+// deliberate silent-turn protocol, this is upstream damage control. They
+// log under distinct subjects (`upstream_empty_response_sentinel` vs
+// `no_reply`) so an operator can tell a healthy quiet turn from a stream of
+// upstream empties that warrant investigation.
+//
+// Strict detection: leading `(Empty response:` AND a dict-encoded
+// `'stop_reason'` key. Catches the observed shape
+// `(Empty response: {'content': [...], 'stop_reason': 'end_turn', ...})`
+// while allowing legit prose like "Empty response from the cache layer".
+export function isUpstreamEmptyResponseSentinel(text: string): boolean {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith('(Empty response:')) return false
+  return trimmed.includes("'stop_reason'")
 }
 
 function describe(err: unknown): string {


### PR DESCRIPTION
## Incident

A real Anthropic thinking-block signature leaked into a public Slack channel on 2026-05-21.

## Failure mode

When the LLM ends a turn carrying only a `thinking` block (no text, no tool call), some upstream provider-SDK paths fabricate a single text block whose body is a Python-repr dump of the raw API response — including the model's thinking content and Anthropic's tamper-proof signature. The fabricated string looks like:

```
(Empty response: {'content': [{'type': 'thinking', 'thinking': '...', 'signature': 'EpQC...'}], 'stop_reason': 'end_turn', 'model': 'claude-opus-4-5-20251101', 'usage': {...}})
```

`validateChannelTurn` in `src/channels/router.ts` saw that as the assistant's reply text and posted it verbatim through the `assistant_text_without_channel_tool` recovery path. No guard existed to distinguish a real assistant turn from an upstream debug dump.

## Fix (two commits)

**Commit `0a6fa01` — recovery path (production leak, closes the incident).**

Adds `isUpstreamEmptyResponseSentinel(text)` to `src/channels/router.ts` and short-circuits `validateChannelTurn` before the recovery post. Logged under `suppressed upstream_empty_response_sentinel` (distinct from the healthy `no_reply` subject) so an operator can tell a quiet-turn from a stream of upstream empties that warrant investigation.

**Commit `f1175c3` — tool layer (defense-in-depth).**

Mirrors the same guard in `channel_send` and `channel_reply`. A well-behaved model never calls a channel tool with this sentinel as the `text` argument, but it has been observed quoting it verbatim when reasoning out loud. The tool-layer denial is a second independent barrier — it fires even if the recovery-path guard were somehow bypassed, and it surfaces a clear denial message back to the model rather than a silent drop.

The two commits were kept separate and independent: each typechecks and passes tests on its own. The recovery path is the one that closed the production leak; the tool layer is defense-in-depth.

## Why not fold into `isNoReplySignal`

`isNoReplySignal` documents the agent's deliberate silent-turn protocol (`NO_REPLY`, `(NO_REPLY)`, empty visible text). This new guard is upstream damage control — a string the agent never intentionally produces. Collapsing them would make the log unreadable for operators: a healthy `(NO_REPLY)` turn and a `(Empty response: ...)` sentinel warrant different responses (the first is fine, the second warrants checking whether the provider is regressing).

## Detection boundary

`isUpstreamEmptyResponseSentinel` returns `true` only when the trimmed text starts with literal `(Empty response:` AND contains `'stop_reason'` (Python-dict single-quoted form). That combination has essentially zero false-positives against legit prose: "Empty response from the cache layer" does not start with the prefix and does not contain `'stop_reason'`, so it remains recoverable. Negative tests pin this boundary at all three call sites (router, `channel_send`, `channel_reply`).

## Relation to `cbf6abe`

`cbf6abe` (`session-origin: discipline the channel agent toward one reply per inbound`) addresses a different angle of the same production incident — the two consecutive bot bubbles per inbound. This PR is the complementary fix for the specific info-leak failure mode: the fabricated sentinel that was already in the model context and forwarded by the recovery path. The two fixes are orthogonal and stacked cleanly; this branch rebased on top of `cbf6abe` without conflict.

## Pre-merge gates

| Gate | Result |
|---|---|
| `bun run typecheck` | ✅ clean |
| `bun run lint` | ✅ 0 errors (18 pre-existing warnings, none in changed files) |
| `bun run format:check` | ✅ clean |
| `bun test` | ✅ 4509 pass, 0 fail (5 new tests: suppression in `validateChannelTurn`, denial in `channel_send` and `channel_reply`, false-positive boundary at each call site) |

## Mutation test

Commenting out the new guard in `validateChannelTurn` causes the router test to fail with `Expected length: 0, Received length: 1` on the production-shape payload. The guard is load-bearing, not decorative.

## Diff

6 files changed, 231 insertions(+), 2 deletions(-):

```
src/channels/router.ts                   +32   (isUpstreamEmptyResponseSentinel, validateChannelTurn guard)
src/agent/tools/channel-send.ts          +26 -1 (upstreamEmptyResponseSentinelError guard + helper)
src/agent/tools/channel-reply.ts         +24 -1 (same, mirrored)
src/channels/router.test.ts              +49   (suppression + false-positive boundary)
src/agent/tools/channel-send.test.ts     +62   (denial + false-positive boundary)
src/agent/tools/channel-reply.test.ts    +38   (denial + false-positive boundary)
```