### PR TITLE
run: don't leak idle abort listeners per Codex SSE chunk

### DIFF
--- a/src/run/codex-fetch-observer.test.ts
+++ b/src/run/codex-fetch-observer.test.ts
@@ -576,6 +576,64 @@ describe('installCodexFetchObserver', () => {
     expect(codexLines[0]!.msg).toContain('body_bytes=18')
   })
 
+  test('Idle abort listener count stays bounded across many chunks (no leak)', async () => {
+    // given: a stream that will emit 100 chunks with a long idle window. The
+    // pre-fix shape called `idleController.signal.addEventListener('abort', …)`
+    // inside the per-iteration `Promise.race`, leaking one closure per chunk
+    // when `reader.read()` won. The fix shares one listener across the whole
+    // stream, so listener installations across N chunks must stay at <= 1.
+    const { logger } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    const RealAbortController = globalThis.AbortController
+    let installedAbortListeners = 0
+    class CountingAbortController extends RealAbortController {
+      constructor() {
+        super()
+        const realAdd = this.signal.addEventListener.bind(this.signal)
+        this.signal.addEventListener = ((
+          type: string,
+          listener: EventListenerOrEventListenerObject,
+          options?: AddEventListenerOptions | boolean,
+        ) => {
+          if (type === 'abort') installedAbortListeners += 1
+          return realAdd(type, listener, options)
+        }) as typeof this.signal.addEventListener
+      }
+    }
+    globalThis.AbortController = CountingAbortController as unknown as typeof AbortController
+
+    globalThis.fetch = (async () => {
+      clock.set(5)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 10_000 })
+    try {
+      // when: 100 chunks flow through, each one comfortably inside the idle window
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const drainPromise = drainQuiet(response.body)
+      const chunk = new TextEncoder().encode('x')
+      for (let i = 0; i < 100; i++) {
+        clock.set(10 + i)
+        await ctrl.push(chunk)
+      }
+      clock.set(200)
+      await ctrl.close()
+      await drainPromise
+    } finally {
+      uninstall()
+      globalThis.AbortController = RealAbortController
+    }
+
+    // then: only the single shared listener should ever be installed across
+    // the full lifetime of the stream, regardless of chunk count
+    expect(installedAbortListeners).toBeLessThanOrEqual(1)
+  })
+
   test('TYPECLAW_CODEX_TIMEOUTS=off disables timeouts but keeps observer active', async () => {
     const { logger, entries } = captureLogger()
     const clock = makeClock()

--- a/src/run/codex-fetch-observer.ts
+++ b/src/run/codex-fetch-observer.ts
@@ -210,23 +210,34 @@ function attachBodyTimingTap(
     }
   }
 
+  // The idle abort listener is installed exactly once for the lifetime of the
+  // stream and removed in `finally`. Earlier shapes constructed a fresh
+  // `Promise.race` listener per chunk; if `reader.read()` won the race, the
+  // listener was never removed and closures accumulated on the signal across a
+  // long stream. Keeping one shared abort promise bounds the listener count to
+  // 1 regardless of chunk count.
   const observerBody = new ReadableStream<Uint8Array>({
     async start(controller) {
       const reader = piped.getReader()
       armIdleTimer()
+      let abortFired = false
+      let onAbort: (() => void) | null = null
+      const abortPromise = idleController
+        ? new Promise<never>((_, reject) => {
+            onAbort = () => {
+              abortFired = true
+              reject(idleController.signal.reason ?? new Error('idle timeout'))
+            }
+            if (idleController.signal.aborted) onAbort()
+            else idleController.signal.addEventListener('abort', onAbort, { once: true })
+          })
+        : null
+      // Swallow the shared rejection if no race ever observes it (clean stream
+      // end before any timeout). Without this, an aborted-after-close path
+      // could surface as an unhandled rejection on the runtime.
+      abortPromise?.catch(() => {})
       try {
         while (true) {
-          let abortFired = false
-          const abortPromise = idleController
-            ? new Promise<never>((_, reject) => {
-                const onAbort = () => {
-                  abortFired = true
-                  reject(idleController.signal.reason ?? new Error('idle timeout'))
-                }
-                if (idleController.signal.aborted) onAbort()
-                else idleController.signal.addEventListener('abort', onAbort, { once: true })
-              })
-            : null
           const readPromise = reader.read()
           const result = abortPromise ? await Promise.race([readPromise, abortPromise]) : await readPromise
           if (abortFired) {
@@ -248,6 +259,9 @@ function attachBodyTimingTap(
         settle(message)
         controller.error(err)
       } finally {
+        if (onAbort !== null && idleController !== null && !idleController.signal.aborted) {
+          idleController.signal.removeEventListener('abort', onAbort)
+        }
         reader.releaseLock()
       }
     },


### PR DESCRIPTION
## Problem

[typeey on #408](https://github.com/typeclaw/typeclaw/pull/408#issuecomment-4553655893) flagged a closure leak in the idle path landed by that PR:

> the current `Promise.race` implementation creates a fresh abort listener on every chunk, and unless that listener is explicitly removed when `reader.read()` wins, you can accumulate a lot of closures over a long stream

The flag is correct. Inside the body-tap loop in `src/run/codex-fetch-observer.ts`:

```ts
while (true) {
  let abortFired = false
  const abortPromise = idleController
    ? new Promise<never>((_, reject) => {
        const onAbort = () => { abortFired = true; reject(...) }
        if (idleController.signal.aborted) onAbort()
        else idleController.signal.addEventListener('abort', onAbort, { once: true })
      })
    : null
  // ... await Promise.race([reader.read(), abortPromise])
}
```

A fresh `Promise` (and a fresh `onAbort` closure) is constructed on every iteration. `{ once: true }` only removes the listener if `abort` is actually dispatched — but in the happy path `reader.read()` wins the race and the abort event never fires. The losing `abortPromise` is discarded by `Promise.race`, but the `onAbort` listener stays attached to `idleController.signal` until the `AbortController` itself is GC'd.

For an N-chunk stream, the signal accumulates N listeners. A long Codex turn (~thousands of SSE deltas) parks one closure per delta on a single `AbortSignal`. Each closure closes over `reject`, the previous iteration's local scope, and the controller — non-trivial retained graph.

## What this PR does

Hoists the abort listener out of the loop. One listener is installed for the lifetime of the stream and removed in `finally`.

```ts
let abortFired = false
let onAbort: (() => void) | null = null
const abortPromise = idleController
  ? new Promise<never>((_, reject) => {
      onAbort = () => { abortFired = true; reject(...) }
      if (idleController.signal.aborted) onAbort()
      else idleController.signal.addEventListener('abort', onAbort, { once: true })
    })
  : null
abortPromise?.catch(() => {})   // see "Why the .catch" below

try {
  while (true) {
    const result = abortPromise
      ? await Promise.race([reader.read(), abortPromise])
      : await reader.read()
    if (abortFired) { ... throw ... }
    // ... handle chunk / done ...
  }
} catch (err) { ... }
finally {
  if (onAbort !== null && idleController !== null && !idleController.signal.aborted) {
    idleController.signal.removeEventListener('abort', onAbort)
  }
  reader.releaseLock()
}
```

### Why the shared `abortPromise` is correct

The shared promise has exactly one terminal state: rejected when the idle controller aborts. `Promise.race` polls it on every iteration; the first iteration in which `idleController.signal` is aborted observes the rejection, the loop exits via `throw`, and `finally` runs cleanup. The `abortFired` boolean is a function-scoped flag toggled by the (now single) `onAbort` closure, so the post-race check still distinguishes "abort won" from "read returned `{ done: true }`".

A clean stream end (`done: true`) never resolves nor rejects `abortPromise`. The shared promise simply becomes unreachable when the `start()` async function returns and is GC'd along with the closure.

### Why the `.catch(() => {})`

If the consumer cancels the response body after a clean close (rare but possible), `abortPromise` can be rejected after the loop has exited and after the only `await Promise.race([...])` has resolved. With no awaiter left on the promise, that rejection would surface as an unhandled rejection on Bun. The bare `.catch(() => {})` attaches a noop handler at construction so the rejection is always "handled" even when no race ever observes it. The error path that actually matters (idle timeout while the loop is mid-race) still propagates through the `Promise.race` await, hits `abortFired`, and runs the existing `controller.error(err)` / `settle(message)` path.

### Why `removeEventListener` is guarded on `!signal.aborted`

If the timer fired and dispatched `abort`, the `{ once: true }` listener has already been auto-removed by the EventTarget spec. Calling `removeEventListener` again is harmless, but the guard makes the intent explicit and matches the "remove only what we installed and that is still installed" reading.

## Files changed

| File | Change |
|---|---|
| `src/run/codex-fetch-observer.ts` | +25/-11. Hoist `onAbort` / `abortPromise` above the loop; remove the listener in `finally`; swallow the shared rejection. |
| `src/run/codex-fetch-observer.test.ts` | +58/-0. One regression test: pushes 100 chunks through the observer with a counting `AbortController` shim; asserts `addEventListener('abort', …)` installations stay `<= 1`. |

## Verification

```
bun run typecheck    ✓  (0 errors)
bun run lint         ✓  (60 pre-existing warnings, 0 errors, 0 new)
bun run format:check ✓
bun run test         ✓  (5637/5637 pass, +1 new test over #408's 5636 baseline)
```

### The regression test fails for the right reason on the unfixed code

I stashed the implementation change and re-ran just the new test against the pre-fix observer:

```
expect(received).toBeLessThanOrEqual(expected)

Expected: <= 1
Received: 101
```

101 = 1 initial install + 100 leaked installs across 100 chunks. With the fix, 1. The test is anchored to the actual leak, not to a structural detail of the fix.

## Review notes

- The single most important read is the `finally` block in `attachBodyTimingTap`. It must hold even on the throw path: the `catch` re-throws via `controller.error(err)` and then `finally` removes the listener. If a future refactor moves `removeEventListener` out of `finally`, the leak comes back on the happy path.
- The `.catch(() => {})` on `abortPromise` is load-bearing for the post-close cancel path. Linting / formatting / "dead code" cleanup that strips it will reintroduce unhandled rejections.
- The counting `AbortController` shim in the new test is contained to a single `try/finally` and restores `globalThis.AbortController` on exit. It is the cheapest observable signal for "is this leak still gone" without exposing internals from the observer.

## Related

- #408 — landed the idle path; this PR fixes the listener accumulation flagged in [its review comment](https://github.com/typeclaw/typeclaw/pull/408#issuecomment-4553655893).
- #406 — the observer this is layered on.
- #394 — the original 9-minute production hang that motivated the chain.
