### PR TITLE
memory: drop topics-reading + gate idle/end spawns + thread daily-stream cursor

### DIFF
--- a/src/bundled-plugins/memory/README.md
+++ b/src/bundled-plugins/memory/README.md
@@ -12,6 +12,7 @@ Auto-loaded by every TypeClaw agent. No `plugins[]` entry to add and no opt-out.
     "idleMs": 60000,
     "bufferBytes": 500000,
     "injectionBudgetBytes": 16384,
+    "minIdleDeltaLines": 3,
     "dreaming": { "schedule": "*/30 * * * *" }
   }
 }
@@ -22,6 +23,7 @@ Auto-loaded by every TypeClaw agent. No `plugins[]` entry to add and no opt-out.
 | `memory.idleMs`               | `60000`          | Debounce window before `memory-logger` spawns after a prompt completes. Minimum `1000`.                                                                                                                                                        |
 | `memory.bufferBytes`          | `500000`         | Size-based ceiling: spawns `memory-logger` when the transcript grows by this many bytes since the last run. `0` disables. Minimum `10000` when non-zero.                                                                                       |
 | `memory.injectionBudgetBytes` | `16384`          | Total shard-body budget for direct-mode memory injection. Above this, `loadMemory` switches to index-mode (headings + metadata only) and the agent must call `memory_search` to fetch specific topics or recent stream events. Minimum `4096`. |
+| `memory.minIdleDeltaLines`    | `3`              | Minimum JSONL line growth since the last `memory-logger` run required to fire an idle spawn. Below this, the idle timer ticks but no spawn fires. `0` disables (legacy always-fire-on-idle behavior). Independent of `bufferBytes`.            |
 | `memory.dreaming.schedule`    | `"*/30 * * * *"` | Five-field cron expression for the dreaming subagent.                                                                                                                                                                                          |
 
 All fields are **restart-required** — the plugin reads them once at boot.
@@ -108,11 +110,21 @@ The migration is idempotent and crash-safe.
 
 ## How `session.idle` works
 
-Core fires `session.idle` immediately after every `session.prompt()` completion. The plugin owns the debounce: a `Map<sessionId, Timeout>` reset on every event. When the timer fires, the plugin spawns `memory-logger` for that session.
+Core fires `session.idle` immediately after every `session.prompt()` completion. The plugin owns the debounce: a `Map<sessionId, Timeout>` reset on every event. When the timer fires, the plugin spawns `memory-logger` for that session — unless the min-delta gate suppresses the spawn (see below).
 
-If the user starts a new prompt before the timer fires, the next `session.idle` resets it. If the user disconnects, `session.end` cancels the timer and fires `memory-logger` immediately.
+If the user starts a new prompt before the timer fires, the next `session.idle` resets it. If the user disconnects, `session.end` cancels the timer and fires `memory-logger` immediately (unless the byte-equality skip suppresses it; see below).
 
 In busy channel sessions the agent rarely goes idle long enough to trip the timer. The size-based ceiling handles this: on every `session.idle` the plugin `fs.stat`s the transcript and compares against the size at the last memory-logger run. Once growth reaches `memory.bufferBytes`, the timer is cancelled and `memory-logger` spawns immediately.
+
+### Min-delta gate (idle)
+
+The `session.idle` hook fires after every prompt completion. A chatty channel session that briefly quiets four times in seven minutes would otherwise pay the per-spawn floor (system-prompt prefill + stream-file read + several decision-making turns) on each tick — even when only a handful of new transcript lines have arrived, almost certainly containing nothing memorable.
+
+`memory.minIdleDeltaLines` (default `3`) gates the idle-timer spawn: when the timer fires, if the transcript grew by fewer than this many JSONL lines since the last memory-logger run for the session, the spawn is skipped. The skip is logged as `memory-logger idle skip ses_X (delta below minIdleDeltaLines=N)`. The buffer-trip path is unaffected — sessions that grow `bufferBytes` of unread transcript still spawn regardless of line delta.
+
+### Byte-equality skip (session.end)
+
+When `session.end` arrives and an earlier idle/buffer-trip spawn already drained the transcript to its current size, the session-end spawn is skipped. The skip is logged as `memory-logger session-end skip ses_X (no new bytes since last spawn at N)`. The skip only applies when a real baseline was recorded (`bytesAtLastRun > 0`); sessions that ended before any spawn ran still fire on close.
 
 ## Tests
 

--- a/src/bundled-plugins/memory/README.md
+++ b/src/bundled-plugins/memory/README.md
@@ -126,6 +126,10 @@ The `session.idle` hook fires after every prompt completion. A chatty channel se
 
 When `session.end` arrives and an earlier idle/buffer-trip spawn already drained the transcript to its current size, the session-end spawn is skipped. The skip is logged as `memory-logger session-end skip ses_X (no new bytes since last spawn at N)`. The skip only applies when a real baseline was recorded (`bytesAtLastRun > 0`); sessions that ended before any spawn ran still fire on close.
 
+### Daily-stream cursor (memory-logger payload)
+
+Each `memory-logger` spawn captures the line count of `memory/streams/<today>.jsonl` at the END of its run and stamps it on a per-`parentSessionId` cursor keyed by today's date. The NEXT spawn for the same session on the same day receives `streamLineCursor: N` in its payload — the subagent uses it to skip ahead to `offset=N+1` if it does the optional local-dedup read of today's stream. The cursor is dropped on cross-day rollover (yesterday's cursor points into yesterday's file, which is no longer the spawn's target) and on `session.end`.
+
 ## Tests
 
 Test files in this directory (kebab-case, `.test.ts` neighbors): `paths`, `slug`, `frontmatter`, `topics`, `shard-snapshot`, `delete-tool`, `citations`, `citation-superset`, `migration`, `load-shards`, `load-memory`, `injection-plan`, `search-tool`, `memory-retrieval`, `memory-logger`, `dreaming`, `index`, `integration`. Plus guard policies in `../guard/policies/`: `memory-topics-delete`, `memory-topics-write`, `memory-retrieval-cache-write`.

--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -18,10 +18,11 @@ import type {
   SessionTurnStartEvent,
 } from '@/plugin'
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
+import { formatLocalDate } from '@/shared'
 
 import { renderShard } from './frontmatter'
 import memoryPlugin from './index'
-import { topicShardPath, topicsDir } from './paths'
+import { streamFilePath, topicShardPath, topicsDir } from './paths'
 
 // Fake timers replace ~10s of real setTimeout waits used to exercise the idle
 // debouncer and spawn-timeout race. Date is included in `toFake` so the
@@ -1075,6 +1076,105 @@ describe('session.end byte-equality skip', () => {
     // then: spawn fires (baseline === undefined means "always fire")
     await waitFor(() => spawned.length >= 1, 'session-end spawn fires with no baseline')
     expect(spawned).toHaveLength(1)
+  })
+})
+
+describe('stream line cursor', () => {
+  beforeEach(installFakeClock)
+  afterEach(uninstallFakeClock)
+
+  test('first spawn for a session has no streamLineCursor in the payload', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'a'.repeat(15_000))
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 60_000,
+      bufferBytes: 10_000,
+      minIdleDeltaLines: 0,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    await exports.hooks!['session.idle']!(event, ctx)
+    await appendFile(transcript, 'b'.repeat(10_000))
+    await exports.hooks!['session.idle']!(event, ctx)
+    await waitFor(() => spawned.length >= 1, 'first spawn')
+
+    expect(spawned[0]!.payload).not.toHaveProperty('streamLineCursor')
+  })
+
+  test('subsequent spawn for the same session on the same day carries a streamLineCursor reflecting the daily-stream line count', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'a'.repeat(15_000))
+
+    // pre-seed today's daily stream with two lines (e.g. earlier sessions today)
+    const today = formatLocalDate()
+    const streamPath = streamFilePath(agentDir, today)
+    await mkdir(join(agentDir, 'memory', 'streams'), { recursive: true })
+    await writeFile(streamPath, '{"kind":"fragment"}\n{"kind":"watermark"}\n')
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 60_000,
+      bufferBytes: 10_000,
+      minIdleDeltaLines: 0,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    // first spawn (via buffer-trip) — its post-spawn read of the daily stream
+    // sees the 2 pre-seeded lines and stamps the cursor as 2
+    await exports.hooks!['session.idle']!(event, ctx)
+    await appendFile(transcript, 'b'.repeat(10_000))
+    await exports.hooks!['session.idle']!(event, ctx)
+    await waitFor(() => spawned.length >= 1, 'first spawn')
+
+    // allow the post-spawn cursor-stamp microtask to run
+    await new Promise((r) => setImmediate(r))
+
+    // second spawn — should carry streamLineCursor=2 (set by the first spawn's
+    // post-spawn read of the daily stream)
+    await appendFile(transcript, 'c'.repeat(10_000))
+    await exports.hooks!['session.idle']!(event, ctx)
+    await waitFor(() => spawned.length >= 2, 'second spawn')
+
+    expect(spawned[1]!.payload).toHaveProperty('streamLineCursor', 2)
+  })
+
+  test("cursor is per-session — session B does not inherit session A's cursor", async () => {
+    const transcriptA = join(agentDir, 'a.jsonl')
+    const transcriptB = join(agentDir, 'b.jsonl')
+    await writeFile(transcriptA, 'a'.repeat(15_000))
+    await writeFile(transcriptB, 'b'.repeat(15_000))
+
+    // pre-seed today's daily stream with three lines
+    const today = formatLocalDate()
+    const streamPath = streamFilePath(agentDir, today)
+    await mkdir(join(agentDir, 'memory', 'streams'), { recursive: true })
+    await writeFile(streamPath, '{"a":1}\n{"a":2}\n{"a":3}\n')
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 60_000,
+      bufferBytes: 10_000,
+      minIdleDeltaLines: 0,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+
+    // session A spawns first; cursor for ses_a gets set to 3
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_a', parentTranscriptPath: transcriptA, idleMs: 0 }, ctx)
+    await appendFile(transcriptA, 'x'.repeat(10_000))
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_a', parentTranscriptPath: transcriptA, idleMs: 0 }, ctx)
+    await waitFor(() => spawned.length >= 1, 'session A first spawn')
+    await new Promise((r) => setImmediate(r))
+
+    // session B's first spawn — should NOT see session A's cursor
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_b', parentTranscriptPath: transcriptB, idleMs: 0 }, ctx)
+    await appendFile(transcriptB, 'y'.repeat(10_000))
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_b', parentTranscriptPath: transcriptB, idleMs: 0 }, ctx)
+    await waitFor(() => spawned.length >= 2, 'session B first spawn')
+
+    const sessionBSpawn = spawned.find((s) => (s.payload as { parentSessionId: string }).parentSessionId === 'ses_b')
+    expect(sessionBSpawn).toBeDefined()
+    expect(sessionBSpawn!.payload).not.toHaveProperty('streamLineCursor')
   })
 })
 

--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -862,6 +862,222 @@ describe('session.idle hook (buffer-bytes ceiling)', () => {
   })
 })
 
+describe('session.idle min-delta gate', () => {
+  beforeEach(installFakeClock)
+  afterEach(uninstallFakeClock)
+
+  test('skips idle spawn when transcript line growth is below minIdleDeltaLines', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'a\nb\n')
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 1000,
+      bufferBytes: 0,
+      minIdleDeltaLines: 3,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    // given: 2-line transcript, no prior spawn (baseline absent → 0). Delta=2 < 3.
+    await exports.hooks!['session.idle']!(event, ctx)
+    // when: idleMs elapses (gate runs at timer-fire)
+    await tickMs(1100)
+    await tickMs(50)
+    // then: no spawn
+    expect(spawned).toHaveLength(0)
+  })
+
+  test('fires idle spawn when transcript line growth meets minIdleDeltaLines', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'a\nb\nc\nd\n')
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 1000,
+      bufferBytes: 0,
+      minIdleDeltaLines: 3,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    // 4 lines, baseline=0, delta=4 >= 3 → spawn
+    await exports.hooks!['session.idle']!(event, ctx)
+    await tickMs(1100)
+    await waitFor(() => spawned.length >= 1, 'idle spawn fires when delta >= minIdleDeltaLines')
+    expect(spawned).toHaveLength(1)
+  })
+
+  test('skips subsequent idle spawn when new lines since last spawn is below threshold', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'a\nb\nc\nd\ne\n')
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 1000,
+      bufferBytes: 0,
+      minIdleDeltaLines: 3,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    // given: first idle spawns (5 lines vs baseline 0)
+    await exports.hooks!['session.idle']!(event, ctx)
+    await tickMs(1100)
+    await waitFor(() => spawned.length >= 1, 'first idle spawns')
+    expect(spawned).toHaveLength(1)
+
+    // when: 2 more lines arrive (delta = 2 from baseline of 5) and idle fires again
+    await appendFile(transcript, 'f\ng\n')
+    await exports.hooks!['session.idle']!(event, ctx)
+    await tickMs(1100)
+    // then: no second spawn (2 < 3)
+    expect(spawned).toHaveLength(1)
+
+    // and: when one more line arrives (delta = 3), idle does spawn
+    await appendFile(transcript, 'h\n')
+    await exports.hooks!['session.idle']!(event, ctx)
+    await tickMs(1100)
+    await waitFor(() => spawned.length >= 2, 'second idle spawns when delta reaches threshold')
+    expect(spawned).toHaveLength(2)
+  })
+
+  test('minIdleDeltaLines=0 disables the gate (legacy always-fire behavior)', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'a\n')
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 1000,
+      bufferBytes: 0,
+      minIdleDeltaLines: 0,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    await exports.hooks!['session.idle']!(event, ctx)
+    await tickMs(1100)
+    await waitFor(() => spawned.length >= 1, 'spawn fires when gate is disabled')
+    expect(spawned).toHaveLength(1)
+  })
+
+  test('zero-line transcript is not gated — preserves legacy "fire and let logger decide" behavior', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, '')
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 1000,
+      bufferBytes: 0,
+      minIdleDeltaLines: 3,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    await exports.hooks!['session.idle']!(event, ctx)
+    await tickMs(1100)
+    await waitFor(() => spawned.length >= 1, 'empty-transcript spawn still fires')
+    expect(spawned).toHaveLength(1)
+  })
+
+  test('buffer-trip path is independent of minIdleDeltaLines', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'a\n')
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 60_000,
+      bufferBytes: 10_000,
+      minIdleDeltaLines: 1000,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    // given: baseline initialized
+    await exports.hooks!['session.idle']!(event, ctx)
+    // when: byte growth crosses bufferBytes (only 2 lines added, well below 1000-line gate)
+    await appendFile(transcript, 'b'.repeat(11_000))
+    await exports.hooks!['session.idle']!(event, ctx)
+    // then: buffer-trip fires synchronously despite the gate
+    expect(spawned).toHaveLength(1)
+  })
+})
+
+describe('session.end byte-equality skip', () => {
+  beforeEach(installFakeClock)
+  afterEach(uninstallFakeClock)
+
+  test('skips spawn when session.end arrives with no new bytes since the last logger run', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'a'.repeat(15_000))
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 60_000,
+      bufferBytes: 10_000,
+      minIdleDeltaLines: 0,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    // given: first idle initializes baseline at 15_000 bytes (no spawn)
+    await exports.hooks!['session.idle']!(event, ctx)
+    // when: transcript crosses bufferBytes and idle fires → buffer-trip spawn (baseline now 25_000)
+    await appendFile(transcript, 'b'.repeat(10_000))
+    await exports.hooks!['session.idle']!(event, ctx)
+    await waitFor(() => spawned.length >= 1, 'buffer-trip spawn')
+    expect(spawned).toHaveLength(1)
+
+    // when: session.end arrives with no new bytes
+    await exports.hooks!['session.end']!({ sessionId: 'ses_a' } as SessionEndEvent, ctx)
+    // give the async session.end body a microtask to settle
+    await tickMs(50)
+    // then: no second spawn — the buffer-trip already drained this transcript
+    expect(spawned).toHaveLength(1)
+  })
+
+  test('still spawns on session.end when transcript grew since the last logger run', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'a'.repeat(15_000))
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 60_000,
+      bufferBytes: 10_000,
+      minIdleDeltaLines: 0,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    await exports.hooks!['session.idle']!(event, ctx)
+    await appendFile(transcript, 'b'.repeat(10_000))
+    await exports.hooks!['session.idle']!(event, ctx)
+    await waitFor(() => spawned.length >= 1, 'buffer-trip spawn')
+
+    // given: transcript grows again after the spawn
+    await appendFile(transcript, 'c'.repeat(500))
+    // when: session.end arrives
+    await exports.hooks!['session.end']!({ sessionId: 'ses_a' } as SessionEndEvent, ctx)
+
+    // then: a second spawn fires (delta = 500 bytes > 0)
+    await waitFor(() => spawned.length >= 2, 'session-end spawn fires when transcript grew')
+    expect(spawned).toHaveLength(2)
+  })
+
+  test('still spawns on session.end when no prior logger run set a baseline', async () => {
+    const transcript = join(agentDir, 'transcript.jsonl')
+    await writeFile(transcript, 'a'.repeat(5000))
+
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, {
+      idleMs: 60_000,
+      bufferBytes: 0,
+      minIdleDeltaLines: 0,
+    })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+    const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: transcript, idleMs: 0 }
+
+    // given: idle event set lastIdleEvent (so session.end knows the path), but no prior spawn
+    await exports.hooks!['session.idle']!(event, ctx)
+    // when: session.end fires before any logger spawn has set a baseline
+    await exports.hooks!['session.end']!({ sessionId: 'ses_a' } as SessionEndEvent, ctx)
+    // then: spawn fires (baseline === undefined means "always fire")
+    await waitFor(() => spawned.length >= 1, 'session-end spawn fires with no baseline')
+    expect(spawned).toHaveLength(1)
+  })
+})
+
 describe('per-agent spawn serialization', () => {
   // Real time used here. These tests assert non-overlap via Date.now() inside
   // the mock spawnSubagent (which captures startedAt / finishedAt). Total real

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 
 import type { SessionOrigin } from '@/agent/session-origin'
 import { definePlugin } from '@/plugin'
+import { formatLocalDate } from '@/shared'
 
 import { createDreamingSubagent, type DreamingPayload } from './dreaming'
 import { buildInjectionPlan, DEFAULT_INJECTION_BUDGET_BYTES, MIN_INJECTION_BUDGET_BYTES } from './injection-plan'
@@ -164,6 +165,12 @@ export default definePlugin({
     const lastIdleEvent = new Map<string, { parentTranscriptPath: string | undefined; origin?: SessionOrigin }>()
     const bytesAtLastRun = new Map<string, number>()
     const linesAtLastRun = new Map<string, number>()
+    // Per-session stream-file cursor: the JSONL line count of the daily
+    // stream file at the END of this session's most recent memory-logger
+    // spawn. Keyed by sessionId, valued by `{ date, lineCount }`. Honored
+    // only when `date` matches today's date — yesterday's cursor points
+    // into yesterday's file and the spawn's payload omits it.
+    const streamCursorAtLastRun = new Map<string, { date: string; lineCount: number }>()
 
     // memory-logger is coalesced per agentDir (not per parentSessionId) so that
     // two concurrent channel sessions for the same agent never write to the same
@@ -187,11 +194,16 @@ export default definePlugin({
       const last = lastIdleEvent.get(sessionId)
       if (!last || last.parentTranscriptPath === undefined) return Promise.resolve()
       const parentTranscriptPath = last.parentTranscriptPath
+      const today = formatLocalDate()
+      const priorCursor = streamCursorAtLastRun.get(sessionId)
+      const streamLineCursor =
+        priorCursor !== undefined && priorCursor.date === today ? priorCursor.lineCount : undefined
       const payload: MemoryLoggerPayload = {
         parentSessionId: sessionId,
         parentTranscriptPath,
         agentDir: ctx.agentDir,
         ...(last.origin !== undefined ? { origin: last.origin } : {}),
+        ...(streamLineCursor !== undefined ? { streamLineCursor } : {}),
       }
       const spawnOptions = {
         parentSessionId: sessionId,
@@ -210,6 +222,14 @@ export default definePlugin({
           } catch (err) {
             ctx.logger.error(`memory-logger spawn failed: ${err instanceof Error ? err.message : String(err)}`)
           }
+          // Capture the daily-stream line count POST-spawn so the next spawn
+          // (in the same session, on the same day) can resume past anything
+          // this spawn appended. Tied to today's date — `fireMemoryLogger`
+          // checks the date before honoring the cursor.
+          const todayAfterSpawn = formatLocalDate()
+          const streamPath = streamFilePath(ctx.agentDir, todayAfterSpawn)
+          const streamLineCount = await readLineCount(streamPath)
+          streamCursorAtLastRun.set(sessionId, { date: todayAfterSpawn, lineCount: streamLineCount })
         })
       spawnChain = next
       return next
@@ -458,6 +478,7 @@ export default definePlugin({
             lastIdleEvent.delete(sessionId)
             bytesAtLastRun.delete(sessionId)
             linesAtLastRun.delete(sessionId)
+            streamCursorAtLastRun.delete(sessionId)
           })()
           const cacheFilePath = join(ctx.agentDir, 'memory', '.retrieval-cache', `${sessionId}.md`)
           unlink(cacheFilePath).catch((err) => {

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { access, constants as fsConstants, mkdir, readdir, stat, unlink, writeFile } from 'node:fs/promises'
+import { access, constants as fsConstants, mkdir, readFile, readdir, stat, unlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { CronExpressionParser } from 'cron-parser'
@@ -20,6 +20,22 @@ import { memorySearchTool } from './search-tool'
 const DEFAULT_IDLE_MS = 60_000
 const DEFAULT_BUFFER_BYTES = 500_000
 const MIN_BUFFER_BYTES = 10_000
+// Minimum JSONL line growth since the last memory-logger run required to spawn
+// on a plain `session.idle` tick. The hook fires after every prompt completion,
+// so a chatty channel session that goes briefly quiet 4 times in 7 minutes
+// would otherwise pay the full per-spawn floor (~50 KB context + 4-11 turns of
+// LLM decision-making) on each tick — even when the new transcript content is
+// a handful of lines almost certain to contain nothing memorable.
+//
+// Gate semantics: skip the spawn when (currentLines - linesAtLastRun) < N AND
+// the transcript file actually exists with at least one line. A zero-line
+// transcript (test dummies, brand-new sessions) is NOT gated — the existing
+// "fire and let memory-logger decide" behavior is preserved.
+//
+// The buffer-trip path (size-based ceiling) is independent and unaffected:
+// busy sessions that grow `bufferBytes` of unread transcript still spawn
+// regardless of the idle delta.
+const DEFAULT_MIN_IDLE_DELTA_LINES = 3
 // 30-minute default. Fires short-circuit before any LLM call when nothing
 // sits past the watermark (`dreaming.ts` handler returns when
 // `snapshots.undreamed.length === 0`), so frequent no-op fires are cheap.
@@ -92,6 +108,7 @@ const memoryConfigSchema = z
       })
       .default(DEFAULT_BUFFER_BYTES),
     injectionBudgetBytes: z.number().int().min(MIN_INJECTION_BUDGET_BYTES).default(DEFAULT_INJECTION_BUDGET_BYTES),
+    minIdleDeltaLines: z.number().int().min(0).default(DEFAULT_MIN_IDLE_DELTA_LINES),
     // Test seam: per-spawn ceiling for memory-logger. Operators have no
     // reason to tune this; it exists so the wedge-recovery test can fire
     // the timeout in milliseconds instead of the production 50s. Kept
@@ -108,6 +125,7 @@ const memoryConfigSchema = z
     idleMs: DEFAULT_IDLE_MS,
     bufferBytes: DEFAULT_BUFFER_BYTES,
     injectionBudgetBytes: DEFAULT_INJECTION_BUDGET_BYTES,
+    minIdleDeltaLines: DEFAULT_MIN_IDLE_DELTA_LINES,
     spawnTimeoutMs: SPAWN_TIMEOUT_MS,
     retrievalSpawnTimeoutMs: RETRIEVAL_SPAWN_TIMEOUT_MS,
   })
@@ -117,6 +135,7 @@ export default definePlugin({
   plugin: async (ctx) => {
     const idleMs = ctx.config.idleMs
     const bufferBytes = ctx.config.bufferBytes
+    const minIdleDeltaLines = ctx.config.minIdleDeltaLines
     const spawnTimeoutMs = ctx.config.spawnTimeoutMs
     const retrievalSpawnTimeoutMs = ctx.config.retrievalSpawnTimeoutMs
     const dreamingSchedule = ctx.config.dreaming?.schedule ?? DEFAULT_DREAMING_SCHEDULE
@@ -144,6 +163,7 @@ export default definePlugin({
     const idleTimers = new Map<string, ReturnType<typeof setTimeout>>()
     const lastIdleEvent = new Map<string, { parentTranscriptPath: string | undefined; origin?: SessionOrigin }>()
     const bytesAtLastRun = new Map<string, number>()
+    const linesAtLastRun = new Map<string, number>()
 
     // memory-logger is coalesced per agentDir (not per parentSessionId) so that
     // two concurrent channel sessions for the same agent never write to the same
@@ -181,7 +201,9 @@ export default definePlugin({
         .catch(() => undefined)
         .then(async () => {
           const currentSize = await readSize(parentTranscriptPath)
+          const currentLines = await readLineCount(parentTranscriptPath)
           bytesAtLastRun.set(sessionId, currentSize)
+          linesAtLastRun.set(sessionId, currentLines)
           ctx.logger.info(`memory-logger spawn ${sessionId} reason=${reason} transcript_bytes=${currentSize}`)
           try {
             await raceSpawn(ctx.spawnSubagent('memory-logger', payload, spawnOptions), spawnTimeoutMs)
@@ -210,6 +232,14 @@ export default definePlugin({
         return false
       }
       return currentSize - baseline >= bufferBytes
+    }
+
+    const shouldSkipIdleSpawn = async (sessionId: string, transcriptPath: string): Promise<boolean> => {
+      if (minIdleDeltaLines === 0) return false
+      const currentLines = await readLineCount(transcriptPath)
+      if (currentLines === 0) return false
+      const baseline = linesAtLastRun.get(sessionId) ?? 0
+      return currentLines - baseline < minIdleDeltaLines
     }
 
     const runMemoryRetrieval = async (event: {
@@ -295,9 +325,18 @@ export default definePlugin({
           })
           cancelTimer(event.sessionId)
           const sessionId = event.sessionId
+          const transcriptPath = event.parentTranscriptPath
           const timer = setTimeout(() => {
             idleTimers.delete(sessionId)
-            void fireMemoryLogger(sessionId, 'idle')
+            void (async () => {
+              if (transcriptPath !== undefined && (await shouldSkipIdleSpawn(sessionId, transcriptPath))) {
+                ctx.logger.info(
+                  `memory-logger idle skip ${sessionId} (delta below minIdleDeltaLines=${minIdleDeltaLines})`,
+                )
+                return
+              }
+              void fireMemoryLogger(sessionId, 'idle')
+            })()
           }, idleMs)
           idleTimers.set(sessionId, timer)
           if (
@@ -390,13 +429,40 @@ export default definePlugin({
         'session.end': (event) => {
           if (event.origin?.kind === 'subagent') return
           cancelTimer(event.sessionId)
-          void fireMemoryLogger(event.sessionId, 'session-end')
-          const cacheFilePath = join(ctx.agentDir, 'memory', '.retrieval-cache', `${event.sessionId}.md`)
+          const sessionId = event.sessionId
+          // The skip path detaches via `void (async () => …)()` because
+          // readSize requires an await. fireMemoryLogger itself captures its
+          // payload synchronously from `lastIdleEvent` (see fireMemoryLogger
+          // comment block), so the `lastIdleEvent.delete` that follows can
+          // never race with the chained spawn. The cache-cleanup and
+          // bookkeeping deletes are dispatched alongside (not blocking the
+          // hook return) to preserve the "session.end returns synchronously"
+          // contract that the channel router's tearDownLive path depends on
+          // (see the comment block above this hook).
+          void (async () => {
+            const last = lastIdleEvent.get(sessionId)
+            let skip = false
+            if (last?.parentTranscriptPath !== undefined) {
+              const baseline = bytesAtLastRun.get(sessionId)
+              if (baseline !== undefined && baseline > 0) {
+                const currentSize = await readSize(last.parentTranscriptPath)
+                if (currentSize === baseline) {
+                  ctx.logger.info(
+                    `memory-logger session-end skip ${sessionId} (no new bytes since last spawn at ${baseline})`,
+                  )
+                  skip = true
+                }
+              }
+            }
+            if (!skip) void fireMemoryLogger(sessionId, 'session-end')
+            lastIdleEvent.delete(sessionId)
+            bytesAtLastRun.delete(sessionId)
+            linesAtLastRun.delete(sessionId)
+          })()
+          const cacheFilePath = join(ctx.agentDir, 'memory', '.retrieval-cache', `${sessionId}.md`)
           unlink(cacheFilePath).catch((err) => {
             if (!isEnoent(err)) ctx.logger.warn(`[memory] failed to clean retrieval cache: ${err}`)
           })
-          lastIdleEvent.delete(event.sessionId)
-          bytesAtLastRun.delete(event.sessionId)
         },
       },
       doctorChecks: {
@@ -611,6 +677,21 @@ async function readSize(path: string): Promise<number> {
   try {
     const s = await stat(path)
     return s.size
+  } catch {
+    return 0
+  }
+}
+
+async function readLineCount(path: string): Promise<number> {
+  try {
+    const buf = await readFile(path)
+    if (buf.length === 0) return 0
+    let count = 0
+    for (let i = 0; i < buf.length; i++) {
+      if (buf[i] === 0x0a) count++
+    }
+    if (buf[buf.length - 1] !== 0x0a) count++
+    return count
   } catch {
     return 0
   }

--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -145,6 +145,11 @@ describe('MEMORY_LOGGER_SYSTEM_PROMPT', () => {
     expect(MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()).toContain('dreaming')
   })
 
+  test('teaches the subagent to respect the optional Stream line cursor when present', () => {
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/Stream line cursor:/)
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/offset=N\+1/i)
+  })
+
   test("does not direct the subagent to read memory/topics/ — cross-shard reasoning is dreaming's concern", () => {
     // Positive prohibition is present.
     expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/you do not read `memory\/topics\/`|do not read memory\/topics\//i)
@@ -437,6 +442,35 @@ describe('memoryLoggerSubagent', () => {
     expect(prompt).not.toContain(join(agentDir, 'memory', 'topics'))
     expect(prompt).not.toMatch(/(?:^|[^a-z])Read `?memory\/topics\/`?/m)
     expect(prompt).not.toMatch(/read `?memory\/topics\/`? (?:and|first|to)/i)
+  })
+
+  test('handler emits Stream line cursor line when streamLineCursor is in the payload', async () => {
+    const agentDir = makeAgentDir()
+    const transcript = join(agentDir, 'sessions', 'ses_abc.jsonl')
+    writeFileSync(transcript, '')
+
+    const { runSessionCalls } = await invokeWith(
+      { parentSessionId: 'ses_abc', parentTranscriptPath: transcript, agentDir, streamLineCursor: 7 },
+      agentDir,
+    )
+
+    const prompt = runSessionCalls[0]!.userPrompt!
+    expect(prompt).toMatch(/Stream line cursor: 7/)
+    expect(prompt).toMatch(/offset=8/)
+  })
+
+  test('handler omits Stream line cursor line when payload has no streamLineCursor', async () => {
+    const agentDir = makeAgentDir()
+    const transcript = join(agentDir, 'sessions', 'ses_abc.jsonl')
+    writeFileSync(transcript, '')
+
+    const { runSessionCalls } = await invokeWith(
+      { parentSessionId: 'ses_abc', parentTranscriptPath: transcript, agentDir },
+      agentDir,
+    )
+
+    const prompt = runSessionCalls[0]!.userPrompt!
+    expect(prompt).not.toMatch(/Stream line cursor:/)
   })
 
   test('handler indicates "no prior watermark" when none exists', async () => {

--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -145,6 +145,15 @@ describe('MEMORY_LOGGER_SYSTEM_PROMPT', () => {
     expect(MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()).toContain('dreaming')
   })
 
+  test("does not direct the subagent to read memory/topics/ — cross-shard reasoning is dreaming's concern", () => {
+    // Positive prohibition is present.
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/you do not read `memory\/topics\/`|do not read memory\/topics\//i)
+    // No imperative instructing the subagent TO read topics (matches "Read memory/topics/" or
+    // "read memory/topics/ and ..." style instructions, regardless of leading capitalization).
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).not.toMatch(/(?:^|[^a-z])Read `?memory\/topics\/`?/m)
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).not.toMatch(/read `?memory\/topics\/`? (?:and|first|to)/i)
+  })
+
   test('declares a watermark contract that handles the zero-fragment case', () => {
     expect(MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()).toContain('watermark')
   })
@@ -414,7 +423,7 @@ describe('memoryLoggerSubagent', () => {
     expect(prompt.toLowerCase()).toMatch(/per-fragment provenance|specific transcript entry that anchors/i)
   })
 
-  test('handler points the subagent at memory/topics/ so it can read existing memory first', async () => {
+  test("handler does NOT instruct the subagent to read memory/topics/ — that is dreaming's concern", async () => {
     const agentDir = makeAgentDir()
     const transcript = join(agentDir, 'sessions', 'ses_abc.jsonl')
     writeFileSync(transcript, '')
@@ -424,8 +433,10 @@ describe('memoryLoggerSubagent', () => {
       agentDir,
     )
 
-    expect(runSessionCalls[0]!.userPrompt!).toContain(join(agentDir, 'memory', 'topics'))
-    expect(runSessionCalls[0]!.userPrompt!).toMatch(/read memory\/topics\//i)
+    const prompt = runSessionCalls[0]!.userPrompt!
+    expect(prompt).not.toContain(join(agentDir, 'memory', 'topics'))
+    expect(prompt).not.toMatch(/(?:^|[^a-z])Read `?memory\/topics\/`?/m)
+    expect(prompt).not.toMatch(/read `?memory\/topics\/`? (?:and|first|to)/i)
   })
 
   test('handler indicates "no prior watermark" when none exists', async () => {

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -14,6 +14,13 @@ export const memoryLoggerPayloadSchema = z.object({
   parentTranscriptPath: z.string().min(1),
   agentDir: z.string().min(1),
   origin: z.custom<SessionOrigin>().optional(),
+  // Optional line cursor into today's daily stream file. When present, the
+  // subagent can skip ahead to this line when doing the (optional) local-dedup
+  // read — every line at or before this cursor was already in place at the
+  // end of the prior memory-logger spawn for this parent session today.
+  // Set by the plugin host at spawn time. Absent on the first spawn of the
+  // day, or when the prior spawn was for a different daily file.
+  streamLineCursor: z.number().int().nonnegative().optional(),
 })
 
 // Recovery message for the read-budget short-circuit. The watermark contract
@@ -144,6 +151,8 @@ The \`append\` tool refuses byte-equivalent fragments within the same daily stre
 
 You MAY read \`memory/streams/yyyy-MM-dd.jsonl\` if you want to avoid writing a fragment that is semantically a near-copy of one another spawn in this session has already written today. This is a soft check, not required. If you do read it, read it cheaply: skim the most recent few fragments (the file is append-only, newest entries at the bottom). Do not read the entire file on every spawn — earlier fragments from earlier sessions today are irrelevant to your dedup decision.
 
+When the runtime provides a \`Stream line cursor: N\` in your initial prompt, every line at or before line N was already in place at the end of the prior memory-logger spawn for this parent session. If you do the optional dedup read, pass \`offset=N+1\` to \`read\` so you only see lines this session has not yet evaluated. Absent cursor → start at \`offset=1\` if you choose to read at all.
+
 Recurrence is not duplication. If the transcript shows the same durable preference, pattern, workaround, or commitment occurring again, write a concise recurrence fragment anchored to the new evidence. The dreaming subagent uses distinct-day recurrence to promote tentative facts to confident ones; refusing to write the second or third occurrence starves that signal.
 
 # Fragment format
@@ -201,6 +210,11 @@ function buildInitialPrompt(payload: MemoryLoggerPayload, streamFile: string, wa
     `Transcript file: ${payload.parentTranscriptPath}`,
     `Daily stream file: ${streamFile}`,
   ]
+  if (payload.streamLineCursor !== undefined) {
+    lines.push(
+      `Stream line cursor: ${payload.streamLineCursor} (if you do the optional local-dedup read, start at offset=${payload.streamLineCursor + 1})`,
+    )
+  }
   const conversationContext = renderConversationContext(payload.origin)
   if (conversationContext !== null) lines.push('', conversationContext)
   if (watermark === null) {

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path'
-
 import { z } from 'zod'
 
 import type { SessionOrigin } from '@/agent/session-origin'
@@ -59,9 +57,11 @@ export function isMemoryLoggerPayload(value: unknown): value is MemoryLoggerPayl
 
 export const MEMORY_LOGGER_SYSTEM_PROMPT = `You are typeclaw's memory-extraction subagent.
 
-Your job is to read a session transcript and capture, as fragments, only the durable operational facts a future agent in a future session would concretely need — explicit user instructions, stable identity/role/tool facts, decisions with reasoning, reproducible workarounds, contradictions or violations of existing memory. You write zero or more fragments to today's memory stream file. Then you exit. Most runs produce zero or one fragment; that is the expected output, not a failure.
+Your job is to read a session transcript and capture, as fragments, only the durable operational facts a future agent in a future session would concretely need — explicit user instructions, stable identity/role/tool facts, decisions with reasoning, reproducible workarounds. You write zero or more fragments to today's memory stream file. Then you exit. Most runs produce zero or one fragment; that is the expected output, not a failure.
 
-A separate \`dreaming\` subagent runs later. It consolidates your fragments into long-term memory, dedupes, drops near-duplicates, resolves contradictions, and decides what generalizes. **Dreaming is downstream filtering, not an excuse to over-capture upstream.** Writing five low-signal fragments and trusting dreaming to throw four away wastes tokens at both layers and pollutes memory/topics/ in the interim. Be selective here.
+A separate \`dreaming\` subagent runs later. It consolidates your fragments into long-term memory under \`memory/topics/\`, dedupes near-duplicates across days, resolves contradictions against prior shards, and decides what generalizes. **Dreaming is downstream consolidation, not an excuse to over-capture upstream.** Writing five low-signal fragments and trusting dreaming to throw four away wastes tokens at both layers. Be selective here.
+
+**You do not read \`memory/topics/\`.** Cross-shard contradictions, violations of prior commitments, and semantic dedup against long-term memory are dreaming's job — dreaming has the global view and the authoritative pipeline position to resolve them; you do not. Your input is the parent transcript past your watermark, plus (optionally) today's daily stream for local dedup. That is enough. If a fragment you would write happens to recur a fact already in topics, dreaming will consolidate it — recurrence across distinct days is the signal dreaming uses to promote tentative facts to confident ones, so writing the recurrence is the correct behavior, not a duplicate.
 
 You have exactly four tools: \`read\`, \`find_entry\`, \`append\`, and the watermark-advance tool. You cannot run shell commands, overwrite files, or edit existing content.
 
@@ -110,9 +110,8 @@ Capture-worthy categories:
 - **Stable identity/role/tool facts that will keep mattering.** "User's project repo is X." "User runs Y on Z." Skip casual employment history, casual social-graph trivia, and "this person joined the chat" events — those are derivable from current context when needed.
 - **Decisions with reasoning.** "We chose X over Y because Z" — when X is something the agent will need to honor in a future session.
 - **Reproducible workarounds and non-trivial debugging insights.** Configuration that finally worked, a flag combination that bypassed a known block, a procedure with concrete steps.
-- **Contradictions of existing memory.** The user changed their mind, an old commitment no longer applies. Name the prior memory that is superseded.
-- **Violations of existing memory.** The agent just broke an existing commitment — capture the violation itself.
-- **Corrections the user made to the agent.** Specifically when the agent confidently asserted something false and the user corrected it, in a way that a future session would likely also get wrong.
+- **The user explicitly changing their mind in this session.** When the transcript itself contains "actually, scratch that" or "I changed my mind about X" with an explicit prior position, capture it. Do not try to detect contradictions against \`memory/topics/\` — dreaming handles that with the global view you lack.
+- **Corrections the user made to the agent.** Specifically when the agent confidently asserted something false and the user corrected it within this transcript, in a way that a future session would likely also get wrong.
 
 # What to skip (anti-patterns — these come up constantly)
 
@@ -122,7 +121,7 @@ Capture-worthy categories:
 - **Casual social-graph trivia.** "X used to work at Y." "Z is a friend of W." Skip unless the user explicitly says it will matter ("remember, X is the one who built our Y").
 - **Latency / performance pings.** "User asked how fast the agent responded." Not memory.
 - **The agent's own first-person observations.** "The agent admitted it does not know its model." "The agent replied in character." Skip — the agent is not memorable to itself.
-- **Re-derivable facts.** Anything obvious from the current session's system prompt, memory/topics/, AGENTS.md, or the channel context.
+- **Re-derivable facts.** Anything obvious from the current session's system prompt, AGENTS.md, or the channel context.
 - **Speculation untethered to a quote.** If you cannot point at a specific transcript line, do not write it.
 - **Multi-fragment expansions of one event.** One event produces at most one fragment. Splitting one introduction into "new chat", "new participant", "new participant's job", "new participant's reaction" is over-writing.
 
@@ -139,17 +138,13 @@ When a transcript exposes a credential — for example the agent ran \`env | gre
 
 The \`append\` tool will refuse content that contains a recognizable credential pattern. Treat that error as a bug in your fragment, not a tool limitation: rewrite the fragment to describe the variable name and its discovery, then retry.
 
-# Read existing memory first
+# Local dedup against today's daily stream
 
-Before reading the transcript, read \`memory/topics/\` and the current \`memory/streams/yyyy-MM-dd.jsonl\` stream file. You need that context for three reasons:
+The \`append\` tool refuses byte-equivalent fragments within the same daily stream — if your fragment's topic+body is identical to one already in today's file (modulo whitespace), the tool will reject it and you must rewrite. That refusal is the dedup contract; you do not need to pre-check by reading the file.
 
-- **Notice contradictions.** If the transcript supersedes existing memory, write a fragment that names the prior memory and supersedes it.
-- **Notice violations.** If existing memory contains a commitment the agent just broke, that's a high-value fragment.
-- **Avoid pure restatement.** If a fact is already in memory/topics/ word-for-word, don't write the same fragment again. But: if the transcript shows the same fact occurring a second time, that recurrence is itself worth a fragment — dreaming uses repetition to decide what's stable.
+You MAY read \`memory/streams/yyyy-MM-dd.jsonl\` if you want to avoid writing a fragment that is semantically a near-copy of one another spawn in this session has already written today. This is a soft check, not required. If you do read it, read it cheaply: skim the most recent few fragments (the file is append-only, newest entries at the bottom). Do not read the entire file on every spawn — earlier fragments from earlier sessions today are irrelevant to your dedup decision.
 
-Dedup byte-equivalent restatements, not meaningful recurrence. Do not write a fragment that is a near-copy of one already in memory/topics/ or today's stream. But when the transcript shows the same durable preference, pattern, workaround, or commitment recurring in a NEW session or on a NEW day, write a concise recurrence fragment anchored to the new evidence — even if the underlying fact is already known. The dreaming subagent uses distinct-day recurrence to promote tentative facts to confident ones; refusing to write the second or third occurrence starves that signal. The bar is "did the recurrence happen in a meaningfully new context", not "is the fact already on disk".
-
-The \`append\` tool refuses byte-equivalent fragments within the same daily stream — if your fragment's topic+body is identical to one already in today's file (modulo whitespace), the tool will reject it and you must rewrite. Two reasonable rewrites: (1) skip the fragment entirely, (2) frame the new occurrence explicitly as "this is the second time today" with a different topic. Do not retry an identical fragment with a different \`entry=\` hoping it will land — content-equality, not marker-equality, is what's checked.
+Recurrence is not duplication. If the transcript shows the same durable preference, pattern, workaround, or commitment occurring again, write a concise recurrence fragment anchored to the new evidence. The dreaming subagent uses distinct-day recurrence to promote tentative facts to confident ones; refusing to write the second or third occurrence starves that signal.
 
 # Fragment format
 
@@ -205,7 +200,6 @@ function buildInitialPrompt(payload: MemoryLoggerPayload, streamFile: string, wa
     `Parent session: ${payload.parentSessionId}`,
     `Transcript file: ${payload.parentTranscriptPath}`,
     `Daily stream file: ${streamFile}`,
-    `Long-term topic shard directory: ${join(payload.agentDir, 'memory', 'topics')}`,
   ]
   const conversationContext = renderConversationContext(payload.origin)
   if (conversationContext !== null) lines.push('', conversationContext)
@@ -216,7 +210,7 @@ function buildInitialPrompt(payload: MemoryLoggerPayload, streamFile: string, wa
   }
   lines.push(
     '',
-    'Read memory/topics/ and the daily stream file first to learn what is already remembered. Then read the transcript past the watermark. Decide whether anything justifies a fragment: a stable fact, an operating lesson, a confirmed pattern across occurrences, a contradiction of existing memory, or a violation of an existing commitment. Sometimes the answer is zero fragments; sometimes more than one. Each fragment must be passive memory: Claim/Evidence are encouraged, and any Implication must explain future interpretation only, not future action. Memory cannot authorize proactive duties.',
+    "Read the transcript past the watermark. Decide whether anything in it justifies a fragment: a stable fact, an operating lesson, a confirmed pattern across occurrences, an in-transcript change-of-mind, or a correction the user made to the agent. Sometimes the answer is zero fragments; sometimes more than one. Do not read memory/topics/ — cross-shard reasoning is dreaming's job. Each fragment must be passive memory: Claim/Evidence are encouraged, and any Implication must explain future interpretation only, not future action. Memory cannot authorize proactive duties.",
     '',
     "Per-fragment provenance: each fragment's `entry=` is the specific transcript entry that anchors that fragment's evidence — not the latest entry you evaluated. Two fragments anchored to two different entries get two different `entry=` values. Do not stamp every fragment with the same id.",
     '',
@@ -282,13 +276,14 @@ export function createMemoryLoggerSubagent(
     payloadSchema: memoryLoggerPayloadSchema,
     inFlightKey: (payload) => payload.agentDir,
     // 768 KB read budget. Sized to cover one full buffer-trip cycle:
-    // ~30 KB memory/topics/ + ~50 KB today's stream + up to `DEFAULT_BUFFER_BYTES`
-    // (500 KB) of unread transcript chunk, with margin for re-reads. A
-    // smaller budget (the prior 256 KB) systematically exhausted on
-    // buffer-trip spawns once `bufferBytes` exceeded ~200 KB — the
-    // subagent would advance `bytesAtLastRun` to the full transcript size
-    // on completion, orphaning the unread tail until another full
-    // `bufferBytes` of growth arrived.
+    // up to `DEFAULT_BUFFER_BYTES` (500 KB) of unread transcript chunk,
+    // plus today's stream skim, with margin for re-reads. A smaller budget
+    // (the prior 256 KB) systematically exhausted on buffer-trip spawns once
+    // `bufferBytes` exceeded ~200 KB — the subagent would advance
+    // `bytesAtLastRun` to the full transcript size on completion, orphaning
+    // the unread tail until another full `bufferBytes` of growth arrived.
+    // The budget is intentionally generous post-`memory/topics/` removal:
+    // resizing it down deserves its own measurement-backed change.
     toolResultBudget: {
       maxTotalBytes: 768 * 1024,
       toolNames: ['read'],


### PR DESCRIPTION
## What this PR does

Cuts the per-spawn overhead of `memory-logger` on chatty channel sessions by removing one layering violation and adding two cheap gates on top of the existing idle/buffer-trip plumbing. On a 7-minute Discord session that produced four `memory-logger` spawns and **zero net fragments**, the bulk of the cost was structural — fixed per-spawn floor paid four times, not anything specific to the user's content.

After this PR the same session would:

1. Skip ~~~30 KB of `memory/topics/` body reads per spawn (the subagent no longer reads topics at all — that's dreaming's job).
2. Suppress 2 of the 4 idle spawns via the new line-delta gate (small idle ticks against a transcript that barely grew).
3. Skip the redundant `session.end` spawn when buffer-trip already drained the transcript.
4. Resume today's daily-stream read past the line cursor on the spawn that does fire, instead of re-ingesting earlier-spawn watermarks every time.

Three commits, each independently shippable.

## The bug, in one paragraph

`memory-logger` is the head of the memory pipeline: `transcript → daily streams → topic shards (dreaming)`. Its job is to write fragments to today's daily stream. The system prompt told it to also read `memory/topics/` on every spawn for three reasons (notice contradictions, notice violations, avoid pure restatement). All three of those are downstream-consolidation concerns that **dreaming** does correctly because it has the global view across all shards and streams. memory-logger could only do them locally and partially, and was paying ~30 KB of context + several decision turns per spawn for a result dreaming would re-derive anyway. Compounding: `session.idle` fires after every prompt completion, so a session that quiets 4 times in 7 minutes paid that floor 4 times — even when the new transcript content was a handful of lines almost certain to contain nothing memorable. `session.end` then added a fifth spawn on top of an already-drained transcript.

## Why this is the right shape

The README's own pipeline diagram and the existing recurrence-promotion design at `memory-logger.ts:148-150` already make the case: dreaming uses **distinct-day recurrence** to promote tentative facts to confident ones. The "avoid pure restatement vs memory/topics/" instruction at line 148 was internally inconsistent with the "write the recurrence even if the fact is already known" instruction at line 150 — and the latter is correct, because it's what the dreaming pipeline is designed to consume. memory-logger reading topics was both expensive and counterproductive.

The gate changes are conservative: line-based delta (not raw turn semantics — `SessionIdleEvent` doesn't carry a turn count today), preserves existing observable behavior on test surfaces (fake `/tmp/t.jsonl` paths return 0 lines and don't trigger the gate), and the buffer-trip path is intentionally unaffected (sessions that grow `bufferBytes` of unread transcript still spawn).

The cursor change makes today's daily-stream read O(N spawned-fragments-NOT-from-this-session) instead of O(today's-entire-stream).

## Changes

### Commit 1 — `9fca32b memory: drop topics-reading from memory-logger system prompt`

- `MEMORY_LOGGER_SYSTEM_PROMPT` — delete "Read existing memory first" section; add explicit "You do not read `memory/topics/`" prohibition; rewrite the dedup section to scope reads to today's daily stream only (and only optionally, as a soft check).
- "What to capture" — drop the "Contradictions of existing memory" and "Violations of existing memory" bullets (both require dreaming's global view). Keep "user explicitly changing their mind in this session" (in-transcript) and "Corrections the user made to the agent" (in-transcript) as the durable subset memory-logger can detect locally.
- `buildInitialPrompt` — drop the `Long-term topic shard directory:` line and the "Read memory/topics/ and the daily stream file first…" sentence. Initial prompt now points at the transcript only.
- Drop unused `node:path` `join` import.
- Update the 768 KB `toolResultBudget` comment to note the budget is now over-sized but resizing deserves a separate measurement-backed change.

Tests:
- Replace `handler points the subagent at memory/topics/` with `handler does NOT instruct the subagent to read memory/topics/`. The original test was freezing the layering violation.
- Add a system-prompt-level guard test (`does not direct the subagent to read memory/topics/`) so future drift back into topics-reading fails CI.

### Commit 2 — `15d54b4 memory: gate idle and session.end spawns to suppress zero-delta runs`

Two independent gates, both opt-out via config:

**Min-delta gate on `session.idle`** — new `memory.minIdleDeltaLines` config field (default `3`, minimum `0` to disable). When the idle timer fires, if the JSONL transcript grew by fewer than this many lines since the last `memory-logger` run for this session, the spawn is skipped. Counts via `readLineCount(path)` (single `readFile` + newline scan). The gate is intentionally a no-op when the transcript is zero-line (test dummies, brand-new sessions) so existing observable behavior on fake transcript paths is preserved.

**Byte-equality skip on `session.end`** — when `bytesAtLastRun > 0` and equal to the current transcript size, the session-end spawn is skipped. The `> 0` guard preserves "always fire on end" for sessions that never produced a baseline (no prior idle/buffer-trip ran) and for fake/missing transcript paths.

The session.end hook now detaches its bookkeeping into a `void (async () => …)` to accommodate the `readSize` await without blocking the synchronous return — the channel router's `tearDownLive` path depends on `session.end` not blocking, per the existing comment block at lines 401-417 of `index.ts`. `fireMemoryLogger` still captures its payload synchronously, so the deferred bookkeeping cannot race with the chained spawn.

The buffer-trip path is independent and unaffected — sessions that grow `bufferBytes` of unread transcript still spawn regardless of line delta or end-state byte equality.

Tests: 9 new tests in two `describe` blocks (`session.idle min-delta gate` and `session.end byte-equality skip`) covering gate-fires, gate-skips, threshold-edge, disabled-by-zero, empty-transcript non-gating, buffer-trip independence, no-baseline fallback, and non-zero-delta session.end. README updated to document both gates and the `minIdleDeltaLines` config field.

### Commit 3 — `0a06b0e memory: thread a daily-stream line cursor through the memory-logger payload`

Adds `streamLineCursor: number | undefined` to `MemoryLoggerPayload`. The plugin host:

- After every `memory-logger` spawn settles, captures the line count of today's daily stream file (`readLineCount(streamFilePath(agentDir, today))`) and stamps it on a per-`parentSessionId` cursor keyed by today's date (`Map<sessionId, { date, lineCount }>`).
- Before the next spawn for the same session, looks up the cursor. If the stamp's date matches today's, threads it into the new spawn's payload as `streamLineCursor: N`. If yesterday → omit (the file the cursor points into is no longer the spawn's target).

The system prompt tells the subagent: when present, start the optional local-dedup read at `offset=N+1` so it skips lines this same session put there in an earlier spawn. The dedup read remains optional — absent cursor falls back to the existing "skim the most recent few fragments" instruction.

Without this cursor, the daily-stream read had an O(N²) cost across spawns within a session: each spawn that did the optional local-dedup read ingested everything earlier spawns had appended. A 4-spawn session paid that prefix 4 times.

Tests: 3 new tests in a `stream line cursor` describe block (first spawn has no cursor, subsequent same-day spawn carries the post-spawn line count, session B does not inherit session A's cursor). 2 new tests on `memory-logger.ts` covering the payload-to-prompt rendering. 1 new system-prompt-level guard test that the cursor-handling instruction is present.

## Tests

```
bun test --parallel src/bundled-plugins/memory/
14 new tests in 3 commits.
All 630+ memory plugin tests pass.

bun run test
5495 pass, 0 fail across 303 files.

bun run typecheck   → clean
bun run lint        → 0 new warnings (61 pre-existing in unrelated files)
bun run format:check → clean
```

Diff stat:

```
src/bundled-plugins/memory/README.md             |  20 +-
src/bundled-plugins/memory/index.test.ts         | 318 ++++++++++++++++++++++-
src/bundled-plugins/memory/index.ts              | 114 +++++++-
src/bundled-plugins/memory/memory-logger.test.ts |  51 +++-
src/bundled-plugins/memory/memory-logger.ts      |  57 ++--
5 files changed, 524 insertions(+), 36 deletions(-)
```

## What this PR does NOT do

Three deliberately-deferred follow-ups:

- **Re-tune the 768 KB `toolResultBudget`.** Without topics-reading, the budget is now significantly over-sized — the comment in commit 1 notes this but doesn't change the number. Resizing deserves its own measurement (real-world spawns, not synthetic numbers) and is decoupled from the architectural fix.
- **Audit `dreaming` and `memory-retrieval` system prompts for the same layering question.** Dreaming legitimately spans the whole pipeline, so its reads are not obviously over-reach; memory-retrieval is a different role (turn-start retrieval) and deserves its own pass. Both stay out of this PR.
- **Origin-aware `idleMs` default.** A channel-origin session arguably wants a longer default than `60_000` (TUI). The min-delta gate already addresses most of the pain, and changing user-visible config defaults deserves its own discussion.
