### PR TITLE
skill(github): write review payload to workspace/, not /tmp

### DIFF
--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -145,7 +145,7 @@ The `reviewer` subagent is the analyst; you are the integration layer between it
 
    Then submit the review. **Write the JSON payload to a file with the `write` tool, then run a single bare `gh api --input <file>`** — two steps:
 
-   First write `/tmp/review.json` (via the `write` tool, not bash):
+   First write the payload to `workspace/review-<owner>-<repo>-<N>.json` (via the `write` tool, not bash). Use `workspace/`, **not** `/tmp` — the `write` tool's `nonWorkspaceWrite` guard blocks paths outside the agent's free-write zone, so a `/tmp` write is rejected. The PR-scoped filename (`<owner>-<repo>-<N>`) avoids collisions when you review several PRs at once. `workspace/` is gitignored, so the throwaway payload never lands in a commit:
 
    ```json
    {
@@ -166,7 +166,7 @@ The `reviewer` subagent is the analyst; you are the integration layer between it
    Then post it:
 
    ```sh
-   gh api -X POST /repos/owner/repo/pulls/<N>/reviews --input /tmp/review.json
+   gh api -X POST /repos/owner/repo/pulls/<N>/reviews --input workspace/review-<owner>-<repo>-<N>.json
    ```
 
    **A repo-targeting `gh` command must be a single bare `gh` invocation — no pipes, `;`, `&&`, heredocs, or command substitution.** The `github-cli-auth` plugin injects the GitHub App token into the command's environment, so any sibling/upstream stage in a pipeline would inherit a live token; the runtime blocks those shapes. That is why the old `cat <<'JSON' | gh api --input -` heredoc-pipe no longer works: write the JSON to a file and feed it with `--input <file>` instead. Do **not** use `-f body=...` or `-F 'comments[][body]=...'`: those go through shell argument parsing, so backticks trigger command substitution. The file passes the JSON through untouched — backticks, newlines, and `${...}` all survive verbatim. The same file-then-`--input` pattern applies to any `gh api` POST whose body contains backticks, embedded newlines, or shell metacharacters.


### PR DESCRIPTION
## Background

The GitHub PR-review skill instructs the agent to stage the review JSON to a file, then POST it with `gh api --input <file>`. It told the model to write `/tmp/review.json` **via the `write` tool**. But the `nonWorkspaceWrite` guard (`src/bundled-plugins/guard/policies/non-workspace-write.ts`) blocks `write`/`edit` to any path outside the agent's free-write zone unless the model explicitly acknowledges the guard — and `/tmp` is not in the allowlist. The skill never told the model to acknowledge it.

Result: the `write` silently fails, then `gh api --input /tmp/review.json` reads a missing file, and the formal review is never posted. This was one of the mechanical reasons a reviewer could run to completion yet leave the PR un-reviewed.

## Summary

Point the staging path at `workspace/review-<owner>-<repo>-<N>.json`:
- **Guard**: `workspace/` is the documented free-write zone; the guard passes it without acknowledgement (`isInside(workspace, target)`), so no skill churn around `acknowledgeGuards`.
- **Git safety**: `workspace/` is in the `.gitignore` "truly ignored" block and is never force-committed by the backup plugin (which only force-adds `sessions/` + `todo/`), so the throwaway payload never enters a commit.
- **Collisions**: the PR-scoped filename (`<owner>-<repo>-<N>`) avoids two concurrent reviews clobbering a shared `review.json`.

Why not `/tmp` with a guard-ack: `/tmp` via the `write` tool needs `acknowledgeGuards.nonWorkspaceWrite: true` every time and is semantically outside the project; `workspace/` is the intended free-write zone and needs no ceremony. (The `--input <file>` form itself is unchanged and already complies with the single-bare-`gh` command guard.)

## What this does NOT do

- Does **not** change the `gh` command form, the JSON schema, the verify-landed step, or any other part of the review flow — only the file path.
- Does **not** address the other reason reviews go unposted (a completed background reviewer's completion reminder being dropped when the channel session rolls over). That is a separate, larger fix.
- Does **not** add a new scaffolded temp dir; the repo has none outside `workspace/`, and `workspace/` is the correct home.

## Review notes

- Skill-only (markdown) change, two lines: the `write`-step path and the `gh api --input` path now both use `workspace/review-<owner>-<repo>-<N>.json`.
- Verified `workspace/` is gitignored ("truly ignored" block) and excluded from the backup plugin's staging, so transient payloads won't pollute history.
- The lone remaining `/tmp` mention in the skill is the new explanatory sentence stating why `/tmp` is rejected — intentional.