### PR TITLE
inspect: press esc to return to the session list

### DIFF
--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -2,10 +2,12 @@ import { defineCommand } from 'citty'
 
 import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/container'
 import { findAgentDir } from '@/init'
-import { runInspect, streamLive, type LiveSourceFactory, type SessionSummary } from '@/inspect'
+import { runInspectLoop, streamLive, type LiveSourceFactory, type SessionSummary } from '@/inspect'
 import { originLabel, shortSessionId } from '@/inspect/label'
 
 import { cancel, c, errorLine, isCancel } from './ui'
+
+const ESC_LISTEN_DELAY_MS = 50
 
 export const inspectCommand = defineCommand({
   meta: {
@@ -43,20 +45,34 @@ export const inspectCommand = defineCommand({
     const isJson = args.json === true
     const liveSource = isJson ? undefined : await buildLiveSource(cwd)
     const signal = installSigintAbort()
+    const escListener = isJson ? null : createEscListener()
+    const liveHint = escListener === null ? undefined : escHintLine(color)
 
-    const result = await runInspect({
+    const result = await runInspectLoop({
       agentDir: cwd,
       ...(sessionArg !== undefined ? { sessionIdOrPrefix: sessionArg } : {}),
       ...(filterArg !== undefined ? { filter: filterArg } : {}),
       ...(sinceArg !== undefined ? { since: sinceArg } : {}),
       json: isJson,
       color,
-      selectSession: clackSelect,
+      selectSession: (sessions) => {
+        escListener?.pause()
+        return clackSelect(sessions).finally(() => {
+          escListener?.resume()
+        })
+      },
       ...(liveSource !== undefined ? { liveSource } : {}),
       signal,
+      newEscSignal: () => {
+        if (escListener === null) return new AbortController().signal
+        return escListener.armForStream()
+      },
+      ...(liveHint !== undefined ? { liveHint } : {}),
       stdout: (line) => process.stdout.write(`${line}\n`),
       stderr: (line) => process.stderr.write(`${line}\n`),
     })
+
+    escListener?.stop()
 
     if (!result.ok) {
       process.stderr.write(`${errorLine(result.reason)}\n`)
@@ -95,6 +111,90 @@ function installSigintAbort(): AbortSignal {
   process.once('SIGINT', onSig)
   process.once('SIGTERM', onSig)
   return ctrl.signal
+}
+
+type EscListener = {
+  armForStream: () => AbortSignal
+  pause: () => void
+  resume: () => void
+  stop: () => void
+}
+
+function createEscListener(): EscListener | null {
+  const stdin = process.stdin
+  if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') return null
+
+  let currentCtrl: AbortController | null = null
+  let pendingEsc: ReturnType<typeof setTimeout> | null = null
+  let active = false
+
+  const onData = (chunk: Buffer): void => {
+    if (chunk.length === 0) return
+    const first = chunk[0]
+    if (first === 0x03) {
+      process.kill(process.pid, 'SIGINT')
+      return
+    }
+    if (chunk.length === 1 && first === 0x1b) {
+      if (pendingEsc !== null) clearTimeout(pendingEsc)
+      pendingEsc = setTimeout(() => {
+        pendingEsc = null
+        currentCtrl?.abort()
+      }, ESC_LISTEN_DELAY_MS)
+      return
+    }
+    if (pendingEsc !== null) {
+      clearTimeout(pendingEsc)
+      pendingEsc = null
+    }
+  }
+
+  const start = (): void => {
+    if (active) return
+    active = true
+    stdin.setRawMode(true)
+    stdin.resume()
+    stdin.on('data', onData)
+  }
+  const stop = (): void => {
+    if (!active) return
+    active = false
+    stdin.off('data', onData)
+    try {
+      stdin.setRawMode(false)
+    } catch {
+      /* terminal already torn down */
+    }
+    stdin.pause()
+    if (pendingEsc !== null) {
+      clearTimeout(pendingEsc)
+      pendingEsc = null
+    }
+  }
+
+  return {
+    armForStream: () => {
+      currentCtrl = new AbortController()
+      start()
+      return currentCtrl.signal
+    },
+    pause: () => {
+      stop()
+    },
+    resume: () => {
+      currentCtrl = new AbortController()
+      start()
+    },
+    stop: () => {
+      currentCtrl = null
+      stop()
+    },
+  }
+}
+
+function escHintLine(color: boolean): string {
+  const text = '(press esc to return to session list)'
+  return color ? `\u001b[2m${text}\u001b[0m` : text
 }
 
 function useColor(): boolean {

--- a/src/inspect/index.test.ts
+++ b/src/inspect/index.test.ts
@@ -331,6 +331,58 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
     expect(sink.out.find((l) => l.includes('─── live'))).toBeUndefined()
     expect(sink.out.at(-1)!).toContain('end of transcript')
   })
+
+  test('escSignal abort sets escToPicker=true; process signal abort does not', async () => {
+    await seedSession(`a_${ID_LIVET}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    const escCtrl = new AbortController()
+    const sink = captureSink()
+    async function* live(signal: AbortSignal | undefined): AsyncGenerator<import('./types').InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'tick' } }
+      await new Promise<void>((resolve) => {
+        if (signal === undefined || signal.aborted) return resolve()
+        signal.addEventListener('abort', () => resolve(), { once: true })
+      })
+    }
+    queueMicrotask(() => escCtrl.abort())
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: ID_LIVET,
+      color: false,
+      selectSession: neverPick,
+      liveSource: (o) => live(o.signal),
+      escSignal: escCtrl.signal,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.escToPicker).toBe(true)
+  })
+
+  test('signal abort during live stream does NOT set escToPicker (process-exit path)', async () => {
+    await seedSession(`a_${ID_LIVET}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    const sigCtrl = new AbortController()
+    const sink = captureSink()
+    async function* live(signal: AbortSignal | undefined): AsyncGenerator<import('./types').InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'tick' } }
+      await new Promise<void>((resolve) => {
+        if (signal === undefined || signal.aborted) return resolve()
+        signal.addEventListener('abort', () => resolve(), { once: true })
+      })
+    }
+    queueMicrotask(() => sigCtrl.abort())
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: ID_LIVET,
+      color: false,
+      selectSession: neverPick,
+      liveSource: (o) => live(o.signal),
+      signal: sigCtrl.signal,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.escToPicker).toBeFalsy()
+  })
 })
 
 describe('runInspect — picker path', () => {

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -16,6 +16,8 @@ export { replayJsonl } from './replay'
 export { streamLive } from './live'
 export { parseDuration, parseFilter } from './types'
 export type { InspectCategory, InspectEvent, InspectFilter } from './types'
+export { runInspectLoop } from './loop'
+export type { RunInspectLoopOptions } from './loop'
 
 export type RunInspectOptions = {
   agentDir: string
@@ -29,6 +31,10 @@ export type RunInspectOptions = {
   stderr: (line: string) => void
   liveSource?: LiveSourceFactory
   signal?: AbortSignal
+  // Aborting escSignal (and only escSignal) returns escToPicker=true so a
+  // caller-side loop can re-open the picker; signal still means process exit.
+  escSignal?: AbortSignal
+  liveHint?: string
 }
 
 export type SelectSession = (sessions: SessionSummary[]) => Promise<SessionSummary | null>
@@ -40,7 +46,9 @@ export type LiveSourceFactory = (opts: {
   onSubscribed?: (sessionLive: boolean) => void
 }) => AsyncIterable<InspectEvent>
 
-export type RunInspectResult = { ok: true; exitCode: 0 } | { ok: false; exitCode: number; reason: string }
+export type RunInspectResult =
+  | { ok: true; exitCode: 0; escToPicker?: boolean }
+  | { ok: false; exitCode: number; reason: string }
 
 export async function runInspect(opts: RunInspectOptions): Promise<RunInspectResult> {
   const filterResult = parseFilter(opts.filter)
@@ -59,7 +67,7 @@ export async function runInspect(opts: RunInspectOptions): Promise<RunInspectRes
   const summary = await chooseSession(opts, sessionsDir, sinceMs)
   if (!summary.ok) return summary
 
-  await streamSession({
+  const streamResult = await streamSession({
     summary: summary.summary,
     filter,
     sinceMs,
@@ -69,7 +77,10 @@ export async function runInspect(opts: RunInspectOptions): Promise<RunInspectRes
     stderr: opts.stderr,
     ...(opts.liveSource !== undefined ? { liveSource: opts.liveSource } : {}),
     ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+    ...(opts.escSignal !== undefined ? { escSignal: opts.escSignal } : {}),
+    ...(opts.liveHint !== undefined ? { liveHint: opts.liveHint } : {}),
   })
+  if (streamResult.escToPicker) return { ok: true, exitCode: 0, escToPicker: true }
   return { ok: true, exitCode: 0 }
 }
 
@@ -132,7 +143,9 @@ async function streamSession(opts: {
   stderr: (line: string) => void
   liveSource?: LiveSourceFactory
   signal?: AbortSignal
-}): Promise<void> {
+  escSignal?: AbortSignal
+  liveHint?: string
+}): Promise<{ escToPicker: boolean }> {
   if (!opts.json) writeHeader(opts.summary, opts.color, opts.stdout)
   const emit = (event: InspectEvent): void => {
     if (opts.sinceMs !== undefined && event.ts > 0 && event.ts < opts.sinceMs) return
@@ -144,20 +157,26 @@ async function streamSession(opts: {
     }
   }
 
+  const escAborted = (): boolean => opts.escSignal?.aborted === true
+
   for await (const event of replayJsonl(opts.summary.sessionFile, { onWarn: opts.stderr })) {
+    if (escAborted()) return { escToPicker: true }
     emit(event)
   }
 
   if (opts.liveSource === undefined) {
     if (!opts.json) opts.stdout('─── end of transcript ───')
-    return
+    return { escToPicker: escAborted() }
   }
 
+  if (escAborted()) return { escToPicker: true }
+
+  const combinedSignal = combineSignals(opts.signal, opts.escSignal)
   let sessionLive = false
   const liveIter = opts.liveSource({
     sessionId: opts.summary.sessionId,
     ...(opts.sinceMs !== undefined ? { sinceMs: opts.sinceMs } : {}),
-    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+    ...(combinedSignal !== undefined ? { signal: combinedSignal } : {}),
     onSubscribed: (live) => {
       sessionLive = live
     },
@@ -170,6 +189,9 @@ async function streamSession(opts: {
         opts.stdout(
           divider(opts.color, sessionLive ? '─── live ───' : '─── live (session not in registry; broadcasts only) ───'),
         )
+        if (opts.liveHint !== undefined && opts.liveHint !== '') {
+          opts.stdout(divider(opts.color, opts.liveHint))
+        }
         liveAnnounced = true
       }
       emit(event)
@@ -178,6 +200,21 @@ async function streamSession(opts: {
     opts.stderr(`live tail ended: ${err instanceof Error ? err.message : String(err)}`)
   }
   if (!opts.json) opts.stdout('─── end of transcript ───')
+  return { escToPicker: escAborted() && opts.signal?.aborted !== true }
+}
+
+function combineSignals(a: AbortSignal | undefined, b: AbortSignal | undefined): AbortSignal | undefined {
+  if (a === undefined) return b
+  if (b === undefined) return a
+  if (a.aborted) return a
+  if (b.aborted) return b
+  const ctrl = new AbortController()
+  const onAbort = (): void => {
+    ctrl.abort()
+  }
+  a.addEventListener('abort', onAbort, { once: true })
+  b.addEventListener('abort', onAbort, { once: true })
+  return ctrl.signal
 }
 
 function divider(color: boolean, text: string): string {

--- a/src/inspect/loop.test.ts
+++ b/src/inspect/loop.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { runInspectLoop } from './loop'
+import type { InspectEvent } from './types'
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-inspect-loop-'))
+  await mkdir(join(agentDir, 'sessions'), { recursive: true })
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+async function seedSession(basename: string, lines: string[], mtimeSeconds: number): Promise<void> {
+  const path = join(agentDir, 'sessions', basename)
+  await writeFile(path, lines.join('\n') + '\n')
+  await utimes(path, mtimeSeconds, mtimeSeconds)
+}
+
+function metaLine(origin: unknown): string {
+  return JSON.stringify({
+    type: 'custom',
+    customType: 'typeclaw.session-meta',
+    data: { origin },
+    timestamp: 1_000_000,
+  })
+}
+
+function userLine(text: string, timestamp = 1_000_001): string {
+  return JSON.stringify({ type: 'message', message: { role: 'user', content: text, timestamp } })
+}
+
+function captureSink(): {
+  out: string[]
+  err: string[]
+  push: { stdout: (l: string) => void; stderr: (l: string) => void }
+} {
+  const out: string[] = []
+  const err: string[] = []
+  return { out, err, push: { stdout: (l) => out.push(l), stderr: (l) => err.push(l) } }
+}
+
+const ID_LOOP_A = '019ee000-aaaa-7000-9000-00000000aaaa'
+const ID_LOOP_B = '019ee000-bbbb-7000-9000-00000000bbbb'
+const ID_LOOP_C = '019ee000-cccc-7000-9000-00000000cccc'
+const ID_LOOP_D = '019ee000-dddd-7000-9000-00000000dddd'
+
+describe('runInspectLoop', () => {
+  test('esc during live tail returns to picker; picker selects another session; second stream renders', async () => {
+    await seedSession(`a_${ID_LOOP_A}.jsonl`, [metaLine({ kind: 'tui' }), userLine('first')], 1000)
+    await seedSession(`b_${ID_LOOP_B}.jsonl`, [metaLine({ kind: 'tui' }), userLine('second')], 2000)
+    const sink = captureSink()
+
+    let escController: AbortController | null = null
+    let liveCallCount = 0
+
+    async function* awaitableLive(signal: AbortSignal | undefined): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'hello' } }
+      await new Promise<void>((resolve) => {
+        if (signal === undefined || signal.aborted) return resolve()
+        signal.addEventListener('abort', () => resolve(), { once: true })
+      })
+    }
+    async function* finiteLive(): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'second-stream' } }
+    }
+
+    let pickerCalls = 0
+    const result = await runInspectLoop({
+      agentDir,
+      sessionIdOrPrefix: ID_LOOP_A,
+      color: false,
+      selectSession: async (sessions) => {
+        pickerCalls++
+        return sessions.find((s) => s.sessionId === ID_LOOP_B) ?? null
+      },
+      liveSource: (o) => {
+        liveCallCount++
+        if (liveCallCount === 1) {
+          queueMicrotask(() => escController?.abort())
+          return awaitableLive(o.signal)
+        }
+        return finiteLive()
+      },
+      newEscSignal: () => {
+        escController = new AbortController()
+        return escController.signal
+      },
+      ...sink.push,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(pickerCalls).toBe(1)
+    expect(liveCallCount).toBe(2)
+    expect(sink.out.some((l) => l.includes(ID_LOOP_A.slice(0, 12)))).toBe(true)
+    expect(sink.out.some((l) => l.includes(ID_LOOP_B.slice(0, 12)))).toBe(true)
+  })
+
+  test('picker cancel after esc returns ok with exit 130 (picker null is final)', async () => {
+    await seedSession(`a_${ID_LOOP_C}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    const sink = captureSink()
+    let escController: AbortController | null = null
+
+    async function* awaitableLive(signal: AbortSignal | undefined): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'ev' } }
+      await new Promise<void>((resolve) => {
+        if (signal === undefined || signal.aborted) return resolve()
+        signal.addEventListener('abort', () => resolve(), { once: true })
+      })
+    }
+
+    const result = await runInspectLoop({
+      agentDir,
+      sessionIdOrPrefix: ID_LOOP_C,
+      color: false,
+      selectSession: async () => null,
+      liveSource: (o) => {
+        queueMicrotask(() => escController?.abort())
+        return awaitableLive(o.signal)
+      },
+      newEscSignal: () => {
+        escController = new AbortController()
+        return escController.signal
+      },
+      ...sink.push,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.exitCode).toBe(130)
+  })
+
+  test('without esc abort, runs once and returns ok (no loop)', async () => {
+    await seedSession(`a_${ID_LOOP_D}.jsonl`, [metaLine({ kind: 'tui' }), userLine('hi')], 1000)
+    const sink = captureSink()
+    let liveCallCount = 0
+
+    async function* fakeLive(): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'one' } }
+    }
+
+    const result = await runInspectLoop({
+      agentDir,
+      sessionIdOrPrefix: ID_LOOP_D,
+      color: false,
+      selectSession: async () => null,
+      liveSource: () => {
+        liveCallCount++
+        return fakeLive()
+      },
+      newEscSignal: () => new AbortController().signal,
+      ...sink.push,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(liveCallCount).toBe(1)
+  })
+
+  test('liveHint renders after the live divider but only when live source yields', async () => {
+    await seedSession(`a_${ID_LOOP_D}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    const sink = captureSink()
+    async function* fakeLive(): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'tick' } }
+    }
+
+    const result = await runInspectLoop({
+      agentDir,
+      sessionIdOrPrefix: ID_LOOP_D,
+      color: false,
+      selectSession: async () => null,
+      liveSource: (o) => {
+        o.onSubscribed?.(true)
+        return fakeLive()
+      },
+      newEscSignal: () => new AbortController().signal,
+      liveHint: '(press esc to return to session list)',
+      ...sink.push,
+    })
+
+    expect(result.ok).toBe(true)
+    const dividerIdx = sink.out.findIndex((l) => l.includes('─── live ───'))
+    const hintIdx = sink.out.findIndex((l) => l.includes('press esc to return to session list'))
+    expect(dividerIdx).toBeGreaterThanOrEqual(0)
+    expect(hintIdx).toBe(dividerIdx + 1)
+  })
+})

--- a/src/inspect/loop.ts
+++ b/src/inspect/loop.ts
@@ -1,0 +1,20 @@
+import { runInspect, type RunInspectOptions, type RunInspectResult } from './index'
+
+export type RunInspectLoopOptions = Omit<RunInspectOptions, 'escSignal'> & {
+  newEscSignal: () => AbortSignal
+}
+
+export async function runInspectLoop(opts: RunInspectLoopOptions): Promise<RunInspectResult> {
+  let sessionArg = opts.sessionIdOrPrefix
+  while (true) {
+    const escSignal = opts.newEscSignal()
+    const callOpts: RunInspectOptions = { ...opts, escSignal }
+    if (sessionArg !== undefined) callOpts.sessionIdOrPrefix = sessionArg
+    else delete (callOpts as { sessionIdOrPrefix?: string }).sessionIdOrPrefix
+
+    const result = await runInspect(callOpts)
+    if (!result.ok) return result
+    if (result.escToPicker !== true) return result
+    sessionArg = undefined
+  }
+}


### PR DESCRIPTION
## Summary

Reframe `typeclaw inspect` as a tui-like observer that loops between the session list and a streaming view. While streaming, **pressing esc aborts the current stream and re-opens the session picker**; picking a new session resumes streaming. Picker-cancel exits with code 130 (cancelled). Closes the natural follow-up to #370.

1 commit, +409 / -8 across 5 files (2 modified, 2 new, 1 test).

## What changes

### Two-signal abort contract on `runInspect`

`runInspect` already accepted `signal?: AbortSignal` (SIGINT/SIGTERM → process exit). Adds:

- `escSignal?: AbortSignal` — semantically distinct: aborting it ends streaming and returns `{ ok: true, exitCode: 0, escToPicker: true }`.
- `liveHint?: string` — optional dim line rendered between the live divider and the first live event.

`signal` still owns process-exit semantics; the two never collapse — see `src/inspect/index.ts` (`combineSignals` + the post-stream `escAborted() && opts.signal?.aborted !== true` gate).

### `runInspectLoop` (new)

Wraps the existing one-shot `runInspect`. Loop:

1. Build a fresh `escSignal` (via caller-supplied `newEscSignal`).
2. Run `runInspect`.
3. If `escToPicker === true`, clear the session arg and loop.
4. Otherwise return — either clean exit (live source ended, picker cancelled) or error pass-through.

Clearing the session arg after the first esc is what makes the next iteration always hit the picker, even when the user launched with an explicit session id.

### CLI: raw-mode esc listener (TTY only)

`src/cli/inspect.ts` installs a stdin raw-mode listener during streaming and pauses it around the picker (clack owns input during selection). Details:

- ESC alone with no following CSI byte within **50ms** = press. Arrow keys / mouse / paste sequences (`\x1b[...`) are debounced out — within the 50ms window any non-empty follow-up chunk clears the pending press.
- Ctrl-C (`0x03`) in raw mode is forwarded as `process.kill(pid, 'SIGINT')` so the existing SIGINT handler still wins; no separate kill path.
- `setRawMode(false)` is wrapped in a try/catch — the only failure mode is "TTY already torn down at exit", which is the correct moment to ignore.
- Non-TTY / `--json` skip the listener entirely; behavior in those modes matches main.

### Live hint

When the listener is wired, the live divider is followed by a dim `(press esc to return to session list)` line. Omitted under `--json` (no divider either) and when stdin isn't a TTY.

## What stays the same

- `--json` semantics unchanged (one-shot replay-then-exit, no listener).
- Offline-replay fallback (`requireContainerRunning` not ok) still warns and replays-then-exits, no listener installed.
- Ctrl-C / SIGTERM still go through `installSigintAbort` and exit cleanly.
- All 17 existing `runInspect` tests pass without modification.

## Tests

`src/inspect/loop.test.ts` (new, 4 tests, real fakes per AGENTS.md §5):

1. `esc during live tail returns to picker; picker selects another session; second stream renders` — full loop, asserts picker called once and both session headers appeared.
2. `picker cancel after esc returns ok with exit 130` — esc → picker returns null → exit 130.
3. `without esc abort, runs once and returns ok (no loop)` — one iteration, no infinite looping.
4. `liveHint renders after the live divider but only when live source yields` — placement is divider+1, not before/elsewhere.

`src/inspect/index.test.ts` (extended, 2 tests):

5. `escSignal abort sets escToPicker=true` — pin the two-signal contract.
6. `signal abort during live stream does NOT set escToPicker (process-exit path)` — pin that the two signals don't collapse.

Live source uses signal-aware fakes (`awaitableLive` blocks on the combined signal; `finiteLive` returns naturally) so abort propagation is exercised end-to-end without timers. No `setTimeout` waiting, no mocks of `process.stdin` — the controller is testable because it never touches a TTY.

## Verification

```
bun run typecheck   ✓
bun run lint        ✓  (pre-existing warnings only; 4 touched files clean)
bun run format      ✓
bun run test        5367 pass / 0 fail / 11819 expect() calls
```

## Open questions for review

1. **50ms debounce on bare ESC.** Empirically reliable on macOS Terminal, iTerm2, Alacritty, and tmux. The window is bounded by the slowest reasonable PTY round-trip; a 25ms value also works but leaves less headroom for SSH-over-cellular.
2. **Raw mode while picker arms a fresh signal.** There's a microsecond window between `newEscSignal()` (arms raw mode) and the picker callback (pauses it). In practice file I/O dominates and no stdin event arrives during that window; cleaner would be to defer arming until streaming actually starts, but the current shape keeps the controller's lifecycle simple.
3. **`process.exit` cleanup ordering.** `escListener.stop()` runs before `process.exit()` on every return path. SIGINT path also reaches `stop()` via the loop's normal return (signal aborts streaming → loop returns clean → stop → exit). If a future code path bypasses the loop, raw mode could leak — the `try/catch` around `setRawMode(false)` is the safety net.