### PR TITLE
feat(channels): make stickiness group-aware so the bot observes in busy rooms

### DIFF
--- a/docs/content/docs/internals/engagement.mdx
+++ b/docs/content/docs/internals/engagement.mdx
@@ -24,7 +24,7 @@ Every inbound that survives the `channel.respond` permission gate is tagged with
 `decideEngagement` is a priority ladder. The first matching rule wins; falling off the bottom yields `observe`.
 
 1. **Explicit triggers** (config `trigger`): `dm`, `mention` (platform `<@id>`), `reply` to a bot message. Any one engages.
-2. **Sticky credit**: if `stickiness` is on and the author holds an unexpired credit in the `StickyLedger`, engage and consume it. Credits are granted to the authors a bot reply targets (`grantStickyForReplyTargets`), so a back-and-forth stays engaged without re-mentioning.
+2. **Sticky credit**: if `stickiness` is on and the author holds an unexpired credit in the `StickyLedger`, **consume** it — but it only forces `engage` outside a multi-human group (`isMultiHumanGroup`: not a DM and `effectiveHumans > 1`). Credits are granted to the authors a bot reply targets (`grantStickyForReplyTargets`), so a 1:1 / DM / solo-human back-and-forth stays engaged without re-mentioning. In a multi-human group the credit is still spent (it stays one-shot, so a later membership change can't resurrect stale conversational credit) but does **not** by itself wake the bot — the author must re-address it via mention / reply / alias. Sticky is a dyadic continuation affordance, not a multi-human group auto-reply mandate.
 3. **Alias match**: the message text contains the agent's name or a configured `alias` in plain text (case-insensitive substring, no word boundaries). `basename(agentDir)` is an implicit alias. **Not** suppressed by `mentionsOthers` — addressing two bots by name in one message engages both, each on its own alias.
 4. **Suppressors** (see below) — if any fires, return `observe` even though the solo-human fallback would otherwise engage.
 5. **Solo-human fallback**: if the channel currently holds at most one distinct **human** participant and the author isn't a bot, engage. Reverts to strict the moment a second human posts. This makes a one-human dev channel work without an `@mention` on every line.
@@ -81,10 +81,14 @@ Distinct from the per-session [tool loop guard](/docs/internals/message-stream) 
 
 When active, `composeTurnPrompt` prepends a fenced `**[SYSTEM MESSAGE — not from a human]**` block telling the model it may reply `NO_REPLY` to stay silent. The notice lives in the user-turn suffix (not the system prompt) so it stays cache-neutral, and clears automatically once a human posts.
 
+## Group-chat nudge
+
+A second, milder runtime notice rides the **same** fenced `**[SYSTEM MESSAGE — not from a human]**` convention. On any engaged turn in a multi-human group (`live.multiHumanGroup`, set in `route()` from the same membership + participants the engagement decision used), `composeTurnPrompt` appends a block telling the model it is in a group chat and should reply only when addressed or clearly needed, otherwise `NO_REPLY` / `skip_response`. It is suppressed when the loop guard already fired (one silence notice per turn), and like the loop guard it is a cache-neutral user-turn suffix. The engagement gate already keeps sticky from waking the bot on every follow-up; this nudge tunes the turns the bot **is** woken for. The two share one definition (`isMultiHumanGroup`) so suppression and nudge never disagree.
+
 ## Rules of thumb
 
 - **`decideEngagement` is pure.** Inputs in, `engage`/`observe` out. No I/O, no side effects — the router owns buffering, broadcasting, and membership warming.
-- **The fix for over/under-engagement is `trigger` + `alias`, not new gates.** The `trigger` set already applies symmetrically to humans and bots. Don't add bot-only suppression knobs.
+- **The fix for over/under-engagement is `trigger` + `alias`, not new gates.** The `trigger` set already applies symmetrically to humans and bots. Don't add bot-only suppression knobs. Narrowing an _existing_ permissive rule to the context where it misfires is fine when it stays symmetric — e.g. group-aware sticky keys off `isMultiHumanGroup`, which treats humans and peer bots identically. A new rule that demands extra triggers _from bots specifically_ is not.
 - **`observe` is logged and broadcast on every hit.** An "unanswered mention" is always diagnosable from `typeclaw inspect` or the container logs — never silent.
 - **Observed messages re-enter the next turn.** Treat the context buffer as "what the agent saw while quiet," not as discarded traffic.
 - **Two loop guards, two layers.** Tool-call loops are per-session in `src/agent/`; peer-bot engage loops are per-channel in the router. Don't conflate them.

--- a/src/channels/engagement.test.ts
+++ b/src/channels/engagement.test.ts
@@ -251,6 +251,11 @@ describe('decideEngagement (alias)', () => {
 })
 
 describe('decideEngagement (sticky)', () => {
+  // These cases isolate the sticky mechanic itself, so they run in a
+  // one-human channel where sticky force-engages. Multi-human group
+  // suppression is covered in the `(group-aware sticky)` block below.
+  const solo: readonly ChannelParticipant[] = [participant('alice')]
+
   test('sticky credit consumed engages a follow-up message', () => {
     const ledger = new StickyLedger()
     ledger.grant(KEY, 'alice', 1000)
@@ -260,7 +265,7 @@ describe('decideEngagement (sticky)', () => {
       key: KEY,
       ledger,
       now: 500,
-      participants: crowded,
+      participants: solo,
     })
     expect(decision).toBe('engage')
   })
@@ -268,14 +273,14 @@ describe('decideEngagement (sticky)', () => {
   test('sticky credit is consumed (single message)', () => {
     const ledger = new StickyLedger()
     ledger.grant(KEY, 'alice', 1000)
-    decideEngagement({ message: inbound(), config: baseConfig, key: KEY, ledger, now: 100, participants: crowded })
+    decideEngagement({ message: inbound(), config: baseConfig, key: KEY, ledger, now: 100, participants: solo })
     const second = decideEngagement({
-      message: inbound(),
+      message: inbound({ mentionsOthers: true }),
       config: baseConfig,
       key: KEY,
       ledger,
       now: 200,
-      participants: crowded,
+      participants: solo,
     })
     expect(second).toBe('observe')
   })
@@ -284,12 +289,12 @@ describe('decideEngagement (sticky)', () => {
     const ledger = new StickyLedger()
     ledger.grant(KEY, 'alice', 1000)
     const decision = decideEngagement({
-      message: inbound(),
+      message: inbound({ mentionsOthers: true }),
       config: baseConfig,
       key: KEY,
       ledger,
       now: 5000,
-      participants: crowded,
+      participants: solo,
     })
     expect(decision).toBe('observe')
     expect(ledger.has(KEY, 'alice', 5000)).toBe(false)
@@ -568,7 +573,9 @@ describe('decideEngagement (solo-human fallback)', () => {
     expect(decision).toBe('observe')
   })
 
-  test('sticky credit still bypasses high membership counts', () => {
+  test('sticky credit bypasses high membership when only one human is present', () => {
+    // Solo-human channel (one persisted speaker, membership confirms one
+    // human among many bots): sticky still force-engages the follow-up.
     const ledger = new StickyLedger()
     ledger.grant(KEY, 'alice', 10_000)
     const decision = decideEngagement({
@@ -578,10 +585,138 @@ describe('decideEngagement (solo-human fallback)', () => {
       ledger,
       now: 1000,
       participants: [participant('alice')],
-      membership: { humans: 50, bots: 5, fetchedAt: 1000, truncated: false },
+      membership: { humans: 1, bots: 5, fetchedAt: 1000, truncated: false },
     })
 
     expect(decision).toBe('engage')
+  })
+})
+
+describe('decideEngagement (group-aware sticky)', () => {
+  test('sticky credit force-engages in a DM', () => {
+    const ledger = new StickyLedger()
+    ledger.grant('discord-bot:@dm:d1:', 'alice', 10_000)
+    const decision = decideEngagement({
+      message: inbound({ isDm: true, workspace: '@dm' }),
+      config: baseConfig,
+      key: 'discord-bot:@dm:d1:',
+      ledger,
+      now: 1000,
+      participants: crowded,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('sticky credit force-engages when at most one human is present', () => {
+    const ledger = new StickyLedger()
+    ledger.grant(KEY, 'alice', 10_000)
+    const decision = decideEngagement({
+      message: inbound(),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 1000,
+      participants: [participant('alice')],
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('sticky credit does NOT engage in a multi-human group, but IS consumed', () => {
+    // given a multi-human group and a held credit for alice
+    const ledger = new StickyLedger()
+    ledger.grant(KEY, 'alice', 10_000)
+
+    // when alice posts plain chatter (no mention/reply/alias)
+    const decision = decideEngagement({
+      message: inbound(),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 1000,
+      participants: crowded,
+    })
+
+    // then we observe, and the one-shot credit is spent regardless
+    expect(decision).toBe('observe')
+    expect(ledger.has(KEY, 'alice', 1000)).toBe(false)
+  })
+
+  test('a consumed-in-group credit does not resurrect a later follow-up', () => {
+    // given a credit consumed by a group message (observed above)
+    const ledger = new StickyLedger()
+    ledger.grant(KEY, 'alice', 10_000)
+    decideEngagement({ message: inbound(), config: baseConfig, key: KEY, ledger, now: 1000, participants: crowded })
+
+    // when alice posts again with no fresh trigger
+    const second = decideEngagement({
+      message: inbound(),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 2000,
+      participants: crowded,
+    })
+
+    // then still observe — the spent credit cannot wake us
+    expect(second).toBe('observe')
+  })
+
+  test('explicit mention still engages in a multi-human group despite suppressed sticky', () => {
+    const ledger = new StickyLedger()
+    ledger.grant(KEY, 'alice', 10_000)
+    const decision = decideEngagement({
+      message: inbound({ isBotMention: true }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 1000,
+      participants: crowded,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('alias still engages in a multi-human group despite suppressed sticky', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({ text: '봉봉아 deploy please' }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 1000,
+      participants: crowded,
+      selfAliases: ['봉봉'],
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('peer bot sticky still engages in a one-human channel but observes in a multi-human group', () => {
+    // given a peer bot holding a credit
+    const soloLedger = new StickyLedger()
+    soloLedger.grant(KEY, 'peer1', 10_000)
+    const solo = decideEngagement({
+      message: inbound({ authorId: 'peer1', authorName: 'peer1', authorIsBot: true }),
+      config: baseConfig,
+      key: KEY,
+      ledger: soloLedger,
+      now: 1000,
+      participants: [participant('alice'), { ...participant('peer1'), isBot: true }],
+    })
+    expect(solo).toBe('engage')
+
+    // when the same peer bot holds a credit in a two-human group
+    const groupLedger = new StickyLedger()
+    groupLedger.grant(KEY, 'peer1', 10_000)
+    const group = decideEngagement({
+      message: inbound({ authorId: 'peer1', authorName: 'peer1', authorIsBot: true }),
+      config: baseConfig,
+      key: KEY,
+      ledger: groupLedger,
+      now: 1000,
+      participants: [participant('alice'), participant('bob'), { ...participant('peer1'), isBot: true }],
+    })
+
+    // then symmetric with humans — sticky alone no longer wakes us
+    expect(group).toBe('observe')
   })
 })
 

--- a/src/channels/engagement.ts
+++ b/src/channels/engagement.ts
@@ -81,11 +81,25 @@ export type EngagementInput = {
 export function decideEngagement(input: EngagementInput): EngagementDecision {
   const { message, config, key, ledger, now, participants, selfAliases, botInThread } = input
 
+  // The human count drives both the sticky-credit gate (below) and the
+  // solo-human fallback (bottom). Compute it once, up front. Peer bots are
+  // excluded — a 1-human-N-bot room is still "solo" for engagement purposes.
+  const effectiveHumans = countEffectiveHumans(participants, input.membership, now)
+  const multiHumanGroup = isMultiHumanGroup(message.isDm, effectiveHumans)
+
   if (config.trigger.includes('dm') && message.isDm) return 'engage'
   if (config.trigger.includes('mention') && message.isBotMention) return 'engage'
   if (config.trigger.includes('reply') && message.replyToBotMessageId !== null) return 'engage'
 
-  if (config.stickiness !== 'off' && ledger.consume(key, message.authorId, now)) {
+  // Sticky credit. ALWAYS consume when present (the credit stays one-shot,
+  // so a later membership change can't resurrect stale conversational
+  // credit), but only let it FORCE engagement outside a multi-human group.
+  // In a group, sticky alone no longer wakes the bot on every follow-up —
+  // the author must re-address us (mention/reply/alias) to re-engage. This
+  // narrows an existing permissive rule in the exact context where it's
+  // harmful; it is NOT a new bot-specific gate (peer bots and humans are
+  // treated identically, via `multiHumanGroup`). See engagement.mdx.
+  if (config.stickiness !== 'off' && ledger.consume(key, message.authorId, now) && !multiHumanGroup) {
     return 'engage'
   }
 
@@ -169,11 +183,28 @@ export function decideEngagement(input: EngagementInput): EngagementDecision {
   // peer's first message it's caught forever.
   if (textTargetsAnyPeerBot(message.text, participants)) return 'observe'
 
-  const persistedHumans = participants.filter((p) => p.isBot !== true).length
-  const effectiveHumans = resolveEffectiveHumans(persistedHumans, input.membership, now)
   if (effectiveHumans <= 1 && !message.authorIsBot) return 'engage'
 
   return 'observe'
+}
+
+export function countEffectiveHumans(
+  participants: readonly ChannelParticipant[],
+  membership: MembershipCount | null,
+  now: number,
+): number {
+  const persistedHumans = participants.filter((p) => p.isBot !== true).length
+  return resolveEffectiveHumans(persistedHumans, membership, now)
+}
+
+// A multi-human group is the one place where the chatty "reply to every
+// follow-up" behavior (sticky credit, and the prompt's default eagerness) is
+// wrong. DMs — 1:1, or platform group-DMs reached via the `dm` trigger — and
+// solo-human channels keep the back-and-forth. The router reuses this to
+// decide both sticky suppression and the group-chat prompt nudge, so the two
+// stay in lockstep off one definition.
+export function isMultiHumanGroup(isDm: boolean, effectiveHumans: number): boolean {
+  return !isDm && effectiveHumans > 1
 }
 
 function textTargetsAnyPeerBot(text: string, participants: readonly ChannelParticipant[]): boolean {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4418,12 +4418,14 @@ describe('ChannelRouter peer-bot loop guard', () => {
       )
     }
 
-    // then: a follow-up engaged message must NOT carry the warning
+    // then: a follow-up engaged message must NOT carry the loop-guard warning.
+    // (A group-chat nudge shares the SYSTEM MESSAGE marker in this 2-human
+    // channel, so assert on the loop-guard-specific text, not the marker.)
     nowRef.value += 100
     await router.route(inbound({ authorId: 'alice', externalMessageId: 'alice-2', text: 'follow up' }))
     await router.__testing!.flushDebounce(KEY)
     const lastPrompt = sessions[0]!.prompts[sessions[0]!.prompts.length - 1]!
-    expect(lastPrompt).not.toContain('[SYSTEM MESSAGE — not from a human]')
+    expect(lastPrompt).not.toContain('peer bots have engaged you')
   })
 
   test('loop guard notice is fenced as SYSTEM MESSAGE so models do not reply to it', async () => {
@@ -4452,6 +4454,56 @@ describe('ChannelRouter peer-bot loop guard', () => {
     // and: the old human-readable H2 heading must NOT appear (it was the
     // structural ambiguity that caused the bug)
     expect(lastPrompt).not.toContain('## ⚠️ Loop guard active')
+  })
+
+  test('engaged turn in a multi-human group carries the group-chat nudge', async () => {
+    // given a 2-human channel
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    await router.route(inbound({ authorId: 'alice', isBotMention: true }))
+    await router.__testing!.flushDebounce(KEY)
+    await router.route(inbound({ authorId: 'bob', externalMessageId: 'bob-1', isBotMention: true }))
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.prompts.length = 0
+
+    // when alice explicitly mentions the bot (engages despite the crowd)
+    nowRef.value += 100
+    await router.route(inbound({ authorId: 'alice', externalMessageId: 'alice-2', isBotMention: true, text: 'bot?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then the nudge is present and fenced, and current message still renders
+    const lastPrompt = sessions[0]!.prompts[sessions[0]!.prompts.length - 1]!
+    expect(lastPrompt).toContain('You are in a group chat with multiple people.')
+    expect(lastPrompt).toContain('**[SYSTEM MESSAGE — not from a human]**')
+    expect(lastPrompt).toContain('bot?')
+  })
+
+  test('engaged turn in a solo-human channel does NOT carry the group-chat nudge', async () => {
+    // given a single-human channel
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    // when alice posts (solo-human fallback engages)
+    await router.route(inbound({ authorId: 'alice', isBotMention: false, text: 'just me here' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then no nudge
+    expect(sessions[0]!.prompts[0]).not.toContain('You are in a group chat with multiple people.')
+  })
+
+  test('engaged DM turn does NOT carry the group-chat nudge', async () => {
+    // given a DM
+    const dir = await tempDir()
+    const dmKey: ChannelKey = { adapter: 'discord-bot', workspace: '@dm', chat: 'd1', thread: null }
+    const { router, sessions } = makeRouter(dir)
+
+    // when a DM message arrives
+    await router.route(inbound({ workspace: '@dm', chat: 'd1', isDm: true, text: 'hey' }))
+    await router.__testing!.flushDebounce(dmKey)
+
+    // then no nudge even though dmMembership reports a bot participant
+    expect(sessions[0]!.prompts[0]).not.toContain('You are in a group chat with multiple people.')
   })
 
   test('peer-bot author lines are tagged with [bot] in the prompt', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -14,7 +14,14 @@ import { extractClaimCode } from '@/role-claim'
 import type { Stream } from '@/stream'
 
 import { formatChannelCommandHelp } from './commands'
-import { decideEngagement, grantStickyForReplyTargets, StickyLedger, type EngagementDecision } from './engagement'
+import {
+  countEffectiveHumans,
+  decideEngagement,
+  grantStickyForReplyTargets,
+  isMultiHumanGroup,
+  StickyLedger,
+  type EngagementDecision,
+} from './engagement'
 import {
   MEMBERSHIP_COLD_FETCH_TIMEOUT_MS,
   type MembershipCount,
@@ -430,6 +437,10 @@ type LiveSession = {
   recentEngagedPeerBotTurns: { authorId: string; ts: number }[]
   consecutiveEngagedPeerBotTurns: number
   loopGuardActive: boolean
+  // Set in route() from the same membership+participants the engagement
+  // decision used, so the prompt nudge and sticky suppression agree on
+  // "is this a multi-human group". Read by composeTurnPrompt().
+  multiHumanGroup: boolean
   membershipFetch: Promise<MembershipCount | null> | null
   destroyed: boolean
   unsubProviderErrors: (() => void) | null
@@ -1106,6 +1117,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         recentEngagedPeerBotTurns: [],
         consecutiveEngagedPeerBotTurns: 0,
         loopGuardActive: false,
+        multiHumanGroup: false,
         membershipFetch,
         destroyed: false,
         unsubProviderErrors: null,
@@ -1519,6 +1531,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const text = composeTurnPrompt(observed, batch, {
           adapter: live.key.adapter,
           loopGuardActive: live.loopGuardActive,
+          groupChatNudge: live.multiHumanGroup,
           systemReminders: reminders,
           role: liveRole,
         })
@@ -1776,6 +1789,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
 
     const membership = await membershipForEngagement(live)
+
+    live.multiHumanGroup = isMultiHumanGroup(event.isDm, countEffectiveHumans(live.participants, membership, now()))
 
     const decision: EngagementDecision = decideEngagement({
       message: event,
@@ -2692,6 +2707,7 @@ function composeTurnPrompt(
   state: {
     adapter?: AdapterId
     loopGuardActive: boolean
+    groupChatNudge?: boolean
     systemReminders?: readonly string[]
     now?: Date
     role?: string
@@ -2760,6 +2776,32 @@ function composeTurnPrompt(
       '- If continuing would add noise, reply with `NO_REPLY` to stay silent this turn.',
       '',
       'This notice clears automatically once a human posts again.',
+      '',
+      '---',
+      '',
+    )
+  }
+  // Group-chat nudge: same SYSTEM MESSAGE convention as the loop guard. We
+  // engaged this turn (explicit mention/reply/alias, or a fresh trigger),
+  // but the room has multiple humans, so the default "answer everything"
+  // posture is wrong. The engagement gate already stopped sticky credit
+  // from waking us on every follow-up; this tells the model to be
+  // selective on the turns it IS woken for. Cache-neutral (user-turn
+  // suffix), and skipped when the loop guard already fired to avoid
+  // stacking two silence notices in one turn.
+  if (state.groupChatNudge === true && !state.loopGuardActive) {
+    parts.push(
+      '---',
+      '**[SYSTEM MESSAGE — not from a human]**',
+      '',
+      'You are in a group chat with multiple people. This is an automated',
+      'signal from the channel router, not a message from anyone in the chat.',
+      '**Do not acknowledge or reply to this notice.**',
+      '',
+      'Guidance:',
+      '- Reply only if the current message is addressed to you or clearly needs your input.',
+      '- For chatter between others, side-conversation, or messages that do not need you,',
+      '  reply with `NO_REPLY` (or call `skip_response`) to stay silent and just keep watching.',
       '',
       '---',
       '',


### PR DESCRIPTION
## Background

When the agent was engaged in a **group chat**, it replied to every single message from anyone it had recently replied to. The mechanism is sticky credit: after the bot replies, `grantStickyForReplyTargets` grants each reply-target author a time-windowed credit (default 15 min). On that author's *next* message, `decideEngagement` consumes the credit and engages — regardless of content — then the bot replies and a fresh credit is granted, looping for the whole window.

That tight back-and-forth is exactly what you want in a 1:1 DM. In a multi-human room it makes the bot answer chatter that isn't addressed to it, which reads as spammy and crowds out the humans.

## Summary

Make sticky credit **context-aware** instead of adding a new gate.

- `decideEngagement` still **consumes** sticky credit whenever it's present (it stays one-shot — important so a later membership change can't resurrect stale conversational credit), but it only lets the credit **force `engage`** outside a multi-human group. "Multi-human group" = `isMultiHumanGroup(isDm, effectiveHumans)` → not a DM and `effectiveHumans > 1`.
- In a group, sticky alone no longer wakes the bot. The author re-engages through the **same symmetric triggers humans and peer bots already share** — mention / reply / alias. DMs and solo-human channels keep the chatty continuation.
- **Why this and not a new suppressor / a `peerBotTriggers` knob:** the subsystem's pinned philosophy is "fix over/under-engagement with `trigger` + `alias`, not new gates; no bot-only knobs." This change narrows an *existing* permissive rule in the one context where it misfires, and keys off a condition that treats humans and peer bots identically. It is not a bot-specific gate.
- On the turns the bot **is** woken in a multi-human group, `composeTurnPrompt` appends a group-chat nudge so the model self-selects: reply only when addressed/relevant, else `NO_REPLY` / `skip_response`. It reuses the existing fenced `**[SYSTEM MESSAGE — not from a human]**` convention (cache-neutral user-turn suffix, not the system prompt) and is suppressed when the loop guard already fired, so a turn never stacks two silence notices.
- Router and engagement share **one** `isMultiHumanGroup` definition, so sticky suppression and the prompt nudge can never disagree.

## What this does NOT do

- Does **not** change DM or solo-human behavior — sticky back-and-forth there is unchanged.
- Does **not** add any config field; this is the new default (per product decision).
- Does **not** firewall peer bots behind extra triggers — bot-to-bot remains first-class via the same triggers as humans.
- Does **not** touch the system prompt or the prompt-prefix cache contract (verified by `scripts/dump-system-prompt.test.ts`).
- Does **not** alter the peer-bot loop guard's accounting (observed, sticky-suppressed messages were already non-engaging and don't increment it).

## Review notes

- Load-bearing change: the sticky condition in `decideEngagement` (`… && ledger.consume(...) && !multiHumanGroup`). Note the ordering — `consume()` runs whenever stickiness is on and a credit exists, *then* `multiHumanGroup` decides engage-vs-observe, so the credit is always spent. Tests `sticky credit does NOT engage in a multi-human group, but IS consumed` and `a consumed-in-group credit does not resurrect a later follow-up` pin this.
- One existing test (`sticky credit still bypasses high membership counts`) encoded the old behavior; it's been reframed to the solo-human case and the group case moved into the new `(group-aware sticky)` block.
- The router regression `observed peer-bot messages do not increment the guard` now asserts on the loop-guard-specific text rather than the shared `[SYSTEM MESSAGE]` marker, because the group nudge legitimately shares that marker.
- Docs updated: `docs/content/docs/internals/engagement.mdx` (engage ladder rule #2, new "Group-chat nudge" section, rules-of-thumb clarification that narrowing an existing symmetric rule is allowed).