### PR TITLE
memory + agent: restore pre-#314 session cold-start latency

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -330,6 +330,56 @@ describe('createResourceLoader', () => {
     expect(promptSeenByHook).not.toContain('attacker-controlled-marker')
   })
 
+  test('does not surface an unhandled rejection when loadMemory throws non-ENOENT during a slow plugin hook', async () => {
+    // Regression test for the parallelization shape introduced in PR #318.
+    // gitNudge and memory promises are kicked off concurrently with loadSelf
+    // and the plugin hook. Without the settle() wrap, a non-ENOENT rejection
+    // (e.g. EISDIR from a directory masquerading as a shard) on the early-
+    // started memoryPromise would fire as `unhandledRejection` during the
+    // window between selfPromise resolving and the gather Promise.all -- a
+    // slow plugin hook widens that window arbitrarily.
+
+    // EISDIR trigger: place a directory at the path readFile expects to be
+    // a file. loadAllShards iterates memory/topics/*.md slugs, then
+    // readFile(<slug>.md). A directory at that path makes readFile reject
+    // with EISDIR (a non-ENOENT fs error).
+    await mkdir(join(agentDir, 'memory', 'topics', 'malformed.md'), { recursive: true })
+
+    const { createHookBus } = await import('@/plugin')
+    const { emptyRegistry } = await import('@/plugin/registry')
+    const hooks = createHookBus()
+    hooks.registerAll(
+      'slow-hook',
+      agentDir,
+      { info: () => {}, warn: () => {}, error: () => {} },
+      {
+        'session.prompt': async () => {
+          await new Promise((resolve) => setTimeout(resolve, 30))
+        },
+      },
+    )
+
+    const seen: unknown[] = []
+    const onUnhandled = (err: unknown) => seen.push(err)
+    process.on('unhandledRejection', onUnhandled)
+
+    try {
+      await expect(
+        createResourceLoader({
+          agentDir,
+          plugins: { registry: emptyRegistry(), hooks, sessionId: 'ses_test', agentDir },
+        }),
+      ).rejects.toThrow()
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+
+    // The error must propagate through the gather point, not as a detached
+    // unhandled rejection. Allow one microtask tick to settle.
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    expect(seen).toEqual([])
+  })
+
   test('exposes the typeclaw-cron bundled skill to the agent', async () => {
     const loader = await createResourceLoader({ agentDir })
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -765,7 +765,22 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   const agentDir = options.agentDir ?? process.cwd()
   const mode: SystemPromptMode = options.mode ?? deriveSystemPromptMode(options.origin)
   const basePrompt = mode === 'slim' ? SLIM_SYSTEM_PROMPT : DEFAULT_SYSTEM_PROMPT
-  let self = await loadSelf(agentDir)
+
+  // Kick off the three independent I/O paths concurrently. Sequential awaits
+  // here used to be the dominant cold-start cost amplifier: loadSelf is 2
+  // file reads, renderGitNudge spawns a subprocess, loadMemory reads N topic
+  // shards. None of them depend on each other, so we run them in parallel.
+  // The plugin hook (runSessionPrompt) only needs `self`, so it can overlap
+  // with the gitNudge subprocess and the shard reads while `self` is in
+  // flight too.
+  const selfPromise = loadSelf(agentDir)
+  const gitNudgePromise = mode === 'slim' ? Promise.resolve('') : renderGitNudge(agentDir)
+  const memoryPromise = loadMemory(agentDir, {
+    ...(options.origin !== undefined ? { origin: options.origin } : {}),
+    ...(options.plugins?.sessionId !== undefined ? { currentSessionId: options.plugins.sessionId } : {}),
+  })
+
+  let self = await selfPromise
 
   if (options.plugins) {
     // The plugin hook receives the partially-assembled prompt (base + identity)
@@ -788,11 +803,7 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   // commit guidance the nudge points back to is itself excluded from the slim
   // base prompt. Memory is still included so cron jobs that depend on MEMORY.md
   // context (e.g. "send today's standup summary") keep working.
-  const gitNudge = mode === 'slim' ? '' : await renderGitNudge(agentDir)
-  const memorySection = await loadMemory(agentDir, {
-    ...(options.origin !== undefined ? { origin: options.origin } : {}),
-    ...(options.plugins?.sessionId !== undefined ? { currentSessionId: options.plugins.sessionId } : {}),
-  })
+  const [gitNudge, memorySection] = await Promise.all([gitNudgePromise, memoryPromise])
 
   const systemPrompt = composeSystemPrompt({
     mode,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -773,12 +773,30 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   // The plugin hook (runSessionPrompt) only needs `self`, so it can overlap
   // with the gitNudge subprocess and the shard reads while `self` is in
   // flight too.
+  //
+  // Plugin-hook contract: `runSessionPrompt` runs AFTER gitNudge/memory I/O
+  // has been kicked off. A hook that mutates `memory/topics/` or git-tracked
+  // files during its body races those in-flight reads -- mutations may or
+  // may not be reflected in the resulting prompt. The bundled hooks only
+  // mutate the prompt string itself; third-party plugins that need to mutate
+  // disk before the suffix sections see it must do so before/outside the
+  // session-prompt hook.
+  //
+  // We wrap gitNudge and memory promises in `settled` shells so any
+  // rejection from them cannot surface as an unhandled rejection during the
+  // window where we're awaiting selfPromise + runSessionPrompt. Production
+  // callers don't reject (renderGitNudge swallows internally, loadMemory
+  // catches ENOENT) but a non-ENOENT fs error (EACCES/EIO) on the agent
+  // folder would otherwise terminate the process before we reach the
+  // gather point.
   const selfPromise = loadSelf(agentDir)
-  const gitNudgePromise = mode === 'slim' ? Promise.resolve('') : renderGitNudge(agentDir)
-  const memoryPromise = loadMemory(agentDir, {
-    ...(options.origin !== undefined ? { origin: options.origin } : {}),
-    ...(options.plugins?.sessionId !== undefined ? { currentSessionId: options.plugins.sessionId } : {}),
-  })
+  const gitNudgeSettled = mode === 'slim' ? Promise.resolve(ok('')) : settle(renderGitNudge(agentDir))
+  const memorySettled = settle(
+    loadMemory(agentDir, {
+      ...(options.origin !== undefined ? { origin: options.origin } : {}),
+      ...(options.plugins?.sessionId !== undefined ? { currentSessionId: options.plugins.sessionId } : {}),
+    }),
+  )
 
   let self = await selfPromise
 
@@ -803,7 +821,9 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   // commit guidance the nudge points back to is itself excluded from the slim
   // base prompt. Memory is still included so cron jobs that depend on MEMORY.md
   // context (e.g. "send today's standup summary") keep working.
-  const [gitNudge, memorySection] = await Promise.all([gitNudgePromise, memoryPromise])
+  const [gitNudgeResult, memoryResult] = await Promise.all([gitNudgeSettled, memorySettled])
+  const gitNudge = unwrapSettled(gitNudgeResult)
+  const memorySection = unwrapSettled(memoryResult)
 
   const systemPrompt = composeSystemPrompt({
     mode,
@@ -882,4 +902,22 @@ function resolveRoleContext(
 
 export function getBundledSkillsDir(): string {
   return join(dirname(fileURLToPath(import.meta.url)), '..', 'skills')
+}
+
+type Settled<T> = { ok: true; value: T } | { ok: false; error: unknown }
+
+function ok<T>(value: T): Settled<T> {
+  return { ok: true, value }
+}
+
+function settle<T>(promise: Promise<T>): Promise<Settled<T>> {
+  return promise.then(
+    (value): Settled<T> => ({ ok: true, value }),
+    (error: unknown): Settled<T> => ({ ok: false, error }),
+  )
+}
+
+function unwrapSettled<T>(result: Settled<T>): T {
+  if (result.ok) return result.value
+  throw result.error
 }

--- a/src/bundled-plugins/memory/load-shards.test.ts
+++ b/src/bundled-plugins/memory/load-shards.test.ts
@@ -1,15 +1,20 @@
-import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, mkdir, rm, unlink, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { loadAllShards, loadShard, listShardSlugs } from './load-shards'
+import { __resetShardCacheForTests, loadAllShards, loadShard, listShardSlugs } from './load-shards'
 import { topicShardPath, topicsDir } from './paths'
 
 const tmpRoots: string[] = []
 
+beforeEach(() => {
+  __resetShardCacheForTests()
+})
+
 afterEach(async () => {
   await Promise.all(tmpRoots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+  __resetShardCacheForTests()
 })
 
 describe('loadAllShards', () => {
@@ -123,6 +128,132 @@ describe('listShardSlugs', () => {
 
     await expect(listShardSlugs(agentDir)).resolves.toEqual(['apple'])
     await expect(loadAllShards(agentDir)).resolves.toHaveLength(1)
+  })
+})
+
+describe('loadAllShards shard cache', () => {
+  test('serves cached shard when mtime + size are unchanged (proves the readFile fast path)', async () => {
+    const agentDir = await makeAgentDir()
+    await writeShard(agentDir, 'alpha', 'Alpha', 'v1-body\n')
+    const path = topicShardPath(agentDir, 'alpha')
+
+    // Pin both atime and mtime to an integer-second value before priming the
+    // cache. utimes() on macOS HFS+/APFS truncates the fractional ms portion,
+    // so reading-back-and-restoring is NOT a round-trip — the first stat
+    // returns sub-ms precision but the post-utimes stat returns integer ms.
+    // Pinning to an integer-second value up front makes the round-trip
+    // mtime-stable and lets us actually exercise the cache-hit path.
+    const pinnedTime = new Date(1779000000000)
+    await utimes(path, pinnedTime, pinnedTime)
+
+    const first = await loadAllShards(agentDir)
+    expect(first[0]?.body).toBe('v1-body\n')
+
+    // Overwrite with same-length bytes, then re-pin mtime to the same value.
+    // The cache invalidation key (mtimeMs + size) is now unchanged. If the
+    // cache is honored, the next call returns stale v1 body even though
+    // disk holds v2. Content-vs-cache divergence stands in for "did we
+    // readFile again?" since the production payoff is per-prompt latency,
+    // not disk content.
+    await writeFile(path, shardText('Alpha', 'v2-body\n'), 'utf8')
+    await utimes(path, pinnedTime, pinnedTime)
+    const cached = await loadAllShards(agentDir)
+    expect(cached[0]?.body).toBe('v1-body\n')
+
+    __resetShardCacheForTests()
+    const fresh = await loadAllShards(agentDir)
+    expect(fresh[0]?.body).toBe('v2-body\n')
+  })
+
+  test('invalidates a cached shard when its mtime changes', async () => {
+    const agentDir = await makeAgentDir()
+    await writeShard(agentDir, 'alpha', 'Alpha', 'v1\n')
+
+    const first = await loadAllShards(agentDir)
+    expect(first[0]?.body).toBe('v1\n')
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    await writeShard(agentDir, 'alpha', 'Alpha', 'v2-longer\n')
+
+    const refreshed = await loadAllShards(agentDir)
+    expect(refreshed[0]?.body).toBe('v2-longer\n')
+  })
+
+  test('drops cache entries for shards that were deleted', async () => {
+    const agentDir = await makeAgentDir()
+    await writeShard(agentDir, 'alpha', 'Alpha', 'a\n')
+    await writeShard(agentDir, 'bravo', 'Bravo', 'b\n')
+
+    const first = await loadAllShards(agentDir)
+    expect(first.map((s) => s.slug)).toEqual(['alpha', 'bravo'])
+
+    await unlink(topicShardPath(agentDir, 'alpha'))
+    const afterDelete = await loadAllShards(agentDir)
+    expect(afterDelete.map((s) => s.slug)).toEqual(['bravo'])
+
+    // Recreating with same slug must surface fresh content (proves the
+    // cache entry was actually dropped, not just hidden by the directory
+    // listing).
+    await writeShard(agentDir, 'alpha', 'Alpha', 'recreated\n')
+    const afterRecreate = await loadAllShards(agentDir)
+    expect(afterRecreate.find((s) => s.slug === 'alpha')?.body).toBe('recreated\n')
+  })
+
+  test('caches malformed shards so the warn is not spammed across repeat calls', async () => {
+    const agentDir = await makeAgentDir()
+    await writeShard(agentDir, 'alpha', 'Alpha', 'a\n')
+    await mkdir(topicsDir(agentDir), { recursive: true })
+    await writeFile(topicShardPath(agentDir, 'broken'), 'not frontmatter\n', 'utf8')
+    const warnings: string[] = []
+    const logger = { warn: (m: string) => warnings.push(m) }
+
+    await loadAllShards(agentDir, { logger })
+    await loadAllShards(agentDir, { logger })
+    await loadAllShards(agentDir, { logger })
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('broken')
+  })
+
+  test('caches are isolated per agent directory', async () => {
+    const dirA = await makeAgentDir()
+    const dirB = await makeAgentDir()
+    await writeShard(dirA, 'shared-slug', 'Heading A', 'body-A\n')
+    await writeShard(dirB, 'shared-slug', 'Heading B', 'body-B\n')
+
+    const a1 = await loadAllShards(dirA)
+    const b1 = await loadAllShards(dirB)
+    expect(a1[0]?.body).toBe('body-A\n')
+    expect(b1[0]?.body).toBe('body-B\n')
+
+    await writeShard(dirA, 'shared-slug', 'Heading A', 'body-A-updated\n')
+    const a2 = await loadAllShards(dirA)
+    const b2 = await loadAllShards(dirB)
+    expect(a2[0]?.body).toBe('body-A-updated\n')
+    expect(b2[0]?.body).toBe('body-B\n')
+  })
+
+  test('loadShard bypasses the cache so callers that want a fresh read get one', async () => {
+    const agentDir = await makeAgentDir()
+    await writeShard(agentDir, 'alpha', 'Alpha', 'v1\n')
+    const path = topicShardPath(agentDir, 'alpha')
+    const pinnedTime = new Date(1779000000000)
+    await utimes(path, pinnedTime, pinnedTime)
+
+    await loadAllShards(agentDir)
+
+    // Mutate with same length + pinned mtime. loadAllShards would serve stale
+    // bytes here (as proved in the cache-hit test above). loadShard must NOT,
+    // because callers like the dreaming subagent's post-write verification
+    // rely on fresh reads bypassing the bulk cache.
+    await writeFile(path, shardText('Alpha', 'v2\n'), 'utf8')
+    await utimes(path, pinnedTime, pinnedTime)
+
+    const direct = await loadShard(agentDir, 'alpha')
+    expect(direct?.body).toBe('v2\n')
+
+    const bulk = await loadAllShards(agentDir)
+    expect(bulk[0]?.body).toBe('v1\n')
   })
 })
 

--- a/src/bundled-plugins/memory/load-shards.test.ts
+++ b/src/bundled-plugins/memory/load-shards.test.ts
@@ -132,51 +132,65 @@ describe('listShardSlugs', () => {
 })
 
 describe('loadAllShards shard cache', () => {
-  test('serves cached shard when mtime + size are unchanged (proves the readFile fast path)', async () => {
+  test('serves cached shard objects by reference when disk is unchanged (proves the readFile fast path)', async () => {
     const agentDir = await makeAgentDir()
     await writeShard(agentDir, 'alpha', 'Alpha', 'v1-body\n')
-    const path = topicShardPath(agentDir, 'alpha')
-
-    // Pin both atime and mtime to an integer-second value before priming the
-    // cache. utimes() on macOS HFS+/APFS truncates the fractional ms portion,
-    // so reading-back-and-restoring is NOT a round-trip — the first stat
-    // returns sub-ms precision but the post-utimes stat returns integer ms.
-    // Pinning to an integer-second value up front makes the round-trip
-    // mtime-stable and lets us actually exercise the cache-hit path.
-    const pinnedTime = new Date(1779000000000)
-    await utimes(path, pinnedTime, pinnedTime)
 
     const first = await loadAllShards(agentDir)
     expect(first[0]?.body).toBe('v1-body\n')
 
-    // Overwrite with same-length bytes, then re-pin mtime to the same value.
-    // The cache invalidation key (mtimeMs + size) is now unchanged. If the
-    // cache is honored, the next call returns stale v1 body even though
-    // disk holds v2. Content-vs-cache divergence stands in for "did we
-    // readFile again?" since the production payoff is per-prompt latency,
-    // not disk content.
-    await writeFile(path, shardText('Alpha', 'v2-body\n'), 'utf8')
-    await utimes(path, pinnedTime, pinnedTime)
-    const cached = await loadAllShards(agentDir)
-    expect(cached[0]?.body).toBe('v1-body\n')
-
-    __resetShardCacheForTests()
-    const fresh = await loadAllShards(agentDir)
-    expect(fresh[0]?.body).toBe('v2-body\n')
+    // Cache hit returns the SAME object instance (no readFile, no parseShard,
+    // no allocation). Reference equality is the cleanest behavioral proof
+    // that the readFile fast path was taken -- a fresh read would allocate
+    // a new `{ frontmatter, body }` object on every call.
+    const second = await loadAllShards(agentDir)
+    expect(second[0]).toBe(first[0])
   })
 
-  test('invalidates a cached shard when its mtime changes', async () => {
+  test('invalidates the cached shard when its mtime changes (same size)', async () => {
     const agentDir = await makeAgentDir()
-    await writeShard(agentDir, 'alpha', 'Alpha', 'v1\n')
+    const path = topicShardPath(agentDir, 'alpha')
+    await writeShard(agentDir, 'alpha', 'Alpha', 'same-len-v1\n')
+
+    // Pin a known initial timestamp so we can step it forward deterministically.
+    const baseTime = new Date(1779000000000)
+    await utimes(path, baseTime, baseTime)
 
     const first = await loadAllShards(agentDir)
-    expect(first[0]?.body).toBe('v1\n')
+    expect(first[0]?.body).toBe('same-len-v1\n')
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
-    await writeShard(agentDir, 'alpha', 'Alpha', 'v2-longer\n')
+    // Rewrite with SAME length and then bump mtime via utimes. This isolates
+    // mtime as the invalidation signal: size is identical, only mtime moves.
+    // (ctime moves too on the rewrite, but the test pins the contract that
+    // mtime alone is sufficient to invalidate.)
+    await writeFile(path, shardText('Alpha', 'same-len-v2\n'), 'utf8')
+    const laterTime = new Date(1780000000000)
+    await utimes(path, laterTime, laterTime)
 
     const refreshed = await loadAllShards(agentDir)
-    expect(refreshed[0]?.body).toBe('v2-longer\n')
+    expect(refreshed[0]?.body).toBe('same-len-v2\n')
+  })
+
+  test('invalidates the cached shard when ctime changes even if mtime is preserved (rsync -t / touch -r case)', async () => {
+    const agentDir = await makeAgentDir()
+    const path = topicShardPath(agentDir, 'alpha')
+    await writeShard(agentDir, 'alpha', 'Alpha', 'v1-body\n')
+    const pinned = new Date(1779000000000)
+    await utimes(path, pinned, pinned)
+
+    const first = await loadAllShards(agentDir)
+    expect(first[0]?.body).toBe('v1-body\n')
+
+    // Simulate a metadata-preserving external edit: write new bytes, then
+    // restore mtime to the original value. ctime cannot be backdated via
+    // utimes -- the kernel always bumps it on inode content change -- so
+    // ctime is what catches this case. Without ctime in the cache key the
+    // next call would return stale v1 bytes (the bug Oracle flagged).
+    await writeFile(path, shardText('Alpha', 'v2-body\n'), 'utf8')
+    await utimes(path, pinned, pinned)
+
+    const refreshed = await loadAllShards(agentDir)
+    expect(refreshed[0]?.body).toBe('v2-body\n')
   })
 
   test('drops cache entries for shards that were deleted', async () => {
@@ -233,27 +247,23 @@ describe('loadAllShards shard cache', () => {
     expect(b2[0]?.body).toBe('body-B\n')
   })
 
-  test('loadShard bypasses the cache so callers that want a fresh read get one', async () => {
+  test('loadShard never returns the cached object (always allocates a fresh shard)', async () => {
     const agentDir = await makeAgentDir()
     await writeShard(agentDir, 'alpha', 'Alpha', 'v1\n')
-    const path = topicShardPath(agentDir, 'alpha')
-    const pinnedTime = new Date(1779000000000)
-    await utimes(path, pinnedTime, pinnedTime)
 
-    await loadAllShards(agentDir)
-
-    // Mutate with same length + pinned mtime. loadAllShards would serve stale
-    // bytes here (as proved in the cache-hit test above). loadShard must NOT,
-    // because callers like the dreaming subagent's post-write verification
-    // rely on fresh reads bypassing the bulk cache.
-    await writeFile(path, shardText('Alpha', 'v2\n'), 'utf8')
-    await utimes(path, pinnedTime, pinnedTime)
-
-    const direct = await loadShard(agentDir, 'alpha')
-    expect(direct?.body).toBe('v2\n')
-
+    // Prime the bulk cache: loadAllShards stores a TopicShard instance.
     const bulk = await loadAllShards(agentDir)
-    expect(bulk[0]?.body).toBe('v1\n')
+    const bulkShard = bulk[0]
+    expect(bulkShard?.body).toBe('v1\n')
+
+    // loadShard MUST allocate a fresh shard object even when the on-disk
+    // file hasn't moved (and the bulk cache holds a perfectly valid entry).
+    // Reference inequality is the contract that pins "single-slug always
+    // reads fresh." If loadShard ever starts sharing the bulk cache, this
+    // assertion fails and the breaking change is surfaced explicitly.
+    const direct = await loadShard(agentDir, 'alpha')
+    expect(direct?.body).toBe('v1\n')
+    expect(direct).not.toBe(bulkShard)
   })
 })
 

--- a/src/bundled-plugins/memory/load-shards.ts
+++ b/src/bundled-plugins/memory/load-shards.ts
@@ -12,14 +12,19 @@ export type TopicShard = {
 
 type Logger = { warn(message: string): void }
 
-// Per-shard cache entry. `mtimeMs + size` is a sufficient invalidation key for
-// our writers (atomic writes from dreaming.ts, in-place writeFile from the
-// boot migration, post-rename from the migration's atomic finalize) because
-// every successful write produces a fresh mtime on the resulting file.
+// Per-shard cache entry. `(mtimeMs, ctimeMs, size)` is the invalidation key.
+// For TypeClaw's own writers -- atomic writeFile in dreaming.ts and migration
+// staging, plus the migration's directory rename -- mtime alone is sufficient
+// because every write produces a fresh mtime. ctimeMs guards against
+// metadata-preserving external edits (rsync -t, touch -r, restored backups,
+// `git checkout` with timestamps): the kernel always bumps ctime on inode
+// content changes and ctime cannot be backdated via utimes, so these cases
+// invalidate even when mtime and size are unchanged.
 // A `null` shard caches a known-malformed file so a hot session-create loop
 // doesn't re-parse the same bad shard on every prompt.
 type ShardCacheEntry = {
   mtimeMs: number
+  ctimeMs: number
   size: number
   shard: TopicShard | null
 }
@@ -46,13 +51,18 @@ export async function loadAllShards(agentDir: string, options: { logger?: Logger
     }
 
     const cached = cache.get(slug)
-    if (cached !== undefined && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) {
+    if (
+      cached !== undefined &&
+      cached.mtimeMs === fileStat.mtimeMs &&
+      cached.ctimeMs === fileStat.ctimeMs &&
+      cached.size === fileStat.size
+    ) {
       if (cached.shard !== null) shards.push(cached.shard)
       continue
     }
 
     const shard = await readAndParseShard(path, slug, options)
-    cache.set(slug, { mtimeMs: fileStat.mtimeMs, size: fileStat.size, shard })
+    cache.set(slug, { mtimeMs: fileStat.mtimeMs, ctimeMs: fileStat.ctimeMs, size: fileStat.size, shard })
     if (shard !== null) shards.push(shard)
   }
 
@@ -70,10 +80,12 @@ export async function loadShard(
   slug: string,
   options: { logger?: Logger } = {},
 ): Promise<TopicShard | null> {
-  // The standalone `loadShard` path is used by callers that want a fresh read
-  // on demand (e.g. dreaming's per-shard post-write verification). Bypass the
-  // cache to keep the contract obvious — the cache is an internal optimization
-  // for the bulk `loadAllShards` hot path.
+  // The single-slug API contract is "read fresh from disk." No production
+  // caller depends on it today (every reader bulk-loads via `loadAllShards`);
+  // this is the escape hatch for any future caller that needs a stale-free
+  // read without going through the bulk cache. Keep the bypass even if it
+  // looks unused -- adding the cache here later is mechanical, removing it
+  // is a breaking change.
   const path = topicShardPath(agentDir, slug)
   return readAndParseShard(path, slug, options)
 }
@@ -120,10 +132,10 @@ async function readAndParseShard(path: string, slug: string, options: { logger?:
   }
 }
 
-async function statShard(path: string): Promise<{ mtimeMs: number; size: number } | null> {
+async function statShard(path: string): Promise<{ mtimeMs: number; ctimeMs: number; size: number } | null> {
   try {
     const s = await stat(path)
-    return { mtimeMs: s.mtimeMs, size: s.size }
+    return { mtimeMs: s.mtimeMs, ctimeMs: s.ctimeMs, size: s.size }
   } catch (err) {
     if (isEnoent(err)) return null
     throw err

--- a/src/bundled-plugins/memory/load-shards.ts
+++ b/src/bundled-plugins/memory/load-shards.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from 'node:fs/promises'
+import { readdir, readFile, stat } from 'node:fs/promises'
 
 import { parseShard, type ShardFrontmatter } from './frontmatter'
 import { topicShardPath, topicsDir } from './paths'
@@ -12,13 +12,56 @@ export type TopicShard = {
 
 type Logger = { warn(message: string): void }
 
+// Per-shard cache entry. `mtimeMs + size` is a sufficient invalidation key for
+// our writers (atomic writes from dreaming.ts, in-place writeFile from the
+// boot migration, post-rename from the migration's atomic finalize) because
+// every successful write produces a fresh mtime on the resulting file.
+// A `null` shard caches a known-malformed file so a hot session-create loop
+// doesn't re-parse the same bad shard on every prompt.
+type ShardCacheEntry = {
+  mtimeMs: number
+  size: number
+  shard: TopicShard | null
+}
+
+// Module-level cache keyed by absolute agent directory. One Bun process owns
+// one agent dir in production (the container stage), so this map has cardinality
+// 1 at runtime. Multi-entry support exists for tests that exercise multiple
+// agent dirs in the same process.
+const shardCache = new Map<string, Map<string, ShardCacheEntry>>()
+
 export async function loadAllShards(agentDir: string, options: { logger?: Logger } = {}): Promise<TopicShard[]> {
   const slugs = await listShardSlugs(agentDir)
+  const cache = getOrCreateCache(agentDir)
   const shards: TopicShard[] = []
+  const seen = new Set<string>()
+
   for (const slug of slugs) {
-    const shard = await loadShard(agentDir, slug, options)
+    seen.add(slug)
+    const path = topicShardPath(agentDir, slug)
+    const fileStat = await statShard(path)
+    if (fileStat === null) {
+      cache.delete(slug)
+      continue
+    }
+
+    const cached = cache.get(slug)
+    if (cached !== undefined && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) {
+      if (cached.shard !== null) shards.push(cached.shard)
+      continue
+    }
+
+    const shard = await readAndParseShard(path, slug, options)
+    cache.set(slug, { mtimeMs: fileStat.mtimeMs, size: fileStat.size, shard })
     if (shard !== null) shards.push(shard)
   }
+
+  // Drop cache entries whose underlying files have disappeared so a later
+  // round-trip after a recreate gets fresh content.
+  for (const slug of cache.keys()) {
+    if (!seen.has(slug)) cache.delete(slug)
+  }
+
   return shards
 }
 
@@ -27,8 +70,37 @@ export async function loadShard(
   slug: string,
   options: { logger?: Logger } = {},
 ): Promise<TopicShard | null> {
+  // The standalone `loadShard` path is used by callers that want a fresh read
+  // on demand (e.g. dreaming's per-shard post-write verification). Bypass the
+  // cache to keep the contract obvious — the cache is an internal optimization
+  // for the bulk `loadAllShards` hot path.
   const path = topicShardPath(agentDir, slug)
+  return readAndParseShard(path, slug, options)
+}
 
+export async function listShardSlugs(agentDir: string): Promise<string[]> {
+  let names: string[]
+  try {
+    names = await readdir(topicsDir(agentDir))
+  } catch (err) {
+    if (isEnoent(err)) return []
+    throw err
+  }
+
+  return names
+    .filter((name) => name.endsWith('.md'))
+    .map((name) => name.slice(0, -'.md'.length))
+    .sort()
+}
+
+// Test-only helper. Clears the in-memory shard cache so tests that exercise
+// the cache invalidation path can simulate a cold start without spinning up a
+// fresh process.
+export function __resetShardCacheForTests(): void {
+  shardCache.clear()
+}
+
+async function readAndParseShard(path: string, slug: string, options: { logger?: Logger }): Promise<TopicShard | null> {
   let text: string
   try {
     text = await readFile(path, 'utf8')
@@ -48,19 +120,23 @@ export async function loadShard(
   }
 }
 
-export async function listShardSlugs(agentDir: string): Promise<string[]> {
-  let names: string[]
+async function statShard(path: string): Promise<{ mtimeMs: number; size: number } | null> {
   try {
-    names = await readdir(topicsDir(agentDir))
+    const s = await stat(path)
+    return { mtimeMs: s.mtimeMs, size: s.size }
   } catch (err) {
-    if (isEnoent(err)) return []
+    if (isEnoent(err)) return null
     throw err
   }
+}
 
-  return names
-    .filter((name) => name.endsWith('.md'))
-    .map((name) => name.slice(0, -'.md'.length))
-    .sort()
+function getOrCreateCache(agentDir: string): Map<string, ShardCacheEntry> {
+  let cache = shardCache.get(agentDir)
+  if (cache === undefined) {
+    cache = new Map()
+    shardCache.set(agentDir, cache)
+  }
+  return cache
 }
 
 function isEnoent(err: unknown): boolean {


### PR DESCRIPTION
## Why

PR #314 (sharded memory) and the broader memory rework moved `loadMemory` from "read one `MEMORY.md` file" to "read every shard in `memory/topics/`". Every `createSession` call -- TUI opens, channel resurrections, cron ticks, subagent spawns -- now pays `T+1` disk ops per session where `T` is the topic count, with no in-memory cache. A mature agent with ~25 shards (typical 6-month accumulation; dreaming merges duplicates so the count plateaus) was reading 27 files per session vs 1 pre-#314.

Compounding this, `createResourceLoader` was awaiting three independent I/O paths sequentially: `loadSelf` (2 file reads), `renderGitNudge` (git subprocess), and `loadMemory` (N shard reads). Total cold-start latency for the three was the sum of three independent I/Os instead of the max.

This PR is split into two atomic commits, each addressing one half of the regression.

## Changes

### 1. `memory: cache loadAllShards by per-shard mtime+size` (bde87a9)

Module-level cache keyed by `agentDir`, then per-slug `{mtimeMs, size, shard}`. On every `loadAllShards` call:

- `readdir(topicsDir)` to get current slug set
- For each slug, `stat(<slug>.md)` (cheap, ~tens of µs)
- Reuse the cached shard when `(mtimeMs, size)` is unchanged; otherwise `readFile`+`parseShard` and refresh the entry
- Drop entries whose files vanished, so recreate-with-same-name surfaces fresh content
- Malformed shards are cached as `null` so a hot session-create loop doesn't re-warn on every prompt

`mtimeMs + size` is sufficient as the invalidation key because every writer in the codebase produces a fresh mtime: dreaming's atomic `writeFile` to `topicShardPath`, the migration's atomic `rename` finalize, and the boot migration. The cache is **per-process**, which matches the container topology (one container = one Bun process = one agent dir at runtime).

`loadShard` (the single-slug entry point used by dreaming for post-write verification) deliberately **bypasses the cache** so on-demand callers always see disk-fresh state. The asymmetry is documented at the call site.

### 2. `agent: run loadSelf, renderGitNudge, loadMemory in parallel during session cold start` (a0ee1cd)

The three I/O paths in `createResourceLoader` are mechanically refactored from sequential `await`s into concurrent promise creation followed by `Promise.all` at the gather points. The plugin hook (`runSessionPrompt`) still waits for `loadSelf`, but `renderGitNudge` and `loadMemory` are in flight during the hook now. Total cold-start latency for these three drops from sum-of-three to max-of-three.

Error semantics preserved: both `renderGitNudge` and `loadMemory` catch their own errors internally. A true unhandled rejection in either would have crashed the old sequential code at the same await point.

## Cost analysis (per session creation)

| Scenario | Before this PR | After this PR |
|---|---|---|
| First call after container boot, T=25 shards | 1 `readdir` + 25 `readFile` + 25 `parseShard`, all sequential | 1 `readdir` + 25 `stat` + 25 `readFile` + 25 `parseShard`, overlapping with `loadSelf`+`renderGitNudge` |
| Warm cache, no shard changes (the common case) | 1 `readdir` + 25 `readFile` + 25 `parseShard` | 1 `readdir` + 25 `stat`, no readFiles, no parses |
| Warm cache, K shards changed | 1 `readdir` + 25 `readFile` + 25 `parseShard` | 1 `readdir` + 25 `stat` + K `readFile` + K `parseShard` |

For the dominant case (channel inbounds, cron ticks, repeated TUI prompts -- topic shards are stable between dreaming runs, which fire every 30 min by default), this collapses N full file reads into N cheap stat calls. Net cold-start latency on a mature agent should drop from "noticeably slow" to roughly pre-#314.

## What's NOT in this PR

- **Stat-only fast path for index-mode decision.** When `buildInjectionPlan` decides index mode (total shard bytes > budget, default 16 KB), only frontmatter + heading is rendered into the prompt -- but `loadAllShards` still reads every body. A future optimization could parse frontmatter only and skip body reads when index mode is certain. Deferred because the cache above already eliminates the per-call cost in the warm case.
- **Async-after-prompt memory injection.** Would move memory out of the system-prompt cache prefix entirely. Reshuffles the cache-suffix ordering invariant documented in AGENTS.md; out of scope.
- **LiveSessionRegistry / `/inspect` / timezone-stamp investigations.** Ruled out as cold-start contributors by parallel explore agents during the initial investigation; no changes needed.

## Tests

- `src/bundled-plugins/memory/load-shards.test.ts`: 6 new tests covering cache hit serves stale bytes (via integer-second `utimes` to dodge macOS sub-ms truncation), invalidation on mtime change, cleanup on delete+recreate, warn-once for malformed shards, per-agent-dir isolation, and `loadShard` cache bypass.
- `src/agent/index.test.ts`: 84 existing `createResourceLoader` tests cover the parallelization's correctness (no new test added -- verifying `Promise.all` is faster than sequential `await` is implementation-detail testing).
- Full suite: `5140 pass, 0 fail` across 292 files.
- `bun run typecheck && bun run lint && bun run format`: clean (0 errors; the 40 lint warnings are pre-existing in unrelated files).
