### PR TITLE
agent: drop Korean weekday from the per-turn time anchor

### DIFF
--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -5,7 +5,7 @@ import { formatLocalDateTime, resolveLocalTimezoneName } from '@/shared'
 import { renderTurnTimeAnchor } from './system-prompt'
 
 describe('renderTurnTimeAnchor', () => {
-  test('wraps the ISO timestamp, IANA zone, and weekday pair in a single <current-time> tag', () => {
+  test('wraps the ISO timestamp, IANA zone, and weekday in a single <current-time> tag', () => {
     const now = new Date('2026-01-15T12:00:00+09:00')
 
     const anchor = renderTurnTimeAnchor(now)
@@ -16,21 +16,20 @@ describe('renderTurnTimeAnchor', () => {
     expect(anchor).toContain(`(${resolveLocalTimezoneName()},`)
   })
 
-  test('emits BOTH English and Korean weekday names so a model replying in Korean does not have to translate from English', () => {
+  test('emits the English weekday name (global users get one canonical language, not a localized pair)', () => {
     // Asserting membership in the canonical 7-entry list rather than a
     // specific weekday: the local zone may differ on CI from the
     // zone-agnostic constructor input, so the resolved weekday is not
-    // pinnable. The contract is "both languages present", not "this
-    // specific day".
+    // pinnable. The contract is "an English weekday is present", not
+    // "this specific day".
     const now = new Date('2026-01-15T12:00:00+09:00')
 
     const anchor = renderTurnTimeAnchor(now)
 
-    const koreanDays = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
-    expect(koreanDays.some((d) => anchor.includes(d))).toBe(true)
     const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
     expect(englishDays.some((d) => anchor.includes(d))).toBe(true)
-    expect(anchor).toContain(' / ')
+    const koreanDays = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
+    expect(koreanDays.some((d) => anchor.includes(d))).toBe(false)
   })
 
   test('produces a single-line block with no internal newlines (so prepending `${anchor}\\n\\n${user}` is the only newline boundary)', () => {
@@ -60,10 +59,7 @@ describe('renderTurnTimeAnchor', () => {
     const anchor = renderTurnTimeAnchor(now)
 
     const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
-    const koreanDays = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
     const expectedEn = englishDays[now.getDay()]!
-    const expectedKo = koreanDays[now.getDay()]!
     expect(anchor).toContain(expectedEn)
-    expect(anchor).toContain(expectedKo)
   })
 })

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -151,19 +151,20 @@ TypeClaw runtime version: ${version}.`
 // would already be re-billed on each turn's user message — so this is
 // cache-free relative to the previous "## Now" placement.
 //
-// The block emits both English and Korean weekday names alongside the ISO
-// timestamp because models replying in a non-English language frequently
-// compute weekday-from-ISO incorrectly; pre-computing the weekday in both
-// candidate reply languages removes that arithmetic step entirely. The
-// framing is a single `<current-time>` XML tag for parity with other
-// runtime-injected per-turn blocks the agent already sees
-// (`<system-reminder>` etc.), so the model reads it as a structured anchor
-// rather than as content authored by a human in the chat.
+// The block emits the English weekday name alongside the ISO timestamp
+// because models frequently compute weekday-from-ISO incorrectly;
+// pre-computing it removes that arithmetic step entirely. English only:
+// TypeClaw's users are global, so the anchor uses one canonical language
+// and leaves reply language to each agent's SOUL.md. The framing is a
+// single `<current-time>` XML tag for parity with other runtime-injected
+// per-turn blocks the agent already sees (`<system-reminder>` etc.), so
+// the model reads it as a structured anchor rather than as content
+// authored by a human in the chat.
 export function renderTurnTimeAnchor(now: Date = new Date()): string {
   const iso = formatLocalDateTime(now)
   const zone = resolveLocalTimezoneName()
   const weekday = formatLocalWeekday(now)
-  return `<current-time>${iso} (${zone}, ${weekday.en} / ${weekday.ko})</current-time>`
+  return `<current-time>${iso} (${zone}, ${weekday})</current-time>`
 }
 
 // Compact replacement for DEFAULT_SYSTEM_PROMPT, used by non-interactive

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5849,10 +5849,8 @@ describe('ChannelRouter per-turn wall-clock anchor', () => {
     const close = prompt.indexOf('</current-time>')
     expect(close).toBeGreaterThan(-1)
     const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
-    const koreanDays = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
     const anchor = prompt.slice(0, close + '</current-time>'.length)
     expect(englishDays.some((d) => anchor.includes(d))).toBe(true)
-    expect(koreanDays.some((d) => anchor.includes(d))).toBe(true)
     expect(prompt).toContain('what day is it')
   })
 })

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -24,10 +24,4 @@ export {
   type TunnelSnapshot,
 } from './protocol'
 
-export {
-  formatLocalDate,
-  formatLocalDateTime,
-  formatLocalWeekday,
-  type LocalWeekday,
-  resolveLocalTimezoneName,
-} from './local-time'
+export { formatLocalDate, formatLocalDateTime, formatLocalWeekday, resolveLocalTimezoneName } from './local-time'

--- a/src/shared/local-time.test.ts
+++ b/src/shared/local-time.test.ts
@@ -55,33 +55,25 @@ describe('formatLocalDateTime', () => {
 })
 
 describe('formatLocalWeekday', () => {
-  test('returns matching English + Korean names for every day of the week', () => {
+  test('returns the English name for every day of the week', () => {
     const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
-    const koreanDays = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
     for (let dow = 0; dow < 7; dow++) {
       const d = new Date(2026, 0, 4 + dow, 12, 0, 0)
       expect(d.getDay()).toBe(dow)
-      const result = formatLocalWeekday(d)
-      expect(result.en).toBe(englishDays[dow]!)
-      expect(result.ko).toBe(koreanDays[dow]!)
+      expect(formatLocalWeekday(d)).toBe(englishDays[dow]!)
     }
   })
 
   test('uses today by default when no date argument is given', () => {
     const result = formatLocalWeekday()
-    expect(typeof result.en).toBe('string')
-    expect(typeof result.ko).toBe('string')
-    expect(result.en.length).toBeGreaterThan(0)
-    expect(result.ko.length).toBeGreaterThan(0)
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
   })
 
-  test('the returned names line up with what `Intl.DateTimeFormat` reports for the runtime locale', () => {
+  test('the returned name lines up with what `Intl.DateTimeFormat` reports for en-US', () => {
     const d = new Date(2026, 4, 28, 12, 0, 0)
 
-    const result = formatLocalWeekday(d)
-
-    expect(result.en).toBe(new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(d))
-    expect(result.ko).toBe(new Intl.DateTimeFormat('ko-KR', { weekday: 'long' }).format(d))
+    expect(formatLocalWeekday(d)).toBe(new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(d))
   })
 })
 

--- a/src/shared/local-time.ts
+++ b/src/shared/local-time.ts
@@ -37,34 +37,26 @@ export function resolveLocalTimezoneName(): string {
   }
 }
 
-// English + Korean weekday name pair for a given Date. The per-turn time
-// anchor renders both so the model has the answer to "what day is it"
-// without computing weekday-from-ISO-date — a step LLMs get wrong often
-// enough to matter, especially when answering in a non-English language.
-// Pre-computing in both candidate reply languages removes the arithmetic
-// step entirely instead of trusting the model to do it correctly each
-// turn.
+// English weekday name for a given Date. The per-turn time anchor renders
+// it so the model has the answer to "what day is it" without computing
+// weekday-from-ISO-date — a step LLMs get wrong often enough to matter.
+// Pre-computing the weekday removes the arithmetic step entirely instead
+// of trusting the model to do it correctly each turn. English only:
+// TypeClaw's users are global, so a single canonical language keeps the
+// anchor compact and lets each agent's SOUL.md decide its reply language.
 //
-// Uses Intl.DateTimeFormat with explicit locales. No `timeZone` option:
+// Uses Intl.DateTimeFormat with an explicit locale. No `timeZone` option:
 // the container's local clock is already host-local (the entrypoint
 // propagates TZ via `-e TZ=<host-tz>`), so the runtime's default zone is
-// the one the user sees. Both locales fall back to the hand-rolled
-// 7-entry lookup if Intl throws (no-tzdata, locked-down sandbox) — the
-// fallback names stay readable and never make the prefix empty.
+// the one the user sees. Falls back to the hand-rolled 7-entry lookup if
+// Intl throws (no-tzdata, locked-down sandbox) — the fallback names stay
+// readable and never make the prefix empty.
 const WEEKDAYS_EN = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const
-const WEEKDAYS_KO = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'] as const
 
-export type LocalWeekday = { en: string; ko: string }
-
-export function formatLocalWeekday(date: Date = new Date()): LocalWeekday {
-  const dow = date.getDay()
-  const fallback: LocalWeekday = { en: WEEKDAYS_EN[dow]!, ko: WEEKDAYS_KO[dow]! }
+export function formatLocalWeekday(date: Date = new Date()): string {
   try {
-    return {
-      en: new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(date),
-      ko: new Intl.DateTimeFormat('ko-KR', { weekday: 'long' }).format(date),
-    }
+    return new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(date)
   } catch {
-    return fallback
+    return WEEKDAYS_EN[date.getDay()]!
   }
 }


### PR DESCRIPTION
## Background

The per-turn `<current-time>` anchor injected into every user turn pre-computes the weekday name so the model can answer "what day is it?" without doing error-prone weekday-from-ISO arithmetic. That rationale is language-agnostic — but the prior implementation emitted *two* names, English and Korean:

```
<current-time>2026-01-15T12:00:00+09:00 (Asia/Seoul, Thursday / 목요일)</current-time>
```

The Korean half was a leftover from an early locale assumption that TypeClaw's users were Korean-first. TypeClaw's users are global. Hardcoding a single second language is not justified by the rationale; reply language belongs to each agent's `SOUL.md`, not a runtime-injected anchor.

## Summary

Drops the Korean weekday name from `renderTurnTimeAnchor`. The anchor now emits one canonical English weekday:

```
<current-time>2026-01-15T12:00:00+09:00 (Asia/Seoul, Thursday)</current-time>
```

`formatLocalWeekday` is simplified to return a plain string instead of an `{ en, ko }` pair.
The `LocalWeekday` type and the `WEEKDAYS_KO` fallback table are removed along with it.
The re-export of the now-deleted type from `src/shared/index.ts` is dropped.

## What this does NOT do

- Does not remove the weekday from the anchor or change its purpose — the pre-computation rationale is unchanged.
- Does not change any agent's reply language — that stays in each agent's `SOUL.md`.
- Does not touch any other locale or I18n surface.

## Review notes

- Load-bearing files: `src/shared/local-time.ts` (the `formatLocalWeekday` function) and `src/agent/system-prompt.ts` (`renderTurnTimeAnchor`). The comment block in both has been updated with the English-only/global-users rationale — verify the two stay consistent.
- The `system-prompt.test.ts` change inverts the Korean-presence contract: the test now asserts that *no* Korean weekday appears in the anchor, not merely that an English one does. Tightened, not just updated.
- The `router.test.ts` delta is one deleted line (the Korean-present assertion); the English-present assertion is kept.
- Pre-flight: `bun run typecheck` and `bun run lint` are clean. One pre-existing failure in `update/index.test.ts` reproduces identically on `origin/main` (a worktree-path artifact) and is unrelated to this change.