### PR TITLE
inspect: surface thinking traces in replay and live tail

### DIFF
--- a/src/inspect/live.test.ts
+++ b/src/inspect/live.test.ts
@@ -127,6 +127,61 @@ describe('streamLive — live session events', () => {
     expect(assist.model).toBe('m')
   })
 
+  test('thinking_delta events accumulate until thinking_end then emit one thinking event', async () => {
+    const registry = new LiveSessionRegistry()
+    const session = createFakeAgent()
+    registry.register({ sessionId: 'ses_a', session })
+    const { url } = await startServer({ registry })
+
+    const ctrl = new AbortController()
+    const gen = streamLive({ url, sessionId: 'ses_a', signal: ctrl.signal })
+
+    setTimeout(() => {
+      session.emit({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_delta', delta: 'Should I ' },
+      })
+      session.emit({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_delta', delta: 'read the file?' },
+      })
+      session.emit({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_end', content: 'Should I read the file?' },
+      })
+    }, 50)
+
+    const events = await collectN(gen, 1)
+    ctrl.abort()
+    const think = events[0]!
+    if (think.cat !== 'thinking') throw new Error('expected thinking')
+    expect(think.text).toBe('Should I read the file?')
+    expect(think.redacted).toBeUndefined()
+  })
+
+  test('thinking_end without preceding deltas falls back to event content (Gemini-shaped batched thinking)', async () => {
+    const registry = new LiveSessionRegistry()
+    const session = createFakeAgent()
+    registry.register({ sessionId: 'ses_a', session })
+    const { url } = await startServer({ registry })
+
+    const ctrl = new AbortController()
+    const gen = streamLive({ url, sessionId: 'ses_a', signal: ctrl.signal })
+
+    setTimeout(() => {
+      session.emit({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_end', content: 'one-shot thought' },
+      })
+    }, 50)
+
+    const events = await collectN(gen, 1)
+    ctrl.abort()
+    const think = events[0]!
+    if (think.cat !== 'thinking') throw new Error('expected thinking')
+    expect(think.text).toBe('one-shot thought')
+  })
+
   test('broadcast events surface as InspectEvent.broadcast', async () => {
     const stream = createStream()
     const { url } = await startServer({ stream })

--- a/src/inspect/live.ts
+++ b/src/inspect/live.ts
@@ -21,6 +21,7 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
   let pendingError: string | null = null
 
   const accumulators = new Map<string, string>()
+  const thinkingAccumulators = new Map<string, string>()
 
   const wake = (): void => {
     if (resolveNext !== null) {
@@ -55,7 +56,7 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
       return
     }
     if (msg.type !== 'frame') return
-    const event = frameToEvent(msg.payload, msg.ts, accumulators)
+    const event = frameToEvent(msg.payload, msg.ts, accumulators, thinkingAccumulators)
     if (event !== null) {
       buffer.push(event)
       wake()
@@ -134,12 +135,25 @@ function frameToEvent(
   payload: InspectFramePayload,
   ts: number,
   accumulators: Map<string, string>,
+  thinkingAccumulators: Map<string, string>,
 ): InspectEvent | null {
   switch (payload.kind) {
     case 'text_delta': {
       const existing = accumulators.get(payload.sessionId) ?? ''
       accumulators.set(payload.sessionId, existing + payload.delta)
       return null
+    }
+    case 'thinking_delta': {
+      const existing = thinkingAccumulators.get(payload.sessionId) ?? ''
+      thinkingAccumulators.set(payload.sessionId, existing + payload.delta)
+      return null
+    }
+    case 'thinking_end': {
+      const accumulated = thinkingAccumulators.get(payload.sessionId) ?? ''
+      thinkingAccumulators.delete(payload.sessionId)
+      const text = accumulated !== '' ? accumulated : payload.text
+      if (text === '' && payload.redacted !== true) return null
+      return { cat: 'thinking', ts, text, ...(payload.redacted === true ? { redacted: true } : {}) }
     }
     case 'tool_start':
       return {

--- a/src/inspect/render.test.ts
+++ b/src/inspect/render.test.ts
@@ -83,6 +83,27 @@ describe('renderEvent (plain, no color)', () => {
     expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  error      provider returned 503')
   })
 
+  test('thinking event renders with think tag and the reasoning text', () => {
+    const ev: InspectEvent = {
+      cat: 'thinking',
+      ts: dateMs('15:08:42'),
+      text: 'I should read the file before editing it.',
+    }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  think      I should read the file before editing it.')
+  })
+
+  test('redacted thinking event shows [redacted] marker (safety-filter cut, not silence)', () => {
+    const ev: InspectEvent = { cat: 'thinking', ts: dateMs('15:08:42'), text: '', redacted: true }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  think      [redacted] ')
+  })
+
+  test('thinking event respects maxTextLength truncation', () => {
+    const ev: InspectEvent = { cat: 'thinking', ts: dateMs('15:08:42'), text: 'x'.repeat(500) }
+    const out = renderEvent(ev, { color: false, maxTextLength: 20 })
+    expect(out).toContain('…')
+    expect(stripTime(out)).toBe(`HH:MM:SS  think      ${'x'.repeat(20)}…`)
+  })
+
   test('long text is truncated with an ellipsis', () => {
     const ev: InspectEvent = { cat: 'user', ts: dateMs('15:08:42'), text: 'a'.repeat(500) }
     const out = renderEvent(ev, { color: false, maxTextLength: 30 })

--- a/src/inspect/render.ts
+++ b/src/inspect/render.ts
@@ -34,6 +34,8 @@ function renderTag(event: InspectEvent, opts: RenderOptions): string {
       return tint(opts, 'cyan', padEnd('user', 9))
     case 'assistant':
       return tint(opts, 'green', padEnd('assist', 9))
+    case 'thinking':
+      return tint(opts, 'gray', padEnd('think', 9))
     case 'tool':
       return tint(opts, 'yellow', padEnd(event.phase === 'start' ? 'tool ▸' : 'tool ◂', 9))
     case 'error':
@@ -57,6 +59,11 @@ function renderBody(event: InspectEvent, opts: RenderOptions): string {
       return truncate(singleLine(event.text), opts.maxTextLength ?? DEFAULT_MAX_TEXT)
     case 'assistant':
       return truncate(singleLine(event.text), opts.maxTextLength ?? DEFAULT_MAX_TEXT)
+    case 'thinking': {
+      const prefix = event.redacted === true ? `${tint(opts, 'dim', '[redacted]')} ` : ''
+      const body = event.text === '' ? '' : truncate(singleLine(event.text), opts.maxTextLength ?? DEFAULT_MAX_TEXT)
+      return `${prefix}${tint(opts, 'dim', body)}`
+    }
     case 'tool': {
       if (event.phase === 'start') {
         return `${event.name}(${renderArgs(event.args)})`

--- a/src/inspect/replay.test.ts
+++ b/src/inspect/replay.test.ts
@@ -205,6 +205,111 @@ describe('replayLines', () => {
     expect(errorEvent.message).toBe('provider returned 503')
   })
 
+  test('assistant thinking content block yields a thinking event ordered before text and tool calls', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [
+                { type: 'thinking', thinking: 'Need to read the file to know its shape.' },
+                { type: 'text', text: 'Reading the file now.' },
+                { type: 'toolCall', id: 'c1', name: 'read', arguments: { path: 'x' } },
+              ],
+              stopReason: 'toolUse',
+              usage: { input: 10, output: 20, cacheRead: 0, cacheWrite: 0, totalTokens: 30, cost: { total: 0.0001 } },
+              timestamp: 10_000,
+            },
+          }),
+        ]),
+      ),
+    )
+    expect(events.map((e) => e.cat)).toEqual(['thinking', 'assistant', 'tool', 'done'])
+    const thinking = events[0]!
+    if (thinking.cat !== 'thinking') throw new Error('expected thinking')
+    expect(thinking.text).toBe('Need to read the file to know its shape.')
+    expect(thinking.ts).toBe(10_000)
+    expect(thinking.redacted).toBeUndefined()
+  })
+
+  test('multiple thinking blocks in one turn each yield a thinking event in content-array order', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [
+                { type: 'thinking', thinking: 'first thought' },
+                { type: 'thinking', thinking: 'second thought' },
+                { type: 'text', text: 'done thinking' },
+              ],
+              usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { total: 0 } },
+              timestamp: 5_000,
+            },
+          }),
+        ]),
+      ),
+    )
+    const thinks = events.filter((e) => e.cat === 'thinking')
+    expect(thinks).toHaveLength(2)
+    if (thinks[0]!.cat !== 'thinking' || thinks[1]!.cat !== 'thinking') throw new Error('unreachable')
+    expect(thinks[0]!.text).toBe('first thought')
+    expect(thinks[1]!.text).toBe('second thought')
+  })
+
+  test('redacted thinking block surfaces with redacted:true and empty text (so users see the safety-filter cut, not silence)', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [
+                { type: 'thinking', thinking: '', redacted: true, thinkingSignature: 'opaque-blob' },
+                { type: 'text', text: 'I cannot show my reasoning here.' },
+              ],
+              usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { total: 0 } },
+              timestamp: 5_000,
+            },
+          }),
+        ]),
+      ),
+    )
+    const thinking = events.find((e) => e.cat === 'thinking')
+    expect(thinking).toBeDefined()
+    if (thinking?.cat !== 'thinking') throw new Error('unreachable')
+    expect(thinking.redacted).toBe(true)
+    expect(thinking.text).toBe('')
+  })
+
+  test('empty non-redacted thinking block is dropped (no noise)', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [
+                { type: 'thinking', thinking: '' },
+                { type: 'text', text: 'hello' },
+              ],
+              usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { total: 0 } },
+              timestamp: 5_000,
+            },
+          }),
+        ]),
+      ),
+    )
+    expect(events.find((e) => e.cat === 'thinking')).toBeUndefined()
+    expect(events.find((e) => e.cat === 'assistant')).toBeDefined()
+  })
+
   test('malformed JSON lines are skipped, surrounding events still emit', async () => {
     const warnings: string[] = []
     const events = await collect(

--- a/src/inspect/replay.ts
+++ b/src/inspect/replay.ts
@@ -113,6 +113,7 @@ function* assistantEvents(
   ts: number,
   pending: Map<string, { name: string; startTs: number }>,
 ): Iterable<InspectEvent> {
+  yield* readThinkingEvents(message.content, ts)
   const text = readTextContent(message.content)
   if (text !== null && text !== '') {
     const ev: InspectEvent = {
@@ -215,6 +216,19 @@ function readUsage(value: unknown): {
     cacheWrite: numberOr(u.cacheWrite, 0),
     totalTokens: numberOr(u.totalTokens, 0),
     cost: numberOr(cost?.total, 0),
+  }
+}
+
+function* readThinkingEvents(content: unknown, ts: number): Iterable<InspectEvent> {
+  if (!Array.isArray(content)) return
+  for (const block of content) {
+    if (typeof block !== 'object' || block === null) continue
+    const b = block as Record<string, unknown>
+    if (b.type !== 'thinking') continue
+    const text = typeof b.thinking === 'string' ? b.thinking : ''
+    const redacted = b.redacted === true
+    if (text === '' && !redacted) continue
+    yield { cat: 'thinking', ts, text, ...(redacted ? { redacted: true } : {}) }
   }
 }
 

--- a/src/inspect/types.test.ts
+++ b/src/inspect/types.test.ts
@@ -53,7 +53,7 @@ describe('parseFilter', () => {
     expect(out.ok).toBe(false)
     if (out.ok) throw new Error('unreachable')
     expect(out.reason).toContain('"wat"')
-    expect(out.reason).toContain('meta, user, assistant, tool, error, done, broadcast, cron-fire, inbound')
+    expect(out.reason).toContain('meta, user, assistant, thinking, tool, error, done, broadcast, cron-fire, inbound')
   })
 
   test('case-insensitive token match', () => {
@@ -61,6 +61,15 @@ describe('parseFilter', () => {
     if (!out.ok) throw new Error('expected ok')
     expect(matchesFilter(sampleTool, out.filter)).toBe(true)
     expect(matchesFilter(sampleAssistant, out.filter)).toBe(false)
+  })
+
+  test('thinking category parses and gates correctly (typeclaw inspect --filter thinking)', () => {
+    const out = parseFilter('thinking')
+    if (!out.ok) throw new Error('expected ok')
+    const sampleThinking: InspectEvent = { cat: 'thinking', ts: 0, text: 'reasoning here' }
+    expect(matchesFilter(sampleThinking, out.filter)).toBe(true)
+    expect(matchesFilter(sampleAssistant, out.filter)).toBe(false)
+    expect(matchesFilter(sampleUser, out.filter)).toBe(false)
   })
 })
 

--- a/src/inspect/types.ts
+++ b/src/inspect/types.ts
@@ -4,6 +4,7 @@ export const INSPECT_CATEGORIES = [
   'meta',
   'user',
   'assistant',
+  'thinking',
   'tool',
   'error',
   'done',
@@ -19,6 +20,12 @@ export type InspectEvent =
   | { cat: 'meta'; ts: number; origin: MinimalSessionOrigin }
   | { cat: 'user'; ts: number; text: string }
   | { cat: 'assistant'; ts: number; text: string; provider?: string; model?: string }
+  // Reasoning trace from the model (Claude extended thinking, OpenAI reasoning
+  // summary, Gemini thoughts, etc.). Surfaced for debugging — why the model
+  // picked the next tool / wrote the next thing. `redacted` is true when the
+  // upstream provider hid the content behind a safety filter and only the
+  // opaque continuation payload survives; in that case `text` is empty.
+  | { cat: 'thinking'; ts: number; text: string; redacted?: boolean }
   | {
       cat: 'tool'
       ts: number

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1158,10 +1158,20 @@ function forwardAgentEventToInspect(
   const e = event as { type?: unknown }
   const now = Date.now()
   if (e.type === 'message_update') {
-    const ev = event as { assistantMessageEvent?: { type?: unknown; delta?: unknown } }
+    const ev = event as { assistantMessageEvent?: { type?: unknown; delta?: unknown; content?: unknown } }
     const ame = ev.assistantMessageEvent
     if (ame?.type === 'text_delta' && typeof ame.delta === 'string') {
       sendInspect(ws, { type: 'frame', ts: now, payload: { kind: 'text_delta', sessionId, delta: ame.delta } })
+      return
+    }
+    if (ame?.type === 'thinking_delta' && typeof ame.delta === 'string') {
+      sendInspect(ws, { type: 'frame', ts: now, payload: { kind: 'thinking_delta', sessionId, delta: ame.delta } })
+      return
+    }
+    if (ame?.type === 'thinking_end') {
+      const text = typeof ame.content === 'string' ? ame.content : ''
+      sendInspect(ws, { type: 'frame', ts: now, payload: { kind: 'thinking_end', sessionId, text } })
+      return
     }
     return
   }

--- a/src/server/inspect-ws.test.ts
+++ b/src/server/inspect-ws.test.ts
@@ -158,6 +158,30 @@ describe('/inspect WS handler', () => {
     ws.close()
   })
 
+  test('thinking_delta and thinking_end events forward as frames', async () => {
+    const registry = new LiveSessionRegistry()
+    const session = createFakeAgent()
+    registry.register({ sessionId: 'ses_live', session })
+    const { url } = await startServer({ liveSessionRegistry: registry })
+    const { ws, waitFor } = await connectInspect(url)
+    ws.send(JSON.stringify({ type: 'subscribe', sessionId: 'ses_live' }))
+    await waitFor((m) => m.type === 'subscribed')
+
+    session.emit({ type: 'message_update', assistantMessageEvent: { type: 'thinking_delta', delta: 'planning ' } })
+    const deltaFrame = await waitFor((m) => m.type === 'frame' && m.payload.kind === 'thinking_delta')
+    if (deltaFrame.type !== 'frame' || deltaFrame.payload.kind !== 'thinking_delta') throw new Error('unreachable')
+    expect(deltaFrame.payload.delta).toBe('planning ')
+
+    session.emit({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'thinking_end', content: 'planning ahead' },
+    })
+    const endFrame = await waitFor((m) => m.type === 'frame' && m.payload.kind === 'thinking_end')
+    if (endFrame.type !== 'frame' || endFrame.payload.kind !== 'thinking_end') throw new Error('unreachable')
+    expect(endFrame.payload.text).toBe('planning ahead')
+    ws.close()
+  })
+
   test('message_end events forward as frames with usage normalised', async () => {
     const registry = new LiveSessionRegistry()
     const session = createFakeAgent()

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -57,6 +57,12 @@ export type InspectClientMessage = {
 
 export type InspectFramePayload =
   | { kind: 'text_delta'; sessionId: string; delta: string }
+  // Reasoning trace from the model, streamed as deltas like text. `thinking_end`
+  // closes a thinking block; `text` is the joined deltas (empty when redacted).
+  // `redacted: true` means the upstream provider hid the content behind a
+  // safety filter and only the opaque continuation payload survives.
+  | { kind: 'thinking_delta'; sessionId: string; delta: string }
+  | { kind: 'thinking_end'; sessionId: string; text: string; redacted?: boolean }
   | { kind: 'tool_start'; sessionId: string; toolCallId: string; name: string; args: unknown }
   | {
       kind: 'tool_end'


### PR DESCRIPTION
## What this PR does

Surfaces model **thinking traces** (Claude extended thinking, OpenAI reasoning summaries, Gemini thoughts) in `typeclaw inspect` — both replay-from-JSONL and live-tail-via-WS paths. They were already being persisted and streamed by upstream `pi-coding-agent` and `pi-ai`; inspect was silently dropping them.

After this PR:

```
HH:MM:SS  user       look into the cron-coalescing bug and write a fix
HH:MM:SS  think      The leaf entry on the failing job is a toolResult, not an
                     assistant message. That means the post-tool LLM call never
                     produced a follow-up, so the chain's inFlight flag was
                     cleared but no done event was emitted. Let me read…
HH:MM:SS  assist     Reading the cron consumer to confirm the inFlight bookkeeping.
HH:MM:SS  tool ▸     read({"path":"src/cron/consumer.ts"})
HH:MM:SS  tool ◂     read → ok "…" (38ms)
```

Before this PR, the `think` line was invisible — the user saw the `read` call but had no way to know *why* the agent picked it. Thinking is the single biggest debugging signal modern reasoning models emit, and `typeclaw inspect` exists for debugging.

## The bug

The upstream `@mariozechner/pi-ai` SDK has had thinking blocks as a first-class shape for the entire lifetime of typeclaw:

- `ThinkingContent { type: "thinking"; thinking: string; thinkingSignature?: string; redacted?: boolean }` is one of the three legal members of `AssistantMessage.content[]` (alongside `TextContent` and `ToolCall`) — `node_modules/@mariozechner/pi-ai/dist/types.d.ts:81-89`.
- The streaming event protocol emits `thinking_start` / `thinking_delta` / `thinking_end` events with their own `contentIndex`, mirroring the text stream — `dist/types.d.ts:181-193`.
- `pi-coding-agent` writes these blocks verbatim into `sessions/*.jsonl` — confirmed via grep of `dist/core/compaction/compaction.js:184`, `dist/core/export-html/template.js:1155`, etc.

typeclaw was dropping them at four places:

1. **`src/inspect/replay.ts:221-232`** — `readTextContent` only matched `type === 'text'` blocks. Thinking blocks were silently skipped.
2. **`src/server/index.ts:1160-1166`** — `forwardAgentEventToInspect` only forwarded `text_delta`; `thinking_delta` / `thinking_end` fell into the unhandled tail.
3. **`src/shared/protocol.ts:58`** — `InspectFramePayload` had no `thinking_*` kind.
4. **`src/inspect/types.ts:3-14`** — `InspectEvent` had no `thinking` category, so even if frames arrived live they had nowhere to land.

## Why this matters

Reasoning models are now the default for nontrivial work. Claude `opus-4-6` and Sonnet 4.5 with extended thinking, OpenAI o-series and gpt-5.x with reasoning summaries, Gemini 2.5+ with thought signatures, Kimi K2 thinking. The thinking trace is where the model says "I'm going to do X because Y" — and the JSONL already had it. Inspect was the last mile.

The most acute case is debugging tool-use mistakes: the model picks the wrong tool or the wrong argument, the result fails, and without thinking you cannot tell whether the model misread the task, misunderstood the file it was looking at, or hallucinated a constraint. With thinking, the failure is usually self-evident from the trace itself.

## Changes

### New `thinking` InspectEvent variant — `src/inspect/types.ts`

```ts
| { cat: 'thinking'; ts: number; text: string; redacted?: boolean }
```

Added to `INSPECT_CATEGORIES` so the existing filter DSL works without separate code: `typeclaw inspect --filter thinking` (only reasoning), `--filter !thinking` (silence reasoning), `--filter assistant,tool` (pre-existing behavior, still excludes thinking).

The `redacted: true` flag fires when the upstream provider hid the content behind a safety filter and only the opaque continuation payload survives in `thinkingSignature`. In that case `text` is empty by contract — the renderer shows `[redacted]` instead of silence, so the user knows the safety filter cut rather than the model thinking nothing.

### New wire frames — `src/shared/protocol.ts`

```ts
| { kind: 'thinking_delta'; sessionId: string; delta: string }
| { kind: 'thinking_end'; sessionId: string; text: string; redacted?: boolean }
```

Same accumulator-then-finalizer shape as `text_delta` → `message_end`. The wire protocol intentionally exposes `thinking_end` carrying the full joined text — providers that don't stream thinking deltas (Gemini batches its thoughts into the closing event) still work.

### Replay — `src/inspect/replay.ts`

Adds `readThinkingEvents(content, ts)` that walks `message.content[]` and yields a thinking event per `{ type: 'thinking', thinking, redacted? }` block. Called before the existing text/tool-call logic in `assistantEvents` so the emitted order is **thinking → text → tool calls** per turn — matching the order the SDK actually emits and the order that makes debugging stories read top-to-bottom.

Empty non-redacted thinking blocks are dropped (some providers emit them as no-ops). Empty redacted blocks are kept so the safety-filter cut is visible.

### Server — `src/server/index.ts`

Extends `forwardAgentEventToInspect`'s `message_update` branch with two new sub-cases mirroring the existing `text_delta`:

```ts
if (ame?.type === 'thinking_delta' && typeof ame.delta === 'string') {
  sendInspect(ws, { ..., payload: { kind: 'thinking_delta', sessionId, delta: ame.delta } })
}
if (ame?.type === 'thinking_end') {
  const text = typeof ame.content === 'string' ? ame.content : ''
  sendInspect(ws, { ..., payload: { kind: 'thinking_end', sessionId, text } })
}
```

### Live client — `src/inspect/live.ts`

Adds a second accumulator `thinkingAccumulators: Map<string, string>` parallel to the existing text one. `frameToEvent` handles the new frames symmetrically: deltas append, `thinking_end` flushes and emits one `thinking` InspectEvent. Fallback: when no deltas arrived (Gemini-batched case), uses `payload.text` directly.

### Renderer — `src/inspect/render.ts`

```
HH:MM:SS  think      <reasoning text>
HH:MM:SS  think      [redacted]
```

Tag is `think` in dim gray (matches the existing `done` event's color treatment — auxiliary, lower-salience signal). Body is dim too, so thinking visually recedes when you're scanning for tool calls / errors. `[redacted]` shows in dim brackets when the safety flag is set.

Truncation respects the existing `maxTextLength` knob (default 200 chars, same as user/assistant text). The `--json` path emits the new event verbatim — no special-casing.

## Tests

11 new tests across the affected layers, all behavior-tests (no implementation coupling):

| Layer | Test | What it pins |
|---|---|---|
| `replay.test.ts` | thinking block yields ordered event | Thinking interleaves correctly: thinking → assistant → tool → done |
| `replay.test.ts` | multiple thinking blocks per turn | Each yields its own event, in content-array order |
| `replay.test.ts` | redacted thinking surfaces with `redacted: true` | Safety-filter cut is visible, not silent |
| `replay.test.ts` | empty non-redacted thinking is dropped | No noise from no-op blocks |
| `live.test.ts` | thinking_delta accumulates → thinking_end emits one event | Mirror of existing text-streaming test |
| `live.test.ts` | thinking_end without deltas falls back to `content` | Gemini batched case |
| `render.test.ts` | thinking renders with `think` tag | Format pinned |
| `render.test.ts` | redacted shows `[redacted]` marker | Format pinned |
| `render.test.ts` | thinking respects `maxTextLength` | Truncation consistent with text |
| `types.test.ts` | thinking parses as filter category | `--filter thinking` works |
| `inspect-ws.test.ts` | server forwards thinking_delta/thinking_end | Wire contract |

`bun test --parallel src/inspect/ src/server/inspect-ws.test.ts src/shared/` — 132 tests, 0 failures.

Pre-commit checks all clean: `bun run typecheck`, `bun run lint` (0 errors; 41 warnings are all pre-existing in unrelated files — same count as `origin/main`), `bun run format`.

Full-suite flakes (9–16 timeouts) are pre-existing — verified by `git stash && bun run test` on the clean `origin/main` tree showing the same range (11 fails). Every flake is in a CLI subprocess test that spawns `bun src/cli/index.ts`; none of my changes touch CLI bootstrapping, plugin loading, or subprocess paths.

## Diff stats

```
src/inspect/live.test.ts      |  55 +++++++++++++++
src/inspect/live.ts           |  16 ++++-
src/inspect/render.test.ts    |  21 ++++++
src/inspect/render.ts         |   7 ++
src/inspect/replay.test.ts    | 105 ++++++++++++++++++++++++++++++
src/inspect/replay.ts         |  14 ++++
src/inspect/types.test.ts     |  11 +++-
src/inspect/types.ts          |   7 ++
src/server/index.ts           |  12 +++-
src/server/inspect-ws.test.ts |  24 ++++++
src/shared/protocol.ts        |   6 ++
11 files changed, 275 insertions(+), 3 deletions(-)
```

## What this PR does NOT do

This is Phase 1 of the "more debugging info in inspect" thread. Three deliberately-deferred follow-ups:

- **`responseId` / `api` propagation** — pi-ai's `AssistantMessage` carries `responseId` (provider-side message id, useful for cross-referencing with Anthropic console / OpenAI dashboard logs) and `api` (which upstream API actually served the call — `anthropic-messages` vs `bedrock-converse-stream` vs `google-vertex` matter for debugging). Currently dropped by `buildMessageEndPayload`. Cheap follow-up.
- **Less truncation, opt-in** — `--full` flag that sets `maxTextLength: Infinity` and disables tool-args/result truncation. Default-truncated stays right for triage; full-render right for single-event debugging.
- **Cost-on-error** — when a turn fails with usage present, the `error` path currently drops the partial `done` event so the cost ledger misses aborted runs.

Wanted to keep this PR scoped to the headline change (thinking traces) and ship it.
