### PR TITLE
run: observe Codex Responses fetch with phase timings

### DIFF
--- a/src/run/codex-fetch-observer.test.ts
+++ b/src/run/codex-fetch-observer.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { installCodexFetchObserver } from './codex-fetch-observer'
+
+type LogEntry = { level: 'info' | 'warn'; msg: string }
+
+function captureLogger(): { logger: { info: (m: string) => void; warn: (m: string) => void }; entries: LogEntry[] } {
+  const entries: LogEntry[] = []
+  return {
+    entries,
+    logger: {
+      info: (m) => entries.push({ level: 'info', msg: m }),
+      warn: (m) => entries.push({ level: 'warn', msg: m }),
+    },
+  }
+}
+
+// Programmable clock so phase timings are deterministic. `now()` returns
+// whatever the test most recently set; production reads timings via the
+// `now` option, so we never depend on real wall-clock in assertions.
+function makeClock() {
+  let ms = 0
+  return {
+    now: () => ms,
+    set: (v: number) => {
+      ms = v
+    },
+  }
+}
+
+// Body controller pair: lets the test push chunks/close/error into a Response
+// body at the moments it chooses, after walking the clock to the right value.
+// More predictable than a self-scheduling fake because each event awaits a
+// microtask flush before the next test step assertion.
+function makeControllableBody(): {
+  body: ReadableStream<Uint8Array>
+  push: (data: Uint8Array) => Promise<void>
+  close: () => Promise<void>
+  error: (err: Error) => Promise<void>
+} {
+  let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null
+  let resolveReady!: (c: ReadableStreamDefaultController<Uint8Array>) => void
+  const ready = new Promise<ReadableStreamDefaultController<Uint8Array>>((resolve) => {
+    resolveReady = resolve
+  })
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controllerRef = controller
+      resolveReady(controller)
+    },
+  })
+  const flush = () => new Promise<void>((r) => queueMicrotask(r))
+  return {
+    body,
+    push: async (data) => {
+      const c = controllerRef ?? (await ready)
+      c.enqueue(data)
+      await flush()
+      await flush()
+    },
+    close: async () => {
+      const c = controllerRef ?? (await ready)
+      c.close()
+      await flush()
+    },
+    error: async (err) => {
+      const c = controllerRef ?? (await ready)
+      c.error(err)
+      await flush()
+    },
+  }
+}
+
+// Drain a readable stream to completion, ignoring chunks. Lets us trigger the
+// observer's final log without caring about what the SSE consumer would do.
+async function drainQuiet(stream: ReadableStream<Uint8Array> | null): Promise<void> {
+  if (stream === null) return
+  const reader = stream.getReader()
+  try {
+    while (true) {
+      const { done } = await reader.read()
+      if (done) break
+    }
+  } catch {
+    // expected for error-stream tests
+  }
+}
+
+const originalFetch = globalThis.fetch
+
+describe('installCodexFetchObserver', () => {
+  beforeEach(() => {
+    // Tests can mutate globalThis.fetch; reset to the platform default each
+    // time so a misbehaving test doesn't leak into the next.
+    globalThis.fetch = originalFetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('passes non-Codex requests through unchanged (no wrapping)', async () => {
+    const { logger, entries } = captureLogger()
+    const sentinel = Symbol('upstream')
+    globalThis.fetch = (async () => sentinel as unknown as Response) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger })
+    try {
+      const result = await fetch('https://example.com/some/other/path')
+      expect(result).toBe(sentinel as unknown as Response)
+      expect(entries).toEqual([])
+    } finally {
+      uninstall()
+    }
+  })
+
+  test('propagates errors from non-Codex upstream verbatim', async () => {
+    const { logger, entries } = captureLogger()
+    const upstreamError = new Error('upstream boom')
+    globalThis.fetch = (async () => {
+      throw upstreamError
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger })
+    try {
+      await expect(fetch('https://api.openai.com/v1/responses')).rejects.toBe(upstreamError)
+      expect(entries).toEqual([])
+    } finally {
+      uninstall()
+    }
+  })
+
+  test('logs phase timings for a Codex request', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(50)
+      return new Response(ctrl.body, {
+        status: 200,
+        headers: { 'x-request-id': 'req_abc123', 'content-type': 'text/event-stream' },
+      })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now })
+    try {
+      clock.set(0)
+      const responsePromise = fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const response = await responsePromise
+      expect(response.status).toBe(200)
+      const drainPromise = drainQuiet(response.body)
+      clock.set(200)
+      await ctrl.push(new TextEncoder().encode('data: {"type":"response.created"}\n\n'))
+      clock.set(1500)
+      await ctrl.push(new TextEncoder().encode('data: {"type":"response.output_text.delta","delta":"hi"}\n\n'))
+      clock.set(2000)
+      await ctrl.close()
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines.length).toBe(1)
+    const line = codexLines[0]!.msg
+    expect(line).toContain('status=200')
+    expect(line).toContain('headers_ms=50')
+    expect(line).toContain('first_byte_ms=200')
+    expect(line).toContain('total_ms=2000')
+    expect(line).toContain('request_id=req_abc123')
+    expect(line).toContain('retry_after=null')
+    expect(line).toContain('error=null')
+  })
+
+  test('logs retry_after header when present (throttling signal)', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(10)
+      return new Response(ctrl.body, {
+        status: 429,
+        headers: { 'retry-after': '42', 'x-request-id': 'req_throttled' },
+      })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now })
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const drainPromise = drainQuiet(response.body)
+      clock.set(20)
+      await ctrl.close()
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines.length).toBe(1)
+    expect(codexLines[0]!.msg).toContain('status=429')
+    expect(codexLines[0]!.msg).toContain('retry_after=42')
+  })
+
+  test('logs stream errors with error message and partial timings', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(30)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now })
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const drainPromise = drainQuiet(response.body)
+      clock.set(100)
+      await ctrl.push(new TextEncoder().encode('data: hi\n\n'))
+      clock.set(300)
+      await ctrl.error(new Error('connection reset by peer'))
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines.length).toBe(1)
+    const line = codexLines[0]!.msg
+    expect(line).toContain('status=200')
+    expect(line).toContain('first_byte_ms=100')
+    expect(line).toContain('error="connection reset by peer"')
+  })
+
+  test('logs fetch() rejection (pre-response error)', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    globalThis.fetch = (async () => {
+      clock.set(500)
+      throw new Error('fetch failed')
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now })
+    try {
+      clock.set(0)
+      await expect(fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })).rejects.toThrow(
+        'fetch failed',
+      )
+    } finally {
+      uninstall()
+    }
+
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines.length).toBe(1)
+    expect(codexLines[0]!.msg).toContain('error="fetch failed"')
+    expect(codexLines[0]!.msg).toContain('headers_ms=null')
+    expect(codexLines[0]!.msg).toContain('first_byte_ms=null')
+    expect(codexLines[0]!.msg).toMatch(/total_ms=\d+/)
+  })
+
+  test('matches Codex URL by host and path, ignores other paths on same host', async () => {
+    const { logger, entries } = captureLogger()
+    const sentinel = new Response(null, { status: 204 })
+    globalThis.fetch = (async () => sentinel) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger })
+    try {
+      const result = await fetch('https://chatgpt.com/backend-api/me')
+      expect(result).toBe(sentinel)
+      expect(entries.filter((e) => e.msg.startsWith('[codex-fetch]'))).toEqual([])
+    } finally {
+      uninstall()
+    }
+  })
+
+  test('uninstall restores original fetch', () => {
+    const { logger } = captureLogger()
+    const before = globalThis.fetch
+    const uninstall = installCodexFetchObserver({ logger })
+    expect(globalThis.fetch).not.toBe(before)
+    uninstall()
+    expect(globalThis.fetch).toBe(before)
+  })
+
+  test('double install warns and returns existing uninstall', () => {
+    const { logger, entries } = captureLogger()
+    const uninstall1 = installCodexFetchObserver({ logger })
+    const wrappedAfterFirst = globalThis.fetch
+    const uninstall2 = installCodexFetchObserver({ logger })
+    try {
+      expect(globalThis.fetch).toBe(wrappedAfterFirst)
+      const warns = entries.filter((e) => e.level === 'warn')
+      expect(warns.length).toBe(1)
+      expect(warns[0]!.msg).toContain('[codex-fetch]')
+      expect(warns[0]!.msg).toContain('already installed')
+    } finally {
+      uninstall1()
+      uninstall2()
+    }
+  })
+
+  test('TYPECLAW_CODEX_FETCH_OBSERVER=off disables installation', () => {
+    const { logger, entries } = captureLogger()
+    const before = globalThis.fetch
+    process.env.TYPECLAW_CODEX_FETCH_OBSERVER = 'off'
+    try {
+      const uninstall = installCodexFetchObserver({ logger })
+      expect(globalThis.fetch).toBe(before)
+      uninstall()
+      expect(globalThis.fetch).toBe(before)
+      expect(entries.filter((e) => e.msg.startsWith('[codex-fetch]'))).toEqual([])
+    } finally {
+      delete process.env.TYPECLAW_CODEX_FETCH_OBSERVER
+    }
+  })
+
+  test('custom codexHost option matches a different host (for staging/testing)', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(5)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, codexHost: 'staging.example.com', now: clock.now })
+    try {
+      clock.set(0)
+      const response = await fetch('https://staging.example.com/backend-api/codex/responses', { method: 'POST' })
+      const drainPromise = drainQuiet(response.body)
+      clock.set(20)
+      await ctrl.close()
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    expect(entries.filter((e) => e.msg.startsWith('[codex-fetch]')).length).toBe(1)
+  })
+})

--- a/src/run/codex-fetch-observer.ts
+++ b/src/run/codex-fetch-observer.ts
@@ -1,0 +1,241 @@
+export type CodexFetchObserverLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+}
+
+export type CodexFetchObserverOptions = {
+  logger?: CodexFetchObserverLogger
+  codexHost?: string
+  now?: () => number
+}
+
+const DEFAULT_CODEX_HOST = 'chatgpt.com'
+const CODEX_PATH_FRAGMENT = '/codex/responses'
+const ENV_DISABLE = 'TYPECLAW_CODEX_FETCH_OBSERVER'
+const LOG_PREFIX = '[codex-fetch]'
+
+const consoleLogger: CodexFetchObserverLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+}
+
+type InstallState = {
+  originalFetch: typeof fetch
+  uninstall: () => void
+}
+
+let installed: InstallState | null = null
+
+// Returns true when the request is for the Codex Responses endpoint and we
+// should attach phase-timing instrumentation. Method check matches the
+// pi-ai provider (only POST hits codex/responses); GETs to the same host
+// (auth probes, etc.) are deliberately ignored.
+function shouldObserve(input: RequestInfo | URL, init: RequestInit | undefined, codexHost: string): boolean {
+  const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase()
+  if (method !== 'POST') return false
+  let urlString: string
+  if (typeof input === 'string') urlString = input
+  else if (input instanceof URL) urlString = input.toString()
+  else urlString = input.url
+  let parsed: URL
+  try {
+    parsed = new URL(urlString)
+  } catch {
+    return false
+  }
+  if (parsed.hostname !== codexHost) return false
+  return parsed.pathname.includes(CODEX_PATH_FRAGMENT)
+}
+
+function quote(value: string | null): string {
+  if (value === null) return 'null'
+  return `"${value.replace(/"/g, '\\"')}"`
+}
+
+function formatLine(fields: {
+  status: number | null
+  headersMs: number | null
+  firstByteMs: number | null
+  totalMs: number
+  bodyBytes: number
+  retryAfter: string | null
+  requestId: string | null
+  error: string | null
+}): string {
+  return [
+    LOG_PREFIX,
+    `status=${fields.status === null ? 'null' : fields.status}`,
+    `headers_ms=${fields.headersMs === null ? 'null' : fields.headersMs}`,
+    `first_byte_ms=${fields.firstByteMs === null ? 'null' : fields.firstByteMs}`,
+    `total_ms=${fields.totalMs}`,
+    `body_bytes=${fields.bodyBytes}`,
+    `retry_after=${fields.retryAfter === null ? 'null' : fields.retryAfter}`,
+    `request_id=${fields.requestId === null ? 'null' : fields.requestId}`,
+    `error=${quote(fields.error)}`,
+  ].join(' ')
+}
+
+function attachBodyTimingTap(
+  response: Response,
+  start: number,
+  headersMs: number,
+  status: number,
+  retryAfter: string | null,
+  requestId: string | null,
+  now: () => number,
+  logger: CodexFetchObserverLogger,
+): Response {
+  if (response.body === null) {
+    logger.info(
+      formatLine({
+        status,
+        headersMs,
+        firstByteMs: null,
+        totalMs: now() - start,
+        bodyBytes: 0,
+        retryAfter,
+        requestId,
+        error: null,
+      }),
+    )
+    return response
+  }
+
+  let firstByteMs: number | null = null
+  let bodyBytes = 0
+  let settled = false
+
+  const settle = (error: string | null) => {
+    if (settled) return
+    settled = true
+    logger.info(
+      formatLine({
+        status,
+        headersMs,
+        firstByteMs,
+        totalMs: now() - start,
+        bodyBytes,
+        retryAfter,
+        requestId,
+        error,
+      }),
+    )
+  }
+
+  const tap = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      if (firstByteMs === null) firstByteMs = now() - start
+      bodyBytes += chunk.byteLength
+      controller.enqueue(chunk)
+    },
+    flush() {
+      settle(null)
+    },
+  })
+
+  const piped = response.body.pipeThrough(tap, { preventCancel: false })
+
+  // We can't observe a `cancel()` on the downstream consumer directly from
+  // the TransformStream, but pipeThrough propagates cancellation to the
+  // source, which terminates the readable side; the `flush` callback fires
+  // on a clean close, and any error surfaces by aborting the piped stream's
+  // reader. The consumer-facing stream below adds an explicit cancel hook.
+  const observerBody = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = piped.getReader()
+      try {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) {
+            controller.close()
+            return
+          }
+          controller.enqueue(value)
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        settle(message)
+        controller.error(err)
+      } finally {
+        reader.releaseLock()
+      }
+    },
+    cancel(reason) {
+      const message = reason === undefined ? 'cancelled' : reason instanceof Error ? reason.message : String(reason)
+      settle(message)
+    },
+  })
+
+  return new Response(observerBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+}
+
+export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}): () => void {
+  if (process.env[ENV_DISABLE] === 'off') {
+    return () => {}
+  }
+  const logger = opts.logger ?? consoleLogger
+  if (installed !== null) {
+    logger.warn(`${LOG_PREFIX} install called but observer already installed; ignoring`)
+    return installed.uninstall
+  }
+
+  const codexHost = opts.codexHost ?? DEFAULT_CODEX_HOST
+  const now = opts.now ?? Date.now
+  const originalFetch = globalThis.fetch
+
+  const wrappedImpl = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ): Promise<Response> => {
+    if (!shouldObserve(input, init, codexHost)) {
+      return originalFetch(input, init)
+    }
+    const start = now()
+    let response: Response
+    try {
+      response = await originalFetch(input, init)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.info(
+        formatLine({
+          status: null,
+          headersMs: null,
+          firstByteMs: null,
+          totalMs: now() - start,
+          bodyBytes: 0,
+          retryAfter: null,
+          requestId: null,
+          error: message,
+        }),
+      )
+      throw err
+    }
+    const headersMs = now() - start
+    const retryAfter = response.headers.get('retry-after')
+    const requestId = response.headers.get('x-request-id')
+    return attachBodyTimingTap(response, start, headersMs, response.status, retryAfter, requestId, now, logger)
+  }
+
+  // Preserve any static methods Bun attaches to `globalThis.fetch` (e.g.
+  // `preconnect`) so the wrapper is a drop-in replacement.
+  const wrapped = Object.assign(wrappedImpl, {
+    preconnect: (originalFetch as { preconnect?: (url: string) => void }).preconnect ?? (() => {}),
+  }) as typeof fetch
+
+  globalThis.fetch = wrapped
+
+  const uninstall = () => {
+    if (installed === null) return
+    if (globalThis.fetch === wrapped) {
+      globalThis.fetch = originalFetch
+    }
+    installed = null
+  }
+
+  installed = { originalFetch, uninstall }
+  return uninstall
+}

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -59,6 +59,7 @@ import { createTunnelManager, type TunnelManager, type TunnelManagerOptions } fr
 
 import { BUNDLED_PLUGINS } from './bundled-plugins'
 import { buildChannelSessionFactory } from './channel-session-factory'
+import { installCodexFetchObserver } from './codex-fetch-observer'
 import { createPluginRuntime, type PluginRuntime, type PluginSubagentEntry } from './plugin-runtime'
 
 type BunServer = ReturnType<Server['start']>
@@ -112,6 +113,14 @@ export async function startAgent({
   createTunnelManager: createTunnelManagerFor = createTunnelManager,
 }: StartAgentOptions): Promise<StartAgentResult> {
   const reloadRegistry = new ReloadRegistry()
+
+  // Wrap globalThis.fetch BEFORE any plugin/session/manager construction so
+  // every Codex Responses call from anywhere in the container is observed.
+  // Logs one `[codex-fetch]` line per matched request with phase timings;
+  // never aborts, never retries — purely passive instrumentation while we
+  // investigate the recurring multi-minute Codex stalls (see issue #394).
+  // Opt out with TYPECLAW_CODEX_FETCH_OBSERVER=off.
+  const uninstallCodexFetchObserver = installCodexFetchObserver()
 
   // The host CLI sets TYPECLAW_CONTAINER_NAME when it `docker run`s us. When
   // running outside a typeclaw container (tests, ad-hoc `bun run typeclaw run`
@@ -585,6 +594,7 @@ export async function startAgent({
     subagentCompletionBridge.stop()
     await tunnelManager.stop()
     await channelManager.stop()
+    uninstallCodexFetchObserver()
   }
 
   if (!attachTui) {


### PR DESCRIPTION
## Problem

Issue #394 (agent took ~9 min to reply to a simple instruction) prompted a deep analysis of session traces. Aggregating stalls across a full day on the affected agent revealed a pattern that rules out per-request flakiness:

- 21 stalls >60 s in a single day
- 4 stalls >5 min (worst at 9m 58s)
- Stalls cluster in time across distinct sessions: 6 stalls in a 19-minute window, 7 in a 33-minute window, with long zero-stall gaps in between — incident-shaped, not a stable per-request rate
- No correlation with payload size: a 4-token output request stalled for 268 s; a 16,827-token input request stalled for 292 s
- Same model, same account, same container throughout

The `openai-codex-responses` provider in `@mariozechner/pi-ai` does a bare `await fetch(url, { signal })` then a bare `reader.read()` on the SSE body, with no idle timeout and no phase logging. The latest pi-ai release (0.73.1) has the same code as the vendored 0.67.3 — bumping the dependency is a no-op.

We do not yet know **which phase** of the Codex request consumes the time:

- TCP connect / TLS handshake stalled before headers?
- Request sent; response headers never arrived (server-side queue)?
- Headers received; first SSE byte never started flowing (worker assigned but blocked)?
- Mid-stream gap after partial response?

Each cause needs a different fix. Shipping a client-side abort or retry based on a guess could make things worse — if the issue is upstream queueing (the most likely explanation given the clustering pattern), aborting just rejoins the queue.

## What this PR does

Installs a passive `globalThis.fetch` wrapper at the top of `startAgent` (container stage only — host CLI commands go through different entrypoints and are unaffected). For requests matching `chatgpt.com/.../codex/responses` (POST), the wrapper logs one line to stderr per completed request:

```
[codex-fetch] status=200 headers_ms=243 first_byte_ms=812 total_ms=14523 body_bytes=8421 retry_after=null request_id=req_abc123 error=null
```

Fields:

| Field | Meaning |
|---|---|
| `status` | HTTP status code; `null` if fetch itself rejected |
| `headers_ms` | Milliseconds from request POST to response headers received |
| `first_byte_ms` | Milliseconds from request POST to first SSE byte |
| `total_ms` | Milliseconds from request POST to body end (or error) |
| `body_bytes` | Total bytes streamed |
| `retry_after` | Value of the `Retry-After` header if present — explicit throttling signal |
| `request_id` | Value of `x-request-id` — correlatable with provider support |
| `error` | Error message if the stream or fetch rejected |

The wrapper is purely passive: no abort, no retry, no header injection. Bytes flow through a `TransformStream` untouched and are forwarded byte-for-byte to the original consumer. Non-Codex URLs are not wrapped at all — zero overhead. Stream errors and pre-response fetch rejections still log with whatever timing fields are available.

Opt out: `TYPECLAW_CODEX_FETCH_OBSERVER=off`.

## Why diagnose-only

The incident-shaped clustering pattern means something external to the container changes state (upstream queue depth, a worker pool cycling, a rate-limit window). Without knowing which phase stalls, a client-side mitigation risks:

- Aborting a request that was about to succeed (wasting the queue position already held)
- Masking a billing or throttle signal the upstream is deliberately emitting
- Choosing the wrong retry strategy for the wrong failure mode

Once this observer runs through a few stall events, the phase breakdown will either point to a specific mitigation (request-level deadline if it's `headers_ms`, mid-stream keepalive if it's `first_byte_ms` after headers succeed, model fallback profile in `src/agent/model-fallback.ts` if it's account-level) or surface an upstream issue to file at the provider. That targeted mitigation is the next PR.

## Files changed

| File | Change |
|---|---|
| `src/run/codex-fetch-observer.ts` | URL matcher + body-tap via `TransformStream` + second `ReadableStream` wrap so consumer cancel is observable. Preserves `globalThis.fetch.preconnect` if Bun sets it. |
| `src/run/codex-fetch-observer.test.ts` | 11 tests: non-Codex passthrough (asserts sentinel identity, verifying zero wrapping), upstream error propagation, phase timings with deterministic clock and controllable body, Retry-After throttling signal, mid-stream errors, pre-response errors, URL match scope (same host, different path), uninstall restores original, double-install warns, env opt-out, custom host override. |
| `src/run/index.ts` | `installCodexFetchObserver` called at top of `startAgent` (before plugin and session construction); `uninstallCodexFetchObserver` added to the `stop` cleanup chain. |

## Verification

```
bun run typecheck    ✓  (0 errors)
bun run lint         ✓  (60 pre-existing warnings, 0 errors, 0 new)
bun run format:check ✓
bun run test         ✓  (5629/5629 pass)
```

## Review Notes

The key read is `src/run/codex-fetch-observer.ts`: verify the `TransformStream` tap does not buffer — chunks must be enqueued synchronously and the controller must not accumulate. The sentinel-identity assertion in the non-Codex passthrough test is the strongest guarantee that unmatched URLs are completely unwrapped.

Once this lands, grep for `[codex-fetch]` in `typeclaw logs -f` on the affected agent. The `headers_ms` vs `first_byte_ms` vs `total_ms` split across stall events will determine whether the next PR is a deadline, a keepalive, or a provider bug report.

This PR relates to #394 but does not fix it — the fix will follow once there is phase-level evidence to act on.