### PR TITLE
memory: commit pending legacy deletions even when topics dir is absent

### DIFF
--- a/src/bundled-plugins/memory/migration.test.ts
+++ b/src/bundled-plugins/memory/migration.test.ts
@@ -631,6 +631,54 @@ describe('runShardingMigration', () => {
     expect(latest.stdout).toContain('memory: clean up 2 pre-shard file(s) orphaned by earlier migration')
   })
 
+  test('commits pending legacy deletions even when topics dir was never created', async () => {
+    await initGitRepo(agentDir)
+    await writeFlatStream('2026-05-20', 'orphan-1\n')
+    await writeFlatStream('2026-05-21', 'orphan-2\n')
+    await writeFlatStream('2026-05-22', 'orphan-3\n')
+    await git(agentDir, ['add', '--', 'memory/2026-05-20.jsonl', 'memory/2026-05-21.jsonl', 'memory/2026-05-22.jsonl'])
+    await git(agentDir, ['commit', '-m', 'pre-shard legacy state'])
+    await rm(join(memoryDir, '2026-05-20.jsonl'))
+    await rm(join(memoryDir, '2026-05-21.jsonl'))
+    await rm(join(memoryDir, '2026-05-22.jsonl'))
+    await git(agentDir, [
+      'add',
+      '-u',
+      '--',
+      'memory/2026-05-20.jsonl',
+      'memory/2026-05-21.jsonl',
+      'memory/2026-05-22.jsonl',
+    ])
+    const beforePorcelain = await git(agentDir, ['status', '--porcelain', '--untracked-files=no'])
+    expect(beforePorcelain.stdout).toContain('D  memory/2026-05-20.jsonl')
+    expect(beforePorcelain.stdout).toContain('D  memory/2026-05-21.jsonl')
+    expect(beforePorcelain.stdout).toContain('D  memory/2026-05-22.jsonl')
+    expect(existsSync(join(memoryDir, 'topics'))).toBe(false)
+
+    await runShardingMigration({ agentDir, logger })
+
+    const porcelain = await git(agentDir, ['status', '--porcelain', '--untracked-files=no'])
+    expect(porcelain.stdout).toBe('')
+    const latest = await git(agentDir, ['log', '--oneline', '-1'])
+    expect(latest.stdout).toContain('memory: clean up 3 pre-shard file(s) orphaned by earlier migration')
+  })
+
+  test('commits pending legacy deletions when topics dir is absent and deletions are unstaged', async () => {
+    await initGitRepo(agentDir)
+    await writeFlatStream('2026-05-20', 'orphan-1\n')
+    await git(agentDir, ['add', '--', 'memory/2026-05-20.jsonl'])
+    await git(agentDir, ['commit', '-m', 'pre-shard legacy state'])
+    await rm(join(memoryDir, '2026-05-20.jsonl'))
+    expect(existsSync(join(memoryDir, 'topics'))).toBe(false)
+
+    await runShardingMigration({ agentDir, logger })
+
+    const porcelain = await git(agentDir, ['status', '--porcelain', '--untracked-files=no'])
+    expect(porcelain.stdout).toBe('')
+    const latest = await git(agentDir, ['log', '--oneline', '-1'])
+    expect(latest.stdout).toContain('memory: clean up 1 pre-shard file(s) orphaned by earlier migration')
+  })
+
   test('no-op when post-shard tree is clean and no pending deletions exist', async () => {
     await initGitRepo(agentDir)
     await writePreMigratedTree()

--- a/src/bundled-plugins/memory/migration.ts
+++ b/src/bundled-plugins/memory/migration.ts
@@ -246,28 +246,32 @@ async function recoverShardingOrphans(
   logger: MigrationLogger,
   git: MigrationGit | undefined,
 ): Promise<void> {
-  if (!existsSync(topicsDir(agentDir))) return
+  if (existsSync(topicsDir(agentDir))) {
+    let cleaned = false
+    const memoryPath = rootMemoryPath(agentDir)
+    if (existsSync(memoryPath)) {
+      await unlink(memoryPath)
+      cleaned = true
+    }
 
-  let cleaned = false
-  const memoryPath = rootMemoryPath(agentDir)
-  if (existsSync(memoryPath)) {
-    await unlink(memoryPath)
-    cleaned = true
+    const memoryDir = join(agentDir, 'memory')
+    const dates = await collectFlatJsonlDates(memoryDir)
+    for (const date of dates) {
+      if (!existsSync(streamFilePath(agentDir, date))) continue
+      await unlink(join(memoryDir, `${date}.jsonl`))
+      cleaned = true
+    }
+
+    if (cleaned) logger.info('[memory:migration] cleaned orphaned pre-shard memory files')
   }
 
-  const memoryDir = join(agentDir, 'memory')
-  const dates = await collectFlatJsonlDates(memoryDir)
-  for (const date of dates) {
-    if (!existsSync(streamFilePath(agentDir, date))) continue
-    await unlink(join(memoryDir, `${date}.jsonl`))
-    cleaned = true
-  }
-
-  if (cleaned) logger.info('[memory:migration] cleaned orphaned pre-shard memory files')
-
-  // Always called, even when nothing was cleaned this boot: pre-#315 migrations
-  // and earlier runs of this function unlinked without committing, leaving
+  // Always called, even when nothing was cleaned this boot AND even when the
+  // sharded layout never landed on this agent: pre-#315 migrations and
+  // earlier runs of this function unlinked without committing, leaving
   // staged deletions that survive across reboots until cleared explicitly.
+  // The earlier guard (`return` when topicsDir is absent) stranded any agent
+  // whose pre-shard files were deleted but whose sharding never completed —
+  // their staged deletions sat in the index forever.
   await commitPendingLegacyDeletions(agentDir, logger, git)
 }
 


### PR DESCRIPTION
## What this PR does

Fixes a follow-on bug from #315: the recovery commit for "pre-shard memory files deleted by an earlier migration but never committed" still doesn't fire for some agents, because it sits behind an early-return guard that requires `memory/topics/` to exist.

## The bug

PR #315 added `commitPendingLegacyDeletions` inside `recoverShardingOrphans` so already-affected agents could heal their orphaned staged deletions on the next boot. The commit was added to the function tail with a comment explicitly calling out "always called, even when nothing was cleaned this boot" — but the function still owns the early return at its top:

```ts
async function recoverShardingOrphans(...) {
  if (!existsSync(topicsDir(agentDir))) return   // ← strands a real population
  // ...orphan cleanup...
  await commitPendingLegacyDeletions(agentDir, logger, git)
}
```

The early return strands one specific population: agents whose pre-shard files (`MEMORY.md`, `memory/<date>.jsonl`) were deleted by an interrupted migration AND that never completed sharding (typically because `MEMORY.md` was already absent by the time the post-#315 boot ran, so `runShardingMigration`'s main body short-circuits at the `!existsSync(rootMemoryPath)` check too). For those agents, `memory/topics/` never gets created, so `recoverShardingOrphans` returns at line 1, and `commitPendingLegacyDeletions` never runs. The staged deletions sit in the index forever.

Reproducer is exactly what the user reported:

```
On branch main
Changes to be committed:
        deleted:    memory/2026-05-20.jsonl
        deleted:    memory/2026-05-21.jsonl
        deleted:    memory/2026-05-22.jsonl
```

…across multiple agents, surviving every `typeclaw start` since #315 landed.

## The fix

Move the topicsDir-gated orphan-cleanup block inside the `existsSync` branch (its semantics are unchanged — that work genuinely depends on the sharded layout being present), and call `commitPendingLegacyDeletions` unconditionally after the branch:

```ts
async function recoverShardingOrphans(...) {
  if (existsSync(topicsDir(agentDir))) {
    // ...orphan cleanup (unchanged)...
  }
  await commitPendingLegacyDeletions(agentDir, logger, git)
}
```

`commitPendingLegacyDeletions` already short-circuits cheaply on healthy agents — one `git diff HEAD --diff-filter=D -- memory/ MEMORY.md` returns an empty list and the function bails before any add/commit. The unconditional call is effectively free on the happy path.

## Tests

Two new regression tests in `migration.test.ts`, both inside `describe('runShardingMigration')`:

1. **commits pending legacy deletions even when topics dir was never created** — init a git repo, commit three flat `memory/2026-05-{20,21,22}.jsonl` files, `rm` them, `git add -u` the deletions, run the migration. Asserts the working tree is clean and the latest commit says `memory: clean up 3 pre-shard file(s) orphaned by earlier migration`. **This is the literal user-reported reproducer.**
2. **commits pending legacy deletions when topics dir is absent and deletions are unstaged** — same shape but the `rm` is not followed by `git add -u`, so `commitPendingLegacyDeletions` exercises its `pending.workingTreeOnly` staging branch as well.

Both tests fail against pre-fix `migration.ts` (verified by `git stash` + re-run during development):

```
(fail) commits pending legacy deletions even when topics dir was never created
       Expected: ""
       Received: " D memory/2026-05-20.jsonl\n D memory/2026-05-21.jsonl\n D memory/2026-05-22.jsonl\n"

(fail) commits pending legacy deletions when topics dir is absent and deletions are unstaged
       Expected: ""
       Received: " D memory/2026-05-20.jsonl\n"
```

Both pass after the fix.

## Recovery for already-affected agents

Same as #315: this fix only repairs FUTURE boots of affected agents. After the next `npm install` of the released version and one `typeclaw restart`, the staged deletions get auto-committed and the agent self-heals. No manual `git add -u` needed by the user this time — the original #315 manual-recovery snippet stays as a fallback for users who can't update, but it shouldn't be required.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 41 pre-existing warnings, 0 errors, none in changed files
- `bun run format` — clean
- `bun test --parallel src/bundled-plugins/memory/migration.test.ts` — 43 pass / 0 fail (41 pre-existing + 2 new)
- `bun test --parallel src/bundled-plugins/memory/` — 596 pass / 0 fail across 28 files
