### PR TITLE
tunnels: make `name` optional on `tunnel add` and `tunnel set`

### DIFF
--- a/src/cli/tunnel.test.ts
+++ b/src/cli/tunnel.test.ts
@@ -131,6 +131,84 @@ describe('tunnel add/remove config flows', () => {
     expect(result.reason).toMatch(/env var name/)
   })
 
+  test('interactive add prompts for the name when omitted and writes the new tunnel', async () => {
+    const cwd = await makeAgentDir({
+      tunnels: [
+        {
+          name: 'existing',
+          provider: 'external',
+          for: { kind: 'manual' },
+          upstreamPort: 5173,
+          externalUrl: 'https://demo.example.com',
+        },
+      ],
+    })
+    const prompts = sequencedPrompts(['fresh', '5174'])
+
+    const result = await tunnel.runTunnelAddFlow(
+      cwd,
+      {},
+      {
+        selectProvider: async () => 'cloudflare-quick',
+        selectOwner: async () => 'manual',
+        text: prompts.text,
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error(result.reason)
+    expect(result.value.name).toBe('fresh')
+    const config = await readConfig(cwd)
+    expect(config.tunnels.map((entry: { name: string }) => entry.name)).toEqual(['existing', 'fresh'])
+  })
+
+  test('add rejects a duplicate name surfaced through the interactive prompt', async () => {
+    const cwd = await makeAgentDir({
+      tunnels: [
+        {
+          name: 'existing',
+          provider: 'external',
+          for: { kind: 'manual' },
+          upstreamPort: 5173,
+          externalUrl: 'https://demo.example.com',
+        },
+      ],
+    })
+    const prompts = sequencedPrompts(['existing'])
+
+    const result = await tunnel.runTunnelAddFlow(
+      cwd,
+      {},
+      {
+        selectProvider: async () => 'cloudflare-quick',
+        selectOwner: async () => 'manual',
+        text: prompts.text,
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/already exists/)
+  })
+
+  test('non-interactive add rejects a name that violates the schema regex', async () => {
+    const cwd = await makeAgentDir({})
+
+    const result = await tunnel.runTunnelAddFlow(cwd, {
+      name: 'Bad Name',
+      provider: 'external',
+      forManual: true,
+      upstreamPort: '5173',
+      externalUrl: 'https://demo.example.com',
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/lowercase, digits/)
+    const config = await readConfig(cwd)
+    expect(config.tunnels ?? []).toEqual([])
+  })
+
   test('non-interactive add writes an external manual tunnel', async () => {
     const cwd = await makeAgentDir({})
 
@@ -396,6 +474,87 @@ describe('tunnel set config flow', () => {
     expect(result.ok).toBe(true)
     if (!result.ok) throw new Error(result.reason)
     expect(result.value.externalUrl).toBe('https://new.example.com')
+  })
+
+  test('interactive set with no name auto-picks the only configured tunnel', async () => {
+    const cwd = await makeAgentDir({
+      tunnels: [
+        {
+          name: 'manual-demo',
+          provider: 'external',
+          for: { kind: 'manual' },
+          upstreamPort: 5173,
+          externalUrl: 'https://old.example.com',
+        },
+      ],
+    })
+
+    const result = await tunnel.runTunnelSetFlow(
+      cwd,
+      {},
+      {
+        selectProvider: async () => 'external',
+        selectOwner: async () => 'manual',
+        selectSetField: async () => 'externalUrl',
+        text: async () => 'https://new.example.com',
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error(result.reason)
+    expect(result.value.name).toBe('manual-demo')
+    expect(result.value.externalUrl).toBe('https://new.example.com')
+  })
+
+  test('interactive set with no name picks from multiple configured tunnels', async () => {
+    const cwd = await makeAgentDir({
+      tunnels: [
+        {
+          name: 'first',
+          provider: 'external',
+          for: { kind: 'manual' },
+          upstreamPort: 5173,
+          externalUrl: 'https://first.example.com',
+        },
+        {
+          name: 'second',
+          provider: 'external',
+          for: { kind: 'manual' },
+          upstreamPort: 5174,
+          externalUrl: 'https://second-old.example.com',
+        },
+      ],
+    })
+
+    const result = await tunnel.runTunnelSetFlow(
+      cwd,
+      {},
+      {
+        selectProvider: async () => 'external',
+        selectOwner: async () => 'manual',
+        selectSetField: async () => 'externalUrl',
+        selectExistingTunnel: async () => 'second',
+        text: async () => 'https://second-new.example.com',
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error(result.reason)
+    expect(result.value.name).toBe('second')
+    expect(result.value.externalUrl).toBe('https://second-new.example.com')
+    const config = await readConfig(cwd)
+    expect(config.tunnels[0].externalUrl).toBe('https://first.example.com')
+    expect(config.tunnels[1].externalUrl).toBe('https://second-new.example.com')
+  })
+
+  test('set refuses cleanly with no name when there are zero tunnels', async () => {
+    const cwd = await makeAgentDir({})
+
+    const result = await tunnel.runTunnelSetFlow(cwd, {})
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toMatch(/no tunnels configured/)
   })
 
   test('set refuses cleanly when typeclaw.json is schema-invalid', async () => {

--- a/src/cli/tunnel.ts
+++ b/src/cli/tunnel.ts
@@ -13,7 +13,7 @@ import type { TunnelConfig, TunnelFor, TunnelProvider } from '@/tunnels'
 import { c, errorLine } from './ui'
 
 type AddArgs = {
-  name: string
+  name?: string
   provider?: string
   forChannel?: string
   forManual?: boolean
@@ -24,7 +24,7 @@ type AddArgs = {
 }
 
 type SetArgs = {
-  name: string
+  name?: string
   provider?: string
   upstreamPort?: string
   externalUrl?: string
@@ -51,6 +51,12 @@ export type TunnelPrompts = {
   selectSetField?: (
     choices: readonly { value: TunnelSetField; label: string; hint?: string }[],
   ) => Promise<TunnelSetField | symbol>
+  // Only `runTunnelSetFlow` uses this when the positional `name` is omitted
+  // and more than one tunnel is configured. Optional so existing callers
+  // (especially `runTunnelAddFlow` tests) don't have to stub it.
+  selectExistingTunnel?: (
+    choices: readonly { value: string; label: string; hint?: string }[],
+  ) => Promise<string | symbol>
   text: (message: string, validate?: TextValidator) => Promise<string | symbol>
 }
 
@@ -87,6 +93,15 @@ const defaultPrompts: TunnelPrompts = {
         ...(choice.hint !== undefined ? { hint: choice.hint } : {}),
       })),
     }),
+  selectExistingTunnel: (choices) =>
+    select<string>({
+      message: 'Pick a tunnel to edit',
+      options: choices.map((choice) => ({
+        value: choice.value,
+        label: choice.label,
+        ...(choice.hint !== undefined ? { hint: choice.hint } : {}),
+      })),
+    }),
   text: (message, validate) =>
     text({ message, ...(validate !== undefined ? { validate: (v) => validate(v ?? '') } : {}) }),
 }
@@ -94,7 +109,7 @@ const defaultPrompts: TunnelPrompts = {
 const addSub = defineCommand({
   meta: { name: 'add', description: 'add a public tunnel entry to typeclaw.json' },
   args: {
-    name: { type: 'positional', required: true, description: 'tunnel name' },
+    name: { type: 'positional', required: false, description: 'tunnel name (omit to prompt interactively)' },
     provider: { type: 'string', description: 'external | cloudflare-quick | cloudflare-named' },
     'for-channel': { type: 'string', description: 'own this tunnel from a channel adapter' },
     'for-manual': { type: 'boolean', description: 'create a manually-owned tunnel' },
@@ -108,7 +123,7 @@ const addSub = defineCommand({
   },
   async run({ args }) {
     const result = await runTunnelAddFlow(ensureAgentDir(), {
-      name: String(args.name),
+      ...(args.name !== undefined ? { name: String(args.name) } : {}),
       ...(args.provider !== undefined ? { provider: String(args.provider) } : {}),
       ...(args['for-channel'] !== undefined ? { forChannel: String(args['for-channel']) } : {}),
       ...(args['for-manual'] === true ? { forManual: true } : {}),
@@ -175,7 +190,7 @@ const setSub = defineCommand({
     description: 'edit an existing tunnel entry in typeclaw.json (symmetric with `typeclaw channel set`)',
   },
   args: {
-    name: { type: 'positional', required: true, description: 'tunnel name' },
+    name: { type: 'positional', required: false, description: 'tunnel name (omit to pick interactively)' },
     provider: { type: 'string', description: 'external | cloudflare-quick | cloudflare-named' },
     'upstream-port': { type: 'string', description: 'container-local upstream port (manual non-named tunnels)' },
     'external-url': { type: 'string', description: 'https URL for provider=external' },
@@ -187,7 +202,7 @@ const setSub = defineCommand({
   },
   async run({ args }) {
     const result = await runTunnelSetFlow(ensureAgentDir(), {
-      name: String(args.name),
+      ...(args.name !== undefined ? { name: String(args.name) } : {}),
       ...(args.provider !== undefined ? { provider: String(args.provider) } : {}),
       ...(args['upstream-port'] !== undefined ? { upstreamPort: String(args['upstream-port']) } : {}),
       ...(args['external-url'] !== undefined ? { externalUrl: String(args['external-url']) } : {}),
@@ -260,8 +275,10 @@ export async function runTunnelAddFlow(
   const validation = validateConfig(cwd)
   if (!validation.ok) return { ok: false, reason: validation.reason }
   const config = loadConfigSync(cwd)
-  if (config.tunnels.some((entry) => entry.name === args.name))
-    return { ok: false, reason: `tunnel "${args.name}" already exists` }
+  const existingNames = new Set(config.tunnels.map((entry) => entry.name))
+  const name = args.name ?? (await promptText('Tunnel name', prompts, makeTunnelNameValidator(existingNames)))
+  const nameError = validateTunnelName(name, existingNames)
+  if (nameError !== undefined) return { ok: false, reason: nameError }
 
   const provider = await resolveProvider(args.provider, prompts)
   const tunnelFor = await resolveFor(args, prompts)
@@ -296,7 +313,7 @@ export async function runTunnelAddFlow(
   }
 
   const tunnel: TunnelConfig = {
-    name: args.name,
+    name,
     provider,
     for: tunnelFor,
     ...(externalUrl !== undefined ? { externalUrl } : {}),
@@ -342,8 +359,16 @@ export async function runTunnelSetFlow(
   const validation = validateConfig(cwd)
   if (!validation.ok) return { ok: false, reason: validation.reason }
   const config = loadConfigSync(cwd)
-  const existing = config.tunnels.find((entry) => entry.name === args.name)
-  if (existing === undefined) return { ok: false, reason: `unknown tunnel: ${args.name}` }
+  if (config.tunnels.length === 0) {
+    return { ok: false, reason: 'no tunnels configured. Run `typeclaw tunnel add` first.' }
+  }
+  const nameResult =
+    args.name !== undefined
+      ? { ok: true as const, value: args.name }
+      : await resolveExistingTunnelName(config.tunnels, prompts)
+  if (!nameResult.ok) return nameResult
+  const existing = config.tunnels.find((entry) => entry.name === nameResult.value)
+  if (existing === undefined) return { ok: false, reason: `unknown tunnel: ${nameResult.value}` }
 
   const flagFields = collectSetFlagFields(args)
   const interactive = flagFields.length === 0
@@ -360,7 +385,10 @@ export async function runTunnelSetFlow(
   } else if (interactive) {
     const choices = buildSetFieldChoices(existing)
     if (choices.length === 0) {
-      return { ok: false, reason: `tunnel "${args.name}" has no editable fields for provider "${existing.provider}"` }
+      return {
+        ok: false,
+        reason: `tunnel "${existing.name}" has no editable fields for provider "${existing.provider}"`,
+      }
     }
     if (prompts.selectSetField === undefined) {
       return { ok: false, reason: 'interactive set requires selectSetField prompt (pass a flag, e.g. --provider)' }
@@ -704,6 +732,30 @@ function parseLiveArgs(args: LiveArgs): { url?: string; timeoutMs: number } {
   return { ...(args.url !== undefined ? { url: args.url } : {}), timeoutMs }
 }
 
+async function resolveExistingTunnelName(
+  tunnels: readonly TunnelConfig[],
+  prompts: TunnelPrompts,
+): Promise<LiveResult<string>> {
+  if (tunnels.length === 1) return { ok: true, value: tunnels[0]!.name }
+  if (prompts.selectExistingTunnel === undefined) {
+    return {
+      ok: false,
+      reason: 'interactive set requires selectExistingTunnel prompt (pass the tunnel name positionally)',
+    }
+  }
+  const choices = tunnels.map((entry) => ({
+    value: entry.name,
+    label: entry.name,
+    hint: `${entry.provider} · ${entry.for.kind === 'channel' ? `channel:${entry.for.name}` : 'manual'}`,
+  }))
+  const choice = await prompts.selectExistingTunnel(choices)
+  if (isCancel(choice)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return { ok: true, value: choice }
+}
+
 async function resolveProvider(input: string | undefined, prompts: TunnelPrompts): Promise<TunnelProvider> {
   if (input === 'external' || input === 'cloudflare-quick' || input === 'cloudflare-named') return input
   if (input !== undefined) throw new Error(`unknown tunnel provider: ${input}`)
@@ -743,6 +795,24 @@ async function promptText(message: string, prompts: TunnelPrompts, validate?: Te
 
 function validateNonEmpty(requiredMessage: string): TextValidator {
   return (value) => (value.trim().length > 0 ? undefined : requiredMessage)
+}
+
+// Mirrors the regex on `tunnelEntrySchema.name` in src/config/config.ts so
+// the interactive prompt rejects shapes the post-write schema validation
+// would reject anyway, but with a clear inline error instead of a Zod dump.
+const TUNNEL_NAME_REGEX = /^[a-z0-9][a-z0-9-_]*$/
+
+function validateTunnelName(value: string, existing: ReadonlySet<string>): string | undefined {
+  if (value.trim().length === 0) return 'Tunnel name is required'
+  if (!TUNNEL_NAME_REGEX.test(value)) {
+    return 'Tunnel name must match /^[a-z0-9][a-z0-9-_]*$/ (lowercase, digits, dashes, underscores)'
+  }
+  if (existing.has(value)) return `tunnel "${value}" already exists`
+  return undefined
+}
+
+function makeTunnelNameValidator(existing: ReadonlySet<string>): TextValidator {
+  return (value) => validateTunnelName(value, existing)
 }
 
 function validateUpstreamPort(value: string): string | undefined {


### PR DESCRIPTION
## What this PR does

Makes `name` optional on `typeclaw tunnel add` and `typeclaw tunnel set` so they are symmetric with `typeclaw channel add` and `typeclaw channel set`, which already accept the adapter positional as optional and fall back to a clack prompt.

Before this PR you had to know the tunnel name up front even though `tunnel set` already drops into an interactive field picker (PR #384) once the name resolves, and `tunnel add` already prompts for provider, owner, port, etc.:

```
$ typeclaw tunnel add
USAGE typeclaw tunnel add [OPTIONS] NAME
Missing required positional argument: NAME

$ typeclaw tunnel set
USAGE typeclaw tunnel set [OPTIONS] NAME
Missing required positional argument: NAME
```

This is a direct follow-up to PR #383 (cloudflare-named provider) and PR #384 (`tunnel set` subcommand).

1 commit, +241 / −12 across 2 files.

## Changes

### `tunnel add` with no name

Prompts via `promptText('Tunnel name', ...)` with a validator that:

- enforces the same `/^[a-z0-9][a-z0-9-_]*$/` regex as `tunnelEntrySchema.name` (`src/config/config.ts:276`)
- rejects duplicates inline instead of letting the post-write `loadConfigSync` throw on disk

The regex is duplicated with a load-bearing comment pointing at the schema, so a maintainer who tightens the schema regex sees the prompt validator that needs to stay in sync.

### `tunnel set` with no name

- **0 tunnels** → clean error pointing at `typeclaw tunnel add`
- **1 tunnel** → auto-pick, mirroring `channel set`'s single-adapter shortcut (`src/cli/channel.ts:418`)
- **2+ tunnels** → `selectExistingTunnel` clack select with name, provider, and owner hints (e.g. `cloudflare-quick · channel:github`), then the existing field-picker flow from PR #384 runs as before

### `TunnelPrompts.selectExistingTunnel`

New optional field on `TunnelPrompts`, same pattern PR #384 used for `selectSetField`. Existing `runTunnelAddFlow` test stubs require no updates.

## Files

| File | Change |
|---|---|
| `src/cli/tunnel.ts` | +82 / −12 — `AddArgs.name` / `SetArgs.name` become optional; `addSub` / `setSub` positionals become `required: false`; `runTunnelAddFlow` prompts for name when omitted; `runTunnelSetFlow` calls new `resolveExistingTunnelName` helper; new `TUNNEL_NAME_REGEX`, `validateTunnelName`, `makeTunnelNameValidator` helpers; new optional `selectExistingTunnel` on `TunnelPrompts` with default impl |
| `src/cli/tunnel.test.ts` | +159 / 0 — 6 new tests |

## Design notes

**Why validate the name regex up front in `tunnel add`.** Before this PR, a non-conforming name on non-interactive `tunnel add` would write the entry to `typeclaw.json` and then throw out of `loadConfigSync` on the post-write read, leaving a half-baked file on disk. Catching the regex at the validator layer means the on-disk file is never touched on a bad name — same fail-closed semantics PR #384 documented for `tunnel set`'s post-write rollback.

**Why the prompt-side validator and the inline `validateTunnelName` call both run.** Clack's `text()` re-prompts when the validator returns a string, but test stubs bypass that loop and return the next sequenced answer directly. The explicit `validateTunnelName(name, existingNames)` call after `promptText` returns makes the duplicate-rejection test pass without needing to model clack's re-prompt loop in the test double. Same defense-in-depth `runTunnelAddFlow` already uses for non-interactive `--external-url`.

**Why 1-tunnel auto-pick.** Matches `channel set` exactly (`src/cli/channel.ts:418`). A single-item clack select adds friction for zero information — symmetric UX over clever consistency.

**`tunnel remove` not changed.** Asked the user; deferred to a follow-up if desired.

## Tests

6 new tests in `src/cli/tunnel.test.ts`:

**`tunnel add/remove config flows`**
- `interactive add prompts for the name when omitted and writes the new tunnel` — `sequencedPrompts(['fresh', '5174'])`, asserts the new entry is appended to an existing tunnel list
- `add rejects a duplicate name surfaced through the interactive prompt` — `sequencedPrompts(['existing'])`, asserts `result.ok === false` and `/already exists/`
- `non-interactive add rejects a name that violates the schema regex` — `name: 'Bad Name'`, asserts `/lowercase, digits/` and on-disk `tunnels` array stays empty

**`tunnel set config flow`**
- `interactive set with no name auto-picks the only configured tunnel` — single-tunnel agent dir, no `selectExistingTunnel` stub; auto-pick fires
- `interactive set with no name picks from multiple configured tunnels` — two-tunnel agent dir, `selectExistingTunnel: async () => 'second'`, asserts only the picked tunnel's URL is rewritten
- `set refuses cleanly with no name when there are zero tunnels` — empty agent dir, asserts `/no tunnels configured/`

## Verification

```
bun run typecheck     ✓
bun run lint          ✓  (61 pre-existing warnings, 0 errors, 0 on changed files)
bun run format:check  ✓
bun run test          5452 pass / 1 fail / 11993 expect() calls (+6 net new tests)
```

The 1 failing test (`scripts/generate-schema.test.ts` — `typeclaw.schema.json` drift guard) is pre-existing on `main` at HEAD. Verified by stashing these changes and re-running — identical failure. Unrelated to this PR.

## Compatibility

- **CLI surface**: additive. Positional `name` on `tunnel add` / `tunnel set` becomes optional. All existing invocations with a name positional continue working unchanged.
- **`AddArgs` / `SetArgs` types**: `name` becomes `string | undefined`. Existing callers passing `name` are unaffected.
- **`TunnelPrompts` type**: gains optional `selectExistingTunnel`. Existing callers require no update.
- **Schema**: unchanged. No `typeclaw.json` migration.
- **Rollback**: revert this one commit. No on-disk state.

## Out of scope

- Symmetric `tunnel remove` interactive picker (asked the user; deferred)
- `tunnel rename`
- `channel add` / `channel set` — already symmetric