### PR TITLE
channels: retry empty channel turns instead of dead-air silent drop

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -18,9 +18,12 @@ import {
   CHANNEL_MAX_OUTPUT_TOKENS,
   createChannelRouter,
   DUPLICATE_SEND_ERROR,
+  EMPTY_TURN_FALLBACK_TEXT,
+  EMPTY_TURN_RETRY_NUDGE,
   extractPlainTextChannelToolCallText,
   getPlainTextChannelToolCallKind,
   MAX_CHANNEL_SENDS_PER_TURN,
+  MAX_EMPTY_TURN_RETRIES,
   MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN,
   MAX_TYPING_HEARTBEAT_MS,
   OUTBOUND_FLOOD_ERROR,
@@ -2905,7 +2908,9 @@ describe('ChannelRouter channel-turn protocol', () => {
   // The leaf-assistant branch recovers ONLY 'stop' and 'toolUse'. length /
   // error / aborted carry visible text too, but it's a truncation or an
   // errored partial, not a deliberate reply — recovering it would post broken
-  // output. This is the load-bearing scoping of the mid-turn fix.
+  // output. This is the load-bearing scoping of the mid-turn fix. The truncated
+  // prose is NEVER posted; instead the empty-turn guard retries the turn and,
+  // on exhaustion, posts the fallback (asserted in the empty-turn suite below).
   for (const stopReason of ['length', 'error', 'aborted'] as const) {
     test(`mid-turn recovery: does NOT recover a leaf assistant with stopReason='${stopReason}'`, async () => {
       const dir = await tempDir()
@@ -2923,11 +2928,93 @@ describe('ChannelRouter channel-turn protocol', () => {
       }
       await router.__testing!.flushDebounce(KEY)
 
-      expect(sent).toHaveLength(0)
+      expect(sent.some((s) => s.text.includes('partial truncated output'))).toBe(false)
       expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
-      expect(logs.some((m) => m.includes('no recoverable assistant text in branch'))).toBe(true)
     })
   }
+
+  test('empty-turn guard: pure reasoning-loop retries then recovers when a later attempt replies', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'ambiguous thing' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async (text) => {
+      attempt++
+      // First prompt: degenerate empty `length` leaf (no send). Retry nudge
+      // arrives as the second prompt; on it the model finally replies.
+      if (attempt === 1) {
+        sessions[0]!.setAssistantMidTurn('thought-loop output that must not be posted', 'length')
+        return
+      }
+      expect(text).toContain(EMPTY_TURN_RETRY_NUDGE)
+      sessions[0]!.setAssistantText('SENT')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here is your answer' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sent.map((s) => s.text)).toEqual(['here is your answer'])
+    expect(sent.some((s) => s.text === EMPTY_TURN_FALLBACK_TEXT)).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_retry attempt=1'))).toBe(true)
+    expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
+  })
+
+  test('empty-turn guard: pure reasoning-loop posts the fallback after retries are exhausted', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'ambiguous thing' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantMidTurn('never-ending loop output', 'length')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // 1 original prompt + MAX_EMPTY_TURN_RETRIES retry prompts.
+    expect(sessions[0]!.prompts).toHaveLength(1 + MAX_EMPTY_TURN_RETRIES)
+    expect(sent.map((s) => s.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
+    expect(logs.some((m) => m.includes(`empty_turn_retry attempt=${MAX_EMPTY_TURN_RETRIES}`))).toBe(true)
+    expect(logs.some((m) => m.includes('empty_turn_fallback cause=retries_exhausted'))).toBe(true)
+  })
+
+  test('empty-turn guard: a turn that thrashed the send path skips retry and posts the fallback once', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'say something' }))
+    sessions[0]!.onPrompt = async () => {
+      // The model committed to silence, then thrashed the send path (denied
+      // skip-locked) and left no recoverable prose. Re-prompting would just
+      // re-thrash, so the guard skips retry and posts the fallback once.
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'changed my mind' })
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'denied attempt' })
+      sessions[0]!.setAssistantMidTurn('stranded loop output', 'length')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent.map((s) => s.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
+    expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_fallback cause=send_thrash'))).toBe(true)
+  })
 
   test('mid-turn recovery: does NOT fire when the model successfully replied (channel send happened)', async () => {
     const dir = await tempDir()

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -181,6 +181,44 @@ export const MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN = 3
 // including reasoning). Deliberately NOT lowered in `providers.ts`, where
 // `maxTokens` is the model's true capability that compaction math reads.
 export const CHANNEL_MAX_OUTPUT_TOKENS = 4096
+// Ceiling on automatic re-prompts for a turn that ended with NO user-facing
+// reply AND no attempted send — the pure "the model burned its budget thinking
+// and produced nothing" failure. The canonical trigger is Fireworks'
+// kimi-k2p6-turbo spiraling into a long reasoning loop on an ambiguous request
+// until it hits CHANNEL_MAX_OUTPUT_TOKENS (`stopReason: 'length'`); the same
+// path also catches a provider/router `aborted` leaf that left no recoverable
+// prose. Each retry injects EMPTY_TURN_RETRY_NUDGE as a reminder-only turn (no
+// new inbound) so `drain()` re-runs `session.prompt()` against the same branch.
+// Bounded because a genuinely stuck model would otherwise re-loop forever; on
+// exhaustion the user gets EMPTY_TURN_FALLBACK_TEXT instead of dead air. Reset
+// at turn start alongside `turnSeq`. Deliberately NOT applied to turns that
+// ATTEMPTED a send this turn (skip-locked or policy-denied) — those already
+// thrashed the send path, so a re-prompt would just re-thrash; they skip
+// straight to the fallback. See validateChannelTurn's candidate===null branch.
+export const MAX_EMPTY_TURN_RETRIES = 2
+// Reminder-only nudge injected before an empty-turn retry. Uses the repo's
+// SYSTEM MESSAGE framing (see composeTurnPrompt) so persona-rich models do not
+// reply to the notice itself. Neutral by design: it asks for a direct reply
+// without prescribing length or tone, matching the chosen "just retry" posture.
+export const EMPTY_TURN_RETRY_NUDGE = [
+  '---',
+  '**[SYSTEM MESSAGE — not from a human]**',
+  '',
+  'Your previous turn ended without sending any reply to the channel. This is',
+  'an automated signal from the channel router, not a message from anyone in',
+  'the chat. **Do not acknowledge or reply to this notice itself.**',
+  '',
+  'Respond to the last user message now with a direct answer via your channel',
+  'reply tool. If you genuinely have nothing to say, reply with `NO_REPLY`.',
+  '',
+  '---',
+].join('\n')
+// Posted to the channel (via the `source:'system'` one-shot bypass) when an
+// empty turn cannot be recovered AND retries are exhausted (or are skipped
+// because the turn thrashed the send path). Replaces the historical silent
+// drop so the human is never left staring at dead air after a degenerate turn.
+export const EMPTY_TURN_FALLBACK_TEXT =
+  "⚠️ I got stuck putting together a reply and couldn't finish. Could you rephrase or try again?"
 // Rolling window for outbound send-rate telemetry. 5s matches Discord's
 // rate-limit shape (5 msg / 5 s / channel) and comfortably covers Slack's
 // 1 msg/s sustained. The window is observational; exceeding the burst
@@ -484,6 +522,14 @@ type LiveSession = {
   // livelock the byte-identical loop-guard misses. Reset at turn start and
   // cleared per-target on a successful delivery to that target.
   policyDeniedToolSendsThisTurn: Map<string, number>
+  // Count of automatic empty-turn re-prompts already spent on the CURRENT
+  // logical turn, bounded by `MAX_EMPTY_TURN_RETRIES`. A "logical turn" spans
+  // the original user batch plus any router-injected retry nudges, so this is
+  // reset only when a real user/reminder batch starts a fresh turn — NOT on the
+  // reminder-only iterations the retry itself queues. `validateChannelTurn`
+  // increments it before injecting EMPTY_TURN_RETRY_NUDGE and reads it to decide
+  // retry-vs-fallback. See the candidate===null branch.
+  emptyTurnRetries: number
   // Stamped by `markTurnSkipped` (called from the `skip_response` tool)
   // with the current `turnSeq`. Read at the top of `validateChannelTurn`:
   // if it matches the just-completed turn, recovery is skipped entirely
@@ -1362,6 +1408,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         successfulSendsAtTurnStart: 0,
         inFlightToolSends: new Map(),
         policyDeniedToolSendsThisTurn: new Map(),
+        emptyTurnRetries: 0,
         skippedTurn: null,
         skipLockedSendTurn: null,
         pendingQuoteCandidate: null,
@@ -1830,6 +1877,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.consecutiveSends.clear()
           live.lastSentText.clear()
           live.pendingQuoteCandidate = captureQuoteCandidate(live.key.adapter, batch, observed)
+          // A real user batch starts a fresh logical turn → restore the full
+          // empty-turn retry budget. Reset here (batch.length > 0) and NOT in
+          // the per-prompt block below, so the reminder-only iterations the
+          // retry itself queues do not refill the budget and loop forever.
+          live.emptyTurnRetries = 0
         } else if (live.lastTurnAuthorId !== null) {
           live.currentTurnEngageReactions = []
           // Reminder-only turn (batch.length === 0, reminders.length > 0):
@@ -2898,15 +2950,64 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
     if (live.successfulChannelSends > successfulSendsBeforePrompt) return
 
+    const postEmptyTurnFallback = async (cause: string): Promise<void> => {
+      logger.warn(`[channels] ${live.keyId} empty_turn_fallback cause=${cause}`)
+      const result = await send(
+        {
+          adapter: live.key.adapter,
+          workspace: live.key.workspace,
+          chat: live.key.chat,
+          thread: live.key.thread,
+          text: EMPTY_TURN_FALLBACK_TEXT,
+        },
+        { source: 'system' },
+      )
+      if (!result.ok) {
+        logger.warn(`[channels] ${live.keyId}: empty-turn fallback send failed: ${result.error}`)
+      }
+    }
+
     const candidate = recoverableAssistantText(live.session)
     if (candidate === null) {
-      // Observability: previously a silent bail-out. The most common cause is a
-      // turn that ends mid-loop with NO assistant message at all (leaf is a
-      // session header / model_change / similar non-message entry, or a session
-      // that just started). Logged at debug-level info so operators can grep for
-      // unexpected silent turns; not warn-level because legitimate empty-state
-      // sessions hit this on every TUI-only check before the first user prompt.
-      logger.info(`[channels] ${live.keyId}: no recoverable assistant text in branch`)
+      // No recoverable assistant prose: the turn ended with no usable reply.
+      // Two distinct shapes, handled differently (Option B):
+      //
+      //   1. The model THRASHED the send path this turn — it tried to send but
+      //      every attempt was denied (skip-locked, or policy-denied/duplicate/
+      //      cap, tracked on skipLockedSendTurn / policyDeniedToolSendsThisTurn).
+      //      Re-prompting would just re-thrash, so skip retry and post the
+      //      user-facing fallback once.
+      //
+      //   2. The PURE reasoning-loop — no send was ever attempted; the model
+      //      burned its budget thinking and produced nothing (the canonical
+      //      kimi `stopReason: 'length'` / `aborted` degeneration). Re-prompt up
+      //      to MAX_EMPTY_TURN_RETRIES with a neutral nudge; on exhaustion, fall
+      //      back. The nudge is injected as a reminder-only turn so drain()'s
+      //      while-loop re-runs session.prompt() against the same branch.
+      //
+      // The legitimate empty-state case (a TUI-only check before any user
+      // prompt, no inbound this turn) is excluded: no batch means no real turn
+      // to retry or apologize for — keep the historical silent bail there.
+      const attemptedSendThisTurn =
+        live.skipLockedSendTurn === live.turnSeq || live.policyDeniedToolSendsThisTurn.size > 0
+
+      // Only a TRUNCATED assistant leaf (length/error/aborted) from a real
+      // conversational turn is a degeneration worth retrying. A cold/empty turn
+      // (no inbound author, or no assistant message at all) keeps the historical
+      // silent bail — re-prompting it would manufacture replies to nothing.
+      if (live.currentTurnAuthorId === null || !assistantLeafTruncated(live.session)) {
+        logger.info(`[channels] ${live.keyId}: no recoverable assistant text in branch`)
+        return
+      }
+      if (!attemptedSendThisTurn && live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES) {
+        live.emptyTurnRetries++
+        logger.warn(
+          `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES}`,
+        )
+        live.pendingSystemReminders.push(EMPTY_TURN_RETRY_NUDGE)
+        return
+      }
+      await postEmptyTurnFallback(attemptedSendThisTurn ? 'send_thrash' : 'retries_exhausted')
       return
     }
 
@@ -4164,6 +4265,20 @@ function recoverableAssistantText(
     cursor = parent
   }
   return null
+}
+
+// True only when the leaf is an assistant message that was CUT OFF mid-output:
+// `length` (hit the token cap — the canonical kimi reasoning-loop), `error`, or
+// `aborted`. This is the precise signature of "the model was producing but got
+// truncated", as distinct from a turn that produced no assistant message at all
+// (leaf undefined / a non-assistant entry), which is a benign empty/cold turn —
+// NOT something to re-prompt. The empty-turn retry guard keys off this so it
+// fires for real degenerations and stays silent for cold sessions.
+function assistantLeafTruncated(session: AgentSession): boolean {
+  const leaf = session.sessionManager.getLeafEntry()
+  if (!leaf || leaf.type !== 'message' || leaf.message.role !== 'assistant') return false
+  const stop = leaf.message.stopReason
+  return stop === 'length' || stop === 'error' || stop === 'aborted'
 }
 
 function visibleAssistantText(message: AssistantMessage): string {


### PR DESCRIPTION
## Background

A channel agent processed a user message, spiraled into a long internal reasoning loop on an ambiguous request, and hit the per-turn output-token cap. It produced no reply (stopReason: `length`). The router's recovery path treated it as a truncation rather than a deliberate reply, returned null, and silently dropped the turn. The user saw dead air. The same silent drop hit provider/router aborted leaves with no recoverable prose.

The scoping gap: the router didn't distinguish a truncated real turn from a cold/empty one — no inbound author, or no assistant message at all. Both bailed silently.

## Summary

`validateChannelTurn` now detects a **truncated assistant leaf** via the new assistantLeafTruncated helper: an assistant-role message whose stopReason is length, error, or aborted. Truncated real turns get one of two recoveries — **Option B: re-prompt or fallback, never silent drop**.

**Pure reasoning-loop** (no send attempted this turn): re-prompt up to `MAX_EMPTY_TURN_RETRIES` (2) by injecting a neutral system-message nudge into pendingSystemReminders. The drain loop then re-runs session.prompt() against the same branch. On exhaustion, post a user-facing fallback once.

**Send-thrash** (every send attempt this turn was denied — skip-locked or policy-denied): skip retry. A re-prompt would just re-thrash the same denied sends. Post the fallback once.

**Why retry via a reminder, not a new user message?** The nudge is injected as a reminder-only iteration so the drain loop sees it without creating a new user batch. The retry budget (`emptyTurnRetries` on LiveSession) resets only on a real user batch — never on reminder-only iterations — so the loop can't run forever.

**Why send-thrash skips retry:** the model already tried to send; re-prompting against the same branch can't unblock a skip-locked or policy-denied send. A single fallback is the right outcome.

**Cold/empty turns unchanged:** a turn with no inbound author, or no assistant message at all, was never a real conversational exchange. The historical silent bail stays.

## What this does NOT do

- Does not change how truncated prose is handled when `recoverableAssistantText` finds text — that path posts the recoverable text directly, as before.
- Does not add retry logic for provider soft-errors (handled by the existing subscribeProviderErrors path).
- Does not affect cron or subagent turns — channel router only.
- Does not add per-channel config for the retry budget or fallback text.

## Review notes

- **Load-bearing:** `assistantLeafTruncated` in src/channels/router.ts — it must require an assistant-role leaf. Without the role check, a tool-result leaf with a truncating stopReason on a cold turn would incorrectly enter the retry path.
- **Budget reset invariant:** `emptyTurnRetries` increments each retry and resets inside the drain loop only on a non-reminder real batch. If it reset on reminder-only turns, the budget would never deplete.
- **Send-thrash detection:** skipLockedSendTurn and policyDeniedToolSendsThisTurn are set during the turn. Checking them before the retry decision reads the current turn's outcome, not a prior turn's stale flag.
- Tests assert observable behavior — prompts issued, messages sent, log markers — via the existing FakeSession/makeRouter harness. Three new tests: pure-loop retries-then-recovers, pure-loop exhausts-then-fallback, send-thrash skips-retry-then-fallback. The existing scoping test is updated to confirm the new behavior — truncated recoverable prose still posts; a truncated turn with no prose now retries or falls back instead of dropping silently.
- One test failure in the full suite is pre-existing and environmental: `resolveSelfPackageJsonPath > points at this package manifest`.
  It asserts the manifest path ends with `typeclaw/package.json`, but a worktree with a different directory name resolves a different suffix. It passes in CI. No file touched by this PR is near src/update/.