### PR TITLE
channels: preflight github app installation permissions at adapter start

### DIFF
--- a/src/channels/adapters/github/auth-app.test.ts
+++ b/src/channels/adapters/github/auth-app.test.ts
@@ -214,6 +214,60 @@ describe('AppAuthStrategy', () => {
 
     await expect(strategy.getSelf()).rejects.toThrow(/bot user lookup failed: 401/i)
   })
+
+  it('reads installation permissions and events via GET /app/installations/{id}', async () => {
+    const calls: string[] = []
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: privateKeyPem },
+      installationId: 99,
+      fetchImpl: fakeFetch(async (url) => {
+        calls.push(String(url))
+        return Response.json({
+          permissions: { issues: 'write', metadata: 'read' },
+          events: ['issues', 'issue_comment'],
+        })
+      }),
+    })
+
+    const grants = await strategy.getInstallationGrants()
+
+    expect(grants).toEqual({
+      permissions: { issues: 'write', metadata: 'read' },
+      events: ['issues', 'issue_comment'],
+    })
+    expect(calls).toEqual(['https://api.github.com/app/installations/99'])
+  })
+
+  it('filters unknown permission levels and non-string events out of the grants', async () => {
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: privateKeyPem },
+      installationId: 99,
+      fetchImpl: fakeFetch(async () =>
+        Response.json({
+          permissions: { issues: 'write', metadata: 'read', mystery: 'banana' },
+          events: ['issues', 42, null],
+        }),
+      ),
+    })
+
+    const grants = await strategy.getInstallationGrants()
+
+    expect(grants.permissions).toEqual({ issues: 'write', metadata: 'read' })
+    expect(grants.events).toEqual(['issues'])
+  })
+
+  it('throws when the installation lookup fails', async () => {
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: privateKeyPem },
+      installationId: 99,
+      fetchImpl: fakeFetch(async () => new Response('boom', { status: 500 })),
+    })
+
+    await expect(strategy.getInstallationGrants()).rejects.toThrow(/installation fetch failed: 500/i)
+  })
 })
 
 function fakeFetch(handler: (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>): typeof fetch {

--- a/src/channels/adapters/github/auth-app.ts
+++ b/src/channels/adapters/github/auth-app.ts
@@ -2,7 +2,7 @@ import { createPrivateKey } from 'node:crypto'
 
 import { resolveSecret, type Secret } from '@/secrets/resolve'
 
-import type { GithubAuthStrategy, GithubSelfUser } from './auth'
+import type { GithubAuthStrategy, GithubInstallationGrants, GithubSelfUser } from './auth'
 import { GITHUB_API_BASE, githubJsonHeaders, githubPublicHeaders } from './auth-pat'
 
 export class AppAuthStrategy implements GithubAuthStrategy {
@@ -67,6 +67,24 @@ export class AppAuthStrategy implements GithubAuthStrategy {
     }
     this._selfUser = { id: user.id, login: user.login }
     return this._selfUser
+  }
+
+  async getInstallationGrants(): Promise<GithubInstallationGrants> {
+    const jwt = await this.mintJwt()
+    const installId = await this.resolveInstallationId(jwt)
+    const response = await this.fetchImpl(`${GITHUB_API_BASE}/app/installations/${installId}`, {
+      headers: githubJsonHeaders(jwt),
+    })
+    if (!response.ok) throw new Error(`GitHub App installation fetch failed: ${response.status}`)
+    const raw = (await response.json()) as { permissions?: unknown; events?: unknown }
+    const permissions: Record<string, 'read' | 'write' | 'admin'> = {}
+    if (raw.permissions !== null && typeof raw.permissions === 'object') {
+      for (const [key, value] of Object.entries(raw.permissions as Record<string, unknown>)) {
+        if (value === 'read' || value === 'write' || value === 'admin') permissions[key] = value
+      }
+    }
+    const events = Array.isArray(raw.events) ? raw.events.filter((e): e is string => typeof e === 'string') : []
+    return { permissions, events }
   }
 
   async dispose(): Promise<void> {

--- a/src/channels/adapters/github/auth.ts
+++ b/src/channels/adapters/github/auth.ts
@@ -7,7 +7,17 @@ export type GithubAuthStrategy = {
   token: () => Promise<string>
   authHeaders: () => Promise<HeadersInit>
   getSelf: () => Promise<GithubSelfUser>
+  // App-only: returns the installation's granted-permissions map and declared
+  // events so the adapter can preflight against the configured eventAllowlist
+  // before any webhook arrives. PATs return access via token scopes, not an
+  // installation grant, so they leave this undefined.
+  getInstallationGrants?: () => Promise<GithubInstallationGrants>
   dispose: () => Promise<void>
+}
+
+export type GithubInstallationGrants = {
+  permissions: Readonly<Record<string, 'read' | 'write' | 'admin'>>
+  events: readonly string[]
 }
 
 export type GithubSelfUser = {

--- a/src/channels/adapters/github/event-permissions.test.ts
+++ b/src/channels/adapters/github/event-permissions.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'bun:test'
+
+import { findPermissionGaps, permissionKeyForEvent } from './event-permissions'
+
+describe('permissionKeyForEvent', () => {
+  it('maps dotted event names to the permission family', () => {
+    expect(permissionKeyForEvent('issue_comment.created')).toBe('issues')
+    expect(permissionKeyForEvent('pull_request_review_comment.created')).toBe('pull_requests')
+    expect(permissionKeyForEvent('discussion.created')).toBe('discussions')
+  })
+
+  it('maps bare event-family names to the permission family', () => {
+    expect(permissionKeyForEvent('issues')).toBe('issues')
+    expect(permissionKeyForEvent('pull_request_review')).toBe('pull_requests')
+    expect(permissionKeyForEvent('discussion_comment')).toBe('discussions')
+  })
+
+  it('returns null for events typeclaw does not yet know about', () => {
+    expect(permissionKeyForEvent('star.created')).toBeNull()
+    expect(permissionKeyForEvent('marketplace_purchase.purchased')).toBeNull()
+  })
+})
+
+describe('findPermissionGaps', () => {
+  it('returns a gap when the App has zero relevant permissions', () => {
+    const gaps = findPermissionGaps(['issues.opened', 'pull_request.opened'], {
+      metadata: 'read',
+      repository_hooks: 'write',
+    })
+    expect(gaps).toEqual([
+      { permissionKey: 'issues', uiLabel: 'Issues', granted: null, events: ['issues.opened'], needsWrite: true },
+      {
+        permissionKey: 'pull_requests',
+        uiLabel: 'Pull requests',
+        granted: null,
+        events: ['pull_request.opened'],
+        needsWrite: true,
+      },
+    ])
+  })
+
+  it('returns a gap when the App has read but not write on a required permission', () => {
+    const gaps = findPermissionGaps(['issues.opened'], { issues: 'read' })
+    expect(gaps).toEqual([
+      { permissionKey: 'issues', uiLabel: 'Issues', granted: 'read', events: ['issues.opened'], needsWrite: true },
+    ])
+  })
+
+  it('returns no gaps when every required permission has write', () => {
+    const gaps = findPermissionGaps(['issues.opened', 'pull_request_review_comment.created'], {
+      issues: 'write',
+      pull_requests: 'write',
+    })
+    expect(gaps).toEqual([])
+  })
+
+  it('treats admin as satisfying a write requirement', () => {
+    const gaps = findPermissionGaps(['issues.opened'], { issues: 'admin' })
+    expect(gaps).toEqual([])
+  })
+
+  it('coalesces multiple events under the same permission into a single gap', () => {
+    const gaps = findPermissionGaps(['issues.opened', 'issue_comment.created', 'pull_request.opened'], {
+      metadata: 'read',
+    })
+    expect(gaps).toHaveLength(2)
+    const issues = gaps.find((g) => g.permissionKey === 'issues')
+    expect(issues?.events).toEqual(['issue_comment.created', 'issues.opened'])
+  })
+
+  it('silently ignores allowlist entries it does not recognise', () => {
+    const gaps = findPermissionGaps(['issues.opened', 'star.created', 'marketplace_purchase.purchased'], {
+      issues: 'write',
+    })
+    expect(gaps).toEqual([])
+  })
+
+  it('sorts gaps by permission key for stable warning output', () => {
+    const gaps = findPermissionGaps(['pull_request.opened', 'discussion.created', 'issues.opened'], {
+      metadata: 'read',
+    })
+    expect(gaps.map((g) => g.permissionKey)).toEqual(['discussions', 'issues', 'pull_requests'])
+  })
+})

--- a/src/channels/adapters/github/event-permissions.ts
+++ b/src/channels/adapters/github/event-permissions.ts
@@ -1,0 +1,83 @@
+// Maps a GitHub webhook event (in the form used in typeclaw.json#channels.github.eventAllowlist,
+// e.g. "issue_comment.created" or just "issues") to the GitHub App "Repository permissions"
+// key that gates BOTH receiving payload fields AND posting replies for that event family.
+//
+// Source: https://docs.github.com/en/webhooks/webhook-events-and-payloads (each event page
+// links to the App permission it requires).
+//
+// The permission key on the LEFT is what github.com calls the permission in the App settings UI
+// ("Issues", "Pull requests", "Discussions"); the value on the RIGHT is the snake_case key that
+// appears in the `permissions` object on GET /app/installations/{id} responses. They MUST match
+// the strings GitHub actually emits — these are checked at runtime against an installation grant
+// map, not normalised.
+export const EVENT_PERMISSION_KEY: Record<string, string> = {
+  issues: 'issues',
+  issue_comment: 'issues',
+  pull_request: 'pull_requests',
+  pull_request_review: 'pull_requests',
+  pull_request_review_comment: 'pull_requests',
+  pull_request_review_thread: 'pull_requests',
+  discussion: 'discussions',
+  discussion_comment: 'discussions',
+  commit_comment: 'contents',
+  push: 'contents',
+}
+
+// Human-readable label for each App permission key, mirroring github.com's
+// "Repository permissions" section verbatim. Used in the preflight warning so
+// users can grep for the exact string on the App settings page.
+export const PERMISSION_UI_LABEL: Record<string, string> = {
+  issues: 'Issues',
+  pull_requests: 'Pull requests',
+  discussions: 'Discussions',
+  contents: 'Contents',
+  metadata: 'Metadata',
+}
+
+export type GrantLevel = 'read' | 'write' | 'admin'
+
+// Accepts both the dotted form ("issues.opened", as used in
+// typeclaw.json#channels.github.eventAllowlist) and the bare event family
+// ("issues", as used in webhook event-header names).
+export function permissionKeyForEvent(event: string): string | null {
+  const family = event.includes('.') ? event.slice(0, event.indexOf('.')) : event
+  return EVENT_PERMISSION_KEY[family] ?? null
+}
+
+export type PermissionGap = {
+  permissionKey: string
+  uiLabel: string
+  granted: GrantLevel | null
+  events: string[]
+  needsWrite: boolean
+}
+
+// Unknown allowlist items are silently ignored — forward-compat for events
+// typeclaw doesn't yet know about. `needsWrite` is hardcoded true because
+// channel_reply is today's only canonical exit; flip to a per-event flag the
+// day a read-only github channel becomes a supported use case.
+export function findPermissionGaps(
+  eventAllowlist: readonly string[],
+  installationPermissions: Readonly<Record<string, GrantLevel>>,
+): PermissionGap[] {
+  const eventsByKey = new Map<string, Set<string>>()
+  for (const event of eventAllowlist) {
+    const key = permissionKeyForEvent(event)
+    if (key === null) continue
+    if (!eventsByKey.has(key)) eventsByKey.set(key, new Set())
+    eventsByKey.get(key)?.add(event)
+  }
+  const gaps: PermissionGap[] = []
+  for (const [permissionKey, events] of eventsByKey) {
+    const granted = installationPermissions[permissionKey] ?? null
+    if (granted === 'write' || granted === 'admin') continue
+    gaps.push({
+      permissionKey,
+      uiLabel: PERMISSION_UI_LABEL[permissionKey] ?? permissionKey,
+      granted,
+      events: [...events].sort(),
+      needsWrite: true,
+    })
+  }
+  return gaps.sort((a, b) => a.permissionKey.localeCompare(b.permissionKey))
+}

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -6,13 +6,18 @@ import type { GithubSecretsBlock } from '@/secrets/schema'
 import { buildAuthStrategy } from './auth'
 import { createGithubChannelNameResolver } from './channel-resolver'
 import { createDeliveryDedup } from './dedup'
+import { findPermissionGaps } from './event-permissions'
 import { createGithubFetchAttachmentCallback } from './fetch-attachment'
 import { createGithubHistoryCallback } from './history'
 import { createGithubWebhookHandler } from './inbound'
 import { applyManagedPath, buildManagedPath, resolveAgentId } from './managed-path'
 import { createGithubMembershipResolver } from './membership'
 import { createGithubOutboundCallback } from './outbound'
-import { buildPermissionGuidance, parseListHooksPermissionStatus } from './permission-guidance'
+import {
+  buildAppPermissionPreflightGuidance,
+  buildPermissionGuidance,
+  parseListHooksPermissionStatus,
+} from './permission-guidance'
 import { deregisterGithubWebhooks, registerGithubWebhooks, type WebhookRegistrationResult } from './webhook-register'
 
 export type GithubAdapterLogger = {
@@ -141,6 +146,11 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
       process.env.GH_TOKEN = await auth.token()
       started = true
       logger.info(`[github] webhook listening on port ${options.configRef().webhookPort} as @${self.login}`)
+      // Best-effort: App-only preflight that compares the installation's granted
+      // permissions against the configured eventAllowlist and warns about gaps.
+      // Catches the most common misconfiguration (App installed with the default
+      // metadata-only permission set) before any event fires a 403.
+      await runAppPermissionPreflight(logger, auth, options.configRef().eventAllowlist)
       // Repository webhook registration is best-effort: failures are logged
       // per-repo, the adapter stays up. A misconfigured PAT or App that
       // can't manage hooks must not prevent the adapter from accepting
@@ -289,6 +299,24 @@ function logRegistrationOutcome(
   if (permissionFailures.length > 0) {
     logger.warn(buildPermissionGuidance(authType, permissionFailures))
   }
+}
+
+async function runAppPermissionPreflight(
+  logger: GithubAdapterLogger,
+  auth: ReturnType<typeof buildAuthStrategy>,
+  eventAllowlist: readonly string[],
+): Promise<void> {
+  if (auth.getInstallationGrants === undefined) return
+  let grants
+  try {
+    grants = await auth.getInstallationGrants()
+  } catch (err) {
+    logger.warn(`[github] permission preflight skipped: ${err instanceof Error ? err.message : String(err)}`)
+    return
+  }
+  const gaps = findPermissionGaps(eventAllowlist, grants.permissions)
+  if (gaps.length === 0) return
+  logger.warn(buildAppPermissionPreflightGuidance(gaps))
 }
 
 function logDeregistrationOutcome(

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -1,10 +1,27 @@
 import { describe, expect, test } from 'bun:test'
+import { generateKeyPairSync } from 'node:crypto'
 
 import { createChannelRouter, type ChannelRouter } from '@/channels/router'
 import type { ChannelAdapterConfig, GithubAdapterConfig } from '@/channels/schema'
 import type { GithubSecretsBlock } from '@/secrets/schema'
 
 import { createGithubAdapter } from './index'
+
+const APP_PRIVATE_KEY_PEM = generateKeyPairSync('rsa', { modulusLength: 2048 })
+  .privateKey.export({ type: 'pkcs8', format: 'pem' })
+  .toString()
+
+function appSecrets(): GithubSecretsBlock {
+  return {
+    auth: {
+      type: 'app',
+      appId: 12345,
+      installationId: 99,
+      privateKey: { value: APP_PRIVATE_KEY_PEM },
+    },
+    webhookSecret: { value: 'wh-secret' },
+  }
+}
 
 type Call = { url: string; method: string; body?: string }
 
@@ -584,5 +601,144 @@ describe('createGithubAdapter lifecycle', () => {
     await adapter.stop()
 
     expect(deleted).toEqual([])
+  })
+
+  test('App auth: preflight warns when installation permissions do not cover the configured eventAllowlist', async () => {
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url === 'https://api.github.com/app' && method === 'GET') {
+        return Response.json({ slug: 'typeey-app' })
+      }
+      if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
+        return Response.json({ id: 42, login: 'typeey-app[bot]' })
+      }
+      if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
+        return Response.json({
+          permissions: { metadata: 'read', repository_hooks: 'write' },
+          events: [],
+        })
+      }
+      if (url === 'https://api.github.com/app/installations/99/access_tokens' && method === 'POST') {
+        return Response.json({ token: 'ghs_inst', expires_at: '2099-01-01T00:00:00Z' })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const logger = recordingLogger()
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig([], null),
+      secrets: appSecrets(),
+      agentDir: '/tmp/agent',
+      logger,
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+    })
+
+    await adapter.start()
+    await adapter.stop()
+
+    const preflightWarning = logger.messages.find((m) =>
+      m.startsWith('warn:[github] GitHub App installation is missing permissions'),
+    )
+    expect(preflightWarning).toBeDefined()
+    expect(preflightWarning).toContain('Issues: granted=none, need=Read and write')
+    expect(preflightWarning).toContain('Pull requests: granted=none, need=Read and write')
+    expect(preflightWarning).toContain('covers: issue_comment.created')
+    expect(preflightWarning).toContain('Resource not accessible by integration')
+  })
+
+  test('App auth: preflight stays silent when every required permission is granted', async () => {
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url === 'https://api.github.com/app' && method === 'GET') {
+        return Response.json({ slug: 'typeey-app' })
+      }
+      if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
+        return Response.json({ id: 42, login: 'typeey-app[bot]' })
+      }
+      if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
+        return Response.json({
+          permissions: { issues: 'write', pull_requests: 'write', metadata: 'read' },
+          events: ['issues', 'issue_comment', 'pull_request'],
+        })
+      }
+      if (url === 'https://api.github.com/app/installations/99/access_tokens' && method === 'POST') {
+        return Response.json({ token: 'ghs_inst', expires_at: '2099-01-01T00:00:00Z' })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const logger = recordingLogger()
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig([], null),
+      secrets: appSecrets(),
+      agentDir: '/tmp/agent',
+      logger,
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+    })
+
+    await adapter.start()
+    await adapter.stop()
+
+    expect(logger.messages.some((m) => m.includes('GitHub App installation is missing'))).toBe(false)
+  })
+
+  test('PAT auth: preflight is skipped (no installation grant to inspect)', async () => {
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const logger = recordingLogger()
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig([], null),
+      secrets: patSecrets(),
+      agentDir: '/tmp/agent',
+      logger,
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+    })
+
+    await adapter.start()
+    await adapter.stop()
+
+    expect(logger.messages.some((m) => m.includes('GitHub App installation is missing'))).toBe(false)
+    expect(logger.messages.some((m) => m.includes('preflight skipped'))).toBe(false)
+  })
+
+  test('App auth: preflight failure is logged as a skip, not propagated as an adapter-start error', async () => {
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url === 'https://api.github.com/app' && method === 'GET') {
+        return Response.json({ slug: 'typeey-app' })
+      }
+      if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
+        return Response.json({ id: 42, login: 'typeey-app[bot]' })
+      }
+      if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
+        return new Response('boom', { status: 500 })
+      }
+      if (url === 'https://api.github.com/app/installations/99/access_tokens' && method === 'POST') {
+        return Response.json({ token: 'ghs_inst', expires_at: '2099-01-01T00:00:00Z' })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const logger = recordingLogger()
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig([], null),
+      secrets: appSecrets(),
+      agentDir: '/tmp/agent',
+      logger,
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+    })
+
+    await expect(adapter.start()).resolves.toBeUndefined()
+    await adapter.stop()
+
+    expect(logger.messages.find((m) => m.startsWith('warn:[github] permission preflight skipped:'))).toBeDefined()
   })
 })

--- a/src/channels/adapters/github/permission-guidance.test.ts
+++ b/src/channels/adapters/github/permission-guidance.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 
-import { buildPermissionGuidance, parseListHooksPermissionStatus } from './permission-guidance'
+import {
+  buildAppPermissionPreflightGuidance,
+  buildPermissionGuidance,
+  parseListHooksPermissionStatus,
+} from './permission-guidance'
 
 describe('parseListHooksPermissionStatus', () => {
   test('returns 404 for a 404 list-hooks error', () => {
@@ -126,5 +130,75 @@ describe('buildPermissionGuidance', () => {
     expect(patMsg).toContain('hides private repos')
     expect(appMsg).toContain('404')
     expect(appMsg).toContain('hides private repos')
+  })
+})
+
+describe('buildAppPermissionPreflightGuidance', () => {
+  test('headlines with the number of missing permission families', () => {
+    const msg = buildAppPermissionPreflightGuidance([
+      { permissionKey: 'issues', uiLabel: 'Issues', granted: null, events: ['issues.opened'], needsWrite: true },
+    ])
+    expect(msg).toContain('missing permissions for 1 configured event family')
+  })
+
+  test('pluralises the headline when multiple families are missing', () => {
+    const msg = buildAppPermissionPreflightGuidance([
+      { permissionKey: 'issues', uiLabel: 'Issues', granted: null, events: ['issues.opened'], needsWrite: true },
+      {
+        permissionKey: 'pull_requests',
+        uiLabel: 'Pull requests',
+        granted: null,
+        events: ['pull_request.opened'],
+        needsWrite: true,
+      },
+    ])
+    expect(msg).toContain('2 configured event families')
+  })
+
+  test('uses verbatim github.com UI labels for each gap', () => {
+    const msg = buildAppPermissionPreflightGuidance([
+      {
+        permissionKey: 'pull_requests',
+        uiLabel: 'Pull requests',
+        granted: 'read',
+        events: ['pull_request.opened'],
+        needsWrite: true,
+      },
+    ])
+    expect(msg).toContain('Pull requests: granted=read, need=Read and write')
+    expect(msg).toContain('Permissions & events')
+  })
+
+  test('lists the events covered by each missing permission so the user knows what will fail', () => {
+    const msg = buildAppPermissionPreflightGuidance([
+      {
+        permissionKey: 'issues',
+        uiLabel: 'Issues',
+        granted: null,
+        events: ['issue_comment.created', 'issues.opened'],
+        needsWrite: true,
+      },
+    ])
+    expect(msg).toContain('covers: issue_comment.created, issues.opened')
+  })
+
+  test('reports granted=none when no grant exists at all (not "read" or "write")', () => {
+    const msg = buildAppPermissionPreflightGuidance([
+      {
+        permissionKey: 'discussions',
+        uiLabel: 'Discussions',
+        granted: null,
+        events: ['discussion.created'],
+        needsWrite: true,
+      },
+    ])
+    expect(msg).toContain('granted=none')
+  })
+
+  test('mentions the 403 message users will see if they ignore the warning', () => {
+    const msg = buildAppPermissionPreflightGuidance([
+      { permissionKey: 'issues', uiLabel: 'Issues', granted: null, events: ['issues.opened'], needsWrite: true },
+    ])
+    expect(msg).toContain('Resource not accessible by integration')
   })
 })

--- a/src/channels/adapters/github/permission-guidance.ts
+++ b/src/channels/adapters/github/permission-guidance.ts
@@ -1,3 +1,5 @@
+import type { PermissionGap } from './event-permissions'
+
 export type GithubAuthType = 'pat' | 'app'
 
 // Parses webhook-register errors of the shape `list hooks failed: <status> <body>`.
@@ -65,5 +67,31 @@ export function buildPermissionGuidance(
       '    5. If the app permissions changed in step 2, install owners must accept the updated permissions from the install page before the new access takes effect.',
     )
   }
+  return lines.join('\n')
+}
+
+// Always GitHub App: PATs don't have per-installation permission grants
+// (their access is gated by token scopes, surfaced by the existing 404/403
+// flow in webhook-register).
+export function buildAppPermissionPreflightGuidance(gaps: ReadonlyArray<PermissionGap>): string {
+  const lines = [
+    `[github] GitHub App installation is missing permissions for ${gaps.length} configured event ${gaps.length === 1 ? 'family' : 'families'}:`,
+  ]
+  for (const gap of gaps) {
+    const eventList = gap.events.join(', ')
+    const grantedLabel = gap.granted === null ? 'none' : gap.granted
+    const needLabel = gap.needsWrite ? 'Read and write' : 'Read-only'
+    lines.push(`  - ${gap.uiLabel}: granted=${grantedLabel}, need=${needLabel} (covers: ${eventList})`)
+  }
+  lines.push(
+    '',
+    '  Fix:',
+    '    1. Open https://github.com/settings/apps and edit the app TypeClaw is using.',
+    '    2. Under "Permissions & events" → "Repository permissions", set each missing permission above to the listed level. Save.',
+    '    3. Open the install page (Install App / Configure for the org) and accept the updated permissions request — the new access only takes effect after the install owner accepts.',
+    '    4. If the org enforces SAML SSO, ensure the App is authorized for the org from the org settings → Third-party Apps page.',
+    '',
+    '  Webhooks already received will continue to deliver, but payload fields and reply attempts that require the missing permission will fail with 403 ("Resource not accessible by integration") until the install is reaccepted.',
+  )
   return lines.join('\n')
 }


### PR DESCRIPTION
## What this PR does

Catches the most common GitHub App misconfiguration **at adapter start**, before any webhook event triggers a `403 Resource not accessible by integration` deep inside the outbound path. If the App was installed with only the default `metadata: read` permission (or any subset that doesn't cover the configured `eventAllowlist`), `typeclaw start` now logs a precise, actionable warning naming every missing permission family, the events that depend on it, and the exact steps to fix it.

This is **PR-B of three** in a series triggered by a real-world bug report (#392, #393, follow-ups). PR-A (#395) extracted the existing webhook-time permission guidance into its own module so this PR could add a sibling formatter without entangling the adapter factory. PR-C (forthcoming) will add per-endpoint guidance to outbound 403s for cases where the preflight permission state changes between adapter start and a later API call.

## The bug this prevents

User reported a clean install where the github channel adapter started cleanly, registered its webhook successfully, received inbound events, but every `channel_reply` failed with:

```
[channels] channel_reply failed: github:typeclaw/typeclaw/issue:394: GitHub API 403:
  {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/issues/comments#create-an-issue-comment","status":"403"}
```

A live probe against the installation confirmed the cause:

```
GET /app/installations/{id}
{
  "permissions": { "metadata": "read", "repository_hooks": "write" },
  "events": []
}
```

The App was installed with only enough access to register a webhook. Every configured event in `typeclaw.json#channels.github.eventAllowlist` (7 of them, spanning issues, pull requests, and discussions) needed at least `Read & write` on its corresponding repository permission — none of which were granted. The first symptom appeared not at `start()`, not at webhook registration, not at the first inbound event, but at the **first attempted reply**, as an opaque 403 from a deep call inside `outbound.ts`.

The root cause is a user-side config issue. The typeclaw-side problem is that we let the user discover it the worst possible way.

## The fix

Three small primitives and one wiring change. Each is a separate commit on this branch so review can happen file-by-file:

### Commit 1: `channels: add event-permissions module mapping github events to App permission families`

New `src/channels/adapters/github/event-permissions.ts`. Static reference data (event family → permission key) sourced from https://docs.github.com/en/webhooks/webhook-events-and-payloads, plus a `findPermissionGaps()` helper that coalesces an `eventAllowlist` into one `PermissionGap` per missing-or-under-leveled permission family.

Edge cases pinned by 10 unit tests in `event-permissions.test.ts`:
- dotted (`'issues.opened'`) and bare (`'issues'`) event names both resolve
- `admin` grant satisfies a `write` requirement
- allowlist items typeclaw doesn't recognise are silently ignored (forward-compat)
- multiple events under one permission coalesce into one `Gap`
- `Gap`s are sorted by permission key for stable warning output

### Commit 2: `channels: expose installation permission map via AppAuthStrategy`

`GithubAuthStrategy` (in `auth.ts`) gains an **optional** `getInstallationGrants(): Promise<GithubInstallationGrants>`. Implemented on `AppAuthStrategy` via `GET /app/installations/{installation_id}`, returns `{ permissions, events }`. The response parser drops unknown permission levels and non-string events so the rest of the pipeline never sees malformed grants (GitHub's permission vocabulary has expanded several times historically).

PAT auth leaves this slot undefined by design — PAT access is gated by token scopes, surfaced by the existing 404/403 flow in `webhook-register`. A PAT implementation of this method would have to lie about its model. `typeof` check at the call site short-circuits cleanly.

3 unit tests in `auth-app.test.ts` cover happy path, filtering, and HTTP failure.

### Commit 3: `channels: add buildAppPermissionPreflightGuidance string builder`

New string formatter in `permission-guidance.ts` (next to the existing `buildPermissionGuidance` so both keep their github.com UI labels in lockstep). Multi-line warning that:
- headlines with the count of missing permission families (singular/plural pluralised)
- lists each `Gap` with its verbatim github.com UI label (`'Issues'`, `'Pull requests'`, `'Discussions'`), the events it covers, current grant level, required level
- ends with a numbered fix and the 403 body text users will hit if they ignore the warning (so they can grep their logs for either the preflight warning OR the 403 itself and arrive at the same fix)

App-only by design (PATs never produce a `PermissionGap`). 6 unit tests in `permission-guidance.test.ts` cover headline pluralisation, label verbatim-ness, event listing, `granted=none`, and 403-symptom mention.

### Commit 4: `channels: run github app permission preflight at adapter start`

The actual wiring. `start()` already calls `auth.getSelf()` to resolve the bot's login/id; right after, it now awaits a new `runAppPermissionPreflight(logger, auth, eventAllowlist)`. The helper:
- short-circuits when `auth.getInstallationGrants` is undefined (PAT)
- catches any throw from GitHub and logs as `[github] permission preflight skipped: <reason>` — the adapter must come up regardless of GitHub-side availability for a supplementary check
- compares grants against the allowlist via `findPermissionGaps`, logs the warning if any gaps exist

4 integration tests in `lifecycle.test.ts`:
- App + insufficient grants → preflight warning is emitted with the right text
- App + sufficient grants → no preflight warning
- PAT → preflight does not run (no `getInstallationGrants` method)
- App + GitHub returns 500 on installation fetch → preflight skipped, `start()` still resolves successfully

## Verified end-to-end against the misconfigured App that triggered the bug

```sh
$ bun -e 'import { AppAuthStrategy } from "./src/channels/adapters/github/auth-app.ts";
          import { findPermissionGaps } from "./src/channels/adapters/github/event-permissions.ts";
          import { buildAppPermissionPreflightGuidance } from "./src/channels/adapters/github/permission-guidance.ts";
          const strat = new AppAuthStrategy({ appId, privateKey: { value: pem } });
          const grants = await strat.getInstallationGrants();
          const gaps = findPermissionGaps(allowlist, grants.permissions);
          console.log(buildAppPermissionPreflightGuidance(gaps));'

[github] GitHub App installation is missing permissions for 3 configured event families:
  - Discussions: granted=none, need=Read and write (covers: discussion.created, discussion_comment.created)
  - Issues: granted=none, need=Read and write (covers: issue_comment.created, issues.opened)
  - Pull requests: granted=none, need=Read and write (covers: pull_request.opened, pull_request_review.submitted, pull_request_review_comment.created)

  Fix:
    1. Open https://github.com/settings/apps and edit the app TypeClaw is using.
    2. Under "Permissions & events" → "Repository permissions", set each missing permission above to the listed level. Save.
    3. Open the install page (Install App / Configure for the org) and accept the updated permissions request — the new access only takes effect after the install owner accepts.
    4. If the org enforces SAML SSO, ensure the App is authorized for the org from the org settings → Third-party Apps page.

  Webhooks already received will continue to deliver, but payload fields and reply attempts that require the missing permission will fail with 403 ("Resource not accessible by integration") until the install is reaccepted.
```

Exactly the user's misconfiguration, exactly the fix steps. No guesswork.

## Files

| File | Status | Lines |
|---|---|---|
| `src/channels/adapters/github/event-permissions.ts` | NEW | +83 |
| `src/channels/adapters/github/event-permissions.test.ts` | NEW | +84 |
| `src/channels/adapters/github/auth.ts` | EDIT | +10 −0 |
| `src/channels/adapters/github/auth-app.ts` | EDIT | +19 −1 |
| `src/channels/adapters/github/auth-app.test.ts` | EDIT | +54 −0 |
| `src/channels/adapters/github/permission-guidance.ts` | EDIT | +27 −1 |
| `src/channels/adapters/github/permission-guidance.test.ts` | EDIT | +75 −1 |
| `src/channels/adapters/github/index.ts` | EDIT | +29 −1 |
| `src/channels/adapters/github/lifecycle.test.ts` | EDIT | +156 −0 |

Net behavior change is one new `await` in `start()` and a recorder-logger warning when grants are insufficient. No changes to webhook registration, inbound handling, outbound calls, or any other adapter path.

## Verification

```
bun run typecheck                                                ✓
bun run lint                                                     ✓  (0 errors)
bun run format:check                                             ✓
bun test --parallel src/channels/adapters/github/              119 pass, 0 fail across 13 files  (+23 from main)
bun run test                                                   5560 pass, 0 fail across 306 files  (+23 from main)
```

Each commit was verified to typecheck and pass its own tests in isolation:
- After commit 1: typecheck ✓, 10 new tests pass.
- After commit 2: typecheck ✓, 13 new tests pass (10 + 3).
- After commit 3: typecheck ✓, 19 new tests pass (10 + 3 + 6).
- After commit 4: typecheck ✓, 23 new tests pass (10 + 3 + 6 + 4).

## Sequencing

PR-B in a 3-PR series. Currently branched off **PR-A** (#395 — refactor that extracted `permission-guidance.ts` into its own file). Once #395 merges, this PR will be rebased onto `main` (a no-op rebase if #395 lands first, since this PR consumes #395's module via its already-correct import path).

PR-C (outbound 403 guidance) is independent of this PR; it can land in either order after #395.
