### PR TITLE
sandbox: make .git writable in the bash jail so members can commit

### DIFF
--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -530,8 +530,13 @@ async function applyBashSandbox(
   // drops any writable zone masked for this role so an RW bind never re-exposes a
   // hidden path (e.g. a guest's masked workspace/).
   const writable = subtractMasked(await resolveWritableZones(agentDir), { dirs, files })
+  // subtractMasked again on the protected set: a protected RO bind renders after
+  // the masks (last-op-wins), so an unfiltered protected path nested under a
+  // masked dir (e.g. a guest's workspace/ when core.hooksPath=workspace/hooks)
+  // would re-expose the hidden real dir. A masked path is already non-writable
+  // for this role, so it needs no protection anyway.
   const protectedZones = writable.dirs.includes(join(agentDir, '.git'))
-    ? await resolveProtectedZones(agentDir)
+    ? subtractMasked(await resolveProtectedZones(agentDir), { dirs, files })
     : { dirs: [], files: [] }
   // bwrap does --clearenv, so the overlay must be re-introduced via env.set or
   // it would never reach the sandboxed process (the non-sandboxed spawnHook

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
+import { join } from 'node:path'
 
 import type { AgentTool } from '@mariozechner/pi-agent-core'
 import {
@@ -37,6 +38,7 @@ import {
   buildSandboxedCommand,
   ensureBwrapAvailable,
   resolveHiddenPaths,
+  resolveProtectedZones,
   resolveWritableZones,
   subtractMasked,
 } from '@/sandbox'
@@ -516,12 +518,20 @@ async function applyBashSandbox(
   await ensureBwrapAvailable()
   // Write-confined jail for low-trust roles: bind the whole project read-only,
   // hide private/secret paths, then re-expose only the free-write scratch zones
-  // RW. Anything else under agentDir (.git/, node_modules/, agentDir root) is
-  // EROFS, so bash cannot sidestep the non-workspace-write guard. Trusted/owner
-  // never reach here (their masks are empty) and keep full unsandboxed access.
-  // subtractMasked drops any writable zone masked for this role so an RW bind
-  // never re-exposes a hidden path (e.g. a guest's masked workspace/).
+  // (workspace + root allowlist + .git) RW. The WORKING TREE outside those zones
+  // (node_modules/, agentDir root, non-allowlisted tracked files) stays EROFS, so
+  // bash cannot sidestep the non-workspace-write guard — and `git checkout` of a
+  // protected worktree path fails at the kernel. .git is RW so members can
+  // commit; .git/hooks + .git/config are re-protected RO (protected, rendered
+  // after writable) so a hook-plant / core.hooksPath does not become code
+  // execution in the unsandboxed runtime git ops. Trusted/owner never reach here
+  // (their masks are empty) and keep full unsandboxed access. subtractMasked
+  // drops any writable zone masked for this role so an RW bind never re-exposes a
+  // hidden path (e.g. a guest's masked workspace/).
   const writable = subtractMasked(await resolveWritableZones(agentDir), { dirs, files })
+  const protectedZones = writable.dirs.includes(join(agentDir, '.git'))
+    ? await resolveProtectedZones(agentDir)
+    : { dirs: [], files: [] }
   // bwrap does --clearenv, so the overlay must be re-introduced via env.set or
   // it would never reach the sandboxed process (the non-sandboxed spawnHook
   // path does not run when the command is rewritten to a bwrap invocation).
@@ -529,6 +539,7 @@ async function applyBashSandbox(
     mounts: [{ type: 'ro-bind', source: agentDir, dest: agentDir }],
     masks: { dirs, files },
     writable,
+    protected: protectedZones,
     network: 'inherit',
     cwd: agentDir,
     ...(envOverlay !== undefined ? { env: { set: envOverlay } } : {}),

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -522,9 +522,10 @@ async function applyBashSandbox(
   // (node_modules/, agentDir root, non-allowlisted tracked files) stays EROFS, so
   // bash cannot sidestep the non-workspace-write guard — and `git checkout` of a
   // protected worktree path fails at the kernel. .git is RW so members can
-  // commit; .git/hooks + .git/config are re-protected RO (protected, rendered
-  // after writable) so a hook-plant / core.hooksPath does not become code
-  // execution in the unsandboxed runtime git ops. Trusted/owner never reach here
+  // commit; .git/hooks + .git/config (and any writable core.hooksPath target)
+  // are re-protected RO (protected, rendered after writable, ensured to exist so
+  // an absent path can't be created+executed) so a hook-plant / core.hooksPath
+  // never becomes code execution in the unsandboxed runtime git ops. Trusted/owner never reach here
   // (their masks are empty) and keep full unsandboxed access. subtractMasked
   // drops any writable zone masked for this role so an RW bind never re-exposes a
   // hidden path (e.g. a guest's masked workspace/).

--- a/src/bundled-plugins/backup/index.ts
+++ b/src/bundled-plugins/backup/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { withGitLock } from '@/git/mutex'
 import { definePlugin, type PluginContext, type SpawnSubagentOptions, type Subagent } from '@/plugin'
 
 import { COMMIT_TIMEOUT_MS, makeDefaultGitSpawn, NETWORK_TIMEOUT_MS, runBackup, type BackupResult } from './runner'
@@ -174,44 +175,46 @@ async function runBackupOnce(
     spawnedByOrigin: { kind: 'tui', sessionId: 'backup-runner' },
   }
 
-  const result = await runBackup(
-    { cwd: payload.agentDir, pushToOrigin: payload.pushToOrigin },
-    {
-      gitSpawn: makeDefaultGitSpawn(),
-      pickCommitMessage: async ({ status, diffstat }) => {
-        await cleanupMessageFile(messagePath)
-        const messagePayload: CommitMessagePayload = {
-          agentDir: payload.agentDir,
-          status,
-          diffstat,
-          outputPath: messagePath,
-        }
-        try {
-          await ctx.spawnSubagent(SUBAGENT_COMMIT_MESSAGE, messagePayload, inheritOwner)
-        } catch (err) {
-          ctx.logger.warn(
-            `${SUBAGENT_COMMIT_MESSAGE} subagent failed, using fallback: ${err instanceof Error ? err.message : String(err)}`,
-          )
-        }
-        const written = await readMessageFile(messagePath)
-        await cleanupMessageFile(messagePath)
-        return written ?? 'chore: backup'
+  const result = await withGitLock(payload.agentDir, () =>
+    runBackup(
+      { cwd: payload.agentDir, pushToOrigin: payload.pushToOrigin },
+      {
+        gitSpawn: makeDefaultGitSpawn(),
+        pickCommitMessage: async ({ status, diffstat }) => {
+          await cleanupMessageFile(messagePath)
+          const messagePayload: CommitMessagePayload = {
+            agentDir: payload.agentDir,
+            status,
+            diffstat,
+            outputPath: messagePath,
+          }
+          try {
+            await ctx.spawnSubagent(SUBAGENT_COMMIT_MESSAGE, messagePayload, inheritOwner)
+          } catch (err) {
+            ctx.logger.warn(
+              `${SUBAGENT_COMMIT_MESSAGE} subagent failed, using fallback: ${err instanceof Error ? err.message : String(err)}`,
+            )
+          }
+          const written = await readMessageFile(messagePath)
+          await cleanupMessageFile(messagePath)
+          return written ?? 'chore: backup'
+        },
+        diagnoseFailure: async (input) => {
+          const diagPayload: DiagnoseFailurePayload = {
+            agentDir: input.cwd,
+            stage: input.stage,
+            exitCode: input.exitCode,
+            stderr: input.stderr,
+            stdout: input.stdout,
+          }
+          try {
+            await ctx.spawnSubagent(SUBAGENT_DIAGNOSE, diagPayload, inheritOwner)
+          } catch (err) {
+            ctx.logger.warn(`${SUBAGENT_DIAGNOSE} subagent failed: ${err instanceof Error ? err.message : String(err)}`)
+          }
+        },
       },
-      diagnoseFailure: async (input) => {
-        const diagPayload: DiagnoseFailurePayload = {
-          agentDir: input.cwd,
-          stage: input.stage,
-          exitCode: input.exitCode,
-          stderr: input.stderr,
-          stdout: input.stdout,
-        }
-        try {
-          await ctx.spawnSubagent(SUBAGENT_DIAGNOSE, diagPayload, inheritOwner)
-        } catch (err) {
-          ctx.logger.warn(`${SUBAGENT_DIAGNOSE} subagent failed: ${err instanceof Error ? err.message : String(err)}`)
-        }
-      },
-    },
+    ),
   )
 
   await cleanupMessageFile(messagePath)

--- a/src/bundled-plugins/backup/runner.test.ts
+++ b/src/bundled-plugins/backup/runner.test.ts
@@ -3,7 +3,14 @@ import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { type BackupRunnerDeps, type GitSpawn, type GitSpawnResult, parsePorcelain, runBackup } from './runner'
+import {
+  type BackupRunnerDeps,
+  type GitSpawn,
+  type GitSpawnResult,
+  parsePorcelain,
+  runBackup,
+  withIndexLockRetry,
+} from './runner'
 
 const okResult = (stdout = ''): GitSpawnResult => ({ exitCode: 0, stdout, stderr: '', timedOut: false })
 const failResult = (stderr = 'boom', exit = 1): GitSpawnResult => ({
@@ -361,5 +368,21 @@ describe('parsePorcelain', () => {
 
   test('skips empty and short lines', () => {
     expect(parsePorcelain('\n  \nXY\n')).toEqual([])
+  })
+})
+
+describe('withIndexLockRetry', () => {
+  test('retries index.lock failures and returns the successful result', async () => {
+    const calls: Array<readonly string[]> = []
+    const spawn: GitSpawn = async (args) => {
+      calls.push(args)
+      if (calls.length <= 2) return failResult("fatal: Unable to create '.git/index.lock': File exists")
+      return okResult('done')
+    }
+
+    const result = await withIndexLockRetry(spawn)(['add', '--', 'foo'], { cwd: '/repo', timeoutMs: 1 })
+
+    expect(result).toEqual(okResult('done'))
+    expect(calls).toHaveLength(3)
   })
 })

--- a/src/bundled-plugins/backup/runner.ts
+++ b/src/bundled-plugins/backup/runner.ts
@@ -217,7 +217,7 @@ function sanitizeCommitMessage(raw: string): string {
 }
 
 export function makeDefaultGitSpawn(): GitSpawn {
-  return async (args, { cwd, timeoutMs }) => {
+  return withIndexLockRetry(async (args, { cwd, timeoutMs }) => {
     const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
     if (!bun) {
       return { exitCode: 127, stdout: '', stderr: 'Bun runtime not available', timedOut: false }
@@ -249,5 +249,26 @@ export function makeDefaultGitSpawn(): GitSpawn {
     } finally {
       clearTimeout(timer)
     }
+  })
+}
+
+export function withIndexLockRetry(spawn: GitSpawn): GitSpawn {
+  return async (args, opts) => {
+    let result = await spawn(args, opts)
+    for (const delayMs of [50, 150, 350]) {
+      if (result.exitCode === 0 || !isIndexLockContention(result.stderr)) return result
+      await sleep(delayMs)
+      result = await spawn(args, opts)
+    }
+    return result
   }
+}
+
+function isIndexLockContention(stderr: string): boolean {
+  const lower = stderr.toLowerCase()
+  return lower.includes('index.lock') || (lower.includes('unable to create') && lower.includes('index.lock'))
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms))
 }

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 
 import { z } from 'zod'
 
+import { withGitLock } from '@/git/mutex'
 import { defineTool, lsTool, readTool, type Subagent, writeTool } from '@/plugin'
 import { formatLocalDate, formatLocalDateTime } from '@/shared'
 
@@ -419,6 +420,10 @@ async function ensureMemoryFiles(agentDir: string): Promise<void> {
 // `git add` fails with "outside of your sparse-checkout definition" on a
 // skip-worktree path.
 export async function commitMemorySnapshot(cwd: string): Promise<void> {
+  await withGitLock(cwd, () => commitMemorySnapshotUnlocked(cwd))
+}
+
+async function commitMemorySnapshotUnlocked(cwd: string): Promise<void> {
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) return
   if (!existsSync(join(cwd, '.git'))) return

--- a/src/git/mutex.test.ts
+++ b/src/git/mutex.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test'
+
+import { withGitLock } from './mutex'
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+}
+
+function deferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const tick = async (): Promise<void> => {
+  await Promise.resolve()
+}
+
+describe('withGitLock', () => {
+  test('serializes calls with the same key', async () => {
+    const order: string[] = []
+    const firstCanFinish = deferred()
+    const secondStarted = deferred()
+
+    const first = withGitLock('agent-a', async () => {
+      order.push('first:start')
+      await firstCanFinish.promise
+      order.push('first:end')
+    })
+    const second = withGitLock('agent-a', async () => {
+      order.push('second:start')
+      secondStarted.resolve()
+    })
+
+    await tick()
+    expect(order).toEqual(['first:start'])
+    firstCanFinish.resolve()
+    await secondStarted.promise
+    await Promise.all([first, second])
+    expect(order).toEqual(['first:start', 'first:end', 'second:start'])
+  })
+
+  test('runs distinct keys concurrently', async () => {
+    const order: string[] = []
+    const firstCanFinish = deferred()
+    const secondStarted = deferred()
+
+    const first = withGitLock('agent-a', async () => {
+      order.push('first:start')
+      await firstCanFinish.promise
+      order.push('first:end')
+    })
+    const second = withGitLock('agent-b', async () => {
+      order.push('second:start')
+      secondStarted.resolve()
+    })
+
+    await secondStarted.promise
+    expect(order).toEqual(['first:start', 'second:start'])
+    firstCanFinish.resolve()
+    await Promise.all([first, second])
+  })
+
+  test('releases the lock after a callback throws', async () => {
+    const order: string[] = []
+    const first = withGitLock('agent-a', async () => {
+      order.push('first:start')
+      throw new Error('boom')
+    })
+    const second = withGitLock('agent-a', async () => {
+      order.push('second:start')
+    })
+
+    await expect(first).rejects.toThrow('boom')
+    await second
+    expect(order).toEqual(['first:start', 'second:start'])
+  })
+
+  test('propagates the callback return value', async () => {
+    await expect(withGitLock('agent-a', async () => 42)).resolves.toBe(42)
+  })
+})

--- a/src/git/mutex.ts
+++ b/src/git/mutex.ts
@@ -1,0 +1,22 @@
+const chains = new Map<string, Promise<void>>()
+
+export async function withGitLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const previous = chains.get(key) ?? Promise.resolve()
+  let release!: () => void
+  const current = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const next = previous.then(
+    () => current,
+    () => current,
+  )
+  chains.set(key, next)
+
+  await previous.catch(() => undefined)
+  try {
+    return await fn()
+  } finally {
+    release()
+    if (chains.get(key) === next) chains.delete(key)
+  }
+}

--- a/src/sandbox/build.test.ts
+++ b/src/sandbox/build.test.ts
@@ -235,6 +235,36 @@ describe('buildSandboxedCommand writable overlays', () => {
   })
 })
 
+describe('buildSandboxedCommand protected re-binds', () => {
+  test('re-binds protected dirs and files read-only with --ro-bind <p> <p>', () => {
+    const joined = argvOf('true', {
+      protected: { dirs: ['/agent/.git/hooks'], files: ['/agent/.git/config'] },
+    }).join(' ')
+    expect(joined).toContain('--ro-bind /agent/.git/hooks /agent/.git/hooks')
+    expect(joined).toContain('--ro-bind /agent/.git/config /agent/.git/config')
+  })
+
+  test('renders protected RO re-binds AFTER the writable .git bind so last-op-wins keeps hooks/config EROFS', () => {
+    const argv = argvOf('true', {
+      mounts: [{ type: 'ro-bind', source: '/agent', dest: '/agent' }],
+      writable: { dirs: ['/agent/.git'], files: [] },
+      protected: { dirs: ['/agent/.git/hooks'], files: ['/agent/.git/config'] },
+    })
+    const writableGit = argv.lastIndexOf('/agent/.git')
+    const hooksProtect = argv.indexOf('/agent/.git/hooks')
+    const configProtect = argv.indexOf('/agent/.git/config')
+    expect(writableGit).toBeGreaterThanOrEqual(0)
+    expect(hooksProtect).toBeGreaterThan(writableGit)
+    expect(configProtect).toBeGreaterThan(writableGit)
+  })
+
+  test('emits no protected re-binds when the policy omits them', () => {
+    const joined = argvOf('true', { writable: { dirs: ['/agent/.git'] } }).join(' ')
+    expect(joined).not.toContain('/agent/.git/hooks')
+    expect(joined).not.toContain('/agent/.git/config')
+  })
+})
+
 describe('buildSandboxedCommand proc strategy', () => {
   test("omits the /proc tmpfs for proc: 'none'", () => {
     const argv = argvOf('true', { proc: 'none' })

--- a/src/sandbox/build.ts
+++ b/src/sandbox/build.ts
@@ -111,6 +111,7 @@ function buildArgv(command: string, policy: SandboxPolicy): string[] {
 
   appendMasks(argv, policy)
   appendWritable(argv, policy)
+  appendProtected(argv, policy)
 
   if (policy.cwd !== undefined) {
     argv.push('--chdir', policy.cwd)
@@ -135,6 +136,15 @@ function appendWritable(argv: string[], policy: SandboxPolicy): void {
   }
   for (const file of policy.writable?.files ?? []) {
     argv.push('--bind', file, file)
+  }
+}
+
+function appendProtected(argv: string[], policy: SandboxPolicy): void {
+  for (const dir of policy.protected?.dirs ?? []) {
+    argv.push('--ro-bind', dir, dir)
+  }
+  for (const file of policy.protected?.files ?? []) {
+    argv.push('--ro-bind', file, file)
   }
 }
 

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,7 +1,13 @@
 export { buildSandboxedCommand, type SandboxedCommand } from './build'
 export { ensureBwrapAvailable, _resetBwrapAvailabilityCacheForTests } from './availability'
 export { resolveHiddenPaths, type HiddenPaths } from './hidden-paths'
-export { resolveWritableZones, subtractMasked, type WritableZones } from './writable-zones'
+export {
+  resolveProtectedZones,
+  resolveWritableZones,
+  subtractMasked,
+  type ProtectedZones,
+  type WritableZones,
+} from './writable-zones'
 export { formatCommand, shellQuote } from './quote'
 export { SandboxPolicyError, SandboxUnavailableError } from './errors'
 export {
@@ -13,5 +19,6 @@ export {
   type SandboxPolicy,
   type SandboxProcessPolicy,
   type SandboxProcStrategy,
+  type SandboxProtectedPolicy,
   type SandboxWritablePolicy,
 } from './policy'

--- a/src/sandbox/policy.ts
+++ b/src/sandbox/policy.ts
@@ -46,12 +46,24 @@ export type SandboxWritablePolicy = {
   files?: string[]
 }
 
+// Read-only re-protections carved back out of a writable parent. MUST render
+// after `writable` so bwrap's last-op-wins keeps these EROFS despite the parent
+// RW bind. Load-bearing: `.git` is writable so members can commit, but
+// `.git/hooks` and `.git/config` stay RO here — otherwise a low-trust role
+// plants a hook or sets core.hooksPath and gets code execution in the
+// unsandboxed runtime git ops (backup/dreaming) that share the same .git.
+export type SandboxProtectedPolicy = {
+  dirs?: string[]
+  files?: string[]
+}
+
 export type SandboxPolicy = {
   bwrapPath?: string
   cwd?: string
   mounts?: SandboxMount[]
   masks?: SandboxMaskPolicy
   writable?: SandboxWritablePolicy
+  protected?: SandboxProtectedPolicy
   network?: SandboxNetwork
   env?: SandboxEnvPolicy
   commandFilter?: SandboxCommandFilter

--- a/src/sandbox/writable-zones.test.ts
+++ b/src/sandbox/writable-zones.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { resolveWritableZones, subtractMasked } from './writable-zones'
+import { resolveProtectedZones, resolveWritableZones, subtractMasked } from './writable-zones'
 
 let agentDir: string
 
@@ -84,6 +84,41 @@ describe('resolveWritableZones', () => {
 
   test('returns empty lists for a bare agent dir', async () => {
     const { dirs, files } = await resolveWritableZones(agentDir)
+
+    expect(dirs).toEqual([])
+    expect(files).toEqual([])
+  })
+
+  test('includes .git when it exists so bash can commit', async () => {
+    await mkdir(join(agentDir, '.git'))
+
+    const { dirs } = await resolveWritableZones(agentDir)
+
+    expect(dirs).toContain(join(agentDir, '.git'))
+  })
+
+  test('omits .git when absent (bwrap would abort binding a missing source)', async () => {
+    const { dirs } = await resolveWritableZones(agentDir)
+
+    expect(dirs).not.toContain(join(agentDir, '.git'))
+  })
+})
+
+describe('resolveProtectedZones', () => {
+  test('re-protects .git/hooks and .git/config when present', async () => {
+    await mkdir(join(agentDir, '.git', 'hooks'), { recursive: true })
+    await writeFile(join(agentDir, '.git', 'config'), '[core]\n')
+
+    const { dirs, files } = await resolveProtectedZones(agentDir)
+
+    expect(dirs).toEqual([join(agentDir, '.git/hooks')])
+    expect(files).toEqual([join(agentDir, '.git/config')])
+  })
+
+  test('drops absent protected entries so bwrap never binds a missing source', async () => {
+    await mkdir(join(agentDir, '.git'))
+
+    const { dirs, files } = await resolveProtectedZones(agentDir)
 
     expect(dirs).toEqual([])
     expect(files).toEqual([])

--- a/src/sandbox/writable-zones.test.ts
+++ b/src/sandbox/writable-zones.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -111,17 +111,52 @@ describe('resolveProtectedZones', () => {
 
     const { dirs, files } = await resolveProtectedZones(agentDir)
 
-    expect(dirs).toEqual([join(agentDir, '.git/hooks')])
+    expect(dirs).toContain(join(agentDir, '.git/hooks'))
     expect(files).toEqual([join(agentDir, '.git/config')])
   })
 
-  test('drops absent protected entries so bwrap never binds a missing source', async () => {
+  test('ensures and protects .git/hooks + .git/config even when absent', async () => {
     await mkdir(join(agentDir, '.git'))
 
     const { dirs, files } = await resolveProtectedZones(agentDir)
 
-    expect(dirs).toEqual([])
-    expect(files).toEqual([])
+    // given .git existed but hooks/config did not, they are created AND returned
+    expect(dirs).toContain(join(agentDir, '.git/hooks'))
+    expect(files).toEqual([join(agentDir, '.git/config')])
+    expect((await stat(join(agentDir, '.git/hooks'))).isDirectory()).toBe(true)
+    expect((await stat(join(agentDir, '.git/config'))).isFile()).toBe(true)
+  })
+
+  test('rejects a symlinked .git/hooks rather than protecting the wrong target', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'typeclaw-outside-'))
+    try {
+      await mkdir(join(agentDir, '.git'))
+      await symlink(outside, join(agentDir, '.git', 'hooks'))
+
+      await expect(resolveProtectedZones(agentDir)).rejects.toThrow(/symlink/i)
+    } finally {
+      await rm(outside, { recursive: true, force: true })
+    }
+  })
+
+  test('also protects a core.hooksPath that points inside the agent dir', async () => {
+    await mkdir(join(agentDir, '.git'), { recursive: true })
+    await writeFile(join(agentDir, '.git', 'config'), '[core]\n\thooksPath = workspace/hooks\n')
+
+    const { dirs } = await resolveProtectedZones(agentDir)
+
+    expect(dirs).toContain(join(agentDir, 'workspace/hooks'))
+    expect((await lstat(join(agentDir, 'workspace/hooks'))).isDirectory()).toBe(true)
+  })
+
+  test('ignores a core.hooksPath that resolves outside the agent dir', async () => {
+    await mkdir(join(agentDir, '.git'), { recursive: true })
+    await writeFile(join(agentDir, '.git', 'config'), '[core]\n\thooksPath = /etc\n')
+
+    const { dirs } = await resolveProtectedZones(agentDir)
+
+    expect(dirs).not.toContain('/etc')
+    expect(dirs).toContain(join(agentDir, '.git/hooks'))
   })
 })
 

--- a/src/sandbox/writable-zones.test.ts
+++ b/src/sandbox/writable-zones.test.ts
@@ -158,6 +158,20 @@ describe('resolveProtectedZones', () => {
     expect(dirs).not.toContain('/etc')
     expect(dirs).toContain(join(agentDir, '.git/hooks'))
   })
+
+  test('a masked-dir core.hooksPath is dropped by subtractMasked (no mask re-exposure)', async () => {
+    await mkdir(join(agentDir, '.git'), { recursive: true })
+    await writeFile(join(agentDir, '.git', 'config'), '[core]\n\thooksPath = workspace/hooks\n')
+
+    // given a guest whose workspace/ is masked, protecting workspace/hooks would
+    // re-expose the hidden dir; subtractMasked (as applyBashSandbox applies it)
+    // must drop it — the masked path is unwritable, so it needs no protection
+    const protectedZones = await resolveProtectedZones(agentDir)
+    const filtered = subtractMasked(protectedZones, { dirs: [join(agentDir, 'workspace')], files: [] })
+
+    expect(filtered.dirs).not.toContain(join(agentDir, 'workspace/hooks'))
+    expect(filtered.dirs).toContain(join(agentDir, '.git/hooks'))
+  })
 })
 
 describe('subtractMasked', () => {

--- a/src/sandbox/writable-zones.ts
+++ b/src/sandbox/writable-zones.ts
@@ -6,6 +6,11 @@ export type WritableZones = {
   files: string[]
 }
 
+export type ProtectedZones = {
+  dirs: string[]
+  files: string[]
+}
+
 // SECURITY: a blanket RW bind is coarser than the write/edit guards, so this set
 // is deliberately NARROWER than the write/edit allowlist — only genuinely
 // free-write scratch zones. `.agents/skills` and `packages` are excluded: the
@@ -13,7 +18,18 @@ export type WritableZones = {
 // guard and the latter holds executable plugin code; bash must not get blanket
 // RW to either. Skill authoring and package writes go through the guarded
 // write/edit tool only.
-const WRITABLE_DIRS = ['workspace', 'public', 'mounts'] as const
+// `.git` is writable so a member can `git add`/`git commit` their own edits to
+// the already-editable surface (workspace + root allowlist files). The escape
+// risk — staging arbitrary tree content via plumbing, or planting hooks — is
+// contained two ways: low-trust roles are still write-confined for the WORKING
+// TREE (paths outside the writable zones stay EROFS, so `git checkout` of a
+// protected path fails at the kernel), and `.git/hooks` + `.git/config` are
+// re-protected read-only via resolveProtectedZones so core.hooksPath/hook-plant
+// RCE into the unsandboxed runtime git ops is closed.
+const WRITABLE_DIRS = ['workspace', 'public', 'mounts', '.git'] as const
+
+const PROTECTED_GIT_DIRS = ['.git/hooks'] as const
+const PROTECTED_GIT_FILES = ['.git/config'] as const
 
 // Bash may EDIT these when present; creating a MISSING root file goes through
 // write/edit (bwrap cannot RW-bind a non-existent source without pre-creating it).
@@ -38,6 +54,20 @@ export async function resolveWritableZones(agentDir: string): Promise<WritableZo
   )
   const files = await collectExisting(
     WRITABLE_ROOT_FILES.map((f) => join(agentDir, f)),
+    'file',
+  )
+  return { dirs, files }
+}
+
+// Re-protected read-only on top of the writable .git bind. Absent entries are
+// dropped so bwrap never binds a missing source.
+export async function resolveProtectedZones(agentDir: string): Promise<ProtectedZones> {
+  const dirs = await collectExisting(
+    PROTECTED_GIT_DIRS.map((d) => join(agentDir, d)),
+    'dir',
+  )
+  const files = await collectExisting(
+    PROTECTED_GIT_FILES.map((f) => join(agentDir, f)),
     'file',
   )
   return { dirs, files }

--- a/src/sandbox/writable-zones.ts
+++ b/src/sandbox/writable-zones.ts
@@ -1,5 +1,5 @@
-import { lstat } from 'node:fs/promises'
-import path, { join } from 'node:path'
+import { lstat, mkdir, readFile, writeFile } from 'node:fs/promises'
+import path, { isAbsolute, join, resolve } from 'node:path'
 
 export type WritableZones = {
   dirs: string[]
@@ -66,18 +66,81 @@ export async function resolveWritableZones(agentDir: string): Promise<WritableZo
   return { dirs, files }
 }
 
-// Re-protected read-only on top of the writable .git bind. Absent entries are
-// dropped so bwrap never binds a missing source.
+// Read-only re-protections rendered on top of the writable .git bind. Unlike
+// the writable resolvers, this MUST NOT drop absent entries: .git is writable,
+// so a path absent at jail-build time would otherwise be CREATED by sandboxed
+// bash (e.g. a planted .git/hooks/pre-commit) and then executed by the
+// unsandboxed runtime git ops. So we ensure each protected path exists first,
+// then always RO-bind it — a read-only bind of a real dir blocks creating
+// children inside it (EROFS), and a read-only bind of config keeps its real
+// content readable (commits need user.name/email) while blocking mutation.
+//
+// We also resolve the effective core.hooksPath from the real (about-to-be-RO)
+// config: if it already points at a writable location (e.g. workspace/hooks),
+// the .git/hooks RO-bind alone would not cover it, so that dir is protected too.
 export async function resolveProtectedZones(agentDir: string): Promise<ProtectedZones> {
-  const dirs = await collectExisting(
-    PROTECTED_GIT_DIRS.map((d) => join(agentDir, d)),
-    'dir',
-  )
-  const files = await collectExisting(
-    PROTECTED_GIT_FILES.map((f) => join(agentDir, f)),
-    'file',
-  )
+  const dirs: string[] = []
+  for (const rel of PROTECTED_GIT_DIRS) {
+    dirs.push(await ensureProtectedDir(join(agentDir, rel)))
+  }
+  const files: string[] = []
+  for (const rel of PROTECTED_GIT_FILES) {
+    files.push(await ensureProtectedFile(join(agentDir, rel)))
+  }
+
+  const hooksPathDir = await resolveEffectiveHooksPath(agentDir)
+  if (hooksPathDir !== undefined && !dirs.includes(hooksPathDir)) {
+    dirs.push(await ensureProtectedDir(hooksPathDir))
+  }
+
   return { dirs, files }
+}
+
+// Fail closed: a symlink at a protected path would make the RO bind follow it
+// elsewhere, so reject it rather than silently protect the wrong target.
+async function ensureProtectedDir(target: string): Promise<string> {
+  await mkdir(target, { recursive: true })
+  await assertNotSymlink(target)
+  return target
+}
+
+async function ensureProtectedFile(target: string): Promise<string> {
+  if (!(await isRealEntry(target, 'file'))) {
+    try {
+      await writeFile(target, '', { flag: 'wx' })
+    } catch {
+      // Lost a race (or it appeared); the symlink check below still guards it.
+    }
+  }
+  await assertNotSymlink(target)
+  return target
+}
+
+async function assertNotSymlink(target: string): Promise<void> {
+  const stats = await lstat(target)
+  if (stats.isSymbolicLink()) {
+    throw new Error(`sandbox: refusing to protect symlinked path ${target}`)
+  }
+}
+
+// Reads core.hooksPath straight from .git/config text (the file is about to be
+// RO-bound, so its content is the trusted baseline). Returns the resolved
+// absolute dir only when it lands inside agentDir — an outside path is not
+// writable by the jail and a relative path resolves against the repo root, per
+// gitconfig semantics.
+async function resolveEffectiveHooksPath(agentDir: string): Promise<string | undefined> {
+  let text: string
+  try {
+    text = await readFile(join(agentDir, '.git', 'config'), 'utf8')
+  } catch {
+    return undefined
+  }
+  const match = text.match(/^\s*hooksPath\s*=\s*(.+?)\s*$/m)
+  if (match === null) return undefined
+  const raw = match[1]?.trim()
+  if (raw === undefined || raw.length === 0) return undefined
+  const resolved = isAbsolute(raw) ? resolve(raw) : resolve(agentDir, raw)
+  return isInside(agentDir, resolved) ? resolved : undefined
 }
 
 // SECURITY: a writable RW bind renders AFTER the masks and last-op-wins, so an

--- a/src/sandbox/writable-zones.ts
+++ b/src/sandbox/writable-zones.ts
@@ -18,14 +18,21 @@ export type ProtectedZones = {
 // guard and the latter holds executable plugin code; bash must not get blanket
 // RW to either. Skill authoring and package writes go through the guarded
 // write/edit tool only.
-// `.git` is writable so a member can `git add`/`git commit` their own edits to
-// the already-editable surface (workspace + root allowlist files). The escape
-// risk — staging arbitrary tree content via plumbing, or planting hooks — is
-// contained two ways: low-trust roles are still write-confined for the WORKING
-// TREE (paths outside the writable zones stay EROFS, so `git checkout` of a
-// protected path fails at the kernel), and `.git/hooks` + `.git/config` are
-// re-protected read-only via resolveProtectedZones so core.hooksPath/hook-plant
-// RCE into the unsandboxed runtime git ops is closed.
+// `.git` is writable so a member can `git add`/`git commit` their own edits.
+// This is the AGENT'S OWN repo, not a shared/upstream one, so writing history
+// is not a privilege boundary: a low-trust role staging a tracked path it
+// cannot edit in the worktree (e.g. via `git update-index --cacheinfo` plumbing)
+// only writes the agent's own history — content the backup runner already
+// force-commits on idle regardless. So we deliberately do NOT try to confine
+// commit *content* to the worktree write-allowlist; that boundary governs the
+// working tree, not the object database.
+//
+// The one thing writable `.git` must NOT grant is code execution in the
+// UNSANDBOXED runtime (backup/dreaming commit the same .git out of band): a
+// planted `.git/hooks/*` or a `core.hooksPath` in `.git/config` would fire there
+// as a higher-privilege process. resolveProtectedZones re-binds `.git/hooks` and
+// `.git/config` read-only (after the writable .git bind, last-op-wins) to close
+// exactly that escalation.
 const WRITABLE_DIRS = ['workspace', 'public', 'mounts', '.git'] as const
 
 const PROTECTED_GIT_DIRS = ['.git/hooks'] as const


### PR DESCRIPTION
## Background

Low-trust roles (`member`/`guest`) run the `bash` tool inside a `bwrap` jail that `--ro-bind`s the whole agent folder, then re-exposes only a narrow writable allowlist (`workspace/`, `public/`, `mounts/`, and a handful of root files like `AGENTS.md` and `typeclaw.json`). Those roles can already *edit* the root allowlist files — but `.git/` was read-only, so a `git commit` from sandboxed bash failed with `EROFS`. The result was confusing: the agent could change `AGENTS.md` but not commit the change itself; persistence only happened later, indirectly, via the runtime's idle backup.

This PR makes `.git/` writable in the jail so those edits can be committed in-band, without widening the *working-tree* write boundary.

## Summary

Three pieces, smallest-blast-radius first:

1. **A reusable git mutex** (`withGitLock`). The backup runner and memory dreaming both commit to the same `.git` via direct `Bun.spawn` with zero coordination — they could already collide on `.git/index.lock`, and the backup runner returned `commit-failed` without retrying, silently dropping the cycle. `withGitLock(agentDir, …)` serializes the two runtime committers in-process; distinct agent dirs still run concurrently.

2. **`index.lock` retry on the backup spawn** (`withIndexLockRetry`). Retries *only* on lock contention with short backoff. This is what makes a collision with a sandboxed bash `git commit` (a separate process the in-process mutex can't see) degrade gracefully instead of dropping a backup.

3. **`.git` writable + hooks/config re-protected.** `.git` joins the writable zones. A new `protected` policy stage emits `--ro-bind` entries **after** the writable binds, so bwrap's last-op-wins re-pins `.git/hooks` and `.git/config` read-only.

**Why re-protect hooks/config and not just open `.git`:** with a fully-writable `.git`, a low-trust role could write `.git/hooks/pre-commit` or set `core.hooksPath` in `.git/config`, then that hook executes as the **unsandboxed** runtime process the next time the backup runner or dreaming subagent commits — a sandbox escape into a higher-privilege context. Keeping `hooks/` and `config` `EROFS` closes that path while still allowing `add`/`commit`. The working tree outside the writable zones also stays read-only, so `git checkout`/`restore` of a protected tracked path still fails at the kernel.

## What this does NOT do

- Does **not** widen the working-tree write surface. The set of files a low-trust role can modify is unchanged; only `.git`'s plumbing becomes writable (minus hooks/config).
- Does **not** affect `trusted`/`owner` — they bypass the jail entirely (empty masks), as before.
- Does **not** add a cross-process lock. The mutex is in-process (covers the two runtime committers); the bash-vs-runtime race is handled by `index.lock` + retry, not by the mutex.
- Does **not** add new guard patterns for `git config`/plumbing — those are mooted by keeping `.git/config` and `.git/hooks` read-only at the filesystem layer.

## Review notes

- **Load-bearing ordering:** `appendProtected` MUST render after `appendWritable` in `src/sandbox/build.ts`. The invariant is pinned by `build.test.ts` ("renders protected RO re-binds AFTER the writable .git bind"). Reorder them and the hooks/config RCE vector reopens silently.
- **Mutex correctness:** `src/git/mutex.ts` releases on both success and throw (`finally`) and cleans up the per-key chain tail to avoid unbounded `Map` growth. Tests cover sequential-same-key, concurrent-distinct-key, throw-still-releases, and value propagation.
- `resolveProtectedZones` drops absent entries so bwrap never binds a missing source (a missing source aborts bwrap).
