### PR TITLE
portbroker: stop the auth-failure reconnect loop on restart

### DIFF
--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -589,6 +589,77 @@ describe('startDaemon', () => {
     expect(existsSync(registrationFilePath('coder'))).toBe(false)
   })
 
+  test('fatal auth failure GCs the matching registration (broker + file + list)', async () => {
+    const startCalls: PortbrokerStartInput[] = []
+    const stopCalls: Array<{ name: string; reason: string }> = []
+    const portbroker: PortbrokerCallbacks = {
+      start: async (input) => {
+        startCalls.push(input)
+      },
+      stop: async (name, reason) => {
+        stopCalls.push({ name, reason })
+      },
+      forwardedPorts: () => [],
+    }
+    daemon = await startDaemon({ exec: fakeExec(new Set(['coder'])), gcIntervalMs: 1_000_000, portbroker })
+    await send({
+      kind: 'register',
+      containerName: 'coder',
+      cwd: '/agent/coder',
+      wsHostPort: 12345,
+      portForward: { allow: '*' },
+      brokerToken: 'T1',
+    })
+    expect(existsSync(registrationFilePath('coder'))).toBe(true)
+
+    startCalls[0]?.onFatalAuthFailure?.({ brokerToken: 'T1', reason: 'invalid token' })
+
+    await waitFor(() => !existsSync(registrationFilePath('coder')))
+    expect(stopCalls).toEqual([{ name: 'coder', reason: 'fatal-auth' }])
+    const list = await send({ kind: 'list' })
+    expect(list.ok).toBe(true)
+    if (!list.ok) return
+    expect((list.result as ListResult).registrations).toHaveLength(0)
+  })
+
+  test('stale fatal auth (T_old) does not delete a freshly re-registered T_new', async () => {
+    const startCalls: PortbrokerStartInput[] = []
+    const stopCalls: Array<{ name: string; reason: string }> = []
+    const portbroker: PortbrokerCallbacks = {
+      start: async (input) => {
+        startCalls.push(input)
+      },
+      stop: async (name, reason) => {
+        stopCalls.push({ name, reason })
+      },
+      forwardedPorts: () => [],
+    }
+    daemon = await startDaemon({ exec: fakeExec(new Set(['coder'])), gcIntervalMs: 1_000_000, portbroker })
+
+    const base = {
+      kind: 'register' as const,
+      containerName: 'coder',
+      cwd: '/agent/coder',
+      wsHostPort: 12345,
+      portForward: { allow: '*' as const },
+    }
+    await send({ ...base, brokerToken: 'T1' })
+    await send({ ...base, brokerToken: 'T2' })
+    expect(existsSync(registrationFilePath('coder'))).toBe(true)
+
+    startCalls[0]?.onFatalAuthFailure?.({ brokerToken: 'T1', reason: 'invalid token' })
+
+    await expectStable(() => !existsSync(registrationFilePath('coder')), {
+      durationMs: 60,
+      description: 'T_new registration deleted by stale T_old fatal callback',
+    })
+    expect(stopCalls).toEqual([])
+    const list = await send({ kind: 'list' })
+    expect(list.ok).toBe(true)
+    if (!list.ok) return
+    expect((list.result as ListResult).registrations).toEqual([{ containerName: 'coder', cwd: '/agent/coder' }])
+  })
+
   test('persisted registrations survive daemon respawn (HTTP restart works against a fresh daemon)', async () => {
     const restartCalls: Array<{ containerName: string; cwd: string }> = []
     const restart = async ({ containerName, cwd }: { containerName: string; cwd: string }) => {

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -70,7 +70,7 @@ export type RestartPreflight = (input: {
 
 export type PortbrokerCallbacks = {
   start: (input: PortbrokerStartInput) => Promise<void>
-  stop: (containerName: string, reason: 'deregistered' | 'broker-stopped') => Promise<void>
+  stop: (containerName: string, reason: 'deregistered' | 'broker-stopped' | 'fatal-auth') => Promise<void>
   // Returns ports the broker is currently exposing on the host for this
   // container. Empty array when the container is unregistered, when the broker
   // is disabled (`portForward.allow: []`), or when nothing inside the
@@ -87,6 +87,7 @@ export type PortbrokerStartInput = {
   brokerToken: string
   onEvent: (event: PortForwardEvent) => void
   onTailscaleServeEvent: (event: TailscaleServeEvent) => void
+  onFatalAuthFailure?: (info: { brokerToken: string; reason: string }) => void
 }
 
 export type DaemonLogEvent =
@@ -227,6 +228,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   const version = opts.version ?? UNVERSIONED_SENTINEL
   const cwds = new Map<string, string>()
   const restartTokens = new Map<string, string>()
+  const brokerTokens = new Map<string, string>()
   const perContainerSerial = new Map<string, Promise<unknown>>()
   const gcMisses = new Map<string, number>()
   let stopped = false
@@ -285,6 +287,24 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     } catch {}
   }
 
+  // A broker reports fatal auth when its token no longer matches the running
+  // container (typically a stale T_old broker revived on hostd boot racing a
+  // container that now expects T_new). The token guard is load-bearing: a fresh
+  // register may have overwritten brokerTokens with T_new before this late
+  // callback fires, in which case we must NOT delete the live registration.
+  const handleFatalAuthFailure = (containerName: string, failedToken: string, reason: string): Promise<void> =>
+    runSerially(containerName, async () => {
+      if (brokerTokens.get(containerName) !== failedToken) return
+      brokerTokens.delete(containerName)
+      cwds.delete(containerName)
+      restartTokens.delete(containerName)
+      gcMisses.delete(containerName)
+      if (opts.portbroker) await opts.portbroker.stop(containerName, 'fatal-auth').catch(() => {})
+      if (opts.kakaoRenewal) await opts.kakaoRenewal.stop(containerName).catch(() => {})
+      await removeRegistrationFile(containerName)
+      log({ kind: 'registration-skipped', containerName, reason: `fatal broker auth: ${reason}` })
+    })
+
   const applyRegistration = async (payload: RegisterPayload): Promise<void> => {
     const alreadyRegistered = cwds.has(payload.containerName)
     cwds.set(payload.containerName, payload.cwd)
@@ -299,6 +319,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       payload.portForward !== undefined &&
       payload.brokerToken !== undefined
     ) {
+      brokerTokens.set(payload.containerName, payload.brokerToken)
       await opts.portbroker.start({
         containerName: payload.containerName,
         cwd: payload.cwd,
@@ -307,6 +328,9 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
         brokerToken: payload.brokerToken,
         onEvent: (event) => log({ kind: 'port-forward-event', event }),
         onTailscaleServeEvent: (event) => log({ kind: 'tailscale-serve-event', event }),
+        onFatalAuthFailure: ({ brokerToken, reason }) => {
+          void handleFatalAuthFailure(payload.containerName, brokerToken, reason)
+        },
       })
     }
     if (opts.kakaoRenewal) {
@@ -335,6 +359,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     runSerially(req.containerName, async () => {
       const hadCwd = cwds.delete(req.containerName)
       restartTokens.delete(req.containerName)
+      brokerTokens.delete(req.containerName)
       gcMisses.delete(req.containerName)
       if (opts.portbroker) await opts.portbroker.stop(req.containerName, 'deregistered').catch(() => {})
       if (opts.kakaoRenewal) await opts.kakaoRenewal.stop(req.containerName).catch(() => {})

--- a/src/hostd/portbroker-manager.ts
+++ b/src/hostd/portbroker-manager.ts
@@ -70,6 +70,13 @@ export function createPortbrokerManager(opts: PortbrokerManagerOptions = {}): Po
           if (event.kind === 'port-forward-opened') tailscale.servePort(event.port)
           else if (event.kind === 'port-forward-closed') tailscale.stopPort(event.port)
         },
+        onFatalAuthFailure: (reason) => {
+          // The broker has already stopped itself. Drop it from the map so a
+          // later stop()/start() doesn't double-stop or race the dead instance,
+          // then let hostd GC the stale registration (token-guarded).
+          if (brokers.get(input.containerName) === broker) brokers.delete(input.containerName)
+          input.onFatalAuthFailure?.({ brokerToken: input.brokerToken, reason })
+        },
         onLog: (msg) => log(`[portbroker:${input.containerName}] ${msg}`),
       })
       brokers.set(input.containerName, broker)

--- a/src/portbroker/hostd-client.test.ts
+++ b/src/portbroker/hostd-client.test.ts
@@ -118,10 +118,16 @@ function makeFakeListenHost(opts: { failPorts?: Set<number>; listeners: Map<numb
   }
 }
 
-function setup(opts: { policy: PortForward; resolveHostPort?: () => Promise<number | null>; failPorts?: Set<number> }) {
+function setup(opts: {
+  policy: PortForward
+  resolveHostPort?: () => Promise<number | null>
+  failPorts?: Set<number>
+  connectWs?: () => Promise<WsClient>
+}) {
   const ws = makeFakeWs()
   const listeners = new Map<number, FakeListener>()
   const events: PortForwardEvent[] = []
+  const fatalAuthFailures: string[] = []
   const broker = createBroker({
     containerName: 'test-agent',
     cwd: '/tmp/test',
@@ -129,11 +135,12 @@ function setup(opts: { policy: PortForward; resolveHostPort?: () => Promise<numb
     resolveHostPort: opts.resolveHostPort ?? (async () => 12345),
     brokerToken: 'tok',
     onEvent: (e) => events.push(e),
-    connectWs: async () => ws,
+    onFatalAuthFailure: (reason) => fatalAuthFailures.push(reason),
+    connectWs: opts.connectWs ?? (async () => ws),
     listenHost: makeFakeListenHost({ ...(opts.failPorts ? { failPorts: opts.failPorts } : {}), listeners }),
     reconnectDelaysMs: [10, 10],
   })
-  return { broker, ws, listeners, events }
+  return { broker, ws, listeners, events, fatalAuthFailures }
 }
 
 describe('createBroker', () => {
@@ -151,6 +158,35 @@ describe('createBroker', () => {
     await waitFor(() => ws.outbox.some((m) => m.type === 'broker-hello'))
     ws.emit({ type: 'broker-hello-ack' })
     expect(ws.outbox).toContainEqual({ type: 'port-watch-subscribe' })
+    await broker.stop()
+  })
+
+  test('auth nack (invalid token) is fatal: no reconnect, fires onFatalAuthFailure', async () => {
+    const { broker, ws, fatalAuthFailures } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await waitFor(() => ws.outbox.some((m) => m.type === 'broker-hello'))
+    const helloCount = () => ws.outbox.filter((m) => m.type === 'broker-hello').length
+    expect(helloCount()).toBe(1)
+
+    ws.emit({ type: 'broker-hello-nack', reason: 'invalid token' })
+
+    await waitFor(() => fatalAuthFailures.length > 0)
+    expect(fatalAuthFailures).toEqual(['invalid token'])
+    expect(ws.closed).toBe(true)
+    await expectStable(() => helloCount() > 1, { durationMs: 60, description: 'reconnect-after-auth-nack' })
+    expect(helloCount()).toBe(1)
+    await broker.stop()
+  })
+
+  test('non-auth WS close still reconnects', async () => {
+    const { broker, ws, fatalAuthFailures } = setup({ policy: { allow: '*' } })
+    broker.start()
+    await waitFor(() => ws.outbox.some((m) => m.type === 'broker-hello'))
+
+    ws.triggerClose()
+
+    await waitFor(() => ws.outbox.filter((m) => m.type === 'broker-hello').length >= 2)
+    expect(fatalAuthFailures).toEqual([])
     await broker.stop()
   })
 

--- a/src/portbroker/hostd-client.ts
+++ b/src/portbroker/hostd-client.ts
@@ -25,6 +25,10 @@ export type BrokerOptions = {
   resolveHostPort: () => Promise<number | null>
   brokerToken: string
   onEvent: (event: PortForwardEvent) => void
+  // A broker's token is immutable for its lifetime, so an auth rejection can
+  // never be repaired by reconnecting. On auth nack the broker stops for good
+  // and reports the reason so hostd can GC the stale registration.
+  onFatalAuthFailure?: (reason: string) => void
   onLog?: (msg: string) => void
   connectWs?: (url: string) => Promise<WsClient>
   listenHost?: ListenHostFn
@@ -67,6 +71,11 @@ export type Broker = {
 
 const DEFAULT_RECONNECT_DELAYS = [1_000, 2_000, 4_000, 10_000]
 const DEFAULT_HOST_BIND = '127.0.0.1'
+
+// broker-hello-nack reasons emitted by container-server.ts when authentication
+// fails. These are immutable for a broker instance's lifetime, so reconnecting
+// the same broker can only reproduce them — the broker must stop instead.
+const AUTH_NACK_REASONS: ReadonlySet<string> = new Set(['invalid token', 'expected broker-hello first'])
 
 export function createBroker(opts: BrokerOptions): Broker {
   const log = opts.onLog ?? (() => {})
@@ -211,7 +220,11 @@ export function createBroker(opts: BrokerOptions): Broker {
         return
       case 'broker-hello-nack':
         log(`broker-hello rejected: ${msg.reason}`)
-        if (ws) ws.close()
+        if (AUTH_NACK_REASONS.has(msg.reason)) {
+          fatalStop(msg.reason)
+        } else if (ws) {
+          ws.close()
+        }
         return
       case 'port-listen-snapshot':
         for (const { port, bindAddr } of msg.ports) {
@@ -307,6 +320,27 @@ export function createBroker(opts: BrokerOptions): Broker {
     }, delay)
   }
 
+  const teardown = (): void => {
+    stopped = true
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    teardownAllForwarders('broker-stopped')
+    if (ws) {
+      try {
+        ws.close()
+      } catch {}
+      ws = null
+    }
+  }
+
+  const fatalStop = (reason: string): void => {
+    if (stopped) return
+    teardown()
+    opts.onFatalAuthFailure?.(reason)
+  }
+
   return {
     start() {
       if (!brokerEnabled(opts.policy)) {
@@ -316,18 +350,7 @@ export function createBroker(opts: BrokerOptions): Broker {
       void connect()
     },
     async stop() {
-      stopped = true
-      if (reconnectTimer !== null) {
-        clearTimeout(reconnectTimer)
-        reconnectTimer = null
-      }
-      teardownAllForwarders('broker-stopped')
-      if (ws) {
-        try {
-          ws.close()
-        } catch {}
-        ws = null
-      }
+      teardown()
     },
     forwardedPorts() {
       return Array.from(forwarders.keys())


### PR DESCRIPTION
## Background

After a restart, hostd logs flood with an endless loop:

```
portbroker-log {"kind":"portbroker-log","event":{"kind":"auth-failed","reason":"token mismatch"}}
```

repeating every ~1-2 seconds, indefinitely.

The broker token is minted fresh on every `typeclaw start` (`randomBytes(32)` in `src/container/start.ts`) and baked into the container at `docker run` time as `TYPECLAW_HOSTD_BROKER_TOKEN`. It is immutable for the lifetime of a broker instance — reconnecting can never make a wrong token match. When a host-side broker fails the broker-hello handshake, the client did `ws.close()` → `onClose` → `scheduleReconnect()` → reconnect → re-send the same wrong token → nack again. The TCP/WS connect itself succeeds (only the app-level hello is rejected), so `reconnectAttempt` resets to 0 each connect and the backoff never grows — ~1-2 s loop forever.

The tokens diverge after an ungraceful hostd death (crash / kill -9 / reboot): the persisted `registrations/<name>.json` survives with `T_old`, boot-time restore revives a `T_old` broker (restore errs toward reviving on a flaky `docker ps` probe), and `typeclaw restart` brings up a container expecting `T_new`. The existing serialized-swap fix in `portbroker-manager.ts` only collapses the one-shot race when a fresh register supersedes the stale broker; when nothing supersedes it, it loops.

## Summary

Treat an auth broker-hello-nack (`invalid token` / `expected broker-hello first`) as terminal rather than reconnectable.

- `src/portbroker/hostd-client.ts` — auth nack calls a `fatalStop` path (set stopped, clear reconnect timer, tear down forwarders, close WS) instead of reconnecting, and reports the reason via a new `onFatalAuthFailure` option. Non-auth closes still reconnect via the existing backoff. `stop()` and `fatalStop()` share an extracted `teardown()`.
- `src/hostd/portbroker-manager.ts` — bubbles `onFatalAuthFailure` upward and drops the dead broker from its map (identity-guarded so it can't evict a newer broker).
- `src/hostd/daemon.ts` — on fatal auth, GCs the matching registration (stop broker + clear maps + unlink persisted file) so it is NOT revived on the next boot. The removal is token-guarded: if a fresh register already overwrote the stored token with `T_new`, a late `T_old` callback is a no-op and the live registration is preserved.

The serialized swap-on-re-register contract and the restore-on-unknown probe behavior are both left intact.

## Preview

N/A — no UI changes.

## What this does NOT do

- Does **not** change behavior for non-auth disconnections — those still reconnect with the existing backoff.
- Does **not** change the serialized swap-on-re-register contract in `portbroker-manager.ts`.
- Does **not** change the restore-on-unknown probe behavior in `daemon.ts`.
- Does **not** affect any broker whose token matches the current container token.

## Review notes

- **Load-bearing invariant:** the token guard in `daemon.ts` (`storedToken === fatalToken`) must match the persisted token, not the manager's in-memory broker. If a fresh `T_new` register already overwrote the file, `storedToken` is `T_new` ≠ `T_old` and the callback is a no-op — the live registration is preserved. Verify this guard is checked against `readRegistration()` output, not against the manager map.
- **`fatalStop` vs `stop`:** the key difference is that `fatalStop` fires `onFatalAuthFailure` and bypasses the reconnect path entirely. A `stop()` call from outside (e.g., manager teardown) still goes through the normal `teardown()` path.
- **Tests:**
  - `hostd-client.test.ts` — auth nack stops permanently (no reconnect, fires `onFatalAuthFailure`); non-auth WS close still reconnects.
  - `daemon.test.ts` — fatal auth GCs the matching registration (broker stopped + file removed + evicted from list); a stale `T_old` fatal callback does NOT delete a freshly re-registered `T_new`.
- Checks: `bun run typecheck`, `bun run lint`, `bun run format`, `bun run test` all pass. One pre-existing unrelated failure (`resolveSelfPackageJsonPath > points at this package manifest`) triggers only in a worktree whose directory isn't named `typeclaw`; it passes in CI and on a normal checkout.