### PR TITLE
channels: drop inbound floods at the router

### DIFF
--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -30,6 +30,7 @@ import {
   type ChannelSessionRecord,
 } from './persistence'
 import { QUOTED_REPLY_EXCERPT_MAX_CHARS, type AdapterId, type ChannelAdapterConfig } from './schema'
+import { checkSpam } from './spam-filter'
 import type {
   ChannelHistoryMessage,
   ChannelKey,
@@ -1091,6 +1092,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const observed: ObservedInbound[] = []
     for (const item of seeded) {
       if (item.kind === 'message') {
+        if (!checkSpam(item.message.text).ok) continue
         observed.push({
           text: item.message.text,
           authorId: item.message.authorId,
@@ -1453,6 +1455,20 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       workspace: event.workspace,
       chat: event.chat,
       thread: event.thread,
+    }
+
+    // Spam filter runs before everything (including claim/permission/command
+    // dispatch) so a flood message can't bypass it by colliding with a claim
+    // prefix or a slash command. We drop silently — same convention as other
+    // pre-route rejections like permission denial — to avoid amplifying the
+    // grief with a chatty error reply.
+    const spam = checkSpam(event.text)
+    if (!spam.ok) {
+      publishInbound(event, 'denied')
+      logger.info(
+        `[channels] ${channelKeyId(key)}: dropped by spam filter author=${event.authorId} id=${event.externalMessageId} reason=${spam.reason} len=${event.text.length}`,
+      )
+      return
     }
 
     // Role-claim intercept runs BEFORE the channel.respond gate so the

--- a/src/channels/spam-filter.test.ts
+++ b/src/channels/spam-filter.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from 'bun:test'
+
+import { checkSpam } from './spam-filter'
+
+describe('checkSpam — short messages always pass', () => {
+  test('empty string passes', () => {
+    expect(checkSpam('')).toEqual({ ok: true })
+  })
+
+  test('one-liner Korean laughter passes', () => {
+    expect(checkSpam('ㅋㅋㅋ')).toEqual({ ok: true })
+  })
+
+  test('enthusiastic but short laughter passes', () => {
+    expect(checkSpam('ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ')).toEqual({ ok: true })
+  })
+
+  test('short emphatic punctuation passes', () => {
+    expect(checkSpam('!!!!!!!!!!')).toEqual({ ok: true })
+  })
+
+  test('short English chatter passes', () => {
+    expect(checkSpam('lol that was wild')).toEqual({ ok: true })
+  })
+})
+
+describe('checkSpam — flood patterns are blocked', () => {
+  test('production case: 500x ㅋ is blocked by repeated-char-run', () => {
+    const result = checkSpam('ㅋ'.repeat(500))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toMatch(/^repeated-char-run:/)
+  })
+
+  test('40x ㅋ on the edge of MIN_LENGTH is blocked', () => {
+    const result = checkSpam('ㅋ'.repeat(40))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toMatch(/^repeated-char-run:40$/)
+  })
+
+  test('Latin character flood is blocked', () => {
+    const result = checkSpam('a'.repeat(100))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toMatch(/^repeated-char-run:/)
+  })
+
+  test('emoji flood is blocked', () => {
+    const result = checkSpam('🤣'.repeat(60))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toMatch(/^repeated-char-run:/)
+  })
+
+  test('precomposed Korean syllable repetition is blocked', () => {
+    const result = checkSpam('크'.repeat(80))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toMatch(/^repeated-char-run:/)
+  })
+
+  test('alternating two characters with low diversity is blocked', () => {
+    const result = checkSpam('ab'.repeat(60))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toMatch(/^low-unique-ratio:/)
+  })
+
+  test('character dominance is blocked even when runs are broken up', () => {
+    // 'a' interleaved with rotating chars: no run >2, but ~90% are 'a'.
+    const filler = 'bcdefghij'
+    let text = ''
+    for (let i = 0; i < 100; i++) text += 'aa' + filler[i % filler.length]
+    const result = checkSpam(text)
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toMatch(/^(char-dominance|low-unique-ratio):/)
+  })
+})
+
+describe('checkSpam — long benign messages pass', () => {
+  test('long English sentence passes', () => {
+    const text =
+      'I think the new release dropped this morning, which is great timing because we still need to coordinate with the platform team about the upgrade window and rollback plan.'
+    expect(checkSpam(text)).toEqual({ ok: true })
+  })
+
+  test('long Korean sentence with natural ㅋㅋㅋ scattered passes', () => {
+    const text =
+      '오늘 회의에서 결정된 내용 정리해서 공유드릴게요 ㅋㅋㅋ 다음주 배포 일정도 같이 확인 부탁드려요 ㅋㅋㅋ 그리고 새로 들어온 이슈 우선순위도 한번 봐주시면 감사하겠습니다'
+    expect(checkSpam(text)).toEqual({ ok: true })
+  })
+
+  test('mixed-language paragraph passes', () => {
+    const text =
+      'Latest 빌드 is failing on CI — looks like a flaky 테스트 in the channel router. PR #1234 should fix it once review is done.'
+    expect(checkSpam(text)).toEqual({ ok: true })
+  })
+
+  test('code snippet with repeated tokens passes', () => {
+    const text = 'function foo(a, b, c, d, e, f) { return a + b + c + d + e + f; }'
+    expect(checkSpam(text)).toEqual({ ok: true })
+  })
+})
+
+describe('checkSpam — Unicode normalisation', () => {
+  test('compatibility jamo and initial jamo collapse to the same run', () => {
+    const compat = '\u314b'.repeat(40)
+    const initial = '\u110f'.repeat(40)
+    expect(checkSpam(compat).ok).toBe(false)
+    expect(checkSpam(initial).ok).toBe(false)
+  })
+})

--- a/src/channels/spam-filter.ts
+++ b/src/channels/spam-filter.ts
@@ -1,0 +1,79 @@
+// Inbound content filter for the "single character repeated hundreds of
+// times" griefing pattern (e.g. 500x "ㅋ" on one line). Tuned to ignore
+// normal "ㅋㅋㅋ" / "lol" / "..." chatter and only flag egregious floods.
+// Operates on NFKC-normalised graphemes so "ㅋ" (U+314B compat jamo) and
+// "ᄏ" (U+110F initial jamo) collapse to the same code point; precomposed
+// syllables ("크크크" U+D06C) are still distinct and caught by run length.
+
+export type SpamCheckResult = { ok: true } | { ok: false; reason: string }
+
+// MIN_LENGTH guards against false positives on short chat (a 6-char "ㅋㅋㅋㅋㅋㅋ"
+// is normal). MAX_RUN was picked against the production case — anything over
+// a dozen is unusual, 30 leaves headroom for "ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ대박" or "!!!!!!!".
+// MIN_LONG_LENGTH gates the more expensive ratio/dominance checks to messages
+// long enough that a low unique-char ratio is meaningful signal. Dominance
+// bound matches the public DorianAarno/SpamFilter Discord rule (85%) with
+// slightly looser cutoff to keep our false-positive rate low.
+const MIN_LENGTH = 40
+const MAX_RUN = 30
+const MIN_LONG_LENGTH = 80
+const MIN_UNIQUE_RATIO = 0.05
+const MAX_DOMINANCE = 0.9
+
+export function checkSpam(text: string): SpamCheckResult {
+  if (text.length < MIN_LENGTH) return { ok: true }
+
+  const graphemes = Array.from(text.normalize('NFKC'))
+  if (graphemes.length < MIN_LENGTH) return { ok: true }
+
+  const longestRun = findLongestRun(graphemes)
+  if (longestRun >= MAX_RUN) {
+    return { ok: false, reason: `repeated-char-run:${longestRun}` }
+  }
+
+  if (graphemes.length < MIN_LONG_LENGTH) return { ok: true }
+
+  const counts = countGraphemes(graphemes)
+  const uniqueRatio = counts.size / graphemes.length
+  if (uniqueRatio < MIN_UNIQUE_RATIO) {
+    return { ok: false, reason: `low-unique-ratio:${uniqueRatio.toFixed(3)}` }
+  }
+
+  const dominance = maxValue(counts) / graphemes.length
+  if (dominance > MAX_DOMINANCE) {
+    return { ok: false, reason: `char-dominance:${dominance.toFixed(2)}` }
+  }
+
+  return { ok: true }
+}
+
+function findLongestRun(graphemes: readonly string[]): number {
+  if (graphemes.length === 0) return 0
+  let longest = 1
+  let current = 1
+  for (let i = 1; i < graphemes.length; i++) {
+    if (graphemes[i] === graphemes[i - 1]) {
+      current++
+      if (current > longest) longest = current
+    } else {
+      current = 1
+    }
+  }
+  return longest
+}
+
+function countGraphemes(graphemes: readonly string[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const g of graphemes) {
+    counts.set(g, (counts.get(g) ?? 0) + 1)
+  }
+  return counts
+}
+
+function maxValue(counts: Map<string, number>): number {
+  let max = 0
+  for (const v of counts.values()) {
+    if (v > max) max = v
+  }
+  return max
+}


### PR DESCRIPTION
## Summary

A user pasted ~500 repeated "ㅋ" characters (Korean laughter jamo, U+314B) into a Slack channel routed through typeclaw. The model consumed the whole flood as a single inbound message and burned tokens for nothing. This PR adds a spam filter that drops those floods before they reach the model.

## Root cause

There was no pre-route guard for pathologically repetitive text. Any message that made it past the channel adapter went straight into the context window. A single user in a public-channel deployment could grief the agent indefinitely — no exploit required, just paste.

## Changes

### `src/channels/spam-filter.ts` (new)

Pure function `checkSpam(text)` returning a discriminated union: `{ok: true}` or `{ok: false, reason: string}`. No I/O, no state, no config reads. The result shape mirrors the `{ok, reason}` union established in `src/cron/schema.ts`.

Three layered checks on NFKC-normalised graphemes, cheapest first:

1. **Longest identical run ≥ 30** — catches the production trigger directly.
2. **Unique-grapheme ratio < 5%** on messages ≥ 80 chars — catches low-diversity floods of two or three alternating characters.
3. **Any single grapheme covers > 90%** of messages ≥ 80 chars — catches floods with a small noise tail.

A 40-char length floor means short chatter ("ㅋㅋㅋ", "lol", "!!!!!") always passes. NFKC normalisation collapses compatibility jamo (U+314B "ㅋ") and initial jamo (U+110F "ᄏ") to the same code point so both forms are caught by the run-length check; precomposed syllables ("크크크", U+D06C) remain distinct but the run-length check catches those too.

### `src/channels/router.ts` (+16 lines)

Two call sites:

- **Top of `router.route()`** — runs before claim/permission/command dispatch. A flood cannot bypass the filter by colliding with a slash command or claim prefix.
- **`prefetchChannelContext` loop** — cold-start history backfill skips flagged items so the same spam that triggered the original message cannot re-enter via history replay.

Both sites drop silently with a log line. This matches the existing pre-route denial convention (channel `respond` denial at line 1494): we do not send an error reply because a chatty reply would amplify the grief.

### `src/channels/spam-filter.test.ts` (new, 17 tests)

- 5 **short-pass** cases: empty string, "ㅋㅋㅋ", 10× ㅋ, "!!!!!!!!!!", "lol that was wild" — all must pass.
- 7 **flood-blocked** cases: 500× ㅋ (production trigger), 40× ㅋ (MIN_LENGTH edge), 100× "a", 60× 🤣, 80× 크 (precomposed syllable), 60× "ab" (low-diversity), interleaved dominance pattern.
- 4 **long-benign-pass** cases: long English prose, long Korean with scattered ㅋ, mixed-script, code snippet.
- 1 **Unicode normalisation** case: compatibility jamo and initial jamo collapse to the same run.

## Design notes

**One chokepoint covers all adapters.** Every adapter — Slack, Discord, Telegram, KakaoTalk, GitHub — calls `router.route(InboundMessage)`. Patching the top of `route()` applies the guard in one place rather than editing five separate classifier paths.

**No config knob in v1.** The defaults handle the known threat. Adding a `typeclaw.json` tuning field later is easy; removing one is hard. This stays out of the config schema until there is evidence that the thresholds need user control.

**Pure function, co-located test.** `spam-filter.ts` has no side effects. The test file sits next to it following the repo's `<file>.test.ts` convention (mirrors `telegram-bot-format.test.ts`).

## Verification

```
bun run typecheck           ✓  0 errors
bun run lint                ✓  0 errors  (60 pre-existing warnings in dockerfile.ts, none from new files)
bun run format              ✓  clean
bun test --parallel src/channels/   ✓  1013 pass, 0 fail
```

## Review notes

- **`checkSpam` in `src/channels/spam-filter.ts`** is the load-bearing logic. The three checks are ordered cheapest first; the 40-char length floor is the first guard inside the function, before any of the three runs. Moving the floor or changing its value changes the false-positive boundary — cover any threshold change with a new short-pass test.
- **The two `router.ts` call sites** are independent. The `prefetchChannelContext` patch is defensive rather than critical — it prevents history replay from re-importing the same spam on cold start.
- **Silent drop is intentional.** The log line gives operators visibility without sending anything to the channel. If the policy needs to change (e.g. a short "message too repetitive" reply), both call sites are clearly marked.