### PR TITLE
memory: batch memory-retrieval searches and cache stream/dreaming-state reads

### DIFF
--- a/src/bundled-plugins/memory/dreaming-state.test.ts
+++ b/src/bundled-plugins/memory/dreaming-state.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
+  __resetDreamingStateCacheForTests,
   addDreamedIds,
   clearDreamedIds,
   DREAMING_STATE_FILE,
@@ -17,10 +18,12 @@ let agentDir: string
 
 beforeEach(async () => {
   agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-dream-state-'))
+  __resetDreamingStateCacheForTests()
 })
 
 afterEach(async () => {
   await rm(agentDir, { recursive: true, force: true })
+  __resetDreamingStateCacheForTests()
 })
 
 describe('loadDreamingState', () => {
@@ -148,5 +151,44 @@ describe('clearDreamedIds', () => {
     const cleared = clearDreamedIds(state, '2026-04-27', 't2')
     expect(cleared.dreamedThrough['2026-04-26']?.dreamedIds).toEqual(['keep'])
     expect(cleared.dreamedThrough['2026-04-27']?.dreamedIds).toEqual([])
+  })
+})
+
+describe('loadDreamingState cache', () => {
+  test('second load returns the same state reference (cache hit) when file is untouched', async () => {
+    const state = addDreamedIds(emptyState(), '2026-04-27', ['a'], 'now')
+    await saveDreamingState(agentDir, state)
+
+    const first = await loadDreamingState(agentDir)
+    const second = await loadDreamingState(agentDir)
+
+    expect(second).toBe(first)
+  })
+
+  test('saveDreamingState invalidates the cache (mtime bumps)', async () => {
+    await saveDreamingState(agentDir, addDreamedIds(emptyState(), '2026-04-27', ['a'], 't1'))
+    const first = await loadDreamingState(agentDir)
+    expect(first.dreamedThrough['2026-04-27']?.dreamedIds).toEqual(['a'])
+
+    await saveDreamingState(agentDir, addDreamedIds(emptyState(), '2026-04-27', ['a', 'b'], 't2'))
+    const second = await loadDreamingState(agentDir)
+
+    expect(second).not.toBe(first)
+    expect(second.dreamedThrough['2026-04-27']?.dreamedIds).toEqual(['a', 'b'])
+  })
+
+  test('cache drops entry when file disappears so a recreate returns fresh state', async () => {
+    await saveDreamingState(agentDir, addDreamedIds(emptyState(), '2026-04-27', ['a'], 'now'))
+    const first = await loadDreamingState(agentDir)
+    expect(first.dreamedThrough['2026-04-27']?.dreamedIds).toEqual(['a'])
+
+    await rm(join(agentDir, DREAMING_STATE_FILE))
+    const empty = await loadDreamingState(agentDir)
+    expect(empty).toEqual(emptyState())
+
+    await saveDreamingState(agentDir, addDreamedIds(emptyState(), '2026-04-28', ['z'], 'later'))
+    const recreated = await loadDreamingState(agentDir)
+    expect(recreated.dreamedThrough['2026-04-28']?.dreamedIds).toEqual(['z'])
+    expect(recreated.dreamedThrough['2026-04-27']).toBeUndefined()
   })
 })

--- a/src/bundled-plugins/memory/dreaming-state.ts
+++ b/src/bundled-plugins/memory/dreaming-state.ts
@@ -1,10 +1,28 @@
 import { existsSync } from 'node:fs'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
 export const DREAMING_STATE_FILE = 'memory/.dreaming-state.json'
 
 const VERSION = 2
+
+// Stat-keyed cache for `.dreaming-state.json`. The file is read once at
+// the start of every dreaming run AND once per `readAllStreamDays` call
+// (which fires inside every `memory_search` invocation). For a retrieval
+// subagent that issues 3 parallel searches, this cache turns 3 reads +
+// 3 JSON.parses into 3 stats + 1 parse — small per-call savings, but the
+// file is tiny so the win is mostly avoiding GC pressure on busy
+// channel sessions. Invalidation key matches the stream-file cache
+// (`load-shards.ts` and `stream-io.ts` use the same `(mtimeMs, ctimeMs,
+// size)` shape); `saveDreamingState` uses `writeFile` which bumps both
+// mtime and ctime.
+type DreamingStateCacheEntry = {
+  mtimeMs: number
+  ctimeMs: number
+  size: number
+  state: DreamingState
+}
+const dreamingStateCache = new Map<string, DreamingStateCacheEntry>()
 
 // Per-day "dreamed" set: the set of stream-event ids dreaming has already
 // reasoned over for a given day. Anything in this set is either cited from
@@ -32,8 +50,35 @@ export function emptyState(): DreamingState {
 
 export async function loadDreamingState(agentDir: string): Promise<DreamingState> {
   const path = join(agentDir, DREAMING_STATE_FILE)
-  if (!existsSync(path)) return emptyState()
+  if (!existsSync(path)) {
+    dreamingStateCache.delete(path)
+    return emptyState()
+  }
 
+  let fileStat: { mtimeMs: number; ctimeMs: number; size: number }
+  try {
+    const s = await stat(path)
+    fileStat = { mtimeMs: s.mtimeMs, ctimeMs: s.ctimeMs, size: s.size }
+  } catch {
+    return emptyState()
+  }
+
+  const cached = dreamingStateCache.get(path)
+  if (
+    cached !== undefined &&
+    cached.mtimeMs === fileStat.mtimeMs &&
+    cached.ctimeMs === fileStat.ctimeMs &&
+    cached.size === fileStat.size
+  ) {
+    return cached.state
+  }
+
+  const state = await loadDreamingStateFromDisk(path)
+  dreamingStateCache.set(path, { ...fileStat, state })
+  return state
+}
+
+async function loadDreamingStateFromDisk(path: string): Promise<DreamingState> {
   let raw: string
   try {
     raw = await readFile(path, 'utf8')
@@ -56,6 +101,10 @@ export async function saveDreamingState(agentDir: string, state: DreamingState):
   const path = join(agentDir, DREAMING_STATE_FILE)
   await mkdir(dirname(path), { recursive: true })
   await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, 'utf8')
+}
+
+export function __resetDreamingStateCacheForTests(): void {
+  dreamingStateCache.clear()
 }
 
 export function getDreamedIds(state: DreamingState, date: string): ReadonlySet<string> {

--- a/src/bundled-plugins/memory/memory-retrieval.ts
+++ b/src/bundled-plugins/memory/memory-retrieval.ts
@@ -31,7 +31,7 @@ export type CreateMemoryRetrievalSubagentOptions = {
 
 export const MEMORY_RETRIEVAL_SYSTEM_PROMPT = `You are the memory-retrieval subagent. Read the user's most recent prompt and decide what's relevant from BOTH topic shards in \`memory/topics/\` (consolidated long-term memory) AND undreamed daily-stream events under \`memory/streams/\` (recent fragments not yet folded into shards). Use \`memory_search\` to query both surfaces; use \`read\`/\`ls\` to pull full shard bodies when needed. Synthesize a focused ≤8 KB summary of the relevant memory. Save by \`write\`ing it to the exact path provided in your payload as \`cacheFilePath\`. Be ruthlessly concise. Do NOT write anywhere else. Do NOT delete files.
 
-Search discipline: make AT MOST 3 \`memory_search\` calls before writing the cache. Pick queries that match the user's literal phrasing — not framing vocabulary, not metadata (session ids, dates), not words from your own system prompt. If 3 well-chosen searches turn up nothing relevant, write the empty-context note and stop.`
+Search discipline: issue ALL your \`memory_search\` queries in a SINGLE response as parallel tool calls (up to 3 at once), then wait for every result before deciding what to do next. Different angles in parallel, NEVER one search per turn — sequential searches waste a full LLM round-trip per query (~3s each) on file I/O that takes milliseconds. Pick queries that match the user's literal phrasing — not framing vocabulary, not metadata (session ids, dates), not words from your own system prompt. If the parallel batch turns up nothing relevant, write the empty-context note and stop.`
 
 export function memoryRetrievalExhaustedMessage(used: number, max: number): string {
   const usedKb = Math.round(used / 1024)

--- a/src/bundled-plugins/memory/stream-io.test.ts
+++ b/src/bundled-plugins/memory/stream-io.test.ts
@@ -7,6 +7,7 @@ import { DREAMING_STATE_FILE } from './dreaming-state'
 import { streamFilePath, streamsDir } from './paths'
 import type { FragmentEvent, LegacyProseEvent, WatermarkEvent } from './stream-events'
 import {
+  __resetStreamFileCacheForTests,
   appendEvents,
   countEvents,
   filterUndreamedEvents,
@@ -391,3 +392,85 @@ function fragmentFor(id: string, topic: string): FragmentEvent {
     body: `body for ${topic}`,
   }
 }
+
+describe('readEvents cache', () => {
+  let dir: string
+  let path: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(os.tmpdir(), 'typeclaw-stream-cache-'))
+    path = join(dir, 'stream.jsonl')
+    __resetStreamFileCacheForTests()
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+    __resetStreamFileCacheForTests()
+  })
+
+  test('second read returns the same array reference (cache hit) when file is untouched', async () => {
+    const fragment = fragmentFor('e1', 't1')
+    await appendEvents(path, [fragment])
+
+    const first = await readEvents(path)
+    const second = await readEvents(path)
+
+    expect(second).toBe(first)
+  })
+
+  test('appendEvents invalidates the cache (mtime change picked up by stat-based key)', async () => {
+    await appendEvents(path, [fragmentFor('e1', 't1')])
+    const first = await readEvents(path)
+    expect(first).toHaveLength(1)
+
+    await appendEvents(path, [fragmentFor('e2', 't2')])
+    const second = await readEvents(path)
+
+    expect(second).not.toBe(first)
+    expect(second).toHaveLength(2)
+    expect(second.map((e) => (e.type === 'fragment' ? e.id : null))).toEqual(['e1', 'e2'])
+  })
+
+  test('writeEventsAtomic invalidates the cache (rename bumps mtime)', async () => {
+    await appendEvents(path, [fragmentFor('e1', 't1'), fragmentFor('e2', 't2')])
+    const first = await readEvents(path)
+    expect(first).toHaveLength(2)
+
+    await writeEventsAtomic(path, [fragmentFor('e2', 't2')])
+    const second = await readEvents(path)
+
+    expect(second).not.toBe(first)
+    expect(second).toHaveLength(1)
+    expect(second[0]!.type === 'fragment' && second[0]!.id).toBe('e2')
+  })
+
+  test('cache drops entry when file disappears so a recreate returns fresh content', async () => {
+    await appendEvents(path, [fragmentFor('e1', 't1')])
+    const first = await readEvents(path)
+    expect(first).toHaveLength(1)
+
+    await rm(path)
+    const empty = await readEvents(path)
+    expect(empty).toEqual([])
+
+    await appendEvents(path, [fragmentFor('e2', 't2')])
+    const recreated = await readEvents(path)
+    expect(recreated).toHaveLength(1)
+    expect(recreated[0]!.type === 'fragment' && recreated[0]!.id).toBe('e2')
+  })
+
+  test('cache survives across readAllStreamDays calls when no writes occur', async () => {
+    const agentDir = await mkdtemp(join(os.tmpdir(), 'typeclaw-stream-cache-days-'))
+    try {
+      await mkdir(streamsDir(agentDir), { recursive: true })
+      await appendEvents(streamFilePath(agentDir, '2026-05-20'), [fragmentFor('e1', 't1')])
+
+      const first = await readAllStreamDays(agentDir)
+      const second = await readAllStreamDays(agentDir)
+
+      expect(second[0]!.events).toBe(first[0]!.events)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/bundled-plugins/memory/stream-io.ts
+++ b/src/bundled-plugins/memory/stream-io.ts
@@ -1,4 +1,4 @@
-import { readFile, appendFile, readdir, writeFile, rename } from 'node:fs/promises'
+import { readFile, appendFile, readdir, stat, writeFile, rename } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { getDreamedIds, loadDreamingState } from './dreaming-state'
@@ -8,7 +8,59 @@ import { parseEventLine, type StreamEvent } from './stream-events'
 const STREAM_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}\.jsonl$/
 const STREAM_DATE_FROM_FILENAME = /^(\d{4}-\d{2}-\d{2})\.jsonl$/
 
+// Per-file event cache. `(mtimeMs, ctimeMs, size)` is the invalidation key,
+// mirroring `load-shards.ts`'s shard cache. The three writers in this module
+// — `appendEvents` (memory-logger appends), `writeEventsAtomic` (dreaming
+// compaction + migration), and any external `writeFile` — all bump mtime
+// and/or ctime, so stat-based invalidation is sufficient without explicit
+// hooks. ctimeMs guards metadata-preserving external edits (rsync -t,
+// `touch -r`, restored backups, `git checkout` with timestamps): the kernel
+// always bumps ctime on inode content changes and ctime cannot be backdated
+// via utimes.
+//
+// Module-level keyed by absolute file path. One Bun process owns one agent
+// dir in production (the container stage), so cardinality is small. Multi-
+// path support exists because dreaming compacts multiple files per run and
+// memory_search reads every dated stream.
+type StreamFileCacheEntry = {
+  mtimeMs: number
+  ctimeMs: number
+  size: number
+  events: StreamEvent[]
+}
+const streamFileCache = new Map<string, StreamFileCacheEntry>()
+
 export async function readEvents(path: string): Promise<StreamEvent[]> {
+  const fileStat = await statFile(path)
+  if (fileStat === null) {
+    // File disappeared since last cache populate (e.g. dreaming dropped a
+    // fully-GC'd day). Drop the entry so a future recreate gets fresh
+    // content.
+    streamFileCache.delete(path)
+    return []
+  }
+
+  const cached = streamFileCache.get(path)
+  if (
+    cached !== undefined &&
+    cached.mtimeMs === fileStat.mtimeMs &&
+    cached.ctimeMs === fileStat.ctimeMs &&
+    cached.size === fileStat.size
+  ) {
+    return cached.events
+  }
+
+  const events = await readEventsFromDisk(path)
+  streamFileCache.set(path, {
+    mtimeMs: fileStat.mtimeMs,
+    ctimeMs: fileStat.ctimeMs,
+    size: fileStat.size,
+    events,
+  })
+  return events
+}
+
+async function readEventsFromDisk(path: string): Promise<StreamEvent[]> {
   let raw: string
   try {
     raw = await readFile(path, 'utf-8')
@@ -32,6 +84,24 @@ export async function readEvents(path: string): Promise<StreamEvent[]> {
   }
 
   return events
+}
+
+async function statFile(path: string): Promise<{ mtimeMs: number; ctimeMs: number; size: number } | null> {
+  try {
+    const s = await stat(path)
+    return { mtimeMs: s.mtimeMs, ctimeMs: s.ctimeMs, size: s.size }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw err
+  }
+}
+
+// Test-only helper. Clears the in-memory stream-file cache so tests that
+// exercise the cache invalidation path can simulate a cold start without
+// spinning up a fresh process. Mirrors `__resetShardCacheForTests` in
+// `load-shards.ts`.
+export function __resetStreamFileCacheForTests(): void {
+  streamFileCache.clear()
 }
 
 export async function appendEvents(path: string, events: readonly StreamEvent[]): Promise<void> {


### PR DESCRIPTION
## What this PR does

Two targeted changes to `src/bundled-plugins/memory/` that together cut empirically-measured memory-retrieval latency from ~22s to ~6s per retrieval.

| Commit | Change |
|---|---|
| `memory: instruct memory-retrieval to batch memory_search calls in one turn` | One-line prompt rewrite. Adds a "Search discipline" paragraph instructing the model to emit all `memory_search` calls in parallel within a single response, and names the cost of serial emission. No logic change. |
| `memory: add stat-keyed cache to readEvents and loadDreamingState` | Module-level stat-keyed caches for `readEvents` (in `stream-io.ts`) and `loadDreamingState` (in `dreaming-state.ts`), mirroring the existing shard-cache pattern in `load-shards.ts`. Invalidation key is `(mtimeMs, ctimeMs, size)`. |

## Why

**The batching problem.** The `memory-retrieval` subagent was emitting one `memory_search` call per turn instead of batching. A real kakao agent session (`019e5f42`) ran for ~22s: 6 serial round-trips of `kimi-k2p6-turbo` at ~3s each, against milliseconds of actual file I/O.

The underlying runtime (`@mariozechner/pi-agent-core@0.67.3`) already executes sibling tool calls concurrently by default (`agent.js:124`: `toolExecution ?? "parallel"`). The bottleneck was that the model never emitted sibling calls — it emitted them one at a time across turns. The system prompt at `src/bundled-plugins/memory/memory-retrieval.ts:32` capped the count ("AT MOST 3 `memory_search` calls") but never told the model to batch. Adding a single "Search discipline" paragraph fixes that.

**The cache problem.** With no cache, every `memory_search` invocation re-reads all `memory/streams/*.jsonl` files and `.dreaming-state.json` from disk. For a typical retrieval (3 searches) against the kakao agent (10 stream files, 255 events, ~202 KB stream JSONL) that's ~30 redundant `readFile` calls and ~765 zod parses per turn. `dreaming` also pays this cost twice per run (`collectStreamSnapshots` then `compactDailyStreams`).

## How

**Prompt change (`memory-retrieval.ts`).** The new "Search discipline" paragraph is placed immediately after the existing search-cap instruction. It explicitly names "parallel tool calls in a single response" and explains the LLM round-trip cost of serial emission. The existing test assertions on `MEMORY_RETRIEVAL_SYSTEM_PROMPT` (`cacheFilePath` and `memory_search` presence) still pass.

**Stat-keyed cache (`stream-io.ts`, `dreaming-state.ts`).** Both caches use `(mtimeMs, ctimeMs, size)` as the invalidation key, matching the pattern in `load-shards.ts`. All three writers on this surface — `appendEvents`, `writeEventsAtomic`, `saveDreamingState` — bump mtime via plain `writeFile` / `appendFile` / rename, so stat-based invalidation works without explicit cache-clear hooks. The cache lives at module level (Map, unbounded) — same scope and lifetime as the shard cache; agent processes are short-lived per-session so GC pressure is not a concern.

**Other callsite wins.** Beyond retrieval itself: `dreaming` gets a cache hit on its 2nd read of touched stream files in `compactDailyStreams`; `countFragmentEvents` (commit-message builder), `append-tool` duplicate-detection reads, and `watermark.ts` lookups all hit the cache on their non-first accesses within the same process lifetime.

## Predicted impact

~22s → ~6s per retrieval, comprised of:

- **Parallel search batching** — 6 serial LLM round-trips → 2 (initial emission + write). ~14s saved at ~3s/round-trip on `kimi-k2p6-turbo`.
- **Cache** — eliminates ~95% of stream file I/O across the 2nd and 3rd searches within a single retrieval and across consecutive memory-logger appends. Structural win for busy channel sessions where retrievals fire on every turn (GC pressure relief from eliminated zod-parse churn).

## Tests

- 8 new cache tests across `stream-io.test.ts` (5) and `dreaming-state.test.ts` (3) covering: same-reference cache hits, append-and-rewrite invalidation, recreate-after-delete, and cache survival across `readAllStreamDays` calls.
- All 305 memory-plugin tests pass deterministically (up from 297).
- `bun run typecheck`, `bun run lint`, `bun run format:check` all clean.
- Full-suite parallel run has the same set of pre-existing parallel-contention flakes (5000ms-timeout subprocess tests in `src/cli/`, `src/plugin/`, `src/run/`) as the baseline; none in memory-plugin code or files touched by these changes.

## Out of scope (documented for reviewers)

- **Query-length floor on `memory_search`** (`z.string().min(2)`) — would reduce noisy short-Korean-query results, but is a separate quality concern.
- **Parallelizing `loadAllShards`'s 49 sequential `stat()` calls** — minor win, separate PR.
- **Memoizing `buildInjectionPlan`** between `runMemoryRetrieval` and `loadMemory` — minor, separate PR.

## Files changed

- `src/bundled-plugins/memory/memory-retrieval.ts` — 1 line, prompt
- `src/bundled-plugins/memory/stream-io.ts` — stat-keyed cache + exports
- `src/bundled-plugins/memory/stream-io.test.ts` — 5 new cache tests
- `src/bundled-plugins/memory/dreaming-state.ts` — stat-keyed cache + export
- `src/bundled-plugins/memory/dreaming-state.test.ts` — 3 new cache tests