### PR TITLE
fix(security): scope privateSurfaceRead to path-bearing fields

### DIFF
--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -69,7 +69,6 @@ describe('private-surface-read guard — free-text field scoping (no false posit
   test('does not block a path-LIKE value in a free-text field', () => {
     expect(check('channel_reply', { text: 'see workspace/notes.md for details' })).toBeUndefined()
     expect(check('grep', { pattern: 'memory/topics', path: 'public' })).toBeUndefined()
-    expect(check('grep', { pattern: 'token', path: 'public', glob: 'workspace/*.md' })).toBeUndefined()
     expect(check('edit', { path: 'public/x.md', edits: [{ oldText: 'workspace/a', newText: 'memory/b' }] })).toBe(
       undefined,
     )
@@ -106,6 +105,34 @@ describe('private-surface-read guard — free-text field scoping (no false posit
         attachments: [{ path: 'memory/leak.md', filename: 'report.pdf' }],
       })?.block,
     ).toBe(true)
+  })
+})
+
+describe('private-surface-read guard — grep/find glob path-filters are scanned', () => {
+  test('blocks a grep glob that reaches a hidden subtree (non-hidden search root)', () => {
+    expect(check('grep', { pattern: 'x', path: '.', glob: 'workspace/**' })?.block).toBe(true)
+    expect(check('grep', { pattern: 'x', glob: 'memory/**' })?.block).toBe(true)
+    expect(check('grep', { pattern: 'x', path: 'public', glob: 'sessions/*.jsonl' })?.block).toBe(true)
+    expect(check('grep', { pattern: 'x', path: 'public', glob: 'workspace/*.md' })?.block).toBe(true)
+  })
+
+  test('blocks a find pattern that reaches a hidden subtree (find.pattern is a glob)', () => {
+    expect(check('find', { path: '.', pattern: 'workspace/**' })?.block).toBe(true)
+    expect(check('find', { pattern: 'memory/**' })?.block).toBe(true)
+  })
+
+  test('allows a grep glob that does not select a hidden subtree (no false positive)', () => {
+    expect(check('grep', { pattern: 'token', path: 'public', glob: '*.ts' })).toBeUndefined()
+    expect(check('grep', { pattern: 'token', path: 'public', glob: '**/*.spec.ts' })).toBeUndefined()
+  })
+
+  test('grep.pattern (a regex, not a path) is still exempt from scanning', () => {
+    expect(check('grep', { pattern: 'sessions' })).toBeUndefined()
+    expect(check('grep', { pattern: 'memory', path: 'public' })).toBeUndefined()
+  })
+
+  test('a future tool with a pattern key is NOT exempt (fail-closed)', () => {
+    expect(check('some_search_tool', { pattern: 'workspace/x' })?.block).toBe(true)
   })
 })
 

--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -58,6 +58,38 @@ describe('private-surface-read guard — fail-closed across ALL tools (not a whi
   })
 })
 
+describe('private-surface-read guard — free-text field scoping (no false positives)', () => {
+  test('does not block a bare hidden-dir NAME in a free-text field', () => {
+    expect(check('channel_reply', { text: 'memory' })).toBeUndefined()
+    expect(check('websearch', { query: 'workspace' })).toBeUndefined()
+    expect(check('grep', { pattern: 'sessions', path: 'public' })).toBeUndefined()
+    expect(check('look_at_channel_attachment', { prompt: 'sessions' })).toBeUndefined()
+  })
+
+  test('does not block a path-LIKE value in a free-text field', () => {
+    expect(check('channel_reply', { text: 'see workspace/notes.md for details' })).toBeUndefined()
+    expect(check('grep', { pattern: 'memory/topics', path: 'public' })).toBeUndefined()
+    expect(check('grep', { pattern: 'token', path: 'public', glob: 'workspace/*.md' })).toBeUndefined()
+    expect(check('edit', { path: 'public/x.md', edits: [{ oldText: 'workspace/a', newText: 'memory/b' }] })).toBe(
+      undefined,
+    )
+    expect(check('append', { topic: 'workspace', body: 'about memory' })).toBeUndefined()
+  })
+
+  test('STILL blocks a hidden path in a genuine path field (scoping did not open a hole)', () => {
+    expect(check('read', { path: 'memory' })?.block).toBe(true)
+    expect(check('read', { path: 'workspace/notes.md' })?.block).toBe(true)
+    expect(check('grep', { pattern: 'token', path: 'sessions' })?.block).toBe(true)
+    expect(check('look_at', { images: [{ path: 'memory/x.png' }] })?.block).toBe(true)
+    expect(check('channel_send', { text: 'memory', attachments: [{ path: 'sessions/s.jsonl' }] })?.block).toBe(true)
+  })
+
+  test('fail-closed: an UNKNOWN key on an unknown tool is still scanned', () => {
+    expect(check('some_new_plugin_tool', { srcPath: 'memory/x' })?.block).toBe(true)
+    expect(check('some_new_plugin_tool', { nested: { target: 'workspace/y' } })?.block).toBe(true)
+  })
+})
+
 describe('private-surface-read guard — false-positive control', () => {
   test('does not block prose args that merely mention a dir name without a separator', () => {
     expect(check('channel_send', { text: 'tell me about the workspace and memory' })).toBeUndefined()

--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -88,6 +88,25 @@ describe('private-surface-read guard — free-text field scoping (no false posit
     expect(check('some_new_plugin_tool', { srcPath: 'memory/x' })?.block).toBe(true)
     expect(check('some_new_plugin_tool', { nested: { target: 'workspace/y' } })?.block).toBe(true)
   })
+
+  test('does not block an attachment display filename that equals a hidden-dir name', () => {
+    expect(
+      check('channel_send', {
+        text: 'see attached',
+        attachments: [{ path: 'public/report.pdf', filename: 'memory' }],
+      }),
+    ).toBeUndefined()
+    expect(check('channel_reply', { attachments: [{ path: 'public/x.md', filename: 'sessions' }] })).toBeUndefined()
+    expect(check('channel_fetch_attachment', { attachment_id: 1, filename: 'workspace' })).toBeUndefined()
+  })
+
+  test('STILL blocks a hidden attachments[].path even when filename is exempt', () => {
+    expect(
+      check('channel_send', {
+        attachments: [{ path: 'memory/leak.md', filename: 'report.pdf' }],
+      })?.block,
+    ).toBe(true)
+  })
 })
 
 describe('private-surface-read guard — false-positive control', () => {

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -96,6 +96,14 @@ const NON_PATH_KEYS = new Set([
   // grep tool: a glob like `workspace/*.md` is a filter pattern, not the
   // search root (that is `path`), so it must not resolve-match a hidden dir.
   'glob',
+  // channel_send/channel_reply attachments[].filename and
+  // channel_fetch_attachment.filename: display-only metadata (defaults to the
+  // basename of the real `path`), never the file location the guard cares
+  // about — `attachments[].path` carries that and is NOT exempted. Without
+  // this, an attachment named e.g. "memory" is blocked even when its path is a
+  // safe `public/...`. Verified across the tool surface: no tool uses
+  // `filename` as a path argument.
+  'filename',
 ])
 
 // Recursively collects strings that could be paths, skipping values under

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -48,7 +48,7 @@ export function checkPrivateSurfaceReadGuard(options: {
   const deniedFiles = hidden.files
   if (deniedDirs.length === 0 && deniedFiles.length === 0) return undefined
 
-  for (const candidate of collectPathCandidates(args)) {
+  for (const candidate of collectPathCandidates(args, tool)) {
     const hit = matchHidden(candidate, agentDir, deniedDirs, deniedFiles)
     if (hit !== undefined) {
       return {
@@ -63,19 +63,21 @@ export function checkPrivateSurfaceReadGuard(options: {
   return undefined
 }
 
-// Free-text field names whose values are prose/queries/patterns, NOT paths.
-// Scanning them caused false positives: a guest's `channel_reply({ text:
-// "the memory leak" })`, `websearch({ query: "workspace setup" })`, or
-// `grep({ pattern: "sessions" })` all resolve to a bare hidden-dir name and
-// were wrongly blocked. The value here is a DENYLIST OF KEY NAMES, not a tool
-// whitelist: an unknown field on an unknown tool is still scanned (fail-closed
-// for new path-bearing readers), we only skip values whose KEY is a known
-// free-text field. `command` is included because bash (the only tool with it)
-// is already exempt via UNSCANNED_TOOLS and its access is bwrap-contained.
+// Field names whose values are ALWAYS free text (prose/queries/ids), NEVER a
+// filesystem path, for EVERY tool. Scanning them caused false positives: a
+// guest's `channel_reply({ text: "the memory leak" })` or `websearch({ query:
+// "workspace setup" })` resolve to a bare hidden-dir name and were wrongly
+// blocked. This is a DENYLIST OF KEY NAMES, not a tool whitelist: an unknown
+// field on an unknown tool is still scanned (fail-closed for new path-bearing
+// readers); we only skip values whose KEY is universally free text. `command`
+// is here because bash (its only user) is already exempt via UNSCANNED_TOOLS.
+//
+// `glob` and `pattern` are deliberately ABSENT — they are tool-dependent (a
+// glob/path-filter in grep/find, a regex only in grep) and handled by
+// FREE_TEXT_KEYS_BY_TOOL below.
 const NON_PATH_KEYS = new Set([
   'text',
   'query',
-  'pattern',
   'prompt',
   'selector',
   'url',
@@ -93,46 +95,59 @@ const NON_PATH_KEYS = new Set([
   'newText',
   // memory append tool: fragment topic is free text.
   'topic',
-  // grep tool: a glob like `workspace/*.md` is a filter pattern, not the
-  // search root (that is `path`), so it must not resolve-match a hidden dir.
-  'glob',
   // channel_send/channel_reply attachments[].filename and
   // channel_fetch_attachment.filename: display-only metadata (defaults to the
   // basename of the real `path`), never the file location the guard cares
-  // about — `attachments[].path` carries that and is NOT exempted. Without
-  // this, an attachment named e.g. "memory" is blocked even when its path is a
-  // safe `public/...`. Verified across the tool surface: no tool uses
-  // `filename` as a path argument.
+  // about — `attachments[].path` carries that and is NOT exempted.
   'filename',
 ])
 
-// Recursively collects strings that could be paths, skipping values under
-// NON_PATH_KEYS. Matching is left to matchHidden, which realpath-resolves each
-// candidate against agentDir and only fires on one that lands inside a hidden
-// directory. Fail-closed by design: a bare path-bearing value equal to a hidden
-// dir name (e.g. `path: "memory"`) is still blocked. Top-level strings and
-// array elements carry no key, so they are always scanned (an array of paths
-// like attachments[].path is collected even though the array key itself —
-// `attachments` — is not in NON_PATH_KEYS).
-function collectPathCandidates(value: unknown): string[] {
+// Keys that are free text in SPECIFIC tools but path-bearing in others, so a
+// global denylist would either over-block or open a bypass. Scoped per tool:
+//   - grep.pattern  : a regex/search string (e.g. "sessions"), NOT a path.
+// Notably NOT listed (and therefore SCANNED):
+//   - grep.glob / find.pattern : both are glob path-filters resolved RELATIVE
+//     to the search root, so `grep({ path: '.', glob: 'workspace/**' })` and
+//     `find({ path: '.', pattern: 'workspace/**' })` reach a hidden subtree.
+//     Exempting them let the only hidden-identifying arg through (the bypass a
+//     review caught). They have no false-positive risk: path.resolve treats
+//     glob metacharacters as literal, so `*.ts` -> `/agent/*.ts` (passes) while
+//     `workspace/**` -> `/agent/workspace/**` (correctly blocked).
+// Fail-closed: only the listed tool's listed key is exempted; an unknown tool
+// (or grep gaining a new key) scans everything.
+const FREE_TEXT_KEYS_BY_TOOL: Record<string, ReadonlySet<string>> = {
+  grep: new Set(['pattern']),
+}
+
+// Recursively collects strings that could be paths, skipping values under a
+// universally-free-text key or a tool-scoped free-text key. matchHidden then
+// realpath-resolves each candidate and fires only on one landing inside a
+// hidden directory. Fail-closed by design: a bare path-bearing value equal to a
+// hidden dir name (e.g. `path: "memory"`) is still blocked. `underExempt`
+// propagates so nested values under an exempt key (e.g. a structured pattern)
+// stay exempt; top-level strings and array elements carry no key and are always
+// scanned (so attachments[].path is collected).
+function collectPathCandidates(value: unknown, tool: string): string[] {
   const out: string[] = []
-  walk(value, out)
+  walk(value, out, tool, false)
   return out
 }
 
-function walk(value: unknown, out: string[]): void {
+function walk(value: unknown, out: string[], tool: string, underExempt: boolean): void {
   if (typeof value === 'string') {
+    if (underExempt) return
     out.push(value)
     return
   }
   if (Array.isArray(value)) {
-    for (const item of value) walk(item, out)
+    for (const item of value) walk(item, out, tool, underExempt)
     return
   }
   if (value !== null && typeof value === 'object') {
+    const toolFreeText = FREE_TEXT_KEYS_BY_TOOL[tool]
     for (const [key, item] of Object.entries(value)) {
-      if (NON_PATH_KEYS.has(key)) continue
-      walk(item, out)
+      const keyIsExempt = NON_PATH_KEYS.has(key) || (toolFreeText?.has(key) ?? false)
+      walk(item, out, tool, underExempt || keyIsExempt)
     }
   }
 }

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -63,15 +63,49 @@ export function checkPrivateSurfaceReadGuard(options: {
   return undefined
 }
 
-// Recursively collects every string in args. Matching is left to matchHidden,
-// which resolves each string against agentDir and only fires on one that lands
-// inside a hidden directory — so the decision is "does this resolve under a
-// secret dir", not a guess about whether the string was "meant" as a path.
-// Fail-closed by design: a bare arg value equal to a hidden dir name (e.g.
-// "memory") is treated as that directory and blocked, because the alternative
-// — letting `grep <pat> workspace` through — is exactly the bypass this guard
-// exists to stop. Multi-word prose ("about memory and workspace") resolves to a
-// path that is NOT a hidden dir, so it passes.
+// Free-text field names whose values are prose/queries/patterns, NOT paths.
+// Scanning them caused false positives: a guest's `channel_reply({ text:
+// "the memory leak" })`, `websearch({ query: "workspace setup" })`, or
+// `grep({ pattern: "sessions" })` all resolve to a bare hidden-dir name and
+// were wrongly blocked. The value here is a DENYLIST OF KEY NAMES, not a tool
+// whitelist: an unknown field on an unknown tool is still scanned (fail-closed
+// for new path-bearing readers), we only skip values whose KEY is a known
+// free-text field. `command` is included because bash (the only tool with it)
+// is already exempt via UNSCANNED_TOOLS and its access is bwrap-contained.
+const NON_PATH_KEYS = new Set([
+  'text',
+  'query',
+  'pattern',
+  'prompt',
+  'selector',
+  'url',
+  'message',
+  'body',
+  'content',
+  'command',
+  'reason',
+  'subject',
+  'description',
+  'title',
+  'name',
+  // edit tool: replacement text is free-form and may quote a hidden path.
+  'oldText',
+  'newText',
+  // memory append tool: fragment topic is free text.
+  'topic',
+  // grep tool: a glob like `workspace/*.md` is a filter pattern, not the
+  // search root (that is `path`), so it must not resolve-match a hidden dir.
+  'glob',
+])
+
+// Recursively collects strings that could be paths, skipping values under
+// NON_PATH_KEYS. Matching is left to matchHidden, which realpath-resolves each
+// candidate against agentDir and only fires on one that lands inside a hidden
+// directory. Fail-closed by design: a bare path-bearing value equal to a hidden
+// dir name (e.g. `path: "memory"`) is still blocked. Top-level strings and
+// array elements carry no key, so they are always scanned (an array of paths
+// like attachments[].path is collected even though the array key itself —
+// `attachments` — is not in NON_PATH_KEYS).
 function collectPathCandidates(value: unknown): string[] {
   const out: string[] = []
   walk(value, out)
@@ -88,7 +122,10 @@ function walk(value: unknown, out: string[]): void {
     return
   }
   if (value !== null && typeof value === 'object') {
-    for (const item of Object.values(value)) walk(item, out)
+    for (const [key, item] of Object.entries(value)) {
+      if (NON_PATH_KEYS.has(key)) continue
+      walk(item, out)
+    }
   }
 }
 


### PR DESCRIPTION
> **Stacked on #495.** Base is `fix/private-surface-symlink`, not `main`. Merge #495 first, then this retargets to `main` automatically.

## Security blocker (found in pre-release review)

`privateSurfaceRead` scanned **every** string argument of every non-bash tool recursively and blocked any that resolved under a hidden dir. For a restricted role (`guest`) this **over-blocked legitimate, non-path arguments**:

```
channel_reply({ text: "memory" })        -> blocked (bare hidden-dir name)
websearch({ query: "workspace" })        -> blocked
grep({ pattern: "sessions" })            -> blocked
look_at_channel_attachment({ prompt: "sessions" }) -> blocked
```

A guest could barely talk to the agent without tripping spurious blocks on ordinary words. This is a release blocker on the usability side of the same guard.

## Fix

Make the recursive arg walk **key-aware**: skip values under a denylist of known free-text keys (`text`, `query`, `pattern`, `prompt`, `selector`, `url`, `message`, `body`, `content`, `command`, `reason`, `subject`, `description`, `title`, `name`, `oldText`, `newText`, `topic`, `glob`).

Critically, this is a **denylist of KEY NAMES, not a tool whitelist** — an unknown field on an unknown tool is still scanned, so the guard stays **fail-closed** for any new path-bearing reader that ships. Top-level strings and array elements carry no key, so `attachments[].path` and `images[].path` are still collected.

## No hole opened

I audited every non-bash tool's input schema (builtin pi tools + core agent tools + bundled plugin tools). The **only** path-bearing keys across the entire surface are:

- `path` (read, edit, write, ls, grep, find, find_entry, delete_topic_shard, look_at images)
- `images[].path` (look_at)
- `attachments[].path` (channel_send, channel_reply)

None of the exempted keys is ever used as a filesystem path. `oldText`/`newText` (edit replacement text), `topic` (memory fragment topic), and `glob` (grep filter, not the search root) were added after the audit flagged them as free-text that previously caused false positives.

## Tests

- bare hidden-dir names and path-like strings in free-text fields → allowed
- genuine path fields (`path`, `images[].path`, `attachments[].path`) → still blocked
- fail-closed: an **unknown** key on an unknown tool → still scanned and blocked

## Test plan

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check` clean. Security + memory + sandbox suites: 1132 pass, 0 fail.

> Two pre-existing full-suite failures (`resolveSelfPackageJsonPath`, Xvfb entrypoint-shim) are environment/worktree-path artifacts in files this PR does not touch.