### PR TITLE
Route KakaoTalk outbound attachments through `client.sendAttachment`

### DIFF
--- a/src/channels/adapters/kakaotalk.test.ts
+++ b/src/channels/adapters/kakaotalk.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import type {
+  AttachmentInput,
   KakaoChat,
   KakaoMember,
   KakaoMessage,
@@ -62,6 +63,12 @@ class FakeListener implements KakaoTalkListener {
   }
 }
 
+function isAttachmentInputArray(
+  x: Uint8Array | Buffer | ReadonlyArray<AttachmentInput>,
+): x is ReadonlyArray<AttachmentInput> {
+  return Array.isArray(x)
+}
+
 class FakeClient implements KakaoTalkClient {
   loginCalls = 0
   sendMessageCalls: Array<{ chatId: string; text: string }> = []
@@ -102,6 +109,39 @@ class FakeClient implements KakaoTalkClient {
   async sendMessage(chatId: string, text: string): Promise<KakaoSendResult> {
     this.sendMessageCalls.push({ chatId, text })
     return this.sendResult
+  }
+
+  sendAttachmentCalls: Array<
+    | { kind: 'single'; chatId: string; data: Uint8Array | Buffer; filename: string; mimeType?: string }
+    | { kind: 'array'; chatId: string; attachments: ReadonlyArray<AttachmentInput> }
+  > = []
+  attachmentResult: KakaoSendResult = { success: true, status_code: 0, chat_id: '111', log_id: 'L-att', sent_at: 0 }
+
+  sendAttachment(
+    chatId: string,
+    data: Uint8Array | Buffer,
+    filename: string,
+    mimeType?: string,
+  ): Promise<KakaoSendResult>
+  sendAttachment(chatId: string, attachments: ReadonlyArray<AttachmentInput>): Promise<KakaoSendResult>
+  async sendAttachment(
+    chatId: string,
+    dataOrAttachments: Uint8Array | Buffer | ReadonlyArray<AttachmentInput>,
+    filename?: string,
+    mimeType?: string,
+  ): Promise<KakaoSendResult> {
+    if (isAttachmentInputArray(dataOrAttachments)) {
+      this.sendAttachmentCalls.push({ kind: 'array', chatId, attachments: dataOrAttachments })
+    } else {
+      this.sendAttachmentCalls.push({
+        kind: 'single',
+        chatId,
+        data: dataOrAttachments,
+        filename: filename!,
+        ...(mimeType !== undefined ? { mimeType } : {}),
+      })
+    }
+    return this.attachmentResult
   }
 
   async markRead(chatId: string, logId: string, opts?: { linkId?: string }): Promise<KakaoMarkReadResult> {
@@ -294,7 +334,80 @@ describe('createKakaotalkAdapter — outbound', () => {
     await router.stop()
   })
 
-  test('returns ok:false (and does NOT send) when attachments are present', async () => {
+  test('uploads attachments via sendAttachment when present (no text)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kakao-att-'))
+    const filepath = join(dir, 'photo.jpg')
+    await writeFile(filepath, Buffer.from('fake-image-bytes'))
+
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+    })
+    await adapter.start()
+
+    const result = await router.send({
+      adapter: 'kakaotalk',
+      workspace: '@kakao-dm',
+      chat: '111',
+      attachments: [{ path: filepath }],
+    })
+    expect(result.ok).toBe(true)
+    expect(client.sendMessageCalls).toHaveLength(0)
+    expect(client.sendAttachmentCalls).toHaveLength(1)
+    const call = client.sendAttachmentCalls[0]!
+    expect(call.kind).toBe('array')
+    if (call.kind !== 'array') return
+    expect(call.chatId).toBe('111')
+    expect(call.attachments).toHaveLength(1)
+    expect(call.attachments[0]!.filename).toBe('photo.jpg')
+
+    await adapter.stop()
+    await router.stop()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  test('uploads files first, then posts text when both are provided', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kakao-att-'))
+    const filepath = join(dir, 'spec.pdf')
+    await writeFile(filepath, Buffer.from('fake-pdf'))
+
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+    })
+    await adapter.start()
+
+    const result = await router.send({
+      adapter: 'kakaotalk',
+      workspace: '@kakao-dm',
+      chat: '222',
+      text: 'see attached',
+      attachments: [{ path: filepath, filename: 'specification.pdf' }],
+    })
+    expect(result.ok).toBe(true)
+    expect(client.sendAttachmentCalls).toHaveLength(1)
+    expect(client.sendMessageCalls).toEqual([{ chatId: '222', text: 'see attached' }])
+    const call = client.sendAttachmentCalls[0]!
+    expect(call.kind).toBe('array')
+    if (call.kind !== 'array') return
+    expect(call.attachments[0]!.filename).toBe('specification.pdf')
+
+    await adapter.stop()
+    await router.stop()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  test('returns ok:false when the attachment file is missing (does not silently drop)', async () => {
     const client = new FakeClient()
     const listener = new FakeListener()
     const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
@@ -311,15 +424,13 @@ describe('createKakaotalkAdapter — outbound', () => {
       workspace: '@kakao-dm',
       chat: '111',
       text: 'hi',
-      attachments: [{ path: '/tmp/some-file.png' }],
+      attachments: [{ path: '/nonexistent/path/photo.jpg' }],
     })
     expect(result.ok).toBe(false)
     if (result.ok) return
-    expect(result.error).toContain('does not support attachments')
-    // The agent contract violation Oracle flagged: text MUST NOT have been
-    // sent if we report failure. Otherwise the agent would say "I sent your
-    // message" while the file silently disappeared.
+    expect(result.error).toContain('readFile failed')
     expect(client.sendMessageCalls).toHaveLength(0)
+    expect(client.sendAttachmentCalls).toHaveLength(0)
 
     await adapter.stop()
     await router.stop()

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -2,6 +2,7 @@ import {
   KakaoCredentialManager,
   KakaoTalkClient as RealKakaoTalkClient,
   KakaoTalkListener as RealKakaoTalkListener,
+  type AttachmentInput,
   type KakaoChat,
   type KakaoMember,
   type KakaoMessage,
@@ -56,6 +57,13 @@ export interface KakaoTalkClient {
   getChats(options?: { all?: boolean; search?: string }): Promise<KakaoChat[]>
   getMessages(chatId: string, options?: { count?: number; from?: string }): Promise<KakaoMessage[]>
   sendMessage(chatId: string, text: string): Promise<KakaoSendResult>
+  sendAttachment(
+    chatId: string,
+    data: Uint8Array | Buffer,
+    filename: string,
+    mimeType?: string,
+  ): Promise<KakaoSendResult>
+  sendAttachment(chatId: string, attachments: ReadonlyArray<AttachmentInput>): Promise<KakaoSendResult>
   markRead(chatId: string, logId: string, opts?: { linkId?: string }): Promise<KakaoMarkReadResult>
   getProfile(): Promise<KakaoProfile>
   getMembers(chatId: string): Promise<KakaoMember[]>
@@ -160,49 +168,77 @@ function formatLabel(name: string | undefined, id: string, prefix = ''): string 
   return `${prefix}${name}(${id})`
 }
 
+async function readAttachmentBuffer(path: string): Promise<Buffer> {
+  const { readFile } = await import('node:fs/promises')
+  return await readFile(path)
+}
+
 export function createOutboundCallback(deps: {
-  client: Pick<KakaoTalkClient, 'sendMessage'>
+  client: Pick<KakaoTalkClient, 'sendMessage' | 'sendAttachment'>
   logger: KakaotalkAdapterLogger
   formatChannelTag: (workspace: string, chat: string) => Promise<string>
+  readFile?: (path: string) => Promise<Buffer>
 }): OutboundCallback {
   const { client, logger, formatChannelTag } = deps
+  const readFile = deps.readFile ?? readAttachmentBuffer
   return async (msg: OutboundMessage): Promise<SendResult> => {
     if (msg.adapter !== 'kakaotalk') {
       return { ok: false, error: `unknown adapter: ${msg.adapter}` }
     }
     const text = msg.text ?? ''
     const attachments = msg.attachments ?? []
-    if (attachments.length > 0) {
-      // Fail loudly rather than partial-send. The agent contract is "ok=true
-      // means the request as a whole succeeded"; sending text while silently
-      // dropping the attachments would let the agent confidently report
-      // "I sent your file" when the file never arrived.
-      logger.error(
-        `[kakaotalk] outbound rejected: ${attachments.length} attachment(s) supplied but KakaoTalk is text-only`,
-      )
-      return {
-        ok: false,
-        error: 'KakaoTalk does not support attachments; send text without files or use a different channel for files',
-      }
-    }
-    if (text === '') {
-      return { ok: false, error: 'message has no text (KakaoTalk does not support attachment-only messages)' }
+    if (text === '' && attachments.length === 0) {
+      return { ok: false, error: 'message has neither text nor attachments' }
     }
     const tag = await formatChannelTag(msg.workspace, msg.chat)
-    logger.info(`[kakaotalk] outbound ${tag} text_len=${text.length}`)
-    try {
-      const result = await client.sendMessage(msg.chat, text)
-      if (!result.success) {
-        logger.error(`[kakaotalk] sendMessage status_code=${result.status_code} ${tag}`)
-        return { ok: false, error: `kakaotalk send failed with status ${result.status_code}` }
+    logger.info(`[kakaotalk] outbound ${tag} text_len=${text.length} attachments=${attachments.length}`)
+
+    // KakaoTalk has no shared text-with-file send (Slack's initial_comment) — files first, then text.
+    if (attachments.length > 0) {
+      let items: AttachmentInput[]
+      try {
+        items = await Promise.all(
+          attachments.map(async (a) => {
+            const filename = a.filename ?? a.path.split('/').pop() ?? 'file'
+            const data = await readFile(a.path)
+            return { data, filename }
+          }),
+        )
+      } catch (err) {
+        const message = describe(err)
+        logger.error(`[kakaotalk] readFile failed: ${message}`)
+        return { ok: false, error: `readFile failed: ${message}` }
       }
-      logger.info(`[kakaotalk] sent log_id=${result.log_id} ${tag}`)
-      return { ok: true }
-    } catch (err) {
-      const message = describe(err)
-      logger.error(`[kakaotalk] sendMessage failed: ${message}`)
-      return { ok: false, error: message }
+      try {
+        const result = await client.sendAttachment(msg.chat, items)
+        if (!result.success) {
+          logger.error(`[kakaotalk] sendAttachment status_code=${result.status_code} ${tag}`)
+          return { ok: false, error: `kakaotalk attachment send failed with status ${result.status_code}` }
+        }
+        logger.info(`[kakaotalk] uploaded log_id=${result.log_id} attachments=${items.length} ${tag}`)
+      } catch (err) {
+        const message = describe(err)
+        logger.error(`[kakaotalk] sendAttachment failed: ${message}`)
+        return { ok: false, error: message }
+      }
     }
+
+    if (text !== '') {
+      try {
+        const result = await client.sendMessage(msg.chat, text)
+        if (!result.success) {
+          logger.error(`[kakaotalk] sendMessage status_code=${result.status_code} ${tag}`)
+          return { ok: false, error: `kakaotalk send failed with status ${result.status_code}` }
+        }
+        logger.info(`[kakaotalk] sent log_id=${result.log_id} ${tag}`)
+      } catch (err) {
+        const message = describe(err)
+        logger.error(`[kakaotalk] sendMessage failed: ${message}`)
+        return { ok: false, error: message }
+      }
+    }
+
+    return { ok: true }
   }
 }
 

--- a/src/skills/typeclaw-channel-kakaotalk/SKILL.md
+++ b/src/skills/typeclaw-channel-kakaotalk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typeclaw-channel-kakaotalk
-description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `kakaotalk`, AND before calling `channel_fetch_attachment` against a KakaoTalk URL. KakaoTalk renders messages as plain text — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and other markdown all appear literally. There is no `@mention` syntax, no message threads, no replies-with-quote, and no outbound file attachments or stickers. Inbound photos / files / video / audio CAN be downloaded via `channel_fetch_attachment` (the placeholder text includes the URL); inbound stickers are metadata-only and cannot be fetched. URLs expire ~3 days after the message arrives. Read this skill before composing or fetching anything on KakaoTalk.
+description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `kakaotalk`, AND before calling `channel_fetch_attachment` against a KakaoTalk URL. KakaoTalk renders messages as plain text — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and other markdown all appear literally. There is no `@mention` syntax, no message threads, no replies-with-quote, and no outbound stickers. Outbound file attachments (photos, videos, audio, generic files, multi-photo galleries) ARE supported — pass them via `attachments[]` on `channel_send` / `channel_reply` and the adapter routes by MIME. Inbound photos / files / video / audio CAN be downloaded via `channel_fetch_attachment` (the placeholder text includes the URL); inbound stickers are metadata-only and cannot be fetched. URLs expire ~3 days after the message arrives. Read this skill before composing or fetching anything on KakaoTalk.
 ---
 
 # typeclaw-channel-kakaotalk
@@ -21,15 +21,19 @@ If you produce any of the following, KakaoTalk will render it literally and the 
 - **Links with display text** — `[label](url)` becomes the literal string. Send the bare URL on its own; the KakaoTalk client will auto-link it.
 - **Mentions** — there is no `@user` syntax that the protocol surfaces. Address people by name in the message body.
 - **Threads / replies-with-quote** — every message is a top-level chat post. There is no per-message reply UI.
-- **Outbound attachments / stickers** — agent-messenger's KakaoTalk SDK exposes no upload API. The adapter is outbound text-only. If the user asks you to send a file or sticker, say so and offer an alternative (paste a link, summarize the file, ship it via another channel).
-
-The adapter rejects outbound attachments via `ok: false` rather than partially sending the text — the agent contract is "ok=true means the whole request succeeded", so a silent drop would let you confidently report "I sent your file" when the file never arrived.
+- **Outbound stickers / emoticons** — the KakaoTalk sticker store requires desktop-app purchase flows that the SDK does not replicate. Inbound stickers ARE surfaced (see below), but you cannot send one. If the user asks for a sticker, acknowledge the limit and offer text.
 
 ## What KakaoTalk DOES support
 
 - Plain UTF-8 text. Emoji are fine.
 - URLs auto-linkify in the client. Send them bare — `https://example.com/foo`, no markdown wrapping.
 - Newlines render as line breaks. You can use `\n\n` to space paragraphs.
+- **Outbound file attachments** — photos, videos, audio, generic files, and multi-photo galleries. Pass each as an `OutboundAttachment { path, filename? }` on the `attachments[]` field of `channel_send` / `channel_reply`. The adapter sniffs the MIME from the filename and routes to the right KakaoTalk message type, so the caller does not pick photo-vs-file-vs-multiphoto by hand:
+  - Single attachment → single send. `image/*` renders inline with tap-to-zoom; `video/*` as an inline player; `audio/*` as a voice bubble; everything else as a downloadable file.
+  - Multiple attachments, all image MIMEs → multi-photo gallery (one chat bubble containing every image).
+  - Multiple attachments with mixed kinds (e.g. photo + PDF) → individual sends, one bubble each, in array order.
+  - Each send is fail-fast: if any upload fails the adapter returns `ok: false` immediately rather than partial-success.
+- **Text + attachments in one `channel_send`** — files upload first, then the text posts as a separate chat bubble. KakaoTalk has no Slack-style `initial_comment` that lets text and files share a single send.
 
 ## Inbound attachments and stickers
 
@@ -103,8 +107,4 @@ The adapter drops every inbound where `event.author_id` equals the logged-in acc
 
 ## When you cannot answer in KakaoTalk
 
-If the user asks you to do something the adapter cannot do (send a file, render markdown, post in a thread), say so plainly:
-
-> "I can't attach files through this chat. Want me to drop the file in [other channel] instead?"
-
-Better than silently dropping the attachment and pretending you sent it.
+If the user asks you to do something the adapter cannot do (render markdown, post in a thread, send a sticker), say so plainly. Files are fine — those go through `attachments[]` as described above — but markdown rendering, threading, and stickers are real limits. Acknowledge the limit instead of silently dropping the request.


### PR DESCRIPTION
## Summary

Routes KakaoTalk outbound attachments through `client.sendAttachment` so the adapter never has to know KakaoTalk's `message_type` table. The reject guard from when the SDK was outbound text-only is gone; `attachments[]` on an `OutboundMessage` now flows end-to-end.

> **⚠️ Depends on [agent-messenger#201](https://github.com/agent-messenger/agent-messenger/pull/201)** — that PR adds the `sendAttachment` overload (array of `{ data, filename, mime? }`) that this PR consumes. This stays in draft until #201 merges and ships a release; bumping `dependencies.agent-messenger` to the released version is the final step before flipping to ready-for-review.

## What changed

### `src/channels/adapters/kakaotalk.ts` — outbound rewrite

The structural `KakaoTalkClient` interface gains the same `sendAttachment` overload upstream now exposes (single buffer OR `ReadonlyArray<{ data, filename, mime? }>`), and `createOutboundCallback` routes by the shape of `msg.attachments`:

| `OutboundMessage` shape | Adapter behavior |
| --- | --- |
| `text` only | `sendMessage(text)` — unchanged |
| `attachments` only | `sendAttachment(items[])` — upstream picks single/multi-photo/sequential |
| `text` + `attachments` | upload first, then `sendMessage(text)` |
| `readFile` throws | `ok:false`, neither files nor text are posted |

KakaoTalk has no Slack-style `initial_comment` that bundles text and files into a single send, so the upload-then-text sequence is load-bearing for chat ordering. The Discord adapter uses the same shape.

The prior fail-loud contract is preserved: if the upload step reports `success: false` or `readFile` throws, the adapter returns `ok: false` **without** posting the text, so the agent can't confidently say "I sent your file" while the file silently disappeared.

### `src/channels/adapters/kakaotalk.test.ts` — outbound tests

The single "rejects attachments" outbound test is replaced by three positive cases:

1. **attachments only** — verifies `sendAttachment` was called with the right `chatId`/`filename`, and `sendMessage` was not.
2. **text + attachments ordering** — verifies both methods are called and the attachments call uses an explicit `filename` override when provided.
3. **`readFile` failure** — verifies the partial-success contract: neither `sendAttachment` nor `sendMessage` runs, `result.error` includes `readFile failed`.

The fake `KakaoTalkClient` implementation (`FakeClient`) gets a `sendAttachment` overload that records each call shape, so future tests can assert the array's contents.

### `src/skills/typeclaw-channel-kakaotalk/SKILL.md` — runtime guidance

The skill description and the "What KakaoTalk does NOT support" section no longer claim the channel is outbound text-only. The "What KakaoTalk DOES support" section now documents the `OutboundAttachment` shape, the auto-routing behavior, and the "files first, then text" send order. The "When you cannot answer in KakaoTalk" closing section is trimmed accordingly (stickers and markdown are still real limits; files are no longer one).

## Validation

- `bun test src/channels/adapters/kakaotalk.test.ts` → 32/32 pass.
- `bun run typecheck` → clean.
- Live KakaoTalk DM end-to-end: with this adapter against the agent-messenger#201 branch, the agent sent a photo and a PDF, the recipient received both with native KakaoTalk previews, and the adapter log shows the new line shape (`outbound ... attachments=N`, `uploaded log_id=...`) without the old `outbound rejected` line.

## Out of scope

- The `kakaotalk-fetch-attachment` inbound path is unchanged — inbound photo/file/video/audio download via `channel_fetch_attachment` already worked before this PR.
- No new schema fields on `OutboundMessage` or `OutboundAttachment`; those are the same shapes already used by the Slack and Discord adapters.
- Multi-photo gallery vs sequential dispatch is decided **inside** `client.sendAttachment` in agent-messenger#201, not here — typeclaw stays free of MIME / `message_type` knowledge.


## Screnshot
<img width="1206" height="1546" alt="IMG_8537" src="https://github.com/user-attachments/assets/dd5bdf4d-3f18-4063-beb6-037fcdb6d057" />
<img width="1206" height="1304" alt="IMG_8538" src="https://github.com/user-attachments/assets/9527b2c5-cbfc-4b61-9a18-821d9b11ca0d" />
