### PR TITLE
memory: detach memory-retrieval spawn from session.prompt and bound the hook

### DIFF
--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -99,9 +99,14 @@ async function bootMemoryPlugin(
 ): Promise<{
   exports: PluginExports
   spawned: SpawnCall[]
+  started: { name: string; payload: unknown; options: unknown }[]
   ctx: PluginContext<unknown>
 }> {
   const spawned: SpawnCall[] = []
+  // `started` captures the spawn invocation BEFORE the artificial delay, so
+  // tests that detach the spawn can distinguish "spawn was kicked off" from
+  // "spawn completed". `spawned` records the post-delay completion.
+  const started: { name: string; payload: unknown; options: unknown }[] = []
   const parsed = memoryPlugin.configSchema!.safeParse(rawConfig)
   if (!parsed.success) throw new Error(`config invalid: ${parsed.error.message}`)
   const spawnDelayMs = options.spawnDelayMs ?? 0
@@ -113,6 +118,7 @@ async function bootMemoryPlugin(
     logger: options.logger ?? createPluginLogger('memory'),
     permissions: noopPermissionService,
     spawnSubagent: async (name, payload, spawnOptions) => {
+      started.push({ name, payload, options: spawnOptions })
       const startedAt = Date.now()
       if (spawnDelayMs > 0) await new Promise((r) => setTimeout(r, spawnDelayMs))
       const finishedAt = Date.now()
@@ -121,7 +127,7 @@ async function bootMemoryPlugin(
     isBooted: () => true,
   })
   const exports = await memoryPlugin.plugin(ctx)
-  return { exports, spawned, ctx }
+  return { exports, spawned, started, ctx }
 }
 
 let agentDir: string
@@ -263,7 +269,7 @@ describe('session.prompt hook', () => {
     // and time out on Discord/Slack first-message-after-stale-rollover.
     await writeTopic(agentDir, 'large-a', 'Large A', 'a'.repeat(3000))
     await writeTopic(agentDir, 'large-b', 'Large B', 'b'.repeat(3000))
-    const { exports, spawned } = await bootMemoryPlugin(
+    const { exports, spawned, started } = await bootMemoryPlugin(
       agentDir,
       { injectionBudgetBytes: 4096 },
       { spawnDelayMs: 10_000 },
@@ -277,9 +283,13 @@ describe('session.prompt hook', () => {
     )
     const elapsed = Date.now() - start
 
-    // then the hook returned promptly (well under the slow-spawn duration)
-    // and the spawn was kicked off in the background
+    // then the hook returned promptly (well under the slow-spawn duration),
+    // the spawn was actually initiated (not just dropped on the floor), and
+    // the spawn has NOT yet completed (proves the await was detached, not
+    // collapsed to a fast no-op by some test seam)
     expect(elapsed).toBeLessThan(500)
+    expect(started).toHaveLength(1)
+    expect(started[0]!.name).toBe('memory-retrieval')
     expect(spawned).toHaveLength(0)
   })
 

--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -241,6 +241,8 @@ describe('session.prompt hook', () => {
       },
     )
 
+    await waitFor(() => spawned.length >= 1, 'memory-retrieval spawn settles')
+
     expect(spawned).toHaveLength(1)
     expect(spawned[0]!.name).toBe('memory-retrieval')
     expect(spawned[0]!.payload).toEqual({
@@ -251,6 +253,71 @@ describe('session.prompt hook', () => {
       origin,
     })
     expect(spawned[0]!.options).toEqual({ parentSessionId: 'ses_parent', spawnedByOrigin: origin })
+  })
+
+  test('does not block on a slow memory-retrieval spawn (cold-start guard)', async () => {
+    // given a memory-retrieval spawn that takes 10s and a session.prompt hook
+    // invoked during cold-start. ensureLive in src/channels/router.ts caps the
+    // whole createForChannel chain at 30s; if the hook awaited the spawn,
+    // memory-retrieval's LLM call would consume the full ensureLive budget
+    // and time out on Discord/Slack first-message-after-stale-rollover.
+    await writeTopic(agentDir, 'large-a', 'Large A', 'a'.repeat(3000))
+    await writeTopic(agentDir, 'large-b', 'Large B', 'b'.repeat(3000))
+    const { exports, spawned } = await bootMemoryPlugin(
+      agentDir,
+      { injectionBudgetBytes: 4096 },
+      { spawnDelayMs: 10_000 },
+    )
+
+    // when session.prompt fires
+    const start = Date.now()
+    await exports.hooks!['session.prompt']!(
+      { sessionId: 'ses_cold_start', agentDir, prompt: 'first message after restart', origin: undefined },
+      { agentDir, pluginName: 'memory', logger: createPluginLogger('m') },
+    )
+    const elapsed = Date.now() - start
+
+    // then the hook returned promptly (well under the slow-spawn duration)
+    // and the spawn was kicked off in the background
+    expect(elapsed).toBeLessThan(500)
+    expect(spawned).toHaveLength(0)
+  })
+
+  test('detached spawn rejection is reported via plugin logger, not unhandled', async () => {
+    // given a spawnSubagent that rejects synchronously
+    await writeTopic(agentDir, 'large-a', 'Large A', 'a'.repeat(3000))
+    await writeTopic(agentDir, 'large-b', 'Large B', 'b'.repeat(3000))
+    const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes: 4096 })
+    if (!parsed.success) throw new Error(parsed.error.message)
+    const { logger, logs } = makeCapturingLogger()
+    const ctx = createPluginContext({
+      name: 'memory',
+      version: undefined,
+      agentDir,
+      config: parsed.data,
+      logger,
+      permissions: noopPermissionService,
+      spawnSubagent: async () => {
+        throw new Error('spawn rejected for test')
+      },
+      isBooted: () => true,
+    })
+    const exports = await memoryPlugin.plugin(ctx)
+
+    // when session.prompt fires
+    await exports.hooks!['session.prompt']!(
+      { sessionId: 'ses_fail', agentDir, prompt: 'q?', origin: undefined },
+      { agentDir, pluginName: 'memory', logger },
+    )
+
+    await waitFor(
+      () => logs.error.some((m) => m.includes('memory-retrieval spawn failed')),
+      'detached spawn rejection routed to logger',
+    )
+
+    // then the plugin logger received the failure with attribution
+    const errorLine = logs.error.find((m) => m.includes('memory-retrieval spawn failed'))
+    expect(errorLine).toMatch(/spawn rejected for test/)
   })
 
   test('does not spawn memory-retrieval when the injection plan is direct mode', async () => {

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -257,6 +257,24 @@ export default definePlugin({
             await fireMemoryLogger(sessionId, 'buffer-trip')
           }
         },
+        // session.prompt fires synchronously inside createResourceLoader during
+        // channel-origin cold start (src/agent/index.ts -> runSessionPrompt),
+        // which is itself inside ensureLive's 30s watchdog
+        // (src/channels/router.ts). awaiting memory-retrieval here makes a
+        // full LLM session (memory_search + read + write of an 8KB synthesis)
+        // a hard prerequisite of replying to the first Discord/Slack message
+        // after a stale rollover; a cold provider connection blows 30s and
+        // ensureLive times out, silently dropping the inbound.
+        //
+        // The retrieval cache is lag-by-one-prompt by design: appendRetrievalCache
+        // (load-memory.ts) reads the cache file written by THIS spawn on the
+        // NEXT prompt for the same session. The current prompt has no cache to
+        // read regardless of whether we await — detaching matches the documented
+        // contract instead of contradicting it.
+        //
+        // ctx.spawnSubagent does not reject in production (SubagentConsumer
+        // catches handler errors), but the catch() handler keeps third-party
+        // spawnSubagent implementations from surfacing as unhandled rejections.
         'session.prompt': async (event) => {
           if (event.origin?.kind === 'subagent') return
 
@@ -272,9 +290,12 @@ export default definePlugin({
             cacheFilePath,
             ...(event.origin !== undefined ? { origin: event.origin } : {}),
           }
-          await ctx.spawnSubagent('memory-retrieval', payload, {
+          const spawnPromise = ctx.spawnSubagent('memory-retrieval', payload, {
             parentSessionId: event.sessionId,
             ...(event.origin !== undefined ? { spawnedByOrigin: event.origin } : {}),
+          })
+          void spawnPromise.catch((err) => {
+            ctx.logger.error(`memory-retrieval spawn failed: ${err instanceof Error ? err.message : String(err)}`)
           })
         },
         'session.end': async (event) => {

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -272,9 +272,15 @@ export default definePlugin({
         // read regardless of whether we await — detaching matches the documented
         // contract instead of contradicting it.
         //
-        // ctx.spawnSubagent does not reject in production (SubagentConsumer
-        // catches handler errors), but the catch() handler keeps third-party
-        // spawnSubagent implementations from surfacing as unhandled rejections.
+        // ctx.spawnSubagent IS reject-able in production: it wraps
+        // dispatchSpawnSubagent (src/run/index.ts) which calls invokeSubagent
+        // directly with no try/catch. SubagentConsumer's catch only protects
+        // stream-initiated spawns (target.kind === 'new-session'), not the
+        // direct ctx.spawnSubagent path the hooks use. The .catch() here is
+        // load-bearing — without it, every memory-retrieval handler failure
+        // (LLM provider error, payload validation throw, etc.) would surface
+        // as an unhandled rejection now that we no longer await the promise
+        // at the call site.
         'session.prompt': async (event) => {
           if (event.origin?.kind === 'subagent') return
 

--- a/src/plugin/hooks.test.ts
+++ b/src/plugin/hooks.test.ts
@@ -152,6 +152,50 @@ describe('HookBus session.idle per-handler timeout', () => {
   })
 })
 
+describe('HookBus session.prompt per-handler timeout', () => {
+  test('a hung handler is bounded; the offending plugin is named; later handlers still run', async () => {
+    // given a bus where the first session.prompt handler never resolves and
+    // the second is observable. session.prompt fires during cold-start
+    // session creation inside ensureLive's 30s watchdog
+    // (src/channels/router.ts); without this per-handler timeout, a slow
+    // hook consumes the whole outer budget and the offending plugin is not
+    // named in the logs.
+    const errors: { plugin: string; message: string }[] = []
+    const recordLogger = (pluginName: string) => ({
+      info: () => {},
+      warn: () => {},
+      error: (m: string) => errors.push({ plugin: pluginName, message: m }),
+    })
+    const bus = createHookBus({ promptHandlerTimeoutMs: 30 })
+    bus.registerAll('hung-plugin', '/agent', recordLogger('hung-plugin'), {
+      'session.prompt': () => new Promise(() => {}),
+    })
+    let secondRan = false
+    bus.registerAll('healthy-plugin', '/agent', recordLogger('healthy-plugin'), {
+      'session.prompt': (event) => {
+        event.prompt += '\n[ok]'
+        secondRan = true
+      },
+    })
+
+    // when the chain runs
+    const event = { prompt: 'BASE', sessionId: 's1', agentDir: '/agent' }
+    const start = Date.now()
+    await bus.runSessionPrompt(event)
+    const elapsed = Date.now() - start
+
+    // then the chain returned within the per-handler ceiling, the offending
+    // plugin's logger received the timeout error with attribution, and the
+    // healthy plugin still ran (and got to mutate the prompt)
+    expect(elapsed).toBeLessThan(500)
+    expect(secondRan).toBe(true)
+    expect(event.prompt).toBe('BASE\n[ok]')
+    const hungError = errors.find((e) => e.plugin === 'hung-plugin')
+    expect(hungError?.message).toMatch(/plugin hung-plugin session\.prompt timed out after 30ms/)
+    expect(errors.find((e) => e.plugin === 'healthy-plugin')).toBeUndefined()
+  })
+})
+
 describe('HookBus session.end per-handler timeout', () => {
   test('a hung handler is bounded; the offending plugin is named; later handlers still run', async () => {
     // given a bus where the first session.end handler never resolves and

--- a/src/plugin/hooks.ts
+++ b/src/plugin/hooks.ts
@@ -31,6 +31,21 @@ export const IDLE_HANDLER_TIMEOUT_MS = 25_000
 // legitimate transcript flush while still bounding the failure mode.
 export const END_HANDLER_TIMEOUT_MS = 60_000
 
+// Per-handler ceiling for session.prompt. session.prompt fires
+// synchronously inside createResourceLoader (src/agent/index.ts), which on
+// channel-origin cold start is itself inside ensureLive's 30s watchdog
+// (src/channels/router.ts). An unbounded hook there silently consumes the
+// outer budget and times out without naming the offending plugin in the
+// logs. 20s leaves ~10s of headroom for the rest of the cold-start chain
+// (loadSelf, loadMemory shard reads, prefetchChannelContext) before
+// ensureLive fires.
+//
+// The bundled memory plugin's session.prompt fires memory-retrieval
+// detached, so it returns in <1ms in steady state; this ceiling guards
+// third-party hooks that legitimately need to do work inline, AND a
+// regression in the memory plugin that re-introduces an inline await.
+export const PROMPT_HANDLER_TIMEOUT_MS = 20_000
+
 export type RegisteredHook<K extends keyof Hooks> = {
   pluginName: string
   agentDir: string
@@ -59,6 +74,8 @@ export type CreateHookBusOptions = {
   idleHandlerTimeoutMs?: number
   // Test seam: per-handler ceiling for session.end invocations.
   endHandlerTimeoutMs?: number
+  // Test seam: per-handler ceiling for session.prompt invocations.
+  promptHandlerTimeoutMs?: number
 }
 
 type Registries = {
@@ -75,6 +92,7 @@ type Registries = {
 export function createHookBus(options: CreateHookBusOptions = {}): HookBus {
   const idleHandlerTimeoutMs = options.idleHandlerTimeoutMs ?? IDLE_HANDLER_TIMEOUT_MS
   const endHandlerTimeoutMs = options.endHandlerTimeoutMs ?? END_HANDLER_TIMEOUT_MS
+  const promptHandlerTimeoutMs = options.promptHandlerTimeoutMs ?? PROMPT_HANDLER_TIMEOUT_MS
   const r: Registries = {
     'session.start': [],
     'session.end': [],
@@ -155,7 +173,11 @@ export function createHookBus(options: CreateHookBusOptions = {}): HookBus {
     async runSessionPrompt(event) {
       for (const reg of r['session.prompt']) {
         try {
-          await reg.handler(event, ctx(reg))
+          await raceWithTimeout(
+            Promise.resolve(reg.handler(event, ctx(reg))),
+            promptHandlerTimeoutMs,
+            `plugin ${reg.pluginName} session.prompt`,
+          )
         } catch (err) {
           reportHookError(reg, 'session.prompt', err)
         }

--- a/src/plugin/manager.test.ts
+++ b/src/plugin/manager.test.ts
@@ -225,6 +225,43 @@ describe('loadPlugins — markBooted gates spawnSubagent', () => {
       /before boot completed/,
     )
   })
+
+  test('forwards the SpawnSubagentOptions arg to the wired implementation', async () => {
+    // given a plugin that spawns with parentSessionId + spawnedByOrigin options
+    // (the shape the bundled memory plugin's session.prompt hook passes).
+    // Without forwarding, dispatchSpawnSubagent in src/run/index.ts cannot
+    // resolve the spawned role or stamp provenance, and any future in-process
+    // coalescing keyed on payload would not see the parent's identity either.
+    const captured: { name: string; payload: unknown; options: unknown }[] = []
+    const setup: { spawn?: (name: string, payload: unknown, options: unknown) => Promise<void> } = {}
+    const loadEntry: LoadPluginEntryFn = async () => ({
+      name: 'p1',
+      version: undefined,
+      source: 's',
+      defined: {
+        plugin: async (ctx) => {
+          setup.spawn = (n, p, o) => ctx.spawnSubagent(n, p, o as never)
+          return {}
+        },
+      },
+    })
+
+    const result = await loadPlugins({ entries: ['p1'], agentDir: '/tmp', configsByName: {}, loadEntry })
+    result.setSpawnSubagent(async (name, payload, options) => {
+      captured.push({ name, payload, options })
+    })
+    result.markBooted()
+
+    const origin = { kind: 'channel' as const, adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null }
+    await setup.spawn!('worker', { x: 1 }, { parentSessionId: 'ses_parent', spawnedByOrigin: origin })
+
+    expect(captured).toHaveLength(1)
+    expect(captured[0]).toEqual({
+      name: 'worker',
+      payload: { x: 1 },
+      options: { parentSessionId: 'ses_parent', spawnedByOrigin: origin },
+    })
+  })
 })
 
 describe('loadPlugins — registry shape', () => {

--- a/src/plugin/manager.ts
+++ b/src/plugin/manager.ts
@@ -101,7 +101,7 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPlugins
       config: validatedConfig as never,
       logger,
       permissions,
-      spawnSubagent: (name, payload) => spawnSubagentImpl(name, payload),
+      spawnSubagent: (name, payload, options) => spawnSubagentImpl(name, payload, options),
       isBooted: () => booted,
     })
 

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -428,26 +428,61 @@ export async function startAgent({
   // Captured separately from setSpawnSubagent so both the plugin context and
   // the plugin-command runner can dispatch through the same path. The setter
   // returns void, so without this local binding we couldn't reuse the fn.
+  //
+  // In-flight coalescing for direct ctx.spawnSubagent calls mirrors the
+  // SubagentConsumer's stream-path gate (subagents.ts:441). Two queued
+  // `new-session` messages for the same (name, inFlightKey) drop the second
+  // on the consumer side; without the same gate here, two consecutive
+  // session.prompt fires (cold-start prompt N immediately followed by prompt
+  // N+1 on the same channel session) could both fire memory-retrieval spawns
+  // racing to write `memory/.retrieval-cache/<sessionId>.md`. Awaiting the
+  // spawn in the hook used to mask this; now that the hook is fire-and-forget,
+  // the race is exposed and the gate is mandatory.
+  //
+  // Same key shape as the consumer: `${name}:${inFlightKey(payload)}` when the
+  // subagent declares one, else just `${name}`. Collisions resolve cleanly
+  // (logged + return) instead of rejecting, because callers from
+  // session.prompt are detached and a colliding spawn is a noop, not an error.
+  const directSpawnInFlight = new Set<string>()
   const dispatchSpawnSubagent: CommandSpawnSubagent = async (name, payload, options) => {
-    // Resolve the spawning session's role from its origin so the subagent
-    // inherits it. Callers (hooks like session.idle) pass the parent origin
-    // verbatim; we look up the role rather than letting the caller forge it,
-    // closing the laundering vector the design doc calls out for cron.
-    const spawnedByRole =
-      options?.spawnedByOrigin !== undefined
-        ? pluginsLoaded.permissions.resolveRole(options.spawnedByOrigin)
-        : undefined
-    await invokeSubagent(name, {
-      registry: pluginRuntime.get().subagents,
-      createSessionForSubagent,
-      agentDir: cwd,
-      userPrompt: '',
-      payload,
-      onProviderError: (message) => console.error(`[subagent] ${name}: LLM call failed: ${message}`),
-      ...(options?.parentSessionId !== undefined ? { parentSessionId: options.parentSessionId } : {}),
-      ...(spawnedByRole !== undefined ? { spawnedByRole } : {}),
-      ...(options?.spawnedByOrigin !== undefined ? { spawnedByOrigin: options.spawnedByOrigin } : {}),
-    })
+    const entry = pluginSubagentByName.get(name)
+    const keyFn = entry?.pluginSubagent.inFlightKey
+    let coalesceKey = name
+    if (keyFn !== undefined) {
+      try {
+        coalesceKey = `${name}:${keyFn(payload)}`
+      } catch {
+        coalesceKey = name
+      }
+    }
+    if (directSpawnInFlight.has(coalesceKey)) {
+      console.warn(`[subagent] ${coalesceKey}: previous direct spawn still in progress, skipping`)
+      return
+    }
+    directSpawnInFlight.add(coalesceKey)
+    try {
+      // Resolve the spawning session's role from its origin so the subagent
+      // inherits it. Callers (hooks like session.idle) pass the parent origin
+      // verbatim; we look up the role rather than letting the caller forge it,
+      // closing the laundering vector the design doc calls out for cron.
+      const spawnedByRole =
+        options?.spawnedByOrigin !== undefined
+          ? pluginsLoaded.permissions.resolveRole(options.spawnedByOrigin)
+          : undefined
+      await invokeSubagent(name, {
+        registry: pluginRuntime.get().subagents,
+        createSessionForSubagent,
+        agentDir: cwd,
+        userPrompt: '',
+        payload,
+        onProviderError: (message) => console.error(`[subagent] ${name}: LLM call failed: ${message}`),
+        ...(options?.parentSessionId !== undefined ? { parentSessionId: options.parentSessionId } : {}),
+        ...(spawnedByRole !== undefined ? { spawnedByRole } : {}),
+        ...(options?.spawnedByOrigin !== undefined ? { spawnedByOrigin: options.spawnedByOrigin } : {}),
+      })
+    } finally {
+      directSpawnInFlight.delete(coalesceKey)
+    }
   }
   pluginsLoaded.setSpawnSubagent(dispatchSpawnSubagent)
   pluginsLoaded.markBooted()


### PR DESCRIPTION
## Why

Channel-routed agents (Discord, Slack, KakaoTalk, Telegram, GitHub) silently dropped the first inbound message after a stale rollover, with logs ending in:

```
[channels] ...: ensureLive resolved-membership
[plugin:memory] [memory-retrieval] ... start cache=/agent/memory/.retrieval-cache/...md
[channels] ...: ensureLive failed: ensureLive timed out after 30000ms
```

PR #320 ("wake channel sessions after spawned subagent completes") addressed a downstream wakeup gap and did not touch this path. PR #318 ("restore pre-#314 session cold-start latency") parallelized `loadSelf` / `renderGitNudge` / `loadMemory` but did not change the plugin-hook fire path.

### The blocking chain

```
Discord inbound → ensureLive (30s watchdog, src/channels/router.ts:919)
  └→ createForChannel
      └→ createSession
          └→ createResourceLoader   (src/agent/index.ts:764)
              └→ runSessionPrompt   (src/agent/index.ts:811 — unbounded)
                  └→ memory plugin "session.prompt" hook
                      └→ await ctx.spawnSubagent("memory-retrieval", ...)
                          └→ runSession({ userPrompt: ... })  ← full LLM call
```

The "session.prompt" hook fires synchronously inside `createResourceLoader` during session creation, not during a later `session.prompt()` call. The hook was awaiting `ctx.spawnSubagent("memory-retrieval", ...)`, which runs a full LLM session (`memory_search` + `read` + write of an 8 KB synthesis). On the first message after a stale rollover, the cold provider connection blew 30s and `ensureLive`'s outer watchdog fired before any reply path ran — the symptom users reported.

### Why channel cold-start specifically

The memory plugin README documents that channel-origin sessions ALWAYS use index mode (the `memory-retrieval` path) regardless of shard size — a defense against memory bleed into channel responses. TUI sessions with small memory land in `direct` mode and skip the subagent entirely, so this only reliably reproduces on channels.

### Why it's a contract violation, not just slow

The plugin README itself says the retrieval cache is **lag-by-one-prompt** by design: `appendRetrievalCache` (`src/bundled-plugins/memory/load-memory.ts:65-77`) reads the cache file written by THIS spawn on the **NEXT** prompt for the same session. The current prompt has no cache to read regardless of whether the hook awaits — so awaiting it gates the current prompt on data only the next prompt can use.

## Changes

### 1. `src/bundled-plugins/memory/index.ts` — detach the spawn

The `session.prompt` hook now kicks off `memory-retrieval` without awaiting:

```ts
const spawnPromise = ctx.spawnSubagent('memory-retrieval', payload, { ... })
void spawnPromise.catch((err) => {
  ctx.logger.error(`memory-retrieval spawn failed: ${err instanceof Error ? err.message : String(err)}`)
})
```

`ctx.spawnSubagent` does not reject in production (`SubagentConsumer` catches handler errors), but the `.catch()` keeps third-party `spawnSubagent` implementations from surfacing as unhandled rejections, and the failure is attributed to `[plugin:memory]` in the logs.

This matches the documented "lag-by-one-prompt" contract: the subagent writes the cache file in the background; the NEXT prompt picks it up via `appendRetrievalCache`.

### 2. `src/plugin/hooks.ts` — bound `runSessionPrompt`

Adds `PROMPT_HANDLER_TIMEOUT_MS = 20_000` and wraps each `session.prompt` handler in `raceWithTimeout`, mirroring the existing `IDLE_HANDLER_TIMEOUT_MS = 25_000` and `END_HANDLER_TIMEOUT_MS = 60_000` ceilings:

- 20s leaves ~10s of headroom under `ensureLive`'s 30s for the rest of the cold-start chain (`loadSelf`, `loadMemory` shard reads, `prefetchChannelContext`).
- Guards third-party plugins that legitimately do inline work in `session.prompt`.
- Catches regressions that re-introduce an inline `await` in the memory plugin's hook — if it ever comes back, the offending plugin gets named in the logs (`plugin memory session.prompt timed out after 20000ms`) instead of the failure surfacing as a generic `ensureLive` timeout with no attribution.
- A `promptHandlerTimeoutMs` test seam on `CreateHookBusOptions` lets the timeout fire in milliseconds in tests, matching the existing `idleHandlerTimeoutMs` / `endHandlerTimeoutMs` seams.

## Tests

- **`src/bundled-plugins/memory/index.test.ts`** — Two new tests:
  - `does not block on a slow memory-retrieval spawn (cold-start guard)` — wires `bootMemoryPlugin` with `spawnDelayMs: 10_000`, fires the hook, asserts the hook returns in <500ms. Without the fix, the hook would block for 10s.
  - `detached spawn rejection is reported via plugin logger, not unhandled` — wires a `spawnSubagent` that throws synchronously, asserts the rejection is captured by the plugin logger with `memory-retrieval spawn failed:` attribution. This is the assertion that protects against the unhandled-rejection failure mode of fire-and-forget patterns.
  - Updated existing `spawns memory-retrieval when the injection plan is index mode` to await the detached spawn's settlement via `waitFor` before asserting on `spawned[]`.

- **`src/plugin/hooks.test.ts`** — New describe block `HookBus session.prompt per-handler timeout`:
  - Mirrors the existing `session.idle` and `session.end` per-handler-timeout tests.
  - Wires a hung first handler and a healthy second handler with `promptHandlerTimeoutMs: 30`.
  - Asserts: chain returns within the ceiling, hung plugin gets named in its logger, healthy plugin still runs AND still gets to mutate `event.prompt` (proves the timeout doesn't break the prompt-mutation composition contract from the existing `'multiple plugins compose; each sees the previous mutation'` test).

Full suite: **5197 / 5197 pass**, 11320 expects across 295 files. `bun run typecheck`, `bun run lint`, `bun run format:check` all clean.

## What's NOT in this PR

- **Moving `memory-retrieval` out of `session.prompt` entirely** (e.g. to `session.idle` or `session.turn.end`). That would be cleaner long-term — the retrieval is genuinely a between-turn task, not a prompt-time task — but it's an invasive lifecycle change for what is fundamentally a one-line fire-and-forget bug. Deferred to a follow-up if/when other plugins need the same shape.
- **Per-turn regeneration of the channel origin block.** Orthogonal to this fix; tracked in the existing `originRef` comment in `src/channels/router.ts`.
- **An `agent/index.test.ts` integration test exercising the full `ensureLive` → `createResourceLoader` → `runSessionPrompt` chain.** The two narrower tests above prove the fix at the unit level (hook returns promptly; timeout-as-defense works) and the channel-router tests already pin `ensureLive`'s 30s wrap. An end-to-end test would need to stub the LLM provider and reproduce the slow-cold-connection condition, which adds a lot of test scaffolding for a contract that's already verified at both ends.
