### PR TITLE
fix(inspect): fix keyboard handling in live view and picker

### DIFF
--- a/src/cli/inspect.test.ts
+++ b/src/cli/inspect.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test'
+import { EventEmitter } from 'node:events'
+
+import { createEscListener } from './inspect'
+
+function tick(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+class FakeTty extends EventEmitter {
+  isTTY = true as const
+  rawMode = false
+  resumed = false
+  setRawMode(value: boolean): this {
+    this.rawMode = value
+    return this
+  }
+  resume(): this {
+    this.resumed = true
+    return this
+  }
+  pause(): this {
+    this.resumed = false
+    return this
+  }
+  feed(bytes: number[]): void {
+    this.emit('data', Buffer.from(bytes))
+  }
+}
+
+describe('createEscListener wiring', () => {
+  test('returns null when the input is not a TTY', () => {
+    const tty = new FakeTty()
+    tty.isTTY = false as unknown as true
+    expect(createEscListener(() => {}, tty as never)).toBeNull()
+  })
+
+  test('Ctrl-C byte invokes onSigint directly (no SIGINT round-trip)', () => {
+    // given: an armed listener on a fake TTY
+    const tty = new FakeTty()
+    let sigints = 0
+    const listener = createEscListener(() => {
+      sigints += 1
+    }, tty as never)!
+    listener.armForStream()
+    // when: the raw 0x03 byte arrives during the live tail
+    tty.feed([0x03])
+    // then: the exit callback fires straight away
+    expect(sigints).toBe(1)
+    listener.stop()
+  })
+
+  test('bare ESC aborts the per-stream signal without touching onSigint', async () => {
+    // given: an armed listener that records sigint calls
+    const tty = new FakeTty()
+    let sigints = 0
+    const listener = createEscListener(() => {
+      sigints += 1
+    }, tty as never)!
+    const escSignal = listener.armForStream()
+    // when: a bare ESC arrives and the debounce window elapses
+    tty.feed([0x1b])
+    await tick(80)
+    // then: only the per-stream esc signal aborts; the exit path is untouched
+    expect(escSignal.aborted).toBe(true)
+    expect(sigints).toBe(0)
+    listener.stop()
+  })
+
+  test('listener attaches its data handler before resuming the stream', () => {
+    const tty = new FakeTty()
+    const order: string[] = []
+    tty.on('newListener', (event) => {
+      if (event === 'data') order.push('listen')
+    })
+    const origResume = tty.resume.bind(tty)
+    tty.resume = function patchedResume(this: FakeTty) {
+      order.push('resume')
+      return origResume()
+    }
+    const listener = createEscListener(() => {}, tty as never)!
+    listener.armForStream()
+    expect(order).toEqual(['listen', 'resume'])
+    listener.stop()
+  })
+})

--- a/src/cli/inspect.test.ts
+++ b/src/cli/inspect.test.ts
@@ -83,4 +83,27 @@ describe('createEscListener wiring', () => {
     expect(order).toEqual(['listen', 'resume'])
     listener.stop()
   })
+
+  test('pause() hands stdin to the picker: raw mode off, listener detached, stream still flowing', () => {
+    // given: an armed listener (raw mode on, our data handler attached)
+    const tty = new FakeTty()
+    let sigints = 0
+    const listener = createEscListener(() => {
+      sigints += 1
+    }, tty as never)!
+    listener.armForStream()
+    expect(tty.rawMode).toBe(true)
+    expect(tty.listenerCount('data')).toBe(1)
+    // when: the picker takes over and we pause the listener
+    listener.pause()
+    // then: raw mode is released and our handler is gone so clack can own input,
+    //       but the stream is NOT paused — otherwise clack never receives bytes
+    expect(tty.rawMode).toBe(false)
+    expect(tty.listenerCount('data')).toBe(0)
+    expect(tty.resumed).toBe(true)
+    // and: bytes arriving while the picker owns input never reach our callback
+    tty.feed([0x03])
+    expect(sigints).toBe(0)
+    listener.stop()
+  })
 })

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -45,8 +45,12 @@ export const inspectCommand = defineCommand({
 
     const isJson = args.json === true
     const liveSource = isJson ? undefined : await buildLiveSource(cwd)
-    const signal = installSigintAbort()
-    const escListener = isJson ? null : createEscListener()
+    const signalCtrl = installSigintAbort()
+    const signal = signalCtrl.signal
+    // Raw-mode Ctrl-C arrives as byte 0x03 and must abort the exit controller
+    // directly: under Bun a self-issued process.kill(SIGINT) does not reliably
+    // re-enter our process.once('SIGINT') handler, so the live tail never exits.
+    const escListener = isJson ? null : createEscListener(() => signalCtrl.abort())
     const liveHint = escListener === null ? undefined : escHintLine(color)
 
     // try/finally so a thrown loop never leaves the terminal stuck in raw mode.
@@ -108,14 +112,14 @@ async function buildLiveSource(cwd: string): Promise<LiveSourceFactory | undefin
     })
 }
 
-function installSigintAbort(): AbortSignal {
+function installSigintAbort(): AbortController {
   const ctrl = new AbortController()
   const onSig = (): void => {
     ctrl.abort()
   }
   process.once('SIGINT', onSig)
   process.once('SIGTERM', onSig)
-  return ctrl.signal
+  return ctrl
 }
 
 type EscListener = {
@@ -125,8 +129,10 @@ type EscListener = {
   stop: () => void
 }
 
-function createEscListener(): EscListener | null {
-  const stdin = process.stdin
+type RawInput = Pick<NodeJS.ReadStream, 'isTTY' | 'setRawMode' | 'resume' | 'pause' | 'on' | 'off'>
+
+export function createEscListener(onSigint: () => void, input: RawInput = process.stdin): EscListener | null {
+  const stdin = input
   if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') return null
 
   const ctrl = createEscController({ debounceMs: ESC_LISTEN_DELAY_MS })
@@ -134,15 +140,17 @@ function createEscListener(): EscListener | null {
 
   const onData = (chunk: Buffer): void => {
     const { sigint } = ctrl.onChunk(chunk)
-    if (sigint) process.kill(process.pid, 'SIGINT')
+    if (sigint) onSigint()
   }
 
   const start = (): void => {
     if (active) return
     active = true
     stdin.setRawMode(true)
-    stdin.resume()
+    // Attach the data handler before resume() so no raw-mode keystroke can slip
+    // through between resuming the stream and registering the listener.
     stdin.on('data', onData)
+    stdin.resume()
   }
   const stop = (): void => {
     if (!active) return

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -161,7 +161,10 @@ export function createEscListener(onSigint: () => void, input: RawInput = proces
     } catch {
       /* terminal already torn down */
     }
-    stdin.pause()
+    // Do NOT pause stdin here: this teardown hands control to the clack picker,
+    // and under Bun clack does not reliably re-flow a previously paused
+    // process.stdin, so its keypresses never arrive and arrow keys echo as raw
+    // bytes. Leaving the stream flowing lets clack own raw mode during the picker.
     ctrl.clearPending()
   }
 


### PR DESCRIPTION
## Background

`typeclaw inspect` has two keyboard-handling bugs in the live tail, both rooted in `createEscListener`:

**Bug 1 — ESC and Ctrl-C did nothing in the live view.** Raw mode delivers Ctrl-C as byte `0x03`, not a POSIX signal. The listener tried to convert it back into a process signal via `process.kill(process.pid, 'SIGINT')`. Under Bun, a self-issued signal does not reliably re-enter a `process.once('SIGINT')` handler, so the exit AbortController never aborted and the live stream kept running indefinitely. ESC was collateral damage from the same wedged listener.

**Bug 2 — The session picker froze after returning from the live view.** The interactive session picker (a `@clack/prompts` `select` list) rendered correctly but arrow keys did nothing — instead the raw escape sequences were echoed as cooked-mode text below the list:

```
│  ○ 019e7353-615  Subagent memory-retrieval ← 019e734d-6a6  5m ago
└
^[[B^[[B^[[B^[[D^[[B
```

`createEscListener`'s `stop()` — invoked via `pause()` to hand control back to the picker — called `stdin.pause()` after restoring cooked mode. Under Bun, clack's `select()` does not reliably re-flow a `process.stdin` that was explicitly paused, so its readline keypress machinery never received bytes; the TTY stayed in cooked mode and echoed raw arrow sequences.

## Summary

**Commit 1 — fix ESC and Ctrl-C** (`31c97c0`): Abort the exit controller directly from the raw `0x03` byte instead of round-tripping through the OS:

- `installSigintAbort()` now returns the AbortController (not just its signal).
- `createEscListener(onSigint)` takes an `onSigint` callback wired to `signalCtrl.abort()`; `onData` calls `onSigint()` on byte `0x03` directly.
- The stdin `'data'` handler is attached **before** `resume()`, closing a window where a keystroke could slip through between stream activation and handler registration.
- `createEscListener` accepts an injectable input stream (defaulting to `process.stdin`, mirroring `streamLive`'s `WebSocketImpl` test seam) so the wiring is testable without a real TTY.

**Commit 2 — fix picker freeze** (`3be2651`): Drop `stdin.pause()` from `stop()`. Removing our `'data'` listener and restoring cooked mode is sufficient to hand stdin to clack; leaving the stream flowing lets clack own raw mode and read keypresses during the picker. The live-tail ESC listener re-enters raw mode via `start()`/`resume()` on its own ownership path when the user returns to the live view.

## What this does NOT do

- Does not change the ESC debounce or `createEscController` dispatch logic.
- Does not change the `streamLive` abort path or WebSocket teardown.
- Does not affect any path outside the live tail and session-picker handoff.

## Review notes

- Load-bearing in commit 1: the `onSigint` callback in `createEscListener` (`src/cli/inspect.ts`). Verify it calls `signalCtrl.abort()` directly on byte `0x03` — no `process.kill` anywhere in the hot path. Confirm `installSigintAbort()` returns `{ signal, controller }` and the controller is not leaked.
- Load-bearing in commit 2: `stop()` in `createEscListener`. Verify that after `pause()` the stream remains flowing (not paused), raw mode is off, and our `'data'` handler is detached — so bytes reach clack but not our callback.
- `src/cli/inspect.test.ts` pins these invariants with a fake TTY: (1) Ctrl-C byte `0x03` invokes `onSigint` directly with no SIGINT round-trip; (2) bare ESC aborts only the per-stream signal; (3) the `'data'` handler attaches before `resume()`; (4) a non-TTY input stream returns `null`; (5) after `pause()` the stream remains flowing, raw mode is off, and the data listener is detached. Existing `inspect-controller.test.ts` is unchanged and still passes.
- One unrelated test failure: `resolveSelfPackageJsonPath > points at this package manifest` fails only because this branch was developed in a worktree directory not named `typeclaw` (the assertion expects the path to end with `typeclaw/package.json`). It passes in a normally-named checkout and in CI.