### PR TITLE
inspect: unify tui/inspect/logs into one session viewer

### DIFF
--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -2,7 +2,19 @@ import { defineCommand } from 'citty'
 
 import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/container'
 import { findAgentDir } from '@/init'
-import { runInspectLoop, streamLive, type LiveSourceFactory, type SessionSummary } from '@/inspect'
+import {
+  listViewerItems,
+  openViewerItem,
+  parseDuration,
+  parseFilter,
+  resolveSession,
+  runInspectLoop,
+  runViewerLoop,
+  streamLive,
+  type LiveSourceFactory,
+  type SessionSummary,
+  type ViewerItem,
+} from '@/inspect'
 import { originLabel, shortSessionId } from '@/inspect/label'
 
 import { createTailScope } from './inspect-controller'
@@ -13,12 +25,12 @@ const ESC_DEBOUNCE_MS = 50
 export const inspectCommand = defineCommand({
   meta: {
     name: 'inspect',
-    description: 'observe a session: replay the transcript, then tail live activity (host stage)',
+    description: 'session viewer: pick a session, the live TUI, or container logs to observe (host stage)',
   },
   args: {
     session: {
       type: 'positional',
-      description: 'session id or short prefix (omit to pick from a list)',
+      description: 'session id or short prefix (omit to pick from the list)',
       required: false,
     },
     filter: {
@@ -42,42 +54,168 @@ export const inspectCommand = defineCommand({
     const sessionArg = typeof args.session === 'string' ? args.session : undefined
     const filterArg = typeof args.filter === 'string' ? args.filter : undefined
     const sinceArg = typeof args.since === 'string' ? args.since : undefined
-
     const isJson = args.json === true
-    const liveSource = isJson ? undefined : await buildLiveSource(cwd)
-    const interactive = !isJson && Boolean(process.stdin.isTTY)
-    const liveHint = interactive ? escHintLine(color) : undefined
 
-    const result = await runInspectLoop({
-      agentDir: cwd,
-      ...(sessionArg !== undefined ? { sessionIdOrPrefix: sessionArg } : {}),
-      ...(filterArg !== undefined ? { filter: filterArg } : {}),
-      ...(sinceArg !== undefined ? { since: sinceArg } : {}),
-      json: isJson,
-      color,
-      selectSession: (sessions, selectOpts) => clackSelect(sessions, selectOpts?.initialSessionId),
-      ...(liveSource !== undefined ? { liveSource } : {}),
-      createTailScope: () => createTailScope({ debounceMs: ESC_DEBOUNCE_MS }),
-      ...(interactive ? { interactive: true } : {}),
-      ...(liveHint !== undefined ? { liveHint } : {}),
-      stdout: (line) => process.stdout.write(`${line}\n`),
-      stderr: (line) => process.stderr.write(`${line}\n`),
-    })
-
-    if (!result.ok) {
-      process.stderr.write(`${errorLine(result.reason)}\n`)
-      process.exit(result.exitCode)
+    // JSON mode stays the scriptable, session-only path: no list, no logs/tui
+    // rows, explicit session id required. Behavior is unchanged from before the
+    // viewer merge.
+    if (isJson) {
+      const result = await runInspectLoop({
+        agentDir: cwd,
+        ...(sessionArg !== undefined ? { sessionIdOrPrefix: sessionArg } : {}),
+        ...(filterArg !== undefined ? { filter: filterArg } : {}),
+        ...(sinceArg !== undefined ? { since: sinceArg } : {}),
+        json: true,
+        color,
+        selectSession: (sessions, selectOpts) => clackSelectSession(sessions, selectOpts?.initialSessionId),
+        createTailScope: () => createTailScope({ debounceMs: ESC_DEBOUNCE_MS }),
+        stdout: (line) => process.stdout.write(`${line}\n`),
+        stderr: (line) => process.stderr.write(`${line}\n`),
+      })
+      finish(result)
+      return
     }
-    process.exit(result.exitCode)
+
+    const exitCode = await runInspectViewer({
+      cwd,
+      ...(sessionArg !== undefined ? { sessionArg } : {}),
+      ...(filterArg !== undefined ? { filterArg } : {}),
+      ...(sinceArg !== undefined ? { sinceArg } : {}),
+      color,
+    })
+    process.exit(exitCode)
   },
 })
 
-async function buildLiveSource(cwd: string): Promise<LiveSourceFactory | undefined> {
-  const precheck = await requireContainerRunning({ cwd })
-  if (!precheck.ok) {
-    process.stderr.write(`${c.yellow('⚠')} ${precheck.reason}; tailing live events disabled\n`)
-    return undefined
+export type RunInspectViewerOptions = {
+  cwd: string
+  sessionArg?: string
+  filterArg?: string
+  sinceArg?: string
+  color?: boolean
+}
+
+// The interactive session-viewer: list → open → back to list. Shared by the
+// `inspect` command and `tui`'s esc-detach fallthrough. Returns an exit code
+// instead of calling process.exit so callers can chain (e.g. tui drops here).
+export async function runInspectViewer(opts: RunInspectViewerOptions): Promise<number> {
+  const { cwd } = opts
+  const color = opts.color ?? useColor()
+
+  const filterResult = parseFilter(opts.filterArg)
+  if (!filterResult.ok) {
+    process.stderr.write(`${errorLine(filterResult.reason)}\n`)
+    return 2
   }
+  let sinceMs: number | undefined
+  if (opts.sinceArg !== undefined) {
+    const d = parseDuration(opts.sinceArg)
+    if (!d.ok) {
+      process.stderr.write(`${errorLine(d.reason)}\n`)
+      return 2
+    }
+    sinceMs = Date.now() - d.ms
+  }
+
+  const containerRunning = (await requireContainerRunning({ cwd })).ok
+  if (!containerRunning) {
+    process.stderr.write(`${c.yellow('⚠')} container not running; showing read-only history and logs only\n`)
+  }
+
+  const sessionsDir = `${cwd}/sessions`
+
+  // Resolve a session arg (id or short prefix) to a full session id BEFORE the
+  // loop: runViewerLoop matches preselectKey against exact itemKeys, so a bare
+  // prefix would otherwise miss every row and report "no sessions". 'logs' is a
+  // reserved key, not a session, so it bypasses resolution.
+  let preselectKey: string | undefined
+  if (opts.sessionArg !== undefined && opts.sessionArg !== 'logs') {
+    const resolved = await resolveSession(sessionsDir, opts.sessionArg, (l) => process.stderr.write(`${l}\n`))
+    if (!resolved.ok) {
+      const reason =
+        resolved.reason === 'ambiguous'
+          ? `Ambiguous session prefix "${opts.sessionArg}" matches ${resolved.matches.length} sessions. Use a longer prefix or run \`typeclaw inspect\` without args.`
+          : `No session matching "${opts.sessionArg}" in ${sessionsDir}/`
+      process.stderr.write(`${errorLine(reason)}\n`)
+      return resolved.reason === 'ambiguous' ? 2 : 1
+    }
+    preselectKey = resolved.summary.sessionId
+  } else if (opts.sessionArg === 'logs') {
+    preselectKey = 'logs'
+  }
+
+  const interactive = Boolean(process.stdin.isTTY)
+  const liveHint = interactive ? escHintLine(color) : undefined
+  const liveSource = containerRunning ? await buildLiveSource(cwd) : undefined
+
+  const stdout = (line: string): void => {
+    process.stdout.write(`${line}\n`)
+  }
+  const stderr = (line: string): void => {
+    process.stderr.write(`${line}\n`)
+  }
+
+  const open = openViewerItem({
+    cwd,
+    filter: filterResult.filter,
+    sinceMs,
+    json: false,
+    color,
+    interactive,
+    stdout,
+    stderr,
+    resolveTuiUrl: () => resolveTuiUrl(cwd),
+    ...(liveSource !== undefined ? { liveSource } : {}),
+    ...(liveHint !== undefined ? { liveHint } : {}),
+  })
+
+  const result = await runViewerLoop<ViewerItem>({
+    listItems: async () => {
+      const listOpts: Parameters<typeof listViewerItems>[0] = {
+        sessionsDir,
+        containerRunning,
+        limit: 20,
+        onWarn: stderr,
+      }
+      if (sinceMs !== undefined) listOpts.sinceMs = sinceMs
+      return (await listViewerItems(listOpts)).items
+    },
+    keyOf: (item) => (item.kind === 'logs' ? 'logs' : item.summary.sessionId),
+    ...(preselectKey !== undefined ? { preselectKey } : {}),
+    selectItem: (items, selectOpts) => clackSelectItem(items, selectOpts.initialKey),
+    openItem: open,
+    createTailScope: () => createTailScope({ debounceMs: ESC_DEBOUNCE_MS }),
+    onEmpty: () => ({
+      ok: false,
+      exitCode: 1,
+      reason: `No sessions found in ${sessionsDir}/.\nStart a session with \`typeclaw tui\` or send a message from a configured channel.`,
+    }),
+  })
+
+  if (!result.ok && result.reason !== undefined) {
+    process.stderr.write(`${errorLine(result.reason)}\n`)
+  }
+  return result.exitCode
+}
+
+function finish(result: { ok: boolean; exitCode: number; reason?: string }): void {
+  if (!result.ok && result.reason !== undefined) {
+    process.stderr.write(`${errorLine(result.reason)}\n`)
+  }
+  process.exit(result.exitCode)
+}
+
+async function resolveTuiUrl(cwd: string): Promise<string> {
+  const precheck = await requireContainerRunning({ cwd })
+  if (!precheck.ok) throw new Error(precheck.reason)
+  const port = await resolveHostPort({ cwd })
+  const token = await resolveTuiToken({ cwd })
+  const url = new URL(`ws://127.0.0.1:${port}`)
+  if (token !== null) url.searchParams.set('token', token)
+  return url.toString()
+}
+
+async function buildLiveSource(cwd: string): Promise<LiveSourceFactory | undefined> {
   const port = await resolveHostPort({ cwd })
   const token = await resolveTuiToken({ cwd })
   const baseUrl = new URL(`ws://127.0.0.1:${port}/inspect`)
@@ -94,7 +232,7 @@ async function buildLiveSource(cwd: string): Promise<LiveSourceFactory | undefin
 }
 
 function escHintLine(color: boolean): string {
-  const text = '(esc to return to session list · q to quit)'
+  const text = '(esc to return to the list · q to quit)'
   return color ? `\u001b[2m${text}\u001b[0m` : text
 }
 
@@ -105,7 +243,29 @@ function useColor(): boolean {
   return Boolean(process.stdout.isTTY)
 }
 
-async function clackSelect(
+async function clackSelectItem(items: ViewerItem[], initialKey: string | undefined): Promise<ViewerItem | null> {
+  const { select } = await import('@clack/prompts')
+  prepareStdinForClack()
+  const keyOf = (item: ViewerItem): string => (item.kind === 'logs' ? 'logs' : item.summary.sessionId)
+  const preferred =
+    initialKey !== undefined && items.some((i) => keyOf(i) === initialKey) ? initialKey : keyOf(items[0]!)
+  const picked = await select<string>({
+    message: `Pick what to view (showing ${items.length})`,
+    options: items.map((item) => ({
+      value: keyOf(item),
+      label: itemLabel(item),
+      ...itemHint(item),
+    })),
+    initialValue: preferred,
+  })
+  if (isCancel(picked)) {
+    cancel('Cancelled.')
+    return null
+  }
+  return items.find((i) => keyOf(i) === picked) ?? null
+}
+
+async function clackSelectSession(
   sessions: SessionSummary[],
   initialSessionId: string | undefined,
 ): Promise<SessionSummary | null> {
@@ -119,7 +279,7 @@ async function clackSelect(
     message: `Pick a session to inspect (showing ${sessions.length})`,
     options: sessions.map((s) => ({
       value: s.sessionId,
-      label: formatRowLabel(s),
+      label: sessionRowLabel(s),
       ...(s.firstPrompt !== null ? { hint: truncate(s.firstPrompt, 60) } : { hint: '(no prompt)' }),
     })),
     initialValue: preferred,
@@ -131,7 +291,20 @@ async function clackSelect(
   return sessions.find((s) => s.sessionId === picked) ?? null
 }
 
-function formatRowLabel(s: SessionSummary): string {
+function itemLabel(item: ViewerItem): string {
+  if (item.kind === 'logs') return `${c.dim('▤')} container logs`
+  if (item.kind === 'tui') return `${c.green('●')} ${c.bold('live TUI')}  ${sessionRowLabel(item.summary)}`
+  return `${c.dim('○')} ${sessionRowLabel(item.summary)}`
+}
+
+function itemHint(item: ViewerItem): { hint: string } {
+  if (item.kind === 'logs') return { hint: 'read-only · works offline' }
+  if (item.kind === 'tui') return { hint: 'read+write · esc detaches and ends the live session' }
+  if (item.summary.firstPrompt !== null) return { hint: truncate(item.summary.firstPrompt, 60) }
+  return { hint: '(no prompt)' }
+}
+
+function sessionRowLabel(s: SessionSummary): string {
   const id = shortSessionId(s.sessionId)
   const label = s.origin === null ? '(unknown origin)' : originLabel(s.origin)
   const when = formatRelative(s.mtimeMs)

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -172,12 +172,15 @@ export async function runInspectViewer(opts: RunInspectViewerOptions): Promise<n
     ...(liveHint !== undefined ? { liveHint } : {}),
   })
 
+  const cliAllowWritable = opts.allowWritable !== false
   const result = await runViewerLoop<ViewerItem>({
-    listItems: async () => {
+    listItems: async ({ allowWritable: loopAllowWritable }) => {
       const listOpts: Parameters<typeof listViewerItems>[0] = {
         sessionsDir,
         containerRunning,
-        allowWritable: opts.allowWritable !== false,
+        // Compose the CLI-level permission (false on tui detach handoff) with
+        // the loop-level one (false after returning to the picker from a viewer).
+        allowWritable: cliAllowWritable && loopAllowWritable,
         limit: 20,
         onWarn: stderr,
       }

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -93,6 +93,9 @@ export type RunInspectViewerOptions = {
   filterArg?: string
   sinceArg?: string
   color?: boolean
+  // Set false by the `tui` detach handoff: the live session was just ended, so
+  // no row should be offered as writable (see listViewerItems).
+  allowWritable?: boolean
 }
 
 // The interactive session-viewer: list → open → back to list. Shared by the
@@ -174,6 +177,7 @@ export async function runInspectViewer(opts: RunInspectViewerOptions): Promise<n
       const listOpts: Parameters<typeof listViewerItems>[0] = {
         sessionsDir,
         containerRunning,
+        allowWritable: opts.allowWritable !== false,
         limit: 20,
         onWarn: stderr,
       }

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -3,6 +3,7 @@ import { defineCommand } from 'citty'
 import { logs, parseTailValue } from '@/container'
 import { findAgentDir } from '@/init'
 
+import { runInspectViewer } from './inspect'
 import { c, errorLine } from './ui'
 
 export const logsCommand = defineCommand({
@@ -22,6 +23,11 @@ export const logsCommand = defineCommand({
       alias: 'n',
       description: 'number of lines to show from the end of the logs (non-negative integer or "all")',
     },
+    list: {
+      type: 'boolean',
+      description: 'open the session viewer on the logs entry instead of dumping logs',
+      default: false,
+    },
   },
   async run({ args }) {
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
@@ -34,6 +40,15 @@ export const logsCommand = defineCommand({
         process.exit(2)
       }
       tail = parsed.value
+    }
+
+    // The viewer is strictly opt-in via --list, so the default `typeclaw logs`
+    // (piped, redirected, -f, or a plain TTY dump) keeps the raw `docker logs`
+    // pump that `typeclaw logs | grep` and CI depend on. --list drops into the
+    // session viewer pre-opened on the logs entry, where esc returns to the list.
+    if (args.list) {
+      const exitCode = await runInspectViewer({ cwd, sessionArg: 'logs' })
+      process.exit(exitCode)
     }
 
     if (args.follow) {

--- a/src/cli/tui.ts
+++ b/src/cli/tui.ts
@@ -43,9 +43,11 @@ export const tui = defineCommand({
 
     // Esc detached from the live session: drop into the viewer list so the user
     // can pick another session or the container logs — `tui` is just a deep-link
-    // into the session viewer, pre-opened on the live session.
+    // into the session viewer, pre-opened on the live session. allowWritable
+    // is false because detaching ended the live session, so no row may be
+    // offered as a writable "live TUI" anymore.
     if (result.ok && result.escToPicker === true) {
-      const viewerExit = await runInspectViewer({ cwd })
+      const viewerExit = await runInspectViewer({ cwd, allowWritable: false })
       process.exit(viewerExit)
       return
     }

--- a/src/cli/tui.ts
+++ b/src/cli/tui.ts
@@ -3,14 +3,16 @@ import { defineCommand } from 'citty'
 import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/container'
 import { findAgentDir } from '@/init'
 import { CLI_VERSION } from '@/init/cli-version'
-import { createTui, formatVersionMismatchWarning } from '@/tui'
+import { runTuiViewer } from '@/inspect'
+import { formatVersionMismatchWarning } from '@/tui'
 
+import { runInspectViewer } from './inspect'
 import { errorLine } from './ui'
 
 export const tui = defineCommand({
   meta: {
     name: 'tui',
-    description: 'start the tui client',
+    description: 'open the live agent session in the read+write viewer (host stage)',
   },
   args: {
     prompt: {
@@ -25,50 +27,40 @@ export const tui = defineCommand({
     },
   },
   async run({ args }) {
-    const resolveUrl: () => Promise<string> = args.url !== undefined ? async () => args.url as string : defaultUrl
+    const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+    const resolveUrl: () => Promise<string> =
+      args.url !== undefined ? async () => args.url as string : () => defaultUrl(cwd)
 
-    let initialPrompt: string | undefined = args.prompt
-    let attempt = 0
-    const RECONNECT_MAX_ATTEMPTS = 30
-    const RECONNECT_BACKOFF_MS = 1_000
+    const result = await runTuiViewer({
+      resolveUrl,
+      ...(args.prompt !== undefined ? { initialPrompt: args.prompt } : {}),
+      expectedVersion: CLI_VERSION,
+      onVersionMismatch: (info) => {
+        process.stderr.write(`${formatVersionMismatchWarning(info)}\n`)
+      },
+      stderr: (line) => process.stderr.write(`${line}\n`),
+    })
 
-    while (true) {
-      const url = await resolveUrl()
-      const tui = createTui({
-        url,
-        ...(initialPrompt !== undefined ? { initialPrompt } : {}),
-        expectedVersion: CLI_VERSION,
-        onVersionMismatch: (info) => {
-          process.stderr.write(`${formatVersionMismatchWarning(info)}\n`)
-        },
-      })
-      const outcome = await tui.run()
-      if (!outcome.lostConnection) return
-      // The TUI lost its WS post-handshake (container restart, network blip,
-      // hostd hiccup). Re-resolve the URL because the host port can change
-      // across container lifecycles (see resolveHostPort), then reconnect.
-      // The initial prompt is intentionally cleared after the first cycle:
-      // on a reconnect, the agent is resuming the same session — replaying
-      // the prompt would re-send it to the LLM.
-      initialPrompt = undefined
-      attempt += 1
-      if (attempt > RECONNECT_MAX_ATTEMPTS) {
-        console.error(errorLine(`disconnected; gave up after ${RECONNECT_MAX_ATTEMPTS} reconnect attempts`))
-        process.exit(1)
-      }
-      process.stderr.write(`reconnecting (attempt ${attempt}/${RECONNECT_MAX_ATTEMPTS})...\n`)
-      await new Promise((resolve) => setTimeout(resolve, RECONNECT_BACKOFF_MS))
+    // Esc detached from the live session: drop into the viewer list so the user
+    // can pick another session or the container logs — `tui` is just a deep-link
+    // into the session viewer, pre-opened on the live session.
+    if (result.ok && result.escToPicker === true) {
+      const viewerExit = await runInspectViewer({ cwd })
+      process.exit(viewerExit)
+      return
     }
+
+    if (!result.ok) {
+      process.stderr.write(`${errorLine(result.reason)}\n`)
+      process.exit(result.exitCode)
+    }
+    process.exit(result.exitCode)
   },
 })
 
-async function defaultUrl(): Promise<string> {
-  const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+async function defaultUrl(cwd: string): Promise<string> {
   const precheck = await requireContainerRunning({ cwd })
-  if (!precheck.ok) {
-    console.error(errorLine(precheck.reason))
-    process.exit(1)
-  }
+  if (!precheck.ok) throw new Error(precheck.reason)
   const port = await resolveHostPort({ cwd })
   const token = await resolveTuiToken({ cwd })
   const url = new URL(`ws://127.0.0.1:${port}`)

--- a/src/compose/logs.ts
+++ b/src/compose/logs.ts
@@ -100,7 +100,7 @@ export async function composeLogs({
       follow,
       ...(tail !== undefined ? { tail } : {}),
     })
-    const proc = bun.spawn({ cmd, stdout: 'pipe', stderr: 'pipe' })
+    const proc = bun.spawn({ cmd, stdin: 'ignore', stdout: 'pipe', stderr: 'pipe' })
     return { agent, proc }
   })
 

--- a/src/container/logs.test.ts
+++ b/src/container/logs.test.ts
@@ -164,6 +164,41 @@ describe('pumpWithTimestamps', () => {
 
     expect(chunks.join('')).toBe(`${expectedStamp} partial\n`)
   })
+
+  test('resolves when the signal aborts mid-read on a never-ending stream (the esc-in-logs freeze)', async () => {
+    // A `docker logs -f` stream that never emits or closes: without abort-aware
+    // reading, pumpWithTimestamps would hang forever and esc could not escape.
+    let cancelled = false
+    const stream = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true
+      },
+    })
+    const sink = { write: (): boolean => true } as unknown as NodeJS.WritableStream
+    const ctrl = new AbortController()
+
+    const pump = pumpWithTimestamps(stream, sink, makeLogTimestampReformatter(), ctrl.signal)
+    queueMicrotask(() => ctrl.abort())
+
+    // then it resolves (does not hang) and the reader was cancelled
+    await pump
+    expect(cancelled).toBe(true)
+  })
+
+  test('returns immediately when the signal is already aborted', async () => {
+    let cancelled = false
+    const stream = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true
+      },
+    })
+    const sink = { write: (): boolean => true } as unknown as NodeJS.WritableStream
+    const ctrl = new AbortController()
+    ctrl.abort()
+
+    await pumpWithTimestamps(stream, sink, makeLogTimestampReformatter(), ctrl.signal)
+    expect(cancelled).toBe(true)
+  })
 })
 
 function formatLocal(d: Date): string {

--- a/src/container/logs.ts
+++ b/src/container/logs.ts
@@ -44,27 +44,48 @@ export async function logs({
       return { ok: false, reason: `Container ${plan.containerName} not found. Run \`typeclaw start\` first.` }
     }
 
-    const proc = bun.spawn({ cmd: buildDockerLogsCmd(plan), cwd, stdout: 'pipe', stderr: 'pipe' })
+    // stdin:'ignore' — `docker logs` never reads stdin, and letting the child
+    // hold the TTY breaks the viewer's raw-mode keypress listener (esc/q/ctrl-c
+    // stop reaching it, freezing the logs view with no way out).
+    const proc = bun.spawn({ cmd: buildDockerLogsCmd(plan), cwd, stdin: 'ignore', stdout: 'pipe', stderr: 'pipe' })
 
+    // `docker logs -f` never exits on its own; aborting the signal must kill it
+    // so the pumps' stream readers end. Escalate to SIGKILL if SIGTERM is
+    // ignored, otherwise Promise.all(pumps) could hang until the pipes close.
+    let killTimer: ReturnType<typeof setTimeout> | undefined
     const onAbort = (): void => {
       try {
         proc.kill('SIGTERM')
+        killTimer = setTimeout(() => {
+          try {
+            proc.kill('SIGKILL')
+          } catch {
+            // already exited
+          }
+        }, 2_000)
       } catch {
         // already exited
       }
     }
     signal?.addEventListener('abort', onAbort, { once: true })
+    // The signal may already be aborted before we attached the listener (esc
+    // pressed during container existence check); addEventListener would then
+    // never fire, leaving docker logs -f running forever.
+    if (signal?.aborted === true) onAbort()
 
-    const colorOut = useColor ?? supportsColor(out)
-    const colorErr = useColor ?? supportsColor(err)
-    await Promise.all([
-      pumpWithTimestamps(proc.stdout, out, makeLogTimestampReformatter(undefined, { color: colorOut })),
-      pumpWithTimestamps(proc.stderr, err, makeLogTimestampReformatter(undefined, { color: colorErr })),
-    ])
-    const exitCode = await proc.exited
-    signal?.removeEventListener('abort', onAbort)
-
-    return { ok: true, containerName: plan.containerName, exitCode }
+    try {
+      const colorOut = useColor ?? supportsColor(out)
+      const colorErr = useColor ?? supportsColor(err)
+      await Promise.all([
+        pumpWithTimestamps(proc.stdout, out, makeLogTimestampReformatter(undefined, { color: colorOut })),
+        pumpWithTimestamps(proc.stderr, err, makeLogTimestampReformatter(undefined, { color: colorErr })),
+      ])
+      const exitCode = await proc.exited
+      return { ok: true, containerName: plan.containerName, exitCode }
+    } finally {
+      if (killTimer !== undefined) clearTimeout(killTimer)
+      signal?.removeEventListener('abort', onAbort)
+    }
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
   }

--- a/src/container/logs.ts
+++ b/src/container/logs.ts
@@ -77,8 +77,8 @@ export async function logs({
       const colorOut = useColor ?? supportsColor(out)
       const colorErr = useColor ?? supportsColor(err)
       await Promise.all([
-        pumpWithTimestamps(proc.stdout, out, makeLogTimestampReformatter(undefined, { color: colorOut })),
-        pumpWithTimestamps(proc.stderr, err, makeLogTimestampReformatter(undefined, { color: colorErr })),
+        pumpWithTimestamps(proc.stdout, out, makeLogTimestampReformatter(undefined, { color: colorOut }), signal),
+        pumpWithTimestamps(proc.stderr, err, makeLogTimestampReformatter(undefined, { color: colorErr }), signal),
       ])
       const exitCode = await proc.exited
       return { ok: true, containerName: plan.containerName, exitCode }
@@ -122,30 +122,57 @@ export function buildDockerLogsCmd(plan: LogsPlan): string[] {
 
 // Exported for `compose/logs.ts` so the multi-agent path reuses the same
 // reformatter and stays consistent with single-agent output.
+//
+// Abort handling is load-bearing for the interactive logs viewer: killing
+// `docker logs -f` does NOT reliably make Bun's pending `reader.read()` resolve
+// (the killed child may not promptly EOF its piped stdout — see the OrbStack
+// /proc quirk). Without cancelling the reader on abort, esc would hang forever.
+// So on abort we cancel the reader, which unblocks the pending read; the caller
+// still kills the process for OS-side cleanup.
 export async function pumpWithTimestamps(
   stream: ReadableStream<Uint8Array>,
   sink: NodeJS.WritableStream,
   reformatter: TimestampReformatter = makeLogTimestampReformatter(),
+  signal?: AbortSignal,
 ): Promise<void> {
   const decoder = new TextDecoder()
   const reader = stream.getReader()
+  let aborted = signal?.aborted === true
+  const onAbort = (): void => {
+    aborted = true
+    void reader.cancel().catch(() => {})
+  }
+  if (aborted) onAbort()
+  else signal?.addEventListener('abort', onAbort, { once: true })
+
   try {
     while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
-      if (value && value.byteLength > 0) {
-        const out = reformatter.write(decoder.decode(value, { stream: true }))
+      if (aborted) break
+      const chunk = await reader.read().catch((error: unknown) => {
+        if (aborted || signal?.aborted === true) return null
+        throw error
+      })
+      if (chunk === null || chunk.done || aborted) break
+      if (chunk.value && chunk.value.byteLength > 0) {
+        const out = reformatter.write(decoder.decode(chunk.value, { stream: true }))
         if (out.length > 0) sink.write(out)
       }
     }
-    const tail = decoder.decode()
-    if (tail.length > 0) {
-      const out = reformatter.write(tail)
-      if (out.length > 0) sink.write(out)
+    if (!aborted) {
+      const tail = decoder.decode()
+      if (tail.length > 0) {
+        const out = reformatter.write(tail)
+        if (out.length > 0) sink.write(out)
+      }
+      const flushed = reformatter.flush()
+      if (flushed.length > 0) sink.write(flushed)
     }
-    const flushed = reformatter.flush()
-    if (flushed.length > 0) sink.write(flushed)
   } finally {
-    reader.releaseLock()
+    signal?.removeEventListener('abort', onAbort)
+    try {
+      reader.releaseLock()
+    } catch {
+      // harmless if cancel/abort raced with stream teardown
+    }
   }
 }

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1975,7 +1975,7 @@ describe('defaultRunHatching', () => {
   // care about is "did it pass cliEntry through to start()", and the rest of
   // the function (waitForAgent + TUI) just needs to not blow up.
   const fakeTui: typeof import('@/tui').createTui = () =>
-    ({ run: async () => ({ lostConnection: false }) }) as ReturnType<typeof import('@/tui').createTui>
+    ({ run: async () => ({ reason: 'exit', exitCode: 0 }) }) as ReturnType<typeof import('@/tui').createTui>
   const fakeWaitForAgent = async () => {}
 
   test('forwards cliEntry to start() when provided', async () => {
@@ -2032,7 +2032,7 @@ describe('defaultRunHatching', () => {
     const calls: Parameters<typeof import('@/tui').createTui>[0][] = []
     const fn: typeof import('@/tui').createTui = (options) => {
       calls.push(options)
-      return { run: async () => ({ lostConnection: false }) } as ReturnType<typeof import('@/tui').createTui>
+      return { run: async () => ({ reason: 'exit', exitCode: 0 }) } as ReturnType<typeof import('@/tui').createTui>
     }
     return { fn, calls }
   }

--- a/src/inspect/index.test.ts
+++ b/src/inspect/index.test.ts
@@ -380,6 +380,29 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
     if (!result.ok) throw new Error('unreachable')
     expect(result.escToPicker).toBeFalsy()
   })
+
+  test('replay-only interactive prints the end-of-transcript footer exactly once', async () => {
+    // Regression: the streamSessionEvents refactor briefly printed the footer
+    // twice (at replay-only-idle AND at end) when the interactive viewer aborted.
+    await seedSession(`a_${ID_LIVET}.jsonl`, [metaLine({ kind: 'tui' }), userLine('hi')], 1000)
+    const ctrl = new AbortController()
+    const sink = captureSink()
+    // Abort AFTER replay finishes and the viewer is parked in the idle wait, so
+    // the footer is reached (aborting during replay would skip it entirely).
+    setTimeout(() => ctrl.abort(), 30)
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: ID_LIVET,
+      color: false,
+      interactive: true,
+      selectSession: neverPick,
+      signal: ctrl.signal,
+      ...sink.push,
+    })
+    expect(result.ok).toBe(true)
+    const footers = sink.out.filter((l) => l.includes('end of transcript'))
+    expect(footers).toHaveLength(1)
+  })
 })
 
 describe('runInspect — picker path', () => {

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -34,6 +34,8 @@ export type { OpenViewerDeps } from './open-item'
 export { runTuiViewer } from './tui-item'
 export type { RunTuiViewerOptions } from './tui-item'
 export { streamLogs } from './logs-item'
+export { createTranscriptView } from './transcript-view'
+export type { TranscriptViewOptions, TranscriptViewOutcome } from './transcript-view'
 
 export type RunInspectOptions = {
   agentDir: string

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -180,51 +180,58 @@ async function chooseSession(
   return { ok: true, summary: picked }
 }
 
-async function streamSession(opts: {
+// Lifecycle phases surfaced to a consumer so renderers can react (e.g. batch a
+// pi-tui render at replay-end, announce a live divider). `sessionLive` on
+// 'live-start' is the registry hit/miss from the live source's onSubscribed.
+export type StreamPhase =
+  | { phase: 'replay-end' }
+  | { phase: 'replay-only-idle' }
+  | { phase: 'live-start'; sessionLive: boolean }
+  | { phase: 'end' }
+
+export type StreamSessionEventsOptions = {
   summary: SessionSummary
   filter: InspectFilter
   sinceMs: number | undefined
-  json: boolean
-  color: boolean
-  stdout: (line: string) => void
-  stderr: (line: string) => void
+  onEvent: (event: InspectEvent) => void
+  onPhase?: (phase: StreamPhase) => void
+  onWarn?: (msg: string) => void
   liveSource?: LiveSourceFactory
   signal?: AbortSignal
-  liveHint?: string
-  interactive?: boolean
-}): Promise<{ escToPicker: boolean }> {
-  if (!opts.json) writeHeader(opts.summary, opts.color, opts.stdout)
-  const emit = (event: InspectEvent): void => {
+  // When true and replay-only with a signal, block until aborted instead of
+  // returning immediately — a stable interactive viewer that esc/q dismisses.
+  blockWhenReplayOnly?: boolean
+}
+
+// The read path shared by the line renderer and the pi-tui transcript view:
+// replay the JSONL transcript, then optionally live-tail, applying since/filter
+// and honoring signal.aborted (-> escToPicker). Knows nothing about rendering —
+// it just delivers ordered, filtered InspectEvents to onEvent and announces
+// phase transitions via onPhase.
+export async function streamSessionEvents(opts: StreamSessionEventsOptions): Promise<{ escToPicker: boolean }> {
+  const aborted = (): boolean => opts.signal?.aborted === true
+  const deliver = (event: InspectEvent): void => {
     if (opts.sinceMs !== undefined && event.ts > 0 && event.ts < opts.sinceMs) return
     if (!matchesFilter(event, opts.filter)) return
-    if (opts.json) {
-      opts.stdout(JSON.stringify({ sessionId: opts.summary.sessionId, ...event }))
-    } else {
-      opts.stdout(renderEvent(event, { color: opts.color }))
-    }
+    opts.onEvent(event)
   }
 
-  const aborted = (): boolean => opts.signal?.aborted === true
-
-  for await (const event of replayJsonl(opts.summary.sessionFile, { onWarn: opts.stderr })) {
+  for await (const event of replayJsonl(
+    opts.summary.sessionFile,
+    opts.onWarn !== undefined ? { onWarn: opts.onWarn } : {},
+  )) {
     if (aborted()) return { escToPicker: true }
-    emit(event)
+    deliver(event)
   }
+  opts.onPhase?.({ phase: 'replay-end' })
 
   if (opts.liveSource === undefined) {
-    if (!opts.json) opts.stdout('─── end of transcript ───')
-    // Already aborted during replay (user pressed esc/q): honor it, don't lose the keystroke.
     if (aborted()) return { escToPicker: true }
-    // Interactive replay-only: hold a stable viewer like `dreams` instead of
-    // bouncing straight back to the picker. Block until the tail scope aborts
-    // (esc → back, q/ctrl-c → exit). Never block without a signal (non-TTY has
-    // no listener and would hang) or in json/non-interactive mode (scriptability).
-    if (opts.interactive === true && !opts.json && opts.signal !== undefined) {
-      if (opts.liveHint !== undefined && opts.liveHint !== '') {
-        opts.stdout(divider(opts.color, opts.liveHint))
-      }
+    if (opts.blockWhenReplayOnly === true && opts.signal !== undefined) {
+      opts.onPhase?.({ phase: 'replay-only-idle' })
       await waitForAbort(opts.signal)
     }
+    opts.onPhase?.({ phase: 'end' })
     return { escToPicker: aborted() }
   }
 
@@ -243,22 +250,83 @@ async function streamSession(opts: {
   let liveAnnounced = false
   try {
     for await (const event of liveIter) {
-      if (!liveAnnounced && !opts.json) {
-        opts.stdout(
-          divider(opts.color, sessionLive ? '─── live ───' : '─── live (session not in registry; broadcasts only) ───'),
-        )
-        if (opts.liveHint !== undefined && opts.liveHint !== '') {
-          opts.stdout(divider(opts.color, opts.liveHint))
-        }
+      if (!liveAnnounced) {
+        opts.onPhase?.({ phase: 'live-start', sessionLive })
         liveAnnounced = true
       }
-      emit(event)
+      deliver(event)
     }
   } catch (err) {
-    opts.stderr(`live tail ended: ${err instanceof Error ? err.message : String(err)}`)
+    opts.onWarn?.(`live tail ended: ${err instanceof Error ? err.message : String(err)}`)
   }
-  if (!opts.json) opts.stdout('─── end of transcript ───')
+  opts.onPhase?.({ phase: 'end' })
   return { escToPicker: aborted() }
+}
+
+// Line/JSON renderer: the original streamSession behavior, now expressed as a
+// streamSessionEvents consumer. Preserves the exact header/divider output and
+// scriptable stdout/JSON contract.
+async function streamSession(opts: {
+  summary: SessionSummary
+  filter: InspectFilter
+  sinceMs: number | undefined
+  json: boolean
+  color: boolean
+  stdout: (line: string) => void
+  stderr: (line: string) => void
+  liveSource?: LiveSourceFactory
+  signal?: AbortSignal
+  liveHint?: string
+  interactive?: boolean
+}): Promise<{ escToPicker: boolean }> {
+  if (!opts.json) writeHeader(opts.summary, opts.color, opts.stdout)
+
+  const onEvent = (event: InspectEvent): void => {
+    if (opts.json) opts.stdout(JSON.stringify({ sessionId: opts.summary.sessionId, ...event }))
+    else opts.stdout(renderEvent(event, { color: opts.color }))
+  }
+
+  const emitHint = (): void => {
+    if (!opts.json && opts.liveHint !== undefined && opts.liveHint !== '') {
+      opts.stdout(divider(opts.color, opts.liveHint))
+    }
+  }
+
+  // Replay-only prints the end-of-transcript footer once at the idle point (the
+  // viewer then blocks); the terminal 'end' phase must not print it a second
+  // time. Live mode skips the idle phase and prints the footer only at 'end'.
+  let footerPrinted = false
+  const printFooter = (): void => {
+    opts.stdout('─── end of transcript ───')
+    footerPrinted = true
+  }
+
+  const onPhase = (p: StreamPhase): void => {
+    if (opts.json) return
+    if (p.phase === 'replay-only-idle') {
+      printFooter()
+      emitHint()
+    } else if (p.phase === 'live-start') {
+      opts.stdout(
+        divider(opts.color, p.sessionLive ? '─── live ───' : '─── live (session not in registry; broadcasts only) ───'),
+      )
+      emitHint()
+    } else if (p.phase === 'end' && !footerPrinted) {
+      printFooter()
+    }
+  }
+
+  return streamSessionEvents({
+    summary: opts.summary,
+    filter: opts.filter,
+    sinceMs: opts.sinceMs,
+    onEvent,
+    onPhase,
+    onWarn: opts.stderr,
+    ...(opts.liveSource !== undefined ? { liveSource: opts.liveSource } : {}),
+    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+    blockWhenReplayOnly: opts.interactive === true && !opts.json,
+  })
 }
 
 function divider(color: boolean, text: string): string {

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -16,8 +16,24 @@ export { replayJsonl } from './replay'
 export { streamLive } from './live'
 export { parseDuration, parseFilter } from './types'
 export type { InspectCategory, InspectEvent, InspectFilter } from './types'
-export { runInspectLoop } from './loop'
-export type { RunInspectLoopOptions } from './loop'
+export { runInspectLoop, runViewerLoop } from './loop'
+export type {
+  OpenItem,
+  OpenItemContext,
+  RunInspectLoopOptions,
+  RunViewerLoopOptions,
+  SelectItem,
+  TailController,
+} from './loop'
+export type { ViewerItem } from './item'
+export { isWritable, itemKey } from './item'
+export { listViewerItems } from './item-list'
+export type { ListViewerItemsOptions, ViewerList } from './item-list'
+export { openViewerItem } from './open-item'
+export type { OpenViewerDeps } from './open-item'
+export { runTuiViewer } from './tui-item'
+export type { RunTuiViewerOptions } from './tui-item'
+export { streamLogs } from './logs-item'
 
 export type RunInspectOptions = {
   agentDir: string
@@ -51,7 +67,7 @@ export type LiveSourceFactory = (opts: {
 }) => AsyncIterable<InspectEvent>
 
 export type RunInspectResult =
-  | { ok: true; exitCode: 0; escToPicker?: boolean }
+  | { ok: true; exitCode: number; escToPicker?: boolean }
   | { ok: false; exitCode: number; reason: string }
 
 export type InspectTarget = {

--- a/src/inspect/item-list.test.ts
+++ b/src/inspect/item-list.test.ts
@@ -64,6 +64,21 @@ describe('listViewerItems', () => {
     expect(items.filter((i) => i.kind === 'session')).toHaveLength(2)
   })
 
+  test('allowWritable:false suppresses the writable row even with the container up (detach handoff)', async () => {
+    await seed(`a_${ID_A}.jsonl`, { kind: 'tui' }, 1000)
+    await seed(`b_${ID_B}.jsonl`, { kind: 'tui' }, 3000)
+
+    const { items, writableSessionId } = await listViewerItems({
+      sessionsDir,
+      containerRunning: true,
+      allowWritable: false,
+    })
+
+    expect(writableSessionId).toBeNull()
+    expect(items.filter((i) => i.kind === 'tui')).toHaveLength(0)
+    expect(items.filter((i) => i.kind === 'session')).toHaveLength(2)
+  })
+
   test('appends a logs row by default, suppressible via includeLogs:false', async () => {
     await seed(`a_${ID_A}.jsonl`, { kind: 'tui' }, 1000)
 

--- a/src/inspect/item-list.test.ts
+++ b/src/inspect/item-list.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { listViewerItems } from './item-list'
+
+let agentDir: string
+let sessionsDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-item-list-'))
+  sessionsDir = join(agentDir, 'sessions')
+  await mkdir(sessionsDir, { recursive: true })
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+const ID_A = '019ee000-aaaa-7000-9000-00000000aaaa'
+const ID_B = '019ee000-bbbb-7000-9000-00000000bbbb'
+const ID_C = '019ee000-cccc-7000-9000-00000000cccc'
+
+function metaLine(origin: unknown): string {
+  return JSON.stringify({
+    type: 'custom',
+    customType: 'typeclaw.session-meta',
+    data: { origin },
+    timestamp: 1_000_000,
+  })
+}
+
+async function seed(basename: string, origin: unknown, mtimeSeconds: number): Promise<void> {
+  const path = join(sessionsDir, basename)
+  await writeFile(path, metaLine(origin) + '\n')
+  await utimes(path, mtimeSeconds, mtimeSeconds)
+}
+
+describe('listViewerItems', () => {
+  test('marks the most-recent tui-origin session as the single writable item when container is up', async () => {
+    await seed(`a_${ID_A}.jsonl`, { kind: 'tui' }, 1000)
+    await seed(`b_${ID_B}.jsonl`, { kind: 'tui' }, 3000)
+    await seed(`c_${ID_C}.jsonl`, { kind: 'cron', jobId: 'j', jobKind: 'prompt' }, 2000)
+
+    const { items, writableSessionId } = await listViewerItems({ sessionsDir, containerRunning: true })
+
+    expect(writableSessionId).toBe(ID_B)
+    const writable = items.filter((i) => i.kind === 'tui')
+    expect(writable).toHaveLength(1)
+    expect(writable[0]).toMatchObject({ kind: 'tui', writable: true })
+    const cronItem = items.find((i) => i.kind === 'session' && i.summary.sessionId === ID_C)
+    expect(cronItem).toBeDefined()
+  })
+
+  test('all sessions are read-only when the container is down', async () => {
+    await seed(`a_${ID_A}.jsonl`, { kind: 'tui' }, 1000)
+    await seed(`b_${ID_B}.jsonl`, { kind: 'tui' }, 2000)
+
+    const { items, writableSessionId } = await listViewerItems({ sessionsDir, containerRunning: false })
+
+    expect(writableSessionId).toBeNull()
+    expect(items.filter((i) => i.kind === 'tui')).toHaveLength(0)
+    expect(items.filter((i) => i.kind === 'session')).toHaveLength(2)
+  })
+
+  test('appends a logs row by default, suppressible via includeLogs:false', async () => {
+    await seed(`a_${ID_A}.jsonl`, { kind: 'tui' }, 1000)
+
+    const withLogs = await listViewerItems({ sessionsDir, containerRunning: true })
+    expect(withLogs.items.at(-1)).toEqual({ kind: 'logs' })
+
+    const withoutLogs = await listViewerItems({ sessionsDir, containerRunning: true, includeLogs: false })
+    expect(withoutLogs.items.some((i) => i.kind === 'logs')).toBe(false)
+  })
+
+  test('no writable item when container is up but no tui-origin session exists', async () => {
+    await seed(`c_${ID_C}.jsonl`, { kind: 'cron', jobId: 'j', jobKind: 'prompt' }, 2000)
+
+    const { writableSessionId, items } = await listViewerItems({ sessionsDir, containerRunning: true })
+
+    expect(writableSessionId).toBeNull()
+    expect(items.filter((i) => i.kind === 'tui')).toHaveLength(0)
+  })
+})

--- a/src/inspect/item-list.ts
+++ b/src/inspect/item-list.ts
@@ -4,6 +4,11 @@ import { listSessions, type ListSessionsOptions, type SessionSummary } from './s
 export type ListViewerItemsOptions = ListSessionsOptions & {
   containerRunning: boolean
   includeLogs?: boolean
+  // Defaults to true. The detach-to-list path (after `typeclaw tui` esc) sets
+  // this false: detaching ENDS the server-side session, so the just-killed
+  // (most-recent) tui transcript — and any older tui transcript the heuristic
+  // would otherwise promote — must NOT be offered as a writable live row.
+  allowWritable?: boolean
 }
 
 export type ViewerList = {
@@ -19,7 +24,8 @@ export type ViewerList = {
 // available offline) so it sits below the divider in the picker.
 export async function listViewerItems(opts: ListViewerItemsOptions): Promise<ViewerList> {
   const sessions = await listSessions(opts)
-  const writableSessionId = opts.containerRunning ? pickWritableSession(sessions) : null
+  const allowWritable = opts.allowWritable !== false
+  const writableSessionId = opts.containerRunning && allowWritable ? pickWritableSession(sessions) : null
 
   const items: ViewerItem[] = sessions.map((summary) =>
     summary.sessionId === writableSessionId

--- a/src/inspect/item-list.ts
+++ b/src/inspect/item-list.ts
@@ -1,0 +1,38 @@
+import type { ViewerItem } from './item'
+import { listSessions, type ListSessionsOptions, type SessionSummary } from './session-list'
+
+export type ListViewerItemsOptions = ListSessionsOptions & {
+  containerRunning: boolean
+  includeLogs?: boolean
+}
+
+export type ViewerList = {
+  items: ViewerItem[]
+  writableSessionId: string | null
+}
+
+// Builds the session-viewer list. The writable TUI row is a heuristic, not an
+// authoritative query: when the container is up, the single most-recent
+// tui-origin session becomes the read+write `tui` item; every other session is
+// read-only. With the container down there is no live session to drive, so all
+// sessions are read-only. The `logs` row is appended last (container stdout,
+// available offline) so it sits below the divider in the picker.
+export async function listViewerItems(opts: ListViewerItemsOptions): Promise<ViewerList> {
+  const sessions = await listSessions(opts)
+  const writableSessionId = opts.containerRunning ? pickWritableSession(sessions) : null
+
+  const items: ViewerItem[] = sessions.map((summary) =>
+    summary.sessionId === writableSessionId
+      ? { kind: 'tui', summary, writable: true }
+      : { kind: 'session', summary, writable: false },
+  )
+
+  if (opts.includeLogs !== false) items.push({ kind: 'logs' })
+
+  return { items, writableSessionId }
+}
+
+function pickWritableSession(sessions: SessionSummary[]): string | null {
+  const tuiSession = sessions.find((s) => s.origin?.kind === 'tui')
+  return tuiSession?.sessionId ?? null
+}

--- a/src/inspect/item.test.ts
+++ b/src/inspect/item.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+
+import { isWritable, itemKey, type ViewerItem } from './item'
+
+const summary = {
+  sessionId: 'sid-1',
+  sessionFile: '/x/sid-1.jsonl',
+  basename: 'sid-1.jsonl',
+  mtimeMs: 1,
+  origin: { kind: 'tui' as const },
+  firstPrompt: null,
+}
+
+describe('ViewerItem helpers', () => {
+  test('isWritable is true only for the tui item', () => {
+    expect(isWritable({ kind: 'tui', summary, writable: true })).toBe(true)
+    expect(isWritable({ kind: 'session', summary, writable: false })).toBe(false)
+    expect(isWritable({ kind: 'logs' })).toBe(false)
+  })
+
+  test('itemKey returns the session id for sessions and a stable key for logs', () => {
+    const tui: ViewerItem = { kind: 'tui', summary, writable: true }
+    const session: ViewerItem = { kind: 'session', summary, writable: false }
+    expect(itemKey(tui)).toBe('sid-1')
+    expect(itemKey(session)).toBe('sid-1')
+    expect(itemKey({ kind: 'logs' })).toBe('logs')
+  })
+})

--- a/src/inspect/item.ts
+++ b/src/inspect/item.ts
@@ -1,0 +1,17 @@
+import type { SessionSummary } from './session-list'
+
+// At most one item is `writable` (the live TUI session); every other session is
+// read-only. `logs` carries no session — it is container stdout, available even
+// when the agent server is down.
+export type ViewerItem =
+  | { kind: 'session'; summary: SessionSummary; writable: false }
+  | { kind: 'tui'; summary: SessionSummary; writable: true }
+  | { kind: 'logs' }
+
+export function isWritable(item: ViewerItem): item is Extract<ViewerItem, { kind: 'tui' }> {
+  return item.kind === 'tui'
+}
+
+export function itemKey(item: ViewerItem): string {
+  return item.kind === 'logs' ? 'logs' : item.summary.sessionId
+}

--- a/src/inspect/label.test.ts
+++ b/src/inspect/label.test.ts
@@ -11,9 +11,9 @@ describe('originLabel', () => {
     expect(originLabel({ kind: 'cron', jobId: 'daily-backup', jobKind: 'prompt' })).toBe('Cron daily-backup (prompt)')
   })
 
-  test('subagent origin includes name and shortened parent id', () => {
+  test('subagent origin shows the subagent name without the redundant parent id', () => {
     expect(originLabel({ kind: 'subagent', subagent: 'memory-logger', parentSessionId: 'ses_abcdef1234567890' })).toBe(
-      'Subagent memory-logger ← ses_abcdef12',
+      'Subagent memory-logger',
     )
   })
 

--- a/src/inspect/label.ts
+++ b/src/inspect/label.ts
@@ -17,7 +17,7 @@ export function originLabel(origin: MinimalSessionOrigin): string {
     case 'cron':
       return `Cron ${origin.jobId} (${origin.jobKind})`
     case 'subagent':
-      return `Subagent ${origin.subagent} ← ${shortSessionId(origin.parentSessionId)}`
+      return `Subagent ${origin.subagent}`
     case 'channel':
       return channelLabel(origin)
     case 'system':

--- a/src/inspect/logs-item.ts
+++ b/src/inspect/logs-item.ts
@@ -1,0 +1,79 @@
+import { logs } from '@/container'
+
+export type StreamLogsOptions = {
+  cwd: string
+  color: boolean
+  stdout: (line: string) => void
+  stderr: (line: string) => void
+  signal?: AbortSignal
+  liveHint?: string
+}
+
+export type StreamLogsResult = { escToPicker: boolean }
+
+// Interactive container-logs viewer for the session-viewer list. Unlike the raw
+// `logs` pump (host-stage, used for `typeclaw logs | grep`), this one runs under
+// the loop's tail scope: aborting the signal (esc/q/ctrl-c) kills `docker logs`
+// and returns control to the picker. Works with the agent server down — it only
+// needs the container to exist.
+export async function streamLogs(opts: StreamLogsOptions): Promise<StreamLogsResult> {
+  const aborted = (): boolean => opts.signal?.aborted === true
+  if (aborted()) return { escToPicker: true }
+
+  opts.stdout(divider(opts.color, '─── container logs ───'))
+  if (opts.liveHint !== undefined && opts.liveHint !== '') {
+    opts.stdout(divider(opts.color, opts.liveHint))
+  }
+
+  const out = lineSink(opts.stdout)
+  const err = lineSink(opts.stderr)
+
+  const result = await logs({
+    cwd: opts.cwd,
+    follow: true,
+    out,
+    err,
+    useColor: opts.color,
+    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+  })
+
+  if (!result.ok) {
+    opts.stderr(result.reason)
+    return { escToPicker: aborted() }
+  }
+  return { escToPicker: aborted() }
+}
+
+function divider(color: boolean, text: string): string {
+  if (color) return `\u001b[2m${text}\u001b[0m`
+  return text
+}
+
+// `logs` writes pre-formatted chunks (already newline-terminated) to a
+// WritableStream; the loop's sink wants newline-free lines. Buffer partial
+// lines and forward complete ones so a chunk split mid-line never emits a
+// truncated row.
+function lineSink(emit: (line: string) => void): NodeJS.WritableStream {
+  let buffer = ''
+  const flushLines = (): void => {
+    let idx = buffer.indexOf('\n')
+    while (idx !== -1) {
+      emit(buffer.slice(0, idx))
+      buffer = buffer.slice(idx + 1)
+      idx = buffer.indexOf('\n')
+    }
+  }
+  return {
+    write(chunk: string | Uint8Array): boolean {
+      buffer += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk)
+      flushLines()
+      return true
+    },
+    end(): void {
+      if (buffer.length > 0) {
+        emit(buffer)
+        buffer = ''
+      }
+    },
+  } as unknown as NodeJS.WritableStream
+}

--- a/src/inspect/loop.ts
+++ b/src/inspect/loop.ts
@@ -12,7 +12,15 @@ export type OpenItemContext = {
 
 export type SelectItem<TItem> = (items: TItem[], opts: { initialKey?: string }) => Promise<TItem | null>
 
-export type OpenItem<TItem> = (item: TItem, ctx: OpenItemContext) => Promise<RunInspectResult>
+export type OpenItemResult = {
+  result: RunInspectResult
+  // True only when the viewer that just closed ended a writable (live TUI)
+  // session — i.e. a tui detach. Logs and read-only transcripts return
+  // escToPicker WITHOUT this, so they must not suppress the writable row.
+  endedWritableSession?: boolean
+}
+
+export type OpenItem<TItem> = (item: TItem, ctx: OpenItemContext) => Promise<OpenItemResult>
 
 export type ListItemsContext = {
   // False once the user has returned to the picker from any viewer: the prior
@@ -62,10 +70,13 @@ export async function runViewerLoop<TItem>(opts: RunViewerLoopOptions<TItem>): P
       lastPickedKey = opts.keyOf(chosen)
     }
 
-    const result = await opts.openItem(chosen, { createTailScope: opts.createTailScope })
+    const opened = await opts.openItem(chosen, { createTailScope: opts.createTailScope })
+    const result = opened.result
     if (!result.ok) return result
     if (result.escToPicker !== true) return result
-    allowWritable = false
+    // Only a writable (tui) detach ends the live session; leaving logs or a
+    // read-only transcript leaves it untouched, so the writable row stays.
+    if (opened.endedWritableSession === true) allowWritable = false
   }
 }
 

--- a/src/inspect/loop.ts
+++ b/src/inspect/loop.ts
@@ -14,8 +14,15 @@ export type SelectItem<TItem> = (items: TItem[], opts: { initialKey?: string }) 
 
 export type OpenItem<TItem> = (item: TItem, ctx: OpenItemContext) => Promise<RunInspectResult>
 
+export type ListItemsContext = {
+  // False once the user has returned to the picker from any viewer: the prior
+  // viewer interaction ended, so there is no proof of a still-live writable
+  // session — a detached tui session must not be re-promoted as writable.
+  allowWritable: boolean
+}
+
 export type RunViewerLoopOptions<TItem> = {
-  listItems: () => Promise<TItem[]>
+  listItems: (ctx: ListItemsContext) => Promise<TItem[]>
   keyOf: (item: TItem) => string
   preselectKey?: string
   selectItem: SelectItem<TItem>
@@ -33,9 +40,14 @@ export type RunViewerLoopOptions<TItem> = {
 export async function runViewerLoop<TItem>(opts: RunViewerLoopOptions<TItem>): Promise<RunInspectResult> {
   let preselectKey = opts.preselectKey
   let lastPickedKey: string | undefined
+  // Writable is only safe on the very first list. Returning to the picker means
+  // a viewer was just opened and left — any writable session it might represent
+  // is gone (detach ends the live session), so subsequent refreshes are
+  // read-only.
+  let allowWritable = true
 
   while (true) {
-    const items = await opts.listItems()
+    const items = await opts.listItems({ allowWritable })
     if (items.length === 0) return opts.onEmpty()
 
     let chosen: TItem | null
@@ -53,6 +65,7 @@ export async function runViewerLoop<TItem>(opts: RunViewerLoopOptions<TItem>): P
     const result = await opts.openItem(chosen, { createTailScope: opts.createTailScope })
     if (!result.ok) return result
     if (result.escToPicker !== true) return result
+    allowWritable = false
   }
 }
 

--- a/src/inspect/loop.ts
+++ b/src/inspect/loop.ts
@@ -6,6 +6,56 @@ export type TailController = {
   dispose: () => void
 }
 
+export type OpenItemContext = {
+  createTailScope: () => TailController
+}
+
+export type SelectItem<TItem> = (items: TItem[], opts: { initialKey?: string }) => Promise<TItem | null>
+
+export type OpenItem<TItem> = (item: TItem, ctx: OpenItemContext) => Promise<RunInspectResult>
+
+export type RunViewerLoopOptions<TItem> = {
+  listItems: () => Promise<TItem[]>
+  keyOf: (item: TItem) => string
+  preselectKey?: string
+  selectItem: SelectItem<TItem>
+  openItem: OpenItem<TItem>
+  createTailScope: () => TailController
+  onEmpty: () => RunInspectResult
+}
+
+// The session-viewer state machine: pick an item → open it → on back, re-open
+// the picker; on exit, return. `openItem` owns the per-branch lifecycle and
+// decides whether to request a tail scope (session/logs do; tui does not, since
+// it owns its own raw-mode terminal). When used, the tail scope is created
+// inside `openItem` AFTER the picker resolves and disposed before the picker
+// re-opens, so clack always owns a clean cooked-mode stdin.
+export async function runViewerLoop<TItem>(opts: RunViewerLoopOptions<TItem>): Promise<RunInspectResult> {
+  let preselectKey = opts.preselectKey
+  let lastPickedKey: string | undefined
+
+  while (true) {
+    const items = await opts.listItems()
+    if (items.length === 0) return opts.onEmpty()
+
+    let chosen: TItem | null
+    if (preselectKey !== undefined) {
+      chosen = items.find((i) => opts.keyOf(i) === preselectKey) ?? null
+      preselectKey = undefined
+      if (chosen === null) return opts.onEmpty()
+    } else {
+      const hint = lastPickedKey
+      chosen = await opts.selectItem(items, hint !== undefined ? { initialKey: hint } : {})
+      if (chosen === null) return { ok: false, exitCode: 130, reason: 'cancelled' }
+      lastPickedKey = opts.keyOf(chosen)
+    }
+
+    const result = await opts.openItem(chosen, { createTailScope: opts.createTailScope })
+    if (!result.ok) return result
+    if (result.escToPicker !== true) return result
+  }
+}
+
 export type RunInspectLoopOptions = Omit<RunInspectOptions, 'signal'> & {
   // Builds a fresh interaction scope for ONE live-tail attempt: a new
   // AbortController plus a temporary raw-mode listener. The loop creates it
@@ -30,12 +80,9 @@ export async function runInspectLoop(opts: RunInspectLoopOptions): Promise<RunIn
     if (sessionArg !== undefined) resolveOpts.sessionIdOrPrefix = sessionArg
     else delete (resolveOpts as { sessionIdOrPrefix?: string }).sessionIdOrPrefix
 
-    // Picker phase: cooked-mode stdin, no tail scope alive.
     const resolved = await resolveInspectTarget(resolveOpts)
     if (!resolved.ok) return resolved
 
-    // Streaming phase: scope owns raw-mode stdin start-to-dispose, never
-    // spanning the picker above or the next iteration's picker below.
     const scope = opts.createTailScope()
     let result: RunInspectResult
     try {

--- a/src/inspect/open-item.ts
+++ b/src/inspect/open-item.ts
@@ -1,5 +1,5 @@
 import type { LiveSourceFactory, RunInspectResult } from './index'
-import { streamInspectTarget } from './index'
+import { createTranscriptView, streamInspectTarget } from './index'
 import type { ViewerItem } from './item'
 import { streamLogs } from './logs-item'
 import type { OpenItemContext, TailController } from './loop'
@@ -22,10 +22,11 @@ export type OpenViewerDeps = {
   onVersionMismatch?: (info: { expected: string; actual: string }) => void
 }
 
-// Dispatches a selected list item to its viewer. session/logs run under the
-// loop's tail scope (raw-mode esc/q/ctrl-c handling owned by the loop); tui
-// runs WITHOUT a tail scope because createTui owns its own raw-mode terminal —
-// two raw-stdin owners would corrupt input.
+// Dispatches a selected list item to its viewer. The tui branch and the
+// interactive read-only transcript view each own their own raw-mode pi-tui
+// terminal, so they run WITHOUT the loop's tail scope (two raw-stdin owners
+// would corrupt input). The line/JSON session path and logs run UNDER the tail
+// scope, which owns the raw-mode esc/q/ctrl-c handling.
 export function openViewerItem(deps: OpenViewerDeps) {
   return async (item: ViewerItem, ctx: OpenItemContext): Promise<RunInspectResult> => {
     if (item.kind === 'tui') {
@@ -35,6 +36,20 @@ export function openViewerItem(deps: OpenViewerDeps) {
         ...(deps.expectedVersion !== undefined ? { expectedVersion: deps.expectedVersion } : {}),
         ...(deps.onVersionMismatch !== undefined ? { onVersionMismatch: deps.onVersionMismatch } : {}),
       })
+    }
+
+    // Interactive-TTY read-only session -> rich pi-tui transcript view. Owns its
+    // own terminal, so it bypasses the tail scope. JSON/non-TTY falls through to
+    // the scriptable line renderer below.
+    if (item.kind === 'session' && deps.interactive && !deps.json) {
+      const view = createTranscriptView({
+        summary: item.summary,
+        filter: deps.filter,
+        sinceMs: deps.sinceMs,
+        ...(deps.liveSource !== undefined ? { liveSource: deps.liveSource } : {}),
+      })
+      const outcome = await view.run()
+      return outcome.reason === 'back' ? { ok: true, exitCode: 0, escToPicker: true } : { ok: true, exitCode: 0 }
     }
 
     const scope = ctx.createTailScope()

--- a/src/inspect/open-item.ts
+++ b/src/inspect/open-item.ts
@@ -2,7 +2,7 @@ import type { LiveSourceFactory, RunInspectResult } from './index'
 import { createTranscriptView, streamInspectTarget } from './index'
 import type { ViewerItem } from './item'
 import { streamLogs } from './logs-item'
-import type { OpenItemContext, TailController } from './loop'
+import type { OpenItemContext, OpenItemResult, TailController } from './loop'
 import { runTuiViewer } from './tui-item'
 import type { InspectFilter } from './types'
 
@@ -28,19 +28,23 @@ export type OpenViewerDeps = {
 // would corrupt input). The line/JSON session path and logs run UNDER the tail
 // scope, which owns the raw-mode esc/q/ctrl-c handling.
 export function openViewerItem(deps: OpenViewerDeps) {
-  return async (item: ViewerItem, ctx: OpenItemContext): Promise<RunInspectResult> => {
+  return async (item: ViewerItem, ctx: OpenItemContext): Promise<OpenItemResult> => {
     if (item.kind === 'tui') {
-      return runTuiViewer({
+      const result = await runTuiViewer({
         resolveUrl: deps.resolveTuiUrl,
         stderr: deps.stderr,
         ...(deps.expectedVersion !== undefined ? { expectedVersion: deps.expectedVersion } : {}),
         ...(deps.onVersionMismatch !== undefined ? { onVersionMismatch: deps.onVersionMismatch } : {}),
       })
+      // Detaching the writable tui viewer ends the live session — the only path
+      // that should suppress the writable row on the next list refresh.
+      return { result, endedWritableSession: result.ok && result.escToPicker === true }
     }
 
     // Interactive-TTY read-only session -> rich pi-tui transcript view. Owns its
     // own terminal, so it bypasses the tail scope. JSON/non-TTY falls through to
-    // the scriptable line renderer below.
+    // the scriptable line renderer below. Read-only: esc does NOT end a live
+    // session, so endedWritableSession stays unset.
     if (item.kind === 'session' && deps.interactive && !deps.json) {
       const view = createTranscriptView({
         summary: item.summary,
@@ -49,13 +53,15 @@ export function openViewerItem(deps: OpenViewerDeps) {
         ...(deps.liveSource !== undefined ? { liveSource: deps.liveSource } : {}),
       })
       const outcome = await view.run()
-      return outcome.reason === 'back' ? { ok: true, exitCode: 0, escToPicker: true } : { ok: true, exitCode: 0 }
+      const result: RunInspectResult =
+        outcome.reason === 'back' ? { ok: true, exitCode: 0, escToPicker: true } : { ok: true, exitCode: 0 }
+      return { result }
     }
 
     const scope = ctx.createTailScope()
     try {
       if (item.kind === 'logs') {
-        const result = await streamLogs({
+        const logsResult = await streamLogs({
           cwd: deps.cwd,
           color: deps.color,
           stdout: deps.stdout,
@@ -63,7 +69,8 @@ export function openViewerItem(deps: OpenViewerDeps) {
           signal: scope.signal,
           ...(deps.liveHint !== undefined ? { liveHint: deps.liveHint } : {}),
         })
-        return toResult(result.escToPicker, scope)
+        // Logs esc does NOT touch the live session — no endedWritableSession.
+        return { result: toResult(logsResult.escToPicker, scope) }
       }
 
       const sessionResult = await streamInspectTarget({
@@ -79,7 +86,7 @@ export function openViewerItem(deps: OpenViewerDeps) {
         ...(deps.interactive ? { interactive: true } : {}),
       })
       const escToPicker = sessionResult.ok && sessionResult.escToPicker === true
-      return toResult(escToPicker, scope)
+      return { result: toResult(escToPicker, scope) }
     } finally {
       scope.dispose()
     }

--- a/src/inspect/open-item.ts
+++ b/src/inspect/open-item.ts
@@ -1,0 +1,78 @@
+import type { LiveSourceFactory, RunInspectResult } from './index'
+import { streamInspectTarget } from './index'
+import type { ViewerItem } from './item'
+import { streamLogs } from './logs-item'
+import type { OpenItemContext, TailController } from './loop'
+import { runTuiViewer } from './tui-item'
+import type { InspectFilter } from './types'
+
+export type OpenViewerDeps = {
+  cwd: string
+  filter: InspectFilter
+  sinceMs: number | undefined
+  json: boolean
+  color: boolean
+  interactive: boolean
+  stdout: (line: string) => void
+  stderr: (line: string) => void
+  liveSource?: LiveSourceFactory
+  liveHint?: string
+  resolveTuiUrl: () => Promise<string>
+  expectedVersion?: string
+  onVersionMismatch?: (info: { expected: string; actual: string }) => void
+}
+
+// Dispatches a selected list item to its viewer. session/logs run under the
+// loop's tail scope (raw-mode esc/q/ctrl-c handling owned by the loop); tui
+// runs WITHOUT a tail scope because createTui owns its own raw-mode terminal —
+// two raw-stdin owners would corrupt input.
+export function openViewerItem(deps: OpenViewerDeps) {
+  return async (item: ViewerItem, ctx: OpenItemContext): Promise<RunInspectResult> => {
+    if (item.kind === 'tui') {
+      return runTuiViewer({
+        resolveUrl: deps.resolveTuiUrl,
+        stderr: deps.stderr,
+        ...(deps.expectedVersion !== undefined ? { expectedVersion: deps.expectedVersion } : {}),
+        ...(deps.onVersionMismatch !== undefined ? { onVersionMismatch: deps.onVersionMismatch } : {}),
+      })
+    }
+
+    const scope = ctx.createTailScope()
+    try {
+      if (item.kind === 'logs') {
+        const result = await streamLogs({
+          cwd: deps.cwd,
+          color: deps.color,
+          stdout: deps.stdout,
+          stderr: deps.stderr,
+          signal: scope.signal,
+          ...(deps.liveHint !== undefined ? { liveHint: deps.liveHint } : {}),
+        })
+        return toResult(result.escToPicker, scope)
+      }
+
+      const sessionResult = await streamInspectTarget({
+        agentDir: deps.cwd,
+        target: { summary: item.summary, filter: deps.filter, sinceMs: deps.sinceMs },
+        json: deps.json,
+        color: deps.color,
+        stdout: deps.stdout,
+        stderr: deps.stderr,
+        signal: scope.signal,
+        ...(deps.liveSource !== undefined ? { liveSource: deps.liveSource } : {}),
+        ...(deps.liveHint !== undefined ? { liveHint: deps.liveHint } : {}),
+        ...(deps.interactive ? { interactive: true } : {}),
+      })
+      const escToPicker = sessionResult.ok && sessionResult.escToPicker === true
+      return toResult(escToPicker, scope)
+    } finally {
+      scope.dispose()
+    }
+  }
+}
+
+function toResult(escToPicker: boolean, scope: TailController): RunInspectResult {
+  if (scope.intent() === 'exit') return { ok: true, exitCode: 0 }
+  if (escToPicker) return { ok: true, exitCode: 0, escToPicker: true }
+  return { ok: true, exitCode: 0 }
+}

--- a/src/inspect/preview.test.ts
+++ b/src/inspect/preview.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test'
+
+import { previewForHint } from './preview'
+
+const TIME = '<current-time>2026-06-04T22:36:14+09:00 (Asia/Seoul, Thursday)</current-time>'
+
+describe('previewForHint', () => {
+  test('subagent origin → null (machine payload, label already names it)', () => {
+    expect(
+      previewForHint({ kind: 'subagent', subagent: 'memory-logger', parentSessionId: 'p' }, 'Parent session: p'),
+    ).toBeNull()
+  })
+
+  describe('tui / structural fallback', () => {
+    test('strips the leading <current-time> anchor', () => {
+      expect(previewForHint({ kind: 'tui' }, `${TIME}\n\nfix the parser`)).toBe('fix the parser')
+    })
+
+    test('skips a SYSTEM MESSAGE fence then takes the real line', () => {
+      const text = `${TIME}\n\n---\n**[SYSTEM MESSAGE — not from a human]**\n\nIncomplete todo items remain.\n---\n\nthe actual ask`
+      expect(previewForHint({ kind: 'tui' }, text)).toBe('the actual ask')
+    })
+
+    test('a turn that is only injected blocks → null', () => {
+      const text = `${TIME}\n\n---\n**[SYSTEM MESSAGE — not from a human]**\n\nrestarted.\n---`
+      expect(previewForHint({ kind: 'tui' }, text)).toBeNull()
+    })
+
+    test('skips a future <some-new-tag> block without code changes', () => {
+      const text = `<some-new-tag>whatever the runtime adds next</some-new-tag>\n\nreal message`
+      expect(previewForHint({ kind: 'tui' }, text)).toBe('real message')
+    })
+
+    test('a plain user message with no preamble passes through', () => {
+      expect(previewForHint({ kind: 'tui' }, 'just a normal prompt')).toBe('just a normal prompt')
+    })
+  })
+
+  describe('channel', () => {
+    const channelOrigin = { kind: 'channel' as const, adapter: 'slack-bot', workspace: 'w', chat: 'c', thread: null }
+
+    test('extracts the addressed message, ignoring recent context', () => {
+      const text = [
+        TIME,
+        '',
+        '## Recent context (not addressed to you, for awareness only)',
+        '[2026-06-04T22:00:00Z] <@U1> (alice): someone else chatting',
+        '',
+        '## Current message (addressed to you)',
+        '[2026-06-04T22:36:00Z] <@U2> (bob): is staging still down?',
+      ].join('\n')
+      expect(previewForHint(channelOrigin, text)).toBe('is staging still down?')
+    })
+
+    test('joins a multi-line addressed message', () => {
+      const text = [
+        '## Current message (addressed to you)',
+        '[2026-06-04T22:36:00Z] <@U2> (bob): first line',
+        'second line',
+      ].join('\n')
+      expect(previewForHint(channelOrigin, text)).toBe('first line second line')
+    })
+
+    test('handles the plural "Current messages" header', () => {
+      const text = ['## Current messages (addressed to you)', '[2026-06-04T22:36:00Z] <@U2> (bob): batched ask'].join(
+        '\n',
+      )
+      expect(previewForHint(channelOrigin, text)).toBe('batched ask')
+    })
+
+    test('no addressed message (system-notice-only turn) → null', () => {
+      const text = `${TIME}\n\n---\n**[SYSTEM MESSAGE — not from a human]**\n\nloop guard.\n---`
+      expect(previewForHint(channelOrigin, text)).toBeNull()
+    })
+
+    test('tolerates a missing stamp / bot tag', () => {
+      const text = ['## Current message (addressed to you)', '<@U2> (bot-name) [bot]: ping'].join('\n')
+      expect(previewForHint(channelOrigin, text)).toBe('ping')
+    })
+  })
+})

--- a/src/inspect/preview.ts
+++ b/src/inspect/preview.ts
@@ -1,0 +1,106 @@
+import type { MinimalSessionOrigin } from '@/agent/session-meta'
+
+// Builds the one-line session-list hint from a session's first user turn.
+// User turns are wrapped in runtime-injected preamble (<current-time>, role
+// anchors, SYSTEM MESSAGE fences, channel context sections, …) that grows over
+// time. Rather than chase every block, this keys off stable semantic
+// boundaries and prefers null over a misleading hint — it is a cosmetic glance,
+// not a faithful reconstruction.
+export function previewForHint(origin: MinimalSessionOrigin | null, text: string): string | null {
+  // A subagent's first message is a machine payload (Parent session:, …) and
+  // the row label already names the subagent.
+  if (origin?.kind === 'subagent') return null
+  if (origin?.kind === 'channel') return channelPreview(text)
+  return structuralPreview(text)
+}
+
+// `[ISO] <@authorId> (authorName) [bot]: actual text` — the only line carrying
+// human-typed text in a channel turn. The stamp is omitted when ts<=0, so it is
+// optional here; name and bot tag are also optional.
+const AUTHOR_LINE = /^(?:\[[^\]]+\]\s+)?<[^>]+>(?:\s+\([^)]+\))?(?:\s+\[bot\])?:\s*(.*)$/
+
+const CURRENT_MESSAGE_HEADER = /^## Current messages? \(addressed to you\)\s*$/
+
+// Channel preview: extract ONLY from the "## Current message(s) (addressed to
+// you)" section — never the "## Recent context" section above it, which is other
+// people's messages the agent was only made aware of. Returns null if no
+// addressed message is found.
+function channelPreview(text: string): string | null {
+  const lines = text.split('\n')
+  const headerIdx = lines.findIndex((l) => CURRENT_MESSAGE_HEADER.test(l))
+  if (headerIdx === -1) return null
+
+  for (let i = headerIdx + 1; i < lines.length; i++) {
+    const match = AUTHOR_LINE.exec(lines[i]!)
+    if (match === null) continue
+    const payload = collectMessage(match[1] ?? '', lines, i + 1)
+    const trimmed = payload.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+  return null
+}
+
+// An author line's text plus any continuation lines (a multi-line message
+// continues without the author prefix) until the next author line, a structural
+// boundary (## / ---), or a quote anchor (>).
+function collectMessage(first: string, lines: string[], start: number): string {
+  const parts = [first]
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i]!
+    if (AUTHOR_LINE.test(line) || line.startsWith('## ') || line.startsWith('---') || line.startsWith('>')) break
+    parts.push(line)
+  }
+  return parts.join(' ')
+}
+
+// Origin-agnostic fallback (TUI, cron, system, unknown): skip leading injected
+// structure — XML-tag blocks, `--- … ---` SYSTEM MESSAGE fences, `## …`
+// sections, and blank lines — then take the first remaining real line. This
+// degrades gracefully as new runtime notices (which follow the same framing
+// conventions) are added, without needing per-block updates.
+function structuralPreview(text: string): string | null {
+  const lines = text.split('\n')
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]!
+    const trimmed = line.trim()
+    if (trimmed === '') {
+      i++
+    } else if (trimmed.startsWith('<')) {
+      i = skipXmlOrTagLine(lines, i)
+    } else if (trimmed.startsWith('---')) {
+      i = skipFence(lines, i)
+    } else if (trimmed.startsWith('#')) {
+      i++
+    } else {
+      return looksInjected(trimmed) ? null : trimmed
+    }
+  }
+  return null
+}
+
+// Skips a leading XML block. If the opening tag closes on the same line or
+// spans lines, advance past the matching close tag; otherwise skip just the one
+// line (a stray `<…>` shouldn't swallow the rest).
+function skipXmlOrTagLine(lines: string[], start: number): number {
+  const open = /^<([a-zA-Z][\w-]*)/.exec(lines[start]!.trim())
+  if (open === null) return start + 1
+  const close = `</${open[1]}>`
+  for (let i = start; i < lines.length; i++) {
+    if (lines[i]!.includes(close)) return i + 1
+  }
+  return start + 1
+}
+
+// Skips a `---` fenced block (SYSTEM MESSAGE framing): from the opening `---`
+// to the next standalone `---`.
+function skipFence(lines: string[], start: number): number {
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i]!.trim() === '---') return i + 1
+  }
+  return start + 1
+}
+
+function looksInjected(line: string): boolean {
+  return line.startsWith('**[SYSTEM') || line.startsWith('[security/')
+}

--- a/src/inspect/session-list.test.ts
+++ b/src/inspect/session-list.test.ts
@@ -109,6 +109,17 @@ describe('listSessions', () => {
     expect(sessions[0]?.firstPrompt).toBeNull()
   })
 
+  test('subagent with a machine payload as its first message → firstPrompt is null (no preamble noise)', async () => {
+    const payload = `Parent session: ${UUID_B}\nTranscript file: /agent/sessions/x.jsonl\nDaily stream file: /agent/memory/streams/today.jsonl`
+    await writeSession(
+      `2026-06-04T00-00-00-000Z_${UUID_A}.jsonl`,
+      [metaLine({ kind: 'subagent', subagent: 'memory-logger', parentSessionId: UUID_B }), userLine(payload)],
+      1000,
+    )
+    const sessions = await listSessions({ sessionsDir: dir })
+    expect(sessions[0]?.firstPrompt).toBeNull()
+  })
+
   test('strips the injected <current-time> anchor from the first-prompt hint', async () => {
     const text = '<current-time>2026-06-04T22:36:14+09:00 (Asia/Seoul, Thursday)</current-time>\n\nfix the parser'
     await writeSession(`2026-06-04T00-00-00-000Z_${UUID_A}.jsonl`, [metaLine({ kind: 'tui' }), userLine(text)], 1000)

--- a/src/inspect/session-list.test.ts
+++ b/src/inspect/session-list.test.ts
@@ -109,6 +109,31 @@ describe('listSessions', () => {
     expect(sessions[0]?.firstPrompt).toBeNull()
   })
 
+  test('strips the injected <current-time> anchor from the first-prompt hint', async () => {
+    const text = '<current-time>2026-06-04T22:36:14+09:00 (Asia/Seoul, Thursday)</current-time>\n\nfix the parser'
+    await writeSession(`2026-06-04T00-00-00-000Z_${UUID_A}.jsonl`, [metaLine({ kind: 'tui' }), userLine(text)], 1000)
+    const sessions = await listSessions({ sessionsDir: dir })
+    expect(sessions[0]?.firstPrompt).toBe('fix the parser')
+  })
+
+  test('a turn that is only the time anchor falls through to the next real user message', async () => {
+    const anchorOnly = '<current-time>2026-06-04T22:36:14+09:00 (Asia/Seoul, Thursday)</current-time>'
+    await writeSession(
+      `2026-06-04T00-00-00-000Z_${UUID_A}.jsonl`,
+      [metaLine({ kind: 'tui' }), userLine(anchorOnly, 1000), userLine(`${anchorOnly}\n\nthe real ask`, 2000)],
+      1000,
+    )
+    const sessions = await listSessions({ sessionsDir: dir })
+    expect(sessions[0]?.firstPrompt).toBe('the real ask')
+  })
+
+  test('strips the <hatching> bootstrap block from the first-prompt hint', async () => {
+    const text = '<hatching>secret ritual</hatching>\n\nactual first message'
+    await writeSession(`2026-06-04T00-00-00-000Z_${UUID_A}.jsonl`, [metaLine({ kind: 'tui' }), userLine(text)], 1000)
+    const sessions = await listSessions({ sessionsDir: dir })
+    expect(sessions[0]?.firstPrompt).toBe('actual first message')
+  })
+
   test('channel origin with names preserved in summary', async () => {
     await writeSession(
       `2026-05-22T00-00-00-000Z_${UUID_A}.jsonl`,

--- a/src/inspect/session-list.ts
+++ b/src/inspect/session-list.ts
@@ -143,12 +143,25 @@ async function peekSession(
   let bytesRead = 0
   for await (const event of replayJsonl(path, onWarn !== undefined ? { onWarn } : {})) {
     if (event.cat === 'meta' && origin === null) origin = event.origin
-    if (event.cat === 'user' && firstPrompt === null) firstPrompt = event.text
+    if (event.cat === 'user' && firstPrompt === null) firstPrompt = previewPrompt(event.text)
     if (origin !== null && firstPrompt !== null) break
     bytesRead += approximateSize(event)
     if (bytesRead > PREVIEW_MAX_BYTES) break
   }
   return { origin, firstPrompt }
+}
+
+// Strips runtime-injected blocks that lead every user turn (the per-turn
+// <current-time> anchor; the <hatching> bootstrap ritual) so the session-list
+// hint shows the real prompt. Returns null when nothing meaningful remains —
+// e.g. a turn that was only the time anchor — so the picker keeps scanning for
+// the next user message instead of showing a blank hint.
+function previewPrompt(text: string): string | null {
+  const stripped = text
+    .replace(/<current-time>[\s\S]*?<\/current-time>\s*/g, '')
+    .replace(/<hatching>[\s\S]*?<\/hatching>\s*/g, '')
+    .trim()
+  return stripped.length > 0 ? stripped : null
 }
 
 function approximateSize(event: { ts: number }): number {

--- a/src/inspect/session-list.ts
+++ b/src/inspect/session-list.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 
 import type { MinimalSessionOrigin } from '@/agent/session-meta'
 
+import { previewForHint } from './preview'
 import { replayJsonl } from './replay'
 
 export type SessionSummary = {
@@ -139,34 +140,28 @@ async function peekSession(
   onWarn?: (msg: string) => void,
 ): Promise<{ origin: MinimalSessionOrigin | null; firstPrompt: string | null }> {
   let origin: MinimalSessionOrigin | null = null
-  let firstPrompt: string | null = null
+  const userTexts: string[] = []
   let bytesRead = 0
   for await (const event of replayJsonl(path, onWarn !== undefined ? { onWarn } : {})) {
     if (event.cat === 'meta' && origin === null) origin = event.origin
-    if (event.cat === 'user' && firstPrompt === null) firstPrompt = previewPrompt(event.text)
-    if (origin !== null && firstPrompt !== null) break
+    if (event.cat === 'user' && userTexts.length < MAX_PREVIEW_CANDIDATES) userTexts.push(event.text)
+    if (origin !== null && userTexts.length >= MAX_PREVIEW_CANDIDATES) break
     bytesRead += approximateSize(event)
     if (bytesRead > PREVIEW_MAX_BYTES) break
   }
-  // A subagent's first "user" message is a machine-built payload (Parent
-  // session:, Transcript file:, …), never user prose — and the row label
-  // already names the subagent. Drop the hint rather than show that noise.
-  if (origin?.kind === 'subagent') firstPrompt = null
+  // Resolve the hint after the loop so origin (which selects the extraction
+  // strategy) is known even if a user event precedes the meta event. A turn
+  // that is pure injected preamble yields null, so fall through to the next user
+  // turn for a useful glance.
+  let firstPrompt: string | null = null
+  for (const text of userTexts) {
+    firstPrompt = previewForHint(origin, text)
+    if (firstPrompt !== null) break
+  }
   return { origin, firstPrompt }
 }
 
-// Strips runtime-injected blocks that lead every user turn (the per-turn
-// <current-time> anchor; the <hatching> bootstrap ritual) so the session-list
-// hint shows the real prompt. Returns null when nothing meaningful remains —
-// e.g. a turn that was only the time anchor — so the picker keeps scanning for
-// the next user message instead of showing a blank hint.
-function previewPrompt(text: string): string | null {
-  const stripped = text
-    .replace(/<current-time>[\s\S]*?<\/current-time>\s*/g, '')
-    .replace(/<hatching>[\s\S]*?<\/hatching>\s*/g, '')
-    .trim()
-  return stripped.length > 0 ? stripped : null
-}
+const MAX_PREVIEW_CANDIDATES = 5
 
 function approximateSize(event: { ts: number }): number {
   return JSON.stringify(event).length

--- a/src/inspect/session-list.ts
+++ b/src/inspect/session-list.ts
@@ -148,6 +148,10 @@ async function peekSession(
     bytesRead += approximateSize(event)
     if (bytesRead > PREVIEW_MAX_BYTES) break
   }
+  // A subagent's first "user" message is a machine-built payload (Parent
+  // session:, Transcript file:, …), never user prose — and the row label
+  // already names the subagent. Drop the hint rather than show that noise.
+  if (origin?.kind === 'subagent') firstPrompt = null
   return { origin, firstPrompt }
 }
 

--- a/src/inspect/stream-events.test.ts
+++ b/src/inspect/stream-events.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { streamSessionEvents, type StreamPhase } from './index'
+import type { SessionSummary } from './session-list'
+import type { InspectEvent } from './types'
+import { parseFilter } from './types'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'typeclaw-stream-events-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+const FILTER = parseFilter(undefined)
+if (!FILTER.ok) throw new Error('default filter must parse')
+
+function metaLine(origin: unknown): string {
+  return JSON.stringify({ type: 'custom', customType: 'typeclaw.session-meta', data: { origin }, timestamp: 1_000_000 })
+}
+function userLine(text: string, ts = 1_000_100): string {
+  return JSON.stringify({ type: 'message', message: { role: 'user', content: text, timestamp: ts } })
+}
+
+async function seed(lines: string[]): Promise<SessionSummary> {
+  const file = join(dir, 'sess.jsonl')
+  await writeFile(file, lines.join('\n') + '\n')
+  return {
+    sessionId: 'sess',
+    sessionFile: file,
+    basename: 'sess.jsonl',
+    mtimeMs: 1,
+    origin: { kind: 'tui' },
+    firstPrompt: null,
+  }
+}
+
+describe('streamSessionEvents', () => {
+  test('replay-only delivers events then announces replay-end and end', async () => {
+    const summary = await seed([metaLine({ kind: 'tui' }), userLine('hello')])
+    const events: InspectEvent[] = []
+    const phases: StreamPhase['phase'][] = []
+
+    const result = await streamSessionEvents({
+      summary,
+      filter: FILTER.filter,
+      sinceMs: undefined,
+      onEvent: (e) => events.push(e),
+      onPhase: (p) => phases.push(p.phase),
+    })
+
+    expect(result).toEqual({ escToPicker: false })
+    expect(events.map((e) => e.cat)).toEqual(['meta', 'user'])
+    expect(phases).toEqual(['replay-end', 'end'])
+  })
+
+  test('replay then live preserves ordering and announces live-start with sessionLive', async () => {
+    const summary = await seed([metaLine({ kind: 'tui' }), userLine('first')])
+    const events: InspectEvent[] = []
+    const phases: StreamPhase[] = []
+
+    async function* live(o: { onSubscribed?: (live: boolean) => void }): AsyncGenerator<InspectEvent> {
+      o.onSubscribed?.(true)
+      yield { cat: 'broadcast', ts: 2_000, payload: { kind: 'tick' } }
+    }
+
+    const result = await streamSessionEvents({
+      summary,
+      filter: FILTER.filter,
+      sinceMs: undefined,
+      onEvent: (e) => events.push(e),
+      onPhase: (p) => phases.push(p),
+      liveSource: (o) => live(o),
+    })
+
+    expect(result).toEqual({ escToPicker: false })
+    expect(events.map((e) => e.cat)).toEqual(['meta', 'user', 'broadcast'])
+    expect(phases.map((p) => p.phase)).toEqual(['replay-end', 'live-start', 'end'])
+    const liveStart = phases.find((p) => p.phase === 'live-start')
+    expect(liveStart).toEqual({ phase: 'live-start', sessionLive: true })
+  })
+
+  test('abort during live tail returns escToPicker', async () => {
+    const summary = await seed([metaLine({ kind: 'tui' })])
+    const ctrl = new AbortController()
+    const events: InspectEvent[] = []
+
+    async function* live(o: { signal?: AbortSignal }): AsyncGenerator<InspectEvent> {
+      yield { cat: 'broadcast', ts: 2_000, payload: { kind: 'one' } }
+      await new Promise<void>((resolve) => {
+        if (o.signal?.aborted) return resolve()
+        o.signal?.addEventListener('abort', () => resolve(), { once: true })
+      })
+    }
+
+    const promise = streamSessionEvents({
+      summary,
+      filter: FILTER.filter,
+      sinceMs: undefined,
+      onEvent: (e) => {
+        events.push(e)
+        if (e.cat === 'broadcast') ctrl.abort()
+      },
+      liveSource: (o) => live(o),
+      signal: ctrl.signal,
+    })
+
+    const result = await promise
+    expect(result).toEqual({ escToPicker: true })
+  })
+
+  test('since cutoff and filter are applied before onEvent', async () => {
+    const summary = await seed([metaLine({ kind: 'tui' }), userLine('old', 1_000), userLine('new', 9_000)])
+    const filtered = parseFilter('!meta')
+    if (!filtered.ok) throw new Error('filter parse')
+    const events: InspectEvent[] = []
+
+    await streamSessionEvents({
+      summary,
+      filter: filtered.filter,
+      sinceMs: 5_000,
+      onEvent: (e) => events.push(e),
+    })
+
+    // meta excluded by filter; 'old' (ts 1000) dropped by since; only 'new' remains
+    expect(events.map((e) => e.cat)).toEqual(['user'])
+    expect(events[0]).toMatchObject({ cat: 'user', text: 'new' })
+  })
+
+  test('blockWhenReplayOnly waits for the signal before ending', async () => {
+    const summary = await seed([metaLine({ kind: 'tui' })])
+    const ctrl = new AbortController()
+    const phases: StreamPhase['phase'][] = []
+
+    const promise = streamSessionEvents({
+      summary,
+      filter: FILTER.filter,
+      sinceMs: undefined,
+      onEvent: () => {},
+      onPhase: (p) => phases.push(p.phase),
+      signal: ctrl.signal,
+      blockWhenReplayOnly: true,
+    })
+
+    // Has not ended yet; idle phase announced, waiting on the signal.
+    await new Promise((r) => setTimeout(r, 20))
+    expect(phases).toEqual(['replay-end', 'replay-only-idle'])
+
+    ctrl.abort()
+    const result = await promise
+    expect(result).toEqual({ escToPicker: true })
+    expect(phases).toEqual(['replay-end', 'replay-only-idle', 'end'])
+  })
+})

--- a/src/inspect/transcript-view.test.ts
+++ b/src/inspect/transcript-view.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { Markdown, type Terminal, Text } from '@mariozechner/pi-tui'
+
+import type { SessionSummary } from './session-list'
+import { createTranscriptView, componentFor } from './transcript-view'
+import type { InspectEvent } from './types'
+import { parseFilter } from './types'
+
+class FakeTerminal implements Terminal {
+  rows = 30
+  columns = 80
+  kittyProtocolActive = false
+  stopped = false
+  private inputHandler: ((data: string) => void) | null = null
+
+  start(onInput: (data: string) => void): void {
+    this.inputHandler = onInput
+  }
+  stop(): void {
+    this.stopped = true
+  }
+  async drainInput(): Promise<void> {}
+  write(): void {}
+  moveBy(): void {}
+  hideCursor(): void {}
+  showCursor(): void {}
+  clearLine(): void {}
+  clearFromCursor(): void {}
+  clearScreen(): void {}
+  setTitle(): void {}
+  feed(data: string): void {
+    this.inputHandler?.(data)
+  }
+}
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 10))
+
+describe('componentFor', () => {
+  test('assistant text becomes a Markdown block', () => {
+    const ev: InspectEvent = { cat: 'assistant', ts: 1, text: '# hi\n\nbody' }
+    expect(componentFor(ev)).toBeInstanceOf(Markdown)
+  })
+
+  test('user / tool / meta / done become Text components', () => {
+    const cases: InspectEvent[] = [
+      { cat: 'user', ts: 1, text: 'hello' },
+      { cat: 'tool', ts: 1, phase: 'start', toolCallId: 'c1', name: 'read', args: { path: 'x' } },
+      {
+        cat: 'tool',
+        ts: 1,
+        phase: 'end',
+        toolCallId: 'c1',
+        name: 'read',
+        result: 'ok',
+        isError: false,
+        durationMs: 12,
+      },
+      { cat: 'meta', ts: 1, origin: { kind: 'tui' } },
+      { cat: 'done', ts: 1, input: 10, output: 20, cacheRead: 0, cacheWrite: 0, totalTokens: 30, cost: 0.01 },
+      { cat: 'error', ts: 1, message: 'boom' },
+    ]
+    for (const ev of cases) expect(componentFor(ev)).toBeInstanceOf(Text)
+  })
+})
+
+describe('createTranscriptView run()', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'typeclaw-transcript-view-'))
+  })
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  const FILTER = parseFilter(undefined)
+  if (!FILTER.ok) throw new Error('default filter')
+
+  async function seed(): Promise<SessionSummary> {
+    const file = join(dir, 's.jsonl')
+    const lines = [
+      JSON.stringify({
+        type: 'custom',
+        customType: 'typeclaw.session-meta',
+        data: { origin: { kind: 'tui' } },
+        timestamp: 1,
+      }),
+      JSON.stringify({ type: 'message', message: { role: 'user', content: 'hi', timestamp: 2 } }),
+    ]
+    await writeFile(file, lines.join('\n') + '\n')
+    return {
+      sessionId: 's',
+      sessionFile: file,
+      basename: 's.jsonl',
+      mtimeMs: 1,
+      origin: { kind: 'tui' },
+      firstPrompt: null,
+    }
+  }
+
+  test('esc returns back; the terminal is stopped', async () => {
+    const summary = await seed()
+    const terminal = new FakeTerminal()
+    const view = createTranscriptView({
+      summary,
+      filter: FILTER.filter,
+      sinceMs: undefined,
+      createTerminal: () => terminal,
+    })
+
+    const runPromise = view.run()
+    await flush()
+    terminal.feed('\x1b')
+
+    await expect(runPromise).resolves.toEqual({ reason: 'back' })
+    expect(terminal.stopped).toBe(true)
+  })
+
+  test('q exits', async () => {
+    const summary = await seed()
+    const terminal = new FakeTerminal()
+    const view = createTranscriptView({
+      summary,
+      filter: FILTER.filter,
+      sinceMs: undefined,
+      createTerminal: () => terminal,
+    })
+
+    const runPromise = view.run()
+    await flush()
+    terminal.feed('q')
+
+    await expect(runPromise).resolves.toEqual({ reason: 'exit' })
+  })
+
+  test('ctrl-c exits', async () => {
+    const summary = await seed()
+    const terminal = new FakeTerminal()
+    const view = createTranscriptView({
+      summary,
+      filter: FILTER.filter,
+      sinceMs: undefined,
+      createTerminal: () => terminal,
+    })
+
+    const runPromise = view.run()
+    await flush()
+    terminal.feed('\x03')
+
+    await expect(runPromise).resolves.toEqual({ reason: 'exit' })
+  })
+})

--- a/src/inspect/transcript-view.ts
+++ b/src/inspect/transcript-view.ts
@@ -1,0 +1,182 @@
+import {
+  Key,
+  Markdown,
+  matchesKey,
+  ProcessTerminal,
+  type Component,
+  type Terminal,
+  Text,
+  TUI,
+} from '@mariozechner/pi-tui'
+
+import { formatToolEnd, formatToolStart, formatUserPromptHistory } from '@/tui/format'
+import { colors, markdownTheme } from '@/tui/theme'
+
+import { streamSessionEvents, type LiveSourceFactory, type StreamPhase } from './index'
+import { originLabel, shortSessionId } from './label'
+import type { SessionSummary } from './session-list'
+import type { InspectEvent, InspectFilter } from './types'
+
+export type TranscriptViewOutcome = { reason: 'back' | 'exit' }
+
+export type TranscriptViewOptions = {
+  summary: SessionSummary
+  filter: InspectFilter
+  sinceMs: number | undefined
+  liveSource?: LiveSourceFactory
+  createTerminal?: () => Terminal
+}
+
+// Read-only pi-tui transcript viewer: the rich counterpart to the line
+// renderer, matching the live TUI's look (markdown assistant blocks, formatted
+// tool panels) but with NO editor and NO websocket writes. It owns its own
+// raw-mode terminal, so the caller must NOT wrap it in a tail scope (a second
+// raw-stdin owner would corrupt input — same rule as the writable tui branch).
+// esc -> back to the list; q / ctrl-c -> exit.
+export function createTranscriptView(opts: TranscriptViewOptions) {
+  async function run(): Promise<TranscriptViewOutcome> {
+    const terminal = (opts.createTerminal ?? (() => new ProcessTerminal()))()
+    const tui = new TUI(terminal)
+
+    const status = new Text(statusLine('replay'), 0, 0)
+    tui.addChild(new Text(header(opts.summary), 0, 0))
+    tui.addChild(status)
+    tui.start()
+    tui.requestRender()
+
+    // The status line is pinned last (no editor to pin, unlike createTui). Each
+    // appended history entry is inserted before it: strip status, add entry,
+    // re-add status.
+    const append = (component: Component): void => {
+      tui.removeChild(status)
+      tui.addChild(component)
+      tui.addChild(status)
+    }
+
+    let settle: ((o: TranscriptViewOutcome) => void) | null = null
+    const outcome = new Promise<TranscriptViewOutcome>((resolve) => {
+      settle = resolve
+    })
+    const finish = (reason: TranscriptViewOutcome['reason']): void => {
+      if (settle === null) return
+      const fn = settle
+      settle = null
+      tui.stop()
+      fn({ reason })
+    }
+
+    tui.addInputListener((data) => {
+      if (matchesKey(data, Key.ctrl('c')) || data === 'q') {
+        finish('exit')
+        return { consume: true }
+      }
+      if (matchesKey(data, Key.escape)) {
+        finish('back')
+        return { consume: true }
+      }
+      return undefined
+    })
+
+    const abort = new AbortController()
+    // Drive the shared read pipeline into the component tree. Batch renders
+    // during replay (one render at replay-end) to avoid redraw storms on long
+    // transcripts; render per event once live.
+    let live = false
+    const onEvent = (event: InspectEvent): void => {
+      append(componentFor(event))
+      if (live) tui.requestRender()
+    }
+    const onPhase = (phase: StreamPhase): void => {
+      if (phase.phase === 'replay-end') {
+        tui.requestRender()
+      } else if (phase.phase === 'live-start') {
+        append(new Text(divider(phase.sessionLive ? 'live' : 'live (broadcasts only)'), 0, 0))
+        live = true
+        tui.requestRender()
+      }
+    }
+
+    const pump = streamSessionEvents({
+      summary: opts.summary,
+      filter: opts.filter,
+      sinceMs: opts.sinceMs,
+      onEvent,
+      onPhase,
+      signal: abort.signal,
+      ...(opts.liveSource !== undefined ? { liveSource: opts.liveSource } : {}),
+      blockWhenReplayOnly: true,
+    })
+
+    const result = await outcome
+    // The viewer was dismissed: stop the pipeline (replay-only idle wait, or a
+    // live tail) so it does not run past the closed terminal.
+    abort.abort()
+    await pump.catch(() => {})
+    return result
+  }
+
+  return { run }
+}
+
+export function componentFor(event: InspectEvent): Component {
+  switch (event.cat) {
+    case 'assistant':
+      return new Markdown(event.text, 0, 0, markdownTheme)
+    case 'user':
+      return new Text(formatUserPromptHistory(event.text), 0, 0)
+    case 'tool':
+      return new Text(
+        event.phase === 'start'
+          ? formatToolStart(event.name, event.args)
+          : formatToolEnd(event.name, event.isError === true, event.result, event.durationMs ?? 0),
+        0,
+        0,
+      )
+    case 'thinking':
+      return new Text(colors.gray(event.redacted === true ? '[redacted thinking]' : event.text), 0, 0)
+    case 'meta':
+      return new Text(colors.dim(`origin: ${originLabel(event.origin)}`), 0, 0)
+    case 'error':
+      return new Text(
+        event.stopReason === 'aborted' ? colors.yellow(event.message) : colors.red(`error: ${event.message}`),
+        0,
+        0,
+      )
+    case 'done':
+      return new Text(colors.dim(doneSummary(event)), 0, 0)
+    case 'broadcast':
+      return new Text(colors.dim(`broadcast: ${compact(event.payload)}`), 0, 0)
+    case 'cron-fire':
+      return new Text(colors.dim(`cron ${event.jobId} fired`), 0, 0)
+    case 'inbound':
+      return new Text(colors.cyan(`[${event.decision}] ${event.authorName}: ${event.text}`), 0, 0)
+  }
+}
+
+function doneSummary(event: Extract<InspectEvent, { cat: 'done' }>): string {
+  const parts = [`${event.input} in / ${event.output} out tok`, `$${event.cost.toFixed(4)}`]
+  if (event.stopReason !== undefined) parts.push(`stop=${event.stopReason}`)
+  return parts.join(' · ')
+}
+
+function compact(payload: unknown): string {
+  if (payload !== null && typeof payload === 'object' && 'kind' in payload) {
+    return String((payload as { kind: unknown }).kind)
+  }
+  const s = JSON.stringify(payload) ?? String(payload)
+  return s.length > 200 ? `${s.slice(0, 200)}…` : s
+}
+
+function header(summary: SessionSummary): string {
+  const id = shortSessionId(summary.sessionId)
+  const label = summary.origin === null ? '(unknown origin)' : originLabel(summary.origin)
+  return colors.dim(`─── ${id} · ${label} ───`)
+}
+
+function statusLine(_phase: 'replay'): string {
+  return colors.dim('── read-only · esc to return to list · q to quit ──')
+}
+
+function divider(text: string): string {
+  return colors.dim(`─── ${text} ───`)
+}

--- a/src/inspect/tui-item.test.ts
+++ b/src/inspect/tui-item.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test'
+
+import { runTuiViewer } from './tui-item'
+
+const noopSleep = async (): Promise<void> => {}
+
+describe('runTuiViewer', () => {
+  test('detach maps to escToPicker (back to the list)', async () => {
+    const result = await runTuiViewer({
+      resolveUrl: async () => 'ws://x',
+      runTui: async () => ({ reason: 'detach' }),
+      stderr: () => {},
+      sleep: noopSleep,
+    })
+
+    expect(result).toEqual({ ok: true, exitCode: 0, escToPicker: true })
+  })
+
+  test('exit maps to a terminal result with the exit code', async () => {
+    const result = await runTuiViewer({
+      resolveUrl: async () => 'ws://x',
+      runTui: async () => ({ reason: 'exit', exitCode: 0 }),
+      stderr: () => {},
+      sleep: noopSleep,
+    })
+
+    expect(result).toEqual({ ok: true, exitCode: 0 })
+  })
+
+  test('lostConnection reconnects, re-resolving the URL and clearing the initial prompt', async () => {
+    const resolvedUrls: string[] = []
+    const prompts: (string | undefined)[] = []
+    let calls = 0
+
+    const result = await runTuiViewer({
+      resolveUrl: async () => {
+        const url = `ws://attempt-${resolvedUrls.length}`
+        resolvedUrls.push(url)
+        return url
+      },
+      initialPrompt: 'hello',
+      runTui: async (opts) => {
+        prompts.push(opts.initialPrompt)
+        calls++
+        if (calls === 1) return { reason: 'lostConnection' }
+        return { reason: 'detach' }
+      },
+      stderr: () => {},
+      sleep: noopSleep,
+    })
+
+    expect(result).toEqual({ ok: true, exitCode: 0, escToPicker: true })
+    expect(resolvedUrls).toEqual(['ws://attempt-0', 'ws://attempt-1'])
+    expect(prompts).toEqual(['hello', undefined])
+  })
+
+  test('gives up after the reconnect cap and returns an error result', async () => {
+    const result = await runTuiViewer({
+      resolveUrl: async () => 'ws://x',
+      runTui: async () => ({ reason: 'lostConnection' }),
+      reconnectMaxAttempts: 2,
+      stderr: () => {},
+      sleep: noopSleep,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.exitCode).toBe(1)
+    expect(result.reason).toContain('gave up after 2')
+  })
+
+  test('a resolveUrl failure returns an error result without launching the tui', async () => {
+    let launched = false
+    const result = await runTuiViewer({
+      resolveUrl: async () => {
+        throw new Error('container not running')
+      },
+      runTui: async () => {
+        launched = true
+        return { reason: 'detach' }
+      },
+      stderr: () => {},
+      sleep: noopSleep,
+    })
+
+    expect(launched).toBe(false)
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).toBe('container not running')
+  })
+})

--- a/src/inspect/tui-item.ts
+++ b/src/inspect/tui-item.ts
@@ -1,0 +1,97 @@
+import { createTui, type TuiRunResult } from '@/tui'
+
+import type { RunInspectResult } from './index'
+
+export type TuiRunner = (opts: {
+  url: string
+  initialPrompt?: string
+  expectedVersion?: string
+  onVersionMismatch?: (info: { expected: string; actual: string }) => void
+}) => Promise<TuiRunResult>
+
+export type RunTuiViewerOptions = {
+  resolveUrl: () => Promise<string>
+  initialPrompt?: string
+  expectedVersion?: string
+  onVersionMismatch?: (info: { expected: string; actual: string }) => void
+  stderr: (line: string) => void
+  runTui?: TuiRunner
+  reconnectMaxAttempts?: number
+  reconnectBackoffMs?: number
+  sleep?: (ms: number) => Promise<void>
+}
+
+const DEFAULT_RECONNECT_MAX_ATTEMPTS = 30
+const DEFAULT_RECONNECT_BACKOFF_MS = 1_000
+
+// The interactive read+write viewer branch. Unlike session/logs, this does NOT
+// run under the loop's tail scope: createTui owns its own raw-mode pi-tui
+// terminal and esc/ctrl-c handling, so a second raw-stdin owner would corrupt
+// input. The branch maps createTui's outcome into the loop's result contract:
+// detach → back to the list (escToPicker), exit → terminate, lostConnection →
+// reconnect (the self-restart case), connectFailed → error result.
+export async function runTuiViewer(opts: RunTuiViewerOptions): Promise<RunInspectResult> {
+  const runTui = opts.runTui ?? defaultRunTui
+  const sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)))
+  const maxAttempts = opts.reconnectMaxAttempts ?? DEFAULT_RECONNECT_MAX_ATTEMPTS
+  const backoffMs = opts.reconnectBackoffMs ?? DEFAULT_RECONNECT_BACKOFF_MS
+
+  let initialPrompt = opts.initialPrompt
+  let attempt = 0
+
+  while (true) {
+    let url: string
+    try {
+      url = await opts.resolveUrl()
+    } catch (err) {
+      return { ok: false, exitCode: 1, reason: errorMessage(err) }
+    }
+
+    let result: TuiRunResult
+    try {
+      result = await runTui({
+        url,
+        ...(initialPrompt !== undefined ? { initialPrompt } : {}),
+        ...(opts.expectedVersion !== undefined ? { expectedVersion: opts.expectedVersion } : {}),
+        ...(opts.onVersionMismatch !== undefined ? { onVersionMismatch: opts.onVersionMismatch } : {}),
+      })
+    } catch (err) {
+      return { ok: false, exitCode: 1, reason: errorMessage(err) }
+    }
+
+    if (result.reason === 'detach') return { ok: true, exitCode: 0, escToPicker: true }
+    if (result.reason === 'exit') return { ok: true, exitCode: result.exitCode }
+    if (result.reason === 'connectFailed') return { ok: false, exitCode: 1, reason: 'connection failed' }
+
+    // lostConnection: the WS dropped post-handshake (self-restart, network
+    // blip). Re-resolve the URL because the host port can change across
+    // container lifecycles, then reconnect. Clear the initial prompt so a
+    // reconnect resuming the same session does not re-send it to the LLM.
+    initialPrompt = undefined
+    attempt += 1
+    if (attempt > maxAttempts) {
+      return { ok: false, exitCode: 1, reason: `disconnected; gave up after ${maxAttempts} reconnect attempts` }
+    }
+    opts.stderr(`reconnecting (attempt ${attempt}/${maxAttempts})...`)
+    await sleep(backoffMs)
+  }
+}
+
+function defaultRunTui(opts: {
+  url: string
+  initialPrompt?: string
+  expectedVersion?: string
+  onVersionMismatch?: (info: { expected: string; actual: string }) => void
+}): Promise<TuiRunResult> {
+  return createTui({
+    url: opts.url,
+    exit: () => {},
+    ...(opts.initialPrompt !== undefined ? { initialPrompt: opts.initialPrompt } : {}),
+    ...(opts.expectedVersion !== undefined ? { expectedVersion: opts.expectedVersion } : {}),
+    ...(opts.onVersionMismatch !== undefined ? { onVersionMismatch: opts.onVersionMismatch } : {}),
+  }).run()
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/inspect/viewer-loop.test.ts
+++ b/src/inspect/viewer-loop.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { RunInspectResult } from './index'
+import { runViewerLoop, type TailController } from './loop'
+
+type FakeItem = { key: string; kind: 'session' | 'tui' | 'logs' }
+
+function fakeScope(onDispose?: () => void): TailController {
+  const ctrl = new AbortController()
+  return {
+    signal: ctrl.signal,
+    intent: () => null,
+    dispose: () => {
+      onDispose?.()
+      ctrl.abort()
+    },
+  }
+}
+
+const back: RunInspectResult = { ok: true, exitCode: 0, escToPicker: true }
+const done: RunInspectResult = { ok: true, exitCode: 0 }
+
+describe('runViewerLoop', () => {
+  test('opens the preselected item directly, skipping the picker', async () => {
+    let pickerCalls = 0
+    const opened: string[] = []
+
+    const result = await runViewerLoop<FakeItem>({
+      listItems: async () => [
+        { key: 'a', kind: 'session' },
+        { key: 'logs', kind: 'logs' },
+      ],
+      keyOf: (i) => i.key,
+      preselectKey: 'logs',
+      selectItem: async () => {
+        pickerCalls++
+        return null
+      },
+      openItem: async (item) => {
+        opened.push(item.key)
+        return done
+      },
+      createTailScope: () => fakeScope(),
+      onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
+    })
+
+    expect(result).toEqual(done)
+    expect(pickerCalls).toBe(0)
+    expect(opened).toEqual(['logs'])
+  })
+
+  test('back (escToPicker) re-opens the picker; second selection runs and ends', async () => {
+    let pickerCalls = 0
+    const opened: string[] = []
+
+    const result = await runViewerLoop<FakeItem>({
+      listItems: async () => [
+        { key: 'a', kind: 'session' },
+        { key: 'b', kind: 'session' },
+      ],
+      keyOf: (i) => i.key,
+      selectItem: async (items) => {
+        pickerCalls++
+        return items[pickerCalls - 1] ?? null
+      },
+      openItem: async (item) => {
+        opened.push(item.key)
+        return opened.length === 1 ? back : done
+      },
+      createTailScope: () => fakeScope(),
+      onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
+    })
+
+    expect(result).toEqual(done)
+    expect(pickerCalls).toBe(2)
+    expect(opened).toEqual(['a', 'b'])
+  })
+
+  test('the tui branch does not create a tail scope (no double raw-stdin owner)', async () => {
+    let tailScopesCreated = 0
+
+    await runViewerLoop<FakeItem>({
+      listItems: async () => [{ key: 'live', kind: 'tui' }],
+      keyOf: (i) => i.key,
+      preselectKey: 'live',
+      selectItem: async () => null,
+      openItem: async (item, ctx) => {
+        // A real tui opener never touches ctx.createTailScope; assert the loop
+        // does not force one on the branch.
+        if (item.kind === 'session' || item.kind === 'logs') ctx.createTailScope()
+        return done
+      },
+      createTailScope: () => {
+        tailScopesCreated++
+        return fakeScope()
+      },
+      onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
+    })
+
+    expect(tailScopesCreated).toBe(0)
+  })
+
+  test('picker cancel returns exit code 130', async () => {
+    const result = await runViewerLoop<FakeItem>({
+      listItems: async () => [{ key: 'a', kind: 'session' }],
+      keyOf: (i) => i.key,
+      selectItem: async () => null,
+      openItem: async () => done,
+      createTailScope: () => fakeScope(),
+      onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.exitCode).toBe(130)
+  })
+
+  test('empty list returns the onEmpty result', async () => {
+    const result = await runViewerLoop<FakeItem>({
+      listItems: async () => [],
+      keyOf: (i) => i.key,
+      selectItem: async () => null,
+      openItem: async () => done,
+      createTailScope: () => fakeScope(),
+      onEmpty: () => ({ ok: false, exitCode: 1, reason: 'no sessions' }),
+    })
+
+    expect(result).toEqual({ ok: false, exitCode: 1, reason: 'no sessions' })
+  })
+
+  test('a non-ok open result short-circuits the loop', async () => {
+    const result = await runViewerLoop<FakeItem>({
+      listItems: async () => [{ key: 'a', kind: 'session' }],
+      keyOf: (i) => i.key,
+      preselectKey: 'a',
+      selectItem: async () => null,
+      openItem: async () => ({ ok: false, exitCode: 2, reason: 'boom' }),
+      createTailScope: () => fakeScope(),
+      onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
+    })
+
+    expect(result).toEqual({ ok: false, exitCode: 2, reason: 'boom' })
+  })
+})

--- a/src/inspect/viewer-loop.test.ts
+++ b/src/inspect/viewer-loop.test.ts
@@ -20,6 +20,14 @@ function fakeScope(onDispose?: () => void): TailController {
 const back: RunInspectResult = { ok: true, exitCode: 0, escToPicker: true }
 const done: RunInspectResult = { ok: true, exitCode: 0 }
 
+// openItem now returns { result, endedWritableSession? }. wrap() is the common
+// "ordinary back/done" case; wrapWritable() marks a tui-style writable detach.
+const wrap = (result: RunInspectResult): { result: RunInspectResult } => ({ result })
+const wrapWritable = (result: RunInspectResult): { result: RunInspectResult; endedWritableSession: boolean } => ({
+  result,
+  endedWritableSession: result.ok && result.escToPicker === true,
+})
+
 describe('runViewerLoop', () => {
   test('opens the preselected item directly, skipping the picker', async () => {
     let pickerCalls = 0
@@ -38,7 +46,7 @@ describe('runViewerLoop', () => {
       },
       openItem: async (item) => {
         opened.push(item.key)
-        return done
+        return wrap(done)
       },
       createTailScope: () => fakeScope(),
       onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
@@ -65,7 +73,7 @@ describe('runViewerLoop', () => {
       },
       openItem: async (item) => {
         opened.push(item.key)
-        return opened.length === 1 ? back : done
+        return wrap(opened.length === 1 ? back : done)
       },
       createTailScope: () => fakeScope(),
       onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
@@ -76,9 +84,9 @@ describe('runViewerLoop', () => {
     expect(opened).toEqual(['a', 'b'])
   })
 
-  test('listItems gets allowWritable:true first, then false after returning to the picker', async () => {
-    // Regression: after detaching from a tui (live) row, the next list refresh
-    // must not re-promote the now-dead session as writable.
+  test('allowWritable flips false after a writable (tui) detach', async () => {
+    // Regression: detaching from a tui (live) row ends the session, so the next
+    // list refresh must not re-promote the now-dead session as writable.
     const allowWritableCalls: boolean[] = []
     let pickerCalls = 0
 
@@ -95,12 +103,40 @@ describe('runViewerLoop', () => {
         pickerCalls++
         return items[pickerCalls - 1] ?? null
       },
-      openItem: async () => (pickerCalls === 1 ? back : done),
+      openItem: async () => (pickerCalls === 1 ? wrapWritable(back) : wrap(done)),
       createTailScope: () => fakeScope(),
       onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
     })
 
     expect(allowWritableCalls).toEqual([true, false])
+  })
+
+  test('allowWritable stays true after leaving logs or a read-only transcript (no live session ended)', async () => {
+    // Esc from logs / read-only must NOT disable the writable row: those viewers
+    // do not touch the live TUI session.
+    const allowWritableCalls: boolean[] = []
+    let pickerCalls = 0
+
+    await runViewerLoop<FakeItem>({
+      listItems: async ({ allowWritable }) => {
+        allowWritableCalls.push(allowWritable)
+        return [
+          { key: 'logs', kind: 'logs' },
+          { key: 'a', kind: 'session' },
+        ]
+      },
+      keyOf: (i) => i.key,
+      selectItem: async (items) => {
+        pickerCalls++
+        return items[pickerCalls - 1] ?? null
+      },
+      // First open (logs) returns back WITHOUT endedWritableSession; second ends.
+      openItem: async () => (pickerCalls === 1 ? wrap(back) : wrap(done)),
+      createTailScope: () => fakeScope(),
+      onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
+    })
+
+    expect(allowWritableCalls).toEqual([true, true])
   })
 
   test('the tui branch does not create a tail scope (no double raw-stdin owner)', async () => {
@@ -115,7 +151,7 @@ describe('runViewerLoop', () => {
         // A real tui opener never touches ctx.createTailScope; assert the loop
         // does not force one on the branch.
         if (item.kind === 'session' || item.kind === 'logs') ctx.createTailScope()
-        return done
+        return wrap(done)
       },
       createTailScope: () => {
         tailScopesCreated++
@@ -132,7 +168,7 @@ describe('runViewerLoop', () => {
       listItems: async () => [{ key: 'a', kind: 'session' }],
       keyOf: (i) => i.key,
       selectItem: async () => null,
-      openItem: async () => done,
+      openItem: async () => wrap(done),
       createTailScope: () => fakeScope(),
       onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
     })
@@ -147,7 +183,7 @@ describe('runViewerLoop', () => {
       listItems: async () => [],
       keyOf: (i) => i.key,
       selectItem: async () => null,
-      openItem: async () => done,
+      openItem: async () => wrap(done),
       createTailScope: () => fakeScope(),
       onEmpty: () => ({ ok: false, exitCode: 1, reason: 'no sessions' }),
     })
@@ -161,7 +197,7 @@ describe('runViewerLoop', () => {
       keyOf: (i) => i.key,
       preselectKey: 'a',
       selectItem: async () => null,
-      openItem: async () => ({ ok: false, exitCode: 2, reason: 'boom' }),
+      openItem: async () => wrap({ ok: false, exitCode: 2, reason: 'boom' }),
       createTailScope: () => fakeScope(),
       onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
     })

--- a/src/inspect/viewer-loop.test.ts
+++ b/src/inspect/viewer-loop.test.ts
@@ -76,6 +76,33 @@ describe('runViewerLoop', () => {
     expect(opened).toEqual(['a', 'b'])
   })
 
+  test('listItems gets allowWritable:true first, then false after returning to the picker', async () => {
+    // Regression: after detaching from a tui (live) row, the next list refresh
+    // must not re-promote the now-dead session as writable.
+    const allowWritableCalls: boolean[] = []
+    let pickerCalls = 0
+
+    await runViewerLoop<FakeItem>({
+      listItems: async ({ allowWritable }) => {
+        allowWritableCalls.push(allowWritable)
+        return [
+          { key: 'live', kind: 'tui' },
+          { key: 'b', kind: 'session' },
+        ]
+      },
+      keyOf: (i) => i.key,
+      selectItem: async (items) => {
+        pickerCalls++
+        return items[pickerCalls - 1] ?? null
+      },
+      openItem: async () => (pickerCalls === 1 ? back : done),
+      createTailScope: () => fakeScope(),
+      onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
+    })
+
+    expect(allowWritableCalls).toEqual([true, false])
+  })
+
   test('the tui branch does not create a tail scope (no double raw-stdin owner)', async () => {
     let tailScopesCreated = 0
 

--- a/src/tui/index.test.ts
+++ b/src/tui/index.test.ts
@@ -143,11 +143,11 @@ describe('createTui', () => {
     client.triggerClose()
 
     // then
-    await expect(runPromise).rejects.toThrow('closed before the session was ready')
+    await expect(runPromise).resolves.toEqual({ reason: 'connectFailed' })
     expect(exitCode).toBe(1)
   })
 
-  test('exits when the server never sends connected', async () => {
+  test('reports connectFailed when the server never sends connected', async () => {
     // given
     const terminal = new FakeTerminal()
     const client = fakeClient()
@@ -164,7 +164,7 @@ describe('createTui', () => {
     })
 
     // when / then
-    await expect(tui.run()).rejects.toThrow('timed out waiting for connected message')
+    await expect(tui.run()).resolves.toEqual({ reason: 'connectFailed' })
     expect(exitCode).toBe(1)
   })
 
@@ -1102,7 +1102,7 @@ describe('createTui queue panel', () => {
     )
   })
 
-  test('returns lostConnection: true when the WS closes after handshake without user action', async () => {
+  test('resolves lostConnection when the WS closes after handshake without user action', async () => {
     // given
     const terminal = new FakeTerminal()
     const client = fakeClient()
@@ -1120,31 +1120,47 @@ describe('createTui queue panel', () => {
     client.triggerClose()
 
     // then
-    await expect(runPromise).resolves.toEqual({ lostConnection: true })
+    await expect(runPromise).resolves.toEqual({ reason: 'lostConnection' })
   })
 
-  test('returns lostConnection: false when the user submits /quit', async () => {
+  test('resolves exit when the user submits /quit', async () => {
     // given
     const terminal = new FakeTerminal()
     const client = fakeClient()
     client.emit({ type: 'connected', sessionId: 'sid-quit' })
-    let exitCode: number | undefined
     const tui = createTui({
       url: 'ws://ignored',
       initialPrompt: '/quit',
       createClient: async () => client,
       createTerminal: () => terminal,
-      exit: (code) => {
-        exitCode = code
-        client.triggerClose()
-      },
+      exit: () => {},
     })
 
     // when
     const outcome = await tui.run()
 
     // then
-    expect(outcome).toEqual({ lostConnection: false })
-    expect(exitCode).toBe(0)
+    expect(outcome).toEqual({ reason: 'exit', exitCode: 0 })
+  })
+
+  test('resolves detach when Esc is pressed while idle', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-detach' })
+    const tui = createTui({
+      url: 'ws://ignored',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+      exit: () => {},
+    })
+
+    // when
+    const runPromise = tui.run()
+    await flush()
+    terminal.feed('\x1b')
+
+    // then
+    await expect(runPromise).resolves.toEqual({ reason: 'detach' })
   })
 })

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -50,13 +50,21 @@ export type TuiOptions = {
   onVersionMismatch?: (info: VersionMismatch) => void
 }
 
-// Outcome of a single `run()` cycle. The CLI's reconnect loop reads this to
-// decide whether to spin again or exit. `lostConnection` is true when the
-// WS closed AFTER the connected handshake without a deliberate /quit or
-// Ctrl+C — exactly the case a self-restart produces, and the only one
-// where a fresh connect can recover the session. Quit / Ctrl+C / pre-
-// handshake errors all resolve with `lostConnection: false`.
-export type TuiRunOutcome = { lostConnection: boolean }
+// Outcome of a single `run()` cycle.
+//   - 'detach': idle Esc — return to the session-viewer list. Closing the WS
+//     ends the server-side AgentSession (accepted; the list re-shows it as a
+//     read-only transcript).
+//   - 'exit': deliberate /quit or Ctrl+C — terminate the client.
+//   - 'lostConnection': WS closed AFTER the handshake without a deliberate
+//     quit/detach — exactly the self-restart case, and the only one where a
+//     fresh connect can recover the session.
+//   - 'connectFailed': pre-handshake connect/handshake error.
+// The CLI reconnect loop spins only on 'lostConnection'.
+export type TuiRunResult =
+  | { reason: 'detach' }
+  | { reason: 'exit'; exitCode: number }
+  | { reason: 'lostConnection' }
+  | { reason: 'connectFailed' }
 
 export function createTui({
   url,
@@ -68,7 +76,7 @@ export function createTui({
   expectedVersion,
   onVersionMismatch,
 }: TuiOptions) {
-  async function run(): Promise<TuiRunOutcome> {
+  async function run(): Promise<TuiRunResult> {
     const terminal = createTerminal()
     const tui = new TUI(terminal)
     const displayUrl = redactUrl(url)
@@ -78,13 +86,19 @@ export function createTui({
     tui.start()
     tui.requestRender()
 
-    const client = await createClient(url).catch((err) => {
+    // Pre-handshake failures resolve 'connectFailed' (not throw): the standalone
+    // CLI injects exit=process.exit so exit(1) ends the process and the return is
+    // moot; the viewer injects a no-op exit so run() resolves cleanly and the
+    // caller maps connectFailed into an error result instead of an uncaught reject.
+    const maybeClient = await createClient(url).catch((err) => {
       status.setText(colors.red(`connection error: ${err instanceof Error ? err.message : String(err)}`))
       tui.requestRender()
       tui.stop()
       exit(1)
-      throw err
+      return null
     })
+    if (maybeClient === null) return { reason: 'connectFailed' }
+    const client = maybeClient
 
     const handshake = await waitForConnected(client, displayUrl, handshakeTimeoutMs).catch((err) => {
       status.setText(colors.red(`connection error: ${err instanceof Error ? err.message : String(err)}`))
@@ -92,10 +106,10 @@ export function createTui({
       client.close()
       tui.stop()
       exit(1)
-      throw err
+      return null
     })
+    if (handshake === null) return { reason: 'connectFailed' }
 
-    let userInitiatedShutdown = false
     const { sessionId, serverVersion } = handshake
     status.setText(colors.dim(`session: ${sessionId}`))
     tui.requestRender()
@@ -231,12 +245,23 @@ export function createTui({
       }
     })
 
-    const closed = new Promise<boolean>((resolve) => {
-      client.onClose(() => {
-        appendHistory(new Text(colors.dim('disconnected'), 0, 0))
-        tui.requestRender()
-        resolve(!userInitiatedShutdown)
-      })
+    let settleOutcome: ((result: TuiRunResult) => void) | null = null
+    const outcome = new Promise<TuiRunResult>((resolve) => {
+      settleOutcome = resolve
+    })
+    const settle = (result: TuiRunResult): void => {
+      if (settleOutcome === null) return
+      const fn = settleOutcome
+      settleOutcome = null
+      fn(result)
+    }
+
+    client.onClose(() => {
+      appendHistory(new Text(colors.dim('disconnected'), 0, 0))
+      tui.requestRender()
+      // A user-initiated detach/exit already closed the WS deliberately and
+      // settled the outcome; onClose then fires but must not override it.
+      settle({ reason: 'lostConnection' })
     })
 
     function send(text: string): Promise<void> {
@@ -249,7 +274,7 @@ export function createTui({
 
     function runTuiCommand(command: TuiCommandName): boolean {
       if (command === 'quit') {
-        shutdown(0)
+        exitWith(0)
         return true
       }
       if (command === 'reload') {
@@ -266,29 +291,44 @@ export function createTui({
       return true
     }
 
-    // Esc aborts an in-flight reply. The Editor does not bind Esc, so a
-    // top-level input listener can intercept it without fighting the editor.
+    // Esc means "abort the in-flight reply" while a turn is generating, and
+    // "detach back to the session list" when idle. The Editor does not bind
+    // Esc, so a top-level listener intercepts it without fighting the editor.
     tui.addInputListener((data) => {
-      if (matchesKey(data, Key.escape) && replyInFlight) {
+      if (!matchesKey(data, Key.escape)) return undefined
+      if (replyInFlight) {
         client.send({ type: 'abort' })
         return { consume: true }
       }
-      return undefined
+      detach()
+      return { consume: true }
     })
 
-    const shutdown = (code: number) => {
-      userInitiatedShutdown = true
+    // Settle BEFORE closing the client: client.close() fires onClose, which
+    // settles 'lostConnection'. settle() is idempotent, so the first call wins —
+    // settling the deliberate outcome first keeps the later onClose a no-op.
+    const teardown = (): void => {
       tui.stop()
       client.close()
+    }
+
+    const exitWith = (code: number): void => {
+      settle({ reason: 'exit', exitCode: code })
+      teardown()
       exit(code)
     }
 
-    // Ctrl+C exits cleanly. In raw mode the kernel does NOT generate SIGINT,
-    // so we must intercept the \x03 byte ourselves. The Editor would otherwise
-    // swallow it. tui.stop() restores raw-mode/cursor/echo before we exit.
+    const detach = (): void => {
+      settle({ reason: 'detach' })
+      teardown()
+    }
+
+    // Ctrl+C exits the client. In raw mode the kernel does NOT generate SIGINT,
+    // so we intercept the \x03 byte ourselves; the Editor would otherwise
+    // swallow it. teardown() restores raw-mode/cursor/echo before we settle.
     tui.addInputListener((data) => {
       if (matchesKey(data, Key.ctrl('c'))) {
-        shutdown(0)
+        exitWith(0)
         return { consume: true }
       }
       return undefined
@@ -330,15 +370,15 @@ export function createTui({
       const command = parseBareTuiCommand(initialPrompt)
       if (command !== null) {
         runTuiCommand(command)
-        if (command === 'quit') return { lostConnection: false }
+        if (command === 'quit') return { reason: 'exit', exitCode: 0 }
       } else {
         await send(initialPrompt)
       }
     }
 
-    const lostConnection = await closed
+    const result = await outcome
     tui.stop()
-    return { lostConnection }
+    return result
   }
 
   return { run }


### PR DESCRIPTION
## What

Merges `tui`, `inspect`, and `logs` into a single **list-first session viewer**. The viewer's home screen is one list where every selectable thing is a row:

- **any session** → read-only replay + live tail (today's `inspect`)
- **the live TUI session** → read+write (today's `tui`)
- **container logs** → read-only log stream (today's `logs`)

The three commands stay, but become **deep-links** into the same viewer. `esc` returns to the list from any viewer; `ctrl-c` exits.

## Why

`tui`, `inspect`, and `logs` are three windows onto the same agent. `tui`+`inspect` already share the server, port/token discovery, and the same `AgentSession` event source — the only real differences are read-vs-write and the renderer. Unifying them gives one mental model and one back-button (`esc` → list) everywhere, and naturally fills a gap: re-opening a TUI session now replays its transcript from disk first.

## How

**Server is untouched** — this is pure client-side composition.

- **`ViewerItem`** union (`session | tui | logs`). `listViewerItems()` marks **at most one** writable TUI row via a heuristic (container up + most-recent tui-origin session); everything else is read-only. The logs row is always present (works with the server down).
- **`runViewerLoop`** — a generic pick → open → back state machine. `session`/`logs` branches run under the loop's tail scope; the **`tui` branch skips the tail scope** because `createTui` owns its own raw-mode terminal (two raw-stdin owners would corrupt input). `runInspectLoop` is kept verbatim as the JSON/scriptable session-only path.
- **`createTui`** now returns a structured `TuiRunResult` (`detach | exit | lostConnection | connectFailed`). `esc` aborts an in-flight reply, or detaches to the list when idle; `ctrl-c`/`/quit` exit. **Detach closes the WS, which ends the server-side session** (accepted — no server change; the list re-shows it as a read-only transcript).
- **`logs`** viewer is opt-in via `typeclaw logs --list`. The default dump and `-f`/piped paths stay the raw `docker logs` pump, so `typeclaw logs | grep` and CI are unaffected.

## Commits

1. `tui: return a structured TuiRunResult from createTui`
2. `inspect: add the ViewerItem session-viewer core` (model, loop, branch handlers, dispatcher — lands with tests, no CLI consumer yet)
3. `inspect: wire tui/inspect/logs into the session viewer`

## Design decisions

- **Reuse `inspect`** as the core name (it already *is* the list-first viewer); `tui`/`logs` are deep-links.
- **One canonical writable row** (most-recent tui session) rather than every live session — keeps "who owns the session" simple.
- **Heuristic** writable detection (no new protocol) over an authoritative server query.
- **Detach = teardown** because keeping the session alive on WS-close would require a server change (the close handler disposes the session today, asserted by `server/index.test.ts`).

## Testing

`typecheck` / `lint` (0 errors) / `format:check` clean. Full suite: **7178 pass, 1 skip** (the one failing assertion is an unrelated worktree-directory-name artifact that passes on CI). New tests cover the `ViewerItem` model, `listViewerItems` heuristic, `runViewerLoop` (incl. a regression that the **tui branch never creates a tail scope**), `runTuiViewer` outcome mapping + reconnect, and the new `createTui` detach/exit/connectFailed outcomes.

Reviewed by Oracle; all four flagged issues fixed (prefix deep-link resolution, logs `--list` opt-in, `connectFailed` contract, version-mismatch forwarding).

## Update: rich read-only transcript view

The interactive `inspect` session view now renders with pi-tui components (the same engine as the live TUI) instead of one terse line per event — assistant text as **Markdown blocks**, tool calls as **formatted panels**, matching the live TUI's look but **read-only** (no editor; a sticky `── read-only · esc to return to list · q to quit ──` footer).

**How:**
- Extracted `streamSessionEvents` — the shared replay→live read pipeline (since/filter/abort, lifecycle phases) that the line renderer and the new view both consume. The line/JSON renderer is now a thin consumer with identical output (a footer-dedup regression test guards this).
- New `createTranscriptView` (read-only sibling to `createTui`): builds a pi-tui tree from `InspectEvent`s, reusing `tui/format` + `markdownTheme`. Batches renders during replay, per-event once live. Owns its own raw-mode terminal (esc → list, q/ctrl-c → exit), so `open-item` routes interactive-TTY session items here **without** the tail scope — same raw-stdin-ownership rule as the writable tui branch.

**Unchanged:** `--json`/piped/non-TTY keep the scriptable line renderer; the container-logs item stays the raw `docker logs` stream; the writable tui item stays `createTui`.

**Reviewed by Oracle** (design + implementation); fixed the findings (duplicate end-of-transcript footer, a key-binding doc, and a `compact(undefined)` guard).

## Known follow-up (non-blocking)

`containerRunning` is sampled once when the viewer opens; if the container starts/stops while the list is open, the writable row can be stale until re-entry. Recomputing per list-refresh is a small follow-up (adds a Docker call per refresh).