### PR TITLE
test-helpers: deflake expectStable mid-duration rejection

### DIFF
--- a/src/test-helpers/wait-for.test.ts
+++ b/src/test-helpers/wait-for.test.ts
@@ -60,12 +60,19 @@ describe('expectStable', () => {
   })
 
   test('rejects when predicate becomes truthy mid-duration', async () => {
-    let flipped = false
-    setTimeout(() => {
-      flipped = true
-    }, 10)
+    // Drive the flip from the polling loop itself rather than a wall-clock
+    // setTimeout — under heavy CI contention (18 parallel workers) a 10ms
+    // timer can be delayed past the 50ms duration, leaving the predicate
+    // falsy and turning the expected rejection into a silent resolve. A
+    // call-counter is deterministic: the third poll flips it, well before
+    // the deadline regardless of scheduler load.
+    let calls = 0
+    const predicate = () => {
+      calls++
+      return calls >= 3
+    }
 
-    await expect(expectStable(() => flipped, { durationMs: 50, description: 'no-event' })).rejects.toThrow(
+    await expect(expectStable(predicate, { durationMs: 50, description: 'no-event' })).rejects.toThrow(
       /no-event became truthy before 50ms elapsed/,
     )
   })


### PR DESCRIPTION
## Summary

The `fix/wait-for-flake` branch eliminates a timing-dependent flake in `expectStable`'s "becomes truthy mid-duration" test. The flake caused a single test failure in CI run [26522181803](https://github.com/typeclaw/typeclaw/actions/runs/26522181803), where a 10ms `setTimeout` was delayed by 14× under parallel-worker contention, turning an expected rejection into a silent resolve.

## What failed and why

The test relied on `setTimeout(() => { flipped = true }, 10)` racing a `durationMs: 50` deadline inside `expectStable`. Under heavy CI contention — 18 parallel workers via `bun test --parallel` — libuv can delay that timer well past 50ms. When it does:

1. The predicate stays falsy for the entire duration.
2. `expectStable` resolves (its contract: predicate stays falsy → resolves).
3. `.rejects.toThrow(...)` fails because the promise resolved instead of rejecting.

The passing run showed the test completing in 10.68ms. The failing run showed 151.30ms — a 14× slowdown consistent with the timer being held off until after the deadline expired.

Increasing the timeout would just widen the race; the fundamental problem is using wall-clock timers at all. Under enough contention, any fixed `setTimeout` can lose.

## What changed

Replace the `setTimeout`-driven flip with a call-counter-driven predicate. The predicate increments a counter on each poll and returns `true` on the third call. Since `expectStable` polls every 5ms, the third call lands at ~10ms regardless of scheduler load — fully deterministic, zero wall-clock dependency.

The observable behavior under test is unchanged: the predicate flips from falsy to truthy during the `durationMs: 50` window, so `expectStable` still rejects with the `/no-event became truthy before 50ms elapsed/` message.

```diff
-  let flipped = false
-  setTimeout(() => {
-    flipped = true
-  }, 10)
+  let calls = 0
+  const predicate = () => {
+    calls++
+    return calls >= 3
+  }

-  await expect(expectStable(() => flipped, { durationMs: 50, description: 'no-event' })).rejects.toThrow(
+  await expect(expectStable(predicate, { durationMs: 50, description: 'no-event' })).rejects.toThrow(
     /no-event became truthy before 50ms elapsed/,
   )
```

## Verification

- **10/10 clean** in isolation.
- **Stress-tested**: 15 concurrent runs (3 parallel × 5 iterations), all pass.
- **Full suite**: 5686 pass / 0 fail.
- `bun run typecheck` — clean.
- `bun run lint` — 0 errors.
- `bun run format:check` — clean.

## Review notes

The only file touched is `src/test-helpers/wait-for.test.ts`. No production code changed, no new dependencies, no timing constants introduced. The fix is structural: the predicate flip is now driven by the poll count, which is controlled by `expectStable` itself, not by an external timer racing the deadline.