### PR TITLE
channels: stop replying to KakaoTalk notification feed (type=71)

### DIFF
--- a/src/channels/adapters/kakaotalk-classify.test.ts
+++ b/src/channels/adapters/kakaotalk-classify.test.ts
@@ -70,6 +70,39 @@ describe('classifyInbound', () => {
     expect(verdict).toEqual({ kind: 'drop', reason: 'unknown_chat' })
   })
 
+  test('drops bot_message when LOCO message_type=71 (kakao notification feed)', () => {
+    const verdict = classifyInbound(
+      event({ message_type: 71, author_id: 406180744, author_name: '카카오 고객센터', message: '시스템 알림' }),
+      groupConfig(),
+      { selfUserId: '999', lookupChat: groupLookup },
+    )
+    expect(verdict).toEqual({ kind: 'drop', reason: 'bot_message' })
+  })
+
+  test('bot_message drop wins over unknown_chat (independent of resolver state)', () => {
+    const verdict = classifyInbound(event({ message_type: 71 }), groupConfig(), {
+      selfUserId: '999',
+      lookupChat: () => null,
+    })
+    expect(verdict).toEqual({ kind: 'drop', reason: 'bot_message' })
+  })
+
+  test('self_author still wins over bot_message (defense in depth)', () => {
+    const verdict = classifyInbound(event({ message_type: 71, author_id: 999 }), groupConfig(), {
+      selfUserId: '999',
+      lookupChat: groupLookup,
+    })
+    expect(verdict).toEqual({ kind: 'drop', reason: 'self_author' })
+  })
+
+  test('normal text (message_type=1) is not dropped as bot_message', () => {
+    const verdict = classifyInbound(event({ message_type: 1 }), dmConfig(), {
+      selfUserId: '999',
+      lookupChat: dmLookup,
+    })
+    expect(verdict.kind).toBe('route')
+  })
+
   test('routes a 1:1 message and stamps the dm workspace + isDm', () => {
     const verdict = classifyInbound(event(), dmConfig(), {
       selfUserId: '999',

--- a/src/channels/adapters/kakaotalk-classify.ts
+++ b/src/channels/adapters/kakaotalk-classify.ts
@@ -4,7 +4,16 @@ import { matchesAnyAlias } from '@/channels/engagement'
 import type { ChannelAdapterConfig } from '@/channels/schema'
 import type { InboundMessage } from '@/channels/types'
 
-export type InboundDropReason = 'self_author' | 'empty_text' | 'unknown_chat' | 'pre_connect'
+export type InboundDropReason = 'self_author' | 'empty_text' | 'unknown_chat' | 'pre_connect' | 'bot_message'
+
+// LOCO message_type 71 is KakaoTalk's notification/feed channel — official
+// accounts like "카카오 고객센터" and "카카오계정" (login alerts, security
+// notices, system messages). These arrive in @kakao-group buckets because
+// they aren't normal user chats, but they are not human conversation and
+// the agent should never reply to them. Not enumerated in
+// agent-messenger's `KAKAO_MESSAGE_TYPE` because that const only covers
+// user-composable types (TEXT/PHOTO/VIDEO/AUDIO/FILE/MULTIPHOTO).
+const KAKAO_NOTIFICATION_MESSAGE_TYPE = 71
 
 export type InboundClassification =
   | { kind: 'drop'; reason: InboundDropReason }
@@ -31,6 +40,9 @@ export function classifyInbound(
   }
   if (String(event.author_id) === context.selfUserId) {
     return { kind: 'drop', reason: 'self_author' }
+  }
+  if (event.message_type === KAKAO_NOTIFICATION_MESSAGE_TYPE) {
+    return { kind: 'drop', reason: 'bot_message' }
   }
 
   const text = event.message ?? ''

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -671,6 +671,8 @@ function dropHint(reason: InboundDropReason): string {
   switch (reason) {
     case 'unknown_chat':
       return ' (chat not in cache after refresh and provisional registration; check earlier resolver-refresh-failed warnings)'
+    case 'bot_message':
+      return ' (LOCO message_type=71 is KakaoTalk notification/feed; official accounts like 카카오 고객센터 / 카카오계정 / login alerts)'
     case 'empty_text':
     case 'pre_connect':
     case 'self_author':


### PR DESCRIPTION
## Summary

The KakaoTalk adapter was happily letting the agent respond to official-account notifications like **카카오 고객센터** (KakaoTalk customer center) and **카카오계정** (Kakao Account login alerts / security notices). These arrive as LOCO `message_type=71`, get bucketed into `@kakao-group` because they're not in `getChats({all:true})`, and then sail through `classifyInbound` as if a human typed them.

This PR adds a `bot_message` drop reason to the inbound classifier that fires on `message_type === 71`, so the agent never sees them.

## Why this matters

Live evidence from a real session (chat IDs and author IDs straight from the user's `typeclaw logs` paste):

```
22:07:00 [kakaotalk] provisional chat=4967554298218106 ... bucket=@kakao-group reason=not_in_getchats
22:07:00 [kakaotalk] inbound  log_id=… author=406180744 #@kakao-group:4967554298218106 type=71 text_len=15
22:07:00 [kakaotalk] routed   log_id=… ... mention=false dm=false
22:07:02 [channels] prompting batch=1 text_len=57
22:07:09 [kakaotalk] outbound bucket=@kakao-group chat=4967554298218106 text_len=127 attachments=0
…
22:08:12 [channels] skipped_by_tool reason="same KakaoTalk notice repeated; no new info to add"
```

In other words: the agent saw a stream of KakaoTalk system notifications, repeatedly tried to "reply" to them, burned Codex turns generating each reply, sent them back to the notification chat (where nobody reads them), and eventually noticed mid-loop that it was wasting cycles. The same pattern repeated for `chat=4973564619930444` (a different official-account stream).

It's wrong on three axes at once: wasted tokens, polluted memory/transcript with bot noise, and replies sent to a chat that has no human reader.

## Root cause

The Kakao adapter doesn't have any concept of "bot author" — there's a chain of holes that let `type=71` reach the prompt path:

1. **`agent-messenger`'s `KAKAO_MESSAGE_TYPE` enum doesn't include 71.** It only covers user-composable types — `TEXT=1`, `PHOTO=2`, `VIDEO=3`, `AUDIO=5`, `FILE=18`, `MULTIPHOTO=27`. 71 is KakaoTalk's notification/feed channel; the SDK surfaces it raw with no flag.

2. **The official-account chat isn't in `getChats({all:true})`,** so `kakaotalk.ts:367` registers a provisional `@kakao-group` entry. That gets the message past the `unknown_chat` drop.

3. **`authorIsBot` is hardcoded `false` in `classifyInbound`** (`kakaotalk-classify.ts:64`). Slack/Discord/Telegram adapters all set it from an SDK flag (`event.bot_id`, `event.author.bot`, `author.is_bot`); KakaoTalk has no equivalent flag exposed. So the engagement layer's peer-bot loop guard (`engagement.ts:174`) can't help either.

4. **The author isn't us, so `self_author` doesn't catch it.** Text isn't empty, so `empty_text` doesn't catch it. There was no fifth drop reason for "this is structurally a bot notification, not a human message."

The result: every `type=71` push event was treated identically to a human typing "안녕" in a normal group chat.

## Fix

Add a fifth `InboundDropReason` in `src/channels/adapters/kakaotalk-classify.ts`:

```ts
export type InboundDropReason = 'self_author' | 'empty_text' | 'unknown_chat' | 'pre_connect' | 'bot_message'

const KAKAO_NOTIFICATION_MESSAGE_TYPE = 71

// in classifyInbound:
if (event.message_type === KAKAO_NOTIFICATION_MESSAGE_TYPE) {
  return { kind: 'drop', reason: 'bot_message' }
}
```

Placement is **after `self_author`** (so genuine self-echoes still take that branch — defence-in-depth, exercised by a test) and **before `empty_text` / `unknown_chat`** (so bot notifications drop regardless of resolver state — also tested).

`dropHint` in `kakaotalk.ts` gets a matching case so the operator log line is self-explanatory:

```
[kakaotalk] dropped log_id=… reason=bot_message (LOCO message_type=71 is KakaoTalk notification/feed; official accounts like 카카오 고객센터 / 카카오계정 / login alerts)
```

### Why a block-list instead of an allow-list?

I considered inverting it (only allow `TEXT/PHOTO/VIDEO/AUDIO/FILE/MULTIPHOTO` through). I went with the narrow block-list because:

- Emoticons (`message_type` 6/12/20/22/25) come through a **separate** `emoticon` listener event, not the `message` event, so they aren't on this path — but a future SDK change could merge them, and an allow-list would silently start dropping them.
- A new user-composable message type added by KakaoTalk would be silently swallowed by an allow-list; we'd rather route it (and discover any breakage immediately) than drop it.

If more bot-notification types show up later (`72`, `73`, …) the constant becomes a `Set` and the check becomes `.has()`. Cheap to evolve.

### Why not detect by author name (e.g. starts with "카카오")?

False-positive risk on real users whose nicknames happen to start with 카카오. The wire-protocol message type is unambiguous and observed across both bot accounts in the report (`카카오 고객센터` author `406180744` and `카카오계정` author `277770466` both arrived as `type=71`). Name heuristics aren't needed and would be strictly worse.

## Tests

`src/channels/adapters/kakaotalk-classify.test.ts` gains four cases:

- `drops bot_message when LOCO message_type=71` — happy path with the real author ID and Korean nickname from live logs.
- `bot_message drop wins over unknown_chat` — bot drops even when the chat resolver returns null (proves order-independence).
- `self_author still wins over bot_message` — a (hypothetical) self-echoed `type=71` is still dropped as `self_author`, not `bot_message` (defence-in-depth ordering).
- `normal text (message_type=1) is not dropped as bot_message` — regression guard.

```
$ bun run check && bun run test
…
All matched files use the correct format.
…
 5664 pass
 0 fail
 12457 expect() calls
Ran 5664 tests across 311 files.
```

## Scope

- No changes to engagement, router, permissions, or any other adapter.
- No changes to the `agent-messenger` SDK — we work around the missing enum entry locally; if the SDK ever surfaces a real bot flag we can switch to it without touching the engagement layer (`authorIsBot` is the obvious upgrade path).
- No effect on inbound `mark-read` behaviour: `markReadIfSupported` already runs **before** classify, so the user-side unread counter still clears for `type=71` messages — we just don't reply to them.
