### PR TITLE
test: cover spawnedByRole inheritance in spawn_subagent tool

### DIFF
--- a/src/agent/tools/spawn-subagent.test.ts
+++ b/src/agent/tools/spawn-subagent.test.ts
@@ -6,7 +6,12 @@ import { createStream } from '@/stream'
 import type { AgentSession } from '../index'
 import { LiveSubagentRegistry } from '../live-subagents'
 import type { SessionOrigin } from '../session-origin'
-import type { CreateSessionForSubagent, Subagent, SubagentRegistry } from '../subagents'
+import type {
+  CreateSessionForSubagent,
+  CreateSessionForSubagentOptions,
+  Subagent,
+  SubagentRegistry,
+} from '../subagents'
 import { createSpawnSubagentTool } from './spawn-subagent'
 
 const ctx = {} as Parameters<ReturnType<typeof createSpawnSubagentTool>['execute']>[4]
@@ -453,5 +458,51 @@ describe('createSpawnSubagentTool — concurrency', () => {
     resolveA()
     resolveB()
     await new Promise((r) => setImmediate(r))
+  })
+})
+
+describe('createSpawnSubagentTool — role inheritance', () => {
+  function permService(role: string): PermissionService {
+    return {
+      has: () => true,
+      resolveRole: () => role,
+      describe: () => ({ role, permissions: ['subagent.spawn'] }),
+      replaceRoles: () => {},
+    }
+  }
+
+  test('forwards the parent origin role (resolved via permissions) as spawnedByRole', async () => {
+    const session = stubSession()
+    let capturedOptions: CreateSessionForSubagentOptions | undefined
+    const { tool } = fixedSpawn({
+      createSession: async (_subagent, options) => {
+        capturedOptions = options
+        return session
+      },
+      permissions: permService('owner'),
+    })
+
+    const result = await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+
+    const details = result.details as { ok: boolean }
+    expect(details.ok).toBe(true)
+    expect(capturedOptions?.spawnedByRole).toBe('owner')
+  })
+
+  test('does not forge a role when no permission service is wired', async () => {
+    const session = stubSession()
+    let capturedOptions: CreateSessionForSubagentOptions | undefined
+    const { tool } = fixedSpawn({
+      createSession: async (_subagent, options) => {
+        capturedOptions = options
+        return session
+      },
+    })
+
+    const result = await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+
+    const details = result.details as { ok: boolean }
+    expect(details.ok).toBe(true)
+    expect(capturedOptions?.spawnedByRole).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #465. That PR fixed the `spawn_subagent` tool to resolve the parent session's role via `PermissionService.resolveRole(origin)` and forward it as `spawnedByRole`, so tool-spawned subagents inherit the parent's role instead of falling back to `guest`. The fix shipped without a test that guards the behavior — this PR adds it.

## Why the fix was effectively untested

- `permissions.test.ts` only exercises `resolveRole` in isolation (subagent origin with `spawnedByRole` → role; without → `guest`). It never checks that the tool populates that field.
- `spawn-subagent.test.ts` stubbed `createSessionForSubagent` with `async () => session`, discarding the options entirely.

Net effect: deleting the `...(spawnedByRole !== undefined ? { spawnedByRole } : {})` line from `spawn-subagent.ts` left the whole suite green.

## Changes

Two assertions in `spawn-subagent.test.ts` on the options handed to `createSessionForSubagent` — the seam the resolved role flows through (tool → `startSubagent` → `invokeSubagent` → `createSessionForSubagent`):

- **forwards the parent origin role as `spawnedByRole`** — with a permission service resolving to `owner`, asserts `createSessionForSubagent` receives `spawnedByRole: 'owner'`.
- **does not forge a role when no permission service is wired** — with no `permissions`, asserts `spawnedByRole` stays `undefined`.

## Testing

- Both tests pass against current `main`.
- Mutation check: temporarily removing the forwarding line in `spawn-subagent.ts` makes the first test fail (expected `'owner'`, got `undefined`) while the second stays green — confirming the test guards real behavior, not a literal.
- Test-only change; reuses the existing `fixedSpawn` helper and adds a local `permService`.

## Notes

Pre-commit typecheck/lint/format were not run locally because the throwaway worktree had no installed toolchain (`tsgo`/`oxlint`/`oxfmt` resolve via `node_modules`). The change is a self-contained test addition using already-exported types (`CreateSessionForSubagentOptions`); CI will run the full gate.