### PR TITLE
feat(channels): add /help command listing available commands without an LLM call

### DIFF
--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -842,7 +842,7 @@ describe('createInteractionHandler', () => {
   type CapturedCall = { url: string; init: RequestInit }
   type RouterCall = { key: ChannelKey; name: string; invokerId: string }
   type RouterResult =
-    | { kind: 'handled'; name: string }
+    | { kind: 'handled'; name: string; reply?: string }
     | { kind: 'no-live-session' }
     | { kind: 'permission-denied' }
     | { kind: 'unknown-command'; name: string }
@@ -912,6 +912,18 @@ describe('createInteractionHandler', () => {
     expect(fetchCalls[0]!.url).toBe('https://discord.com/api/v10/interactions/i-1/tok-abc/callback')
     const body = JSON.parse(fetchCalls[0]!.init.body as string)
     expect(body.data.content).toContain('Stopped')
+    expect(body.data.flags).toBe(64)
+  })
+
+  test('/help interaction acks with the handler-provided command list', async () => {
+    const helpText = 'Available commands:\n/help — List available commands\n/stop — Abort the current turn'
+    const { handler, fetchCalls } = setup(async () => ({ kind: 'handled', name: 'help', reply: helpText }))
+
+    await handler(interaction({ data: { name: 'help', type: DISCORD_SLASH_COMMAND_TYPE_CHAT_INPUT } }))
+
+    expect(fetchCalls).toHaveLength(1)
+    const body = JSON.parse(fetchCalls[0]!.init.body as string)
+    expect(body.data.content).toBe(helpText)
     expect(body.data.flags).toBe(64)
   })
 

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -42,6 +42,7 @@ import {
 // commands here is the documented extension point: declare the entry here,
 // then add the matching handler in createChannelRouter's command registry.
 const SLASH_COMMANDS: readonly DiscordCommandDeclaration[] = [
+  { name: 'help', description: 'List available commands' },
   { name: 'stop', description: 'Abort the current turn in this channel' },
 ]
 const SLASH_COMMAND_NAMES: ReadonlySet<string> = new Set(SLASH_COMMANDS.map((c) => c.name))
@@ -508,7 +509,9 @@ export function createInteractionHandler(
       })
       const replyContent =
         result.kind === 'handled'
-          ? STOP_REPLY_ABORTED
+          ? // Dynamic commands (e.g. /help) carry their own reply; static
+            // control commands (/stop) fall back to the fixed confirmation.
+            (result.reply ?? STOP_REPLY_ABORTED)
           : result.kind === 'no-live-session'
             ? STOP_REPLY_NO_LIVE_SESSION
             : result.kind === 'permission-denied'

--- a/src/channels/adapters/slack-bot-slash-commands.test.ts
+++ b/src/channels/adapters/slack-bot-slash-commands.test.ts
@@ -4,8 +4,10 @@ import type { SlackSocketModeSlashCommandArgs } from 'agent-messenger/slackbot'
 
 import {
   buildSlashAckPayload,
+  commandResultReply,
   parseSlashCommand,
   parseThreadCommand,
+  SLACK_SLASH_REPLY_ABORTED,
   type ThreadCommandInput,
 } from './slack-bot-slash-commands'
 
@@ -174,5 +176,17 @@ describe('buildSlashAckPayload', () => {
       response_type: 'ephemeral',
       text: 'Stopped.',
     })
+  })
+})
+
+describe('commandResultReply', () => {
+  test('uses a handler-provided reply when present (dynamic commands like /help)', () => {
+    expect(commandResultReply({ kind: 'handled', name: 'help', reply: 'Available commands:\n/help — List' })).toBe(
+      'Available commands:\n/help — List',
+    )
+  })
+
+  test('falls back to the static abort string when no reply is provided (/stop)', () => {
+    expect(commandResultReply({ kind: 'handled', name: 'stop' })).toBe(SLACK_SLASH_REPLY_ABORTED)
   })
 })

--- a/src/channels/adapters/slack-bot-slash-commands.ts
+++ b/src/channels/adapters/slack-bot-slash-commands.ts
@@ -135,7 +135,9 @@ export const SLACK_SLASH_REPLY_AMBIGUOUS =
 export function commandResultReply(result: ExecuteCommandResult): string {
   switch (result.kind) {
     case 'handled':
-      return SLACK_SLASH_REPLY_ABORTED
+      // Dynamic commands (e.g. /help) carry their own reply; static control
+      // commands (/stop) leave it undefined and fall back to the fixed string.
+      return result.reply ?? SLACK_SLASH_REPLY_ABORTED
     case 'no-live-session':
       return SLACK_SLASH_REPLY_NO_LIVE_SESSION
     case 'permission-denied':

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -51,7 +51,7 @@ import { slackTsToMillis } from './slack-bot-time'
 // slash_commands events we route vs drop. The ui.test.ts manifest-drift
 // test asserts equality between this set and SLACK_APP_MANIFEST.features.
 // slash_commands so the two can never silently diverge.
-export const SLACK_SLASH_COMMAND_NAMES: ReadonlySet<string> = new Set(['stop'])
+export const SLACK_SLASH_COMMAND_NAMES: ReadonlySet<string> = new Set(['help', 'stop'])
 
 // Resolvers fall back to the raw id on failure, so a name equal to the id
 // means resolution failed; we render the bare id rather than `id(id)`. The

--- a/src/channels/commands.test.ts
+++ b/src/channels/commands.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { CommandInfo } from '@/commands'
+
+import { formatChannelCommandHelp } from './commands'
+
+const info = (name: string, description: string): CommandInfo => ({
+  name,
+  aliases: [],
+  description,
+  permission: 'session.control',
+  requiresLiveSession: true,
+})
+
+describe('formatChannelCommandHelp', () => {
+  test('renders one line per command with the slash prefix', () => {
+    const text = formatChannelCommandHelp([
+      info('help', 'List available commands'),
+      info('stop', 'Stop the current turn'),
+    ])
+
+    expect(text).toBe(
+      ['Available commands:', '/help — List available commands', '/stop — Stop the current turn'].join('\n'),
+    )
+  })
+
+  test('handles an empty registry', () => {
+    expect(formatChannelCommandHelp([])).toBe('No commands are available.')
+  })
+})

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -1,0 +1,10 @@
+import type { CommandInfo } from '@/commands'
+
+// Generated from registry metadata so the listing can never drift from the
+// actual command set. The `/` prefix is canonical across every surface; Slack
+// threads accept the `!` alias for the same names.
+export function formatChannelCommandHelp(commands: readonly CommandInfo[]): string {
+  if (commands.length === 0) return 'No commands are available.'
+  const lines = commands.map((command) => `/${command.name} — ${command.description}`)
+  return ['Available commands:', ...lines].join('\n')
+}

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5258,6 +5258,95 @@ describe('ChannelRouter channel.respond gate', () => {
     expect(sent[0]!.text).toContain('Available commands')
   })
 
+  test('author WITHOUT channel.respond can still /help via text prefix (parity with native slash)', async () => {
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    // nobody is absent from the table → no channel.respond. /help is ungated,
+    // so it must still answer rather than being dropped by the respond gate.
+    const permissions = buildPermissions({})
+    const { router, sessions } = makeRouter(dir, { permissions })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ authorId: 'nobody', text: '/help', externalMessageId: 'm-help' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('Available commands')
+    expect(sessions).toHaveLength(0)
+  })
+
+  test('author WITHOUT channel.respond typing /stop is still denied at the respond gate', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const permissions = buildPermissions({})
+    const { router } = makeRouter(dir, { permissions, logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ authorId: 'nobody', text: '/stop', externalMessageId: 'm-stop' }))
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((l) => l.includes('denied by permissions (channel.respond)'))).toBe(true)
+  })
+
+  test('author WITHOUT channel.respond typing an unknown /foo is still denied at the respond gate', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const permissions = buildPermissions({})
+    const { router } = makeRouter(dir, { permissions, logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ authorId: 'nobody', text: '/foo', externalMessageId: 'm-foo' }))
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((l) => l.includes('denied by permissions (channel.respond)'))).toBe(true)
+    expect(logs.some((l) => l.includes('ignoring unknown command'))).toBe(false)
+  })
+
+  test('escaped //help is not executed as a command and stays subject to the respond gate', async () => {
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const permissions = buildPermissions({})
+    const { router } = makeRouter(dir, { permissions })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ authorId: 'nobody', text: '//help', externalMessageId: 'm-esc' }))
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(sent).toHaveLength(0)
+  })
+
+  test('authorized author typing /help gets exactly one reply (no double execution)', async () => {
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const permissions = buildPermissions({ alice: ['channel.respond', 'session.control'] })
+    const { router } = makeRouter(dir, { permissions })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ authorId: 'alice', text: '/help', externalMessageId: 'm-help' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+  })
+
   test('native executeCommand /help does not require session.control', async () => {
     const dir = await tempDir()
     const permissions = buildPermissions({ stranger: ['channel.respond'] })

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -3069,6 +3069,24 @@ describe('ChannelRouter commands', () => {
 
     expect(sessions).toHaveLength(0)
   })
+
+  test('/help replies with the command list on a cold channel without creating a session', async () => {
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '/help' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions).toHaveLength(0)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('/help')
+    expect(sent[0]!.text).toContain('/stop')
+  })
 })
 
 describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
@@ -3090,7 +3108,7 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
     releasePrompt!()
     await draining
 
-    expect(result).toEqual({ kind: 'handled', name: 'stop' })
+    expect(result).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
     expect(sessions[0]!.aborted).toBe(1)
   })
 
@@ -3103,7 +3121,7 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
     const result = await router.executeCommand(KEY, 'stop', { invokerId: 'alice' })
     await router.__testing!.flushDebounce(KEY)
 
-    expect(result).toEqual({ kind: 'handled', name: 'stop' })
+    expect(result).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
     expect(sessions[0]!.aborted).toBe(1)
     expect(sessions[0]!.prompts).toEqual([])
     expect(router.__testing!.isTypingActive(KEY)).toBe(false)
@@ -3116,6 +3134,18 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
     const result = await router.executeCommand(KEY, 'stop', { invokerId: 'alice' })
 
     expect(result).toEqual({ kind: 'no-live-session' })
+    expect(sessions).toHaveLength(0)
+  })
+
+  test('help on a cold channel returns the command list (no live session required)', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    const result = await router.executeCommand(KEY, 'help', { invokerId: 'alice' })
+
+    expect(result.kind).toBe('handled')
+    expect(result.kind === 'handled' && result.reply).toContain('/help')
+    expect(result.kind === 'handled' && result.reply).toContain('/stop')
     expect(sessions).toHaveLength(0)
   })
 
@@ -3141,7 +3171,7 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
     await router.__testing!.flushDebounce(KEY)
     const result = await router.executeCommand(KEY, 'STOP', { invokerId: 'alice' })
 
-    expect(result).toEqual({ kind: 'handled', name: 'stop' })
+    expect(result).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
     expect(sessions[0]!.aborted).toBe(1)
   })
 
@@ -3190,7 +3220,7 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
 
     const result = await router.executeCommand({ ...KEY, thread: null }, 'stop', { invokerId: 'alice' })
 
-    expect(result).toEqual({ kind: 'handled', name: 'stop' })
+    expect(result).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
     expect(sessions[0]!.aborted).toBe(1)
   })
 
@@ -3205,7 +3235,7 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
 
     const result = await router.executeCommand({ ...KEY, thread: null }, 'stop', { invokerId: 'alice' })
 
-    expect(result).toEqual({ kind: 'handled', name: 'stop' })
+    expect(result).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
     expect(sessions[0]!.aborted).toBe(1)
     expect(sessions[1]!.aborted).toBe(0)
   })
@@ -5211,6 +5241,33 @@ describe('ChannelRouter channel.respond gate', () => {
     expect(sessions[0]!.aborted).toBe(1)
   })
 
+  test('respond-capable author WITHOUT session.control can still /help via text prefix', async () => {
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const permissions = buildPermissions({ stranger: ['channel.respond'] })
+    const { router } = makeRouter(dir, { permissions })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ authorId: 'stranger', text: '/help', externalMessageId: 'm-help' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('Available commands')
+  })
+
+  test('native executeCommand /help does not require session.control', async () => {
+    const dir = await tempDir()
+    const permissions = buildPermissions({ stranger: ['channel.respond'] })
+    const { router } = makeRouter(dir, { permissions })
+
+    const result = await router.executeCommand(KEY, 'help', { invokerId: 'stranger' })
+
+    expect(result.kind).toBe('handled')
+  })
+
   test('native executeCommand gates on session.control, not channel.respond', async () => {
     const dir = await tempDir()
     const permissions = buildPermissions({
@@ -5228,7 +5285,7 @@ describe('ChannelRouter channel.respond gate', () => {
     expect(sessions[0]!.aborted).toBe(0)
 
     const allowed = await router.executeCommand(KEY, 'stop', { invokerId: 'alice' })
-    expect(allowed).toEqual({ kind: 'handled', name: 'stop' })
+    expect(allowed).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
     expect(sessions[0]!.aborted).toBe(1)
   })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -7,12 +7,13 @@ import { createSession, renderTurnRoleAnchor, renderTurnTimeAnchor, type AgentSe
 import { subscribeProviderErrors } from '@/agent/provider-error'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
-import { createCommandRegistry } from '@/commands'
+import { type Command, createCommandRegistry } from '@/commands'
 import { CORE_PERMISSIONS, type PermissionService } from '@/permissions'
 import type { HookBus } from '@/plugin'
 import { extractClaimCode } from '@/role-claim'
 import type { Stream } from '@/stream'
 
+import { formatChannelCommandHelp } from './commands'
 import { decideEngagement, grantStickyForReplyTargets, StickyLedger, type EngagementDecision } from './engagement'
 import {
   MEMBERSHIP_COLD_FETCH_TIMEOUT_MS,
@@ -439,14 +440,16 @@ type LiveSession = {
 // pipeline (e.g. Discord native slash commands fired from listener.on
 // ('interaction_create')). Handlers that need a real inbound — for some
 // future hypothetical command like `/quote` — must guard on event !== null
-// instead of assuming it.
+// instead of assuming it. `live` is null for session-less commands
+// (requiresLiveSession:false, e.g. /help); session-control handlers run only
+// after the dispatch layer has resolved a live session, so they may assert it.
 type ChannelCommandContext = {
-  live: LiveSession
+  live: LiveSession | null
   event: InboundMessage | null
 }
 
 export type ExecuteCommandResult =
-  | { kind: 'handled'; name: string }
+  | { kind: 'handled'; name: string; reply?: string }
   | { kind: 'unknown-command'; name: string }
   | { kind: 'no-live-session' }
   | { kind: 'permission-denied' }
@@ -721,14 +724,31 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const historyCallbacks = new Map<ChannelKey['adapter'], Set<HistoryCallback>>()
   const fetchAttachmentCallbacks = new Map<ChannelKey['adapter'], Set<FetchAttachmentCallback>>()
   const stickyLedger = new StickyLedger()
-  const commands = createCommandRegistry<ChannelCommandContext>([
+  // The /help handler reads the live registry to enumerate commands, so it
+  // forward-references `commands`. Safe at runtime — the handler only runs on
+  // invocation, long after the assignment below completes.
+  const channelCommands: readonly Command<ChannelCommandContext>[] = [
+    {
+      name: 'help',
+      description: 'List available commands.',
+      permission: 'none',
+      requiresLiveSession: false,
+      handler: () => ({ reply: formatChannelCommandHelp(commands.list()) }),
+    },
     {
       name: 'stop',
+      description: 'Stop the current agent turn in this channel.',
+      permission: 'session.control',
+      requiresLiveSession: true,
       handler: async ({ live }) => {
-        await stopCurrentChannelTurn(live)
+        // requiresLiveSession:true guarantees the dispatch layer resolved a
+        // session before running this handler, so `live` is non-null here.
+        await stopCurrentChannelTurn(live!)
+        return { reply: 'Stopped the current turn.' }
       },
     },
-  ])
+  ]
+  const commands = createCommandRegistry<ChannelCommandContext>(channelCommands)
 
   // Implicit dir-name alias: agent folder basename matches Docker
   // container name (per AGENTS.md), the typical Discord/Slack bot
@@ -1663,22 +1683,43 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // Commands are control traffic, not engaged inbounds; if the session is stale,
       // the next engaged inbound will perform the rollover before prompting.
       const keyId = channelKeyId(key)
-      if (!commands.has(parsedCommand.name)) {
+      const commandInfo = commands.get(parsedCommand.name)
+      if (commandInfo === undefined) {
         logger.info(`[channels] ${keyId}: ignoring unknown command /${parsedCommand.name}`)
         return
       }
-      if (isSessionControlDenied(event)) {
+      if (commandInfo.permission === 'session.control' && isSessionControlDenied(event)) {
         logger.info(
           `[channels] ${keyId}: denied command /${parsedCommand.name} by permissions (session.control) author=${event.authorId}`,
         )
         return
       }
-      const existingLive = liveSessions.get(keyId)
-      if (!existingLive || existingLive.destroyed) {
-        logger.info(`[channels] ${keyId}: ignoring command /${parsedCommand.name} with no live session`)
-        return
+      // Session-less commands (e.g. /help) are informational and run without a
+      // live session; their handler reply is posted straight back to the channel.
+      let existingLive: LiveSession | null = null
+      if (commandInfo.requiresLiveSession) {
+        existingLive = liveSessions.get(keyId) ?? null
+        if (existingLive === null || existingLive.destroyed) {
+          logger.info(`[channels] ${keyId}: ignoring command /${parsedCommand.name} with no live session`)
+          return
+        }
       }
       const commandResult = await commands.execute(event.text, { live: existingLive, event })
+      if (commandResult.kind === 'handled') {
+        if (commandResult.reply !== undefined) {
+          await send(
+            {
+              adapter: event.adapter,
+              workspace: event.workspace,
+              chat: event.chat,
+              thread: event.thread,
+              text: commandResult.reply,
+            },
+            { source: 'system' },
+          )
+        }
+        return
+      }
       if (commandResult.kind !== 'not-command') return
     }
 
@@ -2416,38 +2457,49 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     options: ExecuteCommandOptions,
   ): Promise<ExecuteCommandResult> => {
     const lowered = name.toLowerCase()
-    if (!commands.has(lowered)) {
+    const commandInfo = commands.get(lowered)
+    if (commandInfo === undefined) {
       return { kind: 'unknown-command', name: lowered }
     }
     // Gates on session.control (not channel.respond) so a respond-capable
     // guest cannot abort another speaker's turn. Runs BEFORE the live-session
     // lookup so an unauthorized invoker gets 'permission-denied' regardless of
     // session state, rather than leaking session presence via the
-    // 'no-live-session' vs 'permission-denied' distinction.
-    const partial: SessionOrigin = {
-      kind: 'channel',
-      adapter: key.adapter,
-      workspace: key.workspace,
-      chat: key.chat,
-      thread: key.thread,
-      lastInboundAuthorId: options.invokerId,
+    // 'no-live-session' vs 'permission-denied' distinction. Session-less
+    // informational commands (e.g. /help) declare permission:'none' and skip
+    // both the gate and the lookup so they work in channels with no live turn.
+    if (commandInfo.permission === 'session.control') {
+      const partial: SessionOrigin = {
+        kind: 'channel',
+        adapter: key.adapter,
+        workspace: key.workspace,
+        chat: key.chat,
+        thread: key.thread,
+        lastInboundAuthorId: options.invokerId,
+      }
+      if (!permissions.has(partial, CORE_PERMISSIONS.sessionControl)) {
+        return { kind: 'permission-denied' }
+      }
     }
-    if (!permissions.has(partial, CORE_PERMISSIONS.sessionControl)) {
-      return { kind: 'permission-denied' }
+    let live: LiveSession | null = null
+    if (commandInfo.requiresLiveSession) {
+      const resolved = resolveLiveSessionForCommand(liveSessions, key)
+      if (resolved.kind === 'none') {
+        return { kind: 'no-live-session' }
+      }
+      if (resolved.kind === 'ambiguous') {
+        return { kind: 'ambiguous', matchCount: resolved.count }
+      }
+      live = resolved.session
     }
-    const resolved = resolveLiveSessionForCommand(liveSessions, key)
-    if (resolved.kind === 'none') {
-      return { kind: 'no-live-session' }
-    }
-    if (resolved.kind === 'ambiguous') {
-      return { kind: 'ambiguous', matchCount: resolved.count }
-    }
-    const result = await commands.execute(`/${lowered}`, { live: resolved.session, event: null })
+    const result = await commands.execute(`/${lowered}`, { live, event: null })
     if (result.kind === 'handled') {
-      return { kind: 'handled', name: result.name }
+      return result.reply !== undefined
+        ? { kind: 'handled', name: result.name, reply: result.reply }
+        : { kind: 'handled', name: result.name }
     }
     // commands.execute can only return not-command (impossible — we pass a
-    // leading slash), unknown-command (impossible — we just checked has()),
+    // leading slash), unknown-command (impossible — we just checked get()),
     // or handled. Any other outcome is a bug.
     return { kind: 'unknown-command', name: lowered }
   }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -7,7 +7,7 @@ import { createSession, renderTurnRoleAnchor, renderTurnTimeAnchor, type AgentSe
 import { subscribeProviderErrors } from '@/agent/provider-error'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
-import { type Command, createCommandRegistry } from '@/commands'
+import { type Command, type CommandResult, createCommandRegistry } from '@/commands'
 import { CORE_PERMISSIONS, type PermissionService } from '@/permissions'
 import type { HookBus } from '@/plugin'
 import { extractClaimCode } from '@/role-claim'
@@ -1623,6 +1623,28 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
+  // Executes a parsed channel command and posts its reply (if any) back to the
+  // originating channel. Shared by the pre-gate public-command fast path and the
+  // post-gate command block so the execute→reply shape can't drift between them.
+  // Gating (channel.respond / session.control) and live-session resolution stay
+  // at the call sites — this helper only runs the handler and delivers the reply.
+  const runChannelCommand = async (event: InboundMessage, live: LiveSession | null): Promise<CommandResult> => {
+    const result = await commands.execute(event.text, { live, event })
+    if (result.kind === 'handled' && result.reply !== undefined) {
+      await send(
+        {
+          adapter: event.adapter,
+          workspace: event.workspace,
+          chat: event.chat,
+          thread: event.thread,
+          text: result.reply,
+        },
+        { source: 'system' },
+      )
+    }
+    return result
+  }
+
   const route = async (event: InboundMessage): Promise<void> => {
     const adapterConfig = options.configForAdapter(event.adapter)
     if (!adapterConfig) return
@@ -1670,6 +1692,25 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       }
     }
 
+    // Parse once, here, so the public-command fast path (below) and the
+    // post-gate command block share one parse and lookup.
+    const parsedCommand = commands.parse(event.text)
+    const commandInfo = parsedCommand === null ? undefined : commands.get(parsedCommand.name)
+
+    // Public-command fast path: a known command that is both ungated
+    // (permission:'none') AND informational (requiresLiveSession:false) runs
+    // BEFORE the channel.respond gate, mirroring the native-slash path where
+    // such commands skip permissions entirely. Both conditions are required so
+    // a future "public but live-session-aware" command can't silently bypass
+    // the gate. It only reveals already-public command names — it never creates
+    // a session or prompts the agent — so it is not a channel.respond bypass in
+    // any meaningful sense. Unknown commands, /stop, //escaped text, and plain
+    // messages all fall through to the gate unchanged.
+    if (parsedCommand !== null && commandInfo?.permission === 'none' && !commandInfo.requiresLiveSession) {
+      await runChannelCommand(event, null)
+      return
+    }
+
     if (isChannelRespondDenied(event)) {
       publishInbound(event, 'denied')
       logger.info(
@@ -1678,12 +1719,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return
     }
 
-    const parsedCommand = commands.parse(event.text)
     if (parsedCommand !== null) {
       // Commands are control traffic, not engaged inbounds; if the session is stale,
       // the next engaged inbound will perform the rollover before prompting.
       const keyId = channelKeyId(key)
-      const commandInfo = commands.get(parsedCommand.name)
       if (commandInfo === undefined) {
         logger.info(`[channels] ${keyId}: ignoring unknown command /${parsedCommand.name}`)
         return
@@ -1704,22 +1743,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           return
         }
       }
-      const commandResult = await commands.execute(event.text, { live: existingLive, event })
-      if (commandResult.kind === 'handled') {
-        if (commandResult.reply !== undefined) {
-          await send(
-            {
-              adapter: event.adapter,
-              workspace: event.workspace,
-              chat: event.chat,
-              thread: event.thread,
-              text: commandResult.reply,
-            },
-            { source: 'system' },
-          )
-        }
-        return
-      }
+      const commandResult = await runChannelCommand(event, existingLive)
       if (commandResult.kind !== 'not-command') return
     }
 

--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
+import { SLACK_SLASH_COMMAND_NAMES } from '@/channels/adapters/slack-bot'
+
 import {
   c,
   done,
@@ -452,6 +454,17 @@ describe('printSlackAppManifestSetup', () => {
     const stop = slashCommands.find((c) => c.command === '/stop')
     expect(stop).toBeDefined()
     expect(stop!.description).toBeTruthy()
+  })
+
+  test('manifest declares /help as a slash command with a description', () => {
+    const help = SLACK_APP_MANIFEST.features.slash_commands.find((c) => c.command === '/help')
+    expect(help).toBeDefined()
+    expect(help!.description).toBeTruthy()
+  })
+
+  test('manifest slash commands stay in sync with the runtime allow-list', () => {
+    const manifestNames = new Set(SLACK_APP_MANIFEST.features.slash_commands.map((c) => c.command.replace(/^\//, '')))
+    expect(manifestNames).toEqual(new Set(SLACK_SLASH_COMMAND_NAMES))
   })
 
   test('manifest grants the `commands` scope so slash_commands envelopes can route', () => {

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -153,6 +153,12 @@ export const SLACK_APP_MANIFEST = {
     // than silently routing real slash invocations to a third-party URL.
     slash_commands: [
       {
+        command: '/help',
+        description: 'List available commands',
+        url: 'https://example.invalid/typeclaw-uses-socket-mode',
+        should_escape: false,
+      },
+      {
         command: '/stop',
         description: 'Abort the current turn in this channel',
         // usage_hint is intentionally omitted. Slack's manifest validator

--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -21,6 +21,7 @@ describe('createCommandRegistry', () => {
       {
         name: 'stop',
         aliases: ['abort'],
+        description: 'Stop',
         handler: ({ label }, command) => {
           handled.push(`${label}:${command.name}`)
         },
@@ -42,10 +43,57 @@ describe('createCommandRegistry', () => {
   })
 
   test('reports whether a command or alias is registered', () => {
-    const registry = createCommandRegistry<undefined>([{ name: 'stop', aliases: ['abort'], handler: () => {} }])
+    const registry = createCommandRegistry<undefined>([
+      { name: 'stop', aliases: ['abort'], description: 'Stop', handler: () => {} },
+    ])
 
     expect(registry.has('STOP')).toBe(true)
     expect(registry.has('abort')).toBe(true)
     expect(registry.has('missing')).toBe(false)
+  })
+
+  test('surfaces a handler reply on the handled result', async () => {
+    const registry = createCommandRegistry<undefined>([
+      { name: 'help', description: 'List', handler: () => ({ reply: 'all commands' }) },
+    ])
+
+    await expect(registry.execute('/help', undefined)).resolves.toEqual({
+      kind: 'handled',
+      name: 'help',
+      reply: 'all commands',
+    })
+  })
+
+  test('lists canonical commands with defaulted policy, folding aliases', () => {
+    const registry = createCommandRegistry<undefined>([
+      { name: 'stop', aliases: ['abort'], description: 'Stop the turn', handler: () => {} },
+      {
+        name: 'help',
+        description: 'List commands',
+        permission: 'none',
+        requiresLiveSession: false,
+        handler: () => {},
+      },
+    ])
+
+    expect(registry.list()).toEqual([
+      {
+        name: 'stop',
+        aliases: ['abort'],
+        description: 'Stop the turn',
+        permission: 'session.control',
+        requiresLiveSession: true,
+      },
+      { name: 'help', aliases: [], description: 'List commands', permission: 'none', requiresLiveSession: false },
+    ])
+  })
+
+  test('get() resolves aliases to the canonical command info', () => {
+    const registry = createCommandRegistry<undefined>([
+      { name: 'stop', aliases: ['abort'], description: 'Stop the turn', handler: () => {} },
+    ])
+
+    expect(registry.get('ABORT')?.name).toBe('stop')
+    expect(registry.get('missing')).toBeUndefined()
   })
 })

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,8 +1,27 @@
-export type CommandHandler<Context> = (context: Context, command: ParsedCommand) => Promise<void> | void
+// Returning nothing keeps the void contract — the dispatch layer then falls
+// back to its static per-result-kind reply. A `reply` lets dynamic commands
+// (/help) surface text the dispatcher could not have known statically.
+export type CommandHandlerResult = void | { reply?: string }
+
+export type CommandHandler<Context> = (
+  context: Context,
+  command: ParsedCommand,
+) => Promise<CommandHandlerResult> | CommandHandlerResult
+
+// `permission` and `requiresLiveSession` are command-level policy the dispatch
+// layer (the channel router) enforces. They live on the command, not the
+// dispatcher, so a new command declares its own requirements in one place:
+// 'session.control' + requiresLiveSession:true is the control-command default
+// (/stop); 'none' + requiresLiveSession:false is the informational default
+// (/help). Both are optional so plain registries (tests, TUI) need not care.
+export type CommandPermission = 'none' | 'session.control'
 
 export type Command<Context> = {
   name: string
   aliases?: readonly string[]
+  description: string
+  permission?: CommandPermission
+  requiresLiveSession?: boolean
   handler: CommandHandler<Context>
 }
 
@@ -11,14 +30,27 @@ export type ParsedCommand = {
   args: string
 }
 
+// Read-only view of a registered command, used to generate help text from the
+// registry so the listing can never drift from the actual command set. Aliases
+// are folded into the canonical entry rather than listed as separate commands.
+export type CommandInfo = {
+  name: string
+  aliases: readonly string[]
+  description: string
+  permission: CommandPermission
+  requiresLiveSession: boolean
+}
+
 export type CommandResult =
   | { kind: 'not-command' }
   | { kind: 'unknown-command'; name: string }
-  | { kind: 'handled'; name: string }
+  | { kind: 'handled'; name: string; reply?: string }
 
 export type CommandRegistry<Context> = {
   parse: (text: string) => ParsedCommand | null
   has: (name: string) => boolean
+  get: (name: string) => CommandInfo | undefined
+  list: () => readonly CommandInfo[]
   execute: (text: string, context: Context) => Promise<CommandResult>
 }
 
@@ -33,16 +65,34 @@ export function createCommandRegistry<Context>(commands: readonly Command<Contex
     }
   }
 
+  const info = (command: Command<Context>): CommandInfo => ({
+    name: command.name,
+    aliases: command.aliases ?? [],
+    description: command.description,
+    permission: command.permission ?? 'session.control',
+    requiresLiveSession: command.requiresLiveSession ?? true,
+  })
+
   return {
     parse: parseCommand,
     has: (name) => byName.has(name.toLowerCase()),
+    get: (name) => {
+      const command = byName.get(name.toLowerCase())
+      return command ? info(command) : undefined
+    },
+    // Canonical commands only, in declaration order. Aliases resolve to the
+    // same Command object, so de-dupe by identity to avoid duplicate rows.
+    list: () => commands.map(info),
     execute: async (text, context) => {
       const parsed = parseCommand(text)
       if (parsed === null) return { kind: 'not-command' }
       const command = byName.get(parsed.name)
       if (!command) return { kind: 'unknown-command', name: parsed.name }
-      await command.handler(context, parsed)
-      return { kind: 'handled', name: command.name }
+      const result = await command.handler(context, parsed)
+      const reply = result?.reply
+      return reply !== undefined
+        ? { kind: 'handled', name: command.name, reply }
+        : { kind: 'handled', name: command.name }
     },
   }
 }


### PR DESCRIPTION
## Background

Channel users had no way to discover what commands an agent accepts. The only
command was `/stop`, and you had to already know it existed. There was also no
in-band, zero-cost way to ask — typing anything that wasn't `/stop` fell through
to the agent and burned an LLM turn just to answer "what can I type here?".

This adds a `/help` command that lists the available commands and replies
directly, without ever reaching the agent (no LLM call).

## Summary

`/help` is registered as a normal channel command alongside `/stop`, so it works
on every surface that already routes commands: text-prefix `/help`, Slack native
slash command, Slack `!help` thread fallback, and Discord slash interaction.

Two design decisions a reviewer would otherwise have to ask about:

- **Generated, not hardcoded help text.** `/help` enumerates the registry via
  new `list()`/`get()` metadata accessors and formats from each command's
  `description`. Adding a future command makes it appear in `/help`
  automatically — the listing can't drift from the actual command set.

- **Session-less + ungated, modeled explicitly rather than special-cased.**
  `/stop` requires a live turn and `session.control` permission. `/help` needs
  neither. Instead of branching on the command *name* in the dispatcher, commands
  now declare `permission` and `requiresLiveSession`, and both dispatch paths
  (`route()` text-prefix and `executeCommand`) honor those declarations. `/help`
  is ungated because it only reveals command names that are already public via
  the platform slash-command pickers; gating it behind `session.control` would
  make it useless in the exact shared channels where discovery matters most.

The registry generalization (metadata + a `{ reply }` handler payload) lands as a
separate first commit with no behavior change, so the `/help` commit is purely
the feature.

## What this does NOT do

- Does not add a TUI-local `/help`. The TUI only intercepts `/quit`/`/exit`
  client-side; `/help` typed in the TUI would reach the server like any prompt.
  Out of scope here.
- Does not introduce per-command help visibility (e.g. hiding admin-only
  commands from the listing). With only `stop` + `help` today there's nothing to
  hide; that can be modeled later if a sensitive command is added.
- Does not rename the Discord/Slack `STOP_REPLY_*` constants now that the reply
  path is shared — they remain accurate for `/stop`, and `/help` uses the
  handler-provided `reply`.

## Review notes

- Load-bearing change: the two dispatch sites in `src/channels/router.ts`
  (`route()` text-prefix block and `executeCommand`) now branch on
  `commandInfo.permission` / `commandInfo.requiresLiveSession`. Verify `/stop`
  still gates on `session.control` and still returns `no-live-session` on a cold
  channel — covered by the existing tests, which were updated only to reflect
  that `/stop` now also carries a confirmation `reply`.
- The `/help` handler forward-references `commands` (it reads the registry it
  belongs to). This is safe because the handler only runs on invocation, long
  after construction; the array is declared first, then handed to
  `createCommandRegistry`.
- Slack manifest sync: `SLACK_APP_MANIFEST.features.slash_commands` and the
  runtime `SLACK_SLASH_COMMAND_NAMES` allow-list are now asserted equal by a new
  drift test in `ui.test.ts`, making good on the comment that already claimed
  this invariant.
