### PR TITLE
docs: note Contents: read is required to review private repos

### DIFF
--- a/docs/content/docs/recipes/code-reviewer.mdx
+++ b/docs/content/docs/recipes/code-reviewer.mdx
@@ -63,11 +63,20 @@ When it finishes, it **installs the repository webhooks for you** and enables th
 
 The default GitHub event allowlist already covers reviews. If you want to narrow it to just the review path, the relevant events are `pull_request.review_requested`, `pull_request.review_request_removed`, `pull_request_review.submitted`, and `pull_request_review_comment.created` — keep `review_request_removed` so the agent still sees when a review request is withdrawn. Tell the agent to tighten `channels.github.eventAllowlist`, or adjust it and run `typeclaw reload`. See [/reference/channel-adapters](/docs/reference/channel-adapters) for the full event list.
 
-<Callout type="info" title="App auth and contents:write">
-  An App only needs **Pull requests: read/write** to post reviews. Grant **Contents: write** _only_ if the agent will
-  also push fix branches — GitHub bundles branch creation into that scope, so there's no narrower one. Keep a ruleset on
-  `main` that requires pull requests, and the bot opens branches and PRs without ever touching `main` directly. The
-  wizard's permission note lists exactly what to enable.
+<Callout type="info" title="App auth and the Contents permission">
+  On a **public** repo an App only needs **Pull requests: read/write** to read the diff and post reviews. On a
+  **private** repo the agent also needs **Contents: read** — `git clone` (and any raw file-tree access) of a private
+  repo fails with 403/404 without it; **Metadata: read** alone lets the App _see_ the repo but not read its files. Grant
+  **Contents: write** _only_ if the agent will also push fix branches — GitHub bundles branch creation into that scope,
+  so there's no narrower one. Keep a ruleset on `main` that requires pull requests, and the bot opens branches and PRs
+  without ever touching `main` directly. The wizard's permission note lists exactly what to enable.
+</Callout>
+
+<Callout type="warn" title="The preflight won't catch a missing Contents grant">
+  TypeClaw's App permission preflight only checks permissions tied to your configured `eventAllowlist` (issues, pull
+  requests, discussions), so a private-repo reviewer missing **Contents: read** passes preflight cleanly and then fails
+  at runtime when the agent tries to clone or read files. If reviews on a private repo error with "Resource not
+  accessible by integration," add **Contents: read** to the App.
 </Callout>
 
 ## Set up the decoy reviewer


### PR DESCRIPTION
## Background

The code-reviewer recipe's App-auth callout framed the Contents permission only as "Contents: write" for pushing fix branches, and said nothing about private-repo access. A user following the recipe and configuring the reviewer against a private repo would grant only Pull requests: read/write — the correct permission for a public repo — and then hit a 403 at runtime when the agent tried to clone.

The root-cause gap is in the App permission preflight (runAppPermissionPreflight → findPermissionGaps in `src/channels/adapters/github/event-permissions.ts`). It only checks permission families tied to the configured eventAllowlist (issues, pull_requests, discussions). Cloning is not modelled there, so a private-repo reviewer missing Contents: read passes preflight cleanly and surfaces the error only at runtime as "Resource not accessible by integration."

## Summary

Splits the App-auth callout into two:

1. **Rewritten info callout** — distinguishes public (Pull requests: read/write is sufficient) from private (also needs Contents: read, because `git clone` and raw file-tree access of a private repo return 403/404 without it; Metadata: read alone lets the App see the repo but not read its files). The existing Contents: write guidance for pushing fix branches is preserved.

2. **New warn callout** — flags that TypeClaw's permission preflight will not catch a missing Contents grant, and tells the reader what runtime symptom to look for and how to fix it.

## What this does NOT do

- No code changes — docs only, single file.
- Does not change the preflight logic (modelling clone in findPermissionGaps is a follow-up; the warn callout documents the gap in the meantime).

## Review notes

The load-bearing distinction is Metadata: read vs Contents: read. GitHub's own docs conflate these for public repos (Metadata is implicit), which is why the original callout missed the private-repo case — on a public repo `git clone` works without a Contents grant because the repo is world-readable. The new copy makes that asymmetry explicit.