### PR TITLE
fix(inspect): resume stdin before clack pickers so inspect doesn't freeze over SSH

### DIFF
--- a/src/cli/dreams.ts
+++ b/src/cli/dreams.ts
@@ -4,7 +4,7 @@ import { type DreamEntry, renderListRow, runDreams, type ViewAction } from '@/dr
 import { findAgentDir } from '@/init'
 
 import { createEscController } from './inspect-controller'
-import { c, cancel, errorLine, isCancel } from './ui'
+import { c, cancel, errorLine, isCancel, prepareStdinForClack } from './ui'
 
 const ESC_DEBOUNCE_MS = 50
 const QUIT_KEY = 0x71
@@ -123,6 +123,7 @@ async function clackSelect(
   initialSha: string | undefined,
 ): Promise<DreamEntry | null> {
   const { select } = await import('@clack/prompts')
+  prepareStdinForClack()
   const preferred = initialSha !== undefined && entries.some((e) => e.sha === initialSha) ? initialSha : entries[0]?.sha
   const picked = await select<string>({
     message: `Pick a dream to open (${entries.length} total)`,

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -6,7 +6,7 @@ import { runInspectLoop, streamLive, type LiveSourceFactory, type SessionSummary
 import { originLabel, shortSessionId } from '@/inspect/label'
 
 import { createEscController } from './inspect-controller'
-import { cancel, c, errorLine, isCancel } from './ui'
+import { cancel, c, errorLine, isCancel, prepareStdinForClack } from './ui'
 
 const ESC_LISTEN_DELAY_MS = 50
 
@@ -212,6 +212,7 @@ async function clackSelect(
   initialSessionId: string | undefined,
 ): Promise<SessionSummary | null> {
   const { select } = await import('@clack/prompts')
+  prepareStdinForClack()
   const preferred =
     initialSessionId !== undefined && sessions.some((s) => s.sessionId === initialSessionId)
       ? initialSessionId

--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -7,6 +7,7 @@ import {
   done,
   errorLine,
   link,
+  prepareStdinForClack,
   printDiscordInviteHint,
   printSlackAppManifestSetup,
   renderStartSuccess,
@@ -349,6 +350,68 @@ describe('spinner', () => {
       s.start('working...')
       s.error('boom')
     }).not.toThrow()
+  })
+})
+
+describe('prepareStdinForClack', () => {
+  type FakeStdin = {
+    isTTY: boolean
+    setRawMode?: (value: boolean) => void
+    rawModeCalls: boolean[]
+    resumed: number
+    resume: () => void
+  }
+
+  function fakeStdin(opts: { isTTY: boolean; hasSetRawMode?: boolean; rawModeThrows?: boolean }): FakeStdin {
+    const s: FakeStdin = {
+      isTTY: opts.isTTY,
+      rawModeCalls: [],
+      resumed: 0,
+      resume() {
+        this.resumed += 1
+      },
+    }
+    if (opts.hasSetRawMode !== false) {
+      s.setRawMode = (value: boolean): void => {
+        s.rawModeCalls.push(value)
+        if (opts.rawModeThrows === true) throw new Error('terminal torn down')
+      }
+    }
+    return s
+  }
+
+  test('resumes stdin so a clack picker receives bytes over an SSH pseudo-TTY', () => {
+    // given: a TTY that has never been resumed (the first-picker state over SSH)
+    const stdin = fakeStdin({ isTTY: true })
+    // when: handing stdin to clack
+    prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)
+    // then: the stream is resumed so clack's keypress listener gets input
+    expect(stdin.resumed).toBe(1)
+  })
+
+  test('clears stale raw mode before the picker takes over', () => {
+    const stdin = fakeStdin({ isTTY: true })
+    prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)
+    expect(stdin.rawModeCalls).toEqual([false])
+  })
+
+  test('is a no-op on a non-TTY stdin (piped/redirected input)', () => {
+    const stdin = fakeStdin({ isTTY: false })
+    prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)
+    expect(stdin.resumed).toBe(0)
+    expect(stdin.rawModeCalls).toEqual([])
+  })
+
+  test('still resumes when setRawMode throws (terminal already torn down)', () => {
+    const stdin = fakeStdin({ isTTY: true, rawModeThrows: true })
+    expect(() => prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)).not.toThrow()
+    expect(stdin.resumed).toBe(1)
+  })
+
+  test('resumes even when setRawMode is unavailable on the stream', () => {
+    const stdin = fakeStdin({ isTTY: true, hasSetRawMode: false })
+    expect(() => prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)).not.toThrow()
+    expect(stdin.resumed).toBe(1)
   })
 })
 

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -7,6 +7,28 @@ import { type AutoUpgradeOutcome, describeAutoUpgrade } from '@/init/auto-upgrad
 
 export { cancel, intro, isCancel, log, note, outro }
 
+type ClackInput = Pick<NodeJS.ReadStream, 'isTTY' | 'setRawMode' | 'resume'>
+
+// Hand stdin to a clack picker in a state it can own. Over an SSH pseudo-TTY,
+// Bun's readline keypress wiring only transitions stdin into flowing raw mode
+// reliably once the stream has already been resumed; on a never-resumed stdin
+// the picker renders but arrow keys echo as raw `^[[B` and never advance it.
+// Local terminals dodge this because stdin was already flowing. So before every
+// picker: clear any stale raw mode for a clean baseline, then resume the stream.
+// Never pause() here — a previously-paused process.stdin does not reliably
+// re-flow under Bun, which is the same failure this resume() is fixing.
+export function prepareStdinForClack(input: ClackInput = process.stdin): void {
+  if (!input.isTTY) return
+  if (typeof input.setRawMode === 'function') {
+    try {
+      input.setRawMode(false)
+    } catch {
+      /* terminal already torn down */
+    }
+  }
+  input.resume()
+}
+
 function colorize(modifier: Parameters<typeof styleText>[0], s: string): string {
   if (!colorsEnabled()) return s
   return styleText(modifier, s)


### PR DESCRIPTION
## Background

`typeclaw inspect` freezes on the first interactive session picker when run over SSH: the `@clack/prompts` select renders, but arrow keys echo as raw `^[[B` instead of moving the cursor, and the picker never resolves. The bug does not reproduce on a local terminal, and the second picker (reached by pressing ESC back from a live tail) works correctly.

Root cause: the raw-mode ESC listener (`createEscListener`) calls `process.stdin.resume()` inside its `start()` path, which runs during the live tail — never before the first picker. On a never-resumed stdin, Bun's readline keypress wiring does not reliably transition an SSH pseudo-TTY into flowing raw mode, so clack never receives keypresses; the terminal echoes them in cooked mode instead. Local terminals bypass this because stdin is already flowing. The second picker works because the listener has already resumed stdin by then — which is also why the existing code comments warn against pausing stdin on the picker handoff.

`typeclaw dreams` shares the identical picker shape and carries the same latent bug.

## Summary

Add a shared helper `prepareStdinForClack()` in `src/cli/ui.ts` and call it immediately before every `@clack/prompts` select in `inspect` and `dreams`.

**Why resume and not pause.** A previously-paused `process.stdin` does not re-flow reliably under Bun — the exact failure being fixed. The helper therefore deliberately never calls `pause()`. Existing `escListener` pause/resume around the picker is untouched, so the ESC-back-to-picker path during a live tail continues to work.

**Why a shared helper in `ui.ts` and not inline.** Both `inspect` and `dreams` need the identical handoff contract. Centralising it keeps the rationale in one place and prevents the two callers from drifting apart.

**What the helper does.** On a TTY input stream: clears any stale raw mode via `setRawMode(false)` (wrapped in try/catch for the "terminal already torn down" edge case), then calls `resume()`. On a non-TTY stream it is a no-op. It never pauses.

## What this does NOT do

- Does not replace `@clack/prompts` with a hand-rolled picker. This is the minimal targeted fix; a custom picker would only be warranted if real SSH testing shows this still fails.
- Does not change the ESC / Ctrl-C controller, live-tail signal wiring, or the non-interactive `--json` path.
- Does not globally manipulate other stdin listeners — the call is scoped to the picker handoff only.

## Review notes

- Load-bearing change: `prepareStdinForClack()` in `src/cli/ui.ts`. Invariant: always `resume()` on a TTY, never `pause()`.
- Five regression tests in `src/cli/ui.test.ts` pin the contract: resume on TTY, clear raw mode before resume, no-op on non-TTY, resilience when `setRawMode` throws, resilience when `setRawMode` is absent.
- The full suite passes (59 tests across `src/cli/ui.test.ts`, `src/cli/inspect.test.ts`, `src/inspect/loop.test.ts`). Eight failures in the suite are environmental — a fresh worktree is missing the checked-in generated `*.schema.json` files, causing schema-drift / scaffold / `resolveSelfPackageJobPath` tests to fail. These are unrelated to this change and do not reproduce in a normal checkout.
- Not verified on a live SSH host; the fix targets the documented Bun + SSH pseudo-TTY mechanism. End-to-end SSH verification is the natural next step after merge.