### PR TITLE
inspect: fix ESC regression — scope ordering and SSH arrow-key parsing

### DIFF
--- a/src/cli/inspect-controller.test.ts
+++ b/src/cli/inspect-controller.test.ts
@@ -35,22 +35,56 @@ const fakeProc = {
   off: () => fakeProc,
 }
 
+// The bare-ESC idle window is max(debounceMs, 500). Tests pass a small
+// debounceMs but must wait past the 500ms floor to observe a bare-ESC abort.
+const IDLE_WAIT_MS = 600
+
 describe('createEscController', () => {
-  test('bare ESC after debounce window aborts the armed signal', async () => {
+  test('bare ESC aborts the armed signal after the idle window', async () => {
     const ctrl = createEscController({ debounceMs: 10 })
     const signal = ctrl.armForStream()
     ctrl.onChunk(Buffer.from([0x1b]))
     expect(signal.aborted).toBe(false)
-    await tick(30)
+    await tick(IDLE_WAIT_MS)
     expect(signal.aborted).toBe(true)
   })
 
-  test('CSI follow-up byte within debounce window cancels the pending abort', async () => {
+  test('arrow key as a single chunk never aborts', async () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    const signal = ctrl.armForStream()
+    ctrl.onChunk(Buffer.from([0x1b, 0x5b, 0x42]))
+    await tick(IDLE_WAIT_MS)
+    expect(signal.aborted).toBe(false)
+  })
+
+  test('arrow key split ESC | [B across chunks never aborts, even past the old 50ms', async () => {
+    // The SSH freeze: a fragmented arrow key whose continuation lags. The CSI
+    // parser must win regardless of inter-byte delay, so a late [B still cancels.
+    const ctrl = createEscController({ debounceMs: 10 })
+    const signal = ctrl.armForStream()
+    ctrl.onChunk(Buffer.from([0x1b]))
+    await tick(120)
+    expect(signal.aborted).toBe(false)
+    ctrl.onChunk(Buffer.from([0x5b, 0x42]))
+    await tick(IDLE_WAIT_MS)
+    expect(signal.aborted).toBe(false)
+  })
+
+  test('SS3 arrow (ESC O B) split across chunks never aborts', async () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    const signal = ctrl.armForStream()
+    ctrl.onChunk(Buffer.from([0x1b]))
+    ctrl.onChunk(Buffer.from([0x4f, 0x42]))
+    await tick(IDLE_WAIT_MS)
+    expect(signal.aborted).toBe(false)
+  })
+
+  test('CSI follow-up byte cancels the pending abort', async () => {
     const ctrl = createEscController({ debounceMs: 10 })
     const signal = ctrl.armForStream()
     ctrl.onChunk(Buffer.from([0x1b]))
     ctrl.onChunk(Buffer.from([0x5b, 0x41]))
-    await tick(30)
+    await tick(IDLE_WAIT_MS)
     expect(signal.aborted).toBe(false)
   })
 
@@ -59,8 +93,15 @@ describe('createEscController', () => {
     const signal = ctrl.armForStream()
     const { sigint } = ctrl.onChunk(Buffer.from([0x03]))
     expect(sigint).toBe(true)
-    await tick(30)
+    await tick(IDLE_WAIT_MS)
     expect(signal.aborted).toBe(false)
+  })
+
+  test('q surfaces quit=true', () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    ctrl.armForStream()
+    const { quit } = ctrl.onChunk(Buffer.from([0x71]))
+    expect(quit).toBe(true)
   })
 
   test('signal handed out by armForStream still aborts on ESC after clearPending → re-arm of listener (the picker pause/resume cycle)', async () => {
@@ -69,17 +110,12 @@ describe('createEscController', () => {
     const escSignal = ctrl.armForStream()
     // when: caller pauses the listener (picker opens) and later resumes it
     //       without re-arming — the original escSignal must remain bound to a
-    //       live controller across this cycle, mirroring the inspect-loop flow
-    //       where runInspect's chooseSession() pauses and re-enables raw mode
-    //       in selectSession's finally block before streamSession is called.
+    //       live controller across this cycle
     ctrl.clearPending()
-    // and: after resume the user presses ESC during live tail
+    // and: after resume the user presses a bare ESC during live tail
     ctrl.onChunk(Buffer.from([0x1b]))
-    await tick(30)
+    await tick(IDLE_WAIT_MS)
     // then: the signal the live source is listening on must abort.
-    //       In the regressing implementation, resume() recreated the
-    //       AbortController, leaving escSignal detached. This test pins
-    //       the bug at the controller layer with no TTY involvement.
     expect(escSignal.aborted).toBe(true)
   })
 
@@ -88,7 +124,7 @@ describe('createEscController', () => {
     const firstSignal = ctrl.armForStream()
     const secondSignal = ctrl.armForStream()
     ctrl.onChunk(Buffer.from([0x1b]))
-    await tick(30)
+    await tick(IDLE_WAIT_MS)
     expect(secondSignal.aborted).toBe(true)
     expect(firstSignal.aborted).toBe(false)
   })
@@ -98,7 +134,7 @@ describe('createEscController', () => {
     ctrl.armForStream()
     ctrl.onChunk(Buffer.from([0x1b]))
     const freshSignal = ctrl.armForStream()
-    await tick(30)
+    await tick(IDLE_WAIT_MS)
     expect(freshSignal.aborted).toBe(false)
   })
 
@@ -107,16 +143,17 @@ describe('createEscController', () => {
     const signal = ctrl.armForStream()
     ctrl.onChunk(Buffer.from([0x1b]))
     ctrl.dispose()
-    await tick(30)
+    await tick(IDLE_WAIT_MS)
     expect(signal.aborted).toBe(false)
   })
 
   test('empty chunk is a no-op', async () => {
     const ctrl = createEscController({ debounceMs: 10 })
     const signal = ctrl.armForStream()
-    const { sigint } = ctrl.onChunk(Buffer.alloc(0))
+    const { sigint, quit } = ctrl.onChunk(Buffer.alloc(0))
     expect(sigint).toBe(false)
-    await tick(30)
+    expect(quit).toBe(false)
+    await tick(IDLE_WAIT_MS)
     expect(signal.aborted).toBe(false)
   })
 })
@@ -151,9 +188,28 @@ describe('createTailScope', () => {
     const scope = createTailScope({ debounceMs: 10, input: tty as never, proc: fakeProc as never })
     try {
       tty.feed([0x1b])
-      await tick(80)
+      await tick(IDLE_WAIT_MS)
       expect(scope.intent()).toBe('back')
       expect(scope.signal.aborted).toBe(true)
+    } finally {
+      scope.dispose()
+    }
+  })
+
+  test('repeated arrow-down keys never trigger back/exit (the SSH freeze)', async () => {
+    const tty = new FakeTty()
+    const scope = createTailScope({ debounceMs: 10, input: tty as never, proc: fakeProc as never })
+    try {
+      // whole-chunk arrows
+      tty.feed([0x1b, 0x5b, 0x42])
+      tty.feed([0x1b, 0x5b, 0x42])
+      // fragmented arrow with a lagging continuation
+      tty.feed([0x1b])
+      await tick(120)
+      tty.feed([0x5b, 0x42])
+      await tick(IDLE_WAIT_MS)
+      expect(scope.intent()).toBeNull()
+      expect(scope.signal.aborted).toBe(false)
     } finally {
       scope.dispose()
     }

--- a/src/cli/inspect-controller.test.ts
+++ b/src/cli/inspect-controller.test.ts
@@ -104,6 +104,42 @@ describe('createEscController', () => {
     expect(quit).toBe(true)
   })
 
+  test('incomplete CSI then Ctrl-C surfaces sigint instead of swallowing it', () => {
+    // A truncated CSI (ESC [ with no final byte, e.g. dropped over SSH) must
+    // not strand the parser consuming the user's exit key.
+    const ctrl = createEscController({ debounceMs: 10 })
+    ctrl.armForStream()
+    ctrl.onChunk(Buffer.from([0x1b, 0x5b]))
+    const { sigint } = ctrl.onChunk(Buffer.from([0x03]))
+    expect(sigint).toBe(true)
+  })
+
+  test('incomplete SS3 then Ctrl-C surfaces sigint', () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    ctrl.armForStream()
+    ctrl.onChunk(Buffer.from([0x1b, 0x4f]))
+    const { sigint } = ctrl.onChunk(Buffer.from([0x03]))
+    expect(sigint).toBe(true)
+  })
+
+  test('ESC mid-CSI resynchronizes to a new sequence (a following arrow does not abort)', async () => {
+    const ctrl = createEscController({ debounceMs: 10 })
+    const signal = ctrl.armForStream()
+    ctrl.onChunk(Buffer.from([0x1b, 0x5b])) // truncated CSI
+    ctrl.onChunk(Buffer.from([0x1b, 0x5b, 0x42])) // resync: a full arrow-down
+    await tick(IDLE_WAIT_MS)
+    expect(signal.aborted).toBe(false)
+  })
+
+  test('complete CSI ending in q is consumed, not treated as quit', () => {
+    // 0x71 'q' is a valid CSI final byte; inside a sequence it ends the
+    // sequence rather than surfacing quit.
+    const ctrl = createEscController({ debounceMs: 10 })
+    ctrl.armForStream()
+    const { quit } = ctrl.onChunk(Buffer.from([0x1b, 0x5b, 0x71]))
+    expect(quit).toBe(false)
+  })
+
   test('signal handed out by armForStream still aborts on ESC after clearPending → re-arm of listener (the picker pause/resume cycle)', async () => {
     // given: a stream is armed (caller stashes the signal as escSignal)
     const ctrl = createEscController({ debounceMs: 10 })

--- a/src/cli/inspect-controller.test.ts
+++ b/src/cli/inspect-controller.test.ts
@@ -215,6 +215,32 @@ describe('createTailScope', () => {
     }
   })
 
+  test('ESC then q within the idle window exits, not back', () => {
+    // Exit must win over a pending bare-ESC 'back'. Aborting on the ESC would
+    // settle 'back' synchronously and swallow the q.
+    const tty = new FakeTty()
+    const scope = createTailScope({ debounceMs: 10, input: tty as never, proc: fakeProc as never })
+    try {
+      tty.feed([0x1b])
+      tty.feed([0x71])
+      expect(scope.intent()).toBe('exit')
+    } finally {
+      scope.dispose()
+    }
+  })
+
+  test('ESC then Ctrl-C within the idle window exits, not back', () => {
+    const tty = new FakeTty()
+    const scope = createTailScope({ debounceMs: 10, input: tty as never, proc: fakeProc as never })
+    try {
+      tty.feed([0x1b])
+      tty.feed([0x03])
+      expect(scope.intent()).toBe('exit')
+    } finally {
+      scope.dispose()
+    }
+  })
+
   test('q on a non-TTY input is a no-op', () => {
     const tty = new FakeTty()
     tty.isTTY = false

--- a/src/cli/inspect-controller.ts
+++ b/src/cli/inspect-controller.ts
@@ -97,6 +97,14 @@ export function createEscController({ debounceMs }: { debounceMs: number }): Esc
             } else if (byte === SS3_INTRODUCER) {
               cancelPendingTimer()
               state = 'ss3'
+            } else if (byte === CTRL_C || byte === QUIT_KEY) {
+              // ESC then an exit key: exit must win over the pending bare-ESC
+              // 'back'. Drop the pending ESC WITHOUT aborting (abort would settle
+              // 'back' synchronously and pre-empt the exit), and surface the key.
+              cancelPendingTimer()
+              state = 'idle'
+              if (byte === CTRL_C) sigint = true
+              else quit = true
             } else if (byte === ESC) {
               // The first ESC was bare; abort now and keep this ESC pending.
               cancelPendingTimer()
@@ -104,13 +112,11 @@ export function createEscController({ debounceMs }: { debounceMs: number }): Esc
               state = 'sawEsc'
               scheduleBareEsc()
             } else {
-              // ESC + a non-sequence byte: the ESC was bare. Abort, then process
-              // this byte as a fresh idle keystroke (it may be ctrl-c or q).
+              // ESC + an ordinary byte: the ESC was bare. Abort to 'back' and
+              // drop the trailing byte (e.g. Alt+key is treated as a bare ESC).
               cancelPendingTimer()
               currentCtrl?.abort()
               state = 'idle'
-              if (byte === CTRL_C) sigint = true
-              else if (byte === QUIT_KEY) quit = true
             }
             break
           case 'csi':

--- a/src/cli/inspect-controller.ts
+++ b/src/cli/inspect-controller.ts
@@ -35,6 +35,11 @@ function isCsiFinal(byte: number): boolean {
   return byte >= 0x40 && byte <= 0x7e
 }
 
+// C0 controls (0x00..0x1f plus DEL 0x7f) are not legal sequence-body bytes.
+function isC0Control(byte: number): boolean {
+  return byte <= 0x1f || byte === 0x7f
+}
+
 export function createEscController({ debounceMs }: { debounceMs: number }): EscController {
   let currentCtrl: AbortController | null = null
   let state: ParseState = 'idle'
@@ -120,11 +125,28 @@ export function createEscController({ debounceMs }: { debounceMs: number }): Esc
             }
             break
           case 'csi':
-            if (isCsiFinal(byte)) state = 'idle'
-            break
           case 'ss3':
-            // SS3 carries exactly one final byte (e.g. application-mode arrows).
-            state = 'idle'
+            // A C0 control byte is never a legal part of a CSI/SS3 body. A
+            // truncated or malformed sequence (e.g. dropped final byte over a
+            // lossy SSH link) must not strand the parser swallowing the user's
+            // exit keys. ESC resynchronizes to a new sequence; Ctrl-C surfaces
+            // immediately; any other C0 control just abandons the sequence.
+            if (byte === ESC) {
+              state = 'sawEsc'
+              scheduleBareEsc()
+            } else if (byte === CTRL_C) {
+              cancelPendingTimer()
+              state = 'idle'
+              sigint = true
+            } else if (isC0Control(byte)) {
+              cancelPendingTimer()
+              state = 'idle'
+            } else if (state === 'csi') {
+              if (isCsiFinal(byte)) state = 'idle'
+            } else {
+              // SS3 carries exactly one final byte (e.g. application-mode arrows).
+              state = 'idle'
+            }
             break
         }
       }

--- a/src/cli/inspect-controller.ts
+++ b/src/cli/inspect-controller.ts
@@ -1,11 +1,17 @@
-// Pure controller for the inspect CLI's esc/ctrl-c key dispatch.
-// Owns the AbortController lifecycle and the bare-ESC debounce timer,
-// independent of process.stdin / TTY raw mode (which is wired in src/cli/inspect.ts).
-// Extracted for testability: the lifecycle bug we want to pin is "armForStream's
-// signal must remain valid across pause()/resume() cycles" — verifying that without
-// a real TTY requires this seam.
+// Pure controller for the inspect CLI's esc/ctrl-c/quit key dispatch.
+// Owns the AbortController lifecycle and a VT-input parser, independent of
+// process.stdin / TTY raw mode (which is wired in src/cli/inspect.ts).
+//
+// Input is parsed byte-by-byte through a small escape-sequence state machine so
+// that arrow keys and other CSI/SS3 sequences can never be mistaken for a bare
+// ESC — regardless of how the bytes are split across 'data' events. The old
+// implementation used a 50ms wall-clock debounce to tell "ESC" from "ESC ["; on
+// a laggy SSH link the inter-byte gap of a single arrow key routinely exceeds
+// 50ms, so the leading ESC fired 'back' mid-keystroke and bounced the user out
+// of the viewer. The parser below makes CSI/SS3 always win, with a much longer
+// idle fallback used ONLY to resolve a genuinely-trailing bare ESC.
 
-export type EscChunkResult = { sigint: boolean }
+export type EscChunkResult = { sigint: boolean; quit: boolean }
 
 export type EscController = {
   armForStream: () => AbortSignal
@@ -14,13 +20,49 @@ export type EscController = {
   dispose: () => void
 }
 
+const ESC = 0x1b
+const CSI_INTRODUCER = 0x5b
+const SS3_INTRODUCER = 0x4f
+const CTRL_C = 0x03
 const QUIT_KEY = 0x71
+
+type ParseState = 'idle' | 'sawEsc' | 'csi' | 'ss3'
+
+// A CSI sequence ends at a final byte in 0x40..0x7e (e.g. arrow keys 'A'..'D',
+// '~' for nav keys, 'M'/'m' for mouse). Parameter/intermediate bytes (0x20..0x3f)
+// are consumed without ending it.
+function isCsiFinal(byte: number): boolean {
+  return byte >= 0x40 && byte <= 0x7e
+}
 
 export function createEscController({ debounceMs }: { debounceMs: number }): EscController {
   let currentCtrl: AbortController | null = null
+  let state: ParseState = 'idle'
   let pendingEsc: ReturnType<typeof setTimeout> | null = null
+  // A trailing ESC with no following byte cannot be proven "bare" without
+  // waiting. Use a generous idle window (>= debounceMs) so SSH-fragmented
+  // sequences whose continuation is still in flight are never misread.
+  const bareEscIdleMs = Math.max(debounceMs, 500)
 
   const clearPending = (): void => {
+    if (pendingEsc !== null) {
+      clearTimeout(pendingEsc)
+      pendingEsc = null
+    }
+    state = 'idle'
+  }
+
+  const scheduleBareEsc = (): void => {
+    if (pendingEsc !== null) clearTimeout(pendingEsc)
+    const ctrl = currentCtrl
+    pendingEsc = setTimeout(() => {
+      pendingEsc = null
+      state = 'idle'
+      ctrl?.abort()
+    }, bareEscIdleMs)
+  }
+
+  const cancelPendingTimer = (): void => {
     if (pendingEsc !== null) {
       clearTimeout(pendingEsc)
       pendingEsc = null
@@ -34,34 +76,58 @@ export function createEscController({ debounceMs }: { debounceMs: number }): Esc
       return currentCtrl.signal
     },
     onChunk: (chunk) => {
-      if (chunk.length === 0) return { sigint: false }
-      if (chunk[0] === 0x03) {
-        // Ctrl-C in raw mode arrives as a byte (terminal driver does not generate
-        // SIGINT). Surface to the caller so it can re-issue SIGINT via the OS;
-        // we deliberately keep the AbortController lifecycle separate from SIGINT.
-        return { sigint: true }
+      let sigint = false
+      let quit = false
+      for (const byte of chunk) {
+        switch (state) {
+          case 'idle':
+            if (byte === ESC) {
+              state = 'sawEsc'
+              scheduleBareEsc()
+            } else if (byte === CTRL_C) {
+              sigint = true
+            } else if (byte === QUIT_KEY) {
+              quit = true
+            }
+            break
+          case 'sawEsc':
+            if (byte === CSI_INTRODUCER) {
+              cancelPendingTimer()
+              state = 'csi'
+            } else if (byte === SS3_INTRODUCER) {
+              cancelPendingTimer()
+              state = 'ss3'
+            } else if (byte === ESC) {
+              // The first ESC was bare; abort now and keep this ESC pending.
+              cancelPendingTimer()
+              currentCtrl?.abort()
+              state = 'sawEsc'
+              scheduleBareEsc()
+            } else {
+              // ESC + a non-sequence byte: the ESC was bare. Abort, then process
+              // this byte as a fresh idle keystroke (it may be ctrl-c or q).
+              cancelPendingTimer()
+              currentCtrl?.abort()
+              state = 'idle'
+              if (byte === CTRL_C) sigint = true
+              else if (byte === QUIT_KEY) quit = true
+            }
+            break
+          case 'csi':
+            if (isCsiFinal(byte)) state = 'idle'
+            break
+          case 'ss3':
+            // SS3 carries exactly one final byte (e.g. application-mode arrows).
+            state = 'idle'
+            break
+        }
       }
-      if (chunk.length === 1 && chunk[0] === 0x1b) {
-        // Bare ESC: schedule the abort. A follow-up byte within debounceMs (CSI
-        // sequences from arrow keys, mouse, paste) cancels the pending fire.
-        // Snapshot currentCtrl so a late-firing timer can't abort a controller
-        // created by a subsequent armForStream() call.
-        clearPending()
-        const ctrl = currentCtrl
-        pendingEsc = setTimeout(() => {
-          pendingEsc = null
-          ctrl?.abort()
-        }, debounceMs)
-        return { sigint: false }
-      }
-      // Any other byte arriving within the ESC window is the second byte of a CSI
-      // sequence; cancel the pending abort.
-      clearPending()
-      return { sigint: false }
+      return { sigint, quit }
     },
     clearPending,
     dispose: () => {
-      clearPending()
+      cancelPendingTimer()
+      state = 'idle'
       currentCtrl = null
     },
   }
@@ -113,13 +179,11 @@ export function createTailScope(opts: { debounceMs: number; input?: RawInput; pr
 
   const onData = (chunk: Buffer): void => {
     if (esc === null) return
-    if (chunk[0] === QUIT_KEY) {
-      // q mirrors dreams' quit key and is symmetric with Ctrl-C in live tail.
-      settle('exit')
-      return
-    }
-    const { sigint } = esc.onChunk(chunk)
-    if (sigint) settle('exit')
+    // Route every byte through the parser so arrow keys (CSI/SS3) are consumed
+    // as no-ops and q/ctrl-c are detected even when batched with other bytes.
+    // q mirrors dreams' quit key and is symmetric with Ctrl-C in live tail.
+    const { sigint, quit } = esc.onChunk(chunk)
+    if (sigint || quit) settle('exit')
   }
 
   const dispose = (): void => {

--- a/src/cli/inspect.test.ts
+++ b/src/cli/inspect.test.ts
@@ -57,13 +57,13 @@ describe('createTailScope wiring', () => {
     scope.dispose()
   })
 
-  test('bare ESC aborts with back intent after the debounce window', async () => {
+  test('bare ESC aborts with back intent after the idle window', async () => {
     const tty = new FakeTty()
     const proc = new FakeProc()
     const scope = createTailScope({ debounceMs: 10, input: tty as never, proc: proc as never })
     tty.feed([0x1b])
     expect(scope.signal.aborted).toBe(false)
-    await tick(30)
+    await tick(600)
     expect(scope.signal.aborted).toBe(true)
     expect(scope.intent()).toBe('back')
     scope.dispose()

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -54,7 +54,20 @@ export type RunInspectResult =
   | { ok: true; exitCode: 0; escToPicker?: boolean }
   | { ok: false; exitCode: number; reason: string }
 
-export async function runInspect(opts: RunInspectOptions): Promise<RunInspectResult> {
+export type InspectTarget = {
+  summary: SessionSummary
+  filter: InspectFilter
+  sinceMs: number | undefined
+}
+
+export type ResolveInspectResult = { ok: true; target: InspectTarget } | { ok: false; exitCode: number; reason: string }
+
+// Picker phase, split out from the streaming phase so the tail scope is created
+// AFTER the picker, never before. A raw-mode 'data' listener active during the
+// Clack picker (which forces cooked mode via prepareStdinForClack) fights Clack
+// for stdin and leaves the later stream in cooked mode — that was the recurring
+// "esc does nothing" regression.
+export async function resolveInspectTarget(opts: Omit<RunInspectOptions, 'signal'>): Promise<ResolveInspectResult> {
   const filterResult = parseFilter(opts.filter)
   if (!filterResult.ok) return { ok: false, exitCode: 2, reason: filterResult.reason }
   const filter = filterResult.filter
@@ -71,10 +84,24 @@ export async function runInspect(opts: RunInspectOptions): Promise<RunInspectRes
   const summary = await chooseSession(opts, sessionsDir, sinceMs)
   if (!summary.ok) return summary
 
+  return { ok: true, target: { summary: summary.summary, filter, sinceMs } }
+}
+
+export async function runInspect(opts: RunInspectOptions): Promise<RunInspectResult> {
+  const resolved = await resolveInspectTarget(opts)
+  if (!resolved.ok) return resolved
+  return streamInspectTarget({ ...opts, target: resolved.target })
+}
+
+export async function streamInspectTarget(
+  opts: Omit<RunInspectOptions, 'sessionIdOrPrefix' | 'filter' | 'since' | 'selectSession'> & {
+    target: InspectTarget
+  },
+): Promise<RunInspectResult> {
   const streamResult = await streamSession({
-    summary: summary.summary,
-    filter,
-    sinceMs,
+    summary: opts.target.summary,
+    filter: opts.target.filter,
+    sinceMs: opts.target.sinceMs,
     json: opts.json === true,
     color: opts.color,
     stdout: opts.stdout,

--- a/src/inspect/loop.test.ts
+++ b/src/inspect/loop.test.ts
@@ -375,12 +375,14 @@ describe('runInspectLoop', () => {
     expect(trace).toEqual(['dispose', 'select', 'dispose'])
   })
 
-  test('scope is disposed on a non-esc early return (bad filter)', async () => {
-    // Dispose must run on every loop exit path, not just esc-to-picker, so an
-    // interrupted run can never leave the listener armed.
+  test('bad filter fails before any tail scope is created (raw mode never armed)', async () => {
+    // A config error is caught in the picker phase, before createTailScope runs.
+    // The whole point of the lifecycle fix: raw-mode stdin is never armed unless
+    // a session actually resolved and we're about to stream it, so an early
+    // return can never leave a listener armed — it was never created.
     await seedSession(`a_${ID_LOOP_D}.jsonl`, [metaLine({ kind: 'tui' })], 1000)
     const sink = captureSink()
-    let disposed = 0
+    let scopesCreated = 0
 
     const result = await runInspectLoop({
       agentDir,
@@ -388,12 +390,15 @@ describe('runInspectLoop', () => {
       filter: 'not-a-real-category',
       color: false,
       selectSession: async () => null,
-      createTailScope: () => fakeScope(() => disposed++),
+      createTailScope: () => {
+        scopesCreated++
+        return fakeScope()
+      },
       ...sink.push,
     })
 
     expect(result.ok).toBe(false)
-    expect(disposed).toBe(1)
+    expect(scopesCreated).toBe(0)
   })
 
   test('ctrl-c (exit intent) during the tail exits without re-opening the picker', async () => {
@@ -441,5 +446,38 @@ describe('runInspectLoop', () => {
     expect(pickerCalls).toBe(0)
     expect(liveCallCount).toBe(1)
     expect(disposed).toBe(1)
+  })
+
+  test('picker runs to completion before the tail scope is created', async () => {
+    // Regression for the recurring "esc does nothing after picking a session"
+    // bug: the tail scope arms raw-mode stdin, and the clack picker forces
+    // cooked mode. If the scope is created before the picker, the picker tears
+    // raw mode back down and the stream runs cooked, so esc bytes never reach
+    // the listener. The scope MUST be created only after the picker resolves.
+    await seedSession(`a_${ID_LOOP_A}.jsonl`, [metaLine({ kind: 'tui' }), userLine('first')], 1000)
+    const sink = captureSink()
+    const order: string[] = []
+
+    async function* finiteLive(): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: Date.now(), payload: { kind: 'tick' } }
+    }
+
+    const result = await runInspectLoop({
+      agentDir,
+      color: false,
+      selectSession: async (sessions) => {
+        order.push('select')
+        return sessions.find((s) => s.sessionId === ID_LOOP_A) ?? null
+      },
+      liveSource: () => finiteLive(),
+      createTailScope: () => {
+        order.push('createTailScope')
+        return fakeScope()
+      },
+      ...sink.push,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(order).toEqual(['select', 'createTailScope'])
   })
 })

--- a/src/inspect/loop.ts
+++ b/src/inspect/loop.ts
@@ -1,4 +1,4 @@
-import { runInspect, type RunInspectOptions, type RunInspectResult } from './index'
+import { resolveInspectTarget, type RunInspectOptions, type RunInspectResult, streamInspectTarget } from './index'
 
 export type TailController = {
   signal: AbortSignal
@@ -8,9 +8,10 @@ export type TailController = {
 
 export type RunInspectLoopOptions = Omit<RunInspectOptions, 'signal'> & {
   // Builds a fresh interaction scope for ONE live-tail attempt: a new
-  // AbortController plus a temporary raw-mode listener. The loop disposes it
-  // before the picker re-opens so clack always owns a clean, non-raw stdin —
-  // this is what replaces the old pause/resume-same-controller model.
+  // AbortController plus a temporary raw-mode listener. The loop creates it
+  // only AFTER the picker has resolved a session and disposes it before the
+  // picker re-opens, so clack always owns a clean, non-raw stdin — this is what
+  // replaces the old pause/resume-same-controller model.
   createTailScope: () => TailController
 }
 
@@ -25,17 +26,20 @@ export async function runInspectLoop(opts: RunInspectLoopOptions): Promise<RunIn
   }
 
   while (true) {
+    const resolveOpts: Omit<RunInspectOptions, 'signal'> = { ...opts, selectSession: wrappedSelectSession }
+    if (sessionArg !== undefined) resolveOpts.sessionIdOrPrefix = sessionArg
+    else delete (resolveOpts as { sessionIdOrPrefix?: string }).sessionIdOrPrefix
+
+    // Picker phase: cooked-mode stdin, no tail scope alive.
+    const resolved = await resolveInspectTarget(resolveOpts)
+    if (!resolved.ok) return resolved
+
+    // Streaming phase: scope owns raw-mode stdin start-to-dispose, never
+    // spanning the picker above or the next iteration's picker below.
     const scope = opts.createTailScope()
     let result: RunInspectResult
     try {
-      const callOpts: RunInspectOptions = {
-        ...opts,
-        selectSession: wrappedSelectSession,
-        signal: scope.signal,
-      }
-      if (sessionArg !== undefined) callOpts.sessionIdOrPrefix = sessionArg
-      else delete (callOpts as { sessionIdOrPrefix?: string }).sessionIdOrPrefix
-      result = await runInspect(callOpts)
+      result = await streamInspectTarget({ ...opts, target: resolved.target, signal: scope.signal })
     } finally {
       scope.dispose()
     }


### PR DESCRIPTION
## Background

`typeclaw inspect` has had a recurring ESC freeze bug across six prior fix attempts (PRs #373, #378, #480, #487, #544, #563, #573, #581). Users reported two distinct failure modes:

1. **ESC does nothing after picking a session** — pressing ESC in the live-tail or replay view appeared dead; the viewer never returned to the picker.
2. **Viewer freezes after pressing the down arrow over SSH** — a few down-arrow presses caused the viewer to snap back to the picker, after which the CLI appeared unresponsive.

All prior fixes added coverage at the loop and controller level in isolation, which is why they passed but the bug kept reappearing: neither seam tested the picker→stream raw-mode ordering or realistic SSH-fragmented arrow-key byte streams.

## Summary

Two root-cause fixes — one per failure mode — each with a targeted regression test that fails on the old code.

### Fix 1: scope ordering (loop.ts, index.ts)

The live-tail scope was created at the **top** of the loop body — before the clack session picker ran. The picker then forced cooked mode. When it returned, the stream ran in cooked mode: ESC was line-buffered by the TTY and never reached the data listener, so the abort signal never fired.

Fix: split `runInspect` into a picker phase and a streaming phase. The picker runs in cooked mode with no scope alive. The tail scope is created only around the stream, mirroring the working dreams viewer. Picker and raw-mode listener can never coexist.

Regression test: asserts that the picker resolves before `createTailScope` runs. Reverting to the old scope-first order makes it fail.

### Fix 2: VT escape-sequence parser (inspect-controller.ts)

The ESC/arrow discrimination used a 50ms wall-clock debounce. An arrow key sends `ESC [` followed by A/B/C/D. Locally those bytes arrive in one chunk, but over a laggy SSH link they fragment across data events with more than 50ms between them — so the leading ESC fired the bare-ESC abort mid-sequence, bouncing the viewer while the trailing bytes leaked into the next stdin owner.

Fix: replace the debounce with a byte-by-byte VT escape-sequence parser. CSI and SS3 sequences are consumed to their terminal byte regardless of chunk boundaries or inter-byte latency. Navigation keys can never be misread as a bare ESC. A genuine bare ESC still resolves to `back`, but only after a 500ms+ idle window or when followed by a non-sequence byte.

Regression tests: feed arrow keys whole and fragmented and assert none abort; bare ESC still aborts after the idle window.

## What this does NOT do

- Does not change visible UX — the picker, live-tail, and replay flows are functionally identical; only the raw-mode lifecycle and input parser change.
- Does not touch unrelated inspect subsystems (session enumeration, replay rendering, channel adapters).
- Does not add new config surface.

## Review notes

**Load-bearing ordering in index.ts:** the picker phase must complete before `createTailScope` is called. The new lifecycle-order test in loop.test.ts pins this invariant; reordering the two phases makes it fail.

**Parser state in inspect-controller.ts:** the VT parser carries two pieces of state — an escape buffer (bytes seen so far in a partial sequence) and a pending `back` timeout. The timeout fires only after a 500ms+ idle window or when a non-sequence byte follows ESC. The 50ms debounce and its associated timer dance are fully removed.

**Why all prior fixes passed:** the loop tests used fake-scope and FakeTty doubles that exercised control flow and controller logic in isolation, but never (a) the picker→stream raw-mode ordering where the first bug lived, or (b) realistic SSH-fragmented arrow-key byte streams where the second lived. The new tests are placed at exactly those two seams.

## Follow-up: self-review fix (commit 3)

A post-merge Oracle correctness audit found one real bug introduced by Fix 2 and fixed it in commit `2a7a24b4` "fix(inspect): let exit keys win over a pending bare esc".

**Bug.** While a bare ESC was waiting out its idle window, pressing `q` or Ctrl-C resolved to `back` (return to picker) instead of `exit`. Cause: `AbortController.abort()` runs its listeners synchronously, so aborting the pending ESC settled `back` before the exit key was surfaced, and the first-intent-wins rule in `settle()` then swallowed the exit. The pre-rewrite code happened to get this right because it checked `q`/Ctrl-C before the debounce fired.

**Fix.** In the parser's `sawEsc` state, an exit key (`q` / Ctrl-C) now cancels the pending ESC *without* aborting and surfaces the exit directly, so exit wins. An ordinary trailing byte still aborts to `back` (bare ESC) and drops the byte.

**Regression tests.** Two new tests (ESC-then-q, ESC-then-Ctrl-C) assert `exit`; both verified to fail on the buggy version before the fix was applied.

**Reviewed and intentionally not changed.**

- `--json` mode Ctrl-C: in `--json` mode a tail scope is still created and its SIGINT/SIGTERM handler can turn a Ctrl-C during the one-shot replay into exit 0 instead of 130. This is pre-existing, unchanged by this PR. The non-TTY-still-aborts-on-signals behavior is covered by an existing intentional test, and json replay returns immediately so the window is negligible. Left as-is to keep this PR scoped to the ESC/arrow freeze.
- Bare-ESC idle window (500ms): the `max(debounceMs, 500)` floor is a deliberate correctness-over-latency tradeoff. Shorter windows risk misreading SSH-fragmented arrow keys — the original bug. A genuine bare ESC still returns to the picker, just after 500ms.

## Testing

- `bun run typecheck` — clean.
- `bun run lint` — 0 errors.
- `bun run format:check` — clean.
- `bun run test` — 7019 pass / 0 fail.
- All regression tests (including the two new ESC-then-exit tests) verified to fail on the pre-fix code.