### PR TITLE
agent: self-restart handoff so the TUI sees 'I'm back' after restart

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -305,6 +305,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
                     containerName: options.containerName,
                     originatingSessionId: sessionManager.getSessionId(),
                     ...(options.stream ? { stream: options.stream } : {}),
+                    ...buildRestartHandoffWiring(options, sessionManager),
                   }),
                 ]
               : []),
@@ -376,6 +377,26 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     if (materializedSkills) await materializedSkills.dispose()
   }
   return { session, dispose }
+}
+
+// Decides whether the restart tool should write the cross-restart handoff
+// file (`<agentDir>/.typeclaw/restart-pending.json`) and supplies the agentDir
+// + session file path it needs to do so. Returns an empty object — meaning
+// "no handoff" — for any session whose origin is not TUI, so a channel-
+// originated or cron-originated `restart` call cannot accidentally produce an
+// "I'm back" greeting in the next container's first TUI session. See
+// issue #291's scoping concerns. Also returns empty when the session is not
+// persisted to disk (in-memory sessions have no file the next container could
+// reopen).
+export function buildRestartHandoffWiring(
+  options: { origin?: SessionOrigin; plugins?: { agentDir: string } },
+  sessionManager: SessionManager,
+): { agentDir?: string; originatingSessionFile?: string } {
+  if (options.origin?.kind !== 'tui') return {}
+  const agentDir = options.plugins?.agentDir
+  const sessionFile = sessionManager.getSessionFile()
+  if (agentDir === undefined || sessionFile === undefined) return {}
+  return { agentDir, originatingSessionFile: sessionFile }
 }
 
 // Subscribes the given session to the in-process broadcast that the `restart`

--- a/src/agent/restart-handoff/index.test.ts
+++ b/src/agent/restart-handoff/index.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { consumeRestartHandoff, RESTART_HANDOFF_TTL_MS, restartHandoffPath, writeRestartHandoff } from './index'
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-restart-handoff-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('writeRestartHandoff', () => {
+  test('persists handoff at .typeclaw/restart-pending.json', async () => {
+    await writeRestartHandoff(agentDir, {
+      schemaVersion: 1,
+      restartedAt: '2026-05-26T10:00:00.000Z',
+      originatingSessionId: 'ses-abc',
+      originatingSessionFile: 'ses-abc.jsonl',
+    })
+
+    const raw = await readFile(restartHandoffPath(agentDir), 'utf8')
+    expect(JSON.parse(raw)).toEqual({
+      schemaVersion: 1,
+      restartedAt: '2026-05-26T10:00:00.000Z',
+      originatingSessionId: 'ses-abc',
+      originatingSessionFile: 'ses-abc.jsonl',
+    })
+  })
+
+  test('creates the .typeclaw/ directory on demand', async () => {
+    expect(existsSync(join(agentDir, '.typeclaw'))).toBe(false)
+    await writeRestartHandoff(agentDir, {
+      schemaVersion: 1,
+      restartedAt: '2026-05-26T10:00:00.000Z',
+      originatingSessionId: 'ses-abc',
+      originatingSessionFile: 'ses-abc.jsonl',
+    })
+    expect(existsSync(join(agentDir, '.typeclaw'))).toBe(true)
+  })
+
+  test('does not throw when the agent directory does not exist (best-effort)', async () => {
+    await expect(
+      writeRestartHandoff('/nonexistent/path/that/does/not/exist', {
+        schemaVersion: 1,
+        restartedAt: '2026-05-26T10:00:00.000Z',
+        originatingSessionId: 'ses-abc',
+        originatingSessionFile: 'ses-abc.jsonl',
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  test('overwrites a prior handoff file', async () => {
+    await writeRestartHandoff(agentDir, {
+      schemaVersion: 1,
+      restartedAt: '2026-05-26T10:00:00.000Z',
+      originatingSessionId: 'ses-first',
+      originatingSessionFile: 'ses-first.jsonl',
+    })
+    await writeRestartHandoff(agentDir, {
+      schemaVersion: 1,
+      restartedAt: '2026-05-26T10:00:01.000Z',
+      originatingSessionId: 'ses-second',
+      originatingSessionFile: 'ses-second.jsonl',
+    })
+
+    const raw = await readFile(restartHandoffPath(agentDir), 'utf8')
+    expect(JSON.parse(raw).originatingSessionId).toBe('ses-second')
+  })
+})
+
+describe('consumeRestartHandoff', () => {
+  test('returns null when no handoff file exists', async () => {
+    const result = await consumeRestartHandoff(agentDir)
+    expect(result).toBeNull()
+  })
+
+  test('returns the handoff and deletes the file on success', async () => {
+    await writeRestartHandoff(agentDir, {
+      schemaVersion: 1,
+      restartedAt: '2026-05-26T10:00:00.000Z',
+      originatingSessionId: 'ses-abc',
+      originatingSessionFile: 'ses-abc.jsonl',
+    })
+
+    const result = await consumeRestartHandoff(agentDir, {
+      now: Date.parse('2026-05-26T10:00:30.000Z'),
+    })
+
+    expect(result).toEqual({
+      schemaVersion: 1,
+      restartedAt: '2026-05-26T10:00:00.000Z',
+      originatingSessionId: 'ses-abc',
+      originatingSessionFile: 'ses-abc.jsonl',
+    })
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
+  })
+
+  test('returns null AND deletes the file when older than ttlMs', async () => {
+    await writeRestartHandoff(agentDir, {
+      schemaVersion: 1,
+      restartedAt: '2026-05-26T10:00:00.000Z',
+      originatingSessionId: 'ses-abc',
+      originatingSessionFile: 'ses-abc.jsonl',
+    })
+
+    const result = await consumeRestartHandoff(agentDir, {
+      now: Date.parse('2026-05-26T10:01:10.000Z'),
+    })
+
+    expect(result).toBeNull()
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
+  })
+
+  test('uses RESTART_HANDOFF_TTL_MS (60s) as the default TTL', async () => {
+    await writeRestartHandoff(agentDir, {
+      schemaVersion: 1,
+      restartedAt: new Date(Date.now() - (RESTART_HANDOFF_TTL_MS + 5_000)).toISOString(),
+      originatingSessionId: 'ses-abc',
+      originatingSessionFile: 'ses-abc.jsonl',
+    })
+
+    const result = await consumeRestartHandoff(agentDir)
+
+    expect(result).toBeNull()
+  })
+
+  test('returns null AND deletes the file when JSON is malformed', async () => {
+    const path = restartHandoffPath(agentDir)
+    await writeFile(path.replace(/[^/]+$/, ''), '', 'utf8').catch(() => undefined)
+    await Bun.write(path, '{ not valid json')
+
+    const result = await consumeRestartHandoff(agentDir)
+
+    expect(result).toBeNull()
+    expect(existsSync(path)).toBe(false)
+  })
+
+  test('returns null when schemaVersion is missing or wrong', async () => {
+    const path = restartHandoffPath(agentDir)
+    await Bun.write(
+      path,
+      JSON.stringify({
+        schemaVersion: 99,
+        restartedAt: '2026-05-26T10:00:00.000Z',
+        originatingSessionId: 'ses-abc',
+        originatingSessionFile: 'ses-abc.jsonl',
+      }),
+    )
+
+    const result = await consumeRestartHandoff(agentDir, {
+      now: Date.parse('2026-05-26T10:00:30.000Z'),
+    })
+
+    expect(result).toBeNull()
+    expect(existsSync(path)).toBe(false)
+  })
+
+  test('returns null when originatingSessionId is empty', async () => {
+    const path = restartHandoffPath(agentDir)
+    await Bun.write(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        restartedAt: '2026-05-26T10:00:00.000Z',
+        originatingSessionId: '',
+        originatingSessionFile: 'ses-abc.jsonl',
+      }),
+    )
+
+    const result = await consumeRestartHandoff(agentDir, {
+      now: Date.parse('2026-05-26T10:00:30.000Z'),
+    })
+
+    expect(result).toBeNull()
+  })
+
+  test('returns null when restartedAt is not parseable as a date', async () => {
+    const path = restartHandoffPath(agentDir)
+    await Bun.write(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        restartedAt: 'not-a-date',
+        originatingSessionId: 'ses-abc',
+        originatingSessionFile: 'ses-abc.jsonl',
+      }),
+    )
+
+    const result = await consumeRestartHandoff(agentDir, {
+      now: Date.parse('2026-05-26T10:00:30.000Z'),
+    })
+
+    expect(result).toBeNull()
+    expect(existsSync(path)).toBe(false)
+  })
+
+  test('returns the handoff exactly once (second consume sees no file)', async () => {
+    await writeRestartHandoff(agentDir, {
+      schemaVersion: 1,
+      restartedAt: '2026-05-26T10:00:00.000Z',
+      originatingSessionId: 'ses-abc',
+      originatingSessionFile: 'ses-abc.jsonl',
+    })
+
+    const first = await consumeRestartHandoff(agentDir, {
+      now: Date.parse('2026-05-26T10:00:30.000Z'),
+    })
+    const second = await consumeRestartHandoff(agentDir, {
+      now: Date.parse('2026-05-26T10:00:30.000Z'),
+    })
+
+    expect(first).not.toBeNull()
+    expect(second).toBeNull()
+  })
+})

--- a/src/agent/restart-handoff/index.ts
+++ b/src/agent/restart-handoff/index.ts
@@ -1,0 +1,91 @@
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+import { restartHandoffPath } from './paths'
+
+export { restartHandoffPath } from './paths'
+
+export const RESTART_HANDOFF_TTL_MS = 60_000
+
+export type RestartHandoff = {
+  schemaVersion: 1
+  restartedAt: string
+  originatingSessionId: string
+  originatingSessionFile: string
+}
+
+// Atomic write via `.tmp` + rename so a crash mid-write never leaves the
+// reader pointed at a partial JSON blob. The new container's consume() will
+// either see the prior good file, the new good file, or nothing — never a
+// half-written one. Errors are swallowed: handoff is best-effort. A failed
+// write means the next boot cold-starts (no greeting), which is the same
+// graceful degradation as the dying container being SIGKILL'd before the
+// write could run.
+export async function writeRestartHandoff(agentDir: string, handoff: RestartHandoff): Promise<void> {
+  const path = restartHandoffPath(agentDir)
+  try {
+    await mkdir(dirname(path), { recursive: true })
+    const tmp = `${path}.tmp`
+    await writeFile(tmp, JSON.stringify(handoff), 'utf8')
+    await rename(tmp, path)
+  } catch {
+    return
+  }
+}
+
+// Read-and-delete in one call so the file is removed even if the caller
+// rejects the contents (TTL expired, malformed JSON, wrong schemaVersion).
+// Otherwise a stale file would linger until the NEXT restart wrote a fresh
+// one, and the boot consumer would re-read the stale entry every time.
+//
+// Returns the parsed handoff iff the file existed, was valid JSON of the
+// expected shape, and was within `ttlMs` of `now`. Otherwise returns null.
+// `now` and `ttlMs` are injectable so tests can drive the recency gate
+// without sleeping.
+export async function consumeRestartHandoff(
+  agentDir: string,
+  options: { now?: number; ttlMs?: number } = {},
+): Promise<RestartHandoff | null> {
+  const path = restartHandoffPath(agentDir)
+  const now = options.now ?? Date.now()
+  const ttlMs = options.ttlMs ?? RESTART_HANDOFF_TTL_MS
+
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch {
+    return null
+  }
+
+  await rm(path, { force: true }).catch(() => undefined)
+
+  const handoff = parseHandoff(raw)
+  if (handoff === null) return null
+
+  const restartedAtMs = Date.parse(handoff.restartedAt)
+  if (Number.isNaN(restartedAtMs)) return null
+  if (now - restartedAtMs > ttlMs) return null
+
+  return handoff
+}
+
+function parseHandoff(raw: string): RestartHandoff | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (parsed === null || typeof parsed !== 'object') return null
+  const obj = parsed as Record<string, unknown>
+  if (obj.schemaVersion !== 1) return null
+  if (typeof obj.restartedAt !== 'string') return null
+  if (typeof obj.originatingSessionId !== 'string' || obj.originatingSessionId === '') return null
+  if (typeof obj.originatingSessionFile !== 'string' || obj.originatingSessionFile === '') return null
+  return {
+    schemaVersion: 1,
+    restartedAt: obj.restartedAt,
+    originatingSessionId: obj.originatingSessionId,
+    originatingSessionFile: obj.originatingSessionFile,
+  }
+}

--- a/src/agent/restart-handoff/paths.ts
+++ b/src/agent/restart-handoff/paths.ts
@@ -1,0 +1,11 @@
+import { join } from 'node:path'
+
+// Single source of truth for the restart-handoff file path so the writer
+// (src/agent/tools/restart.ts) and the reader (src/server/index.ts) cannot
+// drift. Sibling of `.typeclaw/backup-message.tmp` — same ephemeral-tenant
+// pattern (write-then-read-and-delete, not gitignored, dir created on
+// demand). See src/bundled-plugins/backup/subagents.ts:messageFilePath for
+// the prior art.
+export function restartHandoffPath(agentDir: string): string {
+  return join(agentDir, '.typeclaw', 'restart-pending.json')
+}

--- a/src/agent/tools/restart.test.ts
+++ b/src/agent/tools/restart.test.ts
@@ -1,5 +1,10 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
+import { restartHandoffPath } from '@/agent/restart-handoff'
 import { createStream, type StreamMessage } from '@/stream'
 
 import { createRestartTool } from './restart'
@@ -293,5 +298,139 @@ describe('createRestartTool', () => {
     expect(result.details).toEqual({ ok: true, containerName: 'coder' })
     await waitForCondition(() => exitCode !== undefined)
     expect(exitCode).toBe(0)
+  })
+})
+
+describe('createRestartTool restart-pending handoff', () => {
+  let agentDir: string
+
+  beforeEach(async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-restart-tool-handoff-'))
+  })
+
+  afterEach(async () => {
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('writes the handoff file when agentDir and originatingSessionFile are passed', async () => {
+    // given
+    server = startOkServer()
+    const tool = createRestartTool({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      hostdToken: 'secret',
+      originatingSessionId: 'ses-originator',
+      exit: () => {},
+      agentDir,
+      originatingSessionFile: '/some/abs/path/ses-originator.jsonl',
+    })
+
+    // when
+    await tool.execute('id', {}, undefined, undefined, fakeCtx)
+
+    // then
+    const raw = await readFile(restartHandoffPath(agentDir), 'utf8')
+    const parsed = JSON.parse(raw)
+    expect(parsed.schemaVersion).toBe(1)
+    expect(parsed.originatingSessionId).toBe('ses-originator')
+    expect(parsed.originatingSessionFile).toBe('ses-originator.jsonl')
+    expect(typeof parsed.restartedAt).toBe('string')
+    expect(new Date(parsed.restartedAt).toISOString()).toBe(parsed.restartedAt)
+  })
+
+  test('skips the handoff when agentDir is omitted (non-TUI origins do not greet)', async () => {
+    // given
+    server = startOkServer()
+    const tool = createRestartTool({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      hostdToken: 'secret',
+      originatingSessionId: 'ses-channel',
+      exit: () => {},
+      originatingSessionFile: 'ses-channel.jsonl',
+    })
+
+    // when
+    await tool.execute('id', {}, undefined, undefined, fakeCtx)
+
+    // then
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
+  })
+
+  test('skips the handoff when originatingSessionFile is omitted (in-memory sessions)', async () => {
+    // given
+    server = startOkServer()
+    const tool = createRestartTool({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      hostdToken: 'secret',
+      originatingSessionId: 'ses-inmem',
+      exit: () => {},
+      agentDir,
+    })
+
+    // when
+    await tool.execute('id', {}, undefined, undefined, fakeCtx)
+
+    // then
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
+  })
+
+  test('does not write the handoff when hostd denies the restart', async () => {
+    // given
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ ok: false, reason: 'denied' })
+      },
+    })
+    const tool = createRestartTool({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      hostdToken: 'bad',
+      originatingSessionId: 'ses-originator',
+      exit: () => {
+        throw new Error('exit should not run')
+      },
+      agentDir,
+      originatingSessionFile: 'ses-originator.jsonl',
+    })
+
+    // when
+    await tool.execute('id', {}, undefined, undefined, fakeCtx)
+
+    // then
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
+  })
+
+  test('uses the broadcast restartedAt timestamp in the handoff (single source of truth)', async () => {
+    // given
+    server = startOkServer()
+    const stream = createStream()
+    const received: StreamMessage[] = []
+    stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => received.push(msg))
+    const tool = createRestartTool({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      hostdToken: 'secret',
+      originatingSessionId: 'ses-originator',
+      exit: () => {},
+      stream,
+      agentDir,
+      originatingSessionFile: 'ses-originator.jsonl',
+    })
+
+    // when
+    await tool.execute('id', {}, undefined, undefined, fakeCtx)
+
+    // then
+    const broadcastTs = (received[0]?.payload as { restartedAt: string }).restartedAt
+    const handoff = JSON.parse(await readFile(restartHandoffPath(agentDir), 'utf8'))
+    expect(handoff.restartedAt).toBe(broadcastTs)
   })
 })

--- a/src/agent/tools/restart.ts
+++ b/src/agent/tools/restart.ts
@@ -1,6 +1,9 @@
+import { basename } from 'node:path'
+
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
+import { writeRestartHandoff } from '@/agent/restart-handoff'
 import { send, sendHttp } from '@/hostd/client'
 import { containerSocketPath } from '@/hostd/paths'
 import type { Stream } from '@/stream'
@@ -36,6 +39,24 @@ export type CreateRestartToolOptions = {
   // true)` assertion flips to `ok: false, reason: 'daemon ack timeout'`.
   // Optional so production callers keep the 5s default unchanged.
   ackTimeoutMs?: number
+  // Agent folder root. Required to write the cross-restart handoff file
+  // (`<agentDir>/.typeclaw/restart-pending.json`) that lets the next
+  // container reattach to the originating session and produce the
+  // "I'm back" turn. Omit to skip the handoff write (used by sessions
+  // whose origin is not TUI — see `originatingSessionFile` below — and
+  // by ad-hoc tool construction in tests that do not need the handoff).
+  agentDir?: string
+  // Absolute path or basename of the originating session's JSONL file on
+  // disk. Required alongside `agentDir` to enable the handoff; the new
+  // container uses this to reopen the session via `SessionManager.open`
+  // so the `typeclaw.restart-self` custom message entry that was just
+  // appended is part of the LLM context on the next turn. When omitted,
+  // no handoff is written — the new container cold-starts and no
+  // "I'm back" greeting fires. Gates the handoff on the origin being a
+  // TUI session: channel/cron/subagent origins should pass undefined so
+  // the next boot does not produce a stray channel post or unattended
+  // greeting (see issue #291's scoping concerns).
+  originatingSessionFile?: string
 }
 
 export type RestartToolDetails = { ok: boolean; containerName: string; reason?: string }
@@ -55,6 +76,8 @@ export function createRestartTool({
   stream,
   originatingSessionId,
   ackTimeoutMs,
+  agentDir,
+  originatingSessionFile,
 }: CreateRestartToolOptions) {
   const doExit = exit ?? ((code: number) => process.exit(code))
   const httpUrl = hostdUrl ?? process.env.TYPECLAW_HOSTD_URL
@@ -104,12 +127,30 @@ export function createRestartTool({
       // synchronous (broker.ts deliver()) and SessionManager.appendCustomMessageEntry
       // does a synchronous JSONL write, so the fan-out completes inside this
       // tick — well before the EXIT_DELAY_MS timer fires.
+      const restartedAt = new Date().toISOString()
       const broadcast: ContainerRestartingBroadcast = {
         kind: 'container-restarting',
-        restartedAt: new Date().toISOString(),
+        restartedAt,
         originatingSessionId,
       }
       stream?.publish({ target: { kind: 'broadcast' }, payload: broadcast })
+
+      // Write the cross-restart handoff AFTER the broadcast has run so the
+      // originating session's JSONL already contains the `typeclaw.restart-self`
+      // custom message entry that the next container will hydrate on
+      // `SessionManager.open`. Without that ordering, the new container could
+      // theoretically open the JSONL before the entry was flushed and miss
+      // the model-instruction the entry carries. Gated on agentDir +
+      // originatingSessionFile so non-TUI origins (channel/cron/subagent)
+      // skip the file write — see issue #291's scoping concerns.
+      if (agentDir !== undefined && originatingSessionFile !== undefined) {
+        await writeRestartHandoff(agentDir, {
+          schemaVersion: 1,
+          restartedAt,
+          originatingSessionId,
+          originatingSessionFile: basename(originatingSessionFile),
+        })
+      }
 
       // Schedule the exit on the next tick so the tool result is delivered to
       // the model before the process dies. The host daemon polls for the

--- a/src/cli/tui.ts
+++ b/src/cli/tui.ts
@@ -25,16 +25,40 @@ export const tui = defineCommand({
     },
   },
   async run({ args }) {
-    const url = args.url ?? (await defaultUrl())
-    const tui = createTui({
-      url,
-      ...(args.prompt !== undefined ? { initialPrompt: args.prompt } : {}),
-      expectedVersion: CLI_VERSION,
-      onVersionMismatch: (info) => {
-        process.stderr.write(`${formatVersionMismatchWarning(info)}\n`)
-      },
-    })
-    await tui.run()
+    const resolveUrl: () => Promise<string> = args.url !== undefined ? async () => args.url as string : defaultUrl
+
+    let initialPrompt: string | undefined = args.prompt
+    let attempt = 0
+    const RECONNECT_MAX_ATTEMPTS = 30
+    const RECONNECT_BACKOFF_MS = 1_000
+
+    while (true) {
+      const url = await resolveUrl()
+      const tui = createTui({
+        url,
+        ...(initialPrompt !== undefined ? { initialPrompt } : {}),
+        expectedVersion: CLI_VERSION,
+        onVersionMismatch: (info) => {
+          process.stderr.write(`${formatVersionMismatchWarning(info)}\n`)
+        },
+      })
+      const outcome = await tui.run()
+      if (!outcome.lostConnection) return
+      // The TUI lost its WS post-handshake (container restart, network blip,
+      // hostd hiccup). Re-resolve the URL because the host port can change
+      // across container lifecycles (see resolveHostPort), then reconnect.
+      // The initial prompt is intentionally cleared after the first cycle:
+      // on a reconnect, the agent is resuming the same session — replaying
+      // the prompt would re-send it to the LLM.
+      initialPrompt = undefined
+      attempt += 1
+      if (attempt > RECONNECT_MAX_ATTEMPTS) {
+        console.error(errorLine(`disconnected; gave up after ${RECONNECT_MAX_ATTEMPTS} reconnect attempts`))
+        process.exit(1)
+      }
+      process.stderr.write(`reconnecting (attempt ${attempt}/${RECONNECT_MAX_ATTEMPTS})...\n`)
+      await new Promise((resolve) => setTimeout(resolve, RECONNECT_BACKOFF_MS))
+    }
   },
 })
 

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1920,7 +1920,7 @@ describe('defaultRunHatching', () => {
   // care about is "did it pass cliEntry through to start()", and the rest of
   // the function (waitForAgent + TUI) just needs to not blow up.
   const fakeTui: typeof import('@/tui').createTui = () =>
-    ({ run: async () => {} }) as ReturnType<typeof import('@/tui').createTui>
+    ({ run: async () => ({ lostConnection: false }) }) as ReturnType<typeof import('@/tui').createTui>
   const fakeWaitForAgent = async () => {}
 
   test('forwards cliEntry to start() when provided', async () => {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -63,7 +63,7 @@ import { createPluginRuntime, type PluginRuntime, type PluginSubagentEntry } fro
 
 type BunServer = ReturnType<Server['start']>
 
-export type TuiFactory = (options: TuiOptions) => { run: () => Promise<void> }
+export type TuiFactory = (options: TuiOptions) => { run: () => Promise<unknown> }
 
 export type LoadCronFn = (agentDir: string, options?: { subagents?: SubagentRegistry }) => Promise<LoadCronResult>
 export type SchedulerFactory = (options: { cwd: string; file: CronFile; onFire: (job: CronJob) => void }) => Scheduler
@@ -86,7 +86,7 @@ export type StartAgentOptions = {
 
 export type StartAgentResult = {
   server: BunServer
-  tuiPromise: Promise<void> | null
+  tuiPromise: Promise<unknown> | null
   scheduler: Scheduler | null
   cronConsumer: CronConsumer | null
   subagentConsumer: SubagentConsumer

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -11,7 +11,7 @@ import type { CreateSessionForSubagent, SubagentRegistry } from '@/agent/subagen
 import type { CronJob } from '@/cron'
 import { createHookBus, type HookBus, type PluginRegistry } from '@/plugin'
 import { createPluginRuntime, type PluginRuntime } from '@/run/plugin-runtime'
-import type { SessionFactory } from '@/sessions'
+import { createSessionFactory, type SessionFactory } from '@/sessions'
 import type { ServerMessage, TunnelLogsServerMessage } from '@/shared'
 import { createStream } from '@/stream'
 import { expectStable, waitFor as waitForState } from '@/test-helpers/wait-for'
@@ -576,6 +576,206 @@ describe('createServer session persistence wiring', () => {
     expect(connected.serverVersion).toBeUndefined()
 
     ws.close()
+  })
+})
+
+describe('createServer restart-handoff consumption', () => {
+  // pi's SessionManager._persist no-ops until the first assistant message is
+  // appended (line 549-557 of pi 0.67.3's session-manager.js). For the seed
+  // session to land on disk so the server can reopen it, the seed has to
+  // include a user + assistant turn before the restart-self custom message.
+  // In production, the originating session has run many turns before the
+  // restart fires, so this matches reality.
+  async function makeAgentDirWithSession(): Promise<{
+    agentDir: string
+    sessionsDir: string
+    sessionId: string
+    sessionFile: string
+  }> {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-server-handoff-'))
+    const sessionsDir = join(agentDir, 'sessions')
+    const seedFactory = createSessionFactory({ agentDir })
+    const seedManager = seedFactory.createPersisted()
+    const now = Date.now()
+    seedManager.appendMessage({ role: 'user', content: 'hi', timestamp: now })
+    seedManager.appendMessage({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'hello' }],
+      api: 'fake',
+      provider: 'fake',
+      model: 'fake',
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 },
+      },
+      stopReason: 'stop',
+      timestamp: now + 1,
+    })
+    seedManager.appendCustomMessageEntry('typeclaw.restart-self', 'restart instruction', false)
+    const sessionFile = seedManager.getSessionFile()
+    if (!sessionFile) throw new Error('expected persisted session file')
+    return { agentDir, sessionsDir, sessionId: seedManager.getSessionId(), sessionFile }
+  }
+
+  async function writeHandoff(
+    agentDir: string,
+    payload: { restartedAt: string; originatingSessionId: string; originatingSessionFile: string },
+  ): Promise<void> {
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(join(agentDir, '.typeclaw'), { recursive: true })
+    await writeFile(
+      join(agentDir, '.typeclaw', 'restart-pending.json'),
+      JSON.stringify({ schemaVersion: 1, ...payload }),
+      'utf8',
+    )
+  }
+
+  test('reopens the originating session and fires a kick prompt when a fresh handoff is present', async () => {
+    // given
+    const { agentDir, sessionId, sessionFile } = await makeAgentDirWithSession()
+    await writeHandoff(agentDir, {
+      restartedAt: new Date().toISOString(),
+      originatingSessionId: sessionId,
+      originatingSessionFile: sessionFile.split('/').pop()!,
+    })
+
+    const session = createFakeSession()
+    const stream = createStream()
+    const observed: CreateSessionOptions[] = []
+    const factory = createSessionFactory({ agentDir })
+    const built = createServer({
+      port: 0,
+      agentDir,
+      sessionFactory: factory,
+      stream,
+      createSession: async (options = {}) => {
+        observed.push(options)
+        return session
+      },
+    }).start()
+    server = built
+
+    // when
+    const { ws, waitFor } = await connect(`ws://localhost:${built.port}`)
+    const connected = await waitFor((m) => m.type === 'connected')
+
+    // then
+    if (connected.type !== 'connected') throw new Error('unreachable')
+    expect(connected.sessionId).toBe(sessionId)
+    await waitForState(() => session.promptCalls.length > 0)
+    expect(session.promptCalls).toEqual([' '])
+
+    ws.close()
+  })
+
+  test('cold-starts a fresh session when no handoff file is present', async () => {
+    // given
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-server-handoff-cold-'))
+
+    const session = createFakeSession()
+    const stream = createStream()
+    const factory = createSessionFactory({ agentDir })
+    const built = createServer({
+      port: 0,
+      agentDir,
+      sessionFactory: factory,
+      stream,
+      createSession: async () => session,
+    }).start()
+    server = built
+
+    // when
+    const { ws, waitFor } = await connect(`ws://localhost:${built.port}`)
+    const connected = await waitFor((m) => m.type === 'connected')
+
+    // then
+    if (connected.type !== 'connected') throw new Error('unreachable')
+    expect(connected.sessionId).not.toBe('')
+    await expectStable(() => session.promptCalls.length > 0, { durationMs: 200, intervalMs: 50 })
+    expect(session.promptCalls).toEqual([])
+
+    ws.close()
+  })
+
+  test('ignores an expired handoff file (>60s old) and cold-starts instead', async () => {
+    // given
+    const { agentDir, sessionId, sessionFile } = await makeAgentDirWithSession()
+    await writeHandoff(agentDir, {
+      restartedAt: new Date(Date.now() - 90_000).toISOString(),
+      originatingSessionId: sessionId,
+      originatingSessionFile: sessionFile.split('/').pop()!,
+    })
+
+    const session = createFakeSession()
+    const stream = createStream()
+    const factory = createSessionFactory({ agentDir })
+    const built = createServer({
+      port: 0,
+      agentDir,
+      sessionFactory: factory,
+      stream,
+      createSession: async () => session,
+    }).start()
+    server = built
+
+    // when
+    const { ws, waitFor } = await connect(`ws://localhost:${built.port}`)
+    const connected = await waitFor((m) => m.type === 'connected')
+
+    // then
+    if (connected.type !== 'connected') throw new Error('unreachable')
+    expect(connected.sessionId).not.toBe(sessionId)
+    await expectStable(() => session.promptCalls.length > 0, { durationMs: 200, intervalMs: 50 })
+    expect(session.promptCalls).toEqual([])
+
+    ws.close()
+  })
+
+  test('handoff is consumed exactly once across multiple ws opens (second ws is a fresh session)', async () => {
+    // given
+    const { agentDir, sessionId, sessionFile } = await makeAgentDirWithSession()
+    await writeHandoff(agentDir, {
+      restartedAt: new Date().toISOString(),
+      originatingSessionId: sessionId,
+      originatingSessionFile: sessionFile.split('/').pop()!,
+    })
+
+    const sessions: ReturnType<typeof createFakeSession>[] = []
+    const stream = createStream()
+    const factory = createSessionFactory({ agentDir })
+    const built = createServer({
+      port: 0,
+      agentDir,
+      sessionFactory: factory,
+      stream,
+      createSession: async () => {
+        const s = createFakeSession()
+        sessions.push(s)
+        return s
+      },
+    }).start()
+    server = built
+    const url = `ws://localhost:${built.port}`
+
+    // when
+    const a = await connect(url)
+    const connectedA = await a.waitFor((m) => m.type === 'connected')
+    if (connectedA.type !== 'connected') throw new Error('unreachable')
+    a.ws.close()
+
+    const b = await connect(url)
+    const connectedB = await b.waitFor((m) => m.type === 'connected')
+
+    // then
+    if (connectedB.type !== 'connected') throw new Error('unreachable')
+    expect(connectedA.sessionId).toBe(sessionId)
+    expect(connectedB.sessionId).not.toBe(sessionId)
+
+    b.ws.close()
   })
 })
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,3 +1,4 @@
+import { SessionManager } from '@mariozechner/pi-coding-agent'
 import type { Server as BunServer, ServerWebSocket } from 'bun'
 
 import {
@@ -10,6 +11,7 @@ import { runPluginDoctorChecks, runPluginDoctorFix } from '@/agent/doctor'
 import type { LiveSessionRegistry } from '@/agent/live-sessions'
 import type { LiveSubagentRegistry } from '@/agent/live-subagents'
 import { detectProviderError } from '@/agent/provider-error'
+import { consumeRestartHandoff, type RestartHandoff } from '@/agent/restart-handoff'
 import type { SessionOrigin } from '@/agent/session-origin'
 import { parseSubagentCompletedPayload, renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
 import type { CreateSessionForSubagent } from '@/agent/subagents'
@@ -233,6 +235,42 @@ export function createServer({
 }: ServerOptions) {
   const sessionStates = new WeakMap<Ws, SessionState>()
   const callIdToWs = new Map<string, AnyOwnerWs>()
+
+  // The first TUI WS open per container lifetime checks for
+  // `.typeclaw/restart-pending.json`; subsequent opens see null. The
+  // in-flight promise serializes concurrent first-opens — two TUIs
+  // reconnecting at the same instant share the single consume() call rather
+  // than each racing to reopen the originator's JSONL. Once the promise
+  // resolves, the handoff is consumed exactly once: subsequent opens see
+  // `handoffPending === false` and return null without checking the file.
+  let handoffInFlight: Promise<RestartHandoff | null> | null = null
+  let handoffPending = true
+  async function takeRestartHandoff(): Promise<RestartHandoff | null> {
+    if (!handoffPending) return null
+    if (handoffInFlight !== null) return handoffInFlight
+    if (agentDir === undefined) {
+      handoffPending = false
+      return null
+    }
+    handoffInFlight = consumeRestartHandoff(agentDir).catch(() => null)
+    const result = await handoffInFlight
+    handoffPending = false
+    handoffInFlight = null
+    return result
+  }
+
+  function resumeFromHandoff(handoff: RestartHandoff, factory: SessionFactory | undefined): SessionManager | null {
+    if (factory === undefined) return null
+    const sessionPath = `${factory.sessionDir()}/${handoff.originatingSessionFile}`
+    try {
+      return SessionManager.open(sessionPath)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.warn(`restart-handoff: failed to reopen ${sessionPath}: ${message}`)
+      return null
+    }
+  }
+
   const commandRunner: CommandRunner | undefined = commandRunnerFactory
     ? commandRunnerFactory({
         stdout(callId, chunk) {
@@ -397,7 +435,9 @@ export function createServer({
           if (rawWs.data.kind === 'inspect') return
           const ws = rawWs as Ws
           try {
-            const sessionManager = sessionFactory?.createPersisted()
+            const handoff = await takeRestartHandoff()
+            const resumed = handoff !== null ? resumeFromHandoff(handoff, sessionFactory) : null
+            const sessionManager = resumed ?? sessionFactory?.createPersisted()
             const sessionFileId = sessionManager?.getSessionId() ?? ws.data.sessionId
             // Snapshot the runtime once so the entire session lifecycle for this
             // ws connection sees one consistent generation of registry+hooks. A
@@ -485,6 +525,24 @@ export function createServer({
               ...(runtimeVersion !== undefined ? { serverVersion: runtimeVersion } : {}),
             })
             console.log(`session ${sessionFileId}: open`)
+
+            // Fire the post-restart kick. The originator's JSONL already
+            // contains the `typeclaw.restart-self` custom message entry that
+            // the dying container appended (see subscribeRestartNotice in
+            // src/agent/index.ts). pi's buildSessionContext() hydrates that
+            // entry as a `role: "user"` LLM message on the next prompt, so
+            // a single-space kick is enough to trigger a turn — the entry's
+            // own text instructs the model to "briefly confirm the restart
+            // completed". Publish AFTER the session-target subscription is
+            // wired (state.unsubPrompts above) so the kick is enqueued, not
+            // dropped on the floor.
+            if (resumed !== null && stream) {
+              stream.publish({
+                target: { kind: 'session', sessionId: sessionFileId },
+                payload: { kind: 'prompt', text: ' ', delivery: 'queue' },
+                meta: { source: 'restart-handoff' },
+              })
+            }
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err)
             console.error(`session ${ws.data.sessionId}: open failed: ${message}`)

--- a/src/tui/index.test.ts
+++ b/src/tui/index.test.ts
@@ -931,4 +931,50 @@ describe('createTui queue panel', () => {
       'WARN: host CLI is v1.2.3, agent container is v1.2.0. Some commands may hang or fail. Try `typeclaw restart --build`.',
     )
   })
+
+  test('returns lostConnection: true when the WS closes after handshake without user action', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-lost' })
+    const tui = createTui({
+      url: 'ws://ignored',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+      exit: () => {},
+    })
+
+    // when
+    const runPromise = tui.run()
+    await flush()
+    client.triggerClose()
+
+    // then
+    await expect(runPromise).resolves.toEqual({ lostConnection: true })
+  })
+
+  test('returns lostConnection: false when the user submits /quit', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-quit' })
+    let exitCode: number | undefined
+    const tui = createTui({
+      url: 'ws://ignored',
+      initialPrompt: '/quit',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+      exit: (code) => {
+        exitCode = code
+        client.triggerClose()
+      },
+    })
+
+    // when
+    const outcome = await tui.run()
+
+    // then
+    expect(outcome).toEqual({ lostConnection: false })
+    expect(exitCode).toBe(0)
+  })
 })

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -44,6 +44,14 @@ export type TuiOptions = {
   onVersionMismatch?: (info: VersionMismatch) => void
 }
 
+// Outcome of a single `run()` cycle. The CLI's reconnect loop reads this to
+// decide whether to spin again or exit. `lostConnection` is true when the
+// WS closed AFTER the connected handshake without a deliberate /quit or
+// Ctrl+C — exactly the case a self-restart produces, and the only one
+// where a fresh connect can recover the session. Quit / Ctrl+C / pre-
+// handshake errors all resolve with `lostConnection: false`.
+export type TuiRunOutcome = { lostConnection: boolean }
+
 export function createTui({
   url,
   initialPrompt,
@@ -54,7 +62,7 @@ export function createTui({
   expectedVersion,
   onVersionMismatch,
 }: TuiOptions) {
-  async function run(): Promise<void> {
+  async function run(): Promise<TuiRunOutcome> {
     const terminal = createTerminal()
     const tui = new TUI(terminal)
     const displayUrl = redactUrl(url)
@@ -80,6 +88,8 @@ export function createTui({
       exit(1)
       throw err
     })
+
+    let userInitiatedShutdown = false
     const { sessionId, serverVersion } = handshake
     status.setText(colors.dim(`session: ${sessionId}`))
     tui.requestRender()
@@ -196,11 +206,11 @@ export function createTui({
       }
     })
 
-    const closed = new Promise<void>((resolve) => {
+    const closed = new Promise<boolean>((resolve) => {
       client.onClose(() => {
         appendHistory(new Text(colors.dim('disconnected'), 0, 0))
         tui.requestRender()
-        resolve()
+        resolve(!userInitiatedShutdown)
       })
     })
 
@@ -223,6 +233,7 @@ export function createTui({
     })
 
     const shutdown = (code: number) => {
+      userInitiatedShutdown = true
       tui.stop()
       client.close()
       exit(code)
@@ -268,13 +279,14 @@ export function createTui({
       // instead of leaking the command into the agent's chat context.
       if (isQuitCommand(initialPrompt)) {
         shutdown(0)
-        return
+        return { lostConnection: false }
       }
       await send(initialPrompt)
     }
 
-    await closed
+    const lostConnection = await closed
     tui.stop()
+    return { lostConnection }
   }
 
   return { run }


### PR DESCRIPTION
## What this PR does

Closes #291. After the agent calls its own `restart` tool from a TUI session, the host CLI now auto-reconnects to the new container and the agent produces a proactive "I'm back" turn in the same TUI window — no manual `typeclaw tui` re-run, no stray channel posts from cron- or channel-originated restarts.

```
H: restart
Agent: Okay, restarting now.
(container exits, new container boots, ~1-2s)
reconnecting (attempt 1/30)...
Agent: I'm back. Where were we?
```

5 commits, +887 / -22 across 10 files (3 new). Each commit builds and tests cleanly on its own; the chain reads as: refactor → infrastructure → writer → reader → user-visible behavior.

## Reframe of what was already there

Reading the existing code before writing any new code, I found that the model-side instruction is already in place. The `restart` tool's broadcast already triggers `subscribeRestartNotice` in `src/agent/index.ts`, which appends a `typeclaw.restart-self` custom-message entry to the originating session's JSONL with the text "Your very next reply must briefly confirm the restart completed". That entry survives the process death.

What the issue called for under "What's missing" turned out to be three smaller pieces than a casual read of the issue suggests:

1. **The new container creates a fresh session** (`crypto.randomUUID()` in `src/server/index.ts:377`). The previous session's JSONL with the restart-self entry is never reopened, so the LLM never sees the instruction.
2. **`originatingSessionId` is lost on exit.** The Stream is in-memory; the dying container has no way to tell the new one "this session was the originator".
3. **The TUI websocket dies and the user reconnects manually.**

So the actual work is:

- A small file-based handoff carrying the originator's session JSONL path.
- A reader on the next container that reopens the same session via `SessionManager.open` and publishes a minimal kick prompt to fire one turn (pi's `buildSessionContext` hydrates the restart-self entry as a `role: user` LLM message automatically — verified against `pi-coding-agent` 0.67.3 `session-manager.js:171-172` and `messages.js:89-95`).
- A reconnect loop in the host CLI.

The model's "I'm back" copy is entirely driven by the existing `formatRestartNoticeOriginating`. No new prompt copy in this PR.

## What's in the diff

Five commits, each scoped to a single logical change.

### 1. `tui: surface lost-connection state via TuiRunOutcome`

Pure refactor. `createTui(...).run()` returns `Promise<TuiRunOutcome>` instead of `Promise<void>`. `{ lostConnection: true }` is set iff the WS closed after the connected handshake without a user-initiated `/quit` or Ctrl+C. Existing behavior unchanged for all current callers (`TuiFactory` widens to `Promise<unknown>` so `run/index.ts` keeps fire-and-forget semantics; init.test.ts updates the type of its fake-TUI return value).

### 2. `agent: add restart-handoff module for cross-restart originator state`

New module `src/agent/restart-handoff/` with three exports:

| Export | Behavior |
|---|---|
| `restartHandoffPath(agentDir)` | `<agentDir>/.typeclaw/restart-pending.json` — single source of truth so writer and reader cannot drift. |
| `writeRestartHandoff(agentDir, handoff)` | Atomic write (`.tmp` + rename), best-effort: failures are swallowed so a failed write degrades into a cold-start rather than blocking the restart. |
| `consumeRestartHandoff(agentDir, { now?, ttlMs? })` | Read-and-delete in one call so stale entries do not linger when the TTL gate rejects them. Schema-version-1 only; malformed JSON, bad shapes, and expired `restartedAt` all return `null` and delete the file. Default TTL 60 s. |

File location follows the existing `.typeclaw/backup-message.tmp` ephemeral-tenant pattern (dying-writer / next-reader handshake, not gitignored because it self-cleans before any backup pass).

Module is dead code until the next two commits wire it.

### 3. `agent: write restart-handoff from the restart tool on TUI-origin restarts`

`src/agent/tools/restart.ts` gains `agentDir?` and `originatingSessionFile?` options. When both are present, the tool writes the handoff after the broadcast publishes (so the restart-self JSONL append has already landed) and before the exit timer fires. The `restartedAt` timestamp is the same string the broadcast carries — single source of truth.

`src/agent/index.ts` adds `buildRestartHandoffWiring(options, sessionManager)` which returns the handoff fields only when `origin.kind === 'tui'` AND the SessionManager is persisted. Channel-, cron-, and subagent-originated restarts get an empty object, so the next boot stays silent (acceptance criterion: "cron-triggered or channel-triggered restarts do not produce stray channel posts").

### 4. `server: consume restart-handoff at first TUI WS open and kick a turn`

`src/server/index.ts` gains a one-shot `takeRestartHandoff()` that consumes the file on the first TUI WS open per container lifetime. An in-flight promise serializes concurrent first-opens (two TUIs racing to reconnect do not both try to reopen the same JSONL), and a `handoffPending` flag fences post-resolve calls so the second WS open after a successful resume gets a fresh session.

When the handoff is valid and within TTL, the server reopens the originator's session via `SessionManager.open(<sessionDir>/<file>)` instead of calling `sessionFactory.createPersisted()`, and after the `connected` frame is sent it publishes a single-space prompt to the resumed session's stream target via the existing `state.unsubPrompts` subscription. The drain loop enqueues, pi runs `buildSessionContext`, the restart-self custom-message entry becomes a `role: user` LLM context, and the model fires the "I'm back" turn per its existing instructions.

Cold start (no file), expired file (>60 s old), and malformed JSON all fall through to `createPersisted()` and produce no kick.

### 5. `cli/tui: reconnect on lost connection so self-restart looks continuous`

`src/cli/tui.ts` wraps the existing `run()` call in a loop driven by `TuiRunOutcome.lostConnection`. When the WS closes mid-session without a user-initiated `/quit` or Ctrl+C:

- Re-resolves the host port via `resolveHostPort({ cwd })` (the port can change across container lifecycles; `typeclaw start` allocates a fresh free port).
- Renders `reconnecting (attempt N/30)...` to stderr.
- Waits 1 s, reconnects.
- Up to 30 attempts (covers `--build` rebuilds for most non-Docker-image-pull cases).

The initial prompt is cleared after the first cycle so reconnects do not replay it — the resumed session already has it in its transcript.

## Edge cases & scoping

| Scenario | Behavior |
|---|---|
| Cold start, no handoff file | Fresh session, no greeting. ✓ |
| Cold start, stale handoff (>60 s) | Read sees expired, deletes file, fresh session. ✓ |
| Handoff write fails | Restart proceeds; new container cold-starts; user reconnects to a fresh session. ✓ |
| Crash between write and exit | Stale file; next boot's TTL gate or the next restart's overwrite handles it. ✓ |
| Two TUIs at restart, both reconnect | First TUI to open WS consumes handoff and resumes originator. Second TUI gets a fresh session. ✓ |
| Channel/cron/subagent triggers `restart` | Handoff write skipped at the source; new container cold-starts; no stray channel post. ✓ |
| `typeclaw stop` from another terminal | No handoff written by `stop` flow. On next `start`, no file → cold start. ✓ |
| `--build` rebuild >60 s | TTL expires → cold start. v1 limitation. See "Out of scope" below. |

## What this PR does NOT do

- **Hostd-ACK-driven TTL window**: an image rebuild can exceed 60 s. The fix would be to start the TTL clock when hostd confirms the new container is up rather than from `restartedAt`. Deferred — would need hostd protocol changes.
- **Channel-originator greeting**: a Slack-originated `restart` does not produce an "I'm back" in the channel. Deferred — would require channel-adapter handoff plumbing the current handoff schema doesn't carry.
- **Persistent event stream**: discussed in the issue as a longer-term abstraction; the file-based handoff used here is option (a) from the issue and the right size for v1.
- **TUI history rehydration on reconnect**: the user keeps whatever is on screen; the resumed session has full JSONL but the TUI does not replay it.

## Verification

```
bun run typecheck    ✓
bun run lint         ✓  (62 pre-existing warnings, 0 errors, 0 on touched files)
bun run format       ✓
bun run test         5439 pass / 0 fail / 11947 expect() calls
```

Each of the 5 commits passes `typecheck` + relevant test scope in isolation (verified per-commit during stacking).

New tests:

| File | Coverage |
|---|---|
| `src/agent/restart-handoff/index.test.ts` (13 tests) | Round-trip, atomic write, missing directory tolerated, TTL expiry with injected clock, malformed JSON, wrong schema version, empty originator id, unparseable date, exactly-once. |
| `src/agent/tools/restart.test.ts` (+5 tests) | Writes handoff when wired, skips when agentDir omitted, skips when sessionFile omitted (in-memory sessions), no write on hostd denial, broadcast and handoff share `restartedAt`. |
| `src/server/index.test.ts` (+4 tests) | Reopens originator's session and fires kick on fresh handoff, cold-starts when no file, ignores expired file, exactly-once across multiple WS opens. |
| `src/tui/index.test.ts` (+2 tests) | `lostConnection: true` on post-handshake WS close, `lostConnection: false` on `/quit`. |

## Acceptance criteria

From issue #291:

- [x] `H: restart` from TUI produces a coherent "Okay" turn followed by a proactive "I'm back" turn in the same TUI window without user reconnect.
- [x] Cold start after `typeclaw stop` (no recent restart-pending) does NOT produce an "I'm back" greeting.
- [x] Cron-triggered or channel-triggered restarts do not produce stray channel posts.
- [x] Recency window is documented (60 s) and tested (boot 70 s after exit → no greeting).
- [x] Existing `container-restarting` broadcast contract (originator vs sibling) is preserved.
