### PR TITLE
inspect: surface tool results (including tool-result-cap markers) by reading role:toolResult messages

### DIFF
--- a/src/inspect/replay.test.ts
+++ b/src/inspect/replay.test.ts
@@ -247,6 +247,163 @@ describe('replayLines', () => {
     )
     expect(events).toEqual([])
   })
+
+  test('top-level role:toolResult message (real pi-coding-agent format) yields a tool end event with text joined from content parts', async () => {
+    // Real pi-coding-agent emits toolResult as its own top-level message, not as a block inside the prior assistant message.
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [{ type: 'toolCall', id: 'functions.read:0', name: 'read', arguments: { path: '/agent/x.md' } }],
+              usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { total: 0 } },
+              stopReason: 'toolUse',
+              timestamp: 1_000,
+            },
+          }),
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'toolResult',
+              toolCallId: 'functions.read:0',
+              toolName: 'read',
+              content: [{ type: 'text', text: 'Successfully read /agent/x.md' }],
+              isError: false,
+              timestamp: 1_250,
+            },
+          }),
+        ]),
+      ),
+    )
+    const ends = events.filter((e) => e.cat === 'tool' && e.phase === 'end')
+    expect(ends).toHaveLength(1)
+    const end = ends[0]!
+    if (end.cat !== 'tool' || end.phase !== 'end') throw new Error('unreachable')
+    expect(end.name).toBe('read')
+    expect(end.toolCallId).toBe('functions.read:0')
+    expect(end.isError).toBe(false)
+    expect(end.result).toBe('Successfully read /agent/x.md')
+    expect(end.durationMs).toBe(250)
+  })
+
+  test('top-level role:toolResult with isError surfaces error status', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [{ type: 'toolCall', id: 'bash:0', name: 'bash', arguments: { command: 'false' } }],
+              timestamp: 1_000,
+            },
+          }),
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'toolResult',
+              toolCallId: 'bash:0',
+              toolName: 'bash',
+              content: [{ type: 'text', text: 'exit code 1' }],
+              isError: true,
+              timestamp: 1_100,
+            },
+          }),
+        ]),
+      ),
+    )
+    const end = events.find((e) => e.cat === 'tool' && e.phase === 'end')
+    if (end === undefined || end.cat !== 'tool' || end.phase !== 'end') throw new Error('expected tool end')
+    expect(end.isError).toBe(true)
+    expect(end.result).toBe('exit code 1')
+  })
+
+  test('top-level role:toolResult joins multiple text parts and surfaces tool-result-cap markers verbatim', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [{ type: 'toolCall', id: 'read:0', name: 'read', arguments: { path: 'big.txt' } }],
+              timestamp: 1_000,
+            },
+          }),
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'toolResult',
+              toolCallId: 'read:0',
+              toolName: 'read',
+              content: [
+                { type: 'text', text: 'first chunk' },
+                {
+                  type: 'text',
+                  text: '\n\n[tool-result-cap: 5000 bytes truncated from text part; original was 65536 bytes, textMaxBytes=65536]',
+                },
+              ],
+              isError: false,
+              timestamp: 1_100,
+            },
+          }),
+        ]),
+      ),
+    )
+    const end = events.find((e) => e.cat === 'tool' && e.phase === 'end')
+    if (end === undefined || end.cat !== 'tool' || end.phase !== 'end') throw new Error('expected tool end')
+    expect(end.result).toContain('first chunk')
+    expect(end.result).toContain('[tool-result-cap:')
+  })
+
+  test('top-level role:toolResult without a matching prior toolCall still emits a tool end (defensive: name from toolName)', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'toolResult',
+              toolCallId: 'orphan:0',
+              toolName: 'read',
+              content: [{ type: 'text', text: 'orphan result' }],
+              isError: false,
+              timestamp: 5_000,
+            },
+          }),
+        ]),
+      ),
+    )
+    expect(events).toHaveLength(1)
+    const end = events[0]!
+    if (end.cat !== 'tool' || end.phase !== 'end') throw new Error('expected tool end')
+    expect(end.name).toBe('read')
+    expect(end.durationMs).toBe(0)
+    expect(end.result).toBe('orphan result')
+  })
+
+  test('top-level role:toolResult message does NOT emit a spurious done event', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'toolResult',
+              toolCallId: 'read:0',
+              toolName: 'read',
+              content: [{ type: 'text', text: 'x' }],
+              isError: false,
+              timestamp: 1_000,
+            },
+          }),
+        ]),
+      ),
+    )
+    expect(events.find((e) => e.cat === 'done')).toBeUndefined()
+  })
 })
 
 describe('replayJsonl (real file in tmpdir)', () => {

--- a/src/inspect/replay.ts
+++ b/src/inspect/replay.ts
@@ -76,6 +76,36 @@ function* eventsFromEntry(
     yield* assistantEvents(message as AssistantMessage, ts, pending)
     return
   }
+  if (role === 'toolResult') {
+    const ev = toolResultMessageEvent(message, ts, pending)
+    if (ev !== null) yield ev
+    return
+  }
+}
+
+function toolResultMessageEvent(
+  message: { role: string; [k: string]: unknown },
+  ts: number,
+  pending: Map<string, { name: string; startTs: number }>,
+): InspectEvent | null {
+  const toolCallId = typeof message.toolCallId === 'string' ? message.toolCallId : null
+  if (toolCallId === null) return null
+  const entry = pending.get(toolCallId)
+  pending.delete(toolCallId)
+  const name = entry?.name ?? (typeof message.toolName === 'string' ? message.toolName : 'unknown')
+  const durationMs = entry !== undefined ? Math.max(0, ts - entry.startTs) : 0
+  const isError = message.isError === true
+  const text = readTextContent(message.content)
+  return {
+    cat: 'tool',
+    ts,
+    phase: 'end',
+    toolCallId,
+    name,
+    ...(text !== null && text !== '' ? { result: text } : {}),
+    isError,
+    durationMs,
+  }
 }
 
 function* assistantEvents(


### PR DESCRIPTION
## Why

`typeclaw inspect` showed tool call start lines (`tool ▸`) for every production session but never showed matching end lines (`tool ◂`). The result text was completely absent.

Root cause: `eventsFromEntry` in `src/inspect/replay.ts` had a branch that matched `toolResult` blocks INSIDE an assistant message's `content[]`. Real pi-coding-agent sessions don't store results that way — they emit the result as its own top-level message with `role: 'toolResult'`, `toolCallId`, `toolName`, and `content: ContentPart[]`. The existing code was dead against every production session. The original test at line 103 of `replay.test.ts` used a synthetic shape that exercised a branch the runtime never produced.

## What

### `src/inspect/replay.ts` (+30 lines)

Adds a `role === 'toolResult'` branch to `eventsFromEntry` and a new helper `toolResultMessageEvent`:

- Reads `toolCallId` and looks up the pending `toolCall` start entry to compute `durationMs`.
- Joins `ContentPart[]` text via the existing `readTextContent` helper.
- Emits an `InspectEvent` with `cat: 'tool'`, `phase: 'end'`, and the joined result text.

**Bonus**: `tool-result-cap` mutates oversized content parts in place, replacing them with `[tool-result-cap: ...]` markers. Because the new branch surfaces text parts verbatim, those markers now appear in `inspect` output — operators can see at a glance which tool results were elided for context-window reasons.

The old synthetic branch is preserved. It's still exercised by the existing test and is harmless as a defensive fallback.

### `src/inspect/replay.test.ts` (+157 lines, 5 new tests)

1. **Happy path** — `role: 'toolResult'` message yields one `tool end` event with correct `name`, `toolCallId`, `isError: false`, `result`, and `durationMs`.
2. **`isError: true`** — error status is threaded through to the event.
3. **Multiple text parts + `tool-result-cap` markers** — multi-part content is joined; the `[tool-result-cap: ...]` placeholder from a truncated part appears verbatim in `result`.
4. **Orphan `toolResult`** (no matching prior `toolCall`) — emits an event using `toolName` as a fallback name, `durationMs: 0`, no panic.
5. **No spurious `done` event** — processing a `toolResult` message does not accidentally yield any extra events.

## Before / After

**Before** (real production session output):

```
17:49:06  tool ▸     write({"path":"/agent/IDENTITY.md","content":"I am 도비 (Dobby).\n"})
17:49:06  tool ▸     read({"path":"/agent/typeclaw.json"})
17:49:06  done       tokens: 232 in / 111 out · stop=toolUse
17:49:07  tool ▸     write({"path":"/agent/typeclaw.json","content":"{\n  ...})
17:49:07  done       tokens: 445 in / 204 out · stop=toolUse
17:49:09  assist     완벽해! 도비라고 불러 주셔서 기쁘다 😊
```

**After** — paired `tool ◂` lines now appear with the result text:

```
17:49:06  tool ▸     write({"path":"/agent/IDENTITY.md","content":"I am 도비 (Dobby).\n"})
17:49:06  tool ▸     read({"path":"/agent/typeclaw.json"})
17:49:06  done       tokens: 232 in / 111 out · stop=toolUse
17:49:07  tool ◂     write → ok "Successfully wrote 17 bytes to /agent/IDENTITY.md" (1.2s)
17:49:07  tool ◂     read → ok "{ "$schema": "./node_modules/typeclaw/typeclaw.schema.json", "model": "fireworks…" (1.2s)
17:49:07  tool ▸     write({"path":"/agent/typeclaw.json","content":"{\n  ...})
17:49:07  done       tokens: 445 in / 204 out · stop=toolUse
17:49:09  tool ◂     write → ok "Successfully wrote 254 bytes to /agent/typeclaw.json" (1.6s)
17:49:09  assist     완벽해! 도비라고 불러 주셔서 기쁘다 😊
```

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 41 pre-existing warnings, 0 errors (none in changed files)
- `bun run format:check` — clean
- `bun test src/inspect/replay.test.ts` — 17/17 pass
- `bun test src/inspect/` — 94/94 pass
- End-to-end against a real production session JSONL: `tool ◂` lines appear correctly with result text and timing that were completely absent before.

Flaky test note: the full `bun run test` suite has a small (1–3) failure tail under parallel load from memory-plugin timing and hostd WS port collisions. These also fail on `origin/main` and are pre-existing CI noise, not regressions from this change.