### PR TITLE
fix(channels): keep inbound attachments resolvable for the whole turn

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -6471,3 +6471,49 @@ describe('ChannelRouter output-token cap', () => {
     expect(sessions[0]!.lastStreamMaxTokens).toBe(256)
   })
 })
+
+describe('ChannelRouter inbound attachment lookup', () => {
+  const PHOTO = {
+    id: 1,
+    kind: 'photo' as const,
+    ref: 'https://example.test/photo.jpg',
+    mimetype: 'image/jpeg',
+  }
+
+  test('resolves the current turn attachment mid-prompt after the queue is drained', async () => {
+    // The attachment lives on the promptQueue item until drain() splices the
+    // queue empty at the top of the turn. The model only calls
+    // look_at_channel_attachment DURING the prompt — by then promptQueue and
+    // contextBuffer are both empty, so the lookup must read from the
+    // turn-scoped snapshot, not the (now-empty) queues.
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    let lookedUp: ReturnType<typeof router.lookupInboundAttachment> = null
+    let listedDuringTurn: readonly number[] = []
+    await router.route(inbound({ text: '이거 읽어봐', attachments: [PHOTO] }))
+    sessions[0]!.onPrompt = () => {
+      lookedUp = router.lookupInboundAttachment({ ...KEY, id: 1 })
+      listedDuringTurn = router.listInboundAttachmentIds(KEY)
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(lookedUp).not.toBeNull()
+    expect(lookedUp!.ref).toBe(PHOTO.ref)
+    expect(listedDuringTurn).toEqual([1])
+  })
+
+  test('clears the turn-scoped attachment snapshot after the turn ends', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+
+    await router.route(inbound({ text: '이거 읽어봐', attachments: [PHOTO] }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // After the turn fully drains, the attachment is no longer part of any
+    // pending or in-flight turn, so a late lookup must miss.
+    expect(router.lookupInboundAttachment({ ...KEY, id: 1 })).toBeNull()
+    expect(router.listInboundAttachmentIds(KEY)).toEqual([])
+  })
+})

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -324,6 +324,14 @@ type LiveSession = {
   originRef: { current: SessionOrigin | undefined }
   promptQueue: QueuedInbound[]
   contextBuffer: ObservedInbound[]
+  // Attachments of the messages composing the in-flight turn. drain()
+  // splices promptQueue/contextBuffer empty BEFORE calling prompt(), but
+  // the model only requests an attachment (look_at_channel_attachment /
+  // channel_fetch_attachment) DURING prompt() — by which point both queues
+  // are empty. This turn-scoped snapshot, populated right after the splice
+  // and cleared when the turn ends, is what the lookup reads so a freshly-
+  // arrived attachment stays resolvable for the whole turn it belongs to.
+  currentTurnAttachments: readonly InboundAttachment[]
   draining: boolean
   debounceTimer: ReturnType<typeof setTimeout> | null
   typingTimer: ReturnType<typeof setInterval> | null
@@ -1081,6 +1089,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         promptQueue: [],
         pendingSystemReminders: [],
         contextBuffer: [],
+        currentTurnAttachments: [],
         draining: false,
         debounceTimer: null,
         typingTimer: null,
@@ -1494,6 +1503,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const batch = live.promptQueue.splice(0, live.promptQueue.length)
         const observed = live.contextBuffer.splice(0, live.contextBuffer.length)
         const reminders = live.pendingSystemReminders.splice(0, live.pendingSystemReminders.length)
+        live.currentTurnAttachments = collectTurnAttachments(observed, batch)
 
         if (batch.length > 0) {
           live.currentTurnAuthorId = batch[batch.length - 1]!.authorId
@@ -1568,6 +1578,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.draining = false
       live.currentTurnAuthorId = null
       live.currentTurnAuthorIds = new Set()
+      live.currentTurnAttachments = []
       await stopTypingHeartbeat(live)
     }
   }
@@ -2058,9 +2069,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // Walk newest → oldest so that when an id collides across messages
     // (e.g. two photos in the same session each labelled `#1`) the agent's
     // `attachment_id: 1` always resolves to the CURRENT inbound's
-    // attachment. promptQueue holds the about-to-be-delivered turn and
-    // is therefore the freshest; within each list, append-order maps to
-    // wall-clock order, so iterating in reverse gives recency.
+    // attachment. currentTurnAttachments holds the in-flight turn — the
+    // only place the about-to-be-viewed attachment lives once drain() has
+    // spliced promptQueue empty — and is therefore the freshest; promptQueue
+    // then holds any inbound that arrived mid-turn. Within each list,
+    // append-order maps to wall-clock order, so iterating in reverse gives
+    // recency.
+    const found = findAttachmentById(live.currentTurnAttachments, args.id)
+    if (found !== null) return found
     const haystacks: ReadonlyArray<ReadonlyArray<{ attachments?: readonly InboundAttachment[] }>> = [
       live.promptQueue,
       live.contextBuffer,
@@ -2068,8 +2084,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     for (const haystack of haystacks) {
       for (let i = haystack.length - 1; i >= 0; i--) {
         const item = haystack[i]
-        const found = item?.attachments?.find((attachment) => attachment.id === args.id)
-        if (found !== undefined) return found
+        const hit = item?.attachments?.find((attachment) => attachment.id === args.id)
+        if (hit !== undefined) return hit
       }
     }
     return null
@@ -2079,6 +2095,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const live = liveSessions.get(channelKeyId(args))
     if (live === undefined) return []
     const ids = new Set<number>()
+    for (const attachment of live.currentTurnAttachments) ids.add(attachment.id)
     for (const item of [...live.promptQueue, ...live.contextBuffer]) {
       for (const attachment of item.attachments ?? []) ids.add(attachment.id)
     }
@@ -2699,6 +2716,24 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       },
     },
   }
+}
+
+function collectTurnAttachments(
+  observed: readonly ObservedInbound[],
+  batch: readonly QueuedInbound[],
+): readonly InboundAttachment[] {
+  const out: InboundAttachment[] = []
+  for (const item of observed) out.push(...(item.attachments ?? []))
+  for (const item of batch) out.push(...(item.attachments ?? []))
+  return out
+}
+
+function findAttachmentById(attachments: readonly InboundAttachment[], id: number): InboundAttachment | null {
+  for (let i = attachments.length - 1; i >= 0; i--) {
+    const attachment = attachments[i]
+    if (attachment?.id === id) return attachment
+  }
+  return null
 }
 
 function composeTurnPrompt(


### PR DESCRIPTION
## Background

A KakaoTalk user sent a photo and asked the agent to read it. The agent saw the `[KakaoTalk attachment #1: photo 442x327 image/jpeg]` placeholder in its prompt and correctly called `look_at_channel_attachment({attachment_id: 1})` — but the tool returned `no attachment with id=1 in this turn`. The agent gracefully degraded to "please re-upload", but the attachment was right there.

Root cause is a lifecycle mismatch in the channel router, not the model. Inbound attachments live only on the `promptQueue` / `contextBuffer` items. `drain()` splices **both** queues empty at the top of every turn and feeds the spliced items into `composeTurnPrompt()` — but never restores them. The model only requests an attachment *during* `prompt()`, by which point `lookupInboundAttachment` walks two now-empty arrays and returns `null`. The text placeholder survives into the prompt (so the model sees attachment #1), but the binary-backing registry entry is already gone.

## Summary

Snapshot the turn's attachments into a turn-scoped `LiveSession.currentTurnAttachments` field, populated right after the splice in `drain()` and cleared in the drain `finally` (same lifecycle as `currentTurnAuthorId`). `lookupInboundAttachment` and `listInboundAttachmentIds` now consult that snapshot first, then fall back to the queues.

Why snapshot rather than "don't splice": the splice is load-bearing — it's what hands the batch to `composeTurnPrompt` and bounds the turn. Re-deriving from a separate field keeps the existing drain flow untouched and scopes attachment visibility to exactly the turn the attachment belongs to.

The snapshot is searched newest→oldest (batch appended after observed, reverse iteration) to preserve the existing id-collision recency rule: when two messages each carry `#1`, `attachment_id: 1` resolves to the current inbound.

## What this does NOT do

- No change to attachment ID assignment, the placeholder text, or any adapter.
- No change to how mid-turn inbounds enqueue (they still land in `promptQueue` and remain searchable).
- Does not persist attachments across turns — a lookup after the turn fully drains still (correctly) misses.

## Review notes

- Load-bearing change: `live.currentTurnAttachments = collectTurnAttachments(observed, batch)` immediately after the splice, and the `= []` reset in the drain `finally`. The invariant to verify is that the snapshot is alive for the entire `prompt()` and gone afterward.
- `channel_fetch_attachment` shares the same `lookupInboundAttachment` / `listInboundAttachmentIds` path, so it's fixed by the same change.
- Tests added in `router.test.ts` drive a real `route() → drain()` cycle and assert the lookup mid-prompt via `onPrompt` (the only point where the queues are empty) — the failing-first regression test. A second test pins the post-turn cleared state.