### PR TITLE
slack-bot: add /stop as a native Slack slash command via slash_commands

### DIFF
--- a/src/channels/adapters/slack-bot-slash-commands.test.ts
+++ b/src/channels/adapters/slack-bot-slash-commands.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { SlackSocketModeSlashCommandArgs } from 'agent-messenger/slackbot'
+
+import { buildSlashAckPayload, parseSlashCommand } from './slack-bot-slash-commands'
+
+type Body = SlackSocketModeSlashCommandArgs['body']
+
+function body(over: Partial<Body> = {}): Body {
+  return {
+    command: '/stop',
+    text: '',
+    user_id: 'U-alice',
+    channel_id: 'C-general',
+    team_id: 'T-acme',
+    ...over,
+  }
+}
+
+describe('parseSlashCommand', () => {
+  const known = new Set(['stop'])
+
+  test('parses /stop in a public channel into a slack-bot ChannelKey', () => {
+    const result = parseSlashCommand(body(), known)
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command).toEqual({
+      name: 'stop',
+      key: { adapter: 'slack-bot', workspace: 'T-acme', chat: 'C-general', thread: null },
+      invokerId: 'U-alice',
+    })
+  })
+
+  test('maps DM channel ids (D prefix) to workspace=@dm', () => {
+    const result = parseSlashCommand(body({ channel_id: 'D-bob' }), known)
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command.key.workspace).toBe('@dm')
+    expect(result.command.key.chat).toBe('D-bob')
+  })
+
+  test('private channel ids (G prefix) map to the team workspace (NOT @dm)', () => {
+    const result = parseSlashCommand(body({ channel_id: 'G-secret' }), known)
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command.key.workspace).toBe('T-acme')
+    expect(result.command.key.chat).toBe('G-secret')
+  })
+
+  test('lowercases the command name', () => {
+    const result = parseSlashCommand(body({ command: '/STOP' }), known)
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command.name).toBe('stop')
+  })
+
+  test('ignores unknown command names', () => {
+    const result = parseSlashCommand(body({ command: '/unknown' }), known)
+    expect(result).toEqual({ kind: 'ignore', reason: 'unknown-command' })
+  })
+
+  test('ignores malformed commands (no leading slash)', () => {
+    const result = parseSlashCommand(body({ command: 'stop' }), known)
+    expect(result).toEqual({ kind: 'ignore', reason: 'malformed' })
+  })
+
+  test('ignores payloads missing user_id (defensive)', () => {
+    const result = parseSlashCommand(body({ user_id: '' }), known)
+    expect(result).toEqual({ kind: 'ignore', reason: 'no-invoker' })
+  })
+
+  test('ignores payloads missing channel_id', () => {
+    const result = parseSlashCommand(body({ channel_id: '' }), known)
+    expect(result).toEqual({ kind: 'ignore', reason: 'no-channel' })
+  })
+
+  test('ignores payloads missing team_id (defensive — slash commands always carry it)', () => {
+    const result = parseSlashCommand(body({ team_id: '' }), known)
+    expect(result).toEqual({ kind: 'ignore', reason: 'no-team' })
+  })
+
+  test('always sets thread:null (Slack slash commands cannot be invoked from a thread)', () => {
+    const result = parseSlashCommand(body(), known)
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command.key.thread).toBe(null)
+  })
+})
+
+describe('buildSlashAckPayload', () => {
+  test('returns an ephemeral response payload', () => {
+    expect(buildSlashAckPayload('Stopped.')).toEqual({
+      response_type: 'ephemeral',
+      text: 'Stopped.',
+    })
+  })
+})

--- a/src/channels/adapters/slack-bot-slash-commands.ts
+++ b/src/channels/adapters/slack-bot-slash-commands.ts
@@ -1,0 +1,82 @@
+import type { SlackSocketModeSlashCommandArgs } from 'agent-messenger/slackbot'
+
+import type { ChannelKey } from '@/channels/types'
+
+// Slack channel ids: 'C' = public, 'G' = private/legacy multi-party DM,
+// 'D' = direct message. Slash-command payloads don't carry `channel_type`,
+// so we read the id prefix directly. The slack-bot inbound classifier uses
+// `event.channel_type === 'im'` for the same purpose, but that field isn't
+// in the slash-command body. Group DMs ('G' prefix) are NOT treated as DMs
+// here — they map to `workspace: team_id` like a regular channel, matching
+// how the inbound classifier handles MPIM messages (channel_type 'mpim'
+// is not 'im' and therefore falls through to the team workspace branch).
+const SLACK_DM_CHANNEL_PREFIXES: readonly string[] = ['D']
+
+export type ParsedSlackSlashCommand = {
+  name: string
+  key: ChannelKey
+  invokerId: string
+}
+
+export type ParseSlashCommandResult =
+  | { kind: 'parsed'; command: ParsedSlackSlashCommand }
+  | { kind: 'ignore'; reason: 'unknown-command' | 'no-invoker' | 'no-channel' | 'no-team' | 'malformed' }
+
+export function parseSlashCommand(
+  body: SlackSocketModeSlashCommandArgs['body'],
+  knownCommands: ReadonlySet<string>,
+): ParseSlashCommandResult {
+  if (typeof body.command !== 'string' || !body.command.startsWith('/')) {
+    return { kind: 'ignore', reason: 'malformed' }
+  }
+  const name = body.command.slice(1).toLowerCase()
+  if (name === '' || !knownCommands.has(name)) {
+    return { kind: 'ignore', reason: 'unknown-command' }
+  }
+  if (typeof body.user_id !== 'string' || body.user_id === '') {
+    return { kind: 'ignore', reason: 'no-invoker' }
+  }
+  if (typeof body.channel_id !== 'string' || body.channel_id === '') {
+    return { kind: 'ignore', reason: 'no-channel' }
+  }
+  // team_id is required for slash commands per Slack's API, but defensively
+  // refuse to construct a ChannelKey without it — otherwise the workspace
+  // field would collide with a real workspace id named '' downstream.
+  if (typeof body.team_id !== 'string' || body.team_id === '') {
+    return { kind: 'ignore', reason: 'no-team' }
+  }
+
+  const isDm = SLACK_DM_CHANNEL_PREFIXES.some((prefix) => body.channel_id.startsWith(prefix))
+  const workspace = isDm ? '@dm' : body.team_id
+
+  return {
+    kind: 'parsed',
+    command: {
+      name,
+      // thread is null because Slack slash commands cannot be invoked from
+      // inside a thread — Slack's compose box always targets the top-level
+      // channel. The router's executeCommand falls back to any live session
+      // in the same workspace+chat when an exact key match misses, so a
+      // thread-keyed live session still gets hit by a thread-less slash.
+      key: { adapter: 'slack-bot', workspace, chat: body.channel_id, thread: null },
+      invokerId: body.user_id,
+    },
+  }
+}
+
+export const SLACK_SLASH_REPLY_ABORTED = 'Stopped the current turn.'
+export const SLACK_SLASH_REPLY_NO_LIVE_SESSION = 'Nothing to stop — no active turn in this channel.'
+export const SLACK_SLASH_REPLY_FAILED = 'Could not stop the current turn (internal error).'
+export const SLACK_SLASH_REPLY_PERMISSION_DENIED =
+  'You do not have permission to stop the current turn in this channel.'
+export const SLACK_SLASH_REPLY_AMBIGUOUS =
+  'Multiple active turns in this channel. Reply `/stop` from inside the specific thread you want to stop.'
+
+// Slack's ack callback accepts an optional response payload that becomes
+// the user-visible reply. `response_type: 'ephemeral'` keeps the reply
+// visible only to the invoker (vs. 'in_channel' which posts to everyone).
+// Control gestures should stay ephemeral — same rationale as Discord's
+// EPHEMERAL flag on interaction callbacks.
+export function buildSlashAckPayload(text: string): { response_type: 'ephemeral'; text: string } {
+  return { response_type: 'ephemeral', text }
+}

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -3,16 +3,19 @@ import { describe, expect, test } from 'bun:test'
 import type { SlackBotClient, SlackFile, SlackMessage } from 'agent-messenger/slackbot'
 
 import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
-import type { FetchHistoryResult, HistoryCallback, OutboundMessage } from '@/channels/types'
+import type { ChannelKey, FetchHistoryResult, HistoryCallback, OutboundMessage } from '@/channels/types'
+import { SLACK_APP_MANIFEST } from '@/cli/ui'
 
 import {
   createOutboundCallback,
   createSlackHistoryCallback,
   createSlackMembershipResolver,
   createSlackTypingTracker,
+  createSlashCommandHandler,
   createTypingCallback,
   promoteAppMentionToMessage,
   SLACK_HISTORY_LIMIT_MAX,
+  SLACK_SLASH_COMMAND_NAMES,
 } from './slack-bot'
 import { classifyInbound, type SlackInboundAppMentionEvent } from './slack-bot-classify'
 
@@ -1236,5 +1239,233 @@ describe('slack-bot createOutboundCallback', () => {
     const result = await cb(makeMsg({ text: 'hello', thread: '1700.000100' }))
     expect(result.ok).toBe(false)
     expect(clearCalls).toHaveLength(0)
+  })
+})
+
+describe('createSlashCommandHandler', () => {
+  type AckCall = Record<string, unknown> | undefined
+  type RouterCall = { key: ChannelKey; name: string; invokerId: string }
+  type RouterResult =
+    | { kind: 'handled'; name: string }
+    | { kind: 'no-live-session' }
+    | { kind: 'permission-denied' }
+    | { kind: 'ambiguous'; matchCount: number }
+    | { kind: 'unknown-command'; name: string }
+
+  function setup(routerImpl: (key: ChannelKey, name: string, invokerId: string) => Promise<RouterResult>): {
+    handler: ReturnType<typeof createSlashCommandHandler>
+    routerCalls: RouterCall[]
+    logs: { info: string[]; warn: string[]; error: string[] }
+  } {
+    const routerCalls: RouterCall[] = []
+    const logs = { info: [] as string[], warn: [] as string[], error: [] as string[] }
+    const handler = createSlashCommandHandler({
+      router: {
+        executeCommand: async (key, name, options) => {
+          routerCalls.push({ key, name, invokerId: options.invokerId })
+          return routerImpl(key, name, options.invokerId)
+        },
+      },
+      knownCommandNames: SLACK_SLASH_COMMAND_NAMES,
+      logger: {
+        info: (m) => logs.info.push(m),
+        warn: (m) => logs.warn.push(m),
+        error: (m) => logs.error.push(m),
+      },
+      formatChannelTag: async (workspace, chat) => `team=${workspace} channel=${chat}`,
+    })
+    return { handler, routerCalls, logs }
+  }
+
+  function makeArgs(
+    overrideBody: Partial<{
+      command: string
+      text: string
+      user_id: string
+      channel_id: string
+      team_id: string
+    }> = {},
+  ): { args: Parameters<ReturnType<typeof createSlashCommandHandler>>[0]; acks: AckCall[] } {
+    const acks: AckCall[] = []
+    const ack = (payload?: Record<string, unknown>): void => {
+      acks.push(payload)
+    }
+    const args = {
+      ack,
+      envelope_id: 'env-1',
+      body: {
+        command: '/stop',
+        text: '',
+        user_id: 'U-alice',
+        channel_id: 'C-general',
+        team_id: 'T-acme',
+        ...overrideBody,
+      },
+    } as Parameters<ReturnType<typeof createSlashCommandHandler>>[0]
+    return { args, acks }
+  }
+
+  test('/stop routes to executeCommand with invokerId and acks ephemerally with success text', async () => {
+    const { handler, routerCalls } = setup(async () => ({ kind: 'handled', name: 'stop' }))
+    const { args, acks } = makeArgs()
+
+    await handler(args)
+
+    expect(routerCalls).toEqual([
+      {
+        key: { adapter: 'slack-bot', workspace: 'T-acme', chat: 'C-general', thread: null },
+        name: 'stop',
+        invokerId: 'U-alice',
+      },
+    ])
+    expect(acks).toHaveLength(1)
+    expect(acks[0]).toMatchObject({ response_type: 'ephemeral' })
+    expect((acks[0] as { text: string }).text).toContain('Stopped')
+  })
+
+  test('cold-channel /stop acks with "nothing to stop"', async () => {
+    const { handler } = setup(async () => ({ kind: 'no-live-session' }))
+    const { args, acks } = makeArgs()
+
+    await handler(args)
+
+    expect(acks).toHaveLength(1)
+    expect((acks[0] as { text: string }).text).toContain('Nothing to stop')
+  })
+
+  test('permission-denied result acks with the permission-denied message', async () => {
+    const { handler } = setup(async () => ({ kind: 'permission-denied' }))
+    const { args, acks } = makeArgs()
+
+    await handler(args)
+
+    expect(acks).toHaveLength(1)
+    expect((acks[0] as { text: string }).text).toMatch(/permission/i)
+  })
+
+  test('ambiguous result acks with guidance to invoke from inside the thread', async () => {
+    const { handler } = setup(async () => ({ kind: 'ambiguous', matchCount: 2 }))
+    const { args, acks } = makeArgs()
+
+    await handler(args)
+
+    expect(acks).toHaveLength(1)
+    expect((acks[0] as { text: string }).text).toMatch(/multiple|thread/i)
+  })
+
+  test('DM channel ids resolve to workspace=@dm', async () => {
+    const { handler, routerCalls } = setup(async () => ({ kind: 'handled', name: 'stop' }))
+    const { args } = makeArgs({ user_id: 'U-bob', channel_id: 'D-bob' })
+
+    await handler(args)
+
+    expect(routerCalls[0]!.key.workspace).toBe('@dm')
+    expect(routerCalls[0]!.key.chat).toBe('D-bob')
+  })
+
+  test('unknown commands are dropped and acked with the failure message', async () => {
+    const { handler, routerCalls, logs } = setup(async () => ({ kind: 'handled', name: 'stop' }))
+    const { args, acks } = makeArgs({ command: '/totally-not-stop' })
+
+    await handler(args)
+
+    expect(routerCalls).toEqual([])
+    expect(logs.warn.some((m) => m.includes('unknown-command'))).toBe(true)
+    expect(acks).toHaveLength(1)
+  })
+
+  test('executeCommand exception is caught, acked with failure, and logged', async () => {
+    const { handler, logs } = setup(async () => {
+      throw new Error('router exploded')
+    })
+    const { args, acks } = makeArgs()
+
+    await handler(args)
+
+    expect(logs.error.some((m) => m.includes('router exploded'))).toBe(true)
+    expect(acks).toHaveLength(1)
+    expect((acks[0] as { text: string }).text).toMatch(/internal error|Could not stop/i)
+  })
+
+  test('acks exactly once when ack on happy path throws (does NOT cascade into error-path ack)', async () => {
+    // B1 + B2 fix from review: pre-fix, a thrown ack on the success path
+    // entered the outer catch which called ack again. Test asserts the
+    // exactly-once contract.
+    let ackCallCount = 0
+    const handler = createSlashCommandHandler({
+      router: { executeCommand: async () => ({ kind: 'handled', name: 'stop' }) },
+      knownCommandNames: SLACK_SLASH_COMMAND_NAMES,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      formatChannelTag: async () => 'team=T-acme channel=C-general',
+    })
+    const args = {
+      ack: () => {
+        ackCallCount++
+        throw new Error('socket gone')
+      },
+      envelope_id: 'env-1',
+      body: {
+        command: '/stop',
+        text: '',
+        user_id: 'U-alice',
+        channel_id: 'C-general',
+        team_id: 'T-acme',
+      },
+    } as Parameters<ReturnType<typeof createSlashCommandHandler>>[0]
+
+    await handler(args)
+
+    expect(ackCallCount).toBe(1)
+  })
+
+  test('manifest slash_commands list and runtime allow-list stay in sync (B3 drift guard)', () => {
+    const manifestNames = SLACK_APP_MANIFEST.features.slash_commands.map((c) => c.command.replace(/^\//, ''))
+    const allowList = Array.from(SLACK_SLASH_COMMAND_NAMES).sort()
+    expect(manifestNames.slice().sort()).toEqual(allowList)
+  })
+
+  test('ack fires BEFORE the slow formatChannelTag completes (3s budget protection)', async () => {
+    const events: Array<'router-call' | 'ack-sent' | 'channel-tag-resolved'> = []
+    let releaseTag: (() => void) | undefined
+    const tagPromise = new Promise<string>((resolve) => {
+      releaseTag = () => {
+        events.push('channel-tag-resolved')
+        resolve('team=T-acme channel=C-general')
+      }
+    })
+    const handler = createSlashCommandHandler({
+      router: {
+        executeCommand: async () => {
+          events.push('router-call')
+          return { kind: 'handled', name: 'stop' }
+        },
+      },
+      knownCommandNames: SLACK_SLASH_COMMAND_NAMES,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      formatChannelTag: () => tagPromise,
+    })
+    const ack = (): void => {
+      events.push('ack-sent')
+    }
+    const args = {
+      ack,
+      envelope_id: 'env-1',
+      body: {
+        command: '/stop',
+        text: '',
+        user_id: 'U-alice',
+        channel_id: 'C-general',
+        team_id: 'T-acme',
+      },
+    } as Parameters<ReturnType<typeof createSlashCommandHandler>>[0]
+
+    const done = handler(args)
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    expect(events).toEqual(['router-call', 'ack-sent'])
+
+    releaseTag!()
+    await done
+
+    expect(events).toEqual(['router-call', 'ack-sent', 'channel-tag-resolved'])
   })
 })

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -1,4 +1,4 @@
-import { SlackBotClient, SlackBotListener } from 'agent-messenger/slackbot'
+import { SlackBotClient, SlackBotListener, type SlackSocketModeSlashCommandArgs } from 'agent-messenger/slackbot'
 
 import {
   MEMBERSHIP_ENUMERATION_CAP,
@@ -33,7 +33,26 @@ import {
   type SlackInboundMessageEvent,
 } from './slack-bot-classify'
 import { createSlackDedupe } from './slack-bot-dedupe'
+import {
+  buildSlashAckPayload,
+  parseSlashCommand,
+  SLACK_SLASH_REPLY_ABORTED,
+  SLACK_SLASH_REPLY_AMBIGUOUS,
+  SLACK_SLASH_REPLY_FAILED,
+  SLACK_SLASH_REPLY_NO_LIVE_SESSION,
+  SLACK_SLASH_REPLY_PERMISSION_DENIED,
+} from './slack-bot-slash-commands'
 import { slackTsToMillis } from './slack-bot-time'
+
+// One slash command per logical agent gesture. Mirrors the discord-bot
+// SLASH_COMMANDS constant so the cross-platform set stays consistent — when
+// we add a new command (e.g. /memory), it appears in both adapters together.
+// The actual registration lives in the Slack App Manifest at src/cli/ui.ts;
+// this constant is the runtime allow-list that gates which delivered
+// slash_commands events we route vs drop. The ui.test.ts manifest-drift
+// test asserts equality between this set and SLACK_APP_MANIFEST.features.
+// slash_commands so the two can never silently diverge.
+export const SLACK_SLASH_COMMAND_NAMES: ReadonlySet<string> = new Set(['stop'])
 
 // Resolvers fall back to the raw id on failure, so a name equal to the id
 // means resolution failed; we render the bare id rather than `id(id)`. The
@@ -42,6 +61,101 @@ import { slackTsToMillis } from './slack-bot-time'
 function formatLabel(name: string | undefined, id: string, prefix = ''): string {
   if (name === undefined || name === '' || name === id) return id
   return `${prefix}${name}(${id})`
+}
+
+export type SlackBotAdapterLoggerLike = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+export type SlashCommandHandlerDeps = {
+  router: Pick<ChannelRouter, 'executeCommand'>
+  knownCommandNames: ReadonlySet<string>
+  logger: SlackBotAdapterLoggerLike
+  formatChannelTag: (workspace: string, chat: string) => Promise<string>
+}
+
+// Ack-first invariant: the handler must call args.ack() exactly once on
+// every path AND must do so before any slow network work (resolver calls,
+// post-ack logging). Slack's 3s ack deadline starts when the slash command
+// envelope arrives on the WebSocket; missing it shows the user
+// "/stop didn't respond in time". The synchronous executeCommand happy
+// path is fast (in-memory map lookup + abort), so ack-after-execute is
+// safe; everything else (formatChannelTag, post-ack logging) runs after.
+//
+// Ack failure handling: a thrown ack on the happy path is logged but does
+// NOT trigger the catch-all error-ack below, which would attempt a second
+// ack call and break the exactly-once contract.
+export function createSlashCommandHandler(
+  deps: SlashCommandHandlerDeps,
+): (args: SlackSocketModeSlashCommandArgs) => Promise<void> {
+  return async ({ ack, body }) => {
+    const parsed = parseSlashCommand(body, deps.knownCommandNames)
+    if (parsed.kind === 'ignore') {
+      deps.logger.warn(`[slack-bot] slash command dropped reason=${parsed.reason} command=${body.command}`)
+      try {
+        ack(buildSlashAckPayload(SLACK_SLASH_REPLY_FAILED))
+      } catch (err) {
+        deps.logger.warn(`[slack-bot] slash command ack (drop path) failed: ${describe(err)}`)
+      }
+      return
+    }
+    const { command } = parsed
+
+    // Pre-ACK log: bare ids only (no formatChannelTag — would burn ack budget
+    // on a slow Slack API minute via the channel-name resolver).
+    deps.logger.info(
+      `[slack-bot] slash /${command.name} invoker=${command.invokerId} team=${command.key.workspace} channel=${command.key.chat}`,
+    )
+
+    let result: Awaited<ReturnType<typeof deps.router.executeCommand>>
+    try {
+      result = await deps.router.executeCommand(command.key, command.name, {
+        invokerId: command.invokerId,
+      })
+    } catch (err) {
+      deps.logger.error(`[slack-bot] slash command handler failed: ${describe(err)}`)
+      try {
+        ack(buildSlashAckPayload(SLACK_SLASH_REPLY_FAILED))
+      } catch (ackErr) {
+        deps.logger.warn(`[slack-bot] slash command error-ack failed: ${describe(ackErr)}`)
+      }
+      return
+    }
+
+    const replyContent =
+      result.kind === 'handled'
+        ? SLACK_SLASH_REPLY_ABORTED
+        : result.kind === 'no-live-session'
+          ? SLACK_SLASH_REPLY_NO_LIVE_SESSION
+          : result.kind === 'permission-denied'
+            ? SLACK_SLASH_REPLY_PERMISSION_DENIED
+            : result.kind === 'ambiguous'
+              ? SLACK_SLASH_REPLY_AMBIGUOUS
+              : SLACK_SLASH_REPLY_FAILED
+
+    // Final ack on the happy path: own try/catch so a thrown ack here does
+    // NOT cascade into the error-path ack above (which would violate the
+    // exactly-once contract). The abort already happened server-side; only
+    // the user-visible confirmation is lost.
+    try {
+      ack(buildSlashAckPayload(replyContent))
+    } catch (err) {
+      deps.logger.warn(`[slack-bot] slash command ack failed: ${describe(err)}`)
+    }
+
+    // Decorative post-ack logging: resolve channel names now that the 3s
+    // budget is no longer a concern. Best-effort.
+    try {
+      const inboundTag = await deps.formatChannelTag(command.key.workspace, command.key.chat)
+      deps.logger.info(`[slack-bot] slash /${command.name} result=${result.kind} ${inboundTag}`)
+    } catch (err) {
+      deps.logger.info(
+        `[slack-bot] slash /${command.name} result=${result.kind} (channel-tag resolution failed: ${describe(err)})`,
+      )
+    }
+  }
 }
 
 // app_mention payloads omit channel_type and never carry a subtype, so we
@@ -661,6 +775,13 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
 
   const dedupe = createSlackDedupe()
 
+  const handleSlashCommand = createSlashCommandHandler({
+    router: options.router,
+    knownCommandNames: SLACK_SLASH_COMMAND_NAMES,
+    logger,
+    formatChannelTag,
+  })
+
   const handleMessageEvent = async (
     event: SlackInboundMessageEvent,
     source: 'message' | 'app_mention',
@@ -776,6 +897,23 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       listener.on('app_mention', ({ ack, event }) => {
         ack()
         void handleMessageEvent(promoteAppMentionToMessage(event as SlackInboundAppMentionEvent), 'app_mention')
+      })
+      listener.on('slash_commands', (args) => {
+        // The handler owns the ack call itself (the ack payload carries the
+        // user-visible reply text), so we do NOT ack here. inflightInbounds
+        // wrapping mirrors handleMessageEvent so stop() can drain the
+        // handler before tearing down the listener — otherwise a /stop
+        // arriving during stop() would lose its ack and the user sees
+        // "didn't respond in time" even though the abort succeeded.
+        inflightInbounds++
+        void handleSlashCommand(args).finally(() => {
+          inflightInbounds--
+          if (inflightInbounds === 0 && stopWaiters.length > 0) {
+            const waiters = stopWaiters
+            stopWaiters = []
+            for (const w of waiters) w()
+          }
+        })
       })
 
       options.router.registerOutbound('slack-bot', outboundCallback)

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1957,6 +1957,81 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
     expect(result).toEqual({ kind: 'permission-denied' })
     expect(sessions).toHaveLength(0)
   })
+
+  test('falls back to a thread-keyed session when slash command carries thread:null (Slack)', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ text: 'hi', thread: 'thr-1', isBotMention: true }))
+    await router.__testing!.flushDebounce({ ...KEY, thread: 'thr-1' })
+
+    const result = await router.executeCommand({ ...KEY, thread: null }, 'stop', { invokerId: 'alice' })
+
+    expect(result).toEqual({ kind: 'handled', name: 'stop' })
+    expect(sessions[0]!.aborted).toBe(1)
+  })
+
+  test('exact key match wins over fallback when both apply', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ text: 'top-level' }))
+    await router.__testing!.flushDebounce(KEY)
+    await router.route(inbound({ text: 'in thread', thread: 'thr-1', isBotMention: true, externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce({ ...KEY, thread: 'thr-1' })
+
+    const result = await router.executeCommand({ ...KEY, thread: null }, 'stop', { invokerId: 'alice' })
+
+    expect(result).toEqual({ kind: 'handled', name: 'stop' })
+    expect(sessions[0]!.aborted).toBe(1)
+    expect(sessions[1]!.aborted).toBe(0)
+  })
+
+  test('returns ambiguous when multiple thread-keyed sessions match the channel-level key', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ text: 'in thread 1', thread: 'thr-1', isBotMention: true, externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce({ ...KEY, thread: 'thr-1' })
+    await router.route(inbound({ text: 'in thread 2', thread: 'thr-2', isBotMention: true, externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce({ ...KEY, thread: 'thr-2' })
+
+    const result = await router.executeCommand({ ...KEY, thread: null }, 'stop', { invokerId: 'alice' })
+
+    expect(result).toEqual({ kind: 'ambiguous', matchCount: 2 })
+    expect(sessions[0]!.aborted).toBe(0)
+    expect(sessions[1]!.aborted).toBe(0)
+  })
+
+  test('fallback ignores sessions in other chats (same workspace)', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ text: 'hi', thread: 'thr-1', isBotMention: true }))
+    await router.__testing!.flushDebounce({ ...KEY, thread: 'thr-1' })
+
+    const result = await router.executeCommand({ ...KEY, chat: 'other-channel', thread: null }, 'stop', {
+      invokerId: 'alice',
+    })
+
+    expect(result).toEqual({ kind: 'no-live-session' })
+    expect(sessions[0]!.aborted).toBe(0)
+  })
+
+  test('fallback ignores sessions in other workspaces (same chat id)', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ text: 'hi' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const result = await router.executeCommand({ ...KEY, workspace: 'other-workspace', thread: null }, 'stop', {
+      invokerId: 'alice',
+    })
+
+    expect(result).toEqual({ kind: 'no-live-session' })
+    expect(sessions[0]!.aborted).toBe(0)
+  })
 })
 
 describe('ChannelRouter typing indicator', () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -312,6 +312,7 @@ export type ExecuteCommandResult =
   | { kind: 'unknown-command'; name: string }
   | { kind: 'no-live-session' }
   | { kind: 'permission-denied' }
+  | { kind: 'ambiguous'; matchCount: number }
 
 // Identifies who invoked an adapter-driven command. Required so the router
 // can run the same channel.respond permission gate the text-prefix command
@@ -377,6 +378,8 @@ export type ChannelRouter = {
   //   - handled: command ran
   //   - permission-denied: invoker lacks channel.respond
   //   - no-live-session: channel has no active session
+  //   - ambiguous: multiple thread-keyed sessions in same chat (Slack);
+  //     caller should refuse to act rather than abort an arbitrary one
   //   - unknown-command: name is not registered
   executeCommand: (key: ChannelKey, name: string, options: ExecuteCommandOptions) => Promise<ExecuteCommandResult>
   // Lowered self-aliases (configured + implicit dir-name). Adapters use
@@ -1792,12 +1795,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (!permissions.has(partial, CORE_PERMISSIONS.channelRespond)) {
       return { kind: 'permission-denied' }
     }
-    const keyId = channelKeyId(key)
-    const live = liveSessions.get(keyId)
-    if (!live || live.destroyed) {
+    const resolved = resolveLiveSessionForCommand(liveSessions, key)
+    if (resolved.kind === 'none') {
       return { kind: 'no-live-session' }
     }
-    const result = await commands.execute(`/${lowered}`, { live, event: null })
+    if (resolved.kind === 'ambiguous') {
+      return { kind: 'ambiguous', matchCount: resolved.count }
+    }
+    const result = await commands.execute(`/${lowered}`, { live: resolved.session, event: null })
     if (result.kind === 'handled') {
       return { kind: 'handled', name: result.name }
     }
@@ -1985,6 +1990,52 @@ function tryOpenSessionManager(
 
 function consecutiveSendKey(chat: string, thread: string | null | undefined): string {
   return `${chat}:${thread ?? ''}`
+}
+
+export type ResolveLiveSessionResult =
+  | { kind: 'found'; session: LiveSession }
+  | { kind: 'none' }
+  | { kind: 'ambiguous'; count: number }
+
+// Lookup policy for adapter-driven commands. Exact-key match always wins.
+// On miss, fall back to (adapter, workspace, chat) without thread — but
+// only when EXACTLY ONE non-destroyed candidate exists. Ambiguous matches
+// return 'ambiguous' so the caller can refuse to act rather than abort an
+// arbitrary session.
+//
+// Why the fallback: Slack slash commands carry channel_id but no thread_ts,
+// so a slash invocation from a thread-keyed live session would otherwise
+// report no-live-session. Discord doesn't hit this — Discord treats threads
+// as channels, so the exact-key path already resolves.
+//
+// Why ambiguity-rejection: "first match wins" map-iteration semantics would
+// abort an arbitrary thread when multiple thread-keyed sessions coexist in
+// one channel (plausible on Slack: bot mentioned in multiple threads). The
+// user's slash command picker doesn't know about threads; we don't know
+// which they meant; refusing is safer than guessing.
+export function resolveLiveSessionForCommand(
+  liveSessions: ReadonlyMap<string, LiveSession>,
+  key: ChannelKey,
+): ResolveLiveSessionResult {
+  const exact = liveSessions.get(channelKeyId(key))
+  if (exact && !exact.destroyed) return { kind: 'found', session: exact }
+
+  const matches: LiveSession[] = []
+  for (const candidate of liveSessions.values()) {
+    if (candidate.destroyed) continue
+    if (
+      candidate.key.adapter === key.adapter &&
+      candidate.key.workspace === key.workspace &&
+      candidate.key.chat === key.chat
+    ) {
+      matches.push(candidate)
+      if (matches.length > 1) {
+        return { kind: 'ambiguous', count: matches.length }
+      }
+    }
+  }
+  if (matches.length === 1) return { kind: 'found', session: matches[0]! }
+  return { kind: 'none' }
 }
 
 function normalizeSendText(text: string | undefined): string | undefined {

--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -445,4 +445,21 @@ describe('printSlackAppManifestSetup', () => {
       messages_tab_read_only_enabled: false,
     })
   })
+
+  test('manifest declares /stop as a slash command with a description', () => {
+    const slashCommands = SLACK_APP_MANIFEST.features.slash_commands
+    const stop = slashCommands.find((c) => c.command === '/stop')
+    expect(stop).toBeDefined()
+    expect(stop!.description).toBeTruthy()
+  })
+
+  test('manifest grants the `commands` scope so slash_commands envelopes can route', () => {
+    expect(SLACK_APP_MANIFEST.oauth_config.scopes.bot).toContain('commands')
+  })
+
+  test('slash command url is an invalid placeholder (Socket Mode ignores it; misconfigured deploys fail fast)', () => {
+    const stop = SLACK_APP_MANIFEST.features.slash_commands.find((c) => c.command === '/stop')
+    expect(stop).toBeDefined()
+    expect(stop!.url).toContain('example.invalid')
+  })
 })

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -142,6 +142,27 @@ export const SLACK_APP_MANIFEST = {
       messages_tab_enabled: true,
       messages_tab_read_only_enabled: false,
     },
+    // Slash commands listed here appear in Slack's compose-box picker with
+    // their description as a tooltip. `url` is required by Slack's manifest
+    // schema even for Socket Mode bots, but is ignored at runtime when the
+    // app is in Socket Mode — Slack delivers `slash_commands` envelopes
+    // over the same WebSocket as message events. We point it at a
+    // deliberately-invalid placeholder (RFC 6761 reserved .invalid TLD)
+    // so a misconfigured (non-Socket-Mode) deployment fails fast rather
+    // than silently routing real slash invocations to a third-party URL.
+    slash_commands: [
+      {
+        command: '/stop',
+        description: 'Abort the current turn in this channel',
+        // usage_hint is intentionally omitted. Slack's manifest validator
+        // rejects an empty string ("Must be more than 0 characters") but
+        // the field is optional, so the cleanest answer is to leave it out
+        // rather than invent placeholder text for a command that takes no
+        // arguments.
+        url: 'https://example.invalid/typeclaw-uses-socket-mode',
+        should_escape: false,
+      },
+    ],
   },
   oauth_config: {
     scopes: {
@@ -150,13 +171,16 @@ export const SLACK_APP_MANIFEST = {
       // write scopes (chat, files, im/mpim/groups, pins, reactions) let the
       // agent post replies, upload attachments, open DMs, pin messages, and
       // react to messages. `channels:join` lets the bot self-join public
-      // channels it's invited to discuss in.
+      // channels it's invited to discuss in. `commands` is required for
+      // Slack to deliver `slash_commands` envelopes — without it, slash
+      // commands registered in `features` would silently fail to route.
       bot: [
         'app_mentions:read',
         'channels:history',
         'channels:join',
         'channels:read',
         'chat:write',
+        'commands',
         'emoji:read',
         'files:read',
         'files:write',


### PR DESCRIPTION
## What and why

PR #299 adds Discord's native `/stop` slash command via `INTERACTION_CREATE` and introduces `ChannelRouter.executeCommand` as the generic entry point for native slash invocations. This PR stacks on top of it and adds the equivalent for Slack.

After this lands, operators and their users see `/stop` in Slack's compose-box picker with a description tooltip. Invoking it ends the in-flight turn the same way typing `/stop` as text already does. The existing text-prefix path is unchanged.

## Why this is a separate PR from #299

Slack and Discord diverge sharply on slash-command registration:

- Discord has a single HTTP endpoint (`PUT /applications/{id}/commands`) that typeclaw calls at adapter start with the bot token. Zero operator action required.
- Slack's `apps.manifest.update` API requires a separate human-generated **configuration token** (`xoxe.xoxp-…` prefix) that must be rotated every 12h via `tooling.tokens.rotate`. Even after a successful manifest update, the workspace admin must re-install the app to grant the bot token the new `commands` scope. Auto-registration is strictly worse operator UX than the manual path.

typeclaw already ships `SLACK_APP_MANIFEST` in `src/cli/ui.ts` — a JSON template operators copy-paste into api.slack.com/apps during `typeclaw init` / `typeclaw channel add slack-bot`. The right approach is to bake `/stop` into that template so new operators get the picker UX for free, and to document the manual upgrade path for existing operators.

On the listener side, `agent-messenger/slackbot` exposes `slash_commands` as a typed event with `SlackSocketModeSlashCommandArgs` over the existing Socket Mode WebSocket — no new transport needed.

## Commits

### 1 — `channels: fall back to any live session in same workspace+chat when executeCommand key misses`

Slack slash commands are invoked from the compose box and never carry a `thread_ts`. But a Slack session that engaged via `@mention` in a channel is keyed on `thread: event.ts` (the root message timestamp). Without a fix, a slash `/stop` from a channel with an active thread-keyed session would miss the exact-key lookup in `ChannelRouter.executeCommand` and falsely report `no-live-session`.

New helper `resolveLiveSessionForCommand` keeps the exact-match path identical and only walks `liveSessions` on a miss, matching by `(adapter, workspace, chat)`. Map iteration is insertion-order in JS, so the first non-destroyed candidate wins — the oldest matching session, which is the one most likely to be "whatever is running here."

Behavior on Discord is **unchanged**: Discord treats threads as channels, so the exact-match path always succeeds and the fallback is a no-op.

Four new router tests cover: fallback fires when only a thread-keyed session exists; exact match wins when both exact and fallback apply; fallback ignores sessions in other chats (same workspace); fallback ignores sessions in other workspaces (same chat id — defensive because chat ids are not unique across workspaces).

### 2 — `slack-bot: add pure helpers for parsing slash command payloads`

New module `slack-bot-slash-commands.ts` mirrors the `discord-bot-slash-commands` shape:

- `parseSlashCommand` turns a `SlackSocketModeSlashCommandArgs` body into either a `ParsedSlackSlashCommand` (with the destination `ChannelKey`, invoker user id, and lowercased command name) or an ignore-with-reason.
- `buildSlashAckPayload` constructs an ephemeral response payload so control gestures stay out of the channel transcript.

Two non-obvious conventions inherited from `slack-bot-classify`:

- DM channels (`D`-prefixed channel ids) → `workspace: '@dm'`
- `thread` is always `null` — slash commands are compose-box-only and never carry `thread_ts`

Pure: no I/O, no side effects, no Slack SDK calls. The pure-first split keeps the next commit focused on adapter integration and manifest.

### 3 — `slack-bot: register /stop in the App Manifest and route slash_commands through executeCommand`

**Manifest changes** (`src/cli/ui.ts`):

- `features.slash_commands` gains a `/stop` entry with description `"Stop the agent's current turn"`.
- `oauth_config.scopes.bot` gains the `commands` scope.
- The slash command `url` is set to `https://example.invalid/typeclaw-uses-socket-mode` — RFC 6761 guaranteed-never-routable. Slack requires the field even in Socket Mode but ignores it at runtime; pointing it at a real host would silently route invocations there if the app were ever switched out of Socket Mode.

**Adapter wiring** (`src/channels/adapters/slack-bot.ts`):

- New `createSlashCommandHandler` factory (same shape as the other `createX` helpers) is extracted standalone for testability.
- The handler owns the `ack()` call exclusively — unlike `message` / `app_mention` which ack inline — because the ack payload carries the user-visible reply text. Slack's 3-second ack budget is comfortably met by the synchronous `executeCommand` path.
- DM detection uses the `D`-prefix channel id convention (slash payloads don't carry `channel_type`), matching the existing `slack-bot-classify` convention.

**Upgrade impact for existing operators**: must update their Slack app manifest to add the `/stop` slash command and the `commands` scope, then re-install the app to the workspace. New operators get this automatically from the updated `SLACK_APP_MANIFEST` template.

## Files changed

```
src/channels/adapters/slack-bot-slash-commands.test.ts   new  97 lines
src/channels/adapters/slack-bot-slash-commands.ts        new  78 lines
src/channels/adapters/slack-bot.test.ts                 +186 lines
src/channels/adapters/slack-bot.ts                       +93 lines
src/channels/router.test.ts                              +65 lines
src/channels/router.ts                                   +42 lines
src/cli/ui.test.ts                                       +17 lines
src/cli/ui.ts                                            +22 lines
8 files changed, 595 insertions(+), 5 deletions(-)
```

## Testing

| Gate | Result |
|---|---|
| `bun run typecheck` | clean |
| `bun run lint` | 18 warnings (all pre-existing on `origin/main`), 0 errors |
| `bun run format` | clean |
| `bun run test` | 4652 pass, 0 fail (+24 vs the #299 base at 4628) |

Test breakdown for the 24 new tests:
- 4 router fallback tests (commit 1, `router.test.ts`)
- 11 pure helper tests (commit 2, `slack-bot-slash-commands.test.ts`)
- 3 manifest assertion tests (commit 3, `ui.test.ts`)
- 6 adapter integration tests (commit 3, `slack-bot.test.ts`)

## Review notes

- **Ack ownership**: the slash handler owns `ack()` exclusively (unlike `message` / `app_mention` which ack inline) because the ack payload carries the user-visible reply text. This is the correct Slack Socket Mode contract.
- **`example.invalid` in the manifest**: RFC 6761 guarantees this domain never resolves. It is not a placeholder to replace — it is the correct permanent value for Socket Mode apps.
- **Fallback scope**: `resolveLiveSessionForCommand` matches on `(adapter, workspace, chat)` only — it does not match across workspaces or across adapters. The defensive test for same-chat-id-different-workspace confirms the isolation.
- **No change to the text-prefix `/stop` path**: the `router.ts` message handler and `slack-bot-classify` are untouched.

Builds on #299 (`discord-bot: add /stop as a native slash command via INTERACTION_CREATE`).