### PR TITLE
Add typeclaw update command

### DIFF
--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -133,6 +133,17 @@ typeclaw doctor --only docker,config               # narrow to categories
 
 Categories: `docker`, `config`, `secrets`, `network`, `git`, plus per-plugin checks.
 
+## Update
+
+```sh
+typeclaw update                                    # update the globally installed CLI (auto-detect Bun/npm)
+typeclaw update --manager bun                      # force Bun global update
+typeclaw update --manager npm                      # force npm global update
+typeclaw update --dry-run                          # print the updater command without running it
+```
+
+Auto-detection only trusts known global install layouts. Source checkouts and local `node_modules/typeclaw` installs require an explicit `--manager`.
+
 ## Usage
 
 ```sh

--- a/src/cli/builtins.ts
+++ b/src/cli/builtins.ts
@@ -23,6 +23,7 @@ export const BUILTIN_COMMAND_NAMES = [
   'model',
   'doctor',
   'usage',
+  'update',
   '_hostd',
 ] as const
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -71,6 +71,7 @@ describe('BUILTIN_COMMAND_NAMES exposure', () => {
     expect(BUILTIN_COMMAND_NAMES).toContain('tui')
     expect(BUILTIN_COMMAND_NAMES).toContain('doctor')
     expect(BUILTIN_COMMAND_NAMES).toContain('cron')
+    expect(BUILTIN_COMMAND_NAMES).toContain('update')
     expect(BUILTIN_COMMAND_NAMES).toContain('_hostd')
   })
 })
@@ -118,6 +119,23 @@ describe('typeclaw --help on host stage', () => {
     const { stdout, code } = await runCli(['--help'], dir)
     expect(code).toBe(0)
     expect(stdout).not.toContain('Plugin commands:')
+  })
+})
+
+describe('typeclaw update on host stage', () => {
+  test.concurrent('dry-run prints the selected updater command without hitting the registry', async () => {
+    const dir = await mkAgent()
+    const { stdout, stderr, code } = await runCli(['update', '--manager=bun', '--dry-run'], dir)
+    expect(code).toBe(0)
+    expect(stderr).toBe('')
+    expect(stdout.trim()).toBe('bun update -g typeclaw --latest')
+  })
+
+  test.concurrent('auto mode refuses a source checkout because it cannot prove the global manager', async () => {
+    const dir = await mkAgent()
+    const { stderr, code } = await runCli(['update', '--dry-run'], dir)
+    expect(code).toBe(1)
+    expect(stderr).toContain('Cannot auto-detect how TypeClaw was installed')
   })
 })
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,6 +33,7 @@ const main = defineCommand({
     model: () => import('./model').then((m) => m.modelCommand),
     doctor: () => import('./doctor').then((m) => m.doctorCommand),
     usage: () => import('./usage').then((m) => m.usageCommand),
+    update: () => import('./update').then((m) => m.updateCommand),
     _hostd: () => import('./hostd').then((m) => m.hostdCommand),
   },
 })

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,0 +1,82 @@
+import { defineCommand } from 'citty'
+
+import { formatCommand, planSelfUpdate, type UpdateManagerSelection } from '@/update'
+
+import { c, errorLine, successLine } from './ui'
+
+const MANAGERS = ['auto', 'bun', 'npm'] as const
+
+export const updateCommand = defineCommand({
+  meta: {
+    name: 'update',
+    description: 'update the globally installed typeclaw CLI',
+  },
+  args: {
+    manager: {
+      type: 'string',
+      description: 'package manager to use: auto, bun, or npm',
+      default: 'auto',
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'print the update command without running it',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const manager = parseManager(args.manager)
+    if (manager === null) {
+      console.error(errorLine(`Invalid --manager=${args.manager}. Expected auto, bun, or npm.`))
+      process.exit(2)
+    }
+
+    const plan = planSelfUpdate({ manager })
+    if (!plan.ok) {
+      console.error(errorLine(plan.reason))
+      process.exit(1)
+    }
+
+    const rendered = formatCommand(plan.command)
+    if (args['dry-run']) {
+      process.stdout.write(`${rendered}\n`)
+      return
+    }
+
+    process.stdout.write(`${c.cyan('Updating TypeClaw with:')} ${rendered}\n`)
+    const exitCode = await runUpdateCommand(plan.command)
+    if (exitCode !== 0) {
+      console.error(errorLine(`Update command exited with code ${exitCode}.`))
+      process.exit(exitCode)
+    }
+    process.stdout.write(`${successLine('TypeClaw update command completed.')}\n`)
+    process.stdout.write(`${c.dim('Restart running agent containers to pick up the new CLI runtime.')}\n`)
+  },
+})
+
+function parseManager(value: string | undefined): UpdateManagerSelection | null {
+  if (value === undefined) return 'auto'
+  return (MANAGERS as readonly string[]).includes(value) ? (value as UpdateManagerSelection) : null
+}
+
+async function runUpdateCommand(command: string[]): Promise<number> {
+  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+  if (!bun) {
+    console.error(errorLine('bun runtime not available'))
+    return 1
+  }
+  try {
+    const proc = bun.spawn({
+      cmd: command,
+      stdin: 'inherit',
+      stdout: 'inherit',
+      stderr: 'inherit',
+    })
+    return await proc.exited
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      console.error(errorLine(`${command[0]} not found in $PATH.`))
+      return 127
+    }
+    throw error
+  }
+}

--- a/src/update/index.test.ts
+++ b/src/update/index.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test'
+import { join } from 'node:path'
+
+import { formatCommand, planSelfUpdate, resolveSelfPackageJsonPath } from './index'
+
+describe('planSelfUpdate', () => {
+  test('detects a Bun global install and updates with bun', () => {
+    const packageJsonPath = join('/home/alice', '.bun', 'install', 'global', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'bun',
+      command: ['bun', 'update', '-g', 'typeclaw', '--latest'],
+      detectedFrom: packageJsonPath,
+    })
+  })
+
+  test('detects an npm global install and updates with npm', () => {
+    const packageJsonPath = join('/usr/local/lib', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'npm',
+      command: ['npm', 'install', '-g', 'typeclaw@latest'],
+      detectedFrom: packageJsonPath,
+    })
+  })
+
+  test('refuses local node_modules installs because updating a global package would be wrong', () => {
+    const packageJsonPath = join('/work', 'agent', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+
+    expect(plan).toEqual({
+      ok: false,
+      reason:
+        'Cannot auto-detect how TypeClaw was installed from this checkout. Re-run with --manager=bun or --manager=npm if you want to update a global install.',
+    })
+  })
+
+  test('refuses auto mode from a source checkout because it is not a self update', () => {
+    const packageJsonPath = join('/work', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+
+    expect(plan).toEqual({
+      ok: false,
+      reason:
+        'Cannot auto-detect how TypeClaw was installed from this checkout. Re-run with --manager=bun or --manager=npm if you want to update a global install.',
+    })
+  })
+
+  test('explicit manager overrides source-checkout detection', () => {
+    const packageJsonPath = join('/work', 'typeclaw', 'package.json')
+
+    expect(planSelfUpdate({ manager: 'bun', packageJsonPath })).toEqual({
+      ok: true,
+      manager: 'bun',
+      command: ['bun', 'update', '-g', 'typeclaw', '--latest'],
+      detectedFrom: packageJsonPath,
+    })
+    expect(planSelfUpdate({ manager: 'npm', packageJsonPath })).toEqual({
+      ok: true,
+      manager: 'npm',
+      command: ['npm', 'install', '-g', 'typeclaw@latest'],
+      detectedFrom: packageJsonPath,
+    })
+  })
+})
+
+describe('formatCommand', () => {
+  test('shell-quotes arguments with spaces or shell metacharacters', () => {
+    expect(formatCommand(['npm', 'install', '-g', 'typeclaw@latest'])).toBe('npm install -g typeclaw@latest')
+    expect(formatCommand(['cmd', 'two words', "can't"])).toBe(`cmd 'two words' 'can'\\''t'`)
+  })
+})
+
+describe('resolveSelfPackageJsonPath', () => {
+  test('points at this package manifest', () => {
+    expect(resolveSelfPackageJsonPath()).toEndWith(join('typeclaw', 'package.json'))
+  })
+})

--- a/src/update/index.ts
+++ b/src/update/index.ts
@@ -1,0 +1,68 @@
+import { join } from 'node:path'
+
+export type UpdateManager = 'bun' | 'npm'
+export type UpdateManagerSelection = 'auto' | UpdateManager
+
+export type SelfUpdatePlan =
+  | { ok: true; manager: UpdateManager; command: string[]; detectedFrom: string }
+  | { ok: false; reason: string }
+
+export function resolveSelfPackageJsonPath(): string {
+  return join(import.meta.dir, '..', '..', 'package.json')
+}
+
+export function planSelfUpdate(options: { manager: UpdateManagerSelection; packageJsonPath?: string }): SelfUpdatePlan {
+  const packageJsonPath = options.packageJsonPath ?? resolveSelfPackageJsonPath()
+  const manager = options.manager === 'auto' ? detectInstallManager(packageJsonPath) : options.manager
+  if (manager === null) {
+    return {
+      ok: false,
+      reason:
+        'Cannot auto-detect how TypeClaw was installed from this checkout. Re-run with --manager=bun or --manager=npm if you want to update a global install.',
+    }
+  }
+  return {
+    ok: true,
+    manager,
+    command: commandForManager(manager),
+    detectedFrom: packageJsonPath,
+  }
+}
+
+export function commandForManager(manager: UpdateManager): string[] {
+  switch (manager) {
+    case 'bun':
+      return ['bun', 'update', '-g', 'typeclaw', '--latest']
+    case 'npm':
+      return ['npm', 'install', '-g', 'typeclaw@latest']
+  }
+}
+
+export function formatCommand(command: readonly string[]): string {
+  return command.map(shellQuote).join(' ')
+}
+
+function detectInstallManager(packageJsonPath: string): UpdateManager | null {
+  const parts = packageJsonPath.split(/[\\/]+/).filter(Boolean)
+  const packageJson = parts[parts.length - 1]
+  const packageName = parts[parts.length - 2]
+  const nodeModulesIdx = parts.lastIndexOf('node_modules')
+  if (packageJson !== 'package.json' || packageName !== 'typeclaw' || nodeModulesIdx === -1) return null
+
+  const bunGlobalIdx = parts.lastIndexOf('.bun')
+  if (
+    bunGlobalIdx !== -1 &&
+    parts[bunGlobalIdx + 1] === 'install' &&
+    parts[bunGlobalIdx + 2] === 'global' &&
+    parts[bunGlobalIdx + 3] === 'node_modules'
+  ) {
+    return 'bun'
+  }
+  if (parts[nodeModulesIdx - 1] === 'lib') return 'npm'
+  return null
+}
+
+function shellQuote(arg: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(arg)) return arg
+  return `'${arg.replaceAll("'", "'\\''")}'`
+}


### PR DESCRIPTION
## Summary
- add a host-stage `typeclaw update` command
- support Bun and npm global self-update commands, with conservative auto-detection
- document the command in the CLI reference

## Tests
- `bun run format`
- `bun run typecheck`
- `bun run lint`
- `bun test --parallel src/update/index.test.ts src/cli/index.test.ts`
- `git diff --check --cached`

## Notes
- Real registry mutation was intentionally not tested; covered via `--dry-run` and planner tests.