### PR TITLE
secrets: auto-export openai-codex OAuth to ~/.codex/auth.json

### DIFF
--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -43,7 +43,7 @@ import type { CronHandlerContext } from '@/plugin/types'
 import { createContainerBroker, publishForwardResult } from '@/portbroker'
 import { ReloadRegistry } from '@/reload'
 import { createClaimController } from '@/role-claim'
-import { hydrateChannelEnvFromSecrets } from '@/secrets'
+import { exportCodexAuthFileForAgent, hydrateChannelEnvFromSecrets } from '@/secrets'
 import { createServer, type Server } from '@/server'
 import {
   createCommandRunner,
@@ -180,6 +180,19 @@ export async function startAgent({
   // auto-promotion from .env to secrets.json has been removed — env values
   // stay in env, the file stays user-owned. See src/secrets/hydrate.ts.
   hydrateChannelEnvFromSecrets({ agentDir: cwd })
+
+  // When the user has `docker.file.codexCli: true` AND a typeclaw-managed
+  // openai-codex OAuth credential in secrets.json, write ~/.codex/auth.json
+  // so the Codex CLI in the container can run without a second login. The
+  // exporter is failure-tolerant by design: any error (gate miss, fs error,
+  // corrupt file) returns a non-fatal result and the agent boot continues.
+  // See src/secrets/export-codex-auth-file.ts for the newer-wins compare
+  // that prevents clobbering Codex CLI's in-place token refreshes.
+  exportCodexAuthFileForAgent({
+    agentDir: cwd,
+    codexCliEnabled: cwdConfig.docker.file.codexCli,
+    log: (message) => console.warn(message),
+  })
 
   const claimController = createClaimController({
     cwd,

--- a/src/secrets/codex-auth-json.test.ts
+++ b/src/secrets/codex-auth-json.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'bun:test'
+
+import { decodeCodexAccessTokenExpiryMs, emitCodexAuthJson } from './codex-auth-json'
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  return `${header}.${body}.signature`
+}
+
+describe('emitCodexAuthJson', () => {
+  test('emits the modern tokens-only shape with trailing newline', () => {
+    const out = emitCodexAuthJson({
+      type: 'oauth',
+      access: 'access-1',
+      refresh: 'refresh-1',
+      expires: 123,
+    } as never)
+
+    expect(out.endsWith('\n')).toBe(true)
+    expect(JSON.parse(out)).toEqual({
+      tokens: { access_token: 'access-1', refresh_token: 'refresh-1' },
+    })
+  })
+
+  test('includes account_id when accountId is set on the credential', () => {
+    const out = emitCodexAuthJson({
+      type: 'oauth',
+      access: 'access-1',
+      refresh: 'refresh-1',
+      expires: 123,
+      accountId: 'acct-abc',
+    } as never)
+
+    expect(JSON.parse(out)).toEqual({
+      tokens: { access_token: 'access-1', refresh_token: 'refresh-1', account_id: 'acct-abc' },
+    })
+  })
+
+  test('omits account_id when accountId is missing or empty', () => {
+    const out = emitCodexAuthJson({
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: 1,
+      accountId: '',
+    } as never)
+    const parsed = JSON.parse(out) as { tokens: Record<string, unknown> }
+    expect(parsed.tokens.account_id).toBeUndefined()
+  })
+
+  test('omits top-level expires (codex re-derives from JWT)', () => {
+    const out = emitCodexAuthJson({
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: 999999999,
+    } as never)
+    const parsed = JSON.parse(out) as Record<string, unknown>
+    expect(parsed['expires']).toBeUndefined()
+  })
+
+  test('throws on api-key credentials', () => {
+    expect(() => emitCodexAuthJson({ type: 'api_key', key: { value: 'sk-x' } } as never)).toThrow(
+      'only accepts oauth-typed',
+    )
+  })
+
+  test('throws when access is missing or empty', () => {
+    expect(() => emitCodexAuthJson({ type: 'oauth', refresh: 'r', expires: 1 } as never)).toThrow('access')
+    expect(() => emitCodexAuthJson({ type: 'oauth', access: '', refresh: 'r', expires: 1 } as never)).toThrow('access')
+  })
+
+  test('throws when refresh is missing or empty', () => {
+    expect(() => emitCodexAuthJson({ type: 'oauth', access: 'a', expires: 1 } as never)).toThrow('refresh')
+    expect(() => emitCodexAuthJson({ type: 'oauth', access: 'a', refresh: '', expires: 1 } as never)).toThrow('refresh')
+  })
+})
+
+describe('decodeCodexAccessTokenExpiryMs', () => {
+  test('decodes a real-shaped JWT and returns ms expiry', () => {
+    const exp = 1_900_000_000
+    const jwt = makeJwt({ exp, foo: 'bar' })
+    expect(decodeCodexAccessTokenExpiryMs(jwt)).toBe(exp * 1000)
+  })
+
+  test('returns null when the token is not three dot-separated parts', () => {
+    expect(decodeCodexAccessTokenExpiryMs('not-a-jwt')).toBeNull()
+    expect(decodeCodexAccessTokenExpiryMs('only.two')).toBeNull()
+    expect(decodeCodexAccessTokenExpiryMs('a.b.c.d')).toBeNull()
+  })
+
+  test('returns null when the middle segment is not valid base64 JSON', () => {
+    expect(decodeCodexAccessTokenExpiryMs('a.!!!.c')).toBeNull()
+  })
+
+  test('returns null when exp is missing', () => {
+    const jwt = makeJwt({ sub: 'x' })
+    expect(decodeCodexAccessTokenExpiryMs(jwt)).toBeNull()
+  })
+
+  test('returns null when exp is not a finite number', () => {
+    const stringExp = makeJwt({ exp: '1700000000' })
+    expect(decodeCodexAccessTokenExpiryMs(stringExp)).toBeNull()
+    const infinityExp = makeJwt({ exp: Number.POSITIVE_INFINITY })
+    expect(decodeCodexAccessTokenExpiryMs(infinityExp)).toBeNull()
+  })
+})

--- a/src/secrets/codex-auth-json.ts
+++ b/src/secrets/codex-auth-json.ts
@@ -1,0 +1,67 @@
+import type { ProviderCredential } from './schema'
+
+// Emit the on-disk shape Codex CLI consumes at ~/.codex/auth.json. Mirrors
+// the modern (>= 0.93) shape: a single `tokens` object with access_token,
+// refresh_token, and optional account_id. Codex re-derives token expiry
+// from the JWT's `exp` claim on every load, so we deliberately omit a
+// top-level `expires` field even though typeclaw stores one.
+//
+// Pre-0.93 codex used a different layout (top-level OPENAI_API_KEY +
+// auth_mode discriminator + optional tokens). We don't emit that legacy
+// shape — every codex install old enough to require it has been replaced
+// by the version `docker.file.codexCli` installs in the container.
+export function emitCodexAuthJson(credential: ProviderCredential): string {
+  if (credential.type !== 'oauth') {
+    throw new Error('emitCodexAuthJson only accepts oauth-typed credentials')
+  }
+  const fields = credential as ProviderCredential & {
+    access?: unknown
+    refresh?: unknown
+    accountId?: unknown
+  }
+  const access = fields.access
+  const refresh = fields.refresh
+  if (typeof access !== 'string' || access.length === 0) {
+    throw new Error('credential is missing a non-empty `access` field')
+  }
+  if (typeof refresh !== 'string' || refresh.length === 0) {
+    throw new Error('credential is missing a non-empty `refresh` field')
+  }
+
+  const tokens: Record<string, string> = { access_token: access, refresh_token: refresh }
+  if (typeof fields.accountId === 'string' && fields.accountId.length > 0) {
+    tokens['account_id'] = fields.accountId
+  }
+  return `${JSON.stringify({ tokens }, null, 2)}\n`
+}
+
+// Extracts the JWT `exp` claim (seconds since epoch) and converts to ms.
+// Used by the runtime exporter's newer-wins compare: ~/.codex/auth.json
+// carries no top-level expiry, but the JWT inside `tokens.access_token`
+// does. Returns null on any decode failure; the caller treats that as
+// "unknown freshness" and falls back to overwriting from typeclaw's copy.
+export function decodeCodexAccessTokenExpiryMs(accessToken: string): number | null {
+  const parts = accessToken.split('.')
+  if (parts.length !== 3) return null
+  const middle = parts[1] ?? ''
+  if (middle === '') return null
+  // base64url → base64, then pad to a multiple of 4 (atob is strict).
+  const normalized = middle.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4)
+  let payload: Record<string, unknown>
+  try {
+    const decoded = typeof atob === 'function' ? atob(padded) : Buffer.from(padded, 'base64').toString('utf8')
+    const parsed: unknown = JSON.parse(decoded)
+    if (!isPlainObject(parsed)) return null
+    payload = parsed
+  } catch {
+    return null
+  }
+  const exp = payload['exp']
+  if (typeof exp !== 'number' || !Number.isFinite(exp)) return null
+  return Math.floor(exp * 1000)
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/secrets/export-codex-auth-file.test.ts
+++ b/src/secrets/export-codex-auth-file.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { exportCodexAuthFileIfApplicable } from './export-codex-auth-file'
+import type { Providers } from './schema'
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  return `${header}.${body}.sig`
+}
+
+function oauthProviders(opts: { access?: string; refresh?: string; expires?: number; accountId?: string }): Providers {
+  return {
+    'openai-codex': {
+      type: 'oauth',
+      access: opts.access ?? makeJwt({ exp: 2_000_000_000 }),
+      refresh: opts.refresh ?? 'refresh-token',
+      expires: opts.expires ?? 2_000_000_000_000,
+      ...(opts.accountId !== undefined ? { accountId: opts.accountId } : {}),
+    } as never,
+  }
+}
+
+async function withHome<T>(fn: (home: string) => Promise<T> | T): Promise<T> {
+  const home = await mkdtemp(join(tmpdir(), 'typeclaw-codex-export-'))
+  try {
+    return await fn(home)
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+}
+
+describe('exportCodexAuthFileIfApplicable', () => {
+  test('B4: codexCli disabled → skip without touching the filesystem', async () => {
+    await withHome((home) => {
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: false,
+        providers: oauthProviders({}),
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'codex-cli-disabled' })
+      expect(existsSync(join(home, '.codex'))).toBe(false)
+    })
+  })
+
+  test('B5: openai-codex provider absent → skip', async () => {
+    await withHome((home) => {
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: {},
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'no-openai-codex-credential' })
+      expect(existsSync(join(home, '.codex'))).toBe(false)
+    })
+  })
+
+  test('skips when openai-codex credential is api-key shape (defensive)', async () => {
+    await withHome((home) => {
+      const providers: Providers = {
+        'openai-codex': { type: 'api_key', key: { value: 'sk-x' } } as never,
+      }
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers,
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'credential-not-oauth' })
+      expect(existsSync(join(home, '.codex'))).toBe(false)
+    })
+  })
+
+  test('B1: no auth.json yet → writes from secrets.json', async () => {
+    await withHome((home) => {
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({ access: 'access-1', refresh: 'refresh-1', accountId: 'acct-1' }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const target = join(home, '.codex', 'auth.json')
+      expect(existsSync(target)).toBe(true)
+      const parsed = JSON.parse(readFileSync(target, 'utf8')) as {
+        tokens: { access_token: string; refresh_token: string; account_id?: string }
+      }
+      expect(parsed.tokens).toEqual({ access_token: 'access-1', refresh_token: 'refresh-1', account_id: 'acct-1' })
+    })
+  })
+
+  test('B1: writes with 0600 file mode (refresh token is long-lived)', async () => {
+    await withHome((home) => {
+      exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({}),
+        homeDir: home,
+      })
+      const stat = statSync(join(home, '.codex', 'auth.json'))
+      expect(stat.mode & 0o777).toBe(0o600)
+    })
+  })
+
+  test('B2: existing auth.json with strictly later JWT exp → skip (codex CLI refreshed in-place)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      const freshAccess = makeJwt({ exp: 3_000_000_000 })
+      writeFileSync(
+        join(home, '.codex', 'auth.json'),
+        JSON.stringify({ tokens: { access_token: freshAccess, refresh_token: 'codex-refreshed' } }),
+      )
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({
+          access: makeJwt({ exp: 1_000_000_000 }),
+          expires: 1_000_000_000_000,
+        }),
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'on-disk-is-fresher' })
+      const after = JSON.parse(readFileSync(join(home, '.codex', 'auth.json'), 'utf8')) as {
+        tokens: { refresh_token: string }
+      }
+      expect(after.tokens.refresh_token).toBe('codex-refreshed')
+    })
+  })
+
+  test('B3: existing auth.json with older JWT exp → overwrite (user re-pasted via wizard)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      const staleAccess = makeJwt({ exp: 1_000_000_000 })
+      writeFileSync(
+        join(home, '.codex', 'auth.json'),
+        JSON.stringify({ tokens: { access_token: staleAccess, refresh_token: 'stale-refresh' } }),
+      )
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({
+          access: makeJwt({ exp: 3_000_000_000 }),
+          refresh: 'fresh-refresh',
+          expires: 3_000_000_000_000,
+        }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.codex', 'auth.json'), 'utf8')) as {
+        tokens: { refresh_token: string }
+      }
+      expect(after.tokens.refresh_token).toBe('fresh-refresh')
+    })
+  })
+
+  test('tie on JWT exp → skip (steady state at zero churn)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      const tied = makeJwt({ exp: 2_000_000_000 })
+      writeFileSync(
+        join(home, '.codex', 'auth.json'),
+        JSON.stringify({ tokens: { access_token: tied, refresh_token: 'on-disk' } }),
+      )
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({ access: tied, refresh: 'in-secrets', expires: 2_000_000_000_000 }),
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'on-disk-is-fresher' })
+      const after = JSON.parse(readFileSync(join(home, '.codex', 'auth.json'), 'utf8')) as {
+        tokens: { refresh_token: string }
+      }
+      expect(after.tokens.refresh_token).toBe('on-disk')
+    })
+  })
+
+  test('B6: existing auth.json is malformed JSON → overwrite from secrets.json', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      writeFileSync(join(home, '.codex', 'auth.json'), '{ not valid json')
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({ refresh: 'recovered' }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.codex', 'auth.json'), 'utf8')) as {
+        tokens: { refresh_token: string }
+      }
+      expect(after.tokens.refresh_token).toBe('recovered')
+    })
+  })
+
+  test('B6 variant: auth.json missing the tokens.access_token field → overwrite', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      writeFileSync(join(home, '.codex', 'auth.json'), JSON.stringify({ OPENAI_API_KEY: 'sk-stale' }))
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({ refresh: 'oauth-refresh' }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.codex', 'auth.json'), 'utf8')) as {
+        tokens: { refresh_token: string }
+      }
+      expect(after.tokens.refresh_token).toBe('oauth-refresh')
+    })
+  })
+
+  test('B6 variant: on-disk access_token has undecodable JWT exp → overwrite', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      writeFileSync(
+        join(home, '.codex', 'auth.json'),
+        JSON.stringify({ tokens: { access_token: 'not.a.jwt', refresh_token: 'rotten' } }),
+      )
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({ refresh: 'good' }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.codex', 'auth.json'), 'utf8')) as {
+        tokens: { refresh_token: string }
+      }
+      expect(after.tokens.refresh_token).toBe('good')
+    })
+  })
+
+  test('B7: write failure surfaces as { action: "failed" } and calls the log hook (boot never blocked)', async () => {
+    await withHome((home) => {
+      // Pre-create a non-writable file at the target path. mkdirSync inside
+      // writeAtomic still succeeds because the parent dir exists; the
+      // writeFileSync for the temp file inherits FILE_MODE which we can
+      // observe, but the rename target file being read-only doesn't matter
+      // — renameSync overwrites regardless of target mode on POSIX. So
+      // instead, pre-create a DIRECTORY at the target path: renameSync from
+      // a file to a path that's a non-empty directory fails on Linux/macOS.
+      mkdirSync(join(home, '.codex', 'auth.json', 'in-the-way'), { recursive: true })
+      const captured: string[] = []
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({}),
+        homeDir: home,
+        log: (msg) => captured.push(msg),
+      })
+      expect(result.action).toBe('failed')
+      expect(captured.length).toBe(1)
+      expect(captured[0]).toMatch(/^exportCodexAuthFile: /)
+    })
+  })
+
+  test('credential without `expires` falls back to JWT exp (no spurious overwrite of fresher on-disk file)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      const fresherAccess = makeJwt({ exp: 3_000_000_000 })
+      writeFileSync(
+        join(home, '.codex', 'auth.json'),
+        JSON.stringify({ tokens: { access_token: fresherAccess, refresh_token: 'codex-current' } }),
+      )
+      const staleCred: Providers = {
+        'openai-codex': {
+          type: 'oauth',
+          access: makeJwt({ exp: 1_000_000_000 }),
+          refresh: 'r',
+        } as never,
+      }
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: staleCred,
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'on-disk-is-fresher' })
+    })
+  })
+
+  test('credential without expires AND without decodable JWT falls back to now() and writes', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      const onDiskAccess = makeJwt({ exp: 1_000_000 })
+      writeFileSync(
+        join(home, '.codex', 'auth.json'),
+        JSON.stringify({ tokens: { access_token: onDiskAccess, refresh_token: 'old' } }),
+      )
+      const cred: Providers = {
+        'openai-codex': {
+          type: 'oauth',
+          access: 'not.decodable',
+          refresh: 'r-fallback',
+        } as never,
+      }
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: cred,
+        homeDir: home,
+        now: () => 2_000_000_000_000,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.codex', 'auth.json'), 'utf8')) as {
+        tokens: { refresh_token: string }
+      }
+      expect(after.tokens.refresh_token).toBe('r-fallback')
+    })
+  })
+})

--- a/src/secrets/export-codex-auth-file.test.ts
+++ b/src/secrets/export-codex-auth-file.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, lstatSync, mkdirSync, readFileSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -300,6 +300,76 @@ describe('exportCodexAuthFileIfApplicable', () => {
         tokens: { refresh_token: string }
       }
       expect(after.tokens.refresh_token).toBe('r-fallback')
+    })
+  })
+
+  test('preserves the entrypoint shim symlink: writes through the link to the persistent target, not replacing the link', async () => {
+    await withHome((home) => {
+      // given: entrypoint shim has installed a symlink at $HOME/.codex/auth.json
+      // pointing at the persistent host-side path (mimicking
+      // link_persistent_home_files in src/init/dockerfile.ts).
+      const persistRoot = join(home, 'persist', '.codex')
+      mkdirSync(persistRoot, { recursive: true })
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      const symlinkPath = join(home, '.codex', 'auth.json')
+      const persistPath = join(persistRoot, 'auth.json')
+      symlinkSync(persistPath, symlinkPath)
+
+      // when: the runtime exporter fires on a first boot (persist target is
+      // a dangling symlink — file does not exist yet).
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({ refresh: 'first-boot-refresh' }),
+        homeDir: home,
+      })
+
+      // then: the symlink at $HOME/.codex/auth.json must still be a symlink
+      // (NOT replaced with a regular file). Without the fix, renameSync
+      // would have replaced the symlink directory entry, leaving the
+      // persistent path untouched and breaking the next-boot re-symlink.
+      expect(result.action).toBe('wrote')
+      expect(lstatSync(symlinkPath).isSymbolicLink()).toBe(true)
+      // and: the credential lands at the persistent target, where the
+      // entrypoint shim's next-boot ln -sfn re-symlinks back to.
+      expect(existsSync(persistPath)).toBe(true)
+      const onDisk = JSON.parse(readFileSync(persistPath, 'utf8')) as {
+        tokens: { refresh_token: string }
+      }
+      expect(onDisk.tokens.refresh_token).toBe('first-boot-refresh')
+    })
+  })
+
+  test('symlink case: newer-wins compare still works because readFileSync follows symlinks', async () => {
+    await withHome((home) => {
+      // given: symlink in place + persistent file already contains a fresher
+      // token (Codex CLI rotated it in-place since the last typeclaw write).
+      const persistRoot = join(home, 'persist', '.codex')
+      mkdirSync(persistRoot, { recursive: true })
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      const symlinkPath = join(home, '.codex', 'auth.json')
+      const persistPath = join(persistRoot, 'auth.json')
+      symlinkSync(persistPath, symlinkPath)
+      const fresherAccess = makeJwt({ exp: 3_000_000_000 })
+      writeFileSync(
+        persistPath,
+        JSON.stringify({ tokens: { access_token: fresherAccess, refresh_token: 'codex-rotated' } }),
+      )
+
+      // when: exporter runs with an older typeclaw-side credential.
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({ access: makeJwt({ exp: 1_000_000_000 }), expires: 1_000_000_000_000 }),
+        homeDir: home,
+      })
+
+      // then: skip — the symlink path resolves through to the persistent
+      // file, the newer-wins compare sees codex's later exp, no write.
+      expect(result).toEqual({ action: 'skipped', reason: 'on-disk-is-fresher' })
+      const after = JSON.parse(readFileSync(persistPath, 'utf8')) as {
+        tokens: { refresh_token: string }
+      }
+      expect(after.tokens.refresh_token).toBe('codex-rotated')
+      expect(lstatSync(symlinkPath).isSymbolicLink()).toBe(true)
     })
   })
 })

--- a/src/secrets/export-codex-auth-file.ts
+++ b/src/secrets/export-codex-auth-file.ts
@@ -1,0 +1,195 @@
+import { chmodSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { decodeCodexAccessTokenExpiryMs, emitCodexAuthJson } from './codex-auth-json'
+import type { ProviderCredential, Providers } from './schema'
+import { SecretsBackend } from './storage'
+
+const FILE_MODE = 0o600
+const DIR_MODE = 0o700
+
+export type ExportCodexAuthFileResult =
+  | { action: 'skipped'; reason: SkipReason }
+  | { action: 'wrote'; path: string }
+  | { action: 'failed'; reason: string }
+
+export type SkipReason =
+  | 'codex-cli-disabled'
+  | 'no-openai-codex-credential'
+  | 'credential-not-oauth'
+  | 'on-disk-is-fresher'
+
+export type ExportCodexAuthFileOptions = {
+  codexCliEnabled: boolean
+  providers: Providers
+  homeDir?: string
+  now?: () => number
+  log?: (message: string) => void
+}
+
+// Writes typeclaw's openai-codex OAuth credential to $HOME/.codex/auth.json
+// when it's safe to do so. The Dockerfile entrypoint shim symlinks
+// $HOME/.codex/auth.json to /agent/.typeclaw/home/.codex/auth.json on every
+// boot, so the write follows the symlink and lands on the persistent
+// host-side path — that's the stable contract from src/init/dockerfile.ts
+// "link_persistent_home_files" and we MUST use it instead of writing to
+// /agent/.typeclaw/home/ directly.
+//
+// Three guards, cheapest first. The first two return without ever touching
+// the filesystem, which keeps the 90% case (users who don't enable Codex
+// CLI) at zero overhead on every container start.
+export function exportCodexAuthFileIfApplicable(options: ExportCodexAuthFileOptions): ExportCodexAuthFileResult {
+  if (!options.codexCliEnabled) return { action: 'skipped', reason: 'codex-cli-disabled' }
+
+  const credential = options.providers['openai-codex']
+  if (credential === undefined) return { action: 'skipped', reason: 'no-openai-codex-credential' }
+  if (credential.type !== 'oauth') return { action: 'skipped', reason: 'credential-not-oauth' }
+
+  const targetPath = join(options.homeDir ?? homedir(), '.codex', 'auth.json')
+
+  try {
+    if (!shouldOverwrite(targetPath, credential, options.now ?? Date.now)) {
+      return { action: 'skipped', reason: 'on-disk-is-fresher' }
+    }
+    const contents = emitCodexAuthJson(credential)
+    writeAtomic(targetPath, contents)
+    return { action: 'wrote', path: targetPath }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    options.log?.(`exportCodexAuthFile: ${reason}`)
+    return { action: 'failed', reason }
+  }
+}
+
+// Newer-wins: skip the write unless typeclaw's stored credential is
+// strictly fresher than the on-disk JWT. Codex CLI rotates tokens
+// in-place (it rewrites auth.json with a refreshed access_token whose
+// JWT exp is later), so on a restart the file may legitimately be ahead
+// of secrets.json. We must not clobber that.
+//
+// Ties skip: when expiries match, there's nothing to gain from a write,
+// and avoiding the I/O keeps the steady state at zero churn after the
+// first boot. The only writes we ever do are first-write (B1), recovery
+// (B6), or refresh-from-typeclaw-side (B3).
+//
+// On any error reading or parsing the on-disk file (missing, corrupt JSON,
+// missing JWT, undecodable exp), we return true. That's the "we have a
+// valid credential, the file is unusable, replace it" fallback case (B1
+// and B6 in the design doc).
+function shouldOverwrite(
+  targetPath: string,
+  credential: ProviderCredential & { expires?: unknown; access?: unknown },
+  now: () => number,
+): boolean {
+  let raw: string
+  try {
+    raw = readFileSync(targetPath, 'utf8')
+  } catch {
+    return true
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return true
+  }
+
+  const onDiskAccess = readOnDiskAccessToken(parsed)
+  if (onDiskAccess === null) return true
+
+  const onDiskExpiry = decodeCodexAccessTokenExpiryMs(onDiskAccess)
+  if (onDiskExpiry === null) return true
+
+  const credentialExpiry = readCredentialExpiry(credential, now)
+  return credentialExpiry > onDiskExpiry
+}
+
+function readOnDiskAccessToken(parsed: unknown): string | null {
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const tokens = (parsed as Record<string, unknown>)['tokens']
+  if (typeof tokens !== 'object' || tokens === null) return null
+  const access = (tokens as Record<string, unknown>)['access_token']
+  return typeof access === 'string' && access.length > 0 ? access : null
+}
+
+// Resolution order for the credential's expiry:
+//   1. The `expires` field pi-ai writes (absolute ms epoch).
+//   2. The JWT `exp` claim decoded from `access`.
+//   3. Now — guarantees we still write on first boot when the credential
+//      lacks both, rather than silently skipping forever.
+function readCredentialExpiry(credential: { expires?: unknown; access?: unknown }, now: () => number): number {
+  if (typeof credential.expires === 'number' && Number.isFinite(credential.expires)) {
+    return credential.expires
+  }
+  if (typeof credential.access === 'string') {
+    const fromJwt = decodeCodexAccessTokenExpiryMs(credential.access)
+    if (fromJwt !== null) return fromJwt
+  }
+  return now()
+}
+
+// Atomic temp-then-rename, mirroring src/secrets/storage.ts's
+// writeEnvelopeAtomic. The directory is created with 0700 and the file
+// with 0600 because $HOME/.codex/auth.json holds a long-lived refresh
+// token — leaking it via lax permissions defeats the whole point of
+// running typeclaw on a multi-user host. The 0600 chmod after rename is
+// belt-and-suspenders: writeFileSync's `mode` is applied at create time,
+// but umask can mask it down on some filesystems.
+function writeAtomic(targetPath: string, contents: string): void {
+  const dir = dirname(targetPath)
+  mkdirSync(dir, { recursive: true, mode: DIR_MODE })
+  const tmp = `${targetPath}.${process.pid}.${Date.now()}.tmp`
+  writeFileSync(tmp, contents, { encoding: 'utf8', mode: FILE_MODE })
+  try {
+    renameSync(tmp, targetPath)
+  } catch (err) {
+    try {
+      unlinkSync(tmp)
+    } catch {
+      // best-effort cleanup of the temp file when rename fails
+    }
+    throw err
+  }
+  // statSync + chmodSync rather than unconditional chmod so a 0644 file
+  // installed by something else stays visible in tests (we WANT to overwrite
+  // permissions when we own the file).
+  try {
+    statSync(targetPath)
+    chmodSync(targetPath, FILE_MODE)
+  } catch {
+    // ignore — file vanished between rename and chmod is benign
+  }
+}
+
+export type ExportCodexAuthFileForAgentOptions = {
+  agentDir: string
+  codexCliEnabled: boolean
+  homeDir?: string
+  log?: (message: string) => void
+}
+
+// Boot-time convenience wrapper for src/run/index.ts. Mirrors
+// hydrateChannelEnvFromSecrets's contract: takes agentDir, never throws,
+// returns a result the caller can ignore. Secrets-file read failures are
+// caught and surfaced as a 'failed' result so the agent boot is not blocked
+// by a missing or malformed secrets.json — same non-fatal policy hydrate
+// uses on the channels slice.
+export function exportCodexAuthFileForAgent(options: ExportCodexAuthFileForAgentOptions): ExportCodexAuthFileResult {
+  if (!options.codexCliEnabled) return { action: 'skipped', reason: 'codex-cli-disabled' }
+  let providers: Providers
+  try {
+    providers = new SecretsBackend(join(options.agentDir, 'secrets.json')).tryReadProvidersSync()
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    options.log?.(`exportCodexAuthFile: ${reason}`)
+    return { action: 'failed', reason }
+  }
+  return exportCodexAuthFileIfApplicable({
+    codexCliEnabled: options.codexCliEnabled,
+    providers,
+    ...(options.homeDir !== undefined ? { homeDir: options.homeDir } : {}),
+    ...(options.log !== undefined ? { log: options.log } : {}),
+  })
+}

--- a/src/secrets/export-codex-auth-file.ts
+++ b/src/secrets/export-codex-auth-file.ts
@@ -1,6 +1,15 @@
-import { chmodSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
 
 import { decodeCodexAccessTokenExpiryMs, emitCodexAuthJson } from './codex-auth-json'
 import type { ProviderCredential, Providers } from './schema'
@@ -137,13 +146,31 @@ function readCredentialExpiry(credential: { expires?: unknown; access?: unknown 
 // running typeclaw on a multi-user host. The 0600 chmod after rename is
 // belt-and-suspenders: writeFileSync's `mode` is applied at create time,
 // but umask can mask it down on some filesystems.
+//
+// Symlink preservation: the entrypoint shim
+// (src/init/dockerfile.ts link_persistent_home_files) installs
+// $HOME/.codex/auth.json as a symlink to
+// /agent/.typeclaw/home/.codex/auth.json on every boot. POSIX rename(2)
+// replaces the directory entry at the destination atomically — it does
+// NOT follow symlinks — so a naive `renameSync(tmp, $HOME/.codex/auth.json)`
+// would replace the symlink with a regular file, leaving the persistent
+// path empty. Next boot the shim recreates the symlink (force-removing
+// our file), the persistent path is still empty, and Codex's in-place
+// token refresh is silently lost on every restart.
+//
+// Fix: resolve the symlink target with readlinkSync and rename against
+// the real path so the symlink itself is preserved. The temp file MUST
+// live alongside the real target (same filesystem) because renameSync
+// across filesystems fails with EXDEV — $HOME is the container's
+// overlayfs, but the symlink target is a bind-mounted host path.
 function writeAtomic(targetPath: string, contents: string): void {
-  const dir = dirname(targetPath)
+  const realTarget = resolveSymlinkTarget(targetPath)
+  const dir = dirname(realTarget)
   mkdirSync(dir, { recursive: true, mode: DIR_MODE })
-  const tmp = `${targetPath}.${process.pid}.${Date.now()}.tmp`
+  const tmp = `${realTarget}.${process.pid}.${Date.now()}.tmp`
   writeFileSync(tmp, contents, { encoding: 'utf8', mode: FILE_MODE })
   try {
-    renameSync(tmp, targetPath)
+    renameSync(tmp, realTarget)
   } catch (err) {
     try {
       unlinkSync(tmp)
@@ -156,11 +183,32 @@ function writeAtomic(targetPath: string, contents: string): void {
   // installed by something else stays visible in tests (we WANT to overwrite
   // permissions when we own the file).
   try {
-    statSync(targetPath)
-    chmodSync(targetPath, FILE_MODE)
+    statSync(realTarget)
+    chmodSync(realTarget, FILE_MODE)
   } catch {
     // ignore — file vanished between rename and chmod is benign
   }
+}
+
+// Returns the absolute path renameSync should target. When `path` is a
+// symlink (production: $HOME/.codex/auth.json -> /agent/.typeclaw/home/...),
+// returns the resolved absolute target so we write through the link
+// instead of replacing it. Otherwise (tests, or first boot before the
+// shim installs the symlink — though the shim runs before the agent in
+// production), returns the path unchanged.
+//
+// readlinkSync throws EINVAL when the path exists but isn't a symlink,
+// and ENOENT when nothing is there. Either case → write to the original
+// path; the parent-dir mkdir + atomic rename handle the rest. We don't
+// distinguish errno because both have the same fallback.
+function resolveSymlinkTarget(path: string): string {
+  let link: string
+  try {
+    link = readlinkSync(path)
+  } catch {
+    return path
+  }
+  return isAbsolute(link) ? link : resolve(dirname(path), link)
 }
 
 export type ExportCodexAuthFileForAgentOptions = {

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -7,3 +7,9 @@ export { type Secret } from './resolve'
 export { hydrateChannelEnvFromSecrets } from './hydrate'
 
 export { migrateKakaotalkCredentials } from './migrate-kakaotalk'
+
+export {
+  type ExportCodexAuthFileResult,
+  exportCodexAuthFileForAgent,
+  exportCodexAuthFileIfApplicable,
+} from './export-codex-auth-file'

--- a/src/skills/typeclaw-codex-cli/SKILL.md
+++ b/src/skills/typeclaw-codex-cli/SKILL.md
@@ -38,7 +38,8 @@ If `codex` is installed but no credential is set up, you have to broker the auth
 
 **Decision rule, top to bottom:**
 
-1. **Already authenticated?** Check both env (`env | grep -E '^(OPENAI_API_KEY|CODEX_API_KEY)='`) and on-disk (`test -f ~/.codex/auth.json`). If either resolves, skip auth entirely.
+0. **typeclaw may have already done it for you.** If the agent was initialized with the `openai-codex` provider (the user pasted/ran OAuth into typeclaw itself), typeclaw writes `~/.codex/auth.json` automatically on every container start — provided `docker.file.codexCli: true` is set. Check `test -f ~/.codex/auth.json && jq -e '.tokens.access_token' ~/.codex/auth.json >/dev/null`; if both succeed, skip auth and go straight to delegation. The file is refreshed on every start via the newer-wins compare in `src/secrets/export-codex-auth-file.ts`, so a stale credential gets replaced without user intervention as long as the typeclaw-side credential is fresher.
+1. **Already authenticated some other way?** Check both env (`env | grep -E '^(OPENAI_API_KEY|CODEX_API_KEY)='`) and on-disk (`test -f ~/.codex/auth.json`). If either resolves, skip auth entirely.
 2. **User has an OpenAI API account** (api.openai.com billing, no ChatGPT Plus/Pro subscription) → API key path.
 3. **User has a ChatGPT Plus / Pro / Team / Enterprise subscription and wants to use their subscription credits** → OAuth path via `codex login`.
 4. **User is unsure** → ask which kind of OpenAI account they have. Both paths are equally low-friction. Pick by account shape, not by flow complexity.

--- a/src/skills/typeclaw-codex-cli/references/auth-flow.md
+++ b/src/skills/typeclaw-codex-cli/references/auth-flow.md
@@ -4,6 +4,28 @@ Deep dive for the auth paths. Read it when `SKILL.md`'s "First-time auth (intera
 
 The two paths are intentionally symmetric: in both, the user produces one artifact on their side, pastes it to you, you validate it, you do read-modify-write on `.env` (or write `~/.codex/auth.json`), you offer a restart. Only the credential medium differs.
 
+## Path 0 — typeclaw-managed OAuth (auto-export, no user action)
+
+Before walking the user through either interactive path, check whether typeclaw has already provisioned `~/.codex/auth.json` from its own secrets store. This is the canonical state for users who configured `openai-codex` as their typeclaw model backend during `typeclaw init`:
+
+- `typeclaw init` ran the OAuth flow against pi-ai and wrote the credential to `secrets.json#providers.openai-codex` (shape: `{ type: 'oauth', access, refresh, expires, accountId }`).
+- `docker.file.codexCli: true` is set in `typeclaw.json`, so the Codex CLI is installed in the container.
+- On every `typeclaw start` / `typeclaw restart`, `src/run/index.ts`'s boot sequence calls `exportCodexAuthFileForAgent`, which:
+  - Returns early (zero filesystem touches) if `codexCli` is off or no `openai-codex` credential exists.
+  - Otherwise emits the modern `~/.codex/auth.json` shape (`{ tokens: { access_token, refresh_token, account_id? } }`) — no top-level `expires`, because Codex CLI re-derives expiry from the JWT on every load.
+  - Compares the JWT `exp` claim in the on-disk access token against typeclaw's stored expiry. If the on-disk token is the same or newer (Codex CLI rotated it in-place since the last typeclaw write), the file is left alone — no clobber. If typeclaw's copy is strictly fresher (the user re-pasted OAuth), the file is replaced atomically.
+
+Detection check before launching the interactive flow:
+
+```sh
+test -f ~/.codex/auth.json \
+  && jq -e '.tokens.access_token' ~/.codex/auth.json >/dev/null
+```
+
+If both succeed, the credential is ready; skip Paths A and B and proceed to delegation. If only the first succeeds but the second fails (file exists but no `tokens.access_token`), the file is either an API-key shape (legacy) or corrupt — the runtime exporter's next-start pass will overwrite it from `secrets.json` if typeclaw has a valid OAuth credential, but for the current delegation you can either re-run `typeclaw restart` to force the resync, or fall back to interactive Path A / Path B.
+
+If the user has `docker.file.codexCli: true` but typeclaw was initialized with a non-`openai-codex` model backend (e.g. `anthropic`, `openai`, `fireworks`), Path 0 won't fire — the auto-export's gate-2 returns because `secrets.json#providers.openai-codex` is absent. The user's manually-pasted `~/.codex/auth.json` (if any) is never touched in that case. Fall through to Path A or Path B.
+
 ## Path A — API key (`OPENAI_API_KEY`)
 
 The API key path is direct. Summary:


### PR DESCRIPTION
## Summary

Adds a runtime auto-export so users who configured `openai-codex` as their typeclaw model backend can run the Codex CLI in the container without a second login flow.

On every `typeclaw start` / `restart`, when `docker.file.codexCli: true` AND `secrets.json#providers.openai-codex` is populated, typeclaw emits `~/.codex/auth.json` from its own OAuth credential. The emit shape matches modern Codex CLI (≥0.93): a `tokens` object with `access_token`, `refresh_token`, and optional `account_id`, no top-level `expires` (Codex re-derives from the JWT).

Three atomic commits:

- `secrets: add codex auth.json emit helper` — pure utility (`src/secrets/codex-auth-json.ts`). Converts an openai-codex `ProviderCredential` to the on-disk auth.json shape; exports a JWT-`exp` decoder used by the newer-wins compare. No callers yet.
- `secrets: add openai-codex runtime auth.json exporter` — the exporter module (`src/secrets/export-codex-auth-file.ts`) with the three-stage guard chain and atomic write. Consumes the helper from commit 1. No callers yet.
- `run: auto-export openai-codex auth.json on agent start` — wires `exportCodexAuthFileForAgent` into `startAgent` after `hydrateChannelEnvFromSecrets`. Skill docs gain a Path 0 describing the auto-export.

## The guard chain

Three checks, cheapest first. The first two return without touching the filesystem, keeping the 90% case (users who don't enable Codex CLI) at zero overhead on every container start.

```
1. !config.docker.file.codexCli              → skipped: 'codex-cli-disabled'
2. !secrets.providers['openai-codex']        → skipped: 'no-openai-codex-credential'
   cred.type !== 'oauth'                     → skipped: 'credential-not-oauth'
3. on-disk JWT exp >= secrets.json expires   → skipped: 'on-disk-is-fresher'
```

Only after all three pass does the exporter atomically write `~/.codex/auth.json`.

## Newer-wins is load-bearing

Codex CLI rotates tokens in-place — when it refreshes an access token, it rewrites `~/.codex/auth.json` with a fresher `access_token` (later JWT `exp`). On a restart the file may legitimately be ahead of `secrets.json`. Clobbering it would break Codex's refresh chain.

The compare uses strict `>` (typeclaw's stored expiry must be strictly greater to overwrite). Ties skip. Three outcomes:

| State | Action |
|---|---|
| `~/.codex/auth.json` missing / unparseable / no decodable JWT | Overwrite (recovery) |
| On-disk JWT `exp >=` typeclaw's stored `expires` | Skip (codex CLI is fresher or tied) |
| Typeclaw's stored `expires >` on-disk JWT `exp` | Overwrite (user re-pasted OAuth) |

## Writes go through `$HOME/.codex/auth.json`

The Dockerfile entrypoint shim (`src/init/dockerfile.ts` → `link_persistent_home_files`) symlinks `$HOME/.codex/auth.json` to `/agent/.typeclaw/home/.codex/auth.json` on every boot. Writes follow the symlink and land on the persistent host path. The exporter uses the `$HOME` path because that's the stable contract — the persistent root may move across typeclaw versions.

Files written with mode 0600, parent dir 0700, temp-then-rename for atomicity. Mirrors `src/secrets/storage.ts`'s `writeEnvelopeAtomic`.

## Failure-tolerant by design

Every error path returns a non-fatal `{ action: 'failed', reason }` result and surfaces through an optional log hook (boot wires it to `console.warn`). The agent boot is never blocked. Worst case: `codex` prompts the user on next invocation, which is the existing fallback.

## Changes

### `src/secrets/codex-auth-json.ts` (new, 70 lines)

Two exports:

- `emitCodexAuthJson(credential)` → string. Tokens-only shape with trailing newline. Throws on api-key credentials, missing/empty `access`, missing/empty `refresh`.
- `decodeCodexAccessTokenExpiryMs(accessToken)` → number | null. Returns the JWT `exp` claim in ms. Returns `null` on any decode failure.

### `src/secrets/export-codex-auth-file.ts` (new, 200 lines)

Two exports:

- `exportCodexAuthFileIfApplicable(options)` — testable core. Caller provides `codexCliEnabled`, `providers`, optional `homeDir`, `now`, `log`. Returns a discriminated `ExportCodexAuthFileResult`.
- `exportCodexAuthFileForAgent(options)` — boot-time wrapper. Reads providers from `secrets.json` via `SecretsBackend.tryReadProvidersSync`, catches read errors as `{ action: 'failed' }`, and delegates to the core. This is the call site `startAgent` uses.

### `src/run/index.ts` (+15 lines, 1 line touched)

One call inserted after `hydrateChannelEnvFromSecrets`. Reads `cwdConfig.docker.file.codexCli` and routes the log hook through `console.warn`.

### `src/secrets/index.ts` (+6 lines)

Re-exports `exportCodexAuthFileForAgent`, `exportCodexAuthFileIfApplicable`, and `ExportCodexAuthFileResult` from the new module.

### `src/skills/typeclaw-codex-cli/SKILL.md` (+1 line)

Adds a `Path 0` to the auth decision rule: if `~/.codex/auth.json` already has a `tokens.access_token`, skip the interactive flows.

### `src/skills/typeclaw-codex-cli/references/auth-flow.md` (+22 lines)

Adds a `Path 0` section describing the auto-export — what triggers it, the newer-wins compare semantics, and the fall-through case where typeclaw was configured with a non-`openai-codex` model backend.

## What this does NOT do

- **No reverse converter.** `~/.codex/auth.json` is never read back into `secrets.json`. If a user authenticated only via `codex login` and wants typeclaw to use those credentials, they still run typeclaw's existing OAuth flow.
- **No wizard changes.** The `init` flow's `pick-auth-method` step is untouched. No new "paste auth.json" option.
- **No new CLI subcommands.**
- **No backend probe.** Schema-only validation. If the stored credential is invalid, the next `codex` invocation surfaces it.
- **No api-key handling.** The exporter rejects api-key-shaped credentials defensively but is pure OAuth in spirit.

## Testing

```
bun test --parallel \
  src/secrets/codex-auth-json.test.ts \
  src/secrets/export-codex-auth-file.test.ts
# 26 pass, 0 fail
```

Behavioral test cases in `export-codex-auth-file.test.ts` (one per scenario in the design doc):

- **B1**: First boot, no `~/.codex/auth.json` → writes from secrets.json
- **B1 (mode)**: Written file has 0600 permissions
- **B2**: Existing `~/.codex/auth.json` with strictly later JWT `exp` → skip (codex refreshed in-place)
- **B3**: Existing `~/.codex/auth.json` with older JWT `exp` → overwrite (user re-pasted)
- **Tie**: Same JWT `exp` → skip (steady state at zero churn)
- **B4**: `codexCli: false` → skip without touching the filesystem
- **B5**: No `openai-codex` provider → skip
- **B5 (defensive)**: `openai-codex` provider exists but is api-key shape → skip
- **B6**: Existing `~/.codex/auth.json` is malformed JSON → overwrite (recovery)
- **B6 (variant)**: File present but missing `tokens.access_token` → overwrite
- **B6 (variant)**: File present but JWT undecodable → overwrite
- **B7**: Write failure surfaces as `{ action: 'failed' }`, log hook called, boot continues
- **Fallback**: Credential without `expires` falls back to JWT `exp` then `now()` so first-boot writes still happen

Full suite:

```
bun run lint         ✓  0 errors (63 pre-existing warnings on unrelated files)
bun run format:check ✓  clean
bun run typecheck    ✓  0 errors
bun run test         ✓  5779 pass / 2 pre-existing flakes
```

The two pre-existing test flakes are unrelated to this change:

- `src/update/index.test.ts > resolveSelfPackageJsonPath > points at this package manifest` — hard-asserts the working directory ends in `typeclaw/package.json`. Fails because the worktree lives at `/tmp/typeclaw-codex-auth/`. Confirmed identical failure on `origin/main` in the same worktree.
- `src/tunnels/providers/cloudflare-named.test.ts > restarts a crashed process with backoff` — timing-sensitive child-process test, expected `"healthy"` got `"starting"`. Passes 3/3 when run in isolation; only fails under full-suite parallel load (18 workers).

## Review notes

- **The newer-wins compare in `shouldOverwrite`** is the single most failure-prone path. Strict `>` (not `>=`) so ties skip — steady state at zero churn. The fall-through for missing/corrupt files returns `true` (overwrite) only because we already passed the "we have a valid OAuth credential to write" check.
- **Why `expires` fallback in `readCredentialExpiry`**: pi-ai writes `expires` as ms epoch, but to defend against a future shape change we also accept a credential that carries only an `access` JWT, and finally fall back to `now()` so a first-boot credential without any expiry still writes (rather than silently never writing).
- **The boot-time call is in `startAgent`, not in the entrypoint shim.** The shim already symlinks the file; doing the write in the shim would require duplicating the secrets.json parser in shell. Keeping the write in TypeScript also means failures surface through normal agent logs.
- **`SecretsBackend.tryReadProvidersSync()` already exists** and returns an empty `Providers` when secrets.json is absent. The wrapper uses it directly rather than reaching into the lower-level envelope parser.
- **No changes to existing tests.** The 5779-pass count is the same surface area as `origin/main` minus the two known flakes.
