### PR TITLE
role-claim: accept claims from any chat, grant platform-wide author rule

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4295,23 +4295,32 @@ describe('ChannelRouter role-claim bypass', () => {
     expect(router.liveCount()).toBe(0)
   })
 
-  test('non-DM with claim code → handler NOT invoked, falls through to gate (denied)', async () => {
+  test('non-DM (group/channel) with claim code → handler IS invoked, reply sent, no session created, gate bypassed', async () => {
     const dir = await tempDir()
+    const sent: SentMsg[] = []
     let calls = 0
-    const claimHandler: ClaimHandler = async () => {
+    const claimHandler: ClaimHandler = async (input) => {
       calls++
-      return { kind: 'consumed', reply: 'x' }
+      expect(input.isDm).toBe(false)
+      expect(input.text).toContain('claim-')
+      return { kind: 'consumed', reply: 'Welcome owner!' }
     }
     const { router, sessions } = makeRouter(dir, {
       permissions: denyAllPermissions,
       claimHandler,
     })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ adapter: msg.adapter, chat: msg.chat, text: msg.text })
+      return { ok: true }
+    })
 
     await router.route(inbound({ isDm: false, text: 'claim-AAAA-BBBB' }))
     await new Promise((r) => setTimeout(r, 10))
 
-    expect(calls).toBe(0)
+    expect(calls).toBe(1)
+    expect(sent).toEqual([{ adapter: 'discord-bot', chat: 'c1', text: 'Welcome owner!' }])
     expect(sessions).toHaveLength(0)
+    expect(router.liveCount()).toBe(0)
   })
 
   test('DM without a claim code → handler NOT invoked, falls through to gate (denied)', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1340,10 +1340,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
     // Role-claim intercept runs BEFORE the channel.respond gate so the
     // operator can bootstrap permissions on a fresh agent that has no
-    // role match rules yet. Cheap pre-check: only DMs whose text contains
-    // a `claim-` prefix can be claim attempts, and only when a handler
+    // role match rules yet. Cheap pre-check: any inbound whose text
+    // contains a `claim-` prefix is a candidate, and only when a handler
     // is registered. Everything else falls straight through to the gate.
-    if (claimHandler !== undefined && event.isDm && extractClaimCode(event.text) !== null) {
+    // Claims are accepted from any chat (DM, group, thread) because the
+    // resulting match rule is platform-wide + author-scoped — see
+    // src/role-claim/match-rule.ts.
+    if (claimHandler !== undefined && extractClaimCode(event.text) !== null) {
       const outcome = await claimHandler({
         adapter: event.adapter,
         workspace: event.workspace,

--- a/src/cli/role.ts
+++ b/src/cli/role.ts
@@ -11,7 +11,7 @@ const claimSub = defineCommand({
   meta: {
     name: 'claim',
     description:
-      'claim a channel identity (Slack/Discord/etc.) for a role on this agent. Sends a code via the host CLI; you DM that code back to the bot to prove control of the channel account.',
+      'claim a channel identity (Slack/Discord/etc.) for a role on this agent. Sends a code via the host CLI; you send that code back to the bot from any chat (DM, group, channel) to prove control of the channel account. The resulting match rule grants the role to your author identity across every chat on that platform.',
   },
   args: {
     as: {
@@ -57,7 +57,7 @@ const claimSub = defineCommand({
         s.stop('Ready.')
         const expiresInSec = Math.max(0, Math.round((payload.expiresAt - Date.now()) / 1000))
         const lines = [
-          `Send this message to your bot as a DM:`,
+          `Send this message to your bot from any chat (DM, group, or channel):`,
           '',
           `  ${c.bold(payload.code)}`,
           '',

--- a/src/role-claim/code.ts
+++ b/src/role-claim/code.ts
@@ -1,17 +1,17 @@
 import { randomBytes } from 'node:crypto'
 
 // Role-claim codes are short, human-typeable tokens the operator sends from
-// their host CLI to the bot via a channel DM to prove ownership of that
-// channel identity. Shape: `claim-XXXX-YYYY` where each block is 4 chars
-// from a Crockford-style base32 alphabet (0-9 + A-Z minus I, L, O, U to
-// dodge OCR-confusable / profane shapes). 8 chars * 5 bits = 40 bits of
-// entropy, which is overkill for a TTL'd in-memory window but cheap to
-// display and dictate over voice.
+// their host CLI to the bot in any chat (DM, group, channel) to prove
+// ownership of that channel identity. Shape: `claim-XXXX-YYYY` where each
+// block is 4 chars from a Crockford-style base32 alphabet (0-9 + A-Z minus
+// I, L, O, U to dodge OCR-confusable / profane shapes). 8 chars * 5 bits =
+// 40 bits of entropy, which is overkill for a TTL'd in-memory window but
+// cheap to display and dictate over voice.
 //
 // The `claim-` prefix lets the channel router recognize potential claim
-// attempts in a DM body without scanning the whole text for hex blocks,
-// and distinguishes claim DMs from normal first-message text like "hi"
-// which would otherwise need a regex of its own to disambiguate.
+// attempts in inbound text without scanning the whole body for hex blocks,
+// and distinguishes claim messages from normal first-message text like
+// "hi" which would otherwise need a regex of its own to disambiguate.
 
 export const CLAIM_CODE_PREFIX = 'claim-'
 

--- a/src/role-claim/controller.test.ts
+++ b/src/role-claim/controller.test.ts
@@ -60,13 +60,13 @@ describe('ClaimController', () => {
     })
 
     expect(outcome.kind).toBe('consumed')
-    expect(grants).toEqual([{ role: 'owner', rule: 'slack:T0123 author:U_ME' }])
+    expect(grants).toEqual([{ role: 'owner', rule: 'slack:* author:U_ME' }])
     expect(replaceArg).toBe(provided)
     expect(events).toHaveLength(1)
     expect(events[0]!.kind).toBe('completed')
     if (events[0]!.kind === 'completed') {
       expect(events[0]!.role).toBe('owner')
-      expect(events[0]!.matchRule).toBe('slack:T0123 author:U_ME')
+      expect(events[0]!.matchRule).toBe('slack:* author:U_ME')
       expect(events[0]!.authorId).toBe('U_ME')
     }
   })

--- a/src/role-claim/controller.ts
+++ b/src/role-claim/controller.ts
@@ -10,8 +10,9 @@ import { createPendingClaimRegistry, type PendingClaim, type PendingClaimRegistr
 //
 //   1. The host CLI (typeclaw role claim) opens a WS and sends `claim_start`.
 //   2. The WS server forwards that to controller.startClaim().
-//   3. The channel router's claimHandler (also wired here) intercepts DMs
-//      bearing the code and calls controller.tryConsumeInbound().
+//   3. The channel router's claimHandler (also wired here) intercepts any
+//      inbound bearing the code (DM, group, or channel) and calls
+//      controller.tryConsumeInbound().
 //   4. On consume, the controller writes to typeclaw.json#roles.<role>.match
 //      via grantRole, then reloads the live PermissionService so the new
 //      match rule takes effect without a container restart.

--- a/src/role-claim/match-rule.ts
+++ b/src/role-claim/match-rule.ts
@@ -1,15 +1,19 @@
 // Builds a canonical match-rule DSL string from an inbound channel origin,
-// for the role table. Output shapes:
+// for the role table. Output shape is always platform-wide + author:
 //
-//   slack:T0123 author:U_ALICE
-//   discord:9999 author:U_ALICE
-//   telegram:42 author:U_ALICE
-//   kakao:dm/<chatId> author:<authorId>
+//   slack:* author:<authorId>
+//   discord:* author:<authorId>
+//   telegram:* author:<authorId>
+//   kakao:* author:<authorId>
 //
-// The author qualifier is always emitted so a claim grants the specific
-// human, not the whole workspace. To grant the whole workspace, the
-// operator edits typeclaw.json by hand or runs a future `typeclaw role grant`
-// without --claim.
+// "Platform-wide" means every chat the adapter sees on that platform —
+// DMs, group chats, and threads alike — gated by the author qualifier so
+// only this specific human is matched. The intent is: once an operator
+// proves they control a channel identity (by sending a code to the bot),
+// they keep their role wherever they speak from on the same platform. To
+// scope tighter (e.g. one workspace, one chat), the operator edits
+// typeclaw.json by hand; the claim flow is deliberately broad because
+// re-claiming on every new chat would be tedious for the common case.
 
 import type { ChannelKey } from '@/channels/types'
 
@@ -31,14 +35,5 @@ const ADAPTER_TO_PLATFORM: Record<ChannelKey['adapter'], 'slack' | 'discord' | '
 
 export function formatClaimMatchRule(origin: PartialChannelOrigin): string {
   const platform = ADAPTER_TO_PLATFORM[origin.adapter]
-  const authorQual = ` author:${origin.authorId}`
-  if (origin.adapter === 'kakaotalk') {
-    // Kakao has no workspace; routes use dm/group/open buckets. We can't
-    // know which bucket from a partial origin alone (adapter-side classifies
-    // it), so claim flows are restricted to DM and we emit the specific
-    // chat-id form so the rule grants only this 1:1 conversation, not every
-    // DM the agent is in.
-    return `${platform}:dm/${origin.chat}${authorQual}`
-  }
-  return `${platform}:${origin.workspace}${authorQual}`
+  return `${platform}:* author:${origin.authorId}`
 }

--- a/src/role-claim/pending.test.ts
+++ b/src/role-claim/pending.test.ts
@@ -41,7 +41,7 @@ describe('PendingClaimRegistry', () => {
       kind: 'consumed',
       code: 'claim-AAAA-BBBB',
       role: 'owner',
-      matchRule: 'slack:T0123 author:U_ALICE',
+      matchRule: 'slack:* author:U_ALICE',
       origin: aliceOnSlack,
     })
     expect(reg.size()).toBe(0)
@@ -146,27 +146,27 @@ describe('PendingClaimRegistry', () => {
 })
 
 describe('formatClaimMatchRule', () => {
-  test('slack uses workspace + author', () => {
-    expect(formatClaimMatchRule(aliceOnSlack)).toBe('slack:T0123 author:U_ALICE')
+  test('slack: platform-wide wildcard + author', () => {
+    expect(formatClaimMatchRule(aliceOnSlack)).toBe('slack:* author:U_ALICE')
   })
 
-  test('discord uses guild + author', () => {
-    expect(formatClaimMatchRule(bobOnDiscord)).toBe('discord:9999 author:U_BOB')
+  test('discord: platform-wide wildcard + author', () => {
+    expect(formatClaimMatchRule(bobOnDiscord)).toBe('discord:* author:U_BOB')
   })
 
-  test('kakao uses dm/<chat> bucket form', () => {
+  test('kakao: platform-wide wildcard + author (works for DM, group, and open chats alike)', () => {
     expect(
       formatClaimMatchRule({
         adapter: 'kakaotalk',
         workspace: '',
         chat: '42',
-        isDm: true,
+        isDm: false,
         authorId: 'kakao_user_x',
       }),
-    ).toBe('kakao:dm/42 author:kakao_user_x')
+    ).toBe('kakao:* author:kakao_user_x')
   })
 
-  test('telegram uses chat workspace + author', () => {
+  test('telegram: platform-wide wildcard + author', () => {
     expect(
       formatClaimMatchRule({
         adapter: 'telegram-bot',
@@ -175,6 +175,18 @@ describe('formatClaimMatchRule', () => {
         isDm: true,
         authorId: 'tg_user',
       }),
-    ).toBe('telegram:42 author:tg_user')
+    ).toBe('telegram:* author:tg_user')
+  })
+
+  test('claim from a non-DM context produces the same platform-wide rule', () => {
+    expect(
+      formatClaimMatchRule({
+        adapter: 'slack-bot',
+        workspace: 'T0123',
+        chat: 'C0GENERAL',
+        isDm: false,
+        authorId: 'U_ALICE',
+      }),
+    ).toBe('slack:* author:U_ALICE')
   })
 })

--- a/src/role-claim/pending.ts
+++ b/src/role-claim/pending.ts
@@ -21,8 +21,8 @@ export type PendingClaimRegistry = {
   cancel: (code: string) => boolean
   current: () => PendingClaim | null
   // Snapshot of consumption result without actually committing the grant.
-  // The router calls this on every DM-shaped inbound; the grant only fires
-  // when the result is 'consumed'.
+  // The router calls this on every claim-code-bearing inbound; the grant
+  // only fires when the result is 'consumed'.
   tryConsume: (
     code: string,
     origin: PartialChannelOrigin,


### PR DESCRIPTION
## What this PR does

Loosens the role-claim flow in two coupled ways:

1. The channel router now intercepts any inbound bearing a claim code, regardless of whether the message is a DM. Previously only DMs were inspected.
2. `formatClaimMatchRule` now emits a platform-wide rule rather than a workspace-pinned one.

## The problem

**DM-only gate**: Operators deploying the bot exclusively in group channels — or on platforms where the bot doesn't accept DMs — had no path to complete a role claim. The claim-intercept branch was gated on `event.isDm`, so claim codes sent from group chats were silently dropped even after the operator had already broadcast the code.

**Workspace-pinned grants**: After a successful claim, the emitted match rule was locked to one workspace coordinate. For example: `slack:T0123 author:U_ALICE`. Speaking from a second workspace, guild, or KakaoTalk group would resolve the operator to guest, forcing a repeat of the claim dance even though they had already authenticated. The expected mental model is "this is me across this platform," not "this is me in this specific workspace."

## The fix

**Router** (`src/channels/router.ts`):
Drop the `event.isDm` precondition on the claim intercept. Any inbound containing a valid claim code now reaches the handler.

**Match-rule formatter** (`src/role-claim/match-rule.ts`):
Emit a platform-wide rule of the form `<platform>:* author:<id>` for every adapter: slack, discord, telegram, kakao. The workspace/guild/group coordinate is dropped. Because the author ID is always present, broadening from one workspace to one platform does not lower the security bar.

**CLI copy** (`src/cli/role.ts`):
Description and spinner text updated — "DM the code" → "send the code from any chat".

**Stale wording** — inline comments in code.ts, controller.ts, and pending.ts under `src/role-claim/` updated to match the new behavior.

## Security note

The `rolePromotion` guard (high-tier) is unchanged.
Grants go through `grantRole()` and are written to the roles config.
The grant is gated by an operator-issued pairing code from the host CLI — the agent cannot start a claim, only consume one whose code the operator already broadcast.
Changing the resulting match rule's scope from "this workspace + this author" to "this platform + this author" does not bypass any guard.

## Tests

| File | Change |
|---|---|
| `src/role-claim/pending.test.ts` | Formatter expectations updated to the new platform-wide shape; new test covering non-DM claim contexts. |
| `src/role-claim/controller.test.ts` | Happy-path asserted match rule updated to the platform-wide form. |
| `src/channels/router.test.ts` | "non-DM with claim code → handler NOT invoked" inverted: handler IS invoked, reply sent, no session created. |

## Pre-commit verification

| Check | Result |
|---|---|
| `bun run typecheck` | Clean |
| `bun run lint` | 0 errors (60 pre-existing warnings, unrelated to this PR) |
| `bun run format:check` | Clean |
| `bun run test` | 5350/5350 pass |

## Diff stats

```
 src/channels/router.test.ts       |  17 +-
 src/channels/router.ts            |   9 +-
 src/cli/role.ts                   |   4 +-
 src/role-claim/code.ts            |  18 +-
 src/role-claim/controller.test.ts |   4 +-
 src/role-claim/controller.ts      |   5 +-
 src/role-claim/match-rule.ts      |  33 ++--
 src/role-claim/pending.test.ts    |  32 ++--
 src/role-claim/pending.ts         |   4 +-
 9 files changed, ~70 insertions(+), ~56 deletions(-)
```