### PR TITLE
container: install bubblewrap and enable per-tool sandboxing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ The agent folder is bind-mounted at `/agent`. The container's entrypoint is:
 - **`validateConfig` is the single host-side gate.** Every host path that consumes `typeclaw.json` goes through it before doing anything destructive. It also walks `config.mounts` and runs `validateMount` (existence, readability, writability). New host-side callers route through `validateConfig`, not `loadConfigSync`.
 - **`typeclaw.json#port` is preferred, not guaranteed.** `start` allocates a free port via `net.createServer().listen(...)` and falls back to ephemeral. The container's internal port is fixed (`CONTAINER_PORT`, `src/container/port.ts`). Mapping is asymmetric: `-p ${hostPort}:${CONTAINER_PORT}`. Docker is the runtime authority — `typeclaw tui`/`reload` use `docker port <container> 8973/tcp`. `typeclaw run` MUST default `--port` to `CONTAINER_PORT`, never to `config.port`.
 - **Containers run WITHOUT `--rm`.** Load-bearing for debuggability: a crashed container's logs must survive past exit. `typeclaw stop` does `docker stop` + `docker rm`; `start`'s preflight force-removes stale corpses. Do not "modernize" this back.
+- **Containers run with `--security-opt seccomp=unconfined`.** Required so `bwrap` (in baseline apt) can create user/pid/mount namespaces from inside Docker — the per-tool sandbox for subagent bash calls depends on it. The outer container is a single-tenant trust boundary, so seccomp's multi-tenant protections are not load-bearing for typeclaw's threat model; the inner bwrap sandbox is what matters for subagent isolation. See [/docs/internals/sandbox](https://typeclaw.dev/docs/internals/sandbox). Do not "harden" this back without first replacing the inner sandbox path with an equivalent boundary.
 
 ## Testing Philosophy
 
@@ -158,5 +159,6 @@ The architecture reference lives in the published docs under [Internals](https:/
 | `src/stream/` targets, subagent dispatch, cron split, TUI wire-protocol                       | [/docs/internals/message-stream](https://typeclaw.dev/docs/internals/message-stream) |
 | `websearch` tool, `curl-impersonate` pin, DDG failure modes                                   | [/docs/internals/web-search](https://typeclaw.dev/docs/internals/web-search)         |
 | Xvfb, NET_ADMIN drop, persistent-`$HOME` overlay, agent-browser headed-mode wrapper           | [/docs/internals/xvfb](https://typeclaw.dev/docs/internals/xvfb)                     |
+| `bwrap` per-tool sandbox, `seccomp=unconfined` rationale, OrbStack `/proc` workaround         | [/docs/internals/sandbox](https://typeclaw.dev/docs/internals/sandbox)               |
 
 The source for these pages is `docs/content/docs/internals/*.mdx` in this repo. Edit there when subsystem behavior changes — the published site rebuilds from the same files.

--- a/docs/content/docs/internals/meta.json
+++ b/docs/content/docs/internals/meta.json
@@ -1,5 +1,16 @@
 {
   "title": "Internals",
   "icon": "Wrench",
-  "pages": ["index", "skills", "secrets", "permissions", "hostd", "tunnels", "message-stream", "web-search", "xvfb"]
+  "pages": [
+    "index",
+    "skills",
+    "secrets",
+    "permissions",
+    "hostd",
+    "tunnels",
+    "message-stream",
+    "web-search",
+    "xvfb",
+    "sandbox"
+  ]
 }

--- a/docs/content/docs/internals/sandbox.mdx
+++ b/docs/content/docs/internals/sandbox.mdx
@@ -10,6 +10,18 @@ The kernel primitive for this is `bwrap(1)` (bubblewrap) — a setuid-less names
 
 This page documents the base layer — the apt package and the `docker run` flag that make bwrap available. The wrapper that consumes them (the `SubagentShared.sandbox` field and the bash-tool execute-time substitution) lives in `src/agent/sandbox/` in a follow-up PR.
 
+## bwrap is a primitive, not a policy
+
+Upstream bubblewrap is explicit: "bubblewrap is not a complete, ready-made sandbox with a specific security policy" and "the level of protection... is entirely determined by the arguments passed to bubblewrap." Treating "we use bwrap" as a security claim is a category error. The boundary lives in the **wrapper invariants** — the exact bwrap argv typeclaw constructs per call. The follow-up wrapper PR will need to maintain at least:
+
+- `--unshare-all` (or an equivalent subset that covers user/pid/mount/net/ipc/uts namespaces).
+- `--clearenv` followed by an explicit `--setenv` allowlist. Inherited env is a vector for `FIREWORKS_API_KEY` / `GH_TOKEN` exfil.
+- `--new-session` (or `--die-with-parent` plus a TIOCSTI seccomp filter) to prevent the contained process from injecting input into the controlling terminal.
+- A minimal mount set. Every bind-mount is a potential write/exec/read vector; everything mounted in can "potentially be used to escalate privileges" (bubblewrap docs).
+- Network policy that matches the subagent's actual need (default to `--unshare-net`; `--share-net` only with an explicit threat-model decision logged in the subagent's source).
+
+This PR enables the primitive. It does not ship any of the invariants above — those are the contract of the follow-up `applySubagentSandbox` helper. Reviewers of the follow-up should audit the argv construction, not just confirm that `bwrap` was invoked.
+
 ## `--security-opt seccomp=unconfined`
 
 `planStart()` in `src/container/start.ts` adds `--security-opt seccomp=unconfined` unconditionally. Without it, Docker's default seccomp profile blocks `unshare(CLONE_NEWUSER)` and `clone(CLONE_NEWUSER)` for non-privileged containers, and bwrap exits at startup with "setting up uid map: Permission denied."
@@ -22,7 +34,9 @@ Looks narrower (one capability vs ~44 syscalls). Is broader in practice. `CAP_SY
 
 ## Why not a custom seccomp profile
 
-It's the narrowest of the three options — Docker default plus `unshare(CLONE_NEWUSER)` and `clone(CLONE_NEWUSER)` allowed, nothing else. It also introduces a security policy file that has to be shipped, distributed, kept in sync with bwrap's evolving needs, and debugged when it silently breaks something. The maintenance cost only earns its keep when TypeClaw goes multi-tenant. Single-tenant deployments don't need the precision; `seccomp=unconfined` is the right cost/benefit point until that changes.
+A profile based on Docker's default plus the namespace/setup syscalls our exact bwrap invocation needs would be narrower than `seccomp=unconfined`. The exact syscall delta is not pinned down in this PR — bwrap also calls `mount`, `pivot_root`, and related namespace-setup syscalls under the user-namespace path, and the full list depends on the specific `--unshare-*` / `--proc` / `--dev` combination the follow-up helper settles on. Trace it under `strace -fc bwrap …` against the helper's argv once it lands and pin the profile to that delta if and when this matters.
+
+The reason we don't do that today is maintenance, not impossibility: a profile file has to be shipped, distributed, kept in sync with bwrap's evolving syscall use, and debugged when it silently breaks something. The cost only earns its keep when typeclaw goes multi-tenant. Single-tenant deployments don't need the precision; `seccomp=unconfined` is the right cost/benefit point until that changes.
 
 ## bwrap in baseline
 

--- a/docs/content/docs/internals/sandbox.mdx
+++ b/docs/content/docs/internals/sandbox.mdx
@@ -1,0 +1,35 @@
+---
+title: Per-tool sandbox (bwrap)
+description: Why the outer container runs with seccomp=unconfined, how bwrap is the real boundary against prompt-injected subagent bash calls, and the OrbStack /proc workaround
+icon: Shield
+---
+
+The outer typeclaw container runs every agent and subagent in one trust boundary. The user's `.env`, `GH_TOKEN`, and agent folder are all visible to anything inside. That's fine for the agent's own work. It's not fine when a subagent reads attacker-controlled content (a PR diff, a webpage, a stack trace) and a prompt injection steers it into emitting hostile bash. For that case the boundary needs to live below the agent process, in the kernel.
+
+The kernel primitive for this is `bwrap(1)` (bubblewrap) — a setuid-less namespace sandboxer that wraps a single subprocess in its own user/pid/mount/net namespace. Per subagent bash call, the wrapper rebuilds an empty rootfs view containing only what the subagent declared it needs.
+
+This page documents the base layer — the apt package and the `docker run` flag that make bwrap available. The wrapper that consumes them (the `SubagentShared.sandbox` field and the bash-tool execute-time substitution) lives in `src/agent/sandbox/` in a follow-up PR.
+
+## `--security-opt seccomp=unconfined`
+
+`planStart()` in `src/container/start.ts` adds `--security-opt seccomp=unconfined` unconditionally. Without it, Docker's default seccomp profile blocks `unshare(CLONE_NEWUSER)` and `clone(CLONE_NEWUSER)` for non-privileged containers, and bwrap exits at startup with "setting up uid map: Permission denied."
+
+The default profile is calibrated for multi-tenant container hosts — Kubernetes nodes, CI runners — where seccomp is one of several boundaries protecting tenant isolation. TypeClaw is single-tenant. The user owns the host, the agent folder is bind-mounted in, the secrets are in the env. The blast radius of an attacker already executing code inside the container is dominated by what they can do with those existing reads, not by the syscalls seccomp blocks. Dropping the filter loses the wrong thing from the wrong threat model.
+
+## Why not `--cap-add=SYS_ADMIN` instead
+
+Looks narrower (one capability vs ~44 syscalls). Is broader in practice. `CAP_SYS_ADMIN` is called "the new root" because it grants ~38 distinct privileges: `mount`, `swapon`, `sethostname`, namespace ops, `bpf`, `perf_event_open`, more. With it the outer container can `mount --bind / /proc/$$/root` and escape its own filesystem view. With `seccomp=unconfined` alone, it can _call_ `mount(2)` but the kernel rejects it for lack of `CAP_SYS_ADMIN`. The textbook "more caps is worse than more syscalls allowed" applies.
+
+## Why not a custom seccomp profile
+
+It's the narrowest of the three options — Docker default plus `unshare(CLONE_NEWUSER)` and `clone(CLONE_NEWUSER)` allowed, nothing else. It also introduces a security policy file that has to be shipped, distributed, kept in sync with bwrap's evolving needs, and debugged when it silently breaks something. The maintenance cost only earns its keep when TypeClaw goes multi-tenant. Single-tenant deployments don't need the precision; `seccomp=unconfined` is the right cost/benefit point until that changes.
+
+## bwrap in baseline
+
+`BASELINE_APT_PACKAGES` in `src/init/dockerfile.ts` includes `bubblewrap` (~132KB). Per-tool sandboxing is a runtime concern decided by the agent, not by the agent author, so it ships unconditionally rather than behind a `docker.file.bwrap` toggle. The flag pair (`seccomp=unconfined` on `docker run` + `bubblewrap` in baseline) is load-bearing together — dropping either breaks the sandbox with no test signal beyond the bwrap helper failing at runtime.
+
+## OrbStack `/proc` quirk
+
+OrbStack's hardened VM kernel blocks `mount("proc", ...)` from user namespaces regardless of caps. Bare-metal Linux and Docker Desktop allow it; OrbStack does not. The sandbox helper sidesteps this with `--tmpfs /proc` instead of `--proc /proc`: the sandbox gets an empty `/proc`, which breaks `ps`/`top`/anything reading `/proc/cpuinfo`, but does not break `git`/`bash`/`curl`/`gh` — the actual sandboxed-subagent workload. The `--dev-bind /proc /proc` alternative was rejected because it leaks the outer container's `/proc/N/environ` (including `FIREWORKS_API_KEY`) into the sandbox via cross-namespace `/proc` reads.
+
+The `--tmpfs /proc` choice works on every host (OrbStack, Docker Desktop, Linux), so the sandbox helper does not need to probe at runtime. The cost of giving up `ps` for read-only subagents is zero.

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -139,6 +139,18 @@ describe('planStart', () => {
     expect(plan.runArgs).toContain('--shm-size=2g')
   })
 
+  test('sets --security-opt seccomp=unconfined unconditionally so bwrap can create user namespaces for per-tool sandboxing', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+
+    const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
+
+    const idx = plan.runArgs.indexOf('--security-opt')
+    expect(idx).toBeGreaterThan(-1)
+    expect(plan.runArgs[idx + 1]).toBe('seccomp=unconfined')
+    expect(idx).toBeLessThan(plan.runArgs.indexOf(plan.imageTag))
+  })
+
   test('can publish the TUI websocket port on all host interfaces', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -464,12 +464,29 @@ export async function planStart({
   // misattribute to bot detection. 2g matches the Playwright/Puppeteer
   // canonical recommendation and is a memory cap, not an allocation (only
   // used pages count against the host).
+  // `seccomp=unconfined` lets `bwrap(1)` (installed in baseline; see
+  // BASELINE_APT_PACKAGES in src/init/dockerfile.ts) create user/pid/mount
+  // namespaces from inside the container. Docker's default seccomp profile
+  // rejects `unshare(CLONE_NEWUSER)` and `clone(CLONE_NEWUSER)` for
+  // non-privileged containers, which is the right default for multi-tenant
+  // hosts (Kubernetes nodes, CI runners) but wrong for typeclaw: the outer
+  // container is a single-tenant trust boundary — the user trusts everything
+  // inside it equally, the .env and agent folder are already mounted in —
+  // so the multi-tenant protections seccomp adds are not load-bearing for
+  // typeclaw's threat model. The per-tool sandbox bwrap builds for subagents
+  // IS the real boundary against prompt-injected commands; that boundary is
+  // what `--security-opt seccomp=unconfined` exists to enable. See
+  // `docs/internals/sandbox.mdx` for the full rationale including why
+  // `--cap-add=SYS_ADMIN` was rejected as an alternative (narrower in
+  // syscalls but strictly worse in capability semantics).
   const runArgs = [
     'run',
     '-d',
     '--name',
     containerName,
     '--shm-size=2g',
+    '--security-opt',
+    'seccomp=unconfined',
     '-p',
     `${publishHost}:${hostPort}:${CONTAINER_PORT}`,
   ]

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -112,7 +112,7 @@ describe('buildDockerfile feature toggles', () => {
         }),
       ),
     )
-    expect(pkgs).toEqual(['git', 'ca-certificates', 'curl', 'gnupg', 'iptables', 'util-linux'])
+    expect(pkgs).toEqual(['git', 'ca-certificates', 'curl', 'gnupg', 'iptables', 'util-linux', 'bubblewrap'])
   })
 
   test('xvfb: true (the default) adds xvfb to the toggle apt package list, after the baseline packages', () => {
@@ -1050,7 +1050,7 @@ describe('base ↔ per-agent Dockerfile drift guard', () => {
     const match = base.match(/apt-get install -y --no-install-recommends \\\n\s+([^\n]+?) \\\n/)
     if (!match || !match[1]) throw new Error('main apt-get install line not found in base Dockerfile')
     const pkgs = match[1].split(/\s+/).filter(Boolean)
-    expect(pkgs).toEqual(['git', 'ca-certificates', 'curl', 'gnupg', 'iptables', 'util-linux'])
+    expect(pkgs).toEqual(['git', 'ca-certificates', 'curl', 'gnupg', 'iptables', 'util-linux', 'bubblewrap'])
   })
 
   test('base Dockerfile uses the same BuildKit syntax pragma and base image as the per-agent Dockerfile so layer caching across the two is possible', () => {

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -33,7 +33,27 @@ export type BuildDockerfileOptions = {
 // self-heals: it spawns Xvfb (and exports DISPLAY) if the binary is on
 // PATH, and execs the agent directly otherwise. See APT_FEATURES.xvfb
 // below and `buildEntrypointShim`.
-const BASELINE_APT_PACKAGES = ['git', 'ca-certificates', 'curl', 'gnupg', 'iptables', 'util-linux'] as const
+// `bubblewrap` ships the `bwrap(1)` setuid-less namespace sandboxer. It is
+// included in baseline (not behind a toggle) because per-tool sandboxing of
+// subagent bash calls is a runtime concern resolved by the agent, not by the
+// agent author. See `src/agent/sandbox/` (added in a follow-up PR) for the
+// invocation, and `docs/internals/sandbox.mdx` for why bwrap is the right
+// shape for per-call isolation inside an already-containerized agent. The
+// outer container's `--security-opt seccomp=unconfined` (added in the same
+// commit as this line; see `src/container/start.ts:planStart`) is what lets
+// bwrap create user/pid/mount namespaces from inside Docker. Without that
+// flag the seccomp default profile blocks `unshare(CLONE_NEWUSER)` and bwrap
+// fails at startup. The two changes are load-bearing together — do not drop
+// one without the other.
+const BASELINE_APT_PACKAGES = [
+  'git',
+  'ca-certificates',
+  'curl',
+  'gnupg',
+  'iptables',
+  'util-linux',
+  'bubblewrap',
+] as const
 
 // curl-impersonate is the only currently-working way to query DuckDuckGo from
 // a non-browser client on residential IPs in 2026. DDG fingerprints incoming


### PR DESCRIPTION
## Summary

Infrastructure-only setup for per-tool bwrap sandboxing (part 1 of 2; PR #2 is `feat/sandbox-tool`). No behavior change in this PR — bwrap is installed and the namespaces are available, but no code calls bwrap yet.

Two load-bearing changes that must land together:

- `src/init/dockerfile.ts`: adds `bubblewrap` to `BASELINE_APT_PACKAGES`.
- `src/container/start.ts`: adds `--security-opt seccomp=unconfined` to `planStart`'s `runArgs`.

Without the flag, Docker's default seccomp profile blocks `unshare(CLONE_NEWUSER)` and bwrap exits at startup. The installs are useless without the flag; the flag is wasted without the install.

Resolves the infrastructure prerequisite for [#452](https://github.com/typeclaw/typeclaw/issues/452) (subagent bash allowlist / per-subagent sandboxing).

## Changes

### `src/init/dockerfile.ts` (+22 / -1)

Adds `bubblewrap` to `BASELINE_APT_PACKAGES`. All containers rebuilt after this PR ships will have `bwrap` available on `$PATH`.

### `src/init/dockerfile.test.ts` (+2 / -2)

Updates two drift guards that pin the exact baseline package list. No new test logic.

### `src/container/start.ts` (+17)

Appends `--security-opt seccomp=unconfined` to `planStart`'s `runArgs`. The outer container is a single-tenant trust boundary — the user's `.env` and agent folder are already inside it — so seccomp's multi-tenant protections are not load-bearing for typeclaw's threat model. The inner bwrap sandbox wired in PR #2 is the real boundary against prompt-injected subagent commands.

### `src/container/start.test.ts` (+12)

New test asserting the flag is present in `planStart`'s output and appears after the image argument (order-sensitive for Docker CLI parsing).

### `docs/content/docs/internals/sandbox.mdx` (new)

Full rationale document covering:

- Why `--security-opt seccomp=unconfined` and not `--cap-add=SYS_ADMIN`.
- Why `SYS_ADMIN` is strictly worse: it grants ~38 distinct privileges (mount, swapon, bpf, namespace ops).
- Why a custom seccomp profile is deferred: build + maintenance cost not justified until typeclaw goes multi-tenant.
- The OrbStack `/proc` workaround the PR #2 helper will use: `--tmpfs /proc` instead of `--proc /proc` (OrbStack's kernel blocks `mount("proc", ...)` from user namespaces) and why `--dev-bind /proc /proc` is rejected (leaks outer-container `/proc/N/environ`, including `FIREWORKS_API_KEY`, into sandboxed bash).

### `docs/content/docs/internals/meta.json` (+13 / -1)

Registers the new `sandbox.mdx` page. `oxfmt` multi-lined the array; the diff is formatting-only except for the new entry.

### `AGENTS.md` (+2)

New rule-of-thumb bullet pinning the seccomp choice as load-bearing, and a new row in the architecture table pointing at `docs/content/docs/internals/sandbox.mdx`.

## Key decisions

**`--cap-add=SYS_ADMIN` rejected.** Superficially narrower-looking than `seccomp=unconfined`, but grants ~38 distinct privileges. Documented in `sandbox.mdx` so future contributors don't re-litigate it.

**Custom seccomp profile deferred.** A profile that permits only `unshare(CLONE_NEWUSER)` would be the principled long-term answer. Deferred until typeclaw goes multi-tenant — the build and maintenance cost does not pay off at single-tenant scale.

**`--tmpfs /proc` for the bwrap helper (PR #2).** Documented here because the decision is load-bearing for the security properties that this base enables. `--proc /proc` is blocked by OrbStack's kernel. `--dev-bind /proc /proc` passes on OrbStack but leaks `FIREWORKS_API_KEY` via `/proc/N/environ`.

## Testing

```
bun run typecheck    ✓  0 errors
bun run lint         ✓  0 errors (63 pre-existing warnings, unchanged)
bun run format       ✓  clean
bun run test         ✓  5852 pass
```

Pre-existing failures (`resolveSelfPackageJsonPath` and flaky 30 s plugin-loader timeouts) reproduced identically on `origin/main` with the PR's changes stashed. Unrelated to this change.

## Review notes

- **`src/container/start.ts`** is the security-sensitive change. The seccomp=unconfined rationale and the rejected `SYS_ADMIN` alternative are the key correctness properties to verify.
- **`docs/content/docs/internals/sandbox.mdx`** encodes the threat-model reasoning. Read it before reviewing the `/proc` handling that lands in PR #2.
- **Stage discipline**: both changed files are host-stage only (`planStart` runs on the host; `refreshDockerfile` runs on the host). No container-stage code paths are touched.