### PR TITLE
channels: show Slack typing status in flat DMs

### DIFF
--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -344,6 +344,44 @@ describe('slack-bot classifyInbound — route path', () => {
     expect(verdict.payload.thread).toBeNull()
   })
 
+  test('a flat DM anchors typingThread on the inbound ts so the status can render', () => {
+    const event = buildEvent({ channel_type: 'im', channel: 'D0DM', text: 'private hi' })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.thread).toBeNull()
+    expect(verdict.payload.typingThread).toBe('1700000000.000100')
+  })
+
+  test('a non-DM message carries no typingThread (the channel typing path uses thread)', () => {
+    const event = buildEvent({ text: 'just chatting' })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.typingThread).toBeUndefined()
+  })
+
+  test('a DM already in a thread does not override typingThread (thread drives status)', () => {
+    const event = buildEvent({
+      channel_type: 'im',
+      channel: 'D0DM',
+      text: 'in a thread',
+      ts: '1700000010.000200',
+      thread_ts: '1700000000.000100',
+    })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.thread).toBe('1700000000.000100')
+    expect(verdict.payload.typingThread).toBeUndefined()
+  })
+
   test('non-mention team message with no alias match leaves thread null (existing behavior)', () => {
     const event = buildEvent({ text: 'just chatting' })
 

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -92,6 +92,11 @@ export function classifyInbound(
   // found, keeping the cost negligible in mention-heavy channels.
   const aliasMatched = !isBotMention && matchesAnyAlias(rawText, context.selfAliases ?? [])
   const thread = event.thread_ts ?? (!isDm && (isBotMention || aliasMatched) ? event.ts : null)
+  // DMs stay flat (`thread` null), but Slack's typing status still needs a real
+  // message ts; anchor it on the inbound so the indicator renders without
+  // threading the reply. `assistant.threads.setStatus` accepts any live channel
+  // message ts, confirmed against the API.
+  const typingThread = isDm && thread === null ? event.ts : undefined
 
   // A reply is "to the bot" only when the thread parent was authored by the
   // bot. Slack surfaces the parent author via `parent_user_id` on every
@@ -130,6 +135,7 @@ export function classifyInbound(
       workspace,
       chat: event.channel,
       thread,
+      ...(typingThread !== undefined ? { typingThread } : {}),
       text,
       ...(attachments.length > 0 ? { attachments } : {}),
       externalMessageId: event.ts,

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -70,6 +70,67 @@ describe('slack-bot createTypingCallback', () => {
     expect(calls).toEqual([{ channel: 'C0CHANNEL', threadTs: '1700000000.000100', status: 'is typing...' }])
   })
 
+  test('calls setStatus on a flat DM using typingThread when thread is null', async () => {
+    // given
+    const { tracker, calls } = makeFakeTracker()
+    const cb = createTypingCallback({
+      typingTracker: tracker,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    // when
+    await cb({
+      adapter: 'slack-bot',
+      workspace: '@dm',
+      chat: 'D0DM',
+      thread: null,
+      typingThread: '1700000000.000100',
+      phase: 'tick',
+    })
+    // then
+    expect(calls).toEqual([{ channel: 'D0DM', threadTs: '1700000000.000100', status: 'is typing...' }])
+  })
+
+  test('phase=stop on a flat DM clears using typingThread', async () => {
+    // given
+    const { tracker, calls, clears } = makeFakeTracker()
+    const cb = createTypingCallback({
+      typingTracker: tracker,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    // when
+    await cb({
+      adapter: 'slack-bot',
+      workspace: '@dm',
+      chat: 'D0DM',
+      thread: null,
+      typingThread: '1700000000.000100',
+      phase: 'stop',
+    })
+    // then
+    expect(calls).toHaveLength(0)
+    expect(clears).toEqual([{ chat: 'D0DM', thread: '1700000000.000100' }])
+  })
+
+  test('typingThread takes precedence over thread when both are present', async () => {
+    // given
+    const { tracker, calls } = makeFakeTracker()
+    const cb = createTypingCallback({
+      typingTracker: tracker,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    // when
+    await cb({
+      adapter: 'slack-bot',
+      workspace: '@dm',
+      chat: 'D0DM',
+      thread: '1700000000.000999',
+      typingThread: '1700000000.000100',
+      phase: 'tick',
+    })
+    // then
+    expect(calls).toEqual([{ channel: 'D0DM', threadTs: '1700000000.000100', status: 'is typing...' }])
+  })
+
   test('is a no-op (logs info, no API call) for top-level chats without a thread', async () => {
     // given
     const { tracker, calls } = makeFakeTracker()
@@ -1463,6 +1524,30 @@ describe('slack-bot createOutboundCallback', () => {
     })
     await cb(makeMsg({ text: 'hello' }))
     expect(clearCalls).toEqual([{ chat: 'C0', thread: undefined }])
+  })
+
+  test('flat DM send posts top-level but clears the status on typingThread', async () => {
+    // given
+    const { client, posts } = makeFakeClient()
+    const clearCalls: Array<{ chat: string; thread: string | null | undefined }> = []
+    const cb = createOutboundCallback({
+      client,
+      logger: silentLogger(),
+      formatChannelTag: tag,
+      readFile: fakeRead,
+      typingTracker: {
+        clearAfterSend: async (chat, thread) => {
+          clearCalls.push({ chat, thread })
+        },
+      },
+    })
+    // when
+    const result = await cb(makeMsg({ chat: 'D0', text: 'hi', thread: null, typingThread: '1700.000100' }))
+    // then
+    expect(result.ok).toBe(true)
+    expect(posts).toHaveLength(1)
+    expect(posts[0]!.options?.thread_ts).toBeUndefined()
+    expect(clearCalls).toEqual([{ chat: 'D0', thread: '1700.000100' }])
   })
 
   test('threaded uploadFile triggers clearAfterSend after the LAST attachment', async () => {

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -351,18 +351,23 @@ export function createTypingCallback(deps: {
   const { typingTracker, logger, formatChannelTag } = deps
   return async (target: TypingTarget): Promise<void> => {
     if (target.adapter !== 'slack-bot') return
+    // DMs are flat (thread null) but setStatus still needs a real message ts;
+    // `typingThread` carries the inbound ts for exactly that case. Real channel
+    // threads keep using `thread`. Either way the status is keyed on one ts.
+    const statusThread =
+      target.typingThread !== undefined && target.typingThread !== '' ? target.typingThread : target.thread
     const tag = formatChannelTag
-      ? await formatChannelTag(target.workspace, target.thread ?? target.chat)
-      : `channel=${target.thread ?? target.chat}`
-    if (target.thread === undefined || target.thread === null || target.thread === '') {
+      ? await formatChannelTag(target.workspace, statusThread ?? target.chat)
+      : `channel=${statusThread ?? target.chat}`
+    if (statusThread === undefined || statusThread === null || statusThread === '') {
       if (target.phase === 'tick') logger.info(`[slack-bot] typing (no-op, top-level chat) ${tag}`)
       return
     }
     if (target.phase === 'stop') {
-      await typingTracker.clearAfterSend(target.chat, target.thread)
+      await typingTracker.clearAfterSend(target.chat, statusThread)
       return
     }
-    await typingTracker.setStatus(target.chat, target.thread, 'is typing...')
+    await typingTracker.setStatus(target.chat, statusThread, 'is typing...')
   }
 }
 
@@ -823,7 +828,7 @@ export function createOutboundCallback(deps: {
           // top-level posts.
           if (threadTs === null && chunks.length > 1) threadTs = sent.ts
         }
-        if (typingTracker) await typingTracker.clearAfterSend(msg.chat, msg.thread)
+        if (typingTracker) await typingTracker.clearAfterSend(msg.chat, msg.typingThread ?? msg.thread)
         return { ok: true }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
@@ -856,7 +861,7 @@ export function createOutboundCallback(deps: {
         return { ok: false, error: `uploadFile failed: ${message}` }
       }
     }
-    if (typingTracker) await typingTracker.clearAfterSend(msg.chat, msg.thread)
+    if (typingTracker) await typingTracker.clearAfterSend(msg.chat, msg.typingThread ?? msg.thread)
     return { ok: true }
   }
 }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1348,6 +1348,23 @@ describe('ChannelRouter outbound', () => {
     expect(captured).toEqual({ chat: 'c-99', text: 'announcement' })
   })
 
+  test('stamps the turn typingThread onto a DM send so the adapter can clear the status', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    let capturedTypingThread: string | undefined
+    let capturedThread: string | null | undefined
+    router.registerOutbound('discord-bot', async (msg) => {
+      capturedTypingThread = msg.typingThread
+      capturedThread = msg.thread
+      return { ok: true }
+    })
+    await router.route(inbound({ isDm: true, thread: null, typingThread: 'dm-ts-1', text: 'hi bot' }))
+    const result = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply' })
+    expect(result.ok).toBe(true)
+    expect(capturedTypingThread).toBe('dm-ts-1')
+    expect(capturedThread).toBeUndefined()
+  })
+
   test('returns ok:false with adapter error when callback denies', async () => {
     const dir = await tempDir()
     const { router } = makeRouter(dir)
@@ -3726,6 +3743,17 @@ describe('ChannelRouter typing indicator', () => {
     })
     await router.route(inbound({ thread: 'thread-7', text: 'hi bot' }))
     expect(calls[0]).toEqual({ chat: 'c1', thread: 'thread-7' })
+  })
+
+  test('forwards typingThread for a flat DM while the session thread stays null', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    const calls: Array<{ chat: string; thread: string | null | undefined; typingThread: string | undefined }> = []
+    router.registerTyping('discord-bot', async (target) => {
+      calls.push({ chat: target.chat, thread: target.thread, typingThread: target.typingThread })
+    })
+    await router.route(inbound({ isDm: true, thread: null, typingThread: 'dm-ts-1', text: 'hi bot' }))
+    expect(calls[0]).toEqual({ chat: 'c1', thread: null, typingThread: 'dm-ts-1' })
   })
 
   test('typing-callback rejection does not crash route', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -290,6 +290,7 @@ type QueuedInbound = {
   isBotMention: boolean
   replyToBotMessageId: string | null
   isDm: boolean
+  typingThread?: string
   receivedAt: number
   // Original platform timestamp (Slack/Discord), in ms since epoch. Used
   // by composeTurnPrompt to render an ISO 8601 prefix on each line so the
@@ -358,6 +359,11 @@ type LiveSession = {
   // origin so `channel_react` reacts to the triggering message, not whichever
   // inbound happens to be latest in the queue. Null on reminder-only turns.
   currentTurnReactionRef: ReactionRef | null
+  // Typing-status anchor of the inbound that triggered THIS turn (last item in
+  // the drained batch, mirroring `currentTurnReactionRef`). Adapter-opaque ts
+  // carried only to the typing path; null when the triggering inbound supplied
+  // none (every non-DM inbound, and reminder-only turns).
+  currentTurnTypingThread: string | null
   // One engage-:eyes:-add promise per inbound coalesced into THIS turn, each
   // resolving to its removable per-instance ref (or null). A debounced turn can
   // batch several inbounds that each got their own :eyes:, so every entry is
@@ -1181,6 +1187,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         currentTurnAuthorId: null,
         currentTurnAuthorIds: new Set(),
         currentTurnReactionRef: null,
+        currentTurnTypingThread: null,
         currentTurnEngageReactions: [],
         // `lastTurnAuthorId` (string, used for `lastInboundAuthorId` in
         // origin) and `lastTurnAuthorIds` (Set, used by
@@ -1366,6 +1373,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       workspace: live.key.workspace,
       chat: live.key.chat,
       thread: live.key.thread,
+      ...(live.currentTurnTypingThread !== null ? { typingThread: live.currentTurnTypingThread } : {}),
       phase,
     }
     await Promise.all(
@@ -1595,6 +1603,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.currentTurnAuthorId = batch[batch.length - 1]!.authorId
           live.currentTurnAuthorIds = new Set(batch.map((m) => m.authorId))
           live.currentTurnReactionRef = batch[batch.length - 1]!.reactionRef ?? null
+          live.currentTurnTypingThread = batch[batch.length - 1]!.typingThread ?? null
           live.currentTurnEngageReactions = batch.flatMap((m) =>
             m.engageReaction !== undefined ? [m.engageReaction] : [],
           )
@@ -1677,7 +1686,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.currentTurnReactionRef = null
       live.currentTurnEngageReactions = []
       live.currentTurnAttachments = []
+      // Reset AFTER stopTypingHeartbeat: its final 'stop' tick reads the anchor
+      // to clear a flat-DM status; clearing it first would strand the indicator.
       await stopTypingHeartbeat(live)
+      live.currentTurnTypingThread = null
     }
   }
 
@@ -2043,9 +2055,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       isBotMention: event.isBotMention,
       replyToBotMessageId: event.replyToBotMessageId,
       isDm: event.isDm,
+      ...(event.typingThread !== undefined ? { typingThread: event.typingThread } : {}),
       receivedAt: now(),
       ts: event.ts,
     })
+    // Make the typing anchor live BEFORE startTypingHeartbeat fires (route()
+    // starts the heartbeat right after enqueue, ahead of drain). drain() later
+    // refreshes it to the last inbound of a coalesced batch.
+    if (event.typingThread !== undefined) live.currentTurnTypingThread = event.typingThread
   }
 
   const registerOutbound = (adapter: ChannelKey['adapter'], cb: OutboundCallback): void => {
@@ -2480,6 +2497,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       if (text !== undefined) live.lastSentText.set(sendKey, text)
       live.inFlightToolSends.set(sendKey, (live.inFlightToolSends.get(sendKey) ?? 0) + 1)
       reserved = true
+    }
+
+    // The adapter needs the typing anchor to clear a flat-DM status (msg.thread
+    // is null there, so a thread-keyed clear would no-op). Kept off msg.thread
+    // to leave reply threading untouched.
+    if (live?.currentTurnTypingThread != null && msg.typingThread === undefined) {
+      msg = { ...msg, typingThread: live.currentTurnTypingThread }
     }
 
     // Snapshot the callbacks before iterating so a callback that mutates the

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -94,6 +94,15 @@ export type InboundMessage = {
   // means "unknown" — the formatter renders such lines without a
   // timestamp prefix instead of stamping them with the wrong clock.
   ts: number
+  // Platform-native anchor for showing a typing/status indicator, kept
+  // SEPARATE from `thread` on purpose: `thread` drives reply threading,
+  // this drives ONLY the typing surface. Slack's `assistant.threads.
+  // setStatus` (the bot's only typing signal) requires a real message ts
+  // even in a flat DM, where `thread` is null because replies stay top-
+  // level. The classifier sets this to the inbound message ts for DMs so
+  // the status can render without forcing the reply into a thread. Omitted
+  // for non-DM inbounds, where the typing path falls back to `thread`.
+  typingThread?: string
   // Opaque, adapter-owned handle for the entity an emoji reaction would
   // attach to. The classifier stamps it because only there is the platform-
   // side target type still known (GitHub: issue body vs issue-comment vs
@@ -183,6 +192,10 @@ export type OutboundMessage = {
   // `uploadFile` does not accept a content body or a thread id, see the
   // adapter for the workaround details.
   attachments?: OutboundAttachment[]
+  // Typing-only anchor (see InboundMessage.typingThread), stamped by the
+  // router from the live session so the adapter can CLEAR the status after a
+  // flat DM send — where `thread` is null and would otherwise no-op the clear.
+  typingThread?: string
   // Set by the router (native render mode + anchor fired) so an adapter can
   // reply to the inbound it answers. Telegram/Discord consume `externalMessageId`;
   // `quote`-mode adapters never see this (the router prepends the blockquote into
@@ -224,6 +237,10 @@ export type TypingTarget = {
   workspace: string
   chat: string
   thread?: string | null
+  // Typing-only anchor (see InboundMessage.typingThread). An adapter whose
+  // typing surface needs a message ts even when `thread` is null (Slack DMs)
+  // reads this first and falls back to `thread`. Never used for reply routing.
+  typingThread?: string
   // 'tick' is the heartbeat fired during debouncing/generation; adapters
   // should set the indicator visible. 'stop' is fired exactly once when the
   // router decides the turn is over (drain finally, /stop command, or


### PR DESCRIPTION
## Problem

The Slack bot never showed a typing/status indicator in 1:1 DMs.

Slack's only bot-accessible typing signal is `assistant.threads.setStatus`, which requires a `thread_ts`. The inbound classifier sets `thread: null` for DMs (replies stay flat/top-level), and the typing callback bailed out whenever `thread` was empty — so DMs logged `[slack-bot] typing (no-op, top-level chat)` and no status ever rendered. Channels worked because mentions/threads give them a `thread_ts`.

## Key finding (verified against the live API)

`assistant.threads.setStatus` accepts **any live message ts in the channel** as `thread_ts` — not only a feature-created "assistant thread". Confirmed directly:

- `setStatus(D…, <real DM message ts>, "is typing...")` → `ok: true`, status renders in the flat DM
- `setStatus(D…, "0000000000.000000", …)` → `invalid_thread_ts`
- works on a normal workspace **without** enabling the paid *Agents & AI Apps* feature

So we can anchor the DM typing status on the inbound message ts while still posting the reply flat.

## Approach

Add a typing-only anchor field, `typingThread`, kept deliberately **separate from `thread`** so reply threading is never affected:

- **classifier** (`slack-bot-classify.ts`): for a flat DM, set `typingThread = event.ts` (leaves `thread` null; non-DM and already-threaded DMs get no `typingThread`).
- **router** (`router.ts`): carry the turn's anchor on the live session, include it on the `TypingTarget`, and stamp it onto the outbound `OutboundMessage` so the status can be **cleared** after a flat send (where `msg.thread` is null and a thread-keyed clear would no-op). Never touches `ChannelKey.thread`, so session identity / history / dedupe are unchanged.
- **adapter** (`slack-bot.ts`): `createTypingCallback` and `createOutboundCallback` prefer `typingThread` over `thread` when calling `setStatus` / `clearAfterSend`. Real channel threads keep using `thread`.

Reply posting still keys off `msg.thread` only, so DM replies remain top-level.

## Tests

- classifier: flat DM anchors `typingThread` on the inbound ts; non-DM and already-threaded DM carry none.
- router: DM inbound forwards `typingThread` on the `TypingTarget` while the session thread stays null; a DM send gets `typingThread` stamped (and `thread` stays unset).
- adapter: DM `tick` calls `setStatus` on `typingThread`; DM `stop` clears on `typingThread`; `typingThread` wins over `thread`; a flat DM send posts with **no** `thread_ts` yet still clears the status.

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and the channel suites all pass.

> Note: one unrelated pre-existing test (`resolveSelfPackageJsonPath > points at this package manifest`) fails only because it was run from a worktree dir not named `typeclaw`; it passes in a standard `typeclaw` checkout / CI.