### PR TITLE
fix(github): seed GH_TOKEN for single-owner multi-repo Apps

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -176,17 +176,18 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         throw err
       }
       started = true
-      // GH_TOKEN is a single process-wide env var the container's `gh` CLI
-      // reads, but a GitHub App spanning multiple owners has no single correct
-      // token. Seed/refresh it only when exactly one repo is configured (PAT,
-      // or App with one unambiguous installation). With multiple repos we skip
-      // the global seed: ad-hoc `gh` calls must target a specific repo, and the
-      // adapter's own API calls always resolve a repo-scoped token via authToken.
-      const ghTokenRepo = ghTokenSeedRepo(options.configRef().repos ?? [])
-      const seedGhToken = async (): Promise<void> => {
-        process.env.GH_TOKEN = await auth.token(ghTokenRepo === null ? undefined : { repoSlug: ghTokenRepo })
-      }
-      if (ghTokenRepo !== null || options.secrets.auth.type === 'pat') {
+      // GitHub Apps install per owner, so the single process-wide GH_TOKEN is
+      // unambiguous whenever every configured repo shares one owner (one
+      // installation) — regardless of repo count. Only repos spanning >1 owner
+      // are ambiguous; that case skips the global seed (authToken still resolves
+      // a repo-scoped token per call). Keying off owner count, not repo count,
+      // is the fix for single-owner/multi-repo Apps that the old gate skipped.
+      const ghTokenContext = ghTokenSeedContext(options.secrets.auth.type, options.configRef().repos ?? [])
+      if (ghTokenContext !== null) {
+        const seedContext = ghTokenContext
+        const seedGhToken = async (): Promise<void> => {
+          process.env.GH_TOKEN = await auth.token(seedContext)
+        }
         await seedGhToken()
         const tokenRefreshIntervalMs = options.tokenRefreshIntervalMs ?? DEFAULT_TOKEN_REFRESH_INTERVAL_MS
         if (tokenRefreshIntervalMs > 0) {
@@ -207,7 +208,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         }
       } else {
         logger.info(
-          '[github] multiple repos configured across possibly-different owners; GH_TOKEN not seeded globally. ' +
+          '[github] repos span multiple owners (multiple App installations); GH_TOKEN not seeded globally. ' +
             'Ad-hoc `gh` commands should set a repo-scoped token explicitly.',
         )
       }
@@ -427,11 +428,15 @@ function logDeregistrationOutcome(
   }
 }
 
-// Two repos under the same owner share an installation and could in principle
-// share a global GH_TOKEN, but the marginal value doesn't justify the special
-// case — only a single configured repo yields an unambiguous seed.
-function ghTokenSeedRepo(repos: readonly string[]): string | null {
-  return repos.length === 1 ? (repos[0] ?? null) : null
+// Returns the context for seeding GH_TOKEN, or null to skip. null only when an
+// App's repos span multiple owners (multiple installations); single-owner Apps
+// seed owner-scoped, sole-installation and PAT seed context-free (undefined).
+function ghTokenSeedContext(authType: 'pat' | 'app', repos: readonly string[]): GithubAuthContext | undefined | null {
+  if (authType === 'pat') return undefined
+  const owners = new Set(repos.map((repo) => repo.split('/')[0]).filter((owner) => owner !== undefined && owner !== ''))
+  if (owners.size === 0) return undefined
+  if (owners.size > 1) return null
+  return { owner: [...owners][0] }
 }
 
 function defaultSleep(ms: number): Promise<void> {

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -176,15 +176,12 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         throw err
       }
       started = true
-      // GitHub Apps install per owner, so the single process-wide GH_TOKEN is
-      // unambiguous whenever every configured repo shares one owner (one
-      // installation) — regardless of repo count. Only repos spanning >1 owner
-      // are ambiguous; that case skips the global seed (authToken still resolves
-      // a repo-scoped token per call). Keying off owner count, not repo count,
-      // is the fix for single-owner/multi-repo Apps that the old gate skipped.
-      const ghTokenContext = ghTokenSeedContext(options.secrets.auth.type, options.configRef().repos ?? [])
-      if (ghTokenContext !== null) {
-        const seedContext = ghTokenContext
+      // Seed the process-wide GH_TOKEN when it's unambiguous; skip otherwise.
+      // See ghTokenSeedDecision for why one owner is required. On skip, authToken
+      // still resolves a repo-scoped token per call for the adapter's own traffic.
+      const seed = ghTokenSeedDecision(options.secrets.auth.type, options.configRef().repos ?? [])
+      if (seed.kind === 'seed') {
+        const seedContext = seed.context
         const seedGhToken = async (): Promise<void> => {
           process.env.GH_TOKEN = await auth.token(seedContext)
         }
@@ -208,8 +205,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         }
       } else {
         logger.info(
-          '[github] repos span multiple owners (multiple App installations); GH_TOKEN not seeded globally. ' +
-            'Ad-hoc `gh` commands should set a repo-scoped token explicitly.',
+          `${GH_TOKEN_SKIP_LOG[seed.reason]} Ad-hoc \`gh\` commands should set a repo-scoped token explicitly.`,
         )
       }
       logger.info(`[github] webhook listening on port ${options.configRef().webhookPort} as @${self.login}`)
@@ -428,15 +424,33 @@ function logDeregistrationOutcome(
   }
 }
 
-// Returns the context for seeding GH_TOKEN, or null to skip. null only when an
-// App's repos span multiple owners (multiple installations); single-owner Apps
-// seed owner-scoped, sole-installation and PAT seed context-free (undefined).
-function ghTokenSeedContext(authType: 'pat' | 'app', repos: readonly string[]): GithubAuthContext | undefined | null {
-  if (authType === 'pat') return undefined
-  const owners = new Set(repos.map((repo) => repo.split('/')[0]).filter((owner) => owner !== undefined && owner !== ''))
-  if (owners.size === 0) return undefined
-  if (owners.size > 1) return null
-  return { owner: [...owners][0] }
+type GhTokenSeedDecision =
+  | { kind: 'seed'; context?: GithubAuthContext }
+  | { kind: 'skip'; reason: 'no-repos' | 'multiple-owners' }
+
+const GH_TOKEN_SKIP_LOG: Record<'no-repos' | 'multiple-owners', string> = {
+  'no-repos':
+    '[github] no repos[] configured; GH_TOKEN not seeded globally (cannot prove which App installation to use).',
+  'multiple-owners': '[github] repos span multiple owners (multiple App installations); GH_TOKEN not seeded globally.',
+}
+
+// Decides how to seed the process-wide GH_TOKEN. PATs aren't installation-scoped
+// (seed context-free). For App auth we seed from a configured repo slug, which
+// resolves the installation via repos/{owner}/{repo}/installation — the only
+// lookup that works for both org- and user-owned repos. One owner is required:
+// no-repos can't prove an installation, multi-owner needs >1 token.
+function ghTokenSeedDecision(authType: 'pat' | 'app', repos: readonly string[]): GhTokenSeedDecision {
+  if (authType === 'pat') return { kind: 'seed' }
+  const slugs = [...new Set(repos.filter(isWellFormedSlug))].sort()
+  if (slugs.length === 0) return { kind: 'skip', reason: 'no-repos' }
+  const owners = new Set(slugs.map((slug) => slug.split('/')[0]))
+  if (owners.size > 1) return { kind: 'skip', reason: 'multiple-owners' }
+  return { kind: 'seed', context: { repoSlug: slugs[0] } }
+}
+
+function isWellFormedSlug(repo: string): boolean {
+  const [owner, name, ...rest] = repo.split('/')
+  return owner !== undefined && owner !== '' && name !== undefined && name !== '' && rest.length === 0
 }
 
 function defaultSleep(ms: number): Promise<void> {

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -975,13 +975,12 @@ describe('createGithubAdapter lifecycle', () => {
     await adapter.stop()
   })
 
-  test('App auth: single-owner multi-repo seeds GH_TOKEN via the owner installation', async () => {
+  test('App auth: single-owner multi-repo seeds GH_TOKEN via a repo installation lookup', async () => {
     const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
       if (url === 'https://api.github.com/app' && method === 'GET') return Response.json({ slug: 'typeey-app' })
       if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
         return Response.json({ id: 42, login: 'typeey-app[bot]' })
       }
-      if (url === 'https://api.github.com/orgs/acme/installation' && method === 'GET') return Response.json({ id: 99 })
       if (url.endsWith('/installation') && method === 'GET') return Response.json({ id: 99 })
       if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
         return Response.json({ permissions: { metadata: 'read' }, events: [] })
@@ -1009,7 +1008,55 @@ describe('createGithubAdapter lifecycle', () => {
 
     await adapter.start()
     expect(process.env.GH_TOKEN).toBe('ghs_owner')
-    expect(calls.some((c) => c.url === 'https://api.github.com/orgs/acme/installation')).toBe(true)
+    // Seed must use the repo endpoint (works for org- AND user-owned repos),
+    // never orgs/{owner}/installation (404s on personal accounts).
+    expect(calls.some((c) => c.url === 'https://api.github.com/repos/acme/gadgets/installation')).toBe(true)
+    expect(calls.some((c) => c.url.startsWith('https://api.github.com/orgs/'))).toBe(false)
+    await adapter.stop()
+    expect(process.env.GH_TOKEN).toBeUndefined()
+  })
+
+  test('App auth: user-owned (personal account) repo seeds GH_TOKEN via the repo installation', async () => {
+    const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
+      if (url === 'https://api.github.com/app' && method === 'GET') return Response.json({ slug: 'typeey-app' })
+      if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
+        return Response.json({ id: 42, login: 'typeey-app[bot]' })
+      }
+      // A personal account only resolves through repos/{owner}/{repo}/installation.
+      // orgs/{owner}/installation would 404 here — the regression this guards.
+      if (url === 'https://api.github.com/repos/octocat/hello/installation' && method === 'GET') {
+        return Response.json({ id: 77 })
+      }
+      if (url === 'https://api.github.com/orgs/octocat/installation' && method === 'GET') {
+        return new Response('Not Found', { status: 404 })
+      }
+      if (url === 'https://api.github.com/app/installations/77' && method === 'GET') {
+        return Response.json({ permissions: { metadata: 'read' }, events: [] })
+      }
+      if (url === 'https://api.github.com/app/installations/77/access_tokens' && method === 'POST') {
+        return Response.json({ token: 'ghs_user', expires_at: '2099-01-01T00:00:00Z' })
+      }
+      if (url.includes('/hooks')) {
+        if (method === 'GET') return Response.json([])
+        if (method === 'POST') return Response.json({ id: 7 }, { status: 201 })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig(['octocat/hello']),
+      secrets: appSecrets(),
+      agentDir: '/tmp/agent',
+      logger: silentLogger(),
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
+    })
+
+    await adapter.start()
+    expect(process.env.GH_TOKEN).toBe('ghs_user')
+    expect(calls.some((c) => c.url === 'https://api.github.com/orgs/octocat/installation')).toBe(false)
     await adapter.stop()
     expect(process.env.GH_TOKEN).toBeUndefined()
   })
@@ -1052,7 +1099,7 @@ describe('createGithubAdapter lifecycle', () => {
     await adapter.stop()
   })
 
-  test('App auth: sole installation with no repos configured seeds GH_TOKEN context-free', async () => {
+  test('App auth: no repos configured skips the GH_TOKEN seed and logs guidance', async () => {
     const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
       if (url === 'https://api.github.com/app' && method === 'GET') return Response.json({ slug: 'typeey-app' })
       if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
@@ -1068,21 +1115,23 @@ describe('createGithubAdapter lifecycle', () => {
       return new Response('unexpected', { status: 500 })
     })
 
+    const logger = recordingLogger()
     const adapter = createGithubAdapter({
       router: freshRouter(),
       configRef: () => githubConfig([], null),
       secrets: appSecrets(),
       agentDir: '/tmp/agent',
-      logger: silentLogger(),
+      logger,
       fetchImpl,
       httpListenImpl: () => ({ stop: async () => {} }),
       webhookRegistrationDelayMs: 0,
     })
 
     await adapter.start()
-    expect(process.env.GH_TOKEN).toBe('ghs_sole')
-    expect(calls.some((c) => c.url === 'https://api.github.com/app/installations')).toBe(true)
-    await adapter.stop()
     expect(process.env.GH_TOKEN).toBeUndefined()
+    expect(logger.messages.some((m) => m.includes('no repos[] configured'))).toBe(true)
+    // No seed attempt means we never POST for an access token.
+    expect(calls.some((c) => c.url.endsWith('/access_tokens'))).toBe(false)
+    await adapter.stop()
   })
 })

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -892,6 +892,9 @@ describe('createGithubAdapter lifecycle', () => {
       if (url === 'https://api.github.com/repos/acme/widgets/installation' && method === 'GET') {
         return Response.json({ id: 99 })
       }
+      if (url === 'https://api.github.com/orgs/acme/installation' && method === 'GET') {
+        return Response.json({ id: 99 })
+      }
       if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
         return Response.json({
           permissions: { issues: 'write', pull_requests: 'write', metadata: 'read' },
@@ -970,5 +973,116 @@ describe('createGithubAdapter lifecycle', () => {
     await adapter.start()
     expect(setIntervalCalls).toBe(0)
     await adapter.stop()
+  })
+
+  test('App auth: single-owner multi-repo seeds GH_TOKEN via the owner installation', async () => {
+    const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
+      if (url === 'https://api.github.com/app' && method === 'GET') return Response.json({ slug: 'typeey-app' })
+      if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
+        return Response.json({ id: 42, login: 'typeey-app[bot]' })
+      }
+      if (url === 'https://api.github.com/orgs/acme/installation' && method === 'GET') return Response.json({ id: 99 })
+      if (url.endsWith('/installation') && method === 'GET') return Response.json({ id: 99 })
+      if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
+        return Response.json({ permissions: { metadata: 'read' }, events: [] })
+      }
+      if (url === 'https://api.github.com/app/installations/99/access_tokens' && method === 'POST') {
+        return Response.json({ token: 'ghs_owner', expires_at: '2099-01-01T00:00:00Z' })
+      }
+      if (url.includes('/hooks')) {
+        if (method === 'GET') return Response.json([])
+        if (method === 'POST') return Response.json({ id: 7 }, { status: 201 })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig(['acme/widgets', 'acme/gadgets']),
+      secrets: appSecrets(),
+      agentDir: '/tmp/agent',
+      logger: silentLogger(),
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
+    })
+
+    await adapter.start()
+    expect(process.env.GH_TOKEN).toBe('ghs_owner')
+    expect(calls.some((c) => c.url === 'https://api.github.com/orgs/acme/installation')).toBe(true)
+    await adapter.stop()
+    expect(process.env.GH_TOKEN).toBeUndefined()
+  })
+
+  test('App auth: repos spanning multiple owners skip the GH_TOKEN seed and log guidance', async () => {
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+      if (url === 'https://api.github.com/app' && method === 'GET') return Response.json({ slug: 'typeey-app' })
+      if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
+        return Response.json({ id: 42, login: 'typeey-app[bot]' })
+      }
+      if (url.endsWith('/installation') && method === 'GET') return Response.json({ id: 99 })
+      if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
+        return Response.json({ permissions: { metadata: 'read' }, events: [] })
+      }
+      if (url === 'https://api.github.com/app/installations/99/access_tokens' && method === 'POST') {
+        return Response.json({ token: 'ghs_inst', expires_at: '2099-01-01T00:00:00Z' })
+      }
+      if (url.includes('/hooks')) {
+        if (method === 'GET') return Response.json([])
+        if (method === 'POST') return Response.json({ id: 7 }, { status: 201 })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const logger = recordingLogger()
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig(['acme/widgets', 'globex/gizmos']),
+      secrets: appSecrets(),
+      agentDir: '/tmp/agent',
+      logger,
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
+    })
+
+    await adapter.start()
+    expect(process.env.GH_TOKEN).toBeUndefined()
+    expect(logger.messages.some((m) => m.includes('repos span multiple owners'))).toBe(true)
+    await adapter.stop()
+  })
+
+  test('App auth: sole installation with no repos configured seeds GH_TOKEN context-free', async () => {
+    const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
+      if (url === 'https://api.github.com/app' && method === 'GET') return Response.json({ slug: 'typeey-app' })
+      if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
+        return Response.json({ id: 42, login: 'typeey-app[bot]' })
+      }
+      if (url === 'https://api.github.com/app/installations' && method === 'GET') return Response.json([{ id: 99 }])
+      if (url === 'https://api.github.com/app/installations/99' && method === 'GET') {
+        return Response.json({ permissions: { metadata: 'read' }, events: [] })
+      }
+      if (url === 'https://api.github.com/app/installations/99/access_tokens' && method === 'POST') {
+        return Response.json({ token: 'ghs_sole', expires_at: '2099-01-01T00:00:00Z' })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig([], null),
+      secrets: appSecrets(),
+      agentDir: '/tmp/agent',
+      logger: silentLogger(),
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
+    })
+
+    await adapter.start()
+    expect(process.env.GH_TOKEN).toBe('ghs_sole')
+    expect(calls.some((c) => c.url === 'https://api.github.com/app/installations')).toBe(true)
+    await adapter.stop()
+    expect(process.env.GH_TOKEN).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Background

A running agent with GitHub **App** credentials in `secrets.json` failed to authenticate `gh` for ad-hoc calls — `gh auth status` reported "no hosts logged in" — and resorted to ~90s of trial-and-error (inspecting `secrets.json`, fumbling `node` heredocs, tripping over the PKCS#1 private key) before manually minting an installation token to post PR reviews.

Root cause: the adapter seeds the process-wide `GH_TOKEN` only when **exactly one repo** is configured (or PAT auth), keying off *repo count* via `ghTokenSeedRepo`. But a GitHub App installs **per owner**, so the correct token is unambiguous whenever every configured repo shares a single owner — no matter how many repos are listed. The old gate conflated "multiple repos" with "multiple installations," leaving `GH_TOKEN` empty for the common single-owner/multi-repo setup (e.g. several `typeclaw/*` repos under one installation). The agent then had a perfectly resolvable token it was never handed.

## Summary

Key the seed off **owner count, not repo count**:

- **PAT** → seed context-free (unchanged).
- **App, all repos under one owner** → seed using an owner-scoped context (`{ owner }`), which `AppAuthStrategy` already resolves via `GET /orgs/{owner}/installation`.
- **App, no repos configured** → seed context-free; `AppAuthStrategy` discovers the sole installation.
- **App, repos spanning >1 owner** → genuinely ambiguous; keep the skip + log. The adapter's own API calls still resolve a repo-scoped token per call via `authToken`, so outbound posting is unaffected.

Why owner-scoped and not repo-scoped for the seed: a single `GH_TOKEN` must represent one installation; the owner is the installation boundary, so `{ owner }` is the smallest unambiguous key that works for any number of repos under that owner.

This complements #521 (multi-installation support on the read/outbound path) by fixing the *seed* path it left conservative.

## What this does NOT do

- Does not change PAT behavior or the outbound/read token resolution.
- Does not attempt to seed a global token for genuinely multi-owner Apps — that case remains a deliberate skip with operator guidance.
- Does not add a `gh` wrapper, credential helper, or any new CLI surface.

## Review notes

- Load-bearing change: `ghTokenSeedContext(authType, repos)` (replaces `ghTokenSeedRepo`) — returns `undefined` (context-free seed), `{ owner }` (owner-scoped seed), or `null` (skip). The `null`-vs-`undefined` distinction is the crux; the closure narrows `null` out before calling `auth.token`.
- Invariant to verify: single-owner/multi-repo now seeds (`GET /orgs/{owner}/installation`); multi-owner still skips and logs. Both are covered by new lifecycle tests, plus a sole-installation context-free case.
