### PR TITLE
docs: add typeclaw compose reference page (beta)

### DIFF
--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -119,7 +119,7 @@ typeclaw compose doctor
 typeclaw compose doctor --fix --only docker,config
 ```
 
-Thin loop over per-agent commands across every immediate subdirectory of cwd. Subdirectories whose name starts with `.` or `_` are skipped, so you can park disabled or in-progress agents (e.g. `_archived-coder/`) next to live ones without compose touching them. No shared lifecycle.
+Thin loop over per-agent commands across every immediate subdirectory of cwd. Subdirectories whose name starts with `.` or `_` are skipped, so you can park disabled or in-progress agents (e.g. `_archived-coder/`) next to live ones without compose touching them. No shared lifecycle. Beta — see [/reference/compose](/docs/reference/compose) for the full surface.
 
 ## Doctor
 

--- a/docs/content/docs/reference/compose.mdx
+++ b/docs/content/docs/reference/compose.mdx
@@ -65,13 +65,13 @@ Agents without a running container are skipped with a `compose: skipping <name> 
 
 ### `doctor`
 
-| Flag              | Default | Effect                                                                   |
-| ----------------- | ------- | ------------------------------------------------------------------------ |
-| `-v`, `--verbose` | `false` | show per-check details                                                   |
-| `--json`          | `false` | emit the full report as JSON                                             |
-| `--fix`           | `false` | attempt per-agent auto-fixes and commit changes inside each agent folder |
-| `--only <a,b,c>`  | (none)  | comma-separated category filter forwarded to each agent's `doctor` run   |
-| `--shallow`       | `false` | run cross-agent checks only; skip per-agent `doctor` runs                |
+| Flag              | Default | Effect                                                                                                                                                  |
+| ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-v`, `--verbose` | `false` | show per-check details                                                                                                                                  |
+| `--json`          | `false` | emit the full report as JSON                                                                                                                            |
+| `--fix`           | `false` | attempt per-agent auto-fixes; on success, `git add` + `git commit` the changed paths inside each agent folder (skipped if the folder is not a git repo) |
+| `--only <a,b,c>`  | (none)  | comma-separated category filter forwarded to each agent's `doctor` run                                                                                  |
+| `--shallow`       | `false` | run cross-agent checks only; skip per-agent `doctor` runs                                                                                               |
 
 `status`, `stop` take no flags.
 
@@ -79,10 +79,10 @@ Agents without a running container are skipped with a `compose: skipping <name> 
 
 Beyond fanning out per-agent `doctor`, `compose doctor` runs whole-fleet checks:
 
-| Check                                  | Status on conflict | Detects                                                                          |
-| -------------------------------------- | ------------------ | -------------------------------------------------------------------------------- |
-| `compose.no-port-collisions`           | `warning`          | two or more agents declaring the same `typeclaw.json#port`                       |
-| `compose.no-container-name-collisions` | `error`            | two folders hashing to the same Docker container name (folder paths must differ) |
+| Check                                  | Status on conflict | Detects                                                               |
+| -------------------------------------- | ------------------ | --------------------------------------------------------------------- |
+| `compose.no-port-collisions`           | `warning`          | two or more agents declaring the same `typeclaw.json#port`            |
+| `compose.no-container-name-collisions` | `error`            | two different agent folders hashing to the same Docker container name |
 
 Port collisions are warnings, not errors: `start` resolves them at runtime by falling back to ephemeral ports per agent. Container-name collisions are errors: Docker enforces unique names, and a collision means one agent will fail to start until you rename a folder.
 

--- a/docs/content/docs/reference/compose.mdx
+++ b/docs/content/docs/reference/compose.mdx
@@ -1,0 +1,125 @@
+---
+title: typeclaw compose
+description: Fan host-stage commands out across every agent folder in cwd
+icon: Layers
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+<Callout type="warn" title="Beta">
+  `typeclaw compose` is beta. Flags, output format, and exit-code semantics may change between minor releases. Pin your
+  typeclaw version if you script against it.
+</Callout>
+
+`compose` is a thin fan-out wrapper around the per-agent host-stage commands. It discovers every immediate subdirectory of cwd that contains a `typeclaw.json`, runs the matching per-agent command against each one in parallel, and aggregates results.
+
+There is no shared lifecycle, no "compose project," and no inter-agent coordination at runtime. Each agent keeps its own container, port, mounts, env file, and config. `compose` is sugar over `for d in */; do (cd "$d" && typeclaw <cmd>); done` — with a single progress board, deterministic ordering, and per-agent failure isolation.
+
+## Discovery
+
+Cwd is scanned **one directory deep**. A subdirectory is treated as an agent when:
+
+- the name does not start with `.` (skips `.git/`, `.vscode/`, etc.)
+- the name does not start with `_` (park disabled or in-progress agents as `_archived-coder/`, `_wip-foo/` without compose touching them)
+- the directory contains a `typeclaw.json`
+
+Agents are sorted by folder name so output across `start` / `stop` / `status` / `restart` / `logs` is stable regardless of filesystem readdir order. When zero agents are discovered, every subcommand exits 0 with a `No typeclaw agents found in immediate subdirectories of cwd.` notice — discovery is not a failure.
+
+## Subcommands
+
+| Command                    | Per-agent equivalent | Parallel | Notes                                                                                       |
+| -------------------------- | -------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `typeclaw compose start`   | `typeclaw start`     | yes      | host port collisions fall back to ephemeral per agent                                       |
+| `typeclaw compose stop`    | `typeclaw stop`      | yes      | already-stopped agents report `not running`, not failure                                    |
+| `typeclaw compose restart` | `typeclaw restart`   | yes      | `stop` then `start` per agent; surfaces both phases on the progress board                   |
+| `typeclaw compose status`  | (inspects Docker)    | yes      | running / stopped / absent + resolved host port for running agents                          |
+| `typeclaw compose logs`    | `typeclaw logs`      | yes      | multiplexed; each line prefixed with the agent name and a deterministic color               |
+| `typeclaw compose usage`   | `typeclaw usage`     | yes      | aggregates per-agent token usage; one corrupt `sessions/` dir does not blank out the report |
+| `typeclaw compose doctor`  | `typeclaw doctor`    | yes      | per-agent `doctor` plus cross-agent checks (port collisions, container-name collisions)     |
+
+## Flags
+
+### `start` / `restart`
+
+| Flag         | Default                    | Effect                                                                               |
+| ------------ | -------------------------- | ------------------------------------------------------------------------------------ |
+| `--port <n>` | each agent's `config.port` | preferred host port for every agent; per-agent bind conflicts fall back to ephemeral |
+| `--build`    | `false`                    | force-regenerate each Dockerfile from the template and rebuild before starting       |
+
+### `logs`
+
+| Flag                    | Default | Effect                                                                                       |
+| ----------------------- | ------- | -------------------------------------------------------------------------------------------- |
+| `-f`, `--follow`        | `false` | stream new log output as it arrives                                                          |
+| `-n`, `--tail <N\|all>` | (none)  | show only the last `N` lines per agent (or `all`); non-negative integer or the literal `all` |
+
+Agents without a running container are skipped with a `compose: skipping <name> (container not running)` notice on stderr. Lines arriving at the same time from multiple agents are interleaved at line boundaries — partial lines are buffered, never shredded mid-character.
+
+### `usage`
+
+| Flag      | Default | Effect                                                               |
+| --------- | ------- | -------------------------------------------------------------------- |
+| `--since` | (none)  | ISO date or relative duration (`today`, `7d`, `30d`)                 |
+| `--until` | (none)  | ISO date upper bound, exclusive                                      |
+| `--json`  | `false` | emit the aggregated report as JSON (one object covering every agent) |
+
+### `doctor`
+
+| Flag              | Default | Effect                                                                   |
+| ----------------- | ------- | ------------------------------------------------------------------------ |
+| `-v`, `--verbose` | `false` | show per-check details                                                   |
+| `--json`          | `false` | emit the full report as JSON                                             |
+| `--fix`           | `false` | attempt per-agent auto-fixes and commit changes inside each agent folder |
+| `--only <a,b,c>`  | (none)  | comma-separated category filter forwarded to each agent's `doctor` run   |
+| `--shallow`       | `false` | run cross-agent checks only; skip per-agent `doctor` runs                |
+
+`status`, `stop` take no flags.
+
+## Cross-agent checks (`compose doctor`)
+
+Beyond fanning out per-agent `doctor`, `compose doctor` runs whole-fleet checks:
+
+| Check                                  | Status on conflict | Detects                                                                          |
+| -------------------------------------- | ------------------ | -------------------------------------------------------------------------------- |
+| `compose.no-port-collisions`           | `warning`          | two or more agents declaring the same `typeclaw.json#port`                       |
+| `compose.no-container-name-collisions` | `error`            | two folders hashing to the same Docker container name (folder paths must differ) |
+
+Port collisions are warnings, not errors: `start` resolves them at runtime by falling back to ephemeral ports per agent. Container-name collisions are errors: Docker enforces unique names, and a collision means one agent will fail to start until you rename a folder.
+
+## Exit codes
+
+| Code | Meaning                                                                                                       |
+| ---- | ------------------------------------------------------------------------------------------------------------- |
+| `0`  | every agent succeeded, or zero agents were discovered                                                         |
+| `1`  | at least one agent failed (the progress board shows which); for `logs`, a non-cancelled child exited non-zero |
+| `2`  | invalid flag value (e.g. `--tail` not a non-negative integer or `all`)                                        |
+
+Sigint/sigterm during `logs --follow` shuts every child `docker logs` down cleanly and exits 0; only real per-child failures bubble up.
+
+## Layout
+
+```
+~/agents/
+├── alice/           # typeclaw agent
+│   ├── typeclaw.json
+│   └── ...
+├── bob/             # typeclaw agent
+│   ├── typeclaw.json
+│   └── ...
+├── _archived-coder/ # skipped (leading underscore)
+│   └── typeclaw.json
+└── .git/            # skipped (leading dot)
+```
+
+From `~/agents/`:
+
+```sh
+typeclaw compose start            # starts alice and bob in parallel
+typeclaw compose logs -f          # streams alice and bob's docker logs, interleaved
+typeclaw compose doctor --shallow # cross-agent checks only, fast
+```
+
+## Related
+
+- Per-agent commands: [/reference/cli](/docs/reference/cli)
+- Port and container-name mechanics: [/concepts/architecture](/docs/concepts/architecture)

--- a/docs/content/docs/reference/meta.json
+++ b/docs/content/docs/reference/meta.json
@@ -10,6 +10,7 @@
     "permissions",
     "channel-adapters",
     "tunnel-providers",
+    "compose",
     "plugin-api",
     "bundled-plugins",
     "stream-targets",


### PR DESCRIPTION
## Summary

Adds a full reference page for `typeclaw compose` at `/reference/compose` and wires it into the sidebar and the existing CLI reference.

The page is marked **Beta** via a fumadocs `Callout` at the top because flags, output format, and exit codes may change between minor releases — the compose surface is still settling.

## Changes

### `docs/content/docs/reference/compose.mdx` (new, 125 lines)

- **Beta callout** — explains that the CLI surface may change between minor releases.
- **Framing paragraph** — positions compose as a thin fan-out wrapper with no shared lifecycle or compose project.
- **Discovery rules** — one-depth scan, skips dot-prefixed (`.git`, `.vscode`) and underscore-prefixed (`_archived-coder`) directories, requires `typeclaw.json`, deterministic name-sort, exits 0 with a notice when no agents are found.
- **Subcommands table** — start / stop / restart / status / logs / usage / doctor with per-agent equivalent and notes (parallel execution, ephemeral-port fallback, etc.).
- **Flags subsections** — per-subcommand flag tables (start/restart, logs, usage, doctor) with default + effect columns. `status` and `stop` noted as no-flag.
- **Cross-agent doctor checks** — `compose.no-port-collisions` (warning, runtime falls back to ephemeral) and `compose.no-container-name-collisions` (error, Docker enforces uniqueness).
- **Exit codes table** — 0 / 1 / 2 with semantics, plus a note on SIGINT/SIGTERM during `logs --follow`.
- **Sample layout** — shows `_archived-coder/` and `.git/` being skipped, plus three example invocations.
- **Related links** — cross-links to `/reference/cli` and `/concepts/architecture`.

### `docs/content/docs/reference/meta.json` (+1 line)

Inserts `"compose"` between `"tunnel-providers"` and `"plugin-api"` so the sidebar entry appears in the right position.

### `docs/content/docs/reference/cli.mdx` (+1 line)

Appends "Beta — see /reference/compose for the full surface" to the existing Compose blurb so the new page is discoverable from the CLI reference.

## Why beta?

The `typeclaw compose` CLI was added in the previous patch. The compose surface is functional but intentionally not frozen — subcommand flags and exit-code semantics are likely to evolve as the feature matures. Marking it beta in the docs signals this to users before they build automation around it.

## Verification

```
bun install          ✓ clean
bun run lint         ✓ 0 errors (oxlint)
bun run format:check ✓ clean (oxfmt)
bun run build        ✓ 42 static pages (was 41)
```

Generated output confirmed:

- `.next/server/app/docs/reference/compose.{html,rsc,meta}` exist.
- "Beta" appears twice in the rendered HTML (callout title + table cell).
- All 7 `compose <subcommand>` strings appear in rendered output.
- Cross-agent check names (`compose.no-port-collisions`, `compose.no-container-name-collisions`) appear in rendered output.

No CI workflow exists for docs lint/format/build on this repo; the parent repo's `bun run typecheck` excludes the docs tree per `docs/README.md`. The manual build run above was the verification gate.

## Review notes

- Content-only change. No new components — the `Callout` with `type="warn"` is already used elsewhere in the fumadocs site.
- The discovery-rules section mirrors the implementation in `src/compose/discover.ts` (dot-skip added at init, underscore-skip added in commit `379fac2`). If those rules change, this page needs updating.
- The cross-agent doctor check table describes runtime behavior, not config — there are no new `typeclaw.json` fields introduced here.