### PR TITLE
guard: route wrapped builtin tools through customTools

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -27,7 +27,13 @@ import { createCompactionSettingsManager } from './compaction'
 import { renderGitNudge } from './git-nudge'
 import type { LiveSubagentRegistry } from './live-subagents'
 import { lookAtTool } from './multimodal'
-import { resolveBuiltinToolRefs, wrapPluginTool, wrapSystemAgentTool, wrapSystemTool } from './plugin-tools'
+import {
+  buildBuiltinPiToolOverrides,
+  resolveBuiltinToolRefs,
+  wrapPluginTool,
+  wrapSystemAgentTool,
+  wrapSystemTool,
+} from './plugin-tools'
 import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
 import { SESSION_META_CUSTOM_TYPE, sessionMetaPayload } from './session-meta'
@@ -313,7 +319,22 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
               stream: options.stream,
             }),
           ]
-  const customToolsPreBudget = [...wrapSystemTools(customSystemTools, options.plugins, getOrigin), ...pluginCustomTools]
+  // Hook coverage for pi's builtin coding tools (read/bash/edit/write/grep/
+  // find/ls) — pi 0.67.3 ignores `tools:` for implementation, so the only
+  // way to interpose typeclaw guards is to ship same-named ToolDefinition
+  // entries through `customTools`. Skipped when there are no tool hooks,
+  // since wrapping reduces to a passthrough in that case.
+  const builtinPiToolOverrides =
+    options.plugins && hasToolHooks(options.plugins)
+      ? buildBuiltinPiToolOverrides({
+          agentDir: options.plugins.agentDir,
+          sessionId: options.plugins.sessionId,
+          hooks: options.plugins.hooks,
+          getOrigin,
+        })
+      : []
+  const wrappedCustomSystemTools = wrapSystemTools(customSystemTools, options.plugins, getOrigin)
+  const customToolsPreBudget = [...wrappedCustomSystemTools, ...pluginCustomTools, ...builtinPiToolOverrides]
   const customTools =
     sessionBudget && sessionBudgetState
       ? customToolsPreBudget.map((t) => wrapToolDefinitionWithBudget(t, sessionBudget, sessionBudgetState))
@@ -330,6 +351,21 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     ...(tools ? { tools } : {}),
     customTools,
   })
+
+  // Re-narrow the active tool set after `createAgentSession`. pi 0.67.3's
+  // `_refreshToolRegistry` runs with `includeAllExtensionTools: true` and
+  // pushes every customTool name into the active set, which would widen
+  // a subagent's declared `[edit]` to all 7 builtin overrides plus every
+  // typeclaw custom tool. The intended active set is the names the caller
+  // would have gotten WITHOUT the builtin overrides: pi's `initialActiveToolNames`
+  // (derived from `tools:`) union the names from typeclaw/plugin customTools.
+  // `builtinPiToolOverrides` are implementation overrides, never additions.
+  if (builtinPiToolOverrides.length > 0) {
+    const baseActiveNames = tools !== undefined ? tools.map((t) => t.name) : ['read', 'bash', 'edit', 'write']
+    const customToolActiveNames = [...wrappedCustomSystemTools, ...pluginCustomTools].map((t) => t.name)
+    const intendedActive = [...new Set([...baseActiveNames, ...customToolActiveNames])]
+    session.setActiveToolsByName(intendedActive)
+  }
 
   const unsubRestart = subscribeRestartNotice(options.stream, sessionManager)
 

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1,15 +1,24 @@
-import { describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp } from 'node:fs/promises'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import { defineTool as definePiTool } from '@mariozechner/pi-coding-agent'
+import type { ToolDefinition } from '@mariozechner/pi-coding-agent'
 import { Type } from '@sinclair/typebox'
 import { z } from 'zod'
 
-import { createHookBus, defineTool } from '@/plugin'
+import { createHookBus, defineTool, type PluginRegistry } from '@/plugin'
 
-import { wrapPluginTool, wrapSystemAgentTool, wrapSystemTool, zodToToolParameters } from './plugin-tools'
+import {
+  buildBuiltinPiToolOverrides,
+  defaultBuiltinPiAgentTools,
+  wrapAgentToolAsCustomToolDefinition,
+  wrapPluginTool,
+  wrapSystemAgentTool,
+  wrapSystemTool,
+  zodToToolParameters,
+} from './plugin-tools'
 
 const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
 
@@ -697,5 +706,304 @@ describe('resolveBuiltinToolRefs (dual-route)', () => {
   test('throws on unknown built-in names', async () => {
     const { resolveBuiltinToolRefs } = await import('./plugin-tools')
     expect(() => resolveBuiltinToolRefs([{ __builtinTool: 'nope' }])).toThrow(/unknown built-in tool ref/)
+  })
+})
+
+describe('wrapAgentToolAsCustomToolDefinition (pi customTools override path)', () => {
+  test('the returned ToolDefinition runs tool.before/runFinalWriteGuards before delegating to the underlying pi AgentTool', async () => {
+    let executedUnderlying = 0
+    const beforeArgs: unknown[] = []
+    const tool = {
+      name: 'edit',
+      label: 'edit',
+      description: '',
+      parameters: Type.Object({
+        path: Type.String(),
+        edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })),
+      }),
+      async execute(_id: string, _params: unknown) {
+        executedUnderlying++
+        return { content: [{ type: 'text' as const, text: 'underlying ran' }], details: undefined }
+      },
+    }
+    const hooks = createHookBus()
+    hooks.registerAll('p1', '/agent', noopLogger, {
+      'tool.before': (event) => {
+        beforeArgs.push({ ...event.args })
+      },
+    })
+
+    const wrapped = wrapAgentToolAsCustomToolDefinition(tool, { agentDir: '/agent', sessionId: 's', hooks })
+
+    expect(wrapped.name).toBe('edit')
+    const result = await wrapped.execute(
+      'c',
+      { path: 'workspace/notes.md', edits: [{ oldText: 'a', newText: 'b' }] },
+      undefined,
+      undefined,
+      {} as never,
+    )
+    expect(textOfFirstContent(result)).toBe('underlying ran')
+    expect(executedUnderlying).toBe(1)
+    expect(beforeArgs).toEqual([{ path: 'workspace/notes.md', edits: [{ oldText: 'a', newText: 'b' }] }])
+  })
+
+  test('regression: managedConfig guard blocks an edit that would produce invalid typeclaw.json, on the customTool override path', async () => {
+    // PR #283's failure mode: pi 0.67.3 ignores `tools:` for implementation
+    // overrides, so the channel-session `edit` tool that landed commit
+    // 6d1c42c in ~/typeclaw/servant ran pi's internal builtin and bypassed
+    // both `tool.before` and `runFinalWriteGuards`. The fix routes wrapped
+    // builtin pi tools through `customTools`, which IS the override path
+    // pi honors. This test pins the post-fix behavior end-to-end: a tool
+    // call that mutates typeclaw.json to an invalid shape MUST be blocked
+    // by `runFinalWriteGuards` (which calls `checkManagedConfigGuard`),
+    // before the underlying pi `edit` is invoked.
+    const dir = await mkdtemp(path.join(tmpdir(), 'typeclaw-managed-config-'))
+    const configPath = path.join(dir, 'typeclaw.json')
+    const validConfig = {
+      models: { default: 'anthropic/claude-haiku-4-5' },
+    }
+    await Bun.write(configPath, `${JSON.stringify(validConfig, null, 2)}\n`)
+
+    let executedUnderlying = 0
+    const tool = {
+      name: 'edit',
+      label: 'edit',
+      description: '',
+      parameters: Type.Object({
+        path: Type.String(),
+        edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })),
+      }),
+      async execute(_id: string, _params: unknown) {
+        executedUnderlying++
+        return { content: [{ type: 'text' as const, text: 'should not run' }], details: undefined }
+      },
+    }
+    const hooks = createHookBus()
+    hooks.registerAll('p1', dir, noopLogger, {})
+
+    const wrapped = wrapAgentToolAsCustomToolDefinition(tool, { agentDir: dir, sessionId: 's', hooks })
+
+    await expect(
+      wrapped.execute(
+        'c',
+        {
+          path: configPath,
+          edits: [{ oldText: 'anthropic/claude-haiku-4-5', newText: 'kimi' }],
+        },
+        undefined,
+        undefined,
+        {} as never,
+      ),
+    ).rejects.toThrow(/Guard `managedConfig` blocked edit/)
+    expect(executedUnderlying).toBe(0)
+  })
+
+  test('defaultBuiltinPiAgentTools returns the seven pi coding-tool refs that need hook coverage', async () => {
+    const tools = defaultBuiltinPiAgentTools()
+    expect(tools.map((t) => t.name)).toEqual(['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls'])
+  })
+
+  test('buildBuiltinPiToolOverrides produces same-named ToolDefinitions ready for customTools', async () => {
+    const hooks = createHookBus()
+    const overrides = buildBuiltinPiToolOverrides({ agentDir: '/agent', sessionId: 's', hooks })
+    expect(overrides.map((t) => t.name)).toEqual(['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls'])
+  })
+
+  test('buildBuiltinPiToolOverrides preserves edit guard-acknowledgement schema (so the model can pass acknowledgeGuards on edit)', async () => {
+    const hooks = createHookBus()
+    const overrides = buildBuiltinPiToolOverrides({ agentDir: '/agent', sessionId: 's', hooks })
+    const edit = overrides.find((t) => t.name === 'edit')
+    expect(edit).toBeDefined()
+    const params = (edit as ToolDefinition).parameters as { properties?: Record<string, unknown> }
+    expect(params.properties).toBeDefined()
+    expect(params.properties).toHaveProperty('acknowledgeGuards')
+  })
+})
+
+describe('setupSession integration: builtin pi tools route through customTools when hooks are present', () => {
+  // End-to-end seam test for the bug PR #283 thought it had closed: PR #283's
+  // managedConfig guard only fires when the active `edit` tool is the wrapped
+  // one — but pi 0.67.3 ignores `tools:` for implementation, so without
+  // routing wrapped builtins through `customTools`, the active `edit` is
+  // pi's internal builtin and the guard never sees the call. This test
+  // builds a real AgentSession via `createSession` and asserts that the
+  // active `edit` came from `sdk` (customTools override) rather than
+  // `builtin`. If the override wiring in `setupSession` is removed, this
+  // test fails immediately.
+  let agentDir: string
+  let prevCwd: string
+  let prevFireworks: string | undefined
+
+  beforeEach(async () => {
+    agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-guard-wiring-'))
+    prevCwd = process.cwd()
+    prevFireworks = process.env.FIREWORKS_API_KEY
+    process.env.FIREWORKS_API_KEY = 'fw_test'
+    process.chdir(agentDir)
+    await Bun.write(
+      path.join(agentDir, 'typeclaw.json'),
+      JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
+    )
+    const { reloadConfig } = await import('@/config/config')
+    reloadConfig(agentDir)
+  })
+
+  afterEach(async () => {
+    if (prevFireworks === undefined) delete process.env.FIREWORKS_API_KEY
+    else process.env.FIREWORKS_API_KEY = prevFireworks
+    const { __resetConfigForTesting } = await import('@/config/config')
+    const { resetAuthForTesting } = await import('./auth')
+    __resetConfigForTesting()
+    resetAuthForTesting()
+    process.chdir(prevCwd)
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('with tool.before hooks present, the active `edit` is the customTools override (sourceInfo.source === "sdk"), not pi\'s builtin', async () => {
+    const { createSession } = await import('./index')
+    const hooks = createHookBus()
+    hooks.registerAll('p1', agentDir, noopLogger, {
+      'tool.before': () => undefined,
+    })
+    const registry: PluginRegistry = {
+      tools: [],
+      subagents: [],
+      cronJobs: [],
+      skills: [],
+      skillsDirs: [],
+      doctorChecks: [],
+      commands: [],
+    }
+
+    const session = await createSession({
+      plugins: { registry, hooks, sessionId: 'test-session', agentDir },
+    })
+
+    const allTools = session.getAllTools()
+    const editInfo = allTools.find((t) => t.name === 'edit')
+    expect(editInfo).toBeDefined()
+    expect(editInfo?.sourceInfo.source).toBe('sdk')
+
+    session.dispose()
+  })
+
+  test("without any tool hooks, the active `edit` falls through to pi's builtin (no wrapping overhead)", async () => {
+    const { createSession } = await import('./index')
+
+    const session = await createSession({})
+
+    const allTools = session.getAllTools()
+    const editInfo = allTools.find((t) => t.name === 'edit')
+    expect(editInfo).toBeDefined()
+    expect(editInfo?.sourceInfo.source).toBe('builtin')
+
+    session.dispose()
+  })
+
+  test('regression: subagent declaring [edit] only must NOT also activate read/bash/write/grep/find/ls just because builtin overrides exist in customTools', async () => {
+    // The customTools override path widens pi's active tool set as a side effect:
+    // pi's `_refreshToolRegistry` runs with `includeAllExtensionTools: true`,
+    // which appends every customTool name into `nextActiveToolNames` even when
+    // the caller passed a narrow `tools:` filter. Without explicit re-narrowing,
+    // a subagent declaring `toolRefs: [{ __builtinTool: 'edit' }]` ends up with
+    // all 7 builtin pi tools (read/bash/edit/write/grep/find/ls) active, which
+    // is a security regression — a read-only memory-logger subagent silently
+    // gets full edit/write/bash capability. See QA finding for PR #290.
+    const { createSession } = await import('./index')
+    const hooks = createHookBus()
+    hooks.registerAll('p1', agentDir, noopLogger, {
+      'tool.before': () => undefined,
+    })
+    const registry: PluginRegistry = {
+      tools: [],
+      subagents: [],
+      cronJobs: [],
+      skills: [],
+      skillsDirs: [],
+      doctorChecks: [],
+      commands: [],
+    }
+
+    const session = await createSession({
+      plugins: { registry, hooks, sessionId: 'test-session', agentDir },
+      pluginSubagent: { pluginName: 'p1', toolRefs: [{ __builtinTool: 'edit' }], toolNamePrefix: 's' },
+    })
+
+    expect(session.getActiveToolNames().sort()).toEqual(['edit'])
+
+    session.dispose()
+  })
+
+  test('subagent declaring [read, grep] gets exactly those two active, with the wrapped (sdk) implementations', async () => {
+    const { createSession } = await import('./index')
+    const hooks = createHookBus()
+    hooks.registerAll('p1', agentDir, noopLogger, {
+      'tool.before': () => undefined,
+    })
+    const registry: PluginRegistry = {
+      tools: [],
+      subagents: [],
+      cronJobs: [],
+      skills: [],
+      skillsDirs: [],
+      doctorChecks: [],
+      commands: [],
+    }
+
+    const session = await createSession({
+      plugins: { registry, hooks, sessionId: 'test-session', agentDir },
+      pluginSubagent: {
+        pluginName: 'p1',
+        toolRefs: [{ __builtinTool: 'read' }, { __builtinTool: 'grep' }],
+        toolNamePrefix: 's',
+      },
+    })
+
+    expect(session.getActiveToolNames().sort()).toEqual(['grep', 'read'])
+    const all = session.getAllTools()
+    const readInfo = all.find((t) => t.name === 'read')
+    const grepInfo = all.find((t) => t.name === 'grep')
+    expect(readInfo?.sourceInfo.source).toBe('sdk')
+    expect(grepInfo?.sourceInfo.source).toBe('sdk')
+
+    session.dispose()
+  })
+
+  test('TUI session with hooks gets exactly pi default 4 active builtins (read/bash/edit/write) plus typeclaw customTools, not all 7 pi builtins', async () => {
+    // TUI/channel sessions pass no `options.tools`, so the intended active
+    // set is pi's defaultActiveToolNames union the typeclaw customSystemTools.
+    // The unconditional inclusion of grep/find/ls overrides would otherwise
+    // widen the TUI's active set silently — not a security regression like
+    // the subagent case, but still an unintended scope expansion.
+    const { createSession } = await import('./index')
+    const hooks = createHookBus()
+    hooks.registerAll('p1', agentDir, noopLogger, {
+      'tool.before': () => undefined,
+    })
+    const registry: PluginRegistry = {
+      tools: [],
+      subagents: [],
+      cronJobs: [],
+      skills: [],
+      skillsDirs: [],
+      doctorChecks: [],
+      commands: [],
+    }
+
+    const session = await createSession({
+      plugins: { registry, hooks, sessionId: 'test-session', agentDir },
+    })
+
+    const active = new Set(session.getActiveToolNames())
+    expect(active.has('read')).toBe(true)
+    expect(active.has('bash')).toBe(true)
+    expect(active.has('edit')).toBe(true)
+    expect(active.has('write')).toBe(true)
+    expect(active.has('grep')).toBe(false)
+    expect(active.has('find')).toBe(false)
+    expect(active.has('ls')).toBe(false)
+
+    session.dispose()
   })
 })

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -44,19 +44,20 @@ const ACKNOWLEDGE_GUARDS_SCHEMA = Type.Optional(
   ),
 )
 
-// `BuiltinToolRef.__builtinTool` strings are dual-routed when a plugin
-// subagent declares them: pi-coding-agent's own coding tools flow through
-// `createAgentSession({ tools: AgentTool[] })` (which pi treats as a strict
-// base-tool override — exactly the declared subset becomes active), and
-// typeclaw's own web tools flow through `customTools: ToolDefinition[]` (the
-// only path pi accepts for non-pi tool definitions). Routing typeclaw tools
-// through `tools:` silently drops them (pi's `tools` validator rejects shapes
-// it doesn't recognize); routing pi tools through `customTools:` would work
-// but ALSO auto-injects pi's default 4 base tools (read/bash/edit/write),
-// widening every plugin subagent's allowlist beyond what it declared. The
-// dual route is the only shape that gives "subagent gets exactly what it
-// asked for, nothing more." See `src/agent/index.ts` `createSessionWithDispose`
-// for the consumer that splits the resolved arrays into the two pi fields.
+// pi-coding-agent 0.67.3 contract (load-bearing for hook coverage):
+//   - `createAgentSession({ tools: AgentTool[] })` is ONLY a name filter for
+//     `initialActiveToolNames`. It does NOT swap builtin implementations.
+//   - `customTools: ToolDefinition[]` entries override builtins by name in
+//     `_refreshToolRegistry` (the registry merge writes customTools last).
+//
+// Consequence: to put a `tool.before` hook around pi's builtin read/bash/edit/
+// write, TypeClaw must wrap them as `ToolDefinition`s and pass them via
+// `customTools` — not via `tools`. `wrapAgentToolAsCustomToolDefinition`
+// produces those wrapped definitions; `setupSession` in `src/agent/index.ts`
+// appends them whenever the session has any `tool.before` / `tool.after`
+// hooks registered. Subagent narrowing still comes from `tools:` (the
+// name-filter path); the wrapped customTools just replace the implementation
+// underneath so subagent and channel sessions share the same hook coverage.
 type PiAgentToolName = 'read' | 'bash' | 'edit' | 'write' | 'grep' | 'find' | 'ls'
 type TypeclawToolName = 'websearch' | 'webfetch'
 
@@ -299,6 +300,70 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
       }
     },
   }
+}
+
+// Wraps a pi-coding-agent AgentTool into a ToolDefinition so it can ride in
+// `customTools` and override pi's same-named builtin (see top-of-file contract
+// block). The hook + guard pipeline matches `wrapSystemAgentTool`; only the
+// input/output shape differs.
+export function wrapAgentToolAsCustomToolDefinition<TParams extends TSchema, TDetails = unknown>(
+  tool: AgentTool<TParams, TDetails>,
+  opts: WrapSystemToolOptions,
+): ToolDefinition<TParams, TDetails> {
+  return piDefineTool({
+    name: tool.name,
+    label: tool.label,
+    description: tool.description,
+    parameters: withGuardAcknowledgements(tool.name, tool.parameters),
+    prepareArguments: tool.prepareArguments,
+    async execute(toolCallId, params, signal, onUpdate) {
+      const mutableArgs = params as Record<string, unknown>
+      const liveOrigin = opts.getOrigin?.()
+      const blockResult = await opts.hooks.runToolBefore({
+        tool: tool.name,
+        sessionId: opts.sessionId,
+        callId: toolCallId,
+        args: mutableArgs,
+        ...(liveOrigin !== undefined ? { origin: liveOrigin } : {}),
+      })
+      if (blockResult !== undefined) {
+        throw new Error(`blocked: ${blockResult.reason}`)
+      }
+      const guardResult = await runFinalWriteGuards({
+        tool: tool.name,
+        args: mutableArgs,
+        agentDir: opts.agentDir,
+      })
+      if (guardResult !== undefined) {
+        throw new Error(`blocked: ${guardResult.reason}`)
+      }
+      stripGuardAcknowledgements(mutableArgs)
+
+      const result = await tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate)
+      const hookResult: ToolResult = {
+        content: result.content as ContentPart[],
+        details: result.details,
+      }
+      await opts.hooks.runToolAfter({
+        tool: tool.name,
+        sessionId: opts.sessionId,
+        callId: toolCallId,
+        result: hookResult,
+      })
+      return {
+        content: hookResult.content as ContentPart[],
+        details: hookResult.details as TDetails,
+      }
+    },
+  })
+}
+
+export function defaultBuiltinPiAgentTools(): AgentTool<any, any>[] {
+  return [piReadTool, piBashTool, piEditTool, piWriteTool, piGrepTool, piFindTool, piLsTool]
+}
+
+export function buildBuiltinPiToolOverrides(opts: WrapSystemToolOptions): ToolDefinition<any, any>[] {
+  return defaultBuiltinPiAgentTools().map((tool) => wrapAgentToolAsCustomToolDefinition(tool, opts))
 }
 
 function errorResult(message: string) {

--- a/src/skills/typeclaw-plugins/SKILL.md
+++ b/src/skills/typeclaw-plugins/SKILL.md
@@ -718,7 +718,7 @@ Plugin `ToolContext` is `{ signal, sessionId, agentDir, logger }`. There is no `
   - `session.prompt`: `src/agent/index.ts` `createResourceLoader` (after default prompt assembly)
   - `session.idle`: `src/server/index.ts` `drain()` — fires immediately after every `session.prompt()` resolves (success or error)
   - `session.start`/`session.end`: `src/server/index.ts` ws open/close
-  - `tool.before`/`tool.after`: `src/agent/plugin-tools.ts` `wrapPluginTool`, `wrapSystemTool`, and `wrapSystemAgentTool`
+  - `tool.before`/`tool.after`: `src/agent/plugin-tools.ts` `wrapPluginTool`, `wrapSystemTool`, `wrapSystemAgentTool`, and `wrapAgentToolAsCustomToolDefinition`. The last one is the load-bearing path for pi's builtin coding tools (`read`/`bash`/`edit`/`write`/`grep`/`find`/`ls`): pi-coding-agent 0.67.3 treats `createAgentSession({ tools })` as a name filter only, so the wrapping has to ride in `customTools` to actually override the builtin implementations. See the top-of-file contract block in `plugin-tools.ts` for the full reasoning.
 - **Schema additions**: `src/config/config.ts` (`plugins` array, `.catchall(z.unknown())` for per-plugin blocks, `extractPluginConfigs`)
 
 ### Audit log on boot


### PR DESCRIPTION
## Summary

PR #283 added the `managedConfig` guard to block any `edit`/`write` that would produce an invalid `typeclaw.json` or `cron.json`. It did not fire on a real production `edit`: in a production agent (commit `6d1c42c`), the active default model was changed to `"kimi"` — a value `parseConfigJson` correctly rejects — and the tool call succeeded silently. Only the subsequent `reload` surfaced the bad config.

The same bypass class silenced the `skillAuthoring` and `nonWorkspaceWrite` guards for every channel and subagent session.

## Root cause

`pi-coding-agent@0.67.3`'s `createAgentSession({ tools: AgentTool[] })` is only a name filter for `initialActiveToolNames`. It does not swap builtin tool implementations. TypeClaw's `wrapSystemAgentTool` wrappers were passed through the `tools:` field, so the active `edit` at runtime was pi's own internal builtin — with no `tool.before` hook chain and no `runFinalWriteGuards` call. The wrappers were dead code for channel and subagent sessions.

## Fix — part 1: route wrapped builtins through `customTools`

`pi`'s `_refreshToolRegistry` registers `customTools` after builtins, so a `customTool` named `edit` replaces the builtin `edit` in the live tool registry. The hook chain now runs on every call from every session type.

**`src/agent/plugin-tools.ts`** — `wrapAgentToolAsCustomToolDefinition(tool, opts)` converts a pi `AgentTool` into a `ToolDefinition` whose `execute` runs the typeclaw hook pipeline before delegating. Hook + guard logic mirrors `wrapSystemAgentTool` byte for byte; only the input/output shape differs. `defaultBuiltinPiAgentTools()` returns the seven coding tools in pi's `allTools` registry order. `buildBuiltinPiToolOverrides(opts)` produces the wrapped entries ready for `customTools`. The top-of-file contract comment is rewritten to document pi 0.67.3's `tools`-vs-`customTools` asymmetry so a future refactor doesn't reintroduce the bug.

**`src/agent/index.ts`** — `setupSession` appends the wrapped builtin overrides to `customTools` when `hasToolHooks(plugins)` is true. Sessions with no hooks skip the override entirely; no wrapping overhead on the fast path.

## Fix — part 2: re-narrow the active tool set (discovered by self-review)

The `customTools` override path widens pi's active tool set as a side effect: `pi._refreshToolRegistry` runs with `includeAllExtensionTools: true` and pushes every `customTool` name into the active set, including the seven builtin overrides. Without explicit re-narrowing, a subagent declaring `toolRefs: [{ __builtinTool: 'edit' }]` ends up with all seven builtin pi tools active — a **security regression** caught by post-fix QA review (a read-only `memory-logger` subagent would silently get full `edit`/`write`/`bash` capability).

`setupSession` now calls `session.setActiveToolsByName(intendedActive)` after `createAgentSession`. The intended active set is pi's default-or-declared active names (i.e. `tools?.map(t => t.name) ?? ['read','bash','edit','write']`) unioned with the names from typeclaw/plugin customTools. The builtin overrides are implementation-only and never widen the active set.

Subagent narrowing is preserved end-to-end: a subagent declaring `[edit]` gets exactly `['edit']` active, not the full seven.

## Tests

**Unit tests** on `wrapAgentToolAsCustomToolDefinition` and `buildBuiltinPiToolOverrides` covering hook delegation, guard blocking, schema preservation, and the canonical tool-name list.

**Seam tests** that create a real `AgentSession` via `createSession`, asserting:
- the active `edit` came from `sdk` (customTools override) when hooks are present;
- `builtin` (no override) when no hooks are registered;
- a subagent declaring `[edit]` gets `getActiveToolNames() === ['edit']`;
- a subagent declaring `[read, grep]` gets exactly those active, both with `sdk`-sourced implementations;
- a TUI session with hooks still gets pi's default four (`read/bash/edit/write`) active, not the full seven.

Each seam test is **mutation-verified** per AGENTS.md §1: commenting out the wiring (the `customTools` append, OR the `setActiveToolsByName` call) flips the assertions and surfaces the regression they exist to catch.

**Doc update** in `src/skills/typeclaw-plugins/SKILL.md` so the next maintainer debugging hook coverage finds `wrapAgentToolAsCustomToolDefinition` and the customTools override path, not just the (now insufficient) `wrapSystemAgentTool` story.

## Pre-flight

```
bun run typecheck   clean
bun run lint        0 errors (18 pre-existing warnings, none in changed files)
bun run format      clean
bun test            4593/4593 pass
```

Related: https://github.com/typeclaw/typeclaw/pull/283
