### PR TITLE
tunnel: refuse mutations cleanly when typeclaw.json is broken instead of stack-tracing

### DIFF
--- a/src/cli/tunnel.test.ts
+++ b/src/cli/tunnel.test.ts
@@ -70,6 +70,62 @@ describe('tunnel add/remove config flows', () => {
     ])
   })
 
+  test('add refuses cleanly with a result-shaped reason when typeclaw.json is malformed JSON', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-tunnel-broken-'))
+    await writeFile(join(cwd, 'typeclaw.json'), 'NOT JSON AT ALL {{{', 'utf8')
+
+    const result = await tunnel.runTunnelAddFlow(cwd, {
+      name: 'demo',
+      provider: 'external',
+      forManual: true,
+      upstreamPort: '5173',
+      externalUrl: 'https://demo.example.com',
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/not valid JSON/)
+  })
+
+  test('add refuses cleanly with a result-shaped reason when typeclaw.json is schema-invalid', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-tunnel-broken-'))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'not-a-known-model' } }), 'utf8')
+
+    const result = await tunnel.runTunnelAddFlow(cwd, {
+      name: 'demo',
+      provider: 'external',
+      forManual: true,
+      upstreamPort: '5173',
+      externalUrl: 'https://demo.example.com',
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/typeclaw\.json is invalid/)
+  })
+
+  test('remove refuses cleanly with a result-shaped reason when typeclaw.json is malformed JSON', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-tunnel-broken-'))
+    await writeFile(join(cwd, 'typeclaw.json'), '{ not json', 'utf8')
+
+    const result = tunnel.runTunnelRemoveFlow(cwd, { name: 'demo' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/not valid JSON/)
+  })
+
+  test('remove refuses cleanly with a result-shaped reason when typeclaw.json is schema-invalid', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-tunnel-broken-'))
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'not-a-known-model' } }), 'utf8')
+
+    const result = tunnel.runTunnelRemoveFlow(cwd, { name: 'demo' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/typeclaw\.json is invalid/)
+  })
+
   test('remove refuses channel-owned tunnels and removes manual tunnels', async () => {
     const cwd = await makeAgentDir({
       tunnels: [

--- a/src/cli/tunnel.ts
+++ b/src/cli/tunnel.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { select, text, isCancel, cancel, log } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
-import { loadConfigSync } from '@/config'
+import { loadConfigSync, validateConfig } from '@/config'
 import { resolveHostPort, resolveTuiToken } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 import type { ClientMessage, ServerMessage, TunnelLogsServerMessage, TunnelSnapshot } from '@/shared'
@@ -168,6 +168,15 @@ export async function runTunnelAddFlow(
   args: AddArgs,
   prompts: TunnelPrompts = defaultPrompts,
 ): Promise<LiveResult<TunnelConfig>> {
+  // Strict gate before any read: a malformed or schema-invalid `typeclaw.json`
+  // would otherwise throw out of the subsequent `loadConfigSync` and surface
+  // as an uncaught exception instead of the clean exit-1-with-reason that
+  // every other LiveResult consumer expects. Same fence PR #288 documented
+  // for the `start`/`restart`/`reload` path: destructive paths route through
+  // `validateConfig` so the file's invariants are checked once, up front,
+  // and the rest of the flow can lean on them.
+  const validation = validateConfig(cwd)
+  if (!validation.ok) return { ok: false, reason: validation.reason }
   const config = loadConfigSync(cwd)
   if (config.tunnels.some((entry) => entry.name === args.name))
     return { ok: false, reason: `tunnel "${args.name}" already exists` }
@@ -206,6 +215,9 @@ export async function runTunnelAddFlow(
 }
 
 export function runTunnelRemoveFlow(cwd: string, args: RemoveArgs): LiveResult<{ removed: TunnelConfig }> {
+  // Same strict gate as `runTunnelAddFlow`. See the comment there for why.
+  const validation = validateConfig(cwd)
+  if (!validation.ok) return { ok: false, reason: validation.reason }
   const config = loadConfigSync(cwd)
   const tunnel = config.tunnels.find((entry) => entry.name === args.name)
   if (tunnel === undefined) return { ok: false, reason: `unknown tunnel: ${args.name}` }


### PR DESCRIPTION
## Summary

Final follow-up to #288. The two `tunnel` mutation flows (`tunnel add`, `tunnel remove`) reached into `loadConfigSync(cwd)` directly and let the throw escape as an uncaught exception — even though both already return `LiveResult<T>` and every consumer is wired to render `reason` on `!ok`. The user-facing effect on a broken `typeclaw.json` is a raw stack trace instead of the clean `exit 1 + reason on stderr` shape every other CLI mutation produces.

## Root cause

```ts
// src/cli/tunnel.ts (before)
export async function runTunnelAddFlow(cwd, args, prompts) {
  const config = loadConfigSync(cwd)        // <-- throws on broken JSON
  if (config.tunnels.some(...)) return { ok: false, reason: ... }
  ...
}

export function runTunnelRemoveFlow(cwd, args) {
  const config = loadConfigSync(cwd)        // <-- same throw
  ...
}
```

Repro on `main`:

```sh
> echo '{ not json' > typeclaw.json
> typeclaw tunnel remove demo
warning: typeclaw.json is not valid JSON: ...       # <-- from #288's eager snapshot
warning: continuing with default config so ...
error: typeclaw.json is not valid JSON: JSON Parse error: Expected '}'
    at loadConfigSync (src/config/config.ts:646:15)
    at runTunnelRemoveFlow (src/cli/tunnel.ts:209:18)
exit 1
```

Same shape for `tunnel add`.

## Fix

Insert `validateConfig(cwd)` at the top of each flow and surface its `reason` as a `LiveResult` failure. This is the same fence `validateConfig` already provides for `start` / `restart` / `reload`, and the same shape `models-mutation.ts#writeModels` already uses for `model set` / `add` / `remove` (PR #288's mutation path). After the gate, the existing `loadConfigSync(cwd)` calls are guaranteed to succeed because `validateConfig` already parsed + schema-checked the same bytes.

After:

```sh
> typeclaw tunnel remove demo
✖ typeclaw.json is not valid JSON: JSON Parse error: Expected "}"
exit 1
```

No stack trace, same exit code, machine-readable `reason` on stderr.

## Why this is the right design

The PR #288 fence is two-layer:

| Layer | Helper | Used by |
|---|---|---|
| Diagnostic (read-only) | `loadConfigSyncOrDefaults` (soft-fail to defaults + stderr warning) | `status`, `doctor`, `model list` (#289), `role list` (#293) |
| Destructive (mutation) | `validateConfig` (strict gate returning `{ok, reason}`) | `start`, `restart`, `reload`, `model set/add/remove`, **`tunnel add/remove` (this PR)** |

Soft-failing tunnel mutations would be wrong — silently writing a `tunnel` entry into a broken-on-disk file would leave the user with a worse state than they started in. The strict gate is the right answer; this PR just makes the gate route through the existing result-shaped contract instead of leaking a throw.

Diagnostic paths (`tunnel list`, `tunnel status`, `tunnel logs`) don't touch `loadConfigSync` directly — they connect to the running agent over WebSocket — so they are unchanged.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Valid `typeclaw.json` + `tunnel add/remove` | Works | Works (no change — `validateConfig` returns `ok` immediately) |
| Missing `typeclaw.json` + `tunnel add/remove` | `ensureAgentDir` exit 1 with hint to `typeclaw init` | Same (no change — orthogonal check) |
| Malformed `typeclaw.json` + `tunnel add/remove` | Uncaught exception, exit 1, stack trace | Exit 1, `✖ typeclaw.json is not valid JSON: ...` on stderr |
| Schema-invalid `typeclaw.json` + `tunnel add/remove` | Uncaught exception, exit 1, stack trace | Exit 1, `✖ typeclaw.json is invalid: <path>: <message>` on stderr |
| Missing mount path + `tunnel add/remove` | Would crash later inside `writeRawConfig`'s post-write `loadConfigSync` if migration applied | Exit 1, `✖ mount "<name>": path <path> does not exist` on stderr (new behavior) |
| Any state + `tunnel list/status/logs` | Unchanged | Unchanged |

The missing-mount-path row is a small **scope expansion** of the strict gate — `validateConfig` already checks mount accessibility (it's the host-side single gate documented in AGENTS.md). Refusing `tunnel add` when mounts are unreachable is consistent with `start` / `restart` / `reload` refusing the same way, and it's the right call: if the user can't start the container, they can't apply the tunnel entry they just added either.

## Tests

**`src/cli/tunnel.test.ts`** — 4 new unit tests on the exported flows, modeled on the existing `tunnel add/remove config flows` describe block in the same file:

- `runTunnelAddFlow` + malformed JSON → `ok: false`, `reason` matches `/not valid JSON/`.
- `runTunnelAddFlow` + schema-invalid JSON → `ok: false`, `reason` matches `/typeclaw\.json is invalid/`.
- `runTunnelRemoveFlow` + malformed JSON → same shape.
- `runTunnelRemoveFlow` + schema-invalid JSON → same shape.

**Mutation check** (AGENTS.md §1 acceptance bar): reverting `validateConfig` out of `runTunnelAddFlow` and `runTunnelRemoveFlow` makes all 4 new tests fail (the throw escapes the function and Bun's test runner surfaces it as a failed expect call). The 6 pre-existing tunnel tests keep passing. Tests pin the new behavior, not the implementation.

**Test layer choice**: domain-layer tests on the exported flow functions, per AGENTS.md §2 "test at the right layer." The CLI thin layer doesn't need separate spawn-based testing for this fix — the logic lives entirely in `runTunnelAddFlow` / `runTunnelRemoveFlow`, and the existing test file already exercises both functions directly with `makeAgentDir` tmpdirs.

## Audit complete

I audited every CLI subcommand against this broken-config crash class across three PRs. Final state:

- ✅ `status`, `doctor`, `logs`, `stop`, `usage`, `tui` — #288 (merged)
- ✅ `model list` — #289 (merged)
- ✅ `role list` — #293 (open)
- ✅ `tunnel add`, `tunnel remove` — this PR
- Already correct (defensive helpers, container-precondition checks, or no config read): `cron list`, `provider list`, `model set/add/remove`, `tunnel list/status/logs`, `role claim`, all `--help` paths

## Try it

```sh
mkdir -p /tmp/broken && cd /tmp/broken
echo '{ not json' > typeclaw.json
typeclaw tunnel remove demo            # exit 1, ✖ not valid JSON, no stack trace
typeclaw tunnel add demo --for-manual --upstream-port 5173 --provider external --external-url https://x.example.com
                                       # exit 1, same shape
```

## Files changed

- `src/cli/tunnel.ts` (+13 −1): add `validateConfig` import; insert the strict gate at the top of `runTunnelAddFlow` and `runTunnelRemoveFlow` + comment block documenting the fence.
- `src/cli/tunnel.test.ts` (+56): 4 new unit tests in the existing `tunnel add/remove config flows` describe block.

## Pre-merge gates

```
bun run typecheck   clean
bun run lint        18 warnings (matches #288 baseline, none in changed files), 0 errors
bun run format      clean
bun test            4580 pass / 0 fail
```
