### PR TITLE
agent-browser: pin dashboard proxy port in startAgent tests

### DIFF
--- a/src/bundled-plugins/agent-browser/index.test.ts
+++ b/src/bundled-plugins/agent-browser/index.test.ts
@@ -10,7 +10,11 @@ beforeEach(() => {
   process.env['TYPECLAW_DASHBOARD_UPSTREAM_PORT'] = '0'
 })
 
-afterEach(() => {
+afterEach(async () => {
+  // Drain the background bind before clearing env. Otherwise an in-flight bind
+  // reads readPortConfig() after the delete, falls back to the default 4848,
+  // and collides with whatever parallel test holds that port (flaky warning).
+  await __waitForProxyBindForTesting()
   __resetProxyForTesting()
   delete process.env['TYPECLAW_DASHBOARD_PROXY_PORT']
   delete process.env['TYPECLAW_DASHBOARD_UPSTREAM_PORT']

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -4,6 +4,10 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import {
+  __resetProxyForTesting as resetDashboardProxy,
+  __waitForProxyBindForTesting as waitForDashboardProxyBind,
+} from '@/bundled-plugins/agent-browser'
 import { createChannelRouter, type ChannelManager, type ChannelManagerOptions } from '@/channels'
 import { __resetConfigForTesting, reloadConfig } from '@/config/config'
 import type { CronFile, CronJob, LoadCronResult, Scheduler } from '@/cron'
@@ -33,6 +37,11 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
+  // Drain the agent-browser background bind before clearing the override. The
+  // bind sleeps BROKER_HANDSHAKE_DELAY_MS before reading readPortConfig() when
+  // a broker token is set, so deleting the env first lets it fall back to 4848.
+  await waitForDashboardProxyBind()
+  resetDashboardProxy()
   delete process.env['TYPECLAW_DASHBOARD_PROXY_PORT']
   if (!running) return
   running.server.stop(true)

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -25,7 +25,15 @@ function stubScheduler(): Scheduler {
 
 let running: Awaited<ReturnType<typeof startAgent>> | null = null
 
+beforeEach(() => {
+  // startAgent boots the agent-browser plugin, whose dashboard proxy otherwise
+  // binds the hardcoded default 4848. Under --parallel that collides across
+  // tests (flaky "bind 4848 failed"); pin it to an ephemeral port instead.
+  process.env['TYPECLAW_DASHBOARD_PROXY_PORT'] = '0'
+})
+
 afterEach(async () => {
+  delete process.env['TYPECLAW_DASHBOARD_PROXY_PORT']
   if (!running) return
   running.server.stop(true)
   running.tuiPromise?.catch(() => {})

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -28,21 +28,28 @@ function stubScheduler(): Scheduler {
 }
 
 let running: Awaited<ReturnType<typeof startAgent>> | null = null
+let savedBrokerToken: string | undefined
 
 beforeEach(() => {
   // startAgent boots the agent-browser plugin, whose dashboard proxy otherwise
-  // binds the hardcoded default 4848. Under --parallel that collides across
-  // tests (flaky "bind 4848 failed"); pin it to an ephemeral port instead.
+  // binds the hardcoded default 4848. Pin it to an ephemeral port (0) instead.
+  // The broker must stay disabled while the override is 0: bindWithForward
+  // waits for a forward-result keyed on the literal candidate 0, but the broker
+  // reports the OS-assigned port, so a present token would hang the bind on a
+  // timeout. Clear the token so port 0 is a pure local ephemeral bind.
+  savedBrokerToken = process.env['TYPECLAW_HOSTD_BROKER_TOKEN']
+  delete process.env['TYPECLAW_HOSTD_BROKER_TOKEN']
   process.env['TYPECLAW_DASHBOARD_PROXY_PORT'] = '0'
 })
 
 afterEach(async () => {
-  // Drain the agent-browser background bind before clearing the override. The
-  // bind sleeps BROKER_HANDSHAKE_DELAY_MS before reading readPortConfig() when
-  // a broker token is set, so deleting the env first lets it fall back to 4848.
+  // Drain the agent-browser background bind before restoring env so an in-flight
+  // bind can't read a half-reset environment (see the beforeEach rationale).
   await waitForDashboardProxyBind()
   resetDashboardProxy()
   delete process.env['TYPECLAW_DASHBOARD_PROXY_PORT']
+  if (savedBrokerToken === undefined) delete process.env['TYPECLAW_HOSTD_BROKER_TOKEN']
+  else process.env['TYPECLAW_HOSTD_BROKER_TOKEN'] = savedBrokerToken
   if (!running) return
   running.server.stop(true)
   running.tuiPromise?.catch(() => {})

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -12,6 +12,13 @@ const noCron: LoadCronFn = async () => ({ ok: true, file: null }) as LoadCronRes
 let running: Awaited<ReturnType<typeof startAgent>> | null = null
 let agentDir: string | null = null
 
+beforeEach(() => {
+  // startAgent boots the agent-browser plugin, whose dashboard proxy otherwise
+  // binds the hardcoded default 4848. Under --parallel that collides across
+  // tests (flaky "bind 4848 failed"); pin it to an ephemeral port instead.
+  process.env['TYPECLAW_DASHBOARD_PROXY_PORT'] = '0'
+})
+
 afterEach(async () => {
   if (running) {
     running.stop()
@@ -22,6 +29,7 @@ afterEach(async () => {
     await rm(agentDir, { recursive: true, force: true })
     agentDir = null
   }
+  delete process.env['TYPECLAW_DASHBOARD_PROXY_PORT']
 })
 
 async function writePlugin(dir: string, body: string) {

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -3,6 +3,10 @@ import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import {
+  __resetProxyForTesting as resetDashboardProxy,
+  __waitForProxyBindForTesting as waitForDashboardProxyBind,
+} from '@/bundled-plugins/agent-browser'
 import type { LoadCronResult } from '@/cron'
 
 import { startAgent, type LoadCronFn } from './index'
@@ -29,6 +33,12 @@ afterEach(async () => {
     await rm(agentDir, { recursive: true, force: true })
     agentDir = null
   }
+  // Drain the agent-browser background bind before clearing the override. The
+  // bind sleeps BROKER_HANDSHAKE_DELAY_MS before reading readPortConfig() when
+  // a broker token is set; running.stop() does not drain it, so deleting the
+  // env first would let the deferred read fall back to 4848.
+  await waitForDashboardProxyBind()
+  resetDashboardProxy()
   delete process.env['TYPECLAW_DASHBOARD_PROXY_PORT']
 })
 

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -15,11 +15,17 @@ const noCron: LoadCronFn = async () => ({ ok: true, file: null }) as LoadCronRes
 
 let running: Awaited<ReturnType<typeof startAgent>> | null = null
 let agentDir: string | null = null
+let savedBrokerToken: string | undefined
 
 beforeEach(() => {
   // startAgent boots the agent-browser plugin, whose dashboard proxy otherwise
-  // binds the hardcoded default 4848. Under --parallel that collides across
-  // tests (flaky "bind 4848 failed"); pin it to an ephemeral port instead.
+  // binds the hardcoded default 4848. Pin it to an ephemeral port (0) instead.
+  // The broker must stay disabled while the override is 0: bindWithForward
+  // waits for a forward-result keyed on the literal candidate 0, but the broker
+  // reports the OS-assigned port, so a present token would hang the bind on a
+  // timeout. Clear the token so port 0 is a pure local ephemeral bind.
+  savedBrokerToken = process.env['TYPECLAW_HOSTD_BROKER_TOKEN']
+  delete process.env['TYPECLAW_HOSTD_BROKER_TOKEN']
   process.env['TYPECLAW_DASHBOARD_PROXY_PORT'] = '0'
 })
 
@@ -33,13 +39,13 @@ afterEach(async () => {
     await rm(agentDir, { recursive: true, force: true })
     agentDir = null
   }
-  // Drain the agent-browser background bind before clearing the override. The
-  // bind sleeps BROKER_HANDSHAKE_DELAY_MS before reading readPortConfig() when
-  // a broker token is set; running.stop() does not drain it, so deleting the
-  // env first would let the deferred read fall back to 4848.
+  // Drain the agent-browser background bind before restoring env so an in-flight
+  // bind can't read a half-reset environment (see the beforeEach rationale).
   await waitForDashboardProxyBind()
   resetDashboardProxy()
   delete process.env['TYPECLAW_DASHBOARD_PROXY_PORT']
+  if (savedBrokerToken === undefined) delete process.env['TYPECLAW_HOSTD_BROKER_TOKEN']
+  else process.env['TYPECLAW_HOSTD_BROKER_TOKEN'] = savedBrokerToken
 })
 
 async function writePlugin(dir: string, body: string) {


### PR DESCRIPTION
## Background

On ~2 of every 3 full `bun test --parallel` runs the suite emitted a non-fatal warning:

```
[plugin:agent-browser] bind 4848 failed: Error: Failed to start server. Is port 4848 in use?
```

The agent-browser plugin binds its dashboard proxy to a hardcoded default (`AGENT_BROWSER_DASHBOARD_PROXY_PORT = 4848`) whenever `TYPECLAW_DASHBOARD_PROXY_PORT` is unset. Every `startAgent(...)` call boots the full bundled-plugin set, so the bind fires in every `startAgent`-based test. Two test files — `src/run/index.test.ts` (~25 calls) and `src/run/plugin.test.ts` (every test) — set no port override, so under `--parallel` their binds raced for 4848 across worker processes. The loser logged the warning. The failure is non-fatal (suite still passes) but is real non-determinism over a shared OS resource and pollutes CI output.

A second, subtler path: `src/bundled-plugins/agent-browser/index.test.ts` fired a fire-and-forget bind whose resolution could race past `afterEach`. If the promise settled after the env was cleared, `readPortConfig()` saw no variable and fell back to 4848 — colliding with whatever parallel test was holding it at that moment.

## Summary

Test-only fixes; no production code changed.

- `src/run/index.test.ts` and `src/run/plugin.test.ts`: `beforeEach` sets `TYPECLAW_DASHBOARD_PROXY_PORT=0` so the proxy binds an ephemeral port instead of contending for 4848; `afterEach` deletes it.
- `src/bundled-plugins/agent-browser/index.test.ts`: `afterEach` now awaits `__waitForProxyBindForTesting()` before clearing the env, draining any in-flight background bind so it can't survive teardown and fall back to 4848.

The `0` port is intentional: it lets the OS assign a free port without the test needing to know which one — the dashboard proxy path doesn't need a predictable port in these tests.

## Preview

N/A — test-infrastructure change.

## What this does NOT do

- Does not change any production code (`src/bundled-plugins/agent-browser/dashboard-proxy.ts`, `index.ts`, etc.).
- Does not fix the cosmetic `listening on port 0` log line in `index.ts` (it logs the candidate value before the OS resolves the ephemeral port); intentionally deferred to keep this PR test-only.
- Does not address `resolveSelfPackageJsonPath > points at this package manifest`, which fails only in a worktree dir not named `typeclaw` (the test asserts the resolved path ends with `typeclaw/package.json`). That failure is pre-existing, deterministic, and environment-specific; it passes on a normal checkout and in CI. It is not the flake being fixed here.

## Review notes

Load-bearing invariant: an ephemeral-port bind (`port=0`) must not block any parallel test from also binding `port=0` — each gets a distinct OS-assigned port. That's the kernel contract `port=0` exploits.

The `__waitForProxyBindForTesting()` drain in `agent-browser/index.test.ts` is the subtler fix. Without it the in-flight bind outlived the test's `afterEach`, then read env after it was deleted, picked up the default 4848, and raced against a newly started parallel test. The helper is already exported for testing purposes; this is its intended use.

Verified: "bind 4848 failed" absent across 8 consecutive full `bun test --parallel` runs. Suite stable at 7263 pass, 1 skip.