### PR TITLE
subagents: fix registry shim dropping visibility and requiresSpecificPermission

### DIFF
--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -19,19 +19,40 @@ export type SubagentContext<P = unknown> = {
 
 export type RunSession = (override?: { userPrompt?: string }) => Promise<void>
 
-export type Subagent<P = unknown> = {
+// Fields shared verbatim between the plugin-author-facing `Subagent` in
+// `@/plugin/types` and the runtime-internal `Subagent` below. Every consumer
+// that reads from `SubagentRegistry` (the spawn_subagent tool, payload
+// validation, default session construction) only touches these fields, so
+// keeping them in a single declaration makes the plugin→internal shim a
+// rest-spread instead of a hand-maintained property list. Adding a new field
+// here surfaces it on both types in one edit, which is the regression class
+// the previous shim shape suffered: `visibility` and `requiresSpecificPermission`
+// existed on the plugin type but were silently dropped by the shim, so every
+// plugin-contributed public subagent appeared internal at the registry layer.
+//
+// The two fields that intentionally diverge — `tools` and `customTools` —
+// live on each concrete `Subagent` type below. The plugin side uses
+// `BuiltinToolRef[]` + `Tool<any>[]` (the public plugin API, decoupled from
+// pi-coding-agent's internal tool shape); the internal side uses the resolved
+// `AgentSessionTools` + `ToolDefinition[]` that pi-coding-agent actually
+// consumes. The boundary is real and load-bearing — collapsing it would
+// expose pi-coding-agent's internal API as part of the plugin contract.
+export type SubagentShared<P = unknown> = {
   systemPrompt: string
   // Model profile this subagent prefers. Resolved against `config.models` at
   // session construction. Unknown profile names fall back to `default` with
   // a warning. See `Subagent` in `@/plugin/types` for the full contract.
   profile?: string
-  tools?: AgentSessionTools
-  customTools?: ToolDefinition[]
   payloadSchema?: z.ZodType<P>
   handler?: (ctx: SubagentContext<P>, runSession: RunSession) => Promise<void>
   toolResultBudget?: ToolResultBudget
   visibility?: 'public' | 'internal'
   requiresSpecificPermission?: boolean
+}
+
+export type Subagent<P = unknown> = SubagentShared<P> & {
+  tools?: AgentSessionTools
+  customTools?: ToolDefinition[]
 }
 
 export type SubagentRegistry = Readonly<Record<string, Subagent<any>>>

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -1,7 +1,7 @@
 import type { z } from 'zod'
 
 import type { SessionOrigin } from '@/agent/session-origin'
-import type { ToolResultBudget } from '@/agent/tool-result-budget'
+import type { SubagentShared } from '@/agent/subagents'
 import type { PermissionService } from '@/permissions'
 
 export type ContentPart = { type: 'text'; text: string } | { type: 'image'; mimeType: string; data: string }
@@ -40,61 +40,28 @@ export type SubagentContext<P = unknown> = {
 
 export type RunSession = (override?: { userPrompt?: string }) => Promise<void>
 
-export type Subagent<P = unknown> = {
-  systemPrompt: string
-  // Model profile this subagent prefers. Resolved against `models` in
-  // typeclaw.json at session construction. Unknown profile names fall back to
-  // `default` with a warning. Well-known names: `default`, `fast`, `deep`,
-  // `vision`. Subagents that want a specific tier (e.g. memory-logger wants
-  // `fast`, dreaming wants `deep`) declare it here so the user only has to
-  // map tier → model in config rather than wire each subagent individually.
-  profile?: string
+// The plugin-author-facing subagent declaration. Differs from
+// `@/agent/subagents`'s `Subagent` only in the shape of `tools`/`customTools`:
+// plugins reference builtin tools via tagged `BuiltinToolRef` strings (the
+// stable plugin API) and contribute their own `Tool<any>[]`; the runtime
+// resolves those refs to pi-coding-agent's wrapped tool shapes before the
+// session sees them. Every other field is inherited from `SubagentShared`
+// so a new shared field surfaces on both types in one edit. See
+// `SubagentShared`'s doc-comment for the regression history.
+//
+// `inFlightKey` lives here only (not on the shared shape) because it is
+// consumed exclusively by the `SubagentConsumer` via the
+// `pluginSubagentByName` map, which holds the original plugin reference —
+// the registry-flowing shim never needs to carry it.
+export type Subagent<P = unknown> = SubagentShared<P> & {
   tools?: BuiltinToolRef[]
   customTools?: Tool<any>[]
-  payloadSchema?: z.ZodType<P>
-  handler?: (ctx: SubagentContext<P>, runSession: RunSession) => Promise<void>
   // Coalescing key for the SubagentConsumer's in-flight set. Default is the
   // subagent name alone (only one instance of the subagent runs at a time).
   // Override to allow per-payload concurrency, e.g. memory-logger keyed by
   // parentSessionId so different parent sessions run in parallel while
   // duplicate runs against the same session deduplicate.
   inFlightKey?: (payload: P) => string
-  // Defensive ceiling on cumulative bytes of tool-result text per subagent
-  // run, applied to the named tools only. Once exceeded, subsequent calls to
-  // those tools short-circuit with a fixed message instructing the agent to
-  // stop reading. See `src/agent/tool-result-budget.ts` for the full
-  // rationale; the short version is: a single broken tool (e.g. find_entry
-  // failing because of a schema mismatch) can cause an agent to fall back to
-  // chunked reads of huge files, ballooning subagent token cost. The budget
-  // bounds the blast radius without changing per-call semantics for healthy
-  // runs.
-  toolResultBudget?: ToolResultBudget
-  // Whether the LLM-driven main agent can invoke this subagent via the
-  // `spawn_subagent` tool.
-  // - 'internal' (default): only invokable via cron jobs, plugin lifecycle
-  //   hooks, or programmatic `ctx.spawnSubagent` calls. The main agent does
-  //   NOT see this subagent in its tool surface. Existing bundled subagents
-  //   (memory-logger, dreaming, backup, backup-message, backup-diagnose)
-  //   omit this field and therefore remain internal — they are infrastructure,
-  //   not orchestration targets, and accidentally exposing a write-capable
-  //   one (e.g. `backup` mutates git history) to agent-initiated invocation
-  //   would be a real footgun.
-  // - 'public': exposed to the main agent via `spawn_subagent`. The agent
-  //   can decide mid-conversation to invoke this subagent. Reserved for
-  //   subagents explicitly designed as orchestration targets (e.g. explorer,
-  //   operator). The default is 'internal' specifically so adding a new
-  //   bundled subagent never accidentally widens the agent-facing surface.
-  visibility?: 'public' | 'internal'
-  // Whether spawning this subagent requires a per-subagent permission of
-  // the form `subagent.spawn.<name>`, rather than the generic
-  // `subagent.spawn`. Default false: the generic spawn permission is
-  // sufficient (suitable for read-only / cheap subagents like explorer).
-  // Set true for subagents whose blast radius warrants a separate gate
-  // (the bundled operator is write-capable, so its spawn permission must
-  // NOT be implied by the generic permission held by every channel
-  // member). When true, the spawn tool checks ONLY the per-subagent
-  // permission and never falls back to the generic.
-  requiresSpecificPermission?: boolean
 }
 
 // Cron job map keys are local; the runtime prefixes with `__plugin_<plugin-name>_`

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -10,6 +10,7 @@ import {
   type Subagent as InternalSubagent,
   type SubagentConsumer,
   type SubagentRegistry,
+  type SubagentShared,
 } from '@/agent/subagents'
 import { resolveCapOptionsFromConfig } from '@/bundled-plugins/tool-result-cap'
 import { createChannelManager, createChannelsReloadable, type ChannelManager } from '@/channels'
@@ -637,6 +638,26 @@ export function mergeSubagents(pluginRegistry: PluginRegistry): {
   return { registry: merged, pluginSubagentByShim, pluginSubagentByName }
 }
 
+// Compile-time proof that every plugin-only key on `@/plugin`'s `Subagent`
+// (i.e. every key NOT inherited from `SubagentShared`) has been classified
+// for the shim. When a future maintainer introduces a new field on plugin-side
+// `Subagent` that isn't on `SubagentShared`, the `satisfies` clause on
+// `PLUGIN_ONLY_KEYS_DROPPED_BY_SHIM` below fails at compile time until the
+// new key is listed there — and the destructuring in `pluginSubagentShim`
+// is updated to discard it. Without this guard, the shim's rest-spread
+// would silently leak future plugin-only fields into the internal registry —
+// the opposite-direction drift from the bug this PR fixes for shared fields.
+type PluginOnlySubagentKeys = Exclude<keyof import('@/plugin').Subagent<any>, keyof SubagentShared<any>>
+const PLUGIN_ONLY_KEYS_DROPPED_BY_SHIM = {
+  tools: true,
+  customTools: true,
+  inFlightKey: true,
+} satisfies Record<PluginOnlySubagentKeys, true>
+// Reference the table so it's not dead code. The value is a runtime no-op;
+// the load-bearing work is the `satisfies` clause above which forces
+// exhaustive classification of plugin-only keys at compile time.
+void PLUGIN_ONLY_KEYS_DROPPED_BY_SHIM
+
 function pluginSubagentShim(subagent: import('@/plugin').Subagent<any>): InternalSubagent<any> {
   // The two diverging fields (`tools` is `BuiltinToolRef[]` plugin-side vs
   // `AgentSessionTools` internal-side; `customTools` similarly differs) are
@@ -649,7 +670,8 @@ function pluginSubagentShim(subagent: import('@/plugin').Subagent<any>): Interna
   // verbatim — including `visibility` and `requiresSpecificPermission`,
   // whose silent drop in the previous shim made every plugin-contributed
   // public subagent (scout, explorer, operator) invisible to the
-  // `spawn_subagent` tool.
+  // `spawn_subagent` tool. The list of keys removed here is enforced
+  // exhaustive at compile time by `PLUGIN_ONLY_KEYS_DROPPED_BY_SHIM` above.
   const { tools: _tools, customTools: _customTools, inFlightKey: _inFlightKey, ...shared } = subagent
   return shared
 }

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -602,7 +602,15 @@ function makeDefaultSchedulerFactory(internalJobs: () => CronJob[]): SchedulerFa
   return ({ file, onFire }) => createScheduler({ jobs: [...file.jobs, ...internalJobs()], onFire })
 }
 
-function mergeSubagents(pluginRegistry: PluginRegistry): {
+// Exported for the regression test in `merge-subagents.test.ts`. The shim
+// layer between the plugin-author-facing `Subagent` (`@/plugin/types`) and
+// the runtime-internal `Subagent` (`@/agent/subagents`) is the load-bearing
+// translation point for visibility, payload-schema, and permission gating —
+// fields that flow through the `SubagentRegistry` without going through the
+// `pluginSubagentByShim` recovery path. Previous regressions silently
+// dropped fields here, hiding every public bundled subagent (scout,
+// explorer, operator) from the `spawn_subagent` tool surface.
+export function mergeSubagents(pluginRegistry: PluginRegistry): {
   registry: SubagentRegistry
   pluginSubagentByShim: WeakMap<InternalSubagent<any>, PluginSubagentEntry>
   pluginSubagentByName: Map<string, PluginSubagentEntry>
@@ -630,9 +638,18 @@ function mergeSubagents(pluginRegistry: PluginRegistry): {
 }
 
 function pluginSubagentShim(subagent: import('@/plugin').Subagent<any>): InternalSubagent<any> {
-  return {
-    systemPrompt: subagent.systemPrompt,
-    ...(subagent.payloadSchema ? { payloadSchema: subagent.payloadSchema } : {}),
-    ...(subagent.handler ? { handler: subagent.handler as InternalSubagent<any>['handler'] } : {}),
-  }
+  // The two diverging fields (`tools` is `BuiltinToolRef[]` plugin-side vs
+  // `AgentSessionTools` internal-side; `customTools` similarly differs) are
+  // resolved later in `createSessionForSubagent` via the
+  // `pluginSubagentByShim` lookup, which recovers the original plugin
+  // reference. `inFlightKey` is consumed only by the SubagentConsumer via
+  // `pluginSubagentByName`, not through this shim's registry path. Every
+  // other plugin-side field lives on `SubagentShared` and is structurally
+  // assignable to the internal `Subagent`, so a rest-spread carries them
+  // verbatim — including `visibility` and `requiresSpecificPermission`,
+  // whose silent drop in the previous shim made every plugin-contributed
+  // public subagent (scout, explorer, operator) invisible to the
+  // `spawn_subagent` tool.
+  const { tools: _tools, customTools: _customTools, inFlightKey: _inFlightKey, ...shared } = subagent
+  return shared
 }

--- a/src/run/merge-subagents.test.ts
+++ b/src/run/merge-subagents.test.ts
@@ -151,6 +151,40 @@ describe('mergeSubagents', () => {
     expect(pluginSubagentByName.get('roundtrip')?.pluginSubagent).toBe(plugin)
   })
 
+  test('drops tools, customTools, and inFlightKey from the registry-visible shim', () => {
+    // The shim must NOT carry plugin-only fields through to the internal
+    // registry. `tools` and `customTools` have different shapes on each side
+    // (BuiltinToolRef[] vs AgentSessionTools, Tool<any>[] vs ToolDefinition[]),
+    // so they get resolved later via the pluginSubagentByShim WeakMap.
+    // `inFlightKey` is consumed only by the SubagentConsumer via
+    // pluginSubagentByName, not through the registry path. Confirming these
+    // are absent on the shim pins the negative boundary so the rest-spread
+    // can't silently leak a future plugin-only field into the internal type.
+    const registry = registerSubagent(emptyRegistry(), 'rich', {
+      systemPrompt: 'fake',
+      visibility: 'public',
+      tools: [{ __builtinTool: 'read' }],
+      customTools: [
+        {
+          description: 'noop',
+          parameters: z.object({}),
+          execute: async () => ({ content: [] }),
+        },
+      ],
+      inFlightKey: () => 'k',
+    })
+
+    const { registry: merged } = mergeSubagents(registry)
+    const shim = merged.rich
+    if (shim === undefined) throw new Error('shim missing from merged registry')
+
+    expect(Object.hasOwn(shim, 'tools')).toBe(false)
+    expect(Object.hasOwn(shim, 'customTools')).toBe(false)
+    expect(Object.hasOwn(shim, 'inFlightKey')).toBe(false)
+    expect(Object.hasOwn(shim, 'visibility')).toBe(true)
+    expect(Object.hasOwn(shim, 'systemPrompt')).toBe(true)
+  })
+
   test('rejects duplicate subagent names across plugins', () => {
     const registry = emptyRegistry()
     registry.subagents.push({ pluginName: 'a', subagentName: 'dup', subagent: { systemPrompt: 'a' } })

--- a/src/run/merge-subagents.test.ts
+++ b/src/run/merge-subagents.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test'
+
+import { z } from 'zod'
+
+import type { PluginRegistry, Subagent as PluginSubagent } from '@/plugin'
+
+import { mergeSubagents } from './index'
+
+function emptyRegistry(): PluginRegistry {
+  return {
+    tools: [],
+    subagents: [],
+    cronJobs: [],
+    skills: [],
+    skillsDirs: [],
+    doctorChecks: [],
+    commands: [],
+  }
+}
+
+function registerSubagent(reg: PluginRegistry, name: string, subagent: PluginSubagent<any>): PluginRegistry {
+  reg.subagents.push({ pluginName: 'test-plugin', subagentName: name, subagent })
+  return reg
+}
+
+describe('mergeSubagents', () => {
+  test('preserves visibility:public so spawn_subagent surfaces plugin-contributed public subagents', () => {
+    // given — the exact scout/explorer/operator regression: a plugin
+    // contributing a public subagent. Before the shim refactor, this field
+    // was silently dropped during merge, making the registered subagent
+    // indistinguishable from an internal one to `isPublicSubagent` in
+    // `spawn-subagent.ts:isPublicSubagent` — every public bundled subagent
+    // showed up as `Available: (none)` from the agent's POV.
+    const registry = registerSubagent(emptyRegistry(), 'scout', {
+      systemPrompt: 'fake scout',
+      visibility: 'public',
+    })
+
+    const { registry: merged } = mergeSubagents(registry)
+
+    expect(merged.scout?.visibility).toBe('public')
+  })
+
+  test('preserves visibility:internal explicitly (distinct from the absent-field default)', () => {
+    const registry = registerSubagent(emptyRegistry(), 'internal-thing', {
+      systemPrompt: 'fake internal',
+      visibility: 'internal',
+    })
+
+    const { registry: merged } = mergeSubagents(registry)
+
+    expect(merged['internal-thing']?.visibility).toBe('internal')
+  })
+
+  test('preserves the absence of visibility (default-internal behavior)', () => {
+    // Bundled memory-logger / dreaming / backup omit `visibility` and rely
+    // on `isPublicSubagent` returning false for `undefined`. A "helpful"
+    // shim that defaulted to a concrete value would change the policy for
+    // every silent internal subagent — keep it absent.
+    const registry = registerSubagent(emptyRegistry(), 'silent', {
+      systemPrompt: 'fake silent',
+    })
+
+    const { registry: merged } = mergeSubagents(registry)
+
+    expect(merged.silent?.visibility).toBeUndefined()
+  })
+
+  test('preserves requiresSpecificPermission so per-subagent permission gates take effect', () => {
+    // The operator subagent sets this to force a per-spawn permission check
+    // (`subagent.spawn.operator`) instead of falling back to the generic
+    // `subagent.spawn`. Dropping this in the shim would silently widen the
+    // gate to "anyone with the generic permission can spawn operator",
+    // bypassing the write-capability isolation operator declares it for.
+    const registry = registerSubagent(emptyRegistry(), 'operator', {
+      systemPrompt: 'fake operator',
+      visibility: 'public',
+      requiresSpecificPermission: true,
+    })
+
+    const { registry: merged } = mergeSubagents(registry)
+
+    expect(merged.operator?.requiresSpecificPermission).toBe(true)
+  })
+
+  test('preserves payloadSchema so payload validation runs against the right contract', () => {
+    const schema = z.object({ topic: z.string() })
+    const registry = registerSubagent(emptyRegistry(), 'schemafied', {
+      systemPrompt: 'fake',
+      payloadSchema: schema,
+    })
+
+    const { registry: merged } = mergeSubagents(registry)
+
+    expect(merged.schemafied?.payloadSchema).toBe(schema)
+  })
+
+  test('preserves handler reference so plugin-defined logic runs on spawn', () => {
+    const handler = async () => {}
+    const registry = registerSubagent(emptyRegistry(), 'handled', {
+      systemPrompt: 'fake',
+      handler,
+    })
+
+    const { registry: merged } = mergeSubagents(registry)
+
+    expect(merged.handled?.handler).toBe(handler)
+  })
+
+  test('preserves profile so per-subagent model selection survives the shim', () => {
+    const registry = registerSubagent(emptyRegistry(), 'fast-one', {
+      systemPrompt: 'fake',
+      profile: 'fast',
+    })
+
+    const { registry: merged } = mergeSubagents(registry)
+
+    expect(merged['fast-one']?.profile).toBe('fast')
+  })
+
+  test('preserves toolResultBudget so the per-run byte ceiling reaches the runtime', () => {
+    const budget = { maxTotalBytes: 1024, toolNames: ['read'] as const }
+    const registry = registerSubagent(emptyRegistry(), 'budgeted', {
+      systemPrompt: 'fake',
+      toolResultBudget: budget,
+    })
+
+    const { registry: merged } = mergeSubagents(registry)
+
+    expect(merged.budgeted?.toolResultBudget).toBe(budget)
+  })
+
+  test('keeps the original plugin reference recoverable via pluginSubagentByShim', () => {
+    // The shim discards `tools`, `customTools`, and `inFlightKey` from the
+    // registry-visible object, but createSessionForSubagent must still be
+    // able to recover the original plugin subagent (which carries those
+    // fields) so it can resolve BuiltinToolRef[] → AgentSessionTools at
+    // session-creation time. This is the WeakMap-roundtrip invariant.
+    const plugin: PluginSubagent<any> = {
+      systemPrompt: 'fake',
+      visibility: 'public',
+      inFlightKey: (p: unknown) => `key:${JSON.stringify(p)}`,
+    }
+    const registry = registerSubagent(emptyRegistry(), 'roundtrip', plugin)
+
+    const { registry: merged, pluginSubagentByShim, pluginSubagentByName } = mergeSubagents(registry)
+    const shim = merged.roundtrip
+    if (shim === undefined) throw new Error('shim missing from merged registry')
+
+    expect(pluginSubagentByShim.get(shim)?.pluginSubagent).toBe(plugin)
+    expect(pluginSubagentByName.get('roundtrip')?.pluginSubagent).toBe(plugin)
+  })
+
+  test('rejects duplicate subagent names across plugins', () => {
+    const registry = emptyRegistry()
+    registry.subagents.push({ pluginName: 'a', subagentName: 'dup', subagent: { systemPrompt: 'a' } })
+    registry.subagents.push({ pluginName: 'b', subagentName: 'dup', subagent: { systemPrompt: 'b' } })
+
+    expect(() => mergeSubagents(registry)).toThrow(/already registered/)
+  })
+})


### PR DESCRIPTION
Calling `spawn_subagent({ subagent_type: 'scout', ... })` (and `explorer`, `operator`) returned `Unknown subagent: scout. Available: (none).` for every plugin-contributed public subagent, even though the boot log reported all of them registered. The `spawn_subagent` tool surface was empty for channel and cron sessions.

## Root cause

`pluginSubagentShim` in `src/run/index.ts` translated the plugin-author-facing `Subagent` (`@/plugin/types`) into the runtime-internal `Subagent` (`@/agent/subagents`) by hand-listing exactly three fields:

```ts
return {
  systemPrompt: subagent.systemPrompt,
  ...(subagent.payloadSchema ? { payloadSchema: subagent.payloadSchema } : {}),
  ...(subagent.handler       ? { handler: subagent.handler }            : {}),
}
```

This silently dropped every other shared field. Two of them are load-bearing at the registry layer:

- `visibility` — read directly by `spawn-subagent.ts:isPublicSubagent` (`return sub.visibility === 'public'`). Stripped → every plugin subagent looked internal → `publicSubagentNames(registry)` returned `[]`.
- `requiresSpecificPermission` — read by the per-subagent permission gate in the same file.

The `pluginSubagentByShim` WeakMap recovers the original plugin object for `tools` / `customTools` / `inFlightKey` / `profile` / `toolResultBudget` resolution at session-creation time, so those paths kept working — masking the bug until someone actually tried to call a public subagent.

## Fix

Structural, not tactical. Two cheaper alternatives were considered and rejected:

- **Option A (copy the two missing fields into the shim):** fixes the symptom, leaves the bug class. The next field added to either type silently drops again — exactly how `visibility` shipped in the first place.
- **Option B (collapse to one `Subagent` type with union-typed tools):** conflates the public plugin API with the runtime-internal shape, forcing every read site to handle both representations. Rejected because the `BuiltinToolRef[] vs AgentSessionTools` and `Tool<any>[] vs ToolDefinition[]` divergences are load-bearing — they exist so plugin authors don't import pi-coding-agent internals and so the runtime can wrap tools with origin stamping, hook bus, permission gating, and tool-result-budget counting before the session sees them.

**Option C (this PR):**

1. Extract `SubagentShared<P>` into `@/agent/subagents` holding the seven fields identical on both sides: `systemPrompt`, `profile`, `payloadSchema`, `handler`, `toolResultBudget`, `visibility`, `requiresSpecificPermission`.
2. Re-derive the internal `Subagent` as `SubagentShared & { tools?: AgentSessionTools; customTools?: ToolDefinition[] }` and the plugin-side `Subagent` as `SubagentShared & { tools?: BuiltinToolRef[]; customTools?: Tool<any>[]; inFlightKey? }`. The two diverging shapes stay on each concrete type.
3. Rewrite the shim as a rest-spread with an explicit exclusion list:

```ts
const { tools: _tools, customTools: _customTools, inFlightKey: _inFlightKey, ...shared } = subagent
return shared
```

The three excluded fields cannot flow through the registry shim: the first two are type-mismatched and recovered via the WeakMap downstream; `inFlightKey` is consumed only by `SubagentConsumer` via `pluginSubagentByName`. Every other shared field now flows through automatically — new fields added to `SubagentShared` require no shim edit.

## Regression test

New file: `src/run/merge-subagents.test.ts`, 10 tests against the now-exported `mergeSubagents` function.

5 tests fail against the pre-fix shim (verified by reverting and re-running):
- `visibility: 'public'` survives the shim
- `visibility: 'internal'` survives the shim
- `requiresSpecificPermission: true` survives the shim
- `profile` survives the shim
- `toolResultBudget` survives the shim

5 tests pass on both the old and new shim (absent-visibility default, `payloadSchema`, `handler`, WeakMap roundtrip, duplicate-name error) — pinpointing exactly the dropped fields without flagging unaffected paths. The mutation check from the testing philosophy is satisfied: commenting out the spread breaks at least one assertion.

## Checks

```
bun run typecheck   clean
bun run lint        0 errors on changed files
bun run format      clean
bun run test        4512/4512 pass
```

## Scope and follow-up

This PR fixes the registry-shim drop only. There is a separate TUI wiring gap: `createServer` in `src/server/index.ts` does not receive `liveSubagentRegistry` / `subagentRegistry` / `createSessionForSubagent`, so the `spawn_subagent` tool only appears on channel and cron sessions (where the full options are threaded through `startAgent`). That gap is intentionally out of scope here and will be addressed in a follow-up PR.