### PR TITLE
feat(models): add Claude Opus 4.8 to the Anthropic lineup

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1181,12 +1181,14 @@ describe('recommended models', () => {
   test('sortRecommendedFirst floats the recommended Anthropic model to the top', () => {
     const haiku = model('anthropic/claude-haiku-4-5', { modelName: 'Claude Haiku 4.5' })
     const sonnet = model('anthropic/claude-sonnet-4-6', { modelName: 'Claude Sonnet 4.6' })
-    const opus = model('anthropic/claude-opus-4-7', { modelName: 'Claude Opus 4.7' })
-    const sorted = sortRecommendedFirst([haiku, sonnet, opus])
+    const opus47 = model('anthropic/claude-opus-4-7', { modelName: 'Claude Opus 4.7' })
+    const opus48 = model('anthropic/claude-opus-4-8', { modelName: 'Claude Opus 4.8' })
+    const sorted = sortRecommendedFirst([haiku, sonnet, opus47, opus48])
     expect(sorted.map((o) => o.ref)).toEqual([
       'anthropic/claude-sonnet-4-6',
       'anthropic/claude-haiku-4-5',
       'anthropic/claude-opus-4-7',
+      'anthropic/claude-opus-4-8',
     ])
   })
 

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -115,11 +115,12 @@ describe('listKnownModelRefs', () => {
     expect(refs).toContain('zai-coding/glm-5.1')
   })
 
-  test('includes the current Anthropic GA tier (Haiku 4.5 / Sonnet 4.6 / Opus 4.7)', () => {
+  test('includes the current Anthropic GA tier (Haiku 4.5 / Sonnet 4.6 / Opus 4.7 / Opus 4.8)', () => {
     const refs = listKnownModelRefs()
     expect(refs).toContain('anthropic/claude-haiku-4-5')
     expect(refs).toContain('anthropic/claude-sonnet-4-6')
     expect(refs).toContain('anthropic/claude-opus-4-7')
+    expect(refs).toContain('anthropic/claude-opus-4-8')
   })
 })
 
@@ -130,6 +131,10 @@ describe('providerForModelRef anthropic', () => {
 
   test('routes claude-opus-4-7 to anthropic', () => {
     expect(providerForModelRef('anthropic/claude-opus-4-7')).toBe('anthropic')
+  })
+
+  test('routes claude-opus-4-8 to anthropic', () => {
+    expect(providerForModelRef('anthropic/claude-opus-4-8')).toBe('anthropic')
   })
 })
 
@@ -149,6 +154,7 @@ describe('defaultThinkingLevelForRef', () => {
 
   test('non-OpenAI providers defer to the SDK default (returns undefined)', () => {
     expect(defaultThinkingLevelForRef('anthropic/claude-opus-4-7')).toBeUndefined()
+    expect(defaultThinkingLevelForRef('anthropic/claude-opus-4-8')).toBeUndefined()
     expect(defaultThinkingLevelForRef('anthropic/claude-sonnet-4-6')).toBeUndefined()
     expect(defaultThinkingLevelForRef('anthropic/claude-haiku-4-5')).toBeUndefined()
     expect(defaultThinkingLevelForRef('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')).toBeUndefined()

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -197,10 +197,11 @@ export const KNOWN_PROVIDERS = {
   // anthropic`) before relying on the env-var path. Same rule applies to any
   // future dual-auth provider — keep the surprise in mind when expanding.
   //
-  // Model lineup is the current GA tier as of 2026-04-16: Opus 4.7 (top,
-  // released Apr 16 2026), Sonnet 4.6 (mid, Feb 5 2026), Haiku 4.5 (fast,
-  // Oct 1 2025). Anthropic's own model overview lists these three as the
-  // current recommended set and flags earlier Opus/Sonnet variants with
+  // Model lineup is the current GA tier as of 2026-05-29: Opus 4.8 (top,
+  // released May 2026), Opus 4.7 (prior top, Apr 16 2026), Sonnet 4.6 (mid,
+  // Feb 5 2026), Haiku 4.5 (fast, Oct 1 2025). Anthropic's own model overview
+  // lists the latest Opus/Sonnet/Haiku as the current recommended set and
+  // flags earlier Opus/Sonnet variants with
   // "Consider migrating to current models." Opus 4 / Sonnet 4 are deprecated
   // (retirement: Jun 15 2026); the 4.5/4.6 alternates remain Active but are
   // not the recommended path.
@@ -267,6 +268,18 @@ export const KNOWN_PROVIDERS = {
       'claude-opus-4-7': {
         id: 'claude-opus-4-7',
         name: 'Claude Opus 4.7',
+        api: 'anthropic-messages',
+        provider: 'anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+        contextWindow: 1000000,
+        maxTokens: 128000,
+      },
+      'claude-opus-4-8': {
+        id: 'claude-opus-4-8',
+        name: 'Claude Opus 4.8',
         api: 'anthropic-messages',
         provider: 'anthropic',
         baseUrl: 'https://api.anthropic.com',


### PR DESCRIPTION
## Background

The Anthropic provider lineup in `src/config/providers.ts` topped out at `claude-opus-4-7`. Anthropic has since released **Opus 4.8** as the new top-tier GA model, but it was not registered, so it was unreachable as a model ref (`anthropic/claude-opus-4-8`) — it never appeared in `listKnownModelRefs()`, the init picker, or anywhere a user could select it.

The existing lineup comment (L200-221) already documents the refresh discipline: Opus/Sonnet 4.6+ ids are **PINNED SNAPSHOTS**, not evergreen aliases, so a new Opus family is a real edit here and ships under a new id rather than silently advancing `claude-opus-4-7`. This PR is exactly that edit.

## Summary

Registers `claude-opus-4-8` as a new entry alongside (not replacing) `claude-opus-4-7`, following the pinned-snapshot policy the lineup comment spells out.

- The new entry mirrors the 4.7 shape: `anthropic-messages` API, text+image input, 1M context window, 128k max output, and the same per-token pricing tier (`input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25`).
- **Why keep 4.7:** these ids are fixed snapshots, so 4.8 is additive — existing sessions pinned to 4.7 keep resolving. The lineup comment is updated to reflect 4.8 as the new top with 4.7 as the prior top.
- **Why not mark 4.8 as recommended:** `RECOMMENDED_MODEL_REFS` deliberately keeps Anthropic's recommendation at `claude-sonnet-4-6` (one recommendation per provider, per the comment in `init.ts`). Opus stays a non-recommended opt-in, so it continues to sort below Sonnet in the picker — the existing `sortRecommendedFirst` behavior is preserved.

Test coverage added in the same spots that already guard 4.7: `listKnownModelRefs` membership, `providerForModelRef` routing, `defaultThinkingLevelForRef` classification, and the `sortRecommendedFirst` ordering test.

## What this does NOT do

- Does **not** remove or deprecate `claude-opus-4-7`.
- Does **not** change pricing, context window, or capabilities of any existing model.
- Does **not** promote Opus to the recommended slot — Sonnet 4.6 stays the Anthropic recommendation.
- Does **not** touch the `pi-ai` / `pi-coding-agent` SDK or any provider other than `anthropic`.

## Review notes

- The load-bearing change is the new `claude-opus-4-8` block in `src/config/providers.ts`. Verify the pricing/context/maxTokens fields match Anthropic's published Opus 4.8 table before merge — they are copied from the 4.7 tier as a conservative default and should be confirmed against the official numbers.
- The lineup comment update is intentional, per the documented refresh discipline (pinned snapshot → new id, comment tracks the current top).
- Verification: `bun run lint` (0 errors), `bun run format:check` (clean), `bun typecheck` (0 errors). Full suite passes except one pre-existing, environment-dependent failure — `require-parallel preload > allows bun test --parallel`, which fails identically on `main` under bun 1.3.11 (the guard keys off `BUN_TEST_WORKER_ID`, absent in this bun version) and is unrelated to this change.
