### PR TITLE
channels: suppress plain-text channel_reply(...) leaks in turn recovery

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1731,6 +1731,68 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('suppressed kimi_tool_call_leak'))).toBe(false)
   })
 
+  test('suppresses leaked plain-text channel_reply(...) function-call serialization instead of posting it to the channel', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('channel_reply({"text":"hi there"})')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('suppressed plain_text_channel_tool_call'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('suppresses leaked plain-text channel_send(...) serialization the same way', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('channel_send({"adapter":"discord-bot","chat":"c1","text":"hi"})')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('suppressed plain_text_channel_tool_call'))).toBe(true)
+  })
+
+  test('still recovers prose that mentions channel_reply in a non-call shape', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'how do I reply?' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('Use the channel_reply tool — pass `text` and I will deliver it for you.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('channel_reply tool')
+    expect(logs.some((m) => m.includes('suppressed plain_text_channel_tool_call'))).toBe(false)
+  })
+
   test('recovers visible assistant text when no channel tool sent a message', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1998,6 +1998,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return
     }
 
+    if (isLikelyPlainTextChannelToolCall(assistantText)) {
+      logger.warn(`[channels] ${live.keyId}: suppressed plain_text_channel_tool_call text_len=${assistantText.length}`)
+      return
+    }
+
     // `source` distinguishes the two recovery shapes for log triage:
     //   - 'leaf': the assistant message IS the leaf (existing behavior; model
     //     ended its turn with text but forgot to call channel_reply).
@@ -2958,6 +2963,36 @@ const KIMI_CHANNEL_TOOL_ID_RE = /(?:functions\.)?channel_(?:reply|send):\d+/
 export function isLikelyKimiChannelToolLeak(text: string): boolean {
   if (!containsKimiToolDelimiter(text)) return false
   return KIMI_CHANNEL_TOOL_ID_RE.test(text)
+}
+
+// Detects the *plain-text* shape of a leaked channel-tool invocation — the
+// model serialized the tool call as ordinary prose instead of producing a
+// real tool call. Observed against Kimi-family deployments on KakaoTalk:
+// the entire assistant message body is literally
+//
+//   channel_reply({"text":"<the user-facing greeting the bot meant to send>"})
+//
+// with no Kimi delimiter tokens (`<|tool_call_begin|>` etc.), so
+// `isLikelyKimiChannelToolLeak` cannot catch it. Without a guard the
+// recovery path in `validateChannelTurn` posts this raw function-call
+// serialization straight to the channel, which is exactly what
+// users see in the reported screenshots.
+//
+// Structural-only detection (NOT a substring search): the trimmed text must
+// *start* with `channel_reply(` or `channel_send(`, and that opening paren
+// must enclose at least one `"` (the JSON argument). This deliberately
+// matches the leak shape while letting prose that merely *mentions* the
+// tool name (e.g. "I would normally call channel_reply here but...") reach
+// the user — that false-positive class is already locked in by the
+// `still recovers legit prose that happens to mention "channel_reply"` test.
+//
+// The trailing close paren is NOT required: the model sometimes truncates
+// mid-serialization, and a half-leaked `channel_reply({"text":"..."` is
+// just as user-hostile as the full shape.
+const PLAIN_TEXT_CHANNEL_TOOL_CALL_RE = /^channel_(?:reply|send)\s*\(\s*[^)]*"/
+
+export function isLikelyPlainTextChannelToolCall(text: string): boolean {
+  return PLAIN_TEXT_CHANNEL_TOOL_CALL_RE.test(text.trim())
 }
 
 function describe(err: unknown): string {


### PR DESCRIPTION
## Summary

A KakaoTalk channel reported the bot sending raw function-call syntax as plain text. The leaked message body looked like:

```
channel_reply({"text":"<the user-facing greeting the bot meant to send>"})
```

The model emitted its `channel_reply` invocation as ordinary assistant text instead of producing a real tool call. With no tool fired, `validateChannelTurn`'s recovery path picked up the assistant text and posted the raw function-call serialization straight to the user.

## Root cause

`isLikelyKimiChannelToolLeak` in `src/channels/router.ts` only catches the **delimiter-wrapped** Kimi shape — e.g. `<|tool_call_begin|>functions.channel_reply:0<|tool_call_argument_begin|>{...}<|tool_call_end|>`. Its predicate requires `containsKimiToolDelimiter` to match a `<|...|>` token, so a plain-text leak with no delimiters slips through and is treated as legitimate assistant prose worth recovering.

This is the same class of upstream-parser failure (Kimi-family models on Fireworks/vLLM emitting their tool-call template inline in `choice.delta.content` instead of `choice.delta.tool_calls`) — just a different observed shape.

## Changes

### `src/channels/router.ts` (+35 lines)

New sibling detector `isLikelyPlainTextChannelToolCall`:

```ts
const PLAIN_TEXT_CHANNEL_TOOL_CALL_RE = /^channel_(?:reply|send)\s*\(\s*[^)]*"/

export function isLikelyPlainTextChannelToolCall(text: string): boolean {
  return PLAIN_TEXT_CHANNEL_TOOL_CALL_RE.test(text.trim())
}
```

**Structural-only**, not a substring search:

1. **Anchored at start** of the trimmed body — prose that merely *mentions* `channel_reply` won't match.
2. **Requires `(`** opening a parameter list — distinguishes a serialized call from a sentence containing the tool name.
3. **Requires a `"`** inside the opening parens — ensures it looks like JSON arguments, not e.g. `channel_reply (the tool above)`.
4. **Closing paren is NOT required** — models sometimes truncate mid-serialization, and a half-leaked `channel_reply({"text":"..."` is just as user-hostile as the full shape.

Wired into `validateChannelTurn` as a third guard, after `isUpstreamEmptyResponseSentinel` and `isLikelyKimiChannelToolLeak`, with the matching log subject `suppressed plain_text_channel_tool_call` for operator triage.

### `src/channels/router.test.ts` (+62 lines)

Three new behavior tests:

1. **`suppresses leaked plain-text channel_reply(...) ...`** — true-positive: the canonical leak shape (with a synthetic `"hi there"` payload, not the original user content) is suppressed, `sent` is empty, the new log subject is emitted.
2. **`suppresses leaked plain-text channel_send(...) the same way`** — mirror coverage for the `channel_send` variant.
3. **`still recovers prose that mentions channel_reply in a non-call shape`** — false-positive guard: a sentence like *"Use the channel_reply tool — pass `text` and I will deliver it for you."* still reaches the user via the existing recovery path. Locks in the boundary that the regex shape was designed for.

## What this does NOT do

- **No change at the `channel_reply` / `channel_send` tool boundaries.** Existing `kimiToolCallLeakError` already covers the case where the model invokes the tool with a delimiter-leaked body as the `text` argument; the new shape only matters when no tool fires at all, which is exclusively a recovery-path concern.
- **No model prompt changes.** This is defense-in-depth at the router, not a behavior change for healthy turns.
- **No log-level escalation.** Same `logger.warn` shape as the sibling Kimi-delimiter guard; operators triage both via `suppressed_*` grep.

## Verification

```
bun run typecheck    ✓  0 errors
bun run lint         ✓  60 pre-existing warnings, 0 errors
bun run format       ✓  clean
bun test --parallel src/channels/router.test.ts   ✓  226 pass, 0 fail
```

Full `bun run test` flakes on the pre-existing `resolveSelfPackageJsonPath > points at this package manifest` (the worktree path doesn't end in `typeclaw/`); reproduces identically on `origin/main` with my diff reverted. Unrelated to this PR.

## Review notes

- The regex shape is the load-bearing decision. Loosen it (e.g. drop the `"` requirement) and you'd start suppressing legitimate prose like *"call channel_reply()  to reply"*. Tighten it (e.g. require the closing paren) and you'd let truncated leaks through.
- `validateChannelTurn` guard ordering is **`upstream_empty_response_sentinel` → `kimi_tool_call_leak` → `plain_text_channel_tool_call`**. The order is deliberate: each predicate is strictly narrower than the previous, and earlier guards have richer log context (Kimi sentinel matches carry the failing model's stop_reason).
- Test payloads use synthetic strings (`"hi there"`) rather than the reported user content to keep private chat text out of the repo.
