### PR TITLE
Add mcpServers config schema

### DIFF
--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -199,6 +199,12 @@ describe('mcpServerSchema', () => {
     expect(parsed).toEqual({ name: 'remote-docs', args: [], url: 'https://mcp.example.com/mcp', env: {} })
   })
 
+  test('preserves explicit request timeout', () => {
+    const parsed = mcpServerSchema.parse({ name: 'with-timeout', timeoutMs: 1234, command: 'server' })
+
+    expect(parsed.timeoutMs).toBe(1234)
+  })
+
   test('rejects a server with both command and url', () => {
     expect(() =>
       mcpServerSchema.parse({ name: 'mixed', command: 'server', url: 'https://mcp.example.com/mcp' }),
@@ -230,6 +236,14 @@ describe('mcpServerSchema', () => {
   test('rejects names outside the mount namespace pattern', () => {
     expect(() => mcpServerSchema.parse({ name: 'BadName', command: 'server' })).toThrow(/MCP server name/)
     expect(() => mcpServerSchema.parse({ name: '-bad', command: 'server' })).toThrow(/MCP server name/)
+  })
+
+  test('rejects double underscore names because the sequence separates MCP tool namespaces', () => {
+    expect(() => mcpServerSchema.parse({ name: 'bad__server', command: 'server' })).toThrow(/must not contain '__'/)
+  })
+
+  test('allows single underscores in server names', () => {
+    expect(() => mcpServerSchema.parse({ name: 'good_server', command: 'server' })).not.toThrow()
   })
 })
 

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -13,6 +13,7 @@ import {
   loadConfigSyncOrDefaults,
   loadPluginConfigsSync,
   migrateLegacyConfigShape,
+  mcpServerSchema,
   mountSchema,
   resolveProfile,
   validateConfig,
@@ -175,6 +176,82 @@ describe('configSchema', () => {
       mounts: [{ name: 'src', path: '~/src', description: 'monorepo' }],
     })
     expect(parsed.mounts[0]?.description).toBe('monorepo')
+  })
+})
+
+describe('mcpServerSchema', () => {
+  test('accepts a stdio server config', () => {
+    const parsed = mcpServerSchema.parse({
+      name: 'filesystem',
+      command: 'bunx',
+      args: ['@modelcontextprotocol/server-filesystem'],
+    })
+    expect(parsed).toEqual({
+      name: 'filesystem',
+      command: 'bunx',
+      args: ['@modelcontextprotocol/server-filesystem'],
+      env: {},
+    })
+  })
+
+  test('accepts an http server config', () => {
+    const parsed = mcpServerSchema.parse({ name: 'remote-docs', url: 'https://mcp.example.com/mcp' })
+    expect(parsed).toEqual({ name: 'remote-docs', args: [], url: 'https://mcp.example.com/mcp', env: {} })
+  })
+
+  test('rejects a server with both command and url', () => {
+    expect(() =>
+      mcpServerSchema.parse({ name: 'mixed', command: 'server', url: 'https://mcp.example.com/mcp' }),
+    ).toThrow(/either stdio \(command\) or http \(url\)/)
+  })
+
+  test('rejects a server with neither command nor url', () => {
+    expect(() => mcpServerSchema.parse({ name: 'missing-transport' })).toThrow(
+      /either stdio \(command\) or http \(url\)/,
+    )
+  })
+
+  test('normalises env string shorthand and env-object secrets', () => {
+    const parsed = mcpServerSchema.parse({
+      name: 'with-env',
+      command: 'server',
+      env: {
+        INLINE_TOKEN: 'test-token',
+        API_KEY: { env: 'MCP_API_KEY' },
+      },
+    })
+
+    expect(parsed.env).toEqual({
+      INLINE_TOKEN: { value: 'test-token' },
+      API_KEY: { env: 'MCP_API_KEY' },
+    })
+  })
+
+  test('rejects names outside the mount namespace pattern', () => {
+    expect(() => mcpServerSchema.parse({ name: 'BadName', command: 'server' })).toThrow(/MCP server name/)
+    expect(() => mcpServerSchema.parse({ name: '-bad', command: 'server' })).toThrow(/MCP server name/)
+  })
+})
+
+describe('configSchema mcpServers field', () => {
+  test('defaults to [] when omitted', () => {
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
+    expect(parsed.mcpServers).toEqual([])
+  })
+
+  test('accepts stdio and http server declarations', () => {
+    const parsed = configSchema.parse({
+      models: { default: VALID_MODEL },
+      mcpServers: [
+        { name: 'filesystem', command: 'bunx', args: ['@modelcontextprotocol/server-filesystem'] },
+        { name: 'remote-docs', url: 'https://mcp.example.com/mcp' },
+      ],
+    })
+
+    expect(parsed.mcpServers).toEqual([
+      { name: 'filesystem', command: 'bunx', args: ['@modelcontextprotocol/server-filesystem'], env: {} },
+      { name: 'remote-docs', args: [], url: 'https://mcp.example.com/mcp', env: {} },
+    ])
   })
 })
 

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -278,6 +278,16 @@ describe('mcpServerSchema', () => {
     expect(() => mcpServerSchema.parse({ name: 'slow', command: 'server', timeoutMs: 600_001 })).toThrow()
     expect(() => mcpServerSchema.parse({ name: 'ok-slow', command: 'server', timeoutMs: 600_000 })).not.toThrow()
   })
+
+  test('preserves an optional description for the later MCP catalog', () => {
+    const parsed = mcpServerSchema.parse({
+      name: 'github',
+      description: 'GitHub issues, PRs, and code search',
+      command: 'server',
+    })
+
+    expect(parsed.description).toBe('GitHub issues, PRs, and code search')
+  })
 })
 
 describe('configSchema mcpServers field', () => {
@@ -299,6 +309,21 @@ describe('configSchema mcpServers field', () => {
       { name: 'filesystem', command: 'bunx', args: ['@modelcontextprotocol/server-filesystem'], env: {} },
       { name: 'remote-docs', args: [], url: 'https://mcp.example.com/mcp', env: {} },
     ])
+  })
+
+  test('rejects duplicate server names with an indexed path at the offending entry', () => {
+    const result = configSchema.safeParse({
+      models: { default: VALID_MODEL },
+      mcpServers: [
+        { name: 'github', command: 'server' },
+        { name: 'github', url: 'https://mcp.example.com/mcp' },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected duplicate names to be rejected')
+    const issue = result.error.issues.find((i) => i.message.includes('duplicates'))
+    expect(issue?.path).toEqual(['mcpServers', 1, 'name'])
   })
 })
 

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -245,6 +245,39 @@ describe('mcpServerSchema', () => {
   test('allows single underscores in server names', () => {
     expect(() => mcpServerSchema.parse({ name: 'good_server', command: 'server' })).not.toThrow()
   })
+
+  test('rejects a url that is not http(s)', () => {
+    expect(() => mcpServerSchema.parse({ name: 'ftp-server', url: 'ftp://mcp.example.com/mcp' })).toThrow(
+      /http:\/\/ or https:\/\//,
+    )
+  })
+
+  test('accepts a plain http url', () => {
+    expect(() => mcpServerSchema.parse({ name: 'local-http', url: 'http://localhost:8080/mcp' })).not.toThrow()
+  })
+
+  test('accepts http(s) urls regardless of scheme casing', () => {
+    expect(() => mcpServerSchema.parse({ name: 'upper-https', url: 'HTTPS://mcp.example.com/mcp' })).not.toThrow()
+    expect(() => mcpServerSchema.parse({ name: 'upper-http', url: 'HTTP://localhost:8080/mcp' })).not.toThrow()
+  })
+
+  test('rejects env keys that are not valid identifiers', () => {
+    expect(() => mcpServerSchema.parse({ name: 'bad-env', command: 'server', env: { 'API KEY': 'x' } })).toThrow(
+      /valid identifier/,
+    )
+    expect(() => mcpServerSchema.parse({ name: 'bad-env2', command: 'server', env: { '1LEADING': 'x' } })).toThrow(
+      /valid identifier/,
+    )
+  })
+
+  test('rejects a whitespace-only command', () => {
+    expect(() => mcpServerSchema.parse({ name: 'blank-cmd', command: '   ' })).toThrow()
+  })
+
+  test('rejects a timeout above the 10-minute ceiling', () => {
+    expect(() => mcpServerSchema.parse({ name: 'slow', command: 'server', timeoutMs: 600_001 })).toThrow()
+    expect(() => mcpServerSchema.parse({ name: 'ok-slow', command: 'server', timeoutMs: 600_000 })).not.toThrow()
+  })
 })
 
 describe('configSchema mcpServers field', () => {
@@ -311,6 +344,17 @@ describe('configSchema preserves unknown top-level keys (plugin config blocks)',
     })
 
     expect(configs).toEqual({ agentBrowser: { dashboardProxy: false }, customPlugin: { enabled: true } })
+  })
+
+  test('treats mcpServers and tunnels as known top-level keys, not plugin blocks', () => {
+    const configs = extractPluginConfigs({
+      models: { default: VALID_MODEL },
+      mcpServers: [{ name: 'fs', command: 'server' }],
+      tunnels: [{ provider: 'cloudflare-quick' }],
+      customPlugin: { enabled: true },
+    })
+
+    expect(configs).toEqual({ customPlugin: { enabled: true } })
   })
 })
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -31,6 +31,30 @@ const DEFAULT_PORT = 8973
 // of files like `mounts/.git` or `mounts/Hello`.
 const MOUNT_NAME_PATTERN = /^[a-z0-9][a-z0-9-_]*$/
 
+// Shell-portable env var identifier: a leading letter or underscore followed by
+// letters, digits, or underscores. MCP `env` keys are passed verbatim to a child
+// process environment, so an invalid identifier (spaces, `=`, leading digit)
+// would be silently dropped or corrupt the spawned server's env.
+const ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+// Upper bound for a per-server MCP request timeout: 10 minutes. Long-running
+// MCP tools (large crawls, builds) can legitimately take minutes, but a ceiling
+// guards against fat-finger values that would re-introduce the unbounded-hang
+// failure mode the explicit timeouts exist to prevent.
+const MCP_MAX_TIMEOUT_MS = 600_000
+
+// URL schemes are case-insensitive (RFC 3986), and the WHATWG parser normalizes
+// `.protocol` to lowercase. Checking the parsed protocol instead of a raw
+// `startsWith` keeps `HTTPS://…` valid, which `z.string().url()` already accepts.
+function isHttpProtocol(value: string): boolean {
+  try {
+    const protocol = new URL(value).protocol
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 export const mountSchema = z.object({
   name: z.string().regex(MOUNT_NAME_PATTERN, 'mount name must be lowercase alphanumeric with - or _'),
   path: z.string().min(1),
@@ -53,11 +77,19 @@ export const mcpServerSchema = z
       .refine((name) => !name.includes('__'), {
         message: "MCP server name must not contain '__' (reserved as the tool-namespace separator)",
       }),
-    timeoutMs: z.number().int().positive().optional(),
-    command: z.string().min(1).optional(),
+    timeoutMs: z.number().int().positive().max(MCP_MAX_TIMEOUT_MS).optional(),
+    command: z.string().trim().min(1).optional(),
     args: z.array(z.string()).default([]),
-    url: z.string().url().optional(),
-    env: z.record(z.string(), secretFieldSchema).default({}),
+    url: z
+      .string()
+      .url()
+      .refine((u) => isHttpProtocol(u), {
+        message: 'MCP server url must use http:// or https://',
+      })
+      .optional(),
+    env: z
+      .record(z.string().regex(ENV_NAME_PATTERN, 'env var name must be a valid identifier'), secretFieldSchema)
+      .default({}),
   })
   .refine((server) => (server.command !== undefined) !== (server.url !== undefined), {
     message: 'MCP server must be either stdio (command) or http (url), not both or neither',
@@ -666,6 +698,8 @@ export function extractPluginConfigs(raw: unknown): Record<string, unknown> {
     'git',
     'roles',
     'permissions',
+    'tunnels',
+    'mcpServers',
   ])
   const result: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -47,7 +47,13 @@ export type Mount = z.infer<typeof mountSchema>
 // would make ownership, lifetime, and credential injection ambiguous at boot.
 export const mcpServerSchema = z
   .object({
-    name: z.string().regex(MOUNT_NAME_PATTERN, 'MCP server name must be lowercase alphanumeric with - or _'),
+    name: z
+      .string()
+      .regex(MOUNT_NAME_PATTERN, 'MCP server name must be lowercase alphanumeric with - or _')
+      .refine((name) => !name.includes('__'), {
+        message: "MCP server name must not contain '__' (reserved as the tool-namespace separator)",
+      }),
+    timeoutMs: z.number().int().positive().optional(),
     command: z.string().min(1).optional(),
     args: z.array(z.string()).default([]),
     url: z.string().url().optional(),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -77,6 +77,7 @@ export const mcpServerSchema = z
       .refine((name) => !name.includes('__'), {
         message: "MCP server name must not contain '__' (reserved as the tool-namespace separator)",
       }),
+    description: z.string().optional(),
     timeoutMs: z.number().int().positive().max(MCP_MAX_TIMEOUT_MS).optional(),
     command: z.string().trim().min(1).optional(),
     args: z.array(z.string()).default([]),
@@ -96,6 +97,30 @@ export const mcpServerSchema = z
   })
 
 export type McpServer = z.infer<typeof mcpServerSchema>
+
+// The name becomes the `<server>__<tool>` namespace at dispatch, so duplicates
+// would make tool lookup ambiguous and silently shadow one server behind
+// another. Reject them with an indexed path so the error points at the
+// offending entry instead of the whole array.
+const mcpServersArraySchema = z
+  .array(mcpServerSchema)
+  .default([])
+  .superRefine((entries, ctx) => {
+    const seen = new Map<string, number>()
+    for (let i = 0; i < entries.length; i++) {
+      const name = entries[i]!.name
+      const prev = seen.get(name)
+      if (prev !== undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: [i, 'name'],
+          message: `mcpServers[${i}].name duplicates mcpServers[${prev}].name ('${name}')`,
+        })
+      } else {
+        seen.set(name, i)
+      }
+    }
+  })
 
 const portNumber = z.number().int().min(1).max(65535)
 
@@ -449,7 +474,7 @@ export const configSchema = z
     // host paths exposed) without failing the whole config load. `typeclaw
     // init` omits this field so users don't see noise for the empty case.
     mounts: z.array(mountSchema).default([]),
-    mcpServers: z.array(mcpServerSchema).default([]),
+    mcpServers: mcpServersArraySchema,
     plugins: z.array(z.string().min(1)).default([]),
     // Additional names the agent answers to in channel engagement, on top
     // of `basename(agentDir)` which is always implicit. Each entry is a

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -8,6 +8,7 @@ import { z } from 'zod'
 import { channelsSchema } from '@/channels/schema'
 import { commitSystemFileSync } from '@/git/system-commit'
 import { rolesConfigSchema } from '@/permissions/schema'
+import { secretFieldSchema } from '@/secrets/resolve'
 
 import {
   DEFAULT_MODEL_REF,
@@ -38,6 +39,25 @@ export const mountSchema = z.object({
 })
 
 export type Mount = z.infer<typeof mountSchema>
+
+// MCP servers are keyed by the same shell/disk-safe namespace as mounts because
+// the name becomes the tool namespace exposed to the agent. The transport is an
+// XOR on purpose: stdio servers are child processes (`command` + `args` + env),
+// while Streamable HTTP servers are remote endpoints (`url`); accepting both
+// would make ownership, lifetime, and credential injection ambiguous at boot.
+export const mcpServerSchema = z
+  .object({
+    name: z.string().regex(MOUNT_NAME_PATTERN, 'MCP server name must be lowercase alphanumeric with - or _'),
+    command: z.string().min(1).optional(),
+    args: z.array(z.string()).default([]),
+    url: z.string().url().optional(),
+    env: z.record(z.string(), secretFieldSchema).default({}),
+  })
+  .refine((server) => (server.command !== undefined) !== (server.url !== undefined), {
+    message: 'MCP server must be either stdio (command) or http (url), not both or neither',
+  })
+
+export type McpServer = z.infer<typeof mcpServerSchema>
 
 const portNumber = z.number().int().min(1).max(65535)
 
@@ -391,6 +411,7 @@ export const configSchema = z
     // host paths exposed) without failing the whole config load. `typeclaw
     // init` omits this field so users don't see noise for the empty case.
     mounts: z.array(mountSchema).default([]),
+    mcpServers: z.array(mcpServerSchema).default([]),
     plugins: z.array(z.string().min(1)).default([]),
     // Additional names the agent answers to in channel engagement, on top
     // of `basename(agentDir)` which is always implicit. Each entry is a
@@ -538,6 +559,7 @@ export const FIELD_EFFECTS: Record<string, FieldEffect> = {
   models: 'applied',
   port: 'restart-required',
   mounts: 'restart-required',
+  mcpServers: 'restart-required',
   plugins: 'restart-required',
   alias: 'applied',
   channels: 'applied',


### PR DESCRIPTION
## Background

We want MCP support, but the central constraint is token economy — a naive integration dumps every tool schema into the system prompt (N servers × M tools = N×M schemas), which rots context with every server added. The agreed architecture keeps prompt cost flat at ~N via a per-server catalog in the system prompt plus three fixed dispatcher tools. This PR lays the foundation: declaring MCP servers in `typeclaw.json`.

## Summary

Adds `mcpServers` array to the config schema. Four non-obvious decisions:

1. **Transport XOR.** A server is either stdio (`command`+`args`) or Streamable HTTP (`url`), enforced by a `.refine` at parse time. Accepting both shapes on the same object makes process ownership, lifetime, and credentials ambiguous.
2. **`env` reuses `secretFieldSchema`.** No second credential mechanism. The env-wins resolver already handles secret indirection; re-using it keeps the mental model consistent.
3. **`name` reuses `MOUNT_NAME_PATTERN`.** The name becomes the `<server>__<tool>` namespace in later PRs and must be shell/disk-safe; borrowing the existing pattern enforces this cheaply.
4. **Classified `restart-required` in `FIELD_EFFECTS`.** MCP connections are established at boot like mounts and tunnels. The `reloadable.test.ts` coverage guard requires every new schema field to have a classification; omitting it would fail CI.

Regenerated `typeclaw.schema.json` reflects the new field.

## Example

```jsonc
{
  "mcpServers": [
    {
      "name": "github",
      "description": "GitHub issues, PRs, and code search",
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-github"],
      "env": {
        "GITHUB_TOKEN": { "env": "GITHUB_TOKEN" }
      }
    },
    {
      "name": "context7",
      "description": "Up-to-date library docs",
      "url": "https://mcp.context7.com/mcp"
    }
  ]
}
```

Two servers shown: a **stdio** server (`command`+`args`, with a credential pulled from the environment via the `{ "env": "VAR" }` secret form) and a **Streamable HTTP** server (`url`). Supplying both `command` and `url` on the same entry is rejected at parse time.

## What this does NOT do

No client, connection logic, tools, or prompt changes. This is config-only. Declaring a server in `typeclaw.json` has no runtime effect until later PRs in this stack.

## Review notes

The load-bearing invariants are the `command`-XOR-`url` `.refine` (verify with a config that supplies both — it should be rejected) and the `restart-required` classification in `FIELD_EFFECTS`.