### PR TITLE
cron list: short-circuit docker discovery when running inside the container

### DIFF
--- a/src/cli/cron.ts
+++ b/src/cli/cron.ts
@@ -38,7 +38,7 @@ const listSub = defineCommand({
     }
 
     let url: string | undefined = args.url
-    if (url === undefined) {
+    if (url === undefined && process.env.TYPECLAW_CONTAINER_NAME === undefined) {
       const precheck = await requireContainerRunning({ cwd })
       if (!precheck.ok) {
         console.error(errorLine(precheck.reason))

--- a/src/cron/bridge.test.ts
+++ b/src/cron/bridge.test.ts
@@ -2,9 +2,10 @@ import { afterEach, describe, expect, test } from 'bun:test'
 
 import type { Server } from 'bun'
 
+import { CONTAINER_PORT } from '@/container'
 import type { ClientMessage, CronListEntryPayload, ServerMessage } from '@/shared'
 
-import { fetchCronList } from './bridge'
+import { fetchCronList, resolveInContainerUrl } from './bridge'
 
 let server: Server<undefined> | null = null
 
@@ -113,5 +114,61 @@ describe('cron list bridge', () => {
 
     const result = await fetchCronList({ cwd: process.cwd(), url: `ws://127.0.0.1:${port}`, timeoutMs: 300 })
     expect(result.kind).toBe('timeout')
+  })
+})
+
+describe('resolveInContainerUrl', () => {
+  test('returns null when TYPECLAW_CONTAINER_NAME is unset (host stage)', () => {
+    expect(resolveInContainerUrl({})).toBeNull()
+    expect(resolveInContainerUrl({ TYPECLAW_TUI_TOKEN: 'tok' })).toBeNull()
+  })
+
+  test('builds a loopback URL on CONTAINER_PORT when running inside the container', () => {
+    const url = resolveInContainerUrl({ TYPECLAW_CONTAINER_NAME: 'agent', TYPECLAW_TUI_TOKEN: 'tok' })
+    expect(url).toBe(`ws://127.0.0.1:${CONTAINER_PORT}/?token=tok`)
+  })
+
+  test('omits the token query when TYPECLAW_TUI_TOKEN is unset or empty', () => {
+    expect(resolveInContainerUrl({ TYPECLAW_CONTAINER_NAME: 'agent' })).toBe(`ws://127.0.0.1:${CONTAINER_PORT}/`)
+    expect(resolveInContainerUrl({ TYPECLAW_CONTAINER_NAME: 'agent', TYPECLAW_TUI_TOKEN: '' })).toBe(
+      `ws://127.0.0.1:${CONTAINER_PORT}/`,
+    )
+  })
+})
+
+describe('fetchCronList in-container path', () => {
+  test('uses the env-derived in-container URL when no --url is given', async () => {
+    // The mutation check: if dial() ignored the injected env and fell
+    // back to resolveHostPort (the broken pre-fix behavior), it would
+    // try to shell out to docker — which on this host returns the
+    // configured port from typeclaw.json, NOT 127.0.0.1:CONTAINER_PORT.
+    // We can't bind on CONTAINER_PORT in test (collisions), so we assert
+    // that an in-container `fetchCronList` call dials CONTAINER_PORT
+    // specifically by inspecting the unreachable error.
+    const result = await fetchCronList({
+      cwd: process.cwd(),
+      timeoutMs: 200,
+      env: { TYPECLAW_CONTAINER_NAME: 'agent', TYPECLAW_TUI_TOKEN: 'secret-token-value' },
+    })
+    expect(result.kind).toBe('unreachable')
+    if (result.kind !== 'unreachable') throw new Error('expected unreachable result')
+    expect(result.reason).toContain(`127.0.0.1:${CONTAINER_PORT}`)
+    expect(result.reason).toContain('token=%3Credacted%3E')
+    expect(result.reason).not.toContain('secret-token-value')
+  })
+
+  test('explicit --url wins over the env-derived in-container URL', async () => {
+    const port = startFakeAgent((msg) => {
+      if (msg.type !== 'cron_list') return null
+      return { type: 'cron_list_result', requestId: msg.requestId, result: { ok: true, jobs: [], nowMs: 0 } }
+    })
+
+    const result = await fetchCronList({
+      cwd: process.cwd(),
+      url: `ws://127.0.0.1:${port}`,
+      timeoutMs: HAPPY_PATH_TIMEOUT_MS,
+      env: { TYPECLAW_CONTAINER_NAME: 'agent', TYPECLAW_TUI_TOKEN: 'tok' },
+    })
+    expect(result.kind).toBe('ok')
   })
 })

--- a/src/cron/bridge.ts
+++ b/src/cron/bridge.ts
@@ -1,10 +1,14 @@
-import { resolveHostPort, resolveTuiToken } from '@/container'
+import { CONTAINER_PORT, resolveHostPort, resolveTuiToken } from '@/container'
 import type { ClientMessage, CronListEntryPayload, ServerMessage } from '@/shared'
 
 export type CronListBridgeOptions = {
   cwd: string
   url?: string
   timeoutMs?: number
+  // Injected for tests so the in-container short-circuit can be exercised
+  // without polluting process.env. Production callers omit this and the
+  // bridge reads from process.env directly.
+  env?: NodeJS.ProcessEnv
 }
 
 export type CronListBridgeResult =
@@ -34,9 +38,7 @@ async function dial(opts: CronListBridgeOptions): Promise<DialResult> {
   let url = opts.url
   if (url === undefined) {
     try {
-      const port = await resolveHostPort({ cwd: opts.cwd })
-      const token = await resolveTuiToken({ cwd: opts.cwd })
-      url = buildBridgeUrl(port, token)
+      url = resolveInContainerUrl(opts.env ?? process.env) ?? (await resolveHostUrl(opts.cwd))
     } catch (err) {
       return { kind: 'unreachable', reason: err instanceof Error ? err.message : String(err) }
     }
@@ -113,6 +115,25 @@ async function awaitReply(ws: WebSocket, timeoutMs: number, requestId: string): 
     }
     ws.addEventListener('message', onMessage)
   })
+}
+
+// In-container short-circuit: when typeclaw runs `docker run`, it sets
+// TYPECLAW_CONTAINER_NAME (always) and TYPECLAW_TUI_TOKEN (when configured).
+// Inside the container, docker is not on $PATH, so the host-side discovery
+// path (resolveHostPort/resolveTuiToken — both shell out to `docker`) fails
+// with "docker: command not found". We don't need docker here: the agent's
+// WS server is listening on CONTAINER_PORT on the container's loopback, and
+// the token is already in our env. Skip docker entirely and dial directly.
+export function resolveInContainerUrl(env: NodeJS.ProcessEnv): string | null {
+  if (env.TYPECLAW_CONTAINER_NAME === undefined) return null
+  const token = env.TYPECLAW_TUI_TOKEN ?? ''
+  return buildBridgeUrl(CONTAINER_PORT, token !== '' ? token : null)
+}
+
+async function resolveHostUrl(cwd: string): Promise<string> {
+  const port = await resolveHostPort({ cwd })
+  const token = await resolveTuiToken({ cwd })
+  return buildBridgeUrl(port, token)
 }
 
 function buildBridgeUrl(port: number, token: string | null): string {


### PR DESCRIPTION
## Summary

`typeclaw cron list` is supposed to be callable from anywhere — host stage or container stage — to show the merged user + plugin job view. It works on the host, but inside the container the command fails before it can dial the agent's WS server:

```
1 ⨯ Container coder not found. Run `typeclaw start` first.
```

Same container the agent is running in. The agent IS started.

Symptom matches the user-reported behavior:

> `typeclaw cron list로 플러그인 포함 전체 스케줄까지 보려 했는데, 현재 컨테이너 안에는 docker가 없어 merged view 조회는 실패했어요.`

## Root cause

Two layers shell out to `docker`, and `docker` is not on `$PATH` inside the container:

1. **`cli/cron.ts`** runs `requireContainerRunning({ cwd })` as a precheck → `docker inspect`.
2. **`cron/bridge.ts#dial`** resolves the WS URL via `resolveHostPort` (→ `docker port`) and `resolveTuiToken` (→ `docker inspect`).

Both are the right design for the host stage (Docker is the source of truth for "what host port is this agent on?"), but they treat the running container as the canonical caller. From inside the container the answer is much simpler and doesn't need Docker at all: the agent's WS server is listening on the fixed `CONTAINER_PORT` (8973) on loopback, and `docker run` already injected `TYPECLAW_TUI_TOKEN` into the env.

## Fix

Short-circuit both layers when running inside the container, keyed on `process.env.TYPECLAW_CONTAINER_NAME` (the env var the host CLI sets on `docker run`, used the same way by `src/run/index.ts` to decide whether to enable the `restart` tool):

- **`src/cron/bridge.ts`** — new `resolveInContainerUrl(env)` helper. When `TYPECLAW_CONTAINER_NAME` is set, builds `ws://127.0.0.1:CONTAINER_PORT?token=<TYPECLAW_TUI_TOKEN>` directly from env. Falls back to the existing host-stage docker discovery (`resolveHostPort` + `resolveTuiToken`) otherwise. Threads through an optional `env` field on `CronListBridgeOptions` so tests can exercise the path without polluting `process.env`.
- **`src/cli/cron.ts`** — skip the `requireContainerRunning` precheck when the env says we're inside the container. The bridge's own unreachable-handling still reports a clear error if the WS server happens to be down.

`--url` continues to win over both paths, so power users can still target a remote agent.

## Why env-keyed, not "is docker on `$PATH`"

The env var is the contract the host already establishes when it `docker run`s us. Probing `$PATH` would (a) need to handle a tri-state ("docker missing", "docker present but daemon down", "docker present and works"), (b) couple the bridge to an implementation detail of the host (some operators may install docker inside a container for nested use), (c) make the in-container path indistinguishable from a misconfigured host machine. The env-var check is what `src/run/index.ts` already uses to gate the `restart` tool, so this PR follows the same convention.

## Tests

| File | New cases | What's covered |
|---|---|---|
| `src/cron/bridge.test.ts` | 5 | `resolveInContainerUrl`: null when env unset, builds URL with token, omits token when unset/empty. End-to-end `fetchCronList`: env-derived URL dials `127.0.0.1:CONTAINER_PORT` with redacted token, explicit `--url` still wins. |

**Mutation check (per AGENTS.md §1):** removing the in-container call in `dial()` makes the new `fetchCronList in-container path > uses the env-derived in-container URL when no --url is given` test fail — verified.

`bun run typecheck` / `bun run lint` (0 errors, 60 pre-existing warnings) / `bun run format` / `bun run test` (5355 pass, 0 fail) all green.

## Out of scope

`typeclaw reload`, `typeclaw role claim`, `typeclaw inspect`, `typeclaw tui` have the same docker-discovery shape in their default-URL paths. Fixing them is a sibling problem with the same solution but lives outside this PR's scope. A follow-up could hoist the `resolveInContainerUrl` / `resolveHostUrl` pair into `src/container/` as a shared helper for every WS-client subcommand.