### PR TITLE
tunnels: default tokenEnv and prompt for token value in cloudflare-named wizards

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -8,8 +8,10 @@ import { config } from '@/config'
 import { start, status, stop } from '@/container'
 import {
   CHANNEL_KINDS,
+  appendOrReplaceEnvKey,
   findAgentDir,
   formatEagerGithubWebhookInstallResult,
+  hasEnvKey,
   isInitialized,
   readConfiguredChannels,
   readGithubAuthType,
@@ -61,7 +63,7 @@ const addSub = defineCommand({
 
     intro(`Adding channel: ${CHANNEL_LABELS[channel]}`)
 
-    const credentials = await collectCredentials(channel)
+    const credentials = await collectCredentials(channel, cwd)
 
     const events: AddChannelStepEvent[] = []
     try {
@@ -604,7 +606,7 @@ type CollectedCredentials =
       auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string; installationId?: number }
     }
 
-async function collectCredentials(channel: ChannelKind): Promise<CollectedCredentials> {
+async function collectCredentials(channel: ChannelKind, cwd: string): Promise<CollectedCredentials> {
   switch (channel) {
     case 'discord-bot':
       return { channel, discordBotToken: await promptDiscordToken() }
@@ -628,13 +630,13 @@ async function collectCredentials(channel: ChannelKind): Promise<CollectedCreden
       }
     }
     case 'github': {
-      const creds = await promptGithubCredentials()
+      const creds = await promptGithubCredentials(cwd)
       return { channel, ...creds }
     }
   }
 }
 
-async function promptGithubCredentials(): Promise<{
+async function promptGithubCredentials(cwd: string): Promise<{
   webhookSecret: string
   tunnelProvider: GithubTunnelProvider
   webhookUrl?: string
@@ -696,7 +698,7 @@ async function promptGithubCredentials(): Promise<{
     cancel('Aborted.')
     process.exit(0)
   }
-  const namedCreds = tunnelProvider === 'cloudflare-named' ? await promptCloudflareNamedTunnel() : undefined
+  const namedCreds = tunnelProvider === 'cloudflare-named' ? await promptCloudflareNamedTunnel(cwd) : undefined
   const port = await text({
     message: 'Local webhook port inside the agent container',
     initialValue: '8975',
@@ -740,13 +742,14 @@ async function promptGithubCredentials(): Promise<{
   }
 }
 
-async function promptCloudflareNamedTunnel(): Promise<{ hostname: string; tokenEnv: string }> {
+async function promptCloudflareNamedTunnel(cwd: string): Promise<{ hostname: string; tokenEnv: string }> {
+  const tokenEnv = 'CLOUDFLARE_TUNNEL_TOKEN'
   note(
     [
       'Cloudflare Named Tunnel needs a tunnel you created in the Zero Trust dashboard:',
       '  1. Networks → Tunnels → Create a tunnel → Cloudflared. Copy the token shown on the install screen.',
       '  2. Public Hostname tab → Add: subdomain + your-domain, service type HTTP, URL localhost:<webhook port>.',
-      '  3. Put the token in .env under the env var name you supply below.',
+      `  3. Paste the token below when prompted — TypeClaw will write it to .env as ${tokenEnv}.`,
       'A tunnel without a Public Hostname registers but routes nothing.',
     ].join('\n'),
     'Cloudflare named tunnel',
@@ -759,21 +762,16 @@ async function promptCloudflareNamedTunnel(): Promise<{ hostname: string; tokenE
     cancel('Aborted.')
     process.exit(0)
   }
-  const tokenEnv = await text({
-    message: 'Env var name holding the tunnel token',
-    initialValue: 'CLOUDFLARE_TUNNEL_TOKEN',
-    validate: (value) => {
-      const v = value ?? ''
-      if (v.trim().length === 0) return 'Env var name is required'
-      if (!/^[A-Z_][A-Z0-9_]*$/.test(v)) {
-        return 'Must be an env var name like CLOUDFLARE_TUNNEL_TOKEN (uppercase, digits, underscore)'
-      }
-      return undefined
-    },
-  })
-  if (isCancel(tokenEnv)) {
-    cancel('Aborted.')
-    process.exit(0)
+  if (!hasEnvKey(cwd, tokenEnv)) {
+    const token = await password({
+      message: `Cloudflare tunnel token (will be written to .env as ${tokenEnv})`,
+      validate: (value) => (value && value.length > 0 ? undefined : 'Token is required'),
+    })
+    if (isCancel(token)) {
+      cancel('Aborted.')
+      process.exit(0)
+    }
+    appendOrReplaceEnvKey(cwd, tokenEnv, token)
   }
   return { hostname, tokenEnv }
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -14,8 +14,10 @@ import {
 } from '@/config/providers'
 import { checkDockerAvailable, type DockerAvailability } from '@/container'
 import {
+  appendOrReplaceEnvKey,
   findAgentDir,
   formatEagerGithubWebhookInstallResult,
+  hasEnvKey,
   hasExistingChannelSecrets,
   isDirectoryNonEmpty,
   isHatched,
@@ -359,7 +361,7 @@ export interface WizardPrompts {
   pickChannel: (initial: ChannelChoice | undefined) => Promise<StepResult<ChannelChoice>>
   hasExistingChannelSecrets: (cwd: string, channel: Exclude<ChannelChoice, 'none'>) => Promise<boolean>
   askReuseExistingChannel: (channel: Exclude<ChannelChoice, 'none'>) => Promise<StepResult<'reuse' | 'prompt'>>
-  runChannelFlow: (choice: ChannelChoice) => Promise<StepResult<CollectedInputs['channelSecrets']>>
+  runChannelFlow: (choice: ChannelChoice, cwd: string) => Promise<StepResult<CollectedInputs['channelSecrets']>>
   runOAuthLogin: (
     provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
     cwd: string,
@@ -691,7 +693,7 @@ export async function collectWizardInputs(cwd: string, prompts: WizardPrompts): 
       }
 
       case 'channel-flow': {
-        const result = onResult(step, await prompts.runChannelFlow(state.channelChoice!))
+        const result = onResult(step, await prompts.runChannelFlow(state.channelChoice!, cwd))
         if (result.kind === 'back') {
           step = state.channelReuseOffered === true ? 'reuse-existing-channel' : 'pick-channel'
           break
@@ -1011,7 +1013,10 @@ async function pickChannel(initial: ChannelChoice | undefined): Promise<StepResu
   return value(choice)
 }
 
-async function runChannelFlow(choice: ChannelChoice): Promise<StepResult<CollectedInputs['channelSecrets']>> {
+async function runChannelFlow(
+  choice: ChannelChoice,
+  cwd: string,
+): Promise<StepResult<CollectedInputs['channelSecrets']>> {
   switch (choice) {
     case 'none':
       return value({})
@@ -1024,7 +1029,7 @@ async function runChannelFlow(choice: ChannelChoice): Promise<StepResult<Collect
     case 'telegram':
       return runTelegramFlow()
     case 'github':
-      return runGithubFlow()
+      return runGithubFlow(cwd)
   }
 }
 
@@ -1144,7 +1149,7 @@ async function runSlackFlow(): Promise<StepResult<CollectedInputs['channelSecret
   }
 }
 
-async function runGithubFlow(): Promise<StepResult<CollectedInputs['channelSecrets']>> {
+async function runGithubFlow(cwd: string): Promise<StepResult<CollectedInputs['channelSecrets']>> {
   note(
     [
       'Choose PAT auth for a quick setup, or GitHub App auth for expiring installation tokens.',
@@ -1189,7 +1194,7 @@ async function runGithubFlow(): Promise<StepResult<CollectedInputs['channelSecre
         })
       : undefined
   if (isCancel(webhookUrl)) return back()
-  const namedCreds = tunnelProvider === 'cloudflare-named' ? await promptGithubCloudflareNamedTunnel() : undefined
+  const namedCreds = tunnelProvider === 'cloudflare-named' ? await promptGithubCloudflareNamedTunnel(cwd) : undefined
   if (namedCreds === null) return back()
   const port = await text({
     message: 'Local webhook port inside the agent container',
@@ -1227,13 +1232,14 @@ async function runGithubFlow(): Promise<StepResult<CollectedInputs['channelSecre
   })
 }
 
-async function promptGithubCloudflareNamedTunnel(): Promise<{ hostname: string; tokenEnv: string } | null> {
+async function promptGithubCloudflareNamedTunnel(cwd: string): Promise<{ hostname: string; tokenEnv: string } | null> {
+  const tokenEnv = 'CLOUDFLARE_TUNNEL_TOKEN'
   note(
     [
       'Cloudflare Named Tunnel needs a tunnel you created in the Zero Trust dashboard:',
       '  1. Networks → Tunnels → Create a tunnel → Cloudflared. Copy the token shown on the install screen.',
       '  2. Public Hostname tab → Add: subdomain + your-domain, service type HTTP, URL localhost:<webhook port>.',
-      '  3. Put the token in .env under the env var name you supply below.',
+      `  3. Paste the token below when prompted — TypeClaw will write it to .env as ${tokenEnv}.`,
       'A tunnel without a Public Hostname registers but routes nothing.',
     ].join('\n'),
     'Cloudflare named tunnel',
@@ -1243,19 +1249,14 @@ async function promptGithubCloudflareNamedTunnel(): Promise<{ hostname: string; 
     validate: (v) => validateGithubUrl(v ?? '', 'Hostname is required'),
   })
   if (isCancel(hostname)) return null
-  const tokenEnv = await text({
-    message: 'Env var name holding the tunnel token',
-    initialValue: 'CLOUDFLARE_TUNNEL_TOKEN',
-    validate: (v) => {
-      const raw = v ?? ''
-      if (raw.trim().length === 0) return 'Env var name is required'
-      if (!/^[A-Z_][A-Z0-9_]*$/.test(raw)) {
-        return 'Must be an env var name like CLOUDFLARE_TUNNEL_TOKEN (uppercase, digits, underscore)'
-      }
-      return undefined
-    },
-  })
-  if (isCancel(tokenEnv)) return null
+  if (!hasEnvKey(cwd, tokenEnv)) {
+    const token = await password({
+      message: `Cloudflare tunnel token (will be written to .env as ${tokenEnv})`,
+      validate: (v) => (v && v.length > 0 ? undefined : 'Token is required'),
+    })
+    if (isCancel(token)) return null
+    appendOrReplaceEnvKey(cwd, tokenEnv, token)
+  }
   return { hostname, tokenEnv }
 }
 

--- a/src/cli/tunnel.test.ts
+++ b/src/cli/tunnel.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
 import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -46,9 +47,9 @@ describe('tunnel add/remove config flows', () => {
     expect(config.docker.file.cloudflared).toBe(true)
   })
 
-  test('interactive add writes a cloudflare-named channel tunnel and enables cloudflared', async () => {
+  test('interactive add writes a cloudflare-named channel tunnel, defaults tokenEnv, prompts for token, writes .env', async () => {
     const cwd = await makeAgentDir({})
-    const prompts = sequencedPrompts(['https://agent.example.com', 'CLOUDFLARE_TUNNEL_TOKEN'])
+    const textPrompts = sequencedPrompts(['https://agent.example.com'])
 
     const result = await tunnel.runTunnelAddFlow(
       cwd,
@@ -56,7 +57,8 @@ describe('tunnel add/remove config flows', () => {
       {
         selectProvider: async () => 'cloudflare-named',
         selectOwner: async () => 'channel',
-        text: prompts.text,
+        text: textPrompts.text,
+        password: async () => 'tunnel-token-from-prompt',
       },
     )
 
@@ -72,6 +74,49 @@ describe('tunnel add/remove config flows', () => {
       },
     ])
     expect(config.docker.file.cloudflared).toBe(true)
+    const env = await Bun.file(join(cwd, '.env')).text()
+    expect(env).toBe('CLOUDFLARE_TUNNEL_TOKEN=tunnel-token-from-prompt\n')
+  })
+
+  test('interactive add with cloudflare-named does NOT prompt for token when .env already has it', async () => {
+    const cwd = await makeAgentDir({})
+    await writeFile(join(cwd, '.env'), 'CLOUDFLARE_TUNNEL_TOKEN=preexisting-token\n', 'utf8')
+    let passwordCalls = 0
+
+    const result = await tunnel.runTunnelAddFlow(
+      cwd,
+      { name: 'github-webhook', forChannel: 'github' },
+      {
+        selectProvider: async () => 'cloudflare-named',
+        selectOwner: async () => 'channel',
+        text: async () => 'https://agent.example.com',
+        password: async () => {
+          passwordCalls += 1
+          return 'should-not-be-written'
+        },
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    expect(passwordCalls).toBe(0)
+    const env = await Bun.file(join(cwd, '.env')).text()
+    expect(env).toBe('CLOUDFLARE_TUNNEL_TOKEN=preexisting-token\n')
+  })
+
+  test('non-interactive add with cloudflare-named defaults tokenEnv and never prompts for the token value', async () => {
+    const cwd = await makeAgentDir({})
+
+    const result = await tunnel.runTunnelAddFlow(cwd, {
+      name: 'github-webhook',
+      provider: 'cloudflare-named',
+      forChannel: 'github',
+      hostname: 'https://agent.example.com',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error(result.reason)
+    expect(result.value.tokenEnv).toBe('CLOUDFLARE_TUNNEL_TOKEN')
+    expect(existsSync(join(cwd, '.env'))).toBe(false)
   })
 
   test('non-interactive add writes a cloudflare-named manual tunnel without upstreamPort', async () => {
@@ -569,6 +614,60 @@ describe('tunnel set config flow', () => {
     expect(result.ok).toBe(false)
     if (result.ok) throw new Error('unreachable')
     expect(result.reason).toMatch(/typeclaw\.json is invalid/)
+  })
+
+  test('interactive set switching TO cloudflare-named prompts for the token and writes .env', async () => {
+    const cwd = await makeAgentDir({
+      tunnels: [
+        {
+          name: 'github-webhook',
+          provider: 'cloudflare-quick',
+          for: { kind: 'channel', name: 'github' },
+        },
+      ],
+    })
+
+    const result = await tunnel.runTunnelSetFlow(
+      cwd,
+      { name: 'github-webhook' },
+      {
+        selectProvider: async () => 'cloudflare-named',
+        selectOwner: async () => 'channel',
+        selectSetField: async () => 'provider',
+        text: async () => 'https://agent.example.com',
+        password: async () => 'rotated-token',
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error(result.reason)
+    expect(result.value.provider).toBe('cloudflare-named')
+    expect(result.value.tokenEnv).toBe('CLOUDFLARE_TUNNEL_TOKEN')
+    const env = await Bun.file(join(cwd, '.env')).text()
+    expect(env).toBe('CLOUDFLARE_TUNNEL_TOKEN=rotated-token\n')
+  })
+
+  test('non-interactive set switching TO cloudflare-named defaults tokenEnv and never prompts for the token value', async () => {
+    const cwd = await makeAgentDir({
+      tunnels: [
+        {
+          name: 'github-webhook',
+          provider: 'cloudflare-quick',
+          for: { kind: 'channel', name: 'github' },
+        },
+      ],
+    })
+
+    const result = await tunnel.runTunnelSetFlow(cwd, {
+      name: 'github-webhook',
+      provider: 'cloudflare-named',
+      hostname: 'https://agent.example.com',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error(result.reason)
+    expect(result.value.tokenEnv).toBe('CLOUDFLARE_TUNNEL_TOKEN')
+    expect(existsSync(join(cwd, '.env'))).toBe(false)
   })
 })
 

--- a/src/cli/tunnel.ts
+++ b/src/cli/tunnel.ts
@@ -1,12 +1,12 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-import { select, text, isCancel, cancel, log } from '@clack/prompts'
+import { select, text, password, isCancel, cancel, log } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import { loadConfigSync, validateConfig } from '@/config'
 import { resolveHostPort, resolveTuiToken } from '@/container'
-import { findAgentDir, isInitialized } from '@/init'
+import { appendOrReplaceEnvKey, findAgentDir, hasEnvKey, isInitialized } from '@/init'
 import type { ClientMessage, ServerMessage, TunnelLogsServerMessage, TunnelSnapshot } from '@/shared'
 import type { TunnelConfig, TunnelFor, TunnelProvider } from '@/tunnels'
 
@@ -58,7 +58,15 @@ export type TunnelPrompts = {
     choices: readonly { value: string; label: string; hint?: string }[],
   ) => Promise<string | symbol>
   text: (message: string, validate?: TextValidator) => Promise<string | symbol>
+  // Only fires when the user picks `cloudflare-named` AND the resolved
+  // `tokenEnv` is missing from the agent's `.env`. Optional so existing
+  // callers/tests don't have to stub it; flows that need it but don't get
+  // one fall back to skipping the token write (the user can still set
+  // `.env` by hand). Same compat pattern as `selectSetField`.
+  password?: (message: string, validate?: TextValidator) => Promise<string | symbol>
 }
+
+const DEFAULT_TUNNEL_TOKEN_ENV = 'CLOUDFLARE_TUNNEL_TOKEN'
 
 const DEFAULT_TIMEOUT_MS = 15_000
 
@@ -104,6 +112,8 @@ const defaultPrompts: TunnelPrompts = {
     }),
   text: (message, validate) =>
     text({ message, ...(validate !== undefined ? { validate: (v) => validate(v ?? '') } : {}) }),
+  password: (message, validate) =>
+    password({ message, ...(validate !== undefined ? { validate: (v) => validate(v ?? '') } : {}) }),
 }
 
 const addSub = defineCommand({
@@ -307,9 +317,16 @@ export async function runTunnelAddFlow(
       ))
     const hostnameError = validateHttpsUrl(hostname)
     if (hostnameError !== undefined) return { ok: false, reason: `hostname: ${hostnameError}` }
-    tokenEnv = args.tokenEnv ?? (await promptText('Env var name holding the tunnel token', prompts, validateTokenEnv))
+    tokenEnv = args.tokenEnv ?? DEFAULT_TUNNEL_TOKEN_ENV
     const tokenError = validateTokenEnv(tokenEnv)
     if (tokenError !== undefined) return { ok: false, reason: `token-env: ${tokenError}` }
+    // Only prompt for the token VALUE in interactive mode. `--provider` on
+    // the CLI signals scripted invocation; bombarding a script with a
+    // password prompt it can't satisfy would deadlock CI runs.
+    if (args.provider === undefined) {
+      const tokenPromptResult = await maybePromptTunnelTokenValue(cwd, tokenEnv, prompts)
+      if (!tokenPromptResult.ok) return tokenPromptResult
+    }
   }
 
   const tunnel: TunnelConfig = {
@@ -468,12 +485,7 @@ export async function runTunnelSetFlow(
         nextHostname = raw
       }
       if (nextTokenEnv === undefined) {
-        const raw =
-          args.tokenEnv ??
-          (interactive
-            ? await promptText('Env var name holding the tunnel token', prompts, validateTokenEnv)
-            : undefined)
-        if (raw === undefined) return { ok: false, reason: "provider 'cloudflare-named' requires --token-env" }
+        const raw = args.tokenEnv ?? DEFAULT_TUNNEL_TOKEN_ENV
         const err = validateTokenEnv(raw)
         if (err !== undefined) return { ok: false, reason: `token-env: ${err}` }
         nextTokenEnv = raw
@@ -497,6 +509,11 @@ export async function runTunnelSetFlow(
     ...(nextUpstreamPort !== undefined ? { upstreamPort: nextUpstreamPort } : {}),
     ...(nextHostname !== undefined ? { hostname: nextHostname } : {}),
     ...(nextTokenEnv !== undefined ? { tokenEnv: nextTokenEnv } : {}),
+  }
+
+  if (interactive && next.provider === 'cloudflare-named' && next.tokenEnv !== undefined) {
+    const tokenPromptResult = await maybePromptTunnelTokenValue(cwd, next.tokenEnv, prompts)
+    if (!tokenPromptResult.ok) return tokenPromptResult
   }
 
   const raw = readRawConfig(cwd)
@@ -754,6 +771,24 @@ async function resolveExistingTunnelName(
     process.exit(0)
   }
   return { ok: true, value: choice }
+}
+
+async function maybePromptTunnelTokenValue(
+  cwd: string,
+  tokenEnv: string,
+  prompts: TunnelPrompts,
+): Promise<LiveResult<void>> {
+  if (hasEnvKey(cwd, tokenEnv)) return { ok: true, value: undefined }
+  if (prompts.password === undefined) return { ok: true, value: undefined }
+  const value = await prompts.password(`Cloudflare tunnel token (will be written to .env as ${tokenEnv})`, (v) =>
+    v.length > 0 ? undefined : 'Token is required',
+  )
+  if (isCancel(value)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  appendOrReplaceEnvKey(cwd, tokenEnv, value)
+  return { ok: true, value: undefined }
 }
 
 async function resolveProvider(input: string | undefined, prompts: TunnelPrompts): Promise<TunnelProvider> {

--- a/src/init/env-file.test.ts
+++ b/src/init/env-file.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { appendOrReplaceEnvKey, hasEnvKey, readEnvFile } from './env-file'
+
+describe('readEnvFile', () => {
+  test('returns an empty map when .env is missing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    expect(readEnvFile(cwd).size).toBe(0)
+  })
+
+  test('parses KEY=value lines, skipping blanks and comments', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), '# a comment\n\nFOO=bar\nBAZ=qux\n', 'utf8')
+    const env = readEnvFile(cwd)
+    expect(env.get('FOO')).toBe('bar')
+    expect(env.get('BAZ')).toBe('qux')
+    expect(env.size).toBe(2)
+  })
+
+  test('preserves quotes verbatim (matches docker --env-file semantics)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), 'QUOTED="hello"\n', 'utf8')
+    expect(readEnvFile(cwd).get('QUOTED')).toBe('"hello"')
+  })
+
+  test('treats only the first `=` as the separator', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), 'EQUATION=a=b=c\n', 'utf8')
+    expect(readEnvFile(cwd).get('EQUATION')).toBe('a=b=c')
+  })
+
+  test('skips lines without `=` and lines starting with `=`', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), 'STRAY_LINE\n=noKey\nOK=yes\n', 'utf8')
+    const env = readEnvFile(cwd)
+    expect(env.size).toBe(1)
+    expect(env.get('OK')).toBe('yes')
+  })
+})
+
+describe('hasEnvKey', () => {
+  test('returns false when the key is missing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), 'OTHER=value\n', 'utf8')
+    expect(hasEnvKey(cwd, 'MISSING')).toBe(false)
+  })
+
+  test('returns false when the key is present but empty', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), 'EMPTY=\n', 'utf8')
+    expect(hasEnvKey(cwd, 'EMPTY')).toBe(false)
+  })
+
+  test('returns true when the key has a non-empty value', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), 'FILLED=something\n', 'utf8')
+    expect(hasEnvKey(cwd, 'FILLED')).toBe(true)
+  })
+
+  test('returns false when .env is missing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    expect(hasEnvKey(cwd, 'ANY')).toBe(false)
+  })
+})
+
+describe('appendOrReplaceEnvKey', () => {
+  test('creates .env with KEY=value when the file is missing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    appendOrReplaceEnvKey(cwd, 'FOO', 'bar')
+    expect(await readFile(join(cwd, '.env'), 'utf8')).toBe('FOO=bar\n')
+  })
+
+  test('appends a new key after existing keys', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), 'EXISTING=keep\n', 'utf8')
+    appendOrReplaceEnvKey(cwd, 'FRESH', 'value')
+    expect(await readFile(join(cwd, '.env'), 'utf8')).toBe('EXISTING=keep\nFRESH=value\n')
+  })
+
+  test('replaces an existing key in place, preserving surrounding lines', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), '# header\nFIRST=a\nTARGET=old\nLAST=z\n', 'utf8')
+    appendOrReplaceEnvKey(cwd, 'TARGET', 'new')
+    expect(await readFile(join(cwd, '.env'), 'utf8')).toBe('# header\nFIRST=a\nTARGET=new\nLAST=z\n')
+  })
+
+  test('does not strip or add quotes around the value', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    appendOrReplaceEnvKey(cwd, 'TOKEN', 'eyJhbGc.abc.def')
+    expect(await readFile(join(cwd, '.env'), 'utf8')).toBe('TOKEN=eyJhbGc.abc.def\n')
+  })
+
+  test('handles a file without a trailing newline', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), 'EXISTING=keep', 'utf8')
+    appendOrReplaceEnvKey(cwd, 'FRESH', 'value')
+    expect(await readFile(join(cwd, '.env'), 'utf8')).toBe('EXISTING=keep\nFRESH=value\n')
+  })
+
+  test('does not double up trailing blank lines when appending', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), 'EXISTING=keep\n', 'utf8')
+    appendOrReplaceEnvKey(cwd, 'FRESH', 'value')
+    const out = await readFile(join(cwd, '.env'), 'utf8')
+    expect(out).toBe('EXISTING=keep\nFRESH=value\n')
+    expect(out.split('\n').filter((line) => line === '').length).toBe(1)
+  })
+})

--- a/src/init/env-file.ts
+++ b/src/init/env-file.ts
@@ -1,0 +1,66 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ENV_FILE = '.env'
+
+// Parse the agent's `.env` into a key-value map, matching Docker's
+// `--env-file` parser semantics: blank lines and `#`-lines ignored, no
+// quote stripping, no shell expansion, no whitespace trimming around `=`.
+// Lines without `=` are skipped. Last value wins on duplicate keys.
+export function readEnvFile(cwd: string): Map<string, string> {
+  const out = new Map<string, string>()
+  let raw: string
+  try {
+    raw = readFileSync(join(cwd, ENV_FILE), 'utf8')
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') return out
+    throw err
+  }
+  for (const line of raw.split(/\r?\n/)) {
+    if (line.length === 0) continue
+    if (line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq <= 0) continue
+    const key = line.slice(0, eq)
+    const value = line.slice(eq + 1)
+    out.set(key, value)
+  }
+  return out
+}
+
+export function hasEnvKey(cwd: string, key: string): boolean {
+  const value = readEnvFile(cwd).get(key)
+  return value !== undefined && value.length > 0
+}
+
+// Write `key=value` to the agent's `.env`. Idempotent: replaces an existing
+// line for the same key in place (preserving order and surrounding comments),
+// or appends if absent. Creates the file if missing. The value is written
+// verbatim with no quoting because Docker's `--env-file` parser does not
+// strip quotes (a wrapping `"..."` would land in `process.env` literally).
+export function appendOrReplaceEnvKey(cwd: string, key: string, value: string): void {
+  const path = join(cwd, ENV_FILE)
+  let raw = ''
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch (err) {
+    if (!(err instanceof Error) || !('code' in err) || err.code !== 'ENOENT') throw err
+  }
+  const lines = raw.length === 0 ? [] : raw.split(/\r?\n/)
+  // `"foo\n".split(/\r?\n/)` returns `["foo", ""]` — strip that phantom
+  // trailing empty element so the rebuilt output ends in exactly one newline
+  // regardless of replace-vs-append path.
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
+  let replaced = false
+  const next = lines.map((line) => {
+    if (line.startsWith('#')) return line
+    const eq = line.indexOf('=')
+    if (eq <= 0) return line
+    if (line.slice(0, eq) !== key) return line
+    replaced = true
+    return `${key}=${value}`
+  })
+  if (!replaced) next.push(`${key}=${value}`)
+  const out = `${next.join('\n')}\n`
+  writeFileSync(path, out, 'utf8')
+}

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -33,6 +33,8 @@ export { formatEagerGithubWebhookInstallResult, installGithubWebhooksEagerly } f
 
 export { GITKEEP_FILE, PACKAGES_DIR } from './paths'
 
+export { appendOrReplaceEnvKey, hasEnvKey, readEnvFile } from './env-file'
+
 const CONFIG_FILE = 'typeclaw.json'
 const CRON_FILE = 'cron.json'
 const PACKAGE_FILE = 'package.json'


### PR DESCRIPTION
## What this PR does

Closes the last UX gap on the `cloudflare-named` flow introduced in PR #383. PR #385 made the surrounding wizards interactive; this PR follows up on the question "do we need to ask Env var name holding the tunnel token?" and the refinement "for ux, if there's no env value, we should prompt."

Before this PR, the user was asked to type the env var NAME holding the cloudflare tunnel token (99% of the time just `CLOUDFLARE_TUNNEL_TOKEN`), and even after the wizard finished they still had to hand-edit `.env` to paste the actual token. Both prompts are friction for decisions the user does not want to make.

Two changes, applied symmetrically across all three wizard sites that touch `cloudflare-named` (`init`, `channel add github`, `tunnel add`/`tunnel set`):

1. **Default `tokenEnv` to `CLOUDFLARE_TUNNEL_TOKEN`, drop the naming prompt.** Power users with multiple named tunnels can still pass `--token-env=FOO` to `tunnel add` / `tunnel set`, and the `tunnel set` field picker still exposes `tokenEnv` for explicit rotation. Matches how typeclaw treats `FIREWORKS_API_KEY` / `OPENAI_API_KEY` — well-known constants the user never names.

2. **If `.env` lacks the resolved `tokenEnv` AND we're in interactive mode, prompt for the token VALUE (password, masked) and append `KEY=value` to `.env`.** The wizard becomes self-contained — paste once, never open `.env`.

4 commits, +384 / −43 across 7 files.

## Shape

### Before

```
✔ Public hostname configured in the dashboard (https://...) · https://agent.example.com
◆ Env var name holding the tunnel token
│ CLOUDFLARE_TUNNEL_TOKEN_                                  ← 99% just hit Enter
└
... wizard ends. user opens .env, pastes the token by hand, restarts.
```

### After

```
✔ Public hostname configured in the dashboard (https://...) · https://agent.example.com
◆ Cloudflare tunnel token (will be written to .env as CLOUDFLARE_TUNNEL_TOKEN)
│ ********                                                  ← masked password
└
... wizard ends. .env already has the token. just restart.
```

If `.env` already has `CLOUDFLARE_TUNNEL_TOKEN=<non-empty>`, the prompt is skipped entirely.

## Commits

| # | Commit | Files |
|---|---|---|
| 1 | init: add .env read/write helpers (env-file module) | `src/init/env-file.ts` (NEW, 66 lines), `src/init/env-file.test.ts` (NEW, 15 tests), `src/init/index.ts` (+2 barrel re-export) |
| 2 | tunnel: drop tokenEnv name prompt, write token value to .env | `src/cli/tunnel.ts`, `src/cli/tunnel.test.ts` (+4 new tests, 1 updated) |
| 3 | channel: drop tokenEnv name prompt in github cloudflare-named flow | `src/cli/channel.ts` |
| 4 | init: drop tokenEnv name prompt in github cloudflare-named wizard | `src/cli/init.ts` |

Each commit's tests pass at HEAD-of-that-commit. Commit 1 is a pure helper with zero callers; commits 2/3/4 are independent wire-ups into each wizard site.

## The new env-file module

Three helpers in `src/init/env-file.ts` matching Docker's `--env-file` parser semantics:

- `readEnvFile(cwd)` — returns `Map<string, string>`. Blank lines and `#`-lines skipped, no quote stripping, no shell expansion, no whitespace trim around `=`, lines without `=` skipped, first `=` is the separator.
- `hasEnvKey(cwd, key)` — true iff key is present AND non-empty.
- `appendOrReplaceEnvKey(cwd, key, value)` — in-place line replace if the key exists, append otherwise. No quoting (Docker's `--env-file` does not unwrap quotes — wrapping in `"..."` would land in `process.env` literally). Preserves the rest of `.env` verbatim including comments. Creates the file if missing.

15 tests cover: missing file, blank/comment lines, quote preservation, first-`=`-only separator semantics, skip-malformed-lines, `hasEnvKey` empty-value handling, create-on-missing, append-after-existing, in-place replace preserving surrounding lines, no-quote round-trip, missing-trailing-newline handling, and the trailing-blank-line-doubling guard.

## Files

| File | Change |
|---|---|
| `src/init/env-file.ts` | NEW (+66 lines) — `readEnvFile`, `hasEnvKey`, `appendOrReplaceEnvKey` |
| `src/init/env-file.test.ts` | NEW (+111 lines, 15 tests) |
| `src/init/index.ts` | +2 — re-export from barrel |
| `src/cli/tunnel.ts` | +41 / −12 — drop name prompt, `DEFAULT_TUNNEL_TOKEN_ENV` const, `maybePromptTunnelTokenValue` helper, `TunnelPrompts.password` optional with default, gate value prompt on interactive mode |
| `src/cli/tunnel.test.ts` | +93 / −12 — 4 new tests, 1 updated |
| `src/cli/channel.ts` | +20 / −22 — drop name prompt, thread `cwd` through `collectCredentials` → `promptGithubCredentials` → `promptCloudflareNamedTunnel`, prompt for token value if `.env` lacks it |
| `src/cli/init.ts` | +22 / −21 — drop name prompt, widen `WizardPrompts.runChannelFlow` with `cwd`, thread through `runGithubFlow` → `promptGithubCloudflareNamedTunnel`, prompt for token value if `.env` lacks it |

## Design notes

**Why a token VALUE prompt instead of just defaulting `tokenEnv` and telling the user to edit `.env`.** The user explicitly asked for both: drop the naming prompt AND prompt for the value if absent. The naming layer was friction without a decision; the manual `.env` step was an out-of-wizard surprise. One prompt closes both gaps.

**Why this is the first place typeclaw writes to `.env` itself.** The pre-existing invariant (asserted in `src/init/index.test.ts`) is about init scaffolding — typeclaw should not create an empty `.env` from scratch. That invariant is preserved: we only touch `.env` when the user is actively configuring `cloudflare-named`, which requires a real secret. Non-`cloudflare-named` init paths still leave `.env` absent.

**Why interactive-mode gating on the token VALUE prompt.** `tunnel add --provider cloudflare-named ...` and `tunnel set --provider cloudflare-named ...` are scripted invocations. An unsatisfiable password prompt would deadlock a CI run. In `runTunnelAddFlow` the signal is `args.provider === undefined` (wizard path). In `runTunnelSetFlow` it's the existing `interactive` flag. Same signals PR #384/#385 established.

**Why `TunnelPrompts.password` is optional.** Mirrors the `selectSetField?` / `selectExistingTunnel?` pattern from PR #384/#385: existing test stubs that don't pass `password` keep working; a missing stub falls back to skipping the token write. Without this compat behavior every `cloudflare-named` test would have to stub a new prompt method even when the test isn't about the token flow.

**Why the parser matches Docker's `--env-file` bit-for-bit.** Reading the same file Docker reads with different semantics is a debugging trap. The `auth-flow.md` skill doc already documents the no-quote-stripping behavior for `CLAUDE_CODE_OAUTH_TOKEN`; this is the same trap encoded in source.

**Why `appendOrReplaceEnvKey` rebuilds the file instead of using `fs.appendFile`.** Replace-in-place keeps line ordering stable across rotations. A user rotating their cloudflare token via `tunnel set` should see a single changed line in the `.env` diff, not the old key at the top and a new duplicate at the bottom.

**Why 4 commits.** A pre-commit guard rejected the original 7-file mega-commit. Splitting was the right call: commit 1 is a pure helper that's perfectly revertable; commits 2/3/4 are independent wire-ups of that helper into each of the 3 wizard sites.

**Why the 3 wizard sites are not centralized into a shared helper.** They differ in cancel semantics, `note()` placement, and URL validators. A shared helper would need to thread all of those through, making it larger than the duplication it eliminates.

## Verification

```
bun run typecheck     ✓
bun run lint          ✓  (61 pre-existing warnings, 0 errors, 0 on changed files)
bun run format:check  ✓
bun run test          5471 pass / 1 fail / 12026 expect() calls (+19 net new tests)
```

The 1 failing test (`scripts/generate-schema.test.ts` — `typeclaw.schema.json` drift guard) is pre-existing on `main` at HEAD. Verified: stashing these changes and re-running produces the identical failure. Unrelated to this PR.

19 net new tests: 15 in `src/init/env-file.test.ts`, 4 new + 1 updated in `src/cli/tunnel.test.ts`.

## Compatibility

- **Schema**: unchanged. `tokenEnv` is still required when `provider === 'cloudflare-named'`; we just default it instead of prompting.
- **CLI surface**: additive. `--token-env` on `tunnel add` / `tunnel set` keeps the same meaning. Wizard interaction shape changes (password prompt for the token VALUE instead of text prompt for the env var NAME).
- **`TunnelPrompts.password?`**: new optional prompt. Existing test stubs require no update.
- **`WizardPrompts.runChannelFlow`**: signature widens with `cwd: string`. Existing `async () => ...` test stubs are unchanged — TypeScript's excess-args rule accepts them; verified `bun run typecheck` clean and all 49 `init.test.ts` tests pass.
- **`.env` writes**: only fires when the user explicitly configures `cloudflare-named` via an interactive wizard. The "never scaffold an empty `.env`" invariant from init tests is preserved.
- **Rollback**: revert all four commits. No on-disk state.

## Out of scope

- Migrating existing `cloudflare-named` tunnels with custom `tokenEnv` names. The schema still accepts any uppercase identifier; existing configs keep working.
- Rotating the token VALUE via `tunnel set`. Users can edit `.env` directly. A `--token-value <secret>` flag would put secrets in shell history; deliberately not done.
- Symmetric token-value rotation on `channel set github`. The auth credential rotation flow is its own surface; this PR only touches the `cloudflare-named` tunnel slice.
