### PR TITLE
feat(permissions): cap subagent_output/cancel to the requester's role

### DIFF
--- a/src/agent/live-subagents.ts
+++ b/src/agent/live-subagents.ts
@@ -19,6 +19,10 @@ export type LiveSubagent = {
   sessionId: string
   subagentName: string
   parentSessionId?: string
+  // Role that resolved at spawn time, captured for the provenance cap on
+  // subagent_output/subagent_cancel. Absent when no permission service was
+  // active at spawn, in which case the cap fails closed.
+  spawnedByRole?: string
   startedAt: number
   status: SubagentStatus
   completion?: SubagentCompletion

--- a/src/agent/tools/spawn-subagent.test.ts
+++ b/src/agent/tools/spawn-subagent.test.ts
@@ -299,6 +299,7 @@ describe('createSpawnSubagentTool — permissions gating', () => {
     return {
       has: (_origin, permission) => allowed.has(permission),
       resolveRole: () => 'tester',
+      compareRoleSeverity: () => undefined,
       describe: () => ({ role: 'tester', permissions: [...allowed] }),
       replaceRoles: () => {},
     }
@@ -466,6 +467,7 @@ describe('createSpawnSubagentTool — role inheritance', () => {
     return {
       has: () => true,
       resolveRole: () => role,
+      compareRoleSeverity: () => undefined,
       describe: () => ({ role, permissions: ['subagent.spawn'] }),
       replaceRoles: () => {},
     }

--- a/src/agent/tools/spawn-subagent.ts
+++ b/src/agent/tools/spawn-subagent.ts
@@ -129,6 +129,7 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
         sessionId: resolvedHandle.sessionId ?? '<pending>',
         subagentName,
         parentSessionId,
+        ...(spawnedByRole !== undefined ? { spawnedByRole } : {}),
         startedAt,
         status: 'running' as const,
         abort: resolvedHandle.abort,

--- a/src/agent/tools/subagent-access.ts
+++ b/src/agent/tools/subagent-access.ts
@@ -1,0 +1,37 @@
+import type { PermissionService } from '@/permissions'
+
+import type { LiveSubagent } from '../live-subagents'
+import type { SessionOrigin } from '../session-origin'
+
+export type SubagentAccessPermission = 'subagent.output' | 'subagent.cancel'
+
+// Caps subagent_output/subagent_cancel to the requester's role: the caller
+// must hold the permission AND resolve to a role at least as high as the
+// role that spawned the subagent. Returns a denial reason string, or null
+// when access is allowed. Fails closed — a missing spawn role or an
+// unknown role on either side denies rather than allows.
+export function denySubagentAccess(
+  permissions: PermissionService | undefined,
+  origin: SessionOrigin | undefined,
+  live: Pick<LiveSubagent, 'spawnedByRole'>,
+  permission: SubagentAccessPermission,
+): string | null {
+  if (permissions === undefined) return null
+
+  if (!permissions.has(origin, permission)) {
+    return `${permission} denied: insufficient permissions`
+  }
+
+  const spawnedByRole = live.spawnedByRole
+  if (spawnedByRole === undefined) {
+    return `${permission} denied: subagent spawn role unavailable`
+  }
+
+  const requesterRole = permissions.resolveRole(origin)
+  const cmp = permissions.compareRoleSeverity(requesterRole, spawnedByRole)
+  if (cmp === undefined || cmp < 0) {
+    return `${permission} denied: requester role cannot access subagent spawned by higher role`
+  }
+
+  return null
+}

--- a/src/agent/tools/subagent-access.ts
+++ b/src/agent/tools/subagent-access.ts
@@ -1,37 +1,67 @@
 import type { PermissionService } from '@/permissions'
 
-import type { LiveSubagent } from '../live-subagents'
+import type { LiveSubagent, LiveSubagentRegistry } from '../live-subagents'
 import type { SessionOrigin } from '../session-origin'
 
 export type SubagentAccessPermission = 'subagent.output' | 'subagent.cancel'
 
-// Caps subagent_output/subagent_cancel to the requester's role: the caller
-// must hold the permission AND resolve to a role at least as high as the
-// role that spawned the subagent. Returns a denial reason string, or null
-// when access is allowed. Fails closed — a missing spawn role or an
-// unknown role on either side denies rather than allows.
-export function denySubagentAccess(
-  permissions: PermissionService | undefined,
-  origin: SessionOrigin | undefined,
-  live: Pick<LiveSubagent, 'spawnedByRole'>,
-  permission: SubagentAccessPermission,
-): string | null {
-  if (permissions === undefined) return null
+export type SubagentAccessResult = { ok: true; live: LiveSubagent } | { ok: false; message: string }
+
+export type AuthorizeLiveSubagentAccessArgs = {
+  permissions: PermissionService | undefined
+  origin: SessionOrigin | undefined
+  liveRegistry: LiveSubagentRegistry
+  taskId: string
+  permission: SubagentAccessPermission
+}
+
+// Authorizes a single subagent_output/subagent_cancel call and resolves the
+// live entry in one place so the two tools cannot drift. Caps access to the
+// requester's role: the caller must hold the permission AND resolve to a role
+// at least as high as the role that spawned the subagent.
+//
+// The ordering closes an existence oracle: the task-independent base-permission
+// check runs BEFORE any registry lookup, and for non-owner callers an absent
+// task, a capped task, and a task with missing provenance all collapse to one
+// identical denial — so a lower-role caller cannot probe which task IDs are
+// live. Only `owner` (the trust root, which outranks every spawner) learns the
+// truthful `Unknown task_id` for a genuine miss. The cap fails closed.
+export function authorizeLiveSubagentAccess(args: AuthorizeLiveSubagentAccessArgs): SubagentAccessResult {
+  const { permissions, origin, liveRegistry, taskId, permission } = args
+
+  if (permissions === undefined) {
+    const live = liveRegistry.get(taskId)
+    if (live === undefined) {
+      return { ok: false, message: `Unknown task_id: ${taskId}.` }
+    }
+    return { ok: true, live }
+  }
 
   if (!permissions.has(origin, permission)) {
-    return `${permission} denied: insufficient permissions`
+    return { ok: false, message: `${permission} denied: insufficient permissions` }
+  }
+
+  const requesterRole = permissions.resolveRole(origin)
+  const accessAll = requesterRole === 'owner'
+  const opaqueDenial = `${permission} denied: unknown task_id or insufficient role`
+
+  const live = liveRegistry.get(taskId)
+  if (live === undefined) {
+    return { ok: false, message: accessAll ? `Unknown task_id: ${taskId}.` : opaqueDenial }
+  }
+  if (accessAll) {
+    return { ok: true, live }
   }
 
   const spawnedByRole = live.spawnedByRole
   if (spawnedByRole === undefined) {
-    return `${permission} denied: subagent spawn role unavailable`
+    return { ok: false, message: opaqueDenial }
   }
 
-  const requesterRole = permissions.resolveRole(origin)
   const cmp = permissions.compareRoleSeverity(requesterRole, spawnedByRole)
   if (cmp === undefined || cmp < 0) {
-    return `${permission} denied: requester role cannot access subagent spawned by higher role`
+    return { ok: false, message: opaqueDenial }
   }
 
-  return null
+  return { ok: true, live }
 }

--- a/src/agent/tools/subagent-cancel.test.ts
+++ b/src/agent/tools/subagent-cancel.test.ts
@@ -1,9 +1,29 @@
 import { describe, expect, test } from 'bun:test'
 
+import { createPermissionService, rolesConfigSchema } from '@/permissions'
+
 import { LiveSubagentRegistry, type LiveSubagent } from '../live-subagents'
+import type { SessionOrigin } from '../session-origin'
 import { createSubagentCancelTool } from './subagent-cancel'
 
 const ctx = {} as Parameters<ReturnType<typeof createSubagentCancelTool>['execute']>[4]
+
+const guestOrigin: SessionOrigin = {
+  kind: 'channel',
+  adapter: 'slack-bot',
+  workspace: 'T0123',
+  chat: 'C_GEN',
+  thread: null,
+}
+const memberOrigin: SessionOrigin = { ...guestOrigin, lastInboundAuthorId: 'U_MEMBER' }
+
+function capPermissions() {
+  const roles = rolesConfigSchema.parse({
+    guest: { match: [], permissions: ['subagent.cancel'] },
+    member: { match: ['slack:T0123 author:U_MEMBER'], permissions: ['subagent.cancel'] },
+  })
+  return createPermissionService({ roles })
+}
 
 function makeLive(overrides: Partial<LiveSubagent> = {}): LiveSubagent {
   return {
@@ -103,6 +123,7 @@ describe('createSubagentCancelTool', () => {
       permissions: {
         has: () => false,
         resolveRole: () => 'guest',
+        compareRoleSeverity: () => undefined,
         describe: () => ({ role: 'guest', permissions: [] }),
         replaceRoles: () => {},
       },
@@ -111,5 +132,41 @@ describe('createSubagentCancelTool', () => {
     const details = result.details as { ok: boolean; error?: string }
     expect(details.ok).toBe(false)
     expect(details.error).toContain('denied')
+  })
+})
+
+describe('createSubagentCancelTool — provenance cap', () => {
+  function makeTool(registry: LiveSubagentRegistry, origin: SessionOrigin) {
+    return createSubagentCancelTool({ liveRegistry: registry, getOrigin: () => origin, permissions: capPermissions() })
+  }
+
+  test('guest cannot cancel a member-spawned subagent even when granted subagent.cancel', async () => {
+    const registry = new LiveSubagentRegistry()
+    let aborted = 0
+    registry.register(makeLive({ spawnedByRole: 'member', abort: async () => void (aborted += 1) }))
+    const result = await makeTool(registry, guestOrigin).execute('c', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('higher role')
+    expect(aborted).toBe(0)
+  })
+
+  test('member can cancel a member-spawned subagent', async () => {
+    const registry = new LiveSubagentRegistry()
+    let aborted = 0
+    registry.register(makeLive({ spawnedByRole: 'member', abort: async () => void (aborted += 1) }))
+    const result = await makeTool(registry, memberOrigin).execute('c', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean }
+    expect(details.ok).toBe(true)
+    expect(aborted).toBe(1)
+  })
+
+  test('missing spawn role fails closed', async () => {
+    const registry = new LiveSubagentRegistry()
+    registry.register(makeLive())
+    const result = await makeTool(registry, memberOrigin).execute('c', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('spawn role unavailable')
   })
 })

--- a/src/agent/tools/subagent-cancel.test.ts
+++ b/src/agent/tools/subagent-cancel.test.ts
@@ -16,9 +16,11 @@ const guestOrigin: SessionOrigin = {
   thread: null,
 }
 const memberOrigin: SessionOrigin = { ...guestOrigin, lastInboundAuthorId: 'U_MEMBER' }
+const ownerOrigin: SessionOrigin = { ...guestOrigin, lastInboundAuthorId: 'U_OWNER' }
 
 function capPermissions() {
   const roles = rolesConfigSchema.parse({
+    owner: { match: ['slack:T0123 author:U_OWNER'] },
     guest: { match: [], permissions: ['subagent.cancel'] },
     member: { match: ['slack:T0123 author:U_MEMBER'], permissions: ['subagent.cancel'] },
   })
@@ -136,18 +138,20 @@ describe('createSubagentCancelTool', () => {
 })
 
 describe('createSubagentCancelTool — provenance cap', () => {
+  const OPAQUE = 'subagent.cancel denied: unknown task_id or insufficient role'
+
   function makeTool(registry: LiveSubagentRegistry, origin: SessionOrigin) {
     return createSubagentCancelTool({ liveRegistry: registry, getOrigin: () => origin, permissions: capPermissions() })
   }
 
-  test('guest cannot cancel a member-spawned subagent even when granted subagent.cancel', async () => {
+  test('guest cannot cancel a member-spawned subagent and abort is not invoked', async () => {
     const registry = new LiveSubagentRegistry()
     let aborted = 0
     registry.register(makeLive({ spawnedByRole: 'member', abort: async () => void (aborted += 1) }))
     const result = await makeTool(registry, guestOrigin).execute('c', { task_id: 'bg_c1' }, undefined, undefined, ctx)
     const details = result.details as { ok: boolean; error?: string }
     expect(details.ok).toBe(false)
-    expect(details.error).toContain('higher role')
+    expect(details.error).toBe(OPAQUE)
     expect(aborted).toBe(0)
   })
 
@@ -161,12 +165,31 @@ describe('createSubagentCancelTool — provenance cap', () => {
     expect(aborted).toBe(1)
   })
 
-  test('missing spawn role fails closed', async () => {
-    const registry = new LiveSubagentRegistry()
-    registry.register(makeLive())
-    const result = await makeTool(registry, memberOrigin).execute('c', { task_id: 'bg_c1' }, undefined, undefined, ctx)
-    const details = result.details as { ok: boolean; error?: string }
-    expect(details.ok).toBe(false)
-    expect(details.error).toContain('spawn role unavailable')
+  test('a low-role caller cannot distinguish absent, capped, or missing-provenance tasks', async () => {
+    const capped = new LiveSubagentRegistry()
+    capped.register(makeLive({ spawnedByRole: 'member' }))
+    const noProvenance = new LiveSubagentRegistry()
+    noProvenance.register(makeLive())
+    const empty = new LiveSubagentRegistry()
+
+    const errorFor = async (registry: LiveSubagentRegistry): Promise<string> => {
+      const r = await makeTool(registry, guestOrigin).execute('c', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+      return (r.details as { error?: string }).error ?? ''
+    }
+
+    expect(await errorFor(empty)).toBe(OPAQUE)
+    expect(await errorFor(capped)).toBe(OPAQUE)
+    expect(await errorFor(noProvenance)).toBe(OPAQUE)
+  })
+
+  test('owner bypasses the cap and gets truthful Unknown task_id for an absent task', async () => {
+    const higher = new LiveSubagentRegistry()
+    higher.register(makeLive({ spawnedByRole: 'member' }))
+    const empty = new LiveSubagentRegistry()
+
+    const allowed = await makeTool(higher, ownerOrigin).execute('c', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+    const miss = await makeTool(empty, ownerOrigin).execute('c', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+    expect((allowed.details as { ok: boolean }).ok).toBe(true)
+    expect((miss.details as { error?: string }).error).toContain('Unknown task_id')
   })
 })

--- a/src/agent/tools/subagent-cancel.ts
+++ b/src/agent/tools/subagent-cancel.ts
@@ -5,7 +5,7 @@ import type { PermissionService } from '@/permissions'
 
 import type { LiveSubagentRegistry } from '../live-subagents'
 import type { SessionOrigin } from '../session-origin'
-import { denySubagentAccess } from './subagent-access'
+import { authorizeLiveSubagentAccess } from './subagent-access'
 
 export type SubagentCancelToolDetails =
   | { ok: true; taskId: string; subagent: string; alreadyDone: boolean }
@@ -34,14 +34,17 @@ export function createSubagentCancelTool(options: CreateSubagentCancelToolOption
     }),
 
     async execute(_toolCallId, params): Promise<ToolReturn> {
-      const live = liveRegistry.get(params.task_id)
-      if (live === undefined) {
-        return errorResult(`Unknown task_id: ${params.task_id}.`)
+      const access = authorizeLiveSubagentAccess({
+        permissions,
+        origin: getOrigin(),
+        liveRegistry,
+        taskId: params.task_id,
+        permission: 'subagent.cancel',
+      })
+      if (!access.ok) {
+        return errorResult(access.message)
       }
-      const denial = denySubagentAccess(permissions, getOrigin(), live, 'subagent.cancel')
-      if (denial !== null) {
-        return errorResult(denial)
-      }
+      const live = access.live
       if (live.status !== 'running') {
         const details: SubagentCancelToolDetails = {
           ok: true,

--- a/src/agent/tools/subagent-cancel.ts
+++ b/src/agent/tools/subagent-cancel.ts
@@ -5,6 +5,7 @@ import type { PermissionService } from '@/permissions'
 
 import type { LiveSubagentRegistry } from '../live-subagents'
 import type { SessionOrigin } from '../session-origin'
+import { denySubagentAccess } from './subagent-access'
 
 export type SubagentCancelToolDetails =
   | { ok: true; taskId: string; subagent: string; alreadyDone: boolean }
@@ -33,12 +34,13 @@ export function createSubagentCancelTool(options: CreateSubagentCancelToolOption
     }),
 
     async execute(_toolCallId, params): Promise<ToolReturn> {
-      if (permissions !== undefined && !permissions.has(getOrigin(), 'subagent.cancel')) {
-        return errorResult('subagent.cancel denied: insufficient permissions')
-      }
       const live = liveRegistry.get(params.task_id)
       if (live === undefined) {
         return errorResult(`Unknown task_id: ${params.task_id}.`)
+      }
+      const denial = denySubagentAccess(permissions, getOrigin(), live, 'subagent.cancel')
+      if (denial !== null) {
+        return errorResult(denial)
       }
       if (live.status !== 'running') {
         const details: SubagentCancelToolDetails = {

--- a/src/agent/tools/subagent-output.test.ts
+++ b/src/agent/tools/subagent-output.test.ts
@@ -1,9 +1,33 @@
 import { describe, expect, test } from 'bun:test'
 
+import { createPermissionService, rolesConfigSchema } from '@/permissions'
+
 import { LiveSubagentRegistry, type LiveSubagent } from '../live-subagents'
+import type { SessionOrigin } from '../session-origin'
 import { createSubagentOutputTool } from './subagent-output'
 
 const ctx = {} as Parameters<ReturnType<typeof createSubagentOutputTool>['execute']>[4]
+
+const guestOrigin: SessionOrigin = {
+  kind: 'channel',
+  adapter: 'slack-bot',
+  workspace: 'T0123',
+  chat: 'C_GEN',
+  thread: null,
+}
+
+// guest is granted subagent.output explicitly, while a member match rule
+// covers author U_MEMBER — so the only thing that can deny a granted guest
+// is the provenance cap, not a missing permission.
+function capPermissions() {
+  const roles = rolesConfigSchema.parse({
+    guest: { match: [], permissions: ['subagent.output', 'subagent.cancel'] },
+    member: { match: ['slack:T0123 author:U_MEMBER'], permissions: ['subagent.output', 'subagent.cancel'] },
+  })
+  return createPermissionService({ roles })
+}
+
+const memberOrigin: SessionOrigin = { ...guestOrigin, lastInboundAuthorId: 'U_MEMBER' }
 
 function makeLive(overrides: Partial<LiveSubagent> = {}): LiveSubagent {
   return {
@@ -175,6 +199,7 @@ describe('createSubagentOutputTool — permissions', () => {
       permissions: {
         has: () => false,
         resolveRole: () => 'guest',
+        compareRoleSeverity: () => undefined,
         describe: () => ({ role: 'guest', permissions: [] }),
         replaceRoles: () => {},
       },
@@ -183,5 +208,68 @@ describe('createSubagentOutputTool — permissions', () => {
     const details = result.details as { ok: boolean; error?: string }
     expect(details.ok).toBe(false)
     expect(details.error).toContain('denied')
+  })
+})
+
+describe('createSubagentOutputTool — provenance cap', () => {
+  function makeTool(registry: LiveSubagentRegistry, origin: SessionOrigin) {
+    return createSubagentOutputTool({ liveRegistry: registry, getOrigin: () => origin, permissions: capPermissions() })
+  }
+
+  test('guest cannot read a member-spawned subagent even when granted subagent.output', async () => {
+    const registry = new LiveSubagentRegistry()
+    registry.register(makeLive({ spawnedByRole: 'member' }))
+    const result = await makeTool(registry, guestOrigin).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('higher role')
+  })
+
+  test('member can read a member-spawned subagent', async () => {
+    const registry = new LiveSubagentRegistry()
+    registry.register(makeLive({ spawnedByRole: 'member' }))
+    const result = await makeTool(registry, memberOrigin).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean }
+    expect(details.ok).toBe(true)
+  })
+
+  test('member can read a guest-spawned subagent (same-or-lower spawner allowed)', async () => {
+    const registry = new LiveSubagentRegistry()
+    registry.register(makeLive({ spawnedByRole: 'guest' }))
+    const result = await makeTool(registry, memberOrigin).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean }
+    expect(details.ok).toBe(true)
+  })
+
+  test('missing spawn role fails closed', async () => {
+    const registry = new LiveSubagentRegistry()
+    registry.register(makeLive())
+    const result = await makeTool(registry, memberOrigin).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('spawn role unavailable')
+  })
+
+  test('no permission service preserves open behavior', async () => {
+    const registry = new LiveSubagentRegistry()
+    registry.register(makeLive({ spawnedByRole: 'owner' }))
+    const tool = createSubagentOutputTool({ liveRegistry: registry, getOrigin: () => guestOrigin })
+    const result = await tool.execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const details = result.details as { ok: boolean }
+    expect(details.ok).toBe(true)
+  })
+
+  test('unknown task_id is reported before the cap, regardless of role', async () => {
+    const registry = new LiveSubagentRegistry()
+    const result = await makeTool(registry, guestOrigin).execute(
+      'c',
+      { task_id: 'bg_missing' },
+      undefined,
+      undefined,
+      ctx,
+    )
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('Unknown task_id')
   })
 })

--- a/src/agent/tools/subagent-output.test.ts
+++ b/src/agent/tools/subagent-output.test.ts
@@ -16,11 +16,13 @@ const guestOrigin: SessionOrigin = {
   thread: null,
 }
 
-// guest is granted subagent.output explicitly, while a member match rule
-// covers author U_MEMBER — so the only thing that can deny a granted guest
-// is the provenance cap, not a missing permission.
+// guest is granted subagent.output explicitly so the only thing that can deny
+// a granted guest is the provenance cap, not a missing permission. member and
+// owner match rules cover specific authors so role-scoped behavior can be
+// exercised through the real permission service.
 function capPermissions() {
   const roles = rolesConfigSchema.parse({
+    owner: { match: ['slack:T0123 author:U_OWNER'] },
     guest: { match: [], permissions: ['subagent.output', 'subagent.cancel'] },
     member: { match: ['slack:T0123 author:U_MEMBER'], permissions: ['subagent.output', 'subagent.cancel'] },
   })
@@ -28,6 +30,7 @@ function capPermissions() {
 }
 
 const memberOrigin: SessionOrigin = { ...guestOrigin, lastInboundAuthorId: 'U_MEMBER' }
+const ownerOrigin: SessionOrigin = { ...guestOrigin, lastInboundAuthorId: 'U_OWNER' }
 
 function makeLive(overrides: Partial<LiveSubagent> = {}): LiveSubagent {
   return {
@@ -212,64 +215,95 @@ describe('createSubagentOutputTool — permissions', () => {
 })
 
 describe('createSubagentOutputTool — provenance cap', () => {
+  const OPAQUE = 'subagent.output denied: unknown task_id or insufficient role'
+
   function makeTool(registry: LiveSubagentRegistry, origin: SessionOrigin) {
     return createSubagentOutputTool({ liveRegistry: registry, getOrigin: () => origin, permissions: capPermissions() })
   }
 
-  test('guest cannot read a member-spawned subagent even when granted subagent.output', async () => {
-    const registry = new LiveSubagentRegistry()
-    registry.register(makeLive({ spawnedByRole: 'member' }))
-    const result = await makeTool(registry, guestOrigin).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+  async function errorFor(origin: SessionOrigin, registry: LiveSubagentRegistry, taskId: string): Promise<string> {
+    const result = await makeTool(registry, origin).execute('c', { task_id: taskId }, undefined, undefined, ctx)
     const details = result.details as { ok: boolean; error?: string }
     expect(details.ok).toBe(false)
-    expect(details.error).toContain('higher role')
-  })
+    return details.error ?? ''
+  }
 
   test('member can read a member-spawned subagent', async () => {
     const registry = new LiveSubagentRegistry()
     registry.register(makeLive({ spawnedByRole: 'member' }))
     const result = await makeTool(registry, memberOrigin).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
-    const details = result.details as { ok: boolean }
-    expect(details.ok).toBe(true)
+    expect((result.details as { ok: boolean }).ok).toBe(true)
   })
 
   test('member can read a guest-spawned subagent (same-or-lower spawner allowed)', async () => {
     const registry = new LiveSubagentRegistry()
     registry.register(makeLive({ spawnedByRole: 'guest' }))
     const result = await makeTool(registry, memberOrigin).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
-    const details = result.details as { ok: boolean }
-    expect(details.ok).toBe(true)
+    expect((result.details as { ok: boolean }).ok).toBe(true)
   })
 
-  test('missing spawn role fails closed', async () => {
+  test('a low-role caller cannot distinguish absent, capped, or missing-provenance tasks', async () => {
+    const capped = new LiveSubagentRegistry()
+    capped.register(makeLive({ spawnedByRole: 'member' }))
+    const noProvenance = new LiveSubagentRegistry()
+    noProvenance.register(makeLive())
+    const empty = new LiveSubagentRegistry()
+
+    const absentMsg = await errorFor(guestOrigin, empty, 'bg_o1')
+    const cappedMsg = await errorFor(guestOrigin, capped, 'bg_o1')
+    const noProvenanceMsg = await errorFor(guestOrigin, noProvenance, 'bg_o1')
+
+    expect(absentMsg).toBe(OPAQUE)
+    expect(cappedMsg).toBe(OPAQUE)
+    expect(noProvenanceMsg).toBe(OPAQUE)
+  })
+
+  test('owner gets a truthful Unknown task_id for an absent task', async () => {
     const registry = new LiveSubagentRegistry()
-    registry.register(makeLive())
-    const result = await makeTool(registry, memberOrigin).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
-    const details = result.details as { ok: boolean; error?: string }
-    expect(details.ok).toBe(false)
-    expect(details.error).toContain('spawn role unavailable')
+    const msg = await errorFor(ownerOrigin, registry, 'bg_missing')
+    expect(msg).toContain('Unknown task_id')
   })
 
-  test('no permission service preserves open behavior', async () => {
+  test('owner bypasses the cap and missing-provenance fail-closed', async () => {
+    const higher = new LiveSubagentRegistry()
+    higher.register(makeLive({ spawnedByRole: 'member' }))
+    const noProvenance = new LiveSubagentRegistry()
+    noProvenance.register(makeLive())
+
+    const r1 = await makeTool(higher, ownerOrigin).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const r2 = await makeTool(noProvenance, ownerOrigin).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    expect((r1.details as { ok: boolean }).ok).toBe(true)
+    expect((r2.details as { ok: boolean }).ok).toBe(true)
+  })
+
+  test('a caller lacking the base permission gets the same denial whether the task exists or not', async () => {
+    const denyBase = createPermissionService({
+      roles: rolesConfigSchema.parse({ guest: { match: [], permissions: [] } }),
+    })
+    const present = new LiveSubagentRegistry()
+    present.register(makeLive({ spawnedByRole: 'member' }))
+    const absent = new LiveSubagentRegistry()
+    const tool = (registry: LiveSubagentRegistry) =>
+      createSubagentOutputTool({ liveRegistry: registry, getOrigin: () => guestOrigin, permissions: denyBase })
+
+    const presentRes = await tool(present).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const absentRes = await tool(absent).execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const presentErr = (presentRes.details as { error?: string }).error
+    const absentErr = (absentRes.details as { error?: string }).error
+    expect(presentErr).toBe('subagent.output denied: insufficient permissions')
+    expect(absentErr).toBe(presentErr)
+  })
+
+  test('no permission service preserves truthful unknown and open access', async () => {
     const registry = new LiveSubagentRegistry()
     registry.register(makeLive({ spawnedByRole: 'owner' }))
-    const tool = createSubagentOutputTool({ liveRegistry: registry, getOrigin: () => guestOrigin })
-    const result = await tool.execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
-    const details = result.details as { ok: boolean }
-    expect(details.ok).toBe(true)
-  })
+    const empty = new LiveSubagentRegistry()
+    const allow = createSubagentOutputTool({ liveRegistry: registry, getOrigin: () => guestOrigin })
+    const miss = createSubagentOutputTool({ liveRegistry: empty, getOrigin: () => guestOrigin })
 
-  test('unknown task_id is reported before the cap, regardless of role', async () => {
-    const registry = new LiveSubagentRegistry()
-    const result = await makeTool(registry, guestOrigin).execute(
-      'c',
-      { task_id: 'bg_missing' },
-      undefined,
-      undefined,
-      ctx,
-    )
-    const details = result.details as { ok: boolean; error?: string }
-    expect(details.ok).toBe(false)
-    expect(details.error).toContain('Unknown task_id')
+    const allowRes = await allow.execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const missRes = await miss.execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    expect((allowRes.details as { ok: boolean }).ok).toBe(true)
+    expect((missRes.details as { error?: string }).error).toContain('Unknown task_id')
   })
 })

--- a/src/agent/tools/subagent-output.ts
+++ b/src/agent/tools/subagent-output.ts
@@ -5,6 +5,7 @@ import type { PermissionService } from '@/permissions'
 
 import type { LiveSubagentRegistry, StatusSnapshot, SubagentProgressEvent } from '../live-subagents'
 import type { SessionOrigin } from '../session-origin'
+import { denySubagentAccess } from './subagent-access'
 
 export type SubagentOutputToolDetails =
   | {
@@ -64,8 +65,13 @@ export function createSubagentOutputTool(options: CreateSubagentOutputToolOption
     }),
 
     async execute(_toolCallId, params) {
-      if (permissions !== undefined && !permissions.has(getOrigin(), 'subagent.output')) {
-        return errorResult('subagent.output denied: insufficient permissions')
+      const live = liveRegistry.get(params.task_id)
+      if (live === undefined) {
+        return errorResult(`Unknown task_id: ${params.task_id}.`)
+      }
+      const denial = denySubagentAccess(permissions, getOrigin(), live, 'subagent.output')
+      if (denial !== null) {
+        return errorResult(denial)
       }
       const snap = liveRegistry.snapshot(params.task_id, now())
       if (snap === undefined) {

--- a/src/agent/tools/subagent-output.ts
+++ b/src/agent/tools/subagent-output.ts
@@ -5,7 +5,7 @@ import type { PermissionService } from '@/permissions'
 
 import type { LiveSubagentRegistry, StatusSnapshot, SubagentProgressEvent } from '../live-subagents'
 import type { SessionOrigin } from '../session-origin'
-import { denySubagentAccess } from './subagent-access'
+import { authorizeLiveSubagentAccess } from './subagent-access'
 
 export type SubagentOutputToolDetails =
   | {
@@ -65,13 +65,15 @@ export function createSubagentOutputTool(options: CreateSubagentOutputToolOption
     }),
 
     async execute(_toolCallId, params) {
-      const live = liveRegistry.get(params.task_id)
-      if (live === undefined) {
-        return errorResult(`Unknown task_id: ${params.task_id}.`)
-      }
-      const denial = denySubagentAccess(permissions, getOrigin(), live, 'subagent.output')
-      if (denial !== null) {
-        return errorResult(denial)
+      const access = authorizeLiveSubagentAccess({
+        permissions,
+        origin: getOrigin(),
+        liveRegistry,
+        taskId: params.task_id,
+        permission: 'subagent.output',
+      })
+      if (!access.ok) {
+        return errorResult(access.message)
       }
       const snap = liveRegistry.snapshot(params.task_id, now())
       if (snap === undefined) {

--- a/src/channels/router.inbound-stream.test.ts
+++ b/src/channels/router.inbound-stream.test.ts
@@ -31,6 +31,7 @@ class FakeSession {
 const grantAll: PermissionService = {
   has: () => true,
   resolveRole: () => 'owner',
+  compareRoleSeverity: () => 1,
   describe: () => ({ role: 'owner', permissions: ['channel.respond'] }),
   replaceRoles: () => {},
 }
@@ -38,6 +39,7 @@ const grantAll: PermissionService = {
 const denyAll: PermissionService = {
   has: () => false,
   resolveRole: () => 'guest',
+  compareRoleSeverity: () => undefined,
   describe: () => ({ role: 'guest', permissions: [] }),
   replaceRoles: () => {},
 }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -186,6 +186,7 @@ type SessionFactoryArgs = {
 const grantAllPermissions: PermissionService = {
   has: () => true,
   resolveRole: () => 'owner',
+  compareRoleSeverity: () => 1,
   describe: () => ({ role: 'owner', permissions: ['channel.respond'] }),
   replaceRoles: () => {},
 }
@@ -3213,6 +3214,7 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
     const allowAliceOnly: PermissionService = {
       has: (origin) => origin !== undefined && origin.kind === 'channel' && origin.lastInboundAuthorId === 'alice',
       resolveRole: () => 'member',
+      compareRoleSeverity: () => undefined,
       describe: () => ({ role: 'member', permissions: ['channel.respond'] }),
       replaceRoles: () => {},
     }
@@ -3233,6 +3235,7 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
     const denyAll: PermissionService = {
       has: () => false,
       resolveRole: () => 'guest',
+      compareRoleSeverity: () => undefined,
       describe: () => ({ role: 'guest', permissions: [] }),
       replaceRoles: () => {},
     }
@@ -5242,6 +5245,7 @@ describe('ChannelRouter channel.respond gate', () => {
       return grants.includes(permission)
     },
     resolveRole: () => 'guest',
+    compareRoleSeverity: () => undefined,
     describe: () => ({ role: 'guest', permissions: [] }),
     replaceRoles: () => {},
   })
@@ -5469,6 +5473,7 @@ describe('ChannelRouter channel.respond gate', () => {
     const permissions: PermissionService = {
       has: () => false,
       resolveRole: () => 'guest',
+      compareRoleSeverity: () => undefined,
       describe: () => ({ role: 'guest', permissions: [] }),
       replaceRoles: () => {},
     }
@@ -5488,6 +5493,7 @@ describe('ChannelRouter role-claim bypass', () => {
   const denyAllPermissions: PermissionService = {
     has: () => false,
     resolveRole: () => 'guest',
+    compareRoleSeverity: () => undefined,
     describe: () => ({ role: 'guest', permissions: [] }),
     replaceRoles: () => {},
   }
@@ -6379,6 +6385,7 @@ describe('ChannelRouter per-turn live role anchor', () => {
     const guestPermissions: PermissionService = {
       has: () => true,
       resolveRole: () => 'guest',
+      compareRoleSeverity: () => undefined,
       describe: () => ({ role: 'guest', permissions: [] }),
       replaceRoles: () => {},
     }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -711,6 +711,7 @@ export type ClaimHandler = (input: ClaimHandlerInput) => Promise<ClaimHandlerOut
 const GRANT_ALL_PERMISSIONS: PermissionService = {
   has: () => true,
   resolveRole: () => 'owner',
+  compareRoleSeverity: () => 1,
   describe: () => ({ role: 'owner', permissions: [CORE_PERMISSIONS.channelRespond] }),
   replaceRoles: () => {},
 }

--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -288,3 +288,39 @@ describe('describe()', () => {
     expect(desc.permissions).toEqual([])
   })
 })
+
+describe('PermissionService — compareRoleSeverity', () => {
+  test('built-in tower orders owner > trusted > member > guest', () => {
+    const svc = createPermissionService()
+    expect(svc.compareRoleSeverity('owner', 'trusted')).toBe(1)
+    expect(svc.compareRoleSeverity('trusted', 'member')).toBe(1)
+    expect(svc.compareRoleSeverity('member', 'guest')).toBe(1)
+    expect(svc.compareRoleSeverity('guest', 'owner')).toBe(-1)
+    expect(svc.compareRoleSeverity('member', 'member')).toBe(0)
+  })
+
+  test('configured custom role slots between trusted and member', () => {
+    const roles = parseRoles({
+      partner: { match: ['slack:T0123 author:U_PARTNER'], permissions: ['channel.respond'] },
+    })
+    const svc = createPermissionService({ roles, pluginPermissions: PLUGIN_PERMS })
+    expect(svc.compareRoleSeverity('partner', 'member')).toBe(1)
+    expect(svc.compareRoleSeverity('partner', 'trusted')).toBe(-1)
+    expect(svc.compareRoleSeverity('trusted', 'partner')).toBe(1)
+  })
+
+  test('two configured custom roles compare equal', () => {
+    const roles = parseRoles({
+      partner: { match: ['slack:T0 author:U_A'], permissions: ['channel.respond'] },
+      vendor: { match: ['slack:T0 author:U_B'], permissions: ['channel.respond'] },
+    })
+    const svc = createPermissionService({ roles, pluginPermissions: PLUGIN_PERMS })
+    expect(svc.compareRoleSeverity('partner', 'vendor')).toBe(0)
+  })
+
+  test('unknown role on either side returns undefined (caller must deny)', () => {
+    const svc = createPermissionService()
+    expect(svc.compareRoleSeverity('ghost', 'member')).toBeUndefined()
+    expect(svc.compareRoleSeverity('owner', 'ghost')).toBeUndefined()
+  })
+})

--- a/src/permissions/permissions.ts
+++ b/src/permissions/permissions.ts
@@ -9,6 +9,12 @@ export type PermissionService = {
   has(origin: SessionOrigin | undefined, permission: string): boolean
   resolveRole(origin: SessionOrigin | undefined): string
   describe(origin: SessionOrigin | undefined): { role: string; permissions: readonly string[] }
+  // Orders two role names on the severity tower so callers can cap an
+  // action to the requester's role (a guest turn must not read the output
+  // of a member-spawned subagent). `undefined` means an unknown role on
+  // either side and MUST be treated as deny, never allow — mistreating it
+  // as allow reopens the privilege-escalation hole this gate closes.
+  compareRoleSeverity(a: string, b: string): -1 | 0 | 1 | undefined
   // Rebuilds the resolved role table from the given roles config, preserving
   // the same plugin-permission set captured at construction time. Used by
   // the config reloadable so role match-rule edits (typeclaw role claim,
@@ -25,6 +31,7 @@ export type UnknownPermissionWarning = {
 export const noopPermissionService: PermissionService = {
   has: () => false,
   resolveRole: () => 'guest',
+  compareRoleSeverity: () => undefined,
   describe: () => ({ role: 'guest', permissions: [] }),
   replaceRoles: () => {},
 }
@@ -139,6 +146,15 @@ export function createPermissionService(opts: CreatePermissionServiceOptions = {
     return 'guest'
   }
 
+  function roleSeverity(name: string): number | undefined {
+    if (name === 'owner') return 4
+    if (name === 'trusted') return 3
+    if (name === 'member') return 1
+    if (name === 'guest') return 0
+    if (byName.has(name)) return 2
+    return undefined
+  }
+
   return {
     has(origin, permission) {
       // Fail-safe floor: an undefined origin holds nothing, regardless of
@@ -156,6 +172,14 @@ export function createPermissionService(opts: CreatePermissionServiceOptions = {
       return role.permissions.includes(permission)
     },
     resolveRole,
+    compareRoleSeverity(a, b) {
+      const aRank = roleSeverity(a)
+      const bRank = roleSeverity(b)
+      if (aRank === undefined || bRank === undefined) return undefined
+      if (aRank < bRank) return -1
+      if (aRank > bRank) return 1
+      return 0
+    },
     describe(origin) {
       const name = resolveRole(origin)
       const role = byName.get(name)

--- a/src/role-claim/controller.test.ts
+++ b/src/role-claim/controller.test.ts
@@ -9,6 +9,7 @@ function makePermissions(): { service: PermissionService; lastReplacement: Roles
   const service: PermissionService = {
     has: () => false,
     resolveRole: () => 'guest',
+    compareRoleSeverity: () => undefined,
     describe: () => ({ role: 'guest', permissions: [] }),
     replaceRoles: (roles) => {
       lastReplacement = roles


### PR DESCRIPTION
## Background

In a GitHub channel session we hit `subagent.output denied: insufficient permissions` when the agent tried to read the result of a background `reviewer` subagent it had spawned moments earlier. The spawn succeeded; the read did not.

Root cause is a provenance gap, not a missing permission string. `subagent_output`/`subagent_cancel` gate on `permissions.has(getOrigin(), …)`, and in a channel session `getOrigin()` is the *current turn's* origin. For a reminder-only turn (the subagent-completion `<system-reminder>`), the router restores `lastInboundAuthorId` to the last human speaker. On GitHub App-auth that speaker resolves to `guest`, and `guest` holds no subagent permissions — so the agent was blocked from reading its own subagent.

The operator's decision was **not** to make the parent always able to read its own subagent (that reopens a hole in shared channels), but the inverse: **cap these tools to the requester's role.** A requester must not reach a subagent spawned by a higher role than they currently resolve to. A `guest` turn cannot see or cancel a `member`/`trusted`/`owner`-spawned subagent — even if `guest` has been granted `subagent.output`/`subagent.cancel`.

## Summary

Two checks now apply to `subagent_output` and `subagent_cancel`: the existing "holds the permission" check, **and** a new "requester role ≥ spawner role" cap. The cap is enforced via a shared `denySubagentAccess` helper so both tools stay identical.

- **Why a severity rank and not permission-set superset?** A high-trust custom role with intentionally narrow permissions would fail superset comparison and be unable to reach a `member`-spawned subagent it should reach. A fixed tower avoids that surprise: `owner > trusted > (custom) > member > guest`, with every configured custom role at one tier between trusted and member (matching the existing resolver contract that custom roles slot there).
- **Why fail closed?** This is security provenance. A missing `spawnedByRole` (e.g. a spawn with no permission service) or an unknown role on either side denies rather than allows.
- **No `parentSessionId` exemption.** A channel session contains turns from different authors/roles; trusting "same session" as a privilege boundary would reopen exactly the guest-reading-member-spawned hole. The cap is strict.
- **Provenance source.** `spawn_subagent` already resolves the spawner's role; it now also persists it on the `LiveSubagent` registry entry so the tools can compare.

## What this does NOT do

- Does not change the "agent reads its own background reviewer" UX gap on its own. Under the strict cap, a reminder-only turn whose last speaker is a guest will still be denied — that is the intended, operator-requested behavior. If "agent-owned background tasks" is wanted later, it needs a separate stored-principal model, not a session-identity bypass.
- Does not alter `subagent.spawn` gating or the role tower itself.
- Does not touch the channel router's reminder-turn author restoration.

## Review notes

- Load-bearing invariant: `denySubagentAccess` (`src/agent/tools/subagent-access.ts`) must compose **both** the `has(...)` check and the severity cap, and must treat `compareRoleSeverity === undefined` as deny. If a future edit lets `undefined` fall through to allow, the privilege-escalation hole reopens.
- `compareRoleSeverity` returns `undefined` for unknown roles by design; the only caller treats that as deny.
- The two tools resolve the live entry and surface `Unknown task_id` *before* the cap, so a too-low requester cannot probe task existence via the denial message.
- `noopPermissionService` and the inline `PermissionService` stubs across the suite gained the new interface member; the grant-all stubs return `1` (requester always wins) to preserve their "allow everything" intent.
