### PR TITLE
fix(discord): drop THREAD_CREATED system notice to stop double replies

### DIFF
--- a/src/channels/adapters/discord-bot-classify.test.ts
+++ b/src/channels/adapters/discord-bot-classify.test.ts
@@ -183,6 +183,70 @@ describe('classifyInbound — drop paths', () => {
   })
 })
 
+describe('classifyInbound — thread-created system message', () => {
+  test('drops the parent-channel THREAD_CREATED notice (ref points at the new thread, no message_id)', () => {
+    const event = buildEvent({
+      channel_id: 'parent-c1',
+      content: 'my new thread name',
+      message_reference: { channel_id: 'thread-t1', guild_id: 'g1' },
+    })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict).toEqual({ kind: 'drop', reason: 'thread_created_system' })
+  })
+
+  test('routes the in-thread THREAD_STARTER_MESSAGE (ref points at parent but carries the original message_id)', () => {
+    const event = buildEvent({
+      channel_id: 'thread-t1',
+      content: 'first message in the thread',
+      message_reference: { message_id: 'original-m1', channel_id: 'parent-c1', guild_id: 'g1' },
+    })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.chat).toBe('thread-t1')
+  })
+
+  test('routes a normal same-channel reply (ref.channel_id === event.channel_id)', () => {
+    const event = buildEvent({
+      channel_id: 'c1',
+      content: 'replying here',
+      message_reference: { message_id: 'parent-1', channel_id: 'c1' },
+    })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+  })
+
+  test('routes a cross-channel reference that still carries a message_id (forward/crosspost, not a thread notice)', () => {
+    const event = buildEvent({
+      channel_id: 'c1',
+      content: 'forwarded from elsewhere',
+      message_reference: { message_id: 'src-9', channel_id: 'other-c2', guild_id: 'g1' },
+    })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+  })
+
+  test('does not treat a cross-GUILD reference without message_id as a thread notice', () => {
+    const event = buildEvent({
+      channel_id: 'c1',
+      content: 'unusual cross-guild reference',
+      message_reference: { channel_id: 'other-c2', guild_id: 'other-guild' },
+    })
+
+    const verdict = classifyInbound(event, baseConfig, BOT_USER_ID)
+
+    expect(verdict.kind).toBe('route')
+  })
+})
+
 describe('classifyInbound — peer-bot routing', () => {
   test('routes a peer bot message with authorIsBot=true', () => {
     const event = buildEvent({

--- a/src/channels/adapters/discord-bot-classify.ts
+++ b/src/channels/adapters/discord-bot-classify.ts
@@ -12,6 +12,7 @@ export type InboundDropReason =
   | 'self_author' // event.author.id === botUserId; we never route our own messages back to ourselves
   | 'empty_content' // SDK delivered content: '' — usually missing MessageContent intent
   | 'pre_connect' // bot identity is not known yet, so mention/self/reply classification cannot be trusted
+  | 'thread_created_system' // Discord's THREAD_CREATED system notice posted to the PARENT channel when a public thread is created from a message
 
 export type InboundClassification =
   | { kind: 'drop'; reason: InboundDropReason }
@@ -37,6 +38,10 @@ export function classifyInbound(
   }
   const { text, attachments } = splitInbound(event)
   if (text === '') return { kind: 'drop', reason: 'empty_content' }
+
+  if (isThreadCreatedSystemMessage(event)) {
+    return { kind: 'drop', reason: 'thread_created_system' }
+  }
 
   const isDm = event.guild_id === undefined
   const workspace = isDm ? '@dm' : event.guild_id!
@@ -106,6 +111,24 @@ export function classifyInbound(
 // mechanism that drives the "Replying to @user" header in the client).
 function isReplyToBot(event: DiscordGatewayMessageCreateEvent, botUserId: string): boolean {
   return (event.mentions ?? []).some((m) => m.id === botUserId)
+}
+
+// Creating a public thread from a message fires TWO MESSAGE_CREATE events: a
+// THREAD_CREATED notice in the parent channel (content = thread name) and a
+// THREAD_STARTER_MESSAGE inside the thread. Each opens its own router session,
+// so the agent replies twice. The numeric Discord message type (18) that would
+// filter this cleanly is destroyed by the agent-messenger listener (it does
+// `{ ...d, type: t }`, overwriting `d.type` with the dispatch name), so we
+// fingerprint the notice by its reference instead: it points at a DIFFERENT
+// channel (the new thread) with no source `message_id`. The message_id-absent
+// check is load-bearing — it spares normal cross-channel replies and the
+// in-thread starter, both of which DO carry a message_id.
+function isThreadCreatedSystemMessage(event: DiscordGatewayMessageCreateEvent): boolean {
+  const ref = event.message_reference
+  if (ref?.channel_id === undefined) return false
+  if (ref.channel_id === event.channel_id) return false
+  if (ref.message_id !== undefined) return false
+  return ref.guild_id === undefined || event.guild_id === undefined || ref.guild_id === event.guild_id
 }
 
 type SplitInbound = { text: string; attachments: InboundAttachment[] }

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -763,6 +763,7 @@ function dropHint(reason: InboundDropReason): string {
       return ' (enable MESSAGE CONTENT INTENT in Discord Developer Portal and restart)'
     case 'pre_connect':
     case 'self_author':
+    case 'thread_created_system':
       return ''
   }
 }


### PR DESCRIPTION
## Background

Observed in production (the typeclaw Discord server): when a user creates a public thread from a message, **Typeey replies twice** — once in the parent channel and once inside the thread — with two *different* generations seconds apart, not a duplicated string.

Root-cause mechanism: creating a public thread from a message makes Discord's gateway fire **two** `MESSAGE_CREATE` events:

1. **`THREAD_CREATED`** (Discord numeric message type `18`) — a system notice posted to the **parent channel**; its `content` is the new thread's name.
2. **`THREAD_STARTER_MESSAGE`** (type `21`) — the first message **inside** the thread.

The Discord classifier keys every inbound to a router session as `chat = event.channel_id, thread = null`. The two events therefore land in two **independent** sessions (parent vs. thread) with no shared engagement/dedup state, so the agent engages and replies in both. The in-thread reply is the intended one; the parent-channel `THREAD_CREATED` notice is the spurious trigger.

## Summary

Drop the `THREAD_CREATED` parent-channel system notice in `classifyInbound` via a new `thread_created_system` drop reason.

**Why fingerprint the reference shape instead of filtering by message type:** the clean discriminator would be Discord's numeric message type (`18`), but it is unavailable to us. The `agent-messenger` gateway listener builds events with `{ ...d, type: t }`, overwriting Discord's numeric `d.type` with the gateway **dispatch name** (`"MESSAGE_CREATE"`). This holds even on the latest `agent-messenger` (2.19.0), so upgrading would not help and an upstream SDK change is out of scope here.

Instead we detect the notice by its `message_reference`: it points at a **different** channel (the new thread) and carries **no source `message_id`**. The `message_id`-absent check is load-bearing — normal cross-channel replies, forwards/crossposts, and the in-thread `THREAD_STARTER_MESSAGE` all *do* carry a `message_id`, so they are preserved. A guild-equality guard avoids misclassifying unusual cross-guild references.

## What this does NOT do

- Does not add gateway-level message deduplication (Discord warns events may arrive 0–N times); that's a broader change and not needed to fix this symptom.
- Does not change Discord's thread→session keying model (threads remain separate sessions, matching the existing adapter design).
- Does not touch the in-thread reply path — the agent still responds inside the thread as intended.
- Does not bump `agent-messenger`.

## Review notes

- Load-bearing change: `isThreadCreatedSystemMessage` in `src/channels/adapters/discord-bot-classify.ts`. The invariant to verify is **"drop iff `message_reference.channel_id` is present, differs from `event.channel_id`, and `message_id` is absent (with guild-equality guard)."**
- Tests cover the five cases that pin this invariant: parent-channel notice (dropped), in-thread starter (routed), same-channel reply (routed), cross-channel forward with `message_id` (routed), and cross-guild reference without `message_id` (routed).
- The new drop reason is wired into the exhaustive `dropHint` switch in `discord-bot.ts` (no operator hint — this is expected, benign behavior).
- If Discord ever starts attaching a `message_id` to the type-18 notice, the predicate stops dropping it — deliberately failing open toward "never suppress a real user message."
