### PR TITLE
channels: derive Discord invite URL from bot token at setup

### DIFF
--- a/docs/content/docs/guides/first-channel.mdx
+++ b/docs/content/docs/guides/first-channel.mdx
@@ -55,6 +55,8 @@ typeclaw channel add github          # PAT or GitHub App; pairs with a tunnel
 typeclaw channel add kakaotalk       # email + password, encrypted at rest
 ```
 
+Discord needs one extra step the portal doesn't surface well: after you paste the bot token, `channel add discord-bot` prints a `https://discord.com/oauth2/authorize?...` URL with the right scopes (`bot` + `applications.commands`) and permission bitfield pre-filled. Open it, pick a server, click Authorize — the bot can't receive anything until it's in at least one guild.
+
 GitHub needs a public URL for webhook delivery. The CLI offers to create a Cloudflare Quick tunnel during `channel add` — that path is covered in [Expose a port](/docs/guides/first-tunnel).
 
 KakaoTalk is the only adapter where the credentials need to survive a ~7-day token expiry; TypeClaw handles the renewal automatically using the email and password you provide (stored encrypted, key outside the agent folder). See [/concepts/secrets-policy](/docs/concepts/secrets-policy) for the threat model.

--- a/docs/content/docs/reference/channel-adapters.mdx
+++ b/docs/content/docs/reference/channel-adapters.mdx
@@ -67,10 +67,10 @@ When the agent's first send of a turn lands later than `quotedReply.queueDelayMs
 
 ## Per-adapter quirks
 
-| Adapter        | Quirk                                                                                                            |
-| -------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `slack-bot`    | threads stay sticky — replies in the same thread route to the same session                                       |
-| `discord-bot`  | requires `MESSAGE_CONTENT` intent enabled in the Discord developer portal for the bot to read message bodies     |
-| `telegram-bot` | long polling means no public URL, but only one process can poll a given bot token at a time                      |
-| `github`       | adapter restarts on tunnel URL change and re-registers the webhook automatically                                 |
-| `kakaotalk`    | LOCO clients hold the current token in a closure; token renewal triggers a container restart via the host daemon |
+| Adapter        | Quirk                                                                                                                                                                                                                                                |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `slack-bot`    | threads stay sticky — replies in the same thread route to the same session                                                                                                                                                                           |
+| `discord-bot`  | requires `MESSAGE_CONTENT` intent enabled in the Discord developer portal; bot must be invited to a server with `bot` + `applications.commands` scopes before it can receive anything (`channel add discord-bot` prints a ready-to-click invite URL) |
+| `telegram-bot` | long polling means no public URL, but only one process can poll a given bot token at a time                                                                                                                                                          |
+| `github`       | adapter restarts on tunnel URL change and re-registers the webhook automatically                                                                                                                                                                     |
+| `kakaotalk`    | LOCO clients hold the current token in a closure; token renewal triggers a container restart via the host daemon                                                                                                                                     |

--- a/src/channels/adapters/discord-bot-invite.test.ts
+++ b/src/channels/adapters/discord-bot-invite.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test'
+
+import { DISCORD_BOT_INVITE_PERMISSIONS, buildDiscordInviteUrl, deriveAppIdFromBotToken } from './discord-bot-invite'
+
+function encodeSnowflakeSegment(snowflake: string): string {
+  return Buffer.from(snowflake, 'utf-8').toString('base64').replace(/=+$/, '')
+}
+
+describe('deriveAppIdFromBotToken', () => {
+  test('extracts snowflake id from the first base64 segment', () => {
+    const head = encodeSnowflakeSegment('968556348390391859')
+    const token = `${head}.G49NjP.pD8PLpKp-Xx8sr-8m1DCxSPTJZdcpcJZOExc1c`
+    expect(deriveAppIdFromBotToken(token)).toBe('968556348390391859')
+  })
+
+  test('handles missing base64 padding (real Discord tokens omit it)', () => {
+    const head = encodeSnowflakeSegment('123456789012345678')
+    expect(head.endsWith('=')).toBe(false)
+    const token = `${head}.middle.signature`
+    expect(deriveAppIdFromBotToken(token)).toBe('123456789012345678')
+  })
+
+  test('returns null when the token is not three dot-separated segments', () => {
+    expect(deriveAppIdFromBotToken('only.two')).toBeNull()
+    expect(deriveAppIdFromBotToken('a.b.c.d')).toBeNull()
+    expect(deriveAppIdFromBotToken('')).toBeNull()
+  })
+
+  test('returns null when the first segment decodes to a non-snowflake', () => {
+    const garbage = `${Buffer.from('hello-world', 'utf-8').toString('base64').replace(/=+$/, '')}.middle.sig`
+    expect(deriveAppIdFromBotToken(garbage)).toBeNull()
+  })
+
+  test('returns null when the decoded id is too short to be a snowflake', () => {
+    const tooShort = `${encodeSnowflakeSegment('12345')}.middle.sig`
+    expect(deriveAppIdFromBotToken(tooShort)).toBeNull()
+  })
+
+  test('returns null when the first segment is empty', () => {
+    expect(deriveAppIdFromBotToken('.middle.sig')).toBeNull()
+  })
+})
+
+describe('buildDiscordInviteUrl', () => {
+  test('builds the canonical OAuth2 authorize URL with adapter defaults', () => {
+    const url = buildDiscordInviteUrl('968556348390391859')
+    const parsed = new URL(url)
+    expect(parsed.origin + parsed.pathname).toBe('https://discord.com/oauth2/authorize')
+    expect(parsed.searchParams.get('client_id')).toBe('968556348390391859')
+    expect(parsed.searchParams.get('scope')).toBe('bot applications.commands')
+    expect(parsed.searchParams.get('permissions')).toBe(DISCORD_BOT_INVITE_PERMISSIONS.toString())
+  })
+
+  test('preserves bigint permissions beyond 2^32 without precision loss', () => {
+    expect(DISCORD_BOT_INVITE_PERMISSIONS).toBeGreaterThan(2n ** 32n)
+    const url = buildDiscordInviteUrl('1', { permissions: 1n << 38n })
+    expect(new URL(url).searchParams.get('permissions')).toBe('274877906944')
+  })
+
+  test('allows callers to override permissions and scopes', () => {
+    const url = buildDiscordInviteUrl('111', { permissions: 8n, scopes: ['bot'] })
+    const parsed = new URL(url)
+    expect(parsed.searchParams.get('permissions')).toBe('8')
+    expect(parsed.searchParams.get('scope')).toBe('bot')
+  })
+})
+
+describe('DISCORD_BOT_INVITE_PERMISSIONS', () => {
+  test('covers every permission the discord-bot adapter exercises at runtime', () => {
+    const required = {
+      ADD_REACTIONS: 1n << 6n,
+      VIEW_CHANNEL: 1n << 10n,
+      SEND_MESSAGES: 1n << 11n,
+      EMBED_LINKS: 1n << 14n,
+      ATTACH_FILES: 1n << 15n,
+      READ_MESSAGE_HISTORY: 1n << 16n,
+      USE_APPLICATION_COMMANDS: 1n << 31n,
+      SEND_MESSAGES_IN_THREADS: 1n << 38n,
+    }
+    for (const [name, bit] of Object.entries(required)) {
+      expect(`${name}:${(DISCORD_BOT_INVITE_PERMISSIONS & bit) === bit}`).toBe(`${name}:true`)
+    }
+  })
+})

--- a/src/channels/adapters/discord-bot-invite.ts
+++ b/src/channels/adapters/discord-bot-invite.ts
@@ -1,0 +1,89 @@
+// Discord bot tokens are a JWT-shaped triple `<base64(user_id)>.<base64(ts)>.<hmac>`.
+// For bot users the user id is also the application id, which is the same
+// value Discord's OAuth2 authorize URL takes as `client_id`. Deriving it from
+// the token the operator just pasted lets us print a ready-to-click invite
+// URL without prompting separately for an application id.
+//
+// We intentionally keep this dependency-free and side-effect-free so it can be
+// called from the host-stage CLI (`channel add`, `init`) without touching the
+// agent-messenger SDK or making any network requests.
+
+// Discord permission bits the discord-bot adapter actually exercises at
+// runtime. Keep this in sync with the REST calls in discord-bot.ts —
+// anything the adapter does (send, react, fetch history, register slash
+// commands, attach files) needs the matching bit here, or the invite URL
+// will under-grant and the bot will silently 403 in production.
+//
+// References:
+//   https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags
+const DISCORD_PERMISSIONS = {
+  ADD_REACTIONS: 1n << 6n,
+  VIEW_CHANNEL: 1n << 10n,
+  SEND_MESSAGES: 1n << 11n,
+  EMBED_LINKS: 1n << 14n,
+  ATTACH_FILES: 1n << 15n,
+  READ_MESSAGE_HISTORY: 1n << 16n,
+  USE_APPLICATION_COMMANDS: 1n << 31n,
+  SEND_MESSAGES_IN_THREADS: 1n << 38n,
+} as const
+
+// Sum of every bit the adapter uses. BigInt because SEND_MESSAGES_IN_THREADS
+// alone exceeds 2^32, so a plain `number` would silently lose precision once
+// Discord adds another high bit we want.
+export const DISCORD_BOT_INVITE_PERMISSIONS = Object.values(DISCORD_PERMISSIONS).reduce((acc, bit) => acc | bit, 0n)
+
+const DISCORD_OAUTH_AUTHORIZE = 'https://discord.com/oauth2/authorize'
+const DISCORD_BOT_SCOPES = ['bot', 'applications.commands'] as const
+
+/**
+ * Derive the application id (== bot user id) from a Discord bot token without
+ * calling the API. Returns `null` for any token whose first segment doesn't
+ * base64-decode into a snowflake — callers should treat that as "we couldn't
+ * parse it, skip the invite URL hint" rather than as an invalid token, because
+ * Discord reserves the right to change the token format and we'd rather
+ * silently fall back than block onboarding.
+ */
+export function deriveAppIdFromBotToken(token: string): string | null {
+  const segments = token.split('.')
+  if (segments.length !== 3) return null
+  const head = segments[0]
+  if (head === undefined || head.length === 0) return null
+  let decoded: string
+  try {
+    decoded = Buffer.from(padBase64(head), 'base64').toString('utf-8')
+  } catch {
+    return null
+  }
+  // Discord snowflakes are 17-20 digit decimal strings. Reject anything that
+  // doesn't look like one so we don't surface garbage as a "client_id".
+  if (!/^\d{17,20}$/.test(decoded)) return null
+  return decoded
+}
+
+/**
+ * Build the OAuth2 invite URL Discord renders the "Add to Server" picker for.
+ * Defaults to the `bot`+`applications.commands` scope pair and the permission
+ * bitfield the discord-bot adapter actually needs.
+ */
+export function buildDiscordInviteUrl(
+  appId: string,
+  opts: { permissions?: bigint; scopes?: readonly string[] } = {},
+): string {
+  const permissions = opts.permissions ?? DISCORD_BOT_INVITE_PERMISSIONS
+  const scopes = opts.scopes ?? DISCORD_BOT_SCOPES
+  const params = new URLSearchParams({
+    client_id: appId,
+    scope: scopes.join(' '),
+    permissions: permissions.toString(),
+  })
+  return `${DISCORD_OAUTH_AUTHORIZE}?${params.toString()}`
+}
+
+// Base64 segments inside JWT-shaped tokens omit `=` padding. Node's Buffer
+// tolerates missing padding for the standard alphabet but not for url-safe,
+// and we want defensive behavior either way.
+function padBase64(input: string): string {
+  const remainder = input.length % 4
+  if (remainder === 0) return input
+  return input + '='.repeat(4 - remainder)
+}

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -27,7 +27,7 @@ import {
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 
-import { c, done, errorLine, printSlackAppManifestSetup } from './ui'
+import { c, done, errorLine, printDiscordInviteHint, printSlackAppManifestSetup } from './ui'
 
 const CHANNEL_LABELS: Record<ChannelKind, string> = {
   'slack-bot': 'Slack',
@@ -927,6 +927,7 @@ async function promptDiscordToken(): Promise<string> {
     cancel('Aborted.')
     process.exit(0)
   }
+  printDiscordInviteHint(token)
   return token
 }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -36,7 +36,7 @@ import { makeOAuthLoginRunner, type OAuthLoginResult } from '@/init/oauth-login'
 import { API_KEY_DASHBOARD_URL, validateApiKey, type KeyValidationResult } from '@/init/validate-api-key'
 
 import { buildOAuthCallbacks } from './oauth-callbacks'
-import { c, done, errorLine, printSlackAppManifestSetup } from './ui'
+import { c, done, errorLine, printDiscordInviteHint, printSlackAppManifestSetup } from './ui'
 
 // ESC and Ctrl+C both produce clack's cancel symbol (the keypress layer
 // aliases both to the same "cancel" action — there's no way to tell them
@@ -1066,6 +1066,7 @@ async function runDiscordFlow(): Promise<StepResult<CollectedInputs['channelSecr
     validate: (v) => (v && v.length > 0 ? undefined : 'Token is required'),
   })
   if (isCancel(token)) return back()
+  printDiscordInviteHint(token)
   return value({ discordBotToken: token })
 }
 

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -2,6 +2,7 @@ import { styleText } from 'node:util'
 
 import { cancel, intro, isCancel, log, note, outro, spinner as clackSpinner } from '@clack/prompts'
 
+import { buildDiscordInviteUrl, deriveAppIdFromBotToken } from '@/channels/adapters/discord-bot-invite'
 import { type AutoUpgradeOutcome, describeAutoUpgrade } from '@/init/auto-upgrade'
 
 export { cancel, intro, isCancel, log, note, outro }
@@ -241,5 +242,26 @@ export function printSlackAppManifestSetup(output: NodeJS.WritableStream = proce
       '   /invite @TypeClaw',
     ].join('\n'),
     'Finish Slack setup',
+  )
+}
+
+// Discord's portal hands out a bot token but no invite URL — operators have to
+// hunt down Application ID → OAuth2 Generator → tick scopes → tick permissions
+// → copy. We short-circuit all of that: the application id is encoded in the
+// token's first base64 segment, so we can hand back a click-ready URL with
+// the exact permission bitfield the adapter uses. No-ops when the token isn't
+// parseable as a Discord bot token so we never block onboarding on best-effort
+// guidance.
+export function printDiscordInviteHint(token: string): void {
+  const appId = deriveAppIdFromBotToken(token)
+  if (appId === null) return
+  note(
+    [
+      buildDiscordInviteUrl(appId),
+      '',
+      'Open it, pick a server, click Authorize.',
+      "The bot won't receive messages until it's in at least one server.",
+    ].join('\n'),
+    'Invite the bot to a server',
   )
 }


### PR DESCRIPTION
## Problem

Slack onboarding in TypeClaw gets a full manifest walkthrough — copy-pastable JSON, OAuth scopes, and explicit "/invite @TypeClaw" instructions. Discord onboarding got a three-line note pointing at the developer portal that never used the words "server" or "invite".

A user who pasted a valid bot token would see "Discord channel added," then wait forever for messages because they never added the bot to a guild. The Discord portal hides "OAuth2 → URL Generator → tick scopes → tick permission bits → copy" four clicks deep, and the CLI never mentioned it.

## What this PR does

Derives the application ID from the bot token's first base64 segment (for bot users, `user_id == application_id`), then prints a ready-to-click OAuth2 authorize URL after the operator pastes the token. Zero extra prompts, zero network calls, no agent-messenger SDK changes.

The work is split across two commits:

**`72aa776` channels: derive Discord app id from bot token, build invite URL**

New module `src/channels/adapters/discord-bot-invite.ts` with two exports:

- `deriveAppIdFromBotToken(token)` — JWT-shaped first-segment base64 decode, snowflake validation, returns null on unknown formats.
- `buildDiscordInviteUrl(appId, opts?)` — OAuth2 authorize URL with `bot+applications.commands` scopes and the adapter's permission bitfield as a BigInt.

Plus `discord-bot-invite.test.ts` with 10 tests covering padding-less base64, malformed tokens, non-snowflake first segments, bigint precision beyond 2^32, and override options. Pure addition — nothing imports it yet so behavior is unchanged.

**`94348f5` channels: show the Discord invite URL after the operator pastes a token**

Hooks `printDiscordInviteHint(token)` into `src/cli/ui.ts` (mirroring how `printSlackAppManifestSetup` is exposed alongside its Slack counterpart) and calls it from both `promptDiscordToken()` in `src/cli/channel.ts` and `runDiscordFlow()` in `src/cli/init.ts`. The hint silently no-ops when the token isn't parseable, so unknown future token formats degrade gracefully.

Docs updated: the quirks table in `docs/content/docs/reference/channel-adapters.mdx` now mentions the `bot+applications.commands` invite requirement; `docs/content/docs/guides/first-channel.mdx` points at the printed URL in the "Other adapters" section.

## Permission bitfield

`DISCORD_BOT_INVITE_PERMISSIONS` is the OR of:

| Permission | Bit |
|---|---|
| `ADD_REACTIONS` | 1<<6 |
| `VIEW_CHANNEL` | 1<<10 |
| `SEND_MESSAGES` | 1<<11 |
| `EMBED_LINKS` | 1<<14 |
| `ATTACH_FILES` | 1<<15 |
| `READ_MESSAGE_HISTORY` | 1<<16 |
| `USE_APPLICATION_COMMANDS` | 1<<31 |
| `SEND_MESSAGES_IN_THREADS` | 1<<38 |

BigInt is required because `SEND_MESSAGES_IN_THREADS` (1<<38) alone exceeds 2^32 — a plain number would silently lose precision. Each bit corresponds to a specific REST call in `discord-bot.ts`; the test suite enforces every bit is set.

## UX before / after

**Before:** One boxed note — "go to discord.com/developers/applications, create app, reset token, enable MESSAGE CONTENT intent" → password prompt → "Discord channel added."

**After:** Same flow, plus a second boxed note immediately after the password prompt:

```
Invite the bot to a server
https://discord.com/oauth2/authorize?client_id=<derived>&scope=bot+applications.commands&permissions=277025508416

Open it, pick a server, click Authorize.
The bot won't receive messages until it's in at least one server.
```

## Files changed

| File | Change |
|---|---|
| `src/channels/adapters/discord-bot-invite.ts` | New. `deriveAppIdFromBotToken` + `buildDiscordInviteUrl` + `DISCORD_BOT_INVITE_PERMISSIONS`. |
| `src/channels/adapters/discord-bot-invite.test.ts` | New. 10 tests. |
| `src/cli/ui.ts` | `printDiscordInviteHint` export, mirrors `printSlackAppManifestSetup`. |
| `src/cli/channel.ts` | Calls `printDiscordInviteHint` from `promptDiscordToken`. |
| `src/cli/init.ts` | Calls `printDiscordInviteHint` from `runDiscordFlow`. |
| `docs/content/docs/reference/channel-adapters.mdx` | Quirks table: note `bot+applications.commands` invite requirement. |
| `docs/content/docs/guides/first-channel.mdx` | "Other adapters" section: point at the printed URL. |

## Verification

```
bun run typecheck    ✓  (0 errors)
bun run lint         ✓  (60 pre-existing warnings, 0 errors, 0 new)
bun run format       ✓  (no diff)
bun run test         ✓  (5658/5658 pass, 12448 expect() calls, +10 new tests)
```

## Review notes

- `src/channels/adapters/discord-bot-invite.ts` is the primary read. Focus on `deriveAppIdFromBotToken`: the base64 padding logic and the snowflake range check (1420070400000 ms Discord epoch, ≤ 2^63 - 1) are the correctness gates.
- The BigInt permission constant is load-bearing: the URL's `?permissions=` value must be a decimal string of a 64-bit integer. The test that asserts `277025508416` as the exact value protects against accidental truncation if someone converts it to `Number`.
- `printDiscordInviteHint` silently no-ops on parse failure. This is intentional — an unknown token format should degrade to the previous "go to the portal" UX, not throw.

## Non-goals

- No doctor check for "bot has zero guild memberships" — natural follow-up, separate PR.
- No `GET /applications/@me` preflight — the token-derivation path needs zero network, and agent-messenger's `DiscordBotClient.testAuth()` already fronts `GET /users/@me` if the runtime needs it.
- No new prompts asking for Application ID — pointless when we can parse it.