### PR TITLE
feat(agent): add grant_role tool for conversational role management

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -9,7 +9,7 @@ import { loadMemory } from '@/bundled-plugins/memory/load-memory'
 import type { ChannelRouter } from '@/channels/router'
 import { getConfig, resolveModel, resolveProfile } from '@/config'
 import { defaultThinkingLevelForRef, providerForModelRef, type KnownModelRef } from '@/config/providers'
-import type { PermissionService } from '@/permissions'
+import type { PermissionService, RolesConfig } from '@/permissions'
 import type {
   BuiltinToolRef,
   HookBus,
@@ -50,6 +50,7 @@ import { createChannelFetchAttachmentTool } from './tools/channel-fetch-attachme
 import { createChannelHistoryTool } from './tools/channel-history'
 import { createChannelReplyTool } from './tools/channel-reply'
 import { createChannelSendTool } from './tools/channel-send'
+import { createGrantRoleTool } from './tools/grant-role'
 import { createRestartTool } from './tools/restart'
 import { createSkipResponseTool } from './tools/skip-response'
 import { createSpawnSubagentTool } from './tools/spawn-subagent'
@@ -141,6 +142,10 @@ export type CreateSessionOptions = {
   // prompt is not regenerated; see `typeclaw-permissions` skill for how the
   // agent should interpret the snapshot on later turns.
   permissions?: PermissionService
+  // Live roles snapshot for the grant_role tool's hot-reload after a match
+  // grant. Production threads `() => getConfig().roles`; omitted when no
+  // grant_role tool is wired (the tool requires permissions too).
+  rolesProvider?: () => RolesConfig | undefined
   // Model profile name. Resolved against `config.models` to pick the concrete
   // model ref this session binds to. Unknown profile names fall back to
   // `default` with a one-time console warning. Omitted → `default`. Threaded
@@ -321,6 +326,12 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
               getOrigin,
               permissions: options.permissions,
               stream: options.stream,
+            }),
+            ...buildRoleGrantTools({
+              agentDir: options.plugins?.agentDir,
+              getOrigin,
+              permissions: options.permissions,
+              rolesProvider: options.rolesProvider,
             }),
           ]
   // Hook coverage for pi's builtin coding tools (read/bash/edit/write/grep/
@@ -573,6 +584,25 @@ export function buildSubagentOrchestrationTools(opts: {
       liveRegistry: opts.liveRegistry,
       getOrigin: opts.getOrigin,
       ...(opts.permissions ? { permissions: opts.permissions } : {}),
+    }),
+  ]
+}
+
+export function buildRoleGrantTools(opts: {
+  agentDir: string | undefined
+  getOrigin: () => SessionOrigin | undefined
+  permissions: PermissionService | undefined
+  rolesProvider: (() => RolesConfig | undefined) | undefined
+}): ToolDefinition[] {
+  if (opts.agentDir === undefined || opts.permissions === undefined || opts.rolesProvider === undefined) {
+    return []
+  }
+  return [
+    createGrantRoleTool({
+      agentDir: opts.agentDir,
+      getOrigin: opts.getOrigin,
+      permissions: opts.permissions,
+      rolesProvider: opts.rolesProvider,
     }),
   ]
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -142,10 +142,11 @@ export type CreateSessionOptions = {
   // prompt is not regenerated; see `typeclaw-permissions` skill for how the
   // agent should interpret the snapshot on later turns.
   permissions?: PermissionService
-  // Live roles snapshot for the grant_role tool's hot-reload after a match
-  // grant. Production threads `() => getConfig().roles`; omitted when no
-  // grant_role tool is wired (the tool requires permissions too).
-  rolesProvider?: () => RolesConfig | undefined
+  // Re-reads roles from disk for the grant_role tool's hot-reload after a match
+  // grant. Production threads a reload-then-read (reloadConfig + getConfig);
+  // must not be an in-memory snapshot or the grant reapplies stale roles.
+  // Omitted when no grant_role tool is wired (the tool requires permissions).
+  reloadRoles?: () => RolesConfig | undefined
   // Model profile name. Resolved against `config.models` to pick the concrete
   // model ref this session binds to. Unknown profile names fall back to
   // `default` with a one-time console warning. Omitted → `default`. Threaded
@@ -331,7 +332,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
               agentDir: options.plugins?.agentDir,
               getOrigin,
               permissions: options.permissions,
-              rolesProvider: options.rolesProvider,
+              reloadRoles: options.reloadRoles,
             }),
           ]
   // Hook coverage for pi's builtin coding tools (read/bash/edit/write/grep/
@@ -592,9 +593,9 @@ export function buildRoleGrantTools(opts: {
   agentDir: string | undefined
   getOrigin: () => SessionOrigin | undefined
   permissions: PermissionService | undefined
-  rolesProvider: (() => RolesConfig | undefined) | undefined
+  reloadRoles: (() => RolesConfig | undefined) | undefined
 }): ToolDefinition[] {
-  if (opts.agentDir === undefined || opts.permissions === undefined || opts.rolesProvider === undefined) {
+  if (opts.agentDir === undefined || opts.permissions === undefined || opts.reloadRoles === undefined) {
     return []
   }
   return [
@@ -602,7 +603,7 @@ export function buildRoleGrantTools(opts: {
       agentDir: opts.agentDir,
       getOrigin: opts.getOrigin,
       permissions: opts.permissions,
-      rolesProvider: opts.rolesProvider,
+      reloadRoles: opts.reloadRoles,
     }),
   ]
 }

--- a/src/agent/tools/grant-role.test.ts
+++ b/src/agent/tools/grant-role.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { createPermissionService, type RolesConfig } from '@/permissions'
+
+import type { SessionOrigin } from '../session-origin'
+import { createGrantRoleTool } from './grant-role'
+
+const ctx = {} as Parameters<ReturnType<typeof createGrantRoleTool>['execute']>[4]
+
+const OWNER_DM: SessionOrigin = {
+  kind: 'channel',
+  adapter: 'slack-bot',
+  workspace: '@dm',
+  chat: 'D_OWNER',
+  thread: null,
+  lastInboundAuthorId: 'U_OWNER',
+}
+const TRUSTED_DM: SessionOrigin = {
+  kind: 'channel',
+  adapter: 'slack-bot',
+  workspace: '@dm',
+  chat: 'D_TRENT',
+  thread: null,
+  lastInboundAuthorId: 'U_TRENT',
+}
+const TRUSTED_GROUP: SessionOrigin = {
+  kind: 'channel',
+  adapter: 'slack-bot',
+  workspace: 'T0123',
+  chat: 'C_PUBLIC',
+  thread: null,
+  lastInboundAuthorId: 'U_TRENT',
+}
+const TUI: SessionOrigin = { kind: 'tui', sessionId: 's1' }
+
+const ROLES: RolesConfig = {
+  owner: { match: [{ kind: 'channel', platform: 'slack', author: 'U_OWNER' }] },
+  trusted: { match: [{ kind: 'channel', platform: 'slack', author: 'U_TRENT' }] },
+} as unknown as RolesConfig
+
+function freshAgentDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'typeclaw-grantrole-test-'))
+  writeFileSync(
+    join(dir, 'typeclaw.json'),
+    `${JSON.stringify({ roles: { owner: { match: ['slack:* author:U_OWNER'] }, trusted: { match: ['slack:* author:U_TRENT'] } } }, null, 2)}\n`,
+  )
+  return dir
+}
+
+function readRoles(dir: string): Record<string, { match?: string[]; permissions?: string[] }> {
+  return (JSON.parse(readFileSync(join(dir, 'typeclaw.json'), 'utf8')) as { roles: Record<string, never> }).roles
+}
+
+function makeTool(dir: string, origin: SessionOrigin | undefined) {
+  const permissions = createPermissionService({ roles: ROLES })
+  return createGrantRoleTool({
+    agentDir: dir,
+    getOrigin: () => origin,
+    permissions,
+    rolesProvider: () => ROLES,
+  })
+}
+
+async function run(tool: ReturnType<typeof createGrantRoleTool>, params: Record<string, unknown>) {
+  const result = await tool.execute('call_1', params as never, undefined, undefined, ctx)
+  return result.details as
+    | { ok: true; mode: string; role: string; value: string; added: boolean; restartRequired: boolean }
+    | { ok: false; error: string }
+}
+
+describe('grant_role gate — origin', () => {
+  test('group-channel origin is refused even for trusted (confused-deputy surface)', async () => {
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, TRUSTED_GROUP), { role: 'member', match: 'slack:T0123 author:U_X' })
+    expect(details.ok).toBe(false)
+    if (!details.ok) expect(details.error).toContain('TUI or a 1:1 DM')
+    // nothing written
+    expect(readRoles(dir).member).toBeUndefined()
+  })
+
+  test('undefined origin is refused', async () => {
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, undefined), { role: 'member', match: 'slack:T0123 author:U_X' })
+    expect(details.ok).toBe(false)
+  })
+
+  test('owner DM is allowed', async () => {
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, OWNER_DM), { role: 'member', match: 'slack:T0123 author:U_WIFE' })
+    expect(details.ok).toBe(true)
+    expect(readRoles(dir).member?.match).toContain('slack:T0123 author:U_WIFE')
+  })
+
+  test('TUI is allowed', async () => {
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, TUI), { role: 'member', match: 'slack:T0123 author:U_WIFE' })
+    expect(details.ok).toBe(true)
+  })
+})
+
+describe('grant_role gate — tier ceiling', () => {
+  test('trusted cannot grant owner', async () => {
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, TRUSTED_DM), { role: 'owner', match: 'slack:* author:U_X' })
+    expect(details.ok).toBe(false)
+    if (!details.ok) expect(details.error).toContain("cannot grant the higher 'owner'")
+    expect(readRoles(dir).owner?.match).not.toContain('slack:* author:U_X')
+  })
+
+  test('trusted CAN grant trusted (single-principal DM)', async () => {
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, TRUSTED_DM), { role: 'trusted', match: 'slack:T0123 author:U_PEER' })
+    expect(details.ok).toBe(true)
+  })
+
+  test('owner can grant trusted', async () => {
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, OWNER_DM), { role: 'trusted', match: 'slack:T0123 author:U_PEER' })
+    expect(details.ok).toBe(true)
+  })
+})
+
+describe('grant_role — permission grants', () => {
+  test('owner can open guest channel.respond (the "let community in" flow); restart-required', async () => {
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, OWNER_DM), { role: 'guest', permission: 'channel.respond' })
+    expect(details.ok).toBe(true)
+    if (details.ok) expect(details.restartRequired).toBe(true)
+    expect(readRoles(dir).guest?.permissions).toContain('channel.respond')
+  })
+
+  test('security.bypass.* is never grantable via the tool', async () => {
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, OWNER_DM), { role: 'guest', permission: 'security.bypass.medium' })
+    expect(details.ok).toBe(false)
+    if (!details.ok) expect(details.error).toContain('security.bypass')
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('grant-only-what-you-hold: trusted cannot grant a permission it lacks', async () => {
+    // trusted does NOT hold cron.modify (only owner does)
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, TRUSTED_DM), { role: 'member', permission: 'cron.modify' })
+    expect(details.ok).toBe(false)
+    if (!details.ok) expect(details.error).toContain('does not hold')
+  })
+
+  test('trusted CAN grant a permission it holds (channel.respond)', async () => {
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, TRUSTED_DM), { role: 'guest', permission: 'channel.respond' })
+    expect(details.ok).toBe(true)
+  })
+})
+
+describe('grant_role — argument validation', () => {
+  test('requires exactly one of match or permission', async () => {
+    const dir = freshAgentDir()
+    const both = await run(makeTool(dir, OWNER_DM), {
+      role: 'member',
+      match: 'slack:T0123 author:U_X',
+      permission: 'channel.respond',
+    })
+    expect(both.ok).toBe(false)
+    const neither = await run(makeTool(dir, OWNER_DM), { role: 'member' })
+    expect(neither.ok).toBe(false)
+  })
+
+  test('rejects malformed match rules', async () => {
+    const dir = freshAgentDir()
+    const details = await run(makeTool(dir, OWNER_DM), { role: 'member', match: 'team:T0123' })
+    expect(details.ok).toBe(false)
+    if (!details.ok) expect(details.error).toContain('Invalid match rule')
+  })
+})

--- a/src/agent/tools/grant-role.test.ts
+++ b/src/agent/tools/grant-role.test.ts
@@ -60,8 +60,14 @@ function makeTool(dir: string, origin: SessionOrigin | undefined) {
     agentDir: dir,
     getOrigin: () => origin,
     permissions,
-    rolesProvider: () => ROLES,
+    // Mirror production: re-read roles FROM the just-written file, not a
+    // static snapshot, so the test exercises the real disk-fresh contract.
+    reloadRoles: () => readRolesFromDisk(dir),
   })
+}
+
+function readRolesFromDisk(dir: string): RolesConfig | undefined {
+  return (JSON.parse(readFileSync(join(dir, 'typeclaw.json'), 'utf8')) as { roles?: RolesConfig }).roles
 }
 
 async function run(tool: ReturnType<typeof createGrantRoleTool>, params: Record<string, unknown>) {
@@ -173,5 +179,37 @@ describe('grant_role — argument validation', () => {
     const details = await run(makeTool(dir, OWNER_DM), { role: 'member', match: 'team:T0123' })
     expect(details.ok).toBe(false)
     if (!details.ok) expect(details.error).toContain('Invalid match rule')
+  })
+})
+
+describe('grant_role — hot-reload reads the post-grant state', () => {
+  test('replaceRoles receives the freshly-written roles, not a stale snapshot', async () => {
+    const dir = freshAgentDir()
+    let replacedWith: Record<string, { match?: string[] }> | undefined
+    const permissions = createPermissionService({ roles: ROLES })
+    const spied: typeof permissions = {
+      ...permissions,
+      replaceRoles: (roles) => {
+        replacedWith = roles as unknown as Record<string, { match?: string[] }> | undefined
+      },
+    }
+    const tool = createGrantRoleTool({
+      agentDir: dir,
+      getOrigin: () => OWNER_DM,
+      permissions: spied,
+      reloadRoles: () => readRolesFromDisk(dir),
+    })
+
+    await tool.execute(
+      'call_1',
+      { role: 'member', match: 'slack:T0123 author:U_WIFE' } as never,
+      undefined,
+      undefined,
+      ctx,
+    )
+
+    // the value handed to replaceRoles must reflect the grant that just landed
+    // on disk — the bug was reading an in-memory snapshot taken before the write
+    expect(replacedWith?.member?.match).toContain('slack:T0123 author:U_WIFE')
   })
 })

--- a/src/agent/tools/grant-role.ts
+++ b/src/agent/tools/grant-role.ts
@@ -20,11 +20,16 @@ export type CreateGrantRoleToolOptions = {
   agentDir: string
   getOrigin: () => SessionOrigin | undefined
   permissions: PermissionService
-  // Live roles snapshot used to hot-reload match-grants after writing. A
-  // permission-grant is restart-required, so reloading it has no runtime
-  // effect, but we reload anyway so a same-session subsequent match-grant
-  // sees a consistent table.
-  rolesProvider: () => RolesConfig | undefined
+  // Re-reads roles FROM DISK and returns the fresh set, for hot-reloading a
+  // match-grant after grantRole writes typeclaw.json. Must NOT read an
+  // in-memory config snapshot: grantRole writes the file directly, so a
+  // snapshot taken before the live config pointer is reloaded would be stale
+  // and replaceRoles would reapply the pre-grant table. Production wires this
+  // to reloadConfig(agentDir) + getConfig().roles, matching the config
+  // reloadable. A permission-grant is restart-required, so the reload has no
+  // runtime effect for it, but we reload anyway to keep a same-session
+  // subsequent match-grant reading a consistent table.
+  reloadRoles: () => RolesConfig | undefined
 }
 
 // Roles this tool may target, lowest to highest. `guest` is a valid target
@@ -56,7 +61,7 @@ function isSinglePrincipalOrigin(origin: SessionOrigin | undefined): boolean {
 }
 
 export function createGrantRoleTool(options: CreateGrantRoleToolOptions) {
-  const { agentDir, getOrigin, permissions, rolesProvider } = options
+  const { agentDir, getOrigin, permissions, reloadRoles } = options
 
   return defineTool({
     name: 'grant_role',
@@ -171,7 +176,7 @@ export function createGrantRoleTool(options: CreateGrantRoleToolOptions) {
 
   function reload(): void {
     try {
-      permissions.replaceRoles(rolesProvider())
+      permissions.replaceRoles(reloadRoles())
     } catch {
       // Best-effort hot-reload of match-grants. A failure here does not undo
       // the on-disk write; the next config reload / restart picks it up.

--- a/src/agent/tools/grant-role.ts
+++ b/src/agent/tools/grant-role.ts
@@ -1,0 +1,209 @@
+import { Type } from '@mariozechner/pi-ai'
+import { defineTool } from '@mariozechner/pi-coding-agent'
+
+import {
+  grantRole,
+  grantRolePermission,
+  isDmChannelOrigin,
+  parseMatchRule,
+  type PermissionService,
+  type RolesConfig,
+} from '@/permissions'
+
+import type { SessionOrigin } from '../session-origin'
+
+export type GrantRoleToolDetails =
+  | { ok: true; mode: 'match' | 'permission'; role: string; value: string; added: boolean; restartRequired: boolean }
+  | { ok: false; error: string }
+
+export type CreateGrantRoleToolOptions = {
+  agentDir: string
+  getOrigin: () => SessionOrigin | undefined
+  permissions: PermissionService
+  // Live roles snapshot used to hot-reload match-grants after writing. A
+  // permission-grant is restart-required, so reloading it has no runtime
+  // effect, but we reload anyway so a same-session subsequent match-grant
+  // sees a consistent table.
+  rolesProvider: () => RolesConfig | undefined
+}
+
+// Roles this tool may target, lowest to highest. `guest` is a valid target
+// (an operator opening guest channel.respond) but never a granter — the gate
+// below requires the caller to resolve to owner/trusted.
+const TIER_ORDER = ['guest', 'member', 'trusted', 'owner'] as const
+type TierRole = (typeof TIER_ORDER)[number]
+
+function tierOf(role: string): number {
+  return TIER_ORDER.indexOf(role as TierRole)
+}
+
+function isTierRole(role: string): role is TierRole {
+  return (TIER_ORDER as readonly string[]).includes(role)
+}
+
+// A single-principal turn carries only the principal's own first-party words:
+// the TUI (a human typing directly) or a 1:1 DM (principal + bot, no
+// third-party messages buffered in). A group/open channel turn always mixes in
+// other authors' messages, which is the confused-deputy surface that lets a
+// guest prompt-inject a trusted turn into rewriting the access-control table.
+// Role grants are confined to single-principal turns so that surface does not
+// exist.
+function isSinglePrincipalOrigin(origin: SessionOrigin | undefined): boolean {
+  if (origin === undefined) return false
+  if (origin.kind === 'tui') return true
+  if (origin.kind === 'channel') return isDmChannelOrigin(origin)
+  return false
+}
+
+export function createGrantRoleTool(options: CreateGrantRoleToolOptions) {
+  const { agentDir, getOrigin, permissions, rolesProvider } = options
+
+  return defineTool({
+    name: 'grant_role',
+    label: 'Grant Role',
+    description:
+      'Assign an author to a role (match grant) or give a role a capability (permission grant), by editing typeclaw.json#roles. ' +
+      'Use this to onboard a teammate ("respond to author U_X" → grant them member) or to open the agent to a wider audience ' +
+      '("let anyone in this channel message you" → grant guest channel.respond). ' +
+      'Only callable from the TUI or a 1:1 DM by an owner or trusted user — group-channel turns cannot use it. ' +
+      'Permission grants are restart-required: they land in typeclaw.json but take effect on the next `typeclaw restart`.',
+    parameters: Type.Object({
+      role: Type.Union(
+        [Type.Literal('owner'), Type.Literal('trusted'), Type.Literal('member'), Type.Literal('guest')],
+        {
+          description: 'The role to grant TO.',
+        },
+      ),
+      match: Type.Optional(
+        Type.String({
+          description:
+            'A match rule assigning an author/scope to the role, e.g. "slack:T0123 author:U_WIFE". ' +
+            'Provide exactly one of match or permission.',
+        }),
+      ),
+      permission: Type.Optional(
+        Type.String({
+          description:
+            'A capability to add to the role, e.g. "channel.respond". Provide exactly one of match or permission. ' +
+            'security.bypass.* permissions cannot be granted through this tool.',
+        }),
+      ),
+    }),
+
+    async execute(_toolCallId, params): Promise<ToolReturn> {
+      const origin = getOrigin()
+
+      if (!isSinglePrincipalOrigin(origin)) {
+        return err(
+          'grant_role is only available from the TUI or a 1:1 DM. A group-channel turn cannot change roles, ' +
+            'because it mixes in other participants\u2019 messages (prompt-injection surface).',
+        )
+      }
+
+      const callerRole = permissions.resolveRole(origin)
+      if (callerRole !== 'owner' && callerRole !== 'trusted') {
+        return err(`grant_role denied: caller resolves to '${callerRole}'; only owner or trusted may grant roles.`)
+      }
+
+      const hasMatch = typeof params.match === 'string' && params.match.length > 0
+      const hasPermission = typeof params.permission === 'string' && params.permission.length > 0
+      if (hasMatch === hasPermission) {
+        return err('Provide exactly one of `match` or `permission`.')
+      }
+
+      if (!isTierRole(params.role)) {
+        return err(`Unknown target role '${params.role}'.`)
+      }
+
+      // Tier ceiling: a granter may not assign or empower a role ABOVE its own.
+      // owner(3) ≥ trusted(2) ≥ member(1) ≥ guest(0).
+      if (tierOf(params.role) > tierOf(callerRole)) {
+        return err(`grant_role denied: a ${callerRole} caller cannot grant the higher '${params.role}' role.`)
+      }
+
+      return hasMatch
+        ? grantMatch(params.role, params.match as string)
+        : grantPermission(callerRole, params.role, params.permission as string)
+    },
+  })
+
+  function grantMatch(role: string, matchRule: string): ToolReturn {
+    const parsed = parseMatchRule(matchRule)
+    if (!parsed.ok) {
+      return err(`Invalid match rule '${matchRule}': ${parsed.error}`)
+    }
+
+    const result = grantRole({ cwd: agentDir, roleName: role, matchRule })
+    if (!result.ok) return err(result.reason)
+
+    reload()
+    return ok('match', role, matchRule, result.added, false)
+  }
+
+  function grantPermission(callerRole: string, role: string, permission: string): ToolReturn {
+    // security.bypass.* defeats guards rather than enabling a feature; never
+    // grantable through an agent tool. It stays a deliberate hand-edit gated by
+    // the rolePromotion guard + an explicit ack.
+    if (permission.startsWith('security.bypass.')) {
+      return err(
+        `grant_role refuses to grant '${permission}': security.bypass.* permissions disable security guards and ` +
+          'must be set by hand-editing typeclaw.json (gated by the rolePromotion guard), not via this tool.',
+      )
+    }
+
+    // "Grant only what you hold": the caller cannot confer a capability it does
+    // not itself possess. Owner's resolved set is the expanded wildcard, so an
+    // owner can grant any non-bypass core permission; trusted is capped at its
+    // literal set.
+    const callerPerms = permissions.describe(getOrigin()).permissions
+    if (!callerPerms.includes(permission)) {
+      return err(
+        `grant_role denied: a ${callerRole} caller cannot grant '${permission}' because it does not hold that permission.`,
+      )
+    }
+
+    const result = grantRolePermission({ cwd: agentDir, roleName: role, permission })
+    if (!result.ok) return err(result.reason)
+
+    reload()
+    return ok('permission', role, permission, result.added, true)
+  }
+
+  function reload(): void {
+    try {
+      permissions.replaceRoles(rolesProvider())
+    } catch {
+      // Best-effort hot-reload of match-grants. A failure here does not undo
+      // the on-disk write; the next config reload / restart picks it up.
+    }
+  }
+}
+
+function ok(
+  mode: 'match' | 'permission',
+  role: string,
+  value: string,
+  added: boolean,
+  restartRequired: boolean,
+): ToolReturn {
+  const details: GrantRoleToolDetails = { ok: true, mode, role, value, added, restartRequired }
+  const note = added ? '' : ' (already on file)'
+  const restart = restartRequired
+    ? ' This permission grant is restart-required; run `typeclaw restart` for it to take effect.'
+    : ''
+  const text =
+    mode === 'match'
+      ? `Granted role '${role}' the match rule '${value}'${note}.${restart}`
+      : `Granted role '${role}' the permission '${value}'${note}.${restart}`
+  return { content: [{ type: 'text', text }], details }
+}
+
+function err(message: string): ToolReturn {
+  const details: GrantRoleToolDetails = { ok: false, error: message }
+  return { content: [{ type: 'text', text: message }], details }
+}
+
+type ToolReturn = {
+  content: { type: 'text'; text: string }[]
+  details: GrantRoleToolDetails
+}

--- a/src/permissions/grant.test.ts
+++ b/src/permissions/grant.test.ts
@@ -3,7 +3,8 @@ import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { grantRole } from './grant'
+import { BUILTIN_ROLES } from './builtins'
+import { grantRole, grantRolePermission } from './grant'
 
 function freshAgentDir(initialConfig: Record<string, unknown> = {}): string {
   const dir = mkdtempSync(join(tmpdir(), 'typeclaw-grant-test-'))
@@ -104,5 +105,56 @@ describe('grantRole', () => {
     expect(config.channels).toEqual({ 'slack-bot': {} })
     expect(config.roles.owner?.match).toEqual(['tui', 'slack:T0123 author:U_ME'])
     expect(config.roles.member?.match).toEqual(['slack:T0123'])
+  })
+})
+
+describe('grantRolePermission', () => {
+  test('granting a permission to a built-in role with NO explicit permissions materializes defaults + new perm (does NOT narrow)', () => {
+    // given: guest has no explicit permissions[] in the file (uses defaults)
+    const dir = freshAgentDir({ roles: { guest: { match: ['discord:*'] } } })
+
+    // when: an operator grants guest channel.respond
+    const result = grantRolePermission({ cwd: dir, roleName: 'guest', permission: 'channel.respond' })
+    expect(result).toEqual({ ok: true, added: true })
+
+    // then: the written set is guest's built-in defaults (empty) + the new perm,
+    // NOT a narrowing to some other shape; match is preserved
+    const config = readConfig(dir) as { roles: { guest: { match: string[]; permissions: string[] } } }
+    expect(config.roles.guest.permissions).toEqual([...BUILTIN_ROLES.guest.permissions, 'channel.respond'])
+    expect(config.roles.guest.match).toEqual(['discord:*'])
+  })
+
+  test('granting to a built-in role preserves its FULL default capability set (member is not narrowed to one perm)', () => {
+    const dir = freshAgentDir({ roles: { member: { match: ['slack:T0123'] } } })
+
+    grantRolePermission({ cwd: dir, roleName: 'member', permission: 'cron.schedule' })
+
+    const config = readConfig(dir) as { roles: { member: { permissions: string[] } } }
+    // every built-in member default must survive the grant
+    for (const p of BUILTIN_ROLES.member.permissions) {
+      expect(config.roles.member.permissions).toContain(p)
+    }
+    expect(config.roles.member.permissions).toContain('cron.schedule')
+  })
+
+  test('appends to an explicit permissions[] without clobbering it', () => {
+    const dir = freshAgentDir({
+      roles: { guest: { match: ['discord:*'], permissions: ['channel.respond'] } },
+    })
+    grantRolePermission({ cwd: dir, roleName: 'guest', permission: 'fs.see.private' })
+
+    const config = readConfig(dir) as { roles: { guest: { permissions: string[] } } }
+    expect(config.roles.guest.permissions).toEqual(['channel.respond', 'fs.see.private'])
+  })
+
+  test('idempotent: granting a permission the role already effectively holds is a no-op', () => {
+    // member's defaults already include channel.respond
+    const dir = freshAgentDir({ roles: { member: { match: ['slack:T0123'] } } })
+    const result = grantRolePermission({ cwd: dir, roleName: 'member', permission: 'channel.respond' })
+    expect(result).toEqual({ ok: true, added: false })
+
+    const config = readConfig(dir) as { roles: { member: { permissions?: string[] } } }
+    // no narrowing write happened; the file role still has no explicit permissions[]
+    expect(config.roles.member.permissions).toBeUndefined()
   })
 })

--- a/src/permissions/grant.ts
+++ b/src/permissions/grant.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { BUILTIN_ROLES, isBuiltinRoleName } from './builtins'
 import { parseMatchRule } from './match-rule'
 
 // Appends `rule` to `typeclaw.json#roles.<name>.match`, creating the role
@@ -23,15 +24,89 @@ export type GrantOptions = {
   matchRule: string
 }
 
+export type GrantPermissionOptions = {
+  cwd: string
+  roleName: string
+  permission: string
+}
+
 export function grantRole(opts: GrantOptions): GrantResult {
   const validation = parseMatchRule(opts.matchRule)
   if (!validation.ok) {
     return { ok: false, reason: `invalid match rule '${opts.matchRule}': ${validation.error}` }
   }
 
-  const path = join(opts.cwd, CONFIG_FILE)
+  const loaded = loadConfigObject(opts.cwd, opts.roleName)
+  if (!loaded.ok) return loaded
+
+  const { obj, roles, role } = loaded
+  const existingMatch = Array.isArray(role.match) ? [...(role.match as unknown[])] : []
+
+  // Dedup by exact string equality — match rules canonicalize during load,
+  // and a literal duplicate in the file is a noise source the schema doesn't
+  // currently dedupe for us.
+  if (existingMatch.includes(opts.matchRule)) {
+    return { ok: true, added: false }
+  }
+
+  role.match = [...existingMatch, opts.matchRule]
+  roles[opts.roleName] = role
+  obj.roles = roles
+
+  return writeConfigObject(opts.cwd, obj)
+}
+
+// Appends `permission` to `typeclaw.json#roles.<name>.permissions`. For a
+// built-in role with no explicit `permissions[]`, the runtime treats the
+// field as "use built-in defaults" (see resolveOne in permissions.ts), so a
+// naive write of `[permission]` would NARROW the role to a single capability,
+// silently dropping its defaults. We materialize the current effective set
+// (explicit field if present, else the built-in default list) and append to
+// THAT, preserving every existing capability. Idempotent: a permission the
+// role already holds is a no-op.
+//
+// NOTE: `roles.permissions` is `restart-required` (FIELD_EFFECTS); the write
+// lands on disk but does not take effect until the next container restart.
+// Callers must surface that to the operator.
+export function grantRolePermission(opts: GrantPermissionOptions): GrantResult {
+  const loaded = loadConfigObject(opts.cwd, opts.roleName)
+  if (!loaded.ok) return loaded
+
+  const { obj, roles, role } = loaded
+  const effective = effectivePermissions(opts.roleName, role)
+
+  if (effective.includes(opts.permission)) {
+    return { ok: true, added: false }
+  }
+
+  role.permissions = [...effective, opts.permission]
+  roles[opts.roleName] = role
+  obj.roles = roles
+
+  return writeConfigObject(opts.cwd, obj)
+}
+
+function effectivePermissions(roleName: string, role: Record<string, unknown>): string[] {
+  if (Array.isArray(role.permissions)) {
+    return role.permissions.filter((p): p is string => typeof p === 'string')
+  }
+  if (isBuiltinRoleName(roleName)) {
+    return [...BUILTIN_ROLES[roleName].permissions]
+  }
+  return []
+}
+
+type LoadedConfig = {
+  ok: true
+  obj: Record<string, unknown>
+  roles: Record<string, unknown>
+  role: Record<string, unknown>
+}
+
+function loadConfigObject(cwd: string, roleName: string): LoadedConfig | { ok: false; reason: string } {
+  const path = join(cwd, CONFIG_FILE)
   if (!existsSync(path)) {
-    return { ok: false, reason: `${CONFIG_FILE} not found at ${opts.cwd}` }
+    return { ok: false, reason: `${CONFIG_FILE} not found at ${cwd}` }
   }
 
   let raw: string
@@ -54,26 +129,17 @@ export function grantRole(opts: GrantOptions): GrantResult {
 
   const obj = json as Record<string, unknown>
   const roles = isPlainObject(obj.roles) ? { ...obj.roles } : {}
-  const role = isPlainObject(roles[opts.roleName]) ? { ...(roles[opts.roleName] as Record<string, unknown>) } : {}
-  const existingMatch = Array.isArray(role.match) ? [...(role.match as unknown[])] : []
+  const role = isPlainObject(roles[roleName]) ? { ...(roles[roleName] as Record<string, unknown>) } : {}
+  return { ok: true, obj, roles, role }
+}
 
-  // Dedup by exact string equality — match rules canonicalize during load,
-  // and a literal duplicate in the file is a noise source the schema doesn't
-  // currently dedupe for us.
-  if (existingMatch.includes(opts.matchRule)) {
-    return { ok: true, added: false }
-  }
-
-  role.match = [...existingMatch, opts.matchRule]
-  roles[opts.roleName] = role
-  obj.roles = roles
-
+function writeConfigObject(cwd: string, obj: Record<string, unknown>): GrantResult {
+  const path = join(cwd, CONFIG_FILE)
   try {
     writeAtomic(path, `${JSON.stringify(obj, null, 2)}\n`)
   } catch (error) {
     return { ok: false, reason: `failed to write ${CONFIG_FILE}: ${describeError(error)}` }
   }
-
   return { ok: true, added: true }
 }
 

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -24,6 +24,12 @@ export {
   type PermissionService,
   type UnknownPermissionWarning,
 } from './permissions'
-export { grantRole, type GrantOptions, type GrantResult } from './grant'
-export { matchesOrigin, type MatchableOrigin } from './resolve'
+export {
+  grantRole,
+  grantRolePermission,
+  type GrantOptions,
+  type GrantPermissionOptions,
+  type GrantResult,
+} from './grant'
+export { matchesOrigin, isDmChannelOrigin, type MatchableOrigin } from './resolve'
 export { MATCH_RULE_JSON_SCHEMA_PATTERN, rolesConfigSchema, type RoleConfig, type RolesConfig } from './schema'

--- a/src/permissions/resolve.ts
+++ b/src/permissions/resolve.ts
@@ -79,3 +79,13 @@ function matchesBucket(
   if (platform === 'telegram') return origin.workspace === 'dm' || origin.workspace.startsWith('@')
   return false
 }
+
+// True only for a 1:1 direct-message channel origin (a two-participant
+// conversation: the principal + the bot). Reuses the same per-adapter
+// workspace markers as the `dm` match-rule bucket. A DM is the only channel
+// shape with no third-party content buffered into a turn, so role-grant tools
+// treat an owner/trusted DM as injection-equivalent to the TUI; group/open
+// channels never qualify.
+export function isDmChannelOrigin(origin: { adapter: AdapterId; workspace: string }): boolean {
+  return matchesBucket('dm', { kind: 'channel', adapter: origin.adapter, workspace: origin.workspace, chat: '' })
+}

--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -47,9 +47,10 @@ export type BuildChannelSessionFactoryDeps = {
   // the production wiring can plumb in pluginsLoaded.permissions while tests
   // (or stand-alone callers) keep the previous no-annotation behavior.
   permissions?: PermissionService
-  // Live roles snapshot for the grant_role tool's hot-reload. Forwarded to
-  // createSession; the tool only mounts when permissions is also present.
-  rolesProvider?: () => RolesConfig | undefined
+  // Re-reads roles from disk for the grant_role tool's hot-reload (reload then
+  // read, not an in-memory snapshot). Forwarded to createSession; the tool only
+  // mounts when permissions is also present.
+  reloadRoles?: () => RolesConfig | undefined
   // Test seam: lets a fake stand in for the agent session creator so tests
   // can assert exactly which CreateSessionOptions the factory builds without
   // needing a live LLM, plugin runtime, or session manager on disk.
@@ -127,7 +128,7 @@ export function buildChannelSessionFactory(deps: BuildChannelSessionFactoryDeps)
       ...(deps.containerName !== undefined ? { containerName: deps.containerName } : {}),
       ...(deps.runtimeVersion !== undefined ? { runtimeVersion: deps.runtimeVersion } : {}),
       ...(deps.permissions !== undefined ? { permissions: deps.permissions } : {}),
-      ...(deps.rolesProvider !== undefined ? { rolesProvider: deps.rolesProvider } : {}),
+      ...(deps.reloadRoles !== undefined ? { reloadRoles: deps.reloadRoles } : {}),
       ...(deps.liveSubagentRegistry !== undefined ? { liveSubagentRegistry: deps.liveSubagentRegistry } : {}),
       ...(deps.subagentRegistry !== undefined ? { subagentRegistry: deps.subagentRegistry } : {}),
       ...(deps.getCreateSessionForSubagent !== undefined

--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -7,7 +7,7 @@ import type { CreateSessionForSubagent, SubagentRegistry } from '@/agent/subagen
 import { capJsonlFileInPlace } from '@/bundled-plugins/tool-result-cap/cap-jsonl'
 import type { CapOptions } from '@/bundled-plugins/tool-result-cap/cap-result'
 import type { CreateSessionForChannel, ChannelRouter } from '@/channels'
-import type { PermissionService } from '@/permissions'
+import type { PermissionService, RolesConfig } from '@/permissions'
 import type { ReloadRegistry } from '@/reload'
 import type { SessionFactory } from '@/sessions'
 import type { Stream } from '@/stream'
@@ -47,6 +47,9 @@ export type BuildChannelSessionFactoryDeps = {
   // the production wiring can plumb in pluginsLoaded.permissions while tests
   // (or stand-alone callers) keep the previous no-annotation behavior.
   permissions?: PermissionService
+  // Live roles snapshot for the grant_role tool's hot-reload. Forwarded to
+  // createSession; the tool only mounts when permissions is also present.
+  rolesProvider?: () => RolesConfig | undefined
   // Test seam: lets a fake stand in for the agent session creator so tests
   // can assert exactly which CreateSessionOptions the factory builds without
   // needing a live LLM, plugin runtime, or session manager on disk.
@@ -124,6 +127,7 @@ export function buildChannelSessionFactory(deps: BuildChannelSessionFactoryDeps)
       ...(deps.containerName !== undefined ? { containerName: deps.containerName } : {}),
       ...(deps.runtimeVersion !== undefined ? { runtimeVersion: deps.runtimeVersion } : {}),
       ...(deps.permissions !== undefined ? { permissions: deps.permissions } : {}),
+      ...(deps.rolesProvider !== undefined ? { rolesProvider: deps.rolesProvider } : {}),
       ...(deps.liveSubagentRegistry !== undefined ? { liveSubagentRegistry: deps.liveSubagentRegistry } : {}),
       ...(deps.subagentRegistry !== undefined ? { subagentRegistry: deps.subagentRegistry } : {}),
       ...(deps.getCreateSessionForSubagent !== undefined

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -24,7 +24,7 @@ import {
   type SubagentCompletionBridge,
 } from '@/channels'
 import { createTunnelBridge, type TunnelBridge } from '@/channels/tunnel-bridge'
-import { createConfigReloadable, getConfig, loadConfigSync, loadPluginConfigsSync } from '@/config'
+import { createConfigReloadable, getConfig, loadConfigSync, loadPluginConfigsSync, reloadConfig } from '@/config'
 import {
   type CronConsumer,
   type CronJob,
@@ -245,7 +245,7 @@ export async function startAgent({
       getChannelRouter: () => channelManager.router,
       rehydrateCapOptions: resolveCapOptionsFromConfig(pluginConfigsByName['tool-result-cap']),
       permissions: pluginsLoaded.permissions,
-      rolesProvider: () => getConfig().roles,
+      reloadRoles: () => reloadRolesFromDisk(cwd),
       liveSubagentRegistry,
       liveSessionRegistry,
       subagentRegistry: pluginRuntime.get().subagents,
@@ -688,6 +688,21 @@ async function disposeMaterializedSkills(pluginRuntime: PluginRuntime): Promise<
   const current = pluginRuntime.get().materializedSkills
   const all = current ? [...pending, current] : pending
   await Promise.allSettled(all.map((m) => m.dispose()))
+}
+
+// grant_role's hot-reload hook: reload the live config FROM DISK (grantRole
+// wrote typeclaw.json directly, bypassing the in-memory snapshot) and return
+// the fresh roles for permissions.replaceRoles. Mirrors the config reloadable's
+// reload-then-read order. Falls back to the current snapshot if the just-written
+// file fails to parse — the on-disk write still stands and the next reload picks
+// it up; replaceRoles with stale roles is no worse than not reloading.
+function reloadRolesFromDisk(cwd: string): ReturnType<typeof getConfig>['roles'] {
+  try {
+    reloadConfig(cwd)
+  } catch {
+    // keep the current pointer; see above
+  }
+  return getConfig().roles
 }
 
 async function startScheduler({

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -245,6 +245,7 @@ export async function startAgent({
       getChannelRouter: () => channelManager.router,
       rehydrateCapOptions: resolveCapOptionsFromConfig(pluginConfigsByName['tool-result-cap']),
       permissions: pluginsLoaded.permissions,
+      rolesProvider: () => getConfig().roles,
       liveSubagentRegistry,
       liveSessionRegistry,
       subagentRegistry: pluginRuntime.get().subagents,


### PR DESCRIPTION
> Stacked on #502 (base: `feat/scoped-permissions`). Review #502 first.

## Background

Onboarding someone to a TypeClaw agent today means hand-editing `typeclaw.json#roles` or running `typeclaw role claim` once per person from the CLI. For the crowd-facing scenarios this work targets — a community Discord, a maintainer bot — that is too clunky. We want the operator to manage access conversationally: "respond to author U_WIFE" → grant them member; "let anyone in this channel message you" → grant `guest` `channel.respond`.

The hard part is doing this safely. A role grant is a confused-deputy target. A guest can post prompt-injection into a group channel where a trusted human is engaged; the trusted turn carries the guest's buffered messages in its context, and the model cannot reliably tell the trusted principal's instructions from the guest's quoted text. If `grant_role` were callable from that turn, the injection could steer it into granting the guest capabilities — using the trusted human's authority. "You can only grant what you hold" bounds the grant to the trusted user's power, but that power is exactly what the attacker wants.

## Summary

The gate confines all grants to **single-principal turns**, where no third-party content enters the turn:

- **origin** must be TUI or a 1:1 DM (`isDmChannelOrigin`); group/open channels are refused outright. A DM is two participants (principal + bot), structurally like the TUI — no buffered third-party messages, so no injection surface.
- **caller** must resolve to `owner` or `trusted`.
- **tier ceiling**: a granter cannot assign or empower a role above its own (owner ≥ trusted ≥ member ≥ guest).
- **permission grants** additionally require "grant only what you hold", and `security.bypass.*` is **never** grantable via the tool — it disables guards and stays a deliberate hand-edit gated by the `rolePromotion` guard.

The tool calls `grantRole` / `grantRolePermission` directly (atomic `typeclaw.json` write + `replaceRoles` hot-reload) — the same out-of-band path the role-claim flow uses, which `rolePromotion` intentionally does not cover (its docstring says so). `grantRolePermission` materializes a built-in role's effective default permission set before appending, so granting one capability to a role with no explicit `permissions[]` does not silently narrow it.

This design follows an adversarial review that rejected an earlier "owner+trusted can grant from any channel" version as exploitable via the chain above.

## What this does NOT do

- **TUI grants.** The server's TUI `createSession` does not thread a `PermissionService` (the known-hardening item in `sandbox.mdx`), so `grant_role` is **DM-only** for now. Threading the server permission service is a separate follow-up.
- **Grant `security.bypass.*`.** Refused by the tool; remains a hand-edit.
- **Drop the `member:*` init default.** That is a separate PR.
- **Make permission grants take effect live.** `roles.permissions` is `restart-required`; the tool result says so.

## Review notes

- **Load-bearing:** the gate in `src/agent/tools/grant-role.ts` — specifically `isSinglePrincipalOrigin` (the confused-deputy defense), the tier ceiling, the `security.bypass.*` refusal, and the "grant only what you hold" check. Gate tests in `grant-role.test.ts` cover each branch, including the group-channel rejection.
- **Invariant to verify:** `grantRolePermission` must not narrow a built-in role. `grant.test.ts` pins that granting one permission to `member`/`guest` preserves the full default set.
- **Two commits:** the primitives (`grantRolePermission`, `isDmChannelOrigin`) land first with their own tests; the tool + wiring second.