### PR TITLE
memory: recover agents whose pre-shard files are deleted but uncommitted

### DIFF
--- a/src/bundled-plugins/memory/migration.test.ts
+++ b/src/bundled-plugins/memory/migration.test.ts
@@ -543,6 +543,127 @@ describe('runShardingMigration', () => {
     expect(files.has('memory/MEMORY.md.pre-shard.bak')).toBe(true)
   })
 
+  test('orphan cleanup commits the deletions it performs (issue #315 path 2)', async () => {
+    await initGitRepo(agentDir)
+    await writePreMigratedTree()
+    await writeRootMemory('# Memory\n\n## Orphan\nold\n')
+    await writeFlatStream('2026-05-18', 'orphan\n')
+    await git(agentDir, [
+      'add',
+      '--',
+      'MEMORY.md',
+      'memory/2026-05-18.jsonl',
+      'memory/topics/existing.md',
+      'memory/streams/2026-05-18.jsonl',
+      'memory/MEMORY.md.pre-shard.bak',
+    ])
+    await git(agentDir, ['commit', '-m', 'pre-shard state with orphans'])
+
+    await runShardingMigration({ agentDir, logger })
+
+    const porcelain = await git(agentDir, ['status', '--porcelain', '--untracked-files=no'])
+    expect(porcelain.stdout).toBe('')
+    const latest = await git(agentDir, ['log', '--oneline', '-1'])
+    expect(latest.stdout).toContain('memory: clean up 2 pre-shard file(s) orphaned by earlier migration')
+    const tracked = await git(agentDir, ['ls-tree', '-r', '--name-only', 'HEAD'])
+    const files = new Set(tracked.stdout.split('\n').filter((line) => line !== ''))
+    expect(files.has('MEMORY.md')).toBe(false)
+    expect(files.has('memory/2026-05-18.jsonl')).toBe(false)
+    expect(files.has('memory/topics/existing.md')).toBe(true)
+    expect(files.has('memory/streams/2026-05-18.jsonl')).toBe(true)
+  })
+
+  test('recovers already-affected agents by committing pre-existing staged deletions', async () => {
+    await initGitRepo(agentDir)
+    await writePreMigratedTree()
+    await writeRootMemory('# Memory\n\n## Stale\nold\n')
+    await writeFlatStream('2026-05-19', 'stale\n')
+    await git(agentDir, [
+      'add',
+      '--',
+      'MEMORY.md',
+      'memory/2026-05-19.jsonl',
+      'memory/topics/existing.md',
+      'memory/streams/2026-05-18.jsonl',
+      'memory/MEMORY.md.pre-shard.bak',
+    ])
+    await git(agentDir, ['commit', '-m', 'pre-shard state'])
+    await rm(join(agentDir, 'MEMORY.md'))
+    await rm(join(memoryDir, '2026-05-19.jsonl'))
+    await git(agentDir, ['add', '-u', '--', 'MEMORY.md', 'memory/2026-05-19.jsonl'])
+    const beforePorcelain = await git(agentDir, ['status', '--porcelain', '--untracked-files=no'])
+    expect(beforePorcelain.stdout).toContain('D  MEMORY.md')
+    expect(beforePorcelain.stdout).toContain('D  memory/2026-05-19.jsonl')
+
+    await runShardingMigration({ agentDir, logger })
+
+    expect(messages.warn).toEqual([])
+    expect(messages.error).toEqual([])
+    const porcelain = await git(agentDir, ['status', '--porcelain', '--untracked-files=no'])
+    expect(porcelain.stdout).toBe('')
+    const latest = await git(agentDir, ['log', '--oneline', '-1'])
+    expect(latest.stdout).toContain('memory: clean up 2 pre-shard file(s) orphaned by earlier migration')
+  })
+
+  test('recovers already-affected agents whose deletions were never staged', async () => {
+    await initGitRepo(agentDir)
+    await writePreMigratedTree()
+    await writeRootMemory('# Memory\n\n## Stale\nold\n')
+    await writeFlatStream('2026-05-19', 'stale\n')
+    await git(agentDir, [
+      'add',
+      '--',
+      'MEMORY.md',
+      'memory/2026-05-19.jsonl',
+      'memory/topics/existing.md',
+      'memory/streams/2026-05-18.jsonl',
+      'memory/MEMORY.md.pre-shard.bak',
+    ])
+    await git(agentDir, ['commit', '-m', 'pre-shard state'])
+    await rm(join(agentDir, 'MEMORY.md'))
+    await rm(join(memoryDir, '2026-05-19.jsonl'))
+
+    await runShardingMigration({ agentDir, logger })
+
+    const porcelain = await git(agentDir, ['status', '--porcelain', '--untracked-files=no'])
+    expect(porcelain.stdout).toBe('')
+    const latest = await git(agentDir, ['log', '--oneline', '-1'])
+    expect(latest.stdout).toContain('memory: clean up 2 pre-shard file(s) orphaned by earlier migration')
+  })
+
+  test('no-op when post-shard tree is clean and no pending deletions exist', async () => {
+    await initGitRepo(agentDir)
+    await writePreMigratedTree()
+    await git(agentDir, [
+      'add',
+      '--',
+      'memory/topics/existing.md',
+      'memory/streams/2026-05-18.jsonl',
+      'memory/MEMORY.md.pre-shard.bak',
+    ])
+    await git(agentDir, ['commit', '-m', 'post-shard state'])
+    const headBefore = await git(agentDir, ['rev-parse', 'HEAD'])
+
+    await runShardingMigration({ agentDir, logger })
+
+    const headAfter = await git(agentDir, ['rev-parse', 'HEAD'])
+    expect(headAfter.stdout).toBe(headBefore.stdout)
+    const porcelain = await git(agentDir, ['status', '--porcelain', '--untracked-files=no'])
+    expect(porcelain.stdout).toBe('')
+  })
+
+  test('recovery is silent and harmless outside a git repo', async () => {
+    await writePreMigratedTree()
+    await writeRootMemory('# Memory\n\n## Orphan\nold\n')
+    await writeFlatStream('2026-05-18', 'orphan\n')
+
+    const result = await runShardingMigration({ agentDir, logger })
+
+    expect(result.migrated).toBe(false)
+    expect(existsSync(join(agentDir, 'MEMORY.md'))).toBe(false)
+    expect(existsSync(join(memoryDir, '2026-05-18.jsonl'))).toBe(false)
+  })
+
   async function writeRepresentativeFixture(): Promise<{ dreaming: string; skill: string }> {
     await writeRootMemory(representativeMemory())
     await writeFlatStream('2026-05-18', '{"type":"fragment","id":"id-1"}\n')

--- a/src/bundled-plugins/memory/migration.ts
+++ b/src/bundled-plugins/memory/migration.ts
@@ -77,7 +77,7 @@ export async function runShardingMigration(options: RunShardingMigrationOptions)
     ...extra,
   })
 
-  await recoverShardingOrphans(options.agentDir, options.logger)
+  await recoverShardingOrphans(options.agentDir, options.logger, options.git)
 
   if (existsSync(topicsDir(options.agentDir)) || !existsSync(rootMemoryPath(options.agentDir))) {
     return empty()
@@ -241,7 +241,11 @@ async function recoverShardingMigration(agentDir: string, logger: MigrationLogge
   )
 }
 
-async function recoverShardingOrphans(agentDir: string, logger: MigrationLogger): Promise<void> {
+async function recoverShardingOrphans(
+  agentDir: string,
+  logger: MigrationLogger,
+  git: MigrationGit | undefined,
+): Promise<void> {
   if (!existsSync(topicsDir(agentDir))) return
 
   let cleaned = false
@@ -260,6 +264,11 @@ async function recoverShardingOrphans(agentDir: string, logger: MigrationLogger)
   }
 
   if (cleaned) logger.info('[memory:migration] cleaned orphaned pre-shard memory files')
+
+  // Always called, even when nothing was cleaned this boot: pre-#315 migrations
+  // and earlier runs of this function unlinked without committing, leaving
+  // staged deletions that survive across reboots until cleared explicitly.
+  await commitPendingLegacyDeletions(agentDir, logger, git)
 }
 
 async function collectFlatJsonlDates(memoryDir: string): Promise<string[]> {
@@ -538,6 +547,68 @@ async function commitShardingMigration(
   if (commitSharding.exitCode !== 0) {
     logger.warn(`[memory:migration] git commit failed: ${commitSharding.stderr || commitSharding.stdout}`.trim())
   }
+}
+
+async function commitPendingLegacyDeletions(
+  agentDir: string,
+  logger: MigrationLogger,
+  git: MigrationGit | undefined,
+): Promise<void> {
+  const spawn = git?.spawn ?? spawnGit
+  const inside = await spawn(['rev-parse', '--is-inside-work-tree'], { cwd: agentDir })
+  if (inside.exitCode !== 0) return
+
+  const pending = await collectLegacyDeletions(agentDir, spawn)
+  if (pending.all.length === 0) return
+
+  // `git add -u` errors with "pathspec did not match" on paths whose deletion
+  // is already in the index, so stage only the working-tree-only deletions.
+  // The already-staged set is picked up by the commit directly.
+  if (pending.workingTreeOnly.length > 0) {
+    const addDeletions = await spawn(['add', '-u', '--', ...pending.workingTreeOnly], { cwd: agentDir })
+    if (addDeletions.exitCode !== 0) {
+      logger.warn(`[memory:migration] git add failed: ${addDeletions.stderr || addDeletions.stdout}`.trim())
+      return
+    }
+  }
+
+  const commit = await spawn(
+    [
+      'commit',
+      '-m',
+      `memory: clean up ${pending.all.length} pre-shard file(s) orphaned by earlier migration`,
+      '--no-edit',
+    ],
+    { cwd: agentDir },
+  )
+  if (commit.exitCode !== 0) {
+    logger.warn(`[memory:migration] git commit failed: ${commit.stderr || commit.stdout}`.trim())
+  }
+}
+
+async function collectLegacyDeletions(
+  agentDir: string,
+  spawn: NonNullable<MigrationGit['spawn']>,
+): Promise<{ all: string[]; workingTreeOnly: string[] }> {
+  const isLegacy = (line: string): boolean => line === 'MEMORY.md' || /^memory\/\d{4}-\d{2}-\d{2}\.jsonl$/.test(line)
+  const parse = (out: string): string[] =>
+    out
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(isLegacy)
+
+  const allDiff = await spawn(['diff', 'HEAD', '--name-only', '--diff-filter=D', '--', 'memory/', 'MEMORY.md'], {
+    cwd: agentDir,
+  })
+  if (allDiff.exitCode !== 0) return { all: [], workingTreeOnly: [] }
+  const all = parse(allDiff.stdout)
+  if (all.length === 0) return { all: [], workingTreeOnly: [] }
+
+  const wtDiff = await spawn(['diff', '--name-only', '--diff-filter=D', '--', 'memory/', 'MEMORY.md'], {
+    cwd: agentDir,
+  })
+  const workingTreeOnly = wtDiff.exitCode === 0 ? parse(wtDiff.stdout) : []
+  return { all, workingTreeOnly }
 }
 
 async function spawnGit(


### PR DESCRIPTION
## Why

PR #315 made the happy-path sharding migration commit its own deletions, but two sibling paths still produce the same `git status` symptom users keep hitting on Slack/issues:

```
On branch main
Changes to be committed:
        deleted:    memory/2026-05-05.jsonl
        deleted:    memory/2026-05-06.jsonl
        ...
```

1. **`recoverShardingOrphans`** (`migration.ts:244`) runs on every boot whenever `memory/topics/` exists and unlinks orphan `MEMORY.md` + flat `memory/<date>.jsonl` files. It never stages or commits the deletion, so the orphan reappears in the index as a staged deletion that lives forever. `runShardingMigration` then early-returns at line 82 because `topicsDir` already exists, so `commitShardingMigration` (the PR #315 fix) is never reached.

2. **Agents that completed sharding migration before PR #315 merged** (commit `6cb93ce`, May 22) already have staged deletions in their index from that older code path. PR #315's own body explicitly acknowledges this:

   > Recovery for already-affected agents
   > This fix only repairs future migrations. Existing affected agents won't re-trigger `runShardingMigration` because it early-returns when `memory/topics/` already exists.

   Manual `git add -u && git commit` was the only remedy.

Both shapes converge on "tracked legacy file is gone but the deletion was never committed" and can be fixed by a single unconditional sweep on the next boot.

## What

### `commitPendingLegacyDeletions` in `migration.ts`

Called unconditionally from `recoverShardingOrphans`, even when nothing was cleaned this boot, because already-affected agents need recovery without any fresh unlink to trigger it.

- `git diff HEAD --name-only --diff-filter=D -- memory/ MEMORY.md` enumerates every tracked path that is gone from either the index or the working tree. Filter to legacy shapes (`MEMORY.md`, `memory/<date>.jsonl`).
- `git diff --name-only --diff-filter=D` (without `--cached`) isolates the working-tree-only subset. Only those get `git add -u --` because `git add -u <path>` errors with `pathspec did not match` when the deletion is already in the index. Already-staged deletions pass through to the commit directly.
- Commit with subject `memory: clean up N pre-shard file(s) orphaned by earlier migration`.
- Outside a git repo, silent no-op (matches `commitMigration` / `commitShardingMigration`).
- No-op when no legacy deletions are pending (returns before staging anything).

### Tests (5 new cases in `migration.test.ts`)

1. **orphan cleanup commits the deletions it performs (issue #315 path 2)** — repo has flat `memory/<date>.jsonl` + root `MEMORY.md` orphans alongside a complete sharded tree, all tracked. `runShardingMigration` cleans the orphans and the same call commits them. `git status --porcelain --untracked-files=no` clean; latest commit subject lands.
2. **recovers already-affected agents by committing pre-existing staged deletions** — files were tracked, deleted from disk, AND already `git add -u`'d to the index before the migration ran. Boot picks up the staged deletions and commits them without re-staging.
3. **recovers already-affected agents whose deletions were never staged** — files were tracked and deleted from disk only (working-tree-only). Boot stages them via `git add -u` then commits.
4. **no-op when post-shard tree is clean and no pending deletions exist** — sharded tree fully committed, no orphans. HEAD doesn't advance and porcelain stays clean (idempotency on subsequent boots).
5. **recovery is silent and harmless outside a git repo** — orphan files cleaned from disk; no errors, no warnings.

## Rollout

Per the user's instruction: cut a release after this merges, and already-affected agents will commit their own stale deletions on the next `typeclaw start` cycle. Nothing for users to run manually.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 41 pre-existing warnings, 0 errors, none in changed files
- `bun run format:check` — clean
- `bun test src/bundled-plugins/memory/migration.test.ts` — 41 pass (36 pre-existing + 5 new)
- `bun test src/bundled-plugins/memory/` — 581 pass / 0 fail across 28 files
