### PR TITLE
fix(server): wire channelRouter into ctx.prompt sessions so channel_send exists

### DIFF
--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -371,6 +371,7 @@ export async function startAgent({
             runtimeVersion: runtimeVersionOpt.runtimeVersion,
             containerName: containerNameOpt.containerName,
             sessionFactory,
+            channelRouter: channelManager.router,
           }),
         subagent: (subName: string, payload?: unknown) =>
           dispatchSpawnSubagent(subName, payload, {
@@ -585,6 +586,7 @@ export async function startAgent({
       containerName,
       outbound,
       sessionFactory,
+      channelRouter: channelManager.router,
     })
 
   const server = createServer({

--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -97,6 +97,7 @@ function makeRunner(commands: RegisteredCommand[]) {
     containerName: 'test-agent',
     outbound,
     sessionFactory,
+    channelRouter: undefined,
   })
   return { runner, frames, decodeStdout, agentDir }
 }
@@ -407,6 +408,7 @@ describe('CommandRunner', () => {
       containerName: 'test-agent',
       outbound,
       sessionFactory,
+      channelRouter: undefined,
     })
     runner.start({ callId: 'sub-1', name: 'parent', args: undefined }, null)
     await waitForExit(frames, 'sub-1')
@@ -724,5 +726,46 @@ describe('runPromptForCommand', () => {
       })
     }
     expect(new Set(seen).size).toBe(3)
+  })
+
+  // Regression guard: cron-handler / plugin-command ctx.prompt sessions used to
+  // be created without channelRouter, so buildChannelTools emitted no
+  // channel_send. A handler told to post to a channel then had no tool and
+  // burned a runaway bash loop trying to find one. The router must reach
+  // createSessionWithDispose.
+  test('forwards channelRouter to createSessionWithDispose so channel_send is wired', async () => {
+    const { sessionFactory, agentDir } = makeSessionFactoryForTest()
+    const runtime = makeRuntime([])
+    const sentinelRouter = { __sentinel: 'router' } as unknown as Parameters<
+      typeof runPromptForCommand
+    >[0]['channelRouter']
+    let captured: { channelRouter?: unknown } | undefined
+    const fakeCreate = async (options: unknown): Promise<{ session: object; dispose: () => Promise<void> }> => {
+      captured = options as typeof captured
+      const session = {
+        prompt: async () => {},
+        getLastAssistantText: () => 'ok',
+        dispose: () => {},
+        abort: async () => {},
+      }
+      return { session: session as object, dispose: async () => {} }
+    }
+
+    await runPromptForCommand({
+      text: 'post to channel',
+      origin: { kind: 'cron', jobId: 'test', jobKind: 'handler', scheduledByOrigin: { kind: 'config-file' } },
+      runtime,
+      agentDir,
+      permissions: noopPermissionService,
+      signal: new AbortController().signal,
+      runtimeVersion: '0.0.0-test',
+      containerName: 'test-agent',
+      sessionFactory,
+      channelRouter: sentinelRouter,
+      _createSession: fakeCreate as Parameters<typeof runPromptForCommand>[0]['_createSession'],
+    })
+
+    expect(captured).toBeDefined()
+    expect(captured!.channelRouter).toBe(sentinelRouter)
   })
 })

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -5,6 +5,7 @@ import {
   type CreateSessionResult,
   type SessionOrigin,
 } from '@/agent'
+import type { ChannelRouter } from '@/channels/router'
 import type { PermissionService } from '@/permissions'
 import type {
   CommandExecResult,
@@ -44,6 +45,14 @@ export type CommandRunnerOptions = {
   // `SessionManager.inMemory()` and never persist usage — see
   // `runPromptForCommand` below.
   sessionFactory: SessionFactory
+  // Channel router threaded into every `ctx.prompt` session so the model can
+  // call `channel_send`. Without this, `buildChannelTools` (src/agent/index.ts)
+  // receives `undefined` and emits no channel tools — a plugin command or cron
+  // handler told to post to a channel then has no tool to do it and falls back
+  // to flailing bash loops. The cron `prompt` path already passes
+  // `channelManager.router` via `createSessionForCron`; this is the matching
+  // wire for the handler/command path.
+  channelRouter: ChannelRouter | undefined
 }
 
 type CommandHandle = {
@@ -182,6 +191,7 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
               permissions: opts.permissions,
               signal: abortController.signal,
               sessionFactory: opts.sessionFactory,
+              channelRouter: opts.channelRouter,
             }),
           subagent: (subName, payload) =>
             opts.spawnSubagent(subName, payload, {
@@ -363,6 +373,9 @@ export async function runPromptForCommand(args: {
   // cron `prompt` path uses in src/run/index.ts. Passing in-memory here
   // regresses `typeclaw usage` (see CommandRunnerOptions.sessionFactory).
   sessionFactory: SessionFactory
+  // See CommandRunnerOptions.channelRouter. Threaded to createSessionWithDispose
+  // so the spawned session exposes `channel_send`.
+  channelRouter?: ChannelRouter
   // Test seam for the agent-session boundary. Production passes the real
   // `createSessionWithDispose`; tests inject a fake to verify wiring
   // (specifically: the sessionManager handed off must be persisted, not
@@ -388,6 +401,7 @@ export async function runPromptForCommand(args: {
       sessionId,
       agentDir: args.agentDir,
     },
+    ...(args.channelRouter !== undefined ? { channelRouter: args.channelRouter } : {}),
     ...(args.runtimeVersion !== undefined ? { runtimeVersion: args.runtimeVersion } : {}),
     ...(args.containerName !== undefined ? { containerName: args.containerName } : {}),
   })


### PR DESCRIPTION
## Background

A cron job lost a turn to a runaway loop and burned **~110.7M tokens in a single 25-minute run** (87% of that day's entire spend) — 728 LLM turns, **721 of them `bash`** — before exhausting its context and erroring out without ever delivering its message.

Root cause: the job is a cron **handler** (`jobKind: "handler"`). Handler jobs run their LLM turn through `ctx.prompt` → `runPromptForCommand`, which created the session **without `channelRouter`**. `buildChannelTools` (`src/agent/index.ts`) returns `[]` when the router is `undefined`, so the session had **no `channel_send` tool**. The handler's prompt instructed the model to post to a channel via `channel_send`; with no such tool present, the model spiraled into bash loops hunting for an alternate send path (`grep`-ing node_modules, `curl localhost`, `node -e` requiring `.ts` files, and dozens of "let's try calling channel_send anyway" no-ops).

The cron **prompt** path was never affected — `createSessionForCron` (`src/run/index.ts`) already passes `channelManager.router`. Only the handler/command path (which also backs every plugin command's `ctx.prompt`) was missing the wire. The intent was already documented in `runPromptForCommand` ("so the model can call channel_send, websearch, etc.") — the argument was simply never threaded.

## Summary

Thread `channelRouter` through the command/handler prompt path so `ctx.prompt` sessions expose `channel_send`, matching what cron prompt sessions already get:

- `CommandRunnerOptions` and `runPromptForCommand` now carry `channelRouter`, forwarded to `createSessionWithDispose`.
- The two call sites in `startAgent` (the cron-handler `ctx.prompt` and `createCommandRunner`) pass `channelManager.router`, which is already in scope.

Why pass the router rather than special-casing the prompt: `buildChannelTools` is the single existing gate for channel tools and keys solely off router presence. Supplying the router reuses that path verbatim — no new branching, and plugin commands get the same fix for free.

## What this does NOT do

- Does **not** add a per-turn tool-call cap / runaway guard. The missing `channel_send` was the *trigger*; a turn-cap is a separate defense-in-depth change (the real model↔tool loop lives in the upstream `pi-coding-agent` lib, so it needs its own design). Out of scope here.
- Does **not** touch the cron `prompt` path or subagent tool sets (subagents intentionally get a restricted set via `pluginSubagent`).
- Does **not** change any plugin's prompt text.

## Review notes

- Load-bearing change: `src/server/command-runner.ts` — `channelRouter` reaching `createSessionWithDispose`. Invariant to verify: with a router present, the spawned session's tool set includes `channel_send`.
- The regression test (`forwards channelRouter to createSessionWithDispose…`) captures the options handed to the session factory and asserts the router is forwarded. I verified it goes **Red** without the one-line forward and **Green** with it.
- Two unrelated tests in `src/init/dockerfile.test.ts` flake under full-suite parallel load (they shell out to real `Xvfb`/process spawns and race under concurrency); they pass 207/0 in isolation and touch none of the files in this PR.