### PR TITLE
docs(skills): correct skill-load mechanism, warn against guessing paths

### DIFF
--- a/docs/content/docs/internals/skills.mdx
+++ b/docs/content/docs/internals/skills.mdx
@@ -4,7 +4,7 @@ description: Four loading sources, naming rules, and why descriptions are trigge
 icon: BookOpen
 ---
 
-Skills are markdown files with `name` + `description` frontmatter, loaded on demand via the `skill` tool. Four sources, each with a different owner:
+Skills are markdown files with `name` + `description` frontmatter, surfaced to the agent in the `<available_skills>` system-prompt section. The agent loads one on demand by `read`-ing the `SKILL.md` at the `<location>` path that section advertises — there is no dedicated `skill` tool. (The `load_skill` tool is a separate, subagent-only mechanism for in-memory `LoadableSkill`s; see [Subagent skills](#subagent-skills-load_skill).) Four sources, each with a different owner:
 
 | Source                 | Path                                        | Owner             | When to add                                                                                                                 |
 | ---------------------- | ------------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------- |
@@ -28,3 +28,15 @@ The LLM picks skills by description. Name the failure modes, platforms, and verb
 ## Skills are lazy
 
 Adding one costs zero tokens until loaded. Right home for platform-specific guidance and large runbooks. **Do not** copy skill content into tool descriptions — those reload into every tool-call prefix, which is exactly the cost model skills avoid.
+
+## How the agent loads a skill
+
+The four sources above are all **file-based**: the upstream `DefaultResourceLoader` walks `additionalSkillPaths` (`src/agent/index.ts`), parses each `SKILL.md` frontmatter, and renders `name` + `description` + an absolute `<location>` into the `<available_skills>` block. The system prompt instructs the agent to **`read` the `<location>` path** when a description matches — the body loads only then.
+
+The agent must use the exact `<location>` path verbatim. It must **not** construct or guess skill paths (e.g. `node_modules/typeclaw/src/skills/<name>/SKILL.md`): muscle-memory and user skills live under the agent dir, the bundled path resolves through the installed package, and a guessed path that doesn't exist is the most common skill-load failure. If a skill you expect isn't listed in `<available_skills>`, it isn't file-based — don't go hunting for its `SKILL.md` on disk.
+
+## Subagent skills (`load_skill`)
+
+Subagents bypass the file-based resource loader entirely, so the startup discovery path is unavailable to them. A plugin can instead hand a subagent a typed `load_skill` tool via `createLoadSkillTool` (`src/plugin/load-skill.ts`), passing in-memory `LoadableSkill` objects (`name` / `description` / `content`). The tool's `name` parameter is a Zod enum of the supplied skill names, so the subagent picks from a fixed menu — it can't read a `SKILL.md` off disk.
+
+This is distinct from the main-agent flow: `load_skill` returns a `content` string the plugin embedded at build time, not a discovered file. The only bundled consumer is the `reviewer` subagent (`src/bundled-plugins/reviewer/`), whose `code-review` and `general` skills are `LoadableSkill`s — there is no `code-review/SKILL.md` anywhere in the tree.

--- a/src/skills/typeclaw-skills/SKILL.md
+++ b/src/skills/typeclaw-skills/SKILL.md
@@ -5,7 +5,9 @@ description: Use this skill whenever the user asks you to install, find, list, u
 
 # typeclaw-skills
 
-You operate inside an agent folder. Skills — markdown files with YAML frontmatter — are how this folder teaches you new procedures, conventions, and APIs without changing your code. The runtime discovers them on session start, parses each `SKILL.md`'s frontmatter, and surfaces the `name` + `description` to you so you can decide when to read the body. **You do not import or invoke skills; you read them when their description matches the current request.**
+You operate inside an agent folder. Skills — markdown files with YAML frontmatter — are how this folder teaches you new procedures, conventions, and APIs without changing your code. The runtime discovers them on session start, parses each `SKILL.md`'s frontmatter, and surfaces the `name` + `description` (plus an absolute `<location>` path) to you in the `<available_skills>` section so you can decide when to read the body. **You do not import or invoke skills; you load one by `read`-ing the `SKILL.md` at the exact `<location>` path that section gives you.**
+
+**Never construct or guess a skill's path.** Use the `<location>` verbatim. Do not assume a layout like `node_modules/typeclaw/src/skills/<name>/SKILL.md` — bundled skills resolve through the installed package, user skills live under `.agents/skills/`, and muscle-memory skills under `memory/skills/`. If a skill you expect is not listed in `<available_skills>`, it is not a file-based skill and has no `SKILL.md` to read — stop looking on disk. (Subagent-only skills loaded via the `load_skill` tool, e.g. the `reviewer` subagent's `code-review`, are never files.)
 
 This skill exists so you (a) understand which skills you can edit and which you must not, (b) can install new skills cleanly when the user asks, and (c) can author your own skills without colliding with the rest of the system.
 


### PR DESCRIPTION
## Background

The skills internals doc (`docs/content/docs/internals/skills.mdx`) claimed that skills are "loaded on demand via the `skill` tool" — but no such tool exists at runtime. The statement conflates two unrelated mechanisms and is exactly the pattern that causes an agent to hunt for skill files on disk via guessed paths.

The confusion has a concrete symptom: an agent tried to read `code-review/SKILL.md` from several constructed paths and failed, because `code-review` is a subagent-only `LoadableSkill` with no file on disk — it is served in-memory by `createLoadSkillTool` (`src/plugin/load-skill.ts`).

## Summary

The two skill systems are distinct:

- **Main agent (file-based):** `DefaultResourceLoader` walks `additionalSkillPaths` at boot, renders `<available_skills>` with an absolute `<location>` per skill. The agent loads a skill by reading the `SKILL.md` at that path — verbatim, not constructed.
- **Subagent (`load_skill`):** bypasses the file loader entirely. A plugin hands the subagent a typed `load_skill` tool serving in-memory `LoadableSkill`s. The only bundled consumer is the `reviewer` subagent; its `code-review`/`general` skills have no `SKILL.md` on disk.

Changes:

- **`docs/content/docs/internals/skills.mdx`**: fix the false claim about the skill tool; add "How the agent loads a skill" section (file-based flow, `<location>` verbatim rule, no guessing) and "Subagent skills (`load_skill`)" section drawing the file-vs-memory distinction.
- **`src/skills/typeclaw-skills/SKILL.md`** (read by the runtime agent): state the load mechanism explicitly (read the `<location>` from `<available_skills>`) and forbid constructing or guessing skill paths — the most common skill-load failure mode.

## What this does NOT do

- No code or behavior changes — docs and the runtime agent's own skill file only.
- Does not change how either skill system works; only documents what already exists.

## Review notes

The load-bearing change for runtime behavior is `src/skills/typeclaw-skills/SKILL.md`: agents read this file directly, so the "never guess paths" constraint takes effect immediately without a code deploy.

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check` clean. Full suite: 6142 pass / 1 skip / 1 fail. The single failure (`resolveSelfPackageJsonPath`) is a pre-existing worktree-path artifact unrelated to these doc-only changes (same one noted in prior PRs).