### PR TITLE
cli: capture full multi-line PEM when pasting a github app key

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -1,5 +1,4 @@
 import { randomBytes } from 'node:crypto'
-import { readFile } from 'node:fs/promises'
 
 import { cancel, confirm, intro, isCancel, log, note, password, select, spinner, text } from '@clack/prompts'
 import { defineCommand } from 'citty'
@@ -27,6 +26,7 @@ import {
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 
+import { CANCEL_SYMBOL, promptPrivateKeyPem } from './prompt-pem'
 import { c, done, errorLine, printDiscordInviteHint, printSlackAppManifestSetup } from './ui'
 
 const CHANNEL_LABELS: Record<ChannelKind, string> = {
@@ -805,15 +805,12 @@ async function promptGithubAuthUpdate(currentType: 'pat' | 'app'): Promise<Githu
       ].join('\n'),
       'Rotate the GitHub App private key',
     )
-    const privateKeyInput = await text({
-      message: 'New GitHub App private key PEM, escaped PEM, or path to .pem file',
-      validate: (value) => (value && value.length > 0 ? undefined : 'Private key is required'),
-    })
-    if (isCancel(privateKeyInput)) {
+    const privateKey = await promptPrivateKeyPem('New GitHub App private key PEM, escaped PEM, or path to .pem file')
+    if (privateKey === CANCEL_SYMBOL) {
       cancel('Aborted.')
       process.exit(0)
     }
-    return { type: 'app', privateKey: await resolvePrivateKeyInput(privateKeyInput) }
+    return { type: 'app', privateKey }
   }
 
   note(
@@ -855,11 +852,8 @@ async function promptGithubAppAuth(): Promise<{
     cancel('Aborted.')
     process.exit(0)
   }
-  const privateKeyInput = await text({
-    message: 'GitHub App private key PEM, escaped PEM, or path to .pem file',
-    validate: (value) => (value && value.length > 0 ? undefined : 'Private key is required'),
-  })
-  if (isCancel(privateKeyInput)) {
+  const privateKey = await promptPrivateKeyPem('GitHub App private key PEM, escaped PEM, or path to .pem file')
+  if (privateKey === CANCEL_SYMBOL) {
     cancel('Aborted.')
     process.exit(0)
   }
@@ -876,15 +870,9 @@ async function promptGithubAppAuth(): Promise<{
   return {
     type: 'app',
     appId: Number(appId),
-    privateKey: await resolvePrivateKeyInput(privateKeyInput),
+    privateKey,
     ...(parsedInstallationId !== undefined ? { installationId: parsedInstallationId } : {}),
   }
-}
-
-async function resolvePrivateKeyInput(input: string): Promise<string> {
-  const normalized = input.replace(/\\n/g, '\n')
-  if (normalized.includes('-----BEGIN') && normalized.includes('PRIVATE KEY-----')) return normalized
-  return await readFile(input, 'utf8')
 }
 
 function parseRepos(input: string): string[] {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,5 +1,4 @@
 import { randomBytes } from 'node:crypto'
-import { readFile } from 'node:fs/promises'
 
 import { cancel, confirm, intro, isCancel, log, note, password, select, spinner, text } from '@clack/prompts'
 import { defineCommand } from 'citty'
@@ -36,6 +35,7 @@ import { makeOAuthLoginRunner, type OAuthLoginResult } from '@/init/oauth-login'
 import { API_KEY_DASHBOARD_URL, validateApiKey, type KeyValidationResult } from '@/init/validate-api-key'
 
 import { buildOAuthCallbacks } from './oauth-callbacks'
+import { CANCEL_SYMBOL, promptPrivateKeyPem } from './prompt-pem'
 import { c, done, errorLine, printDiscordInviteHint, printSlackAppManifestSetup } from './ui'
 
 // ESC and Ctrl+C both produce clack's cancel symbol (the keypress layer
@@ -1300,11 +1300,8 @@ async function promptGithubAppAuth(): Promise<{
     validate: (v) => validatePositiveInteger(v ?? '', 'App ID is required'),
   })
   if (isCancel(appId)) return null
-  const privateKeyInput = await text({
-    message: 'GitHub App private key PEM, escaped PEM, or path to .pem file',
-    validate: (v) => (v && v.length > 0 ? undefined : 'Private key is required'),
-  })
-  if (isCancel(privateKeyInput)) return null
+  const privateKey = await promptPrivateKeyPem('GitHub App private key PEM, escaped PEM, or path to .pem file')
+  if (privateKey === CANCEL_SYMBOL) return null
   const installationId = await text({
     message: 'Installation ID (optional; leave blank to auto-discover)',
     validate: (v) =>
@@ -1315,15 +1312,9 @@ async function promptGithubAppAuth(): Promise<{
   return {
     type: 'app',
     appId: Number(appId),
-    privateKey: await resolveGithubPrivateKey(privateKeyInput),
+    privateKey,
     ...(parsedInstallationId !== undefined ? { installationId: parsedInstallationId } : {}),
   }
-}
-
-async function resolveGithubPrivateKey(input: string): Promise<string> {
-  const normalized = input.replace(/\\n/g, '\n')
-  if (normalized.includes('-----BEGIN') && normalized.includes('PRIVATE KEY-----')) return normalized
-  return await readFile(input, 'utf8')
 }
 
 function parseGithubRepos(input: string): string[] {

--- a/src/cli/prompt-pem.test.ts
+++ b/src/cli/prompt-pem.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+
+import {
+  CANCEL_SYMBOL,
+  createReadlineLineReader,
+  readPrivateKeyFromLines,
+  resolvePrivateKeyInput,
+  type ReadLineFn,
+} from './prompt-pem'
+
+function fromLines(lines: (string | typeof CANCEL_SYMBOL)[]): ReadLineFn {
+  let i = 0
+  return async () => {
+    if (i >= lines.length) return CANCEL_SYMBOL
+    const v = lines[i++]
+    return v as string | typeof CANCEL_SYMBOL
+  }
+}
+
+const SAMPLE_PEM = [
+  '-----BEGIN RSA PRIVATE KEY-----',
+  'MIIEpAIBAAKCAQEAtest1234',
+  'AAAAAAAAAAAAAAAAAAAAAAAAA',
+  '-----END RSA PRIVATE KEY-----',
+].join('\n')
+
+describe('readPrivateKeyFromLines', () => {
+  test('returns single-line input verbatim when it is not a PEM block', async () => {
+    const result = await readPrivateKeyFromLines(fromLines(['/path/to/key.pem']))
+    expect(result).toBe('/path/to/key.pem')
+  })
+
+  test('returns escaped-PEM single-line input verbatim', async () => {
+    const escaped = '-----BEGIN RSA PRIVATE KEY-----\\nABC\\n-----END RSA PRIVATE KEY-----'
+    const result = await readPrivateKeyFromLines(fromLines([escaped]))
+    expect(result).toBe(escaped)
+  })
+
+  test('captures a full multi-line PEM block (the bug this fixes)', async () => {
+    const lines = SAMPLE_PEM.split('\n')
+    const result = await readPrivateKeyFromLines(fromLines(lines))
+    expect(result).toBe(`${SAMPLE_PEM}\n`)
+  })
+
+  test('handles PEM with leading blank lines (stray Enter before paste)', async () => {
+    const lines = ['', '', ...SAMPLE_PEM.split('\n')]
+    const result = await readPrivateKeyFromLines(fromLines(lines))
+    expect(result).toBe(`${SAMPLE_PEM}\n`)
+  })
+
+  test('handles EC PRIVATE KEY header variant', async () => {
+    const ec = ['-----BEGIN EC PRIVATE KEY-----', 'data', '-----END EC PRIVATE KEY-----'].join('\n')
+    const result = await readPrivateKeyFromLines(fromLines(ec.split('\n')))
+    expect(result).toBe(`${ec}\n`)
+  })
+
+  test('handles generic PRIVATE KEY (PKCS#8) header', async () => {
+    const pkcs8 = ['-----BEGIN PRIVATE KEY-----', 'data', '-----END PRIVATE KEY-----'].join('\n')
+    const result = await readPrivateKeyFromLines(fromLines(pkcs8.split('\n')))
+    expect(result).toBe(`${pkcs8}\n`)
+  })
+
+  test('strips trailing CR/whitespace from each line (CRLF paste)', async () => {
+    const lines = ['-----BEGIN RSA PRIVATE KEY-----\r', 'data\r', '-----END RSA PRIVATE KEY-----\r']
+    const result = await readPrivateKeyFromLines(fromLines(lines))
+    expect(result).toBe(`${SAMPLE_PEM.split('\n').slice(0, 1).join('')}\ndata\n-----END RSA PRIVATE KEY-----\n`)
+  })
+
+  test('returns CANCEL_SYMBOL when reader cancels mid-block', async () => {
+    const result = await readPrivateKeyFromLines(fromLines(['-----BEGIN RSA PRIVATE KEY-----', CANCEL_SYMBOL]))
+    expect(result).toBe(CANCEL_SYMBOL)
+  })
+
+  test('returns CANCEL_SYMBOL when reader cancels before any input', async () => {
+    const result = await readPrivateKeyFromLines(fromLines([CANCEL_SYMBOL]))
+    expect(result).toBe(CANCEL_SYMBOL)
+  })
+})
+
+describe('resolvePrivateKeyInput', () => {
+  let tmp: string
+
+  beforeAll(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'typeclaw-pem-'))
+  })
+
+  afterAll(async () => {
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  test('passes through a real multi-line PEM unchanged', async () => {
+    const out = await resolvePrivateKeyInput(SAMPLE_PEM)
+    expect(out).toBe(SAMPLE_PEM)
+  })
+
+  test('unescapes a single-line escaped PEM', async () => {
+    const escaped = SAMPLE_PEM.replace(/\n/g, '\\n')
+    const out = await resolvePrivateKeyInput(escaped)
+    expect(out).toBe(SAMPLE_PEM)
+  })
+
+  test('does NOT unescape a multi-line PEM that happens to contain \\n', async () => {
+    const mixed = `${SAMPLE_PEM}\nliteral\\nshould stay`
+    const out = await resolvePrivateKeyInput(mixed)
+    expect(out).toBe(mixed)
+  })
+
+  test('reads PEM from a file path', async () => {
+    const path = join(tmp, 'key.pem')
+    await writeFile(path, SAMPLE_PEM, 'utf8')
+    const out = await resolvePrivateKeyInput(path)
+    expect(out).toBe(SAMPLE_PEM)
+  })
+
+  test('throws ENOENT for a non-existent path that is not a PEM', async () => {
+    await expect(resolvePrivateKeyInput(join(tmp, 'does-not-exist.pem'))).rejects.toThrow()
+  })
+})
+
+describe('createReadlineLineReader', () => {
+  test('yields lines from a Readable stream then cancels on close', async () => {
+    const input = Readable.from([SAMPLE_PEM + '\n'])
+    const reader = createReadlineLineReader(input)
+    const lines = SAMPLE_PEM.split('\n')
+    for (const expected of lines) {
+      const got = await reader.next()
+      expect(got).toBe(expected)
+    }
+    const after = await reader.next()
+    expect(after).toBe(CANCEL_SYMBOL)
+  })
+
+  test('queues lines when consumer reads after they arrive', async () => {
+    const input = Readable.from(['one\ntwo\nthree\n'])
+    const reader = createReadlineLineReader(input)
+    await new Promise((r) => setTimeout(r, 10))
+    expect(await reader.next()).toBe('one')
+    expect(await reader.next()).toBe('two')
+    expect(await reader.next()).toBe('three')
+  })
+})

--- a/src/cli/prompt-pem.ts
+++ b/src/cli/prompt-pem.ts
@@ -1,8 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { createInterface, type Interface } from 'node:readline'
-import { type Readable } from 'node:stream'
 
-import { isCancel, log } from '@clack/prompts'
+import { log } from '@clack/prompts'
 
 const BEGIN_MARKER = '-----BEGIN'
 const END_MARKER_RE = /^-----END [A-Z0-9 ]*PRIVATE KEY-----\s*$/
@@ -77,7 +76,7 @@ function createStdinLineReader(): StdinLineReader {
   return createReadlineLineReader(process.stdin)
 }
 
-export function createReadlineLineReader(input: NodeJS.ReadableStream | Readable): StdinLineReader {
+export function createReadlineLineReader(input: NodeJS.ReadableStream): StdinLineReader {
   const rl: Interface = createInterface({ input, terminal: false })
   const queue: string[] = []
   const waiters: ((value: string | typeof CANCEL_SYMBOL) => void)[] = []
@@ -112,5 +111,3 @@ export function createReadlineLineReader(input: NodeJS.ReadableStream | Readable
     close: () => rl.close(),
   }
 }
-
-export { isCancel }

--- a/src/cli/prompt-pem.ts
+++ b/src/cli/prompt-pem.ts
@@ -1,0 +1,116 @@
+import { readFile } from 'node:fs/promises'
+import { createInterface, type Interface } from 'node:readline'
+import { type Readable } from 'node:stream'
+
+import { isCancel, log } from '@clack/prompts'
+
+const BEGIN_MARKER = '-----BEGIN'
+const END_MARKER_RE = /^-----END [A-Z0-9 ]*PRIVATE KEY-----\s*$/
+const END_MARKER_INLINE_RE = /-----END [A-Z0-9 ]*PRIVATE KEY-----/
+
+export const CANCEL_SYMBOL = Symbol('cancel')
+
+export type ReadLineFn = () => Promise<string | typeof CANCEL_SYMBOL>
+
+export async function promptPrivateKeyPem(message: string): Promise<string | typeof CANCEL_SYMBOL> {
+  log.step(message)
+  log.message('Paste the PEM (including BEGIN/END lines), a path to a .pem file, or an escaped PEM.')
+
+  const reader = createStdinLineReader()
+  try {
+    const raw = await readPrivateKeyFromLines(reader.next)
+    if (raw === CANCEL_SYMBOL) return CANCEL_SYMBOL
+    return await resolvePrivateKeyInput(raw)
+  } finally {
+    reader.close()
+  }
+}
+
+/**
+ * Read a PEM block (or single-line value) using `readLine`.
+ *
+ * A line starting with `-----BEGIN` switches into block mode, accumulating
+ * until a line matches `-----END ... PRIVATE KEY-----`. Otherwise the first
+ * non-empty line is returned verbatim (path or escaped PEM). Leading blank
+ * lines are skipped so a stray Enter does not abort the prompt.
+ */
+export async function readPrivateKeyFromLines(readLine: ReadLineFn): Promise<string | typeof CANCEL_SYMBOL> {
+  let first: string
+  while (true) {
+    const line = await readLine()
+    if (line === CANCEL_SYMBOL) return CANCEL_SYMBOL
+    if (line.trim().length > 0) {
+      first = line
+      break
+    }
+  }
+
+  if (!first.trimStart().startsWith(BEGIN_MARKER)) return first.trim()
+
+  // Escaped-PEM pasted as one line (contains both BEGIN and END markers and
+  // no real newlines) bypasses block mode entirely.
+  if (END_MARKER_INLINE_RE.test(first)) return first.trim()
+
+  const lines: string[] = [first.trimEnd()]
+  while (true) {
+    const line = await readLine()
+    if (line === CANCEL_SYMBOL) return CANCEL_SYMBOL
+    const trimmed = line.trimEnd()
+    lines.push(trimmed)
+    if (END_MARKER_RE.test(trimmed)) break
+  }
+  return `${lines.join('\n')}\n`
+}
+
+export async function resolvePrivateKeyInput(input: string): Promise<string> {
+  const unescaped = input.includes('\\n') && !input.includes('\n') ? input.replace(/\\n/g, '\n') : input
+  if (unescaped.includes('-----BEGIN') && unescaped.includes('PRIVATE KEY-----')) return unescaped
+  return await readFile(input, 'utf8')
+}
+
+type StdinLineReader = {
+  next: ReadLineFn
+  close: () => void
+}
+
+function createStdinLineReader(): StdinLineReader {
+  return createReadlineLineReader(process.stdin)
+}
+
+export function createReadlineLineReader(input: NodeJS.ReadableStream | Readable): StdinLineReader {
+  const rl: Interface = createInterface({ input, terminal: false })
+  const queue: string[] = []
+  const waiters: ((value: string | typeof CANCEL_SYMBOL) => void)[] = []
+  let closed = false
+
+  rl.on('line', (line) => {
+    const waiter = waiters.shift()
+    if (waiter) waiter(line)
+    else queue.push(line)
+  })
+  rl.on('close', () => {
+    closed = true
+    for (const w of waiters.splice(0)) w(CANCEL_SYMBOL)
+  })
+
+  const next: ReadLineFn = () =>
+    new Promise((resolve) => {
+      const queued = queue.shift()
+      if (queued !== undefined) {
+        resolve(queued)
+        return
+      }
+      if (closed) {
+        resolve(CANCEL_SYMBOL)
+        return
+      }
+      waiters.push(resolve)
+    })
+
+  return {
+    next,
+    close: () => rl.close(),
+  }
+}
+
+export { isCancel }


### PR DESCRIPTION
## Problem

When an operator pastes a real GitHub App private key into the auth prompt during `typeclaw init` or `typeclaw channel`, only the first line was captured. The prompt used `text()` from `@clack/prompts`, which treats the first newline in the paste as Enter and submits immediately. The captured value was `-----BEGIN RSA PRIVATE KEY-----` — the header line — which the downstream resolver treated as a filesystem path and threw ENOENT.

## What this PR does

**New file `src/cli/prompt-pem.ts`** exports `promptPrivateKeyPem(message)` and a pure helper `readPrivateKeyFromLines(readLine)`.

- Uses `node:readline` to read stdin line by line instead of clack's char-buffered `text()`.
- If the first non-empty line does not start with `-----BEGIN`, returns it as-is (single-line path or escaped PEM).
- If the first line contains both `BEGIN` and `END` markers, treats it as an inline escaped PEM and returns.
- Otherwise enters "block mode" and accumulates lines until a line matches the END marker pattern.
- Handles CRLF (strips trailing `\r`), skips leading blank lines (stray Enter before paste).
- Returns `CANCEL_SYMBOL` on stdin close.

`resolvePrivateKeyInput()` then: real PEM → pass through; escaped single-line with literal `\n` → unescape; otherwise → read from disk.

**`src/cli/channel.ts` and `src/cli/init.ts`** both call `promptPrivateKeyPem()` instead of `text()` and drop the now-dead private resolver helpers and the `readFile` import.

## Tests

New file `src/cli/prompt-pem.test.ts` — 16 tests covering:

- Single-line path passthrough
- Single-line escaped PEM passthrough
- Multi-line PEM block capture (the bug)
- Leading blank lines before paste
- RSA, EC, and generic PKCS#8 `PRIVATE KEY` headers
- CRLF line endings
- Cancellation mid-block and pre-input
- `resolvePrivateKeyInput`: real PEM, escaped PEM, mixed multi-line + literal `\n` (no unescape), file-path read, ENOENT
- `createReadlineLineReader`: end-to-end with Readable stream + queueing

Full suite: 5680 pass, 0 fail. Typecheck clean. Lint: only pre-existing warnings on unrelated files.

## Files changed

| File | Change |
|---|---|
| `src/cli/prompt-pem.ts` | New. Line-buffered PEM prompt + resolver. |
| `src/cli/prompt-pem.test.ts` | New. 16 tests. |
| `src/cli/channel.ts` | +7 −19. Uses `promptPrivateKeyPem`, removes dead resolver helpers. |
| `src/cli/init.ts` | +4 −13. Same. |

## Review notes

- `readPrivateKeyFromLines` in `src/cli/prompt-pem.ts` is the primary read. The state machine has three branches (passthrough, inline-escaped, block mode); the block-terminator regex `/^-----END [A-Z0-9 ]*PRIVATE KEY-----\s*$/` gates multi-line accumulation.
- The leading-blank-line skip handles the common case where the operator hits Enter once before pasting; without it, the first "line" seen is an empty string and the state machine exits early.
- `resolvePrivateKeyInput` deliberately does not unescape when the input spans multiple real lines with literal `\n` — only single-line `\n`-escaped PEMs are unescaped. A test pins this behavior.