### PR TITLE
github: skip draft PRs cleanly instead of silently observing them

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -395,6 +395,16 @@ describe('classifyGithubInbound', () => {
       expect(msg?.text).toContain('requested your review on PR #7')
     })
 
+    it('review_requested on a draft PR triggers a review under the default config', () => {
+      const msg = classifyGithubInbound(
+        'pull_request',
+        reviewRequestedPayload({ reviewerLogin: 'typeclaw-bot', draft: true }),
+        'typeclaw-bot',
+      )
+      expect(msg?.isBotMention).toBe(true)
+      expect(msg?.text).toContain('requested your review on PR #7')
+    })
+
     describe("reviewOn: 'opened'", () => {
       it('synthesizes a review trigger for an opened PR', () => {
         const msg = classifyGithubInbound('pull_request', openedPayload(), 'typeclaw-bot', { reviewOn: 'opened' })
@@ -427,13 +437,11 @@ describe('classifyGithubInbound', () => {
         expect(msg?.text).toContain('requested your review on PR #7')
       })
 
-      it('skips the auto-review on a draft PR, landing it as awareness-only context', () => {
+      it('skips a draft PR cleanly (null), deferring to the ready_for_review trigger', () => {
         const msg = classifyGithubInbound('pull_request', openedPayload({ draft: true }), 'typeclaw-bot', {
           reviewOn: 'opened',
         })
-        expect(msg?.chat).toBe('pr:7')
-        expect(msg?.isBotMention).toBe(false)
-        expect(msg?.text).not.toContain('Please review the changes line-by-line')
+        expect(msg).toBe(null)
       })
 
       it('still auto-reviews when draft is explicitly false', () => {
@@ -453,6 +461,14 @@ describe('classifyGithubInbound', () => {
         )
         expect(msg?.isBotMention).toBe(true)
         expect(msg?.text).toContain('requested your review on PR #7')
+      })
+
+      it('reviews a skipped draft once it turns ready (ready_for_review fires on the draft→ready transition)', () => {
+        const msg = classifyGithubInbound('pull_request', readyForReviewPayload(), 'typeclaw-bot', {
+          reviewOn: 'opened',
+        })
+        expect(msg?.isBotMention).toBe(true)
+        expect(msg?.text).toContain('Please review the changes line-by-line')
       })
 
       it('suppresses the review trigger when the bot opened its own PR (handler drops the self-authored event)', () => {

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -411,6 +411,13 @@ export function classifyGithubInbound(
     // the PR is non-draft once ready — preserving "review when no longer draft".
     const isOpenLike = action === 'opened' || action === 'ready_for_review'
     if (isOpenLike && reviewOn === 'opened') {
+      // Draft opened under `review.on: "opened"`: skip cleanly (null wakes no
+      // session) and wait for the `ready_for_review` trigger. Must NOT fall
+      // through to the awareness path below, where a multi-collaborator repo
+      // silently `observed`s it — a draft whose `ready_for_review` delivery is
+      // later lost would then never get reviewed (huxley#1721). `review_requested`
+      // on a draft is unaffected: it returns above via classifyReviewRequest.
+      if (readBoolean(pr, 'draft') === true) return null
       const trigger = classifyOpenedReviewTrigger({
         payload,
         pr,
@@ -643,12 +650,6 @@ function classifyOpenedReviewTrigger(input: OpenedReviewTriggerInput): InboundMe
   // distinct login, so a decoy-opened PR would otherwise wake a self-review.
   const decoyLogin = resolveDecoyReviewerLogin(selfLogin, authType)
   if (sender.login === selfLogin || (decoyLogin !== null && sender.login === decoyLogin)) return null
-
-  // A draft PR is work-in-progress, so the automatic `opened` path skips it: null
-  // here drops to awareness-only context (like a non-`opened` reviewOn) instead of
-  // waking a review. An explicit `review_requested` still triggers on a draft via
-  // classifyReviewRequest, preserving "skip until explicitly requested".
-  if (readBoolean(pr, 'draft') === true) return null
 
   const title = readString(pr, 'title') ?? `#${number}`
   const head = readString(readRecord(pr.head), 'ref')

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -192,8 +192,9 @@ export const SEEDED_GITHUB_EVENT_ALLOWLISTS: readonly (readonly string[])[] = [
 // prefix is implied by this field living under the review config); `off` is the
 // disable sentinel, matching the `engagement.stickiness: 'off'` convention:
 //   - 'review_requested' — review only when the bot is requested (default)
-//   - 'opened'           — review every non-draft PR as soon as it opens; draft
-//                          PRs are skipped until an explicit review_requested
+//   - 'opened'           — review every non-draft PR as soon as it opens; a draft
+//                          PR wakes no session and is reviewed once it turns ready
+//                          (ready_for_review) or the bot is explicitly requested
 //   - 'off'              — disable code review entirely
 export const GITHUB_REVIEW_ON_VALUES = ['review_requested', 'opened', 'off'] as const
 


### PR DESCRIPTION
## Background

With `review.on: "opened"`, a draft pull_request.opened event was classified
as awareness-only context inside classifyGithubInbound. In a multi-collaborator
repository, the engagement layer resolved that to observe — no review ran, nothing
was logged. The intended recovery was the ready_for_review event firing on the
draft→ready transition, but if that webhook delivery was lost (e.g. an ephemeral
tunnel dropping it), the PR was never reviewed. Net effect: a draft PR opened under
this config could be silently skipped with no trace.

## Summary

A draft pull_request.opened under `review.on: "opened"` now returns null from
classifyGithubInbound — a clean skip that wakes no session — instead of an
awareness-only message the engagement layer can silently observe. The review still
fires via ready_for_review when the author marks the PR ready, or via review_requested.

Invariant this satisfies: a PR must never be silently observed while review
automation is enabled. Only `review.on: "off"` routes opened PRs into observe.

A review_requested on a draft is unaffected — it returns earlier via
classifyReviewRequest, never reaching the draft guard.

The now-dead draft check inside classifyOpenedReviewTrigger was removed
(unreachable after the new guard).

**Behavior after this fix:**

| Event | review.on | Draft? | Result |
|---|---|---|---|
| pull_request.opened | `"opened"` | yes | clean skip — **changed** (was: silently observed) |
| pull_request.opened / ready_for_review | `"opened"` | no | review |
| review_requested | opened or review_requested | yes | review (unchanged) |
| pull_request.opened | review_requested or off | any | awareness/observe (unchanged) |

## Preview

N/A. The observable difference is the absence of a ghost observe turn when
a draft PR is opened.

## What this does NOT do

- Does not change the ready_for_review trigger — review still fires when the
  author marks the PR ready.
- Does not affect review_requested on a draft — triggers review as before.
- Does not address webhook-delivery reliability for ready_for_review events
  (see Follow-up).

## Review notes

- **Load-bearing:** the new early return in classifyGithubInbound
  (`src/channels/adapters/github/inbound.ts`).
  It guards the case where action is `"opened"` and the PR is a draft
  under the opened review mode. Must sit before the awareness-only path,
  after classifyReviewRequest, so review_requested on a draft isn't caught.
- **Dead-code removal:** classifyOpenedReviewTrigger had a draft guard
  that became unreachable after the new outer guard. Removed to avoid
  false confidence from a live-looking but inert branch.
- **Schema:** `src/channels/schema.ts` doc comment for the opened mode
  updated to describe the draft skip.
- **Tests (103 pass):** existing draft test updated to assert null (clean
  skip); two new cases — skipped draft reviewed via ready_for_review,
  and review_requested on a draft triggers review under the default config.
- Typecheck clean, lint 0 errors, format clean. All 1518 channels tests pass.

## Follow-up

This fixes the silent-observe half. A separate PR will address webhook-delivery
reliability — a lost ready_for_review delivery over an ephemeral tunnel can still
prevent review of a draft PR that was already opened.