### PR TITLE
feat(init): scope chat agents by default; drop the member:["*"] seeding

### DIFF
--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -217,22 +217,22 @@ describe('runAddChannel', () => {
     expect(after.idleMs).toBe(60_000)
   })
 
-  test('writes roles.member.match: ["*"] when adding a chat adapter to a freshly scaffolded folder', async () => {
+  test('does NOT seed a member match when adding a chat adapter (scoped-by-default; owner claim grants access)', async () => {
     await runAddChannel({ cwd: root, channel: 'slack-bot', slackBotToken: 'xoxb', slackAppToken: 'xapp' })
 
     const cfg = (await readConfig()) as { roles?: { member?: { match?: string[] } } }
-    expect(cfg.roles?.member?.match).toEqual(['*'])
+    expect(cfg.roles?.member?.match).toBeUndefined()
   })
 
-  test('does not duplicate the "*" entry when a second chat adapter is added later', async () => {
+  test('does not seed member match across multiple chat adapters', async () => {
     await runAddChannel({ cwd: root, channel: 'slack-bot', slackBotToken: 'xoxb', slackAppToken: 'xapp' })
     await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-x' })
 
     const cfg = (await readConfig()) as { roles?: { member?: { match?: string[] } } }
-    expect(cfg.roles?.member?.match).toEqual(['*'])
+    expect(cfg.roles?.member?.match).toBeUndefined()
   })
 
-  test('preserves existing roles.member.match entries (set-union semantics, no clobber)', async () => {
+  test('leaves an operator-authored member.match untouched (no wildcard appended)', async () => {
     const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as Record<string, unknown>
     cfg.roles = { member: { match: ['slack:T0123 author:U_EXISTING'] } }
     await writeFile(join(root, 'typeclaw.json'), `${JSON.stringify(cfg, null, 2)}\n`)
@@ -240,10 +240,10 @@ describe('runAddChannel', () => {
     await runAddChannel({ cwd: root, channel: 'discord-bot', discordBotToken: 'discord-x' })
 
     const after = (await readConfig()) as { roles?: { member?: { match?: string[] } } }
-    expect(after.roles?.member?.match).toEqual(['slack:T0123 author:U_EXISTING', '*'])
+    expect(after.roles?.member?.match).toEqual(['slack:T0123 author:U_EXISTING'])
   })
 
-  test('preserves existing roles.owner block (does not overwrite when adding a channel)', async () => {
+  test('preserves existing roles.owner block and adds no member wildcard when adding a channel', async () => {
     const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as Record<string, unknown>
     cfg.roles = { owner: { match: ['slack:@dm author:U_ME'] } }
     await writeFile(join(root, 'typeclaw.json'), `${JSON.stringify(cfg, null, 2)}\n`)
@@ -254,7 +254,7 @@ describe('runAddChannel', () => {
       roles?: { owner?: { match?: string[] }; member?: { match?: string[] } }
     }
     expect(after.roles?.owner?.match).toEqual(['slack:@dm author:U_ME'])
-    expect(after.roles?.member?.match).toEqual(['*'])
+    expect(after.roles?.member?.match).toBeUndefined()
   })
 
   test('rejects re-adding an already-configured channel', async () => {

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1004,29 +1004,27 @@ describe('scaffold', () => {
     expect(cfg.channels).toEqual({ 'discord-bot': {} })
   })
 
-  // A freshly-hatched agent with no roles config silently drops every inbound
-  // chat message because no role's match[] covers the channel session, so the
-  // origin resolves to `guest` (no channel.respond). `roles.member.match: ["*"]`
-  // grants the built-in `member` role (which already carries channel.respond)
-  // to any channel origin, so the agent talks out of the box. The owner-claim
-  // flow is then a privilege upgrade (cron, security bypass) for one human,
-  // not a precondition for the agent to speak at all.
-  test('writes roles.member.match: ["*"] when any chat adapter is selected (so freshly hatched agents respond)', async () => {
+  // Scoped-by-default: a freshly-hatched chat agent seeds NO member match, so
+  // every inbound author resolves to `guest` and is dropped until the operator
+  // claims `owner` (runOwnerClaim) and explicitly grants others. This makes the
+  // owner-claim flow a precondition for the agent to speak — surfaced by the
+  // mute-until-claimed warning — rather than letting any stranger drive it.
+  test('seeds NO member match when a chat adapter is selected (scoped-by-default)', async () => {
     await scaffold(root, { withSlack: true })
 
     const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
       roles?: { member?: { match?: string[] } }
     }
-    expect(cfg.roles?.member?.match).toEqual(['*'])
+    expect(cfg.roles?.member?.match).toBeUndefined()
   })
 
-  test('writes roles.member.match: ["*"] exactly once when multiple chat adapters are selected', async () => {
+  test('seeds NO member match even when multiple chat adapters are selected', async () => {
     await scaffold(root, { withDiscord: true, withSlack: true, withTelegram: true, withKakaotalk: true })
 
     const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
       roles?: { member?: { match?: string[] } }
     }
-    expect(cfg.roles?.member?.match).toEqual(['*'])
+    expect(cfg.roles?.member).toBeUndefined()
   })
 
   test('omits roles block entirely when no chat adapter is selected (greenfield is silent until configured)', async () => {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -39,14 +39,6 @@ const CONFIG_FILE = 'typeclaw.json'
 const CRON_FILE = 'cron.json'
 const PACKAGE_FILE = 'package.json'
 
-// Seeded into `typeclaw.json#roles.member.match[]` whenever a chat adapter
-// (slack-bot, discord-bot, telegram-bot, kakaotalk) is wired. The "*" rule
-// matches every channel session on every platform, so the built-in `member`
-// role (which already carries `channel.respond`) covers any inbound the
-// router sees. Without this, freshly-hatched agents silently drop every
-// chat message — see scaffold() and ensureDefaultChatMemberMatch() below.
-const DEFAULT_CHAT_MEMBER_MATCH_RULE = '*'
-
 const MARKDOWN_FILES = ['AGENTS.md', 'IDENTITY.md', 'SOUL.md', 'USER.md'] as const
 
 // `packages/` is a bun workspace root (see `workspaces` in buildPackageJson).
@@ -586,11 +578,11 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   if (options.withTelegram) channels['telegram-bot'] = {}
   if (options.withKakaotalk) channels.kakaotalk = {}
   if (Object.keys(channels).length > 0) config.channels = channels
-  // See DEFAULT_CHAT_MEMBER_MATCH_RULE for why this is here. GitHub is wired
-  // separately (writeGithubChannelForInit) and seeds per-repo member.match
-  // entries instead of the wildcard, so a github-only init stays scoped to
-  // the repos the operator opted in to.
-  if (Object.keys(channels).length > 0) config.roles = { member: { match: [DEFAULT_CHAT_MEMBER_MATCH_RULE] } }
+  // No default `member` match is seeded. A fresh chat agent starts with every
+  // inbound author resolving to `guest` (dropped) until the operator claims
+  // `owner` (runOwnerClaim, post-hatch) and explicitly grants others. GitHub is
+  // wired separately and seeds per-repo `member.match` entries scoped to the
+  // opted-in repos. See runOwnerClaim for the mute-until-claimed warning.
   await writeFile(join(root, CONFIG_FILE), `${JSON.stringify(config, null, 2)}\n`)
 
   const cron = {
@@ -1046,8 +1038,6 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
   if (options.channel === 'github') {
     await appendGithubMatchRules(options.cwd, options.repos)
     await maybeInstallGithubWebhooks(options, emit)
-  } else {
-    await ensureDefaultChatMemberMatch(options.cwd)
   }
 
   // Commit the typeclaw.json change so the agent folder isn't silently
@@ -1324,24 +1314,6 @@ async function appendGithubMatchRules(cwd: string, repos: readonly string[]): Pr
   const merged = new Set(existing)
   for (const repo of repos) merged.add(`github:${repo}`)
   member.match = Array.from(merged)
-  roles.member = member
-  parsed.roles = roles
-  await writeFile(path, `${JSON.stringify(parsed, null, 2)}\n`)
-}
-
-// Chat-adapter counterpart of appendGithubMatchRules. See
-// DEFAULT_CHAT_MEMBER_MATCH_RULE for the rationale. Set-union semantics: re-
-// running `typeclaw channel add` for additional chat adapters is a no-op on
-// the match list, and any pre-existing rules the operator hand-authored
-// (e.g. owner-claim's per-author entry on `owner`) are left intact.
-async function ensureDefaultChatMemberMatch(cwd: string): Promise<void> {
-  const path = join(cwd, CONFIG_FILE)
-  const parsed = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>
-  const roles = isObjectRecord(parsed.roles) ? { ...parsed.roles } : {}
-  const member = isObjectRecord(roles.member) ? { ...roles.member } : {}
-  const existing = Array.isArray(member.match) ? member.match.filter((v): v is string => typeof v === 'string') : []
-  if (existing.includes(DEFAULT_CHAT_MEMBER_MATCH_RULE)) return
-  member.match = [...existing, DEFAULT_CHAT_MEMBER_MATCH_RULE]
   roles.member = member
   parsed.roles = roles
   await writeFile(path, `${JSON.stringify(parsed, null, 2)}\n`)

--- a/src/init/run-owner-claim.ts
+++ b/src/init/run-owner-claim.ts
@@ -43,7 +43,7 @@ export async function runOwnerClaim({ url, configuredChannels }: RunOwnerClaimOp
     initialValue: true,
   })
   if (isCancel(proceed) || proceed === false) {
-    log.info(`Skipping. Run ${c.bold('typeclaw role claim')} later when you're ready.`)
+    warnMuteUntilClaimed()
     return
   }
 
@@ -78,9 +78,27 @@ export async function runOwnerClaim({ url, configuredChannels }: RunOwnerClaimOp
   }
   if (result.kind === 'error') {
     s.stop(c.red(`Claim failed: ${result.payload.reason}`))
-    log.info(`You can retry with ${c.bold('typeclaw role claim')} anytime.`)
+    warnMuteUntilClaimed()
     return
   }
   s.stop(c.yellow(`Claim timed out — no DM received within the window.`))
-  log.info(`Run ${c.bold('typeclaw role claim')} when you're ready.`)
+  warnMuteUntilClaimed()
+}
+
+// Printed on every path that finishes init WITHOUT a successful owner claim.
+// Since the scoped-by-default change removed the `member: ["*"]` seeding, an
+// unclaimed chat agent resolves every inbound to `guest` and drops it — the
+// agent answers no one. This is a footgun unless the operator is told plainly,
+// so the warning is loud and names the exact recovery command.
+function warnMuteUntilClaimed(): void {
+  note(
+    [
+      `Your agent will respond to ${c.bold('no one')} until you claim the owner role —`,
+      `every inbound message is currently dropped.`,
+      '',
+      `Run ${c.bold('typeclaw role claim')} to pair yourself, then grant others`,
+      `with the agent (ask it: "respond to <user>") or by editing typeclaw.json#roles.`,
+    ].join('\n'),
+    c.yellow('Heads up: agent is muted'),
+  )
 }


### PR DESCRIPTION
> Part of the scoped-permissions work alongside #502 and #507. Independent of both (init-time change); can land in any order.

## Background

A freshly-hatched chat agent seeded `roles.member.match: ["*"]`. That wildcard makes the built-in `member` role — which carries `channel.respond`, `fs.see.private`, and `security.bypass.low` — match every author on every wired platform. So out of the box, any stranger in any Slack/Discord/Telegram/KakaoTalk channel the agent joins can drive it: prompt it, spawn subagents, read the private working surface. For the crowd-facing agents this is meant to support (a community Discord, a maintainer bot), that is the wrong default — the whole point is that maintainers are trusted and everyone else is not.

## Summary

Removes the `member:["*"]` seeding at every site that wrote it: the init scaffold, the post-hatch `ensureDefaultChatMemberMatch` pass, and the `typeclaw channel add` path (the latter two were the same helper, now deleted). GitHub is unchanged — it already seeds per-repo `member.match` entries scoped to the repos the operator opted into, which is exactly the model we want.

With the wildcard gone, every inbound author resolves to `guest` and is dropped until the operator claims `owner` and explicitly grants others (via the `grant_role` tool from #507, the CLI claim flow, or a hand-edit). To keep that from being a silent footgun, the owner-claim flow now prints a **loud mute-until-claimed warning** on every path that finishes init without a successful claim — skip, error, or timeout — naming `typeclaw role claim` as the recovery.

The 1:1 DM case, the common scenario, is clean: claim owner, done, no other participants to worry about.

## Preview

<!-- No UI/output changes to show. -->

## What this does NOT do

- **Migrate existing agents.** This is init-time only. An agent that already has `member:["*"]` on disk keeps it — silently demoting a running production agent's whole audience to guest on upgrade would be a nasty surprise.
- **Hard-block init without a claim.** Skip is still allowed (headless/CI init must work); it just warns loudly.
- **Change the permission model or add the grant tool.** Those are #502 and #507.

## Review notes

- **Behavioral change to the default posture of every new chat agent.** The load-bearing assertion: scaffold and `runAddChannel` seed no `member` match (pinned by updated tests in `index.test.ts` and `add-channel.test.ts`); GitHub per-repo seeding is untouched (existing tests still green).
- The mute-until-claimed warning in `run-owner-claim.ts` is thin clack UI; per the repo testing philosophy that layer is not unit-tested.