### PR TITLE
subagents: dual-route builtin tool refs so the live tool list is exactly what was declared

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -220,9 +220,16 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
   const getOrigin: () => SessionOrigin | undefined =
     options.originRef !== undefined ? () => options.originRef!.current : () => options.origin
 
-  const subagentBuiltinTools = options.pluginSubagent?.toolRefs
+  // Subagent built-in tool refs are dual-routed (see BUILTIN_TOOL_DEFINITION
+  // dual-map in plugin-tools.ts): pi-side coding tools go to `tools:` so they
+  // become the strict base set, typeclaw-side web tools go to `customTools:`.
+  // The two `tools:` fields below (effective `options.tools` and the resolved
+  // subagent pi-side builtins) are mutually exclusive — `options.tools` is only
+  // passed by non-subagent callers like multimodal look-at; subagent sessions
+  // never set both.
+  const resolvedSubagentBuiltins = options.pluginSubagent?.toolRefs
     ? resolveBuiltinToolRefs(options.pluginSubagent.toolRefs)
-    : undefined
+    : { agentTools: [], toolDefinitions: [] }
   const pluginCustomTools = options.pluginSubagent
     ? wrapSubagentCustomTools(options.pluginSubagent, options.plugins, getOrigin)
     : wrapRegistryTools(options.plugins, getOrigin)
@@ -239,11 +246,9 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     : undefined
   const sessionBudgetState = sessionBudget ? createBudgetState() : undefined
 
-  const hookWrappedTools = wrapSystemAgentTools(
-    options.tools ?? (subagentBuiltinTools as AgentSessionTools | undefined),
-    options.plugins,
-    getOrigin,
-  )
+  const effectiveTools =
+    options.tools ?? (options.pluginSubagent ? (resolvedSubagentBuiltins.agentTools as AgentSessionTools) : undefined)
+  const hookWrappedTools = wrapSystemAgentTools(effectiveTools, options.plugins, getOrigin)
   const tools =
     sessionBudget && sessionBudgetState && hookWrappedTools
       ? (hookWrappedTools.map((t) =>
@@ -280,7 +285,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     options.customTools !== undefined
       ? options.customTools
       : options.pluginSubagent
-        ? []
+        ? resolvedSubagentBuiltins.toolDefinitions
         : [
             websearchTool,
             webfetchTool,

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -595,3 +595,79 @@ describe('getOrigin (live origin holder)', () => {
     expect((seenOrigins[1] as { jobId: string }).jobId).toBe('j2')
   })
 })
+
+describe('resolveBuiltinToolRefs (dual-route)', () => {
+  test('pi-side coding tools go to agentTools, typeclaw-side web tools go to toolDefinitions', async () => {
+    const { resolveBuiltinToolRefs } = await import('./plugin-tools')
+    const resolved = resolveBuiltinToolRefs([
+      { __builtinTool: 'read' },
+      { __builtinTool: 'bash' },
+      { __builtinTool: 'edit' },
+      { __builtinTool: 'write' },
+      { __builtinTool: 'grep' },
+      { __builtinTool: 'find' },
+      { __builtinTool: 'ls' },
+      { __builtinTool: 'websearch' },
+      { __builtinTool: 'webfetch' },
+    ])
+    expect(resolved.agentTools.map((t) => t.name)).toEqual(['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls'])
+    expect(resolved.toolDefinitions.map((t) => t.name)).toEqual(['websearch', 'webfetch'])
+  })
+
+  test('pi-side resolve to pi-coding-agent AgentTool exports by reference equality (not *ToolDefinition variant)', async () => {
+    const { resolveBuiltinToolRefs } = await import('./plugin-tools')
+    const pi = await import('@mariozechner/pi-coding-agent')
+    const cases: { name: string; expected: unknown }[] = [
+      { name: 'read', expected: pi.readTool },
+      { name: 'bash', expected: pi.bashTool },
+      { name: 'edit', expected: pi.editTool },
+      { name: 'write', expected: pi.writeTool },
+      { name: 'grep', expected: pi.grepTool },
+      { name: 'find', expected: pi.findTool },
+      { name: 'ls', expected: pi.lsTool },
+    ]
+    for (const { name, expected } of cases) {
+      const r = resolveBuiltinToolRefs([{ __builtinTool: name }])
+      expect(r.agentTools.length).toBe(1)
+      expect(r.toolDefinitions.length).toBe(0)
+      expect(r.agentTools[0]).toBe(expected as never)
+    }
+  })
+
+  test('typeclaw-side resolve to the original ToolDefinition imports by reference equality', async () => {
+    const { resolveBuiltinToolRefs } = await import('./plugin-tools')
+    const { websearchTool } = await import('./tools/websearch')
+    const { webfetchTool } = await import('./tools/webfetch')
+    const ws = resolveBuiltinToolRefs([{ __builtinTool: 'websearch' }])
+    const wf = resolveBuiltinToolRefs([{ __builtinTool: 'webfetch' }])
+    expect(ws.agentTools).toEqual([])
+    expect(ws.toolDefinitions[0]).toBe(websearchTool)
+    expect(wf.agentTools).toEqual([])
+    expect(wf.toolDefinitions[0]).toBe(webfetchTool)
+  })
+
+  test('mixed refs partition correctly: scout-shape (web only) leaves agentTools empty', async () => {
+    const { resolveBuiltinToolRefs } = await import('./plugin-tools')
+    const r = resolveBuiltinToolRefs([{ __builtinTool: 'websearch' }, { __builtinTool: 'webfetch' }])
+    expect(r.agentTools).toEqual([])
+    expect(r.toolDefinitions.map((t) => t.name).sort()).toEqual(['webfetch', 'websearch'])
+  })
+
+  test('mixed refs partition correctly: explorer-shape (coding only) leaves toolDefinitions empty', async () => {
+    const { resolveBuiltinToolRefs } = await import('./plugin-tools')
+    const r = resolveBuiltinToolRefs([
+      { __builtinTool: 'read' },
+      { __builtinTool: 'grep' },
+      { __builtinTool: 'find' },
+      { __builtinTool: 'ls' },
+      { __builtinTool: 'bash' },
+    ])
+    expect(r.toolDefinitions).toEqual([])
+    expect(r.agentTools.map((t) => t.name).sort()).toEqual(['bash', 'find', 'grep', 'ls', 'read'])
+  })
+
+  test('throws on unknown built-in names', async () => {
+    const { resolveBuiltinToolRefs } = await import('./plugin-tools')
+    expect(() => resolveBuiltinToolRefs([{ __builtinTool: 'nope' }])).toThrow(/unknown built-in tool ref/)
+  })
+})

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -34,48 +34,6 @@ import type { SessionOrigin } from './session-origin'
 import { webfetchTool } from './tools/webfetch'
 import { websearchTool } from './tools/websearch'
 
-// `ToolDefinition.execute` carries a 5th `ctx: ExtensionContext` argument that
-// `AgentTool.execute` does not — TypeScript correctly refuses the assignment
-// because the wider signature can't satisfy a position that the consumer
-// believes accepts at most 4 args. At runtime, the 5th arg is unused by
-// websearch/webfetch (their executes only read `params` and `signal`), so the
-// adapter is a thin pass-through that drops the extra parameter and keeps the
-// hook/budget/wrap pipeline (which is keyed on AgentTool shape) working
-// uniformly for every entry in `BUILTIN_TOOL_MAP`. Don't reach for this for
-// pi-coding-agent's own bashTool/readTool etc. — those are already AgentTools.
-function toAgentTool<TParams extends TSchema, TDetails = unknown>(
-  tool: ToolDefinition<TParams, TDetails, never>,
-): AgentTool<TParams, TDetails> {
-  return {
-    name: tool.name,
-    label: tool.label,
-    description: tool.description,
-    parameters: tool.parameters,
-    ...(tool.prepareArguments ? { prepareArguments: tool.prepareArguments } : {}),
-    async execute(toolCallId, params, signal, onUpdate) {
-      return tool.execute(toolCallId, params, signal, onUpdate, undefined as never)
-    },
-  }
-}
-
-const websearchAgentTool = toAgentTool(
-  websearchTool as unknown as ToolDefinition<typeof websearchTool.parameters, unknown, never>,
-)
-const webfetchAgentTool = toAgentTool(
-  webfetchTool as unknown as ToolDefinition<typeof webfetchTool.parameters, unknown, never>,
-)
-
-type AnyAgentTool =
-  | typeof piReadTool
-  | typeof piBashTool
-  | typeof piEditTool
-  | typeof piWriteTool
-  | typeof piGrepTool
-  | typeof piFindTool
-  | typeof piLsTool
-  | typeof websearchAgentTool
-  | typeof webfetchAgentTool
-
 const ACKNOWLEDGE_GUARDS_SCHEMA = Type.Optional(
   Type.Object(
     {
@@ -85,24 +43,64 @@ const ACKNOWLEDGE_GUARDS_SCHEMA = Type.Optional(
   ),
 )
 
-const BUILTIN_TOOL_MAP: Record<string, AnyAgentTool> = {
+// `BuiltinToolRef.__builtinTool` strings are dual-routed when a plugin
+// subagent declares them: pi-coding-agent's own coding tools flow through
+// `createAgentSession({ tools: AgentTool[] })` (which pi treats as a strict
+// base-tool override — exactly the declared subset becomes active), and
+// typeclaw's own web tools flow through `customTools: ToolDefinition[]` (the
+// only path pi accepts for non-pi tool definitions). Routing typeclaw tools
+// through `tools:` silently drops them (pi's `tools` validator rejects shapes
+// it doesn't recognize); routing pi tools through `customTools:` would work
+// but ALSO auto-injects pi's default 4 base tools (read/bash/edit/write),
+// widening every plugin subagent's allowlist beyond what it declared. The
+// dual route is the only shape that gives "subagent gets exactly what it
+// asked for, nothing more." See `src/agent/index.ts` `createSessionWithDispose`
+// for the consumer that splits the resolved arrays into the two pi fields.
+type PiAgentToolName = 'read' | 'bash' | 'edit' | 'write' | 'grep' | 'find' | 'ls'
+type TypeclawToolName = 'websearch' | 'webfetch'
+
+const PI_AGENT_TOOL_MAP: Record<PiAgentToolName, AgentTool<any, any>> = {
+  read: piReadTool,
   bash: piBashTool,
   edit: piEditTool,
-  find: piFindTool,
-  grep: piGrepTool,
-  ls: piLsTool,
-  read: piReadTool,
   write: piWriteTool,
-  websearch: websearchAgentTool,
-  webfetch: webfetchAgentTool,
+  grep: piGrepTool,
+  find: piFindTool,
+  ls: piLsTool,
 }
 
-export function resolveBuiltinToolRefs(refs: BuiltinToolRef[]): AnyAgentTool[] {
-  return refs.map((ref) => {
-    const tool = BUILTIN_TOOL_MAP[ref.__builtinTool]
-    if (!tool) throw new Error(`unknown built-in tool ref: ${ref.__builtinTool}`)
-    return tool
-  })
+const TYPECLAW_TOOL_DEFINITION_MAP: Record<TypeclawToolName, ToolDefinition<any, any, any>> = {
+  websearch: websearchTool,
+  webfetch: webfetchTool,
+}
+
+function isPiAgentToolName(name: string): name is PiAgentToolName {
+  return name in PI_AGENT_TOOL_MAP
+}
+
+function isTypeclawToolName(name: string): name is TypeclawToolName {
+  return name in TYPECLAW_TOOL_DEFINITION_MAP
+}
+
+export type ResolvedBuiltinTools = {
+  agentTools: AgentTool<any, any>[]
+  toolDefinitions: ToolDefinition<any, any, any>[]
+}
+
+export function resolveBuiltinToolRefs(refs: BuiltinToolRef[]): ResolvedBuiltinTools {
+  const agentTools: AgentTool<any, any>[] = []
+  const toolDefinitions: ToolDefinition<any, any, any>[] = []
+  for (const ref of refs) {
+    const name = ref.__builtinTool
+    if (isPiAgentToolName(name)) {
+      agentTools.push(PI_AGENT_TOOL_MAP[name])
+    } else if (isTypeclawToolName(name)) {
+      toolDefinitions.push(TYPECLAW_TOOL_DEFINITION_MAP[name])
+    } else {
+      throw new Error(`unknown built-in tool ref: ${name}`)
+    }
+  }
+  return { agentTools, toolDefinitions }
 }
 
 export type WrapToolOptions = {

--- a/src/bundled-plugins/scout/scout.test.ts
+++ b/src/bundled-plugins/scout/scout.test.ts
@@ -90,6 +90,19 @@ describe('scout subagent declaration', () => {
     expect(toolNames).not.toContain('edit')
   })
 
+  test('toolRefs dual-route correctly: websearch+webfetch land in toolDefinitions (customTools path), with no pi-side agentTools leaking', async () => {
+    const { resolveBuiltinToolRefs } = await import('@/agent/plugin-tools')
+    const { websearchTool } = await import('@/agent/tools/websearch')
+    const { webfetchTool } = await import('@/agent/tools/webfetch')
+    const sub = createScoutSubagent()
+    const resolved = resolveBuiltinToolRefs(sub.tools ?? [])
+    expect(resolved.agentTools).toEqual([])
+    expect(resolved.toolDefinitions.map((t) => t.name).sort()).toEqual(['webfetch', 'websearch'])
+    const byName = Object.fromEntries(resolved.toolDefinitions.map((t) => [t.name, t]))
+    expect(byName.websearch).toBe(websearchTool)
+    expect(byName.webfetch).toBe(webfetchTool)
+  })
+
   test('declares a tool-result budget keyed on websearch+webfetch (so a runaway scout cannot exhaust parent context)', () => {
     const sub = createScoutSubagent()
     expect(sub.toolResultBudget).toBeDefined()


### PR DESCRIPTION
## Problem

Plugin subagents declared with `tools: BuiltinToolRef[]` (e.g. the bundled scout subagent: `tools: [websearchTool, webfetchTool]`) booted with zero tools in `agent._state.tools`. Every tool call from inside the subagent returned `Tool websearch not found` from pi-agent-core's `agent-loop.ts:295`.

**Production failure (kakao agent, 2026-05-21):** user 뚜욜 asked for weather in 5 cities; 봉봉 spawned 5 scout subagents in parallel; 4 failed with `Tool websearch not found`. 봉봉 then fell back to direct `webfetch` calls from the parent session, which worked — because the main-agent path already routes websearch/webfetch through `customSystemTools` as `ToolDefinition[]`.

## Root cause

`pi-coding-agent`'s `createAgentSession` has two distinct tool-registration fields with different shape requirements:

- **`tools: AgentTool[]`** — strict base-tool override. pi accepts these (its own `AgentTool` exports) verbatim, and the active tool list becomes EXACTLY this set.
- **`customTools: ToolDefinition[]`** — additive registration that lives alongside pi's default 4 base tools (`read`/`bash`/`edit`/`write`); anything in `customTools` is unioned with that default.

Pre-fix, typeclaw's `BUILTIN_TOOL_MAP` adapted both pi-side and typeclaw-side tools to `AgentTool` shape via a `toAgentTool()` adapter, then passed the lot through `tools:`. pi accepts its own `AgentTool` exports fine but silently drops the adapted typeclaw entries (it discriminates on internal structure, not type signature). Result:

- **scout** (declares `tools: [websearchTool, webfetchTool]`): both entries dropped → `agent._state.tools === []` → "Tool websearch not found" on every call.
- **explorer / operator / memory-logger / dreaming / backup** (declare `tools: [pi AgentTool exports]`, no typeclaw entries): worked correctly — their declared subsets became active.

## Fix — dual-route

`resolveBuiltinToolRefs` partitions resolved `BuiltinToolRef`s by which side owns them:

- **Pi-side coding tools** (`read`/`bash`/`edit`/`write`/`grep`/`find`/`ls`) → `tools: AgentTool[]` using pi's `*Tool` exports verbatim
- **typeclaw-side web tools** (`websearch`/`webfetch`) → `customTools: ToolDefinition[]` using the original imports verbatim

`createSessionWithDispose` splits the returned `{ agentTools, toolDefinitions }` into the matching pi fields. The dead `toAgentTool()` adapter is removed.

### Why dual-route, not just "route everything through customTools"

Routing pi-side tools through `customTools:` also works around the silent-drop bug, but pi auto-injects `read`/`bash`/`edit`/`write` as defaults whenever `tools:` is unset. A subagent declaring `tools: [readTool]` would end up with `[read, bash, edit, write]` live — widening every plugin subagent's allowlist beyond what it asked for. Most consequentially:

- **explorer** (`READ-ONLY` prompt contract) would gain `edit` and `write`
- **backup write-only** subagent would gain `read`, `bash`, `edit`
- **dreaming** would gain `bash` and `edit`

The dual route is the only shape that gives "subagent gets exactly what it asked for, nothing more." This was caught in self-review of an earlier version of this PR that used the single-route approach.

## Verification

Probe inside a running kakao container against pi-coding-agent@0.67.3, across every bundled subagent shape:

```
OK  scout           live: ["websearch","webfetch"]                            declared: ["websearch","webfetch"]
OK  explorer        live: ["read","grep","find","ls","bash"]                  declared: ["read","grep","find","ls","bash"]
OK  operator        live: ["read","grep","find","ls","bash","write","edit"]   declared: ["read","grep","find","ls","bash","write","edit"]
OK  memory-logger   live: ["read"]                                            declared: ["read"]
OK  dreaming        live: ["read","write","ls"]                               declared: ["read","write","ls"]
OK  backup write    live: ["write"]                                           declared: ["write"]
OK  backup mixed    live: ["bash","read","write"]                             declared: ["bash","read","write"]
```

Every subagent's live tool list matches its declared set exactly.

## Tests

**`src/agent/plugin-tools.test.ts`** — 6 tests on the dual-route partitioning:

- pi-side and typeclaw-side partition correctly across the full builtin set
- pi-side refs resolve to pi's `*Tool` `AgentTool` exports by reference equality (catches regression to `*ToolDefinition` or back to the dead adapter)
- typeclaw-side refs resolve to the original `websearchTool` / `webfetchTool` imports by reference equality
- scout-shape (web only) leaves `agentTools` empty
- explorer-shape (coding only) leaves `toolDefinitions` empty
- unknown ref name throws

**`src/bundled-plugins/scout/scout.test.ts`** — updated regression test:

- scout's declared `tools: [websearchTool, webfetchTool]` round-trip to `toolDefinitions` only (`agentTools` empty), with reference equality against the original imports.

## Impact

| Session type | Before | After |
|---|---|---|
| **scout** subagent | `websearch` / `webfetch` → "Tool not found" on every call | Live tools `[websearch, webfetch]` exactly |
| **explorer / operator** | Worked (pi-side AgentTools registered fine) | Unchanged — same declared sets |
| **memory-logger / dreaming / backup** | Worked (pi-side AgentTools registered fine) | Unchanged — same declared sets |
| **Main agent** (TUI / channel / cron) | Already worked via `customSystemTools` | Unchanged |

## Follow-up (out of scope)

**Stale belief in kakao agent MEMORY.md** (lines 242, 440): "The `websearch` tool is currently non-functional in this environment due to a missing `curl_chrome136` executable." The binary is fully present and functional; the belief was written when the agent misdiagnosed this bug. After this fix ships, the agent will observe `websearch` working and dreaming can supersede the fragment naturally.
