### PR TITLE
Add CLI support for managing mounts

### DIFF
--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -105,6 +105,18 @@ typeclaw tunnel remove <name>
 
 `--for-manual` flags the tunnel as user-owned. `--for-channel <name>` scopes it to an adapter's webhook.
 
+## Mounts
+
+```sh
+typeclaw mount list
+typeclaw mount list --json
+typeclaw mount add downloads ~/Downloads --read-only
+typeclaw mount add work ./workspace --description "local worktree"
+typeclaw mount remove downloads
+```
+
+Mounts expose host directories inside the container at `/agent/mounts/<name>`. Names must be lowercase alphanumeric with `-` or `_`. Adding/removing a mount updates `typeclaw.json`; restart the running agent with `typeclaw restart` for Docker to apply the bind mount.
+
 ## Compose
 
 ```sh

--- a/docs/content/docs/reference/typeclaw-json.mdx
+++ b/docs/content/docs/reference/typeclaw-json.mdx
@@ -61,6 +61,31 @@ Provider-family defaults override the SDK's reasoning level at session creation:
 | `autoAllowResolvers` | `true`  | Narrowly carve out port 53 to nameservers in `/etc/resolv.conf` so VPC-internal DNS keeps working                                                                  |
 | `allow`              | `[]`    | Explicit IPv4 CIDRs that punch through wholesale                                                                                                                   |
 
+## `mounts`
+
+```json
+{
+  "mounts": [
+    {
+      "name": "downloads",
+      "path": "~/Downloads",
+      "readOnly": true,
+      "description": "files to inspect"
+    }
+  ]
+}
+```
+
+Each mount maps a host directory to `/agent/mounts/<name>` inside the container. `path` accepts absolute paths, relative paths resolved from the agent folder, and `~`/`~/...`. `readOnly` defaults to `false`; use `true` for reference data the agent should inspect but not edit. Mount changes are restart-required because Docker bind mounts are fixed when the container starts.
+
+The CLI can manage this block:
+
+```sh
+typeclaw mount add downloads ~/Downloads --read-only
+typeclaw mount list
+typeclaw mount remove downloads
+```
+
 ## `docker.file`
 
 | Toggle        | Default | Effect                                                  |

--- a/src/cli/builtins.ts
+++ b/src/cli/builtins.ts
@@ -21,6 +21,7 @@ export const BUILTIN_COMMAND_NAMES = [
   'role',
   'provider',
   'model',
+  'mount',
   'doctor',
   'usage',
   'update',

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -71,6 +71,7 @@ describe('BUILTIN_COMMAND_NAMES exposure', () => {
     expect(BUILTIN_COMMAND_NAMES).toContain('tui')
     expect(BUILTIN_COMMAND_NAMES).toContain('doctor')
     expect(BUILTIN_COMMAND_NAMES).toContain('cron')
+    expect(BUILTIN_COMMAND_NAMES).toContain('mount')
     expect(BUILTIN_COMMAND_NAMES).toContain('update')
     expect(BUILTIN_COMMAND_NAMES).toContain('_hostd')
   })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,6 +31,7 @@ const main = defineCommand({
     role: () => import('./role').then((m) => m.roleCommand),
     provider: () => import('./provider').then((m) => m.providerCommand),
     model: () => import('./model').then((m) => m.modelCommand),
+    mount: () => import('./mount').then((m) => m.mountCommand),
     doctor: () => import('./doctor').then((m) => m.doctorCommand),
     usage: () => import('./usage').then((m) => m.usageCommand),
     update: () => import('./update').then((m) => m.updateCommand),

--- a/src/cli/mount.test.ts
+++ b/src/cli/mount.test.ts
@@ -3,7 +3,11 @@ import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promi
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { formatMountList } from './mount'
+
 const CLI_ENTRY = join(import.meta.dir, 'index.ts')
+const ANSI_SEQUENCE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[a-zA-Z]`, 'g')
+const stripAnsi = (s: string): string => s.replace(ANSI_SEQUENCE, '')
 
 describe('typeclaw mount CLI', () => {
   let cwd: string
@@ -29,6 +33,42 @@ describe('typeclaw mount CLI', () => {
     const exitCode = await proc.exited
     return { exitCode, stdout, stderr }
   }
+
+  test('list output keeps columns aligned when status text is colored', () => {
+    const previousForceColor = process.env.FORCE_COLOR
+    const previousNoColor = process.env.NO_COLOR
+    process.env.FORCE_COLOR = '1'
+    delete process.env.NO_COLOR
+
+    try {
+      const rendered = formatMountList([
+        {
+          name: 'one',
+          path: '/tmp/one',
+          readOnly: false,
+          resolvedPath: '/tmp/one',
+          targetPath: '/agent/mounts/one',
+          status: 'ok',
+        },
+        {
+          name: 'two',
+          path: '/tmp/two',
+          readOnly: false,
+          resolvedPath: '/tmp/two',
+          targetPath: '/agent/mounts/two',
+          status: 'error',
+        },
+      ])
+
+      const rows = stripAnsi(rendered).split('\n').slice(1)
+      expect(rows[0]?.indexOf('/tmp/one')).toBe(rows[1]?.indexOf('/tmp/two'))
+    } finally {
+      if (previousForceColor === undefined) delete process.env.FORCE_COLOR
+      else process.env.FORCE_COLOR = previousForceColor
+      if (previousNoColor === undefined) delete process.env.NO_COLOR
+      else process.env.NO_COLOR = previousNoColor
+    }
+  })
 
   test('add writes a mount and tells the user to restart', async () => {
     await mkdir(join(cwd, 'downloads'))

--- a/src/cli/mount.test.ts
+++ b/src/cli/mount.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const CLI_ENTRY = join(import.meta.dir, 'index.ts')
+
+describe('typeclaw mount CLI', () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-mount-cli-'))
+    await writeFile(join(cwd, 'typeclaw.json'), '{}\n')
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  async function runMount(args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn({
+      cmd: ['bun', CLI_ENTRY, 'mount', ...args],
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, NO_COLOR: '1' },
+    })
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+    const exitCode = await proc.exited
+    return { exitCode, stdout, stderr }
+  }
+
+  test('add writes a mount and tells the user to restart', async () => {
+    await mkdir(join(cwd, 'downloads'))
+
+    const result = await runMount(['add', 'downloads', './downloads', '--read-only', '--description=shared files'])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe('')
+    expect(result.stdout).toContain('Added mount "downloads"')
+    expect(result.stdout).toContain('typeclaw restart')
+
+    const raw = JSON.parse(await readFile(join(cwd, 'typeclaw.json'), 'utf8')) as { mounts?: unknown[] }
+    expect(raw.mounts).toEqual([
+      { name: 'downloads', path: './downloads', readOnly: true, description: 'shared files' },
+    ])
+  })
+
+  test('list --json emits resolved host and container paths', async () => {
+    await mkdir(join(cwd, 'downloads'))
+    expect((await runMount(['add', 'downloads', './downloads'])).exitCode).toBe(0)
+
+    const result = await runMount(['list', '--json'])
+    const resolvedDownloads = await realpath(join(cwd, 'downloads'))
+
+    expect(result.exitCode).toBe(0)
+    const parsed = JSON.parse(result.stdout) as {
+      mounts: Array<{ name: string; resolvedPath: string; targetPath: string; status: string }>
+    }
+    expect(parsed.mounts).toHaveLength(1)
+    expect(parsed.mounts[0]).toMatchObject({
+      name: 'downloads',
+      resolvedPath: resolvedDownloads,
+      targetPath: '/agent/mounts/downloads',
+      status: 'ok',
+    })
+  })
+
+  test('remove deletes the mount and tells the user to restart', async () => {
+    await mkdir(join(cwd, 'downloads'))
+    expect((await runMount(['add', 'downloads', './downloads'])).exitCode).toBe(0)
+
+    const result = await runMount(['remove', 'downloads'])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('Removed mount "downloads"')
+    expect(result.stdout).toContain('typeclaw restart')
+    const raw = JSON.parse(await readFile(join(cwd, 'typeclaw.json'), 'utf8')) as { mounts?: unknown[] }
+    expect(raw.mounts).toEqual([])
+  })
+
+  test('add refuses missing host paths', async () => {
+    const result = await runMount(['add', 'missing', './missing'])
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('does not exist')
+    const raw = JSON.parse(await readFile(join(cwd, 'typeclaw.json'), 'utf8')) as { mounts?: unknown[] }
+    expect(raw.mounts).toBeUndefined()
+  })
+})

--- a/src/cli/mount.ts
+++ b/src/cli/mount.ts
@@ -1,0 +1,156 @@
+import { defineCommand } from 'citty'
+
+import { addMount, listMounts, removeMount, type MountListEntry } from '@/config/mounts-mutation'
+import { findAgentDir, isInitialized } from '@/init'
+
+import { c, errorLine, successLine } from './ui'
+
+const listSub = defineCommand({
+  meta: {
+    name: 'list',
+    description: 'list host directories mounted into the agent container',
+  },
+  args: {
+    json: {
+      type: 'boolean',
+      description: 'emit mounts as JSON',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = ensureAgentDir()
+    const mounts = listMounts(cwd)
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify({ mounts }, null, 2)}\n`)
+      return
+    }
+    process.stdout.write(`${formatMountList(mounts)}\n`)
+  },
+})
+
+const addSub = defineCommand({
+  meta: {
+    name: 'add',
+    description: 'add a host directory mount to typeclaw.json',
+  },
+  args: {
+    name: {
+      type: 'positional',
+      description: 'mount name; appears inside the container at /agent/mounts/<name>',
+      required: true,
+    },
+    path: {
+      type: 'positional',
+      description: 'host directory path to expose inside the container',
+      required: true,
+    },
+    'read-only': {
+      type: 'boolean',
+      description: 'mount read-only inside the container',
+      default: false,
+    },
+    description: {
+      type: 'string',
+      description: 'optional human-readable note stored in typeclaw.json',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = ensureAgentDir()
+    const result = addMount(cwd, args.name, args.path, {
+      readOnly: args['read-only'] === true,
+      ...(args.description !== undefined ? { description: args.description } : {}),
+    })
+    if (!result.ok) {
+      console.error(errorLine(result.reason))
+      process.exit(1)
+    }
+    process.stdout.write(`${successLine(`Added mount "${result.entry.name}".`)}\n`)
+    process.stdout.write(`${formatMountEntry(result.entry)}\n`)
+    process.stdout.write(`${c.dim('Apply change:')} ${c.cyan('typeclaw restart')}\n`)
+  },
+})
+
+const removeSub = defineCommand({
+  meta: {
+    name: 'remove',
+    description: 'remove a host directory mount from typeclaw.json',
+  },
+  args: {
+    name: {
+      type: 'positional',
+      description: 'mount name to remove',
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const cwd = ensureAgentDir()
+    const result = removeMount(cwd, args.name)
+    if (!result.ok) {
+      console.error(errorLine(result.reason))
+      process.exit(1)
+    }
+    process.stdout.write(`${successLine(`Removed mount "${result.removed.name}".`)}\n`)
+    process.stdout.write(`${c.dim('Apply change:')} ${c.cyan('typeclaw restart')}\n`)
+  },
+})
+
+export const mountCommand = defineCommand({
+  meta: {
+    name: 'mount',
+    description: 'manage host directories mounted into the agent container',
+  },
+  subCommands: {
+    list: listSub,
+    add: addSub,
+    remove: removeSub,
+  },
+})
+
+export function formatMountList(mounts: readonly MountListEntry[]): string {
+  if (mounts.length === 0) return c.dim('No mounts configured.')
+
+  const nameWidth = Math.max(4, ...mounts.map((m) => m.name.length))
+  const modeWidth = 'MODE'.length
+  const statusWidth = Math.max(6, ...mounts.map((m) => m.status.length))
+  const lines: string[] = []
+  lines.push(
+    c.dim(
+      `${'NAME'.padEnd(nameWidth)}  ${'MODE'.padEnd(modeWidth)}  ${'STATUS'.padEnd(statusWidth)}  HOST PATH -> CONTAINER PATH`,
+    ),
+  )
+  for (const mount of mounts) {
+    const mode = mount.readOnly ? 'ro' : 'rw'
+    const status = mount.status === 'ok' ? c.green('ok') : c.red('error')
+    lines.push(
+      `${mount.name.padEnd(nameWidth)}  ${mode.padEnd(modeWidth)}  ${status.padEnd(statusWidth)}  ${mount.resolvedPath} -> ${mount.targetPath}`,
+    )
+    if (mount.description !== undefined) {
+      lines.push(`${' '.repeat(nameWidth + modeWidth + statusWidth + 6)}${c.dim(mount.description)}`)
+    }
+    if (mount.statusReason !== undefined) {
+      lines.push(`${' '.repeat(nameWidth + modeWidth + statusWidth + 6)}${c.yellow(mount.statusReason)}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function formatMountEntry(mount: MountListEntry): string {
+  const mode = mount.readOnly ? 'read-only' : 'read-write'
+  const details = [
+    `${c.dim('host:')} ${mount.resolvedPath}`,
+    `${c.dim('container:')} ${mount.targetPath}`,
+    `${c.dim('mode:')} ${mode}`,
+  ]
+  if (mount.description !== undefined) details.push(`${c.dim('description:')} ${mount.description}`)
+  return details.join('\n')
+}
+
+function ensureAgentDir(): string {
+  const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+  if (!isInitialized(cwd)) {
+    console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first, or cd into an agent folder.'))
+    process.exit(1)
+  }
+  return cwd
+}

--- a/src/cli/mount.ts
+++ b/src/cli/mount.ts
@@ -121,9 +121,10 @@ export function formatMountList(mounts: readonly MountListEntry[]): string {
   )
   for (const mount of mounts) {
     const mode = mount.readOnly ? 'ro' : 'rw'
-    const status = mount.status === 'ok' ? c.green('ok') : c.red('error')
+    const statusText = mount.status.padEnd(statusWidth)
+    const status = mount.status === 'ok' ? c.green(statusText) : c.red(statusText)
     lines.push(
-      `${mount.name.padEnd(nameWidth)}  ${mode.padEnd(modeWidth)}  ${status.padEnd(statusWidth)}  ${mount.resolvedPath} -> ${mount.targetPath}`,
+      `${mount.name.padEnd(nameWidth)}  ${mode.padEnd(modeWidth)}  ${status}  ${mount.resolvedPath} -> ${mount.targetPath}`,
     )
     if (mount.description !== undefined) {
       lines.push(`${' '.repeat(nameWidth + modeWidth + statusWidth + 6)}${c.dim(mount.description)}`)

--- a/src/config/mounts-mutation.test.ts
+++ b/src/config/mounts-mutation.test.ts
@@ -59,6 +59,24 @@ describe('mounts mutation', () => {
     expect(raw.mounts).toBeUndefined()
   })
 
+  test('adds a mount when an unrelated existing mount path is broken', async () => {
+    const hostDir = join(cwd, 'projects')
+    await mkdir(hostDir)
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({ mounts: [{ name: 'gone', path: join(cwd, 'gone') }] }, null, 2),
+    )
+
+    const result = addMount(cwd, 'projects', hostDir)
+
+    expect(result.ok).toBe(true)
+    const raw = JSON.parse(await readFile(join(cwd, 'typeclaw.json'), 'utf8')) as { mounts?: unknown[] }
+    expect(raw.mounts).toEqual([
+      { name: 'gone', path: join(cwd, 'gone'), readOnly: false },
+      { name: 'projects', path: hostDir, readOnly: false },
+    ])
+  })
+
   test('removes a mount by name', async () => {
     const hostDir = join(cwd, 'projects')
     await mkdir(hostDir)
@@ -68,6 +86,30 @@ describe('mounts mutation', () => {
 
     expect(result.ok).toBe(true)
     expect(listMounts(cwd)).toEqual([])
+  })
+
+  test('removes a mount when an unrelated existing mount path is broken', async () => {
+    const hostDir = join(cwd, 'projects')
+    await mkdir(hostDir)
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify(
+        {
+          mounts: [
+            { name: 'gone', path: join(cwd, 'gone') },
+            { name: 'projects', path: hostDir, readOnly: false },
+          ],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const result = removeMount(cwd, 'projects')
+
+    expect(result.ok).toBe(true)
+    const raw = JSON.parse(await readFile(join(cwd, 'typeclaw.json'), 'utf8')) as { mounts?: unknown[] }
+    expect(raw.mounts).toEqual([{ name: 'gone', path: join(cwd, 'gone'), readOnly: false }])
   })
 
   test('list reports broken mount paths without throwing', async () => {

--- a/src/config/mounts-mutation.test.ts
+++ b/src/config/mounts-mutation.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { addMount, listMounts, removeMount } from './mounts-mutation'
+
+describe('mounts mutation', () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-mounts-'))
+    await writeFile(join(cwd, 'typeclaw.json'), '{}\n')
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  test('adds a mount and reports the container target', async () => {
+    const hostDir = join(cwd, 'projects')
+    await mkdir(hostDir)
+
+    const result = addMount(cwd, 'projects', './projects', { description: 'work repos' })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.entry).toMatchObject({
+      name: 'projects',
+      path: './projects',
+      readOnly: false,
+      description: 'work repos',
+      resolvedPath: hostDir,
+      targetPath: '/agent/mounts/projects',
+      status: 'ok',
+    })
+
+    const raw = JSON.parse(await readFile(join(cwd, 'typeclaw.json'), 'utf8')) as { mounts?: unknown[] }
+    expect(raw.mounts).toEqual([{ name: 'projects', path: './projects', readOnly: false, description: 'work repos' }])
+  })
+
+  test('refuses duplicate mount names', async () => {
+    const hostDir = join(cwd, 'projects')
+    await mkdir(hostDir)
+    expect(addMount(cwd, 'projects', hostDir).ok).toBe(true)
+
+    const duplicate = addMount(cwd, 'projects', hostDir)
+
+    expect(duplicate.ok).toBe(false)
+    if (!duplicate.ok) expect(duplicate.reason).toContain('already exists')
+  })
+
+  test('refuses a missing host path before writing typeclaw.json', async () => {
+    const result = addMount(cwd, 'missing', join(cwd, 'missing'))
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain('does not exist')
+    const raw = JSON.parse(await readFile(join(cwd, 'typeclaw.json'), 'utf8')) as { mounts?: unknown[] }
+    expect(raw.mounts).toBeUndefined()
+  })
+
+  test('removes a mount by name', async () => {
+    const hostDir = join(cwd, 'projects')
+    await mkdir(hostDir)
+    expect(addMount(cwd, 'projects', hostDir).ok).toBe(true)
+
+    const result = removeMount(cwd, 'projects')
+
+    expect(result.ok).toBe(true)
+    expect(listMounts(cwd)).toEqual([])
+  })
+
+  test('list reports broken mount paths without throwing', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({ mounts: [{ name: 'gone', path: join(cwd, 'gone') }] }, null, 2),
+    )
+
+    const [entry] = listMounts(cwd)
+
+    expect(entry?.name).toBe('gone')
+    expect(entry?.status).toBe('error')
+    expect(entry?.statusReason).toContain('does not exist')
+  })
+})

--- a/src/config/mounts-mutation.ts
+++ b/src/config/mounts-mutation.ts
@@ -1,0 +1,166 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { commitSystemFileSync } from '@/git/system-commit'
+
+import {
+  configSchema,
+  expandMountPath,
+  loadConfigSyncOrDefaults,
+  mountSchema,
+  validateMount,
+  type Mount,
+} from './config'
+
+const CONFIG_FILE = 'typeclaw.json'
+const MOUNT_TARGET_PREFIX = '/agent/mounts'
+
+export type MountListEntry = Mount & {
+  resolvedPath: string
+  targetPath: string
+  status: 'ok' | 'error'
+  statusReason?: string
+}
+
+export type AddMountOptions = {
+  readOnly?: boolean
+  description?: string | undefined
+}
+
+export type AddMountResult = { ok: true; entry: MountListEntry } | { ok: false; reason: string }
+export type RemoveMountResult = { ok: true; removed: MountListEntry } | { ok: false; reason: string }
+
+export function listMounts(cwd: string): MountListEntry[] {
+  const mounts = loadConfigSyncOrDefaults(cwd).mounts
+  return mounts.map((mount) => toListEntry(mount, cwd))
+}
+
+export function addMount(cwd: string, name: string, path: string, options: AddMountOptions = {}): AddMountResult {
+  const mount = buildMount(name, path, options)
+  if (!mount.ok) return mount
+
+  const check = validateMount(mount.value, cwd)
+  if (!check.ok) return check
+
+  const parsed = readConfigRecord(cwd)
+  if (!parsed.ok) return parsed
+
+  const current = readMounts(parsed.value)
+  if (!current.ok) return current
+  if (current.value.some((m) => m.name === mount.value.name)) {
+    return {
+      ok: false,
+      reason: `Mount "${mount.value.name}" already exists. Remove it first with \`typeclaw mount remove ${mount.value.name}\`.`,
+    }
+  }
+
+  const next = { ...parsed.value, mounts: [...current.value, mount.value] }
+  const write = writeMounts(cwd, next, `mount: add ${mount.value.name}`)
+  if (!write.ok) return write
+  return { ok: true, entry: toListEntry(mount.value, cwd) }
+}
+
+export function removeMount(cwd: string, name: string): RemoveMountResult {
+  const trimmed = name.trim()
+  if (trimmed.length === 0) return { ok: false, reason: 'Mount name cannot be empty.' }
+
+  const parsed = readConfigRecord(cwd)
+  if (!parsed.ok) return parsed
+
+  const current = readMounts(parsed.value)
+  if (!current.ok) return current
+
+  const removed = current.value.find((m) => m.name === trimmed)
+  if (removed === undefined) return { ok: false, reason: `Mount "${trimmed}" not found in ${CONFIG_FILE}.` }
+
+  const next = { ...parsed.value, mounts: current.value.filter((m) => m.name !== trimmed) }
+  const write = writeMounts(cwd, next, `mount: remove ${trimmed}`)
+  if (!write.ok) return write
+  return { ok: true, removed: toListEntry(removed, cwd) }
+}
+
+function buildMount(
+  name: string,
+  path: string,
+  options: AddMountOptions,
+): { ok: true; value: Mount } | { ok: false; reason: string } {
+  const description = options.description?.trim()
+  const raw = {
+    name: name.trim(),
+    path,
+    readOnly: options.readOnly ?? false,
+    ...(description !== undefined && description.length > 0 ? { description } : {}),
+  }
+  const parsed = mountSchema.safeParse(raw)
+  if (!parsed.success) {
+    return { ok: false, reason: parsed.error.issues.map(formatIssue).join('; ') }
+  }
+  return { ok: true, value: parsed.data }
+}
+
+function readConfigRecord(cwd: string): { ok: true; value: Record<string, unknown> } | { ok: false; reason: string } {
+  try {
+    const raw = readFileSync(join(cwd, CONFIG_FILE), 'utf8')
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { ok: false, reason: `${CONFIG_FILE} must contain a JSON object.` }
+    }
+    return { ok: true, value: parsed as Record<string, unknown> }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { ok: false, reason: `${CONFIG_FILE} not found at ${cwd}. Run \`typeclaw init\` first.` }
+    }
+    return { ok: false, reason: `Failed to read ${CONFIG_FILE}: ${(error as Error).message}` }
+  }
+}
+
+function readMounts(record: Record<string, unknown>): { ok: true; value: Mount[] } | { ok: false; reason: string } {
+  const parsed = configSchema.safeParse(record)
+  if (!parsed.success) {
+    return { ok: false, reason: `${CONFIG_FILE} is invalid: ${parsed.error.issues.map(formatIssue).join('; ')}` }
+  }
+  return { ok: true, value: parsed.data.mounts }
+}
+
+function writeMounts(
+  cwd: string,
+  record: Record<string, unknown>,
+  commitMessage: string,
+): { ok: true } | { ok: false; reason: string } {
+  const parsed = configSchema.safeParse(record)
+  if (!parsed.success) {
+    return { ok: false, reason: `mounts block would be invalid: ${parsed.error.issues.map(formatIssue).join('; ')}` }
+  }
+
+  for (const mount of parsed.data.mounts) {
+    const check = validateMount(mount, cwd)
+    if (!check.ok) return check
+  }
+
+  try {
+    writeFileSync(join(cwd, CONFIG_FILE), `${JSON.stringify(record, null, 2)}\n`)
+  } catch (error) {
+    return { ok: false, reason: `Failed to write ${CONFIG_FILE}: ${(error as Error).message}` }
+  }
+
+  commitSystemFileSync(cwd, CONFIG_FILE, commitMessage)
+  return { ok: true }
+}
+
+function toListEntry(mount: Mount, cwd: string): MountListEntry {
+  const resolvedPath = expandMountPath(mount.path, cwd)
+  const targetPath = `${MOUNT_TARGET_PREFIX}/${mount.name}`
+  const check = validateMount(mount, cwd)
+  return {
+    ...mount,
+    resolvedPath,
+    targetPath,
+    status: check.ok ? 'ok' : 'error',
+    ...(!check.ok ? { statusReason: check.reason } : {}),
+  }
+}
+
+function formatIssue(issue: { path: PropertyKey[]; message: string }): string {
+  const path = issue.path.length > 0 ? issue.path.map(String).join('.') : '<root>'
+  return `${path}: ${issue.message}`
+}

--- a/src/config/mounts-mutation.ts
+++ b/src/config/mounts-mutation.ts
@@ -132,11 +132,6 @@ function writeMounts(
     return { ok: false, reason: `mounts block would be invalid: ${parsed.error.issues.map(formatIssue).join('; ')}` }
   }
 
-  for (const mount of parsed.data.mounts) {
-    const check = validateMount(mount, cwd)
-    if (!check.ok) return check
-  }
-
   try {
     writeFileSync(join(cwd, CONFIG_FILE), `${JSON.stringify(record, null, 2)}\n`)
   } catch (error) {


### PR DESCRIPTION
## Summary
- add `typeclaw mount add/list/remove` for host directory mounts
- validate mount names and host path accessibility before writing `typeclaw.json`
- show resolved host paths, container target paths, mode, and restart guidance
- document the new command and the `mounts` config block

## Tests
- `bun run format`
- `bun run typecheck`
- `bun run lint`
- `bun test --parallel src/config/mounts-mutation.test.ts src/cli/mount.test.ts src/cli/index.test.ts`
- `git diff --check --cached`

## Notes
- Mount changes are still restart-required because Docker bind mounts are fixed when the container starts.
- Live Docker restart with a newly mounted host directory was not tested.