### PR TITLE
fix(channels): let channel_reply opt out of turn-termination via `continue`

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -338,6 +338,44 @@ describe('createChannelReplyTool', () => {
     expect(tool.description).toContain('default way to respond')
   })
 
+  describe('continue flag (mid-turn status reply)', () => {
+    test('surfaces continue: true in details so the router keeps the turn alive', async () => {
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async () => ({ ok: true })),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, { text: 'working on it…', continue: true })
+      expect(result.details).toEqual({ ok: true, continue: true })
+    })
+
+    test('omits continue from details by default so the reply stays terminal', async () => {
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async () => ({ ok: true })),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, { text: 'done' })
+      expect(result.details).toEqual({ ok: true })
+    })
+
+    test('continue: false stays terminal (only true keeps the turn alive)', async () => {
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async () => ({ ok: true })),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, { text: 'done', continue: false })
+      expect(result.details).toEqual({ ok: true })
+    })
+
+    test('a denied reply never carries continue (no turn to keep alive)', async () => {
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async () => ({ ok: false, error: 'denied by allow rules' })),
+        origin: slackThreadOrigin,
+      })
+      const result = await runTool(tool, { text: 'nope', continue: true })
+      expect(result.details).toEqual({ ok: false, error: 'denied by allow rules' })
+    })
+  })
+
   describe('attachments', () => {
     test('forwards attachments and text to router.send', async () => {
       const calls: OutboundMessage[] = []

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -71,11 +71,20 @@ export function createChannelReplyTool({
           },
         ),
       ),
+      continue: Type.Optional(
+        Type.Boolean({
+          description:
+            'Set `true` ONLY when this reply is a mid-turn status update (e.g. "working on it…") and you still have work to do THIS turn — fetching data, running a tool, spawning a subagent, then replying again. ' +
+            'A normal reply omits this: by default a successful reply ends the turn (no wasted follow-up LLM call). ' +
+            'Do not set it just to seem responsive; only when genuine multi-step work follows in the same turn.',
+        }),
+      ),
     }),
 
     async execute(_toolCallId, params) {
       const text = params.text
       const attachments = params.attachments
+      const keepTurnAlive = params.continue === true
       if ((text === undefined || text === '') && (attachments === undefined || attachments.length === 0)) {
         logger.warn(formatChannelToolFailure('channel_reply', 'missing text and attachments'))
         return {
@@ -130,7 +139,14 @@ export function createChannelReplyTool({
           ),
         )
       }
-      const details: { ok: boolean; error?: string } = result.ok ? { ok: true } : { ok: false, error: result.error }
+      // `continue` is read by the router's terminal hook (installChannelReplyTerminalHook),
+      // not by this tool — it suppresses the post-reply abort so a multi-step turn
+      // keeps going. Success-only: a denied reply never ran, so there is no turn to keep.
+      const details: { ok: boolean; error?: string; continue?: boolean } = result.ok
+        ? keepTurnAlive
+          ? { ok: true, continue: true }
+          : { ok: true }
+        : { ok: false, error: result.error }
       // Echo the delivered text back to the model. The adapter classifier
       // drops self-authored messages on the inbound path (`self_author`),
       // so the bot otherwise has ZERO visibility into what it just said —

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5876,7 +5876,11 @@ describe('ChannelRouter per-turn wall-clock anchor', () => {
 })
 
 describe('ChannelRouter post-tool follow-up suppression', () => {
-  function afterToolContext(toolName: string, result: { ok: boolean }, isError: boolean): AfterToolCallContext {
+  function afterToolContext(
+    toolName: string,
+    result: { ok: boolean; continue?: boolean },
+    isError: boolean,
+  ): AfterToolCallContext {
     const toolResult = {
       content: [{ type: 'text' as const, text: 'ignored' }],
       details: result,
@@ -5908,6 +5912,12 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
 
     // then the run's abort signal is fired — the follow-up stream sees it aborted
     expect(agent.signal.aborted).toBe(true)
+  })
+
+  test('does NOT abort when channel_reply opts out with continue: true', async () => {
+    const agent = await liveAgentAfterRoute(await tempDir())
+    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true, continue: true }, false))
+    expect(agent.signal.aborted).toBe(false)
   })
 
   test('does NOT abort when channel_reply was rejected (details.ok === false)', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1248,16 +1248,22 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // tools and `channel_send` must keep the follow-up so genuine multi-step turns
   // continue. A prior non-typeclaw `afterToolCall` (none today) would be
   // composed, not clobbered.
+  //
+  // `channel_reply({ continue: true })` is the explicit opt-out: a mid-turn
+  // status reply ("working on it…") that the model follows with more work this
+  // turn. The tool surfaces that intent as `details.continue === true`, and we
+  // keep the follow-up so the turn proceeds. The kimi 32k loop only recurs when
+  // the model genuinely has nothing left to say after a reply, which `continue`
+  // asserts is not the case; Layer 2's maxTokens cap still bounds any misuse.
   const installChannelReplyTerminalHook = (live: LiveSession): void => {
     const { agent } = live.session
     const prior = agent.afterToolCall
     agent.afterToolCall = async (context, signal) => {
       const result = prior ? await prior(context, signal) : undefined
-      const succeeded =
-        context.toolCall.name === 'channel_reply' &&
-        !context.isError &&
-        (context.result.details as { ok?: unknown } | undefined)?.ok === true
-      if (succeeded && agent.signal?.aborted !== true) {
+      const details = context.result.details as { ok?: unknown; continue?: unknown } | undefined
+      const succeeded = context.toolCall.name === 'channel_reply' && !context.isError && details?.ok === true
+      const keepTurnAlive = details?.continue === true
+      if (succeeded && !keepTurnAlive && agent.signal?.aborted !== true) {
         logger.info(`[channels] ${live.keyId} terminal_after_channel_reply`)
         agent.abort()
       }

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -9,6 +9,10 @@ GitHub renders normal Markdown in issues, PRs, discussions, and review comments.
 - There is no typing indicator.
 - For PR review threads, keep `thread` set to reply in-place. Omit `thread` for a top-level PR/issue comment.
 
+## Mid-turn status replies need `continue: true`
+
+A successful `channel_reply` ends your turn by default — the runtime stops the model right after the reply lands. That is correct for a final answer, but it will **silently truncate** a turn that still has work to do. If you post a status line like "Reviewing now, I'll be back with findings" and then expect to keep working (fetch the diff, spawn the reviewer, post the review) in the **same** turn, you must call `channel_reply({ text: "…", continue: true })`. Without `continue: true`, the turn ends at that status reply and the review never runs. Reserve `continue: true` for genuine multi-step turns; the final reply that wraps up the turn omits it.
+
 ## Opening new issues and PRs
 
 The `gh` CLI is pre-authenticated via `GH_TOKEN` (injected by the adapter at startup). Use it to open new issues or PRs:
@@ -38,6 +42,8 @@ Why delegate: the `reviewer` subagent runs on the `deep` model profile, loads a 
    ```
 
 2. **Spawn the `reviewer` subagent with the PR target.** Use `run_in_background: true` so you stay responsive while the deep model works. Pass the PR URL (or `owner/repo#N`) plus any context the requester gave you (focus areas, specific files, etc.) so the reviewer knows what the requester cares about.
+
+   If you post an "on it" acknowledgement before fetching the diff or spawning the reviewer, it **must** be `channel_reply({ text: "…", continue: true })` — a bare reply ends the turn and the review never starts (see "Mid-turn status replies need `continue: true`" above).
 
    The reviewer will fetch the diff itself (`gh pr diff`, `gh api /repos/.../pulls/<n>`), load the matching skill (`code-review` for a code PR; `general` for a mixed-format change), and return a `<review>` block.
 


### PR DESCRIPTION
## Problem

#484 made a successful `channel_reply` **terminal** — it fires `agent.abort()` from the `afterToolCall` hook so pi-agent-core's unconditional post-tool follow-up LLM call never runs, which stops Fireworks `kimi-k2p6-turbo` from degenerating that empty follow-up into a 32000-token repetition loop. That was the right call for the loop, but it bakes in an assumption:

> a successful `channel_reply` is the last thing the turn wants to do.

That holds for conversational replies (reply → done). It **breaks any multi-step turn that posts a status line first.**

### Production symptom

The GitHub PR-review flow is exactly that shape. The `typeclaw-channel-github` / `code-review` skills tell the agent to:

1. `channel_reply` "Reviewing now, I'll be back with findings"
2. fetch the diff, spawn the `reviewer` subagent, post the review via `gh api`
3. `channel_reply` a one-line summary

Under #484 the turn dies at step 1. Observed live (~17 min after #484 shipped as 0.15.1): a re-review request produced only the "Re-reviewing now! Let me fetch the latest diff…" preamble, then `stopReason: aborted`, `usage: 0/0`. The review never ran. The session transcript shows the empty assistant turn immediately after the successful `channel_reply` tool result, and the container logged `terminal_after_channel_reply`.

The two parts of the system now contradict each other:
- **router / #484:** "a successful `channel_reply` ends the turn"
- **github + code-review skills:** "reply with a status line, *then* keep working"

## Fix

An explicit, opt-in escape hatch — not a widening or removal of the terminal hook.

- **`channel_reply` gains an optional `continue` param.** On success it surfaces `details.continue === true`. The terminal hook reads that and skips the abort, so the follow-up proceeds and the turn keeps going. Default is unchanged: a bare `channel_reply` is still terminal, so the kimi loop fix from #484 is fully preserved for ordinary replies.
- **Why this is safe re: the original bug.** The 32k loop only recurs when the model genuinely has nothing left to say after a reply. `continue: true` is the model asserting the opposite (real multi-step work follows), where the follow-up is *wanted*. Layer 2's `maxTokens: 4096` cap from #484 still bounds the blast radius if a model misuses the flag.
- **Skill update.** `typeclaw-channel-github` documents the rule ("Mid-turn status replies need `continue: true`") and the review workflow points the "on it" acknowledgement at `channel_reply({ continue: true })`.

## Scope

`continue` is success-only — a denied reply never ran, so there's no turn to keep alive. It's threaded into `details` (read by the router, not the tool). No new tool surface, no stream-path changes.

## Tests

- **Tool** (`channel-reply.test.ts`): `continue: true` → `details.continue === true`; `continue` omitted / `continue: false` → terminal (no `continue` in details); a denied reply never carries `continue`.
- **Hook** (`router.test.ts`): `channel_reply` with `continue: true` does **not** abort the run; existing five cases (success aborts, rejected/errored/read-only/`channel_send` don't) still hold.

## Verification

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, `bun run test` all pass. (The one unrelated failure, `resolveSelfPackageJsonPath`, fails only because the dev worktree dir isn't named `typeclaw/` — same caveat #484 noted; passes in a normal checkout.)