### PR TITLE
channels: stop leaked plain-text skip_response() from posting to channels

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2411,6 +2411,48 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('suppressed plain_text_channel_tool_call'))).toBe(true)
   })
 
+  test('suppresses leaked plain-text skip_response(...) serialization instead of posting it to the channel', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('skip_response({ reason: "Empty messages, no content to respond to" })')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('suppressed plain_text_channel_tool_call'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('still recovers prose that mentions skip_response in a non-call shape', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'how do you decline a turn?' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('I call the skip_response tool when there is nothing worth replying to.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('skip_response tool')
+    expect(logs.some((m) => m.includes('suppressed plain_text_channel_tool_call'))).toBe(false)
+  })
+
   test('still recovers prose that mentions channel_reply in a non-call shape', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3803,10 +3803,10 @@ export function isLikelyKimiChannelToolLeak(text: string): boolean {
   return KIMI_CHANNEL_TOOL_ID_RE.test(text)
 }
 
-// Detects the *plain-text* shape of a leaked channel-tool invocation — the
-// model serialized the tool call as ordinary prose instead of producing a
-// real tool call. Observed against Kimi-family deployments on KakaoTalk:
-// the entire assistant message body is literally
+// Detects the *plain-text* shape of a leaked tool invocation — the model
+// serialized a tool call as ordinary prose instead of producing a real tool
+// call. Observed against Kimi-family deployments on KakaoTalk: the entire
+// assistant message body is literally
 //
 //   channel_reply({"text":"<the user-facing greeting the bot meant to send>"})
 //
@@ -3816,18 +3816,27 @@ export function isLikelyKimiChannelToolLeak(text: string): boolean {
 // serialization straight to the channel, which is exactly what
 // users see in the reported screenshots.
 //
+// `skip_response` belongs here too, and is the more insidious case: the model
+// means to *decline* the turn but serializes the decision as prose —
+//
+//   skip_response({ reason: "Empty messages, no content to respond to" })
+//
+// Because the recovery path treats this as ordinary assistant text, the bot
+// posts its own "I'm staying silent" plumbing to the channel, the exact
+// opposite of the intended no-op. It is never a legitimate user-facing reply.
+//
 // Structural-only detection (NOT a substring search): the trimmed text must
-// *start* with `channel_reply(` or `channel_send(`, and that opening paren
-// must enclose at least one `"` (the JSON argument). This deliberately
-// matches the leak shape while letting prose that merely *mentions* the
-// tool name (e.g. "I would normally call channel_reply here but...") reach
-// the user — that false-positive class is already locked in by the
-// `still recovers legit prose that happens to mention "channel_reply"` test.
+// *start* with `channel_reply(`, `channel_send(`, or `skip_response(`, and
+// that opening paren must enclose at least one `"` (the serialized argument).
+// This deliberately matches the leak shape while letting prose that merely
+// *mentions* a tool name (e.g. "I would normally call channel_reply here
+// but...") reach the user — that false-positive class is already locked in by
+// the `still recovers prose that mentions channel_reply` test.
 //
 // The trailing close paren is NOT required: the model sometimes truncates
 // mid-serialization, and a half-leaked `channel_reply({"text":"..."` is
 // just as user-hostile as the full shape.
-const PLAIN_TEXT_CHANNEL_TOOL_CALL_RE = /^channel_(?:reply|send)\s*\(\s*[^)]*"/
+const PLAIN_TEXT_CHANNEL_TOOL_CALL_RE = /^(?:channel_(?:reply|send)|skip_response)\s*\(\s*[^)]*"/
 
 export function isLikelyPlainTextChannelToolCall(text: string): boolean {
   return PLAIN_TEXT_CHANNEL_TOOL_CALL_RE.test(text.trim())


### PR DESCRIPTION
## What

When a model decides to decline a turn but serializes the decision as **prose** instead of issuing a real tool call —

```
skip_response({ reason: "Empty messages, no content to respond to" })
```

— `validateChannelTurn`'s recovery path treated it as ordinary assistant text and posted the plumbing straight to the channel. That's the exact opposite of the intended no-op: the bot announces its own silence machinery to the user. (Seen in the wild on PR #590.)

## Why it slipped through

The recovery path already suppresses leaked plain-text tool calls via `isLikelyPlainTextChannelToolCall`, but its regex only matched `channel_reply(` / `channel_send(`:

```ts
const PLAIN_TEXT_CHANNEL_TOOL_CALL_RE = /^channel_(?:reply|send)\s*\(\s*[^)]*"/
```

A plain-text `skip_response(` leak didn't match any guard (`endsWithNoReplySignal`, `isUpstreamEmptyResponseSentinel`, `isLikelyKimiChannelToolLeak`, `isLikelyPlainTextChannelToolCall`), so it fell through to the system-source recovery `send()`.

## Fix

Extend the alternation to also match `skip_response(`, keeping the same structural shape (leading tool name + an enclosed quote) so prose that merely *mentions* the tool — e.g. "I call the skip_response tool when…" — still reaches the user.

```ts
const PLAIN_TEXT_CHANNEL_TOOL_CALL_RE = /^(?:channel_(?:reply|send)|skip_response)\s*\(\s*[^)]*"/
```

## Tests

Two new behavior-level tests in `router.test.ts`, mirroring the existing channel_reply/channel_send leak tests:

- **suppresses** a plain-text `skip_response({ reason: "…" })` leak (0 sends, logs `suppressed plain_text_channel_tool_call`, no recovery send).
- **still recovers** prose that merely mentions `skip_response` in a non-call shape (1 send, no suppression) — guards the false-positive boundary.

Full `src/channels/router.test.ts` suite: 304 pass, 0 fail. `bun run typecheck`, `bun run lint` (0 errors), `bun run format` all clean.