### PR TITLE
channels: convert KakaoTalk sent_at from seconds to milliseconds at the adapter boundary

### DIFF
--- a/src/channels/adapters/kakaotalk-classify.test.ts
+++ b/src/channels/adapters/kakaotalk-classify.test.ts
@@ -33,7 +33,7 @@ const event = (overrides: Partial<KakaoTalkPushMessageEvent> = {}): KakaoTalkPus
   message: 'hello',
   message_type: 1,
   attachment: null,
-  sent_at: 1_730_000_000_000,
+  sent_at: 1_730_000_000,
   ...overrides,
 })
 
@@ -86,6 +86,7 @@ describe('classifyInbound', () => {
     expect(verdict.payload.externalMessageId).toBe('L1')
     expect(verdict.payload.authorId).toBe('222')
     expect(verdict.payload.ts).toBe(1_730_000_000_000)
+    expect(new Date(verdict.payload.ts).getUTCFullYear()).toBe(2024)
     expect(verdict.payload.authorIsBot).toBe(false)
     expect(verdict.payload.replyToBotMessageId).toBeNull()
     expect(verdict.payload.replyToOtherMessageId).toBeNull()

--- a/src/channels/adapters/kakaotalk-classify.ts
+++ b/src/channels/adapters/kakaotalk-classify.ts
@@ -67,7 +67,10 @@ export function classifyInbound(
       mentionsOthers: false,
       replyToOtherMessageId: null,
       isDm: chatInfo.isDm,
-      ts: event.sent_at,
+      // SDK delivers `sent_at` in Unix seconds (LOCO `sendAt`); contract
+      // wants ms (see `src/channels/types.ts`). Without `* 1000`, ms-based
+      // renderers (inspect -f, etc.) produce 1970-01-21-shaped dates.
+      ts: event.sent_at * 1000,
     },
   }
 }

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -257,7 +257,7 @@ export function createKakaoHistoryCallback(deps: {
             authorId,
             authorName,
             text: formatHistoryText(m),
-            ts: m.sent_at,
+            ts: m.sent_at * 1000,
             isBot: selfId !== null && authorId === selfId,
             replyToBotMessageId: null,
           }


### PR DESCRIPTION
## Why

Running `typeclaw inspect -f` on a KakaoTalk session rendered every message timestamp as 1970-01-21 — roughly 21 days into the Unix epoch, with the seconds-of-day matching modern wall-clock time. A timestamp prefix like `[1970-01-21T14:21:56.328Z]` is the canonical signature for a value in seconds being passed to `new Date(...)` which expects milliseconds.

## Root cause

The agent-messenger KakaoTalk SDK delivers `sent_at` in **Unix seconds**, mirroring the LOCO protocol's `sendAt` wire field. Fixture evidence: the agent-messenger test files use `1700000000` — 10 digits, which is Nov 2023 in seconds.

typeclaw's channel contract requires milliseconds since epoch, documented at `src/channels/types.ts:47-52`.

The arithmetic makes the symptom obvious. A raw `sent_at` of 1761... seconds, fed to `new Date()` which expects ms, lands ~1761 ms past the epoch — producing `1970-01-21T14:21:56`. Exact match.

## Why this is our fix, not agent-messenger's

The SDK correctly forwards the platform-native unit. Every other adapter normalizes at the boundary:

| Adapter | How |
|---|---|
| Slack | `slackTsToMillis` — rounds `parsed * 1000` |
| Telegram | `event.date * 1000` |
| Discord | `Date.parse(event.timestamp)` — Discord sends ISO strings |

KakaoTalk was the only adapter missing this step. The fix belongs in typeclaw, not upstream.

## What changed

**`kakaotalk-classify.ts:70`** — live messages. Also covers stickers: the attachment handler routes emoticons through the same classifier path:

```ts
ts: event.sent_at * 1000,
```

**`kakaotalk.ts:260`** — history backfill:

```ts
ts: m.sent_at * 1000,
```

**`kakaotalk-classify.test.ts`** — three test changes:

- Fixture updated to seconds (`1_730_000_000`).
- Existing assertion `ts === 1_730_000_000_000` preserved — pins the contract.
- New `getUTCFullYear() === 2024` sanity check so future regressions surface with a clearer failure message.

A 3-line comment at the call site names (a) the upstream unit, (b) where the contract is documented, (c) the visible failure mode. Source and destination are both bare `number` — the type system cannot catch a future "simplification" that drops the multiply. The comment is the defensive anchor against this exact bug recurring.

## Test fixtures left alone

The 16 other `sent_at` lines in `kakaotalk.test.ts` and `kakaotalk-attachment.test.ts` are opaque event payloads that flow through code paths which never assert on the resulting `ts` value. Leaving them at "year 56,773" is harmless and avoids churn.

## Verification

```
bun test src/channels/adapters/kakaotalk --parallel    65 pass / 0 fail (~890ms)
bun run typecheck                                       ✓ 0 errors
bun run lint                                            ✓ 0 errors (41 pre-existing warnings, none in changed files)
bun run format                                          ✓ clean
```
