### PR TITLE
reviewer: bound spawn with a timeout so a stalled review can't strand the parent

### DIFF
--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -828,6 +828,72 @@ describe('startSubagent', () => {
     }
   })
 
+  test('timeoutMs settles completion with ok=false when prompt wedges (parent gets woken, not stranded)', async () => {
+    // given: a session whose prompt never resolves, and a subagent with a tiny timeout
+    let abortCount = 0
+    const session = {
+      prompt: () => new Promise<void>(() => {}),
+      dispose: () => {},
+      subscribe: () => () => {},
+      abort: async () => {
+        abortCount += 1
+      },
+    } as unknown as AgentSession
+    const registry = { greeter: { systemPrompt: 'X', timeoutMs: 20 } satisfies Subagent }
+
+    // when
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_timeout',
+    })
+    const result = await completion
+
+    // then: the spawn fails (so spawn_subagent fires the FAILED broadcast) and the session is aborted
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('timed out')
+    }
+    expect(abortCount).toBe(1)
+  })
+
+  test('without timeoutMs a slow prompt keeps completion pending (legacy unbounded behavior preserved)', async () => {
+    // given: a session whose prompt has not resolved yet, and no timeout declared
+    let resolvePrompt: () => void = () => {}
+    const session = {
+      prompt: () =>
+        new Promise<void>((r) => {
+          resolvePrompt = r
+        }),
+      dispose: () => {},
+      subscribe: () => () => {},
+      abort: async () => {},
+    } as unknown as AgentSession
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+
+    // when
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_unbounded',
+    })
+    let settled = false
+    void completion.then(() => {
+      settled = true
+    })
+    await new Promise((r) => setTimeout(r, 30))
+
+    // then: still pending — no ceiling fired
+    expect(settled).toBe(false)
+    resolvePrompt()
+    await completion
+    expect(settled).toBe(true)
+  })
+
   test('onSession fires once with the live session and abort handle', async () => {
     // given
     const { session } = subscribableFakeSession()

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -325,6 +325,20 @@ export type StartSubagentOptions = InvokeSubagentOptions & {
 // The two promises share a single underlying invokeSubagent invocation;
 // `completion` settles after dispose, so the session reference exposed via
 // `handle.abort` becomes a no-op once `completion` resolves.
+//
+// `timeoutMs` enforcement: the `spawn_subagent` tool drives its background
+// `subagent.completed` broadcast off this `completion` promise, so an
+// unbounded `invokeSubagent` (a wedged `session.prompt` that never settles)
+// would leave `completion` pending forever and the parent never woken. When
+// the subagent declares `timeoutMs`, we race the work against a ceiling and
+// settle `completion` with `ok: false` on expiry — which fires the FAILED
+// broadcast so the parent learns the spawn died instead of hanging silently.
+// This mirrors `awaitWithSubagentTimeout` on the SubagentConsumer path; here
+// the timeout resolves (rather than rejects) because `completion` already maps
+// failures to `{ ok: false }`. Cancellation is best-effort: pi's
+// `session.prompt` takes no AbortSignal, so we call the session `abort` handle
+// (which the handle resolution captured) to tear down what we can; the LLM
+// stream may keep running until the OS reaps it.
 export function startSubagent(name: string, options: StartSubagentOptions): StartSubagentResult {
   let resolveHandle: (h: SubagentHandle) => void
   let rejectHandle: (err: Error) => void
@@ -334,11 +348,13 @@ export function startSubagent(name: string, options: StartSubagentOptions): Star
   })
   let handleSettled = false
   let finalMessage: string | undefined
+  let abortSession: (() => Promise<void>) | undefined
 
-  const completion = invokeSubagent(name, {
+  const work = invokeSubagent(name, {
     ...options,
     onSessionCreated: (event) => {
       handleSettled = true
+      abortSession = event.abort
       resolveHandle({ taskId: options.taskId, sessionId: event.sessionId, abort: event.abort })
       if (options.onSession !== undefined) {
         options.onSession(event)
@@ -357,7 +373,34 @@ export function startSubagent(name: string, options: StartSubagentOptions): Star
       return { ok: false as const, error }
     })
 
+  const timeoutMs = options.registry[name]?.timeoutMs
+  const completion = timeoutMs === undefined ? work : raceSubagentCompletion(work, name, options.taskId, timeoutMs)
+
+  void completion.then(() => {
+    if (timeoutMs !== undefined) void abortSession?.()
+  })
+
   return { handle, completion }
+}
+
+type SubagentCompletion = { ok: true; finalMessage?: string } | { ok: false; error: string }
+
+function raceSubagentCompletion(
+  work: Promise<SubagentCompletion>,
+  name: string,
+  taskId: string,
+  timeoutMs: number,
+): Promise<SubagentCompletion> {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const timeout = new Promise<SubagentCompletion>((resolve) => {
+    timer = setTimeout(
+      () => resolve({ ok: false, error: new SubagentTimeoutError(name, taskId, timeoutMs).message }),
+      timeoutMs,
+    )
+  })
+  return Promise.race([work, timeout]).finally(() => {
+    if (timer !== null) clearTimeout(timer)
+  })
 }
 
 function attachFinalMessageCapture(session: AgentSession, onFinalMessage: (msg: string) => void): void {

--- a/src/bundled-plugins/reviewer/reviewer.test.ts
+++ b/src/bundled-plugins/reviewer/reviewer.test.ts
@@ -175,6 +175,18 @@ describe('reviewer subagent declaration', () => {
     expect(budget).toBeLessThan(1_000_000)
   })
 
+  test('declares a spawn timeout so a stalled review fails the parent loudly instead of hanging forever', () => {
+    const sub = createReviewerSubagent()
+    expect(sub.timeoutMs).toBeGreaterThan(0)
+  })
+
+  test('spawn timeout is generous enough for a deep-model review but not unbounded', () => {
+    const sub = createReviewerSubagent()
+    const timeout = sub.timeoutMs ?? 0
+    expect(timeout).toBeGreaterThanOrEqual(60_000)
+    expect(timeout).toBeLessThanOrEqual(1_800_000)
+  })
+
   test('inFlightKey returns distinct values for distinct requestId payloads (parallel spawns must not coalesce)', () => {
     const sub = createReviewerSubagent()
     const k1 = sub.inFlightKey?.({ requestId: 'bg_a' })

--- a/src/bundled-plugins/reviewer/reviewer.ts
+++ b/src/bundled-plugins/reviewer/reviewer.ts
@@ -26,6 +26,19 @@ import { GENERAL_REVIEW_SKILL } from './skills/general'
 // no runtime change required.
 export const REVIEWER_SKILLS: readonly LoadableSkill[] = [CODE_REVIEW_SKILL, GENERAL_REVIEW_SKILL]
 
+// Without a ceiling, a reviewer whose `session.prompt` stalls mid-turn (model
+// wedges after a tool error, never emits a terminal message) leaves `completion`
+// pending forever: the `subagent.completed` broadcast never fires and the parent
+// channel session is never woken to post the review — the spawn hangs silently.
+// The ceiling makes `awaitWithSubagentTimeout` settle with SubagentTimeoutError,
+// surfacing to the parent as a FAILED completion reminder so the request fails
+// loudly instead of vanishing. Sized for a thorough `deep`-model review (large
+// diff + a few web lookups), well above the typical sub-minute review. This is
+// liveness for the parent, not hard cancellation: pi's `session.prompt` takes no
+// AbortSignal, so the LLM stream may run until the OS reaps it. See
+// src/agent/subagents.ts `timeoutMs`.
+export const REVIEWER_SPAWN_TIMEOUT_MS = 600_000
+
 // TODO(#452): Restrict the reviewer's `bash` to git and a curated set of
 // read-only `gh` subcommands once per-subagent bash allowlist support lands.
 // Today the read-only contract is enforced only by this system prompt, the
@@ -159,6 +172,7 @@ If none of the listed skills fit the target, load \`general\` and explain in \`<
     customTools: [loadSkillTool],
     payloadSchema: reviewerPayloadSchema,
     visibility: 'public',
+    timeoutMs: REVIEWER_SPAWN_TIMEOUT_MS,
     inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     toolResultBudget: {
       // Higher than explorer (256KB) because a reviewer typically reads larger


### PR DESCRIPTION
## Problem

A `reviewer` subagent spawned to review a GitHub PR can stall mid-turn and **strand the parent forever**, with no error surfaced anywhere.

Observed in production: a `@bot review this PR` request spawned the reviewer in the background. Mid-review the model called a tool by a wrong name, got a `Tool ... not found` result, and then **wedged** — the subagent's final transcript entry is the errored `toolResult`, with no terminal assistant message and no `<review>` block.

Because `createReviewerSubagent()` declared **no `timeoutMs`**, the spawn's `completion` promise never settled (pi's `session.prompt` takes no `AbortSignal`, so a half-open stream stays alive). Per `src/agent/tools/spawn-subagent.ts`, the `subagent.completed` broadcast only fires from `completion.then(...)` — so it **never fired**. The parent channel session was never woken via the completion bridge, and **no review was ever posted**. The PR just went silent after the "reviewing now" status comment.

## Fix

Declare a wall-clock ceiling on the reviewer spawn (`REVIEWER_SPAWN_TIMEOUT_MS = 600_000`, 10 min). When exceeded, `awaitWithSubagentTimeout` settles the spawn with a `SubagentTimeoutError`, which surfaces to the parent as a **FAILED** completion reminder (`renderSubagentCompletionReminder`) instead of hanging silently. This is the same liveness mechanism the `memory-retrieval` subagent already uses (`timeoutMs: 30_000`).

This is **liveness for the parent, not hard cancellation** — the underlying LLM stream may keep running until the OS reaps it; the ceiling's job is to release the parent (and the coalescing key) so the request fails loudly.

## Sizing

10 min is generous for a thorough `deep`-model review of a large diff plus a few web lookups, well above the typical sub-minute review, well below "wait forever".

## Scope

This is the **liveness** half of the fix. The naming-slip *trigger* (model called `web_search`/`web_fetch` instead of `websearch`/`webfetch`) is addressed separately by a "did you mean?" nudge on unknown tool calls — intentionally a different PR.

## Tests

- `declares a spawn timeout so a stalled review fails the parent loudly instead of hanging forever`
- `spawn timeout is generous enough for a deep-model review but not unbounded`

Both assert behavior (a bounded, positive ceiling) rather than the literal constant, so they survive a value change but fail if the timeout is removed — guarding the exact regression this PR fixes.

## Checks

`bun run typecheck`, `bun run lint`, `bun run format:check` all pass. Reviewer suite: 50 pass. (Full-suite has one pre-existing, unrelated failure — `resolveSelfPackageJsonPath` asserts the cwd ends in `typeclaw/`, which fails only because the build ran from a `/tmp` worktree; it passes in isolation and is untouched by this change.)
