### PR TITLE
docs: audit and fix all mdx pages, add Permissions and CLI Reference

### DIFF
--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -8,13 +8,13 @@ A **channel** is any platform the agent talks through. Inbound messages route to
 
 ## Built-in adapters
 
-| Adapter        | Authentication                                        | Notes                                                                 |
-| -------------- | ----------------------------------------------------- | --------------------------------------------------------------------- |
-| `slack-bot`    | Bot token + app token                                 | Socket Mode, no public URL required                                   |
-| `discord-bot`  | Bot token                                             | Standard intent-based connection                                      |
-| `telegram-bot` | Bot token                                             | Long polling, no webhook required                                     |
-| `github`       | PAT or GitHub App                                     | Pairs with a tunnel for webhook delivery                              |
-| `kakaotalk`    | Sub-device login (email + password, stored encrypted) | LOCO protocol; survives 7-day token expiry via host-side renewal cron |
+| Adapter        | Authentication                                                                       | Notes                                                                 |
+| -------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| `slack-bot`    | Bot token + app token                                                                | Socket Mode, no public URL required                                   |
+| `discord-bot`  | Bot token                                                                            | Standard intent-based connection                                      |
+| `telegram-bot` | Bot token                                                                            | Long polling, no webhook required                                     |
+| `github`       | Fine-grained PAT, or GitHub App (`appId` + `privateKey` + optional `installationId`) | Pairs with a tunnel for webhook delivery                              |
+| `kakaotalk`    | Sub-device login (email + password, stored encrypted)                                | LOCO protocol; survives 7-day token expiry via host-side renewal cron |
 
 ## Wire one up
 
@@ -24,11 +24,24 @@ typeclaw channel add slack-bot
 
 The CLI prompts for tokens, writes them into `secrets.json` (under `channels.slack-bot`), and updates `typeclaw.json` so the adapter starts on the next reload.
 
-Rotating credentials:
+## Rotating credentials
+
+Most adapters accept rotation through `set`:
 
 ```sh
 typeclaw channel set slack-bot
+typeclaw channel set discord-bot
+typeclaw channel set telegram-bot
+typeclaw channel set github
 ```
+
+**KakaoTalk is the exception.** It needs a fresh sub-device login (interactive phone-passcode flow), so rotation goes through `reauth`:
+
+```sh
+typeclaw channel reauth kakaotalk
+```
+
+Trying to rotate KakaoTalk via `channel set` is not supported — use `reauth`.
 
 ## How routing works
 
@@ -45,11 +58,11 @@ The router never blocks on a slow adapter. Each adapter owns its own outbound qu
 
 By default `channel.respond` is granted to:
 
-- **owner** — TUI sessions
+- **owner** — TUI sessions, plus any author you've paired via `typeclaw role claim --as owner`
 - **trusted** — must declare a `match[]` rule (e.g. `"slack:T0123 author:U_ME"`)
-- **member** — declares which conversations the agent should answer in at all
+- **member** — must declare which conversations the agent should answer in
 
-If your agent silently ignores all inbound messages, you almost certainly haven't put a non-owner role's `match[]` rule on the chats it should answer in.
+If your agent silently ignores all inbound messages, you almost certainly haven't put a non-owner role's `match[]` rule on the chats it should answer in. See [Permissions](/docs/permissions) for the role model and match-rule DSL.
 
 ## Group-chat awareness
 

--- a/docs/content/docs/cli.mdx
+++ b/docs/content/docs/cli.mdx
@@ -1,0 +1,121 @@
+---
+title: CLI Reference
+description: Every typeclaw command, what stage it runs in, and the flags that matter
+icon: Terminal
+---
+
+TypeClaw runs code in three stages with different filesystems. The CLI command names encode the stage. `init` creates the host stage; `start`/`stop`/`restart`/`logs`/`tui`/`reload`/`shell` etc. are **host-stage launchers**; `run` is the **container-stage** entrypoint Docker actually executes. You almost never run `typeclaw run` directly.
+
+This page covers the commands not already documented in dedicated pages. See also: [Channels](/docs/channels), [Cron](/docs/cron), [Tunnels](/docs/tunnels), [Permissions](/docs/permissions).
+
+## Lifecycle
+
+| Command            | Description                                                                                                                                  |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `typeclaw init`    | Interactive wizard. Scaffolds the agent folder; optionally wires the first provider + first channel.                                         |
+| `typeclaw start`   | `docker run` the container with the configured ports + mounts + env-file. Spawns `hostd` on first call per host. Flags: `--port`, `--build`. |
+| `typeclaw restart` | `stop` + `start` with the same flag set as `start`.                                                                                          |
+| `typeclaw stop`    | `docker stop` then `docker rm` so a clean stop leaves no trace.                                                                              |
+| `typeclaw status`  | Container + daemon registration state.                                                                                                       |
+| `typeclaw logs`    | Print container stdout/stderr with reformatted local timestamps. `-f` / `--follow` to stream.                                                |
+| `typeclaw shell`   | Drop into a shell inside the running container. `--shell` to pick (defaults to `bash` if present, else `sh`).                                |
+| `typeclaw tui`     | Attach an interactive TUI. Takes an optional one-shot prompt argument; `--url` to override the websocket URL.                                |
+| `typeclaw reload`  | Re-read `typeclaw.json` and apply hot-reloadable fields. Reports which fields require a restart.                                             |
+
+`--port` is the **preferred** host port. On bind conflict, `start` allocates an ephemeral port; subsequent commands (`tui`, `reload`, etc.) resolve the actual port by querying Docker.
+
+## Providers
+
+```sh
+typeclaw provider add        # interactive: pick provider + auth method
+typeclaw provider add fireworks --key fw_xxx
+typeclaw provider add openai --oauth
+typeclaw provider add openai --env MY_OPENAI_KEY    # bind to a custom env var
+typeclaw provider set <id>   # rotate
+typeclaw provider remove <id> [--force]
+typeclaw provider list       # shows resolution: file vs env
+```
+
+Providers are LLM credentials. The store is `secrets.json#providers`; see [Secrets](/docs/secrets) for the env-wins / file-never-auto-mutated policy.
+
+## Models
+
+```sh
+typeclaw model set default fireworks/kimi-k2
+typeclaw model add deep anthropic/claude-opus-4-5
+typeclaw model remove fast
+typeclaw model list                # current profiles
+typeclaw model list --available    # every known provider/model ref
+```
+
+Profiles (`default`, `fast`, `deep`, `vision`, or any custom name) map to a single ref or a fallback chain. Unknown profile names resolve to `default` with a one-time warning at session construction.
+
+## Roles
+
+See [Permissions](/docs/permissions) for the full role model. Quick reference:
+
+```sh
+typeclaw role claim --as owner --channel slack-bot     # pair a channel author to a role
+typeclaw role list                                     # show declared roles + match rules
+```
+
+`--ttl` (default 600000 ms) controls how long the claim code stays valid. Drop `--channel` to listen on every wired adapter.
+
+## Channels, Cron, Tunnels
+
+Covered on their own pages:
+
+- [`typeclaw channel add | set | reauth`](/docs/channels)
+- [`typeclaw cron list`](/docs/cron) (edit `cron.json` directly, then `reload`)
+- [`typeclaw tunnel add | list | status | logs | remove`](/docs/tunnels)
+
+## Compose
+
+`typeclaw compose` orchestrates multiple agents across immediate subdirectories of cwd. Each subdirectory is an independent agent folder (own container, own `~/.typeclaw/` registration, own port).
+
+```sh
+cd ~/my-agent-fleet/
+
+typeclaw compose start           # docker run every agent subfolder
+typeclaw compose start --build   # regenerate Dockerfiles and rebuild
+typeclaw compose stop            # stop all
+typeclaw compose restart         # stop + start
+typeclaw compose status          # one row per agent
+typeclaw compose logs -f         # follow logs from every agent, interleaved
+typeclaw compose usage --since 7d
+typeclaw compose doctor          # run doctor in every agent, summarize
+typeclaw compose doctor --fix --only docker,config
+```
+
+Compose is a thin loop over the per-agent commands — there is no shared lifecycle, no orchestration manifest, no inter-agent networking magic. Just "do `X` on every agent in this directory."
+
+## Doctor
+
+```sh
+typeclaw doctor                  # human-readable report; exit 0/1
+typeclaw doctor -v               # show per-check details
+typeclaw doctor --json           # JSON for scripting
+typeclaw doctor --fix            # attempt auto-fixes and commit changes
+typeclaw doctor --only docker,config   # narrow to specific categories
+```
+
+Diagnoses the host, agent folder, and plugins. Categories include `docker`, `config`, `secrets`, `network`, `git`, plus per-plugin checks. `--fix` is safe by design: every fix is git-committed so you can audit and revert.
+
+## Usage
+
+```sh
+typeclaw usage                          # summary across recent sessions
+typeclaw usage daily --since 7d         # one row per calendar day
+typeclaw usage session --limit 20       # top sessions by cost
+typeclaw usage models                   # one row per provider/model
+typeclaw usage origin                   # one row per session origin (tui/cron/channel/subagent)
+typeclaw usage --json                   # machine-readable
+```
+
+Common flags on every subcommand: `--since <duration>` / `--until <iso>`, `--cwd <path>`, `--json`.
+
+## Hidden commands
+
+`typeclaw _hostd` is the host-side daemon entry, spawned automatically by the first `start` on the host. It's hidden from `--help` and not intended for direct invocation. State lives at `~/.typeclaw/` (override with `TYPECLAW_HOME` for tests).
+
+`typeclaw run` is the container-stage entrypoint Docker actually executes. The host CLI never invokes it directly.

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -4,7 +4,7 @@ description: Everything in typeclaw.json, what's hot-reloadable, what isn't
 icon: Settings
 ---
 
-`typeclaw.json` is the agent's single source of truth. It's JSON Schema–validated (see `typeclaw.schema.json` at the agent folder root after `typeclaw init`).
+`typeclaw.json` is the agent's single source of truth. It's JSON Schema–validated; `typeclaw init` scaffolds a `$schema` field pointing at `./node_modules/typeclaw/typeclaw.schema.json` so editors get autocomplete out of the box.
 
 ## Agent folder layout
 
@@ -22,19 +22,97 @@ my-agent/
 └── memory/           # MEMORY.md + muscle-memory skills (force-committed)
 ```
 
-## Common fields
+## Top-level fields
 
-| Field         | What it does                                                                  | Reload behavior      |
-| ------------- | ----------------------------------------------------------------------------- | -------------------- |
-| `port`        | Preferred host port (CLI falls back to ephemeral on conflict)                 | restart-required     |
-| `mounts`      | Host directories exposed inside the container                                 | restart-required     |
-| `plugins`     | Plugin module specifiers                                                      | restart-required     |
-| `channels`    | Per-adapter config (`slack-bot`, `discord-bot`, `github`, `kakaotalk`, …)     | live for most fields |
-| `portForward` | Allow/deny list for auto port forwarding (default `*`)                        | restart-required     |
-| `tunnels`     | Public URLs for inbound webhooks and ad-hoc exposure                          | restart-required     |
-| `roles`       | Permission roles bundling allowed actions and match rules                     | restart-required     |
-| `dockerfile`  | Toggles for `gh`, `python`, `tmux`, `ffmpeg`, `cjkFonts`, plus `append` lines | rebuild via `start`  |
-| `memory`      | Idle window and dreaming schedule for the bundled memory plugin               | restart-required     |
+| Field         | What it does                                                                      | Reload behavior                              |
+| ------------- | --------------------------------------------------------------------------------- | -------------------------------------------- |
+| `models`      | Model profiles (`default` is required; `fast`, `deep`, `vision` are conventional) | live                                         |
+| `port`        | Preferred host port (CLI falls back to ephemeral on conflict)                     | restart-required                             |
+| `mounts`      | Host directories exposed inside the container                                     | restart-required                             |
+| `plugins`     | Plugin module specifiers                                                          | restart-required                             |
+| `alias`       | Additional names the agent answers to in channels                                 | live                                         |
+| `channels`    | Per-adapter config (`slack-bot`, `discord-bot`, `github`, `kakaotalk`, …)         | live                                         |
+| `portForward` | Allow/deny list for auto port forwarding (default `*`)                            | restart-required                             |
+| `network`     | Egress filtering — `blockInternal`, `autoAllowResolvers`, `allow`                 | restart-required                             |
+| `tunnels`     | Public URLs for inbound webhooks and ad-hoc exposure                              | restart-required                             |
+| `roles`       | Permission roles bundling permissions + match rules                               | `match` live, `permissions` restart-required |
+| `docker.file` | Dockerfile feature toggles + `append` lines                                       | rebuild via `start`                          |
+| `git.ignore`  | Append additional lines to the managed `.gitignore`                               | rebuild via `start`                          |
+
+Plugin-owned config blocks (e.g. the bundled memory plugin's `memory.*`) live at the top level under their plugin name and are validated by the plugin's own `configSchema`.
+
+## `models`
+
+`models` maps a profile name to one or more curated model refs. The `default` profile is required; every other profile is optional and falls back to `default` if missing.
+
+```json
+{
+  "models": {
+    "default": "fireworks/kimi-k2",
+    "fast": "openai/gpt-5.4-mini",
+    "deep": ["anthropic/claude-opus-4-5", "fireworks/kimi-k2"],
+    "vision": "openai/gpt-5.4"
+  }
+}
+```
+
+Each value is either a single `<provider>/<model>` ref or a non-empty array forming a **fallback chain**: when a turn against the first ref fails, the runtime disposes the failed session and replays the prompt against the next ref.
+
+Use the CLI instead of hand-editing:
+
+```sh
+typeclaw model set default fireworks/kimi-k2
+typeclaw model list --available     # every known provider/model ref
+typeclaw model add deep anthropic/claude-opus-4-5
+```
+
+## `network`
+
+The container ships with an egress filter installed by the entrypoint shim:
+
+```json
+{
+  "network": {
+    "blockInternal": true,
+    "autoAllowResolvers": true,
+    "allow": []
+  }
+}
+```
+
+- `blockInternal` (default `true`) — DROP traffic to RFC1918, link-local (incl. cloud metadata at `169.254.169.254`), CGNAT, multicast/reserved, and IPv6 ULA/link-local/multicast. Loopback (`-o lo`) is always allowed, so `localhost` dev servers keep working.
+- `autoAllowResolvers` (default `true`) — narrowly carve out port 53 to every nameserver in `/etc/resolv.conf` so VPC-internal DNS (e.g. AWS at `10.0.0.2`) keeps working.
+- `allow` — explicit IPv4 CIDRs that punch through wholesale. For VPC-private services the agent must reach by IP.
+
+## `docker.file`
+
+| Toggle        | Default | What it does                                                 |
+| ------------- | ------- | ------------------------------------------------------------ |
+| `gh`          | `true`  | install GitHub CLI                                           |
+| `python`      | `true`  | install Python 3 + uv                                        |
+| `tmux`        | `true`  | install tmux                                                 |
+| `ffmpeg`      | `false` | install ffmpeg                                               |
+| `cjkFonts`    | `true`  | install `fonts-noto-cjk` so Chromium renders CJK glyphs      |
+| `cloudflared` | `true`  | install cloudflared for `cloudflare-quick` tunnels           |
+| `xvfb`        | `true`  | install Xvfb for headed Chrome (better bot-detection scores) |
+| `claudeCode`  | `false` | install Anthropic's Claude Code CLI                          |
+| `append`      | `[]`    | extra Dockerfile lines appended verbatim                     |
+
+Boolean toggles can also take a version string (e.g. `"gh": "2.40.0"`) which becomes an `apt-get install pkg=<version>` pin. `claudeCode` is boolean-only.
+
+## `git.ignore`
+
+```json
+{
+  "git": {
+    "ignore": {
+      "append": [".cache/", "scratch/"]
+    }
+  }
+}
+```
+
+`append` lines are added to the managed `.gitignore` on every `typeclaw start`. The truly-ignored entries (`.env`, `node_modules/`, `workspace/`, `Dockerfile`, …) and system-managed entries (`sessions/`, `memory/` are gitignored but force-committed by TypeClaw on its own schedule) are always present and not configurable.
 
 ## Hot reload
 
@@ -42,10 +120,19 @@ my-agent/
 typeclaw reload
 ```
 
-Most channel fields, role lists, and plugin-owned config blocks reload live. Boot-only fields (`port`, `mounts`, `plugins`, `portForward`, `tunnels`) are captured once at container start; `reload` will tell you which fields require a restart.
+Most channel fields, role match lists, alias entries, and plugin-owned config blocks reload live. Boot-only fields (`port`, `mounts`, `plugins`, `portForward`, `network`, `tunnels`) are captured once at container start; `reload` reports which changes require a restart.
 
 ## Managed files
 
-TypeClaw owns the `Dockerfile` and `.gitignore` for your agent folder, and **rewrites them on every `start`**. This is deliberate — the source of truth is the CLI version installed in `node_modules/typeclaw`, not the on-disk file. To pick up a Dockerfile template change, just run `typeclaw start` again.
+TypeClaw owns the `Dockerfile` and `.gitignore` for your agent folder and **rewrites them on every `start`**. This is deliberate — the source of truth is the CLI version installed in `node_modules/typeclaw`, not the on-disk file. To pick up a Dockerfile template change, just run `typeclaw start` again.
 
 `sessions/` and `memory/` are gitignored but force-committed by TypeClaw itself: `sessions/` via auto-backup, `memory/` via the dreaming subagent. The agent doesn't stage them by hand, but their history is preserved.
+
+## Legacy shapes
+
+If your `typeclaw.json` predates a schema change, TypeClaw auto-migrates on first load and commits the rewrite with a descriptive subject:
+
+- Top-level `dockerfile` → `docker.file`
+- Top-level `gitignore` → `git.ignore`
+- Top-level `model` → `models.default`
+- Per-adapter `channels.<adapter>.allow[]` → `roles.member.match[]`

--- a/docs/content/docs/cron.mdx
+++ b/docs/content/docs/cron.mdx
@@ -8,33 +8,45 @@ Cron jobs live in `cron.json` at your agent folder root:
 
 ```json
 {
+  "$schema": "./node_modules/typeclaw/cron.schema.json",
   "jobs": [
     {
-      "name": "morning-status",
+      "id": "morning-status",
       "schedule": "0 9 * * *",
       "kind": "prompt",
-      "prompt": "Summarize yesterday's commits and post to #standup"
+      "prompt": "Summarize yesterday's commits and post to #standup",
+      "scheduledByRole": "owner"
     },
     {
-      "name": "backup-db",
+      "id": "backup-db",
       "schedule": "0 3 * * *",
       "kind": "exec",
-      "exec": "/agent/scripts/backup.sh"
+      "command": ["/agent/scripts/backup.sh"],
+      "scheduledByRole": "owner"
     }
   ]
 }
 ```
 
-`reload` after editing — no restart needed.
+`typeclaw reload` after editing — no restart needed.
 
 ## Two kinds
 
-- **`prompt`** — fires a prompt into a fresh session. Use this when you want LLM reasoning.
-- **`exec`** — runs a shell command inside the container. Use this for deterministic side-effects.
+- **`prompt`** — fires a prompt into a fresh session. Use this when you want LLM reasoning. Optionally carries a `subagent` field to spawn a specific named subagent instead of a top-level agent session.
+- **`exec`** — runs a shell command inside the container. `command` is an **array of strings** (argv-style, not a shell string).
+
+Each job needs:
+
+- `id` — unique identifier, `[a-zA-Z0-9_-]+`
+- `schedule` — standard 5-field cron expression (no seconds)
+- `kind` — `"prompt"` or `"exec"`
+- `scheduledByRole` — the role the firing session runs as (see [Permissions](/docs/permissions))
+
+`scheduledByRole` is **required**. If you forget it on a hand-edited entry, TypeClaw auto-stamps `"owner"` on first load and commits the rewrite — this prevents the container from crash-looping on legacy files.
 
 ## Per-job coalescing
 
-If a job is still running when its next tick fires, the next tick is **dropped** for that specific job (and logged), not queued. This means a slow daily job can't pile up overnight into 24 backlogged runs.
+If a job is still running when its next tick fires, the next tick is **dropped** for that specific job (and logged), not queued. A slow daily job can't pile up overnight into 24 backlogged runs.
 
 The scheduler itself is a pure clock — it just emits "this job's time has come" events. The consumer (the part that actually runs the prompt or exec) owns the per-jobId in-flight set and decides whether to start a new run or skip.
 
@@ -48,12 +60,13 @@ When the job fires, the resulting session resolves to the **stamped role**, not 
 
 ```sh
 typeclaw cron list
+typeclaw cron list --json
 ```
 
 Shows every cron registered in the running agent — both your `cron.json` and any plugins that contribute jobs at boot.
 
 ## Limits
 
-- Cron triggers `prompt` and `exec` only — there's no third kind, and adding one requires extending the consumer.
-- Scheduling expressions use [`cron-parser`](https://github.com/harrisiirak/cron-parser) syntax (standard 5-field cron, no seconds field).
+- Cron triggers `prompt` and `exec` only — adding a third kind requires extending the consumer.
+- Scheduling expressions use [`cron-parser`](https://github.com/harrisiirak/cron-parser) syntax (standard 5-field cron, no seconds).
 - The scheduler ticks every second; sub-minute precision is not supported.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -47,6 +47,8 @@ The host stage owns nothing the agent owns. The container stage has no Docker ac
 
 - [Quickstart](/docs/quickstart) — running in under a minute
 - [Configuration](/docs/configuration) — what's in `typeclaw.json`
+- [Permissions](/docs/permissions) — roles, match rules, security bypass tiers
+- [Channels](/docs/channels) — wire Slack, Discord, GitHub, Telegram, KakaoTalk
 - [Plugins](/docs/plugins) — write your first plugin
-- [Channels](/docs/channels) — wire Slack, Discord, GitHub
 - [Memory](/docs/memory) — how the agent learns over time
+- [CLI Reference](/docs/cli) — every command and flag

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -4,11 +4,15 @@
     "quickstart",
     "configuration",
     "---",
-    "plugins",
+    "permissions",
     "channels",
     "memory",
     "secrets",
+    "---",
+    "plugins",
     "cron",
-    "tunnels"
+    "tunnels",
+    "---",
+    "cli"
   ]
 }

--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -1,0 +1,143 @@
+---
+title: Permissions
+description: Roles, match rules, and the two-axis security bypass policy
+icon: ShieldCheck
+---
+
+TypeClaw gates every privileged action through a per-actor permission service. **Roles** bundle permission strings and match rules. **Actors** are derived at runtime from the session origin — nothing about an actor is stored on disk. The first role whose `match[]` rules match wins; the fallback is the built-in `guest` role, which has no permissions.
+
+If your agent silently ignores all your Slack/Discord messages, it's almost always because no non-`owner` role's `match[]` covers the chats your authors live in. The router gates inbound messages on `channel.respond` BEFORE creating a session, and the default for unmatched origins is `guest`.
+
+## Built-in roles
+
+| Role      | Default `match[]`   | Default permissions                                                                                                                                                             |
+| --------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `owner`   | `[{ kind: 'tui' }]` | `channel.respond`, `cron.*`, `subagent.*`, `security.bypass.low`, `security.bypass.medium`, plus every plugin-contributed `security.bypass.<guard>` **except** high-tier guards |
+| `trusted` | `[]`                | `channel.respond`, `cron.schedule`, `subagent.*`, `security.bypass.low`                                                                                                         |
+| `member`  | `[]`                | `channel.respond`, `subagent.spawn`, `subagent.cancel`                                                                                                                          |
+| `guest`   | `[]` (fallback)     | (none)                                                                                                                                                                          |
+
+User-declared `match[]` **appends** to the built-in match list. User-declared `permissions[]` **replaces** the built-in list entirely — there is no merge. To restrict `owner` to only the TUI without any other authors, leave `roles.owner.match` empty.
+
+## Match-rule DSL
+
+Compact strings, parsed at config load. Examples:
+
+```
+tui                                  # any TUI session
+cron                                 # any cron-fired session
+subagent                             # any subagent
+subagent:memory-logger               # one specific subagent
+*                                    # any channel session, any platform
+slack:*                              # any Slack chat, any workspace
+slack:T0123                          # one Slack workspace
+slack:T0123/C0ABCDE                  # one specific Slack chat
+slack:T0123 author:U_ME              # one author in one workspace
+slack:dm/*                           # any Slack DM
+discord:9999                         # one Discord guild
+discord:9999 author:U_MOD            # one Discord author across a guild
+telegram:42                          # one Telegram chat id
+kakao:group/*                        # any KakaoTalk group chat
+```
+
+Within one rule, tokens are AND'd. Across multiple `match[]` entries on the same role they're OR'd.
+
+The parser rejects redundant or impossible forms (e.g. `slack:*/C0ABCDE` — wildcard workspace with specific chat) and gives precise typo errors (`autor:` → "Did you mean 'author:'?").
+
+## Declaring roles
+
+```json
+{
+  "roles": {
+    "owner": {
+      "match": ["slack:T0123 author:U_ME", "discord:9999 author:U_MOD"]
+    },
+    "member": {
+      "match": ["slack:T0123/C0GENERAL", "discord:9999/general"]
+    }
+  }
+}
+```
+
+`roles.match` is **live** (reloadable via `typeclaw reload`). `roles.permissions` is **restart-required** because plugin contexts and the security plugin capture the permissions contract at boot.
+
+## Claiming a role from a channel
+
+Hand-authoring `author:U_…` IDs is painful and error-prone. Use the claim flow instead:
+
+```sh
+typeclaw role claim --as owner --channel slack-bot
+```
+
+The agent prints a one-time code. DM that code to your bot from the account you want to pair. On match, the resulting `slack:<team> author:<user>` rule is appended to `roles.owner.match[]` automatically and the file is committed.
+
+`--ttl` controls how long the code stays valid (default `600000` ms = 10 minutes). Drop `--channel` to listen on every wired adapter at once.
+
+```sh
+typeclaw role list
+```
+
+shows the roles declared on this agent and what each one's `match[]` resolves to.
+
+## Security bypass tiers
+
+The bundled `security` plugin gates `tool.before` events on a **two-axis severity policy**. Each guard exports a tier (`low` / `medium` / `high`), and `tool.before` accepts EITHER the tier permission (`security.bypass.low|medium|high`) OR the per-guard permission (e.g. `security.bypass.secretExfilBash`).
+
+### `high` — audience-leak
+
+Bypass sends data to a third-party audience outside the operator's control loop. **No role auto-bypasses high.** Per-call ack required from every role, including `owner`. Reading `permissions: ['security.bypass.high']` into a custom role re-opens this; the default doesn't.
+
+Inhabitants:
+
+- `outboundSecret` — outbound channel message contains a secret-shaped string
+- `systemPromptLeak` — outbound message echoes the system prompt
+- `gitExfil` — `git push` to an unfamiliar remote
+- `gitRemoteTainted` — push after a same-session `git remote set-url`
+
+The canonical motivating case: an owner-permissioned operator asks the agent to "post deploy status to #general" — even with full permissions, the agent must not silently include a stack-trace `Bearer ghp_…` line.
+
+### `medium` — silent-attack
+
+Bypass produces attacker-favorable state in model context without immediate operator visibility. Inhabitants:
+
+- `secretExfilBash` — `bash env`, `bash printenv`, …
+- `secretExfilRead` — `read .env`, `read secrets.json`, …
+- `ssrf` — `curl http://169.254.169.254/...` (cloud IMDS)
+- `sessionSearchSecrets` — `session_search` query returning secret-shaped hits
+
+`owner` bypasses (operator already has equivalent host access via TUI). `trusted` does NOT — they get `bypass.low` only.
+
+### `low` — noisy, immediately recoverable
+
+Reserved tier. No inhabitants today. Exists so `trusted`'s `bypass.low` grant has a forward-compatible home when a future guard ships at low.
+
+### Re-opening a high-tier bypass for a role
+
+Add the per-guard string explicitly:
+
+```json
+{
+  "roles": {
+    "trusted": {
+      "permissions": ["channel.respond", "security.bypass.low", "security.bypass.gitExfil"]
+    }
+  }
+}
+```
+
+This is opt-in by design. The high-tier defaults are conservative; the operator who wants pre-PR-#255 ergonomics adds them by hand.
+
+## Provenance on cron and subagents
+
+Cron and subagent sessions don't resolve via match-rule walking — they carry **stamped provenance**:
+
+- **Cron**: `scheduledByRole` is required on every job. The firing session resolves as that role.
+- **Subagent**: `spawnedByRole` is the parent session's role at spawn time, snapshotted for the subagent's lifetime.
+
+This closes the laundering attack: a `guest`-resolving channel session that asks the agent to schedule a cron gets `scheduledByRole: 'guest'` stamped in `cron.json`. When the job fires, it still runs as `guest` — no privilege escalation through scheduling.
+
+## Common pitfalls
+
+- **Forgot to claim a role.** Run `typeclaw role claim --as owner`. Without a match, your messages resolve to `guest` and the router drops them.
+- **Built-in role with `match: []` but no `permissions[]` line.** That's fine — defaults apply. But declaring `"permissions": []` explicitly **wipes all permissions**, including the role's default `channel.respond`. There is no merge.
+- **Permission typos.** Boot-time warning lists every user-declared permission that doesn't match `CORE_PERMISSIONS ∪ <plugin permissions>`. Read the boot log.

--- a/docs/content/docs/plugins.mdx
+++ b/docs/content/docs/plugins.mdx
@@ -59,22 +59,32 @@ Then `typeclaw start` picks it up.
 
 The `factory(ctx)` callback receives a `PluginContext` with the live `permissions` service, the message stream, the agent's session store, the agent folder path, and a few other capabilities. Everything plugins talk to flows through this object — there are no module-global imports of agent state.
 
+Read the parsed config snapshot for your plugin via `ctx.config` (a frozen object matching your `configSchema`). Boot-only fields are snapshots; fields you declared as reloadable are re-parsed on `typeclaw reload`.
+
 ## Bundled plugins
 
-Three plugins ship with TypeClaw and load automatically:
+Nine plugins ship with TypeClaw and load automatically. You don't list them in `plugins[]`; they're always on.
 
-- **`memory`** — observes work, writes daily memory streams, distills them into `MEMORY.md` and muscle-memory skills on a cron schedule
-- **`security`** — gates `tool.before` events on a two-axis severity policy (audience-leak vs. silent-attack), with per-guard and tier-level bypass permissions
-- **`operator`** — exposes the `do-things` subagent that can write files and edit the workspace
+| Plugin            | What it does                                                                                                                     |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `security`        | Gates `tool.before` events on a two-axis severity policy (audience-leak vs. silent-attack); see [Permissions](/docs/permissions) |
+| `tool-result-cap` | Truncates oversized tool results so a single command can't blow the context window                                               |
+| `guard`           | Managed-file guards — blocks accidental overwrites of `typeclaw.json`, `cron.json`, and `MEMORY.md` outside the right subagent   |
+| `memory`          | Observes work, writes daily memory streams, distills them into `MEMORY.md` and muscle-memory skills on a cron schedule           |
+| `backup`          | Auto-commits `sessions/` and `memory/` on idle so growth is git-auditable                                                        |
+| `agent-browser`   | Headed Chrome under Xvfb for bot-resistant browsing; includes a dashboard proxy                                                  |
+| `explorer`        | Workspace exploration tools — file tree, glob, grep tuned for agent ergonomics                                                   |
+| `scout`           | Web-research subagent that scrapes and summarizes                                                                                |
+| `operator`        | Exposes the `operator` subagent — a focused worker that can write files and edit the workspace                                   |
 
-You don't list these in `plugins[]`; they're always on. Their config blocks (`memory.*`, etc.) live at the top level of `typeclaw.json` and are validated at boot.
+Their config blocks (e.g. `memory.*`, `agent-browser.*`) live at the top level of `typeclaw.json` and are validated at boot.
 
 ## Lifecycle
 
 Plugins are loaded once at container start. They can:
 
 - Mutate behavior at runtime via tool execution and stream subscriptions
-- Read live config via `ctx.config.getConfig()` (boot-only fields are snapshots; reloadable fields are live)
+- Read live config via `ctx.config` (boot-only fields are snapshots; reloadable fields are live)
 - Spawn subagents with provenance (the spawning role is stamped so security gates apply)
 
 Plugins **cannot** change which other plugins are loaded, or rewrite the Dockerfile, or escape the container. The trust boundary is the container, not the plugin.

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -22,7 +22,17 @@ mkdir my-agent && cd my-agent
 typeclaw init
 ```
 
-`init` writes `typeclaw.json`, `.env`, a `Dockerfile`, a `package.json` with `typeclaw` as a dependency, a managed `.gitignore`, and a few placeholder folders (`workspace/`, `sessions/`, `memory/`).
+`init` is an interactive wizard. It writes `typeclaw.json`, `.env`, a `Dockerfile`, a `package.json` with `typeclaw` as a dependency, a managed `.gitignore`, and a few placeholder folders (`workspace/`, `sessions/`, `memory/`). It can also wire your first LLM provider and first channel adapter during setup.
+
+## Pick a model
+
+```sh
+typeclaw provider add fireworks      # add an API key (or OAuth)
+typeclaw model set default fireworks/kimi-k2
+typeclaw model list --available      # all known provider/model refs
+```
+
+The `default` profile is required — every session that doesn't request a specific profile uses it. See [Configuration → `models`](/docs/configuration#models) for fallback chains and the `fast` / `deep` / `vision` profile conventions.
 
 ## Start the container
 
@@ -35,7 +45,8 @@ The first run builds the per-agent image; subsequent runs start in seconds. `sta
 ## Attach a TUI
 
 ```sh
-typeclaw tui
+typeclaw tui                          # interactive
+typeclaw tui "hello, who are you?"    # one-shot prompt
 ```
 
 You're talking to the agent. Send it a prompt, watch it think.
@@ -48,20 +59,43 @@ typeclaw channel add discord-bot
 typeclaw channel add github
 ```
 
-The agent picks up the new channel on the next reload — no restart needed.
+Channel config is hot-reloadable, so the agent picks it up on the next `typeclaw reload`. If the agent is running, the CLI may prompt you to apply immediately.
+
+KakaoTalk uses a separate re-auth flow (sub-device login + device_uuid; survives 7-day token expiry via host-side renewal):
+
+```sh
+typeclaw channel reauth kakaotalk
+```
+
+Rotating any other channel's credentials:
+
+```sh
+typeclaw channel set slack-bot
+```
+
+## Wire up a role
+
+Before the agent will respond in your Slack/Discord/etc. chats, it needs to know **who** can talk to it. Run the claim flow:
+
+```sh
+typeclaw role claim --as owner --channel slack-bot
+```
+
+The agent prints a one-time code. DM it to your bot from the account you want to pair, and your match rule is added to `roles.owner.match[]` automatically. See [Permissions](/docs/permissions) for the full role model.
 
 ## Add a cron
 
-Edit `cron.json` in your agent folder:
+Edit `cron.json` in your agent folder (see [Cron](/docs/cron) for the full schema):
 
 ```json
 {
   "jobs": [
     {
-      "name": "morning-status",
+      "id": "morning-status",
       "schedule": "0 9 * * *",
       "kind": "prompt",
-      "prompt": "Summarize yesterday's commits and post to #standup"
+      "prompt": "Summarize yesterday's commits and post to #standup",
+      "scheduledByRole": "owner"
     }
   ]
 }
@@ -79,14 +113,21 @@ The job is now live.
 
 ```sh
 typeclaw status          # container + daemon registration state
-typeclaw logs -f         # follow container stdout/stderr
+typeclaw logs            # container stdout/stderr (one-shot)
+typeclaw logs -f         # follow
 typeclaw cron list       # every cron registered in the running agent
+typeclaw role list       # roles declared on this agent
 typeclaw shell           # drop into a shell inside the container
+typeclaw usage           # token spend summary
+typeclaw doctor          # diagnose host, agent folder, and plugins
 ```
 
-## Stop
+See [CLI Reference](/docs/cli) for the full command surface.
+
+## Stop / restart
 
 ```sh
+typeclaw restart         # stop + start with the same flags
 typeclaw stop
 ```
 

--- a/docs/content/docs/tunnels.mdx
+++ b/docs/content/docs/tunnels.mdx
@@ -35,11 +35,12 @@ Both reduce to: give me a public URL that proxies to `127.0.0.1:<port>` inside t
 
 ## Providers
 
-| Provider           | Subprocess                     | URL                                             | When to use                                                         |
-| ------------------ | ------------------------------ | ----------------------------------------------- | ------------------------------------------------------------------- |
-| `cloudflare-quick` | `cloudflared tunnel --url ...` | Parsed from cloudflared stderr; rotates per run | Default — zero signup, fine for dev and most webhook use cases      |
-| `external`         | None                           | Static, from `externalUrl` in config            | You run your own reverse proxy (Caddy, ngrok, fly.io, etc.)         |
-| `cloudflare-named` | `cloudflared tunnel run <id>`  | Known from Cloudflare config (stable hostname)  | After `typeclaw tunnel upgrade` — requires Cloudflare account + DNS |
+| Provider           | URL                                             | When to use                                                    |
+| ------------------ | ----------------------------------------------- | -------------------------------------------------------------- |
+| `cloudflare-quick` | Parsed from cloudflared stderr; rotates per run | Default — zero signup, fine for dev and most webhook use cases |
+| `external`         | Static, from `externalUrl` in config            | You run your own reverse proxy (Caddy, ngrok, fly.io, etc.)    |
+
+Adding a `cloudflare-quick` tunnel automatically sets `docker.file.cloudflared: true` so the next `typeclaw start` rebuilds the image with the cloudflared binary.
 
 ## Channel-owned tunnels
 
@@ -52,11 +53,22 @@ No config mutation is involved. The rotating `trycloudflare.com` URL is runtime 
 `for: { kind: "manual" }` tunnels are owned by `typeclaw tunnel add` / `tunnel remove`. They're useful when you want to expose a dev server temporarily:
 
 ```sh
-typeclaw tunnel add my-demo --provider cloudflare-quick --port 5173
+typeclaw tunnel add my-demo \
+  --provider cloudflare-quick \
+  --for-manual \
+  --upstream-port 5173
+
+typeclaw tunnel list
 typeclaw tunnel status my-demo
 typeclaw tunnel logs my-demo
 typeclaw tunnel remove my-demo
 ```
+
+`--for-manual` flags the tunnel as user-owned (vs `--for-channel <name>` which scopes it to an adapter's webhook). `--upstream-port` is the container-local port the tunnel proxies to. If you omit either flag, the CLI prompts interactively.
+
+## Pointing a tunnel at a service with a proxy port
+
+Some services pair a host-facing compatibility proxy with a separate in-container server (the bundled `agent-browser` skill is the canonical example: it publishes both `/tmp/typeclaw-agent-browser-proxy-port` and `/tmp/typeclaw-agent-browser-upstream-port`). The tunnel's `upstreamPort` must name the **in-container server**, not the proxy. Tunneling the proxy port silently double-hops and looks like it works until something downstream times out.
 
 ## Auto port-forward vs. tunnels
 


### PR DESCRIPTION
## Why

The docs site had accumulated a class of bug that's hard to catch in review but breaks users immediately: field names, command flags, and provider lists that don't match the source they describe. A parallel four-agent audit cross-referenced every claim in `docs/content/docs/` against `src/cli/`, `src/config/config.ts`, `src/permissions/`, `src/cron/schema.ts`, `src/tunnels/types.ts`, and `src/run/bundled-plugins.ts`. Ten P0 bugs found; all fixed and verified in this PR.

## P0 fixes (would actively mislead or break users)

**cron.mdx** — Example used `name` and `exec` fields. The schema (`src/cron/schema.ts`) requires `id` and `command: string[]`. A user copy-pasting the example would hit `parseCronFile` validation failure at boot. Fixed the fields and added the now-required `scheduledByRole`.

**tunnels.mdx** — Documented a `cloudflare-named` provider and a `typeclaw tunnel upgrade` subcommand. Neither exists. `TunnelProvider` in `src/tunnels/types.ts` is strictly `'external' | 'cloudflare-quick'`; there is no upgrade path. Removed both. Also replaced the `--port` flag with the actual `--upstream-port` (`src/cli/tunnel.ts:70`) and added `--for-manual` so the example is non-interactive.

**configuration.mdx** — Said `typeclaw.schema.json` lives at the agent folder root. It is installed at `node_modules/typeclaw/typeclaw.schema.json` (`src/init/index.ts:545`). Also: the `docker.file` toggle table was missing `xvfb`, `claudeCode`, and `cloudflared`; and the page used the old `dockerfile.*` key shape rather than the auto-migrated `docker.file.*` shape.

**plugins.mdx** — Said "three plugins ship." `bundled-plugins.ts` registers nine: `security`, `tool-result-cap`, `guard`, `memory`, `backup`, `agent-browser`, `explorer`, `scout`, `operator`. Added a table with a one-line description for each. Corrected the operator subagent name (`operator`, not `do-things`) and fixed the plugin context API (`ctx.config` is a frozen property, not `ctx.config.getConfig()`).

**quickstart.mdx** — Said "no restart needed" after `channel add`. `FIELD_EFFECTS.channels` is `'applied'`, meaning it is hot-reloadable, but the CLI does prompt for restart when a container is running. Updated to reflect the actual behavior and added the first-run steps that were missing: provider add, model set, channel reauth flow for KakaoTalk.

**channels.mdx** — Never mentioned `typeclaw channel reauth kakaotalk`, which is the only way to rotate KakaoTalk credentials (the sub-device login requires interactive phone-passcode + `device_uuid` replay; `channel set` does not support it). Added the reauth flow and linked the new Permissions page for match-rule context.

## P1 additions

**permissions.mdx** (new, ~140 lines) — Roles and the match-rule DSL, the two-axis security bypass policy (high = audience-leak, never auto-bypassed; medium = silent-attack, owner-only), `typeclaw role claim` end-to-end with a before/after config example, and the silent-agent pitfall (no `channel.respond` = every inbound dropped silently).

**cli.mdx** (new, ~100 lines) — Every command that doesn't have its own dedicated page: lifecycle (`init`, `start`, `stop`, `restart`, `logs`), providers, models, roles, `compose`, `doctor` (with `--fix` safety note), and `usage` subcommands.

**configuration.mdx** expanded — `models` fallback chains, `network` block (`blockInternal`, `autoAllowResolvers`, `allow`), `git.ignore`, full `docker.file` toggle table, legacy-shape migration list.

**meta.json** — Reordered so Permissions sits next to Channels, where users will look for it.

**index.mdx** — Next Steps now links both Permissions and CLI Reference.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean (18 pre-existing warnings, 0 new errors)
- `bun run format:check` — clean
- `bun run test` — 4683 tests pass
- `bun run build` in `docs/` — all 11 pages render

## Known follow-ups (not in this PR)

- **CLI message vs. FIELD_EFFECTS mismatch**: `src/cli/channel.ts:1011` prints "Channel config is restart-required" but `FIELD_EFFECTS.channels` is `'applied'`. The doc now reflects the source truth; the CLI message should be updated in a separate PR.
- **P2 docs infra**: sitemap, robots, `llms.txt`, `editOnGitHub` link, `lastModified` plugin, MDX component wiring, accessibility contrast, OG image — deferred.
- **Future pages**: agent-browser.mdx, backup.mdx, subagents.mdx, port-forward/hostd.mdx.