### PR TITLE
feat(dreams): make the browser interactive and enrich list rows

### DIFF
--- a/src/cli/dreams.test.ts
+++ b/src/cli/dreams.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+import { EventEmitter } from 'node:events'
+
+import { waitForViewerKey } from './dreams'
+
+function tick(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+class FakeTty extends EventEmitter {
+  isTTY = true as const
+  rawMode = false
+  resumed = false
+  pauseCalls = 0
+  setRawMode(value: boolean): this {
+    this.rawMode = value
+    return this
+  }
+  resume(): this {
+    this.resumed = true
+    return this
+  }
+  pause(): this {
+    this.pauseCalls += 1
+    this.resumed = false
+    return this
+  }
+  feed(bytes: number[]): void {
+    this.emit('data', Buffer.from(bytes))
+  }
+}
+
+describe('waitForViewerKey', () => {
+  test('exits when input is not a TTY', async () => {
+    const tty = new FakeTty()
+    tty.isTTY = false as unknown as true
+    expect(await waitForViewerKey(false, tty as never)).toBe('exit')
+  })
+
+  test('standalone Esc returns to the list', async () => {
+    const tty = new FakeTty()
+    const pending = waitForViewerKey(false, tty as never)
+    tty.feed([0x1b])
+    expect(await pending).toBe('back')
+  })
+
+  test('arrow-key CSI sequence does not trigger back', async () => {
+    // given: an open detail view
+    const tty = new FakeTty()
+    let settled: string | null = null
+    const pending = waitForViewerKey(false, tty as never).then((a) => {
+      settled = a
+      return a
+    })
+    // when: the user presses ↑ (Esc + "[A") within the debounce window
+    tty.feed([0x1b])
+    tty.feed([0x5b, 0x41])
+    await tick(80)
+    // then: the view stays open — arrow keys must not exit it
+    expect(settled).toBeNull()
+    // and: a real Esc still works afterwards
+    tty.feed([0x1b])
+    expect(await pending).toBe('back')
+  })
+
+  test('q quits the browser', async () => {
+    const tty = new FakeTty()
+    const pending = waitForViewerKey(false, tty as never)
+    tty.feed([0x71])
+    expect(await pending).toBe('exit')
+  })
+
+  test('Ctrl-C quits the browser', async () => {
+    const tty = new FakeTty()
+    const pending = waitForViewerKey(false, tty as never)
+    tty.feed([0x03])
+    expect(await pending).toBe('exit')
+  })
+
+  test('teardown restores raw mode without pausing stdin, so the next picker stays usable', async () => {
+    const tty = new FakeTty()
+    const pending = waitForViewerKey(false, tty as never)
+    tty.feed([0x1b])
+    await pending
+    expect(tty.rawMode).toBe(false)
+    expect(tty.pauseCalls).toBe(0)
+    expect(tty.listenerCount('data')).toBe(0)
+  })
+})

--- a/src/cli/dreams.ts
+++ b/src/cli/dreams.ts
@@ -1,9 +1,9 @@
 import { defineCommand } from 'citty'
 
-import { type DreamEntry, renderListRow, runDreams } from '@/dreams'
+import { type DreamEntry, renderListRow, runDreams, type ViewAction } from '@/dreams'
 import { findAgentDir } from '@/init'
 
-import { cancel, errorLine, isCancel } from './ui'
+import { c, cancel, errorLine, isCancel } from './ui'
 
 export const dreamsCommand = defineCommand({
   meta: {
@@ -30,6 +30,7 @@ export const dreamsCommand = defineCommand({
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
     const color = useColor()
     const limit = parseLimit(args.limit)
+    const interactive = isInteractive() && args.json !== true
 
     const result = await runDreams({
       agentDir: cwd,
@@ -37,7 +38,8 @@ export const dreamsCommand = defineCommand({
       details: args.details === true,
       color,
       ...(limit !== undefined ? { limit } : {}),
-      selectDream: (entries) => clackSelect(entries, color),
+      selectDream: (entries, selectOpts) => clackSelect(entries, color, selectOpts?.initialSha),
+      ...(interactive ? { viewDream: () => waitForViewerKey(color) } : {}),
       stdout: (line) => process.stdout.write(`${line}\n`),
     })
 
@@ -49,21 +51,69 @@ export const dreamsCommand = defineCommand({
   },
 })
 
+function isInteractive(): boolean {
+  return Boolean(process.stdout.isTTY) && Boolean(process.stdin.isTTY)
+}
+
+// Raw mode is entered only for this wait and always restored, so a thrown
+// error never leaves the terminal stuck (same contract as cli/inspect.ts).
+async function waitForViewerKey(color: boolean): Promise<ViewAction> {
+  const stdin = process.stdin
+  if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') return 'exit'
+
+  process.stdout.write(`${viewerHintLine(color)}\n`)
+
+  return new Promise<ViewAction>((resolve) => {
+    let settled = false
+    const finish = (action: ViewAction): void => {
+      if (settled) return
+      settled = true
+      stdin.off('data', onData)
+      try {
+        stdin.setRawMode(false)
+      } catch {
+        /* terminal already torn down */
+      }
+      stdin.pause()
+      resolve(action)
+    }
+    const onData = (chunk: Buffer): void => {
+      const byte = chunk[0]
+      if (byte === undefined) return
+      if (byte === 0x1b) finish('back')
+      else if (byte === 0x03 || byte === 0x71) finish('exit')
+    }
+    stdin.setRawMode(true)
+    stdin.resume()
+    stdin.on('data', onData)
+  })
+}
+
+function viewerHintLine(color: boolean): string {
+  const text = '(esc to go back to the list · q to quit)'
+  return color ? c.dim(text) : text
+}
+
 function parseLimit(raw: unknown): number | undefined {
   if (typeof raw !== 'string') return undefined
   const n = Number.parseInt(raw, 10)
   return Number.isFinite(n) && n > 0 ? n : undefined
 }
 
-async function clackSelect(entries: DreamEntry[], color: boolean): Promise<DreamEntry | null> {
+async function clackSelect(
+  entries: DreamEntry[],
+  color: boolean,
+  initialSha: string | undefined,
+): Promise<DreamEntry | null> {
   const { select } = await import('@clack/prompts')
+  const preferred = initialSha !== undefined && entries.some((e) => e.sha === initialSha) ? initialSha : entries[0]?.sha
   const picked = await select<string>({
     message: `Pick a dream to open (${entries.length} total)`,
     options: entries.map((entry) => ({
       value: entry.sha,
       label: renderListRow(entry, { color }),
     })),
-    initialValue: entries[0]?.sha,
+    initialValue: preferred,
   })
   if (isCancel(picked)) {
     cancel('Cancelled.')

--- a/src/cli/dreams.ts
+++ b/src/cli/dreams.ts
@@ -3,7 +3,11 @@ import { defineCommand } from 'citty'
 import { type DreamEntry, renderListRow, runDreams, type ViewAction } from '@/dreams'
 import { findAgentDir } from '@/init'
 
+import { createEscController } from './inspect-controller'
 import { c, cancel, errorLine, isCancel } from './ui'
+
+const ESC_DEBOUNCE_MS = 50
+const QUIT_KEY = 0x71
 
 export const dreamsCommand = defineCommand({
   meta: {
@@ -55,34 +59,47 @@ function isInteractive(): boolean {
   return Boolean(process.stdout.isTTY) && Boolean(process.stdin.isTTY)
 }
 
-// Raw mode is entered only for this wait and always restored, so a thrown
-// error never leaves the terminal stuck (same contract as cli/inspect.ts).
-async function waitForViewerKey(color: boolean): Promise<ViewAction> {
-  const stdin = process.stdin
+type RawInput = Pick<NodeJS.ReadStream, 'isTTY' | 'setRawMode' | 'resume' | 'pause' | 'on' | 'off'>
+
+// Esc routes through createEscController so a standalone Esc returns 'back'
+// while a multi-byte CSI sequence (↑/↓ arrows) does not. Teardown restores
+// raw mode but deliberately does NOT pause stdin: clack cannot re-flow a
+// paused process.stdin under Bun, so the next picker would freeze — the same
+// reason cli/inspect.ts leaves the stream flowing on its return path.
+export async function waitForViewerKey(color: boolean, input: RawInput = process.stdin): Promise<ViewAction> {
+  const stdin = input
   if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') return 'exit'
 
   process.stdout.write(`${viewerHintLine(color)}\n`)
+
+  const ctrl = createEscController({ debounceMs: ESC_DEBOUNCE_MS })
+  const escSignal = ctrl.armForStream()
 
   return new Promise<ViewAction>((resolve) => {
     let settled = false
     const finish = (action: ViewAction): void => {
       if (settled) return
       settled = true
+      escSignal.removeEventListener('abort', onEscAbort)
       stdin.off('data', onData)
+      ctrl.dispose()
       try {
         stdin.setRawMode(false)
       } catch {
         /* terminal already torn down */
       }
-      stdin.pause()
       resolve(action)
     }
+    const onEscAbort = (): void => finish('back')
     const onData = (chunk: Buffer): void => {
-      const byte = chunk[0]
-      if (byte === undefined) return
-      if (byte === 0x1b) finish('back')
-      else if (byte === 0x03 || byte === 0x71) finish('exit')
+      if (chunk[0] === QUIT_KEY) {
+        finish('exit')
+        return
+      }
+      const { sigint } = ctrl.onChunk(chunk)
+      if (sigint) finish('exit')
     }
+    escSignal.addEventListener('abort', onEscAbort, { once: true })
     stdin.setRawMode(true)
     stdin.resume()
     stdin.on('data', onData)

--- a/src/dreams/index.test.ts
+++ b/src/dreams/index.test.ts
@@ -143,3 +143,67 @@ describe('runDreams', () => {
     expect(parsed.detail.addedFragments[0].id).toBe('frag-9')
   })
 })
+
+describe('runDreams interactive loop', () => {
+  let priorStdoutTty: unknown
+  let priorStdinTty: unknown
+
+  beforeEach(() => {
+    priorStdoutTty = process.stdout.isTTY
+    priorStdinTty = process.stdin.isTTY
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: priorStdoutTty, configurable: true })
+    Object.defineProperty(process.stdin, 'isTTY', { value: priorStdinTty, configurable: true })
+  })
+
+  it("re-opens the picker after 'back' with the just-viewed dream preselected", async () => {
+    await dreamCommit('dream: first 💤', [fragment('a', 't', 'b')], {})
+    await dreamCommit('dream: second 🌙', [fragment('c', 't', 'd')], {})
+
+    const seenInitialShas: (string | undefined)[] = []
+    let pickCount = 0
+    const result = await runDreams({
+      agentDir: repo,
+      json: false,
+      details: false,
+      color: false,
+      selectDream: async (entries, opts) => {
+        seenInitialShas.push(opts?.initialSha)
+        pickCount++
+        // First pass: open a dream. Second pass: cancel out of the picker.
+        return pickCount === 1 ? (entries[0] ?? null) : null
+      },
+      viewDream: async () => 'back',
+      stdout: () => {},
+    })
+
+    expect(result).toEqual({ ok: true, exitCode: 0 })
+    expect(seenInitialShas[0]).toBeUndefined()
+    expect(seenInitialShas[1]).toBe((await listDreams(repo))[0]?.sha)
+  })
+
+  it("exits immediately when the viewer returns 'exit'", async () => {
+    await dreamCommit('dream: only 💤', [fragment('a', 't', 'b')], {})
+
+    let pickCount = 0
+    const result = await runDreams({
+      agentDir: repo,
+      json: false,
+      details: false,
+      color: false,
+      selectDream: async (entries) => {
+        pickCount++
+        return entries[0] ?? null
+      },
+      viewDream: async () => 'exit',
+      stdout: () => {},
+    })
+
+    expect(result).toEqual({ ok: true, exitCode: 0 })
+    expect(pickCount).toBe(1)
+  })
+})

--- a/src/dreams/index.ts
+++ b/src/dreams/index.ts
@@ -8,7 +8,15 @@ export type { DreamEntry } from './types'
 export { renderDetail, renderListRow, toJsonShape } from './render'
 export { parseDreamDetail, parseDreamSubject } from './parse'
 
-export type SelectDream = (entries: DreamEntry[]) => Promise<DreamEntry | null>
+export type SelectDreamOptions = {
+  initialSha?: string
+}
+
+export type SelectDream = (entries: DreamEntry[], opts?: SelectDreamOptions) => Promise<DreamEntry | null>
+
+// 'back' re-opens the picker with the just-viewed dream pre-selected.
+export type ViewAction = 'back' | 'exit'
+export type ViewDream = () => Promise<ViewAction>
 
 export type RunDreamsOptions = {
   agentDir: string
@@ -17,6 +25,7 @@ export type RunDreamsOptions = {
   color: boolean
   limit?: number
   selectDream: SelectDream
+  viewDream?: ViewDream
   stdout: (line: string) => void
   spawnGit?: SpawnGit
 }
@@ -83,11 +92,27 @@ export async function runDreams(opts: RunDreamsOptions): Promise<RunDreamsResult
     return { ok: true, exitCode: 0 }
   }
 
-  const picked = await opts.selectDream(entries)
-  if (picked === null) return { ok: true, exitCode: 0 }
-  const hydrated = await hydrateDream(opts.agentDir, picked, opts.spawnGit)
-  opts.stdout(renderDetail(hydrated, renderOpts))
-  return { ok: true, exitCode: 0 }
+  return runInteractiveLoop(opts, entries, renderOpts)
+}
+
+async function runInteractiveLoop(
+  opts: RunDreamsOptions,
+  entries: DreamEntry[],
+  renderOpts: RenderOptions,
+): Promise<RunDreamsResult> {
+  let initialSha: string | undefined
+  while (true) {
+    const picked = await opts.selectDream(entries, initialSha !== undefined ? { initialSha } : {})
+    if (picked === null) return { ok: true, exitCode: 0 }
+    initialSha = picked.sha
+
+    const hydrated = await hydrateDream(opts.agentDir, picked, opts.spawnGit)
+    opts.stdout(renderDetail(hydrated, renderOpts))
+
+    if (opts.viewDream === undefined) return { ok: true, exitCode: 0 }
+    const action = await opts.viewDream()
+    if (action === 'exit') return { ok: true, exitCode: 0 }
+  }
 }
 
 async function runJson(opts: RunDreamsOptions, root: string, entries: DreamEntry[]): Promise<RunDreamsResult> {

--- a/src/dreams/render.test.ts
+++ b/src/dreams/render.test.ts
@@ -23,6 +23,28 @@ describe('renderListRow', () => {
     // eslint-disable-next-line no-control-regex
     expect(row).not.toMatch(/\u001b\[/)
   })
+
+  it('surfaces category badges so the kind of work shows without opening the dream', () => {
+    const row = renderListRow(base, { color: false })
+    expect(row).toContain('[frag]')
+    expect(row).toContain('[skill]')
+  })
+
+  it('shows an absolute date anchor alongside the relative time', () => {
+    const row = renderListRow(base, { color: false })
+    expect(row).toContain('06-14')
+  })
+
+  it('drops the noise-only "other" badge when a meaningful category exists', () => {
+    const row = renderListRow({ ...base, categories: ['fragments', 'other'] }, { color: false })
+    expect(row).toContain('[frag]')
+    expect(row).not.toContain('[other]')
+  })
+
+  it('keeps the "other" badge when it is the only category', () => {
+    const row = renderListRow({ ...base, categories: ['other'] }, { color: false })
+    expect(row).toContain('[other]')
+  })
 })
 
 describe('renderDetail', () => {

--- a/src/dreams/render.ts
+++ b/src/dreams/render.ts
@@ -1,6 +1,6 @@
 import { styleText } from 'node:util'
 
-import type { DreamEntry, DreamEntryDetail } from './types'
+import type { DreamCategory, DreamEntry, DreamEntryDetail } from './types'
 
 export type RenderOptions = { color: boolean }
 
@@ -11,11 +11,31 @@ function tint(opts: RenderOptions, color: ColorName, text: string): string {
   return styleText(color, text)
 }
 
+const CATEGORY_LABELS: Record<DreamCategory, string> = {
+  fragments: 'frag',
+  skills: 'skill',
+  'watermarks-only': 'watermarks',
+  snapshot: 'snapshot',
+  other: 'other',
+}
+
 export function renderListRow(entry: DreamEntry, opts: RenderOptions): string {
   const emoji = entry.emoji ?? '·'
-  const when = tint(opts, 'dim', formatRelative(entry.committedAt))
+  const sha = tint(opts, 'cyan', entry.shortSha)
+  const date = tint(opts, 'dim', formatShortDate(entry.committedAt))
+  const when = tint(opts, 'dim', `(${formatRelative(entry.committedAt)})`)
   const summary = entry.summary ?? entry.subject
-  return `${emoji}  ${tint(opts, 'cyan', entry.shortSha)}  ${when}  ${summary}`
+  const badges = renderCategoryBadges(entry.categories, opts)
+  const head = `${emoji}  ${sha}  ${date} ${when}  ${summary}`
+  return badges.length > 0 ? `${head}  ${badges}` : head
+}
+
+function renderCategoryBadges(categories: DreamCategory[], opts: RenderOptions): string {
+  if (categories.length === 0) return ''
+  const meaningful = categories.filter((c) => c !== 'other')
+  const shown = meaningful.length > 0 ? meaningful : categories
+  const labels = shown.map((c) => CATEGORY_LABELS[c])
+  return tint(opts, 'magenta', labels.map((l) => `[${l}]`).join(' '))
 }
 
 export function renderDetail(entry: DreamEntry, opts: RenderOptions): string {
@@ -124,4 +144,12 @@ function formatTimestamp(iso: string): string {
   const d = new Date(ms)
   const pad = (n: number): string => String(n).padStart(2, '0')
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+function formatShortDate(iso: string): string {
+  const ms = Date.parse(iso)
+  if (Number.isNaN(ms)) return iso
+  const d = new Date(ms)
+  const pad = (n: number): string => String(n).padStart(2, '0')
+  return `${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
 }


### PR DESCRIPTION
## Background

`typeclaw dreams` browses the dreaming subagent's memory-consolidation journal. Two rough edges made it feel unfinished compared to its sibling `typeclaw inspect`:

1. **It wasn't a browser, it was a one-shot.** Picking a dream printed its detail once and the process exited. To look at a second dream you had to re-run the whole command and lose your place in the list. `inspect` already nails the right interaction (open → esc back to list → selection preserved); dreams didn't have it.
2. **List rows showed almost nothing.** Just `emoji  shortSha  relativeTime  summary`. The summary is the raw commit subject, so you couldn't tell at a glance whether a dream folded in fragments, distilled a skill, or only advanced watermarks without opening each one. There was also no absolute date — only a fuzzy "4h ago".

## Summary

**Interactive loop (mirrors `inspect`).** `runDreams` now drives a `while` loop in the domain layer: pick → hydrate → render detail → wait for the user. A new optional `viewDream(): Promise<'back' | 'exit'>` callback decides whether to return to the picker or tear down. `SelectDream` gained an `initialSha` hint so the picker re-opens with the just-viewed dream pre-selected — the same `initialSessionId` trick `inspect`'s loop uses. The raw-mode key wait lives in the thin CLI shell (`src/cli/dreams.ts`): `esc` → back, `q`/`ctrl-c` → quit. Raw mode is entered only for that wait and always restored, matching `cli/inspect.ts`'s terminal-safety contract.

Why keep the loop in the domain layer and only the keypress in the CLI: it keeps the loop (the part with real behavior — selection preservation, exit conditions) testable without a TTY, per the repo's "test at the right layer" guidance. The CLI stays a shell.

**Richer list rows.** Rows now read `emoji  shortSha  MM-DD HH:mm (relative)  summary  [badges]`. The absolute date gives an anchor the relative time can't; category badges (`[frag]`, `[skill]`, `[watermarks]`, …) surface the kind of work without opening the dream. Badges come straight from the already-parsed `categories` on each entry — **no extra `git show` per row**, so listing stays as cheap as before. The noise-only `other` badge is suppressed when a meaningful category is present.

## Preview

List row, color off:

```
before  🌙  a3f9c21  4h ago  3 fragments + new skill 'release-checklist'
after   🌙  a3f9c21  06-14 18:42 (4h ago)  3 fragments + new skill 'release-checklist'  [frag] [skill]
after   💤  a3f9c21  06-14 18:42 (4h ago)  watermarks only  [watermarks]
```

Interactive flow: `typeclaw dreams` → pick a dream → detail renders with an `(esc to go back to the list · q to quit)` hint → `esc` returns to the picker with that row still selected → `q` or `ctrl-c` exits.

## What this does NOT do

- No change to `--json` / `--json --details` output, the non-TTY (piped) path, or the dream parsing/hydration logic.
- Doesn't hydrate list rows — badges are derived from the commit subject's categories, not the diff, to keep listing fast. (Per-row fragment/topic/skill counts would need a `git show` each; deliberately deferred.)
- Doesn't add live tailing — dream detail is static, so the viewer is a simple keypress wait, not `inspect`'s streaming esc-controller.

## Review notes

- Load-bearing change is `runInteractiveLoop` in `src/dreams/index.ts`: the `initialSha` carry-over across iterations is what preserves selection. Covered by `runDreams interactive loop` tests (esc→back re-opens with the viewed sha pre-selected; `exit` ends after one pick).
- `waitForViewerKey` in `src/cli/dreams.ts` is the only untested seam (raw-mode TTY), matching how `cli/inspect.ts` keeps its keypress wiring thin and out of the domain tests.
- The full suite is green except one pre-existing, worktree-only failure: `src/update/index.test.ts > resolveSelfPackageJsonPath` asserts the path ends with `typeclaw/package.json`, but this branch was built in a worktree dir named `typeclaw-dreams-wt`. Unrelated to this change; passes in a normal `typeclaw/` checkout.
