### PR TITLE
server: persist sessions from plugin command/cron-handler ctx.prompt

### DIFF
--- a/src/agent/multimodal/look-at.ts
+++ b/src/agent/multimodal/look-at.ts
@@ -80,6 +80,14 @@ export const lookAtTool = defineTool({
         parentSessionId: '<look-at-tool>',
       }
 
+      // TODO(usage-accounting): this falls through to SessionManager.inMemory()
+      // because no sessionManager is passed, so the look_at subagent's
+      // message.usage never reaches the sessions/ JSONLs that `typeclaw usage`
+      // and the bundled `backup` plugin scan. Same root-cause class as the
+      // plugin-command/cron-handler path fixed in `runPromptForCommand`
+      // (src/server/command-runner.ts). Fixing this requires threading a
+      // SessionFactory into pi-coding-agent's tool execute() signature, which
+      // is a separate change.
       const { session, dispose } = await createSessionWithDispose({
         systemPromptOverride: systemPrompt,
         origin,

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -338,6 +338,7 @@ export async function startAgent({
             signal: abortController.signal,
             runtimeVersion: runtimeVersionOpt.runtimeVersion,
             containerName: containerNameOpt.containerName,
+            sessionFactory,
           }),
         subagent: (subName: string, payload?: unknown) =>
           dispatchSpawnSubagent(subName, payload, {
@@ -551,6 +552,7 @@ export async function startAgent({
       runtimeVersion: CLI_VERSION,
       containerName,
       outbound,
+      sessionFactory,
     })
 
   const server = createServer({

--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'bun:test'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { z } from 'zod'
 
@@ -8,11 +11,13 @@ import type { PluginCommand, PluginRegistry } from '@/plugin'
 import { defineCommand } from '@/plugin/define'
 import { emptyRegistry, type RegisteredCommand } from '@/plugin/registry'
 import { createPluginRuntime, type PluginRuntime } from '@/run/plugin-runtime'
+import { createSessionFactory, type SessionFactory } from '@/sessions'
 
 import {
   bindSignalToSession,
   createCommandRunner,
   runExecForCommand,
+  runPromptForCommand,
   type CommandOutbound,
   type CommandSpawnSubagent,
 } from './command-runner'
@@ -74,19 +79,26 @@ function registerCommand(
 
 const noopSpawn: CommandSpawnSubagent = async () => {}
 
+function makeSessionFactoryForTest(): { sessionFactory: SessionFactory; agentDir: string } {
+  const agentDir = mkdtempSync(join(tmpdir(), 'typeclaw-cmdrunner-'))
+  return { sessionFactory: createSessionFactory({ agentDir }), agentDir }
+}
+
 function makeRunner(commands: RegisteredCommand[]) {
   const { outbound, frames, decodeStdout } = makeOutboundCapture()
   const runtime = makeRuntime(commands)
+  const { sessionFactory, agentDir } = makeSessionFactoryForTest()
   const runner = createCommandRunner({
     pluginRuntime: runtime,
     permissions: noopPermissionService,
     spawnSubagent: noopSpawn,
-    agentDir: '/tmp/agent',
+    agentDir,
     runtimeVersion: '0.0.0-test',
     containerName: 'test-agent',
     outbound,
+    sessionFactory,
   })
-  return { runner, frames, decodeStdout }
+  return { runner, frames, decodeStdout, agentDir }
 }
 
 async function waitForExit(frames: CapturedFrame[], callId: string, timeoutMs = 2_000): Promise<CapturedFrame> {
@@ -227,10 +239,10 @@ describe('CommandRunner', () => {
         return 0
       },
     })
-    const { runner, frames, decodeStdout } = makeRunner([registerCommand('eitheristic', cmd)])
+    const { runner, frames, decodeStdout, agentDir } = makeRunner([registerCommand('eitheristic', cmd)])
     runner.start({ callId: 'g1', name: 'eitheristic', args: undefined }, null)
     await waitForExit(frames, 'g1')
-    expect(decodeStdout()).toContain('agentDir=/tmp/agent')
+    expect(decodeStdout()).toBe(`agentDir=${agentDir}`)
   })
 
   test('QA-C8: concurrent commands with distinct callIds do not interfere', async () => {
@@ -385,14 +397,16 @@ describe('CommandRunner', () => {
     })
     const { outbound, frames } = makeOutboundCapture()
     const runtime = makeRuntime([registerCommand('parent', cmd)])
+    const { sessionFactory, agentDir } = makeSessionFactoryForTest()
     const runner = createCommandRunner({
       pluginRuntime: runtime,
       permissions: noopPermissionService,
       spawnSubagent: capturingSpawn,
-      agentDir: '/tmp/agent',
+      agentDir,
       runtimeVersion: '0.0.0-test',
       containerName: 'test-agent',
       outbound,
+      sessionFactory,
     })
     runner.start({ callId: 'sub-1', name: 'parent', args: undefined }, null)
     await waitForExit(frames, 'sub-1')
@@ -627,5 +641,88 @@ describe('CommandRunner — review follow-ups', () => {
     expect(parsed.spawnedByOrigin?.kind).toBe('cron')
     expect(parsed.spawnedByOrigin?.jobId).toBe('nightly-checks')
     expect(parsed.spawnedByOrigin?.scheduledByRole).toBe('member')
+  })
+})
+
+describe('runPromptForCommand', () => {
+  // Regression guard: ctx.prompt sessions used to fall through to
+  // SessionManager.inMemory() (no sessionManager passed to
+  // createSessionWithDispose), which silently dropped every plugin
+  // cron-handler / plugin-command LLM call from `typeclaw usage` reports
+  // even though Fireworks still billed them. The persisted SessionManager
+  // is what makes the session JSONL exist on disk; the session-meta stamp
+  // in src/agent/index.ts only fires when getSessionFile() is defined.
+  test('hands createSessionWithDispose a persisted sessionManager rooted under sessions/', async () => {
+    const { sessionFactory, agentDir } = makeSessionFactoryForTest()
+    const runtime = makeRuntime([])
+    let captured: { sessionManager: { getSessionFile: () => string | undefined } } | undefined
+    const fakeCreate = async (options: unknown): Promise<{ session: object; dispose: () => Promise<void> }> => {
+      captured = options as typeof captured
+      const session = {
+        prompt: async () => {},
+        getLastAssistantText: () => 'ok',
+        dispose: () => {},
+        abort: async () => {},
+      }
+      return { session: session as object, dispose: async () => {} }
+    }
+
+    const result = await runPromptForCommand({
+      text: 'hi',
+      origin: { kind: 'cron', jobId: 'test', jobKind: 'handler', scheduledByOrigin: { kind: 'config-file' } },
+      runtime,
+      agentDir,
+      permissions: noopPermissionService,
+      signal: new AbortController().signal,
+      runtimeVersion: '0.0.0-test',
+      containerName: 'test-agent',
+      sessionFactory,
+      _createSession: fakeCreate as Parameters<typeof runPromptForCommand>[0]['_createSession'],
+    })
+
+    expect(result).toBe('ok')
+    expect(captured).toBeDefined()
+    const sessionFile = captured!.sessionManager.getSessionFile()
+    expect(typeof sessionFile).toBe('string')
+    expect(sessionFile).toContain(sessionFactory.sessionDir())
+  })
+
+  test('each call gets a fresh sessionManager (distinct files per invocation)', async () => {
+    const { sessionFactory, agentDir } = makeSessionFactoryForTest()
+    const runtime = makeRuntime([])
+    const seen: string[] = []
+    const fakeCreate = async (options: unknown): Promise<{ session: object; dispose: () => Promise<void> }> => {
+      const file = (options as { sessionManager: { getSessionFile: () => string } }).sessionManager.getSessionFile()
+      seen.push(file)
+      const session = {
+        prompt: async () => {},
+        getLastAssistantText: () => '',
+        dispose: () => {},
+        abort: async () => {},
+      }
+      return { session: session as object, dispose: async () => {} }
+    }
+
+    const origin = {
+      kind: 'cron' as const,
+      jobId: 'test',
+      jobKind: 'handler' as const,
+      scheduledByOrigin: { kind: 'config-file' as const },
+    }
+    for (let i = 0; i < 3; i++) {
+      await runPromptForCommand({
+        text: `tick ${i}`,
+        origin,
+        runtime,
+        agentDir,
+        permissions: noopPermissionService,
+        signal: new AbortController().signal,
+        runtimeVersion: '0.0.0-test',
+        containerName: 'test-agent',
+        sessionFactory,
+        _createSession: fakeCreate as Parameters<typeof runPromptForCommand>[0]['_createSession'],
+      })
+    }
+    expect(new Set(seen).size).toBe(3)
   })
 })

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -1,4 +1,9 @@
-import { createSessionWithDispose, type SessionOrigin } from '@/agent'
+import {
+  createSessionWithDispose,
+  type CreateSessionOptions,
+  type CreateSessionResult,
+  type SessionOrigin,
+} from '@/agent'
 import type { PermissionService } from '@/permissions'
 import type {
   CommandExecResult,
@@ -11,6 +16,7 @@ import type {
   SpawnSubagentOptions,
 } from '@/plugin'
 import type { PluginRuntime } from '@/run/plugin-runtime'
+import type { SessionFactory } from '@/sessions'
 
 export type CommandSpawnSubagent = (name: string, payload?: unknown, options?: SpawnSubagentOptions) => Promise<void>
 
@@ -29,6 +35,14 @@ export type CommandRunnerOptions = {
   runtimeVersion: string | undefined
   containerName: string | undefined
   outbound: CommandOutbound
+  // Hands a persisted SessionManager to every prompt session spawned from a
+  // plugin command's `ctx.prompt`. Required so the session writes its JSONL
+  // (and therefore its `message.usage`) under sessions/, which is what
+  // `typeclaw usage` and the `bundled-plugins/backup` plugin scan. Without
+  // this every plugin-command LLM call would fall through to
+  // `SessionManager.inMemory()` and never persist usage — see
+  // `runPromptForCommand` below.
+  sessionFactory: SessionFactory
 }
 
 type CommandHandle = {
@@ -166,6 +180,7 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
               containerName: opts.containerName,
               permissions: opts.permissions,
               signal: abortController.signal,
+              sessionFactory: opts.sessionFactory,
             }),
           subagent: (subName, payload) =>
             opts.spawnSubagent(subName, payload, {
@@ -331,6 +346,8 @@ function writeLine(stream: WritableStream<Uint8Array>, line: string): void {
   void writer.write(new TextEncoder().encode(`${line}\n`)).then(() => writer.releaseLock())
 }
 
+export type CreateSessionForCommand = (options: CreateSessionOptions) => Promise<CreateSessionResult>
+
 export async function runPromptForCommand(args: {
   text: string
   origin: SessionOrigin
@@ -340,6 +357,16 @@ export async function runPromptForCommand(args: {
   containerName: string | undefined
   permissions: PermissionService
   signal: AbortSignal
+  // Persisted-session source. Each call gets a fresh SessionManager so the
+  // resulting JSONL is its own file under sessions/ — the same shape the
+  // cron `prompt` path uses in src/run/index.ts. Passing in-memory here
+  // regresses `typeclaw usage` (see CommandRunnerOptions.sessionFactory).
+  sessionFactory: SessionFactory
+  // Test seam for the agent-session boundary. Production passes the real
+  // `createSessionWithDispose`; tests inject a fake to verify wiring
+  // (specifically: the sessionManager handed off must be persisted, not
+  // in-memory) without booting the full session stack.
+  _createSession?: CreateSessionForCommand
 }): Promise<string> {
   // Mirrors src/agent/multimodal/look-at.ts: spawn a session, prompt, capture
   // the final assistant text, dispose. Unlike look-at we want the FULL agent
@@ -349,9 +376,11 @@ export async function runPromptForCommand(args: {
   // loader (no `systemPromptOverride`).
   const snapshot = args.runtime.get()
   const sessionId = resolveSessionIdForOrigin(args.origin)
-  const { session, dispose } = await createSessionWithDispose({
+  const create = args._createSession ?? createSessionWithDispose
+  const { session, dispose } = await create({
     origin: args.origin,
     permissions: args.permissions,
+    sessionManager: args.sessionFactory.createPersisted(),
     plugins: {
       registry: snapshot.registry,
       hooks: snapshot.hooks,


### PR DESCRIPTION
## Summary

`ctx.prompt` from plugin commands and `kind: 'handler'` cron jobs was creating in-memory agent sessions, so the resulting `message.usage` never reached the `sessions/*.jsonl` files that `typeclaw usage` scans. Fireworks (and every other provider) still billed the calls — they were just invisible in the report.

## Why this matters

I ran two plugin crons on `*/5 * * * *` and `*/30 * * * *` for a day. Numbers from the same agent, same day:

| Source | Tokens |
|---|---|
| Fireworks dashboard, May 27, one API key | **254.5M** |
| `typeclaw usage --since 1d` | **9.1M Sent** |

That's ~27x. The missing 245M tokens were all on the plugin cron handler `ctx.prompt` path. Big enough that the existing `By origin` breakdown was effectively lying — handler runs were entirely invisible, not just attributed to the wrong bucket.

The same root-cause class also hits two adjacent paths:

- `src/server/command-runner.ts:159` — `ctx.prompt` from plugin commands (`typeclaw <plugin-command>`), used by anything that calls `runPromptForCommand` through `createCommandRunner`.
- `src/agent/multimodal/look-at.ts:83` — `look_at` tool spawning a vision subagent (separate change; see TODO marker added in this PR).

Confirmed against raw JSONL:

```
$ for f in sessions/*.jsonl; do
    jq -c 'select(.message.role=="assistant") | .message.usage' "$f" 2>/dev/null
  done | jq -s '{n:length, input:(map(.input)|add), output:(map(.output)|add), cacheRead:(map(.cacheRead)|add), totalTokens:(map(.totalTokens)|add)}'
{
  "n": 17076,
  "input": 116008379,
  "output": 6746805,
  "cacheRead": 409539072,
  "totalTokens": 532294256
}
```

`typeclaw usage` showed numbers consistent with the above (`Sent: 533M` lifetime, `Sent: 9.1M` today), but the dashboard for the same day showed `254.5M`. So the JSONL data is faithfully scanned — the JSONLs themselves were just missing the handler/command runs.

## Root cause

`runPromptForCommand` in `src/server/command-runner.ts:352` (before this PR) called `createSessionWithDispose({ origin, permissions, plugins, ... })` with **no `sessionManager`**. The default in `src/agent/index.ts:270` is:

```ts
const sessionManager = options.sessionManager ?? SessionManager.inMemory()
```

`SessionManager.inMemory()` never writes a JSONL. And the `typeclaw.session-meta` origin stamp at `src/agent/index.ts:282` is explicitly gated on `getSessionFile() !== undefined`, so the in-memory path also loses origin attribution — even if anyone could read the in-memory log they couldn't bucket it.

Two distinct production callers hit this path:

| Caller | File | Trigger |
|---|---|---|
| `kind: 'handler'` cron `ctx.prompt` | `src/run/index.ts:331` | every plugin cron handler that calls `ctx.prompt` |
| Plugin command `ctx.prompt` | `src/server/command-runner.ts:159` | every `typeclaw <plugin-command>` whose `run(ctx)` calls `ctx.prompt` |

Both already had a `SessionFactory` available in their outer scope — the cron `prompt`-kind path on `src/run/index.ts:353` already wires it correctly. The handler path just never picked it up.

## Fix

1. `CommandRunnerOptions` gains a required `sessionFactory: SessionFactory`.
2. `runPromptForCommand` takes `sessionFactory` and passes `sessionManager: sessionFactory.createPersisted()` into `createSessionWithDispose`. Each call gets a fresh `SessionManager` → fresh JSONL → matches the existing cron-`prompt` shape.
3. Both call sites in `src/run/index.ts` thread `sessionFactory` through.
4. Adds a test seam (`_createSession?: CreateSessionForCommand`) so unit tests can verify the wiring without booting the agent stack.

## Tests

Two regression-guard tests in `src/server/command-runner.test.ts`:

1. **`hands createSessionWithDispose a persisted sessionManager rooted under sessions/`** — pins the contract that the `sessionManager` passed downstream has `getSessionFile() !== undefined` and that the file path lives under the agent's `sessions/` directory. This is the exact gate that the session-meta stamp checks, so the test pins the user-visible behavior, not the implementation.
2. **`each call gets a fresh sessionManager (distinct files per invocation)`** — guards against a future regression where someone caches the `SessionManager` at the runner level (which would silently merge concurrent ctx.prompt calls into one JSONL and re-introduce attribution problems).

Existing test coverage: the `makeRunner` helper now provides a real tmp-dir-backed `SessionFactory` instead of a hardcoded string, so every existing test exercises the same persistence path. One existing assertion was updated to assert against the actual injected `agentDir` instead of a literal.

All 5650 tests pass.

## Out of scope (follow-up)

`src/agent/multimodal/look-at.ts:83` has the same root cause but a different fix shape — it lives inside a pi-coding-agent tool `execute()`, which doesn't currently expose a `SessionFactory` to threaded callers. Added a `TODO(usage-accounting)` comment there pointing at this fix.

Token volume from `look_at` is much lower than from background crons (it only fires when the model chooses to look at an image), so this PR addresses the explosive case first.
