### PR TITLE
channels: post provider soft-errors back to the originating channel

### DIFF
--- a/src/agent/provider-error.test.ts
+++ b/src/agent/provider-error.test.ts
@@ -4,28 +4,26 @@ import type { AgentSession } from './index'
 import { detectProviderError, subscribeProviderErrors } from './provider-error'
 
 describe('detectProviderError', () => {
-  test('returns the errorMessage for assistant message with stopReason=error', () => {
+  test('preserves the raw errorMessage on `message` for operator surfaces (logs/TUI)', () => {
     const result = detectProviderError({
       role: 'assistant',
       stopReason: 'error',
       errorMessage: 'Your account is not active, please check your billing details on our website.',
     })
 
-    expect(result).toEqual({
-      message: 'Your account is not active, please check your billing details on our website.',
-    })
+    expect(result?.message).toBe('Your account is not active, please check your billing details on our website.')
   })
 
-  test('falls back to a generic message when stopReason=error has no errorMessage', () => {
+  test('falls back to a generic raw message when stopReason=error has no errorMessage', () => {
     const result = detectProviderError({ role: 'assistant', stopReason: 'error' })
 
-    expect(result).toEqual({ message: 'LLM call failed' })
+    expect(result?.message).toBe('LLM call failed')
   })
 
-  test('falls back to a generic message when errorMessage is an empty string', () => {
+  test('falls back to a generic raw message when errorMessage is an empty string', () => {
     const result = detectProviderError({ role: 'assistant', stopReason: 'error', errorMessage: '' })
 
-    expect(result).toEqual({ message: 'LLM call failed' })
+    expect(result?.message).toBe('LLM call failed')
   })
 
   test('returns null for stopReason=aborted (user-initiated, not a provider failure)', () => {
@@ -61,6 +59,45 @@ describe('detectProviderError', () => {
     })
 
     expect(result).toBeNull()
+  })
+})
+
+describe('detectProviderError safeMessage redaction', () => {
+  test('maps rate/usage-limit errors to a canonical channel-safe sentence', () => {
+    const raw = 'You have hit your ChatGPT usage limit (team plan). Try again in ~40 min.'
+    const result = detectProviderError({ role: 'assistant', stopReason: 'error', errorMessage: raw })
+
+    expect(result?.safeMessage).toMatch(/rate-limited/i)
+    expect(result?.safeMessage).not.toContain('team plan')
+  })
+
+  test('maps billing/quota errors to a billing-safe sentence without echoing the raw text', () => {
+    const raw =
+      'Your account is not active, please check your billing details on our website https://x.test/acct/secret-123.'
+    const result = detectProviderError({ role: 'assistant', stopReason: 'error', errorMessage: raw })
+
+    expect(result?.safeMessage).toMatch(/billing\/quota/i)
+    expect(result?.safeMessage).not.toContain('secret-123')
+    expect(result?.safeMessage).not.toContain('https://')
+  })
+
+  test('collapses unknown / malformed-response failures to a generic notice (no raw leak)', () => {
+    const raw = 'malformed response: {"id":"resp_abc","debug":"Bearer sk-live-LEAK","body":"<html>500</html>"}'
+    const result = detectProviderError({ role: 'assistant', stopReason: 'error', errorMessage: raw })
+
+    expect(result?.safeMessage).toBe(
+      'The upstream LLM provider failed. Operators can check `typeclaw logs` for details.',
+    )
+    expect(result?.safeMessage).not.toContain('sk-live-LEAK')
+    expect(result?.safeMessage).not.toContain('resp_abc')
+  })
+
+  test('still exposes the raw text on `message` even when `safeMessage` is redacted', () => {
+    const raw = 'malformed response: Bearer sk-live-LEAK'
+    const result = detectProviderError({ role: 'assistant', stopReason: 'error', errorMessage: raw })
+
+    expect(result?.message).toBe(raw)
+    expect(result?.safeMessage).not.toBe(raw)
   })
 })
 

--- a/src/agent/provider-error.ts
+++ b/src/agent/provider-error.ts
@@ -13,7 +13,39 @@ import type { AgentSession } from './index'
 // not by this helper.
 
 export type DetectedProviderError = {
+  // Raw provider text. Safe for logs and operator-only surfaces (TUI,
+  // `typeclaw logs`), but NOT for channels — see `safeMessage`.
   message: string
+  // Redacted, user-facing variant for public/multi-user channels. Known-safe
+  // operational classes (rate/usage limit, billing/quota) map to a canonical
+  // sentence; everything else (malformed-response SDK dumps, unknown failures)
+  // collapses to a generic notice so provider response bodies, URLs, or tokens
+  // can never leak to a channel.
+  safeMessage: string
+}
+
+const GENERIC_SAFE_NOTICE = 'The upstream LLM provider failed. Operators can check `typeclaw logs` for details.'
+
+// Each entry pairs a narrow matcher against the raw provider text with the
+// canonical, leak-free sentence shown in channels. Matchers are intentionally
+// specific: a miss falls through to GENERIC_SAFE_NOTICE rather than echoing raw
+// text, so adding a new class is opt-in and never widens what we expose.
+const SAFE_CLASSES: ReadonlyArray<{ match: RegExp; safe: string }> = [
+  {
+    match: /\b(usage limit|rate limit|rate.?limited|too many requests|429)\b/i,
+    safe: 'The upstream LLM provider is rate-limited (usage limit reached). Try again shortly.',
+  },
+  {
+    match: /\b(billing|quota|insufficient.*(credit|fund|balance)|payment|account is not active)\b/i,
+    safe: 'The upstream LLM provider rejected the request for a billing/quota reason. Operators can check `typeclaw logs` for details.',
+  },
+]
+
+function toSafeMessage(raw: string): string {
+  for (const { match, safe } of SAFE_CLASSES) {
+    if (match.test(raw)) return safe
+  }
+  return GENERIC_SAFE_NOTICE
 }
 
 export function detectProviderError(message: unknown): DetectedProviderError | null {
@@ -25,7 +57,7 @@ export function detectProviderError(message: unknown): DetectedProviderError | n
   // ignore aborts (no surface to render them on).
   if (m.stopReason !== 'error') return null
   const text = typeof m.errorMessage === 'string' && m.errorMessage.length > 0 ? m.errorMessage : 'LLM call failed'
-  return { message: text }
+  return { message: text, safeMessage: toSafeMessage(text) }
 }
 
 export type ProviderErrorListener = (error: DetectedProviderError) => void

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4829,6 +4829,49 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     expect(errors.some((m) => /LLM call failed: billing not active/.test(m))).toBe(true)
   })
 
+  test('posts LLM soft errors back to the originating channel so the human is not left in silence', async () => {
+    // given: a turn that ends with stopReason=error (rate/usage limit) and
+    // therefore emits no assistant text. Without surfacing it, the channel
+    // sees no reply at all — the exact "why didn't Paul respond" failure mode.
+    const dir = await tempDir()
+    const sent: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        fake.prompt = async (_text) => {
+          fake.emit({
+            type: 'message_end',
+            message: {
+              role: 'assistant',
+              stopReason: 'error',
+              errorMessage: 'You have hit your ChatGPT usage limit (team plan). Try again in ~40 min.',
+            },
+          })
+        }
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: 'ses_soft_err_posts',
+          dispose: async () => {},
+          getTranscriptPath: () => undefined,
+        }
+      },
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    // when
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then
+    expect(sent.some((t) => /usage limit \(team plan\)/.test(t))).toBe(true)
+  })
+
   test('upgrades hard prompt-throws to logger.error (not warn) so `typeclaw logs` operators see them at the right level', async () => {
     // given
     const dir = await tempDir()

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4829,10 +4829,12 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     expect(errors.some((m) => /LLM call failed: billing not active/.test(m))).toBe(true)
   })
 
-  test('posts LLM soft errors back to the originating channel so the human is not left in silence', async () => {
-    // given: a turn that ends with stopReason=error (rate/usage limit) and
-    // therefore emits no assistant text. Without surfacing it, the channel
-    // sees no reply at all — the exact "why didn't Paul respond" failure mode.
+  test('posts a REDACTED LLM soft-error notice to the channel (raw provider text never leaks)', async () => {
+    // given: a turn ending with stopReason=error whose raw provider text carries
+    // potentially sensitive detail. Without surfacing it the channel sees silence
+    // (the "why didn't Paul respond" failure mode); surfacing it RAW would leak
+    // backend details into a public/multi-user channel. The router must post the
+    // redacted safeMessage instead.
     const dir = await tempDir()
     const sent: string[] = []
     const router = createChannelRouter({
@@ -4869,7 +4871,8 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     await router.__testing!.flushDebounce(KEY)
 
     // then
-    expect(sent.some((t) => /usage limit \(team plan\)/.test(t))).toBe(true)
+    expect(sent.some((t) => /rate-limited/i.test(t))).toBe(true)
+    expect(sent.some((t) => /team plan/.test(t))).toBe(false)
   })
 
   test('upgrades hard prompt-throws to logger.error (not warn) so `typeclaw logs` operators see them at the right level', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1367,6 +1367,29 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       }
       live.unsubProviderErrors = subscribeProviderErrors(created.session, (err) => {
         logger.error(`[channels] ${live.keyId}: LLM call failed: ${err.message}`)
+        // A provider soft-error (rate/usage limit, billing, malformed response)
+        // ends the turn with no assistant text, so the human otherwise sees
+        // silence. Surface the provider message via a 'system' send — the same
+        // one-shot bypass path validateChannelTurn uses, so it lands regardless
+        // of per-turn send caps and skips the duplicate guard.
+        void send(
+          {
+            adapter: live.key.adapter,
+            workspace: live.key.workspace,
+            chat: live.key.chat,
+            thread: live.key.thread,
+            text: `⚠️ ${err.message}`,
+          },
+          { source: 'system' },
+        )
+          .then((result) => {
+            if (!result.ok) {
+              logger.warn(`[channels] ${live.keyId}: provider-error notice send failed: ${result.error}`)
+            }
+          })
+          .catch((sendErr) => {
+            logger.warn(`[channels] ${live.keyId}: provider-error notice send threw: ${describe(sendErr)}`)
+          })
       })
       live.unsubTodoOutcome = created.session.subscribe((event: unknown) => {
         const usage = extractTurnUsage(event)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1369,16 +1369,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         logger.error(`[channels] ${live.keyId}: LLM call failed: ${err.message}`)
         // A provider soft-error (rate/usage limit, billing, malformed response)
         // ends the turn with no assistant text, so the human otherwise sees
-        // silence. Surface the provider message via a 'system' send — the same
-        // one-shot bypass path validateChannelTurn uses, so it lands regardless
-        // of per-turn send caps and skips the duplicate guard.
+        // silence. Surface the REDACTED `safeMessage` (never the raw provider
+        // text, which can carry response bodies / URLs / tokens) via a 'system'
+        // send — the same one-shot bypass path validateChannelTurn uses, so it
+        // lands regardless of per-turn send caps and skips the duplicate guard.
         void send(
           {
             adapter: live.key.adapter,
             workspace: live.key.workspace,
             chat: live.key.chat,
             thread: live.key.thread,
-            text: `⚠️ ${err.message}`,
+            text: `⚠️ ${err.safeMessage}`,
           },
           { source: 'system' },
         )


### PR DESCRIPTION
## Background

A user DM'd Paul (a typeclaw agent) and got silence. No reply, no error, nothing — they followed up asking why the bot wasn't responding and still got nothing.

Root cause: the turn hit a provider soft-error. pi-coding-agent encodes upstream LLM failures (rate/usage limit, billing, malformed response) **in the assistant message** as `stopReason: 'error'` with a populated `errorMessage`, rather than throwing. The model produces no text deltas, so `recoverableAssistantText()` returns `null` for `stopReason: 'error'`, `validateChannelTurn()` finds nothing to recover, and the turn ends with **zero output to the channel**.

The router already subscribed to these soft errors (`subscribeProviderErrors` in `ensureLive`), but the callback only logged them to `typeclaw logs`. The human in the channel saw nothing. In the incident, the underlying error was literally:

> You have hit your ChatGPT usage limit (team plan). Try again in ~40 min.

— actionable information the human never received.

## Summary

Make the existing `subscribeProviderErrors` callback also post the provider message back to the originating channel.

- **Why a `'system'` send and not `'tool'`:** a provider error means no `channel_reply`/`channel_send` happened, but the recovery still has to land unconditionally. `source: 'system'` is the same one-shot bypass path `validateChannelTurn` already uses for recovered text — it skips the per-turn send cap and the duplicate guard, so the notice is never swallowed by turn-level policy.
- **Why post the raw provider message:** the upstream string ("...usage limit... try again in ~40 min") is exactly what the human needs. It's prefixed with a warning sign so it reads as a system notice, not as the agent's own words.
- **Fire-and-forget with failure logging:** the callback is sync (it fires off `message_end`), so the send is `void`-ed; a failed/throwing send is logged at `warn` rather than masking the original provider error.

## What this does NOT do

- Does not add automatic model fallback (e.g. switching to the `fast` model on a rate limit). That's a separate, larger change; this PR only makes the failure *visible* instead of silent.
- Does not touch hard prompt-throws (network drops) — those already go through the `drain()` try/catch and are out of scope here.
- Does not change cron/subagent behavior; this is the channel router callback only.

## Review notes

- Load-bearing line: the `{ source: 'system' }` flag in the new `send(...)` call (`src/channels/router.ts`). It's what guarantees the notice bypasses per-turn caps and the duplicate guard. The mirror is `validateChannelTurn`'s existing recovery send.
- The new test (`posts LLM soft errors back to the originating channel...`) drives a `prompt()` that resolves normally but emits a `message_end` with `stopReason: 'error'`, and asserts the error text reaches a registered outbound callback — the same harness as the adjacent logging test.
