### PR TITLE
channels: outbound flood protection

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import type { ChannelRouter } from '@/channels/router'
+import { OUTBOUND_FLOOD_ERROR, type ChannelRouter } from '@/channels/router'
 import type { OutboundMessage, SendResult } from '@/channels/types'
 
 import {
@@ -147,6 +147,18 @@ describe('createChannelReplyTool', () => {
     const text = (result.content[0] as { text: string }).text
     expect(text).toContain('channel_reply denied')
     expect(text).toContain('denied by allow rules')
+  })
+
+  test('reports outbound flood denial back to the agent without posting', async () => {
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => ({ ok: false, error: OUTBOUND_FLOOD_ERROR, code: 'outbound-flood' })),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, { text: 'ㅋ'.repeat(500) })
+    expect(result.details).toEqual({ ok: false, error: OUTBOUND_FLOOD_ERROR })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('channel_reply denied')
+    expect(text).toContain(OUTBOUND_FLOOD_ERROR)
   })
 
   describe('tool-result marker', () => {

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import type { ChannelRouter } from '@/channels/router'
+import { OUTBOUND_FLOOD_ERROR, type ChannelRouter } from '@/channels/router'
 import type { OutboundMessage, SendResult } from '@/channels/types'
 
 import { TOOL_RESULT_PREFIX } from './channel-reply'
@@ -105,6 +105,22 @@ describe('createChannelSendTool', () => {
     expect(result.details).toEqual({ ok: false, error: 'denied by allow rules' })
     expect(result.content[0]?.type).toBe('text')
     expect((result.content[0] as { text: string }).text).toContain('denied')
+  })
+
+  test('reports outbound flood denial back to the agent without posting', async () => {
+    const tool = createChannelSendTool({
+      router: fakeRouter(async () => ({ ok: false, error: OUTBOUND_FLOOD_ERROR, code: 'outbound-flood' })),
+    })
+    const result = await runTool(tool, {
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      text: 'ㅋ'.repeat(500),
+    })
+    expect(result.details).toEqual({ ok: false, error: OUTBOUND_FLOOD_ERROR })
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('channel_send denied')
+    expect(text).toContain(OUTBOUND_FLOOD_ERROR)
   })
 
   test('first send (count=1) returns the delivery confirmation with echoed text', async () => {

--- a/src/channels/outbound-flood-filter.test.ts
+++ b/src/channels/outbound-flood-filter.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+
+import { checkOutboundFlood } from './outbound-flood-filter'
+
+describe('checkOutboundFlood — short outbound messages pass', () => {
+  test('empty text passes', () => {
+    expect(checkOutboundFlood('')).toEqual({ ok: true })
+  })
+
+  test('short laughter passes', () => {
+    expect(checkOutboundFlood('ㅋㅋㅋ')).toEqual({ ok: true })
+  })
+
+  test('short emphatic punctuation passes', () => {
+    expect(checkOutboundFlood('!!!!!!!!!!')).toEqual({ ok: true })
+  })
+})
+
+describe('checkOutboundFlood — outbound flood patterns are blocked', () => {
+  test('blocks the production-shaped 500x Korean laughter flood', () => {
+    const result = checkOutboundFlood('ㅋ'.repeat(500))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected outbound flood')
+    expect(result.reason).toMatch(/^repeated-char-run:/)
+  })
+
+  test('blocks alternating low-diversity text', () => {
+    const result = checkOutboundFlood('ab'.repeat(60))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected outbound flood')
+    expect(result.reason).toMatch(/^low-unique-ratio:/)
+  })
+})
+
+describe('checkOutboundFlood — benign outbound messages pass', () => {
+  test('long prose passes', () => {
+    const text =
+      'I checked the deployment logs and the service is healthy now. The earlier failure came from a transient queue timeout, so I will keep watching for another cycle.'
+    expect(checkOutboundFlood(text)).toEqual({ ok: true })
+  })
+
+  test('long mixed-language reply with scattered laughter passes', () => {
+    const text =
+      '확인했습니다 ㅋㅋㅋ 지금 배포 상태는 정상이고, next step은 로그를 한 번 더 보는 거예요. 이상 있으면 바로 공유드릴게요 ㅋㅋㅋ'
+    expect(checkOutboundFlood(text)).toEqual({ ok: true })
+  })
+})

--- a/src/channels/outbound-flood-filter.ts
+++ b/src/channels/outbound-flood-filter.ts
@@ -1,0 +1,57 @@
+export type OutboundFloodCheckResult = { ok: true } | { ok: false; reason: string }
+
+const MIN_LENGTH = 40
+const MAX_RUN = 30
+const MIN_LONG_LENGTH = 80
+const MIN_UNIQUE_RATIO = 0.05
+const MAX_DOMINANCE = 0.9
+
+export function checkOutboundFlood(text: string): OutboundFloodCheckResult {
+  if (text.length < MIN_LENGTH) return { ok: true }
+
+  const graphemes = Array.from(text.normalize('NFKC'))
+  if (graphemes.length < MIN_LENGTH) return { ok: true }
+
+  const longestRun = findLongestRun(graphemes)
+  if (longestRun >= MAX_RUN) return { ok: false, reason: `repeated-char-run:${longestRun}` }
+
+  if (graphemes.length < MIN_LONG_LENGTH) return { ok: true }
+
+  const counts = countGraphemes(graphemes)
+  const uniqueRatio = counts.size / graphemes.length
+  if (uniqueRatio < MIN_UNIQUE_RATIO) return { ok: false, reason: `low-unique-ratio:${uniqueRatio.toFixed(3)}` }
+
+  const dominance = maxValue(counts) / graphemes.length
+  if (dominance > MAX_DOMINANCE) return { ok: false, reason: `char-dominance:${dominance.toFixed(2)}` }
+
+  return { ok: true }
+}
+
+function findLongestRun(graphemes: readonly string[]): number {
+  if (graphemes.length === 0) return 0
+  let longest = 1
+  let current = 1
+  for (let i = 1; i < graphemes.length; i++) {
+    if (graphemes[i] === graphemes[i - 1]) {
+      current++
+      if (current > longest) longest = current
+    } else {
+      current = 1
+    }
+  }
+  return longest
+}
+
+function countGraphemes(graphemes: readonly string[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const grapheme of graphemes) counts.set(grapheme, (counts.get(grapheme) ?? 0) + 1)
+  return counts
+}
+
+function maxValue(counts: Map<string, number>): number {
+  let max = 0
+  for (const value of counts.values()) {
+    if (value > max) max = value
+  }
+  return max
+}

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -17,6 +17,7 @@ import {
   DUPLICATE_SEND_ERROR,
   MAX_CHANNEL_SENDS_PER_TURN,
   MAX_TYPING_HEARTBEAT_MS,
+  OUTBOUND_FLOOD_ERROR,
   SEND_RATE_WARN_THRESHOLD,
   SEND_RATE_WINDOW_MS,
   SESSION_GC_INTERVAL_MS,
@@ -2295,6 +2296,65 @@ describe('ChannelRouter duplicate-send guard', () => {
     )
     expect(sys).toEqual({ ok: true })
     expect(delivered).toBe(2)
+  })
+})
+
+describe('ChannelRouter outbound flood guard', () => {
+  test('blocks repeated-character outbound text before adapter delivery', async () => {
+    const dir = await tempDir()
+    let delivered = 0
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => {
+      delivered++
+      return { ok: true }
+    })
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    const result = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'ㅋ'.repeat(500) })
+    expect(result).toEqual({ ok: false, error: OUTBOUND_FLOOD_ERROR, code: 'outbound-flood' })
+    expect(delivered).toBe(0)
+  })
+
+  test('does not pre-drop repeated-character inbound messages', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ text: 'ㅋ'.repeat(500) }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sessions[0]!.prompts[0]).toContain('ㅋ'.repeat(500))
+  })
+
+  test('allows a normal reply when only the quote anchor contains repeated-character inbound text', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: string[] = []
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'ㅋ'.repeat(500), authorId: 'U_ALICE', authorName: 'Alice' }))
+    nowRef.value += 100
+    await router.route(
+      inbound({
+        isBotMention: false,
+        externalMessageId: 'm-observed',
+        authorId: 'bob',
+        authorName: 'bob',
+        text: 'also waiting',
+      }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value += 200
+
+    const result = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'normal reply' })
+    expect(result).toEqual({ ok: true })
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toContain('normal reply')
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -21,6 +21,7 @@ import {
   type MembershipResolverResult,
 } from './membership'
 import { createMembershipCache, type MembershipCache } from './membership-cache'
+import { checkOutboundFlood } from './outbound-flood-filter'
 import { updateParticipants } from './participants'
 import {
   channelsSessionsPath,
@@ -107,6 +108,7 @@ export const SEND_RATE_WINDOW_MS = 5_000
 // send still emits a structured log line regardless of rate — this
 // constant only controls when the warning marker appears.
 export const SEND_RATE_WARN_THRESHOLD = 3
+export const OUTBOUND_FLOOD_ERROR = 'outbound message denied: content looks like a repeated-character flood'
 
 /**
  * Maximum age of the last engaged inbound before the next inbound triggers a fresh session.
@@ -1843,6 +1845,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const callbacks = outboundCallbacks.get(msg.adapter)
     if (!callbacks || callbacks.size === 0) {
       return { ok: false, error: `no adapter registered for "${msg.adapter}"`, code: 'no-adapter' }
+    }
+
+    const authoredText = normalizeSendText(msg.text)
+    if (authoredText !== undefined) {
+      const flood = checkOutboundFlood(authoredText)
+      if (!flood.ok) return { ok: false, error: OUTBOUND_FLOOD_ERROR, code: 'outbound-flood' }
     }
 
     const keyId = channelKeyId({

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -128,7 +128,13 @@ export type OutboundMessage = {
   attachments?: OutboundAttachment[]
 }
 
-export type SendErrorCode = 'duplicate' | 'turn-cap' | 'no-adapter' | 'callback-rejected' | 'skip-locked'
+export type SendErrorCode =
+  | 'duplicate'
+  | 'turn-cap'
+  | 'outbound-flood'
+  | 'no-adapter'
+  | 'callback-rejected'
+  | 'skip-locked'
 
 export type SendResult = { ok: true } | { ok: false; error: string; code?: SendErrorCode }
 


### PR DESCRIPTION
## Summary

Re-implements flood protection as an **outbound** guard — the mirror image of the inbound spam filter from #446 (later reverted). Where #446 dropped repetitive inbound messages before they reached the model, this PR checks the agent's own outbound text before it reaches the adapter. The model still receives all inbound messages unchanged; only what the agent attempts to *send* is filtered.

Three commits:

- `channels: add outbound flood classifier` — new pure function `checkOutboundFlood` in `src/channels/outbound-flood-filter.ts`. Same NFKC-grapheme approach as the inbound classifier: longest-run ≥ 30, unique-ratio < 5% on messages ≥ 80 chars, single-grapheme dominance > 90%. Short messages (< 40 graphemes) always pass.
- `channels: block outbound flood sends` — `ChannelRouter.send()` calls `checkOutboundFlood` on the authored text before the quote-anchor is prepended. Returns `{ ok: false, code: 'outbound-flood' }` and delivers nothing.
- `agent: surface outbound flood tool denials` — `channel_send` and `channel_reply` tool handlers surface the denial in the tool result so the model sees a `channel_reply denied` / `channel_send denied` message instead of a silent failure.

## Changes

### `src/channels/outbound-flood-filter.ts` (new)

Pure function `checkOutboundFlood(text)` returning `{ ok: true }` or `{ ok: false; reason: string }`. No I/O, no state. Three checks on NFKC-normalised graphemes, cheapest first:

1. Longest identical run ≥ 30 — catches the production trigger directly.
2. Unique-grapheme ratio < 5% on messages ≥ 80 chars — catches low-diversity floods.
3. Single-grapheme dominance > 90% on messages ≥ 80 chars — catches floods with a small noise tail.

A 40-grapheme length floor passes all short chatter ("ㅋㅋㅋ", "!!!!!", "lol").

### `src/channels/router.ts` (+8 lines)

Guard runs at the top of the `send()` path, before `normalizeSendText` prepends the quote anchor. Checked text is the authored body, not the quote-augmented delivery payload. Returns the new `SendErrorCode` value `'outbound-flood'` with a stable `OUTBOUND_FLOOD_ERROR` message constant (exported for tool-layer assertions).

### `src/channels/types.ts`

`SendErrorCode` union extended with `'outbound-flood'`.

### `src/agent/tools/channel-send.test.ts`, `src/agent/tools/channel-reply.test.ts`

One new test each: a faked router returning `{ ok: false, error: OUTBOUND_FLOOD_ERROR, code: 'outbound-flood' }` verifies the tool result contains the denied message and the error string.

## What this does NOT do

- **No inbound filtering.** The inbound path is untouched. Repeated-character messages from users still reach the model prompt — the revert of #446 stays in place.
- **No config knob.** Same rationale as the inbound classifier: defaults handle the known threat; a tuning field can be added when there is evidence it is needed.
- **No changes to adapter classifiers, skill files, or history backfill.** This guard is at the send layer only.

## Testing

```
bun test --parallel \
  src/channels/outbound-flood-filter.test.ts \
  src/channels/router.test.ts \
  src/agent/tools/channel-send.test.ts \
  src/agent/tools/channel-reply.test.ts
# 310 pass, 0 fail
```

Key behavioral cases in `src/channels/router.test.ts`:

- Repeated-character outbound text is blocked; adapter `delivered` count stays at 0.
- Inbound repeated-character messages are **not** pre-dropped — the model prompt still receives them.
- A normal reply whose quote anchor happens to contain spammy inbound text still sends successfully (flood check runs on authored text, not the full delivery payload).

Full suite:

```
bun run lint         ✓  exits 0 (pre-existing warnings in dockerfile.ts, none from new files)
bun run format:check ✓  clean
bun run typecheck    ✓  0 errors
bun run test         ✓  5737 pass
```

## Review notes

- **`checkOutboundFlood` in `src/channels/outbound-flood-filter.ts`** is the load-bearing logic. Thresholds mirror `checkSpam` in the inbound classifier for symmetry.
- **Guard position in `send()`**: runs before `normalizeSendText` so the check sees exactly what the agent authored, not the adapter-ready payload. Moving it after the quote-anchor prepend would cause normal replies quoting a spammy inbound message to fail.
- **`OUTBOUND_FLOOD_ERROR` is exported** so tool-layer tests can assert on the exact string without coupling to the router internals.