### PR TITLE
channels: drop self-authored github events by login as well as id

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -258,6 +258,90 @@ describe('createGithubWebhookHandler', () => {
   })
 })
 
+describe('createGithubWebhookHandler — self-author drop', () => {
+  function selfAuthoredHandler(
+    routed: InboundMessage[],
+    overrides: { selfId?: string | null; selfLogin?: string | null } = {},
+  ): (req: Request) => Promise<Response> {
+    return createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['issue_comment.created', 'pull_request_review_comment.created', 'issues.opened'],
+      selfId: () => overrides.selfId ?? '99',
+      selfLogin: () => overrides.selfLogin ?? 'typeclaw-bot',
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+  }
+
+  it('drops issue_comment authored by self (matched by id)', async () => {
+    const routed: InboundMessage[] = []
+    const handler = selfAuthoredHandler(routed)
+    const payload = issueCommentPayload({ pullRequest: false })
+    ;(payload.comment as Record<string, unknown>).user = { login: 'typeclaw-bot', id: 99, type: 'Bot' }
+    await handler(signedRequest(JSON.stringify(payload), 'issue_comment', 'self-by-id'))
+    expect(routed).toHaveLength(0)
+  })
+
+  it('drops issue_comment authored by self (matched by login when id differs)', async () => {
+    const routed: InboundMessage[] = []
+    const handler = selfAuthoredHandler(routed)
+    const payload = issueCommentPayload({ pullRequest: false })
+    // Same login, different id — simulates the issue #452 case where the
+    // id-only guard would have let the webhook through.
+    ;(payload.comment as Record<string, unknown>).user = { login: 'typeclaw-bot', id: 12345, type: 'Bot' }
+    await handler(signedRequest(JSON.stringify(payload), 'issue_comment', 'self-by-login'))
+    expect(routed).toHaveLength(0)
+  })
+
+  it('drops pull_request_review_comment authored by self (matched by login)', async () => {
+    const routed: InboundMessage[] = []
+    const handler = selfAuthoredHandler(routed)
+    const payload = reviewCommentPayload()
+    ;(payload.comment as Record<string, unknown>).user = { login: 'typeclaw-bot', id: 54321, type: 'Bot' }
+    await handler(signedRequest(JSON.stringify(payload), 'pull_request_review_comment', 'self-review-by-login'))
+    expect(routed).toHaveLength(0)
+  })
+
+  it('drops issues.opened authored by self (matched by login)', async () => {
+    const routed: InboundMessage[] = []
+    const handler = selfAuthoredHandler(routed)
+    const payload = {
+      action: 'opened',
+      repository: repo(),
+      issue: {
+        number: 11,
+        id: 1100,
+        body: 'opened by the bot',
+        created_at: '2026-01-01T00:00:00Z',
+        user: { login: 'typeclaw-bot', id: 12345, type: 'Bot' },
+      },
+    }
+    await handler(signedRequest(JSON.stringify(payload), 'issues', 'self-issue-by-login'))
+    expect(routed).toHaveLength(0)
+  })
+
+  it('routes issue_comment from a different author when neither id nor login matches', async () => {
+    const routed: InboundMessage[] = []
+    const handler = selfAuthoredHandler(routed)
+    const body = JSON.stringify(issueCommentPayload({ pullRequest: false }))
+    await handler(signedRequest(body, 'issue_comment', 'other-author'))
+    expect(routed).toHaveLength(1)
+    expect(routed[0]?.authorName).toBe('alice')
+  })
+
+  it('still drops by login when selfId is null (e.g. id getter not yet resolved)', async () => {
+    const routed: InboundMessage[] = []
+    const handler = selfAuthoredHandler(routed, { selfId: null })
+    const payload = issueCommentPayload({ pullRequest: false })
+    ;(payload.comment as Record<string, unknown>).user = { login: 'typeclaw-bot', id: 99, type: 'Bot' }
+    await handler(signedRequest(JSON.stringify(payload), 'issue_comment', 'self-id-null'))
+    expect(routed).toHaveLength(0)
+  })
+})
+
 function signedRequest(body: string, event: string, delivery: string): Request {
   const sig = `sha256=${createHmac('sha256', 'secret').update(body).digest('hex')}`
   return new Request('https://example.com/github', {

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -44,11 +44,17 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
     if (!isGithubEventAllowed(options.allowlist(), event, action)) return ok()
 
     const selfId = options.selfId()
+    const selfLogin = options.selfLogin()
     const author = readAuthor(payload)
-    if (selfId !== null && author !== null && String(author.id) === selfId) return ok()
+    if (author !== null && isSelfAuthor(author, selfId, selfLogin)) {
+      options.logger.info(
+        `[github] dropped self-authored ${event}${action !== null ? `.${action}` : ''} from @${author.login}`,
+      )
+      return ok()
+    }
 
     const teamIsBotMember = await resolveTeamMembership(event, payload, options)
-    const classified = classifyGithubInbound(event, payload, options.selfLogin(), {
+    const classified = classifyGithubInbound(event, payload, selfLogin, {
       teamIsBotMember,
     })
     if (classified === null) return ok()
@@ -364,6 +370,17 @@ function readAuthor(payload: Record<string, unknown>): GithubUser | null {
     if (user !== null) return user
   }
   return null
+}
+
+// Matches by id OR login. Issue #452 captured a self-responding loop where
+// the id-only guard didn't fire and the bot replied to its own comments ~8
+// times in a row. Login is the second line of defense and aligns with the
+// slack/discord/telegram/kakaotalk adapters, which all drop self-authored
+// events at the classifier layer.
+function isSelfAuthor(author: GithubUser, selfId: string | null, selfLogin: string | null): boolean {
+  if (selfId !== null && String(author.id) === selfId) return true
+  if (selfLogin !== null && author.login === selfLogin) return true
+  return false
 }
 
 type GithubUser = { login: string; id: number; type?: string }


### PR DESCRIPTION
## Summary

The GitHub channel adapter's webhook handler dropped self-authored events only when `String(author.id) === selfId`. Issue #452 captured a self-responding loop where the bot replied to its own issue comments ~8 times in a row, which means the id check alone is not sufficient as a defense.

This PR adds **login** as a second match key so a self-authored event is dropped if either `author.id === selfId` **or** `author.login === selfLogin`. Same pattern, two keys instead of one — defense in depth at the same enforcement point.

## Why two keys

- The other channel adapters (`slack-bot`, `discord-bot`, `telegram-bot`, `kakaotalk`) all drop self-authored events in their classifier layer using the bot's identity, and the GitHub adapter was the only one relying on a single key.
- The id check still misfires in practice (issue #452). Whether the cause was a transient `selfId === null` race, a payload variant, or something subtler in `auth.getSelf()` resolution doesn't matter for the fix: matching on login as well covers all of those cases without changing the existing happy path.
- Login is a stable secondary key for the bot's identity. For App auth, `selfLogin` is `<app-slug>[bot]`; for PAT auth, it is the PAT owner's login. Both match the `payload.<comment|issue|pr|discussion|review>.user.login` that GitHub sends in webhook payloads.

## Changes

### `src/channels/adapters/github/inbound.ts` (+19 / -2)

- Extract `selfLogin` once at the top of the webhook handler (was previously read again inside `classifyGithubInbound`; now passed through).
- Replace the id-only self check with a call to a new private helper `isSelfAuthor(author, selfId, selfLogin)` that returns true if either key matches.
- Emit one `logger.info('[github] dropped self-authored …')` line when the drop fires so operators can see why a webhook was swallowed.

### `src/channels/adapters/github/inbound.test.ts` (+84)

New `describe('createGithubWebhookHandler — self-author drop')` block with 6 cases:

1. `issue_comment` self-authored, matched by id (regression-pin for the existing behavior).
2. `issue_comment` self-authored, matched by **login when id differs** — directly simulates the #452 case.
3. `pull_request_review_comment` self-authored, matched by login.
4. `issues.opened` self-authored, matched by login.
5. **Negative case**: a non-self `issue_comment` still routes through.
6. `selfId` is null (e.g. the getter has not resolved yet) and the drop still fires via login.

## What this does NOT do

- **No new options or config.** Uses the existing `selfId()` / `selfLogin()` getters already wired through `createGithubAdapter`.
- **No router-layer changes.** This is a pure GitHub-adapter improvement; the outbound flood filter from #451 and the agent-side loop guard from #450 stay where they are. This is the missing third layer: inbound self-author suppression at the GitHub adapter.
- **No change to `classifyGithubInbound`.** The classifier still handles all events the same way; only the handler-level short-circuit gets a second match key.

## Testing

```
bun test --parallel src/channels/adapters/github/inbound.test.ts
# 24 pass, 0 fail
```

Full suite + typecheck + lint + format all clean against this branch.

Fixes #452-class regressions (the issue itself is closed, but the bot's self-responding behavior on it was the prompt for this PR).
