### PR TITLE
channels: surface kakaotalk reply context to the agent

### DIFF
--- a/src/channels/adapters/discord-bot-reference.test.ts
+++ b/src/channels/adapters/discord-bot-reference.test.ts
@@ -4,7 +4,7 @@ import { enrichDiscordMessageReferences, type DiscordReferenceFetch } from './di
 
 type FetchCall = { channelId: string; messageId: string }
 
-function fakeFetch(messages: ReadonlyMap<string, { authorName: string; text: string } | null>): {
+function fakeFetch(messages: ReadonlyMap<string, { authorId: string; authorName: string; text: string } | null>): {
   fetch: DiscordReferenceFetch
   calls: FetchCall[]
 } {
@@ -21,16 +21,24 @@ function fakeFetch(messages: ReadonlyMap<string, { authorName: string; text: str
 describe('enrichDiscordMessageReferences', () => {
   test('prepends the parent message content for Discord replies', async () => {
     const { fetch, calls } = fakeFetch(
-      new Map([['111111111111111111:222222222222222222', { authorName: 'Alice', text: 'parent text' }]]),
+      new Map([
+        ['111111111111111111:222222222222222222', { authorId: 'alice-id', authorName: 'Alice', text: 'parent text' }],
+      ]),
     )
 
-    const text = await enrichDiscordMessageReferences({
+    const result = await enrichDiscordMessageReferences({
       text: 'actual reply',
       reply: { channelId: '111111111111111111', messageId: '222222222222222222' },
       fetchMessage: fetch,
     })
 
-    expect(text).toBe('> ↩ Reply to Alice: parent text\nactual reply')
+    expect(result).toEqual({
+      text: 'actual reply',
+      referenceContext: {
+        kind: 'reply',
+        sources: [{ adapter: 'discord-bot', authorId: 'alice-id', authorName: 'Alice', text: 'parent text' }],
+      },
+    })
     expect(calls).toEqual([{ channelId: '111111111111111111', messageId: '222222222222222222' }])
   })
 
@@ -41,41 +49,47 @@ describe('enrichDiscordMessageReferences', () => {
       throw new Error('missing access')
     }
 
-    const text = await enrichDiscordMessageReferences({
+    const result = await enrichDiscordMessageReferences({
       text: 'actual reply',
       reply: { channelId: '111111111111111111', messageId: '222222222222222222' },
       fetchMessage: fetch,
     })
 
-    expect(text).toBe('actual reply')
+    expect(result).toEqual({ text: 'actual reply' })
     expect(calls).toEqual([{ channelId: '111111111111111111', messageId: '222222222222222222' }])
   })
 
   test('appends resolved content for a standard guild message link', async () => {
     const { fetch } = fakeFetch(
-      new Map([['222222222222222222:333333333333333333', { authorName: 'Bob', text: 'linked text' }]]),
+      new Map([
+        ['222222222222222222:333333333333333333', { authorId: 'bob-id', authorName: 'Bob', text: 'linked text' }],
+      ]),
     )
 
-    const text = await enrichDiscordMessageReferences({
+    const result = await enrichDiscordMessageReferences({
       text: 'see https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333',
       fetchMessage: fetch,
     })
 
-    expect(text).toBe(
-      'see https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333\n\n> 🔗 Discord message from Bob: linked text',
-    )
+    expect(result).toEqual({
+      text: 'see https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333',
+      referenceContext: {
+        kind: 'link',
+        sources: [{ adapter: 'discord-bot', authorId: 'bob-id', authorName: 'Bob', text: 'linked text' }],
+      },
+    })
   })
 
   test('accepts discordapp.com, canary.discord.com, and ptb.discord.com message links', async () => {
     const { fetch, calls } = fakeFetch(
       new Map([
-        ['222222222222222222:333333333333333333', { authorName: 'Alice', text: 'one' }],
-        ['444444444444444444:555555555555555555', { authorName: 'Bob', text: 'two' }],
-        ['666666666666666666:777777777777777777', { authorName: 'Carol', text: 'three' }],
+        ['222222222222222222:333333333333333333', { authorId: 'alice-id', authorName: 'Alice', text: 'one' }],
+        ['444444444444444444:555555555555555555', { authorId: 'bob-id', authorName: 'Bob', text: 'two' }],
+        ['666666666666666666:777777777777777777', { authorId: 'carol-id', authorName: 'Carol', text: 'three' }],
       ]),
     )
 
-    const text = await enrichDiscordMessageReferences({
+    const result = await enrichDiscordMessageReferences({
       text: 'links https://discordapp.com/channels/111111111111111111/222222222222222222/333333333333333333 https://canary.discord.com/channels/@me/444444444444444444/555555555555555555 https://ptb.discord.com/channels/111111111111111111/666666666666666666/777777777777777777',
       fetchMessage: fetch,
     })
@@ -85,20 +99,22 @@ describe('enrichDiscordMessageReferences', () => {
       { channelId: '444444444444444444', messageId: '555555555555555555' },
       { channelId: '666666666666666666', messageId: '777777777777777777' },
     ])
-    expect(text).toContain('> 🔗 Discord message from Alice: one')
-    expect(text).toContain('> 🔗 Discord message from Bob: two')
-    expect(text).toContain('> 🔗 Discord message from Carol: three')
+    expect(result.referenceContext?.sources).toEqual([
+      { adapter: 'discord-bot', authorId: 'alice-id', authorName: 'Alice', text: 'one' },
+      { adapter: 'discord-bot', authorId: 'bob-id', authorName: 'Bob', text: 'two' },
+      { adapter: 'discord-bot', authorId: 'carol-id', authorName: 'Carol', text: 'three' },
+    ])
   })
 
   test('deduplicates links and caps resolved message links per inbound', async () => {
     const { fetch, calls } = fakeFetch(
       new Map([
-        ['222222222222222222:333333333333333333', { authorName: 'Alice', text: 'one' }],
-        ['444444444444444444:555555555555555555', { authorName: 'Bob', text: 'two' }],
+        ['222222222222222222:333333333333333333', { authorId: 'alice-id', authorName: 'Alice', text: 'one' }],
+        ['444444444444444444:555555555555555555', { authorId: 'bob-id', authorName: 'Bob', text: 'two' }],
       ]),
     )
 
-    const text = await enrichDiscordMessageReferences({
+    const result = await enrichDiscordMessageReferences({
       text: 'https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333 https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333 https://discord.com/channels/111111111111111111/444444444444444444/555555555555555555 https://discord.com/channels/111111111111111111/666666666666666666/777777777777777777',
       fetchMessage: fetch,
       linkLimit: 2,
@@ -108,51 +124,52 @@ describe('enrichDiscordMessageReferences', () => {
       { channelId: '222222222222222222', messageId: '333333333333333333' },
       { channelId: '444444444444444444', messageId: '555555555555555555' },
     ])
-    expect(text).toContain('Alice: one')
-    expect(text).toContain('Bob: two')
-    expect(text).not.toContain('777777777777777777:')
+    expect(result.referenceContext?.sources).toEqual([
+      { adapter: 'discord-bot', authorId: 'alice-id', authorName: 'Alice', text: 'one' },
+      { adapter: 'discord-bot', authorId: 'bob-id', authorName: 'Bob', text: 'two' },
+    ])
   })
 
   test('leaves non-message URLs untouched and does not fetch', async () => {
     const { fetch, calls } = fakeFetch(new Map())
 
-    const text = await enrichDiscordMessageReferences({
+    const result = await enrichDiscordMessageReferences({
       text: 'not a message https://discord.com/developers/docs/resources/channel',
       fetchMessage: fetch,
     })
 
-    expect(text).toBe('not a message https://discord.com/developers/docs/resources/channel')
+    expect(result).toEqual({ text: 'not a message https://discord.com/developers/docs/resources/channel' })
     expect(calls).toEqual([])
   })
 
   test('leaves message-link text unchanged when fetch returns null', async () => {
     const { fetch } = fakeFetch(new Map([['222222222222222222:333333333333333333', null]]))
 
-    const text = await enrichDiscordMessageReferences({
+    const result = await enrichDiscordMessageReferences({
       text: 'see https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333',
       fetchMessage: fetch,
     })
 
-    expect(text).toBe('see https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333')
+    expect(result).toEqual({
+      text: 'see https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333',
+    })
   })
 
-  test('truncates resolved quote and link text', async () => {
+  test('keeps full resolved quote and link text for render-time truncation', async () => {
     const longText = `${'x'.repeat(280)}tail`
     const { fetch } = fakeFetch(
       new Map([
-        ['111111111111111111:222222222222222222', { authorName: 'Alice', text: longText }],
-        ['333333333333333333:444444444444444444', { authorName: 'Bob', text: longText }],
+        ['111111111111111111:222222222222222222', { authorId: 'alice-id', authorName: 'Alice', text: longText }],
+        ['333333333333333333:444444444444444444', { authorId: 'bob-id', authorName: 'Bob', text: longText }],
       ]),
     )
 
-    const text = await enrichDiscordMessageReferences({
+    const result = await enrichDiscordMessageReferences({
       text: 'see https://discord.com/channels/111111111111111111/333333333333333333/444444444444444444',
       reply: { channelId: '111111111111111111', messageId: '222222222222222222' },
       fetchMessage: fetch,
     })
 
-    expect(text).toContain(`> ↩ Reply to Alice: ${'x'.repeat(280)}…`)
-    expect(text).toContain(`> 🔗 Discord message from Bob: ${'x'.repeat(280)}…`)
-    expect(text).not.toContain('tail')
+    expect(result.referenceContext?.sources.map((source) => source.text)).toEqual([longText, longText])
   })
 })

--- a/src/channels/adapters/discord-bot-reference.ts
+++ b/src/channels/adapters/discord-bot-reference.ts
@@ -1,4 +1,7 @@
+import type { InboundReferenceContext, QuoteAnchorSource } from '@/channels/types'
+
 export type DiscordResolvedReference = {
+  authorId: string
   authorName: string
   text: string
 }
@@ -15,31 +18,26 @@ export async function enrichDiscordMessageReferences(args: {
   reply?: DiscordMessagePointer
   fetchMessage: DiscordReferenceFetch
   linkLimit?: number
-  textLimit?: number
-}): Promise<string> {
-  const textLimit = args.textLimit ?? 280
-  const parts: string[] = []
+}): Promise<{ text: string; referenceContext?: InboundReferenceContext }> {
+  const sources: QuoteAnchorSource[] = []
+  let hasReply = false
 
   if (args.reply !== undefined) {
     const parent = await fetchSafely(args.fetchMessage, args.reply)
-    if (parent !== null) parts.push(renderReply(parent, textLimit))
+    if (parent !== null) {
+      sources.push(toSource(parent))
+      hasReply = true
+    }
   }
-
-  parts.push(args.text)
 
   const links = extractDiscordMessageLinks(args.text).slice(0, args.linkLimit ?? 3)
-  const linkBlocks: string[] = []
   for (const link of links) {
     const message = await fetchSafely(args.fetchMessage, link)
-    if (message !== null) linkBlocks.push(renderLink(message, textLimit))
+    if (message !== null) sources.push(toSource(message))
   }
 
-  if (linkBlocks.length > 0) parts.push(linkBlocks.join('\n'))
-
-  return parts.join('\n\n').replace(/^(.+)\n\n(.*)$/s, (all, first: string, rest: string) => {
-    if (!first.startsWith('> ↩ Reply to ')) return all
-    return `${first}\n${rest}`
-  })
+  if (sources.length === 0) return { text: args.text }
+  return { text: args.text, referenceContext: { kind: hasReply ? 'reply' : 'link', sources } }
 }
 
 const DISCORD_MESSAGE_LINK = /https?:\/\/(?:canary\.|ptb\.)?discord(?:app)?\.com\/channels\/(\d+|@me)\/(\d+)\/(\d+)/g
@@ -70,19 +68,11 @@ async function fetchSafely(
   }
 }
 
-function renderReply(message: DiscordResolvedReference, textLimit: number): string {
-  return `> ↩ Reply to ${singleLine(message.authorName)}: ${truncate(singleLine(message.text), textLimit)}`
-}
-
-function renderLink(message: DiscordResolvedReference, textLimit: number): string {
-  return `> 🔗 Discord message from ${singleLine(message.authorName)}: ${truncate(singleLine(message.text), textLimit)}`
-}
-
-function singleLine(value: string): string {
-  return value.replace(/\s+/g, ' ').trim()
-}
-
-function truncate(value: string, limit: number): string {
-  if (value.length <= limit) return value
-  return `${value.slice(0, limit)}…`
+function toSource(message: DiscordResolvedReference): QuoteAnchorSource {
+  return {
+    adapter: 'discord-bot',
+    authorId: message.authorId,
+    authorName: message.authorName,
+    text: message.text,
+  }
 }

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -904,19 +904,25 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       }
 
       const replyMessageId = event.message_reference?.message_id
-      const enrichedText = await enrichDiscordMessageReferences({
+      const referenceResult = await enrichDiscordMessageReferences({
         text: verdict.payload.text,
         ...(replyMessageId !== undefined
           ? { reply: { channelId: event.message_reference?.channel_id ?? event.channel_id, messageId: replyMessageId } }
           : {}),
         fetchMessage: async (channelId, messageId) => {
-          const message: { author: { username: string; global_name?: string | null }; content: string } =
+          const message: { author: { id: string; username: string; global_name?: string | null }; content: string } =
             await client.getMessage(channelId, messageId)
-          return { authorName: message.author.global_name ?? message.author.username, text: message.content }
+          return {
+            authorId: message.author.id,
+            authorName: message.author.global_name ?? message.author.username,
+            text: message.content,
+          }
         },
       })
       const payload =
-        enrichedText === verdict.payload.text ? verdict.payload : { ...verdict.payload, text: enrichedText }
+        referenceResult.referenceContext === undefined
+          ? verdict.payload
+          : { ...verdict.payload, referenceContext: referenceResult.referenceContext }
 
       const routedTag = await formatChannelTag(payload.workspace, payload.chat)
       logger.info(

--- a/src/channels/adapters/kakaotalk-classify.test.ts
+++ b/src/channels/adapters/kakaotalk-classify.test.ts
@@ -161,6 +161,137 @@ describe('classifyInbound', () => {
     expect(verdict.payload.attachments).toBe(attachments)
   })
 
+  test('keeps raw text and sets referenceContext for replies to the bot', () => {
+    const verdict = classifyInbound(
+      event({
+        message: 'yes, please',
+        message_type: 26,
+        attachment: {
+          attach_only: false,
+          src_logId: 'BOT-L1',
+          src_userId: 999,
+          src_message: 'Do you want me to summarize this?',
+          src_type: 1,
+        },
+      }),
+      dmConfig(),
+      { selfUserId: '999', lookupChat: dmLookup },
+    )
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.text).toBe('yes, please')
+    expect(verdict.payload.referenceContext).toEqual({
+      kind: 'reply',
+      sources: [
+        { adapter: 'kakaotalk', authorId: '999', authorName: '999', text: 'Do you want me to summarize this?' },
+      ],
+    })
+    expect(verdict.payload.replyToBotMessageId).toBe('BOT-L1')
+    expect(verdict.payload.replyToOtherMessageId).toBeNull()
+  })
+
+  test('keeps raw text and sets referenceContext for replies to another user', () => {
+    const verdict = classifyInbound(
+      event({
+        message: 'I agree with this',
+        message_type: 26,
+        attachment: {
+          attach_only: false,
+          src_logId: 'USER-L1',
+          src_userId: 333,
+          src_message: 'We should ship the smaller fix first.',
+          src_type: 1,
+        },
+      }),
+      groupConfig(),
+      { selfUserId: '999', lookupChat: groupLookup },
+    )
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.text).toBe('I agree with this')
+    expect(verdict.payload.referenceContext).toEqual({
+      kind: 'reply',
+      sources: [
+        { adapter: 'kakaotalk', authorId: '333', authorName: '333', text: 'We should ship the smaller fix first.' },
+      ],
+    })
+    expect(verdict.payload.replyToBotMessageId).toBeNull()
+    expect(verdict.payload.replyToOtherMessageId).toBe('USER-L1')
+  })
+
+  test('sets reply ids but skips the quote block when quoted text is empty', () => {
+    const verdict = classifyInbound(
+      event({
+        message: 'what was attached?',
+        message_type: 26,
+        attachment: {
+          attach_only: true,
+          src_logId: 'BOT-L2',
+          src_userId: 999,
+          src_message: '',
+          src_type: 2,
+        },
+      }),
+      dmConfig(),
+      { selfUserId: '999', lookupChat: dmLookup },
+    )
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.text).toBe('what was attached?')
+    expect(verdict.payload.referenceContext).toBeUndefined()
+    expect(verdict.payload.replyToBotMessageId).toBe('BOT-L2')
+    expect(verdict.payload.replyToOtherMessageId).toBeNull()
+  })
+
+  test('keeps full quoted text in referenceContext without adapter-side truncation', () => {
+    const longQuote = `${'a'.repeat(280)}${'b'.repeat(20)}`
+    const verdict = classifyInbound(
+      event({
+        message: 'short answer',
+        message_type: 26,
+        attachment: {
+          attach_only: false,
+          src_logId: 'USER-L2',
+          src_userId: 333,
+          src_message: longQuote,
+          src_type: 1,
+        },
+      }),
+      groupConfig(),
+      { selfUserId: '999', lookupChat: groupLookup },
+    )
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.text).toBe('short answer')
+    expect(verdict.payload.referenceContext?.sources[0]?.text).toBe(longQuote)
+  })
+
+  test('does not treat aliases inside the quoted text as a fresh mention', () => {
+    const verdict = classifyInbound(
+      event({
+        message: 'following up',
+        message_type: 26,
+        attachment: {
+          attach_only: false,
+          src_logId: 'USER-L3',
+          src_userId: 333,
+          src_message: 'claudie should look at this',
+          src_type: 1,
+        },
+      }),
+      groupConfig(),
+      { selfUserId: '999', lookupChat: groupLookup, selfAliases: ['claudie'] },
+    )
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.isBotMention).toBe(false)
+  })
+
   test('absent alias keeps isBotMention=false on plain message', () => {
     const verdict = classifyInbound(event({ message: 'random thought' }), dmConfig(), {
       selfUserId: '999',

--- a/src/channels/adapters/kakaotalk-classify.ts
+++ b/src/channels/adapters/kakaotalk-classify.ts
@@ -1,8 +1,8 @@
-import type { KakaoTalkPushMessageEvent } from 'agent-messenger/kakaotalk'
+import { KAKAO_MESSAGE_TYPE, type KakaoTalkPushMessageEvent } from 'agent-messenger/kakaotalk'
 
 import { matchesAnyAlias } from '@/channels/engagement'
 import type { ChannelAdapterConfig } from '@/channels/schema'
-import type { InboundAttachment, InboundMessage } from '@/channels/types'
+import type { InboundAttachment, InboundMessage, InboundReferenceContext } from '@/channels/types'
 
 export type InboundDropReason = 'self_author' | 'empty_text' | 'unknown_chat' | 'pre_connect' | 'bot_message'
 
@@ -49,7 +49,9 @@ export function classifyInbound(
     return { kind: 'drop', reason: 'bot_message' }
   }
 
-  const text = event.message ?? ''
+  const rawText = event.message ?? ''
+  const replyContext = parseReplyContext(event, context.selfUserId)
+  const text = rawText
   if (text === '') return { kind: 'drop', reason: 'empty_text' }
 
   const chatInfo = context.lookupChat(event.chat_id)
@@ -64,7 +66,7 @@ export function classifyInbound(
   // mention (see engagement.ts: alias is unconditional and ranks alongside
   // explicit triggers). Without aliases configured, only `reply` and `dm`
   // triggers can fire on KakaoTalk.
-  const aliasMatched = matchesAnyAlias(text, context.selfAliases ?? [])
+  const aliasMatched = matchesAnyAlias(rawText, context.selfAliases ?? [])
 
   return {
     kind: 'route',
@@ -74,6 +76,7 @@ export function classifyInbound(
       chat: event.chat_id,
       thread: null,
       text,
+      ...referenceContextPayload(replyContext),
       ...(context.attachments !== undefined && context.attachments.length > 0
         ? { attachments: context.attachments }
         : {}),
@@ -82,9 +85,9 @@ export function classifyInbound(
       authorName: event.author_name ?? String(event.author_id),
       authorIsBot: false,
       isBotMention: aliasMatched,
-      replyToBotMessageId: null,
+      replyToBotMessageId: replyContext?.target === 'bot' ? replyContext.logId : null,
       mentionsOthers: false,
-      replyToOtherMessageId: null,
+      replyToOtherMessageId: replyContext?.target === 'other' ? replyContext.logId : null,
       isDm: chatInfo.isDm,
       // SDK delivers `sent_at` in Unix seconds (LOCO `sendAt`); contract
       // wants ms (see `src/channels/types.ts`). Without `* 1000`, ms-based
@@ -92,4 +95,62 @@ export function classifyInbound(
       ts: event.sent_at * 1000,
     },
   }
+}
+
+type ParsedReplyContext = {
+  logId: string
+  authorId: string
+  authorName: string
+  quotedText: string | null
+  target: 'bot' | 'other'
+}
+
+function parseReplyContext(event: KakaoTalkPushMessageEvent, selfUserId: string): ParsedReplyContext | null {
+  if (event.message_type !== KAKAO_MESSAGE_TYPE.REPLY) return null
+  if (event.attachment === null) return null
+
+  const logId = stringField(event.attachment, 'src_logId')
+  const sourceUserId = numericField(event.attachment, 'src_userId')
+  if (logId === null || sourceUserId === null) return null
+
+  const sourceAuthorId = String(sourceUserId)
+  const quotedText = stringField(event.attachment, 'src_message')
+  return {
+    logId,
+    authorId: sourceAuthorId,
+    // classifyInbound is synchronous and has no cheap author resolver access;
+    // fall back to Kakao's stable source user id rather than fetching.
+    authorName: sourceAuthorId,
+    quotedText,
+    target: sourceAuthorId === selfUserId ? 'bot' : 'other',
+  }
+}
+
+function referenceContextPayload(
+  replyContext: ParsedReplyContext | null,
+): { referenceContext: InboundReferenceContext } | Record<string, never> {
+  if (replyContext === null || replyContext.quotedText === null || replyContext.quotedText.trim() === '') return {}
+  return {
+    referenceContext: {
+      kind: 'reply',
+      sources: [
+        {
+          adapter: 'kakaotalk',
+          authorId: replyContext.authorId,
+          authorName: replyContext.authorName,
+          text: replyContext.quotedText,
+        },
+      ],
+    },
+  }
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function numericField(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
 }

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -4,6 +4,7 @@ import { matchesAnyAlias } from '@/channels/engagement'
 import type { ChannelAdapterConfig } from '@/channels/schema'
 import type { InboundAttachment, InboundMessage } from '@/channels/types'
 
+import { hasSlackMessageShareAttachments } from './slack-bot-reference'
 import { slackTsToMillis } from './slack-bot-time'
 
 export type SlackInboundMessageEvent = SlackSocketModeMessageEvent
@@ -62,7 +63,8 @@ export function classifyInbound(
 
   const rawText = event.text ?? ''
   const { text, attachments } = splitInbound(event)
-  if (text === '') return { kind: 'drop', reason: 'empty_text' }
+  const slackAttachments = Array.isArray(event.attachments) ? event.attachments : undefined
+  if (text === '' && !hasSlackMessageShareAttachments(slackAttachments)) return { kind: 'drop', reason: 'empty_text' }
 
   const isDm = event.channel_type === 'im'
   const workspace = isDm ? '@dm' : context.teamId

--- a/src/channels/adapters/slack-bot-reference.test.ts
+++ b/src/channels/adapters/slack-bot-reference.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  enrichSlackReferenceContext,
+  hasSlackMessageShareAttachments,
+  type SlackReferenceFetch,
+} from './slack-bot-reference'
+
+type FetchCall = { channelId: string; messageTs: string }
+
+function fakeFetch(messages: ReadonlyMap<string, { authorId: string; authorName: string; text: string } | null>): {
+  fetch: SlackReferenceFetch
+  calls: FetchCall[]
+} {
+  const calls: FetchCall[] = []
+  return {
+    calls,
+    fetch: async (channelId, messageTs) => {
+      calls.push({ channelId, messageTs })
+      return messages.get(`${channelId}:${messageTs}`) ?? null
+    },
+  }
+}
+
+describe('enrichSlackReferenceContext', () => {
+  test('keeps raw text and adds thread-root reply context', async () => {
+    const { fetch, calls } = fakeFetch(
+      new Map([['C1:1700.000001', { authorId: 'UBOB', authorName: 'Bob', text: 'root text' }]]),
+    )
+
+    const result = await enrichSlackReferenceContext({
+      text: 'actual reply',
+      channelId: 'C1',
+      threadTs: '1700.000001',
+      messageTs: '1700.000002',
+      fetchMessage: fetch,
+    })
+
+    expect(result).toEqual({
+      text: 'actual reply',
+      referenceContext: {
+        kind: 'reply',
+        sources: [{ adapter: 'slack-bot', authorId: 'UBOB', authorName: 'Bob', text: 'root text' }],
+      },
+    })
+    expect(calls).toEqual([{ channelId: 'C1', messageTs: '1700.000001' }])
+  })
+
+  test('keeps share-only raw text empty and adds quote context from share attachments', async () => {
+    const result = await enrichSlackReferenceContext({
+      text: '',
+      channelId: 'C1',
+      messageTs: '1700.000002',
+      attachments: [{ author_id: 'UBOB', author_name: 'Bob', text: 'shared text' }],
+      fetchMessage: async () => null,
+    })
+
+    expect(result).toEqual({
+      text: '',
+      referenceContext: {
+        kind: 'quote',
+        sources: [{ adapter: 'slack-bot', authorId: 'UBOB', authorName: 'Bob', text: 'shared text' }],
+      },
+    })
+  })
+
+  test('resolves Slack permalinks with dedupe and cap', async () => {
+    const { fetch, calls } = fakeFetch(
+      new Map([
+        ['C1:1700000000.000001', { authorId: 'U1', authorName: 'Alice', text: 'one' }],
+        ['C2:1700000000.000002', { authorId: 'U2', authorName: 'Bob', text: 'two' }],
+      ]),
+    )
+
+    const result = await enrichSlackReferenceContext({
+      text: 'see https://acme.slack.com/archives/C1/p1700000000000001 https://acme.slack.com/archives/C1/p1700000000000001 https://acme.slack.com/archives/C2/p1700000000000002 https://acme.slack.com/archives/C3/p1700000000000003',
+      channelId: 'C0',
+      messageTs: '1700.000003',
+      fetchMessage: fetch,
+      linkLimit: 2,
+    })
+
+    expect(calls).toEqual([
+      { channelId: 'C1', messageTs: '1700000000.000001' },
+      { channelId: 'C2', messageTs: '1700000000.000002' },
+    ])
+    expect(result.referenceContext?.sources).toEqual([
+      { adapter: 'slack-bot', authorId: 'U1', authorName: 'Alice', text: 'one' },
+      { adapter: 'slack-bot', authorId: 'U2', authorName: 'Bob', text: 'two' },
+    ])
+  })
+
+  test('omits failed references and reports no context when nothing resolves', async () => {
+    const result = await enrichSlackReferenceContext({
+      text: 'see https://acme.slack.com/archives/C1/p1700000000000001',
+      channelId: 'C0',
+      messageTs: '1700.000003',
+      fetchMessage: async () => {
+        throw new Error('missing access')
+      },
+    })
+
+    expect(result).toEqual({ text: 'see https://acme.slack.com/archives/C1/p1700000000000001' })
+  })
+})
+
+describe('hasSlackMessageShareAttachments', () => {
+  test('detects attachments with share text and an author id', () => {
+    expect(hasSlackMessageShareAttachments([{ author_id: 'UBOB', text: 'shared text' }])).toBe(true)
+    expect(hasSlackMessageShareAttachments([{ text: 'missing author' }])).toBe(false)
+  })
+})

--- a/src/channels/adapters/slack-bot-reference.ts
+++ b/src/channels/adapters/slack-bot-reference.ts
@@ -1,0 +1,123 @@
+import type { InboundReferenceContext, QuoteAnchorSource } from '@/channels/types'
+
+export type SlackResolvedReference = {
+  authorId: string
+  authorName: string
+  text: string
+}
+
+export type SlackReferenceFetch = (channelId: string, messageTs: string) => Promise<SlackResolvedReference | null>
+
+export type SlackMessagePointer = {
+  channelId: string
+  messageTs: string
+}
+
+export async function enrichSlackReferenceContext(args: {
+  text: string
+  channelId: string
+  threadTs?: string
+  messageTs: string
+  attachments?: readonly unknown[]
+  fetchMessage: SlackReferenceFetch
+  linkLimit?: number
+}): Promise<{ text: string; referenceContext?: InboundReferenceContext }> {
+  const sources: QuoteAnchorSource[] = []
+  let kind: InboundReferenceContext['kind'] = 'link'
+
+  if (args.threadTs !== undefined && args.threadTs !== args.messageTs) {
+    const parent = await fetchSafely(args.fetchMessage, { channelId: args.channelId, messageTs: args.threadTs })
+    if (parent !== null) {
+      sources.push(toSource(parent))
+      kind = 'reply'
+    }
+  }
+
+  for (const source of extractSlackShareSources(args.attachments ?? [])) {
+    sources.push(source)
+    if (kind !== 'reply') kind = 'quote'
+  }
+
+  const links = extractSlackMessageLinks(args.text).slice(0, args.linkLimit ?? 3)
+  const seen = new Set(sources.map((source) => `${source.authorId}\x00${source.text}`))
+  for (const link of links) {
+    const message = await fetchSafely(args.fetchMessage, link)
+    if (message === null) continue
+    const source = toSource(message)
+    const key = `${source.authorId}\x00${source.text}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    sources.push(source)
+  }
+
+  if (sources.length === 0) return { text: args.text }
+  return { text: args.text, referenceContext: { kind, sources } }
+}
+
+export function hasSlackMessageShareAttachments(attachments: readonly unknown[] | undefined): boolean {
+  return extractSlackShareSources(attachments ?? []).length > 0
+}
+
+const SLACK_ARCHIVE_LINK = /https?:\/\/[^\s/]+\.slack\.com\/archives\/([^/\s]+)\/p(\d{10})(\d{6})/g
+
+function extractSlackMessageLinks(text: string): SlackMessagePointer[] {
+  const seen = new Set<string>()
+  const links: SlackMessagePointer[] = []
+  for (const match of text.matchAll(SLACK_ARCHIVE_LINK)) {
+    const channelId = match[1]
+    const seconds = match[2]
+    const micros = match[3]
+    if (channelId === undefined || seconds === undefined || micros === undefined) continue
+    const messageTs = `${seconds}.${micros}`
+    const key = `${channelId}:${messageTs}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    links.push({ channelId, messageTs })
+  }
+  return links
+}
+
+function extractSlackShareSources(attachments: readonly unknown[]): QuoteAnchorSource[] {
+  const sources: QuoteAnchorSource[] = []
+  for (const attachment of attachments) {
+    const record = recordValue(attachment)
+    if (record === null) continue
+    const text = stringField(record, 'text') ?? stringField(record, 'fallback')
+    if (text === null || text.trim() === '') continue
+    const authorId = stringField(record, 'author_id') ?? stringField(record, 'user') ?? stringField(record, 'user_id')
+    if (authorId === null) continue
+    sources.push({
+      adapter: 'slack-bot',
+      authorId,
+      authorName: stringField(record, 'author_name') ?? authorId,
+      text,
+    })
+  }
+  return sources
+}
+
+async function fetchSafely(
+  fetchMessage: SlackReferenceFetch,
+  pointer: SlackMessagePointer,
+): Promise<SlackResolvedReference | null> {
+  try {
+    return await fetchMessage(pointer.channelId, pointer.messageTs)
+  } catch {
+    return null
+  }
+}
+
+function toSource(message: SlackResolvedReference): QuoteAnchorSource {
+  return { adapter: 'slack-bot', authorId: message.authorId, authorName: message.authorName, text: message.text }
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -43,6 +43,7 @@ import {
   type SlackInboundMessageEvent,
 } from './slack-bot-classify'
 import { createSlackDedupe } from './slack-bot-dedupe'
+import { enrichSlackReferenceContext } from './slack-bot-reference'
 import {
   buildSlashAckPayload,
   commandResultReply,
@@ -261,6 +262,7 @@ export type SlackBotAdapterOptions = {
   // classifier behaves as before (no alias-driven thread anchoring), so
   // tests and ad-hoc adapter constructions stay backwards-compatible.
   selfAliasesRef?: () => readonly string[]
+  fetchImpl?: typeof fetch
 }
 
 export type SlackBotAdapter = {
@@ -902,9 +904,46 @@ export function createFetchAttachmentCallback(deps: {
   }
 }
 
+function createSlackReferenceFetch(deps: { token: string; fetchImpl: typeof fetch }) {
+  return async (channelId: string, messageTs: string) => {
+    const url = new URL('https://slack.com/api/conversations.replies')
+    url.searchParams.set('channel', channelId)
+    url.searchParams.set('ts', messageTs)
+    url.searchParams.set('limit', '1')
+    const response = await deps.fetchImpl(url, { headers: { Authorization: `Bearer ${deps.token}` } })
+    if (!response.ok) return null
+    const body = recordValue(await response.json())
+    if (body === null || body.ok !== true) return null
+    const messages = arrayField(body, 'messages')
+    const first = recordValue(messages[0])
+    if (first === null) return null
+    const authorId = stringField(first, 'user') ?? stringField(first, 'bot_id')
+    const text = stringField(first, 'text')
+    if (authorId === null || text === null) return null
+    return { authorId, authorName: authorId, text }
+  }
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function arrayField(record: Record<string, unknown>, key: string): readonly unknown[] {
+  const value = record[key]
+  return Array.isArray(value) ? value : []
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
 export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBotAdapter {
   const logger = options.logger ?? consoleLogger
   const client = new SlackBotClient()
+  const fetchImpl = options.fetchImpl ?? fetch
   let listener: SlackBotListener | null = null
   let botUserId: string | null = null
   let teamId: string | null = null
@@ -1058,7 +1097,22 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       }
 
       dedupe.mark(event)
-      const enriched = { ...verdict.payload, authorName: resolvedUserName }
+      const slackAttachments = Array.isArray(event.attachments) ? event.attachments : undefined
+      const referenceResult = await enrichSlackReferenceContext({
+        text: verdict.payload.text,
+        channelId: event.channel,
+        ...(event.thread_ts !== undefined ? { threadTs: event.thread_ts } : {}),
+        messageTs: event.ts,
+        ...(slackAttachments !== undefined ? { attachments: slackAttachments } : {}),
+        fetchMessage: createSlackReferenceFetch({ token: options.token, fetchImpl }),
+      })
+      const enriched = {
+        ...verdict.payload,
+        authorName: resolvedUserName,
+        ...(referenceResult.referenceContext !== undefined
+          ? { referenceContext: referenceResult.referenceContext }
+          : {}),
+      }
       const routedTag = await formatChannelTag(enriched.workspace, enriched.chat)
       logger.info(
         `[slack-bot] routed ts=${event.ts} ${routedTag} mention=${enriched.isBotMention} reply=${enriched.replyToBotMessageId !== null}`,

--- a/src/channels/engagement.test.ts
+++ b/src/channels/engagement.test.ts
@@ -214,6 +214,46 @@ describe('decideEngagement (alias)', () => {
     expect(decision).toBe('engage')
   })
 
+  test('observes when alias appears only in referenceContext source text', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({
+        text: 'following up on this',
+        referenceContext: {
+          kind: 'reply',
+          sources: [{ adapter: 'discord-bot', authorId: 'bob', authorName: 'Bob', text: '봉봉아 please check' }],
+        },
+      }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: crowded,
+      selfAliases: ['봉봉'],
+    })
+    expect(decision).toBe('observe')
+  })
+
+  test('engages when alias appears in raw message text even with referenceContext present', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({
+        text: '봉봉아 following up',
+        referenceContext: {
+          kind: 'reply',
+          sources: [{ adapter: 'discord-bot', authorId: 'bob', authorName: 'Bob', text: 'unrelated parent' }],
+        },
+      }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: crowded,
+      selfAliases: ['봉봉'],
+    })
+    expect(decision).toBe('engage')
+  })
+
   test('alias engagement runs after explicit triggers (mention still wins for sticky-credit grant)', () => {
     // Sanity: alias path doesn't break existing trigger ordering. A
     // message with both <@id> mention AND alias text engages, same as
@@ -427,6 +467,31 @@ describe('decideEngagement (solo-human fallback)', () => {
 
     // then we observe — the fallback is for humans, not bots
     expect(decision).toBe('observe')
+  })
+
+  test('peer bot name inside referenceContext does not suppress solo-human fallback', () => {
+    const ledger = new StickyLedger()
+    const participants: ChannelParticipant[] = [
+      participant('alice'),
+      { ...participant('peer1'), authorName: 'Winky', isBot: true },
+    ]
+
+    const decision = decideEngagement({
+      message: inbound({
+        text: 'what do you think?',
+        referenceContext: {
+          kind: 'reply',
+          sources: [{ adapter: 'discord-bot', authorId: 'bob', authorName: 'Bob', text: 'Winky should answer' }],
+        },
+      }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants,
+    })
+
+    expect(decision).toBe('engage')
   })
 
   test('peer bot still engages on explicit mention even in solo-human channel', () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -32,7 +32,7 @@ import {
   type ChannelRouter,
   type ClaimHandler,
 } from './router'
-import { defaultHistoryConfig, type ChannelAdapterConfig } from './schema'
+import { defaultHistoryConfig, QUOTED_REPLY_EXCERPT_MAX_CHARS, type ChannelAdapterConfig } from './schema'
 import type {
   ChannelHistoryMessage,
   ChannelKey,
@@ -6354,6 +6354,61 @@ describe('ChannelRouter injectSubagentCompletionReminder', () => {
     expect(reminderPrompt).toContain('## Recent context')
     expect(reminderPrompt).toContain('side chatter')
     expect(reminderPrompt).not.toContain('## Current message')
+  })
+
+  test('referenceContext renders quote lines above the current author line and truncates at render time', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const longQuote = `${'x'.repeat(QUOTED_REPLY_EXCERPT_MAX_CHARS)}tail`
+
+    await router.route(
+      inbound({
+        text: 'actual reply',
+        referenceContext: {
+          kind: 'reply',
+          sources: [
+            { adapter: 'discord-bot', authorId: 'bob', authorName: 'Bob', text: longQuote },
+            { adapter: 'discord-bot', authorId: 'carol', authorName: 'Carol', text: 'linked context' },
+          ],
+        },
+      }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0] ?? ''
+    expect(prompt).toContain(`> <@bob>: ${'x'.repeat(QUOTED_REPLY_EXCERPT_MAX_CHARS - 1)}…`)
+    expect(prompt).not.toContain('tail')
+    expect(prompt).toContain('> <@carol>: linked context')
+    expect(prompt.indexOf('> <@bob>:')).toBeLessThan(prompt.indexOf(`<@alice> (alice): actual reply`))
+  })
+
+  test('share-only Slack referenceContext renders even when raw text is empty', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(
+      inbound({
+        adapter: 'slack-bot',
+        workspace: 'T0ACME',
+        chat: 'C0CHANNEL',
+        text: '',
+        referenceContext: {
+          kind: 'quote',
+          sources: [{ adapter: 'slack-bot', authorId: 'UBOB', authorName: 'Bob', text: 'shared message body' }],
+        },
+      }),
+    )
+    await router.__testing!.flushDebounce({
+      adapter: 'slack-bot',
+      workspace: 'T0ACME',
+      chat: 'C0CHANNEL',
+      thread: null,
+    })
+
+    const prompt = sessions[0]!.prompts[0] ?? ''
+    expect(prompt).toContain('> <@UBOB>: shared message body')
+    expect(prompt).toContain('<@alice> (alice): ')
+    expect(prompt.indexOf('> <@UBOB>: shared message body')).toBeLessThan(prompt.indexOf('<@alice> (alice): '))
   })
 
   test("reminder lookup skips destroyed sessions (channels GC'd while subagent was running drops the reminder)", async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -53,6 +53,7 @@ import type {
   HistoryCallback,
   InboundAttachment,
   InboundMessage,
+  InboundReferenceContext,
   RemoveReactionCallback,
   RemoveReactionRequest,
   OutboundCallback,
@@ -280,6 +281,7 @@ export type ConfigForAdapter = (adapter: ChannelKey['adapter']) => ChannelAdapte
 
 type QueuedInbound = {
   text: string
+  referenceContext?: InboundReferenceContext
   attachments?: readonly InboundAttachment[]
   authorId: string
   authorName: string
@@ -302,6 +304,7 @@ type QueuedInbound = {
 
 type ObservedInbound = {
   text: string
+  referenceContext?: InboundReferenceContext
   attachments?: readonly InboundAttachment[]
   authorId: string
   authorName: string
@@ -1315,6 +1318,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       if (item.kind === 'message') {
         observed.push({
           text: item.message.text,
+          ...(item.message.referenceContext !== undefined ? { referenceContext: item.message.referenceContext } : {}),
           authorId: item.message.authorId,
           authorName: item.message.authorName,
           authorIsBot: item.message.isBot,
@@ -2025,6 +2029,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const observe = (live: LiveSession, event: InboundMessage): void => {
     live.contextBuffer.push({
       text: event.text,
+      ...(event.referenceContext !== undefined ? { referenceContext: event.referenceContext } : {}),
       ...(event.attachments !== undefined && event.attachments.length > 0 ? { attachments: event.attachments } : {}),
       authorId: event.authorId,
       authorName: event.authorName,
@@ -2045,6 +2050,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   ): void => {
     live.promptQueue.push({
       text: event.text,
+      ...(event.referenceContext !== undefined ? { referenceContext: event.referenceContext } : {}),
       ...(event.attachments !== undefined && event.attachments.length > 0 ? { attachments: event.attachments } : {}),
       authorId: event.authorId,
       authorName: event.authorName,
@@ -3156,7 +3162,7 @@ function composeTurnPrompt(
   if (observed.length > 0) {
     parts.push('## Recent context (not addressed to you, for awareness only)')
     for (const o of observed) {
-      parts.push(formatAuthorLine(o.ts, adapter, o.authorId, o.authorName, o.authorIsBot, o.text))
+      parts.push(formatInboundPromptLines(o, adapter))
     }
     parts.push('')
   }
@@ -3174,7 +3180,7 @@ function composeTurnPrompt(
       )
     }
     for (const b of batch) {
-      parts.push(formatAuthorLine(b.ts, adapter, b.authorId, b.authorName, b.authorIsBot, b.text))
+      parts.push(formatInboundPromptLines(b, adapter))
     }
   }
   return parts.join('\n')
@@ -3191,6 +3197,24 @@ function formatAuthorLine(
   const tag = authorIsBot ? ' [bot]' : ''
   const stamp = ts > 0 ? `[${new Date(ts).toISOString()}] ` : ''
   return `${stamp}${formatAuthorReference(adapter, authorId, authorName)} (${authorName})${tag}: ${text}`
+}
+
+function formatInboundPromptLines(
+  inbound: {
+    ts: number
+    authorId: string
+    authorName: string
+    authorIsBot: boolean
+    text: string
+    referenceContext?: InboundReferenceContext
+  },
+  adapter: AdapterId,
+): string {
+  const lines = inbound.referenceContext?.sources.map(renderQuoteAnchor) ?? []
+  lines.push(
+    formatAuthorLine(inbound.ts, adapter, inbound.authorId, inbound.authorName, inbound.authorIsBot, inbound.text),
+  )
+  return lines.join('\n')
 }
 
 export type { QuoteAnchorSource } from './types'

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -52,6 +52,9 @@ export type InboundMessage = {
   chat: string
   thread: string | null
   text: string
+  // Prompt-only context for replied-to / quoted / linked messages. Kept out
+  // of `text` so the engagement gate sees only the human-authored body.
+  referenceContext?: InboundReferenceContext
   // Non-text attachments the user sent on this inbound. Empty / omitted
   // when the message is text-only. The router carries these through to
   // the live session's promptQueue/contextBuffer so channel tools can
@@ -220,6 +223,11 @@ export type QuoteAnchorSource = {
   text: string
 }
 
+export type InboundReferenceContext = {
+  kind: 'reply' | 'quote' | 'link'
+  sources: readonly QuoteAnchorSource[]
+}
+
 export type SendErrorCode =
   | 'duplicate'
   | 'turn-cap'
@@ -297,6 +305,7 @@ export type ChannelHistoryMessage = {
   authorId: string
   authorName: string
   text: string
+  referenceContext?: InboundReferenceContext
   attachments?: readonly InboundAttachment[]
   ts: number
   isBot: boolean


### PR DESCRIPTION
## Problem

When a user **replies to / quotes** a message in KakaoTalk (답장/인용), the agent never saw the quoted message. The classifier hardcoded `replyToBotMessageId`, `replyToOtherMessageId`, and `mentionsOthers` to null/false, so:

- the model had no idea what was being replied to, and
- the engagement `reply` trigger could never fire on KakaoTalk.

The quoted content is **already in the inbound push payload** (no network fetch needed): KakaoTalk REPLY messages (LOCO type `26`) carry `src_logId` / `src_userId` / `src_message` on `event.attachment`.

## Change

`src/channels/adapters/kakaotalk-classify.ts`:

- Parse the reply attachment defensively (same `stringField`/`numericField` style as `kakaotalk-attachment.ts`).
- **Prepend a prompt-safe quote block** to the inbound text, mirroring the existing attachment-placeholder pattern:
  ```
  > ↩ Reply to <author>: <quoted text>
  <user's actual message>
  ```
- Set `replyToBotMessageId` / `replyToOtherMessageId` from the source author (`src_userId` vs `selfUserId`) so the engagement `reply` trigger works for the bot case.
- Quoted text is whitespace-normalized and truncated to **280 chars**. Empty quoted text → reply ids still set, block skipped. Alias matching still runs against the user's own text only (not the quoted text).

No router/type plumbing — everything rides in `InboundMessage.text`. No network calls. No other adapters touched.

## Behavior

| Case | Prompt-visible text |
|---|---|
| Reply to bot | `> ↩ Reply to <id>: <quote>` + message; `replyToBotMessageId` set |
| Reply to other | `> ↩ Reply to <id>: <quote>` + message; `replyToOtherMessageId` set |
| Empty quoted text | message only; reply id still set |
| Long quote | truncated to 280 chars + `…` |

> Note: quoted author is rendered by source user id because `classifyInbound` is synchronous with no cheap author-resolver access; a follow-up could resolve display names.

## Tests
`kakaotalk-classify.test.ts` covers all four cases above (TDD: red first). 

## Checks
- `bun run lint` — 0 errors (64 pre-existing warnings)
- `bun run format:check` — clean
- `bun run typecheck` — clean
- channel test suite green (`bun test src/channels`)