### PR TITLE
channels: wire github review.on into the inbound classifier

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -306,6 +306,152 @@ describe('classifyGithubInbound', () => {
       expect(msg?.isBotMention).toBe(false)
     })
   })
+
+  describe('review.on gating', () => {
+    it('defaults to review_requested when reviewOn is omitted: opened stays awareness-only', () => {
+      const msg = classifyGithubInbound('pull_request', openedPayload(), 'typeclaw-bot')
+      expect(msg?.isBotMention).toBe(false)
+      expect(msg?.text).not.toContain('Please review the changes line-by-line')
+    })
+
+    it('defaults to review_requested when reviewOn is omitted: review_requested triggers a review', () => {
+      const msg = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' }),
+        'typeclaw-bot',
+      )
+      expect(msg?.isBotMention).toBe(true)
+      expect(msg?.text).toContain('requested your review on PR #7')
+    })
+
+    describe("reviewOn: 'opened'", () => {
+      it('synthesizes a review trigger for an opened PR', () => {
+        const msg = classifyGithubInbound('pull_request', openedPayload(), 'typeclaw-bot', { reviewOn: 'opened' })
+        expect(msg?.chat).toBe('pr:7')
+        expect(msg?.text).toContain('@alice opened PR #7: "Add the thing"')
+        expect(msg?.text).toContain('feat-branch → main')
+        expect(msg?.text).toContain('Please review the changes line-by-line and post your feedback.')
+        expect(msg?.isBotMention).toBe(true)
+        expect(msg?.authorName).toBe('alice')
+      })
+
+      it('falls back to PR id and omits the branch when title/branch info is absent', () => {
+        const payload = openedPayload()
+        delete (payload.pull_request as Record<string, unknown>).title
+        delete (payload.pull_request as Record<string, unknown>).head
+        delete (payload.pull_request as Record<string, unknown>).base
+        const msg = classifyGithubInbound('pull_request', payload, 'typeclaw-bot', { reviewOn: 'opened' })
+        expect(msg?.text).toContain('opened PR #7')
+        expect(msg?.text).not.toContain('Branch:')
+      })
+
+      it('still triggers a review on an explicit review_requested (opened is a superset)', () => {
+        const msg = classifyGithubInbound(
+          'pull_request',
+          reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' }),
+          'typeclaw-bot',
+          { reviewOn: 'opened' },
+        )
+        expect(msg?.isBotMention).toBe(true)
+        expect(msg?.text).toContain('requested your review on PR #7')
+      })
+
+      it('suppresses the review trigger when the bot opened its own PR (handler drops the self-authored event)', () => {
+        const payload = openedPayload()
+        ;(payload.sender as Record<string, unknown>).login = 'typeclaw-bot'
+        ;(payload.pull_request as Record<string, unknown>).user = { login: 'typeclaw-bot', id: 99, type: 'Bot' }
+        const msg = classifyGithubInbound('pull_request', payload, 'typeclaw-bot', { reviewOn: 'opened' })
+        expect(msg?.isBotMention).toBe(false)
+        expect(msg?.text).not.toContain('Please review the changes line-by-line')
+      })
+
+      it('suppresses the review trigger when the App decoy opened the PR', () => {
+        const payload = openedPayload()
+        ;(payload.sender as Record<string, unknown>).login = 'typeclaw'
+        ;(payload.pull_request as Record<string, unknown>).user = { login: 'typeclaw', id: 42, type: 'User' }
+        const msg = classifyGithubInbound('pull_request', payload, 'typeclaw[bot]', {
+          reviewOn: 'opened',
+          authType: 'app',
+        })
+        expect(msg?.isBotMention).toBe(false)
+        expect(msg?.text).not.toContain('Please review the changes line-by-line')
+      })
+    })
+
+    describe("reviewOn: 'off'", () => {
+      it('drops a review_requested event entirely', () => {
+        const msg = classifyGithubInbound(
+          'pull_request',
+          reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' }),
+          'typeclaw-bot',
+          { reviewOn: 'off' },
+        )
+        expect(msg).toBe(null)
+      })
+
+      it('drops a review_request_removed event entirely', () => {
+        const msg = classifyGithubInbound(
+          'pull_request',
+          reviewRequestRemovedPayload({ reviewerLogin: 'typeclaw-bot' }),
+          'typeclaw-bot',
+          { reviewOn: 'off' },
+        )
+        expect(msg).toBe(null)
+      })
+
+      it('leaves an opened PR as awareness-only context (review trigger suppressed, engagement untouched)', () => {
+        const msg = classifyGithubInbound('pull_request', openedPayload(), 'typeclaw-bot', { reviewOn: 'off' })
+        expect(msg?.chat).toBe('pr:7')
+        expect(msg?.isBotMention).toBe(false)
+        expect(msg?.text).not.toContain('Please review the changes line-by-line')
+      })
+    })
+  })
+})
+
+describe('createGithubWebhookHandler — review.on wiring', () => {
+  const baseOptions = (routed: InboundMessage[], reviewOn?: () => 'review_requested' | 'opened' | 'off') => ({
+    webhookSecret: 'secret',
+    dedup: createDeliveryDedup(),
+    allowlist: () => ['pull_request.opened', 'pull_request.review_requested'],
+    selfId: () => '99',
+    selfLogin: () => 'typeclaw-bot',
+    logger,
+    route: (msg: InboundMessage) => {
+      routed.push(msg)
+    },
+    ...(reviewOn !== undefined ? { reviewOn } : {}),
+  })
+
+  it("routes an opened PR as a review trigger when reviewOn is 'opened'", async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler(baseOptions(routed, () => 'opened'))
+    await handler(signedRequest(JSON.stringify(openedPayload()), 'pull_request', 'on-opened-1'))
+    expect(routed).toHaveLength(1)
+    expect(routed[0]?.isBotMention).toBe(true)
+    expect(routed[0]?.text).toContain('Please review the changes line-by-line')
+  })
+
+  it("drops a review_requested event when reviewOn is 'off'", async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler(baseOptions(routed, () => 'off'))
+    await handler(
+      signedRequest(
+        JSON.stringify(reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' })),
+        'pull_request',
+        'on-off-1',
+      ),
+    )
+    expect(routed).toHaveLength(0)
+  })
+
+  it('preserves request-driven behavior when reviewOn is omitted', async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler(baseOptions(routed))
+    await handler(signedRequest(JSON.stringify(openedPayload()), 'pull_request', 'on-default-1'))
+    expect(routed).toHaveLength(1)
+    expect(routed[0]?.isBotMention).toBe(false)
+  })
 })
 
 describe('createGithubWebhookHandler — pull_request.opened lands as context', () => {

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from 'node:crypto'
 
+import type { GithubReviewOn } from '@/channels/schema'
 import type { InboundMessage } from '@/channels/types'
 
 import type { GithubAuthContext } from './auth'
@@ -23,6 +24,14 @@ export type GithubWebhookHandlerOptions = {
   // an appended operator-policy note telling the agent not to submit an APPROVE
   // review; the github skill keys off that note to downgrade approve→COMMENT.
   allowApprove?: () => boolean
+  // Which pull_request action triggers an agent code review. Defaults to
+  // 'review_requested' when omitted, preserving the request-driven behavior.
+  // 'opened' additionally wakes the bot to review every PR the moment it opens;
+  // 'off' suppresses the dedicated review-trigger synthesis entirely (an
+  // explicit review_requested no longer wakes a session). Orthogonal to the
+  // eventAllowlist (the outer "process this webhook?" gate) — this is the inner
+  // "does an admitted pull_request event become a review-trigger inbound?" gate.
+  reviewOn?: () => GithubReviewOn
   route: (message: InboundMessage) => void
   logger: GithubInboundLogger
   // Optional: resolves whether the bot is a member of the given team. When
@@ -75,6 +84,7 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
     const classified = classifyGithubInbound(event, payload, selfLogin, {
       teamIsBotMember,
       authType: options.authType?.() ?? 'pat',
+      reviewOn: options.reviewOn?.() ?? 'review_requested',
     })
     if (classified === null) return ok()
 
@@ -173,7 +183,7 @@ export function classifyGithubInbound(
   event: string,
   payload: Record<string, unknown>,
   selfLogin: string | null,
-  options?: { teamIsBotMember?: boolean; authType?: 'pat' | 'app' },
+  options?: { teamIsBotMember?: boolean; authType?: 'pat' | 'app'; reviewOn?: GithubReviewOn },
 ): InboundMessage | null {
   const repository = readRepository(payload)
   if (repository === null) return null
@@ -266,7 +276,12 @@ export function classifyGithubInbound(
     const id = readNumber(pr, 'id') ?? number
     if (number === null || id === null) return null
     const action = readString(payload, 'action')
+    const reviewOn = options?.reviewOn ?? 'review_requested'
     if (action === 'review_requested' || action === 'review_request_removed') {
+      // `off` disables the dedicated review trigger: these two actions exist
+      // only to drive review-request behavior here, so under `off` they wake no
+      // session rather than falling through to awareness-only context.
+      if (reviewOn === 'off') return null
       return classifyReviewRequest({
         action,
         payload,
@@ -277,6 +292,17 @@ export function classifyGithubInbound(
         authType: options?.authType ?? 'pat',
         teamIsBotMember: options?.teamIsBotMember,
       })
+    }
+    if (action === 'opened' && reviewOn === 'opened') {
+      const trigger = classifyOpenedReviewTrigger({
+        payload,
+        pr,
+        number,
+        base,
+        selfLogin,
+        authType: options?.authType ?? 'pat',
+      })
+      if (trigger !== null) return trigger
     }
     return buildInbound(
       { ...base, chat: `pr:${number}`, thread: null },
@@ -402,6 +428,53 @@ function classifyReviewRequest(input: ReviewRequestInput): InboundMessage | null
   const updatedAt = readString(pr, 'updated_at') ?? ''
   const prId = readNumber(pr, 'id') ?? number
   const externalMessageId = `pr-${prId}-${action}-${updatedAt}`
+
+  return {
+    ...base,
+    chat: `pr:${number}`,
+    thread: null,
+    text,
+    externalMessageId,
+    authorId: String(sender.id),
+    authorName: sender.login,
+    authorIsBot: sender.type === 'Bot',
+    isBotMention: true,
+    replyToBotMessageId: null,
+    ts: updatedAt !== '' ? Date.parse(updatedAt) || 0 : 0,
+  }
+}
+
+type OpenedReviewTriggerInput = {
+  payload: Record<string, unknown>
+  pr: Record<string, unknown>
+  number: number
+  base: Pick<InboundMessage, 'adapter' | 'workspace' | 'isDm' | 'mentionsOthers' | 'replyToOtherMessageId'>
+  selfLogin: string | null
+  authType: 'pat' | 'app'
+}
+
+function classifyOpenedReviewTrigger(input: OpenedReviewTriggerInput): InboundMessage | null {
+  const { payload, pr, number, base, selfLogin, authType } = input
+  if (selfLogin === null) return null
+  const sender = readUser(payload.sender) ?? readUser(pr.user)
+  if (sender === null) return null
+  // Defensive self-loop guard mirroring classifyReviewRequest: the handler-level
+  // self-author drop already discards bot-opened PRs, but the decoy account is a
+  // distinct login, so a decoy-opened PR would otherwise wake a self-review.
+  const decoyLogin = resolveDecoyReviewerLogin(selfLogin, authType)
+  if (sender.login === selfLogin || (decoyLogin !== null && sender.login === decoyLogin)) return null
+
+  const title = readString(pr, 'title') ?? `#${number}`
+  const head = readString(readRecord(pr.head), 'ref')
+  const baseRef = readString(readRecord(pr.base), 'ref')
+  const branchSegment = head !== null && baseRef !== null ? ` Branch: ${head} → ${baseRef}.` : ''
+  const text =
+    `@${sender.login} opened PR #${number}: "${title}".${branchSegment}` +
+    ' Please review the changes line-by-line and post your feedback.'
+
+  const updatedAt = readString(pr, 'updated_at') ?? ''
+  const prId = readNumber(pr, 'id') ?? number
+  const externalMessageId = `pr-${prId}-opened-${updatedAt}`
 
   return {
     ...base,

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -155,6 +155,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     selfLogin: () => selfLogin,
     authType: () => options.secrets.auth.type,
     allowApprove: () => options.configRef().review.approve,
+    reviewOn: () => options.configRef().review.on,
     isBotInTeam,
     authToken,
     fetchImpl,


### PR DESCRIPTION
## Background

#579 added the `channels.github.review.on` enum (`'review_requested' | 'opened' | 'off'`, default `'review_requested'`) as **config surface only**. Its own "What this does NOT do" called out the follow-up explicitly:

> Does not yet wire `on` into the inbound classifier — this PR is the config surface only. Gating `opened`/`review_requested` inbounds on `on` (and mapping the bare action names back to `pull_request.<action>` webhook keys) is a follow-up.

This is that follow-up. `review.on` now actually changes behavior.

## Summary

`reviewOn` threads from the adapter config (`index.ts`, mirroring the existing `allowApprove` callback) through `GithubWebhookHandlerOptions` into the pure `classifyGithubInbound`. The `pull_request` branch gates on it:

| `pull_request` action | `review_requested` (default) | `opened` | `off` |
| --- | --- | --- | --- |
| `opened` | awareness-only context | **review trigger** | awareness-only context |
| `review_requested` | review trigger (if bot/decoy/team requested) | review trigger (if bot/decoy/team requested) | **dropped** |
| `review_request_removed` | stop-review signal | stop-review signal | **dropped** |

- **`review_requested`** (default): unchanged. Review fires only when the bot — or, under App auth, its decoy reviewer account / its team — is the requested reviewer.
- **`opened`**: every `pull_request.opened` synthesizes a review-trigger inbound (`isBotMention: true`, "Please review the changes line-by-line and post your feedback."). An explicit `review_requested` **still** triggers too — `opened` is a superset, not a swap, so requesting a review after opening is never silently ignored.
- **`off`**: `review_requested` / `review_request_removed` wake no session at all. Opened PRs remain awareness-only context (so general `@mention` engagement on a PR body is untouched — `off` disables the dedicated **code-review trigger**, not all PR awareness).

`opened` triggers go through a new, small `classifyOpenedReviewTrigger` rather than reusing `classifyReviewRequest`, because an `opened` payload has no `requested_reviewer`/`requested_team` and the decoy/team gating is meaningless for it.

## Design notes

- **Default preserves today's behavior.** `reviewOn` defaults to `'review_requested'` both at the handler call-site (`options.reviewOn?.() ?? 'review_requested'`) and inside the classifier's `options`, so direct classifier callers and every existing test are unchanged.
- **Orthogonal to `eventAllowlist`.** The allowlist is the outer "process this webhook at all?" gate; `review.on` is the inner "does an admitted `pull_request` event become a review-trigger inbound?" gate. The allowlist is untouched.
- **Self/decoy-loop safety.** The handler-level self-author drop already discards bot-opened PRs, but the App decoy account has a **distinct** login from the bot login that drop checks — so `classifyOpenedReviewTrigger` keeps a defensive self/decoy guard, mirroring `classifyReviewRequest`.
- Design reviewed for the `opened`-superset, `off`-drop, and loop-safety decisions before implementation.

## Tests

`inbound.test.ts` gains a `review.on gating` matrix: default backward-compat (omitted `reviewOn`), `opened` (synthesis, branch/title fallback, `review_requested` superset, self + decoy suppression), and `off` (drops `review_requested`/`review_request_removed`, leaves `opened` as awareness-only), plus three handler-level tests proving the `reviewOn` callback wiring end-to-end.

## Checks

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and the channel test suite all pass. (The one failure in the full run — `resolveSelfPackageJsonPath > points at this package manifest` — is a worktree-directory-name artifact: it asserts the path ends with `typeclaw/package.json`, unrelated to this change.)

## What this does NOT do

- Does not touch `approve` semantics, the approval-policy note, or the `typeclaw-channel-github` skill (the skill reacts to whatever review-trigger inbound arrives; its flow is unchanged).
- Does not add cross-event dedup: in `opened` mode a PR that is both opened and then has the bot requested can wake two sessions. That's the intended superset behavior; stateful dedup is out of scope.

Follow-up to #579.
