### PR TITLE
Add MCP dispatcher tools and per-server prompt catalog

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -274,6 +274,25 @@ describe('createResourceLoader', () => {
     expect(prompt).not.toContain('Session started at')
   })
 
+  test('composeSystemPrompt places MCP catalog after origin and before memory', () => {
+    const catalog = '## MCP servers\n\n- files (2 tools): Filesystem tools'
+    const prompt = composeSystemPrompt({
+      self: '# Identity\n\nfoo',
+      origin: { kind: 'tui', sessionId: 'ses_test' },
+      mcpCatalog: catalog,
+      gitNudge: '',
+      memorySection: '## Memory\n\nmemory-marker',
+    })
+
+    const originIndex = prompt.indexOf('## Session origin')
+    const catalogIndex = prompt.indexOf(catalog)
+    const memoryIndex = prompt.indexOf('memory-marker')
+
+    expect(originIndex).toBeGreaterThan(-1)
+    expect(catalogIndex).toBeGreaterThan(originIndex)
+    expect(memoryIndex).toBeGreaterThan(catalogIndex)
+  })
+
   test('memory section is NOT visible to plugin session.prompt hooks (intentional: memory injection is core-owned and runs after all plugin hooks)', async () => {
     // The security plugin's applyPromptInjectionDefense scans `event.prompt`
     // for attack patterns during the session.prompt hook chain. After this PR

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -2,13 +2,21 @@ import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { createAgentSession, DefaultResourceLoader, SessionManager } from '@mariozechner/pi-coding-agent'
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  defineTool as definePiTool,
+  SessionManager,
+} from '@mariozechner/pi-coding-agent'
 import type { AgentSession, ToolDefinition } from '@mariozechner/pi-coding-agent'
 
 import { loadMemory } from '@/bundled-plugins/memory/load-memory'
 import type { ChannelRouter } from '@/channels/router'
 import { getConfig, resolveModel, resolveProfile } from '@/config'
 import { defaultThinkingLevelForRef, providerForModelRef, type KnownModelRef } from '@/config/providers'
+import { renderMcpCatalog } from '@/mcp/catalog'
+import type { McpManager } from '@/mcp/manager'
+import { createMcpDispatcherTools, MCP_DISPATCHER_TOOL_NAMES } from '@/mcp/tools'
 import type { PermissionService, RolesConfig } from '@/permissions'
 import type {
   BuiltinToolRef,
@@ -34,6 +42,7 @@ import {
   wrapPluginTool,
   wrapSystemAgentTool,
   wrapSystemTool,
+  zodToToolParameters,
 } from './plugin-tools'
 import { createReloadTool } from './reload-tool'
 import { loadSelf } from './self'
@@ -98,6 +107,7 @@ export type CreateSessionOptions = {
   sessionManager?: SessionManager
   stream?: Stream
   channelRouter?: ChannelRouter
+  mcpManager?: McpManager
   // Bypass the file-based resource loader (IDENTITY.md, SOUL.md, MEMORY.md,
   // memory/, bundled skills) and use this string verbatim as the system prompt.
   systemPromptOverride?: string
@@ -232,6 +242,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
           ...(options.origin ? { origin: options.origin } : {}),
           ...(options.permissions ? { permissions: options.permissions } : {}),
           ...(options.runtimeVersion !== undefined ? { runtimeVersion: options.runtimeVersion } : {}),
+          ...(options.mcpManager !== undefined ? { mcpManager: options.mcpManager } : {}),
         })
 
   const getOrigin: () => SessionOrigin | undefined =
@@ -307,6 +318,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
             websearchTool,
             webfetchTool,
             lookAtTool,
+            ...(options.mcpManager ? buildMcpDispatcherToolDefinitions(options.mcpManager) : []),
             ...(options.reloadRegistry ? [createReloadTool({ registry: options.reloadRegistry })] : []),
             ...(options.stream ? [createStreamSnapshotTool({ stream: options.stream })] : []),
             ...buildChannelTools(options.channelRouter, options.origin, sessionManager.getSessionId()),
@@ -555,6 +567,40 @@ export function buildChannelTools(
   return tools
 }
 
+export function buildMcpDispatcherToolDefinitions(manager: McpManager): ToolDefinition[] {
+  const tools = createMcpDispatcherTools(manager)
+  return [
+    defineMcpDispatcherTool(MCP_DISPATCHER_TOOL_NAMES[0], tools[0]),
+    defineMcpDispatcherTool(MCP_DISPATCHER_TOOL_NAMES[1], tools[1]),
+    defineMcpDispatcherTool(MCP_DISPATCHER_TOOL_NAMES[2], tools[2]),
+  ]
+}
+
+function defineMcpDispatcherTool<P>(name: string, tool: PluginTool<P>): ToolDefinition {
+  return definePiTool({
+    name,
+    label: name,
+    description: tool.description,
+    parameters: zodToToolParameters(tool.parameters),
+    async execute(_toolCallId, params, signal) {
+      const validated = tool.parameters.safeParse(params)
+      if (!validated.success) {
+        return {
+          content: [{ type: 'text' as const, text: `invalid arguments: ${validated.error.message}` }],
+          details: null,
+        }
+      }
+      const result = await tool.execute(validated.data, {
+        signal,
+        sessionId: 'mcp-dispatcher',
+        agentDir: process.cwd(),
+        logger: { info() {}, warn() {}, error() {} },
+      })
+      return { content: result.content, details: result.details ?? null }
+    },
+  })
+}
+
 export function buildSubagentOrchestrationTools(opts: {
   liveRegistry: LiveSubagentRegistry | undefined
   registry: SubagentRegistry | undefined
@@ -722,6 +768,7 @@ export type CreateResourceLoaderOptions = {
   plugins?: PluginSessionWiring
   materializedSkills?: MaterializedSkills | null
   origin?: SessionOrigin
+  mcpManager?: McpManager
   permissions?: PermissionService
   runtimeVersion?: string
   // Explicit override for the prompt mode. When omitted, the mode is derived
@@ -785,6 +832,7 @@ export type SystemPromptComposition = {
   runtimeVersion?: string
   origin?: SessionOrigin
   roleContext?: SessionRoleContext
+  mcpCatalog?: string
   gitNudge: string
   memorySection: string
 }
@@ -821,6 +869,9 @@ export function composeSystemPrompt(parts: SystemPromptComposition): string {
   }
   if (parts.origin !== undefined) {
     prompt = `${prompt}\n\n${renderSessionOrigin(parts.origin, Date.now(), parts.roleContext)}`
+  }
+  if (parts.mcpCatalog !== undefined && parts.mcpCatalog !== '') {
+    prompt = `${prompt}\n\n${parts.mcpCatalog}`
   }
   if (parts.gitNudge !== '') {
     prompt = `${prompt}\n\n${parts.gitNudge}`
@@ -901,6 +952,9 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
     ...(options.runtimeVersion !== undefined ? { runtimeVersion: options.runtimeVersion } : {}),
     ...(options.origin !== undefined ? { origin: options.origin } : {}),
     ...(roleContext !== undefined ? { roleContext } : {}),
+    ...(mode === 'full' && options.mcpManager !== undefined
+      ? { mcpCatalog: renderMcpCatalog(options.mcpManager.listServers()) }
+      : {}),
     gitNudge,
     memorySection,
   })

--- a/src/mcp/catalog.test.ts
+++ b/src/mcp/catalog.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+
+import { renderMcpCatalog } from './catalog'
+
+describe('renderMcpCatalog', () => {
+  test('returns an empty string when there are no connected MCP servers', () => {
+    expect(renderMcpCatalog([])).toBe('')
+    expect(renderMcpCatalog([{ name: 'failed', connected: false, toolCount: 3 }])).toBe('')
+  })
+
+  test('renders connected servers with tool counts and descriptions', () => {
+    const catalog = renderMcpCatalog([
+      { name: 'files', description: 'Filesystem tools', connected: true, toolCount: 2 },
+      { name: 'git', connected: true, toolCount: 1 },
+    ])
+
+    expect(catalog).toContain('## MCP servers')
+    expect(catalog).toContain('- files (2 tools): Filesystem tools')
+    expect(catalog).toContain('- git (1 tools): no description')
+    expect(catalog).toContain('mcp_list_tools(server)')
+  })
+
+  test('does not advertise disconnected servers', () => {
+    const catalog = renderMcpCatalog([
+      { name: 'files', connected: true, toolCount: 2 },
+      { name: 'broken', description: 'Unavailable', connected: false, toolCount: 9 },
+    ])
+
+    expect(catalog).toContain('files')
+    expect(catalog).not.toContain('broken')
+  })
+})

--- a/src/mcp/catalog.ts
+++ b/src/mcp/catalog.ts
@@ -15,8 +15,9 @@ export function renderMcpCatalog(servers: McpCatalogServer[]): string {
     return `- ${server.name} (${toolCount} tools): ${description}`
   })
 
-  // WHY: this catalog is inserted in the cacheable stable prompt region and is
-  // omitted when empty so agents without MCP keep byte-identical prompts.
+  // WHY: this catalog is boot-stable for prompt-cache locality; MCP
+  // tools/list_changed notifications are intentionally not reflected here until
+  // the manager refresh path is invoked or the session restarts.
   return [
     '## MCP servers',
     '',

--- a/src/mcp/catalog.ts
+++ b/src/mcp/catalog.ts
@@ -1,0 +1,28 @@
+export type McpCatalogServer = {
+  name: string
+  description?: string
+  connected: boolean
+  toolCount?: number
+}
+
+export function renderMcpCatalog(servers: McpCatalogServer[]): string {
+  const connected = servers.filter((server) => server.connected)
+  if (connected.length === 0) return ''
+
+  const lines = connected.map((server) => {
+    const toolCount = server.toolCount ?? 0
+    const description = server.description?.trim() ? server.description.trim() : 'no description'
+    return `- ${server.name} (${toolCount} tools): ${description}`
+  })
+
+  // WHY: this catalog is inserted in the cacheable stable prompt region and is
+  // omitted when empty so agents without MCP keep byte-identical prompts.
+  return [
+    '## MCP servers',
+    '',
+    'The following MCP servers are connected. Each exposes tools you can discover and call:',
+    ...lines,
+    '',
+    "Use `mcp_list_tools(server)` to see a server's tools, `mcp_describe(server, tool)` for a tool's input schema, and `mcp_call(server, tool, args)` to invoke it.",
+  ].join('\n')
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -14,3 +14,12 @@ export {
   type McpConnectResult,
   type McpManager,
 } from './manager'
+export { renderMcpCatalog, type McpCatalogServer } from './catalog'
+export {
+  createMcpDispatcherTools,
+  MCP_DISPATCHER_TOOL_NAMES,
+  type McpCallArgs,
+  type McpDescribeArgs,
+  type McpDispatcherTool,
+  type McpListToolsArgs,
+} from './tools'

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -69,6 +69,7 @@ export function createMcpManager(
         return {
           name: server.name,
           connected: connections.has(server.name),
+          ...(server.description === undefined ? {} : { description: server.description }),
           ...(toolCount === undefined ? {} : { toolCount }),
         }
       })

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -6,7 +6,13 @@ import type { ToolContext } from '@/plugin/types'
 
 import type { McpConnection, McpToolInfo } from './client'
 import type { McpManager } from './manager'
-import { createMcpDispatcherTools, type McpCallArgs, type McpDescribeArgs, type McpListToolsArgs } from './tools'
+import {
+  createMcpDispatcherTools,
+  sanitizeMcpError,
+  type McpCallArgs,
+  type McpDescribeArgs,
+  type McpListToolsArgs,
+} from './tools'
 
 describe('createMcpDispatcherTools', () => {
   test('mcp_list_tools returns namespaced tool names and descriptions', async () => {
@@ -82,6 +88,40 @@ describe('createMcpDispatcherTools', () => {
     })
   })
 
+  test('mcp_call preserves text and image content together', async () => {
+    const manager = fakeManager({
+      files: fakeConnection('files', [], {
+        content: [
+          { type: 'text', text: 'caption' },
+          { type: 'image', mimeType: 'image/png', data: 'base64-image' },
+        ],
+      }),
+    })
+    const [, , callTool] = createMcpDispatcherTools(manager)
+
+    const result = await callTool.execute({ server: 'files', tool: 'screenshot' } satisfies McpCallArgs, toolContext())
+
+    expect(result.content).toEqual([
+      { type: 'text', text: 'caption' },
+      { type: 'image', mimeType: 'image/png', data: 'base64-image' },
+    ])
+  })
+
+  test('mcp_call emits summaries for unrepresentable embedded resources', async () => {
+    const manager = fakeManager({
+      files: fakeConnection('files', [], {
+        content: [
+          { type: 'resource', resource: { uri: 'file:///report.pdf', mimeType: 'application/pdf', text: 'pdf' } },
+        ],
+      }),
+    })
+    const [, , callTool] = createMcpDispatcherTools(manager)
+
+    const result = await callTool.execute({ server: 'files', tool: 'read' } satisfies McpCallArgs, toolContext())
+
+    expect(result.content).toEqual([{ type: 'text', text: '[mcp:resource file:///report.pdf]' }])
+  })
+
   test('mcp_call surfaces SDK error results as text instead of throwing', async () => {
     const manager = fakeManager({
       files: fakeConnection('files', [], { content: [{ type: 'text', text: 'permission denied' }], isError: true }),
@@ -94,6 +134,38 @@ describe('createMcpDispatcherTools', () => {
       content: [{ type: 'text', text: 'MCP tool error: permission denied' }],
       details: { server: 'files', tool: 'read', isError: true },
     })
+  })
+
+  test('mcp_call sanitizes SDK error result text before surfacing it', async () => {
+    const manager = fakeManager({
+      files: fakeConnection('files', [], {
+        content: [{ type: 'text', text: 'failed at /private/tmp/secret.txt with API_KEY=shh' }],
+        isError: true,
+      }),
+    })
+    const [, , callTool] = createMcpDispatcherTools(manager)
+
+    const result = await callTool.execute({ server: 'files', tool: 'read' } satisfies McpCallArgs, toolContext())
+
+    expect(result.content).toEqual([{ type: 'text', text: 'MCP tool error: failed at <path> with API_KEY=<redacted>' }])
+  })
+})
+
+describe('sanitizeMcpError', () => {
+  test('leaves normal short messages intact', () => {
+    expect(sanitizeMcpError('permission denied')).toBe('permission denied')
+  })
+
+  test('truncates long messages', () => {
+    expect(sanitizeMcpError('x'.repeat(600))).toHaveLength(500)
+    expect(sanitizeMcpError('x'.repeat(600))).toEndWith('...')
+  })
+
+  test('redacts absolute paths and env-style assignments', () => {
+    expect(sanitizeMcpError('failed at /tmp/agent/secrets.txt with TOKEN=secret')).toBe(
+      'failed at <path> with TOKEN=<redacted>',
+    )
+    expect(sanitizeMcpError('failed at C:\\agent\\secrets.txt')).toBe('failed at <path>')
   })
 })
 
@@ -124,6 +196,9 @@ function fakeConnection(name: string, tools: McpToolInfo[], result?: CallToolRes
   return {
     name,
     async listTools() {
+      return tools
+    },
+    async refresh() {
       return tools
     },
     async callTool() {

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+
+import type { ToolContext } from '@/plugin/types'
+
+import type { McpConnection, McpToolInfo } from './client'
+import type { McpManager } from './manager'
+import { createMcpDispatcherTools, type McpCallArgs, type McpDescribeArgs, type McpListToolsArgs } from './tools'
+
+describe('createMcpDispatcherTools', () => {
+  test('mcp_list_tools returns namespaced tool names and descriptions', async () => {
+    const manager = fakeManager({
+      files: fakeConnection('files', [
+        { name: 'read', description: 'Read a file', inputSchema: { type: 'object' } },
+        { name: 'write', description: '', inputSchema: { type: 'object' } },
+      ]),
+    })
+    const [listTools] = createMcpDispatcherTools(manager)
+
+    const result = await listTools.execute({ server: 'files' } satisfies McpListToolsArgs, toolContext())
+
+    expect(result.content).toEqual([
+      {
+        type: 'text',
+        text: 'Tools for MCP server "files":\n- files__read — Read a file\n- files__write — no description',
+      },
+    ])
+  })
+
+  test('mcp_list_tools reports unknown servers with available server names', async () => {
+    const manager = fakeManager({ files: fakeConnection('files', []) })
+    const [listTools] = createMcpDispatcherTools(manager)
+
+    const result = await listTools.execute({ server: 'missing' } satisfies McpListToolsArgs, toolContext())
+
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: 'Unknown MCP server "missing". Available servers: files.',
+    })
+  })
+
+  test('mcp_describe returns inputSchema JSON for bare and namespaced tool ids', async () => {
+    const manager = fakeManager({
+      files: fakeConnection('files', [
+        {
+          name: 'read',
+          description: 'Read a file',
+          inputSchema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+        },
+      ]),
+    })
+    const [, describeTool] = createMcpDispatcherTools(manager)
+
+    const bare = await describeTool.execute({ server: 'files', tool: 'read' } satisfies McpDescribeArgs, toolContext())
+    const namespaced = await describeTool.execute(
+      { server: 'ignored', tool: 'files__read' } satisfies McpDescribeArgs,
+      toolContext(),
+    )
+
+    const text = expectText(bare.content[0])
+    expect(text).toContain('MCP tool files__read')
+    expect(text).toContain('Description: Read a file')
+    expect(text).toContain('"path": {')
+    expect(namespaced).toEqual(bare)
+  })
+
+  test('mcp_call maps text results and includes call details', async () => {
+    const manager = fakeManager({
+      files: fakeConnection('files', [], { content: [{ type: 'text', text: 'file contents' }] }),
+    })
+    const [, , callTool] = createMcpDispatcherTools(manager)
+
+    const result = await callTool.execute(
+      { server: 'files', tool: 'read', args: { path: 'README.md' } } satisfies McpCallArgs,
+      toolContext(),
+    )
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'file contents' }],
+      details: { server: 'files', tool: 'read', isError: false },
+    })
+  })
+
+  test('mcp_call surfaces SDK error results as text instead of throwing', async () => {
+    const manager = fakeManager({
+      files: fakeConnection('files', [], { content: [{ type: 'text', text: 'permission denied' }], isError: true }),
+    })
+    const [, , callTool] = createMcpDispatcherTools(manager)
+
+    const result = await callTool.execute({ server: 'files', tool: 'read' } satisfies McpCallArgs, toolContext())
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'MCP tool error: permission denied' }],
+      details: { server: 'files', tool: 'read', isError: true },
+    })
+  })
+})
+
+function fakeManager(connections: Record<string, McpConnection>): McpManager {
+  return {
+    async connectAll() {
+      return Object.entries(connections).map(([name, connection]) => ({
+        ok: true as const,
+        name,
+        connection,
+        toolCount: 0,
+      }))
+    },
+    getConnection(name) {
+      return connections[name]
+    },
+    listServers() {
+      return Object.keys(connections).map((name) => ({ name, connected: true, toolCount: 0 }))
+    },
+    async refresh() {
+      return Object.keys(connections).map((name) => ({ ok: true as const, name, toolCount: 0 }))
+    },
+    async closeAll() {},
+  }
+}
+
+function fakeConnection(name: string, tools: McpToolInfo[], result?: CallToolResult): McpConnection {
+  return {
+    name,
+    async listTools() {
+      return tools
+    },
+    async callTool() {
+      return result ?? { content: [{ type: 'text', text: 'ok' }] }
+    },
+    async close() {},
+  }
+}
+
+function toolContext(): ToolContext {
+  return {
+    signal: undefined,
+    sessionId: 'ses_test',
+    agentDir: '/agent',
+    logger: { info() {}, warn() {}, error() {} },
+  }
+}
+
+function expectText(
+  part: { type: 'text'; text: string } | { type: 'image'; mimeType: string; data: string } | undefined,
+): string {
+  expect(part?.type).toBe('text')
+  if (part?.type !== 'text') throw new Error('expected text content')
+  return part.text
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,0 +1,134 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+
+import { defineTool } from '@/plugin/define'
+import type { ContentPart, Tool, ToolResult } from '@/plugin/types'
+
+import type { McpManager } from './manager'
+import { namespaceToolName, parseNamespacedTool } from './manager'
+
+export const MCP_DISPATCHER_TOOL_NAMES = ['mcp_list_tools', 'mcp_describe', 'mcp_call'] as const
+
+export type McpListToolsArgs = { server: string }
+export type McpDescribeArgs = { server: string; tool: string }
+export type McpCallArgs = { server: string; tool: string; args?: Record<string, unknown> }
+export type McpDispatcherTool = Tool<McpListToolsArgs> | Tool<McpDescribeArgs> | Tool<McpCallArgs>
+export type McpDispatcherTools = [Tool<McpListToolsArgs>, Tool<McpDescribeArgs>, Tool<McpCallArgs>]
+
+export function createMcpDispatcherTools(manager: McpManager): McpDispatcherTools {
+  return [createListToolsTool(manager), createDescribeTool(manager), createCallTool(manager)]
+}
+
+function createListToolsTool(manager: McpManager): Tool<McpListToolsArgs> {
+  return defineTool<McpListToolsArgs>({
+    description: 'List the tools exposed by one connected MCP server. Returns namespaced tool ids and descriptions.',
+    parameters: z.object({
+      server: z.string().describe('The MCP server name from the system prompt catalog.'),
+    }),
+    async execute(args) {
+      const connection = manager.getConnection(args.server)
+      if (connection === undefined) return textResult(unknownServerMessage(manager, args.server))
+
+      const tools = await connection.listTools()
+      if (tools.length === 0) return textResult(`MCP server ${JSON.stringify(args.server)} exposes no tools.`)
+
+      const lines = tools.map((tool) => {
+        const description = tool.description.trim() === '' ? 'no description' : tool.description.trim()
+        return `- ${namespaceToolName(args.server, tool.name)} — ${description}`
+      })
+      return textResult(`Tools for MCP server ${JSON.stringify(args.server)}:\n${lines.join('\n')}`)
+    },
+  })
+}
+
+function createDescribeTool(manager: McpManager): Tool<McpDescribeArgs> {
+  return defineTool<McpDescribeArgs>({
+    description: 'Describe one MCP tool. Returns its description and full input JSON Schema.',
+    parameters: z.object({
+      server: z.string().describe('The MCP server name from the system prompt catalog.'),
+      tool: z.string().describe('The bare tool name or namespaced server__tool id.'),
+    }),
+    async execute(args) {
+      const resolved = resolveToolArgs(args.server, args.tool)
+      const connection = manager.getConnection(resolved.server)
+      if (connection === undefined) return textResult(unknownServerMessage(manager, resolved.server))
+
+      const tools = await connection.listTools()
+      const tool = tools.find((item) => item.name === resolved.tool)
+      if (tool === undefined) {
+        const available = tools.map((item) => namespaceToolName(resolved.server, item.name)).join(', ')
+        return textResult(
+          `Unknown MCP tool ${JSON.stringify(resolved.tool)} on server ${JSON.stringify(resolved.server)}. Available tools: ${available || 'none'}.`,
+        )
+      }
+
+      const description = tool.description.trim() === '' ? 'no description' : tool.description.trim()
+      return textResult(
+        [
+          `MCP tool ${namespaceToolName(resolved.server, tool.name)}`,
+          `Description: ${description}`,
+          '',
+          'Input schema:',
+          '```json',
+          JSON.stringify(tool.inputSchema, null, 2),
+          '```',
+        ].join('\n'),
+      )
+    },
+  })
+}
+
+function createCallTool(manager: McpManager): Tool<McpCallArgs> {
+  return defineTool<McpCallArgs>({
+    description: 'Call an MCP tool on a connected server. Use mcp_describe first to learn the input schema.',
+    parameters: z.object({
+      server: z.string().describe('The MCP server name from the system prompt catalog.'),
+      tool: z.string().describe('The bare tool name or namespaced server__tool id.'),
+      args: z.record(z.string(), z.unknown()).optional().describe('Arguments matching the tool input schema.'),
+    }),
+    async execute(args) {
+      const resolved = resolveToolArgs(args.server, args.tool)
+      const connection = manager.getConnection(resolved.server)
+      if (connection === undefined) return textResult(unknownServerMessage(manager, resolved.server))
+
+      const result = await connection.callTool(resolved.tool, args.args ?? {})
+      return mapCallToolResult(resolved.server, resolved.tool, result)
+    },
+  })
+}
+
+function resolveToolArgs(server: string, tool: string): { server: string; tool: string } {
+  const parsed = parseNamespacedTool(tool)
+  return parsed ?? { server, tool }
+}
+
+function unknownServerMessage(manager: McpManager, server: string): string {
+  const available = manager
+    .listServers()
+    .filter((entry) => entry.connected)
+    .map((entry) => entry.name)
+    .join(', ')
+  return `Unknown MCP server ${JSON.stringify(server)}. Available servers: ${available || 'none'}.`
+}
+
+function mapCallToolResult(server: string, tool: string, result: CallToolResult): ToolResult {
+  const content = result.content.flatMap((part): ContentPart[] => {
+    if (part.type === 'text' && typeof part.text === 'string') return [{ type: 'text', text: part.text }]
+    return []
+  })
+  const textContent: { type: 'text'; text: string }[] =
+    content.length > 0
+      ? content.filter((part) => part.type === 'text')
+      : [{ type: 'text', text: JSON.stringify(result.content) }]
+  if (result.isError === true) {
+    return {
+      content: textContent.map((part) => ({ type: 'text' as const, text: `MCP tool error: ${part.text}` })),
+      details: { server, tool, isError: true },
+    }
+  }
+  return { content: textContent, details: { server, tool, isError: false } }
+}
+
+function textResult(text: string): ToolResult {
+  return { content: [{ type: 'text', text }] }
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { defineTool } from '@/plugin/define'
 import type { ContentPart, Tool, ToolResult } from '@/plugin/types'
 
+import type { McpConnection, McpToolInfo } from './client'
 import type { McpManager } from './manager'
 import { namespaceToolName, parseNamespacedTool } from './manager'
 
@@ -29,7 +30,7 @@ function createListToolsTool(manager: McpManager): Tool<McpListToolsArgs> {
       const connection = manager.getConnection(args.server)
       if (connection === undefined) return textResult(unknownServerMessage(manager, args.server))
 
-      const tools = await connection.listTools()
+      const tools = await safeListTools(connection)
       if (tools.length === 0) return textResult(`MCP server ${JSON.stringify(args.server)} exposes no tools.`)
 
       const lines = tools.map((tool) => {
@@ -53,7 +54,7 @@ function createDescribeTool(manager: McpManager): Tool<McpDescribeArgs> {
       const connection = manager.getConnection(resolved.server)
       if (connection === undefined) return textResult(unknownServerMessage(manager, resolved.server))
 
-      const tools = await connection.listTools()
+      const tools = await safeListTools(connection)
       const tool = tools.find((item) => item.name === resolved.tool)
       if (tool === undefined) {
         const available = tools.map((item) => namespaceToolName(resolved.server, item.name)).join(', ')
@@ -91,7 +92,7 @@ function createCallTool(manager: McpManager): Tool<McpCallArgs> {
       const connection = manager.getConnection(resolved.server)
       if (connection === undefined) return textResult(unknownServerMessage(manager, resolved.server))
 
-      const result = await connection.callTool(resolved.tool, args.args ?? {})
+      const result = await safeCallTool(connection, resolved.tool, args.args ?? {})
       return mapCallToolResult(resolved.server, resolved.tool, result)
     },
   })
@@ -111,22 +112,77 @@ function unknownServerMessage(manager: McpManager, server: string): string {
   return `Unknown MCP server ${JSON.stringify(server)}. Available servers: ${available || 'none'}.`
 }
 
+async function safeListTools(connection: McpConnection): Promise<McpToolInfo[]> {
+  try {
+    return await connection.listTools()
+  } catch (cause) {
+    throw new Error(`MCP list tools failed: ${sanitizeMcpError(errorMessage(cause))}`)
+  }
+}
+
+async function safeCallTool(
+  connection: McpConnection,
+  tool: string,
+  args: Record<string, unknown>,
+): Promise<CallToolResult> {
+  try {
+    return await connection.callTool(tool, args)
+  } catch (cause) {
+    throw new Error(`MCP call failed: ${sanitizeMcpError(errorMessage(cause))}`)
+  }
+}
+
 function mapCallToolResult(server: string, tool: string, result: CallToolResult): ToolResult {
-  const content = result.content.flatMap((part): ContentPart[] => {
-    if (part.type === 'text' && typeof part.text === 'string') return [{ type: 'text', text: part.text }]
-    return []
-  })
-  const textContent: { type: 'text'; text: string }[] =
-    content.length > 0
-      ? content.filter((part) => part.type === 'text')
-      : [{ type: 'text', text: JSON.stringify(result.content) }]
+  const content = result.content.map(mapMcpContentPart)
   if (result.isError === true) {
     return {
-      content: textContent.map((part) => ({ type: 'text' as const, text: `MCP tool error: ${part.text}` })),
+      content: content.map((part) =>
+        part.type === 'text' ? { type: 'text' as const, text: `MCP tool error: ${sanitizeMcpError(part.text)}` } : part,
+      ),
       details: { server, tool, isError: true },
     }
   }
-  return { content: textContent, details: { server, tool, isError: false } }
+  return { content, details: { server, tool, isError: false } }
+}
+
+function mapMcpContentPart(part: CallToolResult['content'][number]): ContentPart {
+  if (part.type === 'text' && typeof part.text === 'string') return { type: 'text', text: part.text }
+  if (part.type === 'image' && typeof part.data === 'string' && typeof part.mimeType === 'string') {
+    return { type: 'image', mimeType: part.mimeType, data: part.data }
+  }
+  return { type: 'text', text: summarizeUnsupportedPart(part) }
+}
+
+function summarizeUnsupportedPart(part: CallToolResult['content'][number]): string {
+  const type = typeof part.type === 'string' ? part.type : 'unknown'
+  const uri = readNestedString(part, 'resource', 'uri') ?? readString(part, 'uri')
+  if (uri !== undefined) return `[mcp:${type} ${uri}]`
+  const mimeType = readNestedString(part, 'resource', 'mimeType') ?? readString(part, 'mimeType')
+  if (mimeType !== undefined) return `[mcp:${type} ${mimeType}]`
+  return `[mcp:${type} omitted]`
+}
+
+export function sanitizeMcpError(raw: string): string {
+  const scrubbed = raw
+    .replace(/\b([A-Z_][A-Z0-9_]*)=\S+/g, '$1=<redacted>')
+    .replace(/(?:\/[\w.-]+)+/g, '<path>')
+    .replace(/\b[A-Za-z]:\\[^\s]+/g, '<path>')
+  return scrubbed.length <= 500 ? scrubbed : `${scrubbed.slice(0, 497)}...`
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause)
+}
+
+function readString(value: unknown, key: string): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const found = (value as Record<string, unknown>)[key]
+  return typeof found === 'string' ? found : undefined
+}
+
+function readNestedString(value: unknown, key: string, nestedKey: string): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  return readString((value as Record<string, unknown>)[key], nestedKey)
 }
 
 function textResult(text: string): ToolResult {

--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -7,6 +7,7 @@ import type { CreateSessionForSubagent, SubagentRegistry } from '@/agent/subagen
 import { capJsonlFileInPlace } from '@/bundled-plugins/tool-result-cap/cap-jsonl'
 import type { CapOptions } from '@/bundled-plugins/tool-result-cap/cap-result'
 import type { CreateSessionForChannel, ChannelRouter } from '@/channels'
+import type { McpManager } from '@/mcp'
 import type { PermissionService, RolesConfig } from '@/permissions'
 import type { ReloadRegistry } from '@/reload'
 import type { SessionFactory } from '@/sessions'
@@ -35,6 +36,7 @@ export type BuildChannelSessionFactoryDeps = {
   // cycle while still ensuring the factory's sessions get the same router
   // their inbound messages came from.
   getChannelRouter: () => ChannelRouter
+  mcpManager?: McpManager
   containerName?: string
   runtimeVersion?: string
   // When set, rehydrating a session JSONL caps oversized tool results in the
@@ -113,6 +115,7 @@ export function buildChannelSessionFactory(deps: BuildChannelSessionFactoryDeps)
       sessionManager,
       stream: deps.stream,
       channelRouter: deps.getChannelRouter(),
+      ...(deps.mcpManager !== undefined ? { mcpManager: deps.mcpManager } : {}),
       origin,
       originRef,
       ...(snap.hasAnyPluginContent

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -38,6 +38,7 @@ import {
   type Scheduler,
 } from '@/cron'
 import { CLI_VERSION } from '@/init/cli-version'
+import { createMcpManager } from '@/mcp'
 import { loadPlugins, type LoadPluginsResult, pluginCronJobs, type PluginRegistry, summarizeLoaded } from '@/plugin'
 import { createPluginLogger } from '@/plugin/context'
 import type { CronHandlerContext } from '@/plugin/types'
@@ -140,6 +141,15 @@ export async function startAgent({
   const pluginConfigsByName = loadPluginConfigsSync(cwd)
   const cwdConfig = loadConfigSync(cwd)
   const githubTokenBridge = createGithubTokenBridge()
+  const mcpManager =
+    cwdConfig.mcpServers.length > 0 ? createMcpManager(cwdConfig.mcpServers, { env: process.env }) : null
+  if (mcpManager !== null) {
+    const results = await mcpManager.connectAll()
+    for (const result of results) {
+      if (!result.ok) console.warn(`[mcp] ${result.name} failed to connect: ${result.error.message}`)
+    }
+  }
+  const mcpManagerOpt = mcpManager !== null ? { mcpManager } : {}
   const pluginsLoaded = await loadPlugins({
     entries: cwdConfig.plugins,
     agentDir: cwd,
@@ -255,6 +265,7 @@ export async function startAgent({
       getCreateSessionForSubagent: () => createSessionForSubagent,
       ...containerNameOpt,
       ...runtimeVersionOpt,
+      ...mcpManagerOpt,
     }),
     permissions: pluginsLoaded.permissions,
     claimHandler: claimController.claimHandler,
@@ -376,6 +387,7 @@ export async function startAgent({
             containerName: containerNameOpt.containerName,
             sessionFactory,
             channelRouter: channelManager.router,
+            ...mcpManagerOpt,
           }),
         subagent: (subName: string, payload?: unknown) =>
           dispatchSpawnSubagent(subName, payload, {
@@ -424,6 +436,7 @@ export async function startAgent({
         createSessionForSubagent,
         ...containerNameOpt,
         ...runtimeVersionOpt,
+        ...mcpManagerOpt,
       })
       liveSessionRegistry.register({ sessionId, session })
       return {
@@ -591,6 +604,7 @@ export async function startAgent({
       outbound,
       sessionFactory,
       channelRouter: channelManager.router,
+      ...mcpManagerOpt,
     })
 
   const server = createServer({
@@ -600,6 +614,7 @@ export async function startAgent({
     sessionFactory,
     stream,
     channelRouter: channelManager.router,
+    ...mcpManagerOpt,
     agentDir: cwd,
     pluginRuntime,
     claimController,
@@ -634,6 +649,7 @@ export async function startAgent({
     subagentCompletionBridge.stop()
     await tunnelManager.stop()
     await channelManager.stop()
+    await mcpManager?.closeAll()
     uninstallCodexFetchObserver()
   }
 

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -6,6 +6,7 @@ import {
   type SessionOrigin,
 } from '@/agent'
 import type { ChannelRouter } from '@/channels/router'
+import type { McpManager } from '@/mcp'
 import type { PermissionService } from '@/permissions'
 import type {
   CommandExecResult,
@@ -53,6 +54,7 @@ export type CommandRunnerOptions = {
   // `channelManager.router` via `createSessionForCron`; this is the matching
   // wire for the handler/command path.
   channelRouter: ChannelRouter | undefined
+  mcpManager?: McpManager
 }
 
 type CommandHandle = {
@@ -192,6 +194,7 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
               signal: abortController.signal,
               sessionFactory: opts.sessionFactory,
               channelRouter: opts.channelRouter,
+              ...(opts.mcpManager !== undefined ? { mcpManager: opts.mcpManager } : {}),
             }),
           subagent: (subName, payload) =>
             opts.spawnSubagent(subName, payload, {
@@ -376,6 +379,7 @@ export async function runPromptForCommand(args: {
   // See CommandRunnerOptions.channelRouter. Threaded to createSessionWithDispose
   // so the spawned session exposes `channel_send`.
   channelRouter?: ChannelRouter
+  mcpManager?: McpManager
   // Test seam for the agent-session boundary. Production passes the real
   // `createSessionWithDispose`; tests inject a fake to verify wiring
   // (specifically: the sessionManager handed off must be persisted, not
@@ -402,6 +406,7 @@ export async function runPromptForCommand(args: {
       agentDir: args.agentDir,
     },
     ...(args.channelRouter !== undefined ? { channelRouter: args.channelRouter } : {}),
+    ...(args.mcpManager !== undefined ? { mcpManager: args.mcpManager } : {}),
     ...(args.runtimeVersion !== undefined ? { runtimeVersion: args.runtimeVersion } : {}),
     ...(args.containerName !== undefined ? { containerName: args.containerName } : {}),
   })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,6 +19,7 @@ import { parseSubagentCompletedPayload, renderSubagentCompletionReminder } from 
 import type { CreateSessionForSubagent } from '@/agent/subagents'
 import type { ChannelRouter } from '@/channels/router'
 import { aggregateCronList, type CronListEntry, loadCron } from '@/cron'
+import type { McpManager } from '@/mcp'
 import type { HookBus } from '@/plugin'
 import type { BrokerWsData, ContainerBroker } from '@/portbroker'
 import type { ReloadAllResult, ReloadRegistry } from '@/reload'
@@ -61,6 +62,7 @@ export type ServerOptions = {
   sessionFactory?: SessionFactory
   stream?: Stream
   channelRouter?: ChannelRouter
+  mcpManager?: McpManager
   agentDir?: string
   pluginRuntime?: PluginRuntime
   containerName?: string
@@ -221,6 +223,7 @@ export function createServer({
   sessionFactory,
   stream,
   channelRouter,
+  mcpManager,
   agentDir,
   pluginRuntime,
   containerName,
@@ -471,6 +474,7 @@ export function createServer({
               origin,
               ...(stream ? { stream } : {}),
               ...(channelRouter ? { channelRouter } : {}),
+              ...(mcpManager ? { mcpManager } : {}),
               ...(pluginsWiring ? { plugins: pluginsWiring } : {}),
               ...(containerName !== undefined ? { containerName } : {}),
               ...(runtimeVersion !== undefined ? { runtimeVersion } : {}),


### PR DESCRIPTION
Stacked on #523 — review/merge in order.

## Background

PR #523 can connect to MCP servers; this PR exposes them to the model without bloating the prompt. This is where the token-economy design pays off.

## Summary

**Three fixed dispatcher tools** replace N×M individual tool registrations:
- `mcp_list_tools(server)` — enumerate a connected server's tools on demand.
- `mcp_describe(server, tool)` — fetch the full input JSON Schema for one tool on demand.
- `mcp_call(server, tool, args)` — invoke a tool.

All three handle unknown server/tool gracefully (helpful error strings, never throw) and surface MCP `isError` results as text rather than exceptions.

**Per-server catalog in the system prompt.** One line per connected server rendered into the STABLE (cacheable) region of the prompt — after origin/role, before git-nudge and memory — so the cache-suffix contract is preserved. When there are no connected servers the block is omitted entirely, keeping byte-identical prompts for agents that don't use MCP.

**Boot wiring in `src/run/index.ts`.** Manager created from `config.mcpServers`, `connectAll()` awaited, threaded into TUI/server/channel/cron/command sessions, `closeAll()` on shutdown.

**Why a dispatcher and not per-tool native registration.** `pi-coding-agent` 0.67.3's `setActiveToolsByName` only filters pre-registered tools; it cannot hot-add definitions mid-session (verified by reading the installed package). Individual MCP tools can never become native tools after the session starts, so the generic dispatcher is not a workaround — it's the only design that fits the runtime.

**Subagents do not get the dispatcher.** Their tool set is intentionally narrowed; MCP access is an operator-level concern.

## What this does NOT do

No code-execution/sandbox invocation path ("code mode") — deferred as a possible future for workflow-heavy servers. No MCP resources or prompts yet (tools only). The cache-suffix guard test (`scripts/dump-system-prompt.test.ts`) passes unchanged because the catalog is empty when no servers are connected (the placeholder dumper has none).

## Review notes

Two load-bearing things:

1. **Catalog placement preserves the cache-suffix contract.** A direct `composeSystemPrompt` test asserts the catalog sits after origin and before memory. Reordering the section breaks that test.
2. **Boot wiring in `src/run/index.ts`.** Verify the manager lifecycle: create → `connectAll` → thread into sessions → `closeAll` on stop. Confirm the manager is NOT threaded into subagent sessions.

Pre-existing flaky tests unrelated to this change: a schema-drift guard (also fails on clean main) and `resolveSelfPackageJsonPath` (worktree-path sensitive).