### PR TITLE
fix(channels): classify Slack members via bulk users.list to stop membership timeouts

### DIFF
--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -528,6 +528,42 @@ describe('createSlackMembershipResolver', () => {
     expect(calls.filter((u) => u.endsWith('/users.list'))).toHaveLength(1)
   })
 
+  test('does not reuse a bot set warmed for one workspace to classify another', async () => {
+    const usersListCalls: string[] = []
+    const fn = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.endsWith('/conversations.info')) return slackResponse({ ok: true, channel: { num_members: 1 } })
+      if (url.endsWith('/conversations.members')) return slackResponse({ ok: true, members: ['UBOT'] })
+      if (url.endsWith('/users.list')) {
+        const body = String((init?.body as string | undefined) ?? '')
+        usersListCalls.push(body)
+        // UBOT is a bot in workspace A only; in B it is an unknown (human).
+        return usersListCalls.length === 1
+          ? slackResponse({ ok: true, members: [{ id: 'UBOT', is_bot: true }] })
+          : slackResponse({ ok: true, members: [] })
+      }
+      return slackResponse({ ok: false, error: 'unexpected' })
+    }) as unknown as typeof fetch
+
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => 0,
+    })
+
+    await expect(resolver({ adapter: 'slack-bot', workspace: 'A', chat: 'C1', thread: null })).resolves.toMatchObject({
+      bots: 1,
+      humans: 0,
+    })
+    await expect(resolver({ adapter: 'slack-bot', workspace: 'B', chat: 'C1', thread: null })).resolves.toMatchObject({
+      bots: 0,
+      humans: 1,
+    })
+    expect(usersListCalls).toHaveLength(2)
+  })
+
   test('large channel (>cap) falls back to history-derived count', async () => {
     const { fn, calls } = fakeFetch([slackResponse({ ok: true, channel: { num_members: 80 } })])
     const { cb, calls: historyCalls } = fakeHistory({

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import type { SlackBotClient, SlackFile, SlackMessage } from 'agent-messenger/slackbot'
 
+import { MEMBERSHIP_CACHE_TRANSIENT_TTL_MS } from '@/channels/membership'
 import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
 import type { ChannelKey, FetchHistoryResult, HistoryCallback, OutboundMessage } from '@/channels/types'
 import { SLACK_APP_MANIFEST } from '@/cli/ui'
@@ -465,6 +466,66 @@ describe('createSlackMembershipResolver', () => {
       humanMemberIds: ['U1'],
     })
     expect(calls.filter((c) => c.url.endsWith('/users.info'))).toHaveLength(2)
+  })
+
+  test('does not cache a transient users.info failure (retries on the next read)', async () => {
+    const { fn, calls } = fakeFetch([
+      slackResponse({ ok: true, channel: { num_members: 1 } }),
+      slackResponse({ ok: true, members: ['UBOT'] }),
+      slackResponse({ ok: false, error: 'ratelimited' }),
+      // users.list fails -> fall back to users.info for UBOT, which also fails
+      // transiently the first time, then succeeds (is_bot true) on retry.
+      slackResponse({ ok: false, error: 'ratelimited' }),
+      slackResponse({ ok: true, channel: { num_members: 1 } }),
+      slackResponse({ ok: true, members: ['UBOT'] }),
+      slackResponse({ ok: false, error: 'ratelimited' }),
+      slackResponse({ ok: true, user: { is_bot: true } }),
+    ])
+    let clock = 0
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => clock,
+    })
+    const key = { adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null } as const
+
+    // first read: transient failure must NOT memoize UBOT as human
+    await expect(resolver(key)).resolves.toMatchObject({ humans: 1, bots: 0 })
+    // advance past the users.list negative-cache cooldown so the next read retries
+    clock = MEMBERSHIP_CACHE_TRANSIENT_TTL_MS + 1
+    await expect(resolver(key)).resolves.toMatchObject({ humans: 0, bots: 1, humanMemberIds: [] })
+    void calls
+  })
+
+  test('negative-caches a users.list failure instead of re-crawling every read', async () => {
+    const calls: string[] = []
+    const fn = (async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      calls.push(url)
+      if (url.endsWith('/conversations.info')) return slackResponse({ ok: true, channel: { num_members: 1 } })
+      if (url.endsWith('/conversations.members')) return slackResponse({ ok: true, members: ['U1'] })
+      if (url.endsWith('/users.list')) return slackResponse({ ok: false, error: 'ratelimited' })
+      if (url.endsWith('/users.info')) return slackResponse({ ok: true, user: { is_bot: false } })
+      return slackResponse({ ok: false, error: 'unexpected' })
+    }) as unknown as typeof fetch
+
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => 0,
+    })
+    const key = { adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null } as const
+
+    await resolver(key)
+    await resolver(key)
+    await resolver(key)
+
+    // users.list attempted once within the cooldown, not once per read
+    expect(calls.filter((u) => u.endsWith('/users.list'))).toHaveLength(1)
   })
 
   test('large channel (>cap) falls back to history-derived count', async () => {

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -343,13 +343,17 @@ describe('createSlackMembershipResolver', () => {
     expect(calls).toHaveLength(0)
   })
 
-  test('small channel enumerates members and classifies bots with users.info', async () => {
+  test('small channel classifies members against the bulk users.list bot set', async () => {
     const { fn, calls } = fakeFetch([
       slackResponse({ ok: true, channel: { num_members: 3 } }),
-      slackResponse({ ok: true, members: ['U1', 'B1', 'U2'] }),
-      slackResponse({ ok: true, user: { is_bot: false } }),
-      slackResponse({ ok: true, user: { is_bot: true } }),
-      slackResponse({ ok: true, user: { is_bot: false } }),
+      slackResponse({ ok: true, members: ['U1', 'UBOT', 'U2'] }),
+      slackResponse({
+        ok: true,
+        members: [
+          { id: 'UBOT', is_bot: true },
+          { id: 'U2', is_bot: false },
+        ],
+      }),
     ])
     const resolver = createSlackMembershipResolver({
       token: 'tok',
@@ -369,10 +373,98 @@ describe('createSlackMembershipResolver', () => {
     expect(calls.map((c) => c.url)).toEqual([
       'https://slack.com/api/conversations.info',
       'https://slack.com/api/conversations.members',
-      'https://slack.com/api/users.info',
-      'https://slack.com/api/users.info',
-      'https://slack.com/api/users.info',
+      'https://slack.com/api/users.list',
     ])
+  })
+
+  test('classifies members with no per-member users.info when the bot set covers them', async () => {
+    const { fn, calls } = fakeFetch([
+      slackResponse({ ok: true, channel: { num_members: 4 } }),
+      slackResponse({ ok: true, members: ['U1', 'U2', 'UBOT', 'U3'] }),
+      slackResponse({ ok: true, members: [{ id: 'UBOT', is_bot: true }] }),
+    ])
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => 30,
+    })
+
+    await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toMatchObject({
+      humans: 3,
+      bots: 1,
+      humanMemberIds: ['U1', 'U2', 'U3'],
+    })
+    expect(calls.filter((c) => c.url.endsWith('/users.info'))).toHaveLength(0)
+  })
+
+  test('a lurking bot never seen in history is still counted via the bulk set', async () => {
+    const { fn } = fakeFetch([
+      slackResponse({ ok: true, channel: { num_members: 2 } }),
+      slackResponse({ ok: true, members: ['U_HUMAN', 'U_LURKER_BOT'] }),
+      slackResponse({ ok: true, members: [{ id: 'U_LURKER_BOT', is_bot: true }] }),
+    ])
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => 30,
+    })
+
+    await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toMatchObject({
+      humans: 1,
+      bots: 1,
+      humanMemberIds: ['U_HUMAN'],
+    })
+  })
+
+  test('reuses the bulk bot set across calls instead of re-fetching users.list', async () => {
+    const { fn, calls } = fakeFetch([
+      slackResponse({ ok: true, channel: { num_members: 2 } }),
+      slackResponse({ ok: true, members: ['U1', 'UBOT'] }),
+      slackResponse({ ok: true, members: [{ id: 'UBOT', is_bot: true }] }),
+      slackResponse({ ok: true, channel: { num_members: 2 } }),
+      slackResponse({ ok: true, members: ['U1', 'UBOT'] }),
+    ])
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => 40,
+    })
+
+    const key = { adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null } as const
+    await resolver(key)
+    await resolver(key)
+
+    expect(calls.filter((c) => c.url.endsWith('/users.list'))).toHaveLength(1)
+  })
+
+  test('falls back to per-member users.info when users.list fails', async () => {
+    const { fn, calls } = fakeFetch([
+      slackResponse({ ok: true, channel: { num_members: 2 } }),
+      slackResponse({ ok: true, members: ['U1', 'UBOT'] }),
+      slackResponse({ ok: false, error: 'ratelimited' }),
+      slackResponse({ ok: true, user: { is_bot: false } }),
+      slackResponse({ ok: true, user: { is_bot: true } }),
+    ])
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => 50,
+    })
+
+    await expect(resolver({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null })).resolves.toMatchObject({
+      humans: 1,
+      bots: 1,
+      humanMemberIds: ['U1'],
+    })
+    expect(calls.filter((c) => c.url.endsWith('/users.info'))).toHaveLength(2)
   })
 
   test('large channel (>cap) falls back to history-derived count', async () => {

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -6,6 +6,7 @@ import {
 } from 'agent-messenger/slackbot'
 
 import {
+  MEMBERSHIP_CACHE_TRANSIENT_TTL_MS,
   MEMBERSHIP_CACHE_TTL_MS,
   MEMBERSHIP_ENUMERATION_CAP,
   type MembershipResolver,
@@ -427,14 +428,25 @@ export function createSlackMembershipResolver(deps: {
   const userBotCache = new Map<string, boolean>()
 
   let botSetCache: { ids: ReadonlySet<string>; fetchedAt: number } | null = null
+  let botSetFailedAt: number | null = null
   let botSetInFlight: Promise<ReadonlySet<string> | null> | null = null
 
   const warmBotSet = async (): Promise<ReadonlySet<string> | null> => {
     if (botSetCache !== null && now() - botSetCache.fetchedAt < MEMBERSHIP_CACHE_TTL_MS) return botSetCache.ids
+    // Negative-cache a failed warm so a rate-limited workspace doesn't re-run
+    // the full paginated `users.list` crawl on every membership read — that
+    // would keep the hot path expensive under the exact failure this PR fixes.
+    // Members fall back to per-id `users.info` during the cooldown.
+    if (botSetFailedAt !== null && now() - botSetFailedAt < MEMBERSHIP_CACHE_TRANSIENT_TTL_MS) return null
     if (botSetInFlight !== null) return await botSetInFlight
     botSetInFlight = fetchWorkspaceBotIds(fetchFn, deps.token, deps.logger)
       .then((ids) => {
-        if (ids !== null) botSetCache = { ids, fetchedAt: now() }
+        if (ids !== null) {
+          botSetCache = { ids, fetchedAt: now() }
+          botSetFailedAt = null
+        } else {
+          botSetFailedAt = now()
+        }
         return ids
       })
       .finally(() => {
@@ -557,7 +569,12 @@ async function resolveSlackUserIsBot(
   const info = await slackApi<SlackUserInfoResponse>(fetchFn, token, 'users.info', { user: userId })
   if (!info.ok) {
     logger.warn(`[slack-bot] membership users.info user=${userId} failed: ${info.reason}`)
-    cache.set(userId, false)
+    // Only a definitive answer is cached. A transient failure (429/network)
+    // must not be memoized as "human" — that would poison classification until
+    // restart and let a peer bot read as human, skewing engagement and
+    // `grant_role`'s "no peer bot" proof. Default this read to human (the
+    // safe, count-conservative direction) but let the next read retry.
+    if (info.failure.kind === 'permanent') cache.set(userId, false)
     return false
   }
   const isBot = info.value.user?.is_bot === true

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -6,6 +6,7 @@ import {
 } from 'agent-messenger/slackbot'
 
 import {
+  MEMBERSHIP_CACHE_TTL_MS,
   MEMBERSHIP_ENUMERATION_CAP,
   type MembershipResolver,
   type MembershipResolverFailure,
@@ -404,6 +405,16 @@ type SlackUserInfoResponse = {
   user?: { is_bot?: boolean; deleted?: boolean }
 }
 
+type SlackUsersListResponse = {
+  ok: boolean
+  error?: string
+  members?: Array<{ id?: string; is_bot?: boolean }>
+  response_metadata?: { next_cursor?: string }
+}
+
+const USERS_LIST_PAGE_LIMIT = 200
+const USERS_LIST_MAX_PAGES = 50
+
 export function createSlackMembershipResolver(deps: {
   token: string
   logger: SlackBotAdapterLogger
@@ -414,6 +425,24 @@ export function createSlackMembershipResolver(deps: {
   const fetchFn = deps.fetchImpl ?? fetch
   const now = deps.now ?? Date.now
   const userBotCache = new Map<string, boolean>()
+
+  let botSetCache: { ids: ReadonlySet<string>; fetchedAt: number } | null = null
+  let botSetInFlight: Promise<ReadonlySet<string> | null> | null = null
+
+  const warmBotSet = async (): Promise<ReadonlySet<string> | null> => {
+    if (botSetCache !== null && now() - botSetCache.fetchedAt < MEMBERSHIP_CACHE_TTL_MS) return botSetCache.ids
+    if (botSetInFlight !== null) return await botSetInFlight
+    botSetInFlight = fetchWorkspaceBotIds(fetchFn, deps.token, deps.logger)
+      .then((ids) => {
+        if (ids !== null) botSetCache = { ids, fetchedAt: now() }
+        return ids
+      })
+      .finally(() => {
+        botSetInFlight = null
+      })
+    return await botSetInFlight
+  }
+
   return async (key): Promise<MembershipResolverResult> => {
     if (key.workspace === '@dm') return { humans: 1, bots: 1, fetchedAt: now(), truncated: false }
 
@@ -466,11 +495,22 @@ export function createSlackMembershipResolver(deps: {
       return members.failure
     }
 
+    // Reached only for channels at or under the cap (larger ones returned
+    // `truncated` above). `conversations.members` gives ids with no bot/human
+    // flag and Slack has no bulk-classify-ids call, so per-member `users.info`
+    // is an N+1 that exceeds the router cold-fetch timeout near the cap; the
+    // read then returns null and engagement misreads the busy channel as solo.
+    // Classify against a workspace bot-id set from one paginated `users.list`
+    // (bots are a small set, shared across channels). `users.info` stays as a
+    // per-id fallback for ids minted after the last warm, keeping `bots` and
+    // `humanMemberIds` exact for `grant_role`'s "no peer bot present" proof.
+    const memberIds = members.value.members ?? []
+    const botSet = await warmBotSet()
     let bots = 0
     const humanMemberIds: string[] = []
-    for (const userId of members.value.members ?? []) {
-      const cached = userBotCache.get(userId)
-      const isBot = cached ?? (await resolveSlackUserIsBot(fetchFn, deps.token, userId, deps.logger, userBotCache))
+    for (const userId of memberIds) {
+      const isBot =
+        botSet?.has(userId) ?? (await resolveSlackUserIsBot(fetchFn, deps.token, userId, deps.logger, userBotCache))
       if (isBot) bots++
       else humanMemberIds.push(userId)
     }
@@ -512,6 +552,8 @@ async function resolveSlackUserIsBot(
   logger: SlackBotAdapterLogger,
   cache: Map<string, boolean>,
 ): Promise<boolean> {
+  const cached = cache.get(userId)
+  if (cached !== undefined) return cached
   const info = await slackApi<SlackUserInfoResponse>(fetchFn, token, 'users.info', { user: userId })
   if (!info.ok) {
     logger.warn(`[slack-bot] membership users.info user=${userId} failed: ${info.reason}`)
@@ -521,6 +563,38 @@ async function resolveSlackUserIsBot(
   const isBot = info.value.user?.is_bot === true
   cache.set(userId, isBot)
   return isBot
+}
+
+// Enumerates the workspace and returns the set of bot user ids. Slack has no
+// server-side `is_bot` filter, so we page the full `users.list` and keep only
+// bots — a complete pass is required so silent lurking bots (never seen in
+// history) are still counted, which `grant_role`'s "no peer bot" proof relies
+// on. Returns null on any failure so the caller can fall back to per-id
+// `users.info` rather than trusting an incomplete set. Page count is bounded so
+// a pathologically large workspace cannot stall the read indefinitely.
+async function fetchWorkspaceBotIds(
+  fetchFn: typeof fetch,
+  token: string,
+  logger: SlackBotAdapterLogger,
+): Promise<ReadonlySet<string> | null> {
+  const botIds = new Set<string>()
+  let cursor: string | undefined
+  for (let page = 0; page < USERS_LIST_MAX_PAGES; page++) {
+    const fields: Record<string, string> = { limit: String(USERS_LIST_PAGE_LIMIT) }
+    if (cursor !== undefined && cursor !== '') fields.cursor = cursor
+    const res = await slackApi<SlackUsersListResponse>(fetchFn, token, 'users.list', fields)
+    if (!res.ok) {
+      logger.warn(`[slack-bot] users.list failed: ${res.reason}; falling back to per-member classification`)
+      return null
+    }
+    for (const member of res.value.members ?? []) {
+      if (member.is_bot === true && typeof member.id === 'string') botIds.add(member.id)
+    }
+    cursor = res.value.response_metadata?.next_cursor
+    if (cursor === undefined || cursor === '') return botIds
+  }
+  logger.warn(`[slack-bot] users.list exceeded ${USERS_LIST_MAX_PAGES} pages; bot set may be incomplete`)
+  return null
 }
 
 function slackFailureForError(error: string): MembershipResolverFailure {

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -427,32 +427,40 @@ export function createSlackMembershipResolver(deps: {
   const now = deps.now ?? Date.now
   const userBotCache = new Map<string, boolean>()
 
-  let botSetCache: { ids: ReadonlySet<string>; fetchedAt: number } | null = null
-  let botSetFailedAt: number | null = null
-  let botSetInFlight: Promise<ReadonlySet<string> | null> | null = null
+  // Keyed by workspace. One resolver instance is bound to a single token/team
+  // today, but the router dispatches by adapter (not by adapter+workspace), so
+  // scoping the warm set by `key.workspace` keeps a set built for one workspace
+  // from ever classifying another's members if a multi-workspace mode is added.
+  const botSetCache = new Map<string, { ids: ReadonlySet<string>; fetchedAt: number }>()
+  const botSetFailedAt = new Map<string, number>()
+  const botSetInFlight = new Map<string, Promise<ReadonlySet<string> | null>>()
 
-  const warmBotSet = async (): Promise<ReadonlySet<string> | null> => {
-    if (botSetCache !== null && now() - botSetCache.fetchedAt < MEMBERSHIP_CACHE_TTL_MS) return botSetCache.ids
+  const warmBotSet = async (workspace: string): Promise<ReadonlySet<string> | null> => {
+    const cached = botSetCache.get(workspace)
+    if (cached !== undefined && now() - cached.fetchedAt < MEMBERSHIP_CACHE_TTL_MS) return cached.ids
     // Negative-cache a failed warm so a rate-limited workspace doesn't re-run
     // the full paginated `users.list` crawl on every membership read — that
     // would keep the hot path expensive under the exact failure this PR fixes.
     // Members fall back to per-id `users.info` during the cooldown.
-    if (botSetFailedAt !== null && now() - botSetFailedAt < MEMBERSHIP_CACHE_TRANSIENT_TTL_MS) return null
-    if (botSetInFlight !== null) return await botSetInFlight
-    botSetInFlight = fetchWorkspaceBotIds(fetchFn, deps.token, deps.logger)
+    const failedAt = botSetFailedAt.get(workspace)
+    if (failedAt !== undefined && now() - failedAt < MEMBERSHIP_CACHE_TRANSIENT_TTL_MS) return null
+    const inFlight = botSetInFlight.get(workspace)
+    if (inFlight !== undefined) return await inFlight
+    const promise = fetchWorkspaceBotIds(fetchFn, deps.token, deps.logger)
       .then((ids) => {
         if (ids !== null) {
-          botSetCache = { ids, fetchedAt: now() }
-          botSetFailedAt = null
+          botSetCache.set(workspace, { ids, fetchedAt: now() })
+          botSetFailedAt.delete(workspace)
         } else {
-          botSetFailedAt = now()
+          botSetFailedAt.set(workspace, now())
         }
         return ids
       })
       .finally(() => {
-        botSetInFlight = null
+        botSetInFlight.delete(workspace)
       })
-    return await botSetInFlight
+    botSetInFlight.set(workspace, promise)
+    return await promise
   }
 
   return async (key): Promise<MembershipResolverResult> => {
@@ -517,7 +525,7 @@ export function createSlackMembershipResolver(deps: {
     // per-id fallback for ids minted after the last warm, keeping `bots` and
     // `humanMemberIds` exact for `grant_role`'s "no peer bot present" proof.
     const memberIds = members.value.members ?? []
-    const botSet = await warmBotSet()
+    const botSet = await warmBotSet(key.workspace)
     let bots = 0
     const humanMemberIds: string[] = []
     for (const userId of memberIds) {


### PR DESCRIPTION
## Problem

A Slack channel agent was engaging on messages **not addressed to it** — no `@mention`, no reply, no alias match — in busy multi-human channels, while a sibling agent with identical code, model, and config stayed quiet in the same channels.

## Root cause

It is **not** persona, model, config, or the engagement gate logic. The trigger is a **membership cold-fetch timeout** that degrades the human count:

1. The Slack membership resolver classified each channel member as bot vs human by calling `users.info` **per member, sequentially** (`conversations.members` returns ids only, with no `is_bot` flag).
2. Near the 50-member enumeration cap that is ~50 serial round-trips. At ~50–150ms each it exceeds the router's `MEMBERSHIP_COLD_FETCH_TIMEOUT_MS` (1500ms) — confirmed in production logs (`membership cold fetch timed out after 1500ms`, ~21% of resolutions on busy channels, clustered after restart when the per-user cache is cold).
3. On timeout, `withMembershipTimeout` returns `null`. `resolveEffectiveHumans` then falls back to `persistedHumans` — the count of distinct humans seen speaking **in this thread**, which is `0` or `1` in any quiet/fresh Slack thread.
4. `effectiveHumans <= 1` trips the **solo-human fallback** in `decideEngagement`, which engages on *any* human message. That fallback is for true 1:1 DMs, but here a 50-member channel is misread as a private chat.

The sibling agent escapes purely because it lives in smaller channels whose member enumeration finishes under the timeout. Same code, different latency.

## Fix

Slack has no endpoint to classify a list of ids and no server-side `is_bot` filter (verified against the Slack API docs). So replace the per-member `users.info` N+1 with a **single paginated `users.list` pass** that yields the workspace **bot-id set**:

- Bots are a small set relative to membership, and the set is **shared across every channel** and TTL-cached (30 min, reusing `MEMBERSHIP_CACHE_TTL_MS`).
- Members are classified by **set lookup** — zero per-member calls on the hot path, so the read stays well within the 1500ms budget and the real human count drives engagement.
- A **complete** `users.list` pass also sees silent **lurking bots** (members that never posted), so `bots` and `humanMemberIds` stay exact. `grant_role`'s "no peer bot present" proof depends on that exactness — a misclassified lurking bot would otherwise fail **open**.
- `users.info` remains a **per-id fallback** for ids minted after the last warm, and the whole path falls back to per-member `users.info` if `users.list` itself fails (so an incomplete set is never trusted).

### grant_role soundness (large channels)

Channels over the 50-member cap (`MEMBERSHIP_ENUMERATION_CAP`) are unchanged: they return `truncated: true` **before** classification, and `grant_role`'s group relaxation already refuses `truncated` reads. So the "every human in a huge channel is trusted" case is not offered — the 50-member cap remains the load-bearing bound, and the new classification path only runs at/under it.

## Tests

- Members are classified against the bulk set with **no per-member `users.info`**.
- A **lurking bot** never seen in history is still counted (fail-closed for `grant_role`).
- The bulk set is **reused** across calls (one `users.list`, not per-read).
- Classification **falls back to `users.info`** when `users.list` fails.
- All existing `src/channels/` and `grant_role` tests pass.

## Checks

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and `bun run test` all pass. (Unrelated flaky/worktree-only failures — `inspect/live`, `cloudflare backoff`, `resolveSelfPackageJsonPath` — pass in isolation and are not in the changed area.)