### PR TITLE
feat(inspect): tag aborted turns distinctly from errors

### DIFF
--- a/src/inspect/live.test.ts
+++ b/src/inspect/live.test.ts
@@ -135,6 +135,42 @@ describe('streamLive — live session events', () => {
     expect(assist.model).toBe('m')
   })
 
+  test('aborted message_end surfaces an error event carrying stopReason', async () => {
+    const registry = new LiveSessionRegistry()
+    const session = createFakeAgent()
+    registry.register({ sessionId: 'ses_a', session })
+    const { url } = await startServer({ registry })
+
+    const ctrl = new AbortController()
+    const subscribed = Promise.withResolvers<void>()
+    const gen = streamLive({
+      url,
+      sessionId: 'ses_a',
+      signal: ctrl.signal,
+      onSubscribed: () => subscribed.resolve(),
+    })
+
+    void subscribed.promise.then(() => {
+      session.emit({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          content: [],
+          stopReason: 'aborted',
+          errorMessage: 'Request was aborted.',
+          usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { total: 0 } },
+        },
+      })
+    })
+
+    const events = await collectN(gen, 1)
+    ctrl.abort()
+    const ev = events[0]!
+    if (ev.cat !== 'error') throw new Error('expected error')
+    expect(ev.message).toBe('Request was aborted.')
+    expect(ev.stopReason).toBe('aborted')
+  })
+
   test('thinking_delta events accumulate until thinking_end then emit one thinking event', async () => {
     const registry = new LiveSessionRegistry()
     const session = createFakeAgent()

--- a/src/inspect/live.ts
+++ b/src/inspect/live.ts
@@ -239,7 +239,12 @@ function messageEndToEvents(
       return event
     }
     if (payload.errorMessage !== undefined) {
-      return { cat: 'error', ts, message: payload.errorMessage }
+      return {
+        cat: 'error',
+        ts,
+        message: payload.errorMessage,
+        ...(payload.stopReason !== undefined ? { stopReason: payload.stopReason } : {}),
+      }
     }
     if (payload.usage !== undefined && (payload.usage.totalTokens > 0 || payload.stopReason !== undefined)) {
       return {

--- a/src/inspect/render.test.ts
+++ b/src/inspect/render.test.ts
@@ -83,6 +83,26 @@ describe('renderEvent (plain, no color)', () => {
     expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  error      provider returned 503')
   })
 
+  test('error event appends stopReason when present and not an abort', () => {
+    const ev: InspectEvent = {
+      cat: 'error',
+      ts: dateMs('15:08:46'),
+      message: 'provider returned 503',
+      stopReason: 'error',
+    }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  error      provider returned 503 (stop=error)')
+  })
+
+  test('aborted turn renders an abort tag, not error, and omits the stop suffix', () => {
+    const ev: InspectEvent = {
+      cat: 'error',
+      ts: dateMs('15:08:46'),
+      message: 'Request was aborted.',
+      stopReason: 'aborted',
+    }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  abort      Request was aborted.')
+  })
+
   test('thinking event renders with think tag and the reasoning text', () => {
     const ev: InspectEvent = {
       cat: 'thinking',

--- a/src/inspect/render.ts
+++ b/src/inspect/render.ts
@@ -39,6 +39,7 @@ function renderTag(event: InspectEvent, opts: RenderOptions): string {
     case 'tool':
       return tint(opts, 'yellow', padEnd(event.phase === 'start' ? 'tool ▸' : 'tool ◂', 9))
     case 'error':
+      if (event.stopReason === 'aborted') return tint(opts, 'yellow', padEnd('abort', 9))
       return tint(opts, 'red', padEnd('error', 9))
     case 'done':
       return tint(opts, 'gray', padEnd('done', 9))
@@ -73,8 +74,13 @@ function renderBody(event: InspectEvent, opts: RenderOptions): string {
       const result = renderResult(event.result, opts.maxTextLength ?? DEFAULT_MAX_TEXT)
       return `${event.name} → ${status}${result ? ` ${result}` : ''} (${dur})`
     }
-    case 'error':
-      return tint(opts, 'red', truncate(singleLine(event.message), opts.maxTextLength ?? DEFAULT_MAX_TEXT))
+    case 'error': {
+      const aborted = event.stopReason === 'aborted'
+      const text = truncate(singleLine(event.message), opts.maxTextLength ?? DEFAULT_MAX_TEXT)
+      const suffix =
+        event.stopReason !== undefined && !aborted ? ` ${tint(opts, 'dim', `(stop=${event.stopReason})`)}` : ''
+      return `${tint(opts, aborted ? 'yellow' : 'red', text)}${suffix}`
+    }
     case 'done':
       return renderDone(event, opts)
     case 'broadcast':

--- a/src/inspect/replay.test.ts
+++ b/src/inspect/replay.test.ts
@@ -248,6 +248,30 @@ describe('replayLines', () => {
     expect(errorEvent.message).toBe('provider returned 503')
   })
 
+  test('assistant errorMessage carries stopReason onto the error event', async () => {
+    const events = await collect(
+      replayLines(
+        asLines([
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [],
+              stopReason: 'aborted',
+              errorMessage: 'Request was aborted.',
+              usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { total: 0 } },
+              timestamp: 5000,
+            },
+          }),
+        ]),
+      ),
+    )
+    const errorEvent = events.find((e) => e.cat === 'error')
+    expect(errorEvent).toBeDefined()
+    if (errorEvent?.cat !== 'error') throw new Error('unreachable')
+    expect(errorEvent.stopReason).toBe('aborted')
+  })
+
   test('assistant thinking content block yields a thinking event ordered before text and tool calls', async () => {
     const events = await collect(
       replayLines(

--- a/src/inspect/replay.ts
+++ b/src/inspect/replay.ts
@@ -137,7 +137,12 @@ function* assistantEvents(
     }
   }
   if (typeof message.errorMessage === 'string' && message.errorMessage !== '') {
-    yield { cat: 'error', ts, message: message.errorMessage }
+    yield {
+      cat: 'error',
+      ts,
+      message: message.errorMessage,
+      ...(typeof message.stopReason === 'string' ? { stopReason: message.stopReason } : {}),
+    }
   }
   const usage = readUsage(message.usage)
   if (usage !== null && (usage.totalTokens > 0 || typeof message.stopReason === 'string')) {

--- a/src/inspect/types.ts
+++ b/src/inspect/types.ts
@@ -37,7 +37,10 @@ export type InspectEvent =
       isError?: boolean
       durationMs?: number
     }
-  | { cat: 'error'; ts: number; message: string }
+  // `stopReason` is the upstream-reported reason for the failed/aborted turn
+  // (e.g. 'error', 'aborted'). An 'aborted' stopReason is a user cancel, not a
+  // provider failure, and is rendered distinctly (see render.ts).
+  | { cat: 'error'; ts: number; message: string; stopReason?: string }
   | {
       cat: 'done'
       ts: number


### PR DESCRIPTION
## Background

`typeclaw inspect` rendered every assistant message carrying an `errorMessage` as a red `error` line — including user-cancelled turns, e.g. `22:29:09  error      Request was aborted.`. Root cause: when an assistant `message_end` is converted to an inspect `error` event (both the replay JSONL path and the live websocket path), the upstream `stopReason` was dropped. `"Request was aborted."` is the verbatim `errorMessage` that pi-coding-agent emits with `stopReason: 'aborted'` on an Escape/cancel — not a provider failure. Without `stopReason`, the renderer could not tell a real error from an abort, so an intentional cancel looked like a crash. `src/agent/provider-error.ts` already treats `aborted` as "not a provider failure" for channels/cron; this brings inspect in line.

## Summary

- Plumb `stopReason`: add an optional `stopReason` to the `error` InspectEvent and thread it through both producers — replay.ts (transcript) and live.ts (websocket tail). The server's message_end payload already carried `stopReason`; live just stops discarding it.
- Render aborts distinctly: `stopReason === 'aborted'` now renders as a dim-yellow `abort` tag instead of a red `error`. Genuine errors that carry a non-abort stopReason get a `(stop=<reason>)` suffix. Why a new `abort` tag rather than only recoloring: the tag is what a reader scans first; keeping the word `error` for cancels is the source of the confusion.
- After: `22:29:09  abort      Request was aborted.` and `22:29:09  error      provider returned 503 (stop=error)`.

## What this does NOT do

- Does not change the underlying `errorMessage` text (produced upstream by pi-coding-agent; inspect only surfaces it).
- Does not add a new filter category — aborts keep `cat: 'error'`, so `--filter !error` still hides them; presentation only.
- Does not touch the pre-existing no-op assistant-text-with-errorMessage branch in live.ts (out of scope).

## Review notes

- Load-bearing change: the `stopReason` field on the `error` variant in src/inspect/types.ts and the matching branches in renderTag/renderBody in src/inspect/render.ts.
- Invariant: an aborted turn renders the `abort` tag and omits the `(stop=)` suffix; a non-abort error keeps the red `error` tag and gains the suffix. Covered by new tests in render.test.ts, replay.test.ts, live.test.ts.