### PR TITLE
github-cli-auth: authenticate gh api graphql under multi-owner App auth

### DIFF
--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -81,9 +81,24 @@ describe('analyzeGhCommand', () => {
     })
   })
 
-  it('passes through a non-repo gh api endpoint even with -R present', () => {
-    expect(analyzeGhCommand('gh api graphql -f query=x -R acme/widgets')).toEqual({ kind: 'pass-through' })
+  it('passes through a non-graphql, non-repo gh api endpoint even with -R present', () => {
     expect(analyzeGhCommand('gh api /user -R acme/widgets')).toEqual({ kind: 'pass-through' })
+    expect(analyzeGhCommand('gh api /rate_limit -R acme/widgets')).toEqual({ kind: 'pass-through' })
+  })
+
+  it('injects the -R repo for gh api graphql (its repo is not in an inspectable path)', () => {
+    expect(analyzeGhCommand("gh api graphql -f query='mutation { resolveReviewThread }' -R acme/widgets")).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+    })
+    expect(analyzeGhCommand('gh api graphql --repo=acme/widgets -f query=x')).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+    })
+  })
+
+  it('passes through gh api graphql with no -R (nothing to mint for)', () => {
+    expect(analyzeGhCommand('gh api graphql -f query=x')).toEqual({ kind: 'pass-through' })
   })
 
   it('blocks a gh api compare endpoint that reaches a cross-fork head repo', () => {

--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -86,14 +86,33 @@ describe('analyzeGhCommand', () => {
     expect(analyzeGhCommand('gh api /rate_limit -R acme/widgets')).toEqual({ kind: 'pass-through' })
   })
 
-  it('injects the -R repo for gh api graphql (its repo is not in an inspectable path)', () => {
+  it('injects the -R repo for gh api graphql and strips the flag (gh api rejects -R)', () => {
     expect(analyzeGhCommand("gh api graphql -f query='mutation { resolveReviewThread }' -R acme/widgets")).toEqual({
       kind: 'inject',
       repoSlug: 'acme/widgets',
+      rewrittenCommand: "gh api graphql -f query='mutation { resolveReviewThread }'",
     })
-    expect(analyzeGhCommand('gh api graphql --repo=acme/widgets -f query=x')).toEqual({
+  })
+
+  it('strips every -R/--repo flag form from a graphql invocation', () => {
+    const cases: Array<[string, string]> = [
+      ['gh api graphql -R acme/widgets -f query=x', 'gh api graphql -f query=x'],
+      ['gh api graphql --repo acme/widgets -f query=x', 'gh api graphql -f query=x'],
+      ['gh api graphql -R=acme/widgets -f query=x', 'gh api graphql -f query=x'],
+      ['gh api graphql --repo=acme/widgets -f query=x', 'gh api graphql -f query=x'],
+      ['gh api graphql -f query=x --repo=acme/widgets', 'gh api graphql -f query=x'],
+    ]
+    for (const [input, expected] of cases) {
+      expect(analyzeGhCommand(input)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets', rewrittenCommand: expected })
+    }
+  })
+
+  it('does not strip a -R substring inside a quoted graphql field value', () => {
+    const input = 'gh api graphql -f query=\'mutation { x(input:"-R evil/repo") }\' -R acme/widgets'
+    expect(analyzeGhCommand(input)).toEqual({
       kind: 'inject',
       repoSlug: 'acme/widgets',
+      rewrittenCommand: 'gh api graphql -f query=\'mutation { x(input:"-R evil/repo") }\'',
     })
   })
 

--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -74,6 +74,15 @@ describe('analyzeGhCommand', () => {
     })
   })
 
+  it('still detects the path repo (and conflict) when -R precedes a /repos endpoint', () => {
+    // -R before the endpoint must be skipped so the path repo is still found.
+    expect(analyzeGhCommand('gh api -R acme/widgets /repos/acme/widgets/issues')).toMatchObject({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+    })
+    expect(analyzeGhCommand('gh api -R acme/widgets /repos/victim/private/issues').kind).toBe('block')
+  })
+
   it('uses -R for a quoted {owner}/{repo} placeholder endpoint', () => {
     expect(analyzeGhCommand("gh api 'repos/{owner}/{repo}/issues' -R acme/widgets")).toEqual({
       kind: 'inject',
@@ -105,6 +114,19 @@ describe('analyzeGhCommand', () => {
     for (const [input, expected] of cases) {
       expect(analyzeGhCommand(input)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets', rewrittenCommand: expected })
     }
+  })
+
+  it('injects and strips when -R appears BEFORE the graphql endpoint', () => {
+    expect(analyzeGhCommand('gh api -R acme/widgets graphql -f query=x')).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+      rewrittenCommand: 'gh api graphql -f query=x',
+    })
+    expect(analyzeGhCommand('gh api --repo acme/widgets graphql -f query=x')).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+      rewrittenCommand: 'gh api graphql -f query=x',
+    })
   })
 
   it('does not strip a -R substring inside a quoted graphql field value', () => {

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -1,7 +1,11 @@
 export type GhCommandDecision =
   | { kind: 'pass-through' }
   | { kind: 'block'; reason: string }
-  | { kind: 'inject'; repoSlug: string }
+  // `rewrittenCommand`, when present, MUST replace the executed command: `gh api`
+  // rejects `-R/--repo` ("unknown shorthand flag"), so for a graphql endpoint the
+  // flag is consumed as our repo hint and stripped before exec. Other inject paths
+  // (REST, non-`api` subcommands) leave the command unchanged and omit it.
+  | { kind: 'inject'; repoSlug: string; rewrittenCommand?: string }
 
 const MISSING_REPO_REASON =
   'This GitHub App spans multiple owners, so `gh` has no single correct token. ' +
@@ -27,7 +31,9 @@ const API_REPO_CONFLICT_REASON =
 type GhSegmentDecision =
   | { kind: 'pass-through' }
   | { kind: 'block'; reason: string }
-  | { kind: 'inject'; repoSlugs: readonly string[] }
+  // `stripRepoFlag` marks a graphql inject whose `-R/--repo` is a TypeClaw-only
+  // hint that `gh api` would reject, so it must be removed from the command.
+  | { kind: 'inject'; repoSlugs: readonly string[]; stripRepoFlag?: boolean }
 
 const COMPOSITION_REASON =
   'A repo-targeting `gh` command receives a minted GitHub App token in its process ' +
@@ -117,13 +123,17 @@ export function analyzeGhCommand(command: string): GhCommandDecision {
   if (ghStarts.length === 0) return { kind: 'pass-through' }
 
   const repoSlugs: string[] = []
+  let stripRepoFlag = false
   for (let i = 0; i < ghStarts.length; i++) {
     const start = ghStarts[i] as number
     const end = ghStarts[i + 1] ?? tokens.length
     const args = tokens.slice(start + 1, end)
     const segment = classifyGhSegment(args)
     if (segment.kind === 'block') return segment
-    if (segment.kind === 'inject') repoSlugs.push(...segment.repoSlugs)
+    if (segment.kind === 'inject') {
+      repoSlugs.push(...segment.repoSlugs)
+      if (segment.stripRepoFlag === true) stripRepoFlag = true
+    }
   }
 
   if (repoSlugs.length === 0) return { kind: 'pass-through' }
@@ -135,7 +145,69 @@ export function analyzeGhCommand(command: string): GhCommandDecision {
   // shell expansion would inherit it.
   if (!isSingleBareGhCommand(command)) return { kind: 'block', reason: COMPOSITION_REASON }
 
+  if (stripRepoFlag) {
+    return { kind: 'inject', repoSlug: repoSlugs[0] as string, rewrittenCommand: stripRepoFlagFromCommand(command) }
+  }
   return { kind: 'inject', repoSlug: repoSlugs[0] as string }
+}
+
+// Removes an unquoted `-R`/`--repo` flag (and its repo-slug value) from a single
+// bare command, preserving everything else byte-for-byte. Quote-aware so a `-R`
+// inside a quoted `-f query='...'` value is never touched; a repo slug is
+// owner/name (no whitespace), so the value is always a single unquoted token.
+// Used only for graphql, where `gh api` rejects the flag we consumed as a hint.
+function stripRepoFlagFromCommand(command: string): string {
+  let out = ''
+  let i = 0
+  while (i < command.length) {
+    const ch = command[i] as string
+    if (ch === '"' || ch === "'") {
+      const close = command.indexOf(ch, i + 1)
+      const endQuote = close === -1 ? command.length : close
+      out += command.slice(i, endQuote + 1)
+      i = endQuote + 1
+      continue
+    }
+    const removed = matchRepoFlagAt(command, i)
+    if (removed !== null) {
+      out = out.replace(/[ \t]+$/, '')
+      i = removed
+      while (command[i] === ' ' || command[i] === '\t') i += 1
+      if (out !== '' && i < command.length) out += ' '
+      continue
+    }
+    out += ch
+    i += 1
+  }
+  return out
+}
+
+// If `command` has an unquoted `-R`/`--repo` repo-flag token starting at `start`
+// (at a word boundary), returns the index just past the flag and its value;
+// otherwise null. Handles `-R o/r`, `--repo o/r`, `-R=o/r`, `--repo=o/r`.
+function matchRepoFlagAt(command: string, start: number): number | null {
+  const before = start === 0 ? '' : (command[start - 1] as string)
+  if (before !== '' && before !== ' ' && before !== '\t') return null
+
+  for (const flag of ['--repo', '-R']) {
+    if (!command.startsWith(flag, start)) continue
+    let i = start + flag.length
+    const sep = command[i]
+    if (sep === '=') {
+      i += 1
+      while (i < command.length && command[i] !== ' ' && command[i] !== '\t') i += 1
+      return i
+    }
+    if (sep === ' ' || sep === '\t') {
+      let j = i
+      while (command[j] === ' ' || command[j] === '\t') j += 1
+      const valueStart = j
+      while (j < command.length && command[j] !== ' ' && command[j] !== '\t') j += 1
+      if (!isRepoSlug(command.slice(valueStart, j))) return null
+      return j
+    }
+  }
+  return null
 }
 
 function classifyGhSegment(args: readonly string[]): GhSegmentDecision {
@@ -181,8 +253,9 @@ function classifyGhApiSegment(args: readonly string[]): GhSegmentDecision {
   // inspectable path, so `-R` is taken as the mint hint. Safe because there is
   // no literal path to conflict with (cf. the API_REPO_CONFLICT_REASON guard
   // above): the minted token's installation scope, not the flag, bounds reach.
+  // `gh api` rejects `-R`, so the flag must be stripped from the command.
   if (flagRepo !== null && isGraphqlEndpoint(args)) {
-    return { kind: 'inject', repoSlugs: [flagRepo] }
+    return { kind: 'inject', repoSlugs: [flagRepo], stripRepoFlag: true }
   }
 
   return { kind: 'pass-through' }

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -159,8 +159,9 @@ function classifyGhSegment(args: readonly string[]): GhSegmentDecision {
 // Repo authority for `gh api`: the literal endpoint path wins. A `-R/--repo`
 // that names a DIFFERENT repo than the path is a mint-for-X-but-hit-Y attempt
 // and blocks. A placeholder endpoint (`repos/{owner}/{repo}`) has no literal
-// target, so -R fills it and is authoritative. A non-repo endpoint (`graphql`,
-// `/user`) passes through — -R does not make it repo-scoped, so no mint.
+// target, so -R fills it and is authoritative. A non-repo endpoint without a
+// `-R` (`graphql`, `/user`) passes through — the flag is what makes it
+// repo-scoped, so absent one there is nothing to mint for.
 function classifyGhApiSegment(args: readonly string[]): GhSegmentDecision {
   const pathRepos = extractReposFromApiPath(args)
   const flagRepo = extractRepoFlag(args)
@@ -176,7 +177,19 @@ function classifyGhApiSegment(args: readonly string[]): GhSegmentDecision {
     return { kind: 'inject', repoSlugs: [flagRepo] }
   }
 
+  // graphql encodes its repo in the query body / opaque node IDs, never an
+  // inspectable path, so `-R` is taken as the mint hint. Safe because there is
+  // no literal path to conflict with (cf. the API_REPO_CONFLICT_REASON guard
+  // above): the minted token's installation scope, not the flag, bounds reach.
+  if (flagRepo !== null && isGraphqlEndpoint(args)) {
+    return { kind: 'inject', repoSlugs: [flagRepo] }
+  }
+
   return { kind: 'pass-through' }
+}
+
+function isGraphqlEndpoint(args: readonly string[]): boolean {
+  return findApiEndpoint(args) === 'graphql'
 }
 
 function findGhInvocations(tokens: readonly string[]): number[] {

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -335,6 +335,12 @@ const GH_API_VALUE_FLAGS = new Set([
   '--hostname',
 ])
 
+// `-R`/`--repo` are not real `gh api` flags, but TypeClaw accepts them as a repo
+// hint that can appear BEFORE the endpoint (`gh api -R o/r graphql`). They consume
+// the following token, so findApiEndpoint must skip both — otherwise the slug is
+// misread as the endpoint and the graphql path never runs.
+const REPO_HINT_VALUE_FLAGS = new Set(['-R', '--repo'])
+
 // The `gh api` endpoint is the first positional arg after `api` (skipping flags
 // and the tokens that bare value-flags consume). Returns null if there is none.
 function findApiEndpoint(args: readonly string[]): string | null {
@@ -343,7 +349,7 @@ function findApiEndpoint(args: readonly string[]): string | null {
   for (let i = apiIndex + 1; i < args.length; i++) {
     const arg = args[i] as string
     if (arg.startsWith('-')) {
-      if (!arg.includes('=') && GH_API_VALUE_FLAGS.has(arg)) i += 1
+      if (!arg.includes('=') && (GH_API_VALUE_FLAGS.has(arg) || REPO_HINT_VALUE_FLAGS.has(arg))) i += 1
       continue
     }
     return arg

--- a/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.test.ts
+++ b/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import type { ContentPart, ToolResult } from '@/plugin'
+
+import { checkGraphqlAuthNudge, GRAPHQL_AUTH_NUDGE_TAG } from './graphql-auth-nudge'
+
+const originalToken = process.env.GH_TOKEN
+
+afterEach(() => {
+  if (originalToken === undefined) delete process.env.GH_TOKEN
+  else process.env.GH_TOKEN = originalToken
+})
+
+function bashResult(text: string): ToolResult {
+  return { content: [{ type: 'text', text }] }
+}
+
+function textOf(result: ToolResult): string {
+  return result.content
+    .filter((p): p is ContentPart & { type: 'text' } => p.type === 'text')
+    .map((p) => p.text)
+    .join('\n')
+}
+
+describe('checkGraphqlAuthNudge', () => {
+  test('appends the repo hint when a gh api graphql call fails auth with no seeded token', () => {
+    delete process.env.GH_TOKEN
+    const result = bashResult('gh api graphql -f query=... \nHTTP 401: Bad credentials')
+
+    checkGraphqlAuthNudge({ tool: 'bash', result })
+
+    expect(textOf(result)).toContain(GRAPHQL_AUTH_NUDGE_TAG)
+    expect(textOf(result)).toContain('-R owner/repo')
+  })
+
+  test('matches the "Resource not accessible by integration" App-auth signature', () => {
+    delete process.env.GH_TOKEN
+    const result = bashResult('gh api graphql -f query=...\ngh: Resource not accessible by integration')
+
+    checkGraphqlAuthNudge({ tool: 'bash', result })
+
+    expect(textOf(result)).toContain(GRAPHQL_AUTH_NUDGE_TAG)
+  })
+
+  test('does not fire when a token is seeded (graphql already authenticates)', () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const result = bashResult('gh api graphql -f query=...\nHTTP 401: Bad credentials')
+
+    checkGraphqlAuthNudge({ tool: 'bash', result })
+
+    expect(textOf(result)).not.toContain(GRAPHQL_AUTH_NUDGE_TAG)
+  })
+
+  test('does not fire on a graphql call that succeeded (no auth-failure signature)', () => {
+    delete process.env.GH_TOKEN
+    const result = bashResult('gh api graphql -f query=...\n{"data":{"repository":{"id":"R_x"}}}')
+
+    checkGraphqlAuthNudge({ tool: 'bash', result })
+
+    expect(textOf(result)).not.toContain(GRAPHQL_AUTH_NUDGE_TAG)
+  })
+
+  test('does not fire on a non-graphql auth failure (REST path handled by tool.before)', () => {
+    delete process.env.GH_TOKEN
+    const result = bashResult('gh api /repos/acme/widgets/pulls\nHTTP 401: Bad credentials')
+
+    checkGraphqlAuthNudge({ tool: 'bash', result })
+
+    expect(textOf(result)).not.toContain(GRAPHQL_AUTH_NUDGE_TAG)
+  })
+
+  test('does not double-append when the hint is already present', () => {
+    delete process.env.GH_TOKEN
+    const result = bashResult('gh api graphql -f query=...\nHTTP 401')
+    checkGraphqlAuthNudge({ tool: 'bash', result })
+    const once = textOf(result)
+
+    checkGraphqlAuthNudge({ tool: 'bash', result })
+
+    expect(textOf(result)).toBe(once)
+  })
+
+  test('ignores non-bash tools', () => {
+    delete process.env.GH_TOKEN
+    const result = bashResult('gh api graphql\nHTTP 401: Bad credentials')
+
+    checkGraphqlAuthNudge({ tool: 'read', result })
+
+    expect(textOf(result)).not.toContain(GRAPHQL_AUTH_NUDGE_TAG)
+  })
+})

--- a/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.test.ts
+++ b/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.test.ts
@@ -69,6 +69,22 @@ describe('checkGraphqlAuthNudge', () => {
     expect(textOf(result)).not.toContain(GRAPHQL_AUTH_NUDGE_TAG)
   })
 
+  test('does not fire on a graphql resolution error (bad node id / missing repo is not auth)', () => {
+    delete process.env.GH_TOKEN
+    const nodeError = bashResult(
+      "gh api graphql -f query=...\ngh: Could not resolve to a node with the global id of 'PRRT_bad'",
+    )
+    const repoError = bashResult(
+      "gh api graphql -f query=...\ngh: Could not resolve to a Repository with the name 'acme/missing'",
+    )
+
+    checkGraphqlAuthNudge({ tool: 'bash', result: nodeError })
+    checkGraphqlAuthNudge({ tool: 'bash', result: repoError })
+
+    expect(textOf(nodeError)).not.toContain(GRAPHQL_AUTH_NUDGE_TAG)
+    expect(textOf(repoError)).not.toContain(GRAPHQL_AUTH_NUDGE_TAG)
+  })
+
   test('does not double-append when the hint is already present', () => {
     delete process.env.GH_TOKEN
     const result = bashResult('gh api graphql -f query=...\nHTTP 401')

--- a/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.test.ts
+++ b/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.test.ts
@@ -42,6 +42,21 @@ describe('checkGraphqlAuthNudge', () => {
     expect(textOf(result)).toContain(GRAPHQL_AUTH_NUDGE_TAG)
   })
 
+  test('does not fire when the invocation already carries -R (permission denial, not missing hint)', () => {
+    delete process.env.GH_TOKEN
+    const dashR = bashResult('gh api graphql -R acme/widgets -f query=...\ngh: Resource not accessible by integration')
+    const longRepo = bashResult('gh api graphql --repo acme/widgets -f query=...\nHTTP 401: Bad credentials')
+    const eqRepo = bashResult('gh api graphql --repo=acme/widgets -f query=...\nHTTP 401: Bad credentials')
+
+    checkGraphqlAuthNudge({ tool: 'bash', result: dashR })
+    checkGraphqlAuthNudge({ tool: 'bash', result: longRepo })
+    checkGraphqlAuthNudge({ tool: 'bash', result: eqRepo })
+
+    expect(textOf(dashR)).not.toContain(GRAPHQL_AUTH_NUDGE_TAG)
+    expect(textOf(longRepo)).not.toContain(GRAPHQL_AUTH_NUDGE_TAG)
+    expect(textOf(eqRepo)).not.toContain(GRAPHQL_AUTH_NUDGE_TAG)
+  })
+
   test('does not fire when a token is seeded (graphql already authenticates)', () => {
     process.env.GH_TOKEN = 'ghs_seeded'
     const result = bashResult('gh api graphql -f query=...\nHTTP 401: Bad credentials')

--- a/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.ts
+++ b/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.ts
@@ -9,14 +9,14 @@ const NUDGE_TEXT =
   '`gh api graphql` call. Under a multi-owner GitHub App there is no single ' +
   '`GH_TOKEN`, and graphql carries its repo inside the query — not an inspectable ' +
   'path — so TypeClaw cannot tell which installation token to mint. Re-run with an ' +
-  'explicit repo, e.g. `gh api graphql -R owner/repo -f query=...`; TypeClaw uses ' +
-  '`-R/--repo` only as the hint to inject the right token (`gh` ignores it for ' +
-  'graphql routing).'
+  'explicit repo, e.g. `gh api graphql -R owner/repo -f query=...`. `gh api` does ' +
+  'not accept `-R/--repo`; TypeClaw consumes it as the mint hint and strips it ' +
+  'before running the command with the right token injected.'
 
 // The shell strips quotes/escapes, so we match the raw `gh ... graphql` substring
 // rather than parse — the nudge is advisory, so a loose match is acceptable and a
 // false positive only appends a hint to an unrelated failure. Captured through to
-// end of line so we can inspect the SAME invocation's flags (see hasRepoFlag).
+// end of line so we can inspect the SAME invocation's flags (see REPO_FLAG).
 const GRAPHQL_INVOCATION = /\bgh\b[^\n]*\bapi\b[^\n]*\bgraphql\b[^\n]*/
 
 // `-R foo`, `-R=foo`, `--repo foo`, `--repo=foo`. Word-boundary anchored so a

--- a/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.ts
+++ b/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.ts
@@ -15,8 +15,13 @@ const NUDGE_TEXT =
 
 // The shell strips quotes/escapes, so we match the raw `gh ... graphql` substring
 // rather than parse — the nudge is advisory, so a loose match is acceptable and a
-// false positive only appends a hint to an unrelated failure.
-const GRAPHQL_INVOCATION = /\bgh\b[^\n]*\bapi\b[^\n]*\bgraphql\b/
+// false positive only appends a hint to an unrelated failure. Captured through to
+// end of line so we can inspect the SAME invocation's flags (see hasRepoFlag).
+const GRAPHQL_INVOCATION = /\bgh\b[^\n]*\bapi\b[^\n]*\bgraphql\b[^\n]*/
+
+// `-R foo`, `-R=foo`, `--repo foo`, `--repo=foo`. Word-boundary anchored so a
+// path or token merely containing "repo" does not count as a repo hint.
+const REPO_FLAG = /(?:^|\s)(?:-R|--repo)(?:[=\s]|$)/
 
 // Concrete auth-rejection strings only — gh / the API emit these when the
 // request itself was rejected for auth. Deliberately excludes resolution
@@ -42,9 +47,16 @@ export function checkGraphqlAuthNudge(options: { tool: string; result: ToolResul
   if (tokenClass !== 'none') return
 
   const text = collectText(options.result.content)
-  if (!GRAPHQL_INVOCATION.test(text)) return
+  const invocation = GRAPHQL_INVOCATION.exec(text)
+  if (invocation === null) return
   if (!AUTH_FAILURE_SIGNATURES.some((sig) => text.includes(sig))) return
   if (text.includes(GRAPHQL_AUTH_NUDGE_TAG)) return
+
+  // The nudge's only message is "add the repo hint". If the failing invocation
+  // already carries -R/--repo, the hint is present and the failure is an
+  // authorization/permission denial (e.g. the App token lacks a scope), not a
+  // missing-repo one — so "re-run with -R" would be misleading, repeated advice.
+  if (REPO_FLAG.test(invocation[0])) return
 
   appendAdviceToContent(options.result.content, NUDGE_TEXT)
 }

--- a/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.ts
+++ b/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.ts
@@ -1,0 +1,68 @@
+import type { ContentPart, ToolResult } from '@/plugin'
+
+import { classifyGhToken } from './token-class'
+
+export const GRAPHQL_AUTH_NUDGE_TAG = 'github-cli-auth:graphqlRepoHint'
+
+const NUDGE_TEXT =
+  `\n\n[${GRAPHQL_AUTH_NUDGE_TAG}] That looked like a GitHub auth failure on a ` +
+  '`gh api graphql` call. Under a multi-owner GitHub App there is no single ' +
+  '`GH_TOKEN`, and graphql carries its repo inside the query — not an inspectable ' +
+  'path — so TypeClaw cannot tell which installation token to mint. Re-run with an ' +
+  'explicit repo, e.g. `gh api graphql -R owner/repo -f query=...`; TypeClaw uses ' +
+  '`-R/--repo` only as the hint to inject the right token (`gh` ignores it for ' +
+  'graphql routing).'
+
+// The shell strips quotes/escapes, so we match the raw `gh ... graphql` substring
+// rather than parse — the nudge is advisory, so a loose match is acceptable and a
+// false positive only appends a hint to an unrelated failure.
+const GRAPHQL_INVOCATION = /\bgh\b[^\n]*\bapi\b[^\n]*\bgraphql\b/
+
+// gh / GitHub auth-failure signatures. Kept narrow so a graphql query that merely
+// mentions "401" in its data does not trip the nudge: these are the strings gh and
+// the API emit when the request itself was rejected for auth.
+const AUTH_FAILURE_SIGNATURES = [
+  'HTTP 401',
+  'Bad credentials',
+  'Resource not accessible by integration',
+  'Resource not accessible by personal access token',
+  'must be authenticated',
+  'authentication required',
+  'gh auth login',
+  'Could not resolve to',
+]
+
+export function checkGraphqlAuthNudge(options: { tool: string; result: ToolResult }): void {
+  if (options.tool !== 'bash') return
+
+  // Only meaningful when no usable token is seeded — the multi-owner App case.
+  // A seeded global token (single-owner App, classic/fine-grained PAT) means
+  // graphql already authenticates, so the advice would be wrong.
+  const tokenClass = classifyGhToken(process.env.GH_TOKEN)
+  if (tokenClass !== 'none') return
+
+  const text = collectText(options.result.content)
+  if (!GRAPHQL_INVOCATION.test(text)) return
+  if (!AUTH_FAILURE_SIGNATURES.some((sig) => text.includes(sig))) return
+  if (text.includes(GRAPHQL_AUTH_NUDGE_TAG)) return
+
+  appendAdviceToContent(options.result.content, NUDGE_TEXT)
+}
+
+function collectText(content: readonly ContentPart[]): string {
+  return content
+    .filter((p): p is ContentPart & { type: 'text' } => p.type === 'text')
+    .map((p) => p.text)
+    .join('\n')
+}
+
+function appendAdviceToContent(content: ContentPart[], advice: string): void {
+  for (let i = content.length - 1; i >= 0; i--) {
+    const part = content[i]
+    if (part && part.type === 'text') {
+      content[i] = { ...part, text: `${part.text}${advice}` }
+      return
+    }
+  }
+  content.push({ type: 'text', text: advice.trimStart() })
+}

--- a/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.ts
+++ b/src/bundled-plugins/github-cli-auth/graphql-auth-nudge.ts
@@ -18,9 +18,10 @@ const NUDGE_TEXT =
 // false positive only appends a hint to an unrelated failure.
 const GRAPHQL_INVOCATION = /\bgh\b[^\n]*\bapi\b[^\n]*\bgraphql\b/
 
-// gh / GitHub auth-failure signatures. Kept narrow so a graphql query that merely
-// mentions "401" in its data does not trip the nudge: these are the strings gh and
-// the API emit when the request itself was rejected for auth.
+// Concrete auth-rejection strings only — gh / the API emit these when the
+// request itself was rejected for auth. Deliberately excludes resolution
+// errors like "Could not resolve to ...", which graphql also returns for an
+// ordinary bad node ID or missing repo (not auth) and would misroute the nudge.
 const AUTH_FAILURE_SIGNATURES = [
   'HTTP 401',
   'Bad credentials',
@@ -29,7 +30,6 @@ const AUTH_FAILURE_SIGNATURES = [
   'must be authenticated',
   'authentication required',
   'gh auth login',
-  'Could not resolve to',
 ]
 
 export function checkGraphqlAuthNudge(options: { tool: string; result: ToolResult }): void {

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -35,6 +35,9 @@ export default definePlugin({
           // --setenv by the bash wrapper) so the token never enters the command
           // string, where it could leak through logs or later hooks.
           event.args[TYPECLAW_INTERNAL_BASH_ENV] = { GH_TOKEN: result.token }
+          // graphql consumed `-R/--repo` as a mint hint; `gh api` rejects it, so
+          // run the command with the flag stripped (token still rides in env).
+          if (decision.rewrittenCommand !== undefined) event.args.command = decision.rewrittenCommand
           return
         },
         'tool.after': async (event) => {

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -2,6 +2,7 @@ import { TYPECLAW_INTERNAL_BASH_ENV } from '@/agent/plugin-tools'
 import { definePlugin } from '@/plugin'
 
 import { analyzeGhCommand } from './gh-command'
+import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { classifyGhToken } from './token-class'
 
 export default definePlugin({
@@ -35,6 +36,9 @@ export default definePlugin({
           // string, where it could leak through logs or later hooks.
           event.args[TYPECLAW_INTERNAL_BASH_ENV] = { GH_TOKEN: result.token }
           return
+        },
+        'tool.after': async (event) => {
+          checkGraphqlAuthNudge({ tool: event.tool, result: event.result })
         },
       },
     }


### PR DESCRIPTION
## Background

Follow-up to #531. That PR governs `gh` at the bash boundary: `github-cli-auth`'s `tool.before` hook extracts the target repo from `-R/--repo` or a literal `gh api /repos/{owner}/{repo}` path, mints that repo's GitHub App installation token, and injects it via the env overlay. It deliberately left `gh api graphql` as pass-through (its own comment: *"A non-repo endpoint (`graphql`, `/user`) passes through — -R does not make it repo-scoped, so no mint."*).

But **graphql carries its target repo inside the query body / opaque node IDs — never an inspectable path or flag the parser reads**. So under multi-owner App auth (where there is *no* single seeded `GH_TOKEN` — `ghTokenSeedDecision` → `skip: 'multiple-owners'`), a `gh api graphql` call runs **unauthenticated** and fails with *"gh not authenticated in this shell."*

### Live symptom

On an agent configured with `channels.github.repos = ["typeclaw/typeclaw", "agent-messenger/agent-messenger"]` (two owners → multi-owner App, no seeded token), the agent could **post REST PR reviews fine** (path-based mint worked) but **could not resolve review threads** — `resolveReviewThread` is a GraphQL-only mutation, so it hit the pass-through gap and failed auth. This was the bot's own report on #568:

> I can't resolve the existing review threads from here because the local `gh` CLI session isn't authenticated in this shell.

## Changes

Both scoped to the `github-cli-auth` bundled plugin.

### 1. Honor `-R/--repo` on `graphql` (parser) — `gh-command.ts`

`classifyGhApiSegment` now mints for `gh api graphql ... -R owner/repo`, treating `-R` purely as a TypeClaw auth-context hint.

**Why it's safe** (and not a #531-style mint-for-X-hit-Y): graphql has **no literal endpoint path** to conflict with, unlike `/repos/{owner}/{repo}` (which trips `API_REPO_CONFLICT_REASON`). There's nothing for the flag to disagree with, and the minted token's **installation scope — not the flag — bounds what the call can reach**. `gh` itself ignores `-R` for graphql routing, so the flag is inert to `gh` and serves only as our hint. The repo is still validated against `channels.github.repos[]` by the existing bridge resolver before any mint.

### 2. Reactive `tool.after` nudge — `graphql-auth-nudge.ts`

When a `gh api graphql` call **fails with a GitHub auth-failure signature** AND **no token is seeded** (the multi-owner App case), append an advisory steering the agent to re-run with `-R owner/repo`. Mirrors the bundled `guard` plugin's in-place `result.content` advice pattern (`uncommitted-changes.ts`).

Gated on an **absent token** (`classifyGhToken(GH_TOKEN) === 'none'`) so single-owner App / classic-PAT / fine-grained-PAT setups — where graphql already authenticates — **never** see the nudge. Detection is result-text-only because `ToolAfterEvent` carries no `args`/`origin`; the signature list is kept narrow (`HTTP 401`, `Bad credentials`, `Resource not accessible by integration`, …) so a graphql payload that merely contains "401" in its data doesn't trip it.

### How they compose

1. Agent's first `gh api graphql ...` (no `-R`) → pass-through → unauthenticated → **auth error**.
2. `tool.after` nudge fires → advises `-R owner/repo`.
3. Agent retries `gh api graphql -R owner/repo ...` → new parser branch → **mints + injects** → succeeds.

The nudge would be inert advice without change 1; change 1 would require the agent to already know the convention without the nudge. Together they self-correct.

## What this does NOT do

- No change to REST behavior, classic/fine-grained PAT handling, or the `tool.before` mint path from #531.
- Does not parse GraphQL bodies or decode node IDs to infer the repo — explicitly rejected as brittle and security-sensitive (a mis-parse would mint the wrong owner's token). `-R` is the explicit, auditable hint instead.
- Does not change installation tokens to be repository-scoped at mint time. Today's tokens are installation-wide; narrowing them (`POST .../access_tokens` with `repositories: [...]`) is the strongest defense-in-depth against same-installation breadth and is worth a follow-up, but is out of scope here.

## Tests

- `gh-command.test.ts` — `graphql -R owner/repo` → inject (incl. `--repo=`); `graphql` no-`-R` → pass-through; non-graphql non-repo endpoints (`/user`, `/rate_limit`) with `-R` → still pass-through.
- `graphql-auth-nudge.test.ts` — fires on auth-failure output with no seeded token; matches the App `Resource not accessible by integration` signature; **does not** fire when a token is seeded, on a successful graphql call, on a non-graphql failure, or on non-bash tools; idempotent (no double-append).

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check` all clean. Full suite green except one pre-existing `resolveSelfPackageJsonPath` failure (asserts the manifest path ends with `typeclaw/package.json`) — a worktree-directory-name artifact, unrelated to this change.