### PR TITLE
fix(security): resolve symlinks in privateSurfaceRead before matching

### DIFF
--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
+import { realpathSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 
 import type { HiddenPaths } from '@/sandbox'
 
@@ -105,5 +109,65 @@ describe('private-surface-read guard — traversal + scope', () => {
 
   test('bash is never blocked here (its access is contained by the bwrap sandbox)', () => {
     expect(check('bash', { command: 'cat workspace/notes.md' })).toBeUndefined()
+  })
+})
+
+describe('private-surface-read guard — symlink bypass defense', () => {
+  // Real filesystem: the bug is that lexical path.resolve does not follow
+  // symlinks. A guest plants public/leak -> ../<hidden> via sandboxed bash,
+  // then reads it back through a non-bash tool whose path lexically lands in
+  // guest-visible public/. The guard must realpath the candidate and catch it.
+  function makeAgentWithSymlinks(): { agentDir: string; hidden: HiddenPaths } {
+    const agentDir = realpathSync(mkdtempSync(path.join(tmpdir(), 'typeclaw-symlink-guard-')))
+    for (const dir of ['workspace', 'memory', 'sessions', 'public']) {
+      mkdirSync(path.join(agentDir, dir), { recursive: true })
+    }
+    writeFileSync(path.join(agentDir, '.env'), 'SECRET=1')
+    writeFileSync(path.join(agentDir, 'memory', 'topic.md'), 'private')
+    symlinkSync(path.join(agentDir, '.env'), path.join(agentDir, 'public', 'env-link'))
+    symlinkSync(path.join(agentDir, 'memory'), path.join(agentDir, 'public', 'mem-link'))
+    return {
+      agentDir,
+      hidden: {
+        dirs: ['workspace', 'memory', 'sessions'].map((d) => path.join(agentDir, d)),
+        files: ['.env', 'secrets.json'].map((f) => path.join(agentDir, f)),
+      },
+    }
+  }
+
+  test('blocks a non-bash read of a public/ symlink pointing at a hidden FILE', () => {
+    const { agentDir, hidden } = makeAgentWithSymlinks()
+    const result = checkPrivateSurfaceReadGuard({ tool: 'read', args: { path: 'public/env-link' }, agentDir, hidden })
+    expect(result?.block).toBe(true)
+  })
+
+  test('blocks a non-bash read THROUGH a public/ symlink pointing at a hidden DIR', () => {
+    const { agentDir, hidden } = makeAgentWithSymlinks()
+    // public/mem-link -> memory/, so public/mem-link/topic.md resolves into memory/
+    const result = checkPrivateSurfaceReadGuard({
+      tool: 'read',
+      args: { path: 'public/mem-link/topic.md' },
+      agentDir,
+      hidden,
+    })
+    expect(result?.block).toBe(true)
+  })
+
+  test('blocks the symlink via a NESTED arg shape (look_at images[].path)', () => {
+    const { agentDir, hidden } = makeAgentWithSymlinks()
+    const result = checkPrivateSurfaceReadGuard({
+      tool: 'look_at',
+      args: { images: [{ path: 'public/env-link' }] },
+      agentDir,
+      hidden,
+    })
+    expect(result?.block).toBe(true)
+  })
+
+  test('still ALLOWS a genuine non-symlink file inside public/', () => {
+    const { agentDir, hidden } = makeAgentWithSymlinks()
+    writeFileSync(path.join(agentDir, 'public', 'real.md'), 'shareable')
+    const result = checkPrivateSurfaceReadGuard({ tool: 'read', args: { path: 'public/real.md' }, agentDir, hidden })
+    expect(result).toBeUndefined()
   })
 })

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from 'node:fs'
 import path from 'node:path'
 
 import type { HiddenPaths } from '@/sandbox'
@@ -96,18 +97,59 @@ function walk(value: unknown, out: string[]): void {
 // exact equality; hidden directories match the dir itself or anything under it,
 // using a trailing slash so `workspace` does not also match a sibling
 // `workspace-notes`.
+//
+// Symlink defense: lexical path.resolve is NOT enough. A restricted role can
+// plant `public/leak -> ../.env` (or `-> ../memory`) via sandboxed bash, then
+// read it back through a non-bash tool whose path lexically lands in the
+// guest-visible `public/`. So we resolve the candidate's REAL path
+// (realpathRealIntendedPath follows symlinks on every existing path component)
+// before matching. Both sides are realpath'd because agentDir itself may sit
+// under a symlink (e.g. /tmp -> /private/tmp on macOS); comparing a real
+// candidate against a lexical deny-list would never match.
 function matchHidden(
   candidate: string,
   agentDir: string,
   deniedDirs: string[],
   deniedFiles: string[],
 ): string | undefined {
-  const resolved = path.resolve(agentDir, candidate)
+  const resolved = realpathRealIntendedPath(path.resolve(agentDir, candidate))
   for (const file of deniedFiles) {
-    if (resolved === file) return file
+    if (resolved === realpathRealIntendedPath(file)) return file
   }
   for (const dir of deniedDirs) {
-    if (resolved === dir || resolved.startsWith(`${dir}/`)) return dir
+    const realDir = realpathRealIntendedPath(dir)
+    if (resolved === realDir || resolved.startsWith(`${realDir}/`)) return dir
   }
   return undefined
+}
+
+// Resolves symlinks on the longest existing prefix of an absolute path, then
+// re-appends the non-existent tail. A bare realpathSync throws on a path that
+// does not exist yet (a write target, or a read of a not-yet-created file), so
+// we walk up to the nearest existing ancestor, realpath THAT (collapsing any
+// symlinked component including a planted symlink), and rejoin the remainder.
+// This catches `public/leak/x` where `public/leak` is a symlink into a hidden
+// dir even though `public/leak/x` itself does not exist. Sync (realpathSync)
+// keeps the guard synchronous so the security tool.before check array stays
+// non-async; the cost is one syscall per existing component, negligible at the
+// tool-call boundary. Sync mirror of resolveRealIntendedPath in the guard
+// plugin's non-workspace-write policy.
+function realpathRealIntendedPath(absolutePath: string): string {
+  const pending: string[] = []
+  let current = absolutePath
+  while (true) {
+    try {
+      return path.join(realpathSync.native(current), ...pending.reverse())
+    } catch (err) {
+      if (!isNotFoundError(err)) throw err
+    }
+    const parent = path.dirname(current)
+    if (parent === current) return absolutePath
+    pending.push(path.basename(current))
+    current = parent
+  }
+}
+
+function isNotFoundError(err: unknown): boolean {
+  return err instanceof Error && 'code' in err && err.code === 'ENOENT'
 }


### PR DESCRIPTION
## Security blocker (found in pre-release review)

`privateSurfaceRead` — the non-bash enforcement point for the role-based filesystem deny-list (#488) — resolved candidate paths **lexically** with `path.resolve`, so it never followed symlinks.

### The bypass

A restricted role (e.g. `guest`) can, via sandboxed bash, plant a symlink inside the guest-visible `public/` dir (#492):

```
public/leak -> ../.env        # or ../memory, ../workspace, ../sessions
```

Then read it back through a **non-bash** tool — `read`, `look_at`, or a `channel_reply` attachment — with `path: "public/leak"`. The guard resolved that lexically to `<agent>/public/leak`, saw it land in the allowed `public/`, and **let it through**. The actual file read followed the symlink to `.env`. The deny-list was bypassed entirely.

The bash sandbox (bwrap masks) caught this; the file-tool enforcement point did not — breaking the "two enforcement points, one deny-list" invariant #488 depends on.

Demonstrated divergence (lexical vs real):
```
lexical resolve -> <agent>/public/env-link   (lands in public/, allowed)
realpath        -> <agent>/.env              (the secret, blocked)
```

## Fix

Resolve the candidate's **real** path before matching: follow symlinks on every existing path component, walking up to the nearest existing ancestor for not-yet-created targets (so `public/leak/x` is caught even if `x` doesn't exist). Both sides are realpath'd because the agent dir itself may sit under a symlink (e.g. `/tmp -> /private/tmp` on macOS) — comparing a real candidate against a lexical deny-list would never match.

Kept **synchronous** via `realpathSync.native` so the security `tool.before` check array stays non-async (one syscall per existing component, negligible at the tool-call boundary). This mirrors the existing `resolveRealIntendedPath` pattern in the guard plugin's `non-workspace-write` policy.

## Tests

- public/ symlink to a hidden **file** → blocked
- read **through** a public/ symlink to a hidden **dir** → blocked
- symlink via a **nested** arg shape (`look_at` `images[].path`) → blocked
- a genuine non-symlink file in `public/` → still allowed

## Release impact

This is one of two blockers gating the sandbox release. The second (false-positive over-blocking) is in a stacked follow-up PR.

## Test plan

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check` clean. Security + sandbox suites: 516 pass, 0 fail.

> Two pre-existing full-suite failures (`resolveSelfPackageJsonPath`, Xvfb entrypoint-shim) are environment/worktree-path artifacts in files this PR does not touch.