### PR TITLE
agent: resolve channel_react target at execute time

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -13,6 +13,7 @@ import type { AgentSession, ToolDefinition } from '@mariozechner/pi-coding-agent
 
 import { loadMemory } from '@/bundled-plugins/memory/load-memory'
 import type { ChannelRouter } from '@/channels/router'
+import type { ReactionRef } from '@/channels/types'
 import { getConfig, resolveModel, resolveProfile } from '@/config'
 import { defaultThinkingLevelForRef, providerForModelRef, type KnownModelRef } from '@/config/providers'
 import { renderMcpCatalog } from '@/mcp/catalog'
@@ -359,7 +360,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
             ...(options.mcpManager ? buildMcpDispatcherToolDefinitions(options.mcpManager) : []),
             ...(options.reloadRegistry ? [createReloadTool({ registry: options.reloadRegistry })] : []),
             ...(options.stream ? [createStreamSnapshotTool({ stream: options.stream })] : []),
-            ...buildChannelTools(options.channelRouter, options.origin, sessionManager.getSessionId()),
+            ...buildChannelTools(options.channelRouter, options.origin, sessionManager.getSessionId(), getOrigin),
             ...(options.containerName
               ? [
                   createRestartTool({
@@ -620,6 +621,7 @@ export function buildChannelTools(
   channelRouter: ChannelRouter | undefined,
   origin: SessionOrigin | undefined,
   sessionId?: string,
+  getOrigin?: () => SessionOrigin | undefined,
 ): ToolDefinition[] {
   if (!channelRouter) return []
   const tools: ToolDefinition[] = []
@@ -633,10 +635,18 @@ export function buildChannelTools(
     tools.push(createChannelReplyTool({ router: channelRouter, origin: channelOrigin }))
     tools.push(createChannelHistoryTool({ router: channelRouter, origin: channelOrigin }))
     tools.push(createChannelSendTool({ router: channelRouter, origin: channelOrigin }))
+    // Read the live turn origin, falling back to the static snapshot when no
+    // getter is wired (composition tests). `reactionRef` is per-turn, so the
+    // getter is what makes reactions work outside tests.
+    const resolveReactionRef = (): ReactionRef | undefined => {
+      const live = getOrigin?.() ?? origin
+      return live.kind === 'channel' ? live.reactionRef : undefined
+    }
     tools.push(
       createChannelReactTool({
         router: channelRouter,
-        origin: { ...channelOrigin, ...(origin.reactionRef !== undefined ? { reactionRef: origin.reactionRef } : {}) },
+        origin: channelOrigin,
+        getReactionRef: resolveReactionRef,
       }),
     )
     tools.push(

--- a/src/agent/tools/channel-react.test.ts
+++ b/src/agent/tools/channel-react.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import type { ChannelRouter } from '@/channels/router'
-import type { ReactionRequest, ReactionResult } from '@/channels/types'
+import type { ReactionRef, ReactionRequest, ReactionResult } from '@/channels/types'
 
 import { createChannelReactTool, type ChannelReactOrigin } from './channel-react'
 
@@ -48,7 +48,11 @@ const githubOrigin: ChannelReactOrigin = {
   workspace: 'acme/project',
   chat: 'pr:7',
   thread: null,
-  reactionRef: { adapter: 'github', value: '{"kind":"issue","owner":"acme","repo":"project","issueNumber":7}' },
+}
+
+const githubReactionRef: ReactionRef = {
+  adapter: 'github',
+  value: '{"kind":"issue","owner":"acme","repo":"project","issueNumber":7}',
 }
 
 const fakeCtx = {} as Parameters<ReturnType<typeof createChannelReactTool>['execute']>[4]
@@ -64,6 +68,7 @@ describe('createChannelReactTool', () => {
         return { ok: true }
       }),
       origin: githubOrigin,
+      getReactionRef: () => githubReactionRef,
       logger: { warn: () => {} },
     })
 
@@ -75,9 +80,36 @@ describe('createChannelReactTool', () => {
       workspace: 'acme/project',
       chat: 'pr:7',
       thread: null,
-      reactionRef: githubOrigin.reactionRef!,
+      reactionRef: githubReactionRef,
       emoji: 'eyes',
     })
+  })
+
+  test('resolves the reaction ref at execute time, not at tool-build time', async () => {
+    // Regression: the tool is built once per session, but the reaction target
+    // is per-turn. A statically captured ref is the session-creation snapshot
+    // (always undefined), so every call would deny. The getter must be read on
+    // execute so each turn reacts to its own triggering message.
+    let current: ReactionRef | undefined
+    let captured: ReactionRequest | undefined
+    const tool = createChannelReactTool({
+      router: fakeRouter(async (req) => {
+        captured = req
+        return { ok: true }
+      }),
+      origin: githubOrigin,
+      getReactionRef: () => current,
+      logger: { warn: () => {} },
+    })
+
+    const denied = await run(tool, 'eyes')
+    expect(denied.details).toEqual({ ok: false, error: 'this conversation has no message to react to' })
+
+    current = githubReactionRef
+    const ok = await run(tool, 'rocket')
+    expect(ok.details).toEqual({ ok: true })
+    expect(captured?.reactionRef).toEqual(githubReactionRef)
+    expect(captured?.emoji).toBe('rocket')
   })
 
   test('denies when the conversation has no reaction target', async () => {
@@ -87,7 +119,8 @@ describe('createChannelReactTool', () => {
         called = true
         return { ok: true }
       }),
-      origin: { ...githubOrigin, reactionRef: undefined },
+      origin: githubOrigin,
+      getReactionRef: () => undefined,
       logger: { warn: () => {} },
     })
 
@@ -101,6 +134,7 @@ describe('createChannelReactTool', () => {
     const tool = createChannelReactTool({
       router: fakeRouter(async () => ({ ok: false, error: 'boom', code: 'permission-denied' })),
       origin: githubOrigin,
+      getReactionRef: () => githubReactionRef,
       logger: { warn: () => {} },
     })
 

--- a/src/agent/tools/channel-react.ts
+++ b/src/agent/tools/channel-react.ts
@@ -13,18 +13,23 @@ export type ChannelReactOrigin = {
   workspace: string
   chat: string
   thread: string | null
-  reactionRef?: ReactionRef
 }
 
 export type CreateChannelReactToolOptions = {
   router: ChannelRouter
   origin: ChannelReactOrigin
+  // Resolved at execute time, not captured: the target is the message that
+  // triggered THIS turn. The tool is built once at session creation, whose
+  // origin snapshot carries no reactionRef, so a static capture would deny
+  // every call.
+  getReactionRef: () => ReactionRef | undefined
   logger?: ChannelToolLogger
 }
 
 export function createChannelReactTool({
   router,
   origin,
+  getReactionRef,
   logger = consoleChannelLogger,
 }: CreateChannelReactToolOptions) {
   return defineTool({
@@ -58,14 +63,15 @@ export function createChannelReactTool({
         }
       }
 
-      if (origin.reactionRef === undefined) return deny('this conversation has no message to react to')
+      const reactionRef = getReactionRef()
+      if (reactionRef === undefined) return deny('this conversation has no message to react to')
 
       const result = await router.react({
         adapter: origin.adapter,
         workspace: origin.workspace,
         chat: origin.chat,
         thread: origin.thread,
-        reactionRef: origin.reactionRef,
+        reactionRef,
         emoji: params.emoji,
       })
 


### PR DESCRIPTION
## Background

In production, an agent on Slack could send replies fine but every `channel_react` call failed with "channel_react denied: this conversation has no message to react to". A human in the thread could see an :eyes: reaction land, which made it look like reactions half-worked. The session transcript confirmed every react tool result was `{ ok: false, error: "this conversation has no message to react to" }` while every reply was `{ ok: true }`.

Root cause: `channel_react` is built once per session in `buildChannelTools`, from the session-creation origin snapshot. That snapshot intentionally omits `reactionRef` because the reaction target is per-turn — it points at the message that triggered the current turn and is only present on the live turn origin. The field is set each turn from the triggering inbound. The tool captured the static snapshot in its closure, so the ref was always `undefined` and the guard denied on every call.

This affected all adapters (Slack/Discord/GitHub), not just Slack. The :eyes: ack still appeared because `autoReactOnEngage` reacts off the live `event.reactionRef` directly, bypassing the tool path entirely, which masked the tool-side breakage.

## Summary

Resolve the reaction ref at execute time instead of capturing it at tool-build time:
- `createChannelReactTool` now takes a `getReactionRef: () => ReactionRef | undefined` getter and reads it inside `execute()`.
- `buildChannelTools` accepts the existing `getOrigin` getter (already used by the other dynamic tools) and derives `reactionRef` from the live turn origin, falling back to the static snapshot when no getter is wired (composition tests).

Why a getter and not just putting `reactionRef` in the session-creation origin: the target changes every turn, so a value stamped at session creation would be stale or absent for every subsequent turn. The getter mirrors how reply/send/history already resolve addressing through `getOrigin`.

## What this does NOT do

- Does not change the Slack/Discord/GitHub reaction adapters or the `ReactionRef` wire format.
- Does not touch `autoReactOnEngage` (the :eyes: path was already correct).
- Does not alter the other channel tools — they only need static addressing.

## Review notes

- Load-bearing change: `src/agent/index.ts` threads `getOrigin` into `buildChannelTools`, and the react tool reads `getOrigin()?.reactionRef` per call.
- Invariant to verify: the ref must be read on execute, not on build. New regression test "resolves the reaction ref at execute time, not at tool-build time" builds the tool while the ref is `undefined`, then flips it and asserts the next call reacts successfully.
- Full suite is green except two failures unrelated to this diff: `resolveSelfPackageJsonPath` (asserts the checkout dir is named `typeclaw`; fails only because the worktree dir name does not match) and a restart-handoff test that passes in isolation (parallel race).