### PR TITLE
multimodal: redirect read of image files to look_at

### DIFF
--- a/src/agent/multimodal/read-redirect.test.ts
+++ b/src/agent/multimodal/read-redirect.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test'
+
+import { GUARD_IMAGE_READ_REDIRECT, checkImageReadRedirect } from './read-redirect'
+
+describe('image-read-redirect guard', () => {
+  test('blocks read of common image extensions', () => {
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'screenshot.png' } })?.block).toBe(true)
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'photo.jpg' } })?.block).toBe(true)
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'photo.jpeg' } })?.block).toBe(true)
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'meme.gif' } })?.block).toBe(true)
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'hero.webp' } })?.block).toBe(true)
+  })
+
+  test('matches extensions case-insensitively', () => {
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'Screenshot.PNG' } })?.block).toBe(true)
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'PHOTO.JPG' } })?.block).toBe(true)
+  })
+
+  test('blocks images under nested paths and absolute paths', () => {
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'workspace/screenshots/foo.png' } })?.block).toBe(true)
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: '/agent/workspace/foo.jpg' } })?.block).toBe(true)
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: '/tmp/agent-browser-snapshot.png' } })?.block).toBe(
+      true,
+    )
+  })
+
+  test('redirect message names look_at and quotes the original path', () => {
+    const result = checkImageReadRedirect({ tool: 'read', args: { path: 'workspace/foo.png' } })
+    expect(result?.reason).toContain('look_at')
+    expect(result?.reason).toContain('"workspace/foo.png"')
+    expect(result?.reason).toContain('imageReadRedirect')
+  })
+
+  test('allows acknowledged read of an image', () => {
+    const result = checkImageReadRedirect({
+      tool: 'read',
+      args: { path: 'workspace/foo.png', acknowledgeGuards: { imageReadRedirect: true } },
+    })
+    expect(result).toBeUndefined()
+  })
+
+  test('allows reads of non-image files', () => {
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'README.md' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'src/index.ts' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'package.json' } })).toBeUndefined()
+  })
+
+  test('allows reads of non-supported image formats (matches upstream attachment scope)', () => {
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'icon.svg' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'photo.heic' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'scan.tiff' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'photo.bmp' } })).toBeUndefined()
+  })
+
+  test('allows reads of extensionless files (matches extension-only trigger contract)', () => {
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'Dockerfile' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 'workspace/raw-screenshot' } })).toBeUndefined()
+  })
+
+  test('does not apply to non-read tools', () => {
+    expect(checkImageReadRedirect({ tool: 'write', args: { path: 'workspace/foo.png' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'edit', args: { path: 'workspace/foo.png' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'bash', args: { path: 'workspace/foo.png' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'grep', args: { path: 'workspace/foo.png' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'ls', args: { path: 'workspace/foo.png' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'find', args: { path: 'workspace/foo.png' } })).toBeUndefined()
+  })
+
+  test('handles non-string and missing path gracefully', () => {
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: 42 } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'read', args: { path: '' } })).toBeUndefined()
+    expect(checkImageReadRedirect({ tool: 'read', args: {} })).toBeUndefined()
+  })
+
+  test('exposes guard name constant', () => {
+    expect(GUARD_IMAGE_READ_REDIRECT).toBe('imageReadRedirect')
+  })
+})

--- a/src/agent/multimodal/read-redirect.ts
+++ b/src/agent/multimodal/read-redirect.ts
@@ -1,0 +1,43 @@
+import path from 'node:path'
+
+import { ACKNOWLEDGE_GUARDS, type GuardBlock, isGuardAcknowledged } from '@/bundled-plugins/guard/policy'
+
+export const GUARD_IMAGE_READ_REDIRECT = 'imageReadRedirect'
+
+// Mirrors the IMAGE_MIME_TYPES set in @mariozechner/pi-coding-agent
+// (dist/utils/mime.ts). Keeping the trigger surface aligned with the upstream
+// read tool's image-attachment behavior means we redirect on exactly the
+// extensions that would otherwise inject `{ type: 'image' }` content parts
+// into the main agent's history.
+//
+// Extension-only matching is preferred over the upstream MIME sniffer's
+// 4100-byte file open because this check runs on every `read` call;
+// extensionless image files still leak as before (no regression), and the
+// agent can force-read via `acknowledgeGuards.imageReadRedirect: true` when
+// it genuinely needs the bytes (e.g. writing image-processing code).
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp'])
+
+export function checkImageReadRedirect(options: {
+  tool: string
+  args: Record<string, unknown>
+}): GuardBlock | undefined {
+  const { tool, args } = options
+  if (tool !== 'read') return undefined
+  if (isGuardAcknowledged(args, GUARD_IMAGE_READ_REDIRECT)) return undefined
+
+  const rawPath = args.path
+  if (typeof rawPath !== 'string' || rawPath === '') return undefined
+
+  const ext = path.extname(rawPath).toLowerCase()
+  if (!IMAGE_EXTENSIONS.has(ext)) return undefined
+
+  return {
+    block: true,
+    reason: [
+      `Guard \`${GUARD_IMAGE_READ_REDIRECT}\` blocked read of an image file: ${rawPath}.`,
+      `Reading images via \`read\` injects the raw bytes into your message history as an image attachment, which can quickly fill your context window.`,
+      `Use \`look_at\` with \`path: ${JSON.stringify(rawPath)}\` instead — it routes the bytes through a vision-capable subagent and returns only text to you. Pass an optional \`prompt\` to ask a specific question (returns shorter text than the default describe-everything path).`,
+      `If you genuinely need the raw image bytes (e.g. writing image-processing code), retry with \`${ACKNOWLEDGE_GUARDS}.${GUARD_IMAGE_READ_REDIRECT}: true\` in the tool arguments.`,
+    ].join(' '),
+  }
+}

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -31,6 +31,7 @@ import type {
   ToolResult,
 } from '@/plugin'
 
+import { checkImageReadRedirect } from './multimodal/read-redirect'
 import type { SessionOrigin } from './session-origin'
 import { webfetchTool } from './tools/webfetch'
 import { websearchTool } from './tools/websearch'
@@ -232,6 +233,10 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       if (guardResult !== undefined) {
         throw new Error(`blocked: ${guardResult.reason}`)
       }
+      const readGuardResult = runFinalReadGuards({ tool: tool.name, args: mutableArgs })
+      if (readGuardResult !== undefined) {
+        throw new Error(`blocked: ${readGuardResult.reason}`)
+      }
       stripGuardAcknowledgements(mutableArgs)
 
       const result = await tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate, ctx)
@@ -280,6 +285,10 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
       })
       if (guardResult !== undefined) {
         throw new Error(`blocked: ${guardResult.reason}`)
+      }
+      const readGuardResult = runFinalReadGuards({ tool: tool.name, args: mutableArgs })
+      if (readGuardResult !== undefined) {
+        throw new Error(`blocked: ${readGuardResult.reason}`)
       }
       stripGuardAcknowledgements(mutableArgs)
 
@@ -337,6 +346,10 @@ export function wrapAgentToolAsCustomToolDefinition<TParams extends TSchema, TDe
       if (guardResult !== undefined) {
         throw new Error(`blocked: ${guardResult.reason}`)
       }
+      const readGuardResult = runFinalReadGuards({ tool: tool.name, args: mutableArgs })
+      if (readGuardResult !== undefined) {
+        throw new Error(`blocked: ${readGuardResult.reason}`)
+      }
       stripGuardAcknowledgements(mutableArgs)
 
       const result = await tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate)
@@ -380,6 +393,10 @@ async function runFinalWriteGuards(options: { tool: string; args: Record<string,
     (await checkSkillAuthoringGuard(options)) ??
     checkNonWorkspaceWriteGuard(options)
   )
+}
+
+function runFinalReadGuards(options: { tool: string; args: Record<string, unknown> }) {
+  return checkImageReadRedirect(options)
 }
 
 function withGuardAcknowledgements<TParams extends TSchema>(toolName: string, parameters: TParams): TParams {


### PR DESCRIPTION
## Why

The upstream `pi-coding-agent` `read` tool detects image MIME types and returns `{ type: 'image', data: base64, mimeType }` content parts **directly into the main agent's message history**. This is the dominant image-context leak path on typeclaw: agent-browser screenshots, channel attachments saved to disk, and any image file on disk are all natural `read` targets — and the agent never actually needs the bytes. It needs the description.

`look_at` already exists (`src/agent/multimodal/look-at.ts`). It spawns a vision-capable `multimodal-looker` subagent with `tools: []` and `customTools: []`, runs the image in a separate context window, and returns only text to the caller. Image bytes never enter the main agent's history. But `look_at` only works when the agent reaches for it. When `read screenshot.png` works fine, there's no friction to reach past it.

The tool-description fix (`read`'s description: "prefer `look_at` for images") was considered and rejected. Tool descriptions are a per-turn token tax — they load into every LLM context on every tool call across every session, for a low-frequency trigger. AGENTS.md documents exactly this cost model via the `e2b08ab`/`ccb4669` production failure: per-platform guidance embedded in tool descriptions was ignored under chat-prose load AND paid the token tax on every channel turn.

The right intervention is a `tool.before`-style guard wired inside the tool-wrap pipeline. The guard fires **exactly when the agent reaches for the wrong tool**, the error message IS the teaching moment, and the token cost is zero on every turn where no image is read.

## What

3 files changed, 138 insertions(+). No registry edits, no new bundled plugin.

### `src/agent/multimodal/read-redirect.ts` (+43)

`checkImageReadRedirect({ tool, args })` returns `{ block: true, reason }` when:

- `tool === 'read'`
- `args.path` ends in `.png`, `.jpg`, `.jpeg`, `.gif`, or `.webp` (case-insensitive)
- `acknowledgeGuards.imageReadRedirect` is not `true`

Lives alongside `look-at.ts` in `src/agent/multimodal/` — the multimodal package owns both halves of the loop: the constructive tool AND the guard that steers traffic to it.

### `src/agent/plugin-tools.ts` (+17)

Adds a `runFinalReadGuards` helper (a one-liner wrapping `checkImageReadRedirect`) and calls it at the same three tool-wrap sites that already call `runFinalWriteGuards`:

- `wrapSystemTool` — covers the pattern uniformly (pi-coding-agent `read` doesn't flow here today but the site already has `runFinalWriteGuards`)
- `wrapSystemAgentTool` — the live path for plugin-subagent tools
- `wrapAgentToolAsCustomToolDefinition` — the live path for the main agent's `read` (called by `buildBuiltinPiToolOverrides`)

All three call sites follow the same pattern: check → throw if blocked → `stripGuardAcknowledgements`. Symmetric with `runFinalWriteGuards` at every site.

### `src/agent/multimodal/read-redirect.test.ts` (+78)

11 test cases:

| Test | What it pins |
|---|---|
| All 5 extensions blocked | trigger surface completeness |
| Case-insensitive match | `.PNG`, `.JPG` behave identically |
| Nested and absolute paths | suffix match, not basename match |
| Message content | names `look_at`, quotes path, names guard |
| Ack escape hatch | `acknowledgeGuards.imageReadRedirect: true` unblocks |
| Non-image files | `.md`, `.ts`, `.json` pass through |
| Non-supported image formats | `.svg`, `.heic`, `.tiff`, `.bmp` pass through (matches upstream scope) |
| Extensionless files | `Dockerfile`, `raw-screenshot` pass through (explicit design contract) |
| Non-read tools | `write`, `edit`, `bash`, `grep`, `ls`, `find` on `.png` pass through |
| Non-string / missing path | no throw, returns `undefined` |
| Guard name constant | `GUARD_IMAGE_READ_REDIRECT === 'imageReadRedirect'` |

## Tradeoffs

### 1. `plugin-tools.ts` inline helper vs. new bundled plugin

A new bundled plugin for a single redirect check adds registry wire-up, ordering rationale, and a `BUNDLED_PLUGINS` entry for what is functionally a one-function check. `plugin-tools.ts` already has the exact precedent: `runFinalWriteGuards` is a local helper wrapping the guard plugin's write-side policy functions and is called inline at the same three sites. `runFinalReadGuards` is its peer. Symmetric design, zero registry surface.

### 2. Why all three wrap sites

Each of the three `wrapXxx` functions in `plugin-tools.ts` is a potential entry point for tools depending on session shape. `runFinalWriteGuards` is already at all three; the read guard follows suit to foreclose gaps if a future code path routes `read` through a site that doesn't carry it today.

### 3. Why `throw` instead of returning a tool result

Matches the existing `runFinalWriteGuards` pattern at all three sites: they all `throw new Error('blocked: ${reason}')`. Tool-error framing is correct semantically — "this call was rejected with a reason" — and matches the agent's mental model for the existing guards.

### 4. Acknowledgement parameter handling

`withGuardAcknowledgements` only advertises the `acknowledgeGuards` schema for `write`/`edit`. The security plugin's existing `read` guards (e.g. `secretExfilRead`) don't extend that either — they rely on the model passing `acknowledgeGuards.<name>: true` on retry after seeing the block message. This guard does the same: the redirect message tells the model the exact ack arg to add. No schema extension required.

### 5. Extension-only matching, not MIME sniffing

The upstream `detectSupportedImageMimeTypeFromFile` does a 4100-byte file open per call. Cheap once; pure overhead when the path obviously has an image extension. Extension-only suffix match is O(string) and zero I/O. Extensionless image files still leak as before — no regression. The ack escape hatch handles the rare case where the agent needs the raw bytes without an extension hint.

### 6. No exemption for `multimodal-looker`

That subagent has `tools: []` and `customTools: []`, so it cannot call `read` at all. Defense-in-depth exemption was considered and rejected as adding code for a path that's mechanically blocked elsewhere.

### 7. `webfetch` on an image URL is not a leak path

`webfetch` returns text (the body is decoded as UTF-8, never as an image content part). `curl` in bash returns text. The `read` tool is the only upstream surface that creates `{ type: 'image' }` parts — so the guard surface is exactly right.

## Scope

- 3 new/modified files only. No changes to `look_at`, its tool description, or any other tool.
- No changes to the slim or full system prompt.
- No changes to `BUNDLED_PLUGINS` or any plugin registry.
- No changes to the `multimodal-looker` subagent.

## Validation

| Gate | Result |
|---|---|
| `bun run typecheck` | clean |
| `bun run lint` | 0 errors (18 pre-existing warnings, none in changed files) |
| `bun run format:check` | clean |
| `bun run test` | 4612 pass, 0 fail (11 new tests in `read-redirect.test.ts`, all green) |

## Diff

3 files changed, 138 insertions(+):

```
src/agent/multimodal/read-redirect.ts       +43  new
src/agent/multimodal/read-redirect.test.ts  +78  new
src/agent/plugin-tools.ts                   +17  runFinalReadGuards helper + 3 call sites
```

## Out of scope (potential follow-ups)

- MIME sniffer fallback for extensionless images. The ack escape hatch handles it for now; a sniffer adds I/O on every read for a rare case.
- Telemetry on redirect-fires vs ack-uses — would let us calibrate whether the trigger surface is right-sized in practice.
- `typeclaw-multimodal` skill for multi-paragraph image-handling guidance (OCR, chart data extraction, etc.) — deferred per design discussion.
