### PR TITLE
channels: Slack + Discord reactions and proactive agent acks

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -200,6 +200,41 @@ describe('renderSessionOrigin', () => {
     expect(out).toContain('"On it."')
   })
 
+  test.each(['slack-bot', 'discord-bot', 'github'] as const)(
+    'reaction-capable channel origin (%s) tells the model to react proactively with channel_react',
+    (adapter) => {
+      const out = renderSessionOrigin({
+        kind: 'channel',
+        adapter,
+        workspace: 'W0',
+        chat: 'C0',
+        thread: null,
+      })
+      expect(out).toMatch(/React like a teammate/i)
+      expect(out).toMatch(/channel_react\(\{ emoji \}\)/)
+      // The proactive guidance names a sentiment-based vocabulary, not just :eyes:.
+      expect(out).toMatch(/rocket/)
+      expect(out).toMatch(/tada/)
+      // A reaction must not be presented as satisfying the reply obligation.
+      expect(out).toMatch(/does NOT satisfy the\s+reply obligation/i)
+    },
+  )
+
+  test.each(['telegram-bot', 'kakaotalk'] as const)(
+    'channel origin without reaction support (%s) omits the proactive-reaction guidance',
+    (adapter) => {
+      const out = renderSessionOrigin({
+        kind: 'channel',
+        adapter,
+        workspace: 'W0',
+        chat: 'C0',
+        thread: null,
+      })
+      expect(out).not.toMatch(/React like a teammate/i)
+      expect(out).not.toMatch(/channel_react/)
+    },
+  )
+
   test('channel origin tells the model that plain-text narration is invisible and must go through channel_reply', () => {
     const out = renderSessionOrigin({
       kind: 'channel',

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -123,14 +123,20 @@ export const PARTICIPANTS_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 type PlatformInfo = {
   displayName: string
   mentionMode: 'angle-id' | 'at-username' | 'alias'
+  // Whether this adapter registers a ReactionCallback, i.e. whether
+  // `channel_react` actually does anything here. Gates the proactive-reaction
+  // prompt guidance so we never tell a KakaoTalk/Telegram agent to react when
+  // the call would no-op. Keep in sync with the adapters that call
+  // `router.registerReaction` (github, slack-bot, discord-bot today).
+  supportsReactions: boolean
 }
 
 const PLATFORM_INFO: Record<AdapterId, PlatformInfo> = {
-  'slack-bot': { displayName: 'Slack', mentionMode: 'angle-id' },
-  'discord-bot': { displayName: 'Discord', mentionMode: 'angle-id' },
-  github: { displayName: 'GitHub', mentionMode: 'at-username' },
-  'telegram-bot': { displayName: 'Telegram', mentionMode: 'at-username' },
-  kakaotalk: { displayName: 'KakaoTalk', mentionMode: 'alias' },
+  'slack-bot': { displayName: 'Slack', mentionMode: 'angle-id', supportsReactions: true },
+  'discord-bot': { displayName: 'Discord', mentionMode: 'angle-id', supportsReactions: true },
+  github: { displayName: 'GitHub', mentionMode: 'at-username', supportsReactions: true },
+  'telegram-bot': { displayName: 'Telegram', mentionMode: 'at-username', supportsReactions: false },
+  kakaotalk: { displayName: 'KakaoTalk', mentionMode: 'alias', supportsReactions: false },
 }
 
 function getPlatformInfo(adapter: AdapterId): PlatformInfo {
@@ -347,6 +353,23 @@ function renderChannelOrigin(
 
   const conversationLine = renderConversationLine(origin)
   if (conversationLine !== null) lines.push('', conversationLine)
+
+  if (platformInfo.supportsReactions) {
+    lines.push(
+      '',
+      '**React like a teammate would.** You can drop an emoji on the message that',
+      'triggered this turn with `channel_react({ emoji })` — it posts no comment,',
+      'just a reaction. Read the message and pick what genuinely fits its tone:',
+      '`+1` to agree or approve, `rocket` for something shipping or exciting,',
+      '`tada` to celebrate, `heart` to show appreciation, `laugh` for something',
+      'funny, `eyes` to signal you are looking. Reach for it when a reaction adds',
+      'real warmth or signal — not on every message, and not just because you can.',
+      'A reaction does NOT satisfy the reply obligation below: when the message',
+      'needs a substantive answer, still send it via `channel_reply`. Think of',
+      'reactions as the lightweight, human layer on top of your words, not a',
+      'replacement for them.',
+    )
+  }
 
   lines.push(
     '',

--- a/src/agent/tools/channel-react.ts
+++ b/src/agent/tools/channel-react.ts
@@ -31,12 +31,19 @@ export function createChannelReactTool({
     name: 'channel_react',
     label: 'Channel React',
     description:
-      'Add an emoji reaction to the message that triggered this turn — a lightweight acknowledgment that does not post a comment. ' +
-      'On GitHub this reacts to the triggering issue/PR/comment (e.g. :eyes: to signal "I am looking at this"). ' +
-      'Use this instead of a textual "on it" reply when a reaction is enough. Pass the bare emoji name, no colons.',
+      'React to the message that triggered this turn with an emoji that fits its content or tone — a lightweight, ' +
+      'human touch that posts no comment. Works on GitHub (issue/PR/comment), Slack, and Discord. ' +
+      'Pick the reaction a thoughtful teammate would leave: :+1: to agree or approve, :rocket: for something ' +
+      'shipping or exciting, :tada: to celebrate, :heart: to show appreciation, :eyes: to signal "I am looking at this", ' +
+      ':laugh: for something funny. Use it when a reaction adds genuine social signal — not on every message. ' +
+      'A reaction does NOT replace `channel_reply`: when the message needs a substantive answer, still send one. ' +
+      'If a reaction alone is the whole response, call `skip_response` afterward so the turn ends cleanly. ' +
+      'Pass the bare emoji name, no colons.',
     parameters: Type.Object({
       emoji: Type.String({
-        description: 'Bare emoji name, no surrounding colons. e.g. "eyes", "+1", "rocket", "heart".',
+        description:
+          'Bare emoji name, no surrounding colons. Choose one that matches the message: ' +
+          'e.g. "+1", "rocket", "tada", "heart", "eyes", "laugh".',
         minLength: 1,
       }),
     }),

--- a/src/channels/adapters/discord-bot-classify.test.ts
+++ b/src/channels/adapters/discord-bot-classify.test.ts
@@ -5,6 +5,7 @@ import type { DiscordGatewayMessageCreateEvent } from 'agent-messenger/discordbo
 import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
 
 import { classifyInbound } from './discord-bot-classify'
+import { encodeDiscordReactionRef } from './discord-bot-reactions'
 
 const BOT_USER_ID = '999'
 
@@ -296,6 +297,7 @@ describe('classifyInbound — route path', () => {
       thread: null,
       text: `hi <@${BOT_USER_ID}>`,
       externalMessageId: 'm1',
+      reactionRef: encodeDiscordReactionRef({ channel: 'c1', message: 'm1' }),
       authorId: 'u1',
       authorName: 'alice',
       authorIsBot: false,

--- a/src/channels/adapters/discord-bot-classify.ts
+++ b/src/channels/adapters/discord-bot-classify.ts
@@ -8,6 +8,8 @@ import type {
 import type { ChannelAdapterConfig } from '@/channels/schema'
 import type { InboundAttachment, InboundMessage } from '@/channels/types'
 
+import { encodeDiscordReactionRef } from './discord-bot-reactions'
+
 export type InboundDropReason =
   | 'self_author' // event.author.id === botUserId; we never route our own messages back to ourselves
   | 'empty_content' // SDK delivered content: '' — usually missing MessageContent intent
@@ -87,6 +89,7 @@ export function classifyInbound(
       text,
       ...(attachments.length > 0 ? { attachments } : {}),
       externalMessageId: event.id,
+      reactionRef: encodeDiscordReactionRef({ channel: event.channel_id, message: event.id }),
       authorId: event.author.id,
       // Discord's post-2023 username system allows pure-numeric handles (e.g.
       // "1411531"); the human-facing display name lives on `global_name`. The

--- a/src/channels/adapters/discord-bot-reactions.test.ts
+++ b/src/channels/adapters/discord-bot-reactions.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'bun:test'
+
+import type { ReactionRequest, RemoveReactionRequest } from '@/channels/types'
+
+import {
+  createDiscordReactionCallback,
+  createDiscordRemoveReactionCallback,
+  decodeDiscordReactionRef,
+  decodeDiscordRemovalRef,
+  encodeDiscordReactionRef,
+  encodeDiscordRemovalRef,
+  type DiscordReactionTarget,
+} from './discord-bot-reactions'
+
+class FakeDiscordError extends Error {
+  constructor(public code: string) {
+    super(code)
+  }
+}
+
+type AddCall = { channel: string; message: string; emoji: string }
+
+const target: DiscordReactionTarget = { channel: 'C1', message: 'M1' }
+
+const addReq = (emoji = 'rocket'): ReactionRequest => ({
+  adapter: 'discord-bot',
+  workspace: 'G1',
+  chat: target.channel,
+  thread: null,
+  reactionRef: encodeDiscordReactionRef(target),
+  emoji,
+})
+
+describe('encode/decode discord reaction ref', () => {
+  it('round-trips the target', () => {
+    expect(decodeDiscordReactionRef(encodeDiscordReactionRef(target))).toEqual(target)
+  })
+
+  it('rejects a ref from another adapter', () => {
+    expect(decodeDiscordReactionRef({ adapter: 'slack-bot', value: '{}' })).toBeNull()
+  })
+
+  it('rejects malformed json', () => {
+    expect(decodeDiscordReactionRef({ adapter: 'discord-bot', value: 'not json' })).toBeNull()
+  })
+})
+
+describe('createDiscordReactionCallback', () => {
+  it('translates the emoji name to unicode and returns a removal ref carrying it', async () => {
+    const calls: AddCall[] = []
+    const cb = createDiscordReactionCallback({
+      client: { addReaction: async (channel, message, emoji) => void calls.push({ channel, message, emoji }) },
+    })
+    const result = await cb(addReq('rocket'))
+    expect(calls).toEqual([{ channel: 'C1', message: 'M1', emoji: '🚀' }])
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(decodeDiscordRemovalRef(result.reactionRef!)).toEqual({ channel: 'C1', message: 'M1', emoji: '🚀' })
+    }
+  })
+
+  it('maps +1 and strips colons', async () => {
+    const calls: AddCall[] = []
+    const cb = createDiscordReactionCallback({
+      client: { addReaction: async (channel, message, emoji) => void calls.push({ channel, message, emoji }) },
+    })
+    await cb(addReq(':+1:'))
+    expect(calls[0]!.emoji).toBe('👍')
+  })
+
+  it('rejects an unmapped emoji name as unsupported without calling the SDK', async () => {
+    let called = false
+    const cb = createDiscordReactionCallback({
+      client: {
+        addReaction: async () => {
+          called = true
+        },
+      },
+    })
+    const result = await cb(addReq('definitely-not-an-emoji'))
+    expect(result).toMatchObject({ ok: false, code: 'unsupported' })
+    expect(called).toBe(false)
+  })
+
+  it('maps Missing Permissions (50013) to permission-denied', async () => {
+    const cb = createDiscordReactionCallback({
+      client: {
+        addReaction: async () => {
+          throw new FakeDiscordError('50013')
+        },
+      },
+    })
+    expect(await cb(addReq())).toMatchObject({ ok: false, code: 'permission-denied' })
+  })
+
+  it('maps Unknown Message (10008) to not-found', async () => {
+    const cb = createDiscordReactionCallback({
+      client: {
+        addReaction: async () => {
+          throw new FakeDiscordError('10008')
+        },
+      },
+    })
+    expect(await cb(addReq())).toMatchObject({ ok: false, code: 'not-found' })
+  })
+
+  it('maps an unrecognized error to transient', async () => {
+    const cb = createDiscordReactionCallback({
+      client: {
+        addReaction: async () => {
+          throw new FakeDiscordError('99999')
+        },
+      },
+    })
+    expect(await cb(addReq())).toMatchObject({ ok: false, code: 'transient' })
+  })
+
+  it('rejects a ref for the wrong adapter', async () => {
+    const cb = createDiscordReactionCallback({ client: { addReaction: async () => {} } })
+    expect(await cb({ ...addReq(), adapter: 'slack-bot' })).toMatchObject({ ok: false, code: 'unsupported' })
+  })
+})
+
+describe('createDiscordRemoveReactionCallback', () => {
+  const removeReq = (emojiUnicode = '🚀'): RemoveReactionRequest => ({
+    adapter: 'discord-bot',
+    workspace: 'G1',
+    chat: target.channel,
+    thread: null,
+    reactionRef: encodeDiscordRemovalRef({ ...target, emoji: emojiUnicode }),
+  })
+
+  it('removes the reaction using the unicode folded into the removal ref', async () => {
+    const calls: AddCall[] = []
+    const cb = createDiscordRemoveReactionCallback({
+      client: { removeReaction: async (channel, message, emoji) => void calls.push({ channel, message, emoji }) },
+    })
+    const result = await cb(removeReq('🚀'))
+    expect(calls).toEqual([{ channel: 'C1', message: 'M1', emoji: '🚀' }])
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects an add ref (missing op=remove) as unsupported', async () => {
+    const cb = createDiscordRemoveReactionCallback({ client: { removeReaction: async () => {} } })
+    const bad: RemoveReactionRequest = {
+      adapter: 'discord-bot',
+      workspace: 'G1',
+      chat: target.channel,
+      thread: null,
+      reactionRef: encodeDiscordReactionRef(target),
+    }
+    expect(await cb(bad)).toMatchObject({ ok: false, code: 'unsupported' })
+  })
+})

--- a/src/channels/adapters/discord-bot-reactions.ts
+++ b/src/channels/adapters/discord-bot-reactions.ts
@@ -1,0 +1,164 @@
+import type { DiscordBotClient } from 'agent-messenger/discordbot'
+
+import type {
+  ReactionCallback,
+  ReactionErrorCode,
+  ReactionRef,
+  ReactionResult,
+  RemoveReactionCallback,
+} from '@/channels/types'
+
+// The reactable target on Discord: a message is addressed by its channel id
+// plus the message id. The classifier stamps this because both values are on
+// the gateway event but `chat`/`externalMessageId` are the only ones that
+// survive into the routed payload — keeping them paired in an opaque ref means
+// the router/tool never have to reassemble Discord's addressing.
+export type DiscordReactionTarget = { channel: string; message: string }
+
+// `RemoveReactionRequest` carries no emoji (the router only round-trips the
+// success ref), so removal needs the resolved unicode folded into the ref:
+// Discord's DELETE is keyed by (channel, message, emoji). Mirrors Slack's
+// removal-ref pattern; GitHub instead carries a per-reaction id.
+export type DiscordReactionRemovalTarget = { channel: string; message: string; emoji: string }
+
+export function encodeDiscordReactionRef(target: DiscordReactionTarget): ReactionRef {
+  return { adapter: 'discord-bot', value: JSON.stringify(target) }
+}
+
+export function decodeDiscordReactionRef(ref: ReactionRef): DiscordReactionTarget | null {
+  if (ref.adapter !== 'discord-bot') return null
+  const parsed = parseRecord(ref.value)
+  if (parsed === null || parsed.op !== undefined) return null
+  const channel = typeof parsed.channel === 'string' ? parsed.channel : null
+  const message = typeof parsed.message === 'string' ? parsed.message : null
+  if (channel === null || message === null) return null
+  return { channel, message }
+}
+
+export function encodeDiscordRemovalRef(target: DiscordReactionRemovalTarget): ReactionRef {
+  return { adapter: 'discord-bot', value: JSON.stringify({ op: 'remove', ...target }) }
+}
+
+export function decodeDiscordRemovalRef(ref: ReactionRef): DiscordReactionRemovalTarget | null {
+  if (ref.adapter !== 'discord-bot') return null
+  const parsed = parseRecord(ref.value)
+  if (parsed === null || parsed.op !== 'remove') return null
+  const channel = typeof parsed.channel === 'string' ? parsed.channel : null
+  const message = typeof parsed.message === 'string' ? parsed.message : null
+  const emoji = typeof parsed.emoji === 'string' ? parsed.emoji : null
+  if (channel === null || message === null || emoji === null) return null
+  return { channel, message, emoji }
+}
+
+// Discord's reaction endpoint takes the literal unicode emoji (URL-encoded by
+// the SDK), NOT a `:name:` shortcode — the agent passes adapter-generic bare
+// names (`+1`, `rocket`), so we translate here. The set mirrors GitHub's fixed
+// reaction vocabulary so the same `channel_react({ emoji })` call works on both
+// platforms, plus a few extra chat-native acks. An unmapped name is reported as
+// `unsupported` rather than forwarded, so a typo gets a clear signal instead of
+// Discord's opaque `10014 Unknown Emoji`.
+const EMOJI_UNICODE: Record<string, string> = {
+  eyes: '👀',
+  '+1': '👍',
+  thumbsup: '👍',
+  '-1': '👎',
+  thumbsdown: '👎',
+  laugh: '😄',
+  hooray: '🎉',
+  tada: '🎉',
+  confused: '😕',
+  heart: '❤️',
+  rocket: '🚀',
+  white_check_mark: '✅',
+  'white-check-mark': '✅',
+  check: '✅',
+  fire: '🔥',
+  eye: '👁️',
+  raised_hands: '🙌',
+}
+
+function resolveEmoji(emoji: string): string | null {
+  const name = emoji.replace(/^:|:$/g, '')
+  return EMOJI_UNICODE[name] ?? null
+}
+
+export function createDiscordReactionCallback(deps: {
+  client: Pick<DiscordBotClient, 'addReaction'>
+}): ReactionCallback {
+  return async (req): Promise<ReactionResult> => {
+    if (req.adapter !== 'discord-bot') {
+      return { ok: false, error: `unknown adapter: ${req.adapter}`, code: 'unsupported' }
+    }
+    const unicode = resolveEmoji(req.emoji)
+    if (unicode === null) {
+      return { ok: false, error: `discord does not support reaction "${req.emoji}"`, code: 'unsupported' }
+    }
+    const target = decodeDiscordReactionRef(req.reactionRef)
+    if (target === null) return { ok: false, error: 'unparseable discord reaction ref', code: 'unsupported' }
+    try {
+      await deps.client.addReaction(target.channel, target.message, unicode)
+    } catch (err) {
+      return { ok: false, error: describe(err), code: classifyDiscordError(err) }
+    }
+    return { ok: true, reactionRef: encodeDiscordRemovalRef({ ...target, emoji: unicode }) }
+  }
+}
+
+export function createDiscordRemoveReactionCallback(deps: {
+  client: Pick<DiscordBotClient, 'removeReaction'>
+}): RemoveReactionCallback {
+  return async (req): Promise<ReactionResult> => {
+    if (req.adapter !== 'discord-bot') {
+      return { ok: false, error: `unknown adapter: ${req.adapter}`, code: 'unsupported' }
+    }
+    const target = decodeDiscordRemovalRef(req.reactionRef)
+    if (target === null) return { ok: false, error: 'unparseable discord reaction removal ref', code: 'unsupported' }
+    try {
+      await deps.client.removeReaction(target.channel, target.message, target.emoji)
+    } catch (err) {
+      return { ok: false, error: describe(err), code: classifyDiscordError(err) }
+    }
+    return { ok: true }
+  }
+}
+
+// DiscordBotError exposes the Discord error code on `.code` as a string. We
+// read it structurally so a wrapped/re-thrown error still classifies. The
+// numeric codes are Discord's documented JSON error codes; `http_4xx` is the
+// SDK's fallback when no JSON code is present.
+function classifyDiscordError(err: unknown): ReactionErrorCode {
+  const code = typeof err === 'object' && err !== null && 'code' in err ? String((err as { code: unknown }).code) : ''
+  switch (code) {
+    case '10003': // Unknown Channel
+    case '10008': // Unknown Message
+    case 'http_404':
+      return 'not-found'
+    case '50001': // Missing Access
+    case '50013': // Missing Permissions
+    case 'http_403':
+    case 'http_401':
+      return 'permission-denied'
+    case '10014': // Unknown Emoji
+      return 'unsupported'
+    case 'http_429':
+      return 'rate-limited'
+    default:
+      return 'transient'
+  }
+}
+
+function parseRecord(value: string): Record<string, unknown> | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    return null
+  }
+  return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : null
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -39,6 +39,7 @@ import {
   type InboundDropReason,
   renderPlaceholder,
 } from './discord-bot-classify'
+import { createDiscordReactionCallback, createDiscordRemoveReactionCallback } from './discord-bot-reactions'
 import { enrichDiscordMessageReferences } from './discord-bot-reference'
 import {
   ackInteraction,
@@ -863,6 +864,9 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
 
   const fetchAttachmentCallback = createFetchAttachmentCallback({ token: options.token, logger })
 
+  const reactionCallback = createDiscordReactionCallback({ client })
+  const removeReactionCallback = createDiscordRemoveReactionCallback({ client })
+
   const interactionHandler = createInteractionHandler({
     router: options.router,
     knownCommandNames: SLASH_COMMAND_NAMES,
@@ -999,6 +1003,8 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       })
 
       options.router.registerOutbound('discord-bot', outboundCallback)
+      options.router.registerReaction('discord-bot', reactionCallback)
+      options.router.registerRemoveReaction('discord-bot', removeReactionCallback)
       options.router.registerTyping('discord-bot', typingCallback)
       options.router.registerChannelNameResolver('discord-bot', channelResolver)
       options.router.registerSelfIdentity('discord-bot', selfIdentityResolver)
@@ -1009,6 +1015,21 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       try {
         await listener.start()
       } catch (err) {
+        // Listener failed after registration — roll back every callback so a
+        // failed start leaves no router state behind (stop() returns early on
+        // !started and would otherwise skip cleanup), mirroring the github
+        // adapter's rollback path.
+        options.router.unregisterOutbound('discord-bot', outboundCallback)
+        options.router.unregisterReaction('discord-bot', reactionCallback)
+        options.router.unregisterRemoveReaction('discord-bot', removeReactionCallback)
+        options.router.unregisterTyping('discord-bot', typingCallback)
+        options.router.unregisterChannelNameResolver('discord-bot', channelResolver)
+        options.router.unregisterSelfIdentity('discord-bot', selfIdentityResolver)
+        options.router.unregisterHistory('discord-bot', historyCallback)
+        options.router.unregisterFetchAttachment('discord-bot', fetchAttachmentCallback)
+        options.router.unregisterMembership('discord-bot', membershipResolver)
+        listener = null
+        botUserId = null
         started = false
         logger.error(`[discord-bot] listener start failed: ${describe(err)}`)
         throw err
@@ -1019,6 +1040,8 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       if (!started) return
       started = false
       options.router.unregisterOutbound('discord-bot', outboundCallback)
+      options.router.unregisterReaction('discord-bot', reactionCallback)
+      options.router.unregisterRemoveReaction('discord-bot', removeReactionCallback)
       options.router.unregisterTyping('discord-bot', typingCallback)
       options.router.unregisterChannelNameResolver('discord-bot', channelResolver)
       options.router.unregisterSelfIdentity('discord-bot', selfIdentityResolver)

--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
 
 import { classifyInbound, type SlackInboundMessageEvent } from './slack-bot-classify'
+import { encodeSlackReactionRef } from './slack-bot-reactions'
 
 const TEAM_ID = 'T0ACME'
 const BOT_USER_ID = 'UBOT'
@@ -266,6 +267,7 @@ describe('slack-bot classifyInbound — route path', () => {
       thread: '1700000000.000100',
       text: `hi <@${BOT_USER_ID}>`,
       externalMessageId: '1700000000.000100',
+      reactionRef: encodeSlackReactionRef({ channel: 'C0CHANNEL', ts: '1700000000.000100' }),
       authorId: 'UALICE',
       authorName: 'UALICE',
       authorIsBot: false,

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -4,6 +4,7 @@ import { matchesAnyAlias } from '@/channels/engagement'
 import type { ChannelAdapterConfig } from '@/channels/schema'
 import type { InboundAttachment, InboundMessage } from '@/channels/types'
 
+import { encodeSlackReactionRef } from './slack-bot-reactions'
 import { hasSlackMessageShareAttachments } from './slack-bot-reference'
 import { slackTsToMillis } from './slack-bot-time'
 
@@ -141,6 +142,7 @@ export function classifyInbound(
       text,
       ...(attachments.length > 0 ? { attachments } : {}),
       externalMessageId: event.ts,
+      reactionRef: encodeSlackReactionRef({ channel: event.channel, ts: event.ts }),
       authorId: event.user,
       authorName: event.user,
       authorIsBot,

--- a/src/channels/adapters/slack-bot-reactions.test.ts
+++ b/src/channels/adapters/slack-bot-reactions.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'bun:test'
+
+import type { ReactionRequest, RemoveReactionRequest } from '@/channels/types'
+
+import {
+  createSlackReactionCallback,
+  createSlackRemoveReactionCallback,
+  decodeSlackReactionRef,
+  decodeSlackRemovalRef,
+  encodeSlackReactionRef,
+  encodeSlackRemovalRef,
+  type SlackReactionTarget,
+} from './slack-bot-reactions'
+
+class FakeSlackError extends Error {
+  constructor(public code: string) {
+    super(code)
+  }
+}
+
+type AddCall = { channel: string; ts: string; emoji: string }
+
+const addReq = (target: SlackReactionTarget, emoji = 'rocket'): ReactionRequest => ({
+  adapter: 'slack-bot',
+  workspace: 'T1',
+  chat: target.channel,
+  thread: null,
+  reactionRef: encodeSlackReactionRef(target),
+  emoji,
+})
+
+describe('encode/decode slack reaction ref', () => {
+  it('round-trips the add target', () => {
+    const target: SlackReactionTarget = { channel: 'C1', ts: '1700000000.000100' }
+    expect(decodeSlackReactionRef(encodeSlackReactionRef(target))).toEqual(target)
+  })
+
+  it('round-trips the removal target with emoji', () => {
+    const target = { channel: 'C1', ts: '1700000000.000100', emoji: 'rocket' }
+    expect(decodeSlackRemovalRef(encodeSlackRemovalRef(target))).toEqual(target)
+  })
+
+  it('rejects a ref from another adapter', () => {
+    expect(decodeSlackReactionRef({ adapter: 'github', value: '{}' })).toBeNull()
+  })
+
+  it('rejects malformed json', () => {
+    expect(decodeSlackReactionRef({ adapter: 'slack-bot', value: 'not json' })).toBeNull()
+  })
+
+  it('does not decode a removal ref as an add ref', () => {
+    const removal = encodeSlackRemovalRef({ channel: 'C1', ts: '1.1', emoji: 'rocket' })
+    expect(decodeSlackReactionRef(removal)).toBeNull()
+  })
+})
+
+describe('createSlackReactionCallback', () => {
+  it('adds the reaction and returns a removal ref carrying the emoji', async () => {
+    const calls: AddCall[] = []
+    const cb = createSlackReactionCallback({
+      client: { addReaction: async (channel, ts, emoji) => void calls.push({ channel, ts, emoji }) },
+    })
+    const result = await cb(addReq({ channel: 'C1', ts: '1.1' }, 'rocket'))
+    expect(calls).toEqual([{ channel: 'C1', ts: '1.1', emoji: 'rocket' }])
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(decodeSlackRemovalRef(result.reactionRef!)).toEqual({ channel: 'C1', ts: '1.1', emoji: 'rocket' })
+    }
+  })
+
+  it('strips surrounding colons before calling the SDK', async () => {
+    const calls: AddCall[] = []
+    const cb = createSlackReactionCallback({
+      client: { addReaction: async (channel, ts, emoji) => void calls.push({ channel, ts, emoji }) },
+    })
+    await cb(addReq({ channel: 'C1', ts: '1.1' }, ':+1:'))
+    expect(calls[0]!.emoji).toBe('+1')
+  })
+
+  it('treats already_reacted as success', async () => {
+    const cb = createSlackReactionCallback({
+      client: {
+        addReaction: async () => {
+          throw new FakeSlackError('already_reacted')
+        },
+      },
+    })
+    const result = await cb(addReq({ channel: 'C1', ts: '1.1' }))
+    expect(result.ok).toBe(true)
+  })
+
+  it('maps invalid_name to unsupported', async () => {
+    const cb = createSlackReactionCallback({
+      client: {
+        addReaction: async () => {
+          throw new FakeSlackError('invalid_name')
+        },
+      },
+    })
+    const result = await cb(addReq({ channel: 'C1', ts: '1.1' }, 'definitely-not-an-emoji'))
+    expect(result).toMatchObject({ ok: false, code: 'unsupported' })
+  })
+
+  it('maps missing_scope to permission-denied with an actionable reactions:write hint', async () => {
+    const cb = createSlackReactionCallback({
+      client: {
+        addReaction: async () => {
+          throw new FakeSlackError('missing_scope')
+        },
+      },
+    })
+    const result = await cb(addReq({ channel: 'C1', ts: '1.1' }))
+    expect(result).toMatchObject({ ok: false, code: 'permission-denied' })
+    if (!result.ok) expect(result.error).toContain('reactions:write')
+  })
+
+  it('maps ratelimited to rate-limited', async () => {
+    const cb = createSlackReactionCallback({
+      client: {
+        addReaction: async () => {
+          throw new FakeSlackError('ratelimited')
+        },
+      },
+    })
+    const result = await cb(addReq({ channel: 'C1', ts: '1.1' }))
+    expect(result).toMatchObject({ ok: false, code: 'rate-limited' })
+  })
+
+  it('rejects an unparseable ref', async () => {
+    const cb = createSlackReactionCallback({ client: { addReaction: async () => {} } })
+    const result = await cb({
+      ...addReq({ channel: 'C1', ts: '1.1' }),
+      reactionRef: { adapter: 'slack-bot', value: 'x' },
+    })
+    expect(result).toMatchObject({ ok: false, code: 'unsupported' })
+  })
+
+  it('rejects a ref for the wrong adapter', async () => {
+    const cb = createSlackReactionCallback({ client: { addReaction: async () => {} } })
+    const result = await cb({ ...addReq({ channel: 'C1', ts: '1.1' }), adapter: 'discord-bot' })
+    expect(result).toMatchObject({ ok: false, code: 'unsupported' })
+  })
+})
+
+describe('createSlackRemoveReactionCallback', () => {
+  const removeReq = (emoji = 'rocket'): RemoveReactionRequest => ({
+    adapter: 'slack-bot',
+    workspace: 'T1',
+    chat: 'C1',
+    thread: null,
+    reactionRef: encodeSlackRemovalRef({ channel: 'C1', ts: '1.1', emoji }),
+  })
+
+  it('removes the reaction by channel, ts and emoji', async () => {
+    const calls: AddCall[] = []
+    const cb = createSlackRemoveReactionCallback({
+      client: { removeReaction: async (channel, ts, emoji) => void calls.push({ channel, ts, emoji }) },
+    })
+    const result = await cb(removeReq('rocket'))
+    expect(calls).toEqual([{ channel: 'C1', ts: '1.1', emoji: 'rocket' }])
+    expect(result.ok).toBe(true)
+  })
+
+  it('treats no_reaction as success', async () => {
+    const cb = createSlackRemoveReactionCallback({
+      client: {
+        removeReaction: async () => {
+          throw new FakeSlackError('no_reaction')
+        },
+      },
+    })
+    expect((await cb(removeReq())).ok).toBe(true)
+  })
+})

--- a/src/channels/adapters/slack-bot-reactions.ts
+++ b/src/channels/adapters/slack-bot-reactions.ts
@@ -1,0 +1,167 @@
+import type { SlackBotClient } from 'agent-messenger/slackbot'
+
+import type {
+  ReactionCallback,
+  ReactionErrorCode,
+  ReactionRef,
+  ReactionResult,
+  RemoveReactionCallback,
+} from '@/channels/types'
+
+// The reactable target on Slack: a message is addressed by its channel id plus
+// the message `ts`. The classifier stamps this because `ts` is the inbound's
+// own message timestamp — the same value that becomes `externalMessageId`
+// downstream, but kept in an opaque ref so the router/tool never have to know
+// Slack's addressing. Mirrors the GitHub `GithubReactionTarget` precedent.
+export type SlackReactionTarget = { channel: string; ts: string }
+
+// Removal needs the emoji name too: Slack's `reactions.remove` is keyed by
+// (channel, ts, name), unlike GitHub's per-reaction id. We fold the emoji that
+// was added into the removal ref so `RemoveReactionCallback` can reconstruct
+// the exact call without the caller tracking it.
+export type SlackReactionRemovalTarget = { channel: string; ts: string; emoji: string }
+
+export function encodeSlackReactionRef(target: SlackReactionTarget): ReactionRef {
+  return { adapter: 'slack-bot', value: JSON.stringify(target) }
+}
+
+export function decodeSlackReactionRef(ref: ReactionRef): SlackReactionTarget | null {
+  if (ref.adapter !== 'slack-bot') return null
+  const parsed = parseRecord(ref.value)
+  if (parsed === null) return null
+  if (parsed.op !== undefined) return null
+  const channel = typeof parsed.channel === 'string' ? parsed.channel : null
+  const ts = typeof parsed.ts === 'string' ? parsed.ts : null
+  if (channel === null || ts === null) return null
+  return { channel, ts }
+}
+
+export function encodeSlackRemovalRef(target: SlackReactionRemovalTarget): ReactionRef {
+  return { adapter: 'slack-bot', value: JSON.stringify({ op: 'remove', ...target }) }
+}
+
+export function decodeSlackRemovalRef(ref: ReactionRef): SlackReactionRemovalTarget | null {
+  if (ref.adapter !== 'slack-bot') return null
+  const parsed = parseRecord(ref.value)
+  if (parsed === null || parsed.op !== 'remove') return null
+  const channel = typeof parsed.channel === 'string' ? parsed.channel : null
+  const ts = typeof parsed.ts === 'string' ? parsed.ts : null
+  const emoji = typeof parsed.emoji === 'string' ? parsed.emoji : null
+  if (channel === null || ts === null || emoji === null) return null
+  return { channel, ts, emoji }
+}
+
+// Slack accepts any custom-emoji name the workspace has, so unlike GitHub there
+// is no fixed allow-list to validate against up front — an unknown name comes
+// back as `invalid_name` from the API, which we map to `unsupported`. We only
+// strip surrounding colons here; the SDK does the same, but normalizing first
+// keeps the removal ref's stored name canonical.
+function normalizeEmoji(emoji: string): string {
+  return emoji.replace(/^:|:$/g, '')
+}
+
+export function createSlackReactionCallback(deps: { client: Pick<SlackBotClient, 'addReaction'> }): ReactionCallback {
+  return async (req): Promise<ReactionResult> => {
+    if (req.adapter !== 'slack-bot') {
+      return { ok: false, error: `unknown adapter: ${req.adapter}`, code: 'unsupported' }
+    }
+    const target = decodeSlackReactionRef(req.reactionRef)
+    if (target === null) return { ok: false, error: 'unparseable slack reaction ref', code: 'unsupported' }
+    const emoji = normalizeEmoji(req.emoji)
+    try {
+      await deps.client.addReaction(target.channel, target.ts, emoji)
+    } catch (err) {
+      // `already_reacted` is the desired end state, not a failure: a duplicate
+      // engage (or a retried tool call) that re-adds the same emoji must read
+      // as success so the model/runtime don't surface a spurious error.
+      const code = slackErrorCode(err)
+      if (code === 'already_reacted') {
+        return { ok: true, reactionRef: encodeSlackRemovalRef({ ...target, emoji }) }
+      }
+      return { ok: false, error: withScopeHint(code, describe(err)), code: classifySlackError(code) }
+    }
+    return { ok: true, reactionRef: encodeSlackRemovalRef({ ...target, emoji }) }
+  }
+}
+
+export function createSlackRemoveReactionCallback(deps: {
+  client: Pick<SlackBotClient, 'removeReaction'>
+}): RemoveReactionCallback {
+  return async (req): Promise<ReactionResult> => {
+    if (req.adapter !== 'slack-bot') {
+      return { ok: false, error: `unknown adapter: ${req.adapter}`, code: 'unsupported' }
+    }
+    const target = decodeSlackRemovalRef(req.reactionRef)
+    if (target === null) return { ok: false, error: 'unparseable slack reaction removal ref', code: 'unsupported' }
+    try {
+      await deps.client.removeReaction(target.channel, target.ts, target.emoji)
+    } catch (err) {
+      // `no_reaction` means the reaction is already gone — the desired end
+      // state for a removal, so treat it as success (idempotent), mirroring the
+      // `already_reacted` handling on the add path.
+      const code = slackErrorCode(err)
+      if (code === 'no_reaction') return { ok: true }
+      return { ok: false, error: describe(err), code: classifySlackError(code) }
+    }
+    return { ok: true }
+  }
+}
+
+// SlackBotError carries the raw Slack API error string on `.code`. We read it
+// structurally (not by instanceof) so a re-thrown or wrapped error still maps
+// correctly, falling back to the message when no code is present.
+function slackErrorCode(err: unknown): string | null {
+  if (typeof err === 'object' && err !== null && 'code' in err) {
+    const code = (err as { code: unknown }).code
+    if (typeof code === 'string') return code
+  }
+  return null
+}
+
+// `reactions:write` is the scope the bot token needs for both add and remove.
+// On `missing_scope` the bare Slack error is uninformative, so append the
+// concrete operator fix — mirroring GitHub's permission-guidance precedent —
+// since autoReactOnEngage surfaces this to host logs on every engaged inbound
+// until the scope is granted.
+function withScopeHint(code: string | null, error: string): string {
+  if (code !== 'missing_scope') return error
+  return `${error} (Slack bot token needs the \`reactions:write\` scope; reinstall/reauthorize the app with that scope.)`
+}
+
+function classifySlackError(code: string | null): ReactionErrorCode {
+  switch (code) {
+    case 'invalid_name':
+    case 'no_item_specified':
+      return 'unsupported'
+    case 'missing_scope':
+    case 'not_in_channel':
+    case 'is_archived':
+    case 'not_authed':
+    case 'invalid_auth':
+      return 'permission-denied'
+    case 'message_not_found':
+    case 'channel_not_found':
+      return 'not-found'
+    case 'ratelimited':
+    case 'rate_limited':
+      return 'rate-limited'
+    default:
+      return 'transient'
+  }
+}
+
+function parseRecord(value: string): Record<string, unknown> | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    return null
+  }
+  return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : null
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -43,6 +43,7 @@ import {
   type SlackInboundMessageEvent,
 } from './slack-bot-classify'
 import { createSlackDedupe } from './slack-bot-dedupe'
+import { createSlackReactionCallback, createSlackRemoveReactionCallback } from './slack-bot-reactions'
 import { enrichSlackReferenceContext } from './slack-bot-reference'
 import {
   buildSlashAckPayload,
@@ -997,6 +998,9 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
 
   const fetchAttachmentCallback = createFetchAttachmentCallback({ client, logger })
 
+  const reactionCallback = createSlackReactionCallback({ client })
+  const removeReactionCallback = createSlackRemoveReactionCallback({ client })
+
   const dedupe = createSlackDedupe()
 
   const handleSlashCommand = createSlashCommandHandler({
@@ -1206,6 +1210,8 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       })
 
       options.router.registerOutbound('slack-bot', outboundCallback)
+      options.router.registerReaction('slack-bot', reactionCallback)
+      options.router.registerRemoveReaction('slack-bot', removeReactionCallback)
       options.router.registerTyping('slack-bot', typingCallback)
       options.router.registerChannelNameResolver('slack-bot', channelResolver)
       options.router.registerSelfIdentity('slack-bot', selfIdentityResolver)
@@ -1216,6 +1222,22 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       try {
         await listener.start()
       } catch (err) {
+        // Listener failed after registration — roll back every callback so a
+        // failed start leaves no router state behind (stop() returns early on
+        // !started and would otherwise skip cleanup), mirroring the github
+        // adapter's rollback path.
+        options.router.unregisterOutbound('slack-bot', outboundCallback)
+        options.router.unregisterReaction('slack-bot', reactionCallback)
+        options.router.unregisterRemoveReaction('slack-bot', removeReactionCallback)
+        options.router.unregisterTyping('slack-bot', typingCallback)
+        options.router.unregisterChannelNameResolver('slack-bot', channelResolver)
+        options.router.unregisterSelfIdentity('slack-bot', selfIdentityResolver)
+        options.router.unregisterHistory('slack-bot', historyCallback)
+        options.router.unregisterFetchAttachment('slack-bot', fetchAttachmentCallback)
+        options.router.unregisterMembership('slack-bot', membershipResolver)
+        listener = null
+        botUserId = null
+        teamId = null
         started = false
         logger.error(`[slack-bot] listener start failed: ${describe(err)}`)
         throw err
@@ -1226,6 +1248,8 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       if (!started) return
       started = false
       options.router.unregisterOutbound('slack-bot', outboundCallback)
+      options.router.unregisterReaction('slack-bot', reactionCallback)
+      options.router.unregisterRemoveReaction('slack-bot', removeReactionCallback)
       options.router.unregisterTyping('slack-bot', typingCallback)
       options.router.unregisterChannelNameResolver('slack-bot', channelResolver)
       options.router.unregisterSelfIdentity('slack-bot', selfIdentityResolver)


### PR DESCRIPTION
Partial follow-up to #553.

## Background

#549 added an adapter-generic emoji-reaction primitive, but only **GitHub** ever registered a `ReactionCallback` — on every other channel `router.react()` returned `unsupported` and auto-`:eyes:`-on-engage was a silent no-op.

## Summary

This PR:

1. **Wires reactions into Slack and Discord** (the two adapters with native reaction APIs), and
2. **Makes the agent react proactively** — choosing a contextually-appropriate emoji (`:+1:`, `:rocket:`, `:tada:`, …) instead of only ever `:eyes:`, on every channel where reactions work.

Three atomic commits:

- **`channels: implement Slack emoji reactions`** — `slack-bot-reactions.ts` (add/remove callbacks via `reactions.add`, keyed by `(channel, ts)`), classifier stamps `reactionRef`, start/stop lifecycle wiring with rollback on `listener.start()` failure.
- **`channels: implement Discord emoji reactions`** — `discord-bot-reactions.ts` (add/remove via the unicode reactions endpoint, keyed by `(channel, message)`, with an emoji-name→unicode map), classifier stamps `reactionRef`, lifecycle wiring + rollback.
- **`agent: make channel_react proactive and sentiment-driven`** — broadens the `channel_react` tool description and adds a "React like a teammate" block to the channel session origin, gated on a new `PlatformInfo.supportsReactions` flag (github/slack/discord = true; telegram/kakaotalk = false).

Design notes:

- **Opaque refs, mirroring GitHub.** Only the originating adapter parses `reactionRef.value`. The success ref returned by the add callback folds in removal info (`RemoveReactionRequest` carries no emoji): Slack stores the emoji name, Discord the resolved unicode.
- **Idempotency.** `already_reacted` / `no_reaction` (Slack) are treated as success, so duplicate webhook deliveries / retried engages don't surface spurious errors — matching GitHub's `200||201` handling.
- **Error mapping.** Platform error codes → `ReactionErrorCode`. Slack `missing_scope` appends an actionable `reactions:write` hint, since `autoReactOnEngage` surfaces it on every engaged inbound.
- **Lifecycle rollback.** Both adapters now unregister all callbacks if `listener.start()` throws (the prior path leaked every callback because `stop()` early-returns on `!started`), matching the github adapter.
- **Anti-over-reaction.** Both the tool description and prompt make clear a reaction does **not** satisfy the reply obligation, and to react only when it adds real signal — not on every message.

## Preview

No visual output — library-internal changes only.

## What this does NOT do

- Telegram (`setMessageReaction`) and KakaoTalk (no public reaction API) — `supportsReactions: false` for both; easy follow-ups.
- GitHub discussion reactions (GraphQL `addReaction`), already deferred in #549.

## Review notes

- **Load-bearing files:** `slack-bot-reactions.ts`, `discord-bot-reactions.ts` (adapter wiring), `src/agent/index.ts` (proactive block, `supportsReactions` gate).
- New unit tests for both reaction modules (encode/decode round-trips, emoji translation, error-code mapping, idempotency, adapter-mismatch guards).
- Classifier tests updated for the stamped `reactionRef`.
- `session-origin` tests assert the proactive block appears for reaction-capable adapters and is absent for telegram/kakaotalk.
- `bun run typecheck`, `lint` (0 errors), `format:check`, and the full suite pass.
- Reviewed by Oracle: no P0s; the lifecycle-rollback, Slack scope-hint, and over-reaction wording were addressed per its feedback.