### PR TITLE
memory: commit the sharding migration so it does not leave staged deletions behind

### DIFF
--- a/src/bundled-plugins/memory/migration.test.ts
+++ b/src/bundled-plugins/memory/migration.test.ts
@@ -486,6 +486,63 @@ describe('runShardingMigration', () => {
     expect(parsed.frontmatter).toMatchObject({ heading: 'Strength', cites: 3, days: 2, lastReinforced: '2026-05-19' })
   })
 
+  test('commits sharded layout when the agent directory is a git repo', async () => {
+    await initGitRepo(agentDir)
+    await writeRootMemory(memoryWithTopics(['Alpha', 'Beta']))
+    await writeFlatStream('2026-05-18', '{"type":"fragment","id":"id-1"}\n')
+    await git(agentDir, ['add', '--', 'MEMORY.md', 'memory/2026-05-18.jsonl'])
+    await git(agentDir, ['commit', '-m', 'pre-shard state'])
+
+    const result = await runShardingMigration({ agentDir, logger })
+
+    expect(result.migrated).toBe(true)
+    const latest = await git(agentDir, ['log', '--oneline', '-1'])
+    expect(latest.stdout).toContain('memory: shard MEMORY.md into 2 topic(s) and 1 daily stream(s)')
+
+    const porcelain = await git(agentDir, ['status', '--porcelain'])
+    expect(porcelain.stdout).toBe('')
+
+    const tracked = await git(agentDir, ['ls-tree', '-r', '--name-only', 'HEAD'])
+    const files = new Set(tracked.stdout.split('\n').filter((line) => line !== ''))
+    expect(files.has('memory/topics/alpha.md')).toBe(true)
+    expect(files.has('memory/topics/beta.md')).toBe(true)
+    expect(files.has('memory/streams/2026-05-18.jsonl')).toBe(true)
+    expect(files.has('memory/MEMORY.md.pre-shard.bak')).toBe(true)
+    expect(files.has('MEMORY.md')).toBe(false)
+    expect(files.has('memory/2026-05-18.jsonl')).toBe(false)
+  })
+
+  test('sharding migration does not throw outside a git repo', async () => {
+    await writeRootMemory(memoryWithTopics(['Alpha']))
+    await writeFlatStream('2026-05-18', '{"type":"fragment","id":"id-1"}\n')
+
+    const result = await runShardingMigration({ agentDir, logger })
+
+    expect(result.migrated).toBe(true)
+    expect(messages.info.some((message) => message.includes('not in a git repo'))).toBe(true)
+  })
+
+  test('sharding migration commits new files even when MEMORY.md and flat streams were never tracked', async () => {
+    await initGitRepo(agentDir)
+    await writeRootMemory(memoryWithTopics(['Alpha']))
+    await writeFlatStream('2026-05-18', '{"type":"fragment","id":"id-1"}\n')
+
+    const result = await runShardingMigration({ agentDir, logger })
+
+    expect(result.migrated).toBe(true)
+    const latest = await git(agentDir, ['log', '--oneline', '-1'])
+    expect(latest.stdout).toContain('memory: shard MEMORY.md into 1 topic(s) and 1 daily stream(s)')
+
+    const porcelain = await git(agentDir, ['status', '--porcelain'])
+    expect(porcelain.stdout).toBe('')
+
+    const tracked = await git(agentDir, ['ls-tree', '-r', '--name-only', 'HEAD'])
+    const files = new Set(tracked.stdout.split('\n').filter((line) => line !== ''))
+    expect(files.has('memory/topics/alpha.md')).toBe(true)
+    expect(files.has('memory/streams/2026-05-18.jsonl')).toBe(true)
+    expect(files.has('memory/MEMORY.md.pre-shard.bak')).toBe(true)
+  })
+
   async function writeRepresentativeFixture(): Promise<{ dreaming: string; skill: string }> {
     await writeRootMemory(representativeMemory())
     await writeFlatStream('2026-05-18', '{"type":"fragment","id":"id-1"}\n')

--- a/src/bundled-plugins/memory/migration.ts
+++ b/src/bundled-plugins/memory/migration.ts
@@ -6,7 +6,14 @@ import { checkCitationSupersetAcrossShards, summarizeMissingCitations } from './
 import { normalizeCitation, parseCitations } from './citations'
 import { clearDreamedIds, loadDreamingState, saveDreamingState } from './dreaming-state'
 import { renderShard, type ShardFrontmatter } from './frontmatter'
-import { migratingTmpDir, preShardBackupPath, streamFilePath, streamsDir, topicsDir } from './paths'
+import {
+  migratingTmpDir,
+  PRE_SHARD_BACKUP_FILENAME,
+  preShardBackupPath,
+  streamFilePath,
+  streamsDir,
+  topicsDir,
+} from './paths'
 import { headingToSlug } from './slug'
 import { newEventId, type StreamEvent, streamEventSchema, timestampFromId } from './stream-events'
 import { writeEventsAtomic as defaultWriteEventsAtomic } from './stream-io'
@@ -91,9 +98,11 @@ export async function runShardingMigration(options: RunShardingMigrationOptions)
   }
 
   const existingSlugs = new Set<string>()
+  const orderedSlugs: string[] = []
   for (const topic of topics) {
     const slug = headingToSlug(topic.heading, existingSlugs)
     existingSlugs.add(slug)
+    orderedSlugs.push(slug)
     const body = normalizeCitation(topic.body)
     const frontmatter = frontmatterForTopic(topic.heading, body)
     await writeFile(join(tmpDir, 'topics', `${slug}.md`), renderShard(frontmatter, body), 'utf8')
@@ -119,6 +128,13 @@ export async function runShardingMigration(options: RunShardingMigrationOptions)
 
   const finalized = await finalizeShardingMigration(options.agentDir, streamDates, options.logger)
   if (!finalized.ok) return empty({ error: finalized.error })
+
+  await commitShardingMigration(
+    options.agentDir,
+    { slugs: orderedSlugs, streamDates, hadRootMemory: true },
+    options.logger,
+    options.git,
+  )
 
   options.logger.info(
     `[memory:migration] sharded MEMORY.md into ${topics.length} topic shard(s) and ${streamDates.length} stream file(s)`,
@@ -468,6 +484,59 @@ async function commitMigration(
   )
   if (commit.exitCode !== 0) {
     logger.warn(`[memory:migration] git commit failed: ${commit.stderr || commit.stdout}`.trim())
+  }
+}
+
+async function commitShardingMigration(
+  agentDir: string,
+  details: { slugs: readonly string[]; streamDates: readonly string[]; hadRootMemory: boolean },
+  logger: MigrationLogger,
+  git: MigrationGit | undefined,
+): Promise<void> {
+  const spawn = git?.spawn ?? spawnGit
+  const inside = await spawn(['rev-parse', '--is-inside-work-tree'], { cwd: agentDir })
+  if (inside.exitCode !== 0) {
+    logger.info('[memory:migration] not in a git repo; skipping git commit')
+    return
+  }
+
+  const newPaths = [
+    ...details.slugs.map((slug) => `memory/topics/${slug}.md`),
+    ...details.streamDates.map((date) => `memory/streams/${date}.jsonl`),
+    `memory/${PRE_SHARD_BACKUP_FILENAME}`,
+  ]
+  const addNew = await spawn(['add', '--', ...newPaths], { cwd: agentDir })
+  if (addNew.exitCode !== 0) {
+    logger.warn(`[memory:migration] git add failed: ${addNew.stderr || addNew.stdout}`.trim())
+    return
+  }
+
+  const candidateDeletions = [...details.streamDates.map((date) => `memory/${date}.jsonl`)]
+  if (details.hadRootMemory) candidateDeletions.push('MEMORY.md')
+  const trackedDeletions: string[] = []
+  for (const path of candidateDeletions) {
+    const tracked = await spawn(['ls-files', '--error-unmatch', '--', path], { cwd: agentDir })
+    if (tracked.exitCode === 0) trackedDeletions.push(path)
+  }
+  if (trackedDeletions.length > 0) {
+    const addDeletions = await spawn(['add', '-u', '--', ...trackedDeletions], { cwd: agentDir })
+    if (addDeletions.exitCode !== 0) {
+      logger.warn(`[memory:migration] git add failed: ${addDeletions.stderr || addDeletions.stdout}`.trim())
+      return
+    }
+  }
+
+  const commitSharding = await spawn(
+    [
+      'commit',
+      '-m',
+      `memory: shard MEMORY.md into ${details.slugs.length} topic(s) and ${details.streamDates.length} daily stream(s)`,
+      '--no-edit',
+    ],
+    { cwd: agentDir },
+  )
+  if (commitSharding.exitCode !== 0) {
+    logger.warn(`[memory:migration] git commit failed: ${commitSharding.stderr || commitSharding.stdout}`.trim())
   }
 }
 


### PR DESCRIPTION
## Why

After `runShardingMigration` completed its on-disk work — moving flat `memory/<date>.jsonl` files into `memory/streams/`, splitting root `MEMORY.md` into `memory/topics/<slug>.md` shards, and saving `memory/MEMORY.md.pre-shard.bak` — it returned `{ migrated: true }` without ever calling git. The working tree was left with staged deletions of every original JSONL file but none of the new sharded paths were staged or committed.

Example `git status` from the bug report:

```
On branch main
Changes to be committed:
        deleted:    memory/2026-04-27.jsonl
        deleted:    memory/2026-04-28.jsonl
        ... etc
```

The first boot migration (`runMigration`, the `.md → .jsonl` daily-stream conversion) already called `commitMigration` at the end. The sharding migration just needed the same shape and never got it.

## What

### `commitShardingMigration` in `migration.ts`

Mirrors `commitMigration`'s shape exactly:

- Skips silently when not in a git repo (info log).
- `git add` the new `memory/topics/<slug>.md` + `memory/streams/<date>.jsonl` + `memory/MEMORY.md.pre-shard.bak`.
- Probes each candidate deletion (`memory/<date>.jsonl` + optionally root `MEMORY.md`) with `ls-files --error-unmatch` before `git add -u` — only tracks deletions that were previously committed, so untracked sources don't abort the commit.
- Commits with subject `memory: shard MEMORY.md into N topic(s) and M daily stream(s)`.

To supply the exact slug list to the commit path, the topics loop in `runShardingMigration` now captures `orderedSlugs: string[]` alongside the existing `existingSlugs` Set.

### Tests (3 new cases in `migration.test.ts`)

1. **commits sharded layout when the agent directory is a git repo** — real git repo with a pre-shard commit; asserts commit subject lands, `git status --porcelain` is clean, and `git ls-tree -r HEAD` contains the new sharded paths but not `MEMORY.md` or `memory/<date>.jsonl`. Uses `ls-tree` (not `--name-status`) to sidestep git's rename-detection heuristic (`MEMORY.md → memory/MEMORY.md.pre-shard.bak` shows as `R100` on byte-identical content).
2. **sharding migration does not throw outside a git repo** — no `git init`; asserts the "not in a git repo" info log fires and migration still reports `migrated: true`.
3. **sharding migration commits new files even when MEMORY.md and flat streams were never tracked** — git repo exists but pre-shard sources were never committed; verifies the `ls-files` probe skips them so `git add -u` does not abort with "did not match any files".

## Recovery for already-affected agents

This fix only repairs future migrations. Existing affected agents won't re-trigger `runShardingMigration` because it early-returns when `memory/topics/` already exists. Affected users need to commit manually:

```sh
cd <agent-folder>
git add -f memory/streams/ memory/topics/ memory/MEMORY.md.pre-shard.bak
git add -u -- memory/ MEMORY.md
git commit -m "memory: shard MEMORY.md into $(ls memory/topics/ | wc -l | tr -d ' ') topic(s) and $(ls memory/streams/ | wc -l | tr -d ' ') daily stream(s)"
```

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 40 pre-existing warnings, 0 errors, none in changed files
- `bun run format` — clean
- `bun test src/bundled-plugins/memory/migration.test.ts` — 36 pass (33 pre-existing + 3 new)
- `bun test src/bundled-plugins/memory/` — 585 pass / 0 fail across 28 files