### PR TITLE
agent: move wall-clock anchor from system prompt to per-turn injection

### DIFF
--- a/scripts/dump-system-prompt.test.ts
+++ b/scripts/dump-system-prompt.test.ts
@@ -12,7 +12,7 @@ describe('dumpSystemPrompt', () => {
   const defaultLoaderKinds: Array<'tui' | 'cron' | 'channel'> = ['tui', 'cron', 'channel']
 
   test.each(defaultLoaderKinds)(
-    '%s origin (default-loader path) renders identity, runtime, origin, role, memory, and now',
+    '%s origin (default-loader path) renders identity, runtime, origin, role, and memory — wall clock lives in the per-turn anchor, not here',
     (kind) => {
       const out = dumpSystemPrompt(kind)
 
@@ -22,18 +22,20 @@ describe('dumpSystemPrompt', () => {
       expect(out).toContain('## Session origin')
       expect(out).toContain('## Your role in this session')
       expect(out).toContain('# Memory')
-      expect(out).toContain('## Now')
-      expect(out).toContain('Session started at')
+      expect(out).not.toContain('## Now')
+      expect(out).not.toContain('Session started at')
+      expect(out).not.toContain('<current-time>')
     },
   )
 
-  test('subagent origin (override path) renders only override + runtime + origin/role + now, NOT identity or memory', () => {
+  test('subagent origin (override path) renders only override + runtime + origin/role, NOT identity, memory, or any wall-clock anchor', () => {
     const out = dumpSystemPrompt('subagent')
 
     expect(out).toContain('## Runtime')
     expect(out).toContain('## Session origin')
     expect(out).toContain('## Your role in this session')
-    expect(out).toContain('## Now')
+    expect(out).not.toContain('## Now')
+    expect(out).not.toContain('<current-time>')
     expect(out).not.toContain('# Identity')
     expect(out).not.toContain('# Memory')
     expect(out).not.toContain('You are a general-purpose AI agent running inside TypeClaw.')
@@ -133,7 +135,7 @@ describe('dumpSystemPrompt', () => {
     (kind) => {
       const result = dumpSystemPromptWithBreakdown(kind)
 
-      const minSections = kind === 'subagent' ? 4 : 7
+      const minSections = kind === 'subagent' ? 3 : 6
       expect(result.sections.length).toBeGreaterThanOrEqual(minSections)
       for (const s of result.sections) {
         expect(s.bytes).toBeGreaterThan(0)
@@ -163,7 +165,6 @@ describe('dumpSystemPrompt', () => {
       'Role context',
       'Git nudge',
       'Memory (MEMORY.md + streams)',
-      'Now (wall clock)',
     ])
   })
 
@@ -176,13 +177,12 @@ describe('dumpSystemPrompt', () => {
       'Session origin',
       'Role context',
       'Memory (MEMORY.md + streams)',
-      'Now (wall clock)',
     ])
   })
 
-  test('subagent breakdown reflects production override path: override + runtime + origin/role + now', () => {
+  test('subagent breakdown reflects production override path: override + runtime + origin/role', () => {
     const names = dumpSystemPromptWithBreakdown('subagent').sections.map((s) => s.name)
-    expect(names).toEqual(['Subagent override prompt', 'Runtime block', 'Session origin + role', 'Now (wall clock)'])
+    expect(names).toEqual(['Subagent override prompt', 'Runtime block', 'Session origin + role'])
     expect(names).not.toContain('SLIM_SYSTEM_PROMPT (base)')
     expect(names).not.toContain('DEFAULT_SYSTEM_PROMPT (base)')
     expect(names).not.toContain('Identity (IDENTITY.md + SOUL.md)')
@@ -223,7 +223,6 @@ describe('dumpSystemPrompt', () => {
     expect(idx('## Session origin')).toBeLessThan(idx('## Your role in this session'))
     expect(idx('## Your role in this session')).toBeLessThan(idx('git reports 2 uncommitted files'))
     expect(idx('git reports 2 uncommitted files')).toBeLessThan(idx('## MEMORY.md'))
-    expect(idx('## MEMORY.md')).toBeLessThan(idx('## Now'))
   })
 
   test('slim-mode section order is least-volatile to most-volatile (cache-suffix contract)', () => {
@@ -234,20 +233,26 @@ describe('dumpSystemPrompt', () => {
     expect(idx('TypeClaw runtime version:')).toBeLessThan(idx('You are running an unattended cron job.'))
     expect(idx('You are running an unattended cron job.')).toBeLessThan(idx('## Your role in this session'))
     expect(idx('## Your role in this session')).toBeLessThan(idx('## MEMORY.md'))
-    expect(idx('## MEMORY.md')).toBeLessThan(idx('## Now'))
   })
 
-  test('now block is the trailing section across every origin kind (cache-prefix invariant)', () => {
-    for (const kind of ['tui', 'cron', 'channel', 'subagent'] as const) {
+  test('memory section is the trailing block when present (cache-prefix invariant for full-mode origins)', () => {
+    for (const kind of ['tui', 'cron', 'channel'] as const) {
       const out = dumpSystemPrompt(kind)
-      const nowIdx = out.lastIndexOf('## Now')
-      expect(nowIdx).toBeGreaterThan(-1)
-      const after = out.slice(nowIdx)
-      expect(after.indexOf('# Memory')).toBe(-1)
-      expect(after.indexOf('## MEMORY.md')).toBe(-1)
+      const memoryIdx = out.lastIndexOf('## MEMORY.md')
+      expect(memoryIdx).toBeGreaterThan(-1)
+      const after = out.slice(memoryIdx)
       expect(after.indexOf('## Session origin')).toBe(-1)
       expect(after.indexOf('TypeClaw runtime version:')).toBe(-1)
       expect(after.indexOf('## Your role in this session')).toBe(-1)
+    }
+  })
+
+  test('no origin kind embeds a wall-clock anchor in the system prompt (per-turn injection invariant)', () => {
+    for (const kind of ['tui', 'cron', 'channel', 'subagent'] as const) {
+      const out = dumpSystemPrompt(kind)
+      expect(out).not.toContain('## Now')
+      expect(out).not.toContain('Session started at')
+      expect(out).not.toContain('<current-time>')
     }
   })
 })

--- a/scripts/dump-system-prompt.ts
+++ b/scripts/dump-system-prompt.ts
@@ -2,19 +2,19 @@
 
 import { parseArgs } from 'node:util'
 
-import { composeSystemPrompt, deriveSystemPromptMode, type SystemPromptMode } from '@/agent'
+import { composeSystemPrompt, deriveSystemPromptMode, renderTurnTimeAnchor, type SystemPromptMode } from '@/agent'
 import type { SessionOrigin, SessionRoleContext } from '@/agent/session-origin'
-import { renderNowBlock } from '@/agent/system-prompt'
 
 type OriginKind = 'tui' | 'cron' | 'channel' | 'subagent'
 const ALL_KINDS: readonly OriginKind[] = ['tui', 'cron', 'channel', 'subagent'] as const
 
 const PLACEHOLDER_RUNTIME_VERSION = '1.2.3-debug'
 
-// Fixed wall-clock for the `## Now` block. The dumper needs a deterministic
-// timestamp so successive runs produce byte-identical output (and so the
-// snapshot tests in dump-system-prompt.test.ts don't drift). Production
-// callers always pass the live `new Date()` — see `composeSystemPrompt`.
+// Fixed wall-clock for the per-turn `<current-time>` anchor. The dumper
+// needs a deterministic timestamp so successive runs produce byte-identical
+// output (and so the snapshot tests in dump-system-prompt.test.ts don't
+// drift). Production callers always pass the live `new Date()` — see
+// `renderTurnTimeAnchor` in src/agent/system-prompt.ts.
 const PLACEHOLDER_NOW = new Date('2026-05-22T15:11:00+09:00')
 
 const PLACEHOLDER_SELF = [
@@ -243,14 +243,12 @@ function dumpSubagentOverridePrompt(): DumpResult {
   const fixture = buildFixture('subagent')
   const runtimeBlock = `## Runtime\n\nTypeClaw runtime version: ${PLACEHOLDER_RUNTIME_VERSION}.`
   const originBlock = `## Session origin\n\nYou are a \`${(fixture.origin as { subagent: string }).subagent}\` subagent spawned by parent session\n\`${(fixture.origin as { parentSessionId: string }).parentSessionId}\`. Stay narrowly within the task you were given.\nReturn cleanly when done; do not sprawl into unrelated work.\n\n## Your role in this session\n\nRole: \`${fixture.roleContext.role}\`. Permissions: ${fixture.roleContext.permissions.map((p) => `\`${p}\``).join(', ')}.\n\nThis is the role the runtime resolved at session creation. Tool calls\nand channel admission are gated by these permissions; a \`blocked:\` or\n"denied by permissions" message means the current actor lacks the\npermission the guard was looking for. See the \`typeclaw-permissions\`\nskill for what each role can do and how to grant access.`
-  const nowBlock = renderNowBlock(PLACEHOLDER_NOW)
 
-  const prompt = `${PLACEHOLDER_SUBAGENT_OVERRIDE}\n\n${runtimeBlock}\n\n${originBlock}\n\n${nowBlock}`
+  const prompt = `${PLACEHOLDER_SUBAGENT_OVERRIDE}\n\n${runtimeBlock}\n\n${originBlock}`
   const sections: SectionBreakdown[] = [
     mkSection('Subagent override prompt', PLACEHOLDER_SUBAGENT_OVERRIDE),
     mkSection('Runtime block', runtimeBlock),
     mkSection('Session origin + role', originBlock),
-    mkSection('Now (wall clock)', nowBlock),
   ]
   return {
     prompt,
@@ -273,7 +271,6 @@ function dumpDefaultLoaderPrompt(kind: Exclude<OriginKind, 'subagent'>, options:
     roleContext: fixture.roleContext,
     gitNudge: wantGitNudge ? PLACEHOLDER_GIT_NUDGE : '',
     memorySection: fixture.memory,
-    now: PLACEHOLDER_NOW,
   } as const
 
   const prompt = composeSystemPrompt(parts)
@@ -299,7 +296,6 @@ function dumpDefaultLoaderPrompt(kind: Exclude<OriginKind, 'subagent'>, options:
     sections.push(mkSection('Git nudge', parts.gitNudge))
   }
   sections.push(mkSection('Memory (MEMORY.md + streams)', parts.memorySection))
-  sections.push(mkSection('Now (wall clock)', renderNowBlock(PLACEHOLDER_NOW)))
 
   return {
     prompt,
@@ -405,6 +401,11 @@ function main(): void {
     process.stdout.write(result.prompt)
     process.stdout.write('\n')
   }
+
+  const anchor = renderTurnTimeAnchor(PLACEHOLDER_NOW)
+  const bar = '═'.repeat(78)
+  process.stdout.write(`\n${bar}\n  PER-TURN INJECTION (prepended to every user message)\n${bar}\n\n`)
+  process.stdout.write(`${anchor}\n`)
 }
 
 if (import.meta.main) {

--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -240,52 +240,38 @@ describe('createResourceLoader', () => {
     expect(nudgeIdx).toBeLessThan(memoryIdx)
   })
 
-  test('renders a `## Now` wall-clock block stamping a session-creation timestamp the model can read', async () => {
-    const { formatLocalDateTime } = await import('@/shared')
-    const now = new Date('2026-05-22T15:11:00+09:00')
-
-    const loader = await createResourceLoader({ agentDir, now })
-
-    const prompt = loader.getSystemPrompt() ?? ''
-    expect(prompt).toContain('## Now')
-    expect(prompt).toContain(`Session started at \`${formatLocalDateTime(now)}\``)
-  })
-
-  test('now block names the IANA timezone the process is in (so the agent reports "Asia/Seoul" instead of just "+09:00")', async () => {
-    const now = new Date('2026-05-22T15:11:00+09:00')
-
-    const loader = await createResourceLoader({ agentDir, now })
-
-    const prompt = loader.getSystemPrompt() ?? ''
-    // The IANA zone name in the block must equal what the process Intl resolves
-    // to. We don't pin a specific zone string because CI and dev machines differ;
-    // we pin the contract: zone-in-prompt == Intl.DateTimeFormat zone.
-    const zone = Intl.DateTimeFormat().resolvedOptions().timeZone
-    expect(prompt).toContain(`(${zone})`)
-  })
-
-  test('now block is the VERY LAST section: comes after memory so the cache prefix stays stable across resurrections', async () => {
+  test('system prompt does NOT contain a wall-clock anchor: the per-turn `<current-time>` block lives in the user message instead', async () => {
     await writeFile(join(agentDir, 'MEMORY.md'), 'memory-content-marker')
-    const now = new Date('2026-05-22T15:11:00+09:00')
 
-    const loader = await createResourceLoader({ agentDir, now })
+    const loader = await createResourceLoader({ agentDir })
+
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).not.toContain('## Now')
+    expect(prompt).not.toContain('Session started at')
+    expect(prompt).not.toContain('<current-time>')
+  })
+
+  test('memory section is the trailing cacheable block now that `## Now` is gone (cache-suffix tail invariant)', async () => {
+    await writeFile(join(agentDir, 'MEMORY.md'), 'memory-content-marker')
+
+    const loader = await createResourceLoader({ agentDir })
 
     const prompt = loader.getSystemPrompt() ?? ''
     const memoryIdx = prompt.indexOf('memory-content-marker')
-    const nowIdx = prompt.indexOf('## Now')
     expect(memoryIdx).toBeGreaterThan(-1)
-    expect(nowIdx).toBeGreaterThan(-1)
-    expect(memoryIdx).toBeLessThan(nowIdx)
-    expect(prompt.indexOf('## Now', nowIdx + 1)).toBe(-1)
+    expect(prompt.indexOf('## Session origin', memoryIdx)).toBe(-1)
+    expect(prompt.indexOf('## Your role in this session', memoryIdx)).toBe(-1)
+    expect(prompt.indexOf('TypeClaw runtime version:', memoryIdx)).toBe(-1)
   })
 
-  test('omits the now block when explicit now is undefined AND the loader default is bypassed (composeSystemPrompt level)', () => {
+  test('composeSystemPrompt does not accept or emit a `now` field (removed when the anchor moved to per-turn injection)', () => {
     const prompt = composeSystemPrompt({
       self: '# Identity\n\nfoo',
       gitNudge: '',
       memorySection: '',
     })
     expect(prompt).not.toContain('## Now')
+    expect(prompt).not.toContain('Session started at')
   })
 
   test('memory section is NOT visible to plugin session.prompt hooks (intentional: memory injection is core-owned and runs after all plugin hooks)', async () => {
@@ -921,23 +907,20 @@ describe('composeSystemPrompt slim mode', () => {
 })
 
 describe('createOverrideResourceLoader', () => {
-  test('starts with the override string verbatim (now block is appended below)', async () => {
+  test('starts with the override string verbatim', async () => {
     const loader = await createOverrideResourceLoader('SUBAGENT PROMPT')
 
     const prompt = loader.getSystemPrompt() ?? ''
     expect(prompt.startsWith('SUBAGENT PROMPT')).toBe(true)
   })
 
-  test('appends a `## Now` wall-clock block as the trailing cache-suffix tail', async () => {
-    const now = new Date('2026-05-22T15:11:00+09:00')
-    const loader = await createOverrideResourceLoader('SUBAGENT PROMPT', undefined, undefined, undefined, now)
+  test('does not append a wall-clock anchor: the per-turn `<current-time>` block lives in the user message instead', async () => {
+    const loader = await createOverrideResourceLoader('SUBAGENT PROMPT')
 
     const prompt = loader.getSystemPrompt() ?? ''
-    expect(prompt).toContain('## Now')
-    expect(prompt).toContain('Session started at')
-    // The block must be the trailing section so the cache prefix stays
-    // stable across session resurrections (only the ~600-byte tail invalidates).
-    expect(prompt.trimEnd().endsWith("the user's local time.")).toBe(true)
+    expect(prompt).not.toContain('## Now')
+    expect(prompt).not.toContain('Session started at')
+    expect(prompt).not.toContain('<current-time>')
   })
 
   test('does not include the typeclaw default system prompt', async () => {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -39,7 +39,7 @@ import { loadSelf } from './self'
 import { SESSION_META_CUSTOM_TYPE, sessionMetaPayload } from './session-meta'
 import { renderSessionOrigin, type SessionOrigin, type SessionRoleContext } from './session-origin'
 import type { CreateSessionForSubagent, SubagentRegistry } from './subagents'
-import { DEFAULT_SYSTEM_PROMPT, renderNowBlock, renderRuntimeBlock, SLIM_SYSTEM_PROMPT } from './system-prompt'
+import { DEFAULT_SYSTEM_PROMPT, renderRuntimeBlock, SLIM_SYSTEM_PROMPT } from './system-prompt'
 import {
   createBudgetState,
   type ToolResultBudget,
@@ -665,12 +665,10 @@ export async function createOverrideResourceLoader(
   origin?: SessionOrigin,
   permissions?: PermissionService,
   runtimeVersion?: string,
-  now: Date = new Date(),
 ): Promise<DefaultResourceLoader> {
   const withRuntime =
     runtimeVersion !== undefined ? `${systemPrompt}\n\n${renderRuntimeBlock(runtimeVersion)}` : systemPrompt
-  const withOriginRendered = withOrigin(withRuntime, origin, permissions)
-  const finalPrompt = `${withOriginRendered}\n\n${renderNowBlock(now)}`
+  const finalPrompt = withOrigin(withRuntime, origin, permissions)
   const loader = new DefaultResourceLoader({
     systemPromptOverride: () => finalPrompt,
     appendSystemPromptOverride: () => [],
@@ -691,11 +689,6 @@ export type CreateResourceLoaderOptions = {
   // 'full' to force the heavy prompt even on an unattended origin (rarely
   // useful; mostly an escape hatch for ad-hoc debugging).
   mode?: SystemPromptMode
-  // Wall-clock anchor stamped into the trailing `## Now` block of the
-  // rendered system prompt. Production callers omit this so each session
-  // gets the current time at creation; tests pass a fixed Date to keep
-  // assertions deterministic. See `renderNowBlock` in system-prompt.ts.
-  now?: Date
 }
 
 // Origins where the operator-facing DEFAULT_SYSTEM_PROMPT, git-nudge, and the
@@ -753,7 +746,6 @@ export type SystemPromptComposition = {
   roleContext?: SessionRoleContext
   gitNudge: string
   memorySection: string
-  now?: Date
 }
 
 // Section-order contract for the system prompt. Kept as a pure string→string
@@ -772,12 +764,14 @@ export type SystemPromptComposition = {
 // 3. memorySection — volatile: MEMORY.md grows on every dream cycle and
 //    memory/yyyy-MM-dd.md grows after every channel turn that triggers
 //    memory-logger.
-// 4. now block — most volatile: changes per second. Pinned to the very
-//    end so every byte UP TO this block stays in the provider's cache
-//    prefix; only the trailing ~60 bytes invalidate on each new session.
-//    `now` is optional — when omitted (debug dumps without a fixed clock,
-//    legacy callers) the block is skipped entirely. See `renderNowBlock`
-//    in system-prompt.ts for why this block exists at all.
+//
+// The wall-clock anchor that used to live here as `## Now` moved out
+// entirely. It is now injected into the user turn at each `session.prompt`
+// site via `renderTurnTimeAnchor` (src/agent/system-prompt.ts) so the
+// stamp reflects the moment of THIS turn, not session creation. Per-turn
+// injection costs zero cached bytes — the user turn is the non-cacheable
+// suffix anyway — and removes the staleness failure mode where a session
+// opened Friday answered "today is Friday" on Thursday.
 export function composeSystemPrompt(parts: SystemPromptComposition): string {
   const base = parts.mode === 'slim' ? SLIM_SYSTEM_PROMPT : DEFAULT_SYSTEM_PROMPT
   let prompt = `${base}\n\n${parts.self}`
@@ -792,9 +786,6 @@ export function composeSystemPrompt(parts: SystemPromptComposition): string {
   }
   if (parts.memorySection !== '') {
     prompt = `${prompt}\n\n${parts.memorySection}`
-  }
-  if (parts.now !== undefined) {
-    prompt = `${prompt}\n\n${renderNowBlock(parts.now)}`
   }
   return prompt
 }
@@ -871,7 +862,6 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
     ...(roleContext !== undefined ? { roleContext } : {}),
     gitNudge,
     memorySection,
-    now: options.now ?? new Date(),
   })
 
   const additionalSkillPaths = [getBundledSkillsDir()]

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -63,6 +63,8 @@ export type { SessionOrigin } from './session-origin'
 
 export type { AgentSession }
 
+export { renderTurnTimeAnchor } from './system-prompt'
+
 type AgentSessionTools = NonNullable<Parameters<typeof createAgentSession>[0]>['tools']
 
 export type PluginSessionWiring = {

--- a/src/agent/model-fallback.test.ts
+++ b/src/agent/model-fallback.test.ts
@@ -105,7 +105,8 @@ describe('promptWithFallback', () => {
     expect(result.refUsed).toBe(REF_A)
     expect(result.attempts).toEqual([{ ref: REF_A, outcome: 'success' }])
     expect(created).toHaveLength(1)
-    expect(created[0]!.promptedWith).toEqual(['hello'])
+    expect(created[0]!.promptedWith).toHaveLength(1)
+    expect(created[0]!.promptedWith[0]).toContain('hello')
     expect(created[0]!.disposed).toBe(false)
   })
 
@@ -134,7 +135,8 @@ describe('promptWithFallback', () => {
     expect(created).toHaveLength(2)
     expect(created[0]!.disposed).toBe(true)
     expect(created[1]!.disposed).toBe(false)
-    expect(created[1]!.promptedWith).toEqual(['hello'])
+    expect(created[1]!.promptedWith).toHaveLength(1)
+    expect(created[1]!.promptedWith[0]).toContain('hello')
   })
 
   test('falls through on a soft (stopReason: error) failure', async () => {
@@ -220,7 +222,7 @@ describe('promptWithFallback', () => {
   })
 
   test('preserves the prompt text across retries (no text mutation between attempts)', async () => {
-    const seen: string[] = []
+    const seen: { ref: string; promptedWith: string[] }[] = []
     await promptWithFallback({
       refs: [REF_A, REF_B],
       text: 'do the thing',
@@ -232,13 +234,14 @@ describe('promptWithFallback', () => {
         return {
           session,
           dispose: async () => {
-            seen.push(`${ref}:${fake.promptedWith.join('|')}`)
+            seen.push({ ref, promptedWith: [...fake.promptedWith] })
           },
         }
       },
     })
-    // First session got 'do the thing' before disposal; the second one was
-    // successful (no dispose call from the helper, since the caller holds it).
-    expect(seen).toEqual([`${REF_A}:do the thing`])
+    expect(seen).toHaveLength(1)
+    expect(seen[0]!.ref).toBe(REF_A)
+    expect(seen[0]!.promptedWith).toHaveLength(1)
+    expect(seen[0]!.promptedWith[0]).toContain('do the thing')
   })
 })

--- a/src/agent/model-fallback.ts
+++ b/src/agent/model-fallback.ts
@@ -4,6 +4,7 @@ import type { KnownModelRef } from '@/config/providers'
 
 import type { AgentSession } from './index'
 import { subscribeProviderErrors } from './provider-error'
+import { renderTurnTimeAnchor } from './system-prompt'
 
 // Result of a single fallback-aware prompt run.
 // - `refUsed` is the ref whose session ultimately handled the turn.
@@ -88,7 +89,7 @@ export async function promptWithFallback(opts: {
     })
     try {
       try {
-        await session.prompt(opts.text)
+        await session.prompt(`${renderTurnTimeAnchor()}\n\n${opts.text}`)
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err))
         const attempt: FallbackAttempt = { ref, outcome: 'hard', errorMessage: error.message }

--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -127,7 +127,7 @@ describe('invokeSubagent', () => {
     })
 
     // then
-    expect(calls.prompt).toEqual(['say hello'])
+    expect(calls.prompt).toEqual([expect.stringContaining('say hello')])
     expect(calls.disposed).toBe(1)
   })
 
@@ -155,7 +155,7 @@ describe('invokeSubagent', () => {
     })
 
     // then
-    expect(calls.prompt).toEqual(['hello Neo'])
+    expect(calls.prompt).toEqual([expect.stringContaining('hello Neo')])
     expect(calls.disposed).toBe(1)
   })
 
@@ -211,8 +211,8 @@ describe('invokeSubagent', () => {
 
     // then
     expect(fakes).toHaveLength(2)
-    expect(fakes[0]!.calls.prompt).toEqual(['first'])
-    expect(fakes[1]!.calls.prompt).toEqual(['second'])
+    expect(fakes[0]!.calls.prompt).toEqual([expect.stringContaining('first')])
+    expect(fakes[1]!.calls.prompt).toEqual([expect.stringContaining('second')])
     expect(fakes[0]!.calls.disposed).toBe(1)
     expect(fakes[1]!.calls.disposed).toBe(1)
   })
@@ -711,7 +711,7 @@ describe('startSubagent', () => {
 
     // then
     expect(result.ok).toBe(true)
-    expect(calls.prompt).toEqual(['hello'])
+    expect(calls.prompt).toEqual([expect.stringContaining('hello')])
     expect(calls.disposed).toBe(1)
   })
 
@@ -884,7 +884,7 @@ describe('startSubagent', () => {
 
     // then
     expect(result).toBeUndefined()
-    expect(calls.prompt).toEqual(['wrapper'])
+    expect(calls.prompt).toEqual([expect.stringContaining('wrapper')])
     expect(calls.disposed).toBe(1)
   })
 })

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -7,6 +7,7 @@ import type { Stream, Unsubscribe } from '@/stream'
 import { type AgentSession, createSession } from './index'
 import { subscribeProviderErrors } from './provider-error'
 import type { SessionOrigin } from './session-origin'
+import { renderTurnTimeAnchor } from './system-prompt'
 import type { ToolResultBudget } from './tool-result-budget'
 
 type AgentSessionTools = NonNullable<Parameters<typeof createSession>[0]>['tools']
@@ -226,7 +227,7 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
         await hooks.runSessionTurnStart({ ...turnEvent, userPrompt: userPromptForTurn })
       }
       try {
-        await session.prompt(userPromptForTurn)
+        await session.prompt(`${renderTurnTimeAnchor()}\n\n${userPromptForTurn}`)
       } finally {
         if (hooks && turnEvent !== undefined) {
           await hooks.runSessionTurnEnd(turnEvent)

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatLocalDateTime, resolveLocalTimezoneName } from '@/shared'
+
+import { renderTurnTimeAnchor } from './system-prompt'
+
+describe('renderTurnTimeAnchor', () => {
+  test('wraps the ISO timestamp, IANA zone, and weekday pair in a single <current-time> tag', () => {
+    const now = new Date('2026-01-15T12:00:00+09:00')
+
+    const anchor = renderTurnTimeAnchor(now)
+
+    expect(anchor.startsWith('<current-time>')).toBe(true)
+    expect(anchor.endsWith('</current-time>')).toBe(true)
+    expect(anchor).toContain(formatLocalDateTime(now))
+    expect(anchor).toContain(`(${resolveLocalTimezoneName()},`)
+  })
+
+  test('emits BOTH English and Korean weekday names so a model replying in Korean does not have to translate from English', () => {
+    // Asserting membership in the canonical 7-entry list rather than a
+    // specific weekday: the local zone may differ on CI from the
+    // zone-agnostic constructor input, so the resolved weekday is not
+    // pinnable. The contract is "both languages present", not "this
+    // specific day".
+    const now = new Date('2026-01-15T12:00:00+09:00')
+
+    const anchor = renderTurnTimeAnchor(now)
+
+    const koreanDays = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
+    expect(koreanDays.some((d) => anchor.includes(d))).toBe(true)
+    const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    expect(englishDays.some((d) => anchor.includes(d))).toBe(true)
+    expect(anchor).toContain(' / ')
+  })
+
+  test('produces a single-line block with no internal newlines (so prepending `${anchor}\\n\\n${user}` is the only newline boundary)', () => {
+    const now = new Date('2026-01-15T12:00:00+09:00')
+
+    const anchor = renderTurnTimeAnchor(now)
+
+    expect(anchor).not.toContain('\n')
+  })
+
+  test('defaults to new Date() when no argument is passed (production callers use this path)', () => {
+    const before = Date.now()
+    const anchor = renderTurnTimeAnchor()
+    const after = Date.now()
+
+    expect(anchor).toContain('<current-time>')
+    expect(anchor).toContain('</current-time>')
+    const match = anchor.match(/<current-time>(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})/)
+    expect(match).not.toBeNull()
+    const ts = new Date(match![1]!).getTime()
+    expect(ts).toBeGreaterThanOrEqual(before - 1000)
+    expect(ts).toBeLessThanOrEqual(after + 1000)
+  })
+
+  test('the weekday matches what `Date.getDay()` would resolve in the runtime zone (the anchor must agree with `date` for the current local day)', () => {
+    const now = new Date()
+    const anchor = renderTurnTimeAnchor(now)
+
+    const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    const koreanDays = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
+    const expectedEn = englishDays[now.getDay()]!
+    const expectedKo = koreanDays[now.getDay()]!
+    expect(anchor).toContain(expectedEn)
+    expect(anchor).toContain(expectedKo)
+  })
+})

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -1,4 +1,4 @@
-import { formatLocalDateTime, resolveLocalTimezoneName } from '@/shared'
+import { formatLocalDateTime, formatLocalWeekday, resolveLocalTimezoneName } from '@/shared'
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a general-purpose AI agent running inside TypeClaw.
 
@@ -153,6 +153,38 @@ export function renderNowBlock(now: Date): string {
   return `## Now
 
 Session started at \`${iso}\` (${zone}). This is a session-creation snapshot, not a live clock — the value above does not advance during this session. If you need the current wall-clock time precisely (e.g. before scheduling a cron, replying with "it's 3pm", or computing a deadline), run \`date\` via bash instead of trusting this stamp; the container's timezone is set to the host's, so \`date\` returns the user's local time.`
+}
+
+// Per-turn wall-clock anchor, intended for prepending to the user message
+// sent to \`session.prompt\`. Distinct from \`renderNowBlock\`, which embeds
+// the same data in the system prompt at session-creation time and goes
+// stale immediately. This helper has no caller in this commit — wiring
+// happens at each \`session.prompt\` site in follow-up commits.
+//
+// Long-lived channel sessions can outlive a session-creation timestamp by
+// days (a session opened Friday and woken Thursday morning reports
+// "today is Friday" because the only dated reference in its context is the
+// stale stamp). The per-turn anchor always reflects the moment the turn is
+// about to be sent, so the model answers "what day is it" against
+// \`new Date()\` rather than against the session-creation snapshot.
+//
+// The user turn is the non-cacheable suffix in every provider's KV cache
+// shape, so per-turn injection invalidates exactly zero cached bytes — the
+// same bytes that would already be re-billed on each turn's user message.
+//
+// The block emits both English and Korean weekday names alongside the ISO
+// timestamp because models replying in a non-English language frequently
+// compute weekday-from-ISO incorrectly; pre-computing the weekday in both
+// candidate reply languages removes that arithmetic step entirely. The
+// framing is a single \`<current-time>\` XML tag for parity with other
+// runtime-injected per-turn blocks the agent already sees
+// (\`<system-reminder>\` etc.), so the model reads it as a structured anchor
+// rather than as content authored by a human in the chat.
+export function renderTurnTimeAnchor(now: Date = new Date()): string {
+  const iso = formatLocalDateTime(now)
+  const zone = resolveLocalTimezoneName()
+  const weekday = formatLocalWeekday(now)
+  return `<current-time>${iso} (${zone}, ${weekday.en} / ${weekday.ko})</current-time>`
 }
 
 // Compact replacement for DEFAULT_SYSTEM_PROMPT, used by non-interactive

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -125,60 +125,29 @@ export function renderRuntimeBlock(version: string): string {
 TypeClaw runtime version: ${version}.`
 }
 
-// Wall-clock anchor for the agent. Without this, models hallucinate the
-// current time (typically defaulting to a UTC-shaped guess from training
-// data), which surfaces as confidently-wrong replies like "it's 6am" when
-// the actual wall-clock is 15:11 +09:00. The container's clock is correct
-// — `-e TZ=<host-tz>` propagation makes `new Date()` resolve to host local
-// time — but the model never sees that value unless we put it in the
-// prompt.
+// Wall-clock anchor injected into the **user turn**, not the system prompt.
 //
-// Positioned as the very last block of the system prompt (after memory)
-// because it changes on every session creation, which is more frequent
-// than any other section: memory changes per dreaming/memory-logger cycle,
-// gitNudge changes per session, but `now` changes per second. Pinning it
-// to the tail means every byte UP TO this block stays in the provider's
-// cache prefix across session resurrections, and only the trailing ~60
-// bytes invalidate.
+// Why per-turn instead of session-creation: long-lived channel sessions can
+// outlive a session-creation timestamp by days (a session opened Friday and
+// woken Thursday morning happily reports "today is Friday" because the only
+// dated reference in its context is the stale stamp). The per-turn anchor
+// always reflects the moment the turn is about to be sent, so the model
+// answers "what day is it" against `new Date()` rather than against the
+// session-creation snapshot.
 //
-// The model still needs to know this is a session-creation snapshot, not
-// a live clock: long-lived channel sessions can outlive the stamp by
-// hours, and the resource loader is not re-rendered per turn (see the
-// CreateSessionOptions doc at the top of src/agent/index.ts). The prose
-// names the snapshot semantics and tells the model how to get a fresh
-// reading when it matters (run `date` via bash).
-export function renderNowBlock(now: Date): string {
-  const iso = formatLocalDateTime(now)
-  const zone = resolveLocalTimezoneName()
-  return `## Now
-
-Session started at \`${iso}\` (${zone}). This is a session-creation snapshot, not a live clock — the value above does not advance during this session. If you need the current wall-clock time precisely (e.g. before scheduling a cron, replying with "it's 3pm", or computing a deadline), run \`date\` via bash instead of trusting this stamp; the container's timezone is set to the host's, so \`date\` returns the user's local time.`
-}
-
-// Per-turn wall-clock anchor, intended for prepending to the user message
-// sent to \`session.prompt\`. Distinct from \`renderNowBlock\`, which embeds
-// the same data in the system prompt at session-creation time and goes
-// stale immediately. This helper has no caller in this commit — wiring
-// happens at each \`session.prompt\` site in follow-up commits.
-//
-// Long-lived channel sessions can outlive a session-creation timestamp by
-// days (a session opened Friday and woken Thursday morning reports
-// "today is Friday" because the only dated reference in its context is the
-// stale stamp). The per-turn anchor always reflects the moment the turn is
-// about to be sent, so the model answers "what day is it" against
-// \`new Date()\` rather than against the session-creation snapshot.
-//
-// The user turn is the non-cacheable suffix in every provider's KV cache
-// shape, so per-turn injection invalidates exactly zero cached bytes — the
-// same bytes that would already be re-billed on each turn's user message.
+// Why this still respects the prompt cache: the user turn is the only
+// non-cacheable suffix in every provider's KV cache shape. Putting the
+// anchor here invalidates exactly zero cached bytes — the same bytes that
+// would already be re-billed on each turn's user message — so this is
+// cache-free relative to the previous "## Now" placement.
 //
 // The block emits both English and Korean weekday names alongside the ISO
 // timestamp because models replying in a non-English language frequently
 // compute weekday-from-ISO incorrectly; pre-computing the weekday in both
 // candidate reply languages removes that arithmetic step entirely. The
-// framing is a single \`<current-time>\` XML tag for parity with other
+// framing is a single `<current-time>` XML tag for parity with other
 // runtime-injected per-turn blocks the agent already sees
-// (\`<system-reminder>\` etc.), so the model reads it as a structured anchor
+// (`<system-reminder>` etc.), so the model reads it as a structured anchor
 // rather than as content authored by a human in the chat.
 export function renderTurnTimeAnchor(now: Date = new Date()): string {
   const iso = formatLocalDateTime(now)

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5537,3 +5537,25 @@ describe('ChannelRouter quote-anchor on outbound', () => {
     expect(sent[0]?.text).toBe('> <@U_ALICE>: screenshot pls')
   })
 })
+
+describe('ChannelRouter per-turn wall-clock anchor', () => {
+  test('every composed turn carries a leading <current-time> block before any other content', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ externalMessageId: 'engage', text: 'what day is it' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt.startsWith('<current-time>')).toBe(true)
+    const close = prompt.indexOf('</current-time>')
+    expect(close).toBeGreaterThan(-1)
+    const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    const koreanDays = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
+    const anchor = prompt.slice(0, close + '</current-time>'.length)
+    expect(englishDays.some((d) => anchor.includes(d))).toBe(true)
+    expect(koreanDays.some((d) => anchor.includes(d))).toBe(true)
+    expect(prompt).toContain('what day is it')
+  })
+})

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3,7 +3,7 @@ import { basename } from 'node:path'
 import type { AssistantMessage } from '@mariozechner/pi-ai'
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
-import { createSession, type AgentSession } from '@/agent'
+import { createSession, renderTurnTimeAnchor, type AgentSession } from '@/agent'
 import { subscribeProviderErrors } from '@/agent/provider-error'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
@@ -2361,12 +2361,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 function composeTurnPrompt(
   observed: readonly ObservedInbound[],
   batch: readonly QueuedInbound[],
-  state: { adapter?: AdapterId; loopGuardActive: boolean; systemReminders?: readonly string[] } = {
+  state: { adapter?: AdapterId; loopGuardActive: boolean; systemReminders?: readonly string[]; now?: Date } = {
     loopGuardActive: false,
   },
 ): string {
   const adapter = state.adapter ?? 'discord-bot'
   const parts: string[] = []
+  parts.push(renderTurnTimeAnchor(state.now), '')
   // System reminders (subagent-completion wakeups today) lead the turn body
   // because they are typically what triggered the drain — when the prompt
   // queue is empty and the only thing in this iteration is a reminder, the

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -112,7 +112,7 @@ describe('createCronConsumer', () => {
     publishCron(stream, promptJob('greet', 'say hi'))
     await new Promise((r) => setImmediate(r))
 
-    expect(factory.callsByJob.get('greet')).toEqual(['say hi'])
+    expect(factory.callsByJob.get('greet')).toEqual([expect.stringContaining('say hi')])
 
     consumer.stop()
   })
@@ -238,7 +238,9 @@ describe('createCronConsumer', () => {
     publishCron(stream, promptJob('slow', 'second'))
     await new Promise((r) => setImmediate(r))
 
-    expect(calls).toEqual(['slow:first'])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain('slow:')
+    expect(calls[0]).toContain('first')
     expect(consumer.inFlightCount()).toBe(1)
 
     releaseBox.fn?.()
@@ -248,7 +250,7 @@ describe('createCronConsumer', () => {
     await new Promise((r) => setImmediate(r))
 
     expect(calls.length).toBeGreaterThanOrEqual(2)
-    expect(calls.includes('slow:third')).toBe(true)
+    expect(calls.some((c) => c.startsWith('slow:') && c.includes('third'))).toBe(true)
 
     consumer.stop()
   })
@@ -357,7 +359,7 @@ describe('createCronConsumer', () => {
     publishCron(stream, promptJob('once', 'hi'))
     await new Promise((r) => setImmediate(r))
 
-    expect(factory.callsByJob.get('once')).toEqual(['hi'])
+    expect(factory.callsByJob.get('once')).toEqual([expect.stringContaining('hi')])
 
     consumer.stop()
   })
@@ -438,7 +440,7 @@ describe('createCronConsumer', () => {
     await new Promise((r) => setImmediate(r))
 
     // then
-    expect(factory.callsByJob.get('plain')).toEqual(['hello'])
+    expect(factory.callsByJob.get('plain')).toEqual([expect.stringContaining('hello')])
     expect(newSessionMessages).toEqual([])
 
     consumer.stop()
@@ -492,7 +494,11 @@ describe('createCronConsumer', () => {
     await new Promise((r) => setImmediate(r))
 
     // then
-    expect(events).toEqual(['prompt:do work', 'idle:cron-sess-1:/tmp/transcript-1.jsonl', 'end:cron-sess-1'])
+    expect(events).toHaveLength(3)
+    expect(events[0]).toStartWith('prompt:')
+    expect(events[0]).toContain('do work')
+    expect(events[1]).toBe('idle:cron-sess-1:/tmp/transcript-1.jsonl')
+    expect(events[2]).toBe('end:cron-sess-1')
 
     consumer.stop()
   })
@@ -780,11 +786,11 @@ describe('createCronConsumer model fallback', () => {
 
       // then: the consumer called createSessionForCron once per ref in chain
       // order, and the second attempt's prompt was actually invoked
-      expect(calls).toEqual([
-        'fb:openai/gpt-5.4-nano',
-        'fb:fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
-        'fb:fireworks/accounts/fireworks/routers/kimi-k2p6-turbo:ok:do thing',
-      ])
+      expect(calls).toHaveLength(3)
+      expect(calls[0]).toBe('fb:openai/gpt-5.4-nano')
+      expect(calls[1]).toBe('fb:fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+      expect(calls[2]).toMatch(/^fb:fireworks\/accounts\/fireworks\/routers\/kimi-k2p6-turbo:ok:/)
+      expect(calls[2]).toContain('do thing')
 
       consumer.stop()
     } finally {

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -1,5 +1,6 @@
 import {
   createSessionWithDispose,
+  renderTurnTimeAnchor,
   type CreateSessionOptions,
   type CreateSessionResult,
   type SessionOrigin,
@@ -392,7 +393,7 @@ export async function runPromptForCommand(args: {
   })
   const detachAbort = bindSignalToSession(args.signal, session)
   try {
-    await session.prompt(args.text)
+    await session.prompt(`${renderTurnTimeAnchor()}\n\n${args.text}`)
     return session.getLastAssistantText() ?? ''
   } finally {
     detachAbort()

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -415,7 +415,7 @@ describe('createServer abort handling (no stream — fallback path)', () => {
 
     ws.send(JSON.stringify({ type: 'prompt', text: 'do thing' }))
     await waitForState(() => session.promptCalls.length > 0)
-    expect(session.promptCalls).toEqual(['do thing'])
+    expect(session.promptCalls).toEqual([expect.stringContaining('do thing')])
     expect(session.abortCalls).toBe(0)
 
     ws.send(JSON.stringify({ type: 'abort' }))
@@ -667,7 +667,9 @@ describe('createServer restart-handoff consumption', () => {
     if (connected.type !== 'connected') throw new Error('unreachable')
     expect(connected.sessionId).toBe(sessionId)
     await waitForState(() => session.promptCalls.length > 0)
-    expect(session.promptCalls).toEqual([' '])
+    expect(session.promptCalls).toHaveLength(1)
+    expect(session.promptCalls[0]).toContain(' ')
+    expect(session.promptCalls[0]).toMatch(/<current-time>.*<\/current-time>/)
 
     ws.close()
   })
@@ -890,13 +892,13 @@ describe('createServer with stream — input queueing bugfix', () => {
     // when
     ws.send(JSON.stringify({ type: 'prompt', text: 'hello' }))
     await waitForState(() => session.promptCalls.length > 0)
-    expect(session.promptCalls).toEqual(['hello'])
+    expect(session.promptCalls).toEqual([expect.stringContaining('hello')])
 
     session.resolvePrompt()
     await waitFor((m) => m.type === 'done')
 
     // then
-    expect(session.promptCalls).toEqual(['hello'])
+    expect(session.promptCalls).toEqual([expect.stringContaining('hello')])
 
     ws.close()
   })
@@ -917,7 +919,7 @@ describe('createServer with stream — input queueing bugfix', () => {
     if (started.type !== 'prompt_started') throw new Error('unreachable')
     expect(started.text).toBe('hi')
     expect(started.messageId).toBeDefined()
-    expect(session.promptCalls).toEqual(['hi'])
+    expect(session.promptCalls).toEqual([expect.stringContaining('hi')])
 
     session.resolvePrompt()
     ws.close()
@@ -938,14 +940,14 @@ describe('createServer with stream — input queueing bugfix', () => {
     await expectStable(() => session.promptCalls.length > 1, { durationMs: 15, description: 'second prompt' })
 
     // then: only the first reached session.prompt — the second is queued
-    expect(session.promptCalls).toEqual(['first'])
+    expect(session.promptCalls).toEqual([expect.stringContaining('first')])
 
     // when: first completes
     session.resolvePrompt()
     await waitForState(() => session.promptCalls.length === 2)
 
     // then: second now reaches session.prompt
-    expect(session.promptCalls).toEqual(['first', 'second'])
+    expect(session.promptCalls).toEqual([expect.stringContaining('first'), expect.stringContaining('second')])
 
     session.resolvePrompt()
     ws.close()
@@ -1024,7 +1026,7 @@ describe('createServer with stream — input queueing bugfix', () => {
     // and: when first completes, second is NOT processed
     session.resolvePrompt()
     await expectStable(() => session.promptCalls.length > 1, { durationMs: 20, description: 'second prompt' })
-    expect(session.promptCalls).toEqual(['first'])
+    expect(session.promptCalls).toEqual([expect.stringContaining('first')])
 
     ws.close()
   })
@@ -1079,16 +1081,16 @@ describe('createServer with stream — input queueing bugfix', () => {
     // when: first prompt starts
     ws.send(JSON.stringify({ type: 'prompt', text: 'first' }))
     await waitForState(() => session.promptCalls.length > 0)
-    expect(session.promptCalls).toEqual(['first'])
+    expect(session.promptCalls).toEqual([expect.stringContaining('first')])
     expect(session.abortCalls).toBe(0)
 
     // when: interrupt-delivery prompt arrives
     ws.send(JSON.stringify({ type: 'prompt', text: 'urgent', delivery: 'interrupt' }))
-    await waitForState(() => session.abortCalls >= 1 && session.promptCalls.includes('urgent'))
+    await waitForState(() => session.abortCalls >= 1 && session.promptCalls.some((p) => p.includes('urgent')))
 
     // then: abort was called, then second prompt was sent
     expect(session.abortCalls).toBeGreaterThanOrEqual(1)
-    expect(session.promptCalls.includes('urgent')).toBe(true)
+    expect(session.promptCalls.some((p) => p.includes('urgent'))).toBe(true)
 
     session.resolvePrompt()
     ws.close()

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@ import type { Server as BunServer, ServerWebSocket } from 'bun'
 
 import {
   createSessionWithDispose as defaultCreateSessionWithDispose,
+  renderTurnTimeAnchor,
   type AgentSession,
   type CreateSessionOptions,
   type CreateSessionResult,
@@ -711,7 +712,7 @@ export function createServer({
               })
             }
             try {
-              await state.session.prompt(msg.text)
+              await state.session.prompt(`${renderTurnTimeAnchor()}\n\n${msg.text}`)
               send(ws, { type: 'done' })
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err)
@@ -951,7 +952,7 @@ async function drain(ws: Ws, state: SessionState, agentDir: string | undefined, 
 
       await fireTurnStart(item.text)
       try {
-        await state.session.prompt(item.text)
+        await state.session.prompt(`${renderTurnTimeAnchor()}\n\n${item.text}`)
         send(ws, { type: 'done' })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -24,4 +24,10 @@ export {
   type TunnelSnapshot,
 } from './protocol'
 
-export { formatLocalDate, formatLocalDateTime, resolveLocalTimezoneName } from './local-time'
+export {
+  formatLocalDate,
+  formatLocalDateTime,
+  formatLocalWeekday,
+  type LocalWeekday,
+  resolveLocalTimezoneName,
+} from './local-time'

--- a/src/shared/local-time.test.ts
+++ b/src/shared/local-time.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { formatLocalDate, formatLocalDateTime, resolveLocalTimezoneName } from './local-time'
+import { formatLocalDate, formatLocalDateTime, formatLocalWeekday, resolveLocalTimezoneName } from './local-time'
 
 describe('formatLocalDate', () => {
   test('formats a date as YYYY-MM-DD using local calendar fields', () => {
@@ -51,6 +51,37 @@ describe('formatLocalDateTime', () => {
     const abs = Math.abs(expectedOffsetMinutes)
     const expected = `${sign}${String(Math.floor(abs / 60)).padStart(2, '0')}:${String(abs % 60).padStart(2, '0')}`
     expect(offsetPart).toBe(expected)
+  })
+})
+
+describe('formatLocalWeekday', () => {
+  test('returns matching English + Korean names for every day of the week', () => {
+    const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    const koreanDays = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
+    for (let dow = 0; dow < 7; dow++) {
+      const d = new Date(2026, 0, 4 + dow, 12, 0, 0)
+      expect(d.getDay()).toBe(dow)
+      const result = formatLocalWeekday(d)
+      expect(result.en).toBe(englishDays[dow]!)
+      expect(result.ko).toBe(koreanDays[dow]!)
+    }
+  })
+
+  test('uses today by default when no date argument is given', () => {
+    const result = formatLocalWeekday()
+    expect(typeof result.en).toBe('string')
+    expect(typeof result.ko).toBe('string')
+    expect(result.en.length).toBeGreaterThan(0)
+    expect(result.ko.length).toBeGreaterThan(0)
+  })
+
+  test('the returned names line up with what `Intl.DateTimeFormat` reports for the runtime locale', () => {
+    const d = new Date(2026, 4, 28, 12, 0, 0)
+
+    const result = formatLocalWeekday(d)
+
+    expect(result.en).toBe(new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(d))
+    expect(result.ko).toBe(new Intl.DateTimeFormat('ko-KR', { weekday: 'long' }).format(d))
   })
 })
 

--- a/src/shared/local-time.ts
+++ b/src/shared/local-time.ts
@@ -36,3 +36,35 @@ export function resolveLocalTimezoneName(): string {
     return 'UTC'
   }
 }
+
+// English + Korean weekday name pair for a given Date. The per-turn time
+// anchor renders both so the model has the answer to "what day is it"
+// without computing weekday-from-ISO-date — a step LLMs get wrong often
+// enough to matter, especially when answering in a non-English language.
+// Pre-computing in both candidate reply languages removes the arithmetic
+// step entirely instead of trusting the model to do it correctly each
+// turn.
+//
+// Uses Intl.DateTimeFormat with explicit locales. No `timeZone` option:
+// the container's local clock is already host-local (the entrypoint
+// propagates TZ via `-e TZ=<host-tz>`), so the runtime's default zone is
+// the one the user sees. Both locales fall back to the hand-rolled
+// 7-entry lookup if Intl throws (no-tzdata, locked-down sandbox) — the
+// fallback names stay readable and never make the prefix empty.
+const WEEKDAYS_EN = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const
+const WEEKDAYS_KO = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'] as const
+
+export type LocalWeekday = { en: string; ko: string }
+
+export function formatLocalWeekday(date: Date = new Date()): LocalWeekday {
+  const dow = date.getDay()
+  const fallback: LocalWeekday = { en: WEEKDAYS_EN[dow]!, ko: WEEKDAYS_KO[dow]! }
+  try {
+    return {
+      en: new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(date),
+      ko: new Intl.DateTimeFormat('ko-KR', { weekday: 'long' }).format(date),
+    }
+  } catch {
+    return fallback
+  }
+}


### PR DESCRIPTION
## Summary

An agent in a long-lived channel session reported the wrong day of the week — confidently calling Thursday "Friday" in a Korean reply. The session was reused across day boundaries (`src/channels/router.ts:ensureLive`) and the model anchored on a stale dated reference in its system prompt.

Root cause: `renderNowBlock` stamped a single ISO timestamp into the system prompt at session-creation time. When the session was opened on one day and woken on another, the model still read the original "Session started at ..." line and computed the day-of-week from that stale anchor. The explicit warning in the prose ("This is a session-creation snapshot, not a live clock") did not prevent the wrong answer.

Fix: remove the `## Now` block from the system prompt entirely and prepend a fresh `<current-time>` tag to every user message at all six prompt call sites. The anchor is always current; there is no staleness window regardless of how long a session has been alive.

## Why per-turn and not a refreshed session-prompt section

The system prompt KV-cache slot at every provider is committed the moment a session opens. Rewriting it on every turn either invalidates the cache entirely (defeating the purpose of the cache-suffix architecture) or requires a provider-specific session restart. Per-turn injection lands in the user-turn slot, which is already non-cacheable. Zero cached bytes are invalidated compared to the previous `## Now` block.

## Why Korean weekday alongside English

A model replying in a non-English language must map an English weekday name to its target-language equivalent before generating text — an arithmetic step that LLMs get wrong with surprising regularity in non-English output. Pre-computing `목요일` alongside `Thursday` removes that step entirely. The two-language coverage is intentional and the failure mode that motivated it was specifically a Korean-language wrong-day reply.

## Changes

### `src/shared/local-time.ts` — `formatLocalWeekday` helper (new)

Returns the long weekday name (`Thursday` / `목요일`) for a given `Date` using `Intl.DateTimeFormat`, with a hand-rolled lookup fallback when `Intl` is unavailable. Both languages are returned so the caller does not have to call `Intl` twice.

### `src/agent/system-prompt.ts` — `renderTurnTimeAnchor` (new), `renderNowBlock` removed

`renderTurnTimeAnchor` emits a single-line `<current-time>` tag: ISO timestamp, IANA zone, English weekday, Korean weekday. `renderNowBlock` and its `now` parameter are deleted from `composeSystemPrompt` and `createOverrideResourceLoader`. Memory becomes the new cache-suffix tail in the system prompt.

### `src/agent/index.ts` — re-exports `renderTurnTimeAnchor`, drops `renderNowBlock` call sites

`createOverrideResourceLoader` no longer accepts or appends a `now` argument. `renderTurnTimeAnchor` is re-exported from the agent index so call sites can import it from a single entry point.

### Six call sites — each prepends `renderTurnTimeAnchor(new Date())` to the user-turn text

| File                           | Path                                                          |
| ------------------------------ | ------------------------------------------------------------- |
| `src/channels/router.ts`       | `composeTurnPrompt` — channel session turns                   |
| `src/server/index.ts`          | TUI stream-drain loop and direct-prompt fallback              |
| `src/agent/model-fallback.ts`  | `promptWithFallback` — all non-TUI, non-channel sessions      |
| `src/agent/subagents.ts`       | subagent dispatch                                             |
| `src/server/command-runner.ts` | `runPrompt` — command-runner path                             |
| `src/cron/consumer.ts`         | (unchanged; cron calls `promptWithFallback`, already covered) |

The `src/run/index.ts` cron session factory is intentionally left untouched. It calls `promptWithFallback`, which now injects the anchor. Wrapping at the factory level would double-prepend.

The `look_at` tool's fixed vision prompt ("Please describe the attached image(s).") is intentionally skipped — weekday is irrelevant for vision description.

### `scripts/dump-system-prompt.ts` — surfaces per-turn anchor as a separate output block

The debug dumper (`bun run debug:prompt`) now prints a `PER-TURN INJECTION` section below the system-prompt dump so operators can see exactly what the model reads, split into system + per-turn views.

## What this does NOT do

- **No changes to session lifecycle or channel routing.** `ensureLive`, session resurrection, and adapter classifiers are untouched.
- **No new config fields.** The anchor is always injected at every call site; there is no opt-out.
- **No changes to `pi-coding-agent` `SessionTurnStartEvent.userPrompt` semantics.** Injection happens inside `composeTurnPrompt` / `promptWithFallback`, after the hook fires with the raw user text. The hook contract stays intact.
- **No changes to the look_at vision path.** The fixed vision prompt is unchanged.

## Testing

```
bun run typecheck    ✓  0 errors
bun run lint         ✓  0 errors (63 pre-existing warnings, unchanged)
bun run format       ✓  clean
bun run test         ✓  5853 pass, 1 pre-existing failure
```

New test files and test changes:

- `src/shared/local-time.test.ts` — `formatLocalWeekday`: all 7 days × 2 languages, Intl agreement check.
- `src/agent/system-prompt.test.ts` — `renderTurnTimeAnchor`: single-line tag, correct wrapping, English + Korean weekday, weekday matches `Date#getDay`.
- `src/agent/index.test.ts` — system prompt has NO wall-clock anchor (positive guard for the deletion); memory is the trailing cacheable section.
- `src/channels/router.test.ts` — every channel turn carries a leading `<current-time>` block.
- `scripts/dump-system-prompt.test.ts` — cache-suffix order now ends at memory (not `## Now`); wall-clock anchor is verified absent from system prompt across all four origin kinds.

The one pre-existing failure is `resolveSelfPackageJsonPath > points at this package manifest` in `src/update/index.test.ts`. It asserts the resolved path ends with `typeclaw/package.json` but fails in any worktree whose directory name is not literally `typeclaw`. Reproduces identically on `origin/main` with this PR's changes reverted. Unrelated to this change.

## Review notes

- **`renderTurnTimeAnchor` in `src/agent/system-prompt.ts`** is the load-bearing new code. The single-line format and both-language weekday are the key correctness properties.
- **Six call sites, not one wrapper**: wrapping `session.prompt` at the `AgentSession` level would have made `SessionTurnStartEvent.userPrompt` diverge from the raw user text. Callers that mine the prompt for keywords (memory retrieval) would have received anchor-prefixed text. Injecting at each call site keeps those contracts clean.
- **Cron path coverage**: cron uses `promptWithFallback` exclusively. The change in `model-fallback.ts` covers it without touching `src/run/index.ts`.
- **Cache impact is zero**: the `## Now` block was already pinned as the cache-suffix tail (non-cacheable). Moving the anchor to the user turn leaves the system-prompt KV cache completely intact.
