### PR TITLE
Add enabled flag to MCP server config

### DIFF
--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -188,6 +188,7 @@ describe('mcpServerSchema', () => {
     })
     expect(parsed).toEqual({
       name: 'filesystem',
+      enabled: true,
       command: 'bunx',
       args: ['@modelcontextprotocol/server-filesystem'],
       env: {},
@@ -196,7 +197,31 @@ describe('mcpServerSchema', () => {
 
   test('accepts an http server config', () => {
     const parsed = mcpServerSchema.parse({ name: 'remote-docs', url: 'https://mcp.example.com/mcp' })
-    expect(parsed).toEqual({ name: 'remote-docs', args: [], url: 'https://mcp.example.com/mcp', env: {} })
+    expect(parsed).toEqual({
+      name: 'remote-docs',
+      enabled: true,
+      args: [],
+      url: 'https://mcp.example.com/mcp',
+      env: {},
+    })
+  })
+
+  test('defaults enabled to true when omitted', () => {
+    const parsed = mcpServerSchema.parse({ name: 'default-on', command: 'server' })
+
+    expect(parsed.enabled).toBe(true)
+  })
+
+  test('preserves enabled: false', () => {
+    const parsed = mcpServerSchema.parse({ name: 'disabled', enabled: false, command: 'server' })
+
+    expect(parsed.enabled).toBe(false)
+  })
+
+  test('preserves explicit enabled: true', () => {
+    const parsed = mcpServerSchema.parse({ name: 'explicitly-on', enabled: true, command: 'server' })
+
+    expect(parsed.enabled).toBe(true)
   })
 
   test('preserves explicit request timeout', () => {
@@ -306,8 +331,14 @@ describe('configSchema mcpServers field', () => {
     })
 
     expect(parsed.mcpServers).toEqual([
-      { name: 'filesystem', command: 'bunx', args: ['@modelcontextprotocol/server-filesystem'], env: {} },
-      { name: 'remote-docs', args: [], url: 'https://mcp.example.com/mcp', env: {} },
+      {
+        name: 'filesystem',
+        enabled: true,
+        command: 'bunx',
+        args: ['@modelcontextprotocol/server-filesystem'],
+        env: {},
+      },
+      { name: 'remote-docs', enabled: true, args: [], url: 'https://mcp.example.com/mcp', env: {} },
     ])
   })
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -78,6 +78,8 @@ export const mcpServerSchema = z
         message: "MCP server name must not contain '__' (reserved as the tool-namespace separator)",
       }),
     description: z.string().optional(),
+    // Default true so omitting the field keeps the server on; set false to keep config but skip connecting.
+    enabled: z.boolean().default(true),
     timeoutMs: z.number().int().positive().max(MCP_MAX_TIMEOUT_MS).optional(),
     command: z.string().trim().min(1).optional(),
     args: z.array(z.string()).default([]),

--- a/src/mcp/client.test.ts
+++ b/src/mcp/client.test.ts
@@ -162,6 +162,7 @@ describe('connectMcpServer', () => {
 function server(timeoutMs?: number): McpServer {
   return {
     name: 'server',
+    enabled: true,
     command: 'server-command',
     args: [],
     env: {},

--- a/src/mcp/manager.test.ts
+++ b/src/mcp/manager.test.ts
@@ -61,6 +61,32 @@ describe('createMcpManager', () => {
     ])
   })
 
+  test('keeps disabled servers invisible to connection lookup and server listing', async () => {
+    const connected: string[] = []
+    const servers: McpServer[] = [server('alpha'), server('disabled', false), server('gamma')]
+    const manager = createMcpManager(servers, {
+      env: {},
+      async connect(mcpServer) {
+        connected.push(mcpServer.name)
+        return fakeConnection(
+          mcpServer.name,
+          [{ name: `${mcpServer.name}-tool`, description: '', inputSchema: {} }],
+          [],
+        )
+      },
+    })
+
+    const results = await manager.connectAll()
+
+    expect(connected).toEqual(['alpha', 'gamma'])
+    expect(results.map((result) => result.name)).toEqual(['alpha', 'gamma'])
+    expect(manager.getConnection('disabled')).toBeUndefined()
+    expect(manager.listServers()).toEqual([
+      { name: 'alpha', connected: true, toolCount: 1 },
+      { name: 'gamma', connected: true, toolCount: 1 },
+    ])
+  })
+
   test('threads an abort signal to each connector', async () => {
     const signals: (AbortSignal | undefined)[] = []
     const abort = new AbortController()
@@ -151,8 +177,8 @@ describe('createMcpManager', () => {
   })
 })
 
-function server(name: string): McpServer {
-  return { name, command: 'server-command', args: [], env: {} }
+function server(name: string, enabled = true): McpServer {
+  return { name, enabled, command: 'server-command', args: [], env: {} }
 }
 
 function fakeConnection(name: string, tools: McpToolInfo[], closed: string[]): McpConnection {

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -27,6 +27,7 @@ export function createMcpManager(
   servers: McpServer[],
   opts: { env: NodeJS.ProcessEnv; connect?: ConnectMcpServerFn },
 ): McpManager {
+  const activeServers = servers.filter((server) => server.enabled)
   const connect = opts.connect ?? connectMcpServer
   const connections = new Map<string, McpConnection>()
   const toolCounts = new Map<string, number>()
@@ -35,7 +36,7 @@ export function createMcpManager(
     async connectAll(connectOpts: { signal?: AbortSignal } = {}): Promise<McpConnectResult[]> {
       const firstIndexByName = new Map<string, number>()
       const results = await Promise.all(
-        servers.map((server, index): Promise<McpConnectResult> => {
+        activeServers.map((server, index): Promise<McpConnectResult> => {
           // The name is the tool namespace and the connections key, so a second
           // server sharing a name would silently shadow the first. Fail the
           // duplicate fast instead of connecting it, keeping routing unambiguous.
@@ -64,7 +65,7 @@ export function createMcpManager(
       return connections.get(name)
     },
     listServers(): { name: string; description?: string; connected: boolean; toolCount?: number }[] {
-      return servers.map((server) => {
+      return activeServers.map((server) => {
         const toolCount = toolCounts.get(server.name)
         return {
           name: server.name,


### PR DESCRIPTION
Stacked on #524 — review/merge in order. (Supersedes #525, which GitHub auto-closed after a stack rebase; the enabled-flag change is unchanged.)

## Background

During review of the MCP stack we wanted a way to keep a server's config in `typeclaw.json` while turning it off — e.g. a server that hangs on connect, or one you're temporarily not using — without deleting and re-adding its block.

## Summary

Adds an `enabled` boolean to each MCP server entry, defaulting to `true`.

- Positive polarity, default-true — omitting the field keeps the server on, matching typeclaw's existing convention (cron job `enabled`, docker feature toggles). A `disabled` flag would be the only negative-polarity toggle in the schema.
- A disabled server is completely invisible: the manager filters disabled servers out at construction (`servers.filter((s) => s.enabled)`), so they are never connected, never spawned, and never appear in the system-prompt catalog or the dispatcher's server lookup — one filter point covers both connection and discovery.
- No `FIELD_EFFECTS` change: `enabled` is a subfield of the already-`restart-required` `mcpServers` path.

## What this does NOT do

No hot-reload of the flag (restart-required like the rest of mcpServers). No per-tool enable/disable — server granularity only.

## Review notes

The load-bearing change is the single manager-level filter — verify the test asserting a disabled server is never connected (fake connect not invoked) and is absent from listServers()/getConnection(). This also doubles as the mitigation for the connect-hang concern raised in review: disable a misbehaving server instead of removing it.