### PR TITLE
channels: stop persisting github eventAllowlist default

### DIFF
--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -132,13 +132,45 @@ export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [
   'pull_request_review.submitted',
 ] as const
 
+// Prior values of DEFAULT_GITHUB_EVENT_ALLOWLIST that shipped in releases and
+// were seeded verbatim into typeclaw.json. Kept as historical record so the
+// migration can recognize and unfreeze configs created by those versions.
+// NEVER edit these in place — they are snapshots of what was on disk.
+//   - v1: 7-event default, shipped 0.5.1–0.10.0 (commit fe4f3a8)
+const GITHUB_EVENT_ALLOWLIST_V1 = [
+  'issue_comment.created',
+  'pull_request_review_comment.created',
+  'discussion_comment.created',
+  'issues.opened',
+  'pull_request.opened',
+  'discussion.created',
+  'pull_request_review.submitted',
+] as const
+//   - v2: added review_requested + review_request_removed, shipped 0.11.0+ (commit 4f365ce)
+const GITHUB_EVENT_ALLOWLIST_V2 = [
+  'issue_comment.created',
+  'pull_request_review_comment.created',
+  'discussion_comment.created',
+  'issues.opened',
+  'pull_request.opened',
+  'pull_request.review_requested',
+  'pull_request.review_request_removed',
+  'discussion.created',
+  'pull_request_review.submitted',
+] as const
+
 // Every event-allowlist that `channel add` / `init` has ever seeded verbatim
-// into typeclaw.json, newest last. The legacy-shape migration uses this to
-// tell a seeded default (safe to strip so the config re-tracks the shipped
-// default) from a user's deliberate customization (must be preserved). Append
-// the prior array here — never edit in place — whenever DEFAULT_GITHUB_EVENT_
-// ALLOWLIST changes, or the migration will start eating user edits.
-export const SEEDED_GITHUB_EVENT_ALLOWLISTS: readonly (readonly string[])[] = [DEFAULT_GITHUB_EVENT_ALLOWLIST]
+// into typeclaw.json, oldest first, current default last. The legacy-shape
+// migration uses this to tell a seeded default (safe to strip so the config
+// re-tracks the shipped default) from a user's deliberate customization (must
+// be preserved). Append the prior array here — never edit in place — whenever
+// DEFAULT_GITHUB_EVENT_ALLOWLIST changes, or configs from the old version stay
+// frozen and the migration starts eating user edits.
+export const SEEDED_GITHUB_EVENT_ALLOWLISTS: readonly (readonly string[])[] = [
+  GITHUB_EVENT_ALLOWLIST_V1,
+  GITHUB_EVENT_ALLOWLIST_V2,
+  DEFAULT_GITHUB_EVENT_ALLOWLIST,
+]
 
 // Which pull_request webhook action triggers an agent code review. The two
 // event values are GitHub's bare PR action names (the `pull_request.` event

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -132,6 +132,14 @@ export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [
   'pull_request_review.submitted',
 ] as const
 
+// Every event-allowlist that `channel add` / `init` has ever seeded verbatim
+// into typeclaw.json, newest last. The legacy-shape migration uses this to
+// tell a seeded default (safe to strip so the config re-tracks the shipped
+// default) from a user's deliberate customization (must be preserved). Append
+// the prior array here — never edit in place — whenever DEFAULT_GITHUB_EVENT_
+// ALLOWLIST changes, or the migration will start eating user edits.
+export const SEEDED_GITHUB_EVENT_ALLOWLISTS: readonly (readonly string[])[] = [DEFAULT_GITHUB_EVENT_ALLOWLIST]
+
 // Which pull_request webhook action triggers an agent code review. The two
 // event values are GitHub's bare PR action names (the `pull_request.` event
 // prefix is implied by this field living under the review config); `off` is the

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1120,6 +1120,55 @@ describe('migrateLegacyConfigShape', () => {
     expect(result.applied).toEqual([{ kind: 'drop-github-seeded-event-allowlist' }])
   })
 
+  // Historical on-disk snapshots seeded by older releases. Inlined verbatim
+  // (not imported) so a future edit to the registry can't silently make these
+  // assertions pass against the wrong list. See SEEDED_GITHUB_EVENT_ALLOWLISTS.
+  const GITHUB_ALLOWLIST_V1 = [
+    'issue_comment.created',
+    'pull_request_review_comment.created',
+    'discussion_comment.created',
+    'issues.opened',
+    'pull_request.opened',
+    'discussion.created',
+    'pull_request_review.submitted',
+  ]
+  const GITHUB_ALLOWLIST_V2 = [
+    'issue_comment.created',
+    'pull_request_review_comment.created',
+    'discussion_comment.created',
+    'issues.opened',
+    'pull_request.opened',
+    'pull_request.review_requested',
+    'pull_request.review_request_removed',
+    'discussion.created',
+    'pull_request_review.submitted',
+  ]
+
+  test.each([
+    ['v1 (0.5.1–0.10.0, 7 events)', GITHUB_ALLOWLIST_V1],
+    ['v2 (0.11.0+, 9 events)', GITHUB_ALLOWLIST_V2],
+  ])('strips an older seeded github eventAllowlist: %s', (_label, seeded) => {
+    const result = migrateLegacyConfigShape({
+      models: { default: VALID_MODEL },
+      channels: { github: { repos: ['acme/widgets'], eventAllowlist: [...seeded] } },
+    })
+    expect(result.changed).toBe(true)
+    const channels = (result.json as Record<string, unknown>).channels as Record<string, Record<string, unknown>>
+    expect(channels.github).toEqual({ repos: ['acme/widgets'] })
+    expect(result.applied).toEqual([{ kind: 'drop-github-seeded-event-allowlist' }])
+  })
+
+  test('preserves a customized list even when it derives from an older seeded default', () => {
+    const customizedFromV1 = [...GITHUB_ALLOWLIST_V1, 'release.published']
+    const result = migrateLegacyConfigShape({
+      models: { default: VALID_MODEL },
+      channels: { github: { eventAllowlist: customizedFromV1 } },
+    })
+    expect(result.changed).toBe(false)
+    const channels = (result.json as Record<string, unknown>).channels as Record<string, Record<string, unknown>>
+    expect(channels.github?.eventAllowlist).toEqual(customizedFromV1)
+  })
+
   test('preserves a user-customized github eventAllowlist (any deviation from a seeded default)', () => {
     const customized = [...DEFAULT_GITHUB_EVENT_ALLOWLIST, 'release.published']
     const result = migrateLegacyConfigShape({

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -4,6 +4,8 @@ import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { DEFAULT_GITHUB_EVENT_ALLOWLIST } from '@/channels/schema'
+
 import {
   buildConfigMigrationCommitMessage,
   configSchema,
@@ -1105,6 +1107,69 @@ describe('migrateLegacyConfigShape', () => {
     expect(result.changed).toBe(false)
     expect(result.applied).toEqual([])
   })
+
+  test('strips a seeded channels.github.eventAllowlist so it re-tracks the shipped default', () => {
+    const result = migrateLegacyConfigShape({
+      models: { default: VALID_MODEL },
+      channels: { github: { repos: ['acme/widgets'], eventAllowlist: [...DEFAULT_GITHUB_EVENT_ALLOWLIST] } },
+    })
+    expect(result.changed).toBe(true)
+    const json = result.json as Record<string, unknown>
+    const channels = json.channels as Record<string, Record<string, unknown>>
+    expect(channels.github).toEqual({ repos: ['acme/widgets'] })
+    expect(result.applied).toEqual([{ kind: 'drop-github-seeded-event-allowlist' }])
+  })
+
+  test('preserves a user-customized github eventAllowlist (any deviation from a seeded default)', () => {
+    const customized = [...DEFAULT_GITHUB_EVENT_ALLOWLIST, 'release.published']
+    const result = migrateLegacyConfigShape({
+      models: { default: VALID_MODEL },
+      channels: { github: { repos: ['acme/widgets'], eventAllowlist: customized } },
+    })
+    expect(result.changed).toBe(false)
+    const json = result.json as Record<string, unknown>
+    const channels = json.channels as Record<string, Record<string, unknown>>
+    expect(channels.github?.eventAllowlist).toEqual(customized)
+  })
+
+  test('treats a reordered seeded allowlist as a customization (deep-equal is order-sensitive)', () => {
+    const reordered = [
+      DEFAULT_GITHUB_EVENT_ALLOWLIST[1],
+      DEFAULT_GITHUB_EVENT_ALLOWLIST[0],
+      ...DEFAULT_GITHUB_EVENT_ALLOWLIST.slice(2),
+    ]
+    const result = migrateLegacyConfigShape({
+      models: { default: VALID_MODEL },
+      channels: { github: { eventAllowlist: reordered } },
+    })
+    expect(result.changed).toBe(false)
+  })
+
+  test('is a no-op when github channel has no eventAllowlist (already canonical)', () => {
+    const input = { models: { default: VALID_MODEL }, channels: { github: { repos: ['acme/widgets'] } } }
+    const result = migrateLegacyConfigShape(input)
+    expect(result.changed).toBe(false)
+    expect(result.json).toBe(input)
+  })
+
+  test('seeded-allowlist strip is idempotent: re-running on the migrated shape does nothing', () => {
+    const first = migrateLegacyConfigShape({
+      models: { default: VALID_MODEL },
+      channels: { github: { repos: ['acme/widgets'], eventAllowlist: [...DEFAULT_GITHUB_EVENT_ALLOWLIST] } },
+    })
+    const second = migrateLegacyConfigShape(first.json)
+    expect(second.changed).toBe(false)
+    expect(second.json).toEqual(first.json)
+  })
+
+  test('migrated github config re-parses through configSchema with the schema default applied', () => {
+    const result = migrateLegacyConfigShape({
+      models: { default: VALID_MODEL },
+      channels: { github: { repos: ['acme/widgets'], eventAllowlist: [...DEFAULT_GITHUB_EVENT_ALLOWLIST] } },
+    })
+    const parsed = configSchema.parse(result.json)
+    expect(parsed.channels.github?.eventAllowlist).toEqual([...DEFAULT_GITHUB_EVENT_ALLOWLIST])
+  })
 })
 
 describe('buildConfigMigrationCommitMessage', () => {
@@ -1147,6 +1212,12 @@ describe('buildConfigMigrationCommitMessage', () => {
     ])
     expect(msg).toContain('warning:')
     expect(msg).toContain('channel:C123')
+  })
+
+  test('names the github seeded-allowlist drop step', () => {
+    const msg = buildConfigMigrationCommitMessage([{ kind: 'drop-github-seeded-event-allowlist' }])
+    expect(msg).toContain('typeclaw.json: drop seeded channels.github.eventAllowlist')
+    expect(msg).toContain('re-tracks the shipped default')
   })
 })
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,7 +5,7 @@ import { isAbsolute, join, resolve } from 'node:path'
 import type { Model } from '@mariozechner/pi-ai'
 import { z } from 'zod'
 
-import { channelsSchema } from '@/channels/schema'
+import { channelsSchema, SEEDED_GITHUB_EVENT_ALLOWLISTS } from '@/channels/schema'
 import { commitSystemFileSync } from '@/git/system-commit'
 import { rolesConfigSchema } from '@/permissions/schema'
 import { secretFieldSchema } from '@/secrets/resolve'
@@ -810,6 +810,7 @@ export type MigrationStep =
   | { kind: 'strip-permissions-gate-channel-respond' }
   | { kind: 'model-to-models'; ref: string }
   | { kind: 'drop-stale-model'; ref: string }
+  | { kind: 'drop-github-seeded-event-allowlist' }
 
 export type MigrationResult = { json: unknown; changed: boolean; applied: MigrationStep[] }
 
@@ -830,13 +831,15 @@ export function migrateLegacyConfigShape(json: unknown): MigrationResult {
   // silently — same precedence rule as the dockerfile/gitignore migrations.
   const hasLegacyModel = 'model' in obj && !('models' in obj) && typeof obj.model === 'string'
   const hasStaleModelAlongsideModels = 'model' in obj && 'models' in obj
+  const hasSeededGithubEventAllowlist = isSeededGithubEventAllowlist(obj)
   if (
     !hasLegacyDockerfile &&
     !hasLegacyGitignore &&
     !channelsAllowMigration.found &&
     !hasLegacyGateChannelRespond &&
     !hasLegacyModel &&
-    !hasStaleModelAlongsideModels
+    !hasStaleModelAlongsideModels &&
+    !hasSeededGithubEventAllowlist
   ) {
     return { json, changed: false, applied: [] }
   }
@@ -897,7 +900,41 @@ export function migrateLegacyConfigShape(json: unknown): MigrationResult {
     delete next.model
     applied.push({ kind: 'drop-stale-model', ref })
   }
+  if (hasSeededGithubEventAllowlist) {
+    dropSeededGithubEventAllowlist(next)
+    applied.push({ kind: 'drop-github-seeded-event-allowlist' })
+  }
   return { json: next, changed: true, applied }
+}
+
+// True when channels.github.eventAllowlist deep-equals an allowlist that
+// `channel add` / `init` has previously seeded verbatim. Such a value is
+// indistinguishable from "the default at that time", so stripping it lets the
+// config re-track the shipped default. A user who hand-edited to any other set
+// (added/removed/reordered an event) fails this check and is preserved.
+function isSeededGithubEventAllowlist(obj: Record<string, unknown>): boolean {
+  const github = isPlainObject(obj.channels) ? obj.channels.github : undefined
+  if (!isPlainObject(github)) return false
+  const list = github.eventAllowlist
+  if (!Array.isArray(list)) return false
+  return SEEDED_GITHUB_EVENT_ALLOWLISTS.some((seeded) => arraysEqual(list, seeded))
+}
+
+function dropSeededGithubEventAllowlist(next: Record<string, unknown>): void {
+  const channels = next.channels
+  if (!isPlainObject(channels)) return
+  const github = channels.github
+  if (!isPlainObject(github)) return
+  const { eventAllowlist: _dropped, ...rest } = github
+  next.channels = { ...channels, github: rest }
+}
+
+function arraysEqual(a: readonly unknown[], b: readonly unknown[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
 }
 
 // Builds a meaningful one-line git commit subject for a typeclaw.json
@@ -949,6 +986,8 @@ function shortStepLabel(step: MigrationStep): string {
       return 'lift model → models.default'
     case 'drop-stale-model':
       return 'drop stale legacy model alongside models'
+    case 'drop-github-seeded-event-allowlist':
+      return 'drop seeded channels.github.eventAllowlist'
   }
 }
 
@@ -972,6 +1011,8 @@ function describeStep(step: MigrationStep): string {
       return step.ref !== ''
         ? `drop stale top-level model (${step.ref}) — models block takes precedence`
         : 'drop stale top-level model — models block takes precedence'
+    case 'drop-github-seeded-event-allowlist':
+      return 'drop seeded channels.github.eventAllowlist so it re-tracks the shipped default'
   }
 }
 

--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -314,7 +314,7 @@ describe('runAddChannel', () => {
     ])
   })
 
-  test('adds github channel: writes typeclaw.json (incl. repos[] and event allowlist), secrets.json, and match rules', async () => {
+  test('adds github channel: writes typeclaw.json (incl. repos[], omitting the defaulted event allowlist), secrets.json, and match rules', async () => {
     const events: AddChannelStepEvent[] = []
     const fetchImpl = recordingGithubFetch()
 
@@ -342,7 +342,9 @@ describe('runAddChannel', () => {
     }
     expect(cfg.channels?.github?.webhookUrl).toBe('https://agent.example.com/gh')
     expect(cfg.channels?.github?.repos).toEqual(['acme/widgets'])
-    expect(cfg.channels?.github?.eventAllowlist).toContain('issue_comment.created')
+    // eventAllowlist is intentionally not persisted so the config tracks the
+    // shipped default across releases; the schema fills it at parse time.
+    expect(cfg.channels?.github?.eventAllowlist).toBeUndefined()
     expect(cfg.tunnels).toEqual([
       {
         name: 'github-webhook',

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1768,7 +1768,7 @@ describe('channel secret reuse (init re-run preserves existing tokens)', () => {
         for: { kind: 'channel', name: 'github' },
       },
     ])
-    expect(Array.isArray(config.channels?.github?.eventAllowlist)).toBe(true)
+    expect(config.channels?.github?.eventAllowlist).toBeUndefined()
     expect(config.roles?.member?.match).toContain('github:acme/repo-a')
 
     const secrets = await readSecrets(root)

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -3,7 +3,6 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { basename, dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { DEFAULT_GITHUB_EVENT_ALLOWLIST } from '@/channels/schema'
 import { config, configSchema, migrateLegacyConfigShape, type Config } from '@/config'
 import {
   DEFAULT_MODEL_REF,
@@ -1167,10 +1166,12 @@ async function mergeChannelIntoConfig(cwd: string, options: AddChannelOptions): 
 }
 
 function buildGithubChannelConfig(options: Extract<AddChannelOptions, { channel: 'github' }>): Record<string, unknown> {
+  // Do NOT write eventAllowlist: the schema defaults it at parse time, so
+  // omitting it lets the user's config track the shipped default across
+  // releases instead of freezing the list captured at `channel add` time.
   return {
     ...(options.webhookUrl !== undefined ? { webhookUrl: options.webhookUrl } : {}),
     webhookPort: options.webhookPort ?? 8975,
-    eventAllowlist: [...DEFAULT_GITHUB_EVENT_ALLOWLIST],
     repos: options.repos,
   }
 }
@@ -1246,7 +1247,6 @@ async function writeGithubChannelForInit(cwd: string, credentials: GithubInitCre
   existingChannels.github = {
     ...(credentials.webhookUrl !== undefined ? { webhookUrl: credentials.webhookUrl } : {}),
     webhookPort: credentials.webhookPort ?? 8975,
-    eventAllowlist: [...DEFAULT_GITHUB_EVENT_ALLOWLIST],
     repos: credentials.repos,
   }
   parsed.channels = existingChannels


### PR DESCRIPTION
## Problem

`channel add` and `init` seeded `channels.github.eventAllowlist` **verbatim** into `typeclaw.json`:

```ts
// buildGithubChannelConfig (src/init/index.ts)
return {
  ...,
  eventAllowlist: [...DEFAULT_GITHUB_EVENT_ALLOWLIST], // ← persisted to disk
  repos: options.repos,
}
```

Once written to the user's config, the value is frozen. When we later add or remove a webhook event in `DEFAULT_GITHUB_EVENT_ALLOWLIST`, existing agents never pick it up — their config still pins whatever list was current at `channel add` time.

This made GitHub the **outlier**: every other channel (Slack/Discord/Telegram/KakaoTalk) writes `{}` and lets the zod schema fill defaults at parse time, so their defaults *do* track code changes across releases.

## Fix

**1. Stop persisting the field.** The schema already has `eventAllowlist: z.array(z.string()).default([...DEFAULT_GITHUB_EVENT_ALLOWLIST])`, so omitting it from the written JSON produces the same runtime value — and now the value tracks the shipped default on every load. Applied to both write paths (`buildGithubChannelConfig` + `writeGithubChannelForInit`).

**2. Migrate existing configs.** New users are fixed by (1), but users who already ran `channel add` still have the stale array pinned. A new key-based legacy-shape migration (`drop-github-seeded-event-allowlist`) strips `eventAllowlist` **only when it deep-equals a known seeded default**, so the config re-tracks the shipped default. A user who customized the list (any deviation — added, removed, or reordered an event) is preserved untouched.

`SEEDED_GITHUB_EVENT_ALLOWLISTS` (in `channels/schema.ts`) is the **append-only** registry the migration matches against. When `DEFAULT_GITHUB_EVENT_ALLOWLIST` changes in a future release, append the prior array there so the migration keeps recognizing older seeded defaults.

## Why deep-equal, not merge

A seeded default is indistinguishable from "the default at that time", so it's safe to strip. Any deviation is treated as a deliberate user choice and preserved. This keeps allowlist semantics as an **exact list** (a user can still remove a default event), rather than turning it into "base + overrides".

## Tests

- `add-channel.test.ts` / `init/index.test.ts`: assert the field is **no longer written** (`toBeUndefined`).
- `config.test.ts`: seeded default is stripped; customized/reordered lists are preserved; no-op when absent; idempotent; re-parses through `configSchema` with the schema default applied; commit-message label.

## Checks

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check` all pass. Full `bun run test` passes except one pre-existing, environment-only failure (`resolveSelfPackageJsonPath` asserts the cwd dir is named `typeclaw`; it fails only because this branch was developed in a worktree dir — unrelated to this change, touches no code here).
