### PR TITLE
inspect: restore last picked session when esc reopens the picker

### DIFF
--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -56,9 +56,9 @@ export const inspectCommand = defineCommand({
       ...(sinceArg !== undefined ? { since: sinceArg } : {}),
       json: isJson,
       color,
-      selectSession: (sessions) => {
+      selectSession: (sessions, selectOpts) => {
         escListener?.pause()
-        return clackSelect(sessions).finally(() => {
+        return clackSelect(sessions, selectOpts?.initialSessionId).finally(() => {
           escListener?.resume()
         })
       },
@@ -189,8 +189,15 @@ function useColor(): boolean {
   return Boolean(process.stdout.isTTY)
 }
 
-async function clackSelect(sessions: SessionSummary[]): Promise<SessionSummary | null> {
+async function clackSelect(
+  sessions: SessionSummary[],
+  initialSessionId: string | undefined,
+): Promise<SessionSummary | null> {
   const { select } = await import('@clack/prompts')
+  const preferred =
+    initialSessionId !== undefined && sessions.some((s) => s.sessionId === initialSessionId)
+      ? initialSessionId
+      : sessions[0]?.sessionId
   const picked = await select<string>({
     message: `Pick a session to inspect (showing ${sessions.length})`,
     options: sessions.map((s) => ({
@@ -198,7 +205,7 @@ async function clackSelect(sessions: SessionSummary[]): Promise<SessionSummary |
       label: formatRowLabel(s),
       ...(s.firstPrompt !== null ? { hint: truncate(s.firstPrompt, 60) } : { hint: '(no prompt)' }),
     })),
-    initialValue: sessions[0]?.sessionId,
+    initialValue: preferred,
   })
   if (isCancel(picked)) {
     cancel('Cancelled.')

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -37,7 +37,11 @@ export type RunInspectOptions = {
   liveHint?: string
 }
 
-export type SelectSession = (sessions: SessionSummary[]) => Promise<SessionSummary | null>
+export type SelectSessionOptions = {
+  initialSessionId?: string
+}
+
+export type SelectSession = (sessions: SessionSummary[], opts?: SelectSessionOptions) => Promise<SessionSummary | null>
 
 export type LiveSourceFactory = (opts: {
   sessionId: string

--- a/src/inspect/loop.test.ts
+++ b/src/inspect/loop.test.ts
@@ -189,4 +189,58 @@ describe('runInspectLoop', () => {
     expect(dividerIdx).toBeGreaterThanOrEqual(0)
     expect(hintIdx).toBe(dividerIdx + 1)
   })
+
+  test('picker re-opened via esc receives previously-selected sessionId as initialSessionId', async () => {
+    await seedSession(`a_${ID_LOOP_A}.jsonl`, [metaLine({ kind: 'tui' }), userLine('first')], 1000)
+    await seedSession(`b_${ID_LOOP_B}.jsonl`, [metaLine({ kind: 'tui' }), userLine('second')], 2000)
+    await seedSession(`c_${ID_LOOP_C}.jsonl`, [metaLine({ kind: 'tui' }), userLine('third')], 3000)
+    const sink = captureSink()
+
+    let escController: AbortController | null = null
+    let liveCallCount = 0
+    const pickerHints: (string | undefined)[] = []
+
+    async function* awaitableLive(signal: AbortSignal | undefined): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'hello' } }
+      await new Promise<void>((resolve) => {
+        if (signal === undefined || signal.aborted) return resolve()
+        signal.addEventListener('abort', () => resolve(), { once: true })
+      })
+    }
+    async function* finiteLive(): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'final' } }
+    }
+
+    let pickerCalls = 0
+    const result = await runInspectLoop({
+      agentDir,
+      color: false,
+      selectSession: async (sessions, selectOpts) => {
+        pickerCalls++
+        pickerHints.push(selectOpts?.initialSessionId)
+        if (pickerCalls === 1) {
+          return sessions.find((s) => s.sessionId === ID_LOOP_A) ?? null
+        }
+        return sessions.find((s) => s.sessionId === ID_LOOP_C) ?? null
+      },
+      liveSource: (o) => {
+        liveCallCount++
+        if (liveCallCount === 1) {
+          queueMicrotask(() => escController?.abort())
+          return awaitableLive(o.signal)
+        }
+        return finiteLive()
+      },
+      newEscSignal: () => {
+        escController = new AbortController()
+        return escController.signal
+      },
+      ...sink.push,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(pickerCalls).toBe(2)
+    expect(pickerHints[0]).toBeUndefined()
+    expect(pickerHints[1]).toBe(ID_LOOP_A)
+  })
 })

--- a/src/inspect/loop.ts
+++ b/src/inspect/loop.ts
@@ -6,9 +6,20 @@ export type RunInspectLoopOptions = Omit<RunInspectOptions, 'escSignal'> & {
 
 export async function runInspectLoop(opts: RunInspectLoopOptions): Promise<RunInspectResult> {
   let sessionArg = opts.sessionIdOrPrefix
+  // Remember the last session the user picked from the interactive picker so
+  // an ESC-back-to-picker re-opens with that row pre-selected. The picker
+  // receives this through the `initialSessionId` hint on its second arg.
+  let lastPickedId: string | undefined
+  const wrappedSelectSession: typeof opts.selectSession = async (sessions, selectOpts) => {
+    const hint = selectOpts?.initialSessionId ?? lastPickedId
+    const picked = await opts.selectSession(sessions, hint !== undefined ? { initialSessionId: hint } : {})
+    if (picked !== null) lastPickedId = picked.sessionId
+    return picked
+  }
+
   while (true) {
     const escSignal = opts.newEscSignal()
-    const callOpts: RunInspectOptions = { ...opts, escSignal }
+    const callOpts: RunInspectOptions = { ...opts, escSignal, selectSession: wrappedSelectSession }
     if (sessionArg !== undefined) callOpts.sessionIdOrPrefix = sessionArg
     else delete (callOpts as { sessionIdOrPrefix?: string }).sessionIdOrPrefix
 


### PR DESCRIPTION
## What this PR does

Fixes the bug where pressing ESC from `typeclaw inspect`'s live tail and returning to the session picker always reset the cursor to the first row, losing the user's position in the list.

1 commit, +82 / -6 across 4 files.

## Root cause

`runInspectLoop` handles the esc-to-picker bounce: it clears `sessionArg` and loops back into `runInspect`. That function calls `opts.selectSession(sessions)`, which delegates to clack's `select` prompt with `initialValue: sessions[0]?.sessionId` — always the first row, no matter which session the user just left.

There was no plumbing to carry "what session was previously picked" across loop iterations, so the picker had no memory.

## Fix

**`src/inspect/loop.ts`** — `runInspectLoop` now wraps `opts.selectSession` in a closure before entering the loop. The closure tracks the last picked `sessionId` across iterations, forwards it as `initialSessionId` on the next picker call, and updates the remembered id whenever the picker returns a non-null pick.

**`src/inspect/index.ts`** — Widens `SelectSession`'s optional second arg to carry `initialSessionId?: string`. Existing `(sessions) => ...` callables stay assignable — TypeScript's bivariance on optional params means no call site updates are needed outside the CLI entry.

**`src/cli/inspect.ts`** — Threads `initialSessionId` into the `clackSelect` helper. The helper computes the preferred initial value as: `initialSessionId` if it's present in the current session list, otherwise `sessions[0]?.sessionId`. The fallback preserves today's behavior on the first iteration and handles the case where the previously-picked session is no longer in the list (session deleted, `--since` filter narrowed it out, etc.).

**`src/inspect/loop.test.ts`** — New test: seeds sessions A/B/C, invokes the loop with no `sessionIdOrPrefix`, picks A on the first call, triggers an esc abort from the live source, and asserts that the second picker call received `initialSessionId` equal to A's id.

## Considered alternatives

**Pass the last-picked id through `runInspect`'s return value.** Rejected: `runInspect` has no business knowing about loop iteration state. Keeping the "remember picks across iterations" concern inside the loop's own closure keeps the return type clean and the boundary sharp.

**Always reset to `sessions[0]`** — the prior behavior. Rejected: if you're bouncing between the picker and a session's live tail, you want your cursor where you left it.

## Compatibility

- No schema change, no protocol change, no on-disk state.
- Existing custom `selectSession` implementations (none outside tests today) keep working — the second arg is optional.
- Single revert restores prior behavior; no follow-up cleanup needed.

## Verification

```
bun run typecheck    ✓
bun run lint         ✓  (61 pre-existing warnings, 0 errors, 0 on touched files)
bun run format:check ✓
bun run test         5415 pass / 0 fail / 11907 expect() calls
```

Mutation check: reverting the loop wrapper in `src/inspect/loop.ts` caused the new test to fail:

```
Expected: "019ee000-aaaa-7000-9000-00000000aaaa"
Received: undefined
```