### PR TITLE
tunnels: add cloudflare-named provider for stable URLs

### DIFF
--- a/docs/content/docs/internals/tunnels.mdx
+++ b/docs/content/docs/internals/tunnels.mdx
@@ -44,13 +44,15 @@ The `for` discriminator owns lifecycle: `{ kind: 'channel', name }` is owned by 
 
 ## Providers
 
-| Provider                           | Subprocess                     | URL source                                | When                                                      |
-| ---------------------------------- | ------------------------------ | ----------------------------------------- | --------------------------------------------------------- |
-| `external`                         | none                           | static `externalUrl` (must be `https://`) | User-supplied reverse proxy (Caddy, ngrok)                |
-| `cloudflare-quick`                 | `cloudflared tunnel --url ...` | parsed from cloudflared stderr            | Default for `channel add github`; URL rotates on restart  |
-| `cloudflare-named` (deferred PR 3) | `cloudflared tunnel run <id>`  | static (`hostname`)                       | After `typeclaw tunnel upgrade`; needs Cloudflare account |
+| Provider           | Subprocess                                             | URL source                                | When                                                                                                            |
+| ------------------ | ------------------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `external`         | none                                                   | static `externalUrl` (must be `https://`) | User-supplied reverse proxy (Caddy, ngrok)                                                                      |
+| `cloudflare-quick` | `cloudflared tunnel --url ...`                         | parsed from cloudflared stderr            | Default for `channel add github`; URL rotates on restart                                                        |
+| `cloudflare-named` | `cloudflared tunnel --no-autoupdate run --token <jwt>` | static (`hostname`)                       | Stable URL bound to a Cloudflare dashboard tunnel; needs a Cloudflare account + a domain in the account's zones |
 
 Schema rejects unimplemented provider names so `start` fails fast instead of tearing down a working container on each restart.
+
+`cloudflare-named` reads its token from an env var named by `tokenEnv` (e.g. `CLOUDFLARE_TUNNEL_TOKEN`) set in `.env`. The token never lives in `typeclaw.json`. `hostname` is informational — `cloudflared` learns the actual hostname → upstream mapping from the Cloudflare dashboard's Public Hostname config, not from typeclaw. If the dashboard hostname drifts from `tunnels[].hostname`, traffic stops flowing but typeclaw still reports the stale URL.
 
 ## Integration
 

--- a/docs/content/docs/reference/tunnel-providers.mdx
+++ b/docs/content/docs/reference/tunnel-providers.mdx
@@ -9,21 +9,69 @@ icon: Globe
 ```ts
 type Tunnel = {
   name: string
-  provider: 'cloudflare-quick' | 'external'
+  provider: 'cloudflare-quick' | 'cloudflare-named' | 'external'
   for: { kind: 'channel'; name: string } | { kind: 'manual' }
-  upstreamPort?: number // required when `for.kind === 'manual'`
+  upstreamPort?: number // required when `for.kind === 'manual'` AND provider !== 'cloudflare-named'
   externalUrl?: string // required when `provider === 'external'`
+  hostname?: string // required when `provider === 'cloudflare-named'`; must be https://
+  tokenEnv?: string // required when `provider === 'cloudflare-named'`; env var name in .env
 }
 ```
 
 ## Providers
 
-| Provider           | URL source                                | Subprocess                   | Stability                         |
-| ------------------ | ----------------------------------------- | ---------------------------- | --------------------------------- |
-| `cloudflare-quick` | parsed from cloudflared stderr at runtime | `cloudflared tunnel --url …` | rotates every cloudflared restart |
-| `external`         | static, from `externalUrl` in config      | none                         | as stable as the URL you provided |
+| Provider           | URL source                                | Subprocess                                         | Stability                           |
+| ------------------ | ----------------------------------------- | -------------------------------------------------- | ----------------------------------- |
+| `cloudflare-quick` | parsed from cloudflared stderr at runtime | `cloudflared tunnel --url …`                       | rotates every cloudflared restart   |
+| `cloudflare-named` | static, from `hostname` in config         | `cloudflared tunnel --no-autoupdate run --token …` | as stable as the dashboard hostname |
+| `external`         | static, from `externalUrl` in config      | none                                               | as stable as the URL you provided   |
 
-`cloudflare-named` is reserved but not yet implemented. The schema rejects provider names with no runtime implementation so `typeclaw start` fails fast before tearing down a working container.
+The schema rejects unknown provider names so `typeclaw start` fails fast before tearing down a working container.
+
+## `cloudflare-named` setup
+
+A `cloudflare-named` tunnel is a "remotely-managed" tunnel ([Cloudflare docs](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/remote-management/)). The user creates and configures it in the Cloudflare Zero Trust dashboard; typeclaw only runs `cloudflared` with the dashboard-issued token.
+
+Required dashboard steps:
+
+1. **Create a tunnel.** `Networks → Tunnels → Create a tunnel → Cloudflared`. Name it, install method = anything (typeclaw doesn't use the installer; just the token). Copy the token shown on the install screen.
+2. **Add a Public Hostname.** On the new tunnel's page, `Public Hostname` tab → `Add a public hostname`. Pick a subdomain + a domain from your account's zones, service type `HTTP`, URL `localhost:<port>` where `<port>` is the in-container upstream.
+
+A tunnel without a Public Hostname registers but routes nothing. `curl` against the configured hostname returns Cloudflare error 530 or 1033. typeclaw cannot detect this — the tunnel shows healthy.
+
+Required typeclaw steps:
+
+1. **Put the token in `.env`.** Pick a var name (convention: `CLOUDFLARE_TUNNEL_TOKEN`):
+
+   ```sh
+   echo 'CLOUDFLARE_TUNNEL_TOKEN=eyJhIjoi…' >> .env
+   ```
+
+2. **Add the tunnel to `typeclaw.json`** via `typeclaw tunnel add` or by hand:
+
+   ```jsonc
+   {
+     "tunnels": [
+       {
+         "name": "github-webhook",
+         "provider": "cloudflare-named",
+         "for": { "kind": "channel", "name": "github" },
+         "hostname": "https://agent.example.com",
+         "tokenEnv": "CLOUDFLARE_TUNNEL_TOKEN",
+       },
+     ],
+   }
+   ```
+
+3. **`typeclaw restart`** so the Dockerfile is regenerated with the `cloudflared` layer and the tunnel manager picks up the new entry.
+
+### Drift between dashboard and config
+
+`hostname` in `typeclaw.json` is informational — `cloudflared` learns the actual hostname→upstream mapping from the dashboard. If the user changes the Public Hostname in the dashboard without updating `tunnels[].hostname`, traffic stops flowing but typeclaw still reports the stale URL on `tunnel-url-changed` events. There is no programmatic detection; typeclaw deliberately does not poll Cloudflare's API.
+
+### Missing token
+
+If `process.env[tokenEnv]` is unset or empty when the manager starts, the named provider transitions to `permanently-failed` with a detail naming the missing env var. `cloudflared` is never spawned. Fix `.env` and `typeclaw restart`.
 
 ## `for` discriminator
 

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -639,6 +639,8 @@ async function promptGithubCredentials(): Promise<{
   tunnelProvider: GithubTunnelProvider
   webhookUrl?: string
   webhookPort?: number
+  hostname?: string
+  tokenEnv?: string
   repos: string[]
   auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string; installationId?: number }
 }> {
@@ -670,6 +672,10 @@ async function promptGithubCredentials(): Promise<{
         value: 'cloudflare-quick',
         label: 'Cloudflare Quick Tunnel — no signup, URL rotates on restart (recommended)',
       },
+      {
+        value: 'cloudflare-named',
+        label: 'Cloudflare Named Tunnel — stable URL, needs Cloudflare account + domain',
+      },
       { value: 'external', label: 'External URL — I have my own reverse proxy / tunnel' },
       { value: 'none', label: 'None — configure later by hand-editing typeclaw.json' },
     ],
@@ -690,6 +696,7 @@ async function promptGithubCredentials(): Promise<{
     cancel('Aborted.')
     process.exit(0)
   }
+  const namedCreds = tunnelProvider === 'cloudflare-named' ? await promptCloudflareNamedTunnel() : undefined
   const port = await text({
     message: 'Local webhook port inside the agent container',
     initialValue: '8975',
@@ -727,9 +734,48 @@ async function promptGithubCredentials(): Promise<{
     tunnelProvider,
     ...(webhookUrl !== undefined ? { webhookUrl } : {}),
     webhookPort: Number(port),
+    ...(namedCreds !== undefined ? namedCreds : {}),
     repos: parseRepos(reposRaw),
     auth,
   }
+}
+
+async function promptCloudflareNamedTunnel(): Promise<{ hostname: string; tokenEnv: string }> {
+  note(
+    [
+      'Cloudflare Named Tunnel needs a tunnel you created in the Zero Trust dashboard:',
+      '  1. Networks → Tunnels → Create a tunnel → Cloudflared. Copy the token shown on the install screen.',
+      '  2. Public Hostname tab → Add: subdomain + your-domain, service type HTTP, URL localhost:<webhook port>.',
+      '  3. Put the token in .env under the env var name you supply below.',
+      'A tunnel without a Public Hostname registers but routes nothing.',
+    ].join('\n'),
+    'Cloudflare named tunnel',
+  )
+  const hostname = await text({
+    message: 'Public hostname configured in the dashboard (https://...)',
+    validate: (value) => validateUrl(value ?? '', 'Hostname is required'),
+  })
+  if (isCancel(hostname)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  const tokenEnv = await text({
+    message: 'Env var name holding the tunnel token',
+    initialValue: 'CLOUDFLARE_TUNNEL_TOKEN',
+    validate: (value) => {
+      const v = value ?? ''
+      if (v.trim().length === 0) return 'Env var name is required'
+      if (!/^[A-Z_][A-Z0-9_]*$/.test(v)) {
+        return 'Must be an env var name like CLOUDFLARE_TUNNEL_TOKEN (uppercase, digits, underscore)'
+      }
+      return undefined
+    },
+  })
+  if (isCancel(tokenEnv)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return { hostname, tokenEnv }
 }
 
 async function promptGithubPatAuth(): Promise<{ type: 'pat'; pat: string }> {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1171,6 +1171,10 @@ async function runGithubFlow(): Promise<StepResult<CollectedInputs['channelSecre
         value: 'cloudflare-quick',
         label: 'Cloudflare Quick Tunnel — no signup, URL rotates on restart (recommended)',
       },
+      {
+        value: 'cloudflare-named',
+        label: 'Cloudflare Named Tunnel — stable URL, needs Cloudflare account + domain',
+      },
       { value: 'external', label: 'External URL — I have my own reverse proxy / tunnel' },
       { value: 'none', label: 'None — configure later by hand-editing typeclaw.json' },
     ],
@@ -1185,6 +1189,8 @@ async function runGithubFlow(): Promise<StepResult<CollectedInputs['channelSecre
         })
       : undefined
   if (isCancel(webhookUrl)) return back()
+  const namedCreds = tunnelProvider === 'cloudflare-named' ? await promptGithubCloudflareNamedTunnel() : undefined
+  if (namedCreds === null) return back()
   const port = await text({
     message: 'Local webhook port inside the agent container',
     initialValue: '8975',
@@ -1214,10 +1220,43 @@ async function runGithubFlow(): Promise<StepResult<CollectedInputs['channelSecre
       tunnelProvider,
       ...(webhookUrl !== undefined ? { webhookUrl } : {}),
       webhookPort: Number(port),
+      ...(namedCreds !== undefined ? namedCreds : {}),
       repos: parseGithubRepos(reposRaw),
       auth,
     },
   })
+}
+
+async function promptGithubCloudflareNamedTunnel(): Promise<{ hostname: string; tokenEnv: string } | null> {
+  note(
+    [
+      'Cloudflare Named Tunnel needs a tunnel you created in the Zero Trust dashboard:',
+      '  1. Networks → Tunnels → Create a tunnel → Cloudflared. Copy the token shown on the install screen.',
+      '  2. Public Hostname tab → Add: subdomain + your-domain, service type HTTP, URL localhost:<webhook port>.',
+      '  3. Put the token in .env under the env var name you supply below.',
+      'A tunnel without a Public Hostname registers but routes nothing.',
+    ].join('\n'),
+    'Cloudflare named tunnel',
+  )
+  const hostname = await text({
+    message: 'Public hostname configured in the dashboard (https://...)',
+    validate: (v) => validateGithubUrl(v ?? '', 'Hostname is required'),
+  })
+  if (isCancel(hostname)) return null
+  const tokenEnv = await text({
+    message: 'Env var name holding the tunnel token',
+    initialValue: 'CLOUDFLARE_TUNNEL_TOKEN',
+    validate: (v) => {
+      const raw = v ?? ''
+      if (raw.trim().length === 0) return 'Env var name is required'
+      if (!/^[A-Z_][A-Z0-9_]*$/.test(raw)) {
+        return 'Must be an env var name like CLOUDFLARE_TUNNEL_TOKEN (uppercase, digits, underscore)'
+      }
+      return undefined
+    },
+  })
+  if (isCancel(tokenEnv)) return null
+  return { hostname, tokenEnv }
 }
 
 async function promptGithubPatAuth(): Promise<{ type: 'pat'; pat: string } | null> {

--- a/src/cli/tunnel.test.ts
+++ b/src/cli/tunnel.test.ts
@@ -46,6 +46,91 @@ describe('tunnel add/remove config flows', () => {
     expect(config.docker.file.cloudflared).toBe(true)
   })
 
+  test('interactive add writes a cloudflare-named channel tunnel and enables cloudflared', async () => {
+    const cwd = await makeAgentDir({})
+    const prompts = sequencedPrompts(['https://agent.example.com', 'CLOUDFLARE_TUNNEL_TOKEN'])
+
+    const result = await tunnel.runTunnelAddFlow(
+      cwd,
+      { name: 'github-webhook', forChannel: 'github' },
+      {
+        selectProvider: async () => 'cloudflare-named',
+        selectOwner: async () => 'channel',
+        text: prompts.text,
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    const config = await readConfig(cwd)
+    expect(config.tunnels).toEqual([
+      {
+        name: 'github-webhook',
+        provider: 'cloudflare-named',
+        for: { kind: 'channel', name: 'github' },
+        hostname: 'https://agent.example.com',
+        tokenEnv: 'CLOUDFLARE_TUNNEL_TOKEN',
+      },
+    ])
+    expect(config.docker.file.cloudflared).toBe(true)
+  })
+
+  test('non-interactive add writes a cloudflare-named manual tunnel without upstreamPort', async () => {
+    const cwd = await makeAgentDir({})
+
+    const result = await tunnel.runTunnelAddFlow(cwd, {
+      name: 'public-demo',
+      provider: 'cloudflare-named',
+      forManual: true,
+      hostname: 'https://demo.example.com',
+      tokenEnv: 'CLOUDFLARE_TUNNEL_TOKEN',
+    })
+
+    expect(result.ok).toBe(true)
+    const config = await readConfig(cwd)
+    expect(config.tunnels).toEqual([
+      {
+        name: 'public-demo',
+        provider: 'cloudflare-named',
+        for: { kind: 'manual' },
+        hostname: 'https://demo.example.com',
+        tokenEnv: 'CLOUDFLARE_TUNNEL_TOKEN',
+      },
+    ])
+    expect(config.tunnels[0].upstreamPort).toBeUndefined()
+  })
+
+  test('add rejects cloudflare-named with non-https hostname', async () => {
+    const cwd = await makeAgentDir({})
+
+    const result = await tunnel.runTunnelAddFlow(cwd, {
+      name: 'demo',
+      provider: 'cloudflare-named',
+      forManual: true,
+      hostname: 'http://agent.example.com',
+      tokenEnv: 'CLOUDFLARE_TUNNEL_TOKEN',
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/https:\/\//)
+  })
+
+  test('add rejects cloudflare-named with lowercase tokenEnv', async () => {
+    const cwd = await makeAgentDir({})
+
+    const result = await tunnel.runTunnelAddFlow(cwd, {
+      name: 'demo',
+      provider: 'cloudflare-named',
+      forManual: true,
+      hostname: 'https://agent.example.com',
+      tokenEnv: 'my_token',
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/env var name/)
+  })
+
   test('non-interactive add writes an external manual tunnel', async () => {
     const cwd = await makeAgentDir({})
 
@@ -256,6 +341,16 @@ function makeTunnelManager(): TunnelManager & { appendLog: (name: string, line: 
     appendLog: (_name, line) => {
       logs.push(line)
       for (const cb of subscribers) cb(line)
+    },
+  }
+}
+
+function sequencedPrompts(answers: string[]): { text: (message: string) => Promise<string> } {
+  let idx = 0
+  return {
+    text: async () => {
+      if (idx >= answers.length) throw new Error(`sequencedPrompts: no answer at index ${idx}`)
+      return answers[idx++]!
     },
   }
 }

--- a/src/cli/tunnel.ts
+++ b/src/cli/tunnel.ts
@@ -19,6 +19,8 @@ type AddArgs = {
   forManual?: boolean
   upstreamPort?: string
   externalUrl?: string
+  hostname?: string
+  tokenEnv?: string
 }
 
 type RemoveArgs = { name: string }
@@ -45,6 +47,11 @@ const defaultPrompts: TunnelPrompts = {
       message: 'Tunnel provider',
       options: [
         { value: 'cloudflare-quick', label: 'Cloudflare Quick Tunnel', hint: 'no signup, URL rotates on restart' },
+        {
+          value: 'cloudflare-named',
+          label: 'Cloudflare Named Tunnel',
+          hint: 'stable URL, needs Cloudflare account + domain',
+        },
         { value: 'external', label: 'External URL', hint: 'bring your own reverse proxy' },
       ],
     }),
@@ -64,11 +71,16 @@ const addSub = defineCommand({
   meta: { name: 'add', description: 'add a public tunnel entry to typeclaw.json' },
   args: {
     name: { type: 'positional', required: true, description: 'tunnel name' },
-    provider: { type: 'string', description: 'external | cloudflare-quick' },
+    provider: { type: 'string', description: 'external | cloudflare-quick | cloudflare-named' },
     'for-channel': { type: 'string', description: 'own this tunnel from a channel adapter' },
     'for-manual': { type: 'boolean', description: 'create a manually-owned tunnel' },
     'upstream-port': { type: 'string', description: 'container-local upstream port for manual tunnels' },
     'external-url': { type: 'string', description: 'https URL for provider=external' },
+    hostname: { type: 'string', description: 'https URL for provider=cloudflare-named (dashboard Public Hostname)' },
+    'token-env': {
+      type: 'string',
+      description: 'env var name holding the cloudflared token (provider=cloudflare-named)',
+    },
   },
   async run({ args }) {
     const result = await runTunnelAddFlow(ensureAgentDir(), {
@@ -78,6 +90,8 @@ const addSub = defineCommand({
       ...(args['for-manual'] === true ? { forManual: true } : {}),
       ...(args['upstream-port'] !== undefined ? { upstreamPort: String(args['upstream-port']) } : {}),
       ...(args['external-url'] !== undefined ? { externalUrl: String(args['external-url']) } : {}),
+      ...(args.hostname !== undefined ? { hostname: String(args.hostname) } : {}),
+      ...(args['token-env'] !== undefined ? { tokenEnv: String(args['token-env']) } : {}),
     })
     if (!result.ok) {
       console.error(errorLine(result.reason))
@@ -184,7 +198,7 @@ export async function runTunnelAddFlow(
   const provider = await resolveProvider(args.provider, prompts)
   const tunnelFor = await resolveFor(args, prompts)
   let upstreamPort: number | undefined
-  if (tunnelFor.kind === 'manual') {
+  if (tunnelFor.kind === 'manual' && provider !== 'cloudflare-named') {
     const raw = args.upstreamPort ?? (await promptText('Upstream port', prompts, validateUpstreamPort))
     const portError = validateUpstreamPort(raw)
     if (portError !== undefined) return { ok: false, reason: `upstream port: ${portError}` }
@@ -196,6 +210,22 @@ export async function runTunnelAddFlow(
     const urlError = validateHttpsUrl(externalUrl)
     if (urlError !== undefined) return { ok: false, reason: `external URL: ${urlError}` }
   }
+  let hostname: string | undefined
+  let tokenEnv: string | undefined
+  if (provider === 'cloudflare-named') {
+    hostname =
+      args.hostname ??
+      (await promptText(
+        'Public hostname configured in the Cloudflare dashboard (https://...)',
+        prompts,
+        validateHttpsUrl,
+      ))
+    const hostnameError = validateHttpsUrl(hostname)
+    if (hostnameError !== undefined) return { ok: false, reason: `hostname: ${hostnameError}` }
+    tokenEnv = args.tokenEnv ?? (await promptText('Env var name holding the tunnel token', prompts, validateTokenEnv))
+    const tokenError = validateTokenEnv(tokenEnv)
+    if (tokenError !== undefined) return { ok: false, reason: `token-env: ${tokenError}` }
+  }
 
   const tunnel: TunnelConfig = {
     name: args.name,
@@ -203,10 +233,12 @@ export async function runTunnelAddFlow(
     for: tunnelFor,
     ...(externalUrl !== undefined ? { externalUrl } : {}),
     ...(upstreamPort !== undefined ? { upstreamPort } : {}),
+    ...(hostname !== undefined ? { hostname } : {}),
+    ...(tokenEnv !== undefined ? { tokenEnv } : {}),
   }
   const raw = readRawConfig(cwd)
   raw.tunnels = [...config.tunnels, tunnel]
-  if (provider === 'cloudflare-quick') {
+  if (provider === 'cloudflare-quick' || provider === 'cloudflare-named') {
     raw.docker = { ...asRecord(raw.docker), file: { ...asRecord(asRecord(raw.docker).file), cloudflared: true } }
   }
   writeRawConfig(cwd, raw)
@@ -379,7 +411,7 @@ function parseLiveArgs(args: LiveArgs): { url?: string; timeoutMs: number } {
 }
 
 async function resolveProvider(input: string | undefined, prompts: TunnelPrompts): Promise<TunnelProvider> {
-  if (input === 'external' || input === 'cloudflare-quick') return input
+  if (input === 'external' || input === 'cloudflare-quick' || input === 'cloudflare-named') return input
   if (input !== undefined) throw new Error(`unknown tunnel provider: ${input}`)
   const choice = await prompts.selectProvider()
   if (isCancel(choice)) {
@@ -435,6 +467,14 @@ function validateHttpsUrl(value: string): string | undefined {
   } catch {
     return 'Must be a valid URL'
   }
+}
+
+function validateTokenEnv(value: string): string | undefined {
+  if (value.trim().length === 0) return 'Env var name is required'
+  if (!/^[A-Z_][A-Z0-9_]*$/.test(value)) {
+    return 'Must be an env var name like CLOUDFLARE_TUNNEL_TOKEN (uppercase, digits, underscore)'
+  }
+  return undefined
 }
 
 function ensureAgentDir(): string {

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1606,7 +1606,7 @@ describe('configSchema tunnels field', () => {
     const parsed = configSchema.parse({ ...baseInput, tunnels: [{ ...externalChannel, provider: 'cloudflare-quick' }] })
     expect(parsed.tunnels[0]?.provider).toBe('cloudflare-quick')
     expect(() =>
-      configSchema.parse({ ...baseInput, tunnels: [{ ...externalChannel, provider: 'cloudflare-named' }] }),
+      configSchema.parse({ ...baseInput, tunnels: [{ ...externalChannel, provider: 'wireguard' }] }),
     ).toThrow()
   })
 
@@ -1614,5 +1614,61 @@ describe('configSchema tunnels field', () => {
     expect(() =>
       configSchema.parse({ ...baseInput, tunnels: [{ ...externalChannel, for: { kind: 'channel', name: '   ' } }] }),
     ).toThrow()
+  })
+
+  describe('cloudflare-named provider', () => {
+    const namedChannel = {
+      name: 'github-webhook',
+      provider: 'cloudflare-named',
+      for: { kind: 'channel', name: 'github' },
+      hostname: 'https://agent.example.com',
+      tokenEnv: 'CLOUDFLARE_TUNNEL_TOKEN',
+    }
+
+    test('accepts a channel-linked named tunnel with hostname and tokenEnv', () => {
+      const parsed = configSchema.parse({ ...baseInput, tunnels: [namedChannel] })
+      expect(parsed.tunnels[0]?.provider).toBe('cloudflare-named')
+      expect(parsed.tunnels[0]?.hostname).toBe('https://agent.example.com')
+      expect(parsed.tunnels[0]?.tokenEnv).toBe('CLOUDFLARE_TUNNEL_TOKEN')
+    })
+
+    test('accepts a manual named tunnel without upstreamPort', () => {
+      const parsed = configSchema.parse({
+        ...baseInput,
+        tunnels: [{ ...namedChannel, for: { kind: 'manual' } }],
+      })
+      expect(parsed.tunnels[0]?.for).toEqual({ kind: 'manual' })
+      expect(parsed.tunnels[0]?.upstreamPort).toBeUndefined()
+    })
+
+    test('rejects named tunnel without hostname', () => {
+      expect(() => configSchema.parse({ ...baseInput, tunnels: [{ ...namedChannel, hostname: undefined }] })).toThrow(
+        /hostname is required/,
+      )
+    })
+
+    test('rejects named tunnel with non-https hostname', () => {
+      expect(() =>
+        configSchema.parse({ ...baseInput, tunnels: [{ ...namedChannel, hostname: 'http://agent.example.com' }] }),
+      ).toThrow(/https:\/\//)
+    })
+
+    test('rejects named tunnel without tokenEnv', () => {
+      expect(() => configSchema.parse({ ...baseInput, tunnels: [{ ...namedChannel, tokenEnv: undefined }] })).toThrow(
+        /tokenEnv is required/,
+      )
+    })
+
+    test('rejects named tunnel with lowercase tokenEnv', () => {
+      expect(() => configSchema.parse({ ...baseInput, tunnels: [{ ...namedChannel, tokenEnv: 'my_token' }] })).toThrow(
+        /env var name/,
+      )
+    })
+
+    test('rejects named tunnel with upstreamPort set', () => {
+      expect(() => configSchema.parse({ ...baseInput, tunnels: [{ ...namedChannel, upstreamPort: 8080 }] })).toThrow(
+        /upstreamPort must not be set/,
+      )
+    })
   })
 })

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -250,15 +250,23 @@ export type NetworkConfig = z.infer<typeof networkSchema>
 
 // Reverse-proxy tunnels expose a container-private port to the public internet
 // via a managed subprocess (cloudflared) or a user-supplied external URL.
-// See AGENTS.md `## Tunnels`. PR 2 ships `cloudflare-quick`; `cloudflare-named`
-// remains deferred to PR 3. Keeping the enum scoped to what's implemented means
-// validateConfig() rejects unsupported providers at `typeclaw start` time,
-// before the container is torn down and rebuilt. `restart-required` because
-// the tunnel manager reads this list once at boot.
+// See AGENTS.md `## Tunnels`. Keeping the enum scoped to what's implemented
+// means validateConfig() rejects unsupported providers at `typeclaw start`
+// time, before the container is torn down and rebuilt. `restart-required`
+// because the tunnel manager reads this list once at boot.
 const tunnelForSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('channel'), name: z.string().trim().min(1) }),
   z.object({ kind: z.literal('manual') }),
 ])
+
+// `tokenEnv` is the NAME of an env var, not the token itself. Restrict to the
+// shell-portable identifier shape (uppercase + digits + underscore, leading
+// non-digit) so a value typed here can't break `--env-file` parsing or shell
+// expansion inside the container. Matches the convention every other env var
+// in the codebase already follows (TYPECLAW_*, OPENAI_*, etc.).
+const tokenEnvNameSchema = z.string().regex(/^[A-Z_][A-Z0-9_]*$/, {
+  message: 'tokenEnv must be an env var name like CLOUDFLARE_TUNNEL_TOKEN (uppercase, digits, underscore)',
+})
 
 const tunnelEntrySchema = z
   .object({
@@ -268,7 +276,7 @@ const tunnelEntrySchema = z
       .regex(/^[a-z0-9][a-z0-9-_]*$/, {
         message: 'tunnel name must match /^[a-z0-9][a-z0-9-_]*$/ (lowercase, digits, dashes, underscores)',
       }),
-    provider: z.enum(['external', 'cloudflare-quick']),
+    provider: z.enum(['external', 'cloudflare-quick', 'cloudflare-named']),
     for: tunnelForSchema,
     externalUrl: z
       .string()
@@ -276,11 +284,31 @@ const tunnelEntrySchema = z
       .refine((u) => u.startsWith('https://'), { message: 'externalUrl must use https://' })
       .optional(),
     upstreamPort: z.number().int().min(1).max(65535).optional(),
+    hostname: z
+      .string()
+      .url()
+      .refine((u) => u.startsWith('https://'), { message: 'hostname must use https://' })
+      .optional(),
+    tokenEnv: tokenEnvNameSchema.optional(),
   })
   .refine((v) => v.provider !== 'external' || (v.externalUrl !== undefined && v.externalUrl.trim() !== ''), {
     message: "tunnels[].externalUrl is required when provider is 'external'",
   })
-  .refine((v) => v.for.kind !== 'manual' || v.upstreamPort !== undefined, {
+  .refine((v) => v.provider !== 'cloudflare-named' || (v.hostname !== undefined && v.hostname.trim() !== ''), {
+    message: "tunnels[].hostname is required when provider is 'cloudflare-named'",
+  })
+  .refine((v) => v.provider !== 'cloudflare-named' || (v.tokenEnv !== undefined && v.tokenEnv.trim() !== ''), {
+    message: "tunnels[].tokenEnv is required when provider is 'cloudflare-named'",
+  })
+  // cloudflared learns the upstream from the Cloudflare dashboard's Public
+  // Hostname mapping, not from typeclaw. An `upstreamPort` here would be
+  // silently ignored; reject at parse time so the contradiction surfaces in
+  // the config file rather than as a debugging surprise.
+  .refine((v) => v.provider !== 'cloudflare-named' || v.upstreamPort === undefined, {
+    message:
+      "tunnels[].upstreamPort must not be set when provider is 'cloudflare-named' (cloudflared reads the upstream from the Cloudflare dashboard)",
+  })
+  .refine((v) => v.for.kind !== 'manual' || v.provider === 'cloudflare-named' || v.upstreamPort !== undefined, {
     message: "tunnels[].upstreamPort is required when for.kind is 'manual'",
   })
 

--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -517,6 +517,104 @@ describe('runAddChannel', () => {
     ])
   })
 
+  test('adds github channel with a cloudflare-named tunnel and cloudflared Dockerfile toggle', async () => {
+    await runAddChannel({
+      cwd: root,
+      channel: 'github',
+      auth: { type: 'pat', pat: 'ghp_test' },
+      webhookSecret: 'wh-secret',
+      tunnelProvider: 'cloudflare-named',
+      hostname: 'https://agent.example.com',
+      tokenEnv: 'CLOUDFLARE_TUNNEL_TOKEN',
+      webhookPort: 8975,
+      repos: ['acme/widgets'],
+    })
+
+    const cfg = (await readConfig()) as {
+      channels?: { github?: { webhookUrl?: string; repos?: string[] } }
+      docker?: { file?: { cloudflared?: boolean } }
+      tunnels?: Array<{
+        name?: string
+        provider?: string
+        hostname?: string
+        tokenEnv?: string
+        for?: { kind?: string; name?: string }
+      }>
+    }
+
+    expect(cfg.channels?.github?.webhookUrl).toBeUndefined()
+    expect(cfg.channels?.github?.repos).toEqual(['acme/widgets'])
+    expect(cfg.docker?.file?.cloudflared).toBe(true)
+    expect(cfg.tunnels).toEqual([
+      {
+        name: 'github-webhook',
+        provider: 'cloudflare-named',
+        for: { kind: 'channel', name: 'github' },
+        hostname: 'https://agent.example.com',
+        tokenEnv: 'CLOUDFLARE_TUNNEL_TOKEN',
+      },
+    ])
+  })
+
+  test('adds github channel (cloudflare-named): eagerly registers webhook using hostname as the public URL', async () => {
+    const fetchImpl = recordingGithubFetch()
+
+    await runAddChannel({
+      cwd: root,
+      channel: 'github',
+      auth: { type: 'pat', pat: 'ghp_test' },
+      webhookSecret: 'wh-secret-named',
+      tunnelProvider: 'cloudflare-named',
+      hostname: 'https://agent.example.com',
+      tokenEnv: 'CLOUDFLARE_TUNNEL_TOKEN',
+      webhookPort: 8975,
+      repos: ['acme/widgets'],
+      fetchImpl: fetchImpl.fn,
+    })
+
+    const posts = fetchImpl.calls.filter((c) => c.method === 'POST' && c.url.endsWith('/hooks'))
+    expect(posts).toHaveLength(1)
+    const body = JSON.parse(posts[0]!.body ?? '{}') as {
+      config?: { url?: string; secret?: string }
+    }
+    // Hostname has no path, so applyManagedPath appends the
+    // /typeclaw/v1/github/<agentId> marker (same path-marker contract that
+    // makes cloudflare-quick hooks recognizable across URL rotations). The
+    // user types the bare hostname; typeclaw owns the path.
+    expect(body.config?.url).toMatch(/^https:\/\/agent\.example\.com\/typeclaw\/v1\/github\/[a-z0-9_.-]+$/)
+    expect(body.config?.secret).toBe('wh-secret-named')
+  })
+
+  test('adds github channel (cloudflare-named): rejects missing hostname', async () => {
+    await expect(
+      runAddChannel({
+        cwd: root,
+        channel: 'github',
+        auth: { type: 'pat', pat: 'ghp_test' },
+        webhookSecret: 'wh-secret',
+        tunnelProvider: 'cloudflare-named',
+        tokenEnv: 'CLOUDFLARE_TUNNEL_TOKEN',
+        webhookPort: 8975,
+        repos: ['acme/widgets'],
+      }),
+    ).rejects.toThrow(/hostname/)
+  })
+
+  test('adds github channel (cloudflare-named): rejects missing tokenEnv', async () => {
+    await expect(
+      runAddChannel({
+        cwd: root,
+        channel: 'github',
+        auth: { type: 'pat', pat: 'ghp_test' },
+        webhookSecret: 'wh-secret',
+        tunnelProvider: 'cloudflare-named',
+        hostname: 'https://agent.example.com',
+        webhookPort: 8975,
+        repos: ['acme/widgets'],
+      }),
+    ).rejects.toThrow(/tokenEnv/)
+  })
+
   test('adds github channel with no tunnel and no webhookUrl', async () => {
     await runAddChannel({
       cwd: root,

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -78,13 +78,24 @@ export type KakaotalkAuthResult = { ok: true } | { ok: false; reason: string }
 export type GithubInitCredentials = {
   webhookSecret: string
   tunnelProvider: GithubTunnelProvider
+  // Set when `tunnelProvider === 'external'`. The user-supplied https URL
+  // that GitHub POSTs to and that lands in `channels.github.webhookUrl`.
   webhookUrl?: string
   webhookPort?: number
+  // Set when `tunnelProvider === 'cloudflare-named'`. The Public Hostname
+  // configured in the Cloudflare dashboard; also used as the webhook URL for
+  // eager registration (GitHub POSTs through the named tunnel to the in-
+  // container webhook server). Kept distinct from `webhookUrl` so the
+  // wizard's branching stays readable and the resulting `tunnels[].hostname`
+  // ends up in the right field rather than being smuggled through
+  // `externalUrl`.
+  hostname?: string
+  tokenEnv?: string
   repos: string[]
   auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string; installationId?: number }
 }
 
-export type GithubTunnelProvider = 'cloudflare-quick' | 'external' | 'none'
+export type GithubTunnelProvider = 'cloudflare-quick' | 'cloudflare-named' | 'external' | 'none'
 
 export type InitStepEvent =
   | { step: 'preflight'; phase: 'start' }
@@ -937,6 +948,8 @@ export type AddChannelOptions = {
       tunnelProvider: GithubTunnelProvider
       webhookUrl?: string
       webhookPort?: number
+      hostname?: string
+      tokenEnv?: string
       repos: string[]
       auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string; installationId?: number }
       fetchImpl?: typeof fetch
@@ -1000,11 +1013,18 @@ async function maybeInstallGithubWebhooks(
   options: Extract<AddChannelOptions, { channel: 'github' }>,
   emit: (event: AddChannelStepEvent) => void,
 ): Promise<void> {
-  if (options.webhookUrl === undefined) return
+  // For `external` and `cloudflare-named` we know the public URL up front
+  // (user-supplied `webhookUrl` or dashboard-configured `hostname`), so we
+  // can register the webhook on GitHub's side eagerly. For `cloudflare-quick`
+  // the URL only exists once cloudflared has emitted it on stderr inside the
+  // container, which hasn't happened yet at host-stage init/channel-add
+  // time — registration is deferred to the adapter's first `start()`.
+  const eagerUrl = resolveEagerWebhookUrl(options)
+  if (eagerUrl === undefined) return
   if (options.repos.length === 0) return
   emit({ step: 'github-webhooks', phase: 'start' })
   const result = await installGithubWebhooksEagerly({
-    webhookUrl: options.webhookUrl,
+    webhookUrl: eagerUrl,
     webhookSecret: options.webhookSecret,
     repos: options.repos,
     auth: options.auth,
@@ -1012,6 +1032,12 @@ async function maybeInstallGithubWebhooks(
     ...(options.fetchImpl !== undefined ? { fetchImpl: options.fetchImpl } : {}),
   })
   emit({ step: 'github-webhooks', phase: 'done', result })
+}
+
+function resolveEagerWebhookUrl(options: Extract<AddChannelOptions, { channel: 'github' }>): string | undefined {
+  if (options.tunnelProvider === 'external') return options.webhookUrl
+  if (options.tunnelProvider === 'cloudflare-named') return options.hostname
+  return undefined
 }
 
 function channelSecretsFromOptions(options: AddChannelOptions): ChannelSecrets {
@@ -1112,29 +1138,53 @@ function mergeGithubTunnelConfig(
   if (options.tunnelProvider === 'external' && options.webhookUrl === undefined) {
     throw new Error('GitHub external tunnel requires webhookUrl')
   }
+  if (options.tunnelProvider === 'cloudflare-named') {
+    if (options.hostname === undefined || options.hostname.trim() === '') {
+      throw new Error('GitHub cloudflare-named tunnel requires hostname')
+    }
+    if (options.tokenEnv === undefined || options.tokenEnv.trim() === '') {
+      throw new Error('GitHub cloudflare-named tunnel requires tokenEnv')
+    }
+  }
 
   const existingTunnels = Array.isArray(parsed.tunnels) ? parsed.tunnels : []
-  const tunnel =
-    options.tunnelProvider === 'external'
-      ? {
-          name: 'github-webhook',
-          provider: 'external',
-          externalUrl: options.webhookUrl,
-          for: { kind: 'channel', name: 'github' },
-        }
-      : {
-          name: 'github-webhook',
-          provider: 'cloudflare-quick',
-          for: { kind: 'channel', name: 'github' },
-        }
+  const tunnel = buildGithubTunnelEntry(options)
   parsed.tunnels = [...existingTunnels, tunnel]
 
-  if (options.tunnelProvider === 'cloudflare-quick') {
+  if (options.tunnelProvider === 'cloudflare-quick' || options.tunnelProvider === 'cloudflare-named') {
     const docker = isObjectRecord(parsed.docker) ? { ...parsed.docker } : {}
     const file = isObjectRecord(docker.file) ? { ...docker.file } : {}
     file.cloudflared = true
     docker.file = file
     parsed.docker = docker
+  }
+}
+
+function buildGithubTunnelEntry(options: Extract<AddChannelOptions, { channel: 'github' }>): Record<string, unknown> {
+  switch (options.tunnelProvider) {
+    case 'external':
+      return {
+        name: 'github-webhook',
+        provider: 'external',
+        externalUrl: options.webhookUrl,
+        for: { kind: 'channel', name: 'github' },
+      }
+    case 'cloudflare-quick':
+      return {
+        name: 'github-webhook',
+        provider: 'cloudflare-quick',
+        for: { kind: 'channel', name: 'github' },
+      }
+    case 'cloudflare-named':
+      return {
+        name: 'github-webhook',
+        provider: 'cloudflare-named',
+        for: { kind: 'channel', name: 'github' },
+        hostname: options.hostname,
+        tokenEnv: options.tokenEnv,
+      }
+    case 'none':
+      throw new Error('buildGithubTunnelEntry called with tunnelProvider=none')
   }
 }
 

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -28,7 +28,7 @@ export type TunnelRequestId = string
 
 export type TunnelSnapshot = {
   name: string
-  provider: 'external' | 'cloudflare-quick'
+  provider: 'external' | 'cloudflare-quick' | 'cloudflare-named'
   for: { kind: 'channel'; name: string } | { kind: 'manual' }
   url: string | null
   status: 'stopped' | 'starting' | 'healthy' | 'unhealthy' | 'permanently-failed'

--- a/src/skills/typeclaw-tunnels/SKILL.md
+++ b/src/skills/typeclaw-tunnels/SKILL.md
@@ -30,6 +30,27 @@ Choose Cloudflare Quick when the user wants the easiest path:
 
 For GitHub channel setup, `typeclaw channel add github` can write a channel-owned Cloudflare Quick tunnel named `github-webhook` and set `docker.file.cloudflared: true`. The first `typeclaw start` or `restart` after that rebuilds the image with `cloudflared` installed.
 
+### Cloudflare Named Tunnel
+
+Choose Cloudflare Named when the user has a domain on Cloudflare and wants a stable URL:
+
+- Cloudflare account required (free), plus a domain already in their account's `Websites` list.
+- The user creates the tunnel in the Zero Trust dashboard (`Networks → Tunnels → Create`), copies the token, and configures a Public Hostname pointing at `localhost:<port>` (where `<port>` is the in-container upstream).
+- The URL is whatever subdomain on their domain they configured (e.g. `https://agent.example.com`).
+- The URL never rotates. It's bound to the tunnel in the dashboard, not the process.
+- `cloudflared` runs inside the container with `cloudflared tunnel run --token <jwt>`. The token comes from `.env`.
+
+Use `provider: "cloudflare-named"` with `hostname: "https://..."` and `tokenEnv: "CLOUDFLARE_TUNNEL_TOKEN"` (or another env var name set in `.env`). The user must:
+
+1. Create the tunnel in the Cloudflare dashboard.
+2. Add at least one Public Hostname mapping `<sub>.<their-domain>` → `localhost:<port>`. A tunnel without a Public Hostname is a no-op — `cloudflared` registers but has nothing to route.
+3. Put the dashboard-printed token in `.env` under the env var named in `tokenEnv`.
+4. `typeclaw restart` to pick up the new tunnel and the cloudflared layer.
+
+The `hostname` field in `typeclaw.json` is informational — typeclaw uses it for `tunnel-url-changed` events and CLI display, but `cloudflared` reads the actual hostname→upstream mapping from the dashboard. If the user changes the hostname in the dashboard, they must also update `tunnels[].hostname` in `typeclaw.json` or downstream consumers (GitHub webhook registration) will keep using the stale URL.
+
+`upstreamPort` is not used for `cloudflare-named` — the dashboard's Public Hostname mapping captures it. The schema rejects `upstreamPort` on named tunnels to surface drift early.
+
 ### External URL
 
 Choose External when the user already has their own reverse proxy or tunnel:
@@ -90,7 +111,18 @@ Use `typeclaw tunnel logs <name> -f` while restarting the agent if you need to w
 
 ### `cloudflared` is not installed
 
-The Cloudflare Quick provider requires `docker.file.cloudflared: true`. If it is missing, add it to `typeclaw.json` or re-run the GitHub channel setup choosing Cloudflare Quick, then run `typeclaw restart` so the Dockerfile is regenerated and the image rebuilds.
+Both Cloudflare providers (`cloudflare-quick` and `cloudflare-named`) require `docker.file.cloudflared: true`. If it is missing, `typeclaw tunnel add` writes it automatically; otherwise add it to `typeclaw.json` by hand and run `typeclaw restart` so the Dockerfile is regenerated and the image rebuilds.
+
+### Named tunnel says "permanently-failed" with `tokenEnv` in the detail
+
+The env var named in `tunnels[].tokenEnv` is not set or is empty in the agent's `.env`. The provider intentionally does not retry this case — fix `.env`, then `typeclaw restart`. `cloudflared` is never spawned with a missing token.
+
+### Named tunnel is healthy but no traffic flows
+
+Two likely causes:
+
+1. The Cloudflare dashboard's Public Hostname tab for this tunnel is empty. A tunnel with no public hostname is a no-op — `cloudflared` registers and waits, but Cloudflare has nothing to route to it. `curl https://<hostname>` returns Cloudflare error 530 or 1033.
+2. The Public Hostname's upstream `localhost:<port>` does not match the in-container service port. typeclaw cannot detect this drift; the user must align the dashboard and the container.
 
 ### Quick tunnel URL changed
 

--- a/src/tunnels/index.ts
+++ b/src/tunnels/index.ts
@@ -1,4 +1,5 @@
 export { createTunnelManager, type TunnelManager, type TunnelManagerOptions, type TunnelManagerLogger } from './manager'
+export { createCloudflareNamedProvider, type CloudflareNamedProviderOptions } from './providers/cloudflare-named'
 export { createCloudflareQuickProvider, type CloudflareQuickProviderOptions } from './providers/cloudflare-quick'
 export {
   type TunnelConfig,

--- a/src/tunnels/manager.ts
+++ b/src/tunnels/manager.ts
@@ -1,5 +1,6 @@
 import type { Stream } from '@/stream'
 
+import { createCloudflareNamedProvider } from './providers/cloudflare-named'
 import { createCloudflareQuickProvider } from './providers/cloudflare-quick'
 import { createExternalProvider } from './providers/external'
 import type { TunnelConfig, TunnelProviderHandle, TunnelState, TunnelUrlChangedPayload } from './types'
@@ -15,6 +16,11 @@ export type TunnelManagerOptions = {
   stream: Stream
   resolveChannelUpstreamPort?: (channelName: string) => number | null
   cloudflareQuickBinary?: string
+  cloudflareNamedBinary?: string
+  // Reads an env var by name. Defaults to `process.env[name]` in production.
+  // Parameterized so tests can drive the named-provider token path without
+  // poking global env and so the manager stays a pure function of its inputs.
+  resolveEnv?: (name: string) => string | undefined
   logger?: TunnelManagerLogger
 }
 
@@ -36,6 +42,7 @@ const consoleLogger: TunnelManagerLogger = {
 export function createTunnelManager(options: TunnelManagerOptions): TunnelManager {
   const logger = options.logger ?? consoleLogger
   const handles = new Map<string, TunnelProviderHandle>()
+  const resolveEnv = options.resolveEnv ?? ((name: string) => process.env[name])
 
   for (const config of options.tunnels) {
     const handle = buildProvider(
@@ -43,6 +50,8 @@ export function createTunnelManager(options: TunnelManagerOptions): TunnelManage
       options.resolveChannelUpstreamPort,
       (url) => publishUrlChange(options.stream, config, url, logger),
       options.cloudflareQuickBinary,
+      options.cloudflareNamedBinary,
+      resolveEnv,
     )
     handles.set(config.name, handle)
   }
@@ -92,6 +101,8 @@ function buildProvider(
   resolveChannelUpstreamPort: TunnelManagerOptions['resolveChannelUpstreamPort'],
   onUrlChange: (url: string) => void,
   cloudflareQuickBinary: string | undefined,
+  cloudflareNamedBinary: string | undefined,
+  resolveEnv: (name: string) => string | undefined,
 ): TunnelProviderHandle {
   switch (config.provider) {
     case 'external':
@@ -102,6 +113,13 @@ function buildProvider(
         upstreamPort: resolveUpstreamPort(config, resolveChannelUpstreamPort),
         onUrlChange,
         binary: cloudflareQuickBinary,
+      })
+    case 'cloudflare-named':
+      return createCloudflareNamedProvider({
+        config,
+        onUrlChange,
+        resolveToken: () => (config.tokenEnv !== undefined ? resolveEnv(config.tokenEnv) : undefined),
+        binary: cloudflareNamedBinary,
       })
   }
 }

--- a/src/tunnels/providers/cloudflare-named.test.ts
+++ b/src/tunnels/providers/cloudflare-named.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'bun:test'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { waitFor } from '@/test-helpers/wait-for'
+
+import { createCloudflareNamedProvider } from './cloudflare-named'
+
+const config = {
+  name: 'github-webhook',
+  provider: 'cloudflare-named',
+  for: { kind: 'channel', name: 'github' },
+  hostname: 'https://agent.example.com',
+  tokenEnv: 'CLOUDFLARE_TUNNEL_TOKEN',
+} as const
+
+describe('createCloudflareNamedProvider', () => {
+  function createScratchDir(): string {
+    return mkdtempSync(join(tmpdir(), 'cloudflare-named-test-'))
+  }
+
+  function installFakeCloudflared(scratchDir: string, script: string): string {
+    const path = join(scratchDir, 'fake-cloudflared')
+    writeFileSync(path, `#!/bin/sh\n${script}\n`, 'utf8')
+    chmodSync(path, 0o755)
+    return path
+  }
+
+  it('emits the configured hostname synchronously at start and spawns cloudflared with the token', async () => {
+    const scratchDir = createScratchDir()
+    const argvFile = join(scratchDir, 'argv.txt')
+    const binary = installFakeCloudflared(
+      scratchDir,
+      `
+printf '%s\n' "$@" > "${argvFile}"
+echo "2026-01-01T00:00:00Z INF Connection registered" >&2
+trap 'exit 0' TERM
+sleep 30
+`,
+    )
+    const urls: string[] = []
+    const provider = createCloudflareNamedProvider({
+      config,
+      binary,
+      onUrlChange: (url) => urls.push(url),
+      resolveToken: () => 'eyJhIjoiZmFrZS10b2tlbiJ9',
+      stopGraceMs: 10,
+    })
+
+    try {
+      // URL must be emitted synchronously - subscribers wire up immediately,
+      // not after cloudflared comes up.
+      await provider.start()
+      expect(urls).toEqual(['https://agent.example.com'])
+      expect(provider.snapshot().url).toBe('https://agent.example.com')
+
+      await waitFor(() => provider.snapshot().status === 'healthy', { description: 'healthy after first stderr' })
+      expect((await readFile(argvFile, 'utf8')).split('\n').filter(Boolean)).toEqual([
+        'tunnel',
+        '--no-autoupdate',
+        'run',
+        '--token',
+        'eyJhIjoiZmFrZS10b2tlbiJ9',
+      ])
+
+      await provider.stop()
+      expect(provider.snapshot().status).toBe('stopped')
+    } finally {
+      await provider.stop()
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('flips to permanently-failed when the token env var is unset', async () => {
+    const scratchDir = createScratchDir()
+    const binary = installFakeCloudflared(scratchDir, 'exit 0')
+    const urls: string[] = []
+    const provider = createCloudflareNamedProvider({
+      config,
+      binary,
+      onUrlChange: (url) => urls.push(url),
+      resolveToken: () => undefined,
+      stopGraceMs: 10,
+    })
+
+    try {
+      await provider.start()
+
+      // URL still emits (hostname is config-bound, not process-bound) so
+      // subscribers like channel adapters see the right URL, but the tunnel
+      // is permanently-failed because no token exists to spawn cloudflared.
+      expect(urls).toEqual(['https://agent.example.com'])
+      const snap = provider.snapshot()
+      expect(snap.status).toBe('permanently-failed')
+      expect(snap.detail).toContain('CLOUDFLARE_TUNNEL_TOKEN')
+      expect(snap.url).toBe('https://agent.example.com')
+    } finally {
+      await provider.stop()
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('also flips to permanently-failed when the token env var is empty string', async () => {
+    const scratchDir = createScratchDir()
+    const binary = installFakeCloudflared(scratchDir, 'exit 0')
+    const provider = createCloudflareNamedProvider({
+      config,
+      binary,
+      onUrlChange: () => {},
+      resolveToken: () => '',
+      stopGraceMs: 10,
+    })
+
+    try {
+      await provider.start()
+      expect(provider.snapshot().status).toBe('permanently-failed')
+    } finally {
+      await provider.stop()
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('restarts a crashed process with backoff', async () => {
+    const scratchDir = createScratchDir()
+    const countFile = join(scratchDir, 'count.txt')
+    const binary = installFakeCloudflared(
+      scratchDir,
+      `
+count=0
+if [ -f "${countFile}" ]; then count=$(cat "${countFile}"); fi
+count=$((count + 1))
+printf '%s' "$count" > "${countFile}"
+if [ "$count" -eq 1 ]; then
+  echo first crash >&2
+  exit 2
+fi
+echo "INF Connection registered after restart" >&2
+trap 'exit 0' TERM
+sleep 30
+`,
+    )
+    const provider = createCloudflareNamedProvider({
+      config,
+      binary,
+      onUrlChange: () => {},
+      resolveToken: () => 'fake-token',
+      restartBackoffMs: [5],
+      stopGraceMs: 10,
+    })
+
+    try {
+      await provider.start()
+      // Health flips on first stderr line of any launch (including launch 1
+      // which then crashes), so the load-bearing invariant under test is
+      // "we observed the second launch happen", not "status == healthy".
+      // Polling the count file directly avoids the launch-1-healthy race.
+      await waitFor(
+        async () => {
+          try {
+            return (await readFile(countFile, 'utf8')) === '2'
+          } catch {
+            return false
+          }
+        },
+        { description: 'second launch wrote count file' },
+      )
+      expect(provider.snapshot().status).toBe('healthy')
+    } finally {
+      await provider.stop()
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('stops retrying after the consecutive-crash cap is reached', async () => {
+    const scratchDir = createScratchDir()
+    const countFile = join(scratchDir, 'count.txt')
+    const binary = installFakeCloudflared(
+      scratchDir,
+      `
+count=0
+if [ -f "${countFile}" ]; then count=$(cat "${countFile}"); fi
+count=$((count + 1))
+printf '%s' "$count" > "${countFile}"
+echo crash "$count" >&2
+exit 3
+`,
+    )
+    const provider = createCloudflareNamedProvider({
+      config,
+      binary,
+      onUrlChange: () => {},
+      resolveToken: () => 'fake-token',
+      restartBackoffMs: [1],
+      maxConsecutiveCrashes: 2,
+    })
+
+    try {
+      await provider.start()
+      await waitFor(() => provider.snapshot().status === 'permanently-failed', { description: 'permanent failure' })
+
+      expect(await readFile(countFile, 'utf8')).toBe('2')
+    } finally {
+      await provider.stop()
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('SIGKILLs processes that ignore SIGTERM during stop', async () => {
+    const scratchDir = createScratchDir()
+    const binary = installFakeCloudflared(
+      scratchDir,
+      `
+echo "INF Connection registered" >&2
+trap '' TERM
+sleep 30
+`,
+    )
+    const provider = createCloudflareNamedProvider({
+      config,
+      binary,
+      onUrlChange: () => {},
+      resolveToken: () => 'fake-token',
+      stopGraceMs: 10,
+    })
+
+    try {
+      await provider.start()
+      await waitFor(() => provider.snapshot().status === 'healthy', { description: 'healthy' })
+
+      await provider.stop()
+      expect(provider.snapshot().status).toBe('stopped')
+    } finally {
+      await provider.stop()
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects construction when hostname is missing', () => {
+    expect(() =>
+      createCloudflareNamedProvider({
+        config: { ...config, hostname: undefined } as unknown as typeof config,
+        onUrlChange: () => {},
+        resolveToken: () => 'fake-token',
+      }),
+    ).toThrow(/hostname is required/)
+  })
+
+  it('rejects construction when tokenEnv is missing', () => {
+    expect(() =>
+      createCloudflareNamedProvider({
+        config: { ...config, tokenEnv: undefined } as unknown as typeof config,
+        onUrlChange: () => {},
+        resolveToken: () => 'fake-token',
+      }),
+    ).toThrow(/tokenEnv is required/)
+  })
+
+  it('rejects construction when the provider field disagrees', () => {
+    expect(() =>
+      createCloudflareNamedProvider({
+        config: { ...config, provider: 'cloudflare-quick' } as unknown as typeof config,
+        onUrlChange: () => {},
+        resolveToken: () => 'fake-token',
+      }),
+    ).toThrow(/provider must be 'cloudflare-named'/)
+  })
+
+  it('subscribers receive future stderr lines without replay', async () => {
+    const scratchDir = createScratchDir()
+    const binary = installFakeCloudflared(
+      scratchDir,
+      `
+echo before >&2
+sleep 0.05
+echo after >&2
+trap 'exit 0' TERM
+sleep 30
+`,
+    )
+    const provider = createCloudflareNamedProvider({
+      config,
+      binary,
+      onUrlChange: () => {},
+      resolveToken: () => 'fake-token',
+      stopGraceMs: 10,
+    })
+
+    try {
+      await provider.start()
+      await waitFor(() => provider.tail().includes('before'), { description: 'first log line' })
+      const received: string[] = []
+      provider.subscribeToLogs((line) => received.push(line))
+      await waitFor(() => received.includes('after'), { description: 'future log line' })
+
+      expect(received).toEqual(['after'])
+    } finally {
+      await provider.stop()
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/tunnels/providers/cloudflare-named.ts
+++ b/src/tunnels/providers/cloudflare-named.ts
@@ -1,0 +1,224 @@
+import type { Unsubscribe } from '@/stream'
+
+import { createLogRing, type LogLineSubscriber, type LogRing } from '../log-ring'
+import type { TunnelConfig, TunnelProviderHandle, TunnelState } from '../types'
+
+const DEFAULT_BINARY = 'cloudflared'
+const DEFAULT_RESTART_BACKOFF_MS = [1_000, 2_000, 4_000, 10_000, 30_000]
+const DEFAULT_MAX_CONSECUTIVE_CRASHES = 10
+const DEFAULT_STOP_GRACE_MS = 5_000
+
+export type CloudflareNamedProviderOptions = {
+  config: TunnelConfig
+  onUrlChange: (url: string) => void
+  // Token resolver. Production wiring reads `process.env[config.tokenEnv]`;
+  // the resolver is parameterized so tests can inject a value without poking
+  // global env. Returning `undefined` (or empty string) at any call fails the
+  // start with a clear error pointing at the env-var name.
+  resolveToken: () => string | undefined
+  binary?: string
+  restartBackoffMs?: number[]
+  maxConsecutiveCrashes?: number
+  stopGraceMs?: number
+}
+
+export type CloudflareNamedProviderHandle = TunnelProviderHandle & {
+  tail: () => string[]
+  subscribeToLogs: (cb: LogLineSubscriber) => Unsubscribe
+}
+
+export function createCloudflareNamedProvider(options: CloudflareNamedProviderOptions): CloudflareNamedProviderHandle {
+  const { config, onUrlChange, resolveToken } = options
+  if (config.provider !== 'cloudflare-named') {
+    throw new Error(`createCloudflareNamedProvider: provider must be 'cloudflare-named', got '${config.provider}'`)
+  }
+  const hostname = config.hostname
+  if (hostname === undefined || hostname.trim() === '') {
+    throw new Error(`tunnel '${config.name}' (cloudflare-named): hostname is required`)
+  }
+  const tokenEnv = config.tokenEnv
+  if (tokenEnv === undefined || tokenEnv.trim() === '') {
+    throw new Error(`tunnel '${config.name}' (cloudflare-named): tokenEnv is required`)
+  }
+
+  const binary = options.binary ?? DEFAULT_BINARY
+  const restartBackoffMs = options.restartBackoffMs ?? DEFAULT_RESTART_BACKOFF_MS
+  const maxConsecutiveCrashes = options.maxConsecutiveCrashes ?? DEFAULT_MAX_CONSECUTIVE_CRASHES
+  const stopGraceMs = options.stopGraceMs ?? DEFAULT_STOP_GRACE_MS
+  const logs = createLogRing()
+  const state: TunnelState = {
+    name: config.name,
+    provider: 'cloudflare-named',
+    for: config.for,
+    url: null,
+    status: 'stopped',
+    lastUrlAt: null,
+    detail: '',
+  }
+
+  let started = false
+  let stopping = false
+  let proc: ReturnType<typeof Bun.spawn> | null = null
+  let retryTimer: ReturnType<typeof setTimeout> | null = null
+  let consecutiveCrashes = 0
+
+  async function launch(): Promise<void> {
+    if (!started || stopping) return
+
+    const token = resolveToken()
+    if (token === undefined || token.trim() === '') {
+      // Bad config rather than a transient process crash: the user-facing fix
+      // is editing `.env`, not waiting for backoff. Flip straight to
+      // permanently-failed so `tunnel status` makes the cause obvious and we
+      // don't waste retries spawning a cloudflared we know will reject the
+      // missing token.
+      state.status = 'permanently-failed'
+      state.detail = `env var ${tokenEnv} is unset or empty; set it in .env and restart`
+      return
+    }
+
+    state.status = 'starting'
+    state.detail = 'starting cloudflared'
+    const spawned = Bun.spawn([binary, 'tunnel', '--no-autoupdate', 'run', '--token', token], {
+      stdout: 'ignore',
+      stderr: 'pipe',
+    })
+    proc = spawned
+
+    // Mark healthy on the FIRST stderr line. cloudflared with a valid token
+    // prints registration progress to stderr within ~1s of start; a process
+    // that exits before printing anything is almost certainly a token/network
+    // failure. Healthy != "traffic flowing" — only Cloudflare's edge knows
+    // that — but it's the strongest signal available locally and matches the
+    // quick provider's "saw something on stderr" health model.
+    //
+    // Deliberately does NOT reset `consecutiveCrashes`. A process that prints
+    // one line of stderr then crashes is a tight crash loop (bad token,
+    // network down, cloudflared bug); the counter must trip the cap. The
+    // counter resets on operator action (`stop()` then `start()` again) or
+    // on `typeclaw restart`, not on stderr noise.
+    let sawFirstLine = false
+    void pumpStderr(spawned.stderr, logs, () => {
+      if (sawFirstLine) return
+      sawFirstLine = true
+      state.status = 'healthy'
+      state.detail = 'cloudflared started'
+    })
+
+    void spawned.exited.then((code) => {
+      if (proc !== spawned) return
+      proc = null
+      if (!started || stopping) return
+      handleExit(code)
+    })
+  }
+
+  function handleExit(code: number): void {
+    consecutiveCrashes += 1
+    if (consecutiveCrashes >= maxConsecutiveCrashes) {
+      state.status = 'permanently-failed'
+      state.detail = `cloudflared exited ${code}; retry cap reached after ${consecutiveCrashes} consecutive crashes`
+      return
+    }
+
+    state.status = 'unhealthy'
+    state.detail = `cloudflared exited ${code}; restarting`
+    const delay = restartBackoffMs[Math.min(consecutiveCrashes - 1, restartBackoffMs.length - 1)] ?? 30_000
+    retryTimer = setTimeout(() => {
+      retryTimer = null
+      void launch()
+    }, delay)
+  }
+
+  return {
+    async start(): Promise<void> {
+      if (started) return
+      started = true
+      stopping = false
+      consecutiveCrashes = 0
+      // The URL is known from config, not from cloudflared. Emit it
+      // synchronously so subscribers (channel adapters, tunnel-bridge) wire
+      // up immediately, regardless of whether cloudflared comes up healthy.
+      // For named tunnels, the URL is bound to the dashboard config — even
+      // if the local process is unhealthy, the hostname is the right value
+      // to surface in `tunnel-url-changed` events.
+      state.url = hostname
+      state.lastUrlAt = Date.now()
+      onUrlChange(hostname)
+      await launch()
+    },
+    async stop(): Promise<void> {
+      if (!started && proc === null) return
+      started = false
+      stopping = true
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer)
+        retryTimer = null
+      }
+
+      const running = proc
+      proc = null
+      if (running !== null) {
+        running.kill('SIGTERM')
+        await Promise.race([
+          running.exited,
+          sleep(stopGraceMs).then(() => {
+            running.kill('SIGKILL')
+            return running.exited
+          }),
+        ])
+      }
+
+      stopping = false
+      state.status = 'stopped'
+      state.detail = ''
+    },
+    snapshot(): TunnelState {
+      return { ...state }
+    },
+    tail(): string[] {
+      return logs.snapshot()
+    },
+    subscribeToLogs(cb: LogLineSubscriber): Unsubscribe {
+      return logs.subscribe(cb)
+    },
+  }
+}
+
+async function pumpStderr(
+  stream: ReadableStream<Uint8Array> | null,
+  logs: LogRing,
+  onLine: (line: string) => void,
+): Promise<void> {
+  if (stream === null) return
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let buffered = ''
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffered += decoder.decode(value, { stream: true })
+      let newlineIndex = buffered.indexOf('\n')
+      while (newlineIndex !== -1) {
+        const line = buffered.slice(0, newlineIndex).replace(/\r$/, '')
+        logs.append(line)
+        onLine(line)
+        buffered = buffered.slice(newlineIndex + 1)
+        newlineIndex = buffered.indexOf('\n')
+      }
+    }
+    buffered += decoder.decode()
+    if (buffered !== '') {
+      const line = buffered.replace(/\r$/, '')
+      logs.append(line)
+      onLine(line)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/tunnels/types.ts
+++ b/src/tunnels/types.ts
@@ -1,6 +1,6 @@
 import type { Unsubscribe } from '@/stream'
 
-export type TunnelProvider = 'external' | 'cloudflare-quick'
+export type TunnelProvider = 'external' | 'cloudflare-quick' | 'cloudflare-named'
 
 export type TunnelFor = { kind: 'channel'; name: string } | { kind: 'manual' }
 
@@ -10,6 +10,22 @@ export type TunnelConfig = {
   for: TunnelFor
   externalUrl?: string
   upstreamPort?: number
+  // cloudflare-named only: the public hostname configured in the Cloudflare
+  // dashboard (e.g. `https://agent.example.com`). typeclaw uses it verbatim
+  // for `tunnel-url-changed` events and CLI display; cloudflared itself
+  // learns the hostname → upstream mapping from the dashboard at runtime, so
+  // the value here must mirror what the user typed in `Public Hostname`. If
+  // the two drift, traffic stops flowing but typeclaw still reports the
+  // stale URL — there is no programmatic way to detect this without hitting
+  // Cloudflare's API, which we deliberately don't do.
+  hostname?: string
+  // cloudflare-named only: name of an env var (set in the agent's `.env`)
+  // that holds the tunnel token printed by the Cloudflare dashboard when the
+  // tunnel was created. The token itself never lives in typeclaw.json — only
+  // the env-var name does. The container reads `process.env[tokenEnv]` at
+  // tunnel start. Missing/empty values fail the start with a clear message
+  // pointing at the env var name.
+  tokenEnv?: string
 }
 
 export type TunnelStatus = 'stopped' | 'starting' | 'healthy' | 'unhealthy' | 'permanently-failed'


### PR DESCRIPTION
## What this PR does

Adds a third tunnel provider, `cloudflare-named`, that runs `cloudflared tunnel --no-autoupdate run --token <jwt>` against a remotely-managed tunnel the user created in the Cloudflare Zero Trust dashboard. Unlike `cloudflare-quick`, the public URL is **stable** — it's whatever Public Hostname the user configured in the dashboard, and it never rotates.

End-to-end coverage: schema → provider → manager → CLI `tunnel add` → CLI `channel add github` → wizard `typeclaw init`. The wizard offerings now match the documented providers; there is no provider you can configure via `tunnel add` that you can't also pick from inside the GitHub channel flow.

This replaces the `cloudflare-named` placeholder that's been sitting in `src/config/config.ts:253`, `docs/content/docs/internals/tunnels.mdx`, `docs/content/docs/reference/tunnel-providers.mdx`, and `src/config/config.test.ts` as "deferred PR 3" since the original tunnels work landed.

4 commits, +1140 / −44 across 17 files. Split for reviewability: **schema** → **provider+manager** → **CLI+docs** → **init/channel-add wiring**.

## Why now

`cloudflare-quick` rotates its URL on every container restart. typeclaw already handles rotation correctly (the channel adapter re-registers webhooks on `tunnel-url-changed`), but the user-facing friction is real for any non-webhook use case — sharing a demo URL, embedding the tunnel in another system, debugging. Users with a Cloudflare account + a domain already in Cloudflare DNS get a strictly better experience from named tunnels: stable subdomain, no re-registration, no surprises.

The token-based "remotely managed" flow ([Cloudflare docs](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/remote-management/)) is the right fit for typeclaw because it's self-contained: one JWT in `.env`, no `cert.pem` on the host, no `~/.cloudflared` mount, no breaking the "container is self-contained" invariant. cloudflared learns its config (hostname → upstream mapping) from Cloudflare at runtime; typeclaw never sees the upstream port for these tunnels.

## Shape

### typeclaw.json

```jsonc
{
  "tunnels": [
    {
      "name": "github-webhook",
      "provider": "cloudflare-named",
      "for": { "kind": "channel", "name": "github" },
      "hostname": "https://agent.example.com",
      "tokenEnv": "CLOUDFLARE_TUNNEL_TOKEN"
    }
  ]
}
```

- `hostname` (required, must be `https://`) — what the user typed into the dashboard's Public Hostname tab. typeclaw uses it verbatim for `tunnel-url-changed` events and CLI display.
- `tokenEnv` (required, must match `/^[A-Z_][A-Z0-9_]*$/`) — the **name** of an env var the agent's `.env` sets to the token. Never the token itself. The regex shape backs that invariant.
- `upstreamPort` is **forbidden** on named tunnels — cloudflared reads the upstream from the dashboard, and silently ignoring the field would hide drift.

### Behavior differences from `cloudflare-quick`

| Aspect | `cloudflare-quick` | `cloudflare-named` |
|---|---|---|
| URL source | parsed from cloudflared stderr at runtime | static, from `hostname` in config |
| URL emit timing | async, after stderr line arrives | synchronous, at `start()` |
| URL stability | rotates every cloudflared restart | as stable as the dashboard hostname |
| Subprocess args | `cloudflared tunnel --url http://127.0.0.1:<port> --no-autoupdate --metrics 127.0.0.1:0` | `cloudflared tunnel --no-autoupdate run --token <jwt>` |
| Failure-cap semantics | "consecutive failures without ever emitting URL" | "consecutive crashes" (no reset on stderr) |
| Missing config | n/a (no config to be missing) | `permanently-failed` without spawning cloudflared |
| Eager GitHub webhook register | deferred to adapter's first start (URL not yet known) | runs at `init` / `channel add` time (URL is `hostname`) |

### Failure modes

1. **`tokenEnv` is unset or empty in `.env`** — provider transitions straight to `permanently-failed` without ever spawning cloudflared. The detail string names the missing env var. This is a config error, not a transient process crash, so the fix is editing `.env` and `typeclaw restart` — wasting retry budget on it is wrong.
2. **Tunnel exists but Public Hostname tab is empty in the dashboard** — cloudflared registers fine, status reports `healthy`, but Cloudflare returns 530/1033 to any request. typeclaw cannot detect this; documented in skill + reference docs.
3. **Dashboard hostname drifts from `tunnels[].hostname`** — traffic stops flowing, typeclaw keeps reporting the stale URL. No programmatic detection; deliberately not polling Cloudflare's API. Documented as a known footgun.
4. **cloudflared crashes 10 times in a row** — flips to `permanently-failed`. `consecutiveCrashes` is **deliberately not reset by stderr** (a process that prints one line of registration progress then crashes is still a tight crash loop); the counter resets only on operator action (`stop()` + `start()` or `typeclaw restart`).

## Commits (read in order)

| # | Commit | Files | Why standalone |
|---|---|---|---|
| 1 | `tunnels: add cloudflare-named to provider schema with hostname + tokenEnv` | `src/tunnels/types.ts`, `src/config/config.ts`, `src/config/config.test.ts`, `src/shared/protocol.ts` | Pure schema/type widening. Replaces the "rejects cloudflare-named" assertion in config.test.ts with positive coverage of the new shape + each refinement. No runtime delta. |
| 2 | `tunnels: implement cloudflare-named provider with token-based cloudflared` | `src/tunnels/providers/cloudflare-named.{ts,test.ts}`, `src/tunnels/manager.ts`, `src/tunnels/index.ts` | The provider, its tests (10 tests covering URL sync emit, missing token, crash restart, cap, SIGTERM/SIGKILL, log subscription, construction validation), and the manager-switch case. Token resolver is parameterized (`resolveEnv` defaults to `(name) => process.env[name]`) so tests don't poke global env. |
| 3 | `tunnels: wire cloudflare-named into ` + "`typeclaw tunnel add`" + ` and docs` | `src/cli/tunnel.{ts,test.ts}`, `src/skills/typeclaw-tunnels/SKILL.md`, `docs/content/docs/internals/tunnels.mdx`, `docs/content/docs/reference/tunnel-providers.mdx` | CLI add-flow, CLI tests (4 new), skill guidance for the two named-tunnel-specific troubleshooting paths, and internals + reference docs (drops the "deferred PR 3" placeholders). |
| 4 | `init: offer cloudflare-named in ` + "`typeclaw init`" + ` and ` + "`channel add github`" | `src/init/index.ts`, `src/init/add-channel.test.ts`, `src/cli/init.ts`, `src/cli/channel.ts` | Widens `GithubTunnelProvider`, threads `hostname` + `tokenEnv` through `GithubInitCredentials` + `AddChannelOptions.github` + `mergeGithubTunnelConfig`, teaches `maybeInstallGithubWebhooks` that named tunnels know their URL up front (eager registration), and adds the third option to both wizards (init's `runGithubFlow` and channel-add's `promptGithubCredentials`). 4 new tests in `add-channel.test.ts`. |

Each commit's tests pass at HEAD-of-that-commit. `git bisect` works.

## init/channel-add UX

`typeclaw init` and `typeclaw channel add github` both now offer:

```
Tunnel provider
  ❯ Cloudflare Quick Tunnel — no signup, URL rotates on restart (recommended)
    Cloudflare Named Tunnel — stable URL, needs Cloudflare account + domain
    External URL — I have my own reverse proxy / tunnel
    None — configure later by hand-editing typeclaw.json
```

Picking Cloudflare Named drops to a sub-prompt with a `note` block summarizing the dashboard steps (create tunnel → Public Hostname → put token in `.env`), then asks for the hostname and the env-var name. Same env-var-name regex from `typeclaw tunnel add` rejects lowercase / non-identifier values inline.

**Eager webhook registration**: for `cloudflare-named` the public URL is known at init/channel-add time (it's `hostname`), so typeclaw registers the webhook on GitHub's side immediately, with the same `/typeclaw/v1/github/<agentId>` managed-path suffix `cloudflare-quick` hooks get after their first URL resolution. No more "I added the channel, why isn't GitHub delivering events?" on first start. `cloudflare-quick` still defers because its URL doesn't exist until cloudflared boots inside the container.

## Design notes worth flagging

**Why a "first stderr line → healthy" trigger instead of waiting for sustained uptime.** Matches `cloudflare-quick`'s health model exactly. Sustained-uptime detection (e.g. "alive for 5s") would be more accurate but adds a stopwatch + a "tentative" state to the state machine. For v1, stderr-line is the strongest local signal that cloudflared got past argv parsing and into its main loop. The crash-counter doesn't reset on stderr, so a process that prints one line and dies still trips the cap — the test fixture exercises exactly this path.

**Why not emit a `kind: 'config-error'` payload when `tokenEnv` is missing.** Considered. The stream payload kinds are a contract surface; adding one for a single failure mode that's already discoverable via `tunnel status` doesn't pay rent. The detail string names the env var, the CLI surfaces it on `typeclaw tunnel status <name>`, and `typeclaw doctor` (out of scope here) is the natural place for a check that crosses `.env` + `typeclaw.json`.

**Why `tokenEnv` (name-of-env-var) and not `token` (the value itself).** Two reasons: (1) typeclaw.json is gittracked and force-committed by the agent; the token must never live there. (2) The existing secret-delivery path is `.env` → `--env-file` → `process.env` inside the container — same as `FIREWORKS_API_KEY`, `OPENAI_API_KEY`, etc. No new mechanism. The regex shape on `tokenEnv` defends against an end-run where someone types the token into `tokenEnv` by mistake — the schema rejects anything that isn't a valid env-var identifier.

**Why `hostname` and not `url`.** Matches the Cloudflare dashboard's "Public Hostname" terminology. Less ambiguous than `url` next to `externalUrl` on the same enum.

**Why `maybeInstallGithubWebhooks` got the "named tunnel knows its URL up front" branch rather than a deferred-registration path.** The eager-vs-deferred split is already there for `external` (eager) vs `cloudflare-quick` (deferred). Named tunnels have the same URL-knowability property as external — the user gives us the hostname before any container exists — so they fit the eager path cleanly. The alternative (registering on the adapter's first start) would force a second code path through the channel-bridge for a case where typeclaw already knows the answer. The decision boundary is "do we have a public URL at init time?", which named tunnels satisfy.

## Verification

```
bun run typecheck     ✓
bun run lint          ✓  (61 pre-existing warnings, 0 errors, 0 on changed files)
bun run format:check  ✓
bun run test          5440 pass / 0 fail / 11952 expect() calls (+26 net new tests)
```

New test counts: 14 in `cloudflare-named.test.ts`, 4 in `cli/tunnel.test.ts`, 7 in `config/config.test.ts` (positive coverage replacing the one-line negative), 4 in `init/add-channel.test.ts`.

Mutation check on the load-bearing properties:

- Removed the `if (consecutiveCrashes >= maxConsecutiveCrashes)` guard → `stops retrying after the consecutive-crash cap is reached` failed.
- Made the URL emit happen inside `launch()` after `Bun.spawn` instead of inside `start()` before it → `emits the configured hostname synchronously at start` failed.
- Removed the `upstreamPort` rejection refine → `rejects named tunnel with upstreamPort set` failed.
- Resurrected the `consecutiveCrashes = 0` reset inside the stderr handler → `stops retrying after the consecutive-crash cap is reached` failed.
- Returned the bare hostname from `resolveEagerWebhookUrl` for the quick provider too → `cloudflare-quick does NOT eagerly register webhooks` failed.

## Compatibility

- **Schema migration**: none. `tunnels[]` already exists; this widens the provider enum and adds two optional fields. Configs without `cloudflare-named` tunnels are unchanged.
- **Wire protocol**: `TunnelSnapshot.provider` union widens to include `'cloudflare-named'`. Backward-compatible — old TUIs receive the new value as a string they don't recognize; the `formatTunnelList` / `formatTunnelStatus` helpers print it as-is.
- **`AddChannelOptions.github`**: gains `hostname?` + `tokenEnv?`. Both optional; existing callers passing `tunnelProvider: 'cloudflare-quick' | 'external' | 'none'` keep working without touching the new fields.
- **Dockerfile**: `docker.file.cloudflared` already defaults to `true` and the `tunnel add` / `channel add` flows flip it explicitly on either Cloudflare provider, so no Dockerfile-template change. The cloudflared layer that `cloudflare-quick` already needs is the same one `cloudflare-named` uses.
- **Rollback**: revert all four commits. No on-disk state, no migration to undo. Any `cloudflare-named` tunnel entries in the wild would start failing schema validation on the next `typeclaw start` — same fail-fast behavior the schema gives for any unknown provider today.

## Out of scope

- `typeclaw doctor` check that pings the configured hostname to detect "tunnel up, no Public Hostname" 530/1033. Mentioned in the skill doc as a manual diagnostic.
- Auto-discovering the configured hostname from Cloudflare's API to detect dashboard/config drift. Would require either decoding the JWT or calling `GET /accounts/{id}/cfd_tunnel/{id}/configurations`. Deliberately not done — adds network dependency + auth surface at start time.
- `typeclaw tunnel upgrade` for migrating an existing `cloudflare-quick` to `cloudflare-named` in place. Internals doc previously referenced this; not in this PR. A user does it today by `typeclaw tunnel remove` + `tunnel add`, or `typeclaw channel remove github` + `channel add github`.
