### PR TITLE
model: soft-fail `typeclaw model list` so a broken typeclaw.json does not crash the diagnostic

### DIFF
--- a/src/cli/model.test.ts
+++ b/src/cli/model.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const CLI_ENTRY = join(import.meta.dir, 'index.ts')
+
+describe('typeclaw model list survives broken typeclaw.json', () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-model-list-broken-'))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  async function runModelList(): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn({
+      cmd: ['bun', CLI_ENTRY, 'model', 'list'],
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, NO_COLOR: '1' },
+    })
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+    const exitCode = await proc.exited
+    return { exitCode, stdout, stderr }
+  }
+
+  test('exits 0 and renders the default profile when typeclaw.json is malformed JSON', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), 'NOT JSON AT ALL {{{')
+    const { exitCode, stdout, stderr } = await runModelList()
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('PROFILE')
+    expect(stdout).toContain('default')
+    expect(stderr).toMatch(/not valid JSON/)
+    expect(stderr).toMatch(/diagnostic commands still work/)
+  })
+
+  test('exits 0 and renders the default profile when typeclaw.json is schema-invalid', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'not-a-known-model' } }))
+    const { exitCode, stdout, stderr } = await runModelList()
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('PROFILE')
+    expect(stdout).toContain('default')
+    expect(stderr).toMatch(/typeclaw\.json is invalid/)
+  })
+})

--- a/src/config/models-mutation.test.ts
+++ b/src/config/models-mutation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { readFile, mkdtemp, rm } from 'node:fs/promises'
+import { readFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -264,6 +264,22 @@ describe('listModelProfiles', () => {
     const entries = listModelProfiles(root, env)
     const dflt = entries.find((e) => e.profile === 'default')
     expect(dflt?.missingProviders).toEqual(['openai'])
+  })
+
+  test('falls back to default models when typeclaw.json is malformed JSON instead of throwing', async () => {
+    await writeFile(join(root, 'typeclaw.json'), 'NOT JSON AT ALL {{{')
+    const entries = listModelProfiles(root, {})
+    expect(entries.length).toBe(1)
+    expect(entries[0]?.profile).toBe('default')
+    expect(entries[0]?.isDefault).toBe(true)
+  })
+
+  test('falls back to default models when typeclaw.json is schema-invalid instead of throwing', async () => {
+    await writeFile(join(root, 'typeclaw.json'), JSON.stringify({ models: { default: 'not-a-known-model' } }))
+    const entries = listModelProfiles(root, {})
+    expect(entries.length).toBe(1)
+    expect(entries[0]?.profile).toBe('default')
+    expect(entries[0]?.isDefault).toBe(true)
   })
 })
 

--- a/src/config/models-mutation.ts
+++ b/src/config/models-mutation.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 
 import { commitSystemFileSync } from '@/git/system-commit'
 
-import { configSchema, loadConfigSync, validateConfig } from './config'
+import { configSchema, loadConfigSyncOrDefaults, validateConfig } from './config'
 import {
   KNOWN_PROVIDERS,
   listKnownModelRefs,
@@ -33,8 +33,16 @@ export type ModelProfileEntry = {
 
 export type ModelMutationResult = { ok: true } | { ok: false; reason: string }
 
+// `listModelProfiles` is the read-only path behind `typeclaw model list`, a
+// diagnostic command. It routes through `loadConfigSyncOrDefaults` (same
+// soft-fail pattern as `typeclaw status` / `doctor`, PR #288) so a broken
+// `typeclaw.json` doesn't crash the command users reach for to see what
+// model config the agent thinks it has. Mutation paths (`setProfile`,
+// `addProfile`, `removeProfile`) stay on the strict gate via `validateConfig`
+// in `writeModels`, because writing through a broken-on-disk file would
+// silently land schema-invalid bytes.
 export function listModelProfiles(cwd: string, env: NodeJS.ProcessEnv = process.env): ModelProfileEntry[] {
-  const models = loadConfigSync(cwd).models
+  const models = loadConfigSyncOrDefaults(cwd).models
   const out: ModelProfileEntry[] = []
   for (const [profile, refs] of Object.entries(models)) {
     const headRef = refs[0]!


### PR DESCRIPTION
## Summary

Follow-up to #288. `typeclaw model list` still crashed with an uncaught exception when `typeclaw.json` was malformed or schema-invalid — the same crash class #288 fixed for `status`/`doctor`/`logs`/`stop`/`usage`/`tui`. `model list` is the diagnostic you'd reach for after the eager-snapshot warning prints to see what model config the agent thinks it has, so a crash here defeats the same workflow #288 set out to enable.

## Root cause

#288 added `loadConfigSyncOrDefaults` and swapped the eager top-level `config` snapshot over to it, so the module-import-time throw is gone. But `listModelProfiles` (the read-only path behind `typeclaw model list`) explicitly re-entered `loadConfigSync`:

```ts
// src/config/models-mutation.ts (before)
export function listModelProfiles(cwd, env = process.env) {
  const models = loadConfigSync(cwd).models
  ...
```

Repro on `main`:

```sh
> echo '{ not json' > typeclaw.json
> typeclaw model list
warning: typeclaw.json is not valid JSON: ...       # <-- from the eager snapshot (#288)
warning: continuing with default config so ...
error: typeclaw.json is not valid JSON: JSON Parse error: Expected '}'
    at loadConfigSync (src/config/config.ts:646:15)
    at listModelProfiles (src/config/models-mutation.ts:37:18)
    at run (src/cli/model.ts:153:21)
exit 1
```

The first two lines come from #288's snapshot; the third is the new crash.

## Fix

One-line swap: `listModelProfiles` now calls `loadConfigSyncOrDefaults` instead of `loadConfigSync`. Same helper, same soft-fail contract, same warning shape #288 already ships. The diagnostic now exits 0 and prints the default profile row:

```sh
> typeclaw model list
warning: typeclaw.json is not valid JSON: ...
warning: continuing with default config so ...
PROFILE  REF                  PROVIDER  STATUS
*default  openai/gpt-5.4-nano  openai        missing-credentials
```

Mutation paths (`setProfile`, `addProfile`, `removeProfile`) are unchanged. They route writes through `writeModels`, which keeps the strict gate via `validateConfig(cwd)` — a broken-on-disk file cannot absorb a write through them.

**Asymmetric on purpose:** list = soft-fail (diagnostic); set/add/remove = strict gate (destructive). Same fence #288 documented: diagnostic paths must survive; destructive paths must surface the hard error.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Valid `typeclaw.json` + `model list` | Works | Works (no change) |
| Missing `typeclaw.json` + `model list` | `ensureAgentDir` exit 1 with hint to `typeclaw init` | Same (no change — orthogonal check) |
| Malformed `typeclaw.json` + `model list` | Uncaught exception, exit 1 | Exit 0, stderr warning, default row rendered |
| Schema-invalid `typeclaw.json` + `model list` | Uncaught exception, exit 1 | Exit 0, stderr warning, default row rendered |
| Any state + `model set` / `add` / `remove` | `validateConfig` hard error on broken file | `validateConfig` hard error on broken file (no change) |
| `model list --available` | Works (early return, no config read) | Works (no change) |

## Tests

**`src/config/models-mutation.test.ts`** — 2 new unit tests on `listModelProfiles`:

- Malformed JSON → returns the schema-default `default` profile entry instead of throwing.
- Schema-invalid JSON → same.

**`src/cli/model.test.ts`** (new file) — 2 spawn-based integration tests:

- Spawn the actual CLI in a tmpdir with malformed JSON: assert exit 0, `PROFILE` header rendered, stderr warning naming the parse error.
- Same with schema-invalid JSON: assert exit 0, default row, stderr warning identifying the config as invalid.

**Mutation check** (the AGENTS.md §1 acceptance bar): reverting `loadConfigSyncOrDefaults` back to `loadConfigSync` on `listModelProfiles` makes all 4 new tests fail (2 unit + 2 integration). Tests pin behavior, not implementation.

## Scope discipline

`tunnel list` doesn't read `loadConfigSync` directly — it talks to the running agent — so it's unaffected.

`role list` (`src/cli/role.ts`) is the same crash shape (calls `loadConfigSync` directly for a read-only display) and a candidate for the same one-line swap. Left out of this PR to keep the change minimal and the diff reviewable; happy to ship as a follow-up if you'd like.

## Try it

```sh
mkdir -p /tmp/broken && cd /tmp/broken
echo '{ not json' > typeclaw.json
typeclaw model list             # exit 0, default row, stderr warning
typeclaw model set default openai/gpt-5.4-nano  # exit 1, validateConfig hard error (unchanged)
```

## Files changed

- `src/config/models-mutation.ts` (+10 −2): swap `loadConfigSync` → `loadConfigSyncOrDefaults` in `listModelProfiles` + a comment block documenting the list-vs-mutation asymmetry.
- `src/config/models-mutation.test.ts` (+17 −1): 2 new unit tests + add `writeFile` to the existing `node:fs/promises` import.
- `src/cli/model.test.ts` (+50, new): 2 new spawn-based integration tests, modeled on #288's `src/cli/status.test.ts`.

## Pre-merge gates

```
bun run typecheck   clean
bun run lint        18 warnings (matches #288 baseline, none in changed files), 0 errors
bun run format      clean
bun test            4576 pass / 0 fail
```
