### PR TITLE
channels: suppress NO_REPLY recovery when reasoning leaks before the token

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1162,6 +1162,114 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sent).toHaveLength(0)
   })
 
+  test('suppresses recovery when assistant ends with NO_REPLY after leaked reasoning', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'haha' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText(
+        'The user is laughing. This is just a reaction, not a direct request. I can choose to not reply. ' +
+          "However, given the recent engagement, a brief no-op is fine. But since the user didn't ask anything, " +
+          "I'll end with NO_REPLY.NO_REPLY",
+      )
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('no_reply (with_leaked_reasoning)'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('suppresses recovery when assistant ends with bare NO_REPLY after prose', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'just FYI' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText("Nothing to add here. I'll end with NO_REPLY")
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('no_reply (with_leaked_reasoning)'))).toBe(true)
+  })
+
+  test('suppresses recovery when assistant ends with parenthesized (NO_REPLY) after prose', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'just FYI' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('Nothing actionable in this message. (NO_REPLY)')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('no_reply (with_leaked_reasoning)'))).toBe(true)
+  })
+
+  test('still recovers prose that mentions NO_REPLY mid-sentence (not at end)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'what does NO_REPLY do?' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText(
+        'NO_REPLY is the silent-turn signal — the agent ends its turn with it to stay quiet.',
+      )
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('silent-turn signal')
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(true)
+  })
+
+  test('still recovers prose where NO_REPLY appears as a substring of another token', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'which env var?' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('The env var is named NO_REPLY_MODE')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('NO_REPLY_MODE')
+  })
+
   test('suppresses upstream `(Empty response: ...)` sentinel instead of leaking thinking/signature', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1742,8 +1742,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const assistantText = latestAssistantText(live.session)
     if (assistantText === null) return
 
-    if (isNoReplySignal(assistantText)) {
-      logger.info(`[channels] ${live.keyId} no_reply`)
+    if (endsWithNoReplySignal(assistantText)) {
+      const leakedReasoning = !isNoReplySignal(assistantText)
+      logger.info(`[channels] ${live.keyId} no_reply${leakedReasoning ? ' (with_leaked_reasoning)' : ''}`)
       return
     }
 
@@ -2320,6 +2321,45 @@ export function isNoReplySignal(text: string): boolean {
   if (trimmed === 'NO_REPLY') return true
   if (trimmed === '(NO_REPLY)') return true
   return false
+}
+
+// Looser sibling of isNoReplySignal, used ONLY by validateChannelTurn's
+// recovery path. Catches leaked-reasoning turns where the model produced
+// prose and then ended with the silent-turn token, e.g.
+//   "The user is laughing. ... I'll end with NO_REPLY.NO_REPLY"
+// Today those fall through to recovery and the entire reasoning paragraph
+// gets posted to the channel — the worst-possible outcome, since the leaked
+// prose is itself an admission that the model intended to stay silent.
+//
+// NOT shared with channel_send / channel_reply misuse guards: those need
+// strict literal match so a legitimate message like "set NO_REPLY=true in
+// the env" isn't rejected as a misuse of the silent-turn signal. Recovery
+// is a different question — by the time we get here the model already
+// failed to call the tool, and "ends in NO_REPLY" is strong evidence of
+// intent to stay silent, not of intent to send those bytes.
+//
+// Matches (returns true):
+//   "NO_REPLY"                        (strict)
+//   "(NO_REPLY)"                      (strict, parenthesized)
+//   "... I'll end with NO_REPLY"      (trailing token after whitespace)
+//   "... end with NO_REPLY."          (+ sentence punctuation)
+//   "... end with NO_REPLY.NO_REPLY"  (model-doubled terminator, glued)
+//   "... and stop. (NO_REPLY)"        (parenthesized at end)
+// Does not match (returns false):
+//   "NO_REPLY means do nothing"       (token at start, prose after)
+//   "the env var is NO_REPLY_MODE"    (substring, not whole token)
+//   "no reply needed"                 (case-sensitive on purpose)
+export function endsWithNoReplySignal(text: string): boolean {
+  if (isNoReplySignal(text)) return true
+  const trimmed = text.trim()
+  if (trimmed === '') return false
+  // Strip trailing sentence punctuation / closing brackets / whitespace, then
+  // check the last whitespace-or-punctuation-separated token. The leading
+  // boundary in the regex (`[\s.!?([]`) treats `.NO_REPLY` as a separate
+  // token from the preceding sentence, which covers the model-doubled
+  // `...NO_REPLY.NO_REPLY` shape.
+  const tail = trimmed.replace(/[.!?)\]\s]+$/, '')
+  return /(?:^|[\s.!?([])\(?NO_REPLY\)?$/.test(tail)
 }
 
 // Detects the upstream "empty response" debug sentinel: when the LLM ends a


### PR DESCRIPTION
## Why

`validateChannelTurn` has a recovery path: if the agent generated assistant text but never called `channel_reply` or `channel_send`, the router auto-posts the leftover text to the channel as a fallback. This path is suppressed when `isNoReplySignal(text)` matches — currently only the strict literal forms `NO_REPLY`, `(NO_REPLY)`, or empty text.

Production failure reported by a user:

```
The user is laughing. This is just a reaction, not a direct request. I can choose to not reply. However, given the recent engagement, a brief no-op is fine. But since the user didn't ask anything, I'll end with NO_REPLY.NO_REPLY
```

The model emitted reasoning prose, then ended with `NO_REPLY` (here doubled and glued via `.`). The strict matcher doesn't match, so recovery fires and the entire reasoning paragraph gets posted to the channel. Worst-possible outcome: the leaked prose is itself an admission that the model intended to stay silent.

## What

Adds a sibling predicate `endsWithNoReplySignal` in `src/channels/router.ts`, used only by the recovery gate in `validateChannelTurn`. It accepts:

- The strict forms (delegates to `isNoReplySignal` so the exact-match fast path is preserved).
- Any trailing `NO_REPLY` or `(NO_REPLY)` token that follows whitespace or sentence punctuation. The leading boundary pattern treats `.NO_REPLY` as a separate token, covering the model-doubled glued shape `.NO_REPLY.NO_REPLY` that triggered the production failure.

The new predicate is NOT shared with the tool-side `noReplyMisuseError` guards in `channel_send` and `channel_reply`. Those guards need strict literal match so legitimate messages like `"set NO_REPLY=true in the env"` aren't rejected as misuse. Recovery is a different question — by the time we get there the model already failed to call the tool, and "ends in NO_REPLY" is strong evidence of intent to stay silent, not intent to send those bytes.

The log line now distinguishes strict matches from `no_reply (with_leaked_reasoning)` so operators can spot models that chronically leak.

### Scope

- No tool-side changes.
- No system-prompt changes — the contract still teaches the strict form; this widens what the recovery path tolerates, in the same lenient-on-purpose spirit as the existing comment on `isNoReplySignal`.
- No schema changes, no API changes.
- Sibling predicate, not a widening of the shared one — `channel_send`/`channel_reply` misuse-guard semantics are untouched.

## Tests

Five new tests in `src/channels/router.test.ts`:

**Positive (suppression fires — recovery does NOT happen):**

1. The user's exact reported example with `.NO_REPLY.NO_REPLY` glued ending.
2. Bare trailing token after prose: `"Nothing to add here. I'll end with NO_REPLY"`
3. Parenthesized form after prose: `"Nothing actionable in this message. (NO_REPLY)"`

**Negative (suppression must NOT fire — recovery DOES happen):**

4. Mid-sentence mention: `"NO_REPLY is the silent-turn signal — the agent ends its turn with it to stay quiet."` (a legitimate reply explaining the signal).
5. Substring of another token: `"The env var is named NO_REPLY_MODE"`

All 193 router tests pass. Full test suite: 5230 pass, 0 fail (pre-existing parallel flakes in `memory/index.test.ts` under parallel load also present on `main`; pass in isolation).

## Verification

```
bun run typecheck    ✓ (0 errors)
bun run lint         ✓ (41 pre-existing warnings in unrelated files, 0 errors in changed files)
bun run format:check ✓
bun run test         ✓ 5230 tests, 193/193 router tests pass
```

2 files changed, 150 insertions(+), 2 deletions(−).