### PR TITLE
channels: extract github permission-guidance into its own module

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -12,6 +12,7 @@ import { createGithubWebhookHandler } from './inbound'
 import { applyManagedPath, buildManagedPath, resolveAgentId } from './managed-path'
 import { createGithubMembershipResolver } from './membership'
 import { createGithubOutboundCallback } from './outbound'
+import { buildPermissionGuidance, parseListHooksPermissionStatus } from './permission-guidance'
 import { deregisterGithubWebhooks, registerGithubWebhooks, type WebhookRegistrationResult } from './webhook-register'
 
 export type GithubAdapterLogger = {
@@ -288,74 +289,6 @@ function logRegistrationOutcome(
   if (permissionFailures.length > 0) {
     logger.warn(buildPermissionGuidance(authType, permissionFailures))
   }
-}
-
-// Parses webhook-register errors of the shape `list hooks failed: <status> <body>`.
-// Returns the status code when it matches the two shapes GitHub emits for
-// missing access on the list-hooks endpoint:
-//   - 404 Not Found: the token cannot see the repo at all (private repo
-//     gated behind missing repository access — GitHub returns 404 instead of
-//     403 to avoid leaking the existence of private repos).
-//   - 403 Forbidden: the token sees the repo but lacks webhook-management
-//     permission, OR is blocked by an org SSO/SAML authorization gate.
-// Returns null for any other error (network, malformed slug, create-hook
-// failures, etc.) so the guidance only fires on the actual symptom.
-export function parseListHooksPermissionStatus(error: string): number | null {
-  const match = error.match(/^list hooks failed: (404|403)\b/)
-  if (match === null) return null
-  return Number(match[1])
-}
-
-// The labels below intentionally mirror github.com's current UI verbatim so a
-// user can grep their settings page for the exact string. If GitHub renames
-// any of these in a future redesign, update both here and the
-// `permissionGuidance` tests in lifecycle.test.ts.
-//
-//   Fine-grained PAT:
-//     Settings → Developer settings → Personal access tokens → Fine-grained tokens
-//     "Resource owner", "Repository access", "Repository permissions" → "Webhooks" → "Read and write", "Metadata" → "Read-only"
-//   GitHub App:
-//     Settings → Developer settings → GitHub Apps → <app> → Permissions & events
-//     "Repository permissions" → "Webhooks" → "Read and write"
-//     Install/configure on the org: <app settings> → Install App / Configure → "Repository access"
-//   Classic PAT (legacy, still supported by GitHub but we don't surface it in
-//     channel-add prompts):
-//     Settings → Developer settings → Personal access tokens (classic)
-//     Scope: "admin:repo_hook" (or full "repo" for private repositories)
-export function buildPermissionGuidance(
-  authType: 'pat' | 'app',
-  failures: ReadonlyArray<{ repo: string; status: number }>,
-): string {
-  const repoList = failures.map((f) => `${f.repo} (${f.status})`).join(', ')
-  const lines: string[] = [
-    `[github] webhook setup needs more access for: ${repoList}.`,
-    '  - 404 from GitHub means the token cannot see the repo (GitHub hides private repos behind 404 instead of 403).',
-    '  - 403 means the token sees the repo but lacks webhook permission, or is blocked by org SAML/SSO.',
-    '',
-  ]
-  if (authType === 'pat') {
-    lines.push(
-      '  Fix (fine-grained personal access token):',
-      '    1. Open https://github.com/settings/personal-access-tokens and edit the token TypeClaw is using.',
-      '    2. Under "Resource owner", select the org that owns the failing repos (e.g. the org in the slug above).',
-      '    3. Under "Repository access", choose "Only select repositories" and add every failing repo (or pick "All repositories").',
-      '    4. Under "Repository permissions", set "Webhooks" to "Read and write" and "Metadata" to "Read-only".',
-      '    5. Save. If the org enforces SAML SSO, click "Configure SSO" next to the token and authorize the org.',
-      '',
-      '  Or (classic personal access token): grant the "admin:repo_hook" scope (or "repo" for private repos),',
-      '  and on a SAML-protected org click "Authorize" next to the token.',
-    )
-  } else {
-    lines.push(
-      '  Fix (GitHub App):',
-      '    1. Open https://github.com/settings/apps and edit the app TypeClaw is using.',
-      '    2. Under "Permissions & events" → "Repository permissions", set "Webhooks" to "Read and write". Save.',
-      '    3. From the app page, click "Install App" (or "Configure" if already installed) and select the org that owns the failing repos.',
-      '    4. Under "Repository access", choose "Only select repositories" and add every failing repo (or pick "All repositories").',
-      '    5. If the app permissions changed in step 2, install owners must accept the updated permissions from the install page before the new access takes effect.',
-    )
-  }
-  return lines.join('\n')
 }
 
 function logDeregistrationOutcome(

--- a/src/channels/adapters/github/permission-guidance.test.ts
+++ b/src/channels/adapters/github/permission-guidance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { buildPermissionGuidance, parseListHooksPermissionStatus } from './index'
+import { buildPermissionGuidance, parseListHooksPermissionStatus } from './permission-guidance'
 
 describe('parseListHooksPermissionStatus', () => {
   test('returns 404 for a 404 list-hooks error', () => {

--- a/src/channels/adapters/github/permission-guidance.ts
+++ b/src/channels/adapters/github/permission-guidance.ts
@@ -1,0 +1,69 @@
+export type GithubAuthType = 'pat' | 'app'
+
+// Parses webhook-register errors of the shape `list hooks failed: <status> <body>`.
+// Returns the status code when it matches the two shapes GitHub emits for
+// missing access on the list-hooks endpoint:
+//   - 404 Not Found: the token cannot see the repo at all (private repo
+//     gated behind missing repository access — GitHub returns 404 instead of
+//     403 to avoid leaking the existence of private repos).
+//   - 403 Forbidden: the token sees the repo but lacks webhook-management
+//     permission, OR is blocked by an org SSO/SAML authorization gate.
+// Returns null for any other error (network, malformed slug, create-hook
+// failures, etc.) so the guidance only fires on the actual symptom.
+export function parseListHooksPermissionStatus(error: string): number | null {
+  const match = error.match(/^list hooks failed: (404|403)\b/)
+  if (match === null) return null
+  return Number(match[1])
+}
+
+// The labels below intentionally mirror github.com's current UI verbatim so a
+// user can grep their settings page for the exact string. If GitHub renames
+// any of these in a future redesign, update both here and the
+// `permissionGuidance` tests in lifecycle.test.ts.
+//
+//   Fine-grained PAT:
+//     Settings → Developer settings → Personal access tokens → Fine-grained tokens
+//     "Resource owner", "Repository access", "Repository permissions" → "Webhooks" → "Read and write", "Metadata" → "Read-only"
+//   GitHub App:
+//     Settings → Developer settings → GitHub Apps → <app> → Permissions & events
+//     "Repository permissions" → "Webhooks" → "Read and write"
+//     Install/configure on the org: <app settings> → Install App / Configure → "Repository access"
+//   Classic PAT (legacy, still supported by GitHub but we don't surface it in
+//     channel-add prompts):
+//     Settings → Developer settings → Personal access tokens (classic)
+//     Scope: "admin:repo_hook" (or full "repo" for private repositories)
+export function buildPermissionGuidance(
+  authType: GithubAuthType,
+  failures: ReadonlyArray<{ repo: string; status: number }>,
+): string {
+  const repoList = failures.map((f) => `${f.repo} (${f.status})`).join(', ')
+  const lines: string[] = [
+    `[github] webhook setup needs more access for: ${repoList}.`,
+    '  - 404 from GitHub means the token cannot see the repo (GitHub hides private repos behind 404 instead of 403).',
+    '  - 403 means the token sees the repo but lacks webhook permission, or is blocked by org SAML/SSO.',
+    '',
+  ]
+  if (authType === 'pat') {
+    lines.push(
+      '  Fix (fine-grained personal access token):',
+      '    1. Open https://github.com/settings/personal-access-tokens and edit the token TypeClaw is using.',
+      '    2. Under "Resource owner", select the org that owns the failing repos (e.g. the org in the slug above).',
+      '    3. Under "Repository access", choose "Only select repositories" and add every failing repo (or pick "All repositories").',
+      '    4. Under "Repository permissions", set "Webhooks" to "Read and write" and "Metadata" to "Read-only".',
+      '    5. Save. If the org enforces SAML SSO, click "Configure SSO" next to the token and authorize the org.',
+      '',
+      '  Or (classic personal access token): grant the "admin:repo_hook" scope (or "repo" for private repos),',
+      '  and on a SAML-protected org click "Authorize" next to the token.',
+    )
+  } else {
+    lines.push(
+      '  Fix (GitHub App):',
+      '    1. Open https://github.com/settings/apps and edit the app TypeClaw is using.',
+      '    2. Under "Permissions & events" → "Repository permissions", set "Webhooks" to "Read and write". Save.',
+      '    3. From the app page, click "Install App" (or "Configure" if already installed) and select the org that owns the failing repos.',
+      '    4. Under "Repository access", choose "Only select repositories" and add every failing repo (or pick "All repositories").',
+      '    5. If the app permissions changed in step 2, install owners must accept the updated permissions from the install page before the new access takes effect.',
+    )
+  }
+  return lines.join('\n')
+}


### PR DESCRIPTION
## What this PR does

Pure refactor: lifts `parseListHooksPermissionStatus` and `buildPermissionGuidance` out of `src/channels/adapters/github/index.ts` into their own module, `src/channels/adapters/github/permission-guidance.ts`. No behavior change. No new dependencies. Test file (`permission-guidance.test.ts`, already existed and was named for the helpers, not the file they live in) updates its import path.

This is the **first** of three PRs that together turn opaque GitHub-App misconfiguration symptoms into actionable user guidance. The other two (a startup permission preflight and outbound-403 guidance) want to call these helpers without depending on the adapter factory module. Doing the move as its own PR keeps the followups behavior-only.

## Why now

`index.ts` is already 369 lines (adapter factory, logger types, `restartAdapter` machinery, two outcome loggers, two parsing helpers, and the WebhookRegistrationResult log walker). The two helpers being moved have no dependency on anything else in `index.ts`, but `index.ts` pulls in the whole adapter wiring graph if you `import` from it.

Two upcoming patches need the helpers from places where reaching for `index.ts` is wrong:

1. **Startup permission preflight** — runs from within the adapter's `start()` path, needs to format a guidance string for an installation whose granted permission map doesn't satisfy the configured `eventAllowlist`. Wants `buildPermissionGuidance`'s auth-type-aware label vocabulary, not the literal "list hooks failed" parser.
2. **Outbound 403 guidance** — runs from `outbound.ts` when `postJson`/`graphql` get a 403 from GitHub. Wants the same per-endpoint, auth-type-aware UI labels, but a different parser (the failure shape is `GitHub API 403: {…}`, not `list hooks failed: 403 …`).

Both want the same verbatim github.com UI labels (the `"Read and write"`, `"Resource owner"`, `"Permissions & events"` strings that match what users actually see on github.com). Sharing those strings via re-import keeps the labels in one place — when GitHub renames `"Permissions & events"` to something else in a future redesign, one file gets edited.

## Files

| File | Change |
|---|---|
| `src/channels/adapters/github/permission-guidance.ts` | **NEW.** 71 lines. Houses `parseListHooksPermissionStatus`, `buildPermissionGuidance`, and a new exported `GithubAuthType = 'pat' \| 'app'` alias. Comment headers explaining the 404-vs-403 GitHub-quirk and the github.com-UI-verbatim labels move verbatim with the code they document. |
| `src/channels/adapters/github/index.ts` | -69 lines. Helpers and their doc comments removed; an `import { buildPermissionGuidance, parseListHooksPermissionStatus } from './permission-guidance'` line added. `logRegistrationOutcome` and its `// One guidance block per start()…` comment stay in `index.ts` because they're entangled with the `WebhookRegistrationResult` walking loop. |
| `src/channels/adapters/github/permission-guidance.test.ts` | Import path: `from './index'` → `from './permission-guidance'`. Test bodies untouched. |

## What did NOT change

- **Function signatures**: identical. `parseListHooksPermissionStatus(error: string): number \| null`, `buildPermissionGuidance(authType: 'pat' \| 'app', failures: …): string`. The new `GithubAuthType` alias is additive — existing call sites still use the inline `'pat' \| 'app'` literal.
- **Function bodies**: identical. Compared the byte-for-byte text against the deleted block before committing.
- **The comment headers above each function**: identical, including the markdown-style `"Settings → Developer settings → …"` arrows, the bullet list explaining 404 vs 403, and the cross-reference to `lifecycle.test.ts`. Those comments encode load-bearing GitHub-API quirks (private repos hide behind 404, not 403) and pin labels to verbatim github.com UI strings; if they go missing during a refactor, the next maintainer will "simplify" them and reintroduce drift between code and the UI it instructs users to use.
- **No external import paths**: `grep`d for `parseListHooksPermissionStatus|buildPermissionGuidance` across `src/` — only `index.ts` (now using the moved import) and the test (now using the moved import) reference them. No other module touches these helpers, so the move doesn't ripple.
- **Re-exports**: deliberately not adding `export { … } from './permission-guidance'` to `index.ts` because no caller outside the adapter directory needs them, and re-exporting would force the test and any future internal caller to choose between two import paths (an invitation to drift).

## Verification

```
bun run typecheck                                                ✓
bun run lint                                                     ✓  (0 errors)
bun run format:check                                             ✓
bun test --parallel src/channels/adapters/github/                96 pass, 0 fail across 12 files
bun run test                                                   5537 pass, 0 fail across 305 files
```

`permission-guidance.test.ts` continues to run all 18 of its existing cases against the moved code (the test file was already named for the helpers' concern, not the location). `lifecycle.test.ts`'s permission-guidance assertions — which exercise the helpers through the adapter — also continue to pass without modification.

## Sequencing

PR-A in a sequence of three. PR-B (startup permission preflight) and PR-C (outbound 403 guidance) will branch off `main` once this lands and will import from `./permission-guidance` directly. Either can land independently after A; they don't depend on each other.
