### PR TITLE
fix(channels): scope Discord membership to the channel, not the whole guild

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -469,7 +469,7 @@ describe('renderSessionOrigin', () => {
     expect(out).not.toContain('guild members')
   })
 
-  test('channel origin renders Discord guild-level caveat for exact counts', () => {
+  test('channel origin renders Discord channel-scoped caveat for exact counts', () => {
     const now = 100_000
     const out = renderSessionOrigin(
       {
@@ -484,7 +484,7 @@ describe('renderSessionOrigin', () => {
     )
 
     expect(out).toContain('This channel has 47 members: 12 humans, 35 bots.')
-    expect(out).toContain('this is the count of guild members')
+    expect(out).toContain('counts only members who can view this channel')
   })
 
   test('channel origin renders large-channel truncated summary', () => {
@@ -501,7 +501,7 @@ describe('renderSessionOrigin', () => {
     expect(out).toContain('exceeds the 50-member cap')
   })
 
-  test('channel origin adds Discord caveat to truncated summaries', () => {
+  test('channel origin omits the channel-scoped caveat on truncated (history-derived) summaries', () => {
     const out = renderSessionOrigin({
       kind: 'channel',
       adapter: 'discord-bot',
@@ -512,7 +512,7 @@ describe('renderSessionOrigin', () => {
     })
 
     expect(out).toContain('approximately 200 members')
-    expect(out).toContain('private channels with permission overwrites')
+    expect(out).not.toContain('counts only members who can view this channel')
   })
 
   test('channel origin omits member summary when membership is missing', () => {

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -400,15 +400,19 @@ function renderMembershipSummary(
   if (membership === undefined) return null
 
   const total = membership.humans + membership.bots
-  const caveat =
-    origin.adapter === 'discord-bot' && origin.workspace !== '@dm'
-      ? ' (Note: this is the count of guild members; private channels with permission overwrites may have fewer actual viewers.)'
-      : ''
+  // Exact Discord counts are channel-scoped (filtered by who can VIEW_CHANNEL),
+  // so the count is the channel's room, not the guild. The truncated branch is
+  // history-derived recent speakers, which is not a channel-membership claim,
+  // so the caveat would mislead there.
   const isExact = !membership.truncated && now - membership.fetchedAt < MEMBERSHIP_FRESHNESS_MS
+  const caveat =
+    isExact && origin.adapter === 'discord-bot' && origin.workspace !== '@dm'
+      ? ' (This counts only members who can view this channel, not the whole guild.)'
+      : ''
   if (isExact) {
     return `This channel has ${total} members: ${membership.humans} humans, ${membership.bots} bots.${caveat} The 10 most recent speakers are listed below.`
   }
-  return `This channel has approximately ${total} members (about ${membership.humans} humans, ${membership.bots} bots — the bot count is approximate, the full member list was not enumerated because it exceeds the 50-member cap).${caveat} The 10 most recent speakers are listed below.`
+  return `This channel has approximately ${total} members (about ${membership.humans} humans, ${membership.bots} bots — the bot count is approximate, the full member list was not enumerated because it exceeds the 50-member cap). The 10 most recent speakers are listed below.`
 }
 
 function renderMentionGuidance(

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -212,6 +212,43 @@ describe('createDiscordMembershipResolver', () => {
     expect(scopedUrls).toContain('https://discord.com/api/v10/guilds/g1')
   })
 
+  test('scopes visibility to key.thread when set, not the parent key.chat', async () => {
+    // given a forward-compatible key shape (chat = parent, thread = thread id);
+    // visibility must be evaluated against the thread channel, not the parent.
+    const { fn, calls } = fakeFetch([
+      jsonResponse({ approximate_member_count: 2 }),
+      jsonResponse([
+        { user: { id: 'u1', bot: false }, roles: [] },
+        { user: { id: 'b1', bot: true }, roles: [] },
+      ]),
+      jsonResponse(publicChannelGuild().channel),
+      jsonResponse(publicChannelGuild().guild),
+    ])
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => 100,
+    })
+
+    // when the inbound is anchored at a thread
+    await expect(
+      resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'parent-c1', thread: 'thread-t9' }),
+    ).resolves.toEqual({
+      humans: 1,
+      bots: 1,
+      fetchedAt: 100,
+      truncated: false,
+      humanMemberIds: ['u1'],
+    })
+
+    // then the channel object fetched is the thread, not the parent
+    const scopedUrls = calls.slice(2).map((c) => c.url)
+    expect(scopedUrls).toContain('https://discord.com/api/v10/channels/thread-t9')
+    expect(scopedUrls).not.toContain('https://discord.com/api/v10/channels/parent-c1')
+  })
+
   test('private channel: @everyone denied VIEW_CHANNEL, only the agent bot allowed → bots:1, humans:1', async () => {
     // given: the exact production shape — guild has 1 human (owner) + 3 bots,
     // but #typeey denies @everyone VIEW_CHANNEL (0x400) and allows only the

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -173,10 +173,22 @@ describe('createDiscordMembershipResolver', () => {
     expect(calls).toHaveLength(0)
   })
 
-  test('small guild enumerates members for an exact bot/human split', async () => {
+  // A fully public channel: @everyone can VIEW_CHANNEL (no deny overwrite),
+  // so the channel-scoped count equals the guild count. Members carry no roles
+  // beyond @everyone; the guild's @everyone role grants VIEW_CHANNEL (0x400).
+  function publicChannelGuild(): { channel: unknown; guild: unknown } {
+    return {
+      channel: { type: 0, permission_overwrites: [] },
+      guild: { owner_id: 'owner', roles: [{ id: 'g1', permissions: String(0x400) }] },
+    }
+  }
+
+  test('small guild enumerates members for an exact bot/human split (public channel)', async () => {
     const { fn, calls } = fakeFetch([
       jsonResponse({ approximate_member_count: 3 }),
       jsonResponse([{ user: { id: 'u1' } }, { user: { id: 'b1', bot: true } }, { user: { id: 'u2', bot: false } }]),
+      jsonResponse(publicChannelGuild().channel),
+      jsonResponse(publicChannelGuild().guild),
     ])
     const resolver = createDiscordMembershipResolver({
       token: 'tok',
@@ -195,6 +207,193 @@ describe('createDiscordMembershipResolver', () => {
     })
     expect(calls[0]!.url).toBe('https://discord.com/api/v10/guilds/g1/preview')
     expect(calls[1]!.url).toBe('https://discord.com/api/v10/guilds/g1/members?limit=100')
+    const scopedUrls = calls.slice(2).map((c) => c.url)
+    expect(scopedUrls).toContain('https://discord.com/api/v10/channels/c1')
+    expect(scopedUrls).toContain('https://discord.com/api/v10/guilds/g1')
+  })
+
+  test('private channel: @everyone denied VIEW_CHANNEL, only the agent bot allowed → bots:1, humans:1', async () => {
+    // given: the exact production shape — guild has 1 human (owner) + 3 bots,
+    // but #typeey denies @everyone VIEW_CHANNEL (0x400) and allows only the
+    // agent's own bot. The owner (human) bypasses overwrites; the two peer
+    // bots have no allow overwrite, so they are not channel-visible.
+    const VIEW = 0x400
+    const { fn } = fakeFetch([
+      jsonResponse({ approximate_member_count: 4 }),
+      jsonResponse([
+        { user: { id: 'owner', bot: false }, roles: [] },
+        { user: { id: 'peerbotA', bot: true }, roles: [] },
+        { user: { id: 'agentbot', bot: true }, roles: [] },
+        { user: { id: 'peerbotB', bot: true }, roles: [] },
+      ]),
+      jsonResponse({
+        type: 0,
+        permission_overwrites: [
+          { id: 'g1', type: 0, allow: '0', deny: String(VIEW) },
+          { id: 'agentbot', type: 1, allow: String(VIEW), deny: '0' },
+        ],
+      }),
+      jsonResponse({ owner_id: 'owner', roles: [{ id: 'g1', permissions: '0' }] }),
+    ])
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => 100,
+    })
+
+    // then: only owner (human) + agentbot (bot) are visible → the single-human
+    // grant_role relaxation can fire.
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      humans: 1,
+      bots: 1,
+      fetchedAt: 100,
+      truncated: false,
+      humanMemberIds: ['owner'],
+    })
+  })
+
+  test('ADMINISTRATOR role bypasses a channel deny overwrite', async () => {
+    const VIEW = 0x400
+    const ADMIN = 0x8
+    const { fn } = fakeFetch([
+      jsonResponse({ approximate_member_count: 2 }),
+      jsonResponse([
+        { user: { id: 'admin', bot: false }, roles: ['adminRole'] },
+        { user: { id: 'agentbot', bot: true }, roles: [] },
+      ]),
+      jsonResponse({
+        type: 0,
+        permission_overwrites: [
+          { id: 'g1', type: 0, allow: '0', deny: String(VIEW) },
+          { id: 'agentbot', type: 1, allow: String(VIEW), deny: '0' },
+        ],
+      }),
+      jsonResponse({
+        owner_id: 'someone-else',
+        roles: [
+          { id: 'g1', permissions: '0' },
+          { id: 'adminRole', permissions: String(ADMIN) },
+        ],
+      }),
+    ])
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => 100,
+    })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      humans: 1,
+      bots: 1,
+      fetchedAt: 100,
+      truncated: false,
+      humanMemberIds: ['admin'],
+    })
+  })
+
+  test('a member referencing an unknown role fails closed to history fallback', async () => {
+    const { fn } = fakeFetch([
+      jsonResponse({ approximate_member_count: 2 }),
+      jsonResponse([{ user: { id: 'u1', bot: false }, roles: ['ghostRole'] }]),
+      jsonResponse({ type: 0, permission_overwrites: [] }),
+      jsonResponse({ owner_id: 'owner', roles: [{ id: 'g1', permissions: String(0x400) }] }),
+    ])
+    const { cb, calls: historyCalls } = fakeHistory({ ok: true, messages: [] })
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: cb,
+      fetchImpl: fn,
+      now: () => 100,
+    })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      humans: 0,
+      bots: 0,
+      fetchedAt: 100,
+      truncated: true,
+    })
+    expect(historyCalls).toHaveLength(1)
+  })
+
+  test('a thread channel fails closed to history fallback (visibility not modelled)', async () => {
+    const { fn } = fakeFetch([
+      jsonResponse({ approximate_member_count: 3 }),
+      jsonResponse([{ user: { id: 'u1', bot: false }, roles: [] }]),
+      jsonResponse({ type: 11, permission_overwrites: [] }),
+      jsonResponse({ owner_id: 'owner', roles: [{ id: 'g1', permissions: String(0x400) }] }),
+    ])
+    const { cb, calls: historyCalls } = fakeHistory({ ok: true, messages: [] })
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: cb,
+      fetchImpl: fn,
+      now: () => 100,
+    })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      humans: 0,
+      bots: 0,
+      fetchedAt: 100,
+      truncated: true,
+    })
+    expect(historyCalls).toHaveLength(1)
+  })
+
+  test('channel fetch failure fails closed to history fallback', async () => {
+    const { fn } = fakeFetch([
+      jsonResponse({ approximate_member_count: 2 }),
+      jsonResponse([{ user: { id: 'u1', bot: false }, roles: [] }]),
+      new Response(null, { status: 403 }),
+      jsonResponse({ owner_id: 'owner', roles: [{ id: 'g1', permissions: String(0x400) }] }),
+    ])
+    const { cb, calls: historyCalls } = fakeHistory({ ok: true, messages: [] })
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: cb,
+      fetchImpl: fn,
+      now: () => 100,
+    })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      humans: 0,
+      bots: 0,
+      fetchedAt: 100,
+      truncated: true,
+    })
+    expect(historyCalls).toHaveLength(1)
+  })
+
+  test('an unidentifiable visible human drops humanMemberIds (counts-only)', async () => {
+    const { fn } = fakeFetch([
+      jsonResponse({ approximate_member_count: 2 }),
+      jsonResponse([
+        { user: { bot: false }, roles: [] },
+        { user: { id: 'b1', bot: true }, roles: [] },
+      ]),
+      jsonResponse(publicChannelGuild().channel),
+      jsonResponse(publicChannelGuild().guild),
+    ])
+    const resolver = createDiscordMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => 100,
+    })
+
+    await expect(resolver({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null })).resolves.toEqual({
+      humans: 1,
+      bots: 1,
+      fetchedAt: 100,
+      truncated: false,
+    })
   })
 
   test('large guild (>cap) falls back to history-derived count', async () => {

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -148,6 +148,116 @@ type DiscordGuildPreview = {
 
 type DiscordGuildMember = {
   user?: { id?: string; bot?: boolean }
+  roles?: string[]
+}
+
+type DiscordPermissionOverwrite = {
+  id?: string
+  type?: number
+  allow?: string
+  deny?: string
+}
+
+// Discord channel `type` values that are threads. A thread's own
+// permission_overwrites are empty and its `parent_id` points at its parent
+// channel (not a category), so the normal "compute from this channel's
+// overwrites" path would treat a thread as fully public. We refuse to count
+// threads channel-scoped and fall back instead — fail-closed.
+const DISCORD_THREAD_CHANNEL_TYPES: ReadonlySet<number> = new Set([10, 11, 12])
+
+type DiscordChannelObject = {
+  type?: number
+  permission_overwrites?: DiscordPermissionOverwrite[]
+}
+
+type DiscordRole = {
+  id?: string
+  permissions?: string
+}
+
+type DiscordGuildObject = {
+  owner_id?: string
+  roles?: DiscordRole[]
+}
+
+// Discord permission bits. Discord serialises permission bitsets as decimal
+// STRINGS that can exceed Number.MAX_SAFE_INTEGER, so all bit math is done in
+// BigInt. Only the two bits this resolver needs are named.
+const DISCORD_PERMISSION_VIEW_CHANNEL = 0x400n
+const DISCORD_PERMISSION_ADMINISTRATOR = 0x8n
+
+function parsePermissionBits(raw: string | undefined): bigint {
+  if (raw === undefined || raw === '') return 0n
+  try {
+    return BigInt(raw)
+  } catch {
+    return 0n
+  }
+}
+
+// Computes whether a single member can VIEW_CHANNEL on a normal guild channel,
+// following Discord's documented resolution order:
+//   base = @everyone role perms OR all of the member's role perms
+//   → owner or ADMINISTRATOR short-circuits to visible
+//   → @everyone channel overwrite (clear deny bits, then set allow bits)
+//   → all matching role overwrites combined (OR every deny, OR every allow;
+//     apply denies then allows)
+//   → member-specific overwrite (clear deny, set allow)
+// Returns null when the data is insufficient to decide (a member references a
+// role absent from the guild role map), so the caller can fail closed rather
+// than guess.
+function memberCanViewChannel(args: {
+  guildId: string
+  ownerId: string | undefined
+  rolePermissions: ReadonlyMap<string, bigint>
+  overwrites: ReadonlyMap<string, { allow: bigint; deny: bigint }>
+  memberId: string | undefined
+  memberRoleIds: readonly string[]
+}): boolean | null {
+  const { guildId, ownerId, rolePermissions, overwrites, memberId, memberRoleIds } = args
+
+  if (memberId !== undefined && ownerId !== undefined && memberId === ownerId) return true
+
+  // Discord's `@everyone` role id always equals the guild id, so the guild id
+  // keys both the base @everyone permissions and the @everyone overwrite.
+  let base = rolePermissions.get(guildId) ?? 0n
+  for (const roleId of memberRoleIds) {
+    const perms = rolePermissions.get(roleId)
+    if (perms === undefined) return null
+    base |= perms
+  }
+
+  if ((base & DISCORD_PERMISSION_ADMINISTRATOR) !== 0n) return true
+
+  let perms = base
+
+  const everyoneOverwrite = overwrites.get(guildId)
+  if (everyoneOverwrite !== undefined) {
+    perms &= ~everyoneOverwrite.deny
+    perms |= everyoneOverwrite.allow
+  }
+
+  let roleDeny = 0n
+  let roleAllow = 0n
+  for (const roleId of memberRoleIds) {
+    const overwrite = overwrites.get(roleId)
+    if (overwrite !== undefined) {
+      roleDeny |= overwrite.deny
+      roleAllow |= overwrite.allow
+    }
+  }
+  perms &= ~roleDeny
+  perms |= roleAllow
+
+  if (memberId !== undefined) {
+    const memberOverwrite = overwrites.get(memberId)
+    if (memberOverwrite !== undefined) {
+      perms &= ~memberOverwrite.deny
+      perms |= memberOverwrite.allow
+    }
+  }
+
+  return (perms & DISCORD_PERMISSION_VIEW_CHANNEL) !== 0n
 }
 
 export function createDiscordMembershipResolver(deps: {
@@ -207,28 +317,132 @@ export function createDiscordMembershipResolver(deps: {
       return members.failure
     }
 
-    let bots = 0
-    let humans = 0
-    const humanMemberIds: string[] = []
-    let everyHumanIdentified = true
-    for (const member of members.value) {
-      if (member.user?.bot === true) {
-        bots++
-        continue
-      }
-      humans++
-      const userId = member.user?.id
-      if (userId === undefined) everyHumanIdentified = false
-      else humanMemberIds.push(userId)
-    }
-    // Only attach identities when every human was identifiable; an
-    // unidentifiable human must not be silently dropped, or a consumer proving
-    // "all humans trusted" would skip an unaccounted member. Falling back to
-    // counts-only keeps that consumer fail-closed.
-    return everyHumanIdentified
-      ? { humans, bots, fetchedAt: now(), truncated: false, humanMemberIds }
-      : { humans, bots, fetchedAt: now(), truncated: false }
+    // Guild `/members` returns the whole guild, not the channel. A bot or
+    // human that cannot VIEW_CHANNEL the target channel is not in the room and
+    // not a prompt-injection surface, so it must not be counted — otherwise a
+    // private channel of "operator + agent bot" inside a multi-bot guild reads
+    // as bots>1 and the grant_role relaxation (provesOnlyAgentBotPresent)
+    // false-refuses. Resolve channel visibility for each member; on ANY
+    // inability to decide, fall back rather than over- or under-count.
+    const scoped = await scopeMembersToChannel({
+      fetchFn,
+      token: deps.token,
+      logger: deps.logger,
+      guildId: key.workspace,
+      channelId: key.chat,
+      members: members.value,
+    })
+    if (scoped === 'fallback') return await fallback()
+
+    return scoped.everyHumanIdentified
+      ? {
+          humans: scoped.humans,
+          bots: scoped.bots,
+          fetchedAt: now(),
+          truncated: false,
+          humanMemberIds: scoped.humanMemberIds,
+        }
+      : { humans: scoped.humans, bots: scoped.bots, fetchedAt: now(), truncated: false }
   }
+}
+
+type ScopedMembership = {
+  humans: number
+  bots: number
+  humanMemberIds: string[]
+  everyHumanIdentified: boolean
+}
+
+// Filters a guild member list down to those who can VIEW_CHANNEL the target
+// channel, then counts humans/bots over that visible set. Returns 'fallback'
+// when channel visibility cannot be computed completely (channel/guild fetch
+// failure, a member referencing an unknown role, or a thread channel whose
+// visibility this resolver does not model) — the caller then derives from
+// history (truncated:true), keeping every security consumer fail-closed.
+async function scopeMembersToChannel(args: {
+  fetchFn: typeof fetch
+  token: string
+  logger: DiscordBotAdapterLogger
+  guildId: string
+  channelId: string
+  members: readonly DiscordGuildMember[]
+}): Promise<ScopedMembership | 'fallback'> {
+  const { fetchFn, token, logger, guildId, channelId, members } = args
+
+  const [channel, guild] = await Promise.all([
+    fetchDiscordJson<DiscordChannelObject>(fetchFn, `${DISCORD_API_BASE}/channels/${channelId}`, token),
+    fetchDiscordJson<DiscordGuildObject>(fetchFn, `${DISCORD_API_BASE}/guilds/${guildId}`, token),
+  ])
+  if (!channel.ok) {
+    logger.warn(
+      `[discord-bot] membership channel=${channelId} fetch failed: ${channel.reason}; deriving from recent message authors`,
+    )
+    return 'fallback'
+  }
+  if (!guild.ok) {
+    logger.warn(
+      `[discord-bot] membership guild=${guildId} fetch failed: ${guild.reason}; deriving from recent message authors`,
+    )
+    return 'fallback'
+  }
+
+  if (channel.value.type !== undefined && DISCORD_THREAD_CHANNEL_TYPES.has(channel.value.type)) {
+    // A thread inherits visibility from its parent channel and (for private
+    // threads) an explicit member list; we do not model either here. Fall
+    // back rather than treat the thread as world-visible.
+    logger.warn(
+      `[discord-bot] membership channel=${channelId} is a thread; deriving from recent message authors instead of channel-scoped enumeration`,
+    )
+    return 'fallback'
+  }
+
+  const rolePermissions = new Map<string, bigint>()
+  for (const role of guild.value.roles ?? []) {
+    if (role.id !== undefined) rolePermissions.set(role.id, parsePermissionBits(role.permissions))
+  }
+
+  const overwrites = new Map<string, { allow: bigint; deny: bigint }>()
+  for (const overwrite of channel.value.permission_overwrites ?? []) {
+    if (overwrite.id === undefined) continue
+    overwrites.set(overwrite.id, {
+      allow: parsePermissionBits(overwrite.allow),
+      deny: parsePermissionBits(overwrite.deny),
+    })
+  }
+
+  let humans = 0
+  let bots = 0
+  const humanMemberIds: string[] = []
+  let everyHumanIdentified = true
+
+  for (const member of members) {
+    const visible = memberCanViewChannel({
+      guildId,
+      ownerId: guild.value.owner_id,
+      rolePermissions,
+      overwrites,
+      memberId: member.user?.id,
+      memberRoleIds: member.roles ?? [],
+    })
+    if (visible === null) {
+      logger.warn(
+        `[discord-bot] membership channel=${channelId} member references unknown role; deriving from recent message authors`,
+      )
+      return 'fallback'
+    }
+    if (!visible) continue
+
+    if (member.user?.bot === true) {
+      bots++
+      continue
+    }
+    humans++
+    const userId = member.user?.id
+    if (userId === undefined) everyHumanIdentified = false
+    else humanMemberIds.push(userId)
+  }
+
+  return { humans, bots, humanMemberIds, everyHumanIdentified }
 }
 
 type DiscordFetchResult<T> =

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -324,12 +324,16 @@ export function createDiscordMembershipResolver(deps: {
     // as bots>1 and the grant_role relaxation (provesOnlyAgentBotPresent)
     // false-refuses. Resolve channel visibility for each member; on ANY
     // inability to decide, fall back rather than over- or under-count.
+    // `key.thread ?? key.chat` mirrors the history callback's channel-id
+    // resolution: today Discord stores a thread's own snowflake in `chat` with
+    // `thread` null, but a future caller that passes `chat=parent,
+    // thread=threadId` must scope visibility to the thread, not the parent.
     const scoped = await scopeMembersToChannel({
       fetchFn,
       token: deps.token,
       logger: deps.logger,
       guildId: key.workspace,
-      channelId: key.chat,
+      channelId: key.thread ?? key.chat,
       members: members.value,
     })
     if (scoped === 'fallback') return await fallback()


### PR DESCRIPTION
## Background

PR #537 relaxed the `grant_role` guard to allow role grants in a **single-human** or **all-humans-trusted** group channel, proven from a membership snapshot. The guard helper `provesOnlyAgentBotPresent` requires `membership.bots === 1` — the only non-human in the room is the agent's own bot — so no peer bot can buffer a prompt-injection message into the turn.

That relaxation never fires on Discord in a common real setup. The Discord membership resolver enumerated **guild-wide** membership via `GET /guilds/{id}/members` and never filtered by who can actually view the target channel. In any guild that hosts **more than one bot**, the guild-wide count reports `bots > 1` even when the *specific channel* is just operator + agent bot — so the guard false-refuses with "this is a mixed-speaker surface".

### Confirmed in production

A private channel with `@everyone` denied `VIEW_CHANNEL` and only the agent bot allowed:

- **Guild membership** (what the resolver returned): `1 human + 3 bots` → `bots !== 1` → refused.
- **Channel membership** (the real authorization surface): `1 human (owner, bypasses overwrites) + 1 bot (agent)` → the two peer bots are denied `VIEW_CHANNEL` and cannot post → should allow.

The peer bots are not a prompt-injection surface for that channel, so counting them is wrong.

## Summary

Filter the guild member list down to members who can `VIEW_CHANNEL` the target channel, then count humans/bots over that visible set. Visibility follows Discord's documented permission-overwrite resolution order:

1. base = `@everyone` role perms `OR` all of the member's role perms
2. `owner_id` or `ADMINISTRATOR` short-circuits to visible
3. `@everyone` channel overwrite (clear deny bits, then set allow bits)
4. all matching role overwrites combined (OR every deny, OR every allow; apply denies then allows)
5. member-specific overwrite (clear deny, set allow)
6. visible iff `VIEW_CHANNEL` is set

All bit math is **BigInt** because Discord serialises permission sets as decimal strings beyond `Number.MAX_SAFE_INTEGER`.

This matches **Slack**, which already scopes membership to the channel via `conversations.members`. The guard's `bots === 1` invariant is unchanged — only the data feeding it is corrected.

Data fetched on the enumeration path: `GET /channels/{chat}` (overwrites + channel type) and `GET /guilds/{id}` (`owner_id` + `roles[].permissions`), in parallel, in addition to the existing preview + members calls.

## Fail-closed

Any inability to compute channel visibility derives from history instead (`truncated: true`), keeping every security consumer fail-closed:

- channel or guild fetch failure
- a member referencing a role absent from the guild role map (`memberCanViewChannel` returns `null`)
- a **thread** channel (its visibility comes from the parent channel + an explicit member list, which this resolver does not model — refusing to treat it as world-visible)

`humanMemberIds` stays channel-scoped, and its `length === humans` invariant is preserved by construction; an unidentifiable visible human drops it to counts-only.

## What this does NOT do

- Does not change the `grant_role` guard or its `bots === 1` / `humanMemberIds` contract.
- Does not change Slack, Telegram, KakaoTalk, or GitHub resolvers.
- Does not merge parent-category overwrites for normal channels (synced categories already copy their overwrites onto the channel; unsynced channels intentionally diverge).
- Does not model private-thread membership — threads fall back to history.

## Origin prose

Exact Discord counts are now channel-scoped, so the origin membership summary's "count of guild members" caveat is replaced with "counts only members who can view this channel". The caveat is gated to the **exact** branch; truncated (history-derived) summaries drop it, since recent-speaker counts are not a channel-membership claim.

## Tests

New `createDiscordMembershipResolver` cases:
- **the exact production shape**: `@everyone` denied `VIEW_CHANNEL`, only the agent bot allowed → `{humans:1, bots:1}` (the single-human relaxation can fire)
- `ADMINISTRATOR` role bypasses a channel deny overwrite
- public channel (no deny) → channel count equals guild count
- fail-closed: unknown-role member → history fallback
- fail-closed: thread channel → history fallback
- fail-closed: channel fetch 403 → history fallback
- unidentifiable visible human → counts-only (no `humanMemberIds`)

Existing enumeration tests updated to supply the channel + guild objects and assert the two new scoped fetches. Origin summary tests updated for the new caveat wording.

## Checks

`typecheck` clean, `lint` 0 errors, `format:check` clean. Full suite green except the one pre-existing environmental failure in `src/update/index.test.ts` (`resolveSelfPackageJsonPath`) on worktree paths — passes on a normal checkout/CI, same as noted in #537.