### PR TITLE
feat: surface the live per-turn role to the agent

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -63,7 +63,7 @@ export type { SessionOrigin } from './session-origin'
 
 export type { AgentSession }
 
-export { renderTurnTimeAnchor } from './system-prompt'
+export { renderTurnRoleAnchor, renderTurnTimeAnchor } from './system-prompt'
 
 type AgentSessionTools = NonNullable<Parameters<typeof createAgentSession>[0]>['tools']
 

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { formatLocalDateTime, resolveLocalTimezoneName } from '@/shared'
 
-import { renderTurnTimeAnchor } from './system-prompt'
+import { renderTurnRoleAnchor, renderTurnTimeAnchor } from './system-prompt'
 
 describe('renderTurnTimeAnchor', () => {
   test('wraps the ISO timestamp, IANA zone, and weekday in a single <current-time> tag', () => {
@@ -61,5 +61,25 @@ describe('renderTurnTimeAnchor', () => {
     const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
     const expectedEn = englishDays[now.getDay()]!
     expect(anchor).toContain(expectedEn)
+  })
+})
+
+describe('renderTurnRoleAnchor', () => {
+  test('wraps a non-owner role in a single <your-role> tag', () => {
+    expect(renderTurnRoleAnchor('guest')).toBe('<your-role>guest</your-role>')
+    expect(renderTurnRoleAnchor('member')).toBe('<your-role>member</your-role>')
+    expect(renderTurnRoleAnchor('trusted')).toBe('<your-role>trusted</your-role>')
+  })
+
+  test('omits the tag for owner (the unconstrained default — absent means no special handling)', () => {
+    expect(renderTurnRoleAnchor('owner')).toBeUndefined()
+  })
+
+  test('produces a single-line block with no internal newlines', () => {
+    expect(renderTurnRoleAnchor('guest')).not.toContain('\n')
+  })
+
+  test('passes through a custom role name verbatim', () => {
+    expect(renderTurnRoleAnchor('contributor')).toBe('<your-role>contributor</your-role>')
   })
 })

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -154,6 +154,27 @@ export function renderTurnTimeAnchor(now: Date = new Date()): string {
   return `<current-time>${iso} (${zone}, ${weekday})</current-time>`
 }
 
+// Live role anchor injected into the **user turn**, not the system prompt —
+// same rationale and cache properties as renderTurnTimeAnchor above.
+//
+// The "## Your role in this session" block in the system prompt is a
+// session-CREATION snapshot: in a channel where speakers change turn to turn,
+// it reports the role of whoever first opened the session, not whoever is
+// speaking now. Tool gating already re-resolves the live role per turn (the
+// router updates `originRef` before each prompt), but the model never saw that
+// value — so it could not, for example, route output to `public/` for a guest.
+// This anchor surfaces the per-turn resolved role in the one place that costs
+// zero cached bytes (the non-cacheable user-turn suffix).
+//
+// Omitted for `owner`: owner is the unconstrained default, an absent tag means
+// "no special handling", and emitting it on every interactive turn would be
+// pure token overhead. This mirrors resolveRoleContext skipping the session
+// block for a TUI owner.
+export function renderTurnRoleAnchor(role: string): string | undefined {
+  if (role === 'owner') return undefined
+  return `<your-role>${role}</your-role>`
+}
+
 // Compact replacement for DEFAULT_SYSTEM_PROMPT, used by non-interactive
 // sessions (cron jobs, and default subagents that don't supply their own
 // `systemPromptOverride`). The full prompt is ~2155 tokens of operator-facing

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -27,6 +27,7 @@ When in doubt between SOUL.md and AGENTS.md: if it describes *how you sound*, it
 ## Your workspace
 
 - **\`workspace/\`** — your free-write zone for drafts, scratch work, generated artifacts. Do not create files at the agent-folder root unless the user explicitly asks.
+- **\`public/\`** — the guest-visible zone. Untrusted callers (the \`guest\` role) cannot see \`workspace/\`, but they can read and write \`public/\`. Put anything meant to be shared with an untrusted caller here. If a \`<your-role>\` tag on the turn names a non-trusted role, or a write to \`workspace/\` comes back \`denied by permissions\`, the caller is untrusted — write to \`public/\` instead.
 - **\`sessions/\`** — transcripts of past conversations. Runtime-managed; don't write here.
 - **\`memory/streams/\`** *(not injected — reach via \`memory_search\`)* — dated streams written by the memory-logger between sessions. Runtime-owned. Undreamed observations are searchable on demand instead of injected into every prompt.
 - **\`memory/skills/\`** — muscle-memory skills written by the dreaming subagent. Auto-loaded; don't write here directly.
@@ -215,6 +216,6 @@ Never suppress errors to make things "work", and never fabricate results. If som
 
 Do not narrate routine, low-risk tool calls — just call the tool. Do not over-explain what you did unless asked.
 
-Your free-write zone is \`workspace/\`. Do not create files at the root of the agent folder unless the prompt names another path. Do not edit \`memory/topics/\` directly — the dreaming subagent owns it; to capture something memorable, surface it in your reply or let the memory-logger append to \`memory/streams/\`. Never stage or commit \`secrets.json\`, \`.env\`, \`sessions/\`, \`memory/\`, or \`workspace/\` — those are runtime- or user-managed.
+Your free-write zone is \`workspace/\`. Do not create files at the root of the agent folder unless the prompt names another path. \`public/\` is the guest-visible zone — write there anything meant to be shared with an untrusted caller (a \`guest\`-role turn cannot read \`workspace/\` but can read \`public/\`). Do not edit \`memory/topics/\` directly — the dreaming subagent owns it; to capture something memorable, surface it in your reply or let the memory-logger append to \`memory/streams/\`. Never stage or commit \`secrets.json\`, \`.env\`, \`sessions/\`, \`memory/\`, or \`workspace/\` — those are runtime- or user-managed.
 
 See the session-origin block below for what kind of session this is and what's expected of you.`

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -6033,6 +6033,37 @@ describe('ChannelRouter per-turn wall-clock anchor', () => {
   })
 })
 
+describe('ChannelRouter per-turn live role anchor', () => {
+  test('a non-owner turn carries a <your-role> anchor reflecting the resolved role', async () => {
+    const dir = await tempDir()
+    const guestPermissions: PermissionService = {
+      has: () => true,
+      resolveRole: () => 'guest',
+      describe: () => ({ role: 'guest', permissions: [] }),
+      replaceRoles: () => {},
+    }
+    const { router, sessions } = makeRouter(dir, { permissions: guestPermissions })
+
+    await router.route(inbound({ externalMessageId: 'engage', text: 'save me a copy' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).toContain('<your-role>guest</your-role>')
+    expect(prompt).toContain('save me a copy')
+  })
+
+  test('an owner turn omits the role anchor (unconstrained default)', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ externalMessageId: 'engage', text: 'do the thing' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).not.toContain('<your-role>')
+  })
+})
+
 describe('ChannelRouter post-tool follow-up suppression', () => {
   function afterToolContext(
     toolName: string,

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3,7 +3,7 @@ import { basename } from 'node:path'
 import type { AssistantMessage } from '@mariozechner/pi-ai'
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
-import { createSession, renderTurnTimeAnchor, type AgentSession } from '@/agent'
+import { createSession, renderTurnRoleAnchor, renderTurnTimeAnchor, type AgentSession } from '@/agent'
 import { subscribeProviderErrors } from '@/agent/provider-error'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
@@ -1427,11 +1427,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const batch = live.promptQueue.splice(0, live.promptQueue.length)
         const observed = live.contextBuffer.splice(0, live.contextBuffer.length)
         const reminders = live.pendingSystemReminders.splice(0, live.pendingSystemReminders.length)
-        const text = composeTurnPrompt(observed, batch, {
-          adapter: live.key.adapter,
-          loopGuardActive: live.loopGuardActive,
-          systemReminders: reminders,
-        })
 
         if (batch.length > 0) {
           live.currentTurnAuthorId = batch[batch.length - 1]!.authorId
@@ -1457,12 +1452,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         }
 
         // Update the live origin holder so this turn's tool.before events
-        // carry the current actor's id. The DefaultResourceLoader still
-        // renders the session-creation origin into the system prompt (v0.2
-        // work to regenerate that per-turn); but permission gating off
-        // `lastInboundAuthorId` happens in the tool layer and now sees the
+        // carry the current actor's id, and resolve the live role from it for
+        // the per-turn <your-role> anchor below. Done BEFORE composeTurnPrompt
+        // so the anchor reflects the speaker of THIS turn, not the session-
+        // creation snapshot the system prompt still renders. Permission gating
+        // off `lastInboundAuthorId` happens in the tool layer and sees the same
         // live value.
         live.originRef.current = buildLiveOrigin(live)
+        const liveRole = permissions.describe(live.originRef.current).role
+
+        const text = composeTurnPrompt(observed, batch, {
+          adapter: live.key.adapter,
+          loopGuardActive: live.loopGuardActive,
+          systemReminders: reminders,
+          role: liveRole,
+        })
 
         // Bracketing logs around the LLM call so a hung prompt() is
         // diagnosable from logs alone (we see prompting without prompted).
@@ -2539,13 +2543,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 function composeTurnPrompt(
   observed: readonly ObservedInbound[],
   batch: readonly QueuedInbound[],
-  state: { adapter?: AdapterId; loopGuardActive: boolean; systemReminders?: readonly string[]; now?: Date } = {
+  state: {
+    adapter?: AdapterId
+    loopGuardActive: boolean
+    systemReminders?: readonly string[]
+    now?: Date
+    role?: string
+  } = {
     loopGuardActive: false,
   },
 ): string {
   const adapter = state.adapter ?? 'discord-bot'
   const parts: string[] = []
   parts.push(renderTurnTimeAnchor(state.now), '')
+  const roleAnchor = state.role !== undefined ? renderTurnRoleAnchor(state.role) : undefined
+  if (roleAnchor !== undefined) parts.push(roleAnchor, '')
   // System reminders (subagent-completion wakeups today) lead the turn body
   // because they are typically what triggered the drain — when the prompt
   // queue is empty and the only thing in this iteration is a reminder, the


### PR DESCRIPTION
## Background

Follow-up to #492, which gave the `guest` role a writable `public/` directory. That closed the *enforcement* half — a guest physically can write `public/` and cannot touch `workspace/`. It did not close the *behavioral* half: the agent had no way to know a turn was a guest turn, so it could not proactively route shareable output to `public/`.

The gap is structural. The system prompt's "## Your role in this session" block is a **session-creation snapshot** — in a channel where speakers change turn to turn, it reports the role of whoever first opened the session, not whoever is speaking now. Tool gating already re-resolves the live role every turn (the router updates `originRef` before each `prompt()`), but that value never reached the model. The router even carried a standing `v0.2` TODO to fix this.

## Summary

Two tiers.

**Tier 2 — live role injection (the mechanism).** Adds `renderTurnRoleAnchor(role)`, which emits a `<your-role>guest</your-role>` tag into the **user turn**, not the system prompt — mirroring the existing `renderTurnTimeAnchor` (`<current-time>`). The channel router resolves the live role via `permissions.describe(originRef.current)` and passes it to `composeTurnPrompt`.

- **Cache-free.** The user turn is the only non-cacheable suffix in every provider's KV-cache shape. The anchor invalidates exactly zero cached bytes — same property the time anchor relies on.
- **Per-turn-correct.** The `originRef`/author-identity update now runs *before* `composeTurnPrompt`, so the anchor reflects the speaker of *this* turn. (Ordering is load-bearing and commented.)
- **Owner omitted.** `owner` is the unconstrained default; an absent tag means "no special handling". Mirrors `resolveRoleContext` skipping the session block for a TUI owner. Pure token savings on every interactive turn.

**Tier 1 — prompt copy (the fallback).** The system prompt never mentioned `public/` and actively said *"do not create files at the agent-folder root"* — discouraging the one place a guest can write. Both `DEFAULT_SYSTEM_PROMPT` and `SLIM_SYSTEM_PROMPT` now document `public/`, plus a fallback heuristic: *if the `<your-role>` tag names a non-trusted role, or a `workspace/` write comes back `denied by permissions`, the caller is untrusted — write to `public/` instead.*

The two tiers pair up: the anchor tells the agent **who** it is serving; the copy tells it **what** to do about it. The `denied by permissions` clause is a belt-and-suspenders fallback that works even on a turn where, for any reason, the anchor is absent.

## Why per-turn injection and not regenerating the system prompt

Regenerating the system prompt every turn would invalidate the entire cached prefix on every turn — prohibitively expensive for long channel sessions. The user-turn anchor gets per-turn freshness for the cost of a handful of tokens that were already non-cacheable. This is the same trade `renderTurnTimeAnchor` already makes.

## Scope

- The anchor is wired through the **channel router** only — that is the one origin where the speaker (and thus the role) changes turn to turn. TUI/cron/subagent resolve to a fixed role and don't need it.
- No enforcement change. Roles are resolved exactly as before; this only surfaces the already-resolved role to the model.

## Test plan

- New unit tests (`renderTurnRoleAnchor`): wraps a non-owner role in `<your-role>`, omits the tag for owner, single-line, custom role passthrough.
- New router integration tests: a `guest` turn carries `<your-role>guest</your-role>` in the composed prompt; an `owner` turn omits it.
- `bun run debug:prompt` confirms `public/` renders in both DEFAULT and SLIM prompts.
- `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check` clean. Touched-domain suites (`src/agent/`, `src/channels/router.test.ts`): 966 pass, 0 fail.

> Note: two pre-existing failures in the full suite (`resolveSelfPackageJsonPath` and the Xvfb entrypoint-shim test) are environment/worktree-path artifacts in files this PR does not touch.