### PR TITLE
feat(sandbox): ship jq in the container baseline so it is sandbox-visible

### DIFF
--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -112,7 +112,7 @@ describe('buildDockerfile feature toggles', () => {
         }),
       ),
     )
-    expect(pkgs).toEqual(['git', 'ca-certificates', 'curl', 'gnupg', 'iptables', 'util-linux', 'bubblewrap'])
+    expect(pkgs).toEqual(['git', 'ca-certificates', 'curl', 'gnupg', 'iptables', 'util-linux', 'bubblewrap', 'jq'])
   })
 
   test('xvfb: true (the default) adds xvfb to the toggle apt package list, after the baseline packages', () => {
@@ -1050,7 +1050,7 @@ describe('base ↔ per-agent Dockerfile drift guard', () => {
     const match = base.match(/apt-get install -y --no-install-recommends \\\n\s+([^\n]+?) \\\n/)
     if (!match || !match[1]) throw new Error('main apt-get install line not found in base Dockerfile')
     const pkgs = match[1].split(/\s+/).filter(Boolean)
-    expect(pkgs).toEqual(['git', 'ca-certificates', 'curl', 'gnupg', 'iptables', 'util-linux', 'bubblewrap'])
+    expect(pkgs).toEqual(['git', 'ca-certificates', 'curl', 'gnupg', 'iptables', 'util-linux', 'bubblewrap', 'jq'])
   })
 
   test('base Dockerfile uses the same BuildKit syntax pragma and base image as the per-agent Dockerfile so layer caching across the two is possible', () => {

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -50,6 +50,16 @@ export type BuildDockerfileOptions = {
 // flag the seccomp default profile blocks `unshare(CLONE_NEWUSER)` and bwrap
 // fails at startup. The two changes are load-bearing together — do not drop
 // one without the other.
+//
+// `jq` is in baseline (not behind a toggle) so it is available to the
+// per-tool bwrap sandbox that wraps agent bash calls. The sandbox only
+// `--ro-bind`s `/usr` + `/bin` from the container (see `src/sandbox/build.ts`),
+// so a binary that is not in the base image is invisible inside the sandbox —
+// there is no per-call install path. JSON munging in one-shot read-only
+// pipelines (`curl ... | jq`, `cat foo.json | jq`) is a baseline expectation
+// for the explorer/reviewer/scout subagents, whose prompts already advertise
+// `jq` as an available pipeline tool, so it ships unconditionally rather than
+// as an opt-in toggle.
 const BASELINE_APT_PACKAGES = [
   'git',
   'ca-certificates',
@@ -58,6 +68,7 @@ const BASELINE_APT_PACKAGES = [
   'iptables',
   'util-linux',
   'bubblewrap',
+  'jq',
 ] as const
 
 // curl-impersonate is the only currently-working way to query DuckDuckGo from


### PR DESCRIPTION
## What

Adds `jq` to `BASELINE_APT_PACKAGES` in `src/init/dockerfile.ts` so it lands in the container base image (and, by extension, the per-agent image).

## Why

The per-tool bwrap sandbox that wraps agent bash calls only `--ro-bind`s `/usr` + `/bin` from the container (see `src/sandbox/build.ts`). A binary that is **not in the base image is invisible inside the sandbox** — there is no per-call install path. `jq` was not installed in the container, so any sandboxed `... | jq` pipeline failed with "command not found".

The `explorer`, `reviewer`, and `scout` subagent prompts already advertise `jq` as an available read-only pipeline tool (`curl ... | jq`, `cat foo.json | jq`), so it ships unconditionally in baseline rather than behind a `docker.file` toggle — consistent with the existing rationale for `bubblewrap`/`util-linux`/`iptables`.

## Notes

- No checked-in base Dockerfile to sync: CI regenerates it from this source via `scripts/emit-base-dockerfile.ts`. Both `buildBaseDockerfile()` and the dev inline path compose from the same `BASELINE_APT_PACKAGES` constant, so they can't drift.
- Existing entrypoint-shim tests asserting the Stop-hook script does **not** contain `jq ` are unaffected (the shim never carried the apt list).

## Testing

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (64 pre-existing warnings, unrelated)
- `bun run format` — no changes
- `bun test src/init/dockerfile.test.ts --parallel` — 207 pass / 0 fail (both baseline-list drift-guard assertions updated)