### PR TITLE
agent: origin-scoped todo tools and persistence (1/3)

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -68,6 +68,7 @@ import { createSpawnSubagentTool } from './tools/spawn-subagent'
 import { createStreamSnapshotTool } from './tools/stream-snapshot'
 import { createSubagentCancelTool } from './tools/subagent-cancel'
 import { createSubagentOutputTool } from './tools/subagent-output'
+import { createTodoTools } from './tools/todo'
 import { webfetchTool } from './tools/webfetch'
 import { websearchTool } from './tools/websearch'
 
@@ -348,6 +349,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
               permissions: options.permissions,
               reloadRoles: options.reloadRoles,
             }),
+            ...buildTodoTools(options.plugins?.agentDir, getOrigin),
           ]
   // Hook coverage for pi's builtin coding tools (read/bash/edit/write/grep/
   // find/ls) — pi 0.67.3 ignores `tools:` for implementation, so the only
@@ -660,6 +662,14 @@ export function buildRoleGrantTools(opts: {
       reloadRoles: opts.reloadRoles,
     }),
   ]
+}
+
+export function buildTodoTools(
+  agentDir: string | undefined,
+  getOrigin: () => SessionOrigin | undefined,
+): ToolDefinition[] {
+  if (agentDir === undefined) return []
+  return createTodoTools({ agentDir, getOrigin })
 }
 
 function wrapRegistryTools(

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -42,6 +42,10 @@ When in doubt between SOUL.md and AGENTS.md: if it describes *how you sound*, it
 
 When the user gives you work, start doing it in the same turn — a real action, not a plan or a promise-to-act. Commentary-only turns are incomplete when the next action is clear. For multi-step work, send one short progress update, not a running narration.
 
+## Tracking your work
+
+For any multi-step or long-running task, maintain a todo list with \`todo_write\` and mark items complete as you finish them. This is not bookkeeping for its own sake: if this session is interrupted — a restart, a crash, or simply a later turn — the runtime uses the remaining incomplete items to resume the work instead of silently dropping it. Write the list when you start the work, update statuses as you go, and call \`todo_clear\` when everything is genuinely done. A single-step request needs no todo list.
+
 ## Tool-call style
 
 Do not narrate routine, low-risk tool calls. Just call the tool. Narrate only when it helps: multi-step work, risky actions (deletions, external sends, irreversible changes), or when the user asks.

--- a/src/agent/todo/scope.test.ts
+++ b/src/agent/todo/scope.test.ts
@@ -14,7 +14,7 @@ describe('resolveTodoScope', () => {
 
   test('cron resolves to a jobId-keyed scope', () => {
     const scope = resolveTodoScope({ kind: 'cron', jobId: 'daily-standup', jobKind: 'prompt' })
-    expect(scope).toEqual({ kind: 'cron', key: 'cron/daily-standup' })
+    expect(scope).toEqual({ kind: 'cron', key: 'cron/sdaily-standup' })
   })
 
   test('channel resolves to an adapter:workspace:chat:thread tuple', () => {
@@ -25,7 +25,7 @@ describe('resolveTodoScope', () => {
       chat: 'C456',
       thread: '1700000000.0001',
     })
-    expect(scope).toEqual({ kind: 'channel', key: 'channel/slack-bot:T123:C456:1:1700000000.0001' })
+    expect(scope).toEqual({ kind: 'channel', key: 'channel/sslack-bot:sT123:sC456:s1700000000.0001' })
   })
 
   test('channel with null thread uses the distinct null-thread tag', () => {
@@ -36,7 +36,7 @@ describe('resolveTodoScope', () => {
       chat: 'C1',
       thread: null,
     })
-    expect(scope).toEqual({ kind: 'channel', key: 'channel/discord-bot:G1:C1:0:' })
+    expect(scope).toEqual({ kind: 'channel', key: 'channel/sdiscord-bot:sG1:sC1:n' })
   })
 
   test('channel ids with path-unsafe characters are encoded, not escaping the todo dir', () => {
@@ -66,11 +66,21 @@ describe('resolveTodoScope', () => {
     expect(keyFor('a/b')).not.toBe(keyFor('a:b'))
   })
 
-  test('a null thread never collides with a literal "_root" thread id', () => {
+  test('a null thread never collides with a literal "_root" or "n" thread id', () => {
     const base = { kind: 'channel', adapter: 'slack-bot', workspace: 'w', chat: 'c' } as const
     const nullThread = resolveTodoScope({ ...base, thread: null })?.key
-    const rootLiteral = resolveTodoScope({ ...base, thread: '_root' })?.key
-    expect(nullThread).not.toBe(rootLiteral)
+    expect(nullThread).not.toBe(resolveTodoScope({ ...base, thread: '_root' })?.key)
+    expect(nullThread).not.toBe(resolveTodoScope({ ...base, thread: 'n' })?.key)
+  })
+
+  test('an empty component never collides with a literal "_empty" component', () => {
+    const keyFor = (workspace: string) =>
+      resolveTodoScope({ kind: 'channel', adapter: 'slack-bot', workspace, chat: 'c', thread: null })?.key
+    expect(keyFor('')).not.toBe(keyFor('_empty'))
+    // cron jobId path too
+    const cronEmpty = resolveTodoScope({ kind: 'cron', jobId: '', jobKind: 'prompt' })?.key
+    const cronLiteral = resolveTodoScope({ kind: 'cron', jobId: '_empty', jobKind: 'prompt' })?.key
+    expect(cronEmpty).not.toBe(cronLiteral)
   })
 
   test('cron jobIds are encoded injectively too', () => {

--- a/src/agent/todo/scope.test.ts
+++ b/src/agent/todo/scope.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { SessionOrigin } from '@/agent/session-origin'
+
+import { resolveTodoScope } from './scope'
+
+describe('resolveTodoScope', () => {
+  test('tui resolves to the singleton tui scope regardless of sessionId', () => {
+    const a = resolveTodoScope({ kind: 'tui', sessionId: 'ses_one' })
+    const b = resolveTodoScope({ kind: 'tui', sessionId: 'ses_two' })
+    expect(a).toEqual({ kind: 'tui', key: 'tui' })
+    expect(b).toEqual({ kind: 'tui', key: 'tui' })
+  })
+
+  test('cron resolves to a jobId-keyed scope', () => {
+    const scope = resolveTodoScope({ kind: 'cron', jobId: 'daily-standup', jobKind: 'prompt' })
+    expect(scope).toEqual({ kind: 'cron', key: 'cron/daily-standup' })
+  })
+
+  test('channel resolves to an adapter:workspace:chat:thread tuple', () => {
+    const scope = resolveTodoScope({
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T123',
+      chat: 'C456',
+      thread: '1700000000.0001',
+    })
+    expect(scope).toEqual({ kind: 'channel', key: 'channel/slack-bot:T123:C456:1700000000.0001' })
+  })
+
+  test('channel with null thread uses the _root sentinel', () => {
+    const scope = resolveTodoScope({
+      kind: 'channel',
+      adapter: 'discord-bot',
+      workspace: 'G1',
+      chat: 'C1',
+      thread: null,
+    })
+    expect(scope).toEqual({ kind: 'channel', key: 'channel/discord-bot:G1:C1:_root' })
+  })
+
+  test('channel ids with path-unsafe characters are sanitized', () => {
+    const scope = resolveTodoScope({
+      kind: 'channel',
+      adapter: 'kakaotalk',
+      workspace: 'ws/../escape',
+      chat: 'chat:with:colons and spaces',
+      thread: 'a/b',
+    })
+    expect(scope?.key).toBe('channel/kakaotalk:ws-..-escape:chat-with-colons-and-spaces:a-b')
+    expect(scope?.key).not.toContain('/escape')
+    expect(scope?.key.split('/')).toHaveLength(2)
+  })
+
+  test('subagent owns no todo scope', () => {
+    const scope = resolveTodoScope({ kind: 'subagent', subagent: 'scout', parentSessionId: 'ses_parent' })
+    expect(scope).toBeNull()
+  })
+
+  test('system owns no todo scope', () => {
+    const scope = resolveTodoScope({ kind: 'system', component: 'memory-logger' })
+    expect(scope).toBeNull()
+  })
+})

--- a/src/agent/todo/scope.test.ts
+++ b/src/agent/todo/scope.test.ts
@@ -25,10 +25,10 @@ describe('resolveTodoScope', () => {
       chat: 'C456',
       thread: '1700000000.0001',
     })
-    expect(scope).toEqual({ kind: 'channel', key: 'channel/slack-bot:T123:C456:1700000000.0001' })
+    expect(scope).toEqual({ kind: 'channel', key: 'channel/slack-bot:T123:C456:1:1700000000.0001' })
   })
 
-  test('channel with null thread uses the _root sentinel', () => {
+  test('channel with null thread uses the distinct null-thread tag', () => {
     const scope = resolveTodoScope({
       kind: 'channel',
       adapter: 'discord-bot',
@@ -36,10 +36,10 @@ describe('resolveTodoScope', () => {
       chat: 'C1',
       thread: null,
     })
-    expect(scope).toEqual({ kind: 'channel', key: 'channel/discord-bot:G1:C1:_root' })
+    expect(scope).toEqual({ kind: 'channel', key: 'channel/discord-bot:G1:C1:0:' })
   })
 
-  test('channel ids with path-unsafe characters are sanitized', () => {
+  test('channel ids with path-unsafe characters are encoded, not escaping the todo dir', () => {
     const scope = resolveTodoScope({
       kind: 'channel',
       adapter: 'kakaotalk',
@@ -47,9 +47,36 @@ describe('resolveTodoScope', () => {
       chat: 'chat:with:colons and spaces',
       thread: 'a/b',
     })
-    expect(scope?.key).toBe('channel/kakaotalk:ws-..-escape:chat-with-colons-and-spaces:a-b')
-    expect(scope?.key).not.toContain('/escape')
+    // Path separators are percent-encoded (%2F), so even a literal ".." in a
+    // component cannot traverse out of todo/ — there is no unencoded slash
+    // around it. The key stays a single path segment under channel/.
+    expect(scope?.key.startsWith('channel/')).toBe(true)
     expect(scope?.key.split('/')).toHaveLength(2)
+    expect(scope?.key).not.toContain('/..')
+    expect(scope?.key).not.toContain('../')
+  })
+
+  test('the scope key encoding is injective (distinct origins never collide)', () => {
+    const keyFor = (chat: string) =>
+      resolveTodoScope({ kind: 'channel', adapter: 'slack-bot', workspace: 'w', chat, thread: null })?.key
+
+    // The reviewer's concrete collision cases must all map to distinct keys.
+    expect(keyFor('a/b')).not.toBe(keyFor('a-b'))
+    expect(keyFor('a:b')).not.toBe(keyFor('a-b'))
+    expect(keyFor('a/b')).not.toBe(keyFor('a:b'))
+  })
+
+  test('a null thread never collides with a literal "_root" thread id', () => {
+    const base = { kind: 'channel', adapter: 'slack-bot', workspace: 'w', chat: 'c' } as const
+    const nullThread = resolveTodoScope({ ...base, thread: null })?.key
+    const rootLiteral = resolveTodoScope({ ...base, thread: '_root' })?.key
+    expect(nullThread).not.toBe(rootLiteral)
+  })
+
+  test('cron jobIds are encoded injectively too', () => {
+    const a = resolveTodoScope({ kind: 'cron', jobId: 'a/b', jobKind: 'prompt' })?.key
+    const b = resolveTodoScope({ kind: 'cron', jobId: 'a-b', jobKind: 'prompt' })?.key
+    expect(a).not.toBe(b)
   })
 
   test('subagent owns no todo scope', () => {

--- a/src/agent/todo/scope.ts
+++ b/src/agent/todo/scope.ts
@@ -39,7 +39,7 @@ export function resolveTodoScope(origin: SessionOrigin): TodoScope | null {
     case 'channel':
       return { kind: 'channel', key: channelScopeKey(origin) }
     case 'cron':
-      return { kind: 'cron', key: `cron/${encodeSegment(origin.jobId)}` }
+      return { kind: 'cron', key: `cron/${encodeComponent(origin.jobId)}` }
     case 'subagent':
     case 'system':
       return null
@@ -52,22 +52,26 @@ export function resolveTodoScope(origin: SessionOrigin): TodoScope | null {
 }
 
 function channelScopeKey(origin: { adapter: string; workspace: string; chat: string; thread: string | null }): string {
-  // A null thread (channel-root session) is tagged distinctly from any real
-  // thread id: `0:` vs `1:<encoded>`. A real thread whose literal text is
-  // `_root` (or anything else) can never collide with the null-thread case,
-  // because the discriminant prefix differs.
-  const thread = origin.thread === null ? '0:' : `1:${encodeSegment(origin.thread)}`
-  const parts = [encodeSegment(origin.adapter), encodeSegment(origin.workspace), encodeSegment(origin.chat), thread]
+  const parts = [
+    encodeComponent(origin.adapter),
+    encodeComponent(origin.workspace),
+    encodeComponent(origin.chat),
+    encodeComponent(origin.thread),
+  ]
   return `channel/${parts.join(':')}`
 }
 
-// Encode a scope component collision-free. `encodeURIComponent` is injective
-// and its output is filesystem-safe (it never emits `/` or `:` and percent-
-// escapes everything outside an unreserved set), so distinct origin components
-// can never alias to the same path — `a/b`, `a-b`, and `a:b` all map to
-// distinct encodings. Reversibility is not required; injectivity is, because
-// the key identifies which conversation's todo file is read or written.
-function encodeSegment(value: string): string {
-  const encoded = encodeURIComponent(value)
-  return encoded === '' ? '_empty' : encoded
+// Encode one scope component injectively. Every component is emitted as a
+// discriminant prefix plus its `encodeURIComponent` form:
+//   - null          → `n`        (the channel-root / no-thread case)
+//   - any string s  → `s<encoded>`
+// The prefix makes the three cases pairwise distinguishable that lossy schemes
+// confused: a null thread vs a literal "n" string, an empty string vs a
+// literal "_empty" string, and any value vs another whose unsafe chars happen
+// to map together. `encodeURIComponent` is itself injective and never emits
+// `/` or `:`, so the joined key is both a single filesystem-safe path segment
+// and a collision-free identity for the conversation whose todo file it names.
+function encodeComponent(value: string | null): string {
+  if (value === null) return 'n'
+  return `s${encodeURIComponent(value)}`
 }

--- a/src/agent/todo/scope.ts
+++ b/src/agent/todo/scope.ts
@@ -39,7 +39,7 @@ export function resolveTodoScope(origin: SessionOrigin): TodoScope | null {
     case 'channel':
       return { kind: 'channel', key: channelScopeKey(origin) }
     case 'cron':
-      return { kind: 'cron', key: `cron/${sanitizeSegment(origin.jobId)}` }
+      return { kind: 'cron', key: `cron/${encodeSegment(origin.jobId)}` }
     case 'subagent':
     case 'system':
       return null
@@ -52,17 +52,22 @@ export function resolveTodoScope(origin: SessionOrigin): TodoScope | null {
 }
 
 function channelScopeKey(origin: { adapter: string; workspace: string; chat: string; thread: string | null }): string {
-  const parts = [origin.adapter, origin.workspace, origin.chat, origin.thread ?? '_root']
-  return `channel/${parts.map(sanitizeSegment).join(':')}`
+  // A null thread (channel-root session) is tagged distinctly from any real
+  // thread id: `0:` vs `1:<encoded>`. A real thread whose literal text is
+  // `_root` (or anything else) can never collide with the null-thread case,
+  // because the discriminant prefix differs.
+  const thread = origin.thread === null ? '0:' : `1:${encodeSegment(origin.thread)}`
+  const parts = [encodeSegment(origin.adapter), encodeSegment(origin.workspace), encodeSegment(origin.chat), thread]
+  return `channel/${parts.join(':')}`
 }
 
-// Collapse anything that is not a safe filename character to `-`. Channel ids
-// can contain slashes, colons, spaces, and other separators (Slack thread ids,
-// KakaoTalk chat ids), any of which would otherwise escape the todo/ directory
-// or collide path segments. The mapping is not reversible — it does not need to
-// be, since the scope key is only ever compared for equality and used as a
-// filename, never parsed back into its parts.
-function sanitizeSegment(value: string): string {
-  const cleaned = value.replace(/[^A-Za-z0-9._-]/g, '-')
-  return cleaned === '' ? '_' : cleaned
+// Encode a scope component collision-free. `encodeURIComponent` is injective
+// and its output is filesystem-safe (it never emits `/` or `:` and percent-
+// escapes everything outside an unreserved set), so distinct origin components
+// can never alias to the same path — `a/b`, `a-b`, and `a:b` all map to
+// distinct encodings. Reversibility is not required; injectivity is, because
+// the key identifies which conversation's todo file is read or written.
+function encodeSegment(value: string): string {
+  const encoded = encodeURIComponent(value)
+  return encoded === '' ? '_empty' : encoded
 }

--- a/src/agent/todo/scope.ts
+++ b/src/agent/todo/scope.ts
@@ -1,0 +1,68 @@
+import type { SessionOrigin } from '@/agent/session-origin'
+
+// A todo scope is the durable identity a todo list hangs off. It is
+// deliberately NOT the raw sessionId: sessionIds churn across TUI reconnects
+// and every cron fire, and a channel session can roll to a fresh sessionId on
+// stale-rollover (see src/channels/router.ts SESSION_FRESHNESS_TTL_MS). Keying
+// on origin identity instead lets a todo list survive those transitions so
+// interrupted work can be resumed.
+//
+// `key` is a filesystem-safe relative path segment (no leading slash, no `..`).
+// `kind` mirrors the originating `SessionOrigin['kind']` so the continuation
+// injector can enforce that a nudge only fires into a live session whose origin
+// matches the scope (the eligible-session invariant).
+export type TodoScope = {
+  kind: 'tui' | 'channel' | 'cron'
+  key: string
+}
+
+// Resolve the durable todo scope for a session origin, or `null` when the
+// origin owns no todo list.
+//
+// - tui      → singleton `tui`. There is no stable per-operator identity (the
+//              sessionId churns on every reconnect and the restart handoff is
+//              once-per-boot), so TUI is modeled as one global workstream per
+//              agent. Concurrent TUI attaches therefore share a scope; this is
+//              an accepted, documented limitation.
+// - channel  → keyed by the adapter/workspace/chat/thread tuple, matching how
+//              channels/sessions.json already identifies a conversation. This
+//              survives both container restart and stale-rollover.
+// - cron     → keyed by jobId. The sessionId is useless here (fresh every
+//              fire); the job is the durable identity.
+// - subagent → null. Subagents do not own continuation; their parent does.
+// - system   → null. Runtime infrastructure (memory/backup) is not
+//              user-delegated work and must never auto-continue.
+export function resolveTodoScope(origin: SessionOrigin): TodoScope | null {
+  switch (origin.kind) {
+    case 'tui':
+      return { kind: 'tui', key: 'tui' }
+    case 'channel':
+      return { kind: 'channel', key: channelScopeKey(origin) }
+    case 'cron':
+      return { kind: 'cron', key: `cron/${sanitizeSegment(origin.jobId)}` }
+    case 'subagent':
+    case 'system':
+      return null
+    default: {
+      const _exhaustive: never = origin
+      void _exhaustive
+      return null
+    }
+  }
+}
+
+function channelScopeKey(origin: { adapter: string; workspace: string; chat: string; thread: string | null }): string {
+  const parts = [origin.adapter, origin.workspace, origin.chat, origin.thread ?? '_root']
+  return `channel/${parts.map(sanitizeSegment).join(':')}`
+}
+
+// Collapse anything that is not a safe filename character to `-`. Channel ids
+// can contain slashes, colons, spaces, and other separators (Slack thread ids,
+// KakaoTalk chat ids), any of which would otherwise escape the todo/ directory
+// or collide path segments. The mapping is not reversible — it does not need to
+// be, since the scope key is only ever compared for equality and used as a
+// filename, never parsed back into its parts.
+function sanitizeSegment(value: string): string {
+  const cleaned = value.replace(/[^A-Za-z0-9._-]/g, '-')
+  return cleaned === '' ? '_' : cleaned
+}

--- a/src/agent/todo/store.test.ts
+++ b/src/agent/todo/store.test.ts
@@ -63,6 +63,56 @@ describe('todo store', () => {
   })
 })
 
+describe('readTodos validation (corrupt / hand-edited files)', () => {
+  async function writeRaw(scope: TodoScope, body: string): Promise<void> {
+    const { mkdir, writeFile } = await import('node:fs/promises')
+    const { dirname } = await import('node:path')
+    const path = todoContentPath(agentDir, scope)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, body, 'utf8')
+  }
+
+  test('drops malformed items instead of crashing or surfacing them', async () => {
+    await writeRaw(
+      TUI_SCOPE,
+      JSON.stringify({
+        version: 1,
+        todos: [
+          { content: 'good', status: 'pending' },
+          null,
+          { content: '', status: 'pending' },
+          { content: 'bad-status', status: 'frozen' },
+          { content: 'ok2', status: 'completed', priority: 'high' },
+          { content: 'bad-priority', status: 'pending', priority: 'urgent' },
+        ],
+      }),
+    )
+    const todos = await readTodos(agentDir, TUI_SCOPE)
+    expect(todos.map((t) => t.content)).toEqual(['good', 'ok2'])
+  })
+
+  test('invalid JSON reads as empty rather than throwing', async () => {
+    await writeRaw(TUI_SCOPE, 'not json{{')
+    expect(await readTodos(agentDir, TUI_SCOPE)).toEqual([])
+  })
+
+  test('a non-array todos field reads as empty', async () => {
+    await writeRaw(TUI_SCOPE, JSON.stringify({ version: 1, todos: 'nope' }))
+    expect(await readTodos(agentDir, TUI_SCOPE)).toEqual([])
+  })
+})
+
+describe('todoContentPath traversal guard', () => {
+  test('throws when a hand-built scope key would escape the todo directory', () => {
+    expect(() => todoContentPath(agentDir, { kind: 'tui', key: '../sessions/x' })).toThrow(/escapes the todo directory/)
+  })
+
+  test('accepts a normal nested key', () => {
+    const path = todoContentPath(agentDir, { kind: 'channel', key: 'channel/sslack:sw:sc:n' })
+    expect(path.endsWith('todo/channel/sslack:sw:sc:n.json')).toBe(true)
+  })
+})
+
 describe('incompleteTodos', () => {
   test('excludes completed and cancelled, keeps pending and in_progress', () => {
     const todos: Todo[] = [

--- a/src/agent/todo/store.test.ts
+++ b/src/agent/todo/store.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { TodoScope } from './scope'
+import { incompleteTodos, readTodos, type Todo, todoContentPath, writeTodos } from './store'
+
+const TUI_SCOPE: TodoScope = { kind: 'tui', key: 'tui' }
+const CHANNEL_SCOPE: TodoScope = { kind: 'channel', key: 'channel/slack-bot:T1:C1:_root' }
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-todo-store-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('todo store', () => {
+  test('reading a non-existent scope returns an empty list', async () => {
+    expect(await readTodos(agentDir, TUI_SCOPE)).toEqual([])
+  })
+
+  test('write then read round-trips the list', async () => {
+    const todos: Todo[] = [
+      { content: 'first', status: 'pending', priority: 'high' },
+      { content: 'second', status: 'in_progress' },
+    ]
+    await writeTodos(agentDir, TUI_SCOPE, todos)
+    expect(await readTodos(agentDir, TUI_SCOPE)).toEqual(todos)
+  })
+
+  test('nested scope keys create their parent directories', async () => {
+    await writeTodos(agentDir, CHANNEL_SCOPE, [{ content: 'x', status: 'pending' }])
+    expect(await readTodos(agentDir, CHANNEL_SCOPE)).toEqual([{ content: 'x', status: 'pending' }])
+  })
+
+  test('atomic write leaves no .tmp file behind', async () => {
+    await writeTodos(agentDir, TUI_SCOPE, [{ content: 'x', status: 'pending' }])
+    const dir = join(agentDir, 'todo')
+    const entries = await readdir(dir)
+    expect(entries.some((e) => e.endsWith('.tmp'))).toBe(false)
+    expect(entries).toContain('tui.json')
+  })
+
+  test('the persisted file is valid pretty-printed JSON with a version', async () => {
+    await writeTodos(agentDir, TUI_SCOPE, [{ content: 'x', status: 'pending' }])
+    const raw = await readFile(todoContentPath(agentDir, TUI_SCOPE), 'utf8')
+    const parsed = JSON.parse(raw)
+    expect(parsed.version).toBe(1)
+    expect(raw.endsWith('\n')).toBe(true)
+  })
+
+  test('concurrent writes resolve to one of the writers without corruption', async () => {
+    const a: Todo[] = [{ content: 'A', status: 'pending' }]
+    const b: Todo[] = [{ content: 'B', status: 'pending' }]
+    await Promise.all([writeTodos(agentDir, TUI_SCOPE, a), writeTodos(agentDir, TUI_SCOPE, b)])
+    const result = await readTodos(agentDir, TUI_SCOPE)
+    expect([JSON.stringify(a), JSON.stringify(b)]).toContain(JSON.stringify(result))
+  })
+})
+
+describe('incompleteTodos', () => {
+  test('excludes completed and cancelled, keeps pending and in_progress', () => {
+    const todos: Todo[] = [
+      { content: 'a', status: 'pending' },
+      { content: 'b', status: 'in_progress' },
+      { content: 'c', status: 'completed' },
+      { content: 'd', status: 'cancelled' },
+    ]
+    expect(incompleteTodos(todos).map((t) => t.content)).toEqual(['a', 'b'])
+  })
+})

--- a/src/agent/todo/store.ts
+++ b/src/agent/todo/store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname, isAbsolute, join, relative } from 'node:path'
 
 import type { TodoScope } from './scope'
 
@@ -26,8 +26,19 @@ export function todoDir(agentDir: string): string {
   return join(agentDir, 'todo')
 }
 
+// Defense-in-depth: the resolved file must stay inside todo/. Scope keys from
+// resolveTodoScope are already collision- and traversal-safe, but this function
+// is an exported primitive — a future caller passing a hand-built scope like
+// `{ key: '../sessions/x' }` would otherwise escape. We assert here rather than
+// trust every caller to use resolveTodoScope.
 export function todoContentPath(agentDir: string, scope: TodoScope): string {
-  return join(todoDir(agentDir), `${scope.key}.json`)
+  const dir = todoDir(agentDir)
+  const path = join(dir, `${scope.key}.json`)
+  const rel = relative(dir, path)
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error(`todo scope key escapes the todo directory: ${JSON.stringify(scope.key)}`)
+  }
+  return path
 }
 
 export async function readTodos(agentDir: string, scope: TodoScope): Promise<Todo[]> {
@@ -39,8 +50,28 @@ export async function readTodos(agentDir: string, scope: TodoScope): Promise<Tod
     if (isEnoent(err)) return []
     throw err
   }
-  const parsed = JSON.parse(raw) as Partial<TodoFile>
-  return Array.isArray(parsed.todos) ? parsed.todos : []
+  let parsed: Partial<TodoFile>
+  try {
+    parsed = JSON.parse(raw) as Partial<TodoFile>
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed.todos)) return []
+  // The file is force-committed and hand-editable, so a corrupt or partially
+  // edited entry can appear. Drop anything that is not a well-formed Todo
+  // rather than let a `null`/malformed item crash incompleteTodos (`t.status`)
+  // or surface as trusted state to the model.
+  return parsed.todos.filter(isValidTodo)
+}
+
+function isValidTodo(value: unknown): value is Todo {
+  if (typeof value !== 'object' || value === null) return false
+  const t = value as Record<string, unknown>
+  if (typeof t.content !== 'string' || t.content.length === 0) return false
+  if (typeof t.status !== 'string' || !(TODO_STATUSES as readonly string[]).includes(t.status)) return false
+  if (t.priority !== undefined && !(TODO_PRIORITIES as readonly string[]).includes(t.priority as string)) return false
+  if (t.id !== undefined && typeof t.id !== 'string') return false
+  return true
 }
 
 // Write is atomic (temp file + rename) so a crash mid-write can never leave a

--- a/src/agent/todo/store.ts
+++ b/src/agent/todo/store.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+import type { TodoScope } from './scope'
+
+export const TODO_STATUSES = ['pending', 'in_progress', 'completed', 'cancelled'] as const
+export type TodoStatus = (typeof TODO_STATUSES)[number]
+
+export const TODO_PRIORITIES = ['high', 'medium', 'low'] as const
+export type TodoPriority = (typeof TODO_PRIORITIES)[number]
+
+export type Todo = {
+  content: string
+  status: TodoStatus
+  priority?: TodoPriority
+  id?: string
+}
+
+type TodoFile = {
+  version: 1
+  todos: Todo[]
+}
+
+export function todoDir(agentDir: string): string {
+  return join(agentDir, 'todo')
+}
+
+export function todoContentPath(agentDir: string, scope: TodoScope): string {
+  return join(todoDir(agentDir), `${scope.key}.json`)
+}
+
+export async function readTodos(agentDir: string, scope: TodoScope): Promise<Todo[]> {
+  const path = todoContentPath(agentDir, scope)
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch (err) {
+    if (isEnoent(err)) return []
+    throw err
+  }
+  const parsed = JSON.parse(raw) as Partial<TodoFile>
+  return Array.isArray(parsed.todos) ? parsed.todos : []
+}
+
+// Write is atomic (temp file + rename) so a crash mid-write can never leave a
+// half-serialized JSON file that the next read would throw on. Mirrors the
+// channels/sessions.json writer. A scope is normally owned by a single live
+// session (see resolveTodoScope), so the only concurrent writers are the rare
+// duplicate-attach case, where last-writer-wins on the rename is acceptable —
+// the alternative (lost-update detection) is not worth a lock for a todo list.
+export async function writeTodos(agentDir: string, scope: TodoScope, todos: Todo[]): Promise<void> {
+  const path = todoContentPath(agentDir, scope)
+  const payload: TodoFile = { version: 1, todos }
+  await mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.${process.pid}.${randomUUID()}.tmp`
+  await writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
+  await rename(tmp, path)
+}
+
+export function incompleteTodos(todos: readonly Todo[]): Todo[] {
+  return todos.filter((t) => t.status !== 'completed' && t.status !== 'cancelled')
+}
+
+function isEnoent(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === 'ENOENT'
+}

--- a/src/agent/tools/todo/index.test.ts
+++ b/src/agent/tools/todo/index.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { SessionOrigin } from '@/agent/session-origin'
+import { resolveTodoScope } from '@/agent/todo/scope'
+import { readTodos } from '@/agent/todo/store'
+
+import { createTodoTools } from './index'
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-todo-tool-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+function toolsFor(origin: SessionOrigin | undefined) {
+  const [write, read, clear] = createTodoTools({ agentDir, getOrigin: () => origin })
+  return { write: write!, read: read!, clear: clear! }
+}
+
+const TUI: SessionOrigin = { kind: 'tui', sessionId: 'ses_x' }
+const CHANNEL: SessionOrigin = { kind: 'channel', adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: null }
+
+describe('todo tools', () => {
+  test('todo_write persists to the resolved scope file', async () => {
+    const { write } = toolsFor(TUI)
+    await write.execute(
+      'call-1',
+      { todos: [{ content: 'task', status: 'pending' }] },
+      undefined,
+      undefined,
+      {} as never,
+    )
+    const scope = resolveTodoScope(TUI)!
+    expect(await readTodos(agentDir, scope)).toEqual([{ content: 'task', status: 'pending' }])
+  })
+
+  test('todo_write reports remaining incomplete count', async () => {
+    const { write } = toolsFor(TUI)
+    const res = await write.execute(
+      'call-1',
+      {
+        todos: [
+          { content: 'a', status: 'completed' },
+          { content: 'b', status: 'pending' },
+        ],
+      },
+      undefined,
+      undefined,
+      {} as never,
+    )
+    expect(res.details).toMatchObject({ ok: true, total: 2, remaining: 1 })
+  })
+
+  test('channel and tui origins write to different scope files', async () => {
+    await toolsFor(TUI).write.execute(
+      'c1',
+      { todos: [{ content: 'tui-task', status: 'pending' }] },
+      undefined,
+      undefined,
+      {} as never,
+    )
+    await toolsFor(CHANNEL).write.execute(
+      'c2',
+      { todos: [{ content: 'chan-task', status: 'pending' }] },
+      undefined,
+      undefined,
+      {} as never,
+    )
+    expect(await readTodos(agentDir, resolveTodoScope(TUI)!)).toEqual([{ content: 'tui-task', status: 'pending' }])
+    expect(await readTodos(agentDir, resolveTodoScope(CHANNEL)!)).toEqual([{ content: 'chan-task', status: 'pending' }])
+  })
+
+  test('todo_read returns the current list', async () => {
+    const { write, read } = toolsFor(TUI)
+    await write.execute('c1', { todos: [{ content: 'x', status: 'in_progress' }] }, undefined, undefined, {} as never)
+    const res = await read.execute('c2', {}, undefined, undefined, {} as never)
+    expect(res.details).toMatchObject({ ok: true, total: 1 })
+    const part = res.content[0]
+    expect(part?.type).toBe('text')
+    expect(part?.type === 'text' ? part.text : '').toContain('in_progress')
+  })
+
+  test('todo_clear empties the list', async () => {
+    const { write, clear } = toolsFor(TUI)
+    await write.execute('c1', { todos: [{ content: 'x', status: 'pending' }] }, undefined, undefined, {} as never)
+    await clear.execute('c2', {}, undefined, undefined, {} as never)
+    expect(await readTodos(agentDir, resolveTodoScope(TUI)!)).toEqual([])
+  })
+
+  test('subagent origin no-ops without writing a file', async () => {
+    const origin: SessionOrigin = { kind: 'subagent', subagent: 'scout', parentSessionId: 'ses_p' }
+    const { write } = toolsFor(origin)
+    const res = await write.execute(
+      'c1',
+      { todos: [{ content: 'x', status: 'pending' }] },
+      undefined,
+      undefined,
+      {} as never,
+    )
+    expect(res.details).toMatchObject({ ok: false, reason: 'no-scope' })
+  })
+})

--- a/src/agent/tools/todo/index.test.ts
+++ b/src/agent/tools/todo/index.test.ts
@@ -106,4 +106,18 @@ describe('todo tools', () => {
     )
     expect(res.details).toMatchObject({ ok: false, reason: 'no-scope' })
   })
+
+  test('undefined origin no-ops (does not fall back to the shared tui scope)', async () => {
+    const { write } = toolsFor(undefined)
+    const res = await write.execute(
+      'c1',
+      { todos: [{ content: 'x', status: 'pending' }] },
+      undefined,
+      undefined,
+      {} as never,
+    )
+    expect(res.details).toMatchObject({ ok: false, reason: 'no-scope' })
+    // The tui scope must remain untouched — no cross-scope leak.
+    expect(await readTodos(agentDir, resolveTodoScope(TUI)!)).toEqual([])
+  })
 })

--- a/src/agent/tools/todo/index.ts
+++ b/src/agent/tools/todo/index.ts
@@ -1,0 +1,110 @@
+import { Type } from '@mariozechner/pi-ai'
+import { defineTool } from '@mariozechner/pi-coding-agent'
+
+import type { SessionOrigin } from '@/agent/session-origin'
+import { resolveTodoScope } from '@/agent/todo/scope'
+import { incompleteTodos, type Todo, TODO_PRIORITIES, TODO_STATUSES, readTodos, writeTodos } from '@/agent/todo/store'
+
+export type CreateTodoToolsOptions = {
+  agentDir: string
+  getOrigin: () => SessionOrigin | undefined
+}
+
+const SUBAGENT_NOTICE =
+  'Todos are owned by the originating session, not by subagents. This call was a no-op. ' +
+  'Report your result to the parent instead.'
+
+type TodoToolDetails = {
+  ok: boolean
+  reason?: string
+  total?: number
+  remaining?: number
+}
+
+const TODO_ITEM = Type.Object({
+  content: Type.String({ minLength: 1, description: 'What the task is.' }),
+  status: Type.Union(
+    TODO_STATUSES.map((s) => Type.Literal(s)),
+    { description: 'One of: pending, in_progress, completed, cancelled.' },
+  ),
+  priority: Type.Optional(Type.Union(TODO_PRIORITIES.map((p) => Type.Literal(p)))),
+  id: Type.Optional(Type.String()),
+})
+
+export function createTodoTools({ agentDir, getOrigin }: CreateTodoToolsOptions) {
+  const writeTool = defineTool({
+    name: 'todo_write',
+    label: 'Write Todos',
+    description:
+      'Replace your entire todo list for this session with the provided items. Maintain a todo ' +
+      'list for any multi-step or long-running task so that if this session is interrupted ' +
+      '(restart, crash, or a later turn), you can resume the remaining work instead of silently ' +
+      'dropping it. Mark items `completed` (or `cancelled`) as you finish them by writing the full ' +
+      'list again with updated statuses. This is a full replace, not a merge: include every item ' +
+      'you still care about on each call.',
+    parameters: Type.Object({
+      todos: Type.Array(TODO_ITEM, { description: 'The complete todo list. Replaces any prior list.' }),
+    }),
+    async execute(_toolCallId, params) {
+      const scope = resolveTodoScope(getOrigin() ?? { kind: 'tui', sessionId: 'unknown' })
+      if (scope === null) {
+        const details: TodoToolDetails = { ok: false, reason: 'no-scope' }
+        return { content: [{ type: 'text' as const, text: SUBAGENT_NOTICE }], details }
+      }
+      const todos = params.todos as Todo[]
+      await writeTodos(agentDir, scope, todos)
+      const remaining = incompleteTodos(todos).length
+      const details: TodoToolDetails = { ok: true, total: todos.length, remaining }
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Saved ${todos.length} todo(s); ${remaining} remaining (${todos.length - remaining} done).`,
+          },
+        ],
+        details,
+      }
+    },
+  })
+
+  const readTool = defineTool({
+    name: 'todo_read',
+    label: 'Read Todos',
+    description: 'Return your current todo list for this session. Use it to re-sync after an interruption.',
+    parameters: Type.Object({}),
+    async execute() {
+      const scope = resolveTodoScope(getOrigin() ?? { kind: 'tui', sessionId: 'unknown' })
+      if (scope === null) {
+        const details: TodoToolDetails = { ok: false, reason: 'no-scope' }
+        return { content: [{ type: 'text' as const, text: SUBAGENT_NOTICE }], details }
+      }
+      const todos = await readTodos(agentDir, scope)
+      const details: TodoToolDetails = { ok: true, total: todos.length }
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(todos, null, 2) }],
+        details,
+      }
+    },
+  })
+
+  const clearTool = defineTool({
+    name: 'todo_clear',
+    label: 'Clear Todos',
+    description:
+      'Empty your todo list for this session. Call this when all work is genuinely done or the ' +
+      'task was abandoned, so the runtime stops tracking pending work.',
+    parameters: Type.Object({}),
+    async execute() {
+      const scope = resolveTodoScope(getOrigin() ?? { kind: 'tui', sessionId: 'unknown' })
+      if (scope === null) {
+        const details: TodoToolDetails = { ok: false, reason: 'no-scope' }
+        return { content: [{ type: 'text' as const, text: SUBAGENT_NOTICE }], details }
+      }
+      await writeTodos(agentDir, scope, [])
+      const details: TodoToolDetails = { ok: true }
+      return { content: [{ type: 'text' as const, text: 'Todo list cleared.' }], details }
+    },
+  })
+
+  return [writeTool, readTool, clearTool]
+}

--- a/src/agent/tools/todo/index.ts
+++ b/src/agent/tools/todo/index.ts
@@ -2,7 +2,7 @@ import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
 import type { SessionOrigin } from '@/agent/session-origin'
-import { resolveTodoScope } from '@/agent/todo/scope'
+import { resolveTodoScope, type TodoScope } from '@/agent/todo/scope'
 import { incompleteTodos, type Todo, TODO_PRIORITIES, TODO_STATUSES, readTodos, writeTodos } from '@/agent/todo/store'
 
 export type CreateTodoToolsOptions = {
@@ -10,15 +10,24 @@ export type CreateTodoToolsOptions = {
   getOrigin: () => SessionOrigin | undefined
 }
 
-const SUBAGENT_NOTICE =
-  'Todos are owned by the originating session, not by subagents. This call was a no-op. ' +
-  'Report your result to the parent instead.'
+const NO_SCOPE_NOTICE =
+  'Todos are owned by the originating session. This session (a subagent, system task, or one ' +
+  'with no resolvable origin) does not own a todo list, so the call was a no-op.'
 
 type TodoToolDetails = {
   ok: boolean
   reason?: string
   total?: number
   remaining?: number
+}
+
+// Resolve the scope for the current origin, or null when this session owns no
+// todo list. An UNDEFINED origin is treated as no-scope, NOT defaulted to the
+// shared TUI scope — defaulting would fail open, silently routing an unknown
+// actor's todos into the operator's global `tui` list.
+function scopeForOrigin(getOrigin: () => SessionOrigin | undefined): TodoScope | null {
+  const origin = getOrigin()
+  return origin === undefined ? null : resolveTodoScope(origin)
 }
 
 const TODO_ITEM = Type.Object({
@@ -46,10 +55,10 @@ export function createTodoTools({ agentDir, getOrigin }: CreateTodoToolsOptions)
       todos: Type.Array(TODO_ITEM, { description: 'The complete todo list. Replaces any prior list.' }),
     }),
     async execute(_toolCallId, params) {
-      const scope = resolveTodoScope(getOrigin() ?? { kind: 'tui', sessionId: 'unknown' })
+      const scope = scopeForOrigin(getOrigin)
       if (scope === null) {
         const details: TodoToolDetails = { ok: false, reason: 'no-scope' }
-        return { content: [{ type: 'text' as const, text: SUBAGENT_NOTICE }], details }
+        return { content: [{ type: 'text' as const, text: NO_SCOPE_NOTICE }], details }
       }
       const todos = params.todos as Todo[]
       await writeTodos(agentDir, scope, todos)
@@ -73,10 +82,10 @@ export function createTodoTools({ agentDir, getOrigin }: CreateTodoToolsOptions)
     description: 'Return your current todo list for this session. Use it to re-sync after an interruption.',
     parameters: Type.Object({}),
     async execute() {
-      const scope = resolveTodoScope(getOrigin() ?? { kind: 'tui', sessionId: 'unknown' })
+      const scope = scopeForOrigin(getOrigin)
       if (scope === null) {
         const details: TodoToolDetails = { ok: false, reason: 'no-scope' }
-        return { content: [{ type: 'text' as const, text: SUBAGENT_NOTICE }], details }
+        return { content: [{ type: 'text' as const, text: NO_SCOPE_NOTICE }], details }
       }
       const todos = await readTodos(agentDir, scope)
       const details: TodoToolDetails = { ok: true, total: todos.length }
@@ -95,10 +104,10 @@ export function createTodoTools({ agentDir, getOrigin }: CreateTodoToolsOptions)
       'task was abandoned, so the runtime stops tracking pending work.',
     parameters: Type.Object({}),
     async execute() {
-      const scope = resolveTodoScope(getOrigin() ?? { kind: 'tui', sessionId: 'unknown' })
+      const scope = scopeForOrigin(getOrigin)
       if (scope === null) {
         const details: TodoToolDetails = { ok: false, reason: 'no-scope' }
-        return { content: [{ type: 'text' as const, text: SUBAGENT_NOTICE }], details }
+        return { content: [{ type: 'text' as const, text: NO_SCOPE_NOTICE }], details }
       }
       await writeTodos(agentDir, scope, [])
       const details: TodoToolDetails = { ok: true }


### PR DESCRIPTION
## What

First of three stacked PRs introducing a **todo-based durable work-recovery** system. This PR lands the **storage primitive + tools + prompt guidance** only — no auto-continuation yet (that is PR 2).

A per-origin todo list is the shared durable primitive. It is keyed by **origin identity**, not the raw `sessionId`, because sessionIds churn across TUI reconnects and every cron fire, and a channel session can roll to a fresh sessionId on stale-rollover. Keying on origin lets a list survive restart, reconnect, and stale-rollover so interrupted work can later be resumed.

## Changes

- `src/agent/todo/scope.ts` — `resolveTodoScope(origin)` maps a `SessionOrigin` to a filesystem-safe key:
  - tui → singleton `tui` (one workstream per agent; concurrent attaches share it, documented)
  - channel → `channel/<adapter>:<workspace>:<chat>:<thread>` tuple
  - cron → `cron/<jobId>`
  - subagent / system → `null` (no scope; they don't own continuation)
- `src/agent/todo/store.ts` — atomic JSON persistence under `todo/<scope>.json` (temp-file + rename, unique temp suffix so concurrent writers don't collide on the temp path).
- `src/agent/tools/todo/` — `todo_write` (batch replace), `todo_read`, `todo_clear`, wired into the core tool set. Subagent origins no-op.
- `src/agent/system-prompt.ts` — strong (not enforced) guidance to maintain a todo list for multi-step work so it can be resumed if interrupted.

## Scope decisions (from pre-impl design review)

- **Origin-keyed, not sessionId-keyed** — survives restart/reconnect/stale-rollover.
- **Batch-replace tool model** (`todo_write` replaces the whole list) — avoids partial-update races.
- **Prompt-guided authoring** — no runtime enforcement.

## Tests

- `scope.test.ts` — per-origin key resolution, tuple sanitization (path-escape safe), null scopes.
- `store.test.ts` — round-trip, ENOENT→empty, atomic write (no `.tmp` leftover), concurrent-write safety.
- `tools/todo/index.test.ts` — per-origin persistence, remaining-count reporting, subagent no-op.

`bun run typecheck` / `lint` (0 errors) / `format:check` clean. All todo tests pass; full suite green except one pre-existing worktree-path artifact (`resolveSelfPackageJsonPath`), unrelated to this change.

## Follow-ups (stacked)

- **PR 2** — core idle-continuation injector (TUI + channel) with bounded-autonomy guards and soft-abort policy.
- **PR 3** — cause-specific integration: subagent-failure surfacing, restart-handoff suppression window, cron carry-forward policy, `todo/` durability + backup wiring.