### PR TITLE
feat(github): wake the agent when assigned to a PR

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -141,6 +141,72 @@ describe('classifyGithubInbound', () => {
     })
   })
 
+  describe('pull_request.assigned', () => {
+    it('wakes the bot when it is the assignee', () => {
+      const msg = classifyGithubInbound(
+        'pull_request',
+        assignedPayload({ assigneeLogin: 'typeclaw-bot' }),
+        'typeclaw-bot',
+      )
+      expect(msg?.chat).toBe('pr:7')
+      expect(msg?.thread).toBe(null)
+      expect(msg?.text).toContain('@alice')
+      expect(msg?.text).toContain('assigned you to PR #7')
+      expect(msg?.text).toContain('feat-branch → main')
+      expect(msg?.text).toContain('Please review the changes line-by-line')
+      expect(msg?.isBotMention).toBe(true)
+      expect(msg?.authorName).toBe('alice')
+    })
+
+    it('drops assignments targeting someone else', () => {
+      const msg = classifyGithubInbound(
+        'pull_request',
+        assignedPayload({ assigneeLogin: 'someone-else' }),
+        'typeclaw-bot',
+      )
+      expect(msg).toBe(null)
+    })
+
+    it('drops self-loop when the bot assigned itself', () => {
+      const payload = assignedPayload({ assigneeLogin: 'typeclaw-bot' })
+      ;(payload.sender as Record<string, unknown>).login = 'typeclaw-bot'
+      const msg = classifyGithubInbound('pull_request', payload, 'typeclaw-bot')
+      expect(msg).toBe(null)
+    })
+
+    it('does NOT treat unassigned as an assignment wake (no bot-mention)', () => {
+      const payload = assignedPayload({ assigneeLogin: 'typeclaw-bot' })
+      payload.action = 'unassigned'
+      const msg = classifyGithubInbound('pull_request', payload, 'typeclaw-bot')
+      expect(msg?.text).not.toContain('assigned you to PR')
+      expect(msg?.isBotMention).not.toBe(true)
+    })
+
+    it('mints an externalMessageId distinct from a review_requested on the same PR', () => {
+      const assigned = classifyGithubInbound(
+        'pull_request',
+        assignedPayload({ assigneeLogin: 'typeclaw-bot', updatedAt: '2026-01-01T00:00:00Z' }),
+        'typeclaw-bot',
+      )
+      const requested = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot', updatedAt: '2026-01-01T00:00:00Z' }),
+        'typeclaw-bot',
+      )
+      expect(assigned?.externalMessageId).not.toBe(requested?.externalMessageId)
+    })
+
+    it('falls back to PR id when title/branch info is absent', () => {
+      const payload = assignedPayload({ assigneeLogin: 'typeclaw-bot' })
+      delete (payload.pull_request as Record<string, unknown>).title
+      delete (payload.pull_request as Record<string, unknown>).head
+      delete (payload.pull_request as Record<string, unknown>).base
+      const msg = classifyGithubInbound('pull_request', payload, 'typeclaw-bot')
+      expect(msg?.text).toContain('PR #7')
+      expect(msg?.text).not.toContain('Branch:')
+    })
+  })
+
   describe('pull_request.opened', () => {
     it('treats an opened PR as a review request in App mode', () => {
       const msg = classifyGithubInbound('pull_request', openedPayload(), 'typeclaw-bot', { authType: 'app' })
@@ -685,6 +751,16 @@ function reviewRequestedTeamPayload(): Record<string, unknown> {
     repository: repo(),
     pull_request: pullRequestForReview('2026-01-01T00:00:00Z'),
     requested_team: { slug: 'reviewers', id: 5000 },
+    sender: { login: 'alice', id: 10, type: 'User' },
+  }
+}
+
+function assignedPayload(options: { assigneeLogin: string; updatedAt?: string }): Record<string, unknown> {
+  return {
+    action: 'assigned',
+    repository: repo(),
+    pull_request: pullRequestForReview(options.updatedAt ?? '2026-01-01T00:00:00Z'),
+    assignee: { login: options.assigneeLogin, id: 42, type: 'User' },
     sender: { login: 'alice', id: 10, type: 'User' },
   }
 }

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -181,6 +181,9 @@ export function classifyGithubInbound(
         teamIsBotMember: options?.teamIsBotMember,
       })
     }
+    if (action === 'assigned') {
+      return classifyAssignment({ payload, pr, number, base, selfLogin })
+    }
     // A GitHub App cannot be added to a PR's requested_reviewers, so it never
     // receives a review_requested event targeting itself. The opened event is
     // the only signal it can act on, so in App mode an opened PR is promoted to
@@ -294,6 +297,60 @@ function classifyReviewRequest(input: ReviewRequestInput): InboundMessage | null
     thread: null,
     text,
     externalMessageId,
+    authorId: String(sender.id),
+    authorName: sender.login,
+    authorIsBot: sender.type === 'Bot',
+    isBotMention: true,
+    replyToBotMessageId: null,
+    ts: updatedAt !== '' ? Date.parse(updatedAt) || 0 : 0,
+  }
+}
+
+type AssignmentInput = {
+  payload: Record<string, unknown>
+  pr: Record<string, unknown>
+  number: number
+  base: Pick<InboundMessage, 'adapter' | 'workspace' | 'isDm' | 'mentionsOthers' | 'replyToOtherMessageId'>
+  selfLogin: string | null
+}
+
+// A GitHub App cannot be added as an issue/PR assignee (the assignee API takes
+// usernames and silently ignores App bots), so this path only ever fires for a
+// real user identity — i.e. PAT auth, including the decoy-user setup where a
+// human account shares the App's name/avatar. The App-auth wake path stays
+// classifyOpenedAsReview. Only `assigned` is handled: `unassigned` is omitted
+// on purpose because a new inbound cannot hard-interrupt an in-flight turn (see
+// router.ts — hard interrupt is not part of v1), so waking a session to "stop"
+// would burn a turn the agent cannot reliably act on.
+function classifyAssignment(input: AssignmentInput): InboundMessage | null {
+  const { payload, pr, number, base, selfLogin } = input
+  if (selfLogin === null) return null
+  const sender = readUser(payload.sender)
+  if (sender === null) return null
+  // Self-loop guard: the bot assigning itself would otherwise wake a fresh
+  // session on every self-assign. Mirrors classifyReviewRequest.
+  if (sender.login === selfLogin) return null
+
+  const assignee = readUser(payload.assignee)
+  if (assignee === null || assignee.login !== selfLogin) return null
+
+  const title = readString(pr, 'title') ?? `#${number}`
+  const head = readString(readRecord(pr.head), 'ref')
+  const baseRef = readString(readRecord(pr.base), 'ref')
+  const branchSegment = head !== null && baseRef !== null ? ` Branch: ${head} → ${baseRef}.` : ''
+  const text =
+    `@${sender.login} assigned you to PR #${number}: "${title}".${branchSegment}` +
+    ' Please review the changes line-by-line and post your feedback.'
+
+  const updatedAt = readString(pr, 'updated_at') ?? ''
+  const prId = readNumber(pr, 'id') ?? number
+
+  return {
+    ...base,
+    chat: `pr:${number}`,
+    thread: null,
+    text,
+    externalMessageId: `pr-${prId}-assigned-${updatedAt}`,
     authorId: String(sender.id),
     authorName: sender.login,
     authorIsBot: sender.type === 'Bot',

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -127,6 +127,7 @@ export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [
   'pull_request.opened',
   'pull_request.review_requested',
   'pull_request.review_request_removed',
+  'pull_request.assigned',
   'discussion.created',
   'pull_request_review.submitted',
 ] as const

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -33,8 +33,9 @@ You are being asked to review a PR in **either** of these cases — treat them i
 
 - **(A) An explicit review-request inbound.** The message text says **"requested your review on PR #N"** or **"requested a review from team @… on PR #N"**. (You do not need to know how it was triggered — the adapter synthesizes this same text whether a human assigned you as a reviewer or, for a GitHub App that cannot be added to `requested_reviewers`, when the PR was opened. From your side it reads the same.)
 - **(B) A human asks you to review in plain language** in a PR/issue body or any comment — "@bot review this PR", "can you take a look at #123", "review the changes when you get a chance". There is no synthetic request text here; you recognize the intent from the message.
+- **(C) An assignment inbound.** The message text says **"assigned you to PR #N"**. Someone added you as an assignee (not a reviewer). Treat it the same as (A) — it is the assignee-based wake path for a real-user identity that mirrors the review-request path.
 
-Both → run the **PR review flow**. Do not review inline yourself and do not just reply with prose impressions: delegate to the `reviewer` subagent so the analysis runs on the `deep` model, then post its findings as an inline review.
+All three → run the **PR review flow**. Do not review inline yourself and do not just reply with prose impressions: delegate to the `reviewer` subagent so the analysis runs on the `deep` model, then post its findings as an inline review.
 
 A `review_request_removed` inbound ("removed your review request on PR #N") is the inverse: the requester un-assigned you. Cancel any in-flight reviewer subagent (`subagent_cancel`) and do not post a partial review.
 


### PR DESCRIPTION
## What

Adds a `pull_request.assigned` engagement path to the GitHub channel adapter. When someone assigns the bot's user identity to a PR (by username), the adapter synthesizes a review-request inbound — mirroring the existing `review_requested` handling.

## Why

A GitHub **App** can be neither a requested reviewer nor an assignee (the assignee REST API takes usernames and silently ignores App bots). The only identity that *can* be assigned by username is a **real user** — i.e. PAT auth, including the "decoy user" pattern where a human account shares the App's name and avatar to look like the app in mentions/comments. This wires assignment up as a first-class wake signal for that identity, alongside the review-request path it already supports.

| Auth | `review_requested` | `assigned` (new) | `opened` |
|---|---|---|---|
| **PAT / decoy user** | engage on username match | **engage on username match** | ignored (waits for explicit signal) |
| **App (`slug[bot]`)** | never targets App | never targets App | promoted to review (unchanged) |

## Design notes

- **`unassigned` is intentionally omitted.** A new inbound cannot hard-interrupt an in-flight turn (`router.ts` — hard interrupt is not part of v1), so waking a session to "stop" would burn a turn the agent cannot reliably act on. The existing `review_request_removed` already over-promises here; this PR does not extend that pattern.
- **Self-loop guard** drops self-assign (`sender.login === selfLogin`), mirroring `classifyReviewRequest`.
- **No team variant** — assignees have no team concept (unlike reviewers).
- The App-only `classifyOpenedAsReview` path is unchanged; it remains the App's only wake signal.

## Changes

- `inbound.ts` — `classifyAssignment` + `assigned` branch in `classifyGithubInbound`.
- `schema.ts` — add `pull_request.assigned` to `DEFAULT_GITHUB_EVENT_ALLOWLIST` (webhook-install consumes this constant, so registration picks it up automatically).
- `inbound.test.ts` — 6 vectors: assignee-is-bot, targets-other (dropped), self-loop, unassigned-not-a-wake, distinct externalMessageId, title/branch fallback.
- `typeclaw-channel-github/SKILL.md` — document the assignment inbound (case C) as a review trigger.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, in untouched files)
- `bun run format` — clean
- `bun test --parallel src/channels/adapters/github/inbound.test.ts` — 44 pass
- schema + webhook-register tests — pass