### PR TITLE
fix(channels): accept skip_response after a send to break a turn livelock

### DIFF
--- a/src/agent/tools/skip-response.test.ts
+++ b/src/agent/tools/skip-response.test.ts
@@ -109,28 +109,27 @@ describe('createSkipResponseTool', () => {
     expect(warns.some((w) => w.includes('empty reason'))).toBe(true)
   })
 
-  test('send-already-happened: tool refuses, returns ok=false with structured error, logs the violation', async () => {
-    const { logger, warns } = memoryLogger()
+  test('recorded-after-send: tool accepts as a terminal no-op (reply stands, nothing more sent)', async () => {
+    const markCalls: Array<{ parentSessionId: string; reason: string }> = []
     const tool = createSkipResponseTool({
       router: fakeRouter({
-        markResult: { kind: 'send-already-happened', keyId: 'discord-bot:g1:c1' },
+        markCalls,
+        markResult: { kind: 'recorded-after-send', keyId: 'discord-bot:g1:c1' },
       }),
       sessionId: 'ses_abc',
-      logger,
     })
-    const result = await runTool(tool, { reason: 'changed my mind' })
+    const result = await runTool(tool, { reason: 'waiting for reviewer subagent' })
 
     expect(result.details).toMatchObject({
-      ok: false,
+      ok: true,
       suppressed: false,
-      reason: 'changed my mind',
-      error: 'send-already-happened',
+      reason: 'waiting for reviewer subagent',
     })
+    expect(result.details.error).toBeUndefined()
     const body = result.content[0]?.type === 'text' ? result.content[0].text : ''
-    expect(body).toContain('skip_response denied')
-    expect(body).toContain('already sent a channel reply')
-    expect(body).toContain('Commit to silence or commit to replying, not both')
-    expect(warns.some((w) => w.includes('channel send already happened this turn'))).toBe(true)
+    expect(body).toContain('skip_response accepted')
+    expect(body).toContain('End your turn now')
+    expect(markCalls).toHaveLength(1)
   })
 
   test('no live session: tool still returns ok but suppressed=false and logs a warning', async () => {

--- a/src/agent/tools/skip-response.ts
+++ b/src/agent/tools/skip-response.ts
@@ -39,10 +39,13 @@ export type SkipResponseDetails = {
 // `skip_response` is preferred whenever the model has a reason worth
 // recording. See session-origin.ts for the prompt-level decision rule.
 //
-// Order-dependence with `channel_reply`/`channel_send`: once `skip_response`
-// fires in a turn, the router rejects any subsequent tool-source send for
-// the same turn with `SKIP_RESPONSE_LOCK_ERROR`. The model gets a clear
-// error and learns to commit on the next turn instead of mid-turn.
+// Order-dependence with `channel_reply`/`channel_send` is asymmetric:
+//   - skip BEFORE any send → commits to silence; the router rejects any
+//     subsequent tool-source send this turn with `SKIP_RESPONSE_LOCK_ERROR`.
+//   - skip AFTER a send → accepted as a terminal no-op (`recorded-after-send`).
+//     The earlier reply stands; this posts nothing and ends the turn. Rejecting
+//     it (the old behavior) drove a livelock: denied a clean silent exit, the
+//     model re-sent, got re-denied on the next skip, and repeated to the cap.
 export function createSkipResponseTool({
   router,
   sessionId,
@@ -55,12 +58,14 @@ export function createSkipResponseTool({
       'Decline to send a user-facing reply this turn, with a logged reason. Use this ' +
       'instead of narrating "I have nothing to add" / "I will stay quiet" in your visible ' +
       'response. The reason is written to host logs (visible via `typeclaw logs -f`) but ' +
-      'never delivered to the user. The contract is bidirectional: after calling this, any ' +
-      '`channel_reply` / `channel_send` in the same turn will be rejected, AND calling this ' +
-      'after a `channel_reply` / `channel_send` has already landed in this turn will also ' +
-      'be rejected — commit to silence or commit to replying, not both. Decide before you ' +
-      'send, and call this as your terminal tool when you decide to stay silent. Prefer ' +
-      'this over the `NO_REPLY` text sentinel whenever you have a reason worth recording.',
+      'never delivered to the user. If you call this BEFORE sending anything this turn, it ' +
+      'commits you to silence and any later `channel_reply` / `channel_send` in the same ' +
+      'turn is rejected. If you call it AFTER a reply has already landed this turn (e.g. you ' +
+      'posted an ack and now want to wait quietly for a backgrounded subagent), it is ' +
+      'accepted as a terminal no-op: your earlier reply stands, nothing further is sent, and ' +
+      'your turn ends. Either way, call this as your terminal tool when you decide to stop ' +
+      'talking — do NOT keep sending "still working" updates. Prefer this over the ' +
+      '`NO_REPLY` text sentinel whenever you have a reason worth recording.',
     parameters: Type.Object({
       reason: Type.String({
         description:
@@ -85,33 +90,20 @@ export function createSkipResponseTool({
       }
 
       const result = router.markTurnSkipped({ parentSessionId: sessionId, reason })
-      if (result.kind === 'send-already-happened') {
-        // Symmetric counterpart of the send-after-skip lock in `router.send()`.
-        // The model already committed to replying earlier in this turn; calling
-        // skip_response now would land the reply AND claim silence at the same
-        // time, which is the contract violation the lock exists to prevent.
-        // Surface a clear error and refuse to stamp the flag so the rest of
-        // the turn behaves as a normal reply turn.
-        logger.warn(
-          formatChannelToolFailure(
-            'skip_response',
-            `channel send already happened this turn (reason=${JSON.stringify(reason)})`,
-          ),
-        )
-        const details: SkipResponseDetails = {
-          ok: false,
-          suppressed: false,
-          reason,
-          error: 'send-already-happened',
-        }
+      if (result.kind === 'recorded-after-send') {
+        // Reply-first skip: an ack already landed; this just ends the turn
+        // quietly. Not suppressed (the reply stands) and not an error (erroring
+        // here is what drove the historical re-send livelock). Router logged it.
+        const details: SkipResponseDetails = { ok: true, suppressed: false, reason }
         return {
           content: [
             {
               type: 'text' as const,
               text:
-                'skip_response denied: you already sent a channel reply in this turn. ' +
-                'Commit to silence or commit to replying, not both. ' +
-                'End your turn now; the reply you already sent stands.',
+                'skip_response accepted: your earlier channel reply this turn stands, and ' +
+                'no further message will be sent. End your turn now — do not send "still ' +
+                'working" updates while a backgrounded subagent runs; the completion ' +
+                'reminder will wake you when it finishes.',
             },
           ],
           details,

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1517,7 +1517,7 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sent[0]!.text).toBe('system-side message')
   })
 
-  test('skip_response: markTurnSkipped returns send-already-happened when a tool-source send already landed this turn (symmetric with skip-locked)', async () => {
+  test('skip_response: markTurnSkipped after a tool-source send is accepted as a terminal no-op (reply stands)', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: Array<{ text: string }> = []
@@ -1530,27 +1530,32 @@ describe('ChannelRouter channel-turn protocol', () => {
     await router.route(inbound({ text: 'hi' }))
     let markResult: ReturnType<ChannelRouter['markTurnSkipped']> | undefined
     sessions[0]!.onPrompt = async () => {
-      // given: a tool-source channel send has already landed this turn
+      // given: a tool-source ack has already landed this turn
       const sendResult = await router.send({
         adapter: 'discord-bot',
         workspace: 'g1',
         chat: 'c1',
-        text: 'real reply that committed us',
+        text: 'On it, reviewing…',
       })
       expect(sendResult.ok).toBe(true)
-      // when: the model tries to skip after committing to a reply
-      markResult = router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'changed my mind' })
+      // when: the model then goes quiet (the ack-then-wait pattern)
+      markResult = router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'waiting for reviewer' })
     }
     await router.__testing!.flushDebounce(KEY)
 
-    // then: skip is refused so the reply stands without a contradictory skip log
-    expect(markResult?.kind).toBe('send-already-happened')
+    // then: the skip is accepted as a no-op; the ack stands and is NOT suppressed
+    expect(markResult?.kind).toBe('recorded-after-send')
     expect(sent).toHaveLength(1)
-    expect(sent[0]!.text).toBe('real reply that committed us')
+    expect(sent[0]!.text).toBe('On it, reviewing…')
+    expect(logs.some((m) => m.includes('skip_after_send'))).toBe(true)
     expect(logs.some((m) => m.includes('skipped_by_tool'))).toBe(false)
   })
 
-  test('skip_response: send-already-happened guard resets across turns (next turn can skip cleanly)', async () => {
+  test('skip_response: after a send does NOT drive a re-send livelock (stops at the single ack)', async () => {
+    // Regression for the skip-after-send livelock: a model that acks then tries
+    // to go quiet must NOT be forced to keep sending. Pre-fix, markTurnSkipped
+    // returned 'send-already-happened' and a model that "re-sends only when the
+    // skip is refused" would spam up to the per-turn cap.
     const dir = await tempDir()
     const sent: Array<{ text: string }> = []
     const { router, sessions } = makeRouter(dir)
@@ -1559,25 +1564,54 @@ describe('ChannelRouter channel-turn protocol', () => {
       return { ok: true }
     })
 
-    // Turn 1: reply normally
-    await router.route(inbound({ text: 'turn-1' }))
+    await router.route(inbound({ text: 'please review PR #1' }))
     sessions[0]!.onPrompt = async () => {
-      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'turn-1 reply' })
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'On it' })
+      for (let i = 0; i < MAX_CHANNEL_SENDS_PER_TURN + 5; i++) {
+        const skip = router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'waiting for reviewer' })
+        if (skip.kind === 'recorded-after-send' || skip.kind === 'recorded') break
+        await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: `still working (${i})` })
+      }
     }
     await router.__testing!.flushDebounce(KEY)
-    expect(sent).toHaveLength(1)
 
-    // Turn 2: skip cleanly — the prior turn's send count must NOT block this skip
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('On it')
+  })
+
+  test('skip_response: send-after-skip lock still applies on the silence-first path', async () => {
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'first' }))
+    sessions[0]!.onPrompt = async () => {
+      // given: silence-first skip with no prior send arms the send lock
+      const r = router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'nothing to add' })
+      expect(r.kind).toBe('recorded')
+      // when: a later tool-source send is attempted in the same turn
+      const send = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'wait, reply' })
+      // then: it is rejected by the skip lock
+      expect(send.ok).toBe(false)
+      expect(send.ok === false ? send.code : '').toBe('skip-locked')
+    }
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent).toHaveLength(0)
+
+    // next turn with no send: skip still records cleanly (per-turn reset)
     let turn2Result: ReturnType<ChannelRouter['markTurnSkipped']> | undefined
     sessions[0]!.onPrompt = () => {
-      turn2Result = router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'no follow-up needed' })
+      turn2Result = router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'still nothing' })
       sessions[0]!.setAssistantText('')
     }
-    await router.route(inbound({ text: 'turn-2', externalMessageId: 'm2' }))
+    await router.route(inbound({ text: 'second', externalMessageId: 'm2' }))
     await router.__testing!.flushDebounce(KEY)
-
     expect(turn2Result?.kind).toBe('recorded')
-    expect(sent).toHaveLength(1)
+    expect(sent).toHaveLength(0)
   })
 
   test('skip_response: markTurnSkipped returns no-live-session when sessionId does not match any live session', () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -498,13 +498,15 @@ export type ChannelRouter = {
   // turn cannot drop a future legitimate reply.
   //
   // Returns:
-  //   - 'recorded'      — the live session was found and the skip was stamped
-  //   - 'send-already-happened' — a tool-source channel send already landed
-  //                       in this turn; the skip is refused (symmetric with
-  //                       the send-after-skip lock in `send()`) so the model
-  //                       cannot land a reply AND claim silence. The flag is
-  //                       NOT stamped, so the turn proceeds as a normal
-  //                       reply turn.
+  //   - 'recorded'      — silence-first: no send had landed this turn, so the
+  //                       skip was stamped and later tool-source sends are
+  //                       locked out via the send-after-skip guard in `send()`
+  //   - 'recorded-after-send' — reply-first: a tool-source channel send already
+  //                       landed this turn and the agent is now going quiet for
+  //                       the rest of it (the normal ack-then-wait pattern). The
+  //                       delivered reply stands; this skip posts nothing and is
+  //                       a terminal no-op. NOT stamped as a skipped turn (a
+  //                       reply already landed), and logged inline by the impl.
   //   - 'no-live-session' — no matching channel session (e.g. tool fired
   //                         outside a channel origin); the tool should
   //                         still log the reason but cannot suppress.
@@ -513,7 +515,7 @@ export type ChannelRouter = {
     reason: string
   }) =>
     | { kind: 'recorded'; keyId: string }
-    | { kind: 'send-already-happened'; keyId: string }
+    | { kind: 'recorded-after-send'; keyId: string }
     | { kind: 'no-live-session' }
   stop: () => Promise<void>
   liveCount: () => number
@@ -2254,13 +2256,22 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     reason: string
   }):
     | { kind: 'recorded'; keyId: string }
-    | { kind: 'send-already-happened'; keyId: string }
+    | { kind: 'recorded-after-send'; keyId: string }
     | { kind: 'no-live-session' } => {
     for (const live of liveSessions.values()) {
       if (live.destroyed) continue
       if (live.sessionId !== args.parentSessionId) continue
       if (live.successfulChannelSends > live.successfulSendsAtTurnStart) {
-        return { kind: 'send-already-happened', keyId: live.keyId }
+        // Reply-first skip ("acked, now going quiet"): accept as a terminal
+        // no-op, never stamp `skippedTurn`. The delivered reply stands and must
+        // not be suppressed, so stamping (which `validateChannelTurn` reads to
+        // drop the turn) would be wrong; the send-after-skip lock only needs to
+        // arm on the silence-first path. Rejecting this instead deadlocks the
+        // agentic loop: denied a clean silent exit the model re-sends, gets
+        // re-denied, and repeats until the per-turn send cap trips. Logged here
+        // since `validateChannelTurn` won't see a `skippedTurn` for it.
+        logger.info(`[channels] ${live.keyId} skip_after_send reason=${JSON.stringify(args.reason)}`)
+        return { kind: 'recorded-after-send', keyId: live.keyId }
       }
       live.skippedTurn = { turnSeq: live.turnSeq, reason: args.reason }
       return { kind: 'recorded', keyId: live.keyId }


### PR DESCRIPTION
## Summary

Fixes a turn-lifecycle **livelock** where a channel agent that delegates to a backgrounded subagent spams the conversation with ~10 "still working" messages before the real result lands.

Observed in production (a GitHub PR channel delegating to the `reviewer` subagent): a single agent turn fired `channel_send` 10 times in ~90s, interleaved with repeated `skip_response failed: channel send already happened this turn`, until the per-turn send cap aborted it.

## Context / Motivation

The agent posts an ack (`"On it, reviewing…"`), then correctly tries to go quiet via `skip_response` while it waits for the completion reminder. But `markTurnSkipped` rejected the skip with `send-already-happened` whenever a tool-source send had already landed this turn. Denied a clean silent exit — and unable to end a channel turn with plain text (invisible in channels) — the model fell back to `channel_send`, which re-armed the same rejection on the next `skip_response`.

The loop runs **inside a single `session.prompt()` agentic tool-loop**, not the drain loop: the `turn=N` field in the logs is `consecutiveSends`, not `turnSeq`, and there are no intervening `prompted` lines or user inbounds (self-authored events are correctly dropped). It only ends when the per-turn send cap (`MAX_CHANNEL_SENDS_PER_TURN = 10`) breaks the loop — 9 messages too late.

The send-XOR-skip contract conflated two distinct things:
- **"don't post twice"** — correct, must keep.
- **"don't ack-then-quit"** — wrong; that's the normal delegate-and-wait shape.

## Changes

Split the contract by order:

- **skip BEFORE any send** → unchanged: commits to silence; later tool-source sends are rejected with `SKIP_RESPONSE_LOCK_ERROR`.
- **skip AFTER a send** → now accepted as a terminal no-op (`recorded-after-send`): the delivered reply stands, nothing further is sent, the turn ends. `skippedTurn` is deliberately **not** stamped (a reply already landed; stamping would make `validateChannelTurn` suppress it). Logged as `skip_after_send`.

The double-reply protection the lock was built for is preserved — the post-send skip posts nothing.

### Files
- `src/channels/router.ts` — `markTurnSkipped` returns `recorded-after-send` (was `send-already-happened`) on the reply-first path; logs `skip_after_send`; type surface + doc comment updated.
- `src/agent/tools/skip-response.ts` — handles `recorded-after-send` as an `ok` terminal no-op with a "stop, don't send more" message; tool description rewritten to the asymmetric contract.
- `src/channels/router.test.ts` — converted the old refusal test to assert no-op acceptance; added a regression test proving the ack→skip loop stops at one send; added a test that the send-after-skip lock still applies on the silence-first path.
- `src/agent/tools/skip-response.test.ts` — updated the tool-level test for the new accept behavior.

## How to Test

```sh
bun run typecheck
bun run lint
bun run format:check
bun test --parallel src/channels/router.test.ts src/agent/tools/skip-response.test.ts
```

## Risk & Rollout

- **Low risk.** Behavior change is confined to the reply-first `skip_response` path in the channels subsystem. The silence-first path (and its `SKIP_RESPONSE_LOCK_ERROR`) is unchanged and covered by a new test.
- **Invariant preserved:** at most one user-facing reply per turn — a post-send skip posts nothing, so it cannot double-reply.
- Rollback: revert this commit; no migrations, no config, no schema.

## Breaking Changes

None for end users. The internal `ChannelRouter.markTurnSkipped` return kind `send-already-happened` is renamed to `recorded-after-send` with inverted semantics (accept vs reject); all in-repo callers and tests are updated in this PR.

## Testing

```
bun run typecheck    ✓  0 errors
bun run lint         ✓  64 warnings, 0 errors (identical to base; pre-existing)
bun run format:check ✓  all files correct
bun test (targeted)  ✓  237 pass, 0 fail (router + skip-response)
bun run test (full)  ✓  5927 pass, 8 fail — pre-existing network-dependent failures
                        (curl-impersonate / websearch / cloudflare-quick exit 143);
                        none touch this change, all green in isolation.
```

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (no doc surface affected)
- [x] Lint/format/typecheck pass
- [x] No secrets/PII in diff/logs
