### PR TITLE
feat(tui): add /reload and /restart slash commands

### DIFF
--- a/src/agent/restart/index.test.ts
+++ b/src/agent/restart/index.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { restartHandoffPath } from '@/agent/restart-handoff'
+
+import { requestContainerRestart } from './index'
+
+let server: ReturnType<typeof Bun.serve> | null = null
+
+const TEST_ACK_TIMEOUT_MS = 30_000
+
+afterEach(() => {
+  server?.stop(true)
+  server = null
+})
+
+describe('requestContainerRestart', () => {
+  let agentDir: string
+
+  beforeEach(async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-request-restart-'))
+  })
+
+  afterEach(async () => {
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('uses HTTP transport and returns the accepted restart timestamp', async () => {
+    // given
+    const requests: Array<{ auth: string | null; body: unknown }> = []
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        requests.push({ auth: req.headers.get('authorization'), body: await req.json() })
+        return Response.json({ ok: true, result: { containerName: 'coder', scheduled: true } })
+      },
+    })
+
+    // when
+    const result = await requestContainerRestart({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      restartedAt: '2026-01-02T03:04:05.000Z',
+    })
+
+    // then
+    expect(result).toEqual({ ok: true, containerName: 'coder', restartedAt: '2026-01-02T03:04:05.000Z' })
+    expect(requests).toEqual([
+      {
+        auth: 'Bearer secret',
+        body: { kind: 'restart', containerName: 'coder', build: false },
+      },
+    ])
+  })
+
+  test('returns failure without writing a handoff when hostd rejects the restart', async () => {
+    // given
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ ok: false, reason: 'not registered: coder' })
+      },
+    })
+
+    // when
+    const result = await requestContainerRestart({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      agentDir,
+      originatingSessionId: 'ses-origin',
+      originatingSessionFile: '/tmp/sessions/ses-origin.jsonl',
+    })
+
+    // then
+    expect(result).toEqual({ ok: false, containerName: 'coder', reason: 'not registered: coder' })
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
+  })
+
+  test('writes handoff only when every handoff field is present', async () => {
+    // given
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ ok: true, result: { containerName: 'coder', scheduled: true } })
+      },
+    })
+
+    // when
+    await requestContainerRestart({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      agentDir,
+      originatingSessionId: 'ses-incomplete',
+      restartedAt: '2026-01-02T03:04:05.000Z',
+    })
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
+
+    const result = await requestContainerRestart({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      agentDir,
+      originatingSessionId: 'ses-origin',
+      originatingSessionFile: '/tmp/sessions/ses-origin.jsonl',
+      restartedAt: '2026-01-02T03:04:05.000Z',
+    })
+
+    // then
+    expect(result).toEqual({ ok: true, containerName: 'coder', restartedAt: '2026-01-02T03:04:05.000Z' })
+    expect(JSON.parse(await readFile(restartHandoffPath(agentDir), 'utf8'))).toEqual({
+      schemaVersion: 1,
+      restartedAt: '2026-01-02T03:04:05.000Z',
+      originatingSessionId: 'ses-origin',
+      originatingSessionFile: 'ses-origin.jsonl',
+    })
+  })
+
+  test('forwards build:true in the RPC body', async () => {
+    // given
+    const requests: unknown[] = []
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        requests.push(await req.json())
+        return Response.json({ ok: true, result: { containerName: 'coder', scheduled: true } })
+      },
+    })
+
+    // when
+    await requestContainerRestart({
+      containerName: 'coder',
+      build: true,
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+    })
+
+    // then
+    expect(requests).toEqual([{ kind: 'restart', containerName: 'coder', build: true }])
+  })
+})

--- a/src/agent/restart/index.test.ts
+++ b/src/agent/restart/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -123,6 +123,34 @@ describe('requestContainerRestart', () => {
       originatingSessionId: 'ses-origin',
       originatingSessionFile: 'ses-origin.jsonl',
     })
+  })
+
+  test('still succeeds when the handoff write fails after hostd accepts', async () => {
+    // given: hostd has accepted, but the handoff target is unwritable because a
+    // regular file occupies the agent dir, so mkdir of `.typeclaw` will throw
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ ok: true, result: { containerName: 'coder', scheduled: true } })
+      },
+    })
+    const fileAsAgentDir = join(agentDir, 'not-a-dir')
+    await writeFile(fileAsAgentDir, 'x', 'utf8')
+
+    // when
+    const result = await requestContainerRestart({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      agentDir: fileAsAgentDir,
+      originatingSessionId: 'ses-origin',
+      originatingSessionFile: '/tmp/sessions/ses-origin.jsonl',
+      restartedAt: '2026-01-02T03:04:05.000Z',
+    })
+
+    // then: the already-committed restart is not demoted to a failure
+    expect(result).toEqual({ ok: true, containerName: 'coder', restartedAt: '2026-01-02T03:04:05.000Z' })
   })
 
   test('forwards build:true in the RPC body', async () => {

--- a/src/agent/restart/index.test.ts
+++ b/src/agent/restart/index.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { restartHandoffPath } from '@/agent/restart-handoff'
+import { createStream, type StreamMessage } from '@/stream'
 
 import { requestContainerRestart } from './index'
 
@@ -123,6 +124,69 @@ describe('requestContainerRestart', () => {
       originatingSessionId: 'ses-origin',
       originatingSessionFile: 'ses-origin.jsonl',
     })
+  })
+
+  test('publishes a container-restarting broadcast before writing the handoff on a successful ACK', async () => {
+    // given: a stream whose subscriber records broadcasts, and a hostd that
+    // accepts. The broadcast must carry the originating session id so the
+    // matching session's subscribeRestartNotice can append restart-self.
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ ok: true, result: { containerName: 'coder', scheduled: true } })
+      },
+    })
+    const stream = createStream()
+    const received: StreamMessage[] = []
+    stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => received.push(msg))
+
+    // when
+    await requestContainerRestart({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      stream,
+      agentDir,
+      originatingSessionId: 'ses-origin',
+      originatingSessionFile: '/tmp/sessions/ses-origin.jsonl',
+      restartedAt: '2026-01-02T03:04:05.000Z',
+    })
+
+    // then
+    expect(received).toHaveLength(1)
+    expect(received[0]?.payload).toEqual({
+      kind: 'container-restarting',
+      restartedAt: '2026-01-02T03:04:05.000Z',
+      originatingSessionId: 'ses-origin',
+    })
+  })
+
+  test('does not publish a broadcast when hostd rejects the restart', async () => {
+    // given
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ ok: false, reason: 'not registered: coder' })
+      },
+    })
+    const stream = createStream()
+    const received: StreamMessage[] = []
+    stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => received.push(msg))
+
+    // when
+    const result = await requestContainerRestart({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      stream,
+      originatingSessionId: 'ses-origin',
+    })
+
+    // then
+    expect(result.ok).toBe(false)
+    expect(received).toHaveLength(0)
   })
 
   test('still succeeds when the handoff write fails after hostd accepts', async () => {

--- a/src/agent/restart/index.ts
+++ b/src/agent/restart/index.ts
@@ -3,8 +3,15 @@ import { basename } from 'node:path'
 import { writeRestartHandoff } from '@/agent/restart-handoff'
 import { send, sendHttp } from '@/hostd/client'
 import { containerSocketPath } from '@/hostd/paths'
+import type { Stream } from '@/stream'
 
 const ACK_TIMEOUT_MS = 5_000
+
+export type ContainerRestartingBroadcast = {
+  kind: 'container-restarting'
+  restartedAt: string
+  originatingSessionId: string
+}
 
 export type RequestContainerRestartOptions = {
   containerName: string
@@ -13,6 +20,13 @@ export type RequestContainerRestartOptions = {
   hostdUrl?: string
   hostdToken?: string
   ackTimeoutMs?: number
+  // When present together with originatingSessionId, the post-ACK
+  // container-restarting broadcast is published here so every live session's
+  // subscribeRestartNotice fans out the restart notice (originator gets
+  // typeclaw.restart-self, siblings get typeclaw.restart). Both the tool and
+  // the server /restart path route through this so the broadcast->handoff
+  // ordering lives in one place.
+  stream?: Stream
   agentDir?: string
   originatingSessionId?: string
   originatingSessionFile?: string
@@ -30,6 +44,7 @@ export async function requestContainerRestart({
   hostdUrl,
   hostdToken,
   ackTimeoutMs,
+  stream,
   agentDir,
   originatingSessionId,
   originatingSessionFile,
@@ -47,6 +62,22 @@ export async function requestContainerRestart({
   if (!reply.ok) return { ok: false, containerName, reason: reply.reason }
 
   const restartTimestamp = restartedAt ?? new Date().toISOString()
+
+  // Fan out the restart notice to every live session BEFORE writing the handoff.
+  // The originating session's subscribeRestartNotice appends the
+  // typeclaw.restart-self entry synchronously (broker delivery + the JSONL
+  // append are both synchronous), so the handoff below points at a JSONL that
+  // already carries the "I'm back" instruction the rebooted container hydrates.
+  // Only after an accepted ACK, never on a failed/timed-out restart.
+  if (stream !== undefined && originatingSessionId !== undefined) {
+    const broadcast: ContainerRestartingBroadcast = {
+      kind: 'container-restarting',
+      restartedAt: restartTimestamp,
+      originatingSessionId,
+    }
+    stream.publish({ target: { kind: 'broadcast' }, payload: broadcast })
+  }
+
   // Post-ACK: hostd has committed the restart, so a handoff-write failure must
   // never demote it to a failure — that would render a false error in the TUI
   // and swallow the accepted response. The handoff is a best-effort resume hint

--- a/src/agent/restart/index.ts
+++ b/src/agent/restart/index.ts
@@ -47,13 +47,23 @@ export async function requestContainerRestart({
   if (!reply.ok) return { ok: false, containerName, reason: reply.reason }
 
   const restartTimestamp = restartedAt ?? new Date().toISOString()
+  // Post-ACK: hostd has committed the restart, so a handoff-write failure must
+  // never demote it to a failure — that would render a false error in the TUI
+  // and swallow the accepted response. The handoff is a best-effort resume hint
+  // only; a missing one just cold-starts the rebooted container without the
+  // "I'm back" greeting. writeRestartHandoff swallows its own errors today, but
+  // guard here too so this contract survives the writer being changed later.
   if (agentDir !== undefined && originatingSessionId !== undefined && originatingSessionFile !== undefined) {
-    await writeRestartHandoff(agentDir, {
-      schemaVersion: 1,
-      restartedAt: restartTimestamp,
-      originatingSessionId,
-      originatingSessionFile: basename(originatingSessionFile),
-    })
+    try {
+      await writeRestartHandoff(agentDir, {
+        schemaVersion: 1,
+        restartedAt: restartTimestamp,
+        originatingSessionId,
+        originatingSessionFile: basename(originatingSessionFile),
+      })
+    } catch {
+      // intentional swallow — see the post-ACK rationale above
+    }
   }
 
   return { ok: true, containerName, restartedAt: restartTimestamp }

--- a/src/agent/restart/index.ts
+++ b/src/agent/restart/index.ts
@@ -1,0 +1,60 @@
+import { basename } from 'node:path'
+
+import { writeRestartHandoff } from '@/agent/restart-handoff'
+import { send, sendHttp } from '@/hostd/client'
+import { containerSocketPath } from '@/hostd/paths'
+
+const ACK_TIMEOUT_MS = 5_000
+
+export type RequestContainerRestartOptions = {
+  containerName: string
+  build?: boolean
+  socketPath?: string
+  hostdUrl?: string
+  hostdToken?: string
+  ackTimeoutMs?: number
+  agentDir?: string
+  originatingSessionId?: string
+  originatingSessionFile?: string
+  restartedAt?: string
+}
+
+export type RequestContainerRestartResult =
+  | { ok: true; containerName: string; restartedAt: string }
+  | { ok: false; containerName: string; reason: string }
+
+export async function requestContainerRestart({
+  containerName,
+  build,
+  socketPath,
+  hostdUrl,
+  hostdToken,
+  ackTimeoutMs,
+  agentDir,
+  originatingSessionId,
+  originatingSessionFile,
+  restartedAt,
+}: RequestContainerRestartOptions): Promise<RequestContainerRestartResult> {
+  const request = { kind: 'restart' as const, containerName, build: build === true }
+  const httpUrl = hostdUrl ?? process.env.TYPECLAW_HOSTD_URL
+  const httpToken = hostdToken ?? process.env.TYPECLAW_HOSTD_TOKEN
+  const ackBudget = ackTimeoutMs ?? ACK_TIMEOUT_MS
+  const reply =
+    httpUrl && httpToken
+      ? await sendHttp(request, { timeoutMs: ackBudget, url: httpUrl, token: httpToken })
+      : await send(request, { timeoutMs: ackBudget, socket: socketPath ?? containerSocketPath() })
+
+  if (!reply.ok) return { ok: false, containerName, reason: reply.reason }
+
+  const restartTimestamp = restartedAt ?? new Date().toISOString()
+  if (agentDir !== undefined && originatingSessionId !== undefined && originatingSessionFile !== undefined) {
+    await writeRestartHandoff(agentDir, {
+      schemaVersion: 1,
+      restartedAt: restartTimestamp,
+      originatingSessionId,
+      originatingSessionFile: basename(originatingSessionFile),
+    })
+  }
+
+  return { ok: true, containerName, restartedAt: restartTimestamp }
+}

--- a/src/agent/tools/restart.ts
+++ b/src/agent/tools/restart.ts
@@ -3,12 +3,10 @@ import { basename } from 'node:path'
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
+import { requestContainerRestart } from '@/agent/restart'
 import { writeRestartHandoff } from '@/agent/restart-handoff'
-import { send, sendHttp } from '@/hostd/client'
-import { containerSocketPath } from '@/hostd/paths'
 import type { Stream } from '@/stream'
 
-const ACK_TIMEOUT_MS = 5_000
 const EXIT_DELAY_MS = 500
 
 export type CreateRestartToolOptions = {
@@ -80,9 +78,6 @@ export function createRestartTool({
   originatingSessionFile,
 }: CreateRestartToolOptions) {
   const doExit = exit ?? ((code: number) => process.exit(code))
-  const httpUrl = hostdUrl ?? process.env.TYPECLAW_HOSTD_URL
-  const ackBudget = ackTimeoutMs ?? ACK_TIMEOUT_MS
-  const httpToken = hostdToken ?? process.env.TYPECLAW_HOSTD_TOKEN
 
   return defineTool({
     name: 'restart',
@@ -109,15 +104,18 @@ export function createRestartTool({
     }),
     async execute(_toolCallId, params) {
       const build = params.build === true
-      const request = { kind: 'restart' as const, containerName, build }
-      const reply =
-        httpUrl && httpToken
-          ? await sendHttp(request, { timeoutMs: ackBudget, url: httpUrl, token: httpToken })
-          : await send(request, { timeoutMs: ackBudget, socket: socketPath ?? containerSocketPath() })
-      if (!reply.ok) {
-        const details: RestartToolDetails = { ok: false, containerName, reason: reply.reason }
+      const result = await requestContainerRestart({
+        containerName,
+        build,
+        ...(socketPath !== undefined ? { socketPath } : {}),
+        ...(hostdUrl !== undefined ? { hostdUrl } : {}),
+        ...(hostdToken !== undefined ? { hostdToken } : {}),
+        ...(ackTimeoutMs !== undefined ? { ackTimeoutMs } : {}),
+      })
+      if (!result.ok) {
+        const details: RestartToolDetails = { ok: false, containerName, reason: result.reason }
         return {
-          content: [{ type: 'text' as const, text: `restart denied: ${reply.reason}` }],
+          content: [{ type: 'text' as const, text: `restart denied: ${result.reason}` }],
           details,
         }
       }
@@ -127,7 +125,7 @@ export function createRestartTool({
       // synchronous (broker.ts deliver()) and SessionManager.appendCustomMessageEntry
       // does a synchronous JSONL write, so the fan-out completes inside this
       // tick — well before the EXIT_DELAY_MS timer fires.
-      const restartedAt = new Date().toISOString()
+      const restartedAt = result.restartedAt
       const broadcast: ContainerRestartingBroadcast = {
         kind: 'container-restarting',
         restartedAt,

--- a/src/agent/tools/restart.ts
+++ b/src/agent/tools/restart.ts
@@ -1,10 +1,7 @@
-import { basename } from 'node:path'
-
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
 import { requestContainerRestart } from '@/agent/restart'
-import { writeRestartHandoff } from '@/agent/restart-handoff'
 import type { Stream } from '@/stream'
 
 const EXIT_DELAY_MS = 500
@@ -59,11 +56,7 @@ export type CreateRestartToolOptions = {
 
 export type RestartToolDetails = { ok: boolean; containerName: string; reason?: string }
 
-export type ContainerRestartingBroadcast = {
-  kind: 'container-restarting'
-  restartedAt: string
-  originatingSessionId: string
-}
+export type { ContainerRestartingBroadcast } from '@/agent/restart'
 
 export function createRestartTool({
   containerName,
@@ -104,13 +97,23 @@ export function createRestartTool({
     }),
     async execute(_toolCallId, params) {
       const build = params.build === true
+      // requestContainerRestart owns the post-ACK broadcast->handoff ordering:
+      // on a successful ACK it publishes the container-restarting notice (which
+      // every live session's subscribeRestartNotice turns into a transcript
+      // entry) and then writes the handoff. Handoff fields are gated to TUI
+      // origins by the caller passing originatingSessionFile only for those —
+      // see issue #291's scoping concerns.
       const result = await requestContainerRestart({
         containerName,
         build,
+        originatingSessionId,
         ...(socketPath !== undefined ? { socketPath } : {}),
         ...(hostdUrl !== undefined ? { hostdUrl } : {}),
         ...(hostdToken !== undefined ? { hostdToken } : {}),
         ...(ackTimeoutMs !== undefined ? { ackTimeoutMs } : {}),
+        ...(stream !== undefined ? { stream } : {}),
+        ...(agentDir !== undefined ? { agentDir } : {}),
+        ...(originatingSessionFile !== undefined ? { originatingSessionFile } : {}),
       })
       if (!result.ok) {
         const details: RestartToolDetails = { ok: false, containerName, reason: result.reason }
@@ -118,36 +121,6 @@ export function createRestartTool({
           content: [{ type: 'text' as const, text: `restart denied: ${result.reason}` }],
           details,
         }
-      }
-
-      // Hostd ACK == restart is committed. Fan out the notice to every live
-      // session BEFORE arming the exit timer. Stream broker delivery is
-      // synchronous (broker.ts deliver()) and SessionManager.appendCustomMessageEntry
-      // does a synchronous JSONL write, so the fan-out completes inside this
-      // tick — well before the EXIT_DELAY_MS timer fires.
-      const restartedAt = result.restartedAt
-      const broadcast: ContainerRestartingBroadcast = {
-        kind: 'container-restarting',
-        restartedAt,
-        originatingSessionId,
-      }
-      stream?.publish({ target: { kind: 'broadcast' }, payload: broadcast })
-
-      // Write the cross-restart handoff AFTER the broadcast has run so the
-      // originating session's JSONL already contains the `typeclaw.restart-self`
-      // custom message entry that the next container will hydrate on
-      // `SessionManager.open`. Without that ordering, the new container could
-      // theoretically open the JSONL before the entry was flushed and miss
-      // the model-instruction the entry carries. Gated on agentDir +
-      // originatingSessionFile so non-TUI origins (channel/cron/subagent)
-      // skip the file write — see issue #291's scoping concerns.
-      if (agentDir !== undefined && originatingSessionFile !== undefined) {
-        await writeRestartHandoff(agentDir, {
-          schemaVersion: 1,
-          restartedAt,
-          originatingSessionId,
-          originatingSessionFile: basename(originatingSessionFile),
-        })
       }
 
       // Schedule the exit on the next tick so the tool result is delivered to

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -130,6 +130,7 @@ async function startWithSession(
     commandRunnerFactory?: (outbound: CommandOutbound) => CommandRunner
     tunnelManager?: TunnelManager
     runtimeVersion?: string
+    containerName?: string
   } = {},
 ): Promise<{ url: string }> {
   const pluginRuntime =
@@ -147,6 +148,7 @@ async function startWithSession(
     ...(extra.commandRunnerFactory ? { commandRunnerFactory: extra.commandRunnerFactory } : {}),
     ...(extra.tunnelManager ? { tunnelManager: extra.tunnelManager } : {}),
     ...(extra.runtimeVersion !== undefined ? { runtimeVersion: extra.runtimeVersion } : {}),
+    ...(extra.containerName !== undefined ? { containerName: extra.containerName } : {}),
   }).start()
   server = built
   return { url: `ws://localhost:${built.port}` }
@@ -434,6 +436,72 @@ describe('createServer abort handling (no stream — fallback path)', () => {
     await waitForState(() => session.abortCalls > 0)
     expect(session.abortCalls).toBe(1)
     ws.close()
+  })
+})
+
+describe('createServer restart handling', () => {
+  test('reports restart unavailable when no container name is configured', async () => {
+    // given
+    const session = createFakeSession()
+    const { url } = await startWithSession(session)
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    // when
+    ws.send(JSON.stringify({ type: 'restart' }))
+
+    // then
+    await expect(waitFor((m) => m.type === 'restart_result')).resolves.toEqual({
+      type: 'restart_result',
+      status: 'failed',
+      error: 'restart unavailable: no container name configured',
+    })
+    ws.close()
+  })
+
+  test('accepts restart when hostd ACKs the container restart RPC', async () => {
+    // given
+    const requests: Array<{ auth: string | null; body: unknown }> = []
+    const hostd = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        requests.push({ auth: req.headers.get('authorization'), body: await req.json() })
+        return Response.json({ ok: true, result: { containerName: 'coder', scheduled: true } })
+      },
+    })
+    const oldUrl = process.env.TYPECLAW_HOSTD_URL
+    const oldToken = process.env.TYPECLAW_HOSTD_TOKEN
+    process.env.TYPECLAW_HOSTD_URL = `http://127.0.0.1:${hostd.port}`
+    process.env.TYPECLAW_HOSTD_TOKEN = 'secret'
+    try {
+      const session = createFakeSession()
+      const { url } = await startWithSession(session, { containerName: 'coder' })
+      const { ws, waitFor } = await connect(url)
+      await waitFor((m) => m.type === 'connected')
+
+      // when
+      ws.send(JSON.stringify({ type: 'restart' }))
+
+      // then
+      await expect(waitFor((m) => m.type === 'restart_result')).resolves.toEqual({
+        type: 'restart_result',
+        status: 'accepted',
+        message: 'restart scheduled; reconnecting when the new container is up',
+      })
+      expect(requests).toEqual([
+        {
+          auth: 'Bearer secret',
+          body: { kind: 'restart', containerName: 'coder', build: false },
+        },
+      ])
+      ws.close()
+    } finally {
+      if (oldUrl === undefined) delete process.env.TYPECLAW_HOSTD_URL
+      else process.env.TYPECLAW_HOSTD_URL = oldUrl
+      if (oldToken === undefined) delete process.env.TYPECLAW_HOSTD_TOKEN
+      else process.env.TYPECLAW_HOSTD_TOKEN = oldToken
+      hostd.stop(true)
+    }
   })
 })
 

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -13,7 +13,7 @@ import { createHookBus, type HookBus, type PluginRegistry } from '@/plugin'
 import { createPluginRuntime, type PluginRuntime } from '@/run/plugin-runtime'
 import { createSessionFactory, type SessionFactory } from '@/sessions'
 import type { ServerMessage, TunnelLogsServerMessage } from '@/shared'
-import { createStream } from '@/stream'
+import { createStream, type StreamMessage } from '@/stream'
 import { expectStable, waitFor as waitForState } from '@/test-helpers/wait-for'
 import type { TunnelManager, TunnelState } from '@/tunnels'
 
@@ -494,6 +494,54 @@ describe('createServer restart handling', () => {
           body: { kind: 'restart', containerName: 'coder', build: false },
         },
       ])
+      ws.close()
+    } finally {
+      if (oldUrl === undefined) delete process.env.TYPECLAW_HOSTD_URL
+      else process.env.TYPECLAW_HOSTD_URL = oldUrl
+      if (oldToken === undefined) delete process.env.TYPECLAW_HOSTD_TOKEN
+      else process.env.TYPECLAW_HOSTD_TOKEN = oldToken
+      hostd.stop(true)
+    }
+  })
+
+  test('publishes the container-restarting notice so the resumed session gets restart-self', async () => {
+    // given: an accepting hostd and a real stream. The server must fan out the
+    // container-restarting broadcast for the originating session — that
+    // broadcast is what subscribeRestartNotice turns into the
+    // typeclaw.restart-self JSONL entry the rebooted container resumes from.
+    const hostd = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ ok: true, result: { containerName: 'coder', scheduled: true } })
+      },
+    })
+    const oldUrl = process.env.TYPECLAW_HOSTD_URL
+    const oldToken = process.env.TYPECLAW_HOSTD_TOKEN
+    process.env.TYPECLAW_HOSTD_URL = `http://127.0.0.1:${hostd.port}`
+    process.env.TYPECLAW_HOSTD_TOKEN = 'secret'
+    try {
+      const stream = createStream()
+      const broadcasts: StreamMessage[] = []
+      stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => broadcasts.push(msg))
+
+      const session = createFakeSession()
+      const { url } = await startWithSession(session, { containerName: 'coder', stream })
+      const { ws, waitFor } = await connect(url)
+      const connected = await waitFor((m) => m.type === 'connected')
+      if (connected.type !== 'connected') throw new Error('unreachable')
+
+      // when
+      ws.send(JSON.stringify({ type: 'restart' }))
+      await waitFor((m) => m.type === 'restart_result')
+
+      // then: the broadcast names the originating session so its
+      // subscribeRestartNotice (covered in agent/index.test.ts) appends
+      // restart-self rather than the sibling notice
+      expect(broadcasts).toHaveLength(1)
+      expect(broadcasts[0]?.payload).toMatchObject({
+        kind: 'container-restarting',
+        originatingSessionId: connected.sessionId,
+      })
       ws.close()
     } finally {
       if (oldUrl === undefined) delete process.env.TYPECLAW_HOSTD_URL

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -654,7 +654,7 @@ export function createServer({
           }
 
           if (msg.type === 'restart') {
-            await handleRestart(ws, state, containerName, agentDir)
+            await handleRestart(ws, state, containerName, agentDir, stream)
             return
           }
 
@@ -1449,6 +1449,7 @@ async function handleRestart(
   state: SessionState | undefined,
   containerName: string | undefined,
   agentDir: string | undefined,
+  stream: Stream | undefined,
 ): Promise<void> {
   if (containerName === undefined) {
     send(ws, {
@@ -1459,12 +1460,18 @@ async function handleRestart(
     return
   }
 
+  // Pass stream so requestContainerRestart fans out the container-restarting
+  // notice — the originating session's subscribeRestartNotice appends the
+  // typeclaw.restart-self entry to its JSONL before the handoff is written, so
+  // the rebooted container resumes with the "I'm back" instruction (same path
+  // the agent restart tool uses).
   const originatingSessionFile = state?.sessionManager?.getSessionFile()
   const result = await requestContainerRestart({
     containerName,
     ...(agentDir !== undefined ? { agentDir } : {}),
     ...(state?.sessionFileId !== undefined ? { originatingSessionId: state.sessionFileId } : {}),
     ...(originatingSessionFile !== undefined ? { originatingSessionFile } : {}),
+    ...(stream !== undefined ? { stream } : {}),
   })
   if (!result.ok) {
     send(ws, { type: 'restart_result', status: 'failed', error: result.reason })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import { runPluginDoctorChecks, runPluginDoctorFix } from '@/agent/doctor'
 import type { LiveSessionRegistry } from '@/agent/live-sessions'
 import type { LiveSubagentRegistry } from '@/agent/live-subagents'
 import { detectProviderError } from '@/agent/provider-error'
+import { requestContainerRestart } from '@/agent/restart'
 import { consumeRestartHandoff, type RestartHandoff } from '@/agent/restart-handoff'
 import type { SessionOrigin } from '@/agent/session-origin'
 import { parseSubagentCompletedPayload, renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
@@ -649,6 +650,11 @@ export function createServer({
 
           if (msg.type === 'reload') {
             await handleReload(ws, reloadAll, reloadRegistry, msg.scope)
+            return
+          }
+
+          if (msg.type === 'restart') {
+            await handleRestart(ws, state, containerName, agentDir)
             return
           }
 
@@ -1436,4 +1442,40 @@ async function handleReload(
       results: [{ scope: 'reload', ok: false, reason: err instanceof Error ? err.message : String(err) }],
     })
   }
+}
+
+async function handleRestart(
+  ws: Ws,
+  state: SessionState | undefined,
+  containerName: string | undefined,
+  agentDir: string | undefined,
+): Promise<void> {
+  if (containerName === undefined) {
+    send(ws, {
+      type: 'restart_result',
+      status: 'failed',
+      error: 'restart unavailable: no container name configured',
+    })
+    return
+  }
+
+  const originatingSessionFile = state?.sessionManager?.getSessionFile()
+  const result = await requestContainerRestart({
+    containerName,
+    ...(agentDir !== undefined ? { agentDir } : {}),
+    ...(state?.sessionFileId !== undefined ? { originatingSessionId: state.sessionFileId } : {}),
+    ...(originatingSessionFile !== undefined ? { originatingSessionFile } : {}),
+  })
+  if (!result.ok) {
+    send(ws, { type: 'restart_result', status: 'failed', error: result.reason })
+    return
+  }
+
+  // hostd's supervisor ACKs first, then runs stop+start in the background;
+  // this process should not self-exit or it could race the daemon-owned stop.
+  send(ws, {
+    type: 'restart_result',
+    status: 'accepted',
+    message: 'restart scheduled; reconnecting when the new container is up',
+  })
 }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -130,6 +130,7 @@ export type InspectServerMessage =
 export type ClientMessage =
   | { type: 'prompt'; text: string; delivery?: PromptDelivery }
   | { type: 'reload'; scope?: string }
+  | { type: 'restart' }
   | { type: 'abort' }
   | { type: 'queue_cancel'; messageId: string }
   | { type: 'doctor'; requestId: DoctorRequestId }
@@ -213,6 +214,7 @@ export type ServerMessage =
   | { type: 'done' }
   | { type: 'error'; message: string }
   | { type: 'reload_result'; results: ReloadResultPayload[] }
+  | { type: 'restart_result'; status: 'accepted' | 'failed'; message?: string; error?: string }
   | { type: 'notification'; payload: unknown; replyTo?: string; meta?: Record<string, string> }
   | { type: 'queue_state'; pending: QueueStateItem[] }
   | { type: 'prompt_started'; messageId: string; text: string }

--- a/src/tui/index.test.ts
+++ b/src/tui/index.test.ts
@@ -480,6 +480,176 @@ describe('createTui', () => {
     expect(client.sent).toEqual([])
   })
 
+  test('/reload sends a reload frame and renders reload results without exiting', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-slash-reload' })
+    let exitCode: number | undefined
+
+    const tui = createTui({
+      url: 'ws://ignored',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+      exit: (code) => {
+        exitCode = code
+      },
+    })
+    const runPromise = tui.run()
+    await flush()
+
+    // when
+    for (const ch of '/reload') terminal.feed(ch)
+    terminal.feed('\r')
+    await flush()
+    client.emit({
+      type: 'reload_result',
+      results: [
+        { scope: 'cron', ok: true, summary: 'loaded 1 job' },
+        { scope: 'channels', ok: false, reason: 'bad config' },
+      ],
+    })
+    await flush()
+
+    // then
+    expect(exitCode).toBeUndefined()
+    expect(client.sent).toEqual([{ type: 'reload' }])
+    expect(client.sent.some((msg) => msg.type === 'prompt')).toBe(false)
+    const visible = terminal.visible()
+    expect(visible).toContain('reloading...')
+    expect(visible).toContain('● [cron] loaded 1 job')
+    expect(visible).toContain('● [channels] bad config')
+
+    client.triggerClose()
+    await runPromise
+  })
+
+  test('/reload with args and //reload are sent as normal prompts', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-slash-reload-literal' })
+
+    const tui = createTui({
+      url: 'ws://ignored',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+    })
+    const runPromise = tui.run()
+    await flush()
+
+    // when
+    for (const ch of '/reload with args') terminal.feed(ch)
+    terminal.feed('\r')
+    await flush()
+    for (const ch of '//reload') terminal.feed(ch)
+    terminal.feed('\r')
+    await flush()
+
+    // then
+    expect(client.sent).toContainEqual({ type: 'prompt', text: '/reload with args' })
+    expect(client.sent).toContainEqual({ type: 'prompt', text: '//reload' })
+    expect(client.sent.some((msg) => msg.type === 'reload')).toBe(false)
+
+    client.triggerClose()
+    await runPromise
+  })
+
+  test('/restart sends a restart frame and renders accepted and failed results without exiting', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-slash-restart' })
+    let exitCode: number | undefined
+
+    const tui = createTui({
+      url: 'ws://ignored',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+      exit: (code) => {
+        exitCode = code
+      },
+    })
+    const runPromise = tui.run()
+    await flush()
+
+    // when
+    for (const ch of '/restart') terminal.feed(ch)
+    terminal.feed('\r')
+    await flush()
+    client.emit({
+      type: 'restart_result',
+      status: 'accepted',
+      message: 'restart scheduled; reconnecting when the new container is up',
+    })
+    await flush()
+    client.emit({ type: 'restart_result', status: 'failed', error: 'denied' })
+    await flush()
+
+    // then
+    expect(exitCode).toBeUndefined()
+    expect(client.sent).toEqual([{ type: 'restart' }])
+    expect(client.sent.some((msg) => msg.type === 'prompt')).toBe(false)
+    const visible = terminal.visible()
+    expect(visible).toContain('restart requested... reconnecting when the new container is up')
+    expect(visible).toContain('restart scheduled; reconnecting when the new container is up')
+    expect(visible).toContain('restart failed: denied')
+
+    client.triggerClose()
+    await runPromise
+  })
+
+  test('reload and restart command matching is case-insensitive and tolerates surrounding whitespace', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-slash-reload-restart-case' })
+
+    const tui = createTui({
+      url: 'ws://ignored',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+    })
+    const runPromise = tui.run()
+    await flush()
+
+    // when
+    for (const ch of '  /RELOAD  ') terminal.feed(ch)
+    terminal.feed('\r')
+    await flush()
+    for (const ch of '  /ReStArT  ') terminal.feed(ch)
+    terminal.feed('\r')
+    await flush()
+
+    // then
+    expect(client.sent).toEqual([{ type: 'reload' }, { type: 'restart' }])
+
+    client.triggerClose()
+    await runPromise
+  })
+
+  test('initialPrompt of /restart sends a restart frame instead of a prompt', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-initial-restart' })
+
+    const tui = createTui({
+      url: 'ws://ignored',
+      initialPrompt: '/restart',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+    })
+    const runPromise = tui.run()
+    await flush()
+
+    // then
+    expect(client.sent).toEqual([{ type: 'restart' }])
+
+    client.triggerClose()
+    await runPromise
+  })
+
   test('does not send abort when Esc is pressed with no reply in flight', async () => {
     // given: connect, finish initial prompt, then idle
     const terminal = new FakeTerminal()

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -11,19 +11,25 @@ export type TerminalFactory = () => Terminal
 
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 30_000
 
-// Bare slash-command names (no leading `/`) the TUI intercepts client-side and
-// turns into a clean process exit. The hatching ritual tells the agent to point
-// users at `/quit` (see src/init/hatching.ts); without an intercept the literal
-// text would be shipped to the LLM as a chat message. Grammar (case-insensitive,
-// whitespace-tolerant, `//foo` escapes to a literal prompt) comes from
-// `parseCommand` in src/commands so channel and TUI slash commands stay
-// consistent. Arguments after the name disqualify the match: `/quit me a story`
-// is a real prompt, not a command.
+// Bare slash-command names (no leading `/`) the TUI intercepts client-side.
+// The hatching ritual tells the agent to point users at `/quit` (see
+// src/init/hatching.ts); without an intercept the literal text would be shipped
+// to the LLM as a chat message. Grammar (case-insensitive, whitespace-tolerant,
+// `//foo` escapes to a literal prompt) comes from `parseCommand` in
+// src/commands so channel and TUI slash commands stay consistent. Arguments
+// after the name disqualify the match: `/quit me a story` is a real prompt, not
+// a command.
 const QUIT_COMMAND_NAMES: ReadonlySet<string> = new Set(['quit', 'exit'])
+const TUI_COMMAND_NAMES: ReadonlySet<TuiCommandName> = new Set(['quit', 'reload', 'restart'])
 
-function isQuitCommand(text: string): boolean {
+type TuiCommandName = 'quit' | 'reload' | 'restart'
+
+function parseBareTuiCommand(text: string): TuiCommandName | null {
   const parsed = parseCommand(text)
-  return parsed !== null && parsed.args.length === 0 && QUIT_COMMAND_NAMES.has(parsed.name)
+  if (parsed === null || parsed.args.length > 0) return null
+  if (QUIT_COMMAND_NAMES.has(parsed.name)) return 'quit'
+  if (TUI_COMMAND_NAMES.has(parsed.name as TuiCommandName)) return parsed.name as TuiCommandName
+  return null
 }
 
 export type VersionMismatch = { expected: string; actual: string }
@@ -203,6 +209,25 @@ export function createTui({
           updateQueuePanel(msg.pending)
           break
         }
+        case 'reload_result': {
+          for (const result of msg.results) {
+            const text = result.ok
+              ? `${colors.green('●')} ${colors.bold(`[${result.scope}]`)} ${result.summary}`
+              : `${colors.red('●')} ${colors.bold(`[${result.scope}]`)} ${result.reason}`
+            appendHistory(new Text(text, 0, 0))
+          }
+          tui.requestRender()
+          break
+        }
+        case 'restart_result': {
+          const text =
+            msg.status === 'accepted'
+              ? colors.green(colors.dim(msg.message ?? 'restart scheduled; reconnecting when the new container is up'))
+              : colors.red(`restart failed: ${msg.error ?? 'unknown error'}`)
+          appendHistory(new Text(text, 0, 0))
+          tui.requestRender()
+          break
+        }
       }
     })
 
@@ -220,6 +245,25 @@ export function createTui({
       return new Promise<void>((resolve) => {
         onReplyDone = resolve
       })
+    }
+
+    function runTuiCommand(command: TuiCommandName): boolean {
+      if (command === 'quit') {
+        shutdown(0)
+        return true
+      }
+      if (command === 'reload') {
+        client.send({ type: 'reload' })
+        appendHistory(new Text(colors.dim('reloading...'), 0, 0))
+        tui.requestRender()
+        return true
+      }
+      client.send({ type: 'restart' })
+      appendHistory(
+        new Text(colors.yellow(colors.dim('restart requested... reconnecting when the new container is up')), 0, 0),
+      )
+      tui.requestRender()
+      return true
     }
 
     // Esc aborts an in-flight reply. The Editor does not bind Esc, so a
@@ -252,8 +296,13 @@ export function createTui({
 
     editor.onSubmit = (text) => {
       if (text.trim().length === 0) return
-      if (isQuitCommand(text)) {
-        shutdown(0)
+      const command = parseBareTuiCommand(text)
+      if (command !== null) {
+        if (command !== 'quit') {
+          editor.setText('')
+          editor.addToHistory(text)
+        }
+        runTuiCommand(command)
         return
       }
       editor.setText('')
@@ -275,13 +324,16 @@ export function createTui({
 
     if (initialPrompt) {
       // initialPrompt bypasses editor.onSubmit, so the quit intercept above
-      // would never run. Guard the same way so `typeclaw tui /quit` exits
-      // instead of leaking the command into the agent's chat context.
-      if (isQuitCommand(initialPrompt)) {
-        shutdown(0)
-        return { lostConnection: false }
+      // would never run. Guard the same way so `typeclaw tui /quit` exits —
+      // and `/reload` / `/restart` stay websocket control frames — instead of
+      // leaking the command into the agent's chat context.
+      const command = parseBareTuiCommand(initialPrompt)
+      if (command !== null) {
+        runTuiCommand(command)
+        if (command === 'quit') return { lostConnection: false }
+      } else {
+        await send(initialPrompt)
       }
-      await send(initialPrompt)
     }
 
     const lostConnection = await closed


### PR DESCRIPTION
## Background

The TUI only intercepts `/quit` (and `/exit`) client-side; every other slash word is shipped to the LLM as chat text. Two host-stage operations had no in-TUI affordance: reloading the agent's reloadable subsystems (you had to drop to a separate `typeclaw reload` shell) and restarting the container (only via the `typeclaw restart` CLI or the agent's own `restart` tool). This adds both as first-class TUI commands so an attached operator can reload config or bounce the container without leaving the session.

## Summary

Both commands are intercepted client-side exactly like `/quit`, but instead of exiting they send a websocket control frame and render the outcome into history — the session stays live.

- **`/reload`** reuses the existing reload path end to end: the TUI sends `{ type: 'reload' }`, the server's existing `handleReload` runs, and the returned `reload_result` is rendered per-scope in the same green/red bullet style as the `typeclaw reload` CLI.

- **`/restart`** is a new WS command. **Why route it through the container server and hostd rather than teaching the TUI to call hostd directly (Option B) or doing stop+start in the host CLI reconnect loop (Option C)?** Stage-separation: the TUI must stay a pure websocket client with no hostd/Docker knowledge. The container→host control boundary already exists and is proven by the agent's own `restart` tool, so the server delegating to hostd is the consistent path. The server calls a shared `requestContainerRestart()` helper (extracted from the restart tool in the first commit) which makes the hostd RPC and writes the restart-handoff file, so the rebooted container resumes the originating session with the existing "I'm back" turn. hostd's supervisor ACKs immediately and runs stop+start in the background, so the server does **not** self-exit — the dropped WS naturally drives the existing 30-attempt reconnect loop in `src/cli/tui.ts`.

The first commit is a pure refactor (extract `requestContainerRestart`, no behavior delta — the tool's existing tests pass unchanged); the second adds the protocol messages, server handler, and TUI wiring.

## What this does NOT do

- No `build`/rebuild flag on the `/restart` TUI command or its protocol message. The agent restart *tool* keeps its `build` option; the TUI command is intentionally the plain stop+start path until there's a single shared hostd contract for build semantics.
- No changes to the `src/cli/tui.ts` reconnect logic — `/restart` relies on the WS dropping to trigger it.
- The TUI gains no hostd or container-name knowledge; all of that stays in the server handler and the shared `src/agent/restart` module.

## Review notes

- Load-bearing decision: the server returns `restart_result: accepted` and does **not** call `process.exit` — see the comment in `handleRestart`. This is deliberate (hostd owns lifecycle teardown); a self-exit could race the daemon-owned stop. Confirmed against `src/hostd/supervisor.ts` / `daemon.ts`.
- `restart_result: accepted` is best-effort — the WS may close before the client renders it; that's fine, the reconnect loop takes over. `failed` keeps the TUI alive and renders a red error.
- Bare-command semantics mirror `/quit`: `/reload foo` (args after the name) and `//reload` (escape) fall through as normal prompts — covered by tests.
