### PR TITLE
tunnels: make cloudflare-quick probe fail-open with 3-min deadline

### DIFF
--- a/src/tunnels/integration.test.ts
+++ b/src/tunnels/integration.test.ts
@@ -20,6 +20,8 @@ function installFakeCloudflared(scratchDir: string): string {
     `#!/bin/sh
 echo "2026-01-01T00:00:00Z INF Requesting new quick Tunnel on trycloudflare.com..." >&2
 echo "2026-01-01T00:00:00Z INF | https://integration.trycloudflare.com |" >&2
+trap 'exit 0' TERM
+sleep 30
 `,
     'utf8',
   )

--- a/src/tunnels/manager.ts
+++ b/src/tunnels/manager.ts
@@ -57,6 +57,7 @@ export function createTunnelManager(options: TunnelManagerOptions): TunnelManage
       options.cloudflareNamedBinary,
       resolveEnv,
       options.cloudflareQuickProbeReady,
+      logger,
     )
     handles.set(config.name, handle)
   }
@@ -109,6 +110,7 @@ function buildProvider(
   cloudflareNamedBinary: string | undefined,
   resolveEnv: (name: string) => string | undefined,
   cloudflareQuickProbeReady: TunnelManagerOptions['cloudflareQuickProbeReady'],
+  logger: TunnelManagerLogger,
 ): TunnelProviderHandle {
   switch (config.provider) {
     case 'external':
@@ -119,6 +121,7 @@ function buildProvider(
         upstreamPort: resolveUpstreamPort(config, resolveChannelUpstreamPort),
         onUrlChange,
         binary: cloudflareQuickBinary,
+        logger,
         ...(cloudflareQuickProbeReady !== undefined ? { probeReady: cloudflareQuickProbeReady } : {}),
       })
     case 'cloudflare-named':

--- a/src/tunnels/providers/cloudflare-quick.test.ts
+++ b/src/tunnels/providers/cloudflare-quick.test.ts
@@ -239,7 +239,9 @@ sleep 30
       binary,
       onUrlChange: (url) => urls.push(url),
       stopGraceMs: 10,
-      probeBackoffMs: [5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+      probeDeadlineMs: 60_000,
+      probeInitialBackoffMs: 5,
+      probeMaxBackoffMs: 5,
       probeReady: async (url) => {
         probeCalls.push(url)
         return allowProbe
@@ -270,47 +272,79 @@ sleep 30
     }
   })
 
-  it('restarts cloudflared when the readiness probe never succeeds', async () => {
+  it('emits the URL anyway after the probe deadline expires, with a warning', async () => {
     const scratchDir = createScratchDir()
-    const countFile = join(scratchDir, 'count.txt')
     const binary = installFakeCloudflared(
       scratchDir,
       `
-count=0
-if [ -f "${countFile}" ]; then count=$(cat "${countFile}"); fi
-count=$((count + 1))
-printf '%s' "$count" > "${countFile}"
-echo "https://attempt-$count.trycloudflare.com" >&2
+echo "https://stuck-probe.trycloudflare.com" >&2
 trap 'exit 0' TERM
 sleep 30
 `,
     )
     const urls: string[] = []
-    let allowProbe = false
+    const warns: string[] = []
     const provider = createCloudflareQuickProvider({
       config,
       upstreamPort: 8975,
       binary,
       onUrlChange: (url) => urls.push(url),
-      restartBackoffMs: [5],
       stopGraceMs: 10,
-      probeBackoffMs: [5, 5],
-      probeReady: async () => allowProbe,
+      probeDeadlineMs: 100,
+      probeInitialBackoffMs: 20,
+      probeMaxBackoffMs: 20,
+      probeReady: async () => false,
+      logger: { info: () => {}, warn: (msg) => warns.push(msg) },
     })
 
     try {
       await provider.start()
-      await waitFor(() => Number(Bun.file(countFile).size) > 0, { description: 'first launch recorded' })
-      await waitFor(async () => (await Bun.file(countFile).text()) === '2', {
-        description: 'second launch after probe failure',
+      await waitFor(() => urls.length === 1, {
+        description: 'URL emitted via fail-open after probe deadline',
       })
 
-      expect(urls).toEqual([])
-
-      allowProbe = true
-      await waitFor(() => urls.length === 1, { description: 'URL emitted after probe recovers' })
-      expect(urls[0]?.startsWith('https://attempt-')).toBe(true)
+      expect(urls).toEqual(['https://stuck-probe.trycloudflare.com'])
       expect(provider.snapshot().status).toBe('healthy')
+      expect(warns.some((m) => m.includes('edge probe did not succeed'))).toBe(true)
+      expect(warns.some((m) => m.includes('emitting URL anyway'))).toBe(true)
+
+      await provider.stop()
+    } finally {
+      await provider.stop()
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('logs probe lifecycle so operators can diagnose tunnel issues from typeclaw logs', async () => {
+    const scratchDir = createScratchDir()
+    const binary = installFakeCloudflared(
+      scratchDir,
+      `
+echo "https://observable.trycloudflare.com" >&2
+trap 'exit 0' TERM
+sleep 30
+`,
+    )
+    const infos: string[] = []
+    const provider = createCloudflareQuickProvider({
+      config,
+      upstreamPort: 8975,
+      binary,
+      onUrlChange: () => {},
+      stopGraceMs: 10,
+      probeDeadlineMs: 5_000,
+      probeInitialBackoffMs: 5,
+      probeMaxBackoffMs: 5,
+      probeReady: async () => true,
+      logger: { info: (msg) => infos.push(msg), warn: () => {} },
+    })
+
+    try {
+      await provider.start()
+      await waitFor(() => provider.snapshot().status === 'healthy', { description: 'healthy' })
+
+      expect(infos.some((m) => m.includes('cloudflared printed URL https://observable.trycloudflare.com'))).toBe(true)
+      expect(infos.some((m) => m.includes('edge reachable after'))).toBe(true)
 
       await provider.stop()
     } finally {
@@ -336,7 +370,7 @@ sleep 30
       binary,
       onUrlChange: () => {},
       stopGraceMs: 10,
-      probeBackoffMs: [5_000],
+      probeDeadlineMs: 60_000,
       probeReady: (_url, signal) =>
         new Promise<boolean>((resolve) => {
           signal.addEventListener('abort', () => {
@@ -348,7 +382,7 @@ sleep 30
 
     try {
       await provider.start()
-      await waitFor(() => provider.snapshot().detail === 'probing tunnel readiness', {
+      await waitFor(() => provider.snapshot().detail.startsWith('probing tunnel readiness'), {
         description: 'probe started',
       })
 

--- a/src/tunnels/providers/cloudflare-quick.ts
+++ b/src/tunnels/providers/cloudflare-quick.ts
@@ -9,17 +9,28 @@ const DEFAULT_RESTART_BACKOFF_MS = [1_000, 2_000, 4_000, 10_000, 30_000]
 const DEFAULT_MAX_FAILURES_WITHOUT_URL = 10
 const DEFAULT_STOP_GRACE_MS = 5_000
 // cloudflared prints the trycloudflare.com URL to stderr the moment the
-// quick-tunnel control connection is established, but the Cloudflare edge
-// does not start accepting HTTPS for that hostname until ~hundreds of ms
-// to a few seconds later. If we publish the URL the instant it's parsed,
-// any caller that registers the URL with an external service (notably
-// GitHub webhook registration → immediate `ping`) loses the first request
-// with "failed to connect to host". We probe the URL ourselves until the
-// edge responds, then emit. Budget is generous enough to absorb a slow
-// edge propagation but bounded so a genuinely broken tunnel still hits
-// the restart cap via `handleExit`.
-const DEFAULT_PROBE_BACKOFF_MS = [250, 500, 1_000, 1_000, 2_000, 2_000, 3_000, 5_000]
-const DEFAULT_PROBE_TIMEOUT_MS = 5_000
+// quick-tunnel control connection comes up, but the ephemeral subdomain
+// can take 1–3 minutes to propagate through DNS resolvers (see
+// cloudflared docs: "it may take some time to be reachable"). If we
+// publish the URL before the edge is reachable, any caller that
+// registers it with an external service (notably GitHub webhook
+// registration → immediate `ping`) loses the first request with
+// "failed to connect to host".
+//
+// Strategy: probe the URL in the background, but ALWAYS emit it once
+// either (a) the probe succeeds, or (b) the fallback deadline expires.
+// Fail-open by design — a flaky probe must never gate registration
+// entirely. Falling back to pre-probe behavior in the worst case is
+// strictly better than silently never emitting at all.
+const DEFAULT_PROBE_INITIAL_BACKOFF_MS = 250
+const DEFAULT_PROBE_MAX_BACKOFF_MS = 5_000
+const DEFAULT_PROBE_FETCH_TIMEOUT_MS = 5_000
+const DEFAULT_PROBE_DEADLINE_MS = 180_000
+
+export type CloudflareQuickProviderLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+}
 
 export type CloudflareQuickProviderOptions = {
   config: TunnelConfig
@@ -30,18 +41,28 @@ export type CloudflareQuickProviderOptions = {
   maxConsecutiveFailuresWithoutUrl?: number
   stopGraceMs?: number
   // Probes the public URL until the Cloudflare edge is actually serving
-  // traffic. Returns `true` once a response is observed (any HTTP status
-  // counts — even 404 from the upstream means the tunnel itself routed
-  // the request), `false` if the probe budget is exhausted. Defaults to
-  // a real `fetch` with retry/backoff; tests inject a stub.
+  // traffic. Returns `true` once any response is observed (including
+  // 4xx/5xx — those still mean the tunnel hostname routed). The provider
+  // calls this in a retry loop until success or `probeDeadlineMs`.
+  // Defaults to a real `fetch`; tests inject a stub.
   probeReady?: (url: string, signal: AbortSignal) => Promise<boolean>
-  probeBackoffMs?: number[]
+  // Hard deadline after URL parse, after which we emit the URL anyway
+  // (with a warning log). 3 minutes by default — covers the slowest
+  // observed quick-tunnel DNS propagation. Must be long enough that
+  // genuinely working tunnels always pass; short enough that broken
+  // tunnels still surface to the caller.
+  probeDeadlineMs?: number
+  probeInitialBackoffMs?: number
+  probeMaxBackoffMs?: number
+  logger?: CloudflareQuickProviderLogger
 }
 
 export type CloudflareQuickProviderHandle = TunnelProviderHandle & {
   tail: () => string[]
   subscribeToLogs: (cb: LogLineSubscriber) => Unsubscribe
 }
+
+const silentLogger: CloudflareQuickProviderLogger = { info: () => {}, warn: () => {} }
 
 export function createCloudflareQuickProvider(options: CloudflareQuickProviderOptions): CloudflareQuickProviderHandle {
   const { config, upstreamPort, onUrlChange } = options
@@ -56,8 +77,12 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
   const restartBackoffMs = options.restartBackoffMs ?? DEFAULT_RESTART_BACKOFF_MS
   const maxConsecutiveFailuresWithoutUrl = options.maxConsecutiveFailuresWithoutUrl ?? DEFAULT_MAX_FAILURES_WITHOUT_URL
   const stopGraceMs = options.stopGraceMs ?? DEFAULT_STOP_GRACE_MS
-  const probeBackoffMs = options.probeBackoffMs ?? DEFAULT_PROBE_BACKOFF_MS
+  const probeDeadlineMs = options.probeDeadlineMs ?? DEFAULT_PROBE_DEADLINE_MS
+  const probeInitialBackoffMs = options.probeInitialBackoffMs ?? DEFAULT_PROBE_INITIAL_BACKOFF_MS
+  const probeMaxBackoffMs = options.probeMaxBackoffMs ?? DEFAULT_PROBE_MAX_BACKOFF_MS
   const probeReady = options.probeReady ?? defaultProbeReady
+  const logger = options.logger ?? silentLogger
+  const logPrefix = `[tunnels] ${config.name}`
   const logs = createLogRing()
   const state: TunnelState = {
     name: config.name,
@@ -74,13 +99,11 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
   let proc: ReturnType<typeof Bun.spawn> | null = null
   let retryTimer: ReturnType<typeof setTimeout> | null = null
   let restartFailuresWithoutUrl = 0
-  let attemptEmittedUrl = false
   let probeAbort: AbortController | null = null
 
   async function launch(): Promise<void> {
     if (!started || stopping) return
 
-    attemptEmittedUrl = false
     state.status = 'starting'
     state.detail = 'starting cloudflared'
     const spawned = Bun.spawn(
@@ -108,28 +131,38 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
     cancelProbe()
     const abort = new AbortController()
     probeAbort = abort
+    const startedAt = Date.now()
 
+    logger.info(
+      `${logPrefix}: cloudflared printed URL ${url}; probing for edge reachability (deadline ${probeDeadlineMs}ms)`,
+    )
     state.status = 'starting'
-    state.detail = 'probing tunnel readiness'
+    state.detail = `probing tunnel readiness (deadline ${probeDeadlineMs}ms)`
 
-    const ready = await probeWithBackoff(url, abort.signal, probeReady, probeBackoffMs)
+    const ready = await probeWithDeadline(url, abort.signal, probeReady, {
+      deadlineMs: probeDeadlineMs,
+      initialBackoffMs: probeInitialBackoffMs,
+      maxBackoffMs: probeMaxBackoffMs,
+    })
     if (probeAbort !== abort) return
     probeAbort = null
     if (!started || stopping) return
     if (proc !== owningProc) return
 
-    if (!ready) {
-      state.detail = 'tunnel URL emitted but probe failed; will restart'
-      owningProc.kill('SIGKILL')
-      return
+    const elapsedMs = Date.now() - startedAt
+    if (ready) {
+      logger.info(`${logPrefix}: edge reachable after ${elapsedMs}ms`)
+      state.detail = `quick tunnel URL reachable after ${elapsedMs}ms`
+    } else {
+      logger.warn(
+        `${logPrefix}: edge probe did not succeed within ${elapsedMs}ms; emitting URL anyway. First webhook delivery may fail if DNS hasn't propagated yet.`,
+      )
+      state.detail = `quick tunnel URL emitted without probe confirmation after ${elapsedMs}ms`
     }
-
-    attemptEmittedUrl = true
     restartFailuresWithoutUrl = 0
     state.url = url
     state.status = 'healthy'
     state.lastUrlAt = Date.now()
-    state.detail = 'quick tunnel URL emitted and reachable'
     onUrlChange(url)
   }
 
@@ -141,7 +174,7 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
   }
 
   function handleExit(code: number): void {
-    if (!attemptEmittedUrl) restartFailuresWithoutUrl += 1
+    if (state.url === null) restartFailuresWithoutUrl += 1
     if (restartFailuresWithoutUrl >= maxConsecutiveFailuresWithoutUrl) {
       state.status = 'permanently-failed'
       state.detail = `cloudflared exited ${code}; retry cap reached before URL emission`
@@ -150,6 +183,7 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
 
     state.status = 'unhealthy'
     state.detail = `cloudflared exited ${code}; restarting`
+    state.url = null
     const delay = restartBackoffMs[Math.min(restartFailuresWithoutUrl - 1, restartBackoffMs.length - 1)] ?? 30_000
     retryTimer = setTimeout(() => {
       retryTimer = null
@@ -256,37 +290,45 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   })
 }
 
-async function probeWithBackoff(
+type ProbeDeadlineOptions = {
+  deadlineMs: number
+  initialBackoffMs: number
+  maxBackoffMs: number
+}
+
+async function probeWithDeadline(
   url: string,
   signal: AbortSignal,
   probe: (url: string, signal: AbortSignal) => Promise<boolean>,
-  backoffMs: number[],
+  opts: ProbeDeadlineOptions,
 ): Promise<boolean> {
-  for (let attempt = 0; attempt <= backoffMs.length; attempt += 1) {
-    if (signal.aborted) return false
+  const deadline = Date.now() + opts.deadlineMs
+  let backoff = opts.initialBackoffMs
+  while (!signal.aborted && Date.now() < deadline) {
     try {
       if (await probe(url, signal)) return true
     } catch {
-      // Probe threw (network error, abort, etc.) — treat as not-ready and back off.
+      // Probe threw (DNS NXDOMAIN, connection refused, abort, etc.) —
+      // treat as not-ready and back off. These errors are expected
+      // during the propagation window for a fresh quick tunnel.
     }
     if (signal.aborted) return false
-    const delay = backoffMs[attempt]
-    if (delay === undefined) return false
-    await sleep(delay, signal)
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) return false
+    await sleep(Math.min(backoff, remaining), signal)
+    backoff = Math.min(backoff * 2, opts.maxBackoffMs)
   }
   return false
 }
 
 async function defaultProbeReady(url: string, signal: AbortSignal): Promise<boolean> {
-  const timeout = AbortSignal.timeout(DEFAULT_PROBE_TIMEOUT_MS)
+  const timeout = AbortSignal.timeout(DEFAULT_PROBE_FETCH_TIMEOUT_MS)
   const combined = AbortSignal.any([signal, timeout])
-  try {
-    // Any response from the Cloudflare edge — including 404, 502, etc. from
-    // the unbound upstream — means the tunnel hostname is live. We only
-    // care about edge reachability, not upstream health.
-    await fetch(url, { method: 'HEAD', redirect: 'manual', signal: combined })
-    return true
-  } catch {
-    return false
-  }
+  // Any response from the Cloudflare edge — including 404/405/502/530
+  // from the unbound or wrong-method upstream — means the tunnel
+  // hostname is live and routing. We only care about edge reachability,
+  // not upstream health. HEAD is the cheapest verb; redirect:'manual'
+  // keeps us from following 301s into unrelated hosts.
+  await fetch(url, { method: 'HEAD', redirect: 'manual', signal: combined })
+  return true
 }


### PR DESCRIPTION
## Problem

After [#399](https://github.com/typeclaw/typeclaw/pull/399) merged, GitHub webhooks stop registering entirely after `typeclaw start` with a cloudflare-quick tunnel. The entire relevant log looks like:

```
14:54:05 [github] webhook listening on port 8975 as @typeey[bot]
14:54:05 [channels] adapter "github" started
14:54:05 [github] webhook registration SKIPPED: a tunnel is configured for this channel but produced no URL yet. Check `typeclaw tunnel status` for the tunnel's health.
14:54:05 typeclaw agent listening on ws://localhost:8973
```

No `[tunnels] github-webhook: URL set to ...` line follows. No registration attempt. No restart. Complete silence. Before #399, the URL would have appeared within a few seconds and the webhook would have been registered.

## Root cause

#399 added a HEAD-probe gate before `onUrlChange(url)` to wait for the Cloudflare edge to be reachable. Two assumptions in that PR were wrong:

1. **The probe budget was too short.** The fixed retry list totalled ~14.75s. Cloudflare's own docs say a fresh quick tunnel "may take some time to be reachable" — empirically 1–3 minutes for the ephemeral `*.trycloudflare.com` subdomain to propagate through arbitrary DNS resolvers. The [buttons project](https://github.com/autonoco/buttons/commit/d2fb029d57849791e01810d18f681c5ce8f7e74c) observed the same symptom and landed at a 3-minute deadline.

2. **The probe was fail-closed with no logging.** When the ~14.75s budget exhausted, #399 SIGKILLed cloudflared. The restart produces a new hostname that starts its own propagation window from zero, fails the probe again, gets killed again, and so on. After 10 failures the tunnel goes `permanently-failed`. None of these state transitions emit log lines, so the operator sees nothing.

## Fix

- **Deadline replaces fixed retry list.** Default 3 minutes (`probeDeadlineMs`), exponential backoff 250ms → 5s. Configurable via options for tests and advanced deployments.
- **Fail-open.** If the deadline expires without a successful probe, the URL is emitted anyway with a warning log. Worst case is pre-#399 behavior (first GitHub ping fails, redeliver works) — strictly better than silently never registering.
- **Lifecycle logging via injected logger.** Every state transition now surfaces in `typeclaw logs`:
  - `[tunnels] github-webhook: cloudflared printed URL https://... ; probing for edge reachability (deadline 180000ms)`
  - `[tunnels] github-webhook: edge reachable after 1234ms` (happy path)
  - `[tunnels] github-webhook: edge probe did not succeed within 180000ms; emitting URL anyway. First webhook delivery may fail if DNS hasn't propagated yet.` (fail-open)
  - `[tunnels] github-webhook: URL set to ...` (existing, from manager)
- **Removed the probe-failure → kill-cloudflared → restart path.** Probe failure does not mean cloudflared is broken; it means the edge is not yet reachable from this host. Killing cloudflared churns hostnames and resets the propagation clock.

## Behavior matrix

| Scenario | pre-#399 | #399 (broken) | This PR |
|---|---|---|---|
| Edge up fast | first ping fails | works | works |
| Edge up slow (5–30s) | first ping fails | works (probe wins) | works (probe wins) |
| Edge up very slow (>3 min) | first ping fails; redeliver works | silent hang then permanent-failed | works after fail-open; first ping may fail |
| Genuinely broken tunnel | repeated retries surface in logs | silent hang then permanent-failed | first probe success or fail-open |

## Test coverage

- **Updated** — "delays onUrlChange until probe succeeds": uses the new deadline/backoff option knobs (deadline, initial backoff, max backoff ms).
- **New** — "emits the URL anyway after the probe deadline expires, with a warning": verifies fail-open semantics and that the warning log fires.
- **New** — "logs probe lifecycle so operators can diagnose tunnel issues from typeclaw logs": verifies the lifecycle log lines that would have made this regression visible from the start.
- **Updated** — "cancels an in-flight readiness probe on stop()": updated to use new option names.
- **Removed** — "restarts cloudflared when the readiness probe never succeeds": intentionally deleted since that behavior is gone.
- **Integration** (`src/tunnels/integration.test.ts`) — fake cloudflared now sleeps after emitting its URL (mirrors real cloudflared, which persists after URL emission). Fixes a race where the in-flight probe was dropped because fake cloudflared exited before the probe finished.

## Verification

```
bun run typecheck    ✓
bun run lint         ✓  (61 pre-existing warnings, 0 errors, 0 new)
bun run format       ✓
bun run test         5584 pass, 0 fail across 3 consecutive runs
```

## Followup

This is a followup to [#399](https://github.com/typeclaw/typeclaw/pull/399) which introduced the regression described above. All 4 files changed are in the tunnels subsystem (`src/tunnels/`) — no other subsystems are affected.