### PR TITLE
Always post inline comments when a PR review has actionable findings

### DIFF
--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -63,7 +63,11 @@ Why delegate: the `reviewer` subagent runs on the `deep` model profile, loads a 
    </review>
    ```
 
-4. **Translate findings into a `gh api` review payload.** Each `<finding>` with `severity` of `blocker`, `concern`, or `nit` and a `location="path:line"` becomes one entry in `comments[]`. Compose the inline `body` from the reviewer's `<issue>` + `<evidence>` + `<suggestion>` — preserve the reviewer's wording, do not paraphrase. Findings whose `location` is `general` (no file:line anchor) go into the top-level review `body` instead. **Skip `praise` findings when building `comments[]`** — they are not actionable, and inline praise comments are exactly the noise the reviewer is supposed to filter out at the source; if you want to surface them, weave them into the top-level review `body` alongside the summary. Map the reviewer's `<verdict>` to the GitHub `event`:
+4. **Translate findings into a `gh api` review payload.** Each `<finding>` with `severity` of `blocker`, `concern`, or `nit` and a `location="path:line"` becomes one entry in `comments[]`. Compose the inline `body` from the reviewer's `<issue>` + `<evidence>` + `<suggestion>` — preserve the reviewer's wording, do not paraphrase. Findings whose `location` is `general` (no file:line anchor) go into the top-level review `body` instead. **Skip `praise` findings when building `comments[]`** — they are not actionable, and inline praise comments are exactly the noise the reviewer is supposed to filter out at the source; if you want to surface them, weave them into the top-level review `body` alongside the summary.
+
+   **The verdict and the inline comments are independent. The verdict sets only the `event` field; it never decides whether you post `comments[]`.** Whenever there is at least one actionable finding (`blocker`/`concern`/`nit`) with a `location="path:line"`, you MUST submit a formal review via `POST /pulls/<N>/reviews` carrying those findings in `comments[]` — including when the verdict is `approve`. An `approve` with three nits is still a formal `APPROVE` review with three inline comments, **not** a plain approval and **not** a flattened summary posted as a top-level comment. Collapsing inline findings into a single `channel_reply` or issue comment loses the line anchors the reviewer worked to produce — that is the exact failure mode this step exists to prevent.
+
+   Map the reviewer's `<verdict>` to the GitHub `event`:
 
    | Reviewer verdict  | GitHub `event`    |
    | ----------------- | ----------------- |
@@ -88,13 +92,21 @@ Why delegate: the `reviewer` subagent runs on the `deep` model profile, loads a 
 
    **Always use `--input -` with a quoted heredoc (`<<'JSON'`) for review bodies.** Do **not** use `-f body=...` or `-F 'comments[][body]=...'`: those go through shell argument parsing, so backticks (\`) trigger command substitution and have to be backslash-escaped, which leaks the literal `\` into the rendered comment. The quoted heredoc passes the JSON through untouched — backticks, newlines, and `${...}` all survive verbatim. The same applies to any other `gh api` POST whose body contains backticks, embedded newlines, or shell metacharacters.
 
-5. **Post a one-line summary with `channel_reply`** so the conversation has a human-readable trace pointing at the review (e.g., "Posted review on PR #N: <verdict>, N findings.").
+5. **Verify the review actually landed before announcing it.** The `gh api` call can fail silently from the model's perspective — a permission denial, a bad `line` anchor, or a malformed payload returns an error you must not paper over. After submitting, confirm the review exists:
+
+   ```sh
+   gh api /repos/owner/repo/pulls/<N>/reviews --jq '.[-1] | {id, state, user: .user.login}'
+   ```
+
+   The returned `id`/`state` is your proof the formal review posted. If the call errored or the review is absent, do **not** fall back to a top-level `channel_reply` that _claims_ a review was posted — fix the payload (most often a `line` that isn't part of the diff; re-anchor it or move that finding to the top-level `body`) and resubmit. A trace reply that says "Posted review" when no review exists is worse than silence.
+
+6. **Then post a one-line summary with `channel_reply`** so the conversation has a human-readable trace pointing at the review (e.g., "Posted review on PR #N: <verdict>, N findings."). This reply is secondary — it points _at_ the formal review, it never substitutes for it. Post it only after step 5 confirmed the review exists.
 
 ### Rules
 
 - **Always delegate to the `reviewer` subagent.** Do not perform the review craft yourself. The reviewer is the source of truth for severity, evidence quality, and what counts as a finding. Your job is mechanics: spawn, wait, translate, post.
 - **Trust the verdict.** Use the GitHub `event` mapped from the reviewer's `<verdict>`. Do not upgrade `comment` → `APPROVE` to seem agreeable, and do not downgrade `request-changes` → `COMMENT` to soften the tone. The reviewer chose deliberately.
-- **No actionable findings → no inline review post.** A finding is "actionable" if its severity is `blocker`, `concern`, or `nit`. If the reviewer returns zero actionable findings:
+- **No actionable findings → no inline review post.** A finding is "actionable" if its severity is `blocker`, `concern`, or `nit`. This branch applies **only when the actionable count is exactly zero** — if there is even one actionable finding with a line anchor, follow step 4 and submit a formal review with `comments[]` regardless of verdict. When the reviewer returns zero actionable findings:
   - `approve` verdict → post a plain `APPROVE` with the `<summary>` as the review body (no `comments[]` array).
   - `comment` verdict → post the summary as a top-level PR comment via `gh api -X POST /repos/.../issues/<N>/comments` instead of submitting an empty review.
   - `request-changes` verdict → submit `REQUEST_CHANGES` with the `<summary>` as the review body and no `comments[]` array. This combination is rare (the reviewer's contract says `request-changes` requires at least one blocker or load-bearing concern), so if it happens, faithfully encode the verdict and trust the reviewer's reasoning is in the summary.


### PR DESCRIPTION
## Background

When the agent is assigned as a reviewer on a GitHub PR, `src/skills/typeclaw-channel-github/SKILL.md` instructs it to: delegate analysis to the bundled `reviewer` subagent, then **translate the `<review>` block into a GitHub review with inline `comments[]`** via `gh api .../pulls/<N>/reviews`.

On a real review run (PR #501), the reviewer returned `approve` with a single actionable `nit` carrying a `path:line` anchor. Instead of posting a formal review with one inline comment, the operator **flattened the finding into a top-level issue comment** ("Posted review: approve. One nit: `src/channels/router.ts:1456`…"). The PR ended up with **zero entries in `/pulls/501/comments` and zero formal reviews** — the line anchor the deep-model reviewer produced was lost.

## Root cause

The skill coupled the `approve` verdict with "no `comments[]`" in the reader's mind:

- Step 4 said actionable findings with a `location` become `comments[]` entries — correct.
- But the **Rules → "No actionable findings → no inline review post"** bullet only described the *zero-findings* case, and its `approve` sub-bullet said *"post a plain `APPROVE` … (no `comments[]` array)."*

A model skimming for the `approve` path lands on that bullet, sees "no `comments[]` array," and posts a bare approval. With one nit in hand, it improvised by dumping the finding into a channel reply / issue comment. The skill never spelled out the most common real combination: **`approve` + ≥1 actionable finding → still a formal review with inline comments.**

This is a **posting/mechanics** failure, on the github-channel skill's side of the boundary. The `reviewer` subagent and its `code-review` skill did their job correctly (a `nit` with a real `path:line` is exactly the anchorable output they're supposed to produce), so neither is touched here.

## What this changes

`src/skills/typeclaw-channel-github/SKILL.md` only:

1. **Decouple verdict from inline comments (Step 4).** New paragraph stating the verdict sets only the GitHub `event` field and never decides whether `comments[]` is posted. Any actionable finding (`blocker`/`concern`/`nit`) with a `location="path:line"` mandates a formal `POST /pulls/<N>/reviews` carrying those findings in `comments[]` — including when the verdict is `approve`.
2. **Scope the zero-findings branch (Rules).** The "No actionable findings → no inline review post" bullet now explicitly applies *only when the actionable count is exactly zero*; otherwise follow Step 4 regardless of verdict.
3. **Verify-before-announce (new Step 5).** Confirm the review exists via `gh api .../pulls/<N>/reviews` before posting the human-readable trace reply, and forbid a trace reply that *claims* a review was posted when none landed. The old Step 5 (one-line `channel_reply` summary) becomes Step 6, explicitly secondary to the formal review.

No code changes; this is a behavioral fix to a loaded skill.

## What this does NOT do

- Does not touch the `reviewer` subagent or its `code-review` skill (correct by the prompt/skill boundary; they produced anchorable output).
- Does not change the github outbound adapter — formal-review creation is intentionally driven by the agent's `gh api` call, not `channel_reply`.
- Does not change the verdict→`event` mapping.

## Test plan

- `bun run lint` — 0 errors (64 pre-existing warnings in `src/init/dockerfile.ts`, unrelated).
- `bun run format:check` — clean.
- `bun run typecheck` — clean.
- `bun run test` — reviewer + github-adapter suites pass (224/224). Two unrelated failures remain and are **environmental, not caused by this doc-only change**: `resolveSelfPackageJsonPath > points at this package manifest` asserts the path ends with `typeclaw/package.json` and fails only because the worktree dir is not named `typeclaw`; `createCloudflareNamedProvider > restarts a crashed process with backoff` is a timing-flaky test that passes on isolated re-run. Neither touches `src/channels/` or `src/skills/`.
