### PR TITLE
compose: skip underscore-prefixed agent directories

### DIFF
--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -119,7 +119,7 @@ typeclaw compose doctor
 typeclaw compose doctor --fix --only docker,config
 ```
 
-Thin loop over per-agent commands across every immediate subdirectory of cwd. No shared lifecycle.
+Thin loop over per-agent commands across every immediate subdirectory of cwd. Subdirectories whose name starts with `.` or `_` are skipped, so you can park disabled or in-progress agents (e.g. `_archived-coder/`) next to live ones without compose touching them. No shared lifecycle.
 
 ## Doctor
 

--- a/src/compose/discover.test.ts
+++ b/src/compose/discover.test.ts
@@ -50,6 +50,14 @@ describe('discoverAgents', () => {
     expect(discoverAgents(root).map((a) => a.name)).toEqual(['coder'])
   })
 
+  test('skips underscore-prefixed directories', async () => {
+    await makeAgent(root, 'coder')
+    await makeAgent(root, '_archived-coder')
+    await makeAgent(root, '_wip')
+
+    expect(discoverAgents(root).map((a) => a.name)).toEqual(['coder'])
+  })
+
   test('ignores files at the compose root, even if named typeclaw.json', async () => {
     await writeFile(join(root, 'typeclaw.json'), '{}\n')
     await makeAgent(root, 'coder')

--- a/src/compose/discover.ts
+++ b/src/compose/discover.ts
@@ -15,6 +15,10 @@ export type AgentEntry = {
 // node_modules-style hidden dirs are not skipped because they don't match the
 // dot-prefix rule, but they also won't pass the typeclaw.json filter).
 //
+// Underscore-prefixed names are also skipped so operators can park a disabled
+// or in-progress agent next to live ones (e.g. `_archived-coder/`) without
+// compose touching it.
+//
 // Returns an empty array when rootCwd doesn't exist or is empty — discovery is
 // not the place to fail; the caller decides what to do with zero agents.
 //
@@ -33,6 +37,7 @@ export function discoverAgents(rootCwd: string): AgentEntry[] {
   for (const entry of entries) {
     if (!entry.isDir) continue
     if (entry.name.startsWith('.')) continue
+    if (entry.name.startsWith('_')) continue
     const cwd = join(root, entry.name)
     if (!isInitialized(cwd)) continue
     agents.push({ name: entry.name, cwd, containerName: containerNameFromCwd(cwd) })


### PR DESCRIPTION
## Motivation

`discoverAgents()` already skips `.`-prefixed subdirectories. Operators had no equivalent escape hatch for directories that are disabled, archived, or in-progress — the only options were to move the folder out of the compose root, or use a `.`-prefix (which clashes with OS hidden-file conventions).

Adding `_`-prefix skipping mirrors the existing dot convention and matches how several tooling ecosystems mark "ignore this" (Jekyll `_drafts/`, Next.js `_internal`, etc.). An operator can now park `_archived-coder/` or `_wip-assistant/` next to live agents without `typeclaw compose start/stop/restart/status/logs/usage` touching them.

## Change

- `src/compose/discover.ts` — adds `if (entry.name.startsWith('_')) continue` to the one-depth scanner loop, immediately after the existing dot-prefix skip. Block comment updated to document the rationale.
- `src/compose/discover.test.ts` — new test `skips underscore-prefixed directories`: creates `coder`, `_archived-coder`, `_wip` and asserts only `coder` is discovered.
- `docs/content/docs/reference/cli.mdx` — Compose section updated to note both `.` and `_` prefixed subdirs are skipped, with the `_archived-coder/` example.

Purely additive filtering. A directory still needs `typeclaw.json` to qualify as an agent target, so no existing layout is affected unless it intentionally uses an `_` prefix.

## Verification

```
bun run typecheck    ✓  (0 errors)
bun run lint         ✓  (0 new errors)
bun run format:check ✓
bun run test         ✓  (5665/5665 pass, new test locks the behavior)
```