### PR TITLE
test-helpers: collapse the expectStable race window (v2 deflake)

### DIFF
--- a/src/test-helpers/wait-for.test.ts
+++ b/src/test-helpers/wait-for.test.ts
@@ -61,19 +61,31 @@ describe('expectStable', () => {
 
   test('rejects when predicate becomes truthy mid-duration', async () => {
     // Drive the flip from the polling loop itself rather than a wall-clock
-    // setTimeout — under heavy CI contention (18 parallel workers) a 10ms
-    // timer can be delayed past the 50ms duration, leaving the predicate
-    // falsy and turning the expected rejection into a silent resolve. A
-    // call-counter is deterministic: the third poll flips it, well before
-    // the deadline regardless of scheduler load.
+    // setTimeout, AND flip on call #2 with a wide durationMs budget.
+    //
+    // History: a previous deflake (74be577) used a call-counter that flipped
+    // on call #3 with durationMs=50ms / intervalMs=5ms. That still leaves a
+    // race: `expectStable` checks `Date.now() < deadline` BETWEEN iterations,
+    // so if any of the two intervening sleeps gets delayed past the 50ms
+    // deadline (run #26550782470: failing test took 74ms, sleeps stretched
+    // under 18-worker `bun test --parallel` contention), the loop exits
+    // before call #3 lands and the expected rejection becomes a silent
+    // resolve.
+    //
+    // Flipping on call #2 with durationMs=5000 collapses the race window:
+    // only ONE sleep separates the first falsy call from the truthy one,
+    // and even a 100x scheduler hiccup (500ms sleep) fits well inside the
+    // budget. The test still exercises the same behavior — predicate
+    // becomes truthy mid-duration, rejection fires — without any wall-clock
+    // dependency in the assertion path.
     let calls = 0
     const predicate = () => {
       calls++
-      return calls >= 3
+      return calls >= 2
     }
 
-    await expect(expectStable(predicate, { durationMs: 50, description: 'no-event' })).rejects.toThrow(
-      /no-event became truthy before 50ms elapsed/,
+    await expect(expectStable(predicate, { durationMs: 5000, description: 'no-event' })).rejects.toThrow(
+      /no-event became truthy before 5000ms elapsed/,
     )
   })
 })


### PR DESCRIPTION
## Summary

CI run [#26550782470](https://github.com/typeclaw/typeclaw/actions/runs/26550782470) on main hit the same flake that PR #424 (74be577) was meant to fix:

```
(fail) expectStable > rejects when predicate becomes truthy mid-duration
error: Expected promise that rejects [74ms test runtime]
```

The primary fix closes the remaining race window in the stability-helper test.

## Root cause

The expectStable loop evaluates the deadline check between iterations. PR #424 replaced a wall-clock timer with a call-counter that flips on call #3, using a 50 ms duration and the default 5 ms interval. That still leaves a race: two 5 ms sleeps separate calls #1, #2, and #3.
Under 18-worker `bun test --parallel` CI contention those sleeps can each stretch well past 5 ms. When one blows past the 50 ms deadline, the loop exits before call #3 lands — the expected rejection becomes a silent resolve. The failing run took 74 ms; a prior main flake (run [#26522181803](https://github.com/typeclaw/typeclaw/actions/runs/26522181803)) took 151 ms.

## Changes

### Deflake — `src/test-helpers/wait-for.test.ts`

- **Flip on call #2** instead of call #3. Only one sleep now separates the first falsy call from the truthy one — the race window collapses from two sleep intervals to one.
- **Widen `durationMs` from 50 ms to 5000 ms.** Even a 100× scheduler hiccup (a 500 ms sleep) fits well inside the budget. The test still exercises the same observable behavior: predicate becomes truthy mid-duration, rejection fires.

## Verification

**Deflake:** 30 consecutive `bun test --parallel src/test-helpers/wait-for.test.ts` — 30 pass, 0 fail.

**Pre-commit checks:**

```
bun run typecheck    ✓  0 errors
bun run lint         ✓  0 errors
bun run format       ✓  clean
```

## Review notes

The load-bearing deflake change is two values: the flip moved from call #3 to call #2, and the duration from 50 ms to 5000 ms.
The expanded comment in the test file documents the full failure history so a future reader understands why both values matter.
