### PR TITLE
inspect: match pi-coding-agent's actual session filename format

### DIFF
--- a/src/inspect/index.test.ts
+++ b/src/inspect/index.test.ts
@@ -70,17 +70,31 @@ function captureSink(): {
 
 const neverPick = async (_: SessionSummary[]): Promise<SessionSummary | null> => null
 
+const ID_ABC = '019dda40-aaaa-7000-9000-00000000aaaa'
+const ID_JSONOUT = '019dda40-bbbb-7000-9000-00000000bbbb'
+const ID_FILT = '019dda40-cccc-7000-9000-00000000cccc'
+const ID_SINCE = '019dda40-dddd-7000-9000-00000000dddd'
+const ID_LIVET = '019dda40-eeee-7000-9000-00000000eeee'
+const ID_DEAD = '019dda40-ffff-7000-9000-00000000ffff'
+const ID_ERR = '019dda40-1111-7000-9000-000000001111'
+const ID_NO_LIVE = '019dda40-2222-7000-9000-000000002222'
+const ID_PICK1 = '019dda40-3333-7000-9000-000000003333'
+const ID_PICK2 = '019dda40-4444-7000-9000-000000004444'
+const ID_AMB_1 = '019dda40-5555-7000-9000-000000000001'
+const ID_AMB_2 = '019dda40-5555-7000-9000-000000000002'
+const AMB_PREFIX = '019dda40-5555'
+
 describe('runInspect — direct session id (replay-then-exit)', () => {
   test('replays meta, user, assistant, done in order; returns ok', async () => {
     await seedSession(
-      '2026-05-22T00-00-00-000Z_ses_abc.jsonl',
+      `2026-05-22T00-00-00-000Z_${ID_ABC}.jsonl`,
       [metaLine({ kind: 'tui' }), userLine('hi'), assistantLine('hello')],
       1000,
     )
     const sink = captureSink()
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_abc',
+      sessionIdOrPrefix: ID_ABC,
       color: false,
       selectSession: neverPick,
       ...sink.push,
@@ -90,17 +104,17 @@ describe('runInspect — direct session id (replay-then-exit)', () => {
     const stripTime = (l: string) => l.replace(/\d{2}:\d{2}:\d{2}/, 'HH:MM:SS')
     const cats = sink.out.slice(1, -1).map((l) => stripTime(l).split('  ')[1]?.trim())
     expect(cats).toEqual(['meta', 'user', 'assist', 'done'])
-    expect(sink.out[0]!).toContain('ses_abc')
+    expect(sink.out[0]!).toContain(ID_ABC.slice(0, 12))
     expect(sink.out[0]!).toContain('TUI')
     expect(sink.out.at(-1)!).toContain('end of transcript')
   })
 
   test('--json emits one event per line and omits the header/footer', async () => {
-    await seedSession('a_ses_jsonout.jsonl', [metaLine({ kind: 'tui' }), userLine('hi')], 1000)
+    await seedSession(`a_${ID_JSONOUT}.jsonl`, [metaLine({ kind: 'tui' }), userLine('hi')], 1000)
     const sink = captureSink()
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_jsonout',
+      sessionIdOrPrefix: ID_JSONOUT,
       json: true,
       color: false,
       selectSession: neverPick,
@@ -110,21 +124,21 @@ describe('runInspect — direct session id (replay-then-exit)', () => {
     expect(sink.out.every((l) => l.startsWith('{'))).toBe(true)
     for (const line of sink.out) {
       const parsed = JSON.parse(line)
-      expect(parsed.sessionId).toBe('ses_jsonout')
+      expect(parsed.sessionId).toBe(ID_JSONOUT)
       expect(typeof parsed.cat).toBe('string')
     }
   })
 
   test('filter narrows which events render', async () => {
     await seedSession(
-      'a_ses_filt.jsonl',
+      `a_${ID_FILT}.jsonl`,
       [metaLine({ kind: 'tui' }), userLine('a'), userLine('b'), assistantLine('hello')],
       1000,
     )
     const sink = captureSink()
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_filt',
+      sessionIdOrPrefix: ID_FILT,
       filter: 'user',
       color: false,
       selectSession: neverPick,
@@ -138,14 +152,14 @@ describe('runInspect — direct session id (replay-then-exit)', () => {
 
   test('--since filters out older events by their timestamp', async () => {
     await seedSession(
-      'a_ses_since.jsonl',
+      `a_${ID_SINCE}.jsonl`,
       [metaLine({ kind: 'tui' }), userLine('old', Date.now() - 86_400_000), userLine('new', Date.now())],
       1000,
     )
     const sink = captureSink()
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_since',
+      sessionIdOrPrefix: ID_SINCE,
       since: '1h',
       color: false,
       selectSession: neverPick,
@@ -162,7 +176,7 @@ describe('runInspect — direct session id (replay-then-exit)', () => {
     const sink = captureSink()
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_does_not_matter',
+      sessionIdOrPrefix: ID_ABC,
       filter: 'wat',
       color: false,
       selectSession: neverPick,
@@ -178,7 +192,7 @@ describe('runInspect — direct session id (replay-then-exit)', () => {
     const sink = captureSink()
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_x',
+      sessionIdOrPrefix: ID_ABC,
       since: 'forever',
       color: false,
       selectSession: neverPick,
@@ -191,9 +205,10 @@ describe('runInspect — direct session id (replay-then-exit)', () => {
 
   test('session not found returns exit 1', async () => {
     const sink = captureSink()
+    const ghostId = '019dda40-dead-7000-9000-000000000000'
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_ghost',
+      sessionIdOrPrefix: ghostId,
       color: false,
       selectSession: neverPick,
       ...sink.push,
@@ -201,16 +216,16 @@ describe('runInspect — direct session id (replay-then-exit)', () => {
     expect(result.ok).toBe(false)
     if (result.ok) throw new Error('unreachable')
     expect(result.exitCode).toBe(1)
-    expect(result.reason).toContain('ses_ghost')
+    expect(result.reason).toContain(ghostId)
   })
 
   test('ambiguous prefix returns exit 2 with all matches listed', async () => {
-    await seedSession('a_ses_abcd111.jsonl', [metaLine({ kind: 'tui' })], 1000)
-    await seedSession('b_ses_abcd222.jsonl', [metaLine({ kind: 'tui' })], 2000)
+    await seedSession(`a_${ID_AMB_1}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    await seedSession(`b_${ID_AMB_2}.jsonl`, [metaLine({ kind: 'tui' })], 2000)
     const sink = captureSink()
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_abcd',
+      sessionIdOrPrefix: AMB_PREFIX,
       color: false,
       selectSession: neverPick,
       ...sink.push,
@@ -218,14 +233,14 @@ describe('runInspect — direct session id (replay-then-exit)', () => {
     expect(result.ok).toBe(false)
     if (result.ok) throw new Error('unreachable')
     expect(result.exitCode).toBe(2)
-    expect(result.reason).toContain('ses_abcd111')
-    expect(result.reason).toContain('ses_abcd222')
+    expect(result.reason).toContain(ID_AMB_1)
+    expect(result.reason).toContain(ID_AMB_2)
   })
 })
 
 describe('runInspect — live tail (when liveSource is provided)', () => {
   test('replays JSONL then prints the live divider, then yields live events', async () => {
-    await seedSession('a_ses_livet.jsonl', [metaLine({ kind: 'tui' }), userLine('hi')], 1000)
+    await seedSession(`a_${ID_LIVET}.jsonl`, [metaLine({ kind: 'tui' }), userLine('hi')], 1000)
     const sink = captureSink()
 
     async function* fakeLive(): AsyncGenerator<import('./types').InspectEvent> {
@@ -244,7 +259,7 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
 
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_livet',
+      sessionIdOrPrefix: ID_LIVET,
       color: false,
       selectSession: neverPick,
       liveSource: (o) => {
@@ -262,14 +277,14 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
   })
 
   test('reports "session not in registry" divider when liveSource onSubscribed says sessionLive=false', async () => {
-    await seedSession('a_ses_dead.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    await seedSession(`a_${ID_DEAD}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
     const sink = captureSink()
     async function* fakeLive(): AsyncGenerator<import('./types').InspectEvent> {
       yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'cron-fired' } }
     }
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_dead',
+      sessionIdOrPrefix: ID_DEAD,
       color: false,
       selectSession: neverPick,
       liveSource: (o) => {
@@ -283,7 +298,7 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
   })
 
   test('live source error surfaces as a stderr warning, then end-of-transcript still prints', async () => {
-    await seedSession('a_ses_err.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    await seedSession(`a_${ID_ERR}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
     const sink = captureSink()
     async function* failingLive(): AsyncGenerator<import('./types').InspectEvent> {
       yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'x' } }
@@ -291,7 +306,7 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
     }
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_err',
+      sessionIdOrPrefix: ID_ERR,
       color: false,
       selectSession: neverPick,
       liveSource: () => failingLive(),
@@ -303,11 +318,11 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
   })
 
   test('without liveSource: same as before (replay-then-exit)', async () => {
-    await seedSession('a_ses_no_live.jsonl', [metaLine({ kind: 'tui' }), userLine('hi')], 1000)
+    await seedSession(`a_${ID_NO_LIVE}.jsonl`, [metaLine({ kind: 'tui' }), userLine('hi')], 1000)
     const sink = captureSink()
     const result = await runInspect({
       agentDir,
-      sessionIdOrPrefix: 'ses_no_live',
+      sessionIdOrPrefix: ID_NO_LIVE,
       color: false,
       selectSession: neverPick,
       ...sink.push,
@@ -335,8 +350,8 @@ describe('runInspect — picker path', () => {
   })
 
   test('passes session summaries to selectSession and replays the picked one', async () => {
-    await seedSession('a_ses_pick1.jsonl', [metaLine({ kind: 'tui' }), userLine('first')], 1000)
-    await seedSession('b_ses_pick2.jsonl', [metaLine({ kind: 'tui' }), userLine('second')], 2000)
+    await seedSession(`a_${ID_PICK1}.jsonl`, [metaLine({ kind: 'tui' }), userLine('first')], 1000)
+    await seedSession(`b_${ID_PICK2}.jsonl`, [metaLine({ kind: 'tui' }), userLine('second')], 2000)
     let offered: SessionSummary[] = []
     const sink = captureSink()
     const result = await runInspect({
@@ -344,17 +359,17 @@ describe('runInspect — picker path', () => {
       color: false,
       selectSession: async (sessions) => {
         offered = sessions
-        return sessions.find((s) => s.sessionId === 'ses_pick1') ?? null
+        return sessions.find((s) => s.sessionId === ID_PICK1) ?? null
       },
       ...sink.push,
     })
     expect(result.ok).toBe(true)
-    expect(offered.map((s) => s.sessionId).sort()).toEqual(['ses_pick1', 'ses_pick2'])
-    expect(sink.out[0]!).toContain('ses_pick1')
+    expect(offered.map((s) => s.sessionId).sort()).toEqual([ID_PICK1, ID_PICK2])
+    expect(sink.out[0]!).toContain(ID_PICK1.slice(0, 12))
   })
 
   test('cancelled picker returns exit 130 (Ctrl-C convention)', async () => {
-    await seedSession('a_ses_x.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    await seedSession(`a_${ID_ABC}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
     const sink = captureSink()
     const result = await runInspect({
       agentDir,
@@ -371,6 +386,22 @@ describe('runInspect — picker path', () => {
     const sink = captureSink()
     const result = await runInspect({
       agentDir,
+      json: true,
+      color: false,
+      selectSession: neverPick,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.exitCode).toBe(2)
+    expect(result.reason).toContain('--json requires an explicit session id')
+  })
+
+  test('--json with a non-id-shaped argument is rejected (interactive picker not allowed)', async () => {
+    const sink = captureSink()
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: 'abc',
       json: true,
       color: false,
       selectSession: neverPick,

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -4,7 +4,7 @@ import { originLabel, shortSessionId } from './label'
 import { renderEvent } from './render'
 import { replayJsonl } from './replay'
 import type { SessionSummary } from './session-list'
-import { listSessions, resolveSession } from './session-list'
+import { isSessionIdShape, listSessions, resolveSession } from './session-list'
 import type { InspectEvent, InspectFilter } from './types'
 import { matchesFilter, parseDuration, parseFilter } from './types'
 
@@ -206,6 +206,8 @@ function formatDate(ms: number): string {
   return `${yyyy}-${mm}-${dd} ${hh}:${mi}:${ss}`
 }
 
+const MIN_EXPLICIT_ID_LENGTH = 8
+
 function looksLikeSessionId(value: string): boolean {
-  return value.startsWith('ses_')
+  return value.length >= MIN_EXPLICIT_ID_LENGTH && isSessionIdShape(value)
 }

--- a/src/inspect/session-list.test.ts
+++ b/src/inspect/session-list.test.ts
@@ -35,6 +35,11 @@ async function writeSession(basename: string, lines: string[], mtimeSeconds: num
   return path
 }
 
+const UUID_A = '019dda40-4ba8-7472-9b06-e72b2b994be5'
+const UUID_B = '019e2c2e-a32e-7230-9f79-62ffe148fec1'
+const UUID_OLD = '019dda40-0000-7000-9000-000000000000'
+const UUID_NEW = '019e4d7d-bfb4-745b-9990-6b7b364bd1bd'
+
 describe('listSessions', () => {
   test('empty directory yields no sessions', async () => {
     const sessions = await listSessions({ sessionsDir: dir })
@@ -46,58 +51,58 @@ describe('listSessions', () => {
     expect(sessions).toEqual([])
   })
 
-  test('extracts session id from filename, origin from meta line, first prompt from first user', async () => {
-    await writeSession(
-      '2026-05-22T06-08-42-380Z_ses_abc123.jsonl',
-      [metaLine({ kind: 'tui' }), userLine('hello world')],
-      1_000_000,
-    )
+  test('extracts session id from pi-coding-agent filename format (ISO timestamp + UUIDv7)', async () => {
+    const basename = `2026-04-29T17-19-00-008Z_${UUID_A}.jsonl`
+    await writeSession(basename, [metaLine({ kind: 'tui' }), userLine('hello world')], 1_000_000)
     const sessions = await listSessions({ sessionsDir: dir })
     expect(sessions).toHaveLength(1)
     const s = sessions[0]!
-    expect(s.sessionId).toBe('ses_abc123')
-    expect(s.basename).toBe('2026-05-22T06-08-42-380Z_ses_abc123.jsonl')
+    expect(s.sessionId).toBe(UUID_A)
+    expect(s.basename).toBe(basename)
     expect(s.origin).toEqual({ kind: 'tui' })
     expect(s.firstPrompt).toBe('hello world')
   })
 
   test('sorts by mtime desc', async () => {
-    await writeSession('2025-01-01T00-00-00-000Z_ses_old.jsonl', [metaLine({ kind: 'tui' })], 100_000)
-    await writeSession('2026-01-01T00-00-00-000Z_ses_new.jsonl', [metaLine({ kind: 'tui' })], 200_000)
+    await writeSession(`2025-01-01T00-00-00-000Z_${UUID_OLD}.jsonl`, [metaLine({ kind: 'tui' })], 100_000)
+    await writeSession(`2026-01-01T00-00-00-000Z_${UUID_NEW}.jsonl`, [metaLine({ kind: 'tui' })], 200_000)
     const sessions = await listSessions({ sessionsDir: dir })
-    expect(sessions.map((s) => s.sessionId)).toEqual(['ses_new', 'ses_old'])
+    expect(sessions.map((s) => s.sessionId)).toEqual([UUID_NEW, UUID_OLD])
   })
 
   test('respects limit', async () => {
+    const ids: string[] = []
     for (let i = 0; i < 5; i++) {
-      await writeSession(`2026-05-22T0${i}-00-00-000Z_ses_${i}.jsonl`, [metaLine({ kind: 'tui' })], 1000 + i)
+      const id = `019e0000-0000-7000-9000-00000000000${i}`
+      ids.push(id)
+      await writeSession(`2026-05-22T0${i}-00-00-000Z_${id}.jsonl`, [metaLine({ kind: 'tui' })], 1000 + i)
     }
     const sessions = await listSessions({ sessionsDir: dir, limit: 2 })
     expect(sessions).toHaveLength(2)
-    expect(sessions.map((s) => s.sessionId)).toEqual(['ses_4', 'ses_3'])
+    expect(sessions.map((s) => s.sessionId)).toEqual([ids[4]!, ids[3]!])
   })
 
   test('sinceMs filters out older sessions', async () => {
-    await writeSession('a_ses_old.jsonl', [metaLine({ kind: 'tui' })], 1000)
-    await writeSession('b_ses_new.jsonl', [metaLine({ kind: 'tui' })], 2000)
+    await writeSession(`a_${UUID_OLD}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    await writeSession(`b_${UUID_NEW}.jsonl`, [metaLine({ kind: 'tui' })], 2000)
     const sessions = await listSessions({ sessionsDir: dir, sinceMs: 1500 * 1000 })
-    expect(sessions.map((s) => s.sessionId)).toEqual(['ses_new'])
+    expect(sessions.map((s) => s.sessionId)).toEqual([UUID_NEW])
   })
 
   test('skips non-jsonl entries and bad filenames with warnings', async () => {
     await writeFile(join(dir, 'random.txt'), 'not jsonl')
     await writeFile(join(dir, 'broken-name.jsonl'), '{}')
-    await writeSession('2026-05-22T00-00-00-000Z_ses_ok.jsonl', [metaLine({ kind: 'tui' })], 1000)
+    await writeSession(`2026-05-22T00-00-00-000Z_${UUID_A}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
     const warnings: string[] = []
     const sessions = await listSessions({ sessionsDir: dir, onWarn: (m) => warnings.push(m) })
-    expect(sessions.map((s) => s.sessionId)).toEqual(['ses_ok'])
+    expect(sessions.map((s) => s.sessionId)).toEqual([UUID_A])
     expect(warnings.some((w) => w.includes('broken-name.jsonl'))).toBe(true)
   })
 
   test('subagent system spawn with no user message → firstPrompt is null (renders as "system spawn" in selector)', async () => {
     await writeSession(
-      '2026-05-22T00-00-00-000Z_ses_sub.jsonl',
-      [metaLine({ kind: 'subagent', subagent: 'memory-logger', parentSessionId: 'ses_parent' })],
+      `2026-05-22T00-00-00-000Z_${UUID_A}.jsonl`,
+      [metaLine({ kind: 'subagent', subagent: 'memory-logger', parentSessionId: UUID_B })],
       1000,
     )
     const sessions = await listSessions({ sessionsDir: dir })
@@ -106,7 +111,7 @@ describe('listSessions', () => {
 
   test('channel origin with names preserved in summary', async () => {
     await writeSession(
-      '2026-05-22T00-00-00-000Z_ses_chan.jsonl',
+      `2026-05-22T00-00-00-000Z_${UUID_A}.jsonl`,
       [
         metaLine({
           kind: 'channel',
@@ -127,55 +132,76 @@ describe('listSessions', () => {
     expect(s.origin.workspaceName).toBe('Acme')
     expect(s.origin.chatName).toBe('general')
   })
+
+  test('regression: production filename from pi-coding-agent (no ses_ prefix) does not get skipped', async () => {
+    const basename = `2026-04-29T17-19-00-008Z_${UUID_A}.jsonl`
+    await writeSession(basename, [metaLine({ kind: 'tui' })], 1000)
+    const warnings: string[] = []
+    const sessions = await listSessions({ sessionsDir: dir, onWarn: (m) => warnings.push(m) })
+    expect(sessions).toHaveLength(1)
+    expect(warnings.filter((w) => w.includes('unexpected name'))).toEqual([])
+  })
+
+  test('rejects filename with empty session id (a__.jsonl)', async () => {
+    await writeFile(join(dir, 'a__.jsonl'), '{}')
+    const warnings: string[] = []
+    const sessions = await listSessions({ sessionsDir: dir, onWarn: (m) => warnings.push(m) })
+    expect(sessions).toEqual([])
+    expect(warnings.some((w) => w.includes('a__.jsonl'))).toBe(true)
+  })
 })
 
 describe('resolveSession', () => {
   test('exact session id match returns ok', async () => {
-    await writeSession('a_ses_abc123.jsonl', [metaLine({ kind: 'tui' })], 1000)
-    const out = await resolveSession(dir, 'ses_abc123')
+    await writeSession(`a_${UUID_A}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    const out = await resolveSession(dir, UUID_A)
     expect(out.ok).toBe(true)
     if (!out.ok) throw new Error('unreachable')
-    expect(out.summary.sessionId).toBe('ses_abc123')
+    expect(out.summary.sessionId).toBe(UUID_A)
   })
 
   test('unique short prefix resolves', async () => {
-    await writeSession('a_ses_abcdef.jsonl', [metaLine({ kind: 'tui' })], 1000)
-    await writeSession('b_ses_xyzxyz.jsonl', [metaLine({ kind: 'tui' })], 2000)
-    const out = await resolveSession(dir, 'ses_abcd')
+    const idA = '019dda40-4ba8-7472-9b06-e72b2b994be5'
+    const idB = '019e2c2e-a32e-7230-9f79-62ffe148fec1'
+    await writeSession(`a_${idA}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    await writeSession(`b_${idB}.jsonl`, [metaLine({ kind: 'tui' })], 2000)
+    const out = await resolveSession(dir, '019dda40')
     expect(out.ok).toBe(true)
     if (!out.ok) throw new Error('unreachable')
-    expect(out.summary.sessionId).toBe('ses_abcdef')
+    expect(out.summary.sessionId).toBe(idA)
   })
 
   test('ambiguous prefix surfaces all matches', async () => {
-    await writeSession('a_ses_abcd111.jsonl', [metaLine({ kind: 'tui' })], 1000)
-    await writeSession('b_ses_abcd222.jsonl', [metaLine({ kind: 'tui' })], 2000)
-    const out = await resolveSession(dir, 'ses_abcd')
+    const idA = '019dda40-aaaa-7000-9000-000000000001'
+    const idB = '019dda40-bbbb-7000-9000-000000000002'
+    await writeSession(`a_${idA}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    await writeSession(`b_${idB}.jsonl`, [metaLine({ kind: 'tui' })], 2000)
+    const out = await resolveSession(dir, '019dda40')
     expect(out.ok).toBe(false)
     if (out.ok) throw new Error('unreachable')
     expect(out.reason).toBe('ambiguous')
-    expect(out.matches.map((m) => m.sessionId).sort()).toEqual(['ses_abcd111', 'ses_abcd222'])
+    expect(out.matches.map((m) => m.sessionId).sort()).toEqual([idA, idB])
   })
 
   test('not found surfaces empty matches', async () => {
-    await writeSession('a_ses_abc.jsonl', [metaLine({ kind: 'tui' })], 1000)
-    const out = await resolveSession(dir, 'ses_notthere')
+    await writeSession(`a_${UUID_A}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    const out = await resolveSession(dir, 'deadbeef-0000-7000-9000-000000000000')
     expect(out.ok).toBe(false)
     if (out.ok) throw new Error('unreachable')
     expect(out.reason).toBe('not-found')
   })
 
-  test('prefix shorter than 4 chars after ses_ is rejected without scanning', async () => {
-    await writeSession('a_ses_abcdef.jsonl', [metaLine({ kind: 'tui' })], 1000)
-    const out = await resolveSession(dir, 'ses_a')
+  test('prefix shorter than 4 chars is rejected without scanning', async () => {
+    await writeSession(`a_${UUID_A}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    const out = await resolveSession(dir, '019')
     expect(out.ok).toBe(false)
     if (out.ok) throw new Error('unreachable')
     expect(out.reason).toBe('not-found')
   })
 
-  test('non-ses_ prefix is rejected as not-found (no accidental random-substring matches)', async () => {
-    await writeSession('a_ses_abcdef.jsonl', [metaLine({ kind: 'tui' })], 1000)
-    const out = await resolveSession(dir, 'abc')
+  test('prefix containing path separators is rejected (no path traversal)', async () => {
+    await writeSession(`a_${UUID_A}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    const out = await resolveSession(dir, '../etc')
     expect(out.ok).toBe(false)
     if (out.ok) throw new Error('unreachable')
     expect(out.reason).toBe('not-found')

--- a/src/inspect/session-list.ts
+++ b/src/inspect/session-list.ts
@@ -21,7 +21,11 @@ export type ListSessionsOptions = {
   onWarn?: (msg: string) => void
 }
 
-const FILENAME_PATTERN = /^.+_(ses_[A-Za-z0-9_-]+)\.jsonl$/
+// pi-coding-agent writes session files as `${ISO_TIMESTAMP}_${SESSION_ID}.jsonl`,
+// where SESSION_ID is a UUIDv7 by default (overridable via `SessionManager.create({ id })`).
+// The trailing token is the id; require it to be filesystem-safe (no `/`, `\`, or whitespace)
+// and start with a non-`_` character so `a__.jsonl` (empty id) doesn't slip through.
+const FILENAME_PATTERN = /^.+_([^_/\\\s][^/\\\s]*)\.jsonl$/
 
 export async function listSessions(opts: ListSessionsOptions): Promise<SessionSummary[]> {
   const entries = await readSessionFiles(opts.sessionsDir, opts.onWarn)
@@ -59,7 +63,7 @@ export type ResolveResult =
   | { ok: true; summary: SessionSummary }
   | { ok: false; reason: 'not-found' | 'ambiguous'; matches: SessionSummary[] }
 
-const MIN_PREFIX_LENGTH = 'ses_'.length + 4
+const MIN_PREFIX_LENGTH = 4
 
 export async function resolveSession(
   sessionsDir: string,
@@ -70,13 +74,19 @@ export async function resolveSession(
   const exact = all.find((s) => s.sessionId === sessionIdOrPrefix)
   if (exact !== undefined) return { ok: true, summary: exact }
 
-  if (!sessionIdOrPrefix.startsWith('ses_') || sessionIdOrPrefix.length < MIN_PREFIX_LENGTH) {
+  if (sessionIdOrPrefix.length < MIN_PREFIX_LENGTH || !isSessionIdShape(sessionIdOrPrefix)) {
     return { ok: false, reason: 'not-found', matches: [] }
   }
   const prefixMatches = all.filter((s) => s.sessionId.startsWith(sessionIdOrPrefix))
   if (prefixMatches.length === 0) return { ok: false, reason: 'not-found', matches: [] }
   if (prefixMatches.length === 1) return { ok: true, summary: prefixMatches[0]! }
   return { ok: false, reason: 'ambiguous', matches: prefixMatches }
+}
+
+const SESSION_ID_SHAPE = /^[^_/\\\s][^/\\\s]*$/
+
+export function isSessionIdShape(value: string): boolean {
+  return SESSION_ID_SHAPE.test(value)
 }
 
 async function readSessionFiles(


### PR DESCRIPTION
## What's broken

`typeclaw inspect` skips every real session file and exits with "No sessions found":

```
$ typeclaw inspect
skipping session file with unexpected name: 2026-04-29T17-19-00-008Z_019dda40-4ba8-7472-9b06-e72b2b994be5.jsonl
skipping session file with unexpected name: 2026-05-15T15-08-34-478Z_019e2c2e-a32e-7230-9f79-62ffe148fec1.jsonl
...
✖ No sessions found in /Users/.../sessions/.
```

## Root cause

`FILENAME_PATTERN` in `src/inspect/session-list.ts` required a `ses_` prefix on the trailing token:

```ts
const FILENAME_PATTERN = /^.+_(ses_[A-Za-z0-9_-]+)\.jsonl$/
//                            ^^^^ never matches reality
```

But the upstream library that owns the session file format — `@mariozechner/pi-coding-agent`'s `SessionManager.create()` — writes files as `${ISO_TIMESTAMP}_${UUIDv7}.jsonl`. The relevant line in `node_modules/@mariozechner/pi-coding-agent/dist/core/session-manager.js`:

```js
this.sessionFile = join(this.getSessionDir(), `${fileTimestamp}_${this.sessionId}.jsonl`)
```

where `this.sessionId = uuidv7()`. No `ses_` anywhere. The codebase already documents the actual format in `src/channels/persistence.ts:134` and `src/usage/aggregate.ts:139` — the inspect code just didn't match it.

The tests in `src/inspect/session-list.test.ts` used hand-crafted `ses_*` fixtures, which is why CI was green while production was 100% broken. PR #N (the inspect feature) shipped with the bug baked in from commit `47c14f7`.

## Fix

1. **`FILENAME_PATTERN`** in `session-list.ts` — drop the `ses_` requirement; keep a filesystem-safe shape check:

   ```ts
   const FILENAME_PATTERN = /^.+_([^_/\\\s][^/\\\s]*)\.jsonl$/
   ```

   The character classes still reject empty ids (`a__.jsonl`) and anything containing `/`, `\`, or whitespace.

2. **`resolveSession`** prefix gate — replaced the `ses_`-only check with the same shape predicate (`isSessionIdShape`, now exported). Minimum prefix length stays at 4 chars to keep typos like `019` from triggering a full-directory scan.

3. **`looksLikeSessionId`** in `src/inspect/index.ts` (gates `--json`'s "session id required" check) — switched from `value.startsWith('ses_')` to a length ≥ 8 + shape check.

## Tests

- Rewrote `session-list.test.ts` and `index.test.ts` fixtures to use realistic pi-coding-agent UUIDv7 ids (`019dda40-…`) instead of `ses_*`, so this drift is caught by CI next time.
- Added a regression test that seeds the **exact filename shape** reported in the bug:

  ```ts
  test('regression: production filename from pi-coding-agent (no ses_ prefix) does not get skipped', async () => {
    const basename = `2026-04-29T17-19-00-008Z_${UUID_A}.jsonl`
    await writeSession(basename, [metaLine({ kind: 'tui' })], 1000)
    const warnings: string[] = []
    const sessions = await listSessions({ sessionsDir: dir, onWarn: (m) => warnings.push(m) })
    expect(sessions).toHaveLength(1)
    expect(warnings.filter((w) => w.includes('unexpected name'))).toEqual([])
  })
  ```

- Added negative tests for empty-id filenames (`a__.jsonl`) and path-traversal prefixes (`../etc`) so the loosened regex doesn't quietly accept garbage.

## Verification

- `bun run typecheck` ✓
- `bun run lint` ✓ (only pre-existing warnings)
- `bun run format` ✓
- `bun test` ✓ — 4785 / 4785 pass

## Reviewer notes

- No runtime behavior changes outside `src/inspect/*`. The session-writing path (`src/sessions/index.ts`) is untouched — this PR aligns the reader to what the writer was already producing.
- The mutation-check (per `AGENTS.md` testing philosophy): commenting out the `FILENAME_PATTERN` change makes the new regression test fail. Commenting out the `resolveSession` shape gate change makes the new path-traversal test fail.