### PR TITLE
channels: bump default reply stickiness window from 5min to 15min

### DIFF
--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -19,7 +19,7 @@ const stickinessSchema = z.union([
   }),
 ])
 
-export const STICKY_DEFAULT_WINDOW_MS = 5 * 60 * 1000
+export const STICKY_DEFAULT_WINDOW_MS = 15 * 60 * 1000
 
 const engagementSchema = z
   .object({

--- a/src/skills/typeclaw-config/SKILL.md
+++ b/src/skills/typeclaw-config/SKILL.md
@@ -138,7 +138,7 @@ Each entry in `channels` is keyed by adapter id and has this shape:
 
 | Field        | Required | Type    | Notes                                                                                                                                                                                    |
 | ------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `engagement` | no       | object  | When the agent should auto-reply vs. stay silent. Defaults to mention/reply/dm with 5-minute reply stickiness. See **Engagement** below.                                                 |
+| `engagement` | no       | object  | When the agent should auto-reply vs. stay silent. Defaults to mention/reply/dm with 15-minute reply stickiness. See **Engagement** below.                                                |
 | `history`    | no       | object  | Cold-start prefetch windows for `(thread.head, thread.tail, channel.tail)`. Set any to `0` to disable that side. Defaults to `{ thread: { head: 3, tail: 10 }, channel: { tail: 10 } }`. |
 | `enabled`    | no       | boolean | Defaults to `true`. Set `false` to disable the adapter entirely without removing its config.                                                                                             |
 
@@ -151,7 +151,7 @@ To stop the agent answering in a specific channel, narrow the `roles` block so t
 ```json
 "engagement": {
   "trigger": ["mention", "reply", "dm"],
-  "stickiness": { "perReply": { "window": 300000 } }
+  "stickiness": { "perReply": { "window": 900000 } }
 }
 ```
 
@@ -159,7 +159,7 @@ To stop the agent answering in a specific channel, narrow the `roles` block so t
   - `mention` — explicit `@bot` mentions.
   - `reply` — message is a Discord reply pointed at the agent's own message.
   - `dm` — any message in a DM channel.
-- **`stickiness`** — either the literal string `"off"`, or `{ perReply: { window: <ms> } }`. Default: 5-minute reply stickiness (`window: 300000`).
+- **`stickiness`** — either the literal string `"off"`, or `{ perReply: { window: <ms> } }`. Default: 15-minute reply stickiness (`window: 900000`).
   - `perReply` means: after the agent replies to a user, follow-up messages from that same user in that same channel within the window also wake the loop, even without a mention. The window is bounded server-side (`1` to `86_400_000` ms — 1 ms to 24 hours).
   - `"off"` disables stickiness — the agent only wakes on explicit triggers.
 
@@ -174,7 +174,7 @@ There is also a **solo-human fallback** built into the runtime that is **not con
   "discord-bot": {
     "engagement": {
       "trigger": ["mention", "reply", "dm"],
-      "stickiness": { "perReply": { "window": 300000 } }
+      "stickiness": { "perReply": { "window": 900000 } }
     },
     "enabled": true
   }


### PR DESCRIPTION
## What this PR does

Bumps the default reply-stickiness window from 5 minutes to 15 minutes.

After the agent replies, follow-up messages from the same user in the same channel within the window also wake the agent loop without requiring an `@mention`. The config field is `channels.<adapter>.engagement.stickiness.perReply.window`.

## Motivation

The 5-minute default was tight enough that ordinary back-and-forth — read the agent's reply, think, type a follow-up — crossed the window and dropped the user into mention-required mode mid-conversation. 15 minutes is closer to how long an active exchange actually takes.

## Changes

- `src/channels/schema.ts`: `STICKY_DEFAULT_WINDOW_MS` changed from 300 000 ms to 900 000 ms.
- `src/skills/typeclaw-config/SKILL.md`: four doc references updated to match (5-minute → 15-minute, 300000 → 900000).

## Backwards compatibility

Fully backwards-compatible. Any explicit `engagement.stickiness` setting in `typeclaw.json` continues to win — only the default applied when the field is omitted changes. The bounded range (1 ms – 86 400 000 ms) is unchanged. `typeclaw.schema.json` (gitignored, regenerated at release time) picks up the new default automatically.