### PR TITLE
channels: improve quote anchor ordering

### DIFF
--- a/src/channels/router.quote-anchor.test.ts
+++ b/src/channels/router.quote-anchor.test.ts
@@ -42,17 +42,23 @@ describe('renderQuoteAnchor', () => {
     )
   })
 
-  test('GitHub: falls back to plain authorName (inbound authorId is a numeric user id, not the handle)', () => {
+  test('GitHub: emits @authorName because inbound authorId is a numeric user id, not the handle', () => {
     expect(renderQuoteAnchor({ adapter: 'github', authorId: '12345', authorName: 'alice', text: 'hello' })).toBe(
-      '> alice: hello',
+      '> @alice: hello',
     )
   })
 
-  test('does NOT emit a literal `> @name:` form on any adapter (PR #374 regression)', () => {
-    for (const adapter of ['slack-bot', 'discord-bot', 'telegram-bot', 'kakaotalk', 'github'] as const) {
+  test('does NOT emit a literal `> @name:` form on adapters where that is not platform mention syntax', () => {
+    for (const adapter of ['slack-bot', 'discord-bot', 'telegram-bot', 'kakaotalk'] as const) {
       const out = renderQuoteAnchor({ adapter, authorId: 'U1', authorName: 'Alice', text: 'hi' })
       expect(out.startsWith('> @')).toBe(false)
     }
+  })
+
+  test('GitHub does not double-prefix handles that already include @', () => {
+    expect(renderQuoteAnchor({ adapter: 'github', authorId: '12345', authorName: '@alice', text: 'hello' })).toBe(
+      '> @alice: hello',
+    )
   })
 
   test('collapses newlines so the quote stays on one line', () => {

--- a/src/channels/router.quote-anchor.test.ts
+++ b/src/channels/router.quote-anchor.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import { captureQuoteCandidate, decideQuoteAnchor, prependQuoteAnchor, renderQuoteAnchor } from './router'
-import {
-  DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS,
-  QUOTED_REPLY_EXCERPT_MAX_CHARS,
-  type ChannelAdapterConfig,
-} from './schema'
+import { QUOTED_REPLY_EXCERPT_MAX_CHARS, type ChannelAdapterConfig } from './schema'
 
 const baseConfig: ChannelAdapterConfig = {
   engagement: { trigger: ['mention', 'reply', 'dm'], stickiness: { perReply: { window: 60_000 } } },
@@ -178,19 +174,9 @@ describe('decideQuoteAnchor', () => {
     expect(decideQuoteAnchor(null, 999_999, baseConfig)).toBeNull()
   })
 
-  test('returns null when send-time delay is below threshold and no intervening observed', () => {
+  test('returns null when no observed message intervened, even after a long delay', () => {
     const candidate = captureQuoteCandidate('slack-bot', [humanInbound], [])!
-    expect(decideQuoteAnchor(candidate, humanInbound.receivedAt + 1_000, baseConfig)).toBeNull()
-  })
-
-  test('returns the anchor when send-time delay crosses the default threshold', () => {
-    const candidate = captureQuoteCandidate('slack-bot', [humanInbound], [])!
-    const out = decideQuoteAnchor(
-      candidate,
-      humanInbound.receivedAt + DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS + 1,
-      baseConfig,
-    )
-    expect(out).toEqual({ adapter: 'slack-bot', authorId: 'U_ALICE', authorName: 'Alice', text: 'hey there' })
+    expect(decideQuoteAnchor(candidate, humanInbound.receivedAt + 600_000, baseConfig)).toBeNull()
   })
 
   test('returns the anchor when an observed message landed after the primary, even within threshold', () => {
@@ -210,21 +196,23 @@ describe('decideQuoteAnchor', () => {
     expect(out).toBeNull()
   })
 
-  test('respects a custom queueDelayMs', () => {
+  test('does not let custom queueDelayMs force a quote when no message intervened', () => {
     const candidate = captureQuoteCandidate('slack-bot', [humanInbound], [])!
     const aggressive: ChannelAdapterConfig = { ...baseConfig, quotedReply: { enabled: true, queueDelayMs: 0 } }
-    expect(decideQuoteAnchor(candidate, humanInbound.receivedAt, aggressive)).toEqual({
+    expect(decideQuoteAnchor(candidate, humanInbound.receivedAt + 600_000, aggressive)).toBeNull()
+  })
+
+  test('quotes with no quotedReply config when an observed message intervened', () => {
+    const candidate = captureQuoteCandidate(
+      'slack-bot',
+      [humanInbound],
+      [{ receivedAt: humanInbound.receivedAt + 500, source: 'observed' }],
+    )!
+    expect(decideQuoteAnchor(candidate, humanInbound.receivedAt + 1_000, baseConfig)).toEqual({
       adapter: 'slack-bot',
       authorId: 'U_ALICE',
       authorName: 'Alice',
       text: 'hey there',
     })
-  })
-
-  test('falls back to the default threshold when the adapter has no quotedReply config', () => {
-    const candidate = captureQuoteCandidate('slack-bot', [humanInbound], [])!
-    expect(
-      decideQuoteAnchor(candidate, humanInbound.receivedAt + DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS + 1, baseConfig),
-    ).toEqual({ adapter: 'slack-bot', authorId: 'U_ALICE', authorName: 'Alice', text: 'hey there' })
   })
 })

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4796,7 +4796,7 @@ describe('ChannelRouter quote-anchor on outbound', () => {
     expect(sent).toEqual(['hi back'])
   })
 
-  test('prepends a `> <@authorId>: excerpt` Discord mention when the reply crosses the queueDelayMs threshold', async () => {
+  test('does NOT prepend a quote after a long delay when no message intervened', async () => {
     const dir = await tempDir()
     const nowRef = { value: 1_000_000 }
     const sent: string[] = []
@@ -4811,7 +4811,7 @@ describe('ChannelRouter quote-anchor on outbound', () => {
 
     nowRef.value += 60_000
     await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'yes I am here' })
-    expect(sent).toEqual(['> <@U_ALICE>: are you there?\n\nyes I am here'])
+    expect(sent).toEqual(['yes I am here'])
   })
 
   test('prepends a quote when an observed message landed between inbound and reply, even within the threshold', async () => {
@@ -4843,6 +4843,34 @@ describe('ChannelRouter quote-anchor on outbound', () => {
     expect(sent[0]).toContain('still blocked')
   })
 
+  test('prepends a quote when an observed message lands after prompt drain but before outbound reply', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: string[] = []
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'deploy status?', authorId: 'U_ALICE', authorName: 'Alice' }))
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value += 100
+    await router.route(
+      inbound({
+        isBotMention: false,
+        externalMessageId: 'm-observed-after-drain',
+        authorId: 'bob',
+        authorName: 'bob',
+        text: 'also waiting',
+      }),
+    )
+    nowRef.value += 200
+
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'still deploying' })
+    expect(sent).toEqual(['> <@U_ALICE>: deploy status?\n\nstill deploying'])
+  })
+
   test('anchors only the FIRST send of a multi-part reply; subsequent sends in the same turn are bare', async () => {
     const dir = await tempDir()
     const nowRef = { value: 1_000_000 }
@@ -4854,6 +4882,16 @@ describe('ChannelRouter quote-anchor on outbound', () => {
     })
 
     await router.route(inbound({ text: 'walk me through it', authorId: 'U_ALICE', authorName: 'Alice' }))
+    nowRef.value += 100
+    await router.route(
+      inbound({
+        isBotMention: false,
+        externalMessageId: 'm-observed',
+        authorId: 'bob',
+        authorName: 'bob',
+        text: 'following along',
+      }),
+    )
     await router.__testing!.flushDebounce(KEY)
     nowRef.value += 60_000
 
@@ -4874,11 +4912,31 @@ describe('ChannelRouter quote-anchor on outbound', () => {
     })
 
     await router.route(inbound({ text: 'turn one', authorId: 'U_ALICE', authorName: 'Alice', externalMessageId: 'm1' }))
+    nowRef.value += 100
+    await router.route(
+      inbound({
+        isBotMention: false,
+        externalMessageId: 'm1-observed',
+        authorId: 'bob',
+        authorName: 'bob',
+        text: 'turn one chatter',
+      }),
+    )
     await router.__testing!.flushDebounce(KEY)
     nowRef.value += 60_000
     await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply one' })
 
     await router.route(inbound({ text: 'turn two', authorId: 'U_ALICE', authorName: 'Alice', externalMessageId: 'm2' }))
+    nowRef.value += 100
+    await router.route(
+      inbound({
+        isBotMention: false,
+        externalMessageId: 'm2-observed',
+        authorId: 'bob',
+        authorName: 'bob',
+        text: 'turn two chatter',
+      }),
+    )
     await router.__testing!.flushDebounce(KEY)
     nowRef.value += 60_000
     await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply two' })
@@ -4920,6 +4978,16 @@ describe('ChannelRouter quote-anchor on outbound', () => {
     })
 
     await router.route(inbound({ text: 'screenshot pls', authorId: 'U_ALICE', authorName: 'Alice' }))
+    nowRef.value += 100
+    await router.route(
+      inbound({
+        isBotMention: false,
+        externalMessageId: 'm-observed',
+        authorId: 'bob',
+        authorName: 'bob',
+        text: 'also curious',
+      }),
+    )
     await router.__testing!.flushDebounce(KEY)
     nowRef.value += 60_000
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -774,6 +774,27 @@ describe('ChannelRouter engagement and prompt composition', () => {
     expect(line).not.toMatch(/\[\d{4}-\d{2}-\d{2}T/)
   })
 
+  test('GitHub prompt attribution uses @login instead of numeric-id mention syntax', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const key: ChannelKey = { adapter: 'github', workspace: 'typeclaw/typeclaw', chat: 'issue:398', thread: null }
+
+    await router.route(
+      inbound({
+        adapter: 'github',
+        workspace: 'typeclaw/typeclaw',
+        chat: 'issue:398',
+        authorId: '12345',
+        authorName: 'devxoul',
+        text: '@typeey can you review this PR',
+      }),
+    )
+    await router.__testing!.flushDebounce(key)
+
+    expect(sessions[0]!.prompts[0]).toContain('@devxoul (devxoul): @typeey can you review this PR')
+    expect(sessions[0]!.prompts[0]).not.toContain('<@12345>')
+  })
+
   test('non-engaging inbound goes to context buffer, not session.prompt', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -29,12 +29,7 @@ import {
   saveChannelSessions,
   type ChannelSessionRecord,
 } from './persistence'
-import {
-  DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS,
-  QUOTED_REPLY_EXCERPT_MAX_CHARS,
-  type AdapterId,
-  type ChannelAdapterConfig,
-} from './schema'
+import { QUOTED_REPLY_EXCERPT_MAX_CHARS, type AdapterId, type ChannelAdapterConfig } from './schema'
 import type {
   ChannelHistoryMessage,
   ChannelKey,
@@ -1730,17 +1725,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const live = liveSessions.get(keyId)
     const sendKey = consecutiveSendKey(msg.chat, msg.thread)
     // Tool-source sends consume the captured quote candidate exactly
-    // once per turn — the decision (delay threshold + intervening-
-    // observed check) runs HERE against the live clock so the relevant
-    // signal is real wall-time between inbound and reply landing, not
-    // drain-vs-send timing artifacts. System sources (recovery, role-
+    // once per turn — the intervening-observed check runs HERE against
+    // the live buffer so the relevant signal is actual channel chatter
+    // between inbound and reply landing, not drain-vs-send timing
+    // artifacts. System sources (recovery, role-
     // claim) skip so they can't accidentally swallow the candidate
     // before the model's own first reply lands. Even when the decision
-    // returns null (delay below threshold, nothing intervened), the
-    // candidate is cleared — a multi-part reply that crosses the
-    // threshold mid-flight must not retroactively anchor chunk 2.
+    // returns null (nothing intervened), the candidate is cleared — a
+    // multi-part reply must not retroactively anchor chunk 2.
     if (live && source === 'tool' && live.pendingQuoteCandidate !== null) {
-      const anchor = decideQuoteAnchor(live.pendingQuoteCandidate, now(), options.configForAdapter(msg.adapter))
+      const quoteCandidate = refreshQuoteCandidate(live.pendingQuoteCandidate, live.contextBuffer)
+      const anchor = decideQuoteAnchor(quoteCandidate, now(), options.configForAdapter(msg.adapter))
       if (anchor !== null) msg = { ...msg, text: prependQuoteAnchor(msg.text ?? '', anchor) }
       live.pendingQuoteCandidate = null
     }
@@ -2290,18 +2285,11 @@ export type QuoteAnchorSource = {
   text: string
 }
 
-// Picks the right author syntax for the platform so the rendered anchor
-// shows a real, clickable mention link (Slack/Discord) instead of literal
-// `@name` text. The literal-text form was the original bug report on
-// PR #374: a plain `@username` string inside the quote looks like (but
-// isn't) a Slack mention; users read that as "wrong-shape mention"
-// because the platform-native form would have been `<@U…>`. Adapters
-// without a stable id-only mention syntax (Telegram dot-form
-// `[name](tg://user?id=)`
-// requires MarkdownV2 escaping; KakaoTalk has no mention syntax at all;
-// GitHub uses `@handle` but the inbound `authorId` is a numeric user id,
-// not the handle) fall back to plain `authorName` so a malformed mention
-// never ships to the platform.
+// Picks the right author syntax for the platform so prompts and rendered
+// quote anchors use the same form the user would type in that channel.
+// Slack/Discord need id mentions (`<@U…>`), GitHub needs handle mentions
+// (`@login`) because inbound author ids are numeric, and adapters without
+// stable id-only mention syntax fall back to plain display names.
 //
 // Notification semantics: Slack and Discord both render `<@…>` as a
 // styled mention link inside blockquotes; whether the mentioned user is
@@ -2311,6 +2299,7 @@ export type QuoteAnchorSource = {
 // This matches PR #374's intent — the user IS being notified that the
 // agent replied to them, which is the whole point of a quote anchor.
 function formatAuthorMention(adapter: AdapterId, authorId: string, authorName: string): string {
+  const displayName = authorName.trim() !== '' ? authorName.trim() : authorId
   switch (adapter) {
     case 'slack-bot':
     case 'discord-bot':
@@ -2318,7 +2307,7 @@ function formatAuthorMention(adapter: AdapterId, authorId: string, authorName: s
     case 'telegram-bot':
     case 'kakaotalk':
     case 'github':
-      return authorName
+      return displayName
   }
 }
 
@@ -2400,31 +2389,40 @@ export function captureQuoteCandidate(
   if (batch.length === 0) return null
   const primary = batch[batch.length - 1]!
   if (primary.authorIsBot) return null
-  const hadInterveningObserved = observed.some((o) => o.source === 'observed' && o.receivedAt >= primary.receivedAt)
   return {
     source: { adapter, authorId: primary.authorId, authorName: primary.authorName, text: primary.text },
     primaryReceivedAt: primary.receivedAt,
-    hadInterveningObserved,
+    hadInterveningObserved: hasInterveningObserved(primary.receivedAt, observed),
   }
+}
+
+function refreshQuoteCandidate(
+  candidate: QuoteAnchorCandidate,
+  observed: readonly QuoteAnchorObservedEntry[],
+): QuoteAnchorCandidate {
+  if (candidate.hadInterveningObserved) return candidate
+  if (!hasInterveningObserved(candidate.primaryReceivedAt, observed)) return candidate
+  return { ...candidate, hadInterveningObserved: true }
+}
+
+function hasInterveningObserved(primaryReceivedAt: number, observed: readonly QuoteAnchorObservedEntry[]): boolean {
+  return observed.some((o) => o.source === 'observed' && o.receivedAt >= primaryReceivedAt)
 }
 
 // Send-time decision: given a captured candidate and the current clock,
 // returns the source to anchor against or null. Skips when:
 //   - quotedReply is disabled in config
-//   - delay is under threshold AND no observed messages came between
-//     primary inbound and now (the "felt instantaneous" path)
+//   - no observed messages came between primary inbound and now
 // A null candidate (no batch yet, or batch was bot-only) always skips.
 export function decideQuoteAnchor(
   candidate: QuoteAnchorCandidate | null,
-  nowMs: number,
+  _nowMs: number,
   adapterConfig: ChannelAdapterConfig | undefined,
 ): QuoteAnchorSource | null {
   if (candidate === null) return null
   const config = adapterConfig?.quotedReply
   if (config !== undefined && config.enabled === false) return null
-  const threshold = config?.queueDelayMs ?? DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS
-  const delay = nowMs - candidate.primaryReceivedAt
-  if (delay < threshold && !candidate.hadInterveningObserved) return null
+  if (!candidate.hadInterveningObserved) return null
   return candidate.source
 }
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1231,6 +1231,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const observed = live.contextBuffer.splice(0, live.contextBuffer.length)
         const reminders = live.pendingSystemReminders.splice(0, live.pendingSystemReminders.length)
         const text = composeTurnPrompt(observed, batch, {
+          adapter: live.key.adapter,
           loopGuardActive: live.loopGuardActive,
           systemReminders: reminders,
         })
@@ -2175,8 +2176,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 function composeTurnPrompt(
   observed: readonly ObservedInbound[],
   batch: readonly QueuedInbound[],
-  state: { loopGuardActive: boolean; systemReminders?: readonly string[] } = { loopGuardActive: false },
+  state: { adapter?: AdapterId; loopGuardActive: boolean; systemReminders?: readonly string[] } = {
+    loopGuardActive: false,
+  },
 ): string {
+  const adapter = state.adapter ?? 'discord-bot'
   const parts: string[] = []
   // System reminders (subagent-completion wakeups today) lead the turn body
   // because they are typically what triggered the drain — when the prompt
@@ -2242,7 +2246,7 @@ function composeTurnPrompt(
   if (observed.length > 0) {
     parts.push('## Recent context (not addressed to you, for awareness only)')
     for (const o of observed) {
-      parts.push(formatAuthorLine(o.ts, o.authorId, o.authorName, o.authorIsBot, o.text))
+      parts.push(formatAuthorLine(o.ts, adapter, o.authorId, o.authorName, o.authorIsBot, o.text))
     }
     parts.push('')
   }
@@ -2260,7 +2264,7 @@ function composeTurnPrompt(
       )
     }
     for (const b of batch) {
-      parts.push(formatAuthorLine(b.ts, b.authorId, b.authorName, b.authorIsBot, b.text))
+      parts.push(formatAuthorLine(b.ts, adapter, b.authorId, b.authorName, b.authorIsBot, b.text))
     }
   }
   return parts.join('\n')
@@ -2268,6 +2272,7 @@ function composeTurnPrompt(
 
 function formatAuthorLine(
   ts: number,
+  adapter: AdapterId,
   authorId: string,
   authorName: string,
   authorIsBot: boolean,
@@ -2275,7 +2280,7 @@ function formatAuthorLine(
 ): string {
   const tag = authorIsBot ? ' [bot]' : ''
   const stamp = ts > 0 ? `[${new Date(ts).toISOString()}] ` : ''
-  return `${stamp}<@${authorId}> (${authorName})${tag}: ${text}`
+  return `${stamp}${formatAuthorReference(adapter, authorId, authorName)} (${authorName})${tag}: ${text}`
 }
 
 export type QuoteAnchorSource = {
@@ -2298,15 +2303,16 @@ export type QuoteAnchorSource = {
 // `allowed_mentions` field which defaults to "ping everyone parsed").
 // This matches PR #374's intent — the user IS being notified that the
 // agent replied to them, which is the whole point of a quote anchor.
-function formatAuthorMention(adapter: AdapterId, authorId: string, authorName: string): string {
+function formatAuthorReference(adapter: AdapterId, authorId: string, authorName: string): string {
   const displayName = authorName.trim() !== '' ? authorName.trim() : authorId
   switch (adapter) {
     case 'slack-bot':
     case 'discord-bot':
       return `<@${authorId}>`
+    case 'github':
+      return displayName.startsWith('@') ? displayName : `@${displayName}`
     case 'telegram-bot':
     case 'kakaotalk':
-    case 'github':
       return displayName
   }
 }
@@ -2330,7 +2336,7 @@ export function renderQuoteAnchor(source: QuoteAnchorSource): string {
       : collapsed.length > QUOTED_REPLY_EXCERPT_MAX_CHARS
         ? `${collapsed.slice(0, QUOTED_REPLY_EXCERPT_MAX_CHARS - 1)}…`
         : collapsed
-  const mention = formatAuthorMention(source.adapter, source.authorId, source.authorName)
+  const mention = formatAuthorReference(source.adapter, source.authorId, source.authorName)
   return `> ${mention}: ${excerpt}`
 }
 

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -87,13 +87,12 @@ const historySchema = z
     },
   })
 
-// When the agent's first send of a turn lands ≥ this many ms after the
-// inbound was received, OR there were intervening observed messages
-// between the inbound and the reply, the router prepends a `> @author:
-// ...` blockquote line referencing the inbound so the user can see which
-// message the reply is anchored to even after the channel has scrolled.
-// 10s is the empirical "felt instantaneous" ceiling — anything faster
-// reads as real-time and needs no anchor.
+// Legacy quote-delay knob retained for config compatibility. Quote anchors
+// are now driven by channel ordering instead: when another live-observed
+// message lands between the inbound and the agent's first reply, the router
+// prepends a platform-specific `> author: ...` blockquote line referencing
+// the inbound. If nothing intervened, the reply is adjacent enough in the
+// channel timeline that it needs no anchor regardless of elapsed wall time.
 export const DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS = 10_000
 
 // Long enough to disambiguate; short enough that a multi-paragraph user


### PR DESCRIPTION
## Summary

Quote anchors were previously emitted whenever the agent's reply landed more than a configurable wall-time threshold after the inbound (default 10 s). This PR replaces that time-based heuristic with a channel-ordering signal: a quote anchor is prepended only when another live message from a different participant lands in the channel *between* the triggering inbound and the agent's reply. If nothing intervened, the reply is adjacent in the channel timeline and needs no anchor regardless of how long the model took to respond.

A second commit corrects the GitHub prompt attribution: inbound authorId on GitHub is a numeric user id, not the handle. Prompts and quote anchors now render `@login` rather than the raw numeric user-id form that GitHub does not resolve to a clickable mention.

Follows up on the review comment in #398: https://github.com/typeclaw/typeclaw/pull/398#issuecomment-4551669498

## Changes

### `src/channels/router.ts`

- Removes the delay-threshold branch from `decideQuoteAnchor`; the only gate remaining is whether an observed message intervened.
- Adds `refreshQuoteCandidate` — called at send time to re-check the context buffer for messages that arrived while the model was thinking. This closes the window where chatter lands post-drain but pre-reply and was previously missed.
- Adds `hasInterveningObserved` as a shared predicate used by both the capture-time and send-time paths.
- Renames the author-format helper to `formatAuthorReference` and extends it with a github case that emits the at-prefixed login, stripping a leading at-sign from the display name if already present.
- Threads the adapter id through the turn-prompt composer and author-line formatter so prompt attribution uses the same platform-aware format as quote anchors.

### `src/channels/schema.ts`

- `DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS` is retained for config compatibility but its doc-comment is updated to reflect its legacy status and describe the new ordering-based trigger.

### `src/channels/router.quote-anchor.test.ts`

- Removes tests that asserted the old time-threshold behavior; replaces them with tests asserting the new contract (null when nothing intervened regardless of elapsed time; anchor when an observed message intervened).
- Adds a double-prefix guard test: the render helper must not prepend a second at-sign to a GitHub handle that already starts with one.
- Updates the GitHub adapter assertion: the rendered form is now the at-prefixed handle form rather than plain display name.

### `src/channels/router.test.ts`

- Replaces the "prepends quote after long delay" integration test with a test confirming no quote fires after a long delay when nothing intervened.
- Adds an integration test for the send-time refresh path: an observed message arriving after prompt drain but before the outbound reply now correctly triggers the anchor.
- Updates existing multi-part and per-turn tests to inject an observed message so quote anchors still fire in those scenarios (previously they relied on the time threshold).
- Adds a test that GitHub prompts render `@login` attribution and do not contain the raw numeric mention form.

## Context

The time-threshold approach had two complementary failure modes:

1. **False positives** — a slow model run with no channel activity triggered a quote anchor, making the reply look like a reply-to when it was really just the next message.
2. **False negatives** — chatter that arrived while the model was thinking was invisible to the old send-time check because the intervening-observed flag was frozen at capture time.

`refreshQuoteCandidate` fixes the false-negative case: it re-scans the live context buffer at send time, so messages that arrived between drain and reply are counted.

The GitHub `@login` fix is independent but related: both the quote anchor and the prompt attribution called the same author-formatting function, so both had the same numeric-id bug. Fixing the shared function fixes both surfaces in one commit.

## Testing

- LSP diagnostics clean for all modified files.
- `bun run typecheck` — pass.
- `bun run lint` — exits 0 (existing unrelated warnings, 0 errors).
- `bun run format:check` — pass.
- `bun test --parallel src/channels/router.quote-anchor.test.ts src/channels/router.test.ts` — 236 pass, 0 fail.
- `bun run test` — 5565 pass, 0 fail.

## Review Notes

The key invariant: a quote anchor fires if and only if `hadInterveningObserved` is true at send time. The refresh helper is the only path that can flip that flag from false to true after capture; it re-scans the full context buffer. Reviewers should verify the filter is scoped to observed entries whose timestamp is at or after the primary inbound — system sources (recovery, role-claim) must not count.

The `_nowMs` parameter of the quote-decision function is retained as an underscore-prefixed unused parameter because it is part of the exported signature and callers already pass it. It can be dropped in a follow-up if no new use emerges.