### PR TITLE
skills: tell the github PR-review agent to skip praise comments

### DIFF
--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -58,6 +58,7 @@ When an incoming message says **"requested your review on PR #N"** (or "requeste
 ### Rules
 
 - Use `event=COMMENT` by default. Use `APPROVE` only when you have high confidence the PR is ready to merge. Use `REQUEST_CHANGES` only when the PR has clear blockers — not for nits.
+- **Only post comments that the author needs to act on.** Do not post praise ("looks good", "nice refactor", "great work"), affirmations of correct code, or restatements of what a line does. If every comment in your review is positive, post a top-level summary via `channel_reply` instead of a review — or skip commenting and just `APPROVE`. Inline comments are for changes, questions, and blockers, not validation.
 - `line` is a line number **in the file**, not a position in the diff. `side: RIGHT` is the new revision (default for additions); `side: LEFT` is the old revision (use for comments on removed lines).
 - For multi-line comments, also set `start_line` and `start_side` (same semantics).
 - If you need to read whole files at the PR's head SHA, use `gh api /repos/owner/repo/contents/<path>?ref=<headRefOid>`.


### PR DESCRIPTION
## Summary

The `typeclaw-channel-github` skill currently tells the agent to do a real code review when GitHub assigns it as a reviewer, but it doesn't say anything about *what* counts as a useful comment. In practice that produces reviews where every inline comment is praise — "looks good", "nice naming", "this is a great refactor" — which is exactly the AI-slop noise that humans skip past in real reviews.

This adds one rule to the skill: inline comments are for things the author needs to act on. Praise, affirmations of correct code, and restatements of what a line does don't belong inline. If the whole review would be positive, the agent should `APPROVE` or post a top-level summary via `channel_reply` — not open empty-noise threads.

## Change

`src/skills/typeclaw-channel-github/SKILL.md`, in the "Reviewing pull requests → Rules" section, immediately after the `event=COMMENT/APPROVE/REQUEST_CHANGES` rule:

> **Only post comments that the author needs to act on.** Do not post praise ("looks good", "nice refactor", "great work"), affirmations of correct code, or restatements of what a line does. If every comment in your review is positive, post a top-level summary via `channel_reply` instead of a review — or skip commenting and just `APPROVE`. Inline comments are for changes, questions, and blockers, not validation.

## Scope

- Markdown-only change to one skill file. No code touched.
- The existing example heredoc (`"Overall: looks good with a few nits."` with a `prefer const` nit and a refactor suggestion) stays as-is — the body field is a summary (allowed) and both inline comments are actionable.
- No new docs page added; the skill is the canonical contract for GitHub channel review behavior (per `AGENTS.md` / `docs/internals/`).

## Checks

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (60 pre-existing warnings, unrelated)
- `bun run format:check` — clean
- `bun run test` — 5686 pass, 0 fail
