### PR TITLE
providers: add Anthropic Claude (Opus 4.7 / Sonnet 4.6 / Haiku 4.5) with api-key + OAuth

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test'
 
-import { KNOWN_PROVIDERS, type KnownProviderId } from '@/config/providers'
+import { KNOWN_PROVIDERS, supportsApiKey, supportsOAuth, type KnownProviderId } from '@/config/providers'
 import type { ModelOption } from '@/init/models-dev'
 
 import { collectWizardInputs, decideExistingApiKeyReuse, WizardAbortedError, type WizardPrompts } from './init'
@@ -93,6 +93,17 @@ describe('collectWizardInputs back-aware flow', () => {
     reasoning: true,
     curated: true,
     supportsVision: false,
+  }
+  const anthropicModel: ModelOption = {
+    providerId: 'anthropic',
+    providerName: 'Anthropic',
+    modelId: 'claude-sonnet-4-6',
+    modelName: 'Claude Sonnet 4.6',
+    ref: 'anthropic/claude-sonnet-4-6',
+    contextWindow: 1000000,
+    reasoning: true,
+    curated: true,
+    supportsVision: true,
   }
 
   function makeRecorder(): { steps: string[]; record: (name: string) => void } {
@@ -1089,5 +1100,75 @@ describe('collectWizardInputs back-aware flow', () => {
       expect(error).toBeInstanceOf(WizardAbortedError)
       expect((error as WizardAbortedError).oauthCredentialsSaved).toBe(false)
     }
+  })
+
+  test('dual-auth provider (anthropic): pickAuthMethod is REAL prompt with both options, not autoValue', async () => {
+    // given: anthropic supports both api-key and oauth. Unlike openai
+    //   (api-key-only) and openai-codex (oauth-only), pickAuthMethod must
+    //   actually ask the user — autoValue is wrong here. We assert the
+    //   prompt sees the live provider and that the wizard honors the
+    //   user's selection literally.
+    let seenProviderId: string | undefined
+    let seenBothAuthModes: boolean | undefined
+    const prompts = makePrompts({
+      loadCatalog: async () => ({ options: [anthropicModel], source: 'curated' }),
+      pickProvider: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: anthropicModel }),
+      pickAuthMethod: async (provider) => {
+        seenProviderId = provider.id
+        seenBothAuthModes = supportsApiKey(provider) && supportsOAuth(provider)
+        return { kind: 'value', value: 'api-key' }
+      },
+      askApiKey: async () => ({ kind: 'value', value: 'sk-ant-test' }),
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(seenProviderId).toBe('anthropic')
+    expect(seenBothAuthModes).toBe(true)
+    expect(result.llmAuth).toEqual({ kind: 'api-key', apiKey: 'sk-ant-test' })
+  })
+
+  test('dual-auth provider (anthropic): user picks oauth → runOAuthLogin fires with anthropic ref', async () => {
+    const loginCalls: Array<{ cwd: string; model: string; providerId: string }> = []
+    const prompts = makePrompts({
+      loadCatalog: async () => ({ options: [anthropicModel], source: 'curated' }),
+      pickProvider: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: anthropicModel }),
+      pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
+      runOAuthLogin: async (provider, cwd, model) => {
+        loginCalls.push({ cwd, model, providerId: provider.id })
+        return { ok: true }
+      },
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(loginCalls).toEqual([{ cwd: '/agent', model: 'anthropic/claude-sonnet-4-6', providerId: 'anthropic' }])
+    expect(result.llmAuth).toEqual({ kind: 'oauth-completed' })
+  })
+
+  test('dual-auth provider (anthropic): oauth failure offers api-key fallback (apiKeyAvailable=true)', async () => {
+    // given: anthropic's OAuth login fails — distinct from openai-codex,
+    //   where api-key fallback is unavailable. The recovery prompt MUST see
+    //   apiKeyAvailable=true so the wizard can route to enter-api-key.
+    let apiKeyAvailableSeen: boolean | undefined
+    const prompts = makePrompts({
+      loadCatalog: async () => ({ options: [anthropicModel], source: 'curated' }),
+      pickProvider: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: anthropicModel }),
+      pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
+      runOAuthLogin: async () => ({ ok: false, reason: 'browser closed' }),
+      askOAuthFailureRecovery: async (_provider, _reason, apiKeyAvailable) => {
+        apiKeyAvailableSeen = apiKeyAvailable
+        return 'api-key'
+      },
+      askApiKey: async () => ({ kind: 'value', value: 'sk-ant-recovered' }),
+    })
+
+    const result = await collectWizardInputs('/agent', prompts)
+
+    expect(apiKeyAvailableSeen).toBe(true)
+    expect(result.llmAuth).toEqual({ kind: 'api-key', apiKey: 'sk-ant-recovered' })
   })
 })

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -374,7 +374,14 @@ export const defaultWizardPrompts: WizardPrompts = {
   hasExistingChannelSecrets,
   askReuseExistingChannel,
   runChannelFlow,
-  runOAuthLogin: (provider, cwd, model) => makeOAuthLoginRunner(buildOAuthCallbacks(provider.name))({ cwd, model }),
+  runOAuthLogin: async (provider, cwd, model) => {
+    const { callbacks, dispose } = buildOAuthCallbacks(provider.name)
+    try {
+      return await makeOAuthLoginRunner(callbacks)({ cwd, model })
+    } finally {
+      dispose()
+    }
+  },
   askOAuthFailureRecovery,
 }
 

--- a/src/cli/oauth-callbacks.test.ts
+++ b/src/cli/oauth-callbacks.test.ts
@@ -4,11 +4,19 @@ import { buildOAuthCallbacks } from './oauth-callbacks'
 
 describe('buildOAuthCallbacks', () => {
   test('provides every callback the OAuth runner forwards to pi-ai, including onManualCodeInput', () => {
-    const callbacks = buildOAuthCallbacks('Test Provider')
+    const { callbacks } = buildOAuthCallbacks('Test Provider')
 
     expect(typeof callbacks.onAuth).toBe('function')
     expect(typeof callbacks.onProgress).toBe('function')
     expect(typeof callbacks.onPrompt).toBe('function')
     expect(typeof callbacks.onManualCodeInput).toBe('function')
+  })
+
+  test('returns a dispose function so call sites can cancel orphaned prompts after pi-ai wins the browser race', () => {
+    const { dispose } = buildOAuthCallbacks('Test Provider')
+
+    expect(typeof dispose).toBe('function')
+    expect(() => dispose()).not.toThrow()
+    expect(() => dispose()).not.toThrow()
   })
 })

--- a/src/cli/oauth-callbacks.ts
+++ b/src/cli/oauth-callbacks.ts
@@ -9,41 +9,71 @@ import type { OAuthCallbacks } from '@/init/oauth-login'
 // concurrent `onManualCodeInput` prompt for users whose browser is on a
 // different host than the CLI. See src/init/oauth-login.ts for the contract
 // on each callback and why onManualCodeInput is required for cross-device.
-export function buildOAuthCallbacks(providerName: string): OAuthCallbacks {
+//
+// Returns `{ callbacks, dispose }` rather than bare callbacks because of a
+// pi-ai contract gap: pi-ai races `onManualCodeInput()` against the local
+// callback server (packages/ai/src/utils/oauth/anthropic.ts:210-253). When
+// the browser wins the race, pi-ai sets `result.code` and falls through to
+// token exchange WITHOUT calling `server.cancelWait()` on the manual side —
+// the manual `text()` prompt is left dangling in clack's render pipeline,
+// re-appearing after every subsequent log line. Without the dispose hook,
+// the user sees "Logged in to {Provider}" immediately followed by the stale
+// "paste the redirect URL here" prompt that's now meaningless. Each call
+// site (init/provider) MUST call `dispose()` in a finally after the OAuth
+// runner returns so the orphaned prompt aborts cleanly; clack honors the
+// signal by resolving the prompt with cancel state, the cancel branch
+// throws inside our callback, and pi-ai's outer `.catch()` swallows it
+// (since it stops awaiting the manual promise on the winning-browser path).
+export type OAuthCallbackHandle = {
+  callbacks: OAuthCallbacks
+  dispose: () => void
+}
+
+export function buildOAuthCallbacks(providerName: string): OAuthCallbackHandle {
+  const controller = new AbortController()
+  const { signal } = controller
   return {
-    onAuth: (url, instructions) => {
-      // Don't put the URL inside note(): clack wraps long lines with the box
-      // border `│` on each wrapped segment, which corrupts the URL when the
-      // user copy-pastes it. Keep instructional text in the box, but print
-      // the URL itself as a bare console.log line that any terminal will
-      // hyperlink intact.
-      const preamble = [
-        `Open this URL in your browser to sign in to ${providerName}.`,
-        '',
-        'If your browser shows "this site can\'t be reached" after you sign in,',
-        'copy the full address from the top of the browser and paste it below.',
-      ]
-      if (instructions) preamble.push('', instructions)
-      note(preamble.join('\n'), 'Browser login')
-      console.log(url)
-      console.log('')
-    },
-    onProgress: (message) => {
-      log.info(message)
-    },
-    onPrompt: async (message, placeholder) => {
-      const value = await text({ message, ...(placeholder !== undefined ? { placeholder } : {}) })
-      if (isCancel(value)) return null
-      return value
-    },
-    onManualCodeInput: async () => {
-      const value = await text({
-        message:
-          'If your browser shows "this site can\'t be reached" after you sign in, copy the full address from the top of the browser and paste it here:',
-        placeholder: 'http://localhost:1455/auth/callback?code=...&state=...',
-      })
-      if (isCancel(value)) throw new Error('Login cancelled by user')
-      return value
+    dispose: () => controller.abort(),
+    callbacks: {
+      onAuth: (url, instructions) => {
+        // Don't put the URL inside note(): clack wraps long lines with the box
+        // border `│` on each wrapped segment, which corrupts the URL when the
+        // user copy-pastes it. Keep instructional text in the box, but print
+        // the URL itself as a bare console.log line that any terminal will
+        // hyperlink intact.
+        const preamble = [
+          `Open this URL in your browser to sign in to ${providerName}.`,
+          '',
+          'If your browser shows "this site can\'t be reached" after you sign in,',
+          'copy the full address from the top of the browser and paste it below.',
+        ]
+        if (instructions) preamble.push('', instructions)
+        note(preamble.join('\n'), 'Browser login')
+        console.log(url)
+        console.log('')
+      },
+      onProgress: (message) => {
+        log.info(message)
+      },
+      onPrompt: async (message, placeholder) => {
+        const value = await text({
+          message,
+          signal,
+          ...(placeholder !== undefined ? { placeholder } : {}),
+        })
+        if (isCancel(value)) return null
+        return value
+      },
+      onManualCodeInput: async () => {
+        const value = await text({
+          message:
+            'If your browser shows "this site can\'t be reached" after you sign in, copy the full address from the top of the browser and paste it here:',
+          placeholder: 'http://localhost:1455/auth/callback?code=...&state=...',
+          signal,
+        })
+        if (isCancel(value)) throw new Error('Login cancelled by user')
+        return value
+      },
     },
   }
 }

--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -367,10 +367,15 @@ async function runOAuthLogin(cwd: string, providerId: KnownProviderId): Promise<
   }
   const modelRef = `${providerId}/${ref}` as const
 
-  const runner = makeOAuthLoginRunner(buildOAuthCallbacks(provider.name))
-  const result = await runner({ cwd, model: modelRef as Parameters<typeof runner>[0]['model'] })
-  if (!result.ok) return { ok: false, reason: result.reason }
-  return { ok: true }
+  const { callbacks, dispose } = buildOAuthCallbacks(provider.name)
+  try {
+    const runner = makeOAuthLoginRunner(callbacks)
+    const result = await runner({ cwd, model: modelRef as Parameters<typeof runner>[0]['model'] })
+    if (!result.ok) return { ok: false, reason: result.reason }
+    return { ok: true }
+  } finally {
+    dispose()
+  }
 }
 
 function authHint(id: KnownProviderId): string {

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -69,6 +69,21 @@ describe('KNOWN_PROVIDERS', () => {
       expect(codingPlanSupported.has(modelId), `${modelId} is not officially Coding-Plan-supported`).toBe(true)
     }
   })
+
+  test('anthropic supports both api-key and oauth on the same provider id', () => {
+    const anthropic = KNOWN_PROVIDERS.anthropic
+    expect(anthropic.baseUrl).toBe('https://api.anthropic.com')
+    expect(anthropic.apiKeyEnv).toBe('ANTHROPIC_API_KEY')
+    expect(anthropic.oauthProviderId).toBe('anthropic')
+    expect(supportsApiKey(anthropic)).toBe(true)
+    expect(supportsOAuth(anthropic)).toBe(true)
+  })
+
+  test('every anthropic model uses the anthropic-messages api so pi-ai routes correctly', () => {
+    for (const [modelId, model] of Object.entries(KNOWN_PROVIDERS.anthropic.models)) {
+      expect(model.api, `anthropic/${modelId} api drift`).toBe('anthropic-messages')
+    }
+  })
 })
 
 describe('providerForModelRef', () => {
@@ -91,5 +106,22 @@ describe('listKnownModelRefs', () => {
     const refs = listKnownModelRefs()
     expect(refs).toContain('zai/glm-4.6')
     expect(refs).toContain('zai-coding/glm-5.1')
+  })
+
+  test('includes the current Anthropic GA tier (Haiku 4.5 / Sonnet 4.6 / Opus 4.7)', () => {
+    const refs = listKnownModelRefs()
+    expect(refs).toContain('anthropic/claude-haiku-4-5')
+    expect(refs).toContain('anthropic/claude-sonnet-4-6')
+    expect(refs).toContain('anthropic/claude-opus-4-7')
+  })
+})
+
+describe('providerForModelRef anthropic', () => {
+  test('routes claude-sonnet-4-6 to anthropic', () => {
+    expect(providerForModelRef('anthropic/claude-sonnet-4-6')).toBe('anthropic')
+  })
+
+  test('routes claude-opus-4-7 to anthropic', () => {
+    expect(providerForModelRef('anthropic/claude-opus-4-7')).toBe('anthropic')
   })
 })

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -108,6 +108,112 @@ export const KNOWN_PROVIDERS = {
       },
     },
   },
+  // Anthropic Claude — both the Anthropic Console API (ANTHROPIC_API_KEY)
+  // and Claude Pro/Max/Team/Enterprise subscriptions (OAuth) reach the same
+  // /v1/messages endpoint and share one provider id. Auth path determines
+  // which headers pi-ai's `anthropic-messages` transport injects: API key
+  // sends a plain `x-api-key`; OAuth sends Bearer + Claude Code identity
+  // (anthropic-beta: claude-code-20250219,oauth-2025-04-20 +
+  // user-agent: claude-cli/<version>), which is exactly the surface a
+  // subscriber's `claude setup-token` credential authorizes. The OAuth dance
+  // itself is authorization-code + PKCE against `claude.ai/oauth/authorize`
+  // with a localhost callback server (not device-code); the existing
+  // `typeclaw-claude-code` skill documents the user-side flow for getting
+  // a subscription credential onto the agent when the in-container browser
+  // callback can't reach the user's machine.
+  //
+  // anthropic is the FIRST provider in the registry where both auth modes
+  // coexist on one entry. The runtime in src/agent/auth.ts has a load-bearing
+  // resolution rule: when secrets.json#providers.anthropic carries an OAuth
+  // credential, `ANTHROPIC_API_KEY` in .env is IGNORED (OAuth-on-disk wins
+  // because env-wins only applies to api-key-shaped credentials). For
+  // api-key-only providers this is invisible; for anthropic it surfaces as
+  // "I added the env var but the agent still uses OAuth." The mitigation is
+  // to remove the OAuth credential explicitly (`typeclaw provider remove
+  // anthropic`) before relying on the env-var path. Same rule applies to any
+  // future dual-auth provider — keep the surprise in mind when expanding.
+  //
+  // Model lineup is the current GA tier as of 2026-04-16: Opus 4.7 (top,
+  // released Apr 16 2026), Sonnet 4.6 (mid, Feb 5 2026), Haiku 4.5 (fast,
+  // Oct 1 2025). Anthropic's own model overview lists these three as the
+  // current recommended set and flags earlier Opus/Sonnet variants with
+  // "Consider migrating to current models." Opus 4 / Sonnet 4 are deprecated
+  // (retirement: Jun 15 2026); the 4.5/4.6 alternates remain Active but are
+  // not the recommended path.
+  //
+  // ID semantics differ across the lineup and matter for forward-compat:
+  //   - `claude-haiku-4-5` is a 4.5-generation CONVENIENCE ALIAS that
+  //     resolves to the latest dated snapshot (currently `-20251001`). Per
+  //     Anthropic's model-id docs, pre-4.6 dateless ids are evergreen
+  //     pointers — Anthropic can ship a new dated snapshot under the same
+  //     alias and we pick it up automatically.
+  //   - `claude-sonnet-4-6` and `claude-opus-4-7` are 4.6+-generation PINNED
+  //     SNAPSHOTS, not aliases. Anthropic explicitly says "the dateless ID is
+  //     the canonical model ID for that release. It maps to a single, fixed
+  //     model snapshot." A future Sonnet 4.6.1 (if it ever exists) would ship
+  //     under a new id, NOT silently replace `claude-sonnet-4-6`.
+  // Consequence for refresh discipline: bumping Haiku is a no-op (alias
+  // catches the latest); bumping Sonnet/Opus to a future 4.7+ family is a
+  // real edit here. Don't assume `claude-opus-4-7` will silently advance.
+  //
+  // Opus 4.7 specifics that affect cost accounting:
+  //   - New tokenizer: same input maps to 1.0-1.3x more tokens than prior
+  //     generations depending on content type. Per-token price is unchanged
+  //     vs Opus 4.6, but total cost on identical workloads can rise meaningfully.
+  //   - 1M token context window (vs 200k on Haiku) and 128k max output (vs
+  //     64k on Sonnet/Haiku). 1M context is at standard pricing — no surcharge.
+  //   - New `xhigh` effort level between `high` and `max` (pi-ai 0.67.x may
+  //     not surface this knob yet; check before relying on it).
+  //
+  // Pricing mirrors Anthropic's official table as of 2026-05; cacheWrite is
+  // the 5m-TTL rate (1.25x input). 1h TTL is ~2x input (not modeled here —
+  // pi-ai's `cacheWrite` field captures the default 5m rate only).
+  anthropic: {
+    id: 'anthropic',
+    name: 'Anthropic',
+    baseUrl: 'https://api.anthropic.com',
+    auth: ['api-key', 'oauth'],
+    apiKeyEnv: 'ANTHROPIC_API_KEY',
+    oauthProviderId: 'anthropic',
+    models: {
+      'claude-haiku-4-5': {
+        id: 'claude-haiku-4-5',
+        name: 'Claude Haiku 4.5',
+        api: 'anthropic-messages',
+        provider: 'anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
+        contextWindow: 200000,
+        maxTokens: 64000,
+      },
+      'claude-sonnet-4-6': {
+        id: 'claude-sonnet-4-6',
+        name: 'Claude Sonnet 4.6',
+        api: 'anthropic-messages',
+        provider: 'anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+        contextWindow: 1000000,
+        maxTokens: 64000,
+      },
+      'claude-opus-4-7': {
+        id: 'claude-opus-4-7',
+        name: 'Claude Opus 4.7',
+        api: 'anthropic-messages',
+        provider: 'anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+        contextWindow: 1000000,
+        maxTokens: 128000,
+      },
+    },
+  },
   // ChatGPT Plus/Pro subscription via the OAuth Codex backend. No API key
   // path here on purpose — the Codex backend is OAuth-only upstream.
   //

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -13,6 +13,7 @@ const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string> = {
   // (Codex is a backend, not a separate provider in their taxonomy). Curated
   // entries are surfaced regardless of upstream membership.
   'openai-codex': 'openai',
+  anthropic: 'anthropic',
   fireworks: 'fireworks-ai',
   zai: 'zai',
   // zai-coding (GLM Coding Plan) is a billing surface, not a separate model


### PR DESCRIPTION
## Summary

Adds Anthropic Claude as a new LLM provider supporting both `ANTHROPIC_API_KEY` (Console / API billing) and OAuth against a Claude Pro/Max/Team/Enterprise subscription. The user originally asked to "implement Claude Code API as a channel"; we clarified that they meant **as a provider** (not a channel adapter), so this is the right shape for the request.

Anthropic is the **first dual-auth provider** in the registry — both methods reach the same `/v1/messages` endpoint on `api.anthropic.com`, so they share one provider id (unlike `openai` vs `openai-codex`, where the Codex endpoint is on a different host and demands a separate entry). When OAuth credentials are present, pi-ai's `anthropic-messages` transport injects Claude Code identity headers (`anthropic-beta: claude-code-20250219,oauth-2025-04-20` + `user-agent: claude-cli/<version>`) — i.e. the exact surface a subscriber's `claude setup-token` credential authorizes. The OAuth dance itself is authorization-code + PKCE with a localhost callback, not device-code.

## Model lineup

Ships the current GA tier verified against [Anthropic's model overview](https://platform.claude.com/docs/en/about-claude/models/overview) as of 2026-04-16:

| Tier | Model ID | Context | Max output | Pricing (in / out / cacheRead / cacheWrite-5m) |
|---|---|---|---|---|
| Top | `claude-opus-4-7` | 1M | 128k | \$5 / \$25 / \$0.50 / \$6.25 |
| Mid | `claude-sonnet-4-6` | 1M | 64k | \$3 / \$15 / \$0.30 / \$3.75 |
| Fast | `claude-haiku-4-5` | 200k | 64k | \$1 / \$5 / \$0.10 / \$1.25 |

### Two semantic shifts worth flagging at the registry site

1. **ID semantics differ across the lineup.** Per [Anthropic's model-id docs](https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions): for pre-4.6 models, dateless ids like `claude-haiku-4-5` are **convenience aliases** that resolve to the latest dated snapshot. Starting with the 4.6 generation, dateless ids like `claude-sonnet-4-6` and `claude-opus-4-7` are **pinned snapshots**, not aliases. The Haiku entry auto-rotates when Anthropic ships a new dated snapshot; Sonnet/Opus require explicit edits to advance. Both behaviors are documented in load-bearing comments at the registry site.

2. **Opus 4.7 ships a new tokenizer.** Same input maps to **1.0–1.3× more tokens** vs prior generations depending on content type. Per-token price is unchanged from 4.6, but identical workloads can cost meaningfully more. Documented at the registry site for anyone tracking spend.

## CLI integration

All three commands enumerate `KNOWN_PROVIDERS` dynamically via `Object.keys()` and `KnownProviderId`-typed exhaustive `Record`s. The new provider and its three model refs flow through automatically with **zero additional plumbing**:

- **`typeclaw init`** — Anthropic appears in the provider picker with hint "API key or OAuth"; the auth-method picker (`pickAuthMethod`) presents both options when the user selects it.
- **`typeclaw provider add`** — accepts `anthropic` as the provider id; `--oauth` routes to OAuth, otherwise prompts for an API key.
- **`typeclaw model list / set / add`** — `anthropic/claude-haiku-4-5`, `anthropic/claude-sonnet-4-6`, and `anthropic/claude-opus-4-7` appear in the available-models list and can be assigned to any profile.

Wires `anthropic` into `PROVIDER_TO_MODELS_DEV` so the init picker also surfaces live Anthropic models from models.dev alongside the curated entries.

## Runtime precedence (hidden in pre-existing rule, now user-visible)

Anthropic is the first dual-auth provider, so an existing rule in `src/agent/auth.ts:53-71` becomes user-visible for the first time: **when an OAuth credential exists on disk in `secrets.json`, `ANTHROPIC_API_KEY` in `.env` is IGNORED.** Env-wins only applies to api-key-shaped credentials; OAuth-on-disk takes precedence. A user who init'd with OAuth and later adds `ANTHROPIC_API_KEY` to `.env` expecting to switch will silently stay on OAuth. The mitigation pointer is `typeclaw provider remove anthropic`. Documented inline at the provider entry.

## OAuth UX bug fix (orphaned post-login prompt)

While testing the OAuth flow end-to-end, surfaced and fixed a clack-rendering bug that affected **all OAuth-capable providers** (anthropic, openai-codex, etc.), not just anthropic. Pi-ai races `onManualCodeInput()` against the local callback server ([`packages/ai/src/utils/oauth/anthropic.ts:210-253`](https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/utils/oauth/anthropic.ts#L210-L253)). When the browser wins the race, pi-ai sets `result.code` and falls through to token exchange **without calling `server.cancelWait()` on the manual side** — the manual `text()` prompt is left dangling in clack's render pipeline and re-appears after each subsequent log line, AFTER the success message.

User-visible symptom (paraphrasing the report):

```
◇  Logged in to Anthropic. ───────────────────╮
│                                             │
│  If the agent is running:  typeclaw reload  │
│                                             │
◇  If your browser shows "this site can't be reached" after you sign in,
   copy the full address from the top of the browser and paste it here:
```

Fix: `buildOAuthCallbacks` now returns `{ callbacks, dispose }`. The dispose hook aborts an internal `AbortController` whose signal is plumbed into both `text()` prompts via clack's `signal` option. Each call site (`typeclaw init`, `typeclaw provider add`) calls `dispose()` in a finally after the OAuth runner returns; clack honors the signal by resolving the orphaned prompt with cancel state, and pi-ai's outer `.catch()` (line 219) swallows the resulting cancel-throw silently since it has stopped awaiting the manual promise on the winning-browser path.

## Test coverage

Three new wizard tests in `src/cli/init.test.ts` cover the previously-uncovered dual-auth branches against `anthropic` directly:

- `pickAuthMethod` is a REAL prompt (not `autoValue`) for a dual-auth provider, with both options visible.
- OAuth path fires `runOAuthLogin` with the correct anthropic ref.
- OAuth failure offers the api-key fallback with `apiKeyAvailable=true` (distinct from oauth-only providers, where it sees `apiKeyAvailable=false`).

Existing oauth-path tests used `openai` (api-key-only, with the oauth branch mocked) or `openai-codex` (oauth-only). Anthropic is the first real exercise of these code paths in production.

## Files changed

- `src/config/providers.ts` — new `anthropic` entry (3 models, load-bearing comments)
- `src/init/models-dev.ts` — one-line addition to `PROVIDER_TO_MODELS_DEV`
- `src/config/providers.test.ts` — auth-method invariants + new model ref assertions
- `src/cli/init.test.ts` — three dual-auth wizard tests
- `src/cli/oauth-callbacks.ts` — `{ callbacks, dispose }` shape with abort plumbing
- `src/cli/init.ts` — wraps `runOAuthLogin` in try/finally to call dispose
- `src/cli/provider.ts` — same try/finally wrapping at the provider-add OAuth call

## Validation

- `bun run typecheck` ✓
- `bun run lint` ✓ (18 pre-existing warnings, 0 errors, none in changed files)
- `bun run format:check` ✓
- `bun run test` — 4564 / 4564 pass (added 4 new tests)

## User-visible behavior after merge

- `typeclaw init` shows Anthropic in the provider picker.
- Users can pick API key (paste `ANTHROPIC_API_KEY`) or OAuth (in-container PKCE flow with localhost callback, or paste a token from `claude setup-token` on their own machine — the existing `typeclaw-claude-code` skill documents the user-side flow).
- Successful OAuth login no longer leaves an orphaned "paste the redirect URL here" prompt rendering on top of the success message.
- The agent's main loop can run on Claude Haiku 4.5 / Sonnet 4.6 / Opus 4.7 against a Pro/Max subscription, no API billing required.

No follow-up migrations needed. The `Dockerfile` does not need a new toggle — pi-ai already carries the Anthropic SDK as a baseline dependency.