### PR TITLE
docs(pr-template): add Preview section for screenshots

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,12 @@ symptom. For features: the gap this fills. The most important section. -->
 <!-- The approach and the key decisions a reviewer would otherwise have to ask
 about. Use "Why X and not Y" for anything non-obvious. Intent, not execution. -->
 
+## Preview
+
+<!-- Attach screenshots or a rendered example so reviewers can see the result
+without checking out the branch. For UI/output changes, before/after pairs.
+Delete if there's nothing visual to show. -->
+
 ## What this does NOT do
 
 <!-- Explicit non-goals. Bounds the blast radius, preempts "did you also…". -->


### PR DESCRIPTION
## Background

The PR template had no designated place for visual evidence — screenshots, rendered output, before/after pairs. Contributors pasted images into arbitrary sections inconsistently, and reviewers had to check out branches to see UI or output changes. A dedicated section with an explicit "delete if nothing visual" comment makes the convention explicit and keeps it optional.

## Summary

Adds a **Preview** section to the PR template, placed after **Summary** and before **What this does NOT do**. The position reinforces stated intent: a visual confirms what the Summary describes. The HTML comment follows the existing template style — imperative, concrete hint, explicit delete-if-inapplicable instruction — so the new section reads consistently with its neighbours.

## What this does NOT do

- Does not make previews mandatory — the section is deletable like every other section in the template.
- Does not touch `CONTRIBUTING.md`, CI configuration, or any tooling — template text only.

## Review notes

Single-file change: one new section (6 lines) inserted into `.github/pull_request_template.md`. Verify that placement reads naturally in context and that the HTML comment delimiters are balanced.