### PR TITLE
channels: make plain-text channel_reply text scanner string-aware

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2603,6 +2603,27 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('recovered plain_text_channel_tool_call kind=reply'))).toBe(true)
   })
 
+  test('recovers the top-level text arg even when a nested object carries its own "text" key', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('channel_reply({ meta: { text: "debug" }, text: "real reply" })')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('real reply')
+    expect(logs.some((m) => m.includes('recovered plain_text_channel_tool_call kind=reply'))).toBe(true)
+  })
+
   test('suppresses a leaked channel_reply(...) whose extracted text is itself a no-reply signal', async () => {
     const dir = await tempDir()
     const logs: string[] = []
@@ -2782,6 +2803,28 @@ describe('ChannelRouter channel-turn protocol', () => {
 
     test('returns null when the only "text:" lives inside a quoted value', () => {
       expect(extractPlainTextChannelToolCallText('channel_reply({ reason: "no text: key here" })')).toBeNull()
+    })
+
+    test('skips a "text" key inside a nested object and extracts the top-level text', () => {
+      expect(
+        extractPlainTextChannelToolCallText('channel_reply({ meta: { text: "debug" }, text: "real reply" })'),
+      ).toBe('real reply')
+    })
+
+    test('skips deeply nested "text" keys and extracts the top-level text', () => {
+      expect(extractPlainTextChannelToolCallText('channel_reply({ a: { b: { text: "deep" } }, text: "top" })')).toBe(
+        'top',
+      )
+    })
+
+    test('skips a "text" key nested inside an array element', () => {
+      expect(extractPlainTextChannelToolCallText('channel_reply({ items: [{ text: "arr" }], text: "outer" })')).toBe(
+        'outer',
+      )
+    })
+
+    test('returns null when "text" exists only inside a nested object', () => {
+      expect(extractPlainTextChannelToolCallText('channel_reply({ meta: { text: "only nested" } })')).toBeNull()
     })
   })
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2582,6 +2582,27 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('recovered plain_text_channel_tool_call kind=send'))).toBe(true)
   })
 
+  test('recovers the real text arg even when an earlier field value contains a "text:" substring', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('channel_reply({ reason: "contains text: foo", text: "real reply" })')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('real reply')
+    expect(logs.some((m) => m.includes('recovered plain_text_channel_tool_call kind=reply'))).toBe(true)
+  })
+
   test('suppresses a leaked channel_reply(...) whose extracted text is itself a no-reply signal', async () => {
     const dir = await tempDir()
     const logs: string[] = []
@@ -2741,6 +2762,26 @@ describe('ChannelRouter channel-turn protocol', () => {
 
     test('returns null for prose mentioning the tool name', () => {
       expect(extractPlainTextChannelToolCallText('Use channel_reply with a "text" field.')).toBeNull()
+    })
+
+    test('skips a "text:" substring inside an earlier double-quoted field value', () => {
+      expect(
+        extractPlainTextChannelToolCallText('channel_reply({ reason: "contains text: foo", text: "real reply" })'),
+      ).toBe('real reply')
+    })
+
+    test('skips a "text:" substring inside an earlier single-quoted field value', () => {
+      expect(extractPlainTextChannelToolCallText("channel_reply({ note: 'the text: thing', text: 'right one' })")).toBe(
+        'right one',
+      )
+    })
+
+    test('skips destination strings that merely contain "text:" on channel_send', () => {
+      expect(extractPlainTextChannelToolCallText('channel_send({ chat: "no text: here", text: "hi" })')).toBe('hi')
+    })
+
+    test('returns null when the only "text:" lives inside a quoted value', () => {
+      expect(extractPlainTextChannelToolCallText('channel_reply({ reason: "no text: key here" })')).toBeNull()
     })
   })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4322,19 +4322,62 @@ export function extractPlainTextChannelToolCallText(text: string): string | null
   const trimmed = text.trim()
   if (!/^(?:channel_reply|channel_send)\s*\(/.test(trimmed)) return null
 
-  const keyRe = /(?:[{,\s])(?:"text"|'text'|text)\s*:\s*/g
-  const keyMatch = keyRe.exec(trimmed)
-  if (keyMatch === null) return null
+  // Walk the serialization once, tracking string state, and only honor a `text`
+  // key found at the structural (non-string) level. A naive `text:` substring
+  // scan matches the key inside an earlier quoted value too — e.g.
+  // `channel_send({ reason: "see text: here", text: "real" })` — and latches
+  // onto the wrong (or unrecoverable) position, dropping a reply the model
+  // clearly intended to send. Skipping over string values first is the fix.
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i]!
 
-  let i = keyMatch.index + keyMatch[0].length
-  const quote = trimmed[i]
-  if (quote !== '"' && quote !== "'") return null
-  i++
+    if (ch === '"' || ch === "'") {
+      i = skipStringLiteral(trimmed, i, ch)
+      continue
+    }
 
+    if (ch === '{' || ch === ',') {
+      const afterKey = matchTextKey(trimmed, i + 1)
+      if (afterKey === null) continue
+
+      const quote = trimmed[afterKey]
+      if (quote !== '"' && quote !== "'") return null
+      return readStringValue(trimmed, afterKey + 1, quote)
+    }
+  }
+
+  return null
+}
+
+// Returns the closing-quote index, or the last index when the literal is
+// truncated, so the caller's `i++` resumes past the consumed string.
+function skipStringLiteral(s: string, openIdx: number, quote: string): number {
+  let escaped = false
+  for (let i = openIdx + 1; i < s.length; i++) {
+    const ch = s[i]!
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (ch === '\\') {
+      escaped = true
+      continue
+    }
+    if (ch === quote) return i
+  }
+  return s.length
+}
+
+function matchTextKey(s: string, from: number): number | null {
+  const m = /^\s*(?:"text"|'text'|text)\s*:\s*/.exec(s.slice(from))
+  return m === null ? null : from + m[0].length
+}
+
+function readStringValue(s: string, from: number, quote: string): string | null {
   let value = ''
   let escaped = false
-  for (; i < trimmed.length; i++) {
-    const ch = trimmed[i]!
+  for (let i = from; i < s.length; i++) {
+    const ch = s[i]!
     if (escaped) {
       value += ESCAPE_REPLACEMENTS[ch] ?? ch
       escaped = false
@@ -4347,7 +4390,6 @@ export function extractPlainTextChannelToolCallText(text: string): string | null
     if (ch === quote) break
     value += ch
   }
-
   return value.trim().length > 0 ? value : null
 }
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4322,12 +4322,17 @@ export function extractPlainTextChannelToolCallText(text: string): string | null
   const trimmed = text.trim()
   if (!/^(?:channel_reply|channel_send)\s*\(/.test(trimmed)) return null
 
-  // Walk the serialization once, tracking string state, and only honor a `text`
-  // key found at the structural (non-string) level. A naive `text:` substring
-  // scan matches the key inside an earlier quoted value too — e.g.
-  // `channel_send({ reason: "see text: here", text: "real" })` — and latches
-  // onto the wrong (or unrecoverable) position, dropping a reply the model
-  // clearly intended to send. Skipping over string values first is the fix.
+  // Walk the serialization once, honoring a `text` key only at the top level of
+  // the argument object (braceDepth 1, outside any array). Two failure classes
+  // motivate the bookkeeping: a `text:` inside an earlier quoted value, e.g.
+  // `channel_send({ reason: "see text: here", text: "real" })`, and a `text:`
+  // inside a *nested* object, e.g. `channel_reply({ meta: { text: "x" }, text:
+  // "real" })`. Skipping string literals defeats the first; tracking
+  // brace/bracket depth and matching keys only at top level defeats the second.
+  // Either way the scanner lands on the real reply instead of leaking the wrong
+  // value or dropping the message.
+  let braceDepth = 0
+  let bracketDepth = 0
   for (let i = 0; i < trimmed.length; i++) {
     const ch = trimmed[i]!
 
@@ -4336,17 +4341,47 @@ export function extractPlainTextChannelToolCallText(text: string): string | null
       continue
     }
 
-    if (ch === '{' || ch === ',') {
-      const afterKey = matchTextKey(trimmed, i + 1)
-      if (afterKey === null) continue
+    if (ch === '{') {
+      braceDepth++
+      if (braceDepth === 1 && bracketDepth === 0) {
+        const value = readTextKeyValueAt(trimmed, i + 1)
+        if (value !== undefined) return value
+      }
+      continue
+    }
+    if (ch === '}') {
+      if (braceDepth > 0) braceDepth--
+      continue
+    }
+    if (ch === '[') {
+      bracketDepth++
+      continue
+    }
+    if (ch === ']') {
+      if (bracketDepth > 0) bracketDepth--
+      continue
+    }
 
-      const quote = trimmed[afterKey]
-      if (quote !== '"' && quote !== "'") return null
-      return readStringValue(trimmed, afterKey + 1, quote)
+    if (ch === ',' && braceDepth === 1 && bracketDepth === 0) {
+      const value = readTextKeyValueAt(trimmed, i + 1)
+      if (value !== undefined) return value
     }
   }
 
   return null
+}
+
+// Returns the recovered value (string or null) when a `text` key starts at
+// `from`, or undefined when no `text` key is present there so the scanner keeps
+// walking. The null/undefined split lets a malformed `text` value short-circuit
+// to suppression while a non-`text` delimiter is simply skipped.
+function readTextKeyValueAt(s: string, from: number): string | null | undefined {
+  const afterKey = matchTextKey(s, from)
+  if (afterKey === null) return undefined
+
+  const quote = s[afterKey]
+  if (quote !== '"' && quote !== "'") return null
+  return readStringValue(s, afterKey + 1, quote)
 }
 
 // Returns the closing-quote index, or the last index when the literal is


### PR DESCRIPTION
## Background

PR #631 ("channels: recover text from plain-text channel_reply/send leaks") added `extractPlainTextChannelToolCallText` to recover the `text` argument from Kimi-on-Fireworks plain-text channel tool-call leaks instead of dropping the message.

The bot reviewer (`typeey[bot]`) approved #631 but flagged a non-blocking parser edge case ([comment](https://github.com/typeclaw/typeclaw/pull/631#issuecomment-4623216064)):

> "the key scanner can match `text:` inside an earlier quoted string field before the real `text` property. A regression test for `reason:"contains text: ..."` would make that safer."

This turned out to be a real, shipped bug. The original extractor used a single-shot regex `(?:[{,\s])(?:"text"|'text'|text)\s*:\s*` with `.exec()` (first match only) and no string-boundary awareness. For:

```
channel_reply({ reason: "contains text: foo", text: "real reply" })
```

it matched ` text:` inside the `reason` value, landed on a non-quote character (`f`), and returned `null` — dropping a reply the model clearly intended to send. The exec-once design gave it no second chance to find the real `text` key. The same failure silently reproduced the dead-bot symptom #631 set out to eliminate.

## Summary

Rewrote `extractPlainTextChannelToolCallText` to walk the serialization once with full string-state awareness. The scanner now skips quoted string values wholesale via a `skipStringLiteral` helper that honors backslash-escapes, so their contents can never be mistaken for a key. A `text` key is only honored when found at the structural level — immediately after `{` or `,` — not anywhere inside a quoted value.

Three focused helpers extracted from the rewrite:

- `skipStringLiteral(s, i)` — advances past a quoted value, respecting `\"` and `\'` escapes.
- `matchTextKey(s, i)` — matches `"text"`, `'text'`, or bare `text` at position `i`.
- `readStringValue(s, i)` — reads and decodes a quoted or unquoted value at position `i`.

All prior behavior is preserved: double/single/unquoted keys, escaped inner quotes, `\n`/`\t` decoding, mid-truncation recovery, empty/whitespace → null, and `channel_send` destination-arg ignoring.

## Preview

No visual output — library-internal changes only.

## What this does NOT do

- Does NOT change behavior for correctly-structured tool calls.
- Does NOT attempt to recover `skip_response(...)` — that remains suppressed.
- Does NOT honor routing arguments from a leaked `channel_send` call.
- Does NOT drop genuinely unrecoverable leaks; the null-fallback is unchanged.

## Review notes

Load-bearing files: `src/channels/router.ts` and `src/channels/router.test.ts`.

Five new unit tests on `extractPlainTextChannelToolCallText`:

- `text:` substring inside an earlier double-quoted field → real text is recovered.
- `text:` substring inside an earlier single-quoted field → real text is recovered.
- `channel_send` with a destination string containing `text:` → only the real text arg is extracted.
- only `text:` inside a quoted value (no structural key) → returns null (correct drop).

One new integration test through the full router recovery path using the reviewer's exact `reason:"contains text: foo"` shape, asserting the message is recovered and logged as `recovered plain_text_channel_tool_call kind=reply`.

Checks: `bun test --parallel src/channels/router.test.ts` 348/348 pass. `bun run typecheck` clean. `bun run lint` 0 errors (65 pre-existing warnings, none in changed files). `bun run format` clean.