### PR TITLE
docs: fix terminal layout shift and rename docker column to docker-first

### DIFF
--- a/docs/src/app/_components/animated-terminal.tsx
+++ b/docs/src/app/_components/animated-terminal.tsx
@@ -59,12 +59,14 @@ export function AnimatedTerminal({ variant = 'default', title = 'my-agent', clas
 
   let remaining = chars
   const rendered: Array<{ text: string; className: string; key: number }> = []
+  const ghost: Array<{ text: string; key: number }> = []
   for (let i = 0; i < SCRIPT.length; i++) {
     const seg = SCRIPT[i]
-    if (remaining <= 0) break
-    const slice = seg.text.slice(0, remaining)
-    rendered.push({ text: slice, className: seg.className, key: i })
-    remaining -= slice.length
+    const visible = remaining > 0 ? seg.text.slice(0, remaining) : ''
+    const hidden = seg.text.slice(visible.length)
+    if (visible) rendered.push({ text: visible, className: seg.className, key: i })
+    if (hidden) ghost.push({ text: hidden, key: i })
+    remaining -= visible.length
   }
 
   const isDone = chars >= TOTAL_CHARS
@@ -103,6 +105,11 @@ export function AnimatedTerminal({ variant = 'default', title = 'my-agent', clas
             }`}
             style={{ height: '1em' }}
           />
+          {ghost.map((seg) => (
+            <span key={`ghost-${seg.key}`} aria-hidden className="text-transparent">
+              {seg.text}
+            </span>
+          ))}
         </code>
       </pre>
     </div>

--- a/docs/src/app/_components/data.ts
+++ b/docs/src/app/_components/data.ts
@@ -46,7 +46,7 @@ export interface Competitor {
   strength: string
   tradeoff: string
   lang: string
-  dockerSandboxed: CompetitorScore
+  dockerFirst: CompetitorScore
   selfImproving: CompetitorScore
   multiChannel: CompetitorScore
   fullFeaturedPlugins: CompetitorScore
@@ -60,7 +60,7 @@ export const COMPETITORS: Competitor[] = [
     strength: 'Feature-rich',
     tradeoff: 'Heavy',
     lang: 'TypeScript',
-    dockerSandboxed: true,
+    dockerFirst: true,
     selfImproving: 'partial',
     multiChannel: true,
     fullFeaturedPlugins: true,
@@ -71,7 +71,7 @@ export const COMPETITORS: Competitor[] = [
     strength: 'Simple',
     tradeoff: 'No plugin system',
     lang: 'TypeScript',
-    dockerSandboxed: false,
+    dockerFirst: false,
     selfImproving: false,
     multiChannel: false,
     fullFeaturedPlugins: false,
@@ -82,7 +82,7 @@ export const COMPETITORS: Competitor[] = [
     strength: 'Fast',
     tradeoff: 'Plugins live outside the runtime',
     lang: 'Go',
-    dockerSandboxed: false,
+    dockerFirst: false,
     selfImproving: false,
     multiChannel: 'partial',
     fullFeaturedPlugins: 'partial',
@@ -93,7 +93,7 @@ export const COMPETITORS: Competitor[] = [
     strength: 'Light',
     tradeoff: 'Plugins live outside the runtime',
     lang: 'Rust',
-    dockerSandboxed: false,
+    dockerFirst: false,
     selfImproving: false,
     multiChannel: 'partial',
     fullFeaturedPlugins: 'partial',
@@ -104,7 +104,7 @@ export const COMPETITORS: Competitor[] = [
     strength: 'Awesome',
     tradeoff: 'Python',
     lang: 'Python',
-    dockerSandboxed: 'partial',
+    dockerFirst: 'partial',
     selfImproving: true,
     multiChannel: true,
     fullFeaturedPlugins: true,
@@ -115,7 +115,7 @@ export const COMPETITORS: Competitor[] = [
     strength: 'TypeScript end to end',
     tradeoff: 'the answer',
     lang: 'TypeScript',
-    dockerSandboxed: true,
+    dockerFirst: true,
     selfImproving: true,
     multiChannel: true,
     fullFeaturedPlugins: true,

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -179,7 +179,7 @@ function MarketingTable() {
         <thead>
           <tr className="border-b border-zinc-200 text-xs tracking-wider text-zinc-500 uppercase dark:border-white/[0.06] dark:text-zinc-500">
             <th className="px-4 py-4 font-medium">Runtime</th>
-            <th className="px-4 py-4 text-center font-medium">Docker-sandboxed</th>
+            <th className="px-4 py-4 text-center font-medium">Docker-first</th>
             <th className="px-4 py-4 text-center font-medium">Self-improving</th>
             <th className="px-4 py-4 text-center font-medium">Multi-channel</th>
             <th className="px-4 py-4 text-center font-medium">Full-featured plugins</th>
@@ -210,7 +210,7 @@ function MarketingTable() {
                 <div className="mt-0.5 font-mono text-[11px] text-zinc-500 dark:text-zinc-500">{r.lang}</div>
               </td>
               <td className="px-4 py-5 text-center">
-                <CheckCell value={r.dockerSandboxed} />
+                <CheckCell value={r.dockerFirst} />
               </td>
               <td className="px-4 py-5 text-center">
                 <CheckCell value={r.selfImproving} />


### PR DESCRIPTION
## Problem

Two small follow-ups from #420, both surfaced reviewing the live page:

1. **The animated terminal shifted layout on every keystroke.** The `<pre>` grew from 1 line of content to 13 lines as the typewriter ran. Each character pushed the sections below it (`How it compares`, `Ready to try it?`, footer) down by a row, then back up when the loop reset. Distracting once you noticed it.
2. **The first comparison column read defensive.** `Docker-sandboxed` describes a mitigation. `Docker-first` describes a design stance — typeclaw treats Docker as the deployment target, not a one-of-many backend. Same column, sharper claim.

## What this PR does

Two atomic commits:

1. **`25e9245` docs: stop the animated terminal from shifting layout as it types**
   The `<pre>` now always renders the full script: typed prefix in its normal colors, the cursor, then the un-typed remainder as `text-transparent`. The cursor sits between visible and invisible characters. The bounding box is constant from frame 0 onward.

   Verified at 1440×900: `pre` height is `272.375 px` at fresh load, mid-typing, and after the cycle completes. Layout below the terminal stays put as the typewriter runs.

2. **`ebecd76` docs: rename the docker comparison column to docker-first**
   Renames the visible column header and the underlying `Competitor` schema field (`dockerSandboxed` → `dockerFirst`) so the data shape matches the rendered label. No score changes; per-competitor cell values stay the same.

## Files changed

| File | Change |
|---|---|
| `docs/src/app/_components/animated-terminal.tsx` | +11 / -4. Renders the un-typed remainder as `text-transparent` so the `pre` bounding box is constant. |
| `docs/src/app/_components/data.ts` | +7 / -7. `dockerSandboxed` → `dockerFirst` on the `Competitor` interface and all six competitor rows. |
| `docs/src/app/page.tsx` | +2 / -2. Column header `Docker-sandboxed` → `Docker-first`; cell read `r.dockerSandboxed` → `r.dockerFirst`. |

## Verification

```
bun run typecheck    ✓  (0 errors)
bun run lint         ✓  (60 pre-existing warnings, 0 errors, 0 new)
bun run format:check ✓
bun run test         ✓  (5681/5681 pass, no test changes)
bun run build        ✓  (41 routes prerendered)
```

Terminal height measured across the typing/pause/reset cycle stays at `272.375 px`. Visual diff of the comparison table verified: column header now reads `DOCKER-FIRST`, checkmark/X cells under it unchanged.

## Review notes

- The `text-transparent` ghost in `animated-terminal.tsx` is the load-bearing part. It must stay rendered (`aria-hidden`, color transparent) — removing it brings the layout shift back. The cursor is positioned between the visible and invisible spans deliberately so it sits at the "typing position" rather than at the end of the full block.
- `data.ts` still owns the `CompetitorScore` schema. If a future PR adds a real competitor (Mastra, Vercel AI SDK, etc.), the `dockerFirst` field gets the same treatment as the other five columns.
- No copy in the marketing prose (`How it compares` heading, subtitle, Notes cells) references `Docker-sandboxed` — the rename is fully contained to the column header + the schema field.

## Related

- #420 — the redesign this polishes
