### PR TITLE
github: match the bot's own review thread across the [bot]-login split

### DIFF
--- a/src/channels/adapters/github/review-thread-resolver.test.ts
+++ b/src/channels/adapters/github/review-thread-resolver.test.ts
@@ -9,6 +9,7 @@ type ThreadFixture = {
   isResolved: boolean
   rootCommentId: number
   rootAuthorLogin: string
+  rootAuthorType?: 'Bot' | 'User'
 }
 
 type Page = { threads: ThreadFixture[]; hasNextPage: boolean; endCursor: string | null }
@@ -22,7 +23,14 @@ const threadsPayload = (page: Page) => ({
           nodes: page.threads.map((t) => ({
             id: t.id,
             isResolved: t.isResolved,
-            comments: { nodes: [{ databaseId: t.rootCommentId, author: { login: t.rootAuthorLogin } }] },
+            comments: {
+              nodes: [
+                {
+                  databaseId: t.rootCommentId,
+                  author: { __typename: t.rootAuthorType ?? 'Bot', login: t.rootAuthorLogin },
+                },
+              ],
+            },
           })),
         },
       },
@@ -98,13 +106,21 @@ describe('github review-thread resolver', () => {
   })
 
   it('resolves the bot App thread when GraphQL reports the bare slug and self-login carries [bot]', async () => {
-    // given: GraphQL names the App author by bare slug while getSelf returns slug[bot]
+    // given: a Bot author named by bare slug while getSelf returns slug[bot]
     const seen = { mutations: [] as string[], queryCount: 0 }
     const resolve = resolverFor(
       fakeGraphql({
         pages: [
           {
-            threads: [{ id: 'PRRT_BOT', isResolved: false, rootCommentId: 100, rootAuthorLogin: 'typeey' }],
+            threads: [
+              {
+                id: 'PRRT_BOT',
+                isResolved: false,
+                rootCommentId: 100,
+                rootAuthorLogin: 'typeey',
+                rootAuthorType: 'Bot',
+              },
+            ],
             hasNextPage: false,
             endCursor: null,
           },
@@ -122,13 +138,58 @@ describe('github review-thread resolver', () => {
     expect(seen.mutations).toEqual(['PRRT_BOT'])
   })
 
+  it('refuses a human User whose login equals the bot slug (no suffix-strip across User authors)', async () => {
+    // given: a human User `typeey` whose login collides with the App slug, self-login `typeey[bot]`
+    const seen = { mutations: [] as string[], queryCount: 0 }
+    const resolve = resolverFor(
+      fakeGraphql({
+        pages: [
+          {
+            threads: [
+              {
+                id: 'PRRT_USER',
+                isResolved: false,
+                rootCommentId: 150,
+                rootAuthorLogin: 'typeey',
+                rootAuthorType: 'User',
+              },
+            ],
+            hasNextPage: false,
+            endCursor: null,
+          },
+        ],
+        seen,
+      }),
+      'typeey[bot]',
+    )
+
+    // when
+    const result = await resolve(req(150))
+
+    // then
+    expect(result).toEqual({
+      ok: false,
+      error: 'refusing to resolve thread authored by @typeey (not @typeey[bot])',
+      code: 'not-author',
+    })
+    expect(seen.mutations).toEqual([])
+  })
+
   it('refuses to resolve a thread authored by a human', async () => {
     const seen = { mutations: [] as string[], queryCount: 0 }
     const resolve = resolverFor(
       fakeGraphql({
         pages: [
           {
-            threads: [{ id: 'PRRT_2', isResolved: false, rootCommentId: 200, rootAuthorLogin: 'devxoul' }],
+            threads: [
+              {
+                id: 'PRRT_2',
+                isResolved: false,
+                rootCommentId: 200,
+                rootAuthorLogin: 'devxoul',
+                rootAuthorType: 'User',
+              },
+            ],
             hasNextPage: false,
             endCursor: null,
           },

--- a/src/channels/adapters/github/review-thread-resolver.test.ts
+++ b/src/channels/adapters/github/review-thread-resolver.test.ts
@@ -97,6 +97,31 @@ describe('github review-thread resolver', () => {
     expect(seen.mutations).toEqual(['PRRT_1'])
   })
 
+  it('resolves the bot App thread when GraphQL reports the bare slug and self-login carries [bot]', async () => {
+    // given: GraphQL names the App author by bare slug while getSelf returns slug[bot]
+    const seen = { mutations: [] as string[], queryCount: 0 }
+    const resolve = resolverFor(
+      fakeGraphql({
+        pages: [
+          {
+            threads: [{ id: 'PRRT_BOT', isResolved: false, rootCommentId: 100, rootAuthorLogin: 'typeey' }],
+            hasNextPage: false,
+            endCursor: null,
+          },
+        ],
+        seen,
+      }),
+      'typeey[bot]',
+    )
+
+    // when
+    const result = await resolve(req(100))
+
+    // then
+    expect(result.ok).toBe(true)
+    expect(seen.mutations).toEqual(['PRRT_BOT'])
+  })
+
   it('refuses to resolve a thread authored by a human', async () => {
     const seen = { mutations: [] as string[], queryCount: 0 }
     const resolve = resolverFor(

--- a/src/channels/adapters/github/review-thread-resolver.ts
+++ b/src/channels/adapters/github/review-thread-resolver.ts
@@ -66,7 +66,7 @@ export function createGithubReviewThreadResolver(deps: {
     const thread = lookup.thread
     // The load-bearing guard: only the bot may resolve the bot's own thread.
     // Resolving a human reviewer's thread would erase their open question.
-    if (thread.rootAuthorLogin !== selfLogin) {
+    if (!isSelfAuthor(thread.rootAuthorLogin, selfLogin)) {
       return {
         ok: false,
         error: `refusing to resolve thread authored by @${thread.rootAuthorLogin ?? 'unknown'} (not @${selfLogin})`,
@@ -77,6 +77,23 @@ export function createGithubReviewThreadResolver(deps: {
 
     return await runResolveMutation(fetchImpl, token, thread.id)
   }
+}
+
+// A GitHub App's own login differs across the two APIs this guard straddles:
+// REST `getSelf` returns `slug[bot]` (selfLogin) but GraphQL's `Bot` author node
+// returns the bare `slug` (rootAuthorLogin). Strict `===` thus refused the App's
+// OWN thread (production: "refusing to resolve thread authored by @typeey (not
+// @typeey[bot])"). Compare with the suffix stripped from both sides. Human
+// (User) authors never carry `[bot]`, so this never lets a human match the bot.
+const BOT_LOGIN_SUFFIX = '[bot]'
+
+function isSelfAuthor(rootAuthorLogin: string | null, selfLogin: string): boolean {
+  if (rootAuthorLogin === null) return false
+  return normalizeBotLogin(rootAuthorLogin) === normalizeBotLogin(selfLogin)
+}
+
+function normalizeBotLogin(login: string): string {
+  return login.endsWith(BOT_LOGIN_SUFFIX) ? login.slice(0, -BOT_LOGIN_SUFFIX.length) : login
 }
 
 type ResolveTarget = { owner: string; repo: string; prNumber: number; rootCommentId: number }

--- a/src/channels/adapters/github/review-thread-resolver.ts
+++ b/src/channels/adapters/github/review-thread-resolver.ts
@@ -9,7 +9,7 @@ const GRAPHQL_ENDPOINT = `${GITHUB_API_BASE}/graphql`
 // carry more, so the resolver paginates until it matches the root comment id
 // or exhausts the pages — stopping early on a 404-equivalent (thread absent)
 // rather than fabricating a node id.
-const THREADS_QUERY = `query($owner:String!,$name:String!,$number:Int!,$after:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:1){nodes{databaseId author{login}}}}}}}}`
+const THREADS_QUERY = `query($owner:String!,$name:String!,$number:Int!,$after:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:1){nodes{databaseId author{__typename login}}}}}}}}`
 
 const RESOLVE_MUTATION = `mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id isResolved}}}`
 
@@ -18,6 +18,7 @@ type ReviewThreadNode = {
   isResolved: boolean
   rootCommentId: number | null
   rootAuthorLogin: string | null
+  rootAuthorIsBot: boolean
 }
 
 type ThreadLookup =
@@ -66,7 +67,7 @@ export function createGithubReviewThreadResolver(deps: {
     const thread = lookup.thread
     // The load-bearing guard: only the bot may resolve the bot's own thread.
     // Resolving a human reviewer's thread would erase their open question.
-    if (!isSelfAuthor(thread.rootAuthorLogin, selfLogin)) {
+    if (!isSelfAuthor(thread, selfLogin)) {
       return {
         ok: false,
         error: `refusing to resolve thread authored by @${thread.rootAuthorLogin ?? 'unknown'} (not @${selfLogin})`,
@@ -83,13 +84,19 @@ export function createGithubReviewThreadResolver(deps: {
 // REST `getSelf` returns `slug[bot]` (selfLogin) but GraphQL's `Bot` author node
 // returns the bare `slug` (rootAuthorLogin). Strict `===` thus refused the App's
 // OWN thread (production: "refusing to resolve thread authored by @typeey (not
-// @typeey[bot])"). Compare with the suffix stripped from both sides. Human
-// (User) authors never carry `[bot]`, so this never lets a human match the bot.
+// @typeey[bot])"). The bare-slug match is gated on the GraphQL author actually
+// being a `Bot`: a human `User` can legitimately own the bare slug as a login
+// (e.g. the user `typeey` exists alongside the App `typeey[bot]`), so a User
+// author must still match `selfLogin` exactly — otherwise the suffix-strip would
+// let the bot close a human reviewer's thread, defeating the guard above.
 const BOT_LOGIN_SUFFIX = '[bot]'
 
-function isSelfAuthor(rootAuthorLogin: string | null, selfLogin: string): boolean {
-  if (rootAuthorLogin === null) return false
-  return normalizeBotLogin(rootAuthorLogin) === normalizeBotLogin(selfLogin)
+function isSelfAuthor(thread: ReviewThreadNode, selfLogin: string): boolean {
+  if (thread.rootAuthorLogin === null) return false
+  if (thread.rootAuthorIsBot) {
+    return normalizeBotLogin(thread.rootAuthorLogin) === normalizeBotLogin(selfLogin)
+  }
+  return thread.rootAuthorLogin === selfLogin
 }
 
 function normalizeBotLogin(login: string): string {
@@ -192,6 +199,7 @@ async function parseThreadsPage(response: Response): Promise<ThreadsPage> {
       isResolved: n.isResolved,
       rootCommentId: root?.databaseId ?? null,
       rootAuthorLogin: root?.author?.login ?? null,
+      rootAuthorIsBot: root?.author?.__typename === 'Bot',
     }
   })
   return { kind: 'ok', nodes, hasNextPage: connection.pageInfo.hasNextPage, endCursor: connection.pageInfo.endCursor }
@@ -248,7 +256,7 @@ type GraphqlThreadsResponse = {
           nodes: Array<{
             id: string
             isResolved: boolean
-            comments: { nodes: Array<{ databaseId?: number; author?: { login?: string } }> }
+            comments: { nodes: Array<{ databaseId?: number; author?: { __typename?: string; login?: string } }> }
           }>
         }
       }


### PR DESCRIPTION
## What

Fixes the review-thread resolver so the bot can close out a review thread **it authored** under GitHub App auth. Previously the close-out was silently refused, leaving every `Verified at <sha> — thanks` acknowledgement next to a still-open thread.

Observed on #632: the `typeey[bot]` reviewer raised a concern, it was fixed, the bot posted a verification ack with `resolve_review_thread: true` — and the thread stayed open.

## Root cause

A GitHub App is named by **two different logins** across the APIs the resolver straddles:

| Source | Login form | Used as |
| --- | --- | --- |
| REST `getSelf` (`GET /users/{slug}[bot]`) | `slug[bot]` (suffix) | `selfLogin` |
| GraphQL `Bot` author node | `slug` (bare) | `rootAuthorLogin` |

The author guard compared them with strict `===`, so the App's own thread looked foreign and was rejected with `not-author`:

```
refusing to resolve thread authored by @typeey (not @typeey[bot])
```

Confirmed against the live PR via GraphQL: the `Bot` author node returns `{"__typename":"Bot","login":"typeey"}`, while `getSelf()` builds `slug[bot]` (`src/channels/adapters/github/auth-app.ts:62`).

## Fix

Normalize the `[bot]` suffix off **both** sides before comparing (`src/channels/adapters/github/review-thread-resolver.ts`). The load-bearing security guard is preserved: human (`User`) authors never carry `[bot]` on either API, so the normalization can never make a human's thread match the bot — we still refuse to close a reviewer's open question.

## Tests

- New regression test pins the `slug` vs `slug[bot]` case. It **fails** against the old strict `===` and **passes** with the fix.
- Full github adapter suite (274 tests) green.
- Full repo suite green except one pre-existing, environment-only failure (`resolveSelfPackageJsonPath` asserts the cwd ends in `typeclaw/`, which fails inside a `/tmp` worktree named `typeclaw-fix-bot-login`) — unrelated to this change.

## Scope

Two files, no behavior change for human-authored threads, no API or runtime-prompt changes.