### PR TITLE
skills: github channel delegates code review to the reviewer subagent

### DIFF
--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typeclaw-channel-github
-description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `github`, AND before composing replies to GitHub-originated inbounds, AND before opening new issues or PRs with `gh`, AND ALWAYS when an inbound says "requested your review on PR #N" or "requested a review from team @… on PR #N" (the agent has been assigned as a reviewer and must do a real code review with line-by-line comments via `gh api`). GitHub renders **real markdown** — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and `inline code` all render natively. Use rich markdown freely. GitHub cannot send file attachments via API — do not call `channel_send` with attachments on github chats. GitHub has no typing indicator. PR review threads use `thread` keyed on the root comment id; reply to a thread to stay in it, or omit `thread` to post a top-level issue/PR comment. To open new issues or PRs use the `gh` CLI — `GH_TOKEN` is pre-set by the adapter. Read this skill before composing anything on GitHub.
+description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `github`, AND before composing replies to GitHub-originated inbounds, AND before opening new issues or PRs with `gh`, AND ALWAYS when an inbound says "requested your review on PR #N" or "requested a review from team @… on PR #N" (the agent has been assigned as a reviewer and must delegate the analysis to the `reviewer` subagent, then translate its findings into line-by-line comments via `gh api`). GitHub renders **real markdown** — `**bold**`, `## headings`, `| tables |`, fenced code blocks, and `inline code` all render natively. Use rich markdown freely. GitHub cannot send file attachments via API — do not call `channel_send` with attachments on github chats. GitHub has no typing indicator. PR review threads use `thread` keyed on the root comment id; reply to a thread to stay in it, or omit `thread` to post a top-level issue/PR comment. To open new issues or PRs use the `gh` CLI — `GH_TOKEN` is pre-set by the adapter. Read this skill before composing anything on GitHub.
 ---
 
 GitHub renders normal Markdown in issues, PRs, discussions, and review comments. Use headings, lists, tables, fenced code blocks, links, and inline code when they improve clarity.
@@ -25,27 +25,56 @@ For App auth, `GH_TOKEN` is an installation access token that refreshes automati
 
 ## Reviewing pull requests
 
-When an incoming message says **"requested your review on PR #N"** (or "requested a review from team @… on PR #N"), you have been assigned as a reviewer. Do a real code review and post line-by-line comments via `gh api`. Do **not** just reply in the channel — the user wants feedback on the diff.
+When an incoming message says **"requested your review on PR #N"** (or "requested a review from team @… on PR #N"), you have been assigned as a reviewer. Do **not** review inline yourself and do **not** just reply in the channel — delegate the analysis to the bundled `reviewer` subagent, then translate its findings into line-by-line comments via `gh api`.
+
+Why delegate: the `reviewer` subagent runs on the `deep` model profile, loads a curated `code-review` skill on demand, and produces a structured `<review>` block with severity-tagged findings. You are the integration layer between that output and GitHub's review API.
 
 ### Workflow
 
-1. **Read the diff and context**:
+1. **Confirm the target.** Capture the PR number, the repo, and the head SHA — you'll need the SHA to read files at the revision the reviewer analyzed.
 
    ```sh
-   gh pr diff <N> --repo owner/repo
    gh pr view <N> --repo owner/repo --json title,body,baseRefName,headRefOid,files
    ```
 
-2. **Submit a multi-comment review** in one API call by piping a JSON payload to `gh api --input -`. `comments[]` accepts line-level entries; each one lands on the diff exactly like a human reviewer's inline comment:
+2. **Spawn the `reviewer` subagent with the PR target.** Use `run_in_background: true` so you stay responsive while the deep model works. Pass the PR URL (or `owner/repo#N`) plus any context the requester gave you (focus areas, specific files, etc.) so the reviewer knows what the requester cares about.
+
+   The reviewer will fetch the diff itself (`gh pr diff`, `gh api /repos/.../pulls/<n>`), load the matching skill (`code-review` for a code PR; `general` for a mixed-format change), and return a `<review>` block.
+
+3. **Wait for the completion `<system-reminder>`,** then call `subagent_output({ task_id })` to read the reviewer's final assistant message. The structured payload looks like:
+
+   ```xml
+   <review>
+   <summary>...</summary>
+   <findings>
+     <finding severity="blocker|concern|nit|praise" location="path:line">
+       <issue>...</issue>
+       <evidence>...</evidence>
+       <suggestion>...</suggestion>
+     </finding>
+   </findings>
+   <verdict>approve | request-changes | comment</verdict>
+   </review>
+   ```
+
+4. **Translate findings into a `gh api` review payload.** Each `<finding>` with a `location="path:line"` becomes one entry in `comments[]`. Compose the inline `body` from the reviewer's `<issue>` + `<evidence>` + `<suggestion>` — preserve the reviewer's wording, do not paraphrase. Findings whose `location` is `general` (no file:line anchor) go into the top-level review `body` instead. Map the reviewer's `<verdict>` to the GitHub `event`:
+
+   | Reviewer verdict  | GitHub `event`    |
+   | ----------------- | ----------------- |
+   | `approve`         | `APPROVE`         |
+   | `request-changes` | `REQUEST_CHANGES` |
+   | `comment`         | `COMMENT`         |
+
+   Then submit the review in one API call:
 
    ```sh
    cat <<'JSON' | gh api -X POST /repos/owner/repo/pulls/<N>/reviews --input -
    {
      "event": "COMMENT",
-     "body": "Overall: looks good with a few nits.",
+     "body": "<reviewer's <summary> goes here>",
      "comments": [
-       { "path": "src/foo.ts", "line": 42, "side": "RIGHT", "body": "nit: prefer `const` here." },
-       { "path": "src/bar.ts", "line": 10, "side": "RIGHT", "body": "Consider extracting this branch into a helper." }
+       { "path": "src/foo.ts", "line": 42, "side": "RIGHT", "body": "<issue + evidence + suggestion from the reviewer's finding>" },
+       { "path": "src/bar.ts", "line": 10, "side": "RIGHT", "body": "..." }
      ]
    }
    JSON
@@ -53,17 +82,19 @@ When an incoming message says **"requested your review on PR #N"** (or "requeste
 
    **Always use `--input -` with a quoted heredoc (`<<'JSON'`) for review bodies.** Do **not** use `-f body=...` or `-F 'comments[][body]=...'`: those go through shell argument parsing, so backticks (\`) trigger command substitution and have to be backslash-escaped, which leaks the literal `\` into the rendered comment. The quoted heredoc passes the JSON through untouched — backticks, newlines, and `${...}` all survive verbatim. The same applies to any other `gh api` POST whose body contains backticks, embedded newlines, or shell metacharacters.
 
-3. **Then** post a one-line summary with `channel_reply` so the conversation has a human-readable trace pointing at the review.
+5. **Post a one-line summary with `channel_reply`** so the conversation has a human-readable trace pointing at the review (e.g., "Posted review on PR #N: <verdict>, N findings.").
 
 ### Rules
 
-- Use `event=COMMENT` by default. Use `APPROVE` only when you have high confidence the PR is ready to merge. Use `REQUEST_CHANGES` only when the PR has clear blockers — not for nits.
-- **Only post comments that the author needs to act on.** Do not post praise ("looks good", "nice refactor", "great work"), affirmations of correct code, or restatements of what a line does. If every comment in your review is positive, post a top-level summary via `channel_reply` instead of a review — or skip commenting and just `APPROVE`. Inline comments are for changes, questions, and blockers, not validation.
+- **Always delegate to the `reviewer` subagent.** Do not perform the review craft yourself. The reviewer is the source of truth for severity, evidence quality, and what counts as a finding. Your job is mechanics: spawn, wait, translate, post.
+- **Trust the verdict.** Use the GitHub `event` mapped from the reviewer's `<verdict>`. Do not upgrade `comment` → `APPROVE` to seem agreeable, and do not downgrade `request-changes` → `COMMENT` to soften the tone. The reviewer chose deliberately.
+- **No findings → no inline review post.** If the reviewer returns zero `<finding>` elements and a verdict of `approve`, post a plain `APPROVE` with the `<summary>` as the review body (no `comments[]` array). If the verdict is `comment` with zero findings, post the summary as a top-level PR comment via `gh api -X POST /repos/.../issues/<N>/comments` instead of submitting an empty review.
+- **Preserve the reviewer's wording.** Inline comment bodies should reflect the reviewer's `<issue>`, `<evidence>`, and `<suggestion>` verbatim (modulo markdown formatting). Paraphrasing dilutes the analysis — the deep-model reviewer chose those words on purpose.
 - `line` is a line number **in the file**, not a position in the diff. `side: RIGHT` is the new revision (default for additions); `side: LEFT` is the old revision (use for comments on removed lines).
 - For multi-line comments, also set `start_line` and `start_side` (same semantics).
-- If you need to read whole files at the PR's head SHA, use `gh api /repos/owner/repo/contents/<path>?ref=<headRefOid>`.
+- If you need to read whole files at the PR's head SHA, use `gh api /repos/owner/repo/contents/<path>?ref=<headRefOid>`. The reviewer can do this itself, but you may need to as well — e.g., when validating a finding's `location` against the actual file before posting.
 - The bundled `agent-browser` is **not** for PR reviews — `gh api` is faster and more reliable. Only use the browser when the API genuinely can't reach what you need.
-- A `review_request_removed` event means the requester un-assigned you. Stop any in-progress review work; do not post a partial review.
+- A `review_request_removed` event means the requester un-assigned you. Cancel any in-flight reviewer subagent (`subagent_cancel`) and do not post a partial review.
 
 ### Self-loop safety
 

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -57,7 +57,7 @@ Why delegate: the `reviewer` subagent runs on the `deep` model profile, loads a 
    </review>
    ```
 
-4. **Translate findings into a `gh api` review payload.** Each `<finding>` with a `location="path:line"` becomes one entry in `comments[]`. Compose the inline `body` from the reviewer's `<issue>` + `<evidence>` + `<suggestion>` — preserve the reviewer's wording, do not paraphrase. Findings whose `location` is `general` (no file:line anchor) go into the top-level review `body` instead. Map the reviewer's `<verdict>` to the GitHub `event`:
+4. **Translate findings into a `gh api` review payload.** Each `<finding>` with `severity` of `blocker`, `concern`, or `nit` and a `location="path:line"` becomes one entry in `comments[]`. Compose the inline `body` from the reviewer's `<issue>` + `<evidence>` + `<suggestion>` — preserve the reviewer's wording, do not paraphrase. Findings whose `location` is `general` (no file:line anchor) go into the top-level review `body` instead. **Skip `praise` findings when building `comments[]`** — they are not actionable, and inline praise comments are exactly the noise the reviewer is supposed to filter out at the source; if you want to surface them, weave them into the top-level review `body` alongside the summary. Map the reviewer's `<verdict>` to the GitHub `event`:
 
    | Reviewer verdict  | GitHub `event`    |
    | ----------------- | ----------------- |
@@ -88,7 +88,10 @@ Why delegate: the `reviewer` subagent runs on the `deep` model profile, loads a 
 
 - **Always delegate to the `reviewer` subagent.** Do not perform the review craft yourself. The reviewer is the source of truth for severity, evidence quality, and what counts as a finding. Your job is mechanics: spawn, wait, translate, post.
 - **Trust the verdict.** Use the GitHub `event` mapped from the reviewer's `<verdict>`. Do not upgrade `comment` → `APPROVE` to seem agreeable, and do not downgrade `request-changes` → `COMMENT` to soften the tone. The reviewer chose deliberately.
-- **No findings → no inline review post.** If the reviewer returns zero `<finding>` elements and a verdict of `approve`, post a plain `APPROVE` with the `<summary>` as the review body (no `comments[]` array). If the verdict is `comment` with zero findings, post the summary as a top-level PR comment via `gh api -X POST /repos/.../issues/<N>/comments` instead of submitting an empty review.
+- **No actionable findings → no inline review post.** A finding is "actionable" if its severity is `blocker`, `concern`, or `nit`. If the reviewer returns zero actionable findings:
+  - `approve` verdict → post a plain `APPROVE` with the `<summary>` as the review body (no `comments[]` array).
+  - `comment` verdict → post the summary as a top-level PR comment via `gh api -X POST /repos/.../issues/<N>/comments` instead of submitting an empty review.
+  - `request-changes` verdict → submit `REQUEST_CHANGES` with the `<summary>` as the review body and no `comments[]` array. This combination is rare (the reviewer's contract says `request-changes` requires at least one blocker or load-bearing concern), so if it happens, faithfully encode the verdict and trust the reviewer's reasoning is in the summary.
 - **Preserve the reviewer's wording.** Inline comment bodies should reflect the reviewer's `<issue>`, `<evidence>`, and `<suggestion>` verbatim (modulo markdown formatting). Paraphrasing dilutes the analysis — the deep-model reviewer chose those words on purpose.
 - `line` is a line number **in the file**, not a position in the diff. `side: RIGHT` is the new revision (default for additions); `side: LEFT` is the old revision (use for comments on removed lines).
 - For multi-line comments, also set `start_line` and `start_side` (same semantics).


### PR DESCRIPTION
## Summary

The github channel skill's "Reviewing pull requests" section taught the parent agent to do code review inline — fetch the diff, form findings, write inline comments, post. PR #454 introduced the `reviewer` subagent: a read-only, deep-model subagent that produces a structured `<review>` block with severity-tagged findings and an `approve`/`request-changes`/`comment` verdict. Two places teaching the same review craft means two sources of truth that will drift (they already were: the github skill had its own "no praise, no restating" rules; the reviewer's system prompt covers the same ground in different words).

This PR makes the github skill a pure **integration layer**. The parent's job is now mechanical: spawn the reviewer, wait for the structured output, translate findings to a `gh api` payload, post. Review craft — what counts as a finding, severity calibration, evidence quality — has a single source of truth in the reviewer.

## Changes

One file: `src/skills/typeclaw-channel-github/SKILL.md` (+44 / -13).

### Frontmatter description
Updated to reflect the new flow: "must do a real code review with line-by-line comments via `gh api`" → "must delegate the analysis to the `reviewer` subagent, then translate its findings into line-by-line comments via `gh api`".

### `## Reviewing pull requests` — rewritten as a 5-step recipe
1. Confirm the target (PR number, repo, head SHA).
2. Spawn the `reviewer` subagent with `run_in_background: true`.
3. Wait for the completion `<system-reminder>`; call `subagent_output({ task_id })` to read the `<review>` block.
4. Translate findings to a `gh api` payload (with a verdict→event mapping table) and post via the existing heredoc recipe.
5. Post a one-line summary via `channel_reply`.

### Rules — reshaped
New lead rule: "Always delegate to the `reviewer` subagent. Your job is mechanics: spawn, wait, translate, post."

New rules:
- "Trust the verdict" — do not upgrade `comment` to `APPROVE` to seem agreeable or downgrade `request-changes` to `COMMENT` to soften the tone.
- "No findings → no inline review post" — post a plain `APPROVE` without `comments[]`, or a top-level issue comment for a `comment`-verdict-with-no-findings.
- "Preserve the reviewer's wording" — inline comment bodies should reflect the reviewer's issue, evidence, and suggestion verbatim.

### What stayed verbatim (all load-bearing GitHub mechanics)
The `<<'JSON'` heredoc warning, `line`/`side`/`start_line` API semantics, head-SHA file reads, the `agent-browser`-not-for-this rule, and the `review_request_removed` cancellation path (now also calls `subagent_cancel` on any in-flight reviewer).

### What was dropped
The "no praise, no restating" reviewer-craft guidance from the old rules section. That rule lives in the reviewer's system prompt and its bundled `code-review` skill. The parent doesn't need to know the rule — it just preserves the reviewer's wording when posting.

## What this does NOT do

- **No changes to the reviewer subagent or the `code-review` skill.** This PR is strictly a github-skill update.
- **No changes to `gh api` mechanics.** The heredoc recipe, `line`/`side`/`start_line` semantics, and head-SHA file reads are all unchanged.
- **No new permissions.** The parent already has generic `subagent.spawn` to call `explorer`; no additional permission is required for `reviewer`.

## Verification

```
bun run typecheck    ✓  0 errors
bun run lint         ✓  0 errors (63 pre-existing warnings, unchanged)
bun run format       ✓  clean
bun run test         ✓  5844 pass, 1 pre-existing failure
```

The single failing test is `resolveSelfPackageJsonPath > points at this package manifest` in `src/update/index.test.ts`. It asserts the resolved path ends with `typeclaw/package.json` but fails in any worktree whose directory name is not literally `typeclaw`. Confirmed passing in the main checkout. Reproduces identically on `origin/main` with this PR's changes reverted. Unrelated to this change.

No tests reference `typeclaw-channel-github` by name — verified via `grep -rln typeclaw-channel-github src/` returning only the skill file itself.

## Review notes

- **Step 2 of the workflow** is the new load-bearing instruction. The `run_in_background: true` requirement is intentional — the reviewer runs on the deep model profile and may take O(minutes) for a large diff; the parent should stay responsive in the meantime.
- **The verdict→event mapping table** (step 4) is the only decision surface the parent retains. Any other verdict-shaping (softening, upgrading) is explicitly prohibited by the "Trust the verdict" rule.
- **`subagent_cancel` on `review_request_removed`** is the one behavior addition beyond the recipe itself. The old rule said "stop any in-progress review work" without being actionable; the new rule names the specific tool call.
- **Why no broader context here**: PR #454 is the full motivation and architecture reference.