### PR TITLE
github: skip auto-review on draft PRs until explicitly requested

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -356,6 +356,34 @@ describe('classifyGithubInbound', () => {
         expect(msg?.text).toContain('requested your review on PR #7')
       })
 
+      it('skips the auto-review on a draft PR, landing it as awareness-only context', () => {
+        const msg = classifyGithubInbound('pull_request', openedPayload({ draft: true }), 'typeclaw-bot', {
+          reviewOn: 'opened',
+        })
+        expect(msg?.chat).toBe('pr:7')
+        expect(msg?.isBotMention).toBe(false)
+        expect(msg?.text).not.toContain('Please review the changes line-by-line')
+      })
+
+      it('still auto-reviews when draft is explicitly false', () => {
+        const msg = classifyGithubInbound('pull_request', openedPayload({ draft: false }), 'typeclaw-bot', {
+          reviewOn: 'opened',
+        })
+        expect(msg?.isBotMention).toBe(true)
+        expect(msg?.text).toContain('Please review the changes line-by-line')
+      })
+
+      it('still triggers on an explicit review_requested even when the PR is a draft', () => {
+        const msg = classifyGithubInbound(
+          'pull_request',
+          reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot', draft: true }),
+          'typeclaw-bot',
+          { reviewOn: 'opened' },
+        )
+        expect(msg?.isBotMention).toBe(true)
+        expect(msg?.text).toContain('requested your review on PR #7')
+      })
+
       it('suppresses the review trigger when the bot opened its own PR (handler drops the self-authored event)', () => {
         const payload = openedPayload()
         ;(payload.sender as Record<string, unknown>).login = 'typeclaw-bot'
@@ -1268,20 +1296,28 @@ function pullRequestForReview(updatedAt: string): Record<string, unknown> {
   }
 }
 
-function openedPayload(options: { updatedAt?: string } = {}): Record<string, unknown> {
+function openedPayload(options: { updatedAt?: string; draft?: boolean } = {}): Record<string, unknown> {
+  const pull_request = pullRequestForReview(options.updatedAt ?? '2026-01-01T00:00:00Z')
+  if (options.draft !== undefined) pull_request.draft = options.draft
   return {
     action: 'opened',
     repository: repo(),
-    pull_request: pullRequestForReview(options.updatedAt ?? '2026-01-01T00:00:00Z'),
+    pull_request,
     sender: { login: 'alice', id: 10, type: 'User' },
   }
 }
 
-function reviewRequestedPayload(options: { reviewerLogin: string; updatedAt?: string }): Record<string, unknown> {
+function reviewRequestedPayload(options: {
+  reviewerLogin: string
+  updatedAt?: string
+  draft?: boolean
+}): Record<string, unknown> {
+  const pull_request = pullRequestForReview(options.updatedAt ?? '2026-01-01T00:00:00Z')
+  if (options.draft !== undefined) pull_request.draft = options.draft
   return {
     action: 'review_requested',
     repository: repo(),
-    pull_request: pullRequestForReview(options.updatedAt ?? '2026-01-01T00:00:00Z'),
+    pull_request,
     requested_reviewer: { login: options.reviewerLogin, id: 42, type: 'User' },
     sender: { login: 'alice', id: 10, type: 'User' },
   }

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -494,6 +494,12 @@ function classifyOpenedReviewTrigger(input: OpenedReviewTriggerInput): InboundMe
   const decoyLogin = resolveDecoyReviewerLogin(selfLogin, authType)
   if (sender.login === selfLogin || (decoyLogin !== null && sender.login === decoyLogin)) return null
 
+  // A draft PR is work-in-progress, so the automatic `opened` path skips it: null
+  // here drops to awareness-only context (like a non-`opened` reviewOn) instead of
+  // waking a review. An explicit `review_requested` still triggers on a draft via
+  // classifyReviewRequest, preserving "skip until explicitly requested".
+  if (readBoolean(pr, 'draft') === true) return null
+
   const title = readString(pr, 'title') ?? `#${number}`
   const head = readString(readRecord(pr.head), 'ref')
   const baseRef = readString(readRecord(pr.base), 'ref')
@@ -736,6 +742,11 @@ function readString(obj: Record<string, unknown> | null, key: string): string | 
 function readNumber(obj: Record<string, unknown> | null, key: string): number | null {
   const value = obj?.[key]
   return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function readBoolean(obj: Record<string, unknown> | null, key: string): boolean | null {
+  const value = obj?.[key]
+  return typeof value === 'boolean' ? value : null
 }
 
 function ok(): Response {

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -136,7 +136,8 @@ export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [
 // prefix is implied by this field living under the review config); `off` is the
 // disable sentinel, matching the `engagement.stickiness: 'off'` convention:
 //   - 'review_requested' — review only when the bot is requested (default)
-//   - 'opened'           — review every PR as soon as it opens
+//   - 'opened'           — review every non-draft PR as soon as it opens; draft
+//                          PRs are skipped until an explicit review_requested
 //   - 'off'              — disable code review entirely
 export const GITHUB_REVIEW_ON_VALUES = ['review_requested', 'opened', 'off'] as const
 


### PR DESCRIPTION
## Background

When an operator sets `channels.github.review.on: 'opened'`, TypeClaw auto-reviews every PR the moment it opens. That sweep includes **draft** PRs. A draft is an explicit "work in progress, not ready" signal from the author — auto-reviewing it is premature (the diff is still churning) and noisy (the bot posts a formal review nobody asked for, then has to re-review once the work lands).

There was no draft awareness anywhere in the GitHub adapter: `pull_request.draft` was never read. The `'opened'` path synthesized a review-trigger inbound (`isBotMention: true`) for any opened PR, draft or not.

## Summary

`classifyOpenedReviewTrigger` now returns `null` when the PR payload's `draft` flag is `true`. That drops the PR to the existing **awareness-only** context path — the same place a non-`'opened'` `reviewOn` already lands an opened PR — instead of waking a review session.

**Why guard only the `opened` path, not `review_requested`:** "auto-review" is precisely the automatic `opened` sweep. An explicit `review_requested` event is a human (or team) deliberately asking for a review, which the request says should still work — "until explicitly requested." So `classifyReviewRequest` is left untouched: requesting the bot on a draft still triggers a review. This keeps the two paths cleanly split — automatic vs. explicit — and means the only behavior change is "the automatic sweep now respects draft status."

A small `readBoolean` helper joins the existing `readString`/`readNumber` payload accessors.

## What this does NOT do

- Does not touch the explicit `review_requested` / `review_request_removed` path — explicit requests fire on drafts as before.
- Does not add a `ready_for_review` trigger. Marking a draft ready does not auto-review it today (that action isn't in the default event allowlist); this PR keeps that behavior. Re-opening for review still goes through an explicit `review_requested`.
- Does not add a new config knob — draft-skip is unconditional under `'opened'`, matching the "work in progress" semantics of a draft.

## Review notes

- Load-bearing change: the single `if (readBoolean(pr, 'draft') === true) return null` line in `classifyOpenedReviewTrigger` (`src/channels/adapters/github/inbound.ts`). Returning `null` is what hands the PR to the awareness-only fallthrough rather than the review trigger.
- Invariant to verify: explicit `review_requested` on a draft still synthesizes a review trigger. Covered by `still triggers on an explicit review_requested even when the PR is a draft`.
- New tests assert: draft `opened` → awareness-only (`isBotMention === false`, no "Please review" text); `draft: false` → still reviews; explicit request on a draft → still reviews. The draft-skip test fails if the guard is removed (verified).
