### PR TITLE
todo: cause-specific recovery integration — restart, subagent, cron, durability (3/3)

### DIFF
--- a/src/agent/subagent-completion-reminder.test.ts
+++ b/src/agent/subagent-completion-reminder.test.ts
@@ -34,6 +34,7 @@ describe('renderSubagentCompletionReminder', () => {
     expect(text).toContain('FAILED')
     expect(text).toContain('provider rate limit')
     expect(text).toContain('subagent_output')
+    expect(text).toContain('todo_write')
   })
 
   test('ok=false without error string falls back to "unknown error"', () => {

--- a/src/agent/subagent-completion-reminder.ts
+++ b/src/agent/subagent-completion-reminder.ts
@@ -43,7 +43,9 @@ export function renderSubagentCompletionReminder(args: CompletionReminderArgs): 
   return (
     `<system-reminder>\n` +
     `Subagent \`${args.subagent}\` (${args.taskId}) FAILED after ${durationStr}: ${err}. ` +
-    `Use subagent_output to inspect.${channelTail}\n` +
+    `Use subagent_output to inspect. If this work was tracked in your todo list, ` +
+    `keep the item pending (or add a recovery item) via todo_write so it is not ` +
+    `dropped.${channelTail}\n` +
     `</system-reminder>`
   )
 }

--- a/src/agent/todo/continuation-wiring.test.ts
+++ b/src/agent/todo/continuation-wiring.test.ts
@@ -7,14 +7,16 @@ import type { SessionOrigin } from '@/agent/session-origin'
 
 import { readContinuationState } from './continuation-state'
 import {
+  armRestartKickForOrigin,
   classifyStopReason,
+  clearTodosForOrigin,
   extractStopReason,
   recordTurnOutcome,
   recordTurnStart,
   runIdleContinuation,
 } from './continuation-wiring'
 import { resolveTodoScope } from './scope'
-import { writeTodos } from './store'
+import { readTodos, writeTodos } from './store'
 
 const TUI: SessionOrigin = { kind: 'tui', sessionId: 'ses_x' }
 const SCOPE = resolveTodoScope(TUI)!
@@ -93,5 +95,25 @@ describe('runIdleContinuation', () => {
     const ok = await runIdleContinuation({ agentDir, origin: TUI, deliver: () => (delivered = true) })
     expect(ok).toBe(false)
     expect(delivered).toBe(false)
+  })
+
+  test('clearTodosForOrigin empties a scope (cron per-fire reset)', async () => {
+    const cron: SessionOrigin = { kind: 'cron', jobId: 'daily', jobKind: 'prompt' }
+    const cronScope = resolveTodoScope(cron)!
+    await writeTodos(agentDir, cronScope, [{ content: 'leftover', status: 'pending' }])
+    await clearTodosForOrigin(agentDir, cron)
+    expect(await readTodos(agentDir, cronScope)).toEqual([])
+  })
+
+  test('an armed restart-kick suppresses the first post-restart idle', async () => {
+    await writeTodos(agentDir, SCOPE, [{ content: 'task', status: 'pending' }])
+    await recordTurnOutcome({ agentDir, origin: TUI, turnId: 't1', stopReason: 'stop' })
+    await armRestartKickForOrigin(agentDir, TUI)
+    let count = 0
+    const first = await runIdleContinuation({ agentDir, origin: TUI, deliver: () => count++ })
+    expect(first).toBe(false)
+    const second = await runIdleContinuation({ agentDir, origin: TUI, deliver: () => count++ })
+    expect(second).toBe(true)
+    expect(count).toBe(1)
   })
 })

--- a/src/agent/todo/continuation-wiring.ts
+++ b/src/agent/todo/continuation-wiring.ts
@@ -2,8 +2,15 @@ import type { SessionOrigin } from '@/agent/session-origin'
 
 import { maybeInjectContinuation } from './continuation'
 import { type TurnOutcome } from './continuation-policy'
-import { onTurnOutcome, onTurnStart, readContinuationState, writeContinuationState } from './continuation-state'
+import {
+  armRestartKickSuppression,
+  onTurnOutcome,
+  onTurnStart,
+  readContinuationState,
+  writeContinuationState,
+} from './continuation-state'
 import { resolveTodoScope } from './scope'
+import { writeTodos } from './store'
 
 // Map a pi `message_end` event's stopReason onto the TurnOutcome stopReason
 // space. Anything we don't recognize collapses to 'unknown' so the idle path
@@ -52,6 +59,23 @@ export async function recordTurnStart(args: {
   const state = await readContinuationState(args.agentDir, scope)
   const next = onTurnStart(state, args.isRealUserTurn)
   if (next !== state) await writeContinuationState(args.agentDir, scope, next)
+}
+
+// Arm the one-shot restart-kick suppressor for an origin's scope, so the first
+// idle after a restart skips exactly one continuation injection (the restart
+// kick prompt owns that turn). No-op for scopeless origins.
+export async function armRestartKickForOrigin(agentDir: string, origin: SessionOrigin): Promise<void> {
+  const scope = resolveTodoScope(origin)
+  if (scope === null) return
+  const state = await readContinuationState(agentDir, scope)
+  await writeContinuationState(agentDir, scope, armRestartKickSuppression(state))
+}
+
+// Empty the todo list for an origin's scope. No-op for scopeless origins.
+export async function clearTodosForOrigin(agentDir: string, origin: SessionOrigin): Promise<void> {
+  const scope = resolveTodoScope(origin)
+  if (scope === null) return
+  await writeTodos(agentDir, scope, [])
 }
 
 export type DeliverContinuation = (text: string) => void

--- a/src/bundled-plugins/backup/runner.test.ts
+++ b/src/bundled-plugins/backup/runner.test.ts
@@ -94,6 +94,27 @@ describe('runBackup', () => {
     expect(addF?.args).toEqual(['add', '-f', '--', 'sessions/a.jsonl'])
   })
 
+  test('force-adds todo/ paths so continuation state survives across restarts', async () => {
+    const cwd = await makeRepo()
+    await mkdir(join(cwd, 'todo'))
+    await writeFile(join(cwd, 'todo', 'tui.json'), '{}')
+    const status = '?? todo/tui.json\n M src/foo.ts\n'
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(status)
+      if (args[0] === 'add' && args[1] === '--') return okResult()
+      if (args[0] === 'add' && args[1] === '-f') return okResult()
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[2] === '--stat') return okResult('foo.ts | 1 +')
+      if (args[0] === 'commit') return okResult()
+      if (args[0] === 'rev-parse') return failResult('no upstream', 128)
+      return okResult()
+    })
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
+    expect(result).toEqual({ ok: true, kind: 'committed' })
+    const addF = calls.find((c) => c.args[0] === 'add' && c.args[1] === '-f')
+    expect(addF?.args).toEqual(['add', '-f', '--', 'todo/tui.json'])
+  })
+
   test('re-stages sessions/ paths that appeared during pickCommitMessage', async () => {
     // given: pickCommitMessage simulates spawning a `backup-message` subagent
     // that writes a NEW session JSONL into sessions/ after the initial status.

--- a/src/bundled-plugins/backup/runner.ts
+++ b/src/bundled-plugins/backup/runner.ts
@@ -5,7 +5,7 @@ export const COMMIT_TIMEOUT_MS = 30_000
 export const NETWORK_TIMEOUT_MS = 60_000
 
 const RUNTIME_OWNED_PREFIXES = ['memory/'] as const
-const FORCE_ADD_PREFIXES = ['sessions/'] as const
+const FORCE_ADD_PREFIXES = ['sessions/', 'todo/'] as const
 
 const NONINTERACTIVE_ENV = {
   GIT_TERMINAL_PROMPT: '0',

--- a/src/init/gitignore.ts
+++ b/src/init/gitignore.ts
@@ -37,11 +37,13 @@ Dockerfile
 .DS_Store
 
 # System-managed: gitignored by default so the agent never stages them by hand,
-# but TypeClaw force-commits them on its own schedule (sessions/ via auto-backup,
-# memory/ via the dreaming subagent). Treat them as runtime-owned, not agent-owned.
+# but TypeClaw force-commits them on its own schedule (sessions/ + todo/ via
+# auto-backup, memory/ via the dreaming subagent). Treat them as runtime-owned,
+# not agent-owned.
 sessions/
 memory/
 channels/
+todo/
 `
 }
 

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -16,6 +16,7 @@ import {
   type SubagentRegistry,
   type SubagentShared,
 } from '@/agent/subagents'
+import { clearTodosForOrigin } from '@/agent/todo/continuation-wiring'
 import { resolveCapOptionsFromConfig } from '@/bundled-plugins/tool-result-cap'
 import {
   createChannelManager,
@@ -434,6 +435,13 @@ export async function startAgent({
         // marker so the audit trail records "user edited cron.json".
         scheduledByOrigin: (job.scheduledByOrigin as SessionOrigin | undefined) ?? { kind: 'config-file' },
       }
+      // Cron todos are per-fire ephemeral by default: each scheduled run starts
+      // with a clean list so an incomplete item from a prior fire cannot
+      // resurrect indefinitely on every tick. (A future opt-in could carry them
+      // forward; until then, clearing is the safe default.)
+      await clearTodosForOrigin(cwd, cronOrigin).catch((err) =>
+        console.error(`[cron] ${job.id}: clear todos failed: ${err instanceof Error ? err.message : String(err)}`),
+      )
       const session = await createSession({
         reloadRegistry,
         sessionManager,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,6 +19,7 @@ import { parseSubagentCompletedPayload, renderSubagentCompletionReminder } from 
 import type { CreateSessionForSubagent } from '@/agent/subagents'
 import { TODO_CONTINUATION_SOURCE } from '@/agent/todo/continuation'
 import {
+  armRestartKickForOrigin,
   extractStopReason,
   recordTurnOutcome,
   recordTurnStart,
@@ -557,6 +558,17 @@ export function createServer({
             // wired (state.unsubPrompts above) so the kick is enqueued, not
             // dropped on the floor.
             if (resumed !== null && stream) {
+              // Arm the one-shot restart-kick suppressor BEFORE publishing the
+              // kick: the kick owns the first post-restart turn ("I'm back"),
+              // so the first idle after it must not also fire a todo
+              // continuation. The flag is consumed by that first idle. Best-
+              // effort: a failure here only risks one redundant nudge, which
+              // the episode budget still bounds.
+              if (agentDir !== undefined) {
+                await armRestartKickForOrigin(agentDir, origin).catch((err) =>
+                  logger.error(`[server] ${sessionFileId}: arm restart-kick suppression failed: ${describeErr(err)}`),
+                )
+              }
               stream.publish({
                 target: { kind: 'session', sessionId: sessionFileId },
                 payload: { kind: 'prompt', text: ' ', delivery: 'queue' },


### PR DESCRIPTION
## What

Final of three stacked PRs. **Stacked on #590** (base: `feat/todo-continuation-injector`). Connects the existing cause-specific paths to the todo primitive and makes `todo/` durable. The continuation engine (#590) handled the generic idle case; this PR handles the three motivating causes.

> Review note: cleanest read against `feat/todo-continuation-injector`.

## Changes (one concern per commit)

1. **Durability** — `todo/` is gitignored and force-added by the backup runner, so per-scope todo lists + continuation guard state survive restart and land in the same auto-backup commit as `sessions/`.
2. **Restart-kick origin helpers** — `armRestartKickForOrigin` / `clearTodosForOrigin` (origin-aware, no-op for scopeless).
3. **Restart double-nudge handshake (#291)** — on TUI handoff resume, arm the one-shot suppressor before the "I'm back" kick so the first post-restart idle does not also fire a continuation.
4. **Subagent-failure recovery** — the failed-subagent completion reminder now nudges the model to keep the related todo item pending (or add a recovery item) via `todo_write`, so the idle injector becomes the backup recovery path for dropped subagent work.
5. **Cron carry-forward policy** — cron todos are per-fire ephemeral by default: each scheduled run starts with a clean list so an incomplete item cannot resurrect on every tick. (Carry-forward can be a future opt-in.)

## Use-case coverage (all three now wired)

| Use case | Mechanism |
|---|---|
| Subagent silently fails | existing completion broadcast surfaces it; reminder now steers the model to keep the todo pending → idle injector resumes it |
| Restart handoff (#291) | same-session resume + kick prompt owns the first turn; suppressor prevents a double nudge; kick wording resumes todos |
| Aborted turn | (handled in #590) soft-abort: preserved, never auto-resumed |

## Tests

`clearTodosForOrigin` cron reset, `armRestartKickForOrigin` one-shot suppression, `todo/` force-add in the backup runner, and the subagent-failure reminder mentioning `todo_write`. Full suite green except one pre-existing worktree-path artifact unrelated to this change.