### PR TITLE
docs: fill in inspect command, quotedReply config, OpenAI thinking-level default

### DIFF
--- a/docs/content/docs/reference/channel-adapters.mdx
+++ b/docs/content/docs/reference/channel-adapters.mdx
@@ -17,7 +17,10 @@ icon: Inbox
 ```json
 {
   "channels": {
-    "slack-bot": { "enabled": true },
+    "slack-bot": {
+      "enabled": true,
+      "quotedReply": { "enabled": true, "queueDelayMs": 10000 }
+    },
     "discord-bot": { "enabled": true },
     "telegram-bot": { "enabled": true },
     "github": {
@@ -30,11 +33,14 @@ icon: Inbox
 }
 ```
 
-| Field         | Adapters | Notes                                                                      |
-| ------------- | -------- | -------------------------------------------------------------------------- |
-| `enabled`     | all      | live-reloadable                                                            |
-| `webhookPort` | `github` | container-side port the webhook server listens on; default `8975`          |
-| `webhookUrl`  | `github` | optional override; when omitted, the URL comes from a channel-owned tunnel |
+| Field                      | Adapters | Notes                                                                                            |
+| -------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `enabled`                  | all      | live-reloadable                                                                                  |
+| `quotedReply`              | all      | auto-anchor delayed replies with a `> @author: …` blockquote prefix; defaults to on, 10s         |
+| `quotedReply.enabled`      | all      | set `false` to never prepend the anchor                                                          |
+| `quotedReply.queueDelayMs` | all      | reply delay threshold in ms; `0` anchors every reply, large values anchor only very late replies |
+| `webhookPort`              | `github` | container-side port the webhook server listens on; default `8975`                                |
+| `webhookUrl`               | `github` | optional override; when omitted, the URL comes from a channel-owned tunnel                       |
 
 Credentials live in `secrets.json#channels.<adapter>` ([/reference/secrets-json](/docs/reference/secrets-json)).
 
@@ -56,6 +62,8 @@ When a message arrives:
 4. Outgoing tool calls (`channel_send`, `channel_reply`) flow back through the adapter.
 
 The router never blocks on a slow adapter. Each adapter owns its own outbound queue.
+
+When the agent's first send of a turn lands later than `quotedReply.queueDelayMs` after the inbound was received, OR the channel had observed messages between the inbound and the reply, the router prepends a single-line `> @author: excerpt` markdown blockquote referencing the inbound so the user can see which message the reply is anchored to even after the channel has scrolled. Slack and Discord get platform-native `<@authorId>` mentions inside the quote; Telegram, KakaoTalk, and GitHub fall back to plain author names because they have no reliable id-only mention syntax inside markdown. Anchoring is first-send-only per turn — multi-part replies don't repeat the quote on every chunk.
 
 ## Per-adapter quirks
 

--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -78,6 +78,18 @@ typeclaw cron list --json
 
 Cron jobs are authored in `cron.json`; the CLI doesn't add/remove them. After editing the file, `typeclaw reload`.
 
+## Inspect
+
+```sh
+typeclaw inspect                                   # pick a session from a list
+typeclaw inspect <session-id-or-prefix>            # replay then live-tail
+typeclaw inspect --filter tool,assistant           # category filter (prefix with ! to exclude)
+typeclaw inspect --since 5m                        # only events newer than 5m (forms: 30s, 5m, 1h, 7d)
+typeclaw inspect <session> --json                  # one JSON event per line; requires an explicit session id
+```
+
+Replays the session's persisted transcript, then keeps the stream open and live-tails new events as they happen — no `--follow` toggle. Press `Esc` to return to the session picker; `Ctrl+C` exits. `--json` mode prints raw events without color or interactive controls.
+
 ## Tunnels
 
 ```sh

--- a/docs/content/docs/reference/typeclaw-json.mdx
+++ b/docs/content/docs/reference/typeclaw-json.mdx
@@ -41,6 +41,8 @@ Plugin-owned config blocks live at the top level under their plugin name and are
 
 `default` is required. Other profile names are conventional but not enforced. Each value is either a single `<provider>/<model>` ref or a non-empty array forming a fallback chain: on failure, the runtime disposes the failed session and replays the prompt against the next ref.
 
+Provider-family defaults override the SDK's reasoning level at session creation: OpenAI-family refs (`openai/*`, `openai-codex/*`) pin `thinkingLevel: 'low'` because GPT-5.x at the SDK default of `medium` pads reasoning tokens on routine tool-driven turns with no observable quality delta. Anthropic, GLM, and Kimi refs keep the SDK default.
+
 ## `network`
 
 ```json


### PR DESCRIPTION
## What this PR does

Audited `docs/` (the typeclaw.dev site) against recent commits and fixed three drifts I found. No source changes.

## What's in the diff

| File | Change |
|---|---|
| `docs/content/docs/reference/cli.mdx` | Adds an `## Inspect` section. `typeclaw inspect` exists, the README features it, but the CLI reference page didn't list it at all. Covers picker mode, the positional id, `--filter`, `--since`, `--json`, plus the replay-then-live-tail behavior and the `Esc` / `Ctrl+C` controls. Written around the current shape — the recent commits dropped the `--follow` toggle (always live-tails now). |
| `docs/content/docs/reference/channel-adapters.mdx` | Adds the new per-adapter `quotedReply` field (PR #374, b3c365b) to the `channels.<adapter>` shape table — three rows: `quotedReply`, `quotedReply.enabled`, `quotedReply.queueDelayMs`. Updates the example JSON to show the default shape. Adds a paragraph under "Routing model" explaining when the router prepends the `> @author: excerpt` blockquote anchor and why the mention syntax is adapter-specific (Slack/Discord get `<@authorId>`; Telegram, KakaoTalk, GitHub fall back to plain names because they have no reliable id-only mention syntax inside markdown). |
| `docs/content/docs/reference/typeclaw-json.mdx` | Adds one sentence to `## models` noting that `openai/*` and `openai-codex/*` refs pin `thinkingLevel: 'low'` at session creation while Anthropic, GLM, and Kimi refs keep the SDK default of `medium`. Rationale (GPT-5.x pads reasoning tokens on routine tool turns) matches the prose comment in `src/config/providers.ts` from PR #375. |

## How I picked the drifts

Walked back through the last ~30 commits since the previous docs refresh, filtered for anything that changed user-facing surface (CLI flags, config schema, default behavior), and grepped `docs/` for mentions. Three drifts surfaced:

- `typeclaw inspect` — missing entirely from `cli.mdx` (grep for `inspect` returned zero matches inside the file).
- `quotedReply` config field — landed in `src/channels/schema.ts` in PR #374, follow-up fix in b3c365b. Zero mentions in `docs/`.
- OpenAI `thinkingLevel: 'low'` default — landed in PR #375. Zero mentions in `docs/`.

Considered also restructuring AGENTS.md to add a dedicated channels section (the channel router lore is currently scattered through the permissions section), but that's a much bigger restructure and out of scope for a docs-site drift sweep.

## Verification

```sh
# docs/
bun run lint        # 0 errors
bun run format      # clean

# root
bun run typecheck   # clean
bun run lint        # 61 pre-existing warnings, 0 errors (unchanged)
bun run format      # clean
bun run test        # 5414 pass / 0 fail
```

Built the site locally with `bun run build` to confirm the MDX renders without warnings.

## Rollback

Revert is a no-op — pure prose additions to three reference pages. No schema, no on-disk state, no protocol change.
