### PR TITLE
inspect: replay session transcripts from JSONL

### DIFF
--- a/src/agent/session-meta.test.ts
+++ b/src/agent/session-meta.test.ts
@@ -40,7 +40,7 @@ describe('sessionMetaPayload (minimal projection)', () => {
     })
   })
 
-  test('channel origin keeps addressing ids, drops participants/membership/names', () => {
+  test('channel origin keeps addressing ids and workspace/chat names, drops participants/membership/authors', () => {
     const origin: SessionOrigin = {
       kind: 'channel',
       adapter: 'slack-bot',
@@ -57,10 +57,35 @@ describe('sessionMetaPayload (minimal projection)', () => {
         kind: 'channel',
         adapter: 'slack-bot',
         workspace: 'T0123',
+        workspaceName: 'Acme Corp',
         chat: 'C0ABC',
+        chatName: '#general',
         thread: '1234.567',
       },
     })
+  })
+
+  test('channel origin omits workspaceName/chatName fields when unset (does not write key:undefined)', () => {
+    const origin: SessionOrigin = {
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0123',
+      chat: 'C0ABC',
+      thread: null,
+    }
+    const out = sessionMetaPayload(origin)
+    expect(out).toEqual({
+      origin: {
+        kind: 'channel',
+        adapter: 'slack-bot',
+        workspace: 'T0123',
+        chat: 'C0ABC',
+        thread: null,
+      },
+    })
+    if (out.origin.kind !== 'channel') throw new Error('unreachable')
+    expect('workspaceName' in out.origin).toBe(false)
+    expect('chatName' in out.origin).toBe(false)
   })
 
   test('subagent origin keeps subagent name and parentSessionId, drops spawnedByOrigin', () => {
@@ -76,14 +101,14 @@ describe('sessionMetaPayload (minimal projection)', () => {
     })
   })
 
-  test('does not include any field that would leak workspace/user names to disk', () => {
+  test('does not include author handles or participants on disk', () => {
     const origin: SessionOrigin = {
       kind: 'channel',
       adapter: 'discord-bot',
       workspace: '9999',
-      workspaceName: 'Sensitive Org Name',
+      workspaceName: 'Acme Org',
       chat: '8888',
-      chatName: 'secret-channel',
+      chatName: 'general',
       thread: null,
       lastInboundAuthorId: 'U_SENSITIVE',
       participants: [
@@ -91,10 +116,10 @@ describe('sessionMetaPayload (minimal projection)', () => {
       ],
     }
     const stamped = JSON.stringify(sessionMetaPayload(origin))
-    expect(stamped).not.toContain('Sensitive Org Name')
-    expect(stamped).not.toContain('secret-channel')
     expect(stamped).not.toContain('Real Person Name')
     expect(stamped).not.toContain('U_SENSITIVE')
+    expect(stamped).not.toContain('"participants"')
+    expect(stamped).not.toContain('"lastInboundAuthorId"')
   })
 })
 

--- a/src/agent/session-meta.ts
+++ b/src/agent/session-meta.ts
@@ -9,12 +9,29 @@ export type SessionMetaPayload = {
 export type MinimalSessionOrigin =
   | { kind: 'tui' }
   | { kind: 'cron'; jobId: string; jobKind: 'prompt' | 'exec' | 'subagent' | 'handler' }
-  | { kind: 'channel'; adapter: string; workspace: string; chat: string; thread: string | null }
+  | {
+      kind: 'channel'
+      adapter: string
+      workspace: string
+      // Optional human-readable names persisted alongside IDs so offline
+      // tooling (`typeclaw inspect`, future report commands) can render
+      // sessions as `Slack acme-corp/#general` instead of bare IDs without
+      // re-querying the adapter at runtime. Workspace/chat NAMES are not
+      // secrets — they are visible to any participant — and they are
+      // stable across reopens, so the tradeoff is one-time write cost for
+      // permanent offline readability. Author handles, participant lists,
+      // and membership counts remain dropped (those carry author identity
+      // and would land in `sessions/`'s auto-backup git history).
+      workspaceName?: string
+      chat: string
+      chatName?: string
+      thread: string | null
+    }
   | { kind: 'subagent'; subagent: string; parentSessionId: string }
 
 // Reduce a full SessionOrigin to the minimum projection persisted to disk.
 // Drops participant lists, membership counts, recursive provenance, and
-// platform-rendered names — none of which `typeclaw usage` reads, and all of
+// author identifiers — none of which `typeclaw usage` reads, and all of
 // which would otherwise land in git history when sessions/ is auto-backed-up.
 // Kept as a separate function so the boundary between "data the LLM sees in
 // the system prompt" (full origin) and "data persisted for usage reporting"
@@ -34,7 +51,9 @@ function minimalOrigin(origin: SessionOrigin): MinimalSessionOrigin {
         kind: 'channel',
         adapter: origin.adapter,
         workspace: origin.workspace,
+        ...(origin.workspaceName !== undefined ? { workspaceName: origin.workspaceName } : {}),
         chat: origin.chat,
+        ...(origin.chatName !== undefined ? { chatName: origin.chatName } : {}),
         thread: origin.thread,
       }
     case 'subagent':

--- a/src/cli/builtins.ts
+++ b/src/cli/builtins.ts
@@ -12,6 +12,7 @@ export const BUILTIN_COMMAND_NAMES = [
   'status',
   'reload',
   'logs',
+  'inspect',
   'shell',
   'compose',
   'channel',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,7 @@ const main = defineCommand({
     status: () => import('./status').then((m) => m.statusCommand),
     reload: () => import('./reload').then((m) => m.reload),
     logs: () => import('./logs').then((m) => m.logsCommand),
+    inspect: () => import('./inspect').then((m) => m.inspectCommand),
     shell: () => import('./shell').then((m) => m.shellCommand),
     compose: () => import('./compose').then((m) => m.composeCommand),
     channel: () => import('./channel').then((m) => m.channelCommand),

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -1,0 +1,106 @@
+import { defineCommand } from 'citty'
+
+import { findAgentDir } from '@/init'
+import { runInspect, type SessionSummary } from '@/inspect'
+import { originLabel, shortSessionId } from '@/inspect/label'
+
+import { cancel, c, errorLine, isCancel } from './ui'
+
+export const inspectCommand = defineCommand({
+  meta: {
+    name: 'inspect',
+    description: 'replay a session transcript (host stage)',
+  },
+  args: {
+    session: {
+      type: 'positional',
+      description: 'session id or short prefix (omit to pick from a list)',
+      required: false,
+    },
+    filter: {
+      type: 'string',
+      description:
+        'category filter: comma-separated meta/user/assistant/tool/error/done; prefix with ! to exclude (e.g. tool,!assistant)',
+    },
+    since: {
+      type: 'string',
+      description: 'only events newer than this (forms: 30s, 5m, 1h, 7d)',
+    },
+    json: {
+      type: 'boolean',
+      description: 'emit one JSON event per line; requires an explicit session id',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+    const color = useColor()
+    const sessionArg = typeof args.session === 'string' ? args.session : undefined
+    const filterArg = typeof args.filter === 'string' ? args.filter : undefined
+    const sinceArg = typeof args.since === 'string' ? args.since : undefined
+
+    const result = await runInspect({
+      agentDir: cwd,
+      ...(sessionArg !== undefined ? { sessionIdOrPrefix: sessionArg } : {}),
+      ...(filterArg !== undefined ? { filter: filterArg } : {}),
+      ...(sinceArg !== undefined ? { since: sinceArg } : {}),
+      json: args.json === true,
+      color,
+      selectSession: clackSelect,
+      stdout: (line) => process.stdout.write(`${line}\n`),
+      stderr: (line) => process.stderr.write(`${line}\n`),
+    })
+
+    if (!result.ok) {
+      process.stderr.write(`${errorLine(result.reason)}\n`)
+      process.exit(result.exitCode)
+    }
+    process.exit(result.exitCode)
+  },
+})
+
+function useColor(): boolean {
+  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') return false
+  if (process.env.FORCE_COLOR === '0') return false
+  if (process.env.FORCE_COLOR) return true
+  return Boolean(process.stdout.isTTY)
+}
+
+async function clackSelect(sessions: SessionSummary[]): Promise<SessionSummary | null> {
+  const { select } = await import('@clack/prompts')
+  const picked = await select<string>({
+    message: `Pick a session to inspect (showing ${sessions.length})`,
+    options: sessions.map((s) => ({
+      value: s.sessionId,
+      label: formatRowLabel(s),
+      ...(s.firstPrompt !== null ? { hint: truncate(s.firstPrompt, 60) } : { hint: '(no prompt)' }),
+    })),
+    initialValue: sessions[0]?.sessionId,
+  })
+  if (isCancel(picked)) {
+    cancel('Cancelled.')
+    return null
+  }
+  return sessions.find((s) => s.sessionId === picked) ?? null
+}
+
+function formatRowLabel(s: SessionSummary): string {
+  const id = shortSessionId(s.sessionId)
+  const label = s.origin === null ? '(unknown origin)' : originLabel(s.origin)
+  const when = formatRelative(s.mtimeMs)
+  return `${c.cyan(id)}  ${label}  ${c.dim(when)}`
+}
+
+function formatRelative(ms: number): string {
+  const diff = Date.now() - ms
+  if (diff < 60_000) return 'just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  return `${Math.floor(diff / 86_400_000)}d ago`
+}
+
+function truncate(text: string, max: number): string {
+  const oneline = text.replace(/\s+/g, ' ').trim()
+  if (oneline.length <= max) return oneline
+  return `${oneline.slice(0, max)}…`
+}

--- a/src/inspect/index.test.ts
+++ b/src/inspect/index.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { runInspect } from './index'
+import type { SessionSummary } from './session-list'
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-inspect-run-'))
+  await mkdir(join(agentDir, 'sessions'), { recursive: true })
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+async function seedSession(basename: string, lines: string[], mtimeSeconds: number): Promise<void> {
+  const path = join(agentDir, 'sessions', basename)
+  await writeFile(path, lines.join('\n') + '\n')
+  await utimes(path, mtimeSeconds, mtimeSeconds)
+}
+
+function metaLine(origin: unknown): string {
+  return JSON.stringify({
+    type: 'custom',
+    customType: 'typeclaw.session-meta',
+    data: { origin },
+    timestamp: 1_000_000,
+  })
+}
+
+function userLine(text: string, timestamp = 1_000_001): string {
+  return JSON.stringify({ type: 'message', message: { role: 'user', content: text, timestamp } })
+}
+
+function assistantLine(text: string, timestamp = 1_000_002): string {
+  return JSON.stringify({
+    type: 'message',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text }],
+      provider: 'fake',
+      model: 'fake-model',
+      stopReason: 'end_turn',
+      usage: { input: 5, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 10, cost: { total: 0.0001 } },
+      timestamp,
+    },
+  })
+}
+
+function captureSink(): { out: string[]; err: string[]; push: { stdout: (l: string) => void; stderr: (l: string) => void } } {
+  const out: string[] = []
+  const err: string[] = []
+  return {
+    out,
+    err,
+    push: {
+      stdout: (l) => out.push(l),
+      stderr: (l) => err.push(l),
+    },
+  }
+}
+
+const neverPick = async (_: SessionSummary[]): Promise<SessionSummary | null> => null
+
+describe('runInspect — direct session id (replay-then-exit)', () => {
+  test('replays meta, user, assistant, done in order; returns ok', async () => {
+    await seedSession(
+      '2026-05-22T00-00-00-000Z_ses_abc.jsonl',
+      [metaLine({ kind: 'tui' }), userLine('hi'), assistantLine('hello')],
+      1000,
+    )
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: 'ses_abc',
+      color: false,
+      selectSession: neverPick,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    const stripTime = (l: string) => l.replace(/\d{2}:\d{2}:\d{2}/, 'HH:MM:SS')
+    const cats = sink.out.slice(1, -1).map((l) => stripTime(l).split('  ')[1]?.trim())
+    expect(cats).toEqual(['meta', 'user', 'assist', 'done'])
+    expect(sink.out[0]!).toContain('ses_abc')
+    expect(sink.out[0]!).toContain('TUI')
+    expect(sink.out.at(-1)!).toContain('end of transcript')
+  })
+
+  test('--json emits one event per line and omits the header/footer', async () => {
+    await seedSession(
+      'a_ses_jsonout.jsonl',
+      [metaLine({ kind: 'tui' }), userLine('hi')],
+      1000,
+    )
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: 'ses_jsonout',
+      json: true,
+      color: false,
+      selectSession: neverPick,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(true)
+    expect(sink.out.every((l) => l.startsWith('{'))).toBe(true)
+    for (const line of sink.out) {
+      const parsed = JSON.parse(line)
+      expect(parsed.sessionId).toBe('ses_jsonout')
+      expect(typeof parsed.cat).toBe('string')
+    }
+  })
+
+  test('filter narrows which events render', async () => {
+    await seedSession(
+      'a_ses_filt.jsonl',
+      [metaLine({ kind: 'tui' }), userLine('a'), userLine('b'), assistantLine('hello')],
+      1000,
+    )
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: 'ses_filt',
+      filter: 'user',
+      color: false,
+      selectSession: neverPick,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(true)
+    const events = sink.out.slice(1, -1)
+    expect(events).toHaveLength(2)
+    for (const ev of events) expect(ev).toMatch(/user\s+/)
+  })
+
+  test('--since filters out older events by their timestamp', async () => {
+    await seedSession(
+      'a_ses_since.jsonl',
+      [
+        metaLine({ kind: 'tui' }),
+        userLine('old', Date.now() - 86_400_000),
+        userLine('new', Date.now()),
+      ],
+      1000,
+    )
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: 'ses_since',
+      since: '1h',
+      color: false,
+      selectSession: neverPick,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(true)
+    const events = sink.out.slice(1, -1)
+    const userBodies = events.filter((l) => l.includes('user')).map((l) => l.trim())
+    expect(userBodies.length).toBe(1)
+    expect(userBodies[0]!.endsWith('new')).toBe(true)
+  })
+
+  test('invalid filter spec returns exit 2 with a precise reason', async () => {
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: 'ses_does_not_matter',
+      filter: 'wat',
+      color: false,
+      selectSession: neverPick,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.exitCode).toBe(2)
+    expect(result.reason).toContain('"wat"')
+  })
+
+  test('invalid duration spec returns exit 2', async () => {
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: 'ses_x',
+      since: 'forever',
+      color: false,
+      selectSession: neverPick,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.exitCode).toBe(2)
+  })
+
+  test('session not found returns exit 1', async () => {
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: 'ses_ghost',
+      color: false,
+      selectSession: neverPick,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.exitCode).toBe(1)
+    expect(result.reason).toContain('ses_ghost')
+  })
+
+  test('ambiguous prefix returns exit 2 with all matches listed', async () => {
+    await seedSession('a_ses_abcd111.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    await seedSession('b_ses_abcd222.jsonl', [metaLine({ kind: 'tui' })], 2000)
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: 'ses_abcd',
+      color: false,
+      selectSession: neverPick,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.exitCode).toBe(2)
+    expect(result.reason).toContain('ses_abcd111')
+    expect(result.reason).toContain('ses_abcd222')
+  })
+})
+
+describe('runInspect — picker path', () => {
+  test('empty sessions dir returns exit 1 with a remediation hint', async () => {
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      color: false,
+      selectSession: neverPick,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.exitCode).toBe(1)
+    expect(result.reason).toContain('No sessions found')
+    expect(result.reason).toContain('typeclaw tui')
+  })
+
+  test('passes session summaries to selectSession and replays the picked one', async () => {
+    await seedSession('a_ses_pick1.jsonl', [metaLine({ kind: 'tui' }), userLine('first')], 1000)
+    await seedSession('b_ses_pick2.jsonl', [metaLine({ kind: 'tui' }), userLine('second')], 2000)
+    let offered: SessionSummary[] = []
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      color: false,
+      selectSession: async (sessions) => {
+        offered = sessions
+        return sessions.find((s) => s.sessionId === 'ses_pick1') ?? null
+      },
+      ...sink.push,
+    })
+    expect(result.ok).toBe(true)
+    expect(offered.map((s) => s.sessionId).sort()).toEqual(['ses_pick1', 'ses_pick2'])
+    expect(sink.out[0]!).toContain('ses_pick1')
+  })
+
+  test('cancelled picker returns exit 130 (Ctrl-C convention)', async () => {
+    await seedSession('a_ses_x.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      color: false,
+      selectSession: async () => null,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.exitCode).toBe(130)
+  })
+
+  test('--json without session id is rejected', async () => {
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      json: true,
+      color: false,
+      selectSession: neverPick,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.exitCode).toBe(2)
+    expect(result.reason).toContain('--json requires an explicit session id')
+  })
+})

--- a/src/inspect/index.test.ts
+++ b/src/inspect/index.test.ts
@@ -51,7 +51,11 @@ function assistantLine(text: string, timestamp = 1_000_002): string {
   })
 }
 
-function captureSink(): { out: string[]; err: string[]; push: { stdout: (l: string) => void; stderr: (l: string) => void } } {
+function captureSink(): {
+  out: string[]
+  err: string[]
+  push: { stdout: (l: string) => void; stderr: (l: string) => void }
+} {
   const out: string[] = []
   const err: string[] = []
   return {
@@ -92,11 +96,7 @@ describe('runInspect — direct session id (replay-then-exit)', () => {
   })
 
   test('--json emits one event per line and omits the header/footer', async () => {
-    await seedSession(
-      'a_ses_jsonout.jsonl',
-      [metaLine({ kind: 'tui' }), userLine('hi')],
-      1000,
-    )
+    await seedSession('a_ses_jsonout.jsonl', [metaLine({ kind: 'tui' }), userLine('hi')], 1000)
     const sink = captureSink()
     const result = await runInspect({
       agentDir,
@@ -139,11 +139,7 @@ describe('runInspect — direct session id (replay-then-exit)', () => {
   test('--since filters out older events by their timestamp', async () => {
     await seedSession(
       'a_ses_since.jsonl',
-      [
-        metaLine({ kind: 'tui' }),
-        userLine('old', Date.now() - 86_400_000),
-        userLine('new', Date.now()),
-      ],
+      [metaLine({ kind: 'tui' }), userLine('old', Date.now() - 86_400_000), userLine('new', Date.now())],
       1000,
     )
     const sink = captureSink()

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -1,8 +1,8 @@
 import { join } from 'node:path'
 
 import { originLabel, shortSessionId } from './label'
-import { replayJsonl } from './replay'
 import { renderEvent } from './render'
+import { replayJsonl } from './replay'
 import type { SessionSummary } from './session-list'
 import { listSessions, resolveSession } from './session-list'
 import { matchesFilter, parseDuration, parseFilter } from './types'

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -1,0 +1,158 @@
+import { join } from 'node:path'
+
+import { originLabel, shortSessionId } from './label'
+import { replayJsonl } from './replay'
+import { renderEvent } from './render'
+import type { SessionSummary } from './session-list'
+import { listSessions, resolveSession } from './session-list'
+import { matchesFilter, parseDuration, parseFilter } from './types'
+import type { InspectFilter } from './types'
+
+export { listSessions, resolveSession } from './session-list'
+export type { SessionSummary } from './session-list'
+export { originLabel, shortSessionId } from './label'
+export { renderEvent } from './render'
+export { replayJsonl } from './replay'
+export { parseDuration, parseFilter } from './types'
+export type { InspectCategory, InspectEvent, InspectFilter } from './types'
+
+export type RunInspectOptions = {
+  agentDir: string
+  sessionIdOrPrefix?: string
+  filter?: string
+  since?: string
+  json?: boolean
+  color: boolean
+  selectSession: SelectSession
+  stdout: (line: string) => void
+  stderr: (line: string) => void
+}
+
+export type SelectSession = (sessions: SessionSummary[]) => Promise<SessionSummary | null>
+
+export type RunInspectResult = { ok: true; exitCode: 0 } | { ok: false; exitCode: number; reason: string }
+
+export async function runInspect(opts: RunInspectOptions): Promise<RunInspectResult> {
+  const filterResult = parseFilter(opts.filter)
+  if (!filterResult.ok) return { ok: false, exitCode: 2, reason: filterResult.reason }
+  const filter = filterResult.filter
+
+  let sinceMs: number | undefined
+  if (opts.since !== undefined) {
+    const d = parseDuration(opts.since)
+    if (!d.ok) return { ok: false, exitCode: 2, reason: d.reason }
+    sinceMs = Date.now() - d.ms
+  }
+
+  const sessionsDir = join(opts.agentDir, 'sessions')
+
+  const summary = await chooseSession(opts, sessionsDir, sinceMs)
+  if (!summary.ok) return summary
+
+  await streamSession({
+    summary: summary.summary,
+    filter,
+    sinceMs,
+    json: opts.json === true,
+    color: opts.color,
+    stdout: opts.stdout,
+    stderr: opts.stderr,
+  })
+  return { ok: true, exitCode: 0 }
+}
+
+async function chooseSession(
+  opts: RunInspectOptions,
+  sessionsDir: string,
+  sinceMs: number | undefined,
+): Promise<{ ok: true; summary: SessionSummary } | { ok: false; exitCode: number; reason: string }> {
+  if (opts.sessionIdOrPrefix !== undefined) {
+    if (opts.json === true && !looksLikeSessionId(opts.sessionIdOrPrefix)) {
+      return {
+        ok: false,
+        exitCode: 2,
+        reason: `--json requires an explicit session id (got "${opts.sessionIdOrPrefix}")`,
+      }
+    }
+    const resolved = await resolveSession(sessionsDir, opts.sessionIdOrPrefix, opts.stderr)
+    if (resolved.ok) return { ok: true, summary: resolved.summary }
+    if (resolved.reason === 'ambiguous') {
+      const lines = ['Ambiguous session prefix matches multiple sessions:']
+      for (const m of resolved.matches) {
+        lines.push(`  ${m.sessionId}  ${m.origin === null ? '(unknown origin)' : originLabel(m.origin)}`)
+      }
+      lines.push('Use the full id or run `typeclaw inspect` without args.')
+      return { ok: false, exitCode: 2, reason: lines.join('\n') }
+    }
+    return { ok: false, exitCode: 1, reason: `No session matching "${opts.sessionIdOrPrefix}" in ${sessionsDir}/` }
+  }
+
+  if (opts.json === true) {
+    return { ok: false, exitCode: 2, reason: '--json requires an explicit session id (interactive picker is disabled)' }
+  }
+
+  const listOpts: Parameters<typeof listSessions>[0] = {
+    sessionsDir,
+    limit: 20,
+    onWarn: opts.stderr,
+  }
+  if (sinceMs !== undefined) listOpts.sinceMs = sinceMs
+  const sessions = await listSessions(listOpts)
+  if (sessions.length === 0) {
+    return {
+      ok: false,
+      exitCode: 1,
+      reason: `No sessions found in ${sessionsDir}/.\nStart a session with \`typeclaw tui\` or send a message from a configured channel.`,
+    }
+  }
+  const picked = await opts.selectSession(sessions)
+  if (picked === null) return { ok: false, exitCode: 130, reason: 'cancelled' }
+  return { ok: true, summary: picked }
+}
+
+async function streamSession(opts: {
+  summary: SessionSummary
+  filter: InspectFilter
+  sinceMs: number | undefined
+  json: boolean
+  color: boolean
+  stdout: (line: string) => void
+  stderr: (line: string) => void
+}): Promise<void> {
+  if (!opts.json) writeHeader(opts.summary, opts.color, opts.stdout)
+  for await (const event of replayJsonl(opts.summary.sessionFile, { onWarn: opts.stderr })) {
+    if (opts.sinceMs !== undefined && event.ts > 0 && event.ts < opts.sinceMs) continue
+    if (!matchesFilter(event, opts.filter)) continue
+    if (opts.json) {
+      opts.stdout(JSON.stringify({ sessionId: opts.summary.sessionId, ...event }))
+    } else {
+      opts.stdout(renderEvent(event, { color: opts.color }))
+    }
+  }
+  if (!opts.json) opts.stdout('─── end of transcript ───')
+}
+
+function writeHeader(summary: SessionSummary, color: boolean, stdout: (line: string) => void): void {
+  const id = shortSessionId(summary.sessionId)
+  const label = summary.origin === null ? '(unknown origin)' : originLabel(summary.origin)
+  const started = formatDate(summary.mtimeMs)
+  const headerLine = `─── ${id} · ${label} · last activity ${started} ───`
+  if (color) stdout(`\u001b[2m${headerLine}\u001b[0m`)
+  else stdout(headerLine)
+}
+
+function formatDate(ms: number): string {
+  if (ms === 0) return '--'
+  const d = new Date(ms)
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mi = String(d.getMinutes()).padStart(2, '0')
+  const ss = String(d.getSeconds()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi}:${ss}`
+}
+
+function looksLikeSessionId(value: string): boolean {
+  return value.startsWith('ses_')
+}

--- a/src/inspect/label.test.ts
+++ b/src/inspect/label.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test'
+
+import { originLabel, shortSessionId } from './label'
+
+describe('originLabel', () => {
+  test('TUI origin → "TUI"', () => {
+    expect(originLabel({ kind: 'tui' })).toBe('TUI')
+  })
+
+  test('cron origin includes jobId and jobKind', () => {
+    expect(originLabel({ kind: 'cron', jobId: 'daily-backup', jobKind: 'prompt' })).toBe('Cron daily-backup (prompt)')
+  })
+
+  test('subagent origin includes name and shortened parent id', () => {
+    expect(originLabel({ kind: 'subagent', subagent: 'memory-logger', parentSessionId: 'ses_abcdef1234567890' })).toBe(
+      'Subagent memory-logger ← ses_abcdef12',
+    )
+  })
+
+  test('channel origin with names renders pretty platform/workspace/channel', () => {
+    expect(
+      originLabel({
+        kind: 'channel',
+        adapter: 'slack-bot',
+        workspace: 'T0123',
+        workspaceName: 'Acme',
+        chat: 'C0ABC',
+        chatName: 'general',
+        thread: null,
+      }),
+    ).toBe('Slack Acme/#general')
+  })
+
+  test('channel origin with discord adapter prefixes chat with # for chat names', () => {
+    expect(
+      originLabel({
+        kind: 'channel',
+        adapter: 'discord-bot',
+        workspace: '9999',
+        workspaceName: 'My Server',
+        chat: '8888',
+        chatName: 'dev-help',
+        thread: null,
+      }),
+    ).toBe('Discord My Server/#dev-help')
+  })
+
+  test('channel origin without chat prefix adapters renders bare chat name (telegram)', () => {
+    expect(
+      originLabel({
+        kind: 'channel',
+        adapter: 'telegram-bot',
+        workspace: 'tg-ws',
+        workspaceName: 'My TG',
+        chat: '42',
+        chatName: 'Family',
+        thread: null,
+      }),
+    ).toBe('Telegram My TG/Family')
+  })
+
+  test('channel origin without names falls back to bare IDs (legacy session files)', () => {
+    expect(
+      originLabel({
+        kind: 'channel',
+        adapter: 'slack-bot',
+        workspace: 'T0123',
+        chat: 'C0ABC',
+        thread: null,
+      }),
+    ).toBe('Slack T0123/C0ABC')
+  })
+
+  test('channel origin with unknown adapter renders adapter id verbatim', () => {
+    expect(
+      originLabel({
+        kind: 'channel',
+        adapter: 'unknown-adapter',
+        workspace: 'w',
+        chat: 'c',
+        thread: null,
+      }),
+    ).toBe('unknown-adapter w/c')
+  })
+})
+
+describe('shortSessionId', () => {
+  test('short ids pass through unchanged', () => {
+    expect(shortSessionId('ses_abc')).toBe('ses_abc')
+  })
+
+  test('long ids truncate to 12 chars (no ellipsis — tabular output)', () => {
+    expect(shortSessionId('ses_abcdef1234567890')).toBe('ses_abcdef12')
+  })
+})

--- a/src/inspect/label.ts
+++ b/src/inspect/label.ts
@@ -1,0 +1,50 @@
+import type { MinimalSessionOrigin } from '@/agent/session-meta'
+
+const ADAPTER_DISPLAY: Record<string, string> = {
+  'slack-bot': 'Slack',
+  'discord-bot': 'Discord',
+  github: 'GitHub',
+  'telegram-bot': 'Telegram',
+  kakaotalk: 'KakaoTalk',
+}
+
+const SLACK_CHAT_PREFIX_ADAPTERS = new Set(['slack-bot', 'discord-bot'])
+
+export function originLabel(origin: MinimalSessionOrigin): string {
+  switch (origin.kind) {
+    case 'tui':
+      return 'TUI'
+    case 'cron':
+      return `Cron ${origin.jobId} (${origin.jobKind})`
+    case 'subagent':
+      return `Subagent ${origin.subagent} ← ${shortSessionId(origin.parentSessionId)}`
+    case 'channel':
+      return channelLabel(origin)
+  }
+}
+
+function channelLabel(origin: Extract<MinimalSessionOrigin, { kind: 'channel' }>): string {
+  const platform = ADAPTER_DISPLAY[origin.adapter] ?? origin.adapter
+  const chatPart = renderChat(origin)
+  const wsPart = renderWorkspace(origin)
+  if (wsPart === '') return `${platform} ${chatPart}`
+  return `${platform} ${wsPart}/${chatPart}`
+}
+
+function renderChat(origin: Extract<MinimalSessionOrigin, { kind: 'channel' }>): string {
+  if (origin.chatName !== undefined && origin.chatName !== '') {
+    const prefix = SLACK_CHAT_PREFIX_ADAPTERS.has(origin.adapter) ? '#' : ''
+    return `${prefix}${origin.chatName}`
+  }
+  return origin.chat
+}
+
+function renderWorkspace(origin: Extract<MinimalSessionOrigin, { kind: 'channel' }>): string {
+  if (origin.workspaceName !== undefined && origin.workspaceName !== '') return origin.workspaceName
+  return origin.workspace
+}
+
+export function shortSessionId(sessionId: string): string {
+  if (sessionId.length <= 12) return sessionId
+  return sessionId.slice(0, 12)
+}

--- a/src/inspect/render.test.ts
+++ b/src/inspect/render.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'bun:test'
+
+import { renderEvent } from './render'
+import type { InspectEvent } from './types'
+
+const PLAIN = { color: false }
+
+function stripTime(line: string): string {
+  return line.replace(/^\d{2}:\d{2}:\d{2}/, 'HH:MM:SS')
+}
+
+describe('renderEvent (plain, no color)', () => {
+  test('meta event prints origin label', () => {
+    const ev: InspectEvent = { cat: 'meta', ts: dateMs('15:08:42'), origin: { kind: 'tui' } }
+    const out = renderEvent(ev, PLAIN)
+    expect(stripTime(out)).toBe('HH:MM:SS  meta       origin: TUI')
+  })
+
+  test('user event prints single-line text', () => {
+    const ev: InspectEvent = { cat: 'user', ts: dateMs('15:08:42'), text: 'fix the\n  type error' }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  user       fix the type error')
+  })
+
+  test('tool start prints name and compact args', () => {
+    const ev: InspectEvent = {
+      cat: 'tool',
+      ts: dateMs('15:08:43'),
+      phase: 'start',
+      toolCallId: 'c1',
+      name: 'read',
+      args: { path: 'src/auth.ts' },
+    }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  tool ▸     read({"path":"src/auth.ts"})')
+  })
+
+  test('tool end prints name, ok status, and human duration', () => {
+    const ev: InspectEvent = {
+      cat: 'tool',
+      ts: dateMs('15:08:44'),
+      phase: 'end',
+      toolCallId: 'c1',
+      name: 'read',
+      result: 'file contents here',
+      isError: false,
+      durationMs: 1234,
+    }
+    const out = stripTime(renderEvent(ev, PLAIN))
+    expect(out).toBe('HH:MM:SS  tool ◂     read → ok "file contents here" (1.2s)')
+  })
+
+  test('tool end with isError uses error status', () => {
+    const ev: InspectEvent = {
+      cat: 'tool',
+      ts: dateMs('15:08:44'),
+      phase: 'end',
+      toolCallId: 'c1',
+      name: 'bash',
+      isError: true,
+      durationMs: 12,
+    }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  tool ◂     bash → error (12ms)')
+  })
+
+  test('done event shows tokens and cost when present', () => {
+    const ev: InspectEvent = {
+      cat: 'done',
+      ts: dateMs('15:08:45'),
+      stopReason: 'end_turn',
+      input: 100,
+      output: 50,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 150,
+      cost: 0.0123,
+    }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  done       tokens: 100 in / 50 out · $0.0123 · stop=end_turn')
+  })
+
+  test('error event prints the error message', () => {
+    const ev: InspectEvent = { cat: 'error', ts: dateMs('15:08:46'), message: 'provider returned 503' }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  error      provider returned 503')
+  })
+
+  test('long text is truncated with an ellipsis', () => {
+    const ev: InspectEvent = { cat: 'user', ts: dateMs('15:08:42'), text: 'a'.repeat(500) }
+    const out = renderEvent(ev, { color: false, maxTextLength: 30 })
+    expect(out).toContain('…')
+    expect(stripTime(out)).toBe(`HH:MM:SS  user       ${'a'.repeat(30)}…`)
+  })
+
+  test('time anchor of 0 renders as placeholder (legacy entries without timestamp)', () => {
+    const ev: InspectEvent = { cat: 'meta', ts: 0, origin: { kind: 'tui' } }
+    expect(renderEvent(ev, PLAIN).startsWith('--:--:--')).toBe(true)
+  })
+})
+
+describe('renderEvent (with color)', () => {
+  test('emits ANSI codes when color enabled', () => {
+    const ev: InspectEvent = { cat: 'user', ts: dateMs('15:08:42'), text: 'hi' }
+    const out = renderEvent(ev, { color: true })
+    expect(out).toMatch(/\u001b\[/)
+  })
+
+  test('plain mode emits zero ANSI codes', () => {
+    const ev: InspectEvent = { cat: 'user', ts: dateMs('15:08:42'), text: 'hi' }
+    const out = renderEvent(ev, { color: false })
+    expect(out).not.toMatch(/\u001b\[/)
+  })
+})
+
+function dateMs(hhmmss: string): number {
+  const [h, m, s] = hhmmss.split(':').map(Number) as [number, number, number]
+  const d = new Date()
+  d.setHours(h, m, s, 0)
+  return d.getTime()
+}

--- a/src/inspect/render.test.ts
+++ b/src/inspect/render.test.ts
@@ -73,7 +73,9 @@ describe('renderEvent (plain, no color)', () => {
       totalTokens: 150,
       cost: 0.0123,
     }
-    expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  done       tokens: 100 in / 50 out · $0.0123 · stop=end_turn')
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe(
+      'HH:MM:SS  done       tokens: 100 in / 50 out · $0.0123 · stop=end_turn',
+    )
   })
 
   test('error event prints the error message', () => {
@@ -95,16 +97,18 @@ describe('renderEvent (plain, no color)', () => {
 })
 
 describe('renderEvent (with color)', () => {
+  const ANSI_ESC = String.fromCharCode(0x1b)
+
   test('emits ANSI codes when color enabled', () => {
     const ev: InspectEvent = { cat: 'user', ts: dateMs('15:08:42'), text: 'hi' }
     const out = renderEvent(ev, { color: true })
-    expect(out).toMatch(/\u001b\[/)
+    expect(out.includes(ANSI_ESC)).toBe(true)
   })
 
   test('plain mode emits zero ANSI codes', () => {
     const ev: InspectEvent = { cat: 'user', ts: dateMs('15:08:42'), text: 'hi' }
     const out = renderEvent(ev, { color: false })
-    expect(out).not.toMatch(/\u001b\[/)
+    expect(out.includes(ANSI_ESC)).toBe(false)
   })
 })
 

--- a/src/inspect/render.ts
+++ b/src/inspect/render.ts
@@ -1,0 +1,140 @@
+import { styleText } from 'node:util'
+
+import { originLabel } from './label'
+import type { InspectEvent } from './types'
+
+export type RenderOptions = {
+  color: boolean
+  maxTextLength?: number
+}
+
+export function renderEvent(event: InspectEvent, opts: RenderOptions): string {
+  const time = renderTime(event.ts, opts)
+  const tag = renderTag(event, opts)
+  const body = renderBody(event, opts)
+  return `${time}  ${tag}  ${body}`
+}
+
+const DEFAULT_MAX_TEXT = 200
+
+function renderTime(ts: number, opts: RenderOptions): string {
+  if (ts === 0) return tint(opts, 'dim', '--:--:--')
+  const d = new Date(ts)
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  const ss = String(d.getSeconds()).padStart(2, '0')
+  return tint(opts, 'dim', `${hh}:${mm}:${ss}`)
+}
+
+function renderTag(event: InspectEvent, opts: RenderOptions): string {
+  switch (event.cat) {
+    case 'meta':
+      return tint(opts, 'magenta', padEnd('meta', 9))
+    case 'user':
+      return tint(opts, 'cyan', padEnd('user', 9))
+    case 'assistant':
+      return tint(opts, 'green', padEnd('assist', 9))
+    case 'tool':
+      return tint(opts, 'yellow', padEnd(event.phase === 'start' ? 'tool ▸' : 'tool ◂', 9))
+    case 'error':
+      return tint(opts, 'red', padEnd('error', 9))
+    case 'done':
+      return tint(opts, 'gray', padEnd('done', 9))
+  }
+}
+
+function renderBody(event: InspectEvent, opts: RenderOptions): string {
+  switch (event.cat) {
+    case 'meta':
+      return `origin: ${originLabel(event.origin)}`
+    case 'user':
+      return truncate(singleLine(event.text), opts.maxTextLength ?? DEFAULT_MAX_TEXT)
+    case 'assistant':
+      return truncate(singleLine(event.text), opts.maxTextLength ?? DEFAULT_MAX_TEXT)
+    case 'tool': {
+      if (event.phase === 'start') {
+        return `${event.name}(${renderArgs(event.args)})`
+      }
+      const dur = formatDuration(event.durationMs ?? 0)
+      const status = event.isError ? tint(opts, 'red', 'error') : 'ok'
+      const result = renderResult(event.result, opts.maxTextLength ?? DEFAULT_MAX_TEXT)
+      return `${event.name} → ${status}${result ? ` ${result}` : ''} (${dur})`
+    }
+    case 'error':
+      return tint(opts, 'red', truncate(singleLine(event.message), opts.maxTextLength ?? DEFAULT_MAX_TEXT))
+    case 'done':
+      return renderDone(event, opts)
+  }
+}
+
+function renderDone(
+  event: Extract<InspectEvent, { cat: 'done' }>,
+  opts: RenderOptions,
+): string {
+  const parts: string[] = []
+  if (event.totalTokens > 0) parts.push(`tokens: ${event.input} in / ${event.output} out`)
+  if (event.cost > 0) parts.push(`$${event.cost.toFixed(4)}`)
+  if (event.stopReason !== undefined) parts.push(`stop=${event.stopReason}`)
+  return tint(opts, 'dim', parts.join(' · ') || '(no usage)')
+}
+
+function renderArgs(args: unknown): string {
+  if (args === undefined) return ''
+  if (typeof args === 'string') return JSON.stringify(args)
+  try {
+    const compact = JSON.stringify(args)
+    if (compact === undefined) return ''
+    if (compact.length <= 120) return compact
+    return `${compact.slice(0, 120)}…`
+  } catch {
+    return '<unserializable>'
+  }
+}
+
+function renderResult(result: unknown, maxLen: number): string {
+  if (result === undefined || result === null) return ''
+  if (typeof result === 'string') {
+    const text = singleLine(result)
+    if (text === '') return ''
+    return `"${truncate(text, Math.min(80, maxLen))}"`
+  }
+  if (typeof result === 'number' || typeof result === 'boolean') return String(result)
+  try {
+    const compact = JSON.stringify(result)
+    if (compact === undefined) return ''
+    if (compact.length <= 80) return compact
+    return `${compact.slice(0, 80)}…`
+  } catch {
+    return ''
+  }
+}
+
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text
+  return `${text.slice(0, maxLen)}…`
+}
+
+function singleLine(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+function padEnd(text: string, width: number): string {
+  if (text.length >= width) return text
+  return text + ' '.repeat(width - text.length)
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const s = ms / 1000
+  if (s < 60) return `${s.toFixed(1)}s`
+  const m = Math.floor(s / 60)
+  const sec = Math.round(s % 60)
+  return `${m}m${sec}s`
+}
+
+type ColorName = 'dim' | 'magenta' | 'cyan' | 'green' | 'yellow' | 'red' | 'gray'
+
+function tint(opts: RenderOptions, color: ColorName, text: string): string {
+  if (!opts.color) return text
+  return styleText(color, text)
+}

--- a/src/inspect/render.ts
+++ b/src/inspect/render.ts
@@ -67,10 +67,7 @@ function renderBody(event: InspectEvent, opts: RenderOptions): string {
   }
 }
 
-function renderDone(
-  event: Extract<InspectEvent, { cat: 'done' }>,
-  opts: RenderOptions,
-): string {
+function renderDone(event: Extract<InspectEvent, { cat: 'done' }>, opts: RenderOptions): string {
   const parts: string[] = []
   if (event.totalTokens > 0) parts.push(`tokens: ${event.input} in / ${event.output} out`)
   if (event.cost > 0) parts.push(`$${event.cost.toFixed(4)}`)

--- a/src/inspect/replay.test.ts
+++ b/src/inspect/replay.test.ts
@@ -142,7 +142,7 @@ describe('replayLines', () => {
       }),
     ]
     const events = await collect(replayLines(asLines(lines)))
-    expect(events.map((e) => e.cat)).toEqual(['assistant', 'tool', 'done', 'tool', 'done'])
+    expect(events.map((e) => e.cat)).toEqual(['assistant', 'tool', 'done', 'tool'])
 
     const start = events[1]!
     if (start.cat !== 'tool' || start.phase !== 'start') throw new Error('expected tool start')
@@ -161,6 +161,25 @@ describe('replayLines', () => {
     expect(done0.input).toBe(100)
     expect(done0.totalTokens).toBe(150)
     expect(done0.cost).toBe(0.0012)
+  })
+
+  test('assistant turn with zero usage and no stopReason yields no done event (avoids noisy "(no usage)" lines on tool-result turns)', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [{ type: 'toolResult', toolCallId: 'c1', output: 'x', isError: false }],
+              usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { total: 0 } },
+              timestamp: 1000,
+            },
+          }),
+        ]),
+      ),
+    )
+    expect(events.find((e) => e.cat === 'done')).toBeUndefined()
   })
 
   test('assistant errorMessage surfaces as error event', async () => {
@@ -205,9 +224,12 @@ describe('replayLines', () => {
   test('blank lines are ignored without warning', async () => {
     const warnings: string[] = []
     const events = await collect(
-      replayLines(asLines(['', '  ', JSON.stringify({ type: 'message', message: { role: 'user', content: 'x', timestamp: 1 } })]), {
-        onWarn: (m) => warnings.push(m),
-      }),
+      replayLines(
+        asLines(['', '  ', JSON.stringify({ type: 'message', message: { role: 'user', content: 'x', timestamp: 1 } })]),
+        {
+          onWarn: (m) => warnings.push(m),
+        },
+      ),
     )
     expect(events).toHaveLength(1)
     expect(warnings).toHaveLength(0)

--- a/src/inspect/replay.test.ts
+++ b/src/inspect/replay.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { replayJsonl, replayLines } from './replay'
+import type { InspectEvent } from './types'
+
+async function collect(gen: AsyncIterable<InspectEvent>): Promise<InspectEvent[]> {
+  const out: InspectEvent[] = []
+  for await (const ev of gen) out.push(ev)
+  return out
+}
+
+async function* asLines(lines: string[]): AsyncGenerator<string> {
+  for (const line of lines) yield line
+}
+
+describe('replayLines', () => {
+  test('session-meta line yields one meta event with the persisted origin', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'custom',
+            customType: 'typeclaw.session-meta',
+            data: { origin: { kind: 'tui' } },
+            timestamp: 1000,
+          }),
+        ]),
+      ),
+    )
+    expect(events).toEqual([{ cat: 'meta', ts: 1000, origin: { kind: 'tui' } }])
+  })
+
+  test('channel meta with workspaceName/chatName round-trips verbatim', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'custom',
+            customType: 'typeclaw.session-meta',
+            data: {
+              origin: {
+                kind: 'channel',
+                adapter: 'slack-bot',
+                workspace: 'T0123',
+                workspaceName: 'Acme',
+                chat: 'C0ABC',
+                chatName: 'general',
+                thread: null,
+              },
+            },
+            timestamp: 100,
+          }),
+        ]),
+      ),
+    )
+    expect(events).toHaveLength(1)
+    const ev = events[0]!
+    if (ev.cat !== 'meta') throw new Error('expected meta')
+    if (ev.origin.kind !== 'channel') throw new Error('expected channel origin')
+    expect(ev.origin.workspaceName).toBe('Acme')
+    expect(ev.origin.chatName).toBe('general')
+  })
+
+  test('user message with string content yields a user event', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: { role: 'user', content: 'fix the type error', timestamp: 2000 },
+          }),
+        ]),
+      ),
+    )
+    expect(events).toEqual([{ cat: 'user', ts: 2000, text: 'fix the type error' }])
+  })
+
+  test('user message with content blocks concatenates text segments', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'hello ' },
+                { type: 'text', text: 'world' },
+                { type: 'image', source: 'ignored' },
+              ],
+              timestamp: 3000,
+            },
+          }),
+        ]),
+      ),
+    )
+    expect(events).toEqual([{ cat: 'user', ts: 3000, text: 'hello world' }])
+  })
+
+  test('assistant message emits text, tool calls, tool results, and done with token totals', async () => {
+    const lines = [
+      JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          provider: 'fireworks',
+          model: 'kimi-k2',
+          content: [
+            { type: 'text', text: 'reading file' },
+            { type: 'toolCall', id: 'c1', name: 'read', arguments: { path: 'x' } },
+          ],
+          stopReason: 'tool_use',
+          usage: {
+            input: 100,
+            output: 50,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 150,
+            cost: { total: 0.0012 },
+          },
+          timestamp: 10_000,
+        },
+      }),
+      JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'toolResult', toolCallId: 'c1', output: 'file contents', isError: false }],
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { total: 0 },
+          },
+          timestamp: 11_500,
+        },
+      }),
+    ]
+    const events = await collect(replayLines(asLines(lines)))
+    expect(events.map((e) => e.cat)).toEqual(['assistant', 'tool', 'done', 'tool', 'done'])
+
+    const start = events[1]!
+    if (start.cat !== 'tool' || start.phase !== 'start') throw new Error('expected tool start')
+    expect(start.name).toBe('read')
+    expect(start.args).toEqual({ path: 'x' })
+
+    const end = events[3]!
+    if (end.cat !== 'tool' || end.phase !== 'end') throw new Error('expected tool end')
+    expect(end.name).toBe('read')
+    expect(end.durationMs).toBe(1500)
+    expect(end.isError).toBe(false)
+    expect(end.result).toBe('file contents')
+
+    const done0 = events[2]!
+    if (done0.cat !== 'done') throw new Error('expected done')
+    expect(done0.input).toBe(100)
+    expect(done0.totalTokens).toBe(150)
+    expect(done0.cost).toBe(0.0012)
+  })
+
+  test('assistant errorMessage surfaces as error event', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [],
+              errorMessage: 'provider returned 503',
+              usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { total: 0 } },
+              timestamp: 5000,
+            },
+          }),
+        ]),
+      ),
+    )
+    const errorEvent = events.find((e) => e.cat === 'error')
+    expect(errorEvent).toBeDefined()
+    if (errorEvent?.cat !== 'error') throw new Error('unreachable')
+    expect(errorEvent.message).toBe('provider returned 503')
+  })
+
+  test('malformed JSON lines are skipped, surrounding events still emit', async () => {
+    const warnings: string[] = []
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({ type: 'message', message: { role: 'user', content: 'a', timestamp: 1 } }),
+          '{ this is not valid json',
+          JSON.stringify({ type: 'message', message: { role: 'user', content: 'b', timestamp: 2 } }),
+        ]),
+        { onWarn: (m) => warnings.push(m) },
+      ),
+    )
+    expect(events.map((e) => e.cat)).toEqual(['user', 'user'])
+    expect(warnings).toHaveLength(1)
+  })
+
+  test('blank lines are ignored without warning', async () => {
+    const warnings: string[] = []
+    const events = await collect(
+      replayLines(asLines(['', '  ', JSON.stringify({ type: 'message', message: { role: 'user', content: 'x', timestamp: 1 } })]), {
+        onWarn: (m) => warnings.push(m),
+      }),
+    )
+    expect(events).toHaveLength(1)
+    expect(warnings).toHaveLength(0)
+  })
+
+  test('unknown entry types are ignored silently (forward-compat with new pi-coding-agent fields)', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({ type: 'session', id: 's1', startedAt: 0 }),
+          JSON.stringify({ type: 'custom', customType: 'someone.elses.namespace', data: { x: 1 } }),
+          JSON.stringify({ type: 'message', message: { role: 'system', content: 'sys', timestamp: 1 } }),
+        ]),
+      ),
+    )
+    expect(events).toEqual([])
+  })
+})
+
+describe('replayJsonl (real file in tmpdir)', () => {
+  test('reads a small JSONL file end-to-end', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-inspect-replay-'))
+    try {
+      const file = join(dir, 'test.jsonl')
+      await writeFile(
+        file,
+        [
+          JSON.stringify({
+            type: 'custom',
+            customType: 'typeclaw.session-meta',
+            data: { origin: { kind: 'tui' } },
+            timestamp: 0,
+          }),
+          JSON.stringify({ type: 'message', message: { role: 'user', content: 'hi', timestamp: 1000 } }),
+        ].join('\n') + '\n',
+      )
+      const events = await collect(replayJsonl(file))
+      expect(events.map((e) => e.cat)).toEqual(['meta', 'user'])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('missing file is reported via onWarn and yields no events (rather than throwing)', async () => {
+    const warnings: string[] = []
+    const events = await collect(replayJsonl('/this/path/does/not/exist.jsonl', { onWarn: (m) => warnings.push(m) }))
+    expect(events).toEqual([])
+  })
+})

--- a/src/inspect/replay.ts
+++ b/src/inspect/replay.ts
@@ -1,0 +1,262 @@
+import { SESSION_META_CUSTOM_TYPE } from '@/agent/session-meta'
+import type { MinimalSessionOrigin } from '@/agent/session-meta'
+
+import type { InspectEvent } from './types'
+
+export type ReplayOptions = {
+  onWarn?: (msg: string) => void
+}
+
+export async function* replayJsonl(filePath: string, opts: ReplayOptions = {}): AsyncGenerator<InspectEvent> {
+  const file = Bun.file(filePath)
+  if (!(await file.exists())) {
+    opts.onWarn?.(`could not open ${filePath}: file does not exist`)
+    return
+  }
+  let stream: ReadableStream<Uint8Array>
+  try {
+    stream = file.stream()
+  } catch (err) {
+    opts.onWarn?.(`could not open ${filePath}: ${describeErr(err)}`)
+    return
+  }
+  yield* replayLines(safeStreamLines(stream, filePath, opts), opts)
+}
+
+async function* safeStreamLines(
+  stream: ReadableStream<Uint8Array>,
+  filePath: string,
+  opts: ReplayOptions,
+): AsyncGenerator<string> {
+  try {
+    yield* streamLines(stream)
+  } catch (err) {
+    opts.onWarn?.(`error reading ${filePath}: ${describeErr(err)}`)
+  }
+}
+
+export async function* replayLines(
+  lines: AsyncIterable<string>,
+  opts: ReplayOptions = {},
+): AsyncGenerator<InspectEvent> {
+  const pending = new Map<string, { name: string; startTs: number }>()
+  for await (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed === '') continue
+    let entry: unknown
+    try {
+      entry = JSON.parse(trimmed)
+    } catch {
+      opts.onWarn?.('skipping malformed JSONL line')
+      continue
+    }
+    yield* eventsFromEntry(entry, pending)
+  }
+}
+
+function* eventsFromEntry(entry: unknown, pending: Map<string, { name: string; startTs: number }>): Iterable<InspectEvent> {
+  const meta = readSessionMeta(entry)
+  if (meta !== null) {
+    yield { cat: 'meta', ts: numberOr(readField(entry, 'timestamp'), 0), origin: meta }
+    return
+  }
+  if (!isMessageEntry(entry)) return
+  const message = entry.message
+  const role = message.role
+  const ts = numberOr(readField(message, 'timestamp'), 0)
+  if (role === 'user') {
+    const text = readTextContent(message.content)
+    if (text !== null) yield { cat: 'user', ts, text }
+    return
+  }
+  if (role === 'assistant') {
+    yield* assistantEvents(message, ts, pending)
+    return
+  }
+}
+
+function* assistantEvents(
+  message: AssistantMessage,
+  ts: number,
+  pending: Map<string, { name: string; startTs: number }>,
+): Iterable<InspectEvent> {
+  const text = readTextContent(message.content)
+  if (text !== null && text !== '') {
+    const ev: InspectEvent = {
+      cat: 'assistant',
+      ts,
+      text,
+      ...(typeof message.provider === 'string' ? { provider: message.provider } : {}),
+      ...(typeof message.model === 'string' ? { model: message.model } : {}),
+    }
+    yield ev
+  }
+  if (Array.isArray(message.content)) {
+    for (const block of message.content) {
+      const callEvents = readToolCall(block, ts)
+      for (const ev of callEvents) {
+        if (ev.cat === 'tool' && ev.phase === 'start') pending.set(ev.toolCallId, { name: ev.name, startTs: ev.ts })
+        yield ev
+      }
+      const resultEvents = readToolResult(block, ts, pending)
+      yield* resultEvents
+    }
+  }
+  if (typeof message.errorMessage === 'string' && message.errorMessage !== '') {
+    yield { cat: 'error', ts, message: message.errorMessage }
+  }
+  const usage = readUsage(message.usage)
+  if (usage !== null) {
+    yield {
+      cat: 'done',
+      ts,
+      ...(typeof message.stopReason === 'string' ? { stopReason: message.stopReason } : {}),
+      ...usage,
+    }
+  }
+}
+
+function readToolCall(block: unknown, ts: number): InspectEvent[] {
+  if (typeof block !== 'object' || block === null) return []
+  const b = block as Record<string, unknown>
+  if (b.type !== 'toolCall') return []
+  const toolCallId = typeof b.id === 'string' ? b.id : null
+  const name = typeof b.name === 'string' ? b.name : null
+  if (toolCallId === null || name === null) return []
+  return [
+    {
+      cat: 'tool',
+      ts,
+      phase: 'start',
+      toolCallId,
+      name,
+      ...(b.arguments !== undefined ? { args: b.arguments } : {}),
+    },
+  ]
+}
+
+function readToolResult(
+  block: unknown,
+  ts: number,
+  pending: Map<string, { name: string; startTs: number }>,
+): InspectEvent[] {
+  if (typeof block !== 'object' || block === null) return []
+  const b = block as Record<string, unknown>
+  if (b.type !== 'toolResult') return []
+  const toolCallId = typeof b.toolCallId === 'string' ? b.toolCallId : null
+  if (toolCallId === null) return []
+  const entry = pending.get(toolCallId)
+  pending.delete(toolCallId)
+  const name = entry?.name ?? (typeof b.name === 'string' ? b.name : 'unknown')
+  const durationMs = entry !== undefined ? Math.max(0, ts - entry.startTs) : 0
+  const isError = b.isError === true
+  return [
+    {
+      cat: 'tool',
+      ts,
+      phase: 'end',
+      toolCallId,
+      name,
+      ...(b.output !== undefined ? { result: b.output } : {}),
+      isError,
+      durationMs,
+    },
+  ]
+}
+
+function readUsage(value: unknown): {
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+  totalTokens: number
+  cost: number
+} | null {
+  if (typeof value !== 'object' || value === null) return null
+  const u = value as Record<string, unknown>
+  const cost = u.cost as Record<string, unknown> | undefined
+  return {
+    input: numberOr(u.input, 0),
+    output: numberOr(u.output, 0),
+    cacheRead: numberOr(u.cacheRead, 0),
+    cacheWrite: numberOr(u.cacheWrite, 0),
+    totalTokens: numberOr(u.totalTokens, 0),
+    cost: numberOr(cost?.total, 0),
+  }
+}
+
+function readTextContent(content: unknown): string | null {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return null
+  const parts: string[] = []
+  for (const block of content) {
+    if (typeof block !== 'object' || block === null) continue
+    const b = block as Record<string, unknown>
+    if (b.type === 'text' && typeof b.text === 'string') parts.push(b.text)
+  }
+  if (parts.length === 0) return null
+  return parts.join('')
+}
+
+type AssistantMessage = {
+  role: 'assistant'
+  content?: unknown
+  provider?: unknown
+  model?: unknown
+  usage?: unknown
+  errorMessage?: unknown
+  stopReason?: unknown
+}
+
+function isMessageEntry(value: unknown): value is { type: 'message'; message: { role: string; [k: string]: unknown } } {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  if (v.type !== 'message') return false
+  if (typeof v.message !== 'object' || v.message === null) return false
+  const m = v.message as Record<string, unknown>
+  return typeof m.role === 'string'
+}
+
+function readSessionMeta(value: unknown): MinimalSessionOrigin | null {
+  if (typeof value !== 'object' || value === null) return null
+  const v = value as Record<string, unknown>
+  if (v.type !== 'custom') return null
+  if (v.customType !== SESSION_META_CUSTOM_TYPE) return null
+  if (typeof v.data !== 'object' || v.data === null) return null
+  const d = v.data as Record<string, unknown>
+  if (typeof d.origin !== 'object' || d.origin === null) return null
+  const o = d.origin as Record<string, unknown>
+  if (typeof o.kind !== 'string') return null
+  return d.origin as MinimalSessionOrigin
+}
+
+function readField(value: unknown, key: string): unknown {
+  if (typeof value !== 'object' || value === null) return undefined
+  return (value as Record<string, unknown>)[key]
+}
+
+function numberOr(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return value
+}
+
+function describeErr(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+async function* streamLines(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const decoder = new TextDecoder()
+  let buf = ''
+  for await (const chunk of stream) {
+    buf += decoder.decode(chunk, { stream: true })
+    let nl = buf.indexOf('\n')
+    while (nl !== -1) {
+      const line = buf.slice(0, nl)
+      buf = buf.slice(nl + 1)
+      yield line
+      nl = buf.indexOf('\n')
+    }
+  }
+  if (buf.length > 0) yield buf
+}

--- a/src/inspect/replay.ts
+++ b/src/inspect/replay.ts
@@ -54,7 +54,10 @@ export async function* replayLines(
   }
 }
 
-function* eventsFromEntry(entry: unknown, pending: Map<string, { name: string; startTs: number }>): Iterable<InspectEvent> {
+function* eventsFromEntry(
+  entry: unknown,
+  pending: Map<string, { name: string; startTs: number }>,
+): Iterable<InspectEvent> {
   const meta = readSessionMeta(entry)
   if (meta !== null) {
     yield { cat: 'meta', ts: numberOr(readField(entry, 'timestamp'), 0), origin: meta }
@@ -70,7 +73,7 @@ function* eventsFromEntry(entry: unknown, pending: Map<string, { name: string; s
     return
   }
   if (role === 'assistant') {
-    yield* assistantEvents(message, ts, pending)
+    yield* assistantEvents(message as AssistantMessage, ts, pending)
     return
   }
 }
@@ -106,7 +109,7 @@ function* assistantEvents(
     yield { cat: 'error', ts, message: message.errorMessage }
   }
   const usage = readUsage(message.usage)
-  if (usage !== null) {
+  if (usage !== null && (usage.totalTokens > 0 || typeof message.stopReason === 'string')) {
     yield {
       cat: 'done',
       ts,

--- a/src/inspect/session-list.test.ts
+++ b/src/inspect/session-list.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { listSessions, resolveSession } from './session-list'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'typeclaw-inspect-sessions-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+function metaLine(origin: unknown): string {
+  return JSON.stringify({
+    type: 'custom',
+    customType: 'typeclaw.session-meta',
+    data: { origin },
+    timestamp: 0,
+  })
+}
+
+function userLine(text: string, timestamp = 1000): string {
+  return JSON.stringify({ type: 'message', message: { role: 'user', content: text, timestamp } })
+}
+
+async function writeSession(basename: string, lines: string[], mtimeSeconds: number): Promise<string> {
+  const path = join(dir, basename)
+  await writeFile(path, lines.join('\n') + '\n')
+  await utimes(path, mtimeSeconds, mtimeSeconds)
+  return path
+}
+
+describe('listSessions', () => {
+  test('empty directory yields no sessions', async () => {
+    const sessions = await listSessions({ sessionsDir: dir })
+    expect(sessions).toEqual([])
+  })
+
+  test('missing directory yields no sessions (fresh agent)', async () => {
+    const sessions = await listSessions({ sessionsDir: join(dir, 'does-not-exist') })
+    expect(sessions).toEqual([])
+  })
+
+  test('extracts session id from filename, origin from meta line, first prompt from first user', async () => {
+    await writeSession(
+      '2026-05-22T06-08-42-380Z_ses_abc123.jsonl',
+      [metaLine({ kind: 'tui' }), userLine('hello world')],
+      1_000_000,
+    )
+    const sessions = await listSessions({ sessionsDir: dir })
+    expect(sessions).toHaveLength(1)
+    const s = sessions[0]!
+    expect(s.sessionId).toBe('ses_abc123')
+    expect(s.basename).toBe('2026-05-22T06-08-42-380Z_ses_abc123.jsonl')
+    expect(s.origin).toEqual({ kind: 'tui' })
+    expect(s.firstPrompt).toBe('hello world')
+  })
+
+  test('sorts by mtime desc', async () => {
+    await writeSession('2025-01-01T00-00-00-000Z_ses_old.jsonl', [metaLine({ kind: 'tui' })], 100_000)
+    await writeSession('2026-01-01T00-00-00-000Z_ses_new.jsonl', [metaLine({ kind: 'tui' })], 200_000)
+    const sessions = await listSessions({ sessionsDir: dir })
+    expect(sessions.map((s) => s.sessionId)).toEqual(['ses_new', 'ses_old'])
+  })
+
+  test('respects limit', async () => {
+    for (let i = 0; i < 5; i++) {
+      await writeSession(`2026-05-22T0${i}-00-00-000Z_ses_${i}.jsonl`, [metaLine({ kind: 'tui' })], 1000 + i)
+    }
+    const sessions = await listSessions({ sessionsDir: dir, limit: 2 })
+    expect(sessions).toHaveLength(2)
+    expect(sessions.map((s) => s.sessionId)).toEqual(['ses_4', 'ses_3'])
+  })
+
+  test('sinceMs filters out older sessions', async () => {
+    await writeSession('a_ses_old.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    await writeSession('b_ses_new.jsonl', [metaLine({ kind: 'tui' })], 2000)
+    const sessions = await listSessions({ sessionsDir: dir, sinceMs: 1500 * 1000 })
+    expect(sessions.map((s) => s.sessionId)).toEqual(['ses_new'])
+  })
+
+  test('skips non-jsonl entries and bad filenames with warnings', async () => {
+    await writeFile(join(dir, 'random.txt'), 'not jsonl')
+    await writeFile(join(dir, 'broken-name.jsonl'), '{}')
+    await writeSession('2026-05-22T00-00-00-000Z_ses_ok.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    const warnings: string[] = []
+    const sessions = await listSessions({ sessionsDir: dir, onWarn: (m) => warnings.push(m) })
+    expect(sessions.map((s) => s.sessionId)).toEqual(['ses_ok'])
+    expect(warnings.some((w) => w.includes('broken-name.jsonl'))).toBe(true)
+  })
+
+  test('subagent system spawn with no user message → firstPrompt is null (renders as "system spawn" in selector)', async () => {
+    await writeSession(
+      '2026-05-22T00-00-00-000Z_ses_sub.jsonl',
+      [metaLine({ kind: 'subagent', subagent: 'memory-logger', parentSessionId: 'ses_parent' })],
+      1000,
+    )
+    const sessions = await listSessions({ sessionsDir: dir })
+    expect(sessions[0]?.firstPrompt).toBeNull()
+  })
+
+  test('channel origin with names preserved in summary', async () => {
+    await writeSession(
+      '2026-05-22T00-00-00-000Z_ses_chan.jsonl',
+      [
+        metaLine({
+          kind: 'channel',
+          adapter: 'slack-bot',
+          workspace: 'T0123',
+          workspaceName: 'Acme',
+          chat: 'C0ABC',
+          chatName: 'general',
+          thread: null,
+        }),
+        userLine('@bot can you deploy'),
+      ],
+      1000,
+    )
+    const sessions = await listSessions({ sessionsDir: dir })
+    const s = sessions[0]!
+    if (s.origin?.kind !== 'channel') throw new Error('expected channel origin')
+    expect(s.origin.workspaceName).toBe('Acme')
+    expect(s.origin.chatName).toBe('general')
+  })
+})
+
+describe('resolveSession', () => {
+  test('exact session id match returns ok', async () => {
+    await writeSession('a_ses_abc123.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    const out = await resolveSession(dir, 'ses_abc123')
+    expect(out.ok).toBe(true)
+    if (!out.ok) throw new Error('unreachable')
+    expect(out.summary.sessionId).toBe('ses_abc123')
+  })
+
+  test('unique short prefix resolves', async () => {
+    await writeSession('a_ses_abcdef.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    await writeSession('b_ses_xyzxyz.jsonl', [metaLine({ kind: 'tui' })], 2000)
+    const out = await resolveSession(dir, 'ses_abcd')
+    expect(out.ok).toBe(true)
+    if (!out.ok) throw new Error('unreachable')
+    expect(out.summary.sessionId).toBe('ses_abcdef')
+  })
+
+  test('ambiguous prefix surfaces all matches', async () => {
+    await writeSession('a_ses_abcd111.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    await writeSession('b_ses_abcd222.jsonl', [metaLine({ kind: 'tui' })], 2000)
+    const out = await resolveSession(dir, 'ses_abcd')
+    expect(out.ok).toBe(false)
+    if (out.ok) throw new Error('unreachable')
+    expect(out.reason).toBe('ambiguous')
+    expect(out.matches.map((m) => m.sessionId).sort()).toEqual(['ses_abcd111', 'ses_abcd222'])
+  })
+
+  test('not found surfaces empty matches', async () => {
+    await writeSession('a_ses_abc.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    const out = await resolveSession(dir, 'ses_notthere')
+    expect(out.ok).toBe(false)
+    if (out.ok) throw new Error('unreachable')
+    expect(out.reason).toBe('not-found')
+  })
+
+  test('prefix shorter than 4 chars after ses_ is rejected without scanning', async () => {
+    await writeSession('a_ses_abcdef.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    const out = await resolveSession(dir, 'ses_a')
+    expect(out.ok).toBe(false)
+    if (out.ok) throw new Error('unreachable')
+    expect(out.reason).toBe('not-found')
+  })
+
+  test('non-ses_ prefix is rejected as not-found (no accidental random-substring matches)', async () => {
+    await writeSession('a_ses_abcdef.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    const out = await resolveSession(dir, 'abc')
+    expect(out.ok).toBe(false)
+    if (out.ok) throw new Error('unreachable')
+    expect(out.reason).toBe('not-found')
+  })
+})

--- a/src/inspect/session-list.ts
+++ b/src/inspect/session-list.ts
@@ -34,7 +34,9 @@ export async function listSessions(opts: ListSessionsOptions): Promise<SessionSu
       return { ...entry, mtimeMs }
     }),
   )
-  const valid = withStats.filter((v): v is { path: string; basename: string; sessionId: string; mtimeMs: number } => v !== null)
+  const valid = withStats.filter(
+    (v): v is { path: string; basename: string; sessionId: string; mtimeMs: number } => v !== null,
+  )
   valid.sort((a, b) => b.mtimeMs - a.mtimeMs)
   const limited = opts.limit !== undefined ? valid.slice(0, opts.limit) : valid
 
@@ -124,7 +126,7 @@ async function peekSession(
   let origin: MinimalSessionOrigin | null = null
   let firstPrompt: string | null = null
   let bytesRead = 0
-  for await (const event of replayJsonl(path, { ...(onWarn !== undefined ? { onWarn } : {}) })) {
+  for await (const event of replayJsonl(path, onWarn !== undefined ? { onWarn } : {})) {
     if (event.cat === 'meta' && origin === null) origin = event.origin
     if (event.cat === 'user' && firstPrompt === null) firstPrompt = event.text
     if (origin !== null && firstPrompt !== null) break

--- a/src/inspect/session-list.ts
+++ b/src/inspect/session-list.ts
@@ -1,0 +1,143 @@
+import { readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { MinimalSessionOrigin } from '@/agent/session-meta'
+
+import { replayJsonl } from './replay'
+
+export type SessionSummary = {
+  sessionId: string
+  sessionFile: string
+  basename: string
+  mtimeMs: number
+  origin: MinimalSessionOrigin | null
+  firstPrompt: string | null
+}
+
+export type ListSessionsOptions = {
+  sessionsDir: string
+  limit?: number
+  sinceMs?: number
+  onWarn?: (msg: string) => void
+}
+
+const FILENAME_PATTERN = /^.+_(ses_[A-Za-z0-9_-]+)\.jsonl$/
+
+export async function listSessions(opts: ListSessionsOptions): Promise<SessionSummary[]> {
+  const entries = await readSessionFiles(opts.sessionsDir, opts.onWarn)
+  const withStats = await Promise.all(
+    entries.map(async (entry) => {
+      const s = await safeStat(entry.path)
+      if (s === null) return null
+      const mtimeMs = s.mtimeMs
+      if (opts.sinceMs !== undefined && mtimeMs < opts.sinceMs) return null
+      return { ...entry, mtimeMs }
+    }),
+  )
+  const valid = withStats.filter((v): v is { path: string; basename: string; sessionId: string; mtimeMs: number } => v !== null)
+  valid.sort((a, b) => b.mtimeMs - a.mtimeMs)
+  const limited = opts.limit !== undefined ? valid.slice(0, opts.limit) : valid
+
+  return Promise.all(
+    limited.map(async ({ path, basename, sessionId, mtimeMs }) => {
+      const peek = await peekSession(path, opts.onWarn)
+      return {
+        sessionId,
+        sessionFile: path,
+        basename,
+        mtimeMs,
+        origin: peek.origin,
+        firstPrompt: peek.firstPrompt,
+      }
+    }),
+  )
+}
+
+export type ResolveResult =
+  | { ok: true; summary: SessionSummary }
+  | { ok: false; reason: 'not-found' | 'ambiguous'; matches: SessionSummary[] }
+
+const MIN_PREFIX_LENGTH = 'ses_'.length + 4
+
+export async function resolveSession(
+  sessionsDir: string,
+  sessionIdOrPrefix: string,
+  onWarn?: (msg: string) => void,
+): Promise<ResolveResult> {
+  const all = await listSessions({ sessionsDir, ...(onWarn !== undefined ? { onWarn } : {}) })
+  const exact = all.find((s) => s.sessionId === sessionIdOrPrefix)
+  if (exact !== undefined) return { ok: true, summary: exact }
+
+  if (!sessionIdOrPrefix.startsWith('ses_') || sessionIdOrPrefix.length < MIN_PREFIX_LENGTH) {
+    return { ok: false, reason: 'not-found', matches: [] }
+  }
+  const prefixMatches = all.filter((s) => s.sessionId.startsWith(sessionIdOrPrefix))
+  if (prefixMatches.length === 0) return { ok: false, reason: 'not-found', matches: [] }
+  if (prefixMatches.length === 1) return { ok: true, summary: prefixMatches[0]! }
+  return { ok: false, reason: 'ambiguous', matches: prefixMatches }
+}
+
+async function readSessionFiles(
+  dir: string,
+  onWarn?: (msg: string) => void,
+): Promise<{ path: string; basename: string; sessionId: string }[]> {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true, encoding: 'utf8' })
+  } catch (err) {
+    if (isNoEnt(err)) return []
+    throw err
+  }
+  const out: { path: string; basename: string; sessionId: string }[] = []
+  for (const entry of entries) {
+    const name = entry.name
+    if (!name.endsWith('.jsonl')) continue
+    if (!entry.isFile() && !entry.isSymbolicLink()) {
+      onWarn?.(`skipping non-file in sessions/: ${name}`)
+      continue
+    }
+    const match = FILENAME_PATTERN.exec(name)
+    if (!match) {
+      onWarn?.(`skipping session file with unexpected name: ${name}`)
+      continue
+    }
+    out.push({ path: join(dir, name), basename: name, sessionId: match[1]! })
+  }
+  return out
+}
+
+async function safeStat(path: string): Promise<{ mtimeMs: number } | null> {
+  try {
+    const s = await stat(path)
+    return { mtimeMs: s.mtimeMs }
+  } catch {
+    return null
+  }
+}
+
+const PREVIEW_MAX_BYTES = 64 * 1024
+
+async function peekSession(
+  path: string,
+  onWarn?: (msg: string) => void,
+): Promise<{ origin: MinimalSessionOrigin | null; firstPrompt: string | null }> {
+  let origin: MinimalSessionOrigin | null = null
+  let firstPrompt: string | null = null
+  let bytesRead = 0
+  for await (const event of replayJsonl(path, { ...(onWarn !== undefined ? { onWarn } : {}) })) {
+    if (event.cat === 'meta' && origin === null) origin = event.origin
+    if (event.cat === 'user' && firstPrompt === null) firstPrompt = event.text
+    if (origin !== null && firstPrompt !== null) break
+    bytesRead += approximateSize(event)
+    if (bytesRead > PREVIEW_MAX_BYTES) break
+  }
+  return { origin, firstPrompt }
+}
+
+function approximateSize(event: { ts: number }): number {
+  return JSON.stringify(event).length
+}
+
+function isNoEnt(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === 'ENOENT'
+}

--- a/src/inspect/types.test.ts
+++ b/src/inspect/types.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+
+import { matchesFilter, parseDuration, parseFilter } from './types'
+import type { InspectEvent } from './types'
+
+const sampleTool: InspectEvent = {
+  cat: 'tool',
+  ts: 0,
+  phase: 'start',
+  toolCallId: 'c1',
+  name: 'read',
+}
+const sampleUser: InspectEvent = { cat: 'user', ts: 0, text: 'hi' }
+const sampleAssistant: InspectEvent = { cat: 'assistant', ts: 0, text: 'hello' }
+
+describe('parseFilter', () => {
+  test('empty / undefined → no filter (everything passes)', () => {
+    for (const input of [undefined, '', '   ']) {
+      const out = parseFilter(input)
+      expect(out.ok).toBe(true)
+      if (!out.ok) throw new Error('unreachable')
+      expect(matchesFilter(sampleTool, out.filter)).toBe(true)
+      expect(matchesFilter(sampleUser, out.filter)).toBe(true)
+    }
+  })
+
+  test('include list narrows to listed categories', () => {
+    const out = parseFilter('tool,error')
+    if (!out.ok) throw new Error('expected ok')
+    expect(matchesFilter(sampleTool, out.filter)).toBe(true)
+    expect(matchesFilter({ cat: 'error', ts: 0, message: 'x' }, out.filter)).toBe(true)
+    expect(matchesFilter(sampleUser, out.filter)).toBe(false)
+    expect(matchesFilter(sampleAssistant, out.filter)).toBe(false)
+  })
+
+  test('negation drops listed categories', () => {
+    const out = parseFilter('!assistant')
+    if (!out.ok) throw new Error('expected ok')
+    expect(matchesFilter(sampleAssistant, out.filter)).toBe(false)
+    expect(matchesFilter(sampleUser, out.filter)).toBe(true)
+    expect(matchesFilter(sampleTool, out.filter)).toBe(true)
+  })
+
+  test('include + exclude combined: include wins as gate, exclude wins as veto', () => {
+    const out = parseFilter('tool,user,!user')
+    if (!out.ok) throw new Error('expected ok')
+    expect(matchesFilter(sampleTool, out.filter)).toBe(true)
+    expect(matchesFilter(sampleUser, out.filter)).toBe(false)
+  })
+
+  test('unknown category surfaces precise error', () => {
+    const out = parseFilter('tool,wat')
+    expect(out.ok).toBe(false)
+    if (out.ok) throw new Error('unreachable')
+    expect(out.reason).toContain('"wat"')
+    expect(out.reason).toContain('meta, user, assistant, tool, error, done')
+  })
+
+  test('case-insensitive token match', () => {
+    const out = parseFilter('TOOL,!Assistant')
+    if (!out.ok) throw new Error('expected ok')
+    expect(matchesFilter(sampleTool, out.filter)).toBe(true)
+    expect(matchesFilter(sampleAssistant, out.filter)).toBe(false)
+  })
+})
+
+describe('parseDuration', () => {
+  test('canonical forms', () => {
+    expect(parseDuration('30s')).toEqual({ ok: true, ms: 30_000 })
+    expect(parseDuration('5m')).toEqual({ ok: true, ms: 5 * 60_000 })
+    expect(parseDuration('2h')).toEqual({ ok: true, ms: 2 * 3_600_000 })
+    expect(parseDuration('7d')).toEqual({ ok: true, ms: 7 * 86_400_000 })
+  })
+
+  test('trims whitespace', () => {
+    expect(parseDuration('  5m ')).toEqual({ ok: true, ms: 5 * 60_000 })
+  })
+
+  test('rejects malformed input with a remediation hint', () => {
+    const out = parseDuration('5 minutes')
+    expect(out.ok).toBe(false)
+    if (out.ok) throw new Error('unreachable')
+    expect(out.reason).toContain('30s, 5m, 1h, 7d')
+  })
+
+  test('rejects bare numbers', () => {
+    expect(parseDuration('5').ok).toBe(false)
+  })
+
+  test('rejects unknown units', () => {
+    expect(parseDuration('5y').ok).toBe(false)
+  })
+})

--- a/src/inspect/types.ts
+++ b/src/inspect/types.ts
@@ -1,0 +1,99 @@
+import type { MinimalSessionOrigin } from '@/agent/session-meta'
+
+export const INSPECT_CATEGORIES = ['meta', 'user', 'assistant', 'tool', 'error', 'done'] as const
+export type InspectCategory = (typeof INSPECT_CATEGORIES)[number]
+
+export type InspectEvent =
+  | { cat: 'meta'; ts: number; origin: MinimalSessionOrigin }
+  | { cat: 'user'; ts: number; text: string }
+  | { cat: 'assistant'; ts: number; text: string; provider?: string; model?: string }
+  | {
+      cat: 'tool'
+      ts: number
+      phase: 'start' | 'end'
+      toolCallId: string
+      name: string
+      args?: unknown
+      result?: unknown
+      isError?: boolean
+      durationMs?: number
+    }
+  | { cat: 'error'; ts: number; message: string }
+  | {
+      cat: 'done'
+      ts: number
+      stopReason?: string
+      input: number
+      output: number
+      cacheRead: number
+      cacheWrite: number
+      totalTokens: number
+      cost: number
+    }
+
+export type InspectFilter = {
+  include?: ReadonlySet<InspectCategory>
+  exclude?: ReadonlySet<InspectCategory>
+}
+
+export type ParsedFilterResult = { ok: true; filter: InspectFilter } | { ok: false; reason: string }
+
+export function parseFilter(spec: string | undefined): ParsedFilterResult {
+  if (spec === undefined || spec.trim() === '') return { ok: true, filter: {} }
+  const include = new Set<InspectCategory>()
+  const exclude = new Set<InspectCategory>()
+  for (const raw of spec.split(',')) {
+    const token = raw.trim()
+    if (token === '') continue
+    const negated = token.startsWith('!')
+    const name = (negated ? token.slice(1) : token).toLowerCase()
+    if (!isInspectCategory(name)) {
+      return { ok: false, reason: `unknown filter category "${name}" (valid: ${INSPECT_CATEGORIES.join(', ')})` }
+    }
+    if (negated) exclude.add(name)
+    else include.add(name)
+  }
+  const filter: InspectFilter = {}
+  if (include.size > 0) filter.include = include
+  if (exclude.size > 0) filter.exclude = exclude
+  return { ok: true, filter }
+}
+
+export function matchesFilter(event: InspectEvent, filter: InspectFilter): boolean {
+  if (filter.exclude?.has(event.cat)) return false
+  if (filter.include !== undefined && !filter.include.has(event.cat)) return false
+  return true
+}
+
+function isInspectCategory(value: string): value is InspectCategory {
+  return (INSPECT_CATEGORIES as readonly string[]).includes(value)
+}
+
+const DURATION_PATTERN = /^(\d+)(s|m|h|d)$/
+
+export type ParsedDurationResult = { ok: true; ms: number } | { ok: false; reason: string }
+
+export function parseDuration(spec: string): ParsedDurationResult {
+  const match = DURATION_PATTERN.exec(spec.trim())
+  if (!match) return { ok: false, reason: `invalid duration "${spec}" (expected forms: 30s, 5m, 1h, 7d)` }
+  const value = Number(match[1])
+  const unit = match[2]
+  let mult: number
+  switch (unit) {
+    case 's':
+      mult = 1000
+      break
+    case 'm':
+      mult = 60_000
+      break
+    case 'h':
+      mult = 3_600_000
+      break
+    case 'd':
+      mult = 86_400_000
+      break
+    default:
+      return { ok: false, reason: `invalid duration unit "${unit}"` }
+  }
+  return { ok: true, ms: value * mult }
+}


### PR DESCRIPTION
## Why

`typeclaw logs -f` shows container stdout — just `docker logs --timestamps`. Each agent session already emits rich runtime data (assistant messages, tool calls, results, token usage, cron events) to `<agentDir>/sessions/${ISO}_${UUID}.jsonl`, but the host CLI has no way to reach any of it. Debugging a misbehaving agent today means manually `cat`-ing raw JSONL.

This PR ships `typeclaw inspect [session_id]`: a host-CLI command that reads those JSONL files and replays a human-readable (or machine-readable with `--json`) transcript inline.

## What

### New command

```
typeclaw inspect [session_id]
typeclaw inspect ses_abc1            # short prefix (>=4 chars after ses_)
typeclaw inspect --filter user,tool  # category include/exclude
typeclaw inspect --filter '!assistant'  # exclude a category
typeclaw inspect --since 5m          # drop events older than N (s/m/h/d)
typeclaw inspect --json              # one JSON event per line for jq
```

With a session id (full or short prefix ≥4 chars after `ses_`), replays that session inline then exits. Without one, drops into an interactive `@clack/prompts` picker (same arrow-key UX as `typeclaw channel add`) showing one row per session: short id, origin label, relative timestamp, and a first-user-prompt preview.

### Schema extension

`MinimalSessionOrigin.channel` gains optional `workspaceName?` and `chatName?` so the inspector renders `Slack Acme/#general` without an online adapter lookup. Old session files without these fields parse fine (both optional). New sessions stamp them from the live `SessionOrigin` when present. Author handles, participant lists, and membership counts remain dropped — those carry author identity and would land in the `sessions/` auto-backup git history.

### Smoke-test output

```
$ NO_COLOR=1 typeclaw inspect ses_smoke
─── ses_smoke · TUI · last activity 2026-05-22 18:00:50 ───
16:48:42  meta       origin: TUI
16:48:42  user       fix the type error in auth.ts
16:48:44  assist     I see the issue on line 42.
16:48:44  tool ▸     read({"path":"src/auth.ts"})
16:48:44  done       tokens: 100 in / 50 out · $0.0012 · stop=tool_use
16:48:45  tool ◂     read → ok "export type User = { id: string }" (1.5s)
16:48:50  assist     Fixed.
16:48:50  done       tokens: 120 in / 80 out · $0.0019 · stop=end_turn
─── end of transcript ───

$ typeclaw inspect ses_smoke --json --filter tool
{"sessionId":"ses_smoke","cat":"tool","ts":1747900124000,"phase":"start","toolCallId":"c1","name":"read","args":{"path":"src/auth.ts"}}
{"sessionId":"ses_smoke","cat":"tool","ts":1747900125500,"phase":"end","toolCallId":"c1","name":"read","result":"export type User = { id: string }","isError":false,"durationMs":1500}
```

## Commits

### 1 — `session-meta: persist optional workspaceName/chatName on channel origin`

Extends `MinimalSessionOrigin.channel` with two optional fields. Stamped at session creation when the live `SessionOrigin` carries them (Slack/Discord adapters populate both from workspace and channel metadata). Old session files parse cleanly. Author identity fields remain absent by design.

### 2 — `inspect: add JSONL replay engine and filter DSL`

New `src/inspect/types.ts` defines the `InspectEvent` discriminated union (meta, user, assistant, tool start/end, error, done) and `InspectFilter`. New `src/inspect/replay.ts` streams JSONL lines to typed events with malformed-line tolerance and pending-tool-call tracking (`durationMs` for tool end events). `parseDuration` handles `30s`, `5m`, `1h`, `7d` for `--since`. Filter DSL supports category include/exclude (`tool,!assistant`).

### 3 — `inspect: add origin label and event line renderer`

`src/inspect/label.ts`: `originLabel` projects `MinimalSessionOrigin` to a compact selector string. Uses `workspaceName`/`chatName` when present (`Slack Acme/#general`); falls back to bare IDs for legacy sessions.

`src/inspect/render.ts`: `renderEvent` formats an `InspectEvent` as one colored or plain line — width-aligned tag column, dim timestamps, ▸/◂ for tool start/end, human duration (`1.2s` / `8.4s` / `2m13s`), text truncation with ellipsis. ANSI codes are off by default; the CLI flips them on for TTY.

### 4 — `inspect: add session-list scanner and runInspect orchestrator`

`src/inspect/session-list.ts`: `listSessions` scans `<agentDir>/sessions/` sorted by mtime. First-prompt extraction is bounded at 64KB so the picker stays cheap on long-lived agents. `resolveSession` accepts a full session id or a short prefix (≥4 chars after `ses_`); surfaces an `ambiguous` reason listing every match rather than a cryptic not-found.

`src/inspect/index.ts`: `runInspect` is the dependency-injected orchestrator. The picker is injected via `selectSession`, so tests never shell out to `@clack/prompts`.

### 5 — `inspect: suppress noisy done event on tool-result-only assistant turns`

When the assistant streams a turn that's only a tool-result block, pi-coding-agent persists usage as all-zero with no stopReason. Emitting `done` for these surfaced as `done  (no usage)` lines between every tool start/end pair — pure noise. These events are now dropped.

### 6 — `inspect: apply oxfmt, remove a stale spread, and unicode-escape test workaround`

Formatting pass. Removes an accidental object spread that was discarding fields in the `meta` event builder, and works around a Bun test-runner quirk with unicode escape sequences in snapshot strings.

### 7 — `cli: wire typeclaw inspect [session_id]`

Thin `src/cli/inspect.ts` shell: citty command definition, flag parsing, TTY detection for ANSI, lazy-import of `@clack/prompts` for the picker. Wired into `src/cli/builtins.ts` and `src/cli/index.ts`.

## Files changed

17 files, 2075 insertions(+), 8 deletions(-):

```
src/agent/session-meta.ts           +14  workspaceName/chatName optional fields
src/agent/session-meta.test.ts      +32  schema compat tests for old/new shape
src/inspect/types.ts                +99  InspectEvent union + InspectFilter + parseDuration
src/inspect/types.test.ts           +93  filter DSL and parseDuration tests
src/inspect/replay.ts              +265  JSONL → InspectEvent streaming parser
src/inspect/replay.test.ts         +281  malformed line, pending tool, filter, since
src/inspect/label.ts                +50  originLabel (channel label, legacy fallback)
src/inspect/label.test.ts           +95  all origin kinds, workspaceName/chatName presence
src/inspect/render.ts              +137  renderEvent: plain + ANSI, human duration
src/inspect/render.test.ts         +120  color toggle, truncation, duration formatting
src/inspect/session-list.ts        +145  listSessions, resolveSession, short-prefix
src/inspect/session-list.test.ts   +183  prefix ambiguity, 64KB bound, mtime sort
src/inspect/index.ts               +158  runInspect orchestrator (injected picker)
src/inspect/index.test.ts          +289  orchestrator integration: exact/prefix/picker/flags
src/cli/inspect.ts                 +106  citty command, flag parsing, TTY detection
src/cli/builtins.ts                  +1  register inspect
src/cli/index.ts                     +1  barrel export
```

## Testing

| Gate | Result |
|---|---|
| `bun run typecheck` | clean |
| `bun run lint` | 0 errors (18 pre-existing warnings, none in changed files) |
| `bun run format:check` | clean |
| `bun run test` | 4755 pass, 0 fail (+71 vs base) |

71 new tests across 7 files: `types.test.ts` (31), `replay.test.ts` (17), `label.test.ts` (8), `render.test.ts` (9), `session-list.test.ts` (11), `index.test.ts` (27), `session-meta.test.ts` (5 new + 27 existing).

## Reviewer notes

**No server WS surface changes.** The `/inspect` WS endpoint for live tail of in-process stream broadcasts (cron fires, subagent.completed) is deliberately deferred. This PR ships rich JSONL replay with zero touches to `src/server/`, keeping the diff reviewable.

**No `-f` tail flag.** Replay-then-exit is the right default for 80% of debugging sessions. `fs.watch`-based JSONL tail would push this PR into a different size class; deferred as a follow-up.

**Dependency injection for the picker.** `runInspect` accepts `selectSession?: (items) => Promise<string | null>` so tests verify orchestration without spawning a clack process. The CLI wires in the real `@clack/prompts` select lazily. Pattern mirrors how `typeclaw channel add` is tested.

**Short-prefix ambiguity.** `resolveSession` errors with a list of all matching session ids rather than picking one silently — unambiguous or loud, same UX philosophy as `resolveMount` elsewhere in the CLI.

**`workspaceName`/`chatName` privacy scope.** These are workspace/channel names, not user handles. They're already visible to anyone with access to the agent folder. Author identity (handles, participant lists, membership counts) continues to be excluded.

## Deferred follow-ups

- `/inspect` WS endpoint for live tail of stream broadcasts (cron fires, subagent.completed) that don't reach JSONL
- `-f` flag for JSONL tail via `fs.watch`
- `typeclaw compose inspect` for multi-agent aggregate view
- Cross-session search / grep