### PR TITLE
docs(recipes): add Recipes section with Code reviewer page

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -6,6 +6,7 @@
       "name": "@typeclaw/docs",
       "dependencies": {
         "@types/mdx": "^2.0.13",
+        "beautiful-mermaid": "^1.1.3",
         "fumadocs-core": "^16.5.0",
         "fumadocs-mdx": "^14.2.6",
         "fumadocs-ui": "^16.5.0",
@@ -411,6 +412,8 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.31", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q=="],
 
+    "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
@@ -451,9 +454,11 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -848,5 +853,7 @@
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
   }
 }

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -1,3 +1,3 @@
 {
-  "pages": ["index", "---", "guides", "concepts", "reference", "internals"]
+  "pages": ["index", "---", "guides", "recipes", "concepts", "reference", "internals"]
 }

--- a/docs/content/docs/recipes/code-reviewer.mdx
+++ b/docs/content/docs/recipes/code-reviewer.mdx
@@ -61,7 +61,7 @@ When it finishes, it **installs the repository webhooks for you** and enables th
 
 ## Scope events to pull-request activity
 
-The default GitHub event allowlist already covers reviews. If you want to narrow it to just the review path, the relevant events are `pull_request.review_requested`, `pull_request_review.submitted`, and `pull_request_review_comment.created`. Tell the agent to tighten `channels.github.eventAllowlist`, or adjust it and run `typeclaw reload`. See [/reference/channel-adapters](/docs/reference/channel-adapters) for the full event list.
+The default GitHub event allowlist already covers reviews. If you want to narrow it to just the review path, the relevant events are `pull_request.review_requested`, `pull_request.review_request_removed`, `pull_request_review.submitted`, and `pull_request_review_comment.created` — keep `review_request_removed` so the agent still sees when a review request is withdrawn. Tell the agent to tighten `channels.github.eventAllowlist`, or adjust it and run `typeclaw reload`. See [/reference/channel-adapters](/docs/reference/channel-adapters) for the full event list.
 
 <Callout type="info" title="App auth and contents:write">
   An App only needs **Pull requests: read/write** to post reviews. Grant **Contents: write** _only_ if the agent will

--- a/docs/content/docs/recipes/code-reviewer.mdx
+++ b/docs/content/docs/recipes/code-reviewer.mdx
@@ -1,0 +1,130 @@
+---
+title: Code reviewer
+description: Request the agent as a PR reviewer and have it post a deep, line-anchored review back to GitHub — no human in the loop
+icon: GitPullRequest
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+Wire the GitHub channel into your repo, request the agent as a reviewer on a pull request, and it runs a deep, line-anchored review through the bundled `reviewer` subagent and posts a formal GitHub review back. No human triggers it; the review request is the trigger.
+
+<Callout type="info" title="This runs in production">
+  <img
+    src="/typeey-cutout.png"
+    alt="Typeey, the TypeClaw mascot"
+    width="64"
+    height="64"
+    style={{ float: 'right', marginLeft: '1rem', marginBottom: '0.5rem' }}
+  />
+  [`@typeey`](https://github.com/typeey) — TypeClaw's own mascot agent — reviews pull requests on
+  [`typeclaw/typeclaw`](https://github.com/typeclaw/typeclaw) exactly this way: request it as a reviewer, it spawns the
+  `reviewer` subagent, posts a formal review. The recipe below is the setup behind that live example.
+</Callout>
+
+This recipe stitches together the GitHub channel adapter, the `reviewer` subagent, a public tunnel for the webhook, and — under GitHub App auth — the decoy-reviewer pattern. Each piece has its own page; this is the assembly.
+
+## How it works
+
+You request the reviewer; the agent does the rest. Under GitHub App auth you request a [decoy account](#set-up-the-decoy-reviewer) that stands in for the bot — that's what fires the webhook. The `reviewer` subagent then analyzes the diff and posts a formal review back to the PR.
+
+```mermaid
+graph LR
+  A[Request the decoy<br/>reviewer on a PR] --> B[GitHub channel<br/>adapter]
+  B --> C[reviewer subagent<br/>analyzes the diff]
+  C --> D[Formal review<br/>posted to the PR]
+```
+
+The sections below set up each hop.
+
+## Wire the GitHub channel
+
+You don't hand-edit `typeclaw.json` for this. Run the wizard from inside your agent folder:
+
+```sh
+typeclaw channel add github
+```
+
+It walks the whole setup interactively:
+
+- **Auth** — pick a fine-grained PAT or a GitHub App. It collects the token (or App ID + private key) and writes them to `secrets.json`, never to `typeclaw.json`.
+- **Tunnel** — GitHub needs a public URL for webhooks. The wizard offers Cloudflare Quick Tunnel (no signup, recommended), a named tunnel, your own external URL, or none. Pick Quick and it provisions the tunnel for you.
+- **Webhook port + secret** — defaults to `8975`; leave the secret blank and it auto-generates one.
+- **Repos** — comma-separated `owner/repo` you want the agent to watch.
+
+When it finishes, it **installs the repository webhooks for you** and enables the adapter. If the container is running, it offers to restart so the change takes effect; otherwise `typeclaw start` picks it up. See [Add a channel](/docs/guides/first-channel) for the shared flow and [/reference/channel-adapters](/docs/reference/channel-adapters) for the GitHub config the wizard writes.
+
+<Callout type="info" title="Or just ask the agent">
+  If the agent is already running with an `owner` paired, you can skip the CLI and ask it in the TUI or a 1:1 DM — _"add
+  the GitHub channel for `owner/repo` using App auth"_ — and let it run the same steps. The CLI is the deterministic
+  path; the agent is the conversational one.
+</Callout>
+
+## Scope events to pull-request activity
+
+The default GitHub event allowlist already covers reviews. If you want to narrow it to just the review path, the relevant events are `pull_request.review_requested`, `pull_request_review.submitted`, and `pull_request_review_comment.created`. Tell the agent to tighten `channels.github.eventAllowlist`, or adjust it and run `typeclaw reload`. See [/reference/channel-adapters](/docs/reference/channel-adapters) for the full event list.
+
+<Callout type="info" title="App auth and contents:write">
+  An App only needs **Pull requests: read/write** to post reviews. Grant **Contents: write** _only_ if the agent will
+  also push fix branches — GitHub bundles branch creation into that scope, so there's no narrower one. Keep a ruleset on
+  `main` that requires pull requests, and the bot opens branches and PRs without ever touching `main` directly. The
+  wizard's permission note lists exactly what to enable.
+</Callout>
+
+## Set up the decoy reviewer
+
+This is the step everyone misses under App auth. **A GitHub App cannot be added as a pull-request reviewer.** The `requested_reviewer` field on a `pull_request.review_requested` webhook only ever holds a real **user** account; the App actor `slug[bot]` is not one, so GitHub never emits a review request targeting an App. The same is true for assignees and `@`-mentions.
+
+The fix is a **decoy user account that impersonates the App** — same display name, same avatar — that you request as the reviewer instead. By convention the decoy is named after the App's slug:
+
+| App slug | Bot actor (posts comments) | Decoy user (you request this) |
+| -------- | -------------------------- | ----------------------------- |
+| `my-app` | `my-app[bot]`              | `my-app`                      |
+
+So for an App whose bot actor is `my-app[bot]`, create a real GitHub user account with the login **`my-app`** and request **`my-app`** as the reviewer on any PR you want looked at. The adapter derives the decoy login by stripping `[bot]` from its own actor and matches the incoming `requested_reviewer.login` against it. Comments still post from the App identity, so the visible reviewer stays consistent.
+
+This is exactly how `@typeey` works: the App's bot actor is `typeey[bot]`, so the decoy account is the real user [`@typeey`](https://github.com/typeey). Requesting `@typeey` on a PR is what wakes the agent.
+
+<Callout type="warn" title="The decoy is the only review trigger">
+  Requesting the decoy (or the bot's team) is the **only** thing that fires a review under App auth. There is no "review
+  every opened PR" behavior — a `pull_request.opened` event lands as awareness-only context. The wake path is
+  `review_requested`, not the assignee `assigned` field.
+</Callout>
+
+<Callout type="info" title="When the slug login was taken">
+  The decoy-login derivation assumes the decoy account's login equals the App slug. If that username was unavailable and
+  you registered `my-app-bot` / `myapp` / etc., see
+  [/internals/github-decoy-reviewer](/docs/internals/github-decoy-reviewer) for the single seam where the login is
+  computed.
+</Callout>
+
+A **PAT-backed** bot needs none of this: it's already a real user you can request by its exact login. Skip straight to the next section.
+
+## The review runs
+
+When the decoy is requested, the agent wakes and delegates the analysis to the bundled **`reviewer`** subagent — read-only tools, a `deep` model profile, and a 5-minute timeout. It's the right delegation target here: `explorer` runs on a fast model and stays shallow, and `operator` needs elevated permissions a public GitHub session doesn't have. The reviewer returns line-anchored findings the agent turns into a review payload. See [/reference/bundled-plugins](/docs/reference/bundled-plugins) for the subagent inventory.
+
+You don't script any of this. The review request lands, the agent reads the diff, spawns the reviewer, and posts back on its own — the same loop `@typeey` runs on every requested PR.
+
+## How the review gets posted
+
+Conversational comments go back through the channel automatically. A **formal review** — approve, request-changes, or inline line comments — is posted through the `gh` CLI, which the adapter pre-authenticates with a `GH_TOKEN` minted for your configured repos. The agent handles this; the notes below are for when you're debugging its output.
+
+<Callout type="warn" title="Single-quote the review body">
+  When the agent posts with `gh api -f body='...'`, single quotes matter. Double quotes let bash run backticks in the
+  markdown (command substitution) and collapse `\n` escapes — which silently corrupts a review body containing `` `code`
+  `` spans. If a posted review reads as mangled, this is the first thing to check.
+</Callout>
+
+<Callout type="info" title="gh may be unauthenticated in-container">
+  If `gh` prompts for `gh auth login` inside a review session, the agent derives App installation auth from
+  `secrets.json`: the App id is `channels.github.auth.appId` and the RSA signing key is
+  `channels.github.auth.privateKey.value` — the `.value`, not the surrounding `privateKey` object.
+</Callout>
+
+## Lock down who can trigger it
+
+Inbound GitHub authors resolve to a role like any other channel. Keep public participants on `guest` with just `channel.respond`, and reserve privileged actions (pushing branches, scheduling cron) for `owner`. To pair yourself as `owner`, run `typeclaw role claim --as owner` and follow the prompt — or, if you're already paired, ask the agent to grant a role via its `grant_role` tool from the TUI or a DM. The review path itself only needs read access plus the ability to post, so a stranger requesting the decoy gets a review — but can't make the agent push to your repo. See [/concepts/permissions-model](/docs/concepts/permissions-model) for why provenance is enforced at the tool boundary.
+
+---
+
+Next: [Schedule a job](/docs/guides/first-cron) — pair the reviewer with a cron prompt to groom issues or summarize PR activity on a schedule.

--- a/docs/content/docs/recipes/meta.json
+++ b/docs/content/docs/recipes/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Recipes",
+  "icon": "ChefHat",
+  "pages": ["code-reviewer"]
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@types/mdx": "^2.0.13",
+    "beautiful-mermaid": "^1.1.3",
     "fumadocs-core": "^16.5.0",
     "fumadocs-mdx": "^14.2.6",
     "fumadocs-ui": "^16.5.0",

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,3 +1,4 @@
+import { remarkMdxMermaid } from 'fumadocs-core/mdx-plugins'
 import { defineDocs, defineConfig } from 'fumadocs-mdx/config'
 
 export const { docs, meta } = defineDocs({
@@ -7,5 +8,6 @@ export const { docs, meta } = defineDocs({
 export default defineConfig({
   mdxOptions: {
     providerImportSource: '@/mdx-components',
+    remarkPlugins: [remarkMdxMermaid],
   },
 })

--- a/docs/src/components/mdx/mermaid.tsx
+++ b/docs/src/components/mdx/mermaid.tsx
@@ -1,0 +1,23 @@
+import { renderMermaidSVG } from 'beautiful-mermaid'
+import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock'
+
+export function Mermaid({ chart }: { chart: string }) {
+  try {
+    const svg = renderMermaidSVG(chart, {
+      bg: 'var(--color-fd-background)',
+      fg: 'var(--color-fd-foreground)',
+      accent: 'var(--color-fd-primary)',
+      muted: 'var(--color-fd-muted-foreground)',
+      surface: 'var(--color-fd-card)',
+      transparent: true,
+    })
+
+    return <div className="my-6 flex justify-center [&_svg]:max-w-full" dangerouslySetInnerHTML={{ __html: svg }} />
+  } catch {
+    return (
+      <CodeBlock title="Mermaid">
+        <Pre>{chart}</Pre>
+      </CodeBlock>
+    )
+  }
+}

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -2,9 +2,12 @@ import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock'
 import defaultMdxComponents from 'fumadocs-ui/mdx'
 import type { MDXComponents } from 'mdx/types'
 
+import { Mermaid } from '@/components/mdx/mermaid'
+
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    Mermaid,
     pre: ({ ref: _, ...props }) => (
       <CodeBlock {...props}>
         <Pre>{props.children}</Pre>


### PR DESCRIPTION
## Background

The docs had no goal-oriented walkthrough surface for topics that stitch multiple features together — they lived entirely in reference pages and individual guide entries. A user who wants to set up a complete workflow like PR code review has to find and mentally assemble three or four separate pages on their own.

The second gap: MDX pages that include architectural diagrams had no native rendering path. Any Mermaid block was either skipped or copy-pasted as an image, making diagrams a manual, drift-prone artifact.

## Summary

**Commit 1 — server-side Mermaid rendering.**
Add `beautiful-mermaid` and a server-rendered `Mermaid` MDX component, wired via `remarkMdxMermaid` from `fumadocs-core`. Any `` ```mermaid `` fenced block in MDX is converted to a themed SVG at build time — no client runtime needed. Colors are wired to the Fumadocs CSS custom properties (`--color-fd-background`, `--color-fd-foreground`, `--color-fd-primary`, etc.) so the diagram automatically respects light and dark themes. If `renderMermaidSVG` throws on a malformed graph, the component falls back to rendering the source as a code block — fail-open for content, never a build error.

Key decisions:
- **Why server-render, not a client component?** No hydration overhead, no layout shift, no client JS bundle contribution. The diagram is static SVG by the time it reaches the browser.
- **Why `beautiful-mermaid` and not `mermaid` + a rehype plugin?** `beautiful-mermaid` exposes a pure synchronous `renderMermaidSVG` call that works in Node at build time without a headless browser. The official `mermaid` package requires a DOM.
- **Why inline CSS vars as theme values?** Fumadocs does not expose Mermaid theme tokens via its theme config; passing the CSS var strings lets the SVG's `style` attributes inherit the correct values at render time without any build-time color extraction.

**Commit 2 — Recipes section + Code reviewer recipe.**
Add a new top-level Recipes section (placed between Guides and Concepts in `content/docs/meta.json`) for goal-oriented, link-heavy walkthroughs that assemble multiple existing features. The first recipe documents the live production setup for PR code review.

## What's in the Code reviewer recipe

The recipe documents the exact setup `@typeey` — TypeClaw's own mascot agent — uses on `typeclaw/typeclaw`: request it as a reviewer on a pull request, it spawns the bundled `reviewer` subagent to do line-anchored analysis, and posts a formal GitHub review back. Nothing human-triggered after the initial wire-up.

Covered in order:

1. **Wire the GitHub channel** via `typeclaw channel add github` — the CLI wizard handles auth (PAT or App), tunnel provisioning, webhook installation, and repo scoping.
2. **Scope events** to the review-request path via `channels.github.eventAllowlist`.
3. **The decoy-reviewer pattern** — a GitHub App cannot be requested as a reviewer directly. A machine account named after the App slug stands in; requesting that account fires the `review_requested` webhook with the App's auth. Explained in prose, a summary table, and a how-it-works diagram.
4. **Output paths** — conversational comments go through `channel_reply`; formal reviews go through `gh api .../pulls/N/reviews`. The recipe shows the single-quoted body quoting required to avoid shell interpolation.
5. **Gotchas** — `gh` may be unauthenticated inside the container by default; the `GH_TOKEN` workaround is called out explicitly.
6. **Role gating** — `grant_role` can restrict reviewer requests to trusted or owner-tier authors.

## Diagram

The how-it-works flow in the recipe (rendered as SVG at build time via the new Mermaid component):

```
Request the decoy reviewer → GitHub channel adapter → reviewer subagent → Formal review posted to PR
```

Left-to-right `graph LR`, themed to match the docs light/dark palette.

## What this does NOT do

- Does not change any runtime behavior, CLI commands, or agent logic.
- Does not add any new channel-adapter configuration options — the recipe documents existing knobs only.
- Does not add a client-side Mermaid fallback; SVG renders at build time or falls back to the raw source code block.
- Does not gate the Recipes section behind any feature flag — it ships as a publicly visible docs section.

## Review notes

- The `Mermaid` component uses `dangerouslySetInnerHTML` to inject the SVG string. The input is the chart source from the author's own MDX, not from user input, so there is no XSS surface here. `renderMermaidSVG` produces a self-contained SVG with no `<script>` tags.
- `remarkMdxMermaid` is added to `source.config.ts` `remarkPlugins` — it runs before the MDX component registry, so the `Mermaid` export in `mdx-components.tsx` is what the remark plugin's output resolves to.
- `meta.json` ordering: `"guides"` → `"recipes"` → `"concepts"` → `"reference"`. The Recipes section appears between Guides and Concepts in the sidebar intentionally — recipes are more task-specific than guides but less structural than concepts.

## Testing

- `bun run lint` — passes (only pre-existing `page.tsx` warnings, not introduced here).
- `bun run format:check` — clean.
- `bun run build` — TypeScript clean; all 46 static pages generated. Server-side Mermaid render runs at build time with no errors.
- Dev server — diagram and page verified visually; light/dark theme switching tracked correctly via the CSS var wiring.