### PR TITLE
feat(agent): support OPENAI_BASE_URL for OpenAI-compatible proxies

### DIFF
--- a/docs/content/docs/reference/env-vars.mdx
+++ b/docs/content/docs/reference/env-vars.mdx
@@ -44,8 +44,13 @@ Set in the host stage; injected into the container via `--env-file .env`.
 | Variable             | Provider    | Default                     | Effect                                                            |
 | -------------------- | ----------- | --------------------------- | ----------------------------------------------------------------- |
 | `ANTHROPIC_BASE_URL` | `anthropic` | `https://api.anthropic.com` | Point the Anthropic provider at an Anthropic-compatible endpoint. |
+| `OPENAI_BASE_URL`    | `openai`    | `https://api.openai.com/v1` | Point the OpenAI provider at an OpenAI-compatible endpoint.       |
 
-`ANTHROPIC_BASE_URL` routes the `anthropic` provider through a proxy that speaks the **native Anthropic Messages protocol** (`/v1/messages`, `x-api-key` or OAuth Bearer) — e.g. LiteLLM, Cloudflare AI Gateway, or a corporate gateway. It is a base-URL swap only; it does **not** enable raw AWS Bedrock, which requires SigV4 signing and a different request path. Trailing slashes are stripped; a non-http(s) value fails the agent at boot. The same endpoint is used by `typeclaw init`'s API-key validation probe.
+`ANTHROPIC_BASE_URL` routes the `anthropic` provider through a proxy that speaks the **native Anthropic Messages protocol** (`/v1/messages`, `x-api-key` or OAuth Bearer) — e.g. LiteLLM, Cloudflare AI Gateway, or a corporate gateway. It is a base-URL swap only; it does **not** enable raw AWS Bedrock, which requires SigV4 signing and a different request path.
+
+`OPENAI_BASE_URL` does the same for the `openai` provider, routing it through an **OpenAI-compatible** endpoint (LiteLLM, Azure-style gateways, corporate proxies). It targets the api-key `openai` provider only — the OAuth-only `openai-codex` ChatGPT backend is unaffected.
+
+Both follow the same rules: trailing slashes are stripped; a non-http(s) value fails the agent at boot. The same endpoint is used by `typeclaw init`'s API-key validation probe.
 
 ## Channel credentials (env-wins)
 

--- a/src/agent/model-overrides.test.ts
+++ b/src/agent/model-overrides.test.ts
@@ -4,10 +4,11 @@ import { resolveModel } from '@/config'
 import type { KnownModelRef } from '@/config/providers'
 import { KNOWN_PROVIDERS } from '@/config/providers'
 
-import { applyModelRuntimeOverrides, effectiveAnthropicBaseUrl } from './model-overrides'
+import { applyModelRuntimeOverrides, effectiveBaseUrl } from './model-overrides'
 
 const ANTHROPIC_REF = 'anthropic/claude-opus-4-8' as KnownModelRef
 const OPENAI_REF = 'openai/gpt-5.4-nano' as KnownModelRef
+const FIREWORKS_REF = 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' as KnownModelRef
 
 describe('applyModelRuntimeOverrides', () => {
   test('overrides anthropic baseUrl when ANTHROPIC_BASE_URL is set', () => {
@@ -18,10 +19,24 @@ describe('applyModelRuntimeOverrides', () => {
     expect(result.baseUrl).toBe('https://gateway.example.com')
   })
 
+  test('overrides openai baseUrl when OPENAI_BASE_URL is set', () => {
+    const model = resolveModel(OPENAI_REF)
+    const result = applyModelRuntimeOverrides(model, OPENAI_REF, {
+      OPENAI_BASE_URL: 'https://gateway.example.com/openai',
+    })
+    expect(result.baseUrl).toBe('https://gateway.example.com/openai')
+  })
+
   test('leaves baseUrl untouched when the env var is unset', () => {
     const model = resolveModel(ANTHROPIC_REF)
     const result = applyModelRuntimeOverrides(model, ANTHROPIC_REF, {})
     expect(result.baseUrl).toBe(KNOWN_PROVIDERS.anthropic.baseUrl)
+  })
+
+  test('leaves openai baseUrl untouched when OPENAI_BASE_URL is unset', () => {
+    const model = resolveModel(OPENAI_REF)
+    const result = applyModelRuntimeOverrides(model, OPENAI_REF, {})
+    expect(result.baseUrl).toBe(KNOWN_PROVIDERS.openai.baseUrl)
   })
 
   test('treats a blank value as unset', () => {
@@ -45,12 +60,27 @@ describe('applyModelRuntimeOverrides', () => {
     expect(KNOWN_PROVIDERS.anthropic.models['claude-opus-4-8']!.baseUrl).toBe(original)
   })
 
-  test('ignores the env var for non-anthropic providers', () => {
-    const model = resolveModel(OPENAI_REF)
-    const result = applyModelRuntimeOverrides(model, OPENAI_REF, {
+  test('uses each provider its own env var, not the other provider', () => {
+    const openaiModel = resolveModel(OPENAI_REF)
+    const openaiResult = applyModelRuntimeOverrides(openaiModel, OPENAI_REF, {
       ANTHROPIC_BASE_URL: 'https://gateway.example.com',
     })
-    expect(result.baseUrl).toBe(KNOWN_PROVIDERS.openai.baseUrl)
+    expect(openaiResult.baseUrl).toBe(KNOWN_PROVIDERS.openai.baseUrl)
+
+    const anthropicModel = resolveModel(ANTHROPIC_REF)
+    const anthropicResult = applyModelRuntimeOverrides(anthropicModel, ANTHROPIC_REF, {
+      OPENAI_BASE_URL: 'https://gateway.example.com',
+    })
+    expect(anthropicResult.baseUrl).toBe(KNOWN_PROVIDERS.anthropic.baseUrl)
+  })
+
+  test('ignores the env vars for providers without an override', () => {
+    const model = resolveModel(FIREWORKS_REF)
+    const result = applyModelRuntimeOverrides(model, FIREWORKS_REF, {
+      ANTHROPIC_BASE_URL: 'https://gateway.example.com',
+      OPENAI_BASE_URL: 'https://gateway.example.com',
+    })
+    expect(result.baseUrl).toBe(KNOWN_PROVIDERS.fireworks.baseUrl)
   })
 
   test('throws on a non-URL value', () => {
@@ -66,16 +96,31 @@ describe('applyModelRuntimeOverrides', () => {
       /http:\/\/ or https:\/\//,
     )
   })
+
+  test('names the offending env var in the error for openai', () => {
+    const model = resolveModel(OPENAI_REF)
+    expect(() => applyModelRuntimeOverrides(model, OPENAI_REF, { OPENAI_BASE_URL: 'not a url' })).toThrow(
+      /OPENAI_BASE_URL is not a valid URL/,
+    )
+  })
 })
 
-describe('effectiveAnthropicBaseUrl', () => {
+describe('effectiveBaseUrl', () => {
   test('returns the override when set', () => {
     expect(
-      effectiveAnthropicBaseUrl('https://api.anthropic.com', { ANTHROPIC_BASE_URL: 'https://proxy.example' }),
+      effectiveBaseUrl('anthropic', 'https://api.anthropic.com', { ANTHROPIC_BASE_URL: 'https://proxy.example' }),
     ).toBe('https://proxy.example')
+    expect(effectiveBaseUrl('openai', 'https://api.openai.com/v1', { OPENAI_BASE_URL: 'https://proxy.example' })).toBe(
+      'https://proxy.example',
+    )
   })
 
   test('returns the fallback when unset', () => {
-    expect(effectiveAnthropicBaseUrl('https://api.anthropic.com', {})).toBe('https://api.anthropic.com')
+    expect(effectiveBaseUrl('anthropic', 'https://api.anthropic.com', {})).toBe('https://api.anthropic.com')
+    expect(effectiveBaseUrl('openai', 'https://api.openai.com/v1', {})).toBe('https://api.openai.com/v1')
+  })
+
+  test('returns undefined for a provider without an override', () => {
+    expect(effectiveBaseUrl('fireworks', 'https://api.fireworks.ai/inference/v1', {})).toBeUndefined()
   })
 })

--- a/src/agent/model-overrides.ts
+++ b/src/agent/model-overrides.ts
@@ -1,13 +1,24 @@
 import type { Api, Model } from '@mariozechner/pi-ai'
 
-import { providerForModelRef, type KnownModelRef } from '@/config/providers'
+import { providerForModelRef, type KnownModelRef, type KnownProviderId } from '@/config/providers'
 
-// Matches the Anthropic SDK's own `ANTHROPIC_BASE_URL` so a working
-// credential/endpoint pair carries over. Scope is a base-URL swap only: it
-// targets Anthropic-compatible gateways (LiteLLM, Cloudflare AI Gateway,
-// corporate proxies) speaking native `/v1/messages` with `x-api-key`/OAuth
-// Bearer — NOT raw AWS Bedrock, which needs SigV4 and a different transport.
-export const ANTHROPIC_BASE_URL_ENV = 'ANTHROPIC_BASE_URL'
+// Providers whose base URL can be swapped to an upstream-compatible gateway at
+// runtime. Each env var mirrors the upstream SDK's own name so a credential /
+// endpoint pair that works with the official CLI carries over:
+//   * ANTHROPIC_BASE_URL — native Anthropic Messages protocol (`/v1/messages`,
+//     `x-api-key` / OAuth Bearer). NOT raw AWS Bedrock (SigV4, different
+//     transport) — that needs a distinct transport, not a base-URL swap.
+//   * OPENAI_BASE_URL — OpenAI-compatible endpoints (LiteLLM, Azure-style
+//     gateways, corporate proxies) speaking the same request shape as
+//     api.openai.com. Targets the `openai` provider only; `openai-codex` is
+//     an OAuth-only ChatGPT backend, not an API-key endpoint, so it is out of
+//     scope here.
+export const PROVIDER_BASE_URL_ENV = {
+  anthropic: 'ANTHROPIC_BASE_URL',
+  openai: 'OPENAI_BASE_URL',
+} as const satisfies Partial<Record<KnownProviderId, string>>
+
+type OverridableProviderId = keyof typeof PROVIDER_BASE_URL_ENV
 
 // Separate from `resolveModel` so resolution stays a pure table lookup; this
 // is the per-process "prepare the model" seam run just before pi-coding-agent
@@ -18,26 +29,38 @@ export function applyModelRuntimeOverrides<TApi extends Api>(
   ref: KnownModelRef,
   env: NodeJS.ProcessEnv = process.env,
 ): Model<TApi> {
-  if (providerForModelRef(ref) !== 'anthropic') return model
+  const providerId = providerForModelRef(ref)
+  if (!isOverridable(providerId)) return model
 
-  const baseUrl = normalizeBaseUrl(env[ANTHROPIC_BASE_URL_ENV])
+  const baseUrl = normalizeBaseUrl(PROVIDER_BASE_URL_ENV[providerId], env[PROVIDER_BASE_URL_ENV[providerId]])
   if (baseUrl === undefined) return model
 
   return { ...model, baseUrl }
 }
 
-// Resolves the effective Anthropic base URL for a process, falling back to the
-// provider default when the override is unset. Used by callers outside the
-// session path (e.g. the init-time API-key probe) that need to hit the same
-// endpoint the runtime will use.
-export function effectiveAnthropicBaseUrl(fallback: string, env: NodeJS.ProcessEnv = process.env): string {
-  return normalizeBaseUrl(env[ANTHROPIC_BASE_URL_ENV]) ?? fallback
+// Resolves the effective base URL for a provider, falling back to the provider
+// default when the override is unset. Returns `undefined` for providers without
+// a base-URL override so callers can keep their hardcoded probe URL. Used by
+// callers outside the session path (e.g. the init-time API-key probe) that need
+// to hit the same endpoint the runtime will use.
+export function effectiveBaseUrl(
+  providerId: KnownProviderId,
+  fallback: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (!isOverridable(providerId)) return undefined
+  const envVar = PROVIDER_BASE_URL_ENV[providerId]
+  return normalizeBaseUrl(envVar, env[envVar]) ?? fallback
+}
+
+function isOverridable(providerId: KnownProviderId): providerId is OverridableProviderId {
+  return providerId in PROVIDER_BASE_URL_ENV
 }
 
 // `undefined` for unset/blank (caller keeps the default); throws on a value
 // that isn't a parseable http(s) URL so a typo fails loudly at boot rather
-// than silently falling back to api.anthropic.com with the wrong credential.
-function normalizeBaseUrl(value: string | undefined): string | undefined {
+// than silently falling back to the public API with the wrong credential.
+function normalizeBaseUrl(envVar: string, value: string | undefined): string | undefined {
   const trimmed = value?.trim()
   if (trimmed === undefined || trimmed === '') return undefined
 
@@ -45,10 +68,10 @@ function normalizeBaseUrl(value: string | undefined): string | undefined {
   try {
     url = new URL(trimmed)
   } catch {
-    throw new Error(`${ANTHROPIC_BASE_URL_ENV} is not a valid URL: ${trimmed}`)
+    throw new Error(`${envVar} is not a valid URL: ${trimmed}`)
   }
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new Error(`${ANTHROPIC_BASE_URL_ENV} must use http:// or https://, got: ${trimmed}`)
+    throw new Error(`${envVar} must use http:// or https://, got: ${trimmed}`)
   }
   return url.toString().replace(/\/+$/, '')
 }

--- a/src/init/validate-api-key.test.ts
+++ b/src/init/validate-api-key.test.ts
@@ -145,6 +145,46 @@ describe('validateApiKey', () => {
     }
   })
 
+  test('probes api.openai.com by default', async () => {
+    const prev = process.env.OPENAI_BASE_URL
+    delete process.env.OPENAI_BASE_URL
+    try {
+      let seenUrl: string | null = null
+      await validateApiKey(
+        'openai',
+        'sk-test',
+        fakeFetch((url) => {
+          seenUrl = url
+          return new Response(okBody, { status: 200 })
+        }),
+      )
+      expect(seenUrl!).toBe('https://api.openai.com/v1/models')
+    } finally {
+      if (prev === undefined) delete process.env.OPENAI_BASE_URL
+      else process.env.OPENAI_BASE_URL = prev
+    }
+  })
+
+  test('probes the proxy endpoint when OPENAI_BASE_URL is set', async () => {
+    const prev = process.env.OPENAI_BASE_URL
+    process.env.OPENAI_BASE_URL = 'https://gateway.example.com/openai/'
+    try {
+      let seenUrl: string | null = null
+      await validateApiKey(
+        'openai',
+        'sk-test',
+        fakeFetch((url) => {
+          seenUrl = url
+          return new Response(okBody, { status: 200 })
+        }),
+      )
+      expect(seenUrl!).toBe('https://gateway.example.com/openai/models')
+    } finally {
+      if (prev === undefined) delete process.env.OPENAI_BASE_URL
+      else process.env.OPENAI_BASE_URL = prev
+    }
+  })
+
   test('skips OAuth-only providers without contacting the network', async () => {
     let called = false
     const result = await validateApiKey('openai-codex', 'whatever', async () => {

--- a/src/init/validate-api-key.ts
+++ b/src/init/validate-api-key.ts
@@ -1,4 +1,4 @@
-import { effectiveAnthropicBaseUrl } from '@/agent/model-overrides'
+import { effectiveBaseUrl } from '@/agent/model-overrides'
 import { KNOWN_PROVIDERS, type KnownProviderId } from '@/config/providers'
 
 const PROVIDER_PROBE: Partial<Record<KnownProviderId, { url: string; authHeader: 'bearer' | 'x-api-key' }>> = {
@@ -9,12 +9,17 @@ const PROVIDER_PROBE: Partial<Record<KnownProviderId, { url: string; authHeader:
   'zai-coding': { url: 'https://api.z.ai/api/coding/paas/v4/models', authHeader: 'bearer' },
 }
 
-// When ANTHROPIC_BASE_URL points at a proxy, probe THAT endpoint — validating
-// the key against api.anthropic.com would test the wrong gateway (and may
-// reject a proxy-only credential). The proxy must expose `/v1/models`.
+// When a base-URL override (ANTHROPIC_BASE_URL / OPENAI_BASE_URL) points at a
+// proxy, probe THAT endpoint — validating against the public API would test the
+// wrong gateway (and may reject a proxy-only credential). The path suffix is
+// whatever the hardcoded default probe URL adds on top of the provider's
+// default baseUrl, so providers with different version-segment conventions
+// (anthropic baseUrl omits `/v1`, openai includes it) each keep their own path.
 function probeUrlFor(providerId: KnownProviderId, defaultUrl: string): string {
-  if (providerId !== 'anthropic') return defaultUrl
-  return `${effectiveAnthropicBaseUrl(KNOWN_PROVIDERS.anthropic.baseUrl)}/v1/models`
+  const defaultBase = KNOWN_PROVIDERS[providerId].baseUrl
+  const base = effectiveBaseUrl(providerId, defaultBase)
+  if (base === undefined) return defaultUrl
+  return `${base}${defaultUrl.slice(defaultBase.length)}`
 }
 
 export type KeyValidationResult =


### PR DESCRIPTION
## What

Follow-up to #535. Adds a runtime base-URL override for the `openai` provider. Setting `OPENAI_BASE_URL` in `.env` routes the provider through an **OpenAI-compatible** gateway instead of `https://api.openai.com/v1`.

```sh
# .env
OPENAI_BASE_URL=https://gateway.example.com/openai
OPENAI_API_KEY=...
```

## Why

#535 shipped `ANTHROPIC_BASE_URL` for the same reason — users behind corporate proxies or running their own gateways (LiteLLM, Azure-style endpoints, Cloudflare AI Gateway, etc.) need to point a provider somewhere other than the public API without forking the provider table. This extends that to OpenAI.

## How

- Generalized the override seam in `src/agent/model-overrides.ts` from anthropic-specific to a `PROVIDER_BASE_URL_ENV` table (`{ anthropic: ANTHROPIC_BASE_URL, openai: OPENAI_BASE_URL }`). `applyModelRuntimeOverrides` now looks the provider up in that table instead of hardcoding `'anthropic'`.
- The env var name mirrors the OpenAI SDK's own `OPENAI_BASE_URL`, so a credential/endpoint pair that works with the official tooling carries over.
- `effectiveAnthropicBaseUrl` → `effectiveBaseUrl(providerId, fallback)`, returning `undefined` for providers without an override so the init probe keeps its hardcoded URL untouched.
- `typeclaw init`'s API-key validation probe (`src/init/validate-api-key.ts`) follows the override for `openai` too. The probe path is derived as `(default probe URL − default baseUrl)`, which **preserves each provider's version-segment convention**: anthropic's `baseUrl` omits `/v1` (probe appends `/v1/models`), openai's includes it (probe appends `/models`). A regression here was caught by the existing anthropic probe tests.
- Same validation contract as anthropic: trailing slashes normalized away, a non-`http(s)` or unparseable value throws at boot (fail loud), and the shared `KNOWN_PROVIDERS` literal is never mutated.

## Scope (honest)

Base-URL swap only, identical to #535. It targets proxies that speak the OpenAI request shape against the `openai` provider. It does **not** touch `openai-codex` — that's the OAuth-only ChatGPT backend, not an API-key endpoint, so a base-URL override doesn't apply.

## Tests

- `src/agent/model-overrides.test.ts` — openai set/unset, trailing-slash normalization, per-provider env isolation (openai doesn't read `ANTHROPIC_BASE_URL` and vice versa), passthrough for providers without an override (fireworks), invalid-URL/non-http(s) throw naming the correct env var, `effectiveBaseUrl` override/fallback/`undefined`.
- `src/init/validate-api-key.test.ts` — probe hits `api.openai.com/v1/models` by default and follows the override when set; existing anthropic probe tests still green (guards the version-segment asymmetry).
- `bun run typecheck`, `bun run lint` (0 errors), `bun run format` all clean. Full `src/agent` + `src/init` suites green (1313 pass / 0 fail).

## Docs

- `docs/content/docs/reference/env-vars.mdx` — `OPENAI_BASE_URL` row + prose in the "Provider endpoint overrides" section.