### PR TITLE
fix(cli): print Discord invite URL flush-left so it copy-pastes cleanly

### DIFF
--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -5,6 +5,7 @@ import {
   done,
   errorLine,
   link,
+  printDiscordInviteHint,
   printSlackAppManifestSetup,
   renderStartSuccess,
   SLACK_APP_MANIFEST,
@@ -461,5 +462,50 @@ describe('printSlackAppManifestSetup', () => {
     const stop = SLACK_APP_MANIFEST.features.slash_commands.find((c) => c.command === '/stop')
     expect(stop).toBeDefined()
     expect(stop!.url).toContain('example.invalid')
+  })
+})
+
+describe('printDiscordInviteHint', () => {
+  const ANSI = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, 'g')
+
+  function captureStdout<T>(fn: () => T): { result: T; output: string } {
+    const original = process.stdout.write.bind(process.stdout)
+    let buf = ''
+    process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+      buf += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8')
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const result = fn()
+      return { result, output: buf.replace(ANSI, '') }
+    } finally {
+      process.stdout.write = original
+    }
+  }
+
+  function tokenForAppId(appId: string): string {
+    const head = Buffer.from(appId, 'utf-8').toString('base64').replace(/=+$/, '')
+    return `${head}.G49NjP.pD8PLpKp-Xx8sr-8m1DCxSPTJZdcpcJZOExc1c`
+  }
+
+  test('emits the invite URL on its own flush-left line so it copy-pastes cleanly', () => {
+    const { output } = captureStdout(() =>
+      withNoColor(() => printDiscordInviteHint(tokenForAppId('968556348390391859'))),
+    )
+
+    const urlLine = output.split('\n').find((line) => line.includes('discord.com/oauth2/authorize'))
+    expect(urlLine).toBeDefined()
+    // flush-left: the URL line carries no clack box gutter that would corrupt a copy
+    expect(urlLine!.startsWith('│')).toBe(false)
+    expect(urlLine!.startsWith('|')).toBe(false)
+    expect(urlLine).toContain('client_id=968556348390391859')
+
+    expect(output).toContain('Invite the bot to a server')
+    expect(output).toContain('pick a server')
+  })
+
+  test('writes nothing when the token is not a parseable Discord bot token', () => {
+    const { output } = captureStdout(() => withNoColor(() => printDiscordInviteHint('not-a-token')))
+    expect(output).toBe('')
   })
 })

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -252,16 +252,18 @@ export function printSlackAppManifestSetup(output: NodeJS.WritableStream = proce
 // the exact permission bitfield the adapter uses. No-ops when the token isn't
 // parseable as a Discord bot token so we never block onboarding on best-effort
 // guidance.
-export function printDiscordInviteHint(token: string): void {
+export function printDiscordInviteHint(token: string, output: NodeJS.WritableStream = process.stdout): void {
   const appId = deriveAppIdFromBotToken(token)
   if (appId === null) return
+  // URL stays OUT of note(): clack wraps long lines with a `│` gutter that
+  // corrupts copy-pasted URLs. Same fix as src/cli/oauth-callbacks.ts.
   note(
     [
-      buildDiscordInviteUrl(appId),
-      '',
-      'Open it, pick a server, click Authorize.',
+      'Open the URL below, pick a server, click Authorize.',
       "The bot won't receive messages until it's in at least one server.",
     ].join('\n'),
     'Invite the bot to a server',
   )
+  output.write(`${buildDiscordInviteUrl(appId)}\n`)
+  output.write('\n')
 }


### PR DESCRIPTION
## Background

`typeclaw channel add discord-bot` (and `init`) prints a ready-to-click Discord OAuth2 invite URL so operators don't have to hand-assemble the Application ID → scopes → permission-bitfield by hand. The URL was rendered **inside** a clack `note()` box. clack wraps any line wider than the box with a `│` gutter on every wrapped segment, so the long invite URL gets split across boxed lines:

```
│  https://discord.com/oauth2/authorize?client_id=...&scope=bot   │
│  +applications.commands&permissions=277025508416                │
```

Dragging to copy then yields a URL polluted with `│`, leading spaces, and a mid-string break — it doesn't paste into a browser. The onboarding shortcut silently produced an unusable URL.

## Summary

Move the URL out of the `note()` body: keep only the instructional prose inside the box and write the URL flush-left to stdout via a raw `output.write`, so the terminal hyperlinks and copies it intact. This is the same fix already established for OAuth login URLs in `src/cli/oauth-callbacks.ts` and for the flush-left Slack manifest in `printSlackAppManifestSetup` — both deliberately keep copy-sensitive payloads out of `note()` for exactly this reason. `printDiscordInviteHint` gains an injectable `output` stream (defaulting to `process.stdout`) so the flush-left behavior is unit-testable without capturing global stdout.

## Preview

Before — the box gutter splits the URL, breaking copy-paste:

```
◇  Invite the bot to a server ──────────────────────────────────────╮
│                                                                    │
│  https://discord.com/oauth2/authorize?client_id=151...&scope=bot   │
│  +applications.commands&permissions=277025508416                   │
│                                                                    │
╰────────────────────────────────────────────────────────────────────╯
```

After — instructions stay boxed, URL is flush-left and copyable:

```
◇  Invite the bot to a server ──────────────────────────────────────╮
│                                                                    │
│  Open the URL below, pick a server, click Authorize.               │
│  The bot won't receive messages until it's in at least one server. │
│                                                                    │
╰────────────────────────────────────────────────────────────────────╯

https://discord.com/oauth2/authorize?client_id=151...&scope=bot+applications.commands&permissions=277025508416
```

## What this does NOT do

- Doesn't touch the URL builder (`buildDiscordInviteUrl`) — scopes and the permission bitfield are unchanged.
- Doesn't change the no-op behavior for unparseable tokens (still prints nothing).
- No runtime/agent, config, or container-stage surface is affected — this is host-stage CLI output only.

## Review notes

Load-bearing line is the `output.write(buildDiscordInviteUrl(appId))` outside the `note()` call. The invariant to verify: the URL must never appear inside the `note()` body (a `│` gutter would corrupt it). The new `printDiscordInviteHint` test asserts exactly that — the URL is absent from the note body and present in the flush-left stream with no `│` character — plus a token-unparseable case that emits nothing.
