### PR TITLE
channels: resolve slack reply, share, and permalink context for the agent

### DIFF
--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -53,6 +53,28 @@ describe('slack-bot classifyInbound — drop paths', () => {
     expect(verdict).toEqual({ kind: 'drop', reason: 'empty_text' })
   })
 
+  test('routes share-only messages so reference enrichment can surface the quoted attachment text', () => {
+    const event = buildEvent({
+      text: '',
+      attachments: [
+        {
+          is_share: true,
+          author_id: 'UALICE',
+          author_name: 'Alice',
+          channel_name: 'general',
+          ts: '1700000000.000050',
+          text: 'shared context',
+        },
+      ],
+    })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.text).toBe('')
+  })
+
   test('routes file-only uploads (empty text) with attachment summary so the agent sees the upload', () => {
     const event = buildEvent({
       text: '',

--- a/src/channels/adapters/slack-bot-reference.test.ts
+++ b/src/channels/adapters/slack-bot-reference.test.ts
@@ -109,4 +109,26 @@ describe('hasSlackMessageShareAttachments', () => {
     expect(hasSlackMessageShareAttachments([{ author_id: 'UBOB', text: 'shared text' }])).toBe(true)
     expect(hasSlackMessageShareAttachments([{ text: 'missing author' }])).toBe(false)
   })
+
+  test('falls back to author_subname for the source name but still requires an author id', async () => {
+    const withSubname = await enrichSlackReferenceContext({
+      text: '',
+      channelId: 'C1',
+      messageTs: '1700.000002',
+      attachments: [{ user_id: 'UEVE', author_subname: 'Eve', text: 'forwarded note' }],
+      fetchMessage: async () => null,
+    })
+    expect(withSubname.referenceContext?.sources).toEqual([
+      { adapter: 'slack-bot', authorId: 'UEVE', authorName: 'Eve', text: 'forwarded note' },
+    ])
+
+    const idless = await enrichSlackReferenceContext({
+      text: '',
+      channelId: 'C1',
+      messageTs: '1700.000002',
+      attachments: [{ author_subname: 'Eve', text: 'forwarded note' }],
+      fetchMessage: async () => null,
+    })
+    expect(idless).toEqual({ text: '' })
+  })
 })

--- a/src/channels/adapters/slack-bot-reference.ts
+++ b/src/channels/adapters/slack-bot-reference.ts
@@ -77,6 +77,11 @@ function extractSlackMessageLinks(text: string): SlackMessagePointer[] {
   return links
 }
 
+// A stable author id is required because the quote renders as `<@id>`
+// downstream; a name-only source would emit `<@unknown>`, worse than omitting
+// the context. Forwarded message-shares put it under `author_id`, classic
+// shares under `user`/`user_id`. `author_subname` is Slack's display-name
+// fallback on forwarded messages — used for the name only, never the id.
 function extractSlackShareSources(attachments: readonly unknown[]): QuoteAnchorSource[] {
   const sources: QuoteAnchorSource[] = []
   for (const attachment of attachments) {
@@ -86,10 +91,11 @@ function extractSlackShareSources(attachments: readonly unknown[]): QuoteAnchorS
     if (text === null || text.trim() === '') continue
     const authorId = stringField(record, 'author_id') ?? stringField(record, 'user') ?? stringField(record, 'user_id')
     if (authorId === null) continue
+    const authorName = stringField(record, 'author_name') ?? stringField(record, 'author_subname') ?? authorId
     sources.push({
       adapter: 'slack-bot',
       authorId,
-      authorName: stringField(record, 'author_name') ?? authorId,
+      authorName,
       text,
     })
   }


### PR DESCRIPTION
## Problem

On Slack the agent could not see referenced content:

- **Threaded replies** delivered `thread_ts` / `parent_user_id` (ids only) — never the parent's text.
- **Forwarded messages / shares** were ignored entirely (only `files` were handled, not message-share `attachments`).
- **Permalinks** (`https://<team>.slack.com/archives/<C>/p<ts>`) were passed through as raw URLs.

## Change

New pure module `src/channels/adapters/slack-bot-reference.ts`:

- `enrichSlackReferenceContext({ channel, ts, threadTs?, text, attachments, fetchMessage })` takes an **injected** `fetchMessage(channel, ts)` so it's unit-testable with a fake (no real network).
- **Prepends** a quote block for the thread-root parent:
  ```
  > ↩ Reply to <author>: <parent text>
  <user's message>
  ```
- **Renders forwarded message-share attachments** (read defensively off the untyped `attachments` index-signature field — no blanket casts):
  ```
  > 🔁 Shared from <author> in #<channel>: <forwarded text>
  ```
- **Resolves pasted permalinks**, decoding the `p<digits>` form back to `{seconds}.{micros}`:
  ```
  > 🔗 Linked Slack message from <author>: <linked text>
  ```

`src/channels/adapters/slack-bot.ts` wires the real `SlackBotClient.getMessage(channel, ts)` (which returns `null` on miss — handled) plus the existing author resolver. `slack-bot-classify.ts` now lets **share-only** messages through (previously dropped as `empty_text`) so they can be enriched.

### Robustness
- Failed fetch (`not_in_channel`, `message_not_found`, network) **degrades gracefully** → falls back, never throws.
- Permalinks **deduped** and **capped to 3**; ts-decoder is a tested pure helper.
- Resolved text **truncated to 280 chars** + `…`.

Everything rides in `InboundMessage.text` — no router/type plumbing. No other adapters touched.

## Behavior

| Case | Prompt-visible text |
|---|---|
| Threaded reply | `> ↩ Reply to <author>: <parent>` + message |
| Forwarded share | message + `> 🔁 Shared from <author> in #<chan>: <text>` |
| Permalink | message + `> 🔗 Linked Slack message from <author>: <text>` |
| Failed fetch | unchanged |
| Cap / truncation | ≤3 permalinks; text capped at 280 + `…` |

## Tests
`slack-bot-reference.test.ts` + `slack-bot-classify.test.ts` cover the reply block, share attachments (incl. ignoring pure link-unfurls), permalink decoding/resolution/cap, failed fetch, truncation, and share-only messages no longer dropped (TDD: red first via missing module).

## Checks
- `bun run lint` — 0 errors (64 pre-existing warnings)
- `bun run format:check` — clean
- `bun run typecheck` — clean
- channel test suite green (`bun test src/channels`)