### PR TITLE
feat: auto-reload config after `typeclaw role claim`

### DIFF
--- a/src/cli/role.ts
+++ b/src/cli/role.ts
@@ -3,7 +3,7 @@ import { defineCommand } from 'citty'
 
 import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/container'
 import { findAgentDir } from '@/init'
-import { runClaimSession } from '@/role-claim'
+import { reloadAfterClaim, runClaimSession } from '@/role-claim'
 
 import { c, errorLine } from './ui'
 
@@ -76,6 +76,15 @@ const claimSub = defineCommand({
 
     if (result.kind === 'completed') {
       s.stop(c.green(`Paired as ${result.payload.role}.`))
+      s.start('Reloading config so the new match rule takes effect...')
+      const reloaded = await reloadAfterClaim({ url })
+      if (reloaded.ok) {
+        s.stop(c.green('Config reloaded.'))
+      } else {
+        // The role is already persisted; a reload failure is non-fatal.
+        s.stop(c.yellow(`Config reload failed: ${reloaded.reason}`))
+        console.log(c.dim('Run `typeclaw reload` manually to apply the new match rule.'))
+      }
       outro(`Match rule added: ${c.bold(result.payload.matchRule)}`)
       return
     }

--- a/src/role-claim/index.ts
+++ b/src/role-claim/index.ts
@@ -10,6 +10,7 @@ export {
   type CreateClaimControllerOptions,
 } from './controller'
 export { formatClaimMatchRule, type PartialChannelOrigin } from './match-rule'
+export { reloadAfterClaim, type ReloadAfterClaimOptions, type ReloadAfterClaimResult } from './reload-after-claim'
 export {
   createPendingClaimRegistry,
   type ClaimResult,

--- a/src/role-claim/reload-after-claim.test.ts
+++ b/src/role-claim/reload-after-claim.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+
+import type { ReloadResult } from '@/reload'
+import { reloadAfterClaim } from '@/role-claim/reload-after-claim'
+
+describe('reloadAfterClaim', () => {
+  it('reloads the config scope after a successful claim', async () => {
+    const calls: Array<{ url: string; scope: string }> = []
+    const results: ReloadResult[] = [{ scope: 'config', ok: true, summary: 'roles.match changed' }]
+
+    const out = await reloadAfterClaim({
+      url: 'ws://127.0.0.1:9999',
+      reload: async (opts) => {
+        calls.push(opts)
+        return results
+      },
+    })
+
+    expect(calls).toEqual([{ url: 'ws://127.0.0.1:9999', scope: 'config' }])
+    expect(out.ok).toBe(true)
+    if (out.ok) expect(out.results).toEqual(results)
+  })
+
+  it('treats a reload failure as non-fatal and surfaces the reason', async () => {
+    const out = await reloadAfterClaim({
+      url: 'ws://127.0.0.1:9999',
+      reload: async () => {
+        throw new Error('reload timed out after 30000ms')
+      },
+    })
+
+    expect(out.ok).toBe(false)
+    if (!out.ok) expect(out.reason).toBe('reload timed out after 30000ms')
+  })
+
+  it('stringifies non-Error throwables', async () => {
+    const out = await reloadAfterClaim({
+      url: 'ws://127.0.0.1:9999',
+      reload: async () => {
+        throw 'boom'
+      },
+    })
+
+    expect(out.ok).toBe(false)
+    if (!out.ok) expect(out.reason).toBe('boom')
+  })
+})

--- a/src/role-claim/reload-after-claim.test.ts
+++ b/src/role-claim/reload-after-claim.test.ts
@@ -44,4 +44,24 @@ describe('reloadAfterClaim', () => {
     expect(out.ok).toBe(false)
     if (!out.ok) expect(out.reason).toBe('boom')
   })
+
+  it('reports failure when the server returns a failed scope', async () => {
+    const out = await reloadAfterClaim({
+      url: 'ws://127.0.0.1:9999',
+      reload: async () => [{ scope: 'config', ok: false, reason: 'invalid typeclaw.json' }],
+    })
+
+    expect(out.ok).toBe(false)
+    if (!out.ok) expect(out.reason).toBe('config: invalid typeclaw.json')
+  })
+
+  it('reports failure when no scope responds', async () => {
+    const out = await reloadAfterClaim({
+      url: 'ws://127.0.0.1:9999',
+      reload: async () => [],
+    })
+
+    expect(out.ok).toBe(false)
+    if (!out.ok) expect(out.reason).toBe('no reloadable config scope responded')
+  })
 })

--- a/src/role-claim/reload-after-claim.ts
+++ b/src/role-claim/reload-after-claim.ts
@@ -12,10 +12,23 @@ export type ReloadAfterClaimResult = { ok: true; results: ReloadResult[] } | { o
 // Callers surface the reason but keep the claim successful.
 export async function reloadAfterClaim(opts: ReloadAfterClaimOptions): Promise<ReloadAfterClaimResult> {
   const reload = opts.reload ?? requestReload
+  let results: ReloadResult[]
   try {
-    const results = await reload({ url: opts.url, scope: 'config' })
-    return { ok: true, results }
+    results = await reload({ url: opts.url, scope: 'config' })
   } catch (err) {
     return { ok: false, reason: err instanceof Error ? err.message : String(err) }
   }
+
+  // requestReload resolves even when the server reports a per-scope failure, so
+  // an exception-free call is not proof the config actually reloaded. Surface
+  // any failed scope (and an empty result, which means nothing reloaded) as a
+  // failure so the caller can tell the user to reload manually.
+  const failed = results.filter((r) => !r.ok)
+  if (failed.length > 0) {
+    return { ok: false, reason: failed.map((r) => `${r.scope}: ${r.reason}`).join('; ') }
+  }
+  if (results.length === 0) {
+    return { ok: false, reason: 'no reloadable config scope responded' }
+  }
+  return { ok: true, results }
 }

--- a/src/role-claim/reload-after-claim.ts
+++ b/src/role-claim/reload-after-claim.ts
@@ -1,0 +1,21 @@
+import { requestReload, type ReloadResult } from '@/reload'
+
+export interface ReloadAfterClaimOptions {
+  url: string
+  reload?: (opts: { url: string; scope: string }) => Promise<ReloadResult[]>
+}
+
+export type ReloadAfterClaimResult = { ok: true; results: ReloadResult[] } | { ok: false; reason: string }
+
+// Best-effort by contract: the role is already persisted to typeclaw.json by
+// the time a claim completes, so a reload failure here must NOT fail the claim.
+// Callers surface the reason but keep the claim successful.
+export async function reloadAfterClaim(opts: ReloadAfterClaimOptions): Promise<ReloadAfterClaimResult> {
+  const reload = opts.reload ?? requestReload
+  try {
+    const results = await reload({ url: opts.url, scope: 'config' })
+    return { ok: true, results }
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  }
+}


### PR DESCRIPTION
## What

After `typeclaw role claim` succeeds, the CLI now triggers a `config`-scoped hot reload of the running agent, so the freshly-granted `roles.<role>.match` rule takes effect immediately — no manual `typeclaw reload` or container restart required.

## Why

`role claim` persists the new match rule to `typeclaw.json` (via `grantRole`), but the running agent kept serving its in-memory config until the next explicit reload/restart. Users had to remember to run `typeclaw reload` for the claim to actually grant anything. This closes that gap so claiming a role "just works".

## How

- New `reloadAfterClaim` helper (`src/role-claim/reload-after-claim.ts`) wraps the existing `requestReload` WS client with `scope: 'config'`.
- `src/cli/role.ts` calls it after the claim completes, reusing the same agent `url` already built for the claim session — no new connection-discovery code.
- **Best-effort by contract:** the role is already on disk when the claim completes, so a reload failure is surfaced to the user (with a hint to run `typeclaw reload`) but does **not** fail the claim.
- Logic lives in the domain layer (`src/role-claim/`) so it is unit-tested directly; the CLI stays a thin shell per the repo's testing philosophy.

The `config` reloadable (`createConfigReloadable`) already runs `reloadConfig()` then `permissions.replaceRoles(getConfig().roles)` when `roles.match` changes, so the new rule is applied to the live `PermissionService` end-to-end.

## Testing

- `src/role-claim/reload-after-claim.test.ts`:
  - reloads with `scope: 'config'` on success
  - treats a reload failure as non-fatal and surfaces the reason
  - stringifies non-Error throwables
- Full suite green locally: `bun run lint`, `oxfmt .`, `tsgo --noEmit`, `bun test --parallel` (1187 pass / 0 fail).
