### PR TITLE
feat(permissions): allow grant_role in trusted-only group channels

### DIFF
--- a/src/agent/tools/grant-role.test.ts
+++ b/src/agent/tools/grant-role.test.ts
@@ -298,6 +298,56 @@ describe('grant_role gate — all-humans-trusted group channel', () => {
   })
 })
 
+describe('grant_role gate — peer bots', () => {
+  test('single-human group with a peer bot present is refused', async () => {
+    const dir = freshAgentDir()
+    // humans===1 but bots===2 (agent + one peer bot), so a peer bot's messages
+    // can still be buffered into the turn — not DM-equivalent.
+    const origin = trustedGroupWithMembership({ humans: 1, bots: 2, truncated: false })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    if (!details.ok) expect(details.error).toContain('another bot')
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('all-trusted group with a peer bot present is refused', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership({
+      humans: 2,
+      bots: 2,
+      truncated: false,
+      humanMemberIds: ['U_TRENT', 'U_OWNER'],
+    })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('github channel is refused (collaborator membership is not a no-peer-bot proof)', async () => {
+    const dir = freshAgentDir()
+    const permissions = createPermissionService({
+      roles: { trusted: { match: [{ kind: 'channel', platform: 'github' }] } } as unknown as RolesConfig,
+    })
+    const tool = createGrantRoleTool({
+      agentDir: dir,
+      getOrigin: () => ({
+        kind: 'channel',
+        adapter: 'github',
+        workspace: 'acme/repo',
+        chat: '1',
+        thread: null,
+        lastInboundAuthorId: 'U_TRENT',
+        membership: { humans: 1, bots: 1, truncated: false, fetchedAt: Date.now(), humanMemberIds: ['U_TRENT'] },
+      }),
+      permissions,
+      reloadRoles: () => readRolesFromDisk(dir),
+    })
+    const details = await run(tool, { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+})
+
 describe('grant_role gate — tier ceiling', () => {
   test('trusted cannot grant owner', async () => {
     const dir = freshAgentDir()

--- a/src/agent/tools/grant-role.test.ts
+++ b/src/agent/tools/grant-role.test.ts
@@ -37,7 +37,9 @@ const TRUSTED_GROUP: SessionOrigin = {
 const TUI: SessionOrigin = { kind: 'tui', sessionId: 's1' }
 
 function trustedGroupWithMembership(
-  membership: { humans: number; bots: number; truncated: boolean; ageMs?: number } | undefined,
+  membership:
+    | { humans: number; bots: number; truncated: boolean; ageMs?: number; humanMemberIds?: readonly string[] }
+    | undefined,
 ): SessionOrigin {
   return {
     kind: 'channel',
@@ -54,6 +56,7 @@ function trustedGroupWithMembership(
             bots: membership.bots,
             truncated: membership.truncated,
             fetchedAt: Date.now() - (membership.ageMs ?? 0),
+            ...(membership.humanMemberIds === undefined ? {} : { humanMemberIds: membership.humanMemberIds }),
           },
         }),
   }
@@ -105,7 +108,7 @@ describe('grant_role gate — origin', () => {
     const dir = freshAgentDir()
     const details = await run(makeTool(dir, TRUSTED_GROUP), { role: 'member', match: 'slack:T0123 author:U_X' })
     expect(details.ok).toBe(false)
-    if (!details.ok) expect(details.error).toContain('one human member')
+    if (!details.ok) expect(details.error).toContain('admits any untrusted human')
     // nothing written
     expect(readRoles(dir).member).toBeUndefined()
   })
@@ -144,7 +147,7 @@ describe('grant_role gate — single-human group channel', () => {
     const origin = trustedGroupWithMembership({ humans: 2, bots: 1, truncated: false })
     const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
     expect(details.ok).toBe(false)
-    if (!details.ok) expect(details.error).toContain('one human member')
+    if (!details.ok) expect(details.error).toContain('admits any untrusted human')
     expect(readRoles(dir).guest?.permissions).toBeUndefined()
   })
 
@@ -186,6 +189,111 @@ describe('grant_role gate — single-human group channel', () => {
     const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
     expect(details.ok).toBe(false)
     if (!details.ok) expect(details.error).toContain('only owner or trusted may grant')
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+})
+
+describe('grant_role gate — all-humans-trusted group channel', () => {
+  test('multi-human group is allowed when every human member resolves to trusted/owner', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership({
+      humans: 2,
+      bots: 1,
+      truncated: false,
+      humanMemberIds: ['U_TRENT', 'U_OWNER'],
+    })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(true)
+    expect(readRoles(dir).guest?.permissions).toContain('subagent.spawn')
+  })
+
+  test('multi-human group is refused when any human member resolves below trusted', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership({
+      humans: 2,
+      bots: 1,
+      truncated: false,
+      humanMemberIds: ['U_TRENT', 'U_STRANGER'],
+    })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    if (!details.ok) expect(details.error).toContain('admits any untrusted human')
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('refused when humanMemberIds length disagrees with the humans count (unaccounted member)', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership({
+      humans: 3,
+      bots: 1,
+      truncated: false,
+      humanMemberIds: ['U_TRENT', 'U_OWNER'],
+    })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('refused when membership carries no humanMemberIds (count-only enumeration)', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership({ humans: 2, bots: 1, truncated: false })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('refused when an all-trusted member list is stale', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership({
+      humans: 2,
+      bots: 1,
+      truncated: false,
+      ageMs: 5 * 60 * 1000,
+      humanMemberIds: ['U_TRENT', 'U_OWNER'],
+    })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('refused when an all-trusted member list is truncated', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership({
+      humans: 2,
+      bots: 1,
+      truncated: true,
+      humanMemberIds: ['U_TRENT', 'U_OWNER'],
+    })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('refused when an all-trusted room exceeds the human-count cap', async () => {
+    const dir = freshAgentDir()
+    // 21 trusted humans (all resolve to trusted via a wildcard match) — over
+    // the cap, so the guard refuses rather than vouch for an oversized room.
+    const ids = Array.from({ length: 21 }, (_, i) => `U_TRENT_${i}`)
+    const permissions = createPermissionService({
+      roles: { trusted: { match: [{ kind: 'channel', platform: 'slack' }] } } as unknown as RolesConfig,
+    })
+    const tool = createGrantRoleTool({
+      agentDir: dir,
+      getOrigin: () => ({
+        kind: 'channel',
+        adapter: 'slack-bot',
+        workspace: 'T0123',
+        chat: 'C_PUBLIC',
+        thread: null,
+        lastInboundAuthorId: ids[0],
+        membership: { humans: ids.length, bots: 1, truncated: false, fetchedAt: Date.now(), humanMemberIds: ids },
+      }),
+      permissions,
+      reloadRoles: () => readRolesFromDisk(dir),
+    })
+    const details = await run(tool, { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    if (!details.ok) expect(details.error).toContain('admits any untrusted human')
     expect(readRoles(dir).guest?.permissions).toBeUndefined()
   })
 })

--- a/src/agent/tools/grant-role.test.ts
+++ b/src/agent/tools/grant-role.test.ts
@@ -36,6 +36,29 @@ const TRUSTED_GROUP: SessionOrigin = {
 }
 const TUI: SessionOrigin = { kind: 'tui', sessionId: 's1' }
 
+function trustedGroupWithMembership(
+  membership: { humans: number; bots: number; truncated: boolean; ageMs?: number } | undefined,
+): SessionOrigin {
+  return {
+    kind: 'channel',
+    adapter: 'slack-bot',
+    workspace: 'T0123',
+    chat: 'C_PUBLIC',
+    thread: null,
+    lastInboundAuthorId: 'U_TRENT',
+    ...(membership === undefined
+      ? {}
+      : {
+          membership: {
+            humans: membership.humans,
+            bots: membership.bots,
+            truncated: membership.truncated,
+            fetchedAt: Date.now() - (membership.ageMs ?? 0),
+          },
+        }),
+  }
+}
+
 const ROLES: RolesConfig = {
   owner: { match: [{ kind: 'channel', platform: 'slack', author: 'U_OWNER' }] },
   trusted: { match: [{ kind: 'channel', platform: 'slack', author: 'U_TRENT' }] },
@@ -82,7 +105,7 @@ describe('grant_role gate — origin', () => {
     const dir = freshAgentDir()
     const details = await run(makeTool(dir, TRUSTED_GROUP), { role: 'member', match: 'slack:T0123 author:U_X' })
     expect(details.ok).toBe(false)
-    if (!details.ok) expect(details.error).toContain('TUI or a 1:1 DM')
+    if (!details.ok) expect(details.error).toContain('one human member')
     // nothing written
     expect(readRoles(dir).member).toBeUndefined()
   })
@@ -104,6 +127,66 @@ describe('grant_role gate — origin', () => {
     const dir = freshAgentDir()
     const details = await run(makeTool(dir, TUI), { role: 'member', match: 'slack:T0123 author:U_WIFE' })
     expect(details.ok).toBe(true)
+  })
+})
+
+describe('grant_role gate — single-human group channel', () => {
+  test('group channel with exactly one human member is allowed for a trusted caller', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership({ humans: 1, bots: 1, truncated: false })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(true)
+    expect(readRoles(dir).guest?.permissions).toContain('subagent.spawn')
+  })
+
+  test('group channel with two humans is refused even when the caller is trusted', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership({ humans: 2, bots: 1, truncated: false })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    if (!details.ok) expect(details.error).toContain('one human member')
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('truncated membership is refused (cannot prove the room is single-human)', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership({ humans: 1, bots: 1, truncated: true })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('stale membership is refused (count may no longer hold)', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership({ humans: 1, bots: 1, truncated: false, ageMs: 5 * 60 * 1000 })
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('missing membership is refused (no proof of who is in the room)', async () => {
+    const dir = freshAgentDir()
+    const origin = trustedGroupWithMembership(undefined)
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
+  })
+
+  test('single-human group with an untrusted caller is still refused by the caller-role check', async () => {
+    const dir = freshAgentDir()
+    const origin: SessionOrigin = {
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0123',
+      chat: 'C_PUBLIC',
+      thread: null,
+      lastInboundAuthorId: 'U_STRANGER',
+      membership: { humans: 1, bots: 1, truncated: false, fetchedAt: Date.now() },
+    }
+    const details = await run(makeTool(dir, origin), { role: 'guest', permission: 'subagent.spawn' })
+    expect(details.ok).toBe(false)
+    if (!details.ok) expect(details.error).toContain('only owner or trusted may grant')
+    expect(readRoles(dir).guest?.permissions).toBeUndefined()
   })
 })
 

--- a/src/agent/tools/grant-role.ts
+++ b/src/agent/tools/grant-role.ts
@@ -83,6 +83,51 @@ function isSingleHumanGroupChannelOrigin(origin: SessionOrigin | undefined, now:
   return membership.humans === 1
 }
 
+// Caps the per-member role resolution this check performs so it can never do
+// unbounded work on a large room. resolveRole is in-memory (a match-rule walk,
+// no I/O), so the real cost is small, but a trusted-only operational channel is
+// small by nature and past this many humans we refuse rather than iterate an
+// arbitrarily long list on a tool call. Adapters already stop enumerating past
+// their own cap; this is the guard-local ceiling.
+const MAX_TRUSTED_GROUP_HUMANS = 20
+
+// Generalises the single-human case: a group channel where the platform proves
+// EVERY human member resolves to trusted/owner is also injection-equivalent to
+// a DM, because no untrusted human can buffer a message into the turn. The
+// proof requires an authoritative, complete identity enumeration — only a
+// fresh, non-truncated membership read that carries `humanMemberIds` (the
+// adapter listed and classified every member in one pass). `humanMemberIds`
+// length must equal `humans` so an unaccounted member cannot slip past; the
+// resolvers construct it that way and we re-check defensively. The room must
+// also be at most MAX_TRUSTED_GROUP_HUMANS humans. Each id is resolved through
+// the same per-author path the turn anchor uses. Adapters that cannot enumerate
+// identities (Telegram, KakaoTalk) never set the field and so only ever qualify
+// via the single-human branch above — fully fail-closed.
+function isAllHumansTrustedGroupChannelOrigin(
+  origin: SessionOrigin | undefined,
+  permissions: PermissionService,
+  now: number,
+): boolean {
+  if (origin?.kind !== 'channel') return false
+  if (isDmChannelOrigin(origin)) return false
+
+  const membership = origin.membership
+  if (membership === undefined) return false
+  if (membership.truncated) return false
+  if (now - membership.fetchedAt >= MEMBERSHIP_FRESHNESS_MS) return false
+
+  const humanMemberIds = membership.humanMemberIds
+  if (humanMemberIds === undefined) return false
+  if (humanMemberIds.length !== membership.humans) return false
+  if (humanMemberIds.length === 0) return false
+  if (humanMemberIds.length > MAX_TRUSTED_GROUP_HUMANS) return false
+
+  return humanMemberIds.every((authorId) => {
+    const role = permissions.resolveRole({ ...origin, lastInboundAuthorId: authorId })
+    return role === 'owner' || role === 'trusted'
+  })
+}
+
 export function createGrantRoleTool(options: CreateGrantRoleToolOptions) {
   const { agentDir, getOrigin, permissions, reloadRoles } = options
 
@@ -93,8 +138,8 @@ export function createGrantRoleTool(options: CreateGrantRoleToolOptions) {
       'Assign an author to a role (match grant) or give a role a capability (permission grant), by editing typeclaw.json#roles. ' +
       'Use this to onboard a teammate ("respond to author U_X" → grant them member) or to open the agent to a wider audience ' +
       '("let anyone in this channel message you" → grant guest channel.respond). ' +
-      'Only callable by an owner or trusted user from the TUI, a 1:1 DM, or a group channel that currently has ' +
-      'exactly one human member — multi-human channel turns cannot use it. ' +
+      'Only callable by an owner or trusted user from the TUI, a 1:1 DM, or a group channel whose human members ' +
+      'are all trusted (or which has a single human member) — channels that admit untrusted humans cannot use it. ' +
       'Permission grants are restart-required: they land in typeclaw.json but take effect on the next `typeclaw restart`.',
     parameters: Type.Object({
       role: Type.Union(
@@ -122,11 +167,16 @@ export function createGrantRoleTool(options: CreateGrantRoleToolOptions) {
     async execute(_toolCallId, params): Promise<ToolReturn> {
       const origin = getOrigin()
 
-      if (!isSinglePrincipalOrigin(origin) && !isSingleHumanGroupChannelOrigin(origin, Date.now())) {
+      const now = Date.now()
+      if (
+        !isSinglePrincipalOrigin(origin) &&
+        !isSingleHumanGroupChannelOrigin(origin, now) &&
+        !isAllHumansTrustedGroupChannelOrigin(origin, permissions, now)
+      ) {
         return err(
-          'grant_role is only available from the TUI, a 1:1 DM, or a group channel that currently has exactly ' +
-            'one human member. A multi-human channel turn cannot change roles, because it mixes in other ' +
-            'participants\u2019 messages (prompt-injection surface).',
+          'grant_role is only available from the TUI, a 1:1 DM, or a group channel whose human members are all ' +
+            'trusted (or which currently has a single human member). A channel that admits any untrusted human ' +
+            'cannot change roles, because it mixes in other participants\u2019 messages (prompt-injection surface).',
         )
       }
 

--- a/src/agent/tools/grant-role.ts
+++ b/src/agent/tools/grant-role.ts
@@ -1,7 +1,7 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
-import { MEMBERSHIP_FRESHNESS_MS } from '@/channels/membership'
+import { MEMBERSHIP_FRESHNESS_MS, type MembershipCount } from '@/channels/membership'
 import {
   grantRole,
   grantRolePermission,
@@ -60,27 +60,47 @@ function isSinglePrincipalOrigin(origin: SessionOrigin | undefined): boolean {
   return false
 }
 
-// A group/open channel that the platform proves contains exactly one human is
-// injection-equivalent to a 1:1 DM: there is no third-party human whose
-// buffered messages could prompt-inject the turn. The lone human is the
-// caller, and the per-turn caller-role check below still requires them to
-// resolve to owner/trusted. We trust ONLY a fresh, complete membership read —
-// `participants` is a bounded, speaker-only, age-filtered list and cannot prove
-// the absence of a silent untrusted lurker, so it is unsuitable for authorizing
-// a write to the access-control table. Every uncertain signal (missing, stale,
-// or truncated membership) fails closed. This mirrors `resolveEffectiveHumans`
-// in src/channels/engagement.ts, which likewise trusts only a fresh complete
-// read to see lurkers.
-function isSingleHumanGroupChannelOrigin(origin: SessionOrigin | undefined, now: number): boolean {
-  if (origin?.kind !== 'channel') return false
-  if (isDmChannelOrigin(origin)) return false
-
+// Shared precondition for treating a non-DM channel as injection-equivalent to
+// a 1:1 DM. A DM is safe because it is "principal + the agent's OWN bot, no
+// third-party content". For a group channel we must independently prove the
+// same room shape from a membership read:
+//   - fresh and NOT truncated, so the count is the complete current membership
+//     (`participants` is speaker-only and cannot see silent lurkers — never
+//     used for authorization here);
+//   - `bots === 1`, i.e. the only non-human is the agent itself. The agent's
+//     own bot is always a member of a chat channel and is never an inbound
+//     author (adapters drop self-authored messages), so a complete read with
+//     exactly one bot proves there are NO peer bots whose buffered messages
+//     could prompt-inject the turn. A peer bot would push the count to >= 2
+//     (or, if misclassified as human, trip the human checks) — fail-closed
+//     either way.
+// GitHub is excluded: its membership is the repo COLLABORATOR list, a different
+// population from the authors that can comment into a PR/issue turn (and the
+// agent App is typically not a collaborator), so `bots === 1` is not a valid
+// "no peer bot" proof there. GitHub grants stay confined to the TUI/DM path.
+function provesOnlyAgentBotPresent(
+  origin: Extract<SessionOrigin, { kind: 'channel' }>,
+  now: number,
+): origin is Extract<SessionOrigin, { kind: 'channel' }> & { membership: MembershipCount } {
+  if (origin.adapter === 'github') return false
   const membership = origin.membership
   if (membership === undefined) return false
   if (membership.truncated) return false
   if (now - membership.fetchedAt >= MEMBERSHIP_FRESHNESS_MS) return false
+  return membership.bots === 1
+}
 
-  return membership.humans === 1
+// A group/open channel that the platform proves contains exactly one human AND
+// no peer bots is injection-equivalent to a 1:1 DM: there is no third-party
+// author (human or bot) whose buffered messages could prompt-inject the turn.
+// The lone human is the caller, and the per-turn caller-role check below still
+// requires them to resolve to owner/trusted.
+function isSingleHumanGroupChannelOrigin(origin: SessionOrigin | undefined, now: number): boolean {
+  if (origin?.kind !== 'channel') return false
+  if (isDmChannelOrigin(origin)) return false
+  if (!provesOnlyAgentBotPresent(origin, now)) return false
+
+  return origin.membership.humans === 1
 }
 
 // Caps the per-member role resolution this check performs so it can never do
@@ -92,17 +112,17 @@ function isSingleHumanGroupChannelOrigin(origin: SessionOrigin | undefined, now:
 const MAX_TRUSTED_GROUP_HUMANS = 20
 
 // Generalises the single-human case: a group channel where the platform proves
-// EVERY human member resolves to trusted/owner is also injection-equivalent to
-// a DM, because no untrusted human can buffer a message into the turn. The
-// proof requires an authoritative, complete identity enumeration — only a
-// fresh, non-truncated membership read that carries `humanMemberIds` (the
-// adapter listed and classified every member in one pass). `humanMemberIds`
-// length must equal `humans` so an unaccounted member cannot slip past; the
-// resolvers construct it that way and we re-check defensively. The room must
-// also be at most MAX_TRUSTED_GROUP_HUMANS humans. Each id is resolved through
-// the same per-author path the turn anchor uses. Adapters that cannot enumerate
-// identities (Telegram, KakaoTalk) never set the field and so only ever qualify
-// via the single-human branch above — fully fail-closed.
+// EVERY human member resolves to trusted/owner AND no peer bots are present is
+// also injection-equivalent to a DM, because no untrusted author (human or bot)
+// can buffer a message into the turn. The human proof requires an authoritative,
+// complete identity enumeration — only a fresh, non-truncated membership read
+// that carries `humanMemberIds` (the adapter listed and classified every member
+// in one pass). `humanMemberIds` length must equal `humans` so an unaccounted
+// member cannot slip past; the resolvers construct it that way and we re-check
+// defensively. The no-peer-bot proof is shared with the single-human branch via
+// provesOnlyAgentBotPresent (also enforces fresh/non-truncated and excludes
+// GitHub). The room must be at most MAX_TRUSTED_GROUP_HUMANS humans. Each id is
+// resolved through the same per-author path the turn anchor uses.
 function isAllHumansTrustedGroupChannelOrigin(
   origin: SessionOrigin | undefined,
   permissions: PermissionService,
@@ -110,12 +130,9 @@ function isAllHumansTrustedGroupChannelOrigin(
 ): boolean {
   if (origin?.kind !== 'channel') return false
   if (isDmChannelOrigin(origin)) return false
+  if (!provesOnlyAgentBotPresent(origin, now)) return false
 
   const membership = origin.membership
-  if (membership === undefined) return false
-  if (membership.truncated) return false
-  if (now - membership.fetchedAt >= MEMBERSHIP_FRESHNESS_MS) return false
-
   const humanMemberIds = membership.humanMemberIds
   if (humanMemberIds === undefined) return false
   if (humanMemberIds.length !== membership.humans) return false
@@ -138,8 +155,9 @@ export function createGrantRoleTool(options: CreateGrantRoleToolOptions) {
       'Assign an author to a role (match grant) or give a role a capability (permission grant), by editing typeclaw.json#roles. ' +
       'Use this to onboard a teammate ("respond to author U_X" → grant them member) or to open the agent to a wider audience ' +
       '("let anyone in this channel message you" → grant guest channel.respond). ' +
-      'Only callable by an owner or trusted user from the TUI, a 1:1 DM, or a group channel whose human members ' +
-      'are all trusted (or which has a single human member) — channels that admit untrusted humans cannot use it. ' +
+      'Only callable by an owner or trusted user from the TUI, a 1:1 DM, or a group channel with no peer bots whose ' +
+      'human members are all trusted (or which has a single human member) — channels that admit untrusted humans or ' +
+      'other bots cannot use it. ' +
       'Permission grants are restart-required: they land in typeclaw.json but take effect on the next `typeclaw restart`.',
     parameters: Type.Object({
       role: Type.Union(
@@ -174,9 +192,10 @@ export function createGrantRoleTool(options: CreateGrantRoleToolOptions) {
         !isAllHumansTrustedGroupChannelOrigin(origin, permissions, now)
       ) {
         return err(
-          'grant_role is only available from the TUI, a 1:1 DM, or a group channel whose human members are all ' +
-            'trusted (or which currently has a single human member). A channel that admits any untrusted human ' +
-            'cannot change roles, because it mixes in other participants\u2019 messages (prompt-injection surface).',
+          'grant_role is only available from the TUI, a 1:1 DM, or a group channel that has no peer bots and whose ' +
+            'human members are all trusted (or which currently has a single human member). A channel that admits any ' +
+            'untrusted human or another bot cannot change roles, because it mixes in other participants\u2019 messages ' +
+            '(prompt-injection surface).',
         )
       }
 

--- a/src/agent/tools/grant-role.ts
+++ b/src/agent/tools/grant-role.ts
@@ -1,6 +1,7 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
+import { MEMBERSHIP_FRESHNESS_MS } from '@/channels/membership'
 import {
   grantRole,
   grantRolePermission,
@@ -48,16 +49,38 @@ function isTierRole(role: string): role is TierRole {
 
 // A single-principal turn carries only the principal's own first-party words:
 // the TUI (a human typing directly) or a 1:1 DM (principal + bot, no
-// third-party messages buffered in). A group/open channel turn always mixes in
-// other authors' messages, which is the confused-deputy surface that lets a
+// third-party messages buffered in). A group/open channel turn normally mixes
+// in other authors' messages, which is the confused-deputy surface that lets a
 // guest prompt-inject a trusted turn into rewriting the access-control table.
-// Role grants are confined to single-principal turns so that surface does not
-// exist.
+// Role grants are confined to turns where that surface does not exist.
 function isSinglePrincipalOrigin(origin: SessionOrigin | undefined): boolean {
   if (origin === undefined) return false
   if (origin.kind === 'tui') return true
   if (origin.kind === 'channel') return isDmChannelOrigin(origin)
   return false
+}
+
+// A group/open channel that the platform proves contains exactly one human is
+// injection-equivalent to a 1:1 DM: there is no third-party human whose
+// buffered messages could prompt-inject the turn. The lone human is the
+// caller, and the per-turn caller-role check below still requires them to
+// resolve to owner/trusted. We trust ONLY a fresh, complete membership read —
+// `participants` is a bounded, speaker-only, age-filtered list and cannot prove
+// the absence of a silent untrusted lurker, so it is unsuitable for authorizing
+// a write to the access-control table. Every uncertain signal (missing, stale,
+// or truncated membership) fails closed. This mirrors `resolveEffectiveHumans`
+// in src/channels/engagement.ts, which likewise trusts only a fresh complete
+// read to see lurkers.
+function isSingleHumanGroupChannelOrigin(origin: SessionOrigin | undefined, now: number): boolean {
+  if (origin?.kind !== 'channel') return false
+  if (isDmChannelOrigin(origin)) return false
+
+  const membership = origin.membership
+  if (membership === undefined) return false
+  if (membership.truncated) return false
+  if (now - membership.fetchedAt >= MEMBERSHIP_FRESHNESS_MS) return false
+
+  return membership.humans === 1
 }
 
 export function createGrantRoleTool(options: CreateGrantRoleToolOptions) {
@@ -70,7 +93,8 @@ export function createGrantRoleTool(options: CreateGrantRoleToolOptions) {
       'Assign an author to a role (match grant) or give a role a capability (permission grant), by editing typeclaw.json#roles. ' +
       'Use this to onboard a teammate ("respond to author U_X" → grant them member) or to open the agent to a wider audience ' +
       '("let anyone in this channel message you" → grant guest channel.respond). ' +
-      'Only callable from the TUI or a 1:1 DM by an owner or trusted user — group-channel turns cannot use it. ' +
+      'Only callable by an owner or trusted user from the TUI, a 1:1 DM, or a group channel that currently has ' +
+      'exactly one human member — multi-human channel turns cannot use it. ' +
       'Permission grants are restart-required: they land in typeclaw.json but take effect on the next `typeclaw restart`.',
     parameters: Type.Object({
       role: Type.Union(
@@ -98,10 +122,11 @@ export function createGrantRoleTool(options: CreateGrantRoleToolOptions) {
     async execute(_toolCallId, params): Promise<ToolReturn> {
       const origin = getOrigin()
 
-      if (!isSinglePrincipalOrigin(origin)) {
+      if (!isSinglePrincipalOrigin(origin) && !isSingleHumanGroupChannelOrigin(origin, Date.now())) {
         return err(
-          'grant_role is only available from the TUI or a 1:1 DM. A group-channel turn cannot change roles, ' +
-            'because it mixes in other participants\u2019 messages (prompt-injection surface).',
+          'grant_role is only available from the TUI, a 1:1 DM, or a group channel that currently has exactly ' +
+            'one human member. A multi-human channel turn cannot change roles, because it mixes in other ' +
+            'participants\u2019 messages (prompt-injection surface).',
         )
       }
 

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -191,6 +191,7 @@ describe('createDiscordMembershipResolver', () => {
       bots: 1,
       fetchedAt: 100,
       truncated: false,
+      humanMemberIds: ['u1', 'u2'],
     })
     expect(calls[0]!.url).toBe('https://discord.com/api/v10/guilds/g1/preview')
     expect(calls[1]!.url).toBe('https://discord.com/api/v10/guilds/g1/members?limit=100')

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -209,11 +209,25 @@ export function createDiscordMembershipResolver(deps: {
 
     let bots = 0
     let humans = 0
+    const humanMemberIds: string[] = []
+    let everyHumanIdentified = true
     for (const member of members.value) {
-      if (member.user?.bot === true) bots++
-      else humans++
+      if (member.user?.bot === true) {
+        bots++
+        continue
+      }
+      humans++
+      const userId = member.user?.id
+      if (userId === undefined) everyHumanIdentified = false
+      else humanMemberIds.push(userId)
     }
-    return { humans, bots, fetchedAt: now(), truncated: false }
+    // Only attach identities when every human was identifiable; an
+    // unidentifiable human must not be silently dropped, or a consumer proving
+    // "all humans trusted" would skip an unaccounted member. Falling back to
+    // counts-only keeps that consumer fail-closed.
+    return everyHumanIdentified
+      ? { humans, bots, fetchedAt: now(), truncated: false, humanMemberIds }
+      : { humans, bots, fetchedAt: now(), truncated: false }
   }
 }
 

--- a/src/channels/adapters/github/membership.ts
+++ b/src/channels/adapters/github/membership.ts
@@ -21,29 +21,18 @@ export function createGithubMembershipResolver(options: {
         },
       )
       if (!response.ok) return response.status >= 500 ? { kind: 'transient' } : { kind: 'permanent' }
-      const users = (await response.json()) as Array<{ type?: string; id?: number }>
-      const truncated = users.length >= 100
+      const users = (await response.json()) as Array<{ type?: string }>
       let bots = 0
       let humans = 0
-      const humanMemberIds: string[] = []
-      let everyHumanIdentified = true
       for (const user of users) {
-        if (user.type === 'Bot') {
-          bots++
-          continue
-        }
-        humans++
-        // Inbound GitHub turns key authorId on the numeric user id (see
-        // inbound.ts), so the resolvable identity is `String(id)`, not `login`.
-        if (user.id === undefined) everyHumanIdentified = false
-        else humanMemberIds.push(String(user.id))
+        if (user.type === 'Bot') bots++
+        else humans++
       }
-      // Identities are a completeness proof; only attach them on a full,
-      // fully-identified enumeration. A truncated page or an unidentifiable
-      // collaborator drops back to counts-only so consumers fail closed.
-      return truncated || !everyHumanIdentified
-        ? { humans, bots, fetchedAt: Date.now(), truncated }
-        : { humans, bots, fetchedAt: Date.now(), truncated, humanMemberIds }
+      // Counts only, no humanMemberIds: GitHub membership is the repo
+      // collaborator list, a different population from the authors that can
+      // comment into a PR/issue turn, so it is not a basis for the channel
+      // grant-role relaxation (see provesOnlyAgentBotPresent in grant-role.ts).
+      return { humans, bots, fetchedAt: Date.now(), truncated: users.length >= 100 }
     } catch {
       return { kind: 'transient' }
     }

--- a/src/channels/adapters/github/membership.ts
+++ b/src/channels/adapters/github/membership.ts
@@ -21,14 +21,29 @@ export function createGithubMembershipResolver(options: {
         },
       )
       if (!response.ok) return response.status >= 500 ? { kind: 'transient' } : { kind: 'permanent' }
-      const users = (await response.json()) as Array<{ type?: string }>
+      const users = (await response.json()) as Array<{ type?: string; id?: number }>
+      const truncated = users.length >= 100
       let bots = 0
       let humans = 0
+      const humanMemberIds: string[] = []
+      let everyHumanIdentified = true
       for (const user of users) {
-        if (user.type === 'Bot') bots++
-        else humans++
+        if (user.type === 'Bot') {
+          bots++
+          continue
+        }
+        humans++
+        // Inbound GitHub turns key authorId on the numeric user id (see
+        // inbound.ts), so the resolvable identity is `String(id)`, not `login`.
+        if (user.id === undefined) everyHumanIdentified = false
+        else humanMemberIds.push(String(user.id))
       }
-      return { humans, bots, fetchedAt: Date.now(), truncated: users.length >= 100 }
+      // Identities are a completeness proof; only attach them on a full,
+      // fully-identified enumeration. A truncated page or an unidentifiable
+      // collaborator drops back to counts-only so consumers fail closed.
+      return truncated || !everyHumanIdentified
+        ? { humans, bots, fetchedAt: Date.now(), truncated }
+        : { humans, bots, fetchedAt: Date.now(), truncated, humanMemberIds }
     } catch {
       return { kind: 'transient' }
     }

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -364,6 +364,7 @@ describe('createSlackMembershipResolver', () => {
       bots: 1,
       fetchedAt: 20,
       truncated: false,
+      humanMemberIds: ['U1', 'U2'],
     })
     expect(calls.map((c) => c.url)).toEqual([
       'https://slack.com/api/conversations.info',

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -459,14 +459,14 @@ export function createSlackMembershipResolver(deps: {
     }
 
     let bots = 0
-    let humans = 0
+    const humanMemberIds: string[] = []
     for (const userId of members.value.members ?? []) {
       const cached = userBotCache.get(userId)
       const isBot = cached ?? (await resolveSlackUserIsBot(fetchFn, deps.token, userId, deps.logger, userBotCache))
       if (isBot) bots++
-      else humans++
+      else humanMemberIds.push(userId)
     }
-    return { humans, bots, fetchedAt: now(), truncated: false }
+    return { humans: humanMemberIds.length, bots, fetchedAt: now(), truncated: false, humanMemberIds }
   }
 }
 

--- a/src/channels/membership.ts
+++ b/src/channels/membership.ts
@@ -21,6 +21,15 @@ export type MembershipCount = {
   bots: number
   fetchedAt: number
   truncated: boolean
+  // Identities of the human members, present ONLY when the adapter enumerated
+  // the COMPLETE current membership and classified every listed member in the
+  // same pass that produced `humans`. When set, `humanMemberIds.length` equals
+  // `humans` by construction, so a consumer can prove "every human in the room
+  // is X" by resolving each id — something the bare `humans` count cannot do.
+  // Left undefined by approximate/truncated/history-derived reads and by
+  // adapters that cannot enumerate members (Telegram, KakaoTalk); consumers
+  // that need a completeness proof must fail closed when it is absent.
+  humanMemberIds?: readonly string[]
 }
 
 export type MembershipResolverFailure = { kind: 'transient' } | { kind: 'permanent' }


### PR DESCRIPTION
## Background

The `grant_role` guard confined role/permission grants to single-principal turns (TUI / 1:1 DM) to close the confused-deputy surface: a group turn buffers in other authors' messages, so a guest could prompt-inject a trusted turn into rewriting the access-control table.

That refused legitimate cases: an operator alone with the bot in a group-capable channel, and small trusted-only operational channels. A channel with no untrusted humans is injection-equivalent to a DM — no untrusted human can buffer a message into the turn — so it is safe to allow.

## Summary

Relax the `grant_role` origin guard so it accepts a group/open channel in two new cases, in addition to the existing TUI and 1:1 DM:

1. **Single-human group** — the platform proves the channel has exactly one human member.
2. **All-humans-trusted group** — the platform proves every human member resolves to trusted or owner.

Two layers of implementation:

**Carry member identities (commits 2–3).** The membership pipeline was count-only (no identities), which cannot prove *who* is in the room. Added an optional field `humanMemberIds?: readonly string[]`, populated ONLY when an adapter enumerated and classified the complete membership in the same pass that produced the human count, guaranteeing the lengths match by construction.
- **Slack / Discord** collect non-bot member ids on their existing ≤-cap enumeration path. Discord drops to counts-only if any member is unidentifiable (never silently dropped).
- **GitHub** emits collaborator ids serialised as strings to match the inbound authorId namespace; counts-only when the page is truncated or any collaborator is unidentifiable.
- **Telegram / KakaoTalk** cannot enumerate members, so they never set the field.

**The guard (commit 4).** The new helper `isAllHumansTrustedGroupChannelOrigin` allows a grant only when ALL hold (fail-closed otherwise): channel not a DM, membership present + non-truncated + fresh, the member-id list present, length equal to the human count, non-empty, at most 20 members (to bound per-member role-resolution work on a tool call), and every id resolving to trusted or owner. The single-human branch remains for adapters that cannot enumerate identities. The per-turn caller-role check, tier ceiling, and grant-only-what-you-hold are all unchanged.

## Preview

N/A — no visual output.

## What this does NOT do

- Does not use `participants` (observed speakers) for authorization — it cannot prove the absence of a silent untrusted lurker. Only an authoritative complete membership enumeration counts.
- Does not relax the per-turn caller check: the acting human must still resolve to owner/trusted.
- Does not enable the multi-human relaxation for Telegram/KakaoTalk (no identity enumeration) — they stay limited to single-human.
- Stale / truncated / missing membership, count/length mismatch, and rooms over the 20-human cap all refuse.

## Review notes

Both relaxations were designed against Oracle review. Key safety points: a bot misclassified as human resolves to guest → fails the check (fail-closed); a human misclassified as bot is defended by the length-equals-count invariant plus same-pass derivation; Discord guild-member overcount only causes false refusals (fail-closed). No user-facing opt-in — the guard is strictly stricter than "single caller is trusted" and fully fail-closed.

Load-bearing invariant: the member-id list length cannot drift from the human count because the field is populated only in the same pass that increments the count. Any adapter that cannot guarantee this omits the field and falls through to the count-only single-human path.

**Tests:** grant-role: single-human allowed; all-trusted multi-human allowed; one-guest-human refused; length-mismatch refused; missing-ids refused; stale refused; truncated refused; over-cap refused; untrusted caller refused. Adapter resolvers: Slack/Discord enumerate paths now assert `humanMemberIds`.

**Checks:** typecheck clean, lint 0 errors, format:check clean, full test suite green (one unrelated environmental failure in `src/update/index.test.ts` on worktree path; passes on a normal checkout/CI).