### PR TITLE
Add windowed multi-signature loop guard for interleaved cycles

### DIFF
--- a/src/agent/loop-guard.test.ts
+++ b/src/agent/loop-guard.test.ts
@@ -290,4 +290,69 @@ describe('createLoopGuard — windowed multi-signature detection', () => {
     expect(() => createLoopGuard({ windowSize: 1 })).toThrow()
     expect(() => createLoopGuard({ windowSize: 4, windowHardBlock: 5 })).toThrow()
   })
+
+  // grep/find/ls have an OPTIONAL path that defaults to cwd. Omitting it and
+  // varying only non-target args (pattern/limit) still hits the same directory,
+  // so those calls must coarsen to a single default-target signature.
+  for (const tool of ['grep', 'find', 'ls'] as const) {
+    test(`coarsens omitted-path ${tool} calls to the default target so non-target args cannot evade the guard`, () => {
+      const guard = createLoopGuard({
+        ...noConsecutive,
+        windowSize: 16,
+        windowSoftWarn: 4,
+        windowHardBlock: 6,
+      })
+      const varyingArgs = [
+        { pattern: 'a*' },
+        { pattern: 'b*', limit: 10 },
+        { pattern: 'c*' },
+        { pattern: 'd*', limit: 50 },
+        { pattern: 'e*' },
+        { pattern: 'f*', limit: 5 },
+      ]
+      let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+      for (const args of varyingArgs) last = guard.check('s1', tool, args)
+      expect(last.kind).toBe('block')
+      if (last.kind === 'block') expect(last.reason).toBe('windowed')
+    })
+
+    test(`treats an empty-string path for ${tool} the same as an omitted path`, () => {
+      const guard = createLoopGuard({
+        ...noConsecutive,
+        windowSize: 16,
+        windowSoftWarn: 4,
+        windowHardBlock: 6,
+      })
+      let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+      for (let i = 0; i < 6; i++) last = guard.check('s1', tool, { path: '', pattern: `p${i}*` })
+      expect(last.kind).toBe('block')
+    })
+
+    test(`does not flag omitted-path ${tool} calls against genuinely distinct explicit targets`, () => {
+      const guard = createLoopGuard({
+        ...noConsecutive,
+        windowSize: 16,
+        windowSoftWarn: 4,
+        windowHardBlock: 6,
+      })
+      const dirs = ['src', 'test', 'docs', 'scripts', 'lib', 'bin']
+      for (const path of dirs) {
+        expect(guard.check('s1', tool, { path, pattern: 'x*' }).kind).toBe('ok')
+      }
+    })
+  }
+
+  // read/write/edit require an explicit path, so absence is malformed input, not
+  // a cwd default — they must NOT be coarsened to a shared default target.
+  test('does not coarsen required-path tools (read) to a default target', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    for (let i = 0; i < 8; i++) {
+      expect(guard.check('s1', 'read', { offset: i, limit: 100 }).kind).toBe('ok')
+    }
+  })
 })

--- a/src/agent/loop-guard.test.ts
+++ b/src/agent/loop-guard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { createLoopGuard, LOOP_HARD_BLOCK, LOOP_SOFT_WARN } from './loop-guard'
+import { createLoopGuard, LOOP_HARD_BLOCK, LOOP_SOFT_WARN, WINDOW_HARD_BLOCK, WINDOW_SOFT_WARN } from './loop-guard'
 
 describe('createLoopGuard', () => {
   test('returns ok for the first call with a given signature', () => {
@@ -126,5 +126,168 @@ describe('createLoopGuard', () => {
     expect(() => createLoopGuard({ softWarn: 1, hardBlock: 5 })).toThrow()
     expect(() => createLoopGuard({ softWarn: 5, hardBlock: 5 })).toThrow()
     expect(() => createLoopGuard({ softWarn: 5, hardBlock: 3 })).toThrow()
+  })
+
+  test('consecutive-identical block reports reason "consecutive"', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+    for (let i = 0; i < 5; i++) last = guard.check('s1', 'bash', { command: 'ls' })
+    expect(last.kind).toBe('block')
+    if (last.kind === 'block') expect(last.reason).toBe('consecutive')
+  })
+})
+
+describe('createLoopGuard — windowed multi-signature detection', () => {
+  // High consecutive thresholds isolate the windowed detector: interleaved
+  // calls never repeat back-to-back, so the consecutive tripwire stays dormant.
+  const noConsecutive = { softWarn: 1000, hardBlock: 1001 }
+
+  test('blocks an interleaved cycle that never repeats consecutively', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    const seq = ['a', 'b', 'c', 'b', 'c', 'b', 'a', 'b', 'c', 'b', 'a', 'b']
+    const decisions = seq.map((cmd) => guard.check('s1', 'bash', { command: cmd }))
+    const blocked = decisions.some((d) => d.kind === 'block')
+    expect(blocked).toBe(true)
+  })
+
+  test('windowed block reports reason "windowed"', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+    const seq = ['b', 'x', 'b', 'x', 'b', 'x', 'b', 'x', 'b', 'x', 'b']
+    for (const cmd of seq) last = guard.check('s1', 'bash', { command: cmd })
+    expect(last.kind).toBe('block')
+    if (last.kind === 'block') {
+      expect(last.reason).toBe('windowed')
+      expect(last.message).toContain('bash')
+    }
+  })
+
+  test('emits a windowed warn before the block', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    const decisions: string[] = []
+    const seq = ['b', 'x', 'b', 'x', 'b', 'x', 'b']
+    for (const cmd of seq) decisions.push(guard.check('s1', 'bash', { command: cmd }).kind)
+    expect(decisions).toContain('warn')
+    expect(decisions).not.toContain('block')
+  })
+
+  // Reproduces the real incident: a subagent re-read one transcript with
+  // drifting offsets. Exact-arg signatures saw distinct calls and never tripped;
+  // path-coarsened signatures collapse them so the windowed guard catches it.
+  test('coarsens path-bearing tools so drifting offsets collapse to one signature', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    const offsets = [49, 50, 51, 50, 51, 50]
+    let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+    for (const offset of offsets) {
+      last = guard.check('s1', 'read', { path: '/agent/transcript.jsonl', offset, limit: 100 })
+    }
+    expect(last.kind).toBe('block')
+    if (last.kind === 'block') expect(last.reason).toBe('windowed')
+  })
+
+  test('does not flag legitimate fan-out reads across distinct paths', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    const paths = ['a.ts', 'b.ts', 'c.ts', 'd.ts', 'e.ts', 'f.ts', 'g.ts', 'h.ts']
+    for (const path of paths) {
+      const d = guard.check('s1', 'read', { path, offset: 0, limit: 100 })
+      expect(d.kind).toBe('ok')
+    }
+  })
+
+  test('does not flag productive read/edit alternation on distinct targets', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    const steps: Array<[string, string]> = [
+      ['read', 'a.ts'],
+      ['edit', 'a.ts'],
+      ['read', 'b.ts'],
+      ['edit', 'b.ts'],
+      ['read', 'c.ts'],
+      ['edit', 'c.ts'],
+    ]
+    for (const [tool, path] of steps) {
+      const d = guard.check('s1', tool, { path })
+      expect(d.kind).toBe('ok')
+    }
+  })
+
+  test('only the last windowSize calls count toward a signature', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 4,
+      windowSoftWarn: 3,
+      windowHardBlock: 4,
+    })
+    const olderThanWindow = ['b', 'b']
+    const fillersFillingWindow = ['p', 'q', 'r']
+    for (const cmd of [...olderThanWindow, ...fillersFillingWindow]) {
+      guard.check('s1', 'bash', { command: cmd })
+    }
+    expect(guard.check('s1', 'bash', { command: 'b' }).kind).toBe('ok')
+  })
+
+  test('keeps windows per session independent', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    for (let i = 0; i < 5; i++) guard.check('s1', 'bash', { command: 'b' })
+    expect(guard.check('s2', 'bash', { command: 'b' }).kind).toBe('ok')
+  })
+
+  test('forget(sessionId) clears the windowed history', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    for (let i = 0; i < 5; i++) guard.check('s1', 'bash', { command: 'b' })
+    guard.forget('s1')
+    expect(guard.check('s1', 'bash', { command: 'b' }).kind).toBe('ok')
+  })
+
+  test('exports default windowed thresholds with a usable ordering', () => {
+    expect(WINDOW_SOFT_WARN).toBeGreaterThanOrEqual(2)
+    expect(WINDOW_HARD_BLOCK).toBeGreaterThan(WINDOW_SOFT_WARN)
+  })
+
+  test('rejects invalid windowed thresholds at construction time', () => {
+    expect(() => createLoopGuard({ windowSoftWarn: 1, windowHardBlock: 6 })).toThrow()
+    expect(() => createLoopGuard({ windowSoftWarn: 6, windowHardBlock: 6 })).toThrow()
+    expect(() => createLoopGuard({ windowSoftWarn: 6, windowHardBlock: 4 })).toThrow()
+    expect(() => createLoopGuard({ windowSize: 1 })).toThrow()
+    expect(() => createLoopGuard({ windowSize: 4, windowHardBlock: 5 })).toThrow()
   })
 })

--- a/src/agent/loop-guard.ts
+++ b/src/agent/loop-guard.ts
@@ -31,10 +31,24 @@ export const WINDOW_SOFT_WARN = 4
 export const WINDOW_HARD_BLOCK = 6
 
 // Tools whose first path-like argument identifies the target. Their windowed
-// signature drops numeric range args so paging one file does not masquerade as
-// progress. Non-path tools keep their full argument signature.
-const PATH_COARSENED_TOOLS = new Set(['read', 'write', 'edit', 'grep', 'ls', 'find', 'glob'])
+// signature keys on that path alone so paging one file with drifting
+// offset/limit collapses to a single signature. Two classes, because the
+// builtins differ in whether the path is required:
+//
+//   - REQUIRED-path tools (read/write/edit): path is mandatory. Coarsen only
+//     when a path key is present; an absent path is malformed input, not a
+//     default, so we must NOT collapse such calls to a shared target.
+//   - DEFAULT-path tools (grep/find/ls): path is OPTIONAL and defaults to the
+//     cwd ("."). Omitting the path and varying only non-target args (pattern,
+//     limit) still hits the same directory, so an omitted/empty path coarsens
+//     to `${tool}#path:.` — otherwise those calls would evade the detector.
+//
+// `glob` is intentionally absent: pi-coding-agent has no `glob` builtin (the
+// glob-pattern arg lives inside grep/find), so listing it here matched nothing.
+const REQUIRED_PATH_TOOLS = new Set(['read', 'write', 'edit'])
+const DEFAULT_PATH_TOOLS = new Set(['grep', 'find', 'ls'])
 const PATH_ARG_KEYS = ['path', 'file', 'filePath', 'filename']
+const DEFAULT_PATH_TARGET = '.'
 
 const MAX_SESSIONS = 256
 
@@ -248,15 +262,21 @@ function makeCallSignature(tool: string, args: unknown): string {
 }
 
 // Coarsened signature for windowed detection: path-bearing tools key on their
-// target path alone so re-reading one file with drifting offset/limit collapses
-// to a single signature. All other tools fall back to the exact signature.
+// target path alone so re-reading one target with drifting non-path args
+// collapses to a single signature. All other tools fall back to the exact
+// signature.
 function makeWindowSignature(tool: string, args: unknown): string {
-  if (PATH_COARSENED_TOOLS.has(tool) && args !== null && typeof args === 'object') {
+  const isRequiredPath = REQUIRED_PATH_TOOLS.has(tool)
+  const isDefaultPath = DEFAULT_PATH_TOOLS.has(tool)
+  if ((isRequiredPath || isDefaultPath) && args !== null && typeof args === 'object') {
     const record = args as Record<string, unknown>
     for (const key of PATH_ARG_KEYS) {
       const value = record[key]
       if (typeof value === 'string' && value.length > 0) return `${tool}#path:${value}`
     }
+    // No explicit path. For default-path tools the effective target is the cwd,
+    // so coarsen to it; for required-path tools we leave the call uncoarsened.
+    if (isDefaultPath) return `${tool}#path:${DEFAULT_PATH_TARGET}`
   }
   return makeCallSignature(tool, args)
 }

--- a/src/agent/loop-guard.ts
+++ b/src/agent/loop-guard.ts
@@ -1,39 +1,49 @@
-// Detects when the model calls the same tool with byte-identical arguments in
-// a tight streak — the classic "stuck in a thought-loop" failure where the
-// agent repeats `bash("ls")` or `read("foo.ts")` indefinitely waiting for a
-// different answer. Two-tier escalation:
+// Detects when the model is stuck looping on tool calls. Two independent
+// detectors run per call; the more severe decision wins.
 //
-//   - At LOOP_SOFT_WARN consecutive identical calls (default 3), the next call
-//     completes normally but the wrapped tool's output is suffixed with a nudge
-//     telling the model it's looping. Soft warning fires ONCE per streak so
-//     the model isn't drowning in identical reminders.
-//   - At LOOP_HARD_BLOCK consecutive identical calls (default 5), the call is
-//     refused outright. The wrapping in plugin-tools.ts maps the refusal to
-//     `errorResult` for plugin tools (the model sees a tool error and must
-//     change strategy) and to a thrown Error for system / pi-builtin tools
-//     (matches the existing `tool.before { block: true }` plumbing).
+// 1. Consecutive-identical (reason: 'consecutive') — catches the tight loop
+//    where the agent repeats `bash("ls")` byte-for-byte waiting for a different
+//    answer. Soft-warn at LOOP_SOFT_WARN (3), hard-block at LOOP_HARD_BLOCK (5).
 //
-// State is per-session and bounded: the guard keeps at most MAX_SESSIONS
-// session entries with LRU eviction, and each session holds at most one
-// signature + counter (we only care about the current tail streak). When a
-// different tool/args combination arrives, the streak resets to 1.
+// 2. Windowed-frequency (reason: 'windowed') — catches interleaved cycles the
+//    consecutive detector cannot see, e.g. read(a)→edit(b)→read(a)→edit(b)…, or
+//    re-reading one file with drifting offsets. Over a sliding window of the
+//    last WINDOW_SIZE calls, if one signature recurs WINDOW_SOFT_WARN times it
+//    warns and WINDOW_HARD_BLOCK times it blocks. Path-bearing tools coarsen
+//    their signature to the path alone (offsets/limits/line ranges dropped) so
+//    that paging the same file in a cycle collapses to one signature.
 //
-// The detector is intentionally placed INSIDE the tool wrappers (not as a
+// Both warn/block decisions carry the byte-identical or coarsened nudge text.
+// The wrapping in plugin-tools.ts maps a block to `errorResult` for plugin tools
+// and to a thrown Error for system / pi-builtin tools (matching the existing
+// `tool.before { block: true }` plumbing).
+//
+// State is per-session and bounded by MAX_SESSIONS with LRU eviction. The
+// detector is intentionally placed INSIDE the tool wrappers (not as a
 // `tool.before` plugin) so it covers every tool category — plugin tools,
 // TypeClaw system tools, and pi-coding-agent builtins — through one chokepoint.
 
 export const LOOP_SOFT_WARN = 3
 export const LOOP_HARD_BLOCK = 5
 
-// Caps in-process memory across many sessions. Each entry is small
-// (signature string + small counters), so this bound is generous; we just
-// don't want unbounded growth if sessionIds churn.
+export const WINDOW_SIZE = 16
+export const WINDOW_SOFT_WARN = 4
+export const WINDOW_HARD_BLOCK = 6
+
+// Tools whose first path-like argument identifies the target. Their windowed
+// signature drops numeric range args so paging one file does not masquerade as
+// progress. Non-path tools keep their full argument signature.
+const PATH_COARSENED_TOOLS = new Set(['read', 'write', 'edit', 'grep', 'ls', 'find', 'glob'])
+const PATH_ARG_KEYS = ['path', 'file', 'filePath', 'filename']
+
 const MAX_SESSIONS = 256
+
+export type LoopReason = 'consecutive' | 'windowed'
 
 export type LoopGuardDecision =
   | { kind: 'ok' }
-  | { kind: 'warn'; count: number; message: string }
-  | { kind: 'block'; count: number; message: string }
+  | { kind: 'warn'; count: number; reason: LoopReason; message: string }
+  | { kind: 'block'; count: number; reason: LoopReason; message: string }
 
 export type LoopGuard = {
   check: (sessionId: string, tool: string, args: unknown) => LoopGuardDecision
@@ -42,27 +52,52 @@ export type LoopGuard = {
 }
 
 type SessionState = {
+  // Consecutive-identical streak: the current tail signature, its run length,
+  // and whether this streak already emitted its one soft warning.
   signature: string
   count: number
-  // Fires the soft warning exactly once per streak instead of every call
-  // from the 3rd onwards. Re-arms when the streak breaks.
   warned: boolean
+  // Windowed history: the last WINDOW_SIZE coarsened signatures, plus the set
+  // of signatures that already emitted their one windowed soft warning while
+  // still present in the window.
+  window: string[]
+  windowWarned: Set<string>
 }
 
 export type CreateLoopGuardOptions = {
   softWarn?: number
   hardBlock?: number
   maxSessions?: number
+  windowSize?: number
+  windowSoftWarn?: number
+  windowHardBlock?: number
 }
 
 export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard {
   const softWarn = options.softWarn ?? LOOP_SOFT_WARN
   const hardBlock = options.hardBlock ?? LOOP_HARD_BLOCK
   const maxSessions = options.maxSessions ?? MAX_SESSIONS
+  const windowSize = options.windowSize ?? WINDOW_SIZE
+  const windowSoftWarn = options.windowSoftWarn ?? WINDOW_SOFT_WARN
+  const windowHardBlock = options.windowHardBlock ?? WINDOW_HARD_BLOCK
 
   if (softWarn < 2) throw new Error(`loop-guard: softWarn must be >= 2 (got ${softWarn})`)
   if (hardBlock <= softWarn) {
     throw new Error(`loop-guard: hardBlock (${hardBlock}) must be greater than softWarn (${softWarn})`)
+  }
+  if (windowSoftWarn < 2) {
+    throw new Error(`loop-guard: windowSoftWarn must be >= 2 (got ${windowSoftWarn})`)
+  }
+  if (windowHardBlock <= windowSoftWarn) {
+    throw new Error(
+      `loop-guard: windowHardBlock (${windowHardBlock}) must be greater than windowSoftWarn (${windowSoftWarn})`,
+    )
+  }
+  if (windowSize < 2) throw new Error(`loop-guard: windowSize must be >= 2 (got ${windowSize})`)
+  if (windowSize < windowHardBlock) {
+    throw new Error(
+      `loop-guard: windowSize (${windowSize}) must be >= windowHardBlock (${windowHardBlock}) for the block to be reachable`,
+    )
   }
 
   // Map preserves insertion order; we rely on that for LRU eviction.
@@ -77,50 +112,90 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
     }
   }
 
+  function evaluateConsecutive(state: SessionState, tool: string): LoopGuardDecision {
+    if (state.count >= hardBlock) {
+      return {
+        kind: 'block',
+        count: state.count,
+        reason: 'consecutive',
+        message: formatBlockMessage(tool, state.count),
+      }
+    }
+    if (state.count >= softWarn && !state.warned) {
+      state.warned = true
+      return { kind: 'warn', count: state.count, reason: 'consecutive', message: formatWarnMessage(tool, state.count) }
+    }
+    return { kind: 'ok' }
+  }
+
+  function evaluateWindowed(state: SessionState, tool: string, windowSig: string): LoopGuardDecision {
+    const count = state.window.reduce((n, sig) => (sig === windowSig ? n + 1 : n), 0)
+    if (count >= windowHardBlock) {
+      return {
+        kind: 'block',
+        count,
+        reason: 'windowed',
+        message: formatWindowedBlockMessage(tool, count),
+      }
+    }
+    if (count >= windowSoftWarn && !state.windowWarned.has(windowSig)) {
+      state.windowWarned.add(windowSig)
+      return {
+        kind: 'warn',
+        count,
+        reason: 'windowed',
+        message: formatWindowedWarnMessage(tool, count),
+      }
+    }
+    return { kind: 'ok' }
+  }
+
   return {
     check(sessionId, tool, args) {
       const signature = makeCallSignature(tool, args)
+      const windowSig = makeWindowSignature(tool, args)
       const existing = sessions.get(sessionId)
 
-      if (!existing || existing.signature !== signature) {
-        touch(sessionId, { signature, count: 1, warned: false })
-        return { kind: 'ok' }
-      }
-
-      const nextCount = existing.count + 1
-      const nextState: SessionState = {
+      const state: SessionState = existing ?? {
         signature,
-        count: nextCount,
-        warned: existing.warned,
+        count: 0,
+        warned: false,
+        window: [],
+        windowWarned: new Set(),
       }
 
-      if (nextCount >= hardBlock) {
-        touch(sessionId, nextState)
-        return {
-          kind: 'block',
-          count: nextCount,
-          message: formatBlockMessage(tool, nextCount),
+      if (state.signature !== signature) {
+        state.signature = signature
+        state.count = 1
+        state.warned = false
+      } else {
+        state.count += 1
+      }
+
+      state.window.push(windowSig)
+      if (state.window.length > windowSize) {
+        const evicted = state.window.shift()
+        if (evicted !== undefined && !state.window.includes(evicted)) {
+          state.windowWarned.delete(evicted)
         }
       }
 
-      if (nextCount >= softWarn && !nextState.warned) {
-        nextState.warned = true
-        touch(sessionId, nextState)
-        return {
-          kind: 'warn',
-          count: nextCount,
-          message: formatWarnMessage(tool, nextCount),
-        }
-      }
+      touch(sessionId, state)
 
-      touch(sessionId, nextState)
+      const consecutive = evaluateConsecutive(state, tool)
+      if (consecutive.kind === 'block') return consecutive
+
+      // Back-to-back identical calls are the consecutive detector's domain; let
+      // it own them so a tight streak doesn't also trip the windowed detector.
+      // The windowed detector exists for INTERLEAVED cycles, so it only acts
+      // when this call breaks the immediate streak (count === 1).
+      const windowed = state.count === 1 ? evaluateWindowed(state, tool, windowSig) : { kind: 'ok' as const }
+      if (windowed.kind === 'block') return windowed
+      if (consecutive.kind === 'warn') return consecutive
+      if (windowed.kind === 'warn') return windowed
       return { kind: 'ok' }
     },
     reset(sessionId) {
-      const existing = sessions.get(sessionId)
-      if (!existing) return
-      // Resetting is what `tool.after` does on a non-identical call too;
-      // exposed for callers that observe a strategy change externally.
       sessions.delete(sessionId)
     },
     forget(sessionId) {
@@ -146,12 +221,44 @@ function formatBlockMessage(tool: string, count: number): string {
   )
 }
 
+function formatWindowedWarnMessage(tool: string, count: number): string {
+  return (
+    `\n\n[loop-guard] You have called \`${tool}\` on the same target ${count} times in a short span. ` +
+    `This looks like a cycle — revisiting the same work without making progress. ` +
+    `If you have enough information, produce the final answer now. ` +
+    `Otherwise change approach instead of repeating this call.`
+  )
+}
+
+function formatWindowedBlockMessage(tool: string, count: number): string {
+  return (
+    `loop-guard: refused \`${tool}\` — called on the same target ${count} times in a short span. ` +
+    `You are cycling on the same work. Stop. Either (1) produce the final answer with the data you already have, ` +
+    `(2) ask the user a clarifying question, or (3) try a meaningfully different approach. ` +
+    `Do not keep re-running this on the same target.`
+  )
+}
+
 function makeCallSignature(tool: string, args: unknown): string {
   try {
     return `${tool}:${stableStringify(args)}`
   } catch {
     return `${tool}:<unstringifiable>`
   }
+}
+
+// Coarsened signature for windowed detection: path-bearing tools key on their
+// target path alone so re-reading one file with drifting offset/limit collapses
+// to a single signature. All other tools fall back to the exact signature.
+function makeWindowSignature(tool: string, args: unknown): string {
+  if (PATH_COARSENED_TOOLS.has(tool) && args !== null && typeof args === 'object') {
+    const record = args as Record<string, unknown>
+    for (const key of PATH_ARG_KEYS) {
+      const value = record[key]
+      if (typeof value === 'string' && value.length > 0) return `${tool}#path:${value}`
+    }
+  }
+  return makeCallSignature(tool, args)
 }
 
 // Order-independent JSON serialization so semantically-identical objects


### PR DESCRIPTION
## Problem

The existing loop guard (`src/agent/loop-guard.ts`) only catches **byte-identical** tool calls repeated **consecutively** (soft-warn at 3, hard-block at 5). Two real loop shapes slip past it entirely:

1. **Interleaved cycles** — `read(a) → edit(b) → read(a) → edit(b) → …`. No two calls are consecutive-identical, so the streak counter resets every call and never escalates.
2. **Drifting-argument re-reads** — re-reading one file with changing `offset`/`limit`. Each `read(path, offset=49)` / `read(path, offset=50)` / `read(path, offset=51)` is a *distinct* signature, so the guard sees progress where there is none.

### Observed in production

A `memory-logger` subagent made **895 `read` calls on a single transcript file** in one session, looping on `offset=49/50/51` of a ~50-line file long past EOF. It never terminated on its own and burned ~130M tokens (≈99% `cacheRead` from re-sending the ballooning loop history each turn). The existing loop guard could not see it because the offsets differed.

## Fix

Add a **second detector** that runs alongside the consecutive one. The more severe decision wins.

**Windowed-frequency detector:** over a sliding window of the last `WINDOW_SIZE` (16) calls, if one signature recurs `WINDOW_SOFT_WARN` (4) times it warns, `WINDOW_HARD_BLOCK` (6) times it blocks.

**Path coarsening:** path-bearing tools (`read`/`write`/`edit`/`grep`/`ls`/`find`/`glob`) key their *windowed* signature on the target path alone, dropping `offset`/`limit`/line ranges. Paging the same file in a loop collapses to one signature — the production incident now trips at ~6 calls instead of 895.

**Precedence:** the consecutive detector keeps ownership of back-to-back identical calls; the windowed detector only acts when a call breaks the immediate streak (`count === 1`). A tight loop reports once, not twice.

## Compatibility

- Decisions gain a `reason: 'consecutive' | 'windowed'` field and the windowed path emits its own message.
- `plugin-tools.ts` consumers only read `.kind` and `.message`, so the added field is backward-compatible — no consumer changes needed.
- All thresholds and the coarsened-tool window are configurable via `CreateLoopGuardOptions` (mirrors the existing `softWarn`/`hardBlock` override pattern).

## Tests

11 new tests cover: interleaved-cycle blocking, the drifting-offset incident, path coarsening, productive fan-out / read-edit alternation **not** tripping, window eviction, per-session isolation, the `reason` field, and threshold validation. All 14 existing tests unchanged. Full `src/agent/` suite (798 tests) passes; typecheck, lint, format clean.

## Note

This is the **structural defense** half of a two-part fix. The companion PR addresses the **root cause** (the memory-logger prompt's missing stop-condition + EOF-read clarity) so the guard normally never fires. Defense-in-depth: fix the wiring fault *and* keep the fuse.