### PR TITLE
feat(permissions): move fail-safe floor to undefined origin; split session.control from channel.respond

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5124,6 +5124,67 @@ describe('ChannelRouter channel.respond gate', () => {
     expect(sessions[0]!.prompts).toHaveLength(1)
   })
 
+  test('respond-capable author WITHOUT session.control cannot /stop via text prefix', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    // guest-shaped: channel.respond granted (can drive turns) but no
+    // session.control, so /stop must be refused.
+    const permissions = buildPermissions({
+      alice: ['channel.respond', 'session.control'],
+      stranger: ['channel.respond'],
+    })
+    const { router, sessions } = makeRouter(dir, { permissions, logs })
+
+    // given: alice (full control) starts a live session
+    await router.route(inbound({ authorId: 'alice', externalMessageId: 'm-alice' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions).toHaveLength(1)
+
+    // when: stranger (respond but no control) types /stop
+    await router.route(inbound({ authorId: 'stranger', text: '/stop', externalMessageId: 'm-stop' }))
+    await new Promise((r) => setTimeout(r, 10))
+
+    // then: the command is refused and the session is not aborted
+    expect(sessions[0]!.aborted).toBe(0)
+    expect(logs.some((l) => l.includes('session.control') && l.includes('author=stranger'))).toBe(true)
+  })
+
+  test('author WITH session.control can /stop via text prefix', async () => {
+    const dir = await tempDir()
+    const permissions = buildPermissions({ alice: ['channel.respond', 'session.control'] })
+    const { router, sessions } = makeRouter(dir, { permissions })
+
+    await router.route(inbound({ authorId: 'alice', externalMessageId: 'm-alice' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions).toHaveLength(1)
+
+    await router.route(inbound({ authorId: 'alice', text: '/stop', externalMessageId: 'm-stop' }))
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(sessions[0]!.aborted).toBe(1)
+  })
+
+  test('native executeCommand gates on session.control, not channel.respond', async () => {
+    const dir = await tempDir()
+    const permissions = buildPermissions({
+      alice: ['channel.respond', 'session.control'],
+      stranger: ['channel.respond'],
+    })
+    const { router, sessions } = makeRouter(dir, { permissions })
+
+    await router.route(inbound({ authorId: 'alice', externalMessageId: 'm-alice' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions).toHaveLength(1)
+
+    const denied = await router.executeCommand(KEY, 'stop', { invokerId: 'stranger' })
+    expect(denied).toEqual({ kind: 'permission-denied' })
+    expect(sessions[0]!.aborted).toBe(0)
+
+    const allowed = await router.executeCommand(KEY, 'stop', { invokerId: 'alice' })
+    expect(allowed).toEqual({ kind: 'handled', name: 'stop' })
+    expect(sessions[0]!.aborted).toBe(1)
+  })
+
   test('deny-all permissions service drops every inbound', async () => {
     const dir = await tempDir()
     const permissions: PermissionService = {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1632,6 +1632,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         logger.info(`[channels] ${keyId}: ignoring unknown command /${parsedCommand.name}`)
         return
       }
+      if (isSessionControlDenied(event)) {
+        logger.info(
+          `[channels] ${keyId}: denied command /${parsedCommand.name} by permissions (session.control) author=${event.authorId}`,
+        )
+        return
+      }
       const existingLive = liveSessions.get(keyId)
       if (!existingLive || existingLive.destroyed) {
         logger.info(`[channels] ${keyId}: ignoring command /${parsedCommand.name} with no live session`)
@@ -1714,17 +1720,24 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     scheduleDebouncedDrain(live)
   }
 
-  const isChannelRespondDenied = (event: InboundMessage): boolean => {
-    const partial: SessionOrigin = {
-      kind: 'channel',
-      adapter: event.adapter,
-      workspace: event.workspace,
-      chat: event.chat,
-      thread: event.thread,
-      lastInboundAuthorId: event.authorId,
-    }
-    return !permissions.has(partial, CORE_PERMISSIONS.channelRespond)
-  }
+  const inboundAuthorOrigin = (event: InboundMessage): SessionOrigin => ({
+    kind: 'channel',
+    adapter: event.adapter,
+    workspace: event.workspace,
+    chat: event.chat,
+    thread: event.thread,
+    lastInboundAuthorId: event.authorId,
+  })
+
+  const isChannelRespondDenied = (event: InboundMessage): boolean =>
+    !permissions.has(inboundAuthorOrigin(event), CORE_PERMISSIONS.channelRespond)
+
+  // Gated separately from channelRespond so a respond-capable guest (an
+  // operator can grant guest channelRespond for masked stranger turns)
+  // cannot /stop another speaker's in-flight turn. session.control is
+  // member-and-up by default.
+  const isSessionControlDenied = (event: InboundMessage): boolean =>
+    !permissions.has(inboundAuthorOrigin(event), CORE_PERMISSIONS.sessionControl)
 
   const updateLoopGuard = (live: LiveSession, event: InboundMessage): void => {
     if (!event.authorIsBot) {
@@ -2350,11 +2363,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (!commands.has(lowered)) {
       return { kind: 'unknown-command', name: lowered }
     }
-    // Permission gate runs BEFORE the live-session lookup so a guest user
-    // invoking /stop on a non-existent session gets 'permission-denied'
-    // (consistent answer regardless of session state) rather than leaking
-    // session presence via the 'no-live-session' vs 'permission-denied'
-    // distinction.
+    // Gates on session.control (not channel.respond) so a respond-capable
+    // guest cannot abort another speaker's turn. Runs BEFORE the live-session
+    // lookup so an unauthorized invoker gets 'permission-denied' regardless of
+    // session state, rather than leaking session presence via the
+    // 'no-live-session' vs 'permission-denied' distinction.
     const partial: SessionOrigin = {
       kind: 'channel',
       adapter: key.adapter,
@@ -2363,7 +2376,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       thread: key.thread,
       lastInboundAuthorId: options.invokerId,
     }
-    if (!permissions.has(partial, CORE_PERMISSIONS.channelRespond)) {
+    if (!permissions.has(partial, CORE_PERMISSIONS.sessionControl)) {
       return { kind: 'permission-denied' }
     }
     const resolved = resolveLiveSessionForCommand(liveSessions, key)

--- a/src/permissions/builtins.test.ts
+++ b/src/permissions/builtins.test.ts
@@ -34,6 +34,7 @@ describe('built-in role contract (role-tower model: owner=high, trusted=medium, 
       'fs.see.secrets',
       'security.bypass.low',
       'security.bypass.medium',
+      'session.control',
       'subagent.cancel',
       'subagent.output',
       'subagent.spawn',
@@ -51,6 +52,7 @@ describe('built-in role contract (role-tower model: owner=high, trusted=medium, 
       'channel.respond',
       'fs.see.private',
       'security.bypass.low',
+      'session.control',
       'subagent.cancel',
       'subagent.output',
       'subagent.spawn',
@@ -65,6 +67,13 @@ describe('built-in role contract (role-tower model: owner=high, trusted=medium, 
   test('guest carries neither fs.see grant (locked-down floor; bash sees neither private surface nor secrets)', () => {
     expect([...BUILTIN_ROLES.guest.permissions]).not.toContain('fs.see.private')
     expect([...BUILTIN_ROLES.guest.permissions]).not.toContain('fs.see.secrets')
+  })
+
+  test('session.control is owner+trusted+member but NOT guest (a respond-capable guest cannot /stop other turns)', () => {
+    expect([...BUILTIN_ROLES.owner.permissions]).toContain('session.control')
+    expect([...BUILTIN_ROLES.trusted.permissions]).toContain('session.control')
+    expect([...BUILTIN_ROLES.member.permissions]).toContain('session.control')
+    expect([...BUILTIN_ROLES.guest.permissions]).not.toContain('session.control')
   })
 
   test('member does NOT carry the operator-specific spawn permission (write-capable subagents are owner+trusted only)', () => {

--- a/src/permissions/builtins.ts
+++ b/src/permissions/builtins.ts
@@ -10,6 +10,12 @@ export const BUILTIN_ROLE_NAMES: readonly BuiltinRoleName[] = ['owner', 'trusted
 // set at boot via expandOwnerWildcard.
 export const CORE_PERMISSIONS = {
   channelRespond: 'channel.respond',
+  // Distinct from channelRespond so a respond-capable guest cannot abort
+  // other speakers' sessions. The /stop command (both the text-prefix and
+  // native-slash paths in the router) gates on this, not on channelRespond:
+  // an operator may grant guest channelRespond to let strangers drive masked
+  // turns, but session lifecycle control stays member-and-up.
+  sessionControl: 'session.control',
   cronSchedule: 'cron.schedule',
   cronModify: 'cron.modify',
   subagentSpawn: 'subagent.spawn',
@@ -17,10 +23,11 @@ export const CORE_PERMISSIONS = {
   subagentOutput: 'subagent.output',
   subagentSpawnOperator: 'subagent.spawn.operator',
   // Phrased as capabilities to SEE, not to hide, so the role tower stays
-  // monotonic (a higher tier sees a strict superset of a lower tier) and the
-  // empty-permission guest is the fail-safe floor. resolveHiddenPaths masks
-  // whatever the resolved role lacks: fsSeePrivate gates workspace/+memory/+
-  // sessions/, fsSeeSecrets gates .env+secrets.json.
+  // monotonic (a higher tier sees a strict superset of a lower tier).
+  // resolveHiddenPaths masks whatever the resolved role lacks: fsSeePrivate
+  // gates workspace/+memory/+sessions/, fsSeeSecrets gates .env+secrets.json.
+  // The fail-safe floor is the undefined origin (see has() in
+  // permissions.ts), not the guest role, which is now grantable.
   fsSeePrivate: 'fs.see.private',
   fsSeeSecrets: 'fs.see.secrets',
 } as const
@@ -62,6 +69,7 @@ export const BUILTIN_ROLES: Readonly<Record<BuiltinRoleName, BuiltinRoleSpec>> =
     match: [{ kind: 'tui' }],
     permissions: [
       CORE_PERMISSIONS.channelRespond,
+      CORE_PERMISSIONS.sessionControl,
       CORE_PERMISSIONS.cronSchedule,
       CORE_PERMISSIONS.cronModify,
       CORE_PERMISSIONS.subagentSpawn,
@@ -80,6 +88,7 @@ export const BUILTIN_ROLES: Readonly<Record<BuiltinRoleName, BuiltinRoleSpec>> =
     match: [],
     permissions: [
       CORE_PERMISSIONS.channelRespond,
+      CORE_PERMISSIONS.sessionControl,
       CORE_PERMISSIONS.cronSchedule,
       CORE_PERMISSIONS.subagentSpawn,
       CORE_PERMISSIONS.subagentCancel,
@@ -95,6 +104,7 @@ export const BUILTIN_ROLES: Readonly<Record<BuiltinRoleName, BuiltinRoleSpec>> =
     match: [],
     permissions: [
       CORE_PERMISSIONS.channelRespond,
+      CORE_PERMISSIONS.sessionControl,
       CORE_PERMISSIONS.subagentSpawn,
       CORE_PERMISSIONS.subagentCancel,
       CORE_PERMISSIONS.subagentOutput,

--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -43,6 +43,20 @@ describe('PermissionService — defaults', () => {
     expect(svc.has(undefined, 'channel.respond')).toBe(false)
   })
 
+  test('undefined origin holds NOTHING even after guest is granted that permission (the fail-safe floor)', () => {
+    // guest is now a grantable role; an operator may open it channel.respond.
+    // The floor must live on the undefined origin, not on guest being empty —
+    // so has(undefined, ...) stays false regardless of what guest carries.
+    const roles = parseRoles({ guest: { match: ['slack:*'], permissions: ['channel.respond'] } })
+    const svc = createPermissionService({ roles })
+    // sanity: a matched guest origin DOES get the granted permission
+    expect(svc.has(slackStrangerChat, 'channel.respond')).toBe(true)
+    // but the undefined origin is closed regardless
+    expect(svc.has(undefined, 'channel.respond')).toBe(false)
+    // resolveRole/describe still report guest for audit; only has() is forced closed
+    expect(svc.resolveRole(undefined)).toBe('guest')
+  })
+
   test('system origin → owner (runtime infrastructure acts on operator behalf)', () => {
     const svc = createPermissionService({ pluginPermissions: PLUGIN_PERMS })
     expect(svc.resolveRole({ kind: 'system', component: 'memory-logger' })).toBe('owner')

--- a/src/permissions/permissions.ts
+++ b/src/permissions/permissions.ts
@@ -141,6 +141,15 @@ export function createPermissionService(opts: CreatePermissionServiceOptions = {
 
   return {
     has(origin, permission) {
+      // Fail-safe floor: an undefined origin holds nothing, regardless of
+      // role permissions. Previously this floor was implicit in `guest`
+      // being empty; now `guest` is grantable (an operator may grant it
+      // `channel.respond`), so the floor must live on the no-actor input
+      // instead. Keeps every downstream `has(maybeUndefined, ...)` check
+      // (bypass tiers, fs.see.*, subagent spawn) closed even after a guest
+      // grant. resolveRole/describe still report 'guest' for audit/display;
+      // only authorization is forced closed.
+      if (origin === undefined) return false
       const roleName = resolveRole(origin)
       const role = byName.get(roleName)
       if (!role) return false


### PR DESCRIPTION
## Background

Today the `guest` role is the security floor by virtue of being empty (`permissions: []`). Every defensive `permissions.has(maybeUndefinedOrigin, ...)` check across the codebase — security bypass tiers, `fs.see.*`, subagent spawn — relies on "resolves to guest" meaning "holds nothing". `resolveRole()` returns `'guest'` for an undefined origin, an unmatched channel author, and cron/subagent origins with an unresolved role.

That coupling blocks a feature we want: scoping crowd-facing agents so unmatched authors fall to `guest` while the operator can still grant `guest` a narrow capability (e.g. `channel.respond`, so strangers get a masked, `public/`-only turn). The moment `guest` is non-empty, the implicit floor collapses — an undefined origin would inherit whatever `guest` carries.

This PR decouples the two so `guest` can become a normal grantable role without weakening the floor. It is the foundation for the follow-ups (dropping the `member:*` default; an agent-callable role-grant tool).

## Summary

**1. The floor moves from the `guest` role to the undefined origin.** `has()` now returns `false` for `origin === undefined` before role resolution. The floor no longer depends on `guest` being empty, so every `has(maybeUndefined, ...)` safety default stays closed regardless of what `guest` is later granted. `resolveRole`/`describe` still report `'guest'` for an undefined origin, so audit and display surfaces are unchanged — only the authorization answer is forced closed.

Why here and not "early-return in `resolveRole`": `resolveRole(undefined)` legitimately returns `'guest'` for display, and the `system` origin legitimately resolves to `owner`. The authorization gate is `has()`, so that is the correct and minimal place to pin the floor.

**2. A new `session.control` permission splits `/stop` from `channel.respond`.** The `/stop` command (both the text-prefix path and the native Discord/Slack slash path) previously gated on `channel.respond`. Once an operator can grant `guest` `channel.respond` (so strangers can drive masked turns), that alias would also hand strangers the ability to abort other speakers' in-flight turns. `session.control` is granted to owner/trusted/member but **not** guest, keeping session lifecycle control member-and-up while respond can be opened to guests independently.

## What this does NOT do

- Does **not** grant `guest` any permission. `guest` stays empty here; this only makes the floor independent of that fact.
- Does **not** drop the `member:*` init default or add a grant tool. Those are follow-up PRs.
- Does **not** change masking, cron/subagent dispatch, or the `rolePromotion` guard.

## Review notes

- **Load-bearing:** the `origin === undefined` short-circuit in `has()` (`src/permissions/permissions.ts`). It is the new floor; removing it silently re-opens every `has(undefined, ...)` default. Stale comments in `builtins.ts` that described "empty-permission guest is the fail-safe floor" are corrected to point at the undefined-origin guard.
- **Invariant to verify:** `session.control` is on owner/trusted/member and absent from guest (pinned by a new test in `builtins.test.ts`), and both `/stop` paths in the router gate on it (pinned by three new tests in `router.test.ts`, including the guest-shaped "respond but no control → /stop refused" case).
- **Note:** `roles.permissions` is `restart-required` per `FIELD_EFFECTS`; this PR only adds built-in defaults, no reloadable-classification change.