### PR TITLE
inspect: surface channel inbound messages as a new `inbound` category

### DIFF
--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -5,6 +5,7 @@ import type { PermissionService } from '@/permissions'
 import type { GithubSecretsBlock } from '@/secrets'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 import { SecretsBackend } from '@/secrets/storage'
+import type { Stream } from '@/stream'
 
 import { createDiscordBotAdapter, type DiscordBotAdapter } from './adapters/discord-bot'
 import { createGithubAdapter, type GithubAdapter } from './adapters/github'
@@ -78,6 +79,11 @@ export type ChannelManagerOptions = {
   // a URL" so error logs can be precise. Same shape as
   // `tunnelUrlForChannel` for consistency. Optional for tests.
   tunnelConfiguredForChannel?: (channelName: string) => boolean
+  // Forwarded to the router as `stream`. When set, every inbound the
+  // router sees is published as a tagged broadcast for inspect surfacing.
+  // Production wiring (`src/run/index.ts`) always passes the agent's
+  // Stream; tests typically omit it.
+  stream?: Stream
 }
 
 export type ChannelManager = {
@@ -113,6 +119,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     ...(options.createSessionForChannel ? { createSessionForChannel: options.createSessionForChannel } : {}),
     ...(options.permissions ? { permissions: options.permissions } : {}),
     ...(options.claimHandler ? { claimHandler: options.claimHandler } : {}),
+    ...(options.stream ? { stream: options.stream } : {}),
   })
   const createDiscordAdapter = options.createDiscordAdapter ?? createDiscordBotAdapter
   const createGithub = options.createGithubAdapter ?? createGithubAdapter

--- a/src/channels/router.inbound-stream.test.ts
+++ b/src/channels/router.inbound-stream.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { AgentSession } from '@/agent'
+import type { PermissionService } from '@/permissions'
+import { createStream, type StreamMessage } from '@/stream'
+
+import { createChannelRouter } from './router'
+import { defaultHistoryConfig, type ChannelAdapterConfig } from './schema'
+import type { InboundMessage } from './types'
+
+const baseConfig: ChannelAdapterConfig = {
+  engagement: { trigger: ['mention', 'reply', 'dm'], stickiness: { perReply: { window: 60_000 } } },
+  enabled: true,
+  history: defaultHistoryConfig(),
+}
+
+class FakeSession {
+  prompt = async (): Promise<void> => {}
+  abort = async (): Promise<void> => {}
+  dispose = (): void => {}
+  subscribe = (): (() => void) => () => {}
+}
+
+const grantAll: PermissionService = {
+  has: () => true,
+  resolveRole: () => 'owner',
+  describe: () => ({ role: 'owner', permissions: ['channel.respond'] }),
+  replaceRoles: () => {},
+}
+
+const denyAll: PermissionService = {
+  has: () => false,
+  resolveRole: () => 'guest',
+  describe: () => ({ role: 'guest', permissions: [] }),
+  replaceRoles: () => {},
+}
+
+function inbound(over: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    adapter: 'discord-bot',
+    workspace: 'g1',
+    chat: 'c1',
+    thread: null,
+    text: 'hello bot',
+    externalMessageId: 'm1',
+    authorId: 'alice',
+    authorName: 'Alice',
+    authorIsBot: false,
+    isBotMention: true,
+    replyToBotMessageId: null,
+    mentionsOthers: false,
+    replyToOtherMessageId: null,
+    isDm: false,
+    ts: 1_700_000_000_000,
+    ...over,
+  }
+}
+
+async function tempDir(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), 'router-inbound-stream-'))
+}
+
+function captureInboundBroadcasts(stream: ReturnType<typeof createStream>): StreamMessage[] {
+  const captured: StreamMessage[] = []
+  stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => {
+    const payload = msg.payload as { kind?: unknown } | null
+    if (payload?.kind === 'channel-inbound') captured.push(msg)
+  })
+  return captured
+}
+
+describe('router publishes channel-inbound broadcasts', () => {
+  test('engaged inbound publishes with decision=engage', async () => {
+    const dir = await tempDir()
+    const stream = createStream()
+    const captured = captureInboundBroadcasts(stream)
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      permissions: grantAll,
+      stream,
+      createSessionForChannel: async () => ({
+        session: new FakeSession() as unknown as AgentSession,
+        sessionId: 'ses_1',
+        dispose: async () => {},
+      }),
+    })
+
+    await router.route(inbound({ text: 'hey @bot help me' }))
+
+    expect(captured).toHaveLength(1)
+    const p = captured[0]!.payload as Record<string, unknown>
+    expect(p.kind).toBe('channel-inbound')
+    expect(p.decision).toBe('engage')
+    expect(p.adapter).toBe('discord-bot')
+    expect(p.authorId).toBe('alice')
+    expect(p.text).toBe('hey @bot help me')
+    expect(p.isBotMention).toBe(true)
+  })
+
+  test('denied inbound publishes with decision=denied (still visible in inspect)', async () => {
+    const dir = await tempDir()
+    const stream = createStream()
+    const captured = captureInboundBroadcasts(stream)
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      permissions: denyAll,
+      stream,
+      createSessionForChannel: async () => ({
+        session: new FakeSession() as unknown as AgentSession,
+        sessionId: 'ses_1',
+        dispose: async () => {},
+      }),
+    })
+
+    await router.route(inbound())
+
+    expect(captured).toHaveLength(1)
+    const p = captured[0]!.payload as Record<string, unknown>
+    expect(p.decision).toBe('denied')
+  })
+
+  test('observed inbound publishes with decision=observe', async () => {
+    const dir = await tempDir()
+    const stream = createStream()
+    const captured = captureInboundBroadcasts(stream)
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      permissions: grantAll,
+      stream,
+      createSessionForChannel: async () => ({
+        session: new FakeSession() as unknown as AgentSession,
+        sessionId: 'ses_1',
+        dispose: async () => {},
+      }),
+    })
+
+    await router.route(
+      inbound({
+        text: 'plain chat between humans',
+        authorId: 'bob',
+        authorName: 'Bob',
+        isBotMention: false,
+        isDm: false,
+        replyToBotMessageId: null,
+        mentionsOthers: true,
+      }),
+    )
+
+    expect(captured).toHaveLength(1)
+    const p = captured[0]!.payload as Record<string, unknown>
+    expect(p.decision).toBe('observe')
+    expect(p.isBotMention).toBe(false)
+  })
+
+  test('omitting stream is a no-op (router still works)', async () => {
+    const dir = await tempDir()
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      permissions: grantAll,
+      createSessionForChannel: async () => ({
+        session: new FakeSession() as unknown as AgentSession,
+        sessionId: 'ses_1',
+        dispose: async () => {},
+      }),
+    })
+
+    await expect(router.route(inbound())).resolves.toBeUndefined()
+  })
+
+  test('claim intercept publishes with decision=claim', async () => {
+    const dir = await tempDir()
+    const stream = createStream()
+    const captured = captureInboundBroadcasts(stream)
+    const sent: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      permissions: denyAll,
+      stream,
+      claimHandler: async () => ({ kind: 'consumed', reply: 'role claimed' }),
+      createSessionForChannel: async () => ({
+        session: new FakeSession() as unknown as AgentSession,
+        sessionId: 'ses_1',
+        dispose: async () => {},
+      }),
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ isDm: true, text: 'claim-7K9M-2X3R' }))
+
+    expect(captured).toHaveLength(1)
+    const p = captured[0]!.payload as Record<string, unknown>
+    expect(p.decision).toBe('claim')
+    expect(sent).toEqual(['role claimed'])
+  })
+})

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -11,6 +11,7 @@ import { createCommandRegistry } from '@/commands'
 import { CORE_PERMISSIONS, type PermissionService } from '@/permissions'
 import type { HookBus } from '@/plugin'
 import { extractClaimCode } from '@/role-claim'
+import type { Stream } from '@/stream'
 
 import { decideEngagement, grantStickyForReplyTargets, StickyLedger, type EngagementDecision } from './engagement'
 import {
@@ -505,6 +506,14 @@ export type CreateChannelRouterOptions = {
   // back over the same chat, or null to fall through to normal routing
   // when no pending claim window matches.
   claimHandler?: ClaimHandler
+  // Optional in-process Stream. When set, every inbound the router sees
+  // is published as a tagged broadcast (`kind: 'channel-inbound'`) so the
+  // `/inspect` WS endpoint can surface it live and `stream.scan()` can
+  // backfill it on subscribe. Decoupled from the routing decision: even
+  // permission-denied and role-claim inbounds publish, so the operator
+  // can diagnose silent drops from `typeclaw inspect` alone. Omitted in
+  // tests that don't care about inspect surfacing.
+  stream?: Stream
 }
 
 export type ClaimHandlerInput = {
@@ -539,6 +548,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const sessionIdleTimeoutMs = options.sessionIdleTimeoutMs ?? SESSION_IDLE_TIMEOUT_MS
   const permissions = options.permissions ?? GRANT_ALL_PERMISSIONS
   const claimHandler = options.claimHandler
+  const stream = options.stream
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
   const outboundCallbacks = new Map<ChannelKey['adapter'], Set<OutboundCallback>>()
@@ -1277,6 +1287,33 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }, wait)
   }
 
+  const publishInbound = (event: InboundMessage, decision: 'engage' | 'observe' | 'denied' | 'claim'): void => {
+    if (stream === undefined) return
+    try {
+      stream.publish({
+        target: { kind: 'broadcast' },
+        payload: {
+          kind: 'channel-inbound',
+          adapter: event.adapter,
+          workspace: event.workspace,
+          chat: event.chat,
+          thread: event.thread,
+          authorId: event.authorId,
+          authorName: event.authorName,
+          authorIsBot: event.authorIsBot,
+          isDm: event.isDm,
+          isBotMention: event.isBotMention,
+          text: event.text,
+          externalMessageId: event.externalMessageId,
+          ts: event.ts,
+          decision,
+        },
+      })
+    } catch (err) {
+      logger.warn(`[channels] inbound stream publish failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
   const route = async (event: InboundMessage): Promise<void> => {
     const adapterConfig = options.configForAdapter(event.adapter)
     if (!adapterConfig) return
@@ -1303,6 +1340,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         text: event.text,
       })
       if (outcome.kind !== 'fallthrough') {
+        publishInbound(event, 'claim')
         logger.info(
           `[channels] ${channelKeyId(key)}: claim ${outcome.kind} author=${event.authorId} id=${event.externalMessageId}`,
         )
@@ -1321,6 +1359,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
 
     if (isChannelRespondDenied(event)) {
+      publishInbound(event, 'denied')
       logger.info(
         `[channels] ${channelKeyId(key)}: denied by permissions (channel.respond) author=${event.authorId} id=${event.externalMessageId}`,
       )
@@ -1388,6 +1427,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     })
 
     if (decision === 'observe') {
+      publishInbound(event, 'observe')
       // Log every observe so an unanswered mention is diagnosable from logs
       // alone instead of "routed but no prompting" silence. The bracketed
       // shape mirrors `prompting batch=` so log scraping can pair them.
@@ -1395,6 +1435,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       observe(live, event)
       return
     }
+
+    publishInbound(event, 'engage')
 
     updateLoopGuard(live, event)
 

--- a/src/inspect/live.test.ts
+++ b/src/inspect/live.test.ts
@@ -144,6 +144,100 @@ describe('streamLive — live session events', () => {
     expect(ev.payload).toEqual({ kind: 'subagent.completed', ok: true })
   })
 
+  test('channel-inbound broadcasts surface as InspectEvent.inbound with channel coords', async () => {
+    const stream = createStream()
+    const { url } = await startServer({ stream })
+    const ctrl = new AbortController()
+    const gen = streamLive({ url, sessionId: 'ses_anything', signal: ctrl.signal })
+
+    setTimeout(() => {
+      stream.publish({
+        target: { kind: 'broadcast' },
+        payload: {
+          kind: 'channel-inbound',
+          adapter: 'slack',
+          workspace: 'acme',
+          chat: 'C12345',
+          thread: null,
+          authorId: 'U_alice',
+          authorName: 'alice',
+          authorIsBot: false,
+          isDm: false,
+          isBotMention: true,
+          text: 'hey bot',
+          externalMessageId: 'm1',
+          ts: 1_700_000_000_000,
+          decision: 'engage',
+        },
+      })
+    }, 50)
+
+    const events = await collectN(gen, 1)
+    ctrl.abort()
+    const ev = events[0]!
+    if (ev.cat !== 'inbound') throw new Error('expected inbound')
+    expect(ev.adapter).toBe('slack')
+    expect(ev.workspace).toBe('acme')
+    expect(ev.chat).toBe('C12345')
+    expect(ev.authorName).toBe('alice')
+    expect(ev.text).toBe('hey bot')
+    expect(ev.decision).toBe('engage')
+    expect(ev.isBotMention).toBe(true)
+    expect(ev.ts).toBe(1_700_000_000_000)
+  })
+
+  test('channel-inbound broadcast with malformed payload falls through as generic broadcast', async () => {
+    const stream = createStream()
+    const { url } = await startServer({ stream })
+    const ctrl = new AbortController()
+    const gen = streamLive({ url, sessionId: 'ses_anything', signal: ctrl.signal })
+
+    setTimeout(() => {
+      stream.publish({
+        target: { kind: 'broadcast' },
+        payload: { kind: 'channel-inbound', adapter: 'slack' },
+      })
+    }, 50)
+
+    const events = await collectN(gen, 1)
+    ctrl.abort()
+    const ev = events[0]!
+    if (ev.cat !== 'broadcast') throw new Error('expected broadcast (malformed inbound falls back)')
+  })
+
+  test('inbound published before subscribe is backfilled via sinceMs', async () => {
+    const stream = createStream()
+    stream.publish({
+      target: { kind: 'broadcast' },
+      payload: {
+        kind: 'channel-inbound',
+        adapter: 'discord',
+        workspace: '9999',
+        chat: '8888',
+        thread: null,
+        authorId: 'U1',
+        authorName: 'bob',
+        authorIsBot: false,
+        isDm: false,
+        isBotMention: true,
+        text: 'historical',
+        externalMessageId: 'm0',
+        ts: 0,
+        decision: 'engage',
+      },
+    })
+
+    const { url } = await startServer({ stream })
+    const ctrl = new AbortController()
+    const gen = streamLive({ url, sessionId: 'ses_anything', sinceMs: 0, signal: ctrl.signal })
+
+    const events = await collectN(gen, 1)
+    ctrl.abort()
+    const ev = events[0]!
+    if (ev.cat !== 'inbound') throw new Error('expected inbound from backfill')
+    expect(ev.text).toBe('historical')
+  })
+
   test('cron-fire events surface as InspectEvent.cron-fire with the jobId', async () => {
     const stream = createStream()
     const { url } = await startServer({ stream })

--- a/src/inspect/live.ts
+++ b/src/inspect/live.ts
@@ -172,6 +172,23 @@ function frameToEvent(
       }
     case 'cron-fire':
       return { cat: 'cron-fire', ts, jobId: payload.jobId, payload: payload.payload }
+    case 'channel_inbound':
+      return {
+        cat: 'inbound',
+        ts: payload.ts > 0 ? payload.ts : ts,
+        adapter: payload.adapter,
+        workspace: payload.workspace,
+        chat: payload.chat,
+        thread: payload.thread,
+        authorId: payload.authorId,
+        authorName: payload.authorName,
+        authorIsBot: payload.authorIsBot,
+        isDm: payload.isDm,
+        isBotMention: payload.isBotMention,
+        text: payload.text,
+        externalMessageId: payload.externalMessageId,
+        decision: payload.decision,
+      }
     default:
       return null
   }

--- a/src/inspect/render.test.ts
+++ b/src/inspect/render.test.ts
@@ -94,6 +94,92 @@ describe('renderEvent (plain, no color)', () => {
     const ev: InspectEvent = { cat: 'meta', ts: 0, origin: { kind: 'tui' } }
     expect(renderEvent(ev, PLAIN).startsWith('--:--:--')).toBe(true)
   })
+
+  test('inbound engage event prints decision, channel coords, author and text', () => {
+    const ev: InspectEvent = {
+      cat: 'inbound',
+      ts: dateMs('15:08:42'),
+      adapter: 'slack',
+      workspace: 'acme',
+      chat: 'C12345',
+      thread: null,
+      authorId: 'U999',
+      authorName: 'alice',
+      authorIsBot: false,
+      isDm: false,
+      isBotMention: true,
+      text: 'hey bot can you help',
+      externalMessageId: 'm1',
+      decision: 'engage',
+    }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe(
+      'HH:MM:SS  inbound    [engage] slack:acme/C12345 alice: hey bot can you help',
+    )
+  })
+
+  test('inbound observe shows [observe] tag', () => {
+    const ev: InspectEvent = {
+      cat: 'inbound',
+      ts: dateMs('15:08:42'),
+      adapter: 'discord',
+      workspace: '9999',
+      chat: '8888',
+      thread: '7777',
+      authorId: 'U1',
+      authorName: 'bob',
+      authorIsBot: false,
+      isDm: false,
+      isBotMention: false,
+      text: 'just chatting',
+      externalMessageId: 'm2',
+      decision: 'observe',
+    }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe(
+      'HH:MM:SS  inbound    [observe] discord:9999/8888#7777 bob: just chatting',
+    )
+  })
+
+  test('inbound denied shows [denied] tag (visible silent drops)', () => {
+    const ev: InspectEvent = {
+      cat: 'inbound',
+      ts: dateMs('15:08:42'),
+      adapter: 'slack',
+      workspace: 'acme',
+      chat: 'C12345',
+      thread: null,
+      authorId: 'U_stranger',
+      authorName: 'stranger',
+      authorIsBot: false,
+      isDm: false,
+      isBotMention: true,
+      text: 'who are you',
+      externalMessageId: 'm3',
+      decision: 'denied',
+    }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe(
+      'HH:MM:SS  inbound    [denied] slack:acme/C12345 stranger: who are you',
+    )
+  })
+
+  test('inbound falls back to authorId when authorName is empty', () => {
+    const ev: InspectEvent = {
+      cat: 'inbound',
+      ts: dateMs('15:08:42'),
+      adapter: 'kakaotalk',
+      workspace: 'kk',
+      chat: 'g1',
+      thread: null,
+      authorId: 'k_user_123',
+      authorName: '',
+      authorIsBot: false,
+      isDm: false,
+      isBotMention: false,
+      text: 'hi',
+      externalMessageId: 'm4',
+      decision: 'observe',
+    }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  inbound    [observe] kakaotalk:kk/g1 k_user_123: hi')
+  })
 })
 
 describe('renderEvent (with color)', () => {

--- a/src/inspect/render.ts
+++ b/src/inspect/render.ts
@@ -44,6 +44,8 @@ function renderTag(event: InspectEvent, opts: RenderOptions): string {
       return tint(opts, 'magenta', padEnd('bcast', 9))
     case 'cron-fire':
       return tint(opts, 'magenta', padEnd('cron', 9))
+    case 'inbound':
+      return tint(opts, 'cyan', padEnd('inbound', 9))
   }
 }
 
@@ -72,6 +74,29 @@ function renderBody(event: InspectEvent, opts: RenderOptions): string {
       return renderBroadcastBody(event.payload, opts.maxTextLength ?? DEFAULT_MAX_TEXT)
     case 'cron-fire':
       return `${event.jobId} fired`
+    case 'inbound':
+      return renderInboundBody(event, opts)
+  }
+}
+
+function renderInboundBody(event: Extract<InspectEvent, { cat: 'inbound' }>, opts: RenderOptions): string {
+  const coord = `${event.adapter}:${event.workspace}/${event.chat}${event.thread === null ? '' : `#${event.thread}`}`
+  const who = event.authorName !== '' ? event.authorName : event.authorId
+  const decisionTag = tint(opts, decisionColor(event.decision), `[${event.decision}]`)
+  const text = truncate(singleLine(event.text), opts.maxTextLength ?? DEFAULT_MAX_TEXT)
+  return `${decisionTag} ${tint(opts, 'dim', coord)} ${who}: ${text}`
+}
+
+function decisionColor(decision: Extract<InspectEvent, { cat: 'inbound' }>['decision']): ColorName {
+  switch (decision) {
+    case 'engage':
+      return 'green'
+    case 'observe':
+      return 'dim'
+    case 'denied':
+      return 'red'
+    case 'claim':
+      return 'magenta'
   }
 }
 

--- a/src/inspect/types.test.ts
+++ b/src/inspect/types.test.ts
@@ -53,7 +53,7 @@ describe('parseFilter', () => {
     expect(out.ok).toBe(false)
     if (out.ok) throw new Error('unreachable')
     expect(out.reason).toContain('"wat"')
-    expect(out.reason).toContain('meta, user, assistant, tool, error, done')
+    expect(out.reason).toContain('meta, user, assistant, tool, error, done, broadcast, cron-fire, inbound')
   })
 
   test('case-insensitive token match', () => {

--- a/src/inspect/types.ts
+++ b/src/inspect/types.ts
@@ -9,8 +9,11 @@ export const INSPECT_CATEGORIES = [
   'done',
   'broadcast',
   'cron-fire',
+  'inbound',
 ] as const
 export type InspectCategory = (typeof INSPECT_CATEGORIES)[number]
+
+export type InboundDecision = 'engage' | 'observe' | 'denied' | 'claim'
 
 export type InspectEvent =
   | { cat: 'meta'; ts: number; origin: MinimalSessionOrigin }
@@ -41,6 +44,22 @@ export type InspectEvent =
     }
   | { cat: 'broadcast'; ts: number; payload: unknown; meta?: Record<string, string> }
   | { cat: 'cron-fire'; ts: number; jobId: string; payload: unknown }
+  | {
+      cat: 'inbound'
+      ts: number
+      adapter: string
+      workspace: string
+      chat: string
+      thread: string | null
+      authorId: string
+      authorName: string
+      authorIsBot: boolean
+      isDm: boolean
+      isBotMention: boolean
+      text: string
+      externalMessageId: string
+      decision: InboundDecision
+    }
 
 export type InspectFilter = {
   include?: ReadonlySet<InspectCategory>

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -214,6 +214,7 @@ export async function startAgent({
     }),
     permissions: pluginsLoaded.permissions,
     claimHandler: claimController.claimHandler,
+    stream,
   })
 
   const createSessionForSubagent: import('@/agent/subagents').CreateSessionForSubagent = async (

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1062,15 +1062,7 @@ function handleInspectMessage(
 
   if (stream !== undefined && typeof msg.sinceMs === 'number') {
     for (const event of stream.scan({ sinceTs: msg.sinceMs, target: { kind: 'broadcast' } })) {
-      sendInspect(ws, {
-        type: 'frame',
-        ts: event.ts,
-        payload: {
-          kind: 'broadcast',
-          payload: event.payload,
-          ...(event.meta !== undefined ? { meta: event.meta } : {}),
-        },
-      })
+      sendInspect(ws, { type: 'frame', ts: event.ts, payload: broadcastEventToFrame(event) })
     }
     for (const event of stream.scan({ sinceTs: msg.sinceMs, target: { kind: 'cron' } })) {
       sendInspect(ws, {
@@ -1092,15 +1084,7 @@ function handleInspectMessage(
 
   if (stream !== undefined) {
     ws.data.unsubBroadcast = stream.subscribe({ target: { kind: 'broadcast' } }, (event) => {
-      sendInspect(ws, {
-        type: 'frame',
-        ts: event.ts,
-        payload: {
-          kind: 'broadcast',
-          payload: event.payload,
-          ...(event.meta !== undefined ? { meta: event.meta } : {}),
-        },
-      })
+      sendInspect(ws, { type: 'frame', ts: event.ts, payload: broadcastEventToFrame(event) })
     })
     ws.data.unsubCron = stream.subscribe({ target: { kind: 'cron' } }, (event) => {
       sendInspect(ws, {
@@ -1116,6 +1100,52 @@ function handleInspectMessage(
 
 function extractJobId(target: StreamMessage['target']): string {
   return target.kind === 'cron' ? target.jobId : ''
+}
+
+function broadcastEventToFrame(event: StreamMessage): InspectFramePayload {
+  const inbound = readChannelInboundBroadcast(event.payload)
+  if (inbound !== null) return inbound
+  return {
+    kind: 'broadcast',
+    payload: event.payload,
+    ...(event.meta !== undefined ? { meta: event.meta } : {}),
+  }
+}
+
+function readChannelInboundBroadcast(payload: unknown): InspectFramePayload | null {
+  if (typeof payload !== 'object' || payload === null) return null
+  const p = payload as Record<string, unknown>
+  if (p.kind !== 'channel-inbound') return null
+  if (typeof p.adapter !== 'string') return null
+  if (typeof p.workspace !== 'string') return null
+  if (typeof p.chat !== 'string') return null
+  if (!(p.thread === null || typeof p.thread === 'string')) return null
+  if (typeof p.authorId !== 'string') return null
+  if (typeof p.authorName !== 'string') return null
+  if (typeof p.authorIsBot !== 'boolean') return null
+  if (typeof p.isDm !== 'boolean') return null
+  if (typeof p.isBotMention !== 'boolean') return null
+  if (typeof p.text !== 'string') return null
+  if (typeof p.externalMessageId !== 'string') return null
+  if (typeof p.ts !== 'number') return null
+  const decision = p.decision
+  if (decision !== 'engage' && decision !== 'observe' && decision !== 'denied' && decision !== 'claim') return null
+  return {
+    kind: 'channel_inbound',
+    adapter: p.adapter,
+    workspace: p.workspace,
+    chat: p.chat,
+    thread: p.thread,
+    authorId: p.authorId,
+    authorName: p.authorName,
+    authorIsBot: p.authorIsBot,
+    isDm: p.isDm,
+    isBotMention: p.isBotMention,
+    text: p.text,
+    externalMessageId: p.externalMessageId,
+    ts: p.ts,
+    decision,
+  }
 }
 
 function forwardAgentEventToInspect(

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -87,6 +87,30 @@ export type InspectFramePayload =
     }
   | { kind: 'broadcast'; payload: unknown; meta?: Record<string, string> }
   | { kind: 'cron-fire'; jobId: string; payload: unknown }
+  // Channel inbound message observed by the router. Surfaced regardless
+  // of the engagement decision so inspect can show what the agent saw,
+  // not just what it chose to act on. `decision` mirrors the router's
+  // EngagementDecision plus 'denied' (channel.respond gate) and 'claim'
+  // (role-claim intercept) for completeness. `text` is the raw inbound
+  // text — no batching, no compose-prompt wrapping.
+  | {
+      kind: 'channel_inbound'
+      adapter: string
+      workspace: string
+      chat: string
+      thread: string | null
+      authorId: string
+      authorName: string
+      authorIsBot: boolean
+      isDm: boolean
+      isBotMention: boolean
+      text: string
+      externalMessageId: string
+      // 0 = platform timestamp unknown; the renderer uses the frame's
+      // wall-clock ts instead.
+      ts: number
+      decision: 'engage' | 'observe' | 'denied' | 'claim'
+    }
 
 export type InspectServerMessage =
   | { type: 'subscribed'; sessionId: string; sessionLive: boolean }


### PR DESCRIPTION
## Summary

`typeclaw inspect` previously had no visibility into inbound channel messages. The router batches every inbound into the composed turn prompt and feeds it to `session.prompt()`, so the inspect view saw exactly one `user` event per turn — losing per-message author, channel coordinates, classification (mention / DM / reply), and the router's engagement decision.

This PR surfaces inbound channel messages as a new `inbound` event category in the inspect view. Both live tail and `sinceMs` backfill are supported, with no new file persistence and no protocol backwards-compatibility cost.

## Motivation

The operator-visible failures this addresses:

1. **Silent denial diagnosis** — when an inbound is dropped by the `channel.respond` permission gate, the router emits a log line but no inspect event. Operators currently have to grep `docker logs` to confirm "did the agent see that message at all?". Now `typeclaw inspect` shows `[denied]` lines inline.
2. **Engagement-decision opacity** — when the agent goes quiet in a busy channel, there's no way to tell from `inspect` whether the router heard messages and chose `observe`, vs. didn't hear them at all (adapter bug). Now every inbound surfaces with its `engage` / `observe` / `denied` / `claim` decision.
3. **Author + coordinates loss** — the composed user prompt smashes N inbounds into one string; individual authors, externalMessageIds, and per-message `isBotMention` flags vanish before reaching inspect.

## Design

The router publishes every inbound to the in-process `Stream` as a tagged broadcast:

```ts
stream.publish({
  target: { kind: 'broadcast' },
  payload: { kind: 'channel-inbound', adapter, workspace, chat, ..., decision },
})
```

The server's `/inspect` WS handler already subscribes to all broadcasts (and backfills via `stream.scan`). A small helper (`broadcastEventToFrame`) detects the `channel-inbound` discriminator and emits a typed `channel_inbound` frame instead of a generic `broadcast`. The client maps the frame to an `InspectEvent` with `cat: 'inbound'`, which the renderer prints as:

```
15:08:42  inbound    [engage] slack:acme/C12345 alice: hey bot can you help
15:08:43  inbound    [observe] discord:9999/8888#7777 bob: just chatting
15:08:44  inbound    [denied] slack:acme/C12345 stranger: who are you
```

**Decoupled from the routing decision.** The publish call sits in `router.route()` and fires on all four outcomes (engage, observe, denied, claim), independent of whether the message reaches a session. This is the single most important property of the change — denied inbounds **must** show up in inspect, otherwise the silent-drop diagnosis case is unsolved.

## Why Stream broadcast over a new persistence file?

Considered but rejected:

- **Embed in `sessions/*.jsonl`** — would require pi-coding-agent's transcript format to learn a new entry kind. Big blast radius for a UI-only feature.
- **New `channels/inbounds.jsonl`** — durable but adds a new file to the agent folder, a new reader to inspect, and a session-mapping problem (which file belongs to which session view). Wrong tradeoff for "show me what's flowing in right now".
- **Embed extra fields in the existing `user` event** — only triggers on engage; loses denied/observe entirely.

The Stream broadcast path reuses every existing piece of inspect plumbing (subscribe, scan/backfill, frame protocol) and matches the way `broadcast` and `cron-fire` already work. The ring buffer is bounded (1000 events default) and ephemeral, which is the right shape for "what just arrived" inspection — anything older lives in the session transcript anyway.

## Files

| Path | What |
|---|---|
| `src/shared/protocol.ts` | New `channel_inbound` variant on `InspectFramePayload` |
| `src/inspect/types.ts` | New `inbound` category on `InspectEvent` + `INSPECT_CATEGORIES` |
| `src/inspect/live.ts` | Map `channel_inbound` frame → `cat: 'inbound'` event |
| `src/inspect/render.ts` | Render the event with decision tag, channel coords, author |
| `src/channels/router.ts` | Publish on engage / observe / denied / claim |
| `src/channels/manager.ts` | Forward `stream` option to the router |
| `src/run/index.ts` | Pass the agent's existing `stream` to the channel manager |
| `src/server/index.ts` | `broadcastEventToFrame` helper + scan/subscribe wiring |

## Tests

**Renderer** (`src/inspect/render.test.ts`) — four cases:
- `engage` event renders the full `[engage] coord author: text` shape
- `observe` event uses the `[observe]` tag and includes the `#thread` suffix when present
- `denied` event uses the `[denied]` tag (the silent-drop visibility case)
- empty `authorName` falls back to `authorId`

**Frame mapping + live tail + backfill** (`src/inspect/live.test.ts`) — three cases:
- end-to-end: publish a `channel-inbound` broadcast, assert it arrives as `cat: 'inbound'` over WS
- malformed payload (missing required fields) falls back to a generic `broadcast` (no crash, no data loss)
- inbound published BEFORE subscribe is backfilled via `sinceMs: 0`

**Router publish** (`src/channels/router.inbound-stream.test.ts`) — five cases:
- engaged inbound publishes with `decision: 'engage'`
- denied inbound publishes with `decision: 'denied'` (operator can see silent drops)
- observed inbound publishes with `decision: 'observe'`
- omitting `stream` is a no-op (router still routes)
- claim intercept publishes with `decision: 'claim'`

Each test is **mutation-verified**: commenting out the corresponding `publishInbound(event, '<decision>')` call flips at least one assertion in the router test file, and the server `broadcastEventToFrame` extraction is exercised by the live test's backfill case.

## Filter compatibility

`typeclaw inspect --filter inbound` and `--filter !inbound` work via the existing `parseFilter` machinery (`inbound` is now one of `INSPECT_CATEGORIES`). The pre-existing `types.test.ts` filter-error case was updated to include the new category in its expected-list assertion.

## Pre-flight

```
bun run typecheck   clean
bun run lint        0 errors (41 pre-existing warnings, all in src/init/dockerfile.ts + adapter tests, none in changed files)
bun run format      clean (after `bun run format`)
bun test            1144/1144 pass on touched paths (src/inspect, src/channels, src/server, src/shared, src/stream, src/run)
```

The remaining handful of flakes in the full suite (memory `session.turn.start`/`session.idle` waitFor timeouts, the agent-browser headed-mode wrapper's 5s timeout, the port-watcher polling-tick test) reproduce identically on a clean `origin/main` baseline and are unrelated to this change.
