### PR TITLE
fix(inspect): scope channel inbounds to the watched session

### DIFF
--- a/src/channels/router.inbound-stream.test.ts
+++ b/src/channels/router.inbound-stream.test.ts
@@ -99,6 +99,7 @@ describe('router publishes channel-inbound broadcasts', () => {
     expect(p.authorId).toBe('alice')
     expect(p.text).toBe('hey @bot help me')
     expect(p.isBotMention).toBe(true)
+    expect(p.sessionId).toBe('ses_1')
   })
 
   test('denied inbound publishes with decision=denied (still visible in inspect)', async () => {
@@ -122,6 +123,7 @@ describe('router publishes channel-inbound broadcasts', () => {
     expect(captured).toHaveLength(1)
     const p = captured[0]!.payload as Record<string, unknown>
     expect(p.decision).toBe('denied')
+    expect(p.sessionId).toBeUndefined()
   })
 
   test('observed inbound publishes with decision=observe', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1461,13 +1461,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }, wait)
   }
 
-  const publishInbound = (event: InboundMessage, decision: 'engage' | 'observe' | 'denied' | 'claim'): void => {
+  const publishInbound = (
+    event: InboundMessage,
+    decision: 'engage' | 'observe' | 'denied' | 'claim',
+    // Undefined before a session exists (denied/claim intercepts). Carried so a
+    // session-scoped `typeclaw inspect` only sees its own session's inbounds —
+    // the broadcast otherwise fans out to every inspect client.
+    sessionId?: string,
+  ): void => {
     if (stream === undefined) return
     try {
       stream.publish({
         target: { kind: 'broadcast' },
         payload: {
           kind: 'channel-inbound',
+          ...(sessionId !== undefined ? { sessionId } : {}),
           adapter: event.adapter,
           workspace: event.workspace,
           chat: event.chat,
@@ -1604,7 +1612,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     })
 
     if (decision === 'observe') {
-      publishInbound(event, 'observe')
+      publishInbound(event, 'observe', live.sessionId)
       // Log every observe so an unanswered mention is diagnosable from logs
       // alone instead of "routed but no prompting" silence. The bracketed
       // shape mirrors `prompting batch=` so log scraping can pair them.
@@ -1613,7 +1621,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return
     }
 
-    publishInbound(event, 'engage')
+    publishInbound(event, 'engage', live.sessionId)
 
     updateLoopGuard(live, event)
 

--- a/src/inspect/live.test.ts
+++ b/src/inspect/live.test.ts
@@ -224,6 +224,7 @@ describe('streamLive — live session events', () => {
         target: { kind: 'broadcast' },
         payload: {
           kind: 'channel-inbound',
+          sessionId: 'ses_anything',
           adapter: 'slack',
           workspace: 'acme',
           chat: 'C12345',
@@ -280,6 +281,7 @@ describe('streamLive — live session events', () => {
       target: { kind: 'broadcast' },
       payload: {
         kind: 'channel-inbound',
+        sessionId: 'ses_anything',
         adapter: 'discord',
         workspace: '9999',
         chat: '8888',

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1119,12 +1119,10 @@ function handleInspectMessage(
   ws.data.unsubBroadcast?.()
   ws.data.unsubCron?.()
 
-  const watchedSessionId = msg.sessionId
-
   if (stream !== undefined && typeof msg.sinceMs === 'number') {
     for (const event of stream.scan({ sinceTs: msg.sinceMs, target: { kind: 'broadcast' } })) {
       const payload = broadcastEventToFrame(event)
-      if (!inspectFrameMatchesSession(payload, watchedSessionId)) continue
+      if (!isFrameForWatchedSession(payload, msg.sessionId)) continue
       sendInspect(ws, { type: 'frame', ts: event.ts, payload })
     }
     for (const event of stream.scan({ sinceTs: msg.sinceMs, target: { kind: 'cron' } })) {
@@ -1148,7 +1146,7 @@ function handleInspectMessage(
   if (stream !== undefined) {
     ws.data.unsubBroadcast = stream.subscribe({ target: { kind: 'broadcast' } }, (event) => {
       const payload = broadcastEventToFrame(event)
-      if (!inspectFrameMatchesSession(payload, watchedSessionId)) return
+      if (!isFrameForWatchedSession(payload, msg.sessionId)) return
       sendInspect(ws, { type: 'frame', ts: event.ts, payload })
     })
     ws.data.unsubCron = stream.subscribe({ target: { kind: 'cron' } }, (event) => {
@@ -1181,7 +1179,7 @@ function broadcastEventToFrame(event: StreamMessage): InspectFramePayload {
 // receives every session's inbounds. Drop the ones that don't belong to the
 // session being watched. Non-inbound broadcasts (subagent completions, cron,
 // tunnels) stay global — they carry no session identity here.
-function inspectFrameMatchesSession(payload: InspectFramePayload, watchedSessionId: string): boolean {
+function isFrameForWatchedSession(payload: InspectFramePayload, watchedSessionId: string): boolean {
   if (payload.kind !== 'channel_inbound') return true
   return payload.sessionId === watchedSessionId
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1119,9 +1119,13 @@ function handleInspectMessage(
   ws.data.unsubBroadcast?.()
   ws.data.unsubCron?.()
 
+  const watchedSessionId = msg.sessionId
+
   if (stream !== undefined && typeof msg.sinceMs === 'number') {
     for (const event of stream.scan({ sinceTs: msg.sinceMs, target: { kind: 'broadcast' } })) {
-      sendInspect(ws, { type: 'frame', ts: event.ts, payload: broadcastEventToFrame(event) })
+      const payload = broadcastEventToFrame(event)
+      if (!inspectFrameMatchesSession(payload, watchedSessionId)) continue
+      sendInspect(ws, { type: 'frame', ts: event.ts, payload })
     }
     for (const event of stream.scan({ sinceTs: msg.sinceMs, target: { kind: 'cron' } })) {
       sendInspect(ws, {
@@ -1143,7 +1147,9 @@ function handleInspectMessage(
 
   if (stream !== undefined) {
     ws.data.unsubBroadcast = stream.subscribe({ target: { kind: 'broadcast' } }, (event) => {
-      sendInspect(ws, { type: 'frame', ts: event.ts, payload: broadcastEventToFrame(event) })
+      const payload = broadcastEventToFrame(event)
+      if (!inspectFrameMatchesSession(payload, watchedSessionId)) return
+      sendInspect(ws, { type: 'frame', ts: event.ts, payload })
     })
     ws.data.unsubCron = stream.subscribe({ target: { kind: 'cron' } }, (event) => {
       sendInspect(ws, {
@@ -1171,6 +1177,15 @@ function broadcastEventToFrame(event: StreamMessage): InspectFramePayload {
   }
 }
 
+// Channel inbounds are published as global broadcasts, so every inspect client
+// receives every session's inbounds. Drop the ones that don't belong to the
+// session being watched. Non-inbound broadcasts (subagent completions, cron,
+// tunnels) stay global — they carry no session identity here.
+function inspectFrameMatchesSession(payload: InspectFramePayload, watchedSessionId: string): boolean {
+  if (payload.kind !== 'channel_inbound') return true
+  return payload.sessionId === watchedSessionId
+}
+
 function readChannelInboundBroadcast(payload: unknown): InspectFramePayload | null {
   if (typeof payload !== 'object' || payload === null) return null
   const p = payload as Record<string, unknown>
@@ -1191,6 +1206,7 @@ function readChannelInboundBroadcast(payload: unknown): InspectFramePayload | nu
   if (decision !== 'engage' && decision !== 'observe' && decision !== 'denied' && decision !== 'claim') return null
   return {
     kind: 'channel_inbound',
+    ...(typeof p.sessionId === 'string' ? { sessionId: p.sessionId } : {}),
     adapter: p.adapter,
     workspace: p.workspace,
     chat: p.chat,

--- a/src/server/inspect-ws.test.ts
+++ b/src/server/inspect-ws.test.ts
@@ -238,6 +238,51 @@ describe('/inspect WS handler', () => {
     ws.close()
   })
 
+  test('channel inbounds from a different session are not forwarded; the watched session is', async () => {
+    const stream = createStream()
+    const { url } = await startServer({ stream })
+    const { ws, waitFor, received } = await connectInspect(url)
+    ws.send(JSON.stringify({ type: 'subscribe', sessionId: 'ses_watched' }))
+    await waitFor((m) => m.type === 'subscribed')
+
+    const inbound = (sessionId: string, text: string): void => {
+      stream.publish({
+        target: { kind: 'broadcast' },
+        payload: {
+          kind: 'channel-inbound',
+          sessionId,
+          adapter: 'slack',
+          workspace: 'acme',
+          chat: 'C1',
+          thread: null,
+          authorId: 'U1',
+          authorName: 'alice',
+          authorIsBot: false,
+          isDm: false,
+          isBotMention: true,
+          text,
+          externalMessageId: 'm1',
+          ts: 1_700_000_000_000,
+          decision: 'engage',
+        },
+      })
+    }
+
+    inbound('ses_other', 'leaked from another session')
+    inbound('ses_watched', 'belongs here')
+
+    const frame = await waitFor((m) => m.type === 'frame' && m.payload.kind === 'channel_inbound')
+    if (frame.type !== 'frame' || frame.payload.kind !== 'channel_inbound') throw new Error('unreachable')
+    expect(frame.payload.text).toBe('belongs here')
+
+    const leaked = received.some(
+      (m) =>
+        m.type === 'frame' && m.payload.kind === 'channel_inbound' && m.payload.text === 'leaked from another session',
+    )
+    expect(leaked).toBe(false)
+    ws.close()
+  })
+
   test('Stream cron events forward as cron-fire frames with the jobId surfaced', async () => {
     const stream = createStream()
     const { url } = await startServer({ stream })

--- a/src/server/inspect-ws.test.ts
+++ b/src/server/inspect-ws.test.ts
@@ -283,6 +283,49 @@ describe('/inspect WS handler', () => {
     ws.close()
   })
 
+  test('sinceMs backfill drops channel inbounds from other sessions; the watched session is backfilled', async () => {
+    const stream = createStream()
+    const t0 = Date.now()
+    const inbound = (sessionId: string, text: string): void => {
+      stream.publish({
+        target: { kind: 'broadcast' },
+        payload: {
+          kind: 'channel-inbound',
+          sessionId,
+          adapter: 'slack',
+          workspace: 'acme',
+          chat: 'C1',
+          thread: null,
+          authorId: 'U1',
+          authorName: 'alice',
+          authorIsBot: false,
+          isDm: false,
+          isBotMention: true,
+          text,
+          externalMessageId: 'm1',
+          ts: 1_700_000_000_000,
+          decision: 'engage',
+        },
+      })
+    }
+    inbound('ses_other', 'leaked from another session')
+    inbound('ses_watched', 'belongs here')
+
+    const { url } = await startServer({ stream })
+    const { ws, waitFor, received } = await connectInspect(url)
+    ws.send(JSON.stringify({ type: 'subscribe', sessionId: 'ses_watched', sinceMs: t0 - 1 }))
+    await waitFor((m) => m.type === 'subscribed')
+
+    const inbounds = received.filter(
+      (m): m is Extract<InspectServerMessage, { type: 'frame' }> =>
+        m.type === 'frame' && m.payload.kind === 'channel_inbound',
+    )
+    expect(inbounds).toHaveLength(1)
+    if (inbounds[0]?.payload.kind !== 'channel_inbound') throw new Error('unreachable')
+    expect(inbounds[0].payload.text).toBe('belongs here')
+    ws.close()
+  })
+
   test('Stream cron events forward as cron-fire frames with the jobId surfaced', async () => {
     const stream = createStream()
     const { url } = await startServer({ stream })

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -101,6 +101,10 @@ export type InspectFramePayload =
   // text — no batching, no compose-prompt wrapping.
   | {
       kind: 'channel_inbound'
+      // Channel session this inbound belongs to. Absent for denied/claim
+      // intercepts that fire before a session exists. The inspect server drops
+      // frames whose sessionId does not match the watched session.
+      sessionId?: string
       adapter: string
       workspace: string
       chat: string


### PR DESCRIPTION
## Background

`typeclaw inspect <sessionId>` subscribed to all broadcast stream events and
forwarded every `channel-inbound` frame to the inspect client. Channel inbounds
are published by `publishInbound` in `src/channels/router.ts` as global
broadcasts — no session identity was attached to the payload, and the
`channel_inbound` inspect frame carried no `sessionId` either. The inspect
handler had no information to filter on, so inbounds originating from
_other_ channel sessions leaked into the session being watched. The same
defect affected both the live tail and the `sinceMs` ring-buffer backfill.

Denied/claim intercepts are excluded from the fix: they fire before a session
exists, so they carry no session identity by design.

## Summary

Thread the channel `sessionId` into the inbound broadcast payload and the
`channel_inbound` inspect frame, then filter in `handleInspectMessage` so only
frames whose `sessionId` matches the watched session are forwarded. A new
`inspectFrameMatchesSession` helper applies the filter consistently to both the
live subscription and the `sinceMs` backfill.

Non-inbound broadcasts (subagent completions, cron, tunnels) carry no session
identity and are intentionally left unfiltered — they remain global.

Why add `sessionId` to the payload instead of filtering at the publisher:
publishing is many-to-many; individual consumers choose what to watch. Keeping
broadcasts global and pushing the filter to the subscriber is the pattern the
rest of the inspect system already follows for other frame types.

## What this does NOT do

- Does not filter any non-inbound broadcast type.
- Does not change the engage/observe/denied/claim decision logic.
- Does not make `sessionId` required on `channel_inbound` frames — pre-session
  intercepts (denied, claim) remain session-less; the field is optional.

## Review notes

- Load-bearing change: `inspectFrameMatchesSession` in `src/server/index.ts`.
  Verify it is applied to both the live subscription path _and_ the `sinceMs`
  backfill — not just one of them.
- `publishInbound` in `src/channels/router.ts` now takes a `sessionId`
  parameter. It is threaded through for observe/engage (where a session exists).
  Denied/claim intercept sites are intentionally left untouched.
- Regression test in `src/server/inspect-ws.test.ts`: an inbound arriving for a
  different session must NOT surface to the watcher; the matching-session inbound
  must still surface. That is the primary invariant.
- `src/inspect/live.test.ts` previously encoded the buggy behavior (any inbound
  surfaces regardless of session). Those tests are updated to publish a matching
  `sessionId`; they now test correct behavior.
- Two full-suite failures observed in a temporary worktree are environmental and
  unrelated: `init/dockerfile.test.ts` is a nondeterministic Xvfb timing race
  that passes in isolation, and `update/index.test.ts` fails because the test
  asserts the manifest path ends with `typeclaw/package.json`, which is false
  when running from a worktree with a different directory name. Neither touches
  channels, inspect, or protocol.