### PR TITLE
channels: auto-anchor delayed channel replies with quoted-inbound prefix

### DIFF
--- a/src/channels/router.quote-anchor.test.ts
+++ b/src/channels/router.quote-anchor.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from 'bun:test'
+
+import { captureQuoteCandidate, decideQuoteAnchor, prependQuoteAnchor, renderQuoteAnchor } from './router'
+import {
+  DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS,
+  QUOTED_REPLY_EXCERPT_MAX_CHARS,
+  type ChannelAdapterConfig,
+} from './schema'
+
+const baseConfig: ChannelAdapterConfig = {
+  engagement: { trigger: ['mention', 'reply', 'dm'], stickiness: { perReply: { window: 60_000 } } },
+  enabled: true,
+  history: { prefetch: { thread: { head: 3, tail: 10 }, channel: { tail: 10 } } },
+}
+
+const humanInbound = {
+  text: 'hey there',
+  authorName: 'Alice',
+  authorIsBot: false,
+  receivedAt: 1000,
+}
+
+describe('renderQuoteAnchor', () => {
+  test('formats single-line user text verbatim', () => {
+    expect(renderQuoteAnchor({ authorName: 'Alice', text: 'hello' })).toBe('> @Alice: hello')
+  })
+
+  test('collapses newlines so the quote stays on one line', () => {
+    expect(renderQuoteAnchor({ authorName: 'Bob', text: 'line one\nline two\n\nline three' })).toBe(
+      '> @Bob: line one line two line three',
+    )
+  })
+
+  test('truncates excerpts longer than the cap with an ellipsis', () => {
+    const long = 'a'.repeat(QUOTED_REPLY_EXCERPT_MAX_CHARS + 50)
+    const out = renderQuoteAnchor({ authorName: 'Carol', text: long })
+    expect(out.length).toBe('> @Carol: '.length + QUOTED_REPLY_EXCERPT_MAX_CHARS)
+    expect(out.endsWith('…')).toBe(true)
+  })
+
+  test('falls back to a no-text marker for bare-mention inbounds', () => {
+    expect(renderQuoteAnchor({ authorName: 'Dave', text: '   ' })).toBe('> @Dave: (no text)')
+    expect(renderQuoteAnchor({ authorName: 'Dave', text: '' })).toBe('> @Dave: (no text)')
+  })
+
+  test('strips a leading > so a quote-of-a-quote stays single-level', () => {
+    expect(renderQuoteAnchor({ authorName: 'Eve', text: '> their reply\nfollowup' })).toBe(
+      '> @Eve: their reply followup',
+    )
+  })
+})
+
+describe('prependQuoteAnchor', () => {
+  test('separates the anchor and reply with a single newline', () => {
+    expect(prependQuoteAnchor('I see you', { authorName: 'Alice', text: 'yo' })).toBe('> @Alice: yo\nI see you')
+  })
+
+  test('returns just the anchor when the reply text is empty (attachment-only)', () => {
+    expect(prependQuoteAnchor('', { authorName: 'Alice', text: 'yo' })).toBe('> @Alice: yo')
+  })
+})
+
+describe('captureQuoteCandidate', () => {
+  test('returns null when the batch is empty', () => {
+    expect(captureQuoteCandidate([], [])).toBeNull()
+  })
+
+  test('returns null when the primary inbound is a bot', () => {
+    expect(captureQuoteCandidate([{ ...humanInbound, authorIsBot: true }], [])).toBeNull()
+  })
+
+  test('captures the LAST batch entry as primary (matches drain semantics)', () => {
+    const earlier = { ...humanInbound, authorName: 'Earlier', text: 'first', receivedAt: 1000 }
+    const later = { ...humanInbound, authorName: 'Later', text: 'second', receivedAt: 2000 }
+    const result = captureQuoteCandidate([earlier, later], [])
+    expect(result?.source).toEqual({ authorName: 'Later', text: 'second' })
+    expect(result?.primaryReceivedAt).toBe(2000)
+  })
+
+  test('flags hadInterveningObserved when any observed entry landed at-or-after the primary', () => {
+    const result = captureQuoteCandidate([humanInbound], [{ receivedAt: humanInbound.receivedAt + 100 }])
+    expect(result?.hadInterveningObserved).toBe(true)
+  })
+
+  test('clears hadInterveningObserved when all observed entries predate the primary', () => {
+    const result = captureQuoteCandidate([humanInbound], [{ receivedAt: humanInbound.receivedAt - 100 }])
+    expect(result?.hadInterveningObserved).toBe(false)
+  })
+})
+
+describe('decideQuoteAnchor', () => {
+  test('null candidate always returns null', () => {
+    expect(decideQuoteAnchor(null, 999_999, baseConfig)).toBeNull()
+  })
+
+  test('returns null when send-time delay is below threshold and no intervening observed', () => {
+    const candidate = captureQuoteCandidate([humanInbound], [])!
+    expect(decideQuoteAnchor(candidate, humanInbound.receivedAt + 1_000, baseConfig)).toBeNull()
+  })
+
+  test('returns the anchor when send-time delay crosses the default threshold', () => {
+    const candidate = captureQuoteCandidate([humanInbound], [])!
+    const out = decideQuoteAnchor(
+      candidate,
+      humanInbound.receivedAt + DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS + 1,
+      baseConfig,
+    )
+    expect(out).toEqual({ authorName: 'Alice', text: 'hey there' })
+  })
+
+  test('returns the anchor when an observed message landed after the primary, even within threshold', () => {
+    const candidate = captureQuoteCandidate([humanInbound], [{ receivedAt: humanInbound.receivedAt + 500 }])!
+    const out = decideQuoteAnchor(candidate, humanInbound.receivedAt + 1_000, baseConfig)
+    expect(out).toEqual({ authorName: 'Alice', text: 'hey there' })
+  })
+
+  test('respects an explicit enabled: false override', () => {
+    const candidate = captureQuoteCandidate([humanInbound], [])!
+    const disabled: ChannelAdapterConfig = { ...baseConfig, quotedReply: { enabled: false, queueDelayMs: 0 } }
+    const out = decideQuoteAnchor(candidate, humanInbound.receivedAt + 999_999, disabled)
+    expect(out).toBeNull()
+  })
+
+  test('respects a custom queueDelayMs', () => {
+    const candidate = captureQuoteCandidate([humanInbound], [])!
+    const aggressive: ChannelAdapterConfig = { ...baseConfig, quotedReply: { enabled: true, queueDelayMs: 0 } }
+    expect(decideQuoteAnchor(candidate, humanInbound.receivedAt, aggressive)).toEqual({
+      authorName: 'Alice',
+      text: 'hey there',
+    })
+  })
+
+  test('falls back to the default threshold when the adapter has no quotedReply config', () => {
+    const candidate = captureQuoteCandidate([humanInbound], [])!
+    expect(
+      decideQuoteAnchor(candidate, humanInbound.receivedAt + DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS + 1, baseConfig),
+    ).toEqual({ authorName: 'Alice', text: 'hey there' })
+  })
+})

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4751,3 +4751,159 @@ describe('ChannelRouter injectSubagentCompletionReminder', () => {
     expect(router.liveCount()).toBe(1)
   })
 })
+
+describe('ChannelRouter quote-anchor on outbound', () => {
+  test('does NOT prepend a quote when the reply lands within the threshold and nothing intervened', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: string[] = []
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'are you there?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    nowRef.value += 500
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'yes' })
+    expect(sent).toEqual(['yes'])
+  })
+
+  test('prepends a `> @author: excerpt` quote when the reply crosses the queueDelayMs threshold', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: string[] = []
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'are you there?', authorName: 'Alice' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    nowRef.value += 60_000
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'yes I am here' })
+    expect(sent).toEqual(['> @Alice: are you there?\nyes I am here'])
+  })
+
+  test('prepends a quote when an observed message landed between inbound and reply, even within the threshold', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: string[] = []
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'cron status?', authorName: 'Alice' }))
+    nowRef.value += 100
+    await router.route(
+      inbound({
+        isBotMention: false,
+        externalMessageId: 'm-observed',
+        authorId: 'bob',
+        authorName: 'bob',
+        text: 'unrelated chatter',
+      }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value += 200
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'still blocked' })
+    expect(sent[0]).toContain('> @Alice: cron status?')
+    expect(sent[0]).toContain('still blocked')
+  })
+
+  test('anchors only the FIRST send of a multi-part reply; subsequent sends in the same turn are bare', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: string[] = []
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'walk me through it', authorName: 'Alice' }))
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value += 60_000
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'first chunk' })
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'second chunk' })
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'third chunk' })
+    expect(sent).toEqual(['> @Alice: walk me through it\nfirst chunk', 'second chunk', 'third chunk'])
+  })
+
+  test('resets per turn so the next batch can anchor again', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: string[] = []
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'turn one', authorName: 'Alice', externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value += 60_000
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply one' })
+
+    await router.route(inbound({ text: 'turn two', authorName: 'Alice', externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value += 60_000
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply two' })
+
+    expect(sent[0]).toBe('> @Alice: turn one\nreply one')
+    expect(sent[1]).toBe('> @Alice: turn two\nreply two')
+  })
+
+  test('respects an adapter config opting out via quotedReply.enabled: false', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: string[] = []
+    const config: ChannelAdapterConfig = {
+      ...baseConfig,
+      quotedReply: { enabled: false, queueDelayMs: 0 },
+    }
+    const { router } = makeRouter(dir, { nowRef, config })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'quiet please', authorName: 'Alice' }))
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value += 600_000
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'sure' })
+    expect(sent).toEqual(['sure'])
+  })
+
+  test('attachments-only sends still anchor (the bare anchor stands alone as the message body)', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: Array<{ text: string | undefined; attachments: unknown }> = []
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text, attachments: msg.attachments })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'screenshot pls', authorName: 'Alice' }))
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value += 60_000
+
+    await router.send({
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      attachments: [{ path: '/agent/screen.png' }],
+    })
+    expect(sent[0]?.text).toBe('> @Alice: screenshot pls')
+  })
+})

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -29,7 +29,11 @@ import {
   saveChannelSessions,
   type ChannelSessionRecord,
 } from './persistence'
-import type { ChannelAdapterConfig } from './schema'
+import {
+  DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS,
+  QUOTED_REPLY_EXCERPT_MAX_CHARS,
+  type ChannelAdapterConfig,
+} from './schema'
 import type {
   ChannelHistoryMessage,
   ChannelKey,
@@ -302,6 +306,15 @@ type LiveSession = {
   // future hard cap without picking a threshold out of thin air.
   sendTimestamps: Map<string, number[]>
   successfulChannelSends: number
+  // Captured by drain() at batch dequeue; read+cleared by send() on the
+  // first tool-source send of the turn. The anchor decision (delay
+  // threshold + intervening-observed check) is evaluated at SEND time
+  // against this snapshot — not at drain time — because the relevant
+  // signal is how long the user waited from inbound to seeing the reply
+  // land, which only the send-side clock knows. Cleared after first
+  // consumption so multi-part replies anchor only on chunk 1. A new
+  // batch overwrites unconditionally.
+  pendingQuoteCandidate: QuoteAnchorCandidate | null
   // Loop-guard state. See PEER_BOT_TURNS_WINDOW_MS / MAX_* constants
   // above. Updated in route() on every engaged peer-bot inbound, reset on
   // any human inbound. The two axes (window ring buffer + since-human
@@ -913,6 +926,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         lastSentText: new Map(),
         sendTimestamps: new Map(),
         successfulChannelSends: 0,
+        pendingQuoteCandidate: null,
         recentEngagedPeerBotTurns: [],
         consecutiveEngagedPeerBotTurns: 0,
         loopGuardActive: false,
@@ -1213,6 +1227,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.currentTurnAuthorIds = new Set(batch.map((m) => m.authorId))
           live.consecutiveSends.clear()
           live.lastSentText.clear()
+          live.pendingQuoteCandidate = captureQuoteCandidate(batch, observed)
         } else if (live.lastTurnAuthorId !== null) {
           // Reminder-only turn (batch.length === 0, reminders.length > 0):
           // restore the author identity from the prior turn so author-
@@ -1695,6 +1710,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     })
     const live = liveSessions.get(keyId)
     const sendKey = consecutiveSendKey(msg.chat, msg.thread)
+    // Tool-source sends consume the captured quote candidate exactly
+    // once per turn — the decision (delay threshold + intervening-
+    // observed check) runs HERE against the live clock so the relevant
+    // signal is real wall-time between inbound and reply landing, not
+    // drain-vs-send timing artifacts. System sources (recovery, role-
+    // claim) skip so they can't accidentally swallow the candidate
+    // before the model's own first reply lands. Even when the decision
+    // returns null (delay below threshold, nothing intervened), the
+    // candidate is cleared — a multi-part reply that crosses the
+    // threshold mid-flight must not retroactively anchor chunk 2.
+    if (live && source === 'tool' && live.pendingQuoteCandidate !== null) {
+      const anchor = decideQuoteAnchor(live.pendingQuoteCandidate, now(), options.configForAdapter(msg.adapter))
+      if (anchor !== null) msg = { ...msg, text: prependQuoteAnchor(msg.text ?? '', anchor) }
+      live.pendingQuoteCandidate = null
+    }
     const text = normalizeSendText(msg.text)
 
     // Central enforcement. Tool-initiated sends are subject to two policies:
@@ -2230,6 +2260,95 @@ function formatAuthorLine(
   const tag = authorIsBot ? ' [bot]' : ''
   const stamp = ts > 0 ? `[${new Date(ts).toISOString()}] ` : ''
   return `${stamp}<@${authorId}> (${authorName})${tag}: ${text}`
+}
+
+export type QuoteAnchorSource = {
+  authorName: string
+  text: string
+}
+
+// Renders the single-line `> @name: excerpt` blockquote prepended to
+// outbound replies when the router decides the reply needs an anchor.
+// Collapses newlines to spaces so a multi-line user message renders on
+// one quoted line (markdown blockquote semantics: a blank line ends the
+// quote, and `> foo\nbar` would split the quote and the reply); strips
+// existing leading `>` so a quote-of-a-quote stays single-level. Empty
+// inbound text (mention-only inbounds like `<@bot>`) falls back to a
+// generic marker so the user still sees "the bot saw your ping".
+export function renderQuoteAnchor(source: QuoteAnchorSource): string {
+  const collapsed = source.text
+    .replace(/\s+/g, ' ')
+    .replace(/^>+\s*/, '')
+    .trim()
+  const excerpt =
+    collapsed === ''
+      ? '(no text)'
+      : collapsed.length > QUOTED_REPLY_EXCERPT_MAX_CHARS
+        ? `${collapsed.slice(0, QUOTED_REPLY_EXCERPT_MAX_CHARS - 1)}…`
+        : collapsed
+  return `> @${source.authorName}: ${excerpt}`
+}
+
+export function prependQuoteAnchor(replyText: string, source: QuoteAnchorSource): string {
+  const anchor = renderQuoteAnchor(source)
+  if (replyText === '') return anchor
+  return `${anchor}\n${replyText}`
+}
+
+type QuoteAnchorBatchEntry = {
+  text: string
+  authorName: string
+  authorIsBot: boolean
+  receivedAt: number
+}
+
+type QuoteAnchorObservedEntry = {
+  receivedAt: number
+}
+
+export type QuoteAnchorCandidate = {
+  source: QuoteAnchorSource
+  primaryReceivedAt: number
+  hadInterveningObserved: boolean
+}
+
+// Snapshot the primary inbound + observed-buffer state at drain time so
+// the send-side decision has the data it needs without holding a
+// reference to the batch arrays. Returns null when there's nothing
+// anchorable (empty batch, primary is a bot).
+export function captureQuoteCandidate(
+  batch: readonly QuoteAnchorBatchEntry[],
+  observed: readonly QuoteAnchorObservedEntry[],
+): QuoteAnchorCandidate | null {
+  if (batch.length === 0) return null
+  const primary = batch[batch.length - 1]!
+  if (primary.authorIsBot) return null
+  const hadInterveningObserved = observed.some((o) => o.receivedAt >= primary.receivedAt)
+  return {
+    source: { authorName: primary.authorName, text: primary.text },
+    primaryReceivedAt: primary.receivedAt,
+    hadInterveningObserved,
+  }
+}
+
+// Send-time decision: given a captured candidate and the current clock,
+// returns the source to anchor against or null. Skips when:
+//   - quotedReply is disabled in config
+//   - delay is under threshold AND no observed messages came between
+//     primary inbound and now (the "felt instantaneous" path)
+// A null candidate (no batch yet, or batch was bot-only) always skips.
+export function decideQuoteAnchor(
+  candidate: QuoteAnchorCandidate | null,
+  nowMs: number,
+  adapterConfig: ChannelAdapterConfig | undefined,
+): QuoteAnchorSource | null {
+  if (candidate === null) return null
+  const config = adapterConfig?.quotedReply
+  if (config !== undefined && config.enabled === false) return null
+  const threshold = config?.queueDelayMs ?? DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS
+  const delay = nowMs - candidate.primaryReceivedAt
+  if (delay < threshold && !candidate.hadInterveningObserved) return null
+  return candidate.source
 }
 
 type Sliced = { kind: 'message'; message: ChannelHistoryMessage } | { kind: 'elision'; elidedCount: number }

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -87,6 +87,26 @@ const historySchema = z
     },
   })
 
+// When the agent's first send of a turn lands ≥ this many ms after the
+// inbound was received, OR there were intervening observed messages
+// between the inbound and the reply, the router prepends a `> @author:
+// ...` blockquote line referencing the inbound so the user can see which
+// message the reply is anchored to even after the channel has scrolled.
+// 10s is the empirical "felt instantaneous" ceiling — anything faster
+// reads as real-time and needs no anchor.
+export const DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS = 10_000
+
+// Long enough to disambiguate; short enough that a multi-paragraph user
+// message doesn't visually dominate the reply.
+export const QUOTED_REPLY_EXCERPT_MAX_CHARS = 100
+
+const quotedReplySchema = z
+  .object({
+    enabled: z.boolean().default(true),
+    queueDelayMs: z.number().int().min(0).default(DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS),
+  })
+  .default({ enabled: true, queueDelayMs: DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS })
+
 // Deliberately non-strict: a stale on-disk file may still carry the
 // legacy `allow` field (`migrateLegacyConfigShape` lifts it into
 // `roles.member.match[]` on load, but a between-reload window can
@@ -97,6 +117,7 @@ const adapterSchema = z.object({
   engagement: engagementSchema,
   history: historySchema,
   enabled: z.boolean().default(true),
+  quotedReply: quotedReplySchema.optional(),
 })
 
 export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [


### PR DESCRIPTION
## What this PR does

When a typeclaw agent is running inside a chat channel (Slack, Discord, Telegram, KakaoTalk), an inbound user message gets queued in the router's `promptQueue` while the agent is busy with another turn. The user sees their message delivered to Slack/etc., then nothing. No "agent is busy", no read receipt. They re-mention, re-ask, sometimes give up.

This PR doesn't solve the "did you receive my message?" problem (typing indicators / reactions — that's a separate follow-up). It solves the related problem: when the agent's eventual reply finally lands, the user has no idea which message it's replying to, because the channel has scrolled, other people have spoken, or the user has switched tabs and forgotten.

The fix: when the agent's first reply of a turn lands ≥10s after the user's inbound was received, OR the channel had any intervening observed messages between inbound and reply, the router auto-prepends a single-line `> @author: excerpt` markdown blockquote referencing the inbound. Within 10s and with no intervening chatter, replies go bare (the user is still looking at the conversation; an anchor adds noise).

## Why this design

The user-facing problem is well-illustrated by a real session that motivated the PR: an agent was busy from 18:07 → 18:12 working through a cron-write the security guards blocked. At 18:11 the user (impatient) sent a bare `<@bot>` mention. The router queued it. At 18:12 the agent's prior reply landed. At 18:17 the agent finally got to the queued mention — 5min 56sec wall-time between user-send and agent-saw-the-prompt — and the reply landed in the channel with zero indication it was a response to the bare ping. With this PR the reply would land as:

```
> @user: <@bot>
yes I'm here — same cron guard still blocking, please re-ask from TUI
```

The decision splits across drain and send. Drain captures the primary inbound + the observed-buffer state at batch dequeue, because `contextBuffer` is empty by the time `send()` runs (drain spliced it into the prompt). Send then evaluates the delay+intervening predicate against the live clock and either prepends the anchor or clears the candidate. Splitting matters because the relevant signal is real wall-time between inbound and reply landing — not the time between inbound and drain.

Anchoring is first-send-only per turn so multi-part replies don't repeat the quote on every chunk. System-source sends (recovery, role-claim) skip the consume so they can't swallow the candidate before the model's own first reply lands. Per-adapter `quotedReply.enabled` and `quotedReply.queueDelayMs` opt in or out; the default is on with the 10s threshold.

## Why markdown `>` rather than native quote-reply APIs

- **Slack**: `chat.postMessage` has no native quote primitive (only `thread_ts`, already used). Literal `>` is the only option.
- **Discord**: native `message_reference` exists, but agent-messenger's `DiscordBotClient.sendMessage` only accepts `{ thread_id }` — no `message_reference` passthrough.
- **Telegram**: `reply_to_message_id` exists in `SendMessageOptions`, but agent-messenger's client surface doesn't expose it yet. Potential polish PR follow-up.
- **KakaoTalk**: `sendMessage(chatId, text)` only — no reply field.

Three of four would need agent-messenger surface changes to use the native API. Markdown `>` works on all four platforms today with zero upstream changes. The structured fields can layer in as a polish PR once the markdown version proves the UX.

## What's in the diff

| File | Change |
|---|---|
| `src/channels/schema.ts` | Adds optional `quotedReply` block per adapter (`enabled`, `queueDelayMs`; defaults: on, 10s). Existing test fixtures need no updating. |
| `src/channels/router.ts` | Adds `pendingQuoteCandidate` to `LiveSession`. Captured at drain, consumed in `send()`. Pure helpers — `renderQuoteAnchor`, `prependQuoteAnchor`, `captureQuoteCandidate`, `decideQuoteAnchor` — exported for unit testing. |
| `src/channels/router.test.ts` | 7 new integration tests: threshold-not-met, threshold-met, intervening-observed, multi-send-only-first-anchored, per-turn-reset, opt-out, attachments-only. |
| `src/channels/router.quote-anchor.test.ts` | 19 new unit tests: excerpt truncation, newline collapsing, leading-`>` strip, bare-mention fallback, candidate capture, decision matrix. |

226 router tests pass (200 pre-existing + 26 new). Full suite (5387 tests) passes.

## Considered alternatives

- **Native quote-reply per adapter** — rejected for this PR; three of four adapters require agent-messenger surface changes. Deferred as a polish PR after the markdown version proves the UX.
- **Typing indicator / reaction-on-inbound** (the "did you receive me?" half) — out of scope here; complementary feature, separate PR.
- **Anchor only on the very-long-delay case** — rejected because the intervening-observed case (channel scrolled past) matters as much as the 10s case, even at sub-10s delays in a fast-moving channel.

## Compatibility & rollback

- Default behavior is anchor-when-needed; existing deployments get the new UX with no config changes.
- Per-adapter `quotedReply: { enabled: false }` disables for ops who'd rather the bot stay bare.
- Rollback is a single revert — no schema migration, no on-disk state, no protocol change.