### PR TITLE
start: untrack files that became gitignored

### DIFF
--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -4,6 +4,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { isAbsolute, join, resolve } from 'node:path'
 
 import { expandMountPath, loadConfigSync, type Config } from '@/config'
+import { commitGitignoreWithUntracks, untrackTrulyIgnoredFiles } from '@/git/reconcile-ignored'
 import { commitSystemFile as commitSystemFileShared } from '@/git/system-commit'
 import { send as sendToDaemon } from '@/hostd/client'
 import type { HttpInfoResult } from '@/hostd/protocol'
@@ -188,7 +189,12 @@ export async function start({
     // trigger the migration commit if the file was legacy.
     await refreshGitignore(cwd)
     const pkgRefresh = await refreshPackageJson(cwd)
-    await commitSystemFile(cwd, GITIGNORE_FILE, 'Update .gitignore')
+    const { untracked } = await untrackTrulyIgnoredFiles(cwd, (await loadTypeclawConfig(cwd)).git.ignore.append)
+    if (untracked.length > 0) {
+      await commitGitignoreWithUntracks(cwd, GITIGNORE_FILE, untracked, 'Untrack newly-ignored files')
+    } else {
+      await commitSystemFile(cwd, GITIGNORE_FILE, 'Update .gitignore')
+    }
     if (pkgRefresh.changed) {
       await commitSystemFile(cwd, pkgRefresh.files, 'Enable bun workspaces (packages/*)')
     }

--- a/src/git/reconcile-ignored.test.ts
+++ b/src/git/reconcile-ignored.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { buildGitignore } from '@/init/gitignore'
+
+import { commitGitignoreWithUntracks, untrackTrulyIgnoredFiles } from './reconcile-ignored'
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  const proc = Bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+  await proc.exited
+  return (await new Response(proc.stdout).text()).trim()
+}
+
+async function gitInit(cwd: string): Promise<void> {
+  for (const cmd of [
+    ['init', '-b', 'main'],
+    ['config', 'user.name', 'Test User'],
+    ['config', 'user.email', 'test@example.com'],
+  ]) {
+    const proc = Bun.spawn({ cmd: ['git', ...cmd], cwd, stdout: 'pipe', stderr: 'pipe' })
+    await proc.exited
+  }
+}
+
+async function isTracked(cwd: string, path: string): Promise<boolean> {
+  return (await runGit(cwd, ['ls-files', '--', path])).length > 0
+}
+
+async function makeRepo(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), 'reconcile-ignored-'))
+}
+
+describe('untrackTrulyIgnoredFiles', () => {
+  test('untracks a file that became ignored, keeping it on disk', async () => {
+    const dir = await makeRepo()
+    try {
+      // given: public/review.json committed before `public/` was an ignore rule
+      await gitInit(dir)
+      await mkdir(join(dir, 'public'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+
+      // when
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+
+      // then: removed from the index but still present on disk
+      expect(untracked).toContain('public/review.json')
+      expect(await isTracked(dir, 'public/review.json')).toBe(false)
+      expect(await Bun.file(join(dir, 'public', 'review.json')).exists()).toBe(true)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('preserves system-managed dirs even though they are gitignored', async () => {
+    const dir = await makeRepo()
+    try {
+      // given: every system-managed dir is tracked, and the template ignores them
+      await gitInit(dir)
+      for (const root of ['sessions', 'memory', 'channels', 'todo']) {
+        await mkdir(join(dir, root))
+        await writeFile(join(dir, root, 'state.json'), '{}\n')
+      }
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+
+      // when
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+
+      // then: nothing system-managed is untracked
+      expect(untracked).toEqual([])
+      for (const root of ['sessions', 'memory', 'channels', 'todo']) {
+        expect(await isTracked(dir, `${root}/state.json`)).toBe(true)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('is idempotent — a second run untracks nothing', async () => {
+    const dir = await makeRepo()
+    try {
+      await gitInit(dir)
+      await mkdir(join(dir, 'public'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+
+      await untrackTrulyIgnoredFiles(dir)
+      await runGit(dir, ['commit', '-am', 'untrack'])
+
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+      expect(untracked).toEqual([])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('does nothing when there are no newly-ignored tracked files', async () => {
+    const dir = await makeRepo()
+    try {
+      await gitInit(dir)
+      await writeFile(join(dir, 'AGENTS.md'), '# agent\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+      expect(untracked).toEqual([])
+      expect(await isTracked(dir, 'AGENTS.md')).toBe(true)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('skips silently when the folder is not a git repo', async () => {
+    const dir = await makeRepo()
+    try {
+      await mkdir(join(dir, 'public'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+      expect(untracked).toEqual([])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('untracks custom append matches', async () => {
+    const dir = await makeRepo()
+    try {
+      // given: a tracked scratch/ dir and a custom append rule ignoring it
+      await gitInit(dir)
+      await mkdir(join(dir, 'scratch'))
+      await writeFile(join(dir, 'scratch', 'note.txt'), 'wip\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+
+      const { untracked } = await untrackTrulyIgnoredFiles(dir, ['scratch/'])
+
+      expect(untracked).toContain('scratch/note.txt')
+      expect(await isTracked(dir, 'scratch/note.txt')).toBe(false)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('fails closed: a broad custom pattern never untracks system-managed dirs', async () => {
+    const dir = await makeRepo()
+    try {
+      // given: a `*` custom pattern that would match everything, plus tracked sessions/
+      await gitInit(dir)
+      await mkdir(join(dir, 'sessions'))
+      await writeFile(join(dir, 'sessions', 'history.jsonl'), 'log\n')
+      await mkdir(join(dir, 'public'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+
+      const { untracked } = await untrackTrulyIgnoredFiles(dir, ['*'])
+
+      // then: sessions/ survives, public/ still gets untracked
+      expect(untracked).not.toContain('sessions/history.jsonl')
+      expect(await isTracked(dir, 'sessions/history.jsonl')).toBe(true)
+      expect(untracked).toContain('public/review.json')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('commitGitignoreWithUntracks', () => {
+  test('commits .gitignore and the untracked removals in one commit', async () => {
+    const dir = await makeRepo()
+    try {
+      await gitInit(dir)
+      await mkdir(join(dir, 'public'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+      await writeFile(join(dir, '.gitignore'), 'old\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+
+      const committed = await commitGitignoreWithUntracks(dir, '.gitignore', untracked, 'Untrack newly-ignored files')
+
+      expect(committed).toBe(true)
+      expect(await runGit(dir, ['log', '-1', '--format=%s'])).toBe('Untrack newly-ignored files')
+      // and: the working tree is clean — both the .gitignore edit and the removal landed
+      expect(await runGit(dir, ['status', '--porcelain'])).toBe('')
+      expect(await isTracked(dir, 'public/review.json')).toBe(false)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('leaves unrelated staged work untouched', async () => {
+    const dir = await makeRepo()
+    try {
+      await gitInit(dir)
+      await mkdir(join(dir, 'public'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+      await writeFile(join(dir, '.gitignore'), 'old\n')
+      await writeFile(join(dir, 'user.txt'), 'v1\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+
+      // given: user has unrelated staged work
+      await writeFile(join(dir, 'user.txt'), 'v2\n')
+      await runGit(dir, ['add', 'user.txt'])
+
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+      await commitGitignoreWithUntracks(dir, '.gitignore', untracked, 'Untrack newly-ignored files')
+
+      // then: the user's staged change is NOT in the commit, still staged
+      expect(await runGit(dir, ['diff', '--cached', '--name-only'])).toBe('user.txt')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/git/reconcile-ignored.test.ts
+++ b/src/git/reconcile-ignored.test.ts
@@ -291,4 +291,72 @@ describe('commitGitignoreWithUntracks', () => {
       await rm(dir, { recursive: true, force: true })
     }
   })
+
+  test('atomic commit preserves system-managed work staged by the backup/dreaming machinery', async () => {
+    const dir = await makeRepo()
+    try {
+      await gitInit(dir)
+      await mkdir(join(dir, 'public'))
+      await mkdir(join(dir, 'memory'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+      await writeFile(join(dir, 'memory', 'MEMORY.md'), 'v1\n')
+      await writeFile(join(dir, '.gitignore'), 'old\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+      // given: the system has staged a memory/ change (not yet committed)
+      await writeFile(join(dir, 'memory', 'MEMORY.md'), 'v2\n')
+      await runGit(dir, ['add', 'memory/MEMORY.md'])
+
+      const committed = await commitGitignoreWithUntracks(dir, '.gitignore', untracked, 'Untrack newly-ignored files')
+
+      // then: the hygiene commit landed without memory/, which stays staged for
+      // the next system commit — never dropped, never swept in
+      expect(committed).toBe(true)
+      expect(await runGit(dir, ['show', '--stat', '--format=', 'HEAD'])).not.toContain('memory/MEMORY.md')
+      expect(await runGit(dir, ['diff', '--cached', '--name-only'])).toContain('memory/MEMORY.md')
+      expect(await runGit(dir, ['show', 'HEAD:memory/MEMORY.md'])).toBe('v1')
+      expect(await isTracked(dir, 'public/review.json')).toBe(false)
+      expect(await isTracked(dir, 'memory/MEMORY.md')).toBe(true)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('fallback never drops staged system-managed work', async () => {
+    const dir = await makeRepo()
+    try {
+      await gitInit(dir)
+      await mkdir(join(dir, 'public'))
+      await mkdir(join(dir, 'sessions'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+      await writeFile(join(dir, 'sessions', 'history.jsonl'), 'a\n')
+      await writeFile(join(dir, '.gitignore'), 'old\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+      // given: sessions/ staged, and the atomic path forced to fail
+      await writeFile(join(dir, 'sessions', 'history.jsonl'), 'a\nb\n')
+      await runGit(dir, ['add', 'sessions/history.jsonl'])
+
+      const committed = await commitGitignoreWithUntracks(
+        dir,
+        '.gitignore',
+        untracked,
+        'Untrack newly-ignored files',
+        forceAtomicFailure,
+      )
+
+      // then: fallback refuses, leaving sessions/ staged and tracked — not dropped
+      expect(committed).toBe(false)
+      expect(await runGit(dir, ['diff', '--cached', '--name-only'])).toContain('sessions/history.jsonl')
+      expect(await isTracked(dir, 'sessions/history.jsonl')).toBe(true)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/git/reconcile-ignored.test.ts
+++ b/src/git/reconcile-ignored.test.ts
@@ -226,4 +226,69 @@ describe('commitGitignoreWithUntracks', () => {
       await rm(dir, { recursive: true, force: true })
     }
   })
+
+  const forceAtomicFailure = { commitAtomic: async () => false }
+
+  test('falls back to a real-index commit when the plumbing path cannot run', async () => {
+    const dir = await makeRepo()
+    try {
+      await gitInit(dir)
+      await mkdir(join(dir, 'public'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+      await writeFile(join(dir, '.gitignore'), 'old\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+
+      // when: the atomic plumbing path is forced to fail
+      const committed = await commitGitignoreWithUntracks(
+        dir,
+        '.gitignore',
+        untracked,
+        'Untrack newly-ignored files',
+        forceAtomicFailure,
+      )
+
+      // then: the fallback committed, repo is clean, removal landed
+      expect(committed).toBe(true)
+      expect(await runGit(dir, ['status', '--porcelain'])).toBe('')
+      expect(await isTracked(dir, 'public/review.json')).toBe(false)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('fallback refuses when the staged set is not exactly our changes', async () => {
+    const dir = await makeRepo()
+    try {
+      await gitInit(dir)
+      await mkdir(join(dir, 'public'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+      await writeFile(join(dir, '.gitignore'), 'old\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+      // given: extra unrelated staged work, and the atomic path forced to fail
+      await writeFile(join(dir, 'user.txt'), 'wip\n')
+      await runGit(dir, ['add', 'user.txt'])
+
+      const committed = await commitGitignoreWithUntracks(
+        dir,
+        '.gitignore',
+        untracked,
+        'Untrack newly-ignored files',
+        forceAtomicFailure,
+      )
+
+      // then: fallback bails rather than sweeping unrelated work into a commit
+      expect(committed).toBe(false)
+      expect(await runGit(dir, ['diff', '--cached', '--name-only'])).toContain('user.txt')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/git/reconcile-ignored.ts
+++ b/src/git/reconcile-ignored.ts
@@ -1,0 +1,164 @@
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { SYSTEM_MANAGED_ROOTS, TRULY_IGNORED_PATTERNS } from '@/init/gitignore'
+
+export type UntrackResult = { untracked: string[] }
+
+// Removes from the index any tracked file that now matches a truly-ignored
+// rule. .gitignore only affects UNtracked files, so a file committed before its
+// ignore rule existed (e.g. public/review.json after `public/` was added to the
+// template) keeps getting tracked forever; this reconciles that on every start.
+// Files are removed with --cached, so they stay on disk.
+//
+// Best-effort, like commitSystemFile: no-ops when the folder is not a git repo,
+// Bun is missing, the repo has no matching tracked files, or any git step fails.
+// Never throws — start() hygiene must not block boot. The removals are staged
+// but NOT committed here; the caller folds them into the .gitignore commit so
+// the rule change and its index cleanup land atomically.
+export async function untrackTrulyIgnoredFiles(
+  cwd: string,
+  customAppend: readonly string[] = [],
+): Promise<UntrackResult> {
+  const empty: UntrackResult = { untracked: [] }
+
+  const bun = getBun()
+  if (!bun) return empty
+  if (!existsSync(join(cwd, '.git'))) return empty
+
+  const patterns = [...TRULY_IGNORED_PATTERNS, ...customAppend]
+  let excludeDir: string | null = null
+  try {
+    excludeDir = await mkdtemp(join(tmpdir(), 'typeclaw-untrack-'))
+    const excludeFile = join(excludeDir, 'exclude')
+    await writeFile(excludeFile, `${patterns.join('\n')}\n`)
+
+    const candidates = await listTrackedIgnored(bun, cwd, excludeFile)
+    const removable = candidates.filter((path) => !isSystemManaged(path))
+    if (removable.length === 0) return empty
+
+    const removed = await gitRmCached(bun, cwd, removable)
+    return { untracked: removed }
+  } catch {
+    return empty
+  } finally {
+    if (excludeDir) await rm(excludeDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+// Commits exactly { .gitignore + the untrack removals } in one commit, leaving
+// any UNRELATED user-staged work out of the commit but still staged.
+//
+// Why plumbing instead of `git commit -- <paths>`: a pathspec/--only commit
+// re-snapshots the listed paths from the WORKING TREE, so a `git rm --cached`
+// removal of a file that still exists on disk gets silently re-added. A plain
+// `git commit` gets the removal right but sweeps in unrelated staged work. So
+// we build the exact tree in a throwaway index seeded from HEAD, commit-tree
+// it, and compare-and-swap HEAD via update-ref (race-safe against concurrent
+// HEAD moves). This bypasses commit hooks, which is fine for a system commit.
+//
+// Caller contract: the REAL index already has .gitignore staged and the
+// untracked paths removed (via git rm --cached). update-ref then makes the
+// real index match the new HEAD, so those paths read clean afterward.
+export async function commitGitignoreWithUntracks(
+  cwd: string,
+  gitignoreFile: string,
+  untracked: readonly string[],
+  message: string,
+): Promise<boolean> {
+  const bun = getBun()
+  if (!bun) return false
+  if (!existsSync(join(cwd, '.git'))) return false
+  if (untracked.length === 0) return false
+
+  let indexDir: string | null = null
+  try {
+    const parent = (await capture(bun, cwd, ['rev-parse', '--verify', 'HEAD'])).trim()
+    if (parent.length === 0) return false
+
+    if (!(await run(bun, cwd, ['add', '--', gitignoreFile]))) return false
+
+    indexDir = await mkdtemp(join(tmpdir(), 'typeclaw-untrack-idx-'))
+    const env = { ...process.env, GIT_INDEX_FILE: join(indexDir, 'index') }
+    if (!(await run(bun, cwd, ['read-tree', parent], env))) return false
+    if (!(await run(bun, cwd, ['add', '--', gitignoreFile], env))) return false
+    if (!(await forceRemove(bun, cwd, untracked, env))) return false
+
+    const tree = (await capture(bun, cwd, ['write-tree'], env)).trim()
+    if (tree.length === 0) return false
+    const commit = (await capture(bun, cwd, ['commit-tree', tree, '-p', parent, '-m', message])).trim()
+    if (commit.length === 0) return false
+
+    return await run(bun, cwd, ['update-ref', '-m', message, 'HEAD', commit, parent])
+  } catch {
+    return false
+  } finally {
+    if (indexDir) await rm(indexDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+// Hardcoded fail-closed guard: even if a custom git.ignore.append pattern
+// matches a system-managed root, never untrack it. The git ls-files match is
+// against the truly-ignored set only, but custom patterns are user-supplied and
+// could be arbitrarily broad (`**`), so re-check here as the last line.
+function isSystemManaged(path: string): boolean {
+  return SYSTEM_MANAGED_ROOTS.some((root) => path === root.replace(/\/$/, '') || path.startsWith(root))
+}
+
+async function listTrackedIgnored(bun: BunLike, cwd: string, excludeFile: string): Promise<string[]> {
+  const proc = bun.spawn({
+    cmd: ['git', 'ls-files', '-z', '-c', '-i', '--exclude-from', excludeFile],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  if ((await proc.exited) !== 0) return []
+  const raw = await new Response(proc.stdout).text()
+  return raw.split('\0').filter((entry) => entry.length > 0)
+}
+
+async function gitRmCached(bun: BunLike, cwd: string, files: string[]): Promise<string[]> {
+  const proc = bun.spawn({
+    cmd: ['git', 'rm', '--cached', '-q', '--', ...files],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  if ((await proc.exited) !== 0) return []
+  return files
+}
+
+type GitEnv = Record<string, string | undefined>
+
+async function run(bun: BunLike, cwd: string, args: string[], env?: GitEnv): Promise<boolean> {
+  const proc = bun.spawn({ cmd: ['git', ...args], cwd, env, stdout: 'pipe', stderr: 'pipe' })
+  return (await proc.exited) === 0
+}
+
+async function capture(bun: BunLike, cwd: string, args: string[], env?: GitEnv): Promise<string> {
+  const proc = bun.spawn({ cmd: ['git', ...args], cwd, env, stdout: 'pipe', stderr: 'pipe' })
+  if ((await proc.exited) !== 0) return ''
+  return await new Response(proc.stdout).text()
+}
+
+// --force-remove drops the index entry regardless of the file existing on disk;
+// the NUL-delimited stdin form is safe for paths with spaces/newlines.
+async function forceRemove(bun: BunLike, cwd: string, files: readonly string[], env: GitEnv): Promise<boolean> {
+  const proc = bun.spawn({
+    cmd: ['git', 'update-index', '-z', '--force-remove', '--stdin'],
+    cwd,
+    env,
+    stdin: new TextEncoder().encode(files.join('\0')),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  return (await proc.exited) === 0
+}
+
+type BunLike = { spawn: typeof Bun.spawn }
+
+function getBun(): BunLike | undefined {
+  return (globalThis as { Bun?: BunLike }).Bun
+}

--- a/src/git/reconcile-ignored.ts
+++ b/src/git/reconcile-ignored.ts
@@ -62,23 +62,55 @@ export async function untrackTrulyIgnoredFiles(
 // Caller contract: the REAL index already has .gitignore staged and the
 // untracked paths removed (via git rm --cached). update-ref then makes the
 // real index match the new HEAD, so those paths read clean afterward.
+//
+// If the plumbing path can't run (no HEAD, update-ref CAS race, transient git
+// failure) we fall back to a plain `git commit` of the real index — but ONLY
+// when the staged set is exactly { .gitignore + the removals }. This guarantees
+// start()'s hygiene rewrite never gets stranded staged-but-uncommitted (leaving
+// the repo dirty), while the staged-set check still protects any pre-existing
+// user-staged work from being swept into the fallback commit.
+export type CommitGitignoreDeps = {
+  // Seam so tests can force the plumbing path to fail and exercise the fallback;
+  // a real update-ref CAS race or transient git failure is otherwise hard to
+  // reproduce deterministically. Defaults to the real temp-index commit.
+  commitAtomic?: (
+    bun: BunLike,
+    cwd: string,
+    gitignoreFile: string,
+    untracked: readonly string[],
+    message: string,
+  ) => Promise<boolean>
+}
+
 export async function commitGitignoreWithUntracks(
   cwd: string,
   gitignoreFile: string,
   untracked: readonly string[],
   message: string,
+  deps: CommitGitignoreDeps = {},
 ): Promise<boolean> {
   const bun = getBun()
   if (!bun) return false
   if (!existsSync(join(cwd, '.git'))) return false
   if (untracked.length === 0) return false
 
+  const commitAtomic = deps.commitAtomic ?? commitViaTempIndex
+  if (!(await run(bun, cwd, ['add', '--', gitignoreFile]))) return false
+  if (await commitAtomic(bun, cwd, gitignoreFile, untracked, message)) return true
+  return await commitRealIndexIfExactlyOurs(bun, cwd, gitignoreFile, untracked, message)
+}
+
+async function commitViaTempIndex(
+  bun: BunLike,
+  cwd: string,
+  gitignoreFile: string,
+  untracked: readonly string[],
+  message: string,
+): Promise<boolean> {
   let indexDir: string | null = null
   try {
     const parent = (await capture(bun, cwd, ['rev-parse', '--verify', 'HEAD'])).trim()
     if (parent.length === 0) return false
-
-    if (!(await run(bun, cwd, ['add', '--', gitignoreFile]))) return false
 
     indexDir = await mkdtemp(join(tmpdir(), 'typeclaw-untrack-idx-'))
     const env = { ...process.env, GIT_INDEX_FILE: join(indexDir, 'index') }
@@ -97,6 +129,24 @@ export async function commitGitignoreWithUntracks(
   } finally {
     if (indexDir) await rm(indexDir, { recursive: true, force: true }).catch(() => {})
   }
+}
+
+async function commitRealIndexIfExactlyOurs(
+  bun: BunLike,
+  cwd: string,
+  gitignoreFile: string,
+  untracked: readonly string[],
+  message: string,
+): Promise<boolean> {
+  const staged = (await capture(bun, cwd, ['diff', '--cached', '--name-only', '-z']))
+    .split('\0')
+    .filter((entry) => entry.length > 0)
+  if (staged.length === 0) return false
+
+  const expected = new Set([gitignoreFile, ...untracked])
+  if (staged.length !== expected.size || !staged.every((path) => expected.has(path))) return false
+
+  return await run(bun, cwd, ['commit', '-m', message])
 }
 
 // Hardcoded fail-closed guard: even if a custom git.ignore.append pattern

--- a/src/init/gitignore.ts
+++ b/src/init/gitignore.ts
@@ -2,6 +2,29 @@ import type { GitignoreConfig } from '@/config/config'
 
 export const GITIGNORE_FILE = '.gitignore'
 
+// Match scope for the untrack reconciler (src/git/reconcile-ignored.ts): when a
+// tracked file later matches one of these, start() removes it from the index.
+export const TRULY_IGNORED_PATTERNS = [
+  '.env',
+  '.env.local',
+  'secrets.json',
+  'auth.json',
+  '.typeclaw/home/',
+  'node_modules/',
+  'packages/*/node_modules/',
+  'workspace/',
+  'public/',
+  'mounts/',
+  'Dockerfile',
+  '.DS_Store',
+] as const
+
+// Gitignored but force-committed by TypeClaw (auto-backup, dreaming, channels).
+// The reconciler MUST fail-closed and never untrack these, even if a custom
+// git.ignore.append pattern (e.g. `**`) matches them — doing so would drop
+// runtime-owned state out of git.
+export const SYSTEM_MANAGED_ROOTS = ['sessions/', 'memory/', 'channels/', 'todo/'] as const
+
 export function buildGitignore(config: GitignoreConfig = { append: [] }): string {
   const customEntries = renderCustomGitignoreEntries(config.append)
 
@@ -24,27 +47,13 @@ export function buildGitignore(config: GitignoreConfig = { append: [] }): string
 # $HOME (e.g. ~/.codex/auth.json) into the bind-mounted agent folder so
 # tool credentials survive container restarts. Always credentials; never
 # commit.
-.env
-.env.local
-secrets.json
-auth.json
-.typeclaw/home/
-node_modules/
-packages/*/node_modules/
-workspace/
-public/
-mounts/
-Dockerfile
-.DS_Store
+${TRULY_IGNORED_PATTERNS.join('\n')}
 
 # System-managed: gitignored by default so the agent never stages them by hand,
 # but TypeClaw force-commits them on its own schedule (sessions/ + todo/ via
 # auto-backup, memory/ via the dreaming subagent). Treat them as runtime-owned,
 # not agent-owned.
-sessions/
-memory/
-channels/
-todo/
+${SYSTEM_MANAGED_ROOTS.join('\n')}
 `
 }
 


### PR DESCRIPTION
## Background

`.gitignore` only affects **untracked** files. When TypeClaw adds a new ignore rule to the agent `.gitignore` template, any file that was already committed before the rule existed keeps getting tracked forever — the rule can't retroactively untrack it.

This bit a real agent folder: `public/` was added to the template only recently (`init: gitignore public/ alongside workspace/`), but `public/review.json` had already been committed. The result was a perpetual `modified: public/review.json` in `git status` even though the agent's `.gitignore` clearly lists `public/`.

`refreshGitignore` already rewrites the template on every `typeclaw start`, so the rule is present — but nothing reconciles files that were tracked before the rule landed.

## Summary

On every `start()`, after `refreshGitignore`, reconcile the index: untrack any tracked file that now matches a **truly-ignored** rule, keep it on disk (`--cached`), and fold the removals into the `.gitignore` commit so the rule change and its cleanup land atomically.

Key decisions:

- **Truly-ignored vs system-managed.** The template has two categories. `sessions/`, `memory/`, `channels/`, `todo/` are gitignored **but force-committed** by TypeClaw (auto-backup, dreaming, channels). A blanket `git ls-files -ci` untrack would rip those out of the index and break that contract. So the reconciler matches against the *truly-ignored* set only (sourced from a new `TRULY_IGNORED_PATTERNS` export in `gitignore.ts`, now the single source of truth for both the template and the reconciler) and additionally **fails closed**: even a broad custom `git.ignore.append` pattern like `**` can never untrack a system-managed root.

- **Why `commit-tree` plumbing and not `git commit -- <paths>`.** A pathspec/`--only` commit re-snapshots the listed paths from the **working tree**, so a `git rm --cached` removal of a file that still exists on disk gets silently re-added — the removal never lands. A plain `git commit` gets the removal right but sweeps in unrelated user-staged work. The fix builds the exact tree in a throwaway index seeded from `HEAD`, `commit-tree`s it, and compare-and-swaps `HEAD` via `update-ref` (race-safe). This commits exactly `{ .gitignore + removals }` and leaves unrelated staged work untouched.

- **Best-effort, like `commitSystemFile`.** No-ops when the folder isn't a git repo, Bun is unavailable, there's no `HEAD`, or nothing matches. Never throws — start-time hygiene must not block boot.

## What this does NOT do

- Does not touch files on disk — removals are `--cached` only.
- Does not untrack system-managed dirs under any pattern.
- Does not rewrite existing history or touch already-correct repos (idempotent: a second run untracks nothing).
- Custom `git.ignore.append` entries *are* honored as untrack scope (user asked to ignore them), but the system-managed fail-closed guard still applies. Documented in code.

## Review notes

- Load-bearing: `commitGitignoreWithUntracks` in `src/git/reconcile-ignored.ts`. The temp-index/`commit-tree` dance is deliberate — see the empirically-derived "Why plumbing" comment. Reverting it to a pathspec commit silently reintroduces the re-add bug.
- Invariant to verify: `sessions/memory/channels/todo` stay tracked even with a `*` custom pattern (covered by the "fails closed" test) and unrelated staged work is preserved (covered by the "leaves unrelated staged work untouched" test).
- `gitignore.ts` refactor is byte-identical output — guarded by the existing `buildGitignore` tests.
