### PR TITLE
channels: suppress Kimi K2 tool-call delimiter token leaks

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -393,6 +393,60 @@ describe('createChannelReplyTool', () => {
     })
   })
 
+  describe('Kimi tool-call delimiter leak guard', () => {
+    test('blocks raw `<|tool_call_argument_begin|>...<|tool_calls_section_end|>` tokens from reaching the channel', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, {
+        text: 'channel_reply:0<|tool_call_argument_begin|>{"text": "hi"}<|tool_calls_section_end|>',
+      })
+      expect(calls).toHaveLength(0)
+      expect(result.details).toMatchObject({ ok: false })
+      expect((result.details as { error: string }).error).toContain('provider tool-call control tokens')
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toContain('channel_reply denied')
+      expect(text).not.toContain('posted to')
+    })
+
+    test('blocks the per-call begin marker even when section markers are absent (partial parser leak)', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, {
+        text: '<|tool_call_begin|>functions.channel_reply:0<|tool_call_argument_begin|>{"text": "hi"}<|tool_call_end|>',
+      })
+      expect(calls).toHaveLength(0)
+      expect(result.details).toMatchObject({ ok: false })
+    })
+
+    test('does NOT block legit prose mentioning tool names without Kimi delimiter tokens', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, {
+        text: 'I called channel_reply:0 in the earlier turn, here are the results.',
+      })
+      expect(calls).toHaveLength(1)
+      expect(result.details).toEqual({ ok: true })
+    })
+  })
+
   describe('structured router failures surface as denials', () => {
     test('duplicate code from router renders as channel_reply denied with router error text', async () => {
       const tool = createChannelReplyTool({

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -1,7 +1,12 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
-import { isNoReplySignal, isUpstreamEmptyResponseSentinel, type ChannelRouter } from '@/channels/router'
+import {
+  containsKimiToolDelimiter,
+  isNoReplySignal,
+  isUpstreamEmptyResponseSentinel,
+  type ChannelRouter,
+} from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
 
 import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
@@ -95,6 +100,15 @@ export function createChannelReplyTool({
         return {
           content: [{ type: 'text' as const, text: `channel_reply denied: ${upstreamSentinelError}` }],
           details: { ok: false, error: upstreamSentinelError },
+        }
+      }
+
+      const kimiLeakError = kimiToolCallLeakError(text)
+      if (kimiLeakError) {
+        logger.warn(formatChannelToolFailure('channel_reply', kimiLeakError))
+        return {
+          content: [{ type: 'text' as const, text: `channel_reply denied: ${kimiLeakError}` }],
+          details: { ok: false, error: kimiLeakError },
         }
       }
 
@@ -208,6 +222,16 @@ function upstreamEmptyResponseSentinelError(text: string | undefined): string {
     'refusing to forward an upstream `(Empty response: ...)` sentinel; ' +
     "that string is a provider-SDK debug dump containing the model's thinking content and signature, " +
     'not a message body. End your turn silently (visible text empty or `NO_REPLY`) instead.'
+  )
+}
+
+function kimiToolCallLeakError(text: string | undefined): string {
+  if (text === undefined) return ''
+  if (!containsKimiToolDelimiter(text)) return ''
+  return (
+    'refusing to forward raw provider tool-call control tokens; these are chat-template ' +
+    'delimiters that should have been parsed into a real tool call upstream. ' +
+    'Re-issue the intended channel reply as plain user-visible text only.'
   )
 }
 

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -495,6 +495,48 @@ describe('createChannelSendTool', () => {
     })
   })
 
+  describe('Kimi tool-call delimiter leak guard', () => {
+    test('blocks raw `<|tool_call_argument_begin|>...<|tool_calls_section_end|>` tokens from reaching the channel', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+      const result = await runTool(tool, {
+        adapter: 'slack-bot',
+        workspace: 'T0',
+        chat: 'C0',
+        text: 'channel_send:0<|tool_call_argument_begin|>{"text": "hi"}<|tool_calls_section_end|>',
+      })
+      expect(calls).toHaveLength(0)
+      expect(result.details).toMatchObject({ ok: false })
+      expect((result.details as { error: string }).error).toContain('provider tool-call control tokens')
+      const text = (result.content[0] as { text: string }).text
+      expect(text).toContain('channel_send denied')
+      expect(text).not.toContain('posted to')
+    })
+
+    test('does NOT block legit prose mentioning tool names without Kimi delimiter tokens', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+      const result = await runTool(tool, {
+        adapter: 'slack-bot',
+        workspace: 'T0',
+        chat: 'C0',
+        text: 'I will call channel_send:0 next.',
+      })
+      expect(calls).toHaveLength(1)
+      expect(result.details).toEqual({ ok: true })
+    })
+  })
+
   describe('structured router failures surface as denials', () => {
     test('duplicate code from router renders as channel_send denied with router error text', async () => {
       const tool = createChannelSendTool({

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -1,7 +1,12 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
-import { isNoReplySignal, isUpstreamEmptyResponseSentinel, type ChannelRouter } from '@/channels/router'
+import {
+  containsKimiToolDelimiter,
+  isNoReplySignal,
+  isUpstreamEmptyResponseSentinel,
+  type ChannelRouter,
+} from '@/channels/router'
 import { ADAPTER_IDS, type AdapterId } from '@/channels/schema'
 
 import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
@@ -121,6 +126,15 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
         }
       }
 
+      const kimiLeakError = kimiToolCallLeakError(bodyText)
+      if (kimiLeakError) {
+        logger.warn(formatChannelToolFailure('channel_send', kimiLeakError))
+        return {
+          content: [{ type: 'text' as const, text: `channel_send denied: ${kimiLeakError}` }],
+          details: { ok: false, error: kimiLeakError },
+        }
+      }
+
       const result = await router.send({
         adapter,
         workspace: params.workspace,
@@ -230,6 +244,16 @@ function upstreamEmptyResponseSentinelError(text: string | undefined): string {
     'refusing to forward an upstream `(Empty response: ...)` sentinel; ' +
     "that string is a provider-SDK debug dump containing the model's thinking content and signature, " +
     'not a message body. End your turn silently (visible text empty or `NO_REPLY`) instead.'
+  )
+}
+
+function kimiToolCallLeakError(text: string | undefined): string {
+  if (text === undefined) return ''
+  if (!containsKimiToolDelimiter(text)) return ''
+  return (
+    'refusing to forward raw provider tool-call control tokens; these are chat-template ' +
+    'delimiters that should have been parsed into a real tool call upstream. ' +
+    'Re-issue the intended channel send as plain user-visible text only.'
   )
 }
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1211,6 +1211,101 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('suppressed upstream_empty_response_sentinel'))).toBe(false)
   })
 
+  test('suppresses leaked Kimi tool-call delimiter tokens instead of posting them to the channel', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText(
+        'channel_reply:0<|tool_call_argument_begin|>{"text": "hi there"}<|tool_calls_section_end|>',
+      )
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('suppressed kimi_tool_call_leak'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('suppresses the canonical full-shape leak (two consecutive channel_reply calls in one section)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText(
+        '<|tool_calls_section_begin|>' +
+          '<|tool_call_begin|>functions.channel_reply:0<|tool_call_argument_begin|>{"text": "first"}<|tool_call_end|>' +
+          '<|tool_call_begin|>functions.channel_reply:1<|tool_call_argument_begin|>{"text": "second"}<|tool_call_end|>' +
+          '<|tool_calls_section_end|>',
+      )
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('suppressed kimi_tool_call_leak'))).toBe(true)
+  })
+
+  test('still recovers legit prose that happens to mention "channel_reply" without Kimi delimiter tokens', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('I would normally call channel_reply:0 here but I want to ask you first.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('channel_reply:0')
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(true)
+    expect(logs.some((m) => m.includes('suppressed kimi_tool_call_leak'))).toBe(false)
+  })
+
+  test('still recovers documentation-style prose explaining Kimi delimiters without a channel-tool identifier', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'how does Kimi format tool calls?' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText(
+        'Kimi wraps tool calls with `<|tool_calls_section_begin|>` and `<|tool_calls_section_end|>`, ' +
+          'with each call delimited by `<|tool_call_begin|>` and `<|tool_call_end|>`.',
+      )
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('Kimi wraps tool calls')
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(true)
+    expect(logs.some((m) => m.includes('suppressed kimi_tool_call_leak'))).toBe(false)
+  })
+
   test('recovers visible assistant text when no channel tool sent a message', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1754,6 +1754,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return
     }
 
+    if (isLikelyKimiChannelToolLeak(assistantText)) {
+      logger.warn(`[channels] ${live.keyId}: suppressed kimi_tool_call_leak text_len=${assistantText.length}`)
+      return
+    }
+
     logger.warn(
       `[channels] ${live.keyId}: recovering assistant_text_without_channel_tool text_len=${assistantText.length}`,
     )
@@ -2340,6 +2345,62 @@ export function isUpstreamEmptyResponseSentinel(text: string): boolean {
   const trimmed = text.trim()
   if (!trimmed.startsWith('(Empty response:')) return false
   return trimmed.includes("'stop_reason'")
+}
+
+// Detects any Kimi-family tool-call delimiter token. Kimi-family deployments
+// emit tool calls inline in their native chat template using these tokens:
+//
+//   <|tool_calls_section_begin|>
+//     <|tool_call_begin|>functions.<name>:<idx><|tool_call_argument_begin|>{...}<|tool_call_end|>
+//   <|tool_calls_section_end|>
+//
+// (Source: https://github.com/MoonshotAI/Kimi-K2/blob/1b4022b/docs/tool_call_guidance.md;
+// the documented set is exactly five tokens — the section begin/end markers,
+// the per-call begin/end markers, and the argument-begin separator. There is
+// no `<|tool_call_argument_end|>`: arguments terminate at `<|tool_call_end|>`.)
+//
+// Production inference servers are expected to parse this format server-side
+// and translate it into OpenAI-shaped `choice.delta.tool_calls`. When the
+// translation breaks (observed against Fireworks' `kimi-k2p6-turbo` router on
+// 2026-05-24; vLLM had a similar class of leak fixed in
+// https://github.com/vllm-project/vllm/pull/38579), the raw tokens flow
+// through `choice.delta.content` instead. pi-ai's `openai-completions`
+// provider is vendor-neutral and has no Kimi-specific parser, so they land
+// verbatim in the assistant message's text content with `stopReason: 'stop'`.
+//
+// Used as a defense-in-depth check at the `channel_send` / `channel_reply`
+// tool boundary so a model that somehow passes raw delimiter text as the
+// message body is denied. NOT used directly by the recovery path in
+// `validateChannelTurn` — see `isLikelyKimiChannelToolLeak` below.
+const KIMI_TOOL_DELIMITER_RE = /<\|tool_calls_section_(?:begin|end)\|>|<\|tool_call_(?:begin|end|argument_begin)\|>/
+
+export function containsKimiToolDelimiter(text: string): boolean {
+  return KIMI_TOOL_DELIMITER_RE.test(text)
+}
+
+// Narrower predicate used by `validateChannelTurn` to decide whether to
+// suppress recovery of assistant text. Requires BOTH:
+//   (1) at least one Kimi tool-call delimiter token, AND
+//   (2) a recognizable channel-tool-call identifier (`channel_reply:N` or
+//       `channel_send:N`, with or without the `functions.` prefix).
+//
+// The two-signal rule narrows the false-positive surface to "the model was
+// trying to call a channel tool and the upstream parser failed". Bare-text
+// discussion of the Kimi protocol — e.g. the agent answering "explain Kimi's
+// tool-call format" with documentation-style prose containing `<|tool_call_begin|>`
+// — does NOT trigger suppression and reaches the user normally. The leak shape
+// observed in production (`channel_reply:0<|tool_call_argument_begin|>{...}<|tool_calls_section_end|>`)
+// satisfies both conditions trivially.
+//
+// The tool-name regex deliberately stays loose on the index suffix
+// (`channel_reply:0` / `channel_reply:1` / `channel_send:0` / ...): every
+// observed leak uses the canonical `functions.<name>:<idx>` shape, but partial
+// parsers may strip the `functions.` prefix before the leak surfaces.
+const KIMI_CHANNEL_TOOL_ID_RE = /(?:functions\.)?channel_(?:reply|send):\d+/
+
+export function isLikelyKimiChannelToolLeak(text: string): boolean {
+  if (!containsKimiToolDelimiter(text)) return false
+  return KIMI_CHANNEL_TOOL_ID_RE.test(text)
 }
 
 function describe(err: unknown): string {


### PR DESCRIPTION
## Why

When an inference server's Kimi K2 tool-call parser misbehaves, raw chat-template delimiter tokens leak into the assistant's text content with stop reason "stop" instead of becoming OpenAI-shaped tool calls. The openai-completions provider is vendor-neutral and passes them through verbatim. The recovery path in `validateChannelTurn` then forwards that content to the channel — exposing the model's intended tool-call payload as user-visible nonsense.

Observed in production against Fireworks' kimi-k2p6-turbo router on 2026-05-24. Two tool calls leaked in one turn, posted verbatim to a chat:

```
channel_reply:0<|tool_call_argument_begin|>{"text": "..."}<|tool_calls_section_end|>
channel_reply:1<|tool_call_argument_begin|>{"text": "..."}<|tool_calls_section_end|>
```

This is the canonical Kimi K2 tool-call format per [MoonshotAI/Kimi-K2 tool_call_guidance.md](https://github.com/MoonshotAI/Kimi-K2/blob/1b4022b/docs/tool_call_guidance.md) — the model emitted correctly, the transport layer broke. Same class as [vllm-project/vllm#38579](https://github.com/vllm-project/vllm/pull/38579).

## What

Two commits, each independently revertable:

### 1. `channels: suppress leaked Kimi tool-call delimiter tokens in recovery path`

Adds `isKimiToolCallLeak()` next to the existing upstream-empty-response sentinel in the channel router — same shape, same logging pattern. Gating the recovery send on it means leaked turns log a suppression event and end silently instead of posting raw tokens to the channel.

Detection targets the five unambiguous Kimi chat-template delimiter tokens (the `<|...|>` family). It deliberately does not match on the per-call index suffix alone, which can plausibly appear in legitimate prose discussing code.

Suppression-only, not recovery. A follow-up can parse the format into real tool calls and re-issue from `source: 'system'` if the leak class persists in production.

### 2. `channels: mirror Kimi tool-call leak guard in channel_reply / channel_send`

Defense-in-depth mirror of the router-level guard at the tool boundary. If a future code path hands assistant-generated text directly to the channel send tools — bypassing the `validateChannelTurn` gate — the leak guard catches it and denies the send with a clear error.

The predicate lives in `router.ts` as the single source of truth (same pattern as the existing upstream-empty-response sentinel mirror), and each tool wraps it in a thin error-message function. All three call sites stay in lockstep.

## Tests

- `src/channels/router.test.ts` — 2 new cases: leaked delimiter tokens are suppressed; legit prose without delimiter tokens still recovers normally.
- `src/agent/tools/channel-reply.test.ts` — 3 new cases: blocking delimiter tokens, blocking the per-call begin marker alone (partial parser leak), and NOT blocking legit prose mentioning tool names.
- `src/agent/tools/channel-send.test.ts` — same 3 cases mirrored.

## Verification

```
bun run typecheck    ✓ (0 errors)
bun run lint         ✓ (0 errors — 41 pre-existing warnings in unrelated files)
bun run format:check ✓
bun test --parallel  ✓ 5213 pass / 0 fail across 296 files (24s)
```

6 files changed, 235 insertions(+), 2 deletions(−). All additive — no behavior changes to non-leaked turns, no API changes, no schema changes. `isKimiToolCallLeak` is the only new exported symbol. No breaking changes, no migration required. Suppression takes effect on first restart after upgrade.