### PR TITLE
channels: delay github webhook registration so the tunnel edge can warm up

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -41,6 +41,17 @@ export type GithubAdapterOptions = {
   // wrong)" so the skip-registration log can be precise and actionable.
   // Optional so tests that don't exercise the tunnel-status path can omit it.
   tunnelConfiguredForChannel?: () => boolean
+  // Sleep between learning the public webhook URL and telling GitHub about
+  // it. cloudflared prints the trycloudflare.com URL as soon as the control
+  // connection comes up, but the Cloudflare edge needs a beat to start
+  // routing traffic for that hostname. If we register with GitHub the
+  // instant we know the URL, GitHub's automatic `ping` delivery races the
+  // edge and lands "failed to connect to host". 2s is enough on every
+  // network we've tested; tests pass 0 to skip.
+  webhookRegistrationDelayMs?: number
+  // Test-only: replaces the wall-clock sleep used for the registration
+  // delay above. Production leaves it undefined and we use `setTimeout`.
+  sleep?: (ms: number) => Promise<void>
 }
 
 export type GithubAdapter = {
@@ -55,9 +66,13 @@ const consoleLogger: GithubAdapterLogger = {
   error: (m) => console.error(m),
 }
 
+const DEFAULT_WEBHOOK_REGISTRATION_DELAY_MS = 2_000
+
 export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapter {
   const logger = options.logger ?? consoleLogger
   const fetchImpl = options.fetchImpl ?? fetch
+  const webhookRegistrationDelayMs = options.webhookRegistrationDelayMs ?? DEFAULT_WEBHOOK_REGISTRATION_DELAY_MS
+  const sleep = options.sleep ?? defaultSleep
   const auth = buildAuthStrategy({ auth: options.secrets.auth, fetchImpl })
   const webhookSecret = resolveSecret(options.secrets.webhookSecret, undefined, process.env)
   if (webhookSecret === undefined || webhookSecret.trim() === '') throw new Error('GitHub webhookSecret is missing')
@@ -178,6 +193,12 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         })
       } else if (repos.length > 0) {
         const legacyProviderHostSuffix = detectLegacyProviderHostSuffix(effectiveUrl)
+        if (webhookRegistrationDelayMs > 0) {
+          logger.info(
+            `[github] waiting ${webhookRegistrationDelayMs}ms before registering webhook so the Cloudflare edge can warm up`,
+          )
+          await sleep(webhookRegistrationDelayMs)
+        }
         const registration = await registerGithubWebhooks({
           token: tokenFn,
           webhookUrl: effectiveUrl,
@@ -333,4 +354,8 @@ function logDeregistrationOutcome(
     else if (h.action === 'missing') logger.info(`[github] webhook ${h.hookId} on ${h.repo} already gone`)
     else logger.warn(`[github] webhook detach failed for ${h.repo}#${h.hookId}: ${h.error ?? 'unknown error'}`)
   }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -121,6 +121,7 @@ describe('createGithubAdapter lifecycle', () => {
       logger: silentLogger(),
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -151,6 +152,7 @@ describe('createGithubAdapter lifecycle', () => {
       logger: silentLogger(),
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -179,6 +181,7 @@ describe('createGithubAdapter lifecycle', () => {
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
       tunnelUrl: () => 'https://x.trycloudflare.com',
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -208,6 +211,7 @@ describe('createGithubAdapter lifecycle', () => {
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
       tunnelUrl: () => 'https://x.trycloudflare.com',
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -237,6 +241,7 @@ describe('createGithubAdapter lifecycle', () => {
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
       tunnelConfiguredForChannel: () => false,
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -267,6 +272,7 @@ describe('createGithubAdapter lifecycle', () => {
       httpListenImpl: () => ({ stop: async () => {} }),
       tunnelUrl: () => null,
       tunnelConfiguredForChannel: () => true,
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -296,6 +302,7 @@ describe('createGithubAdapter lifecycle', () => {
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
       tunnelConfiguredForChannel: () => true,
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -329,6 +336,7 @@ describe('createGithubAdapter lifecycle', () => {
       logger: silentLogger(),
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -351,6 +359,7 @@ describe('createGithubAdapter lifecycle', () => {
       logger: silentLogger(),
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -374,6 +383,7 @@ describe('createGithubAdapter lifecycle', () => {
       logger: silentLogger(),
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -399,6 +409,7 @@ describe('createGithubAdapter lifecycle', () => {
       logger,
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -431,6 +442,7 @@ describe('createGithubAdapter lifecycle', () => {
       logger,
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -486,6 +498,7 @@ describe('createGithubAdapter lifecycle', () => {
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
       tunnelUrl: () => currentTunnelUrl,
+      webhookRegistrationDelayMs: 0,
     })
     await adapter1.start()
     expect(repoHooks.length).toBe(1)
@@ -504,6 +517,7 @@ describe('createGithubAdapter lifecycle', () => {
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
       tunnelUrl: () => currentTunnelUrl,
+      webhookRegistrationDelayMs: 0,
     })
     await adapter2.start()
 
@@ -563,6 +577,7 @@ describe('createGithubAdapter lifecycle', () => {
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
       tunnelUrl: () => 'https://fresh.trycloudflare.com',
+      webhookRegistrationDelayMs: 0,
     })
     await adapter.start()
 
@@ -595,6 +610,7 @@ describe('createGithubAdapter lifecycle', () => {
       logger: silentLogger(),
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -632,6 +648,7 @@ describe('createGithubAdapter lifecycle', () => {
       logger,
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -676,6 +693,7 @@ describe('createGithubAdapter lifecycle', () => {
       logger,
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -699,6 +717,7 @@ describe('createGithubAdapter lifecycle', () => {
       logger,
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
@@ -734,11 +753,86 @@ describe('createGithubAdapter lifecycle', () => {
       logger,
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
     })
 
     await expect(adapter.start()).resolves.toBeUndefined()
     await adapter.stop()
 
     expect(logger.messages.find((m) => m.startsWith('warn:[github] permission preflight skipped:'))).toBeDefined()
+  })
+
+  test('start() sleeps webhookRegistrationDelayMs before calling the GitHub hooks API', async () => {
+    const events: string[] = []
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+      if (url.includes('/repos/acme/widgets/hooks')) {
+        if (method === 'GET') {
+          events.push('hooks-list')
+          return Response.json([])
+        }
+        if (method === 'POST') {
+          events.push('hooks-create')
+          return Response.json({ id: 42 }, { status: 201 })
+        }
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig(['acme/widgets']),
+      secrets: patSecrets(),
+      agentDir: '/tmp/agent',
+      logger: silentLogger(),
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 1234,
+      sleep: async (ms) => {
+        events.push(`sleep(${ms})`)
+      },
+    })
+
+    await adapter.start()
+    await adapter.stop()
+
+    expect(events).toEqual(['sleep(1234)', 'hooks-list', 'hooks-create'])
+  })
+
+  test('start() skips the sleep when webhookRegistrationDelayMs is 0', async () => {
+    const events: string[] = []
+    let sleepCalls = 0
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'GET') {
+        events.push('hooks-list')
+        return Response.json([])
+      }
+      if (url.includes('/repos/acme/widgets/hooks') && method === 'POST') {
+        events.push('hooks-create')
+        return Response.json({ id: 42 }, { status: 201 })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig(['acme/widgets']),
+      secrets: patSecrets(),
+      agentDir: '/tmp/agent',
+      logger: silentLogger(),
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
+      sleep: async () => {
+        sleepCalls += 1
+      },
+    })
+
+    await adapter.start()
+    await adapter.stop()
+
+    expect(sleepCalls).toBe(0)
+    expect(events).toEqual(['hooks-list', 'hooks-create'])
   })
 })

--- a/src/tunnels/integration.test.ts
+++ b/src/tunnels/integration.test.ts
@@ -20,8 +20,6 @@ function installFakeCloudflared(scratchDir: string): string {
     `#!/bin/sh
 echo "2026-01-01T00:00:00Z INF Requesting new quick Tunnel on trycloudflare.com..." >&2
 echo "2026-01-01T00:00:00Z INF | https://integration.trycloudflare.com |" >&2
-trap 'exit 0' TERM
-sleep 30
 `,
     'utf8',
   )
@@ -36,7 +34,6 @@ describe('tunnel URL to channel adapter restart integration', () => {
     const manager = createTunnelManager({
       stream,
       cloudflareQuickBinary: installFakeCloudflared(scratchDir),
-      cloudflareQuickProbeReady: async () => true,
       resolveChannelUpstreamPort: (name) => (name === 'github' ? 8975 : null),
       logger: silentLogger(),
       tunnels: [

--- a/src/tunnels/manager.ts
+++ b/src/tunnels/manager.ts
@@ -21,10 +21,6 @@ export type TunnelManagerOptions = {
   // Parameterized so tests can drive the named-provider token path without
   // poking global env and so the manager stays a pure function of its inputs.
   resolveEnv?: (name: string) => string | undefined
-  // Override the cloudflare-quick readiness probe. Tests inject a stub so
-  // they don't hit the network; production leaves it undefined and the
-  // provider falls back to a real `fetch` against the tunnel URL.
-  cloudflareQuickProbeReady?: (url: string, signal: AbortSignal) => Promise<boolean>
   logger?: TunnelManagerLogger
 }
 
@@ -56,8 +52,6 @@ export function createTunnelManager(options: TunnelManagerOptions): TunnelManage
       options.cloudflareQuickBinary,
       options.cloudflareNamedBinary,
       resolveEnv,
-      options.cloudflareQuickProbeReady,
-      logger,
     )
     handles.set(config.name, handle)
   }
@@ -109,8 +103,6 @@ function buildProvider(
   cloudflareQuickBinary: string | undefined,
   cloudflareNamedBinary: string | undefined,
   resolveEnv: (name: string) => string | undefined,
-  cloudflareQuickProbeReady: TunnelManagerOptions['cloudflareQuickProbeReady'],
-  logger: TunnelManagerLogger,
 ): TunnelProviderHandle {
   switch (config.provider) {
     case 'external':
@@ -121,8 +113,6 @@ function buildProvider(
         upstreamPort: resolveUpstreamPort(config, resolveChannelUpstreamPort),
         onUrlChange,
         binary: cloudflareQuickBinary,
-        logger,
-        ...(cloudflareQuickProbeReady !== undefined ? { probeReady: cloudflareQuickProbeReady } : {}),
       })
     case 'cloudflare-named':
       return createCloudflareNamedProvider({

--- a/src/tunnels/providers/cloudflare-quick.test.ts
+++ b/src/tunnels/providers/cloudflare-quick.test.ts
@@ -46,7 +46,6 @@ sleep 30
       binary,
       onUrlChange: (url) => urls.push(url),
       stopGraceMs: 10,
-      probeReady: async () => true,
     })
 
     try {
@@ -91,7 +90,6 @@ sleep 30
       binary,
       onUrlChange: () => {},
       stopGraceMs: 10,
-      probeReady: async () => true,
     })
 
     try {
@@ -136,7 +134,6 @@ sleep 30
       onUrlChange: (url) => urls.push(url),
       restartBackoffMs: [5],
       stopGraceMs: 10,
-      probeReady: async () => true,
     })
 
     try {
@@ -173,7 +170,6 @@ exit 3
       onUrlChange: () => {},
       restartBackoffMs: [1],
       maxConsecutiveFailuresWithoutUrl: 2,
-      probeReady: async () => true,
     })
 
     try {
@@ -204,7 +200,6 @@ sleep 30
       binary,
       onUrlChange: () => {},
       stopGraceMs: 10,
-      probeReady: async () => true,
     })
 
     try {
@@ -213,182 +208,6 @@ sleep 30
 
       await provider.stop()
 
-      expect(provider.snapshot().status).toBe('stopped')
-    } finally {
-      await provider.stop()
-      rmSync(scratchDir, { recursive: true, force: true })
-    }
-  })
-
-  it('delays onUrlChange until the readiness probe succeeds', async () => {
-    const scratchDir = createScratchDir()
-    const binary = installFakeCloudflared(
-      scratchDir,
-      `
-echo "https://probe-pending.trycloudflare.com" >&2
-trap 'exit 0' TERM
-sleep 30
-`,
-    )
-    const probeCalls: string[] = []
-    let allowProbe = false
-    const urls: string[] = []
-    const provider = createCloudflareQuickProvider({
-      config,
-      upstreamPort: 8975,
-      binary,
-      onUrlChange: (url) => urls.push(url),
-      stopGraceMs: 10,
-      probeDeadlineMs: 60_000,
-      probeInitialBackoffMs: 5,
-      probeMaxBackoffMs: 5,
-      probeReady: async (url) => {
-        probeCalls.push(url)
-        return allowProbe
-      },
-    })
-
-    try {
-      await provider.start()
-      await waitFor(() => probeCalls.length >= 2, { description: 'probe attempted at least twice' })
-
-      expect(urls).toEqual([])
-      expect(provider.snapshot()).toMatchObject({ status: 'starting', url: null })
-
-      allowProbe = true
-      await waitFor(() => urls.length === 1, { description: 'URL emitted after probe success' })
-
-      expect(urls).toEqual(['https://probe-pending.trycloudflare.com'])
-      expect(provider.snapshot()).toMatchObject({
-        status: 'healthy',
-        url: 'https://probe-pending.trycloudflare.com',
-      })
-      expect(probeCalls.every((u) => u === 'https://probe-pending.trycloudflare.com')).toBe(true)
-
-      await provider.stop()
-    } finally {
-      await provider.stop()
-      rmSync(scratchDir, { recursive: true, force: true })
-    }
-  })
-
-  it('emits the URL anyway after the probe deadline expires, with a warning', async () => {
-    const scratchDir = createScratchDir()
-    const binary = installFakeCloudflared(
-      scratchDir,
-      `
-echo "https://stuck-probe.trycloudflare.com" >&2
-trap 'exit 0' TERM
-sleep 30
-`,
-    )
-    const urls: string[] = []
-    const warns: string[] = []
-    const provider = createCloudflareQuickProvider({
-      config,
-      upstreamPort: 8975,
-      binary,
-      onUrlChange: (url) => urls.push(url),
-      stopGraceMs: 10,
-      probeDeadlineMs: 100,
-      probeInitialBackoffMs: 20,
-      probeMaxBackoffMs: 20,
-      probeReady: async () => false,
-      logger: { info: () => {}, warn: (msg) => warns.push(msg) },
-    })
-
-    try {
-      await provider.start()
-      await waitFor(() => urls.length === 1, {
-        description: 'URL emitted via fail-open after probe deadline',
-      })
-
-      expect(urls).toEqual(['https://stuck-probe.trycloudflare.com'])
-      expect(provider.snapshot().status).toBe('healthy')
-      expect(warns.some((m) => m.includes('edge probe did not succeed'))).toBe(true)
-      expect(warns.some((m) => m.includes('emitting URL anyway'))).toBe(true)
-
-      await provider.stop()
-    } finally {
-      await provider.stop()
-      rmSync(scratchDir, { recursive: true, force: true })
-    }
-  })
-
-  it('logs probe lifecycle so operators can diagnose tunnel issues from typeclaw logs', async () => {
-    const scratchDir = createScratchDir()
-    const binary = installFakeCloudflared(
-      scratchDir,
-      `
-echo "https://observable.trycloudflare.com" >&2
-trap 'exit 0' TERM
-sleep 30
-`,
-    )
-    const infos: string[] = []
-    const provider = createCloudflareQuickProvider({
-      config,
-      upstreamPort: 8975,
-      binary,
-      onUrlChange: () => {},
-      stopGraceMs: 10,
-      probeDeadlineMs: 5_000,
-      probeInitialBackoffMs: 5,
-      probeMaxBackoffMs: 5,
-      probeReady: async () => true,
-      logger: { info: (msg) => infos.push(msg), warn: () => {} },
-    })
-
-    try {
-      await provider.start()
-      await waitFor(() => provider.snapshot().status === 'healthy', { description: 'healthy' })
-
-      expect(infos.some((m) => m.includes('cloudflared printed URL https://observable.trycloudflare.com'))).toBe(true)
-      expect(infos.some((m) => m.includes('edge reachable after'))).toBe(true)
-
-      await provider.stop()
-    } finally {
-      await provider.stop()
-      rmSync(scratchDir, { recursive: true, force: true })
-    }
-  })
-
-  it('cancels an in-flight readiness probe on stop()', async () => {
-    const scratchDir = createScratchDir()
-    const binary = installFakeCloudflared(
-      scratchDir,
-      `
-echo "https://abort-me.trycloudflare.com" >&2
-trap 'exit 0' TERM
-sleep 30
-`,
-    )
-    let probeAborted = false
-    const provider = createCloudflareQuickProvider({
-      config,
-      upstreamPort: 8975,
-      binary,
-      onUrlChange: () => {},
-      stopGraceMs: 10,
-      probeDeadlineMs: 60_000,
-      probeReady: (_url, signal) =>
-        new Promise<boolean>((resolve) => {
-          signal.addEventListener('abort', () => {
-            probeAborted = true
-            resolve(false)
-          })
-        }),
-    })
-
-    try {
-      await provider.start()
-      await waitFor(() => provider.snapshot().detail.startsWith('probing tunnel readiness'), {
-        description: 'probe started',
-      })
-
-      await provider.stop()
-
-      expect(probeAborted).toBe(true)
       expect(provider.snapshot().status).toBe('stopped')
     } finally {
       await provider.stop()

--- a/src/tunnels/providers/cloudflare-quick.ts
+++ b/src/tunnels/providers/cloudflare-quick.ts
@@ -8,29 +8,6 @@ const DEFAULT_BINARY = 'cloudflared'
 const DEFAULT_RESTART_BACKOFF_MS = [1_000, 2_000, 4_000, 10_000, 30_000]
 const DEFAULT_MAX_FAILURES_WITHOUT_URL = 10
 const DEFAULT_STOP_GRACE_MS = 5_000
-// cloudflared prints the trycloudflare.com URL to stderr the moment the
-// quick-tunnel control connection comes up, but the ephemeral subdomain
-// can take 1–3 minutes to propagate through DNS resolvers (see
-// cloudflared docs: "it may take some time to be reachable"). If we
-// publish the URL before the edge is reachable, any caller that
-// registers it with an external service (notably GitHub webhook
-// registration → immediate `ping`) loses the first request with
-// "failed to connect to host".
-//
-// Strategy: probe the URL in the background, but ALWAYS emit it once
-// either (a) the probe succeeds, or (b) the fallback deadline expires.
-// Fail-open by design — a flaky probe must never gate registration
-// entirely. Falling back to pre-probe behavior in the worst case is
-// strictly better than silently never emitting at all.
-const DEFAULT_PROBE_INITIAL_BACKOFF_MS = 250
-const DEFAULT_PROBE_MAX_BACKOFF_MS = 5_000
-const DEFAULT_PROBE_FETCH_TIMEOUT_MS = 5_000
-const DEFAULT_PROBE_DEADLINE_MS = 180_000
-
-export type CloudflareQuickProviderLogger = {
-  info: (msg: string) => void
-  warn: (msg: string) => void
-}
 
 export type CloudflareQuickProviderOptions = {
   config: TunnelConfig
@@ -40,29 +17,12 @@ export type CloudflareQuickProviderOptions = {
   restartBackoffMs?: number[]
   maxConsecutiveFailuresWithoutUrl?: number
   stopGraceMs?: number
-  // Probes the public URL until the Cloudflare edge is actually serving
-  // traffic. Returns `true` once any response is observed (including
-  // 4xx/5xx — those still mean the tunnel hostname routed). The provider
-  // calls this in a retry loop until success or `probeDeadlineMs`.
-  // Defaults to a real `fetch`; tests inject a stub.
-  probeReady?: (url: string, signal: AbortSignal) => Promise<boolean>
-  // Hard deadline after URL parse, after which we emit the URL anyway
-  // (with a warning log). 3 minutes by default — covers the slowest
-  // observed quick-tunnel DNS propagation. Must be long enough that
-  // genuinely working tunnels always pass; short enough that broken
-  // tunnels still surface to the caller.
-  probeDeadlineMs?: number
-  probeInitialBackoffMs?: number
-  probeMaxBackoffMs?: number
-  logger?: CloudflareQuickProviderLogger
 }
 
 export type CloudflareQuickProviderHandle = TunnelProviderHandle & {
   tail: () => string[]
   subscribeToLogs: (cb: LogLineSubscriber) => Unsubscribe
 }
-
-const silentLogger: CloudflareQuickProviderLogger = { info: () => {}, warn: () => {} }
 
 export function createCloudflareQuickProvider(options: CloudflareQuickProviderOptions): CloudflareQuickProviderHandle {
   const { config, upstreamPort, onUrlChange } = options
@@ -77,12 +37,6 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
   const restartBackoffMs = options.restartBackoffMs ?? DEFAULT_RESTART_BACKOFF_MS
   const maxConsecutiveFailuresWithoutUrl = options.maxConsecutiveFailuresWithoutUrl ?? DEFAULT_MAX_FAILURES_WITHOUT_URL
   const stopGraceMs = options.stopGraceMs ?? DEFAULT_STOP_GRACE_MS
-  const probeDeadlineMs = options.probeDeadlineMs ?? DEFAULT_PROBE_DEADLINE_MS
-  const probeInitialBackoffMs = options.probeInitialBackoffMs ?? DEFAULT_PROBE_INITIAL_BACKOFF_MS
-  const probeMaxBackoffMs = options.probeMaxBackoffMs ?? DEFAULT_PROBE_MAX_BACKOFF_MS
-  const probeReady = options.probeReady ?? defaultProbeReady
-  const logger = options.logger ?? silentLogger
-  const logPrefix = `[tunnels] ${config.name}`
   const logs = createLogRing()
   const state: TunnelState = {
     name: config.name,
@@ -99,11 +53,12 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
   let proc: ReturnType<typeof Bun.spawn> | null = null
   let retryTimer: ReturnType<typeof setTimeout> | null = null
   let restartFailuresWithoutUrl = 0
-  let probeAbort: AbortController | null = null
+  let attemptEmittedUrl = false
 
   async function launch(): Promise<void> {
     if (!started || stopping) return
 
+    attemptEmittedUrl = false
     state.status = 'starting'
     state.detail = 'starting cloudflared'
     const spawned = Bun.spawn(
@@ -115,8 +70,13 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
     void pumpStderr(spawned.stderr, logs, (line) => {
       const url = extractQuickTunnelUrl(line)
       if (url === null) return
-      if (state.url === url) return
-      void handleUrlEmission(url, spawned)
+      attemptEmittedUrl = true
+      restartFailuresWithoutUrl = 0
+      state.url = url
+      state.status = 'healthy'
+      state.lastUrlAt = Date.now()
+      state.detail = 'quick tunnel URL emitted'
+      onUrlChange(url)
     })
 
     void spawned.exited.then((code) => {
@@ -127,54 +87,8 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
     })
   }
 
-  async function handleUrlEmission(url: string, owningProc: ReturnType<typeof Bun.spawn>): Promise<void> {
-    cancelProbe()
-    const abort = new AbortController()
-    probeAbort = abort
-    const startedAt = Date.now()
-
-    logger.info(
-      `${logPrefix}: cloudflared printed URL ${url}; probing for edge reachability (deadline ${probeDeadlineMs}ms)`,
-    )
-    state.status = 'starting'
-    state.detail = `probing tunnel readiness (deadline ${probeDeadlineMs}ms)`
-
-    const ready = await probeWithDeadline(url, abort.signal, probeReady, {
-      deadlineMs: probeDeadlineMs,
-      initialBackoffMs: probeInitialBackoffMs,
-      maxBackoffMs: probeMaxBackoffMs,
-    })
-    if (probeAbort !== abort) return
-    probeAbort = null
-    if (!started || stopping) return
-    if (proc !== owningProc) return
-
-    const elapsedMs = Date.now() - startedAt
-    if (ready) {
-      logger.info(`${logPrefix}: edge reachable after ${elapsedMs}ms`)
-      state.detail = `quick tunnel URL reachable after ${elapsedMs}ms`
-    } else {
-      logger.warn(
-        `${logPrefix}: edge probe did not succeed within ${elapsedMs}ms; emitting URL anyway. First webhook delivery may fail if DNS hasn't propagated yet.`,
-      )
-      state.detail = `quick tunnel URL emitted without probe confirmation after ${elapsedMs}ms`
-    }
-    restartFailuresWithoutUrl = 0
-    state.url = url
-    state.status = 'healthy'
-    state.lastUrlAt = Date.now()
-    onUrlChange(url)
-  }
-
-  function cancelProbe(): void {
-    if (probeAbort !== null) {
-      probeAbort.abort()
-      probeAbort = null
-    }
-  }
-
   function handleExit(code: number): void {
-    if (state.url === null) restartFailuresWithoutUrl += 1
+    if (!attemptEmittedUrl) restartFailuresWithoutUrl += 1
     if (restartFailuresWithoutUrl >= maxConsecutiveFailuresWithoutUrl) {
       state.status = 'permanently-failed'
       state.detail = `cloudflared exited ${code}; retry cap reached before URL emission`
@@ -183,7 +97,6 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
 
     state.status = 'unhealthy'
     state.detail = `cloudflared exited ${code}; restarting`
-    state.url = null
     const delay = restartBackoffMs[Math.min(restartFailuresWithoutUrl - 1, restartBackoffMs.length - 1)] ?? 30_000
     retryTimer = setTimeout(() => {
       retryTimer = null
@@ -203,7 +116,6 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
       if (!started && proc === null) return
       started = false
       stopping = true
-      cancelProbe()
       if (retryTimer !== null) {
         clearTimeout(retryTimer)
         retryTimer = null
@@ -272,63 +184,6 @@ async function pumpStderr(
   }
 }
 
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    if (signal?.aborted === true) {
-      resolve()
-      return
-    }
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort)
-      resolve()
-    }, ms)
-    const onAbort = (): void => {
-      clearTimeout(timer)
-      resolve()
-    }
-    signal?.addEventListener('abort', onAbort, { once: true })
-  })
-}
-
-type ProbeDeadlineOptions = {
-  deadlineMs: number
-  initialBackoffMs: number
-  maxBackoffMs: number
-}
-
-async function probeWithDeadline(
-  url: string,
-  signal: AbortSignal,
-  probe: (url: string, signal: AbortSignal) => Promise<boolean>,
-  opts: ProbeDeadlineOptions,
-): Promise<boolean> {
-  const deadline = Date.now() + opts.deadlineMs
-  let backoff = opts.initialBackoffMs
-  while (!signal.aborted && Date.now() < deadline) {
-    try {
-      if (await probe(url, signal)) return true
-    } catch {
-      // Probe threw (DNS NXDOMAIN, connection refused, abort, etc.) —
-      // treat as not-ready and back off. These errors are expected
-      // during the propagation window for a fresh quick tunnel.
-    }
-    if (signal.aborted) return false
-    const remaining = deadline - Date.now()
-    if (remaining <= 0) return false
-    await sleep(Math.min(backoff, remaining), signal)
-    backoff = Math.min(backoff * 2, opts.maxBackoffMs)
-  }
-  return false
-}
-
-async function defaultProbeReady(url: string, signal: AbortSignal): Promise<boolean> {
-  const timeout = AbortSignal.timeout(DEFAULT_PROBE_FETCH_TIMEOUT_MS)
-  const combined = AbortSignal.any([signal, timeout])
-  // Any response from the Cloudflare edge — including 404/405/502/530
-  // from the unbound or wrong-method upstream — means the tunnel
-  // hostname is live and routing. We only care about edge reachability,
-  // not upstream health. HEAD is the cheapest verb; redirect:'manual'
-  // keeps us from following 301s into unrelated hosts.
-  await fetch(url, { method: 'HEAD', redirect: 'manual', signal: combined })
-  return true
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }


### PR DESCRIPTION
## Problem

When `typeclaw start` brings up a GitHub channel backed by a cloudflare-quick tunnel, GitHub's automatic post-registration ping consistently fails with "failed to connect to host". This is the third PR in a series targeting that bug: [#399](https://github.com/typeclaw/typeclaw/pull/399) added a HEAD probe from inside the container to gate URL emission; [#402](https://github.com/typeclaw/typeclaw/pull/402) made that probe fail-open with a 3-minute deadline and added lifecycle logging. This PR replaces the probe approach entirely.

## What we learned from #402's logging

With the lifecycle logs from #402 in place, the user ran `typeclaw start` and saw:

```
14:24:09 [tunnels] github-webhook: cloudflared printed URL https://lips-edit-normally-resources.trycloudflare.com; probing for edge reachability (deadline 180000ms)
14:27:09 [tunnels] github-webhook: edge probe did not succeed within 180003ms; emitting URL anyway. First webhook delivery may fail if DNS hasn't propagated yet.
14:27:09 [tunnels] github URL → restarting adapter
14:27:11 [github] registered webhook 631626347 on typeclaw/typeclaw
```

The probe ran its full 3 minutes and never succeeded. Yet immediately after fail-open, registration worked and GitHub's subsequent ping reached the tunnel fine.

We diagnosed by running fetch() from inside the container against the live tunnel URL — every attempt threw "Unable to connect". Running getent hosts on the tunnel hostname returned nothing: DNS resolution silently failed for the ephemeral subdomain. The apex trycloudflare.com and api.github.com both resolved fine; only the ephemeral subdomain failed. The container's nameserver (0.250.250.200, a VPN/WARP resolver) couldn't see fresh *.trycloudflare.com subdomains. Cross-checking with `dig @1.1.1.1` returned the right answer instantly.

## Why the probe approach was fundamentally wrong

The probe asked "can THIS container reach the tunnel?" — but what matters for webhook delivery is "can GitHub reach the tunnel?". Those two paths can disagree any time the container's DNS differs from the public internet, which is exactly the situation where a tunnel is most needed. No amount of tuning the probe deadline fixes this: the probe times out when the container can't resolve the ephemeral subdomain, even when GitHub can reach the tunnel just fine.

## The fix

Drop the probe entirely. Add `webhookRegistrationDelayMs` (default 2000) to GithubAdapterOptions. Sleep that long after receiving the tunnel URL and before calling registerGithubWebhooks. 2 s is empirically sufficient on every network tested to let the Cloudflare edge finish propagating before GitHub's automatic post-registration ping arrives.

| | Probe (#399 / #402) | This PR |
|---|---|---|
| DNS dependency in container | YES — probe fails if container can't resolve tunnel | NO — never resolves the URL from container |
| Worst case if DNS misconfigured | 3 minutes silent wait, then fail-open | 2 seconds, always |
| Cost on happy path | 250 ms–15 s probe round-trips | Always 2 s |
| Webhook-edge race fix | When probe succeeds | When 2 s exceeds edge propagation time |

## Commit structure

Two atomic commits, independently revertable:

1. `tunnels: drop cloudflare-quick readiness probe` — pure revert of the probe machinery from #399 and #402. The cloudflare-quick provider returns to emitting the URL the instant cloudflared prints it. Standing alone, this commit restores pre-#399 behavior (first-ping-fails bug returns).

2. `channels: delay github webhook registration so the tunnel edge can warm up` — adds the 2 s sleep in the github adapter before webhook registration. This is what actually fixes the bug.

Reviewers can review each commit independently.

## Test coverage

- 2 new lifecycle tests in `src/channels/adapters/github/lifecycle.test.ts` covering the delay path.
- 20 existing test sites in that file updated to opt out with `webhookRegistrationDelayMs: 0`.
- All probe-specific tests removed from `src/tunnels/providers/cloudflare-quick.test.ts` (181 lines gone).
- The cloudflareQuickProbeReady stub removed from `src/tunnels/integration.test.ts`.

## Verification

Tested live on the affected machine: `typeclaw start` completes registration within ~2 s instead of 3 minutes, and GitHub's first ping succeeds.

```
bun run typecheck    ✓
bun run lint         ✓  (61 pre-existing warnings, 0 errors, 0 new)
bun run format       ✓
bun run test         5584 pass, 0 fail
```