### PR TITLE
inspect: fix freeze when esc aborts during live-tail connect

### DIFF
--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -49,31 +49,35 @@ export const inspectCommand = defineCommand({
     const escListener = isJson ? null : createEscListener()
     const liveHint = escListener === null ? undefined : escHintLine(color)
 
-    const result = await runInspectLoop({
-      agentDir: cwd,
-      ...(sessionArg !== undefined ? { sessionIdOrPrefix: sessionArg } : {}),
-      ...(filterArg !== undefined ? { filter: filterArg } : {}),
-      ...(sinceArg !== undefined ? { since: sinceArg } : {}),
-      json: isJson,
-      color,
-      selectSession: (sessions, selectOpts) => {
-        escListener?.pause()
-        return clackSelect(sessions, selectOpts?.initialSessionId).finally(() => {
-          escListener?.resume()
-        })
-      },
-      ...(liveSource !== undefined ? { liveSource } : {}),
-      signal,
-      newEscSignal: () => {
-        if (escListener === null) return new AbortController().signal
-        return escListener.armForStream()
-      },
-      ...(liveHint !== undefined ? { liveHint } : {}),
-      stdout: (line) => process.stdout.write(`${line}\n`),
-      stderr: (line) => process.stderr.write(`${line}\n`),
-    })
-
-    escListener?.stop()
+    // try/finally so a thrown loop never leaves the terminal stuck in raw mode.
+    let result: Awaited<ReturnType<typeof runInspectLoop>>
+    try {
+      result = await runInspectLoop({
+        agentDir: cwd,
+        ...(sessionArg !== undefined ? { sessionIdOrPrefix: sessionArg } : {}),
+        ...(filterArg !== undefined ? { filter: filterArg } : {}),
+        ...(sinceArg !== undefined ? { since: sinceArg } : {}),
+        json: isJson,
+        color,
+        selectSession: (sessions, selectOpts) => {
+          escListener?.pause()
+          return clackSelect(sessions, selectOpts?.initialSessionId).finally(() => {
+            escListener?.resume()
+          })
+        },
+        ...(liveSource !== undefined ? { liveSource } : {}),
+        signal,
+        newEscSignal: () => {
+          if (escListener === null) return new AbortController().signal
+          return escListener.armForStream()
+        },
+        ...(liveHint !== undefined ? { liveHint } : {}),
+        stdout: (line) => process.stdout.write(`${line}\n`),
+        stderr: (line) => process.stderr.write(`${line}\n`),
+      })
+    } finally {
+      escListener?.stop()
+    }
 
     if (!result.ok) {
       process.stderr.write(`${errorLine(result.reason)}\n`)

--- a/src/inspect/live.test.ts
+++ b/src/inspect/live.test.ts
@@ -379,6 +379,33 @@ describe('streamLive — live session events', () => {
     expect(String((caught as Error).message)).toContain('invalid')
   })
 
+  test('abort while the websocket is still connecting ends the generator (no hang)', async () => {
+    // Regression: pressing esc during `typeclaw inspect`'s live tail froze the
+    // CLI whenever the abort landed before the socket finished opening. The
+    // abort handler closed the socket and woke the generator loop, but the
+    // `await onOpen` gate never settled, so the generator never reached that
+    // loop — it hung forever and the picker never re-opened (terminal frozen
+    // in raw mode). `onOpen` must settle on abort/close, not only open/error.
+    const FakeWS = makeNeverOpeningWebSocket()
+    const ctrl = new AbortController()
+    const gen = streamLive({
+      url: 'ws://unused',
+      sessionId: 'ses_a',
+      signal: ctrl.signal,
+      WebSocketImpl: FakeWS,
+    })
+
+    const drained = (async () => {
+      const events: InspectEvent[] = []
+      for await (const ev of gen) events.push(ev)
+      return events
+    })()
+    queueMicrotask(() => ctrl.abort())
+
+    const events = await drained
+    expect(events).toEqual([])
+  })
+
   test('unknown server message types are ignored without crashing', async () => {
     // Forward-compat: a future server may add new top-level message `type`
     // values. The client must not crash when it sees one — especially since
@@ -449,6 +476,47 @@ function makeFakeWebSocket(scripted: unknown[]): typeof WebSocket {
         })
       }
     }
+
+    close(): void {
+      this.readyState = 3
+      queueMicrotask(() => this.dispatch('close', {}))
+    }
+
+    private dispatch(type: string, event: unknown): void {
+      const set = this.listeners.get(type)
+      if (set === undefined) return
+      for (const fn of set) fn(event)
+    }
+  }
+  return FakeWS as unknown as typeof WebSocket
+}
+
+// Fake WebSocket stuck in CONNECTING: it never fires `open` or `error` on its
+// own, so the only way out of streamLive's connect gate is abort or close().
+function makeNeverOpeningWebSocket(): typeof WebSocket {
+  class FakeWS {
+    readonly url: string
+    readyState = 0
+    private readonly listeners = new Map<string, Set<(e: unknown) => void>>()
+
+    constructor(url: string) {
+      this.url = url
+    }
+
+    addEventListener(type: string, fn: (e: unknown) => void, _opts?: unknown): void {
+      let set = this.listeners.get(type)
+      if (set === undefined) {
+        set = new Set()
+        this.listeners.set(type, set)
+      }
+      set.add(fn)
+    }
+
+    removeEventListener(type: string, fn: (e: unknown) => void): void {
+      this.listeners.get(type)?.delete(fn)
+    }
+
+    send(_data: string): void {}
 
     close(): void {
       this.readyState = 3

--- a/src/inspect/live.ts
+++ b/src/inspect/live.ts
@@ -63,9 +63,17 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
     }
   })
 
-  const onOpen = new Promise<void>((resolve, reject) => {
-    ws.addEventListener('open', () => resolve(), { once: true })
+  // Settle on open OR on any terminal condition (error/close/abort). Resolving
+  // false here is what unblocks the connect gate when esc aborts mid-connect —
+  // otherwise `await onOpen` would hang forever and freeze the inspect CLI.
+  const onOpen = new Promise<boolean>((resolve, reject) => {
+    ws.addEventListener('open', () => resolve(true), { once: true })
     ws.addEventListener('error', () => reject(new Error('websocket connection failed')), { once: true })
+    ws.addEventListener('close', () => resolve(false), { once: true })
+    if (opts.signal !== undefined) {
+      if (opts.signal.aborted) resolve(false)
+      else opts.signal.addEventListener('abort', () => resolve(false), { once: true })
+    }
   })
   ws.addEventListener('close', () => {
     closed = true
@@ -96,12 +104,14 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
     }
   }
 
+  let opened: boolean
   try {
-    await onOpen
+    opened = await onOpen
   } catch (err) {
     closed = true
     throw err
   }
+  if (!opened || closed || opts.signal?.aborted === true) return
 
   const subscribe: InspectClientMessage = {
     type: 'subscribe',


### PR DESCRIPTION
## Background

Pressing esc during `typeclaw inspect`'s live tail — while the websocket was still in the CONNECTING state — froze the terminal completely. The abort handler correctly closed the socket and called `wake()`, but `wake()` only unblocks the generator's main loop, which lives *after* `await onOpen`. The `onOpen` promise settled only on `'open'` or `'error'`; a close or abort during the connect window left it pending forever.

That hang propagated in a chain: `streamLive()`'s generator never returned → `streamSession()`'s `for await` never completed → `runInspectLoop()` never re-opened the session picker → stdin stayed locked in raw mode under the esc listener. Hard freeze, no recovery without killing the process.

## Summary

**Fix `onOpen` to settle on any terminal condition.** The promise now resolves `true` on `'open'`, rejects on `'error'` (unchanged), and resolves `false` on `'close'` or signal `'abort'` (including an already-aborted signal). After the gate, `streamLive()` returns early if `!opened || closed || signal.aborted` — no subscribe call on a closing socket, no further iteration.

**Why resolve `false` on abort rather than reject?** Rejecting would surface as `"live tail ended: …"` stderr noise. An esc-aborted live tail is a normal exit path, not an error; resolving false keeps it silent and lets the caller end cleanly.

**Defense-in-depth in `inspect.ts`.** The `runInspectLoop()` call is now wrapped in `try/finally { escListener?.stop() }`. Previously `stop()` only ran on the success path; an unexpected throw would have left the terminal stuck in raw mode permanently. This is a secondary guard — the `onOpen` fix eliminates the hang — but it closes the escape hatch for future throws.

**The esc controller (`src/cli/inspect-controller.ts`) is intentionally untouched.** The debounce and abort-signaling layer was already correct.

## What this does NOT do

- Does not change the esc controller or the session-picker flow.
- Does not alter the `'error'`-path behavior: websocket errors still reject and propagate as before.
- Does not add retry logic or surface the abort to the user as a message.

## Review notes

- `src/inspect/live.ts` is the load-bearing change. Verify that the four `onOpen` settlement paths are exhaustive: `'open'` (resolved true), `'error'` (rejected), `'close'` (resolved false), signal `'abort'` (resolved false, with an already-aborted guard for the case where abort fires before listeners attach). The early-return guard after the gate covers all three non-open outcomes (`!opened`, `closed`, `signal.aborted`) — the redundancy is intentional since abort can race with close.
- `src/inspect/live.test.ts` drives a never-opening fake websocket and aborts during CONNECTING. On pre-fix code this test times out at 30 s; post-fix it completes in under 1 ms. TTY-free by design — no pty dependency in CI.
- `src/cli/inspect.ts` only adds the `try/finally` guard; reviewers can treat it as boilerplate.