### PR TITLE
feat(sandbox): ship yq in the container baseline so it is sandbox-visible

### DIFF
--- a/src/bundled-plugins/security/policies/secret-exfil-bash.test.ts
+++ b/src/bundled-plugins/security/policies/secret-exfil-bash.test.ts
@@ -176,6 +176,24 @@ describe('secret-exfil-bash guard', () => {
     expect(checkSecretExfilBashGuard({ tool: 'bash', args: { command: 'cat ~/project/.env' } })?.block).toBe(true)
   })
 
+  test('blocks jq . .env (jq ships in baseline and reads+emits the file like cat)', () => {
+    expect(checkSecretExfilBashGuard({ tool: 'bash', args: { command: 'jq . .env' } })?.block).toBe(true)
+  })
+
+  test('blocks yq . .env (yq ships in baseline and reads+emits the file like cat)', () => {
+    expect(checkSecretExfilBashGuard({ tool: 'bash', args: { command: "yq '.FIREWORKS_API_KEY' .env" } })?.block).toBe(
+      true,
+    )
+  })
+
+  test('blocks jq . .envrc', () => {
+    expect(checkSecretExfilBashGuard({ tool: 'bash', args: { command: 'jq . .envrc' } })?.block).toBe(true)
+  })
+
+  test('blocks yq . .envrc', () => {
+    expect(checkSecretExfilBashGuard({ tool: 'bash', args: { command: 'yq . ./.envrc' } })?.block).toBe(true)
+  })
+
   test('blocks ls -la ~/.ssh/ (private-key directory enumeration)', () => {
     expect(checkSecretExfilBashGuard({ tool: 'bash', args: { command: 'ls -la ~/.ssh/' } })?.block).toBe(true)
   })

--- a/src/bundled-plugins/security/policies/secret-exfil-bash.ts
+++ b/src/bundled-plugins/security/policies/secret-exfil-bash.ts
@@ -49,10 +49,17 @@ const DANGEROUS_COMMAND_PATTERNS: ReadonlyArray<{ pattern: RegExp; label: string
   // `set -e` / `set -euo pipefail`) and require the posix-mode opt-in.
   { pattern: /set\s+-o\s+posix[\s\S]{0,40}(?:^|[\s;|&(`])set(?:[\s;|&)`]|$)/m, label: 'set -o posix; set (env dump)' },
   {
-    pattern: /(cat|less|more|head|tail|bat|xxd|od|hexdump|strings)\s+[^\n;|&`]*\.env(\s|$|[;|&`])/,
+    // jq/yq read+emit arbitrary files just like cat (e.g. `jq . .env`,
+    // `yq '.x' .env`) and both ship in the container baseline, so they are
+    // first-class .env exfil vectors and must be gated here, not just the
+    // pager/dumper family.
+    pattern: /(cat|less|more|head|tail|bat|xxd|od|hexdump|strings|jq|yq)\s+[^\n;|&`]*\.env(\s|$|[;|&`])/,
     label: 'reading .env file',
   },
-  { pattern: /(cat|less|more|head|tail|bat)\s+[^\n;|&`]*\.envrc(\s|$|[;|&`])/, label: 'reading .envrc file' },
+  {
+    pattern: /(cat|less|more|head|tail|bat|jq|yq)\s+[^\n;|&`]*\.envrc(\s|$|[;|&`])/,
+    label: 'reading .envrc file',
+  },
   { pattern: /\.ssh\/(id_[a-z0-9]+|authorized_keys|known_hosts|config)/i, label: '~/.ssh/* private material' },
   {
     pattern: /(cat|less|more|head|tail|ls|find|grep|rg|bat)\s+[^\n;|&`]*~?\/?\.ssh(\/|\s|$|[;|&`])/,

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -21,6 +21,10 @@ import {
   NETWORK_BLOCK_IPV4_NETS,
   NETWORK_BLOCK_IPV6_NETS,
   TYPECLAW_ENTRYPOINT_PATH,
+  YQ_RELEASE_URL_BASE,
+  YQ_SHA256_AMD64,
+  YQ_SHA256_ARM64,
+  YQ_VERSION,
 } from './dockerfile'
 
 // Layer ordering, cache-mount preservation, and on-disk write behavior are
@@ -960,6 +964,58 @@ describe('curl-impersonate layer', () => {
   })
 })
 
+describe('yq layer', () => {
+  test('embeds the pinned version in the release URL so a bump is a deliberate, reviewable change, not a moving "latest" target', () => {
+    const out = buildDockerfile()
+    expect(out).toContain(`${YQ_RELEASE_URL_BASE}/${YQ_VERSION}/yq_linux_`)
+  })
+
+  test('verifies the binary sha256 so a tampered download fails the build', () => {
+    const out = buildDockerfile()
+    expect(out).toContain(YQ_SHA256_AMD64)
+    expect(out).toContain(YQ_SHA256_ARM64)
+    expect(out).toContain('sha256sum -c -')
+  })
+
+  test('branches by TARGETARCH so the same Dockerfile produces correct binaries on amd64 and arm64', () => {
+    const out = buildDockerfile()
+    expect(out).toMatch(/TARGETARCH.*arm64.*echo arm64.*echo amd64/s)
+  })
+
+  test('installs to /usr/local/bin (on $PATH) and smoke-tests at build time so a broken binary fails the build, not the first sandboxed pipeline', () => {
+    const out = buildDockerfile()
+    expect(out).toContain('mv yq /usr/local/bin/yq')
+    expect(out).toContain('/usr/local/bin/yq --version')
+  })
+
+  test('ships unconditionally regardless of toggles, mirroring jq — a sandbox-visible read-only pipeline tool, not a feature gate', () => {
+    const allOff = buildDockerfile(
+      dockerfileSchema.parse({
+        tmux: false,
+        gh: false,
+        python: false,
+        ffmpeg: false,
+        cjkFonts: false,
+        xvfb: false,
+        cloudflared: false,
+      }),
+    )
+    expect(allOff).toContain('mv yq /usr/local/bin/yq')
+  })
+
+  test('yq layer is between curl-impersonate and agent-browser so an agent-browser bump does not invalidate it and the apt baseline (curl, ca-certificates) is satisfied', () => {
+    const out = buildDockerfile()
+    const curlImpersonateIdx = out.indexOf('curl-impersonate.tar.gz')
+    const yqIdx = out.indexOf('mv yq /usr/local/bin/yq')
+    const agentBrowserIdx = out.indexOf('bun install -g agent-browser')
+    expect(curlImpersonateIdx).toBeGreaterThan(-1)
+    expect(yqIdx).toBeGreaterThan(-1)
+    expect(agentBrowserIdx).toBeGreaterThan(-1)
+    expect(curlImpersonateIdx).toBeLessThan(yqIdx)
+    expect(yqIdx).toBeLessThan(agentBrowserIdx)
+  })
+})
+
 describe('cloudflared layer', () => {
   test('cloudflared: true emits the pinned cloudflared download layer', () => {
     const out = buildDockerfile(dockerfileSchema.parse({ cloudflared: true }))
@@ -1014,6 +1070,14 @@ describe('base ↔ per-agent Dockerfile drift guard', () => {
     expect(base).toContain(CURL_IMPERSONATE_SHA256_AMD64)
     expect(base).toContain(CURL_IMPERSONATE_SHA256_ARM64)
     expect(base).toContain(`/usr/local/bin/curl_${CURL_IMPERSONATE_PROFILE} --version`)
+  })
+
+  test('base Dockerfile pins the same yq version, sha256s, and install path as the per-agent Dockerfile so sandboxed `... | yq` resolves regardless of which Dockerfile produced the image', () => {
+    const base = buildBaseDockerfile()
+    expect(base).toContain(`${YQ_RELEASE_URL_BASE}/${YQ_VERSION}/yq_linux_`)
+    expect(base).toContain(YQ_SHA256_AMD64)
+    expect(base).toContain(YQ_SHA256_ARM64)
+    expect(base).toContain('mv yq /usr/local/bin/yq')
   })
 
   test('base Dockerfile installs the full Playwright-tested chromium runtime dep set on amd64 — same list the per-agent Dockerfile depends on Chrome to find at launch time', () => {

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -98,6 +98,33 @@ export const CURL_IMPERSONATE_SHA256_ARM64 = '6766bc67fd3e8e2313875f32b36b5a3fab
 // the impersonation to whatever `curl_chrome` resolves to.
 export const CURL_IMPERSONATE_PROFILE = 'chrome136'
 
+// yq is the YAML/JSON/XML processor the `explorer` and `reviewer` subagent
+// prompts advertise alongside `jq` as a sanctioned one-shot read-only
+// pipeline tool (`... | yq`). Like `jq` (shipped in baseline), a binary that
+// is not in the container base image is invisible inside the per-tool bwrap
+// sandbox that wraps agent bash calls — the sandbox only `--ro-bind`s `/usr`
+// + `/bin` from the container, and there is no per-call install path. So `yq`
+// ships unconditionally, same rationale as `jq`/`bubblewrap`/`util-linux`.
+//
+// This is Mike Farah's Go `yq` (https://github.com/mikefarah/yq), NOT the
+// Python jq-wrapper of the same name in Debian's `yq` apt package. The
+// prompts pair `yq` with `jq` for jq-style expression pipelines, which is
+// Farah's syntax — the Python tool's CLI is incompatible. Distributed as a
+// per-arch static binary (no apt package on trixie for the Go variant), so
+// it follows the pinned-version + per-arch SHA256 + `sha256sum -c` pattern of
+// curl-impersonate and cloudflared rather than the apt baseline list.
+//
+// To bump: pick a release from https://github.com/mikefarah/yq/releases,
+// then for each arch download yq_linux_<arch> and `shasum -a 256` it (or read
+// the SHA-256 column from the release's `checksums` file, cross-indexed via
+// `checksums_hashes_order`). Update all three constants in the same commit;
+// the build fails loudly at `sha256sum -c` on a mismatch. Version literal is
+// the release tag exactly as it appears on GitHub (with `v` prefix).
+export const YQ_VERSION = 'v4.53.2'
+export const YQ_SHA256_AMD64 = 'd56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b'
+export const YQ_SHA256_ARM64 = '03061b2a50c7a498de2bbb92d7cb078ce433011f085a4994117c2726be4106ea'
+export const YQ_RELEASE_URL_BASE = 'https://github.com/mikefarah/yq/releases/download'
+
 // cloudflared powers `cloudflare-quick` tunnels. Pinned-version + per-arch
 // SHA256 mirrors the curl-impersonate pattern above: bumping requires updating
 // all three constants in the same commit, and the build fails loudly at
@@ -1188,6 +1215,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\
 
 ${LAYER_2_5_CURL_IMPERSONATE}
 
+${LAYER_2_6_YQ}
+
 ${LAYER_3_AGENT_BROWSER_ARM64_CONFIG}
 
 ${LAYER_4_AGENT_BROWSER_INSTALL}
@@ -1267,6 +1296,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \\
 
 ${LAYER_2_5_CURL_IMPERSONATE}
 
+${LAYER_2_6_YQ}
+
 ${LAYER_3_AGENT_BROWSER_ARM64_CONFIG}
 
 ${LAYER_4_AGENT_BROWSER_INSTALL}
@@ -1320,6 +1351,24 @@ RUN ARCH_TARBALL="$(if [ "$TARGETARCH" = "arm64" ]; then echo aarch64-linux-gnu;
  && tar -xzf curl-impersonate.tar.gz -C /usr/local/bin/ \\
  && rm curl-impersonate.tar.gz \\
  && /usr/local/bin/curl_${CURL_IMPERSONATE_PROFILE} --version > /dev/null`
+
+// Layer 2.6: install pinned Mike Farah `yq` (Go) so the explorer/reviewer
+// subagents' advertised `... | yq` pipelines resolve inside the bwrap
+// sandbox. Unconditional like the apt baseline (jq, git): a missing binary
+// is invisible to sandboxed bash, so this is not behind a toggle. Placed
+// after curl-impersonate (curl + ca-certificates from baseline guaranteed
+// present) and before agent-browser so an agent-browser bump doesn't
+// invalidate this layer. See the YQ_* constants above for the bump recipe
+// and the Go-vs-Python `yq` rationale.
+const LAYER_2_6_YQ = `# Layer 2.6 (stable): pinned Mike Farah yq for sandbox-visible YAML pipelines.
+RUN ARCH_BIN="$(if [ "$TARGETARCH" = "arm64" ]; then echo arm64; else echo amd64; fi)" \\
+ && ARCH_SHA="$(if [ "$TARGETARCH" = "arm64" ]; then echo ${YQ_SHA256_ARM64}; else echo ${YQ_SHA256_AMD64}; fi)" \\
+ && cd /tmp \\
+ && curl -fsSL -o yq "${YQ_RELEASE_URL_BASE}/${YQ_VERSION}/yq_linux_\${ARCH_BIN}" \\
+ && echo "\${ARCH_SHA}  yq" | sha256sum -c - \\
+ && chmod +x yq \\
+ && mv yq /usr/local/bin/yq \\
+ && /usr/local/bin/yq --version > /dev/null`
 
 const LAYER_3_AGENT_BROWSER_ARM64_CONFIG = `# Layer 3 (stable, arm64 only): point agent-browser at the apt-installed
 # chromium. Independent of the npm install below so it stays cached across


### PR DESCRIPTION
## What

Adds Mike Farah's Go `yq` to the container base image (and, by extension, the per-agent image) as a pinned-version + per-arch SHA256 download layer (`LAYER_2_6_YQ` in `src/init/dockerfile.ts`).

Follow-up to #536, which did the same for `jq`.

## Why

The per-tool bwrap sandbox that wraps agent bash calls only `--ro-bind`s `/usr` + `/bin` from the container (see `src/sandbox/build.ts`). A binary that is **not in the base image is invisible inside the sandbox** — there is no per-call install path.

The `explorer` (`src/bundled-plugins/explorer/explorer.ts`) and `reviewer` (`src/bundled-plugins/reviewer/reviewer.ts:57`) subagent prompts advertise `yq` right alongside `jq` as a sanctioned one-shot read-only pipeline tool:

> one-shot pipelines that do not mutate state (`cat`, `head`, `tail`, `wc`, `sort`, `uniq`, `jq`, `yq`)

But `yq` was never installed in the container, so any sandboxed `... | yq` pipeline failed with "command not found" — the **exact** failure mode #536 fixed for `jq`.

I audited every bash tool the subagent prompts advertise against `oven/bun:1-slim` + `BASELINE_APT_PACKAGES`. After #536, `yq` was the only remaining advertised-but-blocked tool:

| Advertised tool | In base image? | In baseline? | Status |
|---|---|---|---|
| `cat head tail wc sort uniq awk sed grep find` | yes (coreutils/gawk/sed/grep/findutils) | — | OK |
| `git` | no | yes (baseline) | OK |
| `jq` | no | yes (#536) | OK |
| **`yq`** | no | **no** | **fixed here** |

Tools like `rg`/ripgrep, `fd`, and `tree` are **also** absent from the base, but **no subagent prompt advertises them**, and the runtime `grep`/`find` tools are native TS — not shell-outs to ripgrep — so their absence is not a bug. (`rg` appears only in two `secret-exfil-bash` guard regexes as defensive deny-patterns, not as an availability promise.) `gh` is correctly a `docker.file.gh` toggle, not baseline. So this PR adds `yq` only.

## Notes

- **Mike Farah's Go `yq`, not Debian's `yq`.** The apt `yq` package is the Python jq-wrapper by Andrey Kislyuk, whose CLI is incompatible with the jq-style expressions the prompts imply by pairing it with `jq`. The Go variant has no apt package on trixie, so it ships as a pinned binary (`v4.53.2`) via `curl | sha256sum -c`, mirroring the `curl-impersonate`/`cloudflared` pattern rather than the apt baseline list.
- **Unconditional**, not behind a `docker.file` toggle — same rationale as `jq`/`bubblewrap`/`util-linux`: a sandbox-visibility primitive the subagents rely on, not a feature gate.
- **No drift.** Both `buildBaseDockerfile()` and the dev inline path compose from the same `LAYER_2_6_YQ` template. A drift-guard test asserts the base pins the same version/hashes/install path as the per-agent Dockerfile.
- SHA256 hashes verified two ways: computed directly from the downloaded `yq_linux_{amd64,arm64}` binaries, and cross-checked against the SHA-256 column of the release's official `checksums` file (indexed via `checksums_hashes_order`). Both agree.

## Security follow-up (second commit)

Self-review surfaced that `secret-exfil-bash`'s `.env` and `.envrc` deny-rules gate reads by an explicit tool-name alternation (`cat|less|more|head|tail|bat|...`). Both `jq` (shipped in #536) and `yq` (this PR) read a file and emit its full contents to stdout (`jq . .env`, `yq '.x' .env`), making them `cat`-equivalent exfil vectors — but neither was in the alternation. Harmless while the binaries didn't exist; shipping them into the baseline makes both bypasses live, exposing `.env` (which holds `FIREWORKS_API_KEY` and channel credentials).

Commit `fix(security): gate jq/yq .env+.envrc reads in secret-exfil-bash` adds `jq` and `yq` to both the `.env` and `.envrc` tool-name alternations, with red-green-verified tests (each new input is confirmed `before=false` under the old regex, `after=true` under the new one). High-value paths (`~/.ssh`, `~/.aws`, `~/.gnupg`, `/proc/*/environ`) were already caught by separate path-based rules and are unaffected — only the tool-name-gated `.env`/`.envrc` rules had the gap.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (64 pre-existing warnings, unrelated — same set #536 noted)
- `bun run format` — no changes
- `bun test src/init/dockerfile.test.ts --parallel` — 214 pass / 0 fail (7 new tests: pinned-URL, sha256 verification, TARGETARCH branching, install-path + build-time smoke test, unconditional-regardless-of-toggles, layer ordering, and a base↔per-agent drift guard)
- `bun test src/bundled-plugins/security/policies/secret-exfil-bash.test.ts --parallel` — 53 pass / 0 fail (4 new: jq/yq × .env/.envrc)
- `bun run typecheck` / `bun run lint` (0 errors) / `bun run format` — all clean on the security commit too
