### PR TITLE
fix(inspect): disarm esc listener before picker re-opens to stop ssh freeze

### DIFF
--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -75,6 +75,9 @@ export const inspectCommand = defineCommand({
           if (escListener === null) return new AbortController().signal
           return escListener.armForStream()
         },
+        afterEscStream: () => {
+          escListener?.pause()
+        },
         ...(liveHint !== undefined ? { liveHint } : {}),
         stdout: (line) => process.stdout.write(`${line}\n`),
         stderr: (line) => process.stderr.write(`${line}\n`),

--- a/src/inspect/loop.test.ts
+++ b/src/inspect/loop.test.ts
@@ -243,4 +243,84 @@ describe('runInspectLoop', () => {
     expect(pickerHints[0]).toBeUndefined()
     expect(pickerHints[1]).toBe(ID_LOOP_A)
   })
+
+  test('afterEscStream fires after the esc-aborted tail and before the picker re-opens', async () => {
+    // Regression: pressing ESC during the live tail froze the CLI over SSH/Bun
+    // because the raw-mode ESC listener stayed armed across the abort, so clack
+    // inherited a flowing raw stdin it could not own. The loop must disarm the
+    // listener (afterEscStream) after the tail settles and before re-selecting.
+    await seedSession(`a_${ID_LOOP_A}.jsonl`, [metaLine({ kind: 'tui' }), userLine('first')], 1000)
+    await seedSession(`b_${ID_LOOP_B}.jsonl`, [metaLine({ kind: 'tui' }), userLine('second')], 2000)
+    const sink = captureSink()
+
+    const trace: string[] = []
+    let escController: AbortController | null = null
+    let liveCallCount = 0
+
+    async function* awaitableLive(signal: AbortSignal | undefined): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'hello' } }
+      await new Promise<void>((resolve) => {
+        if (signal === undefined || signal.aborted) return resolve()
+        signal.addEventListener('abort', () => resolve(), { once: true })
+      })
+    }
+    async function* finiteLive(): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'second-stream' } }
+    }
+
+    const result = await runInspectLoop({
+      agentDir,
+      sessionIdOrPrefix: ID_LOOP_A,
+      color: false,
+      selectSession: async (sessions) => {
+        trace.push('select')
+        return sessions.find((s) => s.sessionId === ID_LOOP_B) ?? null
+      },
+      liveSource: (o) => {
+        liveCallCount++
+        if (liveCallCount === 1) {
+          queueMicrotask(() => escController?.abort())
+          return awaitableLive(o.signal)
+        }
+        return finiteLive()
+      },
+      newEscSignal: () => {
+        escController = new AbortController()
+        return escController.signal
+      },
+      afterEscStream: () => {
+        trace.push('teardown')
+      },
+      ...sink.push,
+    })
+
+    expect(result.ok).toBe(true)
+    // teardown runs after the aborted first tail, then the picker opens, then
+    // teardown runs again after the second (finite) tail settles.
+    expect(trace).toEqual(['teardown', 'select', 'teardown'])
+  })
+
+  test('afterEscStream fires on a non-esc early return (bad filter)', async () => {
+    // The teardown hook must run on every loop exit path, not just esc-to-picker,
+    // so an interrupted run can never leave the listener armed.
+    await seedSession(`a_${ID_LOOP_D}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
+    const sink = captureSink()
+    let torn = 0
+
+    const result = await runInspectLoop({
+      agentDir,
+      sessionIdOrPrefix: ID_LOOP_D,
+      filter: 'not-a-real-category',
+      color: false,
+      selectSession: async () => null,
+      newEscSignal: () => new AbortController().signal,
+      afterEscStream: () => {
+        torn++
+      },
+      ...sink.push,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(torn).toBe(1)
+  })
 })

--- a/src/inspect/loop.test.ts
+++ b/src/inspect/loop.test.ts
@@ -323,4 +323,54 @@ describe('runInspectLoop', () => {
     expect(result.ok).toBe(false)
     expect(torn).toBe(1)
   })
+
+  test('ctrl-c (sigint signal) during the tail exits without re-opening the picker', async () => {
+    // Ctrl-C must terminate inspect, not loop back to the session list. The exit
+    // signal (process SIGINT) aborts the same tail as ESC, but streamSession
+    // reports escToPicker=false when opts.signal is aborted, so the loop returns.
+    // afterEscStream still tears the listener down exactly once on the way out.
+    await seedSession(`a_${ID_LOOP_A}.jsonl`, [metaLine({ kind: 'tui' }), userLine('first')], 1000)
+    await seedSession(`b_${ID_LOOP_B}.jsonl`, [metaLine({ kind: 'tui' }), userLine('second')], 2000)
+    const sink = captureSink()
+
+    const sigint = new AbortController()
+    let liveCallCount = 0
+    let pickerCalls = 0
+    let torn = 0
+
+    async function* awaitableLive(signal: AbortSignal | undefined): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'hello' } }
+      await new Promise<void>((resolve) => {
+        if (signal === undefined || signal.aborted) return resolve()
+        signal.addEventListener('abort', () => resolve(), { once: true })
+      })
+    }
+
+    const result = await runInspectLoop({
+      agentDir,
+      sessionIdOrPrefix: ID_LOOP_A,
+      color: false,
+      signal: sigint.signal,
+      selectSession: async (sessions) => {
+        pickerCalls++
+        return sessions.find((s) => s.sessionId === ID_LOOP_B) ?? null
+      },
+      liveSource: (o) => {
+        liveCallCount++
+        // Ctrl-C: abort the SIGINT signal mid-tail (esc was never pressed).
+        queueMicrotask(() => sigint.abort())
+        return awaitableLive(o.signal)
+      },
+      newEscSignal: () => new AbortController().signal,
+      afterEscStream: () => {
+        torn++
+      },
+      ...sink.push,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(pickerCalls).toBe(0)
+    expect(liveCallCount).toBe(1)
+    expect(torn).toBe(1)
+  })
 })

--- a/src/inspect/loop.ts
+++ b/src/inspect/loop.ts
@@ -2,6 +2,12 @@ import { runInspect, type RunInspectOptions, type RunInspectResult } from './ind
 
 export type RunInspectLoopOptions = Omit<RunInspectOptions, 'escSignal'> & {
   newEscSignal: () => AbortSignal
+  // Runs after every runInspect attempt settles. The caller disarms the raw-mode
+  // ESC listener here so the live tail releases stdin before clack re-opens the
+  // picker: an ESC-aborted tail leaves the listener armed (raw mode on, 'data'
+  // handler attached), and handing clack that flowing stream freezes the picker
+  // on SSH/Bun pseudo-TTYs.
+  afterEscStream?: () => void
 }
 
 export async function runInspectLoop(opts: RunInspectLoopOptions): Promise<RunInspectResult> {
@@ -23,7 +29,12 @@ export async function runInspectLoop(opts: RunInspectLoopOptions): Promise<RunIn
     if (sessionArg !== undefined) callOpts.sessionIdOrPrefix = sessionArg
     else delete (callOpts as { sessionIdOrPrefix?: string }).sessionIdOrPrefix
 
-    const result = await runInspect(callOpts)
+    let result: RunInspectResult
+    try {
+      result = await runInspect(callOpts)
+    } finally {
+      opts.afterEscStream?.()
+    }
     if (!result.ok) return result
     if (result.escToPicker !== true) return result
     sessionArg = undefined


### PR DESCRIPTION
## Background

`typeclaw inspect` froze when the user pressed ESC during the live tail, reproducibly over an SSH connection (remote pseudo-TTY under Bun), often not on a local terminal. The root cause is a stdin/raw-mode **ownership conflict**, not a hung websocket.

The ESC abort path itself is correct: a bare-ESC byte schedules an abort → aborts the live source signal → the live generator closes the socket and returns → `streamSession` returns `escToPicker: true` → the loop re-opens the clack session picker. The defect is that `createEscListener`, armed via `armForStream()` → `start()` (raw mode on, `data` handler attached, stdin flowing), is **never disarmed** when the tail ends via ESC. `active` stays `true`, raw mode stays on, the `data` handler stays attached, stdin keeps flowing. When the picker re-opens, clack inherits a flowing raw stdin it cannot own; on an SSH pseudo-TTY under Bun this deadlocks and the process appears frozen.

## Summary

`runInspectLoop` now tears the ESC listener down after every `runInspect` attempt before re-entering session selection, via a new `afterEscStream` hook. `inspect.ts` wires it to `escListener?.pause()`, which fully releases stdin (detaches `data`, clears the pending ESC timer, disables raw mode) so clack gets clean, exclusive ownership during session selection.

**Why a `finally`, not inline.** The hook must run on every exit path — esc-to-picker, normal completion, early returns like a bad filter, thrown errors — so an interrupted run never leaves the terminal stuck in raw mode.

**Why at the loop boundary, not inside `selectSession`.** `selectSession`'s existing `pause()`/`resume()` only fires when the picker is shown; the freeze is about listener state *between* the aborted tail and the picker. Disarming at the loop boundary makes ownership unambiguous.

**Why not `stdin.pause()` in teardown.** Intentionally avoided — an existing code comment documents that under Bun, clack cannot re-flow a previously paused `process.stdin`. The fix is exclusive ownership, not pausing the stream.

## What this does NOT do

- Does not rewrite the inspect input layer onto a TUI library — larger change; this is the minimal ownership fix.
- Does not change the ESC debounce window or the websocket live-tail abort path (both already correct).
- Does not add SSH-specific branching; the fix is correct for all TTYs.

## Review notes

Load-bearing change: the `try { result = await runInspect(...) } finally { opts.afterEscStream?.() }` block in `src/inspect/loop.ts` and its wiring in `src/cli/inspect.ts`.

Invariant: after any `runInspect` attempt, the raw-mode ESC listener is disarmed before the picker can re-open.

Tests in `src/inspect/loop.test.ts` pin two things: (1) teardown ordering — teardown → select → teardown across an esc-aborted tail, and (2) that the hook fires on a non-esc early return. Both fail if the `finally` teardown is removed (verified by reverting the production line).