### PR TITLE
inspect: guard frameToEvent against non-frame server messages

### DIFF
--- a/src/inspect/live.test.ts
+++ b/src/inspect/live.test.ts
@@ -209,4 +209,88 @@ describe('streamLive — live session events', () => {
     expect(caught).toBeInstanceOf(Error)
     expect(String((caught as Error).message)).toContain('invalid')
   })
+
+  test('unknown server message types are ignored without crashing', async () => {
+    // Forward-compat: a future server may add new top-level message `type`
+    // values. The client must not crash when it sees one — especially since
+    // such a message will not carry the `payload` field that `frame` carries.
+    // Regression for: TypeError: undefined is not an object (evaluating 'payload.kind')
+    const FakeWS = makeFakeWebSocket([
+      { type: 'subscribed', sessionId: 'ses_a', sessionLive: true },
+      { type: 'future_unknown_kind', whatever: 'data' },
+      {
+        type: 'frame',
+        ts: 1,
+        payload: { kind: 'broadcast', payload: { ok: true } },
+      },
+    ])
+
+    const ctrl = new AbortController()
+    const gen = streamLive({
+      url: 'ws://unused',
+      sessionId: 'ses_a',
+      signal: ctrl.signal,
+      WebSocketImpl: FakeWS,
+    })
+
+    const events = await collectN(gen, 1)
+    ctrl.abort()
+    const ev = events[0]!
+    if (ev.cat !== 'broadcast') throw new Error('expected broadcast')
+    expect(ev.payload).toEqual({ ok: true })
+  })
 })
+
+// Hand-rolled fake WebSocket that delivers a scripted sequence of server
+// messages immediately after subscribe. Used to drive client-side branches
+// (unknown server `type` values, malformed frames) that real servers don't
+// produce in normal operation.
+function makeFakeWebSocket(scripted: unknown[]): typeof WebSocket {
+  class FakeWS {
+    readonly url: string
+    readyState = 0
+    private readonly listeners = new Map<string, Set<(e: unknown) => void>>()
+
+    constructor(url: string) {
+      this.url = url
+      queueMicrotask(() => {
+        this.readyState = 1
+        this.dispatch('open', {})
+      })
+    }
+
+    addEventListener(type: string, fn: (e: unknown) => void, _opts?: unknown): void {
+      let set = this.listeners.get(type)
+      if (set === undefined) {
+        set = new Set()
+        this.listeners.set(type, set)
+      }
+      set.add(fn)
+    }
+
+    removeEventListener(type: string, fn: (e: unknown) => void): void {
+      this.listeners.get(type)?.delete(fn)
+    }
+
+    send(_data: string): void {
+      // After the client subscribes, deliver the scripted messages.
+      for (const msg of scripted) {
+        queueMicrotask(() => {
+          this.dispatch('message', { data: JSON.stringify(msg) })
+        })
+      }
+    }
+
+    close(): void {
+      this.readyState = 3
+      queueMicrotask(() => this.dispatch('close', {}))
+    }
+
+    private dispatch(type: string, event: unknown): void {
+      const set = this.listeners.get(type)
+      if (set === undefined) return
+      for (const fn of set) fn(event)
+    }
+  }
+  return FakeWS as unknown as typeof WebSocket
+}

--- a/src/inspect/live.ts
+++ b/src/inspect/live.ts
@@ -54,6 +54,7 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
       wake()
       return
     }
+    if (msg.type !== 'frame') return
     const event = frameToEvent(msg.payload, msg.ts, accumulators)
     if (event !== null) {
       buffer.push(event)
@@ -171,6 +172,8 @@ function frameToEvent(
       }
     case 'cron-fire':
       return { cat: 'cron-fire', ts, jobId: payload.jobId, payload: payload.payload }
+    default:
+      return null
   }
 }
 


### PR DESCRIPTION
The `streamLive` client's WS `message` handler unconditionally called `frameToEvent(msg.payload, ...)` after handling `subscribed` and `error` types, which crashed with:

```
TypeError: undefined is not an object (evaluating 'payload.kind')
    at frameToEvent (src/inspect/live.ts:137:11)
    at <anonymous>  (src/inspect/live.ts:57:19)
```

whenever the server sent any message whose `type` was not `'frame'` — those messages don't carry a `payload` field, so the `switch (payload.kind)` access threw at runtime. This is a forward-compat hole: the TypeScript types narrowed `msg` to `frame` _structurally_ after the two early returns, but the runtime accepts whatever JSON the server sends, including future top-level kinds the client doesn't know about yet.

## Fix

Two small guards, both in `src/inspect/live.ts`:

1. **`msg.type !== 'frame'` early-return at the message handler** (line 57). The bug surface. Drops any non-`frame`/`subscribed`/`error` server message instead of crashing the generator.
2. **`default: return null` at `frameToEvent`'s inner switch** (line ~174). Defense in depth for the symmetric forward-compat case — a future `payload.kind` the client doesn't recognize is silently dropped instead of falling off the switch with `undefined` behavior.

## Test

Added one regression test: `unknown server message types are ignored without crashing`. It uses a hand-rolled fake `WebSocket` (`makeFakeWebSocket`) to script a three-message sequence — `subscribed` → unknown forward-compat type → real `frame` (broadcast) — and asserts the broadcast still surfaces. Mutation-verified: reverting just `src/inspect/live.ts` while keeping the test produces the exact stack trace from the bug report:

```
TypeError: undefined is not an object (evaluating 'payload.kind')
  at frameToEvent (.../src/inspect/live.ts:137:11)
  at <anonymous>  (.../src/inspect/live.ts:57:19)
```

The fake WS lives next to the test (not in a shared helper) because it's the only test in this file that needs to drive the message stream directly — every other test uses the real server.

## Diff size

3 lines of production code, +84 lines of test (the fake WS is most of it). Full diff:

- `src/inspect/live.ts` — 1 guard at message handler, 1 `default` arm at `frameToEvent` switch
- `src/inspect/live.test.ts` — 1 new test + `makeFakeWebSocket` helper

## Checks

- `bun run typecheck` ✓
- `bun run lint` ✓ (18 pre-existing warnings, 0 errors)
- `bun run format` ✓
- `bun test` ✓ — 4786 / 4786 pass
