### PR TITLE
channels: stop hallucinated outbound from tool-result echo and empty Current-message header

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -8,6 +8,7 @@ import {
   ECHO_MAX_CHARS,
   renderEcho,
   renderOutboundEcho,
+  TOOL_RESULT_PREFIX,
   type ChannelReplyOrigin,
 } from './channel-reply'
 
@@ -107,7 +108,7 @@ describe('createChannelReplyTool', () => {
     })
     const result = await runTool(tool, { text: 'hi' })
     const text = (result.content[0] as { text: string }).text
-    expect(text).toBe('posted to slack-bot:T0/C0: "hi"')
+    expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C0: "hi"`)
   })
 
   test('echoes JSON-quoted text so the model can detect duplicates across iterations', async () => {
@@ -143,6 +144,41 @@ describe('createChannelReplyTool', () => {
     const text = (result.content[0] as { text: string }).text
     expect(text).toContain('channel_reply denied')
     expect(text).toContain('denied by allow rules')
+  })
+
+  describe('tool-result marker', () => {
+    test('success branch is prefixed with the marker so the model cannot read the echo as a user message', async () => {
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async () => ({ ok: true })),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, { text: 'hi' })
+      const text = (result.content[0] as { text: string }).text
+      expect(text.startsWith(TOOL_RESULT_PREFIX)).toBe(true)
+      expect(text).toContain('not a user message')
+    })
+
+    test('denial branch is also prefixed with the marker (same framing for both outcomes)', async () => {
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async () => ({ ok: false, error: 'denied by allow rules' })),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, { text: 'nope' })
+      const text = (result.content[0] as { text: string }).text
+      expect(text.startsWith(TOOL_RESULT_PREFIX)).toBe(true)
+      expect(text).toContain('channel_reply denied')
+    })
+
+    test('marker survives the consecutive-send hint (prefix stays at the very start)', async () => {
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async () => ({ ok: true }), { consecutiveCount: 2 }),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, { text: 'continuing' })
+      const text = (result.content[0] as { text: string }).text
+      expect(text.startsWith(TOOL_RESULT_PREFIX)).toBe(true)
+      expect(text).toContain('2nd consecutive message')
+    })
   })
 
   test('second consecutive reply appends a soft yield hint', async () => {

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -162,13 +162,23 @@ export function createChannelReplyTool({
             }),
           )
         : ''
+      const body = hint ? `${baseText} — ${hint}` : baseText
       return {
-        content: [{ type: 'text' as const, text: hint ? `${baseText} — ${hint}` : baseText }],
+        content: [{ type: 'text' as const, text: `${TOOL_RESULT_PREFIX}${body}` }],
         details,
       }
     },
   })
 }
+
+// Tool results reach the model as USER-role messages (OpenAI / Anthropic
+// tool-API contract — the engine cannot tag them as system). Without this
+// marker a persona-rich model reads its own echo as a fresh user inbound
+// and replies to itself. Observed in production: Kimi K2 on KakaoTalk
+// re-invoked after a successful send saw only the echo as new context
+// and hallucinated a goodbye trigger from it. Mirrored verbatim in
+// channel-send.ts so both tools share one greppable marker.
+export const TOOL_RESULT_PREFIX = '[system: tool result, not a user message] '
 
 export const ECHO_MAX_CHARS = 500
 

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import type { ChannelRouter } from '@/channels/router'
 import type { OutboundMessage, SendResult } from '@/channels/types'
 
+import { TOOL_RESULT_PREFIX } from './channel-reply'
 import { createChannelSendTool } from './channel-send'
 
 function fakeRouter(
@@ -114,7 +115,7 @@ describe('createChannelSendTool', () => {
       text: 'first reply',
     })
     const text = (result.content[0] as { text: string }).text
-    expect(text).toBe('posted to slack-bot:T0/C0: "first reply"')
+    expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C0: "first reply"`)
   })
 
   test('second consecutive send appends a soft yield hint', async () => {
@@ -193,7 +194,7 @@ describe('createChannelSendTool', () => {
         text: 'in thread',
       })
       const text = (result.content[0] as { text: string }).text
-      expect(text).toBe('posted to slack-bot:T0/C0: "in thread"')
+      expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C0: "in thread"`)
     })
 
     test('does NOT warn when the model deliberately posts to a DIFFERENT chat', async () => {
@@ -208,7 +209,7 @@ describe('createChannelSendTool', () => {
         text: 'cross-channel post',
       })
       const text = (result.content[0] as { text: string }).text
-      expect(text).toBe('posted to slack-bot:T0/C-other: "cross-channel post"')
+      expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C-other: "cross-channel post"`)
     })
 
     test('does NOT warn when the origin had no thread to begin with (channel-root origin)', async () => {
@@ -223,7 +224,7 @@ describe('createChannelSendTool', () => {
         text: 'channel-root reply',
       })
       const text = (result.content[0] as { text: string }).text
-      expect(text).toBe('posted to slack-bot:T0/C0: "channel-root reply"')
+      expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C0: "channel-root reply"`)
     })
 
     test('does NOT warn when no origin is supplied (cron / non-channel session)', async () => {
@@ -232,7 +233,7 @@ describe('createChannelSendTool', () => {
       })
       const result = await runTool(tool, { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', text: 'cron post' })
       const text = (result.content[0] as { text: string }).text
-      expect(text).toBe('posted to slack-bot:T0/C0: "cron post"')
+      expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C0: "cron post"`)
     })
 
     test('does NOT warn on adapter mismatch (cross-platform post)', async () => {
@@ -247,7 +248,7 @@ describe('createChannelSendTool', () => {
         text: 'cross-platform',
       })
       const text = (result.content[0] as { text: string }).text
-      expect(text).toBe('posted to discord-bot:g1/d1: "cross-platform"')
+      expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to discord-bot:g1/d1: "cross-platform"`)
     })
 
     test('combines with the consecutive-send hint when both fire', async () => {

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -10,7 +10,7 @@ import {
 import { ADAPTER_IDS, type AdapterId } from '@/channels/schema'
 
 import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
-import { renderOutboundEcho } from './channel-reply'
+import { renderOutboundEcho, TOOL_RESULT_PREFIX } from './channel-reply'
 
 export type ChannelSendOrigin = {
   adapter: AdapterId
@@ -177,9 +177,9 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
         })
         if (threadMismatch) hints.push(threadMismatch)
       }
-      const responseText = hints.length > 0 ? `${baseText} — ${hints.join(' ')}` : baseText
+      const body = hints.length > 0 ? `${baseText} — ${hints.join(' ')}` : baseText
       return {
-        content: [{ type: 'text' as const, text: responseText }],
+        content: [{ type: 'text' as const, text: `${TOOL_RESULT_PREFIX}${body}` }],
         details,
       }
     },

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4132,6 +4132,45 @@ describe('ChannelRouter injectSubagentCompletionReminder', () => {
     expect(combined.indexOf('<system-reminder>')).toBeLessThan(combined.indexOf('follow up'))
   })
 
+  test('reminder-only drain with non-empty contextBuffer never emits an EMPTY `## Current message` header', async () => {
+    // Regression: when a reminder woke drain() with an empty promptQueue
+    // and a non-empty contextBuffer, composeTurnPrompt used to print
+    // `## Current message (addressed to you)` with zero lines under it.
+    // Persona-rich models read the dangling header as proof there was a
+    // new user message they were failing to see and hallucinated content
+    // to reply to. The header is now batch-gated.
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    // given: an engaged inbound creates the live session, then an observed
+    // inbound from a different author lands in the contextBuffer (engagement
+    // 'observe' branch — the contextBuffer is what flushes on the next drain)
+    await router.route(inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    await router.route(inbound({ isBotMention: false, authorId: 'bob', authorName: 'bob', text: 'side chatter' }))
+    const promptsBeforeReminder = sessions[0]!.prompts.length
+
+    // when: a subagent completion fires while the promptQueue is empty
+    router.injectSubagentCompletionReminder({
+      parentSessionId: 'ses_fake_1',
+      subagent: 'explorer',
+      taskId: 'bg_empty_current',
+      ok: true,
+      durationMs: 100,
+    })
+    await waitFor(() => sessions[0]!.prompts.length > promptsBeforeReminder)
+
+    // then: the reminder prompt carries the reminder + observed context,
+    // but the `## Current message` header is absent because there is no
+    // queued inbound to live under it
+    const reminderPrompt = sessions[0]!.prompts[sessions[0]!.prompts.length - 1] ?? ''
+    expect(reminderPrompt).toContain('<system-reminder>')
+    expect(reminderPrompt).toContain('bg_empty_current')
+    expect(reminderPrompt).toContain('## Recent context')
+    expect(reminderPrompt).toContain('side chatter')
+    expect(reminderPrompt).not.toContain('## Current message')
+  })
+
   test("reminder lookup skips destroyed sessions (channels GC'd while subagent was running drops the reminder)", async () => {
     const dir = await tempDir()
     const { router } = makeRouter(dir)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2119,10 +2119,23 @@ function composeTurnPrompt(
       parts.push(formatAuthorLine(o.ts, o.authorId, o.authorName, o.authorIsBot, o.text))
     }
     parts.push('')
-    parts.push(batch.length === 1 ? '## Current message (addressed to you)' : '## Current messages (addressed to you)')
   }
-  for (const b of batch) {
-    parts.push(formatAuthorLine(b.ts, b.authorId, b.authorName, b.authorIsBot, b.text))
+  // Only emit the `## Current message(s)` header when there is at least one
+  // queued inbound to live under it. A reminder-only wakeup (subagent
+  // completion firing while the prompt queue is empty) used to print the
+  // header with zero lines underneath; persona-rich models read the empty
+  // header as "there must be a current message addressed to me" and
+  // hallucinated content to reply to. The header is now batch-gated; the
+  // reminder block above and any observed context still render normally.
+  if (batch.length > 0) {
+    if (observed.length > 0) {
+      parts.push(
+        batch.length === 1 ? '## Current message (addressed to you)' : '## Current messages (addressed to you)',
+      )
+    }
+    for (const b of batch) {
+      parts.push(formatAuthorLine(b.ts, b.authorId, b.authorName, b.authorIsBot, b.text))
+    }
   }
   return parts.join('\n')
 }


### PR DESCRIPTION
## Why

A channel-routed agent sent an unprompted goodbye message into a live chat. No user had said anything that would trigger it; the model invented both the trigger and the response. Investigation of the session log (no subagent fired in that window, no synthetic message injected by the router, the prior user message had no farewell content) traced the hallucination to two independent structural weaknesses in TypeClaw's channel pipeline. Each is exploitable on its own and each is fixed independently.

### Root cause 1: tool-result echo is indistinguishable from a user message

`channel_reply` and `channel_send` return a `posted to <adapter>:<workspace>/<chat>: "<text>"` echo so the bot can detect duplicates across iterations within the same turn. Tool results reach the model as `user`-role messages — that's the OpenAI / Anthropic tool-API contract, the engine cannot tag them as `system`. After a successful send, pi-coding-agent re-invokes the model with the tool-result delta (~500 tokens) appended. A persona-rich model that has been instructed "your job is to reply when users speak to you" can read its own echo as a fresh user inbound and reply to it.

Production session: 566-token input on the hallucinated turn, no new user message in the session JSONL between the previous turn's `channel_reply` tool result and the hallucinated turn's reasoning text "the user said they want to end the conversation… this is marked as addressed to me, so I should reply." No such user message ever existed. The model latched onto its own outbound echo and confabulated a trigger from it. Kimi K2 on Fireworks is the specific weak point we hit; the class is general (any small/distilled/persona-tuned model that doesn't perfectly distinguish tool-result content from user content).

### Root cause 2: `## Current message` header renders with zero messages

`composeTurnPrompt` in `src/channels/router.ts` builds the turn body as:

```
<system-reminders...>

## Recent context (not addressed to you, for awareness only)
[ISO] <@authorId> (authorName): observed text 1
[ISO] <@authorId> (authorName): observed text 2

## Current message (addressed to you)
[ISO] <@authorId> (authorName): the engaging message
```

When `observed.length > 0` but `batch.length === 0` (a reminder-only drain wakeup — subagent completion firing while the promptQueue is empty) the existing code still pushed the `## Current message (addressed to you)` header but then iterated zero `batch` items. The model saw a structured "you have a current message" header with nothing under it and hallucinated the body.

Reminder-only drains are reachable in production: `injectSubagentCompletionReminder` (the only `pendingSystemReminders` populator today) wakes the drain loop after any backgrounded subagent finishes. The hallucination shape and the symptom (model reasoning text referencing a `## Current message` framing the user never sent) are the same as root cause 1, but the structural mechanism is independent. Fixing only one would leave the other in place.

## What

### 1. `channels: prefix channel_reply / channel_send echoes with explicit tool-result marker`

Every successful and denied tool-result content body is now prefixed with `[system: tool result, not a user message] ` via a single shared `TOOL_RESULT_PREFIX` constant exported from `src/agent/tools/channel-reply.ts` and imported by `channel-send.ts`. Both branches (success and denial) get the prefix so the model sees the same framing regardless of outcome.

- Constant lives at one site so any future audit greps one string.
- Marker is short enough that per-send cost stays bounded (the echo is already truncated to 500 chars; the prefix adds ~46 bytes).
- Prefix is fully literal, no template variables — every echo carries the identical leading bytes, so a future "block self-echoes in inbound classification" guard can match a constant.
- Backwards-compatible: nothing downstream parses `posted to ...` (verified by grep; only `channel-reply.ts`, `channel-send.ts`, and their tests reference it).

### 2. `channels: gate `## Current message(s)` header on a non-empty batch`

The `## Current message` / `## Current messages` header in `composeTurnPrompt` is now wrapped in `if (batch.length > 0)`. The reminder block above and any observed-context block still render normally; a reminder-only drain just produces the reminder followed (optionally) by `## Recent context`, with no dangling header.

The trailing `for (const b of batch)` loop is moved inside the same `if` so the structure reads "header implies body" at one glance. Behavior on non-empty batches is unchanged.

## Tests

3 new test cases in `src/agent/tools/channel-reply.test.ts` (under a new `tool-result marker` describe block):
- Success branch is prefixed with the marker.
- Denial branch is also prefixed with the marker.
- Marker survives the consecutive-send hint (prefix stays at position 0 even when a soft yield hint is appended).

Existing exact-match assertions in `channel-reply.test.ts` and `channel-send.test.ts` (8 sites, e.g. `toBe('posted to slack-bot:T0/C0: "first reply"')`) are updated to `toBe(\`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C0: "first reply"\`)` so they stay coupled to the contract (the prefix IS part of the contract), not to a literal a future maintainer might silently change.

1 new test case in `src/channels/router.test.ts` (under the `ChannelRouter injectSubagentCompletionReminder` describe block): a reminder-only drain with a non-empty contextBuffer produces a turn body that contains the reminder + `## Recent context`, but does NOT contain `## Current message`. This is the regression guard.

## Verification

```
bun run typecheck    ✓ 0 errors
bun run lint         ✓ 0 errors (41 pre-existing warnings in unrelated files, none in changed files)
bun run format:check ✓ clean
bun run test         ✓ 5229 pass / 0 fail / 11449 expect calls across 296 files (28s parallel)
```

6 files changed, 113 insertions(+), 14 deletions(−). Additive at the marker site; structural at the router site; no API changes, no schema changes, no migration required. Takes effect on first restart after upgrade.

## What's NOT in this PR

- **A stronger guard that blocks self-echoes at the inbound classifier.** The KakaoTalk adapter classifier already drops self-authored inbound messages via `classifyInbound`'s `self_author` branch — that path is sound. The hallucination came from the model treating the tool-result echo as if it were a new user message inside the same turn's reasoning, not from the channel actually replaying its own outbound. A classifier-level guard would not have caught this; the prefix is the right layer.
- **Removing the echo entirely.** The echo exists for a reason documented in `channel-reply.ts`: the classifier drops self-authored messages on the inbound path so the bot otherwise has ZERO visibility into what it just said, and a model that splits a multi-part reply has no way to tell "did I already send part 1?" from "I haven't started yet." Removing the echo would re-introduce the duplicate-send bug it was added to fix.
- **A model-side change.** This is a structural fix; the failure mode is reproducible across any model that doesn't perfectly distinguish tool-result content from user content under thin context. Hardening the prompt is cheaper and applies to every model.
- **A test against `composeTurnPrompt` directly.** It's not exported. The regression-guard test exercises it through the production wiring (`injectSubagentCompletionReminder` → drain → prompt composition), which is the actual integration that broke.
