### PR TITLE
channels: fence consecutive-send and thread-mismatch hints as SYSTEM MESSAGE

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -192,6 +192,19 @@ describe('createChannelReplyTool', () => {
     expect(text).toContain('2nd consecutive message')
   })
 
+  test('consecutive-send hint is fenced as a SYSTEM MESSAGE so persona-rich models cannot read it as chat', async () => {
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => ({ ok: true }), { consecutiveCount: 2 }),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, { text: 'continuing' })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('**[SYSTEM MESSAGE — not from a human]**')
+    expect(text).toContain('Do not acknowledge or reply to this notice')
+    expect(text).toMatch(/---\s*\n\*\*\[SYSTEM MESSAGE/)
+    expect(text).toMatch(/Do not acknowledge or reply to this notice\.\*\*\s*\n---/)
+  })
+
   describe('renderEcho', () => {
     test('JSON-quotes short text', () => {
       expect(renderEcho('hi')).toBe('"hi"')

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -10,6 +10,7 @@ import {
 import type { AdapterId } from '@/channels/schema'
 
 import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
+import { fenceRuntimeNotice } from './runtime-notice'
 
 export type ChannelReplyOrigin = {
   adapter: AdapterId
@@ -162,7 +163,7 @@ export function createChannelReplyTool({
             }),
           )
         : ''
-      const body = hint ? `${baseText} — ${hint}` : baseText
+      const body = hint ? `${baseText}${hint}` : baseText
       return {
         content: [{ type: 'text' as const, text: `${TOOL_RESULT_PREFIX}${body}` }],
         details,
@@ -246,11 +247,16 @@ function kimiToolCallLeakError(text: string | undefined): string {
 }
 
 // Mirror of the same hint used by channel_send. Kept identical so the model
-// sees the same yield signal regardless of which tool it picked.
+// sees the same yield signal regardless of which tool it picked. The body
+// is wrapped via `fenceRuntimeNotice` (in `./runtime-notice`) so persona-rich
+// models cannot read the trailing prose as a chat instruction and reply to
+// it in-character. See that helper's comment for the failure mode that
+// motivated the framing.
 function consecutiveSendHint(countAfterSend: number): string {
   if (countAfterSend <= 1) return ''
-  if (countAfterSend === 2) {
-    return 'this is your 2nd consecutive message in this conversation; continue only if the reply genuinely needs splitting.'
-  }
-  return `${countAfterSend}th consecutive message with no user reply; end your turn now unless the user explicitly asked for a multi-step response.`
+  const body =
+    countAfterSend === 2
+      ? 'this is your 2nd consecutive message in this conversation; continue only if the reply genuinely needs splitting.'
+      : `${countAfterSend}th consecutive message with no user reply; end your turn now unless the user explicitly asked for a multi-step response.`
+  return fenceRuntimeNotice(body)
 }

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -150,6 +150,35 @@ describe('createChannelSendTool', () => {
     expect(text).toContain('"still going"')
   })
 
+  test('consecutive-send hint is fenced as a SYSTEM MESSAGE so persona-rich models cannot read it as chat', async () => {
+    const tool = createChannelSendTool({
+      router: fakeRouter(async () => ({ ok: true }), { consecutiveCount: 4 }),
+    })
+    const result = await runTool(tool, {
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      text: 'still going',
+    })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('**[SYSTEM MESSAGE — not from a human]**')
+    expect(text).toContain('Do not acknowledge or reply to this notice')
+    expect(text).toMatch(/---\s*\n\*\*\[SYSTEM MESSAGE/)
+    expect(text).toMatch(/Do not acknowledge or reply to this notice\.\*\*\s*\n---/)
+  })
+
+  test('thread-mismatch hint is also fenced as a SYSTEM MESSAGE', async () => {
+    const tool = createChannelSendTool({
+      router: fakeRouter(async () => ({ ok: true })),
+      origin: { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: '1700000000.000100' },
+    })
+    const result = await runTool(tool, { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', text: 'oops' })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('**[SYSTEM MESSAGE — not from a human]**')
+    expect(text).toContain('Do not acknowledge or reply to this notice')
+    expect(text).toContain('origin thread is "1700000000.000100"')
+  })
+
   test('denied sends never carry the hint suffix', async () => {
     const tool = createChannelSendTool({
       router: fakeRouter(async () => ({ ok: false, error: 'denied by allow rules' }), {

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -11,6 +11,7 @@ import { ADAPTER_IDS, type AdapterId } from '@/channels/schema'
 
 import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
 import { renderOutboundEcho, TOOL_RESULT_PREFIX } from './channel-reply'
+import { fenceRuntimeNotice } from './runtime-notice'
 
 export type ChannelSendOrigin = {
   adapter: AdapterId
@@ -177,7 +178,7 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
         })
         if (threadMismatch) hints.push(threadMismatch)
       }
-      const body = hints.length > 0 ? `${baseText} — ${hints.join(' ')}` : baseText
+      const body = hints.length > 0 ? `${baseText}${hints.join('')}` : baseText
       return {
         content: [{ type: 'text' as const, text: `${TOOL_RESULT_PREFIX}${body}` }],
         details,
@@ -195,6 +196,11 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
 //
 // Only fires when the origin had a thread to begin with — channel-root
 // sessions can't have a "missing thread" problem.
+//
+// Body is fenced via `fenceRuntimeNotice` for the same reason the
+// consecutive-send hint is — see that helper's comment for the failure
+// mode (Kimi-K2.x reading trailing tool-result prose as a chat instruction
+// and replying to it in-character).
 function threadMismatchHint(
   origin: ChannelSendOrigin | undefined,
   sent: { adapter: AdapterId; workspace: string; chat: string; thread: string | undefined },
@@ -205,10 +211,10 @@ function threadMismatchHint(
   if (origin.adapter !== sent.adapter) return ''
   if (origin.workspace !== sent.workspace) return ''
   if (origin.chat !== sent.chat) return ''
-  return (
+  return fenceRuntimeNotice(
     `note: this session's origin thread is ${JSON.stringify(origin.thread)} but you posted to channel root. ` +
-    `if breaking out of the thread was intentional, ignore this; otherwise prefer \`channel_reply\` ` +
-    `or pass \`thread: ${JSON.stringify(origin.thread)}\` on your next channel_send.`
+      `if breaking out of the thread was intentional, ignore this; otherwise prefer \`channel_reply\` ` +
+      `or pass \`thread: ${JSON.stringify(origin.thread)}\` on your next channel_send.`,
   )
 }
 
@@ -263,10 +269,12 @@ function kimiToolCallLeakError(text: string | undefined): string {
 // "this is the second consecutive bot message in this chat:thread" — which
 // is the first count where a hint is warranted. Empty string at count <= 1
 // preserves the original tool-result text for the common single-reply case.
+// Mirror of channel-reply.ts; body wrapped via `fenceRuntimeNotice`.
 function consecutiveSendHint(countAfterSend: number): string {
   if (countAfterSend <= 1) return ''
-  if (countAfterSend === 2) {
-    return 'this is your 2nd consecutive message in this conversation; continue only if the reply genuinely needs splitting.'
-  }
-  return `${countAfterSend}th consecutive message with no user reply; end your turn now unless the user explicitly asked for a multi-step response.`
+  const body =
+    countAfterSend === 2
+      ? 'this is your 2nd consecutive message in this conversation; continue only if the reply genuinely needs splitting.'
+      : `${countAfterSend}th consecutive message with no user reply; end your turn now unless the user explicitly asked for a multi-step response.`
+  return fenceRuntimeNotice(body)
 }

--- a/src/agent/tools/runtime-notice.test.ts
+++ b/src/agent/tools/runtime-notice.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test'
+
+import { fenceRuntimeNotice } from './runtime-notice'
+
+describe('fenceRuntimeNotice', () => {
+  test('wraps body in canonical SYSTEM MESSAGE framing with horizontal-rule fences', () => {
+    const out = fenceRuntimeNotice('do not reply to this')
+
+    expect(out).toContain('**[SYSTEM MESSAGE — not from a human]**')
+    expect(out).toContain('do not reply to this')
+    expect(out).toContain('Do not acknowledge or reply to this notice')
+    expect(out).toMatch(/---\s*\n\*\*\[SYSTEM MESSAGE/)
+    expect(out).toMatch(/Do not acknowledge or reply to this notice\.\*\*\s*\n---/)
+  })
+
+  test('leads with a blank-line separator so concatenation onto a base string never collides', () => {
+    const baseText = 'posted to slack-bot:T0/C0: "hi"'
+    const concatenated = `${baseText}${fenceRuntimeNotice('a hint')}`
+
+    expect(concatenated.startsWith(baseText)).toBe(true)
+    expect(concatenated).toMatch(/posted to slack-bot:T0\/C0: "hi"\n\n---\n/)
+  })
+
+  test('preserves the body verbatim (no trimming, no rewrapping)', () => {
+    const body = '   indented body with    multiple   spaces and trailing newline\n'
+
+    expect(fenceRuntimeNotice(body)).toContain(body)
+  })
+
+  test('shape matches the canonical loop-guard block convention documented in router.ts', () => {
+    const out = fenceRuntimeNotice('any body')
+
+    expect(out.split('---').length).toBe(3)
+    expect(out.indexOf('**[SYSTEM MESSAGE')).toBeGreaterThan(out.indexOf('---'))
+    expect(out.lastIndexOf('---')).toBeGreaterThan(out.indexOf('Do not acknowledge'))
+  })
+})

--- a/src/agent/tools/runtime-notice.ts
+++ b/src/agent/tools/runtime-notice.ts
@@ -1,0 +1,41 @@
+// Wraps a runtime-emitted notice body in canonical SYSTEM MESSAGE framing so
+// persona-rich models cannot read the prose as a chat instruction from a
+// human and respond to it in-character.
+//
+// The failure mode this exists to prevent: tool results reach the model as
+// USER-role messages (provider tool-call contract — engines cannot tag them
+// as system). The `TOOL_RESULT_PREFIX` already marks each result's leading
+// position, but trailing natural-language hints (the consecutive-send nudge
+// is the canonical case) still parse as conversational prose, and Kimi-K2.x
+// has been observed in production responding to those hints in-character —
+// an apology directly addressed at the human ("sorry for talking so much,
+// I'll be quieter next time") when the only stimulus in the prompt was the
+// router's "Nth consecutive message; end your turn now" hint. Four
+// consecutive in-character replies to fenced-prose runtime hints in a
+// single drain iteration is the observed shape.
+//
+// Framing convention is the same shape `composeTurnPrompt` uses for the
+// loop-guard block in `router.ts` — bracketed marker, fence rules, and
+// explicit "Do not acknowledge or reply to this notice" closer. The
+// loop-guard block has been in production against Kimi for months without
+// the misread we observed on the consecutive-send hint, which is why we
+// reuse the exact same shape here.
+//
+// Applied unconditionally (not model-gated): the cost is ~40 tokens per
+// hint emission, paid only on consecutive sends (where the hint is already
+// firing), and the framing is safe for every model — well-behaved models
+// read it and move on. Gating by model family would have required a
+// traits table for one defense and would still need extending the moment
+// a second model family exhibited the same misread, so we accept the
+// universal cost in exchange for never having to remember to add a new
+// family to a list.
+export function fenceRuntimeNotice(body: string): string {
+  return (
+    '\n\n---\n' +
+    '**[SYSTEM MESSAGE — not from a human]**\n\n' +
+    body +
+    '\n\nThis is an automated signal from the channel router, not a message ' +
+    'from anyone in the chat. **Do not acknowledge or reply to this notice.**\n' +
+    '---'
+  )
+}


### PR DESCRIPTION
## Summary

Wrap the consecutive-send hint and thread-mismatch hint in canonical `**[SYSTEM MESSAGE — not from a human]**` framing so persona-rich models cannot read trailing tool-result prose as a chat instruction and respond to it in-character.

## Failure mode

Tool results reach the model as USER-role messages — the provider tool-call contract doesn't let engines tag them as system. The existing `TOOL_RESULT_PREFIX` already marks each result's leading position, but a trailing natural-language hint like

> `posted to ... — Nth consecutive message with no user reply; end your turn now unless the user explicitly asked for a multi-step response.`

still parses as conversational prose, and Kimi-K2.x has been observed in production responding to those hints in-character. The smoking gun: in one drain iteration the model emitted four consecutive `channel_reply` calls, each `<thinking>` block fabricating a user question that never appeared in any prompt — including one apologizing directly to the human ("sorry for talking so much, I'll be quieter next time") when the only stimulus in the prompt was the router's "end your turn now" hint itself.

## Fix

New helper `fenceRuntimeNotice(body)` wraps any runtime-emitted notice in the same framing `composeTurnPrompt` already uses for the loop-guard block in `router.ts`:

```
---
**[SYSTEM MESSAGE — not from a human]**

<body>

This is an automated signal from the channel router, not a message from anyone in the chat. **Do not acknowledge or reply to this notice.**
---
```

That framing has been in production against Kimi for months without misread (the loop-guard block ships in every drain that trips the peer-bot threshold), which is why we reuse the exact same shape.

Three callsites updated:

- `channel_reply.ts` consecutive-send hint
- `channel_send.ts` consecutive-send hint
- `channel_send.ts` thread-mismatch hint

## Why unconditional, not model-gated

Applied to every model rather than gated on a `kimi`-family traits table. Two reasons:

1. **Cost is small.** ~40 tokens per hint emission, paid only on consecutive sends (where the hint is already firing). Zero cost on first-of-conversation sends.
2. **Framing is safe for every model.** Claude / GPT / Gemini families read the SYSTEM MESSAGE block and move on — the existing loop-guard block has proven this in production. Gating by family would have required new traits infrastructure for one defense and would still need extending the moment a second model family exhibited the same misread.

The alternative shape (per-family traits table) is the right call if/when a second defense lands that genuinely can't apply universally (e.g. lowering `MAX_CHANNEL_SENDS_PER_TURN` for a specific family). Not landing that infra yet.

## Test surface

- `runtime-notice.test.ts` (new) — unit tests pinning the framing shape and concatenation behavior.
- `channel-reply.test.ts` — new assertion that the consecutive-send hint is fenced. Existing `toContain('2nd consecutive message')` tests continue to pass since the fenced output contains all original phrases verbatim.
- `channel-send.test.ts` — new assertions for both fenced consecutive-send and fenced thread-mismatch hints. Existing assertions unchanged.

## Verification

```
bun run typecheck     ✓
bun run lint          ✓ (0 errors in changed files; 41 pre-existing warnings elsewhere)
bun run format        ✓
bun test (targeted)   ✓ 1103 pass / 0 fail
```

Full suite has a pre-existing parallel-runner flake (varies 0-4 fail across runs on `main` itself) unrelated to this change; targeted suite is stable green.
