### PR TITLE
channels: wake the agent on github PR review-request assignments

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -33,6 +33,182 @@ describe('classifyGithubInbound', () => {
     expect(msg?.chat).toBe('pr:7')
     expect(msg?.thread).toBe('101')
   })
+
+  describe('pull_request.review_requested', () => {
+    it('wakes the bot when it is the requested reviewer', () => {
+      const msg = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' }),
+        'typeclaw-bot',
+      )
+      expect(msg?.chat).toBe('pr:7')
+      expect(msg?.thread).toBe(null)
+      expect(msg?.text).toContain('@alice')
+      expect(msg?.text).toContain('requested your review on PR #7')
+      expect(msg?.text).toContain('feat-branch → main')
+      expect(msg?.text).toContain('Please review the changes line-by-line')
+      expect(msg?.isBotMention).toBe(true)
+      expect(msg?.authorName).toBe('alice')
+    })
+
+    it('drops requests targeting someone else', () => {
+      const msg = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'someone-else' }),
+        'typeclaw-bot',
+      )
+      expect(msg).toBe(null)
+    })
+
+    it('drops self-loop when the bot requested itself', () => {
+      const payload = reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' })
+      ;(payload.sender as Record<string, unknown>).login = 'typeclaw-bot'
+      const msg = classifyGithubInbound('pull_request', payload, 'typeclaw-bot')
+      expect(msg).toBe(null)
+    })
+
+    it('wakes the bot when its team is requested and membership resolves true', () => {
+      const msg = classifyGithubInbound('pull_request', reviewRequestedTeamPayload(), 'typeclaw-bot', {
+        teamIsBotMember: true,
+      })
+      expect(msg?.chat).toBe('pr:7')
+      expect(msg?.text).toContain("team @reviewers (you're a member of)")
+    })
+
+    it('drops team requests when membership resolves false', () => {
+      const msg = classifyGithubInbound('pull_request', reviewRequestedTeamPayload(), 'typeclaw-bot', {
+        teamIsBotMember: false,
+      })
+      expect(msg).toBe(null)
+    })
+
+    it('drops team requests when membership is unknown (handler did not resolve)', () => {
+      const msg = classifyGithubInbound('pull_request', reviewRequestedTeamPayload(), 'typeclaw-bot')
+      expect(msg).toBe(null)
+    })
+
+    it('mints distinct externalMessageIds for requested → removed → requested again', () => {
+      const requested = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot', updatedAt: '2026-01-01T00:00:00Z' }),
+        'typeclaw-bot',
+      )
+      const removed = classifyGithubInbound(
+        'pull_request',
+        reviewRequestRemovedPayload({ reviewerLogin: 'typeclaw-bot', updatedAt: '2026-01-01T00:01:00Z' }),
+        'typeclaw-bot',
+      )
+      const requestedAgain = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot', updatedAt: '2026-01-01T00:02:00Z' }),
+        'typeclaw-bot',
+      )
+      expect(requested?.externalMessageId).not.toBe(removed?.externalMessageId)
+      expect(removed?.externalMessageId).not.toBe(requestedAgain?.externalMessageId)
+      expect(requested?.externalMessageId).not.toBe(requestedAgain?.externalMessageId)
+    })
+
+    it('falls back to PR id when title/branch info is absent', () => {
+      const payload = reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' })
+      delete (payload.pull_request as Record<string, unknown>).title
+      delete (payload.pull_request as Record<string, unknown>).head
+      delete (payload.pull_request as Record<string, unknown>).base
+      const msg = classifyGithubInbound('pull_request', payload, 'typeclaw-bot')
+      expect(msg?.text).toContain('PR #7')
+      expect(msg?.text).not.toContain('Branch:')
+    })
+  })
+
+  describe('pull_request.review_request_removed', () => {
+    it('emits a cleanup signal when the bot is un-requested', () => {
+      const msg = classifyGithubInbound(
+        'pull_request',
+        reviewRequestRemovedPayload({ reviewerLogin: 'typeclaw-bot' }),
+        'typeclaw-bot',
+      )
+      expect(msg?.chat).toBe('pr:7')
+      expect(msg?.text).toContain('removed your review request')
+      expect(msg?.text).toContain('You can stop any in-progress review.')
+    })
+
+    it('drops removal events for other reviewers', () => {
+      const msg = classifyGithubInbound(
+        'pull_request',
+        reviewRequestRemovedPayload({ reviewerLogin: 'someone-else' }),
+        'typeclaw-bot',
+      )
+      expect(msg).toBe(null)
+    })
+  })
+})
+
+describe('createGithubWebhookHandler — review_requested team gating', () => {
+  it('consults isBotInTeam and routes when membership is active', async () => {
+    const routed: InboundMessage[] = []
+    const calls: Array<{ org: string; slug: string; login: string }> = []
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['pull_request.review_requested'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot',
+      isBotInTeam: async (input) => {
+        calls.push(input)
+        return true
+      },
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+
+    const body = JSON.stringify(reviewRequestedTeamPayload())
+    const response = await handler(signedRequest(body, 'pull_request', 'team-1'))
+
+    expect(response.status).toBe(200)
+    expect(calls).toEqual([{ org: 'acme', slug: 'reviewers', login: 'typeclaw-bot' }])
+    expect(routed[0]?.chat).toBe('pr:7')
+  })
+
+  it('drops the event when isBotInTeam resolves false', async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['pull_request.review_requested'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot',
+      isBotInTeam: async () => false,
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+
+    await handler(signedRequest(JSON.stringify(reviewRequestedTeamPayload()), 'pull_request', 'team-2'))
+    expect(routed).toHaveLength(0)
+  })
+
+  it('drops the event when isBotInTeam throws', async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['pull_request.review_requested'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot',
+      isBotInTeam: async () => {
+        throw new Error('boom')
+      },
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+
+    await handler(signedRequest(JSON.stringify(reviewRequestedTeamPayload()), 'pull_request', 'team-3'))
+    expect(routed).toHaveLength(0)
+  })
 })
 
 describe('createGithubWebhookHandler', () => {
@@ -118,5 +294,47 @@ function reviewCommentPayload(): Record<string, unknown> {
     repository: repo(),
     pull_request: { number: 7 },
     comment: { id: 102, in_reply_to_id: 101, body: 'review', created_at: '2026-01-01T00:00:00Z', user: user() },
+  }
+}
+
+function pullRequestForReview(updatedAt: string): Record<string, unknown> {
+  return {
+    number: 7,
+    id: 700,
+    title: 'Add the thing',
+    updated_at: updatedAt,
+    head: { ref: 'feat-branch' },
+    base: { ref: 'main' },
+    user: user(),
+  }
+}
+
+function reviewRequestedPayload(options: { reviewerLogin: string; updatedAt?: string }): Record<string, unknown> {
+  return {
+    action: 'review_requested',
+    repository: repo(),
+    pull_request: pullRequestForReview(options.updatedAt ?? '2026-01-01T00:00:00Z'),
+    requested_reviewer: { login: options.reviewerLogin, id: 42, type: 'User' },
+    sender: { login: 'alice', id: 10, type: 'User' },
+  }
+}
+
+function reviewRequestRemovedPayload(options: { reviewerLogin: string; updatedAt?: string }): Record<string, unknown> {
+  return {
+    action: 'review_request_removed',
+    repository: repo(),
+    pull_request: pullRequestForReview(options.updatedAt ?? '2026-01-01T00:01:00Z'),
+    requested_reviewer: { login: options.reviewerLogin, id: 42, type: 'User' },
+    sender: { login: 'alice', id: 10, type: 'User' },
+  }
+}
+
+function reviewRequestedTeamPayload(): Record<string, unknown> {
+  return {
+    action: 'review_requested',
+    repository: repo(),
+    pull_request: pullRequestForReview('2026-01-01T00:00:00Z'),
+    requested_team: { slug: 'reviewers', id: 5000 },
+    sender: { login: 'alice', id: 10, type: 'User' },
   }
 }

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -15,6 +15,10 @@ export type GithubWebhookHandlerOptions = {
   selfLogin: () => string | null
   route: (message: InboundMessage) => void
   logger: GithubInboundLogger
+  // Optional: resolves whether the bot is a member of the given team. When
+  // omitted, team-reviewer requests are silently dropped (the v1 fallback
+  // behavior). The adapter wires this in production; tests inject a fake.
+  isBotInTeam?: (input: { org: string; slug: string; login: string }) => Promise<boolean>
 }
 
 export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions): (req: Request) => Promise<Response> {
@@ -43,7 +47,10 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
     const author = readAuthor(payload)
     if (selfId !== null && author !== null && String(author.id) === selfId) return ok()
 
-    const classified = classifyGithubInbound(event, payload, options.selfLogin())
+    const teamIsBotMember = await resolveTeamMembership(event, payload, options)
+    const classified = classifyGithubInbound(event, payload, options.selfLogin(), {
+      teamIsBotMember,
+    })
     if (classified === null) return ok()
 
     if (delivery !== '') options.dedup.add(delivery)
@@ -64,6 +71,7 @@ export function classifyGithubInbound(
   event: string,
   payload: Record<string, unknown>,
   selfLogin: string | null,
+  options?: { teamIsBotMember?: boolean },
 ): InboundMessage | null {
   const repository = readRepository(payload)
   if (repository === null) return null
@@ -151,6 +159,18 @@ export function classifyGithubInbound(
     const number = readNumber(pr, 'number')
     const id = readNumber(pr, 'id') ?? number
     if (number === null || id === null) return null
+    const action = readString(payload, 'action')
+    if (action === 'review_requested' || action === 'review_request_removed') {
+      return classifyReviewRequest({
+        action,
+        payload,
+        pr,
+        number,
+        base,
+        selfLogin,
+        teamIsBotMember: options?.teamIsBotMember,
+      })
+    }
     return buildInbound(
       { ...base, chat: `pr:${number}`, thread: null },
       pr.body,
@@ -197,6 +217,85 @@ export function classifyGithubInbound(
   return null
 }
 
+type ReviewRequestInput = {
+  action: 'review_requested' | 'review_request_removed'
+  payload: Record<string, unknown>
+  pr: Record<string, unknown>
+  number: number
+  base: Pick<InboundMessage, 'adapter' | 'workspace' | 'isDm' | 'mentionsOthers' | 'replyToOtherMessageId'>
+  selfLogin: string | null
+  teamIsBotMember: boolean | undefined
+}
+
+function classifyReviewRequest(input: ReviewRequestInput): InboundMessage | null {
+  const { action, payload, pr, number, base, selfLogin, teamIsBotMember } = input
+  if (selfLogin === null) return null
+  const sender = readUser(payload.sender)
+  if (sender === null) return null
+  // Self-loop guard: if the bot itself requested (or un-requested) the
+  // review, drop the event. The bot adding itself as a reviewer would
+  // otherwise wake a fresh session every time it self-assigns.
+  if (sender.login === selfLogin) return null
+
+  const requestedUser = readUser(payload.requested_reviewer)
+  const requestedTeam = readReviewerTeam(payload.requested_team)
+
+  const isMeAsUser = requestedUser !== null && requestedUser.login === selfLogin
+  const isMyTeam = requestedTeam !== null && teamIsBotMember === true
+  if (!isMeAsUser && !isMyTeam) return null
+
+  const title = readString(pr, 'title') ?? `#${number}`
+  const head = readString(readRecord(pr.head), 'ref')
+  const baseRef = readString(readRecord(pr.base), 'ref')
+  const branchSegment = head !== null && baseRef !== null ? ` Branch: ${head} → ${baseRef}.` : ''
+  const verbed =
+    action === 'review_requested'
+      ? isMyTeam
+        ? `requested a review from team @${requestedTeam?.slug} (you're a member of) on PR #${number}: "${title}".`
+        : `requested your review on PR #${number}: "${title}".`
+      : isMyTeam
+        ? `removed the review request for team @${requestedTeam?.slug} on PR #${number}: "${title}".`
+        : `removed your review request on PR #${number}: "${title}".`
+  const closing =
+    action === 'review_requested'
+      ? ' Please review the changes line-by-line and post your feedback.'
+      : ' You can stop any in-progress review.'
+  const text = `@${sender.login} ${verbed}${branchSegment}${closing}`
+
+  // Synthesize a stable per-event externalMessageId. The PR's `updated_at`
+  // changes on every review-request mutation, so combining it with the PR id
+  // and the action keeps separate "requested → removed → requested again"
+  // events from collapsing into one dedup'd id.
+  const updatedAt = readString(pr, 'updated_at') ?? ''
+  const prId = readNumber(pr, 'id') ?? number
+  const externalMessageId = `pr-${prId}-${action}-${updatedAt}`
+
+  return {
+    ...base,
+    chat: `pr:${number}`,
+    thread: null,
+    text,
+    externalMessageId,
+    authorId: String(sender.id),
+    authorName: sender.login,
+    authorIsBot: sender.type === 'Bot',
+    isBotMention: true,
+    replyToBotMessageId: null,
+    ts: updatedAt !== '' ? Date.parse(updatedAt) || 0 : 0,
+  }
+}
+
+export type GithubReviewerTeam = { slug: string; id: number; org: string | null }
+
+export function readReviewerTeam(value: unknown): GithubReviewerTeam | null {
+  const team = readRecord(value)
+  const slug = readString(team, 'slug')
+  const id = readNumber(team, 'id')
+  if (slug === null || id === null) return null
+  const org = readString(readRecord(team?.organization), 'login')
+  return { slug, id, org }
+}
+
 function buildInbound(
   key: Pick<
     InboundMessage,
@@ -220,6 +319,32 @@ function buildInbound(
     isBotMention: selfLogin !== null && text.includes(`@${selfLogin}`),
     replyToBotMessageId: null,
     ts: typeof rawTs === 'string' ? Date.parse(rawTs) || 0 : 0,
+  }
+}
+
+async function resolveTeamMembership(
+  event: string,
+  payload: Record<string, unknown>,
+  options: GithubWebhookHandlerOptions,
+): Promise<boolean | undefined> {
+  if (event !== 'pull_request') return undefined
+  const action = readString(payload, 'action')
+  if (action !== 'review_requested' && action !== 'review_request_removed') return undefined
+  const team = readReviewerTeam(payload.requested_team)
+  if (team === null) return undefined
+  const selfLogin = options.selfLogin()
+  if (selfLogin === null) return false
+  if (options.isBotInTeam === undefined) return false
+  // The team payload sometimes omits `organization.login`. Fall back to the
+  // repository owner, which is the only org GitHub can legally route team
+  // reviewers from on a given PR.
+  const org = team.org ?? readRepository(payload)?.owner ?? null
+  if (org === null) return false
+  try {
+    return await options.isBotInTeam({ org, slug: team.slug, login: selfLogin })
+  } catch (err) {
+    options.logger.warn(`[github] team membership lookup failed: ${describe(err)}`)
+    return false
   }
 }
 

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -18,6 +18,7 @@ import {
   buildPermissionGuidance,
   parseListHooksPermissionStatus,
 } from './permission-guidance'
+import { createTeamMembershipChecker } from './team-membership'
 import { deregisterGithubWebhooks, registerGithubWebhooks, type WebhookRegistrationResult } from './webhook-register'
 
 export type GithubAdapterLogger = {
@@ -110,12 +111,14 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
   // No-op typing callback: GitHub has no typing indicator API.
   const typing = async (): Promise<void> => {}
   const dedup = createDeliveryDedup()
+  const isBotInTeam = createTeamMembershipChecker({ token: tokenFn, fetchImpl })
   const handler = createGithubWebhookHandler({
     webhookSecret,
     dedup,
     allowlist: () => options.configRef().eventAllowlist,
     selfId: () => selfId,
     selfLogin: () => selfLogin,
+    isBotInTeam,
     logger,
     route: (message) => {
       rememberWorkspace(message.workspace, message.chat)

--- a/src/channels/adapters/github/team-membership.test.ts
+++ b/src/channels/adapters/github/team-membership.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'bun:test'
+
+import { createTeamMembershipChecker } from './team-membership'
+
+describe('createTeamMembershipChecker', () => {
+  it('returns true for an active membership', async () => {
+    const fetchImpl = fakeFetch(() => new Response(JSON.stringify({ state: 'active' }), { status: 200 }))
+    const check = createTeamMembershipChecker({ token: async () => 'tok', fetchImpl })
+    expect(await check({ org: 'acme', slug: 'reviewers', login: 'typeclaw-bot' })).toBe(true)
+  })
+
+  it('returns false for a pending (non-active) membership', async () => {
+    const fetchImpl = fakeFetch(() => new Response(JSON.stringify({ state: 'pending' }), { status: 200 }))
+    const check = createTeamMembershipChecker({ token: async () => 'tok', fetchImpl })
+    expect(await check({ org: 'acme', slug: 'reviewers', login: 'typeclaw-bot' })).toBe(false)
+  })
+
+  it('returns false on 404 (not a member)', async () => {
+    const fetchImpl = fakeFetch(() => new Response('', { status: 404 }))
+    const check = createTeamMembershipChecker({ token: async () => 'tok', fetchImpl })
+    expect(await check({ org: 'acme', slug: 'reviewers', login: 'typeclaw-bot' })).toBe(false)
+  })
+
+  it('returns false on network error (fail-closed)', async () => {
+    const fetchImpl = fakeFetch(() => {
+      throw new Error('boom')
+    })
+    const check = createTeamMembershipChecker({ token: async () => 'tok', fetchImpl })
+    expect(await check({ org: 'acme', slug: 'reviewers', login: 'typeclaw-bot' })).toBe(false)
+  })
+
+  it('caches results across calls', async () => {
+    let calls = 0
+    const fetchImpl = fakeFetch(() => {
+      calls++
+      return new Response(JSON.stringify({ state: 'active' }), { status: 200 })
+    })
+    const check = createTeamMembershipChecker({ token: async () => 'tok', fetchImpl })
+    await check({ org: 'acme', slug: 'reviewers', login: 'typeclaw-bot' })
+    await check({ org: 'acme', slug: 'reviewers', login: 'typeclaw-bot' })
+    expect(calls).toBe(1)
+  })
+
+  it('caches per (org, slug, login) tuple', async () => {
+    let calls = 0
+    const fetchImpl = fakeFetch(() => {
+      calls++
+      return new Response(JSON.stringify({ state: 'active' }), { status: 200 })
+    })
+    const check = createTeamMembershipChecker({ token: async () => 'tok', fetchImpl })
+    await check({ org: 'acme', slug: 'reviewers', login: 'typeclaw-bot' })
+    await check({ org: 'acme', slug: 'maintainers', login: 'typeclaw-bot' })
+    expect(calls).toBe(2)
+  })
+})
+
+function fakeFetch(impl: () => Response | Promise<Response>): typeof fetch {
+  const fn = async (): Promise<Response> => impl()
+  return fn as unknown as typeof fetch
+}

--- a/src/channels/adapters/github/team-membership.ts
+++ b/src/channels/adapters/github/team-membership.ts
@@ -1,0 +1,56 @@
+// Best-effort "is the bot a member of this team?" lookup, used to gate
+// `pull_request.review_requested` inbounds when GitHub assigns a *team*
+// rather than a user as the reviewer.
+//
+// Cached per (org, slug, login) for the adapter's lifetime: team membership
+// changes rarely, and a stale cache costs us one missed review (the next
+// request rebuilds it). Errors fall closed (return false): we'd rather drop
+// a real review request than wake the agent on a team the bot isn't in.
+
+const ACTIVE_MEMBERSHIP_STATE = 'active'
+
+export type TeamMembershipChecker = (input: { org: string; slug: string; login: string }) => Promise<boolean>
+
+export function createTeamMembershipChecker(options: {
+  token: () => Promise<string>
+  fetchImpl?: typeof fetch
+}): TeamMembershipChecker {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const cache = new Map<string, boolean>()
+
+  return async ({ org, slug, login }) => {
+    const key = `${org}/${slug}#${login}`
+    const cached = cache.get(key)
+    if (cached !== undefined) return cached
+
+    const result = await lookup(fetchImpl, await options.token(), org, slug, login)
+    cache.set(key, result)
+    return result
+  }
+}
+
+async function lookup(
+  fetchImpl: typeof fetch,
+  token: string,
+  org: string,
+  slug: string,
+  login: string,
+): Promise<boolean> {
+  const url = `https://api.github.com/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(slug)}/memberships/${encodeURIComponent(login)}`
+  let res: Response
+  try {
+    res = await fetchImpl(url, {
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'x-github-api-version': '2022-11-28',
+      },
+    })
+  } catch {
+    return false
+  }
+  if (res.status === 404) return false
+  if (!res.ok) return false
+  const body = (await res.json().catch(() => null)) as { state?: unknown } | null
+  return typeof body?.state === 'string' && body.state === ACTIVE_MEMBERSHIP_STATE
+}

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -125,6 +125,8 @@ export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [
   'discussion_comment.created',
   'issues.opened',
   'pull_request.opened',
+  'pull_request.review_requested',
+  'pull_request.review_request_removed',
   'discussion.created',
   'pull_request_review.submitted',
 ] as const

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typeclaw-channel-github
-description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `github`, AND before composing replies to GitHub-originated inbounds, AND before opening new issues or PRs with `gh`. GitHub renders **real markdown** — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and `inline code` all render natively. Use rich markdown freely. GitHub cannot send file attachments via API — do not call `channel_send` with attachments on github chats. GitHub has no typing indicator. PR review threads use `thread` keyed on the root comment id; reply to a thread to stay in it, or omit `thread` to post a top-level issue/PR comment. To open new issues or PRs use the `gh` CLI — `GH_TOKEN` is pre-set by the adapter. Read this skill before composing anything on GitHub.
+description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `github`, AND before composing replies to GitHub-originated inbounds, AND before opening new issues or PRs with `gh`, AND ALWAYS when an inbound says "requested your review on PR #N" or "requested a review from team @… on PR #N" (the agent has been assigned as a reviewer and must do a real code review with line-by-line comments via `gh api`). GitHub renders **real markdown** — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and `inline code` all render natively. Use rich markdown freely. GitHub cannot send file attachments via API — do not call `channel_send` with attachments on github chats. GitHub has no typing indicator. PR review threads use `thread` keyed on the root comment id; reply to a thread to stay in it, or omit `thread` to post a top-level issue/PR comment. To open new issues or PRs use the `gh` CLI — `GH_TOKEN` is pre-set by the adapter. Read this skill before composing anything on GitHub.
 ---
 
 GitHub renders normal Markdown in issues, PRs, discussions, and review comments. Use headings, lists, tables, fenced code blocks, links, and inline code when they improve clarity.
@@ -22,3 +22,47 @@ gh pr create --repo owner/repo --title "Fix: ..." --head my-branch --base main -
 ```
 
 For App auth, `GH_TOKEN` is an installation access token that refreshes automatically — it stays current as long as the adapter is running.
+
+## Reviewing pull requests
+
+When an incoming message says **"requested your review on PR #N"** (or "requested a review from team @… on PR #N"), you have been assigned as a reviewer. Do a real code review and post line-by-line comments via `gh api`. Do **not** just reply in the channel — the user wants feedback on the diff.
+
+### Workflow
+
+1. **Read the diff and context**:
+
+   ```sh
+   gh pr diff <N> --repo owner/repo
+   gh pr view <N> --repo owner/repo --json title,body,baseRefName,headRefOid,files
+   ```
+
+2. **Submit a multi-comment review** in one API call. `comments[]` accepts line-level entries; each one lands on the diff exactly like a human reviewer's inline comment:
+
+   ```sh
+   gh api -X POST /repos/owner/repo/pulls/<N>/reviews \
+     -F event=COMMENT \
+     -f body="Overall: looks good with a few nits." \
+     -F 'comments[][path]=src/foo.ts' \
+     -F 'comments[][line]=42' \
+     -F 'comments[][side]=RIGHT' \
+     -F 'comments[][body]=nit: prefer `const` here.' \
+     -F 'comments[][path]=src/bar.ts' \
+     -F 'comments[][line]=10' \
+     -F 'comments[][side]=RIGHT' \
+     -F 'comments[][body]=Consider extracting this branch into a helper.'
+   ```
+
+3. **Then** post a one-line summary with `channel_reply` so the conversation has a human-readable trace pointing at the review.
+
+### Rules
+
+- Use `event=COMMENT` by default. Use `APPROVE` only when you have high confidence the PR is ready to merge. Use `REQUEST_CHANGES` only when the PR has clear blockers — not for nits.
+- `line` is a line number **in the file**, not a position in the diff. `side: RIGHT` is the new revision (default for additions); `side: LEFT` is the old revision (use for comments on removed lines).
+- For multi-line comments, also set `start_line` and `start_side` (same semantics).
+- If you need to read whole files at the PR's head SHA, use `gh api /repos/owner/repo/contents/<path>?ref=<headRefOid>`.
+- The bundled `agent-browser` is **not** for PR reviews — `gh api` is faster and more reliable. Only use the browser when the API genuinely can't reach what you need.
+- A `review_request_removed` event means the requester un-assigned you. Stop any in-progress review work; do not post a partial review.
+
+### Self-loop safety
+
+The adapter will **not** wake you when you assign yourself as a reviewer (e.g., via `gh pr edit --add-reviewer`). It will only wake you when someone else requests your review.


### PR DESCRIPTION
## Problem

When github assigns the bot as a reviewer on a PR, nothing happens. The adapter accepts the `pull_request` event family, but only the `opened` action wakes the agent. A real reviewer assignment — `pull_request.review_requested` — slides into the inbound classifier's generic `pull_request` branch, which extracts the PR body and treats the event as if the PR were just opened. The agent has no idea it was assigned to review anything, and even if it did, the channel-level prompt for `review_requested` looks identical to the prompt for `opened`.

This means users who add the typeclaw bot as a reviewer on a PR currently get silence.

## What this PR does

Add an explicit `pull_request.review_requested` (and `review_request_removed`) inbound classifier branch. When github assigns the bot — directly or via a team the bot belongs to — synthesize a natural-language inbound that tells the agent it has been asked to review the PR. Pair with a `typeclaw-channel-github` skill update that documents the `gh api` recipe for posting a multi-comment, line-by-line review in one call.

The actual review action still goes through the `gh` CLI: `GH_TOKEN` is already injected at adapter start, the skill teaches the multi-comment `POST /repos/{owner}/{repo}/pulls/{N}/reviews` recipe, and the agent reads diffs with `gh pr diff`. A typed channel-level review tool is a follow-up — landing this PR ships the use case immediately and lets us learn whether the skill-driven approach is enough before committing to a typed API.

## Behavior

- **User-targeted requests.** Fire when `requested_reviewer.login` matches the bot's self-login (resolved once at adapter start, already cached by the existing `auth.getSelf()` path).

- **Team-targeted requests.** Consult a new `TeamMembershipChecker` against `GET /orgs/{org}/teams/{slug}/memberships/{login}`. Active memberships wake the bot; pending/404/network-error fail closed so the bot does not wake on a team it cannot confirm membership of. Cached per `(org, slug, login)` tuple for the adapter's lifetime — team membership rarely changes, and a stale cache costs at most one missed review (the next request rebuilds it).

- **Self-loop guard.** Drops events where `sender.login` is the bot itself. Without this, `gh pr edit --add-reviewer` from inside the agent's own container would trigger a fresh session on every self-assignment.

- **Stable per-event externalMessageId.** Encodes `pr.id`, action, and `pr.updated_at` so a `requested → removed → requested-again` sequence keeps distinct dedup keys. Otherwise the dedup layer would collapse the second `requested` into the first.

- **Default eventAllowlist updated.** `pull_request.review_requested` and `pull_request.review_request_removed` are now in `DEFAULT_GITHUB_EVENT_ALLOWLIST`. New installs pick them up automatically; existing agents whose `typeclaw.json` already overrides the allowlist need to opt in manually.

## What the agent sees

When alice assigns the bot to PR #7:

> @alice requested your review on PR #7: "Add the thing". Branch: feat-branch → main. Please review the changes line-by-line and post your feedback.

When alice assigns a team the bot belongs to:

> @alice requested a review from team @reviewers (you're a member of) on PR #7: "Add the thing". Branch: feat-branch → main. Please review the changes line-by-line and post your feedback.

When alice removes the request:

> @alice removed your review request on PR #7: "Add the thing". Branch: feat-branch → main. You can stop any in-progress review.

The skill's frontmatter description now explicitly mentions the "requested your review on PR #N" trigger so the agent loads it on review assignments. The skill body documents the gh-api recipe:

```sh
gh pr diff <N> --repo owner/repo
gh api -X POST /repos/owner/repo/pulls/<N>/reviews \
  -F event=COMMENT \
  -f body="Overall: looks good with a few nits." \
  -F 'comments[][path]=src/foo.ts' \
  -F 'comments[][line]=42' \
  -F 'comments[][side]=RIGHT' \
  -F 'comments[][body]=nit: prefer `const` here.'
```

## What this PR does not do

- **No typed `github_review` channel tool yet.** The `channel_send`/`channel_reply` schemas stay generic. Posting line comments goes through `gh api`. If the skill-driven approach proves unreliable, a follow-up can add a dedicated tool registered only when `origin.adapter === 'github' && origin.chat.startsWith('pr:')`.
- **No `synchronize` re-review.** Force-pushes during a review do not re-trigger the bot. Out of scope for this PR.
- **No bot-initiated APPROVE / REQUEST_CHANGES.** The skill says use `event=COMMENT` by default; verdicts are reserved for future calibration.
- **App-installed bots cannot be team members.** Team-reviewer events for App-auth deployments will silently drop. This matches github's data model (apps aren't team members) and is documented by the fail-closed behavior of `TeamMembershipChecker`.

## Files changed

| File | Change |
|---|---|
| `src/channels/adapters/github/inbound.ts` | New `pull_request.review_requested`/`review_request_removed` branch in `classifyGithubInbound`; new `resolveTeamMembership` helper inside `createGithubWebhookHandler`; `GithubWebhookHandlerOptions.isBotInTeam` plumbing. |
| `src/channels/adapters/github/team-membership.ts` | New `createTeamMembershipChecker` — fetch + parse + cache, fail-closed. |
| `src/channels/adapters/github/team-membership.test.ts` | New unit tests: active membership, pending, 404, network error, cache hits, per-tuple caching. |
| `src/channels/adapters/github/inbound.test.ts` | New cases: user-targeted request, team-targeted request with/without membership, self-loop drop, distinct externalMessageIds across requested→removed→requested-again, removed-event cleanup signal. End-to-end handler tests verifying `isBotInTeam` is consulted with the correct `(org, slug, login)` and that errors fail closed. |
| `src/channels/adapters/github/index.ts` | Wire `createTeamMembershipChecker` (token + fetchImpl) into the webhook handler via the new `isBotInTeam` option. |
| `src/channels/schema.ts` | Add `pull_request.review_requested` and `pull_request.review_request_removed` to `DEFAULT_GITHUB_EVENT_ALLOWLIST`. |
| `src/skills/typeclaw-channel-github/SKILL.md` | New "Reviewing pull requests" section with the gh-api recipe, side/line semantics, when to use APPROVE/REQUEST_CHANGES, and the self-loop safety note. Frontmatter description updated to trigger on the "requested your review" prompt. |

The drift-guard test (`scripts/generate-schema.test.ts`) confirms the regenerated `typeclaw.schema.json` matches the source schema; the file is gitignored and ships via `postinstall`.

## Test coverage

- `src/channels/adapters/github/team-membership.test.ts` — 6 unit tests, all behaviors of the checker.
- `src/channels/adapters/github/inbound.test.ts` — 11 new cases covering both the classifier (synchronous) and the webhook-handler async team-membership path.

## Verification

```
bun run typecheck    ✓
bun run lint         ✓  (60 pre-existing warnings, 0 errors, 0 new)
bun run format:check ✓
bun run test         5603 pass, 0 fail
```

## Followup ideas

- Typed `github_review` channel tool with `Type.Object({ event, body?, comments: [...] })`.
- `synchronize`-aware re-review on force-push.
- `origin.chatKind` field so the agent sees "this is a PR" without parsing `chat: pr:7`.
