### PR TITLE
fix(github): drop self-authored events by reading the event's true author

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -261,12 +261,13 @@ describe('createGithubWebhookHandler', () => {
 describe('createGithubWebhookHandler — self-author drop', () => {
   function selfAuthoredHandler(
     routed: InboundMessage[],
-    overrides: { selfId?: string | null; selfLogin?: string | null } = {},
+    overrides: { selfId?: string | null; selfLogin?: string | null; allowlist?: readonly string[] } = {},
   ): (req: Request) => Promise<Response> {
     return createGithubWebhookHandler({
       webhookSecret: 'secret',
       dedup: createDeliveryDedup(),
-      allowlist: () => ['issue_comment.created', 'pull_request_review_comment.created', 'issues.opened'],
+      allowlist: () =>
+        overrides.allowlist ?? ['issue_comment.created', 'pull_request_review_comment.created', 'issues.opened'],
       selfId: () => overrides.selfId ?? '99',
       selfLogin: () => overrides.selfLogin ?? 'typeclaw-bot',
       logger,
@@ -339,6 +340,97 @@ describe('createGithubWebhookHandler — self-author drop', () => {
     ;(payload.comment as Record<string, unknown>).user = { login: 'typeclaw-bot', id: 99, type: 'Bot' }
     await handler(signedRequest(JSON.stringify(payload), 'issue_comment', 'self-id-null'))
     expect(routed).toHaveLength(0)
+  })
+
+  it('drops pull_request_review authored by self even when the PR was opened by someone else', async () => {
+    // Regression for PR #460: the bot submits a review on alice's PR. The
+    // payload's `pull_request.user` is alice, but `review.user` is the bot.
+    // The drop must read the review author, not the PR author, or the bot
+    // wakes a session on its own review and loops.
+    const routed: InboundMessage[] = []
+    const handler = selfAuthoredHandler(routed, {
+      allowlist: ['pull_request_review.submitted'],
+    })
+    const payload = {
+      action: 'submitted',
+      repository: repo(),
+      pull_request: { number: 7, id: 700, user: { login: 'alice', id: 10, type: 'User' } },
+      review: {
+        id: 5001,
+        body: 'looks good',
+        submitted_at: '2026-01-01T00:00:00Z',
+        user: { login: 'typeclaw-bot', id: 99, type: 'Bot' },
+      },
+    }
+    await handler(signedRequest(JSON.stringify(payload), 'pull_request_review', 'self-review-submitted'))
+    expect(routed).toHaveLength(0)
+  })
+
+  it('routes a pull_request_review from another reviewer on the bot-authored PR', async () => {
+    // Guard against over-dropping: the inverse case must still wake the bot.
+    // alice reviews the bot's PR — `pull_request.user` is the bot, but the
+    // review author is alice, so the event must route.
+    const routed: InboundMessage[] = []
+    const handler = selfAuthoredHandler(routed, {
+      allowlist: ['pull_request_review.submitted'],
+    })
+    const payload = {
+      action: 'submitted',
+      repository: repo(),
+      pull_request: { number: 7, id: 700, user: { login: 'typeclaw-bot', id: 99, type: 'Bot' } },
+      review: { id: 5002, body: 'please fix', submitted_at: '2026-01-01T00:00:00Z', user: user() },
+    }
+    await handler(signedRequest(JSON.stringify(payload), 'pull_request_review', 'other-review-submitted'))
+    expect(routed).toHaveLength(1)
+    expect(routed[0]?.authorName).toBe('alice')
+  })
+
+  it('drops self-authored events with no enumerated entity via the sender fallback', async () => {
+    const drops: string[] = []
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['commit_comment'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot',
+      logger: { ...logger, info: (m) => drops.push(m) },
+      route: (msg) => {
+        routedSink.push(msg)
+      },
+    })
+    const routedSink: InboundMessage[] = []
+    const payload = {
+      action: 'created',
+      repository: repo(),
+      sender: { login: 'typeclaw-bot', id: 99, type: 'Bot' },
+    }
+    await handler(signedRequest(JSON.stringify(payload), 'commit_comment', 'self-sender-fallback'))
+    expect(routedSink).toHaveLength(0)
+    expect(drops.some((m) => m.includes('dropped self-authored'))).toBe(true)
+  })
+
+  it('drops self-authored events for an unknown event type via the sender fallback', async () => {
+    const drops: string[] = []
+    const routedSink: InboundMessage[] = []
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['some_future_event'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot',
+      logger: { ...logger, info: (m) => drops.push(m) },
+      route: (msg) => {
+        routedSink.push(msg)
+      },
+    })
+    const payload = {
+      action: 'created',
+      repository: repo(),
+      sender: { login: 'typeclaw-bot', id: 99, type: 'Bot' },
+    }
+    await handler(signedRequest(JSON.stringify(payload), 'some_future_event', 'self-unknown-event'))
+    expect(routedSink).toHaveLength(0)
+    expect(drops.some((m) => m.includes('dropped self-authored'))).toBe(true)
   })
 })
 

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -45,7 +45,7 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
 
     const selfId = options.selfId()
     const selfLogin = options.selfLogin()
-    const author = readAuthor(payload)
+    const author = readAuthor(event, payload)
     if (author !== null && isSelfAuthor(author, selfId, selfLogin)) {
       options.logger.info(
         `[github] dropped self-authored ${event}${action !== null ? `.${action}` : ''} from @${author.login}`,
@@ -363,13 +363,42 @@ function readRepository(payload: Record<string, unknown>): { owner: string; name
   return { owner: ownerLogin, name }
 }
 
-function readAuthor(payload: Record<string, unknown>): GithubUser | null {
-  const candidates = [payload.comment, payload.issue, payload.pull_request, payload.discussion, payload.review]
-  for (const candidate of candidates) {
+function readAuthor(event: string, payload: Record<string, unknown>): GithubUser | null {
+  for (const candidate of eventAuthorCandidates(event, payload)) {
     const user = readUser(readRecord(candidate)?.user)
     if (user !== null) return user
   }
-  return null
+  // Every GitHub webhook payload carries `sender` — the actor who triggered the
+  // delivery. It is the universal fallback so events not enumerated above (and
+  // any future ones the user adds to eventAllowlist) still drop self-authored
+  // deliveries instead of slipping past the guard.
+  return readUser(payload.sender)
+}
+
+// Maps each event to the entity whose `user` is the true author of THIS event,
+// listed before broader containers. A pull_request_review payload ships both
+// `pull_request` (the PR author) and `review` (the reviewer); the self-author
+// drop must see the reviewer, so `review` must come first. PR #455's flat order
+// (`pull_request` before `review`) made a self-review on someone else's PR
+// resolve to the PR author, slip past the drop, and loop (see PR #460).
+const PRIMARY_AUTHOR_KEYS: Record<string, readonly string[]> = {
+  issue_comment: ['comment'],
+  pull_request_review_comment: ['comment'],
+  discussion_comment: ['comment'],
+  commit_comment: ['comment'],
+  pull_request_review: ['review'],
+  pull_request_review_thread: ['pull_request'],
+  issues: ['issue'],
+  pull_request: ['pull_request'],
+  discussion: ['discussion'],
+  release: ['release'],
+}
+
+const FALLBACK_AUTHOR_KEYS = ['comment', 'review', 'issue', 'pull_request', 'discussion', 'release'] as const
+
+function eventAuthorCandidates(event: string, payload: Record<string, unknown>): unknown[] {
+  const keys = PRIMARY_AUTHOR_KEYS[event] ?? FALLBACK_AUTHOR_KEYS
+  return keys.map((key) => payload[key])
 }
 
 // Matches by id OR login. Issue #452 captured a self-responding loop where


### PR DESCRIPTION
## Summary

PR #455 added a self-author drop (match by `id` **or** `login`) to stop the GitHub bot from replying to its own webhook events. It still loops — observed on #460, where the bot posted 12+ sequential self-replies as the reviewer — and it doesn't cover the full event surface.

## Root cause

The drop resolves the event author through `readAuthor`, which walked a **single flat candidate order**:

```ts
const candidates = [payload.comment, payload.issue, payload.pull_request, payload.discussion, payload.review]
```

Two gaps:

**1. Wrong author for multi-entity payloads.** A `pull_request_review` payload carries **both** `pull_request` (authored by whoever opened the PR) and `review` (authored by the reviewer). Because `pull_request` is checked before `review`, `readAuthor` returns the **PR author**, not the reviewer. So when the bot reviews **someone else's** PR:
- `readAuthor` → the PR author (e.g. `devxoul`), not the bot
- `isSelfAuthor` → `false` → event routes → bot wakes a session on **its own review** → loop

**2. No coverage for events without an enumerated entity.** `eventAllowlist` is user-configurable. Events like `commit_comment`, `pull_request_review_thread`, or any event a user adds that doesn't expose one of the five hard-coded keys had **no self-author check at all** — `readAuthor` returned `null` and the event always routed.

The id/login matching from #455 was correct; the author it was matching against was wrong or absent.

## Fix

`readAuthor` is now **event-keyed** and has a **universal fallback**:

- `PRIMARY_AUTHOR_KEYS` maps each event to the entity that owns it — `pull_request_review → review`, `*_comment → comment`, `issues → issue`, `pull_request → pull_request`, `discussion → discussion`, `release → release` — with the specific author entity listed **before** any container.
- Unknown events fall back to most-specific-first (`comment → review → issue → pull_request → discussion → release`) so an author is never masked by its container.
- **Every** event then falls through to `payload.sender`, which GitHub includes on **every webhook delivery**. This guarantees no allowed event — present or future — can bypass the self-author drop.

No change to `isSelfAuthor` or the id/login matching itself — only the author it receives.

## Tests

Four regression tests in `inbound.test.ts`, each verified to **fail** against the old resolution and **pass** with the fix:

1. **Bug case** — bot reviews another user's PR (`pull_request.user = alice`, `review.user = typeclaw-bot`) → **dropped**.
2. **Over-drop guard** — another reviewer reviews the bot's own PR (`pull_request.user = typeclaw-bot`, `review.user = alice`) → **routes** (`authorName = alice`).
3. **Sender fallback (known event w/o entity)** — self-authored `commit_comment` with only `sender` → **dropped**.
4. **Sender fallback (unknown event)** — self-authored `some_future_event` → **dropped**.

## Verification

```
bun test --parallel src/channels/adapters/github/inbound.test.ts   # 28 pass, 0 fail
```

(The 8 module-load failures in the broader `adapters/github/` run are pre-existing in a bare worktree without `node_modules` — `Cannot find module '@mariozechner/pi-coding-agent'` — and are unrelated to this change.)