### PR TITLE
feat(agent): support ANTHROPIC_BASE_URL for Anthropic-compatible proxies

### DIFF
--- a/docs/content/docs/reference/env-vars.mdx
+++ b/docs/content/docs/reference/env-vars.mdx
@@ -37,6 +37,16 @@ Set in the host stage; injected into the container via `--env-file .env`.
 
 Custom env-var names are supported via the `Secret`'s `env` field — `{ "key": { "env": "MY_OPENAI" } }`. See [/concepts/secrets-policy](/docs/concepts/secrets-policy) for resolution order.
 
+## Provider endpoint overrides
+
+Set in the host stage; injected into the container via `--env-file .env`.
+
+| Variable             | Provider    | Default                     | Effect                                                            |
+| -------------------- | ----------- | --------------------------- | ----------------------------------------------------------------- |
+| `ANTHROPIC_BASE_URL` | `anthropic` | `https://api.anthropic.com` | Point the Anthropic provider at an Anthropic-compatible endpoint. |
+
+`ANTHROPIC_BASE_URL` routes the `anthropic` provider through a proxy that speaks the **native Anthropic Messages protocol** (`/v1/messages`, `x-api-key` or OAuth Bearer) — e.g. LiteLLM, Cloudflare AI Gateway, or a corporate gateway. It is a base-URL swap only; it does **not** enable raw AWS Bedrock, which requires SigV4 signing and a different request path. Trailing slashes are stripped; a non-http(s) value fails the agent at boot. The same endpoint is used by `typeclaw init`'s API-key validation probe.
+
 ## Channel credentials (env-wins)
 
 | Variable             | Adapter        | Field      |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -26,6 +26,7 @@ import { getAuthFor } from './auth'
 import { createCompactionSettingsManager } from './compaction'
 import { renderGitNudge } from './git-nudge'
 import type { LiveSubagentRegistry } from './live-subagents'
+import { applyModelRuntimeOverrides } from './model-overrides'
 import { createChannelLookAtTool, lookAtTool } from './multimodal'
 import {
   buildBuiltinPiToolOverrides,
@@ -357,7 +358,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
       ? customToolsPreBudget.map((t) => wrapToolDefinitionWithBudget(t, sessionBudget, sessionBudgetState))
       : customToolsPreBudget
 
-  const model = resolveModel(activeRef)
+  const model = applyModelRuntimeOverrides(resolveModel(activeRef), activeRef)
   const thinkingLevel = defaultThinkingLevelForRef(activeRef)
   const { session } = await createAgentSession({
     model,

--- a/src/agent/model-overrides.test.ts
+++ b/src/agent/model-overrides.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test'
+
+import { resolveModel } from '@/config'
+import type { KnownModelRef } from '@/config/providers'
+import { KNOWN_PROVIDERS } from '@/config/providers'
+
+import { applyModelRuntimeOverrides, effectiveAnthropicBaseUrl } from './model-overrides'
+
+const ANTHROPIC_REF = 'anthropic/claude-opus-4-8' as KnownModelRef
+const OPENAI_REF = 'openai/gpt-5.4-nano' as KnownModelRef
+
+describe('applyModelRuntimeOverrides', () => {
+  test('overrides anthropic baseUrl when ANTHROPIC_BASE_URL is set', () => {
+    const model = resolveModel(ANTHROPIC_REF)
+    const result = applyModelRuntimeOverrides(model, ANTHROPIC_REF, {
+      ANTHROPIC_BASE_URL: 'https://gateway.example.com',
+    })
+    expect(result.baseUrl).toBe('https://gateway.example.com')
+  })
+
+  test('leaves baseUrl untouched when the env var is unset', () => {
+    const model = resolveModel(ANTHROPIC_REF)
+    const result = applyModelRuntimeOverrides(model, ANTHROPIC_REF, {})
+    expect(result.baseUrl).toBe(KNOWN_PROVIDERS.anthropic.baseUrl)
+  })
+
+  test('treats a blank value as unset', () => {
+    const model = resolveModel(ANTHROPIC_REF)
+    const result = applyModelRuntimeOverrides(model, ANTHROPIC_REF, { ANTHROPIC_BASE_URL: '   ' })
+    expect(result.baseUrl).toBe(KNOWN_PROVIDERS.anthropic.baseUrl)
+  })
+
+  test('strips trailing slashes', () => {
+    const model = resolveModel(ANTHROPIC_REF)
+    const result = applyModelRuntimeOverrides(model, ANTHROPIC_REF, {
+      ANTHROPIC_BASE_URL: 'https://gateway.example.com/anthropic//',
+    })
+    expect(result.baseUrl).toBe('https://gateway.example.com/anthropic')
+  })
+
+  test('does not mutate the shared provider-table model literal', () => {
+    const original = KNOWN_PROVIDERS.anthropic.models['claude-opus-4-8']!.baseUrl
+    const model = resolveModel(ANTHROPIC_REF)
+    applyModelRuntimeOverrides(model, ANTHROPIC_REF, { ANTHROPIC_BASE_URL: 'https://gateway.example.com' })
+    expect(KNOWN_PROVIDERS.anthropic.models['claude-opus-4-8']!.baseUrl).toBe(original)
+  })
+
+  test('ignores the env var for non-anthropic providers', () => {
+    const model = resolveModel(OPENAI_REF)
+    const result = applyModelRuntimeOverrides(model, OPENAI_REF, {
+      ANTHROPIC_BASE_URL: 'https://gateway.example.com',
+    })
+    expect(result.baseUrl).toBe(KNOWN_PROVIDERS.openai.baseUrl)
+  })
+
+  test('throws on a non-URL value', () => {
+    const model = resolveModel(ANTHROPIC_REF)
+    expect(() => applyModelRuntimeOverrides(model, ANTHROPIC_REF, { ANTHROPIC_BASE_URL: 'not a url' })).toThrow(
+      /not a valid URL/,
+    )
+  })
+
+  test('throws on a non-http(s) scheme', () => {
+    const model = resolveModel(ANTHROPIC_REF)
+    expect(() => applyModelRuntimeOverrides(model, ANTHROPIC_REF, { ANTHROPIC_BASE_URL: 'ftp://x.example' })).toThrow(
+      /http:\/\/ or https:\/\//,
+    )
+  })
+})
+
+describe('effectiveAnthropicBaseUrl', () => {
+  test('returns the override when set', () => {
+    expect(
+      effectiveAnthropicBaseUrl('https://api.anthropic.com', { ANTHROPIC_BASE_URL: 'https://proxy.example' }),
+    ).toBe('https://proxy.example')
+  })
+
+  test('returns the fallback when unset', () => {
+    expect(effectiveAnthropicBaseUrl('https://api.anthropic.com', {})).toBe('https://api.anthropic.com')
+  })
+})

--- a/src/agent/model-overrides.ts
+++ b/src/agent/model-overrides.ts
@@ -1,0 +1,54 @@
+import type { Api, Model } from '@mariozechner/pi-ai'
+
+import { providerForModelRef, type KnownModelRef } from '@/config/providers'
+
+// Matches the Anthropic SDK's own `ANTHROPIC_BASE_URL` so a working
+// credential/endpoint pair carries over. Scope is a base-URL swap only: it
+// targets Anthropic-compatible gateways (LiteLLM, Cloudflare AI Gateway,
+// corporate proxies) speaking native `/v1/messages` with `x-api-key`/OAuth
+// Bearer — NOT raw AWS Bedrock, which needs SigV4 and a different transport.
+export const ANTHROPIC_BASE_URL_ENV = 'ANTHROPIC_BASE_URL'
+
+// Separate from `resolveModel` so resolution stays a pure table lookup; this
+// is the per-process "prepare the model" seam run just before pi-coding-agent
+// receives it. Clones because the `KNOWN_PROVIDERS` literals are shared static
+// data that must never be mutated.
+export function applyModelRuntimeOverrides<TApi extends Api>(
+  model: Model<TApi>,
+  ref: KnownModelRef,
+  env: NodeJS.ProcessEnv = process.env,
+): Model<TApi> {
+  if (providerForModelRef(ref) !== 'anthropic') return model
+
+  const baseUrl = normalizeBaseUrl(env[ANTHROPIC_BASE_URL_ENV])
+  if (baseUrl === undefined) return model
+
+  return { ...model, baseUrl }
+}
+
+// Resolves the effective Anthropic base URL for a process, falling back to the
+// provider default when the override is unset. Used by callers outside the
+// session path (e.g. the init-time API-key probe) that need to hit the same
+// endpoint the runtime will use.
+export function effectiveAnthropicBaseUrl(fallback: string, env: NodeJS.ProcessEnv = process.env): string {
+  return normalizeBaseUrl(env[ANTHROPIC_BASE_URL_ENV]) ?? fallback
+}
+
+// `undefined` for unset/blank (caller keeps the default); throws on a value
+// that isn't a parseable http(s) URL so a typo fails loudly at boot rather
+// than silently falling back to api.anthropic.com with the wrong credential.
+function normalizeBaseUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (trimmed === undefined || trimmed === '') return undefined
+
+  let url: URL
+  try {
+    url = new URL(trimmed)
+  } catch {
+    throw new Error(`${ANTHROPIC_BASE_URL_ENV} is not a valid URL: ${trimmed}`)
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`${ANTHROPIC_BASE_URL_ENV} must use http:// or https://, got: ${trimmed}`)
+  }
+  return url.toString().replace(/\/+$/, '')
+}

--- a/src/init/validate-api-key.test.ts
+++ b/src/init/validate-api-key.test.ts
@@ -105,6 +105,46 @@ describe('validateApiKey', () => {
     expect(seenHeaders!.Authorization).toBeUndefined()
   })
 
+  test('probes api.anthropic.com by default', async () => {
+    const prev = process.env.ANTHROPIC_BASE_URL
+    delete process.env.ANTHROPIC_BASE_URL
+    try {
+      let seenUrl: string | null = null
+      await validateApiKey(
+        'anthropic',
+        'sk-ant-test',
+        fakeFetch((url) => {
+          seenUrl = url
+          return new Response(okBody, { status: 200 })
+        }),
+      )
+      expect(seenUrl!).toBe('https://api.anthropic.com/v1/models')
+    } finally {
+      if (prev === undefined) delete process.env.ANTHROPIC_BASE_URL
+      else process.env.ANTHROPIC_BASE_URL = prev
+    }
+  })
+
+  test('probes the proxy endpoint when ANTHROPIC_BASE_URL is set', async () => {
+    const prev = process.env.ANTHROPIC_BASE_URL
+    process.env.ANTHROPIC_BASE_URL = 'https://gateway.example.com/anthropic/'
+    try {
+      let seenUrl: string | null = null
+      await validateApiKey(
+        'anthropic',
+        'sk-ant-test',
+        fakeFetch((url) => {
+          seenUrl = url
+          return new Response(okBody, { status: 200 })
+        }),
+      )
+      expect(seenUrl!).toBe('https://gateway.example.com/anthropic/v1/models')
+    } finally {
+      if (prev === undefined) delete process.env.ANTHROPIC_BASE_URL
+      else process.env.ANTHROPIC_BASE_URL = prev
+    }
+  })
+
   test('skips OAuth-only providers without contacting the network', async () => {
     let called = false
     const result = await validateApiKey('openai-codex', 'whatever', async () => {

--- a/src/init/validate-api-key.ts
+++ b/src/init/validate-api-key.ts
@@ -1,3 +1,4 @@
+import { effectiveAnthropicBaseUrl } from '@/agent/model-overrides'
 import { KNOWN_PROVIDERS, type KnownProviderId } from '@/config/providers'
 
 const PROVIDER_PROBE: Partial<Record<KnownProviderId, { url: string; authHeader: 'bearer' | 'x-api-key' }>> = {
@@ -6,6 +7,14 @@ const PROVIDER_PROBE: Partial<Record<KnownProviderId, { url: string; authHeader:
   fireworks: { url: 'https://api.fireworks.ai/inference/v1/models', authHeader: 'bearer' },
   zai: { url: 'https://api.z.ai/api/paas/v4/models', authHeader: 'bearer' },
   'zai-coding': { url: 'https://api.z.ai/api/coding/paas/v4/models', authHeader: 'bearer' },
+}
+
+// When ANTHROPIC_BASE_URL points at a proxy, probe THAT endpoint — validating
+// the key against api.anthropic.com would test the wrong gateway (and may
+// reject a proxy-only credential). The proxy must expose `/v1/models`.
+function probeUrlFor(providerId: KnownProviderId, defaultUrl: string): string {
+  if (providerId !== 'anthropic') return defaultUrl
+  return `${effectiveAnthropicBaseUrl(KNOWN_PROVIDERS.anthropic.baseUrl)}/v1/models`
 }
 
 export type KeyValidationResult =
@@ -36,7 +45,7 @@ export async function validateApiKey(
   }
 
   try {
-    const res = await fetchImpl(probe.url, {
+    const res = await fetchImpl(probeUrlFor(providerId, probe.url), {
       method: 'GET',
       headers,
       signal: AbortSignal.timeout(TIMEOUT_MS),


### PR DESCRIPTION
## What

Adds a runtime base-URL override for the `anthropic` provider. Setting `ANTHROPIC_BASE_URL` in `.env` routes the provider through an Anthropic **Messages-compatible** gateway instead of `https://api.anthropic.com`.

```sh
# .env
ANTHROPIC_BASE_URL=https://gateway.example.com/anthropic
ANTHROPIC_API_KEY=...
```

## Why

Users behind corporate proxies or running their own gateways (LiteLLM, Cloudflare AI Gateway, etc.) need to point the Anthropic provider somewhere other than the public API, without forking the provider table.

## How

- New seam `applyModelRuntimeOverrides` (`src/agent/model-overrides.ts`), applied in `src/agent/index.ts` right before the resolved model reaches `createAgentSession`. This keeps `resolveModel` a pure table lookup and **clones** the shared `KNOWN_PROVIDERS` literal rather than mutating it.
- The env var name mirrors the Anthropic SDK's own `ANTHROPIC_BASE_URL`, so a credential/endpoint pair that works with the official CLI carries over.
- `typeclaw init`'s API-key validation probe (`src/init/validate-api-key.ts`) follows the same endpoint, so init validates the key against the gateway that will actually serve requests — not the wrong host.
- Validation: a non-`http(s)` or unparseable value throws at boot (fail loud, no silent fallback to the wrong endpoint with a proxy-only credential); trailing slashes are normalized away.

## Scope (honest)

This is a **base-URL swap only**. It supports proxies that speak the native Anthropic Messages protocol (`/v1/messages`, `x-api-key` / OAuth Bearer). It does **not** enable raw AWS Bedrock, which uses SigV4 signing and a different request path — that requires a distinct transport, not a base-URL override. Docs say so explicitly.

## Tests

- `src/agent/model-overrides.test.ts` — set/unset/blank, trailing-slash normalization, non-anthropic passthrough, no-mutation of the frozen literal, invalid-URL and non-http(s) throw, `effectiveAnthropicBaseUrl` fallback.
- `src/init/validate-api-key.test.ts` — probe hits `api.anthropic.com` by default and follows the override when set.
- `bun run typecheck`, `bun run lint` (0 errors), `bun run format` all clean. Agent suite (`index`, `model-fallback`) green.

## Docs

- `docs/content/docs/reference/env-vars.mdx` — new "Provider endpoint overrides" section.