### PR TITLE
feat(github): engage App on review requests to its decoy user

### DIFF
--- a/docs/content/docs/internals/github-decoy-reviewer.mdx
+++ b/docs/content/docs/internals/github-decoy-reviewer.mdx
@@ -1,0 +1,74 @@
+---
+title: GitHub decoy reviewer
+description: Why a GitHub App needs a decoy user account to be "assigned to review", and how the adapter matches review requests against it
+icon: UserCheck
+---
+
+A GitHub **App** cannot be added as a pull-request reviewer. The
+`requested_reviewer` field on a `pull_request.review_requested` webhook only
+ever holds a real **user** account; the App actor (`slug[bot]`) is not one, so
+GitHub never emits a `review_requested` event targeting an App. The same is
+true for assignees (`assignee` is also a user) and for `@`-mentions (an App's
+`[bot]` handle is not a mentionable account in the normal sense).
+
+This breaks the natural "assign the bot to review my PR" workflow for any
+TypeClaw agent running under App auth (`channels.github.auth.type: "app"`).
+
+## The decoy-user pattern
+
+The supported workaround is to create a **real GitHub user account that
+impersonates the App** — same display name, same avatar — and request _that
+account_ as the reviewer. To a human looking at the PR, the reviewer reads as
+the app. Comments the agent posts still come from the App identity (the agent
+authenticates as the App), so the visible identity stays consistent.
+
+By convention the decoy account is named after the App's **slug**: an App
+whose bot actor is `my-app[bot]` is impersonated by a user account with login
+`my-app`. Requesting `my-app` as a reviewer is what wakes the agent.
+
+## How the adapter matches it
+
+`classifyReviewRequest` (`src/channels/adapters/github/inbound.ts`) compares the
+incoming `requested_reviewer.login` against the bot's identity. Under App auth
+`selfLogin` is the bot actor `slug[bot]`, which can never match a real reviewer
+login — so the classifier also derives a **decoy login** and matches against
+it:
+
+```ts
+function resolveDecoyReviewerLogin(selfLogin, authType) {
+  if (authType !== 'app') return null // PAT: the bot IS a real user
+  if (!selfLogin.endsWith('[bot]')) return null
+  return selfLogin.slice(0, -'[bot]'.length) || null // my-app[bot] → my-app
+}
+```
+
+A `review_requested` engages the agent when `requested_reviewer.login` equals
+**either** `selfLogin` (the exact `slug[bot]`, kept for completeness) **or** the
+derived decoy login. The same decoy login extends the self-loop guard, so a
+review the decoy account requested of itself is dropped rather than waking a
+fresh session.
+
+Under **PAT auth** there is no decoy: the bot is a real user that can be
+requested directly by its exact login, so `resolveDecoyReviewerLogin` returns
+`null` and matching stays strict (`requested_reviewer.login === selfLogin`).
+
+## Relationship to opened-as-review
+
+`classifyOpenedAsReview` (App mode only) promotes a `pull_request.opened` event
+to a review request because, historically, `opened` was the _only_ signal an
+App could act on. The decoy-reviewer path is the more targeted alternative: it
+lets a human explicitly request review on a specific PR rather than the App
+reviewing every opened PR. Both paths coexist — an operator who configures a
+decoy reviewer gets explicit, on-demand review requests; one who does not still
+gets the broad opened-PR behavior.
+
+## Why slug-derivation, not config (for now)
+
+The slug-strip is a **heuristic default**: it assumes the decoy account's login
+equals the App slug, which holds when the slug was still available as a username
+at account-creation time. When a decoy account's real login diverges from the
+slug (the username was taken, so the operator used `my-app-bot`, `myapp`, …),
+this derivation is the single seam to replace — `resolveDecoyReviewerLogin` is
+the only place the decoy login is computed. A future
+`channels.github.auth.reviewerLogin` (or equivalent) config field slots in there
+without touching the matcher.

--- a/docs/content/docs/internals/meta.json
+++ b/docs/content/docs/internals/meta.json
@@ -10,6 +10,7 @@
     "tunnels",
     "message-stream",
     "engagement",
+    "github-decoy-reviewer",
     "web-search",
     "xvfb",
     "sandbox"

--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -141,6 +141,62 @@ describe('classifyGithubInbound', () => {
     })
   })
 
+  describe('pull_request.review_requested — App decoy reviewer', () => {
+    // In App mode selfLogin is the bot actor `slug[bot]`, which can never appear
+    // as a requested_reviewer. The decoy account named after the App (login =
+    // slug, here `typeclaw`) is what an operator actually requests.
+    it('wakes the App when the decoy (slug) account is requested', () => {
+      const msg = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'typeclaw' }),
+        'typeclaw[bot]',
+        { authType: 'app' },
+      )
+      expect(msg?.chat).toBe('pr:7')
+      expect(msg?.text).toContain('requested your review on PR #7')
+      expect(msg?.isBotMention).toBe(true)
+    })
+
+    it('still wakes the App when the exact slug[bot] login is requested', () => {
+      const msg = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'typeclaw[bot]' }),
+        'typeclaw[bot]',
+        { authType: 'app' },
+      )
+      expect(msg?.isBotMention).toBe(true)
+    })
+
+    it('drops decoy requests targeting an unrelated user', () => {
+      const msg = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'someone-else' }),
+        'typeclaw[bot]',
+        { authType: 'app' },
+      )
+      expect(msg).toBe(null)
+    })
+
+    it('does NOT treat the slug as self in PAT mode', () => {
+      // PAT auth has no decoy: the bot is a real user requested by its exact
+      // login. A bare `typeclaw` reviewer must not match a `typeclaw[bot]` self.
+      const msg = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'typeclaw' }),
+        'typeclaw[bot]',
+        { authType: 'pat' },
+      )
+      expect(msg).toBe(null)
+    })
+
+    it('drops self-loop when the decoy account requested the review itself', () => {
+      const payload = reviewRequestedPayload({ reviewerLogin: 'typeclaw' })
+      ;(payload.sender as Record<string, unknown>).login = 'typeclaw'
+      const msg = classifyGithubInbound('pull_request', payload, 'typeclaw[bot]', { authType: 'app' })
+      expect(msg).toBe(null)
+    })
+  })
+
   describe('pull_request.opened', () => {
     it('treats an opened PR as a review request in App mode', () => {
       const msg = classifyGithubInbound('pull_request', openedPayload(), 'typeclaw-bot', { authType: 'app' })

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -178,6 +178,7 @@ export function classifyGithubInbound(
         number,
         base,
         selfLogin,
+        authType: options?.authType ?? 'pat',
         teamIsBotMember: options?.teamIsBotMember,
       })
     }
@@ -242,23 +243,46 @@ type ReviewRequestInput = {
   number: number
   base: Pick<InboundMessage, 'adapter' | 'workspace' | 'isDm' | 'mentionsOthers' | 'replyToOtherMessageId'>
   selfLogin: string | null
+  authType: 'pat' | 'app'
   teamIsBotMember: boolean | undefined
 }
 
+// A GitHub App can never be a `requested_reviewer` — that field only holds
+// real user accounts, and the App actor (`slug[bot]`) is not one. The
+// supported workaround is a decoy user account named after the App that an
+// operator requests instead (see docs/content/docs/internals/github-decoy-reviewer.mdx).
+// Its login is, by convention, the App slug — i.e. `selfLogin` with the
+// `[bot]` suffix removed (`my-app[bot]` → `my-app`). This is the single seam
+// where that login is resolved: when the decoy account's real login diverges
+// from the slug, a future config field replaces this derivation without
+// touching the matcher. PAT auth has no decoy (the bot IS a real user that can
+// be requested directly), so it returns null.
+const BOT_LOGIN_SUFFIX = '[bot]'
+
+function resolveDecoyReviewerLogin(selfLogin: string, authType: 'pat' | 'app'): string | null {
+  if (authType !== 'app') return null
+  if (!selfLogin.endsWith(BOT_LOGIN_SUFFIX)) return null
+  const slug = selfLogin.slice(0, -BOT_LOGIN_SUFFIX.length)
+  return slug !== '' ? slug : null
+}
+
 function classifyReviewRequest(input: ReviewRequestInput): InboundMessage | null {
-  const { action, payload, pr, number, base, selfLogin, teamIsBotMember } = input
+  const { action, payload, pr, number, base, selfLogin, authType, teamIsBotMember } = input
   if (selfLogin === null) return null
+  const decoyLogin = resolveDecoyReviewerLogin(selfLogin, authType)
   const sender = readUser(payload.sender)
   if (sender === null) return null
-  // Self-loop guard: if the bot itself requested (or un-requested) the
+  // Self-loop guard: if the bot (or its decoy) requested/un-requested the
   // review, drop the event. The bot adding itself as a reviewer would
   // otherwise wake a fresh session every time it self-assigns.
-  if (sender.login === selfLogin) return null
+  if (sender.login === selfLogin || (decoyLogin !== null && sender.login === decoyLogin)) return null
 
   const requestedUser = readUser(payload.requested_reviewer)
   const requestedTeam = readReviewerTeam(payload.requested_team)
 
-  const isMeAsUser = requestedUser !== null && requestedUser.login === selfLogin
+  const isMeAsUser =
+    requestedUser !== null &&
+    (requestedUser.login === selfLogin || (decoyLogin !== null && requestedUser.login === decoyLogin))
   const isMyTeam = requestedTeam !== null && teamIsBotMember === true
   if (!isMeAsUser && !isMyTeam) return null
 

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -31,7 +31,7 @@ Every GitHub inbound lands on a `chat` keyed by its subject: `issue:N`, `pr:N`, 
 
 You are being asked to review a PR in **either** of these cases — treat them identically:
 
-- **(A) An explicit review-request inbound.** The message text says **"requested your review on PR #N"** or **"requested a review from team @… on PR #N"**. (You do not need to know how it was triggered — the adapter synthesizes this same text whether a human assigned you as a reviewer or, for a GitHub App that cannot be added to `requested_reviewers`, when the PR was opened. From your side it reads the same.)
+- **(A) An explicit review-request inbound.** The message text says **"requested your review on PR #N"** or **"requested a review from team @… on PR #N"**. (You do not need to know how it was triggered — the adapter synthesizes this same text whether a human requested you as a reviewer directly, requested a decoy user account that impersonates you as a GitHub App, or — for a GitHub App with no decoy configured — when the PR was opened. From your side it reads the same. See [GitHub decoy reviewer](/docs/internals/github-decoy-reviewer).)
 - **(B) A human asks you to review in plain language** in a PR/issue body or any comment — "@bot review this PR", "can you take a look at #123", "review the changes when you get a chance". There is no synthetic request text here; you recognize the intent from the message.
 
 Both → run the **PR review flow**. Do not review inline yourself and do not just reply with prose impressions: delegate to the `reviewer` subagent so the analysis runs on the `deep` model, then post its findings as an inline review.


### PR DESCRIPTION
## What

Makes a TypeClaw agent running under **GitHub App auth** wake on a `pull_request.review_requested` event when the requested reviewer is the App's **decoy user account**, not just the literal `slug[bot]` actor.

## Why

A GitHub **App cannot be a `requested_reviewer`** — that field only holds real user accounts, and the App actor (`slug[bot]`) is not one. So GitHub never emits a `review_requested` event targeting an App, breaking the natural "assign the bot to review my PR" flow under App auth.

The supported workaround is a **decoy user account that impersonates the App** (same display name + avatar). A human requests *that account* as reviewer; to everyone on the PR it reads as the app, and the agent still posts comments as the App identity. By convention the decoy account is named after the App slug (`my-app[bot]` → decoy login `my-app`).

## How

`classifyReviewRequest` (`src/channels/adapters/github/inbound.ts`) now:
- Derives a **decoy login** in App mode by stripping the `[bot]` suffix from `selfLogin` (`my-app[bot]` → `my-app`), via a single resolver `resolveDecoyReviewerLogin`.
- Matches `requested_reviewer.login` against `selfLogin` **OR** the decoy login.
- Extends the self-loop guard to the decoy login too.

**PAT auth is unchanged**: the bot is a real user requested by its exact login, so the resolver returns `null` and matching stays strict.

| Auth | `review_requested` matches against |
|---|---|
| **PAT** | `selfLogin` (exact) — unchanged |
| **App** | `selfLogin` (`slug[bot]`) **OR** decoy login (`slug`) |

## Config-extraction seam

The slug-strip is a heuristic default (assumes the decoy login equals the App slug). `resolveDecoyReviewerLogin` is the **single seam**: when a decoy account's real login diverges from the slug, a future `channels.github.auth.reviewerLogin` (or equivalent) config field replaces the derivation without touching the matcher. This is called out in the doc and the code comment.

## Changes

- `inbound.ts` — `resolveDecoyReviewerLogin` + decoy matching in `classifyReviewRequest` (threads `authType` in).
- `inbound.test.ts` — 5 vectors: decoy-slug engages (App), exact `slug[bot]` still engages (App), unrelated reviewer dropped, slug does NOT match self in PAT mode, decoy self-loop guard.
- `docs/content/docs/internals/github-decoy-reviewer.mdx` (+ `meta.json`) — documents the pattern, the matcher, the relationship to opened-as-review, and why slug-derivation precedes config.
- `typeclaw-channel-github/SKILL.md` — widened the review-trigger note (case A) to name the decoy path.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, untouched files)
- `bun run format` — clean
- `bun test --parallel src/channels/adapters/github/inbound.test.ts` — 43 pass

## Note

Supersedes #533 (closed), which mistakenly implemented the `assigned`/assignee field instead of the `review_requested` reviewer path.