### PR TITLE
github: re-check and resolve own review threads on PR push

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -640,7 +640,13 @@ export function buildChannelTools(
       }),
     )
     tools.push(createChannelHistoryTool({ router: channelRouter, origin: channelOrigin }))
-    tools.push(createChannelSendTool({ router: channelRouter, origin: channelOrigin }))
+    tools.push(
+      createChannelSendTool({
+        router: channelRouter,
+        origin: channelOrigin,
+        ...(sessionId !== undefined ? { sessionId } : {}),
+      }),
+    )
     // Read the live turn origin, falling back to the static snapshot when no
     // getter is wired (composition tests). `reactionRef` is per-turn, so the
     // getter is what makes reactions work outside tests.

--- a/src/agent/tools/channel-send.resolve.test.ts
+++ b/src/agent/tools/channel-send.resolve.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { hasResolvedThread } from '@/channels/github-review-turn-ledger'
+import { resetReviewTurn } from '@/channels/github-review-turn-ledger'
+import type { ChannelRouter } from '@/channels/router'
+import type {
+  OutboundMessage,
+  ReviewThreadResolveRequest,
+  ReviewThreadResolveResult,
+  SendResult,
+} from '@/channels/types'
+
+import { createChannelSendTool } from './channel-send'
+
+const SESSION = 'ses_cs_resolve'
+
+afterEach(() => resetReviewTurn(SESSION))
+
+function fakeRouter(handlers: {
+  onSend?: (msg: OutboundMessage) => SendResult
+  onResolve?: (req: ReviewThreadResolveRequest) => ReviewThreadResolveResult
+}): ChannelRouter {
+  return {
+    route: async () => {},
+    send: async (msg) => handlers.onSend?.(msg) ?? { ok: true },
+    getConsecutiveSendCount: () => 0,
+    getSendRate: () => ({ count: 0, windowMs: 5_000 }),
+    registerOutbound: () => {},
+    unregisterOutbound: () => {},
+    registerReaction: () => {},
+    unregisterReaction: () => {},
+    react: async () => ({ ok: true }),
+    registerRemoveReaction: () => {},
+    unregisterRemoveReaction: () => {},
+    removeReaction: async () => ({ ok: true }),
+    registerTyping: () => {},
+    unregisterTyping: () => {},
+    registerChannelNameResolver: () => {},
+    unregisterChannelNameResolver: () => {},
+    registerSelfIdentity: () => {},
+    unregisterSelfIdentity: () => {},
+    registerMembership: () => {},
+    unregisterMembership: () => {},
+    registerHistory: () => {},
+    unregisterHistory: () => {},
+    fetchHistory: async () => ({ ok: false, error: 'x' }),
+    registerFetchAttachment: () => {},
+    unregisterFetchAttachment: () => {},
+    fetchAttachment: async () => ({ ok: false, error: 'x' }),
+    registerReviewThreadResolver: () => {},
+    unregisterReviewThreadResolver: () => {},
+    resolveReviewThread: async (req) => handlers.onResolve?.(req) ?? { ok: true },
+    lookupInboundAttachment: () => null,
+    listInboundAttachmentIds: () => [],
+    getSelfAliases: () => [],
+    stop: async () => {},
+    tearDownAllLive: async () => {},
+    liveCount: () => 0,
+    executeCommand: async () => ({ kind: 'no-live-session' }),
+    injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
+    markTurnSkipped: () => ({ kind: 'no-live-session' }),
+    reserveRestartHandoff: () => null,
+    resumeRestartHandoff: async () => {},
+  }
+}
+
+const fakeCtx = {} as Parameters<ReturnType<typeof createChannelSendTool>['execute']>[4]
+
+async function run(
+  tool: ReturnType<typeof createChannelSendTool>,
+  params: Parameters<ReturnType<typeof createChannelSendTool>['execute']>[1],
+) {
+  return tool.execute('id', params, undefined, undefined, fakeCtx)
+}
+
+describe('channel_send resolve_review_thread', () => {
+  test('resolves the thread before posting and records the ledger', async () => {
+    const order: string[] = []
+    const resolveCalls: ReviewThreadResolveRequest[] = []
+    const tool = createChannelSendTool({
+      router: fakeRouter({
+        onSend: () => {
+          order.push('send')
+          return { ok: true }
+        },
+        onResolve: (req) => {
+          order.push('resolve')
+          resolveCalls.push(req)
+          return { ok: true }
+        },
+      }),
+      sessionId: SESSION,
+    })
+
+    const result = await run(tool, {
+      adapter: 'github',
+      workspace: 'acme/widgets',
+      chat: 'pr:12',
+      thread: '555',
+      text: 'addressed in abc123 — resolving',
+      resolve_review_thread: true,
+    })
+
+    expect(result.details).toEqual({ ok: true })
+    expect(order).toEqual(['resolve', 'send'])
+    expect(resolveCalls[0]).toEqual({
+      adapter: 'github',
+      workspace: 'acme/widgets',
+      chat: 'pr:12',
+      rootCommentId: '555',
+    })
+    expect(
+      hasResolvedThread({ sessionId: SESSION, workspace: 'acme/widgets', prNumber: 12, rootCommentId: '555' }),
+    ).toBe(true)
+  })
+
+  test('blocks the send when the resolve fails for a hard reason', async () => {
+    let sent = 0
+    const tool = createChannelSendTool({
+      router: fakeRouter({
+        onSend: () => {
+          sent++
+          return { ok: true }
+        },
+        onResolve: () => ({ ok: false, error: 'refusing: not author', code: 'not-author' }),
+      }),
+      sessionId: SESSION,
+    })
+
+    const result = await run(tool, {
+      adapter: 'github',
+      workspace: 'acme/widgets',
+      chat: 'pr:12',
+      thread: '555',
+      text: 'addressed — resolving',
+      resolve_review_thread: true,
+    })
+
+    expect(sent).toBe(0)
+    expect((result.details as { ok: boolean }).ok).toBe(false)
+    expect((result.details as { error: string }).error).toContain('could not resolve review thread')
+    expect(
+      hasResolvedThread({ sessionId: SESSION, workspace: 'acme/widgets', prNumber: 12, rootCommentId: '555' }),
+    ).toBe(false)
+  })
+
+  test('treats a no-match resolve as non-blocking and still posts', async () => {
+    let sent = 0
+    const tool = createChannelSendTool({
+      router: fakeRouter({
+        onSend: () => {
+          sent++
+          return { ok: true }
+        },
+        onResolve: () => ({ ok: false, error: 'gone', code: 'no-match' }),
+      }),
+      sessionId: SESSION,
+    })
+
+    const result = await run(tool, {
+      adapter: 'github',
+      workspace: 'acme/widgets',
+      chat: 'pr:12',
+      thread: '555',
+      text: 'ack',
+      resolve_review_thread: true,
+    })
+
+    expect(sent).toBe(1)
+    expect((result.details as { ok: boolean }).ok).toBe(true)
+  })
+
+  test('rejects resolve_review_thread without a thread', async () => {
+    let resolved = 0
+    const tool = createChannelSendTool({
+      router: fakeRouter({
+        onResolve: () => {
+          resolved++
+          return { ok: true }
+        },
+      }),
+      sessionId: SESSION,
+    })
+
+    const result = await run(tool, {
+      adapter: 'github',
+      workspace: 'acme/widgets',
+      chat: 'pr:12',
+      text: 'no thread',
+      resolve_review_thread: true,
+    })
+
+    expect(resolved).toBe(0)
+    expect((result.details as { ok: boolean }).ok).toBe(false)
+    expect((result.details as { error: string }).error).toContain('requires a `thread`')
+  })
+
+  test('rejects resolve_review_thread on a non-github adapter', async () => {
+    let resolved = 0
+    const tool = createChannelSendTool({
+      router: fakeRouter({
+        onResolve: () => {
+          resolved++
+          return { ok: true }
+        },
+      }),
+      sessionId: SESSION,
+    })
+
+    const result = await run(tool, {
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: 't1',
+      text: 'resolving',
+      resolve_review_thread: true,
+    })
+
+    expect(resolved).toBe(0)
+    expect((result.details as { ok: boolean }).ok).toBe(false)
+    expect((result.details as { error: string }).error).toContain('only supported on github')
+  })
+
+  test('does not resolve when the flag is unset', async () => {
+    let resolved = 0
+    const tool = createChannelSendTool({
+      router: fakeRouter({
+        onResolve: () => {
+          resolved++
+          return { ok: true }
+        },
+      }),
+      sessionId: SESSION,
+    })
+
+    const result = await run(tool, {
+      adapter: 'github',
+      workspace: 'acme/widgets',
+      chat: 'pr:12',
+      thread: '555',
+      text: 'just a comment, keeping open',
+    })
+
+    expect(resolved).toBe(0)
+    expect((result.details as { ok: boolean }).ok).toBe(true)
+  })
+})

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -1,6 +1,8 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
+import { checkFalseReceipt } from '@/channels/github-false-receipt'
+import { recordResolvedThread } from '@/channels/github-review-turn-ledger'
 import {
   containsKimiToolDelimiter,
   isNoReplySignal,
@@ -28,10 +30,19 @@ export type CreateChannelSendToolOptions = {
   // the model can self-correct on its next turn. Absent for sessions whose
   // origin isn't a channel (e.g. cron prompts that send to channels).
   origin?: ChannelSendOrigin
+  // Scopes the per-turn false-receipt ledger for github resolve close-outs.
+  // Defaults to '' when absent (cron / non-channel sessions); the guard then
+  // finds no recorded action and falls back to its safe default.
+  sessionId?: string
   logger?: ChannelToolLogger
 }
 
-export function createChannelSendTool({ router, origin, logger = consoleChannelLogger }: CreateChannelSendToolOptions) {
+export function createChannelSendTool({
+  router,
+  origin,
+  sessionId = '',
+  logger = consoleChannelLogger,
+}: CreateChannelSendToolOptions) {
   return defineTool({
     name: 'channel_send',
     label: 'Channel Send',
@@ -93,6 +104,15 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
           },
         ),
       ),
+      resolve_review_thread: Type.Optional(
+        Type.Boolean({
+          description:
+            'GitHub review threads ONLY — ignored on every other adapter and on a github send that has no `thread`. ' +
+            'Set `true` to close out a review thread you authored once you have confirmed the new commits address your concern: pass the thread\'s root comment id as `thread`, an acknowledgement (e.g. "addressed in <sha> — resolving") as `text`, and this flag. ' +
+            'This is the post-push close-out path: a `pull_request.synchronize` recheck lists your unresolved threads, and you call this once per addressed thread. ' +
+            "Safe by default — the runtime resolves BEFORE posting and ONLY if the thread's root comment is yours, refusing (and blocking the send) on a human reviewer's thread. Leave it unset to keep the thread open (not addressed, partial fix, disagreement).",
+        }),
+      ),
     }),
 
     async execute(_toolCallId, params) {
@@ -134,6 +154,47 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
           content: [{ type: 'text' as const, text: `channel_send denied: ${kimiLeakError}` }],
           details: { ok: false, error: kimiLeakError },
         }
+      }
+
+      const wantsResolve = params.resolve_review_thread === true
+      const falseReceipt = checkFalseReceipt({
+        sessionId,
+        adapter,
+        workspace: params.workspace,
+        chat: params.chat,
+        thread: params.thread ?? null,
+        text: bodyText,
+        isContinue: false,
+        resolveReviewThread: wantsResolve,
+      })
+      if (falseReceipt.kind === 'block') {
+        logger.warn(formatChannelToolFailure('channel_send', falseReceipt.reason))
+        return {
+          content: [{ type: 'text' as const, text: `channel_send denied: ${falseReceipt.reason}` }],
+          details: { ok: false, error: falseReceipt.reason },
+        }
+      }
+      const falseReceiptNotice = falseReceipt.kind === 'warn' ? falseReceipt.notice : null
+
+      // Resolve BEFORE posting (mirrors channel_reply): a failed resolve must
+      // block the acknowledgement so the bot never posts "addressed — resolving"
+      // next to a still-open thread. The router enforces that only the bot's own
+      // threads can be resolved.
+      if (wantsResolve) {
+        const resolveError = await resolveReviewThreadBeforeSend(router, {
+          adapter,
+          workspace: params.workspace,
+          chat: params.chat,
+          thread: params.thread ?? null,
+        })
+        if (resolveError !== null) {
+          logger.warn(formatChannelToolFailure('channel_send', resolveError))
+          return {
+            content: [{ type: 'text' as const, text: `channel_send denied: ${resolveError}` }],
+            details: { ok: false, error: resolveError },
+          }
+        }
+        recordResolvedThreadFromSend(sessionId, params.workspace, params.chat, params.thread ?? null)
       }
 
       const result = await router.send({
@@ -179,6 +240,8 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
         })
         if (threadMismatch) hints.push(threadMismatch)
 
+        if (falseReceiptNotice !== null) hints.push(fenceRuntimeNotice(falseReceiptNotice))
+
         return {
           content: [{ type: 'text' as const, text: `${fenceToolResult(receipt)}${hints.join('')}` }],
           details,
@@ -190,6 +253,36 @@ export function createChannelSendTool({ router, origin, logger = consoleChannelL
       }
     },
   })
+}
+
+async function resolveReviewThreadBeforeSend(
+  router: ChannelRouter,
+  target: { adapter: AdapterId; workspace: string; chat: string; thread: string | null },
+): Promise<string | null> {
+  if (target.adapter !== 'github') {
+    return 'resolve_review_thread is only supported on github sends.'
+  }
+  if (target.thread === null) {
+    return 'resolve_review_thread requires a `thread` (the review thread root comment id).'
+  }
+  const result = await router.resolveReviewThread({
+    adapter: target.adapter,
+    workspace: target.workspace,
+    chat: target.chat,
+    rootCommentId: target.thread,
+  })
+  if (result.ok) return null
+  if (result.code === 'no-match') return null
+  return `could not resolve review thread: ${result.error}`
+}
+
+function recordResolvedThreadFromSend(sessionId: string, workspace: string, chat: string, thread: string | null): void {
+  if (thread === null) return
+  const m = /^pr:(\d+)$/.exec(chat)
+  if (m === null) return
+  const prNumber = Number(m[1])
+  if (!Number.isSafeInteger(prNumber) || prNumber <= 0) return
+  recordResolvedThread({ sessionId, workspace, prNumber, rootCommentId: thread })
 }
 
 // Returns a behavioral hint when the model posted to the SAME conversation

--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -1313,6 +1313,193 @@ function fakeFetch(fn: (input: string, init?: RequestInit) => Response): typeof 
   return Object.assign(impl, { preconnect: () => {} }) as typeof fetch
 }
 
+describe('createGithubWebhookHandler — pull_request.synchronize recheck', () => {
+  type ThreadNode = { id: string; isResolved: boolean; rootCommentId: number; login: string; isBot?: boolean }
+
+  function threadsFetch(threads: ThreadNode[]): typeof fetch {
+    return fakeFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewThreads: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: threads.map((t) => ({
+                      id: t.id,
+                      isResolved: t.isResolved,
+                      comments: {
+                        nodes: [
+                          {
+                            databaseId: t.rootCommentId,
+                            author: { __typename: t.isBot === false ? 'User' : 'Bot', login: t.login },
+                          },
+                        ],
+                      },
+                    })),
+                  },
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+    )
+  }
+
+  function recheckHandler(input: {
+    fetchImpl: typeof fetch
+    routed: InboundMessage[]
+    tasks: Array<() => Promise<void>>
+    warns?: string[]
+    authToken?: GithubWebhookHandlerOptions['authToken']
+  }) {
+    return createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['pull_request.synchronize'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot[bot]',
+      authType: () => 'app',
+      authToken: input.authToken ?? (async () => 'tok'),
+      fetchImpl: input.fetchImpl,
+      scheduleBackgroundTask: (task) => {
+        input.tasks.push(task)
+      },
+      logger: { info: () => {}, warn: (m) => input.warns?.push(m), error: () => {} },
+      route: (msg) => {
+        input.routed.push(msg)
+      },
+    })
+  }
+
+  function synchronizePayload(headSha = 'abc1234def'): Record<string, unknown> {
+    return {
+      action: 'synchronize',
+      repository: repo(),
+      pull_request: {
+        number: 7,
+        id: 700,
+        title: 'Add widget',
+        head: { ref: 'feature', sha: headSha },
+        base: { ref: 'main' },
+        user: { login: 'alice', id: 10, type: 'User' },
+      },
+      sender: { login: 'alice', id: 10, type: 'User' },
+    }
+  }
+
+  it('does not route when the PR has no bot-authored unresolved threads', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const handler = recheckHandler({
+      fetchImpl: threadsFetch([{ id: 'T_HUMAN', isResolved: false, rootCommentId: 5, login: 'alice', isBot: false }]),
+      routed,
+      tasks,
+    })
+
+    const res = await handler(signedRequest(JSON.stringify(synchronizePayload()), 'pull_request', 'sync-none'))
+
+    expect(res.status).toBe(200)
+    expect(tasks).toHaveLength(1)
+    await tasks[0]?.()
+    expect(routed).toHaveLength(0)
+  })
+
+  it('routes one engaging inbound listing the unresolved bot threads', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const handler = recheckHandler({
+      fetchImpl: threadsFetch([
+        { id: 'T1', isResolved: false, rootCommentId: 100, login: 'typeclaw-bot' },
+        { id: 'T2', isResolved: false, rootCommentId: 200, login: 'typeclaw-bot' },
+        { id: 'T_DONE', isResolved: true, rootCommentId: 300, login: 'typeclaw-bot' },
+      ]),
+      routed,
+      tasks,
+    })
+
+    await handler(signedRequest(JSON.stringify(synchronizePayload('deadbeef999')), 'pull_request', 'sync-some'))
+    await tasks[0]?.()
+
+    expect(routed).toHaveLength(1)
+    const msg = routed[0]!
+    expect(msg.chat).toBe('pr:7')
+    expect(msg.thread).toBe(null)
+    expect(msg.isBotMention).toBe(true)
+    expect(msg.workspace).toBe('acme/project')
+    expect(msg.text).toContain('PR #7')
+    expect(msg.text).toContain('deadbee')
+    expect(msg.text).toContain('100, 200')
+    expect(msg.externalMessageId).toBe('pr-7-recheck-deadbeef999')
+  })
+
+  it('does not route a self-authored synchronize (bot pushed its own PR)', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const handler = recheckHandler({
+      fetchImpl: threadsFetch([{ id: 'T1', isResolved: false, rootCommentId: 100, login: 'typeclaw-bot' }]),
+      routed,
+      tasks,
+    })
+    const payload = synchronizePayload()
+    payload.sender = { login: 'typeclaw-bot[bot]', id: 99, type: 'Bot' }
+
+    await handler(signedRequest(JSON.stringify(payload), 'pull_request', 'sync-self'))
+
+    expect(tasks).toHaveLength(0)
+    expect(routed).toHaveLength(0)
+  })
+
+  it('dedups a redelivered synchronize so the sweep runs once', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const dedup = createDeliveryDedup()
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup,
+      allowlist: () => ['pull_request.synchronize'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot[bot]',
+      authType: () => 'app',
+      authToken: async () => 'tok',
+      fetchImpl: threadsFetch([{ id: 'T1', isResolved: false, rootCommentId: 100, login: 'typeclaw-bot' }]),
+      scheduleBackgroundTask: (task) => {
+        tasks.push(task)
+      },
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+
+    const body = JSON.stringify(synchronizePayload())
+    await handler(signedRequest(body, 'pull_request', 'sync-dup'))
+    await handler(signedRequest(body, 'pull_request', 'sync-dup'))
+
+    expect(tasks).toHaveLength(1)
+  })
+
+  it('warns and does not route when the thread listing fails', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const warns: string[] = []
+    const handler = recheckHandler({
+      fetchImpl: fakeFetch(() => new Response('boom', { status: 500 })),
+      routed,
+      tasks,
+      warns,
+    })
+
+    await handler(signedRequest(JSON.stringify(synchronizePayload()), 'pull_request', 'sync-fail'))
+    await tasks[0]?.()
+
+    expect(routed).toHaveLength(0)
+    expect(warns.some((w) => w.includes('review-thread recheck failed'))).toBe(true)
+  })
+})
+
 describe('createGithubWebhookHandler — allowApprove policy note', () => {
   const baseOptions = (routed: InboundMessage[], allowApprove?: () => boolean): GithubWebhookHandlerOptions => ({
     webhookSecret: 'secret',

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -8,6 +8,7 @@ import { removeRequestedReviewer } from './decoy-reviewer'
 import type { DeliveryDedup } from './dedup'
 import { isGithubEventAllowed } from './event-allowlist'
 import { encodeGithubReactionRef, type GithubReactionTarget } from './reactions'
+import { listUnresolvedSelfReviewThreads } from './review-thread-resolver'
 
 export type GithubInboundLogger = { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void }
 
@@ -77,6 +78,18 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
       options.logger.info(
         `[github] dropped self-authored ${event}${action !== null ? `.${action}` : ''} from @${author.login}`,
       )
+      return ok()
+    }
+
+    // A push to an open PR (`synchronize`) is not a message to react to — it is
+    // a trigger to re-check whether the new commits addressed the bot's own
+    // still-open review threads. The check needs a GraphQL round-trip, so it
+    // runs OFF the ACK path (like the decoy-reviewer drop) and only wakes a
+    // session when there is at least one such thread. Returning here also keeps
+    // synchronize out of the generic awareness-only fallthrough below.
+    if (event === 'pull_request' && action === 'synchronize') {
+      if (delivery !== '') options.dedup.add(delivery)
+      scheduleReviewThreadRecheck({ payload, selfLogin, options })
       return ok()
     }
 
@@ -169,6 +182,96 @@ function maybeScheduleDecoyReviewerDrop(input: {
 
 function defaultScheduleBackgroundTask(task: () => Promise<void>): void {
   void task().catch(() => {})
+}
+
+function scheduleReviewThreadRecheck(input: {
+  payload: Record<string, unknown>
+  selfLogin: string | null
+  options: GithubWebhookHandlerOptions
+}): void {
+  const { payload, selfLogin, options } = input
+  if (selfLogin === null) return
+  const authToken = options.authToken
+  if (authToken === undefined) return
+
+  const repository = readRepository(payload)
+  const pr = readRecord(payload.pull_request)
+  const pullNumber = readNumber(pr, 'number')
+  if (repository === null || pullNumber === null) return
+  const headSha = readString(readRecord(pr?.head), 'sha')
+
+  const fetchImpl = options.fetchImpl ?? fetch
+  const schedule = options.scheduleBackgroundTask ?? defaultScheduleBackgroundTask
+  const target = `${repository.owner}/${repository.name}#${pullNumber}`
+  schedule(async () => {
+    try {
+      const token = await authToken({ repoSlug: `${repository.owner}/${repository.name}` })
+      const result = await listUnresolvedSelfReviewThreads({
+        token,
+        selfLogin,
+        owner: repository.owner,
+        repo: repository.name,
+        prNumber: pullNumber,
+        fetchImpl,
+      })
+      if (!result.ok) {
+        options.logger.warn(`[github] review-thread recheck failed for ${target}: ${result.error}`)
+        return
+      }
+      if (result.threads.length === 0) return
+      options.route(
+        buildRecheckInbound({
+          repository,
+          pullNumber,
+          headSha,
+          rootCommentIds: result.threads.map((t) => t.rootCommentId),
+          title: readString(pr, 'title'),
+        }),
+      )
+    } catch (err) {
+      options.logger.warn(
+        `[github] review-thread recheck failed for ${target}: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  })
+}
+
+function buildRecheckInbound(input: {
+  repository: { owner: string; name: string }
+  pullNumber: number
+  headSha: string | null
+  rootCommentIds: readonly number[]
+  title: string | null
+}): InboundMessage {
+  const { repository, pullNumber, headSha, rootCommentIds, title } = input
+  const titleSegment = title !== null && title.trim() !== '' ? `: "${title}"` : ''
+  const shaSegment = headSha !== null ? ` (now at ${headSha.slice(0, 7)})` : ''
+  const idList = rootCommentIds.join(', ')
+  const text =
+    `PR #${pullNumber}${titleSegment} received new commits${shaSegment}. ` +
+    `You have ${rootCommentIds.length} unresolved review thread(s) you authored on this PR ` +
+    `(root comment id(s): ${idList}). For each, check whether the new commits addressed your ` +
+    `concern. If addressed, reply on that thread via channel_send with a short acknowledgement ` +
+    `and resolve_review_thread: true (the thread id is the root comment id). If not addressed, ` +
+    `leave it open. If none are addressed, end your turn without replying.`
+
+  return {
+    adapter: 'github',
+    workspace: `${repository.owner}/${repository.name}`,
+    chat: `pr:${pullNumber}`,
+    thread: null,
+    text,
+    externalMessageId: `pr-${pullNumber}-recheck-${headSha ?? 'unknown'}`,
+    authorId: 'github-system',
+    authorName: 'github',
+    authorIsBot: false,
+    isBotMention: true,
+    replyToBotMessageId: null,
+    mentionsOthers: false,
+    replyToOtherMessageId: null,
+    isDm: false,
+    ts: 0,
+  }
 }
 
 export async function verifySignature(body: string, secret: string, sigHeader: string): Promise<boolean> {

--- a/src/channels/adapters/github/review-thread-resolver.test.ts
+++ b/src/channels/adapters/github/review-thread-resolver.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test'
 
 import type { ReviewThreadResolveRequest } from '@/channels/types'
 
-import { createGithubReviewThreadResolver } from './review-thread-resolver'
+import { createGithubReviewThreadResolver, listUnresolvedSelfReviewThreads } from './review-thread-resolver'
 
 type ThreadFixture = {
   id: string
@@ -366,5 +366,120 @@ describe('github review-thread resolver', () => {
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.code).toBe('no-match')
     expect(seen.mutations).toEqual([])
+  })
+})
+
+describe('listUnresolvedSelfReviewThreads', () => {
+  const list = (fetchImpl: typeof fetch, selfLogin = 'bot[bot]') =>
+    listUnresolvedSelfReviewThreads({
+      token: 'tok',
+      selfLogin,
+      owner: 'acme',
+      repo: 'widgets',
+      prNumber: 585,
+      fetchImpl,
+    })
+
+  it('returns only the bot-authored, still-unresolved threads', async () => {
+    const fetchImpl = fakeGraphql({
+      pages: [
+        {
+          threads: [
+            { id: 'T_OPEN_BOT', isResolved: false, rootCommentId: 100, rootAuthorLogin: 'bot[bot]' },
+            { id: 'T_RESOLVED_BOT', isResolved: true, rootCommentId: 101, rootAuthorLogin: 'bot[bot]' },
+            {
+              id: 'T_OPEN_HUMAN',
+              isResolved: false,
+              rootCommentId: 102,
+              rootAuthorLogin: 'alice',
+              rootAuthorType: 'User',
+            },
+          ],
+          hasNextPage: false,
+          endCursor: null,
+        },
+      ],
+    })
+
+    const result = await list(fetchImpl)
+
+    expect(result).toEqual({ ok: true, threads: [{ threadId: 'T_OPEN_BOT', rootCommentId: 100 }] })
+  })
+
+  it('paginates across pages and aggregates self threads', async () => {
+    const fetchImpl = fakeGraphql({
+      pages: [
+        {
+          threads: [{ id: 'T1', isResolved: false, rootCommentId: 1, rootAuthorLogin: 'bot[bot]' }],
+          hasNextPage: true,
+          endCursor: 'cur1',
+        },
+        {
+          threads: [{ id: 'T2', isResolved: false, rootCommentId: 2, rootAuthorLogin: 'bot[bot]' }],
+          hasNextPage: false,
+          endCursor: null,
+        },
+      ],
+    })
+
+    const result = await list(fetchImpl)
+
+    expect(result).toEqual({
+      ok: true,
+      threads: [
+        { threadId: 'T1', rootCommentId: 1 },
+        { threadId: 'T2', rootCommentId: 2 },
+      ],
+    })
+  })
+
+  it('matches the App bot thread when GraphQL reports the bare slug and self-login carries [bot]', async () => {
+    const fetchImpl = fakeGraphql({
+      pages: [
+        {
+          threads: [
+            { id: 'T_APP', isResolved: false, rootCommentId: 9, rootAuthorLogin: 'typeey', rootAuthorType: 'Bot' },
+          ],
+          hasNextPage: false,
+          endCursor: null,
+        },
+      ],
+    })
+
+    const result = await list(fetchImpl, 'typeey[bot]')
+
+    expect(result).toEqual({ ok: true, threads: [{ threadId: 'T_APP', rootCommentId: 9 }] })
+  })
+
+  it('returns an empty list when no bot-authored unresolved threads exist', async () => {
+    const fetchImpl = fakeGraphql({
+      pages: [
+        {
+          threads: [
+            { id: 'T_HUMAN', isResolved: false, rootCommentId: 5, rootAuthorLogin: 'alice', rootAuthorType: 'User' },
+          ],
+          hasNextPage: false,
+          endCursor: null,
+        },
+      ],
+    })
+
+    const result = await list(fetchImpl)
+
+    expect(result).toEqual({ ok: true, threads: [] })
+  })
+
+  it('surfaces a transport error as ok:false', async () => {
+    const fetchImpl = Object.assign(
+      async (): Promise<Response> => {
+        throw new Error('network down')
+      },
+      { preconnect: () => {} },
+    )
+
+    const result = await list(fetchImpl)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('network down')
   })
 })

--- a/src/channels/adapters/github/review-thread-resolver.ts
+++ b/src/channels/adapters/github/review-thread-resolver.ts
@@ -128,6 +128,69 @@ function parseDecimalId(value: string | undefined): number | null {
 }
 
 async function findThread(fetchImpl: typeof fetch, token: string, target: ResolveTarget): Promise<ThreadLookup> {
+  let lookup: ThreadLookup = { kind: 'absent' }
+  const outcome = await walkThreadPages(
+    fetchImpl,
+    token,
+    { owner: target.owner, repo: target.repo, prNumber: target.prNumber },
+    (nodes) => {
+      for (const node of nodes) {
+        if (node.rootCommentId === target.rootCommentId) {
+          lookup = { kind: 'found', thread: node }
+          return 'stop'
+        }
+      }
+      return 'continue'
+    },
+  )
+  if (outcome.kind === 'error') return { kind: 'error', result: outcome.result }
+  return lookup
+}
+
+export type UnresolvedSelfReviewThread = { threadId: string; rootCommentId: number }
+
+export type ListUnresolvedSelfReviewThreadsResult =
+  | { ok: true; threads: UnresolvedSelfReviewThread[] }
+  | { ok: false; error: string }
+
+// Reuses the same page-walk and authorship guard (`isSelfAuthor`) as the
+// single-thread resolver so the post-push "did my comments get addressed?"
+// sweep can never surface a human reviewer's thread as a resolve candidate.
+export async function listUnresolvedSelfReviewThreads(deps: {
+  token: string
+  selfLogin: string
+  owner: string
+  repo: string
+  prNumber: number
+  fetchImpl?: typeof fetch
+}): Promise<ListUnresolvedSelfReviewThreadsResult> {
+  const fetchImpl = deps.fetchImpl ?? fetch
+  const threads: UnresolvedSelfReviewThread[] = []
+  const outcome = await walkThreadPages(
+    fetchImpl,
+    deps.token,
+    { owner: deps.owner, repo: deps.repo, prNumber: deps.prNumber },
+    (nodes) => {
+      for (const node of nodes) {
+        if (node.isResolved || node.rootCommentId === null) continue
+        if (!isSelfAuthor(node, deps.selfLogin)) continue
+        threads.push({ threadId: node.id, rootCommentId: node.rootCommentId })
+      }
+      return 'continue'
+    },
+  )
+  if (outcome.kind === 'error') return { ok: false, error: outcome.result.error }
+  return { ok: true, threads }
+}
+
+type WalkOutcome = { kind: 'done' } | { kind: 'error'; result: ReviewThreadResolveResult & { ok: false } }
+
+async function walkThreadPages(
+  fetchImpl: typeof fetch,
+  token: string,
+  target: { owner: string; repo: string; prNumber: number },
+  onPage: (nodes: ReviewThreadNode[]) => 'stop' | 'continue',
+): Promise<WalkOutcome> {
   let after: string | null = null
   for (;;) {
     let response: Response
@@ -148,11 +211,8 @@ async function findThread(fetchImpl: typeof fetch, token: string, target: Resolv
     }
     const parsed = await parseThreadsPage(response)
     if (parsed.kind === 'error') return { kind: 'error', result: parsed.result }
-
-    for (const node of parsed.nodes) {
-      if (node.rootCommentId === target.rootCommentId) return { kind: 'found', thread: node }
-    }
-    if (!parsed.hasNextPage || parsed.endCursor === null) return { kind: 'absent' }
+    if (onPage(parsed.nodes) === 'stop') return { kind: 'done' }
+    if (!parsed.hasNextPage || parsed.endCursor === null) return { kind: 'done' }
     after = parsed.endCursor
   }
 }

--- a/src/channels/schema.test.ts
+++ b/src/channels/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { channelsSchema, STICKY_DEFAULT_WINDOW_MS } from './schema'
+import { channelsSchema, DEFAULT_GITHUB_EVENT_ALLOWLIST, STICKY_DEFAULT_WINDOW_MS } from './schema'
 
 describe('channelsSchema', () => {
   test('parses an empty channels record', () => {
@@ -104,5 +104,11 @@ describe('channelsSchema', () => {
         github: { repos: ['owner/repo'], review: { on: 'closed' } },
       } as unknown as Parameters<typeof channelsSchema.parse>[0]),
     ).toThrow()
+  })
+
+  test('github default eventAllowlist admits pull_request.synchronize (PR-push recheck)', () => {
+    const parsed = channelsSchema.parse({ github: { repos: ['owner/repo'] } })
+    expect(parsed.github?.eventAllowlist).toEqual([...DEFAULT_GITHUB_EVENT_ALLOWLIST])
+    expect(parsed.github?.eventAllowlist).toContain('pull_request.synchronize')
   })
 })

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -126,6 +126,7 @@ export const DEFAULT_GITHUB_EVENT_ALLOWLIST = [
   'pull_request.ready_for_review',
   'pull_request.review_requested',
   'pull_request.review_request_removed',
+  'pull_request.synchronize',
   'discussion.created',
   'pull_request_review.submitted',
 ] as const
@@ -156,6 +157,21 @@ const GITHUB_EVENT_ALLOWLIST_V2 = [
   'discussion.created',
   'pull_request_review.submitted',
 ] as const
+//   - v3: added ready_for_review, shipped 0.12.0+ (the default just before
+//     synchronize was added). Snapshotted here so configs seeded with the
+//     pre-synchronize default unfreeze and re-track the new default.
+const GITHUB_EVENT_ALLOWLIST_V3 = [
+  'issue_comment.created',
+  'pull_request_review_comment.created',
+  'discussion_comment.created',
+  'issues.opened',
+  'pull_request.opened',
+  'pull_request.ready_for_review',
+  'pull_request.review_requested',
+  'pull_request.review_request_removed',
+  'discussion.created',
+  'pull_request_review.submitted',
+] as const
 
 // Every event-allowlist that `channel add` / `init` has ever seeded verbatim
 // into typeclaw.json, oldest first, current default last. The legacy-shape
@@ -167,6 +183,7 @@ const GITHUB_EVENT_ALLOWLIST_V2 = [
 export const SEEDED_GITHUB_EVENT_ALLOWLISTS: readonly (readonly string[])[] = [
   GITHUB_EVENT_ALLOWLIST_V1,
   GITHUB_EVENT_ALLOWLIST_V2,
+  GITHUB_EVENT_ALLOWLIST_V3,
   DEFAULT_GITHUB_EVENT_ALLOWLIST,
 ]
 

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -863,10 +863,23 @@ describe('migrateLegacyConfigShape', () => {
     'discussion.created',
     'pull_request_review.submitted',
   ]
+  const GITHUB_ALLOWLIST_V3 = [
+    'issue_comment.created',
+    'pull_request_review_comment.created',
+    'discussion_comment.created',
+    'issues.opened',
+    'pull_request.opened',
+    'pull_request.ready_for_review',
+    'pull_request.review_requested',
+    'pull_request.review_request_removed',
+    'discussion.created',
+    'pull_request_review.submitted',
+  ]
 
   test.each([
     ['v1 (0.5.1–0.10.0, 7 events)', GITHUB_ALLOWLIST_V1],
     ['v2 (0.11.0+, 9 events)', GITHUB_ALLOWLIST_V2],
+    ['v3 (pre-synchronize, 10 events)', GITHUB_ALLOWLIST_V3],
   ])('strips an older seeded github eventAllowlist: %s', (_label, seeded) => {
     const result = migrateLegacyConfigShape({
       models: { default: VALID_MODEL },


### PR DESCRIPTION
## Background

When the agent reviews a PR it leaves review comments as resolvable threads. After the author pushes fixes, those threads stay open forever — nothing tells the agent to look again. A push to an open PR fires `pull_request.synchronize`, but that event wasn't in the default allowlist and, even if added, fell through to an awareness-only inbound that the engagement gate observes rather than acts on. So the close-out loop was entirely manual.

This wires the loop: on a PR push, the agent re-checks the review threads **it authored**, and for each one the new commits address, posts a short "checked" acknowledgement and resolves the thread. If a thread isn't addressed, it's left open. If there are no bot-authored unresolved threads at all, nothing happens — no session is even woken.

## Summary

**Only wake a turn when there's work.** `synchronize` is intercepted in the webhook handler and the "do I have open threads here?" check runs **off the ACK path** (same pattern as the existing decoy-reviewer drop), so the webhook still returns 200 fast. The GraphQL sweep lists the bot's own unresolved threads; only if ≥1 exists do we synthesize an engaging inbound. A push with no such threads — or one the bot itself pushed (caught by the existing self-author drop) — routes nothing. This satisfies the hard requirement that a turn may end with zero replies.

**Why extend `channel_send` instead of a new tool.** A push can leave several unresolved threads, but `channel_reply`'s `resolve_review_thread` only closes the single session-origin thread. Rather than add a dedicated tool or force one-turn-per-thread, `channel_send` (which already posts to an arbitrary `thread`) gains the same `resolve_review_thread` capability — resolve-before-post, hard-failure blocks the send, turn-ledger recorded, authorship enforced by the existing resolver. The agent closes out every addressed thread in one turn.

**Why the shared helper.** `listUnresolvedSelfReviewThreads` is extracted from the single-thread resolver so the sweep and the resolve path share one page-walk and one `isSelfAuthor` check (with the `[bot]` suffix normalization for Apps). The security invariant — never surface or resolve a human reviewer's thread — lives in one place.

**Allowlist migration.** `pull_request.synchronize` joins the default allowlist, and the pre-synchronize default is snapshotted as V3 in `SEEDED_GITHUB_EVENT_ALLOWLISTS` so existing seeded configs unfreeze and re-track the new default instead of staying pinned.

## What this does NOT do

- Does not judge "addressed" mechanically — that's the agent's call from reading the diff; this PR only wakes it with the right context and gives it a safe resolve primitive.
- Does not touch the human-reviewer path: the authorship guard still refuses any thread the bot didn't author.
- Does not post anything when nothing is addressed (silent turn).
- Does not add a new agent tool.

## Review notes

- **Load-bearing ordering** (`inbound.ts`): the `synchronize` branch sits after the self-author drop and dedup, and returns early so it never double-routes via the generic fallthrough. The sweep is fire-and-forget off the ACK path.
- **Resolve-before-post** (`channel-send.ts`): a failed resolve must block the send so the bot never posts "resolving" next to a still-open thread; only `no-match` is non-blocking. Mirrors `channel_reply`.
- **Engagement**: the synthesized inbound sets `isBotMention: true` so the default `mention` trigger engages it.
- One environmental test (`resolveSelfPackageJsonPath`) fails locally only because the dev worktree dir isn't named `typeclaw`; it passes in a `typeclaw`-named checkout (and CI).