### PR TITLE
init: mark GPT-5.4 mini and Claude Sonnet 4.6 as recommended in model picker

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -3,7 +3,14 @@ import { describe, expect, mock, test } from 'bun:test'
 import { KNOWN_PROVIDERS, supportsApiKey, supportsOAuth, type KnownProviderId } from '@/config/providers'
 import type { ModelOption } from '@/init/models-dev'
 
-import { collectWizardInputs, decideExistingApiKeyReuse, WizardAbortedError, type WizardPrompts } from './init'
+import {
+  collectWizardInputs,
+  decideExistingApiKeyReuse,
+  formatModelLabel,
+  sortRecommendedFirst,
+  WizardAbortedError,
+  type WizardPrompts,
+} from './init'
 
 describe('decideExistingApiKeyReuse', () => {
   test('reuses an existing API key when the user confirms', async () => {
@@ -1170,5 +1177,72 @@ describe('collectWizardInputs back-aware flow', () => {
 
     expect(apiKeyAvailableSeen).toBe(true)
     expect(result.llmAuth).toEqual({ kind: 'api-key', apiKey: 'sk-ant-recovered' })
+  })
+})
+
+describe('recommended models', () => {
+  function model(ref: ModelOption['ref'], overrides: Partial<ModelOption> = {}): ModelOption {
+    const slash = ref.indexOf('/')
+    const providerId = ref.slice(0, slash) as ModelOption['providerId']
+    const modelId = ref.slice(slash + 1)
+    return {
+      ref,
+      providerId,
+      providerName: providerId,
+      modelId,
+      modelName: modelId,
+      reasoning: false,
+      contextWindow: null,
+      curated: true,
+      supportsVision: false,
+      ...overrides,
+    }
+  }
+
+  test('formatModelLabel marks gpt-5.4-mini under openai as Recommended', () => {
+    const o = model('openai/gpt-5.4-mini', { modelName: 'GPT-5.4 mini' })
+    expect(formatModelLabel(o)).toBe('GPT-5.4 mini (Recommended)')
+  })
+
+  test('formatModelLabel marks gpt-5.4-mini under openai-codex as Recommended', () => {
+    const o = model('openai-codex/gpt-5.4-mini', { modelName: 'GPT-5.4 mini' })
+    expect(formatModelLabel(o)).toBe('GPT-5.4 mini (Recommended)')
+  })
+
+  test('formatModelLabel marks claude-sonnet-4-6 as Recommended', () => {
+    const o = model('anthropic/claude-sonnet-4-6', { modelName: 'Claude Sonnet 4.6' })
+    expect(formatModelLabel(o)).toBe('Claude Sonnet 4.6 (Recommended)')
+  })
+
+  test('formatModelLabel leaves non-recommended models unchanged', () => {
+    const o = model('openai/gpt-5.4', { modelName: 'GPT-5.4' })
+    expect(formatModelLabel(o)).toBe('GPT-5.4')
+  })
+
+  test('sortRecommendedFirst floats the recommended OpenAI model to the top', () => {
+    const nano = model('openai/gpt-5.4-nano', { modelName: 'GPT-5.4 nano' })
+    const mini = model('openai/gpt-5.4-mini', { modelName: 'GPT-5.4 mini' })
+    const full = model('openai/gpt-5.4', { modelName: 'GPT-5.4' })
+    const sorted = sortRecommendedFirst([nano, mini, full])
+    expect(sorted.map((o) => o.ref)).toEqual(['openai/gpt-5.4-mini', 'openai/gpt-5.4-nano', 'openai/gpt-5.4'])
+  })
+
+  test('sortRecommendedFirst floats the recommended Anthropic model to the top', () => {
+    const haiku = model('anthropic/claude-haiku-4-5', { modelName: 'Claude Haiku 4.5' })
+    const sonnet = model('anthropic/claude-sonnet-4-6', { modelName: 'Claude Sonnet 4.6' })
+    const opus = model('anthropic/claude-opus-4-7', { modelName: 'Claude Opus 4.7' })
+    const sorted = sortRecommendedFirst([haiku, sonnet, opus])
+    expect(sorted.map((o) => o.ref)).toEqual([
+      'anthropic/claude-sonnet-4-6',
+      'anthropic/claude-haiku-4-5',
+      'anthropic/claude-opus-4-7',
+    ])
+  })
+
+  test('sortRecommendedFirst preserves order when no model is recommended', () => {
+    const a = model('openai/gpt-5.4-nano')
+    const b = model('openai/gpt-5.4')
+    const sorted = sortRecommendedFirst([a, b])
+    expect(sorted.map((o) => o.ref)).toEqual(['openai/gpt-5.4-nano', 'openai/gpt-5.4'])
   })
 })

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -771,12 +771,12 @@ async function pickModelForProvider(
   providerId: KnownProviderId,
   initial: KnownModelRef | undefined,
 ): Promise<StepResult<ModelOption>> {
-  const candidates = options.filter((o) => o.providerId === providerId)
+  const candidates = sortRecommendedFirst(options.filter((o) => o.providerId === providerId))
   const choice = await select<KnownModelRef>({
     message: `Pick a ${KNOWN_PROVIDERS[providerId].name} model`,
     options: candidates.map((o) => ({
       value: o.ref,
-      label: o.modelName,
+      label: formatModelLabel(o),
       hint: formatModelHint(o),
     })),
     initialValue: initial ?? candidates[0]?.ref,
@@ -863,12 +863,12 @@ async function pickVisionModel(
   providerId: KnownProviderId,
   initial: KnownModelRef | undefined,
 ): Promise<StepResult<ModelOption>> {
-  const candidates = options.filter((o) => o.providerId === providerId)
+  const candidates = sortRecommendedFirst(options.filter((o) => o.providerId === providerId))
   const choice = await select<KnownModelRef>({
     message: `Pick a vision-capable ${KNOWN_PROVIDERS[providerId].name} model`,
     options: candidates.map((o) => ({
       value: o.ref,
-      label: o.modelName,
+      label: formatModelLabel(o),
       hint: formatModelHint(o),
     })),
     initialValue: initial ?? candidates[0]?.ref,
@@ -1369,6 +1369,30 @@ function uniqueProviders(options: ModelOption[]): KnownProviderId[] {
     out.push(o.providerId)
   }
   return out
+}
+
+// Per-provider recommended model refs. Surfaces a "(Recommended)" suffix in
+// the picker label and floats the entry to the top of the list (which also
+// makes it the default `initialValue` when the caller has no prior choice).
+// Kept narrow on purpose: one recommendation per provider. gpt-5.4-mini is
+// listed under both `openai` and `openai-codex` because the same model is
+// the right default whether the user authenticates with an API key or with
+// a ChatGPT Plus/Pro subscription. claude-sonnet-4-6 follows Anthropic's
+// own current-tier guidance (see the model lineup notes in providers.ts).
+const RECOMMENDED_MODEL_REFS: ReadonlySet<KnownModelRef> = new Set<KnownModelRef>([
+  'openai/gpt-5.4-mini',
+  'openai-codex/gpt-5.4-mini',
+  'anthropic/claude-sonnet-4-6',
+])
+
+export function formatModelLabel(o: ModelOption): string {
+  return RECOMMENDED_MODEL_REFS.has(o.ref) ? `${o.modelName} (Recommended)` : o.modelName
+}
+
+export function sortRecommendedFirst(options: ModelOption[]): ModelOption[] {
+  const recommended = options.filter((o) => RECOMMENDED_MODEL_REFS.has(o.ref))
+  const rest = options.filter((o) => !RECOMMENDED_MODEL_REFS.has(o.ref))
+  return [...recommended, ...rest]
 }
 
 function formatModelHint(o: ModelOption): string {


### PR DESCRIPTION
## Why

The `typeclaw init` model picker presents every available model in a flat list with no signal about where to start. New users without strong opinions stall on a trivia question, or pick conservatively (smallest/cheapest) when there is a well-understood "right now this is the best price/performance option" answer per provider.

Surfacing a single recommendation per provider removes the stall without removing choice.

## What

- **RECOMMENDED_MODEL_REFS** — a `ReadonlySet<KnownModelRef>` with three entries: `openai/gpt-5.4-mini`, `openai-codex/gpt-5.4-mini`, `anthropic/claude-sonnet-4-6`. The set is the single place to update when recommendations change.
- **formatModelLabel** — appends ` (Recommended)` to a model's display name when its ref is in the set; returns `modelName` unchanged otherwise.
- **sortRecommendedFirst** — stable partition: recommended entries first, rest in original order. The sorted slice becomes the `candidates` array in both `pickModelForProvider` and `pickVisionModel`, so the recommended model floats to the top and becomes the default `initialValue` when no prior selection exists.
- `gpt-5.4-mini` is recommended under both `openai` and `openai-codex` because the model is the same regardless of auth path (API key vs ChatGPT Plus/Pro subscription).
- `claude-sonnet-4-6` follows Anthropic's own current-tier guidance, already documented above the `anthropic` entry in `src/config/providers.ts`.

## Tests

7 new unit tests in `src/cli/init.test.ts` covering `formatModelLabel` and `sortRecommendedFirst`:

- Label marked for each of the three recommended refs.
- Label unchanged for a non-recommended ref.
- Recommended model floats to top for OpenAI and Anthropic lists.
- Order preserved when no model in the list is recommended.

## Verification

- `bun run typecheck` ✓
- `bun run lint` ✓ (0 errors)
- `bun run format` ✓
- `bun test` ✓ — 5141 pass / 0 fail