### PR TITLE
github: reconcile open PRs on adapter start to recover missed review deliveries

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -349,6 +349,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
           token: authToken,
           route: routeInbound,
           logger,
+          isBotInTeam,
           fetchImpl,
         }).catch((err: unknown) => {
           logger.warn(`[github] reconcile pass failed: ${err instanceof Error ? err.message : String(err)}`)

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -1,7 +1,7 @@
 import type { GithubTokenBridge } from '@/channels/github-token-bridge'
 import type { ChannelRouter } from '@/channels/router'
 import type { ChannelAdapterConfig, GithubAdapterConfig } from '@/channels/schema'
-import type { ChannelSelfIdentityResolver } from '@/channels/types'
+import type { ChannelSelfIdentityResolver, InboundMessage } from '@/channels/types'
 import { resolveSecret } from '@/secrets/resolve'
 import type { GithubSecretsBlock } from '@/secrets/schema'
 
@@ -21,6 +21,7 @@ import {
   parseListHooksPermissionStatus,
 } from './permission-guidance'
 import { createGithubReactionCallback, createGithubRemoveReactionCallback } from './reactions'
+import { reconcileOpenPrs } from './reconcile-open-prs'
 import { createGithubReviewStateResolver } from './review-state'
 import { createGithubReviewThreadResolver } from './review-thread-resolver'
 import { createTeamMembershipChecker } from './team-membership'
@@ -160,6 +161,19 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
   const typing = async (): Promise<void> => {}
   const dedup = createDeliveryDedup()
   const isBotInTeam = createTeamMembershipChecker({ token: authToken, fetchImpl })
+  // Shared inbound entry. Both the live webhook handler and the startup
+  // reconciliation pass route through this so a replayed PR takes the exact
+  // same path a real delivery would.
+  const routeInbound = (message: InboundMessage): void => {
+    rememberWorkspace(message.workspace, message.chat)
+    // Ack-first: wrap in Promise.resolve so a synchronous throw inside
+    // router.route() cannot prevent the 200 response from being returned.
+    void Promise.resolve()
+      .then(() => options.router.route(message))
+      .catch((err: unknown) => {
+        logger.error(`[github] route failed: ${err instanceof Error ? err.message : String(err)}`)
+      })
+  }
   const handler = createGithubWebhookHandler({
     webhookSecret,
     dedup,
@@ -173,16 +187,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     authToken,
     fetchImpl,
     logger,
-    route: (message) => {
-      rememberWorkspace(message.workspace, message.chat)
-      // Ack-first: wrap in Promise.resolve so a synchronous throw inside
-      // router.route() cannot prevent the 200 response from being returned.
-      void Promise.resolve()
-        .then(() => options.router.route(message))
-        .catch((err: unknown) => {
-          logger.error(`[github] route failed: ${err instanceof Error ? err.message : String(err)}`)
-        })
-    },
+    route: routeInbound,
   })
 
   return {
@@ -329,6 +334,25 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
           r.action === 'created' || r.action === 'updated' ? [{ repo: r.repo, hookId: r.hookId }] : [],
         )
         logRegistrationOutcome(logger, registration, options.secrets.auth.type)
+      }
+      // Catch up on PRs whose opened/ready_for_review/review_requested delivery
+      // was missed (tunnel-URL churn, dropped delivery, downtime). Best-effort
+      // and last so a failure here never blocks the adapter from coming up; the
+      // helper swallows per-repo errors internally. Runs on every start(), so a
+      // tunnel-driven restart re-checks too. `off` short-circuits inside.
+      if (repos.length > 0) {
+        await reconcileOpenPrs({
+          repos,
+          reviewOn: cfg.review.on,
+          selfLogin,
+          authType: options.secrets.auth.type,
+          token: authToken,
+          route: routeInbound,
+          logger,
+          fetchImpl,
+        }).catch((err: unknown) => {
+          logger.warn(`[github] reconcile pass failed: ${err instanceof Error ? err.message : String(err)}`)
+        })
       }
     },
     async stop(): Promise<void> {

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -1201,4 +1201,86 @@ describe('createGithubAdapter lifecycle', () => {
       expect(calls.some((c) => c.url.includes('/repos/victim/private/'))).toBe(false)
     })
   })
+
+  describe('start() open-PR reconciliation', () => {
+    function reviewConfig(on: 'opened' | 'review_requested' | 'off') {
+      return (): ChannelAdapterConfig & GithubAdapterConfig => {
+        const config = githubConfig(['acme/widgets'])
+        config.review = { on, approve: true }
+        return config
+      }
+    }
+
+    test("reviewOn 'opened' scans open PRs and checks reviews for an un-reviewed one", async () => {
+      const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
+        if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+        const hooks = url.match(/\/repos\/[^/]+\/[^/]+\/hooks\b/)
+        if (hooks) {
+          if (method === 'GET') return Response.json([])
+          if (method === 'POST') return Response.json({ id: 1 }, { status: 201 })
+        }
+        if (url.match(/\/pulls\/7\/reviews/)) return Response.json([])
+        if (url.includes('/pulls?'))
+          return Response.json([
+            {
+              number: 7,
+              id: 700,
+              title: 'Add thing',
+              draft: false,
+              updated_at: '2026-01-01T00:00:00Z',
+              user: { login: 'alice', id: 10, type: 'User' },
+              head: { ref: 'feature' },
+              base: { ref: 'main' },
+              requested_reviewers: [],
+            },
+          ])
+        return new Response('unexpected', { status: 500 })
+      })
+
+      const adapter = createGithubAdapter({
+        router: freshRouter(),
+        configRef: reviewConfig('opened'),
+        secrets: patSecrets(),
+        agentDir: '/tmp/agent',
+        logger: silentLogger(),
+        fetchImpl,
+        httpListenImpl: () => ({ stop: async () => {} }),
+        webhookRegistrationDelayMs: 0,
+      })
+
+      await adapter.start()
+      await adapter.stop()
+
+      expect(calls.some((c) => c.url.includes('/repos/acme/widgets/pulls?state=open'))).toBe(true)
+      expect(calls.some((c) => c.url.includes('/repos/acme/widgets/pulls/7/reviews'))).toBe(true)
+    })
+
+    test("reviewOn 'off' does not scan open PRs", async () => {
+      const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
+        if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+        const hooks = url.match(/\/repos\/[^/]+\/[^/]+\/hooks\b/)
+        if (hooks) {
+          if (method === 'GET') return Response.json([])
+          if (method === 'POST') return Response.json({ id: 1 }, { status: 201 })
+        }
+        return new Response('unexpected', { status: 500 })
+      })
+
+      const adapter = createGithubAdapter({
+        router: freshRouter(),
+        configRef: reviewConfig('off'),
+        secrets: patSecrets(),
+        agentDir: '/tmp/agent',
+        logger: silentLogger(),
+        fetchImpl,
+        httpListenImpl: () => ({ stop: async () => {} }),
+        webhookRegistrationDelayMs: 0,
+      })
+
+      await adapter.start()
+      await adapter.stop()
+
+      expect(calls.some((c) => c.url.includes('/pulls'))).toBe(false)
+    })
+  })
 })

--- a/src/channels/adapters/github/reconcile-open-prs.test.ts
+++ b/src/channels/adapters/github/reconcile-open-prs.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { InboundMessage } from '@/channels/types'
+
+import { reconcileOpenPrs, type ReconcileOpenPrsOptions } from './reconcile-open-prs'
+
+type PrFixture = {
+  number: number
+  id: number
+  title?: string
+  draft?: boolean
+  authorLogin?: string
+  authorId?: number
+  authorType?: 'User' | 'Bot'
+  headRef?: string
+  baseRef?: string
+  updatedAt?: string
+  requestedReviewers?: string[]
+  selfReviewed?: boolean
+  reviewerLogin?: string
+  reviewerType?: 'User' | 'Bot'
+}
+
+function prJson(pr: PrFixture): Record<string, unknown> {
+  return {
+    number: pr.number,
+    id: pr.id,
+    title: pr.title ?? `PR ${pr.number}`,
+    draft: pr.draft ?? false,
+    updated_at: pr.updatedAt ?? '2026-01-01T00:00:00Z',
+    user: { login: pr.authorLogin ?? 'alice', id: pr.authorId ?? 10, type: pr.authorType ?? 'User' },
+    head: { ref: pr.headRef ?? 'feature' },
+    base: { ref: pr.baseRef ?? 'main' },
+    requested_reviewers: (pr.requestedReviewers ?? []).map((login) => ({ login })),
+  }
+}
+
+function reviewsJson(pr: PrFixture): Array<Record<string, unknown>> {
+  if (!pr.selfReviewed) return []
+  return [{ state: 'COMMENTED', user: { login: pr.reviewerLogin ?? 'bot', type: pr.reviewerType ?? 'Bot' } }]
+}
+
+// Serves /pulls (list) and /pulls/{n}/reviews for a single repo from fixtures.
+function fakeGithub(prs: PrFixture[]): typeof fetch {
+  const fn = async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    const reviewsMatch = url.match(/\/pulls\/(\d+)\/reviews/)
+    if (reviewsMatch) {
+      const number = Number(reviewsMatch[1])
+      const pr = prs.find((p) => p.number === number)
+      return Response.json(pr ? reviewsJson(pr) : [])
+    }
+    if (url.includes('/pulls?')) {
+      return Response.json(prs.map(prJson))
+    }
+    return new Response('unexpected', { status: 500 })
+  }
+  return Object.assign(fn, { preconnect: () => {} }) as typeof fetch
+}
+
+function baseOptions(
+  overrides: Partial<ReconcileOpenPrsOptions> & { routed: InboundMessage[] },
+): ReconcileOpenPrsOptions {
+  const { routed, ...rest } = overrides
+  return {
+    repos: ['acme/widgets'],
+    reviewOn: 'opened',
+    selfLogin: 'bot',
+    authType: 'pat',
+    token: async () => 'tok',
+    route: (m) => routed.push(m),
+    logger: { info: () => {}, warn: () => {} },
+    fetchImpl: fakeGithub([]),
+    ...rest,
+  }
+}
+
+describe('reconcileOpenPrs', () => {
+  test("reviewOn 'opened' replays a non-draft, un-reviewed PR as a review trigger", async () => {
+    const routed: InboundMessage[] = []
+    await reconcileOpenPrs(baseOptions({ routed, fetchImpl: fakeGithub([{ number: 7, id: 700, title: 'Add thing' }]) }))
+    expect(routed).toHaveLength(1)
+    const msg = routed[0]
+    expect(msg?.chat).toBe('pr:7')
+    expect(msg?.isBotMention).toBe(true)
+    expect(msg?.text).toContain('opened PR #7: "Add thing"')
+    expect(msg?.text).toContain('Please review the changes line-by-line')
+    expect(msg?.externalMessageId).toBe('pr-700-reconcile-2026-01-01T00:00:00Z')
+  })
+
+  test("reviewOn 'opened' skips a draft PR", async () => {
+    const routed: InboundMessage[] = []
+    await reconcileOpenPrs(baseOptions({ routed, fetchImpl: fakeGithub([{ number: 7, id: 700, draft: true }]) }))
+    expect(routed).toHaveLength(0)
+  })
+
+  test("reviewOn 'opened' skips a PR the bot already reviewed", async () => {
+    const routed: InboundMessage[] = []
+    await reconcileOpenPrs(baseOptions({ routed, fetchImpl: fakeGithub([{ number: 7, id: 700, selfReviewed: true }]) }))
+    expect(routed).toHaveLength(0)
+  })
+
+  test("reviewOn 'opened' skips a PR the bot opened itself", async () => {
+    const routed: InboundMessage[] = []
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        fetchImpl: fakeGithub([{ number: 7, id: 700, authorLogin: 'bot', authorType: 'Bot' }]),
+      }),
+    )
+    expect(routed).toHaveLength(0)
+  })
+
+  test("reviewOn 'off' replays nothing", async () => {
+    const routed: InboundMessage[] = []
+    await reconcileOpenPrs(baseOptions({ routed, reviewOn: 'off', fetchImpl: fakeGithub([{ number: 7, id: 700 }]) }))
+    expect(routed).toHaveLength(0)
+  })
+
+  test("reviewOn 'review_requested' replays only when the bot is a requested reviewer", async () => {
+    const routed: InboundMessage[] = []
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        reviewOn: 'review_requested',
+        fetchImpl: fakeGithub([
+          { number: 7, id: 700, requestedReviewers: ['bot'] },
+          { number: 8, id: 800, requestedReviewers: ['someone-else'] },
+          { number: 9, id: 900, requestedReviewers: [] },
+        ]),
+      }),
+    )
+    expect(routed.map((m) => m.chat)).toEqual(['pr:7'])
+  })
+
+  test("reviewOn 'review_requested' replays a draft when the bot is requested (draft state irrelevant here)", async () => {
+    const routed: InboundMessage[] = []
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        reviewOn: 'review_requested',
+        fetchImpl: fakeGithub([{ number: 7, id: 700, draft: true, requestedReviewers: ['bot'] }]),
+      }),
+    )
+    expect(routed.map((m) => m.chat)).toEqual(['pr:7'])
+  })
+
+  test('App decoy: matches the bare-slug requested reviewer and skips a decoy-opened PR', async () => {
+    const routed: InboundMessage[] = []
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        reviewOn: 'review_requested',
+        selfLogin: 'typey[bot]',
+        authType: 'app',
+        fetchImpl: fakeGithub([
+          { number: 7, id: 700, requestedReviewers: ['typey'] },
+          { number: 8, id: 800, authorLogin: 'typey', requestedReviewers: ['typey'] },
+        ]),
+      }),
+    )
+    expect(routed.map((m) => m.chat)).toEqual(['pr:7'])
+  })
+
+  test('a null selfLogin replays nothing (identity not yet resolved)', async () => {
+    const routed: InboundMessage[] = []
+    await reconcileOpenPrs(baseOptions({ routed, selfLogin: null, fetchImpl: fakeGithub([{ number: 7, id: 700 }]) }))
+    expect(routed).toHaveLength(0)
+  })
+
+  test('a per-repo fetch failure is isolated and reported, not thrown', async () => {
+    const routed: InboundMessage[] = []
+    const failing = Object.assign(async () => new Response('boom', { status: 500 }), {
+      preconnect: () => {},
+    }) as typeof fetch
+    const outcomes = await reconcileOpenPrs(baseOptions({ routed, fetchImpl: failing }))
+    expect(routed).toHaveLength(0)
+    expect(outcomes).toHaveLength(1)
+    expect(outcomes[0]).toMatchObject({ repo: 'acme/widgets' })
+    expect('error' in outcomes[0]!).toBe(true)
+  })
+
+  test('a malformed repo slug is reported without a fetch', async () => {
+    const routed: InboundMessage[] = []
+    let fetched = false
+    const spyFetch = Object.assign(
+      async () => {
+        fetched = true
+        return Response.json([])
+      },
+      { preconnect: () => {} },
+    ) as typeof fetch
+    const outcomes = await reconcileOpenPrs(baseOptions({ routed, repos: ['not-a-slug'], fetchImpl: spyFetch }))
+    expect(fetched).toBe(false)
+    expect(outcomes[0]).toMatchObject({ repo: 'not-a-slug', error: 'malformed repo slug' })
+  })
+})

--- a/src/channels/adapters/github/reconcile-open-prs.test.ts
+++ b/src/channels/adapters/github/reconcile-open-prs.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import type { InboundMessage } from '@/channels/types'
 
 import { reconcileOpenPrs, type ReconcileOpenPrsOptions } from './reconcile-open-prs'
+import type { TeamMembershipChecker } from './team-membership'
 
 type PrFixture = {
   number: number
@@ -16,6 +17,7 @@ type PrFixture = {
   baseRef?: string
   updatedAt?: string
   requestedReviewers?: string[]
+  requestedTeams?: string[]
   selfReviewed?: boolean
   reviewerLogin?: string
   reviewerType?: 'User' | 'Bot'
@@ -32,7 +34,12 @@ function prJson(pr: PrFixture): Record<string, unknown> {
     head: { ref: pr.headRef ?? 'feature' },
     base: { ref: pr.baseRef ?? 'main' },
     requested_reviewers: (pr.requestedReviewers ?? []).map((login) => ({ login })),
+    requested_teams: (pr.requestedTeams ?? []).map((slug) => ({ slug })),
   }
+}
+
+function teamChecker(memberSlugs: readonly string[]): TeamMembershipChecker {
+  return async ({ slug }) => memberSlugs.includes(slug)
 }
 
 function reviewsJson(pr: PrFixture): Array<Record<string, unknown>> {
@@ -143,6 +150,34 @@ describe('reconcileOpenPrs', () => {
       }),
     )
     expect(routed.map((m) => m.chat)).toEqual(['pr:7'])
+  })
+
+  test("reviewOn 'review_requested' replays when review is requested from a team the bot is in", async () => {
+    const routed: InboundMessage[] = []
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        reviewOn: 'review_requested',
+        isBotInTeam: teamChecker(['reviewers']),
+        fetchImpl: fakeGithub([
+          { number: 7, id: 700, requestedTeams: ['reviewers'] },
+          { number: 8, id: 800, requestedTeams: ['other-team'] },
+        ]),
+      }),
+    )
+    expect(routed.map((m) => m.chat)).toEqual(['pr:7'])
+  })
+
+  test("reviewOn 'review_requested' skips team requests when no membership checker is provided", async () => {
+    const routed: InboundMessage[] = []
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        reviewOn: 'review_requested',
+        fetchImpl: fakeGithub([{ number: 7, id: 700, requestedTeams: ['reviewers'] }]),
+      }),
+    )
+    expect(routed).toHaveLength(0)
   })
 
   test('App decoy: matches the bare-slug requested reviewer and skips a decoy-opened PR', async () => {

--- a/src/channels/adapters/github/reconcile-open-prs.ts
+++ b/src/channels/adapters/github/reconcile-open-prs.ts
@@ -3,6 +3,7 @@ import type { InboundMessage } from '@/channels/types'
 
 import type { GithubAuthContext } from './auth'
 import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
+import type { TeamMembershipChecker } from './team-membership'
 
 // Catches up on review work that a live webhook delivery missed. The github
 // adapter only acts on deliveries it receives, so a `pull_request.opened` /
@@ -25,6 +26,11 @@ export type ReconcileOpenPrsOptions = {
   token: (context?: GithubAuthContext) => Promise<string>
   route: (message: InboundMessage) => void
   logger: { info: (m: string) => void; warn: (m: string) => void }
+  // Resolves whether the bot is a member of a requested team, gating
+  // team-requested reviews under review.on 'review_requested' (mirrors the
+  // live webhook path's isMyTeam check in classifyReviewRequest). Omitted in
+  // tests that don't exercise team requests; treated as "not a member".
+  isBotInTeam?: TeamMembershipChecker
   fetchImpl?: typeof fetch
 }
 
@@ -97,14 +103,30 @@ async function prNeedsReview(input: {
 
   if (options.reviewOn === 'review_requested') {
     // Only the explicit request wakes a review under this mode. A draft can
-    // still carry a request, so draft state is irrelevant here.
-    return isReviewRequestedFromSelf(pr, selfLogin, decoyLogin)
+    // still carry a request, so draft state is irrelevant here. Mirrors the
+    // live path's `isMeAsUser || isMyTeam`: a direct user request, OR a team
+    // request the bot is a member of.
+    if (isUserReviewRequestedFromSelf(pr, selfLogin, decoyLogin)) return true
+    return await isTeamReviewRequestedFromSelf(pr, target, selfLogin, options.isBotInTeam)
   }
 
   // reviewOn === 'opened': a non-draft PR the bot has not yet reviewed. Draft
   // PRs wait for the ready_for_review trigger, matching the live-webhook path.
   if (pr.draft) return false
   return !(await botAlreadyReviewed(fetchImpl, token, target, pr.number, selfLogin))
+}
+
+async function isTeamReviewRequestedFromSelf(
+  pr: OpenPr,
+  target: RepoTarget,
+  selfLogin: string,
+  isBotInTeam: TeamMembershipChecker | undefined,
+): Promise<boolean> {
+  if (isBotInTeam === undefined || pr.requestedTeamSlugs.length === 0) return false
+  for (const slug of pr.requestedTeamSlugs) {
+    if (await isBotInTeam({ org: target.owner, slug, login: selfLogin })) return true
+  }
+  return false
 }
 
 function buildSyntheticInbound(pr: OpenPr, target: RepoTarget): InboundMessage {
@@ -149,6 +171,7 @@ type OpenPr = {
   baseRef: string | null
   updatedAt: string
   requestedReviewerLogins: string[]
+  requestedTeamSlugs: string[]
 }
 
 function parseRepo(slug: string): RepoTarget | null {
@@ -204,7 +227,7 @@ async function botAlreadyReviewed(
   return false
 }
 
-function isReviewRequestedFromSelf(pr: OpenPr, selfLogin: string, decoyLogin: string | null): boolean {
+function isUserReviewRequestedFromSelf(pr: OpenPr, selfLogin: string, decoyLogin: string | null): boolean {
   return pr.requestedReviewerLogins.some(
     (login) => isSelfLogin(login, login.endsWith(BOT_LOGIN_SUFFIX), selfLogin) || login === decoyLogin,
   )
@@ -254,6 +277,7 @@ type PrRow = {
   head?: { ref?: unknown }
   base?: { ref?: unknown }
   requested_reviewers?: Array<{ login?: unknown }>
+  requested_teams?: Array<{ slug?: unknown }>
 }
 
 type ReviewRow = { user?: { login?: string; type?: string } }
@@ -277,5 +301,6 @@ function parsePrRow(row: PrRow): OpenPr | null {
     requestedReviewerLogins: (row.requested_reviewers ?? []).flatMap((r) =>
       typeof r.login === 'string' ? [r.login] : [],
     ),
+    requestedTeamSlugs: (row.requested_teams ?? []).flatMap((t) => (typeof t.slug === 'string' ? [t.slug] : [])),
   }
 }

--- a/src/channels/adapters/github/reconcile-open-prs.ts
+++ b/src/channels/adapters/github/reconcile-open-prs.ts
@@ -1,0 +1,281 @@
+import type { GithubReviewOn } from '@/channels/schema'
+import type { InboundMessage } from '@/channels/types'
+
+import type { GithubAuthContext } from './auth'
+import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
+
+// Catches up on review work that a live webhook delivery missed. The github
+// adapter only acts on deliveries it receives, so a `pull_request.opened` /
+// `ready_for_review` dropped while the tunnel URL was churning (cloudflare-quick
+// mints a fresh host every restart) leaves an open PR permanently un-reviewed —
+// nothing wakes the bot for it again. This pass runs on every adapter start()
+// (cold boot AND tunnel-driven restart) and replays the PRs that still need a
+// review as synthetic inbounds through the same router path a real webhook uses.
+//
+// It is intentionally NOT a substitute for webhooks: it is a floor, not the
+// primary path. Drift between a missed delivery and the next start() is the
+// reconciliation window; webhooks remain the low-latency path when delivery
+// works.
+
+export type ReconcileOpenPrsOptions = {
+  repos: readonly string[]
+  reviewOn: GithubReviewOn
+  selfLogin: string | null
+  authType: 'pat' | 'app'
+  token: (context?: GithubAuthContext) => Promise<string>
+  route: (message: InboundMessage) => void
+  logger: { info: (m: string) => void; warn: (m: string) => void }
+  fetchImpl?: typeof fetch
+}
+
+export type ReconcileOutcome = { repo: string; scanned: number; replayed: number } | { repo: string; error: string }
+
+const BOT_LOGIN_SUFFIX = '[bot]'
+
+export async function reconcileOpenPrs(options: ReconcileOpenPrsOptions): Promise<ReconcileOutcome[]> {
+  // `off` disables code review entirely, so there is nothing to catch up on.
+  if (options.reviewOn === 'off') return []
+  if (options.selfLogin === null) return []
+  const fetchImpl = options.fetchImpl ?? fetch
+  const selfLogin = options.selfLogin
+  const decoyLogin = resolveDecoyLogin(selfLogin, options.authType)
+
+  const outcomes: ReconcileOutcome[] = []
+  for (const repo of new Set(options.repos)) {
+    const target = parseRepo(repo)
+    if (target === null) {
+      outcomes.push({ repo, error: 'malformed repo slug' })
+      continue
+    }
+    try {
+      const outcome = await reconcileRepo(target, options, selfLogin, decoyLogin, fetchImpl)
+      outcomes.push(outcome)
+      if (outcome.replayed > 0) {
+        options.logger.info(`[github] reconcile ${repo}: replayed ${outcome.replayed}/${outcome.scanned} open PR(s)`)
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      options.logger.warn(`[github] reconcile ${repo} failed: ${message}`)
+      outcomes.push({ repo, error: message })
+    }
+  }
+  return outcomes
+}
+
+async function reconcileRepo(
+  target: RepoTarget,
+  options: ReconcileOpenPrsOptions,
+  selfLogin: string,
+  decoyLogin: string | null,
+  fetchImpl: typeof fetch,
+): Promise<{ repo: string; scanned: number; replayed: number }> {
+  const repo = `${target.owner}/${target.repo}`
+  const token = await options.token({ repoSlug: repo })
+  const prs = await fetchOpenPrs(fetchImpl, token, target)
+
+  let replayed = 0
+  for (const pr of prs) {
+    const needs = await prNeedsReview({ pr, options, target, token, selfLogin, decoyLogin, fetchImpl })
+    if (!needs) continue
+    options.route(buildSyntheticInbound(pr, target))
+    replayed += 1
+  }
+  return { repo, scanned: prs.length, replayed }
+}
+
+async function prNeedsReview(input: {
+  pr: OpenPr
+  options: ReconcileOpenPrsOptions
+  target: RepoTarget
+  token: string
+  selfLogin: string
+  decoyLogin: string | null
+  fetchImpl: typeof fetch
+}): Promise<boolean> {
+  const { pr, options, target, token, selfLogin, decoyLogin, fetchImpl } = input
+  if (isSelfAuthored(pr, selfLogin, decoyLogin)) return false
+
+  if (options.reviewOn === 'review_requested') {
+    // Only the explicit request wakes a review under this mode. A draft can
+    // still carry a request, so draft state is irrelevant here.
+    return isReviewRequestedFromSelf(pr, selfLogin, decoyLogin)
+  }
+
+  // reviewOn === 'opened': a non-draft PR the bot has not yet reviewed. Draft
+  // PRs wait for the ready_for_review trigger, matching the live-webhook path.
+  if (pr.draft) return false
+  return !(await botAlreadyReviewed(fetchImpl, token, target, pr.number, selfLogin))
+}
+
+function buildSyntheticInbound(pr: OpenPr, target: RepoTarget): InboundMessage {
+  const branchSegment = pr.headRef !== null && pr.baseRef !== null ? ` Branch: ${pr.headRef} → ${pr.baseRef}.` : ''
+  const text =
+    `@${pr.authorLogin} opened PR #${pr.number}: "${pr.title}".${branchSegment}` +
+    ' Please review the changes line-by-line and post your feedback.'
+  // Distinct from the live `pr-<id>-opened-<updatedAt>` id so a replay never
+  // collides with a real opened delivery, while repeated reconciles for the
+  // same unchanged PR dedupe against each other (same updatedAt).
+  const externalMessageId = `pr-${pr.id}-reconcile-${pr.updatedAt}`
+  return {
+    adapter: 'github',
+    workspace: `${target.owner}/${target.repo}`,
+    chat: `pr:${pr.number}`,
+    thread: null,
+    text,
+    externalMessageId,
+    authorId: String(pr.authorId),
+    authorName: pr.authorLogin,
+    authorIsBot: pr.authorIsBot,
+    isBotMention: true,
+    replyToBotMessageId: null,
+    mentionsOthers: false,
+    replyToOtherMessageId: null,
+    isDm: false,
+    ts: pr.updatedAt !== '' ? Date.parse(pr.updatedAt) || 0 : 0,
+  }
+}
+
+type RepoTarget = { owner: string; repo: string }
+
+type OpenPr = {
+  number: number
+  id: number
+  title: string
+  draft: boolean
+  authorLogin: string
+  authorId: number
+  authorIsBot: boolean
+  headRef: string | null
+  baseRef: string | null
+  updatedAt: string
+  requestedReviewerLogins: string[]
+}
+
+function parseRepo(slug: string): RepoTarget | null {
+  const [owner, repo, ...rest] = slug.trim().split('/')
+  if (owner === undefined || owner === '' || repo === undefined || repo === '' || rest.length > 0) return null
+  return { owner, repo }
+}
+
+async function fetchOpenPrs(fetchImpl: typeof fetch, token: string, target: RepoTarget): Promise<OpenPr[]> {
+  const prs: OpenPr[] = []
+  let url: string | null = `${GITHUB_API_BASE}/repos/${target.owner}/${target.repo}/pulls?state=open&per_page=100`
+  while (url !== null) {
+    const response = await fetchImpl(url, { headers: githubJsonHeaders(token) })
+    if (!response.ok) {
+      const body = await response.text().catch(() => '')
+      throw new Error(`GitHub pulls ${response.status}${body !== '' ? `: ${body}` : ''}`)
+    }
+    const page = (await response.json().catch(() => null)) as PrRow[] | null
+    if (page === null) throw new Error('GitHub pulls returned non-JSON')
+    for (const row of page) {
+      const parsed = parsePrRow(row)
+      if (parsed !== null) prs.push(parsed)
+    }
+    url = nextLink(response.headers.get('link'))
+  }
+  return prs
+}
+
+async function botAlreadyReviewed(
+  fetchImpl: typeof fetch,
+  token: string,
+  target: RepoTarget,
+  prNumber: number,
+  selfLogin: string,
+): Promise<boolean> {
+  let url: string | null =
+    `${GITHUB_API_BASE}/repos/${target.owner}/${target.repo}/pulls/${prNumber}/reviews?per_page=100`
+  while (url !== null) {
+    const response = await fetchImpl(url, { headers: githubJsonHeaders(token) })
+    if (!response.ok) {
+      const body = await response.text().catch(() => '')
+      throw new Error(`GitHub reviews ${response.status}${body !== '' ? `: ${body}` : ''}`)
+    }
+    const page = (await response.json().catch(() => null)) as ReviewRow[] | null
+    if (page === null) throw new Error('GitHub reviews returned non-JSON')
+    for (const row of page) {
+      const login = row.user?.login ?? null
+      if (login === null) continue
+      if (isSelfLogin(login, row.user?.type === 'Bot', selfLogin)) return true
+    }
+    url = nextLink(response.headers.get('link'))
+  }
+  return false
+}
+
+function isReviewRequestedFromSelf(pr: OpenPr, selfLogin: string, decoyLogin: string | null): boolean {
+  return pr.requestedReviewerLogins.some(
+    (login) => isSelfLogin(login, login.endsWith(BOT_LOGIN_SUFFIX), selfLogin) || login === decoyLogin,
+  )
+}
+
+function isSelfAuthored(pr: OpenPr, selfLogin: string, decoyLogin: string | null): boolean {
+  return isSelfLogin(pr.authorLogin, pr.authorIsBot, selfLogin) || pr.authorLogin === decoyLogin
+}
+
+// Mirrors review-state.ts isSelfReviewer: a GitHub App's REST login is
+// `slug[bot]`, so the `[bot]` suffix-strip comparison is gated on the actor
+// actually being a Bot to avoid attributing a human who owns the bare slug.
+function isSelfLogin(login: string, isBot: boolean, selfLogin: string): boolean {
+  if (isBot) return normalizeBotLogin(login) === normalizeBotLogin(selfLogin)
+  return login === selfLogin
+}
+
+function normalizeBotLogin(login: string): string {
+  return login.endsWith(BOT_LOGIN_SUFFIX) ? login.slice(0, -BOT_LOGIN_SUFFIX.length) : login
+}
+
+// A GitHub App actor's REST login is `slug[bot]`; the decoy account an operator
+// requests for App-auth reviews is the bare slug. PAT auth has no decoy.
+function resolveDecoyLogin(selfLogin: string, authType: 'pat' | 'app'): string | null {
+  if (authType !== 'app') return null
+  if (!selfLogin.endsWith(BOT_LOGIN_SUFFIX)) return null
+  const slug = selfLogin.slice(0, -BOT_LOGIN_SUFFIX.length)
+  return slug !== '' ? slug : null
+}
+
+function nextLink(linkHeader: string | null): string | null {
+  if (linkHeader === null) return null
+  for (const part of linkHeader.split(',')) {
+    const m = /<([^>]+)>;\s*rel="next"/.exec(part)
+    if (m !== null) return m[1] ?? null
+  }
+  return null
+}
+
+type PrRow = {
+  number?: unknown
+  id?: unknown
+  title?: unknown
+  draft?: unknown
+  updated_at?: unknown
+  user?: { login?: unknown; id?: unknown; type?: unknown }
+  head?: { ref?: unknown }
+  base?: { ref?: unknown }
+  requested_reviewers?: Array<{ login?: unknown }>
+}
+
+type ReviewRow = { user?: { login?: string; type?: string } }
+
+function parsePrRow(row: PrRow): OpenPr | null {
+  const number = typeof row.number === 'number' ? row.number : null
+  const id = typeof row.id === 'number' ? row.id : null
+  const authorLogin = typeof row.user?.login === 'string' ? row.user.login : null
+  if (number === null || id === null || authorLogin === null) return null
+  return {
+    number,
+    id,
+    title: typeof row.title === 'string' ? row.title : `#${number}`,
+    draft: row.draft === true,
+    authorLogin,
+    authorId: typeof row.user?.id === 'number' ? row.user.id : 0,
+    authorIsBot: row.user?.type === 'Bot',
+    headRef: typeof row.head?.ref === 'string' ? row.head.ref : null,
+    baseRef: typeof row.base?.ref === 'string' ? row.base.ref : null,
+    updatedAt: typeof row.updated_at === 'string' ? row.updated_at : '',
+    requestedReviewerLogins: (row.requested_reviewers ?? []).flatMap((r) =>
+      typeof r.login === 'string' ? [r.login] : [],
+    ),
+  }
+}


### PR DESCRIPTION
## Background

The GitHub channel adapter reviews a PR when it receives a live webhook delivery for it. When the webhook tunnel URL churns — the cloudflare-quick provider mints a fresh `*.trycloudflare.com` host on every container restart — or a delivery is simply dropped, a `pull_request.opened` / `pull_request.ready_for_review` / `pull_request.review_requested` event can be missed permanently. Nothing wakes the bot for that PR again, so it goes un-reviewed with no trace.

This is the second half of the failure mode addressed in #648. That PR fixed draft PRs being silently observed instead of cleanly skipped; this PR fixes the delivery-reliability gap that can prevent any review from firing at all when the webhook never arrives.

## Summary

Add a best-effort **open-PR reconciliation pass** (`src/channels/adapters/github/reconcile-open-prs.ts`) that runs on every adapter `start()` — both cold boot and tunnel-driven restart (the channel manager restarts the adapter when the tunnel reassigns a URL). For each configured repo it scans open PRs via the REST API and replays the ones that still need a review as synthetic inbound messages routed through the exact same path a real webhook uses.

A shared `routeInbound` closure was extracted from the adapter so the live webhook handler and the reconciliation loop cannot diverge — same filtering, same router entry point, no duplicated classification logic.

**Filtering by `review.on`:**

- `'opened'` — replays non-draft PRs the bot has not already reviewed (queries the PR's existing reviews). Draft PRs are intentionally skipped, deferring to `ready_for_review`, matching the live-webhook path established in #648.
- `'review_requested'` — replays PRs where the bot (or its App decoy account) is a requested reviewer.
- `'off'` — short-circuits; scans nothing.

**Safety properties:**

- Self-authored PRs (bot or its App decoy) are always skipped.
- The synthetic `externalMessageId` is `pr-<id>-reconcile-<updatedAt>`, which never collides with a live `pr-<id>-opened-<updatedAt>` delivery, while repeated reconciles of an unchanged PR dedupe against each other via the existing message-ID store.
- The pass is scheduled last in `start()`, swallows per-repo errors internally, and never blocks the adapter from coming up.

**Reconciliation is a reliability floor, not a replacement for webhooks.** Webhooks remain the low-latency primary path; this pass only catches what live delivery missed.

**Behavior matrix:**

| `review.on` | PR state | Reconcile action |
|---|---|---|
| `opened` | non-draft, not yet reviewed by bot | replay → review |
| `opened` | non-draft, already reviewed by bot | skip |
| `opened` | draft | skip (waits for `ready_for_review`) |
| `review_requested` | bot/decoy is requested reviewer | replay → review |
| `review_requested` | bot not requested | skip |
| `off` | any | skip (no scan) |
| any | self-authored by bot/decoy | skip |

## Preview

N/A. The observable difference is PRs that would previously go un-reviewed after a tunnel restart now receive a review.

## What this does NOT do

- Does not replace or alter the live webhook path — reconciliation only runs in addition to it.
- Does not guarantee review ordering matches the original webhook delivery order.
- Does not reconcile closed or merged PRs.
- Does not surface reconciliation activity as a visible user-facing event — it fires off internal synthetic messages the router handles identically to real webhook deliveries.

## Review notes

- **Load-bearing:** the `routeInbound` extraction in `src/channels/adapters/github/index.ts` — the live handler and `reconcileOpenPrs` both call this closure. Any future filtering change to one automatically applies to the other.
- **`externalMessageId` collision safety:** live deliveries produce `pr-<id>-opened-<updatedAt>`; reconcile produces `pr-<id>-reconcile-<updatedAt>`. The `-reconcile-` infix is the fence. A reconcile and a live delivery for the same PR at the same `updatedAt` are distinct messages and both process; subsequent reconciles of an unchanged PR dedupe.
- **Fail-safe scheduling:** the reconciliation block is `void`-ed at the end of `start()` — per-repo errors are caught and logged internally; a complete failure of the pass does not affect the adapter's live state.
- **Tests:** 13 new tests — 11 unit tests in `reconcile-open-prs.test.ts` (fake-fetch, covering all filter branches, dedup, self-authored skip, draft skip, API-error swallow) and 2 integration tests in `lifecycle.test.ts` asserting `start()` triggers a scan under `review.on: 'opened'` and skips it under `'off'`. The integration test confirms a replayed PR flows through the real router and creates a live PR session end-to-end. Typecheck clean, lint 0 errors, format clean. One unrelated pre-existing test is environment-path-dependent and passes in CI.