### PR TITLE
fix(channels): carry Slack file attachments through history prefetch

### DIFF
--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -182,7 +182,7 @@ function describeSlackMedia(event: SlackInboundMessageEvent): InboundAttachment[
   return (event.files ?? []).map((file, index) => describeSlackFile(file, index + 1))
 }
 
-function describeSlackFile(file: SlackFile, id: number): InboundAttachment {
+export function describeSlackFile(file: SlackFile, id: number): InboundAttachment {
   return {
     id,
     kind: 'file',
@@ -192,7 +192,7 @@ function describeSlackFile(file: SlackFile, id: number): InboundAttachment {
   }
 }
 
-function renderPlaceholder(attachment: InboundAttachment): string {
+export function renderPlaceholder(attachment: InboundAttachment): string {
   const parts: string[] = [`Slack attachment #${attachment.id}: ${attachment.kind}`]
   if (attachment.mimetype !== undefined) parts.push(attachment.mimetype)
   if (attachment.filename !== undefined) parts.push(`name=${attachment.filename}`)

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -698,6 +698,85 @@ describe('createSlackHistoryCallback', () => {
     expect(result.messages.map((m) => m.text)).toEqual(['first', 'second'])
   })
 
+  test('maps files on history messages into attachments and bakes placeholders into text', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [
+        {
+          ts: '1700000000.000100',
+          user: 'UALICE',
+          text: '이 사진 머임??',
+          thread_ts: '1700000000.000100',
+          files: [{ id: 'F123', name: 'photo.png', mimetype: 'image/png' }],
+        },
+      ],
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: '1700000000.000100', limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const msg = result.messages[0]!
+    expect(msg.attachments).toEqual([
+      { id: 1, kind: 'file', ref: 'F123', filename: 'photo.png', mimetype: 'image/png' },
+    ])
+    expect(msg.text).toBe('이 사진 머임??\n[Slack attachment #1: file image/png name=photo.png]')
+  })
+
+  test('omits attachments and leaves text untouched when a history message has no files', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [{ ts: '1.1', user: 'UALICE', text: 'plain text' }],
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const msg = result.messages[0]!
+    expect(msg.attachments).toBeUndefined()
+    expect(msg.text).toBe('plain text')
+  })
+
+  test('renders file-only history message (no text) as placeholder-only text', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [
+        {
+          ts: '1.1',
+          user: 'UALICE',
+          files: [{ id: 'F9', name: 'doc.pdf', mimetype: 'application/pdf' }],
+        },
+      ],
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const msg = result.messages[0]!
+    expect(msg.text).toBe('[Slack attachment #1: file application/pdf name=doc.pdf]')
+    expect(msg.attachments).toHaveLength(1)
+  })
+
   test('marks bot_message subtype as isBot', async () => {
     // given
     const { fn } = fakeFetch({

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -1,4 +1,9 @@
-import { SlackBotClient, SlackBotListener, type SlackSocketModeSlashCommandArgs } from 'agent-messenger/slackbot'
+import {
+  SlackBotClient,
+  SlackBotListener,
+  type SlackFile,
+  type SlackSocketModeSlashCommandArgs,
+} from 'agent-messenger/slackbot'
 
 import {
   MEMBERSHIP_ENUMERATION_CAP,
@@ -28,7 +33,9 @@ import { createSlackAuthorResolver } from './slack-bot-author-resolver'
 import { createSlackChannelResolver } from './slack-bot-channel-resolver'
 import {
   classifyInbound,
+  describeSlackFile,
   type InboundDropReason,
+  renderPlaceholder,
   type SlackInboundAppMentionEvent,
   type SlackInboundMessageEvent,
 } from './slack-bot-classify'
@@ -369,6 +376,7 @@ type SlackRawHistoryMessage = {
   text?: string
   thread_ts?: string
   parent_user_id?: string
+  files?: SlackFile[]
 }
 
 type SlackHistoryResponse = {
@@ -601,14 +609,29 @@ function mapSlackMessage(msg: SlackRawHistoryMessage, botUserId: string | null):
     msg.parent_user_id === botUserId
       ? msg.thread_ts
       : null
+  // The history fetch bypasses the inbound classifier, so files on
+  // already-posted messages (e.g. an image on a thread root the agent is
+  // later @-mentioned under) must be mapped here too — otherwise they are
+  // silently dropped and look_at_channel_attachment can never resolve them.
+  // Mirror splitInbound: bake placeholders into text and carry the structured
+  // attachments so the router can resolve ids.
+  const attachments = (msg.files ?? []).map((file, index) => describeSlackFile(file, index + 1))
+  const rawText = msg.text ?? ''
+  const text =
+    attachments.length === 0
+      ? rawText
+      : rawText === ''
+        ? attachments.map(renderPlaceholder).join('\n')
+        : `${rawText}\n${attachments.map(renderPlaceholder).join('\n')}`
   return {
     externalMessageId: msg.ts,
     authorId: msg.user ?? msg.bot_id ?? 'unknown',
     authorName: msg.user ?? msg.bot_id ?? 'unknown',
-    text: msg.text ?? '',
+    text,
     ts: slackTsToMillis(msg.ts),
     isBot,
     replyToBotMessageId,
+    ...(attachments.length > 0 ? { attachments } : {}),
   }
 }
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5020,6 +5020,41 @@ describe('ChannelRouter cold-start prefetch', () => {
     expect(occurrences).toBe(1)
   })
 
+  test('carries prefetched message attachments into the turn so look_at can resolve them', async () => {
+    // given: a thread root that carried an image, fetched via prefetch
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.registerHistory('discord-bot', async () => ({
+      ok: true,
+      messages: [
+        historyMessage({
+          externalMessageId: 'root',
+          text: '이 사진 머임??\n[Slack attachment #1: file image/png name=photo.png]',
+          attachments: [{ id: 1, kind: 'file', ref: 'F123', filename: 'photo.png', mimetype: 'image/png' }],
+        }),
+      ],
+    }))
+
+    // The attachment is only resolvable mid-turn (currentTurnAttachments is
+    // reset after prompt() returns), so snapshot it the moment prompt() fires —
+    // exactly when the agent's look_at_channel_attachment tool would run.
+    let resolvedMidTurn: ReturnType<typeof router.lookupInboundAttachment> = null
+    let promptDuringTurn = ''
+
+    // when: the agent is later @-mentioned in that thread
+    await router.route(inbound({ thread: 't-A', externalMessageId: 'engage', text: 'hey bot' }))
+    sessions[0]!.onPrompt = (text) => {
+      promptDuringTurn = text
+      resolvedMidTurn = router.lookupInboundAttachment({ ...THREAD_KEY, id: 1 })
+    }
+    await router.__testing!.flushDebounce(THREAD_KEY)
+
+    // then: the placeholder rendered for the model AND the id resolved to the ref
+    expect(promptDuringTurn).toContain('[Slack attachment #1: file image/png name=photo.png]')
+    expect(resolvedMidTurn).not.toBeNull()
+    expect(resolvedMidTurn!.ref).toBe('F123')
+  })
+
   test('emits an elision marker when thread length exceeds head + tail', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir, {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1254,6 +1254,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           receivedAt: now(),
           ts: item.message.ts,
           source: 'prefetch',
+          ...(item.message.attachments !== undefined ? { attachments: item.message.attachments } : {}),
         })
       } else {
         observed.push({


### PR DESCRIPTION
## Background

A multimodal Slack agent was asked, in a thread, what an image was — and replied that it couldn't see any photo. The session transcript shows the agent *correctly* tried: it called `look_at_channel_attachment(attachment_id=1)` and got back:

> `look_at failed: no attachment with id=1 in this turn (no attachments are present in the current turn).`

So this was never a model/vision-capability issue — the model was multimodal and the agent did reach for the right tool. The image was posted on the **thread root**, before the agent was engaged; the agent only learned about that message through **history prefetch** when it was later @-mentioned in the thread. The prefetch path dropped the attachment on two hops, so the channel router had no record any attachment existed:

1. `mapSlackMessage` built `ChannelHistoryMessage` from raw Slack history without mapping `msg.files` — even though `ChannelHistoryMessage` already carries an `attachments` field. Live socket events go through the classifier (`describeSlackMedia`/`splitInbound`) which handles files; the history fetch bypasses that entirely.
2. `prefetchChannelContext` copied only `text` into `ObservedInbound`, discarding the `attachments` array that `lookupInboundAttachment` searches in the context buffer.

Net effect: no `[Slack attachment #N: …]` placeholder rendered (so the model didn't know an image was there), and even a guessed id wouldn't resolve.

## Summary

Close both hops:

- **Slack history adapter** (`mapSlackMessage`): map `msg.files` → `attachments` using the same `describeSlackFile` the live classifier uses, and bake the `[Slack attachment #N: …]` placeholders into the message text. This mirrors the live path's `splitInbound` exactly — reusing the now-exported `describeSlackFile` and `renderPlaceholder` rather than duplicating the formatting, so live and history attachments render identically.
- **Router prefetch** (`prefetchChannelContext`): carry `item.message.attachments` into the seeded `ObservedInbound`. The field and the `lookupInboundAttachment` context-buffer search already existed; prefetch just wasn't populating it.

Why bake placeholders in the adapter rather than the router: placeholder formatting is platform-specific (it's the same string the Slack classifier emits), and the router stays generic — it only carries the structured `attachments` through, matching how observed/queued attachments already flow.

## What this does NOT do

- No change to the vision pipeline itself (`look_at` subagent, `models.vision`). Once the attachment resolves, the existing path works.
- No change to live (non-prefetch) inbound handling — that path was already correct.
- Discord has the same history-prefetch asymmetry and is addressed in a separate PR; Telegram (no history fetch) and KakaoTalk (symmetric) are unaffected.

## Review notes

- Load-bearing changes: the `msg.files` mapping in `mapSlackMessage` and the one-line `attachments` carry-through in `prefetchChannelContext`.
- The router prefetch test asserts resolution **mid-turn** (inside `onPrompt`), because `currentTurnAttachments` is reset after `prompt()` returns — that is exactly the window in which the real `look_at_channel_attachment` tool runs.
- Attachment id numbering stays 1-based per message, consistent with the live classifier and what `lookupInboundAttachment` expects.