### PR TITLE
fix(channels): strip Markdown from KakaoTalk outbound text

### DIFF
--- a/src/channels/adapters/kakaotalk-format.test.ts
+++ b/src/channels/adapters/kakaotalk-format.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test'
+
+import { toKakaoPlainText } from './kakaotalk-format'
+
+describe('toKakaoPlainText — passthrough', () => {
+  test('returns empty string for empty input', () => {
+    expect(toKakaoPlainText('')).toBe('')
+  })
+
+  test('leaves plain prose untouched', () => {
+    expect(toKakaoPlainText('hello world, nothing to strip here')).toBe('hello world, nothing to strip here')
+  })
+
+  test('preserves newlines', () => {
+    expect(toKakaoPlainText('line one\nline two')).toBe('line one\nline two')
+  })
+
+  test('keeps emoji and non-ASCII content', () => {
+    expect(toKakaoPlainText('확인 완료 ✅ (๑˃̵ᴗ˂̵)و')).toBe('확인 완료 ✅ (๑˃̵ᴗ˂̵)و')
+  })
+})
+
+describe('toKakaoPlainText — bold', () => {
+  test('strips **bold** markers', () => {
+    expect(toKakaoPlainText('hello **world**!')).toBe('hello world!')
+  })
+
+  test('strips __bold__ when not adjacent to word chars', () => {
+    expect(toKakaoPlainText('hello __world__ ok')).toBe('hello world ok')
+  })
+
+  test('does NOT treat snake_case as bold', () => {
+    expect(toKakaoPlainText('use my__var__name here')).toBe('use my__var__name here')
+  })
+})
+
+describe('toKakaoPlainText — italic', () => {
+  test('strips *italic* markers', () => {
+    expect(toKakaoPlainText('this is *italic* text')).toBe('this is italic text')
+  })
+
+  test('strips _italic_ markers', () => {
+    expect(toKakaoPlainText('this is _italic_ text')).toBe('this is italic text')
+  })
+
+  test('does NOT italicize identifiers with underscores', () => {
+    expect(toKakaoPlainText('field is user_id_value here')).toBe('field is user_id_value here')
+  })
+
+  test('does NOT italicize a*b math', () => {
+    expect(toKakaoPlainText('compute a*b*c now')).toBe('compute a*b*c now')
+  })
+})
+
+describe('toKakaoPlainText — inline code', () => {
+  test('strips backticks, keeps content', () => {
+    expect(toKakaoPlainText('call `formatAuthorLine` now')).toBe('call formatAuthorLine now')
+  })
+
+  test('content inside code is not re-tokenized', () => {
+    expect(toKakaoPlainText('`a**b**c`')).toBe('a**b**c')
+  })
+})
+
+describe('toKakaoPlainText — strikethrough', () => {
+  test('strips ~~strike~~ markers', () => {
+    expect(toKakaoPlainText('this is ~~gone~~ now')).toBe('this is gone now')
+  })
+})
+
+describe('toKakaoPlainText — fenced code blocks', () => {
+  test('strips fences and language hint, keeps body', () => {
+    expect(toKakaoPlainText('```js\nconst x = 1\n```')).toBe('const x = 1')
+  })
+
+  test('strips bare fences', () => {
+    expect(toKakaoPlainText('```\nplain body\n```')).toBe('plain body')
+  })
+
+  test('surrounding text survives a fenced block', () => {
+    expect(toKakaoPlainText('before\n```\ncode\n```\nafter')).toBe('before\ncode\nafter')
+  })
+
+  test('an unterminated fence does not drop the tail', () => {
+    expect(toKakaoPlainText('intro\n```js\nstill here')).toBe('intro\nstill here')
+  })
+})
+
+describe('toKakaoPlainText — headings', () => {
+  test('strips leading heading hashes', () => {
+    expect(toKakaoPlainText('### Section title')).toBe('Section title')
+  })
+
+  test('strips hashes at every level', () => {
+    expect(toKakaoPlainText('# h1\n## h2\n###### h6')).toBe('h1\nh2\nh6')
+  })
+
+  test('does NOT strip a mid-line hash', () => {
+    expect(toKakaoPlainText('issue #448 fixed')).toBe('issue #448 fixed')
+  })
+})
+
+describe('toKakaoPlainText — blockquotes', () => {
+  test('strips leading quote arrow', () => {
+    expect(toKakaoPlainText('> quoted line')).toBe('quoted line')
+  })
+
+  test('does NOT strip a mid-line greater-than', () => {
+    expect(toKakaoPlainText('a > b comparison')).toBe('a > b comparison')
+  })
+})
+
+describe('toKakaoPlainText — links', () => {
+  test('collapses [label](url) to "label (url)"', () => {
+    expect(toKakaoPlainText('see [the docs](https://example.com)')).toBe('see the docs (https://example.com)')
+  })
+
+  test('keeps a bare label when url is empty', () => {
+    expect(toKakaoPlainText('[label]()')).toBe('label')
+  })
+})
+
+describe('toKakaoPlainText — lists', () => {
+  test('numbered list markers stay (they read fine unrendered)', () => {
+    expect(toKakaoPlainText('1. first\n2. second')).toBe('1. first\n2. second')
+  })
+
+  test('bullet markers stay', () => {
+    expect(toKakaoPlainText('- one\n- two')).toBe('- one\n- two')
+  })
+})
+
+describe('toKakaoPlainText — realistic agent reply', () => {
+  test('strips the spammy markdown from a release-notes summary', () => {
+    const input = [
+      'Hi, I checked the 0.13.0 / 0.14.0 release notes and the code!',
+      '',
+      'Fixed ✅',
+      '1. **channel_reply JSON leak** — 0.13.0 (#448) `isLikelyPlainTextChannelToolCall` added',
+      '2. **weekday/timezone confusion** — 0.13.0 (#457) `formatLocalWeekday` added',
+      '',
+      'Not yet fixed ❌',
+      '3. **duplicate bot name** — `formatAuthorLine` unchanged',
+    ].join('\n')
+
+    const expected = [
+      'Hi, I checked the 0.13.0 / 0.14.0 release notes and the code!',
+      '',
+      'Fixed ✅',
+      '1. channel_reply JSON leak — 0.13.0 (#448) isLikelyPlainTextChannelToolCall added',
+      '2. weekday/timezone confusion — 0.13.0 (#457) formatLocalWeekday added',
+      '',
+      'Not yet fixed ❌',
+      '3. duplicate bot name — formatAuthorLine unchanged',
+    ].join('\n')
+
+    expect(toKakaoPlainText(input)).toBe(expected)
+  })
+})

--- a/src/channels/adapters/kakaotalk-format.ts
+++ b/src/channels/adapters/kakaotalk-format.ts
@@ -1,0 +1,239 @@
+// KakaoTalk's LOCO protocol renders no rich text — bytes display verbatim, so
+// the agent's Markdown (`**bold**`, `### heading`, fenced ```blocks```) leaks
+// literal `*`/`#`/backtick noise into the chat. This strips the formatting
+// markers and keeps the content. Mirrors telegram-bot-format.ts, but emits
+// plain content instead of re-encoding to MarkdownV2. Links collapse to
+// `label (url)` so the destination survives; list/quote markers stay (they
+// read fine unrendered).
+
+export function toKakaoPlainText(input: string): string {
+  // Pull fenced code out first so a `*` inside a block is not re-tokenized as
+  // italic.
+  const out: string[] = []
+  let i = 0
+  while (i < input.length) {
+    if (matchesAt(input, i, '```')) {
+      const fenceEnd = findFenceEnd(input, i + 3)
+      if (fenceEnd !== -1) {
+        out.push(renderFence(input.slice(i + 3, fenceEnd)))
+        i = fenceEnd + 3
+        continue
+      }
+      // Unterminated fence — strip the open backticks and render the rest
+      // inline so we never infinite-loop and never drop the tail.
+      out.push(renderInline(stripLeadingFence(input.slice(i + 3))))
+      break
+    }
+    const nextFence = input.indexOf('```', i)
+    const segmentEnd = nextFence === -1 ? input.length : nextFence
+    out.push(renderLines(input.slice(i, segmentEnd)))
+    i = segmentEnd
+  }
+  return out.join('')
+}
+
+function matchesAt(s: string, idx: number, needle: string): boolean {
+  return s.slice(idx, idx + needle.length) === needle
+}
+
+function findFenceEnd(s: string, start: number): number {
+  return s.indexOf('```', start)
+}
+
+function stripLeadingFence(inner: string): string {
+  // Drop an optional language hint and the newline after an opening fence.
+  const newline = inner.indexOf('\n')
+  if (newline === -1) return inner
+  const candidate = inner.slice(0, newline).trim()
+  if (candidate === '' || /^[A-Za-z0-9_+\-.]+$/.test(candidate)) {
+    return inner.slice(newline + 1)
+  }
+  return inner
+}
+
+function renderFence(inner: string): string {
+  // Keep the code body verbatim, drop the fences and any language hint.
+  let body = inner
+  const newline = inner.indexOf('\n')
+  if (newline !== -1) {
+    const candidate = inner.slice(0, newline).trim()
+    if (candidate === '' || /^[A-Za-z0-9_+\-.]+$/.test(candidate)) {
+      body = inner.slice(newline + 1)
+    }
+  }
+  if (body.endsWith('\n')) body = body.slice(0, -1)
+  return body
+}
+
+// Strip per-line block markers (heading hashes, blockquote arrows) before
+// running the inline tokenizer on each line. List markers (`- `, `* `, `1.`)
+// are left intact — they read fine as plain text and signal structure.
+function renderLines(text: string): string {
+  const lines = text.split('\n')
+  const rendered = lines.map((line) => renderInline(stripBlockMarkers(line)))
+  return rendered.join('\n')
+}
+
+function stripBlockMarkers(line: string): string {
+  // `### heading` → `heading`; `> quote` → `quote`. Only acts on leading
+  // markers after optional indentation so mid-line `#`/`>` stay literal.
+  const heading = /^(\s*)#{1,6}\s+(.*)$/.exec(line)
+  if (heading !== null) return heading[1]! + heading[2]!
+  const quote = /^(\s*)>\s?(.*)$/.exec(line)
+  if (quote !== null) return quote[1]! + quote[2]!
+  return line
+}
+
+// Inline tokenizer. Recognizes (in priority order):
+//   1. Inline code:   `code`        → code
+//   2. Links:         [text](url)   → text (url)
+//   3. Bold:          **text** / __text__ → text
+//   4. Strikethrough: ~~text~~      → text
+//   5. Italic:        *text* / _text_     → text
+//
+// Bold is checked before italic so `**` is not eaten as two italic markers.
+// Word-boundary guards keep snake_case identifiers and `a*b` math from being
+// mistaken for emphasis — the same rules the Telegram formatter uses.
+function renderInline(text: string): string {
+  const out: string[] = []
+  let i = 0
+  while (i < text.length) {
+    const ch = text[i]!
+
+    if (ch === '`') {
+      const close = text.indexOf('`', i + 1)
+      if (close !== -1) {
+        out.push(text.slice(i + 1, close))
+        i = close + 1
+        continue
+      }
+    }
+
+    if (ch === '[') {
+      const link = parseLink(text, i)
+      if (link !== null) {
+        const label = renderInline(link.label)
+        out.push(link.url === '' ? label : `${label} (${link.url})`)
+        i = link.end
+        continue
+      }
+    }
+
+    if (ch === '*' && text[i + 1] === '*') {
+      const close = findClose(text, i + 2, '**')
+      if (close !== -1 && close > i + 2) {
+        out.push(renderInline(text.slice(i + 2, close)))
+        i = close + 2
+        continue
+      }
+    }
+    if (ch === '_' && text[i + 1] === '_' && !isWordChar(text[i - 1])) {
+      const close = findClose(text, i + 2, '__')
+      if (close !== -1 && close > i + 2 && !isWordChar(text[close + 2])) {
+        out.push(renderInline(text.slice(i + 2, close)))
+        i = close + 2
+        continue
+      }
+    }
+
+    if (ch === '~' && text[i + 1] === '~') {
+      const close = findClose(text, i + 2, '~~')
+      if (close !== -1 && close > i + 2) {
+        out.push(renderInline(text.slice(i + 2, close)))
+        i = close + 2
+        continue
+      }
+    }
+
+    if (ch === '*' && !isWordChar(text[i - 1])) {
+      const close = findInlineClose(text, i + 1, '*')
+      if (close !== -1 && !isWordChar(text[close + 1])) {
+        const inner = text.slice(i + 1, close)
+        if (inner !== '' && !/^\s|\s$/.test(inner)) {
+          out.push(renderInline(inner))
+          i = close + 1
+          continue
+        }
+      }
+    }
+    if (ch === '_' && !isWordChar(text[i - 1])) {
+      const close = findInlineClose(text, i + 1, '_')
+      if (close !== -1 && !isWordChar(text[close + 1])) {
+        const inner = text.slice(i + 1, close)
+        if (inner !== '' && !/^\s|\s$/.test(inner)) {
+          out.push(renderInline(inner))
+          i = close + 1
+          continue
+        }
+      }
+    }
+
+    out.push(ch)
+    i++
+  }
+  return out.join('')
+}
+
+function findClose(text: string, from: number, marker: string): number {
+  let i = from
+  while (i <= text.length - marker.length) {
+    if (text[i] === '\\') {
+      i += 2
+      continue
+    }
+    if (matchesAt(text, i, marker)) return i
+    i++
+  }
+  return -1
+}
+
+function findInlineClose(text: string, from: number, marker: string): number {
+  let i = from
+  while (i < text.length) {
+    if (text[i] === '\n') return -1
+    if (text[i] === '\\') {
+      i += 2
+      continue
+    }
+    if (matchesAt(text, i, marker)) return i
+    i++
+  }
+  return -1
+}
+
+function parseLink(text: string, start: number): { label: string; url: string; end: number } | null {
+  let i = start + 1
+  const labelStart = i
+  while (i < text.length) {
+    const c = text[i]!
+    if (c === '\\') {
+      i += 2
+      continue
+    }
+    if (c === ']') break
+    if (c === '\n') return null
+    i++
+  }
+  if (text[i] !== ']' || text[i + 1] !== '(') return null
+  const label = text.slice(labelStart, i)
+  const urlStart = i + 2
+  let j = urlStart
+  while (j < text.length) {
+    const c = text[j]!
+    if (c === '\\') {
+      j += 2
+      continue
+    }
+    if (c === ')') break
+    if (c === '(') return null
+    if (c === '\n') return null
+    j++
+  }
+  if (text[j] !== ')') return null
+  return { label, url: text.slice(urlStart, j), end: j + 1 }
+}
+
+function isWordChar(ch: string | undefined): boolean {
+  if (ch === undefined) return false
+  return /[A-Za-z0-9_]/.test(ch)
+}

--- a/src/channels/adapters/kakaotalk.test.ts
+++ b/src/channels/adapters/kakaotalk.test.ts
@@ -330,6 +330,34 @@ describe('createKakaotalkAdapter — outbound', () => {
     await router.stop()
   })
 
+  test('strips Markdown formatting before sending (KakaoTalk has no rich text)', async () => {
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+    })
+    await adapter.start()
+    listener.emit('connected', { userId: '999' })
+
+    const result = await router.send({
+      adapter: 'kakaotalk',
+      workspace: '@kakao-dm',
+      chat: '111',
+      text: '고쳐진 것\n1. **JSON 노출** — `formatAuthorLine` 추가됨',
+    })
+    expect(result.ok).toBe(true)
+    expect(client.sendMessageCalls).toEqual([
+      { chatId: '111', text: '고쳐진 것\n1. JSON 노출 — formatAuthorLine 추가됨' },
+    ])
+
+    await adapter.stop()
+    await router.stop()
+  })
+
   test('uploads attachments via sendAttachment when present (no text)', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'kakao-att-'))
     const filepath = join(dir, 'photo.jpg')

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -39,6 +39,7 @@ import { createKakaoAuthorResolver, type KakaoAuthorResolver } from './kakaotalk
 import { createKakaoChannelResolver, type KakaoChannelResolver } from './kakaotalk-channel-resolver'
 import { classifyInbound, type InboundDropReason } from './kakaotalk-classify'
 import { createFetchAttachmentCallback } from './kakaotalk-fetch-attachment'
+import { toKakaoPlainText } from './kakaotalk-format'
 
 // Structural duck-type of the upstream KakaoTalkClient class. The upstream
 // type is a class with private fields, and TypeScript treats those
@@ -182,7 +183,7 @@ export function createOutboundCallback(deps: {
     if (msg.adapter !== 'kakaotalk') {
       return { ok: false, error: `unknown adapter: ${msg.adapter}` }
     }
-    const text = msg.text ?? ''
+    const text = toKakaoPlainText(msg.text ?? '')
     const attachments = msg.attachments ?? []
     if (text === '' && attachments.length === 0) {
       return { ok: false, error: 'message has neither text nor attachments' }

--- a/src/skills/typeclaw-channel-kakaotalk/SKILL.md
+++ b/src/skills/typeclaw-channel-kakaotalk/SKILL.md
@@ -11,14 +11,16 @@ This means **you are messaging as a person, not as a bot.** Other participants s
 
 ## What KakaoTalk does NOT support
 
-If you produce any of the following, KakaoTalk will render it literally and the recipient will see the raw markup:
+KakaoTalk renders messages as plain text — it has no rich-text formatting. **Write plain text from the start.** The adapter strips common markdown as a safety net before sending (so an accidental `**bold**` won't leak literal asterisks), but treat that as a last-resort guard, not a license to write markdown: the strip removes _markers_, it cannot make formatting-dependent layouts like tables readable. Compose for a plain-text surface and you control the result; lean on the stripper and you get whatever falls out.
 
-- **Bold / italic / strikethrough** — `**bold**` shows as `**bold**`. Drop the asterisks; emphasize with word choice or capitalization (sparingly).
-- **Headings** — `# H1`, `## H2`, `### H3` all render as raw `#` characters.
-- **Tables** — pipe-delimited tables become a wall of `|` characters. Use bullet lists or short prose paragraphs instead.
-- **Code fences** — ``` blocks render as raw backticks. For short snippets, paste the code inline. For long snippets, summarize and offer to send it via another channel.
-- **Inline code** — `` `foo` `` renders as `` `foo` ``. Just write `foo`.
-- **Links with display text** — `[label](url)` becomes the literal string. Send the bare URL on its own; the KakaoTalk client will auto-link it.
+Specifically, do not rely on any of the following — write the plain-text equivalent yourself:
+
+- **Bold / italic / strikethrough** — emphasize with word choice or capitalization (sparingly), not `**asterisks**`.
+- **Headings** — `# H1`, `## H2`, `### H3` carry no visual weight here. Use a short label line or just lead with the point.
+- **Tables** — the stripper cannot rescue a pipe-delimited table; it would collapse into an unreadable line. Use bullet lists or short prose paragraphs instead.
+- **Code fences** — for short snippets, paste the code inline as plain text. For long snippets, summarize and offer to send it via another channel.
+- **Inline code** — just write `foo`, no backticks.
+- **Links with display text** — send the bare URL on its own line; the KakaoTalk client auto-links it. (A `[label](url)` that slips through is reduced to `label (url)`, but a bare URL reads cleaner.)
 - **Mentions** — there is no `@user` syntax that the protocol surfaces. Address people by name in the message body.
 - **Threads / replies-with-quote** — every message is a top-level chat post. There is no per-message reply UI.
 - **Outbound stickers / emoticons** — the KakaoTalk sticker store requires desktop-app purchase flows that the SDK does not replicate. Inbound stickers ARE surfaced (see below), but you cannot send one. If the user asks for a sticker, acknowledge the limit and offer text.
@@ -106,4 +108,4 @@ The adapter drops every inbound where `event.author_id` equals the logged-in acc
 
 ## When you cannot answer in KakaoTalk
 
-If the user asks you to do something the adapter cannot do (render markdown, post in a thread, send a sticker), say so plainly. Files are fine — those go through `attachments[]` as described above — but markdown rendering, threading, and stickers are real limits. Acknowledge the limit instead of silently dropping the request.
+If the user asks you to do something the adapter cannot do (post in a thread, send a sticker, render a real table), say so plainly. Files are fine — those go through `attachments[]` as described above — but threading, stickers, and rich formatting are real limits. Markdown markers you emit get stripped to plain text automatically, so a stray `**` won't leak; the limit is that nothing renders as formatting, not that it crashes. Acknowledge the limit instead of silently dropping the request.


### PR DESCRIPTION
## Problem

KakaoTalk's LOCO protocol renders no rich text — whatever bytes we send are displayed verbatim. The agent writes Markdown the way a human would (`**bold**`, `### heading`, `` `code` ``, fenced blocks, `[text](url)`), so a typical reply lands in the chat as literal asterisks, hashes, and backtick fences. It reads as spam:

```
1. **channel_reply JSON 노출** — 0.13.0 (#448) `isLikelyPlainTextChannelToolCall` 추가됨
```

## Fix

Add `toKakaoPlainText` (`src/channels/adapters/kakaotalk-format.ts`), a single-pass tokenizer modeled on the existing `telegram-bot-format.ts` but emitting **plain content** instead of re-encoding to MarkdownV2. Wired into the KakaoTalk outbound callback before `client.sendMessage`, mirroring how Telegram applies `toTelegramMarkdownV2`.

What it does:
- Strips `**bold**` / `__bold__`, `*italic*` / `_italic_`, `` `code` ``, `~~strike~~` markers — keeps the content.
- Drops leading `#` heading hashes and `>` blockquote arrows (mid-line `#`/`>` stay literal — e.g. `issue #448` and `a > b` are untouched).
- Unwraps fenced code blocks (drops fences + language hint, keeps the body).
- Collapses `[label](url)` to `label (url)` so the destination survives.
- Keeps list markers (`1.`, `- `) since they read fine unrendered.
- Word-boundary guards keep `snake_case` identifiers and `a*b` math from being mistaken for emphasis (same rules as the Telegram formatter).

After:
```
1. channel_reply JSON 노출 — 0.13.0 (#448) isLikelyPlainTextChannelToolCall 추가됨
```

## Tests

- `kakaotalk-format.test.ts` — 28 cases covering bold/italic/code/strikethrough/fences/headings/blockquotes/links/lists, edge cases (snake_case, mid-line `#`, unterminated fence), and a realistic agent reply.
- `kakaotalk.test.ts` — adapter-level test asserting Markdown is stripped before `sendMessage` receives the text.

`bun run typecheck`, `bun run lint` (0 errors), and `bun run format` all pass.

## Skill update

The runtime strip is a final gate, not the primary mechanism — the agent should still write plain text from the start. Updated `src/skills/typeclaw-channel-kakaotalk/SKILL.md` to frame the strip as a safety net (an accidental `**bold**` won't leak literal asterisks), while keeping "write plain text" as the instruction, since the stripper removes markers but can't rescue formatting-dependent layouts like tables. Also reframed the "cannot render markdown" limit as "nothing renders as formatting" rather than a hard failure.
