### PR TITLE
test: deny `bun test` without --parallel via preload guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ TypeClaw runs code in three distinct stages. Each stage has a different filesyst
 
 ### dev stage — this repo
 
-Where you are when you run `bun test` or `bun run typecheck` on the typeclaw source tree. The `typeclaw` CLI is executed directly from `src/cli/index.ts` (no install step). There is no agent folder and no container — only the source code of typeclaw itself. Changes here affect how agents are scaffolded and how the CLI behaves, but never an agent's runtime state.
+Where you are when you run `bun run test` or `bun run typecheck` on the typeclaw source tree. The `typeclaw` CLI is executed directly from `src/cli/index.ts` (no install step). There is no agent folder and no container — only the source code of typeclaw itself. Changes here affect how agents are scaffolded and how the CLI behaves, but never an agent's runtime state.
 
 ### host stage — the user's machine
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ See `typeclaw --help` for the full command surface, or [typeclaw.dev](https://ty
 git clone https://github.com/typeclaw/typeclaw
 cd typeclaw
 bun install
-bun test
+bun run test
 ```
 
 Pre-commit checks (all must pass — no exceptions):

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,6 @@
+[test]
+# Preload guard refuses `bun test` without --parallel. See
+# scripts/require-parallel.ts for rationale — TL;DR: Bun has no bunfig
+# knob for --parallel yet (verified against bunfig.zig in oven-sh/bun
+# main), and serial runs are ~3.4x slower than the parallel happy path.
+preload = ["./scripts/require-parallel.ts"]

--- a/scripts/require-parallel.test.ts
+++ b/scripts/require-parallel.test.ts
@@ -18,7 +18,10 @@ async function makeFixtureProject() {
     join(dir, 'noop.test.ts'),
     `import { test, expect } from 'bun:test'\ntest('noop', () => expect(1).toBe(1))\n`,
   )
-  await writeFile(join(dir, 'bunfig.toml'), `[test]\npreload = ["${scriptPath}"]\n`)
+  // JSON.stringify handles TOML basic-string escaping correctly (the escape
+  // sets overlap for `\` and `"`), which lets the test survive contributor
+  // checkouts under paths with embedded quotes or backslashes.
+  await writeFile(join(dir, 'bunfig.toml'), `[test]\npreload = [${JSON.stringify(scriptPath)}]\n`)
   return dir
 }
 

--- a/scripts/require-parallel.test.ts
+++ b/scripts/require-parallel.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptPath = join(dirname(fileURLToPath(import.meta.url)), 'require-parallel.ts')
+
+// Spawn `bun test` in a temp project that preloads our guard, then assert on
+// exit code. We use a temp dir rather than the repo's own tests so we control
+// the trivial test case (one passing test) and don't run the full 5198-test
+// suite per scenario. The preload runs in the spawned process, so its
+// process.exit(1) deny is observable as a non-zero parent exit code.
+
+async function makeFixtureProject() {
+  const dir = await mkdtemp(join(tmpdir(), 'require-parallel-test-'))
+  await writeFile(
+    join(dir, 'noop.test.ts'),
+    `import { test, expect } from 'bun:test'\ntest('noop', () => expect(1).toBe(1))\n`,
+  )
+  await writeFile(join(dir, 'bunfig.toml'), `[test]\npreload = ["${scriptPath}"]\n`)
+  return dir
+}
+
+async function runBunTest(args: string[], env: Record<string, string> = {}) {
+  const dir = await makeFixtureProject()
+  // The parent process running this file is itself `bun test --parallel`, so
+  // its env carries BUN_TEST_WORKER_ID (and possibly TYPECLAW_ALLOW_SERIAL_TESTS
+  // if the contributor set it). Both would leak into the child subprocess and
+  // bypass the guard we're trying to test. Strip them, then layer per-test
+  // overrides on top.
+  const parentEnv = { ...process.env }
+  delete parentEnv.BUN_TEST_WORKER_ID
+  delete parentEnv.TYPECLAW_ALLOW_SERIAL_TESTS
+  try {
+    const proc = Bun.spawn(['bun', 'test', ...args, 'noop.test.ts'], {
+      cwd: dir,
+      env: { ...parentEnv, ...env },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+    return { exitCode, stdout, stderr }
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+describe('require-parallel preload', () => {
+  test('denies `bun test` without --parallel (exit 1, prints deny message)', async () => {
+    const { exitCode, stderr } = await runBunTest([])
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('without --parallel is denied')
+    expect(stderr).toContain('bun run test')
+    expect(stderr).toContain('TYPECLAW_ALLOW_SERIAL_TESTS=1')
+  })
+
+  test('allows `bun test --parallel` (exit 0, tests run)', async () => {
+    const { exitCode, stderr } = await runBunTest(['--parallel'])
+    expect(exitCode).toBe(0)
+    expect(stderr).not.toContain('denied in this repo')
+  })
+
+  test('TYPECLAW_ALLOW_SERIAL_TESTS=1 bypasses the deny (exit 0, prints warn)', async () => {
+    const { exitCode, stderr } = await runBunTest([], { TYPECLAW_ALLOW_SERIAL_TESTS: '1' })
+    expect(exitCode).toBe(0)
+    expect(stderr).toContain('Running serially')
+    expect(stderr).not.toContain('denied in this repo')
+  })
+
+  test('TYPECLAW_ALLOW_SERIAL_TESTS=true is not a bypass (only literal "1") — denies', async () => {
+    const { exitCode } = await runBunTest([], { TYPECLAW_ALLOW_SERIAL_TESTS: 'true' })
+    expect(exitCode).toBe(1)
+  })
+
+  test('TYPECLAW_ALLOW_SERIAL_TESTS=0 is not a bypass — denies', async () => {
+    const { exitCode } = await runBunTest([], { TYPECLAW_ALLOW_SERIAL_TESTS: '0' })
+    expect(exitCode).toBe(1)
+  })
+
+  test('--coverage without --parallel still denies (the guard runs before the coverage flag is honored)', async () => {
+    const { exitCode } = await runBunTest(['--coverage'])
+    expect(exitCode).toBe(1)
+  })
+})

--- a/scripts/require-parallel.ts
+++ b/scripts/require-parallel.ts
@@ -12,7 +12,7 @@
 // the IPC handshake between coordinator and workers). Empirically
 // verified against bun 1.3.14: present under --parallel, absent under
 // serial. If a future Bun version renames this var, the guard fails
-// open (treats every run as serial → always denies), which is the
+// closed (treats every run as serial → always denies), which is the
 // safe direction.
 //
 // Bypass with TYPECLAW_ALLOW_SERIAL_TESTS=1 when debugging a flaky

--- a/scripts/require-parallel.ts
+++ b/scripts/require-parallel.ts
@@ -1,0 +1,41 @@
+// Preloaded by bunfig.toml `[test] preload`. Denies `bun test` without
+// --parallel. Serial runs are ~3.4x slower (44s → 13s, see commit
+// 1c66d5e), and Bun has no bunfig knob for the flag yet (verified
+// against bunfig.zig in oven-sh/bun main, May 2026). Without this
+// guard, IDE test runners and ad-hoc shells silently fall back to the
+// slow path.
+//
+// Detection: Bun strips CLI flags from `Bun.argv` before invoking the
+// preload, so we can't scrape the flag directly. Instead we look for
+// BUN_TEST_WORKER_ID, which Bun sets in the preload env exactly when
+// `--parallel` is active (the variable carries the worker index for
+// the IPC handshake between coordinator and workers). Empirically
+// verified against bun 1.3.14: present under --parallel, absent under
+// serial. If a future Bun version renames this var, the guard fails
+// open (treats every run as serial → always denies), which is the
+// safe direction.
+//
+// Bypass with TYPECLAW_ALLOW_SERIAL_TESTS=1 when debugging a flaky
+// test where worker contention obscures the failure.
+
+const isParallelWorker = typeof process.env.BUN_TEST_WORKER_ID === 'string'
+
+if (isParallelWorker) {
+  // proceed
+} else if (process.env.TYPECLAW_ALLOW_SERIAL_TESTS === '1') {
+  console.warn('[require-parallel] Running serially — TYPECLAW_ALLOW_SERIAL_TESTS=1 set.')
+} else {
+  console.error('')
+  console.error('  ✗ `bun test` without --parallel is denied in this repo.')
+  console.error('')
+  console.error('    Serial runs take ~46s; --parallel cuts that to ~14s on a multi-core')
+  console.error('    machine and is what CI uses. Bun does not (yet) accept `[test] parallel`')
+  console.error('    in bunfig.toml, so we enforce it via this preload.')
+  console.error('')
+  console.error('    Use one of:')
+  console.error('      bun run test                              # preferred')
+  console.error('      bun test --parallel                       # direct')
+  console.error('      TYPECLAW_ALLOW_SERIAL_TESTS=1 bun test    # intentional serial run')
+  console.error('')
+  process.exit(1)
+}


### PR DESCRIPTION
## Why

`bun run test` is parallel (CI hits it via the npm script with `--parallel`), but **plain `bun test` is silently serial**: 46s instead of 14s on a multi-core host. The slow path is what every IDE test runner, editor "run this test" button, and ad-hoc shell falls into.

Adding `[test] parallel = true` to `bunfig.toml` doesn't work — I verified empirically (46s/50% CPU vs 14s/489% CPU under `--parallel`) and against Bun's own source (`src/runtime/cli/bunfig.zig` in [oven-sh/bun#main](https://github.com/oven-sh/bun/blob/main/src/runtime/cli/bunfig.zig), May 2026). The `[test]` block parses 17 keys (`root`, `preload`, `smol`, `coverage`, `randomize`, `retry`, `concurrentTestGlob`, …) but `parallel` is not one of them. Bun's CLI flag exists at the runner layer; the bunfig surface for it hasn't shipped.

So instead of hoping nobody notices, this PR makes the slow path **fail loud**.

## What

```toml
# bunfig.toml
[test]
preload = ["./scripts/require-parallel.ts"]
```

The preload script checks for `process.env.BUN_TEST_WORKER_ID` — Bun sets this env var in worker processes exactly when `--parallel` is on. Empirically verified in 1.3.14: present under `--parallel`, absent under serial. If a future Bun renames the var, the guard fails closed (denies every run), which is the safe direction.

Three modes, all tested:

| Invocation | Result |
|---|---|
| `bun test` | ❌ exit 1, prints the deny message + 3 working alternatives |
| `bun test --parallel` | ✅ proceeds, 5198 pass in 14s |
| `bun run test` | ✅ proceeds (script already passes `--parallel`) |
| `TYPECLAW_ALLOW_SERIAL_TESTS=1 bun test` | ⚠️  warn + proceed |

Bypass env var exists for the legitimate case of debugging a flaky test where worker contention obscures the failure.

CI is unaffected — both workflows already pass `--parallel`. No `package.json` or workflow edits needed.

## The deny message

```
✗ `bun test` without --parallel is denied in this repo.

  Serial runs take ~46s; --parallel cuts that to ~14s on a multi-core
  machine and is what CI uses. Bun does not (yet) accept `[test] parallel`
  in bunfig.toml, so we enforce it via this preload.

  Use one of:
    bun run test                              # preferred
    bun test --parallel                       # direct
    TYPECLAW_ALLOW_SERIAL_TESTS=1 bun test    # intentional serial run
```

## Why not a wrapper script on PATH

Considered and rejected. A PATH-level `bun-test` wrapper would miss IDE test runners (they invoke `bun` directly, not through the wrapper) and editor buttons (same). The preload runs inside every `bun test` invocation regardless of how it was launched, so it's the only mechanism that catches all the cases.

## When to remove this

When Bun ships `[test] parallel` in bunfig — track [oven-sh/bun#1825](https://github.com/oven-sh/bun/issues/1825) (the umbrella issue for the test runner). At that point, delete `scripts/require-parallel.ts`, replace `preload = [...]` with `parallel = true`, and the user-visible behavior stays identical.

## Pre-commit checks

```
bun run typecheck   ✓
bun run lint        ✓ (41 pre-existing warnings, 0 errors)
bun run format      ✓
bun run test        ✓ 5198 pass, 0 fail (14s parallel)
```
