### PR TITLE
channels: fix quote-anchor cold-start fire, mention syntax, reply bleed

### DIFF
--- a/src/channels/router.quote-anchor.test.ts
+++ b/src/channels/router.quote-anchor.test.ts
@@ -15,76 +15,161 @@ const baseConfig: ChannelAdapterConfig = {
 
 const humanInbound = {
   text: 'hey there',
+  authorId: 'U_ALICE',
   authorName: 'Alice',
   authorIsBot: false,
   receivedAt: 1000,
 }
 
 describe('renderQuoteAnchor', () => {
-  test('formats single-line user text verbatim', () => {
-    expect(renderQuoteAnchor({ authorName: 'Alice', text: 'hello' })).toBe('> @Alice: hello')
+  test('Slack: emits a real `<@authorId>` mention so the quote anchors against the platform-native mention', () => {
+    expect(renderQuoteAnchor({ adapter: 'slack-bot', authorId: 'U_ALICE', authorName: 'Alice', text: 'hello' })).toBe(
+      '> <@U_ALICE>: hello',
+    )
+  })
+
+  test('Discord: emits a real `<@authorId>` mention', () => {
+    expect(
+      renderQuoteAnchor({ adapter: 'discord-bot', authorId: '123456789', authorName: 'Alice', text: 'hello' }),
+    ).toBe('> <@123456789>: hello')
+  })
+
+  test('Telegram: falls back to plain authorName (no reliable id-only mention syntax in markdown)', () => {
+    expect(renderQuoteAnchor({ adapter: 'telegram-bot', authorId: '42', authorName: 'Alice', text: 'hello' })).toBe(
+      '> Alice: hello',
+    )
+  })
+
+  test('KakaoTalk: falls back to plain authorName (platform has no mention syntax)', () => {
+    expect(renderQuoteAnchor({ adapter: 'kakaotalk', authorId: 'u-1', authorName: 'Alice', text: 'hello' })).toBe(
+      '> Alice: hello',
+    )
+  })
+
+  test('GitHub: falls back to plain authorName (inbound authorId is a numeric user id, not the handle)', () => {
+    expect(renderQuoteAnchor({ adapter: 'github', authorId: '12345', authorName: 'alice', text: 'hello' })).toBe(
+      '> alice: hello',
+    )
+  })
+
+  test('does NOT emit a literal `> @name:` form on any adapter (PR #374 regression)', () => {
+    for (const adapter of ['slack-bot', 'discord-bot', 'telegram-bot', 'kakaotalk', 'github'] as const) {
+      const out = renderQuoteAnchor({ adapter, authorId: 'U1', authorName: 'Alice', text: 'hi' })
+      expect(out.startsWith('> @')).toBe(false)
+    }
   })
 
   test('collapses newlines so the quote stays on one line', () => {
-    expect(renderQuoteAnchor({ authorName: 'Bob', text: 'line one\nline two\n\nline three' })).toBe(
-      '> @Bob: line one line two line three',
-    )
+    expect(
+      renderQuoteAnchor({
+        adapter: 'slack-bot',
+        authorId: 'U1',
+        authorName: 'Bob',
+        text: 'line one\nline two\n\nline three',
+      }),
+    ).toBe('> <@U1>: line one line two line three')
   })
 
   test('truncates excerpts longer than the cap with an ellipsis', () => {
     const long = 'a'.repeat(QUOTED_REPLY_EXCERPT_MAX_CHARS + 50)
-    const out = renderQuoteAnchor({ authorName: 'Carol', text: long })
-    expect(out.length).toBe('> @Carol: '.length + QUOTED_REPLY_EXCERPT_MAX_CHARS)
+    const out = renderQuoteAnchor({ adapter: 'kakaotalk', authorId: 'u-1', authorName: 'Carol', text: long })
+    expect(out.length).toBe('> Carol: '.length + QUOTED_REPLY_EXCERPT_MAX_CHARS)
     expect(out.endsWith('…')).toBe(true)
   })
 
   test('falls back to a no-text marker for bare-mention inbounds', () => {
-    expect(renderQuoteAnchor({ authorName: 'Dave', text: '   ' })).toBe('> @Dave: (no text)')
-    expect(renderQuoteAnchor({ authorName: 'Dave', text: '' })).toBe('> @Dave: (no text)')
+    expect(renderQuoteAnchor({ adapter: 'slack-bot', authorId: 'U1', authorName: 'Dave', text: '   ' })).toBe(
+      '> <@U1>: (no text)',
+    )
+    expect(renderQuoteAnchor({ adapter: 'slack-bot', authorId: 'U1', authorName: 'Dave', text: '' })).toBe(
+      '> <@U1>: (no text)',
+    )
   })
 
   test('strips a leading > so a quote-of-a-quote stays single-level', () => {
-    expect(renderQuoteAnchor({ authorName: 'Eve', text: '> their reply\nfollowup' })).toBe(
-      '> @Eve: their reply followup',
-    )
+    expect(
+      renderQuoteAnchor({
+        adapter: 'discord-bot',
+        authorId: '987',
+        authorName: 'Eve',
+        text: '> their reply\nfollowup',
+      }),
+    ).toBe('> <@987>: their reply followup')
   })
 })
 
 describe('prependQuoteAnchor', () => {
-  test('separates the anchor and reply with a single newline', () => {
-    expect(prependQuoteAnchor('I see you', { authorName: 'Alice', text: 'yo' })).toBe('> @Alice: yo\nI see you')
+  test('separates the anchor and reply with a blank line so the blockquote does not swallow the reply', () => {
+    expect(
+      prependQuoteAnchor('I see you', { adapter: 'slack-bot', authorId: 'U_ALICE', authorName: 'Alice', text: 'yo' }),
+    ).toBe('> <@U_ALICE>: yo\n\nI see you')
   })
 
   test('returns just the anchor when the reply text is empty (attachment-only)', () => {
-    expect(prependQuoteAnchor('', { authorName: 'Alice', text: 'yo' })).toBe('> @Alice: yo')
+    expect(prependQuoteAnchor('', { adapter: 'slack-bot', authorId: 'U_ALICE', authorName: 'Alice', text: 'yo' })).toBe(
+      '> <@U_ALICE>: yo',
+    )
   })
 })
 
 describe('captureQuoteCandidate', () => {
   test('returns null when the batch is empty', () => {
-    expect(captureQuoteCandidate([], [])).toBeNull()
+    expect(captureQuoteCandidate('slack-bot', [], [])).toBeNull()
   })
 
   test('returns null when the primary inbound is a bot', () => {
-    expect(captureQuoteCandidate([{ ...humanInbound, authorIsBot: true }], [])).toBeNull()
+    expect(captureQuoteCandidate('slack-bot', [{ ...humanInbound, authorIsBot: true }], [])).toBeNull()
   })
 
-  test('captures the LAST batch entry as primary (matches drain semantics)', () => {
-    const earlier = { ...humanInbound, authorName: 'Earlier', text: 'first', receivedAt: 1000 }
-    const later = { ...humanInbound, authorName: 'Later', text: 'second', receivedAt: 2000 }
-    const result = captureQuoteCandidate([earlier, later], [])
-    expect(result?.source).toEqual({ authorName: 'Later', text: 'second' })
+  test('captures the LAST batch entry as primary and stamps the adapter onto source', () => {
+    const earlier = { ...humanInbound, authorId: 'U_EARLY', authorName: 'Earlier', text: 'first', receivedAt: 1000 }
+    const later = { ...humanInbound, authorId: 'U_LATE', authorName: 'Later', text: 'second', receivedAt: 2000 }
+    const result = captureQuoteCandidate('slack-bot', [earlier, later], [])
+    expect(result?.source).toEqual({ adapter: 'slack-bot', authorId: 'U_LATE', authorName: 'Later', text: 'second' })
     expect(result?.primaryReceivedAt).toBe(2000)
   })
 
-  test('flags hadInterveningObserved when any observed entry landed at-or-after the primary', () => {
-    const result = captureQuoteCandidate([humanInbound], [{ receivedAt: humanInbound.receivedAt + 100 }])
+  test('flags hadInterveningObserved when a live-observed entry landed at-or-after the primary', () => {
+    const result = captureQuoteCandidate(
+      'slack-bot',
+      [humanInbound],
+      [{ receivedAt: humanInbound.receivedAt + 100, source: 'observed' }],
+    )
     expect(result?.hadInterveningObserved).toBe(true)
   })
 
-  test('clears hadInterveningObserved when all observed entries predate the primary', () => {
-    const result = captureQuoteCandidate([humanInbound], [{ receivedAt: humanInbound.receivedAt - 100 }])
+  test('clears hadInterveningObserved when all live-observed entries predate the primary', () => {
+    const result = captureQuoteCandidate(
+      'slack-bot',
+      [humanInbound],
+      [{ receivedAt: humanInbound.receivedAt - 100, source: 'observed' }],
+    )
     expect(result?.hadInterveningObserved).toBe(false)
+  })
+
+  test('ignores prefetched scrollback when computing hadInterveningObserved (cold-start regression)', () => {
+    const result = captureQuoteCandidate(
+      'slack-bot',
+      [humanInbound],
+      [
+        { receivedAt: humanInbound.receivedAt + 100, source: 'prefetch' },
+        { receivedAt: humanInbound.receivedAt + 200, source: 'prefetch' },
+        { receivedAt: humanInbound.receivedAt + 300, source: 'prefetch' },
+      ],
+    )
+    expect(result?.hadInterveningObserved).toBe(false)
+  })
+
+  test('mixed prefetch+observed: only the live-observed entries count', () => {
+    const result = captureQuoteCandidate(
+      'slack-bot',
+      [humanInbound],
+      [
+        { receivedAt: humanInbound.receivedAt + 100, source: 'prefetch' },
+        { receivedAt: humanInbound.receivedAt + 200, source: 'observed' },
+      ],
+    )
+    expect(result?.hadInterveningObserved).toBe(true)
   })
 })
 
@@ -94,46 +179,52 @@ describe('decideQuoteAnchor', () => {
   })
 
   test('returns null when send-time delay is below threshold and no intervening observed', () => {
-    const candidate = captureQuoteCandidate([humanInbound], [])!
+    const candidate = captureQuoteCandidate('slack-bot', [humanInbound], [])!
     expect(decideQuoteAnchor(candidate, humanInbound.receivedAt + 1_000, baseConfig)).toBeNull()
   })
 
   test('returns the anchor when send-time delay crosses the default threshold', () => {
-    const candidate = captureQuoteCandidate([humanInbound], [])!
+    const candidate = captureQuoteCandidate('slack-bot', [humanInbound], [])!
     const out = decideQuoteAnchor(
       candidate,
       humanInbound.receivedAt + DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS + 1,
       baseConfig,
     )
-    expect(out).toEqual({ authorName: 'Alice', text: 'hey there' })
+    expect(out).toEqual({ adapter: 'slack-bot', authorId: 'U_ALICE', authorName: 'Alice', text: 'hey there' })
   })
 
   test('returns the anchor when an observed message landed after the primary, even within threshold', () => {
-    const candidate = captureQuoteCandidate([humanInbound], [{ receivedAt: humanInbound.receivedAt + 500 }])!
+    const candidate = captureQuoteCandidate(
+      'slack-bot',
+      [humanInbound],
+      [{ receivedAt: humanInbound.receivedAt + 500, source: 'observed' }],
+    )!
     const out = decideQuoteAnchor(candidate, humanInbound.receivedAt + 1_000, baseConfig)
-    expect(out).toEqual({ authorName: 'Alice', text: 'hey there' })
+    expect(out).toEqual({ adapter: 'slack-bot', authorId: 'U_ALICE', authorName: 'Alice', text: 'hey there' })
   })
 
   test('respects an explicit enabled: false override', () => {
-    const candidate = captureQuoteCandidate([humanInbound], [])!
+    const candidate = captureQuoteCandidate('slack-bot', [humanInbound], [])!
     const disabled: ChannelAdapterConfig = { ...baseConfig, quotedReply: { enabled: false, queueDelayMs: 0 } }
     const out = decideQuoteAnchor(candidate, humanInbound.receivedAt + 999_999, disabled)
     expect(out).toBeNull()
   })
 
   test('respects a custom queueDelayMs', () => {
-    const candidate = captureQuoteCandidate([humanInbound], [])!
+    const candidate = captureQuoteCandidate('slack-bot', [humanInbound], [])!
     const aggressive: ChannelAdapterConfig = { ...baseConfig, quotedReply: { enabled: true, queueDelayMs: 0 } }
     expect(decideQuoteAnchor(candidate, humanInbound.receivedAt, aggressive)).toEqual({
+      adapter: 'slack-bot',
+      authorId: 'U_ALICE',
       authorName: 'Alice',
       text: 'hey there',
     })
   })
 
   test('falls back to the default threshold when the adapter has no quotedReply config', () => {
-    const candidate = captureQuoteCandidate([humanInbound], [])!
+    const candidate = captureQuoteCandidate('slack-bot', [humanInbound], [])!
     expect(
       decideQuoteAnchor(candidate, humanInbound.receivedAt + DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS + 1, baseConfig),
-    ).toEqual({ authorName: 'Alice', text: 'hey there' })
+    ).toEqual({ adapter: 'slack-bot', authorId: 'U_ALICE', authorName: 'Alice', text: 'hey there' })
   })
 })

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4771,7 +4771,32 @@ describe('ChannelRouter quote-anchor on outbound', () => {
     expect(sent).toEqual(['yes'])
   })
 
-  test('prepends a `> @author: excerpt` quote when the reply crosses the queueDelayMs threshold', async () => {
+  test('does NOT anchor a cold-start first turn just because prefetched scrollback exists (PR #374 regression)', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: string[] = []
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+    router.registerHistory('discord-bot', async () => ({
+      ok: true,
+      messages: [
+        historyMessage({ externalMessageId: 'h1', text: 'old chatter 1' }),
+        historyMessage({ externalMessageId: 'h2', text: 'old chatter 2' }),
+      ],
+    }))
+
+    await router.route(inbound({ text: 'hey bot', authorName: 'Alice' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    nowRef.value += 500
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'hi back' })
+    expect(sent).toEqual(['hi back'])
+  })
+
+  test('prepends a `> <@authorId>: excerpt` Discord mention when the reply crosses the queueDelayMs threshold', async () => {
     const dir = await tempDir()
     const nowRef = { value: 1_000_000 }
     const sent: string[] = []
@@ -4781,12 +4806,12 @@ describe('ChannelRouter quote-anchor on outbound', () => {
       return { ok: true }
     })
 
-    await router.route(inbound({ text: 'are you there?', authorName: 'Alice' }))
+    await router.route(inbound({ text: 'are you there?', authorId: 'U_ALICE', authorName: 'Alice' }))
     await router.__testing!.flushDebounce(KEY)
 
     nowRef.value += 60_000
     await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'yes I am here' })
-    expect(sent).toEqual(['> @Alice: are you there?\nyes I am here'])
+    expect(sent).toEqual(['> <@U_ALICE>: are you there?\n\nyes I am here'])
   })
 
   test('prepends a quote when an observed message landed between inbound and reply, even within the threshold', async () => {
@@ -4799,7 +4824,7 @@ describe('ChannelRouter quote-anchor on outbound', () => {
       return { ok: true }
     })
 
-    await router.route(inbound({ text: 'cron status?', authorName: 'Alice' }))
+    await router.route(inbound({ text: 'cron status?', authorId: 'U_ALICE', authorName: 'Alice' }))
     nowRef.value += 100
     await router.route(
       inbound({
@@ -4814,7 +4839,7 @@ describe('ChannelRouter quote-anchor on outbound', () => {
     nowRef.value += 200
 
     await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'still blocked' })
-    expect(sent[0]).toContain('> @Alice: cron status?')
+    expect(sent[0]).toContain('> <@U_ALICE>: cron status?')
     expect(sent[0]).toContain('still blocked')
   })
 
@@ -4828,14 +4853,14 @@ describe('ChannelRouter quote-anchor on outbound', () => {
       return { ok: true }
     })
 
-    await router.route(inbound({ text: 'walk me through it', authorName: 'Alice' }))
+    await router.route(inbound({ text: 'walk me through it', authorId: 'U_ALICE', authorName: 'Alice' }))
     await router.__testing!.flushDebounce(KEY)
     nowRef.value += 60_000
 
     await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'first chunk' })
     await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'second chunk' })
     await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'third chunk' })
-    expect(sent).toEqual(['> @Alice: walk me through it\nfirst chunk', 'second chunk', 'third chunk'])
+    expect(sent).toEqual(['> <@U_ALICE>: walk me through it\n\nfirst chunk', 'second chunk', 'third chunk'])
   })
 
   test('resets per turn so the next batch can anchor again', async () => {
@@ -4848,18 +4873,18 @@ describe('ChannelRouter quote-anchor on outbound', () => {
       return { ok: true }
     })
 
-    await router.route(inbound({ text: 'turn one', authorName: 'Alice', externalMessageId: 'm1' }))
+    await router.route(inbound({ text: 'turn one', authorId: 'U_ALICE', authorName: 'Alice', externalMessageId: 'm1' }))
     await router.__testing!.flushDebounce(KEY)
     nowRef.value += 60_000
     await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply one' })
 
-    await router.route(inbound({ text: 'turn two', authorName: 'Alice', externalMessageId: 'm2' }))
+    await router.route(inbound({ text: 'turn two', authorId: 'U_ALICE', authorName: 'Alice', externalMessageId: 'm2' }))
     await router.__testing!.flushDebounce(KEY)
     nowRef.value += 60_000
     await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply two' })
 
-    expect(sent[0]).toBe('> @Alice: turn one\nreply one')
-    expect(sent[1]).toBe('> @Alice: turn two\nreply two')
+    expect(sent[0]).toBe('> <@U_ALICE>: turn one\n\nreply one')
+    expect(sent[1]).toBe('> <@U_ALICE>: turn two\n\nreply two')
   })
 
   test('respects an adapter config opting out via quotedReply.enabled: false', async () => {
@@ -4894,7 +4919,7 @@ describe('ChannelRouter quote-anchor on outbound', () => {
       return { ok: true }
     })
 
-    await router.route(inbound({ text: 'screenshot pls', authorName: 'Alice' }))
+    await router.route(inbound({ text: 'screenshot pls', authorId: 'U_ALICE', authorName: 'Alice' }))
     await router.__testing!.flushDebounce(KEY)
     nowRef.value += 60_000
 
@@ -4904,6 +4929,6 @@ describe('ChannelRouter quote-anchor on outbound', () => {
       chat: 'c1',
       attachments: [{ path: '/agent/screen.png' }],
     })
-    expect(sent[0]?.text).toBe('> @Alice: screenshot pls')
+    expect(sent[0]?.text).toBe('> <@U_ALICE>: screenshot pls')
   })
 })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -32,6 +32,7 @@ import {
 import {
   DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS,
   QUOTED_REPLY_EXCERPT_MAX_CHARS,
+  type AdapterId,
   type ChannelAdapterConfig,
 } from './schema'
 import type {
@@ -234,6 +235,19 @@ type ObservedInbound = {
   authorIsBot: boolean
   receivedAt: number
   ts: number
+  // Distinguishes scrollback that was bulk-loaded at session cold-start
+  // (`prefetch`) from messages that actually arrived in the channel after
+  // the session went live (`observed`). Both share the same in-memory
+  // shape because the model sees them identically in the prompt's
+  // "Recent context" block, but the quote-anchor decision must treat them
+  // differently: prefetched scrollback is HISTORICAL context, not new
+  // chatter that happened between the primary inbound and the agent's
+  // reply. Counting prefetch entries as "intervening" would fire the
+  // anchor on every fresh-thread first turn (the prefetch stamps
+  // `receivedAt = now()` AFTER the inbound was received during ensureLive,
+  // so by primary-vs-observed timestamp comparison they always look
+  // "later"). See captureQuoteCandidate.
+  source: 'prefetch' | 'observed'
 }
 
 type LiveSession = {
@@ -1019,6 +1033,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           authorIsBot: item.message.isBot,
           receivedAt: now(),
           ts: item.message.ts,
+          source: 'prefetch',
         })
       } else {
         observed.push({
@@ -1028,6 +1043,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           authorIsBot: true,
           receivedAt: now(),
           ts: 0,
+          source: 'prefetch',
         })
       }
     }
@@ -1227,7 +1243,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.currentTurnAuthorIds = new Set(batch.map((m) => m.authorId))
           live.consecutiveSends.clear()
           live.lastSentText.clear()
-          live.pendingQuoteCandidate = captureQuoteCandidate(batch, observed)
+          live.pendingQuoteCandidate = captureQuoteCandidate(live.key.adapter, batch, observed)
         } else if (live.lastTurnAuthorId !== null) {
           // Reminder-only turn (batch.length === 0, reminders.length > 0):
           // restore the author identity from the prior turn so author-
@@ -1538,6 +1554,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       authorIsBot: event.authorIsBot,
       receivedAt: now(),
       ts: event.ts,
+      source: 'observed',
     })
     if (live.contextBuffer.length > CONTEXT_BUFFER_SIZE) {
       live.contextBuffer.splice(0, live.contextBuffer.length - CONTEXT_BUFFER_SIZE)
@@ -2263,11 +2280,45 @@ function formatAuthorLine(
 }
 
 export type QuoteAnchorSource = {
+  adapter: AdapterId
+  authorId: string
   authorName: string
   text: string
 }
 
-// Renders the single-line `> @name: excerpt` blockquote prepended to
+// Picks the right author syntax for the platform so the rendered anchor
+// shows a real, clickable mention link (Slack/Discord) instead of literal
+// `@name` text. The literal-text form was the original bug report on
+// PR #374: a plain `@username` string inside the quote looks like (but
+// isn't) a Slack mention; users read that as "wrong-shape mention"
+// because the platform-native form would have been `<@U…>`. Adapters
+// without a stable id-only mention syntax (Telegram dot-form
+// `[name](tg://user?id=)`
+// requires MarkdownV2 escaping; KakaoTalk has no mention syntax at all;
+// GitHub uses `@handle` but the inbound `authorId` is a numeric user id,
+// not the handle) fall back to plain `authorName` so a malformed mention
+// never ships to the platform.
+//
+// Notification semantics: Slack and Discord both render `<@…>` as a
+// styled mention link inside blockquotes; whether the mentioned user is
+// PINGED is a separate platform-level UX (Slack pings on first appearance
+// in the message regardless of position, Discord respects the
+// `allowed_mentions` field which defaults to "ping everyone parsed").
+// This matches PR #374's intent — the user IS being notified that the
+// agent replied to them, which is the whole point of a quote anchor.
+function formatAuthorMention(adapter: AdapterId, authorId: string, authorName: string): string {
+  switch (adapter) {
+    case 'slack-bot':
+    case 'discord-bot':
+      return `<@${authorId}>`
+    case 'telegram-bot':
+    case 'kakaotalk':
+    case 'github':
+      return authorName
+  }
+}
+
+// Renders the single-line `> @mention: excerpt` blockquote prepended to
 // outbound replies when the router decides the reply needs an anchor.
 // Collapses newlines to spaces so a multi-line user message renders on
 // one quoted line (markdown blockquote semantics: a blank line ends the
@@ -2286,17 +2337,27 @@ export function renderQuoteAnchor(source: QuoteAnchorSource): string {
       : collapsed.length > QUOTED_REPLY_EXCERPT_MAX_CHARS
         ? `${collapsed.slice(0, QUOTED_REPLY_EXCERPT_MAX_CHARS - 1)}…`
         : collapsed
-  return `> @${source.authorName}: ${excerpt}`
+  const mention = formatAuthorMention(source.adapter, source.authorId, source.authorName)
+  return `> ${mention}: ${excerpt}`
 }
 
+// Separates the anchor from the reply with a blank line (`\n\n`), not a
+// single `\n`. In standard GFM and Slack's `markdown` block, a single
+// `\n` inside a paragraph is a soft break rendered as whitespace, which
+// keeps the `>` blockquote styling running visually through the next
+// line — i.e. the agent's reply text gets swallowed into the quote. The
+// blank line forces a paragraph boundary that unambiguously ends the
+// blockquote on every renderer (CommonMark, GFM, Slack mrkdwn, Discord
+// markdown).
 export function prependQuoteAnchor(replyText: string, source: QuoteAnchorSource): string {
   const anchor = renderQuoteAnchor(source)
   if (replyText === '') return anchor
-  return `${anchor}\n${replyText}`
+  return `${anchor}\n\n${replyText}`
 }
 
 type QuoteAnchorBatchEntry = {
   text: string
+  authorId: string
   authorName: string
   authorIsBot: boolean
   receivedAt: number
@@ -2304,6 +2365,7 @@ type QuoteAnchorBatchEntry = {
 
 type QuoteAnchorObservedEntry = {
   receivedAt: number
+  source: 'prefetch' | 'observed'
 }
 
 export type QuoteAnchorCandidate = {
@@ -2316,16 +2378,27 @@ export type QuoteAnchorCandidate = {
 // the send-side decision has the data it needs without holding a
 // reference to the batch arrays. Returns null when there's nothing
 // anchorable (empty batch, primary is a bot).
+//
+// `hadInterveningObserved` counts ONLY live observations (`source ===
+// 'observed'`), not prefetched scrollback. Prefetch stamps `receivedAt =
+// now()` inside ensureLive — wall-clock-later than the primary inbound
+// that triggered ensureLive — so without this gate, every cold-start
+// first turn would see "intervening observed" entries and fire the
+// quote anchor even when the reply lands within milliseconds. The
+// signal we actually want is "did real new chatter arrive between the
+// user's inbound and the agent's reply", which only live observations
+// represent.
 export function captureQuoteCandidate(
+  adapter: AdapterId,
   batch: readonly QuoteAnchorBatchEntry[],
   observed: readonly QuoteAnchorObservedEntry[],
 ): QuoteAnchorCandidate | null {
   if (batch.length === 0) return null
   const primary = batch[batch.length - 1]!
   if (primary.authorIsBot) return null
-  const hadInterveningObserved = observed.some((o) => o.receivedAt >= primary.receivedAt)
+  const hadInterveningObserved = observed.some((o) => o.source === 'observed' && o.receivedAt >= primary.receivedAt)
   return {
-    source: { authorName: primary.authorName, text: primary.text },
+    source: { adapter, authorId: primary.authorId, authorName: primary.authorName, text: primary.text },
     primaryReceivedAt: primary.receivedAt,
     hadInterveningObserved,
   }


### PR DESCRIPTION
## What this PR fixes

PR #374 introduced the quote-anchor feature (auto-prepend `> author: excerpt` when a reply lands after a delay or intervening chatter). It shipped with three bugs that combined into one broken rendering in production.

Real-world repro on Slack: a user sent a fresh mention in a brand-new thread. The agent replied ~22s later. Slack rendered the **entire reply** — anchor plus the bot's full ~600-character answer — as a single blockquote attributed to the user. The anchor contained a literal `@username` string that looked like a Slack mention but wasn't one — no chip, no link, no notification.

## Why (root causes)

### 1. Cold-start prefetch poisoned `hadInterveningObserved`

`prefetchChannelContext` fills `contextBuffer` with historical channel/thread scrollback. Each entry was stamped with `receivedAt: now()` at **prefetch time** — which runs inside `ensureLive`, wall-clock-after the inbound that triggered it.

`captureQuoteCandidate` then evaluated:

```ts
observed.some(o => o.receivedAt >= primary.receivedAt)
```

This was always `true` on the first turn of any fresh thread or channel, because all prefetched entries had timestamps ≥ the inbound. The anchor fired even on instant replies where no real chatter had intervened.

**Fix:** tag each entry with `source: 'prefetch' | 'observed'`. Gate the intervening check on `source === 'observed'`. Prefetched scrollback is historical context, not live chatter.

### 2. Quote anchor used literal `@authorName` instead of platform-native mention syntax

The format was `> @${authorName}: …`. On Slack and Discord this renders as a plain `@username` string — it looks like a mention but isn't one. The native Slack form `<@U…>` renders as a styled, clickable mention chip that resolves to the user's display name; `> @username` does neither. Users read this as "wrong-shape mention" because every other mention in the channel is a real chip.

**Fix:** dispatch on adapter. Slack and Discord get the native `<@${authorId}>` form — the client renders it as a styled, clickable mention chip inside the quote. Telegram, KakaoTalk, and GitHub fall back to plain `${authorName}`:

- Telegram needs MarkdownV2-escaped `[name](tg://user?id=…)` — not safe to emit in a general quote context.
- KakaoTalk has no mention syntax at all.
- GitHub's `authorId` is a numeric user id, not the `@handle` GitHub mentions require.

`renderQuoteAnchor` dispatches through a new `formatAuthorMention(adapter, authorId, authorName)` helper. `QuoteAnchorSource` and `QuoteAnchorBatchEntry` now carry `adapter: AdapterId` and `authorId: string` alongside `authorName`; `captureQuoteCandidate` takes `adapter` as its first arg; the drain-site call site passes `live.key.adapter`.

### 3. Single `\n` between anchor and reply swallowed by the blockquote

`prependQuoteAnchor` joined anchor and reply with a single `\n`. In standard GFM and Slack's markdown block, a single `\n` is a **soft break** (rendered as a space), so the `>` blockquote styling extended through the reply line. The captured Slack output had zero newline characters stored — the soft break collapsed during render, leaving everything on one line inside the quote.

**Fix:** use `\n\n` (paragraph boundary), which unambiguously ends the blockquote on every renderer (CommonMark, GFM, Slack mrkdwn, Discord).

## What's in the diff

3 files, +243 / -54.

| File | Change |
|---|---|
| `src/channels/router.ts` | Adds `source: 'prefetch' \| 'observed'` to `ObservedInbound`; stamps `'prefetch'` at `prefetchChannelContext` push sites and `'observed'` in `observe()`; `captureQuoteCandidate` filters intervening check on `source === 'observed'`; adds `formatAuthorMention` dispatcher; threads `adapter` + `authorId` through `QuoteAnchorSource` / `QuoteAnchorBatchEntry` / `captureQuoteCandidate`; `prependQuoteAnchor` joins with `\n\n`. |
| `src/channels/router.quote-anchor.test.ts` | Per-adapter unit tests for `renderQuoteAnchor` covering Slack/Discord (native `<@authorId>`), Telegram/KakaoTalk/GitHub (plain `authorName`); matrix test pinning no adapter emits the `> @name:` regression shape from PR #374; new tests for `captureQuoteCandidate` ignoring prefetched scrollback and counting mixed prefetch+observed correctly. |
| `src/channels/router.test.ts` | Integration tests updated to the new adapter-aware mention shape (`<@authorId>` for Discord) and the `\n\n` separator; adds the cold-start-prefetch-doesn't-anchor regression test. |

## Before / After

**Before (PR #374, Slack):**

```
> @username: hi

actual reply text here — all one blockquote, reply visually attributed to the user
```

**After (this PR, Slack):**

```
> <@U_ALICE>: hi

actual reply text here — unquoted, preceded by a paragraph break, with a real @Alice mention chip in the quote
```

## Verification

```
bun run typecheck    ✓
bun run lint         ✓  (61 pre-existing warnings, none on changed files)
bun run format:check ✓
bun run test         5406 pass / 0 fail
```

## Compatibility

- No schema changes. Existing `quotedReply.enabled` / `quotedReply.queueDelayMs` config keys still work as-is.
- Single revert restores PR #374 as-was; no on-disk state to migrate.
