### PR TITLE
channels: recover pre-tool assistant text when the follow-up turn never fires

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -35,10 +35,15 @@ class FakeSession {
   public aborted = 0
   public disposed = 0
   public leafEntry: SessionEntry | undefined
+  // Additional entries indexed by id for `getEntry` lookups. Walked by
+  // `recoverableAssistantText` when the leaf is a toolResult and we need to
+  // find the assistant message that called the tool.
+  public entriesById = new Map<string, SessionEntry>()
   public onPrompt: ((text: string) => void | Promise<void>) | undefined
 
   public sessionManager = {
     getLeafEntry: (): SessionEntry | undefined => this.leafEntry,
+    getEntry: (id: string): SessionEntry | undefined => this.entriesById.get(id),
   }
 
   private subscribers = new Set<(event: { type: string; message?: unknown }) => void>()
@@ -1465,6 +1470,192 @@ describe('ChannelRouter channel-turn protocol', () => {
     await router.__testing!.flushDebounce(KEY)
 
     expect(logs.some((m) => m.includes('blocked assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  // Regression for the Kimi-on-Fireworks `kimi-k2p6-turbo` channel-silence
+  // bug observed on 2026-05-26: the model emitted text + a tool call
+  // (stopReason='toolUse'), the tool ran successfully, but the upstream
+  // pi-agent-core loop never produced a follow-up assistant message after
+  // the toolResult. The session JSONL ended with the toolResult as the leaf,
+  // `prompt()` resolved cleanly, and the channel router silently dropped the
+  // pre-tool commentary. User saw nothing in Discord.
+  test('pre-tool recovery: recovers assistant text when leaf is toolResult with no follow-up', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'why is cron not working' }))
+    sessions[0]!.onPrompt = () => {
+      // given: an assistant message with text + a tool call. The model never
+      // produced a follow-up assistant message after the tool result, so the
+      // leaf is the toolResult, NOT the assistant message.
+      const assistantMsg: AssistantMessage = {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: '죄송해요. 크론 이슈는 지금 바로 확인해볼게요.' },
+          { type: 'toolCall', id: 'functions.stream_snapshot:0', name: 'stream_snapshot', arguments: { limit: 20 } },
+        ],
+        api: 'openai-completions',
+        provider: 'fireworks',
+        model: 'accounts/fireworks/routers/kimi-k2p6-turbo',
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'toolUse',
+        timestamp: 1000,
+      }
+      const assistantEntry: SessionEntry = {
+        type: 'message',
+        id: 'assistant-pre-tool',
+        parentId: null,
+        timestamp: '2026-05-26T04:13:13.000Z',
+        message: assistantMsg,
+      }
+      const toolResultEntry: SessionEntry = {
+        type: 'message',
+        id: 'tool-result',
+        parentId: 'assistant-pre-tool',
+        timestamp: '2026-05-26T04:13:16.000Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'functions.stream_snapshot:0',
+          toolName: 'stream_snapshot',
+          content: [{ type: 'text', text: 'stream events here' }],
+          isError: false,
+          timestamp: 1000,
+        },
+      }
+      sessions[0]!.entriesById.set(assistantEntry.id, assistantEntry)
+      sessions[0]!.entriesById.set(toolResultEntry.id, toolResultEntry)
+      sessions[0]!.leafEntry = toolResultEntry
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(
+      logs.some((m) => m.includes('recovering assistant_text_without_channel_tool') && m.includes('source=pre-tool')),
+    ).toBe(true)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('죄송해요. 크론 이슈는 지금 바로 확인해볼게요.')
+  })
+
+  test('pre-tool recovery: still applies NO_REPLY / Kimi-leak / empty-sentinel guards', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'check something' }))
+    sessions[0]!.onPrompt = () => {
+      // given: an assistant message with NO_REPLY text + a tool call. The
+      // pre-tool recovery should NOT send this, because the assistant
+      // explicitly opted out of replying. The downstream guards must still
+      // run on the recovered text.
+      const assistantMsg: AssistantMessage = {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'NO_REPLY' },
+          { type: 'toolCall', id: 't0', name: 'stream_snapshot', arguments: {} },
+        ],
+        api: 'openai-completions',
+        provider: 'fireworks',
+        model: 'test',
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'toolUse',
+        timestamp: 1000,
+      }
+      const assistantEntry: SessionEntry = {
+        type: 'message',
+        id: 'a',
+        parentId: null,
+        timestamp: '2026-05-26T04:13:13.000Z',
+        message: assistantMsg,
+      }
+      const toolResultEntry: SessionEntry = {
+        type: 'message',
+        id: 'tr',
+        parentId: 'a',
+        timestamp: '2026-05-26T04:13:16.000Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 't0',
+          toolName: 'stream_snapshot',
+          content: [{ type: 'text', text: 'x' }],
+          isError: false,
+          timestamp: 1000,
+        },
+      }
+      sessions[0]!.entriesById.set(assistantEntry.id, assistantEntry)
+      sessions[0]!.entriesById.set(toolResultEntry.id, toolResultEntry)
+      sessions[0]!.leafEntry = toolResultEntry
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+    expect(sent).toHaveLength(0)
+  })
+
+  test('pre-tool recovery: does NOT fire when the model successfully replied (channel send happened)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'reply please' }))
+    sessions[0]!.onPrompt = async () => {
+      // Successful channel send during the turn — guard #1
+      // (successfulChannelSends > before) must short-circuit recovery before
+      // the leaf is even inspected. We do NOT need to set leafEntry; the
+      // first guard returns before it's consulted.
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'real reply' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('real reply')
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('silent-leaf observability: logs explicit reason instead of bailing silently', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      // No leaf entry at all — the previous behavior silently returned with
+      // zero log output, making the silent-channel bug undiagnosable from
+      // logs. Now there's an explicit info log naming the reason.
+      sessions[0]!.leafEntry = undefined
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(logs.some((m) => m.includes('no recoverable assistant text in branch'))).toBe(true)
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1781,8 +1781,19 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const validateChannelTurn = async (live: LiveSession, successfulSendsBeforePrompt: number): Promise<void> => {
     if (live.successfulChannelSends > successfulSendsBeforePrompt) return
 
-    const assistantText = latestAssistantText(live.session)
-    if (assistantText === null) return
+    const candidate = recoverableAssistantText(live.session)
+    if (candidate === null) {
+      // Observability: previously a silent bail-out. The most common cause is a
+      // turn that ends mid-loop with NO assistant message at all (leaf is a
+      // session header / model_change / similar non-message entry, or a session
+      // that just started). Logged at debug-level info so operators can grep for
+      // unexpected silent turns; not warn-level because legitimate empty-state
+      // sessions hit this on every TUI-only check before the first user prompt.
+      logger.info(`[channels] ${live.keyId}: no recoverable assistant text in branch`)
+      return
+    }
+
+    const { text: assistantText, source } = candidate
 
     if (endsWithNoReplySignal(assistantText)) {
       const leakedReasoning = !isNoReplySignal(assistantText)
@@ -1802,8 +1813,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return
     }
 
+    // `source` distinguishes the two recovery shapes for log triage:
+    //   - 'leaf': the assistant message IS the leaf (existing behavior; model
+    //     ended its turn with text but forgot to call channel_reply).
+    //   - 'pre-tool': the leaf is a toolResult (or other non-assistant entry)
+    //     and the assistant message lives upstream in the branch. This is the
+    //     Kimi-on-Fireworks `kimi-k2p6-turbo` failure mode where the post-tool
+    //     follow-up LLM call never produced a persisted assistant message, so
+    //     the model's pre-tool commentary is the only user-facing text we have.
+    //     Recovering it means the user gets *something* — strictly better than
+    //     the historical silent drop.
     logger.warn(
-      `[channels] ${live.keyId}: recovering assistant_text_without_channel_tool text_len=${assistantText.length}`,
+      `[channels] ${live.keyId}: recovering assistant_text_without_channel_tool source=${source} text_len=${assistantText.length}`,
     )
     const result = await send(
       {
@@ -2348,12 +2369,67 @@ async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): 
   }
 }
 
-function latestAssistantText(session: AgentSession): string | null {
-  const entry = session.sessionManager.getLeafEntry()
-  if (entry?.type !== 'message') return null
-  if (entry.message.role !== 'assistant') return null
-  if (entry.message.stopReason !== 'stop') return null
-  return visibleAssistantText(entry.message)
+// Walks the session branch backward from the leaf to find a recoverable
+// assistant message — i.e., text the user should see but didn't, because the
+// model failed to call `channel_reply`/`channel_send` before its turn ended.
+//
+// Two recovery shapes:
+//
+//   - source: 'leaf'
+//     The leaf entry IS an assistant message with `stopReason === 'stop'`.
+//     The model finished its turn with visible text but never called a channel
+//     tool. Pre-existing behavior; this is what the historical
+//     `latestAssistantText` covered.
+//
+//   - source: 'pre-tool'
+//     The leaf is a `toolResult` and the immediately-prior assistant message
+//     has `stopReason === 'toolUse'` (it called the tool that produced this
+//     toolResult). The upstream pi-agent-core loop SHOULD have made a
+//     follow-up LLM call after the tool returned, but that call either never
+//     happened or produced no persisted message. Recovers the assistant's
+//     pre-tool commentary so the user gets *something* — observed against
+//     Fireworks' `accounts/fireworks/routers/kimi-k2p6-turbo` on 2026-05-26.
+//
+// Returns null when no recovery is appropriate:
+//   - No leaf, no messages in branch, branch is malformed
+//   - Leaf is an assistant with non-'stop' stopReason (e.g. mid-stream error)
+//     and is NOT preceded by a toolResult pattern — we don't recover partial
+//     errored output because it's typically a truncation, not a deliberate
+//     reply
+//   - Leaf is a user/system message (model hasn't responded yet)
+//
+// `visibleAssistantText` returning '' (empty string) is a valid recovery
+// target — the caller's downstream guards (`endsWithNoReplySignal('')` returns
+// true) handle the no-content case explicitly via the `no_reply` log.
+function recoverableAssistantText(session: AgentSession): { text: string; source: 'leaf' | 'pre-tool' } | null {
+  const leaf = session.sessionManager.getLeafEntry()
+  if (!leaf) return null
+
+  if (leaf.type === 'message' && leaf.message.role === 'assistant') {
+    if (leaf.message.stopReason !== 'stop') return null
+    return { text: visibleAssistantText(leaf.message), source: 'leaf' }
+  }
+
+  // Pre-tool recovery: the leaf must be a toolResult message, and walking
+  // back through parentId chain must land on an assistant message before any
+  // user message (otherwise we'd be recovering text from a turn the user
+  // already saw a reply to). Bounded walk with a depth guard so a malformed
+  // session can't infinite-loop.
+  if (!(leaf.type === 'message' && leaf.message.role === 'toolResult')) return null
+
+  let cursor: { parentId: string | null } | undefined = leaf
+  for (let depth = 0; depth < 32 && cursor?.parentId; depth++) {
+    const parent = session.sessionManager.getEntry(cursor.parentId)
+    if (!parent) return null
+    if (parent.type === 'message') {
+      if (parent.message.role === 'assistant') {
+        return { text: visibleAssistantText(parent.message), source: 'pre-tool' }
+      }
+      if (parent.message.role === 'user') return null
+    }
+    cursor = parent
+  }
+  return null
 }
 
 function visibleAssistantText(message: AssistantMessage): string {


### PR DESCRIPTION
## What this PR does

Fixes a channel-silence bug where the agent generated visible reply text but the user saw nothing on the destination platform. Reproduces against `accounts/fireworks/routers/kimi-k2p6-turbo` — same provider/model the existing Kimi-leak-detection code at `src/channels/router.ts` already documents.

## The bug

A model emitted assistant text plus a tool call (`stopReason: 'toolUse'`), the tool ran successfully, but `session.prompt()` resolved without the model producing a follow-up assistant message. The session JSONL ended with the `toolResult` as the leaf entry. No reply reached the destination channel.

Inspect view of the affected turn:

```
HH:MM:SS  assist     <pre-tool commentary>
HH:MM:SS  tool ▸     <tool>(...)
HH:MM:SS  done       stop=toolUse
HH:MM:SS  tool ◂     <tool> → ok
HH:MM:SS  [channels] <adapter>:T/C:: prompted elapsed_ms=...
```

Then nothing. No log lines from `validateChannelTurn`.

## Root cause

The session JSONL had the `toolResult` as its leaf — the upstream pi-agent-core agent loop should have made a follow-up LLM call after the tool returned, but that call either never happened or produced no persisted assistant message. `wc -l` on the JSONL confirmed: no follow-up assistant message exists.

The channel router's recovery path, `validateChannelTurn`, called `latestAssistantText`:

```ts
function latestAssistantText(session: AgentSession): string | null {
  const entry = session.sessionManager.getLeafEntry()
  if (entry?.type !== 'message') return null
  if (entry.message.role !== 'assistant') return null   // ← fails when leaf is toolResult
  if (entry.message.stopReason !== 'stop') return null
  return visibleAssistantText(entry.message)
}
```

When the leaf is a `toolResult`, the role check fails and the function returns `null`. The caller bailed silently at `router.ts:1785` with **zero log output**, making the silent-channel bug undiagnosable from logs.

This is a documented failure mode of Kimi-family models served via OpenAI-compatible endpoints — see MoonshotAI/Kimi-K2#128, vLLM #41182, SGLang #25358.

## The fix

Replace `latestAssistantText` with `recoverableAssistantText`, which returns a tagged union with two recovery shapes:

```ts
function recoverableAssistantText(session: AgentSession):
  | { text: string; source: 'leaf' | 'pre-tool' }
  | null
```

- **`source: 'leaf'`** — pre-existing behavior. Leaf IS an assistant message with `stopReason === 'stop'` and the model forgot to call `channel_reply` / `channel_send`.
- **`source: 'pre-tool'`** — new. Leaf is a `toolResult`; walks back through `parentId` until it finds an assistant message (must appear before any user message in the branch). Returns the visible text of that pre-tool assistant message.

The recovery `send` then runs through the SAME downstream guards (`endsWithNoReplySignal`, `isUpstreamEmptyResponseSentinel`, `isLikelyKimiChannelToolLeak`) on both sources, so a model that committed to a tool plan AND emitted `NO_REPLY` in its pre-tool text is still correctly suppressed.

The recovery log line now includes `source=leaf|pre-tool` for triage:

```
[channels] <adapter>:T/C:: recovering assistant_text_without_channel_tool source=pre-tool text_len=...
```

The previously-silent `assistantText === null` bail-out is now an explicit `info` log so the silent-channel failure mode is observable in future incidents without grepping JSONL files:

```
[channels] <adapter>:T/C:: no recoverable assistant text in branch
```

## Tradeoff

Pre-tool recovery sends the model's pre-tool commentary (typically a "doing X" progress note) when the post-tool turn fails. The user gets the progress note instead of nothing — strictly better than the historical silent drop, even though the actual post-tool answer is still lost.

Operators get a `warn`-level log on every pre-tool recovery, which makes the underlying upstream failure mode noisy enough to investigate without being so noisy it gets ignored.

## Tests

Four new regression tests in `src/channels/router.test.ts`:

| Test | What it pins |
|---|---|
| `pre-tool recovery: recovers assistant text when leaf is toolResult with no follow-up` | Sets up the JSONL shape (`assistant(toolUse) → toolResult` with no follow-up assistant), asserts text is sent with `source=pre-tool` in the log |
| `pre-tool recovery: still applies NO_REPLY / Kimi-leak / empty-sentinel guards` | Pre-tool text containing `NO_REPLY` is correctly suppressed — `no_reply` log fires, no send happens |
| `pre-tool recovery: does NOT fire when the model successfully replied` | Successful `channel_reply` short-circuits at guard #1 (`successfulChannelSends > before`) before the leaf is even inspected |
| `silent-leaf observability: logs explicit reason instead of bailing silently` | The previously-silent path (no leaf entry at all) now logs `no recoverable assistant text in branch` |

Full router suite (855 tests across 46 files) green. Pre-commit checks (typecheck + lint + format) clean.

## Diff stats

```
src/channels/router.test.ts | 191 +++++++++++++++++++++++++++++++++++++++++++
src/channels/router.ts      |  94 ++++++++++++++++++---
2 files changed, 276 insertions(+), 9 deletions(-)
```

## What this PR does NOT fix

The underlying upstream pi-agent-core / Fireworks-Kimi issue where the post-tool LLM call never produces a persisted assistant message. That's an upstream bug (MoonshotAI/Kimi-K2#128 + vLLM #41182 + SGLang #25358 — see code comment). This PR makes typeclaw resilient to the failure mode instead of attempting to fix it server-side.
