### PR TITLE
channels: accept PKCS#1 RSA private keys for github app auth

### DIFF
--- a/src/channels/adapters/github/auth-app.test.ts
+++ b/src/channels/adapters/github/auth-app.test.ts
@@ -6,12 +6,14 @@ import { AppAuthStrategy } from './auth-app'
 const fixedNow = Date.parse('2026-05-18T12:00:00Z')
 
 let privateKeyPem = ''
+let privateKeyPkcs1Pem = ''
 let publicKeyPem = ''
 let originalNow: () => number
 
 beforeAll(() => {
   const pair = generateKeyPairSync('rsa', { modulusLength: 2048 })
   privateKeyPem = pair.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString()
+  privateKeyPkcs1Pem = pair.privateKey.export({ type: 'pkcs1', format: 'pem' }).toString()
   publicKeyPem = pair.publicKey.export({ type: 'spki', format: 'pem' }).toString()
 })
 
@@ -118,6 +120,51 @@ describe('AppAuthStrategy', () => {
     })
 
     await expect(strategy.token()).rejects.toThrow(/multiple installations \(11, 22\)/i)
+  })
+
+  it('accepts PKCS#1 RSA private keys (the format GitHub hands out by default)', async () => {
+    let jwt = ''
+    const strategy = new AppAuthStrategy({
+      appId: 12345,
+      privateKey: { value: privateKeyPkcs1Pem },
+      installationId: 67890,
+      fetchImpl: fakeFetch(async (_url, init) => {
+        jwt = bearerToken(init)
+        return Response.json({ token: 'installation-token', expires_at: '2026-05-18T13:00:00Z' })
+      }),
+    })
+
+    await strategy.token()
+
+    expect(privateKeyPkcs1Pem).toContain('-----BEGIN RSA PRIVATE KEY-----')
+    expect(verifyJwtSignature(jwt)).toBe(true)
+  })
+
+  it('rejects encrypted private keys with a clear message', async () => {
+    const encryptedPem = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem', cipher: 'aes-256-cbc', passphrase: 'topsecret' },
+    }).privateKey
+
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: encryptedPem },
+      installationId: 99,
+      fetchImpl: fakeFetch(async () => new Response('unreachable', { status: 500 })),
+    })
+
+    await expect(strategy.token()).rejects.toThrow(/encrypted/i)
+  })
+
+  it('rejects malformed PEM input with a descriptive error', async () => {
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: '-----BEGIN RSA PRIVATE KEY-----\nnot-base64\n-----END RSA PRIVATE KEY-----\n' },
+      installationId: 99,
+      fetchImpl: fakeFetch(async () => new Response('unreachable', { status: 500 })),
+    })
+
+    await expect(strategy.token()).rejects.toThrow(/invalid/i)
   })
 
   it('resolves and caches the GitHub App bot user', async () => {

--- a/src/channels/adapters/github/auth-app.ts
+++ b/src/channels/adapters/github/auth-app.ts
@@ -1,3 +1,5 @@
+import { createPrivateKey } from 'node:crypto'
+
 import { resolveSecret, type Secret } from '@/secrets/resolve'
 
 import type { GithubAuthStrategy, GithubSelfUser } from './auth'
@@ -111,10 +113,31 @@ function base64url(input: string | Buffer): string {
 }
 
 async function importRsaPrivateKey(pem: string): Promise<CryptoKey> {
-  const b64 = pem
-    .replace(/-----BEGIN [^-]+-----/, '')
-    .replace(/-----END [^-]+-----/, '')
-    .replace(/\s/g, '')
-  const der = Buffer.from(b64, 'base64')
-  return await crypto.subtle.importKey('pkcs8', der, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign'])
+  // GitHub's "Generate a private key" button hands out PKCS#1 (`-----BEGIN RSA PRIVATE KEY-----`),
+  // but WebCrypto's importKey only accepts PKCS#8. Round-trip through node:crypto, which accepts
+  // both PKCS#1 and PKCS#8 PEM, then re-export as PKCS#8 DER for WebCrypto.
+  const pkcs8Der = pemToPkcs8Der(pem)
+  return await crypto.subtle.importKey('pkcs8', pkcs8Der, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, [
+    'sign',
+  ])
+}
+
+function pemToPkcs8Der(pem: string): ArrayBuffer {
+  if (/-----BEGIN ENCRYPTED PRIVATE KEY-----/.test(pem)) {
+    throw new Error('GitHub App private key is encrypted; provide an unencrypted PEM')
+  }
+  let keyObject
+  try {
+    keyObject = createPrivateKey({ key: pem, format: 'pem' })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`GitHub App private key is invalid: ${message}`)
+  }
+  if (keyObject.asymmetricKeyType !== 'rsa') {
+    throw new Error(`GitHub App private key must be RSA, got ${keyObject.asymmetricKeyType ?? 'unknown'}`)
+  }
+  const der = keyObject.export({ type: 'pkcs8', format: 'der' })
+  const out = new ArrayBuffer(der.byteLength)
+  new Uint8Array(out).set(der)
+  return out
 }


### PR DESCRIPTION
## What this PR does

Fixes a regression where typeclaw's GitHub channel adapter could not authenticate as a GitHub App if the user pasted the private key GitHub gives them from the App settings page.

On a fresh setup the adapter died at start with:

```
[channels] adapter "github" failed to start: Data provided to an operation does not meet requirements
[tunnels] github URL → restarting adapter
[tunnels] github-webhook: URL set to https://<host>.trycloudflare.com
[channels] restartAdapter('github'): adapter not live, skipping
```

The `restartAdapter … adapter not live, skipping` line is the downstream symptom that misled my own investigation — the actual fault is the line above it. The adapter never went live, so the tunnel rotation refresh had nothing to restart.

## The bug

`src/channels/adapters/github/auth-app.ts` minted the GitHub App JWT through `crypto.subtle.importKey('pkcs8', der, …)`, where `der` was the raw base64 body of the PEM file with the armor stripped:

```ts
async function importRsaPrivateKey(pem: string): Promise<CryptoKey> {
  const b64 = pem
    .replace(/-----BEGIN [^-]+-----/, '')
    .replace(/-----END [^-]+-----/, '')
    .replace(/\s/g, '')
  const der = Buffer.from(b64, 'base64')
  return await crypto.subtle.importKey('pkcs8', der, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign'])
}
```

WebCrypto's `importKey` only accepts **PKCS#8** DER (`-----BEGIN PRIVATE KEY-----`, `PrivateKeyInfo` per RFC 5208). The "Generate a private key" button on `https://github.com/settings/apps/<app>/` hands out **PKCS#1** PEM (`-----BEGIN RSA PRIVATE KEY-----`, `RSAPrivateKey` per RFC 8017) — confirmed against GitHub's [docs](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps) ("Generated private keys are downloaded in PEM format. The header is `-----BEGIN RSA PRIVATE KEY-----`"). DER bytes don't match the expected ASN.1 structure → WebCrypto rejects with the opaque `OperationError: Data provided to an operation does not meet requirements`.

So the PAT path always worked, the App path never did for the default GitHub-issued key. The PR I read while diagnosing this — the existing `auth-app.test.ts` — used `pair.privateKey.export({ type: 'pkcs8' })` in the test fixture and so never tripped the bug in CI.

## The fix

Route the PEM through `node:crypto.createPrivateKey`, which accepts **both** PKCS#1 and PKCS#8 PEM, and re-export as PKCS#8 DER for WebCrypto:

```ts
function pemToPkcs8Der(pem: string): ArrayBuffer {
  if (/-----BEGIN ENCRYPTED PRIVATE KEY-----/.test(pem)) {
    throw new Error('GitHub App private key is encrypted; provide an unencrypted PEM')
  }
  let keyObject
  try {
    keyObject = createPrivateKey({ key: pem, format: 'pem' })
  } catch (error) {
    const message = error instanceof Error ? error.message : String(error)
    throw new Error(`GitHub App private key is invalid: ${message}`)
  }
  if (keyObject.asymmetricKeyType !== 'rsa') {
    throw new Error(`GitHub App private key must be RSA, got ${keyObject.asymmetricKeyType ?? 'unknown'}`)
  }
  const der = keyObject.export({ type: 'pkcs8', format: 'der' })
  const out = new ArrayBuffer(der.byteLength)
  new Uint8Array(out).set(der)
  return out
}
```

This is the standard remedy when you need WebCrypto interop on a Node/Bun runtime — Node accepts both formats natively, so we let it normalize. No hand-rolled ASN.1 wrapping, no extra dependency. Verified on Bun 1.3.14 (the version pinned in `bun.lock`) that `createPrivateKey({ key: pkcs1Pem, format: 'pem' }).export({ type: 'pkcs8', format: 'der' })` round-trips cleanly and the resulting DER is accepted by `crypto.subtle.importKey('pkcs8', …)`.

Three failure modes that previously surfaced as the same opaque `OperationError` now throw with descriptive messages:

| Input | Old behavior | New behavior |
|---|---|---|
| PKCS#1 RSA PEM (GitHub default) | `OperationError: Data provided to an operation does not meet requirements` | Works |
| PKCS#8 RSA PEM | Works | Works (unchanged) |
| Encrypted PEM (`-----BEGIN ENCRYPTED PRIVATE KEY-----`) | `OperationError` (opaque) | `GitHub App private key is encrypted; provide an unencrypted PEM` |
| Garbage / corrupted PEM | `OperationError` (opaque) | `GitHub App private key is invalid: <node:crypto reason>` |
| Non-RSA key (Ed25519, EC) | Would mint a malformed JWT and fail server-side at `POST /app/installations/{id}/access_tokens` | `GitHub App private key must be RSA, got <type>` |

The `ArrayBuffer` copy at the end is to satisfy Bun's WebCrypto typings, which want `BufferSource` backed by `ArrayBuffer` rather than `ArrayBufferLike` (which is what `KeyObject.export` returns in `@types/node`). It's not load-bearing for correctness, only for `tsgo --noEmit`.

## Files

| File | Change |
|---|---|
| `src/channels/adapters/github/auth-app.ts` | Replace hand-rolled PEM-strip-then-importKey with `node:crypto.createPrivateKey` round-trip. Add encrypted-PEM, invalid-PEM, and non-RSA-key error paths. +29 / -6. |
| `src/channels/adapters/github/auth-app.test.ts` | Generate a second PKCS#1 fixture alongside the existing PKCS#8 fixture. +3 tests: PKCS#1 acceptance (signature verifies against the original public key), encrypted-PEM rejection with descriptive message, malformed-PEM rejection with descriptive message. The existing 7 tests continue to exercise the PKCS#8 path unchanged. |

No changes to `auth.ts`, `auth-pat.ts`, `webhook-register.ts`, or `index.ts` — the bug was purely in the JWT minter, and the rest of the App auth strategy (installation token exchange, bot user resolution, webhook lifecycle) was already correct.

## Verification

```
bun run typecheck                                           ✓
bun run lint                                                ✓  (0 errors; 61 warnings all pre-existing in unrelated files)
bun run format:check                                        ✓
bun test --parallel src/channels/adapters/github/auth-app.test.ts   10 pass, 0 fail
bun run test                                              5482 pass, 0 fail across 303 files
```

PKCS#1 signature round-trip was confirmed against the test's existing `verifyJwtSignature` helper (Node's `createVerify('RSA-SHA256')` against the matching SPKI public key), so the new code path mints JWTs GitHub will actually accept — not just JWTs that survive importKey.

## Manual smoke (suggested for reviewer)

If you want to reproduce the original failure mode locally and confirm the fix end-to-end:

```sh
# Generate a fresh GitHub App private key on github.com/settings/apps/<app>/
# It downloads as <app>.<date>.private-key.pem with -----BEGIN RSA PRIVATE KEY-----

# On main: paste into typeclaw.json#channels.github.auth.privateKey.value, typeclaw start
# Expected: [channels] adapter "github" failed to start: Data provided to an operation does not meet requirements

# On this branch: same paste, typeclaw start
# Expected: adapter starts, webhook registers, tunnel URL syncs without "adapter not live, skipping"
```
