### PR TITLE
feat(github): log webhook settings before registration

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -225,6 +225,9 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         })
       } else if (repos.length > 0) {
         const legacyProviderHostSuffix = detectLegacyProviderHostSuffix(effectiveUrl)
+        logger.info(
+          `[github] registering webhook for ${repos.length} repo(s) [${repos.join(', ')}] -> ${effectiveUrl} (events: ${cfg.eventAllowlist.join(', ')})`,
+        )
         if (webhookRegistrationDelayMs > 0) {
           logger.info(
             `[github] waiting ${webhookRegistrationDelayMs}ms before registering webhook so the Cloudflare edge can warm up`,

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -134,6 +134,43 @@ describe('createGithubAdapter lifecycle', () => {
     expect(calls.some((c) => c.method === 'POST' && c.url.endsWith('/repos/acme/widgets/hooks'))).toBe(true)
   })
 
+  test('start() logs the webhook settings (effective URL, owner/repo repos, events) before registering', async () => {
+    const logger = recordingLogger()
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+      const match = url.match(/\/repos\/([^/]+)\/([^/]+)\/hooks\b/)
+      if (match) {
+        if (method === 'GET') return Response.json([])
+        if (method === 'POST') return Response.json({ id: 200 }, { status: 201 })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig(['acme/widgets', 'acme/gadgets'], null),
+      secrets: patSecrets(),
+      agentDir: '/tmp/agent',
+      logger,
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      tunnelUrl: () => 'https://x.trycloudflare.com',
+      webhookRegistrationDelayMs: 0,
+    })
+
+    await adapter.start()
+    await adapter.stop()
+
+    const settingsLog = logger.messages.find((m) => m.includes('registering webhook'))
+    expect(settingsLog).toBeDefined()
+    expect(settingsLog).toContain('info:')
+    expect(settingsLog).toContain('https://x.trycloudflare.com/typeclaw/v1/github/')
+    expect(settingsLog).toContain('acme/widgets')
+    expect(settingsLog).toContain('acme/gadgets')
+    expect(settingsLog).toContain('issue_comment.created')
+    expect(settingsLog).toContain('pull_request.opened')
+  })
+
   test('start() registers with configured webhookUrl when no tunnel URL callback is provided', async () => {
     const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
       if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })


### PR DESCRIPTION
## Background

When a GitHub webhook silently fails to deliver — wrong URL, events not subscribed, token scope mismatch — `typeclaw logs` showed only the *outcome* (`registered`, `updated`, `skipped`, `failed`) but never the *inputs* that determined it: the effective webhook URL, the list of repos being wired, and the event allowlist. Diagnosing misconfigured webhooks required manually cross-referencing `typeclaw.json`, the resolved tunnel URL, and GitHub's delivery log.

## Summary

Add one `INFO` log line in the GitHub channel adapter, emitted immediately before it calls the GitHub hooks API, surfacing the effective webhook URL, every repo as `owner/repo`, and the active event allowlist:

```
[github] registering webhook for 2 repo(s) [acme/widgets, acme/gadgets] -> https://x.trycloudflare.com/typeclaw/v1/github/<agent> (events: issue_comment.created, pull_request.opened)
```

This fires on the existing register branch (configured `webhookUrl` or resolved tunnel URL with repos present). The skip paths already emit actionable `WARN` lines and are unchanged. The webhook secret is delivered in the request body, not the URL, so nothing sensitive is logged.

## What this does NOT do

- Does not change any registration logic, retry behavior, or skip conditions.
- Does not add logging to the skip or error paths (those already have `WARN` lines).
- Does not affect the host-stage CLI or any path outside the container adapter.

## Review notes

- Load-bearing change: the `logger.info` call in `src/channels/adapters/github/index.ts`, inserted just before the optional delay and the per-repo hook loop. The invariant to verify: the log fires once per `start()` with the effective URL (managed-path segment applied), all repos as `owner/repo`, and the configured events.
- The new lifecycle test (`start() logs the webhook settings…`) asserts all four invariants — URL shape, both repos, and both events — and is verified Red without the production line, Green with it.