### PR TITLE
agent: let operator and reviewer subagents spawn their own subagents

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -328,11 +328,30 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     }
   }
 
+  // Plugin subagents (operator/reviewer) see ONLY their declared builtins plus
+  // the orchestration tools — never the full main-session tool surface. The
+  // orchestration tools self-omit unless `liveSubagentRegistry`/
+  // `subagentRegistry`/`createSessionForSubagent` are wired (see
+  // buildSubagentOrchestrationTools); `spawn_subagent` enforces MAX_SUBAGENT_DEPTH
+  // at execute time so a depth-capped subagent's spawn fails closed even though
+  // the tool is present.
   const customSystemTools =
     options.customTools !== undefined
       ? options.customTools
       : options.pluginSubagent
-        ? resolvedSubagentBuiltins.toolDefinitions
+        ? [
+            ...resolvedSubagentBuiltins.toolDefinitions,
+            ...buildSubagentOrchestrationTools({
+              liveRegistry: options.liveSubagentRegistry,
+              registry: options.subagentRegistry,
+              createSessionForSubagent: options.createSessionForSubagent,
+              agentDir: options.plugins?.agentDir,
+              parentSessionId: sessionManager.getSessionId(),
+              getOrigin,
+              permissions: options.permissions,
+              stream: options.stream,
+            }),
+          ]
         : [
             webSearchTool,
             webFetchTool,
@@ -702,11 +721,13 @@ export function buildSubagentOrchestrationTools(opts: {
     createSubagentOutputTool({
       liveRegistry: opts.liveRegistry,
       getOrigin: opts.getOrigin,
+      callerSessionId: opts.parentSessionId,
       ...(opts.permissions ? { permissions: opts.permissions } : {}),
     }),
     createSubagentCancelTool({
       liveRegistry: opts.liveRegistry,
       getOrigin: opts.getOrigin,
+      callerSessionId: opts.parentSessionId,
       ...(opts.permissions ? { permissions: opts.permissions } : {}),
     }),
   ]

--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -1,6 +1,65 @@
 import { describe, expect, test } from 'bun:test'
 
-import { renderSessionOrigin, type ChannelParticipant } from './session-origin'
+import {
+  MAX_SUBAGENT_DEPTH,
+  renderSessionOrigin,
+  subagentDepth,
+  type ChannelParticipant,
+  type SessionOrigin,
+} from './session-origin'
+
+describe('subagentDepth', () => {
+  test('non-subagent origins are depth 0', () => {
+    expect(subagentDepth(undefined)).toBe(0)
+    expect(subagentDepth({ kind: 'tui', sessionId: 'ses_root' })).toBe(0)
+    expect(subagentDepth({ kind: 'channel', adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null })).toBe(0)
+  })
+
+  test('a subagent spawned by a root session is depth 1', () => {
+    const origin: SessionOrigin = {
+      kind: 'subagent',
+      subagent: 'operator',
+      parentSessionId: 'ses_root',
+      spawnedByOrigin: { kind: 'tui', sessionId: 'ses_root' },
+    }
+    expect(subagentDepth(origin)).toBe(1)
+  })
+
+  test('a subagent spawned by another subagent is depth 2', () => {
+    const origin: SessionOrigin = {
+      kind: 'subagent',
+      subagent: 'operator',
+      parentSessionId: 'ses_child',
+      spawnedByOrigin: {
+        kind: 'subagent',
+        subagent: 'reviewer',
+        parentSessionId: 'ses_root',
+        spawnedByOrigin: { kind: 'tui', sessionId: 'ses_root' },
+      },
+    }
+    expect(subagentDepth(origin)).toBe(MAX_SUBAGENT_DEPTH)
+  })
+
+  test('a truncated chain (serialized origin dropped spawnedByOrigin) fails closed at the cap', () => {
+    // A subagent origin with no ancestry could be a root-spawned child OR a
+    // truncated grandchild; since we cannot tell, fail closed at the cap so it
+    // cannot earn an extra spawn it may not be entitled to.
+    const origin: SessionOrigin = {
+      kind: 'subagent',
+      subagent: 'operator',
+      parentSessionId: 'ses_child',
+    }
+    expect(subagentDepth(origin)).toBe(MAX_SUBAGENT_DEPTH)
+  })
+
+  test('a cyclic ancestry is capped instead of looping forever', () => {
+    const origin = { kind: 'subagent', subagent: 'loop', parentSessionId: 'ses_x' } as SessionOrigin & {
+      spawnedByOrigin?: SessionOrigin
+    }
+    origin.spawnedByOrigin = origin
+    expect(subagentDepth(origin)).toBeLessThanOrEqual(MAX_SUBAGENT_DEPTH + 2)
+  })
+})
 
 describe('renderSessionOrigin', () => {
   test('TUI origin tells the agent the operator is attached', () => {

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -69,6 +69,36 @@ export type SessionOrigin =
       triggeredBy?: SessionOrigin
     }
 
+// Hard ceiling on the subagent delegation chain. Bounds chain LENGTH, not
+// fan-out breadth: the deepest reachable chain is main (depth 0) →
+// operator/reviewer (depth 1) → nested worker (depth 2). `spawn_subagent`
+// refuses to spawn from a session already at this depth.
+export const MAX_SUBAGENT_DEPTH = 2
+
+// Counts subagent links from the root by walking the `spawnedByOrigin`
+// ancestry. A non-subagent (or undefined) origin is depth 0; each nested
+// subagent origin adds one. Fails CLOSED on ambiguous ancestry: if a subagent
+// origin has no `spawnedByOrigin` (the serialized path in
+// parseSpawnedByOriginJson drops it), the true depth is unknowable, so we
+// return MAX_SUBAGENT_DEPTH rather than assume it sits at the root — a
+// truncated grandchild must not read as a child and earn an extra spawn. A
+// cyclic chain is bounded by the same cap.
+export function subagentDepth(origin: SessionOrigin | undefined): number {
+  let depth = 0
+  let current: SessionOrigin | undefined = origin
+  while (current !== undefined && current.kind === 'subagent') {
+    depth += 1
+    if (current.spawnedByOrigin === undefined) {
+      return MAX_SUBAGENT_DEPTH
+    }
+    if (depth >= MAX_SUBAGENT_DEPTH) {
+      return depth
+    }
+    current = current.spawnedByOrigin
+  }
+  return depth
+}
+
 export const PARTICIPANTS_TOP_K = 10
 export const PARTICIPANTS_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -49,6 +49,12 @@ export type SubagentShared<P = unknown> = {
   toolResultBudget?: ToolResultBudget
   visibility?: 'public' | 'internal'
   requiresSpecificPermission?: boolean
+  // Opt-in: when true, this subagent's session is wired with the orchestration
+  // tools (spawn_subagent/subagent_output/subagent_cancel) so it can delegate
+  // to its own subagents, bounded by MAX_SUBAGENT_DEPTH and caller-owned
+  // registry scoping. Default (unset/false) keeps the subagent a leaf — the
+  // historical contract for explorer/scout/memory-logger/etc.
+  canSpawnSubagents?: boolean
   // Wall-clock ceiling on a single spawn, enforced at the orchestration
   // layer (both `dispatchSpawnSubagent` and the stream-driven
   // `SubagentConsumer`). When exceeded, the orchestrator's `await` settles

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -100,7 +100,7 @@ There are three delegation modes. Pick deliberately.
 [REQUEST]: Concrete instructions — what to find/do/produce, what format, what to SKIP.
 \`\`\`
 
-**Anti-patterns.** Don't fire more than 5 subagents per turn, spawn for a known answer or single-file lookup, poll \`subagent_output\` in a loop (end your turn; the reminder wakes you), or ask a research subagent to make decisions — they find and report, you decide. Subagents cannot recursively spawn subagents.
+**Anti-patterns.** Don't fire more than 5 subagents per turn, spawn for a known answer or single-file lookup, poll \`subagent_output\` in a loop (end your turn; the reminder wakes you), or ask a research subagent to make decisions — they find and report, you decide. Most subagents are leaves; only \`operator\` and \`reviewer\` may delegate one level further, and the chain is hard-capped regardless.
 
 ## Safety
 

--- a/src/agent/tools/spawn-subagent.test.ts
+++ b/src/agent/tools/spawn-subagent.test.ts
@@ -585,3 +585,56 @@ describe('createSpawnSubagentTool — role inheritance', () => {
     expect(capturedOptions?.spawnedByRole).toBeUndefined()
   })
 })
+
+describe('createSpawnSubagentTool — depth guard', () => {
+  function spawnWithOrigin(origin: SessionOrigin) {
+    const registry = makeRegistry()
+    const liveRegistry = new LiveSubagentRegistry()
+    let counter = 0
+    const tool = createSpawnSubagentTool({
+      registry,
+      liveRegistry,
+      createSessionForSubagent: async () => stubSession(),
+      agentDir: '/agent',
+      parentSessionId: 'ses_child',
+      getOrigin: () => origin,
+      generateTaskId: () => `bg_depth${(counter += 1)}`,
+      now: () => 1_000,
+    })
+    return { tool }
+  }
+
+  test('a depth-1 subagent (spawned by a root session) can still spawn', async () => {
+    const { tool } = spawnWithOrigin({
+      kind: 'subagent',
+      subagent: 'operator',
+      parentSessionId: 'ses_child',
+      spawnedByOrigin: { kind: 'tui', sessionId: 'ses_root' },
+    })
+
+    const result = await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+
+    const details = result.details as { ok: boolean }
+    expect(details.ok).toBe(true)
+  })
+
+  test('a subagent already at MAX_SUBAGENT_DEPTH is refused', async () => {
+    const { tool } = spawnWithOrigin({
+      kind: 'subagent',
+      subagent: 'operator',
+      parentSessionId: 'ses_grandchild',
+      spawnedByOrigin: {
+        kind: 'subagent',
+        subagent: 'reviewer',
+        parentSessionId: 'ses_child',
+        spawnedByOrigin: { kind: 'tui', sessionId: 'ses_root' },
+      },
+    })
+
+    const result = await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+
+    const details = result.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('maximum delegation depth')
+  })
+})

--- a/src/agent/tools/spawn-subagent.ts
+++ b/src/agent/tools/spawn-subagent.ts
@@ -7,7 +7,7 @@ import type { PermissionService } from '@/permissions'
 import type { Stream } from '@/stream'
 
 import { type LiveSubagentRegistry, type SubagentCompletion } from '../live-subagents'
-import type { SessionOrigin } from '../session-origin'
+import { MAX_SUBAGENT_DEPTH, type SessionOrigin, subagentDepth } from '../session-origin'
 import { type CreateSessionForSubagent, type Subagent, type SubagentRegistry, startSubagent } from '../subagents'
 
 export const SPAWN_TASK_ID_PREFIX = 'bg_'
@@ -94,6 +94,16 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
       }
       if (!hasPermissionForSubagent(permissions, origin, params.subagent_type, subagent)) {
         return errorResult('subagent.spawn denied: insufficient permissions')
+      }
+      // Fail closed past the chain-length ceiling. The tool is present on
+      // subagent sessions (operator/reviewer can delegate), but a session
+      // already at MAX_SUBAGENT_DEPTH cannot spawn a deeper one — this is the
+      // execute-time guard against runaway recursion, robust to tool-surface
+      // drift and serialized-origin resumes.
+      if (subagentDepth(origin) >= MAX_SUBAGENT_DEPTH) {
+        return errorResult(
+          `subagent.spawn denied: maximum delegation depth (${MAX_SUBAGENT_DEPTH}) reached; a subagent at this depth cannot spawn further subagents`,
+        )
       }
 
       const taskId = generateTaskId()
@@ -224,7 +234,8 @@ export function spawnSubagentDescription(registry: SubagentRegistry): string {
     `When run_in_background=true (preferred for long-running work), the tool returns a task_id immediately and the subagent runs concurrently — ` +
     `you will receive a system-reminder when it completes; do NOT poll subagent_output. ` +
     `When run_in_background=false (default), the tool blocks and returns the subagent's final message synchronously. ` +
-    `Subagents cannot recursively spawn other subagents.`
+    `The delegation chain is depth-limited: a subagent you spawn may itself delegate once more, but no deeper — ` +
+    `keep your delegation tree shallow.`
   )
 }
 

--- a/src/agent/tools/subagent-access.ts
+++ b/src/agent/tools/subagent-access.ts
@@ -13,26 +13,45 @@ export type AuthorizeLiveSubagentAccessArgs = {
   liveRegistry: LiveSubagentRegistry
   taskId: string
   permission: SubagentAccessPermission
+  // The caller's own session id. When the caller is itself a subagent, access
+  // is scoped to subagents IT spawned (live.parentSessionId === callerSessionId)
+  // so a nested subagent cannot read or cancel siblings or parent-branch runs.
+  // Omitted by main-session callers, which keep the role-severity cap only.
+  callerSessionId?: string
 }
 
 // Authorizes a single subagent_output/subagent_cancel call and resolves the
-// live entry in one place so the two tools cannot drift. Caps access to the
-// requester's role: the caller must hold the permission AND resolve to a role
-// at least as high as the role that spawned the subagent.
+// live entry in one place so the two tools cannot drift. Two authorization
+// modes, both requiring the base permission first:
+//   - SUBAGENT caller: scoped to runs it spawned (live.parentSessionId ===
+//     callerSessionId). Ownership is the authorization; the role cap is skipped.
+//   - MAIN-SESSION caller: capped to the requester's role — must resolve to a
+//     role at least as high as the role that spawned the subagent.
 //
 // The ordering closes an existence oracle: the task-independent base-permission
 // check runs BEFORE any registry lookup, and for non-owner callers an absent
 // task, a capped task, and a task with missing provenance all collapse to one
 // identical denial — so a lower-role caller cannot probe which task IDs are
 // live. Only `owner` (the trust root, which outranks every spawner) learns the
-// truthful `Unknown task_id` for a genuine miss. The cap fails closed.
+// truthful `Unknown task_id` for a genuine miss. Both modes fail closed.
 export function authorizeLiveSubagentAccess(args: AuthorizeLiveSubagentAccessArgs): SubagentAccessResult {
-  const { permissions, origin, liveRegistry, taskId, permission } = args
+  const { permissions, origin, liveRegistry, taskId, permission, callerSessionId } = args
+
+  // A subagent caller may only touch subagents it spawned itself — never a
+  // sibling's or its parent's run. For subagent callers this ownership check
+  // REPLACES the role-severity cap (see the ownershipScoped branch below);
+  // main-session callers (subagent origin absent) skip it and fall through to
+  // the role cap, preserving the operator's global visibility over every spawn.
+  const ownershipScoped = origin?.kind === 'subagent'
+  const opaqueOwnershipDenial = `${permission} denied: unknown task_id or not owned by caller`
 
   if (permissions === undefined) {
     const live = liveRegistry.get(taskId)
     if (live === undefined) {
       return { ok: false, message: `Unknown task_id: ${taskId}.` }
+    }
+    if (ownershipScoped && live.parentSessionId !== callerSessionId) {
+      return { ok: false, message: opaqueOwnershipDenial }
     }
     return { ok: true, live }
   }
@@ -43,6 +62,22 @@ export function authorizeLiveSubagentAccess(args: AuthorizeLiveSubagentAccessArg
 
   const requesterRole = permissions.resolveRole(origin)
   const accessAll = requesterRole === 'owner'
+
+  // For a subagent caller, ownership of the run IS the authorization: having
+  // passed the base permission check above, it may manage exactly the children
+  // it spawned. The role-severity cap (below) does NOT apply — a deep subagent
+  // that inherited a low role from, say, a guest channel turn must still be
+  // able to read/cancel its own children; the cap is meant to stop a low-role
+  // MAIN session from reaching a higher-role-spawned run, which ownership
+  // already prevents here. A non-owning subagent caller fails closed.
+  if (ownershipScoped) {
+    const live = liveRegistry.get(taskId)
+    if (live === undefined || live.parentSessionId !== callerSessionId) {
+      return { ok: false, message: opaqueOwnershipDenial }
+    }
+    return { ok: true, live }
+  }
+
   const opaqueDenial = `${permission} denied: unknown task_id or insufficient role`
 
   const live = liveRegistry.get(taskId)

--- a/src/agent/tools/subagent-cancel.ts
+++ b/src/agent/tools/subagent-cancel.ts
@@ -15,10 +15,11 @@ export type CreateSubagentCancelToolOptions = {
   liveRegistry: LiveSubagentRegistry
   getOrigin: () => SessionOrigin | undefined
   permissions?: PermissionService
+  callerSessionId?: string
 }
 
 export function createSubagentCancelTool(options: CreateSubagentCancelToolOptions) {
-  const { liveRegistry, getOrigin, permissions } = options
+  const { liveRegistry, getOrigin, permissions, callerSessionId } = options
 
   return defineTool({
     name: 'subagent_cancel',
@@ -40,6 +41,7 @@ export function createSubagentCancelTool(options: CreateSubagentCancelToolOption
         liveRegistry,
         taskId: params.task_id,
         permission: 'subagent.cancel',
+        ...(callerSessionId !== undefined ? { callerSessionId } : {}),
       })
       if (!access.ok) {
         return errorResult(access.message)

--- a/src/agent/tools/subagent-output.test.ts
+++ b/src/agent/tools/subagent-output.test.ts
@@ -307,3 +307,56 @@ describe('createSubagentOutputTool — provenance cap', () => {
     expect((missRes.details as { error?: string }).error).toContain('Unknown task_id')
   })
 })
+
+describe('createSubagentOutputTool — subagent caller ownership scope', () => {
+  const subagentCaller: SessionOrigin = {
+    kind: 'subagent',
+    subagent: 'operator',
+    parentSessionId: 'ses_root',
+    spawnedByOrigin: { kind: 'tui', sessionId: 'ses_root' },
+  }
+
+  test('a subagent caller can read a child it spawned (live.parentSessionId === callerSessionId)', async () => {
+    const registry = new LiveSubagentRegistry()
+    registry.register(makeLive({ parentSessionId: 'ses_operator', spawnedByRole: 'owner' }))
+    const tool = createSubagentOutputTool({
+      liveRegistry: registry,
+      getOrigin: () => subagentCaller,
+      permissions: capPermissions(),
+      callerSessionId: 'ses_operator',
+    })
+
+    const res = await tool.execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    expect((res.details as { ok: boolean }).ok).toBe(true)
+  })
+
+  test('a subagent caller cannot read a sibling/parent-branch run it did not spawn', async () => {
+    const registry = new LiveSubagentRegistry()
+    registry.register(makeLive({ parentSessionId: 'ses_other_branch', spawnedByRole: 'owner' }))
+    const tool = createSubagentOutputTool({
+      liveRegistry: registry,
+      getOrigin: () => subagentCaller,
+      permissions: capPermissions(),
+      callerSessionId: 'ses_operator',
+    })
+
+    const res = await tool.execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const details = res.details as { ok: boolean; error?: string }
+    expect(details.ok).toBe(false)
+    expect(details.error).toContain('not owned by caller')
+  })
+
+  test('a main-session owner caller keeps global visibility (no ownership scope)', async () => {
+    const registry = new LiveSubagentRegistry()
+    registry.register(makeLive({ parentSessionId: 'ses_other_branch', spawnedByRole: 'member' }))
+    const tool = createSubagentOutputTool({
+      liveRegistry: registry,
+      getOrigin: () => ownerOrigin,
+      permissions: capPermissions(),
+      callerSessionId: 'ses_main',
+    })
+
+    const res = await tool.execute('c', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    expect((res.details as { ok: boolean }).ok).toBe(true)
+  })
+})

--- a/src/agent/tools/subagent-output.ts
+++ b/src/agent/tools/subagent-output.ts
@@ -44,11 +44,12 @@ export type CreateSubagentOutputToolOptions = {
   liveRegistry: LiveSubagentRegistry
   getOrigin: () => SessionOrigin | undefined
   permissions?: PermissionService
+  callerSessionId?: string
   now?: () => number
 }
 
 export function createSubagentOutputTool(options: CreateSubagentOutputToolOptions) {
-  const { liveRegistry, getOrigin, permissions, now = () => Date.now() } = options
+  const { liveRegistry, getOrigin, permissions, callerSessionId, now = () => Date.now() } = options
 
   return defineTool({
     name: SUBAGENT_OUTPUT_TOOL_NAME,
@@ -73,6 +74,7 @@ export function createSubagentOutputTool(options: CreateSubagentOutputToolOption
         liveRegistry,
         taskId: params.task_id,
         permission: 'subagent.output',
+        ...(callerSessionId !== undefined ? { callerSessionId } : {}),
       })
       if (!access.ok) {
         return errorResult(access.message)

--- a/src/bundled-plugins/operator/operator.test.ts
+++ b/src/bundled-plugins/operator/operator.test.ts
@@ -13,7 +13,6 @@ describe('operator subagent — load-bearing prompt phrases', () => {
       'What changed',
       'What you observed',
       'Do NOT commit secrets',
-      'Spawn further subagents',
       'cannot proceed',
       'workspace in a broken state',
       'AGENTS.md',
@@ -31,9 +30,10 @@ describe('operator subagent — load-bearing prompt phrases', () => {
     expect(OPERATOR_SYSTEM_PROMPT).toContain("What's next.")
   })
 
-  test('prompt forbids recursive spawn (defense-in-depth alongside the tool-presence gate)', () => {
+  test('prompt describes depth-limited delegation (operator may spawn one level, not recurse)', () => {
     const lower = OPERATOR_SYSTEM_PROMPT.toLowerCase()
-    expect(lower).toContain('spawn further subagents')
+    expect(lower).toContain('spawn_subagent')
+    expect(lower).toContain('depth-limited')
   })
 
   test('prompt forbids talking to the user directly (Mode B contract: parent owns the conversation)', () => {
@@ -52,6 +52,11 @@ describe('operator subagent declaration', () => {
   test('declares requiresSpecificPermission=true (member with generic subagent.spawn cannot spawn it)', () => {
     const sub = createOperatorSubagent()
     expect(sub.requiresSpecificPermission).toBe(true)
+  })
+
+  test('declares canSpawnSubagents=true (orchestration tools are wired into its session)', () => {
+    const sub = createOperatorSubagent()
+    expect(sub.canSpawnSubagents).toBe(true)
   })
 
   test('uses the default model profile (needs reasoning for multi-step work, not the fast tier)', () => {

--- a/src/bundled-plugins/operator/operator.ts
+++ b/src/bundled-plugins/operator/operator.ts
@@ -18,8 +18,11 @@ You have a full tool set: read, write, edit, grep, find, ls, bash. You can:
 - Run shell commands with side effects (bash without the read-only restriction)
 - Use any tool available to a normal operator session
 
+You CAN delegate, but rarely should:
+- You may \`spawn_subagent\` to hand a clearly separable, context-heavy chunk to a fresh worker — e.g. a focused read-only investigation of a large area you don't want to load into your own context. Spawn only when delegation clearly pays for itself; doing the work yourself is the default. The delegation chain is depth-limited, so a worker you spawn cannot spawn again — keep your own tree flat.
+- Use \`subagent_output\` and \`subagent_cancel\` only for tasks YOU spawned; you cannot see other branches' subagents.
+
 You CANNOT:
-- Spawn further subagents (you are at the end of the delegation chain).
 - Talk to the user directly (the parent owns the conversation).
 - Use channel_send, channel_reply, or any channel tool.
 
@@ -67,6 +70,7 @@ export function createOperatorSubagent(): Subagent<OperatorPayload> {
     payloadSchema: operatorPayloadSchema,
     visibility: 'public',
     requiresSpecificPermission: true,
+    canSpawnSubagents: true,
     inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     toolResultBudget: {
       maxTotalBytes: 1_000_000,

--- a/src/bundled-plugins/reviewer/reviewer.test.ts
+++ b/src/bundled-plugins/reviewer/reviewer.test.ts
@@ -82,9 +82,17 @@ describe('reviewer subagent — load-bearing prompt phrases', () => {
     expect(REVIEWER_SYSTEM_PROMPT).toContain('<suggestion>')
   })
 
-  test('prompt forbids recursive spawn (defense-in-depth alongside the tool-presence gate)', () => {
+  test('prompt frames delegation as context-saving (deep model offloads bulk to cheaper workers)', () => {
     const lower = REVIEWER_SYSTEM_PROMPT.toLowerCase()
-    expect(lower).toContain('spawning further subagents')
+    expect(lower).toContain('spawn_subagent')
+    expect(lower).toContain('cheaper')
+    // The judgment stays with the reviewer — delegation gathers, never decides.
+    expect(lower).toContain('never delegate the judgment')
+  })
+
+  test('prompt still forbids side effects through a delegate (no laundering write access via a subagent)', () => {
+    const lower = REVIEWER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('a subagent you spawn cannot do for you')
   })
 
   test('prompt forbids generic LLM review noise (drift guard: the whole point of a deep-model reviewer)', () => {
@@ -119,6 +127,11 @@ describe('reviewer subagent declaration', () => {
   test('does NOT require a specific permission (member with generic subagent.spawn can spawn it)', () => {
     const sub = createReviewerSubagent()
     expect(sub.requiresSpecificPermission ?? false).toBe(false)
+  })
+
+  test('declares canSpawnSubagents=true (deep-model reviewer offloads bulk gathering to cheaper workers)', () => {
+    const sub = createReviewerSubagent()
+    expect(sub.canSpawnSubagents).toBe(true)
   })
 
   test('tools list is read-only by whitelist: read/grep/find/ls/bash/web_search/web_fetch with NO write/edit', () => {

--- a/src/bundled-plugins/reviewer/reviewer.ts
+++ b/src/bundled-plugins/reviewer/reviewer.ts
@@ -55,9 +55,17 @@ You are STRICTLY PROHIBITED from:
 - Posting to GitHub, Slack, Discord, email, or any channel — the parent owns posting
 - Pushing, merging, rebasing, or otherwise mutating remote state
 - Using bash for: mkdir, touch, rm, cp, mv, git add, git commit, git push, git rebase, git reset, npm install, pip install, or any write operation
-- Spawning further subagents — you are at the end of the delegation chain
 
-Your role is EXCLUSIVELY to analyze and report. The parent agent decides what to do with your findings.
+Your role is EXCLUSIVELY to analyze and report. The parent agent decides what to do with your findings. Delegating part of that analysis is fine; performing side effects through a delegate is NOT — anything you cannot do directly, a subagent you spawn cannot do for you.
+
+## Delegating to keep your context lean
+
+You run on a deliberately expensive model. Reading a sprawling file tree, a giant diff, or a pile of vendor docs into YOUR context burns that budget on grunt work. When a slice of the job is bulky-but-mechanical — "summarize what these 40 files do", "extract the public API of this module", "gather the relevant passages from this 2,000-line diff" — hand it to a cheaper worker with \`spawn_subagent\` and review the distilled result instead of the raw bulk.
+
+- Spawn read-only/research workers for context-heavy gathering, not for forming the verdict. The findings and the \`<review>\` block are YOURS — never delegate the judgment.
+- Each delegated task must be self-contained: the worker does not see this conversation or the target. Put everything it needs in the prompt.
+- The chain is depth-limited: a worker you spawn cannot spawn again. Keep delegation one level deep.
+- \`subagent_output\`/\`subagent_cancel\` reach only the tasks YOU spawned. Use background spawns for parallel gathering, then fold the results into your single review pass.
 
 ## Tools
 
@@ -172,6 +180,7 @@ If none of the listed skills fit the target, load \`general\` and explain in \`<
     customTools: [loadSkillTool],
     payloadSchema: reviewerPayloadSchema,
     visibility: 'public',
+    canSpawnSubagents: true,
     timeoutMs: REVIEWER_SPAWN_TIMEOUT_MS,
     inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     toolResultBudget: {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -347,6 +347,20 @@ export async function startAgent({
           ...(entry.pluginSubagent.customTools ? { customTools: entry.pluginSubagent.customTools } : {}),
           toolNamePrefix: `__plugin_${entry.pluginName}_${entry.subagentName}`,
         },
+        // Orchestration wiring is opt-in per subagent (canSpawnSubagents) so
+        // only operator/reviewer can delegate; explorer/scout/etc. stay leaves.
+        // The same liveSubagentRegistry instance is shared, but
+        // subagent_output/subagent_cancel scope by the caller's session (see
+        // authorizeLiveSubagentAccess) and spawn_subagent caps the chain at
+        // MAX_SUBAGENT_DEPTH. createSessionForSubagent self-references so a
+        // nested spawn re-enters this same factory.
+        ...(entry.pluginSubagent.canSpawnSubagents === true
+          ? {
+              liveSubagentRegistry,
+              subagentRegistry: snap.subagents,
+              createSessionForSubagent,
+            }
+          : {}),
         ...(entry.pluginSubagent.profile !== undefined ? { profile: entry.pluginSubagent.profile } : {}),
         ...(entry.pluginSubagent.toolResultBudget !== undefined
           ? { toolResultBudget: entry.pluginSubagent.toolResultBudget }


### PR DESCRIPTION
## Background

Operator and reviewer were leaf nodes in the delegation tree. Their plugin-subagent sessions were created without the orchestration tools (`spawn_subagent` / `subagent_output` / `subagent_cancel`), so they physically could not delegate — the tool surface wasn't there, reinforced by a "you are at the end of the delegation chain" line in each system prompt.

This hurts two cases:
- `reviewer` runs on a deliberately expensive `deep` model. Reading a sprawling file tree, a giant diff, or vendor docs into its context burns that premium budget on grunt work. It should offload bulky-but-mechanical gathering ("summarize what these 40 files do", "extract this module's public API") to a cheaper worker and review the distilled result.
- `operator` sometimes has a cleanly separable sub-task worth a fresh context window.

## Summary

Nested spawning is now opt-in per subagent via a new `canSpawnSubagents` flag, set only on `operator` and `reviewer`. `explorer` / `scout` / `memory-logger` / etc. stay leaves with prompts untouched.

When the flag is set, `run/index.ts` wires the shared `liveSubagentRegistry`, the subagent registry, and a self-referential `createSessionForSubagent` into the subagent session; `createSessionWithDispose` then appends the orchestration tools to the subagent's declared builtins. The orchestration tools self-omit when those deps are absent, so leaf subagents are unaffected.

Three safety bounds land atomically with the enablement (splitting them would leave an intermediate commit where nested spawning is on but unbounded/unscoped):

- **Depth:** `subagentDepth()` walks the `spawnedByOrigin` ancestry; `spawn_subagent` refuses at execute time once a session is already at `MAX_SUBAGENT_DEPTH` (2). Deepest chain: `main -> operator/reviewer -> one worker`. Execute-time guard (not just tool omission) is robust to tool-surface drift and serialized-origin resumes. Fail-closed on truncated ancestry: `parseSpawnedByOriginJson` can drop `spawnedByOrigin`, so a subagent origin with no ancestry is indistinguishable from a truncated grandchild — `subagentDepth` returns the cap rather than 1, so a truncated grandchild cannot read as a child and earn an extra spawn.
- **Ownership:** a subagent caller can only `subagent_output` / `subagent_cancel` runs it spawned (`live.parentSessionId === callerSessionId`); for subagent callers this ownership check replaces the role-severity cap (the base permission check still runs). Main-session callers unchanged, keep global visibility.
- **Permissions:** `spawnedByRole` inheritance unchanged; no new grants. An `operator` spawned by `owner` inherits `owner` and may spawn again within the depth cap — consistent with the existing model.

## What this does NOT do

- Does NOT enable spawning for any subagent other than `operator` and `reviewer`.
- Does NOT add a fan-out/breadth cap — `MAX_SUBAGENT_DEPTH` bounds chain length, not concurrent children per session (existing per-turn guidance and `inFlightKey` coalescing still apply).
- Does NOT change `BUILTIN_ROLES` or any permission string.

## Review notes

- Load-bearing files: `src/agent/index.ts` (the gate that now appends orchestration tools on the `pluginSubagent` branch) and `src/run/index.ts` (the opt-in wiring).
- Invariant: with `getOrigin()` returning the live in-memory origin (full chain) for interactive spawns, `main -> operator` gives the operator origin depth 1 (allowed) and its child depth 2 (denied). Confirm `run/index.ts` constructs the subagent origin with `spawnedByOrigin` and that `sessionManager.getSessionId()` (the subagent's own id) flows to both `parentSessionId` at spawn and `callerSessionId` at access.
- `subagentDepth`'s fail-closed branch is intentional and security-relevant; see its comment.
- The full local test suite is green except one pre-existing, environment-specific failure unrelated to this change: `resolveSelfPackageJsonPath > points at this package manifest` in `src/update/index.test.ts` asserts the checkout dir is named `typeclaw`; it fails only when run from a worktree not named `typeclaw`. It passes in CI and the main checkout.