### PR TITLE
init: align hatching tui fake with TuiRunOutcome return type

### DIFF
--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1977,7 +1977,7 @@ describe('defaultRunHatching', () => {
     const calls: Parameters<typeof import('@/tui').createTui>[0][] = []
     const fn: typeof import('@/tui').createTui = (options) => {
       calls.push(options)
-      return { run: async () => {} } as ReturnType<typeof import('@/tui').createTui>
+      return { run: async () => ({ lostConnection: false }) } as ReturnType<typeof import('@/tui').createTui>
     }
     return { fn, calls }
   }


### PR DESCRIPTION
## What this PR does

Fixes a typecheck error on `main` that surfaced after two recent commits collided in a way neither caught individually.

```
src/init/index.test.ts(1980,14): error TS2352: Conversion of type
'{ run: () => Promise<void>; }' to type
'{ run: () => Promise<TuiRunOutcome>; }' may be a mistake because neither
type sufficiently overlaps with the other.
```

Confirmed reproducible on `origin/main` at HEAD (`e417a98`) with a clean `bun install --frozen-lockfile && bun run typecheck`. Blocks CI on every PR opened against main — first noticed on #391.

## The collision

- **`5bb3917 tui: surface lost-connection state via TuiRunOutcome`** widened `createTui`'s `run()` return type from `Promise<void>` to `Promise<TuiRunOutcome>` (where `TuiRunOutcome = { lostConnection: boolean }`). It also updated the existing `fakeTui` in `src/init/index.test.ts:1922-1923` to return `{ lostConnection: false }` accordingly.
- **`e417a98 init: inline typeclaw.json into hatching prompt to drop a round-trip`** added a new `capturingTui()` helper at line 1973 whose fake returned `{ run: async () => {} }` — `Promise<void>`.

Both PRs typechecked individually against the main they branched from. The post-merge state has both. The `as ReturnType<typeof import('@/tui').createTui>` cast in `capturingTui` fails because TypeScript correctly observes that `Promise<void>` and `Promise<{ lostConnection: boolean }>` are non-overlapping (an empty object literal would have been allowed under structural widening, but `void` is special and gets rejected).

## The fix

Match the peer fake at line 1923 (`{ run: async () => ({ lostConnection: false }) }`). The hatching tests don't read the return value — they only assert on captured `tui()` options — so any valid `TuiRunOutcome` satisfies the contract.

```diff
- return { run: async () => {} } as ReturnType<typeof import('@/tui').createTui>
+ return { run: async () => ({ lostConnection: false }) } as ReturnType<typeof import('@/tui').createTui>
```

One line, scoped to a test helper. No production code touched.

## Files

| File | Change |
|---|---|
| `src/init/index.test.ts` | `capturingTui()` fake's `run()` returns `{ lostConnection: false }` instead of `void`. +1 / -1. |

## Verification

```
bun run typecheck                                  ✓
bun run lint                                       ✓  (0 errors)
bun run format:check                               ✓
bun test --parallel src/init/index.test.ts        132 pass, 0 fail
bun run test                                     5527 pass, 0 fail across 305 files
```
