### PR TITLE
role: soft-fail `typeclaw role list` so a broken typeclaw.json does not crash the diagnostic

### DIFF
--- a/src/cli/role.test.ts
+++ b/src/cli/role.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const CLI_ENTRY = join(import.meta.dir, 'index.ts')
+
+describe('typeclaw role list survives broken typeclaw.json', () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-role-list-broken-'))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  async function runRoleList(): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn({
+      cmd: ['bun', CLI_ENTRY, 'role', 'list'],
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, NO_COLOR: '1' },
+    })
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+    const exitCode = await proc.exited
+    return { exitCode, stdout, stderr }
+  }
+
+  test('exits 0 and prints the empty-roles hint when typeclaw.json is malformed JSON', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), 'NOT JSON AT ALL {{{')
+    const { exitCode, stdout, stderr } = await runRoleList()
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('No roles declared')
+    expect(stderr).toMatch(/not valid JSON/)
+    expect(stderr).toMatch(/diagnostic commands still work/)
+  })
+
+  test('exits 0 and prints the empty-roles hint when typeclaw.json is schema-invalid', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'not-a-known-model' } }))
+    const { exitCode, stdout, stderr } = await runRoleList()
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('No roles declared')
+    expect(stderr).toMatch(/typeclaw\.json is invalid/)
+  })
+
+  test('exits 0 and renders declared roles when typeclaw.json is valid', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        roles: {
+          member: { match: ['slack:T0123'] },
+        },
+      }),
+    )
+    const { exitCode, stdout, stderr } = await runRoleList()
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('member')
+    expect(stdout).toContain('slack')
+    expect(stderr).not.toMatch(/warning:/)
+  })
+})

--- a/src/cli/role.ts
+++ b/src/cli/role.ts
@@ -95,8 +95,13 @@ const listSub = defineCommand({
   },
   async run() {
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
-    const { loadConfigSync } = await import('@/config')
-    const config = loadConfigSync(cwd)
+    // Diagnostic command: route through `loadConfigSyncOrDefaults` (same
+    // soft-fail pattern as PR #288's `status`/`doctor` and the follow-up for
+    // `model list`) so a broken `typeclaw.json` doesn't crash the very
+    // command users reach for to see which roles the agent thinks it has.
+    // Defaults have no `roles` block, so the empty-state hint fires next.
+    const { loadConfigSyncOrDefaults } = await import('@/config')
+    const config = loadConfigSyncOrDefaults(cwd)
     if (!config.roles || Object.keys(config.roles).length === 0) {
       console.log(c.dim('No roles declared. Run `typeclaw role claim` to add one, or edit typeclaw.json by hand.'))
       return

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,6 +10,7 @@ export {
   gitSchema,
   gitignoreSchema,
   loadConfigSync,
+  loadConfigSyncOrDefaults,
   loadPluginConfigsSync,
   migrateLegacyConfigShape,
   modelsSchema,


### PR DESCRIPTION
## Summary

Another follow-up to #288. `typeclaw role list` crashed with an uncaught exception on a malformed or schema-invalid `typeclaw.json` — same crash class #288 fixed for `status`/`doctor` and #289 fixed for `model list`. `role list` is the read-only display you'd reach for to see which roles the agent thinks it has on this folder; crashing it leaves the user with no way to inspect the very file they're trying to debug.

## Root cause

`src/cli/role.ts` called `loadConfigSync` directly:

```ts
// before
const cwd = findAgentDir(process.cwd()) ?? process.cwd()
const { loadConfigSync } = await import('@/config')
const config = loadConfigSync(cwd)
```

Repro on `main`:

```sh
> echo '{ not json' > typeclaw.json
> typeclaw role list
warning: typeclaw.json is not valid JSON: ...        # <-- from #288's eager snapshot
warning: continuing with default config so ...
error: typeclaw.json is not valid JSON: JSON Parse error: Expected '}'
    at loadConfigSync (src/config/config.ts:646:15)
    at run (src/cli/role.ts:99:20)
exit 1
```

## Fix

Swap the call to `loadConfigSyncOrDefaults` (same helper #288 introduced). `loadConfigSyncOrDefaults` was not re-exported through the `@/config` barrel, so add the export. `role list` reads `config.roles`; defaults have no `roles` block, so the empty-state hint fires next:

```sh
> typeclaw role list
warning: typeclaw.json is not valid JSON: ...
warning: continuing with default config so ...
No roles declared. Run `typeclaw role claim` to add one, or edit typeclaw.json by hand.
```

— exactly the diagnostic message the user needs to make forward progress (fix the file, then `role claim`).

`role claim` (the mutation path) is unchanged: it doesn't read config directly. It connects to the running container via `defaultUrl()` → `resolveHostPort()` → `requireContainerRunning()`, so a broken-config scenario hits "container not found" before any config read happens.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Valid `typeclaw.json` + `role list` | Renders declared roles | Renders declared roles (no change) |
| `typeclaw.json` with no `roles` block + `role list` | Empty-roles hint | Empty-roles hint (no change) |
| Malformed `typeclaw.json` + `role list` | Uncaught exception, exit 1 | Exit 0, stderr warning, empty-roles hint |
| Schema-invalid `typeclaw.json` + `role list` | Uncaught exception, exit 1 | Exit 0, stderr warning, empty-roles hint |
| Any state + `role claim` | Unchanged (gated on running container) | Unchanged |

## Tests

**`src/cli/role.test.ts`** (new file) — 3 spawn-based integration tests, modeled on #288's `status.test.ts` and #289's `model.test.ts`:

- Malformed JSON → exit 0, empty-roles hint rendered, stderr warning naming the parse error.
- Schema-invalid JSON → exit 0, empty-roles hint, stderr warning identifying the config as invalid.
- Valid `roles.member` block → exit 0, role rendered, NO warning on stderr (regression guard against double-warning the happy path).

**Mutation check**: reverting `loadConfigSyncOrDefaults` back to `loadConfigSync` makes the 2 broken-config tests fail (TypeError on the function not existing, then the throw). The valid-config test keeps passing — as it should, since it doesn't depend on the soft-fail behavior. 2 of 3 fail on revert → tests pin the new behavior, not the implementation.

## Audit context

I audited every CLI subcommand against this crash class. Remaining crashes:

- ✅ `model list` — fixed in #289.
- ✅ `role list` — fixed here.
- 🔜 `tunnel add` / `tunnel remove` — same class, different fix shape. Those are mutation paths, so the right answer is "wrap with `validateConfig` first, return `{ok: false, reason}` instead of throwing." Follow-up PR coming.
- Everything else (`status`, `doctor`, `usage`, `logs`, `cron list`, `provider list`, `tui --help`, `shell --help`, `model list --available`, `model set/add/remove`, `role claim --help`) already handles broken config gracefully — either via #288's soft-fail, a defensive `try/catch` in the helper (e.g. `readModelsOrNull` in `providers-mutation.ts`), or a precondition check that exits before any config read (e.g. `requireContainerRunning`).

## Try it

```sh
mkdir -p /tmp/broken && cd /tmp/broken
echo '{ not json' > typeclaw.json
typeclaw role list              # exit 0, empty-roles hint, stderr warning
typeclaw role claim --help      # exit 0 (no config read on --help)
```

## Files changed

- `src/cli/role.ts` (+7 −2): swap `loadConfigSync` → `loadConfigSyncOrDefaults` + comment block.
- `src/config/index.ts` (+1): re-export `loadConfigSyncOrDefaults` through the `@/config` barrel.
- `src/cli/role.test.ts` (+64, new): 3 spawn-based integration tests.

## Pre-merge gates

```
bun run typecheck   clean
bun run lint        18 warnings (matches #288 baseline, none in changed files), 0 errors
bun run format      clean
bun test            4579 pass / 0 fail
```
