### PR TITLE
update: teach typeclaw update to auto-detect local installs

### DIFF
--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -136,15 +136,23 @@ Categories: `docker`, `config`, `secrets`, `network`, `git`, plus per-plugin che
 ## Update
 
 ```sh
-typeclaw update                                    # update the globally installed CLI (auto-detect Bun/npm/pnpm/yarn)
-typeclaw update --manager bun                      # force Bun global update
-typeclaw update --manager npm                      # force npm global update
-typeclaw update --manager pnpm                     # force pnpm global update
-typeclaw update --manager yarn                     # force classic Yarn global update
+typeclaw update                                    # update the installed CLI (auto-detect global vs local, Bun/npm/pnpm/yarn)
+typeclaw update --manager bun                      # force Bun (scope is still auto-detected)
+typeclaw update --manager npm                      # force npm (scope is still auto-detected)
+typeclaw update --manager pnpm                     # force pnpm (scope is still auto-detected)
+typeclaw update --manager yarn                     # force classic Yarn (scope is still auto-detected)
 typeclaw update --dry-run                          # print the updater command without running it
 ```
 
-Auto-detection only trusts known global install layouts (Bun's `.bun/install/global`, npm's `lib/node_modules`, pnpm's `pnpm/global/<N>/node_modules` / legacy `pnpm-global/<N>/node_modules`, and classic Yarn's `yarn/global/node_modules`). Source checkouts and local `node_modules/typeclaw` installs require an explicit `--manager`.
+Auto-detection recognizes these layouts:
+
+- **Bun global** (`~/.bun/install/global/node_modules/typeclaw`) → `bun update -g typeclaw --latest`.
+- **npm global** (`.../lib/node_modules/typeclaw`) → `npm install -g typeclaw@latest`.
+- **pnpm global** (`.../pnpm/global/<N>/node_modules/typeclaw`, or legacy `.../{,.}pnpm-global/<N>/node_modules/typeclaw`) → `pnpm add -g typeclaw@latest`.
+- **classic Yarn global** (`.../yarn/global/node_modules/typeclaw`) → `yarn global upgrade typeclaw --latest`.
+- **Local install** (any other `node_modules/typeclaw`) → drops the global flag and runs in the project root that owns the `node_modules/`. The manager is picked from the lockfile next to that root (`bun.lock` / `bun.lockb` → bun, `pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, `package-lock.json` → npm; bun wins ties).
+
+`--manager` always overrides the detected manager. The scope (global or not) still follows the detected install layout, so `--manager=npm` against a local install runs `npm install typeclaw@latest` (no `-g`), not a stealth global update. Source checkouts have no detectable layout and fall back to a global update — pass `--manager` to pick the registry side.
 
 ## Usage
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -9,7 +9,7 @@ const MANAGERS = ['auto', 'bun', 'npm', 'pnpm', 'yarn'] as const
 export const updateCommand = defineCommand({
   meta: {
     name: 'update',
-    description: 'update the globally installed typeclaw CLI',
+    description: 'update the installed typeclaw CLI (auto-detects global vs local)',
   },
   args: {
     manager: {
@@ -42,8 +42,9 @@ export const updateCommand = defineCommand({
       return
     }
 
-    process.stdout.write(`${c.cyan('Updating TypeClaw with:')} ${rendered}\n`)
-    const exitCode = await runUpdateCommand(plan.command)
+    const scopeLabel = plan.scope === 'global' ? 'global' : `local (${plan.cwd ?? '.'})`
+    process.stdout.write(`${c.cyan(`Updating TypeClaw [${scopeLabel}] with:`)} ${rendered}\n`)
+    const exitCode = await runUpdateCommand(plan.command, plan.cwd)
     if (exitCode !== 0) {
       console.error(errorLine(`Update command exited with code ${exitCode}.`))
       process.exit(exitCode)
@@ -58,7 +59,7 @@ function parseManager(value: string | undefined): UpdateManagerSelection | null 
   return (MANAGERS as readonly string[]).includes(value) ? (value as UpdateManagerSelection) : null
 }
 
-async function runUpdateCommand(command: string[]): Promise<number> {
+async function runUpdateCommand(command: string[], cwd: string | undefined): Promise<number> {
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) {
     console.error(errorLine('bun runtime not available'))
@@ -67,6 +68,7 @@ async function runUpdateCommand(command: string[]): Promise<number> {
   try {
     const proc = bun.spawn({
       cmd: command,
+      cwd,
       stdin: 'inherit',
       stdout: 'inherit',
       stderr: 'inherit',

--- a/src/update/index.test.ts
+++ b/src/update/index.test.ts
@@ -1,39 +1,44 @@
 import { describe, expect, test } from 'bun:test'
 import { join } from 'node:path'
 
-import { formatCommand, planSelfUpdate, resolveSelfPackageJsonPath } from './index'
+import { commandForInstall, formatCommand, planSelfUpdate, resolveSelfPackageJsonPath } from './index'
 
 const AUTO_DETECT_FAILURE_REASON =
   'Cannot auto-detect how TypeClaw was installed from this checkout. Re-run with --manager=bun, --manager=npm, --manager=pnpm, or --manager=yarn if you want to update a global install.'
 
-describe('planSelfUpdate', () => {
-  test('detects a Bun global install and updates with bun', () => {
+const neverExists = (_path: string): boolean => false
+const onlyLockfile = (lockfile: string) => (path: string) => path.endsWith(lockfile)
+
+describe('planSelfUpdate global installs', () => {
+  test('detects a Bun global install and updates with bun -g', () => {
     const packageJsonPath = join('/home/alice', '.bun', 'install', 'global', 'node_modules', 'typeclaw', 'package.json')
 
-    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath, fileExists: neverExists })
 
     expect(plan).toEqual({
       ok: true,
       manager: 'bun',
+      scope: 'global',
       command: ['bun', 'update', '-g', 'typeclaw', '--latest'],
       detectedFrom: packageJsonPath,
     })
   })
 
-  test('detects an npm global install and updates with npm', () => {
+  test('detects an npm global install and updates with npm -g', () => {
     const packageJsonPath = join('/usr/local/lib', 'node_modules', 'typeclaw', 'package.json')
 
-    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath, fileExists: neverExists })
 
     expect(plan).toEqual({
       ok: true,
       manager: 'npm',
+      scope: 'global',
       command: ['npm', 'install', '-g', 'typeclaw@latest'],
       detectedFrom: packageJsonPath,
     })
   })
 
-  test('detects a pnpm macOS global install and updates with pnpm', () => {
+  test('detects a pnpm macOS global install and updates with pnpm -g', () => {
     const packageJsonPath = join(
       '/Users/alice',
       'Library',
@@ -45,17 +50,18 @@ describe('planSelfUpdate', () => {
       'package.json',
     )
 
-    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath, fileExists: neverExists })
 
     expect(plan).toEqual({
       ok: true,
       manager: 'pnpm',
+      scope: 'global',
       command: ['pnpm', 'add', '-g', 'typeclaw@latest'],
       detectedFrom: packageJsonPath,
     })
   })
 
-  test('detects a pnpm Linux global install and updates with pnpm', () => {
+  test('detects a pnpm Linux global install and updates with pnpm -g', () => {
     const packageJsonPath = join(
       '/home/alice',
       '.local',
@@ -68,43 +74,46 @@ describe('planSelfUpdate', () => {
       'package.json',
     )
 
-    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath, fileExists: neverExists })
 
     expect(plan).toEqual({
       ok: true,
       manager: 'pnpm',
+      scope: 'global',
       command: ['pnpm', 'add', '-g', 'typeclaw@latest'],
       detectedFrom: packageJsonPath,
     })
   })
 
-  test('detects a legacy pnpm-global install and updates with pnpm', () => {
+  test('detects a legacy pnpm-global install and updates with pnpm -g', () => {
     const packageJsonPath = join('/home/alice', '.pnpm-global', '5', 'node_modules', 'typeclaw', 'package.json')
 
-    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath, fileExists: neverExists })
 
     expect(plan).toEqual({
       ok: true,
       manager: 'pnpm',
+      scope: 'global',
       command: ['pnpm', 'add', '-g', 'typeclaw@latest'],
       detectedFrom: packageJsonPath,
     })
   })
 
-  test('detects a classic yarn user global install and updates with yarn', () => {
+  test('detects a classic yarn user global install and updates with yarn global', () => {
     const packageJsonPath = join('/home/alice', '.config', 'yarn', 'global', 'node_modules', 'typeclaw', 'package.json')
 
-    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath, fileExists: neverExists })
 
     expect(plan).toEqual({
       ok: true,
       manager: 'yarn',
+      scope: 'global',
       command: ['yarn', 'global', 'upgrade', 'typeclaw', '--latest'],
       detectedFrom: packageJsonPath,
     })
   })
 
-  test('detects a classic yarn system global install and updates with yarn', () => {
+  test('detects a classic yarn system global install and updates with yarn global', () => {
     const packageJsonPath = join(
       '/usr/local/share',
       '.config',
@@ -115,65 +124,229 @@ describe('planSelfUpdate', () => {
       'package.json',
     )
 
-    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath, fileExists: neverExists })
 
     expect(plan).toEqual({
       ok: true,
       manager: 'yarn',
+      scope: 'global',
       command: ['yarn', 'global', 'upgrade', 'typeclaw', '--latest'],
       detectedFrom: packageJsonPath,
     })
   })
+})
 
-  test('refuses local node_modules installs because updating a global package would be wrong', () => {
+describe('planSelfUpdate local installs', () => {
+  test('detects a local install with bun.lock and runs bun update without -g', () => {
     const packageJsonPath = join('/work', 'agent', 'node_modules', 'typeclaw', 'package.json')
 
-    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+    const plan = planSelfUpdate({
+      manager: 'auto',
+      packageJsonPath,
+      fileExists: onlyLockfile('bun.lock'),
+    })
 
     expect(plan).toEqual({
-      ok: false,
-      reason: AUTO_DETECT_FAILURE_REASON,
+      ok: true,
+      manager: 'bun',
+      scope: 'local',
+      command: ['bun', 'update', 'typeclaw', '--latest'],
+      detectedFrom: packageJsonPath,
+      cwd: join('/work', 'agent'),
     })
   })
 
+  test('detects a local install with bun.lockb (legacy binary lockfile) as bun', () => {
+    const packageJsonPath = join('/work', 'agent', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({
+      manager: 'auto',
+      packageJsonPath,
+      fileExists: onlyLockfile('bun.lockb'),
+    })
+
+    expect(plan).toMatchObject({ ok: true, manager: 'bun', scope: 'local' })
+  })
+
+  test('detects a local install with package-lock.json and runs npm install without -g', () => {
+    const packageJsonPath = join('/work', 'agent', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({
+      manager: 'auto',
+      packageJsonPath,
+      fileExists: onlyLockfile('package-lock.json'),
+    })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'npm',
+      scope: 'local',
+      command: ['npm', 'install', 'typeclaw@latest'],
+      detectedFrom: packageJsonPath,
+      cwd: join('/work', 'agent'),
+    })
+  })
+
+  test('detects a local install with pnpm-lock.yaml and runs pnpm add without -g', () => {
+    const packageJsonPath = join('/work', 'agent', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({
+      manager: 'auto',
+      packageJsonPath,
+      fileExists: onlyLockfile('pnpm-lock.yaml'),
+    })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'pnpm',
+      scope: 'local',
+      command: ['pnpm', 'add', 'typeclaw@latest'],
+      detectedFrom: packageJsonPath,
+      cwd: join('/work', 'agent'),
+    })
+  })
+
+  test('detects a local install with yarn.lock and runs yarn upgrade without global', () => {
+    const packageJsonPath = join('/work', 'agent', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({
+      manager: 'auto',
+      packageJsonPath,
+      fileExists: onlyLockfile('yarn.lock'),
+    })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'yarn',
+      scope: 'local',
+      command: ['yarn', 'upgrade', 'typeclaw', '--latest'],
+      detectedFrom: packageJsonPath,
+      cwd: join('/work', 'agent'),
+    })
+  })
+
+  test('falls back to bun when a local install has no recognizable lockfile', () => {
+    const packageJsonPath = join('/work', 'agent', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath, fileExists: neverExists })
+
+    expect(plan).toMatchObject({
+      ok: true,
+      manager: 'bun',
+      scope: 'local',
+      command: ['bun', 'update', 'typeclaw', '--latest'],
+      cwd: join('/work', 'agent'),
+    })
+  })
+
+  test('prefers bun lockfile over every other lockfile when multiple are present', () => {
+    const packageJsonPath = join('/work', 'agent', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({
+      manager: 'auto',
+      packageJsonPath,
+      fileExists: (p) =>
+        p.endsWith('bun.lock') ||
+        p.endsWith('pnpm-lock.yaml') ||
+        p.endsWith('yarn.lock') ||
+        p.endsWith('package-lock.json'),
+    })
+
+    expect(plan).toMatchObject({ ok: true, manager: 'bun', scope: 'local' })
+  })
+
+  test('explicit --manager=npm on a detected local install stays local (no -g)', () => {
+    const packageJsonPath = join('/work', 'agent', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({ manager: 'npm', packageJsonPath, fileExists: onlyLockfile('bun.lock') })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'npm',
+      scope: 'local',
+      command: ['npm', 'install', 'typeclaw@latest'],
+      detectedFrom: packageJsonPath,
+      cwd: join('/work', 'agent'),
+    })
+  })
+
+  test('explicit --manager=yarn on a detected local install stays local (no global)', () => {
+    const packageJsonPath = join('/work', 'agent', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({ manager: 'yarn', packageJsonPath, fileExists: onlyLockfile('bun.lock') })
+
+    expect(plan).toEqual({
+      ok: true,
+      manager: 'yarn',
+      scope: 'local',
+      command: ['yarn', 'upgrade', 'typeclaw', '--latest'],
+      detectedFrom: packageJsonPath,
+      cwd: join('/work', 'agent'),
+    })
+  })
+
+  test('local install at filesystem root resolves install root to "/"', () => {
+    const packageJsonPath = join('/', 'node_modules', 'typeclaw', 'package.json')
+
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath, fileExists: neverExists })
+
+    expect(plan).toMatchObject({ ok: true, scope: 'local', cwd: '/' })
+  })
+})
+
+describe('planSelfUpdate source checkouts and explicit overrides', () => {
   test('refuses auto mode from a source checkout because it is not a self update', () => {
     const packageJsonPath = join('/work', 'typeclaw', 'package.json')
 
-    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath })
+    const plan = planSelfUpdate({ manager: 'auto', packageJsonPath, fileExists: neverExists })
 
-    expect(plan).toEqual({
-      ok: false,
-      reason: AUTO_DETECT_FAILURE_REASON,
-    })
+    expect(plan).toEqual({ ok: false, reason: AUTO_DETECT_FAILURE_REASON })
   })
 
-  test('explicit manager overrides source-checkout detection', () => {
+  test('explicit manager on a source checkout still runs a global update', () => {
     const packageJsonPath = join('/work', 'typeclaw', 'package.json')
 
-    expect(planSelfUpdate({ manager: 'bun', packageJsonPath })).toEqual({
+    expect(planSelfUpdate({ manager: 'bun', packageJsonPath, fileExists: neverExists })).toEqual({
       ok: true,
       manager: 'bun',
+      scope: 'global',
       command: ['bun', 'update', '-g', 'typeclaw', '--latest'],
       detectedFrom: packageJsonPath,
     })
-    expect(planSelfUpdate({ manager: 'npm', packageJsonPath })).toEqual({
+    expect(planSelfUpdate({ manager: 'npm', packageJsonPath, fileExists: neverExists })).toEqual({
       ok: true,
       manager: 'npm',
+      scope: 'global',
       command: ['npm', 'install', '-g', 'typeclaw@latest'],
       detectedFrom: packageJsonPath,
     })
-    expect(planSelfUpdate({ manager: 'pnpm', packageJsonPath })).toEqual({
+    expect(planSelfUpdate({ manager: 'pnpm', packageJsonPath, fileExists: neverExists })).toEqual({
       ok: true,
       manager: 'pnpm',
+      scope: 'global',
       command: ['pnpm', 'add', '-g', 'typeclaw@latest'],
       detectedFrom: packageJsonPath,
     })
-    expect(planSelfUpdate({ manager: 'yarn', packageJsonPath })).toEqual({
+    expect(planSelfUpdate({ manager: 'yarn', packageJsonPath, fileExists: neverExists })).toEqual({
       ok: true,
       manager: 'yarn',
+      scope: 'global',
       command: ['yarn', 'global', 'upgrade', 'typeclaw', '--latest'],
       detectedFrom: packageJsonPath,
     })
+  })
+})
+
+describe('commandForInstall', () => {
+  test('emits the right command shape per (manager, scope) combination', () => {
+    expect(commandForInstall('bun', 'global')).toEqual(['bun', 'update', '-g', 'typeclaw', '--latest'])
+    expect(commandForInstall('bun', 'local')).toEqual(['bun', 'update', 'typeclaw', '--latest'])
+    expect(commandForInstall('npm', 'global')).toEqual(['npm', 'install', '-g', 'typeclaw@latest'])
+    expect(commandForInstall('npm', 'local')).toEqual(['npm', 'install', 'typeclaw@latest'])
+    expect(commandForInstall('pnpm', 'global')).toEqual(['pnpm', 'add', '-g', 'typeclaw@latest'])
+    expect(commandForInstall('pnpm', 'local')).toEqual(['pnpm', 'add', 'typeclaw@latest'])
+    expect(commandForInstall('yarn', 'global')).toEqual(['yarn', 'global', 'upgrade', 'typeclaw', '--latest'])
+    expect(commandForInstall('yarn', 'local')).toEqual(['yarn', 'upgrade', 'typeclaw', '--latest'])
   })
 })
 

--- a/src/update/index.ts
+++ b/src/update/index.ts
@@ -1,44 +1,74 @@
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 
 export type UpdateManager = 'bun' | 'npm' | 'pnpm' | 'yarn'
 export type UpdateManagerSelection = 'auto' | UpdateManager
+export type UpdateScope = 'global' | 'local'
 
 export type SelfUpdatePlan =
-  | { ok: true; manager: UpdateManager; command: string[]; detectedFrom: string }
+  | { ok: true; manager: UpdateManager; scope: UpdateScope; command: string[]; detectedFrom: string; cwd?: string }
   | { ok: false; reason: string }
+
+export type DetectedInstall = {
+  manager: UpdateManager
+  scope: UpdateScope
+  // Defined only for local installs: the directory whose `node_modules/` owns
+  // the installed copy (i.e. where `bun update` / `npm install` must run).
+  installRoot?: string
+}
+
+export type PlanOptions = {
+  manager: UpdateManagerSelection
+  packageJsonPath?: string
+  // Test seam: probes a candidate file's existence (defaults to `node:fs.existsSync`).
+  // Only consulted to pick a manager for local installs from a project lockfile.
+  fileExists?: (path: string) => boolean
+}
 
 export function resolveSelfPackageJsonPath(): string {
   return join(import.meta.dir, '..', '..', 'package.json')
 }
 
-export function planSelfUpdate(options: { manager: UpdateManagerSelection; packageJsonPath?: string }): SelfUpdatePlan {
+export function planSelfUpdate(options: PlanOptions): SelfUpdatePlan {
   const packageJsonPath = options.packageJsonPath ?? resolveSelfPackageJsonPath()
-  const manager = options.manager === 'auto' ? detectInstallManager(packageJsonPath) : options.manager
-  if (manager === null) {
-    return {
-      ok: false,
-      reason:
-        'Cannot auto-detect how TypeClaw was installed from this checkout. Re-run with --manager=bun, --manager=npm, --manager=pnpm, or --manager=yarn if you want to update a global install.',
+  const fileExists = options.fileExists ?? existsSync
+  const detected = detectInstall(packageJsonPath, fileExists)
+
+  if (options.manager === 'auto') {
+    if (detected === null) {
+      return {
+        ok: false,
+        reason:
+          'Cannot auto-detect how TypeClaw was installed from this checkout. Re-run with --manager=bun, --manager=npm, --manager=pnpm, or --manager=yarn if you want to update a global install.',
+      }
     }
+    return buildPlan(detected, packageJsonPath)
   }
-  return {
-    ok: true,
-    manager,
-    command: commandForManager(manager),
-    detectedFrom: packageJsonPath,
-  }
+
+  // Explicit manager. Honor the detected scope when we know it (so an explicit
+  // --manager on a local install doesn't surprise users by silently going
+  // global); fall back to a global update for source checkouts and other
+  // unrecognized layouts, matching the historical behavior.
+  const scope: UpdateScope = detected?.scope ?? 'global'
+  const installRoot =
+    scope === 'local' ? (detected?.installRoot ?? installRootFrom(packageJsonPath) ?? undefined) : undefined
+  return buildPlan({ manager: options.manager, scope, installRoot }, packageJsonPath)
 }
 
-export function commandForManager(manager: UpdateManager): string[] {
+export function commandForInstall(manager: UpdateManager, scope: UpdateScope): string[] {
   switch (manager) {
     case 'bun':
-      return ['bun', 'update', '-g', 'typeclaw', '--latest']
+      return scope === 'global'
+        ? ['bun', 'update', '-g', 'typeclaw', '--latest']
+        : ['bun', 'update', 'typeclaw', '--latest']
     case 'npm':
-      return ['npm', 'install', '-g', 'typeclaw@latest']
+      return scope === 'global' ? ['npm', 'install', '-g', 'typeclaw@latest'] : ['npm', 'install', 'typeclaw@latest']
     case 'pnpm':
-      return ['pnpm', 'add', '-g', 'typeclaw@latest']
+      return scope === 'global' ? ['pnpm', 'add', '-g', 'typeclaw@latest'] : ['pnpm', 'add', 'typeclaw@latest']
     case 'yarn':
-      return ['yarn', 'global', 'upgrade', 'typeclaw', '--latest']
+      return scope === 'global'
+        ? ['yarn', 'global', 'upgrade', 'typeclaw', '--latest']
+        : ['yarn', 'upgrade', 'typeclaw', '--latest']
   }
 }
 
@@ -46,7 +76,18 @@ export function formatCommand(command: readonly string[]): string {
   return command.map(shellQuote).join(' ')
 }
 
-function detectInstallManager(packageJsonPath: string): UpdateManager | null {
+function buildPlan(detected: DetectedInstall, packageJsonPath: string): SelfUpdatePlan {
+  return {
+    ok: true,
+    manager: detected.manager,
+    scope: detected.scope,
+    command: commandForInstall(detected.manager, detected.scope),
+    detectedFrom: packageJsonPath,
+    ...(detected.installRoot ? { cwd: detected.installRoot } : {}),
+  }
+}
+
+function detectInstall(packageJsonPath: string, fileExists: (path: string) => boolean): DetectedInstall | null {
   const parts = packageJsonPath.split(/[\\/]+/).filter(Boolean)
   const packageJson = parts[parts.length - 1]
   const packageName = parts[parts.length - 2]
@@ -61,23 +102,51 @@ function detectInstallManager(packageJsonPath: string): UpdateManager | null {
     parts[bunGlobalIdx + 2] === 'global' &&
     parts[bunGlobalIdx + 3] === 'node_modules'
   ) {
-    return 'bun'
+    return { manager: 'bun', scope: 'global' }
   }
 
   // pnpm shards globals under a numeric major-version segment, e.g.
   // ~/Library/pnpm/global/5/node_modules or legacy ~/.pnpm-global/5/node_modules.
   if (nodeModulesIdx >= 2 && /^\d+$/.test(parts[nodeModulesIdx - 1] ?? '')) {
     const anchor = parts[nodeModulesIdx - 2]
-    if (anchor === 'pnpm-global' || anchor === '.pnpm-global') return 'pnpm'
-    if (anchor === 'global' && parts[nodeModulesIdx - 3] === 'pnpm') return 'pnpm'
+    if (anchor === 'pnpm-global' || anchor === '.pnpm-global') return { manager: 'pnpm', scope: 'global' }
+    if (anchor === 'global' && parts[nodeModulesIdx - 3] === 'pnpm') return { manager: 'pnpm', scope: 'global' }
   }
 
   if (nodeModulesIdx >= 2 && parts[nodeModulesIdx - 1] === 'global' && parts[nodeModulesIdx - 2] === 'yarn') {
-    return 'yarn'
+    return { manager: 'yarn', scope: 'global' }
   }
 
-  if (parts[nodeModulesIdx - 1] === 'lib') return 'npm'
-  return null
+  if (parts[nodeModulesIdx - 1] === 'lib') return { manager: 'npm', scope: 'global' }
+
+  const installRoot = installRootFrom(packageJsonPath)
+  if (installRoot === null) return null
+  return { manager: detectLocalManager(installRoot, fileExists), scope: 'local', installRoot }
+}
+
+function installRootFrom(packageJsonPath: string): string | null {
+  const sepMatch = packageJsonPath.match(/[\\/]/)
+  const sep = sepMatch?.[0] ?? '/'
+  const parts = packageJsonPath.split(/[\\/]+/)
+  const nodeModulesIdx = parts.lastIndexOf('node_modules')
+  if (nodeModulesIdx <= 0) return null
+  const head = parts.slice(0, nodeModulesIdx)
+  // Preserve a leading separator on POSIX paths (`/usr/lib/...` splits to
+  // `['', 'usr', 'lib', ...]`) and Windows drive prefixes (`C:\Users\...`
+  // splits to `['C:', 'Users', ...]`, no leading empty).
+  return head.length === 1 && head[0] === '' ? sep : head.join(sep)
+}
+
+// Prefer the lockfile present in the install root. Probe order is bun -> pnpm
+// -> yarn -> npm so a project with multiple lockfiles checked in (a real,
+// gross-but-common scenario during migrations) lands on bun, matching this
+// repo's default. The CLI's `--manager` flag always wins over this heuristic.
+function detectLocalManager(installRoot: string, fileExists: (path: string) => boolean): UpdateManager {
+  if (fileExists(join(installRoot, 'bun.lock')) || fileExists(join(installRoot, 'bun.lockb'))) return 'bun'
+  if (fileExists(join(installRoot, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (fileExists(join(installRoot, 'yarn.lock'))) return 'yarn'
+  if (fileExists(join(installRoot, 'package-lock.json'))) return 'npm'
+  return 'bun'
 }
 
 function shellQuote(arg: string): string {


### PR DESCRIPTION
## Summary

Before this PR, `typeclaw update --manager=auto` refused to do anything when the running CLI's `package.json` lived in a project-local `node_modules/typeclaw` — i.e., anywhere other than the bun-global or npm-global layouts. And `--manager=bun|npm` always emitted `-g`. Users who installed typeclaw as a project dependency had no working path to self-update: `typeclaw update --manager=bun` would upgrade their global install and never touch the project copy.

This PR adds a `scope` field to the detection result and teaches the update machinery to handle local installs correctly.

## Changes

### `src/update/index.ts`

- `detectInstall` (renamed from `detectInstallManager`) returns `{ manager, scope, installRoot? }` or `null` instead of a bare manager string. The two known global layouts are still recognized by path fingerprint. For any other `node_modules/typeclaw/package.json` path, the function walks back to the directory that contains the `node_modules/` segment and treats that as a local install root.
- For local installs, the manager is inferred from the lockfile next to the install root: `bun.lock` / `bun.lockb` → bun; `package-lock.json` → npm; bun wins ties and is the fallback when no lockfile is found.
- `commandForInstall(manager, scope)` (renamed from `commandForManager`) drops `-g` for local installs: bun local → `bun update typeclaw --latest`; npm local → `npm install typeclaw@latest`.
- `SelfUpdatePlan` gains `scope: 'global' | 'local'` and `cwd?: string` alongside the existing manager field.
- A `fileExists` callback is threaded into `planSelfUpdate` as a test seam (defaults to `node:fs.existsSync`). This keeps lockfile probing out of real filesystem reads in unit tests.

### `src/cli/update.ts`

- Passes `plan.cwd` to the spawn call so a local update runs in the install root, not the process cwd.
- Status line reports `(local)` vs `(global)` scope.
- `--manager` still overrides the detected manager. It now also honors the detected scope: `--manager=npm` on a local install runs `npm install typeclaw@latest` rather than silently issuing a global update. Source checkouts retain the prior back-compat behavior: an explicit `--manager` falls back to a global update, matching the existing test.

### `src/update/index.test.ts`

Full expansion of unit coverage:

- Local install with `bun.lock` → bun, no `-g`.
- Local install with `bun.lockb` → bun, no `-g`.
- Local install with `package-lock.json` → npm, no `-g`.
- No lockfile in local install root → falls back to bun.
- Both lockfiles present → bun wins.
- `--manager=npm` on a local install → `npm install typeclaw@latest`, not `npm install -g`.
- Filesystem-root edge case (`/node_modules/typeclaw`) handled without blowing up.
- Source-checkout refusal and explicit-manager-on-source-checkout back-compat cases retained.

### `docs/content/docs/reference/cli.mdx`

Update section rewritten to document the three recognized layouts (bun global / npm global / local) and the scope-honoring behavior of `--manager`.

## Design notes

**`--manager` scope-honoring is the key behavioral change.** Previously, `--manager=npm` on a local install would issue `npm install -g typeclaw`, silently touching the user's global environment instead of the project. The new behavior keeps the command in the detected scope, which is always the safe choice. The only exception is source checkouts — the fallback to global is preserved there because there is no install root to infer, and the prior test named that behavior explicitly.

**Lockfile probe is a test seam.** `fileExists` defaults to `existsSync` in production. Tests inject a controlled map so they never touch the real filesystem.

**`installRootFrom` is separator-agnostic.** The path walk splits on both forward and backward separators so Windows drive prefixes are handled correctly.

## Verification

```
bun run typecheck    OK  0 errors
bun run lint         OK  0 errors, no new warnings
bun run format:check OK  clean
bun run test         OK  targeted unit tests pass; source-checkout and cli snapshot tests unchanged
```

## Review notes

- The load-bearing read is `detectInstall` in `src/update/index.ts`. The path walk in `installRootFrom` splits on the `node_modules` segment to find the project root; there is an edge-case guard for `/node_modules/typeclaw` (filesystem root — returns `null`).
- Lockfile precedence is intentionally bun-first because the rest of the codebase has the same bias. Ties go to bun; absence falls back to bun. If lockfile probing needs to grow, `fileExists` is already threaded through — add a case to `managerFromLockfile` and cover it with a unit test.
- The `cwd` field on the spawn is load-bearing for correctness: without it, `bun update typeclaw --latest` in a local install root would resolve against the process cwd, which might be a different project.
- All renames (`detectInstallManager` → `detectInstall`, `commandForManager` → `commandForInstall`) are local to `src/update/`. No public API surface changed.