### PR TITLE
agent/tools/subagent-output: drop block/timeout_ms params

### DIFF
--- a/src/agent/live-subagents.test.ts
+++ b/src/agent/live-subagents.test.ts
@@ -19,7 +19,6 @@ function makeLive(overrides: Partial<LiveSubagent> = {}): LiveSubagent {
     startedAt: 1_000,
     status: 'running',
     abort: async () => {},
-    awaitCompletion: async () => ({ ok: true, durationMs: 0 }),
     ...overrides,
   }
 }

--- a/src/agent/live-subagents.ts
+++ b/src/agent/live-subagents.ts
@@ -23,7 +23,6 @@ export type LiveSubagent = {
   status: SubagentStatus
   completion?: SubagentCompletion
   abort: () => Promise<void>
-  awaitCompletion: () => Promise<SubagentCompletion>
 }
 
 export const MAX_EVENTS_PER_SUBAGENT = 100

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -60,7 +60,7 @@ There are two delegation modes. Pick deliberately.
 
 **Mode A — Research fan-out** (in service of the current question)
 
-When you need information to answer the user and the search is broad, fire 2-5 subagents in parallel with \`run_in_background: true\` covering different angles. End your response after spawning. The system will deliver a \`<system-reminder>\` for each completion; gather results then answer the user. Do NOT poll \`subagent_output\` in a tight loop.
+When you need information to answer the user and the search is broad, fire 2-5 subagents in parallel with \`run_in_background: true\` covering different angles. End your response after spawning. The system will deliver a \`<system-reminder>\` for each completion; then call \`subagent_output\` once per task_id to fetch the result and answer the user. \`subagent_output\` always returns immediately with a snapshot — it does not block.
 
 The bundled \`explorer\` subagent is the right tool for **local** reconnaissance — anything reachable on the agent's filesystem: code, past sessions (\`sessions/*.jsonl\`), memory topic shards and daily memory streams, skills, cron jobs, config, git history, mounts, channels state. It is read-only and runs on a fast/cheap model, so fire liberally. Do NOT ask it to plan, decide, or write code — it finds and reports.
 
@@ -78,7 +78,7 @@ The bundled \`operator\` subagent is the right tool for this mode. It is write-c
 
 **Status queries**
 
-If the user asks "how's it going?" or "status?" on a running subagent, call \`subagent_output({ task_id, block: false })\` and report the \`status_summary\` in your own words. Don't pretend to know the status without checking.
+If the user asks "how's it going?" or "status?" on a running subagent, call \`subagent_output({ task_id })\` and report the \`status_summary\` in your own words. Don't pretend to know the status without checking.
 
 **Prompt structure for spawns** (mandatory — the subagent does not see this conversation)
 
@@ -92,7 +92,7 @@ If the user asks "how's it going?" or "status?" on a running subagent, call \`su
 
 - Don't fire more than 5 subagents in a single turn.
 - Don't spawn for a known answer or single-file lookup — do it yourself.
-- Don't poll \`subagent_output\` waiting for completion; end your response and the reminder will wake you.
+- Don't call \`subagent_output\` in a loop waiting for completion; end your response and the reminder will wake you, then fetch the result once.
 - Don't ask a research subagent to make architectural decisions for you — they find and report; you decide.
 - Subagents cannot recursively spawn other subagents.
 

--- a/src/agent/tools/spawn-subagent.ts
+++ b/src/agent/tools/spawn-subagent.ts
@@ -130,7 +130,6 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
         startedAt,
         status: 'running' as const,
         abort: resolvedHandle.abort,
-        awaitCompletion: () => completion.then((c) => completionToFinalShape(c, now() - startedAt)),
       }
       liveRegistry.register(live)
 

--- a/src/agent/tools/subagent-cancel.test.ts
+++ b/src/agent/tools/subagent-cancel.test.ts
@@ -14,7 +14,6 @@ function makeLive(overrides: Partial<LiveSubagent> = {}): LiveSubagent {
     startedAt: 1_000,
     status: 'running',
     abort: async () => {},
-    awaitCompletion: async () => ({ ok: true, durationMs: 0 }),
     ...overrides,
   }
 }

--- a/src/agent/tools/subagent-output.test.ts
+++ b/src/agent/tools/subagent-output.test.ts
@@ -14,7 +14,6 @@ function makeLive(overrides: Partial<LiveSubagent> = {}): LiveSubagent {
     startedAt: 1_000,
     status: 'running',
     abort: async () => {},
-    awaitCompletion: async () => ({ ok: true, durationMs: 0 }),
     ...overrides,
   }
 }
@@ -144,50 +143,10 @@ describe('createSubagentOutputTool — failed status', () => {
   })
 })
 
-describe('createSubagentOutputTool — block:true', () => {
-  test('waits for completion when block=true on a running task', async () => {
+describe('createSubagentOutputTool — never blocks', () => {
+  test('returns immediately even when the subagent is still running', async () => {
     const liveRegistry = new LiveSubagentRegistry()
-    let resolveCompletion: (c: { ok: true; durationMs: number; finalMessage?: string }) => void = () => {}
-    const completionPromise = new Promise<{ ok: true; durationMs: number; finalMessage?: string }>((r) => {
-      resolveCompletion = r
-    })
-    liveRegistry.register(
-      makeLive({
-        awaitCompletion: () => completionPromise,
-      }),
-    )
-
-    const tool = createSubagentOutputTool({
-      liveRegistry,
-      getOrigin: () => undefined,
-      now: () => 5_000,
-    })
-
-    const executePromise = tool.execute(
-      'call_1',
-      { task_id: 'bg_o1', block: true, timeout_ms: 5_000 },
-      undefined,
-      undefined,
-      ctx,
-    )
-    setTimeout(() => {
-      liveRegistry.recordCompletion('bg_o1', { ok: true, finalMessage: 'done', durationMs: 1_000 })
-      resolveCompletion({ ok: true, durationMs: 1_000, finalMessage: 'done' })
-    }, 10)
-
-    const result = await executePromise
-    const details = result.details as { status?: string; finalMessage?: string }
-    expect(details.status).toBe('completed')
-    expect(details.finalMessage).toBe('done')
-  })
-
-  test('returns current state on timeout (does NOT error)', async () => {
-    const liveRegistry = new LiveSubagentRegistry()
-    liveRegistry.register(
-      makeLive({
-        awaitCompletion: () => new Promise(() => {}),
-      }),
-    )
+    liveRegistry.register(makeLive())
 
     const tool = createSubagentOutputTool({
       liveRegistry,
@@ -195,42 +154,14 @@ describe('createSubagentOutputTool — block:true', () => {
       now: () => 2_000,
     })
 
-    const result = await tool.execute(
-      'call_1',
-      { task_id: 'bg_o1', block: true, timeout_ms: 20 },
-      undefined,
-      undefined,
-      ctx,
-    )
-    const details = result.details as { ok: boolean; status?: string }
-    expect(details.ok).toBe(true)
-    expect(details.status).toBe('running')
-  })
-
-  test('block=true on already-completed task short-circuits (no wait)', async () => {
-    const liveRegistry = new LiveSubagentRegistry()
-    liveRegistry.register(makeLive())
-    liveRegistry.recordCompletion('bg_o1', { ok: true, finalMessage: 'fast', durationMs: 100 })
-
-    const tool = createSubagentOutputTool({
-      liveRegistry,
-      getOrigin: () => undefined,
-      now: () => 1_000,
-    })
-
     const start = Date.now()
-    const result = await tool.execute(
-      'call_1',
-      { task_id: 'bg_o1', block: true, timeout_ms: 60_000 },
-      undefined,
-      undefined,
-      ctx,
-    )
+    const result = await tool.execute('call_1', { task_id: 'bg_o1' }, undefined, undefined, ctx)
     const elapsed = Date.now() - start
 
     expect(elapsed).toBeLessThan(50)
-    const details = result.details as { status?: string }
-    expect(details.status).toBe('completed')
+    const details = result.details as { ok: boolean; status?: string }
+    expect(details.ok).toBe(true)
+    expect(details.status).toBe('running')
   })
 })
 

--- a/src/agent/tools/subagent-output.ts
+++ b/src/agent/tools/subagent-output.ts
@@ -6,9 +6,6 @@ import type { PermissionService } from '@/permissions'
 import type { LiveSubagentRegistry, StatusSnapshot, SubagentProgressEvent } from '../live-subagents'
 import type { SessionOrigin } from '../session-origin'
 
-const DEFAULT_TIMEOUT_MS = 60_000
-const MAX_TIMEOUT_MS = 300_000
-
 export type SubagentOutputToolDetails =
   | {
       ok: true
@@ -57,70 +54,25 @@ export function createSubagentOutputTool(options: CreateSubagentOutputToolOption
       'Fetch the current state of a subagent you previously spawned. Returns one of three statuses: ' +
       "'running' (with a human-readable status_summary and a tail of recent progress events), " +
       "'completed' (with the final message), or 'failed' (with the error). " +
-      'Use this when the user asks how a long-running subagent is going, or when you need to retrieve the result of a backgrounded spawn. ' +
-      'When block=true (default false), the tool waits up to timeout_ms for completion before returning. ' +
-      'Prefer block=false and rely on the system-reminder for completion notification; reserve block=true for tight workflows.',
+      'Returns immediately with a snapshot — never blocks. ' +
+      'For backgrounded spawns, end your turn after spawning and wait for the completion <system-reminder>; ' +
+      'then call this once to fetch the result. Use it for ad-hoc status checks too — never in a polling loop.',
     parameters: Type.Object({
       task_id: Type.String({
         description: 'The task_id returned by a previous spawn_subagent call.',
       }),
-      block: Type.Optional(
-        Type.Boolean({
-          description:
-            'If true, wait for the subagent to complete (or time out) before returning. Default false: return immediately with the current state.',
-        }),
-      ),
-      timeout_ms: Type.Optional(
-        Type.Integer({
-          description: `When block=true, max milliseconds to wait (default ${DEFAULT_TIMEOUT_MS}, max ${MAX_TIMEOUT_MS}).`,
-          minimum: 1,
-          maximum: MAX_TIMEOUT_MS,
-        }),
-      ),
     }),
 
     async execute(_toolCallId, params) {
       if (permissions !== undefined && !permissions.has(getOrigin(), 'subagent.output')) {
         return errorResult('subagent.output denied: insufficient permissions')
       }
-      const live = liveRegistry.get(params.task_id)
-      if (live === undefined) {
-        return errorResult(`Unknown task_id: ${params.task_id}.`)
-      }
-
-      const wantsBlock = params.block === true && live.status === 'running'
-      if (wantsBlock) {
-        const timeoutMs = clampTimeout(params.timeout_ms)
-        await raceWithTimeout(live.awaitCompletion(), timeoutMs)
-      }
-
       const snap = liveRegistry.snapshot(params.task_id, now())
       if (snap === undefined) {
         return errorResult(`Unknown task_id: ${params.task_id}.`)
       }
       return renderSnapshot(snap)
     },
-  })
-}
-
-function clampTimeout(value: number | undefined): number {
-  if (value === undefined) return DEFAULT_TIMEOUT_MS
-  return Math.min(Math.max(1, Math.floor(value)), MAX_TIMEOUT_MS)
-}
-
-async function raceWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | undefined> {
-  return new Promise<T | undefined>((resolve) => {
-    const timer = setTimeout(() => resolve(undefined), timeoutMs)
-    promise.then(
-      (value) => {
-        clearTimeout(timer)
-        resolve(value)
-      },
-      () => {
-        clearTimeout(timer)
-        resolve(undefined)
-      },
-    )
   })
 }
 


### PR DESCRIPTION
## What this PR does

Removes the `block` and `timeout_ms` parameters from `subagent_output` and deletes the supporting machinery: `clampTimeout`, `raceWithTimeout`, the `wantsBlock` branch in `execute`, and `awaitCompletion` on the `LiveSubagent` type. The tool now always returns immediately with a snapshot.

## The problem

The completion-push path has been fully wired for some time. When a backgrounded subagent finishes, `spawn-subagent.ts:137-154` publishes a `subagent.completed` broadcast on the Stream. Both routers inject a `<system-reminder>` into the parent's prompt queue:

- TUI path (`server/index.ts:808-821`) — `routeSubagentCompletionReminder` matches `parentSessionId` and pushes the reminder with `delivery: 'interrupt'` when the parent is idle so it wakes immediately.
- Channels path (`channels/subagent-completion-bridge.ts` + `router.ts:1989-2026`) — `injectSubagentCompletionReminder` pushes onto `live.pendingSystemReminders` and triggers `drain()`.

The system prompt already encoded the contract: end the turn after spawning; the system delivers the reminder; fetch once. But `block: true` was a tool-shape exit from that contract — and models used it. A typical bad call:

```
subagent_output({ task_id: "bg_xxx", block: true, timeout_ms: 180000 })
```

Backgrounded spawns held the conversation for up to 5 minutes per call waiting for something the runtime was about to push for free. The model's behavior contradicted its own system prompt; the tool surface allowed it, so it happened.

## Why removing the params is safe

The push mechanism is the correct path and it already works. Agents that already followed the prompt — spawn → end turn → wake on reminder → fetch once — see zero behavioral change. Agents that were holding up conversations with `block: true` now must end the turn instead, which is what the system prompt has required since the push mechanism shipped.

Closing the hatch at the tool schema is cheaper than prompt-tightening (models can reason around prose) or a new tool-level guard (adds complexity for a case that should not exist).

## The fix

**Commit 1 (`05f8534`) — param/type/test changes**

Four files change together; typecheck fails if any is missing.

- `src/agent/tools/subagent-output.ts` — drops `block` and `timeout_ms` from the input schema, drops the `clampTimeout` and `raceWithTimeout` helpers (sole caller was the deleted block branch), drops the `wantsBlock` branch. Tool description rewritten to name the push contract explicitly: "Returns immediately with a snapshot — never blocks. For backgrounded spawns, end your turn after spawning and wait for the completion `<system-reminder>`; then call this once to fetch the result."
- `src/agent/live-subagents.ts` — drops `awaitCompletion` from the `LiveSubagent` type. Its only consumer was the block branch. `SubagentCompletion` itself stays — `recordCompletion` and the spawn-side shape converter still use it.
- `src/agent/tools/spawn-subagent.ts` — drops the `awaitCompletion` field on the `register()` call. The `completion.then(...)` callback that drives `recordCompletion` AND publishes the `subagent.completed` broadcast is untouched — that is the actual push mechanism.
- Tests: the `block:true` describe block in `subagent-output.test.ts` (3 tests) collapses to a single "never blocks" test asserting the tool returns a `running` snapshot immediately when the subagent is still alive. `awaitCompletion` fixture lines removed from `subagent-cancel.test.ts` and `live-subagents.test.ts` where they were only present to satisfy the now-deleted type field.

**Commit 2 (`99285b2`) — prompt copy refresh**

Kept separate so the schema/type delta in commit 1 is reviewable as pure deletion.

- `src/agent/system-prompt.ts` — three call-sites updated. Research fan-out paragraph names the "always returns immediately" contract. Status-query example simplified from `subagent_output({ task_id, block: false })` to `subagent_output({ task_id })`. Anti-pattern bullet rephrased: "Don't call `subagent_output` in a loop waiting for completion; end your response and the reminder will wake you, then fetch the result once."

## Tests

```
bun run typecheck   clean
bun run lint        41 pre-existing warnings (unrelated); 0 errors; 0 warnings in changed files
bun run format      clean
bun test            5296/5296 pass
```

## Diff stats

```
src/agent/live-subagents.test.ts        |  1 -
src/agent/live-subagents.ts             |  1 -
src/agent/system-prompt.ts              |  6 +--
src/agent/tools/spawn-subagent.ts       |  1 -
src/agent/tools/subagent-cancel.test.ts |  1 -
src/agent/tools/subagent-output.test.ts | 83 +++------------------------------
src/agent/tools/subagent-output.ts      | 54 ++-------------------
7 files changed, 13 insertions(+), 134 deletions(-)
```