### PR TITLE
fix(memory): run memory infrastructure as system, not the triggering role

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -712,6 +712,7 @@ export function deriveSystemPromptMode(origin: SessionOrigin | undefined): Syste
       return 'full'
     case 'cron':
     case 'subagent':
+    case 'system':
       return 'slim'
     default: {
       const _exhaustive: never = origin

--- a/src/agent/session-meta.ts
+++ b/src/agent/session-meta.ts
@@ -28,10 +28,12 @@ export type MinimalSessionOrigin =
       thread: string | null
     }
   | { kind: 'subagent'; subagent: string; parentSessionId: string }
+  | { kind: 'system'; component: string }
 
 // Reduce a full SessionOrigin to the minimum projection persisted to disk.
-// Drops participant lists, membership counts, recursive provenance, and
-// author identifiers — none of which `typeclaw usage` reads, and all of
+// Drops participant lists, membership counts, recursive provenance (including
+// the system origin's `triggeredBy`, which can carry channel author identity),
+// and author identifiers — none of which `typeclaw usage` reads, and all of
 // which would otherwise land in git history when sessions/ is auto-backed-up.
 // Kept as a separate function so the boundary between "data the LLM sees in
 // the system prompt" (full origin) and "data persisted for usage reporting"
@@ -58,5 +60,7 @@ function minimalOrigin(origin: SessionOrigin): MinimalSessionOrigin {
       }
     case 'subagent':
       return { kind: 'subagent', subagent: origin.subagent, parentSessionId: origin.parentSessionId }
+    case 'system':
+      return { kind: 'system', component: origin.component }
   }
 }

--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -29,6 +29,17 @@ describe('renderSessionOrigin', () => {
     expect(out).toContain('Stay narrowly within')
   })
 
+  test('system origin names the component and shows honest trigger provenance (not a fake TUI)', () => {
+    const out = renderSessionOrigin({
+      kind: 'system',
+      component: 'memory-logger',
+      triggeredBy: { kind: 'channel', adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null },
+    })
+    expect(out).toContain('`memory-logger` system process')
+    expect(out).toContain('Triggered by: a Slack channel turn')
+    expect(out).not.toContain('TUI session that the operator')
+  })
+
   test('channel origin shows the addressing fields and points at channel_reply by default', () => {
     const out = renderSessionOrigin({
       kind: 'channel',

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -48,6 +48,23 @@ export type SessionOrigin =
       spawnedByRole?: string
       spawnedByOrigin?: SessionOrigin
     }
+  // Runtime-owned infrastructure operating over TypeClaw's own state (memory
+  // logging/retrieval, backup), NOT user-delegated work. It resolves to `owner`
+  // because it acts on the operator's behalf over operator-owned files, with no
+  // single user session to inherit authority from — inheriting the triggering
+  // turn's role (e.g. a guest channel turn) would wrongly classify TypeClaw
+  // infrastructure as the guest actor and block its legitimate sessions//memory/
+  // access. `triggeredBy` keeps honest provenance — "a guest turn triggered the
+  // memory-logger" — without the synthetic-TUI lie. This kind is only ever
+  // constructed by runtime/bundled code; inbound channel/cron content can never
+  // produce it (those origins come from the runtime, not from message text), so
+  // it is not a role-laundering vector.
+  | {
+      kind: 'system'
+      component: string
+      reason?: string
+      triggeredBy?: SessionOrigin
+    }
 
 export const PARTICIPANTS_TOP_K = 10
 export const PARTICIPANTS_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
@@ -118,6 +135,8 @@ export function renderSessionOrigin(
       return withRoleContext(renderChannelOrigin(origin, now), roleContext)
     case 'subagent':
       return withRoleContext(renderSubagentOrigin(origin), roleContext)
+    case 'system':
+      return withRoleContext(renderSystemOrigin(origin), roleContext)
   }
 }
 
@@ -165,6 +184,34 @@ function renderCronOrigin(origin: { jobId: string; jobKind: 'prompt' | 'exec' | 
     "the prompt has everything you should need. If you can't proceed, log",
     'your blockers and exit.',
   ].join('\n')
+}
+
+function renderSystemOrigin(origin: { component: string; reason?: string; triggeredBy?: SessionOrigin }): string {
+  const lines = [
+    '## Session origin',
+    '',
+    `You are the \`${origin.component}\` system process — TypeClaw-owned`,
+    "infrastructure operating over the agent folder on the operator's behalf,",
+    'not a user-delegated task. Do exactly the job described and exit.',
+  ]
+  if (origin.reason !== undefined) lines.push('', `Reason: ${origin.reason}`)
+  if (origin.triggeredBy !== undefined) lines.push('', `Triggered by: ${describeTrigger(origin.triggeredBy)}`)
+  return lines.join('\n')
+}
+
+function describeTrigger(origin: SessionOrigin): string {
+  switch (origin.kind) {
+    case 'tui':
+      return 'a TUI session'
+    case 'cron':
+      return `cron job \`${origin.jobId}\``
+    case 'channel':
+      return `a ${getPlatformInfo(origin.adapter).displayName} channel turn`
+    case 'subagent':
+      return `the \`${origin.subagent}\` subagent`
+    case 'system':
+      return `the \`${origin.component}\` system process`
+  }
 }
 
 function renderSubagentOrigin(origin: { subagent: string; parentSessionId: string }): string {

--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -359,6 +359,51 @@ describe('createSubagentConsumer', () => {
     consumer.stop()
   })
 
+  test('preserves a system spawnedByOrigin through JSON parse (not dropped to guest)', async () => {
+    // given: a streamed spawn whose spawnedByOrigin is a system origin —
+    // exactly how the memory plugin's spawn reaches a stream consumer once
+    // serialized. Regression guard for SESSION_ORIGIN_KINDS dropping 'system'.
+    const stream = createStream()
+    const captured: { spawnedByOrigin?: unknown }[] = []
+    // No custom handler: only the session path threads spawnedByOrigin into
+    // createSessionForSubagent. A handler-based subagent never sees the origin.
+    const registry = {
+      'memory-logger': {
+        systemPrompt: 'X',
+        payloadSchema: z.object({ agentDir: z.string() }),
+      } satisfies Subagent<{ agentDir: string }>,
+    }
+    const consumer = createSubagentConsumer({
+      stream,
+      getRegistry: () => registry,
+      agentDir: '/agent',
+      createSessionForSubagent: async (_subagent, options) => {
+        captured.push({ spawnedByOrigin: options?.spawnedByOrigin })
+        return fakeAgentSession([])
+      },
+      logger: silent,
+    })
+    consumer.start()
+
+    // when
+    const systemOrigin = { kind: 'system', component: 'memory-logger' }
+    stream.publish({
+      target: {
+        kind: 'new-session',
+        subagent: 'memory-logger',
+        spawnedByOriginJson: JSON.stringify(systemOrigin),
+      },
+      payload: { agentDir: '/agent' },
+    })
+    await new Promise((r) => setImmediate(r))
+
+    // then: the system origin survived parsing and reached the spawn
+    expect(captured).toHaveLength(1)
+    expect(captured[0]!.spawnedByOrigin).toEqual(systemOrigin)
+
+    consumer.stop()
+  })
+
   test('warns and ignores messages for unregistered subagent names', async () => {
     // given
     const stream = createStream()

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -455,7 +455,12 @@ function parseSpawnedByOriginJson(
   return parsed
 }
 
-const SESSION_ORIGIN_KINDS = new Set(['tui', 'cron', 'channel', 'subagent'])
+// Must list EVERY SessionOrigin discriminator. `system` is included so a
+// streamed memory/backup spawn (whose spawnedByOrigin is serialized to JSON
+// and re-parsed here) keeps its owner-resolving origin instead of being
+// dropped and silently demoted to guest — the exact regression the system
+// origin exists to prevent. Keep in sync with the SessionOrigin union.
+const SESSION_ORIGIN_KINDS = new Set(['tui', 'cron', 'channel', 'subagent', 'system'])
 function isSessionOriginShape(value: unknown): value is SessionOrigin {
   if (value === null || typeof value !== 'object') return false
   const kind = (value as { kind?: unknown }).kind

--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -294,7 +294,13 @@ describe('session.turn.start hook', () => {
       cacheFilePath: join(agentDir, 'memory', '.retrieval-cache', 'ses_parent.md'),
       origin,
     })
-    expect(spawned[0]!.options).toEqual({ parentSessionId: 'ses_parent', spawnedByOrigin: origin })
+    // Execution authority is `system` (→ owner), with the triggering origin
+    // preserved as `triggeredBy` for audit. Content provenance stays in the
+    // payload `origin` above.
+    expect(spawned[0]!.options).toEqual({
+      parentSessionId: 'ses_parent',
+      spawnedByOrigin: { kind: 'system', component: 'memory-retrieval', triggeredBy: origin },
+    })
   })
 
   test('passes the actual user text, not the assembling system prompt (the bug session.prompt produced)', async () => {

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -6,7 +6,7 @@ import { CronExpressionParser } from 'cron-parser'
 import { z } from 'zod'
 
 import type { SessionOrigin } from '@/agent/session-origin'
-import { definePlugin } from '@/plugin'
+import { definePlugin, type SpawnSubagentOptions } from '@/plugin'
 import { formatLocalDate } from '@/shared'
 
 import { createDreamingSubagent, type DreamingPayload } from './dreaming'
@@ -205,9 +205,20 @@ export default definePlugin({
         ...(last.origin !== undefined ? { origin: last.origin } : {}),
         ...(streamLineCursor !== undefined ? { streamLineCursor } : {}),
       }
-      const spawnOptions = {
+      // Execution authority is `system` (resolves to owner), NOT the
+      // triggering turn's role: memory-logging is TypeClaw infrastructure over
+      // operator-owned sessions//memory/, so a guest channel turn that triggers
+      // it must not demote the logger to guest and get its transcript read
+      // blocked by privateSurfaceRead. The triggering origin is preserved two
+      // ways: `triggeredBy` for audit provenance, and `payload.origin` for
+      // content provenance (memory extraction/retrieval channel-safety).
+      const spawnOptions: SpawnSubagentOptions = {
         parentSessionId: sessionId,
-        ...(last.origin !== undefined ? { spawnedByOrigin: last.origin } : {}),
+        spawnedByOrigin: {
+          kind: 'system',
+          component: 'memory-logger',
+          ...(last.origin !== undefined ? { triggeredBy: last.origin } : {}),
+        },
       }
       const next = spawnChain
         .catch(() => undefined)
@@ -280,10 +291,18 @@ export default definePlugin({
         cacheFilePath,
         ...(event.origin !== undefined ? { origin: event.origin } : {}),
       }
-      await ctx.spawnSubagent('memory-retrieval', payload, {
+      // System authority, not the triggering turn's role — see the
+      // memory-logger spawn above. memory-retrieval writes
+      // memory/.retrieval-cache/, which a guest-demoted role cannot.
+      const retrievalSpawnOptions: SpawnSubagentOptions = {
         parentSessionId: event.sessionId,
-        ...(event.origin !== undefined ? { spawnedByOrigin: event.origin } : {}),
-      })
+        spawnedByOrigin: {
+          kind: 'system',
+          component: 'memory-retrieval',
+          ...(event.origin !== undefined ? { triggeredBy: event.origin } : {}),
+        },
+      }
+      await ctx.spawnSubagent('memory-retrieval', payload, retrievalSpawnOptions)
     }
 
     // Subagents are constructed at boot here (rather than imported as constants)

--- a/src/inspect/label.ts
+++ b/src/inspect/label.ts
@@ -20,6 +20,8 @@ export function originLabel(origin: MinimalSessionOrigin): string {
       return `Subagent ${origin.subagent} ← ${shortSessionId(origin.parentSessionId)}`
     case 'channel':
       return channelLabel(origin)
+    case 'system':
+      return `System ${origin.component}`
   }
 }
 

--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -43,6 +43,20 @@ describe('PermissionService — defaults', () => {
     expect(svc.has(undefined, 'channel.respond')).toBe(false)
   })
 
+  test('system origin → owner (runtime infrastructure acts on operator behalf)', () => {
+    const svc = createPermissionService({ pluginPermissions: PLUGIN_PERMS })
+    expect(svc.resolveRole({ kind: 'system', component: 'memory-logger' })).toBe('owner')
+    // A guest-triggered system process still resolves to owner — the
+    // triggering origin does not demote it.
+    expect(
+      svc.resolveRole({
+        kind: 'system',
+        component: 'memory-logger',
+        triggeredBy: { kind: 'channel', adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null },
+      }),
+    ).toBe('owner')
+  })
+
   test('tui origin → owner via built-in match', () => {
     const svc = createPermissionService({ pluginPermissions: PLUGIN_PERMS })
     expect(svc.resolveRole(tui)).toBe('owner')

--- a/src/permissions/permissions.ts
+++ b/src/permissions/permissions.ts
@@ -110,6 +110,13 @@ export function createPermissionService(opts: CreatePermissionServiceOptions = {
   function resolveRole(origin: SessionOrigin | undefined): string {
     if (origin === undefined) return 'guest'
 
+    // Runtime-owned infrastructure (memory, backup) acts on the operator's
+    // behalf over operator-owned state. It is constructed only by runtime/
+    // bundled code — inbound channel/cron content cannot produce this kind —
+    // so resolving it to owner is not a laundering vector. See the `system`
+    // origin doc in session-origin.ts.
+    if (origin.kind === 'system') return 'owner'
+
     if (origin.kind === 'cron') {
       const role = origin.scheduledByRole
       if (role !== undefined && byName.has(role)) return role

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -250,6 +250,18 @@ export type SpawnSubagentOptions = {
   // `spawnedByOrigin: event.origin`. The runtime resolves `spawnedByRole`
   // from the origin via the PermissionService, so the spawning session's
   // role is inherited rather than forged from outside.
+  //
+  // TRUST MODEL: `spawnedByOrigin` accepts any SessionOrigin, including
+  // `{ kind: 'system' }`, which resolves to owner. That is intentional and
+  // not an escalation path: a plugin is a full-trust, in-process module with
+  // no sandbox (see AGENTS.md / docs/internals/skills) — it can already do
+  // anything the runtime can, so minting a system origin grants it nothing it
+  // lacks. The anti-forgery guarantee this API preserves is narrower and
+  // unaffected: inbound channel/cron CONTENT can never reach owner, because
+  // those origins are constructed by the runtime from the transport, never
+  // from message text, and a content-driven turn cannot produce a `system`
+  // origin. Bundled infra (memory, backup) uses `system` to act on the
+  // operator's own state; third-party plugins should pass `event.origin`.
   parentSessionId?: string
   spawnedByOrigin?: SessionOrigin
 }

--- a/src/sandbox/hidden-paths.test.ts
+++ b/src/sandbox/hidden-paths.test.ts
@@ -35,6 +35,18 @@ describe('resolveHiddenPaths — builtin tiers', () => {
     expect(files).toEqual([])
   })
 
+  test('system origin hides nothing even when triggered by a guest channel turn', () => {
+    const svc = createPermissionService()
+    const origin: SessionOrigin = {
+      kind: 'system',
+      component: 'memory-logger',
+      triggeredBy: { kind: 'channel', adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null },
+    }
+    const { dirs, files } = resolveHiddenPaths(svc, origin, AGENT)
+    expect(dirs).toEqual([])
+    expect(files).toEqual([])
+  })
+
   test('member sees private surface but hides the secret files', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('member'), AGENT)

--- a/src/usage/report.ts
+++ b/src/usage/report.ts
@@ -140,6 +140,8 @@ function renderOriginLabel(kind: OriginKind, ctx: RenderCtx): string {
       return `${color('green', '#', ctx)} ${'channel'}`
     case 'subagent':
       return `${color('yellow', '↳', ctx)} ${'subagent'}`
+    case 'system':
+      return `${color('blue', '⚙', ctx)} ${'system'}`
     case 'unknown':
       return `${dim('?', ctx)} ${dim('unknown', ctx)}`
   }
@@ -211,6 +213,8 @@ function originGlyphOnly(kind: OriginKind, ctx: RenderCtx): string {
       return color('green', '#', ctx)
     case 'subagent':
       return color('yellow', '↳', ctx)
+    case 'system':
+      return color('blue', '⚙', ctx)
     case 'unknown':
       return dim('?', ctx)
   }

--- a/src/usage/scan.ts
+++ b/src/usage/scan.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path'
 // before origin stamping landed AND sessions whose session-meta line is
 // malformed or missing — surfacing them under one explicit label is more
 // honest than silently dropping them.
-export const ORIGIN_KINDS = ['tui', 'cron', 'channel', 'subagent', 'unknown'] as const
+export const ORIGIN_KINDS = ['tui', 'cron', 'channel', 'subagent', 'system', 'unknown'] as const
 export type OriginKind = (typeof ORIGIN_KINDS)[number]
 
 // Narrow projection: session files can grow into tens of MB on long-lived


### PR DESCRIPTION
## Regression (found in pre-release review)

The role-based sandbox (#488) hides `sessions/`, `memory/`, `workspace/` from the `guest` role. The memory infrastructure subagents — `memory-logger` and `memory-retrieval` — inherited the **spawning turn's role** via `spawnedByOrigin: <parent origin>`. When a **guest channel turn** triggered them, they resolved to `guest`, and `privateSurfaceRead` then blocked their legitimate access:

- `memory-logger` reading the parent transcript under `sessions/`
- `memory-retrieval` writing `memory/.retrieval-cache/<id>.md`

Result: **guest channel turns silently fell out of memory** — no error surfaced to the operator, the conversation just stopped being logged/retrieved. Silent data loss.

## Root cause

The bug is not "the subagent uses a guarded tool." It is that the runtime **classified TypeClaw-owned memory infrastructure as the guest actor**. Memory logging is infrastructure that fires after *every* turn regardless of who spoke; it acts on the operator's behalf over operator-owned state, not as user-delegated work. The `backup` plugin already recognized this — it spawns its runner with a synthetic TUI origin so it resolves to `owner`.

## Fix: a first-class `system` origin

Rather than copy backup's synthetic-TUI hack (which lies in audit trails — a guest-triggered job recorded as "TUI-originated"), this adds a proper `{ kind: 'system'; component; triggeredBy? }` session origin:

- **Resolves to `owner`** in the permission service.
- **Honest provenance**: `triggeredBy` records what triggered it (e.g. the guest channel turn) for audit, without claiming a TUI session that never existed.
- **Not a role-laundering vector**: the kind is constructed only by runtime/bundled code. Inbound channel/cron content can never produce it (those origins are runtime-built, never from message text), so resolving it to owner opens no new path for untrusted content to gain authority.

`memory-logger` and `memory-retrieval` now spawn with this origin. Two provenance channels are preserved deliberately:

- **`triggeredBy`** on the origin → execution-time audit (and dropped from the persisted `MinimalSessionOrigin` projection so channel author identity never lands in git-backed `sessions/`).
- **`payload.origin`** → content provenance, unchanged, still drives the existing channel-origin retrieval/extraction safeguards.

## Confidentiality note

Role is authorization, not observability. Guest turns remain eligible for memory logging — the operator's agent is allowed to remember its own conversations. The confidentiality boundary lives at **retrieval/response** (the existing channel-origin index-mode + outbound guards), not at logging. This PR does not change those safeguards.

## Commits

1. `feat(agent): add the system session origin kind and its rendering` — defines the kind, threads it through every exhaustive origin switch (render, slim-prompt, persisted projection, inspect label). Role still falls through to guest here.
2. `feat(permissions): resolve the system origin to owner` — the isolated privilege grant, reviewed on its own.
3. `fix(memory): spawn memory subagents with system authority` — wires the two memory subagents to it.

## Test plan

- New tests: system origin → owner even when `triggeredBy` is a guest channel turn; `resolveHiddenPaths` hides nothing for it; rendered provenance shows the real trigger (not a fake TUI); memory-retrieval spawn carries the system origin with the parent as `triggeredBy`.
- `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check` clean. Touched-domain suites: 969 pass, 0 fail.

> Two pre-existing full-suite failures (`resolveSelfPackageJsonPath`, Xvfb entrypoint-shim) are environment/worktree-path artifacts in files this PR does not touch.