### PR TITLE
Add MCP client layer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@clack/prompts": "^1.2.0",
         "@mariozechner/pi-coding-agent": "^0.67.3",
         "@mariozechner/pi-tui": "^0.67.3",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@mozilla/readability": "^0.6.0",
         "agent-messenger": "2.19.1",
         "cheerio": "^1.2.0",
@@ -150,6 +151,8 @@
 
     "@hapi/hoek": ["@hapi/hoek@11.0.7", "", {}, "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -239,6 +242,8 @@
     "@mistralai/mistralai": ["@mistralai/mistralai@1.14.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ=="],
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
 
@@ -510,6 +515,8 @@
 
     "abstract-level": ["abstract-level@3.1.1", "", { "dependencies": { "buffer": "^6.0.3", "is-buffer": "^2.0.5", "level-supports": "^6.2.0", "level-transcoder": "^1.0.1", "maybe-combine-errors": "^1.0.0", "module-error": "^1.0.1" } }, "sha512-CW2gKbJFTuX1feMvOrvsVMmijAOgI9kg2Ie9Dq3gOcMt/dVVoVmqNlLcEUCT13NxHFMEajcUcVBIplbyDroDiw=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "agent-messenger": ["agent-messenger@2.19.1", "", { "dependencies": { "@hapi/boom": "^10.0.1", "@slack/web-api": "^6.9.0", "@whiskeysockets/baileys": "^7.0.0-rc.9", "better-sqlite3": "^12.0.0", "blessed": "^0.1.81", "bson": "^7.2.0", "classic-level": "^3.0.0", "commander": "^11.1.0", "crypto-js": "^4.2.0", "curve25519-js": "^0.0.4", "node-bignumber": "^1.2.2", "node-int64": "^0.4.0", "node-jose": "^2.2.0", "pino": "^10.3.1", "qrcode": "^1.5.4", "thrift": "^0.20.0", "tweetnacl": "^1.0.3", "ws": "^8.19.0", "zod": "^4.3.6" }, "optionalDependencies": { "koffi": "^2.15.2", "prebuilt-tdlib": "0.1008062.2" }, "bin": { "agent-channeltalk": "dist/src/platforms/channeltalk/cli.js", "agent-channeltalkbot": "dist/src/platforms/channeltalkbot/cli.js", "agent-discord": "dist/src/platforms/discord/cli.js", "agent-discordbot": "dist/src/platforms/discordbot/cli.js", "agent-instagram": "dist/src/platforms/instagram/cli.js", "agent-kakaotalk": "dist/src/platforms/kakaotalk/cli.js", "agent-line": "dist/src/platforms/line/cli.js", "agent-messenger": "dist/src/cli.js", "agent-slack": "dist/src/platforms/slack/cli.js", "agent-slackbot": "dist/src/platforms/slackbot/cli.js", "agent-teams": "dist/src/platforms/teams/cli.js", "agent-telegram": "dist/src/platforms/telegram/cli.js", "agent-telegrambot": "dist/src/platforms/telegrambot/cli.js", "agent-webex": "dist/src/platforms/webex/cli.js", "agent-wechatbot": "dist/src/platforms/wechatbot/cli.js", "agent-whatsapp": "dist/src/platforms/whatsapp/cli.js", "agent-whatsappbot": "dist/src/platforms/whatsappbot/cli.js", "amsg": "dist/src/cli.js" } }, "sha512-r2qhGEoaF4NjqEOYFCJ+ol8sD4BFw/1/elwFlCDknrEiGe+fy/jMgH5w790uLqpjpDM2pk1jPrYVCpmRreNa7g=="],
@@ -556,6 +563,8 @@
 
     "blessed": ["blessed@0.1.81", "", { "bin": { "blessed": "./bin/tput.js" } }, "sha512-LoF5gae+hlmfORcG1M5+5XZi4LBmvlXTzwJWzUlPryN/SJdSflZvROM2TwkT0GMpq7oqT48NRd4GS7BiVBc5OQ=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
@@ -574,9 +583,13 @@
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "cacheable": ["cacheable@2.3.4", "", { "dependencies": { "@cacheable/memory": "^2.0.8", "@cacheable/utils": "^2.4.0", "hookified": "^1.15.0", "keyv": "^5.6.0", "qified": "^0.9.0" } }, "sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
@@ -604,9 +617,19 @@
 
     "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
     "cron-parser": ["cron-parser@5.5.0", "", { "dependencies": { "luxon": "^3.7.1" } }, "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "crypto-js": ["crypto-js@4.2.0", "", {}, "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="],
 
@@ -636,6 +659,8 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
@@ -654,7 +679,11 @@
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
 
@@ -674,6 +703,8 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
@@ -682,9 +713,19 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "eventemitter3": ["eventemitter3@3.1.2", "", {}, "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -712,6 +753,8 @@
 
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
@@ -719,6 +762,10 @@
     "form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
@@ -764,6 +811,8 @@
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
+    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+
     "hookified": ["hookified@1.15.1", "", {}, "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg=="],
 
     "hosted-git-info": ["hosted-git-info@9.0.2", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg=="],
@@ -772,11 +821,13 @@
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
-    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -786,7 +837,9 @@
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
 
@@ -796,9 +849,15 @@
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-stream": ["is-stream@1.1.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "isomorphic-ws": ["isomorphic-ws@4.0.1", "", { "peerDependencies": { "ws": "*" } }, "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "jq-wasm": ["jq-wasm@1.1.0-jq-1.8.1", "", {}, "sha512-lWfu34lpDFIygOYcL5TzxhZIApDR9iR5XywcVoyUAZ6jlQrj8HKHOKeCcHgUm2dE9RVdbP3eqNAKGLuj+k4seQ=="],
 
@@ -809,6 +868,8 @@
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
@@ -844,6 +905,8 @@
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
@@ -870,6 +933,8 @@
 
     "napi-macros": ["napi-macros@2.2.2", "", {}, "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
 
     "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
@@ -892,7 +957,11 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -928,13 +997,19 @@
 
     "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
@@ -943,6 +1018,8 @@
     "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
@@ -958,6 +1035,8 @@
 
     "protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
@@ -972,7 +1051,13 @@
 
     "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
 
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
@@ -988,6 +1073,8 @@
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
@@ -998,9 +1085,27 @@
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -1023,6 +1128,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -1060,6 +1167,8 @@
 
     "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
@@ -1078,6 +1187,8 @@
 
     "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
 
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
@@ -1086,9 +1197,13 @@
 
     "undici-types": ["undici-types@7.25.0", "", {}, "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
@@ -1101,6 +1216,8 @@
     "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
     "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
@@ -1164,6 +1281,8 @@
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
@@ -1188,9 +1307,15 @@
 
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
+    "socks/ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "thrift/ws": ["ws@5.2.4", "", { "dependencies": { "async-limiter": "~1.0.0" } }, "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@clack/prompts": "^1.2.0",
     "@mariozechner/pi-coding-agent": "^0.67.3",
     "@mariozechner/pi-tui": "^0.67.3",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "^0.6.0",
     "agent-messenger": "2.19.1",
     "cheerio": "^1.2.0",

--- a/src/mcp/client.test.ts
+++ b/src/mcp/client.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
+import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
 import type { McpServer } from '@/config/config'
 
-import { createMcpConnection, resolveServerEnv, type McpSdkClient } from './client'
+import { connectMcpServer, createMcpConnection, resolveServerEnv, type McpSdkClient } from './client'
 
 describe('resolveServerEnv', () => {
   test('uses target env key before explicit secret env before secret value', () => {
@@ -35,11 +37,11 @@ describe('McpConnection', () => {
     let listCalls = 0
     const callResult: CallToolResult = { content: [{ type: 'text', text: 'ok' }] }
     const client: McpSdkClient = {
-      async listTools() {
+      async listTools(_params, _options) {
         listCalls += 1
         return { tools: [{ name: 'first', inputSchema: { type: 'object' } }] }
       },
-      async callTool() {
+      async callTool(_params, _resultSchema, _options) {
         return callResult
       },
       async close() {},
@@ -53,4 +55,122 @@ describe('McpConnection', () => {
     expect(second).toBe(first)
     expect(listCalls).toBe(1)
   })
+
+  test('refresh clears the cached catalog before fetching again', async () => {
+    let listCalls = 0
+    const client: McpSdkClient = {
+      async listTools(_params, _options) {
+        listCalls += 1
+        return { tools: [{ name: `tool-${listCalls}`, inputSchema: { type: 'object' } }] }
+      },
+      async callTool(_params, _resultSchema, _options) {
+        return { content: [{ type: 'text', text: 'ok' }] }
+      },
+      async close() {},
+    }
+    const connection = createMcpConnection('server', client)
+
+    const first = await connection.listTools()
+    const refreshed = await connection.refresh()
+    const afterRefresh = await connection.listTools()
+
+    expect(first[0]?.name).toBe('tool-1')
+    expect(refreshed[0]?.name).toBe('tool-2')
+    expect(afterRefresh).toBe(refreshed)
+    expect(listCalls).toBe(2)
+  })
+
+  test('forwards explicit request timeouts to listTools and callTool', async () => {
+    const options: RequestOptions[] = []
+    const client: McpSdkClient = {
+      async listTools(_params, option) {
+        if (option !== undefined) options.push(option)
+        return { tools: [{ name: 'first', inputSchema: { type: 'object' } }] }
+      },
+      async callTool(_params, _resultSchema, option) {
+        if (option !== undefined) options.push(option)
+        return { content: [{ type: 'text', text: 'ok' }] }
+      },
+      async close() {},
+    }
+    const connection = createMcpConnection('server', client, { timeoutMs: 123 })
+
+    await connection.listTools()
+    await connection.callTool('first')
+
+    expect(options.map((option) => option.timeout)).toEqual([123, 123])
+  })
 })
+
+describe('connectMcpServer', () => {
+  test('rejects when client.connect does not settle before the connect deadline', async () => {
+    let closeCalls = 0
+    const client = fakeConnectClient({
+      async connect(_transport, options) {
+        await new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true })
+        })
+      },
+      async close() {
+        closeCalls += 1
+      },
+    })
+
+    await expect(
+      connectMcpServer(server(), { env: {}, client, transport: fakeTransport(), connectTimeoutMs: 20 }),
+    ).rejects.toThrow(/connect timeout/)
+    expect(closeCalls).toBe(1)
+  })
+
+  test('closes a partially-started client and preserves the original connect error', async () => {
+    const connectError = new Error('initialize failed')
+    let closeCalls = 0
+    const client = fakeConnectClient({
+      async connect() {
+        throw connectError
+      },
+      async close() {
+        closeCalls += 1
+      },
+    })
+
+    await expect(
+      connectMcpServer(server(), { env: {}, client, transport: fakeTransport(), connectTimeoutMs: 20 }),
+    ).rejects.toBe(connectError)
+    expect(closeCalls).toBe(1)
+  })
+})
+
+function server(timeoutMs?: number): McpServer {
+  return {
+    name: 'server',
+    command: 'server-command',
+    args: [],
+    env: {},
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  }
+}
+
+function fakeTransport(): Transport {
+  return {
+    async start() {},
+    async send(_message, _options) {},
+    async close() {},
+  }
+}
+
+function fakeConnectClient(overrides: {
+  connect(transport: Transport, options?: RequestOptions): Promise<void>
+  close(): Promise<void>
+}): McpSdkClient & { connect(transport: Transport, options?: RequestOptions): Promise<void> } {
+  return {
+    async listTools(_params, _options) {
+      return { tools: [] }
+    },
+    async callTool(_params, _resultSchema, _options) {
+      return { content: [{ type: 'text', text: 'ok' }] }
+    },
+    connect: overrides.connect,
+    close: overrides.close,
+  }
+}

--- a/src/mcp/client.test.ts
+++ b/src/mcp/client.test.ts
@@ -22,13 +22,31 @@ describe('resolveServerEnv', () => {
       TARGET_TOKEN: 'from-target-env',
       SOURCE_TOKEN: 'from-source-env',
       SOURCE_ONLY_ENV: 'from-source-only-env',
-      PASSTHROUGH: 'kept',
     })
 
     expect(resolved.TARGET_TOKEN).toBe('from-target-env')
     expect(resolved.SOURCE_ONLY).toBe('from-source-only-env')
     expect(resolved.FILE_ONLY).toBe('from-file-only')
-    expect(resolved.PASSTHROUGH).toBe('kept')
+  })
+
+  test('forwards only allowlisted base env, never undeclared secrets', () => {
+    const server: Pick<McpServer, 'env'> = { env: { DECLARED_TOKEN: { env: 'DECLARED_SOURCE' } } }
+
+    const resolved = resolveServerEnv(server, {
+      PATH: '/usr/bin',
+      HOME: '/home/agent',
+      OPENAI_API_KEY: 'sk-secret',
+      GH_TOKEN: 'ghp-secret',
+      FIREWORKS_API_KEY: 'fw-secret',
+      DECLARED_SOURCE: 'declared-value',
+    })
+
+    expect(resolved.PATH).toBe('/usr/bin')
+    expect(resolved.HOME).toBe('/home/agent')
+    expect(resolved.DECLARED_TOKEN).toBe('declared-value')
+    expect(resolved.OPENAI_API_KEY).toBeUndefined()
+    expect(resolved.GH_TOKEN).toBeUndefined()
+    expect(resolved.FIREWORKS_API_KEY).toBeUndefined()
   })
 })
 

--- a/src/mcp/client.test.ts
+++ b/src/mcp/client.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+
+import type { McpServer } from '@/config/config'
+
+import { createMcpConnection, resolveServerEnv, type McpSdkClient } from './client'
+
+describe('resolveServerEnv', () => {
+  test('uses target env key before explicit secret env before secret value', () => {
+    const server: Pick<McpServer, 'env'> = {
+      env: {
+        TARGET_TOKEN: { env: 'SOURCE_TOKEN', value: 'from-file' },
+        SOURCE_ONLY: { env: 'SOURCE_ONLY_ENV', value: 'from-file-source' },
+        FILE_ONLY: { value: 'from-file-only' },
+      },
+    }
+
+    const resolved = resolveServerEnv(server, {
+      TARGET_TOKEN: 'from-target-env',
+      SOURCE_TOKEN: 'from-source-env',
+      SOURCE_ONLY_ENV: 'from-source-only-env',
+      PASSTHROUGH: 'kept',
+    })
+
+    expect(resolved.TARGET_TOKEN).toBe('from-target-env')
+    expect(resolved.SOURCE_ONLY).toBe('from-source-only-env')
+    expect(resolved.FILE_ONLY).toBe('from-file-only')
+    expect(resolved.PASSTHROUGH).toBe('kept')
+  })
+})
+
+describe('McpConnection', () => {
+  test('caches listed tools after the first catalog load', async () => {
+    let listCalls = 0
+    const callResult: CallToolResult = { content: [{ type: 'text', text: 'ok' }] }
+    const client: McpSdkClient = {
+      async listTools() {
+        listCalls += 1
+        return { tools: [{ name: 'first', inputSchema: { type: 'object' } }] }
+      },
+      async callTool() {
+        return callResult
+      },
+      async close() {},
+    }
+    const connection = createMcpConnection('server', client)
+
+    const first = await connection.listTools()
+    const second = await connection.listTools()
+
+    expect(first).toEqual([{ name: 'first', description: '', inputSchema: { type: 'object' } }])
+    expect(second).toBe(first)
+    expect(listCalls).toBe(1)
+  })
+})

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -204,9 +204,19 @@ function attachCloseCause(cause: unknown, closeCause: unknown): void {
   error.cause = { original: error.cause, close: closeCause }
 }
 
+// A stdio MCP server is a child process the agent spawns, so it must NOT
+// inherit the full parent environment: that env holds unrelated credentials
+// (FIREWORKS_API_KEY, GH_TOKEN, channel tokens) and inheriting them leaks every
+// secret to every server. We start from a minimal allowlist needed to spawn and
+// run a process (PATH/HOME to launch npx/bunx, locale + temp for correctness),
+// then overlay only the secrets the server explicitly declares. This mirrors
+// the bwrap sandbox's `--clearenv` + DEFAULT_SANDBOX_ENV leak guard.
+const BASE_ENV_ALLOWLIST = ['PATH', 'HOME', 'LANG', 'LC_ALL', 'TMPDIR', 'TZ'] as const
+
 export function resolveServerEnv(server: Pick<McpServer, 'env'>, env: NodeJS.ProcessEnv): Record<string, string> {
   const childEnv: Record<string, string> = {}
-  for (const [key, value] of Object.entries(env)) {
+  for (const key of BASE_ENV_ALLOWLIST) {
+    const value = env[key]
     if (value !== undefined) childEnv[key] = value
   }
 

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,0 +1,105 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { CallToolResultSchema, type CallToolResult, type ListToolsRequest } from '@modelcontextprotocol/sdk/types.js'
+
+import type { McpServer } from '@/config/config'
+import { resolveSecret } from '@/secrets/resolve'
+
+export type McpToolInfo = {
+  name: string
+  description: string
+  inputSchema: unknown
+}
+
+export type McpConnection = {
+  name: string
+  listTools(): Promise<McpToolInfo[]>
+  callTool(toolName: string, args?: Record<string, unknown>): Promise<CallToolResult>
+  close(): Promise<void>
+}
+
+export type McpSdkClient = {
+  listTools(params?: ListToolsRequest['params']): Promise<{
+    tools: { name: string; description?: string; inputSchema: unknown }[]
+    nextCursor?: string
+  }>
+  callTool(params: { name: string; arguments?: Record<string, unknown> }): Promise<CallToolResult>
+  close(): Promise<void>
+}
+
+export async function connectMcpServer(
+  server: McpServer,
+  opts: { env: NodeJS.ProcessEnv; signal?: AbortSignal },
+): Promise<McpConnection> {
+  const client = new Client({ name: 'typeclaw', version: '0.17.0' }, { capabilities: {} })
+  const transport = server.command
+    ? new StdioClientTransport({ command: server.command, args: server.args, env: resolveServerEnv(server, opts.env) })
+    : new StreamableHTTPClientTransport(new URL(requiredUrl(server)))
+
+  await client.connect(transport, { signal: opts.signal })
+
+  return createMcpConnection(server.name, {
+    listTools: (params) => client.listTools(params),
+    async callTool(params) {
+      const result = await client.callTool(params, CallToolResultSchema)
+      return CallToolResultSchema.parse(result)
+    },
+    close: () => client.close(),
+  })
+}
+
+export function createMcpConnection(name: string, client: McpSdkClient): McpConnection {
+  let cachedTools: McpToolInfo[] | undefined
+
+  return {
+    name,
+    async listTools(): Promise<McpToolInfo[]> {
+      if (cachedTools !== undefined) return cachedTools
+
+      const tools: McpToolInfo[] = []
+      let cursor: string | undefined
+      do {
+        const result = await client.listTools(cursor === undefined ? undefined : { cursor })
+        tools.push(
+          ...result.tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description ?? '',
+            inputSchema: tool.inputSchema,
+          })),
+        )
+        cursor = result.nextCursor
+      } while (cursor !== undefined)
+
+      cachedTools = tools
+      return cachedTools
+    },
+    callTool(toolName: string, args?: Record<string, unknown>): Promise<CallToolResult> {
+      return client.callTool({ name: toolName, arguments: args })
+    },
+    close(): Promise<void> {
+      return client.close()
+    },
+  }
+}
+
+export function resolveServerEnv(server: Pick<McpServer, 'env'>, env: NodeJS.ProcessEnv): Record<string, string> {
+  const childEnv: Record<string, string> = {}
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) childEnv[key] = value
+  }
+
+  for (const [key, secret] of Object.entries(server.env)) {
+    const explicitKeyValue = env[key]
+    const resolved =
+      explicitKeyValue !== undefined && explicitKeyValue !== '' ? explicitKeyValue : resolveSecret(secret, key, env)
+    if (resolved !== undefined) childEnv[key] = resolved
+  }
+
+  return childEnv
+}
+
+function requiredUrl(server: McpServer): string {
+  if (server.url !== undefined) return server.url
+  throw new Error(`MCP server "${server.name}" is missing url`)
+}

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,6 +1,8 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { CallToolResultSchema, type CallToolResult, type ListToolsRequest } from '@modelcontextprotocol/sdk/types.js'
 
 import type { McpServer } from '@/config/config'
@@ -12,75 +14,194 @@ export type McpToolInfo = {
   inputSchema: unknown
 }
 
+// The SDK defaults each request to 60s; typeclaw boot should fail fast enough
+// that one dead MCP server does not make the agent feel hung at startup.
+export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 30_000
+export const DEFAULT_MCP_CONNECT_TIMEOUT_MS = 15_000
+
 export type McpConnection = {
   name: string
   listTools(): Promise<McpToolInfo[]>
+  refresh(): Promise<McpToolInfo[]>
   callTool(toolName: string, args?: Record<string, unknown>): Promise<CallToolResult>
   close(): Promise<void>
 }
 
 export type McpSdkClient = {
-  listTools(params?: ListToolsRequest['params']): Promise<{
+  listTools(
+    params?: ListToolsRequest['params'],
+    options?: RequestOptions,
+  ): Promise<{
     tools: { name: string; description?: string; inputSchema: unknown }[]
     nextCursor?: string
   }>
-  callTool(params: { name: string; arguments?: Record<string, unknown> }): Promise<CallToolResult>
+  callTool(
+    params: { name: string; arguments?: Record<string, unknown> },
+    resultSchema?: typeof CallToolResultSchema,
+    options?: RequestOptions,
+  ): Promise<CallToolResult>
   close(): Promise<void>
+}
+
+type McpConnectClient = McpSdkClient & {
+  connect(transport: Transport, options?: RequestOptions): Promise<void>
 }
 
 export async function connectMcpServer(
   server: McpServer,
-  opts: { env: NodeJS.ProcessEnv; signal?: AbortSignal },
+  opts: {
+    env: NodeJS.ProcessEnv
+    signal?: AbortSignal
+    connectTimeoutMs?: number
+    client?: McpConnectClient
+    transport?: Transport
+  },
 ): Promise<McpConnection> {
-  const client = new Client({ name: 'typeclaw', version: '0.17.0' }, { capabilities: {} })
-  const transport = server.command
-    ? new StdioClientTransport({ command: server.command, args: server.args, env: resolveServerEnv(server, opts.env) })
-    : new StreamableHTTPClientTransport(new URL(requiredUrl(server)))
+  const requestTimeout = server.timeoutMs ?? DEFAULT_MCP_REQUEST_TIMEOUT_MS
+  const connectTimeout = opts.connectTimeoutMs ?? DEFAULT_MCP_CONNECT_TIMEOUT_MS
+  const client = opts.client ?? new Client({ name: 'typeclaw', version: '0.17.0' }, { capabilities: {} })
+  const transport = opts.transport ?? createTransport(server, opts.env)
 
-  await client.connect(transport, { signal: opts.signal })
+  try {
+    await withConnectDeadline(connectTimeout, opts.signal, (signal) =>
+      client.connect(transport, { signal, timeout: requestTimeout }),
+    )
+  } catch (cause) {
+    try {
+      await client.close()
+    } catch (closeCause) {
+      attachCloseCause(cause, closeCause)
+    }
+    throw cause
+  }
 
-  return createMcpConnection(server.name, {
-    listTools: (params) => client.listTools(params),
-    async callTool(params) {
-      const result = await client.callTool(params, CallToolResultSchema)
-      return CallToolResultSchema.parse(result)
+  return createMcpConnection(
+    server.name,
+    {
+      listTools: (params, options) => client.listTools(params, options),
+      async callTool(params, _resultSchema, options) {
+        const result = await client.callTool(params, CallToolResultSchema, options)
+        return CallToolResultSchema.parse(result)
+      },
+      close: () => client.close(),
     },
-    close: () => client.close(),
-  })
+    { timeoutMs: requestTimeout },
+  )
 }
 
-export function createMcpConnection(name: string, client: McpSdkClient): McpConnection {
+export function createMcpConnection(
+  name: string,
+  client: McpSdkClient,
+  opts: { timeoutMs?: number; signal?: AbortSignal } = {},
+): McpConnection {
   let cachedTools: McpToolInfo[] | undefined
+  const timeout = opts.timeoutMs ?? DEFAULT_MCP_REQUEST_TIMEOUT_MS
+
+  async function fetchTools(): Promise<McpToolInfo[]> {
+    const tools: McpToolInfo[] = []
+    let cursor: string | undefined
+    do {
+      const result = await client.listTools(cursor === undefined ? undefined : { cursor }, {
+        timeout,
+        signal: opts.signal,
+      })
+      tools.push(
+        ...result.tools.map((tool) => ({
+          name: tool.name,
+          description: tool.description ?? '',
+          inputSchema: tool.inputSchema,
+        })),
+      )
+      cursor = result.nextCursor
+    } while (cursor !== undefined)
+
+    cachedTools = tools
+    return cachedTools
+  }
 
   return {
     name,
     async listTools(): Promise<McpToolInfo[]> {
       if (cachedTools !== undefined) return cachedTools
-
-      const tools: McpToolInfo[] = []
-      let cursor: string | undefined
-      do {
-        const result = await client.listTools(cursor === undefined ? undefined : { cursor })
-        tools.push(
-          ...result.tools.map((tool) => ({
-            name: tool.name,
-            description: tool.description ?? '',
-            inputSchema: tool.inputSchema,
-          })),
-        )
-        cursor = result.nextCursor
-      } while (cursor !== undefined)
-
-      cachedTools = tools
-      return cachedTools
+      return fetchTools()
+    },
+    refresh(): Promise<McpToolInfo[]> {
+      cachedTools = undefined
+      return fetchTools()
     },
     callTool(toolName: string, args?: Record<string, unknown>): Promise<CallToolResult> {
-      return client.callTool({ name: toolName, arguments: args })
+      return client.callTool({ name: toolName, arguments: args }, CallToolResultSchema, {
+        timeout,
+        signal: opts.signal,
+      })
     },
     close(): Promise<void> {
       return client.close()
     },
   }
+}
+
+function createTransport(server: McpServer, env: NodeJS.ProcessEnv): Transport {
+  return server.command
+    ? new StdioClientTransport({ command: server.command, args: server.args, env: resolveServerEnv(server, env) })
+    : new StreamableHTTPClientTransport(new URL(requiredUrl(server)))
+}
+
+async function withConnectDeadline<T>(
+  timeoutMs: number,
+  parentSignal: AbortSignal | undefined,
+  fn: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const deadline = new AbortController()
+  const timer = setTimeout(() => deadline.abort(new Error('MCP connect timeout')), timeoutMs)
+  const merged = mergeSignals(parentSignal, deadline.signal)
+  const operation = fn(merged.signal)
+  let removeAbortListener = (): void => {}
+  const abort = new Promise<never>((_resolve, reject) => {
+    const onAbort = (): void => reject(merged.signal.reason)
+    removeAbortListener = (): void => merged.signal.removeEventListener('abort', onAbort)
+    if (merged.signal.aborted) onAbort()
+    else merged.signal.addEventListener('abort', onAbort, { once: true })
+  })
+  try {
+    return await Promise.race([operation, abort])
+  } finally {
+    clearTimeout(timer)
+    removeAbortListener()
+    if (merged.signal.aborted) void operation.catch(() => undefined)
+    merged.dispose()
+  }
+}
+
+function mergeSignals(...signals: (AbortSignal | undefined)[]): { signal: AbortSignal; dispose(): void } {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => signal !== undefined)
+  if (activeSignals.length === 0) return { signal: new AbortController().signal, dispose() {} }
+  if (activeSignals.length === 1) return { signal: activeSignals[0]!, dispose() {} }
+
+  const controller = new AbortController()
+  const listeners: (() => void)[] = []
+  for (const signal of activeSignals) {
+    const abort = (): void => controller.abort(signal.reason)
+    if (signal.aborted) {
+      abort()
+      break
+    }
+    signal.addEventListener('abort', abort, { once: true })
+    listeners.push(() => signal.removeEventListener('abort', abort))
+  }
+
+  return {
+    signal: controller.signal,
+    dispose() {
+      for (const remove of listeners) remove()
+    },
+  }
+}
+
+function attachCloseCause(cause: unknown, closeCause: unknown): void {
+  if (!(cause instanceof Error)) return
+  const error = cause as Error & { cause?: unknown }
+  error.cause = { original: error.cause, close: closeCause }
 }
 
 export function resolveServerEnv(server: Pick<McpServer, 'env'>, env: NodeJS.ProcessEnv): Record<string, string> {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,16 @@
+export {
+  connectMcpServer,
+  createMcpConnection,
+  resolveServerEnv,
+  type McpConnection,
+  type McpSdkClient,
+  type McpToolInfo,
+} from './client'
+export {
+  createMcpManager,
+  namespaceToolName,
+  parseNamespacedTool,
+  type ConnectMcpServerFn,
+  type McpConnectResult,
+  type McpManager,
+} from './manager'

--- a/src/mcp/manager.test.ts
+++ b/src/mcp/manager.test.ts
@@ -116,9 +116,38 @@ describe('createMcpManager', () => {
     await manager.connectAll()
     expect(manager.listServers()).toEqual([{ name: 'alpha', connected: true, toolCount: 1 }])
 
-    await manager.refresh()
+    const results = await manager.refresh()
 
+    expect(results).toEqual([{ ok: true, name: 'alpha', toolCount: 2 }])
     expect(manager.listServers()).toEqual([{ name: 'alpha', connected: true, toolCount: 2 }])
+  })
+
+  test('refresh isolates a failing connection so healthy servers still update', async () => {
+    const manager = createMcpManager([server('healthy'), server('broken')], {
+      env: {},
+      async connect(mcpServer) {
+        if (mcpServer.name === 'broken') return failingRefreshConnection(mcpServer.name)
+        return changingConnection(mcpServer.name)
+      },
+    })
+
+    await manager.connectAll()
+    expect(manager.listServers()).toEqual([
+      { name: 'healthy', connected: true, toolCount: 1 },
+      { name: 'broken', connected: true, toolCount: 1 },
+    ])
+
+    const results = await manager.refresh()
+
+    const healthy = results.find((result) => result.name === 'healthy')
+    const broken = results.find((result) => result.name === 'broken')
+    expect(healthy).toEqual({ ok: true, name: 'healthy', toolCount: 2 })
+    if (broken === undefined || broken.ok) throw new Error('expected the broken server to fail refresh')
+    expect(broken.error.message).toMatch(/refresh boom/)
+    expect(manager.listServers()).toEqual([
+      { name: 'healthy', connected: true, toolCount: 2 },
+      { name: 'broken', connected: true, toolCount: 1 },
+    ])
   })
 })
 
@@ -158,6 +187,22 @@ function changingConnection(name: string): McpConnection {
     name,
     listTools,
     refresh: listTools,
+    async callTool() {
+      return { content: [{ type: 'text', text: 'ok' }] }
+    },
+    async close() {},
+  }
+}
+
+function failingRefreshConnection(name: string): McpConnection {
+  return {
+    name,
+    async listTools() {
+      return [{ name: `${name}-tool`, description: '', inputSchema: {} }]
+    },
+    async refresh() {
+      throw new Error('refresh boom')
+    },
     async callTool() {
       return { content: [{ type: 'text', text: 'ok' }] }
     },

--- a/src/mcp/manager.test.ts
+++ b/src/mcp/manager.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { McpServer } from '@/config/config'
+
+import type { McpConnection, McpToolInfo } from './client'
+import { createMcpManager, namespaceToolName, parseNamespacedTool } from './manager'
+
+describe('MCP tool namespacing', () => {
+  test('round-trips tool names that contain the separator by splitting on the first separator', () => {
+    const namespaced = namespaceToolName('filesystem', 'read__file')
+
+    expect(namespaced).toBe('filesystem__read__file')
+    expect(parseNamespacedTool(namespaced)).toEqual({ server: 'filesystem', tool: 'read__file' })
+  })
+
+  test('rejects names without both sides of the separator', () => {
+    expect(parseNamespacedTool('plain')).toBeUndefined()
+    expect(parseNamespacedTool('__tool')).toBeUndefined()
+    expect(parseNamespacedTool('server__')).toBeUndefined()
+  })
+})
+
+describe('createMcpManager', () => {
+  test('keeps healthy servers connected when one server fails and closes every open connection', async () => {
+    const closed: string[] = []
+    const servers: McpServer[] = [server('alpha'), server('broken'), server('gamma')]
+    const manager = createMcpManager(servers, {
+      env: {},
+      async connect(mcpServer) {
+        if (mcpServer.name === 'broken') throw new Error('cannot connect')
+        return fakeConnection(
+          mcpServer.name,
+          [{ name: `${mcpServer.name}-tool`, description: '', inputSchema: {} }],
+          closed,
+        )
+      },
+    })
+
+    const results = await manager.connectAll()
+
+    expect(results.map((result) => ({ name: result.name, ok: result.ok }))).toEqual([
+      { name: 'alpha', ok: true },
+      { name: 'broken', ok: false },
+      { name: 'gamma', ok: true },
+    ])
+    expect(manager.getConnection('alpha')?.name).toBe('alpha')
+    expect(manager.getConnection('broken')).toBeUndefined()
+    expect(manager.listServers()).toEqual([
+      { name: 'alpha', connected: true, toolCount: 1 },
+      { name: 'broken', connected: false },
+      { name: 'gamma', connected: true, toolCount: 1 },
+    ])
+
+    await manager.closeAll()
+
+    expect(closed.sort()).toEqual(['alpha', 'gamma'])
+    expect(manager.listServers()).toEqual([
+      { name: 'alpha', connected: false },
+      { name: 'broken', connected: false },
+      { name: 'gamma', connected: false },
+    ])
+  })
+})
+
+function server(name: string): McpServer {
+  return { name, command: 'server-command', args: [], env: {} }
+}
+
+function fakeConnection(name: string, tools: McpToolInfo[], closed: string[]): McpConnection {
+  return {
+    name,
+    async listTools() {
+      return tools
+    },
+    async callTool() {
+      return { content: [{ type: 'text', text: 'ok' }] }
+    },
+    async close() {
+      closed.push(name)
+    },
+  }
+}

--- a/src/mcp/manager.test.ts
+++ b/src/mcp/manager.test.ts
@@ -60,6 +60,38 @@ describe('createMcpManager', () => {
       { name: 'gamma', connected: false },
     ])
   })
+
+  test('threads an abort signal to each connector', async () => {
+    const signals: (AbortSignal | undefined)[] = []
+    const abort = new AbortController()
+    const manager = createMcpManager([server('alpha'), server('gamma')], {
+      env: {},
+      async connect(mcpServer, opts) {
+        signals.push(opts.signal)
+        return fakeConnection(mcpServer.name, [], [])
+      },
+    })
+
+    await manager.connectAll({ signal: abort.signal })
+
+    expect(signals).toEqual([abort.signal, abort.signal])
+  })
+
+  test('refresh updates cached tool counts from live connections', async () => {
+    const manager = createMcpManager([server('alpha')], {
+      env: {},
+      async connect(mcpServer) {
+        return changingConnection(mcpServer.name)
+      },
+    })
+
+    await manager.connectAll()
+    expect(manager.listServers()).toEqual([{ name: 'alpha', connected: true, toolCount: 1 }])
+
+    await manager.refresh()
+
+    expect(manager.listServers()).toEqual([{ name: 'alpha', connected: true, toolCount: 2 }])
+  })
 })
 
 function server(name: string): McpServer {
@@ -72,11 +104,35 @@ function fakeConnection(name: string, tools: McpToolInfo[], closed: string[]): M
     async listTools() {
       return tools
     },
+    async refresh() {
+      return tools
+    },
     async callTool() {
       return { content: [{ type: 'text', text: 'ok' }] }
     },
     async close() {
       closed.push(name)
     },
+  }
+}
+
+function changingConnection(name: string): McpConnection {
+  let calls = 0
+  const listTools = async (): Promise<McpToolInfo[]> => {
+    calls += 1
+    return Array.from({ length: calls }, (_value, index) => ({
+      name: `tool-${index}`,
+      description: '',
+      inputSchema: {},
+    }))
+  }
+  return {
+    name,
+    listTools,
+    refresh: listTools,
+    async callTool() {
+      return { content: [{ type: 'text', text: 'ok' }] }
+    },
+    async close() {},
   }
 }

--- a/src/mcp/manager.test.ts
+++ b/src/mcp/manager.test.ts
@@ -77,6 +77,34 @@ describe('createMcpManager', () => {
     expect(signals).toEqual([abort.signal, abort.signal])
   })
 
+  test('fails a duplicate server name fast instead of shadowing the first connection', async () => {
+    const connectCalls: string[] = []
+    const manager = createMcpManager([server('dup'), server('dup'), server('other')], {
+      env: {},
+      async connect(mcpServer) {
+        connectCalls.push(mcpServer.name)
+        return fakeConnection(
+          mcpServer.name,
+          [{ name: `${mcpServer.name}-tool`, description: '', inputSchema: {} }],
+          [],
+        )
+      },
+    })
+
+    const results = await manager.connectAll()
+
+    expect(results.map((result) => ({ name: result.name, ok: result.ok }))).toEqual([
+      { name: 'dup', ok: true },
+      { name: 'dup', ok: false },
+      { name: 'other', ok: true },
+    ])
+    const duplicate = results[1]
+    if (duplicate === undefined || duplicate.ok) throw new Error('expected the second server to fail as a duplicate')
+    expect(duplicate.error.message).toMatch(/mcpServers\[1\]\.name duplicates mcpServers\[0\]\.name/)
+    expect(connectCalls).toEqual(['dup', 'other'])
+    expect(manager.getConnection('dup')?.name).toBe('dup')
+  })
+
   test('refresh updates cached tool counts from live connections', async () => {
     const manager = createMcpManager([server('alpha')], {
       env: {},

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -1,0 +1,110 @@
+import type { McpServer } from '@/config/config'
+
+import { connectMcpServer, type McpConnection } from './client'
+
+const TOOL_NAMESPACE_SEPARATOR = '__'
+
+export type McpConnectResult =
+  | { ok: true; name: string; connection: McpConnection; toolCount: number }
+  | { ok: false; name: string; error: Error }
+
+export type McpManager = {
+  connectAll(): Promise<McpConnectResult[]>
+  getConnection(name: string): McpConnection | undefined
+  listServers(): { name: string; description?: string; connected: boolean; toolCount?: number }[]
+  closeAll(): Promise<void>
+}
+
+export type ConnectMcpServerFn = (server: McpServer, opts: { env: NodeJS.ProcessEnv }) => Promise<McpConnection>
+
+export function createMcpManager(
+  servers: McpServer[],
+  opts: { env: NodeJS.ProcessEnv; connect?: ConnectMcpServerFn },
+): McpManager {
+  const connect = opts.connect ?? connectMcpServer
+  const connections = new Map<string, McpConnection>()
+  const toolCounts = new Map<string, number>()
+
+  return {
+    async connectAll(): Promise<McpConnectResult[]> {
+      const results = await Promise.all(servers.map((server) => connectOne(server, opts.env, connect)))
+      for (const result of results) {
+        if (!result.ok) continue
+        connections.set(result.name, result.connection)
+        toolCounts.set(result.name, result.toolCount)
+      }
+      return results
+    },
+    getConnection(name: string): McpConnection | undefined {
+      return connections.get(name)
+    },
+    listServers(): { name: string; description?: string; connected: boolean; toolCount?: number }[] {
+      return servers.map((server) => {
+        const toolCount = toolCounts.get(server.name)
+        return {
+          name: server.name,
+          connected: connections.has(server.name),
+          ...(toolCount === undefined ? {} : { toolCount }),
+        }
+      })
+    },
+    async closeAll(): Promise<void> {
+      await Promise.allSettled([...connections.values()].map((connection) => connection.close()))
+      connections.clear()
+      toolCounts.clear()
+    },
+  }
+}
+
+export function namespaceToolName(server: string, tool: string): string {
+  return `${server}${TOOL_NAMESPACE_SEPARATOR}${tool}`
+}
+
+export function parseNamespacedTool(namespaced: string): { server: string; tool: string } | undefined {
+  const separatorIndex = namespaced.indexOf(TOOL_NAMESPACE_SEPARATOR)
+  if (separatorIndex <= 0) return undefined
+
+  const toolStart = separatorIndex + TOOL_NAMESPACE_SEPARATOR.length
+  if (toolStart >= namespaced.length) return undefined
+
+  return { server: namespaced.slice(0, separatorIndex), tool: namespaced.slice(toolStart) }
+}
+
+async function connectOne(
+  server: McpServer,
+  env: NodeJS.ProcessEnv,
+  connect: ConnectMcpServerFn,
+): Promise<McpConnectResult> {
+  let connection: McpConnection | undefined
+  try {
+    connection = await connect(server, { env })
+    const tools = await connection.listTools()
+    return { ok: true, name: server.name, connection, toolCount: tools.length }
+  } catch (cause) {
+    const closeError = connection === undefined ? undefined : await closeAfterFailedCatalog(connection)
+    if (closeError !== undefined) {
+      return {
+        ok: false,
+        name: server.name,
+        error: new Error(`MCP server "${server.name}" failed to connect and then failed to close`, {
+          cause: { original: cause, close: closeError },
+        }),
+      }
+    }
+    return { ok: false, name: server.name, error: normalizeError(cause) }
+  }
+}
+
+async function closeAfterFailedCatalog(connection: McpConnection): Promise<Error | undefined> {
+  try {
+    await connection.close()
+    return undefined
+  } catch (cause) {
+    return normalizeError(cause)
+  }
+}
+
+function normalizeError(cause: unknown): Error {
+  if (cause instanceof Error) return cause
+  return new Error(String(cause))
+}

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -31,8 +31,25 @@ export function createMcpManager(
 
   return {
     async connectAll(connectOpts: { signal?: AbortSignal } = {}): Promise<McpConnectResult[]> {
+      const firstIndexByName = new Map<string, number>()
       const results = await Promise.all(
-        servers.map((server) => connectOne(server, opts.env, connect, connectOpts.signal)),
+        servers.map((server, index): Promise<McpConnectResult> => {
+          // The name is the tool namespace and the connections key, so a second
+          // server sharing a name would silently shadow the first. Fail the
+          // duplicate fast instead of connecting it, keeping routing unambiguous.
+          const firstIndex = firstIndexByName.get(server.name)
+          if (firstIndex !== undefined) {
+            return Promise.resolve({
+              ok: false,
+              name: server.name,
+              error: new Error(
+                `mcpServers[${index}].name duplicates mcpServers[${firstIndex}].name ('${server.name}')`,
+              ),
+            })
+          }
+          firstIndexByName.set(server.name, index)
+          return connectOne(server, opts.env, connect, connectOpts.signal)
+        }),
       )
       for (const result of results) {
         if (!result.ok) continue

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -9,13 +9,17 @@ export type McpConnectResult =
   | { ok: false; name: string; error: Error }
 
 export type McpManager = {
-  connectAll(): Promise<McpConnectResult[]>
+  connectAll(opts?: { signal?: AbortSignal }): Promise<McpConnectResult[]>
   getConnection(name: string): McpConnection | undefined
   listServers(): { name: string; description?: string; connected: boolean; toolCount?: number }[]
+  refresh(): Promise<void>
   closeAll(): Promise<void>
 }
 
-export type ConnectMcpServerFn = (server: McpServer, opts: { env: NodeJS.ProcessEnv }) => Promise<McpConnection>
+export type ConnectMcpServerFn = (
+  server: McpServer,
+  opts: { env: NodeJS.ProcessEnv; signal?: AbortSignal },
+) => Promise<McpConnection>
 
 export function createMcpManager(
   servers: McpServer[],
@@ -26,8 +30,10 @@ export function createMcpManager(
   const toolCounts = new Map<string, number>()
 
   return {
-    async connectAll(): Promise<McpConnectResult[]> {
-      const results = await Promise.all(servers.map((server) => connectOne(server, opts.env, connect)))
+    async connectAll(connectOpts: { signal?: AbortSignal } = {}): Promise<McpConnectResult[]> {
+      const results = await Promise.all(
+        servers.map((server) => connectOne(server, opts.env, connect, connectOpts.signal)),
+      )
       for (const result of results) {
         if (!result.ok) continue
         connections.set(result.name, result.connection)
@@ -48,6 +54,12 @@ export function createMcpManager(
         }
       })
     },
+    async refresh(): Promise<void> {
+      const refreshed = await Promise.all(
+        [...connections.entries()].map(async ([name, connection]) => [name, await connection.refresh()] as const),
+      )
+      for (const [name, tools] of refreshed) toolCounts.set(name, tools.length)
+    },
     async closeAll(): Promise<void> {
       await Promise.allSettled([...connections.values()].map((connection) => connection.close()))
       connections.clear()
@@ -61,6 +73,8 @@ export function namespaceToolName(server: string, tool: string): string {
 }
 
 export function parseNamespacedTool(namespaced: string): { server: string; tool: string } | undefined {
+  // Config validation reserves `__` out of server names; splitting on the first
+  // separator is therefore unambiguous even when MCP tool names contain it.
   const separatorIndex = namespaced.indexOf(TOOL_NAMESPACE_SEPARATOR)
   if (separatorIndex <= 0) return undefined
 
@@ -74,10 +88,11 @@ async function connectOne(
   server: McpServer,
   env: NodeJS.ProcessEnv,
   connect: ConnectMcpServerFn,
+  signal: AbortSignal | undefined,
 ): Promise<McpConnectResult> {
   let connection: McpConnection | undefined
   try {
-    connection = await connect(server, { env })
+    connection = await connect(server, { env, signal })
     const tools = await connection.listTools()
     return { ok: true, name: server.name, connection, toolCount: tools.length }
   } catch (cause) {

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -8,11 +8,13 @@ export type McpConnectResult =
   | { ok: true; name: string; connection: McpConnection; toolCount: number }
   | { ok: false; name: string; error: Error }
 
+export type McpRefreshResult = { ok: true; name: string; toolCount: number } | { ok: false; name: string; error: Error }
+
 export type McpManager = {
   connectAll(opts?: { signal?: AbortSignal }): Promise<McpConnectResult[]>
   getConnection(name: string): McpConnection | undefined
   listServers(): { name: string; description?: string; connected: boolean; toolCount?: number }[]
-  refresh(): Promise<void>
+  refresh(): Promise<McpRefreshResult[]>
   closeAll(): Promise<void>
 }
 
@@ -71,11 +73,21 @@ export function createMcpManager(
         }
       })
     },
-    async refresh(): Promise<void> {
-      const refreshed = await Promise.all(
-        [...connections.entries()].map(async ([name, connection]) => [name, await connection.refresh()] as const),
+    async refresh(): Promise<McpRefreshResult[]> {
+      // One unhealthy connection must not discard healthy servers' tool-count
+      // updates, so each refresh is isolated and reported per-server instead of
+      // letting a single rejection fail the whole batch.
+      return Promise.all(
+        [...connections.entries()].map(async ([name, connection]): Promise<McpRefreshResult> => {
+          try {
+            const tools = await connection.refresh()
+            toolCounts.set(name, tools.length)
+            return { ok: true, name, toolCount: tools.length }
+          } catch (cause) {
+            return { ok: false, name, error: normalizeError(cause) }
+          }
+        }),
       )
-      for (const [name, tools] of refreshed) toolCounts.set(name, tools.length)
     },
     async closeAll(): Promise<void> {
       await Promise.allSettled([...connections.values()].map((connection) => connection.close()))


### PR DESCRIPTION
Stacked on #522 — review/merge in order.

## Background

PR #522 lets users declare servers in `typeclaw.json`; this PR makes typeclaw actually connect to them. Pure plumbing — no agent wiring yet.

## Summary

New `src/mcp/` module built on the official `@modelcontextprotocol/sdk` (v1.29.0, Bun-compatible). Key design decisions:

**`connectMcpServer`** picks transport by config shape (stdio vs Streamable HTTP) and resolves stdio `env` through the existing env-wins secret resolver. No new credential path.

**`createMcpManager`** is a multi-server pool with two deliberate resilience properties:
- `connectAll()` collects per-server ok/error results so ONE broken server degrades gracefully rather than crashing the pool.
- `closeAll()` closes every connection even if some throw (`Promise.allSettled`) — shutdown is best-effort, not all-or-nothing.

**Tool namespacing** is a pair of pure helpers, `namespaceToolName`/`parseNamespacedTool`, that encode/decode `<server>__<tool>` by splitting on the first `__`. Keeping this logic pure and separate makes the dispatcher in PR3 easy to test in isolation.

**`listTools()` is cached per connection.** Tools are enumerated once at connect time. This is intentional: the catalog rendered into the system prompt needs to be stable; re-enumerating mid-session would change the prompt without a restart.

**Why the official SDK and not a wrapper like MCPorter.** MCPorter's value is its editor-config import, human CLI, and own OAuth credential store — the wrong layer for a Dockerized autonomous runtime that already owns secrets. The SDK is the minimal controllable surface.

## What this does NOT do

No dispatcher tools, no system-prompt catalog, no session wiring — that's PR3. Tests use hand-rolled fakes and a DI'd connect seam; no real MCP servers are spawned.

## Review notes

The load-bearing contract is graceful degradation. Verify the per-server error isolation test: `connectAll` with one server that rejects should resolve (not reject), with the other servers' connections intact.