### PR TITLE
agent: refuse tool-call loops at the wrapper layer

### DIFF
--- a/src/agent/loop-guard.test.ts
+++ b/src/agent/loop-guard.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createLoopGuard, LOOP_HARD_BLOCK, LOOP_SOFT_WARN } from './loop-guard'
+
+describe('createLoopGuard', () => {
+  test('returns ok for the first call with a given signature', () => {
+    const guard = createLoopGuard()
+    const decision = guard.check('s1', 'bash', { command: 'ls' })
+    expect(decision.kind).toBe('ok')
+  })
+
+  test('returns ok up to (softWarn - 1) consecutive identical calls', () => {
+    const guard = createLoopGuard()
+    for (let i = 1; i < LOOP_SOFT_WARN; i++) {
+      const decision = guard.check('s1', 'bash', { command: 'ls' })
+      expect(decision.kind).toBe('ok')
+    }
+  })
+
+  test('emits a warn decision exactly at the softWarn count', () => {
+    const guard = createLoopGuard()
+    for (let i = 1; i < LOOP_SOFT_WARN; i++) {
+      guard.check('s1', 'bash', { command: 'ls' })
+    }
+    const decision = guard.check('s1', 'bash', { command: 'ls' })
+    expect(decision.kind).toBe('warn')
+    if (decision.kind === 'warn') {
+      expect(decision.count).toBe(LOOP_SOFT_WARN)
+      expect(decision.message).toContain('bash')
+      expect(decision.message).toContain('thought-loop')
+    }
+  })
+
+  test('soft warning fires only once per streak', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 10 })
+    expect(guard.check('s1', 'bash', { command: 'ls' }).kind).toBe('ok')
+    expect(guard.check('s1', 'bash', { command: 'ls' }).kind).toBe('ok')
+    expect(guard.check('s1', 'bash', { command: 'ls' }).kind).toBe('warn')
+    expect(guard.check('s1', 'bash', { command: 'ls' }).kind).toBe('ok')
+    expect(guard.check('s1', 'bash', { command: 'ls' }).kind).toBe('ok')
+  })
+
+  test('emits a block decision at the hardBlock count and beyond', () => {
+    const guard = createLoopGuard()
+    let lastDecision: ReturnType<typeof guard.check> = { kind: 'ok' }
+    for (let i = 1; i <= LOOP_HARD_BLOCK; i++) {
+      lastDecision = guard.check('s1', 'bash', { command: 'ls' })
+    }
+    expect(lastDecision.kind).toBe('block')
+    if (lastDecision.kind === 'block') {
+      expect(lastDecision.count).toBe(LOOP_HARD_BLOCK)
+      expect(lastDecision.message).toContain('bash')
+    }
+    const next = guard.check('s1', 'bash', { command: 'ls' })
+    expect(next.kind).toBe('block')
+    if (next.kind === 'block') {
+      expect(next.count).toBe(LOOP_HARD_BLOCK + 1)
+    }
+  })
+
+  test('resets the streak when the tool name changes', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    guard.check('s1', 'bash', { command: 'ls' })
+    guard.check('s1', 'bash', { command: 'ls' })
+    const switched = guard.check('s1', 'read', { path: 'x' })
+    expect(switched.kind).toBe('ok')
+    expect(guard.check('s1', 'read', { path: 'x' }).kind).toBe('ok')
+    expect(guard.check('s1', 'read', { path: 'x' }).kind).toBe('warn')
+  })
+
+  test('resets the streak when the args change', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    guard.check('s1', 'bash', { command: 'ls' })
+    guard.check('s1', 'bash', { command: 'ls' })
+    const switched = guard.check('s1', 'bash', { command: 'pwd' })
+    expect(switched.kind).toBe('ok')
+    expect(guard.check('s1', 'bash', { command: 'pwd' }).kind).toBe('ok')
+    expect(guard.check('s1', 'bash', { command: 'pwd' }).kind).toBe('warn')
+  })
+
+  test('treats key insertion order as irrelevant for equality', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    guard.check('s1', 'edit', { path: 'a.ts', content: 'x' })
+    guard.check('s1', 'edit', { content: 'x', path: 'a.ts' })
+    expect(guard.check('s1', 'edit', { path: 'a.ts', content: 'x' }).kind).toBe('warn')
+  })
+
+  test('keeps streaks per session independent', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    guard.check('s1', 'bash', { command: 'ls' })
+    guard.check('s1', 'bash', { command: 'ls' })
+    expect(guard.check('s2', 'bash', { command: 'ls' }).kind).toBe('ok')
+    expect(guard.check('s1', 'bash', { command: 'ls' }).kind).toBe('warn')
+  })
+
+  test('forget(sessionId) clears a session-scoped streak', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    guard.check('s1', 'bash', { command: 'ls' })
+    guard.check('s1', 'bash', { command: 'ls' })
+    guard.forget('s1')
+    expect(guard.check('s1', 'bash', { command: 'ls' }).kind).toBe('ok')
+    expect(guard.check('s1', 'bash', { command: 'ls' }).kind).toBe('ok')
+    expect(guard.check('s1', 'bash', { command: 'ls' }).kind).toBe('warn')
+  })
+
+  test('evicts the oldest session once maxSessions is exceeded', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5, maxSessions: 2 })
+    guard.check('s1', 'bash', { command: 'ls' })
+    guard.check('s1', 'bash', { command: 'ls' })
+    guard.check('s2', 'bash', { command: 'ls' })
+    guard.check('s2', 'bash', { command: 'ls' })
+    guard.check('s3', 'bash', { command: 'ls' })
+    expect(guard.check('s1', 'bash', { command: 'ls' }).kind).toBe('ok')
+  })
+
+  test('handles unstringifiable arguments without throwing', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    const cyclic: Record<string, unknown> = { name: 'x' }
+    cyclic.self = cyclic
+    expect(() => guard.check('s1', 'bash', cyclic)).not.toThrow()
+    guard.check('s1', 'bash', cyclic)
+    expect(guard.check('s1', 'bash', cyclic).kind).toBe('warn')
+  })
+
+  test('rejects invalid thresholds at construction time', () => {
+    expect(() => createLoopGuard({ softWarn: 1, hardBlock: 5 })).toThrow()
+    expect(() => createLoopGuard({ softWarn: 5, hardBlock: 5 })).toThrow()
+    expect(() => createLoopGuard({ softWarn: 5, hardBlock: 3 })).toThrow()
+  })
+})

--- a/src/agent/loop-guard.ts
+++ b/src/agent/loop-guard.ts
@@ -1,0 +1,170 @@
+// Detects when the model calls the same tool with byte-identical arguments in
+// a tight streak — the classic "stuck in a thought-loop" failure where the
+// agent repeats `bash("ls")` or `read("foo.ts")` indefinitely waiting for a
+// different answer. Two-tier escalation:
+//
+//   - At LOOP_SOFT_WARN consecutive identical calls (default 3), the next call
+//     completes normally but the wrapped tool's output is suffixed with a nudge
+//     telling the model it's looping. Soft warning fires ONCE per streak so
+//     the model isn't drowning in identical reminders.
+//   - At LOOP_HARD_BLOCK consecutive identical calls (default 5), the call is
+//     refused outright. The wrapping in plugin-tools.ts maps the refusal to
+//     `errorResult` for plugin tools (the model sees a tool error and must
+//     change strategy) and to a thrown Error for system / pi-builtin tools
+//     (matches the existing `tool.before { block: true }` plumbing).
+//
+// State is per-session and bounded: the guard keeps at most MAX_SESSIONS
+// session entries with LRU eviction, and each session holds at most one
+// signature + counter (we only care about the current tail streak). When a
+// different tool/args combination arrives, the streak resets to 1.
+//
+// The detector is intentionally placed INSIDE the tool wrappers (not as a
+// `tool.before` plugin) so it covers every tool category — plugin tools,
+// TypeClaw system tools, and pi-coding-agent builtins — through one chokepoint.
+
+export const LOOP_SOFT_WARN = 3
+export const LOOP_HARD_BLOCK = 5
+
+// Caps in-process memory across many sessions. Each entry is small
+// (signature string + small counters), so this bound is generous; we just
+// don't want unbounded growth if sessionIds churn.
+const MAX_SESSIONS = 256
+
+export type LoopGuardDecision =
+  | { kind: 'ok' }
+  | { kind: 'warn'; count: number; message: string }
+  | { kind: 'block'; count: number; message: string }
+
+export type LoopGuard = {
+  check: (sessionId: string, tool: string, args: unknown) => LoopGuardDecision
+  reset: (sessionId: string) => void
+  forget: (sessionId: string) => void
+}
+
+type SessionState = {
+  signature: string
+  count: number
+  // Fires the soft warning exactly once per streak instead of every call
+  // from the 3rd onwards. Re-arms when the streak breaks.
+  warned: boolean
+}
+
+export type CreateLoopGuardOptions = {
+  softWarn?: number
+  hardBlock?: number
+  maxSessions?: number
+}
+
+export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard {
+  const softWarn = options.softWarn ?? LOOP_SOFT_WARN
+  const hardBlock = options.hardBlock ?? LOOP_HARD_BLOCK
+  const maxSessions = options.maxSessions ?? MAX_SESSIONS
+
+  if (softWarn < 2) throw new Error(`loop-guard: softWarn must be >= 2 (got ${softWarn})`)
+  if (hardBlock <= softWarn) {
+    throw new Error(`loop-guard: hardBlock (${hardBlock}) must be greater than softWarn (${softWarn})`)
+  }
+
+  // Map preserves insertion order; we rely on that for LRU eviction.
+  const sessions = new Map<string, SessionState>()
+
+  function touch(sessionId: string, state: SessionState): void {
+    sessions.delete(sessionId)
+    sessions.set(sessionId, state)
+    if (sessions.size > maxSessions) {
+      const oldest = sessions.keys().next().value
+      if (oldest !== undefined) sessions.delete(oldest)
+    }
+  }
+
+  return {
+    check(sessionId, tool, args) {
+      const signature = makeCallSignature(tool, args)
+      const existing = sessions.get(sessionId)
+
+      if (!existing || existing.signature !== signature) {
+        touch(sessionId, { signature, count: 1, warned: false })
+        return { kind: 'ok' }
+      }
+
+      const nextCount = existing.count + 1
+      const nextState: SessionState = {
+        signature,
+        count: nextCount,
+        warned: existing.warned,
+      }
+
+      if (nextCount >= hardBlock) {
+        touch(sessionId, nextState)
+        return {
+          kind: 'block',
+          count: nextCount,
+          message: formatBlockMessage(tool, nextCount),
+        }
+      }
+
+      if (nextCount >= softWarn && !nextState.warned) {
+        nextState.warned = true
+        touch(sessionId, nextState)
+        return {
+          kind: 'warn',
+          count: nextCount,
+          message: formatWarnMessage(tool, nextCount),
+        }
+      }
+
+      touch(sessionId, nextState)
+      return { kind: 'ok' }
+    },
+    reset(sessionId) {
+      const existing = sessions.get(sessionId)
+      if (!existing) return
+      // Resetting is what `tool.after` does on a non-identical call too;
+      // exposed for callers that observe a strategy change externally.
+      sessions.delete(sessionId)
+    },
+    forget(sessionId) {
+      sessions.delete(sessionId)
+    },
+  }
+}
+
+function formatWarnMessage(tool: string, count: number): string {
+  return (
+    `\n\n[loop-guard] You have called \`${tool}\` ${count} times in a row with identical arguments. ` +
+    `This looks like a thought-loop. If you have enough information, produce the final answer now. ` +
+    `If something is unclear, ask the user one specific question. Do not repeat this exact call.`
+  )
+}
+
+function formatBlockMessage(tool: string, count: number): string {
+  return (
+    `loop-guard: refused \`${tool}\` — identical call repeated ${count} times in a row. ` +
+    `Stop. Either (1) produce the final answer with the data you already have, ` +
+    `(2) ask the user a clarifying question, or (3) try a meaningfully different approach. ` +
+    `Do not retry this exact call.`
+  )
+}
+
+function makeCallSignature(tool: string, args: unknown): string {
+  try {
+    return `${tool}:${stableStringify(args)}`
+  } catch {
+    return `${tool}:<unstringifiable>`
+  }
+}
+
+// Order-independent JSON serialization so semantically-identical objects
+// produce identical signatures regardless of key insertion order.
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    const s = JSON.stringify(value)
+    return s ?? 'null'
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`
+  }
+  const obj = value as Record<string, unknown>
+  const keys = Object.keys(obj).sort()
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`
+}

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -11,6 +11,7 @@ import { z } from 'zod'
 import { createHookBus, defineTool, type PluginRegistry } from '@/plugin'
 
 import {
+  __resetSharedLoopGuardForTests,
   buildBuiltinPiToolOverrides,
   defaultBuiltinPiAgentTools,
   wrapAgentToolAsCustomToolDefinition,
@@ -19,6 +20,10 @@ import {
   wrapSystemTool,
   zodToToolParameters,
 } from './plugin-tools'
+
+beforeEach(() => {
+  __resetSharedLoopGuardForTests()
+})
 
 const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
 
@@ -1046,5 +1051,161 @@ describe('setupSession integration: builtin pi tools route through customTools w
     expect(active.has('ls')).toBe(false)
 
     session.dispose()
+  })
+})
+
+describe('loop guard integration', () => {
+  test('appends a soft-warning suffix to a plugin tool result on the third identical call', async () => {
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ q: z.string() }),
+      async execute(args) {
+        return { content: [{ type: 'text', text: `q=${args.q}` }] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'search',
+      agentDir: '/agent',
+      sessionId: 'loop-plugin-1',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+
+    const r1 = (await wrapped.execute('c1', { q: 'a' }, undefined, undefined, {} as never)) as {
+      content: { type: string; text: string }[]
+    }
+    expect(r1.content.length).toBe(1)
+
+    await wrapped.execute('c2', { q: 'a' }, undefined, undefined, {} as never)
+    const r3 = (await wrapped.execute('c3', { q: 'a' }, undefined, undefined, {} as never)) as {
+      content: { type: string; text: string }[]
+    }
+    expect(r3.content.length).toBe(2)
+    expect(r3.content[1]?.text).toContain('loop-guard')
+    expect(r3.content[1]?.text).toContain('search')
+  })
+
+  test('refuses the fifth identical plugin tool call with an error result and never invokes the tool', async () => {
+    const calls: number[] = []
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ q: z.string() }),
+      async execute() {
+        calls.push(1)
+        return { content: [{ type: 'text', text: 'ok' }] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'search',
+      agentDir: '/agent',
+      sessionId: 'loop-plugin-2',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+
+    for (let i = 0; i < 4; i++) {
+      await wrapped.execute(`c${i}`, { q: 'a' }, undefined, undefined, {} as never)
+    }
+    expect(calls.length).toBe(4)
+    const blocked = (await wrapped.execute('c5', { q: 'a' }, undefined, undefined, {} as never)) as {
+      isError?: boolean
+      content: { type: string; text: string }[]
+    }
+    expect(calls.length).toBe(4)
+    expect(blocked.isError).toBe(true)
+    expect(blocked.content[0]?.text).toContain('loop-guard')
+  })
+
+  test('resets the streak when the args change between plugin tool calls', async () => {
+    const calls: string[] = []
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ q: z.string() }),
+      async execute(args) {
+        calls.push(args.q)
+        return { content: [{ type: 'text', text: args.q }] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'search',
+      agentDir: '/agent',
+      sessionId: 'loop-plugin-3',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+
+    await wrapped.execute('c1', { q: 'a' }, undefined, undefined, {} as never)
+    await wrapped.execute('c2', { q: 'a' }, undefined, undefined, {} as never)
+    await wrapped.execute('c3', { q: 'b' }, undefined, undefined, {} as never)
+    await wrapped.execute('c4', { q: 'b' }, undefined, undefined, {} as never)
+    const r5 = (await wrapped.execute('c5', { q: 'b' }, undefined, undefined, {} as never)) as {
+      isError?: boolean
+      content: { type: string; text: string }[]
+    }
+    expect(r5.isError).not.toBe(true)
+    expect(r5.content[1]?.text).toContain('loop-guard')
+    expect(calls).toEqual(['a', 'a', 'b', 'b', 'b'])
+  })
+
+  test('throws on the fifth identical system tool call so the engine surfaces the loop error', async () => {
+    const calls: number[] = []
+    const tool = definePiTool({
+      name: 'webfetch',
+      label: 'webfetch',
+      description: '',
+      parameters: Type.Object({ url: Type.String() }),
+      async execute() {
+        calls.push(1)
+        return { content: [{ type: 'text', text: 'ok' }], details: undefined }
+      },
+    })
+    const wrapped = wrapSystemTool(tool, { agentDir: '/agent', sessionId: 'loop-sys-1', hooks: createHookBus() })
+
+    for (let i = 0; i < 4; i++) {
+      await wrapped.execute(`c${i}`, { url: 'https://example.com' }, undefined, undefined, {} as never)
+    }
+    expect(calls.length).toBe(4)
+    await expect(
+      wrapped.execute('c5', { url: 'https://example.com' }, undefined, undefined, {} as never),
+    ).rejects.toThrow(/loop-guard/)
+    expect(calls.length).toBe(4)
+  })
+
+  test('keeps loop streaks isolated between sessions', async () => {
+    const calls: { session: string }[] = []
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({}),
+      async execute() {
+        return { content: [{ type: 'text', text: 'ok' }] }
+      },
+    })
+
+    const make = (sessionId: string) => {
+      return wrapPluginTool(tool, {
+        pluginName: 'p1',
+        toolName: 'search',
+        agentDir: '/agent',
+        sessionId,
+        logger: noopLogger,
+        hooks: createHookBus(),
+      })
+    }
+
+    const wA = make('loop-iso-A')
+    const wB = make('loop-iso-B')
+
+    for (let i = 0; i < 4; i++) {
+      await wA.execute(`a${i}`, {}, undefined, undefined, {} as never)
+      calls.push({ session: 'A' })
+    }
+    const aBlocked = (await wA.execute('a5', {}, undefined, undefined, {} as never)) as { isError?: boolean }
+    expect(aBlocked.isError).toBe(true)
+
+    const bFirst = (await wB.execute('b1', {}, undefined, undefined, {} as never)) as { isError?: boolean }
+    expect(bFirst.isError).not.toBe(true)
   })
 })

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -31,10 +31,18 @@ import type {
   ToolResult,
 } from '@/plugin'
 
+import { createLoopGuard, type LoopGuard } from './loop-guard'
 import { checkImageReadRedirect } from './multimodal/read-redirect'
 import type { SessionOrigin } from './session-origin'
 import { webfetchTool } from './tools/webfetch'
 import { websearchTool } from './tools/websearch'
+
+// Process-wide loop guard. State is keyed by sessionId so concurrent sessions
+// don't interfere; the guard's own LRU bound keeps it from growing without
+// limit. Wrappers consult it before invoking the underlying tool so the
+// detector covers every tool category — plugin tools, TypeClaw system tools,
+// and pi-coding-agent builtins — through one chokepoint.
+let sharedLoopGuard: LoopGuard = createLoopGuard()
 
 const ACKNOWLEDGE_GUARDS_SCHEMA = Type.Optional(
   Type.Object(
@@ -177,6 +185,11 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
         return errorResult(`blocked: ${blockResult.reason}`)
       }
 
+      const loopDecision = sharedLoopGuard.check(opts.sessionId, opts.toolName, before.args)
+      if (loopDecision.kind === 'block') {
+        return errorResult(loopDecision.message)
+      }
+
       const toolCtx: ToolContext = {
         signal,
         sessionId: opts.sessionId,
@@ -190,6 +203,10 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         return errorResult(message)
+      }
+
+      if (loopDecision.kind === 'warn') {
+        result = appendLoopWarning(result, loopDecision.message)
       }
 
       await opts.hooks.runToolAfter({
@@ -227,6 +244,10 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       if (blockResult !== undefined) {
         throw new Error(`blocked: ${blockResult.reason}`)
       }
+      const loopDecision = sharedLoopGuard.check(opts.sessionId, tool.name, mutableArgs)
+      if (loopDecision.kind === 'block') {
+        throw new Error(loopDecision.message)
+      }
       const guardResult = await runFinalWriteGuards({
         tool: tool.name,
         args: mutableArgs,
@@ -245,6 +266,11 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       const hookResult: ToolResult = {
         content: result.content as ContentPart[],
         details: result.details,
+      }
+      if (loopDecision.kind === 'warn') {
+        const warned = appendLoopWarning(hookResult, loopDecision.message)
+        hookResult.content = warned.content
+        hookResult.details = warned.details
       }
       await opts.hooks.runToolAfter({
         tool: tool.name,
@@ -280,6 +306,10 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
       if (blockResult !== undefined) {
         throw new Error(`blocked: ${blockResult.reason}`)
       }
+      const loopDecision = sharedLoopGuard.check(opts.sessionId, tool.name, mutableArgs)
+      if (loopDecision.kind === 'block') {
+        throw new Error(loopDecision.message)
+      }
       const guardResult = await runFinalWriteGuards({
         tool: tool.name,
         args: mutableArgs,
@@ -298,6 +328,11 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
       const hookResult: ToolResult = {
         content: result.content as ContentPart[],
         details: result.details,
+      }
+      if (loopDecision.kind === 'warn') {
+        const warned = appendLoopWarning(hookResult, loopDecision.message)
+        hookResult.content = warned.content
+        hookResult.details = warned.details
       }
       await opts.hooks.runToolAfter({
         tool: tool.name,
@@ -340,6 +375,10 @@ export function wrapAgentToolAsCustomToolDefinition<TParams extends TSchema, TDe
       if (blockResult !== undefined) {
         throw new Error(`blocked: ${blockResult.reason}`)
       }
+      const loopDecision = sharedLoopGuard.check(opts.sessionId, tool.name, mutableArgs)
+      if (loopDecision.kind === 'block') {
+        throw new Error(loopDecision.message)
+      }
       const guardResult = await runFinalWriteGuards({
         tool: tool.name,
         args: mutableArgs,
@@ -358,6 +397,11 @@ export function wrapAgentToolAsCustomToolDefinition<TParams extends TSchema, TDe
       const hookResult: ToolResult = {
         content: result.content as ContentPart[],
         details: result.details,
+      }
+      if (loopDecision.kind === 'warn') {
+        const warned = appendLoopWarning(hookResult, loopDecision.message)
+        hookResult.content = warned.content
+        hookResult.details = warned.details
       }
       await opts.hooks.runToolAfter({
         tool: tool.name,
@@ -379,6 +423,19 @@ export function defaultBuiltinPiAgentTools(): AgentTool<any, any>[] {
 
 export function buildBuiltinPiToolOverrides(opts: WrapSystemToolOptions): ToolDefinition<any, any>[] {
   return defaultBuiltinPiAgentTools().map((tool) => wrapAgentToolAsCustomToolDefinition(tool, opts))
+}
+
+function appendLoopWarning(result: ToolResult, message: string): ToolResult {
+  const content: ContentPart[] = [...(result.content as ContentPart[]), { type: 'text', text: message }]
+  return { content, details: result.details }
+}
+
+// Test-only seam: swaps the shared loop guard for a fresh instance so tests
+// that reuse sessionIds across cases don't see cross-test streak counts.
+// Production code never calls this; the guard's LRU bound handles
+// long-running processes.
+export function __resetSharedLoopGuardForTests(): void {
+  sharedLoopGuard = createLoopGuard()
 }
 
 function errorResult(message: string) {


### PR DESCRIPTION
## Summary

Detects when the model calls the same tool with byte-identical arguments in a tight streak — the `bash("ls") → bash("ls")` failure mode that burns turns without producing new information. Two-tier escalation, model-agnostic, threaded through the existing tool wrappers so it covers plugin tools, TypeClaw system tools, and pi-coding-agent builtins in one place.

- Soft warn at the 3rd consecutive identical call: suffix the tool's result with a one-shot nudge so the model sees the loop on its next read; warning re-arms only after the streak breaks.
- Hard refuse at the 5th: plugin tools return an error result (`isError: true`); system / pi-builtin tools throw (matching the existing `tool.before { block: true }` plumbing).
- Per-session, sessionId-keyed; LRU-bounded to 256 sessions so a long-lived host process can't accumulate state.

## Root cause

No guard existed at the tool-execution layer. A model stuck in a loop — polling a command that returns the same result, re-running a failed edit, re-reading an already-read file — consumed turns indefinitely. The fix belongs at the wrapper layer because that is the single chokepoint every tool call passes through, regardless of which model is active or which adapter fired.

## Changes

### `src/agent/loop-guard.ts` (new, 170 lines)

Pure module with no I/O. Exports:

- `createLoopGuard(opts?)` — factory returning `{ check, reset, forget }`. Defaults: `softWarn=3`, `hardBlock=5`, `maxSessions=256`.
- `LoopGuardDecision` discriminated union: `{ kind: 'ok' }` | `{ kind: 'warn'; count; message }` | `{ kind: 'block'; count; message }`.
- Constructor validates `softWarn >= 2` and `hardBlock > softWarn`.
- Call signature uses an order-independent `stableStringify` so `{a, b}` and `{b, a}` collide as expected. Cyclic / unstringifiable args fall back to a sentinel signature instead of throwing.
- LRU eviction relies on `Map` preserving insertion order; `touch()` deletes-then-sets each session on every access.

### `src/agent/loop-guard.test.ts` (new, 130 lines, 13 tests)

Covers: first-call ok, streak up to `softWarn-1` ok, warn at exactly `softWarn`, warn fires once per streak (re-arms after break), block at `hardBlock` and beyond, streak resets on tool change, streak resets on args change, key-order independence, per-session isolation, `forget()` clears state, LRU eviction with `maxSessions: 2`, cyclic args don't throw, threshold validation at construction.

### `src/agent/plugin-tools.ts` (+57 lines)

Wires the guard into all four wrappers:

- `wrapPluginTool` — warn appends to result content; block returns `errorResult(message)` before the underlying tool's `execute` runs.
- `wrapSystemTool` — warn appends to `hookResult.content`; block throws `Error(message)`.
- `wrapSystemAgentTool` — same as `wrapSystemTool`.
- `wrapAgentToolAsCustomToolDefinition` — same as `wrapSystemTool`. This is the wrapper that overrides pi's builtins via `customTools`, so loop coverage extends to `read` / `bash` / `edit` / `write` / `grep` / `find` / `ls` automatically.

Shared `LoopGuard` instance is module-scoped (`let sharedLoopGuard`) so concurrent sessions share the detector but their state is sessionId-keyed. A `__resetSharedLoopGuardForTests()` seam swaps the instance for a fresh one (used in tests that reuse `sessionId: 's'` across cases).

Helper added: `appendLoopWarning(result, message)` builds a new `ToolResult` with the nudge appended as a `{ type: 'text', text }` content part. Pure, non-mutating.

### `src/agent/plugin-tools.test.ts` (+161 lines, 5 integration tests)

Adds a `describe('loop guard integration')` block at the end of the file. Also adds a top-level `beforeEach(__resetSharedLoopGuardForTests)` so any future test reusing sessionIds gets a clean guard. Tests:

1. Soft-warning suffix appears on the 3rd identical plugin-tool call.
2. 5th identical call is refused with `isError: true`; the underlying tool's `execute` is never invoked.
3. Streak resets when args change between calls.
4. System-tool path throws on the 5th identical call (engine error surface).
5. Loop streaks stay isolated between sessions.

## Design notes

**Why at the wrapper layer, not a `tool.before` plugin?** The four wrappers in `src/agent/plugin-tools.ts` are the single chokepoint every tool — plugin, system, pi builtin — passes through. A `tool.before` plugin would either need to be a bundled mandatory plugin (mixed signal) or third-party (skippable). One place, automatic coverage.

**Why universal, not model-specific?** Tool-call loops are a model-class failure mode, not kimi-specific. Sonnet, GPT-5, Kimi all exhibit it. A universal guard means no need to plumb `activeRef` into `ToolBeforeEvent` (an SDK boundary change). If a specific model produces too many false positives in production, the guard can be made model-aware later — the seam is `sharedLoopGuard.check(sessionId, tool, args)`.

**Why 3 / 5 and not 2 / 4?** 2 identical calls is a legitimate retry pattern (polling, deferred result). 3 is the smallest streak that signals intent to repeat; 5 leaves the model 2 chances to self-correct after the soft warning before the hard refusal lands.

**Why a process-wide singleton with a reset seam, not per-session injection?** The four wrappers already take a `sessionId` per call site; injecting a per-session guard would require threading another option through every `WrapSystemToolOptions` and `WrapToolOptions` site (every existing test). A module-scoped guard with sessionId keying is the minimal change that keeps the wrappers' signatures stable. The reset seam is for tests; production code's LRU bound is the real memory guard.

## Verification

```
bun run typecheck                                                   ✓ 0 errors
bun run lint                                                        ✓ 0 errors (63 pre-existing warnings, none from new files)
bun run format                                                      ✓ clean
bun test --parallel src/agent/loop-guard.test.ts src/agent/plugin-tools.test.ts
                                                                    ✓ 57 pass, 0 fail
bun run test                                                        ✓ 5742 pass, 1 fail (pre-existing flake, unrelated)
```

The single failing test is `resolveSelfPackageJsonPath > points at this package manifest` in `src/update/index.test.ts`. Fails identically on `origin/main` with this PR's changes stashed — pre-existing, not caused by this PR. Passes in isolation; failure mode is order-dependent on the full suite.

## Review notes

- `src/agent/loop-guard.ts` `check()` (~lines 80-120) — the only state-mutating function. Order is: signature compute → existing-state lookup → tail-streak count → decision. Changing the order changes the soft/block boundary.
- `appendLoopWarning` in `src/agent/plugin-tools.ts` — pure, non-mutating. Adds a new content part rather than mutating the existing one so `tool.after` observers see the same shape as before plus one extra part.
- Four `loopDecision.kind === 'warn'` blocks in the wrappers — each mutates `hookResult.content` / `hookResult.details` in-place AFTER the underlying tool runs, BEFORE `tool.after` fires. Reviewer should verify that the mutation point is between `execute` and `runToolAfter` in every wrapper.
- `__resetSharedLoopGuardForTests` — intentionally ugly name (`__` prefix + `ForTests` suffix) to discourage production use. Production code relies on the LRU bound.