### PR TITLE
channels: native platform reply when anchoring, quote as fallback

### DIFF
--- a/src/channels/adapters/telegram-bot-outbound.test.ts
+++ b/src/channels/adapters/telegram-bot-outbound.test.ts
@@ -161,6 +161,34 @@ describe('telegram-bot createOutboundCallback', () => {
     expect(fake.sendMessageCalls[0]?.options).toEqual({ parse_mode: 'MarkdownV2' })
   })
 
+  test('forwards replyTo as reply_to_message_id so the bot uses Telegram native reply', async () => {
+    const fake = fakeClient()
+    const cb = createOutboundCallback({
+      client: fake.client,
+      logger: silentLogger(),
+      formatChannelTag: async () => 'chat=-100123',
+    })
+
+    const result = await cb(buildOutbound({ replyTo: { externalMessageId: '57' } }))
+
+    expect(result.ok).toBe(true)
+    expect(fake.sendMessageCalls[0]?.options).toEqual({ reply_to_message_id: 57, parse_mode: 'MarkdownV2' })
+  })
+
+  test('drops a non-numeric replyTo id rather than passing NaN', async () => {
+    const fake = fakeClient()
+    const cb = createOutboundCallback({
+      client: fake.client,
+      logger: silentLogger(),
+      formatChannelTag: async () => 'chat=-100123',
+    })
+
+    const result = await cb(buildOutbound({ replyTo: { externalMessageId: 'not-a-number' } }))
+
+    expect(result.ok).toBe(true)
+    expect(fake.sendMessageCalls[0]?.options).toEqual({ parse_mode: 'MarkdownV2' })
+  })
+
   test('uploads each attachment via sendDocument BEFORE posting text', async () => {
     const fake = fakeClient()
     const cb = createOutboundCallback({

--- a/src/channels/adapters/telegram-bot.ts
+++ b/src/channels/adapters/telegram-bot.ts
@@ -251,8 +251,12 @@ export function createOutboundCallback(deps: {
 
     try {
       const rendered = toTelegramMarkdownV2(text)
-      const sendOptions: { message_thread_id?: number; parse_mode: 'MarkdownV2' } = { parse_mode: 'MarkdownV2' }
+      const sendOptions: { message_thread_id?: number; reply_to_message_id?: number; parse_mode: 'MarkdownV2' } = {
+        parse_mode: 'MarkdownV2',
+      }
       if (threadId !== undefined) sendOptions.message_thread_id = threadId
+      const replyToId = parseTelegramMessageId(msg.replyTo?.externalMessageId)
+      if (replyToId !== undefined) sendOptions.reply_to_message_id = replyToId
       const sent = await client.sendMessage(msg.chat, rendered, sendOptions)
       logger.info(`[telegram-bot] sent message_id=${sent.message_id} ${tag}`)
       return { ok: true }
@@ -268,6 +272,12 @@ function parseThreadId(thread: string | null | undefined): number | undefined {
   if (thread === null || thread === undefined || thread === '') return undefined
   const n = Number(thread)
   return Number.isFinite(n) ? n : undefined
+}
+
+function parseTelegramMessageId(id: string | null | undefined): number | undefined {
+  if (id === null || id === undefined || id === '') return undefined
+  const n = Number(id)
+  return Number.isInteger(n) && n > 0 ? n : undefined
 }
 
 type TelegramFileResponse = {

--- a/src/channels/router.quote-anchor.test.ts
+++ b/src/channels/router.quote-anchor.test.ts
@@ -5,6 +5,7 @@ import {
   decideQuoteAnchor,
   prependQuoteAnchor,
   renderQuoteAnchor,
+  resolveReplyRenderMode,
   stripChannelMediaPlaceholders,
 } from './router'
 import { QUOTED_REPLY_EXCERPT_MAX_CHARS, type ChannelAdapterConfig } from './schema'
@@ -21,6 +22,7 @@ const humanInbound = {
   authorName: 'Alice',
   authorIsBot: false,
   receivedAt: 1000,
+  externalMessageId: 'M_ALICE',
 }
 
 describe('renderQuoteAnchor', () => {
@@ -131,10 +133,18 @@ describe('captureQuoteCandidate', () => {
 
   test('captures the LAST batch entry as primary and stamps the adapter onto source', () => {
     const earlier = { ...humanInbound, authorId: 'U_EARLY', authorName: 'Earlier', text: 'first', receivedAt: 1000 }
-    const later = { ...humanInbound, authorId: 'U_LATE', authorName: 'Later', text: 'second', receivedAt: 2000 }
+    const later = {
+      ...humanInbound,
+      authorId: 'U_LATE',
+      authorName: 'Later',
+      text: 'second',
+      receivedAt: 2000,
+      externalMessageId: 'M_LATE',
+    }
     const result = captureQuoteCandidate('slack-bot', [earlier, later], [])
     expect(result?.source).toEqual({ adapter: 'slack-bot', authorId: 'U_LATE', authorName: 'Later', text: 'second' })
     expect(result?.primaryReceivedAt).toBe(2000)
+    expect(result?.externalMessageId).toBe('M_LATE')
   })
 
   test('flags hadInterveningObserved when a live-observed entry landed at-or-after the primary', () => {
@@ -285,7 +295,10 @@ describe('decideQuoteAnchor', () => {
       [{ receivedAt: humanInbound.receivedAt + 500, source: 'observed' }],
     )!
     const out = decideQuoteAnchor(candidate, humanInbound.receivedAt + 1_000, baseConfig)
-    expect(out).toEqual({ adapter: 'slack-bot', authorId: 'U_ALICE', authorName: 'Alice', text: 'hey there' })
+    expect(out).toEqual({
+      source: { adapter: 'slack-bot', authorId: 'U_ALICE', authorName: 'Alice', text: 'hey there' },
+      externalMessageId: 'M_ALICE',
+    })
   })
 
   test('respects an explicit enabled: false override', () => {
@@ -308,10 +321,26 @@ describe('decideQuoteAnchor', () => {
       [{ receivedAt: humanInbound.receivedAt + 500, source: 'observed' }],
     )!
     expect(decideQuoteAnchor(candidate, humanInbound.receivedAt + 1_000, baseConfig)).toEqual({
-      adapter: 'slack-bot',
-      authorId: 'U_ALICE',
-      authorName: 'Alice',
-      text: 'hey there',
+      source: { adapter: 'slack-bot', authorId: 'U_ALICE', authorName: 'Alice', text: 'hey there' },
+      externalMessageId: 'M_ALICE',
     })
+  })
+})
+
+describe('resolveReplyRenderMode', () => {
+  test('Telegram with text uses the native reply primitive', () => {
+    expect(resolveReplyRenderMode({ adapter: 'telegram-bot', workspace: 'w', chat: 'c', text: 'hi' })).toBe('native')
+  })
+
+  test('Telegram attachment-only degrades to quote (sendDocument has no reply param)', () => {
+    expect(
+      resolveReplyRenderMode({ adapter: 'telegram-bot', workspace: 'w', chat: 'c', attachments: [{ path: '/f.png' }] }),
+    ).toBe('quote')
+  })
+
+  test('Slack/Discord/KakaoTalk/GitHub fall back to quote', () => {
+    for (const adapter of ['slack-bot', 'discord-bot', 'kakaotalk', 'github'] as const) {
+      expect(resolveReplyRenderMode({ adapter, workspace: 'w', chat: 'c', text: 'hi' })).toBe('quote')
+    }
   })
 })

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -35,6 +35,7 @@ import type {
   FetchHistoryArgs,
   HistoryCallback,
   InboundMessage,
+  OutboundMessage,
   SendResult,
 } from './types'
 
@@ -5440,6 +5441,71 @@ describe('ChannelRouter quote-anchor on outbound', () => {
 
     await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'still deploying' })
     expect(sent).toEqual(['> <@U_ALICE>: deploy status?\n\nstill deploying'])
+  })
+
+  test('Telegram: anchors via native replyTo (not a blockquote) when a message intervened', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: OutboundMessage[] = []
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('telegram-bot', async (msg) => {
+      sent.push(msg)
+      return { ok: true }
+    })
+
+    await router.route(
+      inbound({
+        adapter: 'telegram-bot',
+        text: 'cron status?',
+        authorId: 'U_ALICE',
+        authorName: 'Alice',
+        externalMessageId: '500',
+      }),
+    )
+    nowRef.value += 100
+    await router.route(
+      inbound({
+        adapter: 'telegram-bot',
+        isBotMention: false,
+        externalMessageId: '501',
+        authorId: 'bob',
+        authorName: 'bob',
+        text: 'unrelated chatter',
+      }),
+    )
+    await router.__testing!.flushDebounce({ adapter: 'telegram-bot', workspace: 'g1', chat: 'c1', thread: null })
+    nowRef.value += 200
+
+    await router.send({ adapter: 'telegram-bot', workspace: 'g1', chat: 'c1', text: 'still blocked' })
+    expect(sent[0]?.replyTo).toEqual({ externalMessageId: '500' })
+    expect(sent[0]?.text).toBe('still blocked')
+  })
+
+  test('Telegram: consecutive reply (nothing intervened) sends plainly — no replyTo, no quote', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const sent: OutboundMessage[] = []
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('telegram-bot', async (msg) => {
+      sent.push(msg)
+      return { ok: true }
+    })
+
+    await router.route(
+      inbound({
+        adapter: 'telegram-bot',
+        text: 'cron status?',
+        authorId: 'U_ALICE',
+        authorName: 'Alice',
+        externalMessageId: '500',
+      }),
+    )
+    await router.__testing!.flushDebounce({ adapter: 'telegram-bot', workspace: 'g1', chat: 'c1', thread: null })
+    nowRef.value += 200
+
+    await router.send({ adapter: 'telegram-bot', workspace: 'g1', chat: 'c1', text: 'all good' })
+    expect(sent[0]?.replyTo).toBeUndefined()
+    expect(sent[0]?.text).toBe('all good')
   })
 
   test('anchors only the FIRST send of a multi-part reply; subsequent sends in the same turn are bare', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1875,7 +1875,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (live && source === 'tool' && live.pendingQuoteCandidate !== null) {
       const quoteCandidate = refreshQuoteCandidate(live.pendingQuoteCandidate, live.contextBuffer)
       const anchor = decideQuoteAnchor(quoteCandidate, now(), options.configForAdapter(msg.adapter))
-      if (anchor !== null) msg = { ...msg, text: prependQuoteAnchor(msg.text ?? '', anchor) }
+      if (anchor !== null) {
+        msg =
+          resolveReplyRenderMode(msg) === 'native'
+            ? { ...msg, replyTo: { externalMessageId: anchor.externalMessageId } }
+            : { ...msg, text: prependQuoteAnchor(msg.text ?? '', anchor.source) }
+      }
       live.pendingQuoteCandidate = null
     }
     const text = normalizeSendText(msg.text)
@@ -2557,6 +2562,7 @@ type QuoteAnchorBatchEntry = {
   authorName: string
   authorIsBot: boolean
   receivedAt: number
+  externalMessageId: string
 }
 
 type QuoteAnchorObservedEntry = {
@@ -2566,8 +2572,16 @@ type QuoteAnchorObservedEntry = {
 
 export type QuoteAnchorCandidate = {
   source: QuoteAnchorSource
+  // Native id of the primary inbound, so a native-reply adapter can point at
+  // the exact message; the blockquote fallback ignores it.
+  externalMessageId: string
   primaryReceivedAt: number
   hadInterveningObserved: boolean
+}
+
+export type QuoteAnchorTarget = {
+  source: QuoteAnchorSource
+  externalMessageId: string
 }
 
 // Strips both current `[<Adapter> attachment #N: ...]` and legacy
@@ -2620,6 +2634,7 @@ export function captureQuoteCandidate(
   if (cleaned === '') return null
   return {
     source: { adapter, authorId: primary.authorId, authorName: primary.authorName, text: cleaned },
+    externalMessageId: primary.externalMessageId,
     primaryReceivedAt: primary.receivedAt,
     hadInterveningObserved: hasInterveningObserved(primary.receivedAt, observed),
   }
@@ -2647,12 +2662,28 @@ export function decideQuoteAnchor(
   candidate: QuoteAnchorCandidate | null,
   _nowMs: number,
   adapterConfig: ChannelAdapterConfig | undefined,
-): QuoteAnchorSource | null {
+): QuoteAnchorTarget | null {
   if (candidate === null) return null
   const config = adapterConfig?.quotedReply
   if (config !== undefined && config.enabled === false) return null
   if (!candidate.hadInterveningObserved) return null
-  return candidate.source
+  return { source: candidate.source, externalMessageId: candidate.externalMessageId }
+}
+
+export type ReplyRenderMode = 'native' | 'quote'
+
+// Per-adapter, per-shape decision: can this exact outbound carry a native
+// platform reply, or must it degrade to the blockquote fallback? Conditional
+// because native support is not uniform within an adapter — Telegram's
+// `sendMessage` accepts `reply_to_message_id` but `sendDocument` does not, so
+// an attachment-only Telegram reply must quote. Slack/Discord/KakaoTalk have
+// no per-message reply the router can drive through `replyTo` today (Slack's
+// primitive is `thread`, Discord's needs SDK support, KakaoTalk has none), and
+// GitHub's PR-review reply already rides on `thread`, not `replyTo`.
+export function resolveReplyRenderMode(msg: OutboundMessage): ReplyRenderMode {
+  const hasText = normalizeSendText(msg.text) !== undefined
+  if (msg.adapter === 'telegram-bot' && hasText) return 'native'
+  return 'quote'
 }
 
 type Sliced = { kind: 'message'; message: ChannelHistoryMessage } | { kind: 'elision'; elidedCount: number }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -126,6 +126,11 @@ export type OutboundMessage = {
   // `uploadFile` does not accept a content body or a thread id, see the
   // adapter for the workaround details.
   attachments?: OutboundAttachment[]
+  // Set by the router when an intervening message means this reply should be
+  // anchored to the inbound it answers. Adapters that support a native reply
+  // primitive (e.g. Telegram `reply_to_message_id`) consume it; others ignore
+  // it because the router has already prepended the blockquote fallback.
+  replyTo?: { externalMessageId: string }
 }
 
 export type SendErrorCode =


### PR DESCRIPTION
## What

When the bot's reply to a user is **interrupted** by another message landing in between, the router anchors the reply back to the inbound it answers. Until now that anchor was always a `> author: excerpt` text blockquote. This PR makes adapters with a **native reply primitive** use it instead, keeping the blockquote as the fallback.

Behavior, by case:

- **Consecutive reply** (nothing intervened) → plain send. No reply, no quote. *(unchanged)*
- **Interrupted reply** (a message intervened) → anchor to the original:
  - adapter supports native reply → **native reply**
  - adapter does not → **quote** (blockquote fallback)

## Why

The quote-anchor was a text-only workaround because the outbound path had no way to express "reply to message X". On platforms that have a real reply UI (Telegram, and later Discord), a native reply is cleaner than injecting a `>` line into the message body.

## How

The **trigger is unchanged** — `hasInterveningObserved` still decides *whether* to anchor (router-observed timing state the model can't reliably see, so it stays router-side; no new tool param). Only the **rendering** moved:

- `QuoteAnchorCandidate` / `QuoteAnchorBatchEntry` now carry the primary inbound's `externalMessageId`, and `decideQuoteAnchor` returns a `QuoteAnchorTarget { source, externalMessageId }`.
- New `OutboundMessage.replyTo?: { externalMessageId }` carries the native-reply target. Platform-neutral — adapters translate.
- New `resolveReplyRenderMode(msg)` capability check decides native-vs-quote per adapter **and outbound shape** (Telegram text = native, Telegram document = quote, since `sendDocument` has no reply param).
- `router.send()` branches on it: native → set `replyTo`; quote → existing `prependQuoteAnchor`. The blockquote fallback stays in one place (no per-adapter duplication).

## Per-adapter

| Adapter | Anchored reply renders as |
|---|---|
| Telegram (text) | **native** `reply_to_message_id` |
| Telegram (document) | quote (SDK `sendDocument` has no reply param) |
| Discord | quote — SDK wrapper doesn't expose `message_reference` yet |
| Slack | quote — its native primitive is threads, handled separately |
| KakaoTalk | quote — no reply concept |
| GitHub | unaffected — PR-review replies already ride on `thread` |

## Invariants preserved

- Per-turn candidate reset; `source === 'tool'`-only consumption; candidate cleared even when no anchor fires.
- Multi-part reply anchors **chunk 1 only**.
- `enabled: false` config opt-out still skips anchoring entirely.

## Tests

- `router.quote-anchor.test.ts`: `externalMessageId` threading, `decideQuoteAnchor` target shape, new `resolveReplyRenderMode` matrix.
- `telegram-bot-outbound.test.ts`: `replyTo` → `reply_to_message_id`; non-numeric id dropped.
- `router.test.ts`: end-to-end — Telegram intervening → native `replyTo`; consecutive → plain (no `replyTo`, no quote).

`bun run typecheck`, `format:check`, `lint` (0 errors) all pass; full suite green except one pre-existing dir-name artifact in `update/index.test.ts` unrelated to this change.

## Follow-ups (not in this PR)

- Discord native reply needs `agent-messenger` to expose `message_reference` (or a direct-REST bypass in the adapter).
- The dead `queueDelayMs` / `DEFAULT_QUOTED_REPLY_QUEUE_DELAY_MS` config knob is left as-is to keep this PR focused; removing it touches the schema reloadable-guard tests.