### PR TITLE
memory: detach session.end's memory-logger spawn from the await chain

### DIFF
--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -70,18 +70,31 @@ async function tickMs(ms: number): Promise<void> {
 // since libuv-and-faked-setTimeout interleavings can leave the final chain
 // link's microtasks pending past the last drain cycle. The poll uses real
 // setImmediate (libuv) not the fake clock.
-// `attempts` is the count of real `setImmediate` cycles we poll for. Under
-// `bun test --parallel`, 18+ workers contend on the event loop and a chain
-// of `fs.stat` → fake-setTimeout → real-microtask-drain can need well over
-// 200 cycles to settle. 2000 is roomy enough for worker contention and still
-// finishes in <50ms on the happy path (each setImmediate is microsecond-scale
-// when nothing is starving it).
-async function waitFor(predicate: () => boolean, label: string, attempts = 2000): Promise<void> {
-  for (let i = 0; i < attempts; i++) {
+//
+// `timeoutMs` bounds the wall-clock budget rather than counting `setImmediate`
+// iterations. Under `bun test --parallel` (18 workers on a typical dev box),
+// libuv's threadpool can saturate to the point where a worker's `fs.readdir`
+// callback sits queued for hundreds of ms while this worker's event loop
+// keeps firing `setImmediate` callbacks. An iteration-count cap exhausts in
+// <50ms under contention, well before the fs chain — `loadAllShards` ->
+// `fs.readdir` -> N x `fs.stat` -> `fs.readFile` -> faked-setTimeout ->
+// spawn.push — actually settles. 10s is roomy enough for any plausibly
+// correct chain and matches Bun's default per-test timeout.
+//
+// Uses `performance.now()` rather than `Date.now()` because several describe
+// blocks (`session.idle hook (debouncer)`, `session.end hook`, etc.) install
+// sinon fake timers with `Date` in `toFake`. Under a faked `Date`,
+// `Date.now()` does not advance between `setImmediate` ticks, so a
+// `Date.now()`-based deadline never expires and a failure path becomes a
+// permanent hang. `performance.now()` is NOT in any test's `toFake` list,
+// so it tracks wall clock under both real and faked Date.
+async function waitFor(predicate: () => boolean, label: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = performance.now() + timeoutMs
+  while (performance.now() < deadline) {
     if (predicate()) return
     await new Promise((r) => setImmediate(r))
   }
-  throw new Error(`waitFor(${label}) exhausted ${attempts} attempts without predicate becoming true`)
+  throw new Error(`waitFor(${label}) exhausted ${timeoutMs}ms without predicate becoming true`)
 }
 
 type SpawnCall = { name: string; payload: unknown; options: unknown; startedAt: number; finishedAt: number }
@@ -575,6 +588,7 @@ describe('session.end hook', () => {
     await exports.hooks!['session.idle']!({ sessionId: 'ses_a', parentTranscriptPath: '/tmp/t.jsonl', idleMs: 0 }, ctx)
     await exports.hooks!['session.end']!({ sessionId: 'ses_a' } as SessionEndEvent, ctx)
 
+    await waitFor(() => spawned.length >= 1, 'memory-logger spawn on session.end')
     expect(spawned).toHaveLength(1)
     expect(spawned[0]!.name).toBe('memory-logger')
   })
@@ -591,6 +605,7 @@ describe('session.end hook', () => {
       logger: createPluginLogger('m'),
     })
 
+    await waitFor(() => !existsSync(cacheFilePath), 'retrieval cache unlinked')
     expect(existsSync(cacheFilePath)).toBe(false)
   })
 
@@ -606,6 +621,10 @@ describe('session.end hook', () => {
       logger,
     })
 
+    await waitFor(
+      () => logs.warn.some((m) => m.includes('failed to clean retrieval cache')),
+      'retrieval cache cleanup warning',
+    )
     expect(logs.warn.some((m) => m.includes('failed to clean retrieval cache'))).toBe(true)
   })
 
@@ -641,8 +660,45 @@ describe('session.end hook', () => {
     await exports.hooks!['session.idle']!({ sessionId: 'ses_a', parentTranscriptPath: '/tmp/t.jsonl', idleMs: 0 }, ctx)
     await exports.hooks!['session.end']!({ sessionId: 'ses_a' } as SessionEndEvent, ctx)
 
+    await waitFor(() => spawned.length >= 1, 'session-end spawn settles')
     await tickMs(1200)
 
+    expect(spawned).toHaveLength(1)
+  })
+})
+
+// Regression guard for the user-visible Discord channel-silence bug: when the
+// router's stale-rollover path calls `tearDownLive(existing)`, it awaits
+// `fireSessionEnd` which awaits this hook. If the hook awaited the
+// memory-logger spawn (which takes 20+ seconds on a real transcript), the
+// new session's cold-start would block for the full subagent runtime — observed
+// as ~28s of channel silence between inbound message and any reply. The
+// detached `void fireMemoryLogger(...)` keeps the hook fast while
+// `spawnChain` preserves the agentDir-keyed serialization invariant.
+describe('session.end channel-silence regression guard', () => {
+  test('session.end returns synchronously even when memory-logger spawn is slow', async () => {
+    const SLOW_SPAWN_MS = 1000
+    const { exports, spawned } = await bootMemoryPlugin(
+      agentDir,
+      { idleMs: 60_000, bufferBytes: 0 },
+      { spawnDelayMs: SLOW_SPAWN_MS },
+    )
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_a', parentTranscriptPath: '/tmp/t.jsonl', idleMs: 0 }, ctx)
+
+    const start = performance.now()
+    await exports.hooks!['session.end']!({ sessionId: 'ses_a' } as SessionEndEvent, ctx)
+    const elapsed = performance.now() - start
+
+    // The hook must return well under SLOW_SPAWN_MS — it's detached from
+    // the spawn. 100ms is a generous ceiling for synchronous bookkeeping
+    // under worker contention; the production user-visible bug had this
+    // path blocking for 22 seconds.
+    expect(elapsed).toBeLessThan(100)
+    expect(spawned).toHaveLength(0)
+
+    await waitFor(() => spawned.length >= 1, 'spawn eventually completes via chain')
     expect(spawned).toHaveLength(1)
   })
 })
@@ -835,6 +891,7 @@ describe('per-agent spawn serialization', () => {
     ])
 
     // then: both spawned, but the second started AFTER the first finished (no overlap)
+    await waitFor(() => spawned.length >= 2, 'both spawns complete')
     expect(spawned).toHaveLength(2)
     const [first, second] = [...spawned].sort((a, b) => a.startedAt - b.startedAt)
     expect(second!.startedAt).toBeGreaterThanOrEqual(first!.finishedAt)
@@ -858,6 +915,7 @@ describe('per-agent spawn serialization', () => {
       exports.hooks!['session.end']!({ sessionId: 'ses_c' } as SessionEndEvent, ctx),
     ])
 
+    await waitFor(() => spawned.length >= 3, 'all three spawns complete')
     expect(spawned).toHaveLength(3)
     expect(spawned.map((s) => (s.payload as { parentSessionId: string }).parentSessionId)).toEqual([
       'ses_a',
@@ -905,6 +963,7 @@ describe('per-agent spawn serialization', () => {
       exports.hooks!['session.end']!({ sessionId: 'ses_b' } as SessionEndEvent, hookCtx),
     ])
 
+    await waitFor(() => spawned.length >= 1, 'second spawn after failing first')
     expect(spawned).toHaveLength(1)
     expect((spawned[0]!.payload as { parentSessionId: string }).parentSessionId).toBe('ses_b')
   })
@@ -960,9 +1019,15 @@ describe('per-agent spawn serialization', () => {
     await exports.hooks!['session.end']!({ sessionId: 'ses_b' } as SessionEndEvent, hookCtx)
     const elapsed = Date.now() - start
 
-    // then the hung spawn timed out within the configured ceiling, the
-    // failure was logged with attribution, and the next spawn ran to
-    // completion
+    // The hook calls themselves return immediately (session.end is now
+    // detached from the spawn chain), so the hung spawn must time out and
+    // the second spawn must complete via the chain settling.
+    await waitFor(() => spawned.length >= 1, 'second spawn after timeout')
+    await waitFor(
+      () => logs.error.some((m) => m.includes('memory-logger spawn failed') && m.includes('timed out after 30ms')),
+      'timeout error log',
+    )
+
     expect(elapsed).toBeLessThan(2000)
     expect(spawned).toHaveLength(1)
     expect((spawned[0]!.payload as { parentSessionId: string }).parentSessionId).toBe('ses_b')
@@ -999,6 +1064,10 @@ describe('lifecycle logging', () => {
     await exports.hooks!['session.idle']!({ sessionId: 'ses_a', parentTranscriptPath: '/tmp/t.jsonl', idleMs: 0 }, ctx)
     await exports.hooks!['session.end']!({ sessionId: 'ses_a' } as SessionEndEvent, ctx)
 
+    await waitFor(
+      () => logs.info.some((m) => m.includes('memory-logger spawn ses_a') && m.includes('reason=session-end')),
+      'memory-logger spawn ses_a reason=session-end',
+    )
     expect(logs.info.some((m) => m.includes('memory-logger spawn ses_a') && m.includes('reason=session-end'))).toBe(
       true,
     )

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -145,39 +145,46 @@ export default definePlugin({
     const lastIdleEvent = new Map<string, { parentTranscriptPath: string | undefined; origin?: SessionOrigin }>()
     const bytesAtLastRun = new Map<string, number>()
 
-    // memory-logger is now coalesced per agentDir (not per parentSessionId) so that
+    // memory-logger is coalesced per agentDir (not per parentSessionId) so that
     // two concurrent channel sessions for the same agent never write to the same
     // daily stream file at the same time. The subagent consumer would silently drop
     // a colliding fire, so we serialize spawn calls *here* (chaining each onto the
     // previous one's settlement) instead of letting the consumer choose between
     // dropping or queueing. The chain holds at most one in-flight promise plus one
-    // queued; older queued fires for the same session are superseded by newer ones
-    // through the lastIdleEvent map (each fire reads the latest snapshot).
+    // queued.
+    //
+    // The `lastIdleEvent` lookup happens SYNCHRONOUSLY at call time and the
+    // snapshot is captured in `payload` before any await. This is load-bearing
+    // for `session.end`'s fire-and-forget path (see hook below): the hook
+    // synchronously cleans up `lastIdleEvent.delete(sessionId)` immediately
+    // after calling fireMemoryLogger, so if the snapshot were read lazily
+    // inside the chained `.then`, it would race with cleanup and the spawn
+    // would silently no-op. Capturing the payload up front decouples the
+    // session-end snapshot from the cleanup that follows.
     let spawnChain: Promise<void> = Promise.resolve()
 
     const fireMemoryLogger = (sessionId: string, reason: 'idle' | 'buffer-trip' | 'session-end'): Promise<void> => {
+      const last = lastIdleEvent.get(sessionId)
+      if (!last || last.parentTranscriptPath === undefined) return Promise.resolve()
+      const parentTranscriptPath = last.parentTranscriptPath
+      const payload: MemoryLoggerPayload = {
+        parentSessionId: sessionId,
+        parentTranscriptPath,
+        agentDir: ctx.agentDir,
+        ...(last.origin !== undefined ? { origin: last.origin } : {}),
+      }
+      const spawnOptions = {
+        parentSessionId: sessionId,
+        ...(last.origin !== undefined ? { spawnedByOrigin: last.origin } : {}),
+      }
       const next = spawnChain
         .catch(() => undefined)
         .then(async () => {
-          const last = lastIdleEvent.get(sessionId)
-          if (!last || last.parentTranscriptPath === undefined) return
-          const payload: MemoryLoggerPayload = {
-            parentSessionId: sessionId,
-            parentTranscriptPath: last.parentTranscriptPath,
-            agentDir: ctx.agentDir,
-            ...(last.origin !== undefined ? { origin: last.origin } : {}),
-          }
-          const currentSize = await readSize(last.parentTranscriptPath)
+          const currentSize = await readSize(parentTranscriptPath)
           bytesAtLastRun.set(sessionId, currentSize)
           ctx.logger.info(`memory-logger spawn ${sessionId} reason=${reason} transcript_bytes=${currentSize}`)
           try {
-            await raceSpawn(
-              ctx.spawnSubagent('memory-logger', payload, {
-                parentSessionId: sessionId,
-                ...(last.origin !== undefined ? { spawnedByOrigin: last.origin } : {}),
-              }),
-              spawnTimeoutMs,
-            )
+            await raceSpawn(ctx.spawnSubagent('memory-logger', payload, spawnOptions), spawnTimeoutMs)
           } catch (err) {
             ctx.logger.error(`memory-logger spawn failed: ${err instanceof Error ? err.message : String(err)}`)
           }
@@ -355,16 +362,39 @@ export default definePlugin({
             ctx.logger.error(`memory-retrieval spawn failed: ${err instanceof Error ? err.message : String(err)}`)
           })
         },
-        'session.end': async (event) => {
+        // The memory-logger spawn is intentionally detached (`void`) instead
+        // of awaited. The channel router calls `tearDownLive` synchronously
+        // inside `ensureLive`'s stale-rollover path (router.ts:718), and
+        // `tearDownLive` awaits `fireSessionEnd` which awaits this hook. An
+        // awaited memory-logger spawn here would block new-session creation
+        // for the full subagent runtime — observed as 22+ seconds of channel
+        // silence on a 22 KB transcript before the new session even starts
+        // its cold-start chain.
+        //
+        // Safety: `fireMemoryLogger` captures the payload synchronously from
+        // `lastIdleEvent` (see comment above), so the `delete` calls below
+        // cannot race with the chained spawn. `spawnChain` still serializes
+        // memory-logger fires per agentDir — the detached promise is queued
+        // onto the chain before this hook returns, so a subsequent fire from
+        // the new session (idle, buffer-trip, or session-end) waits for the
+        // session-end spawn to settle before running.
+        //
+        // The only durability tradeoff: if the agent process dies between
+        // this hook returning and `spawnChain` settling, the session-end
+        // memory-logger fire is lost (its transcript fragments don't make
+        // it into today's daily stream). This is already true for the idle
+        // and buffer-trip paths, which are timer-driven and fire-and-forget
+        // by design. Session JSONLs are force-committed elsewhere, so no
+        // user-visible transcript is lost — only the LLM-distilled stream
+        // fragments for the final batch.
+        'session.end': (event) => {
           if (event.origin?.kind === 'subagent') return
           cancelTimer(event.sessionId)
-          await fireMemoryLogger(event.sessionId, 'session-end')
+          void fireMemoryLogger(event.sessionId, 'session-end')
           const cacheFilePath = join(ctx.agentDir, 'memory', '.retrieval-cache', `${event.sessionId}.md`)
-          try {
-            await unlink(cacheFilePath)
-          } catch (err) {
+          unlink(cacheFilePath).catch((err) => {
             if (!isEnoent(err)) ctx.logger.warn(`[memory] failed to clean retrieval cache: ${err}`)
-          }
+          })
           lastIdleEvent.delete(event.sessionId)
           bytesAtLastRun.delete(event.sessionId)
         },


### PR DESCRIPTION
## What this PR does

Fixes a production bug where a Discord (or any channel) inbound that triggers `stale-rollover` blocks the new session's cold-start for the full memory-logger subagent runtime. Observed in a real session log as **~28 seconds of channel silence** between message arrival and any reply.

## The bug

The channel router's `stale-rollover` path (`src/channels/router.ts:718`) is structured as:

```
ensureLive (stale)
  → await tearDownLive(existing)              router.ts:718
      → await fireSessionEnd(live)            router.ts:1834
          → await live.hooks.runSessionEnd()  router.ts:1148
              → await each session.end handler hooks.ts:145-156
                  → memory plugin: await fireMemoryLogger(sid, 'session-end')
                      → await spawnChain
                      → await ctx.spawnSubagent('memory-logger', ...)
                          → 22.9 seconds of LLM work
```

Every link awaits the next. The memory plugin's `session.end` hook was `await fireMemoryLogger(...)`, which awaits the full subagent run — and that subagent reads a 22 KB transcript and calls an LLM provider, taking 20+ seconds. The new session cannot start its cold-start chain until this returns.

User-visible timeline from the originating log:

```
13:12:48  inbound arrives, router decides stale-rollover
13:12:48  memory-logger spawn (session-end of previous session)
13:13:11  memory-logger done elapsed_ms=22963   ← 23s wait
13:13:11  ensureLive begin (cold-start)         ← new session FINALLY starts
13:13:13  prompting batch=1                     ← LLM call begins
13:13:16  prompted elapsed_ms=3100              ← model done (reply still not sent — but that's a separate issue)
```

## The fix

Detach the spawn so `session.end` returns synchronously:

```diff
-'session.end': async (event) => {
+'session.end': (event) => {
   if (event.origin?.kind === 'subagent') return
   cancelTimer(event.sessionId)
-  await fireMemoryLogger(event.sessionId, 'session-end')
+  void fireMemoryLogger(event.sessionId, 'session-end')
   ...
}
```

## Why the naive shape is unsafe (and the supporting change)

`fireMemoryLogger` previously read `lastIdleEvent.get(sessionId)` **lazily inside the chained `.then`**:

```ts
const next = spawnChain
  .catch(() => undefined)
  .then(async () => {
    const last = lastIdleEvent.get(sessionId)  // ← lazy read
    if (!last || last.parentTranscriptPath === undefined) return
    ...
  })
```

But `session.end`'s next statements after the (formerly awaited) `fireMemoryLogger` call were:

```ts
lastIdleEvent.delete(event.sessionId)
bytesAtLastRun.delete(event.sessionId)
```

So a naive `void fireMemoryLogger(...)` would race the `delete` calls against the lazy `.get(sessionId)`, and the spawn would silently no-op (the queued `.then` reads `undefined` and returns).

The fix restructures `fireMemoryLogger` to read the snapshot **synchronously at call time** and capture it in `payload` / `spawnOptions` before any await:

```ts
const fireMemoryLogger = (sessionId, reason) => {
  const last = lastIdleEvent.get(sessionId)               // synchronous
  if (!last || last.parentTranscriptPath === undefined) return Promise.resolve()
  const parentTranscriptPath = last.parentTranscriptPath
  const payload: MemoryLoggerPayload = { ... }            // captured
  const spawnOptions = { ... }                            // captured
  const next = spawnChain
    .catch(() => undefined)
    .then(async () => {
      // payload/spawnOptions are closed-over; the cleanup that
      // session.end runs after this function returns cannot affect them
      ...
    })
  spawnChain = next   // synchronous assignment — chain ordering preserved
  return next
}
```

This preserves the agentDir-keyed serialization invariant: `spawnChain = next` happens synchronously before `fireMemoryLogger` returns, so a subsequent fire (idle, buffer-trip, session-end) for the same agent chains onto the still-running spawn. No two memory-loggers race on `MEMORY.md` / the daily stream.

## Tradeoff

If the process dies between `session.end` returning and `spawnChain` settling, the session-end memory-logger fire is lost — its transcript fragments don't make it into today's daily stream. This is **already true** for the idle and buffer-trip paths (timer-driven, fire-and-forget by design). Session JSONLs are force-committed elsewhere, so no user-visible transcript is lost — only the LLM-distilled stream fragments for the final batch.

## Tests

- **New regression test**: `session.end returns synchronously even when memory-logger spawn is slow` — pins `session.end` to <100ms even when `spawnDelayMs: 1000`. Without the fix, `await session.end(...)` would block for the full 1s.
- **Existing chain-serialization tests** (`back-to-back idle fires...`, `three back-to-back fires preserve FIFO order`, `a failing spawn does not break the chain`, `a hanging spawn does not wedge the chain`) needed `waitFor` upgrades because the chain settles after `session.end` returns now, not before.
- **`waitFor` helper upgrade** (iteration-count → wall-clock budget): the old `attempts = 2000` cap exhausted in ~50ms under `bun test --parallel` (18 workers contending on libuv's threadpool), well before a chain involving a 50ms `spawnDelayMs` could settle. Switched to a 10s wall-clock budget via `performance.now()` (not `Date.now()`, which is faked in sinon `installFakeClock`). Same fix needed by upstream test infra work, ported here so the existing tests pass.

Full memory plugin suite (586 tests across 28 files) green; channels + plugin hooks suite (860 tests across 47 files) green.

## What this PR does NOT fix

The second issue surfaced in the same log — the agent generated assistant text but never called `channel_reply` / `channel_send`, so nothing reached Discord — is a separate concern (prompt salience / Discord-specific skill loading) and will be addressed in a follow-up.
