### PR TITLE
channels: recognize a bare-slug @mention of an App-auth github bot

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -154,6 +154,19 @@ describe('classifyGithubInbound', () => {
       expect(msg?.isBotMention).toBe(false)
     })
 
+    it('does not treat a longer login sharing the decoy-slug prefix as a self-mention', () => {
+      // The decoy slug for `typeclaw[bot]` is `typeclaw`; `@typeclaw-bot` is a
+      // DIFFERENT GitHub user. A substring check would false-positive here, so
+      // the matcher must respect GitHub-login boundaries (- is a login char).
+      const msg = classifyGithubInbound(
+        'issue_comment',
+        issueCommentPayload({ pullRequest: true, body: '@typeclaw-bot can you review?' }),
+        'typeclaw[bot]',
+        { authType: 'app' },
+      )
+      expect(msg?.isBotMention).toBe(false)
+    })
+
     it('does not derive a decoy slug under PAT auth (only the real login mentions)', () => {
       // PAT bots are real users requested by their actual login; there is no
       // decoy slug, so a bare-prefix collision must not register as a mention.

--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -118,6 +118,63 @@ describe('classifyGithubInbound', () => {
     })
   })
 
+  // Regression: under GitHub App auth selfLogin is the actor login `slug[bot]`,
+  // but a human mentions the App by its bare slug `@slug` (the decoy account).
+  // The classifier must recognize the bare-slug mention or a direct
+  // "@typeey review again" lands with isBotMention=false and the engagement
+  // mention gate never fires (the comment is silently observed/dropped).
+  describe('isBotMention decoy-aware detection (App auth)', () => {
+    it('recognizes a bare-slug @mention of an App bot whose actor login is slug[bot]', () => {
+      const msg = classifyGithubInbound(
+        'issue_comment',
+        issueCommentPayload({ pullRequest: true, body: '@typeclaw review again' }),
+        'typeclaw[bot]',
+        { authType: 'app' },
+      )
+      expect(msg?.isBotMention).toBe(true)
+    })
+
+    it('still recognizes the full slug[bot] @mention under App auth', () => {
+      const msg = classifyGithubInbound(
+        'issue_comment',
+        issueCommentPayload({ pullRequest: true, body: '@typeclaw[bot] review again' }),
+        'typeclaw[bot]',
+        { authType: 'app' },
+      )
+      expect(msg?.isBotMention).toBe(true)
+    })
+
+    it('does not flag an unrelated @mention as a self-mention under App auth', () => {
+      const msg = classifyGithubInbound(
+        'issue_comment',
+        issueCommentPayload({ pullRequest: true, body: '@someone-else take a look' }),
+        'typeclaw[bot]',
+        { authType: 'app' },
+      )
+      expect(msg?.isBotMention).toBe(false)
+    })
+
+    it('does not derive a decoy slug under PAT auth (only the real login mentions)', () => {
+      // PAT bots are real users requested by their actual login; there is no
+      // decoy slug, so a bare-prefix collision must not register as a mention.
+      const hit = classifyGithubInbound(
+        'issue_comment',
+        issueCommentPayload({ pullRequest: true, body: '@typeclaw review again' }),
+        'typeclaw-bot',
+        { authType: 'pat' },
+      )
+      expect(hit?.isBotMention).toBe(false)
+
+      const realMention = classifyGithubInbound(
+        'issue_comment',
+        issueCommentPayload({ pullRequest: true, body: '@typeclaw-bot review again' }),
+        'typeclaw-bot',
+        { authType: 'pat' },
+      )
+      expect(realMention?.isBotMention).toBe(true)
+    })
+  })
+
   describe('pull_request.review_requested', () => {
     it('wakes the bot when it is the requested reviewer', () => {
       const msg = classifyGithubInbound(
@@ -1317,12 +1374,17 @@ function user(): Record<string, unknown> {
   return { login: 'alice', id: 10, type: 'User' }
 }
 
-function issueCommentPayload(options: { pullRequest: boolean }): Record<string, unknown> {
+function issueCommentPayload(options: { pullRequest: boolean; body?: string }): Record<string, unknown> {
   return {
     action: 'created',
     repository: repo(),
     issue: { number: 7, ...(options.pullRequest ? { pull_request: {} } : {}) },
-    comment: { id: 99, body: '@typeclaw-bot hello', created_at: '2026-01-01T00:00:00Z', user: user() },
+    comment: {
+      id: 99,
+      body: options.body ?? '@typeclaw-bot hello',
+      created_at: '2026-01-01T00:00:00Z',
+      user: user(),
+    },
   }
 }
 

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -187,6 +187,7 @@ export function classifyGithubInbound(
 ): InboundMessage | null {
   const repository = readRepository(payload)
   if (repository === null) return null
+  const mention = resolveBotMentionLogins(selfLogin, options?.authType ?? 'pat')
   const base = {
     adapter: 'github' as const,
     workspace: `${repository.owner}/${repository.name}`,
@@ -209,7 +210,7 @@ export function classifyGithubInbound(
       comment.body,
       id,
       user,
-      selfLogin,
+      mention,
       comment.created_at,
       { kind: 'issue-comment', owner: repository.owner, repo: repository.name, commentId: id },
     )
@@ -228,7 +229,7 @@ export function classifyGithubInbound(
       comment.body,
       id,
       readUser(comment.user),
-      selfLogin,
+      mention,
       comment.created_at,
       { kind: 'pr-review-comment', owner: repository.owner, repo: repository.name, commentId: id },
     )
@@ -246,7 +247,7 @@ export function classifyGithubInbound(
       comment.body,
       id,
       readUser(comment.user),
-      selfLogin,
+      mention,
       comment.created_at,
       null,
     )
@@ -270,7 +271,7 @@ export function classifyGithubInbound(
       text,
       id,
       opener,
-      selfLogin,
+      mention,
       issue.created_at,
       { kind: 'issue', owner: repository.owner, repo: repository.name, issueNumber: number },
       action === 'opened' && !hasBody,
@@ -325,7 +326,7 @@ export function classifyGithubInbound(
       prText,
       id,
       opener,
-      selfLogin,
+      mention,
       pr.created_at,
       { kind: 'issue', owner: repository.owner, repo: repository.name, issueNumber: number },
       isOpenLike && !hasBody,
@@ -352,7 +353,7 @@ export function classifyGithubInbound(
       text,
       id,
       reviewer,
-      selfLogin,
+      mention,
       review.submitted_at,
       null,
       !hasBody,
@@ -377,7 +378,7 @@ export function classifyGithubInbound(
       text,
       id,
       opener,
-      selfLogin,
+      mention,
       discussion.created_at,
       null,
       action === 'created' && !hasBody,
@@ -415,6 +416,27 @@ function resolveDecoyReviewerLogin(selfLogin: string, authType: 'pat' | 'app'): 
   if (!selfLogin.endsWith(BOT_LOGIN_SUFFIX)) return null
   const slug = selfLogin.slice(0, -BOT_LOGIN_SUFFIX.length)
   return slug !== '' ? slug : null
+}
+
+// The @-handles that count as "addressed to us" in inbound body text. Under
+// App auth `selfLogin` is the actor login `slug[bot]`, but GitHub renders a
+// human's mention of the App as `@slug` (the bare slug — the decoy account's
+// login), with no `[bot]` suffix and no way to type one. Matching only against
+// `selfLogin` therefore never sees `@typeey` for a `typeey[bot]` actor, so a
+// direct "@typeey review again" lands with isBotMention=false and falls through
+// the engagement mention gate. Include the decoy slug so the bare-slug mention
+// is recognized. Under PAT auth the bot IS a real user, so there is no decoy
+// and only `selfLogin` applies.
+export type BotMentionLogins = readonly string[]
+
+export function resolveBotMentionLogins(selfLogin: string | null, authType: 'pat' | 'app'): BotMentionLogins {
+  if (selfLogin === null) return []
+  const decoyLogin = resolveDecoyReviewerLogin(selfLogin, authType)
+  return decoyLogin !== null ? [selfLogin, decoyLogin] : [selfLogin]
+}
+
+function textMentionsBot(text: string, mentionLogins: BotMentionLogins): boolean {
+  return mentionLogins.some((login) => text.includes(`@${login}`))
 }
 
 function classifyReviewRequest(input: ReviewRequestInput): InboundMessage | null {
@@ -550,7 +572,7 @@ function buildInbound(
   rawText: unknown,
   id: number,
   user: GithubUser | null,
-  selfLogin: string | null,
+  mention: BotMentionLogins,
   rawTs: unknown,
   reactionTarget: GithubReactionTarget | null,
   synthesizedAwareness = false,
@@ -567,7 +589,7 @@ function buildInbound(
   // Synthesized awareness lines carry an `@author` prefix describing who acted;
   // that handle is the author, never a third-party mention of the bot, so the
   // body-text mention heuristic must not fire on it.
-  const isBotMention = !synthesizedAwareness && selfLogin !== null && text.includes(`@${selfLogin}`)
+  const isBotMention = !synthesizedAwareness && textMentionsBot(text, mention)
   return {
     ...key,
     text,

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -435,8 +435,29 @@ export function resolveBotMentionLogins(selfLogin: string | null, authType: 'pat
   return decoyLogin !== null ? [selfLogin, decoyLogin] : [selfLogin]
 }
 
+// GitHub login chars are ASCII letters, digits, and hyphen. A `@login` token is
+// a real mention of `login` only when the char right after it is not one of
+// these — otherwise `@${login}` is a prefix of a longer, different login. This
+// matters for the App decoy slug: `resolveBotMentionLogins('typeclaw[bot]')`
+// yields the bare slug `typeclaw`, and a naive substring check would treat
+// `@typeclaw-bot` (a different user) as a self-mention. The trailing `[` of
+// `@typeclaw[bot]` is not a login char, so the full actor handle still matches.
+const LOGIN_CHAR = /[A-Za-z0-9-]/
+
 function textMentionsBot(text: string, mentionLogins: BotMentionLogins): boolean {
-  return mentionLogins.some((login) => text.includes(`@${login}`))
+  return mentionLogins.some((login) => mentionsLogin(text, login))
+}
+
+function mentionsLogin(text: string, login: string): boolean {
+  const token = `@${login}`
+  let from = 0
+  for (;;) {
+    const at = text.indexOf(token, from)
+    if (at === -1) return false
+    const next = text[at + token.length]
+    if (next === undefined || !LOGIN_CHAR.test(next)) return true
+    from = at + 1
+  }
 }
 
 function classifyReviewRequest(input: ReviewRequestInput): InboundMessage | null {


### PR DESCRIPTION
## Background

Observed in production (typeey on PR #631): a human commented "@typeey review again" on a PR the bot had been reviewing, and the bot stayed silent — it did not respond until a follow-up "@typeey are you up?" was posted. Both were direct @-mentions, yet the first was silently dropped.

Root cause is the GitHub App decoy-reviewer pattern. A GitHub App cannot be a `requested_reviewer`, so the supported workaround is a decoy user account whose login is the App slug (e.g. `typeey`). But the App's *actor* login — what `auth.getSelf().login` returns and what becomes `selfLogin` — is the `[bot]`-suffixed form `typeey[bot]`. GitHub renders a human's mention of the App as the bare slug `@typeey` (no `[bot]`, and there is no way to type the suffix).

The inbound classifier (`src/channels/adapters/github/inbound.ts`, `buildInbound`) set `isBotMention` by matching the comment body against `@${selfLogin}` only — i.e. `@typeey[bot]`. A body containing `@typeey` never matched, so `isBotMention` was `false`. In `decideEngagement` the guaranteed mention-engage (`config.trigger.includes('mention') && message.isBotMention`) was skipped; GitHub inbounds also carry `mentionsOthers=false`/`replyToBotMessageId=null`, so the comment fell through to the engagement fallback and was observed (dropped). The follow-up engaged only because an unrelated path (sticky credit from the now-recorded participant) happened to wake the session — flaky by nature.

## Summary

Resolve the set of @-handles that count as a self-mention, instead of matching a single login. New `resolveBotMentionLogins(selfLogin, authType)` returns the actor `selfLogin` always, plus the decoy slug under App auth — reusing the existing `resolveDecoyReviewerLogin` derivation (strip the `[bot]` suffix). `buildInbound` now takes this list and matches the body against any of them.

- Why reuse `resolveDecoyReviewerLogin`: it is the single existing seam that already encodes the slug-derivation convention used to drop the decoy reviewer; keeping mention detection on the same derivation means the classifier and the decoy logic can never drift on what "the bot's slug" is.
- PAT auth is unchanged: a PAT bot is a real user requested by its actual login, so there is no decoy and only `selfLogin` applies. A bare-prefix collision (e.g. `@typeclaw` for `typeclaw-bot`) does NOT register as a mention under PAT.

## What this does NOT do

- Does NOT change `classifyReviewRequest` / `classifyOpenedReviewTrigger` — those already synthesize `isBotMention: true` for review-request/opened triggers and still receive `selfLogin` for their own decoy/self-loop checks.
- Does NOT change PAT-auth behavior in any way (no decoy is derived).
- Does NOT touch the engagement gate, sticky credit, or any posting code — this is purely inbound mention classification.

## Review notes

Load-bearing change: `buildInbound`'s mention check moves from `text.includes('@' + selfLogin)` to `textMentionsBot(text, resolveBotMentionLogins(selfLogin, authType))`. The `mention` set is computed once at the top of `classifyGithubInbound` and threaded into all seven `buildInbound` call sites; the two `selfLogin` args passed into `classifyReviewRequest`/`classifyOpenedReviewTrigger` are intentionally left as `selfLogin`.

New tests in `inbound.test.ts` (describe: "isBotMention decoy-aware detection (App auth)"): bare-slug `@typeclaw` on a `typeclaw[bot]` actor → isBotMention=true; full `@typeclaw[bot]` still true; unrelated `@someone-else` false; and PAT auth where `@typeclaw` must NOT match `typeclaw-bot` but `@typeclaw-bot` must.

Checks: `bun run typecheck` clean, `bun run lint` 0 errors (65 pre-existing warnings, none in changed files), `bun run format:check` clean. `bun test --parallel src/channels/adapters/github/` 277/277 pass. Full suite: 1 failure, `resolveSelfPackageJsonPath > points at this package manifest` — a pre-existing environmental artifact that asserts the checkout dir is named `typeclaw`; it fails only from a worktree with a different directory name and passes in CI (unrelated to this change; no `src/update/` code touched).