### PR TITLE
feat(tools): nudge websearch/webfetch to prefer the scout subagent

### DIFF
--- a/src/agent/tools/webfetch/tool.ts
+++ b/src/agent/tools/webfetch/tool.ts
@@ -24,6 +24,7 @@ export const webfetchTool = defineTool({
   description:
     'Fetch a single HTTP(S) URL and return the body, optionally compacted by a strategy. ' +
     'Use this when the user references a specific URL or when websearch surfaced a result you need to read in full. ' +
+    'PREFER delegating to the `scout` subagent by default: spawn it whenever you expect more than one fetch, an "across multiple sources" task, or any search-then-fetch loop. Scout runs the noisy fetching in its own context window and returns a distilled, citation-backed answer, keeping bulky page bodies out of yours. Only call this tool directly for a single known URL whose content you will cite immediately. ' +
     'Outbound requests impersonate Chrome 136 at the TLS, HTTP/2, and header layers ' +
     '(via curl-impersonate), which helps with TLS/header fingerprint gates on sites behind Cloudflare/Akamai. ' +
     'It does NOT solve JavaScript challenges, behavioural fingerprinting (mouse/scroll/timing), interactive CAPTCHAs, ' +

--- a/src/agent/tools/webfetch/tool.ts
+++ b/src/agent/tools/webfetch/tool.ts
@@ -24,7 +24,7 @@ export const webfetchTool = defineTool({
   description:
     'Fetch a single HTTP(S) URL and return the body, optionally compacted by a strategy. ' +
     'Use this when the user references a specific URL or when websearch surfaced a result you need to read in full. ' +
-    'PREFER delegating to the `scout` subagent by default: spawn it whenever you expect more than one fetch, an "across multiple sources" task, or any search-then-fetch loop. Scout runs the noisy fetching in its own context window and returns a distilled, citation-backed answer, keeping bulky page bodies out of yours. Only call this tool directly for a single known URL whose content you will cite immediately. ' +
+    'If `spawn_subagent` is available to you, PREFER delegating to the `scout` subagent by default: spawn it whenever you expect more than one fetch, an "across multiple sources" task, or any search-then-fetch loop. Scout runs the noisy fetching in its own context window and returns a distilled, citation-backed answer, keeping bulky page bodies out of yours. Only call this tool directly for a single known URL whose content you will cite immediately — or whenever you cannot spawn subagents (e.g. you are yourself a subagent), in which case fetch here. ' +
     'Outbound requests impersonate Chrome 136 at the TLS, HTTP/2, and header layers ' +
     '(via curl-impersonate), which helps with TLS/header fingerprint gates on sites behind Cloudflare/Akamai. ' +
     'It does NOT solve JavaScript challenges, behavioural fingerprinting (mouse/scroll/timing), interactive CAPTCHAs, ' +

--- a/src/agent/tools/websearch.ts
+++ b/src/agent/tools/websearch.ts
@@ -21,7 +21,7 @@ export const websearchTool = defineTool({
   label: 'Web Search',
   description:
     'Search the public web. Returns a ranked list of {title, url, snippet} entries. Use `source: "wikipedia"` for encyclopedic lookups; otherwise default to general web results from DuckDuckGo. Pair this with the `read` tool by visiting URLs you find with `bash` (curl) when you need full page contents.\n' +
-    'PREFER delegating to the `scout` subagent by default: spawn it whenever the research is non-trivial (more than 1-2 queries, any "across multiple sources" framing, or follow-up fetches of the results). Scout runs `websearch`/`webfetch` in its own context window and returns a distilled, citation-backed answer, so the search churn never pollutes yours. Only call this tool directly for a single query whose top result you will cite immediately.',
+    'If `spawn_subagent` is available to you, PREFER delegating to the `scout` subagent by default: spawn it whenever the research is non-trivial (more than 1-2 queries, any "across multiple sources" framing, or follow-up fetches of the results). Scout runs `websearch`/`webfetch` in its own context window and returns a distilled, citation-backed answer, so the search churn never pollutes yours. Only call this tool directly for a single query whose top result you will cite immediately — or whenever you cannot spawn subagents (e.g. you are yourself a subagent), in which case run the searches here.',
   parameters: Type.Object({
     query: Type.String({ description: 'The search query.' }),
     limit: Type.Optional(

--- a/src/agent/tools/websearch.ts
+++ b/src/agent/tools/websearch.ts
@@ -20,7 +20,8 @@ export const websearchTool = defineTool({
   name: 'websearch',
   label: 'Web Search',
   description:
-    'Search the public web. Returns a ranked list of {title, url, snippet} entries. Use `source: "wikipedia"` for encyclopedic lookups; otherwise default to general web results from DuckDuckGo. Pair this with the `read` tool by visiting URLs you find with `bash` (curl) when you need full page contents.',
+    'Search the public web. Returns a ranked list of {title, url, snippet} entries. Use `source: "wikipedia"` for encyclopedic lookups; otherwise default to general web results from DuckDuckGo. Pair this with the `read` tool by visiting URLs you find with `bash` (curl) when you need full page contents.\n' +
+    'PREFER delegating to the `scout` subagent by default: spawn it whenever the research is non-trivial (more than 1-2 queries, any "across multiple sources" framing, or follow-up fetches of the results). Scout runs `websearch`/`webfetch` in its own context window and returns a distilled, citation-backed answer, so the search churn never pollutes yours. Only call this tool directly for a single query whose top result you will cite immediately.',
   parameters: Type.Object({
     query: Type.String({ description: 'The search query.' }),
     limit: Type.Optional(


### PR DESCRIPTION
## Background

The runtime already tells the agent to delegate non-trivial web research to the bundled `scout` subagent — but only in the **full** `DEFAULT_SYSTEM_PROMPT` (`src/agent/system-prompt.ts`), which slim/cron/subagent sessions don't get. The `websearch` and `webfetch` tool descriptions themselves said nothing about scout, so at the point of use the model had no local signal to delegate. The result: `websearch`/`webfetch` get called directly in the main session, dumping SERPs and full page bodies into a context window that then carries that raw material forever.

## Summary

Bias delegation at the point of use by adding a short `PREFER ... scout` nudge to both tool descriptions. The threshold mirrors the existing system-prompt language (more than 1-2 queries, any "across multiple sources" framing, or a search-then-fetch loop → spawn scout; a single result/known URL you'll cite immediately → call directly).

Why the tool description and not just the system prompt: descriptions travel with the tool into every session that exposes it (including slim modes), and they sit right where the decision is made. The system-prompt guidance stays as the higher-level orchestration story.

## What this does NOT do

- Does not change tool behavior, parameters, or output — description text only.
- Does not force delegation or remove the direct-call path; the single-result escape hatch is explicit.
- Does not touch the `scout` subagent, the system prompt, or the slim prompt.

## Review notes

- Load-bearing change is purely the two description strings in `src/agent/tools/websearch.ts` and `src/agent/tools/webfetch/tool.ts`. No tests assert on these strings, so nothing in CI pins the wording.
- Threshold wording is intentionally aligned with the existing scout guidance in `DEFAULT_SYSTEM_PROMPT` so the two don't contradict each other.