### PR TITLE
channels: let `channel set github` switch auth between PAT and App

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -518,14 +518,14 @@ async function runSetGithub(cwd: string): Promise<void> {
   }
   const authLabel =
     authType === 'pat'
-      ? 'Personal access token (PAT) — the authentication credential (recommended)'
-      : 'GitHub App private key — the authentication credential (recommended)'
+      ? 'Auth credential — rotate the PAT, or switch to GitHub App auth (recommended)'
+      : 'Auth credential — rotate the App private key, or switch to PAT auth (recommended)'
   const choice = await select<GithubSetChoice>({
-    message: 'Which GitHub secret do you want to rotate?',
+    message: 'Which GitHub secret do you want to update?',
     options: [
       { value: 'auth', label: authLabel },
       { value: 'webhook', label: 'Webhook secret — shared secret for verifying GitHub payloads' },
-      { value: 'both', label: 'Both secrets — rotate the auth credential and the webhook secret' },
+      { value: 'both', label: 'Both secrets — update the auth credential and the webhook secret' },
     ],
     initialValue: 'auth',
   })
@@ -537,36 +537,7 @@ async function runSetGithub(cwd: string): Promise<void> {
   const patch: GithubCredentialPatch = {}
 
   if (choice === 'auth' || choice === 'both') {
-    if (authType === 'pat') {
-      note(
-        [
-          'Rotate at https://github.com/settings/personal-access-tokens.',
-          'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used),',
-          'Metadata read, and Webhooks read/write.',
-        ].join('\n'),
-        'Rotate the GitHub PAT',
-      )
-      const { pat } = await promptGithubPatAuth()
-      patch.auth = { type: 'pat', pat }
-    } else {
-      note(
-        [
-          'Rotate at https://github.com/settings/apps/<your-app> → Private keys → Generate a private key.',
-          'GitHub immediately downloads the new .pem. The previous key keeps working until you delete it,',
-          'so it is safe to rotate without downtime.',
-        ].join('\n'),
-        'Rotate the GitHub App private key',
-      )
-      const privateKeyInput = await text({
-        message: 'New GitHub App private key PEM, escaped PEM, or path to .pem file',
-        validate: (value) => (value && value.length > 0 ? undefined : 'Private key is required'),
-      })
-      if (isCancel(privateKeyInput)) {
-        cancel('Aborted.')
-        process.exit(0)
-      }
-      patch.auth = { type: 'app', privateKey: await resolvePrivateKeyInput(privateKeyInput) }
-    }
+    patch.auth = await promptGithubAuthUpdate(authType)
   }
 
   if (choice === 'webhook' || choice === 'both') {
@@ -776,6 +747,88 @@ async function promptCloudflareNamedTunnel(): Promise<{ hostname: string; tokenE
     process.exit(0)
   }
   return { hostname, tokenEnv }
+}
+
+type GithubAuthUpdateAction = 'rotate' | 'switch'
+
+async function promptGithubAuthUpdate(currentType: 'pat' | 'app'): Promise<GithubCredentialPatch['auth']> {
+  const rotateLabel =
+    currentType === 'pat'
+      ? 'Rotate the PAT (replace the current personal access token)'
+      : 'Rotate the App private key (replace the current GitHub App private key)'
+  const switchLabel =
+    currentType === 'pat'
+      ? 'Switch to GitHub App auth (replace the PAT with App credentials)'
+      : 'Switch to PAT auth (replace the App credentials with a personal access token)'
+  const action = await select<GithubAuthUpdateAction>({
+    message: 'Update the GitHub auth credential',
+    options: [
+      { value: 'rotate', label: rotateLabel },
+      { value: 'switch', label: switchLabel },
+    ],
+    initialValue: 'rotate',
+  })
+  if (isCancel(action)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+
+  const nextType: 'pat' | 'app' = action === 'rotate' ? currentType : currentType === 'pat' ? 'app' : 'pat'
+
+  if (nextType === 'pat') {
+    if (action === 'rotate') {
+      note(
+        [
+          'Rotate at https://github.com/settings/personal-access-tokens.',
+          'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used),',
+          'Metadata read, and Webhooks read/write.',
+        ].join('\n'),
+        'Rotate the GitHub PAT',
+      )
+    } else {
+      note(
+        [
+          'Create a fine-grained PAT at https://github.com/settings/personal-access-tokens.',
+          'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used),',
+          'Metadata read, and Webhooks read/write.',
+        ].join('\n'),
+        'Switch to GitHub PAT auth',
+      )
+    }
+    return await promptGithubPatAuth()
+  }
+
+  if (action === 'rotate') {
+    note(
+      [
+        'Rotate at https://github.com/settings/apps/<your-app> → Private keys → Generate a private key.',
+        'GitHub immediately downloads the new .pem. The previous key keeps working until you delete it,',
+        'so it is safe to rotate without downtime.',
+      ].join('\n'),
+      'Rotate the GitHub App private key',
+    )
+    const privateKeyInput = await text({
+      message: 'New GitHub App private key PEM, escaped PEM, or path to .pem file',
+      validate: (value) => (value && value.length > 0 ? undefined : 'Private key is required'),
+    })
+    if (isCancel(privateKeyInput)) {
+      cancel('Aborted.')
+      process.exit(0)
+    }
+    return { type: 'app', privateKey: await resolvePrivateKeyInput(privateKeyInput) }
+  }
+
+  note(
+    [
+      'Create a GitHub App at https://github.com/settings/apps/new and install it on your repositories.',
+      'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used),',
+      'Metadata read, and Webhooks read/write.',
+      'Then collect the App ID, generate a private key (.pem), and grab the Installation ID from the URL',
+      'of the installation page (https://github.com/settings/installations/<installation-id>).',
+    ].join('\n'),
+    'Switch to GitHub App auth',
+  )
+  return await promptGithubAppAuth()
 }
 
 async function promptGithubPatAuth(): Promise<{ type: 'pat'; pat: string }> {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -1426,21 +1426,23 @@ export async function setChannelSecrets(
   })
 }
 
-// Discriminated union of what GitHub credentials the user wants to rotate.
-// The three secrets (PAT/private-key, webhook secret) rotate independently,
+// Discriminated union of what GitHub credentials the user wants to update.
+// The three secrets (PAT/private-key, webhook secret) update independently,
 // so the CLI lets the user pick which one(s) to touch in a single call.
-// `auth.type` must match the existing on-disk auth type — flipping between
-// PAT and App auth is a structural change, not a credential rotation, and
-// belongs in a future `channel migrate-auth` or hand-edit of secrets.json.
+// `auth.type` may differ from the on-disk auth type — switching between PAT
+// and App auth replaces the entire auth block (no field carryover from the
+// previous auth type, since the two shapes share no fields beyond `type`).
 export type GithubCredentialPatch = {
   webhookSecret?: string
   auth?: { type: 'pat'; pat: string } | { type: 'app'; privateKey: string; appId?: number; installationId?: number }
 }
 
-// Rotate one or more credential fields on an already-configured GitHub
+// Update one or more credential fields on an already-configured GitHub
 // channel. Like setChannelSecrets, refuses when secrets.json has no
-// existing github entry. Additionally refuses when the requested auth.type
-// doesn't match the on-disk type — see `GithubCredentialPatch` above.
+// existing github entry. Supports both same-type rotation (preserves env
+// bindings, carries appId/installationId forward when not supplied) and
+// auth-type switching (replaces the entire auth block — see
+// `GithubCredentialPatch` above).
 export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch): Promise<SetChannelTokensResult> {
   if (!existsSync(join(cwd, CONFIG_FILE))) {
     return {
@@ -1466,27 +1468,22 @@ export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch
     if (patch.auth !== undefined) {
       const existingAuth = block.auth
       const existingAuthType = readGithubAuthTypeFromObject(existingAuth)
-      if (existingAuthType !== patch.auth.type) {
-        return {
-          result: {
-            ok: false,
-            reason: `github auth type mismatch: secrets.json currently uses "${existingAuthType ?? 'unknown'}" auth, but you tried to rotate a "${patch.auth.type}" credential. Edit secrets.json by hand to migrate between PAT and App auth.`,
-          },
-        }
-      }
+      const isSameType = existingAuthType === patch.auth.type
       if (patch.auth.type === 'pat') {
-        const previousToken = isObjectRecord(existingAuth) ? (existingAuth as { token?: unknown }).token : undefined
+        const previousToken =
+          isSameType && isObjectRecord(existingAuth) ? (existingAuth as { token?: unknown }).token : undefined
         block.auth = { type: 'pat', token: rotatedSecret(previousToken, patch.auth.pat) }
       } else {
-        const existingApp = isObjectRecord(existingAuth) ? (existingAuth as Record<string, unknown>) : {}
+        const existingApp = isSameType && isObjectRecord(existingAuth) ? (existingAuth as Record<string, unknown>) : {}
         const appId = patch.auth.appId ?? (existingApp.appId as number | undefined)
         const installationId = patch.auth.installationId ?? (existingApp.installationId as number | undefined)
         if (typeof appId !== 'number') {
           return {
             result: {
               ok: false,
-              reason:
-                'github App auth requires appId, but it is missing from secrets.json. Re-run `typeclaw channel add github` to re-establish the App auth block.',
+              reason: isSameType
+                ? 'github App auth requires appId, but it is missing from secrets.json. Re-run `typeclaw channel add github` to re-establish the App auth block.'
+                : 'github App auth requires appId when switching from PAT to App auth.',
             },
           }
         }

--- a/src/init/set-channel.test.ts
+++ b/src/init/set-channel.test.ts
@@ -343,32 +343,105 @@ describe('setGithubSecrets', () => {
     expect(gh.webhookSecret).toEqual({ value: 'wh-new' })
   })
 
-  test('refuses to flip auth from pat to app', async () => {
+  test('switches auth from pat to app and replaces the entire auth block', async () => {
     await seedPatGithub()
 
     const result = await setGithubSecrets(root, {
-      auth: { type: 'app', privateKey: 'whatever' },
+      auth: {
+        type: 'app',
+        appId: 4242,
+        privateKey: '-----BEGIN PRIVATE KEY-----\nswitched\n-----END PRIVATE KEY-----',
+        installationId: 7777,
+      },
+    })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.auth).toEqual({
+      type: 'app',
+      appId: 4242,
+      privateKey: { value: '-----BEGIN PRIVATE KEY-----\nswitched\n-----END PRIVATE KEY-----' },
+      installationId: 7777,
+    })
+  })
+
+  test('switches auth from pat to app without an installationId when omitted', async () => {
+    await seedPatGithub()
+
+    const result = await setGithubSecrets(root, {
+      auth: {
+        type: 'app',
+        appId: 4242,
+        privateKey: '-----BEGIN PRIVATE KEY-----\nswitched\n-----END PRIVATE KEY-----',
+      },
+    })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.auth).toEqual({
+      type: 'app',
+      appId: 4242,
+      privateKey: { value: '-----BEGIN PRIVATE KEY-----\nswitched\n-----END PRIVATE KEY-----' },
+    })
+  })
+
+  test('refuses to switch from pat to app when appId is missing', async () => {
+    await seedPatGithub()
+
+    const result = await setGithubSecrets(root, {
+      auth: { type: 'app', privateKey: '-----BEGIN PRIVATE KEY-----\nswitched\n-----END PRIVATE KEY-----' },
     })
 
     expect(result.ok).toBe(false)
     if (result.ok) throw new Error('unreachable')
-    expect(result.reason).toMatch(/auth type mismatch/i)
-    expect(result.reason).toMatch(/pat/)
+    expect(result.reason).toMatch(/appId/i)
     const secrets = await readSecrets()
     const gh = secrets.channels?.github as Record<string, unknown>
     expect(gh.auth).toEqual({ type: 'pat', token: { value: 'ghp_old' } })
   })
 
-  test('refuses to flip auth from app to pat', async () => {
+  test('switches auth from app to pat and replaces the entire auth block', async () => {
     await seedAppGithub()
 
     const result = await setGithubSecrets(root, {
-      auth: { type: 'pat', pat: 'ghp_whatever' },
+      auth: { type: 'pat', pat: 'ghp_switched' },
     })
 
-    expect(result.ok).toBe(false)
-    if (result.ok) throw new Error('unreachable')
-    expect(result.reason).toMatch(/auth type mismatch/i)
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.auth).toEqual({ type: 'pat', token: { value: 'ghp_switched' } })
+  })
+
+  test('switch from pat to app discards any env-binding on the previous PAT token', async () => {
+    await seedPatGithub()
+    const raw = JSON.parse(await readFile(join(root, 'secrets.json'), 'utf8')) as {
+      channels: Record<string, Record<string, unknown>>
+    }
+    raw.channels.github = {
+      auth: { type: 'pat', token: { value: 'ghp_old', env: 'CUSTOM_GH_PAT' } },
+      webhookSecret: { value: 'wh-old' },
+    }
+    await writeFile(join(root, 'secrets.json'), JSON.stringify(raw, null, 2))
+
+    const result = await setGithubSecrets(root, {
+      auth: {
+        type: 'app',
+        appId: 4242,
+        privateKey: '-----BEGIN PRIVATE KEY-----\nswitched\n-----END PRIVATE KEY-----',
+      },
+    })
+
+    expect(result).toEqual({ ok: true })
+    const secrets = await readSecrets()
+    const gh = secrets.channels?.github as Record<string, unknown>
+    expect(gh.auth).toEqual({
+      type: 'app',
+      appId: 4242,
+      privateKey: { value: '-----BEGIN PRIVATE KEY-----\nswitched\n-----END PRIVATE KEY-----' },
+    })
   })
 
   test('refuses to rotate github when secrets.json has no github entry', async () => {


### PR DESCRIPTION
## What this PR does

Fixes a bug where `typeclaw channel set` could not change the GitHub auth type — switching from a PAT to a GitHub App (or back) required hand-editing `secrets.json`. The CLI only offered a rotation path (same type, new credentials), and `setGithubSecrets` in the backend explicitly rejected auth-type mismatches.

1 commit, +186 / −63 across 3 files.

## Files

| File | Change |
|---|---|
| `src/cli/channel.ts` | +87 / −34 — new `promptGithubAuthUpdate(currentType)` helper that asks "rotate or switch?", then reuses `promptGithubPatAuth` / `promptGithubAppAuth` from the channel-add flow. `runSetGithub` calls this helper; the top-level menu label changes from "rotate" to "update" |
| `src/init/index.ts` | +17 / −20 — removes the auth-type mismatch rejection from `setGithubSecrets`. Same-type rotation is unchanged (env-binding preserved, `appId` / `installationId` carried forward). Switch rebuilds the entire auth block fresh — no field carryover between PAT and App. `GithubCredentialPatch` and `setGithubSecrets` block-comments updated to reflect new contract |
| `src/init/set-channel.test.ts` | +91 / −22 — replaces the two "refuses to flip" tests with 5 cases: (1) pat→app with full app fields, (2) pat→app omitting optional `installationId`, (3) refuses pat→app when `appId` is missing, (4) app→pat replaces the entire block, (5) pat→app switch discards the previous PAT env-binding |

## Design notes

**Why the switch path reuses `promptGithubPatAuth` / `promptGithubAppAuth` verbatim.** The fields required to set up a fresh App or PAT block on a switch are exactly the same ones `channel add github` already prompts for. Reusing those functions keeps the "first-time setup" and "switch later" UX identical and prevents a second prompt path from drifting away from the canonical one over time.

**Why the switch path discards env-bindings from the previous auth.** An `{ env: 'CUSTOM_GH_PAT' }` binding on the old PAT token has no meaningful transfer to the new App's `privateKey` field — different secret, different env var. Carrying it across would be a silent footgun. The switch starts clean; users who want a custom binding on the new credential edit `secrets.json` afterwards, the same workflow available today.

**Why the same-type rotation path is left untouched.** Rotation has well-tested semantics: env-binding preservation, `appId` / `installationId` carry-forward when omitted, half-configured detection. The switch path adds a new branch via an `isSameType` gate, leaving the rotation code entirely undisturbed.

**Why the menu copy changed from "rotate" to "update".** "Rotate" implies same-credential replacement. Now that switching is in scope, "update" is the accurate verb. The leading prompt reads "Update the GitHub auth credential", with "Rotate the PAT" / "Rotate the App private key" and the new "Switch to GitHub App" / "Switch to PAT" as sub-options.

## Verification

```
bun run typecheck     ✓
bun run lint          ✓  (61 pre-existing warnings, 0 errors, 0 on changed files)
bun run format:check  ✓
bun run test          5456 pass / 0 fail / 11998 expect() calls (+3 net new tests after replacing 2 rejection tests with 5 positive/negative cases)
```

## Compatibility

- **`GithubCredentialPatch` type**: unchanged shape. `auth.type === 'app'` still has `appId?: number` (optional). The "appId required" enforcement moved into branch logic inside `setGithubSecrets` — same behavior on same-type rotation (carry forward from disk), required-from-patch on switch.
- **CLI surface**: additive. Users who only want to rotate pick "Rotate the PAT" / "Rotate the App private key" and see the identical flow as before.
- **`secrets.json` on-disk shape**: unchanged. Same `auth: { type, ... }` discriminated union; no migration.
- **Rollback**: revert the one commit.

## Out of scope

Per-field surgical update of just `installationId` or `appId` without rotating the private key. Today's "switch" replaces the whole auth block; users who need to fix just an `installationId` hand-edit `secrets.json`. A future `channel set` flow could grow finer granularity — out of scope here.