### PR TITLE
feat(dreams): add the `typeclaw dreams` journal viewer

### DIFF
--- a/src/cli/builtins.ts
+++ b/src/cli/builtins.ts
@@ -13,6 +13,7 @@ export const BUILTIN_COMMAND_NAMES = [
   'reload',
   'logs',
   'inspect',
+  'dreams',
   'shell',
   'compose',
   'channel',

--- a/src/cli/dreams.ts
+++ b/src/cli/dreams.ts
@@ -1,0 +1,80 @@
+import { defineCommand } from 'citty'
+
+import { type DreamEntry, renderListRow, runDreams } from '@/dreams'
+import { findAgentDir } from '@/init'
+
+import { cancel, errorLine, isCancel } from './ui'
+
+export const dreamsCommand = defineCommand({
+  meta: {
+    name: 'dreams',
+    description: "browse the dreaming subagent's memory-consolidation journal from git history (host stage)",
+  },
+  args: {
+    limit: {
+      type: 'string',
+      description: 'show at most N most-recent dreams',
+    },
+    json: {
+      type: 'boolean',
+      description: 'emit one JSON object per dream (subject-level)',
+      default: false,
+    },
+    details: {
+      type: 'boolean',
+      description: 'with --json, hydrate each dream with its consolidated fragments/shards/skills',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+    const color = useColor()
+    const limit = parseLimit(args.limit)
+
+    const result = await runDreams({
+      agentDir: cwd,
+      json: args.json === true,
+      details: args.details === true,
+      color,
+      ...(limit !== undefined ? { limit } : {}),
+      selectDream: (entries) => clackSelect(entries, color),
+      stdout: (line) => process.stdout.write(`${line}\n`),
+    })
+
+    if (!result.ok) {
+      process.stderr.write(`${errorLine(result.reason)}\n`)
+      process.exit(result.exitCode)
+    }
+    process.exit(result.exitCode)
+  },
+})
+
+function parseLimit(raw: unknown): number | undefined {
+  if (typeof raw !== 'string') return undefined
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+async function clackSelect(entries: DreamEntry[], color: boolean): Promise<DreamEntry | null> {
+  const { select } = await import('@clack/prompts')
+  const picked = await select<string>({
+    message: `Pick a dream to open (${entries.length} total)`,
+    options: entries.map((entry) => ({
+      value: entry.sha,
+      label: renderListRow(entry, { color }),
+    })),
+    initialValue: entries[0]?.sha,
+  })
+  if (isCancel(picked)) {
+    cancel('Cancelled.')
+    return null
+  }
+  return entries.find((entry) => entry.sha === picked) ?? null
+}
+
+function useColor(): boolean {
+  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') return false
+  if (process.env.FORCE_COLOR === '0') return false
+  if (process.env.FORCE_COLOR) return true
+  return Boolean(process.stdout.isTTY)
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@ const main = defineCommand({
     reload: () => import('./reload').then((m) => m.reload),
     logs: () => import('./logs').then((m) => m.logsCommand),
     inspect: () => import('./inspect').then((m) => m.inspectCommand),
+    dreams: () => import('./dreams').then((m) => m.dreamsCommand),
     shell: () => import('./shell').then((m) => m.shellCommand),
     compose: () => import('./compose').then((m) => m.composeCommand),
     channel: () => import('./channel').then((m) => m.channelCommand),

--- a/src/dreams/git.test.ts
+++ b/src/dreams/git.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { parseLogOutput, readDreamCommitLog, readDreamCommitShow, resolveGitRepo } from './git'
+
+let repo: string
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+  const code = await proc.exited
+  if (code !== 0) throw new Error(`git ${args.join(' ')} failed: ${await new Response(proc.stderr).text()}`)
+}
+
+async function commit(cwd: string, subject: string): Promise<void> {
+  await git(['add', '-A'], cwd)
+  await git(['commit', '-m', subject], cwd)
+}
+
+beforeEach(async () => {
+  repo = await mkdtemp(join(tmpdir(), 'typeclaw-dreams-git-'))
+  await git(['init', '-q', '-b', 'main'], repo)
+  await git(['config', 'user.email', 'test@example.com'], repo)
+  await git(['config', 'user.name', 'Test User'], repo)
+  await git(['config', 'commit.gpgsign', 'false'], repo)
+})
+
+afterEach(async () => {
+  await rm(repo, { recursive: true, force: true })
+})
+
+describe('resolveGitRepo', () => {
+  it('resolves the repo root from a subdirectory', async () => {
+    const sub = join(repo, 'memory', 'topics')
+    await mkdir(sub, { recursive: true })
+    await writeFile(join(repo, 'README.md'), '# x\n')
+    await commit(repo, 'init')
+
+    const res = await resolveGitRepo(sub)
+    expect(res.ok).toBe(true)
+    // git canonicalizes the root (on macOS /var → /private/var), so assert the
+    // resolved root is the git toplevel rather than byte-equal to the tmp path.
+    if (res.ok) expect(res.root.endsWith(repo)).toBe(true)
+  })
+
+  it('reports not-a-repo outside any git tree', async () => {
+    const bare = await mkdtemp(join(tmpdir(), 'typeclaw-dreams-bare-'))
+    try {
+      const res = await resolveGitRepo(bare)
+      expect(res).toEqual({ ok: false, reason: 'not-a-repo' })
+    } finally {
+      await rm(bare, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('readDreamCommitLog', () => {
+  it('lists only dream: commits, newest first', async () => {
+    await writeFile(join(repo, 'a.txt'), 'a\n')
+    await commit(repo, 'feat: not a dream')
+    await mkdir(join(repo, 'memory', 'streams'), { recursive: true })
+    await writeFile(join(repo, 'memory', 'streams', '2026-06-14.jsonl'), '{}\n')
+    await commit(repo, 'dream: 1 fragment 🌙')
+    await writeFile(join(repo, 'memory', 'streams', '2026-06-14.jsonl'), '{}\n{}\n')
+    await commit(repo, 'dream: 2 fragments 🧠')
+
+    const commits = await readDreamCommitLog(repo)
+    expect(commits.map((c) => c.subject)).toEqual(['dream: 2 fragments 🧠', 'dream: 1 fragment 🌙'])
+    for (const c of commits) {
+      expect(c.sha).toMatch(/^[0-9a-f]{40}$/)
+      expect(c.committedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    }
+  })
+
+  it('honors the limit', async () => {
+    for (let i = 0; i < 3; i++) {
+      await writeFile(join(repo, 'f.txt'), `${i}\n`)
+      await commit(repo, `dream: ${i} fragments 💤`)
+    }
+    const commits = await readDreamCommitLog(repo, { limit: 2 })
+    expect(commits).toHaveLength(2)
+  })
+
+  it('returns empty when there are no dream commits', async () => {
+    await writeFile(join(repo, 'a.txt'), 'a\n')
+    await commit(repo, 'chore: nothing to dream about')
+    expect(await readDreamCommitLog(repo)).toEqual([])
+  })
+})
+
+describe('readDreamCommitShow', () => {
+  it('returns name-status and patch for a dream commit', async () => {
+    await mkdir(join(repo, 'memory', 'topics'), { recursive: true })
+    await writeFile(join(repo, 'memory', 'topics', 'deploy.md'), '## Deploy\n\nbody\n')
+    await commit(repo, "dream: new skill 'x' ⭐")
+    const head = await readDreamCommitLog(repo)
+    const show = await readDreamCommitShow(repo, head[0]!.sha)
+    expect(show).not.toBeNull()
+    expect(show?.nameStatus).toContain('memory/topics/deploy.md')
+    expect(show?.patch).toContain('+## Deploy')
+  })
+})
+
+describe('parseLogOutput', () => {
+  it('drops malformed records', () => {
+    const good = `abc\x1fab\x1f2026-06-14T00:00:00Z\x1fdream: 1 fragment\x1e`
+    expect(parseLogOutput(`${good}incomplete-record`)).toEqual([
+      { sha: 'abc', shortSha: 'ab', committedAt: '2026-06-14T00:00:00Z', subject: 'dream: 1 fragment' },
+    ])
+  })
+})

--- a/src/dreams/git.test.ts
+++ b/src/dreams/git.test.ts
@@ -87,6 +87,26 @@ describe('readDreamCommitLog', () => {
     await commit(repo, 'chore: nothing to dream about')
     expect(await readDreamCommitLog(repo)).toEqual([])
   })
+
+  it('excludes a non-dream subject whose body contains a dream: line', async () => {
+    await writeFile(join(repo, 'a.txt'), 'a\n')
+    await git(['add', '-A'], repo)
+    await git(['commit', '-m', 'feat: real subject', '-m', 'dream: 3 fragments 🌙'], repo)
+    expect(await readDreamCommitLog(repo)).toEqual([])
+  })
+
+  it('applies the limit after the subject filter, not before', async () => {
+    await writeFile(join(repo, 'real.txt'), 'x\n')
+    await git(['add', '-A'], repo)
+    await git(['commit', '-m', 'chore: impostor', '-m', 'dream: body line 💤'], repo)
+    await writeFile(join(repo, 'd1.txt'), '1\n')
+    await commit(repo, 'dream: 1 fragment 🧠')
+    await writeFile(join(repo, 'd2.txt'), '2\n')
+    await commit(repo, 'dream: 2 fragments ⭐')
+
+    const limited = await readDreamCommitLog(repo, { limit: 2 })
+    expect(limited.map((c) => c.subject)).toEqual(['dream: 2 fragments ⭐', 'dream: 1 fragment 🧠'])
+  })
 })
 
 describe('readDreamCommitShow', () => {

--- a/src/dreams/git.ts
+++ b/src/dreams/git.ts
@@ -1,0 +1,76 @@
+export type GitResult = { exitCode: number; stdout: string; stderr: string }
+export type SpawnGit = (args: string[], cwd: string) => Promise<GitResult>
+
+export type RawCommit = {
+  sha: string
+  shortSha: string
+  committedAt: string
+  subject: string
+}
+
+export type ResolveRepoResult = { ok: true; root: string } | { ok: false; reason: 'not-a-repo' | 'git-failed' }
+
+const FIELD_SEP = '\x1f'
+const RECORD_SEP = '\x1e'
+
+export async function resolveGitRepo(cwd: string, spawnGit: SpawnGit = defaultSpawnGit): Promise<ResolveRepoResult> {
+  const res = await spawnGit(['rev-parse', '--show-toplevel'], cwd)
+  if (res.exitCode === 0) {
+    const root = res.stdout.trim()
+    if (root.length > 0) return { ok: true, root }
+    return { ok: false, reason: 'git-failed' }
+  }
+  if (/not a git repository/i.test(res.stderr)) return { ok: false, reason: 'not-a-repo' }
+  return { ok: false, reason: 'git-failed' }
+}
+
+export async function readDreamCommitLog(
+  root: string,
+  opts: { limit?: number } = {},
+  spawnGit: SpawnGit = defaultSpawnGit,
+): Promise<RawCommit[]> {
+  const args = ['log', '--grep=^dream: ', `--format=%H${FIELD_SEP}%h${FIELD_SEP}%cI${FIELD_SEP}%s${RECORD_SEP}`]
+  if (opts.limit !== undefined && opts.limit > 0) args.push(`--max-count=${opts.limit}`)
+
+  const res = await spawnGit(args, root)
+  if (res.exitCode !== 0) return []
+  return parseLogOutput(res.stdout)
+}
+
+export function parseLogOutput(stdout: string): RawCommit[] {
+  const commits: RawCommit[] = []
+  for (const record of stdout.split(RECORD_SEP)) {
+    const trimmed = record.replace(/^\n+/, '')
+    if (trimmed.length === 0) continue
+    const [sha, shortSha, committedAt, subject] = trimmed.split(FIELD_SEP)
+    if (sha === undefined || shortSha === undefined || committedAt === undefined || subject === undefined) continue
+    commits.push({ sha, shortSha, committedAt, subject })
+  }
+  return commits
+}
+
+export async function readDreamCommitShow(
+  root: string,
+  sha: string,
+  spawnGit: SpawnGit = defaultSpawnGit,
+): Promise<{ nameStatus: string; patch: string } | null> {
+  const nameStatus = await spawnGit(['show', '--no-color', '--find-renames', '--format=', '--name-status', sha], root)
+  if (nameStatus.exitCode !== 0) return null
+  const patch = await spawnGit(['show', '--no-color', '--format=', '--unified=0', sha], root)
+  if (patch.exitCode !== 0) return null
+  return { nameStatus: nameStatus.stdout, patch: patch.stdout }
+}
+
+const defaultSpawnGit: SpawnGit = async (args, cwd) => {
+  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+  if (!bun) return { exitCode: -1, stdout: '', stderr: 'bun runtime not available' }
+  try {
+    const proc = bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+    return { exitCode, stdout, stderr }
+  } catch (err) {
+    return { exitCode: -1, stdout: '', stderr: err instanceof Error ? err.message : String(err) }
+  }
+}

--- a/src/dreams/git.ts
+++ b/src/dreams/git.ts
@@ -24,17 +24,26 @@ export async function resolveGitRepo(cwd: string, spawnGit: SpawnGit = defaultSp
   return { ok: false, reason: 'git-failed' }
 }
 
+const DREAM_SUBJECT_PREFIX = 'dream: '
+
 export async function readDreamCommitLog(
   root: string,
   opts: { limit?: number } = {},
   spawnGit: SpawnGit = defaultSpawnGit,
 ): Promise<RawCommit[]> {
+  // --grep is only a cheap pre-filter: it matches ANY line of the commit
+  // message, so a non-dream commit with a `dream: ...` body line slips
+  // through. The subject is the authoritative contract, so the prefix filter
+  // below is what actually decides membership — and the limit is applied
+  // AFTER it so body-matching impostors can't consume a slot and shrink the
+  // result below the requested count.
   const args = ['log', '--grep=^dream: ', `--format=%H${FIELD_SEP}%h${FIELD_SEP}%cI${FIELD_SEP}%s${RECORD_SEP}`]
-  if (opts.limit !== undefined && opts.limit > 0) args.push(`--max-count=${opts.limit}`)
 
   const res = await spawnGit(args, root)
   if (res.exitCode !== 0) return []
-  return parseLogOutput(res.stdout)
+  const dreams = parseLogOutput(res.stdout).filter((c) => c.subject.startsWith(DREAM_SUBJECT_PREFIX))
+  if (opts.limit !== undefined && opts.limit > 0) return dreams.slice(0, opts.limit)
+  return dreams
 }
 
 export function parseLogOutput(stdout: string): RawCommit[] {

--- a/src/dreams/index.test.ts
+++ b/src/dreams/index.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { hydrateDream, listDreams, runDreams } from './index'
+
+let repo: string
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+  if ((await proc.exited) !== 0) throw new Error(`git ${args.join(' ')}: ${await new Response(proc.stderr).text()}`)
+}
+
+async function dreamCommit(subject: string, fragments: string[], topics: Record<string, string>): Promise<void> {
+  await mkdir(join(repo, 'memory', 'streams'), { recursive: true })
+  if (fragments.length > 0) {
+    await writeFile(join(repo, 'memory', 'streams', '2026-06-14.jsonl'), `${fragments.join('\n')}\n`)
+  }
+  for (const [slug, body] of Object.entries(topics)) {
+    await mkdir(join(repo, 'memory', 'topics'), { recursive: true })
+    await writeFile(join(repo, 'memory', 'topics', `${slug}.md`), body)
+  }
+  await git(['add', '-A'], repo)
+  await git(['commit', '-m', subject], repo)
+}
+
+function fragment(id: string, topic: string, body: string): string {
+  return JSON.stringify({
+    type: 'fragment',
+    id,
+    ts: '2026-06-14T18:42:03.000Z',
+    source: 'tui',
+    entry: 'e',
+    topic,
+    body,
+  })
+}
+
+beforeEach(async () => {
+  repo = await mkdtemp(join(tmpdir(), 'typeclaw-dreams-idx-'))
+  await git(['init', '-q', '-b', 'main'], repo)
+  await git(['config', 'user.email', 'test@example.com'], repo)
+  await git(['config', 'user.name', 'Test User'], repo)
+  await git(['config', 'commit.gpgsign', 'false'], repo)
+})
+
+afterEach(async () => {
+  await rm(repo, { recursive: true, force: true })
+})
+
+describe('listDreams', () => {
+  it('returns subject-level entries without hydrating detail', async () => {
+    await dreamCommit('dream: 1 fragment 🌙', [fragment('019e-id', 'deploy', 'body')], { deploy: '## Deploy\nx\n' })
+    const entries = await listDreams(repo)
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.summary).toBe('1 fragment')
+    expect(entries[0]?.emoji).toBe('🌙')
+    expect(entries[0]?.detail).toBeUndefined()
+  })
+
+  it('returns empty for a non-git directory without throwing', async () => {
+    const bare = await mkdtemp(join(tmpdir(), 'typeclaw-dreams-nogit-'))
+    try {
+      expect(await listDreams(bare)).toEqual([])
+    } finally {
+      await rm(bare, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('hydrateDream', () => {
+  it('parses the selected commit diff into detail', async () => {
+    await dreamCommit("dream: 1 fragment + new skill 'x' 🧠", [fragment('frag-1', 'deploy', 'always typecheck')], {
+      'release-process': '## Release\nbody\n',
+    })
+    await mkdir(join(repo, 'memory', 'skills', 'x'), { recursive: true })
+    await writeFile(join(repo, 'memory', 'skills', 'x', 'SKILL.md'), '---\nname: x\n---\nbody\n')
+    await git(['add', '-A'], repo)
+    await git(['commit', '--amend', '--no-edit'], repo)
+
+    const [entry] = await listDreams(repo)
+    const hydrated = await hydrateDream(repo, entry!)
+    expect(hydrated.detail?.addedFragments[0]).toMatchObject({
+      id: 'frag-1',
+      topic: 'deploy',
+      streamDate: '2026-06-14',
+    })
+    expect(hydrated.detail?.changedTopics.some((t) => t.slug === 'release-process')).toBe(true)
+    expect(hydrated.detail?.createdSkills).toEqual([{ name: 'x', path: 'memory/skills/x/SKILL.md' }])
+  })
+})
+
+describe('runDreams', () => {
+  it('errors with a friendly reason outside a git repo', async () => {
+    const bare = await mkdtemp(join(tmpdir(), 'typeclaw-dreams-err-'))
+    try {
+      const out: string[] = []
+      const result = await runDreams({
+        agentDir: bare,
+        json: false,
+        details: false,
+        color: false,
+        selectDream: async () => null,
+        stdout: (l) => out.push(l),
+      })
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.reason).toContain('Not a git repository')
+    } finally {
+      await rm(bare, { recursive: true, force: true })
+    }
+  })
+
+  it('emits subject-level JSON in --json mode without detail', async () => {
+    await dreamCommit('dream: 2 fragments 💤', [fragment('a', 't', 'b'), fragment('c', 't', 'd')], {})
+    const out: string[] = []
+    await runDreams({
+      agentDir: repo,
+      json: true,
+      details: false,
+      color: false,
+      selectDream: async () => null,
+      stdout: (l) => out.push(l),
+    })
+    expect(out).toHaveLength(1)
+    const parsed = JSON.parse(out[0]!)
+    expect(parsed.summary).toBe('2 fragments')
+    expect(parsed.detail).toBeUndefined()
+  })
+
+  it('hydrates each dream in --json --details mode', async () => {
+    await dreamCommit('dream: 1 fragment 🌙', [fragment('frag-9', 'deploy', 'always typecheck')], {})
+    const out: string[] = []
+    await runDreams({
+      agentDir: repo,
+      json: true,
+      details: true,
+      color: false,
+      selectDream: async () => null,
+      stdout: (l) => out.push(l),
+    })
+    const parsed = JSON.parse(out[0]!)
+    expect(parsed.detail.addedFragments[0].id).toBe('frag-9')
+  })
+})

--- a/src/dreams/index.ts
+++ b/src/dreams/index.ts
@@ -1,0 +1,109 @@
+import { readDreamCommitLog, readDreamCommitShow, resolveGitRepo, type SpawnGit } from './git'
+import { parseDreamDetail, parseDreamSubject } from './parse'
+import { renderDetail, renderListRow, type RenderOptions, toJsonShape } from './render'
+import type { DreamEntry } from './types'
+
+export type { SpawnGit } from './git'
+export type { DreamEntry } from './types'
+export { renderDetail, renderListRow, toJsonShape } from './render'
+export { parseDreamDetail, parseDreamSubject } from './parse'
+
+export type SelectDream = (entries: DreamEntry[]) => Promise<DreamEntry | null>
+
+export type RunDreamsOptions = {
+  agentDir: string
+  json: boolean
+  details: boolean
+  color: boolean
+  limit?: number
+  selectDream: SelectDream
+  stdout: (line: string) => void
+  spawnGit?: SpawnGit
+}
+
+export type RunDreamsResult = { ok: true; exitCode: 0 } | { ok: false; exitCode: number; reason: string }
+
+export async function listDreams(
+  agentDir: string,
+  opts: { limit?: number } = {},
+  spawnGit?: SpawnGit,
+): Promise<DreamEntry[]> {
+  const repo = await resolveGitRepo(agentDir, spawnGit)
+  if (!repo.ok) return []
+  const commits = await readDreamCommitLog(repo.root, opts.limit !== undefined ? { limit: opts.limit } : {}, spawnGit)
+  return commits.map((commit) => {
+    const subject = parseDreamSubject(commit.subject)
+    return {
+      sha: commit.sha,
+      shortSha: commit.shortSha,
+      subject: commit.subject,
+      committedAt: commit.committedAt,
+      isDreamCommit: subject.isDreamCommit,
+      summary: subject.summary,
+      emoji: subject.emoji,
+      categories: subject.categories,
+    }
+  })
+}
+
+export async function hydrateDream(agentDir: string, entry: DreamEntry, spawnGit?: SpawnGit): Promise<DreamEntry> {
+  const repo = await resolveGitRepo(agentDir, spawnGit)
+  if (!repo.ok) return entry
+  const show = await readDreamCommitShow(repo.root, entry.sha, spawnGit)
+  if (show === null) return entry
+  return { ...entry, detail: parseDreamDetail(show.nameStatus, show.patch) }
+}
+
+export async function runDreams(opts: RunDreamsOptions): Promise<RunDreamsResult> {
+  const repo = await resolveGitRepo(opts.agentDir, opts.spawnGit)
+  if (!repo.ok) {
+    if (repo.reason === 'not-a-repo') {
+      return {
+        ok: false,
+        exitCode: 1,
+        reason:
+          "Not a git repository. Dreams live in the agent folder's git history — run this from your agent folder.",
+      }
+    }
+    return { ok: false, exitCode: 1, reason: 'git failed while resolving the repository root.' }
+  }
+
+  const entries = await listDreams(opts.agentDir, opts.limit !== undefined ? { limit: opts.limit } : {}, opts.spawnGit)
+  const renderOpts: RenderOptions = { color: opts.color }
+
+  if (opts.json) return runJson(opts, repo.root, entries)
+
+  if (entries.length === 0) {
+    opts.stdout('No dreams yet. The dreaming subagent commits here after it consolidates memory.')
+    return { ok: true, exitCode: 0 }
+  }
+
+  if (!isInteractive()) {
+    for (const entry of entries) opts.stdout(renderListRow(entry, renderOpts))
+    return { ok: true, exitCode: 0 }
+  }
+
+  const picked = await opts.selectDream(entries)
+  if (picked === null) return { ok: true, exitCode: 0 }
+  const hydrated = await hydrateDream(opts.agentDir, picked, opts.spawnGit)
+  opts.stdout(renderDetail(hydrated, renderOpts))
+  return { ok: true, exitCode: 0 }
+}
+
+async function runJson(opts: RunDreamsOptions, root: string, entries: DreamEntry[]): Promise<RunDreamsResult> {
+  for (const entry of entries) {
+    const final = opts.details ? await hydrateEntryFromRoot(root, entry, opts.spawnGit) : entry
+    opts.stdout(JSON.stringify(toJsonShape(final)))
+  }
+  return { ok: true, exitCode: 0 }
+}
+
+async function hydrateEntryFromRoot(root: string, entry: DreamEntry, spawnGit?: SpawnGit): Promise<DreamEntry> {
+  const show = await readDreamCommitShow(root, entry.sha, spawnGit)
+  if (show === null) return entry
+  return { ...entry, detail: parseDreamDetail(show.nameStatus, show.patch) }
+}
+
+function isInteractive(): boolean {
+  return Boolean(process.stdout.isTTY) && Boolean(process.stdin.isTTY)
+}

--- a/src/dreams/parse.test.ts
+++ b/src/dreams/parse.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'bun:test'
+
+import { parseDreamDetail, parseDreamSubject } from './parse'
+import { DREAM_EMOJI_POOL } from './types'
+
+describe('parseDreamSubject', () => {
+  it('parses summary and trailing emoji', () => {
+    const r = parseDreamSubject("dream: 3 fragments + new skill 'release-checklist' 🌙")
+    expect(r.isDreamCommit).toBe(true)
+    expect(r.summary).toBe("3 fragments + new skill 'release-checklist'")
+    expect(r.emoji).toBe('🌙')
+    expect(r.categories).toEqual(['fragments', 'skills'])
+  })
+
+  it('handles a dream commit with no emoji', () => {
+    const r = parseDreamSubject('dream: 1 fragment')
+    expect(r.isDreamCommit).toBe(true)
+    expect(r.summary).toBe('1 fragment')
+    expect(r.emoji).toBeNull()
+    expect(r.categories).toEqual(['fragments'])
+  })
+
+  it('classifies watermarks-only and snapshot', () => {
+    expect(parseDreamSubject('dream: watermarks only ⭐').categories).toEqual(['watermarks-only'])
+    expect(parseDreamSubject('dream: snapshot 💤').categories).toEqual(['snapshot'])
+  })
+
+  it('rejects non-dream subjects', () => {
+    const r = parseDreamSubject('feat(agent): add channel_react tool')
+    expect(r.isDreamCommit).toBe(false)
+    expect(r.summary).toBeNull()
+  })
+
+  it('every pool emoji is recognized as a trailing emoji', () => {
+    for (const emoji of DREAM_EMOJI_POOL) {
+      expect(parseDreamSubject(`dream: 2 fragments ${emoji}`).emoji).toBe(emoji)
+    }
+  })
+})
+
+describe('parseDreamDetail', () => {
+  const fragment = (id: string, topic: string, body: string): string =>
+    JSON.stringify({ type: 'fragment', id, ts: '2026-06-14T18:42:03.000Z', source: 'tui', entry: 'e', topic, body })
+
+  it('extracts fragments, topic changes, created skills, and state', () => {
+    const nameStatus = [
+      'A\tmemory/topics/release-process.md',
+      'M\tmemory/topics/commit-discipline.md',
+      'A\tmemory/skills/release-checklist/SKILL.md',
+      'M\tmemory/.dreaming-state.json',
+    ].join('\n')
+
+    const patch = [
+      'diff --git a/memory/streams/2026-06-14.jsonl b/memory/streams/2026-06-14.jsonl',
+      '--- a/memory/streams/2026-06-14.jsonl',
+      '+++ b/memory/streams/2026-06-14.jsonl',
+      '@@ -0,0 +1,1 @@',
+      `+${fragment('019e2eca-6fc5-71ef-add9-67a0955a4b35', 'deploy', 'User always runs typecheck before commit')}`,
+      'diff --git a/memory/topics/commit-discipline.md b/memory/topics/commit-discipline.md',
+      '--- a/memory/topics/commit-discipline.md',
+      '+++ b/memory/topics/commit-discipline.md',
+      '@@ -1,1 +1,4 @@',
+      '+line one',
+      '+line two',
+      '-old line',
+    ].join('\n')
+
+    const detail = parseDreamDetail(nameStatus, patch)
+
+    expect(detail.addedFragments).toHaveLength(1)
+    expect(detail.addedFragments[0]).toMatchObject({
+      id: '019e2eca-6fc5-71ef-add9-67a0955a4b35',
+      streamDate: '2026-06-14',
+      topic: 'deploy',
+    })
+    expect(detail.createdSkills).toEqual([
+      { name: 'release-checklist', path: 'memory/skills/release-checklist/SKILL.md' },
+    ])
+    expect(detail.stateChanged).toBe(true)
+
+    const modified = detail.changedTopics.find((t) => t.slug === 'commit-discipline')
+    expect(modified).toMatchObject({ status: 'modified', additions: 2, deletions: 1 })
+    const added = detail.changedTopics.find((t) => t.slug === 'release-process')
+    expect(added?.status).toBe('added')
+  })
+
+  it('ignores deleted stream lines and watermark events', () => {
+    const patch = [
+      'diff --git a/memory/streams/2026-06-14.jsonl b/memory/streams/2026-06-14.jsonl',
+      '+++ b/memory/streams/2026-06-14.jsonl',
+      '@@ -1,2 +1,1 @@',
+      `-${fragment('deleted-id', 'x', 'gone')}`,
+      `+${JSON.stringify({ type: 'watermark', id: 'w1', ts: '2026-06-14T00:00:00.000Z', source: 's', entry: 'e' })}`,
+    ].join('\n')
+
+    const detail = parseDreamDetail('M\tmemory/streams/2026-06-14.jsonl', patch)
+    expect(detail.addedFragments).toHaveLength(0)
+    expect(detail.parseWarnings).toHaveLength(0)
+  })
+
+  it('warns but keeps going on malformed JSONL', () => {
+    const patch = [
+      'diff --git a/memory/streams/2026-06-14.jsonl b/memory/streams/2026-06-14.jsonl',
+      '+++ b/memory/streams/2026-06-14.jsonl',
+      '@@ -0,0 +1,1 @@',
+      '+{not valid json',
+    ].join('\n')
+
+    const detail = parseDreamDetail('M\tmemory/streams/2026-06-14.jsonl', patch)
+    expect(detail.addedFragments).toHaveLength(0)
+    expect(detail.parseWarnings.length).toBeGreaterThan(0)
+  })
+
+  it('classifies renames from name-status', () => {
+    const detail = parseDreamDetail('R100\tmemory/topics/old.md\tmemory/topics/new.md', '')
+    expect(detail.changedTopics).toEqual([
+      { path: 'memory/topics/new.md', slug: 'new', status: 'renamed', additions: null, deletions: null },
+    ])
+  })
+})

--- a/src/dreams/parse.ts
+++ b/src/dreams/parse.ts
@@ -1,0 +1,224 @@
+import {
+  type DreamCategory,
+  type DreamEmoji,
+  DREAM_EMOJI_POOL,
+  type DreamEntryDetail,
+  type FragmentEventSummary,
+  type ShardChangeStatus,
+  type SkillCreation,
+  type TopicShardChange,
+} from './types'
+
+const BODY_PREVIEW_MAX = 80
+const EMOJI_SET = new Set<string>(DREAM_EMOJI_POOL)
+const STREAM_PATH = /^memory\/(?:streams\/)?(\d{4}-\d{2}-\d{2})\.jsonl$/
+const TOPIC_PATH = /^memory\/topics\/(.+)\.md$/
+const SKILL_PATH = /^memory\/skills\/([^/]+)\/SKILL\.md$/
+const STATE_PATH = 'memory/.dreaming-state.json'
+
+export type DreamSubject = {
+  isDreamCommit: boolean
+  summary: string | null
+  emoji: DreamEmoji | null
+  categories: DreamCategory[]
+}
+
+export function parseDreamSubject(subject: string): DreamSubject {
+  const match = /^dream:\s+(.*)$/.exec(subject)
+  if (match === null) {
+    return { isDreamCommit: false, summary: null, emoji: null, categories: [] }
+  }
+
+  const rest = (match[1] ?? '').trim()
+  const { summary, emoji } = splitTrailingEmoji(rest)
+  return {
+    isDreamCommit: true,
+    summary: summary.length > 0 ? summary : null,
+    emoji,
+    categories: classifySummary(summary),
+  }
+}
+
+function splitTrailingEmoji(rest: string): { summary: string; emoji: DreamEmoji | null } {
+  const chars = [...rest]
+  const last = chars.at(-1)
+  if (last !== undefined && EMOJI_SET.has(last)) {
+    return { summary: chars.slice(0, -1).join('').trim(), emoji: last as DreamEmoji }
+  }
+  return { summary: rest, emoji: null }
+}
+
+function classifySummary(summary: string): DreamCategory[] {
+  const categories: DreamCategory[] = []
+  if (/\bfragments?\b/.test(summary)) categories.push('fragments')
+  if (/\bskills?\b/.test(summary)) categories.push('skills')
+  if (/watermarks only/.test(summary)) categories.push('watermarks-only')
+  if (/^snapshot$/.test(summary)) categories.push('snapshot')
+  if (categories.length === 0) categories.push('other')
+  return categories
+}
+
+export function parseDreamDetail(nameStatus: string, patch: string): DreamEntryDetail {
+  const warnings: string[] = []
+  const changedTopics: TopicShardChange[] = []
+  const createdSkills: SkillCreation[] = []
+  let stateChanged = false
+
+  for (const { status, path, oldPath } of parseNameStatus(nameStatus)) {
+    if (path === STATE_PATH || oldPath === STATE_PATH) {
+      stateChanged = true
+      continue
+    }
+    const topic = TOPIC_PATH.exec(path)
+    if (topic !== null) {
+      changedTopics.push({ path, slug: topic[1] ?? path, status, additions: null, deletions: null })
+      continue
+    }
+    if (status === 'added') {
+      const skill = SKILL_PATH.exec(path)
+      if (skill !== null) createdSkills.push({ name: skill[1] ?? '', path })
+    }
+  }
+
+  applyTopicLineCounts(changedTopics, patch, warnings)
+  const addedFragments = extractAddedFragments(patch, warnings)
+
+  return { addedFragments, changedTopics, createdSkills, stateChanged, parseWarnings: warnings }
+}
+
+type NameStatusRow = { status: ShardChangeStatus; path: string; oldPath: string | null }
+
+function parseNameStatus(nameStatus: string): NameStatusRow[] {
+  const rows: NameStatusRow[] = []
+  for (const line of nameStatus.split('\n')) {
+    if (line.trim().length === 0) continue
+    const cols = line.split('\t')
+    const code = cols[0] ?? ''
+    if (code.startsWith('R')) {
+      const oldPath = cols[1] ?? ''
+      const newPath = cols[2] ?? ''
+      if (newPath.length > 0) rows.push({ status: 'renamed', path: newPath, oldPath })
+      continue
+    }
+    const path = cols[1] ?? ''
+    if (path.length === 0) continue
+    rows.push({ status: mapStatusCode(code), path, oldPath: null })
+  }
+  return rows
+}
+
+function mapStatusCode(code: string): ShardChangeStatus {
+  const c = code.charAt(0)
+  if (c === 'A') return 'added'
+  if (c === 'M') return 'modified'
+  if (c === 'D') return 'deleted'
+  if (c === 'R') return 'renamed'
+  return 'unknown'
+}
+
+type ParsedHunk = { path: string; addedLines: string[] }
+
+function* iterateHunks(patch: string): Generator<ParsedHunk> {
+  let currentPath: string | null = null
+  let added: string[] = []
+  const flush = function* (): Generator<ParsedHunk> {
+    if (currentPath !== null) yield { path: currentPath, addedLines: added }
+  }
+
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('diff --git ')) {
+      yield* flush()
+      currentPath = null
+      added = []
+      continue
+    }
+    if (line.startsWith('+++ ')) {
+      currentPath = stripDiffPathPrefix(line.slice(4))
+      continue
+    }
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      added.push(line.slice(1))
+    }
+  }
+  yield* flush()
+}
+
+function stripDiffPathPrefix(raw: string): string {
+  const trimmed = raw.trim()
+  if (trimmed === '/dev/null') return trimmed
+  return trimmed.replace(/^b\//, '')
+}
+
+function extractAddedFragments(patch: string, warnings: string[]): FragmentEventSummary[] {
+  const out: FragmentEventSummary[] = []
+  for (const hunk of iterateHunks(patch)) {
+    const streamMatch = STREAM_PATH.exec(hunk.path)
+    if (streamMatch === null) continue
+    const streamDate = streamMatch[1] ?? null
+    for (const line of hunk.addedLines) {
+      if (line.trim().length === 0) continue
+      const fragment = parseFragmentLine(line, streamDate)
+      if (fragment === null) {
+        warnings.push(`unparseable stream line in ${hunk.path}`)
+        continue
+      }
+      if (fragment !== 'skip') out.push(fragment)
+    }
+  }
+  return out
+}
+
+function parseFragmentLine(line: string, streamDate: string | null): FragmentEventSummary | 'skip' | null {
+  let raw: unknown
+  try {
+    raw = JSON.parse(line)
+  } catch {
+    return null
+  }
+  if (typeof raw !== 'object' || raw === null) return null
+  const obj = raw as Record<string, unknown>
+  if (obj.type !== 'fragment') return 'skip'
+  if (typeof obj.id !== 'string' || obj.id.length === 0) return null
+  return {
+    id: obj.id,
+    streamDate,
+    topic: typeof obj.topic === 'string' ? obj.topic : null,
+    bodyPreview: typeof obj.body === 'string' ? preview(obj.body) : null,
+  }
+}
+
+function applyTopicLineCounts(topics: TopicShardChange[], patch: string, warnings: string[]): void {
+  if (topics.length === 0) return
+  const counts = new Map<string, { additions: number; deletions: number }>()
+  let currentPath: string | null = null
+
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('+++ ')) {
+      currentPath = stripDiffPathPrefix(line.slice(4))
+      if (currentPath !== null && !counts.has(currentPath)) counts.set(currentPath, { additions: 0, deletions: 0 })
+      continue
+    }
+    if (currentPath === null) continue
+    const bucket = counts.get(currentPath)
+    if (bucket === undefined) continue
+    if (line.startsWith('+') && !line.startsWith('+++')) bucket.additions++
+    else if (line.startsWith('-') && !line.startsWith('---')) bucket.deletions++
+  }
+
+  for (const topic of topics) {
+    if (topic.status === 'deleted') continue
+    const bucket = counts.get(topic.path)
+    if (bucket === undefined) {
+      if (topic.status === 'modified') warnings.push(`no diff hunk for modified topic ${topic.path}`)
+      continue
+    }
+    topic.additions = bucket.additions
+    topic.deletions = bucket.deletions
+  }
+}
+
+function preview(body: string): string {
+  const oneline = body.replace(/\s+/g, ' ').trim()
+  if (oneline.length <= BODY_PREVIEW_MAX) return oneline
+  return `${oneline.slice(0, BODY_PREVIEW_MAX)}…`
+}

--- a/src/dreams/render.test.ts
+++ b/src/dreams/render.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test'
+
+import { renderDetail, renderListRow, toJsonShape } from './render'
+import type { DreamEntry } from './types'
+
+const base: DreamEntry = {
+  sha: 'a3f9c21f0000000000000000000000000000abcd',
+  shortSha: 'a3f9c21',
+  subject: "dream: 3 fragments + new skill 'release-checklist' 🌙",
+  committedAt: '2026-06-14T18:42:03.000Z',
+  isDreamCommit: true,
+  summary: "3 fragments + new skill 'release-checklist'",
+  emoji: '🌙',
+  categories: ['fragments', 'skills'],
+}
+
+describe('renderListRow', () => {
+  it('renders emoji, short sha, and summary without ANSI when color is off', () => {
+    const row = renderListRow(base, { color: false })
+    expect(row).toContain('🌙')
+    expect(row).toContain('a3f9c21')
+    expect(row).toContain("3 fragments + new skill 'release-checklist'")
+    // eslint-disable-next-line no-control-regex
+    expect(row).not.toMatch(/\u001b\[/)
+  })
+})
+
+describe('renderDetail', () => {
+  it('lists fragments, topics, and skills with color off', () => {
+    const entry: DreamEntry = {
+      ...base,
+      detail: {
+        addedFragments: [{ id: 'frag-1', streamDate: '2026-06-14', topic: 'deploy', bodyPreview: 'always typecheck' }],
+        changedTopics: [{ path: 'memory/topics/x.md', slug: 'x', status: 'modified', additions: 4, deletions: 1 }],
+        createdSkills: [{ name: 'release-checklist', path: 'memory/skills/release-checklist/SKILL.md' }],
+        stateChanged: true,
+        parseWarnings: [],
+      },
+    }
+    const out = renderDetail(entry, { color: false })
+    expect(out).toContain('fragments folded in (1)')
+    expect(out).toContain('deploy')
+    expect(out).toContain('always typecheck')
+    expect(out).toContain('+4 −1')
+    expect(out).toContain('release-checklist')
+    expect(out).toContain('.dreaming-state.json advanced')
+  })
+
+  it('shows a quiet-dream line when nothing was consolidated', () => {
+    const entry: DreamEntry = {
+      ...base,
+      summary: 'watermarks only',
+      detail: { addedFragments: [], changedTopics: [], createdSkills: [], stateChanged: true, parseWarnings: [] },
+    }
+    expect(renderDetail(entry, { color: false })).toContain('No fragments promoted')
+  })
+})
+
+describe('toJsonShape', () => {
+  it('omits detail when absent and includes it when present', () => {
+    expect(toJsonShape(base).detail).toBeUndefined()
+    const withDetail = toJsonShape({
+      ...base,
+      detail: { addedFragments: [], changedTopics: [], createdSkills: [], stateChanged: false, parseWarnings: [] },
+    })
+    expect(withDetail.detail).toBeDefined()
+  })
+})

--- a/src/dreams/render.ts
+++ b/src/dreams/render.ts
@@ -1,0 +1,127 @@
+import { styleText } from 'node:util'
+
+import type { DreamEntry, DreamEntryDetail } from './types'
+
+export type RenderOptions = { color: boolean }
+
+type ColorName = 'dim' | 'cyan' | 'green' | 'yellow' | 'magenta' | 'gray'
+
+function tint(opts: RenderOptions, color: ColorName, text: string): string {
+  if (!opts.color) return text
+  return styleText(color, text)
+}
+
+export function renderListRow(entry: DreamEntry, opts: RenderOptions): string {
+  const emoji = entry.emoji ?? '·'
+  const when = tint(opts, 'dim', formatRelative(entry.committedAt))
+  const summary = entry.summary ?? entry.subject
+  return `${emoji}  ${tint(opts, 'cyan', entry.shortSha)}  ${when}  ${summary}`
+}
+
+export function renderDetail(entry: DreamEntry, opts: RenderOptions): string {
+  const lines: string[] = []
+  const emoji = entry.emoji ?? '·'
+  lines.push(`${emoji}  ${entry.subject}`)
+  lines.push(
+    tint(
+      opts,
+      'dim',
+      `${entry.shortSha} · ${formatTimestamp(entry.committedAt)} · ${formatRelative(entry.committedAt)}`,
+    ),
+  )
+
+  const detail = entry.detail
+  if (detail === undefined) {
+    lines.push('', tint(opts, 'dim', '(no detail loaded)'))
+    return lines.join('\n')
+  }
+
+  renderFragments(lines, detail, opts)
+  renderTopics(lines, detail, opts)
+  renderSkills(lines, detail, opts)
+
+  if (detail.stateChanged) lines.push('', tint(opts, 'dim', 'state: .dreaming-state.json advanced'))
+  for (const warning of detail.parseWarnings) lines.push(tint(opts, 'yellow', `⚠ ${warning}`))
+
+  if (isQuietDream(detail)) {
+    lines.push('', tint(opts, 'dim', 'No fragments promoted, no shards changed this run.'))
+  }
+  return lines.join('\n')
+}
+
+function renderFragments(lines: string[], detail: DreamEntryDetail, opts: RenderOptions): void {
+  if (detail.addedFragments.length === 0) return
+  lines.push('', section(opts, `fragments folded in (${detail.addedFragments.length})`))
+  for (const f of detail.addedFragments) {
+    const id = tint(opts, 'dim', `${f.streamDate ?? '????'}#${f.id}`)
+    const topic = f.topic !== null ? tint(opts, 'magenta', ` [${f.topic}]`) : ''
+    lines.push(`• ${id}${topic}`)
+    if (f.bodyPreview !== null) lines.push(`    ${tint(opts, 'gray', `"${f.bodyPreview}"`)}`)
+  }
+}
+
+function renderTopics(lines: string[], detail: DreamEntryDetail, opts: RenderOptions): void {
+  if (detail.changedTopics.length === 0) return
+  lines.push('', section(opts, `topic shards changed (${detail.changedTopics.length})`))
+  for (const t of detail.changedTopics) {
+    const counts =
+      t.additions !== null && t.deletions !== null ? tint(opts, 'dim', ` (+${t.additions} −${t.deletions})`) : ''
+    lines.push(`${statusGlyph(t.status, opts)} ${t.slug}${counts}`)
+  }
+}
+
+function renderSkills(lines: string[], detail: DreamEntryDetail, opts: RenderOptions): void {
+  if (detail.createdSkills.length === 0) return
+  lines.push('', section(opts, `skills distilled (${detail.createdSkills.length})`))
+  for (const s of detail.createdSkills)
+    lines.push(`${tint(opts, 'green', '✦')} ${s.name}  ${tint(opts, 'dim', s.path)}`)
+}
+
+export function toJsonShape(entry: DreamEntry): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    sha: entry.sha,
+    shortSha: entry.shortSha,
+    committedAt: entry.committedAt,
+    subject: entry.subject,
+    isDreamCommit: entry.isDreamCommit,
+    summary: entry.summary,
+    emoji: entry.emoji,
+    categories: entry.categories,
+  }
+  if (entry.detail !== undefined) base.detail = entry.detail
+  return base
+}
+
+function isQuietDream(detail: DreamEntryDetail): boolean {
+  return detail.addedFragments.length === 0 && detail.changedTopics.length === 0 && detail.createdSkills.length === 0
+}
+
+function section(opts: RenderOptions, label: string): string {
+  return tint(opts, 'dim', `── ${label} ──`)
+}
+
+function statusGlyph(status: string, opts: RenderOptions): string {
+  if (status === 'added') return tint(opts, 'green', '✚ added   ')
+  if (status === 'modified') return tint(opts, 'yellow', '✎ modified')
+  if (status === 'deleted') return tint(opts, 'dim', '✖ deleted ')
+  if (status === 'renamed') return tint(opts, 'cyan', '→ renamed ')
+  return '? unknown '
+}
+
+function formatRelative(iso: string): string {
+  const ms = Date.parse(iso)
+  if (Number.isNaN(ms)) return iso
+  const diff = Date.now() - ms
+  if (diff < 60_000) return 'just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  return `${Math.floor(diff / 86_400_000)}d ago`
+}
+
+function formatTimestamp(iso: string): string {
+  const ms = Date.parse(iso)
+  if (Number.isNaN(ms)) return iso
+  const d = new Date(ms)
+  const pad = (n: number): string => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}

--- a/src/dreams/types.ts
+++ b/src/dreams/types.ts
@@ -1,0 +1,50 @@
+// Mirrored from the bundled memory plugin's dreaming subagent rather than
+// imported: this host-stage viewer must stay decoupled from runtime plugin
+// internals, and only needs to RECOGNIZE the emoji set, not own it. The
+// grammar test asserts this list stays in sync with the runtime's pool.
+export const DREAM_EMOJI_POOL = ['💤', '🌙', '⭐', '🛌', '😴', '🧠', '💭', '🔮'] as const
+export type DreamEmoji = (typeof DREAM_EMOJI_POOL)[number]
+
+export type DreamCategory = 'fragments' | 'skills' | 'watermarks-only' | 'snapshot' | 'other'
+
+export type DreamEntry = {
+  sha: string
+  shortSha: string
+  subject: string
+  committedAt: string
+  isDreamCommit: boolean
+  summary: string | null
+  emoji: DreamEmoji | null
+  categories: DreamCategory[]
+  detail?: DreamEntryDetail
+}
+
+export type DreamEntryDetail = {
+  addedFragments: FragmentEventSummary[]
+  changedTopics: TopicShardChange[]
+  createdSkills: SkillCreation[]
+  stateChanged: boolean
+  parseWarnings: string[]
+}
+
+export type FragmentEventSummary = {
+  id: string
+  streamDate: string | null
+  topic: string | null
+  bodyPreview: string | null
+}
+
+export type ShardChangeStatus = 'added' | 'modified' | 'deleted' | 'renamed' | 'unknown'
+
+export type TopicShardChange = {
+  path: string
+  slug: string
+  status: ShardChangeStatus
+  additions: number | null
+  deletions: number | null
+}
+
+export type SkillCreation = {
+  name: string
+  path: string
+}


### PR DESCRIPTION
## Background

The bundled memory plugin ships a "dreaming" subagent that consolidates daily memory fragment streams into long-term topic shards and muscle-memory skills. It persists its results by force-committing into the agent folder's git history, using a subject line of the form `dream: <summary> <emoji>` (emoji drawn from a fixed sleep/cognition pool: 💤🌙⭐🛌😴🧠💭🔮 — so `git log --oneline` reads like a dream journal). Until now, there was no host-stage way to read that history: operators had to run raw `git log` and `git show` themselves. This PR adds `typeclaw dreams`, a read-only browsable viewer for that journal.

## Summary

`typeclaw dreams` is a host-stage subcommand that reads `dream:` commits from the agent folder's git history and surfaces them as a browsable journal — list view on the default terminal path, auto-flat when piped, and `--json` for machines.

**Key decisions:**

- **Eager/lazy split.** The list view is subject-level only (emoji, short SHA, relative time, summary), so it stays fast on agent folders with thousands of commits. The detail view is lazy: only the selected commit's diff is parsed (`git show --name-status` + `--unified=0` patch) to reconstruct what was consolidated — folded-in fragments (id, topic, one-line body preview), topic-shard changes (added/modified/deleted/renamed with +/- line counts), and created skills. `.dreaming-state.json` is treated as noise and surfaced only as `stateChanged`.

- **DREAM_EMOJI_POOL is mirrored in `src/dreams/types.ts`, not imported from the bundled plugin.** The viewer is a host-stage tool; importing from a runtime plugin would couple it to the container stage and break the stage-separation invariant in AGENTS.md.

- **git access mirrors the existing `SpawnGit`/`GitResult` seam from `src/doctor/commit.ts`.** No new generic git abstraction is introduced — the injectable seam already exists, and the same pattern keeps tests straightforward (real git in tmp dirs).

- **Read-only.** No live tailing (unlike `inspect`), no working-tree writes. The dreaming code's `skip-worktree` index flag does not affect `git log`/`git show` history reads, so the viewer is unaffected.

- **Guards.** Not-a-git-repo surfaces a friendly error. Empty history / no dream commits surfaces a friendly notice. Subdir cwd resolves the repo root automatically. Malformed or hand-made memory commits produce warnings but never crash.

## Preview

```sh
# From an agent folder that has dream commits:
typeclaw dreams                   # interactive list → detail picker
typeclaw dreams --limit 20        # cap to last 20

# Non-TTY / piped:
typeclaw dreams | head            # auto-flat list, no picker

# Machine-readable:
typeclaw dreams --json            # subject-level JSON array
typeclaw dreams --json --details  # hydrated entries (fragment/shard/skill breakdown)
```

Example list output:

```
💤 a1b2c3d  3 days ago   consolidate async-patterns and tool-retry shards
🧠 d4e5f6a  1 week ago   create skill: proactive-status-update
🌙 b7c8d9e  2 weeks ago  merge 14 fragments into memory-management shard
```

## What this does NOT do

- No live tailing or streaming — this is a history reader, not an observer.
- No semantic markdown diffing of shard bodies — shard changes are line-count summaries only.
- No extra filters beyond `--limit` — deliberately minimal for v1.
- No new CLI surface other than the `dreams` subcommand and its registration in `builtins`.

## Review notes

- **Load-bearing:** `src/dreams/git.ts` — the `--grep '^dream: '` filter and the `--unified=0` diff parsing. Verify that deleted lines (starting with `-`) and the `+++`/`---` watermark lines are correctly skipped during fragment extraction; the parse tests cover both.
- **CLI/domain split:** `src/cli/dreams.ts` is UI-only and delegates to `src/dreams/index.ts`; no domain logic leaks into the CLI layer, matching the repo's architectural contract.
- **Registration:** `src/cli/builtins.ts` and `src/cli/index.ts` are registration-only changes (one import + one entry each); no logic moved.
- **Tests:** 26 tests across `src/dreams/git.test.ts`, `parse.test.ts`, `render.test.ts`, and `index.test.ts` — all using real git in tmp dirs. Coverage includes: subject grammar and every pool emoji, fragment/topic/skill diff extraction, deleted-line and watermark skipping, malformed-JSONL warnings, rename classification, subdir resolution, not-a-repo guard, eager-list-without-hydration, lazy detail, and both `--json` modes.