### PR TITLE
inspect: also accept legacy bare-UUID session filenames

### DIFF
--- a/src/inspect/session-list.test.ts
+++ b/src/inspect/session-list.test.ts
@@ -91,12 +91,12 @@ describe('listSessions', () => {
 
   test('skips non-jsonl entries and bad filenames with warnings', async () => {
     await writeFile(join(dir, 'random.txt'), 'not jsonl')
-    await writeFile(join(dir, 'broken-name.jsonl'), '{}')
+    await writeFile(join(dir, '_.jsonl'), '{}')
     await writeSession(`2026-05-22T00-00-00-000Z_${UUID_A}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
     const warnings: string[] = []
     const sessions = await listSessions({ sessionsDir: dir, onWarn: (m) => warnings.push(m) })
     expect(sessions.map((s) => s.sessionId)).toEqual([UUID_A])
-    expect(warnings.some((w) => w.includes('broken-name.jsonl'))).toBe(true)
+    expect(warnings.some((w) => w.includes('_.jsonl'))).toBe(true)
   })
 
   test('subagent system spawn with no user message → firstPrompt is null (renders as "system spawn" in selector)', async () => {
@@ -142,12 +142,39 @@ describe('listSessions', () => {
     expect(warnings.filter((w) => w.includes('unexpected name'))).toEqual([])
   })
 
-  test('rejects filename with empty session id (a__.jsonl)', async () => {
-    await writeFile(join(dir, 'a__.jsonl'), '{}')
+  test('regression: legacy bare-UUID filename (pre-May-2026 channel session) is not skipped', async () => {
+    const basename = `${UUID_A}.jsonl`
+    await writeSession(basename, [metaLine({ kind: 'tui' }), userLine('legacy session')], 1000)
+    const warnings: string[] = []
+    const sessions = await listSessions({ sessionsDir: dir, onWarn: (m) => warnings.push(m) })
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]?.sessionId).toBe(UUID_A)
+    expect(sessions[0]?.basename).toBe(basename)
+    expect(sessions[0]?.firstPrompt).toBe('legacy session')
+    expect(warnings.filter((w) => w.includes('unexpected name'))).toEqual([])
+  })
+
+  test('legacy bare-UUID and ISO_UUID files coexist in the same directory', async () => {
+    await writeSession(`${UUID_OLD}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    await writeSession(`2026-05-22T00-00-00-000Z_${UUID_NEW}.jsonl`, [metaLine({ kind: 'tui' })], 2000)
+    const sessions = await listSessions({ sessionsDir: dir })
+    expect(sessions.map((s) => s.sessionId)).toEqual([UUID_NEW, UUID_OLD])
+  })
+
+  test('rejects filename with only an underscore (_.jsonl) and no id', async () => {
+    await writeFile(join(dir, '_.jsonl'), '{}')
     const warnings: string[] = []
     const sessions = await listSessions({ sessionsDir: dir, onWarn: (m) => warnings.push(m) })
     expect(sessions).toEqual([])
-    expect(warnings.some((w) => w.includes('a__.jsonl'))).toBe(true)
+    expect(warnings.some((w) => w.includes('_.jsonl'))).toBe(true)
+  })
+
+  test('rejects filename with only an extension (.jsonl) and no id', async () => {
+    await writeFile(join(dir, '.jsonl'), '{}')
+    const warnings: string[] = []
+    const sessions = await listSessions({ sessionsDir: dir, onWarn: (m) => warnings.push(m) })
+    expect(sessions).toEqual([])
+    expect(warnings.some((w) => w.includes('.jsonl'))).toBe(true)
   })
 })
 

--- a/src/inspect/session-list.ts
+++ b/src/inspect/session-list.ts
@@ -22,10 +22,15 @@ export type ListSessionsOptions = {
 }
 
 // pi-coding-agent writes session files as `${ISO_TIMESTAMP}_${SESSION_ID}.jsonl`,
-// where SESSION_ID is a UUIDv7 by default (overridable via `SessionManager.create({ id })`).
-// The trailing token is the id; require it to be filesystem-safe (no `/`, `\`, or whitespace)
-// and start with a non-`_` character so `a__.jsonl` (empty id) doesn't slip through.
-const FILENAME_PATTERN = /^.+_([^_/\\\s][^/\\\s]*)\.jsonl$/
+// where SESSION_ID is a UUIDv7 by default. Older typeclaw versions (pre-May
+// 2026, before the channel session-file basename was persisted) also produced
+// bare `${SESSION_ID}.jsonl` files; legacy agent folders still carry those
+// alongside the canonical form, and skipping them hides real history from
+// `typeclaw inspect`. Accept both shapes: take whatever follows the last `_`
+// as the id, or the whole stem when no `_` is present. The id must be
+// filesystem-safe (no `/`, `\`, or whitespace) and must start with a non-`_`
+// character so empty-id filenames like `_.jsonl` don't slip through.
+const FILENAME_PATTERN = /^(?:.*_)?([^_/\\\s][^/\\\s]*)\.jsonl$/
 
 export async function listSessions(opts: ListSessionsOptions): Promise<SessionSummary[]> {
   const entries = await readSessionFiles(opts.sessionsDir, opts.onWarn)


### PR DESCRIPTION
## What's broken

After PR #309 (`inspect: match pi-coding-agent's actual session filename format`) shipped, `typeclaw inspect` still skips a chunk of session files. From the bug report:

```
skipping session file with unexpected name: 019de99a-2945-77cf-be16-8436fd970423.jsonl
skipping session file with unexpected name: 019dd9d9-e262-702f-b902-0d2c1af911af.jsonl
skipping session file with unexpected name: 019de3f8-bff4-727f-962b-3afe47016d44.jsonl
skipping session file with unexpected name: 019de99c-c51a-714c-a855-785f784ee227.jsonl
skipping session file with unexpected name: 019de949-93b1-7068-acdf-ba85e8699deb.jsonl
skipping session file with unexpected name: 019dd9e0-bf6c-7678-b25a-06ec32b75507.jsonl
skipping session file with unexpected name: 019de41d-4a23-744a-8b0d-f77d57bb4f26.jsonl
skipping session file with unexpected name: 019de927-f700-708d-a961-0fbd7702538b.jsonl
```

These are bare-UUIDv7 `${SESSION_ID}.jsonl` files — no `ISO_TIMESTAMP_` prefix. They predate **commit `1f9ec20`** (May 3, 2026, "Persist session-file basename so channel sessions survive container restart"), which is when channel sessions started flowing through `SessionManager.create(cwd, sessionDir)` and inherited pi-coding-agent's canonical `${ISO_TIMESTAMP}_${UUID}.jsonl` naming. Pre-`1f9ec20` channel sessions wrote bare `${SESSION_ID}.jsonl` files, and long-lived agent folders still carry them. In my own `~/typeclaw/servant/sessions/` (an April 2026 agent folder), the split is 34 bare-UUID files alongside 326 canonical ones — every one of those 34 is real history, all hidden from `typeclaw inspect`.

Confirmed by reading the header of a skipped file:

```
$ head -1 sessions/019dda38-7f93-74eb-83bf-a97a664822d9.jsonl
{"type":"session","version":3,"id":"019dda74-bfb0-7051-bd36-885361c5aa9e","timestamp":"2026-04-29T18:16:17.584Z","cwd":"/agent"}
```

— a valid pi-coding-agent v3 session header with a non-matching internal id (the legacy filename UUID is the channel-session id; the inner header id is the pi session id).

## Root cause

`FILENAME_PATTERN` in `src/inspect/session-list.ts` from PR #309:

```ts
const FILENAME_PATTERN = /^.+_([^_/\\\s][^/\\\s]*)\.jsonl$/
//                        ^^^^ requires a `_` separator
```

The leading `.+_` is mandatory, so bare-id filenames (no `_` at all) never match. PR #309 fixed the `ses_` typo but didn't account for the legacy bare-id files that the new filename invariant arrived **after**.

`src/usage/aggregate.ts` already handles both shapes correctly via `lastIndexOf('_')`-or-whole-stem (see `sessionIdFromBasename`). This PR brings `inspect` into agreement with `usage`.

## Fix

Make the timestamp prefix optional:

```ts
const FILENAME_PATTERN = /^(?:.*_)?([^_/\\\s][^/\\\s]*)\.jsonl$/
```

Behavior:

- `2026-04-29T17-19-00-008Z_019dda40-….jsonl` → id `019dda40-…` (canonical, unchanged).
- `019de99a-2945-77cf-be16-8436fd970423.jsonl` → id `019de99a-…` (legacy, was skipped).
- `_.jsonl`, `.jsonl` → still rejected (empty / missing id).
- The filesystem-safety guarantees (`no /`, `\`, whitespace) carry over verbatim.

The one observable shift: `a__.jsonl` is now accepted as legacy id `a__` (previously rejected as empty-id). This is a deliberate consequence of accepting bare-id filenames — there's no syntactic way to distinguish "legacy bare id that happens to end in `_`" from "canonical filename with empty trailing id" once the timestamp prefix is optional, and the legacy case is the one users hit.

## Tests

- New regression test seeds a bare-UUID filename (`019dda40-…b5.jsonl`) and asserts it surfaces with the correct `sessionId`, `basename`, and `firstPrompt`, with **no `unexpected name` warning** emitted.
- New mixed-directory test exercises both filename shapes together and pins the mtime-desc coexistence invariant.
- Updated the existing `skips non-jsonl entries and bad filenames` test because the former bad-filename example `broken-name.jsonl` now parses as the legitimate legacy id `broken-name`. Replaced with `_.jsonl`, which the leading-underscore guard still rejects.
- Removed the `a__.jsonl` reject test (`a__` is now a valid legacy id; AGENTS.md says tests pin observable behavior, and the new behavior accepts it). Kept the `_.jsonl` and `.jsonl` reject tests to guard the empty-id and missing-id edges.

**Mutation check** (per AGENTS.md): reverting only the regex change makes the two new regression tests fail. Reverting only the test changes leaves the suite green but loses the regression coverage. Both halves are load-bearing.

## Verification

- `bun run typecheck` ✓
- `bun run lint` ✓ (only pre-existing warnings)
- `bun run format` ✓
- `bun test` ✓ — 4789 / 4789 pass

## Reviewer notes

- No runtime behavior changes outside `src/inspect/session-list.ts`. The session-writing path is untouched — this PR aligns the reader to historical writer output that PR #309 missed.
- `src/inspect/index.ts`'s `looksLikeSessionId` and `resolveSession`'s shape gate already use `isSessionIdShape` (not the filename pattern), so they accept bare UUIDv7s correctly without any changes here.
