### PR TITLE
fix(channels): make channel_reply terminal to stop kimi 32k repetition loop

### DIFF
--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -463,6 +463,7 @@ describe('channel manager — reload detects missing tokens and stops adapter', 
         prompts.push(text)
       },
       abort: async () => {},
+      agent: { streamFn: () => undefined, abort: () => {} },
       sessionManager: { getLeafEntry: () => undefined },
       subscribe: () => () => {},
     } as unknown as AgentSession

--- a/src/channels/router.inbound-stream.test.ts
+++ b/src/channels/router.inbound-stream.test.ts
@@ -18,6 +18,10 @@ const baseConfig: ChannelAdapterConfig = {
 }
 
 class FakeSession {
+  agent: { afterToolCall?: unknown; streamFn: unknown; signal?: AbortSignal; abort: () => void } = {
+    streamFn: () => undefined,
+    abort: () => {},
+  }
   prompt = async (): Promise<void> => {}
   abort = async (): Promise<void> => {}
   dispose = (): void => {}

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, writeFile as writeFileFs } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 
+import type { AfterToolCallContext, AfterToolCallResult, StreamFn } from '@mariozechner/pi-agent-core'
 import type { AssistantMessage } from '@mariozechner/pi-ai'
 import type { SessionEntry } from '@mariozechner/pi-coding-agent'
 
@@ -13,6 +14,7 @@ import type { HookBus, SessionIdleEvent } from '@/plugin'
 
 import { channelsSessionsPath, loadChannelSessions, saveChannelSessions } from './persistence'
 import {
+  CHANNEL_MAX_OUTPUT_TOKENS,
   createChannelRouter,
   DUPLICATE_SEND_ERROR,
   MAX_CHANNEL_SENDS_PER_TURN,
@@ -56,14 +58,32 @@ class FakeSession {
   // non-blocking turn terminator for the policy-denial loop guard. A fresh
   // AbortController is installed at the start of every `prompt()` so each turn
   // gets its own run signal (matching pi's per-run AbortController).
-  public agent = {
-    controller: new AbortController(),
-    get signal(): AbortSignal {
-      return this.controller.signal
-    },
-    abort(): void {
-      this.controller.abort()
-    },
+  public lastStreamMaxTokens: number | undefined
+  public agent: {
+    controller: AbortController
+    readonly signal: AbortSignal
+    abort(): void
+    afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>
+    streamFn: StreamFn
+  }
+
+  constructor() {
+    const recordMaxTokens = (maxTokens: number | undefined): void => {
+      this.lastStreamMaxTokens = maxTokens
+    }
+    this.agent = {
+      controller: new AbortController(),
+      get signal(): AbortSignal {
+        return this.controller.signal
+      },
+      abort(): void {
+        this.controller.abort()
+      },
+      streamFn: ((_model, _context, options) => {
+        recordMaxTokens(options?.maxTokens)
+        return undefined as unknown as ReturnType<StreamFn>
+      }) as StreamFn,
+    }
   }
 
   public sessionManager = {
@@ -5852,5 +5872,97 @@ describe('ChannelRouter per-turn wall-clock anchor', () => {
     const anchor = prompt.slice(0, close + '</current-time>'.length)
     expect(englishDays.some((d) => anchor.includes(d))).toBe(true)
     expect(prompt).toContain('what day is it')
+  })
+})
+
+describe('ChannelRouter post-tool follow-up suppression', () => {
+  function afterToolContext(toolName: string, result: { ok: boolean }, isError: boolean): AfterToolCallContext {
+    const toolResult = {
+      content: [{ type: 'text' as const, text: 'ignored' }],
+      details: result,
+    }
+    return {
+      assistantMessage: assistantMessage('') as AfterToolCallContext['assistantMessage'],
+      toolCall: { type: 'toolCall', id: 'tc1', name: toolName, arguments: {} } as AfterToolCallContext['toolCall'],
+      args: {},
+      result: toolResult as AfterToolCallContext['result'],
+      isError,
+      context: { systemPrompt: '', messages: [], tools: [] },
+    }
+  }
+
+  async function liveAgentAfterRoute(dir: string): Promise<FakeSession['agent']> {
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+    return sessions[0]!.agent
+  }
+
+  test('aborts the run after a successful channel_reply so no post-tool follow-up LLM call runs', async () => {
+    // given a live channel session with the terminal hook installed
+    const agent = await liveAgentAfterRoute(await tempDir())
+    expect(agent.afterToolCall).toBeDefined()
+
+    // when channel_reply succeeds (details.ok === true, not an error)
+    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, false))
+
+    // then the run's abort signal is fired — the follow-up stream sees it aborted
+    expect(agent.signal.aborted).toBe(true)
+  })
+
+  test('does NOT abort when channel_reply was rejected (details.ok === false)', async () => {
+    const agent = await liveAgentAfterRoute(await tempDir())
+    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: false }, false))
+    expect(agent.signal.aborted).toBe(false)
+  })
+
+  test('does NOT abort when channel_reply tool result is an error', async () => {
+    const agent = await liveAgentAfterRoute(await tempDir())
+    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, true))
+    expect(agent.signal.aborted).toBe(false)
+  })
+
+  test('does NOT abort after a read-only tool so genuine multi-step turns continue', async () => {
+    const agent = await liveAgentAfterRoute(await tempDir())
+    await agent.afterToolCall!(afterToolContext('read', { ok: true }, false))
+    expect(agent.signal.aborted).toBe(false)
+  })
+
+  test('does NOT abort after a successful channel_send (only channel_reply is terminal)', async () => {
+    const agent = await liveAgentAfterRoute(await tempDir())
+    await agent.afterToolCall!(afterToolContext('channel_send', { ok: true }, false))
+    expect(agent.signal.aborted).toBe(false)
+  })
+})
+
+describe('ChannelRouter output-token cap', () => {
+  async function invokeStream(session: FakeSession, options: { maxTokens?: number } | undefined): Promise<void> {
+    await session.agent.streamFn(
+      {} as Parameters<StreamFn>[0],
+      { systemPrompt: '', messages: [], tools: [] } as Parameters<StreamFn>[1],
+      options as Parameters<StreamFn>[2],
+    )
+  }
+
+  test('caps output tokens at CHANNEL_MAX_OUTPUT_TOKENS when the caller left maxTokens unset', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    await invokeStream(sessions[0]!, undefined)
+
+    expect(sessions[0]!.lastStreamMaxTokens).toBe(CHANNEL_MAX_OUTPUT_TOKENS)
+  })
+
+  test('does not override an explicit per-call maxTokens', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    await invokeStream(sessions[0]!, { maxTokens: 256 })
+
+    expect(sessions[0]!.lastStreamMaxTokens).toBe(256)
   })
 })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -117,6 +117,18 @@ export const MAX_CHANNEL_SENDS_PER_TURN = 10
 // same-tick duplicate/cap denials) is never mistaken for a loop. Reset at turn
 // start alongside `turnSeq`.
 export const MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN = 3
+// Per-request output-token cap for channel sessions, threaded into the agent's
+// stream options to override pi-ai's silent `Math.min(model.maxTokens, 32000)`
+// default (`buildBaseOptions` in @mariozechner/pi-ai). Without it, Fireworks'
+// kimi-k2p6-turbo — which degenerates into single-token repetition on the
+// post-tool follow-up turn — runs the full 32000 tokens (~116s of garbage that
+// never produces a reply) before `stopReason: 'length'`. The terminal-reply
+// hook below removes the turn that triggers this; the cap bounds any other path
+// that still reaches a channel LLM call. 4096 fits a thinking block plus a
+// nontrivial reply (healthy channel turns observed at ~317 output tokens
+// including reasoning). Deliberately NOT lowered in `providers.ts`, where
+// `maxTokens` is the model's true capability that compaction math reads.
+export const CHANNEL_MAX_OUTPUT_TOKENS = 4096
 // Rolling window for outbound send-rate telemetry. 5s matches Discord's
 // rate-limit shape (5 msg / 5 s / channel) and comfortably covers Slack's
 // 1 msg/s sustained. The window is observational; exceeding the burst
@@ -1059,6 +1071,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         logger.error(`[channels] ${live.keyId}: LLM call failed: ${err.message}`)
       })
       live.unsubTypingActivity = subscribeTypingActivity(created.session, live)
+      installChannelReplyTerminalHook(live)
+      installChannelOutputCap(live)
       liveSessions.set(keyId, live)
 
       if (isColdStart) {
@@ -1214,6 +1228,54 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       if (event.type !== 'tool_execution_end') return
       bumpTypingActivity(live)
     })
+  }
+
+  // After a successful `channel_reply`, the model has delivered its user-facing
+  // response and the turn is semantically done. pi-agent-core's loop, however,
+  // unconditionally makes one more LLM call after any tool result (the
+  // "post-tool follow-up") to let multi-step tool chains continue. On a turn
+  // that ended with `channel_reply` there is nothing left to say, and Fireworks'
+  // kimi-k2p6-turbo degenerates that empty follow-up into a 32000-token
+  // repetition loop (see CHANNEL_MAX_OUTPUT_TOKENS). Aborting the run's signal
+  // from `afterToolCall` — which runs during tool execution, before the loop
+  // re-enters the LLM stream — makes the follow-up stream observe an already-
+  // aborted signal and return `stopReason: 'aborted'` without generating. This
+  // is the same `agent.abort()` lever the policy-denied-send cap uses; the
+  // tool's own result is already persisted, so the reply still lands.
+  //
+  // Scope is deliberately narrow: only `channel_reply` (the current-chat user-
+  // facing response), only on success, and only for channel sessions. Read-only
+  // tools and `channel_send` must keep the follow-up so genuine multi-step turns
+  // continue. A prior non-typeclaw `afterToolCall` (none today) would be
+  // composed, not clobbered.
+  const installChannelReplyTerminalHook = (live: LiveSession): void => {
+    const { agent } = live.session
+    const prior = agent.afterToolCall
+    agent.afterToolCall = async (context, signal) => {
+      const result = prior ? await prior(context, signal) : undefined
+      const succeeded =
+        context.toolCall.name === 'channel_reply' &&
+        !context.isError &&
+        (context.result.details as { ok?: unknown } | undefined)?.ok === true
+      if (succeeded && agent.signal?.aborted !== true) {
+        logger.info(`[channels] ${live.keyId} terminal_after_channel_reply`)
+        agent.abort()
+      }
+      return result
+    }
+  }
+
+  // Override pi-ai's hidden `Math.min(model.maxTokens, 32000)` output cap for
+  // channel sessions by threading an explicit `maxTokens` into every stream
+  // call. See CHANNEL_MAX_OUTPUT_TOKENS for why. Composes the existing streamFn
+  // (pi's default `streamSimple` unless a proxy was installed) and only fills
+  // `maxTokens` when the caller left it unset, so an explicit per-call value
+  // still wins.
+  const installChannelOutputCap = (live: LiveSession): void => {
+    const { agent } = live.session
+    const inner = agent.streamFn
+    agent.streamFn = (model, context, options) =>
+      inner(model, context, { ...options, maxTokens: options?.maxTokens ?? CHANNEL_MAX_OUTPUT_TOKENS })
   }
 
   const startTypingHeartbeat = (live: LiveSession): void => {


### PR DESCRIPTION
## Problem

On KakaoTalk group chats, the agent intermittently goes silent for ~116s and never answers an inbound message. Production session transcripts show the failing turn has `stopReason: "length"`, `usage.output: 32000`, and text content that is a single garbage token repeated thousands of times. The head of that garbage is an `(Empty response: {...})` sentinel whose embedded thinking says *"I already replied… Turn is complete."*

### Root cause

The model successfully calls `channel_reply`, but pi-agent-core's loop then makes an **unconditional post-tool follow-up LLM call** (the loop re-enters `streamAssistantResponse` after any tool result, to let multi-step tool chains continue). On a turn that already delivered its reply the model has nothing left to say, and Fireworks' `kimi-k2p6-turbo` degenerates that empty follow-up into a single-token repetition loop.

Two things make it bad:
1. **No early stop.** The follow-up is unconditional, so the degenerate turn always happens after a reply.
2. **No real output cap.** pi-ai silently caps output at `Math.min(model.maxTokens, 32000)` only because typeclaw passes no explicit `maxTokens`; the loop runs the full 32000 tokens (~116s) before stopping.

KakaoTalk hits this far more than Discord because group chat drives many more tool→follow-up cycles; Discord short-circuits earlier (`skip_after_send`).

## Fix (two layers)

**Layer 1 — make `channel_reply` terminal for channel sessions.** An `afterToolCall` hook aborts the run when `channel_reply` succeeds. `afterToolCall` runs during tool execution, *before* the loop re-enters the LLM stream, so the follow-up observes an already-aborted signal and returns `stopReason: "aborted"` without generating. This removes the turn that triggers the bug. Scope is deliberately narrow: only `channel_reply`, only on success (`details.ok === true`, not an error), and only channel sessions — read-only tools and `channel_send` keep the follow-up so genuine multi-step turns continue. Uses the same `agent.abort()` lever as the existing policy-denied-send cap.

**Layer 2 — explicit output cap (defense in depth).** Thread `maxTokens: 4096` into channel stream options to override pi-ai's hidden 32000 default, so any other path that still reaches a channel LLM call cannot burn 32k tokens. 4096 fits a thinking block plus a nontrivial reply (healthy channel turns observed at ~317 output tokens including reasoning). The model's `maxTokens` in `providers.ts` is left truthful — compaction math reads it.

## Tests

- `channel_reply` success aborts the run; rejected reply (`details.ok === false`), errored reply, read-only tool, and `channel_send` do **not** abort.
- The output cap is injected when the caller leaves `maxTokens` unset, and an explicit per-call `maxTokens` still wins.
- Updated the minimal `FakeSession` mocks in `manager.test.ts` and `router.inbound-stream.test.ts` to expose the `agent` surface the router now depends on.

## Verification

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and the channel test suites all pass. (One unrelated test, `resolveSelfPackageJsonPath`, fails only because the worktree dir isn't named `typeclaw/`; it passes in a normal checkout.)
