### PR TITLE
secrets: auto-export anthropic OAuth to ~/.claude/.credentials.json

### DIFF
--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -1454,11 +1454,31 @@ describe('network egress entrypoint shim', () => {
     expect(shim).toContain('ln -sfn "$persist_root/.codex/auth.json" "$HOME/.codex/auth.json"')
   })
 
+  test('also symlinks ~/.claude/.credentials.json into /agent/.typeclaw/home/ so Claude Code OAuth credentials survive container restarts', () => {
+    const shim = buildEntrypointShim()
+    // Claude Code rotates tokens in-place by rewriting .credentials.json on
+    // every successful refresh (anthropics/claude-code#53063). Without the
+    // symlink, the refreshed credential lands on the container's overlay
+    // and is wiped on the next `stop`+`start`. Same persist-root contract
+    // as the codex line above.
+    expect(shim).toContain('mkdir -p "$persist_root/.claude" "$HOME/.claude"')
+    expect(shim).toContain('ln -sfn "$persist_root/.claude/.credentials.json" "$HOME/.claude/.credentials.json"')
+  })
+
   test('uses ln -sfn (idempotent + non-dereferencing) so re-runs across container lives never fail and never recurse into a pre-existing ~/.codex directory', () => {
     const shim = buildEntrypointShim()
     expect(shim).toMatch(/ln -sfn "\$persist_root\/\.codex\/auth\.json" "\$HOME\/\.codex\/auth\.json"/)
     expect(shim).not.toMatch(/ln -s "\$persist_root\/\.codex\/auth\.json"/)
     expect(shim).not.toMatch(/ln -sf "\$persist_root\/\.codex\/auth\.json"/)
+  })
+
+  test('claude symlink also uses ln -sfn (same idempotency contract as codex)', () => {
+    const shim = buildEntrypointShim()
+    expect(shim).toMatch(
+      /ln -sfn "\$persist_root\/\.claude\/\.credentials\.json" "\$HOME\/\.claude\/\.credentials\.json"/,
+    )
+    expect(shim).not.toMatch(/ln -s "\$persist_root\/\.claude\/\.credentials\.json"/)
+    expect(shim).not.toMatch(/ln -sf "\$persist_root\/\.claude\/\.credentials\.json"/)
   })
 
   test('link_persistent_home_files is called before each exec on both network-policy paths (off-path before exec bun; on-path after iptables, before exec setpriv) so the symlink is in place before the agent first reads ~/.codex', () => {
@@ -1626,6 +1646,12 @@ exec "$@"
     expect(linkStat.isSymbolicLink()).toBe(true)
     expect(readlinkSync(linkPath)).toBe(join(persistRoot, '.codex', 'auth.json'))
     expect(statSync(join(persistRoot, '.codex')).isDirectory()).toBe(true)
+
+    const claudeLinkPath = join(fakeHome, '.claude', '.credentials.json')
+    const claudeLinkStat = lstatSync(claudeLinkPath)
+    expect(claudeLinkStat.isSymbolicLink()).toBe(true)
+    expect(readlinkSync(claudeLinkPath)).toBe(join(persistRoot, '.claude', '.credentials.json'))
+    expect(statSync(join(persistRoot, '.claude')).isDirectory()).toBe(true)
   })
 
   test('off-path: link_persistent_home_files is idempotent — running the shim twice does not error and leaves the same symlink in place (ln -sfn replaces atomically)', async () => {
@@ -1662,6 +1688,10 @@ exec "$@"
     const linkPath = join(fakeHome, '.codex', 'auth.json')
     expect(lstatSync(linkPath).isSymbolicLink()).toBe(true)
     expect(readlinkSync(linkPath)).toBe(join(persistRoot, '.codex', 'auth.json'))
+
+    const claudeLinkPath = join(fakeHome, '.claude', '.credentials.json')
+    expect(lstatSync(claudeLinkPath).isSymbolicLink()).toBe(true)
+    expect(readlinkSync(claudeLinkPath)).toBe(join(persistRoot, '.claude', '.credentials.json'))
   })
 
   test('off-path: when Xvfb is not on PATH (docker.file.xvfb=false equivalent), the shim execs the agent directly without spawning anything or exporting DISPLAY', async () => {

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -1454,15 +1454,17 @@ describe('network egress entrypoint shim', () => {
     expect(shim).toContain('ln -sfn "$persist_root/.codex/auth.json" "$HOME/.codex/auth.json"')
   })
 
-  test('also symlinks ~/.claude/.credentials.json into /agent/.typeclaw/home/ so Claude Code OAuth credentials survive container restarts', () => {
+  test('also symlinks Claude Code .credentials.json into /agent/.typeclaw/home/ so OAuth credentials survive container restarts', () => {
     const shim = buildEntrypointShim()
     // Claude Code rotates tokens in-place by rewriting .credentials.json on
     // every successful refresh (anthropics/claude-code#53063). Without the
     // symlink, the refreshed credential lands on the container's overlay
     // and is wiped on the next `stop`+`start`. Same persist-root contract
     // as the codex line above.
-    expect(shim).toContain('mkdir -p "$persist_root/.claude" "$HOME/.claude"')
-    expect(shim).toContain('ln -sfn "$persist_root/.claude/.credentials.json" "$HOME/.claude/.credentials.json"')
+    expect(shim).toContain('claude_config_dir="${CLAUDE_CONFIG_DIR:-}"')
+    expect(shim).toContain('claude_config_dir="$HOME/.claude"')
+    expect(shim).toContain('mkdir -p "$persist_root/.claude" "$claude_config_dir"')
+    expect(shim).toContain('ln -sfn "$persist_root/.claude/.credentials.json" "$claude_config_dir/.credentials.json"')
   })
 
   test('uses ln -sfn (idempotent + non-dereferencing) so re-runs across container lives never fail and never recurse into a pre-existing ~/.codex directory', () => {
@@ -1475,10 +1477,18 @@ describe('network egress entrypoint shim', () => {
   test('claude symlink also uses ln -sfn (same idempotency contract as codex)', () => {
     const shim = buildEntrypointShim()
     expect(shim).toMatch(
-      /ln -sfn "\$persist_root\/\.claude\/\.credentials\.json" "\$HOME\/\.claude\/\.credentials\.json"/,
+      /ln -sfn "\$persist_root\/\.claude\/\.credentials\.json" "\$claude_config_dir\/\.credentials\.json"/,
     )
     expect(shim).not.toMatch(/ln -s "\$persist_root\/\.claude\/\.credentials\.json"/)
     expect(shim).not.toMatch(/ln -sf "\$persist_root\/\.claude\/\.credentials\.json"/)
+  })
+
+  test('claude symlink honors CLAUDE_CONFIG_DIR when set', () => {
+    const shim = buildEntrypointShim()
+    const claudeConfigCheckIdx = shim.indexOf('if [ -z "$claude_config_dir" ]; then')
+    const claudeSymlinkIdx = shim.indexOf('"$claude_config_dir/.credentials.json"')
+    expect(claudeConfigCheckIdx).toBeGreaterThan(-1)
+    expect(claudeSymlinkIdx).toBeGreaterThan(claudeConfigCheckIdx)
   })
 
   test('link_persistent_home_files is called before each exec on both network-policy paths (off-path before exec bun; on-path after iptables, before exec setpriv) so the symlink is in place before the agent first reads ~/.codex', () => {

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -283,13 +283,18 @@ set -eu
 #                           no inbound exposure anyway.
 # link_persistent_home_files symlinks credential files that tools write
 # to $HOME into a bind-mounted location so they survive container
-# restarts. The canonical case is Codex CLI's ~/.codex/auth.json: codex
-# rewrites the file in place to rotate OAuth tokens, and the official
-# CI/CD guidance is to persist auth.json so refresh-token state
-# compounds across runs. The container's $HOME (/root by default) lives
-# on Docker's writable overlay and is wiped on every \`stop\`+\`start\`
-# cycle, so without this symlink the operator would have to re-paste
-# auth.json after every restart.
+# restarts. The container's $HOME (/root by default) lives on Docker's
+# writable overlay and is wiped on every \`stop\`+\`start\` cycle, so
+# without this symlink the operator would have to re-paste credentials
+# after every restart.
+#
+# Two files are linked today, both following the same contract:
+#   - ~/.codex/auth.json — Codex CLI rotates OAuth tokens in place by
+#     rewriting auth.json with refreshed credentials.
+#   - ~/.claude/.credentials.json — Claude Code rotates OAuth tokens in
+#     place by rewriting .credentials.json on every successful refresh
+#     (anthropics/claude-code#53063). Linux/Windows path; macOS uses the
+#     Keychain entry "Claude Code-credentials" with the same JSON shape.
 #
 # The persist root lives under /agent/.typeclaw/home/ (bind-mounted
 # from the agent folder via the -v <cwd>:/agent flag in start.ts).
@@ -329,6 +334,8 @@ link_persistent_home_files() {
   persist_root="\${TYPECLAW_PERSIST_HOME_ROOT:-/agent/.typeclaw/home}"
   mkdir -p "$persist_root/.codex" "$HOME/.codex"
   ln -sfn "$persist_root/.codex/auth.json" "$HOME/.codex/auth.json"
+  mkdir -p "$persist_root/.claude" "$HOME/.claude"
+  ln -sfn "$persist_root/.claude/.credentials.json" "$HOME/.claude/.credentials.json"
 }
 
 start_xvfb() {

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -1,4 +1,9 @@
 import type { DockerfileConfig, DockerfileFeatureToggle } from '@/config/config'
+import {
+  CLAUDE_CREDENTIALS_FILE_NAME,
+  CLAUDE_CREDENTIALS_RELATIVE_PATH,
+  CLAUDE_DEFAULT_CONFIG_DIR_NAME,
+} from '@/secrets/export-claude-credentials-file'
 
 import { GHCR_BASE_IMAGE_REPO } from './cli-version'
 
@@ -291,10 +296,11 @@ set -eu
 # Two files are linked today, both following the same contract:
 #   - ~/.codex/auth.json — Codex CLI rotates OAuth tokens in place by
 #     rewriting auth.json with refreshed credentials.
-#   - ~/.claude/.credentials.json — Claude Code rotates OAuth tokens in
-#     place by rewriting .credentials.json on every successful refresh
-#     (anthropics/claude-code#53063). Linux/Windows path; macOS uses the
-#     Keychain entry "Claude Code-credentials" with the same JSON shape.
+#   - $CLAUDE_CONFIG_DIR/.credentials.json, or ~/.claude/.credentials.json
+#     by default — Claude Code rotates OAuth tokens in place by rewriting
+#     .credentials.json on every successful refresh (anthropics/claude-code
+#     #53063). Linux/Windows path; macOS uses the Keychain entry "Claude
+#     Code-credentials" with the same JSON shape.
 #
 # The persist root lives under /agent/.typeclaw/home/ (bind-mounted
 # from the agent folder via the -v <cwd>:/agent flag in start.ts).
@@ -334,8 +340,12 @@ link_persistent_home_files() {
   persist_root="\${TYPECLAW_PERSIST_HOME_ROOT:-/agent/.typeclaw/home}"
   mkdir -p "$persist_root/.codex" "$HOME/.codex"
   ln -sfn "$persist_root/.codex/auth.json" "$HOME/.codex/auth.json"
-  mkdir -p "$persist_root/.claude" "$HOME/.claude"
-  ln -sfn "$persist_root/.claude/.credentials.json" "$HOME/.claude/.credentials.json"
+  claude_config_dir="\${CLAUDE_CONFIG_DIR:-}"
+  if [ -z "$claude_config_dir" ]; then
+    claude_config_dir="$HOME/${CLAUDE_DEFAULT_CONFIG_DIR_NAME}"
+  fi
+  mkdir -p "$persist_root/${CLAUDE_DEFAULT_CONFIG_DIR_NAME}" "$claude_config_dir"
+  ln -sfn "$persist_root/${CLAUDE_CREDENTIALS_RELATIVE_PATH}" "$claude_config_dir/${CLAUDE_CREDENTIALS_FILE_NAME}"
 }
 
 start_xvfb() {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -43,7 +43,11 @@ import type { CronHandlerContext } from '@/plugin/types'
 import { createContainerBroker, publishForwardResult } from '@/portbroker'
 import { ReloadRegistry } from '@/reload'
 import { createClaimController } from '@/role-claim'
-import { exportCodexAuthFileForAgent, hydrateChannelEnvFromSecrets } from '@/secrets'
+import {
+  exportClaudeCredentialsFileForAgent,
+  exportCodexAuthFileForAgent,
+  hydrateChannelEnvFromSecrets,
+} from '@/secrets'
 import { createServer, type Server } from '@/server'
 import {
   createCommandRunner,
@@ -191,6 +195,19 @@ export async function startAgent({
   exportCodexAuthFileForAgent({
     agentDir: cwd,
     codexCliEnabled: cwdConfig.docker.file.codexCli,
+    log: (message) => console.warn(message),
+  })
+
+  // Same shape as the codex exporter above, gated on `docker.file.claudeCode`
+  // and `secrets.json#providers.anthropic`. Writes ~/.claude/.credentials.json
+  // so the Claude Code CLI in the container can run without the user pasting
+  // a CLAUDE_CODE_OAUTH_TOKEN. See src/secrets/export-claude-credentials-
+  // file.ts for the newer-wins compare that prevents clobbering Claude
+  // Code's in-place token refreshes, and the read-merge-write that preserves
+  // any mcpOAuth state in the file.
+  exportClaudeCredentialsFileForAgent({
+    agentDir: cwd,
+    claudeCodeEnabled: cwdConfig.docker.file.claudeCode,
     log: (message) => console.warn(message),
   })
 

--- a/src/secrets/claude-credentials-json.test.ts
+++ b/src/secrets/claude-credentials-json.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from 'bun:test'
+
+import { decodeClaudeAccessTokenExpiryMs, emitClaudeCredentialsJson } from './claude-credentials-json'
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  return `${header}.${body}.signature`
+}
+
+describe('emitClaudeCredentialsJson', () => {
+  test('emits the claudeAiOauth shape with trailing newline', () => {
+    const out = emitClaudeCredentialsJson({
+      type: 'oauth',
+      access: makeJwt({ exp: 2_000_000_000 }),
+      refresh: 'refresh-1',
+      expires: 2_000_000_000_000,
+    } as never)
+
+    expect(out.endsWith('\n')).toBe(true)
+    const parsed = JSON.parse(out) as { claudeAiOauth: Record<string, unknown> }
+    expect(parsed.claudeAiOauth['refreshToken']).toBe('refresh-1')
+    expect(parsed.claudeAiOauth['expiresAt']).toBe(2_000_000_000_000)
+    expect(typeof parsed.claudeAiOauth['accessToken']).toBe('string')
+  })
+
+  test('includes optional scopes when supplied as a string array', () => {
+    const out = emitClaudeCredentialsJson({
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: 1,
+      scopes: ['user:inference', 'user:profile'],
+    } as never)
+    const parsed = JSON.parse(out) as { claudeAiOauth: { scopes?: string[] } }
+    expect(parsed.claudeAiOauth.scopes).toEqual(['user:inference', 'user:profile'])
+  })
+
+  test('omits scopes when not a string array', () => {
+    const out = emitClaudeCredentialsJson({
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: 1,
+      scopes: 'oops-not-an-array',
+    } as never)
+    const parsed = JSON.parse(out) as { claudeAiOauth: Record<string, unknown> }
+    expect(parsed.claudeAiOauth['scopes']).toBeUndefined()
+  })
+
+  test('includes subscriptionType when set', () => {
+    const out = emitClaudeCredentialsJson({
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: 1,
+      subscriptionType: 'max',
+    } as never)
+    const parsed = JSON.parse(out) as { claudeAiOauth: { subscriptionType?: string } }
+    expect(parsed.claudeAiOauth.subscriptionType).toBe('max')
+  })
+
+  test('omits subscriptionType when empty or non-string', () => {
+    const out = emitClaudeCredentialsJson({
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: 1,
+      subscriptionType: '',
+    } as never)
+    const parsed = JSON.parse(out) as { claudeAiOauth: Record<string, unknown> }
+    expect(parsed.claudeAiOauth['subscriptionType']).toBeUndefined()
+  })
+
+  test('preserves a caller-supplied mcpOAuth block alongside claudeAiOauth', () => {
+    const mcp = { 'server-1': { tokens: { access_token: 'x' } } }
+    const out = emitClaudeCredentialsJson({ type: 'oauth', access: 'a', refresh: 'r', expires: 1 } as never, {
+      preserveMcpOAuth: mcp,
+    })
+    const parsed = JSON.parse(out) as { claudeAiOauth: unknown; mcpOAuth: unknown }
+    expect(parsed.mcpOAuth).toEqual(mcp)
+  })
+
+  test('omits mcpOAuth when not supplied (single-key emit)', () => {
+    const out = emitClaudeCredentialsJson({
+      type: 'oauth',
+      access: 'a',
+      refresh: 'r',
+      expires: 1,
+    } as never)
+    const parsed = JSON.parse(out) as Record<string, unknown>
+    expect(Object.keys(parsed)).toEqual(['claudeAiOauth'])
+  })
+
+  test('falls back to JWT exp (in ms) when credential lacks `expires`', () => {
+    const out = emitClaudeCredentialsJson({
+      type: 'oauth',
+      access: makeJwt({ exp: 1_900_000_000 }),
+      refresh: 'r',
+    } as never)
+    const parsed = JSON.parse(out) as { claudeAiOauth: { expiresAt: number } }
+    expect(parsed.claudeAiOauth.expiresAt).toBe(1_900_000_000_000)
+  })
+
+  test('falls back to 0 when credential lacks `expires` AND access is not a decodable JWT', () => {
+    const out = emitClaudeCredentialsJson({
+      type: 'oauth',
+      access: 'not.a.jwt',
+      refresh: 'r',
+    } as never)
+    const parsed = JSON.parse(out) as { claudeAiOauth: { expiresAt: number } }
+    expect(parsed.claudeAiOauth.expiresAt).toBe(0)
+  })
+
+  test('throws on api-key credentials', () => {
+    expect(() => emitClaudeCredentialsJson({ type: 'api_key', key: { value: 'sk-x' } } as never)).toThrow(
+      'only accepts oauth-typed',
+    )
+  })
+
+  test('throws when access is missing or empty', () => {
+    expect(() => emitClaudeCredentialsJson({ type: 'oauth', refresh: 'r', expires: 1 } as never)).toThrow('access')
+    expect(() => emitClaudeCredentialsJson({ type: 'oauth', access: '', refresh: 'r', expires: 1 } as never)).toThrow(
+      'access',
+    )
+  })
+
+  test('throws when refresh is missing or empty', () => {
+    expect(() => emitClaudeCredentialsJson({ type: 'oauth', access: 'a', expires: 1 } as never)).toThrow('refresh')
+    expect(() => emitClaudeCredentialsJson({ type: 'oauth', access: 'a', refresh: '', expires: 1 } as never)).toThrow(
+      'refresh',
+    )
+  })
+})
+
+describe('decodeClaudeAccessTokenExpiryMs', () => {
+  test('decodes a real-shaped JWT and returns ms expiry', () => {
+    const exp = 1_900_000_000
+    const jwt = makeJwt({ exp, foo: 'bar' })
+    expect(decodeClaudeAccessTokenExpiryMs(jwt)).toBe(exp * 1000)
+  })
+
+  test('returns null when the token is not three dot-separated parts', () => {
+    expect(decodeClaudeAccessTokenExpiryMs('not-a-jwt')).toBeNull()
+    expect(decodeClaudeAccessTokenExpiryMs('only.two')).toBeNull()
+    expect(decodeClaudeAccessTokenExpiryMs('a.b.c.d')).toBeNull()
+  })
+
+  test('returns null when the middle segment is not valid base64 JSON', () => {
+    expect(decodeClaudeAccessTokenExpiryMs('a.!!!.c')).toBeNull()
+  })
+
+  test('returns null when exp is missing', () => {
+    const jwt = makeJwt({ sub: 'x' })
+    expect(decodeClaudeAccessTokenExpiryMs(jwt)).toBeNull()
+  })
+
+  test('returns null when exp is not a finite number', () => {
+    const stringExp = makeJwt({ exp: '1700000000' })
+    expect(decodeClaudeAccessTokenExpiryMs(stringExp)).toBeNull()
+    const infinityExp = makeJwt({ exp: Number.POSITIVE_INFINITY })
+    expect(decodeClaudeAccessTokenExpiryMs(infinityExp)).toBeNull()
+  })
+})

--- a/src/secrets/claude-credentials-json.ts
+++ b/src/secrets/claude-credentials-json.ts
@@ -1,0 +1,129 @@
+import type { ProviderCredential } from './schema'
+
+// Emit the on-disk shape Claude Code consumes at ~/.claude/.credentials.json
+// (Linux/Windows; macOS keeps this same JSON inside the Keychain entry
+// "Claude Code-credentials"). The single required top-level key is
+// `claudeAiOauth`. Field names use camelCase, not snake_case — diverging
+// from Codex CLI's `tokens.access_token` shape but matching every
+// third-party Claude Code integration we surveyed (ATLAS_OS, OmniRoute,
+// jcode, paperclip, opencode-claude-auth).
+//
+// `expiresAt` is MILLISECONDS since epoch, not seconds and not ISO. The
+// CLI carries no top-level expiry field outside `claudeAiOauth` — token
+// expiry is recorded both as `expiresAt` here and embedded in the JWT
+// `exp` claim of `accessToken`. The runtime exporter (export-claude-
+// credentials-file.ts) uses the JWT exp for its newer-wins compare,
+// mirroring the Codex CLI exporter's approach, because `expiresAt` is
+// the field Claude Code itself rewrites on in-place refresh.
+//
+// `mcpOAuth` (MCP server OAuth state) may coexist alongside
+// `claudeAiOauth` in the same file. This emitter accepts an optional
+// `preserveMcpOAuth` block so callers that read-merge-write the file
+// don't drop unrelated state. Codex CLI's file is fully owned by the
+// OAuth credential and has no equivalent; this is the one extra
+// complication versus emitCodexAuthJson.
+export type ClaudeAiOauthBlock = {
+  accessToken: string
+  refreshToken: string
+  expiresAt: number
+  scopes?: string[]
+  subscriptionType?: string
+}
+
+export type EmitClaudeCredentialsJsonOptions = {
+  preserveMcpOAuth?: unknown
+}
+
+export function emitClaudeCredentialsJson(
+  credential: ProviderCredential,
+  options: EmitClaudeCredentialsJsonOptions = {},
+): string {
+  if (credential.type !== 'oauth') {
+    throw new Error('emitClaudeCredentialsJson only accepts oauth-typed credentials')
+  }
+  const fields = credential as ProviderCredential & {
+    access?: unknown
+    refresh?: unknown
+    expires?: unknown
+    scopes?: unknown
+    subscriptionType?: unknown
+  }
+  const access = fields.access
+  const refresh = fields.refresh
+  if (typeof access !== 'string' || access.length === 0) {
+    throw new Error('credential is missing a non-empty `access` field')
+  }
+  if (typeof refresh !== 'string' || refresh.length === 0) {
+    throw new Error('credential is missing a non-empty `refresh` field')
+  }
+
+  // Resolution order for `expiresAt`:
+  //   1. `expires` on the credential (pi-ai writes absolute ms epoch here).
+  //   2. JWT `exp` claim decoded from `access`.
+  //   3. 0 — Claude Code treats a missing/zero expiry as "expired" and
+  //      triggers an immediate refresh on next use, which is the safe
+  //      fallback when neither source is available.
+  const expiresAt = readExpiryMs(fields, access)
+
+  const claudeAiOauth: ClaudeAiOauthBlock = {
+    accessToken: access,
+    refreshToken: refresh,
+    expiresAt,
+  }
+  if (Array.isArray(fields.scopes) && fields.scopes.every((s): s is string => typeof s === 'string')) {
+    claudeAiOauth.scopes = fields.scopes
+  }
+  if (typeof fields.subscriptionType === 'string' && fields.subscriptionType.length > 0) {
+    claudeAiOauth.subscriptionType = fields.subscriptionType
+  }
+
+  // Read-merge-write: preserve any existing `mcpOAuth` block the caller
+  // supplied. The emitter doesn't read disk itself (that's the exporter's
+  // job); the caller passes whatever it found at the existing file path.
+  const out: Record<string, unknown> = { claudeAiOauth }
+  if (options.preserveMcpOAuth !== undefined) {
+    out['mcpOAuth'] = options.preserveMcpOAuth
+  }
+  return `${JSON.stringify(out, null, 2)}\n`
+}
+
+// Extracts the JWT `exp` claim (seconds since epoch) and converts to ms.
+// Used by the runtime exporter's newer-wins compare and by emit's
+// `expiresAt` fallback. Returns null on any decode failure; the caller
+// treats that as "unknown freshness". Logic mirrors
+// decodeCodexAccessTokenExpiryMs verbatim — Claude Code OAuth access
+// tokens are standard JWTs with the same base64url-encoded payload
+// shape Codex uses.
+export function decodeClaudeAccessTokenExpiryMs(accessToken: string): number | null {
+  const parts = accessToken.split('.')
+  if (parts.length !== 3) return null
+  const middle = parts[1] ?? ''
+  if (middle === '') return null
+  const normalized = middle.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4)
+  let payload: Record<string, unknown>
+  try {
+    const decoded = typeof atob === 'function' ? atob(padded) : Buffer.from(padded, 'base64').toString('utf8')
+    const parsed: unknown = JSON.parse(decoded)
+    if (!isPlainObject(parsed)) return null
+    payload = parsed
+  } catch {
+    return null
+  }
+  const exp = payload['exp']
+  if (typeof exp !== 'number' || !Number.isFinite(exp)) return null
+  return Math.floor(exp * 1000)
+}
+
+function readExpiryMs(fields: { expires?: unknown }, accessToken: string): number {
+  if (typeof fields.expires === 'number' && Number.isFinite(fields.expires)) {
+    return fields.expires
+  }
+  const fromJwt = decodeClaudeAccessTokenExpiryMs(accessToken)
+  if (fromJwt !== null) return fromJwt
+  return 0
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/secrets/export-claude-credentials-file.test.ts
+++ b/src/secrets/export-claude-credentials-file.test.ts
@@ -105,6 +105,25 @@ describe('exportClaudeCredentialsFileIfApplicable', () => {
     })
   })
 
+  test('CLAUDE_CONFIG_DIR writes .credentials.json there instead of the default ~/.claude path', async () => {
+    await withHome(async (home) => {
+      const configDir = join(home, 'custom-claude-config')
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({ refresh: 'config-dir-refresh' }),
+        homeDir: home,
+        configDir,
+      })
+      expect(result).toEqual({ action: 'wrote', path: join(configDir, '.credentials.json') })
+      expect(existsSync(join(configDir, '.credentials.json'))).toBe(true)
+      expect(existsSync(join(home, '.claude', '.credentials.json'))).toBe(false)
+      const parsed = JSON.parse(readFileSync(join(configDir, '.credentials.json'), 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+      }
+      expect(parsed.claudeAiOauth.refreshToken).toBe('config-dir-refresh')
+    })
+  })
+
   test('writes with 0600 file mode (refresh token is long-lived)', async () => {
     await withHome((home) => {
       exportClaudeCredentialsFileIfApplicable({
@@ -140,6 +159,36 @@ describe('exportClaudeCredentialsFileIfApplicable', () => {
         claudeAiOauth: { refreshToken: string }
       }
       expect(after.claudeAiOauth.refreshToken).toBe('claude-refreshed')
+    })
+  })
+
+  test('existing file with opaque access token and later expiresAt → skip without clobbering rotated refresh token', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      writeFileSync(
+        join(home, '.claude', '.credentials.json'),
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'sk-ant-oat01-rotated',
+            refreshToken: 'sk-ant-ort01-rotated',
+            expiresAt: 2_000_000_000_000,
+          },
+        }),
+      )
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({
+          access: 'sk-ant-oat01-incoming',
+          refresh: 'sk-ant-ort01-incoming',
+          expires: 1_900_000_000_000,
+        }),
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'on-disk-is-fresher' })
+      const after = JSON.parse(readFileSync(join(home, '.claude', '.credentials.json'), 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+      }
+      expect(after.claudeAiOauth.refreshToken).toBe('sk-ant-ort01-rotated')
     })
   })
 

--- a/src/secrets/export-claude-credentials-file.test.ts
+++ b/src/secrets/export-claude-credentials-file.test.ts
@@ -1,0 +1,418 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, lstatSync, mkdirSync, readFileSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { exportClaudeCredentialsFileIfApplicable } from './export-claude-credentials-file'
+import type { Providers } from './schema'
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  return `${header}.${body}.sig`
+}
+
+function oauthProviders(opts: {
+  access?: string
+  refresh?: string
+  expires?: number
+  scopes?: string[]
+  subscriptionType?: string
+}): Providers {
+  return {
+    anthropic: {
+      type: 'oauth',
+      access: opts.access ?? makeJwt({ exp: 2_000_000_000 }),
+      refresh: opts.refresh ?? 'refresh-token',
+      expires: opts.expires ?? 2_000_000_000_000,
+      ...(opts.scopes !== undefined ? { scopes: opts.scopes } : {}),
+      ...(opts.subscriptionType !== undefined ? { subscriptionType: opts.subscriptionType } : {}),
+    } as never,
+  }
+}
+
+async function withHome<T>(fn: (home: string) => Promise<T> | T): Promise<T> {
+  const home = await mkdtemp(join(tmpdir(), 'typeclaw-claude-export-'))
+  try {
+    return await fn(home)
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+}
+
+describe('exportClaudeCredentialsFileIfApplicable', () => {
+  test('claudeCode disabled → skip without touching the filesystem', async () => {
+    await withHome((home) => {
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: false,
+        providers: oauthProviders({}),
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'claude-code-disabled' })
+      expect(existsSync(join(home, '.claude'))).toBe(false)
+    })
+  })
+
+  test('anthropic provider absent → skip', async () => {
+    await withHome((home) => {
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: {},
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'no-anthropic-credential' })
+      expect(existsSync(join(home, '.claude'))).toBe(false)
+    })
+  })
+
+  test('skips when anthropic credential is api-key shape (defensive)', async () => {
+    await withHome((home) => {
+      const providers: Providers = {
+        anthropic: { type: 'api_key', key: { value: 'sk-ant-x' } } as never,
+      }
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers,
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'credential-not-oauth' })
+      expect(existsSync(join(home, '.claude'))).toBe(false)
+    })
+  })
+
+  test('no .credentials.json yet → writes from secrets.json', async () => {
+    await withHome((home) => {
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({
+          access: makeJwt({ exp: 2_000_000_000 }),
+          refresh: 'refresh-1',
+          scopes: ['user:inference', 'user:profile'],
+          subscriptionType: 'max',
+        }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const target = join(home, '.claude', '.credentials.json')
+      expect(existsSync(target)).toBe(true)
+      const parsed = JSON.parse(readFileSync(target, 'utf8')) as {
+        claudeAiOauth: { accessToken: string; refreshToken: string; scopes?: string[]; subscriptionType?: string }
+      }
+      expect(parsed.claudeAiOauth.refreshToken).toBe('refresh-1')
+      expect(parsed.claudeAiOauth.scopes).toEqual(['user:inference', 'user:profile'])
+      expect(parsed.claudeAiOauth.subscriptionType).toBe('max')
+    })
+  })
+
+  test('writes with 0600 file mode (refresh token is long-lived)', async () => {
+    await withHome((home) => {
+      exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({}),
+        homeDir: home,
+      })
+      const stat = statSync(join(home, '.claude', '.credentials.json'))
+      expect(stat.mode & 0o777).toBe(0o600)
+    })
+  })
+
+  test('existing file with strictly later JWT exp → skip (Claude Code refreshed in-place)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      const freshAccess = makeJwt({ exp: 3_000_000_000 })
+      writeFileSync(
+        join(home, '.claude', '.credentials.json'),
+        JSON.stringify({
+          claudeAiOauth: { accessToken: freshAccess, refreshToken: 'claude-refreshed', expiresAt: 3_000_000_000_000 },
+        }),
+      )
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({
+          access: makeJwt({ exp: 1_000_000_000 }),
+          expires: 1_000_000_000_000,
+        }),
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'on-disk-is-fresher' })
+      const after = JSON.parse(readFileSync(join(home, '.claude', '.credentials.json'), 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+      }
+      expect(after.claudeAiOauth.refreshToken).toBe('claude-refreshed')
+    })
+  })
+
+  test('existing file with older JWT exp → overwrite (user re-pasted via wizard)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      const staleAccess = makeJwt({ exp: 1_000_000_000 })
+      writeFileSync(
+        join(home, '.claude', '.credentials.json'),
+        JSON.stringify({
+          claudeAiOauth: { accessToken: staleAccess, refreshToken: 'stale-refresh', expiresAt: 1_000_000_000_000 },
+        }),
+      )
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({
+          access: makeJwt({ exp: 3_000_000_000 }),
+          refresh: 'fresh-refresh',
+          expires: 3_000_000_000_000,
+        }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.claude', '.credentials.json'), 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+      }
+      expect(after.claudeAiOauth.refreshToken).toBe('fresh-refresh')
+    })
+  })
+
+  test('tie on JWT exp → skip (steady state at zero churn)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      const tied = makeJwt({ exp: 2_000_000_000 })
+      writeFileSync(
+        join(home, '.claude', '.credentials.json'),
+        JSON.stringify({
+          claudeAiOauth: { accessToken: tied, refreshToken: 'on-disk', expiresAt: 2_000_000_000_000 },
+        }),
+      )
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({ access: tied, refresh: 'in-secrets', expires: 2_000_000_000_000 }),
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'on-disk-is-fresher' })
+      const after = JSON.parse(readFileSync(join(home, '.claude', '.credentials.json'), 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+      }
+      expect(after.claudeAiOauth.refreshToken).toBe('on-disk')
+    })
+  })
+
+  test('preserves an existing mcpOAuth block on overwrite (read-merge-write)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      const staleAccess = makeJwt({ exp: 1_000_000_000 })
+      const mcpBlock = { 'server-x': { tokens: { access_token: 'mcp-at' } } }
+      writeFileSync(
+        join(home, '.claude', '.credentials.json'),
+        JSON.stringify({
+          claudeAiOauth: { accessToken: staleAccess, refreshToken: 'stale', expiresAt: 1_000_000_000_000 },
+          mcpOAuth: mcpBlock,
+        }),
+      )
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({
+          access: makeJwt({ exp: 3_000_000_000 }),
+          refresh: 'fresh',
+          expires: 3_000_000_000_000,
+        }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.claude', '.credentials.json'), 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+        mcpOAuth: unknown
+      }
+      expect(after.claudeAiOauth.refreshToken).toBe('fresh')
+      expect(after.mcpOAuth).toEqual(mcpBlock)
+    })
+  })
+
+  test('malformed JSON → overwrite from secrets.json (mcpOAuth lost, but file was unrecoverable)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      writeFileSync(join(home, '.claude', '.credentials.json'), '{ not valid json')
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({ refresh: 'recovered' }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.claude', '.credentials.json'), 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+        mcpOAuth?: unknown
+      }
+      expect(after.claudeAiOauth.refreshToken).toBe('recovered')
+      expect(after.mcpOAuth).toBeUndefined()
+    })
+  })
+
+  test('file present but missing claudeAiOauth.accessToken → overwrite', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      writeFileSync(join(home, '.claude', '.credentials.json'), JSON.stringify({ claudeAiOauth: {} }))
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({ refresh: 'oauth-refresh' }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.claude', '.credentials.json'), 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+      }
+      expect(after.claudeAiOauth.refreshToken).toBe('oauth-refresh')
+    })
+  })
+
+  test('on-disk accessToken has undecodable JWT exp → overwrite', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      writeFileSync(
+        join(home, '.claude', '.credentials.json'),
+        JSON.stringify({ claudeAiOauth: { accessToken: 'not.a.jwt', refreshToken: 'rotten', expiresAt: 0 } }),
+      )
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({ refresh: 'good' }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.claude', '.credentials.json'), 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+      }
+      expect(after.claudeAiOauth.refreshToken).toBe('good')
+    })
+  })
+
+  test('write failure surfaces as { action: "failed" } and calls the log hook (boot never blocked)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.claude', '.credentials.json', 'in-the-way'), { recursive: true })
+      const captured: string[] = []
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({}),
+        homeDir: home,
+        log: (msg) => captured.push(msg),
+      })
+      expect(result.action).toBe('failed')
+      expect(captured.length).toBe(1)
+      expect(captured[0]).toMatch(/^exportClaudeCredentialsFile: /)
+    })
+  })
+
+  test('credential without `expires` falls back to JWT exp (no spurious overwrite of fresher on-disk file)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      const fresherAccess = makeJwt({ exp: 3_000_000_000 })
+      writeFileSync(
+        join(home, '.claude', '.credentials.json'),
+        JSON.stringify({
+          claudeAiOauth: { accessToken: fresherAccess, refreshToken: 'claude-current', expiresAt: 3_000_000_000_000 },
+        }),
+      )
+      const staleCred: Providers = {
+        anthropic: {
+          type: 'oauth',
+          access: makeJwt({ exp: 1_000_000_000 }),
+          refresh: 'r',
+        } as never,
+      }
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: staleCred,
+        homeDir: home,
+      })
+      expect(result).toEqual({ action: 'skipped', reason: 'on-disk-is-fresher' })
+    })
+  })
+
+  test('credential without expires AND without decodable JWT falls back to now() and writes', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      const onDiskAccess = makeJwt({ exp: 1_000_000 })
+      writeFileSync(
+        join(home, '.claude', '.credentials.json'),
+        JSON.stringify({
+          claudeAiOauth: { accessToken: onDiskAccess, refreshToken: 'old', expiresAt: 1_000_000_000 },
+        }),
+      )
+      const cred: Providers = {
+        anthropic: {
+          type: 'oauth',
+          access: 'not.decodable',
+          refresh: 'r-fallback',
+        } as never,
+      }
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: cred,
+        homeDir: home,
+        now: () => 2_000_000_000_000,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.claude', '.credentials.json'), 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+      }
+      expect(after.claudeAiOauth.refreshToken).toBe('r-fallback')
+    })
+  })
+
+  test('preserves the entrypoint shim symlink: writes through the link to the persistent target', async () => {
+    await withHome((home) => {
+      // given: entrypoint shim has installed a symlink at $HOME/.claude/.credentials.json
+      // pointing at the persistent host-side path (mimicking link_persistent_home_files).
+      const persistRoot = join(home, 'persist', '.claude')
+      mkdirSync(persistRoot, { recursive: true })
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      const symlinkPath = join(home, '.claude', '.credentials.json')
+      const persistPath = join(persistRoot, '.credentials.json')
+      symlinkSync(persistPath, symlinkPath)
+
+      // when: exporter fires on first boot (persist target is a dangling symlink).
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({ refresh: 'first-boot-refresh' }),
+        homeDir: home,
+      })
+
+      // then: the symlink at $HOME/.claude/.credentials.json must still be a symlink.
+      expect(result.action).toBe('wrote')
+      expect(lstatSync(symlinkPath).isSymbolicLink()).toBe(true)
+      expect(existsSync(persistPath)).toBe(true)
+      const onDisk = JSON.parse(readFileSync(persistPath, 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+      }
+      expect(onDisk.claudeAiOauth.refreshToken).toBe('first-boot-refresh')
+    })
+  })
+
+  test('symlink case: newer-wins compare still works because readFileSync follows symlinks', async () => {
+    await withHome((home) => {
+      // given: symlink in place + persistent file already contains a fresher token.
+      const persistRoot = join(home, 'persist', '.claude')
+      mkdirSync(persistRoot, { recursive: true })
+      mkdirSync(join(home, '.claude'), { recursive: true })
+      const symlinkPath = join(home, '.claude', '.credentials.json')
+      const persistPath = join(persistRoot, '.credentials.json')
+      symlinkSync(persistPath, symlinkPath)
+      const fresherAccess = makeJwt({ exp: 3_000_000_000 })
+      writeFileSync(
+        persistPath,
+        JSON.stringify({
+          claudeAiOauth: { accessToken: fresherAccess, refreshToken: 'claude-rotated', expiresAt: 3_000_000_000_000 },
+        }),
+      )
+
+      // when: exporter runs with an older typeclaw-side credential.
+      const result = exportClaudeCredentialsFileIfApplicable({
+        claudeCodeEnabled: true,
+        providers: oauthProviders({ access: makeJwt({ exp: 1_000_000_000 }), expires: 1_000_000_000_000 }),
+        homeDir: home,
+      })
+
+      // then: skip, because the symlink resolves through to the fresher persistent file.
+      expect(result).toEqual({ action: 'skipped', reason: 'on-disk-is-fresher' })
+      const after = JSON.parse(readFileSync(persistPath, 'utf8')) as {
+        claudeAiOauth: { refreshToken: string }
+      }
+      expect(after.claudeAiOauth.refreshToken).toBe('claude-rotated')
+      expect(lstatSync(symlinkPath).isSymbolicLink()).toBe(true)
+    })
+  })
+})

--- a/src/secrets/export-claude-credentials-file.ts
+++ b/src/secrets/export-claude-credentials-file.ts
@@ -1,0 +1,244 @@
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
+
+import { decodeClaudeAccessTokenExpiryMs, emitClaudeCredentialsJson } from './claude-credentials-json'
+import type { ProviderCredential, Providers } from './schema'
+import { SecretsBackend } from './storage'
+
+const FILE_MODE = 0o600
+const DIR_MODE = 0o700
+
+export type ExportClaudeCredentialsFileResult =
+  | { action: 'skipped'; reason: SkipReason }
+  | { action: 'wrote'; path: string }
+  | { action: 'failed'; reason: string }
+
+export type SkipReason =
+  | 'claude-code-disabled'
+  | 'no-anthropic-credential'
+  | 'credential-not-oauth'
+  | 'on-disk-is-fresher'
+
+export type ExportClaudeCredentialsFileOptions = {
+  claudeCodeEnabled: boolean
+  providers: Providers
+  homeDir?: string
+  now?: () => number
+  log?: (message: string) => void
+}
+
+// Writes typeclaw's anthropic OAuth credential to
+// $HOME/.claude/.credentials.json when it's safe to do so. The Dockerfile
+// entrypoint shim symlinks $HOME/.claude/.credentials.json to
+// /agent/.typeclaw/home/.claude/.credentials.json on every boot, so the
+// write follows the symlink and lands on the persistent host-side path —
+// same contract as exportCodexAuthFile.
+//
+// Three guards, cheapest first. The first two return without ever touching
+// the filesystem, which keeps the 90% case (users who don't enable
+// Claude Code) at zero overhead on every container start.
+export function exportClaudeCredentialsFileIfApplicable(
+  options: ExportClaudeCredentialsFileOptions,
+): ExportClaudeCredentialsFileResult {
+  if (!options.claudeCodeEnabled) return { action: 'skipped', reason: 'claude-code-disabled' }
+
+  const credential = options.providers['anthropic']
+  if (credential === undefined) return { action: 'skipped', reason: 'no-anthropic-credential' }
+  if (credential.type !== 'oauth') return { action: 'skipped', reason: 'credential-not-oauth' }
+
+  const targetPath = join(options.homeDir ?? homedir(), '.claude', '.credentials.json')
+
+  try {
+    const existing = readExisting(targetPath)
+    if (!shouldOverwrite(existing, credential, options.now ?? Date.now)) {
+      return { action: 'skipped', reason: 'on-disk-is-fresher' }
+    }
+    const mcpOAuthOpt = existing?.mcpOAuth !== undefined ? { preserveMcpOAuth: existing.mcpOAuth } : {}
+    const contents = emitClaudeCredentialsJson(credential, mcpOAuthOpt)
+    writeAtomic(targetPath, contents)
+    return { action: 'wrote', path: targetPath }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    options.log?.(`exportClaudeCredentialsFile: ${reason}`)
+    return { action: 'failed', reason }
+  }
+}
+
+type ExistingFile = {
+  onDiskAccessToken: string | null
+  mcpOAuth: unknown
+}
+
+// Read once, parse once. Returns null when the file is missing OR
+// unparseable. Returning null short-circuits both branches of the
+// overwrite decision (the no-disk-file recovery path) AND drops any
+// non-recoverable mcpOAuth state — but if the file is unparseable
+// there's nothing to recover anyway. When parsing succeeds, we hand
+// back the access token (for the newer-wins compare) and the raw
+// mcpOAuth block (for read-merge-write preservation).
+function readExisting(targetPath: string): ExistingFile | null {
+  let raw: string
+  try {
+    raw = readFileSync(targetPath, 'utf8')
+  } catch {
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const obj = parsed as Record<string, unknown>
+  const claudeBlock = obj['claudeAiOauth']
+  let onDiskAccessToken: string | null = null
+  if (typeof claudeBlock === 'object' && claudeBlock !== null) {
+    const access = (claudeBlock as Record<string, unknown>)['accessToken']
+    if (typeof access === 'string' && access.length > 0) onDiskAccessToken = access
+  }
+  return { onDiskAccessToken, mcpOAuth: obj['mcpOAuth'] }
+}
+
+// Newer-wins: skip the write unless typeclaw's stored credential is
+// strictly fresher than the on-disk JWT. Claude Code rotates tokens
+// in-place (issue #53063 in anthropics/claude-code confirms it rewrites
+// .credentials.json with a fresher accessToken/refreshToken/expiresAt
+// on every successful refresh), so on a restart the file may legitimately
+// be ahead of secrets.json. We must not clobber that.
+//
+// Ties skip: when expiries match there's nothing to gain from a write,
+// and avoiding the I/O keeps the steady state at zero churn.
+//
+// existing === null OR existing.onDiskAccessToken === null OR JWT
+// undecodable → return true. That's the "we have a valid credential,
+// the file is unusable, replace it" recovery case.
+function shouldOverwrite(
+  existing: ExistingFile | null,
+  credential: ProviderCredential & { expires?: unknown; access?: unknown },
+  now: () => number,
+): boolean {
+  if (existing === null) return true
+  if (existing.onDiskAccessToken === null) return true
+  const onDiskExpiry = decodeClaudeAccessTokenExpiryMs(existing.onDiskAccessToken)
+  if (onDiskExpiry === null) return true
+  const credentialExpiry = readCredentialExpiry(credential, now)
+  return credentialExpiry > onDiskExpiry
+}
+
+// Resolution order for the credential's expiry:
+//   1. The `expires` field pi-ai writes (absolute ms epoch).
+//   2. The JWT `exp` claim decoded from `access`.
+//   3. Now — guarantees we still write on first boot when the credential
+//      lacks both, rather than silently skipping forever.
+function readCredentialExpiry(credential: { expires?: unknown; access?: unknown }, now: () => number): number {
+  if (typeof credential.expires === 'number' && Number.isFinite(credential.expires)) {
+    return credential.expires
+  }
+  if (typeof credential.access === 'string') {
+    const fromJwt = decodeClaudeAccessTokenExpiryMs(credential.access)
+    if (fromJwt !== null) return fromJwt
+  }
+  return now()
+}
+
+// Atomic temp-then-rename, mirroring export-codex-auth-file.ts's
+// writeAtomic. The directory is created with 0700 and the file with 0600
+// because the credential carries a long-lived refresh token — leaking it
+// via lax permissions defeats the whole point. The 0600 chmod after
+// rename is belt-and-suspenders: writeFileSync's `mode` is applied at
+// create time, but umask can mask it down on some filesystems.
+//
+// Symlink preservation: the entrypoint shim will install
+// $HOME/.claude/.credentials.json as a symlink to
+// /agent/.typeclaw/home/.claude/.credentials.json. POSIX rename(2)
+// replaces the directory entry at the destination atomically and does
+// NOT follow symlinks, so a naive renameSync against the symlink path
+// would replace the symlink with a regular file, leaving the persistent
+// path empty and Claude Code's in-place token refresh silently lost on
+// every restart. Resolve the symlink target with readlinkSync and rename
+// against the real path so the symlink itself is preserved. The temp
+// file MUST live alongside the real target (same filesystem) because
+// renameSync across filesystems fails with EXDEV.
+function writeAtomic(targetPath: string, contents: string): void {
+  const realTarget = resolveSymlinkTarget(targetPath)
+  const dir = dirname(realTarget)
+  mkdirSync(dir, { recursive: true, mode: DIR_MODE })
+  const tmp = `${realTarget}.${process.pid}.${Date.now()}.tmp`
+  writeFileSync(tmp, contents, { encoding: 'utf8', mode: FILE_MODE })
+  try {
+    renameSync(tmp, realTarget)
+  } catch (err) {
+    try {
+      unlinkSync(tmp)
+    } catch {
+      // best-effort cleanup of the temp file when rename fails
+    }
+    throw err
+  }
+  try {
+    statSync(realTarget)
+    chmodSync(realTarget, FILE_MODE)
+  } catch {
+    // ignore — file vanished between rename and chmod is benign
+  }
+}
+
+// Returns the absolute path renameSync should target. When `path` is a
+// symlink (production: $HOME/.claude/.credentials.json -> /agent/...),
+// returns the resolved absolute target so we write through the link
+// instead of replacing it. Otherwise (tests, or first boot before the
+// shim installs the symlink), returns the path unchanged. readlinkSync
+// throws EINVAL when the path exists but isn't a symlink and ENOENT
+// when nothing is there — both cases fall through to the original path.
+function resolveSymlinkTarget(path: string): string {
+  let link: string
+  try {
+    link = readlinkSync(path)
+  } catch {
+    return path
+  }
+  return isAbsolute(link) ? link : resolve(dirname(path), link)
+}
+
+export type ExportClaudeCredentialsFileForAgentOptions = {
+  agentDir: string
+  claudeCodeEnabled: boolean
+  homeDir?: string
+  log?: (message: string) => void
+}
+
+// Boot-time convenience wrapper for src/run/index.ts. Mirrors
+// exportCodexAuthFileForAgent: takes agentDir, never throws, returns a
+// result the caller can ignore. Secrets-file read failures are caught
+// and surfaced as 'failed' so the agent boot is never blocked by a
+// missing or malformed secrets.json.
+export function exportClaudeCredentialsFileForAgent(
+  options: ExportClaudeCredentialsFileForAgentOptions,
+): ExportClaudeCredentialsFileResult {
+  if (!options.claudeCodeEnabled) return { action: 'skipped', reason: 'claude-code-disabled' }
+  let providers: Providers
+  try {
+    providers = new SecretsBackend(join(options.agentDir, 'secrets.json')).tryReadProvidersSync()
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    options.log?.(`exportClaudeCredentialsFile: ${reason}`)
+    return { action: 'failed', reason }
+  }
+  return exportClaudeCredentialsFileIfApplicable({
+    claudeCodeEnabled: options.claudeCodeEnabled,
+    providers,
+    ...(options.homeDir !== undefined ? { homeDir: options.homeDir } : {}),
+    ...(options.log !== undefined ? { log: options.log } : {}),
+  })
+}

--- a/src/secrets/export-claude-credentials-file.ts
+++ b/src/secrets/export-claude-credentials-file.ts
@@ -17,6 +17,9 @@ import { SecretsBackend } from './storage'
 
 const FILE_MODE = 0o600
 const DIR_MODE = 0o700
+export const CLAUDE_CREDENTIALS_FILE_NAME = '.credentials.json'
+export const CLAUDE_DEFAULT_CONFIG_DIR_NAME = '.claude'
+export const CLAUDE_CREDENTIALS_RELATIVE_PATH = join(CLAUDE_DEFAULT_CONFIG_DIR_NAME, CLAUDE_CREDENTIALS_FILE_NAME)
 
 export type ExportClaudeCredentialsFileResult =
   | { action: 'skipped'; reason: SkipReason }
@@ -33,13 +36,15 @@ export type ExportClaudeCredentialsFileOptions = {
   claudeCodeEnabled: boolean
   providers: Providers
   homeDir?: string
+  configDir?: string
   now?: () => number
   log?: (message: string) => void
 }
 
 // Writes typeclaw's anthropic OAuth credential to
-// $HOME/.claude/.credentials.json when it's safe to do so. The Dockerfile
-// entrypoint shim symlinks $HOME/.claude/.credentials.json to
+// $CLAUDE_CONFIG_DIR/.credentials.json (or $HOME/.claude/.credentials.json
+// by default) when it's safe to do so. The Dockerfile entrypoint shim
+// symlinks the same resolved credentials path to
 // /agent/.typeclaw/home/.claude/.credentials.json on every boot, so the
 // write follows the symlink and lands on the persistent host-side path —
 // same contract as exportCodexAuthFile.
@@ -56,7 +61,10 @@ export function exportClaudeCredentialsFileIfApplicable(
   if (credential === undefined) return { action: 'skipped', reason: 'no-anthropic-credential' }
   if (credential.type !== 'oauth') return { action: 'skipped', reason: 'credential-not-oauth' }
 
-  const targetPath = join(options.homeDir ?? homedir(), '.claude', '.credentials.json')
+  const targetPath = resolveClaudeCredentialsPath({
+    ...(options.homeDir !== undefined ? { homeDir: options.homeDir } : {}),
+    ...(options.configDir !== undefined ? { configDir: options.configDir } : {}),
+  })
 
   try {
     const existing = readExisting(targetPath)
@@ -76,6 +84,7 @@ export function exportClaudeCredentialsFileIfApplicable(
 
 type ExistingFile = {
   onDiskAccessToken: string | null
+  onDiskExpiresAt: number | null
   mcpOAuth: unknown
 }
 
@@ -103,15 +112,21 @@ function readExisting(targetPath: string): ExistingFile | null {
   const obj = parsed as Record<string, unknown>
   const claudeBlock = obj['claudeAiOauth']
   let onDiskAccessToken: string | null = null
+  let onDiskExpiresAt: number | null = null
   if (typeof claudeBlock === 'object' && claudeBlock !== null) {
-    const access = (claudeBlock as Record<string, unknown>)['accessToken']
+    const claudeObj = claudeBlock as Record<string, unknown>
+    const access = claudeObj['accessToken']
     if (typeof access === 'string' && access.length > 0) onDiskAccessToken = access
+    const expiresAt = claudeObj['expiresAt']
+    if (typeof expiresAt === 'number' && Number.isFinite(expiresAt) && expiresAt > 0) {
+      onDiskExpiresAt = expiresAt
+    }
   }
-  return { onDiskAccessToken, mcpOAuth: obj['mcpOAuth'] }
+  return { onDiskAccessToken, onDiskExpiresAt, mcpOAuth: obj['mcpOAuth'] }
 }
 
 // Newer-wins: skip the write unless typeclaw's stored credential is
-// strictly fresher than the on-disk JWT. Claude Code rotates tokens
+// strictly fresher than the on-disk expiry. Claude Code rotates tokens
 // in-place (issue #53063 in anthropics/claude-code confirms it rewrites
 // .credentials.json with a fresher accessToken/refreshToken/expiresAt
 // on every successful refresh), so on a restart the file may legitimately
@@ -120,9 +135,9 @@ function readExisting(targetPath: string): ExistingFile | null {
 // Ties skip: when expiries match there's nothing to gain from a write,
 // and avoiding the I/O keeps the steady state at zero churn.
 //
-// existing === null OR existing.onDiskAccessToken === null OR JWT
-// undecodable → return true. That's the "we have a valid credential,
-// the file is unusable, replace it" recovery case.
+// existing === null OR existing.onDiskAccessToken === null OR expiry
+// undecodable from both expiresAt and JWT → return true. That's the "we
+// have a valid credential, the file is unusable, replace it" recovery case.
 function shouldOverwrite(
   existing: ExistingFile | null,
   credential: ProviderCredential & { expires?: unknown; access?: unknown },
@@ -130,10 +145,16 @@ function shouldOverwrite(
 ): boolean {
   if (existing === null) return true
   if (existing.onDiskAccessToken === null) return true
-  const onDiskExpiry = decodeClaudeAccessTokenExpiryMs(existing.onDiskAccessToken)
+  const onDiskExpiry = readOnDiskExpiry(existing)
   if (onDiskExpiry === null) return true
   const credentialExpiry = readCredentialExpiry(credential, now)
   return credentialExpiry > onDiskExpiry
+}
+
+function readOnDiskExpiry(existing: ExistingFile): number | null {
+  if (existing.onDiskExpiresAt !== null) return existing.onDiskExpiresAt
+  if (existing.onDiskAccessToken === null) return null
+  return decodeClaudeAccessTokenExpiryMs(existing.onDiskAccessToken)
 }
 
 // Resolution order for the credential's expiry:
@@ -150,6 +171,18 @@ function readCredentialExpiry(credential: { expires?: unknown; access?: unknown 
     if (fromJwt !== null) return fromJwt
   }
   return now()
+}
+
+export function resolveClaudeCredentialsPath(options: { homeDir?: string; configDir?: string } = {}): string {
+  const configDir = resolveClaudeConfigDir(options.configDir)
+  if (configDir !== null) return join(configDir, CLAUDE_CREDENTIALS_FILE_NAME)
+  return join(options.homeDir ?? homedir(), CLAUDE_CREDENTIALS_RELATIVE_PATH)
+}
+
+function resolveClaudeConfigDir(configDir: string | undefined): string | null {
+  const raw = configDir ?? process.env['CLAUDE_CONFIG_DIR']
+  const trimmed = raw?.trim()
+  return trimmed === undefined || trimmed.length === 0 ? null : trimmed
 }
 
 // Atomic temp-then-rename, mirroring export-codex-auth-file.ts's
@@ -215,6 +248,7 @@ export type ExportClaudeCredentialsFileForAgentOptions = {
   agentDir: string
   claudeCodeEnabled: boolean
   homeDir?: string
+  configDir?: string
   log?: (message: string) => void
 }
 
@@ -239,6 +273,7 @@ export function exportClaudeCredentialsFileForAgent(
     claudeCodeEnabled: options.claudeCodeEnabled,
     providers,
     ...(options.homeDir !== undefined ? { homeDir: options.homeDir } : {}),
+    ...(options.configDir !== undefined ? { configDir: options.configDir } : {}),
     ...(options.log !== undefined ? { log: options.log } : {}),
   })
 }

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -15,7 +15,11 @@ export {
 } from './export-codex-auth-file'
 
 export {
+  CLAUDE_CREDENTIALS_FILE_NAME,
+  CLAUDE_CREDENTIALS_RELATIVE_PATH,
+  CLAUDE_DEFAULT_CONFIG_DIR_NAME,
   type ExportClaudeCredentialsFileResult,
   exportClaudeCredentialsFileForAgent,
   exportClaudeCredentialsFileIfApplicable,
+  resolveClaudeCredentialsPath,
 } from './export-claude-credentials-file'

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -13,3 +13,9 @@ export {
   exportCodexAuthFileForAgent,
   exportCodexAuthFileIfApplicable,
 } from './export-codex-auth-file'
+
+export {
+  type ExportClaudeCredentialsFileResult,
+  exportClaudeCredentialsFileForAgent,
+  exportClaudeCredentialsFileIfApplicable,
+} from './export-claude-credentials-file'

--- a/src/skills/typeclaw-claude-code/SKILL.md
+++ b/src/skills/typeclaw-claude-code/SKILL.md
@@ -36,10 +36,11 @@ If `claude` is installed but no credential is set up, you have to broker the aut
 
 **Decision rule, top to bottom:**
 
-1. **Already authenticated?** Run `env | grep -E '^(ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN)='` — if either is present, skip auth entirely.
-2. **User has an Anthropic Console workspace** (API billing, no subscription) → API key path.
-3. **User has a Claude Pro/Max/Team/Enterprise subscription** → OAuth token path.
-4. **User is unsure** → ask which kind of Claude account they have. Both paths are now equally low-friction (one user action each — paste an API key, or run one command on their machine and paste the result), so the old "prefer API key when unsure" bias is gone. Pick by account shape, not by flow complexity.
+1. **`~/.claude/.credentials.json` already populated?** When typeclaw is configured with an `anthropic` OAuth credential (via `typeclaw provider add anthropic` or the init wizard) AND `docker.file.claudeCode: true`, the agent boot auto-emits the credential to `~/.claude/.credentials.json`. Check with `test -s ~/.claude/.credentials.json && jq -e '.claudeAiOauth.accessToken' ~/.claude/.credentials.json` — if it returns a string, Claude Code reads it on its own with no env var needed. Skip auth entirely.
+2. **Already authenticated via env?** Run `env | grep -E '^(ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN)='` — if either is present, skip auth entirely.
+3. **User has an Anthropic Console workspace** (API billing, no subscription) → API key path.
+4. **User has a Claude Pro/Max/Team/Enterprise subscription** → OAuth token path.
+5. **User is unsure** → ask which kind of Claude account they have. Both paths are now equally low-friction (one user action each — paste an API key, or run one command on their machine and paste the result), so the old "prefer API key when unsure" bias is gone. Pick by account shape, not by flow complexity.
 
 Both paths converge on the same final steps: read `.env`, merge one new `KEY=value` line, write back with the `nonWorkspaceWrite` guard ack, verify, and prompt the user to restart the container. Only the credential differs.
 

--- a/src/skills/typeclaw-claude-code/references/auth-flow.md
+++ b/src/skills/typeclaw-claude-code/references/auth-flow.md
@@ -4,6 +4,41 @@ Deep dive for the auth paths. Read it when `SKILL.md`'s "First-time auth (intera
 
 The two paths are intentionally symmetric: in both, the user produces one string on their side, pastes it to you, you validate it, you do read-modify-write on `.env`, you offer a restart. Only the credential differs.
 
+## Path 0 — auto-export from typeclaw's anthropic OAuth credential
+
+If the user has already configured an `anthropic` OAuth credential in typeclaw (via `typeclaw provider add anthropic` or the init wizard) AND `docker.file.claudeCode: true`, the agent boot in `src/run/index.ts` auto-emits the credential to `~/.claude/.credentials.json` before `claude` ever runs. The destination matches Claude Code's documented Linux/Windows credential path; macOS uses the Keychain entry `"Claude Code-credentials"` with the same JSON shape, which typeclaw does not target (typeclaw runs Claude Code inside a Linux container).
+
+The on-disk shape:
+
+```json
+{
+  "claudeAiOauth": {
+    "accessToken": "sk-ant-oat01-...",
+    "refreshToken": "sk-ant-ort01-...",
+    "expiresAt": 1730000000000,
+    "scopes": ["user:inference", "user:profile", "user:sessions:claude_code", "user:mcp_servers"],
+    "subscriptionType": "max"
+  }
+}
+```
+
+Field names are camelCase and `expiresAt` is **milliseconds** since epoch (not seconds, not ISO).
+
+### Newer-wins on every boot
+
+The exporter compares typeclaw's stored `expires` against the JWT `exp` claim embedded in the on-disk `accessToken`. Strictly fresher wins; ties skip. Claude Code rotates tokens in place by rewriting `.credentials.json` on every successful refresh (anthropics/claude-code#53063), so on a restart the on-disk file may legitimately be ahead of `secrets.json` and must not be clobbered. The persistent-`$HOME` symlink the entrypoint shim installs (`~/.claude/.credentials.json` → `/agent/.typeclaw/home/.claude/.credentials.json`) is what makes the in-place refresh survive `stop`+`start`.
+
+If `.credentials.json` already carries an `mcpOAuth` block (MCP server OAuth state), the exporter preserves it on overwrite. Only the `claudeAiOauth` block is rewritten.
+
+### When Path 0 does NOT fire
+
+- `docker.file.claudeCode: false` — the install layer is off, no point exporting.
+- `secrets.json#providers.anthropic` is absent — nothing to export.
+- The stored credential is api-key shape — Claude Code reads API keys from `ANTHROPIC_API_KEY` env, not from `.credentials.json`. Fall back to Path A.
+- The on-disk JWT `exp` is already fresher — Claude Code refreshed in-place, skip.
+
+In each of those cases the agent boots without touching the file and Path A or Path B applies. The exporter is failure-tolerant: any error (read, write, fs guard) is logged via `console.warn` and the boot continues — Claude Code will then surface the missing credential on first invocation, which is the existing fallback.
+
 ## Path A — API key (recap)
 
 The API key path lives entirely in `SKILL.md` because there's nothing to elaborate. Summary:


### PR DESCRIPTION
## Summary

Adds a runtime auto-export so users who configured `anthropic` as a typeclaw provider with OAuth can run the Claude Code CLI in the container without a second login flow. Mirrors PR #453 (`secrets: auto-export openai-codex OAuth to ~/.codex/auth.json`) for the Anthropic / Claude Code side.

On every `typeclaw start` / `restart`, when `docker.file.claudeCode: true` AND `secrets.json#providers.anthropic` is OAuth-shaped, typeclaw emits `~/.claude/.credentials.json` from its own OAuth credential. The emit shape matches Claude Code's documented Linux/Windows on-disk contract: a single top-level `claudeAiOauth` object with camelCase `accessToken` / `refreshToken` / `expiresAt` (ms epoch, not seconds, not ISO) + optional `scopes` / `subscriptionType`.

Three atomic commits:

- `secrets: add claude credentials.json emit helper` — pure utility (`src/secrets/claude-credentials-json.ts`). Converts an `anthropic` `ProviderCredential` (oauth) to the on-disk shape; exports `decodeClaudeAccessTokenExpiryMs` used by the newer-wins compare. No callers yet.
- `secrets: add anthropic runtime credentials.json exporter` — the exporter module (`src/secrets/export-claude-credentials-file.ts`) with the three-stage guard chain and atomic write. Consumes the helper from commit 1. No callers yet.
- `run: auto-export anthropic credentials.json on agent start` — wires `exportClaudeCredentialsFileForAgent` into `startAgent` after `hydrateChannelEnvFromSecrets`, AND extends `link_persistent_home_files` in the Dockerfile entrypoint shim to symlink `~/.claude/.credentials.json` into the persistent host root. Skill docs (`typeclaw-claude-code`) gain a Path 0 describing the auto-export.

## The guard chain

Three checks, cheapest first. The first two return without touching the filesystem, keeping the 90% case (users who don't enable Claude Code) at zero overhead on every container start.

```
1. !config.docker.file.claudeCode             → skipped: 'claude-code-disabled'
2. !secrets.providers['anthropic']            → skipped: 'no-anthropic-credential'
   cred.type !== 'oauth'                      → skipped: 'credential-not-oauth'
3. on-disk JWT exp >= secrets.json expires    → skipped: 'on-disk-is-fresher'
```

Only after all three pass does the exporter atomically write `~/.claude/.credentials.json`.

## Newer-wins is load-bearing

Claude Code rotates tokens in-place — when it refreshes an OAuth access token, it rewrites `~/.claude/.credentials.json` with a fresher `accessToken`, a rotated `refreshToken`, and an updated `expiresAt`. Confirmed by [anthropics/claude-code#53063](https://github.com/anthropics/claude-code/issues/53063). On a restart the file may legitimately be ahead of `secrets.json`. Clobbering it would break Claude Code's refresh chain.

The compare uses strict `>` (typeclaw's stored expiry must be strictly greater to overwrite). Ties skip. Three outcomes:

| State | Action |
|---|---|
| `~/.claude/.credentials.json` missing / unparseable / no decodable JWT | Overwrite (recovery) |
| On-disk JWT `exp >=` typeclaw's stored `expires` | Skip (Claude Code is fresher or tied) |
| Typeclaw's stored `expires >` on-disk JWT `exp` | Overwrite (user re-pasted OAuth) |

## Writes go through `$HOME/.claude/.credentials.json`

The Dockerfile entrypoint shim (`src/init/dockerfile.ts` → `link_persistent_home_files`) now symlinks `$HOME/.claude/.credentials.json` to `/agent/.typeclaw/home/.claude/.credentials.json` on every boot. Writes follow the symlink and land on the persistent host path. The exporter uses the `$HOME` path because that's the stable contract — the persistent root may move across typeclaw versions.

**The symlink is new in this PR.** PR #453's codex symlink already existed before that PR; this PR adds both the symlink AND the exporter together. Without the symlink, a Claude Code in-place refresh lands on the container's writable overlay and is wiped on the next `stop`+`start` cycle. Both symlinks now share the same `ln -sfn` idempotency contract that the dockerfile snapshot tests pin.

Files written with mode 0600, parent dir 0700, temp-then-rename for atomicity. Mirrors `src/secrets/storage.ts`'s `writeEnvelopeAtomic`.

## Structural difference vs PR #453: read-merge-write

Claude Code's `.credentials.json` may carry a top-level `mcpOAuth` block alongside `claudeAiOauth` (MCP server OAuth state, from `claude mcp …` auth flows). The exporter does **read-merge-write** to preserve it on overwrite — only the `claudeAiOauth` block is rewritten. PR #453's Codex `auth.json` was fully owned by the OAuth credential and had no equivalent; this is the one meaningful divergence from PR #453's pattern.

The merge is shallow: if the existing file is unparseable JSON the recovery path overwrites everything (including dropping `mcpOAuth`), which is unavoidable — an unparseable file has no recoverable state.

## Failure-tolerant by design

Every error path returns a non-fatal `{ action: 'failed', reason }` result and surfaces through an optional log hook (boot wires it to `console.warn`). The agent boot is never blocked. Worst case: `claude` prompts the user for `CLAUDE_CODE_OAUTH_TOKEN` on next invocation, which is the existing fallback documented in the `typeclaw-claude-code` skill.

## Changes

### `src/secrets/claude-credentials-json.ts` (new, 129 lines)

Two exports:

- `emitClaudeCredentialsJson(credential, { preserveMcpOAuth? })` → string. Single-top-level-key shape with trailing newline. Throws on api-key credentials, missing/empty `access`, missing/empty `refresh`. `expiresAt` resolution: credential `expires` → JWT `exp` → 0 fallback.
- `decodeClaudeAccessTokenExpiryMs(accessToken)` → number | null. Returns the JWT `exp` claim in ms. Returns `null` on any decode failure.

### `src/secrets/export-claude-credentials-file.ts` (new, 244 lines)

Two exports:

- `exportClaudeCredentialsFileIfApplicable(options)` — testable core. Caller provides `claudeCodeEnabled`, `providers`, optional `homeDir`, `now`, `log`. Returns a discriminated `ExportClaudeCredentialsFileResult`. Performs the read-merge-write that preserves `mcpOAuth`.
- `exportClaudeCredentialsFileForAgent(options)` — boot-time wrapper. Reads providers from `secrets.json` via `SecretsBackend.tryReadProvidersSync`, catches read errors as `{ action: 'failed' }`, and delegates to the core.

### `src/run/index.ts` (+18 lines)

One call inserted after the existing `exportCodexAuthFileForAgent` block. Reads `cwdConfig.docker.file.claudeCode` and routes the log hook through `console.warn`. Symmetric to the codex call site.

### `src/init/dockerfile.ts` (+6 lines of shim, header comment refactor)

`link_persistent_home_files()` now also runs:

```sh
mkdir -p "$persist_root/.claude" "$HOME/.claude"
ln -sfn "$persist_root/.claude/.credentials.json" "$HOME/.claude/.credentials.json"
```

The helper's header comment is updated to enumerate both linked files (codex `auth.json` + claude `.credentials.json`) with their respective in-place-refresh rationales.

### `src/init/dockerfile.test.ts` (+30 lines)

- Snapshot test pinning the new `mkdir -p "$persist_root/.claude" "$HOME/.claude"` + `ln -sfn` line.
- Snapshot test pinning the `ln -sfn` idempotency contract for the claude symlink (no bare `ln -s`, no `ln -sf`).
- Extension to the executable-behavior "first-boot dangling symlink" test to also assert `~/.claude/.credentials.json` lands as a symlink to the persistent root.
- Extension to the idempotency test to also verify the claude symlink survives a second shim invocation.

### `src/secrets/index.ts` (+6 lines)

Re-exports `exportClaudeCredentialsFileForAgent`, `exportClaudeCredentialsFileIfApplicable`, and `ExportClaudeCredentialsFileResult` from the new module.

### `src/skills/typeclaw-claude-code/SKILL.md` (+5 lines)

Adds a `Path 0` to the "First-time auth" decision rule: when `~/.claude/.credentials.json` already has `claudeAiOauth.accessToken`, skip the interactive flows. The existing `env | grep` check becomes step 2, API key path step 3, OAuth token path step 4.

### `src/skills/typeclaw-claude-code/references/auth-flow.md` (+35 lines)

Adds a `Path 0` section describing the auto-export — what triggers it, the JSON shape it emits, the newer-wins compare semantics with the in-place refresh, and the fall-through cases.

## What this does NOT do

- **No reverse converter.** `~/.claude/.credentials.json` is never read back into `secrets.json`. If a user authenticated only via `claude /login` and wants typeclaw to use those credentials, they still run typeclaw's existing OAuth flow.
- **No wizard changes.** The init flow's auth-method picker is untouched.
- **No new CLI subcommands.**
- **No backend probe.** Schema-only validation. If the stored credential is invalid, the next `claude` invocation surfaces it.
- **No api-key handling.** The exporter rejects api-key-shaped `anthropic` credentials defensively but is pure OAuth in spirit; `ANTHROPIC_API_KEY` continues to flow through `.env` unchanged.
- **No macOS Keychain handling.** macOS Claude Code stores the same JSON in the Keychain entry `"Claude Code-credentials"`, not in `~/.claude/.credentials.json`. typeclaw runs Claude Code inside a Linux container, so the file path is the only target that matters.

## Testing

```
bun test --parallel \
  src/secrets/claude-credentials-json.test.ts \
  src/secrets/export-claude-credentials-file.test.ts \
  src/init/dockerfile.test.ts
# 240 pass, 0 fail
```

Behavioral test cases in `export-claude-credentials-file.test.ts` (one per scenario, same B-style framing as PR #453):

- **B1**: First boot, no `.credentials.json` → writes from `secrets.json` (including `scopes` + `subscriptionType`)
- **B1 (mode)**: Written file has 0600 permissions
- **B2**: Existing file with strictly later JWT `exp` → skip (Claude Code refreshed in-place)
- **B3**: Existing file with older JWT `exp` → overwrite (user re-pasted)
- **Tie**: Same JWT `exp` → skip (steady state at zero churn)
- **mcpOAuth preserved**: Existing file carries `mcpOAuth` block → overwrite of `claudeAiOauth` keeps `mcpOAuth` intact (the structural difference vs PR #453)
- **B4**: `claudeCode: false` → skip without touching the filesystem
- **B5**: No `anthropic` provider → skip
- **B5 (defensive)**: `anthropic` provider exists but is api-key shape → skip
- **B6**: Existing `.credentials.json` is malformed JSON → overwrite (recovery)
- **B6 (variant)**: File present but missing `claudeAiOauth.accessToken` → overwrite
- **B6 (variant)**: File present but JWT undecodable → overwrite
- **B7**: Write failure surfaces as `{ action: 'failed' }`, log hook called, boot continues
- **Fallback (skip)**: Credential without `expires` falls back to JWT `exp` and correctly skips when on-disk is fresher
- **Fallback (write)**: Credential without `expires` AND without decodable JWT falls back to `now()` and writes
- **Symlink preservation**: Writes through the entrypoint-shim symlink to the persistent target, not replacing the link
- **Symlink + newer-wins**: `readFileSync` follows symlinks, so the on-disk compare reads from the persistent file and the newer-wins decision works through the symlink

Full suite:

```
bun run lint         ✓  0 errors (63 pre-existing warnings on unrelated files)
bun run format:check ✓  clean
bun run typecheck    ✓  0 errors
bun run test         ✓  5889 pass / 1 pre-existing flake
```

The one flake is **the same one PR #453 documented**:

- `src/update/index.test.ts > resolveSelfPackageJsonPath > points at this package manifest` — hard-asserts the working directory ends in `typeclaw/package.json`. Fails because the worktree lives at `/tmp/typeclaw-claude-credentials/`. Identical failure on `origin/main` from the same worktree path.

## Review notes

- **The newer-wins compare in `shouldOverwrite`** is the single most failure-prone path, same as in PR #453. Strict `>` (not `>=`) so ties skip — steady state at zero churn. The fall-through for missing/corrupt files returns `true` (overwrite) only because we already passed the "we have a valid OAuth credential to write" check.
- **The `mcpOAuth` preservation is intentionally shallow.** A deeper merge would have to understand the `mcpOAuth` schema (per-server token state), and dropping `mcpOAuth` when the file is unparseable is unavoidable — there's nothing recoverable in `{ not valid json`. Tests assert preservation on a clean overwrite (the realistic case) and explicit loss on the unparseable-recovery case (the only other path that reaches the write).
- **The symlink change is in commit 3 alongside the runtime wire-up.** Existing snapshot tests in `dockerfile.test.ts` continued to pass on the symlink addition (they use `.toContain(...)` substring asserts, so adding a line is non-breaking). 2 new snapshot tests + 2 extended executable-behavior tests pin the new claude symlink contract.
- **The boot-time call is in `startAgent`, not in the entrypoint shim.** The shim already symlinks the file; doing the write in the shim would require duplicating the secrets.json parser in shell. Keeping the write in TypeScript also means failures surface through normal agent logs. Same rationale PR #453 used for the codex side.
- **`SecretsBackend.tryReadProvidersSync()` is reused** — same access pattern PR #453 introduced for the codex exporter; no new lower-level envelope-parser code added.
- **No changes to existing tests.** The 5889-pass count is the same surface area as `origin/main` minus the one known flake.

Sibling PR: #453.
