### PR TITLE
channels: resume pending todos after a channel-origin restart

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -46,6 +46,7 @@ import {
   zodToToolParameters,
 } from './plugin-tools'
 import { createReloadTool } from './reload-tool'
+import type { RestartHandoffOrigin } from './restart-handoff'
 import { loadSelf } from './self'
 import { SESSION_META_CUSTOM_TYPE, sessionMetaPayload } from './session-meta'
 import { renderSessionOrigin, type SessionOrigin, type SessionRoleContext } from './session-origin'
@@ -446,22 +447,39 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
 
 // Decides whether the restart tool should write the cross-restart handoff
 // file (`<agentDir>/.typeclaw/restart-pending.json`) and supplies the agentDir
-// + session file path it needs to do so. Returns an empty object — meaning
-// "no handoff" — for any session whose origin is not TUI, so a channel-
-// originated or cron-originated `restart` call cannot accidentally produce an
-// "I'm back" greeting in the next container's first TUI session. See
-// issue #291's scoping concerns. Also returns empty when the session is not
-// persisted to disk (in-memory sessions have no file the next container could
-// reopen).
+// + session file path + origin metadata it needs to do so. Returns an empty
+// object — meaning "no handoff" — for cron/subagent/system origins (no
+// attended session the next boot could resume) and for in-memory sessions
+// (no file to reopen).
+//
+// TUI and channel origins both resume: a TUI restart reattaches to the
+// reconnecting client (websocket open handler), a channel restart reopens the
+// originating chat session on the channel router's boot path. The `origin`
+// discriminator in the handoff is what routes the next boot to the correct
+// subsystem.
 export function buildRestartHandoffWiring(
   options: { origin?: SessionOrigin; plugins?: { agentDir: string } },
   sessionManager: SessionManager,
-): { agentDir?: string; originatingSessionFile?: string } {
-  if (options.origin?.kind !== 'tui') return {}
+): { agentDir?: string; originatingSessionFile?: string; handoffOrigin?: RestartHandoffOrigin } {
+  const origin = options.origin
+  if (origin === undefined) return {}
+  const handoffOrigin = restartHandoffOriginFor(origin)
+  if (handoffOrigin === null) return {}
   const agentDir = options.plugins?.agentDir
   const sessionFile = sessionManager.getSessionFile()
   if (agentDir === undefined || sessionFile === undefined) return {}
-  return { agentDir, originatingSessionFile: sessionFile }
+  return { agentDir, originatingSessionFile: sessionFile, handoffOrigin }
+}
+
+function restartHandoffOriginFor(origin: SessionOrigin): RestartHandoffOrigin | null {
+  if (origin.kind === 'tui') return { kind: 'tui' }
+  if (origin.kind === 'channel') {
+    return {
+      kind: 'channel',
+      key: { adapter: origin.adapter, workspace: origin.workspace, chat: origin.chat, thread: origin.thread },
+    }
+  }
+  return null
 }
 
 // Subscribes the given session to the in-process broadcast that the `restart`

--- a/src/agent/restart-handoff-wiring.test.ts
+++ b/src/agent/restart-handoff-wiring.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { SessionManager } from '@mariozechner/pi-coding-agent'
+
+import { buildRestartHandoffWiring } from './index'
+import type { SessionOrigin } from './session-origin'
+
+function fakeSessionManager(sessionFile: string | undefined): SessionManager {
+  return { getSessionFile: () => sessionFile } as unknown as SessionManager
+}
+
+const tuiOrigin: SessionOrigin = { kind: 'tui', sessionId: 'ses-1' }
+const channelOrigin: SessionOrigin = {
+  kind: 'channel',
+  adapter: 'discord-bot',
+  workspace: 'g1',
+  chat: 'c1',
+  thread: 't1',
+}
+
+describe('buildRestartHandoffWiring', () => {
+  test('emits a tui handoff for a persisted TUI session', () => {
+    const result = buildRestartHandoffWiring(
+      { origin: tuiOrigin, plugins: { agentDir: '/agent' } },
+      fakeSessionManager('/agent/sessions/ses-1.jsonl'),
+    )
+    expect(result).toEqual({
+      agentDir: '/agent',
+      originatingSessionFile: '/agent/sessions/ses-1.jsonl',
+      handoffOrigin: { kind: 'tui' },
+    })
+  })
+
+  test('emits a channel handoff carrying the channel key for a persisted channel session', () => {
+    const result = buildRestartHandoffWiring(
+      { origin: channelOrigin, plugins: { agentDir: '/agent' } },
+      fakeSessionManager('/agent/sessions/ses-2.jsonl'),
+    )
+    expect(result).toEqual({
+      agentDir: '/agent',
+      originatingSessionFile: '/agent/sessions/ses-2.jsonl',
+      handoffOrigin: { kind: 'channel', key: { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't1' } },
+    })
+  })
+
+  test('emits nothing for cron / subagent / system origins', () => {
+    const cron: SessionOrigin = { kind: 'cron', jobId: 'j1', jobKind: 'prompt' }
+    const subagent: SessionOrigin = { kind: 'subagent', subagent: 'explorer', parentSessionId: 'p1' }
+    const system: SessionOrigin = { kind: 'system', component: 'backup' }
+    for (const origin of [cron, subagent, system]) {
+      expect(
+        buildRestartHandoffWiring({ origin, plugins: { agentDir: '/agent' } }, fakeSessionManager('/f.jsonl')),
+      ).toEqual({})
+    }
+  })
+
+  test('emits nothing when the session is not persisted (no file on disk)', () => {
+    expect(
+      buildRestartHandoffWiring({ origin: tuiOrigin, plugins: { agentDir: '/agent' } }, fakeSessionManager(undefined)),
+    ).toEqual({})
+  })
+
+  test('emits nothing when agentDir is absent', () => {
+    expect(buildRestartHandoffWiring({ origin: tuiOrigin }, fakeSessionManager('/agent/sessions/ses-1.jsonl'))).toEqual(
+      {},
+    )
+  })
+
+  test('emits nothing when origin is undefined', () => {
+    expect(
+      buildRestartHandoffWiring({ plugins: { agentDir: '/agent' } }, fakeSessionManager('/agent/sessions/ses-1.jsonl')),
+    ).toEqual({})
+  })
+})

--- a/src/agent/restart-handoff/index.test.ts
+++ b/src/agent/restart-handoff/index.test.ts
@@ -4,7 +4,13 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { consumeRestartHandoff, RESTART_HANDOFF_TTL_MS, restartHandoffPath, writeRestartHandoff } from './index'
+import {
+  consumeRestartHandoff,
+  RESTART_HANDOFF_TTL_MS,
+  type RestartHandoff,
+  restartHandoffPath,
+  writeRestartHandoff,
+} from './index'
 
 let agentDir: string
 
@@ -16,59 +22,60 @@ afterEach(async () => {
   await rm(agentDir, { recursive: true, force: true })
 })
 
+function tuiHandoff(overrides: Partial<RestartHandoff> = {}): RestartHandoff {
+  return {
+    schemaVersion: 2,
+    restartedAt: '2026-05-26T10:00:00.000Z',
+    originatingSessionId: 'ses-abc',
+    originatingSessionFile: 'ses-abc.jsonl',
+    origin: { kind: 'tui' },
+    ...overrides,
+  }
+}
+
+function channelHandoff(overrides: Partial<RestartHandoff> = {}): RestartHandoff {
+  return {
+    schemaVersion: 2,
+    restartedAt: '2026-05-26T10:00:00.000Z',
+    originatingSessionId: 'ses-chan',
+    originatingSessionFile: 'ses-chan.jsonl',
+    origin: { kind: 'channel', key: { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null } },
+    ...overrides,
+  }
+}
+
 describe('writeRestartHandoff', () => {
   test('persists handoff at .typeclaw/restart-pending.json', async () => {
-    await writeRestartHandoff(agentDir, {
-      schemaVersion: 1,
-      restartedAt: '2026-05-26T10:00:00.000Z',
-      originatingSessionId: 'ses-abc',
-      originatingSessionFile: 'ses-abc.jsonl',
-    })
+    await writeRestartHandoff(agentDir, tuiHandoff())
 
     const raw = await readFile(restartHandoffPath(agentDir), 'utf8')
-    expect(JSON.parse(raw)).toEqual({
-      schemaVersion: 1,
-      restartedAt: '2026-05-26T10:00:00.000Z',
-      originatingSessionId: 'ses-abc',
-      originatingSessionFile: 'ses-abc.jsonl',
-    })
+    expect(JSON.parse(raw)).toEqual(tuiHandoff())
+  })
+
+  test('round-trips a channel-origin handoff with its channel key', async () => {
+    await writeRestartHandoff(agentDir, channelHandoff())
+
+    const result = await consumeRestartHandoff(agentDir, { now: Date.parse('2026-05-26T10:00:30.000Z') })
+
+    expect(result).toEqual(channelHandoff())
   })
 
   test('creates the .typeclaw/ directory on demand', async () => {
     expect(existsSync(join(agentDir, '.typeclaw'))).toBe(false)
-    await writeRestartHandoff(agentDir, {
-      schemaVersion: 1,
-      restartedAt: '2026-05-26T10:00:00.000Z',
-      originatingSessionId: 'ses-abc',
-      originatingSessionFile: 'ses-abc.jsonl',
-    })
+    await writeRestartHandoff(agentDir, tuiHandoff())
     expect(existsSync(join(agentDir, '.typeclaw'))).toBe(true)
   })
 
   test('does not throw when the agent directory does not exist (best-effort)', async () => {
-    await expect(
-      writeRestartHandoff('/nonexistent/path/that/does/not/exist', {
-        schemaVersion: 1,
-        restartedAt: '2026-05-26T10:00:00.000Z',
-        originatingSessionId: 'ses-abc',
-        originatingSessionFile: 'ses-abc.jsonl',
-      }),
-    ).resolves.toBeUndefined()
+    await expect(writeRestartHandoff('/nonexistent/path/that/does/not/exist', tuiHandoff())).resolves.toBeUndefined()
   })
 
   test('overwrites a prior handoff file', async () => {
-    await writeRestartHandoff(agentDir, {
-      schemaVersion: 1,
-      restartedAt: '2026-05-26T10:00:00.000Z',
-      originatingSessionId: 'ses-first',
-      originatingSessionFile: 'ses-first.jsonl',
-    })
-    await writeRestartHandoff(agentDir, {
-      schemaVersion: 1,
-      restartedAt: '2026-05-26T10:00:01.000Z',
-      originatingSessionId: 'ses-second',
-      originatingSessionFile: 'ses-second.jsonl',
-    })
+    await writeRestartHandoff(agentDir, tuiHandoff({ originatingSessionId: 'ses-first' }))
+    await writeRestartHandoff(
+      agentDir,
+      tuiHandoff({ originatingSessionId: 'ses-second', restartedAt: '2026-05-26T10:00:01.000Z' }),
+    )
 
     const raw = await readFile(restartHandoffPath(agentDir), 'utf8')
     expect(JSON.parse(raw).originatingSessionId).toBe('ses-second')
@@ -82,33 +89,41 @@ describe('consumeRestartHandoff', () => {
   })
 
   test('returns the handoff and deletes the file on success', async () => {
-    await writeRestartHandoff(agentDir, {
-      schemaVersion: 1,
-      restartedAt: '2026-05-26T10:00:00.000Z',
-      originatingSessionId: 'ses-abc',
-      originatingSessionFile: 'ses-abc.jsonl',
-    })
+    await writeRestartHandoff(agentDir, tuiHandoff())
 
     const result = await consumeRestartHandoff(agentDir, {
       now: Date.parse('2026-05-26T10:00:30.000Z'),
     })
 
-    expect(result).toEqual({
-      schemaVersion: 1,
-      restartedAt: '2026-05-26T10:00:00.000Z',
-      originatingSessionId: 'ses-abc',
-      originatingSessionFile: 'ses-abc.jsonl',
-    })
+    expect(result).toEqual(tuiHandoff())
     expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
   })
 
-  test('returns null AND deletes the file when older than ttlMs', async () => {
-    await writeRestartHandoff(agentDir, {
-      schemaVersion: 1,
+  test('reads a v1 handoff forward as a tui origin', async () => {
+    const path = restartHandoffPath(agentDir)
+    await Bun.write(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        restartedAt: '2026-05-26T10:00:00.000Z',
+        originatingSessionId: 'ses-legacy',
+        originatingSessionFile: 'ses-legacy.jsonl',
+      }),
+    )
+
+    const result = await consumeRestartHandoff(agentDir, { now: Date.parse('2026-05-26T10:00:30.000Z') })
+
+    expect(result).toEqual({
+      schemaVersion: 2,
       restartedAt: '2026-05-26T10:00:00.000Z',
-      originatingSessionId: 'ses-abc',
-      originatingSessionFile: 'ses-abc.jsonl',
+      originatingSessionId: 'ses-legacy',
+      originatingSessionFile: 'ses-legacy.jsonl',
+      origin: { kind: 'tui' },
     })
+  })
+
+  test('returns null AND deletes the file when older than ttlMs', async () => {
+    await writeRestartHandoff(agentDir, tuiHandoff())
 
     const result = await consumeRestartHandoff(agentDir, {
       now: Date.parse('2026-05-26T10:01:10.000Z'),
@@ -119,12 +134,10 @@ describe('consumeRestartHandoff', () => {
   })
 
   test('uses RESTART_HANDOFF_TTL_MS (60s) as the default TTL', async () => {
-    await writeRestartHandoff(agentDir, {
-      schemaVersion: 1,
-      restartedAt: new Date(Date.now() - (RESTART_HANDOFF_TTL_MS + 5_000)).toISOString(),
-      originatingSessionId: 'ses-abc',
-      originatingSessionFile: 'ses-abc.jsonl',
-    })
+    await writeRestartHandoff(
+      agentDir,
+      tuiHandoff({ restartedAt: new Date(Date.now() - (RESTART_HANDOFF_TTL_MS + 5_000)).toISOString() }),
+    )
 
     const result = await consumeRestartHandoff(agentDir)
 
@@ -142,17 +155,9 @@ describe('consumeRestartHandoff', () => {
     expect(existsSync(path)).toBe(false)
   })
 
-  test('returns null when schemaVersion is missing or wrong', async () => {
+  test('returns null when schemaVersion is unsupported', async () => {
     const path = restartHandoffPath(agentDir)
-    await Bun.write(
-      path,
-      JSON.stringify({
-        schemaVersion: 99,
-        restartedAt: '2026-05-26T10:00:00.000Z',
-        originatingSessionId: 'ses-abc',
-        originatingSessionFile: 'ses-abc.jsonl',
-      }),
-    )
+    await Bun.write(path, JSON.stringify({ ...channelHandoff(), schemaVersion: 99 }))
 
     const result = await consumeRestartHandoff(agentDir, {
       now: Date.parse('2026-05-26T10:00:30.000Z'),
@@ -162,17 +167,27 @@ describe('consumeRestartHandoff', () => {
     expect(existsSync(path)).toBe(false)
   })
 
-  test('returns null when originatingSessionId is empty', async () => {
+  test('returns null when a v2 channel handoff is missing its key', async () => {
     const path = restartHandoffPath(agentDir)
     await Bun.write(
       path,
       JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         restartedAt: '2026-05-26T10:00:00.000Z',
-        originatingSessionId: '',
-        originatingSessionFile: 'ses-abc.jsonl',
+        originatingSessionId: 'ses-chan',
+        originatingSessionFile: 'ses-chan.jsonl',
+        origin: { kind: 'channel' },
       }),
     )
+
+    const result = await consumeRestartHandoff(agentDir, { now: Date.parse('2026-05-26T10:00:30.000Z') })
+
+    expect(result).toBeNull()
+  })
+
+  test('returns null when originatingSessionId is empty', async () => {
+    const path = restartHandoffPath(agentDir)
+    await Bun.write(path, JSON.stringify(tuiHandoff({ originatingSessionId: '' })))
 
     const result = await consumeRestartHandoff(agentDir, {
       now: Date.parse('2026-05-26T10:00:30.000Z'),
@@ -183,15 +198,7 @@ describe('consumeRestartHandoff', () => {
 
   test('returns null when restartedAt is not parseable as a date', async () => {
     const path = restartHandoffPath(agentDir)
-    await Bun.write(
-      path,
-      JSON.stringify({
-        schemaVersion: 1,
-        restartedAt: 'not-a-date',
-        originatingSessionId: 'ses-abc',
-        originatingSessionFile: 'ses-abc.jsonl',
-      }),
-    )
+    await Bun.write(path, JSON.stringify(tuiHandoff({ restartedAt: 'not-a-date' })))
 
     const result = await consumeRestartHandoff(agentDir, {
       now: Date.parse('2026-05-26T10:00:30.000Z'),
@@ -202,21 +209,55 @@ describe('consumeRestartHandoff', () => {
   })
 
   test('returns the handoff exactly once (second consume sees no file)', async () => {
-    await writeRestartHandoff(agentDir, {
-      schemaVersion: 1,
-      restartedAt: '2026-05-26T10:00:00.000Z',
-      originatingSessionId: 'ses-abc',
-      originatingSessionFile: 'ses-abc.jsonl',
-    })
+    await writeRestartHandoff(agentDir, tuiHandoff())
 
-    const first = await consumeRestartHandoff(agentDir, {
-      now: Date.parse('2026-05-26T10:00:30.000Z'),
-    })
-    const second = await consumeRestartHandoff(agentDir, {
-      now: Date.parse('2026-05-26T10:00:30.000Z'),
-    })
+    const first = await consumeRestartHandoff(agentDir, { now: Date.parse('2026-05-26T10:00:30.000Z') })
+    const second = await consumeRestartHandoff(agentDir, { now: Date.parse('2026-05-26T10:00:30.000Z') })
 
     expect(first).not.toBeNull()
     expect(second).toBeNull()
+  })
+
+  describe('accept predicate (kind-aware claiming)', () => {
+    test('claims a handoff the predicate accepts and deletes the file', async () => {
+      await writeRestartHandoff(agentDir, tuiHandoff())
+
+      const result = await consumeRestartHandoff(agentDir, {
+        now: Date.parse('2026-05-26T10:00:30.000Z'),
+        accept: (h) => h.origin.kind === 'tui',
+      })
+
+      expect(result).toEqual(tuiHandoff())
+      expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
+    })
+
+    test('rejects a handoff the predicate refuses and RESTORES the file', async () => {
+      await writeRestartHandoff(agentDir, channelHandoff())
+
+      const result = await consumeRestartHandoff(agentDir, {
+        now: Date.parse('2026-05-26T10:00:30.000Z'),
+        accept: (h) => h.origin.kind === 'tui',
+      })
+
+      expect(result).toBeNull()
+      expect(existsSync(restartHandoffPath(agentDir))).toBe(true)
+    })
+
+    test('a restored channel handoff is still claimable by the channel predicate', async () => {
+      await writeRestartHandoff(agentDir, channelHandoff())
+
+      const tuiClaim = await consumeRestartHandoff(agentDir, {
+        now: Date.parse('2026-05-26T10:00:30.000Z'),
+        accept: (h) => h.origin.kind === 'tui',
+      })
+      const channelClaim = await consumeRestartHandoff(agentDir, {
+        now: Date.parse('2026-05-26T10:00:30.000Z'),
+        accept: (h) => h.origin.kind === 'channel',
+      })
+
+      expect(tuiClaim).toBeNull()
+      expect(channelClaim).toEqual(channelHandoff())
+      expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
+    })
   })
 })

--- a/src/agent/restart-handoff/index.test.ts
+++ b/src/agent/restart-handoff/index.test.ts
@@ -231,7 +231,7 @@ describe('consumeRestartHandoff', () => {
       expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
     })
 
-    test('rejects a handoff the predicate refuses and RESTORES the file', async () => {
+    test('rejects a handoff the predicate refuses and LEAVES the file untouched', async () => {
       await writeRestartHandoff(agentDir, channelHandoff())
 
       const result = await consumeRestartHandoff(agentDir, {
@@ -243,7 +243,7 @@ describe('consumeRestartHandoff', () => {
       expect(existsSync(restartHandoffPath(agentDir))).toBe(true)
     })
 
-    test('a restored channel handoff is still claimable by the channel predicate', async () => {
+    test('an unclaimed channel handoff is still claimable by the channel predicate', async () => {
       await writeRestartHandoff(agentDir, channelHandoff())
 
       const tuiClaim = await consumeRestartHandoff(agentDir, {

--- a/src/agent/restart-handoff/index.ts
+++ b/src/agent/restart-handoff/index.ts
@@ -1,17 +1,40 @@
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
+import type { AdapterId } from '@/channels/schema'
+
 import { restartHandoffPath } from './paths'
 
 export { restartHandoffPath } from './paths'
 
 export const RESTART_HANDOFF_TTL_MS = 60_000
 
+// The channel coordinates needed to reopen and wake the originating session
+// on the channel side after a restart. Mirrors ChannelKey (src/channels/types)
+// but is duplicated here so the handoff module does not depend on the channel
+// subsystem's full type surface — only the four routing coordinates travel in
+// the handoff file.
+export type RestartHandoffChannelKey = {
+  adapter: AdapterId
+  workspace: string
+  chat: string
+  thread: string | null
+}
+
+// Discriminates which subsystem owns resuming the originating session on boot.
+// A TUI handoff is claimed by the websocket `open` handler (it needs a
+// reconnecting client); a channel handoff is claimed by channel startup (the
+// router reopens the session and wakes it without any client). Splitting the
+// claim by kind is what stops the first TUI reconnect from deleting a
+// channel-origin handoff before channel boot can see it.
+export type RestartHandoffOrigin = { kind: 'tui' } | { kind: 'channel'; key: RestartHandoffChannelKey }
+
 export type RestartHandoff = {
-  schemaVersion: 1
+  schemaVersion: 2
   restartedAt: string
   originatingSessionId: string
   originatingSessionFile: string
+  origin: RestartHandoffOrigin
 }
 
 // Atomic write via `.tmp` + rename so a crash mid-write never leaves the
@@ -38,13 +61,21 @@ export async function writeRestartHandoff(agentDir: string, handoff: RestartHand
 // Otherwise a stale file would linger until the NEXT restart wrote a fresh
 // one, and the boot consumer would re-read the stale entry every time.
 //
+// `accept` lets a caller claim only the handoffs it owns: the TUI path passes
+// a tui-only predicate, channel boot passes a channel-only predicate. When the
+// predicate REJECTS an otherwise-valid handoff, the file is restored so the
+// rightful owner can still claim it (best-effort; a restore failure degrades
+// to the same cold-start as a missing handoff). When `accept` is omitted, any
+// valid handoff is consumed (preserves the original single-consumer behavior
+// for callers that do not need kind-aware claiming).
+//
 // Returns the parsed handoff iff the file existed, was valid JSON of the
-// expected shape, and was within `ttlMs` of `now`. Otherwise returns null.
-// `now` and `ttlMs` are injectable so tests can drive the recency gate
-// without sleeping.
+// expected shape, was within `ttlMs` of `now`, and (if `accept` is given)
+// passed the predicate. Otherwise returns null. `now` and `ttlMs` are
+// injectable so tests can drive the recency gate without sleeping.
 export async function consumeRestartHandoff(
   agentDir: string,
-  options: { now?: number; ttlMs?: number } = {},
+  options: { now?: number; ttlMs?: number; accept?: (handoff: RestartHandoff) => boolean } = {},
 ): Promise<RestartHandoff | null> {
   const path = restartHandoffPath(agentDir)
   const now = options.now ?? Date.now()
@@ -66,6 +97,15 @@ export async function consumeRestartHandoff(
   if (Number.isNaN(restartedAtMs)) return null
   if (now - restartedAtMs > ttlMs) return null
 
+  if (options.accept !== undefined && !options.accept(handoff)) {
+    // Not ours to claim — put the file back so the owning subsystem's
+    // consume() can still find it. Restore is best-effort: if it fails the
+    // handoff is simply lost (cold-start), which is the same fail-safe as a
+    // SIGKILL'd writer.
+    await writeRestartHandoff(agentDir, handoff).catch(() => undefined)
+    return null
+  }
+
   return handoff
 }
 
@@ -78,14 +118,60 @@ function parseHandoff(raw: string): RestartHandoff | null {
   }
   if (parsed === null || typeof parsed !== 'object') return null
   const obj = parsed as Record<string, unknown>
-  if (obj.schemaVersion !== 1) return null
+
   if (typeof obj.restartedAt !== 'string') return null
   if (typeof obj.originatingSessionId !== 'string' || obj.originatingSessionId === '') return null
   if (typeof obj.originatingSessionFile !== 'string' || obj.originatingSessionFile === '') return null
+
+  // v1 handoffs predate the origin discriminator and were only ever written by
+  // TUI sessions (channel/cron origins wrote no handoff). Read them forward as
+  // a tui origin so an in-flight restart that straddles an upgrade still
+  // produces the "I'm back" turn.
+  if (obj.schemaVersion === 1) {
+    return {
+      schemaVersion: 2,
+      restartedAt: obj.restartedAt,
+      originatingSessionId: obj.originatingSessionId,
+      originatingSessionFile: obj.originatingSessionFile,
+      origin: { kind: 'tui' },
+    }
+  }
+
+  if (obj.schemaVersion !== 2) return null
+  const origin = parseOrigin(obj.origin)
+  if (origin === null) return null
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     restartedAt: obj.restartedAt,
     originatingSessionId: obj.originatingSessionId,
     originatingSessionFile: obj.originatingSessionFile,
+    origin,
+  }
+}
+
+function parseOrigin(raw: unknown): RestartHandoffOrigin | null {
+  if (raw === null || typeof raw !== 'object') return null
+  const obj = raw as Record<string, unknown>
+  if (obj.kind === 'tui') return { kind: 'tui' }
+  if (obj.kind === 'channel') {
+    const key = parseChannelKey(obj.key)
+    if (key === null) return null
+    return { kind: 'channel', key }
+  }
+  return null
+}
+
+function parseChannelKey(raw: unknown): RestartHandoffChannelKey | null {
+  if (raw === null || typeof raw !== 'object') return null
+  const obj = raw as Record<string, unknown>
+  if (typeof obj.adapter !== 'string' || obj.adapter === '') return null
+  if (typeof obj.workspace !== 'string') return null
+  if (typeof obj.chat !== 'string') return null
+  if (obj.thread !== null && typeof obj.thread !== 'string') return null
+  return {
+    adapter: obj.adapter as AdapterId,
+    workspace: obj.workspace,
+    chat: obj.chat,
+    thread: obj.thread,
   }
 }

--- a/src/agent/restart-handoff/index.ts
+++ b/src/agent/restart-handoff/index.ts
@@ -88,21 +88,33 @@ export async function consumeRestartHandoff(
     return null
   }
 
-  await rm(path, { force: true }).catch(() => undefined)
-
   const handoff = parseHandoff(raw)
-  if (handoff === null) return null
+
+  // Peek before delete: a handoff we will NOT claim (malformed, expired, or
+  // rejected by `accept`) is left untouched on disk so the rightful consumer
+  // can still find it. The previous delete-then-restore opened a window where
+  // a concurrent rightful consumer saw no file; never deleting an unclaimed
+  // handoff closes that window entirely.
+  if (handoff === null) {
+    await rm(path, { force: true }).catch(() => undefined)
+    return null
+  }
 
   const restartedAtMs = Date.parse(handoff.restartedAt)
-  if (Number.isNaN(restartedAtMs)) return null
-  if (now - restartedAtMs > ttlMs) return null
+  if (Number.isNaN(restartedAtMs) || now - restartedAtMs > ttlMs) {
+    await rm(path, { force: true }).catch(() => undefined)
+    return null
+  }
 
-  if (options.accept !== undefined && !options.accept(handoff)) {
-    // Not ours to claim — put the file back so the owning subsystem's
-    // consume() can still find it. Restore is best-effort: if it fails the
-    // handoff is simply lost (cold-start), which is the same fail-safe as a
-    // SIGKILL'd writer.
-    await writeRestartHandoff(agentDir, handoff).catch(() => undefined)
+  if (options.accept !== undefined && !options.accept(handoff)) return null
+
+  // Claim by deleting. A non-forced unlink distinguishes "we removed it" from
+  // "it was already gone": if another consumer of the same kind claimed it
+  // first, the unlink throws ENOENT and we return null, so the handoff is
+  // honored exactly once even under concurrent same-kind consumers.
+  try {
+    await rm(path)
+  } catch {
     return null
   }
 

--- a/src/agent/restart/index.test.ts
+++ b/src/agent/restart/index.test.ts
@@ -93,7 +93,7 @@ describe('requestContainerRestart', () => {
       },
     })
 
-    // when
+    // when: originatingSessionFile missing → no handoff
     await requestContainerRestart({
       containerName: 'coder',
       hostdUrl: `http://127.0.0.1:${server.port}`,
@@ -101,6 +101,20 @@ describe('requestContainerRestart', () => {
       ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
       agentDir,
       originatingSessionId: 'ses-incomplete',
+      handoffOrigin: { kind: 'tui' },
+      restartedAt: '2026-01-02T03:04:05.000Z',
+    })
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
+
+    // when: handoffOrigin missing → no handoff
+    await requestContainerRestart({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      agentDir,
+      originatingSessionId: 'ses-no-origin',
+      originatingSessionFile: '/tmp/sessions/ses-no-origin.jsonl',
       restartedAt: '2026-01-02T03:04:05.000Z',
     })
     expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
@@ -113,16 +127,18 @@ describe('requestContainerRestart', () => {
       agentDir,
       originatingSessionId: 'ses-origin',
       originatingSessionFile: '/tmp/sessions/ses-origin.jsonl',
+      handoffOrigin: { kind: 'tui' },
       restartedAt: '2026-01-02T03:04:05.000Z',
     })
 
     // then
     expect(result).toEqual({ ok: true, containerName: 'coder', restartedAt: '2026-01-02T03:04:05.000Z' })
     expect(JSON.parse(await readFile(restartHandoffPath(agentDir), 'utf8'))).toEqual({
-      schemaVersion: 1,
+      schemaVersion: 2,
       restartedAt: '2026-01-02T03:04:05.000Z',
       originatingSessionId: 'ses-origin',
       originatingSessionFile: 'ses-origin.jsonl',
+      origin: { kind: 'tui' },
     })
   })
 

--- a/src/agent/restart/index.ts
+++ b/src/agent/restart/index.ts
@@ -1,6 +1,6 @@
 import { basename } from 'node:path'
 
-import { writeRestartHandoff } from '@/agent/restart-handoff'
+import { type RestartHandoffOrigin, writeRestartHandoff } from '@/agent/restart-handoff'
 import { send, sendHttp } from '@/hostd/client'
 import { containerSocketPath } from '@/hostd/paths'
 import type { Stream } from '@/stream'
@@ -30,6 +30,11 @@ export type RequestContainerRestartOptions = {
   agentDir?: string
   originatingSessionId?: string
   originatingSessionFile?: string
+  // Origin metadata persisted into the handoff so the next boot routes the
+  // resume to the right subsystem (tui → websocket open; channel → router
+  // startup). Required alongside agentDir + originatingSessionFile for the
+  // handoff to be written; omitting it skips the handoff entirely.
+  handoffOrigin?: RestartHandoffOrigin
   restartedAt?: string
 }
 
@@ -48,6 +53,7 @@ export async function requestContainerRestart({
   agentDir,
   originatingSessionId,
   originatingSessionFile,
+  handoffOrigin,
   restartedAt,
 }: RequestContainerRestartOptions): Promise<RequestContainerRestartResult> {
   const request = { kind: 'restart' as const, containerName, build: build === true }
@@ -84,13 +90,19 @@ export async function requestContainerRestart({
   // only; a missing one just cold-starts the rebooted container without the
   // "I'm back" greeting. writeRestartHandoff swallows its own errors today, but
   // guard here too so this contract survives the writer being changed later.
-  if (agentDir !== undefined && originatingSessionId !== undefined && originatingSessionFile !== undefined) {
+  if (
+    agentDir !== undefined &&
+    originatingSessionId !== undefined &&
+    originatingSessionFile !== undefined &&
+    handoffOrigin !== undefined
+  ) {
     try {
       await writeRestartHandoff(agentDir, {
-        schemaVersion: 1,
+        schemaVersion: 2,
         restartedAt: restartTimestamp,
         originatingSessionId,
         originatingSessionFile: basename(originatingSessionFile),
+        origin: handoffOrigin,
       })
     } catch {
       // intentional swallow — see the post-ACK rationale above

--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -55,6 +55,7 @@ function makeRouter(options: FakeRouterOptions = {}): ChannelRouter {
     getSelfAliases: () => [],
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    resumeRestartHandoff: async () => {},
     stop: async () => {},
     tearDownAllLive: async () => {},
     liveCount: () => 0,

--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -55,6 +55,7 @@ function makeRouter(options: FakeRouterOptions = {}): ChannelRouter {
     getSelfAliases: () => [],
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    reserveRestartHandoff: () => null,
     resumeRestartHandoff: async () => {},
     stop: async () => {},
     tearDownAllLive: async () => {},

--- a/src/agent/tools/channel-react.test.ts
+++ b/src/agent/tools/channel-react.test.ts
@@ -39,6 +39,7 @@ function fakeRouter(react: (req: ReactionRequest) => Promise<ReactionResult>): C
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    resumeRestartHandoff: async () => {},
   } as unknown as ChannelRouter
 }
 

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -58,6 +58,7 @@ function fakeRouter(
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    resumeRestartHandoff: async () => {},
   }
 }
 

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -58,6 +58,7 @@ function fakeRouter(
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    reserveRestartHandoff: () => null,
     resumeRestartHandoff: async () => {},
   }
 }

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -49,6 +49,7 @@ function fakeRouter(
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    resumeRestartHandoff: async () => {},
   }
 }
 

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -49,6 +49,7 @@ function fakeRouter(
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    reserveRestartHandoff: () => null,
     resumeRestartHandoff: async () => {},
   }
 }

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -77,6 +77,7 @@ function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    resumeRestartHandoff: async () => {},
   }
 }
 

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -77,6 +77,7 @@ function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    reserveRestartHandoff: () => null,
     resumeRestartHandoff: async () => {},
   }
 }

--- a/src/agent/tools/restart.test.ts
+++ b/src/agent/tools/restart.test.ts
@@ -324,6 +324,7 @@ describe('createRestartTool restart-pending handoff', () => {
       exit: () => {},
       agentDir,
       originatingSessionFile: '/some/abs/path/ses-originator.jsonl',
+      handoffOrigin: { kind: 'tui' },
     })
 
     // when
@@ -332,11 +333,64 @@ describe('createRestartTool restart-pending handoff', () => {
     // then
     const raw = await readFile(restartHandoffPath(agentDir), 'utf8')
     const parsed = JSON.parse(raw)
-    expect(parsed.schemaVersion).toBe(1)
+    expect(parsed.schemaVersion).toBe(2)
+    expect(parsed.origin).toEqual({ kind: 'tui' })
     expect(parsed.originatingSessionId).toBe('ses-originator')
     expect(parsed.originatingSessionFile).toBe('ses-originator.jsonl')
     expect(typeof parsed.restartedAt).toBe('string')
     expect(new Date(parsed.restartedAt).toISOString()).toBe(parsed.restartedAt)
+  })
+
+  test('writes a channel-origin handoff carrying the channel key', async () => {
+    // given
+    server = startOkServer()
+    const tool = createRestartTool({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      hostdToken: 'secret',
+      originatingSessionId: 'ses-channel',
+      exit: () => {},
+      agentDir,
+      originatingSessionFile: '/some/abs/path/ses-channel.jsonl',
+      handoffOrigin: {
+        kind: 'channel',
+        key: { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null },
+      },
+    })
+
+    // when
+    await tool.execute('id', {}, undefined, undefined, fakeCtx)
+
+    // then
+    const parsed = JSON.parse(await readFile(restartHandoffPath(agentDir), 'utf8'))
+    expect(parsed.schemaVersion).toBe(2)
+    expect(parsed.origin).toEqual({
+      kind: 'channel',
+      key: { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null },
+    })
+    expect(parsed.originatingSessionFile).toBe('ses-channel.jsonl')
+  })
+
+  test('skips the handoff when handoffOrigin is omitted (cron/subagent/system origins)', async () => {
+    // given
+    server = startOkServer()
+    const tool = createRestartTool({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      hostdToken: 'secret',
+      originatingSessionId: 'ses-cron',
+      exit: () => {},
+      agentDir,
+      originatingSessionFile: 'ses-cron.jsonl',
+    })
+
+    // when
+    await tool.execute('id', {}, undefined, undefined, fakeCtx)
+
+    // then
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
   })
 
   test('skips the handoff when agentDir is omitted (non-TUI origins do not greet)', async () => {
@@ -398,6 +452,7 @@ describe('createRestartTool restart-pending handoff', () => {
       },
       agentDir,
       originatingSessionFile: 'ses-originator.jsonl',
+      handoffOrigin: { kind: 'tui' },
     })
 
     // when
@@ -423,6 +478,7 @@ describe('createRestartTool restart-pending handoff', () => {
       stream,
       agentDir,
       originatingSessionFile: 'ses-originator.jsonl',
+      handoffOrigin: { kind: 'tui' },
     })
 
     // when

--- a/src/agent/tools/restart.ts
+++ b/src/agent/tools/restart.ts
@@ -2,6 +2,7 @@ import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
 import { requestContainerRestart } from '@/agent/restart'
+import type { RestartHandoffOrigin } from '@/agent/restart-handoff'
 import type { Stream } from '@/stream'
 
 const EXIT_DELAY_MS = 500
@@ -47,11 +48,15 @@ export type CreateRestartToolOptions = {
   // so the `typeclaw.restart-self` custom message entry that was just
   // appended is part of the LLM context on the next turn. When omitted,
   // no handoff is written — the new container cold-starts and no
-  // "I'm back" greeting fires. Gates the handoff on the origin being a
-  // TUI session: channel/cron/subagent origins should pass undefined so
-  // the next boot does not produce a stray channel post or unattended
-  // greeting (see issue #291's scoping concerns).
+  // "I'm back" greeting fires. Written for persisted TUI and channel
+  // origins; cron/subagent/system origins pass undefined so the next boot
+  // does not resume an unattended session.
   originatingSessionFile?: string
+  // Which subsystem owns resuming the originating session on the next boot
+  // (tui → websocket open handler; channel → channel router startup). Required
+  // alongside `originatingSessionFile` for the handoff to be written; omit to
+  // skip the handoff. See buildRestartHandoffWiring in src/agent/index.ts.
+  handoffOrigin?: RestartHandoffOrigin
 }
 
 export type RestartToolDetails = { ok: boolean; containerName: string; reason?: string }
@@ -69,6 +74,7 @@ export function createRestartTool({
   ackTimeoutMs,
   agentDir,
   originatingSessionFile,
+  handoffOrigin,
 }: CreateRestartToolOptions) {
   const doExit = exit ?? ((code: number) => process.exit(code))
 
@@ -114,6 +120,7 @@ export function createRestartTool({
         ...(stream !== undefined ? { stream } : {}),
         ...(agentDir !== undefined ? { agentDir } : {}),
         ...(originatingSessionFile !== undefined ? { originatingSessionFile } : {}),
+        ...(handoffOrigin !== undefined ? { handoffOrigin } : {}),
       })
       if (!result.ok) {
         const details: RestartToolDetails = { ok: false, containerName, reason: result.reason }

--- a/src/agent/tools/skip-response.test.ts
+++ b/src/agent/tools/skip-response.test.ts
@@ -57,6 +57,7 @@ function fakeRouter(
       opts.markCalls?.push({ parentSessionId: args.parentSessionId, reason: args.reason })
       return opts.markResult ?? { kind: 'recorded', keyId: 'discord-bot:g1:c1' }
     },
+    reserveRestartHandoff: () => null,
     resumeRestartHandoff: async () => {},
   }
 }

--- a/src/agent/tools/skip-response.test.ts
+++ b/src/agent/tools/skip-response.test.ts
@@ -57,6 +57,7 @@ function fakeRouter(
       opts.markCalls?.push({ parentSessionId: args.parentSessionId, reason: args.reason })
       return opts.markResult ?? { kind: 'recorded', keyId: 'discord-bot:g1:c1' }
     },
+    resumeRestartHandoff: async () => {},
   }
 }
 

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -68,6 +68,7 @@ function fakeRouter(handler: (msg: OutboundMessage) => Promise<SendResult>): Cha
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    reserveRestartHandoff: () => null,
     resumeRestartHandoff: async () => {},
   }
 }

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -68,6 +68,7 @@ function fakeRouter(handler: (msg: OutboundMessage) => Promise<SendResult>): Cha
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    resumeRestartHandoff: async () => {},
   }
 }
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7518,4 +7518,74 @@ describe('resumeRestartHandoff', () => {
     expect(after[0]).toMatchObject({ sessionFile: 'OLD_ses_origin.jsonl', lastInboundAt: 5 })
     expect(logs.some((l) => l.includes('restart-resume ensureLive failed'))).toBe(true)
   })
+
+  test('reserve then a racing inbound coalesces onto one session (no rival create)', async () => {
+    // given: a reservation installed BEFORE any inbound (the boot ordering)
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_origin', '2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    const factoryCalls: SessionFactoryArgs[] = []
+    const { router, sessions } = makeRouter(dir, {
+      factoryCalls,
+      transcriptPathFor: (sessionId) => `/tmp/fake/2026-05-02T16-56-52-380Z_${sessionId}.jsonl`,
+    })
+    const reservation = router.reserveRestartHandoff(channelHandoff())
+    expect(reservation).not.toBeNull()
+
+    // when: a real inbound races in, then the reservation resumes
+    const inboundDone = router.route(inbound({ authorId: 'alice', authorName: 'alice' }))
+    await reservation!.resume()
+    await inboundDone
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: exactly ONE session was created (the inbound coalesced onto the
+    // reserved resume, not a rival), reopening the originating session
+    expect(factoryCalls).toHaveLength(1)
+    expect(factoryCalls[0]?.existingSessionId).toBe('ses_origin')
+    expect(sessions).toHaveLength(1)
+  })
+
+  test('skips the synthetic wake when a real inbound coalesced during boot', async () => {
+    // given: a reservation, then a racing inbound (sawInbound becomes true)
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_origin', '2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    const { router, sessions } = makeRouter(dir, {
+      transcriptPathFor: (sessionId) => `/tmp/fake/2026-05-02T16-56-52-380Z_${sessionId}.jsonl`,
+    })
+    const reservation = router.reserveRestartHandoff(channelHandoff())!
+    // Fire the inbound WITHOUT awaiting: route() coalesces onto the reserved
+    // resume (awaits its `creating` gate), so it cannot complete until resume()
+    // runs — mirroring the boot window where the inbound arrives first.
+    const inboundDone = router.route(inbound({ authorId: 'alice', authorName: 'alice', text: 'hi there' }))
+    await waitFor(() => reservation.sawInbound)
+
+    // when
+    await reservation.resume()
+    await inboundDone
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the only prompt is the real inbound's turn — no extra synthetic
+    // wake turn was stacked on top
+    expect(sessions).toHaveLength(1)
+    const prompts = sessions[0]!.prompts
+    expect(prompts.some((p) => p.includes('hi there'))).toBe(true)
+    expect(prompts.some((p) => p.includes('container just restarted'))).toBe(false)
+  })
+
+  test('still wakes when no inbound races during boot', async () => {
+    // given: a reservation with no racing inbound
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_origin', '2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    const { router, sessions } = makeRouter(dir, {
+      transcriptPathFor: (sessionId) => `/tmp/fake/2026-05-02T16-56-52-380Z_${sessionId}.jsonl`,
+    })
+    const reservation = router.reserveRestartHandoff(channelHandoff())!
+
+    // when
+    await reservation.resume()
+    await waitFor(() => sessions.length > 0 && sessions[0]!.prompts.length > 0)
+
+    // then: the synthetic wake turn fired
+    expect(reservation.sawInbound).toBe(false)
+    expect(sessions[0]?.prompts.some((p) => p.includes('container just restarted'))).toBe(true)
+  })
 })

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -8,6 +8,7 @@ import type { AssistantMessage } from '@mariozechner/pi-ai'
 import type { SessionEntry } from '@mariozechner/pi-coding-agent'
 
 import type { AgentSession } from '@/agent'
+import type { RestartHandoff } from '@/agent/restart-handoff'
 import type { SessionOrigin } from '@/agent/session-origin'
 import type { PermissionService } from '@/permissions'
 import type { HookBus, SessionIdleEvent } from '@/plugin'
@@ -7366,5 +7367,84 @@ describe('review-thread resolver registry', () => {
 
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.code).toBe('transient')
+  })
+})
+
+describe('resumeRestartHandoff', () => {
+  async function seedMapping(dir: string, sessionId: string, sessionFile: string): Promise<void> {
+    await mkdir(join(dir, 'channels'), { recursive: true })
+    await saveChannelSessions(dir, [
+      {
+        adapter: KEY.adapter,
+        workspace: KEY.workspace,
+        chat: KEY.chat,
+        thread: KEY.thread,
+        sessionId,
+        sessionFile,
+        lastInboundAt: 0,
+        participants: [],
+      },
+    ])
+  }
+
+  function channelHandoff(over: Partial<RestartHandoff> = {}): RestartHandoff {
+    return {
+      schemaVersion: 2,
+      restartedAt: new Date().toISOString(),
+      originatingSessionId: 'ses_origin',
+      originatingSessionFile: '2026-05-02T16-56-52-380Z_ses_origin.jsonl',
+      origin: { kind: 'channel', key: { ...KEY } },
+      ...over,
+    }
+  }
+
+  test('reopens the exact originating session and wakes it (drains a turn)', async () => {
+    // given: a persisted mapping for the channel naming the originating session
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_origin', '2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    const factoryCalls: SessionFactoryArgs[] = []
+    const { router, sessions } = makeRouter(dir, {
+      factoryCalls,
+      transcriptPathFor: (sessionId) => `/tmp/fake/2026-05-02T16-56-52-380Z_${sessionId}.jsonl`,
+    })
+
+    // when
+    await router.resumeRestartHandoff(channelHandoff())
+    await waitFor(() => sessions.length > 0 && sessions[0]!.prompts.length > 0)
+
+    // then: reopened the same session id + file, and a turn fired
+    expect(factoryCalls).toHaveLength(1)
+    expect(factoryCalls[0]?.existingSessionId).toBe('ses_origin')
+    expect(factoryCalls[0]?.existingSessionFile).toBe('2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    expect(sessions[0]?.prompts.length).toBe(1)
+  })
+
+  test('skips when the persisted mapping no longer names the handoff session', async () => {
+    // given: the channel rolled over to a different session since the restart
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_other', '2026-05-02T16-56-52-380Z_ses_other.jsonl')
+    const factoryCalls: SessionFactoryArgs[] = []
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { factoryCalls, logs })
+
+    // when
+    await router.resumeRestartHandoff(channelHandoff())
+
+    // then: no reopen, logged the skip
+    expect(factoryCalls).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
+    expect(logs.some((l) => l.includes('restart-resume skipped'))).toBe(true)
+  })
+
+  test('is a no-op for a tui-origin handoff', async () => {
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_origin', '2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    const factoryCalls: SessionFactoryArgs[] = []
+    const { router, sessions } = makeRouter(dir, { factoryCalls })
+
+    await router.resumeRestartHandoff(channelHandoff({ origin: { kind: 'tui' } }))
+
+    expect(factoryCalls).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
   })
 })

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7447,4 +7447,75 @@ describe('resumeRestartHandoff', () => {
     expect(factoryCalls).toHaveLength(0)
     expect(sessions).toHaveLength(0)
   })
+
+  test('reopens even when the persisted mapping is far past the freshness TTL (bypasses stale-rollover)', async () => {
+    // given: a mapping whose lastInboundAt is well beyond SESSION_FRESHNESS_TTL_MS
+    const dir = await tempDir()
+    await mkdir(join(dir, 'channels'), { recursive: true })
+    await saveChannelSessions(dir, [
+      {
+        adapter: KEY.adapter,
+        workspace: KEY.workspace,
+        chat: KEY.chat,
+        thread: KEY.thread,
+        sessionId: 'ses_origin',
+        sessionFile: '2026-05-02T16-56-52-380Z_ses_origin.jsonl',
+        lastInboundAt: 1,
+        participants: [],
+      },
+    ])
+    const nowRef = { value: SESSION_FRESHNESS_TTL_MS * 100 }
+    const factoryCalls: SessionFactoryArgs[] = []
+    const { router } = makeRouter(dir, {
+      nowRef,
+      factoryCalls,
+      transcriptPathFor: (sessionId) => `/tmp/fake/2026-05-02T16-56-52-380Z_${sessionId}.jsonl`,
+    })
+
+    // when
+    await router.resumeRestartHandoff(channelHandoff())
+
+    // then: rehydrated the exact session rather than cold-starting a fresh one
+    expect(factoryCalls).toHaveLength(1)
+    expect(factoryCalls[0]?.existingSessionId).toBe('ses_origin')
+    expect(factoryCalls[0]?.existingSessionFile).toBe('2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+  })
+
+  test('leaves the durable mapping untouched when reopen fails (lossless skip)', async () => {
+    // given: a router whose session factory throws, so ensureLive fails
+    const dir = await tempDir()
+    await mkdir(join(dir, 'channels'), { recursive: true })
+    const seeded = {
+      adapter: KEY.adapter,
+      workspace: KEY.workspace,
+      chat: KEY.chat,
+      thread: KEY.thread,
+      sessionId: 'ses_origin',
+      sessionFile: 'OLD_ses_origin.jsonl',
+      lastInboundAt: 5,
+      participants: [],
+    }
+    await saveChannelSessions(dir, [seeded])
+    const logs: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      permissions: grantAllPermissions,
+      logger: { info: (m) => logs.push(`info:${m}`), warn: (m) => logs.push(`warn:${m}`), error: () => {} },
+      createSessionForChannel: async () => {
+        throw new Error('reopen boom')
+      },
+    })
+
+    // when
+    await router.resumeRestartHandoff(channelHandoff())
+
+    // then: the persisted record is byte-for-byte unchanged (no repointed
+    // sessionFile, no refreshed lastInboundAt), so the next inbound still
+    // stale-rolls into a clean session
+    const after = await loadChannelSessions(dir)
+    expect(after).toHaveLength(1)
+    expect(after[0]).toMatchObject({ sessionFile: 'OLD_ses_origin.jsonl', lastInboundAt: 5 })
+    expect(logs.some((l) => l.includes('restart-resume ensureLive failed'))).toBe(true)
+  })
 })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -697,11 +697,16 @@ export type ChannelRouter = {
     | { kind: 'recorded'; keyId: string }
     | { kind: 'recorded-after-send'; keyId: string }
     | { kind: 'no-live-session' }
-  // Reopen and wake the channel session that fired a restart, so the agent
-  // produces its post-restart turn and resumes pending todos. Called once at
-  // boot from src/run/index.ts after channel adapters have registered. No-op
-  // for non-channel handoffs. Safe to call with a stale/missing mapping — it
+  // Two-phase boot restart-resume. Call `reserveRestartHandoff(handoff)` BEFORE
+  // `channelManager.start()` to install a per-key gate so an inbound that races
+  // the adapters coming online coalesces onto the resume instead of competing
+  // with it; then `await reservation.resume()` AFTER start so the reopen + wake
+  // reply have registered adapters. Returns null for non-channel handoffs or an
+  // unconfigured adapter. `resume()` is safe on a stale/missing mapping — it
   // logs and skips, leaving the todo to resume on the next real inbound.
+  reserveRestartHandoff: (handoff: RestartHandoff) => RestartReservation | null
+  // Reserve + resume in one call (reserve, then immediately resume). For
+  // callers already past adapter startup; prefer the two-phase form at boot.
   resumeRestartHandoff: (handoff: RestartHandoff) => Promise<void>
   stop: () => Promise<void>
   tearDownAllLive: () => Promise<void>
@@ -824,6 +829,16 @@ export type ClaimHandlerOutcome =
   | { kind: 'fail'; reply: string }
   | { kind: 'fallthrough' }
 
+// A boot-time restart-resume reservation for one channel key. `resume()` runs
+// the real reopen after adapters are ready; `sawInbound` records whether a real
+// inbound coalesced onto it in the meantime (in which case the synthetic wake
+// is skipped — the inbound already triggers the turn).
+export type RestartReservation = {
+  keyId: string
+  sawInbound: boolean
+  resume: () => Promise<void>
+}
+
 export type ClaimHandler = (input: ClaimHandlerInput) => Promise<ClaimHandlerOutcome>
 
 const GRANT_ALL_PERMISSIONS: PermissionService = {
@@ -848,6 +863,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const onRestart = options.onRestart
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
+  // Restart-resume reservations, keyed by channelKeyId. Installed by
+  // reserveRestartHandoff BEFORE channel adapters start receiving, so an
+  // inbound that races the boot resume coalesces onto the reservation (via the
+  // `creating` entry it seeds) instead of stale-rolling the mapping or
+  // creating a competing session. `sawInbound` is flipped by route() when an
+  // inbound waited on it, which suppresses the synthetic wake (the real inbound
+  // is the wake). Cleared when the reservation resolves.
+  const restartReservations = new Map<string, RestartReservation>()
   // Bumped by tearDownAllLive() and stop() before they tear sessions down. An
   // in-flight ensureLive() captures the value at creation start and re-checks
   // it right before installing into liveSessions; if it changed, a teardown
@@ -2019,6 +2042,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       if (commandResult.kind !== 'not-command') return
     }
 
+    // If a boot restart-resume reservation is pending for this key, mark that a
+    // real inbound arrived: ensureLive below will coalesce onto the reservation
+    // (via its `creating` seed), and the reservation's resume() will skip the
+    // synthetic wake since this inbound already triggers the turn.
+    const reservation = restartReservations.get(channelKeyId(key))
+    if (reservation !== undefined) reservation.sawInbound = true
+
     const live = await ensureLive(key, event.externalMessageId, event.authorId)
 
     const isNewAuthor = !live.participants.some((p) => p.authorId === event.authorId)
@@ -2976,27 +3006,30 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
-  // Boot-time resume for a restart that originated from a channel session.
-  // The dying container appended a `typeclaw.restart-self` entry to the
-  // originating session's JSONL and wrote a handoff naming it; this reopens
-  // that exact session and wakes it so the model produces the "I'm back" turn
-  // and the post-turn idle resumes any pending todos.
+  // Boot-time resume for a restart that originated from a channel session, in
+  // two phases to close the race with adapters that begin receiving inbounds.
   //
-  // The handoff's channel key is reverse-validated against the persisted
-  // mapping (it must still name the originating session), then `ensureLive` is
-  // called with a `resumeTarget` so it rehydrates that exact session and
-  // bypasses stale-rollover WITHOUT any pre-mutation of the durable mapping —
-  // ensureLive persists only on a successful reopen. If the mapping no longer
-  // matches, the adapter is unconfigured, or reopen fails, resume is skipped
-  // and the durable mapping is left untouched; the pending todo still resumes
-  // on the next real inbound's drain.
+  // PHASE 1 — reserveRestartHandoff(handoff): called BEFORE the adapters start.
+  // It seeds a per-key entry in `creating` so any inbound that arrives during
+  // boot coalesces onto the (not-yet-run) resume instead of stale-rolling the
+  // mapping or creating a competing session. It does NOT touch resolvers or
+  // outbound callbacks (not registered yet) — it only installs the gate.
   //
-  // The wake is enqueued (pendingSystemReminders + drain) before this resolves,
-  // so a caller that awaits resumeRestartHandoff has ordered the synthetic wake
-  // ahead of any real same-channel inbound; the LLM turn itself runs async via
-  // the fire-and-forget drain.
-  const resumeRestartHandoff = async (handoff: RestartHandoff): Promise<void> => {
-    if (handoff.origin.kind !== 'channel') return
+  // PHASE 2 — reservation.resume(): called AFTER channelManager.start(), when
+  // adapters (and thus resolvers + the outbound callback the wake reply needs)
+  // are ready. It removes its own `creating` seed, reopens the exact session
+  // via ensureLive(resumeTarget) (bypassing stale-rollover, persisting only on
+  // success), and — only if no real inbound coalesced in the meantime — arms
+  // the restart-kick suppressor and enqueues the synthetic wake. If an inbound
+  // did arrive, that inbound is the wake, so the synthetic one is skipped to
+  // avoid a duplicate/spurious "I'm back" turn.
+  //
+  // The `typeclaw.restart-self` entry is already in the reopened JSONL (the
+  // dying container appended it on the restart broadcast), so reopening the
+  // file is what produces the greeting; adapter readiness only matters for
+  // delivering the eventual reply.
+  const reserveRestartHandoff = (handoff: RestartHandoff): RestartReservation | null => {
+    if (handoff.origin.kind !== 'channel') return null
     const key: ChannelKey = {
       adapter: handoff.origin.key.adapter,
       workspace: handoff.origin.key.workspace,
@@ -3007,44 +3040,91 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
     if (options.configForAdapter(key.adapter) === undefined) {
       logger.warn(`[channels] ${keyId}: restart-resume skipped — adapter not configured`)
-      return
+      return null
     }
 
-    await ensureLoaded()
-    const record = mappings ? findRecord(mappings, key) : undefined
-    if (record?.sessionId !== handoff.originatingSessionId) {
-      logger.warn(
-        `[channels] ${keyId}: restart-resume skipped — persisted session ` +
-          `${record?.sessionId ?? '<none>'} no longer matches handoff ${handoff.originatingSessionId}`,
-      )
-      return
-    }
+    let resolveGate!: (live: LiveSession) => void
+    let rejectGate!: (err: unknown) => void
+    const gate = new Promise<LiveSession>((res, rej) => {
+      resolveGate = res
+      rejectGate = rej
+    })
+    // Seed `creating` so a racing inbound's ensureLive awaits this gate rather
+    // than starting its own create. Suppress an unhandled-rejection warning on
+    // the skip/failure paths that never get an inbound waiter.
+    creating.set(keyId, gate)
+    gate.catch(() => undefined)
 
-    let live: LiveSession
-    try {
-      live = await ensureLive(key, undefined, undefined, {
-        sessionId: handoff.originatingSessionId,
-        sessionFile: handoff.originatingSessionFile,
-      })
-    } catch (err) {
-      logger.warn(`[channels] ${keyId}: restart-resume ensureLive failed: ${describe(err)}`)
-      return
-    }
-    if (live.sessionId !== handoff.originatingSessionId) {
-      logger.warn(
-        `[channels] ${keyId}: restart-resume reopened a different session ` +
-          `(${live.sessionId} != ${handoff.originatingSessionId}); skipping wake`,
-      )
-      return
-    }
+    const reservation: RestartReservation = {
+      keyId,
+      sawInbound: false,
+      resume: async () => {
+        // Drop our own seed BEFORE calling ensureLive, or ensureLive would
+        // await the gate we are about to resolve and deadlock.
+        if (creating.get(keyId) === gate) creating.delete(keyId)
+        restartReservations.delete(keyId)
 
-    await armRestartKickForOrigin(options.agentDir, buildLiveOrigin(live)).catch((err) =>
-      logger.error(`[channels] ${keyId}: restart-resume arm restart-kick failed: ${describe(err)}`),
-    )
+        await ensureLoaded()
+        const record = mappings ? findRecord(mappings, key) : undefined
+        if (record?.sessionId !== handoff.originatingSessionId) {
+          logger.warn(
+            `[channels] ${keyId}: restart-resume skipped — persisted session ` +
+              `${record?.sessionId ?? '<none>'} no longer matches handoff ${handoff.originatingSessionId}`,
+          )
+          rejectGate(new StaleLiveSessionError(keyId))
+          return
+        }
 
-    live.pendingSystemReminders.push(RESTART_RESUME_WAKE_REMINDER)
-    logger.info(`[channels] ${keyId}: restart-resume waking session ${live.sessionId}`)
-    void drain(live)
+        let live: LiveSession
+        try {
+          live = await ensureLive(key, undefined, undefined, {
+            sessionId: handoff.originatingSessionId,
+            sessionFile: handoff.originatingSessionFile,
+          })
+        } catch (err) {
+          logger.warn(`[channels] ${keyId}: restart-resume ensureLive failed: ${describe(err)}`)
+          rejectGate(err)
+          return
+        }
+        resolveGate(live)
+
+        if (live.sessionId !== handoff.originatingSessionId) {
+          logger.warn(
+            `[channels] ${keyId}: restart-resume reopened a different session ` +
+              `(${live.sessionId} != ${handoff.originatingSessionId}); skipping wake`,
+          )
+          return
+        }
+
+        // A real inbound coalesced onto the reservation during boot: it is the
+        // wake. Adding the synthetic "I'm back" turn on top would duplicate
+        // work / stack a spurious turn, so skip it and let the inbound drain.
+        if (reservation.sawInbound) {
+          logger.info(`[channels] ${keyId}: restart-resume coalesced with a real inbound; skipping synthetic wake`)
+          return
+        }
+
+        await armRestartKickForOrigin(options.agentDir, buildLiveOrigin(live)).catch((err) =>
+          logger.error(`[channels] ${keyId}: restart-resume arm restart-kick failed: ${describe(err)}`),
+        )
+
+        live.pendingSystemReminders.push(RESTART_RESUME_WAKE_REMINDER)
+        logger.info(`[channels] ${keyId}: restart-resume waking session ${live.sessionId}`)
+        void drain(live)
+      },
+    }
+    restartReservations.set(keyId, reservation)
+    return reservation
+  }
+
+  // Reserve + resume in one call, for callers (and tests) that run after the
+  // adapters are already started and so don't need the pre-start gate. Still
+  // benefits from the reservation's sawInbound suppression for inbounds that
+  // race between reserve and resume.
+  const resumeRestartHandoff = async (handoff: RestartHandoff): Promise<void> => {
+    const reservation = reserveRestartHandoff(handoff)
+    if (reservation === null) return
+    await reservation.resume()
   }
 
   const executeCommand = async (
@@ -3206,6 +3286,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     getSelfAliases: computeSelfAliases,
     injectSubagentCompletionReminder,
     markTurnSkipped,
+    reserveRestartHandoff,
     resumeRestartHandoff,
     stop,
     tearDownAllLive,

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1066,10 +1066,20 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     key: ChannelKey,
     triggeringMessageId?: string,
     triggeringAuthorId?: string,
+    // Restart-resume only: force rehydration of this exact (sessionId,
+    // sessionFile) and bypass stale-rollover, so the originating session's
+    // `typeclaw.restart-self` entry is reopened rather than rolled into a fresh
+    // session (a restart easily outlasts SESSION_FRESHNESS_TTL_MS). The mapping
+    // is persisted only through the normal success path below — no pre-mutation
+    // — so a reopen failure leaves the durable mapping untouched.
+    resumeTarget?: { sessionId: string; sessionFile: string },
   ): Promise<LiveSession> => {
     const keyId = channelKeyId(key)
     const existing = liveSessions.get(keyId)
     if (existing && !existing.destroyed) {
+      // A resume that finds the key already live is a no-op for reopening: the
+      // session is up, so just hand it back and let the caller enqueue the wake.
+      if (resumeTarget !== undefined) return existing
       const idleMs = now() - existing.lastInboundAt
       // `lastInboundAt` is only bumped on engaged inbounds (see route()),
       // so a session whose drain loop has been compiling a slow reply for
@@ -1124,6 +1134,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       const record = mappings ? findRecord(mappings, key) : undefined
       let resolvedRecord = record
       if (
+        resumeTarget === undefined &&
         record?.sessionId !== undefined &&
         existing === undefined &&
         now() - (record.lastInboundAt ?? 0) > SESSION_FRESHNESS_TTL_MS
@@ -1150,6 +1161,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             mappings[idx] = resolvedRecord
             await persist()
           }
+        }
+      }
+      if (resumeTarget !== undefined) {
+        // Reopen the exact originating session in-memory only; the success
+        // path below persists it. Carry the prior record's participants when
+        // present so the reopened session keeps its roster.
+        resolvedRecord = {
+          adapter: key.adapter,
+          workspace: key.workspace,
+          chat: key.chat,
+          thread: key.thread,
+          sessionId: resumeTarget.sessionId,
+          sessionFile: resumeTarget.sessionFile,
+          participants: (record?.participants ?? []) as ChannelParticipant[],
+          lastInboundAt: now(),
         }
       }
       const phase = resolvedRecord?.sessionId === undefined ? 'cold-start' : 'rehydrate'
@@ -2957,12 +2983,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // and the post-turn idle resumes any pending todos.
   //
   // The handoff's channel key is reverse-validated against the persisted
-  // mapping: the record is repaired to point at `originatingSessionFile` with a
-  // fresh `lastInboundAt` so `ensureLive` rehydrates the exact session via its
-  // normal rehydrate path instead of stale-rolling it into a fresh one (a
-  // restart easily outlasts SESSION_FRESHNESS_TTL_MS). If the mapping is gone,
-  // the adapter is unconfigured, or reopen fails, resume is skipped — the
-  // pending todo still resumes on the next real inbound's drain.
+  // mapping (it must still name the originating session), then `ensureLive` is
+  // called with a `resumeTarget` so it rehydrates that exact session and
+  // bypasses stale-rollover WITHOUT any pre-mutation of the durable mapping —
+  // ensureLive persists only on a successful reopen. If the mapping no longer
+  // matches, the adapter is unconfigured, or reopen fails, resume is skipped
+  // and the durable mapping is left untouched; the pending todo still resumes
+  // on the next real inbound's drain.
+  //
+  // The wake is enqueued (pendingSystemReminders + drain) before this resolves,
+  // so a caller that awaits resumeRestartHandoff has ordered the synthetic wake
+  // ahead of any real same-channel inbound; the LLM turn itself runs async via
+  // the fire-and-forget drain.
   const resumeRestartHandoff = async (handoff: RestartHandoff): Promise<void> => {
     if (handoff.origin.kind !== 'channel') return
     const key: ChannelKey = {
@@ -2988,21 +3020,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return
     }
 
-    const idx = mappings!.findIndex(
-      (s) =>
-        s.adapter === key.adapter &&
-        s.workspace === key.workspace &&
-        s.chat === key.chat &&
-        (s.thread ?? null) === (key.thread ?? null),
-    )
-    if (idx >= 0) {
-      mappings![idx] = { ...mappings![idx]!, sessionFile: handoff.originatingSessionFile, lastInboundAt: now() }
-      await persist()
-    }
-
     let live: LiveSession
     try {
-      live = await ensureLive(key)
+      live = await ensureLive(key, undefined, undefined, {
+        sessionId: handoff.originatingSessionId,
+        sessionFile: handoff.originatingSessionFile,
+      })
     } catch (err) {
       logger.warn(`[channels] ${keyId}: restart-resume ensureLive failed: ${describe(err)}`)
       return

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -5,9 +5,11 @@ import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession, renderTurnRoleAnchor, renderTurnTimeAnchor, type AgentSession } from '@/agent'
 import { subscribeProviderErrors } from '@/agent/provider-error'
+import type { RestartHandoff } from '@/agent/restart-handoff'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
 import {
+  armRestartKickForOrigin,
   extractTurnUsage,
   recordTurnOutcome,
   recordTurnStart,
@@ -127,6 +129,23 @@ export const SESSION_GC_INTERVAL_MS = 60 * 1000
 // recovery paths (`source: 'system'`) bypass.
 export const MAX_CHANNEL_SENDS_PER_TURN = 10
 export const ENGAGE_REACTION_EMOJI = 'eyes'
+
+// Wake nudge pushed into a resumed channel session at boot so drain() has a
+// non-empty batch and fires a turn. The substantive instruction the model acts
+// on is the `typeclaw.restart-self` entry already in the reopened JSONL (pi
+// hydrates it as a user message); this nudge only triggers the turn. Uses the
+// repo's SYSTEM MESSAGE framing (see composeTurnPrompt) so persona-rich models
+// do not reply to it as if a human wrote it.
+export const RESTART_RESUME_WAKE_REMINDER = [
+  '---',
+  '**[SYSTEM MESSAGE — not from a human]**',
+  '',
+  'The container just restarted and this session was resumed. Act on the',
+  'restart instructions already in your context. Do not acknowledge or reply to',
+  'this notice itself.',
+  '',
+  '---',
+].join('\n')
 // Ceiling on tool-source channel sends that a same-turn router policy DENIED
 // without delivering — `skip-locked`, `turn-cap`, or `duplicate`. Such denials
 // return a soft error and do NOT increment `consecutiveSends`, so a model that
@@ -678,6 +697,12 @@ export type ChannelRouter = {
     | { kind: 'recorded'; keyId: string }
     | { kind: 'recorded-after-send'; keyId: string }
     | { kind: 'no-live-session' }
+  // Reopen and wake the channel session that fired a restart, so the agent
+  // produces its post-restart turn and resumes pending todos. Called once at
+  // boot from src/run/index.ts after channel adapters have registered. No-op
+  // for non-channel handoffs. Safe to call with a stale/missing mapping — it
+  // logs and skips, leaving the todo to resume on the next real inbound.
+  resumeRestartHandoff: (handoff: RestartHandoff) => Promise<void>
   stop: () => Promise<void>
   tearDownAllLive: () => Promise<void>
   liveCount: () => number
@@ -2925,6 +2950,80 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
+  // Boot-time resume for a restart that originated from a channel session.
+  // The dying container appended a `typeclaw.restart-self` entry to the
+  // originating session's JSONL and wrote a handoff naming it; this reopens
+  // that exact session and wakes it so the model produces the "I'm back" turn
+  // and the post-turn idle resumes any pending todos.
+  //
+  // The handoff's channel key is reverse-validated against the persisted
+  // mapping: the record is repaired to point at `originatingSessionFile` with a
+  // fresh `lastInboundAt` so `ensureLive` rehydrates the exact session via its
+  // normal rehydrate path instead of stale-rolling it into a fresh one (a
+  // restart easily outlasts SESSION_FRESHNESS_TTL_MS). If the mapping is gone,
+  // the adapter is unconfigured, or reopen fails, resume is skipped — the
+  // pending todo still resumes on the next real inbound's drain.
+  const resumeRestartHandoff = async (handoff: RestartHandoff): Promise<void> => {
+    if (handoff.origin.kind !== 'channel') return
+    const key: ChannelKey = {
+      adapter: handoff.origin.key.adapter,
+      workspace: handoff.origin.key.workspace,
+      chat: handoff.origin.key.chat,
+      thread: handoff.origin.key.thread,
+    }
+    const keyId = channelKeyId(key)
+
+    if (options.configForAdapter(key.adapter) === undefined) {
+      logger.warn(`[channels] ${keyId}: restart-resume skipped — adapter not configured`)
+      return
+    }
+
+    await ensureLoaded()
+    const record = mappings ? findRecord(mappings, key) : undefined
+    if (record?.sessionId !== handoff.originatingSessionId) {
+      logger.warn(
+        `[channels] ${keyId}: restart-resume skipped — persisted session ` +
+          `${record?.sessionId ?? '<none>'} no longer matches handoff ${handoff.originatingSessionId}`,
+      )
+      return
+    }
+
+    const idx = mappings!.findIndex(
+      (s) =>
+        s.adapter === key.adapter &&
+        s.workspace === key.workspace &&
+        s.chat === key.chat &&
+        (s.thread ?? null) === (key.thread ?? null),
+    )
+    if (idx >= 0) {
+      mappings![idx] = { ...mappings![idx]!, sessionFile: handoff.originatingSessionFile, lastInboundAt: now() }
+      await persist()
+    }
+
+    let live: LiveSession
+    try {
+      live = await ensureLive(key)
+    } catch (err) {
+      logger.warn(`[channels] ${keyId}: restart-resume ensureLive failed: ${describe(err)}`)
+      return
+    }
+    if (live.sessionId !== handoff.originatingSessionId) {
+      logger.warn(
+        `[channels] ${keyId}: restart-resume reopened a different session ` +
+          `(${live.sessionId} != ${handoff.originatingSessionId}); skipping wake`,
+      )
+      return
+    }
+
+    await armRestartKickForOrigin(options.agentDir, buildLiveOrigin(live)).catch((err) =>
+      logger.error(`[channels] ${keyId}: restart-resume arm restart-kick failed: ${describe(err)}`),
+    )
+
+    live.pendingSystemReminders.push(RESTART_RESUME_WAKE_REMINDER)
+    logger.info(`[channels] ${keyId}: restart-resume waking session ${live.sessionId}`)
+    void drain(live)
+  }
+
   const executeCommand = async (
     key: ChannelKey,
     name: string,
@@ -3084,6 +3183,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     getSelfAliases: computeSelfAliases,
     injectSubagentCompletionReminder,
     markTurnSkipped,
+    resumeRestartHandoff,
     stop,
     tearDownAllLive,
     liveCount: () => liveSessions.size,

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -288,9 +288,13 @@ export async function startAgent({
       if (containerName === undefined) {
         return 'Restart is unavailable: this agent is not running inside a typeclaw container.'
       }
-      // No originatingSessionId/stream/handoff: a channel-invoked restart must
-      // not write a resume hint or fire the "I'm back" broadcast that a TUI
-      // restart does (issue #291 scoping — only TUI origins resume).
+      // The /restart admin COMMAND writes no handoff: unlike the `restart`
+      // tool (which runs inside a specific session and resumes that exact
+      // conversation), this command is a fire-and-forget admin action with no
+      // originating session id/file to reopen. The container bounces; the next
+      // real inbound rehydrates the channel and resumes any pending todos via
+      // the normal idle continuation. Wiring command-initiated resume is
+      // tracked separately (see #291).
       const result = await requestContainerRestart({ containerName })
       return result.ok ? 'Restart scheduled; the container will bounce shortly.' : `Restart denied: ${result.reason}`
     },

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -520,22 +520,35 @@ export async function startAgent({
   })
 
   reloadRegistry.register(createChannelsReloadable({ manager: channelManager }))
-  await channelManager.start()
 
-  // Resume a channel-origin restart now that adapters + outbound callbacks are
-  // registered, and AWAIT it: resumeRestartHandoff reopens the originating
-  // session and enqueues the synthetic wake before it resolves (the LLM turn
-  // itself runs async via its fire-and-forget drain). Awaiting here orders the
-  // wake ahead of any real same-channel inbound the server may accept once
-  // boot continues. Claims ONLY channel handoffs — tui handoffs are left on
-  // disk (peek-then-delete never removes an unclaimed handoff) for the
-  // websocket open handler in src/server/index.ts to claim. Best-effort: any
-  // failure leaves the pending todo to resume on the next real inbound.
+  // Two-phase channel restart-resume around adapter startup, to close the race
+  // where an adapter starts receiving before the resume claims the handoff:
+  //   1. Claim the channel handoff and RESERVE the originating key BEFORE
+  //      channelManager.start(). The reservation installs a per-key gate, so an
+  //      inbound that arrives the instant an adapter connects coalesces onto the
+  //      resume instead of stale-rolling the mapping or creating a rival session.
+  //   2. start() the adapters (registers outbound callbacks the wake reply needs).
+  //   3. resume() the reservation: reopen the exact session and enqueue the wake
+  //      — skipped automatically if a real inbound already coalesced in (2)→(3).
+  // Claims ONLY channel handoffs; tui handoffs are left on disk (peek-then-delete
+  // never removes an unclaimed handoff) for the websocket open handler to claim.
+  // Best-effort throughout: any failure leaves the todo to resume on the next inbound.
+  let restartReservation: ReturnType<typeof channelManager.router.reserveRestartHandoff> = null
   try {
     const handoff = await consumeRestartHandoff(cwd, { accept: (h) => h.origin.kind === 'channel' })
-    if (handoff !== null) await channelManager.router.resumeRestartHandoff(handoff)
+    if (handoff !== null) restartReservation = channelManager.router.reserveRestartHandoff(handoff)
   } catch (err) {
-    console.warn(`[run] channel restart-resume failed: ${err instanceof Error ? err.message : err}`)
+    console.warn(`[run] channel restart-resume reserve failed: ${err instanceof Error ? err.message : err}`)
+  }
+
+  await channelManager.start()
+
+  if (restartReservation !== null) {
+    try {
+      await restartReservation.resume()
+    } catch (err) {
+      console.warn(`[run] channel restart-resume failed: ${err instanceof Error ? err.message : err}`)
+    }
   }
 
   // Captured separately from setSpawnSubagent so both the plugin context and

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -4,6 +4,7 @@ import { createSession, createSessionWithDispose } from '@/agent'
 import { LiveSessionRegistry } from '@/agent/live-sessions'
 import { LiveSubagentRegistry } from '@/agent/live-subagents'
 import { requestContainerRestart } from '@/agent/restart'
+import { consumeRestartHandoff } from '@/agent/restart-handoff'
 import type { SessionOrigin } from '@/agent/session-origin'
 import {
   awaitWithSubagentTimeout,
@@ -516,6 +517,17 @@ export async function startAgent({
 
   reloadRegistry.register(createChannelsReloadable({ manager: channelManager }))
   await channelManager.start()
+
+  // Resume a channel-origin restart now that adapters + outbound callbacks are
+  // registered. Claims ONLY channel handoffs (tui handoffs are owned by the
+  // websocket open handler in src/server/index.ts); a tui handoff left on disk
+  // is restored for that path to claim. Best-effort: any failure leaves the
+  // pending todo to resume on the next real inbound.
+  void consumeRestartHandoff(cwd, { accept: (h) => h.origin.kind === 'channel' })
+    .then(async (handoff) => {
+      if (handoff !== null) await channelManager.router.resumeRestartHandoff(handoff)
+    })
+    .catch((err) => console.warn(`[run] channel restart-resume failed: ${err instanceof Error ? err.message : err}`))
 
   // Captured separately from setSpawnSubagent so both the plugin context and
   // the plugin-command runner can dispatch through the same path. The setter

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -519,15 +519,20 @@ export async function startAgent({
   await channelManager.start()
 
   // Resume a channel-origin restart now that adapters + outbound callbacks are
-  // registered. Claims ONLY channel handoffs (tui handoffs are owned by the
-  // websocket open handler in src/server/index.ts); a tui handoff left on disk
-  // is restored for that path to claim. Best-effort: any failure leaves the
-  // pending todo to resume on the next real inbound.
-  void consumeRestartHandoff(cwd, { accept: (h) => h.origin.kind === 'channel' })
-    .then(async (handoff) => {
-      if (handoff !== null) await channelManager.router.resumeRestartHandoff(handoff)
-    })
-    .catch((err) => console.warn(`[run] channel restart-resume failed: ${err instanceof Error ? err.message : err}`))
+  // registered, and AWAIT it: resumeRestartHandoff reopens the originating
+  // session and enqueues the synthetic wake before it resolves (the LLM turn
+  // itself runs async via its fire-and-forget drain). Awaiting here orders the
+  // wake ahead of any real same-channel inbound the server may accept once
+  // boot continues. Claims ONLY channel handoffs — tui handoffs are left on
+  // disk (peek-then-delete never removes an unclaimed handoff) for the
+  // websocket open handler in src/server/index.ts to claim. Best-effort: any
+  // failure leaves the pending todo to resume on the next real inbound.
+  try {
+    const handoff = await consumeRestartHandoff(cwd, { accept: (h) => h.origin.kind === 'channel' })
+    if (handoff !== null) await channelManager.router.resumeRestartHandoff(handoff)
+  } catch (err) {
+    console.warn(`[run] channel restart-resume failed: ${err instanceof Error ? err.message : err}`)
+  }
 
   // Captured separately from setSpawnSubagent so both the plugin context and
   // the plugin-command runner can dispatch through the same path. The setter

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -267,7 +267,7 @@ export function createServer({
       handoffPending = false
       return null
     }
-    handoffInFlight = consumeRestartHandoff(agentDir).catch(() => null)
+    handoffInFlight = consumeRestartHandoff(agentDir, { accept: (h) => h.origin.kind === 'tui' }).catch(() => null)
     const result = await handoffInFlight
     handoffPending = false
     handoffInFlight = null


### PR DESCRIPTION
## Background

A user in a Discord channel told the agent to add a todo ("greet after restart"), then said "restart". The agent wrote the todo and called the `restart` tool; the container restarted — and the agent came back silent. The pending todo was on disk but was never resumed, and no post-restart turn fired.

Container logs showed the restart completing normally. The todo entry (`typeclaw.restart-self`) was present in memory. No follow-up turn ever appeared in the channel.

## Root cause

The restart-resume + todo-continuation machinery was TUI-only by construction.

`buildRestartHandoffWiring` in `src/agent/index.ts` wrote no restart handoff for non-TUI origins. This was a deliberate prior scoping decision (issue #291) to avoid the agent posting an unprompted "I'm back" message into a channel. Only the websocket `open` handler in `src/server/index.ts` consumed the handoff and drove resume.

Channel sessions are created lazily on inbound (`ensureLive`). After a reboot no live channel session exists, no inbound arrives, the handoff is never consumed, and the channel todo-continuation path — which only runs at the tail of a live `drain()` loop — never fires.

## What changed

This PR is 6 commits; the loop-guard abort commit is included because it was on the branch and is orthogonal.

**`agent: add restart-handoff v2 schema with kind-aware consume`**

Handoff carries an `origin` discriminator — `{kind:'tui'}` or `{kind:'channel', key}` — so the next boot routes resume to the right subsystem. v1 files (TUI-only by construction) read forward as a tui origin.

`consumeRestartHandoff` gains an `accept` predicate and **restores** a handoff it declines. The TUI websocket path and the channel-startup path can each claim only their own kind without the first reader deleting the other's file.

**`agent: thread restart handoff origin through the restart tool`**

`createRestartTool` and `requestContainerRestart` accept a `handoffOrigin` and gate the v2 handoff write on it. Callers that omit it (cron/subagent/system, in-memory, ad-hoc test construction) write no handoff, exactly as before.

**`agent: emit a restart handoff for persisted channel sessions`**

`buildRestartHandoffWiring` now returns origin metadata for persisted TUI and channel sessions (still nothing for cron/subagent/system or in-memory sessions). This intentionally extends issue #291's scope — see _Behavior change_ below.

**`server: claim only TUI restart handoffs on websocket open`**

The websocket open handler consumes with a tui-only predicate, leaving a channel handoff on disk for the channel startup path rather than deleting it on the first TUI reconnect.

**`channels: resume a channel-origin restart at boot`**

New `ChannelRouter.resumeRestartHandoff`, driven once from `src/run/index.ts` after `channelManager.start()`. It reopens the exact originating session — repairing the persisted `channels/sessions.json` mapping to bypass stale-rollover (a restart easily outlasts the 5-min freshness TTL, which would otherwise spawn a fresh session and lose the `typeclaw.restart-self` entry) — arms the one-shot restart-kick suppressor, and wakes the session via a fenced SYSTEM-MESSAGE nudge. On a stale/missing mapping, unconfigured adapter, or reopen failure it logs and skips; the todo still resumes on the next real inbound.

**`agent: abort the turn when the loop guard blocks, instead of only refusing`** (orthogonal, included on this branch)

Loop-guard `block` verdicts previously surfaced as `isError` tool results that the model just retried. This fires `session.agent.abort()` at each block branch. Unrelated to the restart fix.

## Behavior change

This **partially reverses issue #291**: channel-origin restarts now resume. The agent reopens the session, fires the post-restart turn, and resumes pending todos — including the in-channel greeting the user explicitly triggered.

The decision to include the in-channel greeting for channel origins was explicit: a user who told the agent to restart and expects a follow-up deserves the resume. TUI behavior is unchanged; cron and subagent origins still write no handoff.

## Testing

New test coverage added in this PR:

- `src/agent/restart-handoff/index.test.ts` — v2 schema, v1 forward-read, `accept` predicate (claim / restore / re-claim across TUI and channel kinds)
- `src/agent/restart-handoff-wiring.test.ts` — `buildRestartHandoffWiring` branch coverage: tui / channel / cron / subagent / system / in-memory / no-file / no-agentDir
- `src/agent/tools/restart.test.ts` — restart tool writes tui + channel handoffs and skips without `handoffOrigin`; `requestContainerRestart` field-gating
- `src/channels/router.test.ts` — `resumeRestartHandoff` reopens the exact session and wakes it; skips on stale mapping; is a no-op for tui handoffs
- `src/agent/plugin-tools.test.ts` — loop-guard abort fires exactly once on block (plugin and system paths); does not fire before the threshold

Gates: `bun run typecheck` clean, `bun run lint` 0 errors, `bun run format:check` clean, `bun run test` 6980 pass / 1 skip.

**One pre-existing test failure** in `src/update/index.test.ts` — `resolveSelfPackageJsonPath > points at this package manifest` — asserts the repo directory basename is `typeclaw`, which fails only when running from a worktree checked out under a differently-named directory. It passes on a standard `typeclaw` checkout and will pass in CI. It is not a regression from this change.

## Risk / graceful degradation

If `resumeRestartHandoff` fails at any step (stale mapping, unconfigured adapter, reopen error) it logs and returns without throwing, so `typeclaw run` startup is unaffected. The todo entry remains on disk and resumes on the next real inbound from that channel. There is no new failure mode that leaves the agent in a broken state.

The `accept` predicate + restore-on-decline logic means a TUI reconnect racing a channel boot cannot permanently consume the other kind's handoff — the file is atomically restored if declined.