### PR TITLE
fix(sandbox): bind dynamic-loader dirs so sandboxed bash can exec

### DIFF
--- a/src/sandbox/build.test.ts
+++ b/src/sandbox/build.test.ts
@@ -41,6 +41,12 @@ describe('buildSandboxedCommand base argv', () => {
     expect(argv).toContain('--tmpfs')
   })
 
+  test('binds the dynamic-loader dirs with --ro-bind-try so bash can exec on both arches', () => {
+    const joined = argvOf('true').join(' ')
+    expect(joined).toContain('--ro-bind-try /lib /lib')
+    expect(joined).toContain('--ro-bind-try /lib64 /lib64')
+  })
+
   test('uses --tmpfs /proc and never --proc or --dev-bind for /proc', () => {
     const argv = argvOf('true')
     const joined = argv.join(' ')

--- a/src/sandbox/build.ts
+++ b/src/sandbox/build.ts
@@ -65,6 +65,18 @@ function buildArgv(command: string, policy: SandboxPolicy): string[] {
 
   argv.push('--ro-bind', '/usr', '/usr', '--ro-bind', '/etc', '/etc', '--dev', '/dev', '--tmpfs', '/tmp')
 
+  // bash's ELF interpreter (the dynamic loader) is named by an absolute path
+  // baked into PT_INTERP — /lib/ld-linux-aarch64.so.1 (arm64) or
+  // /lib64/ld-linux-x86-64.so.2 (amd64). On the usr-merged Debian base those
+  // /lib /lib64 entries are root-level symlinks into /usr/lib that --ro-bind
+  // /usr does NOT recreate, so without these binds the kernel can't find the
+  // loader and bwrap reports it as "execvp bash: No such file or directory"
+  // (the missing file is the loader, not bash). --ro-bind-try, not --ro-bind:
+  // arm64 oven/bun:1-slim ships /lib but no /lib64, and a hard bind of an
+  // absent source aborts bwrap. -try keeps this builder pure (no host probe)
+  // while binding each only when present, correct on both arches.
+  argv.push('--ro-bind-try', '/lib', '/lib', '--ro-bind-try', '/lib64', '/lib64')
+
   if ((policy.proc ?? 'tmpfs') === 'tmpfs') {
     // --tmpfs /proc, never --proc /proc (OrbStack's kernel blocks
     // mount("proc",...) from user namespaces) and never --dev-bind /proc /proc


### PR DESCRIPTION
## Problem

Masked-role (guest/member) subagent bash calls failed with:

```
bwrap: execvp bash: No such file or directory
```

The error names `bash`, but `bash` is present and reachable (`/usr` is bound, so `/usr/bin/bash` resolves on PATH). The **actual** missing file is bash's **dynamic loader**.

Every dynamically-linked binary names its ELF interpreter by an absolute path baked into its `PT_INTERP` header:

- arm64: `/lib/ld-linux-aarch64.so.1`
- amd64: `/lib64/ld-linux-x86-64.so.2`

On the usr-merged Debian base (`oven/bun:1-slim`), `/lib` and `/lib64` are **root-level symlinks** into `/usr/lib`. The per-tool sandbox bound `/usr` and `/etc` but **not** `/lib`/`/lib64`, and `--ro-bind /usr` does **not** recreate those root symlinks. So inside the sandbox the kernel can't resolve the loader when bwrap exec's bash, and `execve` returns `ENOENT` — surfaced as the misleading `execvp bash: No such file or directory`.

This only affected roles that get masks (guest/member). `trusted`/`owner` bash skips the sandbox entirely, so the bug went unnoticed. `build.test.ts` only asserts argv **shape** and never spawns real bwrap (exactly the "no test signal beyond the bwrap helper failing at runtime" gap `docs/internals/sandbox.mdx` warns about), so unit tests stayed green.

## Fix

Bind `/lib` and `/lib64` into the sandbox using **`--ro-bind-try`** (not `--ro-bind`):

```ts
argv.push('--ro-bind-try', '/lib', '/lib', '--ro-bind-try', '/lib64', '/lib64')
```

`-try` is load-bearing: arm64 `oven/bun:1-slim` ships `/lib` but has **no** `/lib64`, and a hard `--ro-bind` of an absent source aborts bwrap with `Can't find source path /lib64`. `-try` binds each only when its source exists, which keeps the builder **pure** (no host-filesystem probe) and correct on both arches.

`/bin`/`/sbin` need no separate bind — they're root symlinks into `/usr/bin`/`/usr/sbin`, already covered by the `/usr` mount and PATH listing `/usr/bin`.

## Verification

Reproduced and fixed against **real bwrap** on `oven/bun:1-slim`:

- Before (typeclaw's exact mount set): `bwrap: execvp bash: No such file or directory` (exit 1)
- After (`--ro-bind-try /lib /lib64` added): `bash -c` runs, `bash --version` prints, exit 0

Checks:

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun test --parallel src/sandbox/` — 57 pass / 1 skip / 0 fail (incl. new `--ro-bind-try` assertion)

> Note: the full suite has one unrelated failure, `resolveSelfPackageJsonPath > points at this package manifest`, which asserts the manifest path ends with `typeclaw/package.json`. It fails only because this work happened in a worktree named `typeclaw-sandbox-lib`; it is independent of this change.