### PR TITLE
chore(github): add CODEOWNERS to auto-assign @typeey as reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS — auto-assigns reviewers on pull requests.
+# Docs: https://docs.github.com/articles/about-code-owners
+#
+# Order matters: the LAST matching pattern wins for a given path.
+
+# Default owner for everything in the repo.
+*       @typeey


### PR DESCRIPTION
## Background

There was no CODEOWNERS file in this repo, which meant GitHub never automatically requested a reviewer when PRs were opened. Every PR required a manual reviewer assignment, making it easy to forget.

## Summary

Adds `.github/CODEOWNERS` with a single catch-all rule:

```
*       @typeey
```

This instructs GitHub to automatically request @typeey as a reviewer on every pull request, regardless of which files are changed.

## Preview

_No visual output — plain text config file._

## What this does NOT do

- Does not add per-directory or per-filetype ownership rules (single catch-all only).
- Does not change any build, CI, or runtime behavior.
- Does not enforce required reviews by itself — to make the review mandatory, enable "Require review from Code Owners" in the branch protection settings for `main`.
- Does not grant write access to @typeey — that must be configured separately in GitHub repo settings for CODEOWNERS to function.

## Review notes

The only file added is `.github/CODEOWNERS` (7 lines). No code is changed.

**Note on CI status:** There is a pre-existing, unrelated typecheck failure on `main` that this PR does not introduce or affect.
CODEOWNERS is a plain text file with no TypeScript.
The root cause is a TS2305 error in the KakaoTalk adapter: `KakaoReplyTarget` is referenced but no longer exported from the upstream package.
The required `typecheck` CI check may show red until that separate issue is fixed.