### PR TITLE
doctor: add host-stage channel adapter health checks

### DIFF
--- a/src/doctor/channel-checks.test.ts
+++ b/src/doctor/channel-checks.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { SecretsBackend } from '@/secrets'
+
+import { buildChannelChecks } from './channel-checks'
+import type { CheckContext, CheckResult, DoctorCheck } from './types'
+
+const TOKEN_ENV_VARS = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'DISCORD_BOT_TOKEN', 'TELEGRAM_BOT_TOKEN'] as const
+
+function makeTmpAgentDir(channels: Record<string, unknown> = {}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'typeclaw-doctor-channels-'))
+  writeFileSync(join(dir, 'typeclaw.json'), JSON.stringify({ channels }), 'utf8')
+  return dir
+}
+
+function writeDotEnv(dir: string, entries: Record<string, string>): void {
+  const body = Object.entries(entries)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n')
+  writeFileSync(join(dir, '.env'), body, 'utf8')
+}
+
+function writeChannelsSecrets(dir: string, channels: Record<string, unknown>): void {
+  new SecretsBackend(join(dir, 'secrets.json')).writeChannelsSync(channels)
+}
+
+function getCheck(name: string): DoctorCheck {
+  const check = buildChannelChecks().find((c) => c.name === name)
+  if (!check) throw new Error(`check not found: ${name}`)
+  return check
+}
+
+async function runCheck(name: string, ctx: CheckContext): Promise<CheckResult> {
+  const check = getCheck(name)
+  if (check.applies && !check.applies(ctx)) return { status: 'skipped', message: 'not applicable' }
+  return check.run(ctx)
+}
+
+function ctxFor(cwd: string): CheckContext {
+  return { cwd, hasAgentFolder: true }
+}
+
+describe('buildChannelChecks', () => {
+  const savedEnv = new Map<string, string | undefined>()
+
+  beforeEach(() => {
+    for (const k of TOKEN_ENV_VARS) {
+      savedEnv.set(k, process.env[k])
+      delete process.env[k]
+    }
+  })
+
+  afterEach(() => {
+    for (const k of TOKEN_ENV_VARS) {
+      const prev = savedEnv.get(k)
+      if (prev === undefined) delete process.env[k]
+      else process.env[k] = prev
+    }
+    savedEnv.clear()
+  })
+
+  test('returns one check per known adapter plus github webhook delivery', () => {
+    const names = buildChannelChecks().map((c) => c.name)
+    expect(names).toEqual([
+      'channel.slack-bot.credentials',
+      'channel.discord-bot.credentials',
+      'channel.telegram-bot.credentials',
+      'channel.kakaotalk.credentials',
+      'channel.github.credentials',
+      'channel.github.webhook-delivery',
+    ])
+  })
+
+  test('every check is gated on hasAgentFolder', () => {
+    const checks = buildChannelChecks()
+    for (const check of checks) {
+      expect(check.applies).toBeDefined()
+      expect(check.applies?.({ cwd: '/nope', hasAgentFolder: false })).toBe(false)
+    }
+  })
+
+  describe('token-based adapters', () => {
+    test('skips when adapter is not declared in typeclaw.json', async () => {
+      const cwd = makeTmpAgentDir({})
+      const result = await runCheck('channel.slack-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('skipped')
+    })
+
+    test('skips when adapter is declared but disabled', async () => {
+      const cwd = makeTmpAgentDir({ 'slack-bot': { enabled: false } })
+      const result = await runCheck('channel.slack-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('skipped')
+    })
+
+    test('slack-bot warns when both tokens are missing', async () => {
+      const cwd = makeTmpAgentDir({ 'slack-bot': {} })
+      const result = await runCheck('channel.slack-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('warning')
+      expect(result.message).toContain('SLACK_BOT_TOKEN')
+      expect(result.message).toContain('SLACK_APP_TOKEN')
+      expect(result.fix?.description).toContain('slack-bot')
+    })
+
+    test('slack-bot warns when only one token is present', async () => {
+      const cwd = makeTmpAgentDir({ 'slack-bot': {} })
+      writeDotEnv(cwd, { SLACK_BOT_TOKEN: 'xoxb-1' })
+      const result = await runCheck('channel.slack-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('warning')
+      expect(result.message).toContain('SLACK_APP_TOKEN')
+      expect(result.message).not.toContain('SLACK_BOT_TOKEN')
+    })
+
+    test('slack-bot passes when both tokens come from .env', async () => {
+      const cwd = makeTmpAgentDir({ 'slack-bot': {} })
+      writeDotEnv(cwd, { SLACK_BOT_TOKEN: 'xoxb-1', SLACK_APP_TOKEN: 'xapp-1' })
+      const result = await runCheck('channel.slack-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+    })
+
+    test('slack-bot passes when both tokens come from process.env (override path)', async () => {
+      const cwd = makeTmpAgentDir({ 'slack-bot': {} })
+      process.env.SLACK_BOT_TOKEN = 'xoxb-shell'
+      process.env.SLACK_APP_TOKEN = 'xapp-shell'
+      const result = await runCheck('channel.slack-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+    })
+
+    test('slack-bot passes when tokens live in secrets.json fields', async () => {
+      const cwd = makeTmpAgentDir({ 'slack-bot': {} })
+      writeChannelsSecrets(cwd, {
+        'slack-bot': {
+          botToken: { value: 'xoxb-from-secrets' },
+          appToken: { value: 'xapp-from-secrets' },
+        },
+      })
+      const result = await runCheck('channel.slack-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+    })
+
+    test('discord-bot warns when DISCORD_BOT_TOKEN is missing', async () => {
+      const cwd = makeTmpAgentDir({ 'discord-bot': {} })
+      const result = await runCheck('channel.discord-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('warning')
+      expect(result.message).toContain('DISCORD_BOT_TOKEN')
+    })
+
+    test('discord-bot passes when token lives in secrets.json', async () => {
+      const cwd = makeTmpAgentDir({ 'discord-bot': {} })
+      writeChannelsSecrets(cwd, { 'discord-bot': { token: { value: 'd-tok' } } })
+      const result = await runCheck('channel.discord-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+    })
+
+    test('telegram-bot warns when TELEGRAM_BOT_TOKEN is missing', async () => {
+      const cwd = makeTmpAgentDir({ 'telegram-bot': {} })
+      const result = await runCheck('channel.telegram-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('warning')
+      expect(result.message).toContain('TELEGRAM_BOT_TOKEN')
+    })
+
+    test('process.env wins over empty .env entry', async () => {
+      const cwd = makeTmpAgentDir({ 'discord-bot': {} })
+      writeDotEnv(cwd, { DISCORD_BOT_TOKEN: '' })
+      process.env.DISCORD_BOT_TOKEN = 'real-token'
+      const result = await runCheck('channel.discord-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+    })
+
+    test('empty string in .env counts as missing', async () => {
+      const cwd = makeTmpAgentDir({ 'discord-bot': {} })
+      writeDotEnv(cwd, { DISCORD_BOT_TOKEN: '' })
+      const result = await runCheck('channel.discord-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('warning')
+    })
+  })
+
+  describe('kakaotalk', () => {
+    test('skips when not configured', async () => {
+      const cwd = makeTmpAgentDir({})
+      const result = await runCheck('channel.kakaotalk.credentials', ctxFor(cwd))
+      expect(result.status).toBe('skipped')
+    })
+
+    test('warns when configured but secrets.json has no accounts', async () => {
+      const cwd = makeTmpAgentDir({ kakaotalk: {} })
+      const result = await runCheck('channel.kakaotalk.credentials', ctxFor(cwd))
+      expect(result.status).toBe('warning')
+      expect(result.message).toMatch(/no accounts/)
+      expect(result.fix?.description).toContain('channel add kakaotalk')
+    })
+
+    test('passes when at least one account exists', async () => {
+      const cwd = makeTmpAgentDir({ kakaotalk: {} })
+      writeChannelsSecrets(cwd, {
+        kakaotalk: {
+          currentAccount: 'a',
+          accounts: {
+            a: {
+              account_id: 'a',
+              oauth_token: 't',
+              user_id: 'u',
+              device_uuid: 'd',
+              device_type: 'pc',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z',
+            },
+          },
+        },
+      })
+      const result = await runCheck('channel.kakaotalk.credentials', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('1 account')
+    })
+  })
+
+  describe('github credentials', () => {
+    test('skips when not configured', async () => {
+      const cwd = makeTmpAgentDir({})
+      const result = await runCheck('channel.github.credentials', ctxFor(cwd))
+      expect(result.status).toBe('skipped')
+    })
+
+    test('errors when github is configured but no secrets block exists', async () => {
+      const cwd = makeTmpAgentDir({ github: { webhookUrl: 'https://example.com/hook' } })
+      const result = await runCheck('channel.github.credentials', ctxFor(cwd))
+      expect(result.status).toBe('error')
+      expect(result.message).toMatch(/missing/)
+    })
+
+    test('passes with PAT auth and webhookSecret', async () => {
+      const cwd = makeTmpAgentDir({ github: { webhookUrl: 'https://example.com/hook' } })
+      writeChannelsSecrets(cwd, {
+        github: {
+          auth: { type: 'pat', token: { value: 'ghp_xxx' } },
+          webhookSecret: { value: 'wh-secret' },
+        },
+      })
+      const result = await runCheck('channel.github.credentials', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('PAT')
+    })
+
+    test('errors when PAT token resolves empty (env binding to unset var)', async () => {
+      const cwd = makeTmpAgentDir({ github: { webhookUrl: 'https://example.com/hook' } })
+      writeChannelsSecrets(cwd, {
+        github: {
+          auth: { type: 'pat', token: { env: 'NEVER_SET_GH_TOKEN' } },
+          webhookSecret: { value: 'wh-secret' },
+        },
+      })
+      delete process.env.NEVER_SET_GH_TOKEN
+      const result = await runCheck('channel.github.credentials', ctxFor(cwd))
+      expect(result.status).toBe('error')
+      expect(result.details?.some((d) => d.includes('auth.token'))).toBe(true)
+    })
+
+    test('passes with App auth', async () => {
+      const cwd = makeTmpAgentDir({ github: { webhookUrl: 'https://example.com/hook' } })
+      writeChannelsSecrets(cwd, {
+        github: {
+          auth: { type: 'app', appId: 123, privateKey: { value: '-----BEGIN-----' } },
+          webhookSecret: { value: 'wh-secret' },
+        },
+      })
+      const result = await runCheck('channel.github.credentials', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('App')
+    })
+  })
+
+  describe('github webhook delivery', () => {
+    test('skips when github not configured', async () => {
+      const cwd = makeTmpAgentDir({})
+      const result = await runCheck('channel.github.webhook-delivery', ctxFor(cwd))
+      expect(result.status).toBe('skipped')
+    })
+
+    test('ok when webhookUrl is set', async () => {
+      const cwd = makeTmpAgentDir({ github: { webhookUrl: 'https://example.com/hook' } })
+      const result = await runCheck('channel.github.webhook-delivery', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('webhookUrl')
+    })
+
+    test('ok when a tunnel binding exists', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'typeclaw-doctor-channels-'))
+      writeFileSync(
+        join(cwd, 'typeclaw.json'),
+        JSON.stringify({
+          channels: { github: { repos: ['org/repo'] } },
+          tunnels: [
+            {
+              name: 'gh',
+              provider: 'cloudflare-quick',
+              for: { kind: 'channel', name: 'github' },
+              upstreamPort: 8975,
+            },
+          ],
+        }),
+        'utf8',
+      )
+      const result = await runCheck('channel.github.webhook-delivery', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('tunnel')
+    })
+
+    test('warning when repos are listed but no URL or tunnel', async () => {
+      const cwd = makeTmpAgentDir({ github: { repos: ['org/repo'] } })
+      const result = await runCheck('channel.github.webhook-delivery', ctxFor(cwd))
+      expect(result.status).toBe('warning')
+      expect(result.message).toContain('no public URL')
+    })
+
+    test('info when no repos and no URL (not yet wired)', async () => {
+      const cwd = makeTmpAgentDir({ github: {} })
+      const result = await runCheck('channel.github.webhook-delivery', ctxFor(cwd))
+      expect(result.status).toBe('info')
+    })
+  })
+})

--- a/src/doctor/channel-checks.test.ts
+++ b/src/doctor/channel-checks.test.ts
@@ -175,6 +175,21 @@ describe('buildChannelChecks', () => {
       const result = await runCheck('channel.discord-bot.credentials', ctxFor(cwd))
       expect(result.status).toBe('warning')
     })
+
+    test('discord-bot passes when secrets.json custom env binding resolves via .env', async () => {
+      const cwd = makeTmpAgentDir({ 'discord-bot': {} })
+      writeChannelsSecrets(cwd, { 'discord-bot': { token: { env: 'MY_DISCORD_TOKEN' } } })
+      writeDotEnv(cwd, { MY_DISCORD_TOKEN: 'd-tok-from-dotenv' })
+      const result = await runCheck('channel.discord-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+    })
+
+    test('discord-bot warns when custom env binding has no value anywhere', async () => {
+      const cwd = makeTmpAgentDir({ 'discord-bot': {} })
+      writeChannelsSecrets(cwd, { 'discord-bot': { token: { env: 'MY_DISCORD_TOKEN' } } })
+      const result = await runCheck('channel.discord-bot.credentials', ctxFor(cwd))
+      expect(result.status).toBe('warning')
+    })
   })
 
   describe('kakaotalk', () => {
@@ -241,6 +256,19 @@ describe('buildChannelChecks', () => {
       const result = await runCheck('channel.github.credentials', ctxFor(cwd))
       expect(result.status).toBe('ok')
       expect(result.message).toContain('PAT')
+    })
+
+    test('passes when PAT token env binding resolves via .env', async () => {
+      const cwd = makeTmpAgentDir({ github: { webhookUrl: 'https://example.com/hook' } })
+      writeChannelsSecrets(cwd, {
+        github: {
+          auth: { type: 'pat', token: { env: 'MY_GH_TOKEN' } },
+          webhookSecret: { value: 'wh-secret' },
+        },
+      })
+      writeDotEnv(cwd, { MY_GH_TOKEN: 'ghp_from_dotenv' })
+      const result = await runCheck('channel.github.credentials', ctxFor(cwd))
+      expect(result.status).toBe('ok')
     })
 
     test('errors when PAT token resolves empty (env binding to unset var)', async () => {

--- a/src/doctor/channel-checks.ts
+++ b/src/doctor/channel-checks.ts
@@ -212,7 +212,7 @@ async function runTokenAdapterCheck(
         'Adapter will be skipped at start until credentials are present.',
         'Resolution order: process.env wins over .env file value over secrets.json value.',
       ],
-      fix: { description: `Run \`typeclaw channel set ${adapter}\` or add the env vars to .env.` },
+      fix: { description: 'Run `typeclaw channel set ' + adapter + '`, or add the env vars to .env.' },
     }
   }
   return { status: 'ok', message: `${adapter} credentials present` }

--- a/src/doctor/channel-checks.ts
+++ b/src/doctor/channel-checks.ts
@@ -5,7 +5,6 @@ import { loadConfigSync, validateConfig } from '@/config'
 import { readEnvFile } from '@/init'
 import { SecretsBackend } from '@/secrets'
 import { channelFieldDefaultEnv } from '@/secrets/defaults'
-import { resolveSecret } from '@/secrets/resolve'
 
 import type { CheckContext, CheckResult, DoctorCheck } from './types'
 
@@ -113,18 +112,19 @@ function githubCredentials(): DoctorCheck {
           fix: { description: 'Run `typeclaw channel set github` to configure GitHub auth.' },
         }
       }
+      const dotEnv = safeReadEnvFile(ctx.cwd)
       const details: string[] = []
-      const webhookSecret = resolveSecret(block.webhookSecret, undefined, process.env)
+      const webhookSecret = resolveSecretHostStage(block.webhookSecret, dotEnv)
       if (webhookSecret === undefined || webhookSecret === '') {
         details.push('webhookSecret is unset (resolves to empty string)')
       }
       if (block.auth.type === 'pat') {
-        const token = resolveSecret(block.auth.token, undefined, process.env)
+        const token = resolveSecretHostStage(block.auth.token, dotEnv)
         if (token === undefined || token === '') {
           details.push('auth.token (PAT) is unset (resolves to empty string)')
         }
       } else {
-        const key = resolveSecret(block.auth.privateKey, undefined, process.env)
+        const key = resolveSecretHostStage(block.auth.privateKey, dotEnv)
         if (key === undefined || key === '') {
           details.push('auth.privateKey (App) is unset (resolves to empty string)')
         }
@@ -219,10 +219,8 @@ async function runTokenAdapterCheck(
 }
 
 // hasTokenForEnv resolves a single env-var-style credential the same way the
-// runtime does: process.env > .env file > secrets.json (resolved via
-// resolveSecret so an `env`-bound Secret consults the right var). Empty
-// strings are treated as unset, matching `effective` checks in
-// `src/secrets/resolve.ts` and the env-wins policy.
+// runtime does, plus one host-stage-specific source: process.env > .env file >
+// secrets.json. Empty strings count as unset, matching `src/secrets/resolve.ts`.
 function hasTokenForEnv(
   adapter: AdapterId,
   envName: string,
@@ -237,8 +235,30 @@ function hasTokenForEnv(
   if (fieldName === undefined) return false
   const secret = adapterSecrets[fieldName]
   if (!isSecretShape(secret)) return false
-  const resolved = resolveSecret(secret, envName, process.env)
+  const resolved = resolveSecretHostStage(secret, dotEnv, envName)
   return resolved !== undefined && resolved !== ''
+}
+
+// resolveSecretHostStage mirrors `resolveSecret` precedence but adds a .env
+// lookup before falling through to process.env. Doctor runs on the host and
+// never executes the container, so .env values are not in process.env. For
+// Secrets bound to a custom env var (e.g. `{ env: 'MY_TOKEN' }`), the runtime
+// would resolve via process.env.MY_TOKEN inside the container — on the host
+// that yields undefined even when the value is sitting in .env. So look up
+// the custom env name in the parsed .env map first.
+function resolveSecretHostStage(
+  secret: { value?: string; env?: string },
+  dotEnv: Map<string, string>,
+  defaultEnv?: string,
+): string | undefined {
+  const envName = secret.env ?? defaultEnv
+  if (envName !== undefined) {
+    const fromProcess = process.env[envName]
+    if (fromProcess !== undefined && fromProcess !== '') return fromProcess
+    const fromDotEnv = dotEnv.get(envName)
+    if (fromDotEnv !== undefined && fromDotEnv !== '') return fromDotEnv
+  }
+  return secret.value
 }
 
 function fieldNameForEnv(adapter: AdapterId, envName: string): string | undefined {

--- a/src/doctor/channel-checks.ts
+++ b/src/doctor/channel-checks.ts
@@ -1,0 +1,308 @@
+import { join } from 'node:path'
+
+import { type AdapterId, type ChannelsConfig } from '@/channels'
+import { loadConfigSync, validateConfig } from '@/config'
+import { readEnvFile } from '@/init'
+import { SecretsBackend } from '@/secrets'
+import { channelFieldDefaultEnv } from '@/secrets/defaults'
+import { resolveSecret } from '@/secrets/resolve'
+
+import type { CheckContext, CheckResult, DoctorCheck } from './types'
+
+// Host-stage channel adapter health checks. These cannot talk to Slack /
+// Discord / Telegram / KakaoTalk / GitHub APIs — that work belongs to the
+// container-stage `start()` preflight on each adapter (see
+// `src/channels/manager.ts` and individual adapters). What doctor CAN do
+// from the host is verify that the credentials the container will look for
+// are actually present and resolvable, so the operator gets a clear,
+// before-`typeclaw start` signal instead of a silent skip in the runtime
+// logs.
+//
+// Every check is gated on `ctx.hasAgentFolder` (typeclaw.json is required to
+// read the channels config) and additionally on the adapter being declared
+// AND enabled in typeclaw.json. A missing or `enabled: false` adapter
+// reports `skipped` so the operator can see the check ran without it
+// turning into noise on minimal setups.
+
+export function buildChannelChecks(): DoctorCheck[] {
+  return [
+    slackBotCredentials(),
+    discordBotCredentials(),
+    telegramBotCredentials(),
+    kakaotalkCredentials(),
+    githubCredentials(),
+    githubWebhookDelivery(),
+  ]
+}
+
+function slackBotCredentials(): DoctorCheck {
+  return {
+    name: 'channel.slack-bot.credentials',
+    category: 'channels',
+    description: 'slack-bot adapter has SLACK_BOT_TOKEN and SLACK_APP_TOKEN',
+    applies: (ctx) => ctx.hasAgentFolder,
+    run: (ctx) => runTokenAdapterCheck(ctx, 'slack-bot', ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN']),
+  }
+}
+
+function discordBotCredentials(): DoctorCheck {
+  return {
+    name: 'channel.discord-bot.credentials',
+    category: 'channels',
+    description: 'discord-bot adapter has DISCORD_BOT_TOKEN',
+    applies: (ctx) => ctx.hasAgentFolder,
+    run: (ctx) => runTokenAdapterCheck(ctx, 'discord-bot', ['DISCORD_BOT_TOKEN']),
+  }
+}
+
+function telegramBotCredentials(): DoctorCheck {
+  return {
+    name: 'channel.telegram-bot.credentials',
+    category: 'channels',
+    description: 'telegram-bot adapter has TELEGRAM_BOT_TOKEN',
+    applies: (ctx) => ctx.hasAgentFolder,
+    run: (ctx) => runTokenAdapterCheck(ctx, 'telegram-bot', ['TELEGRAM_BOT_TOKEN']),
+  }
+}
+
+function kakaotalkCredentials(): DoctorCheck {
+  return {
+    name: 'channel.kakaotalk.credentials',
+    category: 'channels',
+    description: 'kakaotalk adapter has at least one account in secrets.json',
+    applies: (ctx) => ctx.hasAgentFolder,
+    async run(ctx) {
+      const channels = readDeclaredChannels(ctx)
+      if (channels === null) return configInvalidResult()
+      if (!isAdapterActive(channels, 'kakaotalk')) {
+        return { status: 'skipped', message: 'kakaotalk not configured' }
+      }
+      const block = readChannelsSecrets(ctx)?.kakaotalk
+      const accountCount = block?.accounts ? Object.keys(block.accounts).length : 0
+      if (accountCount === 0) {
+        return {
+          status: 'warning',
+          message: 'kakaotalk has no accounts in secrets.json',
+          details: ['Adapter will start but fail authentication and stay disconnected.'],
+          fix: { description: 'Run `typeclaw channel add kakaotalk` to log in an account.' },
+        }
+      }
+      return { status: 'ok', message: `kakaotalk has ${accountCount} account(s)` }
+    },
+  }
+}
+
+function githubCredentials(): DoctorCheck {
+  return {
+    name: 'channel.github.credentials',
+    category: 'channels',
+    description: 'github adapter has auth and webhookSecret in secrets.json',
+    applies: (ctx) => ctx.hasAgentFolder,
+    async run(ctx) {
+      const channels = readDeclaredChannels(ctx)
+      if (channels === null) return configInvalidResult()
+      if (!isAdapterActive(channels, 'github')) {
+        return { status: 'skipped', message: 'github not configured' }
+      }
+      const block = readChannelsSecrets(ctx)?.github
+      if (!block) {
+        return {
+          status: 'error',
+          message: 'github secrets missing from secrets.json',
+          details: ['Adapter requires both `auth` and `webhookSecret`.'],
+          fix: { description: 'Run `typeclaw channel set github` to configure GitHub auth.' },
+        }
+      }
+      const details: string[] = []
+      const webhookSecret = resolveSecret(block.webhookSecret, undefined, process.env)
+      if (webhookSecret === undefined || webhookSecret === '') {
+        details.push('webhookSecret is unset (resolves to empty string)')
+      }
+      if (block.auth.type === 'pat') {
+        const token = resolveSecret(block.auth.token, undefined, process.env)
+        if (token === undefined || token === '') {
+          details.push('auth.token (PAT) is unset (resolves to empty string)')
+        }
+      } else {
+        const key = resolveSecret(block.auth.privateKey, undefined, process.env)
+        if (key === undefined || key === '') {
+          details.push('auth.privateKey (App) is unset (resolves to empty string)')
+        }
+      }
+      if (details.length > 0) {
+        return {
+          status: 'error',
+          message: 'github credentials present but some fields resolve to empty',
+          details,
+          fix: { description: 'Run `typeclaw channel set github` to repopulate the missing fields.' },
+        }
+      }
+      return {
+        status: 'ok',
+        message: `github ${block.auth.type === 'pat' ? 'PAT' : 'App'} auth + webhookSecret resolved`,
+      }
+    },
+  }
+}
+
+function githubWebhookDelivery(): DoctorCheck {
+  return {
+    name: 'channel.github.webhook-delivery',
+    category: 'channels',
+    description: 'github webhook delivery has a public URL (webhookUrl or tunnel)',
+    applies: (ctx) => ctx.hasAgentFolder,
+    async run(ctx) {
+      const cfg = safeLoadConfig(ctx)
+      if (cfg === null) return configInvalidResult()
+      const github = cfg.channels.github
+      if (github === undefined || github.enabled === false) {
+        return { status: 'skipped', message: 'github not configured' }
+      }
+      const hasWebhookUrl = typeof github.webhookUrl === 'string' && github.webhookUrl.length > 0
+      const hasTunnel = cfg.tunnels.some((t) => t.for.kind === 'channel' && t.for.name === 'github')
+      if (hasWebhookUrl || hasTunnel) {
+        const source = hasWebhookUrl ? 'webhookUrl' : 'tunnel'
+        return { status: 'ok', message: `github webhook delivery configured via ${source}` }
+      }
+      if (github.repos.length === 0) {
+        return {
+          status: 'info',
+          message: 'github has no webhookUrl or tunnel, and no repos to register',
+          details: ['Webhooks will not be auto-registered until either webhookUrl or a tunnel binding is set.'],
+        }
+      }
+      return {
+        status: 'warning',
+        message: `github lists ${github.repos.length} repo(s) but has no public URL to deliver webhooks to`,
+        details: [
+          'Either set `channels.github.webhookUrl` in typeclaw.json,',
+          'or add a `tunnels[]` entry with `for: { kind: "channel", name: "github" }`.',
+        ],
+        fix: {
+          description: 'Configure webhookUrl or a github tunnel; see `typeclaw tunnel add` for managed tunnels.',
+        },
+      }
+    },
+  }
+}
+
+async function runTokenAdapterCheck(
+  ctx: CheckContext,
+  adapter: Extract<AdapterId, 'slack-bot' | 'discord-bot' | 'telegram-bot'>,
+  envNames: readonly string[],
+): Promise<CheckResult> {
+  const channels = readDeclaredChannels(ctx)
+  if (channels === null) return configInvalidResult()
+  if (!isAdapterActive(channels, adapter)) {
+    return { status: 'skipped', message: `${adapter} not configured` }
+  }
+  const dotEnv = safeReadEnvFile(ctx.cwd)
+  const channelSecrets = readChannelsSecrets(ctx)
+  const adapterSecrets = (channelSecrets?.[adapter] ?? {}) as Record<string, unknown>
+  const missing: string[] = []
+  for (const envName of envNames) {
+    if (hasTokenForEnv(adapter, envName, dotEnv, adapterSecrets)) continue
+    missing.push(envName)
+  }
+  if (missing.length > 0) {
+    return {
+      status: 'warning',
+      message: `${adapter} missing credentials: ${missing.join(', ')}`,
+      details: [
+        'Adapter will be skipped at start until credentials are present.',
+        'Resolution order: process.env wins over .env file value over secrets.json value.',
+      ],
+      fix: { description: `Run \`typeclaw channel set ${adapter}\` or add the env vars to .env.` },
+    }
+  }
+  return { status: 'ok', message: `${adapter} credentials present` }
+}
+
+// hasTokenForEnv resolves a single env-var-style credential the same way the
+// runtime does: process.env > .env file > secrets.json (resolved via
+// resolveSecret so an `env`-bound Secret consults the right var). Empty
+// strings are treated as unset, matching `effective` checks in
+// `src/secrets/resolve.ts` and the env-wins policy.
+function hasTokenForEnv(
+  adapter: AdapterId,
+  envName: string,
+  dotEnv: Map<string, string>,
+  adapterSecrets: Record<string, unknown>,
+): boolean {
+  const fromProcess = process.env[envName]
+  if (fromProcess !== undefined && fromProcess !== '') return true
+  const fromDotEnv = dotEnv.get(envName)
+  if (fromDotEnv !== undefined && fromDotEnv !== '') return true
+  const fieldName = fieldNameForEnv(adapter, envName)
+  if (fieldName === undefined) return false
+  const secret = adapterSecrets[fieldName]
+  if (!isSecretShape(secret)) return false
+  const resolved = resolveSecret(secret, envName, process.env)
+  return resolved !== undefined && resolved !== ''
+}
+
+function fieldNameForEnv(adapter: AdapterId, envName: string): string | undefined {
+  // Reverse-lookup using channelFieldDefaultEnv: scan the small set of known
+  // fields per adapter for the one whose default env matches. The set is
+  // tiny (1-2 entries) so the linear scan is fine.
+  const candidates: Record<string, readonly string[]> = {
+    'slack-bot': ['botToken', 'appToken'],
+    'discord-bot': ['token'],
+    'telegram-bot': ['token'],
+  }
+  const fields = candidates[adapter]
+  if (!fields) return undefined
+  for (const field of fields) {
+    if (channelFieldDefaultEnv(adapter, field) === envName) return field
+  }
+  return undefined
+}
+
+function isSecretShape(value: unknown): value is { value?: string; env?: string } {
+  if (typeof value !== 'object' || value === null) return false
+  const obj = value as Record<string, unknown>
+  const hasValue = typeof obj['value'] === 'string'
+  const hasEnv = typeof obj['env'] === 'string'
+  return hasValue || hasEnv
+}
+
+function readDeclaredChannels(ctx: CheckContext): ChannelsConfig | null {
+  const cfg = safeLoadConfig(ctx)
+  return cfg?.channels ?? null
+}
+
+function safeLoadConfig(ctx: CheckContext): ReturnType<typeof loadConfigSync> | null {
+  const result = validateConfig(ctx.cwd)
+  if (!result.ok) return null
+  try {
+    return loadConfigSync(ctx.cwd)
+  } catch {
+    return null
+  }
+}
+
+function safeReadEnvFile(cwd: string): Map<string, string> {
+  try {
+    return readEnvFile(cwd)
+  } catch {
+    return new Map()
+  }
+}
+
+function readChannelsSecrets(ctx: CheckContext): ReturnType<SecretsBackend['tryReadChannelsSync']> {
+  try {
+    return new SecretsBackend(join(ctx.cwd, 'secrets.json')).tryReadChannelsSync()
+  } catch {
+    return null
+  }
+}
+
+function isAdapterActive(channels: ChannelsConfig, adapter: AdapterId): boolean {
+  const slot = channels[adapter]
+  if (slot === undefined) return false
+  return slot.enabled !== false
+}
+
+function configInvalidResult(): CheckResult {
+  return { status: 'skipped', message: 'config invalid (covered by config.valid)' }
+}

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -21,6 +21,7 @@ import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { detectMissingDeps } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 
+import { buildChannelChecks } from './channel-checks'
 import type { DoctorCheck } from './types'
 
 export function buildStaticChecks(opts: { dockerExec?: DockerExec } = {}): DoctorCheck[] {
@@ -40,6 +41,7 @@ export function buildStaticChecks(opts: { dockerExec?: DockerExec } = {}): Docto
     hostdRegistration(),
     containerState(dockerExec),
     containerHostPort(),
+    ...buildChannelChecks(),
   ]
 }
 


### PR DESCRIPTION
## Summary

`typeclaw doctor` has 13 static checks covering docker, agent folder, hostd, container, and runtime — but zero for channels. Meanwhile, the channel manager (`src/channels/manager.ts`) silently skips adapters at start when credentials are missing. A user wires Slack into `typeclaw.json`, forgets one env var, `typeclaw start` runs, the bot never replies. The only signal lives in container logs.

This PR adds six static `DoctorCheck`s under a new `channels` category so misconfiguration surfaces on `typeclaw doctor` instead.

## Changes

### `src/doctor/channel-checks.ts` (new, +308)

Six `DoctorCheck` factories exposed as `buildChannelChecks(): DoctorCheck[]`:

- `channel.slack-bot.credentials` — `SLACK_BOT_TOKEN` + `SLACK_APP_TOKEN`
- `channel.discord-bot.credentials` — `DISCORD_BOT_TOKEN`
- `channel.telegram-bot.credentials` — `TELEGRAM_BOT_TOKEN`
- `channel.kakaotalk.credentials` — `secrets.json#channels.kakaotalk.accounts` has ≥1 account
- `channel.github.credentials` — `auth` (PAT or App) + `webhookSecret` resolve to non-empty values
- `channel.github.webhook-delivery` — either `webhookUrl` is set or a `tunnels[]` entry with `for: { kind: 'channel', name: 'github' }` exists; warns when `repos[]` is non-empty but no public URL is configured

### `src/doctor/checks.ts` (+2)

`buildStaticChecks()` spreads `buildChannelChecks()` at the end of the array.

## Stage discipline

All six checks are host-stage only. No network calls to Slack/Discord/Telegram/KakaoTalk/GitHub APIs — that work belongs to each adapter's container-stage `start()` preflight (`client.testAuth()` on Slack, `client.getMe()` on Telegram, etc.). Reads only: `typeclaw.json` (via `loadConfigSync` + `validateConfig`), `.env` (via `readEnvFile`), `secrets.json` (via `SecretsBackend.tryReadChannelsSync()`), and `process.env`. Credential precedence mirrors the runtime via `resolveSecret`: `process.env` > `.env` > `secrets.json#channels.<adapter>.<field>`. Empty strings count as unset.

## Skipped-by-design cases

Adapters absent from `typeclaw.json#channels`, marked `enabled: false`, or blocked by an invalid config report `skipped` rather than an error. Zero noise on minimal setups. None of the checks offer `autoFix` — generating credential stubs is risky; the prescribed fix is `typeclaw channel add/set <adapter>`, surfaced via `fix.description`.

## Sample output

```
[!] channels
    ! slack-bot missing credentials: SLACK_APP_TOKEN
      → Fix: Run `typeclaw channel set slack-bot` or add the env vars to .env.
    - discord-bot not configured
    ! github lists 2 repo(s) but has no public URL to deliver webhooks to
      → Fix: Configure webhookUrl or a github tunnel; see `typeclaw tunnel add`.
```

## Testing

27 tests in `src/doctor/channel-checks.test.ts`, all passing (~210ms with `--parallel`). Coverage matrix:

- All 6 checks in expected order
- `applies()` gate on `hasAgentFolder=false` for every check
- Token adapters: missing both / missing one / resolved from `.env` / resolved from `process.env` / resolved from `secrets.json` / empty-string-counts-as-missing
- Kakao: skipped when not configured / warning on empty accounts / ok with one account
- GitHub: skipped / error when secrets block missing / ok with PAT / ok with App / error when PAT token has `env` binding to unset var
- GitHub webhook: skipped / ok via `webhookUrl` / ok via tunnel binding / warning when repos but no URL / info when no repos and no URL

```
bun run typecheck    ✓  0 errors
bun run lint         ✓  warnings only, all pre-existing in unrelated files
bun run format       ✓  clean
bun run test         ✓  27 new pass, 1 pre-existing failure (resolveSelfPackageJsonPath — reproduces on origin/main in any non-typeclaw-named worktree)
```

## Review notes

- **`src/doctor/channel-checks.ts`** is the load-bearing new file. The `resolveSecret` precedence order and the empty-string-as-unset policy are the key correctness properties.
- **Stage boundary** is the invariant to verify: every check terminates before the network. Any helper that reaches out to Slack/Discord/etc. belongs in the adapter's `start()`, not here.
- **No `autoFix`** is intentional — see skipped-by-design note above.