### PR TITLE
channels: reroute a stranded subagent completion to the rolled-over session

### DIFF
--- a/src/agent/subagent-completion-reminder.test.ts
+++ b/src/agent/subagent-completion-reminder.test.ts
@@ -166,6 +166,33 @@ describe('parseSubagentCompletedPayload', () => {
     expect(parsed?.error).toBe('provider rate limit')
   })
 
+  test('preserves a valid channelKey (with null thread)', () => {
+    const parsed = parseSubagentCompletedPayload({
+      kind: 'subagent.completed',
+      taskId: 'bg_rev',
+      subagent: 'reviewer',
+      parentSessionId: 'ses_abc',
+      ok: true,
+      durationMs: 1,
+      channelKey: { adapter: 'github', workspace: 'acme', chat: 'acme/repo#1', thread: null },
+    })
+    expect(parsed!.channelKey).toEqual({ adapter: 'github', workspace: 'acme', chat: 'acme/repo#1', thread: null })
+  })
+
+  test('drops a malformed channelKey but keeps the rest of the payload', () => {
+    const parsed = parseSubagentCompletedPayload({
+      kind: 'subagent.completed',
+      taskId: 'bg_rev',
+      subagent: 'reviewer',
+      parentSessionId: 'ses_abc',
+      ok: true,
+      durationMs: 1,
+      channelKey: { adapter: 'github', workspace: 'acme' },
+    })
+    expect(parsed).not.toBeNull()
+    expect(parsed!.channelKey).toBeUndefined()
+  })
+
   test('non-completion kind returns null', () => {
     expect(parseSubagentCompletedPayload({ kind: 'tunnel-url-changed', parentSessionId: 'ses_abc' })).toBeNull()
     expect(parseSubagentCompletedPayload({ kind: 'noise' })).toBeNull()

--- a/src/agent/subagent-completion-reminder.ts
+++ b/src/agent/subagent-completion-reminder.ts
@@ -59,6 +59,13 @@ export function formatReminderDuration(ms: number): string {
   return `${min}m${sec}s`
 }
 
+export type SubagentCompletedChannelKey = {
+  adapter: string
+  workspace: string
+  chat: string
+  thread: string | null
+}
+
 export type SubagentCompletedPayload = {
   taskId: string
   subagent: string
@@ -66,6 +73,11 @@ export type SubagentCompletedPayload = {
   ok: boolean
   durationMs: number
   error?: string
+  // Present when the parent was a channel session. Lets the router fall back
+  // to the live successor session for the same channel key when the parent
+  // rolled over (SESSION_FRESHNESS_TTL_MS) or was idle-evicted while the
+  // subagent ran — otherwise the completion is silently dropped.
+  channelKey?: SubagentCompletedChannelKey
 }
 
 // Type guard for the `subagent.completed` broadcast payload. Subscribers
@@ -82,9 +94,11 @@ export function parseSubagentCompletedPayload(payload: unknown): SubagentComplet
     ok?: unknown
     durationMs?: unknown
     error?: unknown
+    channelKey?: unknown
   }
   if (p.kind !== 'subagent.completed') return null
   if (typeof p.parentSessionId !== 'string') return null
+  const channelKey = parseChannelKey(p.channelKey)
   return {
     taskId: typeof p.taskId === 'string' ? p.taskId : '<unknown>',
     subagent: typeof p.subagent === 'string' ? p.subagent : 'subagent',
@@ -92,5 +106,14 @@ export function parseSubagentCompletedPayload(payload: unknown): SubagentComplet
     ok: p.ok === true,
     durationMs: typeof p.durationMs === 'number' ? p.durationMs : 0,
     ...(typeof p.error === 'string' ? { error: p.error } : {}),
+    ...(channelKey !== null ? { channelKey } : {}),
   }
+}
+
+function parseChannelKey(value: unknown): SubagentCompletedChannelKey | null {
+  if (value === null || typeof value !== 'object') return null
+  const k = value as { adapter?: unknown; workspace?: unknown; chat?: unknown; thread?: unknown }
+  if (typeof k.adapter !== 'string' || typeof k.workspace !== 'string' || typeof k.chat !== 'string') return null
+  if (k.thread !== null && typeof k.thread !== 'string') return null
+  return { adapter: k.adapter, workspace: k.workspace, chat: k.chat, thread: k.thread }
 }

--- a/src/agent/tools/spawn-subagent.test.ts
+++ b/src/agent/tools/spawn-subagent.test.ts
@@ -292,6 +292,83 @@ describe('createSpawnSubagentTool — background mode', () => {
     expect(completion?.subagent).toBe('explorer')
     expect(completion?.ok).toBe(true)
   })
+
+  test('channel-origin background completion carries the channel key for rollover-safe routing', async () => {
+    const stream = createStream()
+    const events: unknown[] = []
+    stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => {
+      events.push(msg.payload)
+    })
+    const tool = createSpawnSubagentTool({
+      registry: makeRegistry(),
+      liveRegistry: new LiveSubagentRegistry(),
+      createSessionForSubagent: async () => stubSession(),
+      agentDir: '/agent',
+      parentSessionId: 'ses_parent',
+      getOrigin: () => ({
+        kind: 'channel',
+        adapter: 'slack-bot',
+        workspace: 'T1',
+        chat: 'C1',
+        thread: 't1',
+      }),
+      stream,
+      generateTaskId: () => 'bg_ch',
+      now: () => 1_000,
+    })
+
+    await tool.execute(
+      'call_1',
+      { subagent_type: 'explorer', prompt: 'q', run_in_background: true },
+      undefined,
+      undefined,
+      ctx,
+    )
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+
+    const completion = events.find((e) => (e as { kind?: string }).kind === 'subagent.completed') as
+      | Record<string, unknown>
+      | undefined
+    expect(completion?.channelKey).toEqual({ adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: 't1' })
+  })
+
+  test('non-channel (tui) origin omits the channel key', async () => {
+    const stream = createStream()
+    const events: unknown[] = []
+    stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => {
+      events.push(msg.payload)
+    })
+    const tool = createSpawnSubagentTool({
+      registry: makeRegistry(),
+      liveRegistry: new LiveSubagentRegistry(),
+      createSessionForSubagent: async () => stubSession(),
+      agentDir: '/agent',
+      parentSessionId: 'ses_parent',
+      getOrigin: () => ({ kind: 'tui', sessionId: 'ses_parent' }),
+      stream,
+      generateTaskId: () => 'bg_tui',
+      now: () => 1_000,
+    })
+
+    await tool.execute(
+      'call_1',
+      { subagent_type: 'explorer', prompt: 'q', run_in_background: true },
+      undefined,
+      undefined,
+      ctx,
+    )
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+
+    const completion = events.find((e) => (e as { kind?: string }).kind === 'subagent.completed') as
+      | Record<string, unknown>
+      | undefined
+    expect(completion).toBeDefined()
+    expect(completion?.channelKey).toBeUndefined()
+  })
 })
 
 describe('createSpawnSubagentTool — permissions gating', () => {

--- a/src/agent/tools/spawn-subagent.ts
+++ b/src/agent/tools/spawn-subagent.ts
@@ -136,6 +136,11 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
       }
       liveRegistry.register(live)
 
+      const channelKey =
+        origin?.kind === 'channel'
+          ? { adapter: origin.adapter, workspace: origin.workspace, chat: origin.chat, thread: origin.thread }
+          : undefined
+
       void completion.then((c) => {
         const durationMs = now() - startedAt
         liveRegistry.recordCompletion(taskId, completionToFinalShape(c, durationMs))
@@ -150,6 +155,7 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
               ok: c.ok,
               durationMs,
               ...(c.ok ? {} : { error: c.error }),
+              ...(channelKey !== undefined ? { channelKey } : {}),
             },
           })
         }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -6460,6 +6460,78 @@ describe('ChannelRouter injectSubagentCompletionReminder', () => {
     expect(sessions[0]!.prompts.length).toBe(promptsBefore)
   })
 
+  test('channel-key fallback wakes the rolled-over session when the original parentSessionId is gone', async () => {
+    // given a session that rolls over while a background subagent runs:
+    // m1 opens ses_fake_1; after the freshness TTL, m2 opens ses_fake_2 for the
+    // same channel key. The completion broadcast still carries ses_fake_1.
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value = 1000 + SESSION_FRESHNESS_TTL_MS + 1
+    await router.route(inbound({ externalMessageId: 'm2', text: 'still there?' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions).toHaveLength(2)
+    const promptsBefore = sessions[1]!.prompts.length
+
+    // when the subagent completes carrying the STALE sessionId plus the channel key
+    const result = router.injectSubagentCompletionReminder({
+      parentSessionId: 'ses_fake_1',
+      subagent: 'reviewer',
+      taskId: 'bg_rev',
+      ok: true,
+      durationMs: 360_000,
+      channelKey: KEY,
+    })
+
+    // then it is delivered to the live successor session, not dropped
+    expect(result.kind).toBe('delivered')
+    await waitFor(() => sessions[1]!.prompts.length > promptsBefore)
+    const reminderText = sessions[1]!.prompts[sessions[1]!.prompts.length - 1] ?? ''
+    expect(reminderText).toContain('<system-reminder>')
+    expect(reminderText).toContain('bg_rev')
+    expect(reminderText).toContain('subagent_output')
+  })
+
+  test('exact parentSessionId match is preferred over the channel-key fallback', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+    const promptsBefore = sessions[0]!.prompts.length
+
+    const result = router.injectSubagentCompletionReminder({
+      parentSessionId: 'ses_fake_1',
+      subagent: 'reviewer',
+      taskId: 'bg_exact',
+      ok: true,
+      durationMs: 5_000,
+      channelKey: KEY,
+    })
+
+    expect(result.kind).toBe('delivered')
+    await waitFor(() => sessions[0]!.prompts.length > promptsBefore)
+    expect(sessions[0]!.prompts[sessions[0]!.prompts.length - 1] ?? '').toContain('bg_exact')
+  })
+
+  test('no channelKey and no matching sessionId still returns no-live-session', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    const result = router.injectSubagentCompletionReminder({
+      parentSessionId: 'someone-else',
+      subagent: 'reviewer',
+      taskId: 'bg_nokey',
+      ok: true,
+      durationMs: 100,
+    })
+
+    expect(result).toEqual({ kind: 'no-live-session' })
+  })
+
   test('failed subagent reminder reaches the channel session with FAILED marker and error string', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -671,6 +671,7 @@ export type ChannelRouter = {
     ok: boolean
     durationMs: number
     error?: string
+    channelKey?: { adapter: string; workspace: string; chat: string; thread: string | null }
   }) => { kind: 'delivered'; keyId: string } | { kind: 'no-live-session' }
   // Record that the agent invoked `skip_response` during the current turn
   // for the channel session identified by `parentSessionId`. The reason is
@@ -3221,6 +3222,47 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return { kind: 'unknown-command', name: lowered }
   }
 
+  const deliverCompletionReminder = (
+    live: LiveSession,
+    args: {
+      parentSessionId: string
+      subagent: string
+      taskId: string
+      ok: boolean
+      durationMs: number
+      error?: string
+    },
+  ): { kind: 'delivered'; keyId: string } => {
+    const text = renderSubagentCompletionReminder({
+      subagent: args.subagent,
+      taskId: args.taskId,
+      ok: args.ok,
+      durationMs: args.durationMs,
+      ...(args.error !== undefined ? { error: args.error } : {}),
+      channel: true,
+    })
+    live.pendingSystemReminders.push(text)
+    // The reminder tells the agent to fetch this result now; clear the
+    // subagent_output window so an earlier premature-polling streak can't
+    // hard-block that legitimate fetch.
+    forgetSharedLoopGuardTool(live.sessionId, SUBAGENT_OUTPUT_TOOL_NAME)
+    logger.info(`[channels] ${live.keyId}: subagent-completion reminder queued task=${args.taskId} ok=${args.ok}`)
+    // Wake the drain loop. If a turn is already in flight, the wakeup is
+    // a no-op because drain() will pick up the reminder on its next
+    // iteration (it now gates on promptQueue OR pendingSystemReminders).
+    // If the session is idle, fire drain() immediately rather than going
+    // through the debounce path — the reminder is not a user inbound,
+    // so the "coalesce nearby inbounds" rationale for debouncing does
+    // not apply. Mirrors the TUI path's `idle ? 'interrupt' : 'queue'`
+    // semantics: the channel router doesn't have a `delivery: interrupt`
+    // mechanism (no in-flight abort during a turn), but firing drain()
+    // immediately is the equivalent for an idle session.
+    if (!live.draining) {
+      void drain(live)
+    }
+    return { kind: 'delivered', keyId: live.keyId }
+  }
+
   const injectSubagentCompletionReminder = (args: {
     parentSessionId: string
     subagent: string
@@ -3228,38 +3270,28 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     ok: boolean
     durationMs: number
     error?: string
+    channelKey?: { adapter: string; workspace: string; chat: string; thread: string | null }
   }): { kind: 'delivered'; keyId: string } | { kind: 'no-live-session' } => {
     for (const live of liveSessions.values()) {
       if (live.destroyed) continue
       if (live.sessionId !== args.parentSessionId) continue
-      const text = renderSubagentCompletionReminder({
-        subagent: args.subagent,
-        taskId: args.taskId,
-        ok: args.ok,
-        durationMs: args.durationMs,
-        ...(args.error !== undefined ? { error: args.error } : {}),
-        channel: true,
-      })
-      live.pendingSystemReminders.push(text)
-      // The reminder tells the agent to fetch this result now; clear the
-      // subagent_output window so an earlier premature-polling streak can't
-      // hard-block that legitimate fetch.
-      forgetSharedLoopGuardTool(live.sessionId, SUBAGENT_OUTPUT_TOOL_NAME)
-      logger.info(`[channels] ${live.keyId}: subagent-completion reminder queued task=${args.taskId} ok=${args.ok}`)
-      // Wake the drain loop. If a turn is already in flight, the wakeup is
-      // a no-op because drain() will pick up the reminder on its next
-      // iteration (it now gates on promptQueue OR pendingSystemReminders).
-      // If the session is idle, fire drain() immediately rather than going
-      // through the debounce path — the reminder is not a user inbound,
-      // so the "coalesce nearby inbounds" rationale for debouncing does
-      // not apply. Mirrors the TUI path's `idle ? 'interrupt' : 'queue'`
-      // semantics: the channel router doesn't have a `delivery: interrupt`
-      // mechanism (no in-flight abort during a turn), but firing drain()
-      // immediately is the equivalent for an idle session.
-      if (!live.draining) {
-        void drain(live)
+      return deliverCompletionReminder(live, args)
+    }
+    // The exact parent session is gone. If the subagent was spawned from a
+    // channel session, the conversation may have rolled over
+    // (SESSION_FRESHNESS_TTL_MS) or been idle-evicted onto a fresh sessionId
+    // for the same channel key while the subagent ran. Fall back to the live
+    // successor for that key so a finished review/result still surfaces
+    // instead of being silently dropped.
+    if (args.channelKey !== undefined) {
+      const targetKeyId = channelKeyId(args.channelKey)
+      const successor = liveSessions.get(targetKeyId)
+      if (successor !== undefined && !successor.destroyed) {
+        logger.info(
+          `[channels] ${targetKeyId}: subagent-completion reminder rerouted to live successor (parent ${args.parentSessionId} gone) task=${args.taskId}`,
+        )
+        return deliverCompletionReminder(successor, args)
       }
-      return { kind: 'delivered', keyId: live.keyId }
     }
     return { kind: 'no-live-session' }
   }

--- a/src/channels/subagent-completion-bridge.test.ts
+++ b/src/channels/subagent-completion-bridge.test.ts
@@ -93,7 +93,7 @@ describe('createSubagentCompletionBridge', () => {
     expect(calls).toHaveLength(0)
   })
 
-  test('no-live-session outcome logs an info line (debuggable drop), no throw', () => {
+  test('no-live-session outcome logs a warn line with the channel key (debuggable drop), no throw', () => {
     const stream = createStream()
     const { router, setOutcome } = fakeRouter()
     setOutcome({ kind: 'no-live-session' })
@@ -116,11 +116,15 @@ describe('createSubagentCompletionBridge', () => {
         parentSessionId: 'ses_gone',
         ok: true,
         durationMs: 100,
+        channelKey: { adapter: 'slack-bot', workspace: 'T1', chat: 'C1', thread: 't1' },
       },
     })
 
-    expect(logs.some((l) => l.includes('subagent-completion reminder dropped'))).toBe(true)
-    expect(logs.some((l) => l.includes('ses_gone'))).toBe(true)
+    const dropLine = logs.find((l) => l.includes('subagent-completion reminder dropped'))
+    expect(dropLine).toBeDefined()
+    expect(dropLine).toStartWith('warn:')
+    expect(dropLine).toContain('ses_gone')
+    expect(dropLine).toContain('channelKey=slack-bot:T1:C1:t1')
   })
 
   test('stop() unsubscribes — subsequent broadcasts are not forwarded', () => {

--- a/src/channels/subagent-completion-bridge.ts
+++ b/src/channels/subagent-completion-bridge.ts
@@ -47,27 +47,23 @@ const consoleLogger: SubagentCompletionBridgeLogger = {
 // `LiveSession`, so the lookup is O(N) over live sessions with N small
 // (one per active conversation).
 //
-// On `no-live-session`, we silently drop. Three observable paths reach
-// this branch in production:
+// On `no-live-session`, we drop the reminder. When the parent was a
+// channel session, the broadcast now carries the channel-key coordinate
+// `{ adapter, workspace, chat, thread }`, and the router first tries to
+// reroute to the live successor session for that key — covering the two
+// common drop paths where the exact sessionId is gone but the
+// conversation lives on:
 //
 //   - The parent session was GC'd by the idle-eviction tick
 //     (SESSION_IDLE_MS) while the subagent was running.
 //   - The parent session rolled over (SESSION_FRESHNESS_TTL_MS) when a
-//     new inbound arrived during a long-running subagent — the channel
-//     conversation continues on the new sessionId, but the broadcast
-//     still carries the old one.
-//   - The parent was a TUI session (the TUI bridge in
-//     src/server/index.ts handles it).
+//     new inbound arrived during a long-running subagent.
 //
-// The right fix for the first two paths is for the broadcast to carry
-// the channel-key coordinate `{ adapter, workspace, chat, thread }` so
-// the bridge can fall back to "any live session for the same channel
-// key" when the exact sessionId no longer matches. That requires
-// extending the broadcast payload (consumed by TUI and channel paths)
-// and gating spawn_subagent to capture the origin coordinates — both
-// non-trivial. Deferred until we see this drop pattern in production
-// logs; the info log line below makes the case diagnosable from logs
-// alone.
+// A reminder still reaching this branch means there is no live session
+// for the key at all (the whole conversation went idle), or the parent
+// was a TUI session (handled by the TUI bridge in src/server/index.ts).
+// Logged at warn with the channel key so an undelivered completion is
+// diagnosable from logs alone.
 export function createSubagentCompletionBridge(options: SubagentCompletionBridgeOptions): SubagentCompletionBridge {
   const logger = options.logger ?? consoleLogger
   const unsubscribe = options.stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => {
@@ -75,8 +71,12 @@ export function createSubagentCompletionBridge(options: SubagentCompletionBridge
     if (parsed === null) return
     const result = options.router.injectSubagentCompletionReminder(parsed)
     if (result.kind === 'no-live-session') {
-      logger.info(
-        `[channels] subagent-completion reminder dropped: no live session for parentSessionId=${parsed.parentSessionId} task=${parsed.taskId}`,
+      const keyInfo =
+        parsed.channelKey !== undefined
+          ? ` channelKey=${parsed.channelKey.adapter}:${parsed.channelKey.workspace}:${parsed.channelKey.chat}:${parsed.channelKey.thread ?? ''}`
+          : ''
+      logger.warn(
+        `[channels] subagent-completion reminder dropped: no live session for parentSessionId=${parsed.parentSessionId} task=${parsed.taskId}${keyInfo}`,
       )
     }
   })

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -382,6 +382,6 @@ export type ReviewThreadResolveResult =
 // support review threads never register one; the router answers `unsupported`.
 export type ReviewThreadResolver = (req: ReviewThreadResolveRequest) => Promise<ReviewThreadResolveResult>
 
-export function channelKeyId(key: ChannelKey): string {
+export function channelKeyId(key: { adapter: string; workspace: string; chat: string; thread: string | null }): string {
   return `${key.adapter}:${key.workspace}:${key.chat}:${key.thread ?? ''}`
 }


### PR DESCRIPTION
## Background

A GitHub-reviewing agent spawned a `reviewer` subagent in the background from a channel session, the reviewer finished, but the review was never posted to the PR. The mechanical cause: a background subagent's completion reminder is addressed **only** to the exact `parentSessionId`.

Channel sessions are not stable for the 3–7 minutes a deep-model reviewer runs. Any new inbound during that window rolls the conversation onto a fresh `sessionId` (`SESSION_FRESHNESS_TTL_MS`, 5 min), and a quiet conversation is idle-evicted (`SESSION_IDLE_MS`, 30 min). When the subagent finally completes, its broadcast still carries the **old** `parentSessionId`; `injectSubagentCompletionReminder` scans live sessions, finds no match, returns `no-live-session`, and the reminder is **silently dropped**. The parent never wakes, never calls `subagent_output`, never posts. In the incident that motivated this, a busy thread produced far more completion reminders than visible spawns, with several landing on dead session ids — and zero reviews posted.

The drop was already documented as a known gap in `subagent-completion-bridge.ts` ("deferred until we see this drop pattern in production logs"). We saw it.

## Summary

Route the completion by **channel identity**, not only by the volatile session id:

- `spawn_subagent` stamps the channel key `{adapter, workspace, chat, thread}` onto the `subagent.completed` broadcast when the parent origin is a channel (`getOrigin().kind === 'channel'`). TUI/cron spawns omit it — unchanged.
- `injectSubagentCompletionReminder` still **prefers** an exact `parentSessionId` match (no behavior change for the common case). On a miss, if the broadcast carries a channel key, it reroutes to the live **successor** session for that same key (the rolled-over/new session) via the existing per-key live map. The reminder render + loop-guard clear + drain wakeup are shared with the primary path (extracted into one helper).
- A reminder that still finds nothing now means the whole conversation went idle (or the parent was a TUI session handled elsewhere). That residual drop is logged at **warn** with the channel key, so an undelivered completion is diagnosable from logs alone instead of an info-level whisper.

Split into two commits: a no-behavior widening of `channelKeyId` to accept a structural key (so a loosely-typed key parsed from an untrusted broadcast can be formatted without a cast), then the reroute itself.

## What this does NOT do

- Does **not** persist completions to disk. If there is genuinely **no** live session for the channel key at completion time (the entire conversation idled out), the reminder is still dropped — now loudly (warn + key). A durable pending-completion queue is a larger follow-up; this fixes the common rollover/eviction case where the conversation is still live on a new session.
- Does **not** touch the TUI completion path (`src/server/index.ts`), which already routes by its own session id.
- Does **not** change the reviewer, the posting mechanics, or the `subagent_output` contract.

## Review notes

- Load-bearing change is the fallback branch in `injectSubagentCompletionReminder` (router.ts): exact-match first, channel-key successor second. The `deliverCompletionReminder` helper is a pure extraction so both paths are identical (reminder text, `forgetSharedLoopGuardTool`, drain).
- Tests: router rollover-reroute (m1→ses_fake_1, advance past `SESSION_FRESHNESS_TTL_MS`, m2→ses_fake_2, completion carrying the stale id + key wakes ses_fake_2); exact-match-preferred; no-channelKey still drops. Producer tests assert the key is stamped for a channel origin and omitted for tui. Parser tests round-trip the key and drop a malformed one. Bridge test asserts the drop is now warn-level and includes the channel key.
- `channelKeyId` widening is safe: it only string-concatenates the four fields; `ChannelKey` is assignable to the widened structural param, so all existing callers are intact.