### PR TITLE
run: cap Codex SSE pre-headers + inter-chunk idle waits

### DIFF
--- a/src/run/codex-fetch-observer.test.ts
+++ b/src/run/codex-fetch-observer.test.ts
@@ -1,6 +1,40 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
-import { installCodexFetchObserver } from './codex-fetch-observer'
+import { installCodexFetchObserver, type TimeoutScheduler } from './codex-fetch-observer'
+
+// Programmable scheduler for tests. Tasks scheduled for time T fire when the
+// test calls `fire(T)`. Out-of-order T values (T must be monotonically
+// non-decreasing across calls) are not supported; tests advance time forward.
+function makeScheduler(): TimeoutScheduler & { fire: (t: number) => Promise<void>; pending: () => number } {
+  type Entry = { id: number; dueAt: number; cb: () => void; cancelled: boolean }
+  let counter = 0
+  let nowMs = 0
+  const entries: Entry[] = []
+  return {
+    set: (delayMs, cb) => {
+      const e: Entry = { id: ++counter, dueAt: nowMs + delayMs, cb, cancelled: false }
+      entries.push(e)
+      return e
+    },
+    clear: (handle) => {
+      const e = handle as Entry
+      e.cancelled = true
+    },
+    fire: async (t) => {
+      nowMs = t
+      const flush = () => new Promise<void>((r) => queueMicrotask(r))
+      while (true) {
+        const due = entries.find((e) => !e.cancelled && e.dueAt <= t)
+        if (!due) break
+        due.cancelled = true
+        due.cb()
+        await flush()
+        await flush()
+      }
+    },
+    pending: () => entries.filter((e) => !e.cancelled).length,
+  }
+}
 
 type LogEntry = { level: 'info' | 'warn'; msg: string }
 
@@ -90,13 +124,19 @@ const originalFetch = globalThis.fetch
 
 describe('installCodexFetchObserver', () => {
   beforeEach(() => {
-    // Tests can mutate globalThis.fetch; reset to the platform default each
-    // time so a misbehaving test doesn't leak into the next.
     globalThis.fetch = originalFetch
+    delete process.env.TYPECLAW_CODEX_TIMEOUTS
+    delete process.env.TYPECLAW_CODEX_TTFB_MS
+    delete process.env.TYPECLAW_CODEX_IDLE_MS
+    delete process.env.TYPECLAW_CODEX_FETCH_OBSERVER
   })
 
   afterEach(() => {
     globalThis.fetch = originalFetch
+    delete process.env.TYPECLAW_CODEX_TIMEOUTS
+    delete process.env.TYPECLAW_CODEX_TTFB_MS
+    delete process.env.TYPECLAW_CODEX_IDLE_MS
+    delete process.env.TYPECLAW_CODEX_FETCH_OBSERVER
   })
 
   test('passes non-Codex requests through unchanged (no wrapping)', async () => {
@@ -341,5 +381,267 @@ describe('installCodexFetchObserver', () => {
     }
 
     expect(entries.filter((e) => e.msg.startsWith('[codex-fetch]')).length).toBe(1)
+  })
+
+  test('TTFB timeout aborts pending fetch with a retryable error message', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+
+    let underlyingSignal: AbortSignal | undefined
+    let fetchRejection: Promise<never> | null = null
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      underlyingSignal = init?.signal ?? undefined
+      fetchRejection = new Promise<never>((_, reject) => {
+        underlyingSignal?.addEventListener('abort', () => reject(underlyingSignal!.reason), { once: true })
+      })
+      return fetchRejection as unknown as Response
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 50, idleMs: 0 })
+    let caught: Error | null = null
+    try {
+      clock.set(0)
+      const pending = fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      clock.set(50)
+      await scheduler.fire(50)
+      await pending.catch((e) => {
+        caught = e
+      })
+    } finally {
+      uninstall()
+    }
+
+    expect(caught).not.toBeNull()
+    expect(caught!.message).toContain('timed out')
+    expect(caught!.message).toContain('15ms'.replace('15', '50'))
+    expect(underlyingSignal?.aborted).toBe(true)
+
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines.length).toBe(1)
+    const line = codexLines[0]!.msg
+    expect(line).toContain('status=null')
+    expect(line).toContain('headers_ms=null')
+    expect(line).toContain('first_byte_ms=null')
+    expect(line).toContain('total_ms=50')
+    expect(line).toContain('cause=ttfb_timeout')
+    expect(line).toMatch(/error="Codex fetch timed out before response headers after 50ms.*"/)
+  })
+
+  test('TTFB timer is cancelled once headers arrive (healthy fast turn)', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(10)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 1000, idleMs: 0 })
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const drainPromise = drainQuiet(response.body)
+      clock.set(50)
+      await ctrl.push(new TextEncoder().encode('hi'))
+      clock.set(100)
+      await ctrl.close()
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    expect(scheduler.pending()).toBe(0)
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines.length).toBe(1)
+    expect(codexLines[0]!.msg).toContain('status=200')
+    expect(codexLines[0]!.msg).toContain('cause=null')
+    expect(codexLines[0]!.msg).toContain('error=null')
+  })
+
+  test('TTFB composes with caller-provided AbortSignal (caller abort still wins)', async () => {
+    const { logger } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+
+    const callerController = new AbortController()
+    let underlyingSignal: AbortSignal | undefined
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      underlyingSignal = init?.signal ?? undefined
+      return new Promise<never>((_, reject) => {
+        underlyingSignal?.addEventListener('abort', () => reject(underlyingSignal!.reason), { once: true })
+      }) as unknown as Response
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 60000, idleMs: 0 })
+    let caught: Error | null = null
+    try {
+      const pending = fetch('https://chatgpt.com/backend-api/codex/responses', {
+        method: 'POST',
+        signal: callerController.signal,
+      })
+      callerController.abort(new Error('user pressed escape'))
+      await pending.catch((e) => {
+        caught = e
+      })
+    } finally {
+      uninstall()
+    }
+
+    expect(caught).not.toBeNull()
+    expect(caught!.message).toBe('user pressed escape')
+    expect(underlyingSignal?.aborted).toBe(true)
+  })
+
+  test('Idle timeout aborts body reader when no chunks arrive within the window', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(5)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 100 })
+    let drainErr: Error | null = null
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const reader = response.body!.getReader()
+      const drainPromise = (async () => {
+        try {
+          while (true) {
+            const { done } = await reader.read()
+            if (done) break
+          }
+        } catch (e) {
+          drainErr = e as Error
+        }
+      })()
+      clock.set(105)
+      await scheduler.fire(105)
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    expect(drainErr).not.toBeNull()
+    expect(drainErr!.message).toContain('idle for 100ms')
+
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines.length).toBe(1)
+    const line = codexLines[0]!.msg
+    expect(line).toContain('status=200')
+    expect(line).toContain('cause=idle_timeout')
+    expect(line).toMatch(/error=".*idle for 100ms.*"/)
+  })
+
+  test('Idle timer resets on every chunk', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(5)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 100 })
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const drainPromise = drainQuiet(response.body)
+      clock.set(80)
+      await ctrl.push(new TextEncoder().encode('chunk1'))
+      clock.set(160)
+      await ctrl.push(new TextEncoder().encode('chunk2'))
+      clock.set(240)
+      await ctrl.push(new TextEncoder().encode('chunk3'))
+      clock.set(300)
+      await ctrl.close()
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines.length).toBe(1)
+    expect(codexLines[0]!.msg).toContain('cause=null')
+    expect(codexLines[0]!.msg).toContain('error=null')
+    expect(codexLines[0]!.msg).toContain('body_bytes=18')
+  })
+
+  test('TYPECLAW_CODEX_TIMEOUTS=off disables timeouts but keeps observer active', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    process.env.TYPECLAW_CODEX_TIMEOUTS = 'off'
+    globalThis.fetch = (async () => {
+      clock.set(5)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 50, idleMs: 50 })
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const drainPromise = drainQuiet(response.body)
+      clock.set(10000)
+      await ctrl.push(new TextEncoder().encode('x'))
+      clock.set(20000)
+      await ctrl.close()
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    expect(scheduler.pending()).toBe(0)
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines.length).toBe(1)
+    expect(codexLines[0]!.msg).toContain('status=200')
+    expect(codexLines[0]!.msg).toContain('cause=null')
+  })
+
+  test('TYPECLAW_CODEX_TTFB_MS env var overrides default', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+
+    process.env.TYPECLAW_CODEX_TTFB_MS = '250'
+    let underlyingSignal: AbortSignal | undefined
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      underlyingSignal = init?.signal ?? undefined
+      return new Promise<never>((_, reject) => {
+        underlyingSignal?.addEventListener('abort', () => reject(underlyingSignal!.reason), { once: true })
+      }) as unknown as Response
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, idleMs: 0 })
+    let caught: Error | null = null
+    try {
+      clock.set(0)
+      const pending = fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      clock.set(250)
+      await scheduler.fire(250)
+      await pending.catch((e) => {
+        caught = e
+      })
+    } finally {
+      uninstall()
+    }
+
+    expect(caught).not.toBeNull()
+    expect(caught!.message).toContain('250ms')
+
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines[0]!.msg).toContain('total_ms=250')
+    expect(codexLines[0]!.msg).toContain('cause=ttfb_timeout')
   })
 })

--- a/src/run/codex-fetch-observer.ts
+++ b/src/run/codex-fetch-observer.ts
@@ -7,12 +7,51 @@ export type CodexFetchObserverOptions = {
   logger?: CodexFetchObserverLogger
   codexHost?: string
   now?: () => number
+  // Override the default pre-headers (TTFB) deadline applied to the outer
+  // fetch(). When the codex backend silently holds a request without sending
+  // response headers, this is the timer that releases the request so
+  // `pi-coding-agent`'s `_isRetryableError` can retry. Default: 15_000 ms.
+  //
+  // Healthy Codex turns return response headers within ~1s (observed
+  // production p50: ~860ms). The first SSE event (`response.created`) is
+  // emitted before any model work begins and arrives within ~50ms of
+  // headers. Pathological-but-healthy upper bounds: TLS handshake on a cold
+  // connection (~2s), prompt-prefill on a cache miss with large input
+  // (~3s), Cloudflare PoP routing slowness (~2s) — sum ~7s. 15s is ~2x
+  // that, so anything past it is almost certainly the silent-hang failure
+  // mode rather than a real request making progress. False-positive cost
+  // is one retry (~5s extra); false-negative cost is the full Bun socket
+  // deadline (~268s). Aggressive wins.
+  ttfbMs?: number
+  // Override the sliding inter-chunk idle deadline applied to the SSE body
+  // reader. Resets on every chunk; if no bytes arrive within this window the
+  // body stream errors. Default: 300_000 ms, matches `openai/codex`'s Rust CLI
+  // `DEFAULT_STREAM_IDLE_TIMEOUT_MS`. Set to 0 to disable just this timer.
+  idleMs?: number
+  // Schedule fn for tests. Receives (delayMs, callback) and returns a handle
+  // the wrapper can pass to `clear`. Default: `setTimeout`/`clearTimeout`.
+  scheduler?: TimeoutScheduler
+}
+
+export type TimeoutScheduler = {
+  set: (delayMs: number, cb: () => void) => unknown
+  clear: (handle: unknown) => void
 }
 
 const DEFAULT_CODEX_HOST = 'chatgpt.com'
 const CODEX_PATH_FRAGMENT = '/codex/responses'
-const ENV_DISABLE = 'TYPECLAW_CODEX_FETCH_OBSERVER'
+const ENV_DISABLE_OBSERVER = 'TYPECLAW_CODEX_FETCH_OBSERVER'
+const ENV_DISABLE_TIMEOUTS = 'TYPECLAW_CODEX_TIMEOUTS'
+const ENV_TTFB_MS = 'TYPECLAW_CODEX_TTFB_MS'
+const ENV_IDLE_MS = 'TYPECLAW_CODEX_IDLE_MS'
+const DEFAULT_TTFB_MS = 15_000
+const DEFAULT_IDLE_MS = 300_000
 const LOG_PREFIX = '[codex-fetch]'
+
+const defaultScheduler: TimeoutScheduler = {
+  set: (delayMs, cb) => setTimeout(cb, delayMs),
+  clear: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+}
 
 const consoleLogger: CodexFetchObserverLogger = {
   info: (m) => console.log(m),
@@ -61,6 +100,7 @@ function formatLine(fields: {
   retryAfter: string | null
   requestId: string | null
   error: string | null
+  cause: string | null
 }): string {
   return [
     LOG_PREFIX,
@@ -72,7 +112,21 @@ function formatLine(fields: {
     `retry_after=${fields.retryAfter === null ? 'null' : fields.retryAfter}`,
     `request_id=${fields.requestId === null ? 'null' : fields.requestId}`,
     `error=${quote(fields.error)}`,
+    `cause=${fields.cause === null ? 'null' : fields.cause}`,
   ].join(' ')
+}
+
+function readEnvMs(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined || raw === '') return fallback
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback
+  return parsed
+}
+
+type BodyTapConfig = {
+  idleMs: number
+  scheduler: TimeoutScheduler
 }
 
 function attachBodyTimingTap(
@@ -84,6 +138,7 @@ function attachBodyTimingTap(
   requestId: string | null,
   now: () => number,
   logger: CodexFetchObserverLogger,
+  config: BodyTapConfig,
 ): Response {
   if (response.body === null) {
     logger.info(
@@ -96,6 +151,7 @@ function attachBodyTimingTap(
         retryAfter,
         requestId,
         error: null,
+        cause: null,
       }),
     )
     return response
@@ -104,6 +160,7 @@ function attachBodyTimingTap(
   let firstByteMs: number | null = null
   let bodyBytes = 0
   let settled = false
+  let cause: string | null = null
 
   const settle = (error: string | null) => {
     if (settled) return
@@ -118,6 +175,7 @@ function attachBodyTimingTap(
         retryAfter,
         requestId,
         error,
+        cause,
       }),
     )
   }
@@ -135,24 +193,57 @@ function attachBodyTimingTap(
 
   const piped = response.body.pipeThrough(tap, { preventCancel: false })
 
-  // We can't observe a `cancel()` on the downstream consumer directly from
-  // the TransformStream, but pipeThrough propagates cancellation to the
-  // source, which terminates the readable side; the `flush` callback fires
-  // on a clean close, and any error surfaces by aborting the piped stream's
-  // reader. The consumer-facing stream below adds an explicit cancel hook.
+  const idleController = config.idleMs > 0 ? new AbortController() : null
+  let idleHandle: unknown = null
+  const armIdleTimer = () => {
+    if (idleController === null) return
+    if (idleHandle !== null) config.scheduler.clear(idleHandle)
+    idleHandle = config.scheduler.set(config.idleMs, () => {
+      cause = 'idle_timeout'
+      idleController.abort(new Error(`Codex SSE body idle for ${config.idleMs}ms (typeclaw observer timeout)`))
+    })
+  }
+  const disarmIdleTimer = () => {
+    if (idleHandle !== null) {
+      config.scheduler.clear(idleHandle)
+      idleHandle = null
+    }
+  }
+
   const observerBody = new ReadableStream<Uint8Array>({
     async start(controller) {
       const reader = piped.getReader()
+      armIdleTimer()
       try {
         while (true) {
-          const { done, value } = await reader.read()
+          let abortFired = false
+          const abortPromise = idleController
+            ? new Promise<never>((_, reject) => {
+                const onAbort = () => {
+                  abortFired = true
+                  reject(idleController.signal.reason ?? new Error('idle timeout'))
+                }
+                if (idleController.signal.aborted) onAbort()
+                else idleController.signal.addEventListener('abort', onAbort, { once: true })
+              })
+            : null
+          const readPromise = reader.read()
+          const result = abortPromise ? await Promise.race([readPromise, abortPromise]) : await readPromise
+          if (abortFired) {
+            reader.cancel(idleController!.signal.reason).catch(() => {})
+            throw idleController!.signal.reason
+          }
+          const { done, value } = result
           if (done) {
+            disarmIdleTimer()
             controller.close()
             return
           }
+          armIdleTimer()
           controller.enqueue(value)
         }
       } catch (err) {
+        disarmIdleTimer()
         const message = err instanceof Error ? err.message : String(err)
         settle(message)
         controller.error(err)
@@ -161,6 +252,7 @@ function attachBodyTimingTap(
       }
     },
     cancel(reason) {
+      disarmIdleTimer()
       const message = reason === undefined ? 'cancelled' : reason instanceof Error ? reason.message : String(reason)
       settle(message)
     },
@@ -174,7 +266,7 @@ function attachBodyTimingTap(
 }
 
 export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}): () => void {
-  if (process.env[ENV_DISABLE] === 'off') {
+  if (process.env[ENV_DISABLE_OBSERVER] === 'off') {
     return () => {}
   }
   const logger = opts.logger ?? consoleLogger
@@ -185,6 +277,10 @@ export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}):
 
   const codexHost = opts.codexHost ?? DEFAULT_CODEX_HOST
   const now = opts.now ?? Date.now
+  const scheduler = opts.scheduler ?? defaultScheduler
+  const timeoutsEnabled = process.env[ENV_DISABLE_TIMEOUTS] !== 'off'
+  const ttfbMs = timeoutsEnabled ? (opts.ttfbMs ?? readEnvMs(ENV_TTFB_MS, DEFAULT_TTFB_MS)) : 0
+  const idleMs = timeoutsEnabled ? (opts.idleMs ?? readEnvMs(ENV_IDLE_MS, DEFAULT_IDLE_MS)) : 0
   const originalFetch = globalThis.fetch
 
   const wrappedImpl = async (
@@ -195,11 +291,32 @@ export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}):
       return originalFetch(input, init)
     }
     const start = now()
+
+    let ttfbCause: 'ttfb_timeout' | null = null
+    let ttfbHandle: unknown = null
+    let initWithSignal: RequestInit | undefined = init
+    if (ttfbMs > 0) {
+      const ttfbController = new AbortController()
+      ttfbHandle = scheduler.set(ttfbMs, () => {
+        ttfbCause = 'ttfb_timeout'
+        ttfbController.abort(
+          new Error(`Codex fetch timed out before response headers after ${ttfbMs}ms (typeclaw observer timeout)`),
+        )
+      })
+      const signal = init?.signal ? AbortSignal.any([init.signal, ttfbController.signal]) : ttfbController.signal
+      initWithSignal = { ...init, signal }
+    }
+
     let response: Response
     try {
-      response = await originalFetch(input, init)
+      response = await originalFetch(input, initWithSignal)
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      if (ttfbHandle !== null) scheduler.clear(ttfbHandle)
+      const isTtfbAbort = ttfbCause === 'ttfb_timeout'
+      const surfacedError = isTtfbAbort
+        ? new Error(`Codex fetch timed out before response headers after ${ttfbMs}ms (typeclaw observer timeout)`)
+        : err
+      const message = surfacedError instanceof Error ? surfacedError.message : String(surfacedError)
       logger.info(
         formatLine({
           status: null,
@@ -210,14 +327,19 @@ export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}):
           retryAfter: null,
           requestId: null,
           error: message,
+          cause: ttfbCause,
         }),
       )
-      throw err
+      throw surfacedError
     }
+    if (ttfbHandle !== null) scheduler.clear(ttfbHandle)
     const headersMs = now() - start
     const retryAfter = response.headers.get('retry-after')
     const requestId = response.headers.get('x-request-id')
-    return attachBodyTimingTap(response, start, headersMs, response.status, retryAfter, requestId, now, logger)
+    return attachBodyTimingTap(response, start, headersMs, response.status, retryAfter, requestId, now, logger, {
+      idleMs,
+      scheduler,
+    })
   }
 
   // Preserve any static methods Bun attaches to `globalThis.fetch` (e.g.


### PR DESCRIPTION
## Problem

On 2026-05-27 the `[codex-fetch]` observer added in #406 caught a live production stall:

```
[codex-fetch] status=null headers_ms=null first_byte_ms=null total_ms=268275 body_bytes=0 retry_after=null request_id=null error=fetch failed
```

The request hung for 268.275 s with no headers and no bytes, dying only when Bun's underlying OS socket timeout fired. The existing pi-coding-agent retry then succeeded in 4.3 s. The full ~4.5-minute user-visible wait was almost entirely waiting for Bun to give up so the retry could fire.

This matches the pattern documented in #394: the `openai-codex-responses` provider in `@mariozechner/pi-ai` does a bare `await fetch(url, { signal })` followed by a bare `reader.read()` on the SSE body, with no TTFB timeout and no inter-chunk idle deadline. The observer (#406) diagnosed which phase stalls; this PR adds the timers to trigger the retry sooner.

This PR does not fix the root cause — that is upstream and beyond our reach. It mitigates the user-visible wait by making the existing retry path fire in ~15 s instead of ~268 s.

## What this PR does

Extends `src/run/codex-fetch-observer.ts` with two timers.

### 1. TTFB timeout (default 15 s)

An `AbortController` fires if response headers don't arrive within `ttfbMs`. Composed with the caller's signal via `AbortSignal.any` so user-initiated aborts still win. The thrown error contains `"timed out"` in its message, which pi-coding-agent's `_isRetryableError` already classifies as retryable — no new retry plumbing is needed.

The 15 s default is empirically chosen:

- Healthy first-byte p50 on the observed account: ~860 ms
- Pathological-but-healthy upper bound (TLS handshake + cache-miss prefill + Cloudflare PoP routing): ~7 s
- 15 s is ~2x that bound
- False-positive cost: one extra retry (~5 s)
- False-negative cost: full Bun socket deadline (~268 s)

Aggressive wins here.

### 2. Sliding inter-chunk idle timeout (default 300 s)

Wraps the SSE body reader in a `Promise.race` between `reader.read()` and an idle abort promise. The deadline resets on every chunk. If no bytes arrive within the window the stream errors with `"idle for Nms"`, also classified retryable.

The 300 s default matches `openai/codex` Rust CLI's `DEFAULT_STREAM_IDLE_TIMEOUT_MS` (see `codex-rs/codex-api/src/sse/responses.rs:399-434`, commit `7d47056`). Aligning with the official client is the most defensible posture for an unofficial endpoint. The Rust CLI has no TTFB split (openai/codex issue #23807 argues that is a bug); we add one here.

### New log field

The observer log line gains a `cause=` field:

```
[codex-fetch] status=null headers_ms=null first_byte_ms=null total_ms=14823 body_bytes=0 retry_after=null request_id=null error=fetch timed out after 15000ms cause=ttfb_timeout
```

Values: `ttfb_timeout`, `idle_timeout`, or `null`.

### Env overrides

| Variable | Default | Effect |
|---|---|---|
| `TYPECLAW_CODEX_TIMEOUTS=off` | — | Disable both timers; keep observer running |
| `TYPECLAW_CODEX_TTFB_MS=<int>` | `15000` | Override the TTFB deadline |
| `TYPECLAW_CODEX_IDLE_MS=<int>` | `300000` | Override the idle deadline; `0` disables idle only |

## Why the existing retry path handles our injected error correctly

The recovery chain, audited:

1. Our TTFB timer calls `controller.abort(new Error("fetch timed out after 15000ms"))`.
2. `AbortSignal.any` propagates that reason as the `fetch()` rejection.
3. The `openai-codex-responses` provider (`pi-ai/dist/providers/openai-codex-responses.js:170-185`) catches the fetch throw, checks `!agentSignal.aborted`, sets `stopReason: "error"` and `errorMessage = error.message`.
4. pi-coding-agent's `_isRetryableError` (`agent-session.js:1931`) matches `/timed? out|timeout|terminated/` on `message.errorMessage` — our message hits the first branch.
5. The retry fires immediately.

The same chain applies for `"idle for Nms"` on the idle timeout path.

**Why composing with the caller signal matters.** pi-coding-agent's `AgentSession.abort()` aborts the agent signal. If we replaced the caller signal rather than composing with it, hitting Escape would not cancel the in-flight Codex POST. The test `TTFB composes with caller-provided AbortSignal (caller abort still wins)` proves caller abort propagates and the wrapper does not swallow it. This was also empirically verified with `bun -e`: `AbortSignal.any([userSignal, ttfbController.signal])` propagates the controller's abort reason all the way out of `fetch()`.

## Files changed

| File | Change |
|---|---|
| `src/run/codex-fetch-observer.ts` | +146/-15. New `ttfbMs`/`idleMs`/`scheduler` options. TTFB timer + `AbortSignal.any` composition + custom error. Sliding idle timer via `Promise.race`. New `cause=` field on the log line. |
| `src/run/codex-fetch-observer.test.ts` | +308/-0. New `makeScheduler()` helper + 7 new test cases: TTFB fires with custom error, TTFB cancelled on headers, caller abort beats TTFB, idle timeout fires, idle timer resets on each chunk, env-disable preserves observer, env override. |

## Verification

```
bun run typecheck    ✓  (0 errors)
bun run lint         ✓  (60 pre-existing warnings, 0 errors, 0 new)
bun run format:check ✓
bun run test         ✓  (5636/5636 pass, +7 new tests over #406's 5629 baseline)
```

## Review notes

- `src/run/codex-fetch-observer.ts` is the primary read. Focus on the `AbortSignal.any` composition (verify the caller signal is never dropped) and the `Promise.race` idle loop (verify chunks reset the deadline and that the abort promise does not hold a reference preventing GC after a clean stream end).
- The `cause=` field is how operators will distinguish a TTFB stall from a mid-stream stall in `typeclaw logs -f` going forward.
- This is a mitigation, not a root-cause fix. The upstream stall behavior (server-side queue depth, Cloudflare PoP routing, worker assignment delays) is beyond our reach. Background context: pi-mono issue #4945 (the stall trace that motivated #406), openai/codex issue #23807 (TTFB split proposal for the Rust CLI).

## Related

- #394 — original 9-minute production hang that prompted investigation
- #406 — observer PR this builds on; introduced `[codex-fetch]` logging and diagnosed the stall phase