### PR TITLE
portbroker: close re-register swap race that emitted token-mismatch broadcasts

### DIFF
--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -109,7 +109,7 @@ describe('startDaemon', () => {
 
   test('status surfaces forwardedPorts reported by the portbroker callback', async () => {
     const portbroker: PortbrokerCallbacks = {
-      start: () => {},
+      start: async () => {},
       stop: async () => {},
       forwardedPorts: (name) => (name === 'coder' ? [3000, 5173] : []),
     }
@@ -628,14 +628,15 @@ describe('startDaemon', () => {
   })
 
   test('boot-time restore tolerates corrupted registration files', async () => {
-    daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000 })
+    const alive = new Set(['good'])
+    daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000 })
     await send({ kind: 'register', containerName: 'good', cwd: '/agent/good' })
     await daemon.stop()
 
     await writeFile(join(registrationsDir(), 'broken.json'), '{ this is not json')
     await writeFile(join(registrationsDir(), 'mismatch.json'), JSON.stringify({ containerName: 'other', cwd: '/x' }))
 
-    daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000 })
+    daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000 })
 
     const list = await send({ kind: 'list' })
     expect(list.ok).toBe(true)
@@ -643,17 +644,18 @@ describe('startDaemon', () => {
     expect((list.result as ListResult).registrations.map((r) => r.containerName).sort()).toEqual(['good'])
   })
 
-  test('boot-time restore revives portbroker for persisted registrations with portbroker fields', async () => {
+  test('boot-time restore revives portbroker for persisted registrations whose container is still alive', async () => {
     const startCalls: PortbrokerStartInput[] = []
     const portbroker: PortbrokerCallbacks = {
-      start: (input) => {
+      start: async (input) => {
         startCalls.push(input)
       },
       stop: async () => {},
       forwardedPorts: () => [],
     }
+    const alive = new Set(['with-broker'])
 
-    const d1 = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, portbroker })
+    const d1 = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000, portbroker })
     await send({
       kind: 'register',
       containerName: 'with-broker',
@@ -666,13 +668,87 @@ describe('startDaemon', () => {
     await d1.stop()
 
     startCalls.length = 0
-    daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, portbroker })
+    daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000, portbroker })
 
     expect(startCalls).toHaveLength(1)
     expect(startCalls[0]?.containerName).toBe('with-broker')
     expect(startCalls[0]?.cwd).toBe('/agent/with-broker')
     expect(startCalls[0]?.wsHostPort).toBe(54321)
     expect(startCalls[0]?.brokerToken).toBe('btok')
+  })
+
+  test('boot-time restore skips persisted registrations whose container is gone, and unlinks the leftover file', async () => {
+    const startCalls: PortbrokerStartInput[] = []
+    const portbroker: PortbrokerCallbacks = {
+      start: async (input) => {
+        startCalls.push(input)
+      },
+      stop: async () => {},
+      forwardedPorts: () => [],
+    }
+
+    const d1 = await startDaemon({
+      exec: fakeExec(new Set(['ghost'])),
+      gcIntervalMs: 1_000_000,
+      portbroker,
+    })
+    await send({
+      kind: 'register',
+      containerName: 'ghost',
+      cwd: '/agent/ghost',
+      restartToken: 't',
+      wsHostPort: 54321,
+      portForward: { allow: '*' },
+      brokerToken: 'btok-old',
+    })
+    await d1.stop()
+
+    const filePath = registrationFilePath('ghost')
+    expect(existsSync(filePath)).toBe(true)
+
+    startCalls.length = 0
+    daemon = await startDaemon({ exec: fakeExec(new Set()), gcIntervalMs: 1_000_000, portbroker })
+
+    expect(startCalls).toHaveLength(0)
+    expect(existsSync(filePath)).toBe(false)
+
+    const list = await send({ kind: 'list' })
+    expect(list.ok).toBe(true)
+    if (!list.ok) return
+    expect((list.result as ListResult).registrations).toEqual([])
+  })
+
+  test('boot-time restore tolerates docker probe failures: unknown status still applies the registration', async () => {
+    const startCalls: PortbrokerStartInput[] = []
+    const portbroker: PortbrokerCallbacks = {
+      start: async (input) => {
+        startCalls.push(input)
+      },
+      stop: async () => {},
+      forwardedPorts: () => [],
+    }
+    const flakyExec: DockerExec = async (args) => {
+      if (args[0] === 'ps') return { exitCode: 1, stdout: '', stderr: 'docker daemon hiccup' }
+      return { exitCode: 1, stdout: '', stderr: 'unknown command' }
+    }
+
+    const d1 = await startDaemon({ exec: fakeExec(new Set(['flaky'])), gcIntervalMs: 1_000_000, portbroker })
+    await send({
+      kind: 'register',
+      containerName: 'flaky',
+      cwd: '/agent/flaky',
+      restartToken: 't',
+      wsHostPort: 54321,
+      portForward: { allow: '*' },
+      brokerToken: 'btok',
+    })
+    await d1.stop()
+
+    startCalls.length = 0
+    daemon = await startDaemon({ exec: flakyExec, gcIntervalMs: 1_000_000, portbroker })
+
+    expect(startCalls).toHaveLength(1)
+    expect(existsSync(registrationFilePath('flaky'))).toBe(true)
   })
 
   test('register invokes kakaoRenewal.start with the registered container and cwd', async () => {
@@ -726,7 +802,7 @@ describe('startDaemon', () => {
     expect(stopCalls.sort()).toEqual(['a', 'b'])
   })
 
-  test('boot-time restore invokes kakaoRenewal.start for persisted registrations', async () => {
+  test('boot-time restore invokes kakaoRenewal.start for persisted registrations whose container is still alive', async () => {
     const starts: KakaoRenewalStartInput[] = []
     const kakaoRenewal: KakaoRenewalCallbacks = {
       start: (input) => {
@@ -735,13 +811,14 @@ describe('startDaemon', () => {
       stop: async () => {},
       drain: async () => {},
     }
+    const alive = new Set(['persistent-kakao'])
 
-    const d1 = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, kakaoRenewal })
+    const d1 = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000, kakaoRenewal })
     await send({ kind: 'register', containerName: 'persistent-kakao', cwd: '/agent/pk', restartToken: 't' })
     await d1.stop()
 
     starts.length = 0
-    daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, kakaoRenewal })
+    daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000, kakaoRenewal })
 
     expect(starts).toEqual([{ containerName: 'persistent-kakao', cwd: '/agent/pk' }])
   })

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -69,7 +69,7 @@ export type RestartPreflight = (input: {
 }) => Promise<RpcResponse | null>
 
 export type PortbrokerCallbacks = {
-  start: (input: PortbrokerStartInput) => void
+  start: (input: PortbrokerStartInput) => Promise<void>
   stop: (containerName: string, reason: 'deregistered' | 'broker-stopped') => Promise<void>
   // Returns ports the broker is currently exposing on the host for this
   // container. Empty array when the container is unregistered, when the broker
@@ -157,8 +157,10 @@ function isValidRestoredPayload(value: unknown, expectedName: string): value is 
 }
 
 async function restorePersistedRegistrations(
-  apply: (payload: RestoredPayload) => void,
+  apply: (payload: RestoredPayload) => Promise<void>,
   log: (event: DaemonLogEvent | SupervisorLogEvent) => void,
+  probe: (name: string) => Promise<'alive' | 'gone' | 'unknown'>,
+  removeFile: (name: string) => Promise<void>,
 ): Promise<void> {
   let entries: string[]
   try {
@@ -181,7 +183,23 @@ async function restorePersistedRegistrations(
       log({ kind: 'registration-skipped', containerName: expectedName, reason: 'schema mismatch' })
       continue
     }
-    apply(parsed)
+    // Probe before reviving. A registration file for a container that no
+    // longer exists is a leftover from a daemon that died ungracefully
+    // (crash, `kill -9`, OS reboot) before deregister could clean up.
+    // Reviving its broker would create a stale T_old broker that races a
+    // subsequent `register` call's T_new broker — see portbroker-manager.ts
+    // start() for the swap-race description. `unknown` (docker probe call
+    // failed) errs toward restore: the existing GC tick will tear down the
+    // registration if the container is genuinely gone, and we'd rather pay
+    // one swap-race attempt than tear down a live registration on a flaky
+    // `docker ps`.
+    const status = await probe(expectedName)
+    if (status === 'gone') {
+      await removeFile(expectedName)
+      log({ kind: 'registration-skipped', containerName: expectedName, reason: 'container not running' })
+      continue
+    }
+    await apply(parsed)
   }
 }
 
@@ -267,7 +285,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     } catch {}
   }
 
-  const applyRegistration = (payload: RegisterPayload): void => {
+  const applyRegistration = async (payload: RegisterPayload): Promise<void> => {
     const alreadyRegistered = cwds.has(payload.containerName)
     cwds.set(payload.containerName, payload.cwd)
     if (payload.restartToken) restartTokens.set(payload.containerName, payload.restartToken)
@@ -281,7 +299,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       payload.portForward !== undefined &&
       payload.brokerToken !== undefined
     ) {
-      opts.portbroker.start({
+      await opts.portbroker.start({
         containerName: payload.containerName,
         cwd: payload.cwd,
         policy: payload.portForward,
@@ -308,7 +326,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
           reason: `failed to persist registration: ${error instanceof Error ? error.message : String(error)}`,
         }
       }
-      applyRegistration(req)
+      await applyRegistration(req)
       return { ok: true }
     })
   }
@@ -528,12 +546,31 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   httpPort = httpServer.port ?? 0
   log({ kind: 'daemon-http-listening', host: httpHostname, port: httpPort })
 
+  // GC tick distinguishes "container confirmed gone" from "docker call failed":
+  // a `docker ps` blip should not deregister a live container registration, so
+  // we require gcMissesToDeregister consecutive confirmed absences. Boot-time
+  // restore reuses the same probe but with a stricter policy — see
+  // restorePersistedRegistrations.
+  const probeContainerAlive = async (name: string): Promise<'alive' | 'gone' | 'unknown'> => {
+    try {
+      const result = await exec(['ps', '-a', '--filter', `name=^${name}$`, '--format', '{{.Names}}'])
+      if (result.exitCode !== 0) return 'unknown'
+      const names = result.stdout
+        .trim()
+        .split('\n')
+        .filter((s) => s.length > 0)
+      return names.includes(name) ? 'alive' : 'gone'
+    } catch {
+      return 'unknown'
+    }
+  }
+
   // Boot-time restore: replay every persisted registration into the in-memory
   // maps and revive portbroker for it. Runs before Bun.listen so the socket
   // is never accepting RPCs against a half-restored registry. A bad file
   // (parse error, schema mismatch) is logged-and-skipped — one corrupt
   // registration must not gate every other container's recovery.
-  await restorePersistedRegistrations(applyRegistration, log)
+  await restorePersistedRegistrations(applyRegistration, log, probeContainerAlive, removeRegistrationFile)
 
   const listener: UnixSocketListener<ServerState> = Bun.listen<ServerState>({
     unix: path,
@@ -549,23 +586,6 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   // Restrict socket to the owning user; ~/.typeclaw/run is also 0700.
   await chmod(path, 0o600).catch(() => {})
   log({ kind: 'daemon-listening', socket: path })
-
-  // GC tick distinguishes "container confirmed gone" from "docker call failed":
-  // a `docker ps` blip should not deregister a live container registration, so
-  // we require gcMissesToDeregister consecutive confirmed absences.
-  const probeContainerAlive = async (name: string): Promise<'alive' | 'gone' | 'unknown'> => {
-    try {
-      const result = await exec(['ps', '-a', '--filter', `name=^${name}$`, '--format', '{{.Names}}'])
-      if (result.exitCode !== 0) return 'unknown'
-      const names = result.stdout
-        .trim()
-        .split('\n')
-        .filter((s) => s.length > 0)
-      return names.includes(name) ? 'alive' : 'gone'
-    } catch {
-      return 'unknown'
-    }
-  }
 
   const runGc = async (): Promise<void> => {
     for (const name of Array.from(cwds.keys())) {

--- a/src/hostd/portbroker-manager.test.ts
+++ b/src/hostd/portbroker-manager.test.ts
@@ -44,7 +44,7 @@ describe('createPortbrokerManager Tailscale Serve', () => {
       },
     })
 
-    manager.start({
+    await manager.start({
       containerName: 'coder',
       cwd: '/agent/coder',
       policy: { allow: '*' },
@@ -94,7 +94,7 @@ describe('createPortbrokerManager Tailscale Serve', () => {
       },
     })
 
-    manager.start({
+    await manager.start({
       containerName: 'coder',
       cwd: '/agent/coder',
       policy: { allow: [] },
@@ -108,5 +108,74 @@ describe('createPortbrokerManager Tailscale Serve', () => {
 
     expect(startCalls).toBe(1)
     expect(calls).toEqual([])
+  })
+})
+
+describe('createPortbrokerManager re-register swap', () => {
+  // Why this matters: hostd respawn after ungraceful daemon death restores
+  // the leftover registration file (with the OLD broker token T1) and starts
+  // a T1 broker. The container that the file referred to is already gone;
+  // `typeclaw restart` then registers a NEW broker with T2 for the same
+  // container name. If the T1 broker's stop() were fire-and-forget, T1's
+  // connect loop could win the race and send broker-hello:T1 to the brand-new
+  // container whose env carries T2, producing a one-shot
+  // `auth-failed: token mismatch` broadcast.
+  test('start awaits the existing broker stop before creating the replacement', async () => {
+    const events: string[] = []
+    let releaseOldStop: () => void = () => {}
+    const oldStopHeld = new Promise<void>((resolve) => {
+      releaseOldStop = resolve
+    })
+    let nthBroker = 0
+    const manager = createPortbrokerManager({
+      resolveHostPortFor: async () => 12345,
+      createBrokerFor: (): Broker => {
+        nthBroker += 1
+        const which = nthBroker
+        return {
+          start: () => events.push(`broker${which}:start`),
+          stop: async () => {
+            if (which === 1) {
+              events.push(`broker${which}:stop:awaiting`)
+              await oldStopHeld
+              events.push(`broker${which}:stop:done`)
+            } else {
+              events.push(`broker${which}:stop`)
+            }
+          },
+          forwardedPorts: () => [],
+        }
+      },
+    })
+
+    await manager.start({
+      containerName: 'coder',
+      cwd: '/agent/coder',
+      policy: { allow: '*' },
+      wsHostPort: 12345,
+      brokerToken: 'T1',
+      onEvent: () => {},
+      onTailscaleServeEvent: () => {},
+    })
+
+    const secondStart = manager.start({
+      containerName: 'coder',
+      cwd: '/agent/coder',
+      policy: { allow: '*' },
+      wsHostPort: 12345,
+      brokerToken: 'T2',
+      onEvent: () => {},
+      onTailscaleServeEvent: () => {},
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect(events).toEqual(['broker1:start', 'broker1:stop:awaiting'])
+
+    releaseOldStop()
+    await secondStart
+
+    expect(events).toEqual(['broker1:start', 'broker1:stop:awaiting', 'broker1:stop:done', 'broker2:start'])
+
+    await manager.stop('coder', 'deregistered')
   })
 })

--- a/src/hostd/portbroker-manager.ts
+++ b/src/hostd/portbroker-manager.ts
@@ -26,15 +26,31 @@ export function createPortbrokerManager(opts: PortbrokerManagerOptions = {}): Po
   const brokerFactory = opts.createBrokerFor ?? createBroker
 
   return {
-    start(input: PortbrokerStartInput) {
+    // start() awaits the previous broker's stop before constructing the new
+    // one. The fire-and-forget shape this replaced let a stale T_old broker
+    // win the race to send broker-hello against a brand-new container that
+    // expects T_new, producing a one-shot `auth-failed: token mismatch`
+    // broadcast at every re-register that arrived while the old broker was
+    // still mid-stop. The race window was narrow but reproducible across
+    // hostd-respawn-after-ungraceful-death + typeclaw restart, because the
+    // restored T_old broker is alive for the duration of the register RPC.
+    // Awaiting collapses the window to zero — by the time the T_new broker's
+    // first connect() fires, the T_old broker has set stopped=true, cleared
+    // its reconnect timer, and closed its WS.
+    async start(input: PortbrokerStartInput) {
       const existing = brokers.get(input.containerName)
       if (existing) {
-        void existing.stop().catch(() => {})
+        brokers.delete(input.containerName)
+        try {
+          await existing.stop()
+        } catch {}
       }
       const existingTailscale = tailscaleManagers.get(input.containerName)
       if (existingTailscale) {
         tailscaleManagers.delete(input.containerName)
-        void existingTailscale.stopAll().catch(() => {})
+        try {
+          await existingTailscale.stopAll()
+        } catch {}
       }
       const tailscale = createTailscaleServeManager({
         containerName: input.containerName,


### PR DESCRIPTION
## Summary

Hostd's portbroker emits a one-shot `portbroker auth-failed: token mismatch` broadcast at certain `register` boundaries. Reported symptom: container originally started via `typeclaw compose start`, then restarted with single-agent `typeclaw restart`, then `typeclaw reload` shows

```
bcast      portbroker-log {"kind":"portbroker-log","event":{"kind":"auth-failed","reason":"token mismatch"}}
```

The mismatch only fires once and self-heals on subsequent broker reconnects, so port forwarding ends up working — but the broadcast is noise the operator can't explain, and the underlying race is real.

## Root cause

The container's `/portbroker` auth gate (`src/portbroker/container-server.ts:181`) rejects any `broker-hello` whose token doesn't match `process.env.TYPECLAW_HOSTD_BROKER_TOKEN`, which is fixed at container boot. Hostd's broker sends the token it was constructed with, which is fixed at `Broker` creation in `src/hostd/portbroker-manager.ts`. For a mismatch you need two broker instances on the hostd side with different tokens, both alive long enough that the **wrong one** wins the connect race to a brand-new container.

The race window opens when hostd respawns after an ungraceful daemon death (crash, `kill -9`, OS reboot, or version-drift `shutdown` without time to deregister):

1. `typeclaw compose start` registers agent A with token T1. `~/.typeclaw/run/registrations/agentA.json` records T1. Container env carries T1. T1 broker is alive and authenticated.
2. Daemon dies ungracefully. The leftover registration file survives by design — it's the source of truth for the planned-respawn-then-restore case. Container is still running with T1.
3. Container exits or is removed for an unrelated reason. The registration file still says T1.
4. New daemon boots, `restorePersistedRegistrations()` reads T1 from disk and calls `portbroker.start({brokerToken: T1, ...})`. T1 broker starts polling `resolveHostPort()` for a container that no longer exists.
5. `typeclaw restart` runs `start()`, which generates a NEW T2, sends `register` to the new daemon. `handleRegister` writes T2 to the file and calls `applyRegistration(T2)` → `portbroker.start({brokerToken: T2})`. The manager's old-broker stop was fire-and-forget:
   ```ts
   if (existing) {
     void existing.stop().catch(() => {})
   }
   ```
   T2 broker is constructed and started immediately. **Both T1 and T2 brokers are now alive for a tick or two.**
6. `docker run` starts the new container with `TYPECLAW_HOSTD_BROKER_TOKEN=T2`.
7. Whichever broker's `connect()` wins the race authenticates first. If T1 wins, the container receives `broker-hello:T1`, expects T2, emits **`auth-failed: token mismatch`**, closes with `1008 invalid token`. T1's `.stop()` from the fire-and-forget eventually completes, T2 reconnects and authenticates cleanly. The user sees one broadcast and then nothing.

## Fix

Two coordinated changes — belt-and-suspenders, because either one alone would also fix the symptom but for different sides of the race.

### Change 1: `src/hostd/portbroker-manager.ts` — `start` is async and awaits prior stop

```ts
async start(input: PortbrokerStartInput) {
  const existing = brokers.get(input.containerName)
  if (existing) {
    brokers.delete(input.containerName)
    try {
      await existing.stop()
    } catch {}
  }
  ...
}
```

`start` now returns `Promise<void>` instead of `void`. The signature ripples through `PortbrokerCallbacks.start` in `src/hostd/daemon.ts` and `applyRegistration`, both of which become async and `await` the call. The single call site in `handleRegister` already runs inside `runSerially`, so the await is free.

Closes the swap-race window to zero — by the time the T2 broker's first `connect()` fires, the T1 broker has set `stopped=true`, cleared its reconnect timer, and closed its WS.

### Change 2: `src/hostd/daemon.ts` — restore probes container liveness

```ts
const status = await probe(expectedName)
if (status === 'gone') {
  await removeFile(expectedName)
  log({ kind: 'registration-skipped', containerName: expectedName, reason: 'container not running' })
  continue
}
await apply(parsed)
```

The probe reuses `probeContainerAlive` (the same docker-ps wrapper the GC tick uses), with a stricter policy:

- `alive` → restore. Normal planned-respawn case (e.g. version-drift respawn): the daemon was bounced while the container kept running. Same behavior as before.
- `gone` → skip and unlink the leftover file. **This is the bad actor that creates the T1 broker in the first place.** Removing the file also self-heals the registry across future respawns.
- `unknown` (docker probe call failed) → restore. The existing GC tick will tear down the registration if the container is genuinely gone (after `gcMissesToDeregister` consecutive misses), and we'd rather pay one swap-race attempt than tear down every live registration on a flaky `docker ps`.

`probeContainerAlive` is moved up in `startDaemon` so it's defined before `restorePersistedRegistrations` is called. No behavior change for the GC tick.

### Why both changes

Change 2 alone removes the bad actor before it can race — no T1 broker ever exists, so no race. But it relies on `docker ps` reporting the container as `gone`, and the `unknown` branch deliberately preserves the existing GC behavior. Change 1 alone makes the swap deterministic in favor of T2 even when a stale T1 broker IS alive (Change 2's `unknown` branch, or any other code path that re-registers without a container restart). Together they make the symptom unreproducible from any combination of timing and probe outcome.

## Tests

| File | Cases | What's covered |
|---|---|---|
| `src/hostd/portbroker-manager.test.ts` | +1 | `start` awaits the existing broker's stop before calling `broker.start` on the replacement — verified via a held-promise fixture that emits ordered events. Comment block explains the real-world race this regression test guards against. |
| `src/hostd/daemon.test.ts` | +2 | (a) `gone` restore path: registers a container with `alive: {ghost}`, stops the daemon, then restarts with empty alive set — assert no portbroker.start call, registration file unlinked, list empty. (b) `unknown` restore path: simulates `docker ps` failing with exit 1 — assert the registration IS still restored, file remains. |
| `src/hostd/daemon.test.ts` | updated | The existing "boot-time restore revives portbroker" and "boot-time restore invokes kakaoRenewal.start" tests now pass an `alive` set containing the container they expect to be restored, modeling the realistic planned-respawn case. The default empty `fakeExec()` no longer fits because under the new contract it would correctly skip the restore — the test setup needed to catch up with the new semantics. |
| `src/hostd/daemon.test.ts` | updated | "boot-time restore tolerates corrupted registration files": same `alive` set update for the `good` fixture, same reason. |

**Mutation check (per AGENTS.md §1):** removing the `await` in `portbroker-manager.start`'s existing-stop block reverts to fire-and-forget and makes the new ordering test fail. Removing the `gone → skip + unlink` branch in `restorePersistedRegistrations` makes the new "container is gone" test fail with a stray `portbroker.start` call AND a surviving registration file.

Pre-commit (per AGENTS.md):

- `bun run typecheck` — clean
- `bun run lint` — 0 errors, 60 pre-existing warnings (unrelated files like `slack-bot.test.ts`)
- `bun run format` — clean
- `bun run test` — 5356 pass, 0 fail (44 in the touched test files, 3 new)

## Out of scope

- **`daemonHandle.stop()` does not unlink registration files.** This is intentional and documented — the files are the source of truth for planned respawn. Leaving them lets the new daemon reconnect to still-running containers across a graceful `shutdown` RPC. Change 2's probe gate is the right place to filter out the leftovers without breaking the planned case.
- **Per-container brokerToken rotation on every restart.** Even without the swap race, a one-shot rotation makes the system more sensitive to any future "two brokers alive for a tick" path. Stable tokens would erase the class of bug — but that's a larger contract change (the env-var injection at `docker run` time, the AGENTS.md "fresh token on every register" rule, the registration-file schema) and out of scope for a race fix.
- **The fire-and-forget tailscale-manager stop in the same function.** Also changed to await for symmetry; tailscale doesn't have the broker-hello race, but a fire-and-forget tailscale stop could leak `serve` rules across re-register in adversarial timings. Cheap to fix while we're here.