### PR TITLE
channels: recover a contested reply instead of dropping it after skip_response

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1974,10 +1974,13 @@ describe('ChannelRouter channel-turn protocol', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
+    // The live tool send stays denied (commit-to-silence is binding for the
+    // live path). With no recoverable assistant text in the branch, the
+    // contested-skip fall-through finds nothing to surface, so nothing is sent.
     expect(sendResult?.ok).toBe(false)
     expect(sendResult?.ok === false ? sendResult.code : '').toBe('skip-locked')
     expect(sent).toHaveLength(0)
-    expect(logs.some((m) => m.includes('skipped_by_tool'))).toBe(true)
+    expect(logs.some((m) => m.includes('skip_contested_by_send'))).toBe(true)
   })
 
   test('skip_response: system-source sends (recovery, role-claim) bypass the skip lock', async () => {
@@ -2100,6 +2103,105 @@ describe('ChannelRouter channel-turn protocol', () => {
     await router.__testing!.flushDebounce(KEY)
     expect(turn2Result?.kind).toBe('recorded')
     expect(sent).toHaveLength(0)
+  })
+
+  test('skip_response then contested channel_reply: send stays denied but reply is recovered, not dropped', async () => {
+    // Regression for the production drop: the model called skip_response first,
+    // then changed its mind and called channel_reply. The send is denied
+    // skip-locked (commit-to-silence is binding for the live path), but the
+    // reply text must NOT be silently dropped — recovery posts it via system.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'please review again' }))
+    let sendResult: SendResult | undefined
+    sessions[0]!.onPrompt = async () => {
+      // given: silence-first skip, then a contested reply attempt
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'on second thought' })
+      sendResult = await router.send({
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        text: 'On it — reviewing now.',
+      })
+      sessions[0]!.setAssistantText('On it — reviewing now.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the live tool send is still denied skip-locked...
+    expect(sendResult?.ok).toBe(false)
+    expect(sendResult?.ok === false ? sendResult.code : '').toBe('skip-locked')
+    // ...but recovery surfaces the reply via a system-source send
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('On it — reviewing now.')
+    expect(logs.some((m) => m.includes('skip_contested_by_send'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(true)
+    expect(logs.some((m) => m.includes('skipped_by_tool'))).toBe(false)
+  })
+
+  test('skip_response then contested reply with NO_REPLY text: stays silent (recovery guards still apply)', async () => {
+    // A contested skip falls through to recovery, but recovery's existing
+    // NO_REPLY guard must still suppress: nothing user-facing to surface.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'anything to add?' }))
+    sessions[0]!.onPrompt = async () => {
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'nothing actionable' })
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'NO_REPLY' })
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('contested-skip flag does not leak: a clean skip-only turn after a contested turn still stays silent', async () => {
+    // Per-turn reset guard: the skipLockedSendTurn flag from a contested turn
+    // must not cause a later skip-only turn to bypass its short-circuit.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // turn 1: contested skip (recovers a reply)
+    await router.route(inbound({ text: 'first' }))
+    sessions[0]!.onPrompt = async () => {
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'changed mind' })
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'turn-1 reply' })
+      sessions[0]!.setAssistantText('turn-1 reply')
+    }
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent).toHaveLength(1)
+
+    // turn 2: clean skip-only — must short-circuit, no recovery, no leak
+    sessions[0]!.onPrompt = () => {
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'nothing to add' })
+      sessions[0]!.setAssistantText('this text should NOT be recovered')
+    }
+    await router.route(inbound({ text: 'second', externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(logs.some((m) => m.includes('skipped_by_tool'))).toBe(true)
   })
 
   test('policy-denial loop: repeated skip-locked sends (silence-first) abort the run instead of looping', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -457,9 +457,25 @@ type LiveSession = {
   // with the current `turnSeq`. Read at the top of `validateChannelTurn`:
   // if it matches the just-completed turn, recovery is skipped entirely
   // (no NO_REPLY check, no Kimi leak check, no assistant-text recovery).
-  // The model has explicitly opted out of this turn and we honor that
-  // unconditionally. `null` when no skip has been recorded.
+  // The model has explicitly opted out of this turn and we honor that —
+  // UNLESS the model also tried a tool-source send this turn (see
+  // `skipLockedSendTurn`), in which case the skip was contested and we let
+  // recovery run so the contested reply isn't silently dropped. `null` when
+  // no skip has been recorded.
   skippedTurn: { turnSeq: number; reason: string } | null
+  // Stamped by `send()` with the current `turnSeq` when a tool-source send is
+  // DENIED by the skip lock (the model called `skip_response` first, then
+  // changed its mind and tried `channel_reply`). The send still stays denied —
+  // "commit to silence" is binding for the live send path — but a contested
+  // skip must NOT also suppress the post-turn recovery net: the model produced
+  // user-facing reply text that the skip short-circuit would otherwise drop on
+  // the floor with no retry (the inbound is already drained). When this matches
+  // the just-completed turn, `validateChannelTurn` falls through to the normal
+  // `recoverableAssistantText` path, which posts the reply via `source:'system'`
+  // (subject to the existing NO_REPLY / leak guards). `null` when no skip-locked
+  // send was attempted. Compared by `turnSeq` so a stale value can't leak across
+  // turns.
+  skipLockedSendTurn: number | null
   // Captured by drain() at batch dequeue; read+cleared by send() on the
   // first tool-source send of the turn. The anchor decision (delay
   // threshold + intervening-observed check) is evaluated at SEND time
@@ -1226,6 +1242,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         inFlightToolSends: new Map(),
         policyDeniedToolSendsThisTurn: new Map(),
         skippedTurn: null,
+        skipLockedSendTurn: null,
         pendingQuoteCandidate: null,
         recentEngagedPeerBotTurns: [],
         consecutiveEngagedPeerBotTurns: 0,
@@ -1673,6 +1690,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const engageAddPromises = live.currentTurnEngageReactions
         live.turnSeq++
         live.successfulSendsAtTurnStart = successfulSendsBeforePrompt
+        live.skipLockedSendTurn = null
         live.policyDeniedToolSendsThisTurn.clear()
         await fireSessionTurnStart(live, text)
         try {
@@ -2518,7 +2536,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // violation: the model already committed to silence. Reject before any
       // state mutation so the model gets a clear error and the channel stays
       // silent. System-source sends (recovery, role-claim) are not affected.
+      // Record the contested skip so `validateChannelTurn` doesn't ALSO drop the
+      // reply text on the floor — the live send stays denied, but the post-turn
+      // recovery net must still surface what the model wanted to say.
       if (live.skippedTurn !== null && live.skippedTurn.turnSeq === live.turnSeq) {
+        live.skipLockedSendTurn = live.turnSeq
         return denyPolicyToolSend(SKIP_RESPONSE_LOCK_ERROR, 'skip-locked')
       }
       const currentCount = live.consecutiveSends.get(sendKey) ?? 0
@@ -2627,18 +2649,29 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   const validateChannelTurn = async (live: LiveSession, successfulSendsBeforePrompt: number): Promise<void> => {
-    // `skip_response` short-circuit. Must run before the `successfulChannelSends`
-    // check so a model that called both `skip_response` and a channel tool in
-    // the same turn still resolves as "skipped" — the rejection inside `send()`
-    // means the channel tool returned an error and never actually delivered.
+    // `skip_response` short-circuit. Honoring it bypasses recovery entirely.
     // Stale-flag protection: only honor when stamped on the just-completed
     // turn. A flag set by a previous turn that crashed before validation
     // would otherwise drop the next legitimate user-facing reply.
-    if (live.skippedTurn !== null && live.skippedTurn.turnSeq === live.turnSeq) {
+    //
+    // Contested-skip carve-out: if the model ALSO attempted a tool-source send
+    // this turn (denied `skip-locked` in `send()`, stamped on `skipLockedSendTurn`),
+    // the skip is no longer a clean opt-out — the model produced reply text it
+    // wanted delivered. The live send stays denied, but we must NOT also suppress
+    // recovery, or the reply is silently dropped with nothing to retry it (the
+    // inbound is already drained). Fall through to the normal recovery path, which
+    // posts it via `source:'system'` under the existing NO_REPLY / leak guards.
+    const skipContested = live.skipLockedSendTurn === live.turnSeq
+    if (live.skippedTurn !== null && live.skippedTurn.turnSeq === live.turnSeq && !skipContested) {
       const { reason } = live.skippedTurn
       live.skippedTurn = null
       logger.info(`[channels] ${live.keyId} skipped_by_tool reason=${JSON.stringify(reason)}`)
       return
+    }
+    if (live.skippedTurn !== null && live.skippedTurn.turnSeq === live.turnSeq) {
+      // Clear the now-contested skip so it can't leak into a later turn's check.
+      live.skippedTurn = null
+      logger.info(`[channels] ${live.keyId} skip_contested_by_send recovering reply`)
     }
     if (live.successfulChannelSends > successfulSendsBeforePrompt) return
 


### PR DESCRIPTION
## Background

A channel turn could silently swallow a user-facing reply. Observed in production on `m1` (`typeey` agent) across multiple GitHub PR threads — most visibly on [#585](https://github.com/typeclaw/typeclaw/pull/585#issuecomment-4605980108), where a `@typeey review again` comment was ingested but got **no response**, and nothing ever retried it.

Container logs show the turn started but never finished:

```
18:39:15  pr:585: prompting batch=1 text_len=463      ← "review again" comment ingested (NOT dropped)
18:40:04  channel_reply failed: pr:585: You called `skip_response` earlier in this turn,
          which committed to staying silent. Channel sends are blocked for the rest of this turn.
<no `pr:585: prompted elapsed_ms=` terminal line — turn fizzled, zero further pr:585 activity>
```

**Root cause.** The model called `skip_response` first (silence-first → `skippedTurn` stamped), then changed its mind and called `channel_reply`. Two things then compounded:

1. `send()` correctly denied the tool send with `skip-locked` (commit-to-silence is binding for the live send path).
2. `validateChannelTurn`'s `skip_response` short-circuit then **bypassed recovery entirely** — no NO_REPLY check, no `recoverableAssistantText`. So the reply text the model produced was dropped on the floor. Because the inbound was already drained from the batch, no later webhook re-presented it, and the thread stayed silent until an unrelated event woke it.

This is distinct from the bounded *livelock* the surrounding code already guards (alternating skip/denied-reply → abort ceiling). Here a single skip→reply was enough to lose the message.

## Summary

Treat a skip that is later **contested by a real send attempt** as no longer a clean opt-out, *without* relaxing the live-send denial:

- `send()` stamps a per-turn `skipLockedSendTurn = turnSeq` when it denies a tool send `skip-locked`. The send still returns the denial — the contract that "commit to silence is binding for the live path" is unchanged.
- `validateChannelTurn` honors the skip short-circuit only when the skip was **not** contested. When it was, it falls through to the existing `recoverableAssistantText` path, which posts the reply via `source:'system'` — still subject to the existing NO_REPLY / Kimi-leak / plaintext-tool-call guards.
- The flag is keyed by `turnSeq` and reset at turn start (next to `successfulSendsAtTurnStart` / `policyDeniedToolSendsThisTurn`), so a stale value cannot leak across turns.

**Why deny-but-recover, and not "let the later reply override the skip"?** The override approach (clear the skip, deliver the reply live) is cleaner in the abstract, but it rewrites the documented "irrevocable silence" contract and inverts two intentional regression tests (`channel_send after skip_response … is rejected`, `send-after-skip lock still applies on the silence-first path`). Deny-but-recover keeps that contract intact and is strictly additive: the only behavior change is that a previously-dropped reply now gets surfaced through the same safety net that already rescues "model wrote text but forgot to call channel_reply". The bounded-livelock abort ceiling is untouched.

## What this does NOT do

- Does **not** make the live `channel_reply`/`channel_send` succeed after `skip_response` — it stays denied `skip-locked`. The reply is surfaced post-turn via the recovery path, not the live path.
- Does **not** change the reply-first path (`recorded-after-send`), the silence-first send lock, or the policy-denial abort ceiling.
- Does **not** relax any recovery guard — contested recovery still drops NO_REPLY / tool-leak / plaintext-tool-call text.
- Does not touch GitHub webhook ingestion, engagement, or batching; the event was always delivered correctly.

## Review notes

- Load-bearing change is in `validateChannelTurn` (`src/channels/router.ts`): the short-circuit now ANDs `!skipContested`, with a second clear-only branch so a contested `skippedTurn` can't leak into a later turn's comparison.
- Invariant to verify: a contested skip must (a) keep the live send denied, (b) reset `skipLockedSendTurn` every turn, (c) still respect recovery's silence guards. Covered by three new tests: skip-then-reply recovers the reply; contested skip with `NO_REPLY` text stays silent; the contested flag does not leak into a later skip-only turn.
- The pre-existing `skipped_by_tool`-log assertion in the "channel_send after skip_response is rejected" test was updated to `skip_contested_by_send` (its core "send denied, nothing delivered" assertions are unchanged — that test has no recoverable text, so it exercises the contested-but-nothing-to-recover branch).