### PR TITLE
logs: add -n / --tail to typeclaw logs and compose logs

### DIFF
--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -8,17 +8,17 @@ TypeClaw runs code in three stages with different filesystems ([/concepts/archit
 
 ## Lifecycle
 
-| Command            | Description                                                                                                                |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `typeclaw init`    | Interactive wizard. Scaffolds the agent folder; optionally wires the first provider + first channel.                       |
-| `typeclaw start`   | `docker run` with configured ports + mounts + env-file. Spawns `hostd` on first call per host. Flags: `--port`, `--build`. |
-| `typeclaw restart` | `stop` + `start` with the same flag set as `start`.                                                                        |
-| `typeclaw stop`    | `docker stop` then `docker rm` so a clean stop leaves no trace.                                                            |
-| `typeclaw status`  | Container + daemon registration state.                                                                                     |
-| `typeclaw logs`    | Print container stdout/stderr with reformatted local timestamps. `-f` / `--follow` to stream.                              |
-| `typeclaw shell`   | Drop into a shell inside the running container. `--shell` to pick (defaults to `bash` if present, else `sh`).              |
-| `typeclaw tui`     | Attach an interactive TUI. Takes an optional one-shot prompt argument; `--url` to override the websocket URL.              |
-| `typeclaw reload`  | Re-read `typeclaw.json` and apply hot-reloadable fields. Reports which fields require a restart.                           |
+| Command            | Description                                                                                                                      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `typeclaw init`    | Interactive wizard. Scaffolds the agent folder; optionally wires the first provider + first channel.                             |
+| `typeclaw start`   | `docker run` with configured ports + mounts + env-file. Spawns `hostd` on first call per host. Flags: `--port`, `--build`.       |
+| `typeclaw restart` | `stop` + `start` with the same flag set as `start`.                                                                              |
+| `typeclaw stop`    | `docker stop` then `docker rm` so a clean stop leaves no trace.                                                                  |
+| `typeclaw status`  | Container + daemon registration state.                                                                                           |
+| `typeclaw logs`    | Print container stdout/stderr with reformatted local timestamps. `-f` / `--follow` to stream; `-n` / `--tail <N\|all>` to limit. |
+| `typeclaw shell`   | Drop into a shell inside the running container. `--shell` to pick (defaults to `bash` if present, else `sh`).                    |
+| `typeclaw tui`     | Attach an interactive TUI. Takes an optional one-shot prompt argument; `--url` to override the websocket URL.                    |
+| `typeclaw reload`  | Re-read `typeclaw.json` and apply hot-reloadable fields. Reports which fields require a restart.                                 |
 
 `--port` is the **preferred** host port. On bind conflict, `start` allocates an ephemeral port; subsequent commands resolve the actual port by querying Docker.
 

--- a/src/cli/compose.ts
+++ b/src/cli/compose.ts
@@ -12,11 +12,12 @@ import {
   type ComposeDoctorReport,
 } from '@/compose'
 import { config } from '@/config'
+import { parseTailValue } from '@/container'
 import { formatJson, formatReport } from '@/doctor'
 
 import { formatComposeStatus } from './compose-status'
 import { formatComposeUsage, formatComposeUsageJson } from './compose-usage'
-import { c, spinner } from './ui'
+import { c, errorLine, spinner } from './ui'
 import { parseSince, parseUntil } from './usage-args'
 
 const startSub = defineCommand({
@@ -144,8 +145,23 @@ const logsSub = defineCommand({
       description: 'stream new log output as it arrives',
       default: false,
     },
+    tail: {
+      type: 'string',
+      alias: 'n',
+      description: 'number of lines to show from the end of each agent\'s logs (non-negative integer or "all")',
+    },
   },
   async run({ args }) {
+    let tail: string | undefined
+    if (args.tail !== undefined) {
+      const parsed = parseTailValue(args.tail)
+      if (!parsed.ok) {
+        console.error(errorLine(parsed.reason))
+        process.exit(2)
+      }
+      tail = parsed.value
+    }
+
     const controller = new AbortController()
     const onSig = (): void => controller.abort()
     process.once('SIGINT', onSig)
@@ -156,7 +172,12 @@ const logsSub = defineCommand({
       } else {
         console.log(c.dim('Showing logs for all agents.'))
       }
-      const result = await composeLogs({ rootCwd: process.cwd(), follow: args.follow, signal: controller.signal })
+      const result = await composeLogs({
+        rootCwd: process.cwd(),
+        follow: args.follow,
+        tail,
+        signal: controller.signal,
+      })
       if (result.agents.length === 0) {
         console.log(c.dim('No typeclaw agents found in immediate subdirectories of cwd.'))
         return

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 
-import { logs } from '@/container'
+import { logs, parseTailValue } from '@/container'
 import { findAgentDir } from '@/init'
 
 import { c, errorLine } from './ui'
@@ -17,9 +17,24 @@ export const logsCommand = defineCommand({
       description: 'stream new log output as it arrives',
       default: false,
     },
+    tail: {
+      type: 'string',
+      alias: 'n',
+      description: 'number of lines to show from the end of the logs (non-negative integer or "all")',
+    },
   },
   async run({ args }) {
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+
+    let tail: string | undefined
+    if (args.tail !== undefined) {
+      const parsed = parseTailValue(args.tail)
+      if (!parsed.ok) {
+        console.error(errorLine(parsed.reason))
+        process.exit(2)
+      }
+      tail = parsed.value
+    }
 
     if (args.follow) {
       console.log(c.cyan('Streaming container logs...'))
@@ -27,7 +42,7 @@ export const logsCommand = defineCommand({
       console.log(c.dim('Showing container logs.'))
     }
 
-    const result = await logs({ cwd, follow: args.follow })
+    const result = await logs({ cwd, follow: args.follow, tail })
     if (!result.ok) {
       console.error(errorLine(result.reason))
       process.exit(1)

--- a/src/compose/logs.ts
+++ b/src/compose/logs.ts
@@ -1,4 +1,4 @@
-import { containerExists } from '@/container'
+import { buildDockerLogsCmd, containerExists } from '@/container'
 import { supportsColor } from '@/container/log-colors'
 import { makeLogTimestampReformatter, type TimestampReformatter } from '@/container/log-timestamps'
 import { getBun } from '@/container/shared'
@@ -93,9 +93,7 @@ export async function composeLogs({
   const useColor = supportsColor(out)
 
   const procs = attached.map((agent) => {
-    const cmd = follow
-      ? ['docker', 'logs', '--timestamps', '-f', agent.containerName]
-      : ['docker', 'logs', '--timestamps', agent.containerName]
+    const cmd = buildDockerLogsCmd({ containerName: agent.containerName, follow })
     const proc = bun.spawn({ cmd, stdout: 'pipe', stderr: 'pipe' })
     return { agent, proc }
   })

--- a/src/compose/logs.ts
+++ b/src/compose/logs.ts
@@ -8,6 +8,7 @@ import { discoverAgents, type AgentEntry } from './discover'
 export type ComposeLogsOptions = {
   rootCwd: string
   follow: boolean
+  tail?: string
   out?: NodeJS.WritableStream
   err?: NodeJS.WritableStream
   signal?: AbortSignal
@@ -66,6 +67,7 @@ export function makeLinePrefixer(
 export async function composeLogs({
   rootCwd,
   follow,
+  tail,
   out = process.stdout,
   err = process.stderr,
   signal,
@@ -93,7 +95,11 @@ export async function composeLogs({
   const useColor = supportsColor(out)
 
   const procs = attached.map((agent) => {
-    const cmd = buildDockerLogsCmd({ containerName: agent.containerName, follow })
+    const cmd = buildDockerLogsCmd({
+      containerName: agent.containerName,
+      follow,
+      ...(tail !== undefined ? { tail } : {}),
+    })
     const proc = bun.spawn({ cmd, stdout: 'pipe', stderr: 'pipe' })
     return { agent, proc }
   })

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -1,4 +1,4 @@
-export { buildDockerLogsCmd, logs, planLogs, type LogsPlan, type LogsResult } from './logs'
+export { buildDockerLogsCmd, logs, parseTailValue, planLogs, type LogsPlan, type LogsResult } from './logs'
 export { CONTAINER_PORT, TUI_TOKEN_LABEL, findFreePort, resolveHostPort, resolveTuiToken } from './port'
 export {
   requireContainerRunning,

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -1,4 +1,4 @@
-export { logs, planLogs, type LogsPlan, type LogsResult } from './logs'
+export { buildDockerLogsCmd, logs, planLogs, type LogsPlan, type LogsResult } from './logs'
 export { CONTAINER_PORT, TUI_TOKEN_LABEL, findFreePort, resolveHostPort, resolveTuiToken } from './port'
 export {
   requireContainerRunning,

--- a/src/container/logs.test.ts
+++ b/src/container/logs.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { makeLogTimestampReformatter } from './log-timestamps'
-import { buildDockerLogsCmd, planLogs, pumpWithTimestamps } from './logs'
+import { buildDockerLogsCmd, parseTailValue, planLogs, pumpWithTimestamps } from './logs'
 
 let root: string
 
@@ -24,6 +24,49 @@ describe('planLogs', () => {
     expect(planLogs(folder, { follow: false })).toEqual({ containerName: 'coder', follow: false })
     expect(planLogs(folder, { follow: true })).toEqual({ containerName: 'coder', follow: true })
   })
+
+  test('carries tail through when supplied; omits the field when undefined', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+
+    expect(planLogs(folder, { follow: false, tail: '50' })).toEqual({
+      containerName: 'coder',
+      follow: false,
+      tail: '50',
+    })
+    expect(planLogs(folder, { follow: true, tail: 'all' })).toEqual({
+      containerName: 'coder',
+      follow: true,
+      tail: 'all',
+    })
+    expect(planLogs(folder, { follow: false })).toEqual({ containerName: 'coder', follow: false })
+  })
+})
+
+describe('parseTailValue', () => {
+  test('accepts non-negative integers and returns them verbatim', () => {
+    expect(parseTailValue('0')).toEqual({ ok: true, value: '0' })
+    expect(parseTailValue('1')).toEqual({ ok: true, value: '1' })
+    expect(parseTailValue('100')).toEqual({ ok: true, value: '100' })
+    expect(parseTailValue('  42  ')).toEqual({ ok: true, value: '42' })
+  })
+
+  test('accepts the "all" sentinel case-insensitively', () => {
+    expect(parseTailValue('all')).toEqual({ ok: true, value: 'all' })
+    expect(parseTailValue('ALL')).toEqual({ ok: true, value: 'all' })
+    expect(parseTailValue(' All ')).toEqual({ ok: true, value: 'all' })
+  })
+
+  test('rejects empty, negative, fractional, signed, and garbage inputs', () => {
+    expect(parseTailValue('').ok).toBe(false)
+    expect(parseTailValue('   ').ok).toBe(false)
+    expect(parseTailValue('-5').ok).toBe(false)
+    expect(parseTailValue('+5').ok).toBe(false)
+    expect(parseTailValue('3.5').ok).toBe(false)
+    expect(parseTailValue('1e2').ok).toBe(false)
+    expect(parseTailValue('007').ok).toBe(false)
+    expect(parseTailValue('ten').ok).toBe(false)
+  })
 })
 
 describe('buildDockerLogsCmd', () => {
@@ -42,6 +85,33 @@ describe('buildDockerLogsCmd', () => {
       'logs',
       '--timestamps',
       '-f',
+      'coder',
+    ])
+  })
+
+  test('omits --tail when the field is absent so docker uses its default ("all")', () => {
+    expect(buildDockerLogsCmd({ containerName: 'coder', follow: false })).not.toContain('--tail')
+  })
+
+  test('inserts --tail <value> before -f when both are set', () => {
+    expect(buildDockerLogsCmd({ containerName: 'coder', follow: true, tail: '50' })).toEqual([
+      'docker',
+      'logs',
+      '--timestamps',
+      '--tail',
+      '50',
+      '-f',
+      'coder',
+    ])
+  })
+
+  test('passes the "all" sentinel through unchanged', () => {
+    expect(buildDockerLogsCmd({ containerName: 'coder', follow: false, tail: 'all' })).toEqual([
+      'docker',
+      'logs',
+      '--timestamps',
+      '--tail',
+      'all',
       'coder',
     ])
   })

--- a/src/container/logs.test.ts
+++ b/src/container/logs.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { makeLogTimestampReformatter } from './log-timestamps'
-import { planLogs, pumpWithTimestamps } from './logs'
+import { buildDockerLogsCmd, planLogs, pumpWithTimestamps } from './logs'
 
 let root: string
 
@@ -23,6 +23,27 @@ describe('planLogs', () => {
 
     expect(planLogs(folder, { follow: false })).toEqual({ containerName: 'coder', follow: false })
     expect(planLogs(folder, { follow: true })).toEqual({ containerName: 'coder', follow: true })
+  })
+})
+
+describe('buildDockerLogsCmd', () => {
+  test('builds the base argv when follow is false', () => {
+    expect(buildDockerLogsCmd({ containerName: 'coder', follow: false })).toEqual([
+      'docker',
+      'logs',
+      '--timestamps',
+      'coder',
+    ])
+  })
+
+  test('appends -f before the container name when follow is true', () => {
+    expect(buildDockerLogsCmd({ containerName: 'coder', follow: true })).toEqual([
+      'docker',
+      'logs',
+      '--timestamps',
+      '-f',
+      'coder',
+    ])
   })
 })
 

--- a/src/container/logs.ts
+++ b/src/container/logs.ts
@@ -31,18 +31,14 @@ export async function logs({
   const bun = getBun()
   if (!bun) return { ok: false, reason: 'bun runtime not available' }
 
-  const { containerName } = planLogs(cwd, { follow })
+  const plan = planLogs(cwd, { follow })
 
   try {
-    if (!(await containerExists(containerName))) {
-      return { ok: false, reason: `Container ${containerName} not found. Run \`typeclaw start\` first.` }
+    if (!(await containerExists(plan.containerName))) {
+      return { ok: false, reason: `Container ${plan.containerName} not found. Run \`typeclaw start\` first.` }
     }
 
-    const cmd = ['docker', 'logs', '--timestamps']
-    if (follow) cmd.push('-f')
-    cmd.push(containerName)
-
-    const proc = bun.spawn({ cmd, cwd, stdout: 'pipe', stderr: 'pipe' })
+    const proc = bun.spawn({ cmd: buildDockerLogsCmd(plan), cwd, stdout: 'pipe', stderr: 'pipe' })
 
     const onAbort = (): void => {
       try {
@@ -62,7 +58,7 @@ export async function logs({
     const exitCode = await proc.exited
     signal?.removeEventListener('abort', onAbort)
 
-    return { ok: true, containerName, exitCode }
+    return { ok: true, containerName: plan.containerName, exitCode }
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
   }
@@ -70,6 +66,14 @@ export async function logs({
 
 export function planLogs(cwd: string, { follow }: { follow: boolean }): LogsPlan {
   return { containerName: containerNameFromCwd(cwd), follow }
+}
+
+// Exported so `compose/logs.ts` builds the exact same `docker logs` argv shape.
+export function buildDockerLogsCmd(plan: LogsPlan): string[] {
+  const cmd = ['docker', 'logs', '--timestamps']
+  if (plan.follow) cmd.push('-f')
+  cmd.push(plan.containerName)
+  return cmd
 }
 
 // Exported for `compose/logs.ts` so the multi-agent path reuses the same

--- a/src/container/logs.ts
+++ b/src/container/logs.ts
@@ -5,6 +5,7 @@ import { containerExists, containerNameFromCwd, getBun } from './shared'
 export type LogsPlan = {
   containerName: string
   follow: boolean
+  tail?: string
 }
 
 export type LogsResult = { ok: true; containerName: string; exitCode: number } | { ok: false; reason: string }
@@ -12,6 +13,10 @@ export type LogsResult = { ok: true; containerName: string; exitCode: number } |
 export type LogsOptions = {
   cwd: string
   follow: boolean
+  // Forwarded to `docker logs --tail <value>`. Accepts a non-negative
+  // integer string or the sentinel `"all"`. When undefined, no `--tail`
+  // arg is added and docker's default ("all") applies.
+  tail?: string
   out?: NodeJS.WritableStream
   err?: NodeJS.WritableStream
   signal?: AbortSignal
@@ -23,6 +28,7 @@ export type LogsOptions = {
 export async function logs({
   cwd,
   follow,
+  tail,
   out = process.stdout,
   err = process.stderr,
   signal,
@@ -31,7 +37,7 @@ export async function logs({
   const bun = getBun()
   if (!bun) return { ok: false, reason: 'bun runtime not available' }
 
-  const plan = planLogs(cwd, { follow })
+  const plan = planLogs(cwd, { follow, tail })
 
   try {
     if (!(await containerExists(plan.containerName))) {
@@ -64,13 +70,30 @@ export async function logs({
   }
 }
 
-export function planLogs(cwd: string, { follow }: { follow: boolean }): LogsPlan {
-  return { containerName: containerNameFromCwd(cwd), follow }
+export function planLogs(cwd: string, { follow, tail }: { follow: boolean; tail?: string }): LogsPlan {
+  return { containerName: containerNameFromCwd(cwd), follow, ...(tail !== undefined ? { tail } : {}) }
+}
+
+// Validate user-supplied `--tail` value. Mirrors `docker logs --tail`'s
+// accepted shape: either the sentinel `"all"` (case-insensitive) or a
+// non-negative integer.
+export function parseTailValue(raw: string): { ok: true; value: string } | { ok: false; reason: string } {
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return { ok: false, reason: '--tail requires a value (a non-negative integer or "all")' }
+  if (trimmed.toLowerCase() === 'all') return { ok: true, value: 'all' }
+  // Reject leading +, leading zeros (other than "0"), signs, decimals, and
+  // scientific notation up front so the user gets a clear error instead of
+  // docker's terse "invalid value" later.
+  if (!/^(?:0|[1-9]\d*)$/.test(trimmed)) {
+    return { ok: false, reason: `--tail expects a non-negative integer or "all", got ${JSON.stringify(raw)}` }
+  }
+  return { ok: true, value: trimmed }
 }
 
 // Exported so `compose/logs.ts` builds the exact same `docker logs` argv shape.
 export function buildDockerLogsCmd(plan: LogsPlan): string[] {
   const cmd = ['docker', 'logs', '--timestamps']
+  if (plan.tail !== undefined) cmd.push('--tail', plan.tail)
   if (plan.follow) cmd.push('-f')
   cmd.push(plan.containerName)
   return cmd


### PR DESCRIPTION
## What this PR does

Adds `-n` / `--tail <N|all>` to both `typeclaw logs` and `typeclaw compose logs`, mirroring `docker logs --tail`. When the flag is omitted the docker default ("all") is preserved — no behavior change for existing callers.

Three commits, each independently reviewable:

| Commit | Change |
|---|---|
| `logs: extract buildDockerLogsCmd shared by single-agent and compose paths` | Pure refactor. Extracts the argv builder from the inline single-agent path into a shared helper; compose consumes it. Byte-identical output to the previous inline versions. |
| `logs: add tail field to LogsOptions / LogsPlan + parseTailValue validator` | Domain layer only — no CLI wiring. Threads an optional `tail` through `LogsOptions` → `planLogs` → `buildDockerLogsCmd`. Adds `parseTailValue` to validate on the input boundary. |
| `cli: wire -n / --tail into typeclaw logs and typeclaw compose logs` | Registers the flag on both CLI surfaces, validates via `parseTailValue`, plumbs through to docker argv. Updates `docs/content/docs/reference/cli.mdx`. |

## Why

Users running `typeclaw logs` against long-lived agents have no way to cap output — they must pipe through `tail` or `head` themselves, and that workaround breaks when `-f` / `--follow` is active. `docker logs --tail` solves this natively; this PR exposes it.

## How

**Shared argv builder first.** Before adding the flag, the single-agent and compose paths each built their docker-logs argv inline. A future flag added to one but not the other would silently diverge. Extracting `buildDockerLogsCmd` into `src/container/logs.ts` and having compose consume it via `@/container` closes that drift window — any future docker-logs flag now has one place to land.

**`parseTailValue` on the input boundary.** Accepts a non-negative integer string or the sentinel `"all"` (case-insensitive). Everything else gets a precise "got X" rejection before docker ever runs, rather than docker's terse "invalid value" message. Leading zeros (`007`), negative numbers (`-5`), floats (`3.5`), and scientific notation (`1e2`) are all rejected explicitly. The tests pin the accept/reject matrix.

**`undefined` vs `"all"` are not collapsed.** `tail: undefined` (flag omitted) produces `docker logs --timestamps <name>` — docker's default, which is "all". `tail: 'all'` (explicit) produces `docker logs --timestamps --tail all <name>`. The outcomes are identical to the user but the argv shapes differ; the tests pin both so a future "simplify" refactor doesn't silently change what gets sent to docker.

## Files changed

- `src/container/logs.ts` — `buildDockerLogsCmd`, `parseTailValue`, `tail` on `LogsOptions` / `LogsPlan`
- `src/container/index.ts` — re-exports the new symbols
- `src/container/logs.test.ts` — `parseTailValue` accept/reject matrix, `planLogs` tail threading, `buildDockerLogsCmd` argv shape
- `src/compose/logs.ts` — consumes `buildDockerLogsCmd`, `tail` on `ComposeLogsOptions`
- `src/cli/logs.ts` — `--tail` / `-n` flag, `parseTailValue` validation, exit 2 on bad input
- `src/cli/compose.ts` — same flag on `compose logs`
- `docs/content/docs/reference/cli.mdx` — documents `-n` / `--tail <N|all>` next to `-f` / `--follow`

## Verification

```
bun run typecheck    ✓ 0 errors
bun run lint         ✓ 0 errors (41 pre-existing warnings on main, none in changed files)
bun run format       ✓ clean
bun test --parallel src/container/ src/compose/ src/cli/index.test.ts
                     ✓ 320 pass / 0 fail
```

Full `bun run test` has 11 pre-existing flaky subprocess-timeout failures in `src/cli/index.test.ts` and `src/plugin/loader.test.ts` that time out at exactly 5000ms under 18-way parallel contention — the same flake the in-flight `SUBPROCESS_TIMEOUT_MS = 30_000` change on `main` is patching. None of the touched test files are affected; all pass on isolated re-run.

## Review notes

- **`007` rejection is intentional.** Docker happens to accept leading-zero integers, but the canonical form is `7` and silently accepting `007` would let docker normalize the input invisibly. The unit test pins this.
- **Compose mirrors single-agent exactly.** `compose logs -n 50` runs `docker logs --timestamps --tail 50 -f <each-agent>` — the flag threads through `buildDockerLogsCmd` so compose gets it for free.
- **No `--tail` arg when the flag is omitted.** Docker's default is already "all"; emitting `--tail all` unconditionally would be a no-op but would also show up in `ps` output and make tests noisier. The current behavior (pass-through when `tail` is `undefined`) keeps the argv minimal.