### PR TITLE
agent: default OpenAI thinking level to low

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -8,7 +8,7 @@ import type { AgentSession, ToolDefinition } from '@mariozechner/pi-coding-agent
 import { loadMemory } from '@/bundled-plugins/memory/load-memory'
 import type { ChannelRouter } from '@/channels/router'
 import { getConfig, resolveModel, resolveProfile } from '@/config'
-import { providerForModelRef, type KnownModelRef } from '@/config/providers'
+import { defaultThinkingLevelForRef, providerForModelRef, type KnownModelRef } from '@/config/providers'
 import type { PermissionService } from '@/permissions'
 import type {
   BuiltinToolRef,
@@ -341,6 +341,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
       : customToolsPreBudget
 
   const model = resolveModel(activeRef)
+  const thinkingLevel = defaultThinkingLevelForRef(activeRef)
   const { session } = await createAgentSession({
     model,
     sessionManager,
@@ -350,6 +351,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     resourceLoader,
     ...(tools ? { tools } : {}),
     customTools,
+    ...(thinkingLevel ? { thinkingLevel } : {}),
   })
 
   // Re-narrow the active tool set after `createAgentSession`. pi 0.67.3's

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 
-import { KNOWN_PROVIDERS, listKnownModelRefs, providerForModelRef, supportsApiKey, supportsOAuth } from './providers'
+import {
+  defaultThinkingLevelForRef,
+  KNOWN_PROVIDERS,
+  listKnownModelRefs,
+  providerForModelRef,
+  supportsApiKey,
+  supportsOAuth,
+} from './providers'
 
 describe('KNOWN_PROVIDERS', () => {
   test('every provider model carries a baseUrl that matches the outer provider baseUrl', () => {
@@ -123,5 +130,36 @@ describe('providerForModelRef anthropic', () => {
 
   test('routes claude-opus-4-7 to anthropic', () => {
     expect(providerForModelRef('anthropic/claude-opus-4-7')).toBe('anthropic')
+  })
+})
+
+describe('defaultThinkingLevelForRef', () => {
+  test('OpenAI api-key models default to low', () => {
+    expect(defaultThinkingLevelForRef('openai/gpt-5.4-nano')).toBe('low')
+    expect(defaultThinkingLevelForRef('openai/gpt-5.4-mini')).toBe('low')
+    expect(defaultThinkingLevelForRef('openai/gpt-5.4')).toBe('low')
+    expect(defaultThinkingLevelForRef('openai/gpt-5.5')).toBe('low')
+  })
+
+  test('OpenAI Codex (ChatGPT Plus/Pro OAuth) models also default to low', () => {
+    expect(defaultThinkingLevelForRef('openai-codex/gpt-5.4-mini')).toBe('low')
+    expect(defaultThinkingLevelForRef('openai-codex/gpt-5.4')).toBe('low')
+    expect(defaultThinkingLevelForRef('openai-codex/gpt-5.5')).toBe('low')
+  })
+
+  test('non-OpenAI providers defer to the SDK default (returns undefined)', () => {
+    expect(defaultThinkingLevelForRef('anthropic/claude-opus-4-7')).toBeUndefined()
+    expect(defaultThinkingLevelForRef('anthropic/claude-sonnet-4-6')).toBeUndefined()
+    expect(defaultThinkingLevelForRef('anthropic/claude-haiku-4-5')).toBeUndefined()
+    expect(defaultThinkingLevelForRef('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')).toBeUndefined()
+    expect(defaultThinkingLevelForRef('zai/glm-4.6')).toBeUndefined()
+    expect(defaultThinkingLevelForRef('zai-coding/glm-5.1')).toBeUndefined()
+  })
+
+  test('every known model ref is classified (no provider falls through unhandled)', () => {
+    for (const ref of listKnownModelRefs()) {
+      const level = defaultThinkingLevelForRef(ref)
+      expect(level === 'low' || level === undefined, `${ref} returned unexpected ${String(level)}`).toBe(true)
+    }
   })
 })

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -465,6 +465,24 @@ export function providerForModelRef(ref: KnownModelRef): KnownProviderId {
   throw new Error(`Unknown provider in model ref: ${ref}`)
 }
 
+// Per-provider default for pi-coding-agent's `thinkingLevel` knob. Returning
+// `undefined` defers to the SDK default (`medium`); returning a level pins it
+// to that value at session-creation time.
+//
+// OpenAI-family providers (`openai`, `openai-codex`) pin to `low`: GPT-5.x at
+// `medium` pads reasoning tokens on routine tool-driven turns (code edits,
+// channel replies, cron prompts) with no observable quality delta on this
+// codebase's workloads. Applies to every session that resolves to a GPT model
+// regardless of profile, so the saving is uniform.
+//
+// Anthropic, GLM, and Kimi don't share the padding behavior, so they keep the
+// SDK default.
+export function defaultThinkingLevelForRef(ref: KnownModelRef): 'low' | undefined {
+  const providerId = providerForModelRef(ref)
+  if (providerId === 'openai' || providerId === 'openai-codex') return 'low'
+  return undefined
+}
+
 // `as const satisfies` narrows each entry's `auth` to a tuple of its specific
 // literal values, which makes `provider.auth.includes('oauth')` fail to
 // compile on api-key-only entries (because TS thinks the array can never


### PR DESCRIPTION
## What this PR does

Defaults `thinkingLevel` to `"low"` for every session whose resolved model belongs to an OpenAI-family provider (`openai`, `openai-codex`). All other providers — Anthropic, Z.AI (paygo + Coding Plan), Fireworks/Kimi — keep the SDK default (`"medium"`).

Single threading point: `createSessionWithDispose` in `src/agent/index.ts`, the funnel every typeclaw session flows through (TUI, channels, cron, subagents, multimodal `look-at`, model-fallback retries). So the default applies uniformly regardless of profile (`default`, `fast`, `deep`, `vision`, etc.) or origin.

## Why

GPT-5.x on pi-coding-agent's default `"medium"` aggressively pads reasoning tokens on routine tool-driven turns (code edits, channel replies, cron prompts) — the workloads typeclaw is built around. The output-token premium shows up in `typeclaw usage` without an observable quality delta on these tasks. `"low"` keeps the model reasoning where it matters (multi-step tool plans, error recovery) and stops paying for reasoning on single-step "edit this file" / "post this message" turns.

Scope is "any session that resolves to a GPT model, regardless of profile" — per the clarification in the originating thread. A narrower "only when the requested profile is `default`" rule would leave subagent calls (memory-logger, dreaming, scout) on the old default; widening to every-profile keeps the saving uniform.

## Why this layer

Three plausible homes for the override:

1. **`SettingsManager.setDefaultThinkingLevel(...)`** — would persist into pi's settings file and become globally sticky across sessions. Wrong scope; we want a per-session, per-resolved-model decision.
2. **`scopedModels[].thinkingLevel`** — pi's per-model override array, intended for the interactive `Ctrl+P` model-cycling UI. Wrong contract; we'd be retro-fitting a UI feature into runtime defaulting.
3. **Direct `thinkingLevel` arg on `createAgentSession(...)`** — pi's documented entry point for "pin this session to this level"; the SDK clamps against model capabilities (`getAvailableThinkingLevels()`) for defense-in-depth. This is the right knob.

Path 3 it is. The helper `defaultThinkingLevelForRef(ref)` lives next to `providerForModelRef` (both consult `KNOWN_PROVIDERS`) and emits `"low" | undefined`. Conditional spread (`...(thinkingLevel ? { thinkingLevel } : {})`) keeps the call site clean for the non-OpenAI case — passing `undefined` and passing nothing are semantically identical to pi today, but spreading-or-omitting matches the existing pattern in this function (`...(tools ? { tools } : {})`) and survives any future SDK change that distinguishes the two.

## What's in the diff

| File | Change |
|---|---|
| `src/config/providers.ts` | New exported `defaultThinkingLevelForRef(ref): 'low' \| undefined`. Routes through the existing `providerForModelRef` so adding a future OpenAI sibling (`openai-azure`, `openai-enterprise`) is a one-line addition to `KNOWN_PROVIDERS` + this switch. |
| `src/agent/index.ts` | One new local in `createSessionWithDispose`, threaded into `createAgentSession({ ..., thinkingLevel })` via conditional spread. Pulls the helper from `@/config/providers` next to the existing `providerForModelRef` import. |
| `src/config/providers.test.ts` | 4 new tests: openai api-key models → `"low"`, openai-codex OAuth models → `"low"`, non-OpenAI providers → `undefined`, exhaustiveness sweep over every `listKnownModelRefs()` ref to guarantee no provider falls through unhandled. |

## Why no test on `createSessionWithDispose`

`createSession` requires a real `Model<>`, real auth, real resource loader — none of the existing 18+ `.test.ts` files under `src/agent/` exercise it at this layer. The decision lives entirely in the pure helper; testing it there (with a mutation check verified locally — see "Verification" below) covers the behavior. The call-site wiring is one line and visually verifiable in the diff.

## Considered alternatives

- **`"minimal"` instead of `"low"`** — `minimal` exists in pi's `ThinkingLevel` union and would save even more. Rejected: it's near-zero reasoning, which empirically hurts on multi-step tool orchestration. `low` is the right floor for typeclaw's mixed workloads (tool calls AND prose AND code edits) per the originating discussion.
- **Per-provider config in `typeclaw.json`** — would let operators tune per-model. Rejected for this PR as scope creep; the runtime default is what matters. A `models[profile].thinkingLevel` schema field can layer on later without rewriting this helper.
- **Apply only to the `default` profile** — earlier proposal. Rejected per the in-thread clarification ("all models" → uniform across profiles).
- **Branch on `model.api` (`openai-responses` / `openai-codex-responses`) instead of provider id** — would naturally extend if a future provider runs GPT-shaped APIs through a non-`openai*` provider id. Rejected: every OpenAI provider in `KNOWN_PROVIDERS` already routes through one of those two api strings, and reading provider-id is more obvious to a future reader than reading api-shape. Easy to refactor later if a new provider needs it.

## Verification

```
bun run typecheck   ✓
bun run lint        ✓  (61 pre-existing warnings, untouched)
bun run format:check ✓
bun run test        5365 pass / 7 fail / 11839 expect() calls
```

The 7 failing tests (`typeclaw.schema.json` / `cron.schema.json` / `secrets.schema.json` / `auth.schema.json` drift guards + 2 scaffold tests) reproduce identically on clean `origin/main` and are unrelated to this PR.

**Mutation check** — verified locally that neutralizing the helper (`if (false) return 'low'`) causes 2 of the 4 new tests to fail with `Expected "low", Received: undefined`. The tests are coupled to behavior, not implementation; renaming the function or refactoring its internals leaves them green.

## Compatibility & rollback

- No schema change, no on-disk state, no protocol change.
- Existing agents pick up the new default on their next `typeclaw start` — no `--build` required (this is application code, not a Dockerfile change).
- Operators who want `"medium"` back today can pin the model to a non-OpenAI provider, or wait for the per-profile `thinkingLevel` schema field follow-up. There is no in-tree override knob in this PR; that's deliberate (one decision, one PR).
- Rollback is a single revert. No follow-up cleanup needed.
