### PR TITLE
init: gitignore public/ alongside workspace/

### DIFF
--- a/src/init/gitignore.ts
+++ b/src/init/gitignore.ts
@@ -32,6 +32,7 @@ auth.json
 node_modules/
 packages/*/node_modules/
 workspace/
+public/
 mounts/
 Dockerfile
 .DS_Store


### PR DESCRIPTION
## Background

`public/` is a free-write zone for the agent inside the container — same category as `workspace/`. It's reproducible output, not agent state, so it should never enter git history by default.

Like the rest of `.gitignore`, TypeClaw rewrites this file on every `typeclaw start`, so existing agents pick up the new entry on their next start — no `typeclaw init` re-run needed.

## Summary

Add `public/` to the agent folder's default `.gitignore`, grouped with `workspace/` in the truly-ignored section.

## Preview

```
 workspace/
+public/
 mounts/
```

## What this does NOT do

- Does not add `public/` to the system-managed section (it's truly-ignored reproducible output, not TypeClaw-committed agent state).
- Does not require `typeclaw init` to re-run on existing agents — `refreshDockerfile` already rewrites `.gitignore` on every `typeclaw start`.

## Review notes

`src/init/gitignore.ts` — one line added to the truly-ignored block, immediately after `workspace/`. The comment block at the top of that section already describes the "free-write zone" rationale; `public/` fits naturally there.