### PR TITLE
server: thread subagent orchestration wiring into TUI sessions

### DIFF
--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -475,6 +475,8 @@ export async function startAgent({
     claimController,
     commandRunnerFactory,
     tunnelManager,
+    liveSubagentRegistry,
+    createSessionForSubagent,
     ...containerNameOpt,
     ...runtimeVersionOpt,
     ...tuiTokenOpt,

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -6,6 +6,8 @@ import { join } from 'node:path'
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import type { AgentSession, CreateSessionOptions } from '@/agent'
+import { LiveSubagentRegistry } from '@/agent/live-subagents'
+import type { CreateSessionForSubagent, SubagentRegistry } from '@/agent/subagents'
 import type { CronJob } from '@/cron'
 import { createHookBus, type HookBus, type PluginRegistry } from '@/plugin'
 import { createPluginRuntime, type PluginRuntime } from '@/run/plugin-runtime'
@@ -23,6 +25,28 @@ function makeRuntime(opts: { registry: PluginRegistry; hooks: HookBus }): Plugin
     registry: opts.registry,
     hooks: opts.hooks,
     subagents: {},
+    pluginSubagentByShim: new WeakMap(),
+    hasAnyPluginContent: false,
+    loadedPlugins: [],
+    materializedSkills: null,
+  })
+}
+
+const EMPTY_REGISTRY: PluginRegistry = {
+  tools: [],
+  subagents: [],
+  cronJobs: [],
+  skills: [],
+  skillsDirs: [],
+  doctorChecks: [],
+  commands: [],
+}
+
+function makeRuntimeWith(opts: { subagents: SubagentRegistry }): PluginRuntime {
+  return createPluginRuntime({
+    registry: EMPTY_REGISTRY,
+    hooks: createHookBus(),
+    subagents: opts.subagents,
     pluginSubagentByShim: new WeakMap(),
     hasAnyPluginContent: false,
     loadedPlugins: [],
@@ -550,6 +574,105 @@ describe('createServer session persistence wiring', () => {
     // then
     if (connected.type !== 'connected') throw new Error('unreachable')
     expect(connected.serverVersion).toBeUndefined()
+
+    ws.close()
+  })
+})
+
+describe('createServer TUI subagent orchestration wiring', () => {
+  test('forwards liveSubagentRegistry, subagentRegistry (from runtimeSnapshot), and createSessionForSubagent into createSession on ws open', async () => {
+    // given
+    const session = createFakeSession()
+    const liveSubagentRegistry = new LiveSubagentRegistry()
+    const subagents: SubagentRegistry = { scout: { systemPrompt: 's', visibility: 'public' } }
+    const createSessionForSubagent: CreateSessionForSubagent = async () =>
+      ({ session, hooks: {} as HookBus, sessionId: 'sub' }) as never
+    const pluginRuntime = makeRuntimeWith({ subagents })
+    const observed: CreateSessionOptions[] = []
+    const built = createServer({
+      port: 0,
+      createSession: async (options = {}) => {
+        observed.push(options)
+        return session
+      },
+      agentDir: '/agent',
+      pluginRuntime,
+      liveSubagentRegistry,
+      createSessionForSubagent,
+    }).start()
+    server = built
+
+    // when
+    const { ws, waitFor } = await connect(`ws://localhost:${built.port}`)
+    await waitFor((m) => m.type === 'connected')
+
+    // then
+    expect(observed).toHaveLength(1)
+    expect(observed[0]?.liveSubagentRegistry).toBe(liveSubagentRegistry)
+    expect(observed[0]?.subagentRegistry).toBe(subagents)
+    expect(observed[0]?.createSessionForSubagent).toBe(createSessionForSubagent)
+
+    ws.close()
+  })
+
+  test('omits each orchestration field when the corresponding ServerOption is unset (regression: gate stays closed for tests that did not opt in)', async () => {
+    // given
+    const session = createFakeSession()
+    const observed: CreateSessionOptions[] = []
+    const built = createServer({
+      port: 0,
+      createSession: async (options = {}) => {
+        observed.push(options)
+        return session
+      },
+    }).start()
+    server = built
+
+    // when
+    const { ws, waitFor } = await connect(`ws://localhost:${built.port}`)
+    await waitFor((m) => m.type === 'connected')
+
+    // then
+    expect(observed).toHaveLength(1)
+    expect(observed[0]?.liveSubagentRegistry).toBeUndefined()
+    expect(observed[0]?.subagentRegistry).toBeUndefined()
+    expect(observed[0]?.createSessionForSubagent).toBeUndefined()
+
+    ws.close()
+  })
+
+  test('subagentRegistry stays bound to the snapshot taken at ws open (later pluginRuntime swap does not affect already-connected session)', async () => {
+    // given
+    const session = createFakeSession()
+    const firstSubagents: SubagentRegistry = { scout: { systemPrompt: 'first', visibility: 'public' } }
+    const pluginRuntime = makeRuntimeWith({ subagents: firstSubagents })
+    const observed: CreateSessionOptions[] = []
+    const built = createServer({
+      port: 0,
+      createSession: async (options = {}) => {
+        observed.push(options)
+        return session
+      },
+      agentDir: '/agent',
+      pluginRuntime,
+    }).start()
+    server = built
+
+    // when
+    const { ws, waitFor } = await connect(`ws://localhost:${built.port}`)
+    await waitFor((m) => m.type === 'connected')
+    pluginRuntime.swap({
+      registry: EMPTY_REGISTRY,
+      hooks: createHookBus(),
+      subagents: { explorer: { systemPrompt: 'second', visibility: 'public' } },
+      pluginSubagentByShim: new WeakMap(),
+      hasAnyPluginContent: false,
+      loadedPlugins: [],
+      materializedSkills: null,
+    })
+
+    // then
+    expect(observed[0]?.subagentRegistry).toBe(firstSubagents)
 
     ws.close()
   })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,8 +7,10 @@ import {
   type CreateSessionResult,
 } from '@/agent'
 import { runPluginDoctorChecks, runPluginDoctorFix } from '@/agent/doctor'
+import type { LiveSubagentRegistry } from '@/agent/live-subagents'
 import { detectProviderError } from '@/agent/provider-error'
 import type { SessionOrigin } from '@/agent/session-origin'
+import type { CreateSessionForSubagent } from '@/agent/subagents'
 import type { ChannelRouter } from '@/channels/router'
 import { aggregateCronList, type CronListEntry, loadCron } from '@/cron'
 import type { HookBus } from '@/plugin'
@@ -79,6 +81,27 @@ export type ServerOptions = {
   // without it the four `exec_command`-family messages are answered with
   // `command_error` so the host CLI sees a clean failure.
   commandRunnerFactory?: (outbound: CommandOutbound) => CommandRunner
+  // Subagent orchestration plumbing for TUI sessions. Both fields must be
+  // present together for the spawn_subagent / subagent_output / subagent_cancel
+  // tools to surface; `createSession` gates registration on all three of
+  // (liveSubagentRegistry, subagentRegistry, createSessionForSubagent), and
+  // we derive subagentRegistry per WS connection from the same `pluginRuntime`
+  // snapshot that already feeds `plugins.registry` — so a reload landing
+  // mid-connection keeps using the snapshot the session opened with, matching
+  // the existing per-session lifecycle invariant.
+  //
+  // `createSessionForSubagent` is passed eagerly (not late-bound) because the
+  // TUI server is constructed AFTER the channel manager in `startAgent`,
+  // breaking the construction cycle that forces the channel session factory's
+  // `getCreateSessionForSubagent` late-binding.
+  //
+  // Channel and cron sessions get the same plumbing through
+  // `buildChannelSessionFactory` / `createSessionForCron` (see src/run/). The
+  // three top-level callers must stay aligned; otherwise the agent's tool
+  // surface diverges across origin kinds — exactly the gap PR #281 flagged
+  // as out-of-scope follow-up.
+  liveSubagentRegistry?: LiveSubagentRegistry
+  createSessionForSubagent?: CreateSessionForSubagent
 }
 
 const consoleLogger: ServerLogger = {
@@ -176,6 +199,8 @@ export function createServer({
   logger = consoleLogger,
   claimController,
   commandRunnerFactory,
+  liveSubagentRegistry,
+  createSessionForSubagent,
 }: ServerOptions) {
   const sessionStates = new WeakMap<Ws, SessionState>()
   const callIdToWs = new Map<string, AnyOwnerWs>()
@@ -351,6 +376,15 @@ export function createServer({
                   }
                 : undefined
             const origin: SessionOrigin = { kind: 'tui', sessionId: sessionFileId }
+            // Derive subagentRegistry from the same runtimeSnapshot that
+            // populates `plugins.registry`. createSession gates the orchestration
+            // tools on (liveRegistry, subagentRegistry, createSessionForSubagent,
+            // agentDir) being all-present; threading the registry alongside the
+            // two server-owned fields gives the gate a complete tuple for TUI
+            // sessions whenever the host plumbed in plugin runtime + subagent
+            // wiring (production), while keeping every existing test that omits
+            // either side at exactly its current tool surface.
+            const subagentRegistry = runtimeSnapshot?.subagents
             const result = await createSession({
               reloadRegistry,
               sessionManager,
@@ -360,6 +394,9 @@ export function createServer({
               ...(pluginsWiring ? { plugins: pluginsWiring } : {}),
               ...(containerName !== undefined ? { containerName } : {}),
               ...(runtimeVersion !== undefined ? { runtimeVersion } : {}),
+              ...(liveSubagentRegistry !== undefined ? { liveSubagentRegistry } : {}),
+              ...(subagentRegistry !== undefined ? { subagentRegistry } : {}),
+              ...(createSessionForSubagent !== undefined ? { createSessionForSubagent } : {}),
             })
             const session = 'session' in result ? result.session : result
             const dispose = 'session' in result && result.dispose ? result.dispose : async () => {}


### PR DESCRIPTION
PR #281 fixed the registry-shim drop that hid plugin-contributed public subagents — `visibility` and `requiresSpecificPermission` were stripped during the plugin-`Subagent` → internal-`Subagent` transform in `pluginSubagentShim`, so `publicSubagentNames(registry)` returned `[]` and `spawn_subagent` rejected every plugin-contributed subagent with `Unknown subagent: scout. Available: (none).`. After that fix, `spawn_subagent` works end to end on channel and cron sessions.

It still doesn't work on TUI sessions, and PR #281's body called that out as an out-of-scope follow-up. This PR closes that gap.

## Root cause

The orchestration tools (`spawn_subagent`, `subagent_output`, `subagent_cancel`) are gated by `buildSubagentOrchestrationTools` in `src/agent/index.ts`:

```ts
if (
  opts.liveRegistry === undefined ||
  opts.registry === undefined ||
  opts.createSessionForSubagent === undefined ||
  opts.agentDir === undefined
) {
  return []
}
```

All four must be present, or the function returns an empty list and the tool surface stays empty.

Channel sessions pass all four through `buildChannelSessionFactory` (`src/run/channel-session-factory.ts:125-129`). Cron sessions pass them through `createSessionForCron` in `src/run/index.ts`. TUI sessions don't:

```ts
// src/server/index.ts, WS-open handler
const result = await createSession({
  reloadRegistry, sessionManager, origin,
  ...(stream ? { stream } : {}),
  ...(channelRouter ? { channelRouter } : {}),
  ...(pluginsWiring ? { plugins: pluginsWiring } : {}),
  ...(containerName !== undefined ? { containerName } : {}),
  ...(runtimeVersion !== undefined ? { runtimeVersion } : {}),
  // liveSubagentRegistry / subagentRegistry / createSessionForSubagent — not threaded
})
```

`createServer({...})`'s `ServerOptions` had no fields for them, so the production wiring in `startAgent` had nowhere to plumb the values that channel and cron sessions already had. Result: `spawn_subagent` missing from the TUI tool list while the same agent's channel sessions exposed it. User-visible symptom from the report:

> `spawn_subagent 사용 가능해?`
> `아쉽게도 이 세션에서는 spawn_subagent 도구가 제공되지 않았어 🐶`

## Fix

Three coordinated edits, one new wiring path:

**`src/server/index.ts`** — add to `ServerOptions`:

```ts
liveSubagentRegistry?: LiveSubagentRegistry
createSessionForSubagent?: CreateSessionForSubagent
```

Destructure both in `createServer({...})`, and in the WS-open handler thread them — plus `subagentRegistry` derived from the existing `runtimeSnapshot.subagents` — into `createSession({...})`.

**`src/run/index.ts`** — forward `liveSubagentRegistry` and `createSessionForSubagent` into the `createServer({...})` call. Both already exist in `startAgent`'s scope (the same values channel and cron sessions consume).

## Two design choices worth pinning

**Why `subagentRegistry` is derived from `runtimeSnapshot`, not a third top-level `ServerOption`.** The `runtimeSnapshot` is already taken at WS open for `plugins.registry`, and the per-session lifecycle invariant — "a reload landing mid-connection keeps using the snapshot the session opened with" — requires `subagentRegistry` to share that same snapshot. Threading it as a fourth `ServerOption` would either duplicate the snapshot (forcing the caller to manage two parallel pointers) or invite drift between `plugins.registry` and `subagentRegistry` if one updated and the other didn't. Derivation makes the invariant structural rather than depending on the caller doing the right thing. The third regression test pins this — `pluginRuntime.swap(...)` fired after WS open does not affect the already-connected session's subagentRegistry.

**Why `createSessionForSubagent` is eager (not late-bound via a getter like `buildChannelSessionFactory`'s `getCreateSessionForSubagent`).** The channel session factory is constructed BEFORE `createSessionForSubagent` because the factory's reference to `channelManager.router` and `createSessionForSubagent`'s reference back to `channelManager` form a cycle that's only breakable with a getter (see the construction order in `startAgent`). `createServer` doesn't sit in that cycle — it's constructed AFTER both `channelManager` and `createSessionForSubagent` — so the value is fully resolved by the time we forward it. No closure-cycle, no getter.

## Regression test

New `describe` block in `src/server/index.test.ts` (3 tests):

1. **`forwards liveSubagentRegistry, subagentRegistry, and createSessionForSubagent into createSession on ws open`** — full positive case. Builds a real `pluginRuntime` with one public subagent, passes the two new ServerOptions, opens a WS, and asserts on the `CreateSessionOptions` the server hands to `createSession`. All three values flow through with identity-equality (`toBe`, not `toEqual`) so the test catches accidental wrapping or shallow-copying.

2. **`omits each orchestration field when the corresponding ServerOption is unset`** — negative case. Pins existing behavior for tests and stand-alone callers that don't opt in. Without this, future "always pass a default" simplifications would silently expand every test's tool surface.

3. **`subagentRegistry stays bound to the snapshot taken at ws open`** — pins the lifecycle invariant that motivates derivation from `runtimeSnapshot`. Opens a WS, then calls `pluginRuntime.swap(...)` with a different subagent map; asserts the original session still sees the open-time registry.

### Mutation check (per AGENTS.md §1)

Stashed both source edits, re-ran the new tests:

- Test #1 (positive): **fails** — `subagentRegistry` is now `undefined`, `liveSubagentRegistry` is `undefined`, `createSessionForSubagent` is `undefined`.
- Test #2 (negative): **passes** — its assertion is exactly the no-opt-in case, so the absence of wiring is its happy path.
- Test #3 (snapshot): **fails** — `subagentRegistry` is `undefined` either way (the snapshot read isn't happening at the call site).

This is the correct mutation profile: every positive test fails on revert; the negative test pins existing behavior and must NOT fail on revert. If the negative test had also failed, it would mean it was testing the wiring, not the absence of wiring — which would be a worse test, not a better one.

## Checks

```
bun run typecheck   clean
bun run lint        0 errors on changed files
bun run format      clean
bun run test        4523/4523 pass
```

## Scope

This PR only closes the TUI wiring gap that PR #281 documented as out-of-scope. It does not change the orchestration tool surface, the `Subagent` shape, the permissions gate, the system-prompt rendering, the subagent-completed broadcast routing, or any test that doesn't explicitly opt into the new wiring. Channel and cron sessions are untouched — they already had the full plumbing before #281.
