### PR TITLE
skills: post PR reviews via gh api --input to keep backticks intact

### DIFF
--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -36,21 +36,22 @@ When an incoming message says **"requested your review on PR #N"** (or "requeste
    gh pr view <N> --repo owner/repo --json title,body,baseRefName,headRefOid,files
    ```
 
-2. **Submit a multi-comment review** in one API call. `comments[]` accepts line-level entries; each one lands on the diff exactly like a human reviewer's inline comment:
+2. **Submit a multi-comment review** in one API call by piping a JSON payload to `gh api --input -`. `comments[]` accepts line-level entries; each one lands on the diff exactly like a human reviewer's inline comment:
 
    ```sh
-   gh api -X POST /repos/owner/repo/pulls/<N>/reviews \
-     -F event=COMMENT \
-     -f body="Overall: looks good with a few nits." \
-     -F 'comments[][path]=src/foo.ts' \
-     -F 'comments[][line]=42' \
-     -F 'comments[][side]=RIGHT' \
-     -F 'comments[][body]=nit: prefer `const` here.' \
-     -F 'comments[][path]=src/bar.ts' \
-     -F 'comments[][line]=10' \
-     -F 'comments[][side]=RIGHT' \
-     -F 'comments[][body]=Consider extracting this branch into a helper.'
+   cat <<'JSON' | gh api -X POST /repos/owner/repo/pulls/<N>/reviews --input -
+   {
+     "event": "COMMENT",
+     "body": "Overall: looks good with a few nits.",
+     "comments": [
+       { "path": "src/foo.ts", "line": 42, "side": "RIGHT", "body": "nit: prefer `const` here." },
+       { "path": "src/bar.ts", "line": 10, "side": "RIGHT", "body": "Consider extracting this branch into a helper." }
+     ]
+   }
+   JSON
    ```
+
+   **Always use `--input -` with a quoted heredoc (`<<'JSON'`) for review bodies.** Do **not** use `-f body=...` or `-F 'comments[][body]=...'`: those go through shell argument parsing, so backticks (\`) trigger command substitution and have to be backslash-escaped, which leaks the literal `\` into the rendered comment. The quoted heredoc passes the JSON through untouched — backticks, newlines, and `${...}` all survive verbatim. The same applies to any other `gh api` POST whose body contains backticks, embedded newlines, or shell metacharacters.
 
 3. **Then** post a one-line summary with `channel_reply` so the conversation has a human-readable trace pointing at the review.
 


### PR DESCRIPTION
## Problem

When the typeclaw agent posts a GitHub pull request review that contains inline code spans, the rendered output on GitHub showed a stray backslash before every backtick, and literal `\n\n` strings where paragraph breaks should appear. You can see the broken artifact here:

https://github.com/typeclaw/typeclaw/pull/416#pullrequestreview-4373362271

The root cause is in the `typeclaw-channel-github` skill. The skill's examples taught the agent to post review bodies and comment bodies using `gh api -F` and `-f` flags:

```sh
gh api -X POST .../reviews \
  -F 'comments[][body]=nit: prefer `const` here.' \
  -f body='Two issues below.'
```

Both `-f` and `-F` route the value through shell argument parsing. The shell sees unescaped backticks in the string and tries to execute them as command substitution. The agent defensively backslash-escapes every backtick before constructing the shell command. `gh api` then faithfully forwards the literal backslash to GitHub's API, which stores and renders it literally.

The newline corruption follows the same mechanism: passing a newline via `-f` sends the literal characters `\n` rather than a real line break.

## What this PR does

Rewrites the review-posting example in `src/skills/typeclaw-channel-github/SKILL.md` to pipe a JSON payload via `gh api --input -` from a single-quoted heredoc:

```sh
cat <<'JSON' | gh api -X POST repos/{owner}/{repo}/pulls/{pull_number}/reviews --input -
{
  "body": "Two issues below.",
  "event": "COMMENT",
  "comments": [
    {
      "path": "src/foo.ts",
      "position": 4,
      "body": "nit: prefer `const` here."
    }
  ]
}
JSON
```

The heredoc delimiter must be quoted — `<<'JSON'`, not `<<JSON`. An unquoted heredoc is subject to the same shell interpolation that broke the original: backticks inside the body would be treated as command substitution and the agent would have to escape them again, reintroducing the bug. A quoted heredoc is not interpolated at all — backticks, `${...}`, and embedded newlines reach the API verbatim.

Also added a warning paragraph in the skill explicitly telling the agent not to fall back to `-f` or `-F` for any `gh api` POST whose body contains backticks, newlines, or shell metacharacters.

## Tests

This change is documentation only (`SKILL.md`). No new test files.

Pre-commit checks on the branch all pass:
- `bun run typecheck` — clean.
- `bun run lint` — 60 pre-existing warnings, 0 errors, none on the changed file.
- `bun run format` — clean.
- `bun run test` — 5665 pass, 0 fail.

## Files changed

| File | Change |
|---|---|
| `src/skills/typeclaw-channel-github/SKILL.md` | +13 −12. Replace `-f`/`-F` examples with `--input -` + quoted heredoc. Add warning. |

## Review notes

- The load-bearing detail is the quoted heredoc. The delimiter in the skill example reads `<<'JSON'` — do not modernize this to `<<JSON`. An unquoted heredoc re-introduces the interpolation that caused the original bug.
- The fix is intentionally minimal: only the example that produces the most shell-metacharacter-rich output (review body + comment body) was the trigger. The rest of the skill's read-only `gh api GET` calls use `-q` with jq expressions, which are safe as-is.
- Follow-up: if similar rendering artifacts appear in other channel skills (Discord, Slack) that construct message bodies via shell flags, the same `--input -` + quoted-heredoc pattern applies.