### PR TITLE
agent: abort the turn when the loop guard blocks, instead of only refusing

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -257,6 +257,13 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
   const getOrigin: () => SessionOrigin | undefined =
     options.originRef !== undefined ? () => options.originRef!.current : () => options.origin
 
+  // Holds the session's signal-only abort once `createAgentSession` resolves.
+  // Tools are wrapped BEFORE the session exists, so the loop guard reaches the
+  // abort through this lazily-resolved getter. See `fireLoopAbort` in
+  // plugin-tools.ts for why aborting (not throwing) is what stops the loop.
+  const abortHolder: { abort?: () => void } = {}
+  const getAbort: () => (() => void) | undefined = () => abortHolder.abort
+
   // Subagent built-in tool refs are dual-routed (see BUILTIN_TOOL_DEFINITION
   // dual-map in plugin-tools.ts): pi-side coding tools go to `tools:` so they
   // become the strict base set, typeclaw-side web tools go to `customTools:`.
@@ -268,8 +275,8 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     ? resolveBuiltinToolRefs(options.pluginSubagent.toolRefs)
     : { agentTools: [], toolDefinitions: [] }
   const pluginCustomTools = options.pluginSubagent
-    ? wrapSubagentCustomTools(options.pluginSubagent, options.plugins, getOrigin)
-    : wrapRegistryTools(options.plugins, getOrigin)
+    ? wrapSubagentCustomTools(options.pluginSubagent, options.plugins, getOrigin, getAbort)
+    : wrapRegistryTools(options.plugins, getOrigin, getAbort)
 
   // Per-run budget state for the tool-result byte ceiling. Allocated once per
   // session creation and threaded into every wrapped tool so they share the
@@ -285,7 +292,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
 
   const effectiveTools =
     options.tools ?? (options.pluginSubagent ? (resolvedSubagentBuiltins.agentTools as AgentSessionTools) : undefined)
-  const hookWrappedTools = wrapSystemAgentTools(effectiveTools, options.plugins, getOrigin)
+  const hookWrappedTools = wrapSystemAgentTools(effectiveTools, options.plugins, getOrigin, getAbort)
   const tools =
     sessionBudget && sessionBudgetState && hookWrappedTools
       ? (hookWrappedTools.map((t) =>
@@ -370,10 +377,11 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
           sessionId: options.plugins.sessionId,
           hooks: options.plugins.hooks,
           getOrigin,
+          getAbort,
           ...(options.permissions ? { permissions: options.permissions } : {}),
         })
       : []
-  const wrappedCustomSystemTools = wrapSystemTools(customSystemTools, options.plugins, getOrigin)
+  const wrappedCustomSystemTools = wrapSystemTools(customSystemTools, options.plugins, getOrigin, getAbort)
   const customToolsPreBudget = [...wrappedCustomSystemTools, ...pluginCustomTools, ...builtinPiToolOverrides]
   const customTools =
     sessionBudget && sessionBudgetState
@@ -393,6 +401,10 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     customTools,
     ...(thinkingLevel ? { thinkingLevel } : {}),
   })
+
+  abortHolder.abort = () => {
+    if (session.agent.signal?.aborted !== true) session.agent.abort()
+  }
 
   // The names the session actually exposes to the model: pi's active base set
   // (the caller's `tools:` filter, or pi's default builtins when unset) union
@@ -686,6 +698,7 @@ export function buildRoleGrantTools(opts: {
 function wrapRegistryTools(
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
+  getAbort: () => (() => void) | undefined,
 ): ToolDefinition[] {
   if (!plugins) return []
   return plugins.registry.tools.map((t: PluginRegisteredTool) =>
@@ -697,6 +710,7 @@ function wrapRegistryTools(
       logger: t.logger,
       hooks: plugins.hooks,
       getOrigin,
+      getAbort,
     }),
   )
 }
@@ -705,6 +719,7 @@ function wrapSystemAgentTools(
   tools: AgentSessionTools | undefined,
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
+  getAbort: () => (() => void) | undefined,
 ): AgentSessionTools | undefined {
   if (!tools || !hasToolHooks(plugins)) return tools
   return tools.map((tool) =>
@@ -713,6 +728,7 @@ function wrapSystemAgentTools(
       sessionId: plugins.sessionId,
       hooks: plugins.hooks,
       getOrigin,
+      getAbort,
     }),
   )
 }
@@ -721,6 +737,7 @@ function wrapSystemTools(
   tools: ToolDefinition[],
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
+  getAbort: () => (() => void) | undefined,
 ): ToolDefinition[] {
   if (!hasToolHooks(plugins)) return tools
   return tools.map((tool) =>
@@ -729,6 +746,7 @@ function wrapSystemTools(
       sessionId: plugins.sessionId,
       hooks: plugins.hooks,
       getOrigin,
+      getAbort,
     }),
   )
 }
@@ -742,6 +760,7 @@ function wrapSubagentCustomTools(
   selection: PluginSubagentSelection,
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
+  getAbort: () => (() => void) | undefined,
 ): ToolDefinition[] {
   if (!selection.customTools || !plugins) return []
   const logger = makePluginLogger(selection.pluginName)
@@ -754,6 +773,7 @@ function wrapSubagentCustomTools(
       logger,
       hooks: plugins.hooks,
       getOrigin,
+      getAbort,
     }),
   )
 }

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1330,4 +1330,90 @@ describe('loop guard integration', () => {
     const bFirst = (await wB.execute('b1', {}, undefined, undefined, {} as never)) as { isError?: boolean }
     expect(bFirst.isError).not.toBe(true)
   })
+
+  test('aborts the turn when a plugin tool is blocked so the model cannot keep retrying', async () => {
+    let aborts = 0
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ q: z.string() }),
+      async execute() {
+        return { content: [{ type: 'text', text: 'ok' }] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'search',
+      agentDir: '/agent',
+      sessionId: 'loop-abort-plugin',
+      logger: noopLogger,
+      hooks: createHookBus(),
+      getAbort: () => () => {
+        aborts += 1
+      },
+    })
+
+    for (let i = 0; i < 4; i++) {
+      await wrapped.execute(`c${i}`, { q: 'a' }, undefined, undefined, {} as never)
+    }
+    expect(aborts).toBe(0)
+    await wrapped.execute('c5', { q: 'a' }, undefined, undefined, {} as never)
+    expect(aborts).toBe(1)
+  })
+
+  test('aborts the turn when a system tool is blocked, alongside the thrown loop error', async () => {
+    let aborts = 0
+    const tool = definePiTool({
+      name: 'webfetch',
+      label: 'webfetch',
+      description: '',
+      parameters: Type.Object({ url: Type.String() }),
+      async execute() {
+        return { content: [{ type: 'text', text: 'ok' }], details: undefined }
+      },
+    })
+    const wrapped = wrapSystemTool(tool, {
+      agentDir: '/agent',
+      sessionId: 'loop-abort-sys',
+      hooks: createHookBus(),
+      getAbort: () => () => {
+        aborts += 1
+      },
+    })
+
+    for (let i = 0; i < 4; i++) {
+      await wrapped.execute(`c${i}`, { url: 'https://example.com' }, undefined, undefined, {} as never)
+    }
+    expect(aborts).toBe(0)
+    await expect(
+      wrapped.execute('c5', { url: 'https://example.com' }, undefined, undefined, {} as never),
+    ).rejects.toThrow(/loop-guard/)
+    expect(aborts).toBe(1)
+  })
+
+  test('does not abort while calls are still under the block threshold', async () => {
+    let aborts = 0
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ q: z.string() }),
+      async execute() {
+        return { content: [{ type: 'text', text: 'ok' }] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'search',
+      agentDir: '/agent',
+      sessionId: 'loop-abort-warn-only',
+      logger: noopLogger,
+      hooks: createHookBus(),
+      getAbort: () => () => {
+        aborts += 1
+      },
+    })
+
+    for (let i = 0; i < 4; i++) {
+      await wrapped.execute(`c${i}`, { q: 'a' }, undefined, undefined, {} as never)
+    }
+    expect(aborts).toBe(0)
+  })
 })

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -163,6 +163,10 @@ export type WrapToolOptions = {
   // origin mutates per turn surface the current-turn `lastInboundAuthorId`
   // to `tool.before`. Sessions with a fixed origin can pass `() => origin`.
   getOrigin?: () => SessionOrigin | undefined
+  // Resolves the current turn's abort handle. Resolved lazily (not at wrap
+  // time) because tools are wrapped BEFORE `createAgentSession` returns the
+  // session whose `agent.abort` this points at. See `fireLoopAbort`.
+  getAbort?: () => (() => void) | undefined
 }
 
 export type WrapSystemToolOptions = {
@@ -170,6 +174,7 @@ export type WrapSystemToolOptions = {
   sessionId: string
   hooks: HookBus
   getOrigin?: () => SessionOrigin | undefined
+  getAbort?: () => (() => void) | undefined
   // When present, the bash builtin is rewritten through the per-tool bwrap
   // sandbox with role-derived path masks. Absent (or no masks for the role)
   // runs bash unchanged — preserving today's behavior for trusted+ and for
@@ -228,6 +233,7 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
 
       const loopDecision = sharedLoopGuard.check(opts.sessionId, opts.toolName, before.args)
       if (loopDecision.kind === 'block') {
+        fireLoopAbort(opts.getAbort)
         return errorResult(loopDecision.message)
       }
 
@@ -287,6 +293,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       }
       const loopDecision = sharedLoopGuard.check(opts.sessionId, tool.name, mutableArgs)
       if (loopDecision.kind === 'block') {
+        fireLoopAbort(opts.getAbort)
         throw new Error(loopDecision.message)
       }
       const guardResult = await runFinalWriteGuards({
@@ -349,6 +356,7 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
       }
       const loopDecision = sharedLoopGuard.check(opts.sessionId, tool.name, mutableArgs)
       if (loopDecision.kind === 'block') {
+        fireLoopAbort(opts.getAbort)
         throw new Error(loopDecision.message)
       }
       const guardResult = await runFinalWriteGuards({
@@ -426,6 +434,7 @@ export function wrapAgentToolAsCustomToolDefinition<TParams extends TSchema, TDe
       delete mutableArgs[TYPECLAW_INTERNAL_BASH_ENV]
       const loopDecision = sharedLoopGuard.check(opts.sessionId, tool.name, mutableArgs)
       if (loopDecision.kind === 'block') {
+        fireLoopAbort(opts.getAbort)
         throw new Error(loopDecision.message)
       }
       const guardResult = await runFinalWriteGuards({
@@ -523,6 +532,18 @@ function appendLoopWarning(result: ToolResult, message: string): ToolResult {
 // long-running processes.
 export function __resetSharedLoopGuardForTests(): void {
   sharedLoopGuard = createLoopGuard()
+}
+
+// A loop-guard `block` verdict returned/thrown from a tool's execute() is
+// caught by pi-agent-core and surfaced to the model as an `isError` result,
+// which the model simply retries — the loop never ends. Aborting the run's
+// AbortSignal is the only thing that actually stops the in-flight turn (the
+// next assistant stream sees the aborted signal and ends with stopReason
+// 'aborted'). We use the signal-only `agent.abort`, never `session.abort`,
+// which would deadlock awaiting the very run this tool call belongs to. See
+// the matching pattern in src/channels/router.ts (policy-denied send cap).
+function fireLoopAbort(getAbort: (() => (() => void) | undefined) | undefined): void {
+  getAbort?.()?.()
 }
 
 function errorResult(message: string) {


### PR DESCRIPTION
## Background

The peer-bot loop guard detects runaway identical tool-call loops and raises a `block` verdict. That verdict was toothless in practice: blocked plugin tools returned an `errorResult`; blocked system tools threw. `pi-agent-core` catches both paths and surfaces them to the model as `isError` results — which the model happily retries, since retrying on tool error is exactly what it is supposed to do.

A production session polling `subagent_output` hit the block 560+ times in a row without ever stopping. The guard detected the loop but had no mechanism to actually end the turn.

The only thing that ends an in-flight turn is aborting the run's `AbortSignal` — the exact mechanism already used by the policy-denied channel-send cap in `src/channels/router.ts`.

## Summary

Thread a lazily-resolved abort handle into every tool wrapper and fire `session.agent.abort()` at each `block` branch: `wrapPluginTool`, `wrapSystemTool`, `wrapSystemAgentTool`, and `wrapAgentToolAsCustomToolDefinition`.

Two non-obvious decisions worth verifying:

**Lazy resolution, not eager capture.** Tools are wrapped inside `buildBuiltinPiToolOverrides` / `wrapRegistryTools` / etc., all of which run before `createAgentSession` returns the session object. The abort handle can only be resolved after the session exists. The fix passes a `getAbort?: () => (() => void) | undefined` getter (mirroring the existing `getOrigin` pattern), resolved at execute time rather than at wrap time. The getter is populated via a closure that fills `abortHolder` right after `createAgentSession` resolves.

**`agent.abort()`, not `session.abort()`.** `session.abort()` awaits `waitForIdle()`, which would deadlock on the very run the tool call is being made from. `agent.abort()` is signal-only. An `signal?.aborted !== true` guard makes it idempotent so multiple block branches in the same loop don't compound.

## What this does NOT do

- Does not change the block verdict itself — the loop-guard detection logic is untouched.
- Does not affect the `warn` or `allow` paths; only `block` fires the abort.
- Does not change how the error result is surfaced to the model; the abort races the tool return, so the model may or may not see the error before the turn ends.
- Does not touch the channel-send policy-denial abort ceiling in `src/channels/router.ts`.

## Review notes

- Load-bearing change: `fireLoopAbort` in `src/agent/plugin-tools.ts`. Four call sites — one per wrapping function — must all be present or a tool variant remains unguarded.
- `abortHolder` initialization in `src/agent/index.ts`: must run after `createAgentSession` resolves and before any tool call is executed. The assignment is synchronous immediately after the `await`.
- `signal?.aborted !== true` guard: required for idempotency. Without it, back-to-back blocks on different tool slots could double-abort and surface unexpected behavior in the underlying SDK.
- Three new tests in `plugin-tools.test.ts`: abort fires exactly once on block (plugin path), abort fires on block (system path), abort does not fire before the block threshold.