### PR TITLE
sandbox: add reusable bwrap bash sandbox primitive

### DIFF
--- a/docs/content/docs/internals/sandbox.mdx
+++ b/docs/content/docs/internals/sandbox.mdx
@@ -6,21 +6,21 @@ icon: Shield
 
 The outer typeclaw container runs every agent and subagent in one trust boundary. The user's `.env`, `GH_TOKEN`, and agent folder are all visible to anything inside. That's fine for the agent's own work. It's not fine when a subagent reads attacker-controlled content (a PR diff, a webpage, a stack trace) and a prompt injection steers it into emitting hostile bash. For that case the boundary needs to live below the agent process, in the kernel.
 
-The kernel primitive for this is `bwrap(1)` (bubblewrap) — a setuid-less namespace sandboxer that wraps a single subprocess in its own user/pid/mount/net namespace. Per subagent bash call, the wrapper rebuilds an empty rootfs view containing only what the subagent declared it needs.
+The kernel primitive for this is `bwrap(1)` (bubblewrap) — a setuid-less namespace sandboxer that wraps a single subprocess in its own user/pid/mount/net namespace. Per bash call, the wrapper rebuilds an empty rootfs view containing only what the caller's policy declared it needs.
 
-This page documents the base layer — the apt package and the `docker run` flag that make bwrap available. The wrapper that consumes them (the `SubagentShared.sandbox` field and the bash-tool execute-time substitution) lives in `src/agent/sandbox/` in a follow-up PR.
+The base layer — the apt package and the `docker run` flag that make bwrap available — is documented below. The reusable command builder that consumes them lives in `src/sandbox/`: an origin-agnostic primitive that takes a bash command plus a `SandboxPolicy` and returns the bwrap-wrapped argv. It knows nothing about subagents or the agent runtime; a consumer (the reviewer subagent is the intended first one) resolves a policy from whatever context it has and calls the builder. Wiring the builder into the bash-tool execute path is a separate follow-up.
 
 ## bwrap is a primitive, not a policy
 
-Upstream bubblewrap is explicit: "bubblewrap is not a complete, ready-made sandbox with a specific security policy" and "the level of protection... is entirely determined by the arguments passed to bubblewrap." Treating "we use bwrap" as a security claim is a category error. The boundary lives in the **wrapper invariants** — the exact bwrap argv typeclaw constructs per call. The follow-up wrapper PR will need to maintain at least:
+Upstream bubblewrap is explicit: "bubblewrap is not a complete, ready-made sandbox with a specific security policy" and "the level of protection... is entirely determined by the arguments passed to bubblewrap." Treating "we use bwrap" as a security claim is a category error. The boundary lives in the **builder invariants** — the exact bwrap argv `src/sandbox/build.ts` constructs per call. The always-on invariants are:
 
-- `--unshare-all` (or an equivalent subset that covers user/pid/mount/net/ipc/uts namespaces).
-- `--clearenv` followed by an explicit `--setenv` allowlist. Inherited env is a vector for `FIREWORKS_API_KEY` / `GH_TOKEN` exfil.
-- `--new-session` (or `--die-with-parent` plus a TIOCSTI seccomp filter) to prevent the contained process from injecting input into the controlling terminal.
-- A minimal mount set. Every bind-mount is a potential write/exec/read vector; everything mounted in can "potentially be used to escalate privileges" (bubblewrap docs).
-- Network policy that matches the subagent's actual need (default to `--unshare-net`; `--share-net` only with an explicit threat-model decision logged in the subagent's source).
+- `--unshare-all` — covers the user/pid/mount/net/ipc/uts/cgroup namespaces.
+- `--clearenv` followed by an explicit `--setenv` allowlist (`PATH`, `HOME`, `LANG` by default; consumers name any others). Inherited env is the highest-risk vector for `FIREWORKS_API_KEY` / `GH_TOKEN` exfil.
+- `--new-session` plus `--die-with-parent` (both default-on) to prevent the contained process from injecting input into the controlling terminal via TIOCSTI and to reap the sandbox if the agent dies.
+- A minimal mount set (`--ro-bind /usr`, `--ro-bind /etc`, `--dev /dev`, `--tmpfs /tmp`, `--tmpfs /proc`). Every additional bind-mount a policy declares is a potential write/exec/read vector; everything mounted in can "potentially be used to escalate privileges" (bubblewrap docs).
+- Network isolation by default (`--unshare-all` leaves the net namespace unshared); `--share-net` only when a policy explicitly sets `network: 'inherit'`.
 
-This PR enables the primitive. It does not ship any of the invariants above — those are the contract of the follow-up `applySubagentSandbox` helper. Reviewers of the follow-up should audit the argv construction, not just confirm that `bwrap` was invoked.
+These invariants are the always-on **kernel containment** boundary, applied to every command regardless of policy. Command-syntax restrictions — a prefix allowlist or shell-metacharacter rejection — are _optional_ `commandFilter` knobs a narrow consumer (e.g. a read-only reviewer) can opt into; they are not part of the base boundary, because a general-purpose bash sandbox must allow pipes, `&&`, and `$()`. Reviewers of any consumer should audit the resolved policy and the argv construction, not just confirm that `bwrap` was invoked.
 
 ## `--security-opt seccomp=unconfined`
 

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -40,9 +40,9 @@ export type BuildDockerfileOptions = {
 // below and `buildEntrypointShim`.
 // `bubblewrap` ships the `bwrap(1)` setuid-less namespace sandboxer. It is
 // included in baseline (not behind a toggle) because per-tool sandboxing of
-// subagent bash calls is a runtime concern resolved by the agent, not by the
-// agent author. See `src/agent/sandbox/` (added in a follow-up PR) for the
-// invocation, and `docs/internals/sandbox.mdx` for why bwrap is the right
+// agent bash calls is a runtime concern resolved by the agent, not by the
+// agent author. See `src/sandbox/` for the bwrap command builder, and
+// `docs/internals/sandbox.mdx` for why bwrap is the right
 // shape for per-call isolation inside an already-containerized agent. The
 // outer container's `--security-opt seccomp=unconfined` (added in the same
 // commit as this line; see `src/container/start.ts:planStart`) is what lets

--- a/src/sandbox/availability.test.ts
+++ b/src/sandbox/availability.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { _resetBwrapAvailabilityCacheForTests, ensureBwrapAvailable } from './availability'
+import { SandboxUnavailableError } from './errors'
+
+afterEach(() => {
+  _resetBwrapAvailabilityCacheForTests()
+})
+
+describe('ensureBwrapAvailable', () => {
+  test('throws SandboxUnavailableError when the binary does not exist', async () => {
+    await expect(ensureBwrapAvailable({ bwrapPath: '/nonexistent/definitely-not-bwrap' })).rejects.toBeInstanceOf(
+      SandboxUnavailableError,
+    )
+  })
+
+  test('caches the negative result by path (second call still rejects)', async () => {
+    const opts = { bwrapPath: '/nonexistent/definitely-not-bwrap' }
+    await expect(ensureBwrapAvailable(opts)).rejects.toBeInstanceOf(SandboxUnavailableError)
+    await expect(ensureBwrapAvailable(opts)).rejects.toBeInstanceOf(SandboxUnavailableError)
+  })
+
+  // bwrap is present in the typeclaw container but not on the macOS dev host,
+  // so this asserts the positive path only where the binary actually exists.
+  // Bun.spawnSync THROWS on a missing binary (ENOENT) rather than returning
+  // success:false, so the probe itself must be guarded.
+  const bwrapPresent = (() => {
+    try {
+      return Bun.spawnSync(['bwrap', '--version'], { stdout: 'ignore', stderr: 'ignore' }).success
+    } catch {
+      return false
+    }
+  })()
+  test.skipIf(!bwrapPresent)('resolves when bwrap is on PATH', async () => {
+    await expect(ensureBwrapAvailable()).resolves.toBeUndefined()
+  })
+})

--- a/src/sandbox/availability.ts
+++ b/src/sandbox/availability.ts
@@ -1,0 +1,35 @@
+import { SandboxUnavailableError } from './errors'
+
+// Cached because the binary cannot appear or disappear during a single
+// process lifetime, and a probe per bash call is wasted work. Keyed by the
+// resolved bwrap path so a test (or a consumer pinning a non-default path)
+// re-probes instead of reading another path's cached result.
+const availabilityCache = new Map<string, boolean>()
+
+export async function ensureBwrapAvailable(options?: { bwrapPath?: string }): Promise<void> {
+  const bwrap = options?.bwrapPath ?? 'bwrap'
+  const cached = availabilityCache.get(bwrap)
+  if (cached === true) return
+  if (cached === false) throw new SandboxUnavailableError()
+
+  const available = await probe(bwrap)
+  availabilityCache.set(bwrap, available)
+  if (!available) throw new SandboxUnavailableError()
+}
+
+async function probe(bwrap: string): Promise<boolean> {
+  // Bun.spawn throws synchronously with ENOENT when the binary is not on
+  // PATH, rather than resolving with a non-zero exit code — so the
+  // "not installed" case lands in the catch, not in proc.exitCode.
+  try {
+    const proc = Bun.spawn([bwrap, '--version'], { stdout: 'ignore', stderr: 'ignore' })
+    await proc.exited
+    return proc.exitCode === 0
+  } catch {
+    return false
+  }
+}
+
+export function _resetBwrapAvailabilityCacheForTests(): void {
+  availabilityCache.clear()
+}

--- a/src/sandbox/build.test.ts
+++ b/src/sandbox/build.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildSandboxedCommand } from './build'
+import { SandboxPolicyError } from './errors'
+import type { SandboxPolicy } from './policy'
+
+function argvOf(command: string, policy?: SandboxPolicy): string[] {
+  return buildSandboxedCommand(command, policy).argv
+}
+
+// Returns the value bwrap would receive for a `--flag value`-style option,
+// i.e. the token immediately after the first occurrence of `flag`.
+function valueAfter(argv: string[], flag: string): string | undefined {
+  const i = argv.indexOf(flag)
+  return i === -1 ? undefined : argv[i + 1]
+}
+
+describe('buildSandboxedCommand base argv', () => {
+  test('wraps the command in bwrap and ends with bash -c <command>', () => {
+    const argv = argvOf('git status')
+    expect(argv[0]).toBe('bwrap')
+    expect(argv.slice(-3)).toEqual(['bash', '-c', 'git status'])
+  })
+
+  test('passes the original command verbatim, even with shell operators', () => {
+    const argv = argvOf('git log | head -5 && echo done')
+    expect(argv.slice(-3)).toEqual(['bash', '-c', 'git log | head -5 && echo done'])
+  })
+
+  test('unshares all namespaces and clears the environment by default', () => {
+    const argv = argvOf('true')
+    expect(argv).toContain('--unshare-all')
+    expect(argv).toContain('--clearenv')
+  })
+
+  test('mounts a strict read-only rootfs view', () => {
+    const argv = argvOf('true')
+    expect(argv.join(' ')).toContain('--ro-bind /usr /usr')
+    expect(argv.join(' ')).toContain('--ro-bind /etc /etc')
+    expect(argv).toContain('--dev')
+    expect(argv).toContain('--tmpfs')
+  })
+
+  test('uses --tmpfs /proc and never --proc or --dev-bind for /proc', () => {
+    const argv = argvOf('true')
+    const joined = argv.join(' ')
+    expect(joined).toContain('--tmpfs /proc')
+    expect(joined).not.toContain('--proc /proc')
+    expect(joined).not.toContain('--dev-bind /proc')
+  })
+
+  test('honours a custom bwrap path', () => {
+    const argv = argvOf('true', { bwrapPath: '/usr/local/bin/bwrap' })
+    expect(argv[0]).toBe('/usr/local/bin/bwrap')
+  })
+})
+
+describe('buildSandboxedCommand process hardening', () => {
+  test('adds --new-session and --die-with-parent by default', () => {
+    const argv = argvOf('true')
+    expect(argv).toContain('--new-session')
+    expect(argv).toContain('--die-with-parent')
+  })
+
+  test('omits --new-session when explicitly disabled', () => {
+    const argv = argvOf('true', { process: { newSession: false } })
+    expect(argv).not.toContain('--new-session')
+    expect(argv).toContain('--die-with-parent')
+  })
+
+  test('omits --die-with-parent when explicitly disabled', () => {
+    const argv = argvOf('true', { process: { dieWithParent: false } })
+    expect(argv).not.toContain('--die-with-parent')
+    expect(argv).toContain('--new-session')
+  })
+})
+
+describe('buildSandboxedCommand network policy', () => {
+  test('isolates the network by default', () => {
+    expect(argvOf('true')).not.toContain('--share-net')
+  })
+
+  test("isolates the network for network: 'none'", () => {
+    expect(argvOf('true', { network: 'none' })).not.toContain('--share-net')
+  })
+
+  test("rejoins the outer network for network: 'inherit'", () => {
+    expect(argvOf('true', { network: 'inherit' })).toContain('--share-net')
+  })
+})
+
+describe('buildSandboxedCommand env policy', () => {
+  test('re-introduces only PATH, HOME, LANG by default after --clearenv', () => {
+    const argv = argvOf('true')
+    expect(valueAfter(argv, '--setenv')).toBe('PATH')
+    const setenvKeys = argv.filter((_, i) => argv[i - 1] === '--setenv')
+    expect(setenvKeys).toEqual(['PATH', 'HOME', 'LANG'])
+  })
+
+  test('applies explicit env.set entries', () => {
+    const argv = argvOf('true', { env: { set: { GIT_PAGER: 'cat' } } })
+    const joined = argv.join(' ')
+    expect(joined).toContain('--setenv GIT_PAGER cat')
+  })
+
+  test('passthrough copies only named vars that are present in process.env', () => {
+    const present = 'TYPECLAW_SANDBOX_TEST_PRESENT'
+    const absent = 'TYPECLAW_SANDBOX_TEST_ABSENT'
+    process.env[present] = 'yes'
+    delete process.env[absent]
+    try {
+      const argv = argvOf('true', { env: { passthrough: [present, absent] } })
+      const setenvKeys = argv.filter((_, i) => argv[i - 1] === '--setenv')
+      expect(setenvKeys).toContain(present)
+      expect(setenvKeys).not.toContain(absent)
+    } finally {
+      delete process.env[present]
+    }
+  })
+
+  test('does not leak arbitrary host env into the sandbox', () => {
+    process.env.TYPECLAW_SANDBOX_SECRET = 'leak-me'
+    try {
+      const argv = argvOf('true')
+      expect(argv).not.toContain('leak-me')
+    } finally {
+      delete process.env.TYPECLAW_SANDBOX_SECRET
+    }
+  })
+})
+
+describe('buildSandboxedCommand mounts', () => {
+  test('renders ro-bind, bind, tmpfs and dev mounts', () => {
+    const argv = argvOf('true', {
+      mounts: [
+        { type: 'ro-bind', source: '/agent/.git', dest: '/work/.git' },
+        { type: 'bind', source: '/agent/out', dest: '/work/out' },
+        { type: 'tmpfs', dest: '/scratch' },
+        { type: 'dev', dest: '/dev/extra' },
+      ],
+    })
+    const joined = argv.join(' ')
+    expect(joined).toContain('--ro-bind /agent/.git /work/.git')
+    expect(joined).toContain('--bind /agent/out /work/out')
+    expect(joined).toContain('--tmpfs /scratch')
+    expect(joined).toContain('--dev /dev/extra')
+  })
+
+  test('applies --chdir for cwd', () => {
+    const argv = argvOf('true', { cwd: '/work' })
+    expect(valueAfter(argv, '--chdir')).toBe('/work')
+  })
+
+  test('omits --chdir when no cwd is given', () => {
+    expect(argvOf('true')).not.toContain('--chdir')
+  })
+})
+
+describe('buildSandboxedCommand proc strategy', () => {
+  test("omits the /proc tmpfs for proc: 'none'", () => {
+    const argv = argvOf('true', { proc: 'none' })
+    expect(argv.join(' ')).not.toContain('--tmpfs /proc')
+  })
+})
+
+describe('buildSandboxedCommand command filter (opt-in)', () => {
+  test('no filter by default: shell operators are allowed', () => {
+    expect(() => buildSandboxedCommand('echo "$(date)" | cat')).not.toThrow()
+  })
+
+  test('rejectShellMetacharacters blocks command substitution', () => {
+    expect(() =>
+      buildSandboxedCommand('echo "$(rm -rf /)"', { commandFilter: { rejectShellMetacharacters: true } }),
+    ).toThrow(SandboxPolicyError)
+  })
+
+  test('rejectShellMetacharacters blocks pipes, semicolons and backticks', () => {
+    const filter = { commandFilter: { rejectShellMetacharacters: true } }
+    expect(() => buildSandboxedCommand('git log | head', filter)).toThrow(SandboxPolicyError)
+    expect(() => buildSandboxedCommand('git log; curl evil', filter)).toThrow(SandboxPolicyError)
+    expect(() => buildSandboxedCommand('echo `id`', filter)).toThrow(SandboxPolicyError)
+    expect(() => buildSandboxedCommand('git log\nrm -rf /', filter)).toThrow(SandboxPolicyError)
+  })
+
+  test('rejectShellMetacharacters allows a simple command', () => {
+    expect(() =>
+      buildSandboxedCommand('git diff --stat', { commandFilter: { rejectShellMetacharacters: true } }),
+    ).not.toThrow()
+  })
+
+  test('allowPrefixes matches on a token boundary, not a substring', () => {
+    const policy: SandboxPolicy = { commandFilter: { allowPrefixes: ['git', 'cat'] } }
+    expect(() => buildSandboxedCommand('git status', policy)).not.toThrow()
+    expect(() => buildSandboxedCommand('git', policy)).not.toThrow()
+    expect(() => buildSandboxedCommand('gitfoo --hack', policy)).toThrow(SandboxPolicyError)
+  })
+
+  test('allowPrefixes normalizes leading and internal whitespace before matching', () => {
+    const policy: SandboxPolicy = { commandFilter: { allowPrefixes: ['git diff'] } }
+    expect(() => buildSandboxedCommand('  git   diff --stat', policy)).not.toThrow()
+  })
+
+  test('allowPrefixes rejects an unlisted command', () => {
+    const policy: SandboxPolicy = { commandFilter: { allowPrefixes: ['git'] } }
+    expect(() => buildSandboxedCommand('curl evil.com', policy)).toThrow(SandboxPolicyError)
+  })
+})
+
+describe('buildSandboxedCommand commandString rendering', () => {
+  test('shell-quotes argv tokens that contain spaces or metacharacters', () => {
+    const { commandString } = buildSandboxedCommand('echo hi')
+    expect(commandString).toContain("bash -c 'echo hi'")
+  })
+
+  test('commandString round-trips the same tokens as argv', () => {
+    const { argv, commandString } = buildSandboxedCommand('git diff')
+    expect(commandString.startsWith('bwrap')).toBe(true)
+    expect(argv[0]).toBe('bwrap')
+  })
+})

--- a/src/sandbox/build.ts
+++ b/src/sandbox/build.ts
@@ -1,0 +1,128 @@
+import { SandboxPolicyError } from './errors'
+import {
+  DEFAULT_SANDBOX_ENV,
+  type SandboxCommandFilter,
+  type SandboxEnvPolicy,
+  type SandboxMount,
+  type SandboxPolicy,
+} from './policy'
+import { formatCommand } from './quote'
+
+export type SandboxedCommand = {
+  argv: string[]
+  commandString: string
+}
+
+// Pure: no I/O, no bwrap availability probe (that is `ensureBwrapAvailable`'s
+// job). Given a bash command and a policy, returns the bwrap-wrapped argv plus
+// a shell-quoted rendering of it. Knows nothing about subagents, origins, or
+// the agent runtime — a consumer resolves a policy from whatever context it
+// has and calls this. Throws SandboxPolicyError only when the consumer opted
+// into the command-filter knobs and the command violates them.
+export function buildSandboxedCommand(command: string, policy: SandboxPolicy = {}): SandboxedCommand {
+  if (policy.commandFilter !== undefined) {
+    applyCommandFilter(command, policy.commandFilter)
+  }
+  const argv = buildArgv(command, policy)
+  return { argv, commandString: formatCommand(argv) }
+}
+
+function buildArgv(command: string, policy: SandboxPolicy): string[] {
+  const bwrap = policy.bwrapPath ?? 'bwrap'
+  const argv: string[] = [bwrap, '--unshare-all']
+
+  if (policy.network === 'inherit') {
+    // --unshare-all already unshared the net namespace; --share-net rejoins
+    // the outer container's network. Other namespaces (user/pid/mount/ipc/
+    // uts/cgroup) stay unshared. Default ('none' / undefined) leaves the net
+    // namespace isolated — prompt-injected bash cannot exfiltrate over the
+    // network without the consumer explicitly opting in.
+    argv.push('--share-net')
+  }
+
+  const proc = policy.process ?? {}
+  if (proc.newSession !== false) {
+    // Drops the controlling terminal so the contained process cannot push
+    // input back into the agent's tty via TIOCSTI. Mandated by
+    // docs/internals/sandbox.mdx. Harmless for a one-shot `bash -c`.
+    argv.push('--new-session')
+  }
+  if (proc.dieWithParent !== false) {
+    argv.push('--die-with-parent')
+  }
+
+  argv.push('--clearenv')
+  for (const [key, value] of Object.entries(resolveEnv(policy.env))) {
+    argv.push('--setenv', key, value)
+  }
+
+  argv.push('--ro-bind', '/usr', '/usr', '--ro-bind', '/etc', '/etc', '--dev', '/dev', '--tmpfs', '/tmp')
+
+  if ((policy.proc ?? 'tmpfs') === 'tmpfs') {
+    // --tmpfs /proc, never --proc /proc (OrbStack's kernel blocks
+    // mount("proc",...) from user namespaces) and never --dev-bind /proc /proc
+    // (leaks the outer container's /proc/N/environ — including
+    // FIREWORKS_API_KEY — into the sandbox). See sandbox.mdx.
+    argv.push('--tmpfs', '/proc')
+  }
+
+  for (const mount of policy.mounts ?? []) {
+    appendMount(argv, mount)
+  }
+
+  if (policy.cwd !== undefined) {
+    argv.push('--chdir', policy.cwd)
+  }
+
+  argv.push('bash', '-c', command)
+  return argv
+}
+
+function appendMount(argv: string[], mount: SandboxMount): void {
+  switch (mount.type) {
+    case 'ro-bind':
+      argv.push('--ro-bind', mount.source, mount.dest)
+      return
+    case 'bind':
+      argv.push('--bind', mount.source, mount.dest)
+      return
+    case 'tmpfs':
+      argv.push('--tmpfs', mount.dest)
+      return
+    case 'dev':
+      argv.push('--dev', mount.dest)
+      return
+  }
+}
+
+function resolveEnv(env: SandboxEnvPolicy | undefined): Record<string, string> {
+  const resolved: Record<string, string> = { ...DEFAULT_SANDBOX_ENV, ...env?.set }
+  for (const key of env?.passthrough ?? []) {
+    const value = process.env[key]
+    if (value !== undefined) resolved[key] = value
+  }
+  return resolved
+}
+
+// Token-boundary match: the normalized command must equal a prefix exactly or
+// start with `prefix + ' '`. Substring matching would let `git-evil ...` slip
+// past a `git` prefix; this does not.
+const ALLOWLIST_WHITESPACE = /\s+/g
+const FORBIDDEN_METACHARS = /[;&|`$()<>\\\n]/
+
+function applyCommandFilter(command: string, filter: SandboxCommandFilter): void {
+  if (filter.rejectShellMetacharacters === true && FORBIDDEN_METACHARS.test(command)) {
+    throw new SandboxPolicyError(
+      'command contains a forbidden shell metacharacter. This policy only permits simple commands without ; & | ` $ ( ) < > \\ or newlines.',
+    )
+  }
+  if (filter.allowPrefixes !== undefined) {
+    const normalized = command.trim().replace(ALLOWLIST_WHITESPACE, ' ')
+    const matched = filter.allowPrefixes.some((p) => normalized === p || normalized.startsWith(`${p} `))
+    if (!matched) {
+      throw new SandboxPolicyError(
+        `command does not match any allowed prefix. Allowed: ${filter.allowPrefixes.join(', ')}`,
+      )
+    }
+  }
+}

--- a/src/sandbox/errors.ts
+++ b/src/sandbox/errors.ts
@@ -1,0 +1,20 @@
+export class SandboxUnavailableError extends Error {
+  override readonly name = 'SandboxUnavailableError'
+  constructor() {
+    super(
+      'sandbox unavailable: bwrap binary not found on PATH. Refusing to run a command that requires sandboxing without the kernel boundary in place.',
+    )
+  }
+}
+
+// Raised by the optional command-filter knobs (allowPrefixes,
+// rejectShellMetacharacters). These are consumer-opt-in restrictions layered
+// ABOVE the always-on kernel containment, so a rejection here is a policy
+// decision the consumer asked for — not a failure of the sandbox itself. The
+// message is phrased for the model to read and self-correct from.
+export class SandboxPolicyError extends Error {
+  override readonly name = 'SandboxPolicyError'
+  constructor(reason: string) {
+    super(`sandbox policy rejected command: ${reason}`)
+  }
+}

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,0 +1,14 @@
+export { buildSandboxedCommand, type SandboxedCommand } from './build'
+export { ensureBwrapAvailable } from './availability'
+export { formatCommand, shellQuote } from './quote'
+export { SandboxPolicyError, SandboxUnavailableError } from './errors'
+export {
+  DEFAULT_SANDBOX_ENV,
+  type SandboxCommandFilter,
+  type SandboxEnvPolicy,
+  type SandboxMount,
+  type SandboxNetwork,
+  type SandboxPolicy,
+  type SandboxProcessPolicy,
+  type SandboxProcStrategy,
+} from './policy'

--- a/src/sandbox/policy.ts
+++ b/src/sandbox/policy.ts
@@ -1,0 +1,47 @@
+export type SandboxMount =
+  | { type: 'ro-bind'; source: string; dest: string }
+  | { type: 'bind'; source: string; dest: string }
+  | { type: 'tmpfs'; dest: string }
+  | { type: 'dev'; dest: string }
+
+export type SandboxNetwork = 'none' | 'inherit'
+
+export type SandboxProcStrategy = 'tmpfs' | 'none'
+
+export type SandboxEnvPolicy = {
+  set?: Record<string, string>
+  passthrough?: string[]
+}
+
+export type SandboxCommandFilter = {
+  allowPrefixes?: string[]
+  rejectShellMetacharacters?: boolean
+}
+
+export type SandboxProcessPolicy = {
+  newSession?: boolean
+  dieWithParent?: boolean
+}
+
+export type SandboxPolicy = {
+  bwrapPath?: string
+  cwd?: string
+  mounts?: SandboxMount[]
+  network?: SandboxNetwork
+  env?: SandboxEnvPolicy
+  commandFilter?: SandboxCommandFilter
+  process?: SandboxProcessPolicy
+  proc?: SandboxProcStrategy
+}
+
+// The env the sandbox always re-introduces after `--clearenv`. Anything not
+// listed here (or explicitly named in `env.set` / `env.passthrough` by the
+// consumer) is invisible inside the sandbox. This is the load-bearing leak
+// guard: the container env holds FIREWORKS_API_KEY and GH_TOKEN, and env
+// inheritance is the single highest-risk exfil path for prompt-injected bash.
+// HOME points at /tmp because the sandbox mounts /tmp as a fresh tmpfs.
+export const DEFAULT_SANDBOX_ENV: Record<string, string> = {
+  PATH: '/usr/local/bin:/usr/bin:/bin',
+  HOME: '/tmp',
+  LANG: 'C.UTF-8',
+}

--- a/src/sandbox/quote.test.ts
+++ b/src/sandbox/quote.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatCommand, shellQuote } from './quote'
+
+describe('shellQuote', () => {
+  test('leaves safe tokens unquoted', () => {
+    expect(shellQuote('git')).toBe('git')
+    expect(shellQuote('--stat')).toBe('--stat')
+    expect(shellQuote('/usr/bin/bash')).toBe('/usr/bin/bash')
+  })
+
+  test('quotes tokens with spaces', () => {
+    expect(shellQuote('two words')).toBe("'two words'")
+  })
+
+  test('escapes embedded single quotes', () => {
+    expect(shellQuote("can't")).toBe(`'can'\\''t'`)
+  })
+
+  test('quotes shell metacharacters', () => {
+    expect(shellQuote('a|b')).toBe("'a|b'")
+    expect(shellQuote('$(x)')).toBe("'$(x)'")
+  })
+})
+
+describe('formatCommand', () => {
+  test('joins quoted tokens with spaces', () => {
+    expect(formatCommand(['bash', '-c', 'echo hi'])).toBe("bash -c 'echo hi'")
+  })
+
+  test('preserves a fully-safe argv unquoted', () => {
+    expect(formatCommand(['git', 'diff', '--stat'])).toBe('git diff --stat')
+  })
+})

--- a/src/sandbox/quote.ts
+++ b/src/sandbox/quote.ts
@@ -1,0 +1,18 @@
+// POSIX shell quoting for rendering a bwrap argv array into a single
+// `bash -c`-safe string. Today's bash tool accepts a string `command` slot
+// (`mutableArgs.command`), so the sandbox primitive renders its canonical
+// argv into a quoted string the agent runtime can drop in unchanged.
+//
+// This is a local copy of the same helper in `src/update/index.ts`. It is
+// deliberately not promoted to a shared module yet: two call sites do not
+// justify the coupling, and this primitive is meant to stand alone with zero
+// imports from the rest of the tree. Promote to `src/shared/shell.ts` only
+// when a third independent consumer appears.
+export function shellQuote(arg: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(arg)) return arg
+  return `'${arg.replaceAll("'", "'\\''")}'`
+}
+
+export function formatCommand(argv: readonly string[]): string {
+  return argv.map(shellQuote).join(' ')
+}


### PR DESCRIPTION
## Background

The threat model (documented in `docs/internals/sandbox.mdx`, merged in #463) is narrow and concrete: an agent or subagent reads attacker-controlled content — a PR diff, a webpage, a stack trace — gets prompt-injected, and emits hostile bash. The container is a single-tenant trust boundary, so the defense has to live *below* the agent process, in the kernel. #463 landed the base layer (bubblewrap in baseline apt, `--security-opt seccomp=unconfined`). Nothing consumes it yet.

The first attempt to consume it (#464, now closed) built the bwrap wrapper *around* the `reviewer` subagent: subagent-coupled API, reviewer-specific defaults, and a mandatory shell-metacharacter gate + command allowlist baked into the core. That shape does not generalize. The goal is the opposite — a general, reusable bash sandbox where the kernel boundary applies to *any* bash call (eventually the main agent too), and `reviewer` is merely the first consumer.

## Summary

`src/sandbox/` is an origin-agnostic bwrap command builder. `buildSandboxedCommand(command, policy)` returns `{ argv, commandString }` — argv is canonical; commandString is a shell-quoted rendering for today's string-typed bash-tool `command` slot. The module imports nothing from the agent/runtime; a consumer resolves a `SandboxPolicy` from whatever context it has and calls the builder.

**Kernel containment is the always-on boundary**, applied to every command regardless of policy: `--unshare-all`, `--clearenv` + an explicit `--setenv` allowlist (`PATH`/`HOME`/`LANG` by default — env inheritance is the highest-risk secret-exfil path), `--new-session` + `--die-with-parent`, a minimal read-only rootfs, `--tmpfs /proc` (OrbStack-safe; avoids the `/proc/N/environ` -> `FIREWORKS_API_KEY` leak), and network isolation by default.

**Why command-syntax restrictions are opt-in, not default.** #464 made shell-metacharacter rejection and prefix allowlisting mandatory. That is wrong for a general primitive: normal bash needs pipes, `&&`, and `$()`. Re-evaluating the security model from scratch, the right split is — kernel containment always on (it *contains* the blast radius), command filtering as an optional `commandFilter` knob a narrow consumer (a read-only reviewer) can layer on top. The allowlist/metachar logic is preserved, just demoted from "the security model" to "one consumer's policy."

**Why `--new-session` + `--die-with-parent` (new vs #464).** The docs mandate `--new-session` (TIOCSTI terminal-injection defense); #464 never implemented it. Both are default-on here, harmless for a one-shot `bash -c`.

**Why pure builder + separate preflight.** `buildSandboxedCommand` is pure (no I/O), so argv construction is fully unit-testable on a macOS host with no bwrap. `ensureBwrapAvailable()` is a separate async preflight that fail-closes with `SandboxUnavailableError`. Container-only assertions gate behind `test.skipIf`.

## What this does NOT do

- **No wiring.** The builder is not called from the bash-tool execute path (`src/agent/plugin-tools.ts`) — that is a deliberate follow-up. The realistic call site is confirmed (mutate `mutableArgs.command` after `stripGuardAcknowledgements`, before `tool.execute`), but this PR ships the primitive only.
- **No consumer.** No subagent declares a policy yet; `reviewer` adoption is a follow-up.
- **No subagent/origin coupling.** Intentionally. Policy resolution from `SessionOrigin` belongs in a future agent-side layer, not the primitive.
- **Does not promote `shellQuote` to `src/shared/`.** A local copy lives in `src/sandbox/quote.ts`; two call sites do not justify the coupling, and the primitive is meant to stand alone.

## Review notes

- **`src/sandbox/build.ts`** is the load-bearing code. The invariant to verify: the always-on argv (clearenv + setenv allowlist, unshare-all, tmpfs /proc, default net isolation) is emitted for *every* command, and `commandFilter` rejections happen *before* wrapping.
- **Security re-evaluation from #464**: dropped the mandatory metachar gate + allowlist (now opt-in), dropped the fail-closed "unresolvable subagent origin" logic (belongs in the future agent-side resolver, not the primitive). Kept the bwrap shape, env clearing, default-deny network, and the OrbStack `/proc` workaround.
- **Stale-reference fixups**: `dockerfile.ts` comment and `sandbox.mdx` pointed at `src/agent/sandbox/`; updated to `src/sandbox/` and de-coupled the prose from "subagent" to "agent". The `sandbox.mdx` "primitive vs policy" section now documents the always-on-vs-opt-in split.
- Replaces the design direction of #464 (closed).