### PR TITLE
fix(channels): recreate live channel sessions on roles.match reload

### DIFF
--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -45,6 +45,7 @@ function makeRouter(options: FakeRouterOptions = {}): ChannelRouter {
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     stop: async () => {},
+    tearDownAllLive: async () => {},
     liveCount: () => 0,
   }
 }

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -39,6 +39,7 @@ function fakeRouter(
     listInboundAttachmentIds: () => [],
     getSelfAliases: () => [],
     stop: async () => {},
+    tearDownAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -33,6 +33,7 @@ function fakeRouter(
     listInboundAttachmentIds: () => [],
     getSelfAliases: () => [],
     stop: async () => {},
+    tearDownAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -61,6 +61,7 @@ function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
     listInboundAttachmentIds: () => (overrides.attachments ?? []).map((attachment) => attachment.id),
     getSelfAliases: () => [],
     stop: async () => {},
+    tearDownAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/skip-response.test.ts
+++ b/src/agent/tools/skip-response.test.ts
@@ -38,6 +38,7 @@ function fakeRouter(
     listInboundAttachmentIds: () => [],
     getSelfAliases: () => [],
     stop: async () => {},
+    tearDownAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -52,6 +52,7 @@ function fakeRouter(handler: (msg: OutboundMessage) => Promise<SendResult>): Cha
     listInboundAttachmentIds: () => [],
     getSelfAliases: () => [],
     stop: async () => {},
+    tearDownAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -27,6 +27,7 @@ import {
   SESSION_FRESHNESS_TTL_MS,
   SESSION_IDLE_MS,
   sliceHeadTail,
+  StaleLiveSessionError,
   TURN_CAP_ERROR,
   type ChannelRouter,
   type ClaimHandler,
@@ -802,6 +803,52 @@ describe('ChannelRouter ensureLive watchdog', () => {
     // evicted on timeout) and the second call succeeded into a live session
     expect(callCount).toBe(2)
     expect(router.liveCount()).toBe(1)
+  })
+
+  test('tearDownAllLive() during an in-flight creation discards the stale session instead of installing it', async () => {
+    // given a factory whose first creation blocks until we release it, so we can
+    // run tearDownAllLive() (the roles-reload teardown) in the exact window
+    // between creation start and the liveSessions.set install
+    const dir = await tempDir()
+    let callCount = 0
+    let releaseFirst: (() => void) | undefined
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      createSessionForChannel: async () => {
+        callCount++
+        if (callCount === 1) await firstBlocked
+        const fake = new FakeSession()
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: `ses_race_${callCount}`,
+          dispose: async () => {
+            fake.dispose()
+          },
+        }
+      },
+    })
+
+    // when the first inbound starts creating (and blocks), a roles reload tears
+    // down all live sessions, then the blocked creation is released
+    const routePromise = router.route(inbound())
+    await new Promise((r) => setTimeout(r, 10))
+    await router.tearDownAllLive()
+    releaseFirst!()
+
+    // then the in-flight creation self-disposes (route rejects) and nothing was
+    // installed — the stale-role session never becomes live
+    await expect(routePromise).rejects.toBeInstanceOf(StaleLiveSessionError)
+    expect(router.liveCount()).toBe(0)
+
+    // and a fresh post-reload inbound creates a new live session normally
+    await router.route(inbound({ externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(router.liveCount()).toBe(1)
+    expect(callCount).toBe(2)
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -164,6 +164,19 @@ export const SESSION_FRESHNESS_TTL_MS = 5 * 60 * 1000
 // instead of awaiting the same dead promise forever.
 export const ENSURE_LIVE_TIMEOUT_MS = 30_000
 
+// Thrown by ensureLive() when a teardown (roles reload or shutdown) raced
+// ahead of an in-flight creation. route() has no special handling — it
+// propagates to the adapter's outer catch, dropping this one inbound. The
+// next inbound creates a fresh, post-reload session, which is the intended
+// outcome: a message that arrived mid-reload is cheap to drop, far cheaper
+// than answering it through a session built with the stale role.
+export class StaleLiveSessionError extends Error {
+  constructor(keyId: string) {
+    super(`[channels] ${keyId}: live session creation raced a teardown; discarded`)
+    this.name = 'StaleLiveSessionError'
+  }
+}
+
 // Per-callback ceilings inside the ensureLive chain. The outer watchdog
 // catches the worst case, but per-step timeouts give better log
 // attribution (which step hung) AND graceful degradation: a hung name
@@ -692,6 +705,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const stream = options.stream
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
+  // Bumped by tearDownAllLive() and stop() before they tear sessions down. An
+  // in-flight ensureLive() captures the value at creation start and re-checks
+  // it right before installing into liveSessions; if it changed, a teardown
+  // raced ahead of this creation (e.g. a roles.match reload), so the session
+  // was built with stale role context and must self-dispose instead of
+  // installing — otherwise it would reintroduce the very staleness the
+  // teardown was meant to clear.
+  let liveGeneration = 0
   const outboundCallbacks = new Map<ChannelKey['adapter'], Set<OutboundCallback>>()
   const typingCallbacks = new Map<ChannelKey['adapter'], Set<TypingCallback>>()
   const channelNameResolvers = new Map<ChannelKey['adapter'], Set<ChannelNameResolver>>()
@@ -910,6 +931,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const inFlight = creating.get(keyId)
     if (inFlight) return inFlight
 
+    const generation = liveGeneration
+
     const promise = (async () => {
       await ensureLoaded()
       const record = mappings ? findRecord(mappings, key) : undefined
@@ -1074,6 +1097,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.unsubTypingActivity = subscribeTypingActivity(created.session, live)
       installChannelReplyTerminalHook(live)
       installChannelOutputCap(live)
+
+      // A teardown (roles reload / shutdown) ran while this session was being
+      // built, so it carries stale role context. Dispose it instead of
+      // installing — installing here is the exact window the race exploits.
+      if (generation !== liveGeneration) {
+        logger.info(
+          `[channels] ${keyId}: discarding session created across a teardown (gen ${generation} → ${liveGeneration})`,
+        )
+        await tearDownLive(live)
+        throw new StaleLiveSessionError(keyId)
+      }
       liveSessions.set(keyId, live)
 
       if (isColdStart) {
@@ -2335,6 +2369,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const stop = async (): Promise<void> => {
     if (gcTimer) clearInterval(gcTimer)
     gcTimer = null
+    liveGeneration++
     const all = Array.from(liveSessions.values())
     liveSessions.clear()
     for (const live of all) {
@@ -2348,7 +2383,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // This is how a `roles.<name>.match` reload reaches live channel sessions.
   // Unlike stop() it leaves the GC timer running; unlike stale-rollover it
   // keeps the sessionId, so history survives.
+  //
+  // Bumping liveGeneration BEFORE the snapshot is what makes this race-free:
+  // a session mid-creation (in `creating` but not yet in `liveSessions`) won't
+  // appear in the snapshot below, but it captured the old generation and will
+  // self-dispose at its install guard instead of resurrecting stale role state.
   const tearDownAllLive = async (): Promise<void> => {
+    liveGeneration++
     const all = Array.from(liveSessions.values())
     liveSessions.clear()
     for (const live of all) {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -562,6 +562,7 @@ export type ChannelRouter = {
     | { kind: 'recorded-after-send'; keyId: string }
     | { kind: 'no-live-session' }
   stop: () => Promise<void>
+  tearDownAllLive: () => Promise<void>
   liveCount: () => number
   __testing?: {
     flushDebounce: (key: ChannelKey) => Promise<void>
@@ -2341,6 +2342,20 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
+  // Drops every in-memory session but KEEPS the on-disk records, so the next
+  // inbound per channel rehydrates the same transcript through a fresh
+  // createSession() — which re-renders the frozen system-prompt role block.
+  // This is how a `roles.<name>.match` reload reaches live channel sessions.
+  // Unlike stop() it leaves the GC timer running; unlike stale-rollover it
+  // keeps the sessionId, so history survives.
+  const tearDownAllLive = async (): Promise<void> => {
+    const all = Array.from(liveSessions.values())
+    liveSessions.clear()
+    for (const live of all) {
+      await tearDownLive(live)
+    }
+  }
+
   const executeCommand = async (
     key: ChannelKey,
     name: string,
@@ -2476,6 +2491,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     injectSubagentCompletionReminder,
     markTurnSkipped,
     stop,
+    tearDownAllLive,
     liveCount: () => liveSessions.size,
     __testing: {
       flushDebounce: async (key: ChannelKey) => {

--- a/src/config/reloadable.roles.test.ts
+++ b/src/config/reloadable.roles.test.ts
@@ -79,6 +79,55 @@ describe('config reload: roles split between match (applied) and permissions (re
     ).toBe(true)
   })
 
+  test('roles.<name>.match change → onRolesChanged fired so live channel sessions are recreated', async () => {
+    const cwd = freshAgentDir({
+      model: 'openai/gpt-5.4-mini',
+      roles: { owner: { match: ['tui'] } },
+    })
+    reloadConfig(cwd)
+
+    const permissions = createPermissionService({ roles: { owner: { match: [{ kind: 'tui' }] } } })
+    let recreated = 0
+
+    writeFileSync(
+      join(cwd, 'typeclaw.json'),
+      `${JSON.stringify(
+        { model: 'openai/gpt-5.4-mini', roles: { owner: { match: ['tui', 'slack:T0123 author:U_ME'] } } },
+        null,
+        2,
+      )}\n`,
+    )
+
+    const reloadable = createConfigReloadable({
+      cwd,
+      permissions,
+      onRolesChanged: () => {
+        recreated++
+      },
+    })
+    const result = await reloadable.reload()
+
+    expect(result.ok).toBe(true)
+    expect(recreated).toBe(1)
+  })
+
+  test('reload with no role.match change → onRolesChanged not fired', async () => {
+    const cwd = freshAgentDir({ model: 'openai/gpt-5.4-mini', roles: { owner: { match: ['tui'] } } })
+    reloadConfig(cwd)
+
+    let recreated = 0
+    const reloadable = createConfigReloadable({
+      cwd,
+      onRolesChanged: () => {
+        recreated++
+      },
+    })
+    const result = await reloadable.reload()
+
+    expect(result.ok).toBe(true)
+    expect(recreated).toBe(0)
+  })
+
   test('changing roles.<name>.permissions → reported as restart-required', async () => {
     const cwd = freshAgentDir({
       model: 'openai/gpt-5.4-mini',

--- a/src/config/reloadable.ts
+++ b/src/config/reloadable.ts
@@ -11,6 +11,10 @@ export type CreateConfigReloadableOptions = {
   // hand-edits) take effect without a container restart. `roles.<name>.permissions`
   // changes still require a restart — see FIELD_EFFECTS in config.ts.
   permissions?: PermissionService
+  // Fired after replaceRoles when a `roles.<name>.match` edit is applied. The
+  // run stage wires this to the channel router so live sessions are recreated
+  // and pick up the new role in their (otherwise frozen) system prompt.
+  onRolesChanged?: () => void | Promise<void>
   // Skip the mount-path accessibility check inside validateConfig. Mount paths
   // in typeclaw.json are host paths — they don't resolve inside the container,
   // so the check would always fail on any agent that declares mounts. `mounts`
@@ -22,18 +26,20 @@ export type CreateConfigReloadableOptions = {
 export function createConfigReloadable({
   cwd,
   permissions,
+  onRolesChanged,
   skipMountValidation = false,
 }: CreateConfigReloadableOptions): Reloadable {
   return {
     scope: 'config',
     description: 'typeclaw.json runtime config',
-    reload: async () => doReload(cwd, permissions, skipMountValidation),
+    reload: async () => doReload(cwd, permissions, onRolesChanged, skipMountValidation),
   }
 }
 
 async function doReload(
   cwd: string,
   permissions: PermissionService | undefined,
+  onRolesChanged: (() => void | Promise<void>) | undefined,
   skipMountValidation: boolean,
 ): Promise<ReloadResult> {
   // Mount accessibility belongs to the validation surface, not loadConfigSync —
@@ -59,8 +65,9 @@ async function doReload(
     return { scope: 'config', ok: false, reason: message }
   }
 
-  if (permissions !== undefined && diff.applied.some((c) => c.path === 'roles.match')) {
-    permissions.replaceRoles(getConfig().roles)
+  if (diff.applied.some((c) => c.path === 'roles.match')) {
+    permissions?.replaceRoles(getConfig().roles)
+    await onRolesChanged?.()
   }
 
   return {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -150,6 +150,7 @@ export async function startAgent({
     createConfigReloadable({
       cwd,
       permissions: pluginsLoaded.permissions,
+      onRolesChanged: () => channelManager.router.tearDownAllLive(),
       skipMountValidation: containerName !== undefined,
     }),
   )


### PR DESCRIPTION
## Background

After a `typeclaw reload` that edits `roles.<name>.match`, the live role table is updated (`permissions.replaceRoles` in `src/config/reloadable.ts`). Three places in the runtime surface a session's role:

1. **Tool permission gating** — re-resolved per message via the live `originRef.current` (`src/agent/index.ts:229-230`). Already live.
2. **Per-turn `<your-role>` anchor** in the user-turn suffix — re-resolved per turn (`src/channels/router.ts:1461-1468`). Already live.
3. **System prompt `## Your role in this session` block** — rendered once at session creation by `renderRoleContext()` (`src/agent/session-origin.ts:148-161`) and frozen for the session's lifetime (documented at `session-origin.ts:107-118`). Stale after reload.

The result: after a role change via reload, a promoted or demoted channel user kept their old role in the system prompt until their session was genuinely recreated. Enforcement was never affected — this is a model-signal correctness bug, not a privilege escalation.

## Summary

**Commit 1 — `feat(channels): add ChannelRouter.tearDownAllLive()`** (`src/channels/router.ts`)

New method on the `ChannelRouter` interface that drops every in-memory live session while leaving on-disk records intact (`channels/sessions.json` keeps its `sessionId`/`sessionFile`). The next inbound message per channel rehydrates the same transcript through a fresh `createSession()`, which re-renders the frozen role block with the current resolved role.

The distinction from neighbouring operations matters:
- `stop()` — also clears the GC timer; reserved for shutdown.
- Stale-rollover — drops the `sessionId`, forcing a cold-start with an empty transcript.
- `tearDownAllLive()` — drops in-memory state only. History survives.

Six mock routers in `src/agent/tools/*.test.ts` and `src/channels/adapters/github/*.test.ts` gain the no-op stub to satisfy the updated interface.

**Commit 2 — `fix(config): recreate live channel sessions on roles.match reload`** (`src/config/reloadable.ts`, `src/run/index.ts`)

Adds an `onRolesChanged?: () => void | Promise<void>` hook to `CreateConfigReloadableOptions`, fired right after `replaceRoles` when `roles.match` appears in the applied diff. The run stage (`src/run/index.ts`) wires it:

```ts
onRolesChanged: () => channelManager.router.tearDownAllLive(),
```

The `permissions?.replaceRoles(...)` call is also narrowed: the `permissions !== undefined` guard is no longer required at the outer `if` because the call is now optional-chained, making the branch fire for `onRolesChanged` even when no `PermissionService` is wired (tests, cron).

## What this does NOT do

Does not address the **mixed-speaker staleness** issue: in a group channel, if an owner opens a session and a guest speaks later, the system prompt still asserts the owner's role and permission list (info leak + contradictory signal vs the per-turn anchor). An Oracle architecture review recommends replacing the definitive cached role block with a cache-stable "multi-speaker role policy" block for channel origins, and making the per-turn `<your-role>` anchor authoritative. Planned as a follow-up.

## Review notes

- **Load-bearing line**: `src/run/index.ts` — the single wire between `onRolesChanged` and the router. Everything else is plumbing.
- **Interface change**: `tearDownAllLive` is now required on `ChannelRouter`. Any future mock that omits it will fail to compile — intentional, so the pattern propagates.
- **Pre-existing typecheck errors**: `src/channels/adapters/kakaotalk.ts` and its test have 2 errors (`KakaoReplyTarget` missing from `agent-messenger/kakaotalk`) that exist on `main` and are unrelated to this change.
- **Pre-existing test failures**: schema drift/scaffold guards and `resolveSelfPackageJsonPath` fail on the base commit in this environment (symlinked `node_modules` artifact); none touch channels/config/permissions. New tests in `src/config/reloadable.roles.test.ts` and the full router, manager, and run suites pass.
- `bun run lint` — 0 errors (64 pre-existing warnings). `bun run format:check` — clean.