### PR TITLE
Commit typeclaw.json after a successful role grant

### DIFF
--- a/src/permissions/grant.test.ts
+++ b/src/permissions/grant.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -156,5 +157,104 @@ describe('grantRolePermission', () => {
     const config = readConfig(dir) as { roles: { member: { permissions?: string[] } } }
     // no narrowing write happened; the file role still has no explicit permissions[]
     expect(config.roles.member.permissions).toBeUndefined()
+  })
+})
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  const proc = Bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+  await proc.exited
+  return (await new Response(proc.stdout).text()).trim()
+}
+
+async function gitInit(cwd: string): Promise<void> {
+  for (const cmd of [
+    ['init', '-b', 'main'],
+    ['config', 'user.name', 'Test User'],
+    ['config', 'user.email', 'test@example.com'],
+  ]) {
+    const proc = Bun.spawn({ cmd: ['git', ...cmd], cwd, stdout: 'pipe', stderr: 'pipe' })
+    await proc.exited
+  }
+}
+
+async function seedGitRepo(dir: string, config: unknown): Promise<void> {
+  await gitInit(dir)
+  await writeFile(join(dir, 'typeclaw.json'), `${JSON.stringify(config, null, 2)}\n`)
+  await runGit(dir, ['add', 'typeclaw.json'])
+  await runGit(dir, ['commit', '-m', 'initial'])
+}
+
+describe('grantRole git commit', () => {
+  test('commits typeclaw.json after a successful grant', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-grant-commit-'))
+    try {
+      // given: a git repo with an owner role and no match rules
+      await seedGitRepo(dir, { roles: { owner: { match: [] } } })
+
+      // when: a claim grants a match rule
+      const result = grantRole({ cwd: dir, roleName: 'owner', matchRule: 'slack:* author:U123' })
+
+      // then: the grant succeeded and HEAD is a scoped typeclaw.json commit
+      expect(result).toEqual({ ok: true, added: true })
+      expect(await runGit(dir, ['log', '-1', '--format=%s'])).toBe('typeclaw.json: grant owner role')
+      expect(await runGit(dir, ['show', '--name-only', '--format=', 'HEAD'])).toBe('typeclaw.json')
+      const committed = JSON.parse(await runGit(dir, ['show', 'HEAD:typeclaw.json']))
+      expect(committed.roles.owner.match).toEqual(['slack:* author:U123'])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('uses the role name in the commit subject', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-grant-commit-role-'))
+    try {
+      await seedGitRepo(dir, { roles: { trusted: { match: [] } } })
+
+      grantRole({ cwd: dir, roleName: 'trusted', matchRule: 'discord:* author:42' })
+
+      expect(await runGit(dir, ['log', '-1', '--format=%s'])).toBe('typeclaw.json: grant trusted role')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('does not commit when the rule already exists (idempotent no-op)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-grant-commit-dedup-'))
+    try {
+      // given: the match rule is already on file
+      await seedGitRepo(dir, { roles: { owner: { match: ['slack:* author:U123'] } } })
+      const head = await runGit(dir, ['rev-parse', 'HEAD'])
+
+      // when: the same rule is granted again
+      const result = grantRole({ cwd: dir, roleName: 'owner', matchRule: 'slack:* author:U123' })
+
+      // then: no write, no new commit
+      expect(result).toEqual({ ok: true, added: false })
+      expect(await runGit(dir, ['rev-parse', 'HEAD'])).toBe(head)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('commits only typeclaw.json, leaving other dirty files untouched', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-grant-commit-scope-'))
+    try {
+      // given: an unrelated tracked file the user is mid-editing
+      await gitInit(dir)
+      await writeFile(join(dir, 'typeclaw.json'), `${JSON.stringify({ roles: { owner: { match: [] } } }, null, 2)}\n`)
+      await writeFile(join(dir, 'AGENTS.md'), 'original\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+      await writeFile(join(dir, 'AGENTS.md'), 'user wip\n')
+
+      // when: a grant commits
+      grantRole({ cwd: dir, roleName: 'owner', matchRule: 'slack:* author:U123' })
+
+      // then: the commit holds only typeclaw.json; AGENTS.md stays dirty
+      expect(await runGit(dir, ['show', '--name-only', '--format=', 'HEAD'])).toBe('typeclaw.json')
+      expect(await runGit(dir, ['show', 'HEAD:AGENTS.md'])).toBe('original')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/permissions/grant.ts
+++ b/src/permissions/grant.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { commitSystemFileSync } from '@/git/system-commit'
+
 import { BUILTIN_ROLES, isBuiltinRoleName } from './builtins'
 import { parseMatchRule } from './match-rule'
 
@@ -53,7 +55,15 @@ export function grantRole(opts: GrantOptions): GrantResult {
   roles[opts.roleName] = role
   obj.roles = roles
 
-  return writeConfigObject(opts.cwd, obj)
+  const written = writeConfigObject(opts.cwd, obj)
+  if (!written.ok) return written
+
+  // Best-effort commit so a claimed role survives a fresh clone/rebuild — a
+  // failing commit leaves the on-disk grant intact (history, not correctness).
+  // Subject stays neutral: every grantRole caller hits this, not just claim.
+  commitSystemFileSync(opts.cwd, CONFIG_FILE, `${CONFIG_FILE}: grant ${opts.roleName} role`)
+
+  return written
 }
 
 // Appends `permission` to `typeclaw.json#roles.<name>.permissions`. For a


### PR DESCRIPTION
## Background

`typeclaw role claim` writes the new match rule into `typeclaw.json#roles.<role>.match` and hot-reloads the live permission service, but it never recorded the change in git. The grant only existed as an uncommitted working-tree edit, so a fresh clone, a rebuild, or any operator who ran `git checkout -- typeclaw.json` would silently lose a claimed role — and there was no audit trail of when a role was granted or to whom.

## Summary

Commit `typeclaw.json` immediately after a successful grant, inside `grantRole` — the single persistence chokepoint for role match-rule writes. Both the role-claim handshake (`src/role-claim/controller.ts`) and the conversational `grant_role` tool route through `grantRole`, so wiring the commit here covers every grant path with one change instead of duplicating commit logic per caller.

Key decisions:

- **Why `grantRole`, not the controller or the host CLI?** The container performs the authoritative write against the bind-mounted agent folder, and `grantRole` is the only place that knows whether a real write happened. The host CLI never touches the file; the controller would be claim-specific and miss the `grant_role` tool.
- **Why reuse `commitSystemFileSync`?** It's the same helper config migrations already use (`persistMigratedConfig`). `grantRole` is synchronous, so the sync variant fits without rippling `async` through the controller. It scopes the commit with `git commit --only -- typeclaw.json`, leaving any unrelated dirty working-tree files untouched.
- **Why best-effort?** A non-repo agent folder, missing Bun, or a failing `git commit` leaves the on-disk grant intact. The commit is history/auditability, not correctness — the role is already persisted by the time we try to commit.
- **Why a neutral commit subject (`typeclaw.json: grant <role> role`)?** `grantRole` serves callers beyond `role claim`, so a "via claim" message would be wrong for the `grant_role` tool path.
- **No commit on the idempotent dedup path** (`added: false`) — re-claiming an existing rule produces no write and therefore no empty no-op commit.

## What this does NOT do

- Does not add commit behavior to `grantRolePermission` — that mutates `roles.<name>.permissions` (a `restart-required` field) and is a separate concern from role claim.
- Does not push, rebase, or touch any remote — purely a local history commit on the agent folder.
- Does not change the claim handshake, the match-rule DSL, or the hot-reload path.

## Review notes

- Load-bearing change: the `commitSystemFileSync(...)` call in `src/permissions/grant.ts`, placed **after** `writeConfigObject` succeeds and **before** the `added: false` early return (so dedup stays commit-free).
- Invariant to verify: the commit must be scoped to `typeclaw.json` only. The new test `commits only typeclaw.json, leaving other dirty files untouched` proves an unrelated dirty `AGENTS.md` is not swept into the grant commit.
- Tests use a real temporary git repo (no mocking of git), matching the existing `src/git/system-commit.test.ts` style. The pre-existing `grantRole` / `grantRolePermission` tests are unchanged; the new `grantRole git commit` describe block is additive. `controller.test.ts` injects a fake `grant`, so it stays isolated from disk and required no changes.
