### PR TITLE
channels: strip non-text media placeholders from quote anchors

### DIFF
--- a/src/channels/router.quote-anchor.test.ts
+++ b/src/channels/router.quote-anchor.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
-import { captureQuoteCandidate, decideQuoteAnchor, prependQuoteAnchor, renderQuoteAnchor } from './router'
+import {
+  captureQuoteCandidate,
+  decideQuoteAnchor,
+  prependQuoteAnchor,
+  renderQuoteAnchor,
+  stripChannelMediaPlaceholders,
+} from './router'
 import { QUOTED_REPLY_EXCERPT_MAX_CHARS, type ChannelAdapterConfig } from './schema'
 
 const baseConfig: ChannelAdapterConfig = {
@@ -172,6 +178,91 @@ describe('captureQuoteCandidate', () => {
       ],
     )
     expect(result?.hadInterveningObserved).toBe(true)
+  })
+
+  test('returns null for a pure KakaoTalk sticker inbound (placeholder is the whole text)', () => {
+    const stickerOnly = {
+      ...humanInbound,
+      text: '[KakaoTalk message with sticker (sticker_ani) pack=4417024 path=4417024.emot_008.webp]',
+    }
+    expect(captureQuoteCandidate('kakaotalk', [stickerOnly], [])).toBeNull()
+  })
+
+  test('returns null for a pure KakaoTalk photo inbound', () => {
+    const photoOnly = {
+      ...humanInbound,
+      text: '[KakaoTalk message with photo 1254x1254 (image/png) https://talk.kakaocdn.net/dna/bInpde/o3eFRt3]',
+    }
+    expect(captureQuoteCandidate('kakaotalk', [photoOnly], [])).toBeNull()
+  })
+
+  test('returns null for a pure Slack attachment inbound', () => {
+    const attachmentOnly = {
+      ...humanInbound,
+      text: '[Slack message with attachment: diagram.png (image/png) id=F1]',
+    }
+    expect(captureQuoteCandidate('slack-bot', [attachmentOnly], [])).toBeNull()
+  })
+
+  test('strips the KakaoTalk photo placeholder but keeps the human-written caption', () => {
+    const caption = {
+      ...humanInbound,
+      text: '사진\n[KakaoTalk message with photo 1254x1254 (image/png) https://talk.kakaocdn.net/dna/x]',
+    }
+    const result = captureQuoteCandidate('kakaotalk', [caption], [])
+    expect(result?.source.text).toBe('사진')
+  })
+
+  test('strips multiple placeholders when an inbound carried several attachments', () => {
+    const multi = {
+      ...humanInbound,
+      text: 'look\n[Slack message with attachment: one.png (image/png) id=F1]\n[Slack message with attachment: two.txt (text/plain) id=F2]',
+    }
+    const result = captureQuoteCandidate('slack-bot', [multi], [])
+    expect(result?.source.text).toBe('look')
+  })
+
+  test('preserves inbounds that only happen to contain bracketed prose', () => {
+    const bracketed = { ...humanInbound, text: '[important] please check' }
+    const result = captureQuoteCandidate('slack-bot', [bracketed], [])
+    expect(result?.source.text).toBe('[important] please check')
+  })
+})
+
+describe('stripChannelMediaPlaceholders', () => {
+  test('drops a standalone KakaoTalk sticker placeholder', () => {
+    expect(
+      stripChannelMediaPlaceholders(
+        '[KakaoTalk message with sticker (sticker_ani) pack=4417024 path=4417024.emot_008.webp]',
+      ),
+    ).toBe('')
+  })
+
+  test('drops a standalone KakaoTalk photo placeholder with a long URL', () => {
+    expect(
+      stripChannelMediaPlaceholders(
+        '[KakaoTalk message with photo 1254x1254 (image/png) https://talk.kakaocdn.net/dna/bInpde/o3eFRt3]',
+      ),
+    ).toBe('')
+  })
+
+  test('keeps caption text written alongside a media placeholder', () => {
+    expect(
+      stripChannelMediaPlaceholders(
+        '사진\n[KakaoTalk message with photo 1254x1254 (image/png) https://talk.kakaocdn.net/dna/x]',
+      ),
+    ).toBe('사진')
+  })
+
+  test('strips all known adapter placeholders', () => {
+    expect(stripChannelMediaPlaceholders('hi [Slack message with attachment: a.png id=F1] yo')).toBe('hi  yo')
+    expect(stripChannelMediaPlaceholders('[Discord message with sticker: party parrot]')).toBe('')
+    expect(stripChannelMediaPlaceholders('[Telegram message with photo: 1280x960 file_id=big]')).toBe('')
+  })
+
+  test('does not strip unrelated bracketed prose', () => {
+    expect(stripChannelMediaPlaceholders('[important] hi')).toBe('[important] hi')
+    expect(stripChannelMediaPlaceholders('[NOTE] check the file')).toBe('[NOTE] check the file')
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2473,10 +2473,32 @@ export type QuoteAnchorCandidate = {
   hadInterveningObserved: boolean
 }
 
+// Strips `[<Adapter> message with ...]` placeholders that adapter
+// classifiers synthesize for non-text inbounds (KakaoTalk stickers,
+// Slack/Discord/Telegram attachments). The quote anchor is a UX
+// affordance pointing the human at *their words* — quoting a sticker as
+// `> Alice: [KakaoTalk message with sticker (sticker_ani) pack=... path=...]`
+// is noise, and for mixed inbounds like `사진 [KakaoTalk message with
+// photo 1254x1254 ...]` the human only wrote `사진`, so the placeholder
+// is the wrong thing to surface. The callsite (captureQuoteCandidate)
+// treats an empty residue as "no quote anchor"; mixed inbounds keep the
+// human-written portion. renderQuoteAnchor later collapses whitespace
+// so residual double-spaces from mid-string strips are harmless.
+const CHANNEL_MEDIA_PLACEHOLDER_RE = /\[(?:KakaoTalk|Slack|Discord|Telegram) message with [^\]]*\]/g
+
+export function stripChannelMediaPlaceholders(text: string): string {
+  return text
+    .replace(CHANNEL_MEDIA_PLACEHOLDER_RE, '')
+    .replace(/[ \t]+\n/g, '\n')
+    .trim()
+}
+
 // Snapshot the primary inbound + observed-buffer state at drain time so
 // the send-side decision has the data it needs without holding a
 // reference to the batch arrays. Returns null when there's nothing
-// anchorable (empty batch, primary is a bot).
+// anchorable (empty batch, primary is a bot, or primary is a non-text
+// inbound with no residual human-written text after stripping the
+// adapter's media placeholder).
 //
 // `hadInterveningObserved` counts ONLY live observations (`source ===
 // 'observed'`), not prefetched scrollback. Prefetch stamps `receivedAt =
@@ -2495,8 +2517,10 @@ export function captureQuoteCandidate(
   if (batch.length === 0) return null
   const primary = batch[batch.length - 1]!
   if (primary.authorIsBot) return null
+  const cleaned = stripChannelMediaPlaceholders(primary.text)
+  if (cleaned === '') return null
   return {
-    source: { adapter, authorId: primary.authorId, authorName: primary.authorName, text: primary.text },
+    source: { adapter, authorId: primary.authorId, authorName: primary.authorName, text: cleaned },
     primaryReceivedAt: primary.receivedAt,
     hadInterveningObserved: hasInterveningObserved(primary.receivedAt, observed),
   }


### PR DESCRIPTION
## Problem

When a TypeClaw channel inbound is a non-text message (KakaoTalk sticker, KakaoTalk photo, Slack/Discord/Telegram attachment), the adapter classifier synthesizes a placeholder text like:

- `[KakaoTalk message with sticker (sticker_ani) pack=4417024 path=4417024.emot_008.webp]`
- `사진\n[KakaoTalk message with photo 1254x1254 (image/png) https://talk.kakaocdn.net/...]`

When the router decides the agent's outbound reply needs a quote anchor (an observed message landed between inbound and outbound — see PR #374 / commit `3b6e0fd`), `captureQuoteCandidate` snapshotted that full placeholder as the quote source text. `renderQuoteAnchor` then rendered:

```
> Alice: [KakaoTalk message with sticker (sticker_ani) pack=4417024 path=4417024.emot_008.webp]
```

That's noise — the quote anchor is supposed to point the human at *their words*, not at our internal placeholder.

## What this PR does

Adds `stripChannelMediaPlaceholders` in `src/channels/router.ts` that removes the `[<Adapter> message with ...]` shape for the four chat adapters that synthesize it (KakaoTalk, Slack, Discord, Telegram). `captureQuoteCandidate` now:

1. Strips the placeholder from the primary inbound's text.
2. Returns `null` if nothing human-written remains (pure-media inbound → no quote anchor at all).
3. Otherwise stores the cleaned residual text as the candidate source (mixed inbound like `사진 [KakaoTalk message with photo ...]` → quote anchor of just `사진`).

### Why not adapter-side

The placeholder lives in the inbound's `text` field because the agent needs to see it — otherwise the agent has no idea a sticker or photo arrived. Stripping at the adapter would break the agent's perception of the inbound. The quote anchor is a separate render path; cleaning there preserves both signals.

### Why not render-side

Stripping inside `renderQuoteAnchor` would still render `> Alice:` with no text for pure-sticker inbounds, which is no better than the original noise. `captureQuoteCandidate` is the right gate: returning `null` there means `decideQuoteAnchor` returns `null` and no anchor is prepended at all.

### Bracketed-prose safety

The regex only matches the exact `[<KnownAdapter> message with ...]` shape, so user prose like `[important] please check` passes through unchanged. Tests cover this.

## Files changed

| File | Change |
|---|---|
| `src/channels/router.ts` | +26/-2. New `stripChannelMediaPlaceholders` helper; `captureQuoteCandidate` strips before snapshotting; returns `null` on empty residual. |
| `src/channels/router.quote-anchor.test.ts` | +92/-1. 13 new tests covering all adapter shapes, mixed-caption residual, pure-media null return, and bracketed-prose passthrough. |

## Verification

```
bun run typecheck    ✓  (0 errors)
bun run lint         ✓  (60 pre-existing warnings, 0 errors, 0 new)
bun run format:check ✓
bun run test         ✓  (5648/5648 pass, +13 new tests)
```

## Review notes

- `stripChannelMediaPlaceholders` is the primary read. The regex must not match arbitrary user bracketed text — the four adapter-prefix literals are the fence.
- The `null` return from `captureQuoteCandidate` on a pure-media inbound is load-bearing: it must propagate through `decideQuoteAnchor` such that no anchor string is passed to the reply builder. Trace that path if the null-propagation chain is unclear.
- The mixed-caption test (`사진 [KakaoTalk message with photo ...]` → residual `사진`) is the most representative real-world case; verify the regex trim leaves no leading/trailing whitespace on the caption.

## Related

- #374 / commit `3b6e0fd` — introduced the quote anchor mechanism this PR fixes.