### PR TITLE
config: soft-fail the eager snapshot so diagnostic commands survive a broken typeclaw.json

### DIFF
--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { formatStatus, parseStatusResult, type StatusReport } from './status'
+
+const CLI_ENTRY = join(import.meta.dir, 'index.ts')
 
 function baseReport(overrides: Partial<StatusReport> = {}): StatusReport {
   return {
@@ -172,5 +177,57 @@ describe('formatStatus', () => {
     )
 
     expect(out).not.toContain('\u001b[')
+  })
+})
+
+describe('typeclaw status survives broken typeclaw.json', () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-status-broken-'))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  async function runStatus(): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn({
+      cmd: ['bun', CLI_ENTRY, 'status'],
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, NO_COLOR: '1' },
+    })
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+    const exitCode = await proc.exited
+    return { exitCode, stdout, stderr }
+  }
+
+  test('exits 0 and renders sections when typeclaw.json is malformed JSON', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), 'NOT JSON AT ALL {{{')
+    const { exitCode, stdout, stderr } = await runStatus()
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Container')
+    expect(stdout).toContain('Host daemon')
+    expect(stdout).toContain('Port forwarding')
+    expect(stderr).toMatch(/not valid JSON/)
+    expect(stderr).toMatch(/diagnostic commands still work/)
+  })
+
+  test('exits 0 and renders sections when typeclaw.json is schema-invalid', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'not-a-known-model' } }))
+    const { exitCode, stdout, stderr } = await runStatus()
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Container')
+    expect(stdout).toContain('Host daemon')
+    expect(stderr).toMatch(/typeclaw\.json is invalid/)
+  })
+
+  test('exits 0 and prints no warning when typeclaw.json is missing (fresh dir)', async () => {
+    const { exitCode, stdout, stderr } = await runStatus()
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Container')
+    expect(stderr).not.toMatch(/warning:/)
   })
 })

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -10,6 +10,7 @@ import {
   extractPluginConfigs,
   expandMountPath,
   loadConfigSync,
+  loadConfigSyncOrDefaults,
   loadPluginConfigsSync,
   migrateLegacyConfigShape,
   mountSchema,
@@ -1402,6 +1403,52 @@ describe('loadConfigSync', () => {
       }),
     )
     expect(() => loadConfigSync(cwd)).toThrow(/typeclaw\.json is invalid/)
+  })
+})
+
+describe('loadConfigSyncOrDefaults', () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-load-soft-'))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  test('returns the real config when typeclaw.json is valid (no warning)', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: VALID_MODEL }, port: 9100 }))
+    const warnings: string[] = []
+    const cfg = loadConfigSyncOrDefaults(cwd, { warn: (msg) => warnings.push(msg) })
+    expect(cfg.port).toBe(9100)
+    expect(warnings).toEqual([])
+  })
+
+  test('returns schema defaults when typeclaw.json is missing (no warning — this is the fresh-agent path)', () => {
+    const warnings: string[] = []
+    const cfg = loadConfigSyncOrDefaults(cwd, { warn: (msg) => warnings.push(msg) })
+    expect(cfg.port).toBe(8973)
+    expect(warnings).toEqual([])
+  })
+
+  test('returns schema defaults + warning when typeclaw.json is malformed JSON', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), '{ not json')
+    const warnings: string[] = []
+    const cfg = loadConfigSyncOrDefaults(cwd, { warn: (msg) => warnings.push(msg) })
+    expect(cfg.port).toBe(8973)
+    expect(warnings.length).toBe(1)
+    expect(warnings[0]).toMatch(/not valid JSON/)
+    expect(warnings[0]).toMatch(/diagnostic commands still work/)
+  })
+
+  test('returns schema defaults + warning when typeclaw.json is schema-invalid', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'not-a-known-model' } }))
+    const warnings: string[] = []
+    const cfg = loadConfigSyncOrDefaults(cwd, { warn: (msg) => warnings.push(msg) })
+    expect(cfg.port).toBe(8973)
+    expect(warnings.length).toBe(1)
+    expect(warnings[0]).toMatch(/typeclaw\.json is invalid/)
   })
 })
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -420,15 +420,39 @@ export function expandMountPath(input: string, cwd: string): string {
 
 // Loaded eagerly from process.cwd()/typeclaw.json at module-import time so
 // citty arg defaults (e.g. config.port in src/cli/*.ts) see real values, not
-// hardcoded fallbacks. Missing file → schema defaults; malformed file → throw,
-// which surfaces during CLI startup instead of silently reverting to defaults
-// and confusing the user.
+// hardcoded fallbacks. Missing file → schema defaults; malformed file → ALSO
+// schema defaults plus a stderr warning.
+//
+// Why soft-fail and not throw: every CLI command — including diagnostic ones
+// (`typeclaw status`, `typeclaw doctor`, `typeclaw logs`, `typeclaw stop`,
+// `typeclaw usage`, `typeclaw tui`) — pays this eager-load cost through its
+// import graph, regardless of whether the command actually reads config. A
+// hard throw here turns every read-only diagnostic into a crash exactly when
+// the user needs the diagnostic to figure out what's wrong with their config.
+// `validateConfig` (called by `start`/`restart`/`reload`/host-side mutations)
+// is the strict gate for destructive paths; that's where malformed-config
+// errors should surface, not at module-import time.
 //
 // `config` is a module-import-time snapshot. Container-stage code that must
 // observe `typeclaw run` reloads should call `getConfig()` instead, which
 // returns the current swapped-in value. Host-stage CLI processes are
 // short-lived, so they keep using `config` directly.
-export const config: Config = loadConfigSync(process.cwd())
+export const config: Config = loadConfigSyncOrDefaults(process.cwd())
+
+export function loadConfigSyncOrDefaults(cwd: string, options: { warn?: (message: string) => void } = {}): Config {
+  try {
+    return loadConfigSync(cwd)
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    const warn = options.warn ?? ((message: string) => process.stderr.write(message))
+    warn(
+      `warning: ${detail}\n` +
+        `warning: continuing with default config so diagnostic commands still work; ` +
+        `run \`typeclaw doctor\` or fix ${CONFIG_FILE} before \`typeclaw start\`/\`restart\`/\`reload\`.\n`,
+    )
+    return configSchema.parse({})
+  }
+}
 
 let current: Config = config
 


### PR DESCRIPTION
## Summary

`typeclaw status`, `doctor`, `logs`, `stop`, `usage`, and `tui` all crashed with an uncaught exception when `typeclaw.json` was malformed or schema-invalid — exactly the commands you reach for to diagnose a broken config. The root cause was an eager module-import-time call that threw before the command's `run()` function was ever invoked. This PR replaces it with a soft-fail helper that lets diagnostic commands run on defaults while leaving the strict validation gate intact for destructive commands.

## Root cause

`src/config/config.ts` had:

```ts
export const config: Config = loadConfigSync(process.cwd())
```

This runs at module-import time. Every CLI command transitively imports `@/config`. The `status` command chain is `status → @/init → @/config`; `doctor` goes `doctor → @/config`; and so on. The throw fired before citty's `run()` was called — before any command-specific error handling had a chance to run. The result: attempting to use `typeclaw status` or `typeclaw doctor` to diagnose a bad config produced a raw uncaught exception instead of useful output.

## Fix

Replace the eager call with `loadConfigSyncOrDefaults`, which:

1. Calls `loadConfigSync` (the existing strict path).
2. On any parse or schema error, falls back to `configSchema.parse({})` — the same defaults the missing-file path already produces.
3. Prints a one-time stderr warning naming the error and pointing the user at `typeclaw doctor`.

Strict validation stays exactly where AGENTS.md says it belongs: `validateConfig` remains the single host-side gate that `start`, `restart`, `reload`, and any host-side mutation calls before doing anything destructive. Those callers are unchanged and still surface the same hard error they did before.

**Why this is the right layer:** the eager module-import-time throw bypassed the strict gate entirely for read-only diagnostic paths. The soft-fail moves the throw to the actual destructive callers where the gate already lives — removing the crash without weakening any runtime protection.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Valid `typeclaw.json` | Works | Works (no change) |
| Missing `typeclaw.json` | Returns defaults silently | Returns defaults silently (no change) |
| Malformed / schema-invalid + diagnostic command | Uncaught exception, exit 1 | Exit 0, stderr warning, command works on defaults |
| Malformed / schema-invalid + `start` / `restart` | `validateConfig` hard error | `validateConfig` hard error (no change) |

## Tests

**`src/config/config.test.ts`** — 4 new unit tests for `loadConfigSyncOrDefaults`:

- Valid input returns real config with no warning.
- Missing file returns defaults with no warning (fresh-agent path stays clean).
- Malformed JSON returns defaults + warning that names the error and mentions diagnostic commands.
- Schema-invalid JSON returns defaults + warning identifying the config as invalid.

**`src/cli/status.test.ts`** — 3 new spawn-based integration tests:

- Spawn the actual CLI in a tmpdir with a broken `typeclaw.json` and assert exit 0 + all three rendered sections + the stderr warning.
- Mutation check: reverting the soft-fail makes the malformed-JSON and schema-invalid cases fail with exit code 1, confirming the tests pin the behavior, not the implementation.

## Try it

In any directory:

```sh
echo '{ not json' > typeclaw.json
typeclaw status   # exit 0, renders sections, stderr warning
typeclaw doctor   # exit 0, doctor flags the config issue
typeclaw start    # exit 1, validateConfig hard error (unchanged)
```

## Files changed

- `src/config/config.ts` (+27 −5): new `loadConfigSyncOrDefaults` helper and a comment block explaining the soft-fail design choice.
- `src/config/config.test.ts` (+47 −0): 4 new unit tests.
- `src/cli/status.test.ts` (+58 −1): 3 new spawn-based integration tests.

## Pre-merge gates

```
bun run typecheck   clean
bun run lint        0 errors in changed files (18 pre-existing warnings on main)
bun run format      clean
```
