### PR TITLE
fix: stop loop-guard from blocking post-completion subagent_output fetch

### DIFF
--- a/src/agent/loop-guard.test.ts
+++ b/src/agent/loop-guard.test.ts
@@ -356,3 +356,85 @@ describe('createLoopGuard — windowed multi-signature detection', () => {
     }
   })
 })
+
+describe('createLoopGuard — forgetTool', () => {
+  const noConsecutive = { softWarn: 1000, hardBlock: 1001 }
+
+  function windowGuard() {
+    return createLoopGuard({ ...noConsecutive, windowSize: 16, windowSoftWarn: 4, windowHardBlock: 6 })
+  }
+
+  // Reproduces the incident: premature subagent_output polling (interleaved
+  // with other work, as it was in production — the windowed detector only sees
+  // non-consecutive repeats) poisons the window, then a completion reminder
+  // clears it so the next fetch is allowed.
+  function pollInterleaved(guard: ReturnType<typeof windowGuard>, times: number): ReturnType<typeof guard.check> {
+    const args = { task_id: 'bg_x' }
+    let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+    for (let i = 0; i < times; i++) {
+      last = guard.check('s1', 'subagent_output', args)
+      guard.check('s1', 'bash', { command: `step${i}` })
+    }
+    return last
+  }
+
+  test('clears the windowed residue for the named tool so the next call is allowed', () => {
+    const guard = windowGuard()
+    pollInterleaved(guard, 5)
+    guard.forgetTool('s1', 'subagent_output')
+    expect(guard.check('s1', 'subagent_output', { task_id: 'bg_x' }).kind).toBe('ok')
+  })
+
+  test('without forgetTool the same polling spree still hard-blocks', () => {
+    const guard = windowGuard()
+    const last = pollInterleaved(guard, 6)
+    expect(last.kind).toBe('block')
+    if (last.kind === 'block') expect(last.reason).toBe('windowed')
+  })
+
+  // The windowed detector only evaluates on calls that break the consecutive
+  // streak (count === 1), so bash and subagent_output are interleaved here to
+  // keep each one's window count climbing without a consecutive run.
+  test('does not clear another tool\u2019s accumulated window', () => {
+    const guard = windowGuard()
+    let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+    for (let i = 0; i < 6; i++) {
+      guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+      last = guard.check('s1', 'bash', { command: 'ls' })
+    }
+    // Drop subagent_output's residue; bash's six interleaved entries remain.
+    guard.forgetTool('s1', 'subagent_output')
+    expect(last.kind).toBe('block')
+    if (last.kind === 'block') expect(last.reason).toBe('windowed')
+  })
+
+  test('clears a consecutive streak only when it belongs to the named tool', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+    guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+    guard.forgetTool('s1', 'subagent_output')
+    expect(guard.check('s1', 'subagent_output', { task_id: 'bg_x' }).kind).toBe('ok')
+    expect(guard.check('s1', 'subagent_output', { task_id: 'bg_x' }).kind).toBe('ok')
+    expect(guard.check('s1', 'subagent_output', { task_id: 'bg_x' }).kind).toBe('warn')
+  })
+
+  test('leaves a different tool\u2019s consecutive streak intact', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    guard.check('s1', 'bash', { command: 'ls' })
+    guard.check('s1', 'bash', { command: 'ls' })
+    guard.forgetTool('s1', 'subagent_output')
+    expect(guard.check('s1', 'bash', { command: 'ls' }).kind).toBe('warn')
+  })
+
+  test('coarsened path-bearing residue is cleared by tool name', () => {
+    const guard = windowGuard()
+    for (let i = 0; i < 5; i++) guard.check('s1', 'read', { path: '/a.ts', offset: i })
+    guard.forgetTool('s1', 'read')
+    expect(guard.check('s1', 'read', { path: '/a.ts', offset: 99 }).kind).toBe('ok')
+  })
+
+  test('is a no-op for an unknown session', () => {
+    const guard = windowGuard()
+    expect(() => guard.forgetTool('missing', 'subagent_output')).not.toThrow()
+  })
+})

--- a/src/agent/loop-guard.ts
+++ b/src/agent/loop-guard.ts
@@ -63,6 +63,14 @@ export type LoopGuard = {
   check: (sessionId: string, tool: string, args: unknown) => LoopGuardDecision
   reset: (sessionId: string) => void
   forget: (sessionId: string) => void
+  // Clears only the residue a single tool left behind in a session: its entries
+  // in the windowed history and, if the current consecutive streak belongs to
+  // that tool, the streak itself. Used when a state-change boundary makes a
+  // tool's prior calls irrelevant — e.g. a backgrounded subagent finishing
+  // makes the next `subagent_output` fetch legitimate even though earlier
+  // premature polls poisoned the window. Narrower than `forget`, so an
+  // unrelated tool's accumulating loop on the same session is preserved.
+  forgetTool: (sessionId: string, tool: string) => void
 }
 
 type SessionState = {
@@ -215,7 +223,33 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
     forget(sessionId) {
       sessions.delete(sessionId)
     },
+    forgetTool(sessionId, tool) {
+      const state = sessions.get(sessionId)
+      if (state === undefined) return
+      const retained: string[] = []
+      for (const sig of state.window) {
+        if (signatureBelongsToTool(sig, tool)) {
+          state.windowWarned.delete(sig)
+        } else {
+          retained.push(sig)
+        }
+      }
+      state.window = retained
+      if (signatureBelongsToTool(state.signature, tool)) {
+        state.signature = ''
+        state.count = 0
+        state.warned = false
+      }
+    },
   }
+}
+
+// Both signature builders prefix the tool name: exact signatures as `tool:...`
+// and path-coarsened ones as `tool#path:...`. A tool's residue is therefore any
+// signature starting with `tool:` or `tool#`, never a different tool whose name
+// merely shares this one as a prefix (the delimiter rules that out).
+function signatureBelongsToTool(signature: string, tool: string): boolean {
+  return signature.startsWith(`${tool}:`) || signature.startsWith(`${tool}#`)
 }
 
 function formatWarnMessage(tool: string, count: number): string {

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -16,6 +16,7 @@ import {
   __resetSharedLoopGuardForTests,
   buildBuiltinPiToolOverrides,
   defaultBuiltinPiAgentTools,
+  forgetSharedLoopGuardTool,
   TYPECLAW_INTERNAL_BASH_ENV,
   wrapAgentToolAsCustomToolDefinition,
   wrapPluginTool,
@@ -1238,6 +1239,33 @@ describe('loop guard integration', () => {
     expect(calls.length).toBe(4)
     expect(blocked.isError).toBe(true)
     expect(blocked.content[0]?.text).toContain('loop-guard')
+  })
+
+  test('forgetSharedLoopGuardTool clears the shared streak for the named tool so the next call passes', async () => {
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ q: z.string() }),
+      async execute(args) {
+        return { content: [{ type: 'text', text: `q=${args.q}` }] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'p1',
+      toolName: 'search',
+      agentDir: '/agent',
+      sessionId: 'loop-forget-1',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+
+    for (let i = 0; i < 4; i++) {
+      await wrapped.execute(`c${i}`, { q: 'a' }, undefined, undefined, {} as never)
+    }
+    forgetSharedLoopGuardTool('loop-forget-1', 'search')
+    const after = (await wrapped.execute('c5', { q: 'a' }, undefined, undefined, {} as never)) as {
+      isError?: boolean
+    }
+    expect(after.isError).toBeUndefined()
   })
 
   test('resets the streak when the args change between plugin tool calls', async () => {

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -558,6 +558,16 @@ function appendLoopWarning(result: ToolResult, message: string): ToolResult {
   return { content, details: result.details }
 }
 
+// Clears one tool's loop-guard residue for a session on the process-wide shared
+// guard. The completion-reminder bridges (channel router + TUI server) call this
+// for `subagent_output` when a backgrounded subagent finishes, so the next fetch
+// the reminder asks for isn't blocked by the window the agent's premature polling
+// poisoned. Exposed as a narrow function rather than the guard itself so callers
+// can't reach `check`/`forget` and widen the blast radius.
+export function forgetSharedLoopGuardTool(sessionId: string, tool: string): void {
+  sharedLoopGuard.forgetTool(sessionId, tool)
+}
+
 // Test-only seam: swaps the shared loop guard for a fresh instance so tests
 // that reuse sessionIds across cases don't see cross-test streak counts.
 // Production code never calls this; the guard's LRU bound handles

--- a/src/agent/tools/subagent-output.ts
+++ b/src/agent/tools/subagent-output.ts
@@ -7,6 +7,8 @@ import type { LiveSubagentRegistry, StatusSnapshot, SubagentProgressEvent } from
 import type { SessionOrigin } from '../session-origin'
 import { authorizeLiveSubagentAccess } from './subagent-access'
 
+export const SUBAGENT_OUTPUT_TOOL_NAME = 'subagent_output'
+
 export type SubagentOutputToolDetails =
   | {
       ok: true
@@ -49,7 +51,7 @@ export function createSubagentOutputTool(options: CreateSubagentOutputToolOption
   const { liveRegistry, getOrigin, permissions, now = () => Date.now() } = options
 
   return defineTool({
-    name: 'subagent_output',
+    name: SUBAGENT_OUTPUT_TOOL_NAME,
     label: 'Subagent Output',
     description:
       'Fetch the current state of a subagent you previously spawned. Returns one of three statuses: ' +

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4,6 +4,7 @@ import type { AssistantMessage } from '@mariozechner/pi-ai'
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession, renderTurnRoleAnchor, renderTurnTimeAnchor, type AgentSession } from '@/agent'
+import { forgetSharedLoopGuardTool } from '@/agent/plugin-tools'
 import { subscribeProviderErrors } from '@/agent/provider-error'
 import type { RestartHandoff } from '@/agent/restart-handoff'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
@@ -15,6 +16,7 @@ import {
   recordTurnStart,
   runIdleContinuation,
 } from '@/agent/todo/continuation-wiring'
+import { SUBAGENT_OUTPUT_TOOL_NAME } from '@/agent/tools/subagent-output'
 import { type Command, type CommandPermission, type CommandResult, createCommandRegistry } from '@/commands'
 import { CORE_PERMISSIONS, type PermissionService } from '@/permissions'
 import type { HookBus } from '@/plugin'
@@ -3239,6 +3241,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         channel: true,
       })
       live.pendingSystemReminders.push(text)
+      // The reminder tells the agent to fetch this result now; clear the
+      // subagent_output window so an earlier premature-polling streak can't
+      // hard-block that legitimate fetch.
+      forgetSharedLoopGuardTool(live.sessionId, SUBAGENT_OUTPUT_TOOL_NAME)
       logger.info(`[channels] ${live.keyId}: subagent-completion reminder queued task=${args.taskId} ok=${args.ok}`)
       // Wake the drain loop. If a turn is already in flight, the wakeup is
       // a no-op because drain() will pick up the reminder on its next

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,6 +11,7 @@ import {
 import { runPluginDoctorChecks, runPluginDoctorFix } from '@/agent/doctor'
 import type { LiveSessionRegistry } from '@/agent/live-sessions'
 import type { LiveSubagentRegistry } from '@/agent/live-subagents'
+import { forgetSharedLoopGuardTool } from '@/agent/plugin-tools'
 import { detectProviderError } from '@/agent/provider-error'
 import { requestContainerRestart } from '@/agent/restart'
 import { consumeRestartHandoff, type RestartHandoff } from '@/agent/restart-handoff'
@@ -25,6 +26,7 @@ import {
   recordTurnStart,
   runIdleContinuation,
 } from '@/agent/todo/continuation-wiring'
+import { SUBAGENT_OUTPUT_TOOL_NAME } from '@/agent/tools/subagent-output'
 import type { ChannelRouter } from '@/channels/router'
 import { aggregateCronList, type CronListEntry, loadCron } from '@/cron'
 import type { McpManager } from '@/mcp'
@@ -930,6 +932,12 @@ function routeSubagentCompletionReminder(state: SessionState, msg: StreamMessage
   const parsed = parseSubagentCompletedPayload(msg.payload)
   if (parsed === null) return
   if (parsed.parentSessionId !== state.sessionFileId) return
+
+  // The reminder asks the agent to fetch this result now; clear the
+  // subagent_output window first so an earlier premature-polling streak can't
+  // hard-block that fetch. Reset before publish so the wakeup can't race stale
+  // guard state.
+  forgetSharedLoopGuardTool(state.sessionFileId, SUBAGENT_OUTPUT_TOOL_NAME)
 
   const idle = state.drainQueue.length === 0 && !state.draining
   const delivery = idle ? 'interrupt' : 'queue'


### PR DESCRIPTION
## Background

A channel agent spawned a `reviewer` subagent in the background, then went silent after promising a review. Reconstructed from the transcript:

1. The agent backgrounded `reviewer`, then polled `subagent_output` prematurely ~5 times (interleaved with `bash`/`channel_reply`), each returning `running`.
2. The system delivered the completion `<system-reminder>`: "Subagent reviewer completed in 1m19s. Use subagent_output to fetch the result."
3. The agent obeyed and called `subagent_output` once — that was the 6th occurrence of the signature in the loop-guard's sliding window. It tripped `windowHardBlock`; the block fired `fireLoopAbort`; the turn was aborted (`stopReason: aborted`).

The result was ready, the agent did exactly what the reminder asked, and the guard killed the turn before the fetch could land. User-visible symptom: a "still waiting…" message followed by silence.

Root-cause mechanism: the windowed detector counts recurrences of a signature with no notion of whether the underlying state advanced. A poll returning `running` and the fetch returning `completed` are byte-identical to the guard (same args). So the one legitimate post-completion fetch is indistinguishable from the premature polls and inherits their poisoned window.

## Summary

Clear only `subagent_output`'s loop-guard residue when a completion reminder is delivered, so the next fetch starts from a clean window. The windowed detector stays fully active for genuine premature poll-spam.

- `loop-guard.forgetTool(sessionId, tool)` drops one tool's windowed entries and, if the current consecutive streak belongs to it, that streak too.
- The completion-reminder bridges call it for `subagent_output`: the channel router when the reminder is enqueued for a live session; the TUI server before publishing the reminder, so the wakeup can't race stale guard state.

**Why per-tool clearing and not a full session reset (`forget`)?** A full reset would also wipe a legitimately-accumulating loop on some other tool. The reminder only makes `subagent_output` newly relevant, so the clear is scoped to that tool.

**Why not make the signature result-aware (running vs completed)?** The guard's `check()` runs before the tool executes, so the result isn't available at signature time. Feeding post-tool state back into a pre-tool guard is more coupling than this bug needs.

## What this does NOT do

- Does not weaken the windowed detector. Premature interleaved `subagent_output` poll-spam still warns and hard-blocks at the same thresholds.
- Does not change `fireLoopAbort` behavior. A pre-completion block still aborts the (genuinely looping) turn; the later reminder clears the residue and wakes a clean fetch.
- Does not touch the broadcast payload or the no-live-session drop paths.

## Review notes

- Load-bearing change: `forgetTool` in `src/agent/loop-guard.ts`. The `signatureBelongsToTool` prefix-match keys on `tool:` / `tool#` — the delimiter rules out a different tool that merely shares a name prefix.
- Invariant to verify: clearing `subagent_output` must NOT clear another tool's accumulated window/consecutive state. Covered in `loop-guard.test.ts`.
- The incident-reproduction tests interleave polls with `bash` on purpose: the windowed detector only evaluates on calls that break the consecutive streak (`count === 1`), matching how the real incident unfolded.