### PR TITLE
inspect: scope the live-tail lifecycle per iteration to stop TUI freezes

### DIFF
--- a/src/cli/inspect-controller.ts
+++ b/src/cli/inspect-controller.ts
@@ -64,3 +64,95 @@ export function createEscController({ debounceMs }: { debounceMs: number }): Esc
     },
   }
 }
+
+export type TailIntent = 'back' | 'exit'
+
+export type TailScope = {
+  signal: AbortSignal
+  // null when the tail ended on its own (stream closed / replay-only); the loop
+  // treats null the same as 'back'. The stream only ever sees signal.aborted —
+  // intent is read by the loop, keeping abort decoupled from what abort meant.
+  intent: () => TailIntent | null
+  dispose: () => void
+}
+
+type RawInput = Pick<NodeJS.ReadStream, 'isTTY' | 'setRawMode' | 'resume' | 'on' | 'off'>
+
+type ProcessSignals = Pick<NodeJS.Process, 'once' | 'off'>
+
+// One disposable interaction scope per live-tail iteration. Creates a FRESH
+// AbortController, installs a temporary raw-mode 'data' listener plus
+// SIGINT/SIGTERM handlers, and tears all of it down on dispose(). This mirrors
+// the `dreams` viewer-key pattern: raw mode is scoped to a single tail attempt
+// and never survives into the clack picker, which removes the pause/resume
+// state machine that made the old inspect listener fragile.
+export function createTailScope(opts: { debounceMs: number; input?: RawInput; proc?: ProcessSignals }): TailScope {
+  const stdin = opts.input ?? process.stdin
+  const proc = opts.proc ?? process
+  const controller = new AbortController()
+  let intent: TailIntent | null = null
+  let disposed = false
+
+  const settle = (next: TailIntent): void => {
+    if (intent === null) intent = next
+    controller.abort()
+  }
+
+  const onSigExit = (): void => {
+    settle('exit')
+  }
+
+  const isTty = Boolean(stdin.isTTY) && typeof stdin.setRawMode === 'function'
+  const esc = isTty ? createEscController({ debounceMs: opts.debounceMs }) : null
+  const escSignal = esc?.armForStream()
+  // A bare ESC fires through the debounce controller, not the 'data' handler:
+  // route its abort into 'back' intent here so the loop can re-open the picker.
+  const onEscAbort = (): void => settle('back')
+
+  const onData = (chunk: Buffer): void => {
+    if (esc === null) return
+    const { sigint } = esc.onChunk(chunk)
+    if (sigint) settle('exit')
+  }
+
+  const dispose = (): void => {
+    if (disposed) return
+    disposed = true
+    proc.off('SIGINT', onSigExit)
+    proc.off('SIGTERM', onSigExit)
+    escSignal?.removeEventListener('abort', onEscAbort)
+    if (esc !== null) {
+      stdin.off('data', onData)
+      esc.dispose()
+      try {
+        stdin.setRawMode(false)
+      } catch {
+        /* terminal already torn down */
+      }
+      // Deliberately NOT stdin.pause(): a paused process.stdin does not reliably
+      // re-flow into the next clack picker under Bun (same reason as
+      // prepareStdinForClack / dreams' waitForViewerKey). Leave it flowing.
+    }
+    // Abort last so a stream still awaiting on this signal unblocks during
+    // teardown rather than hanging.
+    controller.abort()
+  }
+
+  proc.once('SIGINT', onSigExit)
+  proc.once('SIGTERM', onSigExit)
+
+  if (esc !== null && escSignal !== undefined) {
+    escSignal.addEventListener('abort', onEscAbort, { once: true })
+    stdin.setRawMode(true)
+    // Attach the data handler before resume() so no raw-mode keystroke slips
+    // through between resuming the stream and registering the listener.
+    stdin.on('data', onData)
+    stdin.resume()
+  }
+
+  return {
+    signal: controller.signal,
+    intent: () => intent,
+    dispose,
+  }
+}

--- a/src/cli/inspect.test.ts
+++ b/src/cli/inspect.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { EventEmitter } from 'node:events'
 
-import { createEscListener } from './inspect'
+import { createTailScope } from './inspect-controller'
 
 function tick(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -11,6 +11,7 @@ class FakeTty extends EventEmitter {
   isTTY = true as const
   rawMode = false
   resumed = false
+  pauseCalls = 0
   setRawMode(value: boolean): this {
     this.rawMode = value
     return this
@@ -20,6 +21,7 @@ class FakeTty extends EventEmitter {
     return this
   }
   pause(): this {
+    this.pauseCalls += 1
     this.resumed = false
     return this
   }
@@ -28,82 +30,101 @@ class FakeTty extends EventEmitter {
   }
 }
 
-describe('createEscListener wiring', () => {
-  test('returns null when the input is not a TTY', () => {
-    const tty = new FakeTty()
-    tty.isTTY = false as unknown as true
-    expect(createEscListener(() => {}, tty as never)).toBeNull()
-  })
+class FakeProc extends EventEmitter {
+  fire(signal: string): void {
+    this.emit(signal)
+  }
+}
 
-  test('Ctrl-C byte invokes onSigint directly (no SIGINT round-trip)', () => {
-    // given: an armed listener on a fake TTY
+describe('createTailScope wiring', () => {
+  test('arms raw mode and attaches a data handler on a TTY', () => {
     const tty = new FakeTty()
-    let sigints = 0
-    const listener = createEscListener(() => {
-      sigints += 1
-    }, tty as never)!
-    listener.armForStream()
-    // when: the raw 0x03 byte arrives during the live tail
-    tty.feed([0x03])
-    // then: the exit callback fires straight away
-    expect(sigints).toBe(1)
-    listener.stop()
-  })
-
-  test('bare ESC aborts the per-stream signal without touching onSigint', async () => {
-    // given: an armed listener that records sigint calls
-    const tty = new FakeTty()
-    let sigints = 0
-    const listener = createEscListener(() => {
-      sigints += 1
-    }, tty as never)!
-    const escSignal = listener.armForStream()
-    // when: a bare ESC arrives and the debounce window elapses
-    tty.feed([0x1b])
-    await tick(80)
-    // then: only the per-stream esc signal aborts; the exit path is untouched
-    expect(escSignal.aborted).toBe(true)
-    expect(sigints).toBe(0)
-    listener.stop()
-  })
-
-  test('listener attaches its data handler before resuming the stream', () => {
-    const tty = new FakeTty()
-    const order: string[] = []
-    tty.on('newListener', (event) => {
-      if (event === 'data') order.push('listen')
-    })
-    const origResume = tty.resume.bind(tty)
-    tty.resume = function patchedResume(this: FakeTty) {
-      order.push('resume')
-      return origResume()
-    }
-    const listener = createEscListener(() => {}, tty as never)!
-    listener.armForStream()
-    expect(order).toEqual(['listen', 'resume'])
-    listener.stop()
-  })
-
-  test('pause() hands stdin to the picker: raw mode off, listener detached, stream still flowing', () => {
-    // given: an armed listener (raw mode on, our data handler attached)
-    const tty = new FakeTty()
-    let sigints = 0
-    const listener = createEscListener(() => {
-      sigints += 1
-    }, tty as never)!
-    listener.armForStream()
+    const proc = new FakeProc()
+    const scope = createTailScope({ debounceMs: 50, input: tty as never, proc: proc as never })
     expect(tty.rawMode).toBe(true)
+    expect(tty.resumed).toBe(true)
     expect(tty.listenerCount('data')).toBe(1)
-    // when: the picker takes over and we pause the listener
-    listener.pause()
-    // then: raw mode is released and our handler is gone so clack can own input,
-    //       but the stream is NOT paused — otherwise clack never receives bytes
+    scope.dispose()
+  })
+
+  test('Ctrl-C byte aborts with exit intent', () => {
+    const tty = new FakeTty()
+    const proc = new FakeProc()
+    const scope = createTailScope({ debounceMs: 50, input: tty as never, proc: proc as never })
+    tty.feed([0x03])
+    expect(scope.signal.aborted).toBe(true)
+    expect(scope.intent()).toBe('exit')
+    scope.dispose()
+  })
+
+  test('bare ESC aborts with back intent after the debounce window', async () => {
+    const tty = new FakeTty()
+    const proc = new FakeProc()
+    const scope = createTailScope({ debounceMs: 10, input: tty as never, proc: proc as never })
+    tty.feed([0x1b])
+    expect(scope.signal.aborted).toBe(false)
+    await tick(30)
+    expect(scope.signal.aborted).toBe(true)
+    expect(scope.intent()).toBe('back')
+    scope.dispose()
+  })
+
+  test('arrow-key CSI sequence does not abort', async () => {
+    const tty = new FakeTty()
+    const proc = new FakeProc()
+    const scope = createTailScope({ debounceMs: 10, input: tty as never, proc: proc as never })
+    tty.feed([0x1b])
+    tty.feed([0x5b, 0x41])
+    await tick(30)
+    expect(scope.signal.aborted).toBe(false)
+    expect(scope.intent()).toBeNull()
+    scope.dispose()
+  })
+
+  test('SIGINT aborts with exit intent', () => {
+    const tty = new FakeTty()
+    const proc = new FakeProc()
+    const scope = createTailScope({ debounceMs: 50, input: tty as never, proc: proc as never })
+    proc.fire('SIGINT')
+    expect(scope.signal.aborted).toBe(true)
+    expect(scope.intent()).toBe('exit')
+    scope.dispose()
+  })
+
+  test('dispose restores raw mode and detaches handlers without pausing stdin', () => {
+    // The next clack picker must inherit a non-raw, still-flowing stdin: a paused
+    // process.stdin does not reliably re-flow under Bun, which is what froze the
+    // picker. Detaching our data handler and clearing raw mode lets clack own it.
+    const tty = new FakeTty()
+    const proc = new FakeProc()
+    const scope = createTailScope({ debounceMs: 50, input: tty as never, proc: proc as never })
+    expect(tty.listenerCount('data')).toBe(1)
+    scope.dispose()
     expect(tty.rawMode).toBe(false)
     expect(tty.listenerCount('data')).toBe(0)
-    expect(tty.resumed).toBe(true)
-    // and: bytes arriving while the picker owns input never reach our callback
-    tty.feed([0x03])
-    expect(sigints).toBe(0)
-    listener.stop()
+    expect(tty.pauseCalls).toBe(0)
+    expect(proc.listenerCount('SIGINT')).toBe(0)
+    expect(proc.listenerCount('SIGTERM')).toBe(0)
+  })
+
+  test('dispose is idempotent', () => {
+    const tty = new FakeTty()
+    const proc = new FakeProc()
+    const scope = createTailScope({ debounceMs: 50, input: tty as never, proc: proc as never })
+    scope.dispose()
+    scope.dispose()
+    expect(tty.listenerCount('data')).toBe(0)
+  })
+
+  test('non-TTY input never touches raw mode but still aborts on signals', () => {
+    const tty = new FakeTty()
+    tty.isTTY = false as unknown as true
+    const proc = new FakeProc()
+    const scope = createTailScope({ debounceMs: 50, input: tty as never, proc: proc as never })
+    expect(tty.listenerCount('data')).toBe(0)
+    proc.fire('SIGTERM')
+    expect(scope.signal.aborted).toBe(true)
+    expect(scope.intent()).toBe('exit')
+    scope.dispose()
   })
 })

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -5,10 +5,10 @@ import { findAgentDir } from '@/init'
 import { runInspectLoop, streamLive, type LiveSourceFactory, type SessionSummary } from '@/inspect'
 import { originLabel, shortSessionId } from '@/inspect/label'
 
-import { createEscController } from './inspect-controller'
+import { createTailScope } from './inspect-controller'
 import { cancel, c, errorLine, isCancel, prepareStdinForClack } from './ui'
 
-const ESC_LISTEN_DELAY_MS = 50
+const ESC_DEBOUNCE_MS = 50
 
 export const inspectCommand = defineCommand({
   meta: {
@@ -45,46 +45,23 @@ export const inspectCommand = defineCommand({
 
     const isJson = args.json === true
     const liveSource = isJson ? undefined : await buildLiveSource(cwd)
-    const signalCtrl = installSigintAbort()
-    const signal = signalCtrl.signal
-    // Raw-mode Ctrl-C arrives as byte 0x03 and must abort the exit controller
-    // directly: under Bun a self-issued process.kill(SIGINT) does not reliably
-    // re-enter our process.once('SIGINT') handler, so the live tail never exits.
-    const escListener = isJson ? null : createEscListener(() => signalCtrl.abort())
-    const liveHint = escListener === null ? undefined : escHintLine(color)
+    const interactive = !isJson && Boolean(process.stdin.isTTY)
+    const liveHint = interactive ? escHintLine(color) : undefined
 
-    // try/finally so a thrown loop never leaves the terminal stuck in raw mode.
-    let result: Awaited<ReturnType<typeof runInspectLoop>>
-    try {
-      result = await runInspectLoop({
-        agentDir: cwd,
-        ...(sessionArg !== undefined ? { sessionIdOrPrefix: sessionArg } : {}),
-        ...(filterArg !== undefined ? { filter: filterArg } : {}),
-        ...(sinceArg !== undefined ? { since: sinceArg } : {}),
-        json: isJson,
-        color,
-        selectSession: (sessions, selectOpts) => {
-          escListener?.pause()
-          return clackSelect(sessions, selectOpts?.initialSessionId).finally(() => {
-            escListener?.resume()
-          })
-        },
-        ...(liveSource !== undefined ? { liveSource } : {}),
-        signal,
-        newEscSignal: () => {
-          if (escListener === null) return new AbortController().signal
-          return escListener.armForStream()
-        },
-        afterEscStream: () => {
-          escListener?.pause()
-        },
-        ...(liveHint !== undefined ? { liveHint } : {}),
-        stdout: (line) => process.stdout.write(`${line}\n`),
-        stderr: (line) => process.stderr.write(`${line}\n`),
-      })
-    } finally {
-      escListener?.stop()
-    }
+    const result = await runInspectLoop({
+      agentDir: cwd,
+      ...(sessionArg !== undefined ? { sessionIdOrPrefix: sessionArg } : {}),
+      ...(filterArg !== undefined ? { filter: filterArg } : {}),
+      ...(sinceArg !== undefined ? { since: sinceArg } : {}),
+      json: isJson,
+      color,
+      selectSession: (sessions, selectOpts) => clackSelect(sessions, selectOpts?.initialSessionId),
+      ...(liveSource !== undefined ? { liveSource } : {}),
+      createTailScope: () => createTailScope({ debounceMs: ESC_DEBOUNCE_MS }),
+      ...(liveHint !== undefined ? { liveHint } : {}),
+      stdout: (line) => process.stdout.write(`${line}\n`),
+      stderr: (line) => process.stderr.write(`${line}\n`),
+    })
 
     if (!result.ok) {
       process.stderr.write(`${errorLine(result.reason)}\n`)
@@ -113,86 +90,6 @@ async function buildLiveSource(cwd: string): Promise<LiveSourceFactory | undefin
       ...(signal !== undefined ? { signal } : {}),
       ...(onSubscribed !== undefined ? { onSubscribed } : {}),
     })
-}
-
-function installSigintAbort(): AbortController {
-  const ctrl = new AbortController()
-  const onSig = (): void => {
-    ctrl.abort()
-  }
-  process.once('SIGINT', onSig)
-  process.once('SIGTERM', onSig)
-  return ctrl
-}
-
-type EscListener = {
-  armForStream: () => AbortSignal
-  pause: () => void
-  resume: () => void
-  stop: () => void
-}
-
-type RawInput = Pick<NodeJS.ReadStream, 'isTTY' | 'setRawMode' | 'resume' | 'pause' | 'on' | 'off'>
-
-export function createEscListener(onSigint: () => void, input: RawInput = process.stdin): EscListener | null {
-  const stdin = input
-  if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') return null
-
-  const ctrl = createEscController({ debounceMs: ESC_LISTEN_DELAY_MS })
-  let active = false
-
-  const onData = (chunk: Buffer): void => {
-    const { sigint } = ctrl.onChunk(chunk)
-    if (sigint) onSigint()
-  }
-
-  const start = (): void => {
-    if (active) return
-    active = true
-    stdin.setRawMode(true)
-    // Attach the data handler before resume() so no raw-mode keystroke can slip
-    // through between resuming the stream and registering the listener.
-    stdin.on('data', onData)
-    stdin.resume()
-  }
-  const stop = (): void => {
-    if (!active) return
-    active = false
-    stdin.off('data', onData)
-    try {
-      stdin.setRawMode(false)
-    } catch {
-      /* terminal already torn down */
-    }
-    // Do NOT pause stdin here: this teardown hands control to the clack picker,
-    // and under Bun clack does not reliably re-flow a previously paused
-    // process.stdin, so its keypresses never arrive and arrow keys echo as raw
-    // bytes. Leaving the stream flowing lets clack own raw mode during the picker.
-    ctrl.clearPending()
-  }
-
-  return {
-    armForStream: () => {
-      const signal = ctrl.armForStream()
-      start()
-      return signal
-    },
-    pause: () => {
-      stop()
-    },
-    resume: () => {
-      // Resume the listener WITHOUT replacing the AbortController.
-      // The signal returned by armForStream() is held by the live source
-      // through streamSession's combinedSignal; replacing the controller
-      // here would orphan that signal so a subsequent ESC press could
-      // not abort the live tail.
-      start()
-    },
-    stop: () => {
-      ctrl.dispose()
-      stop()
-    },
-  }
 }
 
 function escHintLine(color: boolean): string {

--- a/src/inspect/index.test.ts
+++ b/src/inspect/index.test.ts
@@ -332,9 +332,12 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
     expect(sink.out.at(-1)!).toContain('end of transcript')
   })
 
-  test('escSignal abort sets escToPicker=true; process signal abort does not', async () => {
+  test('signal abort during live stream sets escToPicker=true', async () => {
+    // runInspect no longer distinguishes esc from exit: any signal abort during
+    // the tail yields escToPicker=true. The caller's loop reads its scope intent
+    // to decide whether to re-open the picker (esc) or exit (q/ctrl-c).
     await seedSession(`a_${ID_LIVET}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
-    const escCtrl = new AbortController()
+    const ctrl = new AbortController()
     const sink = captureSink()
     async function* live(signal: AbortSignal | undefined): AsyncGenerator<import('./types').InspectEvent> {
       yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'tick' } }
@@ -343,14 +346,14 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
         signal.addEventListener('abort', () => resolve(), { once: true })
       })
     }
-    queueMicrotask(() => escCtrl.abort())
+    queueMicrotask(() => ctrl.abort())
     const result = await runInspect({
       agentDir,
       sessionIdOrPrefix: ID_LIVET,
       color: false,
       selectSession: neverPick,
       liveSource: (o) => live(o.signal),
-      escSignal: escCtrl.signal,
+      signal: ctrl.signal,
       ...sink.push,
     })
     expect(result.ok).toBe(true)
@@ -358,25 +361,19 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
     expect(result.escToPicker).toBe(true)
   })
 
-  test('signal abort during live stream does NOT set escToPicker (process-exit path)', async () => {
+  test('finite live stream that ends on its own does not set escToPicker', async () => {
     await seedSession(`a_${ID_LIVET}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
-    const sigCtrl = new AbortController()
     const sink = captureSink()
-    async function* live(signal: AbortSignal | undefined): AsyncGenerator<import('./types').InspectEvent> {
+    async function* live(): AsyncGenerator<import('./types').InspectEvent> {
       yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'tick' } }
-      await new Promise<void>((resolve) => {
-        if (signal === undefined || signal.aborted) return resolve()
-        signal.addEventListener('abort', () => resolve(), { once: true })
-      })
     }
-    queueMicrotask(() => sigCtrl.abort())
     const result = await runInspect({
       agentDir,
       sessionIdOrPrefix: ID_LIVET,
       color: false,
       selectSession: neverPick,
-      liveSource: (o) => live(o.signal),
-      signal: sigCtrl.signal,
+      liveSource: () => live(),
+      signal: new AbortController().signal,
       ...sink.push,
     })
     expect(result.ok).toBe(true)

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -30,10 +30,9 @@ export type RunInspectOptions = {
   stdout: (line: string) => void
   stderr: (line: string) => void
   liveSource?: LiveSourceFactory
+  // Aborting this signal stops the live tail and returns escToPicker=true; the
+  // caller's loop inspects its own scope intent to tell back from exit.
   signal?: AbortSignal
-  // Aborting escSignal (and only escSignal) returns escToPicker=true so a
-  // caller-side loop can re-open the picker; signal still means process exit.
-  escSignal?: AbortSignal
   liveHint?: string
 }
 
@@ -81,7 +80,6 @@ export async function runInspect(opts: RunInspectOptions): Promise<RunInspectRes
     stderr: opts.stderr,
     ...(opts.liveSource !== undefined ? { liveSource: opts.liveSource } : {}),
     ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
-    ...(opts.escSignal !== undefined ? { escSignal: opts.escSignal } : {}),
     ...(opts.liveHint !== undefined ? { liveHint: opts.liveHint } : {}),
   })
   if (streamResult.escToPicker) return { ok: true, exitCode: 0, escToPicker: true }
@@ -147,7 +145,6 @@ async function streamSession(opts: {
   stderr: (line: string) => void
   liveSource?: LiveSourceFactory
   signal?: AbortSignal
-  escSignal?: AbortSignal
   liveHint?: string
 }): Promise<{ escToPicker: boolean }> {
   if (!opts.json) writeHeader(opts.summary, opts.color, opts.stdout)
@@ -161,26 +158,25 @@ async function streamSession(opts: {
     }
   }
 
-  const escAborted = (): boolean => opts.escSignal?.aborted === true
+  const aborted = (): boolean => opts.signal?.aborted === true
 
   for await (const event of replayJsonl(opts.summary.sessionFile, { onWarn: opts.stderr })) {
-    if (escAborted()) return { escToPicker: true }
+    if (aborted()) return { escToPicker: true }
     emit(event)
   }
 
   if (opts.liveSource === undefined) {
     if (!opts.json) opts.stdout('─── end of transcript ───')
-    return { escToPicker: escAborted() }
+    return { escToPicker: aborted() }
   }
 
-  if (escAborted()) return { escToPicker: true }
+  if (aborted()) return { escToPicker: true }
 
-  const combinedSignal = combineSignals(opts.signal, opts.escSignal)
   let sessionLive = false
   const liveIter = opts.liveSource({
     sessionId: opts.summary.sessionId,
     ...(opts.sinceMs !== undefined ? { sinceMs: opts.sinceMs } : {}),
-    ...(combinedSignal !== undefined ? { signal: combinedSignal } : {}),
+    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
     onSubscribed: (live) => {
       sessionLive = live
     },
@@ -204,21 +200,7 @@ async function streamSession(opts: {
     opts.stderr(`live tail ended: ${err instanceof Error ? err.message : String(err)}`)
   }
   if (!opts.json) opts.stdout('─── end of transcript ───')
-  return { escToPicker: escAborted() && opts.signal?.aborted !== true }
-}
-
-function combineSignals(a: AbortSignal | undefined, b: AbortSignal | undefined): AbortSignal | undefined {
-  if (a === undefined) return b
-  if (b === undefined) return a
-  if (a.aborted) return a
-  if (b.aborted) return b
-  const ctrl = new AbortController()
-  const onAbort = (): void => {
-    ctrl.abort()
-  }
-  a.addEventListener('abort', onAbort, { once: true })
-  b.addEventListener('abort', onAbort, { once: true })
-  return ctrl.signal
+  return { escToPicker: aborted() }
 }
 
 function divider(color: boolean, text: string): string {

--- a/src/inspect/live.test.ts
+++ b/src/inspect/live.test.ts
@@ -444,6 +444,27 @@ describe('streamLive — live session events', () => {
     expect(events).toEqual([])
   })
 
+  test('connect timeout ends the generator when the socket never opens or aborts', async () => {
+    // Without an abort, a socket stuck in CONNECTING would hang `await onOpen`
+    // forever. A bounded connect timeout throws so the tail ends and the CLI
+    // can recover instead of freezing.
+    const FakeWS = makeNeverOpeningWebSocket()
+    const gen = streamLive({
+      url: 'ws://unused',
+      sessionId: 'ses_a',
+      WebSocketImpl: FakeWS,
+      connectTimeoutMs: 20,
+    })
+
+    const drained = (async () => {
+      for await (const _ev of gen) {
+        /* never reached */
+      }
+    })()
+
+    await expect(drained).rejects.toThrow('websocket connect timed out')
+  })
+
   test('unknown server message types are ignored without crashing', async () => {
     // Forward-compat: a future server may add new top-level message `type`
     // values. The client must not crash when it sees one — especially since

--- a/src/inspect/live.ts
+++ b/src/inspect/live.ts
@@ -10,7 +10,10 @@ export type StreamLiveOptions = {
   WebSocketImpl?: typeof WebSocket
   onSubscribed?: (live: boolean) => void
   onError?: (message: string) => void
+  connectTimeoutMs?: number
 }
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 5_000
 
 export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<InspectEvent> {
   const WS = opts.WebSocketImpl ?? WebSocket
@@ -63,9 +66,11 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
     }
   })
 
-  // Settle on open OR on any terminal condition (error/close/abort). Resolving
-  // false here is what unblocks the connect gate when esc aborts mid-connect —
-  // otherwise `await onOpen` would hang forever and freeze the inspect CLI.
+  // Settle on open OR on any terminal condition (error/close/abort/timeout).
+  // Resolving false on abort/close/timeout is what unblocks the connect gate —
+  // otherwise `await onOpen` would hang forever and freeze the inspect CLI. The
+  // timeout bounds Bun/websocket states that neither open nor error promptly.
+  let connectTimer: ReturnType<typeof setTimeout> | null = null
   const onOpen = new Promise<boolean>((resolve, reject) => {
     ws.addEventListener('open', () => resolve(true), { once: true })
     ws.addEventListener('error', () => reject(new Error('websocket connection failed')), { once: true })
@@ -74,6 +79,8 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
       if (opts.signal.aborted) resolve(false)
       else opts.signal.addEventListener('abort', () => resolve(false), { once: true })
     }
+    const timeoutMs = opts.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS
+    connectTimer = setTimeout(() => reject(new Error('websocket connect timed out')), timeoutMs)
   })
   ws.addEventListener('close', () => {
     closed = true
@@ -109,7 +116,14 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
     opened = await onOpen
   } catch (err) {
     closed = true
+    try {
+      ws.close()
+    } catch {
+      /* ignore */
+    }
     throw err
+  } finally {
+    if (connectTimer !== null) clearTimeout(connectTimer)
   }
   if (!opened || closed || opts.signal?.aborted === true) return
 

--- a/src/inspect/loop.test.ts
+++ b/src/inspect/loop.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { runInspectLoop } from './loop'
+import { runInspectLoop, type TailController } from './loop'
 import type { InspectEvent } from './types'
 
 let agentDir: string
@@ -46,6 +46,29 @@ function captureSink(): {
   return { out, err, push: { stdout: (l) => out.push(l), stderr: (l) => err.push(l) } }
 }
 
+type FakeScope = TailController & { back: () => void; exit: () => void }
+
+function fakeScope(onDispose?: () => void): FakeScope {
+  const ctrl = new AbortController()
+  let intent: 'back' | 'exit' | null = null
+  return {
+    signal: ctrl.signal,
+    intent: () => intent,
+    dispose: () => {
+      onDispose?.()
+      ctrl.abort()
+    },
+    back: () => {
+      if (intent === null) intent = 'back'
+      ctrl.abort()
+    },
+    exit: () => {
+      if (intent === null) intent = 'exit'
+      ctrl.abort()
+    },
+  }
+}
+
 const ID_LOOP_A = '019ee000-aaaa-7000-9000-00000000aaaa'
 const ID_LOOP_B = '019ee000-bbbb-7000-9000-00000000bbbb'
 const ID_LOOP_C = '019ee000-cccc-7000-9000-00000000cccc'
@@ -57,7 +80,7 @@ describe('runInspectLoop', () => {
     await seedSession(`b_${ID_LOOP_B}.jsonl`, [metaLine({ kind: 'tui' }), userLine('second')], 2000)
     const sink = captureSink()
 
-    let escController: AbortController | null = null
+    let scope: FakeScope | null = null
     let liveCallCount = 0
 
     async function* awaitableLive(signal: AbortSignal | undefined): AsyncGenerator<InspectEvent> {
@@ -83,14 +106,14 @@ describe('runInspectLoop', () => {
       liveSource: (o) => {
         liveCallCount++
         if (liveCallCount === 1) {
-          queueMicrotask(() => escController?.abort())
+          queueMicrotask(() => scope?.back())
           return awaitableLive(o.signal)
         }
         return finiteLive()
       },
-      newEscSignal: () => {
-        escController = new AbortController()
-        return escController.signal
+      createTailScope: () => {
+        scope = fakeScope()
+        return scope
       },
       ...sink.push,
     })
@@ -105,7 +128,7 @@ describe('runInspectLoop', () => {
   test('picker cancel after esc returns ok with exit 130 (picker null is final)', async () => {
     await seedSession(`a_${ID_LOOP_C}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
     const sink = captureSink()
-    let escController: AbortController | null = null
+    let scope: FakeScope | null = null
 
     async function* awaitableLive(signal: AbortSignal | undefined): AsyncGenerator<InspectEvent> {
       yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'ev' } }
@@ -121,12 +144,12 @@ describe('runInspectLoop', () => {
       color: false,
       selectSession: async () => null,
       liveSource: (o) => {
-        queueMicrotask(() => escController?.abort())
+        queueMicrotask(() => scope?.back())
         return awaitableLive(o.signal)
       },
-      newEscSignal: () => {
-        escController = new AbortController()
-        return escController.signal
+      createTailScope: () => {
+        scope = fakeScope()
+        return scope
       },
       ...sink.push,
     })
@@ -154,7 +177,7 @@ describe('runInspectLoop', () => {
         liveCallCount++
         return fakeLive()
       },
-      newEscSignal: () => new AbortController().signal,
+      createTailScope: () => fakeScope(),
       ...sink.push,
     })
 
@@ -178,7 +201,7 @@ describe('runInspectLoop', () => {
         o.onSubscribed?.(true)
         return fakeLive()
       },
-      newEscSignal: () => new AbortController().signal,
+      createTailScope: () => fakeScope(),
       liveHint: '(press esc to return to session list)',
       ...sink.push,
     })
@@ -196,7 +219,7 @@ describe('runInspectLoop', () => {
     await seedSession(`c_${ID_LOOP_C}.jsonl`, [metaLine({ kind: 'tui' }), userLine('third')], 3000)
     const sink = captureSink()
 
-    let escController: AbortController | null = null
+    let scope: FakeScope | null = null
     let liveCallCount = 0
     const pickerHints: (string | undefined)[] = []
 
@@ -226,14 +249,14 @@ describe('runInspectLoop', () => {
       liveSource: (o) => {
         liveCallCount++
         if (liveCallCount === 1) {
-          queueMicrotask(() => escController?.abort())
+          queueMicrotask(() => scope?.back())
           return awaitableLive(o.signal)
         }
         return finiteLive()
       },
-      newEscSignal: () => {
-        escController = new AbortController()
-        return escController.signal
+      createTailScope: () => {
+        scope = fakeScope()
+        return scope
       },
       ...sink.push,
     })
@@ -244,17 +267,18 @@ describe('runInspectLoop', () => {
     expect(pickerHints[1]).toBe(ID_LOOP_A)
   })
 
-  test('afterEscStream fires after the esc-aborted tail and before the picker re-opens', async () => {
+  test('scope is disposed after the esc-aborted tail and before the picker re-opens', async () => {
     // Regression: pressing ESC during the live tail froze the CLI over SSH/Bun
     // because the raw-mode ESC listener stayed armed across the abort, so clack
-    // inherited a flowing raw stdin it could not own. The loop must disarm the
-    // listener (afterEscStream) after the tail settles and before re-selecting.
+    // inherited a flowing raw stdin it could not own. The loop must dispose the
+    // scope (tearing the listener down) after the tail settles and before the
+    // picker re-opens.
     await seedSession(`a_${ID_LOOP_A}.jsonl`, [metaLine({ kind: 'tui' }), userLine('first')], 1000)
     await seedSession(`b_${ID_LOOP_B}.jsonl`, [metaLine({ kind: 'tui' }), userLine('second')], 2000)
     const sink = captureSink()
 
     const trace: string[] = []
-    let escController: AbortController | null = null
+    let scope: FakeScope | null = null
     let liveCallCount = 0
 
     async function* awaitableLive(signal: AbortSignal | undefined): AsyncGenerator<InspectEvent> {
@@ -279,33 +303,28 @@ describe('runInspectLoop', () => {
       liveSource: (o) => {
         liveCallCount++
         if (liveCallCount === 1) {
-          queueMicrotask(() => escController?.abort())
+          queueMicrotask(() => scope?.back())
           return awaitableLive(o.signal)
         }
         return finiteLive()
       },
-      newEscSignal: () => {
-        escController = new AbortController()
-        return escController.signal
-      },
-      afterEscStream: () => {
-        trace.push('teardown')
+      createTailScope: () => {
+        scope = fakeScope(() => trace.push('dispose'))
+        return scope
       },
       ...sink.push,
     })
 
     expect(result.ok).toBe(true)
-    // teardown runs after the aborted first tail, then the picker opens, then
-    // teardown runs again after the second (finite) tail settles.
-    expect(trace).toEqual(['teardown', 'select', 'teardown'])
+    expect(trace).toEqual(['dispose', 'select', 'dispose'])
   })
 
-  test('afterEscStream fires on a non-esc early return (bad filter)', async () => {
-    // The teardown hook must run on every loop exit path, not just esc-to-picker,
-    // so an interrupted run can never leave the listener armed.
+  test('scope is disposed on a non-esc early return (bad filter)', async () => {
+    // Dispose must run on every loop exit path, not just esc-to-picker, so an
+    // interrupted run can never leave the listener armed.
     await seedSession(`a_${ID_LOOP_D}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
     const sink = captureSink()
-    let torn = 0
+    let disposed = 0
 
     const result = await runInspectLoop({
       agentDir,
@@ -313,30 +332,26 @@ describe('runInspectLoop', () => {
       filter: 'not-a-real-category',
       color: false,
       selectSession: async () => null,
-      newEscSignal: () => new AbortController().signal,
-      afterEscStream: () => {
-        torn++
-      },
+      createTailScope: () => fakeScope(() => disposed++),
       ...sink.push,
     })
 
     expect(result.ok).toBe(false)
-    expect(torn).toBe(1)
+    expect(disposed).toBe(1)
   })
 
-  test('ctrl-c (sigint signal) during the tail exits without re-opening the picker', async () => {
+  test('ctrl-c (exit intent) during the tail exits without re-opening the picker', async () => {
     // Ctrl-C must terminate inspect, not loop back to the session list. The exit
-    // signal (process SIGINT) aborts the same tail as ESC, but streamSession
-    // reports escToPicker=false when opts.signal is aborted, so the loop returns.
-    // afterEscStream still tears the listener down exactly once on the way out.
+    // intent aborts the same tail as ESC, but the loop reads scope.intent()==='exit'
+    // and returns before re-opening the picker. The scope is disposed exactly once.
     await seedSession(`a_${ID_LOOP_A}.jsonl`, [metaLine({ kind: 'tui' }), userLine('first')], 1000)
     await seedSession(`b_${ID_LOOP_B}.jsonl`, [metaLine({ kind: 'tui' }), userLine('second')], 2000)
     const sink = captureSink()
 
-    const sigint = new AbortController()
+    let scope: FakeScope | null = null
     let liveCallCount = 0
     let pickerCalls = 0
-    let torn = 0
+    let disposed = 0
 
     async function* awaitableLive(signal: AbortSignal | undefined): AsyncGenerator<InspectEvent> {
       yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'hello' } }
@@ -350,20 +365,18 @@ describe('runInspectLoop', () => {
       agentDir,
       sessionIdOrPrefix: ID_LOOP_A,
       color: false,
-      signal: sigint.signal,
       selectSession: async (sessions) => {
         pickerCalls++
         return sessions.find((s) => s.sessionId === ID_LOOP_B) ?? null
       },
       liveSource: (o) => {
         liveCallCount++
-        // Ctrl-C: abort the SIGINT signal mid-tail (esc was never pressed).
-        queueMicrotask(() => sigint.abort())
+        queueMicrotask(() => scope?.exit())
         return awaitableLive(o.signal)
       },
-      newEscSignal: () => new AbortController().signal,
-      afterEscStream: () => {
-        torn++
+      createTailScope: () => {
+        scope = fakeScope(() => disposed++)
+        return scope
       },
       ...sink.push,
     })
@@ -371,6 +384,6 @@ describe('runInspectLoop', () => {
     expect(result.ok).toBe(true)
     expect(pickerCalls).toBe(0)
     expect(liveCallCount).toBe(1)
-    expect(torn).toBe(1)
+    expect(disposed).toBe(1)
   })
 })

--- a/src/inspect/loop.ts
+++ b/src/inspect/loop.ts
@@ -1,20 +1,21 @@
 import { runInspect, type RunInspectOptions, type RunInspectResult } from './index'
 
-export type RunInspectLoopOptions = Omit<RunInspectOptions, 'escSignal'> & {
-  newEscSignal: () => AbortSignal
-  // Runs after every runInspect attempt settles. The caller disarms the raw-mode
-  // ESC listener here so the live tail releases stdin before clack re-opens the
-  // picker: an ESC-aborted tail leaves the listener armed (raw mode on, 'data'
-  // handler attached), and handing clack that flowing stream freezes the picker
-  // on SSH/Bun pseudo-TTYs.
-  afterEscStream?: () => void
+export type TailController = {
+  signal: AbortSignal
+  intent: () => 'back' | 'exit' | null
+  dispose: () => void
+}
+
+export type RunInspectLoopOptions = Omit<RunInspectOptions, 'signal'> & {
+  // Builds a fresh interaction scope for ONE live-tail attempt: a new
+  // AbortController plus a temporary raw-mode listener. The loop disposes it
+  // before the picker re-opens so clack always owns a clean, non-raw stdin —
+  // this is what replaces the old pause/resume-same-controller model.
+  createTailScope: () => TailController
 }
 
 export async function runInspectLoop(opts: RunInspectLoopOptions): Promise<RunInspectResult> {
   let sessionArg = opts.sessionIdOrPrefix
-  // Remember the last session the user picked from the interactive picker so
-  // an ESC-back-to-picker re-opens with that row pre-selected. The picker
-  // receives this through the `initialSessionId` hint on its second arg.
   let lastPickedId: string | undefined
   const wrappedSelectSession: typeof opts.selectSession = async (sessions, selectOpts) => {
     const hint = selectOpts?.initialSessionId ?? lastPickedId
@@ -24,18 +25,23 @@ export async function runInspectLoop(opts: RunInspectLoopOptions): Promise<RunIn
   }
 
   while (true) {
-    const escSignal = opts.newEscSignal()
-    const callOpts: RunInspectOptions = { ...opts, escSignal, selectSession: wrappedSelectSession }
-    if (sessionArg !== undefined) callOpts.sessionIdOrPrefix = sessionArg
-    else delete (callOpts as { sessionIdOrPrefix?: string }).sessionIdOrPrefix
-
+    const scope = opts.createTailScope()
     let result: RunInspectResult
     try {
+      const callOpts: RunInspectOptions = {
+        ...opts,
+        selectSession: wrappedSelectSession,
+        signal: scope.signal,
+      }
+      if (sessionArg !== undefined) callOpts.sessionIdOrPrefix = sessionArg
+      else delete (callOpts as { sessionIdOrPrefix?: string }).sessionIdOrPrefix
       result = await runInspect(callOpts)
     } finally {
-      opts.afterEscStream?.()
+      scope.dispose()
     }
+
     if (!result.ok) return result
+    if (scope.intent() === 'exit') return result
     if (result.escToPicker !== true) return result
     sessionArg = undefined
   }


### PR DESCRIPTION
## Background

The interactive `typeclaw inspect` TUI freezes and stops responding after ESC or Ctrl-C during the live tail. The root cause is structural: the old implementation held a single long-lived `EscListener` across the entire picker↔tail loop, relying on `pause()`/`resume()` to hand stdin back and forth between raw mode and the clack picker.

That model required four fragile invariants to hold simultaneously:

1. The raw-mode `'data'` handler had to yield to clack without ever calling `stdin.pause()` — Bun does not reliably re-flow a paused `process.stdin` into the next clack render cycle.
2. `resume()` had to restart the same `AbortController`; replacing it would orphan the signal held by the live source, so ESC would stop aborting the tail.
3. `combineSignals` merged the process SIGINT/SIGTERM signal with the ESC abort signal before passing them into `streamLive`.
4. `streamLive`'s `onOpen` promise had to settle on one of open/error/close/abort or `await onOpen` would hang forever — leaving the terminal locked in raw mode.

Any one invariant breaking left the terminal stuck. The sibling `typeclaw dreams` command never freezes because raw mode is scoped to a brief key-wait and fully torn down before the clack picker re-opens.

## What

Rework `inspect` to follow the `dreams` pattern: one disposable interaction scope per live-tail attempt.

### `createTailScope` — `src/cli/inspect-controller.ts`

A factory that creates a fresh `AbortController`, a temporary raw-mode `'data'` listener, and SIGINT/SIGTERM handlers — all removed on `dispose()`. The scope never survives into the picker:

- ESC encodes `'back'` intent (debounced through the existing `EscController`).
- `q` / Ctrl-C / SIGINT encode `'exit'` intent.
- The live stream only ever observes `signal.aborted`; the loop reads `scope.intent()` to distinguish back from exit.
- `dispose()` tears down raw mode without calling `stdin.pause()`, preserving the Bun stdin re-flow guarantee.
- `dispose()` is idempotent.

### `runInspectLoop` — `src/inspect/loop.ts`

Creates a fresh scope per iteration, passes its `signal` to `runInspect`, and calls `scope.dispose()` in a `finally` block before the picker re-opens. Reads `scope.intent()` to decide whether to loop back or return. Drops `newEscSignal` / `afterEscStream` / the pause/resume dance entirely.

### `streamSession` — `src/inspect/index.ts`

Drops `combineSignals` and `escSignal`. A single `signal` now aborts the tail; any abort returns `escToPicker: true`. The loop owns the back-vs-exit distinction via `scope.intent()`.

### `streamLive` — `src/inspect/live.ts`

Adds a bounded connect timeout (default 5 s) so a WebSocket that never fires open, error, close, or abort cannot hang the connect gate. The timer is always cleared and the socket closed on a failed connect.

**Key invariant enforced:** clack never runs while a raw-mode listener exists, and a raw-mode listener never survives past one live-tail attempt.

## Tests

- **`createTailScope` wiring** — ESC→back (debounced), Ctrl-C/SIGINT→exit, arrow-key CSI sequence ignored (no abort), dispose restores raw mode without pausing stdin, dispose is idempotent, non-TTY path.
- **`streamLive` connect timeout** — no hang when the WebSocket neither opens nor errors within the timeout window.
- **Loop tests** — migrated to the new `createTailScope` seam; pin scope-dispose ordering (dispose → select → dispose) and back-vs-exit intent.
- **`runInspect` tests** — any signal abort during the tail yields `escToPicker: true`; the back-vs-exit distinction is the loop's responsibility.
- JSON / non-interactive mode unchanged.

## Verification

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and the full test suite all pass for the inspect/dreams suites. One unrelated failure (`resolveSelfPackageJsonPath > points at this package manifest`) reproduces identically on main and is a worktree-directory-name artifact; it passes in CI.