### PR TITLE
fix(github): support repos across multiple GitHub App installations

### DIFF
--- a/docs/content/docs/reference/channel-adapters.mdx
+++ b/docs/content/docs/reference/channel-adapters.mdx
@@ -4,13 +4,13 @@ description: Built-in adapters, auth shapes, capabilities
 icon: Inbox
 ---
 
-| Adapter        | Auth                                                                                 | Transport        | Public URL? | Notes                                                  |
-| -------------- | ------------------------------------------------------------------------------------ | ---------------- | ----------- | ------------------------------------------------------ |
-| `slack-bot`    | bot token + app token                                                                | Socket Mode      | no          | standard intent-shaped wiring                          |
-| `discord-bot`  | bot token                                                                            | gateway intents  | no          |                                                        |
-| `telegram-bot` | bot token                                                                            | long polling     | no          |                                                        |
-| `github`       | fine-grained PAT, or GitHub App (`appId` + `privateKey` + optional `installationId`) | webhook delivery | yes         | pairs with a tunnel for inbound webhooks               |
-| `kakaotalk`    | sub-device login (email + password, stored encrypted)                                | LOCO protocol    | no          | survives 7-day token expiry via host-side renewal cron |
+| Adapter        | Auth                                                                                           | Transport        | Public URL? | Notes                                                  |
+| -------------- | ---------------------------------------------------------------------------------------------- | ---------------- | ----------- | ------------------------------------------------------ |
+| `slack-bot`    | bot token + app token                                                                          | Socket Mode      | no          | standard intent-shaped wiring                          |
+| `discord-bot`  | bot token                                                                                      | gateway intents  | no          |                                                        |
+| `telegram-bot` | bot token                                                                                      | long polling     | no          |                                                        |
+| `github`       | fine-grained PAT, or GitHub App (`appId` + `privateKey`; installations auto-resolved per repo) | webhook delivery | yes         | pairs with a tunnel for inbound webhooks               |
+| `kakaotalk`    | sub-device login (email + password, stored encrypted)                                          | LOCO protocol    | no          | survives 7-day token expiry via host-side renewal cron |
 
 ## `channels.<adapter>` shape
 

--- a/src/channels/adapters/github/auth-app.test.ts
+++ b/src/channels/adapters/github/auth-app.test.ts
@@ -32,14 +32,14 @@ describe('AppAuthStrategy', () => {
     const strategy = new AppAuthStrategy({
       appId: 12345,
       privateKey: { value: privateKeyPem },
-      installationId: 67890,
-      fetchImpl: fakeFetch(async (_url, init) => {
+      fetchImpl: fakeFetch(async (url, init) => {
+        if (String(url).endsWith('/installation')) return Response.json({ id: 67890 })
         jwt = bearerToken(init)
         return Response.json({ token: 'installation-token', expires_at: '2026-05-18T13:00:00Z' })
       }),
     })
 
-    await strategy.token()
+    await strategy.token({ repoSlug: 'acme/api' })
 
     const decoded = decodeJwt(jwt)
     expect(decoded.header).toEqual({ alg: 'RS256', typ: 'JWT' })
@@ -47,22 +47,55 @@ describe('AppAuthStrategy', () => {
     expect(verifyJwtSignature(jwt)).toBe(true)
   })
 
-  it('mints and caches installation tokens for configured installations', async () => {
+  it('resolves a repo installation, then mints and caches its token', async () => {
     const calls: string[] = []
     const strategy = new AppAuthStrategy({
       appId: 1,
       privateKey: { value: privateKeyPem },
-      installationId: 99,
       fetchImpl: fakeFetch(async (url) => {
         calls.push(String(url))
+        if (String(url).endsWith('/installation')) return Response.json({ id: 99 })
         return Response.json({ token: 'cached-token', expires_at: '2026-05-18T13:00:00Z' })
       }),
     })
 
-    await expect(strategy.token()).resolves.toBe('cached-token')
-    await expect(strategy.token()).resolves.toBe('cached-token')
+    await expect(strategy.token({ repoSlug: 'acme/api' })).resolves.toBe('cached-token')
+    await expect(strategy.token({ repoSlug: 'acme/api' })).resolves.toBe('cached-token')
 
-    expect(calls).toEqual(['https://api.github.com/app/installations/99/access_tokens'])
+    expect(calls).toEqual([
+      'https://api.github.com/repos/acme/api/installation',
+      'https://api.github.com/app/installations/99/access_tokens',
+    ])
+  })
+
+  it('mints separate tokens for repos under different installations', async () => {
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: privateKeyPem },
+      fetchImpl: fakeFetch(async (url) => {
+        const s = String(url)
+        if (s.endsWith('/repos/acme/api/installation')) return Response.json({ id: 11 })
+        if (s.endsWith('/repos/personal/blog/installation')) return Response.json({ id: 22 })
+        if (s.includes('/app/installations/11/'))
+          return Response.json({ token: 'acme-token', expires_at: '2026-05-18T13:00:00Z' })
+        return Response.json({ token: 'personal-token', expires_at: '2026-05-18T13:00:00Z' })
+      }),
+    })
+
+    await expect(strategy.token({ repoSlug: 'acme/api' })).resolves.toBe('acme-token')
+    await expect(strategy.token({ repoSlug: 'personal/blog' })).resolves.toBe('personal-token')
+  })
+
+  it('throws a clear error when the app is not installed for a repo', async () => {
+    const strategy = new AppAuthStrategy({
+      appId: 1,
+      privateKey: { value: privateKeyPem },
+      fetchImpl: fakeFetch(async () => new Response('Not Found', { status: 404 })),
+    })
+
+    await expect(strategy.token({ repoSlug: 'stranger/repo' })).rejects.toThrow(
+      /not installed for stranger\/repo or lacks access/i,
+    )
   })
 
   it('refreshes cached installation tokens inside the five-minute boundary', async () => {
@@ -70,16 +103,16 @@ describe('AppAuthStrategy', () => {
     const strategy = new AppAuthStrategy({
       appId: 1,
       privateKey: { value: privateKeyPem },
-      installationId: 99,
-      fetchImpl: fakeFetch(async () =>
-        Response.json({ token: tokens.shift() ?? 'extra-token', expires_at: '2026-05-18T13:00:00Z' }),
-      ),
+      fetchImpl: fakeFetch(async (url) => {
+        if (String(url).endsWith('/installation')) return Response.json({ id: 99 })
+        return Response.json({ token: tokens.shift() ?? 'extra-token', expires_at: '2026-05-18T13:00:00Z' })
+      }),
     })
 
-    await expect(strategy.token()).resolves.toBe('first-token')
+    await expect(strategy.token({ repoSlug: 'acme/api' })).resolves.toBe('first-token')
     Date.now = () => Date.parse('2026-05-18T12:56:00Z')
 
-    await expect(strategy.token()).resolves.toBe('second-token')
+    await expect(strategy.token({ repoSlug: 'acme/api' })).resolves.toBe('second-token')
   })
 
   it('auto-discovers a single installation id', async () => {
@@ -119,7 +152,7 @@ describe('AppAuthStrategy', () => {
       fetchImpl: fakeFetch(async () => Response.json([{ id: 11 }, { id: 22 }])),
     })
 
-    await expect(strategy.token()).rejects.toThrow(/multiple installations \(11, 22\)/i)
+    await expect(strategy.token()).rejects.toThrow(/multiple installations \(11, 22\).*repo must be specified/i)
   })
 
   it('accepts PKCS#1 RSA private keys (the format GitHub hands out by default)', async () => {
@@ -127,14 +160,14 @@ describe('AppAuthStrategy', () => {
     const strategy = new AppAuthStrategy({
       appId: 12345,
       privateKey: { value: privateKeyPkcs1Pem },
-      installationId: 67890,
-      fetchImpl: fakeFetch(async (_url, init) => {
+      fetchImpl: fakeFetch(async (url, init) => {
+        if (String(url).endsWith('/installation')) return Response.json({ id: 67890 })
         jwt = bearerToken(init)
         return Response.json({ token: 'installation-token', expires_at: '2026-05-18T13:00:00Z' })
       }),
     })
 
-    await strategy.token()
+    await strategy.token({ repoSlug: 'acme/api' })
 
     expect(privateKeyPkcs1Pem).toContain('-----BEGIN RSA PRIVATE KEY-----')
     expect(verifyJwtSignature(jwt)).toBe(true)
@@ -149,7 +182,6 @@ describe('AppAuthStrategy', () => {
     const strategy = new AppAuthStrategy({
       appId: 1,
       privateKey: { value: encryptedPem },
-      installationId: 99,
       fetchImpl: fakeFetch(async () => new Response('unreachable', { status: 500 })),
     })
 
@@ -160,7 +192,6 @@ describe('AppAuthStrategy', () => {
     const strategy = new AppAuthStrategy({
       appId: 1,
       privateKey: { value: '-----BEGIN RSA PRIVATE KEY-----\nnot-base64\n-----END RSA PRIVATE KEY-----\n' },
-      installationId: 99,
       fetchImpl: fakeFetch(async () => new Response('unreachable', { status: 500 })),
     })
 
@@ -220,9 +251,9 @@ describe('AppAuthStrategy', () => {
     const strategy = new AppAuthStrategy({
       appId: 1,
       privateKey: { value: privateKeyPem },
-      installationId: 99,
       fetchImpl: fakeFetch(async (url) => {
         calls.push(String(url))
+        if (String(url).endsWith('/installation')) return Response.json({ id: 99 })
         return Response.json({
           permissions: { issues: 'write', metadata: 'read' },
           events: ['issues', 'issue_comment'],
@@ -230,29 +261,32 @@ describe('AppAuthStrategy', () => {
       }),
     })
 
-    const grants = await strategy.getInstallationGrants()
+    const grants = await strategy.getInstallationGrants({ repoSlug: 'acme/api' })
 
     expect(grants).toEqual({
       permissions: { issues: 'write', metadata: 'read' },
       events: ['issues', 'issue_comment'],
     })
-    expect(calls).toEqual(['https://api.github.com/app/installations/99'])
+    expect(calls).toEqual([
+      'https://api.github.com/repos/acme/api/installation',
+      'https://api.github.com/app/installations/99',
+    ])
   })
 
   it('filters unknown permission levels and non-string events out of the grants', async () => {
     const strategy = new AppAuthStrategy({
       appId: 1,
       privateKey: { value: privateKeyPem },
-      installationId: 99,
-      fetchImpl: fakeFetch(async () =>
-        Response.json({
+      fetchImpl: fakeFetch(async (url) => {
+        if (String(url).endsWith('/installation')) return Response.json({ id: 99 })
+        return Response.json({
           permissions: { issues: 'write', metadata: 'read', mystery: 'banana' },
           events: ['issues', 42, null],
-        }),
-      ),
+        })
+      }),
     })
 
-    const grants = await strategy.getInstallationGrants()
+    const grants = await strategy.getInstallationGrants({ repoSlug: 'acme/api' })
 
     expect(grants.permissions).toEqual({ issues: 'write', metadata: 'read' })
     expect(grants.events).toEqual(['issues'])
@@ -262,11 +296,15 @@ describe('AppAuthStrategy', () => {
     const strategy = new AppAuthStrategy({
       appId: 1,
       privateKey: { value: privateKeyPem },
-      installationId: 99,
-      fetchImpl: fakeFetch(async () => new Response('boom', { status: 500 })),
+      fetchImpl: fakeFetch(async (url) => {
+        if (String(url).endsWith('/installation')) return Response.json({ id: 99 })
+        return new Response('boom', { status: 500 })
+      }),
     })
 
-    await expect(strategy.getInstallationGrants()).rejects.toThrow(/installation fetch failed: 500/i)
+    await expect(strategy.getInstallationGrants({ repoSlug: 'acme/api' })).rejects.toThrow(
+      /installation fetch failed: 500/i,
+    )
   })
 })
 

--- a/src/channels/adapters/github/auth-app.ts
+++ b/src/channels/adapters/github/auth-app.ts
@@ -2,33 +2,43 @@ import { createPrivateKey } from 'node:crypto'
 
 import { resolveSecret, type Secret } from '@/secrets/resolve'
 
-import type { GithubAuthStrategy, GithubInstallationGrants, GithubSelfUser } from './auth'
+import type { GithubAuthContext, GithubAuthStrategy, GithubInstallationGrants, GithubSelfUser } from './auth'
 import { GITHUB_API_BASE, githubJsonHeaders, githubPublicHeaders } from './auth-pat'
+
+type TokenCacheEntry = { value: string; expiresAt: number }
 
 export class AppAuthStrategy implements GithubAuthStrategy {
   private readonly appId: number
   private readonly privateKeyPem: string
-  private readonly installationId: number | null
   private readonly fetchImpl: typeof fetch
-  private cachedToken: { value: string; expiresAt: number } | null = null
-  private resolvedInstallationId: number | null = null
+  // Keyed by installation id: a single App may span multiple owners, each a
+  // separate installation with its own short-lived token.
+  private readonly tokenCache = new Map<number, TokenCacheEntry>()
+  private readonly repoInstallationCache = new Map<string, number>()
+  private soleInstallationId: number | null = null
   private _selfUser: GithubSelfUser | null = null
 
-  constructor(options: { appId: number; privateKey: Secret; installationId?: number; fetchImpl?: typeof fetch }) {
+  constructor(options: { appId: number; privateKey: Secret; fetchImpl?: typeof fetch }) {
     const privateKeyPem = resolveSecret(options.privateKey, undefined, process.env)
     if (privateKeyPem === undefined || privateKeyPem.trim() === '') throw new Error('GitHub App private key is missing')
     this.appId = options.appId
     this.privateKeyPem = privateKeyPem
-    this.installationId = options.installationId ?? null
     this.fetchImpl = options.fetchImpl ?? fetch
   }
 
-  async token(): Promise<string> {
-    if (this.cachedToken && Date.now() < this.cachedToken.expiresAt - 5 * 60 * 1000) {
-      return this.cachedToken.value
-    }
+  async token(context?: GithubAuthContext): Promise<string> {
     const jwt = await this.mintJwt()
-    const installId = await this.resolveInstallationId(jwt)
+    const installId = await this.resolveInstallationId(jwt, context)
+    return this.installationToken(jwt, installId)
+  }
+
+  async authHeaders(context?: GithubAuthContext): Promise<HeadersInit> {
+    return githubJsonHeaders(await this.token(context))
+  }
+
+  private async installationToken(jwt: string, installId: number): Promise<string> {
+    const cached = this.tokenCache.get(installId)
+    if (cached && Date.now() < cached.expiresAt - 5 * 60 * 1000) return cached.value
     const response = await this.fetchImpl(`${GITHUB_API_BASE}/app/installations/${installId}/access_tokens`, {
       method: 'POST',
       headers: githubJsonHeaders(jwt),
@@ -37,12 +47,8 @@ export class AppAuthStrategy implements GithubAuthStrategy {
     const raw = (await response.json()) as { token?: unknown; expires_at?: unknown }
     if (typeof raw.token !== 'string') throw new Error('GitHub App token response missing token')
     const expiresAt = typeof raw.expires_at === 'string' ? Date.parse(raw.expires_at) : Date.now() + 60 * 60 * 1000
-    this.cachedToken = { value: raw.token, expiresAt }
+    this.tokenCache.set(installId, { value: raw.token, expiresAt })
     return raw.token
-  }
-
-  async authHeaders(): Promise<HeadersInit> {
-    return githubJsonHeaders(await this.token())
   }
 
   async getSelf(): Promise<GithubSelfUser> {
@@ -69,9 +75,9 @@ export class AppAuthStrategy implements GithubAuthStrategy {
     return this._selfUser
   }
 
-  async getInstallationGrants(): Promise<GithubInstallationGrants> {
+  async getInstallationGrants(context?: GithubAuthContext): Promise<GithubInstallationGrants> {
     const jwt = await this.mintJwt()
-    const installId = await this.resolveInstallationId(jwt)
+    const installId = await this.resolveInstallationId(jwt, context)
     const response = await this.fetchImpl(`${GITHUB_API_BASE}/app/installations/${installId}`, {
       headers: githubJsonHeaders(jwt),
     })
@@ -88,7 +94,8 @@ export class AppAuthStrategy implements GithubAuthStrategy {
   }
 
   async dispose(): Promise<void> {
-    this.cachedToken = null
+    this.tokenCache.clear()
+    this.repoInstallationCache.clear()
   }
 
   private async mintJwt(): Promise<string> {
@@ -107,24 +114,40 @@ export class AppAuthStrategy implements GithubAuthStrategy {
     return `${signingInput}.${base64url(Buffer.from(signature))}`
   }
 
-  private async resolveInstallationId(jwt: string): Promise<number> {
-    if (this.resolvedInstallationId !== null) return this.resolvedInstallationId
-    if (this.installationId !== null) {
-      this.resolvedInstallationId = this.installationId
-      return this.installationId
+  private async resolveInstallationId(jwt: string, context?: GithubAuthContext): Promise<number> {
+    if (context?.repoSlug !== undefined && context.repoSlug !== '') {
+      return this.resolveInstallationByEndpoint(jwt, `repos/${context.repoSlug}/installation`, context.repoSlug)
     }
+    if (context?.owner !== undefined && context.owner !== '') {
+      return this.resolveInstallationByEndpoint(jwt, `orgs/${context.owner}/installation`, context.owner)
+    }
+    if (this.soleInstallationId !== null) return this.soleInstallationId
     const response = await this.fetchImpl(`${GITHUB_API_BASE}/app/installations`, { headers: githubJsonHeaders(jwt) })
     if (!response.ok) throw new Error(`GitHub App installations fetch failed: ${response.status}`)
     const list = (await response.json()) as Array<{ id?: unknown }>
     if (list.length === 0) throw new Error('GitHub App has no installations')
     if (list.length > 1) {
       const ids = list.map((installation) => installation.id).join(', ')
-      throw new Error(`GitHub App has multiple installations (${ids}); set installationId in secrets.json`)
+      throw new Error(`GitHub App has multiple installations (${ids}); a repo must be specified to select one`)
     }
     const id = list[0]?.id
     if (typeof id !== 'number') throw new Error('GitHub App installation missing id')
-    this.resolvedInstallationId = id
+    this.soleInstallationId = id
     return id
+  }
+
+  private async resolveInstallationByEndpoint(jwt: string, path: string, target: string): Promise<number> {
+    const cached = this.repoInstallationCache.get(target)
+    if (cached !== undefined) return cached
+    const response = await this.fetchImpl(`${GITHUB_API_BASE}/${path}`, { headers: githubJsonHeaders(jwt) })
+    if (response.status === 404) {
+      throw new Error(`GitHub App is not installed for ${target} or lacks access to that repository`)
+    }
+    if (!response.ok) throw new Error(`GitHub App installation lookup for ${target} failed: ${response.status}`)
+    const raw = (await response.json()) as { id?: unknown }
+    if (typeof raw.id !== 'number') throw new Error(`GitHub App installation for ${target} missing id`)
+    this.repoInstallationCache.set(target, raw.id)
+    return raw.id
   }
 }
 

--- a/src/channels/adapters/github/auth-pat.ts
+++ b/src/channels/adapters/github/auth-pat.ts
@@ -1,6 +1,6 @@
 import { resolveSecret, type Secret } from '@/secrets/resolve'
 
-import type { GithubAuthStrategy, GithubSelfUser } from './auth'
+import type { GithubAuthContext, GithubAuthStrategy, GithubSelfUser } from './auth'
 
 export const GITHUB_API_BASE = 'https://api.github.com'
 
@@ -15,11 +15,11 @@ export class PatAuthStrategy implements GithubAuthStrategy {
     this.fetchImpl = options.fetchImpl ?? fetch
   }
 
-  async token(): Promise<string> {
+  async token(_context?: GithubAuthContext): Promise<string> {
     return this._token
   }
 
-  async authHeaders(): Promise<HeadersInit> {
+  async authHeaders(_context?: GithubAuthContext): Promise<HeadersInit> {
     return githubJsonHeaders(this._token)
   }
 

--- a/src/channels/adapters/github/auth.ts
+++ b/src/channels/adapters/github/auth.ts
@@ -3,15 +3,30 @@ import type { GithubAppAuthBlock, GithubPatAuthBlock } from '@/secrets/schema'
 import { AppAuthStrategy } from './auth-app'
 import { PatAuthStrategy } from './auth-pat'
 
+// Repo identity threaded through every auth call so App auth can pick the
+// correct installation. `repoSlug` is the canonical input ("owner/name"); App
+// auth resolves it to an installation via GET /repos/{owner}/{repo}/installation
+// and caches the result. PAT auth ignores it entirely. Omitted context means
+// "no specific repo" — App auth then falls back to a single discoverable
+// installation (and errors if the App spans multiple installations).
+export type GithubAuthContext = {
+  repoSlug?: string
+  // Org login, for operations that aren't repo-scoped (e.g. team-membership
+  // lookups under GET /orgs/{org}/...). App auth resolves it to an
+  // installation via GET /orgs/{org}/installation. Ignored when repoSlug is set.
+  owner?: string
+}
+
 export type GithubAuthStrategy = {
-  token: () => Promise<string>
-  authHeaders: () => Promise<HeadersInit>
+  token: (context?: GithubAuthContext) => Promise<string>
+  authHeaders: (context?: GithubAuthContext) => Promise<HeadersInit>
   getSelf: () => Promise<GithubSelfUser>
   // App-only: returns the installation's granted-permissions map and declared
   // events so the adapter can preflight against the configured eventAllowlist
   // before any webhook arrives. PATs return access via token scopes, not an
-  // installation grant, so they leave this undefined.
-  getInstallationGrants?: () => Promise<GithubInstallationGrants>
+  // installation grant, so they leave this undefined. Context selects which
+  // installation to inspect when the App spans multiple owners.
+  getInstallationGrants?: (context?: GithubAuthContext) => Promise<GithubInstallationGrants>
   dispose: () => Promise<void>
 }
 
@@ -36,7 +51,6 @@ export function buildAuthStrategy(options: {
       return new AppAuthStrategy({
         appId: options.auth.appId,
         privateKey: options.auth.privateKey,
-        installationId: options.auth.installationId,
         fetchImpl: options.fetchImpl,
       })
   }

--- a/src/channels/adapters/github/channel-resolver.ts
+++ b/src/channels/adapters/github/channel-resolver.ts
@@ -1,10 +1,11 @@
 import type { ChannelNameResolver, ResolvedChannelNames } from '@/channels/types'
 
+import type { GithubAuthContext } from './auth'
 import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 import { parseChat, parseRepo } from './outbound'
 
 export function createGithubChannelNameResolver(options: {
-  token: () => Promise<string>
+  token: (context?: GithubAuthContext) => Promise<string>
   fetchImpl?: typeof fetch
 }): ChannelNameResolver {
   const fetchImpl = options.fetchImpl ?? fetch
@@ -18,7 +19,7 @@ export function createGithubChannelNameResolver(options: {
     const path = chat.kind === 'issue' ? `issues/${chat.number}` : `pulls/${chat.number}`
     try {
       const response = await fetchImpl(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/${path}`, {
-        headers: githubJsonHeaders(await options.token()),
+        headers: githubJsonHeaders(await options.token({ repoSlug: key.workspace })),
       })
       if (!response.ok) return names
       const raw = (await response.json()) as { title?: string }

--- a/src/channels/adapters/github/history.ts
+++ b/src/channels/adapters/github/history.ts
@@ -1,10 +1,11 @@
 import type { ChannelHistoryMessage, FetchHistoryArgs, FetchHistoryResult, HistoryCallback } from '@/channels/types'
 
+import type { GithubAuthContext } from './auth'
 import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 import { parseChat, parseRepo } from './outbound'
 
 export function createGithubHistoryCallback(options: {
-  token: () => Promise<string>
+  token: (context?: GithubAuthContext) => Promise<string>
   workspaceForChat: (chat: string) => string | null
   fetchImpl?: typeof fetch
 }): HistoryCallback {
@@ -26,7 +27,7 @@ export function createGithubHistoryCallback(options: {
       const response = await fetchImpl(
         `${endpoint}?per_page=${Math.min(Math.max(args.limit, 1), 100)}&direction=desc${cursor}`,
         {
-          headers: githubJsonHeaders(await options.token()),
+          headers: githubJsonHeaders(await options.token({ repoSlug: workspace })),
         },
       )
       if (!response.ok) return { ok: false, error: `GitHub history ${response.status}` }

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -3,7 +3,7 @@ import type { ChannelAdapterConfig, GithubAdapterConfig } from '@/channels/schem
 import { resolveSecret } from '@/secrets/resolve'
 import type { GithubSecretsBlock } from '@/secrets/schema'
 
-import { buildAuthStrategy } from './auth'
+import { buildAuthStrategy, type GithubAuthContext } from './auth'
 import { createGithubChannelNameResolver } from './channel-resolver'
 import { createDeliveryDedup } from './dedup'
 import { findPermissionGaps } from './event-permissions'
@@ -99,29 +99,30 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     workspaceByChat.set(chat, workspace)
   }
 
-  const tokenFn = async () => {
-    const t = await auth.token()
-    process.env.GH_TOKEN = t
-    return t
-  }
+  // Repo/owner-aware token resolver. A single GitHub App can span multiple
+  // installations (one per owner); each consumer passes its repo/owner so the
+  // right installation token is minted. Unlike the old single-token path, this
+  // does NOT mutate process.env.GH_TOKEN — that global is seeded separately and
+  // only when exactly one installation applies (see seedGhTokenIfSingle).
+  const authToken = (context?: GithubAuthContext) => auth.token(context)
   const outbound = createGithubOutboundCallback({
-    token: tokenFn,
+    token: authToken,
     authType: options.secrets.auth.type,
     logger,
     fetchImpl,
   })
   const history = createGithubHistoryCallback({
-    token: tokenFn,
+    token: authToken,
     fetchImpl,
     workspaceForChat: (chat) => workspaceByChat.get(chat) ?? null,
   })
-  const membership = createGithubMembershipResolver({ token: tokenFn, fetchImpl })
-  const channelNameResolver = createGithubChannelNameResolver({ token: tokenFn, fetchImpl })
+  const membership = createGithubMembershipResolver({ token: authToken, fetchImpl })
+  const channelNameResolver = createGithubChannelNameResolver({ token: authToken, fetchImpl })
   const fetchAttachment = createGithubFetchAttachmentCallback()
   // No-op typing callback: GitHub has no typing indicator API.
   const typing = async (): Promise<void> => {}
   const dedup = createDeliveryDedup()
-  const isBotInTeam = createTeamMembershipChecker({ token: tokenFn, fetchImpl })
+  const isBotInTeam = createTeamMembershipChecker({ token: authToken, fetchImpl })
   const handler = createGithubWebhookHandler({
     webhookSecret,
     dedup,
@@ -174,35 +175,48 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         selfLogin = null
         throw err
       }
-      // Seed GH_TOKEN so `gh` CLI calls in the container are pre-authenticated.
-      // tokenFn keeps it current on every adapter API call; App tokens refresh
-      // automatically when within 5 minutes of expiry.
-      process.env.GH_TOKEN = await auth.token()
       started = true
-      // Keep GH_TOKEN warm even when the adapter is only receiving inbound
-      // webhooks and not making outbound API calls. This prevents `gh` CLI
-      // calls from the agent from failing with 401 after the token expires.
-      const tokenRefreshIntervalMs = options.tokenRefreshIntervalMs ?? DEFAULT_TOKEN_REFRESH_INTERVAL_MS
-      if (tokenRefreshIntervalMs > 0) {
-        const refresh = () => {
-          tokenFn().catch((err) => {
-            logger.error(`[github] periodic token refresh failed: ${err instanceof Error ? err.message : String(err)}`)
-          })
+      // GH_TOKEN is a single process-wide env var the container's `gh` CLI
+      // reads, but a GitHub App spanning multiple owners has no single correct
+      // token. Seed/refresh it only when exactly one repo is configured (PAT,
+      // or App with one unambiguous installation). With multiple repos we skip
+      // the global seed: ad-hoc `gh` calls must target a specific repo, and the
+      // adapter's own API calls always resolve a repo-scoped token via authToken.
+      const ghTokenRepo = ghTokenSeedRepo(options.configRef().repos ?? [])
+      const seedGhToken = async (): Promise<void> => {
+        process.env.GH_TOKEN = await auth.token(ghTokenRepo === null ? undefined : { repoSlug: ghTokenRepo })
+      }
+      if (ghTokenRepo !== null || options.secrets.auth.type === 'pat') {
+        await seedGhToken()
+        const tokenRefreshIntervalMs = options.tokenRefreshIntervalMs ?? DEFAULT_TOKEN_REFRESH_INTERVAL_MS
+        if (tokenRefreshIntervalMs > 0) {
+          const refresh = () => {
+            seedGhToken().catch((err) => {
+              logger.error(
+                `[github] periodic token refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+              )
+            })
+          }
+          const setIntervalFn =
+            options.setInterval ??
+            ((handler: () => void, ms: number) => {
+              const timer = setInterval(handler, ms)
+              return { clear: () => clearInterval(timer) }
+            })
+          tokenRefreshTimer = setIntervalFn(refresh, tokenRefreshIntervalMs)
         }
-        const setIntervalFn =
-          options.setInterval ??
-          ((handler: () => void, ms: number) => {
-            const timer = setInterval(handler, ms)
-            return { clear: () => clearInterval(timer) }
-          })
-        tokenRefreshTimer = setIntervalFn(refresh, tokenRefreshIntervalMs)
+      } else {
+        logger.info(
+          '[github] multiple repos configured across possibly-different owners; GH_TOKEN not seeded globally. ' +
+            'Ad-hoc `gh` commands should set a repo-scoped token explicitly.',
+        )
       }
       logger.info(`[github] webhook listening on port ${options.configRef().webhookPort} as @${self.login}`)
       // Best-effort: App-only preflight that compares the installation's granted
       // permissions against the configured eventAllowlist and warns about gaps.
       // Catches the most common misconfiguration (App installed with the default
       // metadata-only permission set) before any event fires a 403.
-      await runAppPermissionPreflight(logger, auth, options.configRef().eventAllowlist)
+      await runAppPermissionPreflight(logger, auth, options.configRef().eventAllowlist, options.configRef().repos ?? [])
       // Repository webhook registration is best-effort: failures are logged
       // per-repo, the adapter stays up. A misconfigured PAT or App that
       // can't manage hooks must not prevent the adapter from accepting
@@ -235,7 +249,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
           await sleep(webhookRegistrationDelayMs)
         }
         const registration = await registerGithubWebhooks({
-          token: tokenFn,
+          token: (repoSlug: string) => auth.token({ repoSlug }),
           webhookUrl: effectiveUrl,
           webhookSecret,
           repos,
@@ -266,7 +280,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
       // last to clear the cached App-installation token.
       if (managedHooks.length > 0) {
         const deregistration = await deregisterGithubWebhooks({
-          token: tokenFn,
+          token: (repoSlug: string) => auth.token({ repoSlug }),
           hooks: managedHooks,
           fetchImpl,
         })
@@ -370,18 +384,36 @@ async function runAppPermissionPreflight(
   logger: GithubAdapterLogger,
   auth: ReturnType<typeof buildAuthStrategy>,
   eventAllowlist: readonly string[],
+  repos: readonly string[],
 ): Promise<void> {
   if (auth.getInstallationGrants === undefined) return
-  let grants
-  try {
-    grants = await auth.getInstallationGrants()
-  } catch (err) {
-    logger.warn(`[github] permission preflight skipped: ${err instanceof Error ? err.message : String(err)}`)
-    return
+  const getGrants = (context: GithubAuthContext | undefined) => auth.getInstallationGrants?.(context)
+  // One grants check per distinct owner: installations are owner-scoped, so
+  // repos sharing an owner share an installation. The first repo per owner is
+  // the resolution key. With no repos, fall back to a single context-free check.
+  const reposByOwner = new Map<string, string>()
+  for (const repo of repos) {
+    const owner = repo.split('/')[0]
+    if (owner !== undefined && owner !== '' && !reposByOwner.has(owner)) reposByOwner.set(owner, repo)
   }
-  const gaps = findPermissionGaps(eventAllowlist, grants.permissions)
-  if (gaps.length === 0) return
-  logger.warn(buildAppPermissionPreflightGuidance(gaps))
+  const contexts: Array<{ label: string; context: { repoSlug: string } | undefined }> =
+    reposByOwner.size === 0
+      ? [{ label: 'app', context: undefined }]
+      : [...reposByOwner.values()].map((repo) => ({ label: repo, context: { repoSlug: repo } }))
+  for (const { label, context } of contexts) {
+    let grants
+    try {
+      grants = await getGrants(context)
+    } catch (err) {
+      logger.warn(
+        `[github] permission preflight skipped for ${label}: ${err instanceof Error ? err.message : String(err)}`,
+      )
+      continue
+    }
+    if (grants === undefined) continue
+    const gaps = findPermissionGaps(eventAllowlist, grants.permissions)
+    if (gaps.length > 0) logger.warn(buildAppPermissionPreflightGuidance(gaps))
+  }
 }
 
 function logDeregistrationOutcome(
@@ -393,6 +425,13 @@ function logDeregistrationOutcome(
     else if (h.action === 'missing') logger.info(`[github] webhook ${h.hookId} on ${h.repo} already gone`)
     else logger.warn(`[github] webhook detach failed for ${h.repo}#${h.hookId}: ${h.error ?? 'unknown error'}`)
   }
+}
+
+// Two repos under the same owner share an installation and could in principle
+// share a global GH_TOKEN, but the marginal value doesn't justify the special
+// case — only a single configured repo yields an unambiguous seed.
+function ghTokenSeedRepo(repos: readonly string[]): string | null {
+  return repos.length === 1 ? (repos[0] ?? null) : null
 }
 
 function defaultSleep(ms: number): Promise<void> {

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -16,7 +16,6 @@ function appSecrets(): GithubSecretsBlock {
     auth: {
       type: 'app',
       appId: 12345,
-      installationId: 99,
       privateKey: { value: APP_PRIVATE_KEY_PEM },
     },
     webhookSecret: { value: 'wh-secret' },
@@ -664,6 +663,9 @@ describe('createGithubAdapter lifecycle', () => {
       if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
         return Response.json({ id: 42, login: 'typeey-app[bot]' })
       }
+      if (url === 'https://api.github.com/app/installations' && method === 'GET') {
+        return Response.json([{ id: 99 }])
+      }
       if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
         return Response.json({
           permissions: { metadata: 'read', repository_hooks: 'write' },
@@ -708,6 +710,9 @@ describe('createGithubAdapter lifecycle', () => {
       }
       if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
         return Response.json({ id: 42, login: 'typeey-app[bot]' })
+      }
+      if (url === 'https://api.github.com/app/installations' && method === 'GET') {
+        return Response.json([{ id: 99 }])
       }
       if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
         return Response.json({
@@ -772,6 +777,9 @@ describe('createGithubAdapter lifecycle', () => {
       if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
         return Response.json({ id: 42, login: 'typeey-app[bot]' })
       }
+      if (url === 'https://api.github.com/app/installations' && method === 'GET') {
+        return Response.json([{ id: 99 }])
+      }
       if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
         return new Response('boom', { status: 500 })
       }
@@ -796,7 +804,7 @@ describe('createGithubAdapter lifecycle', () => {
     await expect(adapter.start()).resolves.toBeUndefined()
     await adapter.stop()
 
-    expect(logger.messages.find((m) => m.startsWith('warn:[github] permission preflight skipped:'))).toBeDefined()
+    expect(logger.messages.find((m) => m.startsWith('warn:[github] permission preflight skipped'))).toBeDefined()
   })
 
   test('start() sleeps webhookRegistrationDelayMs before calling the GitHub hooks API', async () => {
@@ -873,13 +881,16 @@ describe('createGithubAdapter lifecycle', () => {
     expect(events).toEqual(['hooks-list', 'hooks-create'])
   })
 
-  test('App auth: periodic token refresh keeps GH_TOKEN warm via setInterval', async () => {
+  test('App auth: single-repo periodic token refresh keeps GH_TOKEN warm via setInterval', async () => {
     const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
       if (url === 'https://api.github.com/app' && method === 'GET') {
         return Response.json({ slug: 'typeey-app' })
       }
       if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
         return Response.json({ id: 42, login: 'typeey-app[bot]' })
+      }
+      if (url === 'https://api.github.com/repos/acme/widgets/installation' && method === 'GET') {
+        return Response.json({ id: 99 })
       }
       if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
         return Response.json({
@@ -889,6 +900,10 @@ describe('createGithubAdapter lifecycle', () => {
       }
       if (url === 'https://api.github.com/app/installations/99/access_tokens' && method === 'POST') {
         return Response.json({ token: 'ghs_fresh', expires_at: '2099-01-01T00:00:00Z' })
+      }
+      if (url.includes('/repos/acme/widgets/hooks')) {
+        if (method === 'GET') return Response.json([])
+        if (method === 'POST') return Response.json({ id: 7 }, { status: 201 })
       }
       return new Response('unexpected', { status: 500 })
     })
@@ -901,7 +916,7 @@ describe('createGithubAdapter lifecycle', () => {
 
     const adapter = createGithubAdapter({
       router: freshRouter(),
-      configRef: () => githubConfig([], null),
+      configRef: () => githubConfig(['acme/widgets']),
       secrets: appSecrets(),
       agentDir: '/tmp/agent',
       logger: silentLogger(),

--- a/src/channels/adapters/github/membership.ts
+++ b/src/channels/adapters/github/membership.ts
@@ -1,10 +1,11 @@
 import type { MembershipResolver, MembershipResolverResult } from '@/channels/membership'
 
+import type { GithubAuthContext } from './auth'
 import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 import { parseRepo } from './outbound'
 
 export function createGithubMembershipResolver(options: {
-  token: () => Promise<string>
+  token: (context?: GithubAuthContext) => Promise<string>
   fetchImpl?: typeof fetch
 }): MembershipResolver {
   const fetchImpl = options.fetchImpl ?? fetch
@@ -16,7 +17,7 @@ export function createGithubMembershipResolver(options: {
       const response = await fetchImpl(
         `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/collaborators?per_page=100`,
         {
-          headers: githubJsonHeaders(await options.token()),
+          headers: githubJsonHeaders(await options.token({ repoSlug: key.workspace })),
         },
       )
       if (!response.ok) return response.status >= 500 ? { kind: 'transient' } : { kind: 'permanent' }

--- a/src/channels/adapters/github/outbound.ts
+++ b/src/channels/adapters/github/outbound.ts
@@ -1,5 +1,6 @@
 import type { OutboundCallback, OutboundMessage, SendResult } from '@/channels/types'
 
+import type { GithubAuthContext } from './auth'
 import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 import {
   buildOutboundPermissionGuidance,
@@ -11,7 +12,7 @@ import {
 export type GithubOutboundLogger = { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void }
 
 export function createGithubOutboundCallback(deps: {
-  token: () => Promise<string>
+  token: (context?: GithubAuthContext) => Promise<string>
   authType: GithubAuthType
   logger: GithubOutboundLogger
   fetchImpl?: typeof fetch
@@ -28,9 +29,12 @@ export function createGithubOutboundCallback(deps: {
     const target = parseChat(msg.chat)
     if (target === null) return { ok: false, error: `invalid GitHub chat: ${msg.chat}` }
 
+    const token = () => deps.token({ repoSlug: msg.workspace })
+
     if (target.kind === 'discussion') {
       return await postDiscussionComment({
         ...deps,
+        token,
         fetchImpl,
         repo,
         discussionNumber: target.number,
@@ -44,7 +48,7 @@ export function createGithubOutboundCallback(deps: {
       : `${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/issues/${target.number}/comments`
     return await postJson(
       fetchImpl,
-      await deps.token(),
+      await token(),
       endpoint,
       { body },
       {

--- a/src/channels/adapters/github/team-membership.ts
+++ b/src/channels/adapters/github/team-membership.ts
@@ -7,12 +7,14 @@
 // request rebuilds it). Errors fall closed (return false): we'd rather drop
 // a real review request than wake the agent on a team the bot isn't in.
 
+import type { GithubAuthContext } from './auth'
+
 const ACTIVE_MEMBERSHIP_STATE = 'active'
 
 export type TeamMembershipChecker = (input: { org: string; slug: string; login: string }) => Promise<boolean>
 
 export function createTeamMembershipChecker(options: {
-  token: () => Promise<string>
+  token: (context?: GithubAuthContext) => Promise<string>
   fetchImpl?: typeof fetch
 }): TeamMembershipChecker {
   const fetchImpl = options.fetchImpl ?? fetch
@@ -23,7 +25,7 @@ export function createTeamMembershipChecker(options: {
     const cached = cache.get(key)
     if (cached !== undefined) return cached
 
-    const result = await lookup(fetchImpl, await options.token(), org, slug, login)
+    const result = await lookup(fetchImpl, await options.token({ owner: org }), org, slug, login)
     cache.set(key, result)
     return result
   }

--- a/src/channels/adapters/github/webhook-register.test.ts
+++ b/src/channels/adapters/github/webhook-register.test.ts
@@ -150,6 +150,67 @@ describe('registerGithubWebhooks', () => {
     expect(good?.action).toBe('created')
   })
 
+  test('resolves a separate token per repo so multi-owner repos use the right installation', async () => {
+    const tokenByRepo: Record<string, string> = { 'acme/api': 'tok-acme', 'personal/blog': 'tok-personal' }
+    const bearerByRepo: Record<string, string | null> = {}
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      const method = init?.method ?? 'GET'
+      const repo = /\/repos\/([^/]+\/[^/]+)\/hooks/.exec(url)?.[1] ?? ''
+      const auth = new Headers(init?.headers).get('authorization')
+      if (method === 'GET') {
+        bearerByRepo[repo] = auth
+        return new Response(JSON.stringify([]), { status: 200 })
+      }
+      return new Response(JSON.stringify({ id: 1 }), { status: 201 })
+    }) as unknown as typeof fetch
+
+    const result = await registerGithubWebhooks(
+      baseOpts({
+        fetchImpl,
+        repos: ['acme/api', 'personal/blog'],
+        token: async (repoSlug: string) => tokenByRepo[repoSlug] ?? 'unknown',
+      }),
+    )
+
+    expect(result.repos.every((r) => r.action === 'created')).toBe(true)
+    expect(bearerByRepo['acme/api']).toBe('Bearer tok-acme')
+    expect(bearerByRepo['personal/blog']).toBe('Bearer tok-personal')
+  })
+
+  test('isolates a per-repo token-resolution failure to that repo only', async () => {
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      const method = init?.method ?? 'GET'
+      if (url.includes('/repos/good/repo/hooks') && method === 'GET') {
+        return new Response(JSON.stringify([]), { status: 200 })
+      }
+      if (url.endsWith('/repos/good/repo/hooks') && method === 'POST') {
+        return new Response(JSON.stringify({ id: 9 }), { status: 201 })
+      }
+      return new Response('', { status: 500 })
+    }) as unknown as typeof fetch
+
+    const result = await registerGithubWebhooks(
+      baseOpts({
+        fetchImpl,
+        repos: ['stranger/repo', 'good/repo'],
+        token: async (repoSlug: string) => {
+          if (repoSlug === 'stranger/repo') throw new Error('App is not installed for stranger/repo')
+          return 'tok-good'
+        },
+      }),
+    )
+
+    const stranger = result.repos.find((r) => r.repo === 'stranger/repo')
+    const good = result.repos.find((r) => r.repo === 'good/repo')
+    expect(stranger?.action).toBe('failed')
+    expect((stranger as Extract<WebhookRegistrationResult['repos'][number], { action: 'failed' }>).error).toContain(
+      'not installed',
+    )
+    expect(good?.action).toBe('created')
+  })
+
   test('reduces dotted event.action names to coarse event names for the hook config', async () => {
     const { fetch: fetchImpl, calls } = makeFetch(({ url, init }) => {
       if (url.includes('/repos/acme/widgets/hooks') && (init?.method ?? 'GET') === 'GET') {

--- a/src/channels/adapters/github/webhook-register.ts
+++ b/src/channels/adapters/github/webhook-register.ts
@@ -1,7 +1,10 @@
 import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 
 export type RegisterGithubWebhooksOptions = {
-  token: () => Promise<string>
+  // Resolves an installation token scoped to the given "owner/name" repo. A
+  // single GitHub App may span multiple owners (separate installations), so
+  // each repo's hook must be created/listed with that repo's own token.
+  token: (repoSlug: string) => Promise<string>
   webhookUrl: string
   webhookSecret: string
   repos: readonly string[]
@@ -51,22 +54,22 @@ export async function registerGithubWebhooks(
   options: RegisterGithubWebhooksOptions,
 ): Promise<WebhookRegistrationResult> {
   const fetchImpl = options.fetchImpl ?? fetch
-  let token: string
-  try {
-    token = await options.token()
-  } catch (err) {
-    const error = describe(err)
-    return { repos: options.repos.map((repo) => ({ repo, action: 'failed' as const, error })) }
-  }
   const repos: WebhookRepoResult[] = []
   for (const repo of options.repos) {
+    let token: string
+    try {
+      token = await options.token(repo)
+    } catch (err) {
+      repos.push({ repo, action: 'failed', error: describe(err) })
+      continue
+    }
     repos.push(await registerOne(fetchImpl, token, repo, options))
   }
   return { repos }
 }
 
 export type DeregisterGithubWebhooksOptions = {
-  token: () => Promise<string>
+  token: (repoSlug: string) => Promise<string>
   hooks: ReadonlyArray<{ repo: string; hookId: number }>
   fetchImpl?: typeof fetch
 }
@@ -79,15 +82,15 @@ export async function deregisterGithubWebhooks(
   options: DeregisterGithubWebhooksOptions,
 ): Promise<WebhookDeregistrationResult> {
   const fetchImpl = options.fetchImpl ?? fetch
-  let token: string
-  try {
-    token = await options.token()
-  } catch (err) {
-    const error = describe(err)
-    return { hooks: options.hooks.map((h) => ({ ...h, action: 'failed', error })) }
-  }
   const hooks: WebhookDeregistrationResult['hooks'] = []
   for (const hook of options.hooks) {
+    let token: string
+    try {
+      token = await options.token(hook.repo)
+    } catch (err) {
+      hooks.push({ ...hook, action: 'failed', error: describe(err) })
+      continue
+    }
     hooks.push(await deleteOne(fetchImpl, token, hook))
   }
   return { hooks }

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -842,7 +842,6 @@ async function promptGithubAppAuth(): Promise<{
   type: 'app'
   appId: number
   privateKey: string
-  installationId?: number
 }> {
   const appId = await text({
     message: 'GitHub App ID',
@@ -857,21 +856,10 @@ async function promptGithubAppAuth(): Promise<{
     cancel('Aborted.')
     process.exit(0)
   }
-  const installationId = await text({
-    message: 'Installation ID (optional; leave blank to auto-discover)',
-    validate: (value) =>
-      value === undefined || value === '' ? undefined : validatePositiveInteger(value, 'Installation ID is required'),
-  })
-  if (isCancel(installationId)) {
-    cancel('Aborted.')
-    process.exit(0)
-  }
-  const parsedInstallationId = installationId === '' ? undefined : Number(installationId)
   return {
     type: 'app',
     appId: Number(appId),
     privateKey,
-    ...(parsedInstallationId !== undefined ? { installationId: parsedInstallationId } : {}),
   }
 }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1293,7 +1293,6 @@ async function promptGithubAppAuth(): Promise<{
   type: 'app'
   appId: number
   privateKey: string
-  installationId?: number
 } | null> {
   const appId = await text({
     message: 'GitHub App ID',
@@ -1302,18 +1301,10 @@ async function promptGithubAppAuth(): Promise<{
   if (isCancel(appId)) return null
   const privateKey = await promptPrivateKeyPem('GitHub App private key PEM, escaped PEM, or path to .pem file')
   if (privateKey === CANCEL_SYMBOL) return null
-  const installationId = await text({
-    message: 'Installation ID (optional; leave blank to auto-discover)',
-    validate: (v) =>
-      v === undefined || v === '' ? undefined : validatePositiveInteger(v, 'Installation ID is required'),
-  })
-  if (isCancel(installationId)) return null
-  const parsedInstallationId = installationId === '' ? undefined : Number(installationId)
   return {
     type: 'app',
     appId: Number(appId),
     privateKey,
-    ...(parsedInstallationId !== undefined ? { installationId: parsedInstallationId } : {}),
   }
 }
 

--- a/src/init/github-webhook-install.ts
+++ b/src/init/github-webhook-install.ts
@@ -57,7 +57,7 @@ export async function installGithubWebhooksEagerly(
 
   try {
     const result = await registerGithubWebhooks({
-      token: () => strategy.token(),
+      token: (repoSlug: string) => strategy.token({ repoSlug }),
       webhookUrl,
       webhookSecret: options.webhookSecret,
       repos: options.repos,
@@ -86,7 +86,6 @@ function authToSecretBlock(auth: GithubInitCredentials['auth']) {
     type: 'app' as const,
     appId: auth.appId,
     privateKey: { value: auth.privateKey },
-    ...(auth.installationId !== undefined ? { installationId: auth.installationId } : {}),
   }
 }
 

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -94,7 +94,7 @@ export type GithubInitCredentials = {
   hostname?: string
   tokenEnv?: string
   repos: string[]
-  auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string; installationId?: number }
+  auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string }
 }
 
 export type GithubTunnelProvider = 'cloudflare-quick' | 'cloudflare-named' | 'external' | 'none'
@@ -998,7 +998,7 @@ export type AddChannelOptions = {
       hostname?: string
       tokenEnv?: string
       repos: string[]
-      auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string; installationId?: number }
+      auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string }
       fetchImpl?: typeof fetch
     }
 )
@@ -1263,9 +1263,6 @@ async function writeGithubChannelForInit(cwd: string, credentials: GithubInitCre
             type: 'app',
             appId: credentials.auth.appId,
             privateKey: { value: credentials.auth.privateKey } satisfies Secret,
-            ...(credentials.auth.installationId !== undefined
-              ? { installationId: credentials.auth.installationId }
-              : {}),
           },
     webhookSecret: { value: credentials.webhookSecret } satisfies Secret,
   }
@@ -1298,7 +1295,6 @@ async function appendGithubSecrets(
             type: 'app',
             appId: options.auth.appId,
             privateKey: { value: options.auth.privateKey } satisfies Secret,
-            ...(options.auth.installationId !== undefined ? { installationId: options.auth.installationId } : {}),
           },
     webhookSecret: { value: options.webhookSecret } satisfies Secret,
   }
@@ -1461,13 +1457,13 @@ export async function setChannelSecrets(
 // previous auth type, since the two shapes share no fields beyond `type`).
 export type GithubCredentialPatch = {
   webhookSecret?: string
-  auth?: { type: 'pat'; pat: string } | { type: 'app'; privateKey: string; appId?: number; installationId?: number }
+  auth?: { type: 'pat'; pat: string } | { type: 'app'; privateKey: string; appId?: number }
 }
 
 // Update one or more credential fields on an already-configured GitHub
 // channel. Like setChannelSecrets, refuses when secrets.json has no
 // existing github entry. Supports both same-type rotation (preserves env
-// bindings, carries appId/installationId forward when not supplied) and
+// bindings, carries appId forward when not supplied) and
 // auth-type switching (replaces the entire auth block — see
 // `GithubCredentialPatch` above).
 export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch): Promise<SetChannelTokensResult> {
@@ -1503,7 +1499,6 @@ export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch
       } else {
         const existingApp = isSameType && isObjectRecord(existingAuth) ? (existingAuth as Record<string, unknown>) : {}
         const appId = patch.auth.appId ?? (existingApp.appId as number | undefined)
-        const installationId = patch.auth.installationId ?? (existingApp.installationId as number | undefined)
         if (typeof appId !== 'number') {
           return {
             result: {
@@ -1518,7 +1513,6 @@ export async function setGithubSecrets(cwd: string, patch: GithubCredentialPatch
           type: 'app',
           appId,
           privateKey: rotatedSecret(existingApp.privateKey, patch.auth.privateKey),
-          ...(installationId !== undefined ? { installationId } : {}),
         }
       }
     }

--- a/src/init/set-channel.test.ts
+++ b/src/init/set-channel.test.ts
@@ -281,7 +281,6 @@ describe('setGithubSecrets', () => {
         type: 'app',
         appId: 1234,
         privateKey: '-----BEGIN PRIVATE KEY-----\nold-key\n-----END PRIVATE KEY-----',
-        installationId: 9999,
       },
     })
   }
@@ -310,7 +309,7 @@ describe('setGithubSecrets', () => {
     expect(gh.webhookSecret).toEqual({ value: 'wh-old' })
   })
 
-  test('rotates the App private key while preserving appId and installationId from disk', async () => {
+  test('rotates the App private key while preserving appId from disk', async () => {
     await seedAppGithub()
 
     const result = await setGithubSecrets(root, {
@@ -324,7 +323,6 @@ describe('setGithubSecrets', () => {
       type: 'app',
       appId: 1234,
       privateKey: { value: '-----BEGIN PRIVATE KEY-----\nrotated\n-----END PRIVATE KEY-----' },
-      installationId: 9999,
     })
   })
 
@@ -344,29 +342,6 @@ describe('setGithubSecrets', () => {
   })
 
   test('switches auth from pat to app and replaces the entire auth block', async () => {
-    await seedPatGithub()
-
-    const result = await setGithubSecrets(root, {
-      auth: {
-        type: 'app',
-        appId: 4242,
-        privateKey: '-----BEGIN PRIVATE KEY-----\nswitched\n-----END PRIVATE KEY-----',
-        installationId: 7777,
-      },
-    })
-
-    expect(result).toEqual({ ok: true })
-    const secrets = await readSecrets()
-    const gh = secrets.channels?.github as Record<string, unknown>
-    expect(gh.auth).toEqual({
-      type: 'app',
-      appId: 4242,
-      privateKey: { value: '-----BEGIN PRIVATE KEY-----\nswitched\n-----END PRIVATE KEY-----' },
-      installationId: 7777,
-    })
-  })
-
-  test('switches auth from pat to app without an installationId when omitted', async () => {
     await seedPatGithub()
 
     const result = await setGithubSecrets(root, {
@@ -503,7 +478,6 @@ describe('setGithubSecrets', () => {
         type: 'app',
         appId: 1234,
         privateKey: { value: '-----BEGIN PRIVATE KEY-----\nold\n-----END PRIVATE KEY-----', env: 'CUSTOM_GH_APP_KEY' },
-        installationId: 9999,
       },
       webhookSecret: { value: 'wh-old' },
     }
@@ -523,7 +497,6 @@ describe('setGithubSecrets', () => {
         value: '-----BEGIN PRIVATE KEY-----\nrotated\n-----END PRIVATE KEY-----',
         env: 'CUSTOM_GH_APP_KEY',
       },
-      installationId: 9999,
     })
   })
 

--- a/src/secrets/schema.test.ts
+++ b/src/secrets/schema.test.ts
@@ -61,6 +61,24 @@ describe('parseSecretsFile (v2 envelope)', () => {
     expect(result.file.channels['discord-bot']).toEqual({ token: { env: 'CUSTOM_DISCORD' } })
   })
 
+  test('migrates legacy github App auth by stripping the removed installationId field', () => {
+    const result = parseSecretsFile({
+      version: 2,
+      channels: {
+        github: {
+          auth: { type: 'app', appId: 123, privateKey: { value: 'pk' }, installationId: 9999 },
+          webhookSecret: { value: 'wh' },
+        },
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const github = result.file.channels.github as { auth: Record<string, unknown> }
+    expect(github.auth).toEqual({ type: 'app', appId: 123, privateKey: { value: 'pk' } })
+    expect('installationId' in github.auth).toBe(false)
+  })
+
   test('accepts channels.kakaotalk credential block', () => {
     const result = parseSecretsFile({
       version: 2,

--- a/src/secrets/schema.ts
+++ b/src/secrets/schema.ts
@@ -49,7 +49,6 @@ const githubAppAuthSchema = z.object({
   type: z.literal('app'),
   appId: z.number().int().positive(),
   privateKey: secretFieldSchema,
-  installationId: z.number().int().positive().optional(),
 })
 
 const githubChannelSchema = z.object({


### PR DESCRIPTION
## Background

`channels.github.repos` in `typeclaw.json` accepts a list of `owner/name` slugs with no restriction on owner, but `secrets.json` only stored a single `channels.github.auth.installationId`. A GitHub App installed on more than one account/org gets a **distinct installation (and installationId) per owner**, and an installation access token is scoped to its own installation. So with the single-id model, every adapter operation for a repo under a *different* owner than the configured installationId failed:

- webhook registration minted one token before the loop and reused it for every repo
- outbound comments, history fetches, membership/collaborator lookups, channel-name resolution all shared that one token

`AppAuthStrategy` even had an explicit guard that *rejected* multi-installation Apps (`GitHub App has multiple installations (…); set installationId in secrets.json`) — the code already knew the model couldn't express this, and forced the operator to pick one owner.

## Summary

Resolve the installation **per repo** instead of pinning one globally. GitHub exposes the exact primitive: `GET /repos/{owner}/{repo}/installation` (App JWT) returns the installation for a repo, so we derive it from the `repos` list the operator already configured — no installation IDs to copy from the UI, no mapping to drift when repos move.

Key decisions:

- **Auto-resolve, not a config map.** Rejected `installations: Record<owner, id>` and per-repo mappings: both push avoidable bookkeeping onto the operator and go stale on repo moves. The repo-level API is canonical.
- **`GithubAuthContext` ({ repoSlug } or { owner }), not `token(owner)`.**  `repoSlug` is the canonical key (repo-level API); `owner` covers the few non-repo-scoped calls (team-membership uses `/orgs/{org}/...`, resolved via `/orgs/{org}/installation`). PAT auth ignores context; App auth caches `repoSlug -> installationId` and keys its token cache by `installationId`. Single-installation Apps still auto-discover with no context.
- **`GH_TOKEN` is only seeded when exactly one repo is configured.** It's a single process-wide env var the container's `gh` CLI reads; with multiple possibly-different owners there is no single correct token. Picking a "primary" owner would make `gh` silently work for one repo and 404 for another — worse than unset. The adapter's own API calls always resolve a repo-scoped token regardless.
- **Migration is a strip-on-read.** `installationId` is removed from `githubAppAuthSchema`; Zod drops the stale field when parsing existing `secrets.json`, and the clean shape persists on the next write. No migration code, no dual schema.

## What this does NOT do

- Does not add any new config surface — the App auth block is now just `appId` + `privateKey`.
- Does not change PAT auth behavior at all (PATs have no installation concept).
- Does not batch-resolve installations up front; resolution is lazy and cached per repo/owner for the adapter's lifetime.
- Does not add a manual installationId override. If a real need surfaces (GH Enterprise quirks, strict startup rate limits), that's a follow-up.

## Review notes

- Load-bearing change: `AppAuthStrategy.resolveInstallationId` (`auth-app.ts`) and the `token(context?)` signature widening that ripples to every consumer — the consumers all build together because the signature change is backward-compatible at call sites but the behavior is now repo-scoped.
- One bug caught mid-refactor: the per-owner preflight initially destructured `auth.getInstallationGrants` into a local, losing the `this` binding (`this.mintJwt` undefined). Now called as a bound method. Worth a glance at `runAppPermissionPreflight`.
- Failure-mode invariant to verify: an App not installed for a configured repo's owner produces a precise per-repo error (`not installed for owner/name or lacks access`) and is isolated — other repos still register. See the new `webhook-register.test.ts` cases.
- Migration invariant: `schema.test.ts` asserts a legacy `installationId` is stripped on read.