### PR TITLE
channels: decorate github outbound 403s with the exact permission fix

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -78,7 +78,12 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     process.env.GH_TOKEN = t
     return t
   }
-  const outbound = createGithubOutboundCallback({ token: tokenFn, logger, fetchImpl })
+  const outbound = createGithubOutboundCallback({
+    token: tokenFn,
+    authType: options.secrets.auth.type,
+    logger,
+    fetchImpl,
+  })
   const history = createGithubHistoryCallback({
     token: tokenFn,
     fetchImpl,

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -123,7 +123,12 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
       },
       { preconnect: () => {} },
     ) as typeof fetch
-    const outbound = createGithubOutboundCallback({ token: async () => 'tok', logger: silent, fetchImpl })
+    const outbound = createGithubOutboundCallback({
+      token: async () => 'tok',
+      authType: 'app',
+      logger: silent,
+      fetchImpl,
+    })
 
     const origin: ChannelReplyOrigin = {
       adapter: 'github',
@@ -165,7 +170,12 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
       },
       { preconnect: () => {} },
     ) as typeof fetch
-    const outbound = createGithubOutboundCallback({ token: async () => 'tok', logger: silent, fetchImpl })
+    const outbound = createGithubOutboundCallback({
+      token: async () => 'tok',
+      authType: 'app',
+      logger: silent,
+      fetchImpl,
+    })
 
     const tool = createChannelReplyTool({
       router: fakeRouter(async (msg) => outbound(msg)),
@@ -192,7 +202,12 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
       },
       { preconnect: () => {} },
     ) as typeof fetch
-    const outbound = createGithubOutboundCallback({ token: async () => 'tok', logger: silent, fetchImpl })
+    const outbound = createGithubOutboundCallback({
+      token: async () => 'tok',
+      authType: 'app',
+      logger: silent,
+      fetchImpl,
+    })
 
     const tool = createChannelReplyTool({
       router: fakeRouter(async (msg) => outbound(msg)),

--- a/src/channels/adapters/github/outbound.test.ts
+++ b/src/channels/adapters/github/outbound.test.ts
@@ -18,6 +18,7 @@ describe('createGithubOutboundCallback', () => {
   it('posts issue and top-level PR comments through the issues comments endpoint', async () => {
     const cb = createGithubOutboundCallback({
       token: async () => 'tok',
+      authType: 'app',
       logger,
       fetchImpl: fakeFetch({
         'POST https://api.github.com/repos/acme/project/issues/42/comments': { status: 201, body: { id: 1 } },
@@ -38,6 +39,7 @@ describe('createGithubOutboundCallback', () => {
   it('posts PR review thread replies through the pull comment replies endpoint', async () => {
     const cb = createGithubOutboundCallback({
       token: async () => 'tok',
+      authType: 'app',
       logger,
       fetchImpl: fakeFetch({
         'POST https://api.github.com/repos/acme/project/pulls/42/comments/99/replies': { status: 201, body: { id: 2 } },
@@ -56,7 +58,12 @@ describe('createGithubOutboundCallback', () => {
   })
 
   it('rejects attachments', async () => {
-    const cb = createGithubOutboundCallback({ token: async () => 'tok', logger, fetchImpl: fakeFetch({}) })
+    const cb = createGithubOutboundCallback({
+      token: async () => 'tok',
+      authType: 'app',
+      logger,
+      fetchImpl: fakeFetch({}),
+    })
 
     const result = await cb({
       adapter: 'github',
@@ -67,5 +74,174 @@ describe('createGithubOutboundCallback', () => {
     })
 
     expect(result).toEqual({ ok: false, error: 'github-bot-does-not-support-attachments' })
+  })
+
+  describe('outbound 403 permission guidance', () => {
+    it('decorates an Issues 403 with App-specific guidance when authType is app', async () => {
+      const cb = createGithubOutboundCallback({
+        token: async () => 'tok',
+        authType: 'app',
+        logger,
+        fetchImpl: fakeFetch({
+          'POST https://api.github.com/repos/acme/project/issues/42/comments': {
+            status: 403,
+            body: { message: 'Resource not accessible by integration' },
+          },
+        }),
+      })
+
+      const result = await cb({
+        adapter: 'github',
+        workspace: 'acme/project',
+        chat: 'issue:42',
+        thread: null,
+        text: 'hello',
+      })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toContain('GitHub API 403')
+      expect(result.error).toContain('Resource not accessible by integration')
+      expect(result.error).toContain('Fix (GitHub App): the App needs "Issues" → "Read and write"')
+      expect(result.error).toContain('https://github.com/settings/apps')
+    })
+
+    it('decorates a PR-reply 403 with the Pull requests permission, not Issues', async () => {
+      const cb = createGithubOutboundCallback({
+        token: async () => 'tok',
+        authType: 'app',
+        logger,
+        fetchImpl: fakeFetch({
+          'POST https://api.github.com/repos/acme/project/pulls/42/comments/99/replies': {
+            status: 403,
+            body: { message: 'Resource not accessible by integration' },
+          },
+        }),
+      })
+
+      const result = await cb({
+        adapter: 'github',
+        workspace: 'acme/project',
+        chat: 'pr:42',
+        thread: '99',
+        text: 'hi',
+      })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toContain('"Pull requests" → "Read and write"')
+      expect(result.error).not.toContain('"Issues" →')
+    })
+
+    it('decorates with PAT-specific guidance when authType is pat', async () => {
+      const cb = createGithubOutboundCallback({
+        token: async () => 'tok',
+        authType: 'pat',
+        logger,
+        fetchImpl: fakeFetch({
+          'POST https://api.github.com/repos/acme/project/issues/42/comments': {
+            status: 403,
+            body: { message: 'Resource not accessible by integration' },
+          },
+        }),
+      })
+
+      const result = await cb({
+        adapter: 'github',
+        workspace: 'acme/project',
+        chat: 'issue:42',
+        thread: null,
+        text: 'hello',
+      })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toContain('Fix (fine-grained personal access token)')
+      expect(result.error).toContain('"Issues" → "Read and write"')
+      expect(result.error).toContain('classic personal access token')
+      expect(result.error).not.toContain('Fix (GitHub App)')
+    })
+
+    it('does NOT decorate other 403 shapes (e.g. org SSO) so the wrong fix is not suggested', async () => {
+      const cb = createGithubOutboundCallback({
+        token: async () => 'tok',
+        authType: 'app',
+        logger,
+        fetchImpl: fakeFetch({
+          'POST https://api.github.com/repos/acme/project/issues/42/comments': {
+            status: 403,
+            body: { message: 'Resource protected by organization SAML enforcement.' },
+          },
+        }),
+      })
+
+      const result = await cb({
+        adapter: 'github',
+        workspace: 'acme/project',
+        chat: 'issue:42',
+        thread: null,
+        text: 'hello',
+      })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toContain('GitHub API 403')
+      expect(result.error).toContain('SAML enforcement')
+      expect(result.error).not.toContain('Fix (GitHub App)')
+      expect(result.error).not.toContain('Fix (fine-grained')
+    })
+
+    it('does NOT decorate non-403 errors', async () => {
+      const cb = createGithubOutboundCallback({
+        token: async () => 'tok',
+        authType: 'app',
+        logger,
+        fetchImpl: fakeFetch({
+          'POST https://api.github.com/repos/acme/project/issues/42/comments': {
+            status: 422,
+            body: { message: 'Validation Failed' },
+          },
+        }),
+      })
+
+      const result = await cb({
+        adapter: 'github',
+        workspace: 'acme/project',
+        chat: 'issue:42',
+        thread: null,
+        text: 'hello',
+      })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toContain('GitHub API 422')
+      expect(result.error).not.toContain('Fix (')
+    })
+
+    it('preserves the existing "GitHub API ${status}:" prefix so downstream parsers keep working', async () => {
+      const cb = createGithubOutboundCallback({
+        token: async () => 'tok',
+        authType: 'app',
+        logger,
+        fetchImpl: fakeFetch({
+          'POST https://api.github.com/repos/acme/project/issues/42/comments': {
+            status: 403,
+            body: { message: 'Resource not accessible by integration' },
+          },
+        }),
+      })
+
+      const result = await cb({
+        adapter: 'github',
+        workspace: 'acme/project',
+        chat: 'issue:42',
+        thread: null,
+        text: 'hello',
+      })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error.startsWith('GitHub API 403:')).toBe(true)
+    })
   })
 })

--- a/src/channels/adapters/github/outbound.ts
+++ b/src/channels/adapters/github/outbound.ts
@@ -1,11 +1,18 @@
 import type { OutboundCallback, OutboundMessage, SendResult } from '@/channels/types'
 
 import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
+import {
+  buildOutboundPermissionGuidance,
+  type GithubAuthType,
+  isOutboundPermissionDenial,
+  type OutboundEndpointKind,
+} from './permission-guidance'
 
 export type GithubOutboundLogger = { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void }
 
 export function createGithubOutboundCallback(deps: {
   token: () => Promise<string>
+  authType: GithubAuthType
   logger: GithubOutboundLogger
   fetchImpl?: typeof fetch
 }): OutboundCallback {
@@ -22,19 +29,35 @@ export function createGithubOutboundCallback(deps: {
     if (target === null) return { ok: false, error: `invalid GitHub chat: ${msg.chat}` }
 
     if (target.kind === 'discussion') {
-      return await postDiscussionComment({ ...deps, fetchImpl, repo, discussionNumber: target.number, body })
+      return await postDiscussionComment({
+        ...deps,
+        fetchImpl,
+        repo,
+        discussionNumber: target.number,
+        body,
+      })
     }
 
-    const endpoint =
-      target.kind === 'pr' && msg.thread !== null && msg.thread !== undefined && msg.thread !== ''
-        ? `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${target.number}/comments/${encodeURIComponent(msg.thread)}/replies`
-        : `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${target.number}/comments`
-    return await postJson(fetchImpl, await deps.token(), endpoint, { body })
+    const isPrReviewReply = target.kind === 'pr' && msg.thread !== null && msg.thread !== undefined && msg.thread !== ''
+    const endpoint = isPrReviewReply
+      ? `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls/${target.number}/comments/${encodeURIComponent(msg.thread ?? '')}/replies`
+      : `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${target.number}/comments`
+    return await postJson(
+      fetchImpl,
+      await deps.token(),
+      endpoint,
+      { body },
+      {
+        authType: deps.authType,
+        endpointKind: isPrReviewReply ? 'pr-review-reply' : 'issue-comment',
+      },
+    )
   }
 }
 
 async function postDiscussionComment(options: {
   token: () => Promise<string>
+  authType: GithubAuthType
   fetchImpl: typeof fetch
   repo: RepoRef
   discussionNumber: number
@@ -43,14 +66,21 @@ async function postDiscussionComment(options: {
   const discussionId = await fetchDiscussionId(options)
   if (!discussionId.ok) return discussionId
   const mutation = `mutation($discussionId:ID!,$body:String!){addDiscussionComment(input:{discussionId:$discussionId,body:$body}){comment{id}}}`
-  return await postGraphql(options.fetchImpl, await options.token(), mutation, {
-    discussionId: discussionId.id,
-    body: options.body,
-  })
+  return await postGraphql(
+    options.fetchImpl,
+    await options.token(),
+    mutation,
+    {
+      discussionId: discussionId.id,
+      body: options.body,
+    },
+    { authType: options.authType, endpointKind: 'discussion-comment' },
+  )
 }
 
 async function fetchDiscussionId(options: {
   token: () => Promise<string>
+  authType: GithubAuthType
   fetchImpl: typeof fetch
   repo: RepoRef
   discussionNumber: number
@@ -65,6 +95,7 @@ async function fetchDiscussionId(options: {
       name: options.repo.name,
       number: options.discussionNumber,
     },
+    { authType: options.authType, endpointKind: 'discussion-comment' },
   )
   if (!result.ok) return result
   const id = result.data.repository?.discussion?.id
@@ -76,8 +107,9 @@ async function postGraphql(
   token: string,
   query: string,
   variables: Record<string, unknown>,
+  guidance: { authType: GithubAuthType; endpointKind: OutboundEndpointKind },
 ): Promise<SendResult> {
-  const result = await graphql(fetchImpl, token, query, variables)
+  const result = await graphql(fetchImpl, token, query, variables, guidance)
   return result.ok ? { ok: true } : { ok: false, error: result.error }
 }
 
@@ -86,6 +118,7 @@ async function graphql<T>(
   token: string,
   query: string,
   variables: Record<string, unknown>,
+  guidance: { authType: GithubAuthType; endpointKind: OutboundEndpointKind },
 ): Promise<{ ok: true; data: T } | { ok: false; error: string }> {
   try {
     const response = await fetchImpl(`${GITHUB_API_BASE}/graphql`, {
@@ -95,10 +128,15 @@ async function graphql<T>(
     })
     const raw = (await response.json()) as { data?: T; errors?: Array<{ message?: string }> }
     if (!response.ok || raw.errors !== undefined) {
-      return {
-        ok: false,
-        error: raw.errors?.map((e) => e.message ?? 'unknown').join('; ') ?? `HTTP ${response.status}`,
-      }
+      // GraphQL errors carry a permission-denial in their `errors[].type` =
+      // 'FORBIDDEN' or message text. Match on either the HTTP 403 (rare for
+      // GraphQL) or the literal denial string in any error message.
+      const message = raw.errors?.map((e) => e.message ?? 'unknown').join('; ') ?? `HTTP ${response.status}`
+      const baseError = response.ok ? message : `GitHub API ${response.status}: ${message}`
+      const decorated = isOutboundPermissionDenial(response.ok ? 403 : response.status, message)
+        ? `${baseError}${buildOutboundPermissionGuidance(guidance)}`
+        : baseError
+      return { ok: false, error: decorated }
     }
     if (raw.data === undefined) return { ok: false, error: 'GraphQL response missing data' }
     return { ok: true, data: raw.data }
@@ -107,7 +145,13 @@ async function graphql<T>(
   }
 }
 
-async function postJson(fetchImpl: typeof fetch, token: string, url: string, payload: unknown): Promise<SendResult> {
+async function postJson(
+  fetchImpl: typeof fetch,
+  token: string,
+  url: string,
+  payload: unknown,
+  guidance: { authType: GithubAuthType; endpointKind: OutboundEndpointKind },
+): Promise<SendResult> {
   try {
     const response = await fetchImpl(url, {
       method: 'POST',
@@ -116,7 +160,11 @@ async function postJson(fetchImpl: typeof fetch, token: string, url: string, pay
     })
     if (response.ok) return { ok: true }
     const text = await response.text().catch(() => '')
-    return { ok: false, error: `GitHub API ${response.status}${text !== '' ? `: ${text}` : ''}` }
+    const baseError = `GitHub API ${response.status}${text !== '' ? `: ${text}` : ''}`
+    const decorated = isOutboundPermissionDenial(response.status, text)
+      ? `${baseError}${buildOutboundPermissionGuidance(guidance)}`
+      : baseError
+    return { ok: false, error: decorated }
   } catch (err) {
     return { ok: false, error: describe(err) }
   }

--- a/src/channels/adapters/github/permission-guidance.test.ts
+++ b/src/channels/adapters/github/permission-guidance.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   buildAppPermissionPreflightGuidance,
+  buildOutboundPermissionGuidance,
   buildPermissionGuidance,
+  isOutboundPermissionDenial,
   parseListHooksPermissionStatus,
 } from './permission-guidance'
 
@@ -200,5 +202,65 @@ describe('buildAppPermissionPreflightGuidance', () => {
       { permissionKey: 'issues', uiLabel: 'Issues', granted: null, events: ['issues.opened'], needsWrite: true },
     ])
     expect(msg).toContain('Resource not accessible by integration')
+  })
+})
+
+describe('isOutboundPermissionDenial', () => {
+  test('matches the exact GitHub body for a permission-denied integration', () => {
+    expect(isOutboundPermissionDenial(403, '{"message":"Resource not accessible by integration"}')).toBe(true)
+  })
+
+  test('does not match other 403 bodies (e.g. org SSO)', () => {
+    expect(isOutboundPermissionDenial(403, '{"message":"Resource protected by organization SAML enforcement."}')).toBe(
+      false,
+    )
+  })
+
+  test('does not match a permission-denial string on a non-403 status', () => {
+    expect(isOutboundPermissionDenial(401, 'Resource not accessible by integration')).toBe(false)
+    expect(isOutboundPermissionDenial(404, 'Resource not accessible by integration')).toBe(false)
+  })
+
+  test('matches when the denial string is embedded in a longer body', () => {
+    expect(
+      isOutboundPermissionDenial(403, '{"foo":1,"message":"Resource not accessible by integration","bar":2}'),
+    ).toBe(true)
+  })
+})
+
+describe('buildOutboundPermissionGuidance', () => {
+  test('App + issue-comment names the "Issues" permission at "Read and write"', () => {
+    const g = buildOutboundPermissionGuidance({ authType: 'app', endpointKind: 'issue-comment' })
+    expect(g).toContain('Fix (GitHub App): the App needs "Issues" → "Read and write".')
+    expect(g).toContain('Open the install page')
+  })
+
+  test('App + pr-review-reply names "Pull requests", not "Issues"', () => {
+    const g = buildOutboundPermissionGuidance({ authType: 'app', endpointKind: 'pr-review-reply' })
+    expect(g).toContain('"Pull requests" → "Read and write"')
+    expect(g).not.toContain('"Issues" →')
+  })
+
+  test('App + discussion-comment names "Discussions"', () => {
+    const g = buildOutboundPermissionGuidance({ authType: 'app', endpointKind: 'discussion-comment' })
+    expect(g).toContain('"Discussions" → "Read and write"')
+  })
+
+  test('PAT + issue-comment names "Issues" for fine-grained and "repo" for classic', () => {
+    const g = buildOutboundPermissionGuidance({ authType: 'pat', endpointKind: 'issue-comment' })
+    expect(g).toContain('Fix (fine-grained personal access token)')
+    expect(g).toContain('"Issues" → "Read and write"')
+    expect(g).toContain('"repo (or public_repo for public repos)" scope')
+  })
+
+  test('PAT + discussion-comment uses the discussion-specific scope and label', () => {
+    const g = buildOutboundPermissionGuidance({ authType: 'pat', endpointKind: 'discussion-comment' })
+    expect(g).toContain('"Discussions" → "Read and write"')
+    expect(g).toContain('"repo" scope')
+  })
+
+  test('App guidance reminds the user the install owner must reaccept the new permissions', () => {
+    const g = buildOutboundPermissionGuidance({ authType: 'app', endpointKind: 'issue-comment' })
+    expect(g).toContain('accept the updated permissions request')
   })
 })

--- a/src/channels/adapters/github/permission-guidance.ts
+++ b/src/channels/adapters/github/permission-guidance.ts
@@ -2,6 +2,12 @@ import type { PermissionGap } from './event-permissions'
 
 export type GithubAuthType = 'pat' | 'app'
 
+// What kind of outbound API the adapter was trying to call when it got a
+// permission-failure response. Each value maps to a distinct GitHub App
+// permission family (and, for PATs, a distinct scope), so each surfaces a
+// different remediation message.
+export type OutboundEndpointKind = 'issue-comment' | 'pr-review-reply' | 'discussion-comment'
+
 // Parses webhook-register errors of the shape `list hooks failed: <status> <body>`.
 // Returns the status code when it matches the two shapes GitHub emits for
 // missing access on the list-hooks endpoint:
@@ -94,4 +100,70 @@ export function buildAppPermissionPreflightGuidance(gaps: ReadonlyArray<Permissi
     '  Webhooks already received will continue to deliver, but payload fields and reply attempts that require the missing permission will fail with 403 ("Resource not accessible by integration") until the install is reaccepted.',
   )
   return lines.join('\n')
+}
+
+// The label and (for App auth) the level appear verbatim on github.com so
+// users can grep their settings page for the exact strings. The PAT scope
+// names are GitHub's canonical token-scope identifiers, also verbatim.
+const OUTBOUND_PERMISSION_FOR_KIND: Record<
+  OutboundEndpointKind,
+  { label: string; level: 'Read and write'; patScope: string; patFineGrained: string }
+> = {
+  'issue-comment': {
+    label: 'Issues',
+    level: 'Read and write',
+    patScope: 'repo (or public_repo for public repos)',
+    patFineGrained: 'Issues',
+  },
+  'pr-review-reply': {
+    label: 'Pull requests',
+    level: 'Read and write',
+    patScope: 'repo',
+    patFineGrained: 'Pull requests',
+  },
+  'discussion-comment': {
+    label: 'Discussions',
+    level: 'Read and write',
+    patScope: 'repo',
+    patFineGrained: 'Discussions',
+  },
+}
+
+// Decorate an outbound-API failure with the precise github.com permission a
+// user needs to enable. Called only on the 403 + "Resource not accessible by
+// integration" combination — other 403s (org SSO, suspended install) need
+// different remediation and would be mis-described here.
+export function buildOutboundPermissionGuidance(options: {
+  authType: GithubAuthType
+  endpointKind: OutboundEndpointKind
+}): string {
+  const perm = OUTBOUND_PERMISSION_FOR_KIND[options.endpointKind]
+  if (options.authType === 'app') {
+    return [
+      '',
+      `  Fix (GitHub App): the App needs "${perm.label}" → "${perm.level}".`,
+      '    1. Open https://github.com/settings/apps and edit the app TypeClaw is using.',
+      `    2. Under "Permissions & events" → "Repository permissions", set "${perm.label}" to "${perm.level}". Save.`,
+      '    3. Open the install page (Install App / Configure for the org) and accept the updated permissions request — the new access only takes effect after the install owner accepts.',
+    ].join('\n')
+  }
+  return [
+    '',
+    `  Fix (fine-grained personal access token): grant "${perm.patFineGrained}" → "Read and write" on the failing repo.`,
+    '    1. Open https://github.com/settings/personal-access-tokens and edit the token TypeClaw is using.',
+    `    2. Under "Repository permissions", set "${perm.patFineGrained}" to "Read and write". Save.`,
+    `    3. If the org enforces SAML SSO, click "Configure SSO" next to the token and authorize the org.`,
+    '',
+    `  Or (classic personal access token): grant the "${perm.patScope}" scope; SAML-protected orgs additionally need "Authorize" next to the token.`,
+  ].join('\n')
+}
+
+// 403 with this exact body is GitHub's signal that the call would succeed
+// with the right permissions. Other 403 bodies (e.g. "OAuth token… needs to
+// be authorized for this organization", suspended installation) need
+// different remediation, so the decoration matcher is intentionally narrow.
+const INTEGRATION_PERMISSION_DENIAL = 'Resource not accessible by integration'
+
+export function isOutboundPermissionDenial(status: number, body: string): boolean {
+  return status === 403 && body.includes(INTEGRATION_PERMISSION_DENIAL)
 }


### PR DESCRIPTION
## What this PR does

When the github channel adapter posts a comment, PR review reply, or discussion comment and GitHub responds with `403 "Resource not accessible by integration"`, the existing `GitHub API 403: {body}` error string now gets a trailing **per-endpoint, per-auth-type "Fix:"** block telling the user exactly which permission to enable.

This is the third in a series of three PRs triggered by a real-world bug report. PR-A (#395, merged) refactored permission guidance into its own module. PR-B (#397, merged) added a startup permission preflight that catches misconfigurations before any event arrives. This PR catches the **other** path: a permission that was correct at start but becomes insufficient later (App settings edited mid-session, install owner downgraded the permission, new repo added to a misconfigured token), or a startup where the preflight itself was skipped due to a transient GitHub-side failure.

The two halves are complementary, not redundant: the preflight runs once at start with a single api call against `/app/installations/{id}`, the outbound decoration runs every time we touch GitHub. Either alone would have shipped a usable improvement; together they make the right fix discoverable from either path.

## Before / after

The user's reported symptom, against the actual misconfigured App on the actual broken `issue:394`:

**Before this PR**:
```
[channels] channel_reply failed: github:typeclaw/typeclaw/issue:394: GitHub API 403:
  {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/issues/comments#create-an-issue-comment","status":"403"}
```

**After this PR** (verified end-to-end against the same code path):
```
[channels] channel_reply failed: github:typeclaw/typeclaw/issue:394: GitHub API 403:
  {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/issues/comments#create-an-issue-comment","status":"403"}
  Fix (GitHub App): the App needs "Issues" → "Read and write".
    1. Open https://github.com/settings/apps and edit the app TypeClaw is using.
    2. Under "Permissions & events" → "Repository permissions", set "Issues" to "Read and write". Save.
    3. Open the install page (Install App / Configure for the org) and accept the updated permissions request — the new access only takes effect after the install owner accepts.
```

If the user is on a PAT instead of an App, the same 403 surfaces with PAT-specific guidance (`"Repository permissions" → "Issues" → "Read and write"` for fine-grained PATs, plus a parenthetical for classic PATs with the `repo` scope name).

## Three endpoint kinds, three different fixes

`createGithubOutboundCallback` now knows which API call it's making when an error comes back, so the guidance is precise rather than generic:

| TypeClaw call site | GitHub API call | App permission | PAT (fine-grained) | PAT (classic) |
|---|---|---|---|---|
| Issue / top-level PR comment | `POST /repos/{o}/{r}/issues/{n}/comments` | **Issues** → Read & write | **Issues** → Read & write | `repo` (or `public_repo`) |
| PR review thread reply | `POST /repos/{o}/{r}/pulls/{n}/comments/{}/replies` | **Pull requests** → Read & write | **Pull requests** → Read & write | `repo` |
| Discussion comment | GraphQL `addDiscussionComment` | **Discussions** → Read & write | **Discussions** → Read & write | `repo` |

A test pins each case to ensure the wrong permission is never suggested for the wrong endpoint (a PR-reply 403 must not say "enable Issues").

## Narrow matcher: only the specific permission-denial body

The decoration is gated by a single matcher: **HTTP 403 AND the response body contains the literal string `"Resource not accessible by integration"`** (GitHub's canonical signal for "this would work with more permissions"). Other 403 shapes get **no** decoration because their fix is different:

- `"Resource protected by organization SAML enforcement."` — fix is to authorize the token/App for the org's SAML, not to change permissions.
- `"Installation suspended"` — fix is to unsuspend the App.
- `"Must have admin rights to Repository."` — fix is to install/configure access at a higher level.

A unit test in `outbound.test.ts` proves that the SAML body **does not** trigger decoration — getting that wrong would actively mislead users into the wrong fix.

## GraphQL quirk handled

Discussion comments go through GraphQL, where permission denials usually arrive as **HTTP 200 + `errors[]` with `type: 'FORBIDDEN'` and the same `"Resource not accessible by integration"` message**, not as HTTP 403. The `graphql()` helper threads the matcher against the error message text (with status synthesized as 403 when the response was 200-with-errors) so discussion permission failures get the same decoration as REST failures. A comment at the matcher site explains the asymmetry so the next maintainer doesn't "simplify" it back to status-only matching.

## Back-compat: prefix preserved

The existing error string format `GitHub API ${status}: ${body}` is preserved verbatim. The fix block is **appended** with a leading newline. A unit test specifically asserts `result.error.startsWith('GitHub API 403:')` is still true so any downstream log parser or test that keys on the prefix keeps working.

## Commits

Two atomic commits on this branch:

### Commit 1 — `channels: add outbound github permission denial helpers and per-endpoint guidance`
Pure additions to `permission-guidance.ts`:
- `OutboundEndpointKind` type
- `buildOutboundPermissionGuidance({ authType, endpointKind })` formatter
- `isOutboundPermissionDenial(status, body)` matcher

Plus 10 unit tests in `permission-guidance.test.ts` covering all three endpoint kinds × both auth types, the SAML-rejection negative case, the non-403 negative case, and the embedded-in-longer-body positive case. No caller yet; lands cleanly on its own.

### Commit 2 — `channels: decorate github outbound 403s with the exact permission fix`
The wiring:
- `outbound.ts`: `createGithubOutboundCallback` takes `authType`; `postJson` and `graphql` take `{ authType, endpointKind }` and decorate via `buildOutboundPermissionGuidance` when `isOutboundPermissionDenial` matches.
- `index.ts`: one-line passthrough of `options.secrets.auth.type` into the outbound callback.
- `outbound.test.ts`: 6 new tests for each endpoint × auth combination plus the SAML / non-403 negative cases.
- `line-comment-thread.test.ts`: 3 existing call sites add the now-required `authType: 'app'` field.

## Files

| File | Status | Lines |
|---|---|---|
| `src/channels/adapters/github/permission-guidance.ts` | EDIT | +72 −0 |
| `src/channels/adapters/github/permission-guidance.test.ts` | EDIT | +62 −0 |
| `src/channels/adapters/github/outbound.ts` | EDIT | +60 −22 |
| `src/channels/adapters/github/outbound.test.ts` | EDIT | +175 −3 |
| `src/channels/adapters/github/line-comment-thread.test.ts` | EDIT | +3 −3 |
| `src/channels/adapters/github/index.ts` | EDIT | +6 −1 |

## Verification

```
bun run typecheck                                                ✓
bun run lint                                                     ✓  (0 errors)
bun run format:check                                             ✓
bun run test                                                  5579 pass, 0 fail across 307 files  (+16 vs main)
```

End-to-end against the actual reported bug: `createGithubOutboundCallback` invoked with the user's `authType='app'` and a fake fetch returning the exact 403 GitHub returned, produces the after-text above byte-for-byte.

## Sequencing

PR-C in a 3-PR series. PR-A (#395) and PR-B (#397) merged ahead of this. This branch was originally stacked on PR-A's branch; after the rebase-merge of PR-A and PR-B to `main`, the branch has been rebased onto current `main` (clean rebase, conflict resolution only in the `permission-guidance.ts` and `permission-guidance.test.ts` "added at end of file" overlaps with PR-B — both files now contain both sets of additions).

After this PR merges: the github channel surfaces App misconfiguration twice — once at start, once on first attempted reply — both times pointing at the exact same fix. Either signal alone resolves the user's session.
