### PR TITLE
agent: bounded todo-continuation injector for TUI and channel (2/3)

### DIFF
--- a/src/agent/todo/continuation-policy.test.ts
+++ b/src/agent/todo/continuation-policy.test.ts
@@ -7,6 +7,7 @@ import {
   emptyContinuationState,
   hasRealProgress,
   hashIncomplete,
+  parseContinuationState,
   type TurnOutcome,
 } from './continuation-policy'
 import type { Todo } from './store'
@@ -70,6 +71,61 @@ describe('hasRealProgress', () => {
     ]
     expect(hasRealProgress(before, fewer)).toBe(true)
     expect(hasRealProgress(before, reworded)).toBe(false)
+  })
+})
+
+describe('parseContinuationState (fail-closed validation)', () => {
+  test('round-trips a fully valid state', () => {
+    const state: ContinuationState = {
+      episode: {
+        episodeId: 'e',
+        startedAt: 1,
+        autoTurnCount: 2,
+        cumulativeTokens: 100,
+        failureCount: 0,
+        stagnationCount: 1,
+        lastIncompleteHash: 'abc',
+      },
+      lastTurnOutcome: { turnId: 't', stopReason: 'stop', endedAt: 9 },
+      suppressNextIdleNudgeReason: 'restart-kick',
+      autoResumeBlockedUntilRealUserTurn: true,
+    }
+    expect(parseContinuationState(state)).toEqual(state)
+  })
+
+  test('non-object input falls back to empty', () => {
+    expect(parseContinuationState(null)).toEqual(emptyContinuationState())
+    expect(parseContinuationState('nope')).toEqual(emptyContinuationState())
+  })
+
+  test('a malformed episode with missing counters collapses to null (no ceiling bypass)', () => {
+    const corrupt = { episode: { episodeId: 'e', startedAt: 1 }, lastTurnOutcome: null }
+    expect(parseContinuationState(corrupt).episode).toBeNull()
+  })
+
+  test('an episode counter that is NaN collapses to null', () => {
+    const corrupt = {
+      episode: {
+        episodeId: 'e',
+        startedAt: 1,
+        autoTurnCount: Number.NaN,
+        cumulativeTokens: 0,
+        failureCount: 0,
+        stagnationCount: 0,
+        lastIncompleteHash: null,
+      },
+    }
+    expect(parseContinuationState(corrupt).episode).toBeNull()
+  })
+
+  test('an unknown stopReason collapses the outcome to null (idle then fails closed)', () => {
+    const corrupt = { lastTurnOutcome: { turnId: 't', stopReason: 'length', endedAt: 1 } }
+    expect(parseContinuationState(corrupt).lastTurnOutcome).toBeNull()
+  })
+
+  test('an unknown suppressor value is dropped', () => {
+    const corrupt = { suppressNextIdleNudgeReason: 'something-else' }
+    expect(parseContinuationState(corrupt).suppressNextIdleNudgeReason).toBeNull()
   })
 })
 

--- a/src/agent/todo/continuation-policy.test.ts
+++ b/src/agent/todo/continuation-policy.test.ts
@@ -194,6 +194,31 @@ describe('decideContinuation', () => {
     expect(decide(state)).toEqual({ kind: 'skip', reason: 'max-tokens' })
   })
 
+  test('accumulates the just-completed turn tokens into the episode', () => {
+    const state = baseState({ lastTurnOutcome: { turnId: 't', stopReason: 'stop', endedAt: 1, tokens: 1234 } })
+    const d = decide(state)
+    expect(d.kind).toBe('inject')
+    if (d.kind === 'inject') expect(d.episode.cumulativeTokens).toBe(1234)
+  })
+
+  test('token spend across turns crosses the ceiling and stops continuation', () => {
+    const nearCeiling = DEFAULT_CONTINUATION_LIMITS.maxCumulativeTokens - 100
+    const state = baseState({
+      lastTurnOutcome: { turnId: 't', stopReason: 'stop', endedAt: 1, tokens: 200 },
+      episode: {
+        episodeId: 'e',
+        startedAt: 1500,
+        autoTurnCount: 1,
+        cumulativeTokens: nearCeiling,
+        failureCount: 0,
+        stagnationCount: 0,
+        lastIncompleteHash: 'prev',
+      },
+    })
+    // nearCeiling + 200 >= maxCumulativeTokens → the folded spend trips the gate.
+    expect(decide(state)).toEqual({ kind: 'skip', reason: 'max-tokens' })
+  })
+
   test('skips at the wall-clock ceiling', () => {
     const state = baseState({
       episode: {

--- a/src/agent/todo/continuation-policy.test.ts
+++ b/src/agent/todo/continuation-policy.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  type ContinuationState,
+  DEFAULT_CONTINUATION_LIMITS,
+  decideContinuation,
+  emptyContinuationState,
+  hasRealProgress,
+  hashIncomplete,
+  type TurnOutcome,
+} from './continuation-policy'
+import type { Todo } from './store'
+
+const STOP: TurnOutcome = { turnId: 't1', stopReason: 'stop', endedAt: 1000 }
+const INCOMPLETE: Todo[] = [{ content: 'do the thing', status: 'pending' }]
+
+let counter = 0
+const newEpisodeId = () => `ep_${counter++}`
+
+function baseState(overrides: Partial<ContinuationState> = {}): ContinuationState {
+  return { ...emptyContinuationState(), lastTurnOutcome: STOP, ...overrides }
+}
+
+function decide(state: ContinuationState, todos: Todo[] = INCOMPLETE, now = 2000) {
+  return decideContinuation({ state, todos, limits: DEFAULT_CONTINUATION_LIMITS, now, newEpisodeId })
+}
+
+describe('hashIncomplete', () => {
+  test('is stable under reordering and whitespace churn', () => {
+    const a: Todo[] = [
+      { content: 'alpha', status: 'pending' },
+      { content: 'beta', status: 'in_progress' },
+    ]
+    const b: Todo[] = [
+      { content: 'beta', status: 'in_progress' },
+      { content: '  alpha  ', status: 'pending' },
+    ]
+    expect(hashIncomplete(a)).toBe(hashIncomplete(b))
+  })
+
+  test('ignores completed/cancelled todos', () => {
+    const a: Todo[] = [{ content: 'x', status: 'pending' }]
+    const b: Todo[] = [
+      { content: 'x', status: 'pending' },
+      { content: 'done', status: 'completed' },
+    ]
+    expect(hashIncomplete(a)).toBe(hashIncomplete(b))
+  })
+
+  test('changes when incomplete content materially changes', () => {
+    const a: Todo[] = [{ content: 'x', status: 'pending' }]
+    const b: Todo[] = [{ content: 'y', status: 'pending' }]
+    expect(hashIncomplete(a)).not.toBe(hashIncomplete(b))
+  })
+})
+
+describe('hasRealProgress', () => {
+  test('true only when the incomplete count shrinks', () => {
+    const before: Todo[] = [
+      { content: 'a', status: 'pending' },
+      { content: 'b', status: 'pending' },
+    ]
+    const fewer: Todo[] = [
+      { content: 'a', status: 'completed' },
+      { content: 'b', status: 'pending' },
+    ]
+    const reworded: Todo[] = [
+      { content: 'a-renamed', status: 'pending' },
+      { content: 'b', status: 'pending' },
+    ]
+    expect(hasRealProgress(before, fewer)).toBe(true)
+    expect(hasRealProgress(before, reworded)).toBe(false)
+  })
+})
+
+describe('decideContinuation', () => {
+  test('injects on the happy path and opens an episode with autoTurnCount 1', () => {
+    const d = decide(baseState())
+    expect(d.kind).toBe('inject')
+    if (d.kind === 'inject') {
+      expect(d.episode.autoTurnCount).toBe(1)
+      expect(d.episode.lastIncompleteHash).toBe(hashIncomplete(INCOMPLETE))
+    }
+  })
+
+  test('skips when there are no incomplete todos', () => {
+    const d = decide(baseState(), [{ content: 'done', status: 'completed' }])
+    expect(d).toEqual({ kind: 'skip', reason: 'no-incomplete-todos' })
+  })
+
+  test('skips and is fail-closed when no turn outcome is recorded', () => {
+    const d = decide(baseState({ lastTurnOutcome: null }))
+    expect(d).toEqual({ kind: 'skip', reason: 'turn-not-safe' })
+  })
+
+  test('skips when the last turn was a user abort', () => {
+    const d = decide(baseState({ lastTurnOutcome: { turnId: 't', stopReason: 'aborted', endedAt: 1 } }))
+    expect(d).toEqual({ kind: 'skip', reason: 'turn-not-safe' })
+  })
+
+  test('skips while the user-abort durable suppressor is set', () => {
+    const d = decide(baseState({ autoResumeBlockedUntilRealUserTurn: true }))
+    expect(d).toEqual({ kind: 'skip', reason: 'user-abort-blocked' })
+  })
+
+  test('consumes the restart-kick one-shot and skips exactly that idle', () => {
+    const d = decide(baseState({ suppressNextIdleNudgeReason: 'restart-kick' }))
+    expect(d).toEqual({ kind: 'skip', reason: 'restart-kick-suppressed' })
+  })
+
+  test('skips at the max-auto-turns ceiling', () => {
+    const state = baseState({
+      episode: {
+        episodeId: 'e',
+        startedAt: 0,
+        autoTurnCount: DEFAULT_CONTINUATION_LIMITS.maxAutoTurns,
+        cumulativeTokens: 0,
+        failureCount: 0,
+        stagnationCount: 0,
+        lastIncompleteHash: null,
+      },
+    })
+    expect(decide(state)).toEqual({ kind: 'skip', reason: 'max-auto-turns' })
+  })
+
+  test('skips at the token ceiling', () => {
+    const state = baseState({
+      episode: {
+        episodeId: 'e',
+        startedAt: 0,
+        autoTurnCount: 0,
+        cumulativeTokens: DEFAULT_CONTINUATION_LIMITS.maxCumulativeTokens,
+        failureCount: 0,
+        stagnationCount: 0,
+        lastIncompleteHash: null,
+      },
+    })
+    expect(decide(state)).toEqual({ kind: 'skip', reason: 'max-tokens' })
+  })
+
+  test('skips at the wall-clock ceiling', () => {
+    const state = baseState({
+      episode: {
+        episodeId: 'e',
+        startedAt: 0,
+        autoTurnCount: 0,
+        cumulativeTokens: 0,
+        failureCount: 0,
+        stagnationCount: 0,
+        lastIncompleteHash: null,
+      },
+    })
+    const now = DEFAULT_CONTINUATION_LIMITS.maxWallClockMs + 1
+    expect(decide(state, INCOMPLETE, now)).toEqual({ kind: 'skip', reason: 'max-wall-clock' })
+  })
+
+  test('stops on stagnation when the incomplete hash is unchanged across the limit', () => {
+    const hash = hashIncomplete(INCOMPLETE)
+    const state = baseState({
+      episode: {
+        episodeId: 'e',
+        startedAt: 1500,
+        autoTurnCount: 1,
+        cumulativeTokens: 0,
+        failureCount: 0,
+        stagnationCount: DEFAULT_CONTINUATION_LIMITS.stagnationLimit - 1,
+        lastIncompleteHash: hash,
+      },
+    })
+    expect(decide(state)).toEqual({ kind: 'skip', reason: 'stagnation' })
+  })
+
+  test('does not count stagnation when the incomplete hash changed', () => {
+    const state = baseState({
+      episode: {
+        episodeId: 'e',
+        startedAt: 1500,
+        autoTurnCount: 1,
+        cumulativeTokens: 0,
+        failureCount: 0,
+        stagnationCount: DEFAULT_CONTINUATION_LIMITS.stagnationLimit - 1,
+        lastIncompleteHash: 'a-different-hash',
+      },
+    })
+    const d = decide(state)
+    expect(d.kind).toBe('inject')
+    if (d.kind === 'inject') expect(d.episode.stagnationCount).toBe(DEFAULT_CONTINUATION_LIMITS.stagnationLimit - 1)
+  })
+})

--- a/src/agent/todo/continuation-policy.ts
+++ b/src/agent/todo/continuation-policy.ts
@@ -1,0 +1,168 @@
+import { createHash } from 'node:crypto'
+
+import { incompleteTodos, type Todo } from './store'
+
+export const DEFAULT_MAX_AUTO_TURNS = 3
+export const DEFAULT_MAX_CUMULATIVE_TOKENS = 25_000
+export const DEFAULT_MAX_WALL_CLOCK_MS = 30 * 60_000
+export const DEFAULT_STAGNATION_LIMIT = 2
+
+export type ContinuationLimits = {
+  maxAutoTurns: number
+  maxCumulativeTokens: number
+  maxWallClockMs: number
+  stagnationLimit: number
+}
+
+export const DEFAULT_CONTINUATION_LIMITS: ContinuationLimits = {
+  maxAutoTurns: DEFAULT_MAX_AUTO_TURNS,
+  maxCumulativeTokens: DEFAULT_MAX_CUMULATIVE_TOKENS,
+  maxWallClockMs: DEFAULT_MAX_WALL_CLOCK_MS,
+  stagnationLimit: DEFAULT_STAGNATION_LIMIT,
+}
+
+// A continuation episode is the unit a budget applies to. It opens when the
+// first auto-nudge fires after a real user turn (or restart recovery) and
+// resets only on the next REAL user prompt — never on the runtime's own
+// injected prompts. Persisting it lets the budgets survive a restart so a
+// crash-loop cannot reset the ceiling.
+export type ContinuationEpisode = {
+  episodeId: string
+  startedAt: number
+  autoTurnCount: number
+  cumulativeTokens: number
+  failureCount: number
+  stagnationCount: number
+  lastIncompleteHash: string | null
+}
+
+// The outcome of the most recently completed turn, recorded from the
+// `message_end` subscription (authoritative) or a prompt `finally` fallback.
+// `stopReason: 'unknown'` is the fail-closed value: an idle that sees it does
+// not auto-inject.
+export type TurnOutcome = {
+  turnId: string
+  stopReason: 'stop' | 'aborted' | 'error' | 'unknown'
+  endedAt: number
+}
+
+export type ContinuationState = {
+  episode: ContinuationEpisode | null
+  lastTurnOutcome: TurnOutcome | null
+  // One-shot suppressor: the restart kick prompt owns the first post-restart
+  // idle, so the first idle after a restart consumes this and skips exactly
+  // one injection.
+  suppressNextIdleNudgeReason: 'restart-kick' | null
+  // Durable user-abort suppressor (policy D1). Set when a turn ends via
+  // explicit user abort; cleared only by the next real user turn. While set,
+  // no auto-continuation fires regardless of episode budget.
+  autoResumeBlockedUntilRealUserTurn: boolean
+}
+
+export function emptyContinuationState(): ContinuationState {
+  return {
+    episode: null,
+    lastTurnOutcome: null,
+    suppressNextIdleNudgeReason: null,
+    autoResumeBlockedUntilRealUserTurn: false,
+  }
+}
+
+// Canonical hash of the INCOMPLETE todos only. Normalization (sort by id or
+// normalized text, collapse whitespace, include status) makes the hash stable
+// under reordering and cosmetic edits so it is a usable stagnation heuristic.
+// It is deliberately NOT used as proof of progress — see hasRealProgress.
+export function hashIncomplete(todos: readonly Todo[]): string {
+  const incomplete = incompleteTodos(todos)
+  const canonical = incomplete
+    .map((t) => ({
+      id: t.id ?? '',
+      status: t.status,
+      content: t.content.trim().replace(/\s+/g, ' '),
+    }))
+    .sort((a, b) => {
+      const ka = a.id !== '' ? a.id : a.content
+      const kb = b.id !== '' ? b.id : b.content
+      return ka < kb ? -1 : ka > kb ? 1 : 0
+    })
+  return createHash('sha256').update(JSON.stringify(canonical)).digest('hex')
+}
+
+// "Real progress" is stricter than "the hash changed": the incomplete set must
+// shrink. Text churn (reword/reorder/split) does not count, which is what
+// closes the fake-progress loophole. Only a drop in the number of incomplete
+// items resets the stagnation counter.
+export function hasRealProgress(prev: readonly Todo[], next: readonly Todo[]): boolean {
+  return incompleteTodos(next).length < incompleteTodos(prev).length
+}
+
+export type ContinuationDecision =
+  | { kind: 'inject'; episode: ContinuationEpisode }
+  | { kind: 'skip'; reason: ContinuationSkipReason }
+
+export type ContinuationSkipReason =
+  | 'no-incomplete-todos'
+  | 'restart-kick-suppressed'
+  | 'user-abort-blocked'
+  | 'turn-not-safe'
+  | 'max-auto-turns'
+  | 'max-tokens'
+  | 'max-wall-clock'
+  | 'stagnation'
+
+// Pure decision: given the current persisted state, the current todos, the
+// last turn outcome, a fresh episode-id factory, and `now`, decide whether to
+// inject a continuation and return the episode to persist. The caller is
+// responsible for persisting `episode` from an `inject` result before actually
+// injecting. Fails closed on every ambiguity.
+export function decideContinuation(args: {
+  state: ContinuationState
+  todos: readonly Todo[]
+  limits: ContinuationLimits
+  now: number
+  newEpisodeId: () => string
+}): ContinuationDecision {
+  const { state, todos, limits, now } = args
+
+  if (incompleteTodos(todos).length === 0) return { kind: 'skip', reason: 'no-incomplete-todos' }
+
+  if (state.suppressNextIdleNudgeReason === 'restart-kick') {
+    return { kind: 'skip', reason: 'restart-kick-suppressed' }
+  }
+
+  if (state.autoResumeBlockedUntilRealUserTurn) return { kind: 'skip', reason: 'user-abort-blocked' }
+
+  const outcome = state.lastTurnOutcome
+  if (outcome === null || outcome.stopReason === 'unknown' || outcome.stopReason === 'aborted') {
+    return { kind: 'skip', reason: 'turn-not-safe' }
+  }
+
+  const hash = hashIncomplete(todos)
+  const episode: ContinuationEpisode = state.episode ?? {
+    episodeId: args.newEpisodeId(),
+    startedAt: now,
+    autoTurnCount: 0,
+    cumulativeTokens: 0,
+    failureCount: 0,
+    stagnationCount: 0,
+    lastIncompleteHash: null,
+  }
+
+  if (episode.autoTurnCount >= limits.maxAutoTurns) return { kind: 'skip', reason: 'max-auto-turns' }
+  if (episode.cumulativeTokens >= limits.maxCumulativeTokens) return { kind: 'skip', reason: 'max-tokens' }
+  if (now - episode.startedAt >= limits.maxWallClockMs) return { kind: 'skip', reason: 'max-wall-clock' }
+
+  const stagnated = episode.lastIncompleteHash === hash
+  const stagnationCount = stagnated ? episode.stagnationCount + 1 : episode.stagnationCount
+  if (stagnationCount >= limits.stagnationLimit) return { kind: 'skip', reason: 'stagnation' }
+
+  return {
+    kind: 'inject',
+    episode: {
+      ...episode,
+      autoTurnCount: episode.autoTurnCount + 1,
+      stagnationCount,
+      lastIncompleteHash: hash,
+    },
+  }
+}

--- a/src/agent/todo/continuation-policy.ts
+++ b/src/agent/todo/continuation-policy.ts
@@ -68,6 +68,61 @@ export function emptyContinuationState(): ContinuationState {
   }
 }
 
+const STOP_REASONS = new Set<TurnOutcome['stopReason']>(['stop', 'aborted', 'error', 'unknown'])
+
+// Validate a persisted state object field-by-field and fail closed: any field
+// that does not match the expected shape is dropped to its empty value rather
+// than trusted. A partially-written file or a newer/older schema must never
+// surface a malformed `episode` whose `undefined`/`NaN` counters would compare
+// false against the ceilings and so bypass the token-burst guard. A malformed
+// episode collapses to `null` (a fresh episode opens on the next decision); a
+// malformed outcome collapses to `null` (the idle path then fails closed, not
+// auto-injecting).
+export function parseContinuationState(value: unknown): ContinuationState {
+  if (typeof value !== 'object' || value === null) return emptyContinuationState()
+  const v = value as Record<string, unknown>
+  return {
+    episode: parseEpisode(v.episode),
+    lastTurnOutcome: parseOutcome(v.lastTurnOutcome),
+    suppressNextIdleNudgeReason: v.suppressNextIdleNudgeReason === 'restart-kick' ? 'restart-kick' : null,
+    autoResumeBlockedUntilRealUserTurn: v.autoResumeBlockedUntilRealUserTurn === true,
+  }
+}
+
+function parseEpisode(value: unknown): ContinuationEpisode | null {
+  if (typeof value !== 'object' || value === null) return null
+  const e = value as Record<string, unknown>
+  if (typeof e.episodeId !== 'string') return null
+  if (!isFiniteNumber(e.startedAt)) return null
+  if (!isFiniteNumber(e.autoTurnCount)) return null
+  if (!isFiniteNumber(e.cumulativeTokens)) return null
+  if (!isFiniteNumber(e.failureCount)) return null
+  if (!isFiniteNumber(e.stagnationCount)) return null
+  if (e.lastIncompleteHash !== null && typeof e.lastIncompleteHash !== 'string') return null
+  return {
+    episodeId: e.episodeId,
+    startedAt: e.startedAt,
+    autoTurnCount: e.autoTurnCount,
+    cumulativeTokens: e.cumulativeTokens,
+    failureCount: e.failureCount,
+    stagnationCount: e.stagnationCount,
+    lastIncompleteHash: e.lastIncompleteHash,
+  }
+}
+
+function parseOutcome(value: unknown): TurnOutcome | null {
+  if (typeof value !== 'object' || value === null) return null
+  const o = value as Record<string, unknown>
+  if (typeof o.turnId !== 'string') return null
+  if (typeof o.stopReason !== 'string' || !STOP_REASONS.has(o.stopReason as TurnOutcome['stopReason'])) return null
+  if (!isFiniteNumber(o.endedAt)) return null
+  return { turnId: o.turnId, stopReason: o.stopReason as TurnOutcome['stopReason'], endedAt: o.endedAt }
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
 // Canonical hash of the INCOMPLETE todos only. Normalization (sort by id or
 // normalized text, collapse whitespace, include status) makes the hash stable
 // under reordering and cosmetic edits so it is a usable stagnation heuristic.

--- a/src/agent/todo/continuation-policy.ts
+++ b/src/agent/todo/continuation-policy.ts
@@ -44,6 +44,11 @@ export type TurnOutcome = {
   turnId: string
   stopReason: 'stop' | 'aborted' | 'error' | 'unknown'
   endedAt: number
+  // Total tokens the just-completed turn consumed (from the assistant
+  // message's usage). Accumulated into the episode's cumulativeTokens so the
+  // token ceiling reflects real spend. Optional for older state files and for
+  // turns whose usage was unavailable; missing counts as 0.
+  tokens?: number
 }
 
 export type ContinuationState = {
@@ -116,7 +121,12 @@ function parseOutcome(value: unknown): TurnOutcome | null {
   if (typeof o.turnId !== 'string') return null
   if (typeof o.stopReason !== 'string' || !STOP_REASONS.has(o.stopReason as TurnOutcome['stopReason'])) return null
   if (!isFiniteNumber(o.endedAt)) return null
-  return { turnId: o.turnId, stopReason: o.stopReason as TurnOutcome['stopReason'], endedAt: o.endedAt }
+  return {
+    turnId: o.turnId,
+    stopReason: o.stopReason as TurnOutcome['stopReason'],
+    endedAt: o.endedAt,
+    ...(isFiniteNumber(o.tokens) ? { tokens: o.tokens } : {}),
+  }
 }
 
 function isFiniteNumber(value: unknown): value is number {
@@ -193,7 +203,7 @@ export function decideContinuation(args: {
   }
 
   const hash = hashIncomplete(todos)
-  const episode: ContinuationEpisode = state.episode ?? {
+  const base: ContinuationEpisode = state.episode ?? {
     episodeId: args.newEpisodeId(),
     startedAt: now,
     autoTurnCount: 0,
@@ -201,6 +211,15 @@ export function decideContinuation(args: {
     failureCount: 0,
     stagnationCount: 0,
     lastIncompleteHash: null,
+  }
+
+  // Fold the just-completed turn's token spend into the episode BEFORE checking
+  // the ceiling, so the budget reflects what the previous auto-turn actually
+  // cost. `lastTurnOutcome.tokens` is the spend of the turn that drove this
+  // idle; missing usage counts as 0.
+  const episode: ContinuationEpisode = {
+    ...base,
+    cumulativeTokens: base.cumulativeTokens + (outcome.tokens ?? 0),
   }
 
   if (episode.autoTurnCount >= limits.maxAutoTurns) return { kind: 'skip', reason: 'max-auto-turns' }

--- a/src/agent/todo/continuation-state.test.ts
+++ b/src/agent/todo/continuation-state.test.ts
@@ -64,6 +64,19 @@ describe('continuation-state persistence', () => {
     await writeFile(continuationStatePath(agentDir, SCOPE), 'not json{{', 'utf8')
     expect(await readContinuationState(agentDir, SCOPE)).toEqual(emptyContinuationState())
   })
+
+  test('a partially-written episode is dropped on read, not trusted', async () => {
+    const { writeFile } = await import('node:fs/promises')
+    const { continuationStatePath } = await import('./continuation-state')
+    const { mkdir } = await import('node:fs/promises')
+    const { dirname } = await import('node:path')
+    const path = continuationStatePath(agentDir, SCOPE)
+    await mkdir(dirname(path), { recursive: true })
+    // valid JSON, but episode is missing its numeric counters
+    await writeFile(path, JSON.stringify({ version: 1, state: { episode: { episodeId: 'e' } } }), 'utf8')
+    const loaded = await readContinuationState(agentDir, SCOPE)
+    expect(loaded.episode).toBeNull()
+  })
 })
 
 describe('onTurnStart', () => {

--- a/src/agent/todo/continuation-state.test.ts
+++ b/src/agent/todo/continuation-state.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  type ContinuationEpisode,
+  type ContinuationState,
+  emptyContinuationState,
+  type TurnOutcome,
+} from './continuation-policy'
+import {
+  armRestartKickSuppression,
+  consumeRestartKickSuppression,
+  onTurnOutcome,
+  onTurnStart,
+  readContinuationState,
+  writeContinuationState,
+} from './continuation-state'
+import type { TodoScope } from './scope'
+
+const SCOPE: TodoScope = { kind: 'tui', key: 'tui' }
+
+const EPISODE: ContinuationEpisode = {
+  episodeId: 'e1',
+  startedAt: 100,
+  autoTurnCount: 2,
+  cumulativeTokens: 5000,
+  failureCount: 0,
+  stagnationCount: 1,
+  lastIncompleteHash: 'abc',
+}
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-cont-state-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('continuation-state persistence', () => {
+  test('reading a non-existent scope returns the empty state', async () => {
+    expect(await readContinuationState(agentDir, SCOPE)).toEqual(emptyContinuationState())
+  })
+
+  test('write then read round-trips and survives a simulated restart', async () => {
+    const state: ContinuationState = {
+      episode: EPISODE,
+      lastTurnOutcome: { turnId: 't', stopReason: 'stop', endedAt: 1 },
+      suppressNextIdleNudgeReason: null,
+      autoResumeBlockedUntilRealUserTurn: false,
+    }
+    await writeContinuationState(agentDir, SCOPE, state)
+    expect(await readContinuationState(agentDir, SCOPE)).toEqual(state)
+  })
+
+  test('corrupt state file falls back to empty (fail-closed)', async () => {
+    await writeContinuationState(agentDir, SCOPE, emptyContinuationState())
+    const { writeFile } = await import('node:fs/promises')
+    const { continuationStatePath } = await import('./continuation-state')
+    await writeFile(continuationStatePath(agentDir, SCOPE), 'not json{{', 'utf8')
+    expect(await readContinuationState(agentDir, SCOPE)).toEqual(emptyContinuationState())
+  })
+})
+
+describe('onTurnStart', () => {
+  test('a real user turn resets the episode and clears suppressors', () => {
+    const state: ContinuationState = {
+      episode: EPISODE,
+      lastTurnOutcome: null,
+      suppressNextIdleNudgeReason: 'restart-kick',
+      autoResumeBlockedUntilRealUserTurn: true,
+    }
+    const next = onTurnStart(state, true)
+    expect(next.episode).toBeNull()
+    expect(next.suppressNextIdleNudgeReason).toBeNull()
+    expect(next.autoResumeBlockedUntilRealUserTurn).toBe(false)
+  })
+
+  test('an injected (non-user) turn does NOT reset the episode budget', () => {
+    const state: ContinuationState = { ...emptyContinuationState(), episode: EPISODE }
+    expect(onTurnStart(state, false)).toBe(state)
+  })
+})
+
+describe('onTurnOutcome', () => {
+  test('records the outcome', () => {
+    const outcome: TurnOutcome = { turnId: 't', stopReason: 'stop', endedAt: 9 }
+    expect(onTurnOutcome(emptyContinuationState(), outcome).lastTurnOutcome).toEqual(outcome)
+  })
+
+  test('a user abort arms the durable suppressor', () => {
+    const outcome: TurnOutcome = { turnId: 't', stopReason: 'aborted', endedAt: 9 }
+    const next = onTurnOutcome(emptyContinuationState(), outcome)
+    expect(next.autoResumeBlockedUntilRealUserTurn).toBe(true)
+  })
+
+  test('a normal stop does not arm the suppressor', () => {
+    const outcome: TurnOutcome = { turnId: 't', stopReason: 'stop', endedAt: 9 }
+    expect(onTurnOutcome(emptyContinuationState(), outcome).autoResumeBlockedUntilRealUserTurn).toBe(false)
+  })
+})
+
+describe('restart-kick suppression', () => {
+  test('arm then consume is a one-shot', () => {
+    const armed = armRestartKickSuppression(emptyContinuationState())
+    expect(armed.suppressNextIdleNudgeReason).toBe('restart-kick')
+    const consumed = consumeRestartKickSuppression(armed)
+    expect(consumed.suppressNextIdleNudgeReason).toBeNull()
+  })
+})

--- a/src/agent/todo/continuation-state.ts
+++ b/src/agent/todo/continuation-state.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+import { type ContinuationState, emptyContinuationState, type TurnOutcome } from './continuation-policy'
+import type { TodoScope } from './scope'
+import { todoDir } from './store'
+
+type StateFile = {
+  version: 1
+  state: ContinuationState
+}
+
+export function continuationStatePath(agentDir: string, scope: TodoScope): string {
+  return join(todoDir(agentDir), '.state', `${scope.key}.json`)
+}
+
+export async function readContinuationState(agentDir: string, scope: TodoScope): Promise<ContinuationState> {
+  const path = continuationStatePath(agentDir, scope)
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch (err) {
+    if (isEnoent(err)) return emptyContinuationState()
+    throw err
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<StateFile>
+    return parsed.state ?? emptyContinuationState()
+  } catch {
+    return emptyContinuationState()
+  }
+}
+
+export async function writeContinuationState(
+  agentDir: string,
+  scope: TodoScope,
+  state: ContinuationState,
+): Promise<void> {
+  const path = continuationStatePath(agentDir, scope)
+  const payload: StateFile = { version: 1, state }
+  await mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.${process.pid}.${randomUUID()}.tmp`
+  await writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
+  await rename(tmp, path)
+}
+
+// A real user turn ends any active continuation episode and clears both
+// suppressors. This is the ONLY thing that resets the episode budget — the
+// runtime's own injected continuation prompts must not. Callers pass `false`
+// for injected prompts so the episode budget keeps counting down.
+export function onTurnStart(state: ContinuationState, isRealUserTurn: boolean): ContinuationState {
+  if (!isRealUserTurn) return state
+  return {
+    ...state,
+    episode: null,
+    autoResumeBlockedUntilRealUserTurn: false,
+    suppressNextIdleNudgeReason: null,
+  }
+}
+
+// Record the most recently completed turn's outcome. Explicit user abort also
+// arms the durable suppressor so no auto-continuation fires until a real user
+// turn clears it (policy D1).
+export function onTurnOutcome(state: ContinuationState, outcome: TurnOutcome): ContinuationState {
+  const next: ContinuationState = { ...state, lastTurnOutcome: outcome }
+  if (outcome.stopReason === 'aborted') next.autoResumeBlockedUntilRealUserTurn = true
+  return next
+}
+
+export function armRestartKickSuppression(state: ContinuationState): ContinuationState {
+  return { ...state, suppressNextIdleNudgeReason: 'restart-kick' }
+}
+
+export function consumeRestartKickSuppression(state: ContinuationState): ContinuationState {
+  if (state.suppressNextIdleNudgeReason === null) return state
+  return { ...state, suppressNextIdleNudgeReason: null }
+}
+
+function isEnoent(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === 'ENOENT'
+}

--- a/src/agent/todo/continuation-state.ts
+++ b/src/agent/todo/continuation-state.ts
@@ -2,7 +2,12 @@ import { randomUUID } from 'node:crypto'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
-import { type ContinuationState, emptyContinuationState, type TurnOutcome } from './continuation-policy'
+import {
+  type ContinuationState,
+  emptyContinuationState,
+  parseContinuationState,
+  type TurnOutcome,
+} from './continuation-policy'
 import type { TodoScope } from './scope'
 import { todoDir } from './store'
 
@@ -26,7 +31,7 @@ export async function readContinuationState(agentDir: string, scope: TodoScope):
   }
   try {
     const parsed = JSON.parse(raw) as Partial<StateFile>
-    return parsed.state ?? emptyContinuationState()
+    return parseContinuationState(parsed.state)
   } catch {
     return emptyContinuationState()
   }

--- a/src/agent/todo/continuation-wiring.test.ts
+++ b/src/agent/todo/continuation-wiring.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { SessionOrigin } from '@/agent/session-origin'
+
+import { readContinuationState } from './continuation-state'
+import {
+  classifyStopReason,
+  extractStopReason,
+  recordTurnOutcome,
+  recordTurnStart,
+  runIdleContinuation,
+} from './continuation-wiring'
+import { resolveTodoScope } from './scope'
+import { writeTodos } from './store'
+
+const TUI: SessionOrigin = { kind: 'tui', sessionId: 'ses_x' }
+const SCOPE = resolveTodoScope(TUI)!
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-cont-wiring-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('classifyStopReason', () => {
+  test('passes through known reasons and collapses the rest to unknown', () => {
+    expect(classifyStopReason('stop')).toBe('stop')
+    expect(classifyStopReason('aborted')).toBe('aborted')
+    expect(classifyStopReason('error')).toBe('error')
+    expect(classifyStopReason('tool_calls')).toBe('unknown')
+    expect(classifyStopReason(undefined)).toBe('unknown')
+  })
+})
+
+describe('extractStopReason', () => {
+  test('reads stopReason from an assistant message_end event', () => {
+    expect(extractStopReason({ type: 'message_end', message: { role: 'assistant', stopReason: 'aborted' } })).toBe(
+      'aborted',
+    )
+  })
+
+  test('ignores non-message_end events', () => {
+    expect(extractStopReason({ type: 'text_delta' })).toBeNull()
+  })
+})
+
+describe('recordTurnOutcome / recordTurnStart', () => {
+  test('records the outcome and a user abort arms the durable suppressor', async () => {
+    await recordTurnOutcome({ agentDir, origin: TUI, turnId: 't1', stopReason: 'aborted' })
+    const state = await readContinuationState(agentDir, SCOPE)
+    expect(state.lastTurnOutcome?.stopReason).toBe('aborted')
+    expect(state.autoResumeBlockedUntilRealUserTurn).toBe(true)
+  })
+
+  test('a real user turn clears the abort suppressor; an injected turn does not', async () => {
+    await recordTurnOutcome({ agentDir, origin: TUI, turnId: 't1', stopReason: 'aborted' })
+    await recordTurnStart({ agentDir, origin: TUI, isRealUserTurn: false })
+    expect((await readContinuationState(agentDir, SCOPE)).autoResumeBlockedUntilRealUserTurn).toBe(true)
+    await recordTurnStart({ agentDir, origin: TUI, isRealUserTurn: true })
+    expect((await readContinuationState(agentDir, SCOPE)).autoResumeBlockedUntilRealUserTurn).toBe(false)
+  })
+
+  test('scopeless origins are a no-op', async () => {
+    const origin: SessionOrigin = { kind: 'subagent', subagent: 's', parentSessionId: 'p' }
+    await recordTurnOutcome({ agentDir, origin, turnId: 't', stopReason: 'stop' })
+    await recordTurnStart({ agentDir, origin, isRealUserTurn: true })
+    // nothing thrown, nothing written
+    expect(true).toBe(true)
+  })
+})
+
+describe('runIdleContinuation', () => {
+  test('delivers the nudge when work remains after a safe turn', async () => {
+    await writeTodos(agentDir, SCOPE, [{ content: 'task', status: 'pending' }])
+    await recordTurnOutcome({ agentDir, origin: TUI, turnId: 't1', stopReason: 'stop' })
+    let delivered: string | null = null
+    const ok = await runIdleContinuation({ agentDir, origin: TUI, deliver: (t) => (delivered = t) })
+    expect(ok).toBe(true)
+    expect(delivered).not.toBeNull()
+  })
+
+  test('does not deliver after a user abort', async () => {
+    await writeTodos(agentDir, SCOPE, [{ content: 'task', status: 'pending' }])
+    await recordTurnOutcome({ agentDir, origin: TUI, turnId: 't1', stopReason: 'aborted' })
+    let delivered = false
+    const ok = await runIdleContinuation({ agentDir, origin: TUI, deliver: () => (delivered = true) })
+    expect(ok).toBe(false)
+    expect(delivered).toBe(false)
+  })
+})

--- a/src/agent/todo/continuation-wiring.ts
+++ b/src/agent/todo/continuation-wiring.ts
@@ -13,13 +13,24 @@ export function classifyStopReason(raw: unknown): TurnOutcome['stopReason'] {
   return 'unknown'
 }
 
-export function extractStopReason(event: unknown): TurnOutcome['stopReason'] | null {
+// Extract the stopReason and token usage from a pi `message_end` event.
+// Returns null for any event that is not an assistant message_end. `tokens`
+// comes from the assistant message's `usage.totalTokens`; it is undefined when
+// the provider did not report usage.
+export function extractTurnUsage(event: unknown): { stopReason: TurnOutcome['stopReason']; tokens?: number } | null {
   if (typeof event !== 'object' || event === null) return null
   const e = event as { type?: unknown; message?: unknown }
   if (e.type !== 'message_end') return null
-  const message = e.message as { role?: unknown; stopReason?: unknown } | undefined
+  const message = e.message as { role?: unknown; stopReason?: unknown; usage?: unknown } | undefined
   if (message?.role !== 'assistant') return null
-  return classifyStopReason(message.stopReason)
+  const usage = message.usage as { totalTokens?: unknown } | undefined
+  const total = usage?.totalTokens
+  const tokens = typeof total === 'number' && Number.isFinite(total) ? total : undefined
+  return { stopReason: classifyStopReason(message.stopReason), ...(tokens !== undefined ? { tokens } : {}) }
+}
+
+export function extractStopReason(event: unknown): TurnOutcome['stopReason'] | null {
+  return extractTurnUsage(event)?.stopReason ?? null
 }
 
 // Persist the just-completed turn's outcome for a scope. No-op for origins
@@ -30,12 +41,18 @@ export async function recordTurnOutcome(args: {
   origin: SessionOrigin
   turnId: string
   stopReason: TurnOutcome['stopReason']
+  tokens?: number
   now?: number
 }): Promise<void> {
   const scope = resolveTodoScope(args.origin)
   if (scope === null) return
   const state = await readContinuationState(args.agentDir, scope)
-  const outcome: TurnOutcome = { turnId: args.turnId, stopReason: args.stopReason, endedAt: args.now ?? Date.now() }
+  const outcome: TurnOutcome = {
+    turnId: args.turnId,
+    stopReason: args.stopReason,
+    endedAt: args.now ?? Date.now(),
+    ...(args.tokens !== undefined ? { tokens: args.tokens } : {}),
+  }
   await writeContinuationState(args.agentDir, scope, onTurnOutcome(state, outcome))
 }
 

--- a/src/agent/todo/continuation-wiring.ts
+++ b/src/agent/todo/continuation-wiring.ts
@@ -1,0 +1,72 @@
+import type { SessionOrigin } from '@/agent/session-origin'
+
+import { maybeInjectContinuation } from './continuation'
+import { type TurnOutcome } from './continuation-policy'
+import { onTurnOutcome, onTurnStart, readContinuationState, writeContinuationState } from './continuation-state'
+import { resolveTodoScope } from './scope'
+
+// Map a pi `message_end` event's stopReason onto the TurnOutcome stopReason
+// space. Anything we don't recognize collapses to 'unknown' so the idle path
+// fails closed (no auto-injection on an outcome we can't classify).
+export function classifyStopReason(raw: unknown): TurnOutcome['stopReason'] {
+  if (raw === 'stop' || raw === 'aborted' || raw === 'error') return raw
+  return 'unknown'
+}
+
+export function extractStopReason(event: unknown): TurnOutcome['stopReason'] | null {
+  if (typeof event !== 'object' || event === null) return null
+  const e = event as { type?: unknown; message?: unknown }
+  if (e.type !== 'message_end') return null
+  const message = e.message as { role?: unknown; stopReason?: unknown } | undefined
+  if (message?.role !== 'assistant') return null
+  return classifyStopReason(message.stopReason)
+}
+
+// Persist the just-completed turn's outcome for a scope. No-op for origins
+// without a todo scope (subagent/system). Safe to call from a subscription
+// callback; it swallows nothing — callers wrap as they see fit.
+export async function recordTurnOutcome(args: {
+  agentDir: string
+  origin: SessionOrigin
+  turnId: string
+  stopReason: TurnOutcome['stopReason']
+  now?: number
+}): Promise<void> {
+  const scope = resolveTodoScope(args.origin)
+  if (scope === null) return
+  const state = await readContinuationState(args.agentDir, scope)
+  const outcome: TurnOutcome = { turnId: args.turnId, stopReason: args.stopReason, endedAt: args.now ?? Date.now() }
+  await writeContinuationState(args.agentDir, scope, onTurnOutcome(state, outcome))
+}
+
+// Reset the continuation episode at the start of a REAL user turn. Injected
+// continuation turns pass isRealUserTurn=false so the episode budget keeps
+// counting down. No-op for scopeless origins.
+export async function recordTurnStart(args: {
+  agentDir: string
+  origin: SessionOrigin
+  isRealUserTurn: boolean
+}): Promise<void> {
+  const scope = resolveTodoScope(args.origin)
+  if (scope === null) return
+  const state = await readContinuationState(args.agentDir, scope)
+  const next = onTurnStart(state, args.isRealUserTurn)
+  if (next !== state) await writeContinuationState(args.agentDir, scope, next)
+}
+
+export type DeliverContinuation = (text: string) => void
+
+// Idle-path entry: decide whether to nudge and, if so, deliver via the
+// origin-appropriate mechanism the caller supplies. Returns true if a nudge
+// was delivered. The decide-and-persist step happens inside
+// maybeInjectContinuation; delivery is the only side effect the caller owns.
+export async function runIdleContinuation(args: {
+  agentDir: string
+  origin: SessionOrigin
+  deliver: DeliverContinuation
+}): Promise<boolean> {
+  const result = await maybeInjectContinuation({ agentDir: args.agentDir, origin: args.origin })
+  if (result.kind !== 'injected') return false
+  args.deliver(result.text)
+  return true
+}

--- a/src/agent/todo/continuation.test.ts
+++ b/src/agent/todo/continuation.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { SessionOrigin } from '@/agent/session-origin'
+
+import { CONTINUATION_PROMPT, maybeInjectContinuation } from './continuation'
+import { DEFAULT_CONTINUATION_LIMITS } from './continuation-policy'
+import {
+  armRestartKickSuppression,
+  onTurnOutcome,
+  readContinuationState,
+  writeContinuationState,
+} from './continuation-state'
+import { resolveTodoScope } from './scope'
+import { writeTodos } from './store'
+
+const TUI: SessionOrigin = { kind: 'tui', sessionId: 'ses_x' }
+const SCOPE = resolveTodoScope(TUI)!
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-cont-inject-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+async function seedSafeOutcome() {
+  await writeContinuationState(
+    agentDir,
+    SCOPE,
+    onTurnOutcome(await readContinuationState(agentDir, SCOPE), { turnId: 't', stopReason: 'stop', endedAt: 1 }),
+  )
+}
+
+describe('maybeInjectContinuation', () => {
+  test('injects the continuation prompt when incomplete todos remain after a safe turn', async () => {
+    await writeTodos(agentDir, SCOPE, [{ content: 'task', status: 'pending' }])
+    await seedSafeOutcome()
+    const res = await maybeInjectContinuation({ agentDir, origin: TUI, newEpisodeId: () => 'ep1' })
+    expect(res.kind).toBe('injected')
+    if (res.kind === 'injected') expect(res.text).toBe(CONTINUATION_PROMPT)
+    const state = await readContinuationState(agentDir, SCOPE)
+    expect(state.episode?.autoTurnCount).toBe(1)
+  })
+
+  test('skips when no incomplete todos', async () => {
+    await writeTodos(agentDir, SCOPE, [{ content: 'done', status: 'completed' }])
+    await seedSafeOutcome()
+    const res = await maybeInjectContinuation({ agentDir, origin: TUI })
+    expect(res).toEqual({ kind: 'skipped', reason: 'no-incomplete-todos' })
+  })
+
+  test('subagent origin is a no-op', async () => {
+    const origin: SessionOrigin = { kind: 'subagent', subagent: 'scout', parentSessionId: 'p' }
+    const res = await maybeInjectContinuation({ agentDir, origin })
+    expect(res).toEqual({ kind: 'skipped', reason: 'no-scope' })
+  })
+
+  test('the restart-kick one-shot suppresses exactly one idle then clears', async () => {
+    await writeTodos(agentDir, SCOPE, [{ content: 'task', status: 'pending' }])
+    await seedSafeOutcome()
+    await writeContinuationState(
+      agentDir,
+      SCOPE,
+      armRestartKickSuppression(await readContinuationState(agentDir, SCOPE)),
+    )
+
+    const first = await maybeInjectContinuation({ agentDir, origin: TUI })
+    expect(first).toEqual({ kind: 'skipped', reason: 'restart-kick-suppressed' })
+    expect((await readContinuationState(agentDir, SCOPE)).suppressNextIdleNudgeReason).toBeNull()
+
+    const second = await maybeInjectContinuation({ agentDir, origin: TUI, newEpisodeId: () => 'ep2' })
+    expect(second.kind).toBe('injected')
+  })
+
+  test('stagnation caps injections when the incomplete set never shrinks', async () => {
+    await writeTodos(agentDir, SCOPE, [{ content: 'task', status: 'pending' }])
+    await seedSafeOutcome()
+
+    const results: string[] = []
+    for (let i = 0; i < 5; i++) {
+      const res = await maybeInjectContinuation({ agentDir, origin: TUI, newEpisodeId: () => 'ep-fixed' })
+      results.push(res.kind)
+    }
+    // Identical todos every idle → stagnation (limit 2) trips before the turn
+    // ceiling (3). Exactly two injections, then permanently skipped.
+    const injected = results.filter((r) => r === 'injected').length
+    expect(injected).toBe(DEFAULT_CONTINUATION_LIMITS.stagnationLimit)
+    expect(results.at(-1)).toBe('skipped')
+  })
+
+  test('the turn ceiling caps useless-but-changing work (no real progress)', async () => {
+    await seedSafeOutcome()
+    const results: string[] = []
+    // Each idle the model rewords the SAME single incomplete item: the hash
+    // changes (no stagnation) but the incomplete count never shrinks. The
+    // max-auto-turns ceiling is what must bound this useless-success loop.
+    for (let i = 0; i < DEFAULT_CONTINUATION_LIMITS.maxAutoTurns + 2; i++) {
+      await writeTodos(agentDir, SCOPE, [{ content: `reworded variant ${i}`, status: 'pending' }])
+      const res = await maybeInjectContinuation({ agentDir, origin: TUI, newEpisodeId: () => 'ep-fixed' })
+      results.push(res.kind)
+    }
+    const injected = results.filter((r) => r === 'injected').length
+    expect(injected).toBe(DEFAULT_CONTINUATION_LIMITS.maxAutoTurns)
+    expect(results.at(-1)).toBe('skipped')
+  })
+
+  test('does not inject after an explicit user abort', async () => {
+    await writeTodos(agentDir, SCOPE, [{ content: 'task', status: 'pending' }])
+    await writeContinuationState(
+      agentDir,
+      SCOPE,
+      onTurnOutcome(await readContinuationState(agentDir, SCOPE), { turnId: 't', stopReason: 'aborted', endedAt: 1 }),
+    )
+    const res = await maybeInjectContinuation({ agentDir, origin: TUI })
+    expect(res).toEqual({ kind: 'skipped', reason: 'user-abort-blocked' })
+  })
+
+  test('budget persists across a simulated restart and stays capped', async () => {
+    await writeTodos(agentDir, SCOPE, [{ content: 'task', status: 'pending' }])
+    await seedSafeOutcome()
+    for (let i = 0; i < 4; i++) {
+      await maybeInjectContinuation({ agentDir, origin: TUI, newEpisodeId: () => 'ep-fixed' })
+    }
+    const beforeRestart = await readContinuationState(agentDir, SCOPE)
+    expect(beforeRestart.episode).not.toBeNull()
+
+    // Simulate restart: the next call reads guard state purely from disk. With
+    // an unchanged incomplete set the cap (stagnation) must still hold — the
+    // budget is not reset by a process boundary.
+    const res = await maybeInjectContinuation({ agentDir, origin: TUI, newEpisodeId: () => 'ep-restart' })
+    expect(res.kind).toBe('skipped')
+  })
+})

--- a/src/agent/todo/continuation.ts
+++ b/src/agent/todo/continuation.ts
@@ -1,0 +1,71 @@
+import type { SessionOrigin } from '@/agent/session-origin'
+
+import { type ContinuationLimits, DEFAULT_CONTINUATION_LIMITS, decideContinuation } from './continuation-policy'
+import { consumeRestartKickSuppression, readContinuationState, writeContinuationState } from './continuation-state'
+import { resolveTodoScope, type TodoScope } from './scope'
+import { readTodos } from './store'
+
+export const TODO_CONTINUATION_SOURCE = 'todo-continuation'
+
+export const CONTINUATION_PROMPT = [
+  '---',
+  '**[SYSTEM MESSAGE — not from a human]**',
+  '',
+  'Incomplete todo items remain in your list. Continue working on the next',
+  'pending item now, without asking for permission. Mark each item complete (or',
+  'cancelled) as you finish it by calling `todo_write` with the updated list. If',
+  'you believe all the work is already done, do not just assert it — re-examine',
+  'each remaining item skeptically, verify the work actually landed, and update',
+  'the list accordingly. When everything is genuinely complete, call',
+  '`todo_clear`. Do not acknowledge or reply to this notice; just continue the',
+  'work.',
+  '',
+  '---',
+  '',
+].join('\n')
+
+export type ContinuationInjectResult =
+  | { kind: 'injected'; scope: TodoScope; text: string }
+  | { kind: 'skipped'; reason: string }
+
+export type MaybeInjectContinuationArgs = {
+  agentDir: string
+  origin: SessionOrigin | undefined
+  now?: number
+  limits?: ContinuationLimits
+  newEpisodeId?: () => string
+}
+
+// Decide-and-persist entry point called from the idle path of each origin's
+// drain loop. On `injected`, the caller is responsible for actually delivering
+// `text` into the session (TUI: stream.publish; channel: pendingSystemReminders
+// + drain). The episode mutation is persisted BEFORE returning so a crash
+// between persist and deliver can only UNDER-count (fail-safe: a missed
+// delivery costs one wasted budget slot, never an unbounded loop).
+//
+// The restart-kick one-shot is consumed here even on skip, so the first
+// post-restart idle always burns the suppressor exactly once.
+export async function maybeInjectContinuation(args: MaybeInjectContinuationArgs): Promise<ContinuationInjectResult> {
+  if (args.origin === undefined) return { kind: 'skipped', reason: 'no-origin' }
+  const scope = resolveTodoScope(args.origin)
+  if (scope === null) return { kind: 'skipped', reason: 'no-scope' }
+
+  const now = args.now ?? Date.now()
+  const limits = args.limits ?? DEFAULT_CONTINUATION_LIMITS
+  const newEpisodeId = args.newEpisodeId ?? (() => crypto.randomUUID())
+
+  const todos = await readTodos(args.agentDir, scope)
+  const state = await readContinuationState(args.agentDir, scope)
+
+  const decision = decideContinuation({ state, todos, limits, now, newEpisodeId })
+
+  if (decision.kind === 'skip') {
+    if (state.suppressNextIdleNudgeReason !== null) {
+      await writeContinuationState(args.agentDir, scope, consumeRestartKickSuppression(state))
+    }
+    return { kind: 'skipped', reason: decision.reason }
+  }
+
+  await writeContinuationState(args.agentDir, scope, { ...state, episode: decision.episode })
+  return { kind: 'injected', scope, text: CONTINUATION_PROMPT }
+}

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -7,6 +7,12 @@ import { createSession, renderTurnRoleAnchor, renderTurnTimeAnchor, type AgentSe
 import { subscribeProviderErrors } from '@/agent/provider-error'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
+import {
+  extractStopReason,
+  recordTurnOutcome,
+  recordTurnStart,
+  runIdleContinuation,
+} from '@/agent/todo/continuation-wiring'
 import { type Command, type CommandPermission, type CommandResult, createCommandRegistry } from '@/commands'
 import { CORE_PERMISSIONS, type PermissionService } from '@/permissions'
 import type { HookBus } from '@/plugin'
@@ -474,6 +480,7 @@ type LiveSession = {
   destroyed: boolean
   unsubProviderErrors: (() => void) | null
   unsubTypingActivity: (() => void) | null
+  unsubTodoOutcome: (() => void) | null
 }
 
 // `event` is null for command invocations that originated outside the inbound
@@ -1213,9 +1220,20 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         destroyed: false,
         unsubProviderErrors: null,
         unsubTypingActivity: null,
+        unsubTodoOutcome: null,
       }
       live.unsubProviderErrors = subscribeProviderErrors(created.session, (err) => {
         logger.error(`[channels] ${live.keyId}: LLM call failed: ${err.message}`)
+      })
+      live.unsubTodoOutcome = created.session.subscribe((event: unknown) => {
+        const stopReason = extractStopReason(event)
+        if (stopReason === null) return
+        void recordTurnOutcome({
+          agentDir: options.agentDir,
+          origin: buildLiveOrigin(live),
+          turnId: live.sessionId,
+          stopReason,
+        }).catch((err) => logger.error(`[channels] ${live.keyId}: todo outcome capture failed: ${describe(err)}`))
       })
       live.unsubTypingActivity = subscribeTypingActivity(created.session, live)
       installChannelReplyTerminalHook(live)
@@ -1505,6 +1523,36 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
+  const recordTodoTurnStart = async (live: LiveSession, isRealUserTurn: boolean): Promise<void> => {
+    try {
+      await recordTurnStart({ agentDir: options.agentDir, origin: buildLiveOrigin(live), isRealUserTurn })
+    } catch (err) {
+      logger.warn(`[channels] ${live.keyId}: todo turn-start failed: ${describe(err)}`)
+    }
+  }
+
+  // After the drain queue empties, push at most one continuation reminder into
+  // pendingSystemReminders. The enclosing drain `while` re-checks that array,
+  // so the reminder is picked up as a batch-empty (injected, non-user) turn in
+  // the same drain pass. The episode guard bounds how many times this can
+  // re-fire; a reminder-only turn records isRealUserTurn=false so it never
+  // resets the budget.
+  const maybeContinueTodosChannel = async (live: LiveSession): Promise<void> => {
+    if (live.destroyed) return
+    if (live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0) return
+    try {
+      await runIdleContinuation({
+        agentDir: options.agentDir,
+        origin: buildLiveOrigin(live),
+        deliver: (text) => {
+          live.pendingSystemReminders.push(text)
+        },
+      })
+    } catch (err) {
+      logger.warn(`[channels] ${live.keyId}: todo continuation failed: ${describe(err)}`)
+    }
+  }
+
   const fireSessionTurnStart = async (live: LiveSession, userPrompt: string): Promise<void> => {
     if (!live.hooks) return
     try {
@@ -1649,6 +1697,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.turnSeq++
         live.successfulSendsAtTurnStart = successfulSendsBeforePrompt
         live.policyDeniedToolSendsThisTurn.clear()
+        const isRealUserTurn = batch.length > 0
         await fireSessionTurnStart(live, text)
         try {
           await live.session.prompt(text)
@@ -1665,6 +1714,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           await fireSessionTurnEnd(live)
         }
         await fireSessionIdle(live)
+        await recordTodoTurnStart(live, isRealUserTurn)
+        await maybeContinueTodosChannel(live)
         live.lastTurnAuthorIds = new Set(live.currentTurnAuthorIds)
         if (live.currentTurnAuthorId !== null) {
           live.lastTurnAuthorId = live.currentTurnAuthorId
@@ -2695,6 +2746,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.unsubProviderErrors = null
     live.unsubTypingActivity?.()
     live.unsubTypingActivity = null
+    live.unsubTodoOutcome?.()
+    live.unsubTodoOutcome = null
     await stopTypingHeartbeat(live)
     try {
       await live.session.abort()

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -8,7 +8,7 @@ import { subscribeProviderErrors } from '@/agent/provider-error'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
 import {
-  extractStopReason,
+  extractTurnUsage,
   recordTurnOutcome,
   recordTurnStart,
   runIdleContinuation,
@@ -1226,13 +1226,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         logger.error(`[channels] ${live.keyId}: LLM call failed: ${err.message}`)
       })
       live.unsubTodoOutcome = created.session.subscribe((event: unknown) => {
-        const stopReason = extractStopReason(event)
-        if (stopReason === null) return
+        const usage = extractTurnUsage(event)
+        if (usage === null) return
         void recordTurnOutcome({
           agentDir: options.agentDir,
           origin: buildLiveOrigin(live),
           turnId: live.sessionId,
-          stopReason,
+          stopReason: usage.stopReason,
+          ...(usage.tokens !== undefined ? { tokens: usage.tokens } : {}),
         }).catch((err) => logger.error(`[channels] ${live.keyId}: todo outcome capture failed: ${describe(err)}`))
       })
       live.unsubTypingActivity = subscribeTypingActivity(created.session, live)

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -408,6 +408,46 @@ describe('createServer tool event forwarding', () => {
   })
 })
 
+describe('createServer todo continuation (drain re-entrancy)', () => {
+  test('consumes an idle continuation in the same drain pass instead of stalling', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'server-todo-cont-'))
+    const { writeTodos } = await import('@/agent/todo/store')
+    const { resolveTodoScope } = await import('@/agent/todo/scope')
+    const { recordTurnOutcome } = await import('@/agent/todo/continuation-wiring')
+    const origin = { kind: 'tui', sessionId: 'x' } as const
+    const scope = resolveTodoScope(origin)!
+    // Pre-seed an incomplete todo AND a safe (stop) turn outcome so the idle
+    // path is eligible to inject. This isolates the property under test — that
+    // the drain loop CONSUMES the continuation — from the async outcome-capture
+    // timing, which is exercised separately at the unit layer.
+    await writeTodos(agentDir, scope, [{ content: 'finish the work', status: 'pending' }])
+    await recordTurnOutcome({ agentDir, origin, turnId: 'seed', stopReason: 'stop' })
+
+    const session = createFakeSession()
+    const stream = createStream()
+    const { url } = await startWithSession(session, {
+      agentDir,
+      stream,
+      sessionFactory: createSessionFactory({ agentDir }),
+    })
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    ws.send(JSON.stringify({ type: 'prompt', text: 'do thing' }))
+    await waitForState(() => session.promptCalls.length === 1)
+    session.resolvePrompt()
+
+    // The continuation must be consumed by the SAME drain loop — a second
+    // prompt() call lands without any further user input. If the old
+    // publish-through-stream path were still in place, draining would already
+    // be true and this would hang until timeout.
+    await waitForState(() => session.promptCalls.length === 2, { timeoutMs: 2000 })
+    expect(session.promptCalls[1]).toContain('Incomplete todo items remain')
+    session.resolvePrompt()
+    ws.close()
+  })
+})
+
 describe('createServer abort handling (no stream — fallback path)', () => {
   test('client { type: "abort" } invokes session.abort()', async () => {
     const session = createFakeSession()

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,6 +17,13 @@ import { consumeRestartHandoff, type RestartHandoff } from '@/agent/restart-hand
 import type { SessionOrigin } from '@/agent/session-origin'
 import { parseSubagentCompletedPayload, renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
 import type { CreateSessionForSubagent } from '@/agent/subagents'
+import { TODO_CONTINUATION_SOURCE } from '@/agent/todo/continuation'
+import {
+  extractStopReason,
+  recordTurnOutcome,
+  recordTurnStart,
+  runIdleContinuation,
+} from '@/agent/todo/continuation-wiring'
 import type { ChannelRouter } from '@/channels/router'
 import { aggregateCronList, type CronListEntry, loadCron } from '@/cron'
 import type { McpManager } from '@/mcp'
@@ -155,6 +162,7 @@ type QueuedPrompt = {
   text: string
   delivery: PromptDelivery
   ts: number
+  source?: string
 }
 
 type SessionState = {
@@ -172,6 +180,7 @@ type SessionState = {
   // generation that ran session.start. A plugin reload mid-connection does
   // not re-target this session's lifecycle hooks.
   runtimeSnapshot: PluginRuntimeState | null
+  unsubTurnOutcome: Unsubscribe | null
   dispose: () => Promise<void>
 }
 
@@ -497,6 +506,7 @@ export function createServer({
               unsubClaim: null,
               activeClaimCode: null,
               runtimeSnapshot: runtimeSnapshot ?? null,
+              unsubTurnOutcome: null,
               dispose,
             }
             sessionStates.set(ws, state)
@@ -505,12 +515,16 @@ export function createServer({
               await runtimeSnapshot.hooks.runSessionStart({ sessionId: sessionFileId, agentDir })
             }
 
+            if (agentDir !== undefined) {
+              state.unsubTurnOutcome = subscribeTurnOutcome(session, agentDir, origin, sessionFileId, logger)
+            }
+
             liveSessionRegistry?.register({ sessionId: sessionFileId, session })
             forwardSessionEvents(ws, session, logger, sessionFileId)
 
             if (stream) {
               state.unsubPrompts = stream.subscribe({ target: { kind: 'session', sessionId: sessionFileId } }, (msg) =>
-                enqueuePrompt(ws, state, msg, agentDir, logger),
+                enqueuePrompt(ws, state, msg, agentDir, logger, stream),
               )
 
               state.unsubBroadcast = stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => {
@@ -798,6 +812,7 @@ export function createServer({
             }
           } finally {
             if (state) {
+              state.unsubTurnOutcome?.()
               state.session.dispose()
               await state.dispose()
               liveSessionRegistry?.unregister(state.sessionFileId)
@@ -867,6 +882,27 @@ function forwardSessionEvents(ws: Ws, session: AgentSession, logger: ServerLogge
   })
 }
 
+// Record each completed turn's stopReason for the todo-continuation guard.
+// Ordering-independent by design: this writes the outcome from `message_end`,
+// and the idle path only reads the stored outcome — it never assumes the
+// event arrived before idle fired. An unrecognized stopReason classifies as
+// 'unknown', which the idle path treats as not-safe-to-continue (fail closed).
+function subscribeTurnOutcome(
+  session: AgentSession,
+  agentDir: string,
+  origin: SessionOrigin,
+  sessionFileId: string,
+  logger: ServerLogger,
+): Unsubscribe {
+  return session.subscribe((event) => {
+    const stopReason = extractStopReason(event)
+    if (stopReason === null) return
+    void recordTurnOutcome({ agentDir, origin, turnId: sessionFileId, stopReason }).catch((err) =>
+      logger.error(`[server] ${sessionFileId}: todo outcome capture failed: ${describeErr(err)}`),
+    )
+  })
+}
+
 function forwardAssistantError(ws: Ws, message: unknown, logger: ServerLogger, sessionFileId: string): void {
   const detected = detectProviderError(message)
   if (detected === null) return
@@ -895,6 +931,7 @@ function enqueuePrompt(
   msg: StreamMessage,
   agentDir: string | undefined,
   logger: ServerLogger,
+  stream: Stream | undefined,
 ): void {
   const payload = msg.payload as { kind?: string; text?: string; delivery?: PromptDelivery }
   if (payload?.kind !== 'prompt' || typeof payload.text !== 'string') return
@@ -904,14 +941,16 @@ function enqueuePrompt(
       send(ws, { type: 'error', message: err instanceof Error ? err.message : String(err) })
     })
   }
+  const source = (msg.meta as { source?: unknown } | undefined)?.source
   state.drainQueue.push({
     streamMessageId: msg.id,
     text: payload.text,
     delivery,
     ts: msg.ts,
+    ...(typeof source === 'string' ? { source } : {}),
   })
   pushQueueState(ws, state)
-  void drain(ws, state, agentDir, logger)
+  void drain(ws, state, agentDir, logger, stream)
 }
 
 // `session.idle` semantically means "the agent finished a prompt and is now
@@ -948,7 +987,13 @@ function makeTurnHookCallers(
   }
 }
 
-async function drain(ws: Ws, state: SessionState, agentDir: string | undefined, logger: ServerLogger): Promise<void> {
+async function drain(
+  ws: Ws,
+  state: SessionState,
+  agentDir: string | undefined,
+  logger: ServerLogger,
+  stream: Stream | undefined,
+): Promise<void> {
   if (state.draining) return
   state.draining = true
   const fireIdle = makeIdleHookCaller(state)
@@ -959,6 +1004,14 @@ async function drain(ws: Ws, state: SessionState, agentDir: string | undefined, 
       if (!item) break
       pushQueueState(ws, state)
       send(ws, { type: 'prompt_started', messageId: item.streamMessageId, text: item.text })
+
+      if (agentDir !== undefined) {
+        await recordTurnStart({
+          agentDir,
+          origin: state.origin,
+          isRealUserTurn: item.source !== TODO_CONTINUATION_SOURCE,
+        }).catch((err) => logger.error(`[server] ${state.sessionFileId}: todo turn-start failed: ${describeErr(err)}`))
+      }
 
       await fireTurnStart(item.text)
       try {
@@ -972,9 +1025,45 @@ async function drain(ws: Ws, state: SessionState, agentDir: string | undefined, 
       await fireTurnEnd()
       await fireIdle()
     }
+    await maybeContinueTodos(state, agentDir, logger, stream)
   } finally {
     state.draining = false
   }
+}
+
+// After the drain queue empties, if incomplete todos remain and all guards
+// pass, publish a single continuation prompt back into this session. It
+// re-enters the same queue tagged with TODO_CONTINUATION_SOURCE so the next
+// drain treats it as an injected (non-user) turn and does not reset the
+// episode budget. Delivered as 'queue' (the session is idle here, so there is
+// no in-flight turn to interrupt).
+async function maybeContinueTodos(
+  state: SessionState,
+  agentDir: string | undefined,
+  logger: ServerLogger,
+  stream: Stream | undefined,
+): Promise<void> {
+  if (agentDir === undefined || stream === undefined) return
+  if (state.drainQueue.length > 0) return
+  try {
+    await runIdleContinuation({
+      agentDir,
+      origin: state.origin,
+      deliver: (text) => {
+        stream.publish({
+          target: { kind: 'session', sessionId: state.sessionFileId },
+          payload: { kind: 'prompt', text, delivery: 'queue' },
+          meta: { source: TODO_CONTINUATION_SOURCE },
+        })
+      },
+    })
+  } catch (err) {
+    logger.error(`[server] ${state.sessionFileId}: todo continuation failed: ${describeErr(err)}`)
+  }
+}
+
+function describeErr(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }
 
 function pushQueueState(ws: Ws, state: SessionState): void {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,7 +19,7 @@ import { parseSubagentCompletedPayload, renderSubagentCompletionReminder } from 
 import type { CreateSessionForSubagent } from '@/agent/subagents'
 import { TODO_CONTINUATION_SOURCE } from '@/agent/todo/continuation'
 import {
-  extractStopReason,
+  extractTurnUsage,
   recordTurnOutcome,
   recordTurnStart,
   runIdleContinuation,
@@ -895,11 +895,15 @@ function subscribeTurnOutcome(
   logger: ServerLogger,
 ): Unsubscribe {
   return session.subscribe((event) => {
-    const stopReason = extractStopReason(event)
-    if (stopReason === null) return
-    void recordTurnOutcome({ agentDir, origin, turnId: sessionFileId, stopReason }).catch((err) =>
-      logger.error(`[server] ${sessionFileId}: todo outcome capture failed: ${describeErr(err)}`),
-    )
+    const usage = extractTurnUsage(event)
+    if (usage === null) return
+    void recordTurnOutcome({
+      agentDir,
+      origin,
+      turnId: sessionFileId,
+      stopReason: usage.stopReason,
+      ...(usage.tokens !== undefined ? { tokens: usage.tokens } : {}),
+    }).catch((err) => logger.error(`[server] ${sessionFileId}: todo outcome capture failed: ${describeErr(err)}`))
   })
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1024,36 +1024,45 @@ async function drain(
       }
       await fireTurnEnd()
       await fireIdle()
+
+      // Idle-continuation runs INSIDE the loop and enqueues directly onto
+      // drainQueue (not via stream.publish). Publishing would re-enter drain()
+      // through the session subscriber while `state.draining` is still true, so
+      // the nested call would no-op and the continuation would stall until some
+      // unrelated event woke the loop again. Enqueuing here lets the same `while`
+      // consume it on the next iteration. Only fires when the queue is otherwise
+      // empty so a real user turn is never preempted by a continuation.
+      if (state.drainQueue.length === 0) {
+        await maybeContinueTodos(state, agentDir, logger)
+      }
     }
-    await maybeContinueTodos(state, agentDir, logger, stream)
   } finally {
     state.draining = false
   }
 }
 
-// After the drain queue empties, if incomplete todos remain and all guards
-// pass, publish a single continuation prompt back into this session. It
-// re-enters the same queue tagged with TODO_CONTINUATION_SOURCE so the next
-// drain treats it as an injected (non-user) turn and does not reset the
-// episode budget. Delivered as 'queue' (the session is idle here, so there is
-// no in-flight turn to interrupt).
+// If incomplete todos remain and all guards pass, push a single continuation
+// prompt directly onto this session's drainQueue, tagged TODO_CONTINUATION_SOURCE
+// so the next drain iteration treats it as an injected (non-user) turn that does
+// not reset the episode budget. The enclosing drain loop consumes it; this never
+// calls drain() itself.
 async function maybeContinueTodos(
   state: SessionState,
   agentDir: string | undefined,
   logger: ServerLogger,
-  stream: Stream | undefined,
 ): Promise<void> {
-  if (agentDir === undefined || stream === undefined) return
-  if (state.drainQueue.length > 0) return
+  if (agentDir === undefined) return
   try {
     await runIdleContinuation({
       agentDir,
       origin: state.origin,
       deliver: (text) => {
-        stream.publish({
-          target: { kind: 'session', sessionId: state.sessionFileId },
-          payload: { kind: 'prompt', text, delivery: 'queue' },
-          meta: { source: TODO_CONTINUATION_SOURCE },
+        state.drainQueue.push({
+          streamMessageId: `todo-continuation-${crypto.randomUUID()}` as StreamMessageId,
+          text,
+          delivery: 'queue',
+          ts: Date.now(),
+          source: TODO_CONTINUATION_SOURCE,
         })
       },
     })


### PR DESCRIPTION
## What

Second of three stacked PRs. **Stacked on #585** (base: `feat/todo-storage`). Adds the core auto-continuation injector: when a session goes idle with incomplete todos, inject a single continuation prompt back into the session so long-running work is not silently dropped. The injector is **core** (plugins cannot inject) and runs on the idle boundary of both the TUI drain loop and the channel router.

> Review note: the diff for this PR is cleanest read against `feat/todo-storage`. If GitHub shows #585's commits too, that's the stacking.

## Token-burst safety (the primary design constraint)

This was reviewed by a separate reasoning pass before implementation. All guards are persisted per-scope under `todo/.state/<scope>.json` so they survive a restart (a crash-loop cannot reset a ceiling):

- **Episode model** — the budget unit. Opens on the first auto-nudge after a real user turn; resets **only** on the next real user turn, never on the runtime's own injected prompts.
- **Hard ceilings** — 3 auto-turns, 25k tokens, 30 min wall-clock per episode.
- **Stagnation cap (limit 2)** — stop when the canonicalized incomplete-todo hash is unchanged. The hash is a *stagnation heuristic only*; real progress (incomplete count shrinking) is what resets it, so text churn cannot fake progress or reset hard budgets.
- **Soft abort (D1)** — turn outcomes are captured **ordering-independently** from `message_end` and read by the idle path. Explicit user abort (`stopReason: 'aborted'`) arms a durable suppressor; auto-continuation never resumes an explicit abort, only non-user drops (restart/crash). Fail closed on unknown/missing outcome.
- **Restart handshake** — an edge-triggered one-shot flag (not a wall-clock window) lets the #291 restart kick own the first post-restart idle. (Consumed in PR 3.)

## Structure

- `continuation-policy.ts` — pure decision function (`decideContinuation`) + episode model + canonical hashing + real-progress test.
- `continuation-state.ts` — atomic per-scope persistence + state mutators (turn-start reset, outcome capture, restart-kick one-shot).
- `continuation.ts` — `maybeInjectContinuation` decide-and-persist entry point.
- `continuation-wiring.ts` — origin-agnostic helpers (stopReason extract/classify, record outcome, record turn-start, runIdleContinuation).
- Wiring into `src/server/index.ts` (TUI drain + stream.publish delivery) and `src/channels/router.ts` (channel idle + pendingSystemReminders delivery).

## Tests

Behavior-level: happy-path injection, no-incomplete skip, subagent no-op, restart-kick one-shot, stagnation cap, useless-success turn-ceiling, user-abort no-resume, budget-persists-across-restart, ordering-independent outcome capture. Full suite green except one pre-existing worktree-path artifact unrelated to this change.

## Commits (split for review)

1. policy + persisted guard state
2. injector + origin wiring helpers
3. wire into the two drain loops

## Follow-up

- **PR 3** — cause-specific integration: subagent-failure wording, restart-handoff suppression flag consumption, cron carry-forward policy, `todo/` durability + backup/gitignore wiring.