### PR TITLE
inspect: always live-tail, drop --follow toggle

### DIFF
--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -10,7 +10,7 @@ import { cancel, c, errorLine, isCancel } from './ui'
 export const inspectCommand = defineCommand({
   meta: {
     name: 'inspect',
-    description: 'replay a session transcript and tail live activity (host stage)',
+    description: 'observe a session: replay the transcript, then tail live activity (host stage)',
   },
   args: {
     session: {
@@ -32,12 +32,6 @@ export const inspectCommand = defineCommand({
       description: 'emit one JSON event per line; requires an explicit session id',
       default: false,
     },
-    follow: {
-      type: 'boolean',
-      description:
-        'tail live activity after replay (default: true when the container is running); pass --no-follow to replay-then-exit',
-      default: true,
-    },
   },
   async run({ args }) {
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
@@ -45,10 +39,9 @@ export const inspectCommand = defineCommand({
     const sessionArg = typeof args.session === 'string' ? args.session : undefined
     const filterArg = typeof args.filter === 'string' ? args.filter : undefined
     const sinceArg = typeof args.since === 'string' ? args.since : undefined
-    const follow = args.follow !== false
 
     const isJson = args.json === true
-    const liveSource = !follow || isJson ? undefined : await buildLiveSource(cwd)
+    const liveSource = isJson ? undefined : await buildLiveSource(cwd)
     const signal = installSigintAbort()
 
     const result = await runInspect({


### PR DESCRIPTION
## Summary

Reframe `typeclaw inspect` as an observing mode (tui-like, read-only): replay the transcript, then always tail live activity. The `--follow` / `--no-follow` knob was a leftover from when inspect was primarily a replay tool — now that "observe a running agent" is the dominant use case, it's pure friction.

1 commit, 1 file, `+2 / -9`.

## What changes

- Remove the `--follow` flag from `src/cli/inspect.ts`.
- Always build the live source unless `--json` is set.
- Tighten the command description from "replay … and tail live activity" to "observe a session: replay the transcript, then tail live activity".

## What stays the same

- `--json` still implies one-shot replay-then-exit (pipe-friendly semantics for scripts).
- When the container isn't running, `buildLiveSource` still falls back to replay-only with the existing `⚠ … tailing live events disabled` warning. No behavior change for the offline-inspection case.
- Runtime path in `src/inspect/runInspect` is unchanged — `liveSource` is already optional, so dropping the toggle is purely a CLI surface change.
- Ctrl-C / SIGTERM still aborts cleanly via the existing `installSigintAbort`.

## Verification

```
bun run typecheck   ✓
bun run lint        ✓  (pre-existing warnings only; touched file clean)
bun run format      ✓
bun test            5358 pass / 0 fail / 11794 expect() calls
```

The existing `src/inspect/index.test.ts` "without liveSource: same as before (replay-then-exit)" case still covers the `--json` path (no `liveSource` supplied → replay-then-exit). The "replays JSONL then prints the live divider" case covers the new always-on default.