### PR TITLE
Add allowApprove flag to github channel config

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -8,6 +8,7 @@ import {
   classifyGithubInbound,
   createGithubWebhookHandler,
   type GithubWebhookHandlerOptions,
+  PR_APPROVAL_DISABLED_NOTE,
   verifySignature,
 } from './inbound'
 import { decodeGithubReactionRef } from './reactions'
@@ -871,6 +872,59 @@ function fakeFetch(fn: (input: string, init?: RequestInit) => Response): typeof 
     fn(typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url, init)
   return Object.assign(impl, { preconnect: () => {} }) as typeof fetch
 }
+
+describe('createGithubWebhookHandler — allowApprove policy note', () => {
+  const baseOptions = (routed: InboundMessage[], allowApprove?: () => boolean): GithubWebhookHandlerOptions => ({
+    webhookSecret: 'secret',
+    dedup: createDeliveryDedup(),
+    allowlist: () => ['pull_request.review_requested', 'issue_comment.created'],
+    selfId: () => '99',
+    selfLogin: () => 'typeclaw-bot',
+    logger,
+    route: (msg) => {
+      routed.push(msg)
+    },
+    ...(allowApprove !== undefined ? { allowApprove } : {}),
+  })
+
+  it('does not append the note when approval is allowed (review_requested)', async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler(baseOptions(routed, () => true))
+    await handler(
+      signedRequest(JSON.stringify(reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' })), 'pull_request', 'd1'),
+    )
+    expect(routed[0]?.text).toContain('requested your review on PR #7')
+    expect(routed[0]?.text).not.toContain(PR_APPROVAL_DISABLED_NOTE)
+  })
+
+  it('does not append the note when allowApprove is omitted (defaults to allowed)', async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler(baseOptions(routed))
+    await handler(
+      signedRequest(JSON.stringify(reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' })), 'pull_request', 'd2'),
+    )
+    expect(routed[0]?.text).not.toContain(PR_APPROVAL_DISABLED_NOTE)
+  })
+
+  it('appends the note to a review_requested inbound when approval is disabled', async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler(baseOptions(routed, () => false))
+    await handler(
+      signedRequest(JSON.stringify(reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' })), 'pull_request', 'd3'),
+    )
+    expect(routed[0]?.text).toContain('requested your review on PR #7')
+    expect(routed[0]?.text).toContain(PR_APPROVAL_DISABLED_NOTE)
+  })
+
+  it('appends the note to a plain-language inbound (issue comment) when approval is disabled', async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler(baseOptions(routed, () => false))
+    await handler(signedRequest(JSON.stringify(issueCommentPayload({ pullRequest: true })), 'issue_comment', 'd4'))
+    expect(routed[0]?.chat).toBe('pr:7')
+    expect(routed[0]?.text).toContain('@typeclaw-bot hello')
+    expect(routed[0]?.text).toContain(PR_APPROVAL_DISABLED_NOTE)
+  })
+})
 
 function signedRequest(body: string, event: string, delivery: string): Request {
   const sig = `sha256=${createHmac('sha256', 'secret').update(body).digest('hex')}`

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -19,6 +19,10 @@ export type GithubWebhookHandlerOptions = {
   // Defaults to 'pat' when omitted. In 'app' mode classifyReviewRequest also
   // matches the App's decoy reviewer login; see resolveDecoyReviewerLogin.
   authType?: () => 'pat' | 'app'
+  // Defaults to true when omitted. When it returns false, every inbound carries
+  // an appended operator-policy note telling the agent not to submit an APPROVE
+  // review; the github skill keys off that note to downgrade approve→COMMENT.
+  allowApprove?: () => boolean
   route: (message: InboundMessage) => void
   logger: GithubInboundLogger
   // Optional: resolves whether the bot is a member of the given team. When
@@ -75,9 +79,27 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
     if (classified === null) return ok()
 
     if (delivery !== '') options.dedup.add(delivery)
-    options.route(classified)
+    options.route(withApprovalPolicy(classified, options.allowApprove?.() ?? true))
     return ok()
   }
+}
+
+export const PR_APPROVAL_DISABLED_NOTE =
+  'Operator policy: PR approval is disabled for this agent ' +
+  '(`channels.github.allowApprove: false`). If you review a PR and the verdict ' +
+  'is `approve`, submit a `COMMENT` review instead of `APPROVE` — post the ' +
+  'findings, but never formally approve.'
+
+// Gating PR approval lives here (inbound text), not at the bash layer: the
+// review is posted via `gh api --input <file>`, so the `event: APPROVE` value
+// sits in a temp file the gh-cli-auth command interceptor never inspects. The
+// note rides on every inbound (cheap: one line, only when an operator has
+// opted out) so it reaches the agent for both webhook review requests and
+// plain-language "@bot review this" asks, which arrive on arbitrary inbounds.
+function withApprovalPolicy(message: InboundMessage, allowApprove: boolean): InboundMessage {
+  if (allowApprove) return message
+  const text = message.text === '' ? PR_APPROVAL_DISABLED_NOTE : `${message.text}\n\n${PR_APPROVAL_DISABLED_NOTE}`
+  return { ...message, text }
 }
 
 // GitHub auto-records the App as a reviewer the moment its review posts, but

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -86,9 +86,9 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
 
 export const PR_APPROVAL_DISABLED_NOTE =
   'Operator policy: PR approval is disabled for this agent ' +
-  '(`channels.github.allowApprove: false`). If you review a PR and the verdict ' +
-  'is `approve`, submit a `COMMENT` review instead of `APPROVE` — post the ' +
-  'findings, but never formally approve.'
+  '(`channels.github.review.approve: false`). If you review a PR and the ' +
+  'verdict is `approve`, submit a `COMMENT` review instead of `APPROVE` — post ' +
+  'the findings, but never formally approve.'
 
 // Gating PR approval lives here (inbound text), not at the bash layer: the
 // review is posted via `gh api --input <file>`, so the `event: APPROVE` value

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -149,6 +149,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     selfId: () => selfId,
     selfLogin: () => selfLogin,
     authType: () => options.secrets.auth.type,
+    allowApprove: () => options.configRef().allowApprove,
     isBotInTeam,
     authToken,
     fetchImpl,

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -149,7 +149,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     selfId: () => selfId,
     selfLogin: () => selfLogin,
     authType: () => options.secrets.auth.type,
-    allowApprove: () => options.configRef().allowApprove,
+    allowApprove: () => options.configRef().review.approve,
     isBotInTeam,
     authToken,
     fetchImpl,

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -77,6 +77,7 @@ function githubConfig(
     webhookPort: 0,
     eventAllowlist: ['issue_comment.created', 'pull_request.opened'],
     repos: [...repos],
+    allowApprove: true,
   }
   if (webhookUrl !== null) config.webhookUrl = webhookUrl
   return config

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -77,7 +77,7 @@ function githubConfig(
     webhookPort: 0,
     eventAllowlist: ['issue_comment.created', 'pull_request.opened'],
     repos: [...repos],
-    allowApprove: true,
+    review: { approve: true },
   }
   if (webhookUrl !== null) config.webhookUrl = webhookUrl
   return config

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -104,7 +104,7 @@ const enabledGithubCfg = () => ({
   webhookPort: 0,
   eventAllowlist: ['issue_comment.created'],
   repos: [],
-  allowApprove: true,
+  review: { approve: true },
 })
 
 const writeGithubSecrets = async (dir: string): Promise<void> => {

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -104,6 +104,7 @@ const enabledGithubCfg = () => ({
   webhookPort: 0,
   eventAllowlist: ['issue_comment.created'],
   repos: [],
+  allowApprove: true,
 })
 
 const writeGithubSecrets = async (dir: string): Promise<void> => {

--- a/src/channels/schema.test.ts
+++ b/src/channels/schema.test.ts
@@ -67,4 +67,14 @@ describe('channelsSchema', () => {
     })
     expect(parsed.github?.webhookUrl).toBe('https://agent.example.com/github')
   })
+
+  test('github allowApprove defaults to true', () => {
+    const parsed = channelsSchema.parse({ github: { repos: ['owner/repo'] } })
+    expect(parsed.github?.allowApprove).toBe(true)
+  })
+
+  test('github allowApprove accepts false', () => {
+    const parsed = channelsSchema.parse({ github: { repos: ['owner/repo'], allowApprove: false } })
+    expect(parsed.github?.allowApprove).toBe(false)
+  })
 })

--- a/src/channels/schema.test.ts
+++ b/src/channels/schema.test.ts
@@ -68,13 +68,18 @@ describe('channelsSchema', () => {
     expect(parsed.github?.webhookUrl).toBe('https://agent.example.com/github')
   })
 
-  test('github allowApprove defaults to true', () => {
+  test('github review.approve defaults to true', () => {
     const parsed = channelsSchema.parse({ github: { repos: ['owner/repo'] } })
-    expect(parsed.github?.allowApprove).toBe(true)
+    expect(parsed.github?.review.approve).toBe(true)
   })
 
-  test('github allowApprove accepts false', () => {
-    const parsed = channelsSchema.parse({ github: { repos: ['owner/repo'], allowApprove: false } })
-    expect(parsed.github?.allowApprove).toBe(false)
+  test('github review.approve accepts false', () => {
+    const parsed = channelsSchema.parse({ github: { repos: ['owner/repo'], review: { approve: false } } })
+    expect(parsed.github?.review.approve).toBe(false)
+  })
+
+  test('github review defaults to { approve: true } when omitted', () => {
+    const parsed = channelsSchema.parse({ github: { repos: ['owner/repo'] } })
+    expect(parsed.github?.review).toEqual({ approve: true })
   })
 })

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -146,6 +146,14 @@ const githubChannelSchema = adapterSchema.extend({
   // this session is deleted so a restart with a different webhookUrl (e.g.
   // a tunnel reassigning a URL) doesn't leave orphaned hooks on GitHub.
   repos: z.array(z.string()).default([]),
+  // Whether the agent may submit a formal PR review with `event: APPROVE`.
+  // When `false`, the adapter appends an operator-policy note to inbounds and
+  // the `typeclaw-channel-github` skill downgrades an `approve` verdict to a
+  // `COMMENT` review (findings still posted, no formal approval). Enforced in
+  // the inbound text rather than at the bash layer because the review posts
+  // via `gh api --input <file>`, so the `event` value lives in a temp file the
+  // command interceptor never sees.
+  allowApprove: z.boolean().default(true),
 })
 
 // KakaoTalk uses the same shape as every other adapter. There used to be an

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -131,6 +131,23 @@ export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [
   'pull_request_review.submitted',
 ] as const
 
+// PR-review policy knobs. Grouped under `review` so future toggles
+// (`requestChanges`, auto-review-on-request, severity thresholds) cluster
+// here instead of flattening onto the channel root.
+//
+// `approve` gates whether the agent may submit a formal review with
+// `event: APPROVE`. When `false`, the adapter appends an operator-policy note
+// to inbounds and the `typeclaw-channel-github` skill downgrades an `approve`
+// verdict to a `COMMENT` review (findings still posted, no formal approval).
+// Enforced in the inbound text rather than at the bash layer because the
+// review posts via `gh api --input <file>`, so the `event` value lives in a
+// temp file the command interceptor never sees.
+const githubReviewSchema = z
+  .object({
+    approve: z.boolean().default(true),
+  })
+  .default({ approve: true })
+
 const githubChannelSchema = adapterSchema.extend({
   // Optional now (PR 2): when omitted and a `tunnels[]` entry with
   // `for: { kind: 'channel', name: 'github' }` exists, the runtime resolves
@@ -146,14 +163,7 @@ const githubChannelSchema = adapterSchema.extend({
   // this session is deleted so a restart with a different webhookUrl (e.g.
   // a tunnel reassigning a URL) doesn't leave orphaned hooks on GitHub.
   repos: z.array(z.string()).default([]),
-  // Whether the agent may submit a formal PR review with `event: APPROVE`.
-  // When `false`, the adapter appends an operator-policy note to inbounds and
-  // the `typeclaw-channel-github` skill downgrades an `approve` verdict to a
-  // `COMMENT` review (findings still posted, no formal approval). Enforced in
-  // the inbound text rather than at the bash layer because the review posts
-  // via `gh api --input <file>`, so the `event` value lives in a temp file the
-  // command interceptor never sees.
-  allowApprove: z.boolean().default(true),
+  review: githubReviewSchema,
 })
 
 // KakaoTalk uses the same shape as every other adapter. There used to be an

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -80,6 +80,8 @@ The `reviewer` subagent is the analyst; you are the integration layer between it
    | `request-changes` | `REQUEST_CHANGES` |
    | `comment`         | `COMMENT`         |
 
+   **Operator approval policy.** If the inbound carries a note that PR approval is disabled (`channels.github.allowApprove: false` — the adapter appends "Operator policy: PR approval is disabled for this agent" to the message), you must **not** submit an `APPROVE`. Map an `approve` verdict to `COMMENT` instead: post the same `<summary>` and all inline `comments[]` as a `COMMENT` review, just without the formal approval. `request-changes` and `comment` verdicts are unaffected (they never approve). Absent that note, approval is enabled and the table above applies unchanged.
+
    Then submit the review. **Write the JSON payload to a file with the `write` tool, then run a single bare `gh api --input <file>`** — two steps:
 
    First write `/tmp/review.json` (via the `write` tool, not bash):
@@ -126,7 +128,7 @@ The `reviewer` subagent is the analyst; you are the integration layer between it
 
 A finding is "actionable" if its severity is `blocker`, `concern`, or `nit`. The inline-review post in step 4 applies whenever the actionable count is **at least one**. When the reviewer returns **exactly zero** actionable findings (only `praise`, or none), there is nothing to anchor inline — handle by verdict:
 
-- `approve` → post a plain `APPROVE` with the `<summary>` as the review body (no `comments[]` array).
+- `approve` → post a plain `APPROVE` with the `<summary>` as the review body (no `comments[]` array). **If the operator approval policy above disabled approval, post the `<summary>` as a top-level PR comment via `gh api -X POST /repos/.../issues/<N>/comments` instead — do not submit any review.**
 - `comment` → post the summary as a top-level PR comment via `gh api -X POST /repos/.../issues/<N>/comments` instead of submitting an empty review.
 - `request-changes` → submit `REQUEST_CHANGES` with the `<summary>` as the review body and no `comments[]` array. This combination is rare (the reviewer's contract says `request-changes` requires at least one blocker or load-bearing concern); if it happens, faithfully encode the verdict and trust the reviewer's reasoning is in the summary.
 

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -80,7 +80,7 @@ The `reviewer` subagent is the analyst; you are the integration layer between it
    | `request-changes` | `REQUEST_CHANGES` |
    | `comment`         | `COMMENT`         |
 
-   **Operator approval policy.** If the inbound carries a note that PR approval is disabled (`channels.github.allowApprove: false` — the adapter appends "Operator policy: PR approval is disabled for this agent" to the message), you must **not** submit an `APPROVE`. Map an `approve` verdict to `COMMENT` instead: post the same `<summary>` and all inline `comments[]` as a `COMMENT` review, just without the formal approval. `request-changes` and `comment` verdicts are unaffected (they never approve). Absent that note, approval is enabled and the table above applies unchanged.
+   **Operator approval policy.** If the inbound carries a note that PR approval is disabled (`channels.github.review.approve: false` — the adapter appends "Operator policy: PR approval is disabled for this agent" to the message), you must **not** submit an `APPROVE`. Map an `approve` verdict to `COMMENT` instead: post the same `<summary>` and all inline `comments[]` as a `COMMENT` review, just without the formal approval. `request-changes` and `comment` verdicts are unaffected (they never approve). Absent that note, approval is enabled and the table above applies unchanged.
 
    Then submit the review. **Write the JSON payload to a file with the `write` tool, then run a single bare `gh api --input <file>`** — two steps:
 
@@ -128,7 +128,7 @@ The `reviewer` subagent is the analyst; you are the integration layer between it
 
 A finding is "actionable" if its severity is `blocker`, `concern`, or `nit`. The inline-review post in step 4 applies whenever the actionable count is **at least one**. When the reviewer returns **exactly zero** actionable findings (only `praise`, or none), there is nothing to anchor inline — handle by verdict:
 
-- `approve` → post a plain `APPROVE` with the `<summary>` as the review body (no `comments[]` array). **If the operator approval policy above disabled approval, post the `<summary>` as a top-level PR comment via `gh api -X POST /repos/.../issues/<N>/comments` instead — do not submit any review.**
+- `approve` → post a plain `APPROVE` with the `<summary>` as the review body (no `comments[]` array). **If the operator approval policy above disabled approval, submit a `COMMENT` review instead — same `<summary>` as the review body, `event: "COMMENT"`, no `comments[]` array. Keep it a formal review, not a top-level issue comment, so the review metadata and flow are preserved.**
 - `comment` → post the summary as a top-level PR comment via `gh api -X POST /repos/.../issues/<N>/comments` instead of submitting an empty review.
 - `request-changes` → submit `REQUEST_CHANGES` with the `<summary>` as the review body and no `comments[]` array. This combination is rare (the reviewer's contract says `request-changes` requires at least one blocker or load-bearing concern); if it happens, faithfully encode the verdict and trust the reviewer's reasoning is in the summary.
 


### PR DESCRIPTION
## Background

When the github channel reviews a PR, the agent currently maps the reviewer subagent's `approve` verdict straight to a formal GitHub `APPROVE` review. There was no way for an operator to allow the agent to *review* PRs (post line-anchored findings) while withholding the authority to *approve* them — a common policy split for a bot account that should comment but never be a green-checkmark approver.

This adds `channels.github.allowApprove` (boolean, **default `true`**, so existing behavior is unchanged). When set to `false`, the agent reviews and comments as before but downgrades any `approve` verdict to a `COMMENT` review — findings still posted, no formal approval.

## Summary

The gate is delivered as an **operator-policy note appended to inbound message text** by the github adapter, and consumed by the `typeclaw-channel-github` skill's verdict→event mapping.

**Why inbound text and not a bash-layer block (the obvious choice):** approval is posted via `gh api --input /tmp/review.json`, so the `event: "APPROVE"` value lives in a temp file. The `github-cli-auth` interceptor only sees the command string (not the file) and early-returns for classic PATs, so a reliable hard block at the bash layer isn't feasible without reading arbitrary temp files. The skill is the single chokepoint every review passes through, so steering the verdict→event mapping there is the reliable seam.

**Why ride the note on every inbound (only when disabled):** the agent is asked to review two ways — a `review_requested` webhook (clean synthetic inbound) *and* plain-language asks ("@bot review #123") that arrive on arbitrary issue/PR/discussion comments. A note attached only to `review_requested` would silently leave plain-language approvals ungated. Appending one line to every github inbound — gated entirely behind the non-default `false` — closes that hole with zero cost on the default (enabled) path.

## What this does NOT do

- Does not change the default: approval stays enabled unless an operator explicitly sets `allowApprove: false`.
- Does not hard-block approval at the API/bash layer — enforcement is via the skill honoring the policy note (see the bash-layer rationale above).
- Does not touch `request-changes` or `comment` verdicts; those never approve regardless.

## Review notes

- Load-bearing change: `withApprovalPolicy` in `src/channels/adapters/github/inbound.ts` (applied once at the `route()` seam) and the policy section added to the skill's verdict→event mapping.
- Invariant to verify: with `allowApprove` defaulted/true, inbound text is byte-identical to before (covered by the "does not append when allowed / when omitted" tests).
- `lifecycle.test.ts` / `manager.test.ts` carry one-line fixture updates only — the new schema field is required, so those `GithubAdapterConfig` literals must include it to compile.