### PR TITLE
Give memory-logger an explicit end-of-file stop contract

### DIFF
--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -237,12 +237,13 @@ describe('MEMORY_LOGGER_SYSTEM_PROMPT', () => {
     expect(lower).toMatch(/do not re-?read|do not retry|do not repeat the (same )?read|never re-?read/)
   })
 
-  test('bounds total read calls so a finite transcript cannot loop indefinitely', () => {
+  test('ties the hard stop to find_entry totalLines, not to a read-call count', () => {
     const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
-    expect(lower).toMatch(/find_entry.*totalLines|totallines.*find_entry|total line count/)
+    expect(lower).toMatch(/`find_entry` gives you `totallines=t` up front, so you always know the last line/)
     expect(lower).toMatch(
-      /once you (have )?(read|reach).*totallines|when .*offset.*exceed|past.*totallines|beyond.*last line/,
+      /the hard stop is `totallines`: a long transcript may legitimately need many `read` chunks to reach it/,
     )
+    expect(lower).not.toMatch(/more than a handful of (?:reads|times)/)
   })
 })
 

--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -224,6 +224,26 @@ describe('MEMORY_LOGGER_SYSTEM_PROMPT', () => {
     const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
     expect(lower).toMatch(/never write the same watermark id|advance the watermark|move forward each run/)
   })
+
+  test('defines an explicit stop trigger for when reads are exhausted', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toMatch(/end of (the )?(file|transcript)|reached the end|no (more|further) (content|lines|entries)/)
+    expect(lower).toMatch(/stop reading|do not (call )?`?read`? again|stop calling read/)
+  })
+
+  test('forbids re-reading the same offset when a read returns nothing new', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toMatch(/empty|nothing new|no new (content|lines|entries)|same (chunk|content|slice|offset)/)
+    expect(lower).toMatch(/do not re-?read|do not retry|do not repeat the (same )?read|never re-?read/)
+  })
+
+  test('bounds total read calls so a finite transcript cannot loop indefinitely', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toMatch(/find_entry.*totalLines|totallines.*find_entry|total line count/)
+    expect(lower).toMatch(
+      /once you (have )?(read|reach).*totallines|when .*offset.*exceed|past.*totallines|beyond.*last line/,
+    )
+  })
 })
 
 describe('memoryLoggerSubagent', () => {

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -81,8 +81,10 @@ Session transcripts are JSONL files where each line is an entry with an \`id\` f
 Typical flow with a watermark:
 
 1. \`find_entry(path=<transcript>, entryId=<watermark>)\` → returns \`line=N, totalLines=T, offset=N+1\`.
-2. \`read(path=<transcript>, offset=N+1)\` → returns the chunk starting AT the first unread entry. Repeat with the next offset until the read tool's continuation notice stops appearing.
+2. \`read(path=<transcript>, offset=N+1)\` → returns the chunk starting AT the first unread entry. Repeat with the next offset until you reach the end of the file. \`find_entry\` already told you \`totalLines=T\`: once a \`read\` has returned line T (or the read tool reports no continuation), you have reached the end of the transcript. Stop reading.
 3. As you read, track the most recent \`id\` you see. That is your new watermark value — pass it as \`latestEntryId\` on the final \`append\` call, or to the watermark-advance tool when there are zero fragments.
+
+**Reading is bounded — a finite transcript takes a finite number of reads.** \`find_entry\` gives you \`totalLines=T\` up front, so you always know the last line. Each \`read\` returns a slice and an offset to continue; advance the offset forward each time. Once you have read line T, or a \`read\` returns no new content (an empty chunk, or the same slice you already saw, or no continuation offset), you are at the end. Do NOT re-read the same offset, and do NOT keep calling \`read\` hoping more will appear — nothing more will. A read that returns nothing new is the end-of-file signal, not a transient error to retry. Re-reading past the end produces no new information and wastes the entire run; treat the first no-new-content read as "done reading" and move to your fragment decision.
 
 Never write the same watermark id you were given as input. If the transcript has no new entries past the watermark, evaluate the entries you can see, then advance the watermark to the latest \`id\` in the transcript (which is on line \`totalLines\` from \`find_entry\`'s reply). The whole point of the watermark is to move forward each run.
 
@@ -202,7 +204,9 @@ When you evaluated the transcript but found nothing worth a fragment, call the w
 
 # Stopping
 
-When you're done, simply stop. There is no completion message to emit.`
+You are done the moment BOTH are true: (1) you have read to the end of the transcript (reached \`totalLines\` from \`find_entry\`, or a \`read\` returned no new content), and (2) you have either written your fragment(s) with the final \`latestEntryId\`, or advanced the watermark for the zero-fragment case. When both hold, simply stop. There is no completion message to emit.
+
+Do not loop. If you notice you have called \`read\` more than a handful of times on the same file, or a \`read\` returned nothing new, you are already at the end — stop reading immediately and proceed to your fragment decision. A transcript has a fixed length; re-reading it cannot surface content that is not there. The single most expensive failure mode for this subagent is re-reading the same file in a cycle instead of recognizing end-of-file and stopping.`
 
 function buildInitialPrompt(payload: MemoryLoggerPayload, streamFile: string, watermark: string | null): string {
   const lines: string[] = [

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -206,7 +206,7 @@ When you evaluated the transcript but found nothing worth a fragment, call the w
 
 You are done the moment BOTH are true: (1) you have read to the end of the transcript (reached \`totalLines\` from \`find_entry\`, or a \`read\` returned no new content), and (2) you have either written your fragment(s) with the final \`latestEntryId\`, or advanced the watermark for the zero-fragment case. When both hold, simply stop. There is no completion message to emit.
 
-Do not loop. If you notice you have called \`read\` more than a handful of times on the same file, or a \`read\` returned nothing new, you are already at the end — stop reading immediately and proceed to your fragment decision. A transcript has a fixed length; re-reading it cannot surface content that is not there. The single most expensive failure mode for this subagent is re-reading the same file in a cycle instead of recognizing end-of-file and stopping.`
+Do not loop. The hard stop is \`totalLines\`: a long transcript may legitimately need many \`read\` chunks to reach it, and that is fine as long as each \`read\` advances the offset toward \`totalLines\`. What is NOT fine is re-reading without progress. If a \`read\` returns no new content, returns the same slice you already saw, or your offset stops advancing, you are at the end — stop reading immediately and proceed to your fragment decision. A transcript has a fixed length; re-reading the same offset cannot surface content that is not there. The single most expensive failure mode for this subagent is re-reading the same file in a cycle instead of recognizing end-of-file and stopping.`
 
 function buildInitialPrompt(payload: MemoryLoggerPayload, streamFile: string, watermark: string | null): string {
   const lines: string[] = [


### PR DESCRIPTION
## Problem

The `memory-logger` subagent reads a session transcript past a watermark and decides whether to write memory fragments. Its reading instructions said to "repeat with the next offset until the read tool's continuation notice stops appearing" — but **never defined what to do when a `read` returns past EOF**. On a short transcript, a read past the end returns nothing new, and the model — with no stop trigger — re-issued the same `read` indefinitely.

### Observed in production

A single `memory-logger` run made **895 `read` calls on one ~50-line transcript**, cycling on `offset=49/50/51` long past EOF. It never terminated on its own and burned **~130M tokens** (≈99% `cacheRead` from re-sending the ballooning loop history each turn) before the run was killed.

## Fix

`read` is a pi-coding-agent builtin, so its EOF return shape can't be changed here — the termination contract is enforced through the subagent prompt:

- **Reading-flow step** now ties stopping to `find_entry`'s `totalLines`: once a `read` returns line T (or reports no continuation), you are at the end of the transcript.
- **New bounded-reading paragraph** states that a no-new-content read **is** the end-of-file signal (not a transient error to retry), and that re-reading the same offset cannot surface content that isn't there.
- **"# Stopping" section** now defines a two-part done condition (read-to-end AND watermark/fragments written) and names the cyclic re-read as the single most expensive failure mode for this subagent.

## Tests

Three new tests assert the contract so it cannot silently regress:
- an explicit stop trigger for exhausted reads,
- the no-re-read rule when a read returns nothing new,
- the bounded-by-`totalLines` guarantee.

All 48 existing `MEMORY_LOGGER_SYSTEM_PROMPT` tests unchanged; full memory suite (615 tests) passes. Typecheck, lint, format clean.

## Relationship to the loop-guard PR

This is the **root-cause** half. The companion PR (windowed multi-signature loop guard) is the **structural backstop** that catches this class of loop regardless of model or prompt adherence. Defense-in-depth: this PR fixes the wiring fault; the guard PR is the fuse. They are independent and can merge in either order.

Note: a pre-existing, unrelated test (`resolveSelfPackageJsonPath > points at this package manifest`) fails in the worktree because the checkout dir is named `typeclaw-memory-rootfix` rather than `typeclaw`; it asserts the path ends with `typeclaw/package.json`. It is environmental and untouched by this change.