### PR TITLE
channels: resolve discord reply and message-link context for the agent

### DIFF
--- a/src/channels/adapters/discord-bot-reference.test.ts
+++ b/src/channels/adapters/discord-bot-reference.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'bun:test'
+
+import { enrichDiscordMessageReferences, type DiscordReferenceFetch } from './discord-bot-reference'
+
+type FetchCall = { channelId: string; messageId: string }
+
+function fakeFetch(messages: ReadonlyMap<string, { authorName: string; text: string } | null>): {
+  fetch: DiscordReferenceFetch
+  calls: FetchCall[]
+} {
+  const calls: FetchCall[] = []
+  return {
+    calls,
+    fetch: async (channelId, messageId) => {
+      calls.push({ channelId, messageId })
+      return messages.get(`${channelId}:${messageId}`) ?? null
+    },
+  }
+}
+
+describe('enrichDiscordMessageReferences', () => {
+  test('prepends the parent message content for Discord replies', async () => {
+    const { fetch, calls } = fakeFetch(
+      new Map([['111111111111111111:222222222222222222', { authorName: 'Alice', text: 'parent text' }]]),
+    )
+
+    const text = await enrichDiscordMessageReferences({
+      text: 'actual reply',
+      reply: { channelId: '111111111111111111', messageId: '222222222222222222' },
+      fetchMessage: fetch,
+    })
+
+    expect(text).toBe('> ↩ Reply to Alice: parent text\nactual reply')
+    expect(calls).toEqual([{ channelId: '111111111111111111', messageId: '222222222222222222' }])
+  })
+
+  test('leaves reply text unchanged when the parent fetch fails', async () => {
+    const calls: FetchCall[] = []
+    const fetch: DiscordReferenceFetch = async (channelId, messageId) => {
+      calls.push({ channelId, messageId })
+      throw new Error('missing access')
+    }
+
+    const text = await enrichDiscordMessageReferences({
+      text: 'actual reply',
+      reply: { channelId: '111111111111111111', messageId: '222222222222222222' },
+      fetchMessage: fetch,
+    })
+
+    expect(text).toBe('actual reply')
+    expect(calls).toEqual([{ channelId: '111111111111111111', messageId: '222222222222222222' }])
+  })
+
+  test('appends resolved content for a standard guild message link', async () => {
+    const { fetch } = fakeFetch(
+      new Map([['222222222222222222:333333333333333333', { authorName: 'Bob', text: 'linked text' }]]),
+    )
+
+    const text = await enrichDiscordMessageReferences({
+      text: 'see https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333',
+      fetchMessage: fetch,
+    })
+
+    expect(text).toBe(
+      'see https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333\n\n> 🔗 Discord message from Bob: linked text',
+    )
+  })
+
+  test('accepts discordapp.com, canary.discord.com, and ptb.discord.com message links', async () => {
+    const { fetch, calls } = fakeFetch(
+      new Map([
+        ['222222222222222222:333333333333333333', { authorName: 'Alice', text: 'one' }],
+        ['444444444444444444:555555555555555555', { authorName: 'Bob', text: 'two' }],
+        ['666666666666666666:777777777777777777', { authorName: 'Carol', text: 'three' }],
+      ]),
+    )
+
+    const text = await enrichDiscordMessageReferences({
+      text: 'links https://discordapp.com/channels/111111111111111111/222222222222222222/333333333333333333 https://canary.discord.com/channels/@me/444444444444444444/555555555555555555 https://ptb.discord.com/channels/111111111111111111/666666666666666666/777777777777777777',
+      fetchMessage: fetch,
+    })
+
+    expect(calls).toEqual([
+      { channelId: '222222222222222222', messageId: '333333333333333333' },
+      { channelId: '444444444444444444', messageId: '555555555555555555' },
+      { channelId: '666666666666666666', messageId: '777777777777777777' },
+    ])
+    expect(text).toContain('> 🔗 Discord message from Alice: one')
+    expect(text).toContain('> 🔗 Discord message from Bob: two')
+    expect(text).toContain('> 🔗 Discord message from Carol: three')
+  })
+
+  test('deduplicates links and caps resolved message links per inbound', async () => {
+    const { fetch, calls } = fakeFetch(
+      new Map([
+        ['222222222222222222:333333333333333333', { authorName: 'Alice', text: 'one' }],
+        ['444444444444444444:555555555555555555', { authorName: 'Bob', text: 'two' }],
+      ]),
+    )
+
+    const text = await enrichDiscordMessageReferences({
+      text: 'https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333 https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333 https://discord.com/channels/111111111111111111/444444444444444444/555555555555555555 https://discord.com/channels/111111111111111111/666666666666666666/777777777777777777',
+      fetchMessage: fetch,
+      linkLimit: 2,
+    })
+
+    expect(calls).toEqual([
+      { channelId: '222222222222222222', messageId: '333333333333333333' },
+      { channelId: '444444444444444444', messageId: '555555555555555555' },
+    ])
+    expect(text).toContain('Alice: one')
+    expect(text).toContain('Bob: two')
+    expect(text).not.toContain('777777777777777777:')
+  })
+
+  test('leaves non-message URLs untouched and does not fetch', async () => {
+    const { fetch, calls } = fakeFetch(new Map())
+
+    const text = await enrichDiscordMessageReferences({
+      text: 'not a message https://discord.com/developers/docs/resources/channel',
+      fetchMessage: fetch,
+    })
+
+    expect(text).toBe('not a message https://discord.com/developers/docs/resources/channel')
+    expect(calls).toEqual([])
+  })
+
+  test('leaves message-link text unchanged when fetch returns null', async () => {
+    const { fetch } = fakeFetch(new Map([['222222222222222222:333333333333333333', null]]))
+
+    const text = await enrichDiscordMessageReferences({
+      text: 'see https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333',
+      fetchMessage: fetch,
+    })
+
+    expect(text).toBe('see https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333')
+  })
+
+  test('truncates resolved quote and link text', async () => {
+    const longText = `${'x'.repeat(280)}tail`
+    const { fetch } = fakeFetch(
+      new Map([
+        ['111111111111111111:222222222222222222', { authorName: 'Alice', text: longText }],
+        ['333333333333333333:444444444444444444', { authorName: 'Bob', text: longText }],
+      ]),
+    )
+
+    const text = await enrichDiscordMessageReferences({
+      text: 'see https://discord.com/channels/111111111111111111/333333333333333333/444444444444444444',
+      reply: { channelId: '111111111111111111', messageId: '222222222222222222' },
+      fetchMessage: fetch,
+    })
+
+    expect(text).toContain(`> ↩ Reply to Alice: ${'x'.repeat(280)}…`)
+    expect(text).toContain(`> 🔗 Discord message from Bob: ${'x'.repeat(280)}…`)
+    expect(text).not.toContain('tail')
+  })
+})

--- a/src/channels/adapters/discord-bot-reference.ts
+++ b/src/channels/adapters/discord-bot-reference.ts
@@ -1,0 +1,88 @@
+export type DiscordResolvedReference = {
+  authorName: string
+  text: string
+}
+
+export type DiscordReferenceFetch = (channelId: string, messageId: string) => Promise<DiscordResolvedReference | null>
+
+export type DiscordMessagePointer = {
+  channelId: string
+  messageId: string
+}
+
+export async function enrichDiscordMessageReferences(args: {
+  text: string
+  reply?: DiscordMessagePointer
+  fetchMessage: DiscordReferenceFetch
+  linkLimit?: number
+  textLimit?: number
+}): Promise<string> {
+  const textLimit = args.textLimit ?? 280
+  const parts: string[] = []
+
+  if (args.reply !== undefined) {
+    const parent = await fetchSafely(args.fetchMessage, args.reply)
+    if (parent !== null) parts.push(renderReply(parent, textLimit))
+  }
+
+  parts.push(args.text)
+
+  const links = extractDiscordMessageLinks(args.text).slice(0, args.linkLimit ?? 3)
+  const linkBlocks: string[] = []
+  for (const link of links) {
+    const message = await fetchSafely(args.fetchMessage, link)
+    if (message !== null) linkBlocks.push(renderLink(message, textLimit))
+  }
+
+  if (linkBlocks.length > 0) parts.push(linkBlocks.join('\n'))
+
+  return parts.join('\n\n').replace(/^(.+)\n\n(.*)$/s, (all, first: string, rest: string) => {
+    if (!first.startsWith('> ↩ Reply to ')) return all
+    return `${first}\n${rest}`
+  })
+}
+
+const DISCORD_MESSAGE_LINK = /https?:\/\/(?:canary\.|ptb\.)?discord(?:app)?\.com\/channels\/(\d+|@me)\/(\d+)\/(\d+)/g
+
+function extractDiscordMessageLinks(text: string): DiscordMessagePointer[] {
+  const seen = new Set<string>()
+  const links: DiscordMessagePointer[] = []
+  for (const match of text.matchAll(DISCORD_MESSAGE_LINK)) {
+    const channelId = match[2]
+    const messageId = match[3]
+    if (channelId === undefined || messageId === undefined) continue
+    const key = `${channelId}:${messageId}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    links.push({ channelId, messageId })
+  }
+  return links
+}
+
+async function fetchSafely(
+  fetchMessage: DiscordReferenceFetch,
+  pointer: DiscordMessagePointer,
+): Promise<DiscordResolvedReference | null> {
+  try {
+    return await fetchMessage(pointer.channelId, pointer.messageId)
+  } catch {
+    return null
+  }
+}
+
+function renderReply(message: DiscordResolvedReference, textLimit: number): string {
+  return `> ↩ Reply to ${singleLine(message.authorName)}: ${truncate(singleLine(message.text), textLimit)}`
+}
+
+function renderLink(message: DiscordResolvedReference, textLimit: number): string {
+  return `> 🔗 Discord message from ${singleLine(message.authorName)}: ${truncate(singleLine(message.text), textLimit)}`
+}
+
+function singleLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function truncate(value: string, limit: number): string {
+  if (value.length <= limit) return value
+  return `${value.slice(0, limit)}…`
+}

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -39,6 +39,7 @@ import {
   type InboundDropReason,
   renderPlaceholder,
 } from './discord-bot-classify'
+import { enrichDiscordMessageReferences } from './discord-bot-reference'
 import {
   ackInteraction,
   parseInteractionAsCommand,
@@ -902,11 +903,26 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         return
       }
 
-      const routedTag = await formatChannelTag(verdict.payload.workspace, verdict.payload.chat)
+      const replyMessageId = event.message_reference?.message_id
+      const enrichedText = await enrichDiscordMessageReferences({
+        text: verdict.payload.text,
+        ...(replyMessageId !== undefined
+          ? { reply: { channelId: event.message_reference?.channel_id ?? event.channel_id, messageId: replyMessageId } }
+          : {}),
+        fetchMessage: async (channelId, messageId) => {
+          const message: { author: { username: string; global_name?: string | null }; content: string } =
+            await client.getMessage(channelId, messageId)
+          return { authorName: message.author.global_name ?? message.author.username, text: message.content }
+        },
+      })
+      const payload =
+        enrichedText === verdict.payload.text ? verdict.payload : { ...verdict.payload, text: enrichedText }
+
+      const routedTag = await formatChannelTag(payload.workspace, payload.chat)
       logger.info(
-        `[discord-bot] routed id=${event.id} ${routedTag} mention=${verdict.payload.isBotMention} reply=${verdict.payload.replyToBotMessageId !== null}`,
+        `[discord-bot] routed id=${event.id} ${routedTag} mention=${payload.isBotMention} reply=${payload.replyToBotMessageId !== null}`,
       )
-      await options.router.route(verdict.payload)
+      await options.router.route(payload)
     } catch (err) {
       logger.error(`[discord-bot] handleInbound failed: ${describe(err)}`)
     } finally {


### PR DESCRIPTION
## Problem

On Discord the agent could not see referenced content:

- **Replies** deliver only `message_reference.message_id` — no parent text inline. The agent knew "this is a reply" but not *to what*.
- **Message links** (`https://discord.com/channels/{guild}/{channel}/{message}`) were passed through as bare URLs; the agent never saw the linked message.

## Change

New pure module `src/channels/adapters/discord-bot-reference.ts`:

- `enrichDiscordMessageReferences({ text, reply?, fetchMessage, linkLimit?, textLimit? })` takes an **injected** `fetchMessage(channelId, messageId)` so it stays unit-testable with a fake fetcher (no real network).
- **Prepends** a quote block for the replied-to parent:
  ```
  > ↩ Reply to <author>: <parent text>
  <user's message>
  ```
- **Appends** blocks for resolved message links:
  ```
  > 🔗 Discord message from <author>: <linked text>
  ```

`src/channels/adapters/discord-bot.ts` wires the real `DiscordBotClient.getMessage(channelId, messageId)` after classification and before `router.route()`. `classifyInbound` stays pure — reply/engagement classification is unchanged.

### Robustness
- Failed fetch (deleted / forbidden / cross-guild / network) **degrades gracefully** → falls back to raw text, never throws, never drops the inbound.
- Links are **deduped** and **capped to the first 3** (`linkLimit`).
- Resolved text **truncated to 280 chars** + `…`, single-lined.
- Link regex handles `discord.com`, `discordapp.com`, `canary.`/`ptb.` subdomains, and `@me` DMs.

Everything rides in `InboundMessage.text` — no router/type plumbing. No other adapters touched.

## Behavior

| Case | Prompt-visible text |
|---|---|
| Reply | `> ↩ Reply to <author>: <parent>` + message |
| Message link | message + `> 🔗 Discord message from <author>: <linked>` |
| Failed fetch | raw text unchanged |
| Cap / truncation | ≤3 links resolved; text capped at 280 + `…` |

## Tests
`discord-bot-reference.test.ts` covers reply enrichment, single/multiple/duplicate links, the cap, failed fetch, truncation, and non-link URLs left untouched (TDD: red first via missing module).

## Checks
- `bun run lint` — 0 errors (64 pre-existing warnings)
- `bun run format:check` — clean
- `bun run typecheck` — clean
- channel test suite green (`bun test src/channels`)