### PR TITLE
channels: gate proactive-reaction prompt on a real reaction target

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -201,7 +201,7 @@ describe('renderSessionOrigin', () => {
   })
 
   test.each(['slack-bot', 'discord-bot', 'github'] as const)(
-    'reaction-capable channel origin (%s) tells the model to react proactively with channel_react',
+    'reaction-capable channel origin (%s) tells the model to react proactively with channel_react when a reaction target exists',
     (adapter) => {
       const out = renderSessionOrigin({
         kind: 'channel',
@@ -209,6 +209,7 @@ describe('renderSessionOrigin', () => {
         workspace: 'W0',
         chat: 'C0',
         thread: null,
+        reactionRef: { adapter, value: 'target' },
       })
       expect(out).toMatch(/React like a teammate/i)
       expect(out).toMatch(/channel_react\(\{ emoji \}\)/)
@@ -217,6 +218,26 @@ describe('renderSessionOrigin', () => {
       expect(out).toMatch(/tada/)
       // A reaction must not be presented as satisfying the reply obligation.
       expect(out).toMatch(/does NOT satisfy the\s+reply obligation/i)
+    },
+  )
+
+  // Regression for the `channel_react denied: this conversation has no message
+  // to react to` incident: reminder-only turns (restart-resume, subagent-
+  // completion, idle/todo continuation) wake a reaction-capable session with
+  // no inbound, so the origin carries no reactionRef. The proactive-reaction
+  // block must be suppressed there, otherwise the model is nudged into a
+  // channel_react the tool will deny.
+  test.each(['slack-bot', 'discord-bot', 'github'] as const)(
+    'reaction-capable channel origin (%s) omits the proactive-reaction guidance when there is no reaction target',
+    (adapter) => {
+      const out = renderSessionOrigin({
+        kind: 'channel',
+        adapter,
+        workspace: 'W0',
+        chat: 'C0',
+        thread: null,
+      })
+      expect(out).not.toMatch(/React like a teammate/i)
     },
   )
 
@@ -229,6 +250,7 @@ describe('renderSessionOrigin', () => {
         workspace: 'W0',
         chat: 'C0',
         thread: null,
+        reactionRef: { adapter, value: 'target' },
       })
       expect(out).not.toMatch(/React like a teammate/i)
       expect(out).not.toMatch(/channel_react/)

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -297,6 +297,7 @@ function renderChannelOrigin(
     chat: string
     chatName?: string
     thread: string | null
+    reactionRef?: ReactionRef
     participants?: readonly ChannelParticipant[]
     membership?: MembershipCount
     self?: ChannelSelfIdentity
@@ -354,7 +355,14 @@ function renderChannelOrigin(
   const conversationLine = renderConversationLine(origin)
   if (conversationLine !== null) lines.push('', conversationLine)
 
-  if (platformInfo.supportsReactions) {
+  // Gate on `reactionRef`, not just the static `supportsReactions` platform
+  // fact: a turn only has a message to react to when the triggering inbound
+  // carried one. Reminder-only turns (restart-resume, subagent-completion,
+  // idle/todo continuation) wake the session with no inbound, so
+  // `buildLiveOrigin` omits `reactionRef`. Prompting "react like a teammate"
+  // there made the model call `channel_react`, which then denied with "this
+  // conversation has no message to react to".
+  if (platformInfo.supportsReactions && origin.reactionRef !== undefined) {
     lines.push(
       '',
       '**React like a teammate would.** You can drop an emoji on the message that',


### PR DESCRIPTION
## Background

A Slack-connected agent emitted `channel_react denied: this conversation has no message to react to` (src/agent/tools/channel-react.ts:61). The tool fails closed when `origin.reactionRef === undefined` — correct behavior — but the agent should never have *called* it.

Root cause is a prompt/tool mismatch from commit 454b4355 ("agent: make channel_react proactive and sentiment-driven"). The "React like a teammate" block in the channel session origin (src/agent/session-origin.ts) is gated only on `PlatformInfo.supportsReactions`, a static platform fact that is always true for Slack/Discord/GitHub. But a turn only has a message to react to when its triggering inbound carried a `reactionRef`.

On reminder-only turns — restart-resume wake (router.ts resumeRestartHandoff), subagent-completion (injectSubagentCompletionReminder), idle/todo continuation (maybeContinueTodosChannel) — the session wakes with no inbound. `drain()` runs with batch.length === 0, so `currentTurnReactionRef` stays null and `buildLiveOrigin` omits `reactionRef`. The prompt still told the model to react, it obliged, and the tool denied. A phantom reaction the model was nudged into making.

## Summary

Gate the proactive-reaction block on `origin.reactionRef !== undefined` in addition to `supportsReactions`. The runtime already threads the per-turn `reactionRef` through `buildLiveOrigin`, so no router changes are needed — only `renderChannelOrigin` had to start reading it.

Why gate in the prompt rather than soften the tool: the tool's fail-closed deny is the correct contract (you genuinely cannot react to a non-existent message). The bug is that the prompt invites a call that can't succeed. Fixing the invitation removes the wasted tool call and the confusing log line at the source.

## What this does NOT do

- Does not change `channel_react`'s deny behavior — reminder-only turns still (correctly) cannot react.
- Does not persist a prior turn's `reactionRef` to let reminder turns react to an older message (semantically wrong — reacting to a stale inbound).
- No change for Telegram/KakaoTalk: `supportsReactions: false` already suppressed the block; the added `reactionRef` in their test just proves the double-guard holds.

## Review notes

- Load-bearing change: src/agent/session-origin.ts — `if (platformInfo.supportsReactions && origin.reactionRef !== undefined)`.
- Regression test: reaction-capable adapters with no `reactionRef` must omit the "React like a teammate" block (the reminder-only case). Existing reaction-capable tests now pass a `reactionRef` to keep asserting the block appears on real inbound turns.