### PR TITLE
channels: add github review.on to gate when PR review runs

### DIFF
--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -77,7 +77,7 @@ function githubConfig(
     webhookPort: 0,
     eventAllowlist: ['issue_comment.created', 'pull_request.opened'],
     repos: [...repos],
-    review: { approve: true },
+    review: { on: 'review_requested', approve: true },
   }
   if (webhookUrl !== null) config.webhookUrl = webhookUrl
   return config

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -104,7 +104,7 @@ const enabledGithubCfg = () => ({
   webhookPort: 0,
   eventAllowlist: ['issue_comment.created'],
   repos: [],
-  review: { approve: true },
+  review: { on: 'review_requested' as const, approve: true },
 })
 
 const writeGithubSecrets = async (dir: string): Promise<void> => {

--- a/src/channels/schema.test.ts
+++ b/src/channels/schema.test.ts
@@ -78,8 +78,31 @@ describe('channelsSchema', () => {
     expect(parsed.github?.review.approve).toBe(false)
   })
 
-  test('github review defaults to { approve: true } when omitted', () => {
+  test('github review defaults to { on: review_requested, approve: true } when omitted', () => {
     const parsed = channelsSchema.parse({ github: { repos: ['owner/repo'] } })
-    expect(parsed.github?.review).toEqual({ approve: true })
+    expect(parsed.github?.review).toEqual({ on: 'review_requested', approve: true })
+  })
+
+  test('github review.on defaults to review_requested', () => {
+    const parsed = channelsSchema.parse({ github: { repos: ['owner/repo'] } })
+    expect(parsed.github?.review.on).toBe('review_requested')
+  })
+
+  test('github review.on accepts off', () => {
+    const parsed = channelsSchema.parse({ github: { repos: ['owner/repo'], review: { on: 'off' } } })
+    expect(parsed.github?.review.on).toBe('off')
+  })
+
+  test('github review.on accepts opened', () => {
+    const parsed = channelsSchema.parse({ github: { repos: ['owner/repo'], review: { on: 'opened' } } })
+    expect(parsed.github?.review.on).toBe('opened')
+  })
+
+  test('github review.on rejects unknown values', () => {
+    expect(() =>
+      channelsSchema.parse({
+        github: { repos: ['owner/repo'], review: { on: 'closed' } },
+      } as unknown as Parameters<typeof channelsSchema.parse>[0]),
+    ).toThrow()
   })
 })

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -131,11 +131,26 @@ export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [
   'pull_request_review.submitted',
 ] as const
 
+// Which pull_request webhook action triggers an agent code review. The two
+// event values are GitHub's bare PR action names (the `pull_request.` event
+// prefix is implied by this field living under the review config); `off` is the
+// disable sentinel, matching the `engagement.stickiness: 'off'` convention:
+//   - 'review_requested' — review only when the bot is requested (default)
+//   - 'opened'           — review every PR as soon as it opens
+//   - 'off'              — disable code review entirely
+export const GITHUB_REVIEW_ON_VALUES = ['review_requested', 'opened', 'off'] as const
+
+export type GithubReviewOn = (typeof GITHUB_REVIEW_ON_VALUES)[number]
+
+export const DEFAULT_GITHUB_REVIEW_ON: GithubReviewOn = 'review_requested'
+
 // PR-review policy knobs. Grouped under `review` so future toggles
-// (`requestChanges`, auto-review-on-request, severity thresholds) cluster
-// here instead of flattening onto the channel root.
+// (`requestChanges`, severity thresholds) cluster here instead of flattening
+// onto the channel root.
 //
-// `approve` gates whether the agent may submit a formal review with
+// `on` gates which pull_request action triggers a code review (see values above).
+//
+// `approve` gates *whether* the agent may submit a formal review with
 // `event: APPROVE`. When `false`, the adapter appends an operator-policy note
 // to inbounds and the `typeclaw-channel-github` skill downgrades an `approve`
 // verdict to a `COMMENT` review (findings still posted, no formal approval).
@@ -144,9 +159,10 @@ export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [
 // temp file the command interceptor never sees.
 const githubReviewSchema = z
   .object({
+    on: z.enum(GITHUB_REVIEW_ON_VALUES).default(DEFAULT_GITHUB_REVIEW_ON),
     approve: z.boolean().default(true),
   })
-  .default({ approve: true })
+  .default({ on: DEFAULT_GITHUB_REVIEW_ON, approve: true })
 
 const githubChannelSchema = adapterSchema.extend({
   // Optional now (PR 2): when omitted and a `tunnels[]` entry with


### PR DESCRIPTION
## Background

The github channel config already exposes a `review` block, but its only knob is `approve` — whether the agent may submit a formal `APPROVE` review. There was no way to control when (or whether) the agent runs a code review at all. Operators who wanted review-on-open, or wanted code review off entirely, had no config surface for it.

## Summary

Add a sibling `review.on` enum to the github channel config:

- `'review_requested'` — review only when the bot is requested (default)
- `'opened'` — review every PR as soon as it opens
- `'off'` — disable code review entirely

`on` and `approve` are orthogonal: `on` gates which pull_request action triggers a review, `approve` gates whether it may end in a formal approval.

Naming decisions:
- `on` (not `when`) mirrors GitHub Actions' `on:` trigger vocabulary that users already know.
- The two event values are GitHub's bare PR action names. The `pull_request.` prefix is dropped because it's implied by the field living under the github review config (`channels.github.review.on`), and bare action names match GitHub Actions' `types: [opened, review_requested]`.
- `off` (not `never`) is the disable sentinel, matching the existing `engagement.stickiness: 'off'` convention elsewhere in the channels config.

Default is `'review_requested'`, preserving today's request-driven behavior — existing configs that omit `on` are unchanged.

## What this does NOT do

- Does not yet wire `on` into the inbound classifier — this PR is the config surface only. Gating `opened`/`review_requested` inbounds on `on` (and mapping the bare action names back to `pull_request.<action>` webhook keys) is a follow-up.
- Does not touch `approve` semantics or the approval-policy note.

## Review notes

- Load-bearing change is in `src/channels/schema.ts`: `GITHUB_REVIEW_ON_VALUES` + the `on` field on `githubReviewSchema`, with the object-level `.default(...)` updated to match.
- `channels` is `applied` in `FIELD_EFFECTS`, so this hot-reloads — no restart needed.
- Test fixtures in `manager.test.ts` / `lifecycle.test.ts` that build `GithubAdapterConfig` literals now include `on`; `schema.test.ts` adds default + accept (`off`, `opened`) + reject coverage.