### PR TITLE
feat(slack): !cmd thread fallback for native slash commands

### DIFF
--- a/src/channels/adapters/slack-bot-slash-commands.test.ts
+++ b/src/channels/adapters/slack-bot-slash-commands.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from 'bun:test'
 
 import type { SlackSocketModeSlashCommandArgs } from 'agent-messenger/slackbot'
 
-import { buildSlashAckPayload, parseSlashCommand } from './slack-bot-slash-commands'
+import {
+  buildSlashAckPayload,
+  parseSlashCommand,
+  parseThreadCommand,
+  type ThreadCommandInput,
+} from './slack-bot-slash-commands'
 
 type Body = SlackSocketModeSlashCommandArgs['body']
 
@@ -84,6 +89,82 @@ describe('parseSlashCommand', () => {
     expect(result.kind).toBe('parsed')
     if (result.kind !== 'parsed') return
     expect(result.command.key.thread).toBe(null)
+  })
+})
+
+describe('parseThreadCommand', () => {
+  const known = new Set(['stop'])
+
+  function input(over: Partial<ThreadCommandInput> = {}): ThreadCommandInput {
+    return {
+      text: '!stop',
+      channel: 'C-general',
+      threadTs: '1700.0001',
+      isDm: false,
+      teamId: 'T-acme',
+      invokerId: 'U-alice',
+      ...over,
+    }
+  }
+
+  test('parses !stop in a thread into a thread-targeted ChannelKey', () => {
+    const result = parseThreadCommand(input(), known)
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command).toEqual({
+      name: 'stop',
+      key: { adapter: 'slack-bot', workspace: 'T-acme', chat: 'C-general', thread: '1700.0001' },
+      invokerId: 'U-alice',
+    })
+  })
+
+  test('top-level (no thread) !stop builds a thread:null key', () => {
+    const result = parseThreadCommand(input({ threadTs: null }), known)
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command.key.thread).toBe(null)
+  })
+
+  test('DM context maps workspace to @dm', () => {
+    const result = parseThreadCommand(input({ isDm: true, channel: 'D-bob' }), known)
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command.key.workspace).toBe('@dm')
+    expect(result.command.key.chat).toBe('D-bob')
+  })
+
+  test('lowercases the command name (!STOP)', () => {
+    const result = parseThreadCommand(input({ text: '!STOP' }), known)
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command.name).toBe('stop')
+  })
+
+  test('accepts trailing args after the command (!stop now please)', () => {
+    const result = parseThreadCommand(input({ text: '!stop now please' }), known)
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command.name).toBe('stop')
+  })
+
+  test('tolerates leading whitespace before the prefix', () => {
+    const result = parseThreadCommand(input({ text: '  !stop' }), known)
+    expect(result.kind).toBe('parsed')
+  })
+
+  test('ignores messages without the ! prefix', () => {
+    const result = parseThreadCommand(input({ text: 'stop the turn' }), known)
+    expect(result).toEqual({ kind: 'ignore', reason: 'no-prefix' })
+  })
+
+  test('ignores a ! message whose first token is not a known command (!nice work)', () => {
+    const result = parseThreadCommand(input({ text: '!nice work' }), known)
+    expect(result).toEqual({ kind: 'ignore', reason: 'unknown-command' })
+  })
+
+  test('ignores a bare ! with no token', () => {
+    const result = parseThreadCommand(input({ text: '! stop' }), known)
+    expect(result).toEqual({ kind: 'ignore', reason: 'unknown-command' })
   })
 })
 

--- a/src/channels/adapters/slack-bot-slash-commands.ts
+++ b/src/channels/adapters/slack-bot-slash-commands.ts
@@ -1,5 +1,6 @@
 import type { SlackSocketModeSlashCommandArgs } from 'agent-messenger/slackbot'
 
+import type { ExecuteCommandResult } from '@/channels/router'
 import type { ChannelKey } from '@/channels/types'
 
 // Slack channel ids: 'C' = public, 'G' = private/legacy multi-party DM,
@@ -64,13 +65,87 @@ export function parseSlashCommand(
   }
 }
 
+// Slack blocks native slash commands inside threads ("/stop is not supported
+// in threads. Sorry!"), so the only way to abort a thread-scoped turn from
+// inside that thread is a normal message. We recognise a leading `!` as an
+// alternate command prefix and route it through the same router.executeCommand
+// path as native slashes. The guard is strict: only a first token that resolves
+// to a known command name is rewritten, so casual messages like "!nice work"
+// pass through untouched as regular agent input.
+//
+// Unlike native slash payloads (which never carry a thread and rely on the
+// router's workspace+chat fallback), a thread message carries `thread_ts`,
+// letting us target the exact thread session and skip the ambiguous-match case
+// entirely.
+export const THREAD_COMMAND_PREFIX = '!'
+
+export type ThreadCommandInput = {
+  text: string
+  channel: string
+  threadTs: string | null
+  isDm: boolean
+  teamId: string
+  invokerId: string
+}
+
+export type ParseThreadCommandResult =
+  | { kind: 'parsed'; command: ParsedSlackSlashCommand }
+  | { kind: 'ignore'; reason: 'no-prefix' | 'unknown-command' }
+
+// Both ignore reasons (`no-prefix`, `unknown-command`) are non-fatal: the
+// caller lets the message flow through as ordinary agent input.
+export function parseThreadCommand(
+  input: ThreadCommandInput,
+  knownCommands: ReadonlySet<string>,
+): ParseThreadCommandResult {
+  const trimmed = input.text.trimStart()
+  if (!trimmed.startsWith(THREAD_COMMAND_PREFIX)) {
+    return { kind: 'ignore', reason: 'no-prefix' }
+  }
+  const firstToken = trimmed.slice(THREAD_COMMAND_PREFIX.length).split(/\s/, 1)[0] ?? ''
+  const name = firstToken.toLowerCase()
+  if (name === '' || !knownCommands.has(name)) {
+    return { kind: 'ignore', reason: 'unknown-command' }
+  }
+
+  const workspace = input.isDm ? '@dm' : input.teamId
+  return {
+    kind: 'parsed',
+    command: {
+      name,
+      key: { adapter: 'slack-bot', workspace, chat: input.channel, thread: input.threadTs },
+      invokerId: input.invokerId,
+    },
+  }
+}
+
 export const SLACK_SLASH_REPLY_ABORTED = 'Stopped the current turn.'
 export const SLACK_SLASH_REPLY_NO_LIVE_SESSION = 'Nothing to stop — no active turn in this channel.'
 export const SLACK_SLASH_REPLY_FAILED = 'Could not stop the current turn (internal error).'
 export const SLACK_SLASH_REPLY_PERMISSION_DENIED =
   'You do not have permission to stop the current turn in this channel.'
+// Native slash commands cannot be invoked from a thread, so the only way to
+// disambiguate is the `!stop` thread-message fallback — advise that, not the
+// impossible `/stop`-in-thread.
 export const SLACK_SLASH_REPLY_AMBIGUOUS =
-  'Multiple active turns in this channel. Reply `/stop` from inside the specific thread you want to stop.'
+  'Multiple active turns in this channel. Reply `!stop` inside the specific thread you want to stop.'
+
+// Single outcome→reply mapping shared by the native-slash (ack payload) and
+// `!cmd` thread (postMessage) delivery paths so the two never drift.
+export function commandResultReply(result: ExecuteCommandResult): string {
+  switch (result.kind) {
+    case 'handled':
+      return SLACK_SLASH_REPLY_ABORTED
+    case 'no-live-session':
+      return SLACK_SLASH_REPLY_NO_LIVE_SESSION
+    case 'permission-denied':
+      return SLACK_SLASH_REPLY_PERMISSION_DENIED
+    case 'ambiguous':
+      return SLACK_SLASH_REPLY_AMBIGUOUS
+    case 'unknown-command':
+      return SLACK_SLASH_REPLY_FAILED
+  }
+}
 
 // Slack's ack callback accepts an optional response payload that becomes
 // the user-visible reply. `response_type: 'ephemeral'` keeps the reply

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -19,6 +19,7 @@ import {
   SLACK_SLASH_COMMAND_NAMES,
 } from './slack-bot'
 import { classifyInbound, type SlackInboundAppMentionEvent } from './slack-bot-classify'
+import { createSlackDedupe } from './slack-bot-dedupe'
 
 describe('slack-bot createTypingCallback', () => {
   type SetStatusCall = { channel: string; threadTs: string; status: string }
@@ -1527,10 +1528,23 @@ describe('createThreadCommandHandler', () => {
     invokerId: 'U-alice',
   }
 
+  // Default reserve: always wins. Tracks call count so tests can assert the
+  // handler reserves only for recognised commands.
+  function makeReserve(result = true): { reserve: () => boolean; calls: () => number } {
+    let calls = 0
+    return {
+      reserve: () => {
+        calls++
+        return result
+      },
+      calls: () => calls,
+    }
+  }
+
   test('!stop in a thread executes with a thread-targeted key and replies into the thread', async () => {
     const { handler, routerCalls, replies } = setup()
 
-    const outcome = await handler(baseInput)
+    const outcome = await handler(baseInput, makeReserve().reserve)
 
     expect(outcome).toEqual({ kind: 'executed' })
     expect(routerCalls).toEqual([
@@ -1546,30 +1560,62 @@ describe('createThreadCommandHandler', () => {
     expect(replies[0]!.text).toContain('Stopped')
   })
 
-  test('non-! message passes through as not-a-command (no router call, no reply)', async () => {
+  test('non-! message passes through as not-a-command without reserving', async () => {
     const { handler, routerCalls, replies } = setup()
+    const r = makeReserve()
 
-    const outcome = await handler({ ...baseInput, text: 'stop the turn please' })
+    const outcome = await handler({ ...baseInput, text: 'stop the turn please' }, r.reserve)
 
     expect(outcome).toEqual({ kind: 'not-a-command' })
+    expect(routerCalls).toHaveLength(0)
+    expect(replies).toHaveLength(0)
+    expect(r.calls()).toBe(0)
+  })
+
+  test('!unknown (not a known command) passes through as not-a-command without reserving', async () => {
+    const { handler, routerCalls, replies } = setup()
+    const r = makeReserve()
+
+    const outcome = await handler({ ...baseInput, text: '!nice work everyone' }, r.reserve)
+
+    expect(outcome).toEqual({ kind: 'not-a-command' })
+    expect(routerCalls).toHaveLength(0)
+    expect(replies).toHaveLength(0)
+    expect(r.calls()).toBe(0)
+  })
+
+  test('a lost reserve race short-circuits to duplicate (no router call, no reply)', async () => {
+    const { handler, routerCalls, replies } = setup()
+
+    const outcome = await handler(baseInput, makeReserve(false).reserve)
+
+    expect(outcome).toEqual({ kind: 'duplicate' })
     expect(routerCalls).toHaveLength(0)
     expect(replies).toHaveLength(0)
   })
 
-  test('!unknown (not a known command) passes through as not-a-command', async () => {
-    const { handler, routerCalls, replies } = setup()
+  test('reserve fires before the router await (sync reservation closes the race)', async () => {
+    const order: string[] = []
+    const { handler } = setup({
+      routerImpl: async () => {
+        order.push('execute')
+        return { kind: 'handled', name: 'stop' }
+      },
+    })
+    const reserve = (): boolean => {
+      order.push('reserve')
+      return true
+    }
 
-    const outcome = await handler({ ...baseInput, text: '!nice work everyone' })
+    await handler(baseInput, reserve)
 
-    expect(outcome).toEqual({ kind: 'not-a-command' })
-    expect(routerCalls).toHaveLength(0)
-    expect(replies).toHaveLength(0)
+    expect(order).toEqual(['reserve', 'execute'])
   })
 
   test('permission-denied result maps to the permission-denied reply', async () => {
     const { handler, replies } = setup({ routerImpl: async () => ({ kind: 'permission-denied' }) })
 
-    await handler(baseInput)
+    await handler(baseInput, makeReserve().reserve)
 
     expect(replies[0]!.text).toContain('permission')
   })
@@ -1577,7 +1623,7 @@ describe('createThreadCommandHandler', () => {
   test('top-level !stop (no thread) targets a thread:null key', async () => {
     const { handler, routerCalls } = setup()
 
-    await handler({ ...baseInput, threadTs: null })
+    await handler({ ...baseInput, threadTs: null }, makeReserve().reserve)
 
     expect(routerCalls[0]!.key.thread).toBe(null)
   })
@@ -1589,7 +1635,7 @@ describe('createThreadCommandHandler', () => {
       },
     })
 
-    const outcome = await handler(baseInput)
+    const outcome = await handler(baseInput, makeReserve().reserve)
 
     expect(outcome).toEqual({ kind: 'executed' })
     expect(replies[0]!.text).toContain('internal error')
@@ -1603,9 +1649,43 @@ describe('createThreadCommandHandler', () => {
       },
     })
 
-    const outcome = await handler(baseInput)
+    const outcome = await handler(baseInput, makeReserve().reserve)
 
     expect(outcome).toEqual({ kind: 'executed' })
     expect(logs.warn.some((l) => l.includes('reply post failed'))).toBe(true)
+  })
+
+  test('two concurrent duplicate deliveries through a real dedupe execute exactly once', async () => {
+    let executions = 0
+    let releaseRouter: (() => void) | undefined
+    const routerGate = new Promise<void>((resolve) => {
+      releaseRouter = resolve
+    })
+    const { handler } = setup({
+      routerImpl: async () => {
+        executions++
+        await routerGate
+        return { kind: 'handled', name: 'stop' }
+      },
+    })
+
+    const dedupe = createSlackDedupe()
+    const event = { channel: 'C-general', ts: '1700.0001', client_msg_id: 'cmid-1' }
+    const reserve = (): boolean => {
+      if (dedupe.check(event) !== null) return false
+      dedupe.mark(event)
+      return true
+    }
+
+    // Both deliveries start before the router resolves, mirroring the message +
+    // app_mention double-delivery interleaving.
+    const first = handler(baseInput, reserve)
+    const second = handler(baseInput, reserve)
+    releaseRouter!()
+    const [a, b] = await Promise.all([first, second])
+
+    const kinds = [a.kind, b.kind].sort()
+    expect(kinds).toEqual(['duplicate', 'executed'])
+    expect(executions).toBe(1)
   })
 })

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -12,6 +12,7 @@ import {
   createSlackMembershipResolver,
   createSlackTypingTracker,
   createSlashCommandHandler,
+  createThreadCommandHandler,
   createTypingCallback,
   promoteAppMentionToMessage,
   SLACK_HISTORY_LIMIT_MAX,
@@ -1467,5 +1468,144 @@ describe('createSlashCommandHandler', () => {
     await done
 
     expect(events).toEqual(['router-call', 'ack-sent', 'channel-tag-resolved'])
+  })
+})
+
+describe('createThreadCommandHandler', () => {
+  type RouterCall = { key: ChannelKey; name: string; invokerId: string }
+  type RouterResult =
+    | { kind: 'handled'; name: string }
+    | { kind: 'no-live-session' }
+    | { kind: 'permission-denied' }
+    | { kind: 'ambiguous'; matchCount: number }
+    | { kind: 'unknown-command'; name: string }
+  type ReplyCall = { chat: string; thread: string | null; text: string }
+
+  function setup(over?: {
+    routerImpl?: (key: ChannelKey, name: string, invokerId: string) => Promise<RouterResult>
+    postReplyImpl?: (args: ReplyCall) => Promise<void>
+  }): {
+    handler: ReturnType<typeof createThreadCommandHandler>
+    routerCalls: RouterCall[]
+    replies: ReplyCall[]
+    logs: { info: string[]; warn: string[]; error: string[] }
+  } {
+    const routerCalls: RouterCall[] = []
+    const replies: ReplyCall[] = []
+    const logs = { info: [] as string[], warn: [] as string[], error: [] as string[] }
+    const handler = createThreadCommandHandler({
+      router: {
+        executeCommand: async (key, name, options) => {
+          routerCalls.push({ key, name, invokerId: options.invokerId })
+          return (over?.routerImpl ?? (async () => ({ kind: 'handled', name: 'stop' }) as RouterResult))(
+            key,
+            name,
+            options.invokerId,
+          )
+        },
+      },
+      knownCommandNames: SLACK_SLASH_COMMAND_NAMES,
+      postReply: async (args) => {
+        replies.push(args)
+        if (over?.postReplyImpl) await over.postReplyImpl(args)
+      },
+      logger: {
+        info: (m) => logs.info.push(m),
+        warn: (m) => logs.warn.push(m),
+        error: (m) => logs.error.push(m),
+      },
+    })
+    return { handler, routerCalls, replies, logs }
+  }
+
+  const baseInput = {
+    text: '!stop',
+    channel: 'C-general',
+    threadTs: '1700.0001',
+    isDm: false,
+    teamId: 'T-acme',
+    invokerId: 'U-alice',
+  }
+
+  test('!stop in a thread executes with a thread-targeted key and replies into the thread', async () => {
+    const { handler, routerCalls, replies } = setup()
+
+    const outcome = await handler(baseInput)
+
+    expect(outcome).toEqual({ kind: 'executed' })
+    expect(routerCalls).toEqual([
+      {
+        key: { adapter: 'slack-bot', workspace: 'T-acme', chat: 'C-general', thread: '1700.0001' },
+        name: 'stop',
+        invokerId: 'U-alice',
+      },
+    ])
+    expect(replies).toHaveLength(1)
+    expect(replies[0]!.chat).toBe('C-general')
+    expect(replies[0]!.thread).toBe('1700.0001')
+    expect(replies[0]!.text).toContain('Stopped')
+  })
+
+  test('non-! message passes through as not-a-command (no router call, no reply)', async () => {
+    const { handler, routerCalls, replies } = setup()
+
+    const outcome = await handler({ ...baseInput, text: 'stop the turn please' })
+
+    expect(outcome).toEqual({ kind: 'not-a-command' })
+    expect(routerCalls).toHaveLength(0)
+    expect(replies).toHaveLength(0)
+  })
+
+  test('!unknown (not a known command) passes through as not-a-command', async () => {
+    const { handler, routerCalls, replies } = setup()
+
+    const outcome = await handler({ ...baseInput, text: '!nice work everyone' })
+
+    expect(outcome).toEqual({ kind: 'not-a-command' })
+    expect(routerCalls).toHaveLength(0)
+    expect(replies).toHaveLength(0)
+  })
+
+  test('permission-denied result maps to the permission-denied reply', async () => {
+    const { handler, replies } = setup({ routerImpl: async () => ({ kind: 'permission-denied' }) })
+
+    await handler(baseInput)
+
+    expect(replies[0]!.text).toContain('permission')
+  })
+
+  test('top-level !stop (no thread) targets a thread:null key', async () => {
+    const { handler, routerCalls } = setup()
+
+    await handler({ ...baseInput, threadTs: null })
+
+    expect(routerCalls[0]!.key.thread).toBe(null)
+  })
+
+  test('executeCommand exception is caught and replies with the failure text', async () => {
+    const { handler, replies, logs } = setup({
+      routerImpl: async () => {
+        throw new Error('boom')
+      },
+    })
+
+    const outcome = await handler(baseInput)
+
+    expect(outcome).toEqual({ kind: 'executed' })
+    expect(replies[0]!.text).toContain('internal error')
+    expect(logs.error.some((l) => l.includes('boom'))).toBe(true)
+  })
+
+  test('a failing reply post is swallowed (still returns executed)', async () => {
+    const { handler, logs } = setup({
+      postReplyImpl: async () => {
+        throw new Error('slack down')
+      },
+    })
+
+    const outcome = await handler(baseInput)
+
+    expect(outcome).toEqual({ kind: 'executed' })
+    expect(logs.warn.some((l) => l.includes('reply post failed'))).toBe(true)
   })
 })

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -39,6 +39,7 @@ import {
   parseSlashCommand,
   parseThreadCommand,
   SLACK_SLASH_REPLY_FAILED,
+  type ThreadCommandInput,
 } from './slack-bot-slash-commands'
 import { slackTsToMillis } from './slack-bot-time'
 
@@ -156,26 +157,31 @@ export type ThreadCommandHandlerDeps = {
   logger: SlackBotAdapterLoggerLike
 }
 
-export type ThreadCommandOutcome = { kind: 'not-a-command' } | { kind: 'executed' }
+export type ThreadCommandOutcome = { kind: 'not-a-command' } | { kind: 'duplicate' } | { kind: 'executed' }
+
+// Synchronous reservation: the adapter marks the dedupe ring inside this hook,
+// which the handler calls before its first `await`. Two duplicate Slack
+// deliveries can both clear `dedupe.check()` on the same JS tick; whichever
+// reserves first wins and returns `true`, the loser returns `false` and aborts
+// — so a control command never runs twice across the check→execute window.
+export type ThreadCommandReserve = () => boolean
 
 // Routes a `!cmd` thread message through the SAME router.executeCommand path as
 // native slashes, then posts the outcome back into the thread. Returns
-// 'not-a-command' (so the caller proceeds with normal classify/route) or
-// 'executed' (so the caller stops — the command was handled, not agent input).
+// 'not-a-command' (caller proceeds with normal classify/route), 'duplicate'
+// (a racing delivery already reserved this event — caller stops silently), or
+// 'executed' (command handled — caller stops; it is not agent input).
 export function createThreadCommandHandler(
   deps: ThreadCommandHandlerDeps,
-): (input: {
-  text: string
-  channel: string
-  threadTs: string | null
-  isDm: boolean
-  teamId: string
-  invokerId: string
-}) => Promise<ThreadCommandOutcome> {
-  return async (input) => {
+): (input: ThreadCommandInput, reserve: ThreadCommandReserve) => Promise<ThreadCommandOutcome> {
+  return async (input, reserve) => {
     const parsed = parseThreadCommand(input, deps.knownCommandNames)
     if (parsed.kind === 'ignore') {
       return { kind: 'not-a-command' }
+    }
+    // Reserve synchronously, before any await, to close the check→execute race.
+    if (!reserve()) {
+      return { kind: 'duplicate' }
     }
     const { command } = parsed
     deps.logger.info(
@@ -881,19 +887,29 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       // so it must short-circuit here. Bypassing classifyInbound also bypasses
       // its self_author / no_user drops, so we replicate those guards: never
       // execute a command from our own message (echo loop) or a userless
-      // system event. Mark dedupe on execution so a Slack redelivery doesn't
-      // fire the command twice.
+      // system event. The `reserve` closure marks dedupe synchronously the
+      // instant the command is recognised (before the router await), closing
+      // the check→execute race for duplicate deliveries.
       if (event.user !== undefined && event.user !== '' && (botUserId === null || event.user !== botUserId)) {
-        const outcome = await handleThreadCommand({
-          text: event.text ?? '',
-          channel: event.channel,
-          threadTs: event.thread_ts ?? null,
-          isDm: event.channel_type === 'im',
-          teamId,
-          invokerId: event.user,
-        })
-        if (outcome.kind === 'executed') {
+        const reserve = (): boolean => {
+          if (dedupe.check(event) !== null) return false
           dedupe.mark(event)
+          return true
+        }
+        const outcome = await handleThreadCommand(
+          {
+            text: event.text ?? '',
+            channel: event.channel,
+            threadTs: event.thread_ts ?? null,
+            isDm: event.channel_type === 'im',
+            teamId,
+            invokerId: event.user,
+          },
+          reserve,
+        )
+        if (outcome.kind === 'executed') return
+        if (outcome.kind === 'duplicate') {
+          logger.info(`[slack-bot] dropped ts=${event.ts} reason=duplicate_delivery (thread-command race)`)
           return
         }
       }

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -35,12 +35,10 @@ import {
 import { createSlackDedupe } from './slack-bot-dedupe'
 import {
   buildSlashAckPayload,
+  commandResultReply,
   parseSlashCommand,
-  SLACK_SLASH_REPLY_ABORTED,
-  SLACK_SLASH_REPLY_AMBIGUOUS,
+  parseThreadCommand,
   SLACK_SLASH_REPLY_FAILED,
-  SLACK_SLASH_REPLY_NO_LIVE_SESSION,
-  SLACK_SLASH_REPLY_PERMISSION_DENIED,
 } from './slack-bot-slash-commands'
 import { slackTsToMillis } from './slack-bot-time'
 
@@ -124,16 +122,7 @@ export function createSlashCommandHandler(
       return
     }
 
-    const replyContent =
-      result.kind === 'handled'
-        ? SLACK_SLASH_REPLY_ABORTED
-        : result.kind === 'no-live-session'
-          ? SLACK_SLASH_REPLY_NO_LIVE_SESSION
-          : result.kind === 'permission-denied'
-            ? SLACK_SLASH_REPLY_PERMISSION_DENIED
-            : result.kind === 'ambiguous'
-              ? SLACK_SLASH_REPLY_AMBIGUOUS
-              : SLACK_SLASH_REPLY_FAILED
+    const replyContent = commandResultReply(result)
 
     // Final ack on the happy path: own try/catch so a thrown ack here does
     // NOT cascade into the error-path ack above (which would violate the
@@ -155,6 +144,62 @@ export function createSlashCommandHandler(
         `[slack-bot] slash /${command.name} result=${result.kind} (channel-tag resolution failed: ${describe(err)})`,
       )
     }
+  }
+}
+
+export type ThreadCommandReplyPoster = (args: { chat: string; thread: string | null; text: string }) => Promise<void>
+
+export type ThreadCommandHandlerDeps = {
+  router: Pick<ChannelRouter, 'executeCommand'>
+  knownCommandNames: ReadonlySet<string>
+  postReply: ThreadCommandReplyPoster
+  logger: SlackBotAdapterLoggerLike
+}
+
+export type ThreadCommandOutcome = { kind: 'not-a-command' } | { kind: 'executed' }
+
+// Routes a `!cmd` thread message through the SAME router.executeCommand path as
+// native slashes, then posts the outcome back into the thread. Returns
+// 'not-a-command' (so the caller proceeds with normal classify/route) or
+// 'executed' (so the caller stops — the command was handled, not agent input).
+export function createThreadCommandHandler(
+  deps: ThreadCommandHandlerDeps,
+): (input: {
+  text: string
+  channel: string
+  threadTs: string | null
+  isDm: boolean
+  teamId: string
+  invokerId: string
+}) => Promise<ThreadCommandOutcome> {
+  return async (input) => {
+    const parsed = parseThreadCommand(input, deps.knownCommandNames)
+    if (parsed.kind === 'ignore') {
+      return { kind: 'not-a-command' }
+    }
+    const { command } = parsed
+    deps.logger.info(
+      `[slack-bot] thread-command !${command.name} invoker=${command.invokerId} team=${command.key.workspace} channel=${command.key.chat} thread=${command.key.thread ?? '(none)'}`,
+    )
+
+    let reply: string
+    try {
+      const result = await deps.router.executeCommand(command.key, command.name, {
+        invokerId: command.invokerId,
+      })
+      reply = commandResultReply(result)
+      deps.logger.info(`[slack-bot] thread-command !${command.name} result=${result.kind}`)
+    } catch (err) {
+      deps.logger.error(`[slack-bot] thread-command !${command.name} failed: ${describe(err)}`)
+      reply = SLACK_SLASH_REPLY_FAILED
+    }
+
+    try {
+      await deps.postReply({ chat: input.channel, thread: input.threadTs, text: reply })
+    } catch (err) {
+      deps.logger.warn(`[slack-bot] thread-command reply post failed: ${describe(err)}`)
+    }
+    return { kind: 'executed' }
   }
 }
 
@@ -783,6 +828,24 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
     formatChannelTag,
   })
 
+  const handleThreadCommand = createThreadCommandHandler({
+    router: options.router,
+    knownCommandNames: SLACK_SLASH_COMMAND_NAMES,
+    logger,
+    postReply: async ({ chat, thread, text }) => {
+      const result = await outboundCallback({
+        adapter: 'slack-bot',
+        workspace: teamId ?? 'unknown',
+        chat,
+        ...(thread !== null ? { thread } : {}),
+        text,
+      })
+      if (!result.ok) {
+        throw new Error(result.error)
+      }
+    },
+  })
+
   const handleMessageEvent = async (
     event: SlackInboundMessageEvent,
     source: 'message' | 'app_mention',
@@ -811,6 +874,28 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
           `[slack-bot] dropped ts=${event.ts} reason=duplicate_delivery (source=${source}, matched=${dedupeMatch})`,
         )
         return
+      }
+
+      // Intercept `!cmd` thread-message commands BEFORE classifyInbound. A
+      // command is control traffic — neither dropped nor routed to the agent —
+      // so it must short-circuit here. Bypassing classifyInbound also bypasses
+      // its self_author / no_user drops, so we replicate those guards: never
+      // execute a command from our own message (echo loop) or a userless
+      // system event. Mark dedupe on execution so a Slack redelivery doesn't
+      // fire the command twice.
+      if (event.user !== undefined && event.user !== '' && (botUserId === null || event.user !== botUserId)) {
+        const outcome = await handleThreadCommand({
+          text: event.text ?? '',
+          channel: event.channel,
+          threadTs: event.thread_ts ?? null,
+          isDm: event.channel_type === 'im',
+          teamId,
+          invokerId: event.user,
+        })
+        if (outcome.kind === 'executed') {
+          dedupe.mark(event)
+          return
+        }
       }
 
       const verdict = classifyInbound(event, options.configRef(), {


### PR DESCRIPTION
## Background

Slack blocks native slash commands inside threads — the platform returns "/stop is not supported in threads. Sorry!" and never fires a slash_commands event for thread invocations.
`/stop` was therefore unusable from inside a thread.
Worse, the AMBIGUOUS reply copy told users to reply "/stop" inside the specific thread — advice Slack makes impossible to follow.

## Summary

Recognize a leading "!" in ordinary messages (which do fire in threads) and route a recognized command through the same executeCommand path as native slashes.
The guard is strict: only a first token matching a known command name (currently "stop", from SLACK_SLASH_COMMAND_NAMES) is treated as a command — casual messages like "!nice work" pass through as ordinary agent input.
Pattern borrowed from NousResearch/hermes-agent's `!` prefix (gateway/platforms/slack.py).

## Design notes

**Exact thread targeting.**
A thread message carries `thread_ts`, so the "!cmd" path targets the exact thread session.
The key is constructed with `key.thread = thread_ts` rather than null.
The native slash path sets thread to null and relies on a workspace+chat fallback — retiring the ambiguous-match case for thread invocations.
The AMBIGUOUS copy now advises "!stop".

**Interception point.**
Interception lives in `handleMessageEvent` before classifyInbound.
A command is control traffic — neither dropped nor agent-routed — so it must short-circuit before classify.
The classifyInbound contract (drop or route) stays clean.

**Security parity.**
Bypassing classifyInbound also bypasses its self_author and no_user drop guards, so those are explicitly replicated.
Never execute a command from the bot's own message (prevents echo loops) or a userless event.
`invokerId` is forwarded to executeCommand, which gates on session.control, so a stranger in a thread cannot abort someone else's turn.
Dedupe is marked on execution so a Slack redelivery or double-delivery cannot fire the command twice.

**Shared reply mapper.**
`commandResultReply` now backs both the native-slash ack payload and the "!cmd" thread postMessage reply.
The two delivery paths cannot drift; the ternary chain in createSlashCommandHandler is de-duplicated.

**Scope.**
Covers every name in SLACK_SLASH_COMMAND_NAMES (not just "stop"), so the feature scales as that set grows with no separate allow-list to drift.

## What this does NOT do

- Does not change native slash behavior for non-thread invocations.
- Does not add a separate allow-list distinct from SLACK_SLASH_COMMAND_NAMES.
- Does not change classifyInbound's contract or the engage/suppress logic downstream.

## Review notes

Load-bearing changes:

- `parseThreadCommand` (slack-bot-slash-commands.ts) — parses the "!" prefix against the known-command set; unknown "!" prefixes return "ignore" and never execute.
- `createThreadCommandHandler` factory (slack-bot.ts) — execute-then-reply cycle, including guard replication.
- Guard block in `handleMessageEvent` (slack-bot.ts) — placed before classifyInbound; dedupe marked on "executed".
- SLACK_SLASH_REPLY_AMBIGUOUS update — the old copy was actionably wrong.

## Testing

87/87 tests pass across the two Slack test files (11 new parseThreadCommand cases, 7 new createThreadCommandHandler cases).
typecheck clean; lint 0 errors; format:check clean.

Two pre-existing failures in the full suite, both unrelated to src/channels/:

- resolveSelfPackageJsonPath — asserts path ends with "typeclaw/package.json"; fails only when the checkout dir name differs from "typeclaw".
- createCloudflareNamedProvider restarts-with-backoff — timing-sensitive tunnel flake.