### PR TITLE
fix(channels): fence channel tool-result echoes as SYSTEM MESSAGE

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -104,14 +104,16 @@ describe('createChannelReplyTool', () => {
     expect(captured.thread).toBeNull()
   })
 
-  test('reports the origin chat AND echoes the sent text in the success message', async () => {
+  test('reports the origin chat AND echoes the sent text inside the SYSTEM MESSAGE fence', async () => {
     const tool = createChannelReplyTool({
       router: fakeRouter(async () => ({ ok: true })),
       origin: slackThreadOrigin,
     })
     const result = await runTool(tool, { text: 'hi' })
     const text = (result.content[0] as { text: string }).text
-    expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C0: "hi"`)
+    expect(text).toContain('posted to slack-bot:T0/C0: "hi"')
+    expect(text).toContain('**[SYSTEM MESSAGE — not from a human]**')
+    expect(text.startsWith('---')).toBe(true)
   })
 
   test('echoes JSON-quoted text so the model can detect duplicates across iterations', async () => {
@@ -161,19 +163,27 @@ describe('createChannelReplyTool', () => {
     expect(text).toContain(OUTBOUND_FLOOD_ERROR)
   })
 
-  describe('tool-result marker', () => {
-    test('success branch is prefixed with the marker so the model cannot read the echo as a user message', async () => {
+  describe('tool-result framing', () => {
+    // The self-reply loop (PR #481): a persona-rich model read its own
+    // echoed prose as a fresh user turn and replied to it. The weak prefix
+    // was insufficient, so the success result — which carries the model's
+    // own words — must sit inside the strong SYSTEM MESSAGE fence with no
+    // unfenced prose ahead of it.
+    test('success branch wraps the echo in the SYSTEM MESSAGE fence so the model cannot read it as a user message', async () => {
       const tool = createChannelReplyTool({
         router: fakeRouter(async () => ({ ok: true })),
         origin: slackThreadOrigin,
       })
       const result = await runTool(tool, { text: 'hi' })
       const text = (result.content[0] as { text: string }).text
-      expect(text.startsWith(TOOL_RESULT_PREFIX)).toBe(true)
-      expect(text).toContain('not a user message')
+      expect(text.startsWith('---')).toBe(true)
+      expect(text).toContain('**[SYSTEM MESSAGE — not from a human]**')
+      expect(text).toContain('your OWN already-delivered message')
+      expect(text).toContain('Do not acknowledge or reply to it')
+      expect(text).not.toContain(TOOL_RESULT_PREFIX)
     })
 
-    test('denial branch is also prefixed with the marker (same framing for both outcomes)', async () => {
+    test('denial branch keeps the lighter prefix (no echoed prose to misread)', async () => {
       const tool = createChannelReplyTool({
         router: fakeRouter(async () => ({ ok: false, error: 'denied by allow rules' })),
         origin: slackThreadOrigin,
@@ -184,14 +194,15 @@ describe('createChannelReplyTool', () => {
       expect(text).toContain('channel_reply denied')
     })
 
-    test('marker survives the consecutive-send hint (prefix stays at the very start)', async () => {
+    test('fence wraps the echo even when the consecutive-send hint is appended', async () => {
       const tool = createChannelReplyTool({
         router: fakeRouter(async () => ({ ok: true }), { consecutiveCount: 2 }),
         origin: slackThreadOrigin,
       })
       const result = await runTool(tool, { text: 'continuing' })
       const text = (result.content[0] as { text: string }).text
-      expect(text.startsWith(TOOL_RESULT_PREFIX)).toBe(true)
+      expect(text.startsWith('---')).toBe(true)
+      expect(text).toContain('your OWN already-delivered message')
       expect(text).toContain('2nd consecutive message')
     })
   })
@@ -218,6 +229,24 @@ describe('createChannelReplyTool', () => {
     expect(text).toContain('Do not acknowledge or reply to this notice')
     expect(text).toMatch(/---\s*\n\*\*\[SYSTEM MESSAGE/)
     expect(text).toMatch(/Do not acknowledge or reply to this notice\.\*\*\s*\n---/)
+  })
+
+  // PR #481: the model answered its own conversational reply ("you're
+  // welcome!") because the echo of that text reached it with only the weak
+  // prefix. The seductive prose must never appear ahead of the fence — the
+  // model's first token of the tool result must be the fence opener.
+  test('a conversational reply is echoed only INSIDE the fence, never as leading prose', async () => {
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => ({ ok: true })),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, { text: "You're welcome! Happy to help 🌸" })
+    const text = (result.content[0] as { text: string }).text
+    expect(text.startsWith('---\n**[SYSTEM MESSAGE — not from a human]**')).toBe(true)
+    const fenceBodyStart = text.indexOf('**[SYSTEM MESSAGE — not from a human]**')
+    expect(text.indexOf("You're welcome!")).toBeGreaterThan(fenceBodyStart)
+    expect(text).toContain('your OWN already-delivered message')
+    expect(text).toContain('Do not acknowledge or reply to it')
   })
 
   describe('renderEcho', () => {

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -249,6 +249,24 @@ describe('createChannelReplyTool', () => {
     expect(text).toContain('Do not acknowledge or reply to it')
   })
 
+  // The model controls `attachment.filename`, so a conversational filename
+  // ("You're welcome!.txt") is model-authored prose in the result too. The
+  // fence must cover it the same way it covers the text echo — it must never
+  // lead the result as unfenced prose.
+  test('a conversational attachment filename is echoed only INSIDE the fence', async () => {
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => ({ ok: true })),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, {
+      attachments: [{ path: '/agent/a.txt', filename: "You're welcome! Happy to help 🌸.txt" }],
+    })
+    const text = (result.content[0] as { text: string }).text
+    expect(text.startsWith('---\n**[SYSTEM MESSAGE — not from a human]**')).toBe(true)
+    const fenceBodyStart = text.indexOf('**[SYSTEM MESSAGE — not from a human]**')
+    expect(text.indexOf("You're welcome!")).toBeGreaterThan(fenceBodyStart)
+  })
+
   describe('renderEcho', () => {
     test('JSON-quotes short text', () => {
       expect(renderEcho('hi')).toBe('"hi"')

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -10,7 +10,7 @@ import {
 import type { AdapterId } from '@/channels/schema'
 
 import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
-import { fenceRuntimeNotice } from './runtime-notice'
+import { fenceRuntimeNotice, fenceToolResult } from './runtime-notice'
 
 export type ChannelReplyOrigin = {
   adapter: AdapterId
@@ -138,34 +138,37 @@ export function createChannelReplyTool({
       // Without this echo, a model that splits a multi-part reply has no
       // way to tell "did I already send part 1?" from "I haven't started
       // yet", and routinely re-sends near-duplicates within the same turn
-      // (observed in production: two consecutive identical
-      // greeting messages to one prompt).
+      // (observed in production: two consecutive identical greeting messages
+      // to one prompt).
       //
-      // We deliberately do NOT cap sends-per-turn here. A complex user
-      // request legitimately needs split replies, and a hard cap would
-      // mutilate that. The fix is to give the model honest feedback —
-      // show it what it sent, let it decide whether to continue.
-      // Truncate past 500 chars so a long reply doesn't double the prompt
-      // size on every subsequent iteration; the prefix is enough to detect
-      // duplication, and the full text is recoverable from the session
-      // JSONL if needed.
-      const echo = renderOutboundEcho(text, attachments)
-      const baseText = result.ok
-        ? `posted to ${origin.adapter}:${origin.workspace}/${origin.chat}: ${echo}`
-        : `channel_reply denied: ${result.error}`
-      const hint = result.ok
-        ? consecutiveSendHint(
-            router.getConsecutiveSendCount({
-              adapter: origin.adapter,
-              workspace: origin.workspace,
-              chat: origin.chat,
-              thread: origin.thread,
-            }),
-          )
-        : ''
-      const body = hint ? `${baseText}${hint}` : baseText
+      // The echo is the model's OWN words, which is uniquely seductive to
+      // "reply" to, so on the success path we wrap the whole result in the
+      // strong SYSTEM MESSAGE fence (`fenceToolResult`) rather than the weak
+      // `[system: tool result...]` prefix — the prefix did not stop Kimi from
+      // answering its own echo and looping (PR #481). Denials carry no echoed
+      // prose (just machine error text), so they keep the lighter prefix.
+      if (result.ok) {
+        const echo = renderOutboundEcho(text, attachments)
+        const receipt = `posted to ${origin.adapter}:${origin.workspace}/${origin.chat}: ${echo}`
+        const hint = consecutiveSendHint(
+          router.getConsecutiveSendCount({
+            adapter: origin.adapter,
+            workspace: origin.workspace,
+            chat: origin.chat,
+            thread: origin.thread,
+          }),
+        )
+        // Keep fenceToolResult here — do NOT "unify" the success branch back to
+        // TOOL_RESULT_PREFIX to match the denial branch below. The prefix is
+        // intentionally weaker and is safe ONLY because denials carry no echoed
+        // prose; the success result does, and the weak prefix let Kimi loop.
+        return {
+          content: [{ type: 'text' as const, text: `${fenceToolResult(receipt)}${hint}` }],
+          details,
+        }
+      }
       return {
-        content: [{ type: 'text' as const, text: `${TOOL_RESULT_PREFIX}${body}` }],
+        content: [{ type: 'text' as const, text: `${TOOL_RESULT_PREFIX}channel_reply denied: ${result.error}` }],
         details,
       }
     },
@@ -188,6 +191,13 @@ export function renderEcho(text: string): string {
   return `${JSON.stringify(text.slice(0, ECHO_MAX_CHARS))}... (${text.length} chars total)`
 }
 
+// DO NOT remove this echo or replace it with a hash/length-only "receipt" to
+// stop the self-reply loop (PR #481). That trade was tried and rejected: the
+// echo is the model's only view of what it already said (the inbound path
+// drops self-authored messages), so without the FULL text a split reply
+// re-sends near-duplicates — the exact bug 58c62c1 added the echo to fix, and
+// a fingerprint cannot catch paraphrased near-dupes. The loop is solved by
+// FENCING this echo (see fenceToolResult call site below), not by removing it.
 export function renderOutboundEcho(
   text: string | undefined,
   attachments: ReadonlyArray<{ path: string; filename?: string }> | undefined,

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -134,7 +134,10 @@ describe('createChannelSendTool', () => {
       text: 'first reply',
     })
     const text = (result.content[0] as { text: string }).text
-    expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C0: "first reply"`)
+    expect(text).toContain('posted to slack-bot:T0/C0: "first reply"')
+    expect(text.startsWith('---')).toBe(true)
+    expect(text).toContain('**[SYSTEM MESSAGE — not from a human]**')
+    expect(text).not.toContain(TOOL_RESULT_PREFIX)
   })
 
   test('second consecutive send appends a soft yield hint', async () => {
@@ -242,7 +245,8 @@ describe('createChannelSendTool', () => {
         text: 'in thread',
       })
       const text = (result.content[0] as { text: string }).text
-      expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C0: "in thread"`)
+      expect(text).toContain('posted to slack-bot:T0/C0: "in thread"')
+      expect(text).not.toContain('origin thread')
     })
 
     test('does NOT warn when the model deliberately posts to a DIFFERENT chat', async () => {
@@ -257,7 +261,8 @@ describe('createChannelSendTool', () => {
         text: 'cross-channel post',
       })
       const text = (result.content[0] as { text: string }).text
-      expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C-other: "cross-channel post"`)
+      expect(text).toContain('posted to slack-bot:T0/C-other: "cross-channel post"')
+      expect(text).not.toContain('origin thread')
     })
 
     test('does NOT warn when the origin had no thread to begin with (channel-root origin)', async () => {
@@ -272,7 +277,8 @@ describe('createChannelSendTool', () => {
         text: 'channel-root reply',
       })
       const text = (result.content[0] as { text: string }).text
-      expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C0: "channel-root reply"`)
+      expect(text).toContain('posted to slack-bot:T0/C0: "channel-root reply"')
+      expect(text).not.toContain('origin thread')
     })
 
     test('does NOT warn when no origin is supplied (cron / non-channel session)', async () => {
@@ -281,7 +287,8 @@ describe('createChannelSendTool', () => {
       })
       const result = await runTool(tool, { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', text: 'cron post' })
       const text = (result.content[0] as { text: string }).text
-      expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to slack-bot:T0/C0: "cron post"`)
+      expect(text).toContain('posted to slack-bot:T0/C0: "cron post"')
+      expect(text).not.toContain('origin thread')
     })
 
     test('does NOT warn on adapter mismatch (cross-platform post)', async () => {
@@ -296,7 +303,8 @@ describe('createChannelSendTool', () => {
         text: 'cross-platform',
       })
       const text = (result.content[0] as { text: string }).text
-      expect(text).toBe(`${TOOL_RESULT_PREFIX}posted to discord-bot:g1/d1: "cross-platform"`)
+      expect(text).toContain('posted to discord-bot:g1/d1: "cross-platform"')
+      expect(text).not.toContain('origin thread')
     })
 
     test('combines with the consecutive-send hint when both fire', async () => {

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -11,7 +11,7 @@ import { ADAPTER_IDS, type AdapterId } from '@/channels/schema'
 
 import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
 import { renderOutboundEcho, TOOL_RESULT_PREFIX } from './channel-reply'
-import { fenceRuntimeNotice } from './runtime-notice'
+import { fenceRuntimeNotice, fenceToolResult } from './runtime-notice'
 
 export type ChannelSendOrigin = {
   adapter: AdapterId
@@ -154,12 +154,13 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
         )
       }
       const details: { ok: boolean; error?: string } = result.ok ? { ok: true } : { ok: false, error: result.error }
-      const echo = renderOutboundEcho(bodyText, attachments)
-      const baseText = result.ok
-        ? `posted to ${params.adapter}:${params.workspace}/${params.chat}: ${echo}`
-        : `channel_send denied: ${result.error}`
-      const hints: string[] = []
+      // Success wraps the echoed sent text in the strong SYSTEM MESSAGE fence;
+      // denials keep the lighter prefix. See channel-reply.ts for the full
+      // rationale (PR #481 self-reply loop).
       if (result.ok) {
+        const echo = renderOutboundEcho(bodyText, attachments)
+        const receipt = `posted to ${params.adapter}:${params.workspace}/${params.chat}: ${echo}`
+        const hints: string[] = []
         const consecutive = consecutiveSendHint(
           router.getConsecutiveSendCount({
             adapter,
@@ -177,10 +178,14 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
           thread: params.thread,
         })
         if (threadMismatch) hints.push(threadMismatch)
+
+        return {
+          content: [{ type: 'text' as const, text: `${fenceToolResult(receipt)}${hints.join('')}` }],
+          details,
+        }
       }
-      const body = hints.length > 0 ? `${baseText}${hints.join('')}` : baseText
       return {
-        content: [{ type: 'text' as const, text: `${TOOL_RESULT_PREFIX}${body}` }],
+        content: [{ type: 'text' as const, text: `${TOOL_RESULT_PREFIX}channel_send denied: ${result.error}` }],
         details,
       }
     },

--- a/src/agent/tools/runtime-notice.test.ts
+++ b/src/agent/tools/runtime-notice.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { fenceRuntimeNotice } from './runtime-notice'
+import { fenceRuntimeNotice, fenceToolResult } from './runtime-notice'
 
 describe('fenceRuntimeNotice', () => {
   test('wraps body in canonical SYSTEM MESSAGE framing with horizontal-rule fences', () => {
@@ -33,5 +33,30 @@ describe('fenceRuntimeNotice', () => {
     expect(out.split('---').length).toBe(3)
     expect(out.indexOf('**[SYSTEM MESSAGE')).toBeGreaterThan(out.indexOf('---'))
     expect(out.lastIndexOf('---')).toBeGreaterThan(out.indexOf('Do not acknowledge'))
+  })
+})
+
+describe('fenceToolResult', () => {
+  test('begins with the fence opener so no echoed prose can lead the result', () => {
+    const out = fenceToolResult('posted to slack-bot:T0/C0: "You\'re welcome!"')
+
+    expect(out.startsWith('---\n**[SYSTEM MESSAGE — not from a human]**')).toBe(true)
+  })
+
+  test('places the receipt inside the fence and labels it as the model\u2019s own output', () => {
+    const receipt = 'posted to slack-bot:T0/C0: "thanks!"'
+    const out = fenceToolResult(receipt)
+
+    expect(out).toContain(receipt)
+    expect(out.indexOf(receipt)).toBeGreaterThan(out.indexOf('**[SYSTEM MESSAGE'))
+    expect(out).toContain('your OWN already-delivered message')
+    expect(out).toContain('Do not acknowledge or reply to it')
+  })
+
+  test('closes with a horizontal-rule fence (three rules total, like the loop-guard block)', () => {
+    const out = fenceToolResult('any receipt')
+
+    expect(out.split('---').length).toBe(3)
+    expect(out.trimEnd().endsWith('---')).toBe(true)
   })
 })

--- a/src/agent/tools/runtime-notice.ts
+++ b/src/agent/tools/runtime-notice.ts
@@ -39,3 +39,31 @@ export function fenceRuntimeNotice(body: string): string {
     '---'
   )
 }
+
+// Wraps a channel tool result (delivery confirmation + echoed sent text) in the
+// SAME canonical SYSTEM MESSAGE framing as fenceRuntimeNotice — but as the
+// ENTIRE result body, not an appended hint, so there is no unfenced prose for
+// the model to read as conversation.
+//
+// The echoed sent text is load-bearing (the bot has no other view of what it
+// just said — the inbound path drops self-authored messages — so without it a
+// split reply re-sends near-duplicates). But that text is the model's OWN
+// words, which is uniquely seductive to "reply" to: a persona-rich model
+// (Kimi K2 on the GitHub channel, PR #481) read its own delivered prose as a
+// fresh user turn and answered it ("you're welcome!", "aww thanks!") until the
+// per-turn send cap. The weak `[system: tool result...]` prefix did not stop
+// the misread; the full fence — bracketed marker, horizontal-rule fences,
+// explicit "Do not reply" closer — has months of production track record
+// against Kimi (it already wraps the consecutive-send and thread-mismatch
+// hints). Reusing the exact same shape extends that protection to the echo.
+export function fenceToolResult(receipt: string): string {
+  return (
+    '---\n' +
+    '**[SYSTEM MESSAGE — not from a human]**\n\n' +
+    receipt +
+    '\n\nThe text above is your OWN already-delivered message, echoed back so ' +
+    'you can see what you sent — it is NOT a new message from anyone in the ' +
+    'chat. **Do not acknowledge or reply to it.**\n' +
+    '---'
+  )
+}


### PR DESCRIPTION
## Background

The bot kept replying to itself in channel conversations — most visibly on PR #481, where it posted a chain of conversational self-replies ("You're welcome!", "Aww, thanks!", "You're right!"). Reported as "it still responds to self comment."

This is **not** the inbound self-author bug earlier fixes (#452, #460, #462) addressed, and **not** a peer-bot loop. Production logs (`@typeey[bot]`, `github` channel) confirm:

- The webhook self-author drop **works**: `[github] dropped self-authored issue_comment.created from @typeey[bot]` fires for every self-comment, so they never re-prompt the session.
- The peer-bot loop guard only fires on inbound `authorIsBot` messages, so it never sees this.

The `pr:481` session timeline shows only **two** prompts but **ten** sends. Turns 6–10 are conversational self-replies generated **within a single prompt's tool loop**. The model emitted `skip_after_send` reasons like *"user acknowledged with ok"* — but **no user message existed**.

## Root cause

`channel_reply` / `channel_send` echo the delivered message text back to the model as the tool result:

```
[system: tool result, not a user message] posted to github:...: "You're welcome! Happy to help 🌸"
```

The echo is deliberate and load-bearing — it was added in `58c62c1` because the inbound path drops self-authored messages, so without it a model splitting a multi-part reply can't tell "did I already send part 1?" and re-sends near-duplicates.

The problem: the echo is the model's **own words**, and it reached the model with only the **weak** `[system: tool result...]` prefix (`f55fa6e`). Tool results arrive as user-role messages, so a persona-rich model (Kimi K2) read its own delivered prose as a fresh user turn and replied to it — looping until the per-turn send cap.

## Fix

Keep the echo. Wrap the **whole success result** in the **strong** `**[SYSTEM MESSAGE — not from a human]**` fence — bracketed marker, horizontal-rule fences, explicit "do not reply" closer — via a new `fenceToolResult` helper in `runtime-notice.ts`.

This is the same framing already proven against Kimi for the consecutive-send and thread-mismatch hints (`7090935`: *"has been in production against Kimi for months without misread"*). The echo body never got upgraded from the weak prefix to this strong fence — that gap is the bug. The fence is applied as the **entire** result body, so no echoed prose ever leads the message.

Denials keep the lighter prefix (they carry no echoed prose, only machine error text).

## Why fence, not remove the echo

Removing the prose (e.g. a hash/length receipt) would regress the duplicate-send behavior `58c62c1` fixed: a fingerprint catches exact re-sends but not paraphrased near-duplicates, and the model loses its only view of what it said. The codebase's documented, production-tested direction for this exact Kimi failure mode is to **strengthen framing**, not strip content — so this fix extends that proven framing to the echo.

## What this does NOT change

- The per-turn send cap, duplicate guard, `skip_response` lock — all remain as defense-in-depth.
- The inbound self-author drop (`isSelfAuthor`) and peer-bot loop guard — untouched.
- Any engage / observe / denied / claim decision.

## Tests

- `channel-reply.test.ts` / `channel-send.test.ts`: success result now asserted to start with the fence (`---\n**[SYSTEM MESSAGE — not from a human]**`), carry the echo **inside** it, and contain no unfenced leading prose. A PR #481 regression asserts a conversational reply ("You're welcome!") is echoed only inside the fence.
- `runtime-notice.test.ts`: new `fenceToolResult` unit tests (fence opener leads, receipt inside, three-rule shape).
- Full suite: 6030 pass / 1 skip. The single failure (`resolveSelfPackageJsonPath > points at this package manifest`) is the known worktree-dirname artifact — it hardcodes `toEndWith('typeclaw/package.json')` and fails in any worktree not literally named `typeclaw`. Unrelated to this change.

## Review notes

- Load-bearing: `fenceToolResult` in `runtime-notice.ts`, applied to the **success** branch of both `channel_reply` and `channel_send`. The whole bug is that the echo must sit inside the strong fence with no prose ahead of it.
- The branch was rebased onto current `main` (which now includes the merged PR #481).