### PR TITLE
channels: treat GitHub ready_for_review as a PR open

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { createHmac } from 'node:crypto'
 
+import { DEFAULT_GITHUB_EVENT_ALLOWLIST } from '@/channels/schema'
 import type { InboundMessage } from '@/channels/types'
 
 import { createDeliveryDedup } from './dedup'
@@ -406,6 +407,44 @@ describe('classifyGithubInbound', () => {
       })
     })
 
+    describe('pull_request.ready_for_review (treated as opened)', () => {
+      it("synthesizes a review trigger when reviewOn is 'opened'", () => {
+        const msg = classifyGithubInbound('pull_request', readyForReviewPayload(), 'typeclaw-bot', {
+          reviewOn: 'opened',
+        })
+        expect(msg?.chat).toBe('pr:7')
+        expect(msg?.text).toContain('@alice opened PR #7: "Add the thing"')
+        expect(msg?.text).toContain('Please review the changes line-by-line and post your feedback.')
+        expect(msg?.isBotMention).toBe(true)
+        expect(msg?.authorName).toBe('alice')
+      })
+
+      it('stays awareness-only when reviewOn defaults to review_requested', () => {
+        const msg = classifyGithubInbound('pull_request', readyForReviewPayload(), 'typeclaw-bot')
+        expect(msg?.chat).toBe('pr:7')
+        expect(msg?.isBotMention).toBe(false)
+        expect(msg?.text).not.toContain('Please review the changes line-by-line')
+      })
+
+      it("stays awareness-only when reviewOn is 'off'", () => {
+        const msg = classifyGithubInbound('pull_request', readyForReviewPayload(), 'typeclaw-bot', {
+          reviewOn: 'off',
+        })
+        expect(msg?.chat).toBe('pr:7')
+        expect(msg?.isBotMention).toBe(false)
+        expect(msg?.text).not.toContain('Please review the changes line-by-line')
+      })
+
+      it('suppresses the review trigger when the bot marked its own PR ready', () => {
+        const payload = readyForReviewPayload()
+        ;(payload.sender as Record<string, unknown>).login = 'typeclaw-bot'
+        ;(payload.pull_request as Record<string, unknown>).user = { login: 'typeclaw-bot', id: 99, type: 'Bot' }
+        const msg = classifyGithubInbound('pull_request', payload, 'typeclaw-bot', { reviewOn: 'opened' })
+        expect(msg?.isBotMention).toBe(false)
+        expect(msg?.text).not.toContain('Please review the changes line-by-line')
+      })
+    })
+
     describe("reviewOn: 'off'", () => {
       it('drops a review_requested event entirely', () => {
         const msg = classifyGithubInbound(
@@ -624,6 +663,18 @@ describe('createGithubWebhookHandler — review.on wiring', () => {
     await handler(signedRequest(JSON.stringify(openedPayload()), 'pull_request', 'on-default-1'))
     expect(routed).toHaveLength(1)
     expect(routed[0]?.isBotMention).toBe(false)
+  })
+
+  it("admits a ready_for_review delivery under the default allowlist and routes it as a review trigger when reviewOn is 'opened'", async () => {
+    const routed: InboundMessage[] = []
+    const handler = createGithubWebhookHandler({
+      ...baseOptions(routed, () => 'opened'),
+      allowlist: () => [...DEFAULT_GITHUB_EVENT_ALLOWLIST],
+    })
+    await handler(signedRequest(JSON.stringify(readyForReviewPayload()), 'pull_request', 'on-rfr-1'))
+    expect(routed).toHaveLength(1)
+    expect(routed[0]?.isBotMention).toBe(true)
+    expect(routed[0]?.text).toContain('Please review the changes line-by-line')
   })
 })
 
@@ -1301,6 +1352,18 @@ function openedPayload(options: { updatedAt?: string; draft?: boolean } = {}): R
   if (options.draft !== undefined) pull_request.draft = options.draft
   return {
     action: 'opened',
+    repository: repo(),
+    pull_request,
+    sender: { login: 'alice', id: 10, type: 'User' },
+  }
+}
+
+function readyForReviewPayload(options: { updatedAt?: string; draft?: boolean } = {}): Record<string, unknown> {
+  const pull_request = pullRequestForReview(options.updatedAt ?? '2026-01-01T00:00:00Z')
+  // ready_for_review fires on the draft→ready transition, so draft is false by then.
+  pull_request.draft = options.draft ?? false
+  return {
+    action: 'ready_for_review',
     repository: repo(),
     pull_request,
     sender: { login: 'alice', id: 10, type: 'User' },

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -301,7 +301,12 @@ export function classifyGithubInbound(
         teamIsBotMember: options?.teamIsBotMember,
       })
     }
-    if (action === 'opened' && reviewOn === 'opened') {
+    // `ready_for_review` (draft→ready) is a fresh review opportunity, so it
+    // reuses the `opened` paths: same review trigger, same title-only awareness
+    // text. The draft skip in classifyOpenedReviewTrigger is a no-op here since
+    // the PR is non-draft once ready — preserving "review when no longer draft".
+    const isOpenLike = action === 'opened' || action === 'ready_for_review'
+    if (isOpenLike && reviewOn === 'opened') {
       const trigger = classifyOpenedReviewTrigger({
         payload,
         pr,
@@ -314,8 +319,7 @@ export function classifyGithubInbound(
     }
     const opener = readUser(pr.user)
     const hasBody = readString(pr, 'body')?.trim() ? true : false
-    const prText =
-      action === 'opened' ? bodyOrOpenedTitle(pr.body, opener, 'PR', number, readString(pr, 'title')) : pr.body
+    const prText = isOpenLike ? bodyOrOpenedTitle(pr.body, opener, 'PR', number, readString(pr, 'title')) : pr.body
     return buildInbound(
       { ...base, chat: `pr:${number}`, thread: null },
       prText,
@@ -324,7 +328,7 @@ export function classifyGithubInbound(
       selfLogin,
       pr.created_at,
       { kind: 'issue', owner: repository.owner, repo: repository.name, issueNumber: number },
-      action === 'opened' && !hasBody,
+      isOpenLike && !hasBody,
     )
   }
 

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -125,6 +125,7 @@ export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [
   'discussion_comment.created',
   'issues.opened',
   'pull_request.opened',
+  'pull_request.ready_for_review',
   'pull_request.review_requested',
   'pull_request.review_request_removed',
   'discussion.created',


### PR DESCRIPTION
## Summary

A draft PR being **marked "Ready for review"** (`pull_request.ready_for_review`) was previously **dropped** by the GitHub channel. Two independent gates blocked it:

1. **Event allowlist** — `pull_request.ready_for_review` was absent from `DEFAULT_GITHUB_EVENT_ALLOWLIST`, so the webhook was discarded at the outer "process this webhook?" filter.
2. **Classifier** — even if allowlisted, the `pull_request` branch only synthesized opened-PR text for `action === 'opened'`; `ready_for_review` fell through to the (often empty) PR body and got dropped by the body-less guard.

This PR treats `ready_for_review` **exactly like `opened`**, per the intended "review a PR once it's no longer a draft" behavior.

## Changes

- **`src/channels/schema.ts`** — add `pull_request.ready_for_review` to `DEFAULT_GITHUB_EVENT_ALLOWLIST`.
- **`src/channels/adapters/github/inbound.ts`** — introduce `isOpenLike = action === 'opened' || action === 'ready_for_review'` and route all three opened-specific behaviors through it:
  - review trigger (`classifyOpenedReviewTrigger`) under `review.on: 'opened'`,
  - title-only awareness text synthesis,
  - the synthesized-awareness flag.

  The draft-skip guard inside `classifyOpenedReviewTrigger` is a harmless no-op here (the PR is non-draft once ready), which **closes the gap** where a PR opened as a draft (and thus skipped) is now reviewed the moment it becomes ready.

## Behavior (mirrors `opened`)

| `review.on` | `ready_for_review` result |
| --- | --- |
| `opened` | triggers a code review |
| `review_requested` (default) | awareness-only context |
| `off` | awareness-only context |

Bot/decoy marking its own PR ready is suppressed by the existing self-loop guard.

## Tests

- 8 new tests (TDD, written failing first): 5 classifier cases covering all `review.on` values + self-loop suppression, plus 1 end-to-end webhook-handler test exercising the **real** `DEFAULT_GITHUB_EVENT_ALLOWLIST` to prove the delivery is admitted and routed.

## Verification

- `bun run typecheck` passed
- `bun run lint` passed (0 errors)
- `bun run format:check` passed
- `bun run test` passed — **7161 pass, 0 fail** (the generated `typeclaw.schema.json` drift guard was satisfied by regenerating the gitignored artifact; no tracked schema change)