### PR TITLE
channels: recover text from plain-text channel_reply/send leaks

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -18,6 +18,8 @@ import {
   CHANNEL_MAX_OUTPUT_TOKENS,
   createChannelRouter,
   DUPLICATE_SEND_ERROR,
+  extractPlainTextChannelToolCallText,
+  getPlainTextChannelToolCallKind,
   MAX_CHANNEL_SENDS_PER_TURN,
   MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN,
   MAX_TYPING_HEARTBEAT_MS,
@@ -2474,7 +2476,7 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('suppressed kimi_tool_call_leak'))).toBe(false)
   })
 
-  test('suppresses leaked plain-text channel_reply(...) function-call serialization instead of posting it to the channel', async () => {
+  test('recovers the text arg from a leaked plain-text channel_reply(...) serialization instead of dropping it', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: Array<{ text: string }> = []
@@ -2490,12 +2492,33 @@ describe('ChannelRouter channel-turn protocol', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    expect(sent).toHaveLength(0)
-    expect(logs.some((m) => m.includes('suppressed plain_text_channel_tool_call'))).toBe(true)
-    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('hi there')
+    expect(logs.some((m) => m.includes('recovered plain_text_channel_tool_call kind=reply'))).toBe(true)
   })
 
-  test('suppresses leaked plain-text channel_send(...) serialization the same way', async () => {
+  test('recovers the text arg from the unquoted-key channel_reply shape Kimi emits', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'yo typeey' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('channel_reply({ text: "hey! what\'s going on today?" })')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe("hey! what's going on today?")
+    expect(logs.some((m) => m.includes('recovered plain_text_channel_tool_call kind=reply'))).toBe(true)
+  })
+
+  test('recovers the text arg from a truncated channel_reply(...) serialization', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: Array<{ text: string }> = []
@@ -2507,12 +2530,74 @@ describe('ChannelRouter channel-turn protocol', () => {
 
     await router.route(inbound({ text: 'hello' }))
     sessions[0]!.onPrompt = () => {
-      sessions[0]!.setAssistantText('channel_send({"adapter":"discord-bot","chat":"c1","text":"hi"})')
+      sessions[0]!.setAssistantText('channel_reply({"text":"hi there, how can I help')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('hi there, how can I help')
+    expect(logs.some((m) => m.includes('recovered plain_text_channel_tool_call kind=reply'))).toBe(true)
+  })
+
+  test('recovers only the text arg from a leaked channel_send(...), ignoring model-supplied destination', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ chat: string; text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ chat: msg.chat, text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('channel_send({"adapter":"discord-bot","chat":"evil-channel","text":"hi"})')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('hi')
+    expect(sent[0]!.chat).not.toBe('evil-channel')
+    expect(logs.some((m) => m.includes('recovered plain_text_channel_tool_call kind=send'))).toBe(true)
+  })
+
+  test('suppresses a leaked channel_reply(...) whose extracted text is itself a no-reply signal', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('channel_reply({"text":"NO_REPLY"})')
     }
     await router.__testing!.flushDebounce(KEY)
 
     expect(sent).toHaveLength(0)
-    expect(logs.some((m) => m.includes('suppressed plain_text_channel_tool_call'))).toBe(true)
+  })
+
+  test('suppresses a leaked channel_reply(...) with no recoverable text arg', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('channel_reply({"reason":"some leaked arg with a " quote"})')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('suppressed unextractable_plain_text_channel_tool_call'))).toBe(true)
   })
 
   test('suppresses leaked plain-text skip_response(...) serialization instead of posting it to the channel', async () => {
@@ -2532,7 +2617,7 @@ describe('ChannelRouter channel-turn protocol', () => {
     await router.__testing!.flushDebounce(KEY)
 
     expect(sent).toHaveLength(0)
-    expect(logs.some((m) => m.includes('suppressed plain_text_channel_tool_call'))).toBe(true)
+    expect(logs.some((m) => m.includes('suppressed plain_text_channel_skip_response'))).toBe(true)
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
   })
 
@@ -2576,6 +2661,66 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sent).toHaveLength(1)
     expect(sent[0]!.text).toContain('channel_reply tool')
     expect(logs.some((m) => m.includes('suppressed plain_text_channel_tool_call'))).toBe(false)
+  })
+
+  describe('getPlainTextChannelToolCallKind', () => {
+    test('classifies anchored reply/send/skip serializations', () => {
+      expect(getPlainTextChannelToolCallKind('channel_reply({"text":"hi"})')).toBe('reply')
+      expect(getPlainTextChannelToolCallKind('channel_send({"chat":"c","text":"hi"})')).toBe('send')
+      expect(getPlainTextChannelToolCallKind('skip_response({ reason: "no content" })')).toBe('skip')
+    })
+
+    test('returns null for prose that merely mentions a tool name', () => {
+      expect(getPlainTextChannelToolCallKind('Use the channel_reply tool to send "text".')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('channel_reply does this')).toBeNull()
+    })
+  })
+
+  describe('extractPlainTextChannelToolCallText', () => {
+    test('extracts double-quoted text', () => {
+      expect(extractPlainTextChannelToolCallText('channel_reply({"text":"hi there"})')).toBe('hi there')
+    })
+
+    test('extracts unquoted-key, single-space, apostrophe-bearing text', () => {
+      expect(extractPlainTextChannelToolCallText('channel_reply({ text: "what\'s up" })')).toBe("what's up")
+    })
+
+    test('extracts single-quoted value with an escaped inner quote', () => {
+      expect(extractPlainTextChannelToolCallText("channel_reply({text: 'it\\'s me'})")).toBe("it's me")
+    })
+
+    test('decodes \\n / \\t escapes inside the value', () => {
+      expect(extractPlainTextChannelToolCallText('channel_reply({"text":"line1\\nline2\\ttab"})')).toBe(
+        'line1\nline2\ttab',
+      )
+    })
+
+    test('recovers a truncated value missing its closing quote and paren', () => {
+      expect(extractPlainTextChannelToolCallText('channel_reply({"text":"hello world')).toBe('hello world')
+    })
+
+    test('ignores destination args and extracts only text from channel_send', () => {
+      expect(
+        extractPlainTextChannelToolCallText('channel_send({"adapter":"discord-bot","chat":"c1","text":"hi"})'),
+      ).toBe('hi')
+    })
+
+    test('returns null when no text arg is present', () => {
+      expect(extractPlainTextChannelToolCallText('channel_reply({"reason":"nope"})')).toBeNull()
+    })
+
+    test('returns null for an empty text value', () => {
+      expect(extractPlainTextChannelToolCallText('channel_reply({"text":""})')).toBeNull()
+      expect(extractPlainTextChannelToolCallText('channel_reply({"text":"   "})')).toBeNull()
+    })
+
+    test('returns null for skip_response (never a user-facing reply)', () => {
+      expect(extractPlainTextChannelToolCallText('skip_response({ reason: "x" })')).toBeNull()
+    })
+
+    test('returns null for prose mentioning the tool name', () => {
+      expect(extractPlainTextChannelToolCallText('Use channel_reply with a "text" field.')).toBeNull()
+    })
   })
 
   test('recovers visible assistant text when no channel tool sent a message', async () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2518,6 +2518,27 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('recovered plain_text_channel_tool_call kind=reply'))).toBe(true)
   })
 
+  test('recovers the text arg from a single-quoted channel_reply(...) serialization', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText("channel_reply({text: 'it\\'s me'})")
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe("it's me")
+    expect(logs.some((m) => m.includes('recovered plain_text_channel_tool_call kind=reply'))).toBe(true)
+  })
+
   test('recovers the text arg from a truncated channel_reply(...) serialization', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4273,8 +4273,12 @@ export function isLikelyKimiChannelToolLeak(text: string): boolean {
 //
 // Structural-only detection (NOT a substring search): the trimmed text must
 // *start* with `channel_reply(`, `channel_send(`, or `skip_response(`, and
-// that opening paren must enclose at least one `"` (the serialized argument).
-// This deliberately matches the leak shape while letting prose that merely
+// that opening paren must enclose at least one quote — `"` or `'` (the
+// serialized argument). The single-quote arm matters because the extractor
+// recovers single-quoted values too; if the classifier only matched `"`, a
+// single-quoted leak like `channel_reply({text: 'hi'})` would bypass the
+// extractor and post raw plumbing. This deliberately matches the leak shape
+// while letting prose that merely
 // *mentions* a tool name (e.g. "I would normally call channel_reply here
 // but...") reach the user — that false-positive class is already locked in by
 // the `still recovers prose that mentions channel_reply` test.
@@ -4282,7 +4286,7 @@ export function isLikelyKimiChannelToolLeak(text: string): boolean {
 // The trailing close paren is NOT required: the model sometimes truncates
 // mid-serialization, and a half-leaked `channel_reply({"text":"..."` is
 // just as user-hostile as the full shape.
-const PLAIN_TEXT_CHANNEL_TOOL_CALL_RE = /^(channel_reply|channel_send|skip_response)\s*\(\s*[^)]*"/
+const PLAIN_TEXT_CHANNEL_TOOL_CALL_RE = /^(channel_reply|channel_send|skip_response)\s*\(\s*[^)]*["']/
 
 export type PlainTextChannelToolCallKind = 'reply' | 'send' | 'skip'
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2854,7 +2854,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return
     }
 
-    const { text: assistantText, source } = candidate
+    const { text: candidateText, source } = candidate
+    let assistantText = candidateText
 
     if (endsWithNoReplySignal(assistantText)) {
       const leakedReasoning = !isNoReplySignal(assistantText)
@@ -2874,9 +2875,48 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return
     }
 
-    if (isLikelyPlainTextChannelToolCall(assistantText)) {
-      logger.warn(`[channels] ${live.keyId}: suppressed plain_text_channel_tool_call text_len=${assistantText.length}`)
+    // Plain-text tool-call leak: the model serialized a channel tool call as
+    // ordinary prose instead of producing a real tool call (a Kimi-on-Fireworks
+    // failure mode — see `isLikelyPlainTextChannelToolCall`). We can't post the
+    // raw `channel_reply({...})` serialization to the channel, but for
+    // reply/send the model's *intent* is unambiguous: deliver the `text` arg.
+    // Extract it and recover the actual message. `skip_response` is the
+    // opposite — a genuine decline — so it stays suppressed.
+    const plainTextToolCallKind = getPlainTextChannelToolCallKind(assistantText)
+    if (plainTextToolCallKind === 'skip') {
+      logger.warn(
+        `[channels] ${live.keyId}: suppressed plain_text_channel_skip_response text_len=${assistantText.length}`,
+      )
       return
+    }
+    if (plainTextToolCallKind !== null) {
+      const extracted = extractPlainTextChannelToolCallText(assistantText)
+      // Unextractable (no `text` arg, empty value, or fully-truncated): fall
+      // back to the historical safe behavior — drop it rather than leak plumbing.
+      if (extracted === null) {
+        logger.warn(
+          `[channels] ${live.keyId}: suppressed unextractable_plain_text_channel_tool_call text_len=${assistantText.length}`,
+        )
+        return
+      }
+      // The extracted value is still untrusted model output: if it is itself a
+      // no-reply signal, an empty-response sentinel, or another (nested) leaked
+      // tool call, suppress it through the same guards rather than re-leaking.
+      if (
+        endsWithNoReplySignal(extracted) ||
+        isUpstreamEmptyResponseSentinel(extracted) ||
+        isLikelyKimiChannelToolLeak(extracted) ||
+        isLikelyPlainTextChannelToolCall(extracted)
+      ) {
+        logger.warn(
+          `[channels] ${live.keyId}: suppressed plain_text_channel_tool_call (unsafe extracted text) text_len=${extracted.length}`,
+        )
+        return
+      }
+      logger.warn(
+        `[channels] ${live.keyId}: recovered plain_text_channel_tool_call kind=${plainTextToolCallKind} text_len=${extracted.length}`,
+      )
+      assistantText = extracted
     }
 
     // `source` distinguishes the three recovery shapes for log triage:
@@ -4242,11 +4282,72 @@ export function isLikelyKimiChannelToolLeak(text: string): boolean {
 // The trailing close paren is NOT required: the model sometimes truncates
 // mid-serialization, and a half-leaked `channel_reply({"text":"..."` is
 // just as user-hostile as the full shape.
-const PLAIN_TEXT_CHANNEL_TOOL_CALL_RE = /^(?:channel_(?:reply|send)|skip_response)\s*\(\s*[^)]*"/
+const PLAIN_TEXT_CHANNEL_TOOL_CALL_RE = /^(channel_reply|channel_send|skip_response)\s*\(\s*[^)]*"/
+
+export type PlainTextChannelToolCallKind = 'reply' | 'send' | 'skip'
+
+export function getPlainTextChannelToolCallKind(text: string): PlainTextChannelToolCallKind | null {
+  const match = PLAIN_TEXT_CHANNEL_TOOL_CALL_RE.exec(text.trim())
+  if (match === null) return null
+  switch (match[1]) {
+    case 'channel_reply':
+      return 'reply'
+    case 'channel_send':
+      return 'send'
+    case 'skip_response':
+      return 'skip'
+    default:
+      return null
+  }
+}
 
 export function isLikelyPlainTextChannelToolCall(text: string): boolean {
-  return PLAIN_TEXT_CHANNEL_TOOL_CALL_RE.test(text.trim())
+  return getPlainTextChannelToolCallKind(text) !== null
 }
+
+// Tolerant single-purpose scanner that pulls the `text` argument out of a
+// plain-text-serialized `channel_reply(...)` / `channel_send(...)` leak. A
+// single regex covering every shape (double/single/unquoted keys, escaped
+// quotes, mid-serialization truncation) is fragile, so this walks the string
+// once and extracts only the first string-valued `text` property. `channel_send`
+// also carries `adapter`/`chat`/`thread`, which are intentionally ignored —
+// recovery always routes back through the current channel, never a
+// model-supplied destination. Returns null when no recoverable, non-empty
+// `text` value is present so the caller can fall back to suppression.
+export function extractPlainTextChannelToolCallText(text: string): string | null {
+  const trimmed = text.trim()
+  if (!/^(?:channel_reply|channel_send)\s*\(/.test(trimmed)) return null
+
+  const keyRe = /(?:[{,\s])(?:"text"|'text'|text)\s*:\s*/g
+  const keyMatch = keyRe.exec(trimmed)
+  if (keyMatch === null) return null
+
+  let i = keyMatch.index + keyMatch[0].length
+  const quote = trimmed[i]
+  if (quote !== '"' && quote !== "'") return null
+  i++
+
+  let value = ''
+  let escaped = false
+  for (; i < trimmed.length; i++) {
+    const ch = trimmed[i]!
+    if (escaped) {
+      value += ESCAPE_REPLACEMENTS[ch] ?? ch
+      escaped = false
+      continue
+    }
+    if (ch === '\\') {
+      escaped = true
+      continue
+    }
+    if (ch === quote) break
+    value += ch
+  }
+
+  return value.trim().length > 0 ? value : null
+}
+
+const ESCAPE_REPLACEMENTS: Record<string, string> = { n: '\n', r: '\r', t: '\t' }
 
 function describe(err: unknown): string {
   return err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Background

A Discord bot using a Kimi-K2 model on Fireworks went completely silent — never posting replies. Root cause: the model was producing its reply but serializing the channel tool call as plain text instead of emitting a real structured tool call. The assistant message body was literally:

```
channel_reply({ text: "yeah i'm here, what's up?" })
```

The channel router (`validateChannelTurn`) detected this leak shape via `isLikelyPlainTextChannelToolCall` and suppressed it outright — logged `suppressed plain_text_channel_tool_call` and returned, posting nothing. From the channel's side the bot looked dead even though the model had produced the exact reply text it intended to send. Verified from container logs (every inbound message went `prompting -> suppressed plain_text_channel_tool_call -> prompted`) and the session transcript (assistant text was literally the channel reply call in plain prose).

## Summary

Recover instead of drop. Extract the `text` argument from leaked plain-text serializations of channel tool calls and deliver it through the existing `source:'system'` recovery path.

Key decisions:

- `skip_response(...)` is **still suppressed** — it's a genuine decline, never a user-facing reply. Posting it would leak "I'm staying silent" plumbing. The suppression log is now `suppressed plain_text_channel_skip_response` to distinguish the two paths.
- Extraction failure **falls back to the historical safe behavior** — if no text arg is found, the value is empty, or the serialization is fully unrecoverable, the message is dropped rather than leaking plumbing text.
- The extractor (`extractPlainTextChannelToolCallText`) is a tolerant single-pass scanner, not a regex. It handles double/single/unquoted keys, escaped quotes, `\n`/`\t` escape sequences, and mid-serialization truncation. The model sometimes truncates, so a half-leaked call is recovered too.
- `channel_send` ignores the model-supplied routing args (`adapter`, `chat`, `thread`). Recovery always routes back through the current channel context, never to a model-supplied destination. This prevents destination spoofing where a leaked call with a crafted target could route the reply somewhere unexpected.
- Extracted text is re-run through the existing downstream guards (`endsWithNoReplySignal`, `isUpstreamEmptyResponseSentinel`, `isLikelyKimiChannelToolLeak`, `isLikelyPlainTextChannelToolCall`) so a nested or no-reply payload cannot re-leak through the recovery path.

Two new exported helpers land near the existing detector:

- `getPlainTextChannelToolCallKind` — returns `'reply'`, `'send'`, `'skip'`, or `null`
- `extractPlainTextChannelToolCallText` — returns the extracted text string or `null`

## Preview

No visual output — library-internal changes only.

## What this does NOT do

- Does NOT change behavior for any correctly-structured tool call.
- Does NOT attempt to recover `skip_response(...)` — that's a deliberate agent choice to stay silent, not a serialization failure.
- Does NOT honor the routing arguments from a leaked `channel_send` call (deliberate; see destination-spoofing note above).
- Does NOT attempt recovery when extraction yields an empty or whitespace-only string.

## Review notes

Load-bearing files: `src/channels/router.ts` (+106/−5) and `src/channels/router.test.ts` (+159/−12).

The `validateChannelTurn` branch for `isLikelyPlainTextChannelToolCall` is replaced with a kind-dispatch: `skip` suppresses, `reply`/`send` extracts and recovers, `null` passes through.

The two existing suppression tests for plain-text `channel_reply` and `channel_send` are **flipped** to assert recovery of the text arg. `skip_response` suppression remains. "Prose that merely mentions channel_reply/skip_response passes through untouched" also remains.

New integration tests cover: unquoted-key Kimi shape, truncated serialization, `channel_send` ignoring model destination, extracted-text-that-is-a-no-reply-signal being suppressed, and unextractable-arg being dropped.

A focused `describe` block unit-tests all parsing edge cases of `getPlainTextChannelToolCallKind` and `extractPlainTextChannelToolCallText`.

**Note on test suite:** `bun test --parallel src/channels/router.test.ts` passes 363/363. Full suite: 7192 pass, 1 fail. The one failure (`resolveSelfPackageJsonPath > points at this package manifest` in `src/update/index.test.ts`) is a pre-existing environmental artifact — that test asserts the checkout directory is named `typeclaw`; it fails only when run from a worktree with a different directory name. It is unrelated to this change (no `src/update/` code is touched) and passes in CI.

Checks: `bun run typecheck` clean, `bun run lint` 0 errors (65 pre-existing warnings, none in changed files), `bun run format:check` clean.