### PR TITLE
fix(channels): carry Discord attachments through history prefetch

### DIFF
--- a/src/channels/adapters/discord-bot-classify.ts
+++ b/src/channels/adapters/discord-bot-classify.ts
@@ -141,7 +141,13 @@ function splitInbound(event: DiscordGatewayMessageCreateEvent): SplitInbound {
   return { text, attachments }
 }
 
-function describeDiscordMedia(event: DiscordGatewayMessageCreateEvent): InboundAttachment[] {
+export type DiscordMediaCarrier = {
+  attachments?: DiscordFile[]
+  embeds?: DiscordGatewayEmbed[]
+  sticker_items?: DiscordGatewayStickerItem[]
+}
+
+export function describeDiscordMedia(event: DiscordMediaCarrier): InboundAttachment[] {
   return [
     ...(event.attachments ?? []).map(describeAttachment),
     ...(event.embeds ?? []).map(describeEmbed),
@@ -167,7 +173,7 @@ function describeSticker(sticker: DiscordGatewayStickerItem): Omit<InboundAttach
   return { kind: 'sticker', ref: '', filename: sticker.name }
 }
 
-function renderPlaceholder(attachment: InboundAttachment): string {
+export function renderPlaceholder(attachment: InboundAttachment): string {
   const parts: string[] = [`Discord attachment #${attachment.id}: ${attachment.kind}`]
   if (attachment.mimetype !== undefined) parts.push(attachment.mimetype)
   if (attachment.filename !== undefined) parts.push(`name=${attachment.filename}`)

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -704,6 +704,92 @@ describe('createDiscordHistoryCallback', () => {
     expect(result.messages.map((m) => m.text)).toEqual(['oldest', 'middle', 'newest'])
   })
 
+  test('maps attachments on history messages into attachments and bakes placeholders into text', async () => {
+    // given
+    const { fn } = fakeFetch([
+      {
+        id: '1',
+        channel_id: 'c1',
+        author: { id: 'u1', username: 'A', bot: false },
+        content: 'what is this?',
+        timestamp: '2026-04-27T00:00:01Z',
+        attachments: [{ url: 'https://cdn.example/photo.png', filename: 'photo.png', content_type: 'image/png' }],
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const msg = result.messages[0]!
+    expect(msg.attachments).toEqual([
+      { id: 1, kind: 'file', ref: 'https://cdn.example/photo.png', filename: 'photo.png', mimetype: 'image/png' },
+    ])
+    expect(msg.text).toBe('what is this?\n[Discord attachment #1: file image/png name=photo.png]')
+  })
+
+  test('omits attachments and leaves text untouched when a history message has no media', async () => {
+    // given
+    const { fn } = fakeFetch([
+      {
+        id: '1',
+        channel_id: 'c1',
+        author: { id: 'u1', username: 'A', bot: false },
+        content: 'plain text',
+        timestamp: '2026-04-27T00:00:01Z',
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const msg = result.messages[0]!
+    expect(msg.attachments).toBeUndefined()
+    expect(msg.text).toBe('plain text')
+  })
+
+  test('renders media-only history message (no text) as placeholder-only text and numbers across media kinds', async () => {
+    // given
+    const { fn } = fakeFetch([
+      {
+        id: '1',
+        channel_id: 'c1',
+        author: { id: 'u1', username: 'A', bot: false },
+        content: '',
+        timestamp: '2026-04-27T00:00:01Z',
+        attachments: [{ url: 'https://cdn.example/a.jpg', filename: 'a.jpg', content_type: 'image/jpeg' }],
+        sticker_items: [{ id: 's1', name: 'wave', format_type: 1 }],
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const msg = result.messages[0]!
+    expect(msg.text).toBe(
+      '[Discord attachment #1: file image/jpeg name=a.jpg]\n[Discord attachment #2: sticker name=wave]',
+    )
+    expect(msg.attachments).toHaveLength(2)
+    expect(msg.attachments!.map((a) => a.id)).toEqual([1, 2])
+  })
+
   test('marks author.bot as isBot', async () => {
     // given
     const { fn } = fakeFetch([

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -1,8 +1,11 @@
 import { DiscordBotClient, DiscordBotListener } from 'agent-messenger/discordbot'
 import {
   DiscordIntent,
+  type DiscordFile,
+  type DiscordGatewayEmbed,
   type DiscordGatewayInteractionEvent,
   type DiscordGatewayMessageCreateEvent,
+  type DiscordGatewayStickerItem,
 } from 'agent-messenger/discordbot'
 
 import {
@@ -29,7 +32,12 @@ import type {
 } from '@/channels/types'
 
 import { createDiscordChannelResolver } from './discord-bot-channel-resolver'
-import { classifyInbound, type InboundDropReason } from './discord-bot-classify'
+import {
+  classifyInbound,
+  describeDiscordMedia,
+  type InboundDropReason,
+  renderPlaceholder,
+} from './discord-bot-classify'
 import {
   ackInteraction,
   parseInteractionAsCommand,
@@ -487,6 +495,9 @@ type DiscordRawHistoryMessage = {
   content: string
   timestamp: string
   message_reference?: { message_id?: string }
+  attachments?: DiscordFile[]
+  embeds?: DiscordGatewayEmbed[]
+  sticker_items?: DiscordGatewayStickerItem[]
 }
 
 // Discord treats threads as separate channels with their own snowflake ids,
@@ -551,14 +562,28 @@ export function createDiscordHistoryCallback(deps: {
 function mapDiscordMessage(msg: DiscordRawHistoryMessage, botUserId: string | null): ChannelHistoryMessage {
   const isBot = msg.author.bot === true || (botUserId !== null && msg.author.id === botUserId)
   const ts = Date.parse(msg.timestamp)
+  // The REST history fetch bypasses the inbound classifier, so attachments,
+  // embeds, and stickers on already-posted messages (e.g. an image on a thread
+  // root the agent is later @-mentioned under) must be mapped here too —
+  // otherwise they are silently dropped and look_at_channel_attachment can
+  // never resolve them. Mirror the classifier's splitInbound: bake placeholders
+  // into text and carry the structured attachments so the router can resolve ids.
+  const attachments = describeDiscordMedia(msg)
+  const text =
+    attachments.length === 0
+      ? msg.content
+      : msg.content === ''
+        ? attachments.map(renderPlaceholder).join('\n')
+        : `${msg.content}\n${attachments.map(renderPlaceholder).join('\n')}`
   return {
     externalMessageId: msg.id,
     authorId: msg.author.id,
     authorName: msg.author.global_name ?? msg.author.username ?? msg.author.id,
-    text: msg.content,
+    text,
     ts: Number.isFinite(ts) ? ts : 0,
     isBot,
     replyToBotMessageId: msg.message_reference?.message_id ?? null,
+    ...(attachments.length > 0 ? { attachments } : {}),
   }
 }
 


### PR DESCRIPTION
## Background

Follow-up to #560 (the Slack version of this bug). After fixing Slack, an audit of the other channel adapters found Discord has the **identical history-prefetch asymmetry**:

- The **live** gateway path (`classifyInbound` → `splitInbound` → `describeDiscordMedia`) correctly extracts `attachments`, `embeds`, and `sticker_items` into the message's `attachments`.
- The **history** path (`mapDiscordMessage`, used by prefetch and membership derivation) built `ChannelHistoryMessage` *without* mapping any of them — the `DiscordRawHistoryMessage` type didn't even declare those fields.

Concretely: an image (or sticker/embed) posted on a thread root before the agent is engaged reaches the agent only through history prefetch when it's later @-mentioned. With the media dropped, no `[Discord attachment #N: …]` placeholder renders and `look_at_channel_attachment` resolves nothing — the agent reports it cannot see the image, exactly as in the Slack case.

Telegram (no history fetch at all) and KakaoTalk (history and live both route through a shared splitter) are unaffected; this is Discord-specific.

## Summary

Mirror the Slack fix:

- **History adapter** (`mapDiscordMessage`): map the raw message's `attachments`/`embeds`/`sticker_items` via the classifier's `describeDiscordMedia`, and bake `[Discord attachment #N: …]` placeholders into the message text — the same shape `splitInbound` produces on the live path.
- **Classifier** (`discord-bot-classify.ts`): export `describeDiscordMedia` and `renderPlaceholder`, and widen `describeDiscordMedia`'s parameter to a structural `DiscordMediaCarrier` so both the gateway event and the raw history message satisfy it. This reuses the live formatting rather than duplicating it, so live and history attachments render identically.

The router-side carry-through (`prefetchChannelContext` copying `attachments` into `ObservedInbound`) landed with #560 and is shared across all adapters, so no router change is needed here.

## What this does NOT do

- No change to the vision pipeline (`look_at` subagent, `models.vision`).
- No change to the live gateway path — it already handled media.
- No change to Telegram or KakaoTalk (not affected).

## Review notes

- Load-bearing change: the `describeDiscordMedia(msg)` call in `mapDiscordMessage` plus the new media fields on `DiscordRawHistoryMessage`.
- `describeDiscordMedia` now takes `DiscordMediaCarrier` (a structural subset) instead of the full gateway event; the gateway event still satisfies it, so the live path is unchanged.
- Attachment id numbering stays 1-based and runs across all media kinds (attachments, then embeds, then stickers), matching the live classifier and what `lookupInboundAttachment` expects.