### PR TITLE
update: auto-detect pnpm and yarn global installs

### DIFF
--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -136,13 +136,15 @@ Categories: `docker`, `config`, `secrets`, `network`, `git`, plus per-plugin che
 ## Update
 
 ```sh
-typeclaw update                                    # update the globally installed CLI (auto-detect Bun/npm)
+typeclaw update                                    # update the globally installed CLI (auto-detect Bun/npm/pnpm/yarn)
 typeclaw update --manager bun                      # force Bun global update
 typeclaw update --manager npm                      # force npm global update
+typeclaw update --manager pnpm                     # force pnpm global update
+typeclaw update --manager yarn                     # force classic Yarn global update
 typeclaw update --dry-run                          # print the updater command without running it
 ```
 
-Auto-detection only trusts known global install layouts. Source checkouts and local `node_modules/typeclaw` installs require an explicit `--manager`.
+Auto-detection only trusts known global install layouts (Bun's `.bun/install/global`, npm's `lib/node_modules`, pnpm's `pnpm/global/<N>/node_modules` / legacy `pnpm-global/<N>/node_modules`, and classic Yarn's `yarn/global/node_modules`). Source checkouts and local `node_modules/typeclaw` installs require an explicit `--manager`.
 
 ## Usage
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -131,6 +131,29 @@ describe('typeclaw update on host stage', () => {
     expect(stdout.trim()).toBe('bun update -g typeclaw --latest')
   })
 
+  test.concurrent('dry-run renders the pnpm command when --manager=pnpm', async () => {
+    const dir = await mkAgent()
+    const { stdout, stderr, code } = await runCli(['update', '--manager=pnpm', '--dry-run'], dir)
+    expect(code).toBe(0)
+    expect(stderr).toBe('')
+    expect(stdout.trim()).toBe('pnpm add -g typeclaw@latest')
+  })
+
+  test.concurrent('dry-run renders the yarn command when --manager=yarn', async () => {
+    const dir = await mkAgent()
+    const { stdout, stderr, code } = await runCli(['update', '--manager=yarn', '--dry-run'], dir)
+    expect(code).toBe(0)
+    expect(stderr).toBe('')
+    expect(stdout.trim()).toBe('yarn global upgrade typeclaw --latest')
+  })
+
+  test.concurrent('rejects unknown --manager values with exit code 2', async () => {
+    const dir = await mkAgent()
+    const { stderr, code } = await runCli(['update', '--manager=cargo', '--dry-run'], dir)
+    expect(code).toBe(2)
+    expect(stderr).toContain('Invalid --manager=cargo')
+  })
+
   test.concurrent('auto mode refuses a source checkout because it cannot prove the global manager', async () => {
     const dir = await mkAgent()
     const { stderr, code } = await runCli(['update', '--dry-run'], dir)

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -4,7 +4,7 @@ import { formatCommand, planSelfUpdate, type UpdateManagerSelection } from '@/up
 
 import { c, errorLine, successLine } from './ui'
 
-const MANAGERS = ['auto', 'bun', 'npm'] as const
+const MANAGERS = ['auto', 'bun', 'npm', 'pnpm', 'yarn'] as const
 
 export const updateCommand = defineCommand({
   meta: {
@@ -14,7 +14,7 @@ export const updateCommand = defineCommand({
   args: {
     manager: {
       type: 'string',
-      description: 'package manager to use: auto, bun, or npm',
+      description: 'package manager to use: auto, bun, npm, pnpm, or yarn',
       default: 'auto',
     },
     'dry-run': {
@@ -26,7 +26,7 @@ export const updateCommand = defineCommand({
   async run({ args }) {
     const manager = parseManager(args.manager)
     if (manager === null) {
-      console.error(errorLine(`Invalid --manager=${args.manager}. Expected auto, bun, or npm.`))
+      console.error(errorLine(`Invalid --manager=${args.manager}. Expected auto, bun, npm, pnpm, or yarn.`))
       process.exit(2)
     }
 

--- a/src/update/index.test.ts
+++ b/src/update/index.test.ts
@@ -3,6 +3,9 @@ import { join } from 'node:path'
 
 import { formatCommand, planSelfUpdate, resolveSelfPackageJsonPath } from './index'
 
+const AUTO_DETECT_FAILURE_REASON =
+  'Cannot auto-detect how TypeClaw was installed from this checkout. Re-run with --manager=bun, --manager=npm, --manager=pnpm, or --manager=yarn if you want to update a global install.'
+
 describe('planSelfUpdate', () => {
   test('detects a Bun global install and updates with bun', () => {
     const packageJsonPath = join('/home/alice', '.bun', 'install', 'global', 'node_modules', 'typeclaw', 'package.json')
@@ -30,6 +33,98 @@ describe('planSelfUpdate', () => {
     })
   })
 
+  test('detects a pnpm macOS global install and updates with pnpm', () => {
+    const packageJsonPath = join(
+      '/Users/alice',
+      'Library',
+      'pnpm',
+      'global',
+      '5',
+      'node_modules',
+      'typeclaw',
+      'package.json',
+    )
+
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'pnpm',
+      command: ['pnpm', 'add', '-g', 'typeclaw@latest'],
+      detectedFrom: packageJsonPath,
+    })
+  })
+
+  test('detects a pnpm Linux global install and updates with pnpm', () => {
+    const packageJsonPath = join(
+      '/home/alice',
+      '.local',
+      'share',
+      'pnpm',
+      'global',
+      '5',
+      'node_modules',
+      'typeclaw',
+      'package.json',
+    )
+
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'pnpm',
+      command: ['pnpm', 'add', '-g', 'typeclaw@latest'],
+      detectedFrom: packageJsonPath,
+    })
+  })
+
+  test('detects a legacy pnpm-global install and updates with pnpm', () => {
+    const packageJsonPath = join('/home/alice', '.pnpm-global', '5', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'pnpm',
+      command: ['pnpm', 'add', '-g', 'typeclaw@latest'],
+      detectedFrom: packageJsonPath,
+    })
+  })
+
+  test('detects a classic yarn user global install and updates with yarn', () => {
+    const packageJsonPath = join('/home/alice', '.config', 'yarn', 'global', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'yarn',
+      command: ['yarn', 'global', 'upgrade', 'typeclaw', '--latest'],
+      detectedFrom: packageJsonPath,
+    })
+  })
+
+  test('detects a classic yarn system global install and updates with yarn', () => {
+    const packageJsonPath = join(
+      '/usr/local/share',
+      '.config',
+      'yarn',
+      'global',
+      'node_modules',
+      'typeclaw',
+      'package.json',
+    )
+
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'yarn',
+      command: ['yarn', 'global', 'upgrade', 'typeclaw', '--latest'],
+      detectedFrom: packageJsonPath,
+    })
+  })
+
   test('refuses local node_modules installs because updating a global package would be wrong', () => {
     const packageJsonPath = join('/work', 'agent', 'node_modules', 'typeclaw', 'package.json')
 
@@ -37,8 +132,7 @@ describe('planSelfUpdate', () => {
 
     expect(plan).toEqual({
       ok: false,
-      reason:
-        'Cannot auto-detect how TypeClaw was installed from this checkout. Re-run with --manager=bun or --manager=npm if you want to update a global install.',
+      reason: AUTO_DETECT_FAILURE_REASON,
     })
   })
 
@@ -49,8 +143,7 @@ describe('planSelfUpdate', () => {
 
     expect(plan).toEqual({
       ok: false,
-      reason:
-        'Cannot auto-detect how TypeClaw was installed from this checkout. Re-run with --manager=bun or --manager=npm if you want to update a global install.',
+      reason: AUTO_DETECT_FAILURE_REASON,
     })
   })
 
@@ -67,6 +160,18 @@ describe('planSelfUpdate', () => {
       ok: true,
       manager: 'npm',
       command: ['npm', 'install', '-g', 'typeclaw@latest'],
+      detectedFrom: packageJsonPath,
+    })
+    expect(planSelfUpdate({ manager: 'pnpm', packageJsonPath })).toEqual({
+      ok: true,
+      manager: 'pnpm',
+      command: ['pnpm', 'add', '-g', 'typeclaw@latest'],
+      detectedFrom: packageJsonPath,
+    })
+    expect(planSelfUpdate({ manager: 'yarn', packageJsonPath })).toEqual({
+      ok: true,
+      manager: 'yarn',
+      command: ['yarn', 'global', 'upgrade', 'typeclaw', '--latest'],
       detectedFrom: packageJsonPath,
     })
   })

--- a/src/update/index.ts
+++ b/src/update/index.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 
-export type UpdateManager = 'bun' | 'npm'
+export type UpdateManager = 'bun' | 'npm' | 'pnpm' | 'yarn'
 export type UpdateManagerSelection = 'auto' | UpdateManager
 
 export type SelfUpdatePlan =
@@ -18,7 +18,7 @@ export function planSelfUpdate(options: { manager: UpdateManagerSelection; packa
     return {
       ok: false,
       reason:
-        'Cannot auto-detect how TypeClaw was installed from this checkout. Re-run with --manager=bun or --manager=npm if you want to update a global install.',
+        'Cannot auto-detect how TypeClaw was installed from this checkout. Re-run with --manager=bun, --manager=npm, --manager=pnpm, or --manager=yarn if you want to update a global install.',
     }
   }
   return {
@@ -35,6 +35,10 @@ export function commandForManager(manager: UpdateManager): string[] {
       return ['bun', 'update', '-g', 'typeclaw', '--latest']
     case 'npm':
       return ['npm', 'install', '-g', 'typeclaw@latest']
+    case 'pnpm':
+      return ['pnpm', 'add', '-g', 'typeclaw@latest']
+    case 'yarn':
+      return ['yarn', 'global', 'upgrade', 'typeclaw', '--latest']
   }
 }
 
@@ -49,6 +53,7 @@ function detectInstallManager(packageJsonPath: string): UpdateManager | null {
   const nodeModulesIdx = parts.lastIndexOf('node_modules')
   if (packageJson !== 'package.json' || packageName !== 'typeclaw' || nodeModulesIdx === -1) return null
 
+  // Bun global: .bun/install/global/node_modules/typeclaw
   const bunGlobalIdx = parts.lastIndexOf('.bun')
   if (
     bunGlobalIdx !== -1 &&
@@ -58,6 +63,19 @@ function detectInstallManager(packageJsonPath: string): UpdateManager | null {
   ) {
     return 'bun'
   }
+
+  // pnpm shards globals under a numeric major-version segment, e.g.
+  // ~/Library/pnpm/global/5/node_modules or legacy ~/.pnpm-global/5/node_modules.
+  if (nodeModulesIdx >= 2 && /^\d+$/.test(parts[nodeModulesIdx - 1] ?? '')) {
+    const anchor = parts[nodeModulesIdx - 2]
+    if (anchor === 'pnpm-global' || anchor === '.pnpm-global') return 'pnpm'
+    if (anchor === 'global' && parts[nodeModulesIdx - 3] === 'pnpm') return 'pnpm'
+  }
+
+  if (nodeModulesIdx >= 2 && parts[nodeModulesIdx - 1] === 'global' && parts[nodeModulesIdx - 2] === 'yarn') {
+    return 'yarn'
+  }
+
   if (parts[nodeModulesIdx - 1] === 'lib') return 'npm'
   return null
 }


### PR DESCRIPTION
## Summary

Extends `--manager=auto` in `typeclaw update` to recognize pnpm and classic Yarn (v1) global install layouts, completing the manager-detection story started in #425. Before this PR, the auto-detect could only fingerprint Bun and npm layouts; any pnpm or yarn user had to fall back to `--manager=pnpm` / `--manager=yarn` explicitly. After this PR, the four major global-install ecosystems all work without any flags.

No behavior changes for Bun or npm. Detection stays purely path-based — no `$PATH` probing, no lockfile sniffing — keeping unit tests hermetic and consistent with the design in #425.

## Changes

### `src/update/index.ts`
- Widens the `UpdateManager` union from `'bun' | 'npm'` to `'bun' | 'npm' | 'pnpm' | 'yarn'`.
- Adds `commandForManager` cases for the two new managers: `pnpm add -g typeclaw@latest` and `yarn global upgrade typeclaw --latest`.
- Adds path-fingerprint detection for three pnpm layout variants:
  - macOS / modern pnpm: `~/Library/pnpm/global/<N>/node_modules/typeclaw`
  - Linux / modern pnpm: `~/.local/share/pnpm/global/<N>/node_modules/typeclaw`
  - Legacy pnpm: `~/.pnpm-global/<N>/node_modules/typeclaw`
  - The version-shard segment is matched with `/^\d+$/` so it does not accidentally match unrelated paths that contain a `pnpm/global/...` substring without a numeric shard.
- Adds detection for classic Yarn: `.../yarn/global/node_modules/typeclaw`.
- Updates the auto-detect failure reason to list all four managers.

### `src/update/index.test.ts`
Adds 5 new `detectInstallManager` tests:
- pnpm on macOS (`Library/pnpm/global/5/node_modules/typeclaw`)
- pnpm on Linux (`.local/share/pnpm/global/6/node_modules/typeclaw`)
- legacy `pnpm-global` layout (`~/.pnpm-global/5/node_modules/typeclaw`)
- yarn user layout (`~/.config/yarn/global/node_modules/typeclaw`)
- yarn system layout (`/usr/local/lib/yarn/global/node_modules/typeclaw`)

Also extends the explicit-manager override test to cover all four managers (was bun and npm only).

### `src/cli/update.ts`
- Adds `'pnpm'` and `'yarn'` to the `MANAGERS` allowlist that validates the `--manager` flag.
- Updates the help text and the invalid-manager error message to list all five accepted values: `auto`, `bun`, `npm`, `pnpm`, `yarn`.

### `src/cli/index.test.ts`
Adds 3 new CLI dry-run integration tests:
- `--manager=pnpm` renders `pnpm add -g typeclaw@latest`.
- `--manager=yarn` renders `yarn global upgrade typeclaw --latest`.
- `--manager=invalid` exits with code 2.

### `docs/content/docs/reference/cli.mdx`
Documents `--manager pnpm` and `--manager yarn` and updates the auto-detect caveat to list every recognized path layout.

## Design notes

**Yarn coverage is intentionally classic (v1) only.** Yarn Berry deprecated `yarn global add` in favor of `yarn dlx`, so there is no Berry-global install path to fingerprint. Running `yarn global upgrade` against a Berry install would fail loudly — the right outcome. Users on Berry should use `yarn dlx typeclaw` instead.

**pnpm's numeric shard guard.** pnpm shards its global store under a numeric major-version segment (`5`, `6`, …). Matching on `/^\d+$/` prevents accidentally fingerprinting unrelated paths that happen to contain a `pnpm/global` substring without the shard.

**Update commands match each ecosystem's canonical idiom.** `pnpm add -g X@latest` and `yarn global upgrade X --latest` are the idiomatic "(re)install global to latest" forms for their respective ecosystems — not `update` sub-commands, which have subtly different semantics in both.

## Testing

```
bun run format:check   ✓  clean
bun run typecheck      ✓  0 errors
bun run lint           ✓  0 errors, 0 new warnings
bun run test           ✓  5702/5703 pass
bun test --parallel src/update/index.test.ts src/cli/index.test.ts  ✓  23/23 pass
```

The single failure in `bun run test` is `resolveSelfPackageJsonPath > points at this package manifest` — a pre-existing test introduced in #425 that hardcodes `toEndWith('typeclaw/package.json')`. It fails when the working copy directory is not named `typeclaw` (e.g. inside a worktree under a temp path). CI always lands in a directory named `typeclaw`, so it passes there. Out of scope for this PR.

## Review notes

- **`detectInstallManager` in `src/update/index.ts`** is the load-bearing change. The path-splitting logic is shared with the existing Bun and npm branches — the new pnpm and yarn arms follow the same pattern and sit directly below them.
- The pnpm three-way branch is ordered most-specific to least-specific. The `/^\d+$/` guard sits at the top of the pnpm arm so all three variants share a single shard check.
- No real registry call runs under this PR. The new tests cover only the `--dry-run` code path, consistent with how the original tests in #425 were written. Live smoke testing requires an actual pnpm or yarn global install.