### PR TITLE
github: block false-receipt PR replies that claim a verdict without acting

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -630,7 +630,13 @@ export function buildChannelTools(
       chat: origin.chat,
       thread: origin.thread,
     }
-    tools.push(createChannelReplyTool({ router: channelRouter, origin: channelOrigin }))
+    tools.push(
+      createChannelReplyTool({
+        router: channelRouter,
+        origin: channelOrigin,
+        ...(sessionId !== undefined ? { sessionId } : {}),
+      }),
+    )
     tools.push(createChannelHistoryTool({ router: channelRouter, origin: channelOrigin }))
     tools.push(createChannelSendTool({ router: channelRouter, origin: channelOrigin }))
     tools.push(

--- a/src/agent/tools/channel-reply.false-receipt.test.ts
+++ b/src/agent/tools/channel-reply.false-receipt.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { recordReview, resetReviewTurn } from '@/channels/github-review-turn-ledger'
+import type { ChannelRouter } from '@/channels/router'
+import type { OutboundMessage, SendResult } from '@/channels/types'
+
+import { createChannelReplyTool, type ChannelReplyOrigin } from './channel-reply'
+
+const SESSION = 'ses_cr_fr'
+const WS = 'acme/widgets'
+
+afterEach(() => resetReviewTurn(SESSION))
+
+function fakeRouter(onSend: (msg: OutboundMessage) => SendResult = () => ({ ok: true })): ChannelRouter {
+  return {
+    route: async () => {},
+    send: async (msg) => onSend(msg),
+    getConsecutiveSendCount: () => 0,
+    getSendRate: () => ({ count: 0, windowMs: 5_000 }),
+    registerOutbound: () => {},
+    unregisterOutbound: () => {},
+    registerReaction: () => {},
+    unregisterReaction: () => {},
+    react: async () => ({ ok: true }),
+    registerRemoveReaction: () => {},
+    unregisterRemoveReaction: () => {},
+    removeReaction: async () => ({ ok: true }),
+    registerTyping: () => {},
+    unregisterTyping: () => {},
+    registerChannelNameResolver: () => {},
+    unregisterChannelNameResolver: () => {},
+    registerSelfIdentity: () => {},
+    unregisterSelfIdentity: () => {},
+    registerMembership: () => {},
+    unregisterMembership: () => {},
+    registerHistory: () => {},
+    unregisterHistory: () => {},
+    fetchHistory: async () => ({ ok: false, error: 'x' }),
+    registerFetchAttachment: () => {},
+    unregisterFetchAttachment: () => {},
+    fetchAttachment: async () => ({ ok: false, error: 'x' }),
+    registerReviewThreadResolver: () => {},
+    unregisterReviewThreadResolver: () => {},
+    resolveReviewThread: async () => ({ ok: true }),
+    lookupInboundAttachment: () => null,
+    listInboundAttachmentIds: () => [],
+    getSelfAliases: () => [],
+    stop: async () => {},
+    tearDownAllLive: async () => {},
+    liveCount: () => 0,
+    executeCommand: async () => ({ kind: 'no-live-session' }),
+    injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
+    markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    reserveRestartHandoff: () => null,
+    resumeRestartHandoff: async () => {},
+  }
+}
+
+const prOrigin: ChannelReplyOrigin = { adapter: 'github', workspace: WS, chat: 'pr:12', thread: null }
+const fakeCtx = {} as Parameters<ReturnType<typeof createChannelReplyTool>['execute']>[4]
+
+function tool(onSend?: (msg: OutboundMessage) => SendResult, origin: ChannelReplyOrigin = prOrigin) {
+  return createChannelReplyTool({ router: fakeRouter(onSend), origin, sessionId: SESSION })
+}
+
+async function run(
+  t: ReturnType<typeof createChannelReplyTool>,
+  params: Parameters<ReturnType<typeof createChannelReplyTool>['execute']>[1],
+) {
+  return t.execute('id', params, undefined, undefined, fakeCtx)
+}
+
+describe('channel_reply false-receipt guard', () => {
+  test('blocks a terminal "Approved" with no review this turn — and posts nothing', async () => {
+    let sent = 0
+    const result = await run(
+      tool(() => {
+        sent++
+        return { ok: true }
+      }),
+      { text: 'Approved! 🎉' },
+    )
+    expect(sent).toBe(0)
+    expect((result.details as { ok: boolean }).ok).toBe(false)
+  })
+
+  test('allows "Approved" once a real APPROVE review was recorded this turn', async () => {
+    recordReview({ sessionId: SESSION, workspace: WS, prNumber: 12, verdict: 'APPROVE' })
+    let sent = 0
+    const result = await run(
+      tool(() => {
+        sent++
+        return { ok: true }
+      }),
+      { text: 'Approved — thanks for the fix!' },
+    )
+    expect(sent).toBe(1)
+    expect((result.details as { ok: boolean }).ok).toBe(true)
+  })
+
+  test('warns (allows + appends notice) on a soft "looks good"', async () => {
+    const result = await run(tool(), { text: 'looks good to me' })
+    expect((result.details as { ok: boolean }).ok).toBe(true)
+    const text = (result.content[0] as { text: string }).text
+    expect(text).toContain('does not create a formal GitHub review')
+  })
+
+  test('does not guard non-github replies', async () => {
+    const slackOrigin: ChannelReplyOrigin = { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null }
+    let sent = 0
+    await run(
+      tool(() => {
+        sent++
+        return { ok: true }
+      }, slackOrigin),
+      { text: 'Approved!' },
+    )
+    expect(sent).toBe(1)
+  })
+})

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -1,6 +1,7 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
+import { checkFalseReceipt } from '@/channels/github-false-receipt'
 import {
   containsKimiToolDelimiter,
   isNoReplySignal,
@@ -22,6 +23,10 @@ export type ChannelReplyOrigin = {
 export type CreateChannelReplyToolOptions = {
   router: ChannelRouter
   origin: ChannelReplyOrigin
+  // Scopes the per-turn false-receipt ledger. Defaults to '' when a caller (e.g.
+  // a focused test) has no session; the guard then simply finds no recorded
+  // action and falls back to its safe default.
+  sessionId?: string
   logger?: ChannelToolLogger
 }
 
@@ -37,6 +42,7 @@ export type CreateChannelReplyToolOptions = {
 export function createChannelReplyTool({
   router,
   origin,
+  sessionId = '',
   logger = consoleChannelLogger,
 }: CreateChannelReplyToolOptions) {
   return defineTool({
@@ -131,6 +137,28 @@ export function createChannelReplyTool({
         }
       }
 
+      // False-receipt guard: deny a terminal reply that CLAIMS a PR verdict /
+      // thread close-out the agent never actually performed this turn. Warn-tier
+      // claims fall through and have their notice appended on success below.
+      const falseReceipt = checkFalseReceipt({
+        sessionId,
+        adapter: origin.adapter,
+        workspace: origin.workspace,
+        chat: origin.chat,
+        thread: origin.thread,
+        text,
+        isContinue: keepTurnAlive,
+        resolveReviewThread: params.resolve_review_thread === true,
+      })
+      if (falseReceipt.kind === 'block') {
+        logger.warn(formatChannelToolFailure('channel_reply', falseReceipt.reason))
+        return {
+          content: [{ type: 'text' as const, text: `channel_reply denied: ${falseReceipt.reason}` }],
+          details: { ok: false, error: falseReceipt.reason },
+        }
+      }
+      const falseReceiptNotice = falseReceipt.kind === 'warn' ? falseReceipt.notice : null
+
       // Resolve BEFORE posting: a successful channel_reply ends the turn, so a
       // resolve attempted "after" the ack would never run (the exact bug this
       // flag fixes). Resolve-failure blocks the reply so the agent never posts
@@ -203,8 +231,9 @@ export function createChannelReplyTool({
         // TOOL_RESULT_PREFIX to match the denial branch below. The prefix is
         // intentionally weaker and is safe ONLY because denials carry no echoed
         // prose; the success result does, and the weak prefix let Kimi loop.
+        const warnNote = falseReceiptNotice !== null ? fenceRuntimeNotice(falseReceiptNotice) : ''
         return {
-          content: [{ type: 'text' as const, text: `${fenceToolResult(receipt)}${hint}` }],
+          content: [{ type: 'text' as const, text: `${fenceToolResult(receipt)}${hint}${warnNote}` }],
           details,
         }
       }

--- a/src/bundled-plugins/github-cli-auth/gh-review-detect.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-detect.test.ts
@@ -8,7 +8,7 @@ describe('detectReviewSubmission — REST --input', () => {
       command: 'gh api -X POST /repos/acme/widgets/pulls/12/reviews --input /tmp/review-12.json',
       inputFileContents: '{ "event": "APPROVE", "body": "lgtm" }',
     })
-    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 12, verdict: 'APPROVE' })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 12, verdict: 'APPROVE', source: 'api' })
   })
 
   test('REQUEST_CHANGES in the input file is detected', () => {
@@ -41,7 +41,7 @@ describe('detectReviewSubmission — REST inline fields', () => {
     const result = detectReviewSubmission({
       command: 'gh api /repos/acme/widgets/pulls/3/reviews -f event=APPROVE',
     })
-    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 3, verdict: 'APPROVE' })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 3, verdict: 'APPROVE', source: 'api' })
   })
 
   test('-F event=REQUEST_CHANGES', () => {
@@ -64,14 +64,19 @@ describe('detectReviewSubmission — gh pr review porcelain', () => {
     const result = detectReviewSubmission({
       command: 'gh pr review 42 --approve -R acme/widgets',
     })
-    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 42, verdict: 'APPROVE' })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 42, verdict: 'APPROVE', source: 'pr-review' })
   })
 
   test('gh pr review --request-changes N --repo owner/repo', () => {
     const result = detectReviewSubmission({
       command: 'gh pr review --request-changes 42 --repo acme/widgets',
     })
-    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 42, verdict: 'REQUEST_CHANGES' })
+    expect(result).toEqual({
+      workspace: 'acme/widgets',
+      prNumber: 42,
+      verdict: 'REQUEST_CHANGES',
+      source: 'pr-review',
+    })
   })
 
   test('gh pr review --comment is not tracked', () => {

--- a/src/bundled-plugins/github-cli-auth/gh-review-detect.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-detect.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test'
+
+import { detectReviewSubmission } from './gh-review-detect'
+
+describe('detectReviewSubmission — REST --input', () => {
+  test('APPROVE in the input file is detected', () => {
+    const result = detectReviewSubmission({
+      command: 'gh api -X POST /repos/acme/widgets/pulls/12/reviews --input /tmp/review-12.json',
+      inputFileContents: '{ "event": "APPROVE", "body": "lgtm" }',
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 12, verdict: 'APPROVE' })
+  })
+
+  test('REQUEST_CHANGES in the input file is detected', () => {
+    const result = detectReviewSubmission({
+      command: 'gh api -X POST /repos/acme/widgets/pulls/7/reviews --input /tmp/r.json',
+      inputFileContents: '{"event":"REQUEST_CHANGES","comments":[]}',
+    })
+    expect(result?.verdict).toBe('REQUEST_CHANGES')
+  })
+
+  test('a COMMENT review is not tracked', () => {
+    const result = detectReviewSubmission({
+      command: 'gh api -X POST /repos/acme/widgets/pulls/7/reviews --input /tmp/r.json',
+      inputFileContents: '{"event":"COMMENT"}',
+    })
+    expect(result).toBeNull()
+  })
+
+  test('malformed file contents yield null (cannot credit a verdict)', () => {
+    const result = detectReviewSubmission({
+      command: 'gh api -X POST /repos/acme/widgets/pulls/7/reviews --input /tmp/r.json',
+      inputFileContents: 'not json',
+    })
+    expect(result).toBeNull()
+  })
+})
+
+describe('detectReviewSubmission — REST inline fields', () => {
+  test('-f event=APPROVE (separate value)', () => {
+    const result = detectReviewSubmission({
+      command: 'gh api /repos/acme/widgets/pulls/3/reviews -f event=APPROVE',
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 3, verdict: 'APPROVE' })
+  })
+
+  test('-F event=REQUEST_CHANGES', () => {
+    const result = detectReviewSubmission({
+      command: 'gh api /repos/acme/widgets/pulls/3/reviews -F event=REQUEST_CHANGES',
+    })
+    expect(result?.verdict).toBe('REQUEST_CHANGES')
+  })
+
+  test('case-insensitive event value', () => {
+    const result = detectReviewSubmission({
+      command: 'gh api /repos/acme/widgets/pulls/3/reviews -f event=approve',
+    })
+    expect(result?.verdict).toBe('APPROVE')
+  })
+})
+
+describe('detectReviewSubmission — gh pr review porcelain', () => {
+  test('gh pr review N --approve -R owner/repo', () => {
+    const result = detectReviewSubmission({
+      command: 'gh pr review 42 --approve -R acme/widgets',
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 42, verdict: 'APPROVE' })
+  })
+
+  test('gh pr review --request-changes N --repo owner/repo', () => {
+    const result = detectReviewSubmission({
+      command: 'gh pr review --request-changes 42 --repo acme/widgets',
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 42, verdict: 'REQUEST_CHANGES' })
+  })
+
+  test('gh pr review --comment is not tracked', () => {
+    const result = detectReviewSubmission({
+      command: 'gh pr review 42 --comment -b "thoughts" -R acme/widgets',
+    })
+    expect(result).toBeNull()
+  })
+})
+
+describe('detectReviewSubmission — non-matches', () => {
+  test('a plain pr view is null', () => {
+    expect(detectReviewSubmission({ command: 'gh pr view 12 -R acme/widgets' })).toBeNull()
+  })
+
+  test('a top-level issue comment is null', () => {
+    expect(
+      detectReviewSubmission({ command: 'gh api -X POST /repos/acme/widgets/issues/12/comments -f body=hi' }),
+    ).toBeNull()
+  })
+
+  test('reviews endpoint without an event is null', () => {
+    expect(
+      detectReviewSubmission({ command: 'gh api /repos/acme/widgets/pulls/12/reviews', inputFileContents: null }),
+    ).toBeNull()
+  })
+
+  test('a non-gh command is null', () => {
+    expect(detectReviewSubmission({ command: 'echo gh api reviews event=APPROVE' })).toBeNull()
+  })
+})

--- a/src/bundled-plugins/github-cli-auth/gh-review-detect.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-detect.ts
@@ -7,10 +7,14 @@ import type { ReviewVerdict } from '@/channels/github-review-turn-ledger'
 // the command is not a verdict-bearing review submission (incl. COMMENT reviews,
 // which carry no false-receipt risk and are not tracked).
 
+// `source` drives success detection downstream: the REST endpoints echo the
+// created review JSON, while the `gh pr review` porcelain prints a plain
+// confirmation line — so each needs its own success markers (see review-recorder).
 export type DetectedReview = {
   workspace: string
   prNumber: number
   verdict: ReviewVerdict
+  source: 'api' | 'pr-review'
 }
 
 export type GhReviewDetectInput = {
@@ -42,7 +46,7 @@ function detectApiReview(args: readonly string[], fileContents: string | null): 
 
   const verdict = verdictFromInlineFields(args) ?? verdictFromFile(fileContents)
   if (verdict === null) return null
-  return { workspace, prNumber, verdict }
+  return { workspace, prNumber, verdict, source: 'api' }
 }
 
 // Inline `-f event=APPROVE` / `--field event=REQUEST_CHANGES` (and `-F` raw).
@@ -94,7 +98,7 @@ function detectPrReview(args: readonly string[]): DetectedReview | null {
   const workspace = repoFromFlag(args)
   const prNumber = prNumberArg(args)
   if (workspace === null || prNumber === null) return null
-  return { workspace, prNumber, verdict }
+  return { workspace, prNumber, verdict, source: 'pr-review' }
 }
 
 function repoFromFlag(args: readonly string[]): string | null {

--- a/src/bundled-plugins/github-cli-auth/gh-review-detect.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-detect.ts
@@ -1,0 +1,171 @@
+import type { ReviewVerdict } from '@/channels/github-review-turn-ledger'
+
+// Extracts the formal-review verdict a successful `gh` command landed, so the
+// false-receipt ledger can credit it. Covers the three vectors the agent uses to
+// post a review: REST create-review via `--input <file>`, REST create-review via
+// inline `-f/-F event=...`, and the `gh pr review` porcelain. Returns null when
+// the command is not a verdict-bearing review submission (incl. COMMENT reviews,
+// which carry no false-receipt risk and are not tracked).
+
+export type DetectedReview = {
+  workspace: string
+  prNumber: number
+  verdict: ReviewVerdict
+}
+
+export type GhReviewDetectInput = {
+  command: string
+  // Contents of the file named by `--input <file>`, when the caller resolved it.
+  // Kept as an injected value so this module does no I/O and stays sync+pure.
+  inputFileContents?: string | null
+}
+
+const REVIEWS_ENDPOINT = /\/repos\/([^/\s]+)\/([^/\s]+)\/pulls\/(\d+)\/reviews\b/
+
+export function detectReviewSubmission(input: GhReviewDetectInput): DetectedReview | null {
+  const args = splitArgs(input.command)
+  if (args[0] !== 'gh') return null
+  const sub = args[1]
+  if (sub === 'api') return detectApiReview(args, input.inputFileContents ?? null)
+  if (sub === 'pr' && args[2] === 'review') return detectPrReview(args)
+  return null
+}
+
+function detectApiReview(args: readonly string[], fileContents: string | null): DetectedReview | null {
+  const endpoint = args.find((a) => REVIEWS_ENDPOINT.test(a))
+  if (endpoint === undefined) return null
+  const m = REVIEWS_ENDPOINT.exec(endpoint)
+  if (m === null) return null
+  const workspace = `${m[1]}/${m[2]}`
+  const prNumber = Number(m[3])
+  if (!Number.isSafeInteger(prNumber)) return null
+
+  const verdict = verdictFromInlineFields(args) ?? verdictFromFile(fileContents)
+  if (verdict === null) return null
+  return { workspace, prNumber, verdict }
+}
+
+// Inline `-f event=APPROVE` / `--field event=REQUEST_CHANGES` (and `-F` raw).
+// gh accepts both `flag value` and `flag=value` shapes; cover both.
+function verdictFromInlineFields(args: readonly string[]): ReviewVerdict | null {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === undefined) continue
+    if (a === '-f' || a === '-F' || a === '--field' || a === '--raw-field') {
+      const v = parseEventAssignment(args[i + 1])
+      if (v !== null) return v
+    }
+    if (a.startsWith('-f=') || a.startsWith('-F=') || a.startsWith('--field=') || a.startsWith('--raw-field=')) {
+      const v = parseEventAssignment(a.slice(a.indexOf('=') + 1))
+      if (v !== null) return v
+    }
+  }
+  return null
+}
+
+function parseEventAssignment(token: string | undefined): ReviewVerdict | null {
+  if (token === undefined) return null
+  const eq = token.indexOf('=')
+  if (eq === -1) return null
+  if (token.slice(0, eq).trim().toLowerCase() !== 'event') return null
+  return normalizeVerdict(token.slice(eq + 1))
+}
+
+function verdictFromFile(contents: string | null): ReviewVerdict | null {
+  if (contents === null || contents === '') return null
+  try {
+    const parsed = JSON.parse(contents) as unknown
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const event = (parsed as Record<string, unknown>).event
+    return typeof event === 'string' ? normalizeVerdict(event) : null
+  } catch {
+    return null
+  }
+}
+
+function detectPrReview(args: readonly string[]): DetectedReview | null {
+  const verdict =
+    args.includes('--approve') || args.includes('-a')
+      ? 'APPROVE'
+      : args.includes('--request-changes') || args.includes('-r')
+        ? 'REQUEST_CHANGES'
+        : null
+  if (verdict === null) return null
+  const workspace = repoFromFlag(args)
+  const prNumber = prNumberArg(args)
+  if (workspace === null || prNumber === null) return null
+  return { workspace, prNumber, verdict }
+}
+
+function repoFromFlag(args: readonly string[]): string | null {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === undefined) continue
+    if ((a === '-R' || a === '--repo') && isRepoSlug(args[i + 1])) return args[i + 1] as string
+    if (a.startsWith('--repo=') && isRepoSlug(a.slice('--repo='.length))) return a.slice('--repo='.length)
+    if (a.startsWith('-R=') && isRepoSlug(a.slice('-R='.length))) return a.slice('-R='.length)
+  }
+  return null
+}
+
+function prNumberArg(args: readonly string[]): number | null {
+  const start = args.indexOf('review') + 1
+  for (let i = start; i < args.length; i++) {
+    const a = args[i]
+    if (a === undefined) continue
+    if (a.startsWith('-')) continue
+    if (/^\d+$/.test(a)) {
+      const n = Number(a)
+      return Number.isSafeInteger(n) ? n : null
+    }
+  }
+  return null
+}
+
+function normalizeVerdict(value: string): ReviewVerdict | null {
+  const v = value.trim().toUpperCase()
+  if (v === 'APPROVE') return 'APPROVE'
+  if (v === 'REQUEST_CHANGES') return 'REQUEST_CHANGES'
+  return null
+}
+
+function isRepoSlug(value: string | undefined): boolean {
+  if (value === undefined) return false
+  const [owner, name, ...rest] = value.split('/')
+  return owner !== undefined && owner !== '' && name !== undefined && name !== '' && rest.length === 0
+}
+
+// Quote-aware whitespace split. The interceptor guarantees a single bare `gh`
+// command before we record (no pipes/substitution), so this only needs to honor
+// quotes, not full shell grammar.
+function splitArgs(command: string): string[] {
+  const out: string[] = []
+  let cur = ''
+  let quote: '"' | "'" | null = null
+  let has = false
+  for (const ch of command) {
+    if (quote !== null) {
+      if (ch === quote) quote = null
+      else cur += ch
+      has = true
+      continue
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch
+      has = true
+      continue
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (has) {
+        out.push(cur)
+        cur = ''
+        has = false
+      }
+      continue
+    }
+    cur += ch
+    has = true
+  }
+  if (has) out.push(cur)
+  return out
+}

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -3,6 +3,7 @@ import { definePlugin } from '@/plugin'
 
 import { analyzeGhCommand } from './gh-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
+import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
 import { classifyGhToken } from './token-class'
 
 export default definePlugin({
@@ -14,6 +15,8 @@ export default definePlugin({
           if (event.tool !== 'bash') return
           const command = event.args.command
           if (typeof command !== 'string' || !command.includes('gh')) return
+
+          await noteReviewCommand({ callId: event.callId, command })
 
           const decision = analyzeGhCommand(command)
           if (decision.kind === 'pass-through') return
@@ -42,6 +45,7 @@ export default definePlugin({
         },
         'tool.after': async (event) => {
           checkGraphqlAuthNudge({ tool: event.tool, result: event.result })
+          commitReviewIfSucceeded({ sessionId: event.sessionId, callId: event.callId, result: event.result })
         },
       },
     }

--- a/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
@@ -73,4 +73,30 @@ describe('review recorder', () => {
     commitReviewIfSucceeded({ sessionId: SESSION, callId: 'c5', result: textResult(SUCCESS_OUTPUT) })
     expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 5, verdict: 'APPROVE' })).toBe(false)
   })
+
+  test('credits a `gh pr review --approve` from its porcelain confirmation line', async () => {
+    await noteReviewCommand({ callId: 'c6', command: `gh pr review 42 --approve -R ${WS}` })
+    commitReviewIfSucceeded({
+      sessionId: SESSION,
+      callId: 'c6',
+      result: textResult(`✓ Approved pull request ${WS}#42`),
+    })
+    expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 42, verdict: 'APPROVE' })).toBe(true)
+  })
+
+  test('credits a `gh pr review --request-changes` from its porcelain confirmation line', async () => {
+    await noteReviewCommand({ callId: 'c7', command: `gh pr review 42 --request-changes -R ${WS}` })
+    commitReviewIfSucceeded({
+      sessionId: SESSION,
+      callId: 'c7',
+      result: textResult(`+ Requested changes to pull request ${WS}#42`),
+    })
+    expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 42, verdict: 'REQUEST_CHANGES' })).toBe(true)
+  })
+
+  test('does NOT credit a porcelain command whose output is missing the confirmation (fail closed)', async () => {
+    await noteReviewCommand({ callId: 'c8', command: `gh pr review 42 --approve -R ${WS}` })
+    commitReviewIfSucceeded({ sessionId: SESSION, callId: 'c8', result: textResult('(no recognizable output)') })
+    expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 42, verdict: 'APPROVE' })).toBe(false)
+  })
 })

--- a/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { hasReview, resetReviewTurn } from '@/channels/github-review-turn-ledger'
+import type { ToolResult } from '@/plugin'
+
+import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
+
+const SESSION = 'ses_recorder'
+const WS = 'acme/widgets'
+
+afterEach(() => resetReviewTurn(SESSION))
+
+function textResult(text: string): ToolResult {
+  return { content: [{ type: 'text', text }] }
+}
+
+const SUCCESS_OUTPUT = '{"id":1,"node_id":"PRR_abc","state":"APPROVED"}'
+const FAILURE_OUTPUT = 'gh: Validation Failed (HTTP 422)'
+
+describe('review recorder', () => {
+  test('credits the ledger when an inline-field APPROVE succeeds', async () => {
+    await noteReviewCommand({
+      callId: 'c1',
+      command: `gh api /repos/${WS}/pulls/5/reviews -f event=APPROVE`,
+    })
+    commitReviewIfSucceeded({ sessionId: SESSION, callId: 'c1', result: textResult(SUCCESS_OUTPUT) })
+    expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 5, verdict: 'APPROVE' })).toBe(true)
+  })
+
+  test('does NOT credit when the command failed', async () => {
+    await noteReviewCommand({
+      callId: 'c2',
+      command: `gh api /repos/${WS}/pulls/5/reviews -f event=APPROVE`,
+    })
+    commitReviewIfSucceeded({ sessionId: SESSION, callId: 'c2', result: textResult(FAILURE_OUTPUT) })
+    expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 5, verdict: 'APPROVE' })).toBe(false)
+  })
+
+  test('does NOT credit on an ambiguous result (fail closed)', async () => {
+    await noteReviewCommand({
+      callId: 'c3',
+      command: `gh api /repos/${WS}/pulls/5/reviews -f event=APPROVE`,
+    })
+    commitReviewIfSucceeded({ sessionId: SESSION, callId: 'c3', result: textResult('(no recognizable output)') })
+    expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 5, verdict: 'APPROVE' })).toBe(false)
+  })
+
+  test('reads the verdict from an --input file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'review-rec-'))
+    const file = join(dir, 'review.json')
+    writeFileSync(file, '{"event":"REQUEST_CHANGES","body":"x"}')
+    try {
+      await noteReviewCommand({
+        callId: 'c4',
+        command: `gh api -X POST /repos/${WS}/pulls/9/reviews --input ${file}`,
+      })
+      commitReviewIfSucceeded({
+        sessionId: SESSION,
+        callId: 'c4',
+        result: textResult('{"node_id":"PRR_z","state":"CHANGES_REQUESTED"}'),
+      })
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 9, verdict: 'REQUEST_CHANGES' })).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('a non-review gh command is ignored', async () => {
+    await noteReviewCommand({ callId: 'c5', command: `gh pr view 5 -R ${WS}` })
+    commitReviewIfSucceeded({ sessionId: SESSION, callId: 'c5', result: textResult(SUCCESS_OUTPUT) })
+    expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 5, verdict: 'APPROVE' })).toBe(false)
+  })
+})

--- a/src/bundled-plugins/github-cli-auth/review-recorder.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.ts
@@ -26,7 +26,7 @@ export function commitReviewIfSucceeded(args: { sessionId: string; callId: strin
   const detected = pending.get(args.callId)
   if (detected === undefined) return
   pending.delete(args.callId)
-  if (!looksSucceeded(collectText(args.result.content))) return
+  if (!looksSucceeded(detected, collectText(args.result.content))) return
   recordReview({
     sessionId: args.sessionId,
     workspace: detected.workspace,
@@ -62,15 +62,27 @@ function stripQuotes(value: string): string {
   return value
 }
 
-// A landed review POST echoes the created review JSON (its node id / state); a
-// rejected one prints a gh/HTTP error. Require a success marker AND no failure
-// marker, so a partial/garbled capture fails closed (uncredited).
-const SUCCESS_MARKERS = ['"node_id":"PRR_', '"state":"APPROVED"', '"state":"CHANGES_REQUESTED"', '"state": "APPROVED"']
+// Success markers are vector-specific. The REST endpoints echo the created
+// review JSON; the `gh pr review` porcelain prints a plain confirmation line
+// ("✓ Approved pull request OWNER/REPO#N" / "+ Requested changes to pull
+// request …", from cli/cli pkg/cmd/pr/review). Matching REST JSON markers
+// against porcelain output left every `gh pr review --approve` uncredited, so a
+// later "Approved" reply in the same turn was wrongly blocked.
+const API_SUCCESS_MARKERS = [
+  '"node_id":"PRR_',
+  '"state":"APPROVED"',
+  '"state":"CHANGES_REQUESTED"',
+  '"state": "APPROVED"',
+]
+const PR_REVIEW_SUCCESS_MARKERS = ['Approved pull request', 'Requested changes to pull request']
 const FAILURE_MARKERS = ['gh: ', 'HTTP 4', 'HTTP 5', 'Bad credentials', 'Not Found', 'Validation Failed']
 
-function looksSucceeded(text: string): boolean {
+// Require a success marker AND no failure marker, so a partial/garbled capture
+// fails closed (uncredited).
+function looksSucceeded(detected: DetectedReview, text: string): boolean {
   if (FAILURE_MARKERS.some((m) => text.includes(m))) return false
-  return SUCCESS_MARKERS.some((m) => text.includes(m))
+  const markers = detected.source === 'pr-review' ? PR_REVIEW_SUCCESS_MARKERS : API_SUCCESS_MARKERS
+  return markers.some((m) => text.includes(m))
 }
 
 function collectText(content: readonly ContentPart[]): string {

--- a/src/bundled-plugins/github-cli-auth/review-recorder.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.ts
@@ -1,0 +1,81 @@
+import { readFile } from 'node:fs/promises'
+
+import { recordReview } from '@/channels/github-review-turn-ledger'
+import type { ContentPart, ToolResult } from '@/plugin'
+
+import { detectReviewSubmission, type DetectedReview } from './gh-review-detect'
+
+// Bridges the bash `gh` interceptor to the false-receipt ledger: at tool.before
+// we detect a review-submission command (resolving its --input file), stash it by
+// callId, and at tool.after we credit the ledger ONLY if the command actually
+// succeeded. Strict success detection is the safe bias here — wrongly crediting a
+// review that never landed would re-open the false-receipt hole, so an ambiguous
+// result is treated as "not landed" and left uncredited.
+
+const pending = new Map<string, DetectedReview>()
+
+const MAX_INPUT_BYTES = 1_000_000
+
+export async function noteReviewCommand(args: { callId: string; command: string }): Promise<void> {
+  const inputFileContents = await readInputFile(args.command)
+  const detected = detectReviewSubmission({ command: args.command, inputFileContents })
+  if (detected !== null) pending.set(args.callId, detected)
+}
+
+export function commitReviewIfSucceeded(args: { sessionId: string; callId: string; result: ToolResult }): void {
+  const detected = pending.get(args.callId)
+  if (detected === undefined) return
+  pending.delete(args.callId)
+  if (!looksSucceeded(collectText(args.result.content))) return
+  recordReview({
+    sessionId: args.sessionId,
+    workspace: detected.workspace,
+    prNumber: detected.prNumber,
+    verdict: detected.verdict,
+  })
+}
+
+async function readInputFile(command: string): Promise<string | null> {
+  const path = inputFilePath(command)
+  if (path === null) return null
+  try {
+    const buf = await readFile(path)
+    if (buf.byteLength > MAX_INPUT_BYTES) return null
+    return buf.toString('utf8')
+  } catch {
+    return null
+  }
+}
+
+function inputFilePath(command: string): string | null {
+  const m = /(?:^|\s)--input(?:=|\s+)(\S+)/.exec(command)
+  if (m === null) return null
+  const raw = m[1] as string
+  if (raw === '-') return null
+  return stripQuotes(raw)
+}
+
+function stripQuotes(value: string): string {
+  if (value.length >= 2 && (value[0] === '"' || value[0] === "'") && value[value.length - 1] === value[0]) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
+// A landed review POST echoes the created review JSON (its node id / state); a
+// rejected one prints a gh/HTTP error. Require a success marker AND no failure
+// marker, so a partial/garbled capture fails closed (uncredited).
+const SUCCESS_MARKERS = ['"node_id":"PRR_', '"state":"APPROVED"', '"state":"CHANGES_REQUESTED"', '"state": "APPROVED"']
+const FAILURE_MARKERS = ['gh: ', 'HTTP 4', 'HTTP 5', 'Bad credentials', 'Not Found', 'Validation Failed']
+
+function looksSucceeded(text: string): boolean {
+  if (FAILURE_MARKERS.some((m) => text.includes(m))) return false
+  return SUCCESS_MARKERS.some((m) => text.includes(m))
+}
+
+function collectText(content: readonly ContentPart[]): string {
+  return content
+    .filter((p): p is ContentPart & { type: 'text' } => p.type === 'text')
+    .map((p) => p.text)
+    .join('\n')
+}

--- a/src/channels/github-false-receipt.test.ts
+++ b/src/channels/github-false-receipt.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { checkFalseReceipt } from './github-false-receipt'
+import { recordResolvedThread, recordReview, resetReviewTurn } from './github-review-turn-ledger'
+
+const S = 'ses_fr'
+const WS = 'acme/widgets'
+
+afterEach(() => resetReviewTurn(S))
+
+function base(over: Partial<Parameters<typeof checkFalseReceipt>[0]> = {}): Parameters<typeof checkFalseReceipt>[0] {
+  return {
+    sessionId: S,
+    adapter: 'github',
+    workspace: WS,
+    chat: 'pr:12',
+    thread: null,
+    text: '',
+    isContinue: false,
+    resolveReviewThread: false,
+    ...over,
+  }
+}
+
+describe('checkFalseReceipt — scope gates', () => {
+  test('non-github adapter is always allowed', () => {
+    expect(checkFalseReceipt(base({ adapter: 'slack-bot', text: 'Approved!' })).kind).toBe('allow')
+  })
+
+  test('non-pr github chat is allowed', () => {
+    expect(checkFalseReceipt(base({ chat: 'issue:12', text: 'Approved!' })).kind).toBe('allow')
+  })
+})
+
+describe('checkFalseReceipt — verdict false receipts', () => {
+  test('terminal "Approved" with no review this turn is BLOCKED', () => {
+    expect(checkFalseReceipt(base({ text: 'Approved!' })).kind).toBe('block')
+  })
+
+  test('terminal "Approved" AFTER a real APPROVE review is allowed', () => {
+    recordReview({ sessionId: S, workspace: WS, prNumber: 12, verdict: 'APPROVE' })
+    expect(checkFalseReceipt(base({ text: 'Approved — thanks!' })).kind).toBe('allow')
+  })
+
+  test('a real REQUEST_CHANGES does not satisfy an approve claim', () => {
+    recordReview({ sessionId: S, workspace: WS, prNumber: 12, verdict: 'REQUEST_CHANGES' })
+    expect(checkFalseReceipt(base({ text: 'Approved!' })).kind).toBe('block')
+  })
+
+  test('terminal "requesting changes" with no review is BLOCKED', () => {
+    expect(checkFalseReceipt(base({ text: 'Requesting changes here.' })).kind).toBe('block')
+  })
+
+  test('continue:true downgrades a hard verdict claim to a warn', () => {
+    expect(checkFalseReceipt(base({ text: 'Approved!', isContinue: true })).kind).toBe('warn')
+  })
+
+  test('soft signal warns, never blocks', () => {
+    expect(checkFalseReceipt(base({ text: 'looks good' })).kind).toBe('warn')
+  })
+
+  test('unrelated text is allowed', () => {
+    expect(checkFalseReceipt(base({ text: 'Can you rebase onto main?' })).kind).toBe('allow')
+  })
+})
+
+describe('checkFalseReceipt — resolve false receipts', () => {
+  test('"resolved" ack in a thread without the flag is BLOCKED', () => {
+    expect(checkFalseReceipt(base({ thread: '555', text: 'That resolves it, thanks!' })).kind).toBe('block')
+  })
+
+  test('"resolved" ack WITH the flag is allowed', () => {
+    expect(
+      checkFalseReceipt(base({ thread: '555', text: 'That resolves it, thanks!', resolveReviewThread: true })).kind,
+    ).toBe('allow')
+  })
+
+  test('"resolved" ack after the thread was resolved this turn is allowed', () => {
+    recordResolvedThread({ sessionId: S, workspace: WS, prNumber: 12, rootCommentId: '555' })
+    expect(checkFalseReceipt(base({ thread: '555', text: 'That resolves it, thanks!' })).kind).toBe('allow')
+  })
+
+  test('a resolve claim on a PR root (no thread) is allowed (not a thread close-out)', () => {
+    expect(checkFalseReceipt(base({ thread: null, text: 'That resolves it.' })).kind).toBe('allow')
+  })
+})

--- a/src/channels/github-false-receipt.ts
+++ b/src/channels/github-false-receipt.ts
@@ -1,0 +1,87 @@
+import { classifyReviewClaim } from './github-review-claim'
+import { hasResolvedThread, hasReview } from './github-review-turn-ledger'
+
+// Decides whether a github PR reply is a false receipt: prose that CLAIMS a
+// formal verdict / thread close-out the agent never actually performed this turn.
+// Pure except for the ledger reads (module singletons); returns the action the
+// channel_reply tool should take. Block only the black-and-white cases; warn on
+// soft signals so casual chatter is never hard-denied.
+
+export type FalseReceiptDecision =
+  | { kind: 'allow' }
+  | { kind: 'block'; reason: string }
+  | { kind: 'warn'; notice: string }
+
+export type FalseReceiptInput = {
+  sessionId: string
+  adapter: string
+  workspace: string
+  chat: string
+  thread: string | null
+  text: string | undefined
+  isContinue: boolean
+  resolveReviewThread: boolean
+}
+
+export function checkFalseReceipt(input: FalseReceiptInput): FalseReceiptDecision {
+  if (input.adapter !== 'github') return { kind: 'allow' }
+  const prNumber = prNumberFromChat(input.chat)
+  if (prNumber === null) return { kind: 'allow' }
+
+  const claim = classifyReviewClaim(input.text ?? '')
+  if (claim === 'ignore') return { kind: 'allow' }
+  if (claim === 'warn') return { kind: 'warn', notice: SOFT_NOTICE }
+
+  // A turn the agent explicitly keeps alive (continue:true) is not yet a receipt
+  // — the real action may still be coming. Never block; nudge instead.
+  if (input.isContinue) return { kind: 'warn', notice: SOFT_NOTICE }
+
+  if (claim === 'block-resolve') {
+    if (input.thread === null) return { kind: 'allow' }
+    if (input.resolveReviewThread) return { kind: 'allow' }
+    if (
+      hasResolvedThread({
+        sessionId: input.sessionId,
+        workspace: input.workspace,
+        prNumber,
+        rootCommentId: input.thread,
+      })
+    ) {
+      return { kind: 'allow' }
+    }
+    return { kind: 'block', reason: RESOLVE_REASON }
+  }
+
+  const verdict = claim === 'block-approve' ? 'APPROVE' : 'REQUEST_CHANGES'
+  if (hasReview({ sessionId: input.sessionId, workspace: input.workspace, prNumber, verdict })) {
+    return { kind: 'allow' }
+  }
+  return { kind: 'block', reason: verdict === 'APPROVE' ? APPROVE_REASON : REQUEST_CHANGES_REASON }
+}
+
+function prNumberFromChat(chat: string): number | null {
+  const m = /^pr:(\d+)$/.exec(chat)
+  if (m === null) return null
+  const n = Number(m[1])
+  return Number.isSafeInteger(n) && n > 0 ? n : null
+}
+
+const APPROVE_REASON =
+  'This reply reads as a formal approval, but no APPROVE review was submitted on this PR this turn. ' +
+  'A chat comment is not a GitHub review — submit the formal review via `gh api -X POST /repos/<owner>/<repo>/pulls/<N>/reviews` ' +
+  '(event: APPROVE) first, then narrate if needed. If you are not actually approving, reword the reply.'
+
+const REQUEST_CHANGES_REASON =
+  'This reply reads as a formal "request changes", but no REQUEST_CHANGES review was submitted on this PR this turn. ' +
+  'Submit the formal review via `gh api -X POST /repos/<owner>/<repo>/pulls/<N>/reviews` (event: REQUEST_CHANGES) first. ' +
+  'If you are not actually requesting changes, reword the reply.'
+
+const RESOLVE_REASON =
+  'This reply reads as closing out a review thread, but `resolve_review_thread: true` was not set and the thread ' +
+  'was not resolved this turn. Pass `resolve_review_thread: true` on this reply to actually resolve it, ' +
+  'or reword if the thread should stay open.'
+
+const SOFT_NOTICE =
+  'Note: a chat comment does not create a formal GitHub review or resolve a thread. ' +
+  'If you mean to approve / request changes, submit a formal review via `gh api`; ' +
+  'to close a thread you authored, set `resolve_review_thread: true`.'

--- a/src/channels/github-review-claim.test.ts
+++ b/src/channels/github-review-claim.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+
+import { classifyReviewClaim, type ReviewClaim } from './github-review-claim'
+
+const cases: ReadonlyArray<[string, ReviewClaim]> = [
+  ['Approved!', 'block-approve'],
+  ['**Approved** — nice work', 'block-approve'],
+  ['I approve this PR', 'block-approve'],
+  ['Approving now.', 'block-approve'],
+  ['Approval submitted ✅', 'block-approve'],
+  ['LGTM, approved', 'block-approve'],
+
+  ['Requesting changes here.', 'block-request-changes'],
+  ['Changes requested — see inline.', 'block-request-changes'],
+  ['I request changes on this.', 'block-request-changes'],
+  ['Blocking this PR until the leak is fixed.', 'block-request-changes'],
+
+  // block-resolve (caller only consults this when thread!=null)
+  ['Verified at abc123, that fixes it. Thanks!', 'block-resolve'],
+  ['Thanks, looks resolved.', 'block-resolve'],
+  ['Marked resolved.', 'block-resolve'],
+  ['That resolves it — closing this out.', 'block-resolve'],
+  ['Confirmed fixed.', 'block-resolve'],
+
+  // warn: soft signals, allowed through with a nudge
+  ['LGTM', 'warn'],
+  ['looks good', 'warn'],
+  ['Looks good to me!', 'warn'],
+  ['seems fine', 'warn'],
+  ['this needs changes IMO', 'warn'],
+  ['looks resolved?', 'warn'],
+
+  ["I haven't approved yet — still reviewing.", 'ignore'],
+  ['I cannot approve this until tests pass.', 'ignore'],
+  ['not approved', 'ignore'],
+  ["I'll approve once CI is green.", 'ignore'],
+  ['Going to review this shortly.', 'ignore'],
+  ['I approved it earlier, in my last review.', 'ignore'],
+  ['Yes, I requested changes yesterday.', 'ignore'],
+  ['Can you clarify the second point?', 'ignore'],
+  ['', 'ignore'],
+]
+
+describe('classifyReviewClaim', () => {
+  for (const [text, expected] of cases) {
+    test(`${JSON.stringify(text)} → ${expected}`, () => {
+      expect(classifyReviewClaim(text)).toBe(expected)
+    })
+  }
+
+  test('block-tier outranks an embedded warn phrase', () => {
+    // given a message carrying both a soft signal and a hard approval claim
+    // when classified
+    // then the hard claim wins
+    expect(classifyReviewClaim('looks good — approved!')).toBe('block-approve')
+  })
+
+  test('negation demotes even when a block phrase is present', () => {
+    expect(classifyReviewClaim("looks good but I haven't approved it")).toBe('ignore')
+  })
+})

--- a/src/channels/github-review-claim.ts
+++ b/src/channels/github-review-claim.ts
@@ -1,0 +1,91 @@
+// Deterministic phrase classifier for the false-receipt guard (channel-reply.ts):
+// how strongly does a github PR reply CLAIM a formal verdict/close-out it may not
+// have actually performed? The taxonomy errs toward WARN over BLOCK on purpose —
+// a false block breaks a legitimate reply; a missed soft-fake only loses a nudge.
+
+export type ReviewClaim = 'block-approve' | 'block-request-changes' | 'block-resolve' | 'warn' | 'ignore'
+
+// Word-boundary anchored so "approved" never fires inside "unapproved".
+const BLOCK_APPROVE: readonly RegExp[] = [
+  /\bapproved\b/,
+  /\bapproving\b/,
+  /\bi approve\b/,
+  /\bapproval (submitted|sent|posted)\b/,
+  /\bsubmitting (the )?approval\b/,
+  /\bformal approval\b/,
+  /\blgtm,? approved\b/,
+]
+
+const BLOCK_REQUEST_CHANGES: readonly RegExp[] = [
+  /\brequest(ing|ed)? changes\b/,
+  /\bchanges requested\b/,
+  /\bi request changes\b/,
+  /\bblocking (this|the|merge)\b/,
+  /\bthis is blocked\b/,
+]
+
+// Only consulted by the caller when thread!=null (a review thread). Bare
+// "resolved" is intentionally NOT here — it collides with the warn-tier "looks
+// resolved?"; resolve claims must carry a definite marker (marked/that/this/
+// thanks) or a verify clause.
+const BLOCK_RESOLVE: readonly RegExp[] = [
+  /\bmarked resolved\b/,
+  /\bthread resolved\b/,
+  /\bthat resolves it\b/,
+  /\bthis resolves it\b/,
+  /\bclosing this out\b/,
+  /\bconfirmed fixed\b/,
+  // verify clause + a fix/resolve verb, allowing a short gap ("verified at <sha>, that fixes it").
+  /\b(verified|confirmed)\b[^.!?]*\b(fix(es|ed)|resolv)/,
+  /\b(thanks,?|fixed,?) (looks )?resolved\b/,
+]
+
+// Casual phrasing that might be chatter, not a formal close-out: allow + nudge.
+const WARN: readonly RegExp[] = [
+  /\blgtm\b/,
+  /\blooks good\b/,
+  /\blooks fine\b/,
+  /\bseems fine\b/,
+  /\bshould be (fine|good)\b/,
+  /\bneeds changes\b/,
+  /\bstill needs work\b/,
+  /\blooks resolved\b/,
+  /\bseems resolved\b/,
+]
+
+// Negation / future-intent / past-reference markers DEMOTE a positive match to
+// ignore. Blocking "I haven't approved" / "I'll approve" / "approved it earlier"
+// (answering a question) is the worst false-positive class, so it is checked first.
+const DEMOTE_TO_IGNORE: readonly RegExp[] = [
+  /\b(haven'?t|have not|did ?n'?t|did not|not yet|never)\b[^.!?]*\b(approv|request|resolv|block)/,
+  /\b(can'?t|cannot|won'?t|will not|wouldn'?t)\b[^.!?]*\b(approv|request|resolv|block)/,
+  /\bnot (approved|resolved|blocked|requesting)\b/,
+  /\b(i'?ll|i will|going to|gonna|about to|planning to)\b[^.!?]*\b(approv|review|request|resolv)/,
+  /\b(approved|resolved|requested changes)\b[^.!?]*\b(earlier|already|yesterday|before|last (review|time)|previously)\b/,
+]
+
+export function classifyReviewClaim(rawText: string): ReviewClaim {
+  const text = normalize(rawText)
+  if (text === '') return 'ignore'
+
+  if (DEMOTE_TO_IGNORE.some((re) => re.test(text))) return 'ignore'
+
+  // Block-tier wins over warn-tier: an unambiguous "approved" in a casual message
+  // is still a formal claim.
+  if (BLOCK_APPROVE.some((re) => re.test(text))) return 'block-approve'
+  if (BLOCK_REQUEST_CHANGES.some((re) => re.test(text))) return 'block-request-changes'
+  if (BLOCK_RESOLVE.some((re) => re.test(text))) return 'block-resolve'
+  if (WARN.some((re) => re.test(text))) return 'warn'
+  return 'ignore'
+}
+
+// Strips markdown/emoji noise so "**Approved!**" and "approved" classify alike,
+// keeping apostrophes + sentence punctuation that the negation regexes rely on.
+function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[*_`~#>]/g, ' ')
+    .replace(/[^\p{L}\p{N}\s'.!?]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}

--- a/src/channels/github-review-turn-ledger.test.ts
+++ b/src/channels/github-review-turn-ledger.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import {
+  hasResolvedThread,
+  hasReview,
+  recordResolvedThread,
+  recordReview,
+  resetReviewTurn,
+} from './github-review-turn-ledger'
+
+const S1 = 'ses_one'
+const S2 = 'ses_two'
+const WS = 'acme/widgets'
+
+afterEach(() => {
+  resetReviewTurn(S1)
+  resetReviewTurn(S2)
+})
+
+describe('review ledger', () => {
+  test('records and reads back a verdict for the same pr', () => {
+    recordReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })
+    expect(hasReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })).toBe(true)
+  })
+
+  test('a recorded APPROVE does not satisfy a REQUEST_CHANGES query', () => {
+    recordReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })
+    expect(hasReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'REQUEST_CHANGES' })).toBe(false)
+  })
+
+  test('verdicts are isolated per pr number', () => {
+    recordReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })
+    expect(hasReview({ sessionId: S1, workspace: WS, prNumber: 99, verdict: 'APPROVE' })).toBe(false)
+  })
+
+  test('verdicts are isolated per session', () => {
+    recordReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })
+    expect(hasReview({ sessionId: S2, workspace: WS, prNumber: 12, verdict: 'APPROVE' })).toBe(false)
+  })
+
+  test('resetReviewTurn clears only the target session', () => {
+    recordReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })
+    recordReview({ sessionId: S2, workspace: WS, prNumber: 12, verdict: 'APPROVE' })
+    resetReviewTurn(S1)
+    expect(hasReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })).toBe(false)
+    expect(hasReview({ sessionId: S2, workspace: WS, prNumber: 12, verdict: 'APPROVE' })).toBe(true)
+  })
+})
+
+describe('resolved-thread ledger', () => {
+  test('records and reads back a resolved thread', () => {
+    recordResolvedThread({ sessionId: S1, workspace: WS, prNumber: 12, rootCommentId: '555' })
+    expect(hasResolvedThread({ sessionId: S1, workspace: WS, prNumber: 12, rootCommentId: '555' })).toBe(true)
+  })
+
+  test('a different root comment is not considered resolved', () => {
+    recordResolvedThread({ sessionId: S1, workspace: WS, prNumber: 12, rootCommentId: '555' })
+    expect(hasResolvedThread({ sessionId: S1, workspace: WS, prNumber: 12, rootCommentId: '777' })).toBe(false)
+  })
+
+  test('resetReviewTurn clears resolved threads for the session', () => {
+    recordResolvedThread({ sessionId: S1, workspace: WS, prNumber: 12, rootCommentId: '555' })
+    resetReviewTurn(S1)
+    expect(hasResolvedThread({ sessionId: S1, workspace: WS, prNumber: 12, rootCommentId: '555' })).toBe(false)
+  })
+})

--- a/src/channels/github-review-turn-ledger.ts
+++ b/src/channels/github-review-turn-ledger.ts
@@ -1,0 +1,71 @@
+// In-process record of REAL github review actions performed during the current
+// turn, shared across two plugin boundaries: github-cli-auth records a formal
+// review / thread-resolve here after the `gh` command SUCCEEDS, and channel-reply
+// consults it before sending a verdict/close-out reply. If the agent claims a
+// verdict in prose but this ledger shows no matching action this turn, the reply
+// is a false receipt (see channel-reply.ts). State is per-session and reset at
+// turn start, so a claim must be backed by an action in the SAME turn.
+
+export type ReviewVerdict = 'APPROVE' | 'REQUEST_CHANGES'
+
+type PrKey = string
+type ThreadKey = string
+
+const reviewsByPr = new Map<PrKey, Set<ReviewVerdict>>()
+const resolvedThreads = new Set<ThreadKey>()
+
+function prKey(sessionId: string, workspace: string, prNumber: number): PrKey {
+  return `${sessionId}::${workspace}::${prNumber}`
+}
+
+function threadKey(sessionId: string, workspace: string, prNumber: number, rootCommentId: string): ThreadKey {
+  return `${sessionId}::${workspace}::${prNumber}::${rootCommentId}`
+}
+
+export function resetReviewTurn(sessionId: string): void {
+  for (const key of reviewsByPr.keys()) {
+    if (key.startsWith(`${sessionId}::`)) reviewsByPr.delete(key)
+  }
+  for (const key of resolvedThreads) {
+    if (key.startsWith(`${sessionId}::`)) resolvedThreads.delete(key)
+  }
+}
+
+export function recordReview(args: {
+  sessionId: string
+  workspace: string
+  prNumber: number
+  verdict: ReviewVerdict
+}): void {
+  const key = prKey(args.sessionId, args.workspace, args.prNumber)
+  const set = reviewsByPr.get(key) ?? new Set<ReviewVerdict>()
+  set.add(args.verdict)
+  reviewsByPr.set(key, set)
+}
+
+export function hasReview(args: {
+  sessionId: string
+  workspace: string
+  prNumber: number
+  verdict: ReviewVerdict
+}): boolean {
+  return reviewsByPr.get(prKey(args.sessionId, args.workspace, args.prNumber))?.has(args.verdict) ?? false
+}
+
+export function recordResolvedThread(args: {
+  sessionId: string
+  workspace: string
+  prNumber: number
+  rootCommentId: string
+}): void {
+  resolvedThreads.add(threadKey(args.sessionId, args.workspace, args.prNumber, args.rootCommentId))
+}
+
+export function hasResolvedThread(args: {
+  sessionId: string
+  workspace: string
+  prNumber: number
+  rootCommentId: string
+}): boolean {
+  return resolvedThreads.has(threadKey(args.sessionId, args.workspace, args.prNumber, args.rootCommentId))
+}

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -32,6 +32,7 @@ import {
   StickyLedger,
   type EngagementDecision,
 } from './engagement'
+import { resetReviewTurn } from './github-review-turn-ledger'
 import {
   MEMBERSHIP_COLD_FETCH_TIMEOUT_MS,
   type MembershipCount,
@@ -1844,6 +1845,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.successfulSendsAtTurnStart = successfulSendsBeforePrompt
         live.skipLockedSendTurn = null
         live.policyDeniedToolSendsThisTurn.clear()
+        resetReviewTurn(live.sessionId)
         const isRealUserTurn = batch.length > 0
         await fireSessionTurnStart(live, text)
         try {


### PR DESCRIPTION
## Background

When the agent reviews a GitHub PR, the failure mode is a **false receipt**: it posts a chat reply like "Approved! 👍" or "verified, looks resolved — thanks" on a `pr:N` and ends its turn, but never submits the formal review (`gh api .../pulls/N/reviews`) or resolves the thread. GitHub shows the PR still "awaiting review" with no review state, while the conversation reads as settled. The same gap applies to "requesting changes" prose with no `REQUEST_CHANGES` review, and to thread acks that omit `resolve_review_thread: true`.

Until now this was discouraged **only** by prose in `typeclaw-channel-github/SKILL.md`. Nothing enforced it, so a model that pattern-matched "they fixed it → say thanks" could strand the verdict every time.

## Summary

A programmatic guard at the `channel_reply` boundary, built from small pure pieces so the heuristic is testable in isolation:

- **`github-review-claim`** — deterministic phrase classifier tiering a reply into `block-approve` / `block-request-changes` / `block-resolve` / `warn` / `ignore`. It anchors block-tier on unambiguous formal phrasing and **demotes negation / future-intent / past-reference to ignore** ("I haven't approved", "I'll approve", "approved it earlier") — the worst false-positive class. Why deterministic and not an LLM call: the guard runs on every PR reply and must be cheap, predictable, and test-locked; it deliberately errs toward **warn over block** so casual chatter is never hard-denied.
- **`github-review-turn-ledger`** — in-memory, per-session record of *real* actions (formal review verdicts, resolved threads), reset at turn start. A verdict claim must be backed by an action in the **same** turn.
- **`github-cli-auth` recorder** — credits the ledger from `tool.after`, **only when the `gh` command actually succeeded**. Success detection is fail-closed: ambiguous/garbled output is treated as not-landed, so a non-existent review is never credited (the safe bias — a wrongly-credited review would re-open the hole). Covers REST `--input`, inline `-f/-F event=`, and `gh pr review --approve/--request-changes`.
- **`github-false-receipt` + `channel_reply` wiring** — runs before `router.send`, so a block posts nothing. `continue:true` (turn explicitly not over) and soft signals downgrade to an appended warn notice. Resolve claims honor the existing `resolve_review_thread` flag.

Why the guard lives in `channel_reply` and not the `gh` interceptor: the false-receipt is the *absence* of an action paired with a *claim*, and the claim only exists in the reply text — the interceptor never sees it. The interceptor's role is the inverse: recording that the real action happened.

## What this does NOT do

- It does **not** stop the agent from approving when it shouldn't (this is not an authorization guard; `review.approve: false` enforcement is unchanged).
- It does **not** yet record reviews submitted via raw `gh api graphql` `addPullRequestReview`/`submitPullRequestReview` mutations — such a review would currently cause a false *block* (safe direction), not a false receipt. Deferred.
- It does **not** harden the `--input` TOCTOU window (read-then-exec); deferred.

## Review notes

- Load-bearing invariant: **a block must post nothing.** The check returns before `router.send`; see `channel-reply.ts`. Verify the block path's `details.ok === false` and zero sends (covered in `channel-reply.false-receipt.test.ts`).
- The other invariant: **credit only on real success.** `review-recorder.ts` requires a success marker AND no failure marker; an unrecognized result stays uncredited. This is what keeps the guard honest.
- Turn-scoping: the ledger reset is wired at turn start in `router.ts`. A claim backed by an action from a *previous* turn will (correctly) not be credited.
- Heuristic boundaries are pinned by `github-review-claim.test.ts` (54 phrase cases) — that's the file to scrutinize for false-positive risk.