### PR TITLE
release: push to protected main via SSH deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        # SSH deploy key (write-enabled) is the only credential allowed to
+        # bypass the `main` branch ruleset (required PR + status check). The
+        # default GITHUB_TOKEN cannot push directly to main, and adding it
+        # to `bypass_actors` is impossible — GitHub Actions itself is not an
+        # installable App. The deploy key, by contrast, is repo-scoped (not
+        # account-scoped like a PAT) and lives in the ruleset's bypass list
+        # via `actor_type: DeployKey`. See:
+        # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets#bypass
+        #
+        # `actions/checkout` configures the origin remote with this key, so
+        # the `Commit and tag` step below can `git push` over SSH without
+        # any further setup. `persist-credentials: true` (the default) is
+        # required — turning it off strips the auth and the push falls back
+        # to anonymous HTTPS.
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -213,9 +229,15 @@ jobs:
         # on fresh runners where no local tag exists), and `git push
         # --force` on the tag is scoped to the specific tag ref so it
         # cannot rewrite branches or other refs.
+        #
+        # Pushes here use the SSH deploy key configured by `actions/checkout`
+        # above. That key — and only that key — is allowed to bypass the
+        # `main` branch ruleset, so this step would fail with GH013
+        # ("repository rule violations") if anything below tried to push
+        # via the default GITHUB_TOKEN.
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "TypeClaw Release Bot"
+          git config user.email "release@typeclaw.dev"
           git add package.json
           git diff --staged --quiet || git commit -m "${{ inputs.version }}"
           git push origin HEAD


### PR DESCRIPTION
## Summary

The `Release` workflow's `Commit and tag` step pushes a version bump to main
via `GITHUB_TOKEN`, which the branch ruleset (id `16320106`) rejects with
`GH013: Repository rule violations found for refs/heads/main`. The ruleset
requires a PR and the `typecheck / lint / format / test` status check; the
default `GITHUB_TOKEN` satisfies neither, and it cannot be added to
`bypass_actors` because GitHub Actions is not an installable App — there is
no `Integration` id to register.

SSH deploy keys, by contrast, are supported as bypass actors via
`actor_type: DeployKey`. They are repo-scoped (not account-scoped like a
PAT), not associated with any user account, and do not cause workflow
re-run loops. This PR wires one in.

## Infrastructure (applied out-of-band before this PR)

These changes were made via the GitHub API so the first merged run works:

- Write-enabled deploy key `release-workflow` (id `152789903`) added to
  `typeclaw/typeclaw`.
- Private key uploaded as repo secret `DEPLOY_KEY`.
- Ruleset `16320106` updated: `bypass_actors` now includes
  `actor_type: DeployKey` (`actor_id: null` — GitHub's bypass class covers
  any deploy key on the repo; there is no per-key granularity).

## Changes

### `.github/workflows/release.yml`

**`actions/checkout@v4`** — add a `with:` block passing
`ssh-key: \${{ secrets.DEPLOY_KEY }}`. Checkout configures the origin remote
with the deploy key, so the `git push` in `Commit and tag` automatically
uses SSH without any further setup. A comment block documents why
`GITHUB_TOKEN` doesn't work, why this beats a PAT, and warns future
maintainers not to set `persist-credentials: false` (which would strip the
auth).

**`Commit and tag`** — change git identity from `github-actions[bot]` to
`TypeClaw Release Bot <release@typeclaw.dev>`. The previous identity was
misleading — the push is no longer authed by the GitHub Actions integration.
A comment above the run script names `GH013` explicitly so a future
maintainer knows what they would hit if they reverted to `GITHUB_TOKEN`.

No other step is touched. The GHCR-before-npm ordering and the
`npm view`/`gh release view` idempotency gates are untouched.

## Verification

After merge, re-run the `Release` workflow at `0.12.0`. Every step is
idempotent at the same version — GHCR push overwrites, npm publish
short-circuits on `npm view typeclaw@0.12.0 version`, `gh release view
0.12.0` short-circuits release creation. The previously failing `Commit and
tag` step will succeed, write `0.12.0` to `package.json` on main, push tag
`0.12.0`, and the final step creates the GitHub Release.

## Local checks

```
bun run typecheck      ✓  0 errors
bun run lint           ✓  60 pre-existing warnings, 0 errors
bun run format:check   ✓  clean
bun test --parallel    ✓  5695 pass, 0 fail
```