### PR TITLE
init: accept Fireworks Fire Pass (fpk_) keys in API key validation

### DIFF
--- a/src/init/validate-api-key.test.ts
+++ b/src/init/validate-api-key.test.ts
@@ -35,6 +35,61 @@ describe('validateApiKey', () => {
     expect(result).toEqual({ kind: 'rejected', status: 401 })
   })
 
+  test('accepts a Fireworks Fire Pass key whose 403 body carries the FORBIDDEN/Fire Pass marker', async () => {
+    const firePassBody = JSON.stringify({
+      error: {
+        message: 'Fire Pass API keys are not authorized for this route.',
+        code: 'FORBIDDEN',
+        type: 'error',
+      },
+    })
+    const result = await validateApiKey(
+      'fireworks',
+      'fpk_test',
+      fakeFetch((url, init) => {
+        expect(url).toBe('https://api.fireworks.ai/inference/v1/models')
+        expect((init.headers as Record<string, string>).Authorization).toBe('Bearer fpk_test')
+        return new Response(firePassBody, { status: 403 })
+      }),
+    )
+    expect(result).toEqual({ kind: 'ok' })
+  })
+
+  test('rejects a Fireworks 403 that is not the Fire Pass marker (e.g. genuinely forbidden)', async () => {
+    const result = await validateApiKey(
+      'fireworks',
+      'fw_test',
+      fakeFetch(() => new Response('{"error":{"message":"forbidden","code":"FORBIDDEN"}}', { status: 403 })),
+    )
+    expect(result).toEqual({ kind: 'rejected', status: 403 })
+  })
+
+  test('does not apply the Fire Pass exception to non-Fireworks providers', async () => {
+    const firePassBody = JSON.stringify({
+      error: { message: 'Fire Pass API keys are not authorized for this route.', code: 'FORBIDDEN' },
+    })
+    const result = await validateApiKey(
+      'openai',
+      'sk-test',
+      fakeFetch(() => new Response(firePassBody, { status: 403 })),
+    )
+    expect(result).toEqual({ kind: 'rejected', status: 403 })
+  })
+
+  test('rejects a Fireworks 401 even if the body somehow mentions Fire Pass', async () => {
+    const result = await validateApiKey(
+      'fireworks',
+      'fpk_bad',
+      fakeFetch(
+        () =>
+          new Response('{"error":{"message":"Fire Pass key invalid","code":"UNAUTHORIZED"}}', {
+            status: 401,
+          }),
+      ),
+    )
+    expect(result).toEqual({ kind: 'rejected', status: 401 })
+  })
+
   test('uses x-api-key + anthropic-version for Anthropic', async () => {
     let seenHeaders: Record<string, string> | null = null
     await validateApiKey(

--- a/src/init/validate-api-key.ts
+++ b/src/init/validate-api-key.ts
@@ -60,6 +60,23 @@ export async function validateApiKey(
       return { kind: 'skipped', reason: 'network-error', detail: 'unexpected response shape' }
     }
     if (res.status === 401 || res.status === 403) {
+      // Fireworks issues two key classes that probe the same /v1/models
+      // endpoint differently:
+      //   * Standard keys (fw_...)  → 200 with the models list
+      //   * Fire Pass keys (fpk_...) → 403 with {"error":{"code":"FORBIDDEN",
+      //     "message":"Fire Pass API keys are not authorized for this route."}}
+      // The 403 *proves* authentication succeeded — the route is just out of
+      // scope for the key. Fire Pass keys do work at chat-completions, which
+      // is exactly the surface typeclaw needs (the only Fireworks model wired
+      // here is the Fire Pass router `kimi-k2p6-turbo`). Treating that 403
+      // as `rejected` is the bug; recognize the marker and accept the key.
+      // Genuinely bad keys still come back as 401 UNAUTHORIZED, untouched.
+      if (providerId === 'fireworks' && res.status === 403) {
+        const body = await readCapped(res, MAX_BODY_BYTES)
+        if (body !== null && isFireworksFirePassForbidden(body)) {
+          return { kind: 'ok' }
+        }
+      }
       return { kind: 'rejected', status: res.status }
     }
     return { kind: 'skipped', reason: 'network-error', detail: `HTTP ${res.status}` }
@@ -73,6 +90,20 @@ export async function validateApiKey(
 }
 
 const MAX_BODY_BYTES = 4096
+
+function isFireworksFirePassForbidden(body: string): boolean {
+  try {
+    const parsed = JSON.parse(body) as { error?: { code?: unknown; message?: unknown } }
+    const err = parsed.error
+    if (!err || typeof err !== 'object') return false
+    if (err.code === 'FORBIDDEN' && typeof err.message === 'string' && err.message.includes('Fire Pass')) {
+      return true
+    }
+    return false
+  } catch {
+    return false
+  }
+}
 
 async function isModelsListShape(res: Response): Promise<boolean> {
   const text = await readCapped(res, MAX_BODY_BYTES)


### PR DESCRIPTION
## What this PR does

Fixes a false-negative in `validateApiKey` that caused Fireworks **Fire Pass** keys (`fpk_...`) to be rejected during `typeclaw init` even though the keys are valid and functional.

## The fix

Fireworks issues two key classes that probe the same `/v1/models` endpoint differently:

- **Standard keys** (`fw_...`) → `200` with a models list
- **Fire Pass keys** (`fpk_...`) → `403` with `{"error":{"code":"FORBIDDEN","message":"Fire Pass API keys are not authorized for this route."}}`

The `403` **proves** authentication succeeded — the `/v1/models` route is simply out of scope for Fire Pass keys. Fire Pass keys do work at chat-completions, which is the only Fireworks surface typeclaw uses (the only wired model is the Fire Pass router `kimi-k2p6-turbo`). Treating that `403` as `rejected` is the bug.

The fix adds a `isFireworksFirePassForbidden(body)` helper that parses the response body and checks for the exact `FORBIDDEN` code + `"Fire Pass"` message substring. When the check matches on a Fireworks `403`, `validateApiKey` returns `{ kind: 'ok' }` instead of `{ kind: 'rejected', status: 403 }`. Genuinely bad keys still come back as `401 UNAUTHORIZED`, untouched.

## Verification

```
bun run typecheck     ✓
bun run lint          ✓
bun run format:check  ✓
bun run test          ✓  (4 new tests added, all pass)
```

## Tests

4 new tests in `src/init/validate-api-key.test.ts`:

1. **Accepts** a Fireworks Fire Pass key whose `403` body carries the `FORBIDDEN` / `"Fire Pass"` marker.
2. **Rejects** a Fireworks `403` that does not carry the Fire Pass marker (e.g. a genuinely forbidden standard key).
3. **Does not apply** the Fire Pass exception to non-Fireworks providers (same body shape → still rejected).
4. **Rejects** a Fireworks `401` even if the body somehow mentions Fire Pass (wrong status code, not the known pattern).

## Why `body.includes('Fire Pass')` is not enough

An exact JSON parse guards against body corruption and accidental substring collisions. The check requires both `code === 'FORBIDDEN'` AND `message.includes('Fire Pass')` so that future Fireworks error shapes with only one field do not accidentally pass.

## Why this is Fireworks-only

The exception is gated on `providerId === 'fireworks'` before the body is even read. No other provider has a documented key class that uses `403` to signal valid-but-scope-limited authentication.

## Files

| File | Change |
|---|---|
| `src/init/validate-api-key.ts` | +31 — `isFireworksFirePassForbidden` helper, Fire Pass exception branch in `validateApiKey` |
| `src/init/validate-api-key.test.ts` | +55 — 4 new tests covering accept, reject-no-marker, cross-provider isolation, wrong-status |
