### PR TITLE
fix(channels): bound policy-denied channel send loops within a turn

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -16,6 +16,7 @@ import {
   createChannelRouter,
   DUPLICATE_SEND_ERROR,
   MAX_CHANNEL_SENDS_PER_TURN,
+  MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN,
   MAX_TYPING_HEARTBEAT_MS,
   OUTBOUND_FLOOD_ERROR,
   SEND_RATE_WARN_THRESHOLD,
@@ -49,6 +50,21 @@ class FakeSession {
   public entriesById = new Map<string, SessionEntry>()
   public onPrompt: ((text: string) => void | Promise<void>) | undefined
 
+  // Mirrors the real `AgentSession.agent` surface the router touches:
+  // `agent.abort()` flips `agent.signal.aborted`. The router uses this as the
+  // non-blocking turn terminator for the policy-denial loop guard. A fresh
+  // AbortController is installed at the start of every `prompt()` so each turn
+  // gets its own run signal (matching pi's per-run AbortController).
+  public agent = {
+    controller: new AbortController(),
+    get signal(): AbortSignal {
+      return this.controller.signal
+    },
+    abort(): void {
+      this.controller.abort()
+    },
+  }
+
   public sessionManager = {
     getLeafEntry: (): SessionEntry | undefined => this.leafEntry,
     getEntry: (id: string): SessionEntry | undefined => this.entriesById.get(id),
@@ -58,10 +74,12 @@ class FakeSession {
 
   prompt = async (text: string): Promise<void> => {
     this.prompts.push(text)
+    this.agent.controller = new AbortController()
     await this.onPrompt?.(text)
   }
   abort = async (): Promise<void> => {
     this.aborted++
+    this.agent.abort()
   }
   dispose = (): void => {
     this.disposed++
@@ -1612,6 +1630,122 @@ describe('ChannelRouter channel-turn protocol', () => {
     await router.__testing!.flushDebounce(KEY)
     expect(turn2Result?.kind).toBe('recorded')
     expect(sent).toHaveLength(0)
+  })
+
+  test('policy-denial loop: repeated skip-locked sends (silence-first) abort the run instead of looping', async () => {
+    // Regression for the silence-first livelock: the model skips, then retries
+    // channel_reply with varied text. Each retry is denied `skip-locked` but
+    // never increments the send cap, so pre-fix the loop ran unbounded.
+    //
+    // Production-faithful: a thrown denial would NOT end the turn (pi catches
+    // tool throws into error results), so the router aborts the run's signal
+    // instead. We mirror pi's loop: keep retrying until `agent.signal.aborted`,
+    // exactly as the real agent loop ends the turn on the next stream once the
+    // signal flips.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'just FYI' }))
+    const sendResults: SendResult[] = []
+    sessions[0]!.onPrompt = async () => {
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'nothing to add' })
+      // when: the model ignores the lock and retries SEQUENTIALLY with DIFFERENT
+      // text each time (so the byte-identical loop-guard never fires), stopping
+      // only when the run signal is aborted — as the real agent loop would
+      let i = 0
+      while (!sessions[0]!.agent.signal.aborted && i < 100) {
+        sendResults.push(
+          await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: `attempt ${i}` }),
+        )
+        i++
+      }
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the run is aborted exactly at the ceiling, every attempt was a soft
+    // skip-locked denial, and nothing was ever delivered to the channel
+    expect(sessions[0]!.agent.signal.aborted).toBe(true)
+    expect(sendResults).toHaveLength(MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN)
+    expect(sendResults.every((r) => r.ok === false && r.code === 'skip-locked')).toBe(true)
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('aborting turn') && m.includes('policy-denied'))).toBe(true)
+  })
+
+  test('policy-denial loop: repeated sequential duplicate sends abort the run (Discord incident)', async () => {
+    // Regression for the Discord livelock: the model delivers a reply, then
+    // re-sends the SAME text on each later iteration. Each is denied `duplicate`
+    // (a no-op skip_response interleaves, so the loop-guard's consecutive-streak
+    // never fires) and never increments the send cap. The first delivery resets
+    // the per-target counter, so the SEQUENTIAL retries that follow must still
+    // accumulate and abort the run.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hi' }))
+    const dupResults: SendResult[] = []
+    sessions[0]!.onPrompt = async () => {
+      // given: a first reply lands (resets the per-target denial counter)
+      const first = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'same text' })
+      expect(first.ok).toBe(true)
+      // when: the model re-sends the identical text until the run is aborted
+      let i = 0
+      while (!sessions[0]!.agent.signal.aborted && i < 100) {
+        dupResults.push(await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'same text' }))
+        i++
+      }
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: duplicates are soft until the ceiling aborts the run; only the
+    // single first reply was ever delivered
+    expect(sessions[0]!.agent.signal.aborted).toBe(true)
+    expect(dupResults).toHaveLength(MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN)
+    expect(dupResults.every((r) => r.ok === false && r.code === 'duplicate')).toBe(true)
+    expect(sent).toEqual([{ text: 'same text' }])
+    expect(logs.some((m) => m.includes('aborting turn') && m.includes('policy-denied'))).toBe(true)
+  })
+
+  test('policy-denial loop: counter resets per turn (denials below the ceiling do not throw, next turn replies)', async () => {
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // turn 1: skip, then deny just below the ceiling (no throw, no delivery)
+    await router.route(inbound({ text: 'first' }))
+    sessions[0]!.onPrompt = async () => {
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'nothing' })
+      for (let i = 0; i < MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN - 1; i++) {
+        await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: `x${i}` })
+      }
+    }
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent).toHaveLength(0)
+
+    // turn 2: a fresh turn — the counter reset means a normal reply lands
+    sessions[0]!.onPrompt = async () => {
+      const r = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'real reply' })
+      expect(r.ok).toBe(true)
+    }
+    await router.route(inbound({ text: 'second', externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('real reply')
   })
 
   test('skip_response: markTurnSkipped returns no-live-session when sessionId does not match any live session', () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -46,6 +46,7 @@ import type {
   OutboundCallback,
   OutboundMessage,
   ResolvedChannelNames,
+  SendErrorCode,
   SendResult,
   TypingCallback,
 } from './types'
@@ -98,6 +99,23 @@ export const SESSION_GC_INTERVAL_MS = 60 * 1000
 // Enforced inside router.send for `source: 'tool'` callers; system
 // recovery paths (`source: 'system'`) bypass.
 export const MAX_CHANNEL_SENDS_PER_TURN = 10
+// Ceiling on tool-source channel sends that a same-turn router policy DENIED
+// without delivering — `skip-locked`, `turn-cap`, or `duplicate`. Such denials
+// return a soft error and do NOT increment `consecutiveSends`, so a model that
+// ignores the denial and retries never trips `MAX_CHANNEL_SENDS_PER_TURN`.
+// Both production livelocks had this shape: the model alternated a no-op
+// `skip_response` with a denied `channel_reply` (~200-400x in one
+// `session.prompt()`) — the interleaving defeated the byte-identical
+// loop-guard's 5-in-a-row streak, and the denials bypassed the send cap. One
+// turn was all `skip-locked`, the other all `duplicate` (byte-identical text).
+// Past this ceiling we ABORT the run's AbortSignal (`agent.abort()`), which
+// ends the turn on the next assistant stream. We can't just throw: the pi tool
+// executor catches a tool's throw into an error result and the turn continues.
+// Counted per send-target and only when NO concurrent reservation for that
+// target is in flight, so a legitimate parallel send-burst (one winner + many
+// same-tick duplicate/cap denials) is never mistaken for a loop. Reset at turn
+// start alongside `turnSeq`.
+export const MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN = 3
 // Rolling window for outbound send-rate telemetry. 5s matches Discord's
 // rate-limit shape (5 msg / 5 s / channel) and comfortably covers Slack's
 // 1 msg/s sustained. The window is observational; exceeding the burst
@@ -347,6 +365,19 @@ type LiveSession = {
   // regardless of which order the model tried them in. Updated only at
   // turn start; reads against the live counter elsewhere are intentional.
   successfulSendsAtTurnStart: number
+  // Per-send-target count of tool-source sends with a reservation currently
+  // in flight (slot reserved, outbound callback not yet settled). Lets the
+  // policy-denial guard tell a legitimate parallel send-burst (denials that
+  // race a still-in-flight winner) from a sequential retry loop (denials with
+  // nothing in flight). Incremented at reservation, decremented in the
+  // callback-loop `finally` so an adapter throw can't strand a target.
+  inFlightToolSends: Map<string, number>
+  // Per-send-target count of policy-denied tool sends this turn that did NOT
+  // race an in-flight reservation. Drives the throw at
+  // `MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN` that breaks the alternating-tool
+  // livelock the byte-identical loop-guard misses. Reset at turn start and
+  // cleared per-target on a successful delivery to that target.
+  policyDeniedToolSendsThisTurn: Map<string, number>
   // Stamped by `markTurnSkipped` (called from the `skip_response` tool)
   // with the current `turnSeq`. Read at the top of `validateChannelTurn`:
   // if it matches the just-completed turn, recovery is skipped entirely
@@ -1011,6 +1042,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         successfulChannelSends: 0,
         turnSeq: 0,
         successfulSendsAtTurnStart: 0,
+        inFlightToolSends: new Map(),
+        policyDeniedToolSendsThisTurn: new Map(),
         skippedTurn: null,
         pendingQuoteCandidate: null,
         recentEngagedPeerBotTurns: [],
@@ -1370,6 +1403,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const successfulSendsBeforePrompt = live.successfulChannelSends
         live.turnSeq++
         live.successfulSendsAtTurnStart = successfulSendsBeforePrompt
+        live.policyDeniedToolSendsThisTurn.clear()
         await fireSessionTurnStart(live, text)
         try {
           await live.session.prompt(text)
@@ -1892,19 +1926,52 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     let priorLastSentText: string | undefined
     let reserved = false
     if (live && source === 'tool') {
+      // Every same-turn policy denial (skip-locked / turn-cap / duplicate)
+      // returns a soft error and does NOT increment `consecutiveSends`, so a
+      // model that ignores the denial and retries never trips the send cap. To
+      // bound that loop we route all three through one tally that ABORTS the run
+      // past the ceiling. The discriminator that keeps legitimate parallel
+      // send-bursts soft: a denial only counts when NO reservation for the same
+      // target is in flight. In a `Promise.all` burst the synchronous denials
+      // all race the one in-flight winner, so they don't count; a sequential
+      // retry loop has nothing in flight, so it does. See
+      // `MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN`.
+      //
+      // Why abort, not throw: pi-agent-core's tool executor catches a throw
+      // from a tool's execute() and converts it into an `isError` tool result —
+      // the turn would continue and the model could retry. The only thing that
+      // actually ends an in-flight turn is aborting the run's AbortSignal:
+      // `agent.abort()` flips it synchronously, then the NEXT assistant stream
+      // (after this tool returns) sees the aborted signal and ends the turn with
+      // stopReason 'aborted'. We must NOT call `session.abort()` here — it
+      // `await`s `waitForIdle()`, which would deadlock waiting for the very run
+      // this tool call belongs to. `agent.abort()` is the signal-only,
+      // non-blocking variant. We still return the soft denial for this call.
+      const denyPolicyToolSend = (error: string, code: SendErrorCode): SendResult => {
+        if ((live.inFlightToolSends.get(sendKey) ?? 0) > 0) {
+          return { ok: false, error, code }
+        }
+        const count = (live.policyDeniedToolSendsThisTurn.get(sendKey) ?? 0) + 1
+        live.policyDeniedToolSendsThisTurn.set(sendKey, count)
+        if (count >= MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN) {
+          logger.warn(`[channels] ${live.keyId}: aborting turn — ${count} policy-denied channel sends (last: ${code})`)
+          if (live.session.agent.signal?.aborted !== true) live.session.agent.abort()
+        }
+        return { ok: false, error, code }
+      }
       // Tool-source send after `skip_response` for the same turn is a contract
       // violation: the model already committed to silence. Reject before any
       // state mutation so the model gets a clear error and the channel stays
       // silent. System-source sends (recovery, role-claim) are not affected.
       if (live.skippedTurn !== null && live.skippedTurn.turnSeq === live.turnSeq) {
-        return { ok: false, error: SKIP_RESPONSE_LOCK_ERROR, code: 'skip-locked' }
+        return denyPolicyToolSend(SKIP_RESPONSE_LOCK_ERROR, 'skip-locked')
       }
       const currentCount = live.consecutiveSends.get(sendKey) ?? 0
       if (currentCount >= MAX_CHANNEL_SENDS_PER_TURN) {
-        return { ok: false, error: TURN_CAP_ERROR, code: 'turn-cap' }
+        return denyPolicyToolSend(TURN_CAP_ERROR, 'turn-cap')
       }
       if (text !== undefined && live.lastSentText.get(sendKey) === text) {
-        return { ok: false, error: DUPLICATE_SEND_ERROR, code: 'duplicate' }
+        return denyPolicyToolSend(DUPLICATE_SEND_ERROR, 'duplicate')
       }
       // Reserve the slot before awaiting. If the callback rejects we roll
       // back below; if it succeeds we keep the increment. The slot reserve
@@ -1915,6 +1982,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       priorLastSentText = live.lastSentText.get(sendKey)
       live.consecutiveSends.set(sendKey, currentCount + 1)
       if (text !== undefined) live.lastSentText.set(sendKey, text)
+      live.inFlightToolSends.set(sendKey, (live.inFlightToolSends.get(sendKey) ?? 0) + 1)
       reserved = true
     }
 
@@ -1924,13 +1992,24 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const snapshot = Array.from(callbacks)
     let lastError: string | undefined
     let delivered = false
-    for (const cb of snapshot) {
-      const result = await cb(msg)
-      if (result.ok) {
-        delivered = true
-        break
+    try {
+      for (const cb of snapshot) {
+        const result = await cb(msg)
+        if (result.ok) {
+          delivered = true
+          break
+        }
+        lastError = result.error
       }
-      lastError = result.error
+    } finally {
+      // Clear the in-flight reservation even if a callback threw, so a flaky
+      // adapter can never strand a target as permanently "in flight" and
+      // disable the policy-denial guard for it.
+      if (live && reserved) {
+        const inFlight = (live.inFlightToolSends.get(sendKey) ?? 1) - 1
+        if (inFlight <= 0) live.inFlightToolSends.delete(sendKey)
+        else live.inFlightToolSends.set(sendKey, inFlight)
+      }
     }
 
     if (!delivered) {
@@ -1950,6 +2029,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
     if (live) {
       live.successfulChannelSends++
+      live.policyDeniedToolSendsThisTurn.delete(sendKey)
       // Don't stop the heartbeat here: the agent may still be mid-turn and
       // about to send another reply. drain()'s finally block owns turn-end
       // stop. But Slack's adapter outbound callback explicitly clears


### PR DESCRIPTION
## Problem

Two production livelocks (v0.14.0) shared one shape: the model alternated a no-op `skip_response` with a **policy-denied** `channel_reply` inside a single `session.prompt()`, hundreds of times, until the provider gave up — flooding `typeclaw logs`.

| Incident | Denial code | Detail |
|---|---|---|
| GitHub PR turn | `skip-locked` (~200×) | silence-first `skip_response`, then retried `channel_reply` with **varied** text |
| Discord turn | `duplicate` (~400×) | re-sent **byte-identical** text after the first reply landed |

Both evaded every existing guard:

- **Byte-identical loop-guard** (`src/agent/loop-guard.ts`) blocks the **same tool 5× in a row**. The `skip_response`/`channel_reply` interleaving (e.g. `1 reply → 3 skip`, repeated) never built a 5-streak of either tool.
- **`MAX_CHANNEL_SENDS_PER_TURN` (10)**: policy-denied sends (`skip-locked`, `turn-cap`, `duplicate`) return a **soft** error and do **not** increment `consecutiveSends`, so the cap was never reached no matter how many times the model retried.
- **Core agentic loop**: no max-iteration cap.

## Fix

Route all three same-turn policy denials through one tally. Past `MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN` (3) for a target, **abort the run's `AbortSignal`** via `agent.abort()`. The signal flips synchronously; the current tool returns its soft denial; the **next assistant stream** sees the aborted signal and ends the turn with `stopReason: "aborted"`.

### Why abort, not throw

`pi-agent-core`'s tool executor (`executePreparedToolCall`) **catches a tool `execute()` throw and converts it into an `isError` tool result** — the turn would continue and the model could retry. The only thing that actually ends an in-flight turn is aborting the run's signal.

We use **`live.session.agent.abort()`** (signal-only, synchronous), **not** `session.abort()` — the latter `await`s `waitForIdle()`, which would **deadlock** waiting for the very run the tool call belongs to.

### Keeping legitimate parallel send-bursts soft

A denial counts toward the ceiling only when **no reservation for the same target is in flight**. `router.send()` runs synchronously up to its first `await cb(msg)`, so in a `Promise.all` burst all the denials are evaluated while the one winner is still in flight (`inFlightToolSends[target] > 0`) → they don't count. A sequential retry loop has nothing in flight between iterations → it counts and eventually aborts.

- `inFlightToolSends` is incremented at slot reservation and decremented in a `finally` around the callback loop, so a throwing adapter can't strand a target.
- The per-target denial counter resets at turn start and on a successful delivery to that target.
- `turn-cap` and `duplicate` denials in a parallel burst stay soft.

## Testing

Three regression tests in `router.test.ts` drive a **production-faithful** loop: the fake session retries `channel_reply` until `agent.signal.aborted` flips (mirroring pi's loop, which ends the turn on the next stream once the signal aborts) — not a manual rethrow. They prove the router actually aborts the run:
- repeated `skip-locked` sends (silence-first, **varied** text) → abort at the ceiling, nothing delivered.
- repeated **sequential** `duplicate` sends (Discord incident) → abort after the first reply lands.
- the per-target denial counter resets per turn (a normal reply lands next turn).

The existing parallel-burst tests stay green: duplicate `N=10` (1 delivered + 9 soft duplicates) and turn-cap `N=15` (10 delivered + 5 soft turn-caps) — neither aborts. 234 `router.test.ts` tests pass; 1295 channels + agent-tools tests pass. `typecheck` / `lint` (0 errors) / `format:check` clean.

## Relationship to prior fix

Complements `37e7f3c` (skip-**after**-send terminal no-op); this bounds the cases that fix deliberately left as hard locks, **plus** the duplicate-loop variant on a different denial path.

## Pre-existing, unrelated test noise

- `resolveSelfPackageJsonPath > points at this package manifest` fails only because this branch is checked out in a worktree dir named `typeclaw-skip-livelock` (the test asserts the path ends with `typeclaw/package.json`).
- `createCloudflareNamedProvider > restarts a crashed process with backoff` is a timing-flaky `src/tunnels/` test (passes in isolation).

Both are independent of this change (which touches only `src/channels/`).