### PR TITLE
agent: add post-hatching file-routing matrix and SOUL.md edit discipline

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -826,6 +826,38 @@ describe('createResourceLoader', () => {
     expect(prompt).toContain('completion `<system-reminder>`')
     expect(prompt).toContain('Surface the result via `channel_reply`')
   })
+
+  test('full prompt carries the post-hatching file-routing matrix so a tone preference cannot land in AGENTS.md and a process rule cannot land in SOUL.md', async () => {
+    // Without these assertions, a future trim of system-prompt.ts could
+    // quietly drop the routing matrix and the prompt would still
+    // type-check, render, and pass every other test — but the agent
+    // would lose the steady-state guidance for which file owns what.
+    const origin: SessionOrigin = { kind: 'tui', sessionId: 'ses_t' }
+
+    const loader = await createResourceLoader({ agentDir, origin })
+
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).toContain('role, function, scope of work')
+    expect(prompt).toContain('voice, tone, register')
+    expect(prompt).toContain('facts about the user')
+    expect(prompt).toContain('working conventions, repeatable procedures')
+    expect(prompt).toContain('how you sound')
+    expect(prompt).toContain('how you work')
+    expect(prompt).toContain('Edit discipline')
+    expect(prompt).toContain('SOUL.md should stay short')
+    expect(prompt).toContain("a single off-day request isn't a durable change")
+  })
+
+  test('slim prompt does NOT carry the post-hatching routing matrix (cron/subagent budget guard against copy-paste regression)', async () => {
+    const origin: SessionOrigin = { kind: 'cron', jobId: 'job-1', jobKind: 'prompt' }
+
+    const loader = await createResourceLoader({ agentDir, origin })
+
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).not.toContain('role, function, scope of work')
+    expect(prompt).not.toContain('how you sound')
+    expect(prompt).not.toContain('Edit discipline')
+  })
 })
 
 describe('deriveSystemPromptMode', () => {

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -12,7 +12,17 @@ TypeClaw is domain-agnostic — your purpose is defined by \`IDENTITY.md\`, your
 - **AGENTS.md** *(read on demand)* — your operating manual. Read at the start of any non-trivial task and re-read whenever process is unclear.
 - **\`memory/topics/\`** *(always injected below, READ-ONLY)* — sharded long-term memory, owned by the dreaming subagent. To capture something memorable, surface it in your reply or let the memory-logger append to \`memory/streams/\`; never edit memory shards directly.
 
-If a task reveals durable guidance or identity/user context, update the owning file (IDENTITY / SOUL / USER / AGENTS) — never memory shards.
+If a task reveals durable guidance or identity/user context, update the owning file (IDENTITY / SOUL / USER / AGENTS) — never memory shards. **Use this routing when you have something durable to record:**
+
+- *role, function, scope of work, who you are to this user* → IDENTITY.md
+- *voice, tone, register, language preferences, persona quirks* → SOUL.md
+- *facts about the user (name, timezone, projects, preferences they hold across tasks)* → USER.md
+- *working conventions, repeatable procedures, "always do X" rules, things future-you needs to read before acting* → AGENTS.md
+- *one-off context for this conversation only* → don't write a file; it'll be captured in \`memory/streams/\` automatically
+
+When in doubt between SOUL.md and AGENTS.md: if it describes *how you sound*, it's SOUL; if it describes *how you work*, it's AGENTS. Tone preferences ("be more terse") go to SOUL.md; process rules ("always run tests before committing") go to AGENTS.md.
+
+**Edit discipline.** Prefer rewriting in place to growing files. SOUL.md should stay short — a paragraph or two; if it's drifting past a screen, you're using it as a scratchpad and the model that reads it will start ignoring the back half. IDENTITY.md is similar — a few lines of who you are, not a résumé. AGENTS.md is the one allowed to grow. Don't rewrite SOUL.md on the first piece of tone feedback in a session — wait until the user repeats a preference or asks you directly to update it; a single off-day request isn't a durable change.
 
 ## Your workspace
 


### PR DESCRIPTION
## Summary

The hatching interview in src/init/hatching.ts gives the agent an explicit one-time routing table: which markdown file gets which kind of update during first boot. After hatching, the system prompt only named the four files with per-file descriptions and a one-liner — "update the owning file (IDENTITY / SOUL / USER / AGENTS)." That is enough for an attentive model, but not enough to stop an ambiguous call from landing a tone preference in AGENTS.md or a process rule in SOUL.md. There were also no guardrails on SOUL.md size (the loader silently truncates at 12 KiB with a [truncated] marker) and no rule against rewriting SOUL.md on every in-the-moment tone nudge.

This PR extends the `## Your agent folder` block inside DEFAULT_SYSTEM_PROMPT with three additions: a five-row routing matrix naming the owning file for each category of durable note, a SOUL-vs-AGENTS disambiguator for the case that trips models most often ("how you sound" vs "how you work"), and an edit-discipline paragraph that frames SOUL.md size as a correctness concern and holds a single off-day tone nudge back until the preference repeats or is explicitly requested.

The change is confined to DEFAULT_SYSTEM_PROMPT and preserves the cache-suffix ordering contract — all additions go inside the existing `## Your agent folder` block, so the section order that scripts/dump-system-prompt.test.ts pins (identity → runtime → origin+role → git → memory) is unchanged. SLIM_SYSTEM_PROMPT (cron and subagent sessions) is deliberately untouched: those sessions do not author identity files, the slim budget is tight (~681 tokens, well under the 1000-token ceiling), and a new test pins the matrix out of the slim path so a future copy-paste regression fails loudly.

## Changes

### `src/agent/system-prompt.ts` (+12 / -2)

The existing "update the owning file" one-liner is extended in place. Three additions follow it, all inside the `## Your agent folder` block:

**Routing matrix** — five bullet rows naming the owning file for each category:

- *role, function, scope of work, who you are to this user* → IDENTITY.md
- *voice, tone, register, language preferences, persona quirks* → SOUL.md
- *facts about the user (name, timezone, projects, preferences across tasks)* → USER.md
- *working conventions, repeatable procedures, "always do X" rules, things future-you needs to read before acting* → AGENTS.md
- *one-off context for this conversation only* → don't write a file; captured in `memory/streams/` automatically

**SOUL-vs-AGENTS disambiguator** — one prose sentence: "if it describes how you sound, it's SOUL; if it describes how you work, it's AGENTS." Tone preferences go to SOUL.md; process rules go to AGENTS.md.

**Edit discipline paragraph** — SOUL.md should stay short (a paragraph or two); a SOUL.md drifting past a screen is being used as a scratchpad, and the model reading it will start ignoring the back half. IDENTITY.md is similar — a few lines, not a résumé. AGENTS.md is the one allowed to grow. Don't rewrite SOUL.md on the first piece of tone feedback in a session; wait until the preference repeats or is explicitly requested.

### `src/agent/index.test.ts` (+32)

Two new tests added to the existing describe('createResourceLoader') block:

**Full-prompt matrix test** — nine string assertions against the `full` origin kind. Pins each row of the routing matrix, the disambiguator sentence, the Edit discipline heading, the SOUL size hint, and the thrash guardrail. Ensures the guidance reaches TUI and channel sessions.

**Slim-prompt exclusion test** — three negative assertions against the `cron` origin kind confirming that the routing matrix, the disambiguator, and the Edit discipline heading are absent from SLIM_SYSTEM_PROMPT. Ensures a future copy-paste of the matrix into the slim path fails loudly.

## What this does NOT do

- **No changes to SLIM_SYSTEM_PROMPT.** Cron and subagent sessions are unchanged.
- **No changes to the hatching prompt** in src/init/hatching.ts. The first-boot interview routing table is unmodified.
- **No changes to `src/agent/self.ts`.** The 12 KiB truncation limit and MAX_FILE_BYTES are unchanged; no new size enforcement at the file-read layer.
- **No changes to the [truncated] behavior.** The edit-discipline guidance is purely advisory in the system prompt; no runtime enforcement is added.
- **No changes to memory shard ownership rules.** The memory/topics/ read-only contract and memory/streams/ append path are untouched.

## Verification

```
bun run typecheck         ✓ tsgo --noEmit, 0 errors
bun run lint              ✓ 0 errors, 63 pre-existing warnings on unrelated files (slack-bot.test.ts etc.)
bun run format            ✓ oxfmt --write . clean, no changes
bun test --parallel src/agent/index.test.ts src/agent/self.test.ts scripts/dump-system-prompt.test.ts
                          ✓ 126 pass / 0 fail / 433 expect() calls
bun run test              ✓ 5855 pass / 1 pre-existing flake
```

The one pre-existing failure is the resolveSelfPackageJsonPath test in src/update/index.test.ts. It hard-asserts the resolved path ends with `typeclaw/package.json`, which fails in any worktree not named typeclaw. Reproduces identically on origin/main with this PR's changes reverted. Documented in PR #457 and #458. Unrelated to this change.

## Review notes

- **Cache-suffix contract preservation.** All additions are inside the existing `## Your agent folder` block — no section reordering, no new top-level sections. The pinned section order in scripts/dump-system-prompt.test.ts (identity → runtime → origin+role → git → memory) is undisturbed.
- **Slim-budget guard.** The negative assertions enforce the 800-token slim-vs-full delta guard at scripts/dump-system-prompt.test.ts:196. The full TUI base prompt grows from ~3,447 to ~3,623 tokens (+176 tokens). The slim cron total stays at 681 tokens, well under the 1000-token ceiling. The delta remains well above the 800-token guard.
- **SOUL-vs-AGENTS disambiguator wording.** "How you sound" vs "how you work" is intentionally short — a fast, memorable heuristic rather than an exhaustive classification rubric.
- **Thrash guardrail permissiveness.** "Wait until the user repeats a preference or asks you directly to update it" is intentionally permissive: an explicit request to update SOUL.md goes through immediately. Only single off-day nudges are held back. The guardrail targets churn, not responsiveness.
- **+176 token cost.** The guidance adds 176 tokens to the full prompt. Acceptable: the misrouting it prevents is far more expensive to undo than the per-session token cost of preventing it.