### PR TITLE
agent: drop orphaned tool results before LLM replay

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -35,6 +35,7 @@ import { getAuthFor } from './auth'
 import { createCompactionSettingsManager } from './compaction'
 import { renderGitNudge } from './git-nudge'
 import type { LiveSubagentRegistry } from './live-subagents'
+import { sanitizeMessagesForLlmReplay } from './llm-replay-sanitizer'
 import { applyModelRuntimeOverrides } from './model-overrides'
 import { createChannelLookAtTool, lookAtTool } from './multimodal'
 import {
@@ -404,6 +405,21 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     customTools,
     ...(thinkingLevel ? { thinkingLevel } : {}),
   })
+
+  // Layer the replay sanitizer over pi's convertToLlm so a transcript with an
+  // orphaned toolResult (e.g. a torn-down restart turn) can't wedge the session
+  // with an Anthropic 400 on every replay. Runs on every provider call path
+  // that goes through the agent. Honors pi's contract that convertToLlm must
+  // not throw: on any failure it falls back to the unsanitized output.
+  const innerConvertToLlm = session.agent.convertToLlm
+  session.agent.convertToLlm = async (messages) => {
+    const converted = await innerConvertToLlm(messages)
+    try {
+      return sanitizeMessagesForLlmReplay(converted).messages
+    } catch {
+      return converted
+    }
+  }
 
   abortHolder.abort = () => {
     if (session.agent.signal?.aborted !== true) session.agent.abort()

--- a/src/agent/llm-replay-sanitizer.test.ts
+++ b/src/agent/llm-replay-sanitizer.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'bun:test'
+
+import type { AssistantMessage, Message, ToolResultMessage } from '@mariozechner/pi-ai'
+
+import { sanitizeMessagesForLlmReplay } from '@/agent/llm-replay-sanitizer'
+
+function user(text: string): Message {
+  return { role: 'user', content: text, timestamp: 1 }
+}
+
+function assistant(toolCallIds: string[], stopReason: AssistantMessage['stopReason'] = 'toolUse'): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: toolCallIds.map((id) => ({ type: 'toolCall' as const, id, name: 'restart', arguments: {} })),
+    api: 'anthropic-messages',
+    provider: 'anthropic',
+    model: 'claude',
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: 1,
+  }
+}
+
+function toolResult(toolCallId: string): ToolResultMessage {
+  return {
+    role: 'toolResult',
+    toolCallId,
+    toolName: 'restart',
+    content: [{ type: 'text', text: 'ok' }],
+    isError: false,
+    timestamp: 1,
+  }
+}
+
+function ids(messages: Message[]): string[] {
+  return messages.map((m) => {
+    if (m.role === 'toolResult') return `result:${m.toolCallId}`
+    if (m.role === 'assistant') {
+      const calls = m.content.filter((b) => b.type === 'toolCall').map((b) => (b as { id: string }).id)
+      return `assistant:${calls.join(',')}`
+    }
+    return 'user'
+  })
+}
+
+describe('sanitizeMessagesForLlmReplay', () => {
+  it('passes valid tool-use history through unchanged', () => {
+    const input = [user('hi'), assistant(['a']), toolResult('a'), assistant([], 'stop')]
+    const { messages, stats } = sanitizeMessagesForLlmReplay(input)
+    expect(messages).toEqual(input)
+    expect(stats).toEqual({ droppedOrphans: 0, droppedDuplicates: 0, droppedErrorAssistants: 0 })
+  })
+
+  it('drops a toolResult whose producing assistant was error/aborted (the dobby poison)', () => {
+    const input = [user('restart'), assistant(['toolu_x'], 'error'), toolResult('toolu_x'), user('you back?')]
+    const { messages, stats } = sanitizeMessagesForLlmReplay(input)
+    expect(ids(messages)).toEqual(['user', 'user'])
+    expect(stats.droppedErrorAssistants).toBe(1)
+    expect(stats.droppedOrphans).toBe(1)
+  })
+
+  it('drops a true orphan toolResult with no preceding toolCall at all', () => {
+    const input = [user('hi'), toolResult('ghost'), assistant([], 'stop')]
+    const { messages, stats } = sanitizeMessagesForLlmReplay(input)
+    expect(ids(messages)).toEqual(['user', 'assistant:'])
+    expect(stats.droppedOrphans).toBe(1)
+  })
+
+  it('keeps multiple tool calls from one assistant with interleaved out-of-order results', () => {
+    const input = [assistant(['a', 'b']), toolResult('b'), toolResult('a')]
+    const { messages, stats } = sanitizeMessagesForLlmReplay(input)
+    expect(ids(messages)).toEqual(['assistant:a,b', 'result:b', 'result:a'])
+    expect(stats.droppedOrphans).toBe(0)
+  })
+
+  it('dedupes a duplicate toolResult for the same toolCallId', () => {
+    const input = [assistant(['a']), toolResult('a'), toolResult('a')]
+    const { messages, stats } = sanitizeMessagesForLlmReplay(input)
+    expect(ids(messages)).toEqual(['assistant:a', 'result:a'])
+    expect(stats.droppedDuplicates).toBe(1)
+  })
+
+  it('drops a late result that arrives after a user message closed the window', () => {
+    const input = [assistant(['a']), toolResult('a'), user('next'), toolResult('a')]
+    const { messages, stats } = sanitizeMessagesForLlmReplay(input)
+    expect(ids(messages)).toEqual(['assistant:a', 'result:a', 'user'])
+    expect(stats.droppedOrphans).toBe(1)
+  })
+
+  it('drops a result belonging to a prior assistant window once a new assistant turn starts', () => {
+    const input = [assistant(['a']), assistant(['b']), toolResult('a'), toolResult('b')]
+    const { messages, stats } = sanitizeMessagesForLlmReplay(input)
+    expect(ids(messages)).toEqual(['assistant:a', 'assistant:b', 'result:b'])
+    expect(stats.droppedOrphans).toBe(1)
+  })
+
+  it('leaves a bare toolCall when its only result was an orphan (pi-ai synthesizes the placeholder)', () => {
+    const input = [assistant(['a']), user('interrupt'), toolResult('a')]
+    const { messages, stats } = sanitizeMessagesForLlmReplay(input)
+    expect(ids(messages)).toEqual(['assistant:a', 'user'])
+    expect(stats.droppedOrphans).toBe(1)
+  })
+})

--- a/src/agent/llm-replay-sanitizer.ts
+++ b/src/agent/llm-replay-sanitizer.ts
@@ -1,0 +1,120 @@
+// Defensive projection applied to the LLM message array right before each
+// provider call, layered on top of pi-coding-agent's `convertToLlm`. It exists
+// to un-wedge sessions whose persisted transcript contains a `toolResult` with
+// no live preceding `toolCall` — the exact shape Anthropic rejects with
+// "unexpected `tool_use_id` found in `tool_result` blocks" (HTTP 400).
+//
+// How a transcript gets poisoned: the self-`restart` tool exits the container
+// mid-turn. The assistant turn carrying the restart `toolCall` can land in the
+// JSONL with `stopReason: "error"/"aborted"` (or be torn down), while its
+// `toolResult` is persisted. On replay, pi-ai's provider-side `transformMessages`
+// DROPS error/aborted assistant turns but passes the `toolResult` through
+// unchanged, leaving a true orphan that the API rejects on every subsequent
+// turn — the session is permanently stuck.
+//
+// pi-ai's `transformMessages` already handles the inverse cases (a `toolCall`
+// with no result → synthetic "No result provided" result; error/aborted
+// assistant turns → dropped). The one gap is an orphaned `toolResult`. This
+// sanitizer fills exactly that gap and nothing more.
+//
+// Invariant (local pending-window, NOT a global id union — Anthropic requires
+// tool results to belong to the immediately preceding tool-use turn):
+//   1. Assistant turns with stopReason "error"/"aborted" are dropped here, so
+//      orphan detection sees the same message set the provider will after its
+//      own drop pass. Without this, a result tied to a dropped assistant would
+//      survive us and be orphaned downstream — the original bug.
+//   2. A `toolResult` is kept only if its `toolCallId` was declared by the most
+//      recent kept assistant tool-use turn AND has not already been emitted in
+//      that window. Any user or assistant message closes the window.
+//   3. Missing results are NOT synthesized here — pi-ai's existing pass inserts
+//      the synthetic placeholder, so dropping an orphan that leaves a bare
+//      `toolCall` is safe and self-healing.
+//
+// This is a read-only projection: it never mutates the persisted JSONL, so an
+// already-poisoned session becomes usable without destructive migration.
+
+import type { Message } from '@mariozechner/pi-ai'
+
+export type ReplaySanitizerStats = {
+  droppedOrphans: number
+  droppedDuplicates: number
+  droppedErrorAssistants: number
+}
+
+export type SanitizeResult = {
+  messages: Message[]
+  stats: ReplaySanitizerStats
+}
+
+function isErroredAssistant(message: Message): boolean {
+  return message.role === 'assistant' && (message.stopReason === 'error' || message.stopReason === 'aborted')
+}
+
+function toolCallIdsOf(message: Extract<Message, { role: 'assistant' }>): string[] {
+  return message.content
+    .filter((block): block is Extract<typeof block, { type: 'toolCall' }> => block.type === 'toolCall')
+    .map((block) => block.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
+
+export function sanitizeMessagesForLlmReplay(messages: Message[]): SanitizeResult {
+  const output: Message[] = []
+  const stats: ReplaySanitizerStats = {
+    droppedOrphans: 0,
+    droppedDuplicates: 0,
+    droppedErrorAssistants: 0,
+  }
+
+  let pendingToolCallIds = new Set<string>()
+  let emittedResultIds = new Set<string>()
+
+  const closeWindow = () => {
+    pendingToolCallIds = new Set()
+    emittedResultIds = new Set()
+  }
+
+  for (const message of messages) {
+    if (message.role === 'assistant') {
+      closeWindow()
+
+      // Mirror pi-ai's provider-side drop of incomplete turns so orphan
+      // detection matches the message set the provider will actually send.
+      if (isErroredAssistant(message)) {
+        stats.droppedErrorAssistants += 1
+        continue
+      }
+
+      const callIds = toolCallIdsOf(message)
+      if (callIds.length > 0) pendingToolCallIds = new Set(callIds)
+      output.push(message)
+      continue
+    }
+
+    if (message.role === 'user') {
+      closeWindow()
+      output.push(message)
+      continue
+    }
+
+    if (message.role === 'toolResult') {
+      const id = message.toolCallId
+      if (!pendingToolCallIds.has(id)) {
+        // Orphan: true orphan, stale late result, or result for a dropped
+        // error/aborted assistant turn.
+        stats.droppedOrphans += 1
+        continue
+      }
+      if (emittedResultIds.has(id)) {
+        stats.droppedDuplicates += 1
+        continue
+      }
+      emittedResultIds.add(id)
+      output.push(message)
+      continue
+    }
+
+    output.push(message)
+  }
+
+  return { messages: output, stats }
+}


### PR DESCRIPTION
## Problem

A self-`restart` tears the container down mid-turn. The assistant turn carrying the restart `toolCall` can land in the session JSONL with `stopReason: "error"/"aborted"` (or truncated), while its `toolResult` is persisted. On reboot the transcript is replayed to Anthropic, whose provider-side transform (`pi-ai`'s `transformMessages`) **drops the error/aborted assistant turn but keeps the `toolResult`**, leaving a dangling `tool_use_id`. The API then rejects it:

```
400 invalid_request_error: messages.40.content.2: unexpected `tool_use_id`
found in `tool_result` blocks: toolu_016Vc7tb3PHh5gmeE36gZkSh
```

Every subsequent turn re-sends the same poisoned history → the same 400. The session is **permanently wedged** and cannot recover on its own.

## Fix

`pi-ai`'s `transformMessages` already handles the inverse cases — a `toolCall` with no result gets a synthetic `"No result provided"` placeholder, and error/aborted assistant turns are dropped. The one gap is an orphaned `toolResult` (a result with no live preceding `toolCall`). This PR fills exactly that gap.

`sanitizeMessagesForLlmReplay` is layered over `pi`'s `convertToLlm` in the single session factory (`createSessionWithDispose`), so it runs on **every live turn path** — TUI, cron, channel, and subagent. It enforces a **local pending-window** invariant (Anthropic requires tool results to belong to the immediately preceding tool-use turn):

1. Assistant turns with `stopReason` `error`/`aborted` are dropped, so orphan detection sees the same message set the provider will after its own drop pass. Without this, a result tied to a dropped assistant survives and gets re-orphaned downstream — the original bug.
2. A `toolResult` is kept only if its `toolCallId` was declared by the most recent kept assistant tool-use turn and hasn't already been emitted in that window. Any user or assistant message closes the window.
3. Missing results are **not** synthesized here — `pi-ai`'s existing pass inserts the placeholder, so dropping an orphan that leaves a bare `toolCall` is safe and self-healing.

It's a **read-only projection**: the persisted JSONL is never mutated, so an already-poisoned session recovers on the next turn with no destructive migration. The wrapper also honors `pi`'s contract that `convertToLlm` must not throw — on any failure it falls back to the unsanitized output.

## Why not also fix the write side?

The restart tool could append a synthetic `toolResult` before exit, but that only reduces how often orphans are *created* — it doesn't un-wedge already-poisoned sessions, and racing manual persistence against the library's own `message_end` flush risks duplicate results. The read-side sanitizer fully neutralizes the orphan regardless of how it was produced (missing result → library synthesizes; error/aborted producer → we drop the orphan), so the minimal, complete fix lives on the read side.

## Tests

`src/agent/llm-replay-sanitizer.test.ts` covers: valid history passthrough, the dobby poison (errored assistant + surviving result), a true orphan with no producer, multiple tool calls with out-of-order results, duplicate-result dedupe, a late result after a user boundary, a result from a prior closed window, and the bare-`toolCall` self-healing case. All 8 pass.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format` — applied
- `bun test --parallel src/agent/llm-replay-sanitizer.test.ts src/agent/index.test.ts` — 99 pass, 0 fail
