### PR TITLE
inspect: keep esc signal alive across picker pause/resume

### DIFF
--- a/src/cli/inspect-controller.test.ts
+++ b/src/cli/inspect-controller.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createEscController } from './inspect-controller'
+
+function tick(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe('createEscController', () => {
+  test('bare ESC after debounce window aborts the armed signal', async () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    const signal = ctrl.armForStream()
+    ctrl.onChunk(Buffer.from([0x1b]))
+    expect(signal.aborted).toBe(false)
+    await tick(30)
+    expect(signal.aborted).toBe(true)
+  })
+
+  test('CSI follow-up byte within debounce window cancels the pending abort', async () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    const signal = ctrl.armForStream()
+    ctrl.onChunk(Buffer.from([0x1b]))
+    ctrl.onChunk(Buffer.from([0x5b, 0x41]))
+    await tick(30)
+    expect(signal.aborted).toBe(false)
+  })
+
+  test('Ctrl-C surfaces sigint=true and never aborts the esc signal', async () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    const signal = ctrl.armForStream()
+    const { sigint } = ctrl.onChunk(Buffer.from([0x03]))
+    expect(sigint).toBe(true)
+    await tick(30)
+    expect(signal.aborted).toBe(false)
+  })
+
+  test('signal handed out by armForStream still aborts on ESC after clearPending → re-arm of listener (the picker pause/resume cycle)', async () => {
+    // given: a stream is armed (caller stashes the signal as escSignal)
+    const ctrl = createEscController({ debounceMs: 10 })
+    const escSignal = ctrl.armForStream()
+    // when: caller pauses the listener (picker opens) and later resumes it
+    //       without re-arming — the original escSignal must remain bound to a
+    //       live controller across this cycle, mirroring the inspect-loop flow
+    //       where runInspect's chooseSession() pauses and re-enables raw mode
+    //       in selectSession's finally block before streamSession is called.
+    ctrl.clearPending()
+    // and: after resume the user presses ESC during live tail
+    ctrl.onChunk(Buffer.from([0x1b]))
+    await tick(30)
+    // then: the signal the live source is listening on must abort.
+    //       In the regressing implementation, resume() recreated the
+    //       AbortController, leaving escSignal detached. This test pins
+    //       the bug at the controller layer with no TTY involvement.
+    expect(escSignal.aborted).toBe(true)
+  })
+
+  test('armForStream after a previous arm: new signal aborts on ESC; old signal stays untouched', async () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    const firstSignal = ctrl.armForStream()
+    const secondSignal = ctrl.armForStream()
+    ctrl.onChunk(Buffer.from([0x1b]))
+    await tick(30)
+    expect(secondSignal.aborted).toBe(true)
+    expect(firstSignal.aborted).toBe(false)
+  })
+
+  test('pending timer from a previous arm does not abort a freshly armed signal', async () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    ctrl.armForStream()
+    ctrl.onChunk(Buffer.from([0x1b]))
+    const freshSignal = ctrl.armForStream()
+    await tick(30)
+    expect(freshSignal.aborted).toBe(false)
+  })
+
+  test('dispose cancels any pending timer and detaches the controller', async () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    const signal = ctrl.armForStream()
+    ctrl.onChunk(Buffer.from([0x1b]))
+    ctrl.dispose()
+    await tick(30)
+    expect(signal.aborted).toBe(false)
+  })
+
+  test('empty chunk is a no-op', async () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    const signal = ctrl.armForStream()
+    const { sigint } = ctrl.onChunk(Buffer.alloc(0))
+    expect(sigint).toBe(false)
+    await tick(30)
+    expect(signal.aborted).toBe(false)
+  })
+})

--- a/src/cli/inspect-controller.ts
+++ b/src/cli/inspect-controller.ts
@@ -1,0 +1,66 @@
+// Pure controller for the inspect CLI's esc/ctrl-c key dispatch.
+// Owns the AbortController lifecycle and the bare-ESC debounce timer,
+// independent of process.stdin / TTY raw mode (which is wired in src/cli/inspect.ts).
+// Extracted for testability: the lifecycle bug we want to pin is "armForStream's
+// signal must remain valid across pause()/resume() cycles" — verifying that without
+// a real TTY requires this seam.
+
+export type EscChunkResult = { sigint: boolean }
+
+export type EscController = {
+  armForStream: () => AbortSignal
+  onChunk: (chunk: Buffer) => EscChunkResult
+  clearPending: () => void
+  dispose: () => void
+}
+
+export function createEscController({ debounceMs }: { debounceMs: number }): EscController {
+  let currentCtrl: AbortController | null = null
+  let pendingEsc: ReturnType<typeof setTimeout> | null = null
+
+  const clearPending = (): void => {
+    if (pendingEsc !== null) {
+      clearTimeout(pendingEsc)
+      pendingEsc = null
+    }
+  }
+
+  return {
+    armForStream: () => {
+      clearPending()
+      currentCtrl = new AbortController()
+      return currentCtrl.signal
+    },
+    onChunk: (chunk) => {
+      if (chunk.length === 0) return { sigint: false }
+      if (chunk[0] === 0x03) {
+        // Ctrl-C in raw mode arrives as a byte (terminal driver does not generate
+        // SIGINT). Surface to the caller so it can re-issue SIGINT via the OS;
+        // we deliberately keep the AbortController lifecycle separate from SIGINT.
+        return { sigint: true }
+      }
+      if (chunk.length === 1 && chunk[0] === 0x1b) {
+        // Bare ESC: schedule the abort. A follow-up byte within debounceMs (CSI
+        // sequences from arrow keys, mouse, paste) cancels the pending fire.
+        // Snapshot currentCtrl so a late-firing timer can't abort a controller
+        // created by a subsequent armForStream() call.
+        clearPending()
+        const ctrl = currentCtrl
+        pendingEsc = setTimeout(() => {
+          pendingEsc = null
+          ctrl?.abort()
+        }, debounceMs)
+        return { sigint: false }
+      }
+      // Any other byte arriving within the ESC window is the second byte of a CSI
+      // sequence; cancel the pending abort.
+      clearPending()
+      return { sigint: false }
+    },
+    clearPending,
+    dispose: () => {
+      clearPending()
+      currentCtrl = null
+    },
+  }
+}

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -5,6 +5,7 @@ import { findAgentDir } from '@/init'
 import { runInspectLoop, streamLive, type LiveSourceFactory, type SessionSummary } from '@/inspect'
 import { originLabel, shortSessionId } from '@/inspect/label'
 
+import { createEscController } from './inspect-controller'
 import { cancel, c, errorLine, isCancel } from './ui'
 
 const ESC_LISTEN_DELAY_MS = 50
@@ -124,29 +125,12 @@ function createEscListener(): EscListener | null {
   const stdin = process.stdin
   if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') return null
 
-  let currentCtrl: AbortController | null = null
-  let pendingEsc: ReturnType<typeof setTimeout> | null = null
+  const ctrl = createEscController({ debounceMs: ESC_LISTEN_DELAY_MS })
   let active = false
 
   const onData = (chunk: Buffer): void => {
-    if (chunk.length === 0) return
-    const first = chunk[0]
-    if (first === 0x03) {
-      process.kill(process.pid, 'SIGINT')
-      return
-    }
-    if (chunk.length === 1 && first === 0x1b) {
-      if (pendingEsc !== null) clearTimeout(pendingEsc)
-      pendingEsc = setTimeout(() => {
-        pendingEsc = null
-        currentCtrl?.abort()
-      }, ESC_LISTEN_DELAY_MS)
-      return
-    }
-    if (pendingEsc !== null) {
-      clearTimeout(pendingEsc)
-      pendingEsc = null
-    }
+    const { sigint } = ctrl.onChunk(chunk)
+    if (sigint) process.kill(process.pid, 'SIGINT')
   }
 
   const start = (): void => {
@@ -166,27 +150,28 @@ function createEscListener(): EscListener | null {
       /* terminal already torn down */
     }
     stdin.pause()
-    if (pendingEsc !== null) {
-      clearTimeout(pendingEsc)
-      pendingEsc = null
-    }
+    ctrl.clearPending()
   }
 
   return {
     armForStream: () => {
-      currentCtrl = new AbortController()
+      const signal = ctrl.armForStream()
       start()
-      return currentCtrl.signal
+      return signal
     },
     pause: () => {
       stop()
     },
     resume: () => {
-      currentCtrl = new AbortController()
+      // Resume the listener WITHOUT replacing the AbortController.
+      // The signal returned by armForStream() is held by the live source
+      // through streamSession's combinedSignal; replacing the controller
+      // here would orphan that signal so a subsequent ESC press could
+      // not abort the live tail.
       start()
     },
     stop: () => {
-      currentCtrl = null
+      ctrl.dispose()
       stop()
     },
   }


### PR DESCRIPTION
## What this PR does

Fixes a regression introduced by #373 where pressing ESC during `typeclaw inspect`'s live tail did nothing. The user also reported ctrl+c appearing stuck — that path is structurally fine (see "Ctrl-C" below), but both symptoms traced to the same orphaned signal.

1 commit, +172 / -28 across 3 files (1 modified, 2 new).

## Root cause

`createEscListener` in `src/cli/inspect.ts` contained this in its `resume()` callback:

```ts
resume: () => {
  currentCtrl = new AbortController()  // BUG
  start()
},
```

`resume()` is called by `selectSession`'s `.finally` after the clack picker closes. By that point `streamSession` has already combined the original signal into the live source's abort chain. The lifecycle:

1. `runInspectLoop` calls `newEscSignal()` → `armForStream()` creates controller C1, returns C1.signal.
2. `runInspect` → `chooseSession()` → `selectSession()` → `pause()` stops the listener.
3. Clack picker runs; user selects a session.
4. `.finally(resume())` → `resume()` creates a new controller C2, sets `currentCtrl = C2`.
5. `streamSession()` runs with `escSignal = C1.signal` — the signal handed back to the loop in step 1.
6. The live source listens to `combineSignals(signal, C1.signal)`.
7. User presses ESC → debounce fires → `currentCtrl?.abort()` → **aborts C2**.
8. **C1 is never aborted** → live source keeps waiting → ESC appears dead.

The bug fires every time the picker runs. That means:
- No-arg launch (`typeclaw inspect`): picker always runs first, so ESC is broken immediately on every use.
- After any esc-to-picker bounce: the next stream's ESC is also broken.

Reproduced standalone with a buggy controller fixture. The existing `runInspectLoop` tests in `src/inspect/loop.test.ts` did not catch this because their `newEscSignal` fake always returned a fresh signal per iteration — the bug lived in the real listener wrapper's lifecycle, which the loop tests never touched.

**Ctrl-C** goes through `process.kill(pid, 'SIGINT')` → `installSigintAbort`'s separate SIGINT controller → `combinedSignal` → live source. That path is unaffected; the user likely bundled "I press keys and nothing happens" as "ctrl+c and esc both broken" while the actual stuck state was the orphaned esc signal.

## Fix

Extract the AbortController and the bare-ESC debounce timer into a pure `createEscController` in a new `src/cli/inspect-controller.ts`. The controller exposes four operations:

- `armForStream()` — creates a fresh AbortController and returns its signal. The old controller (if any) is replaced; the old signal's fate is purely the caller's responsibility.
- `onChunk(buf)` — the byte-level state machine. Returns `{ sigint: true }` on byte `0x03`; queues a debounce abort on bare ESC (`0x1b`); cancels the pending abort on any CSI follow-up byte.
- `clearPending()` — cancels any in-flight debounce timer without aborting the live controller. Called by `pause()` so an ESC typed just before the picker opens can't fire mid-picker.
- `dispose()` — cancels the timer and clears the controller reference.

The abort timer now snapshots `currentCtrl` into a local `ctrl` at schedule time. A late-firing timer can no longer abort a signal created by a subsequent `armForStream()` — the snapshot is closed over at the moment of scheduling, not re-evaluated at firing.

In `inspect.ts`'s `createEscListener`, `resume()` now only re-enables raw mode and re-attaches the data listener. It does not touch the controller. There is no longer a code path that can orphan a signal by replacing the controller after it has been handed to a consumer.

## What's in the diff

| File | Change |
|---|---|
| `src/cli/inspect-controller.ts` | New, 66 lines. Pure controller: no `process.stdin`, no TTY, no imports from `inspect.ts`. |
| `src/cli/inspect-controller.test.ts` | New, 93 lines, 8 tests. Covers the full behavioral surface of the controller without any TTY plumbing. |
| `src/cli/inspect.ts` | Net -15 lines. `createEscListener` is now a thin wrapper: it owns raw mode and the data listener, and delegates byte interpretation + signal management to the pure controller. |

## Tests

The 8 new tests in `src/cli/inspect-controller.test.ts`:

1. **bare ESC after debounce window aborts the armed signal** — happy path. Arm, fire `0x1b`, advance past debounce, assert signal aborted.
2. **CSI follow-up byte within debounce window cancels the pending abort** — arrow-key / mouse / paste sequences must not abort. Fire `0x1b`, immediately fire a CSI byte, advance past window, assert signal still live.
3. **Ctrl-C surfaces `sigint: true` and never aborts the ESC signal** — pins the deliberate separation between the SIGINT forwarding path and the ESC abort path.
4. **signal handed out by `armForStream` still aborts on ESC after `clearPending` → re-arm of listener (the picker pause/resume cycle)** — the regression canary. Arm C1, call `clearPending()` (simulates picker pause), re-attach listener (simulates resume without re-arming), fire ESC, advance past window, assert C1 is aborted.
5. **`armForStream` after a previous arm: new signal aborts on ESC; old signal stays untouched** — pins the loop-iteration contract. Arm C1, arm C2 (new loop iteration), fire ESC, assert C2 aborted and C1 still live.
6. **pending timer from a previous arm does not abort a freshly armed signal** — pins the snapshot-capture guard. Fire ESC (schedules timer capturing C1), arm C2 before the timer fires, advance past window, assert C2 still live and C1 aborted (the timer fired against its snapshot).
7. **`dispose` cancels any pending timer and detaches the controller** — clean shutdown: dispose mid-pending-timer, advance past window, assert nothing was aborted.
8. **empty chunk is a no-op** — edge case; no throw, no state change.

## Verification

```
bun run typecheck   ✓
bun run lint        ✓  (61 pre-existing warnings, 0 errors, 0 on touched files)
bun run format      ✓
bun run test        5406 pass / 0 fail / 11891 expect() calls
```

## Open questions for review

1. **`armForStream` does not abort the previous controller.** This is deliberate — the previous signal may still be in use by a `streamSession` call that the loop hasn't awaited yet. Currently impossible by construction since the loop always awaits `runInspect` before looping. Worth a comment if the reviewer finds it surprising.
2. **`clearPending` vs. abort-on-pause.** An alternative design aborts C1 when `pause()` is called so the live stream is guaranteed dead before the picker opens. This would require the loop to detect the abort-from-pause case and not treat it as a user ESC. The current design keeps the abort semantic purely user-initiated and lets the stream natural-exit or get aborted by the user's ESC after resuming. Tradeoff: current design is simpler but means a user who presses ESC exactly as the picker is opening will see the debounce cancelled (unobservable in practice).

Closes the user-reported bug "I cannot use ctrl+c and esc in typeclaw inspect".