### PR TITLE
channels: skip stale-rollover while drain is in flight

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -568,6 +568,76 @@ describe('ChannelRouter session lifecycle', () => {
     expect(loaded[0]?.lastInboundAt).toBe(SESSION_FRESHNESS_TTL_MS + 1)
   })
 
+  // Regression for the Huxley Slack channel incident on 2026-05-26
+  // (session 019e62c2-179b-734a-9340-b9dd28254636, addressed at the
+  // contract layer by PR #359). The model's second turn was running
+  // longer than SESSION_FRESHNESS_TTL_MS (5 min) because it was
+  // composing a reply off a backgrounded subagent's result. The user
+  // sent a "why is it stopping mid-answer" follow-up at minute 8, which
+  // triggered ensureLive's stale-rollover branch and called
+  // tearDownLive → session.abort() on the in-flight prompt. The reply
+  // was lost. The runIdleGc path already skipped draining sessions; the
+  // ensureLive rollover path was missing the matching guard.
+  test('stale rollover is suppressed while draining; in-flight prompt is not aborted', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { nowRef, logs })
+    let releaseFirstPrompt: () => void = () => {}
+    const firstPromptHeld = new Promise<void>((resolve) => {
+      releaseFirstPrompt = resolve
+    })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    sessions[0]!.onPrompt = async () => {
+      await firstPromptHeld
+    }
+    // Fire drain WITHOUT awaiting — the held onPrompt would otherwise
+    // block flushDebounce forever. The drain runs in the background and
+    // we observe its mid-flight state via live.draining (which the
+    // production rollover branch checks).
+    const drainPromise = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+    // First prompt is now mid-flight: drain() has set live.draining=true
+    // and is blocked at session.prompt(). Bump the clock past the
+    // freshness TTL and route a follow-up inbound — pre-fix, this fired
+    // tearDownLive on the in-flight session and aborted the prompt.
+    nowRef.value = 1000 + SESSION_FRESHNESS_TTL_MS + 1
+    await router.route(inbound({ externalMessageId: 'm2', text: 'why is it stopping mid-answer' }))
+
+    expect(logs.some((l) => l.includes('stale-rollover'))).toBe(false)
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.aborted).toBe(0)
+    expect(sessions[0]!.disposed).toBe(0)
+
+    // Release the held prompt so the drain loop can finish. The
+    // follow-up that arrived during the in-flight turn was enqueued via
+    // the live.draining branch in route() and is picked up on the next
+    // iteration of drain's while-loop.
+    releaseFirstPrompt()
+    await drainPromise
+    expect(sessions[0]!.prompts.length).toBeGreaterThanOrEqual(2)
+  })
+
+  test('rollover STILL fires when idle exceeds TTL and the session is NOT draining', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { nowRef, logs })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+    // First prompt resolved (default FakeSession.prompt is a no-op),
+    // so live.draining is back to false. Bump the clock and route a
+    // follow-up — the draining-guard does not apply, and the original
+    // rollover behavior must still fire.
+    nowRef.value = 1000 + SESSION_FRESHNESS_TTL_MS + 1
+    await router.route(inbound({ externalMessageId: 'm2', text: 'follow up after a long quiet stretch' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(logs.some((l) => l.includes('stale-rollover'))).toBe(true)
+    expect(sessions).toHaveLength(2)
+    expect(sessions[0]!.disposed).toBe(1)
+  })
+
   test('command path does NOT trigger rollover', async () => {
     const dir = await tempDir()
     const nowRef = { value: 1000 }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -723,7 +723,20 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const existing = liveSessions.get(keyId)
     if (existing && !existing.destroyed) {
       const idleMs = now() - existing.lastInboundAt
-      if (idleMs > SESSION_FRESHNESS_TTL_MS) {
+      // `lastInboundAt` is only bumped on engaged inbounds (see route()),
+      // so a session whose drain loop has been compiling a slow reply for
+      // 5+ minutes off a single inbound looks "idle" by this clock even
+      // though `session.prompt()` is mid-flight. Aborting that prompt to
+      // re-cold-start on the next user message wipes the in-flight work
+      // (observed against `openai-codex/gpt-5.5` in PR #359's incident:
+      // a 285s + 227s turn pair lost the second turn entirely to
+      // `tearDownLive` → `session.abort()` triggered by the user's
+      // follow-up at 5min idle). The `runIdleGc` path already skips
+      // draining sessions for the same reason; rollover must match.
+      // The skip is bounded: when the in-flight prompt completes or its
+      // own provider/transport timeout fires, `draining` clears and the
+      // next inbound's idle check picks up rollover normally.
+      if (idleMs > SESSION_FRESHNESS_TTL_MS && !existing.draining) {
         logger.info(`[channels] ${keyId}: stale-rollover (live: ${idleMs}ms idle)`)
         await tearDownLive(existing)
         liveSessions.delete(keyId)


### PR DESCRIPTION
## What this PR does

Fixes a runtime race that permanently lost in-flight channel replies when a user
follow-up arrived past the 5-minute stale-rollover threshold while
`session.prompt()` was still composing. One-line guard added to `ensureLive`'s
rollover branch at `src/channels/router.ts:726`:

```diff
-if (idleMs > SESSION_FRESHNESS_TTL_MS) {
+if (idleMs > SESSION_FRESHNESS_TTL_MS && !existing.draining) {
```

Two regression tests in `src/channels/router.test.ts` pin both sides of the guard.

Companion to PR #359 (https://github.com/typeclaw/typeclaw/pull/359), which fixes
the model contract so the agent doesn't end its turn with `NO_REPLY` after
backgrounding a subagent. This PR is the runtime safety net for when the underlying
race fires regardless — e.g. genuinely slow model turns even with the contract
followed.

## The race

`ensureLive` at `src/channels/router.ts:726` compared `now() - existing.lastInboundAt`
against `SESSION_FRESHNESS_TTL_MS` (5 min, line 111) and unconditionally tore down
sessions above the threshold via `tearDownLive` → `session.abort()`.

The mismatch: `lastInboundAt` only bumps on **engaged inbounds** (in `route()`), so a
session whose `drain()` loop has been awaiting `session.prompt()` for 5+ minutes looks
"idle" by this clock even though work is actively in flight.

**Production incident** — Huxley Slack channel, 2026-05-26, session
`019e62c2-179b-734a-9340-b9dd28254636`. Model: `openai-codex/gpt-5.5`. The agent
backgrounded an `explorer` subagent (33 s), then spent 227 s composing a reply off
the subagent's result. The user's "why is it stopping mid-answer" follow-up at minute
8 triggered `stale-rollover (live: 480000ms idle)`, aborting the in-flight
composition. The reply was permanently lost — the session leaf became
`assistant(stopReason=aborted, errorMessage="Request was aborted")`.

This failure shape is **not recoverable** by PR #355's pre-tool recovery, which
requires `leaf=toolResult`.

## Why the existing constant isn't bumped

`SESSION_FRESHNESS_TTL_MS` (5 min) is deliberately tuned to the LLM provider's
KV-cache TTL — see the rationale comment at `src/channels/router.ts:101-110`.
Bumping it would cost cache hits on every fresh session creation. The narrow guard
preserves the cache contract entirely.

## The fix

The `runIdleGc` path at line 1910 already gates the same teardown on `!live.draining`
for exactly this reason — the `ensureLive` path was the only remaining caller missing
the guard.

The skip is bounded: once the in-flight prompt completes (or the provider/transport
timeout fires and resolves it), `draining` clears and the next inbound's idle check
picks up rollover normally. There is no unbounded-skip concern.

## Tests

Two new regression tests in `src/channels/router.test.ts`, each carrying a comment
naming the incident session id:

| Test | What it pins |
|---|---|
| `stale rollover is suppressed while draining; in-flight prompt is not aborted` | Holds `onPrompt` mid-flight, bumps clock past TTL, routes a follow-up. Asserts no `stale-rollover` log, no new session, `aborted=0`, `disposed=0`. Releases the prompt and verifies the follow-up rides the next drain iteration. |
| `rollover STILL fires when idle exceeds TTL and the session is NOT draining` | Lets the first prompt resolve (`FakeSession.prompt` no-op, so `draining` flips back to `false`), bumps clock past TTL, routes a follow-up. Asserts `stale-rollover` log fires, two sessions created, `disposed=1`. Pins the guard as narrow, not wholesale rollover removal. |

## Pre-commit verification

| Check | Result |
|---|---|
| `bun run typecheck` | Clean |
| `bun run lint` | Clean (41 pre-existing warnings on other files; zero on changed files) |
| `bun run format:check` | Clean |
| `bun test --parallel src/channels/router.test.ts` | 200/200 pass (up from 198; the two new tests are the delta) |
| Full suite | 11 pre-existing flakes on `main` (subprocess/CLI timeouts, unchanged); zero new failures |

## Companion to PR #359

PR #359 (https://github.com/typeclaw/typeclaw/pull/359) addresses the model contract:
the agent no longer ends its turn with `NO_REPLY` after spawning a background subagent
to answer the current inbound. That fix prevents the race from firing in the common case.

This PR is the runtime safety net: if the race fires anyway — because a genuinely slow
turn takes longer than 5 minutes even without a `NO_REPLY` interlude — the in-flight
reply is no longer silently aborted.

## Diff stats

```
src/channels/router.ts      | +14  -1   (one-line guard + rationale comment naming the incident)
src/channels/router.test.ts | +70  -0   (two regression tests + comment block)
2 files changed, +84 -1
```