### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,168 @@
+# Contributing to TypeClaw
+
+Thanks for considering a contribution. This file covers the mechanics of working on TypeClaw itself — setting up a local dev loop, running checks, and shipping a PR. For the architectural why-and-how (stages, hostd, message stream, plugin contracts, testing philosophy), read [AGENTS.md](./AGENTS.md). It's written for the same audience as this file.
+
+## Requirements
+
+- **Bun** ≥ 1.1 (CI pins 1.3.14; any 1.3.x works locally)
+- **Docker** or **OrbStack** — TypeClaw runs every agent in a container, so you need a working Docker daemon to exercise `typeclaw start`, `tui`, `logs`, `reload`, etc.
+- **Git** ≥ 2.40 — worktrees are how most maintainers juggle branches here
+
+Nothing else. No global toolchain, no Node, no Python.
+
+## Getting the code
+
+```sh
+git clone https://github.com/typeclaw/typeclaw
+cd typeclaw
+bun install
+bun run test
+```
+
+`bun install` runs `postinstall`, which regenerates the four JSON schemas at the repo root (`typeclaw.schema.json`, `cron.schema.json`, `secrets.schema.json`, `auth.schema.json`) from the Zod sources. If you change a schema, re-run `bun install` (or `bun run generate:schema`) before committing — the generated files are tracked.
+
+## Local dev loop (recommended)
+
+The fastest way to iterate on TypeClaw is to point a real agent folder at your local checkout instead of the published npm package. `bun link` makes this a one-liner.
+
+**1. Register the local checkout as a global `typeclaw` binary:**
+
+```sh
+cd ~/workspace/typeclaw
+bun link
+```
+
+This puts a `typeclaw` shim on your `PATH` that resolves to `src/cli/index.ts` in this repo. No build step, no rebuild on every edit — every invocation reads the source you just wrote.
+
+**2. Use it to scaffold a real agent:**
+
+```sh
+mkdir -p ~/agents/typeey && cd ~/agents/typeey
+typeclaw init
+```
+
+The `typeclaw` you just ran is the one from your repo. When `init` runs from a linked checkout, it auto-detects the repo root (by walking up from the running script and finding the `package.json` whose `name` is `typeclaw`) and writes `"typeclaw": "file:../../workspace/typeclaw"` (or whatever relative path applies) into the new agent's `package.json`. The agent's `node_modules/typeclaw` then resolves straight into your checkout — no copy, no rebuild.
+
+**3. Start the agent and iterate:**
+
+```sh
+typeclaw start    # builds the dev image (oven/bun:1-slim base) and runs the container
+typeclaw tui      # attach a TUI to the running agent
+```
+
+Edit code in `~/workspace/typeclaw`, then in the agent folder:
+
+- **Host-side changes** (CLI commands, hostd, init flow): re-run the host command. The shim picks up the new source immediately.
+- **Container-side changes** (`src/agent/`, `src/server/`, bundled plugins, tools): `typeclaw restart` to bounce the container. The agent folder is bind-mounted at `/agent`, and `node_modules/typeclaw` inside it resolves to your checkout via the `file:` spec, so source-only edits land without a rebuild.
+- **`Dockerfile` or `package.json` changes** that affect the image: `typeclaw start --build`. The CLI detects `file:`-linked typeclaw deps and threads `bun install --force` so the lockfile rewrites cleanly.
+
+Why this flow instead of `bun add -g typeclaw`? On a dev machine, the published package is always one release behind your working tree, and global reinstalls clobber whatever you're editing. Linking once and forgetting is the only stable setup.
+
+> **Tip.** Keep one "throwaway" agent folder (`~/agents/typeey` is a fine name — it's the mascot) just for poking the CLI. Don't reuse your production agent folder for dev — `typeclaw start --build` rewrites the `Dockerfile` and `.gitignore` every run, which is fine for a scratch folder and annoying for one with uncommitted work.
+
+To revert to the published version later:
+
+```sh
+cd ~/workspace/typeclaw
+bun unlink                # unregisters the global shim
+bun add -g typeclaw       # reinstalls from npm
+```
+
+## Pre-commit checks
+
+All three must pass before every commit. No exceptions, no `--no-verify`:
+
+```sh
+bun run typecheck
+bun run lint
+bun run format
+```
+
+CI runs the same three commands plus `bun test --parallel`. Run the tests locally too — they're fast (`--parallel` shards across CPUs) and most of them don't need Docker:
+
+```sh
+bun run test
+```
+
+A handful of tests in `src/init/` shell out to a real `bun install` and take 4-5s each; that's normal. CI uses `--timeout 30000` for the same reason — keep yours at the default unless you see false negatives.
+
+## Repo layout (the bits you'll touch)
+
+```
+src/
+├── cli/               # UI-only: citty, clack, spinners, process.exit
+├── init/              # `typeclaw init` pipeline
+├── container/         # host-side Docker orchestration (start, stop, logs)
+├── hostd/             # host singleton daemon (port broker, tunnels, control protocol)
+├── server/            # container-side websocket server
+├── agent/             # AgentSession, system prompt composition, tools
+├── channels/          # router + manager + per-platform adapters
+├── plugin/            # plugin contract and registry
+├── bundled-plugins/   # memory, backup, scout, agent-browser, security, ...
+├── secrets/           # .env <-> secrets.json bridge
+├── permissions/       # role + match-rule DSL
+└── stream/            # message stream targets (TUI, channels, subagents)
+
+scripts/
+├── generate-schema.ts        # postinstall hook
+├── dump-system-prompt.ts     # `bun run debug:prompt`
+└── require-parallel.ts       # lint that forbids serial subagent dispatch
+
+docs/                         # typeclaw.dev (Next.js + Fumadocs); ships in-tree
+```
+
+Tests live next to code as `<file>.test.ts`. Domain logic lives in `src/<domain>/`; `src/cli/` is a thin shell that delegates to it.
+
+## Stages (read this before debugging)
+
+TypeClaw code runs in three stages with different filesystems, process owners, and invocation paths. Confusing them is the most common source of "this works on my machine but not in the container":
+
+- **dev stage** — running `bun run test` on this repo. No agent folder, no container.
+- **host stage** — the user's cwd after `typeclaw init`. Holds `typeclaw.json`, `.env`. Host commands (`start`, `stop`, `tui`, `logs`, `compose`) are launchers.
+- **container stage** — inside Docker, with the agent folder bind-mounted at `/agent`. The container's entrypoint is `typeclaw run`.
+
+Annotate stages on paths in code and PR descriptions: `./typeclaw.json` = host stage, `/agent/typeclaw.json` = container stage. AGENTS.md has the full rules-of-thumb table.
+
+## Debugging the system prompt
+
+```sh
+bun run debug:prompt                     # dumps all 4 session origins
+bun run debug:prompt --origin cron       # just one
+bun run debug:prompt --origin channel --no-git-nudge
+```
+
+The renderer is `composeSystemPrompt` in `src/agent/index.ts`. The cache-suffix ordering (least-volatile first → identity → runtime → origin+role → git → memory → now) is enforced by `scripts/dump-system-prompt.test.ts`; reorder one without the other and CI fails.
+
+## Commit and PR conventions
+
+- **Subject style**: `<area>: <imperative summary>` in lowercase, no trailing period. Examples from recent history:
+  - `channels: stop replying to KakaoTalk notification feed (type=71)`
+  - `server: persist sessions from plugin command/cron-handler ctx.prompt`
+  - `readme: show off typeey at the top of the repo readme`
+- **One concern per commit.** Refactors get their own commit, separate from the bugfix or feature that motivated them.
+- **PRs go against `main`.** The repo uses a single long-lived branch; release tags are cut from it by the **Release** workflow.
+- **Docs ship in the same PR** as the code that motivates them. The published site at [typeclaw.dev](https://typeclaw.dev) rebuilds from `docs/content/docs/`.
+- **No `--no-verify`, no skipped CI.** If a check is in your way, fix the check.
+
+## Scrubbing local info before pushing
+
+This repo's `AGENTS.md` has a long section on scrubbing local environment leaks from diffs, commit messages, and PR bodies. The short version:
+
+- No absolute paths from your machine (`/Users/you/...`, `/home/you/...`)
+- No real hostnames, usernames, or LAN IPs
+- No secrets, even expired ones
+- No personal config snippets or terminal prompts in PR bodies
+
+Tests count as committed code — use `mkdtemp(join(tmpdir(), '...'))` for filesystem fixtures and placeholders (`alice@example.com`, `test-host`, `/path/to/file`) for the rest. Never hardcode real names, paths, or IDs.
+
+## Releases
+
+Releases go through the **Release** GitHub Actions workflow (`workflow_dispatch`). Maintainers run it; contributors don't need to think about it. The flow is documented in [AGENTS.md → Release](./AGENTS.md#release), including the load-bearing GHCR-first-then-npm ordering and the patch-vs-minor decision rule.
+
+## Where to ask
+
+- **Bug reports and feature requests** → [GitHub Issues](https://github.com/typeclaw/typeclaw/issues)
+- **Architecture questions** → read [AGENTS.md](./AGENTS.md) and the [Internals docs](https://typeclaw.dev/docs/internals) first; open an issue with the `question` label if it's still unclear
+- **Security issues** → don't open a public issue. Use GitHub's [private vulnerability reporting](https://github.com/typeclaw/typeclaw/security/advisories/new) instead.
+
+Happy hacking.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ bun run lint
 bun run format
 ```
 
-See [AGENTS.md](./AGENTS.md) for the long-form architecture notes — stages, hostd internals, message stream, plugin contracts, and the testing philosophy. The docs site at [typeclaw.dev](https://typeclaw.dev) lives in [`docs/`](./docs/).
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the recommended local dev loop (`bun link` → `typeclaw init`), commit and PR conventions, and where to ask questions. See [AGENTS.md](./AGENTS.md) for the long-form architecture notes — stages, hostd internals, message stream, plugin contracts, and the testing philosophy. The docs site at [typeclaw.dev](https://typeclaw.dev) lives in [`docs/`](./docs/).
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

Adds `CONTRIBUTING.md` at the repo root and adds a one-line pointer to it in `README.md`.

The guide documents the full local dev workflow: `bun link` inside the typeclaw repo, then `typeclaw init` in a separate agent folder. `init` auto-detects the linked repo root via `findTypeclawRoot()` (walks up from `import.meta.url`) and writes a `file:` dep spec into the new agent's `package.json`, so edits in `src/` are live with no rebuild or re-link step.

## Why this document exists

Without it, a new contributor's first instinct is to `npm install -g typeclaw`, run `init`, and then wonder why source edits have no effect. The `bun link` path is non-obvious: it requires a specific init order, and the `file:` dep in the generated `package.json` is the invisible mechanism that makes it work. The doc explains the mechanism, not just the commands.

## Contents

- **Requirements** — Bun ≥ 1.1, Docker.
- **Local dev loop** — `bun link` → `typeclaw init` ordering, why `file:` beats `link:` for this use case.
- **Repo layout** — `src/cli/`, `src/<domain>/`, docs vs source split.
- **Dev/host/container stage model** — brief callout with a pointer to `AGENTS.md` for the full contract.
- **System-prompt debugging** — `bun run debug:prompt` flags.
- **Pre-commit checks** — `bun run typecheck && bun run lint && bun run format`.
- **Commit and PR conventions** — lowercase `area: imperative` subjects, present tense, period on sentence-form bodies.
- **Local-info scrubbing** — what to grep for before pushing, generic placeholder list.
- **Releases** — pointer to the Release workflow; contributors don't cut releases.
- **Security** — GitHub private vulnerability reporting.

## Changes

### `CONTRIBUTING.md` (new, 168 lines)

Full guide. No code changes.

### `README.md` (+1 line)

Adds `See [CONTRIBUTING.md](./CONTRIBUTING.md) for the local dev loop and contribution guidelines.` to the Development section.

## Testing

No code changed. Pre-commit checks pass:

```
bun run typecheck    ✓  (0 errors)
bun run lint         ✓  (60 pre-existing warnings, 0 errors, 0 new)
bun run format:check ✓
```

## Review notes

- The `bun link` → `typeclaw init` ordering section is the core of the document. The key invariant is that `init` must run *after* the link is in place so `findTypeclawRoot()` resolves to the dev tree, not an npm cache.
- The local-info scrubbing list mirrors the rules in `AGENTS.md` so contributors see them in one place without having to read the agent guidelines file.