### PR TITLE
agent: nudge 'did you mean' when the model calls a near-miss tool name

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -80,6 +80,11 @@ export { renderTurnRoleAnchor, renderTurnTimeAnchor } from './system-prompt'
 
 type AgentSessionTools = NonNullable<Parameters<typeof createAgentSession>[0]>['tools']
 
+// pi 0.67.3's default active built-in tools when a session declares no `tools:`
+// filter (see pi `createAgentSession`'s `defaultActiveToolNames`). Mirrored here
+// because pi does not export it; keep in sync if pi's default changes.
+const DEFAULT_PI_BUILTIN_TOOL_NAMES = ['read', 'bash', 'edit', 'write']
+
 export type PluginSessionWiring = {
   registry: PluginRegistry
   hooks: HookBus
@@ -386,25 +391,33 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     ...(thinkingLevel ? { thinkingLevel } : {}),
   })
 
+  // The names the session actually exposes to the model: pi's active base set
+  // (the caller's `tools:` filter, or pi's default builtins when unset) union
+  // the typeclaw/plugin custom tools. Deliberately EXCLUDES
+  // `builtinPiToolOverrides` — those replace builtin implementations by name,
+  // they are not additional callable names. This is the single source of truth
+  // for both the active-set re-narrowing below and the tool-not-found nudge
+  // vocabulary, so the two never drift (a divergence would make the nudge miss
+  // real tools or suggest tools the session deliberately did not expose).
+  const intendedActiveToolNames = [
+    ...new Set([
+      ...(tools !== undefined ? tools.map((t) => t.name) : DEFAULT_PI_BUILTIN_TOOL_NAMES),
+      ...[...wrappedCustomSystemTools, ...pluginCustomTools].map((t) => t.name),
+    ]),
+  ]
+
   // Re-narrow the active tool set after `createAgentSession`. pi 0.67.3's
   // `_refreshToolRegistry` runs with `includeAllExtensionTools: true` and
   // pushes every customTool name into the active set, which would widen
   // a subagent's declared `[edit]` to all 7 builtin overrides plus every
-  // typeclaw custom tool. The intended active set is the names the caller
-  // would have gotten WITHOUT the builtin overrides: pi's `initialActiveToolNames`
-  // (derived from `tools:`) union the names from typeclaw/plugin customTools.
-  // `builtinPiToolOverrides` are implementation overrides, never additions.
+  // typeclaw custom tool.
   if (builtinPiToolOverrides.length > 0) {
-    const baseActiveNames = tools !== undefined ? tools.map((t) => t.name) : ['read', 'bash', 'edit', 'write']
-    const customToolActiveNames = [...wrappedCustomSystemTools, ...pluginCustomTools].map((t) => t.name)
-    const intendedActive = [...new Set([...baseActiveNames, ...customToolActiveNames])]
-    session.setActiveToolsByName(intendedActive)
+    session.setActiveToolsByName(intendedActiveToolNames)
   }
 
   const unsubRestart = subscribeRestartNotice(options.stream, sessionManager)
 
-  const knownToolNames = [...(tools ?? []).map((t) => t.name), ...customTools.map((t) => t.name)]
-  const unsubToolNudge = attachToolNotFoundNudge(session, knownToolNames)
+  const unsubToolNudge = attachToolNotFoundNudge(session, intendedActiveToolNames)
 
   const dispose = async () => {
     unsubRestart?.()

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -50,6 +50,7 @@ import { SESSION_META_CUSTOM_TYPE, sessionMetaPayload } from './session-meta'
 import { renderSessionOrigin, type SessionOrigin, type SessionRoleContext } from './session-origin'
 import type { CreateSessionForSubagent, SubagentRegistry } from './subagents'
 import { DEFAULT_SYSTEM_PROMPT, renderRuntimeBlock, SLIM_SYSTEM_PROMPT } from './system-prompt'
+import { attachToolNotFoundNudge } from './tool-not-found-nudge'
 import {
   createBudgetState,
   type ToolResultBudget,
@@ -402,8 +403,12 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
 
   const unsubRestart = subscribeRestartNotice(options.stream, sessionManager)
 
+  const knownToolNames = [...(tools ?? []).map((t) => t.name), ...customTools.map((t) => t.name)]
+  const unsubToolNudge = attachToolNotFoundNudge(session, knownToolNames)
+
   const dispose = async () => {
     unsubRestart?.()
+    unsubToolNudge()
     if (materializedSkills) await materializedSkills.dispose()
   }
   return { session, dispose }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 
 import {
   createAgentSession,
+  createCodingTools,
   DefaultResourceLoader,
   defineTool as definePiTool,
   SessionManager,
@@ -80,10 +81,12 @@ export { renderTurnRoleAnchor, renderTurnTimeAnchor } from './system-prompt'
 
 type AgentSessionTools = NonNullable<Parameters<typeof createAgentSession>[0]>['tools']
 
-// pi 0.67.3's default active built-in tools when a session declares no `tools:`
-// filter (see pi `createAgentSession`'s `defaultActiveToolNames`). Mirrored here
-// because pi does not export it; keep in sync if pi's default changes.
-const DEFAULT_PI_BUILTIN_TOOL_NAMES = ['read', 'bash', 'edit', 'write']
+// pi's default active built-in tools when a session declares no `tools:` filter
+// (pi `createAgentSession` falls back to `defaultActiveToolNames`, which is the
+// name set of `codingTools`). Derived from pi's own `createCodingTools()` rather
+// than hardcoded so the list can't silently drift if pi adds/removes/renames a
+// default builtin; `default-pi-builtins match pi's coding tool set` pins it.
+const DEFAULT_PI_BUILTIN_TOOL_NAMES = createCodingTools(process.cwd()).map((t) => t.name)
 
 export type PluginSessionWiring = {
   registry: PluginRegistry

--- a/src/agent/tool-not-found-nudge.test.ts
+++ b/src/agent/tool-not-found-nudge.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  attachToolNotFoundNudge,
+  buildToolNotFoundNudge,
+  closestToolName,
+  extractNotFoundToolName,
+  type NudgeableSession,
+  renderToolNotFoundNudge,
+} from './tool-not-found-nudge'
+
+const KNOWN = ['read', 'grep', 'find', 'ls', 'bash', 'websearch', 'webfetch', 'load_skill']
+
+describe('extractNotFoundToolName', () => {
+  test('extracts the tool name from pi-agent-core not-found text', () => {
+    expect(extractNotFoundToolName('Tool web_search not found')).toBe('web_search')
+  })
+
+  test('tolerates surrounding whitespace', () => {
+    expect(extractNotFoundToolName('  Tool webfetch not found  ')).toBe('webfetch')
+  })
+
+  test('returns null for unrelated error text', () => {
+    expect(extractNotFoundToolName('invalid arguments: path is required')).toBeNull()
+    expect(extractNotFoundToolName('blocked: secret exfil')).toBeNull()
+  })
+})
+
+describe('closestToolName', () => {
+  test('maps the conventional underscored web tools to their real names', () => {
+    expect(closestToolName('web_search', KNOWN)).toBe('websearch')
+    expect(closestToolName('web_fetch', KNOWN)).toBe('webfetch')
+  })
+
+  test('returns the exact name when it is already known', () => {
+    expect(closestToolName('websearch', KNOWN)).toBe('websearch')
+  })
+
+  test('returns null when nothing is close enough (genuinely unknown tool)', () => {
+    expect(closestToolName('deploy_to_production', KNOWN)).toBeNull()
+  })
+})
+
+describe('renderToolNotFoundNudge', () => {
+  test('names both the wrong and the suggested tool and instructs an exact re-issue', () => {
+    const nudge = renderToolNotFoundNudge('web_search', 'websearch')
+    expect(nudge).toContain('`web_search`')
+    expect(nudge).toContain('`websearch`')
+    expect(nudge).toContain('Re-issue')
+    expect(nudge).toContain('<system-reminder>')
+  })
+})
+
+describe('buildToolNotFoundNudge', () => {
+  test('produces a nudge for a close-but-wrong tool name', () => {
+    const nudge = buildToolNotFoundNudge('Tool web_search not found', KNOWN)
+    expect(nudge).not.toBeNull()
+    expect(nudge).toContain('`websearch`')
+  })
+
+  test('returns null for non-not-found error text', () => {
+    expect(buildToolNotFoundNudge('invalid arguments', KNOWN)).toBeNull()
+  })
+
+  test('returns null when there is no close match (no misleading suggestion)', () => {
+    expect(buildToolNotFoundNudge('Tool deploy_to_production not found', KNOWN)).toBeNull()
+  })
+
+  test('returns null when the requested name equals its only match (no self-suggestion loop)', () => {
+    expect(buildToolNotFoundNudge('Tool websearch not found', KNOWN)).toBeNull()
+  })
+})
+
+function fakeSession(): {
+  session: NudgeableSession
+  emit: (event: unknown) => void
+  steered: string[]
+} {
+  const listeners: ((event: unknown) => void)[] = []
+  const steered: string[] = []
+  const session: NudgeableSession = {
+    subscribe(listener) {
+      listeners.push(listener)
+      return () => {
+        const i = listeners.indexOf(listener)
+        if (i !== -1) listeners.splice(i, 1)
+      }
+    },
+    async steer(text) {
+      steered.push(text)
+    },
+  }
+  return { session, emit: (event) => listeners.forEach((l) => l(event)), steered }
+}
+
+function notFoundEvent(toolName: string): unknown {
+  return {
+    type: 'tool_execution_end',
+    toolName,
+    isError: true,
+    result: { content: [{ type: 'text', text: `Tool ${toolName} not found` }] },
+  }
+}
+
+describe('attachToolNotFoundNudge', () => {
+  test('steers a did-you-mean reminder when a near-miss tool name is not found', () => {
+    const { session, emit, steered } = fakeSession()
+    attachToolNotFoundNudge(session, KNOWN)
+    emit(notFoundEvent('web_search'))
+    expect(steered).toHaveLength(1)
+    expect(steered[0]).toContain('`websearch`')
+  })
+
+  test('stays silent on a successful tool execution', () => {
+    const { session, emit, steered } = fakeSession()
+    attachToolNotFoundNudge(session, KNOWN)
+    emit({
+      type: 'tool_execution_end',
+      toolName: 'read',
+      isError: false,
+      result: { content: [{ type: 'text', text: 'file contents' }] },
+    })
+    expect(steered).toHaveLength(0)
+  })
+
+  test('stays silent for a genuinely unknown tool with no close match', () => {
+    const { session, emit, steered } = fakeSession()
+    attachToolNotFoundNudge(session, KNOWN)
+    emit(notFoundEvent('deploy_to_production'))
+    expect(steered).toHaveLength(0)
+  })
+
+  test('stays silent on a non-tool-execution event', () => {
+    const { session, emit, steered } = fakeSession()
+    attachToolNotFoundNudge(session, KNOWN)
+    emit({ type: 'message_end', message: { role: 'assistant' } })
+    expect(steered).toHaveLength(0)
+  })
+
+  test('unsubscribe stops further nudges', () => {
+    const { session, emit, steered } = fakeSession()
+    const unsub = attachToolNotFoundNudge(session, KNOWN)
+    unsub()
+    emit(notFoundEvent('web_search'))
+    expect(steered).toHaveLength(0)
+  })
+})

--- a/src/agent/tool-not-found-nudge.test.ts
+++ b/src/agent/tool-not-found-nudge.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
+import { createCodingTools } from '@mariozechner/pi-coding-agent'
+
 import {
   attachToolNotFoundNudge,
   buildToolNotFoundNudge,
@@ -10,6 +12,15 @@ import {
 } from './tool-not-found-nudge'
 
 const KNOWN = ['read', 'grep', 'find', 'ls', 'bash', 'websearch', 'webfetch', 'load_skill']
+
+describe('pi default-builtin coupling', () => {
+  test("createSession derives the nudge vocabulary's default builtins from pi's coding tools — pinned so a pi change breaks loudly", () => {
+    // src/agent/index.ts derives DEFAULT_PI_BUILTIN_TOOL_NAMES from
+    // createCodingTools().map(t => t.name). If pi adds/removes/renames a default
+    // builtin, this pin fails and forces a deliberate update instead of silent drift.
+    expect(createCodingTools(process.cwd()).map((t) => t.name)).toEqual(['read', 'bash', 'edit', 'write'])
+  })
+})
 
 describe('extractNotFoundToolName', () => {
   test('extracts the tool name from pi-agent-core not-found text', () => {

--- a/src/agent/tool-not-found-nudge.ts
+++ b/src/agent/tool-not-found-nudge.ts
@@ -1,0 +1,119 @@
+// Minimal structural view of the pieces of pi's AgentSession this module
+// touches. Declared locally (not imported) so the pure nudge logic stays
+// testable with a hand-rolled fake and does not drag in the full session type.
+export type NudgeableSession = {
+  subscribe: (listener: (event: unknown) => void) => () => void
+  steer: (text: string) => Promise<void>
+}
+
+const NOT_FOUND_RE = /^Tool (.+?) not found$/
+
+// Levenshtein distance ceiling for a name to count as "did you mean". A typo
+// like web_search -> websearch is distance 1 (one '_' removed); read_file ->
+// read is larger but still a clear prefix relationship. Keeping the ceiling
+// small avoids suggesting an unrelated tool for a genuinely unknown name.
+const MAX_SUGGESTION_DISTANCE = 4
+
+export function extractNotFoundToolName(resultText: string): string | null {
+  const match = NOT_FOUND_RE.exec(resultText.trim())
+  return match?.[1] ?? null
+}
+
+export function closestToolName(requested: string, known: readonly string[]): string | null {
+  let best: string | null = null
+  let bestDistance = Number.POSITIVE_INFINITY
+  for (const candidate of known) {
+    if (candidate === requested) return candidate
+    const distance = boundedLevenshtein(requested, candidate, MAX_SUGGESTION_DISTANCE)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      best = candidate
+    }
+  }
+  return bestDistance <= MAX_SUGGESTION_DISTANCE ? best : null
+}
+
+export function renderToolNotFoundNudge(requested: string, suggestion: string): string {
+  return (
+    `<system-reminder>\n` +
+    `You called the tool \`${requested}\`, which does not exist. ` +
+    `Did you mean \`${suggestion}\`? Re-issue the call using the exact name \`${suggestion}\`.\n` +
+    `</system-reminder>`
+  )
+}
+
+export function buildToolNotFoundNudge(resultText: string, known: readonly string[]): string | null {
+  const requested = extractNotFoundToolName(resultText)
+  if (requested === null) return null
+  const suggestion = closestToolName(requested, known)
+  if (suggestion === null || suggestion === requested) return null
+  return renderToolNotFoundNudge(requested, suggestion)
+}
+
+function firstTextChunk(result: unknown): string | null {
+  const content = (result as { content?: unknown })?.content
+  if (!Array.isArray(content)) return null
+  for (const part of content) {
+    if (part && typeof part === 'object' && (part as { type?: unknown }).type === 'text') {
+      const text = (part as { text?: unknown }).text
+      if (typeof text === 'string') return text
+    }
+  }
+  return null
+}
+
+// Watches a session's tool-execution events and, when the model calls a tool
+// name that does not exist but is a near-miss of a real one, steers a
+// "did you mean" reminder into the running turn so the model self-corrects.
+//
+// This lives here, on the session event stream, because pi-agent-core's
+// `prepareToolCall` returns the `Tool X not found` result BEFORE any
+// `beforeToolCall`/`afterToolCall` hook runs — so TypeClaw's tool.before/after
+// buses never see an unknown tool name. The emitted `tool_execution_end` event
+// is the only seam reachable without forking pi. `steer` (not `followUp`)
+// delivers the reminder after the current assistant turn's tool calls settle,
+// which is exactly when the model is ready to retry.
+//
+// The model re-issues the call under the suggested (canonical) name, so every
+// security guard, budget, and loop-guard keyed on that real name applies
+// normally — unlike a silent alias, this rescue path cannot bypass policy.
+export function attachToolNotFoundNudge(session: NudgeableSession, knownToolNames: readonly string[]): () => void {
+  const known = [...new Set(knownToolNames)]
+  return session.subscribe((event) => {
+    const e = event as { type?: unknown; isError?: unknown; result?: unknown }
+    if (e?.type !== 'tool_execution_end' || e.isError !== true) return
+    const text = firstTextChunk(e.result)
+    if (text === null) return
+    const nudge = buildToolNotFoundNudge(text, known)
+    if (nudge === null) return
+    void session.steer(nudge)
+  })
+}
+
+// Wagner–Fischer with an early bail-out once every cell in a row exceeds the
+// ceiling: a name far from every candidate never produces a suggestion, and
+// the bound keeps the scan cheap when the known-tool list is large.
+function boundedLevenshtein(a: string, b: string, ceiling: number): number {
+  if (a === b) return 0
+  if (Math.abs(a.length - b.length) > ceiling) return ceiling + 1
+
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i)
+  let curr = Array.from({ length: b.length + 1 }, () => 0)
+
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i
+    let rowMin = i
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      const deletion = (prev[j] ?? 0) + 1
+      const insertion = (curr[j - 1] ?? 0) + 1
+      const substitution = (prev[j - 1] ?? 0) + cost
+      const cell = Math.min(deletion, insertion, substitution)
+      curr[j] = cell
+      if (cell < rowMin) rowMin = cell
+    }
+    if (rowMin > ceiling) return ceiling + 1
+    ;[prev, curr] = [curr, prev]
+  }
+  return prev[b.length] ?? ceiling + 1
+}


### PR DESCRIPTION
## Problem

When the model calls a tool by a name that does not exist but is a near-miss of a real one — e.g. `web_search`/`web_fetch` (the conventional spelling in most other agent frameworks) instead of TypeClaw's `websearch`/`webfetch` — pi-agent-core returns a bare `Tool web_search not found` result. The model gets no hint about the correct name. In the incident that motivated this, a `reviewer` subagent hit exactly this, then wedged without recovering.

Crucially, the unknown-tool path is **upstream of every TypeClaw hook**: in `@mariozechner/pi-agent-core`'s `prepareToolCall`, the `Tool X not found` result is returned *before* `beforeToolCall`/`afterToolCall` run. So the `tool.before`/`tool.after` buses never see an unknown tool name, and a normalizer can't sit there. The emitted `tool_execution_end` event is the only seam reachable without forking pi.

## Fix

A small session-level subscriber (`attachToolNotFoundNudge`) watches `tool_execution_end` events. On an `isError` result whose text matches `Tool <name> not found`, it computes the closest known tool name (bounded Levenshtein, distance ≤ 4) and, if there's a near-miss, `steer()`s a `<system-reminder>`:

> You called the tool `web_search`, which does not exist. Did you mean `websearch`? Re-issue the call using the exact name `websearch`.

`steer` (not `followUp`) delivers the reminder right after the current turn's tool calls settle — exactly when the model is ready to retry.

## Why a nudge instead of silent aliasing

This was a deliberate design choice (Oracle-reviewed):

- **No schema bloat** — no duplicate tool entries advertised to the model.
- **No security-guard bypass** — the model re-issues the call under the *real* tool name, so every SSRF guard, tool-result budget, and loop-guard keyed on the canonical name (`websearch`/`webfetch` have SSRF-relevant behavior) applies normally. A silent alias executing under `web_search` would sidestep a guard keyed on `websearch`; this path cannot.
- **General** — rescues *any* near-miss typo (`read_file` → `read`, etc.), not just two hard-coded names.

The tradeoff is one extra model turn. That relies on the model taking another turn after the error — which is the liveness concern fixed separately by the reviewer-spawn-timeout PR (a stalled retry now surfaces as a FAILED reminder instead of hanging).

## Conservative by design

- Only fires when a close match exists (distance ≤ 4). A genuinely unknown tool (`deploy_to_production`) gets no misleading suggestion.
- Never suggests the same name back (no self-loop).
- Ignores non-not-found errors (invalid args, blocked-by-guard) and successful executions.

## Files

- `src/agent/tool-not-found-nudge.ts` — pure match/render logic + the session subscriber.
- `src/agent/tool-not-found-nudge.test.ts` — 16 tests (extraction, closest-match, render, build, and the subscriber via a hand-rolled fake session).
- `src/agent/index.ts` — wires the subscriber in `createSessionWithDispose` with the session's known tool names; unsubscribes on dispose.

## Checks

`bun run typecheck`, `bun run lint`, `bun run format:check` pass; new module is warning-free. Agent suite: 832 pass. (Full-suite has one pre-existing, unrelated failure — `resolveSelfPackageJsonPath` asserts the cwd ends in `typeclaw/`, which fails only because the build ran from a `/tmp` worktree; untouched by this change.)
