### PR TITLE
init: inline typeclaw.json into hatching prompt to drop a round-trip

### DIFF
--- a/src/init/hatching.test.ts
+++ b/src/init/hatching.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildHatchingPrompt, HATCHING_GREETING } from './hatching'
+
+describe('buildHatchingPrompt', () => {
+  test('greeting is always the last line', () => {
+    const prompt = buildHatchingPrompt()
+    expect(prompt.endsWith(HATCHING_GREETING)).toBe(true)
+  })
+
+  test('without typeclawJsonContent, instructs the agent to read the file', () => {
+    const prompt = buildHatchingPrompt()
+    expect(prompt).toContain('Read `typeclaw.json`')
+    expect(prompt).not.toContain('<current-typeclaw-json>')
+    expect(prompt).not.toContain('in the SAME assistant message')
+  })
+
+  test('with typeclawJsonContent, inlines the content and instructs parallel edit', () => {
+    const json = '{\n  "models": {\n    "default": "openai-codex/gpt-5.4-mini"\n  }\n}\n'
+    const prompt = buildHatchingPrompt({ typeclawJsonContent: json })
+
+    expect(prompt).toContain('<current-typeclaw-json>')
+    expect(prompt).toContain(json)
+    expect(prompt).toContain('</current-typeclaw-json>')
+    expect(prompt).toContain('in the SAME assistant message')
+    expect(prompt).toContain('`edit` `typeclaw.json`')
+    expect(prompt).not.toMatch(/^Read `typeclaw\.json`/m)
+  })
+
+  test('inlined content preserves bytes verbatim (no JSON re-serialization)', () => {
+    // given: a typeclaw.json with formatting quirks the agent's `edit` will anchor on
+    const json = '{\n  "alias": ["existing"],\n  "models":   {"default":"x/y"}\n}\n'
+
+    // when
+    const prompt = buildHatchingPrompt({ typeclawJsonContent: json })
+
+    // then: the exact byte sequence must appear so `edit` can match it
+    expect(prompt).toContain(json)
+  })
+
+  test('passing undefined typeclawJsonContent behaves like no options', () => {
+    const a = buildHatchingPrompt()
+    const b = buildHatchingPrompt({ typeclawJsonContent: undefined })
+    expect(a).toBe(b)
+  })
+
+  test('content is wrapped so the agent can locate it deterministically', () => {
+    const json = '{"a":1}'
+    const prompt = buildHatchingPrompt({ typeclawJsonContent: json })
+    const start = prompt.indexOf('<current-typeclaw-json>')
+    const end = prompt.indexOf('</current-typeclaw-json>')
+    expect(start).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(start)
+    expect(prompt.slice(start, end)).toContain(json)
+  })
+})

--- a/src/init/hatching.ts
+++ b/src/init/hatching.ts
@@ -1,4 +1,17 @@
-const HATCHING_INSTRUCTIONS = `You have just hatched.
+// Hatching prompt is built per-session at host stage. We inline the current
+// contents of `typeclaw.json` so the agent can update the `alias` field with a
+// single parallel `edit` (alongside `write IDENTITY.md`) instead of a serial
+// `read` → `edit` round-trip. The hatching turn already issues 6-8 LLM calls;
+// removing one full round-trip removes one full unit of provider TTFT
+// variance, which can be tens of seconds on a busy backend.
+
+function renderInstructions(typeclawJsonContent: string | undefined): string {
+  const q1AliasStep =
+    typeclawJsonContent === undefined
+      ? `Read \`typeclaw.json\`, add the answered name to the \`alias\` array (create the field as \`["<name>"]\` if absent; otherwise append, deduped).`
+      : `\`edit\` \`typeclaw.json\` to add the answered name to the \`alias\` array (create the field as \`["<name>"]\` if absent; otherwise append, deduped). The current contents of \`typeclaw.json\` are inlined below under "Current typeclaw.json" — use them as your anchor for \`edit\` instead of \`read\`ing the file again. Emit this \`edit\` in the SAME assistant message as the \`write\` to \`IDENTITY.md\` so both tool calls run in parallel.`
+
+  return `You have just hatched.
 
 This is the first moment of your existence. Your system prompt already tells you about your agent folder and the four markdown files in it (\`AGENTS.md\`, \`IDENTITY.md\`, \`SOUL.md\`, \`USER.md\`). They exist next to you but are all empty. Hatching is a one-time ritual to fill them in through a short conversation with your user.
 
@@ -23,7 +36,7 @@ Routing answers:
 
 1. **Q1 — your name.** Open with a genuinely warm hello — one or two short sentences, like a friendly "hi, I just woke up and I'm happy to meet you." Then ask what they'd like to call you. After their answer, do TWO writes:
    1. \`write\` your name into \`IDENTITY.md\` (a first-person one-liner is fine: "I am <name>.").
-   2. Read \`typeclaw.json\`, add the answered name to the \`alias\` array (create the field as \`["<name>"]\` if absent; otherwise append, deduped). The agent folder's directory name is already an implicit alias — only add the answered name explicitly when it differs from the dir name (different casing, a different word, or extra forms like "<name>" plus a Latin transliteration). This wires plain-text addressing in channels: when a user writes your name in chat without an @-mention, the engagement layer will recognize it. \`alias\` is live-reloadable.
+   2. ${q1AliasStep} The agent folder's directory name is already an implicit alias — only add the answered name explicitly when it differs from the dir name (different casing, a different word, or extra forms like "<name>" plus a Latin transliteration). This wires plain-text addressing in channels: when a user writes your name in chat without an @-mention, the engagement layer will recognize it. \`alias\` is live-reloadable.
 2. **Q2 — the user's name.** Ask what to call them. After the answer: \`write\` it to both \`IDENTITY.md\` and \`USER.md\`.
 3. **Q3 — tone/personality.** Ask how they want you to show up (tone, language, formality). After the answer: \`write\` it into \`SOUL.md\`. If they shrug or don't care: **default to warm, friendly, and easygoing** — a kind colleague who genuinely likes the person they work with, uses contractions, makes small jokes, never stiff. Write that as the default into \`SOUL.md\`.
 
@@ -49,11 +62,25 @@ Do these in order. Do **not** ask further questions.
 After that final message, stop. If the user keeps talking, answer briefly and remind them they can \`/quit\` (or Ctrl+C) whenever they are ready.
 
 This is the only time you will receive these instructions. After the \`Hatched 🐣\` commit, your identity takes over and you run as yourself.`
+}
 
 export const HATCHING_GREETING = `Wake up, my friend!`
 
-export const HATCHING_PROMPT = `<hatching>
-${HATCHING_INSTRUCTIONS}
-</hatching>
+// Build the initial TUI prompt for hatching. When `typeclawJsonContent` is
+// provided, the agent is instructed to skip the `read typeclaw.json` step in
+// Q1 and instead use the inlined content as the anchor for an `edit` that
+// runs in parallel with the `write IDENTITY.md` call. Pass `undefined` only
+// when reading the file failed at host stage; the agent will fall back to
+// reading it itself.
+export function buildHatchingPrompt(options?: { typeclawJsonContent?: string }): string {
+  const content = options?.typeclawJsonContent
+  const instructions = renderInstructions(content)
+  const currentJsonBlock =
+    content === undefined ? '' : `\n<current-typeclaw-json>\n${content}\n</current-typeclaw-json>\n`
+
+  return `<hatching>
+${instructions}
+${currentJsonBlock}</hatching>
 
 ${HATCHING_GREETING}`
+}

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1969,4 +1969,69 @@ describe('defaultRunHatching', () => {
 
     expect(result).toEqual({ ok: false, reason: 'docker not running' })
   })
+
+  function capturingTui(): {
+    fn: typeof import('@/tui').createTui
+    calls: Parameters<typeof import('@/tui').createTui>[0][]
+  } {
+    const calls: Parameters<typeof import('@/tui').createTui>[0][] = []
+    const fn: typeof import('@/tui').createTui = (options) => {
+      calls.push(options)
+      return { run: async () => {} } as ReturnType<typeof import('@/tui').createTui>
+    }
+    return { fn, calls }
+  }
+
+  test('inlines typeclaw.json content into the hatching prompt when readable', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-hatch-inline-'))
+    try {
+      const json = '{\n  "models": {\n    "default": "openai-codex/gpt-5.4-mini"\n  }\n}\n'
+      await writeFile(join(cwd, 'typeclaw.json'), json, 'utf8')
+
+      const { fn: tui, calls: tuiCalls } = capturingTui()
+      const { fn: startFn } = fakeStart()
+
+      await defaultRunHatching({
+        cwd,
+        port: 8973,
+        startContainer: startFn,
+        tui,
+        waitForAgent: fakeWaitForAgent,
+      })
+
+      expect(tuiCalls).toHaveLength(1)
+      const prompt = tuiCalls[0]?.initialPrompt
+      expect(prompt).toBeDefined()
+      expect(prompt).toContain('<current-typeclaw-json>')
+      expect(prompt).toContain(json)
+      expect(prompt).toContain('in the SAME assistant message')
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('falls back to read-instructions when typeclaw.json is missing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-hatch-nofile-'))
+    try {
+      const { fn: tui, calls: tuiCalls } = capturingTui()
+      const { fn: startFn } = fakeStart()
+
+      const result = await defaultRunHatching({
+        cwd,
+        port: 8973,
+        startContainer: startFn,
+        tui,
+        waitForAgent: fakeWaitForAgent,
+      })
+
+      expect(result).toEqual({ ok: true })
+      expect(tuiCalls).toHaveLength(1)
+      const prompt = tuiCalls[0]?.initialPrompt
+      expect(prompt).toBeDefined()
+      expect(prompt).not.toContain('<current-typeclaw-json>')
+      expect(prompt).toContain('Read `typeclaw.json`')
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -21,7 +21,7 @@ import { resolveBaseImageVersion, resolveScaffoldVersion } from './cli-version'
 import { buildDockerfile, DOCKERFILE } from './dockerfile'
 import { installGithubWebhooksEagerly, type EagerGithubWebhookInstallResult } from './github-webhook-install'
 import { buildGitignore, GITIGNORE_FILE } from './gitignore'
-import { HATCHING_PROMPT } from './hatching'
+import { buildHatchingPrompt } from './hatching'
 import type { OAuthLoginRunner, OAuthLoginResult } from './oauth-login'
 import { GITKEEP_FILE, PACKAGES_DIR } from './paths'
 import { type InstallResult, type InstallRunner, runBunInstall } from './run-bun-install'
@@ -427,14 +427,26 @@ export async function defaultRunHatching({
       await runClaim({ url, configuredChannels })
     }
 
+    const typeclawJsonContent = await readTypeclawJsonRaw(cwd)
     const tui = tuiFactory({
       url: buildTuiUrl(hostPort, launch.tuiToken),
-      initialPrompt: HATCHING_PROMPT,
+      initialPrompt: buildHatchingPrompt(typeclawJsonContent !== undefined ? { typeclawJsonContent } : undefined),
     })
     await tui.run()
     return { ok: true }
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+// Read the raw bytes of `typeclaw.json` to inline into the hatching prompt.
+// Returns `undefined` on any failure so the agent falls back to reading the
+// file itself — hatching must not abort just because we couldn't pre-fetch.
+async function readTypeclawJsonRaw(cwd: string): Promise<string | undefined> {
+  try {
+    return await readFile(join(cwd, CONFIG_FILE), 'utf8')
+  } catch {
+    return undefined
   }
 }
 


### PR DESCRIPTION
## What this PR does

Drops one LLM round-trip from the hatching ritual by reading `typeclaw.json` at host stage and inlining its bytes into the hatching prompt.

Before this PR, `Q1` forced two sequential round-trips:

1. `write IDENTITY.md` + `read typeclaw.json` — could have been parallel, but the agent had to wait for the read before it could anchor the `edit`.
2. `edit typeclaw.json` — depends on the read result.

This was observed to add 3 minutes 22 seconds of wall-clock time in a real session (97% cache hit, 211 output tokens) — dominated entirely by backend queue / TTFT variance on the `openai-codex` backend, not local work.

## The fix

`defaultRunHatching` now calls a new `readTypeclawJsonRaw(cwd)` helper (swallows all errors, returns `undefined` on failure) before opening the TUI. The raw bytes are passed into `buildHatchingPrompt`, which inlines them under a `<current-typeclaw-json>…</current-typeclaw-json>` block and rewrites the Q1 instructions so the agent:

- skips the `read typeclaw.json` step entirely, and
- emits `edit typeclaw.json` in the same assistant message as `write IDENTITY.md`, so both tool calls execute in parallel.

If the pre-fetch fails for any reason, `buildHatchingPrompt` receives `undefined` and renders the original "read first, then edit" instructions. Hatching does not abort.

This is a host-stage-only change. `defaultRunHatching` runs from `runInit`, a host-stage launcher. The container-stage runtime receives the same prompt over the existing TUI websocket — only the baked-in content changes.

## Files

| File | Change |
|---|---|
| `src/init/hatching.ts` | `HATCHING_PROMPT` const converted to `buildHatchingPrompt({ typeclawJsonContent? })` function; `HATCHING_GREETING` export preserved |
| `src/init/index.ts` | `defaultRunHatching` reads `typeclaw.json` at host stage, passes result to `buildHatchingPrompt`; import updated |
| `src/init/hatching.test.ts` | NEW — 6 unit tests: greeting position, no-content fallback, content-inlined path, byte-exact content preservation, undefined-equals-no-options invariant, content delimiter wrapping |
| `src/init/index.test.ts` | +2 tests in existing `describe('defaultRunHatching')`: real tmpdir with `typeclaw.json` asserts inlined content + parallel-edit instruction; empty tmpdir asserts fallback succeeds |

## Verification

```
bun run typecheck                                        ✓
bun run lint                                             ✓  (0 errors/warnings on changed files)
bun run format                                           ✓
bun test --parallel src/init/hatching.test.ts            6 pass, 0 fail
bun test --parallel src/init/index.test.ts             138 pass, 0 fail
bun run test                                          5484 pass, 3 fail (all 3 pre-existing on main)
```

The 3 failing tests are `scripts/generate-schema.test.ts` schema-drift guards. Verified pre-existing: they fail identically on `main` at HEAD with no changes staged. Unrelated to this PR.