### PR TITLE
fix(agent): teach github sessions that channel_reply is the PR comment

### DIFF
--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -288,6 +288,22 @@ function renderChannelOrigin(
     'is a tool call. Plain-text output is invisible.',
   ]
 
+  // GitHub has no separate "chat" surface — channel_reply IS a public comment
+  // on this PR/issue. Without saying so, models default to the Slack-style
+  // two-surface split and post operator-facing meta-commentary ("Posted review
+  // result for PR #511") straight into the PR thread, where it reads absurdly.
+  if (origin.adapter === 'github') {
+    lines.push(
+      '',
+      '**`channel_reply` posts a public comment directly on this PR/issue.** It',
+      'is not a side-report to an operator — the reply lands in this exact',
+      'thread, read by everyone on the PR. Write the substance for that',
+      'audience: post the answer (or review summary) itself, never a status',
+      'line about having posted it elsewhere. A narrated "Posted review result',
+      'for PR #N: …" inside the PR is exactly the failure to avoid.',
+    )
+  }
+
   const conversationLine = renderConversationLine(origin)
   if (conversationLine !== null) lines.push('', conversationLine)
 

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -100,7 +100,7 @@ Why delegate: the `reviewer` subagent runs on the `deep` model profile, loads a 
 
    The returned `id`/`state` is your proof the formal review posted. If the call errored or the review is absent, do **not** fall back to a top-level `channel_reply` that _claims_ a review was posted — fix the payload (most often a `line` that isn't part of the diff; re-anchor it or move that finding to the top-level `body`) and resubmit. A trace reply that says "Posted review" when no review exists is worse than silence.
 
-6. **Then post a one-line summary with `channel_reply`** so the conversation has a human-readable trace pointing at the review (e.g., "Posted review on PR #N: <verdict>, N findings."). This reply is secondary — it points _at_ the formal review, it never substitutes for it. Post it only after step 5 confirmed the review exists.
+6. **End the turn with `skip_response`, not a trace reply.** The formal review from step 4 already landed _in this PR_ — it carries the summary, the verdict, and the inline comments. A `channel_reply` here does **not** go to a separate operator channel; on GitHub it posts another public comment on the same PR. A one-line "Posted review on PR #N: …" narrated into the PR thread is meta-commentary addressed to a phantom operator, and it reads absurdly next to the review it claims to point at. So once step 5 confirms the review exists, call `skip_response({ reason: "review posted via gh api" })` to close the turn silently. Only fall back to `channel_reply` when there was **no** formal review to post — the zero-actionable-findings branches in Rules below already use `channel_reply`/issue comments _as_ the substantive reply.
 
 ### Rules
 


### PR DESCRIPTION
## Background

When the agent is assigned as a reviewer on a GitHub PR and replies via `channel_reply`, that reply is posted as a **public comment directly on the PR** — but the agent doesn't behave as if it knows that. Observed on [#511](https://github.com/typeclaw/typeclaw/pull/511#issuecomment-4583250634), the bot commented:

> "Posted review result for PR #511: **APPROVE**. No actionable findings; the documented bitfield matches the source-of-truth constant."

That is a status report addressed to a phantom operator, sitting as a public comment on the very PR it reports about. An agent that understood `channel_reply` *is* the PR comment would either post the substance itself or stay silent because the formal review already carries it.

Root cause is the framing, not the plumbing. Two reinforcing gaps:

1. **`typeclaw-channel-github` skill, step 6** explicitly trained the model on a Slack-style two-surface split: "post the formal review, then post a one-line trace summary via `channel_reply` pointing at it." On GitHub there is no second surface — the "trace channel" and the "formal review" are the same PR thread, so the trace summary lands as another public comment reading absurdly next to the review it points at.
2. **The channel origin block** (`renderChannelOrigin`) calls every platform a "channel session" and never tells GitHub sessions that `channel_reply` becomes a public PR/issue comment. With no concrete mapping, the model falls back on the strongest framing it has — the skill's trace-summary pattern.

## Summary

- **`src/agent/session-origin.ts`** — add a `github`-only clause to the channel origin block stating `channel_reply` posts a public comment on *this exact* PR/issue, so the model writes substance for the PR audience instead of a status line about posting elsewhere. Scoped to `adapter === 'github'` because the two-surface model is legitimately correct for Slack/Discord; only GitHub collapses both surfaces into one.
- **`src/skills/typeclaw-channel-github/SKILL.md` step 6** — replace the trace-summary `channel_reply` with `skip_response({ reason: "review posted via gh api" })`. The formal review from step 4 already carries summary + verdict + inline comments and already landed in the PR; a second comment is pure noise.

## What this does NOT do

- Does not touch the zero-actionable-findings branches, which legitimately use `channel_reply`/issue comments *as* the substantive reply (no formal review exists in those cases).
- Does not change Slack/Discord/Telegram/KakaoTalk origin framing.
- Does not alter the outbound routing or the `channel_reply` tool itself — this is a prompt/skill framing fix only.

## Review notes

- Load-bearing change is the `if (origin.adapter === 'github')` block in `renderChannelOrigin`. Invariant to verify: the clause appears only for github origins. Covered by two new tests (positive for `github`, negative for `slack-bot`).
- Skill step 6 now ends the review turn silently; confirm the surrounding Rules section's `channel_reply` fallbacks (zero-findings branches) are still reachable and unchanged.