### PR TITLE
docs: add PR template focused on context and reasoning

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--
+A PR body explains what the diff cannot: the context and the reasoning.
+Lead with the problem. Justify non-obvious decisions. Do NOT restate the
+diff (no per-file changelog). Do NOT paste CI output. Delete any section
+that genuinely doesn't apply.
+-->
+
+## Background
+
+<!-- Why this PR exists. For bugs: the observed symptom (ideally a production
+observation with concrete numbers) AND the root-cause mechanism — not just the
+symptom. For features: the gap this fills. The most important section. -->
+
+## Summary
+
+<!-- The approach and the key decisions a reviewer would otherwise have to ask
+about. Use "Why X and not Y" for anything non-obvious. Intent, not execution. -->
+
+## What this does NOT do
+
+<!-- Explicit non-goals. Bounds the blast radius, preempts "did you also…". -->
+
+## Review notes
+
+<!-- Point at the load-bearing change and the invariant to verify. Flag anything
+subtle, intentional-but-surprising, or deferred (with issue links). -->


### PR DESCRIPTION
## Background

The repo has no PR template, yet the best PRs already converge on one shape: lead with the problem, explain the root cause, justify non-obvious decisions, bound the scope. New contributors (and the agent) have no way to discover that shape, so PR quality is inconsistent — some bodies are a thorough writeup, others are empty or a one-line restatement of the title.

A review of ~40 recent PRs surfaced the recurring strengths *and* the recurring noise. The noise was the surprise: even strong PRs carried a per-file "Changes" changelog (which just restates the diff) and a pasted `typecheck/lint/format/test ✓` block (which just restates CI). Both are redundant with sources the reviewer already trusts more than prose.

## Summary

Adds `.github/pull_request_template.md` with four sections, each carrying information the diff and CI cannot:

- **Background** — the why. Symptom + root-cause mechanism for bugs, the gap filled for features. Merged "problem" and "root cause" into one section so it flexes across bug/feature/refactor PRs instead of forcing a root-cause heading where there's no bug.
- **Summary** — intent and the "why X not Y" decisions.
- **What this does NOT do** — explicit non-goals; invisible in a diff.
- **Review notes** — the load-bearing change and the invariant to verify.

**Why a single deletable-section template, not multiple `?template=` variants:** the repo's strength is that every PR follows one disciplined shape regardless of type. One template with HTML-comment guidance preserves that; per-type templates fragment it.

This is deliberately stricter than current house style — it drops the per-file changelog and the CI-output block that even the exemplar PRs include, because both duplicate the diff and CI.

## What this does NOT do

- No per-file "Changes" section — that's the diff.
- No verification/testing block — that's CI.
- No checklist — the `typecheck/lint/format` + no-secrets gates already live in `AGENTS.md` and CI.
- No CONTRIBUTING.md or other docs changes.

## Review notes

- The load-bearing content is the HTML comments, not the headings — they encode the Background-vs-Summary boundary ("the world before this PR" vs "what this PR does about it"). The risk is authors blurring the two; sharpen the comment wording if that line needs to be harder.
- This PR's own body follows the template, as a smoke test of whether the shape holds for a docs-only change.
