### PR TITLE
feat(channels): treat opened PRs as review requests in GitHub App mode

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -140,6 +140,97 @@ describe('classifyGithubInbound', () => {
       expect(msg).toBe(null)
     })
   })
+
+  describe('pull_request.opened', () => {
+    it('treats an opened PR as a review request in App mode', () => {
+      const msg = classifyGithubInbound('pull_request', openedPayload(), 'typeclaw-bot', { authType: 'app' })
+      expect(msg?.chat).toBe('pr:7')
+      expect(msg?.thread).toBe(null)
+      expect(msg?.text).toContain('@alice')
+      expect(msg?.text).toContain('requested your review on PR #7')
+      expect(msg?.text).toContain('feat-branch → main')
+      expect(msg?.text).toContain('Please review the changes line-by-line')
+      expect(msg?.isBotMention).toBe(true)
+      expect(msg?.authorName).toBe('alice')
+    })
+
+    it('does NOT treat an opened PR as a review request in PAT mode', () => {
+      // A PAT-backed bot is a real user that can be added to requested_reviewers,
+      // so it waits for the explicit review_requested event instead of reviewing
+      // every opened PR. The opened event lands as awareness-only context.
+      const msg = classifyGithubInbound('pull_request', openedPayload(), 'typeclaw-bot', { authType: 'pat' })
+      expect(msg?.chat).toBe('pr:7')
+      expect(msg?.text).not.toContain('requested your review')
+      expect(msg?.text).not.toContain('Please review the changes line-by-line')
+      expect(msg?.isBotMention).toBe(false)
+    })
+
+    it('does NOT treat an opened PR as a review request when authType is unset', () => {
+      const msg = classifyGithubInbound('pull_request', openedPayload(), 'typeclaw-bot')
+      expect(msg?.text).not.toContain('requested your review')
+    })
+
+    it('drops a bot-opened PR in App mode (self-loop guard)', () => {
+      const payload = openedPayload()
+      ;(payload.sender as Record<string, unknown>).login = 'typeclaw-bot'
+      const msg = classifyGithubInbound('pull_request', payload, 'typeclaw-bot', { authType: 'app' })
+      expect(msg).toBe(null)
+    })
+
+    it('mints distinct externalMessageIds for opened vs a later review_requested on the same PR', () => {
+      const opened = classifyGithubInbound('pull_request', openedPayload(), 'typeclaw-bot', { authType: 'app' })
+      const requested = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' }),
+        'typeclaw-bot',
+      )
+      expect(opened?.externalMessageId).not.toBe(requested?.externalMessageId)
+    })
+  })
+})
+
+describe('createGithubWebhookHandler — pull_request.opened auth gating', () => {
+  it('routes an opened PR as a review request when authType is app', async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['pull_request.opened'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot',
+      authType: () => 'app',
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+
+    await handler(signedRequest(JSON.stringify(openedPayload()), 'pull_request', 'opened-app'))
+    expect(routed).toHaveLength(1)
+    expect(routed[0]?.text).toContain('requested your review on PR #7')
+    expect(routed[0]?.isBotMention).toBe(true)
+  })
+
+  it('routes an opened PR as awareness-only context when authType is pat', async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['pull_request.opened'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot',
+      authType: () => 'pat',
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+
+    await handler(signedRequest(JSON.stringify(openedPayload()), 'pull_request', 'opened-pat'))
+    expect(routed).toHaveLength(1)
+    expect(routed[0]?.text).not.toContain('requested your review')
+    expect(routed[0]?.isBotMention).toBe(false)
+  })
 })
 
 describe('createGithubWebhookHandler — review_requested team gating', () => {
@@ -556,6 +647,15 @@ function pullRequestForReview(updatedAt: string): Record<string, unknown> {
     head: { ref: 'feat-branch' },
     base: { ref: 'main' },
     user: user(),
+  }
+}
+
+function openedPayload(options: { updatedAt?: string } = {}): Record<string, unknown> {
+  return {
+    action: 'opened',
+    repository: repo(),
+    pull_request: pullRequestForReview(options.updatedAt ?? '2026-01-01T00:00:00Z'),
+    sender: { login: 'alice', id: 10, type: 'User' },
   }
 }
 

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -13,6 +13,9 @@ export type GithubWebhookHandlerOptions = {
   allowlist: () => readonly string[]
   selfId: () => string | null
   selfLogin: () => string | null
+  // Defaults to 'pat' when omitted. Only 'app' promotes an opened PR to a
+  // review request; see classifyOpenedAsReview for why.
+  authType?: () => 'pat' | 'app'
   route: (message: InboundMessage) => void
   logger: GithubInboundLogger
   // Optional: resolves whether the bot is a member of the given team. When
@@ -56,6 +59,7 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
     const teamIsBotMember = await resolveTeamMembership(event, payload, options)
     const classified = classifyGithubInbound(event, payload, selfLogin, {
       teamIsBotMember,
+      authType: options.authType?.() ?? 'pat',
     })
     if (classified === null) return ok()
 
@@ -77,7 +81,7 @@ export function classifyGithubInbound(
   event: string,
   payload: Record<string, unknown>,
   selfLogin: string | null,
-  options?: { teamIsBotMember?: boolean },
+  options?: { teamIsBotMember?: boolean; authType?: 'pat' | 'app' },
 ): InboundMessage | null {
   const repository = readRepository(payload)
   if (repository === null) return null
@@ -176,6 +180,14 @@ export function classifyGithubInbound(
         selfLogin,
         teamIsBotMember: options?.teamIsBotMember,
       })
+    }
+    // A GitHub App cannot be added to a PR's requested_reviewers, so it never
+    // receives a review_requested event targeting itself. The opened event is
+    // the only signal it can act on, so in App mode an opened PR is promoted to
+    // a review request. A PAT-backed bot is a real user that can be requested,
+    // so it waits for the explicit request instead of reviewing every PR.
+    if (action === 'opened' && options?.authType === 'app') {
+      return classifyOpenedAsReview({ payload, pr, number, base, selfLogin })
     }
     return buildInbound(
       { ...base, chat: `pr:${number}`, thread: null },
@@ -282,6 +294,47 @@ function classifyReviewRequest(input: ReviewRequestInput): InboundMessage | null
     thread: null,
     text,
     externalMessageId,
+    authorId: String(sender.id),
+    authorName: sender.login,
+    authorIsBot: sender.type === 'Bot',
+    isBotMention: true,
+    replyToBotMessageId: null,
+    ts: updatedAt !== '' ? Date.parse(updatedAt) || 0 : 0,
+  }
+}
+
+type OpenedAsReviewInput = {
+  payload: Record<string, unknown>
+  pr: Record<string, unknown>
+  number: number
+  base: Pick<InboundMessage, 'adapter' | 'workspace' | 'isDm' | 'mentionsOthers' | 'replyToOtherMessageId'>
+  selfLogin: string | null
+}
+
+function classifyOpenedAsReview(input: OpenedAsReviewInput): InboundMessage | null {
+  const { payload, pr, number, base, selfLogin } = input
+  if (selfLogin === null) return null
+  const sender = readUser(payload.sender)
+  if (sender === null) return null
+  if (sender.login === selfLogin) return null
+
+  const title = readString(pr, 'title') ?? `#${number}`
+  const head = readString(readRecord(pr.head), 'ref')
+  const baseRef = readString(readRecord(pr.base), 'ref')
+  const branchSegment = head !== null && baseRef !== null ? ` Branch: ${head} → ${baseRef}.` : ''
+  const text =
+    `@${sender.login} requested your review on PR #${number}: "${title}".${branchSegment}` +
+    ' Please review the changes line-by-line and post your feedback.'
+
+  const updatedAt = readString(pr, 'updated_at') ?? ''
+  const prId = readNumber(pr, 'id') ?? number
+
+  return {
+    ...base,
+    chat: `pr:${number}`,
+    thread: null,
+    text,
+    externalMessageId: `pr-${prId}-opened-${updatedAt}`,
     authorId: String(sender.id),
     authorName: sender.login,
     authorIsBot: sender.type === 'Bot',

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -128,6 +128,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     allowlist: () => options.configRef().eventAllowlist,
     selfId: () => selfId,
     selfLogin: () => selfLogin,
+    authType: () => options.secrets.auth.type,
     isBotInTeam,
     logger,
     route: (message) => {


### PR DESCRIPTION
## What

In **GitHub App** mode, a `pull_request.opened` event is now promoted to a review request, waking the bot to review the PR. In **PAT** mode, behavior is unchanged: an opened PR lands as awareness-only context and the bot waits for an explicit `review_requested` event.

## Why

A GitHub App **cannot be added to a PR's `requested_reviewers` array**, so an App-backed bot never receives a `pull_request.review_requested` event targeting itself. The `opened` event is the only signal it can act on. A PAT-backed bot is a real user account that *can* be requested as a reviewer, so it should keep waiting for the explicit request rather than reviewing every opened PR.

## How

- `classifyGithubInbound` now accepts an `authType: 'pat' | 'app'` option, threaded from the adapter via `options.secrets.auth.type`.
- New `classifyOpenedAsReview` helper builds the inbound for `pull_request.opened` **only when `authType === 'app'`**. It reuses the exact review-request wording (`"requested your review on PR #N… Please review the changes line-by-line and post your feedback."`) so the existing `typeclaw-channel-github` skill trigger fires the `reviewer` subagent **unchanged** — no skill edits needed.
- `authType` on `GithubWebhookHandlerOptions` is optional and defaults to `'pat'`, so existing handler call sites and tests keep their current behavior.

## Self-loop safety

- `PRIMARY_AUTHOR_KEYS['pull_request'] = []` resolves the author from `sender`. For `opened`, `sender` is the PR opener, so a **bot-opened** PR is dropped by the existing self-author guard before classification.
- `classifyOpenedAsReview` additionally re-checks `sender.login === selfLogin` as a second line of defense.

## Scope notes

- Gated by `eventAllowlist` as usual — only fires if `pull_request.opened` (or `pull_request`) is allowlisted. Allowlist defaults are operator-managed and out of scope here.

## Tests

Added to `inbound.test.ts`:
- App mode + human-opened PR → "requested your review on PR #7", `isBotMention: true`.
- PAT mode + opened PR → awareness-only context, **not** a review trigger.
- `authType` unset → no review trigger (defaults to PAT).
- App mode + bot-opened PR → dropped (self-loop guard).
- Distinct `externalMessageId` for `opened` vs a later `review_requested` on the same PR.
- Handler-level end-to-end tests for both `authType: 'app'` and `authType: 'pat'`.

All checks green: `bun run typecheck`, `bun run lint` (0 errors), `bun run format`; full GitHub adapter suite (178 tests) passes.