### PR TITLE
run: await stop() before exit so channel teardown actually runs

### DIFF
--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+
+import { shutdown } from './run'
+
+describe('shutdown', () => {
+  test('awaits stop() before invoking exit', async () => {
+    // given: a stop() that resolves after a microtask hop
+    const events: string[] = []
+    const stop = async (): Promise<void> => {
+      await Promise.resolve()
+      events.push('stop:resolved')
+    }
+    const exit = (code: number): void => {
+      events.push(`exit:${code}`)
+    }
+
+    // when
+    await shutdown({ stop, exit })
+
+    // then
+    expect(events).toEqual(['stop:resolved', 'exit:0'])
+  })
+
+  test('exits with 1 if stop() throws so async teardown failures surface in container exit code', async () => {
+    // given
+    const events: string[] = []
+    const stop = async (): Promise<void> => {
+      await Promise.resolve()
+      throw new Error('boom')
+    }
+    const exit = (code: number): void => {
+      events.push(`exit:${code}`)
+    }
+
+    // when
+    await shutdown({ stop, exit })
+
+    // then
+    expect(events).toEqual(['exit:1'])
+  })
+
+  test('does not invoke exit until every awaited side-effect in stop() completes', async () => {
+    // given: a stop() that performs multiple async hops, mimicking the real
+    // channelManager.stop() → adapter.stop() → deregisterGithubWebhooks() chain
+    const events: string[] = []
+    const stop = async (): Promise<void> => {
+      await Promise.resolve()
+      events.push('a')
+      await Promise.resolve()
+      events.push('b')
+      await Promise.resolve()
+      events.push('c')
+    }
+    const exit = (code: number): void => {
+      events.push(`exit:${code}`)
+    }
+
+    // when
+    await shutdown({ stop, exit })
+
+    // then
+    expect(events).toEqual(['a', 'b', 'c', 'exit:0'])
+  })
+})

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -49,20 +49,39 @@ export const run = defineCommand({
       initialPrompt: args.prompt,
     })
 
-    const onSignal = () => {
-      stop()
-      process.exit(0)
+    const exit = (code: number): void => {
+      process.exit(code)
+    }
+    const onSignal = (): void => {
+      void shutdown({ stop, exit })
     }
     process.once('SIGINT', onSignal)
     process.once('SIGTERM', onSignal)
 
     if (tuiPromise) {
       await tuiPromise
-      stop()
-      process.exit(0)
+      await shutdown({ stop, exit })
     }
   },
 })
+
+// Awaits `stop()` BEFORE exiting so async teardown side-effects (channel
+// adapter teardown, in particular GitHub webhook deregistration) actually
+// complete. The previous code called `stop()` without awaiting and then
+// `process.exit(0)` synchronously, so the in-process DELETE /repos/.../hooks/
+// requests never went out and webhooks survived `typeclaw stop` (which
+// `docker stop`s the container → SIGTERM).
+export async function shutdown(deps: {
+  stop: () => void | Promise<void>
+  exit: (code: number) => void
+}): Promise<void> {
+  try {
+    await deps.stop()
+    deps.exit(0)
+  } catch {
+    deps.exit(1)
+  }
+}
 
 function resolveAttachTui({
   tui,


### PR DESCRIPTION
## What this PR does

Fixes GitHub webhooks surviving `typeclaw stop`. After `docker stop` sends SIGTERM to the container, registered GitHub webhooks are left dangling on user repos because the HTTP deregistration requests never went out. Reproduces with both PAT and GitHub App auth.

## Root cause

`src/cli/run.ts` had two call sites that called `stop()` without awaiting it, then called `process.exit(0)` synchronously:

```ts
// signal path (before)
const onSignal = () => {
  stop()           // fire-and-forget
  process.exit(0)  // kills the process immediately
}

// TUI-exit path (before)
await tuiPromise
stop()           // fire-and-forget
process.exit(0)
```

`stop()` is async all the way down: `channelManager.stop()` → adapter `stop()` → `deregisterGithubWebhooks()` → DELETE `/repos/<owner>/<name>/hooks/<id>`. None of those fetches survived the synchronous `process.exit`.

## Fix

Extract a `shutdown(deps)` helper that `await`s `stop()` before calling `exit`. Both paths now route through it:

```ts
export async function shutdown(deps: {
  stop: () => void | Promise<void>
  exit: (code: number) => void
}): Promise<void> {
  try {
    await deps.stop()
    deps.exit(0)
  } catch {
    deps.exit(1)
  }
}
```

The signal handler stays synchronous (`void shutdown(...)`) because Node signal handlers cannot be async; the shutdown work runs in the background before the event loop drains. The TUI-exit path already runs inside an async context so it does `await shutdown(...)`.

## Tests

New `src/cli/run.test.ts` (3 cases):

1. **Ordering**: `stop:resolved` appears before `exit:0` in the event log.
2. **Error surfacing**: if `stop()` throws, `exit(1)` is called (async teardown failures surface in the container exit code).
3. **Mutation resistance**: simulates the real `channelManager → adapter → deregisterGithubWebhooks` multi-hop async chain and asserts all side-effects complete before `exit`. This test fails when `await deps.stop()` is reverted to `void deps.stop()`.

## Out of scope

SIGKILL / OOM kills bypass this path entirely — that's a separate problem.