### PR TITLE
channels: drop body-less github events, synthesize text where they carry signal

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -534,6 +534,15 @@ describe('classifyGithubInbound — empty-body handling', () => {
     expect(classifyGithubInbound('pull_request', payload, 'typeclaw-bot')).toBe(null)
   })
 
+  it('drops a non-opened issues action with an empty body (only issues.opened synthesizes a title)', () => {
+    const payload = {
+      action: 'edited',
+      repository: repo(),
+      issue: { number: 7, id: 700, title: 'Broken login', body: '', created_at: '2026-01-01T00:00:00Z', user: user() },
+    }
+    expect(classifyGithubInbound('issues', payload, 'typeclaw-bot')).toBe(null)
+  })
+
   it('still routes review_requested through the synthesized review trigger (not affected by the empty-body drop)', () => {
     const msg = classifyGithubInbound(
       'pull_request',

--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -409,6 +409,135 @@ describe('classifyGithubInbound', () => {
   })
 })
 
+describe('classifyGithubInbound — empty-body handling', () => {
+  it('drops a pull_request_review_comment with an empty body', () => {
+    const payload = reviewCommentPayload()
+    ;(payload.comment as Record<string, unknown>).body = ''
+    expect(classifyGithubInbound('pull_request_review_comment', payload, 'typeclaw-bot')).toBe(null)
+  })
+
+  it('drops an issue_comment with a whitespace-only body', () => {
+    const payload = issueCommentPayload({ pullRequest: true })
+    ;(payload.comment as Record<string, unknown>).body = '   \n  '
+    expect(classifyGithubInbound('issue_comment', payload, 'typeclaw-bot')).toBe(null)
+  })
+
+  describe('pull_request_review.submitted with empty body', () => {
+    const reviewSubmitted = (state: string, body = ''): Record<string, unknown> => ({
+      action: 'submitted',
+      repository: repo(),
+      pull_request: { number: 7, id: 700, title: 'Add the thing', user: user() },
+      review: { id: 5002, body, state, submitted_at: '2026-01-01T00:00:00Z', user: user() },
+    })
+
+    it('synthesizes neutral text from an APPROVED state', () => {
+      const msg = classifyGithubInbound('pull_request_review', reviewSubmitted('approved'), 'typeclaw-bot')
+      expect(msg?.text).toBe('@alice approved PR #7: "Add the thing".')
+      expect(msg?.isBotMention).toBe(false)
+    })
+
+    it('synthesizes neutral text from a CHANGES_REQUESTED state', () => {
+      const msg = classifyGithubInbound('pull_request_review', reviewSubmitted('changes_requested'), 'typeclaw-bot')
+      expect(msg?.text).toBe('@alice requested changes on PR #7: "Add the thing".')
+    })
+
+    it('synthesizes neutral text for a body-less COMMENTED review without implying a review was requested', () => {
+      const msg = classifyGithubInbound('pull_request_review', reviewSubmitted('commented'), 'typeclaw-bot')
+      expect(msg?.text).toBe('@alice submitted a review on PR #7: "Add the thing".')
+      expect(msg?.text).not.toContain('Please review')
+    })
+
+    it('keeps the real body when the review has one', () => {
+      const msg = classifyGithubInbound(
+        'pull_request_review',
+        reviewSubmitted('commented', 'looks good'),
+        'typeclaw-bot',
+      )
+      expect(msg?.text).toBe('looks good')
+    })
+  })
+
+  describe('body-less opened events synthesize a title line', () => {
+    it('issues.opened with no body', () => {
+      const payload = {
+        action: 'opened',
+        repository: repo(),
+        issue: {
+          number: 7,
+          id: 700,
+          title: 'Broken login',
+          body: '',
+          created_at: '2026-01-01T00:00:00Z',
+          user: user(),
+        },
+      }
+      const msg = classifyGithubInbound('issues', payload, 'typeclaw-bot')
+      expect(msg?.text).toBe('@alice opened issue #7: "Broken login".')
+      expect(msg?.isBotMention).toBe(false)
+    })
+
+    it('pull_request.opened with no body (awareness fallthrough, reviewOn defaults to review_requested)', () => {
+      const payload = {
+        action: 'opened',
+        repository: repo(),
+        pull_request: {
+          number: 7,
+          id: 700,
+          title: 'Add the thing',
+          body: '',
+          created_at: '2026-01-01T00:00:00Z',
+          user: user(),
+        },
+      }
+      const msg = classifyGithubInbound('pull_request', payload, 'typeclaw-bot')
+      expect(msg?.text).toBe('@alice opened PR #7: "Add the thing".')
+    })
+
+    it('discussion.created with no body', () => {
+      const payload = {
+        action: 'created',
+        repository: repo(),
+        discussion: {
+          number: 7,
+          id: 700,
+          title: 'RFC: caching',
+          body: '',
+          created_at: '2026-01-01T00:00:00Z',
+          user: user(),
+        },
+      }
+      const msg = classifyGithubInbound('discussion', payload, 'typeclaw-bot')
+      expect(msg?.text).toBe('@alice opened discussion #7: "RFC: caching".')
+    })
+  })
+
+  it('drops a non-opened pull_request action with an empty body (e.g. edited)', () => {
+    const payload = {
+      action: 'edited',
+      repository: repo(),
+      pull_request: {
+        number: 7,
+        id: 700,
+        title: 'Add the thing',
+        body: '',
+        created_at: '2026-01-01T00:00:00Z',
+        user: user(),
+      },
+    }
+    expect(classifyGithubInbound('pull_request', payload, 'typeclaw-bot')).toBe(null)
+  })
+
+  it('still routes review_requested through the synthesized review trigger (not affected by the empty-body drop)', () => {
+    const msg = classifyGithubInbound(
+      'pull_request',
+      reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot' }),
+      'typeclaw-bot',
+    )
+    expect(msg?.isBotMention).toBe(true)
+    expect(msg?.text).toContain('requested your review on PR #7')
+  })
+})
+
 describe('createGithubWebhookHandler — review.on wiring', () => {
   const baseOptions = (routed: InboundMessage[], reviewOn?: () => 'review_requested' | 'opened' | 'off') => ({
     webhookSecret: 'secret',

--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -431,26 +431,33 @@ describe('classifyGithubInbound — empty-body handling', () => {
     })
 
     it('synthesizes neutral text from an APPROVED state', () => {
-      const msg = classifyGithubInbound('pull_request_review', reviewSubmitted('approved'), 'typeclaw-bot')
+      const msg = classifyGithubInbound('pull_request_review', reviewSubmitted('APPROVED'), 'typeclaw-bot')
       expect(msg?.text).toBe('@alice approved PR #7: "Add the thing".')
       expect(msg?.isBotMention).toBe(false)
     })
 
     it('synthesizes neutral text from a CHANGES_REQUESTED state', () => {
-      const msg = classifyGithubInbound('pull_request_review', reviewSubmitted('changes_requested'), 'typeclaw-bot')
+      const msg = classifyGithubInbound('pull_request_review', reviewSubmitted('CHANGES_REQUESTED'), 'typeclaw-bot')
       expect(msg?.text).toBe('@alice requested changes on PR #7: "Add the thing".')
     })
 
     it('synthesizes neutral text for a body-less COMMENTED review without implying a review was requested', () => {
-      const msg = classifyGithubInbound('pull_request_review', reviewSubmitted('commented'), 'typeclaw-bot')
+      const msg = classifyGithubInbound('pull_request_review', reviewSubmitted('COMMENTED'), 'typeclaw-bot')
       expect(msg?.text).toBe('@alice submitted a review on PR #7: "Add the thing".')
       expect(msg?.text).not.toContain('Please review')
+    })
+
+    it('matches the state case-insensitively (REST returns uppercase, some payloads lowercase)', () => {
+      const upper = classifyGithubInbound('pull_request_review', reviewSubmitted('APPROVED'), 'typeclaw-bot')
+      const lower = classifyGithubInbound('pull_request_review', reviewSubmitted('approved'), 'typeclaw-bot')
+      expect(lower?.text).toBe(upper?.text)
+      expect(lower?.text).toBe('@alice approved PR #7: "Add the thing".')
     })
 
     it('keeps the real body when the review has one', () => {
       const msg = classifyGithubInbound(
         'pull_request_review',
-        reviewSubmitted('commented', 'looks good'),
+        reviewSubmitted('COMMENTED', 'looks good'),
         'typeclaw-bot',
       )
       expect(msg?.text).toBe('looks good')

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -258,14 +258,17 @@ export function classifyGithubInbound(
     const number = readNumber(issue, 'number')
     const id = readNumber(issue, 'id') ?? number
     if (number === null || id === null) return null
+    const opener = readUser(issue.user)
+    const hasBody = readString(issue, 'body')?.trim() ? true : false
     return buildInbound(
       { ...base, chat: `issue:${number}`, thread: null },
-      issue.body,
+      bodyOrOpenedTitle(issue.body, opener, 'issue', number, readString(issue, 'title')),
       id,
-      readUser(issue.user),
+      opener,
       selfLogin,
       issue.created_at,
       { kind: 'issue', owner: repository.owner, repo: repository.name, issueNumber: number },
+      !hasBody,
     )
   }
 
@@ -304,14 +307,19 @@ export function classifyGithubInbound(
       })
       if (trigger !== null) return trigger
     }
+    const opener = readUser(pr.user)
+    const hasBody = readString(pr, 'body')?.trim() ? true : false
+    const prText =
+      action === 'opened' ? bodyOrOpenedTitle(pr.body, opener, 'PR', number, readString(pr, 'title')) : pr.body
     return buildInbound(
       { ...base, chat: `pr:${number}`, thread: null },
-      pr.body,
+      prText,
       id,
-      readUser(pr.user),
+      opener,
       selfLogin,
       pr.created_at,
       { kind: 'issue', owner: repository.owner, repo: repository.name, issueNumber: number },
+      action === 'opened' && !hasBody,
     )
   }
 
@@ -322,14 +330,23 @@ export function classifyGithubInbound(
     const number = readNumber(pr, 'number')
     const id = readNumber(review, 'id')
     if (number === null || id === null) return null
+    const reviewer = readUser(review.user)
+    const body = readString(review, 'body')
+    const hasBody = body !== null && body.trim() !== ''
+    const text = hasBody
+      ? body
+      : reviewer !== null
+        ? synthesizeReviewStateText(reviewer.login, number, readString(pr, 'title'), readString(review, 'state'))
+        : ''
     return buildInbound(
       { ...base, chat: `pr:${number}`, thread: null },
-      review.body,
+      text,
       id,
-      readUser(review.user),
+      reviewer,
       selfLogin,
       review.submitted_at,
       null,
+      !hasBody,
     )
   }
 
@@ -339,14 +356,22 @@ export function classifyGithubInbound(
     const number = readNumber(discussion, 'number')
     const id = readNumber(discussion, 'id') ?? number
     if (number === null || id === null) return null
+    const action = readString(payload, 'action')
+    const opener = readUser(discussion.user)
+    const hasBody = readString(discussion, 'body')?.trim() ? true : false
+    const text =
+      action === 'created'
+        ? bodyOrOpenedTitle(discussion.body, opener, 'discussion', number, readString(discussion, 'title'))
+        : discussion.body
     return buildInbound(
       { ...base, chat: `discussion:${number}`, thread: null },
-      discussion.body,
+      text,
       id,
-      readUser(discussion.user),
+      opener,
       selfLogin,
       discussion.created_at,
       null,
+      action === 'created' && !hasBody,
     )
   }
 
@@ -513,9 +538,21 @@ function buildInbound(
   selfLogin: string | null,
   rawTs: unknown,
   reactionTarget: GithubReactionTarget | null,
+  synthesizedAwareness = false,
 ): InboundMessage | null {
   if (user === null) return null
   const text = typeof rawText === 'string' ? rawText : ''
+  // A body-less inbound reaches engagement as contentless text; in a solo-human
+  // channel the fallback engages on it and the agent replies with a generic
+  // greeting. The other adapters drop empty text at their classifier — this is
+  // the matching guard. Events whose empty body still carries signal (review
+  // state, opened-PR/issue title) synthesize non-empty text upstream and so
+  // never reach this drop.
+  if (text.trim() === '') return null
+  // Synthesized awareness lines carry an `@author` prefix describing who acted;
+  // that handle is the author, never a third-party mention of the bot, so the
+  // body-text mention heuristic must not fire on it.
+  const isBotMention = !synthesizedAwareness && selfLogin !== null && text.includes(`@${selfLogin}`)
   return {
     ...key,
     text,
@@ -524,10 +561,38 @@ function buildInbound(
     authorId: String(user.id),
     authorName: user.login,
     authorIsBot: user.type === 'Bot',
-    isBotMention: selfLogin !== null && text.includes(`@${selfLogin}`),
+    isBotMention,
     replyToBotMessageId: null,
     ts: typeof rawTs === 'string' ? Date.parse(rawTs) || 0 : 0,
   }
+}
+
+function bodyOrOpenedTitle(
+  rawBody: unknown,
+  opener: GithubUser | null,
+  kind: 'issue' | 'PR' | 'discussion',
+  number: number,
+  title: string | null,
+): string {
+  const body = typeof rawBody === 'string' ? rawBody : ''
+  if (body.trim() !== '' || opener === null) return body
+  const label = title !== null && title.trim() !== '' ? `: "${title}"` : ''
+  return `@${opener.login} opened ${kind} #${number}${label}.`
+}
+
+// Neutral phrasing per review state — must never imply a review was requested
+// or that action is needed; a COMMENTED review in particular must not read as
+// "please review", which is the review-request path's wording.
+function synthesizeReviewStateText(
+  reviewer: string,
+  number: number,
+  title: string | null,
+  state: string | null,
+): string {
+  const label = title !== null && title.trim() !== '' ? `: "${title}"` : ''
+  const verb =
+    state === 'approved' ? 'approved' : state === 'changes_requested' ? 'requested changes on' : 'submitted a review on'
+  return `@${reviewer} ${verb} PR #${number}${label}.`
 }
 
 async function resolveTeamMembership(

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -590,8 +590,16 @@ function synthesizeReviewStateText(
   state: string | null,
 ): string {
   const label = title !== null && title.trim() !== '' ? `: "${title}"` : ''
+  // GitHub's pull_request_review webhook can send the state in either case
+  // depending on the source (webhook payload vs REST), so normalize before
+  // matching — an unmatched state would silently fall back to the neutral verb.
+  const normalized = state?.toLowerCase() ?? null
   const verb =
-    state === 'approved' ? 'approved' : state === 'changes_requested' ? 'requested changes on' : 'submitted a review on'
+    normalized === 'approved'
+      ? 'approved'
+      : normalized === 'changes_requested'
+        ? 'requested changes on'
+        : 'submitted a review on'
   return `@${reviewer} ${verb} PR #${number}${label}.`
 }
 

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -258,17 +258,22 @@ export function classifyGithubInbound(
     const number = readNumber(issue, 'number')
     const id = readNumber(issue, 'id') ?? number
     if (number === null || id === null) return null
+    const action = readString(payload, 'action')
     const opener = readUser(issue.user)
     const hasBody = readString(issue, 'body')?.trim() ? true : false
+    const text =
+      action === 'opened'
+        ? bodyOrOpenedTitle(issue.body, opener, 'issue', number, readString(issue, 'title'))
+        : issue.body
     return buildInbound(
       { ...base, chat: `issue:${number}`, thread: null },
-      bodyOrOpenedTitle(issue.body, opener, 'issue', number, readString(issue, 'title')),
+      text,
       id,
       opener,
       selfLogin,
       issue.created_at,
       { kind: 'issue', owner: repository.owner, repo: repository.name, issueNumber: number },
-      !hasBody,
+      action === 'opened' && !hasBody,
     )
   }
 


### PR DESCRIPTION
## Problem

A github webhook event with an **empty body** wakes the agent into a contentless turn, and in a solo-human channel the engagement fallback engages on it — so the agent replies with a generic greeting instead of doing anything useful.

Observed in production on **#585**: at `18:05:28Z` `@devxoul` submitted a review with `state: COMMENTED` and an empty `body`. The github adapter classified it via `buildInbound`, which normalizes the empty body to `text: ''` and returns a valid `InboundMessage` (it only returns `null` when the author is missing). The PR thread had a single human participant, so `decideEngagement`'s solo-human fallback (`engagement.ts:197`) engaged on the empty message, and the model — seeing `@devxoul:` with nothing after it — posted:

> Hey there! I see you're in the PR #585 thread — anything you need me to review or help with?

### Root cause

`buildInbound` (`src/channels/adapters/github/inbound.ts`) had no empty-text guard. Every **other** adapter drops empty text at its classifier:

| Adapter | Guard |
|---|---|
| Slack | `slack-bot-classify.ts` → `drop: 'empty_text'` (exempts message-share attachments) |
| Discord | `discord-bot-classify.ts` → `drop: 'empty_content'` |
| Telegram | `telegram-bot-classify.ts` → `drop: 'empty_text'` |
| KakaoTalk | `kakaotalk-classify.ts` → `drop: 'empty_text'` |
| **GitHub** | **none** ← the gap |

## Fix

1. **Empty-text guard in `buildInbound`** — `if (text.trim() === '') return null`. Matches the other adapters; drops body-less comments that carry nothing.

2. **Synthesize text for empty-body events that still carry signal**, upstream of the guard, so they aren't lost:
   - `pull_request_review.submitted` → neutral per-state line: `@u approved PR #N: "title"` / `requested changes on` / `submitted a review on`. A body-less `COMMENTED` review deliberately does **not** read as "please review" (that wording belongs to the review-request path).
   - `issues.opened`, `pull_request.opened` (awareness fallthrough), `discussion.created` → `@u opened <kind> #N: "title"`.

3. Synthesized awareness lines carry an `@author` prefix that must not trip the body-text mention heuristic, so `buildInbound` takes a `synthesizedAwareness` flag that forces `isBotMention` false.

The review **request** path is untouched: `pull_request.review_requested` / `reviewOn:'opened'` return from `classifyReviewRequest` / `classifyOpenedReviewTrigger` before `buildInbound`, so they keep their synthesized "Please review the changes line-by-line" text and `isBotMention: true`.

## Scope note

This is orthogonal to #592 (which forbade self-authored / double PR reviews in the github skill). That bug lived in the review flow after a real review request; this one is upstream in adapter classification and never enters the review flow. #592 changed only `SKILL.md` and does not prevent this.

## Tests

Added a `classifyGithubInbound — empty-body handling` block:
- empty/whitespace comments → dropped
- body-less `pull_request_review.submitted` → synthesized neutral text per state (`approved` / `changes_requested` / `commented`); `COMMENTED` asserts it does **not** contain "Please review"; real body preserved
- body-less `issues.opened` / `pull_request.opened` / `discussion.created` → synthesized `opened <kind> #N: "title"`, `isBotMention: false`
- non-opened `pull_request` action (e.g. `edited`) with empty body → dropped
- `review_requested` still routes through the synthesized review trigger

## Checks

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check` all clean. Full suite: 6846 pass, 1 skip, 1 fail — the fail is the pre-existing, unrelated `resolveSelfPackageJsonPath > points at this package manifest` (asserts cwd ends in `typeclaw/`, fails only because the build ran from a `/tmp` worktree; untouched by this change). Channels suite alone: 1320 pass, 0 fail.