### PR TITLE
tui: per-event HH:MM:SS timestamps in TUI and inspect transcript

### DIFF
--- a/src/inspect/transcript-view.ts
+++ b/src/inspect/transcript-view.ts
@@ -83,6 +83,7 @@ export function createTranscriptView(opts: TranscriptViewOptions) {
     // transcripts; render per event once live.
     let live = false
     const onEvent = (event: InspectEvent): void => {
+      append(new Text(formatEventTime(event.ts), 0, 0))
       append(componentFor(event))
       if (live) tui.requestRender()
     }
@@ -165,6 +166,15 @@ function compact(payload: unknown): string {
   }
   const s = JSON.stringify(payload) ?? String(payload)
   return s.length > 200 ? `${s.slice(0, 200)}…` : s
+}
+
+function formatEventTime(ts: number): string {
+  if (ts === 0) return colors.dim('--:--:--')
+  const d = new Date(ts)
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  const ss = String(d.getSeconds()).padStart(2, '0')
+  return colors.dim(`${hh}:${mm}:${ss}`)
 }
 
 function header(summary: SessionSummary): string {

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -256,7 +256,9 @@ describe('createServer tool event forwarding', () => {
     session.emit({ type: 'tool_execution_start', toolCallId: 'tc-1', toolName: 'Read', args: { path: '/x' } })
 
     const msg = await waitFor((m) => m.type === 'tool_start')
-    expect(msg).toEqual({ type: 'tool_start', toolCallId: 'tc-1', name: 'Read', args: { path: '/x' } })
+    if (msg.type !== 'tool_start') throw new Error('unreachable')
+    expect(msg).toMatchObject({ type: 'tool_start', toolCallId: 'tc-1', name: 'Read', args: { path: '/x' } })
+    expect(typeof msg.ts).toBe('number')
     ws.close()
   })
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -199,8 +199,18 @@ export function safeWsSend(ws: { send: (data: string) => void }, msg: ServerMess
   }
 }
 
+const TIMESTAMPED_SERVER_MESSAGES: ReadonlySet<ServerMessage['type']> = new Set([
+  'text_delta',
+  'tool_start',
+  'tool_end',
+  'done',
+  'error',
+  'prompt_started',
+])
+
 function send(ws: Ws, msg: ServerMessage): boolean {
-  return safeWsSend(ws, msg)
+  const stamped = TIMESTAMPED_SERVER_MESSAGES.has(msg.type) ? { ...msg, ts: Date.now() } : msg
+  return safeWsSend(ws, stamped)
 }
 
 function sendTunnelLog(ws: TunnelLogsWs, msg: TunnelLogsServerMessage): boolean {

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -202,22 +202,34 @@ export type ClaimErrorPayload = {
   reason: string
 }
 
+// `ts` (ms since epoch) is the server send time, stamped centrally in `send()`,
+// for the variants the TUI renders into scrollback. Optional on the wire so an
+// old CLI parses a new server's frames; control frames the TUI never timestamps
+// (queue_state, doctor, tunnel, claim, command_*) omit it by design.
 export type ServerMessage =
   // serverVersion is optional so an old CLI talking to a new server still
   // parses cleanly. The server impl always emits it; consumers that care
   // about host/agent skew (the TUI command in particular) read it to warn
   // the user when their CLI is on a different version than the container.
   | { type: 'connected'; sessionId: string; serverVersion?: string }
-  | { type: 'text_delta'; delta: string }
-  | { type: 'tool_start'; toolCallId: string; name: string; args: unknown }
-  | { type: 'tool_end'; toolCallId: string; name: string; error: boolean; result: unknown; durationMs: number }
-  | { type: 'done' }
-  | { type: 'error'; message: string }
+  | { type: 'text_delta'; delta: string; ts?: number }
+  | { type: 'tool_start'; toolCallId: string; name: string; args: unknown; ts?: number }
+  | {
+      type: 'tool_end'
+      toolCallId: string
+      name: string
+      error: boolean
+      result: unknown
+      durationMs: number
+      ts?: number
+    }
+  | { type: 'done'; ts?: number }
+  | { type: 'error'; message: string; ts?: number }
   | { type: 'reload_result'; results: ReloadResultPayload[] }
   | { type: 'restart_result'; status: 'accepted' | 'failed'; message?: string; error?: string }
   | { type: 'notification'; payload: unknown; replyTo?: string; meta?: Record<string, string> }
   | { type: 'queue_state'; pending: QueueStateItem[] }
-  | { type: 'prompt_started'; messageId: string; text: string }
+  | { type: 'prompt_started'; messageId: string; text: string; ts?: number }
   | { type: 'doctor_result'; requestId: DoctorRequestId; checks: DoctorCheckPayload[] }
   | { type: 'doctor_fix_result'; requestId: DoctorRequestId; result: DoctorFixPayload }
   | { type: 'cron_list_result'; requestId: CronListRequestId; result: CronListResultPayload }

--- a/src/tui/format.test.ts
+++ b/src/tui/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { formatToolEnd, formatToolStart } from './format'
+import { formatTimestamp, formatToolEnd, formatToolStart, withTimestamp } from './format'
 
 const stripAnsi = (s: string) =>
   // oxlint-disable-next-line no-control-regex -- intentionally strips ANSI sequences from rendered output
@@ -231,5 +231,22 @@ describe('formatToolEnd results', () => {
   test('result without content key falls back to pretty JSON', () => {
     const out = visible(formatToolEnd('mystery', false, { details: { x: 1 } }, 1))
     expect(out).toContain('"details"')
+  })
+})
+
+describe('formatTimestamp', () => {
+  test('renders HH:MM:SS for a real timestamp', () => {
+    const ts = new Date(2026, 0, 2, 9, 5, 7).getTime()
+    expect(visible(formatTimestamp(ts))).toBe('09:05:07')
+  })
+
+  test('renders the placeholder for undefined and ts=0', () => {
+    expect(visible(formatTimestamp(undefined))).toBe('--:--:--')
+    expect(visible(formatTimestamp(0))).toBe('--:--:--')
+  })
+
+  test('withTimestamp prefixes the body with the time', () => {
+    const ts = new Date(2026, 0, 2, 23, 59, 59).getTime()
+    expect(visible(withTimestamp(ts, 'hello'))).toBe('23:59:59 hello')
   })
 })

--- a/src/tui/format.ts
+++ b/src/tui/format.ts
@@ -24,6 +24,19 @@ export function formatUserPromptHistory(text: string): string {
     .join('\n')
 }
 
+export function formatTimestamp(ts: number | undefined): string {
+  if (ts === undefined || ts === 0) return colors.dim('--:--:--')
+  const d = new Date(ts)
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  const ss = String(d.getSeconds()).padStart(2, '0')
+  return colors.dim(`${hh}:${mm}:${ss}`)
+}
+
+export function withTimestamp(ts: number | undefined, body: string): string {
+  return `${formatTimestamp(ts)} ${body}`
+}
+
 function stripHiddenBlocks(text: string): string {
   return text.replace(/<hatching>[\s\S]*?<\/hatching>\s*/g, '').trimStart()
 }

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -3,7 +3,14 @@ import { Editor, Key, Markdown, matchesKey, ProcessTerminal, type Terminal, Text
 import { parseCommand } from '@/commands'
 
 import { createClient as createClientDefault, type Client } from './client'
-import { formatQueuePanel, formatToolEnd, formatToolStart, formatUserPromptHistory } from './format'
+import {
+  formatQueuePanel,
+  formatTimestamp,
+  formatToolEnd,
+  formatToolStart,
+  formatUserPromptHistory,
+  withTimestamp,
+} from './format'
 import { colors, editorTheme, markdownTheme } from './theme'
 
 export type ClientFactory = (url: string) => Promise<Client>
@@ -173,8 +180,13 @@ export function createTui({
       onReplyDone = null
     }
 
-    const ensureAssistantBlock = (): Markdown => {
+    // A Markdown block can't carry an ANSI timestamp prefix (it'd be parsed as
+    // markdown), so the assistant turn's timestamp is a separate dim Text line
+    // emitted just above the block when it's first created — stamped with the
+    // first delta's server `ts`.
+    const ensureAssistantBlock = (ts: number | undefined): Markdown => {
       if (currentAssistant) return currentAssistant
+      appendHistory(new Text(formatTimestamp(ts), 0, 0))
       const md = new Markdown('', 0, 0, markdownTheme)
       currentAssistant = md
       currentAssistantText = ''
@@ -185,12 +197,12 @@ export function createTui({
     client.onMessage((msg) => {
       switch (msg.type) {
         case 'prompt_started': {
-          appendHistory(new Text(formatUserPromptHistory(msg.text), 0, 0))
+          appendHistory(new Text(withTimestamp(msg.ts, formatUserPromptHistory(msg.text)), 0, 0))
           tui.requestRender()
           break
         }
         case 'text_delta': {
-          const block = ensureAssistantBlock()
+          const block = ensureAssistantBlock(msg.ts)
           currentAssistantText += msg.delta
           block.setText(currentAssistantText)
           tui.requestRender()
@@ -198,13 +210,15 @@ export function createTui({
         }
         case 'tool_start': {
           sealAssistantBlock()
-          appendHistory(new Text(formatToolStart(msg.name, msg.args), 0, 0))
+          appendHistory(new Text(withTimestamp(msg.ts, formatToolStart(msg.name, msg.args)), 0, 0))
           tui.requestRender()
           break
         }
         case 'tool_end': {
           sealAssistantBlock()
-          appendHistory(new Text(formatToolEnd(msg.name, msg.error, msg.result, msg.durationMs), 0, 0))
+          appendHistory(
+            new Text(withTimestamp(msg.ts, formatToolEnd(msg.name, msg.error, msg.result, msg.durationMs)), 0, 0),
+          )
           tui.requestRender()
           break
         }
@@ -214,7 +228,7 @@ export function createTui({
           break
         }
         case 'error': {
-          appendHistory(new Text(colors.red(`error: ${msg.message}`), 0, 0))
+          appendHistory(new Text(withTimestamp(msg.ts, colors.red(`error: ${msg.message}`)), 0, 0))
           finishAssistantTurn()
           tui.requestRender()
           break


### PR DESCRIPTION
## Background

Two of TypeClaw's three session viewers showed no timestamps. The live TUI (`typeclaw tui`) rendered each event — prompts, tool calls, assistant text — with no time at all. The rich inspect transcript viewer (the interactive read-only session view you get when you pick a session in `typeclaw inspect`) was the same: a header and per-entry bodies, but no per-entry time. Only the line-based `inspect` renderer (`src/inspect/render.ts`) already printed `HH:MM:SS`.

That makes both views hard to use for "when did this happen / how long between these two steps" — exactly the questions you ask when watching an agent work or auditing a past run.

## Summary

Two commits along a clean seam (data, then render):

1. **`server`** — add an optional `ts` (send time, ms since epoch) to the `ServerMessage` variants the TUI renders into scrollback (`text_delta`, `tool_start`, `tool_end`, `done`, `error`, `prompt_started`) and stamp it **centrally in the `send()` helper** rather than at each of the ~10 call sites. One choke point, impossible to forget on a new send site.

2. **`tui`** — render a dim `HH:MM:SS` prefix on each history entry, in both the live TUI and the inspect transcript viewer, matching the existing line renderer's format.

**Why server-side `ts` and not client receive-time?** The timestamp reflects when the agent *emitted* the event, not when the client's socket happened to read it — accurate for tool durations and replay, and consistent with the inspect protocol (`InspectEvent.ts`), which is already server-stamped.

**Why `ts?` optional on the wire?** So an old host CLI still parses a new server's frames (same cross-version contract as the existing `serverVersion` field). Control frames the TUI never timestamps (`queue_state`, doctor, tunnel, claim, `command_*`) keep their shape.

**Why a separate timestamp line for the assistant turn?** The assistant body is a pi-tui `Markdown` block; an inline ANSI-colored prefix would be parsed as markdown content. So its timestamp is a dim `Text` line emitted just above the block, stamped with the first delta's `ts`. Every other event prefixes inline. The inspect transcript does the same for all entries to keep `componentFor` pure (and its existing test green).

## What this does NOT do

- No change to the line-based `inspect` renderer — it already had `HH:MM:SS`.
- No date, no milliseconds, no relative/elapsed time — just wall-clock `HH:MM:SS` to match the existing format. Easy to extend later.
- No new config/flag — timestamps are always on.

## Review notes

- **Load-bearing:** the central stamp in `send()` (`src/server/index.ts`) — `TIMESTAMPED_SERVER_MESSAGES` is the allowlist; control frames intentionally excluded.
- **Invariant to verify:** `ts` stays optional in `src/shared/protocol.ts` (old-CLI parse compat). The server test now asserts `ts` is present on the wire for `tool_start`.
- Full suite passes (7234 pass). One unrelated failure (`resolveSelfPackageJsonPath > points at this package manifest`) only reproduces in a worktree whose directory basename isn't `typeclaw`; it passes in CI and the main checkout, and is untouched by this PR.